### PR TITLE
feat(agent/backup): give the backup helper real logs

### DIFF
--- a/agent/cmd/breeze-backup/console_unix.go
+++ b/agent/cmd/breeze-backup/console_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package main
+
+import "os"
+
+// hasConsole reports whether stdout is connected to a terminal. False when the
+// helper is spawned by the agent running as a launchd daemon or systemd
+// service, which is the normal case — the agent passes its own stdio down
+// (sessionbroker/backup.go), and under a service manager that is not a
+// terminal. Mirrors agentapp.hasConsole, which is unexported.
+func hasConsole() bool {
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// redirectStderr points stderr at the log file so Go panic stack traces land
+// there instead of being lost. On Unix the agent's inherited stderr is usually
+// captured by the service manager's journal, so this is belt-and-braces.
+func redirectStderr(f *os.File) {
+	os.Stderr = f
+}

--- a/agent/cmd/breeze-backup/console_windows.go
+++ b/agent/cmd/breeze-backup/console_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+var procGetConsoleWindow = syscall.NewLazyDLL("kernel32.dll").NewProc("GetConsoleWindow")
+
+// hasConsole reports whether the process has an attached console window.
+// False when spawned by the agent service, which is the normal case: the
+// agent hands the helper its own stdio (sessionbroker/backup.go) and under
+// the SCM those handles are NUL. Mirrors agentapp.hasConsole, which is
+// unexported.
+func hasConsole() bool {
+	ret, _, _ := procGetConsoleWindow.Call()
+	return ret != 0
+}
+
+// redirectStderr points STD_ERROR_HANDLE at the log file so Go runtime panics
+// (which write to fd 2) are captured instead of being silently lost to NUL.
+// This is the difference between a crashed backup leaving a stack trace and
+// leaving nothing at all.
+func redirectStderr(f *os.File) {
+	if err := windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(f.Fd())); err != nil {
+		return
+	}
+	os.Stderr = f
+}

--- a/agent/cmd/breeze-backup/logging_test.go
+++ b/agent/cmd/breeze-backup/logging_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/logging"
+)
+
+// TestInitLoggingWritesToFile is the regression guard for #2790: breeze-backup
+// used to rely on the package-level slog default (stdout) while the agent
+// spawned it with inherited stdio, which under a Windows service is NUL. Every
+// line a backup run produced was discarded. The contract this pins is narrow
+// and deliberate — after initLogging, a log line must land in a real file on
+// disk, next to agent.log.
+func TestInitLoggingWritesToFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.LogFile = filepath.Join(dir, "agent.log")
+	cfg.LogLevel = "debug"
+	// No AgentID/ServerURL/AuthToken, so the shipper stays off and this test
+	// makes no network calls.
+	cfg.AgentID = ""
+	cfg.ServerURL = ""
+	cfg.AuthToken = ""
+
+	stop := initLogging(cfg)
+	defer stop()
+
+	logging.L("backup").Info("canary line", "jobId", "test-job-1")
+
+	backupLog := filepath.Join(dir, "backup.log")
+	data, err := os.ReadFile(backupLog)
+	if err != nil {
+		t.Fatalf("expected %s to exist after initLogging: %v", backupLog, err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "canary line") {
+		t.Errorf("backup.log missing the logged message; got:\n%s", got)
+	}
+	// The component tag is what makes these lines filterable via the
+	// diagnostic-logs API; without it they ship as component "unknown".
+	if !strings.Contains(got, "backup") {
+		t.Errorf("backup.log missing the component tag; got:\n%s", got)
+	}
+	if !strings.Contains(got, "test-job-1") {
+		t.Errorf("backup.log dropped structured attrs; got:\n%s", got)
+	}
+}
+
+// TestInitLoggingHonoursDebugLevel pins that the configured level actually
+// reaches the handler. The per-file upload lines added in snapshot.go are at
+// debug, so a hardcoded info default would silently discard exactly the
+// diagnostics this work exists to produce.
+func TestInitLoggingHonoursDebugLevel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.LogFile = filepath.Join(dir, "agent.log")
+	cfg.LogLevel = "debug"
+	cfg.AgentID = ""
+	cfg.ServerURL = ""
+	cfg.AuthToken = ""
+
+	stop := initLogging(cfg)
+	defer stop()
+
+	logging.L("backup").Debug("debug canary")
+
+	data, err := os.ReadFile(filepath.Join(dir, "backup.log"))
+	if err != nil {
+		t.Fatalf("read backup.log: %v", err)
+	}
+	if !strings.Contains(string(data), "debug canary") {
+		t.Errorf("debug line was dropped despite log_level=debug; got:\n%s", string(data))
+	}
+}
+
+// TestInitLoggingWithoutCredentialsReturnsNoopStop guards the os.Exit paths in
+// runBackupHelper: they call the returned stop func explicitly because defers
+// do not run, so it must be safe to call when the shipper was never started.
+func TestInitLoggingWithoutCredentialsReturnsNoopStop(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.LogFile = filepath.Join(dir, "agent.log")
+	cfg.AgentID = ""
+	cfg.ServerURL = ""
+	cfg.AuthToken = ""
+
+	stop := initLogging(cfg)
+	if stop == nil {
+		t.Fatal("initLogging returned a nil stop func")
+	}
+	stop()
+	stop() // idempotent: an os.Exit path may call it after a defer already did
+}

--- a/agent/cmd/breeze-backup/main.go
+++ b/agent/cmd/breeze-backup/main.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -21,11 +22,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/breeze-rmm/agent/internal/authstate"
 	"github.com/breeze-rmm/agent/internal/backup"
 	"github.com/breeze-rmm/agent/internal/backup/providers"
 	"github.com/breeze-rmm/agent/internal/backupipc"
 	"github.com/breeze-rmm/agent/internal/config"
 	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/logging"
+	"github.com/breeze-rmm/agent/internal/secmem"
 	"github.com/spf13/cobra"
 )
 
@@ -95,30 +99,110 @@ func main() {
 	}
 }
 
-func runBackupHelper() {
-	slog.Info("breeze-backup starting", "version", version, "pid", os.Getpid(), "platform", runtime.GOOS)
+// initLogging wires this process into the agent's logging stack: a rotating
+// file at <logdir>/backup.log plus the shared log shipper.
+//
+// Until this existed, breeze-backup relied on the package-level slog default
+// (stdout) and the backup packages used stdlib log.Printf (stderr). The agent
+// spawns us with inherited stdio (sessionbroker/backup.go), which under a
+// Windows service or a launchd daemon is NUL — so every line a backup run
+// produced was discarded, on disk and over the wire alike. A multi-hour hung
+// backup left three lines in agent.log and nothing else (#2790).
+//
+// Returns a close func the caller must run before exiting, including on the
+// os.Exit paths below: the shipper batches on a 60s ticker and only drains on
+// an explicit Stop, so skipping it loses whatever is buffered.
+func initLogging(cfg *config.Config) func() {
+	logDir := filepath.Dir(cfg.LogFile)
+	_ = os.MkdirAll(logDir, 0700)
 
+	var output io.Writer = os.Stdout
+	if rw, err := logging.NewRotatingWriter(
+		filepath.Join(logDir, "backup.log"),
+		cfg.LogMaxSizeMB,
+		cfg.LogMaxBackups,
+	); err == nil {
+		// Spawned from the service with no console, stdout is invalid — a
+		// TeeWriter would abort the whole write on the stdout leg, so go
+		// file-only unless we actually have a console.
+		if hasConsole() {
+			output = logging.TeeWriter(os.Stdout, rw)
+		} else {
+			output = rw
+		}
+	}
+	logging.Init(cfg.LogFormat, cfg.LogLevel, output)
+
+	// Go runtime panics write to fd 2, which bypasses slog entirely and would
+	// otherwise go to NUL under the service. Point stderr at its own plain
+	// file rather than the rotating writer: rotation renames the file out from
+	// under any handle we hand off, and a panic trace split across a rotation
+	// boundary is worse than useless. Panics are rare, so this stays tiny.
+	if pf, err := os.OpenFile(
+		filepath.Join(logDir, "backup-panic.log"),
+		os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600,
+	); err == nil {
+		redirectStderr(pf)
+	}
+
+	// We are spawned by the agent service and run as SYSTEM/root, so the full
+	// config.Load already gave us the real agent credentials. Unlike the user
+	// helper we don't need the helper-scoped token.
+	if cfg.AgentID == "" || cfg.ServerURL == "" || cfg.AuthToken == "" {
+		return func() {}
+	}
+	token := secmem.NewSecureString(cfg.AuthToken)
+	cfg.AuthToken = ""
+	logging.InitShipper(logging.ShipperConfig{
+		ServerURL:    config.NewPersistedServerURLProvider("", cfg.ServerURL, 0),
+		AgentID:      cfg.AgentID,
+		AuthToken:    token,
+		AgentVersion: version + "-backup",
+		MinLevel:     cfg.LogShippingLevel,
+		AuthMonitor:  authstate.NewMonitor(3),
+	})
+	return logging.StopShipper
+}
+
+func runBackupHelper() {
 	if socketPath == "" {
 		socketPath = ipc.DefaultSocketPath()
 	}
 
-	cfg, err := config.Load("")
-	if err != nil {
-		slog.Warn("failed to load config, using defaults", "error", err.Error())
+	// Config first: it carries the log file path, level and shipping
+	// credentials, so there is nowhere useful to send a load failure until
+	// after logging is up. Stash it and log once we can.
+	cfg, cfgErr := config.Load("")
+	if cfgErr != nil {
 		cfg = config.Default()
 	}
+
+	stopLogging := initLogging(cfg)
+	log := logging.L("backup-helper")
+	if cfgErr != nil {
+		log.Warn("failed to load config, using defaults", "error", cfgErr.Error())
+	}
+	log.Info("breeze-backup starting",
+		"version", version,
+		"pid", os.Getpid(),
+		"platform", runtime.GOOS,
+		"logFile", filepath.Join(filepath.Dir(cfg.LogFile), "backup.log"),
+		"logLevel", cfg.LogLevel,
+	)
 
 	// Connect to main agent via IPC
 	conn, err := dialAgent(socketPath)
 	if err != nil {
-		slog.Error("failed to connect to agent", "error", err.Error())
+		log.Error("failed to connect to agent", "error", err.Error())
+		stopLogging()
 		os.Exit(1)
 	}
 	defer conn.Close()
 
 	// Authenticate
 	if err := authenticate(conn); err != nil {
-		slog.Error("authentication failed", "error", err.Error())
+		log.Error("authentication failed", "error", err.Error())
+		stopLogging()
 		os.Exit(1)
 	}
 
@@ -136,7 +220,8 @@ func runBackupHelper() {
 		caps.SupportsVault = true
 	}
 	if err := conn.SendTyped("caps", backupipc.TypeBackupReady, caps); err != nil {
-		slog.Error("failed to send capabilities", "error", err.Error())
+		log.Error("failed to send capabilities", "error", err.Error())
+		stopLogging()
 		os.Exit(1)
 	}
 
@@ -146,7 +231,7 @@ func runBackupHelper() {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCh
-		slog.Info("received shutdown signal")
+		log.Info("received shutdown signal")
 		cancel()
 	}()
 
@@ -157,7 +242,8 @@ func runBackupHelper() {
 	if mgr != nil {
 		mgr.Stop()
 	}
-	slog.Info("breeze-backup exiting")
+	log.Info("breeze-backup exiting")
+	stopLogging()
 }
 
 func dialAgent(path string) (*ipc.Conn, error) {

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,7 +18,16 @@ import (
 	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 	"github.com/breeze-rmm/agent/internal/backup/vss"
 	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/logging"
 )
+
+// log is the package logger. Everything in this package used to call stdlib
+// log.Printf, which writes raw text to stderr and so bypassed slog, the log
+// file and the log shipper entirely — under a Windows service that stderr is
+// NUL, which is why a hung backup produced no diagnostics anywhere (#2790).
+// Routing through logging.L also tags every line with component=backup so it
+// is filterable via the diagnostic-logs API.
+var log = logging.L("backup")
 
 const (
 	jobStatusRunning   = "running"
@@ -178,7 +186,7 @@ func (m *BackupManager) Stop() bool {
 	jobDoneCh := m.jobDoneCh
 	m.mu.Unlock()
 
-	log.Printf("[backup] stopping backup manager")
+	log.Info("stopping backup manager")
 	if jobCancel != nil {
 		jobCancel()
 	}
@@ -191,7 +199,7 @@ func (m *BackupManager) Stop() bool {
 		m.jobDoneCh = nil
 	}
 	m.mu.Unlock()
-	log.Printf("[backup] backup manager stopped")
+	log.Info("backup manager stopped")
 	return true
 }
 
@@ -266,6 +274,14 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		Status:    jobStatusRunning,
 	}
 	backupPaths := append([]string(nil), m.config.Paths...)
+	log.Info("backup run starting",
+		"jobId", job.ID,
+		"paths", strings.Join(backupPaths, string(os.PathListSeparator)),
+		"excludeCount", len(excludes),
+		"vssEnabled", m.config.VSSEnabled,
+		"systemStateEnabled", m.config.SystemStateEnabled,
+		"retention", m.config.Retention,
+	)
 	stopBackupRun := func() (*BackupJob, error) {
 		job.Status = jobStatusStopped
 		job.CompletedAt = time.Now().UTC()
@@ -302,7 +318,10 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		session, vssErr := provider.CreateShadowCopy(vssCtx, extractVolumes(m.config.Paths))
 		cancel()
 		if vssErr != nil {
-			log.Printf("[backup] VSS shadow copy failed, proceeding without VSS: %v", vssErr)
+			log.Warn("VSS shadow copy failed, proceeding without VSS",
+				"elapsedMs", time.Since(vssStart).Milliseconds(),
+				"error", vssErr.Error(),
+			)
 		} else {
 			vssSession = session
 			job.VSSMetadata = &vss.VSSMetadata{
@@ -314,11 +333,14 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 				DurationMs:   time.Since(vssStart).Milliseconds(),
 			}
 			if len(session.Warnings) > 0 {
-				log.Printf("[backup] VSS completed with %d warning(s): %v", len(session.Warnings), session.Warnings)
+				log.Warn("VSS completed with warnings",
+					"warningCount", len(session.Warnings),
+					"warnings", strings.Join(session.Warnings, "; "),
+				)
 			}
 			defer func() {
 				if releaseErr := provider.ReleaseShadowCopy(session); releaseErr != nil {
-					log.Printf("[backup] failed to release VSS shadow copy: %v", releaseErr)
+					log.Warn("failed to release VSS shadow copy", "error", releaseErr.Error())
 				}
 			}()
 		}
@@ -339,7 +361,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		manifest, stagingDir, ssErr := collectSystemState()
 		if ssErr != nil {
 			systemStateErr = ssErr
-			log.Printf("[backup] system state collection failed, proceeding without: %v", ssErr)
+			log.Warn("system state collection failed, proceeding without", "error", ssErr.Error())
 		} else {
 			job.SystemStateManifest = manifest
 			// Collection succeeded on all *required* artifacts (missing a
@@ -349,14 +371,14 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			// is visible without discarding an otherwise-usable backup.
 			if len(manifest.IncompleteSteps) > 0 {
 				job.Warning = fmt.Sprintf("system state collection incomplete: %v failed", manifest.IncompleteSteps)
-				log.Printf("[backup] %s", job.Warning)
+				log.Warn("system state collection incomplete", "warning", job.Warning)
 			}
 			// Append staging dir to backup paths so artifacts are included in snapshot
 			systemStateStagingIdx = len(backupPaths)
 			backupPaths = append(backupPaths, stagingDir)
 			defer func() {
 				if removeErr := os.RemoveAll(stagingDir); removeErr != nil {
-					log.Printf("[backup] failed to clean up system state staging dir: %v", removeErr)
+					log.Warn("failed to clean up system state staging dir", "dir", stagingDir, "error", removeErr.Error())
 				}
 			}()
 		}
@@ -380,13 +402,24 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	if err := runCtx.Err(); err != nil {
 		return stopBackupRun()
 	}
+	// The tree walk emits nothing of its own and can run for many minutes on a
+	// large volume, so without a bounding pair of log lines it is
+	// indistinguishable from a hang. Same reasoning as the per-file upload
+	// timing in snapshot.go (#2790).
+	log.Info("scanning backup paths", "jobId", job.ID, "pathCount", len(backupPaths))
+	scanStart := time.Now()
 	files, scanErr := m.collectBackupFilesFromPaths(runCtx, backupPaths, newExcludeMatcher(excludes))
 	if scanErr != nil {
 		if errors.Is(scanErr, errBackupStopped) {
 			return stopBackupRun()
 		}
-		log.Printf("[backup] backup file scan completed with errors: %v", scanErr)
+		log.Warn("backup file scan completed with errors", "error", scanErr.Error())
 	}
+	log.Info("scan complete",
+		"jobId", job.ID,
+		"files", len(files),
+		"elapsedMs", time.Since(scanStart).Milliseconds(),
+	)
 	if vssSession != nil {
 		// Recover the pre-VSS-rewrite path for each file so the checkpoint
 		// journal has a stable resume key — see originalPathsForVSS and the
@@ -433,7 +466,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	if incrementalDedupeActive {
 		prev, reason := previousManifest(runCtx, m.config.Provider)
 		if prev == nil {
-			log.Printf("[backup] running full backup (no reference dedupe): %s", reason)
+			log.Info("running full backup, no reference dedupe", "reason", reason)
 		} else {
 			prevSnapshot = prev
 		}
@@ -470,7 +503,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	var journal *snapshotJournal
 	var resumedJournal bool
 	if journalDir, ok := resolveJournalDir(m.GetStagingDir()); !ok {
-		log.Printf("[backup] no secure checkpoint journal directory available (only the world-writable temp dir); proceeding without resume support")
+		log.Warn("no secure checkpoint journal directory available, proceeding without resume support")
 	} else {
 		var journalErr error
 		journal, resumedJournal, journalErr = openSnapshotJournal(journalDir, backupIdentity(m.config.Provider, m.config.Paths), journalMaxAge)
@@ -478,7 +511,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			// A journal is a best-effort checkpoint, never a correctness
 			// requirement: degrade to a journal-less run rather than failing
 			// the backup over it.
-			log.Printf("[backup] failed to open checkpoint journal, proceeding without resume support: %v", journalErr)
+			log.Warn("failed to open checkpoint journal, proceeding without resume support", "error", journalErr.Error())
 			journal = nil
 		}
 	}
@@ -488,13 +521,17 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			// journal and the (near-impossible) identity-mismatch case — see
 			// openSnapshotJournal — so the message below is deliberately
 			// generic rather than claiming a specific cause.
-			log.Printf("[backup] discarding unusable checkpoint journal (snapshot %s, older than %s or identity-mismatched), cleaning up its remote prefix",
-				staleID, journalMaxAge)
+			log.Warn("discarding unusable checkpoint journal, cleaning up its remote prefix",
+				"snapshotId", staleID,
+				"maxAge", journalMaxAge.String(),
+			)
 			cleanupSnapshotPrefix(m.config.Provider, staleID)
 		}
 		if resumedJournal {
-			log.Printf("[backup] resuming interrupted backup: journal snapshot %s (%d bytes already uploaded)",
-				journal.snapshotID, journal.ResumedBytes())
+			log.Info("resuming interrupted backup from checkpoint journal",
+				"snapshotId", journal.snapshotID,
+				"resumedBytes", journal.ResumedBytes(),
+			)
 		}
 	}
 
@@ -544,7 +581,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			if errors.Is(retentionErr, errBackupStopped) {
 				return stopBackupRun()
 			}
-			log.Printf("[backup] failed to enforce snapshot retention: %v", retentionErr)
+			log.Warn("failed to enforce snapshot retention", "error", retentionErr.Error())
 		}
 	}
 
@@ -569,7 +606,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		job.ErrorCount = len(snapshot.UploadFailures)
 		failureWarning := summarizeUploadFailures(snapshot.UploadFailures, len(files))
 		appendWarning(job, failureWarning)
-		log.Printf("[backup] %s", failureWarning)
+		log.Warn("snapshot completed with upload failures", "warning", failureWarning, "errorCount", job.ErrorCount)
 	}
 
 	// Collection-phase (scan) errors — permission-denied files, walk failures,
@@ -584,12 +621,31 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		job.ErrorCount += len(scanFailures)
 		scanWarning := summarizeScanErrors(scanFailures)
 		appendWarning(job, scanWarning)
-		log.Printf("[backup] %s", scanWarning)
+		log.Warn("snapshot completed with scan failures", "warning", scanWarning)
 	}
 
 	job.Status = jobStatusCompleted
 	job.Error = errors.Join(scanErr, retentionErr)
+	log.Info("backup run completed",
+		"jobId", job.ID,
+		"snapshotId", snapshotID(snapshot),
+		"filesBackedUp", job.FilesBackedUp,
+		"bytesBackedUp", job.BytesBackedUp,
+		"referencedFiles", job.ReferencedFiles,
+		"referencedBytes", job.ReferencedBytes,
+		"errorCount", job.ErrorCount,
+		"elapsedMs", time.Since(job.StartedAt).Milliseconds(),
+	)
 	return job, nil
+}
+
+// snapshotID returns s.ID, or "" for a nil snapshot, so completion logging
+// never has to guard the nil case inline.
+func snapshotID(s *Snapshot) string {
+	if s == nil {
+		return ""
+	}
+	return s.ID
 }
 
 // maxUploadFailureDetails caps how many individual per-file error messages
@@ -811,7 +867,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))
 			if _, exists := seen[snapshotPath]; exists {
-				log.Printf("[backup] duplicate backup path skipped: %s", snapshotPath)
+				log.Debug("duplicate backup path skipped", "snapshotPath", snapshotPath)
 				continue
 			}
 			seen[snapshotPath] = struct{}{}
@@ -865,7 +921,7 @@ func (m *BackupManager) collectBackupFilesFromPaths(ctx context.Context, paths [
 			}
 			snapshotPath := filepath.ToSlash(filepath.Join(rootLabel, relPath))
 			if _, exists := seen[snapshotPath]; exists {
-				log.Printf("[backup] duplicate backup path skipped: %s", snapshotPath)
+				log.Debug("duplicate backup path skipped", "snapshotPath", snapshotPath)
 				return nil
 			}
 			seen[snapshotPath] = struct{}{}

--- a/agent/internal/backup/exclude.go
+++ b/agent/internal/backup/exclude.go
@@ -1,7 +1,6 @@
 package backup
 
 import (
-	"log"
 	"path"
 	"runtime"
 	"strings"
@@ -57,7 +56,7 @@ func newExcludeMatcherForOS(patterns []string, caseInsensitive bool) *excludeMat
 		if strings.Contains(p, "/") {
 			segs := strings.Split(p, "/")
 			if !validGlobSegments(segs) {
-				log.Printf("[backup] ignoring invalid exclusion pattern %q", raw)
+				log.Warn("ignoring invalid exclusion pattern", "pattern", raw)
 				continue
 			}
 			// Implicit leading "**/" so patterns match at any depth
@@ -65,7 +64,7 @@ func newExcludeMatcherForOS(patterns []string, caseInsensitive bool) *excludeMat
 			m.relPath = append(m.relPath, append([]string{"**"}, segs...))
 		} else {
 			if _, err := path.Match(p, "probe"); err != nil {
-				log.Printf("[backup] ignoring invalid exclusion pattern %q: %v", raw, err)
+				log.Warn("ignoring invalid exclusion pattern", "pattern", raw, "error", err.Error())
 				continue
 			}
 			m.baseName = append(m.baseName, p)

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -9,8 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
-	"log/slog"
 	"os"
 	"path"
 	"sort"
@@ -395,8 +393,11 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		}
 		if len(resumedFiles) > 0 {
 			markDone(len(resumedFiles), resumedBytes)
-			log.Printf("[backup] resuming snapshot %s: %d file(s) / %d bytes already uploaded in a prior run",
-				snapshot.ID, len(resumedFiles), resumedBytes)
+			log.Info("resuming interrupted snapshot from checkpoint journal",
+				"snapshotId", snapshot.ID,
+				"resumedFiles", len(resumedFiles),
+				"resumedBytes", resumedBytes,
+			)
 			emitProgress(true)
 		}
 	}
@@ -439,12 +440,41 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		backupPath := path.Join(prefix, snapshotFilesDir, file.snapshotPath)
 		backupPath = ensureGzipExtension(backupPath)
 
+		// Log the file we are ABOUT to upload, at debug, before we block on it.
+		// This is the line that makes a wedged backup diagnosable: the deadline
+		// below scales with file size and has no ceiling, so a large file whose
+		// upload stalls mid-body can hold the loop for hours with no other
+		// output. Without a start line the last thing in the log is the
+		// previous file's success and there is no way to tell which file is
+		// stuck (#2790, #2798).
+		deadline := uploadDeadline(file.size)
+		log.Debug("uploading file",
+			"path", file.sourcePath,
+			"backupPath", backupPath,
+			"bytes", file.size,
+			"deadlineMs", deadline.Milliseconds(),
+			"snapshotId", snapshot.ID,
+		)
+
+		uploadStart := time.Now()
 		uploadErr := attemptFileUpload(ctx, provider, file, backupPath)
 		if uploadErr != nil && !errors.Is(uploadErr, errBackupStopped) {
 			// Exactly one retry, only for a non-cancel failure (including a
 			// per-file deadline expiry, which attemptFileUpload has already
 			// converted to a plain error). Job-context cancel during the
 			// backoff wait aborts immediately — never retried.
+			//
+			// Warn, not debug: a single retry is the first observable symptom
+			// of a stalling destination, and it is the point at which we have
+			// already burned the full per-file deadline.
+			log.Warn("file upload failed, retrying once",
+				"path", file.sourcePath,
+				"bytes", file.size,
+				"elapsedMs", time.Since(uploadStart).Milliseconds(),
+				"deadlineMs", deadline.Milliseconds(),
+				"retryDelayMs", uploadRetryDelay.Milliseconds(),
+				"error", uploadErr.Error(),
+			)
 			select {
 			case <-ctx.Done():
 				uploadErr = errBackupStopped
@@ -458,9 +488,19 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 			}
 			err := fmt.Errorf("failed to upload %s: %w", file.sourcePath, uploadErr)
 			errs = append(errs, err)
-			log.Printf("[backup] upload failed: %s: %v", file.sourcePath, err)
+			// This is skip-and-continue: the file is dropped from the backup
+			// but the job carries on. Warn so it is visible without debug
+			// shipping, and count it so the summary at the end is trustworthy.
+			log.Warn("file upload failed, skipping file",
+				"path", file.sourcePath,
+				"bytes", file.size,
+				"elapsedMs", time.Since(uploadStart).Milliseconds(),
+				"failedSoFar", len(errs),
+				"error", uploadErr.Error(),
+			)
 			continue
 		}
+		uploadMs := time.Since(uploadStart).Milliseconds()
 
 		// Checksum the source bytes so integrity/test-restore can detect silent
 		// corruption of the stored object. A hash failure here is non-fatal —
@@ -475,10 +515,27 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		// consistent with the pre-existing size-from-collection vs content-from-
 		// upload race. Eliminating it fully requires hashing the bytes as they
 		// stream to the provider (a provider-interface change) — left as future work.
+		// Timed separately from the upload: this is a second full read of the
+		// source file, so on a large file or a slow/network-mounted path it is
+		// a real chunk of wall-clock that produces zero network traffic and
+		// zero progress movement. Without its own timing it looks identical to
+		// a stalled upload from the outside.
+		sumStart := time.Now()
 		checksum, sumErr := sha256File(file.sourcePath)
 		if sumErr != nil {
-			log.Printf("[backup] checksum failed for %s: %v", file.sourcePath, sumErr)
+			log.Warn("checksum failed, file stored without one",
+				"path", file.sourcePath,
+				"bytes", file.size,
+				"error", sumErr.Error(),
+			)
 		}
+		log.Debug("file uploaded",
+			"path", file.sourcePath,
+			"bytes", file.size,
+			"uploadMs", uploadMs,
+			"checksumMs", time.Since(sumStart).Milliseconds(),
+			"snapshotId", snapshot.ID,
+		)
 
 		entry := SnapshotFile{
 			SourcePath:   file.sourcePath,
@@ -546,7 +603,7 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 
 	if journal != nil {
 		if err := journal.Complete(); err != nil {
-			log.Printf("[backup] failed to remove completed checkpoint journal: %v", err)
+			log.Warn("failed to remove completed checkpoint journal", "error", err.Error())
 		}
 		completed = true
 	}
@@ -560,12 +617,22 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 // converted to a plain error so the caller can distinguish "this file
 // stalled" (retry / skip-and-continue) from "the job was cancelled" (abort).
 func attemptFileUpload(ctx context.Context, provider providers.BackupProvider, file backupFile, backupPath string) error {
-	attemptCtx, cancelAttempt := context.WithTimeout(ctx, uploadDeadline(file.size))
+	deadline := uploadDeadline(file.size)
+	attemptCtx, cancelAttempt := context.WithTimeout(ctx, deadline)
 	defer cancelAttempt()
 	uploadErr := uploadSnapshotFile(attemptCtx, provider, file.sourcePath, backupPath)
 	if errors.Is(uploadErr, errBackupStopped) && ctx.Err() == nil {
-		// The per-file deadline fired, not a job cancel.
-		uploadErr = fmt.Errorf("upload stalled: no completion within %s", uploadDeadline(file.size))
+		// The per-file deadline fired, not a job cancel. Log it distinctly:
+		// a deadline expiry means we sat on one file for the whole (size-
+		// scaled, uncapped) window with the destination accepting the request
+		// and never finishing it. That is a different failure from an outright
+		// upload error and it is the signature of the stall in #2798.
+		log.Warn("file upload deadline expired",
+			"path", file.sourcePath,
+			"bytes", file.size,
+			"deadlineMs", deadline.Milliseconds(),
+		)
+		uploadErr = fmt.Errorf("upload stalled: no completion within %s", deadline)
 	}
 	return uploadErr
 }
@@ -594,12 +661,12 @@ func uploadSnapshotFile(ctx context.Context, provider providers.BackupProvider, 
 func cleanupSnapshotPrefix(provider providers.BackupProvider, snapshotID string) {
 	items, err := listSnapshotPrefixItems(provider, snapshotID)
 	if err != nil {
-		slog.Error("failed to list aborted snapshot for cleanup", "snapshotId", snapshotID, "error", err.Error())
+		log.Error("failed to list aborted snapshot for cleanup", "snapshotId", snapshotID, "error", err.Error())
 		return
 	}
 	for _, item := range items {
 		if err := provider.Delete(item); err != nil {
-			slog.Error("failed to clean up aborted snapshot file", "item", item, "error", err.Error())
+			log.Error("failed to clean up aborted snapshot file", "item", item, "error", err.Error())
 		}
 	}
 }
@@ -627,7 +694,7 @@ func ListSnapshots(provider providers.BackupProvider) ([]Snapshot, error) {
 		if err != nil {
 			err = fmt.Errorf("failed to create temp manifest: %w", err)
 			errs = append(errs, err)
-			log.Printf("[backup] snapshot manifest temp file failed: %v", err)
+			log.Warn("snapshot manifest temp file failed", "error", err.Error())
 			continue
 		}
 		tempPath := tempFile.Name()
@@ -637,7 +704,7 @@ func ListSnapshots(provider providers.BackupProvider) ([]Snapshot, error) {
 			os.Remove(tempPath)
 			err = fmt.Errorf("failed to download manifest %s: %w", item, err)
 			errs = append(errs, err)
-			log.Printf("[backup] snapshot manifest download failed: %s: %v", item, err)
+			log.Warn("snapshot manifest download failed", "item", item, "error", err.Error())
 			continue
 		}
 
@@ -646,7 +713,7 @@ func ListSnapshots(provider providers.BackupProvider) ([]Snapshot, error) {
 			os.Remove(tempPath)
 			err = fmt.Errorf("failed to open manifest %s: %w", tempPath, err)
 			errs = append(errs, err)
-			log.Printf("[backup] snapshot manifest open failed: %s: %v", item, err)
+			log.Warn("snapshot manifest open failed", "item", item, "error", err.Error())
 			continue
 		}
 		var snapshot Snapshot
@@ -655,13 +722,13 @@ func ListSnapshots(provider providers.BackupProvider) ([]Snapshot, error) {
 			os.Remove(tempPath)
 			err = fmt.Errorf("failed to decode manifest %s: %w", item, err)
 			errs = append(errs, err)
-			log.Printf("[backup] snapshot manifest decode failed: %s: %v", item, err)
+			log.Warn("snapshot manifest decode failed", "item", item, "error", err.Error())
 			continue
 		}
 		if err := manifestFile.Close(); err != nil {
 			err = fmt.Errorf("failed to close manifest %s: %w", item, err)
 			errs = append(errs, err)
-			log.Printf("[backup] snapshot manifest close failed: %s: %v", item, err)
+			log.Warn("snapshot manifest close failed", "item", item, "error", err.Error())
 		}
 		os.Remove(tempPath)
 
@@ -713,7 +780,7 @@ func DeleteSnapshotContext(ctx context.Context, provider providers.BackupProvide
 		if listErr != nil {
 			listErr = fmt.Errorf("failed to list snapshot %s: %w", snapshot.ID, listErr)
 			errs = append(errs, listErr)
-			log.Printf("[backup] snapshot list failed: %s: %v", snapshot.ID, listErr)
+			log.Warn("snapshot list failed", "snapshotId", snapshot.ID, "error", listErr.Error())
 			continue
 		}
 
@@ -724,7 +791,7 @@ func DeleteSnapshotContext(ctx context.Context, provider providers.BackupProvide
 			if delErr := provider.Delete(item); delErr != nil {
 				delErr = fmt.Errorf("failed to delete %s: %w", item, delErr)
 				errs = append(errs, delErr)
-				log.Printf("[backup] snapshot delete failed: %s: %v", item, delErr)
+				log.Warn("snapshot delete failed", "item", item, "error", delErr.Error())
 			}
 		}
 	}

--- a/agent/internal/backup/verify.go
+++ b/agent/internal/backup/verify.go
@@ -3,7 +3,6 @@ package backup
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -92,7 +91,7 @@ func VerifyIntegrity(provider providers.BackupProvider, snapshotID string) (*Ver
 		if err != nil {
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-verify] temp file create failed for %s: %v", file.BackupPath, err)
+			log.Warn("temp file create failed", "phase", "verify", "backupPath", file.BackupPath, "error", err.Error())
 			continue
 		}
 		tempPath := tempFile.Name()
@@ -104,7 +103,7 @@ func VerifyIntegrity(provider providers.BackupProvider, snapshotID string) (*Ver
 			os.Remove(tempPath)
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-verify] download failed for %s: %v", file.BackupPath, dlErr)
+			log.Warn("download failed", "phase", "verify", "backupPath", file.BackupPath, "error", dlErr.Error())
 			continue
 		}
 
@@ -121,15 +120,15 @@ func VerifyIntegrity(provider providers.BackupProvider, snapshotID string) (*Ver
 			os.Remove(tempPath)
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-verify] stat failed for %s: %v", file.BackupPath, statErr)
+			log.Warn("stat failed", "phase", "verify", "backupPath", file.BackupPath, "error", errString(statErr))
 			continue
 		}
 		if info.Size() != file.Size {
 			os.Remove(tempPath)
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-verify] size mismatch for %s: manifest %d, stored %d",
-				file.BackupPath, file.Size, info.Size())
+			log.Warn("size mismatch", "phase", "verify", "backupPath", file.BackupPath,
+				"expectedBytes", file.Size, "actualBytes", info.Size())
 			continue
 		}
 		if file.Checksum != "" {
@@ -137,8 +136,8 @@ func VerifyIntegrity(provider providers.BackupProvider, snapshotID string) (*Ver
 				os.Remove(tempPath)
 				result.FilesFailed++
 				result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-				log.Printf("[backup-verify] checksum mismatch for %s (manifest %s)",
-					file.BackupPath, file.Checksum)
+				log.Warn("checksum mismatch", "phase", "verify", "backupPath", file.BackupPath,
+					"expected", file.Checksum)
 				continue
 			}
 		} else {
@@ -165,6 +164,17 @@ func VerifyIntegrity(provider providers.BackupProvider, snapshotID string) (*Ver
 
 	result.DurationMs = time.Since(start).Milliseconds()
 	return result, nil
+}
+
+// errString renders an error for a structured log attribute. The log shipper
+// JSON-marshals attrs and a raw error marshals to {}, so errors are logged as
+// strings. Used where the error may be nil (a stat that returned nil info
+// without an error), which err.Error() would panic on.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 const restoreTestPrefix = "breeze-restore-test"
@@ -223,7 +233,7 @@ func TestRestore(provider providers.BackupProvider, snapshotID string, progressF
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-restore] create target dir failed for %s: %v", destPath, err)
+			log.Warn("create target dir failed", "phase", "restore", "destPath", destPath, "error", err.Error())
 			if progressFn != nil {
 				progressFn(i+1, total)
 			}
@@ -236,22 +246,23 @@ func TestRestore(provider providers.BackupProvider, snapshotID string, progressF
 		case dlErr != nil:
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-restore] download failed for %s: %v", file.BackupPath, dlErr)
+			log.Warn("download failed", "phase", "restore", "backupPath", file.BackupPath, "error", dlErr.Error())
 		case statErr != nil || info == nil:
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-restore] stat failed for %s: %v", file.BackupPath, statErr)
+			log.Warn("stat failed", "phase", "restore", "backupPath", file.BackupPath, "error", errString(statErr))
 		case info.Size() != file.Size:
 			// A real test-restore must confirm the bytes came back intact, not
 			// just that a file appeared (same blind spot as VerifyIntegrity).
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-restore] size mismatch for %s: manifest %d, restored %d",
-				file.BackupPath, file.Size, info.Size())
+			log.Warn("size mismatch", "phase", "restore", "backupPath", file.BackupPath,
+				"expectedBytes", file.Size, "actualBytes", info.Size())
 		case file.Checksum != "" && !checksumMatches(destPath, file.Checksum):
 			result.FilesFailed++
 			result.FailedFiles = append(result.FailedFiles, file.BackupPath)
-			log.Printf("[backup-restore] checksum mismatch for %s", file.BackupPath)
+			log.Warn("checksum mismatch", "phase", "restore", "backupPath", file.BackupPath,
+				"expected", file.Checksum)
 		default:
 			result.FilesVerified++
 			result.SizeBytes += info.Size()
@@ -279,7 +290,7 @@ func TestRestore(provider providers.BackupProvider, snapshotID string, progressF
 
 	// Cleanup
 	if cleanErr := os.RemoveAll(restoreDir); cleanErr != nil {
-		log.Printf("[backup-restore] cleanup failed for %s: %v", restoreDir, cleanErr)
+		log.Warn("cleanup failed", "phase", "restore", "path", restoreDir, "error", cleanErr.Error())
 		result.CleanedUp = false
 	} else {
 		result.CleanedUp = true

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -836,6 +836,11 @@ func (h *Heartbeat) handleUserHelperMessage(session *sessionbroker.Session, env 
 		}
 	case backupipc.TypeBackupProgress:
 		if h.wsClient == nil {
+			// The only progress-drop path that produced no record at all: a
+			// backup still running while the WS is down loses every keepalive,
+			// and server-side that is indistinguishable from an agent that
+			// stopped reporting. The send failure below is already logged.
+			log.Warn("dropping backup progress, no websocket client")
 			return
 		}
 		var progress backupipc.BackupProgress


### PR DESCRIPTION
Closes #2790. Groundwork for #2798.

## Why

An operator reported a backup hung for 1h25m and asked, reasonably, whether backups drop a log file anywhere. They don't. Diagnosing it took a code trace instead of a log read, which is the wrong way round.

Two independent causes, both fixed here.

**The helper never initialised the logging package.** `cmd/breeze-backup` fell back to the package-level slog default on stdout, and the agent spawns it with inherited stdio (`sessionbroker/backup.go:102-104`) — under a Windows service those handles are NUL. Everything the process logged was discarded.

**The backup packages used stdlib `log.Printf` at 43 sites.** That writes raw text to stderr and bypasses slog, the log file and the log shipper regardless of how logging is configured. So even with (1) fixed, the actual backup diagnostics would still have gone nowhere.

Net effect: a multi-hour hang left exactly three lines in `agent.log` — helper spawned, helper connected, silence.

## What changed

**Logging bootstrap** (`cmd/breeze-backup/main.go`)
- `initLogging`: rotating `<logdir>/backup.log` at the configured level, plus the shared log shipper. The helper runs as SYSTEM/root and `config.Load` already hands it real agent credentials, so unlike the user helper it needs no helper-scoped token.
- Stderr is redirected to its own `backup-panic.log` rather than the rotating writer, so Go runtime panic traces survive. Rotation renames the file out from under any handle we hand off, and a trace split across a rotation boundary is worse than useless.
- The stop func is called explicitly on every `os.Exit` path. The shipper batches on a 60s ticker and only drains on `Stop`, so a skipped defer silently loses the buffer — and the `os.Exit` paths are exactly the ones whose logs you most want.
- New `console_unix.go` / `console_windows.go`, mirroring the unexported `agentapp` helpers, so a console-attached run still tees to stdout.

**Conversion** — all 43 `log.Printf` sites across `backup.go`, `snapshot.go`, `verify.go`, `exclude.go` now use a package logger tagged `component=backup`, which is what makes them filterable via `GET /devices/:id/diagnostic-logs`. House style throughout: camelCase attrs, `"error", err.Error()` (never the raw error — the shipper JSON-marshals attrs and a bare error marshals to `{}`).

**Instrumentation for the stall class** (#2798). The per-file upload deadline scales with file size and has no ceiling, so one large file stalling mid-body holds the loop for hours in total silence:
- debug line before each upload, naming the file and its computed deadline
- warn when the deadline expires (distinct from an outright upload error — this is the #2798 signature)
- warn on the single retry, with elapsed vs deadline
- warn when a file is skipped, with a running failure count
- the post-upload sha256 re-read is timed separately: it is a second full read of the source that produces no network traffic, so from the outside it is indistinguishable from a stalled upload

**Phase boundaries** that previously emitted nothing: run start with its config, scan start/complete with file count and elapsed, run completion with totals, dedupe counts and elapsed.

**One real silent drop** (`heartbeat.go`): progress arriving while `wsClient` is nil returned with no record at all. Worth being precise here — I had claimed in #2593 and in #2790's body that `SendBackupProgress` drops silently when the send channel is full. That was wrong: it returns an error and `heartbeat.go:846` already logs it at warn. The nil-client branch was the only genuinely silent path.

## Verification

```
go build ./...                          clean
GOOS=windows go build ./...             clean
go vet ./internal/backup/ ./cmd/breeze-backup/ ./internal/heartbeat/   clean
go test -race ./...                     all packages pass
```

Three new tests in `cmd/breeze-backup/logging_test.go` pin the contract: a line reaches a real file on disk with its component tag and structured attrs; `log_level=debug` actually reaches the handler (the per-file upload lines are at debug, so an info-hardcoded default would discard exactly the diagnostics this work exists to produce); and the stop func is safe to call twice, which the `os.Exit` paths depend on.

Smoke-tested the built binary against a bogus socket: config-load failure is now logged instead of vanishing, the startup line reports the resolved log path and level, it degrades to stdout when the log dir isn't writable, and it still exits 1.

`gofmt -l` flags `internal/heartbeat/heartbeat.go`, but that is pre-existing struct-alignment drift at line 247 unrelated to this change — left alone rather than adding unrelated churn to the diff.

## Not in scope

`set_log_level` still doesn't reach the helper process, so raising to debug at runtime won't turn on the per-file lines without a config change and a helper restart. `log_shipping_level` also defaults to `warn`, so the debug lines land on disk but won't ship by default. Both belong with the #2798 fix, where the reaper semantics change anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)