### PR TITLE
fix(compose): drop remaining stale tailwind.config.mjs bind mounts (#2012)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,8 @@ ln -sf docker-compose.override.yml.dev docker-compose.override.yml
 docker compose up --build -d
 ```
 
+**Deleting a config file? Sweep the Compose mounts in the same PR.** Docker creates a missing bind-mount source as an empty **directory** on the host, which then gets `COPY`d into dev images where Vite/PostCSS discovery dies on it (`EISDIR`) — `breeze-web` comes up permanently unhealthy on a fresh clone. `apps/api/src/config/composeBindMounts.test.ts` (required **Test API** job) parses every tracked compose file and fails when a file-shaped, repo-relative bind-mount source doesn't exist — or has already become a phantom directory. Extensionless sources (`./agent/bin`) are exempt as intended build outputs; out-of-repo sources (`../breeze-billing/…`) can't be asserted and are skipped. Shipped three times before the guard existed: #1999 (postcss), #2208 (partial tailwind), #2012 (the mounts #2208 missed).
+
 ### PR Merge Process
 - Branch protection requires status checks, but the repo owner uses `--admin` to bypass when CI is green
 - Use `gh pr merge --squash --admin` (merge commits are disabled on this repo)

--- a/apps/api/src/config/composeBindMounts.test.ts
+++ b/apps/api/src/config/composeBindMounts.test.ts
@@ -1,0 +1,197 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+// apps/api/src/config -> repo root is 4 levels up (same as envComposeParity.test.ts).
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/**
+ * Why this test exists
+ * --------------------
+ * Docker creates a MISSING bind-mount source as an empty **directory** on the
+ * host. When the source was meant to be a file, that phantom directory litters
+ * the working tree and — because the dev Dockerfiles `COPY apps/web ./apps/web`
+ * wholesale — lands inside the image, where Vite/PostCSS config discovery dies
+ * on it (`EISDIR: illegal operation on a directory`). `breeze-web` then never
+ * passes its healthcheck on a fresh clone.
+ *
+ * The trigger is always the same: a config file gets deleted and nobody sweeps
+ * the Compose mounts that referenced it. It has shipped three times:
+ *   #1999 — postcss.config.mjs, after the Tailwind 4 migration
+ *   #2208 — tailwind.config.mjs, but only in docker-compose.override.yml.dev
+ *   #2012 — the two tailwind.config.mjs mounts #2208 missed
+ *
+ * The guard: every **file-shaped**, **repo-relative** bind-mount source in a
+ * tracked Compose file must exist as a file. This lives in the required
+ * `test-api` job so a fourth recurrence cannot go green.
+ */
+
+// Compose's own merge tags. js-yaml throws on unknown tags, so declare them as
+// pass-throughs — we never inspect their values, we just need the file to parse.
+const passthroughTag = (tag: string) =>
+  (['scalar', 'sequence', 'mapping'] as const).map(
+    (kind) => new yaml.Type(tag, { kind, construct: (data: unknown) => data }),
+  );
+
+const COMPOSE_SCHEMA = yaml.DEFAULT_SCHEMA.extend([
+  ...passthroughTag('!reset'),
+  ...passthroughTag('!override'),
+]);
+
+/**
+ * Sources whose basename contains a dot but which are legitimately
+ * DIRECTORIES (e.g. `certs/live.d`, `assets.v2`). Empty today. Add an entry —
+ * repo-root-relative, with a reason — rather than weakening the heuristic. A
+ * stale entry fails the suite below, so this list cannot rot.
+ */
+const DOTTED_DIRECTORY_SOURCES: Record<string, string> = {};
+
+interface Mount {
+  composeFile: string; // repo-root-relative
+  rawSource: string; // exactly as written in the YAML
+  resolved: string; // absolute
+}
+
+function trackedComposeFiles(): string[] {
+  // Tracked files only: a developer's untracked `docker-compose.override.yml.mine`
+  // is their business, and this skips vendored compose files under node_modules.
+  const out = execFileSync(
+    'git',
+    ['ls-files', '-z', '*docker-compose*.yml*', '*docker-compose*', '*compose.yml', '*compose.yaml'],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  );
+  const files = out.split('\0').filter(Boolean);
+  // Note the optional trailing suffix: the mode overrides are named
+  // `docker-compose.override.yml.dev` / `.worktree` / `.ci` / … — anchoring on a
+  // `.yml` *ending* would silently skip the very files that carried #2012.
+  return [...new Set(files)]
+    .filter((f) => /(^|\/)(docker-)?compose[^/]*\.(yml|yaml)(\.[A-Za-z0-9_-]+)?$/.test(f))
+    // `git ls-files` also lists files staged-but-deleted, or absent under a
+    // sparse checkout. Skip those rather than throwing ENOENT.
+    .filter((f) => existsSync(path.join(REPO_ROOT, f)))
+    .sort();
+}
+
+/** Extract the host side of a short-syntax volume entry (`SOURCE:TARGET[:MODE]`). */
+function shortSyntaxSource(entry: string): string | null {
+  const colon = entry.indexOf(':', 1);
+  if (colon === -1) return null; // anonymous volume — target only, no source
+  return entry.slice(0, colon);
+}
+
+function collectMounts(composeFile: string): Mount[] {
+  const abs = path.join(REPO_ROOT, composeFile);
+  const composeDir = path.dirname(abs);
+  const doc = yaml.load(readFileSync(abs, 'utf8'), { schema: COMPOSE_SCHEMA }) as {
+    services?: Record<string, { volumes?: unknown }>;
+  } | null;
+
+  const mounts: Mount[] = [];
+  for (const service of Object.values(doc?.services ?? {})) {
+    const volumes = service?.volumes;
+    if (!Array.isArray(volumes)) continue;
+
+    for (const volume of volumes) {
+      let source: string | null = null;
+
+      if (typeof volume === 'string') {
+        source = shortSyntaxSource(volume);
+      } else if (volume && typeof volume === 'object') {
+        const long = volume as { type?: unknown; source?: unknown };
+        // Long syntax. `type` defaults to `volume`; only binds have a host path.
+        if (long.type === 'bind' && typeof long.source === 'string') source = long.source;
+      }
+
+      if (!source) continue;
+      // Interpolated paths aren't knowable statically.
+      if (source.includes('$')) continue;
+      // Only repo-relative sources. Named volumes (`caddy_data`) and absolute
+      // host paths (`/var/run/docker.sock`) are not ours to validate.
+      if (!source.startsWith('./') && !source.startsWith('../')) continue;
+
+      mounts.push({ composeFile, rawSource: source, resolved: path.resolve(composeDir, source) });
+    }
+  }
+  return mounts;
+}
+
+const composeFiles = trackedComposeFiles();
+const allMounts = composeFiles.flatMap(collectMounts);
+
+/** Inside the repo? `../breeze-billing/...` (a sibling repo) is not. */
+function isInsideRepo(abs: string): boolean {
+  const rel = path.relative(REPO_ROOT, abs);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/** Dot in the basename => meant to be a file. `./agent/bin` is a build output. */
+function isFileShaped(source: string): boolean {
+  return path.basename(source).includes('.');
+}
+
+describe('Compose bind-mount sources', () => {
+  // Fail closed: if discovery silently breaks, the suite must not pass vacuously.
+  it('discovers the tracked compose files and their mounts', () => {
+    expect(composeFiles).toContain('docker-compose.yml');
+    expect(composeFiles).toContain('docker-compose.dev.yml');
+    expect(composeFiles).toContain('deploy/docker-compose.prod.yml');
+    // The mode overrides must be in scope — #2012's two stale mounts lived in
+    // docker-compose.dev.yml and docker-compose.override.yml.worktree.
+    expect(composeFiles).toContain('docker-compose.override.yml.dev');
+    expect(composeFiles).toContain('docker-compose.override.yml.worktree');
+    expect(composeFiles.length).toBeGreaterThanOrEqual(10);
+    expect(allMounts.length).toBeGreaterThanOrEqual(30);
+
+    // Parent-relative sources must be in scope, resolved against the compose
+    // file's own directory. deploy/docker-compose.prod.yml mounts
+    // `../docker/Caddyfile.prod` — a repo file the production stack depends on.
+    const caddyfile = path.join(REPO_ROOT, 'docker/Caddyfile.prod');
+    expect(allMounts.map((m) => m.resolved)).toContain(caddyfile);
+  });
+
+  it('mounts every file-shaped source from a file that actually exists', () => {
+    const problems: string[] = [];
+
+    for (const mount of allMounts) {
+      if (!isInsideRepo(mount.resolved)) continue; // sibling repo / outside checkout
+      if (!isFileShaped(mount.rawSource)) continue; // directory mount, created on demand
+
+      const relResolved = path.relative(REPO_ROOT, mount.resolved);
+      if (DOTTED_DIRECTORY_SOURCES[relResolved]) continue;
+
+      if (!existsSync(mount.resolved)) {
+        problems.push(
+          `${mount.composeFile}: bind-mount source "${mount.rawSource}" does not exist ` +
+            `(looked for ${relResolved}). Docker would create it as an empty directory on ` +
+            `\`docker compose up\`. Drop the mount if the file was deleted, or restore the file.`,
+        );
+        continue;
+      }
+
+      if (statSync(mount.resolved).isDirectory()) {
+        problems.push(
+          `${mount.composeFile}: bind-mount source "${mount.rawSource}" is a DIRECTORY but is ` +
+            `mounted as a file. This is the phantom directory Docker created from a stale ` +
+            `mount — remove it (\`rmdir ${relResolved}\`), or add it to ` +
+            `DOTTED_DIRECTORY_SOURCES if it is a genuine directory.`,
+        );
+      }
+    }
+
+    expect(problems).toEqual([]);
+  });
+
+  it('keeps DOTTED_DIRECTORY_SOURCES free of stale entries', () => {
+    const stale = Object.keys(DOTTED_DIRECTORY_SOURCES).filter((rel) => {
+      const abs = path.join(REPO_ROOT, rel);
+      // Stale = no longer mounted anywhere, or no longer a directory.
+      const stillMounted = allMounts.some((m) => m.resolved === abs);
+      return !stillMounted || !existsSync(abs) || !statSync(abs).isDirectory();
+    });
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -138,7 +138,6 @@ services:
       - ./apps/web/package.json:/app/apps/web/package.json:ro
       - ./apps/web/tsconfig.json:/app/apps/web/tsconfig.json:ro
       - ./apps/web/astro.config.mjs:/app/apps/web/astro.config.mjs:ro
-      - ./apps/web/tailwind.config.mjs:/app/apps/web/tailwind.config.mjs:ro
       - ./packages/shared/package.json:/app/packages/shared/package.json:ro
       - ./packages/shared/tsconfig.json:/app/packages/shared/tsconfig.json:ro
       # Exclude node_modules (use container's)

--- a/docker-compose.override.yml.worktree
+++ b/docker-compose.override.yml.worktree
@@ -62,7 +62,6 @@ services:
       - ./apps/portal/package.json:/app/apps/portal/package.json:ro
       - ./apps/portal/tsconfig.json:/app/apps/portal/tsconfig.json:ro
       - ./apps/portal/astro.config.mjs:/app/apps/portal/astro.config.mjs:ro
-      - ./apps/portal/tailwind.config.mjs:/app/apps/portal/tailwind.config.mjs:ro
       - ./packages/shared/src:/app/packages/shared/src:cached
       - /app/node_modules
       - /app/apps/portal/node_modules


### PR DESCRIPTION
## Problem

The Tailwind 4 migration (#1995 web, #1991 portal) deleted `apps/web/tailwind.config.mjs` and `apps/portal/tailwind.config.mjs`, but dev Compose files kept bind-mounting them. Docker creates a **missing bind-mount source as an empty directory** on the host. The dev Dockerfiles `COPY apps/web ./apps/web` wholesale, so those phantom dirs land in the image, where Vite/PostCSS config discovery dies on them (`EISDIR: illegal operation on a directory`) and `breeze-web` never passes its healthcheck on a fresh clone.

**#2208 fixed only half of this.** It removed the two mounts in `docker-compose.override.yml.dev` and never referenced #2012, so two were left on `main`:

| File | Line on main | Service |
|---|---|---|
| `docker-compose.dev.yml` | 141 | web |
| `docker-compose.override.yml.worktree` | 65 | portal |

Both target files are confirmed nonexistent on `origin/main` (only `apps/helper/tailwind.config.js` remains, and it isn't mounted anywhere).

## Change

**The fix itself is the two deleted lines.** The rest is a regression guard.

1. **Drop the two stale mounts.** TW4 configures via the Vite plugin + CSS `@theme`; nothing reads a standalone config.
2. **Add `apps/api/src/config/composeBindMounts.test.ts`** — because this bug class has now shipped three times (#1999 postcss, #2208 partial tailwind, #2012 the remainder) and each recurrence is a broken dev stack on a fresh clone.

   It parses every tracked Compose file with `js-yaml` and asserts that each **file-shaped, repo-relative** bind-mount source under `services.*.volumes` exists as a file — and hasn't already become a phantom directory (the failure message gives you the `rmdir`).

   It lives in the **required `test-api` job**, next to the existing `envComposeParity` / `proxyTrustCompose` compose invariants, so **no workflow change is needed** (relevant: my token has no `workflow` scope, so a `ci.yml` edit was not pushable — this design sidesteps that entirely rather than leaving a guard that nothing runs).

   Parsing real YAML instead of grepping matters:
   - covers the long-form `type: bind` / `source:`, single- and double-quoted, and flow-sequence spellings — all of which this repo already uses somewhere;
   - inspects **only** `volumes:`, so `command:` / `env_file:` entries can't produce false positives (an `env_file: ./.env.local` would otherwise fail every fresh CI checkout, since `.env*` is gitignored);
   - resolves sources against **each Compose file's own directory**, so `deploy/docker-compose.prod.yml`'s `../docker/Caddyfile.prod` is genuinely in scope (locked in by an explicit assertion);
   - skips what it cannot assert: out-of-repo sources (`../breeze-billing/...`, a sibling repo absent from a normal checkout), interpolated `$VAR` paths, and extensionless sources (`./agent/bin`, `./viewer/bin`, `./helper/bin` — intended build outputs).

   `DOTTED_DIRECTORY_SOURCES` is the escape hatch for a genuine directory with a dot in its name; it's empty today and a staleness test keeps it from rotting.
3. **CLAUDE.md** — one note under Docker Compose Modes: deleting a config file means sweeping the Compose mounts in the same PR.

## Verification

- `vitest run src/config/composeBindMounts.test.ts` → **3 passed**. Sibling compose suites (`envComposeParity`, `proxyTrustCompose`) → **12 passed**, no regression.
- **Fixture-tested every syntax**, by staging throwaway compose files and confirming what the guard does and does not flag:
  - Correctly **flagged**: long-form `type: bind`, `'single-quoted'`, `"double-quoted"`, flow-sequence `['./a.mjs:/a']`, and `../`-relative from a subdirectory.
  - Correctly **ignored**: named volumes (`data_vol:/data`, `type: volume`), absolute hosts (`/var/run/docker.sock`), out-of-repo `../breeze-billing/...`, interpolated `${VAR}/x.json`, and `command:` / `env_file:` list items.
  - Phantom-directory branch verified by `mkdir`-ing a mounted `*.mjs` path — reports the `rmdir`.
- ESLint clean on the new file.
- Independent sweep: zero remaining missing file-shaped bind-mount sources across all 11 compose files; no `tailwind`/`postcss` reference left in any compose file; no stale `COPY` in any Dockerfile. Remaining mentions are historical `docs/superpowers/plans/` design docs, correctly untouched.
- `.github/` is byte-identical to `origin/main`.
- Docker isn't installed in this environment, so `docker compose config` was not run; the compose edits are pure line deletions, validated by parsing both files and diffing the resulting volume lists against `origin/main` (exactly the two intended removals, nothing else).

**If your checkout already has the junk dirs:**

```sh
rmdir apps/web/tailwind.config.mjs apps/portal/tailwind.config.mjs 2>/dev/null
```

Closes #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)