### PR TITLE
fix(agent): winget scans with unreadable output report ErrScanSkipped (#2726)

### DIFF
--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2315,15 +2315,11 @@ func (h *Heartbeat) collectPatchInventory() ([]map[string]any, []map[string]any,
 // everything was skipped serializes as an empty coveredSources array (sweep
 // nothing) rather than being omitted (legacy sweep-all).
 //
-// INTERIM LIMITATION (until #2216 lands): the coverage mechanism keys off
-// providers returning patching.ErrScanSkipped, but the current winget provider
-// still returns (nil, nil) when it can't run (no connected user helper session)
-// instead of the sentinel. So a skipped winget is counted as "scanned and found
-// nothing" and its third_party bucket is treated as COVERED — the coverage guard
-// is inert-but-correct for winget: it never wrongly narrows the sweep, it just
-// can't yet protect winget's own rows. #2216 splits winget.go and has its SYSTEM
-// provider adopt ErrScanSkipped, at which point this mechanism becomes fully
-// effective for winget with no change here. Do not edit winget.go for #2217.
+// The SYSTEM winget provider now participates properly, so a winget that never
+// actually looked at anything no longer marks third_party as covered: an
+// unresolvable winget is never registered as a provider at all, a failed
+// invocation returns an error, and output with no parsable table returns
+// patching.ErrScanSkipped rather than an empty result (#2726).
 func (h *Heartbeat) coveredPatchSources(providerIDs, coveredProviders []string) []string {
 	coveredSet := make(map[string]bool, len(coveredProviders))
 	for _, id := range coveredProviders {

--- a/agent/internal/patching/winget_parse.go
+++ b/agent/internal/patching/winget_parse.go
@@ -2,6 +2,7 @@ package patching
 
 import (
 	"bufio"
+	"errors"
 	"regexp"
 	"strings"
 )
@@ -9,16 +10,66 @@ import (
 // validWingetPkgID matches valid winget package identifiers (e.g. "Mozilla.Firefox", "Google.Chrome").
 var validWingetPkgID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._\-]{0,255}$`)
 
+// errWingetNoTable reports that winget's output contained neither a parsable
+// result table nor a recognized "matched nothing" message, so the run cannot be
+// distinguished from a failure. Callers MUST treat it as a skipped scan and
+// never as an empty result: an empty result is tombstoning input, and sweeping
+// a device's pending third-party patches on the strength of output we could not
+// even parse wipes rows nothing ever inspected (#2726).
+var errWingetNoTable = errors.New("winget output has no parsable table header")
+
+// wingetNoResultsMessages are the messages winget prints INSTEAD of a result
+// table when it ran correctly but matched nothing. This matters because
+// `winget upgrade` on a fully up-to-date machine emits no header at all — just
+// "No installed package found matching input criteria." — so recognizing these
+// is what keeps a genuinely-empty scan from being misreported as a skip (which
+// would leave installed patches stuck as "pending" forever).
+//
+// Necessarily English-only: winget localizes both these strings and its column
+// headers, so on a localized Windows the headerless output falls through to
+// errWingetNoTable and the scan is reported as skipped. That is the safe
+// direction — stale pending rows survive rather than being tombstoned by a scan
+// that saw nothing.
+var wingetNoResultsMessages = []string{
+	"no installed package found",
+	"no package found matching input criteria",
+	"no applicable update found",
+	"no applicable upgrade found",
+	"no available upgrade found",
+	"no newer package versions are available",
+	"no upgrade available",
+	"no upgrades available",
+}
+
+// wingetReportsNoResults reports whether output carries an explicit winget
+// "matched nothing" message.
+func wingetReportsNoResults(output string) bool {
+	lower := strings.ToLower(output)
+	for _, msg := range wingetNoResultsMessages {
+		if strings.Contains(lower, msg) {
+			return true
+		}
+	}
+	return false
+}
+
 // parseWingetUpgradeOutput parses `winget upgrade` table output into available patches.
 // winget upgrade output format:
 //
 //	Name            Id                  Version   Available  Source
 //	---------------------------------------------------------------
 //	Mozilla Firefox Mozilla.Firefox     128.0     129.0      winget
-func parseWingetUpgradeOutput(output string) []AvailablePatch {
+//
+// Returns errWingetNoTable when there is no header AND no recognized
+// "matched nothing" message — see that error's doc comment for why the caller
+// must not collapse that case into an empty slice.
+func parseWingetUpgradeOutput(output string) ([]AvailablePatch, error) {
 	cols := findColumnBoundaries(output, []string{"Name", "Id", "Version", "Available"})
 	if cols == nil {
-		return nil
+		if wingetReportsNoResults(output) {
+			return nil, nil
+		}
+		return nil, errWingetNoTable
 	}
 
 	var patches []AvailablePatch
@@ -65,7 +116,7 @@ func parseWingetUpgradeOutput(output string) []AvailablePatch {
 		})
 	}
 
-	return patches
+	return patches, nil
 }
 
 // parseWingetListOutput parses `winget list` table output into installed patches.

--- a/agent/internal/patching/winget_parse_test.go
+++ b/agent/internal/patching/winget_parse_test.go
@@ -1,6 +1,7 @@
 package patching
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -8,11 +9,112 @@ import (
 
 // --- Table parsing edge cases ---
 
-func TestWingetParseNoHeader(t *testing.T) {
-	output := "some random output\nno table here\n"
-	patches := parseWingetUpgradeOutput(output)
-	if len(patches) != 0 {
-		t.Errorf("expected 0 patches from headerless output, got %d", len(patches))
+// TestParseWingetUpgradeOutputHeaderDetection pins the three-way distinction the
+// tombstoning contract depends on (#2726): parsed rows, a confirmed-empty scan,
+// and "we could not read this output at all" — which must be an error so the
+// caller reports ErrScanSkipped instead of an empty (sweep-triggering) result.
+func TestParseWingetUpgradeOutputHeaderDetection(t *testing.T) {
+	validTable := "Name     Id                Version   Available   Source\n" +
+		"--------------------------------------------------------\n" +
+		"Firefox  Mozilla.Firefox   128.0     129.0       winget\n" +
+		"Git      Git.Git           2.51.0    2.55.0      winget\n"
+
+	tests := []struct {
+		name      string
+		output    string
+		wantIDs   []string
+		wantErr   error
+		wantNoErr bool // genuinely-empty: no rows AND no error
+	}{
+		{
+			name:    "valid header parses every row",
+			output:  validTable,
+			wantIDs: []string{"Mozilla.Firefox", "Git.Git"},
+		},
+		{
+			name: "valid header with zero data rows is a confirmed-empty scan",
+			output: "Name     Id                Version   Available   Source\n" +
+				"--------------------------------------------------------\n",
+			wantNoErr: true,
+		},
+		{
+			name:      "no header but explicit no-results message is confirmed-empty",
+			output:    "No installed package found matching input criteria.\n",
+			wantNoErr: true,
+		},
+		{
+			name:      "no header with no-applicable-upgrade message is confirmed-empty",
+			output:    "   -\nNo applicable upgrade found.\n",
+			wantNoErr: true,
+		},
+		{
+			name:    "missing header errors",
+			output:  "some random output\nno table here\n",
+			wantErr: errWingetNoTable,
+		},
+		{
+			name:    "empty output errors",
+			output:  "",
+			wantErr: errWingetNoTable,
+		},
+		{
+			name:    "whitespace-only output errors",
+			output:  "\n   \n\t\n",
+			wantErr: errWingetNoTable,
+		},
+		{
+			name:    "garbled output errors",
+			output:  "\x00\xff\x01��� garbled\n\x1b[2J\x1b[H\n",
+			wantErr: errWingetNoTable,
+		},
+		{
+			name: "localized header errors rather than reporting empty",
+			output: "Nombre   Id                Versión   Disponible  Origen\n" +
+				"--------------------------------------------------------\n" +
+				"Firefox  Mozilla.Firefox   128.0     129.0       winget\n",
+			wantErr: errWingetNoTable,
+		},
+		{
+			name: "out-of-order columns error rather than mis-parsing",
+			output: "Id       Name              Version   Available   Source\n" +
+				"--------------------------------------------------------\n",
+			wantErr: errWingetNoTable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			patches, err := parseWingetUpgradeOutput(tc.output)
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tc.wantErr)
+				}
+				if patches != nil {
+					t.Errorf("patches = %+v, want nil alongside an error", patches)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantNoErr {
+				if len(patches) != 0 {
+					t.Fatalf("patches = %+v, want empty", patches)
+				}
+				return
+			}
+
+			if len(patches) != len(tc.wantIDs) {
+				t.Fatalf("got %d patches %+v, want %d", len(patches), patches, len(tc.wantIDs))
+			}
+			for i, want := range tc.wantIDs {
+				if patches[i].ID != want {
+					t.Errorf("patches[%d].ID = %q, want %q", i, patches[i].ID, want)
+				}
+			}
+		})
 	}
 }
 
@@ -38,7 +140,10 @@ Firefox  Mozilla.Firefox   128.0     129.0       winget
 1 upgrades available.
 `
 
-	patches := parseWingetUpgradeOutput(output)
+	patches, err := parseWingetUpgradeOutput(output)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(patches) != 1 {
 		t.Fatalf("expected 1 patch, got %d", len(patches))
 	}

--- a/agent/internal/patching/winget_system.go
+++ b/agent/internal/patching/winget_system.go
@@ -56,7 +56,25 @@ func (p *SystemWingetProvider) Scan() ([]AvailablePatch, error) {
 	if code != 0 && stdout == "" {
 		return nil, fmt.Errorf("winget upgrade failed (exit %d): %s", code, strings.TrimSpace(stderr))
 	}
-	return parseWingetUpgradeOutput(stdout), nil
+	patches, parseErr := parseWingetUpgradeOutput(stdout)
+	if parseErr != nil {
+		// winget exited without a table we could read and without saying it
+		// matched nothing (localized column headers, garbled or truncated
+		// console-less output, empty stdout on exit 0). We cannot claim to have
+		// enumerated this device's third-party packages, so report a skip. A
+		// skipped provider is excluded from scan coverage, which stops the
+		// server sweeping existing third_party pending rows to "missing" on the
+		// strength of a scan that never inspected them (#2726).
+		//
+		// Both streams are bounded and stdout is included deliberately: on the
+		// most common real trigger (localized column headers) stderr is empty,
+		// and the unparsable stdout head is the only clue a tech has for why
+		// this device keeps reporting a skipped winget scan.
+		return nil, fmt.Errorf("%w: %v (exit %d, stdout: %q, stderr: %q)",
+			ErrScanSkipped, parseErr, code,
+			truncatePatchField(stdout), truncatePatchField(stderr))
+	}
+	return patches, nil
 }
 
 func (p *SystemWingetProvider) Install(patchID string) (InstallResult, error) {

--- a/agent/internal/patching/winget_system_test.go
+++ b/agent/internal/patching/winget_system_test.go
@@ -1,6 +1,8 @@
 package patching
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +43,91 @@ func TestSystemScanParsesUpgrades(t *testing.T) {
 	}
 	if len(patches) != 1 || patches[0].ID != "Mozilla.Firefox" {
 		t.Fatalf("got %+v", patches)
+	}
+}
+
+// TestSystemScanUnreadableOutputIsSkippedNotEmpty is the regression guard for
+// #2726: a scan whose output we cannot parse must surface ErrScanSkipped so
+// PatchManager drops winget from scan coverage. Returning (nil, nil) here made a
+// failed scan indistinguishable from "nothing pending" and tombstoned the
+// device's third_party pending rows.
+func TestSystemScanUnreadableOutputIsSkippedNotEmpty(t *testing.T) {
+	tests := []struct {
+		name        string
+		stdout      string
+		stderr      string
+		exitCode    int
+		wantSkipped bool
+	}{
+		{name: "empty stdout on exit 0", stdout: "", wantSkipped: true},
+		{name: "garbled output", stdout: "\x1b[2J??? not a table\n", wantSkipped: true},
+		{name: "localized header", stdout: "Nombre  Id  Versión  Disponible\n----------------\n", wantSkipped: true},
+		{
+			name:     "nonzero exit but readable table still scans",
+			stdout:   "Name    Id               Version  Available Source\n" + strings.Repeat("-", 50) + "\nFirefox Mozilla.Firefox   1.0      2.0       winget\n",
+			exitCode: 1,
+		},
+		{name: "explicit no-results message is a real empty scan", stdout: "No installed package found matching input criteria.\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewSystemWingetProvider(`C:\wg\winget.exe`, func(string, []string, time.Duration) (string, string, int, error) {
+				return tc.stdout, tc.stderr, tc.exitCode, nil
+			})
+
+			patches, err := p.Scan()
+			skipped := errors.Is(err, ErrScanSkipped)
+
+			if skipped != tc.wantSkipped {
+				t.Fatalf("errors.Is(err, ErrScanSkipped) = %v (err=%v), want %v", skipped, err, tc.wantSkipped)
+			}
+			if tc.wantSkipped {
+				if patches != nil {
+					t.Errorf("patches = %+v, want nil on a skipped scan", patches)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// A skipped winget must not count toward scan coverage, or the server sweeps the
+// third_party bucket anyway and the fix is inert (#2217 + #2726).
+func TestSkippedSystemWingetIsNotCovered(t *testing.T) {
+	p := NewSystemWingetProvider(`C:\wg\winget.exe`, func(string, []string, time.Duration) (string, string, int, error) {
+		return "not a winget table at all\n", "", 0, nil
+	})
+
+	_, covered, err := NewPatchManager(p).ScanWithCoverage()
+	if err != nil {
+		t.Fatalf("ScanWithCoverage should not surface a skip as failure: %v", err)
+	}
+	if len(covered) != 0 {
+		t.Fatalf("covered = %v, want empty so third_party is not swept", covered)
+	}
+}
+
+// The counterpart: a winget that really did enumerate an empty upgrade list must
+// stay covered, otherwise installed patches are never tombstoned and linger as
+// "pending" forever.
+func TestConfirmedEmptySystemWingetScanStaysCovered(t *testing.T) {
+	p := NewSystemWingetProvider(`C:\wg\winget.exe`, func(string, []string, time.Duration) (string, string, int, error) {
+		return "No installed package found matching input criteria.\n", "", 0, nil
+	})
+
+	patches, covered, err := NewPatchManager(p).ScanWithCoverage()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(patches) != 0 {
+		t.Fatalf("patches = %+v, want empty", patches)
+	}
+	if fmt.Sprint(covered) != "[winget]" {
+		t.Fatalf("covered = %v, want [winget]", covered)
 	}
 }
 


### PR DESCRIPTION
## Problem

`parseWingetUpgradeOutput` returned `nil` **with no error** when `findColumnBoundaries` found no table header (`agent/internal/patching/winget_parse.go:19-22`). A failed or garbled `winget upgrade` was therefore indistinguishable from "nothing to upgrade":

1. `SystemWingetProvider.Scan` passed the empty result off as a successful scan.
2. `PatchManager.ScanWithCoverage` counted `winget` as **covered**.
3. `coveredPatchSources` marked the `third_party` bucket covered.
4. The pending-patches upload swept the device's existing third-party pending rows to `missing`.

Net effect: a winget scan that never inspected anything **tombstoned rows it never looked at**. The `#2216` comment on `coveredPatchSources` already documented this as a known gap.

## Fix

- `parseWingetUpgradeOutput` returns `([]AvailablePatch, error)`, erroring with `errWingetNoTable` when there is no parsable header.
- `SystemWingetProvider.Scan` maps that to `ErrScanSkipped`, so `ScanWithCoverage` drops winget from coverage and the server sweeps nothing.
- Dropped the now-stale `INTERIM LIMITATION (until #2216 lands)` comment at `heartbeat.go:2318`.

### The part that needed care: "no header" is not always a failure

`winget upgrade` on a fully up-to-date machine prints **no header at all** — just `No installed package found matching input criteria.` Mapping *every* headerless output to a skip would have been a regression in the opposite direction: `third_party` would never be swept, and patches would stay `pending` forever after being installed.

So the parse now distinguishes three cases:

| Output | Result | Sweep behavior |
|---|---|---|
| Header present | rows parsed (empty is empty) | third_party swept |
| No header, explicit winget "matched nothing" message | confirmed-empty, no error | third_party swept |
| No header, no recognized message | `errWingetNoTable` → `ErrScanSkipped` | **nothing swept** |

Localized Windows lands in the third bucket (winget localizes both its column headers and these messages). That is the safe direction: stale pending rows survive rather than being wiped by a scan that saw nothing.

The skip error carries a bounded (`truncatePatchField`) stdout **and** stderr snippet — on the most common real trigger, localized headers, stderr is empty and the unparsable stdout head is the only diagnostic a tech has.

## Deliberately out of scope

- **`parseWingetListOutput`** is left unchanged. Verified the installed-patch path is a pure upsert with no sweep (`apps/api/src/routes/agents/patches.ts:376-406`, and the agent short-circuits on `len(installedItems) == 0` at `heartbeat.go:2243`), so an empty result there tombstones nothing. The pending path is the only one that reconciles.
- **The "binary unavailable" half** was already handled — `RegisterSystemWinget` only registers when winget resolves, and `Scan`'s exec/exit-code paths already return real errors.
- **`--scope machine` / per-user installs** is #2727 and needs design; not touched here.

## Tests

Table-driven, using a fake `cmdRunner` with canned output — **no Windows hardware needed**.

`winget_parse_test.go` → `TestParseWingetUpgradeOutputHeaderDetection` (10 cases): valid header multi-row, valid header zero rows, two explicit no-results messages, missing header, empty output, whitespace-only, garbled/ANSI bytes, localized header, out-of-order columns.

`winget_system_test.go`:
- `TestSystemScanUnreadableOutputIsSkippedNotEmpty` — 5 cases at the provider boundary, including "nonzero exit but readable table still scans".
- `TestSkippedSystemWingetIsNotCovered` — the regression guard that matters: a skipped winget must not appear in `ScanWithCoverage`'s covered set, or the fix is inert.
- `TestConfirmedEmptySystemWingetScanStaysCovered` — the counterpart, so this fix doesn't strand rows as `pending` forever.

### Verification

```
go test ./internal/patching/... ./internal/heartbeat/...
ok  github.com/breeze-rmm/agent/internal/patching   0.170s
ok  github.com/breeze-rmm/agent/internal/heartbeat  41.070s

go vet ./internal/patching/... ./internal/heartbeat/...   # clean
GOOS=windows go vet ./internal/patching/...               # clean
```

Note: `-race` could not be linked locally (no C compiler in this sandbox — `-race` requires cgo). CI's `test-agent` job runs `go test -race`.

Closes #2726

🤖 Generated with [Claude Code](https://claude.com/claude-code)