### PR TITLE
fix(web): shorten search trigger label + h1→h2 heading order in AI drawer (#2381)

### DIFF
--- a/apps/web/src/components/ai/AiChatMessages.tsx
+++ b/apps/web/src/components/ai/AiChatMessages.tsx
@@ -158,9 +158,15 @@ export default function AiChatMessages({
     return (
       <div className="flex flex-1 flex-col items-center justify-center p-6">
         <Bot className="h-10 w-10 text-muted-foreground" />
-        <h3 className="mt-3 text-sm font-medium text-foreground">
+        {/*
+          h2 (not h3) so the drawer heading follows the page <h1> without
+          skipping a level — screen-reader outline navigation depends on it.
+          Styling is intentionally unchanged; the visual size comes from the
+          text-sm/font-medium classes, not the tag. See issue #2381.
+        */}
+        <h2 className="mt-3 text-sm font-medium text-foreground">
           {t("aiChatMessages.title")}
-        </h3>
+        </h2>
         <p className="mt-1 text-xs text-muted-foreground">
           {t("aiChatMessages.description")}
         </p>

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -641,7 +641,7 @@
       }
     },
     "search": {
-      "prompt": "Geräte, Skripte, Warnmeldungen, Benutzer und Einstellungen durchsuchen",
+      "prompt": "Breeze durchsuchen",
       "placeholder": "Geräte, Skripte, Warnmeldungen, Benutzer und Einstellungen durchsuchen…",
       "searching": "Wird gesucht…",
       "startTyping": "Beginnen Sie mit der Eingabe, um Geräte, Skripte, Warnmeldungen, Benutzer und Einstellungen zu durchsuchen.",

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -641,7 +641,7 @@
       }
     },
     "search": {
-      "prompt": "Search devices, scripts, alerts, users, settings",
+      "prompt": "Search Breeze",
       "placeholder": "Search devices, scripts, alerts, users, settings…",
       "searching": "Searching…",
       "startTyping": "Start typing to search across devices, scripts, alerts, users, and settings.",

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -641,7 +641,7 @@
       }
     },
     "search": {
-      "prompt": "Buscar dispositivos, scripts, alertas, usuarios, configuraciones",
+      "prompt": "Buscar en Breeze",
       "placeholder": "Buscar dispositivos, scripts, alertas, usuarios, configuraciones…",
       "searching": "Buscando…",
       "startTyping": "Empiece a escribir para buscar en dispositivos, scripts, alertas, usuarios y configuraciones.",

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -641,7 +641,7 @@
       }
     },
     "search": {
-      "prompt": "Rechercher des appareils, scripts, alertes, utilisateurs et paramètres",
+      "prompt": "Rechercher dans Breeze",
       "placeholder": "Rechercher des appareils, scripts, alertes, utilisateurs et paramètres...",
       "searching": "Cherche...",
       "startTyping": "Commencez à saisir du texte pour rechercher parmi les appareils, scripts, alertes, utilisateurs et paramètres.",

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -641,7 +641,7 @@
       }
     },
     "search": {
-      "prompt": "Rechercher des appareils, scripts, alertes, utilisateurs et paramètres",
+      "prompt": "Rechercher dans Breeze",
       "placeholder": "Rechercher des appareils, scripts, alertes, utilisateurs et paramètres...",
       "searching": "Cherche...",
       "startTyping": "Commencez à taper pour rechercher entre appareils, scripts, alertes, utilisateurs et paramètres.",

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -641,7 +641,7 @@
       }
     },
     "search": {
-      "prompt": "Cerca dispositivi, script, avvisi, utenti, impostazioni",
+      "prompt": "Cerca in Breeze",
       "placeholder": "Cerca dispositivi, script, avvisi, utenti, impostazioni...",
       "searching": "Ricerca…",
       "startTyping": "Inizia a digitare per eseguire ricerche tra dispositivi, script, avvisi, utenti e impostazioni.",

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -641,7 +641,7 @@
       }
     },
     "search": {
-      "prompt": "Pesquisar dispositivos, scripts, alertas, usuários e configurações",
+      "prompt": "Pesquisar no Breeze",
       "placeholder": "Pesquisar dispositivos, scripts, alertas, usuários e configurações…",
       "searching": "Pesquisando…",
       "startTyping": "Comece a digitar para pesquisar dispositivos, scripts, alertas, usuários e configurações.",


### PR DESCRIPTION
Closes #2381

Three app-shell findings from the design scan. Two were real and are fixed; the third was audit-only and needs no code change.

## 1. Global search placeholder overflowed its box — fixed

The header search trigger renders `layout.search.prompt` in a `min-w-0 flex-1 truncate whitespace-nowrap` span (`apps/web/src/components/layout/CommandPalette.tsx:556`). Truncation was already wired up correctly, so nothing was visually spilling — but the container is `xl:flex-1 xl:max-w-md` (448px ceiling, `Header.tsx:281`) and the row also carries a 16px search icon, `px-3`/`gap-2` spacing, and the ⌘K badge. That leaves roughly ~250-350px for text, and the label was wider than that at common widths, so it was *permanently* ellipsised — the user never saw the end of it, and the scan measured the overflow.

Rather than accept a label that is always cut off, the trigger label is now short enough to fit outright:

| Locale | Before | After |
|---|---|---|
| en | Search devices, scripts, alerts, users, settings | Search Breeze |
| de-DE | Geräte, Skripte, Warnmeldungen, Benutzer und Einstellungen durchsuchen | Breeze durchsuchen |
| es-419 | Buscar dispositivos, scripts, alertas, usuarios, configuraciones | Buscar en Breeze |
| fr-CA | Rechercher des appareils, scripts, alertes, utilisateurs et paramètres | Rechercher dans Breeze |
| fr-FR | Rechercher des appareils, scripts, alertes, utilisateurs et paramètres | Rechercher dans Breeze |
| it-IT | Cerca dispositivi, script, avvisi, utenti, impostazioni | Cerca in Breeze |
| pt-BR | Pesquisar dispositivos, scripts, alertas, usuários e configurações | Pesquisar no Breeze |

Shortening only the English string would have left the bug in place for the other six locales — the German and French strings were ~45% longer than English, so they overflowed worst.

**No discoverability is lost:** the full category list still lives on `layout.search.placeholder`, which is the input inside the *open* palette (a `max-w-2xl` dialog with plenty of room), and `layout.search.startTyping` repeats it in the empty state. Both are untouched. The trigger only has to say "this is search".

Note this repo has **seven** locales, not five — `de-DE, en, es-419, fr-CA, fr-FR, it-IT, pt-BR` — and the key lives in `common.json` under `layout.search.prompt`, not in a `layout.json` namespace. All seven are updated.

## 2. Skipped heading level (h1 → h3) — fixed

`apps/web/src/components/ai/AiChatMessages.tsx:161` rendered the assistant empty-state title ("Breeze AI Assistant") as `<h3>` directly after the page `<h1>`, with no `<h2>` in between, which breaks screen-reader outline navigation. Now an `<h2>`.

Verified this is the correct level and creates no new conflict: it is the only heading in the drawer (`AiChatSidebar.tsx` renders its own title at line 163 in a non-heading element), so `<h2>` makes it the drawer's top-level heading directly under the page `<h1>`. Styling is unchanged — the visual size comes from `text-sm font-medium`, not the tag.

## 3. Layout containers clipping positioned children — audited, no change needed

**Verdict: not reproducible against the shell containers.** The CSS containment claim is technically accurate — `DashboardLayout.astro:42` (`flex h-screen overflow-hidden`) and `:44` (`flex flex-1 flex-col overflow-hidden`) do establish clip boxes, and neither carries `relative` — but no popover actually gets cut off, because every shell overlay already sidesteps them:

| Overlay | Mechanism |
|---|---|
| `Dialog.tsx:123`, `Drawer.tsx:87` | `createPortal` + `fixed inset-0 z-50` |
| Command palette (`CommandPalette.tsx:564`) | `fixed inset-0 z-50` |
| `Toast.tsx:76`, AI sidebar, HelpPanel, OnboardingTour | mounted as siblings **outside** both clip boxes (`DashboardLayout.astro:55-58`) |
| Mobile sidebar (`Sidebar.tsx:804,808`) | `fixed` |
| Header menus — theme `Header.tsx:353`, user `:424`, `NotificationCenter.tsx:356`, `OrgSwitcher.tsx:239`, `TimerWidget.tsx:105` | plain `absolute`, but anchored at the top of a viewport-height column and opening downward into ~`100vh − 64px`, each either short or self-capping (`max-h-96`, `max-h-[calc(100vh-220px)]`, `max-w-[calc(100vw-1.5rem)]`) |
| `HelpTooltip.tsx:79/91` | dual strategy — `absolute` for `side='top'`, `fixed` from a measured trigger rect for `side='bottom'` |

There is no `components/ui/` directory and no Radix/floating-ui dependency in this repo; all overlays are hand-rolled. For the header menus, being clipped by a viewport-sized container is indistinguishable from being cut by the viewport itself, which the `max-h`/`max-w` clamps already prevent. The codebase also already recognises this bug class and solves it correctly where it matters — see the portal + `fixed` anchor comment at `DeviceList.tsx:570-582`.

### One real clip found, but out of scope for this issue

The sweep did surface a genuine clipped dropdown — just not in the shell:

- `apps/web/src/components/settings/EnrollmentKeyManager.tsx:563` — an `absolute right-0 top-full z-10` installer-download menu inside a table row whose ancestor is `<div className="overflow-x-auto">` (`:476`). Because `overflow-x: auto` makes `overflow-y` compute to `auto`, a `top-full` menu on the last rows is clipped/scroll-trapped. Same shape as the bug `DeviceList` already portals around.
- Fragile but not currently broken: `OverflowTabs.tsx:149` (`absolute top-full z-20`) would clip if ever dropped inside a `ResponsiveTable` `overflow-x-auto` wrapper.

Left untouched deliberately to keep this PR scoped to the reported shell issue — worth a follow-up issue retargeted at `EnrollmentKeyManager`.

## Testing

- `vitest run --pool=forks --no-file-parallelism` over `src/lib/i18n/`, `src/components/layout/`, `src/components/ai/AiChatMessages.test.tsx`, `AiChatSidebar.test.tsx`, `WorkspaceChatPanel.test.tsx` — **19 files / 189 tests passed**. This covers the i18n contract suites (`localeParity`, `translationCoverage`, `keyUsage`, `extractionQuality`) that guard the locale catalogs.
- `eslint src/components/ai/AiChatMessages.tsx` — clean.
- No test asserted on the old heading level or the old prompt string, so no test needed updating; changing a string *value* (not a key) keeps locale parity intact.

Locale JSON was edited line-precise and re-parsed for all seven files, so the diff is exactly one line per catalog with no reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)