### PR TITLE
fix(api): clear superseded token suspension on offboarding drain entry (#2785)

### DIFF
--- a/apps/api/src/__tests__/integration/offboardingDrainSuspendedEntry.integration.test.ts
+++ b/apps/api/src/__tests__/integration/offboardingDrainSuspendedEntry.integration.test.ts
@@ -1,0 +1,189 @@
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { withSystemDbAccessContext } from '../../db';
+import { deviceCommands, devices, organizations } from '../../db/schema';
+import { AGENT_TOKEN_SUSPEND_REASON } from '../../services/agentTokenSuspension';
+import { claimPendingCommandsForDevice } from '../../services/commandDispatch';
+import { beginOrganizationOffboarding } from '../../services/tenantOffboarding';
+import { getAgentTenantState, invalidateAgentTenantCache } from '../../services/tenantStatus';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+/**
+ * #2785 — offboarding drain entered from `suspended`/`churned`.
+ *
+ * The mocked unit suite can only prove that the drain issues an UPDATE with the
+ * right WHERE clause. The property that actually matters is DELIVERABILITY: a
+ * device that was token-suspended by an earlier sever must, after the
+ * transition, be able to CLAIM its queued `self_uninstall`. agentAuthMiddleware
+ * 401s on `devices.agent_token_suspended_at` *before* it ever reaches the drain
+ * narrowing, so leaving the column set means the uninstall sits `pending` for
+ * the whole 72h window and the tenant finalizes with a "never drained" report —
+ * the exact failure #2774 exists to remove.
+ *
+ * This drives the real service against real Postgres: real enum values, real
+ * RLS/system contexts, real `device_commands` claim CAS.
+ */
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+const SUSPEND_REASON = AGENT_TOKEN_SUSPEND_REASON.tenantSuspended;
+const PROBE_REASON = AGENT_TOKEN_SUSPEND_REASON.crossTenantProbe;
+
+async function seedDevice(
+  orgId: string,
+  siteId: string,
+  label: string,
+  suspendedReason: string | null
+): Promise<{ id: string }> {
+  const agentId = `agent-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId,
+      hostname: `host-${label}`,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+      // The precondition: an earlier sever (or a cross-tenant probe) already
+      // locked this device's agent token.
+      agentTokenSuspendedAt: suspendedReason ? new Date() : null,
+      agentTokenSuspendedReason: suspendedReason,
+    })
+    .returning({ id: devices.id });
+  return { id: row!.id };
+}
+
+/**
+ * The PATCH route commits `status='offboarding'` BEFORE calling
+ * begin*Offboarding (see tenantOffboarding.repairIncompleteEntry's comment), so
+ * the fixture must do the same or getAgentTenantState would never report
+ * 'draining'.
+ */
+async function commitOffboardingStatus(orgId: string): Promise<void> {
+  await getTestDb()
+    .update(organizations)
+    .set({ status: 'offboarding', updatedAt: new Date() })
+    .where(eq(organizations.id, orgId));
+  await invalidateAgentTenantCache([orgId]);
+}
+
+async function readSuspension(deviceId: string) {
+  const [row] = await getTestDb()
+    .select({
+      suspendedAt: devices.agentTokenSuspendedAt,
+      reason: devices.agentTokenSuspendedReason,
+    })
+    .from(devices)
+    .where(eq(devices.id, deviceId));
+  return row!;
+}
+
+async function readPendingUninstalls(deviceId: string) {
+  return getTestDb()
+    .select({ id: deviceCommands.id, status: deviceCommands.status })
+    .from(deviceCommands)
+    .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'self_uninstall')));
+}
+
+describe('#2785 offboarding drain entered from a severed state', () => {
+  runDb(
+    'a previously tenant-suspended device can actually CLAIM its queued self_uninstall',
+    async () => {
+      const partner = await createPartner({ status: 'active' });
+      // Entering the drain from `suspended` — the transition #2781 never covered.
+      const org = await createOrganization({ partnerId: partner.id, status: 'suspended' });
+      const site = await createSite({ orgId: org.id });
+      const stranded = await seedDevice(org.id, site.id, 'stranded', SUSPEND_REASON);
+
+      await commitOffboardingStatus(org.id);
+      await beginOrganizationOffboarding(org.id, null);
+
+      // 1. The superseded suspension is gone, so agentAuthMiddleware's
+      //    pre-tenant-state 401 no longer fires for this device.
+      const after = await readSuspension(stranded.id);
+      expect(after.suspendedAt).toBeNull();
+      expect(after.reason).toBeNull();
+
+      // 2. The tenant reads as draining, so the agent surface narrows rather
+      //    than closing.
+      await expect(getAgentTenantState(org.id)).resolves.toBe('draining');
+
+      // 3. The uninstall was queued...
+      const queued = await readPendingUninstalls(stranded.id);
+      expect(queued).toHaveLength(1);
+      expect(queued[0]!.status).toBe('pending');
+
+      // 4. ...and is genuinely deliverable: the drain-narrowed claim (the exact
+      //    allowlist routes/agents/commands.ts passes when tenantDraining) hands
+      //    it over and CAS-flips it to `sent`. This is the end-to-end property;
+      //    everything above is intermediate state.
+      const claimed = await withSystemDbAccessContext(() =>
+        claimPendingCommandsForDevice(stranded.id, 10, 'agent', ['self_uninstall'])
+      );
+      expect(claimed.map((row) => row.type)).toEqual(['self_uninstall']);
+
+      const afterClaim = await readPendingUninstalls(stranded.id);
+      expect(afterClaim[0]!.status).toBe('sent');
+    }
+  );
+
+  runDb('churned → offboarding is equally deliverable', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'churned' });
+    const site = await createSite({ orgId: org.id });
+    const stranded = await seedDevice(org.id, site.id, 'churned', SUSPEND_REASON);
+
+    await commitOffboardingStatus(org.id);
+    await beginOrganizationOffboarding(org.id, null);
+
+    expect((await readSuspension(stranded.id)).suspendedAt).toBeNull();
+    const claimed = await withSystemDbAccessContext(() =>
+      claimPendingCommandsForDevice(stranded.id, 10, 'agent', ['self_uninstall'])
+    );
+    expect(claimed.map((row) => row.type)).toEqual(['self_uninstall']);
+  });
+
+  runDb(
+    'a probe-suspended device stays suspended, and another tenant is never touched',
+    async () => {
+      const partner = await createPartner({ status: 'active' });
+      const org = await createOrganization({ partnerId: partner.id, status: 'suspended' });
+      const site = await createSite({ orgId: org.id });
+      const stranded = await seedDevice(org.id, site.id, 'stranded', SUSPEND_REASON);
+      // Same org, different reason tag: a security suspension the drain must NOT
+      // launder into a working credential.
+      const probed = await seedDevice(org.id, site.id, 'probed', PROBE_REASON);
+
+      // A completely separate tenant, also tenant-suspended: the restore is
+      // scoped to the draining org ids, so this must be untouched.
+      const otherPartner = await createPartner({ status: 'suspended' });
+      const otherOrg = await createOrganization({
+        partnerId: otherPartner.id,
+        status: 'suspended',
+      });
+      const otherSite = await createSite({ orgId: otherOrg.id });
+      const bystander = await seedDevice(otherOrg.id, otherSite.id, 'bystander', SUSPEND_REASON);
+
+      await commitOffboardingStatus(org.id);
+      await beginOrganizationOffboarding(org.id, null);
+
+      expect((await readSuspension(stranded.id)).suspendedAt).toBeNull();
+
+      const probeAfter = await readSuspension(probed.id);
+      expect(probeAfter.suspendedAt).not.toBeNull();
+      expect(probeAfter.reason).toBe(PROBE_REASON);
+
+      const bystanderAfter = await readSuspension(bystander.id);
+      expect(bystanderAfter.suspendedAt).not.toBeNull();
+      expect(bystanderAfter.reason).toBe(SUSPEND_REASON);
+      // ...and no command was queued into the bystander tenant.
+      expect(await readPendingUninstalls(bystander.id)).toHaveLength(0);
+    }
+  );
+});

--- a/apps/api/src/services/tenantLifecycle.test.ts
+++ b/apps/api/src/services/tenantLifecycle.test.ts
@@ -317,6 +317,7 @@ describe('tenantLifecycle — agent fleet severance', () => {
         // (vi.clearAllMocks in beforeEach clears calls, not implementations).
         vi.mocked(disconnectAgent).mockImplementationOnce(() => {
           order.push('disconnect');
+          return 'closed';
         });
         const recordInvalidate = async () => {
           order.push('invalidate');

--- a/apps/api/src/services/tenantLifecycle.test.ts
+++ b/apps/api/src/services/tenantLifecycle.test.ts
@@ -223,8 +223,11 @@ describe('tenantLifecycle — agent fleet severance', () => {
 
       const result = await revokeOrganizationTenantAccess('org-1', { agentChannel: 'drain' });
 
-      // No devices UPDATE: agent tokens stay valid for the drain window.
-      expect(updateLog.some((u) => u.table === devices)).toBe(false);
+      // The ONLY devices UPDATE is the #2785 unsuspend — never a suspend. Agent
+      // tokens must stay valid for the drain window.
+      const deviceUpdates = updateLog.filter((u) => u.table === devices);
+      expect(deviceUpdates).toHaveLength(1);
+      expect(deviceUpdates[0]!.values.agentTokenSuspendedAt).toBeNull();
       // Enrollment keys still expire — no NEW devices during a drain.
       expect(updateLog.some((u) => u.table === enrollmentKeys)).toBe(true);
       expect(invalidateAgentTenantCache).toHaveBeenCalledWith(['org-1']);
@@ -249,9 +252,115 @@ describe('tenantLifecycle — agent fleet severance', () => {
 
       const result = await revokePartnerTenantAccess('partner-1', { agentChannel: 'drain' });
 
-      expect(updateLog.some((u) => u.table === devices)).toBe(false);
+      const deviceUpdates = updateLog.filter((u) => u.table === devices);
+      expect(deviceUpdates).toHaveLength(1);
+      expect(deviceUpdates[0]!.values.agentTokenSuspendedAt).toBeNull();
       expect(updateLog.some((u) => u.table === enrollmentKeys)).toBe(true);
       expect(result.agentTokensSuspended).toBe(0);
+    });
+
+    // #2785 — entering the drain from suspended/churned. agentAuthMiddleware
+    // 401s on devices.agentTokenSuspendedAt BEFORE it reaches the drain
+    // narrowing, so a drain that leaves a prior sever's suspension in place
+    // queues self_uninstalls that can never be delivered.
+    describe('#2785 supersedes a prior token suspension', () => {
+      it('clears the tenant-suspension so the queued self_uninstall is deliverable', async () => {
+        queueSelect([{ userId: 'u1' }]); // organizationUsers
+        returningByTable.set(devices, [{ id: 'd1' }, { id: 'd2' }]);
+
+        await revokeOrganizationTenantAccess('org-1', { agentChannel: 'drain' });
+
+        const deviceUpdate = updateLog.find((u) => u.table === devices)!;
+        expect(deviceUpdate.values.agentTokenSuspendedAt).toBeNull();
+        expect(deviceUpdate.values.agentTokenSuspendedReason).toBeNull();
+      });
+
+      it('scopes the unsuspend to the draining orgs AND the tenant_suspended reason tag', async () => {
+        queueSelect([{ userId: 'u1' }]); // organizationUsers
+
+        await revokeOrganizationTenantAccess('org-1', { agentChannel: 'drain' });
+
+        const deviceUpdate = updateLog.find((u) => u.table === devices)!;
+        const clauses = andClauses(deviceUpdate.where);
+        // Tenant isolation: only the orgs being drained.
+        expect(clauses).toContainEqual({ inArray: ['devices.orgId', ['org-1']] });
+        // Reason-tag isolation: a cross-tenant-probe (or any other) suspension
+        // must survive the transition. Dropping this predicate would turn the
+        // drain into a fleet-wide unsuspend — assert it explicitly.
+        expect(clauses).toContainEqual({
+          eq: ['devices.agentTokenSuspendedReason', 'tenant_suspended'],
+        });
+        // ...and the UPDATE writes nothing beyond lifting the suspension.
+        expect(Object.keys(deviceUpdate.values).sort()).toEqual([
+          'agentTokenSuspendedAt',
+          'agentTokenSuspendedReason',
+        ]);
+      });
+
+      it('never writes a suspension timestamp in drain mode', async () => {
+        queueSelect([{ userId: 'u1' }]); // organizationUsers
+
+        await revokeOrganizationTenantAccess('org-1', { agentChannel: 'drain' });
+
+        for (const update of updateLog.filter((u) => u.table === devices)) {
+          expect(update.values.agentTokenSuspendedAt).toBeNull();
+          expect(update.values.agentTokenSuspendedReason).toBeNull();
+        }
+      });
+
+      it('lifts the suspension AFTER the socket sever, before the final cache drop', async () => {
+        const order: string[] = [];
+        queueSelect([{ userId: 'u1' }]); // organizationUsers
+        queueSelect([{ agentId: 'agent-live' }]); // devices in org (socket sweep)
+        vi.mocked(getConnectedAgentIds).mockReturnValueOnce(['agent-live']);
+        // ...Once variants so these implementations can't leak into later tests
+        // (vi.clearAllMocks in beforeEach clears calls, not implementations).
+        vi.mocked(disconnectAgent).mockImplementationOnce(() => {
+          order.push('disconnect');
+        });
+        const recordInvalidate = async () => {
+          order.push('invalidate');
+        };
+        vi.mocked(invalidateAgentTenantCache)
+          .mockImplementationOnce(recordInvalidate)
+          .mockImplementationOnce(recordInvalidate);
+        const baseUpdate = vi.mocked(db.update).getMockImplementation()!;
+        vi.mocked(db.update).mockImplementation((table: any) => {
+          if (table === devices) order.push('unsuspend');
+          return baseUpdate(table);
+        });
+
+        await revokeOrganizationTenantAccess('org-1', { agentChannel: 'drain' });
+
+        // Restore must not re-open the auth gate before live sockets are torn
+        // down, and the cache invalidation stays the LAST write (in drain mode
+        // the cache IS the narrowing gate).
+        expect(order.indexOf('unsuspend')).toBeGreaterThan(order.indexOf('disconnect'));
+        expect(order[order.length - 1]).toBe('invalidate');
+      });
+
+      it('partner drain lifts suspensions across every org under the partner', async () => {
+        queueSelect([{ id: 'org-1' }, { id: 'org-2' }]); // organizations under partner
+        queueSelect([{ userId: 'pu1' }]); // partnerUsers
+        queueSelect([{ userId: 'ou1' }]); // org memberships
+
+        await revokePartnerTenantAccess('partner-1', { agentChannel: 'drain' });
+
+        const clauses = andClauses(updateLog.find((u) => u.table === devices)!.where);
+        expect(clauses).toContainEqual({ inArray: ['devices.orgId', ['org-1', 'org-2']] });
+        expect(clauses).toContainEqual({
+          eq: ['devices.agentTokenSuspendedReason', 'tenant_suspended'],
+        });
+      });
+
+      it('drain with no orgs under the partner touches no devices', async () => {
+        queueSelect([]); // organizations under partner
+        queueSelect([{ userId: 'pu1' }]); // partnerUsers
+
+        await revokePartnerTenantAccess('partner-1', { agentChannel: 'drain' });
+
+        expect(updateLog.some((u) => u.table === devices)).toBe(false);
+      });
     });
   });
 });

--- a/apps/api/src/services/tenantLifecycle.ts
+++ b/apps/api/src/services/tenantLifecycle.ts
@@ -139,17 +139,43 @@ export async function severAgentCredentialsForOrgIds(
  * draining tenant must not keep an interactive control channel). Agent tokens
  * are deliberately left untouched: they are the delivery path for the queued
  * self_uninstall.
+ *
+ * #2785: "left untouched" is not enough when the drain is entered from
+ * `suspended`/`churned`, where an earlier sever already set
+ * devices.agentTokenSuspendedAt. agentAuthMiddleware checks that column BEFORE
+ * it consults the tenant state (agentAuth.ts: suspension 401 precedes the
+ * getAgentTenantState drain narrowing), so those devices 401 on every poll for
+ * the whole drain window and the queued self_uninstall is undeliverable by
+ * construction — the exact failure #2774 exists to remove. So the drain also
+ * LIFTS the suspensions it is superseding, reusing
+ * restoreAgentCredentialsForOrgIds for its narrowness: scoped to these orgIds
+ * and to reason=TENANT_SUSPENDED_TOKEN_REASON, so a cross-tenant-probe
+ * suspension (or any other reason tag) survives the transition untouched.
  */
 export async function prepareAgentDrainForOrgIds(
   orgIds: string[]
-): Promise<{ enrollmentKeysInvalidated: number }> {
+): Promise<{ enrollmentKeysInvalidated: number; agentTokensRestored: number }> {
   if (orgIds.length === 0) {
-    return { enrollmentKeysInvalidated: 0 };
+    return { enrollmentKeysInvalidated: 0, agentTokensRestored: 0 };
   }
 
   await invalidateAgentTenantCache(orgIds);
   const enrollmentKeysInvalidated = await expireEnrollmentKeysForOrgIds(orgIds, new Date());
   await disconnectLiveAgentSocketsForOrgIds(orgIds, 'Tenant offboarding');
+  // Lift the superseded tenant-suspensions AFTER the socket sever, not before:
+  // clearing the flag re-opens this fleet's auth gate, and a device that
+  // reconnected between the restore and the sever sweep's device read would keep
+  // a full WS control channel until the reaper's next re-sweep. Callers
+  // (begin*Offboarding) await this whole function before queueDrainUninstalls,
+  // so the unsuspend still lands before any self_uninstall is queued.
+  const { agentTokensRestored } = await restoreAgentCredentialsForOrgIds(orgIds);
+  if (agentTokensRestored > 0) {
+    // Operationally load-bearing: this is the only signal that a drain was
+    // entered from an already-severed state, i.e. the stranded-fleet case.
+    console.warn(
+      `[tenantLifecycle] drain entry lifted ${agentTokensRestored} superseded tenant-suspension(s) so the queued self_uninstall is deliverable`
+    );
+  }
   // Invalidate a SECOND time, after the teardown. In sever mode the cache is
   // only an optimization (agentTokenSuspendedAt is the real-time cutoff), but
   // in drain mode tokens stay alive, so this cache IS the gate: a read that
@@ -160,7 +186,7 @@ export async function prepareAgentDrainForOrgIds(
   // socket re-sweep bounds whatever still slips through.
   await invalidateAgentTenantCache(orgIds);
 
-  return { enrollmentKeysInvalidated };
+  return { enrollmentKeysInvalidated, agentTokensRestored };
 }
 
 /**
@@ -169,6 +195,13 @@ export async function prepareAgentDrainForOrgIds(
  * probe suspensions intact. Expired enrollment keys are NOT un-expired —
  * operators regenerate keys; silently reviving an arbitrarily old key would be
  * wrong.
+ *
+ * Two callers, both narrow by construction: reactivation
+ * (restore{Organization,Partner}TenantAccess) and drain entry
+ * (prepareAgentDrainForOrgIds, #2785). Both pass an explicit org-id list, and
+ * the reason-tag equality is the second half of the guard — keep BOTH
+ * predicates on any future edit, or a drain/reactivation would silently lift a
+ * security-driven suspension.
  */
 async function restoreAgentCredentialsForOrgIds(orgIds: string[]): Promise<TenantRestorationResult> {
   if (orgIds.length === 0) return { agentTokensRestored: 0 };

--- a/apps/api/src/services/tenantOffboarding.test.ts
+++ b/apps/api/src/services/tenantOffboarding.test.ts
@@ -67,7 +67,10 @@ const REVOCATION_RESULT = {
 
 vi.mock('./tenantLifecycle', () => ({
   disconnectLiveAgentSocketsForOrgIds: vi.fn(async () => undefined),
-  prepareAgentDrainForOrgIds: vi.fn(async () => ({ enrollmentKeysInvalidated: 0 })),
+  prepareAgentDrainForOrgIds: vi.fn(async () => ({
+    enrollmentKeysInvalidated: 0,
+    agentTokensRestored: 0,
+  })),
   revokeOrganizationTenantAccess: vi.fn(async () => ({
     apiKeysRevoked: 0,
     userSessionsRevoked: 0,
@@ -106,6 +109,7 @@ import { deviceCommands, devices, organizations, partners } from '../db/schema';
 import { writeAuditEvent } from './auditEvents';
 import {
   disconnectLiveAgentSocketsForOrgIds,
+  prepareAgentDrainForOrgIds,
   revokeOrganizationTenantAccess,
   revokePartnerTenantAccess,
   severAgentCredentialsForOrgIds,
@@ -519,6 +523,28 @@ describe('sweepOffboardingTenants', () => {
       expect.objectContaining({ action: 'organization.offboarding_entry_repaired' })
     );
     expect(severAgentCredentialsForOrgIds).not.toHaveBeenCalled();
+  });
+
+  // #2785: the drain prep is what lifts a superseded token suspension, so the
+  // repair path must run it BEFORE queueing — same order as begin*Offboarding.
+  // Queue-first would leave the uninstall pending against a fleet still 401ing.
+  it('runs drain prep before queueing uninstalls when repairing an entry', async () => {
+    let insertsAtPrepareTime = -1;
+    vi.mocked(prepareAgentDrainForOrgIds).mockImplementationOnce(async () => {
+      insertsAtPrepareTime = insertLog.length;
+      return { enrollmentKeysInvalidated: 0, agentTokensRestored: 0 };
+    });
+    queueCandidates([{ id: 'org-1', startedAt: null }], []);
+    queueSelect([{ id: 'd1' }]); // devices to queue
+    queueSelect([]); // no existing uninstalls
+
+    await sweepOffboardingTenants(NOW);
+
+    expect(prepareAgentDrainForOrgIds).toHaveBeenCalledWith(['org-1']);
+    // Nothing had been queued yet when the prep (the #2785 unsuspend) ran...
+    expect(insertsAtPrepareTime).toBe(0);
+    // ...and the uninstall was queued after it, not skipped.
+    expect(insertLog[0]!.rows[0]).toMatchObject({ deviceId: 'd1', type: 'self_uninstall' });
   });
 
   // One bad tenant must not starve every other draining tenant's finalization

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -546,8 +546,11 @@ async function repairIncompleteEntry(
   console.warn(
     `[tenantOffboarding] ${scope} ${scopeId} is offboarding with no drain stamp — completing the entry`
   );
-  const queued = await queueDrainUninstalls(orgIds, null);
+  // Drain prep FIRST, matching begin*Offboarding: #2785 made this step the one
+  // that lifts a superseded token suspension, so queueing before it would leave
+  // a window where the uninstall exists but the fleet is still 401ing.
   await prepareAgentDrainForOrgIds(orgIds);
+  const queued = await queueDrainUninstalls(orgIds, null);
 
   if (scope === 'organization') {
     await db


### PR DESCRIPTION
Closes #2785

## Problem

`offboarding` drain entered from `suspended` or `churned` queues `self_uninstall`
commands that can never be delivered. Three facts combine:

1. `prepareAgentDrainForOrgIds` deliberately leaves agent tokens alive (that is
   the point of drain mode) but never **clears** a suspension already set by an
   earlier sever.
2. `agentAuthMiddleware` 401s on `devices.agent_token_suspended_at` at
   `middleware/agentAuth.ts:387` — *before* the drain narrowing at
   `middleware/agentAuth.ts:546`. A severed device never reaches the drain branch.
3. Nothing validates status transitions, so `suspended → offboarding` and
   `churned → offboarding` are both reachable via a normal `PATCH /orgs/:id`.

Net effect: the agent 401s on every poll for 72h, the drain reaper finalizes to
`churned`, and the per-device report claims the fleet never drained — the exact
false-confidence failure #2774 exists to remove, reintroduced on the transitions
#2781 didn't cover. It's also the blocker for cleaning up the already-stranded
agents in US prod, because the only route through today is
`churned → active → offboarding`, and the intermediate `active` hop briefly
restores portal login for an ex-customer.

## Fix

`prepareAgentDrainForOrgIds` now lifts the suspensions the drain supersedes by
reusing the existing module-private `restoreAgentCredentialsForOrgIds` — chosen
over teaching `agentAuth` to ignore suspension while draining, which would widen
the auth gate and resurrect probe-suspended devices too.

**Narrowness is the whole safety argument**, and it comes from the reused helper
rather than new code. The UPDATE carries both predicates:

```ts
.where(and(
  inArray(devices.orgId, orgIds),                                       // only the draining orgs
  eq(devices.agentTokenSuspendedReason, TENANT_SUSPENDED_TOKEN_REASON)  // only 'tenant_suspended'
))
```

So a `cross-tenant-probe` suspension (or any future reason tag) survives the
transition, and no other tenant's credentials are touched. Two unit tests assert
each predicate directly, because a dropped predicate would turn a drain entry
into a fleet-wide unsuspend and still pass a shape-only test.

**Ordering.** The unsuspend runs *after* the live-socket sever and *before* the
final `invalidateAgentTenantCache` (which stays the last write — in drain mode
the cache *is* the narrowing gate). Restoring before the sever would re-open the
auth gate while the sever sweep's device read was still in flight, leaving a
reconnected device with a full WS control channel until the reaper's next
re-sweep. Callers await the whole function before `queueDrainUninstalls`, so the
unsuspend still lands before any uninstall is queued.

`repairIncompleteEntry` (drain reaper) was queue-then-prepare; it is now
prepare-then-queue to match `begin*Offboarding`, so there is no window where an
uninstall is queued against a fleet that is still 401ing. Guarded by a new
ordering test.

Also added: a `console.warn` when the count is non-zero. It is the only signal
that a drain was entered from an already-severed state, which is exactly the
population being cleaned up in prod.

## Out of scope (deliberately)

**Whether `churned → offboarding` should be permitted at all.** The issue raises
it, and it is a real question — today it's reachable only because nothing
validates status transitions, which is a weaker reason than a deliberate one.
That is transition-validation design (does re-draining a churned tenant deserve
a dedicated admin action?), not a bug fix, so it is left for a separate decision.
This PR makes the transition *work correctly* if taken; it does not rule on
whether it should be takeable.

## Verification

- `apps/api/src/services/tenantLifecycle.test.ts` — 16 passed. **6 of them fail
  on `origin/main`** (verified by reverting the source file and re-running), so
  they are genuine regression guards, not restatements of the new code.
- `apps/api/src/services/tenantOffboarding.test.ts` — 20 passed, incl. the new
  repair-ordering test, which was also verified to fail against the old
  queue-then-prepare order.
- Also green single-fork: `routes/orgs.test.ts` + `middleware/agentAuth.test.ts`
  (216), `services/{deleteTenant,aiToolsOrgs,tenantStatus}.test.ts`.
- `tsc --noEmit` clean on `apps/api`.
- New integration test
  `apps/api/src/__tests__/integration/offboardingDrainSuspendedEntry.integration.test.ts`
  drives the real service against Postgres and asserts the property that
  actually matters — **deliverability**: a previously `tenant_suspended` device
  ends up able to *claim* its queued `self_uninstall` via
  `claimPendingCommandsForDevice(..., ['self_uninstall'])` (the same allowlist
  the drain-narrowed route passes), plus the `churned → offboarding` case, a
  probe-suspended device staying suspended, and a separate tenant being
  untouched.
  **Not executed locally** — this sandbox has no Postgres, Redis, or Docker
  (`.env.test` absent, ports closed), so it is typechecked and pattern-matched
  against existing integration suites but its first real run will be CI's
  Integration Tests job. Flagging explicitly rather than implying it was green.

No schema, migration, or new table — no RLS/cascade registration applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
