### PR TITLE
fix(api): map object-storage upload failures to actionable 502/503 (#2794)

### DIFF
--- a/apps/api/src/routes/partner_multi_org_orgid.test.ts
+++ b/apps/api/src/routes/partner_multi_org_orgid.test.ts
@@ -180,11 +180,18 @@ vi.mock('../db/schema', () => ({
 vi.mock('../services', () => ({}));
 vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn(), writeAuditEvent: vi.fn() }));
 vi.mock('../services/deploymentTargetResolver', () => ({ resolveDeploymentTargets: vi.fn().mockResolvedValue([]) }));
-vi.mock('../services/s3Storage', () => ({
-  uploadBinary: vi.fn(),
-  getPresignedUrl: vi.fn(() => Promise.resolve('https://s3.example.com/presigned')),
-  isS3Configured: vi.fn(() => false),
-}));
+vi.mock('../services/s3Storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/s3Storage')>();
+  return {
+    uploadBinary: vi.fn(),
+    getPresignedUrl: vi.fn(() => Promise.resolve('https://s3.example.com/presigned')),
+    isS3Configured: vi.fn(() => false),
+    // routes/software.ts branches on these with `instanceof` (#2794); a mock
+    // that omits them makes the export access throw.
+    S3ConfigError: actual.S3ConfigError,
+    S3OperationError: actual.S3OperationError,
+  };
+});
 vi.mock('../services/redis', () => ({
   isRedisAvailable: vi.fn(() => false),
   getRedisConnection: vi.fn(),

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -444,6 +444,27 @@ describe('software routes', () => {
         expect(body.error).toMatch(/S3_ENDPOINT/);
       });
 
+      // `message` quotes the offending S3_ENDPOINT value (redacted at the
+      // source, but still server config). The 503 body must use
+      // `clientMessage`, which drops the value entirely — belt and braces, so
+      // a future S3ConfigError thrower can't leak through this route (#2794).
+      it('does not echo inline endpoint credentials in the 503 body', async () => {
+        vi.mocked(uploadBinary).mockRejectedValueOnce(
+          new S3ConfigError(
+            'Invalid S3_ENDPOINT env var: S3 endpoint "s3://AKIAIOSFODNN7EXAMPLE:sUp3r-s3cr3t@host" is not a valid URL.',
+            'The S3_ENDPOINT env var is not a valid URL.'
+          )
+        );
+
+        const res = await uploadOnce();
+        const body = await res.json();
+
+        expect(res.status).toBe(503);
+        expect(JSON.stringify(body)).not.toMatch(/AKIAIOSFODNN7EXAMPLE/);
+        expect(JSON.stringify(body)).not.toMatch(/sUp3r-s3cr3t/);
+        expect(body.error).toMatch(/S3_ENDPOINT/);
+      });
+
       it('maps an unrecognized throw to 502 without echoing the raw error', async () => {
         vi.mocked(uploadBinary).mockRejectedValueOnce(
           new Error('ENOENT: open /tmp/breeze-uploads/secret-path.upload')

--- a/apps/api/src/routes/software.test.ts
+++ b/apps/api/src/routes/software.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { softwareRoutes, computeSoftwareDeploymentAggregateStatus } from './software';
 import { db } from '../db';
-import { uploadBinary, isS3Configured } from '../services/s3Storage';
+import {
+  uploadBinary,
+  isS3Configured,
+  S3ConfigError,
+  S3OperationError,
+} from '../services/s3Storage';
 import { captureException } from '../services/sentry';
 import { parseStreamingMultipart } from '../services/streamingUpload';
 import { createHash } from 'node:crypto';
@@ -105,11 +110,19 @@ vi.mock('../services/deploymentTargetResolver', () => ({
   resolveDeploymentTargets: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock('../services/s3Storage', () => ({
-  uploadBinary: vi.fn(),
-  getPresignedUrl: vi.fn(() => Promise.resolve('https://s3.example.com/presigned')),
-  isS3Configured: vi.fn(() => false)
-}));
+vi.mock('../services/s3Storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/s3Storage')>();
+  return {
+    uploadBinary: vi.fn(),
+    getPresignedUrl: vi.fn(() => Promise.resolve('https://s3.example.com/presigned')),
+    isS3Configured: vi.fn(() => false),
+    // Real classes, not stubs: the upload route branches on `instanceof` to
+    // pick 502 vs 503 (#2794), and a stubbed/undefined export would make that
+    // check throw at runtime instead of mapping the error.
+    S3ConfigError: actual.S3ConfigError,
+    S3OperationError: actual.S3OperationError,
+  };
+});
 
 vi.mock('./agentWs', () => ({
   sendCommandToAgent: vi.fn(() => true)
@@ -378,6 +391,71 @@ describe('software routes', () => {
       const call = vi.mocked(uploadBinary).mock.calls[0]!;
       expect(call[2]).toBe(expectedChecksum); // checksum from the streamed hash
       expect(typeof call[0]).toBe('string');  // temp file path, not an in-memory buffer
+    });
+
+    // #2794: object-storage faults used to reach the global error handler as an
+    // opaque `500 {error:'Internal Server Error'}`, so a self-hoster had no path
+    // from "Failed to upload version" to a cause.
+    describe('object storage failure mapping', () => {
+      const uploadOnce = async () => {
+        vi.mocked(isS3Configured).mockReturnValueOnce(true);
+        vi.mocked(db.select).mockReturnValueOnce(
+          selectResult([{ id: catalogId, orgId: 'org-123', name: 'Acme Tool' }])
+        );
+        const fd = new FormData();
+        fd.append('version', '1.0.0');
+        fd.append('file', new File(['payload'], 'pkg.msi', { type: 'application/octet-stream' }));
+        return app.request(`/software/catalog/${catalogId}/versions/upload`, {
+          method: 'POST',
+          headers: { Authorization: 'Bearer token' },
+          body: fd,
+        });
+      };
+
+      it('maps an S3OperationError to 502 with the actionable hint and failure code', async () => {
+        vi.mocked(uploadBinary).mockRejectedValueOnce(
+          new S3OperationError(
+            'uploadBinary',
+            {
+              code: 'bucket_missing',
+              message: 'The configured bucket does not exist. Check S3_BUCKET.',
+            },
+            new Error('NoSuchBucket')
+          )
+        );
+
+        const res = await uploadOnce();
+        const body = await res.json();
+
+        expect(res.status).toBe(502);
+        expect(body.error).toMatch(/S3_BUCKET/);
+        expect(body.storageFailure).toBe('bucket_missing');
+      });
+
+      it('maps an S3ConfigError to 503, matching the isS3Configured() gate', async () => {
+        vi.mocked(uploadBinary).mockRejectedValueOnce(
+          new S3ConfigError('Invalid S3_ENDPOINT env var: Invalid URL')
+        );
+
+        const res = await uploadOnce();
+        const body = await res.json();
+
+        expect(res.status).toBe(503);
+        expect(body.error).toMatch(/S3_ENDPOINT/);
+      });
+
+      it('maps an unrecognized throw to 502 without echoing the raw error', async () => {
+        vi.mocked(uploadBinary).mockRejectedValueOnce(
+          new Error('ENOENT: open /tmp/breeze-uploads/secret-path.upload')
+        );
+
+        const res = await uploadOnce();
+        const body = await res.json();
+
+        expect(res.status).toBe(502);
+        expect(body.error).not.toMatch(/ENOENT|secret-path/);
+        expect(body.error).toMatch(/object storage/i);
+      });
     });
 
     it('rejects a disallowed file extension during streaming (400)', async () => {

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -15,7 +15,14 @@ import { authMiddleware, requireMfa, requirePermission, requireScope } from '../
 import { writeRouteAudit } from '../services/auditEvents';
 import { resolveDeploymentTargets } from '../services/deploymentTargetResolver';
 import { resolveEdrInstaller, type ResolvedInstaller } from '../services/edrInstallerResolver';
-import { uploadBinary, getPresignedUrl, isS3Configured, isS3NotFound } from '../services/s3Storage';
+import {
+  uploadBinary,
+  getPresignedUrl,
+  isS3Configured,
+  isS3NotFound,
+  S3ConfigError,
+  S3OperationError,
+} from '../services/s3Storage';
 import { sendCommandToAgent, type AgentCommand } from './agentWs';
 import {
   parseStreamingMultipart,
@@ -893,8 +900,33 @@ softwareRoutes.post(
       const versionId = randomUUID();
       const s3Key = `software/${orgId}/${catalogId}/${versionId}/${originalFileName}`;
 
-      // Upload to S3
-      await uploadBinary(tempPath, s3Key, checksum);
+      // Upload to S3. Previously a bare call, so any storage fault (bad
+      // credentials, missing bucket, unreachable endpoint, MinIO TLS mismatch,
+      // region mismatch) reached the global handler as an opaque
+      // `500 Internal Server Error` and a self-hoster had no path from the
+      // symptom to a cause (#2794). Map it to a status that says whose problem
+      // it is, carrying the operator-actionable hint.
+      try {
+        await uploadBinary(tempPath, s3Key, checksum);
+      } catch (err) {
+        captureException(err, c);
+        // Misconfigured env => 503, matching the isS3Configured() gate above.
+        if (err instanceof S3ConfigError) {
+          return c.json({ error: err.message }, 503);
+        }
+        // Storage reachable-ish but failing => 502. The message is curated in
+        // classifyS3Failure and never echoes raw provider output.
+        if (err instanceof S3OperationError) {
+          return c.json({ error: err.message, storageFailure: err.failureCode }, 502);
+        }
+        return c.json(
+          {
+            error:
+              'Upload to object storage failed before the request was sent. Check the API server logs for details.',
+          },
+          502
+        );
+      }
 
       const versionRecord = await insertLatestSoftwareVersion(catalogId, {
         id: versionId,

--- a/apps/api/src/routes/software.ts
+++ b/apps/api/src/routes/software.ts
@@ -911,8 +911,10 @@ softwareRoutes.post(
       } catch (err) {
         captureException(err, c);
         // Misconfigured env => 503, matching the isS3Configured() gate above.
+        // `clientMessage`, not `message`: the latter can quote the raw
+        // S3_ENDPOINT value, which may carry inline credentials.
         if (err instanceof S3ConfigError) {
-          return c.json({ error: err.message }, 503);
+          return c.json({ error: err.clientMessage }, 503);
         }
         // Storage reachable-ish but failing => 502. The message is curated in
         // classifyS3Failure and never echoes raw provider output.

--- a/apps/api/src/routes/software_inventory_site_scope.test.ts
+++ b/apps/api/src/routes/software_inventory_site_scope.test.ts
@@ -71,11 +71,18 @@ vi.mock('../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
 vi.mock('../services/deploymentTargetResolver', () => ({
   resolveDeploymentTargets: vi.fn().mockResolvedValue([]),
 }));
-vi.mock('../services/s3Storage', () => ({
-  uploadBinary: vi.fn(),
-  getPresignedUrl: vi.fn(),
-  isS3Configured: vi.fn(() => false),
-}));
+vi.mock('../services/s3Storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/s3Storage')>();
+  return {
+    uploadBinary: vi.fn(),
+    getPresignedUrl: vi.fn(),
+    isS3Configured: vi.fn(() => false),
+    // routes/software.ts branches on these with `instanceof` (#2794); a mock
+    // that omits them makes the export access throw.
+    S3ConfigError: actual.S3ConfigError,
+    S3OperationError: actual.S3OperationError,
+  };
+});
 vi.mock('./agentWs', () => ({ sendCommandToAgent: vi.fn() }));
 
 const ORG_ID = 'org-111';

--- a/apps/api/src/services/s3Storage.test.ts
+++ b/apps/api/src/services/s3Storage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 
 const s3ClientCtorMock = vi.fn();
 const s3SendMock = vi.fn(async () => ({}));
@@ -88,11 +88,213 @@ describe('s3Storage getS3Client (via uploadBinary)', () => {
 
   it('throws a clear error naming S3_ENDPOINT (not "Invalid URL") for a malformed value', async () => {
     process.env.S3_ENDPOINT = 'not a valid url with spaces';
-    const { uploadBinary } = await import('./s3Storage');
+    const { uploadBinary, S3ConfigError } = await import('./s3Storage');
 
     await expect(uploadBinary('/tmp/binary', 'binaries/agent.bin')).rejects.toThrow(
       /Invalid S3_ENDPOINT env var/,
     );
+    await expect(uploadBinary('/tmp/binary', 'binaries/agent.bin')).rejects.toBeInstanceOf(
+      S3ConfigError,
+    );
     expect(s3ClientCtorMock).not.toHaveBeenCalled();
+  });
+});
+
+// #2794: every object-storage fault used to propagate to the global error
+// handler as `500 {error:'Internal Server Error'}`, so a self-hoster saw
+// "Failed to upload version" with no path to a cause. These lock in the mapping
+// from the codes the SDK / Node net+TLS layers actually emit onto hints that
+// name the env var to fix.
+describe('classifyS3Failure', () => {
+  /** An AWS SDK service error: code on `name`, message may echo request detail. */
+  function awsError(name: string, extra: Record<string, unknown> = {}): Error {
+    const err = new Error(`provider response mentioning ${name}`);
+    err.name = name;
+    return Object.assign(err, extra);
+  }
+
+  const cases: Array<[string, Error, string, RegExp]> = [
+    ['InvalidAccessKeyId', awsError('InvalidAccessKeyId'), 'credentials_invalid', /S3_ACCESS_KEY/],
+    ['SignatureDoesNotMatch', awsError('SignatureDoesNotMatch'), 'credentials_signature', /S3_SECRET_KEY/],
+    ['NoSuchBucket', awsError('NoSuchBucket'), 'bucket_missing', /S3_BUCKET/],
+    ['AccessDenied', awsError('AccessDenied'), 'access_denied', /s3:PutObject/],
+    ['PermanentRedirect', awsError('PermanentRedirect'), 'region_mismatch', /S3_REGION/],
+    ['RequestTimeTooSkewed', awsError('RequestTimeTooSkewed'), 'clock_skew', /NTP/],
+    ['ECONNREFUSED', awsError('Error', { code: 'ECONNREFUSED' }), 'endpoint_refused', /S3_ENDPOINT/],
+    ['ENOTFOUND', awsError('Error', { code: 'ENOTFOUND' }), 'endpoint_dns', /resolve/i],
+    ['ETIMEDOUT', awsError('Error', { code: 'ETIMEDOUT' }), 'endpoint_unreachable', /firewall/],
+    [
+      'DEPTH_ZERO_SELF_SIGNED_CERT',
+      awsError('Error', { code: 'DEPTH_ZERO_SELF_SIGNED_CERT' }),
+      'endpoint_tls',
+      /self-signed/,
+    ],
+  ];
+
+  for (const [label, err, expectedCode, messagePattern] of cases) {
+    it(`maps ${label} to ${expectedCode} with an actionable hint`, async () => {
+      const { classifyS3Failure } = await import('./s3Storage');
+      const result = classifyS3Failure(err);
+      expect(result.code).toBe(expectedCode);
+      expect(result.message).toMatch(messagePattern);
+    });
+  }
+
+  it('matches any OpenSSL CERT_* variant by prefix', async () => {
+    const { classifyS3Failure } = await import('./s3Storage');
+    expect(classifyS3Failure(awsError('Error', { code: 'CERT_HAS_EXPIRED' })).code).toBe(
+      'endpoint_tls',
+    );
+    expect(classifyS3Failure(awsError('Error', { code: 'CERT_SIGNATURE_FAILURE' })).code).toBe(
+      'endpoint_tls',
+    );
+  });
+
+  it('finds the code on a wrapped cause chain, not just the top-level error', async () => {
+    const { classifyS3Failure } = await import('./s3Storage');
+    const socketErr = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    const wrapped = new Error('failed to send request', { cause: socketErr });
+
+    expect(classifyS3Failure(wrapped).code).toBe('endpoint_refused');
+  });
+
+  it('falls back to provider_error for a 5xx with no recognizable code', async () => {
+    const { classifyS3Failure } = await import('./s3Storage');
+    const err = awsError('InternalError', { $metadata: { httpStatusCode: 503 } });
+
+    const result = classifyS3Failure(err);
+    expect(result.code).toBe('provider_error');
+    expect(result.message).toMatch(/HTTP 503/);
+  });
+
+  it('echoes an unmapped provider code so MinIO-specific faults stay greppable', async () => {
+    const { classifyS3Failure } = await import('./s3Storage');
+    const result = classifyS3Failure(awsError('XMinioServerNotInitialized'));
+
+    expect(result.code).toBe('unknown');
+    expect(result.message).toMatch(/XMinioServerNotInitialized/);
+  });
+
+  it('returns a generic hint when there is no code at all', async () => {
+    const { classifyS3Failure } = await import('./s3Storage');
+    const result = classifyS3Failure(new Error('boom'));
+
+    expect(result.code).toBe('unknown');
+    expect(result.message).toMatch(/unrecognized reason/);
+  });
+
+  it('strips characters that could inject a newline into a log line', async () => {
+    const { classifyS3Failure } = await import('./s3Storage');
+    const result = classifyS3Failure(awsError('Bad\nCode\rInjected'));
+
+    expect(result.message).not.toMatch(/[\n\r]/);
+  });
+
+  // The classification message is returned to an API caller, and provider
+  // responses for signature/permission faults can echo the access key id and
+  // the string-to-sign. Curated text only — never the raw provider message.
+  it('never echoes the raw provider message, which can contain credentials', async () => {
+    const { classifyS3Failure } = await import('./s3Storage');
+    const leaky = new Error(
+      'SignatureDoesNotMatch: AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE StringToSign=PUT\nsecret-material-here',
+    );
+    leaky.name = 'SignatureDoesNotMatch';
+
+    const result = classifyS3Failure(leaky);
+    expect(result.message).not.toMatch(/AKIAIOSFODNN7EXAMPLE/);
+    expect(result.message).not.toMatch(/StringToSign/);
+    expect(result.message).not.toMatch(/secret-material-here/);
+  });
+});
+
+describe('uploadBinary object-storage error handling', () => {
+  const FAKE_ACCESS_KEY = 'AKIAIOSFODNN7EXAMPLE';
+  const FAKE_SECRET_KEY = 'wJalrXUtnFEMI-K7MDENG-bPxRfiCYEXAMPLEKEY';
+  let consoleErrorSpy: MockInstance<(...args: unknown[]) => void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    process.env.S3_BUCKET = 'binaries';
+    process.env.S3_ACCESS_KEY = FAKE_ACCESS_KEY;
+    process.env.S3_SECRET_KEY = FAKE_SECRET_KEY;
+    process.env.S3_ENDPOINT = 'https://minio.internal.example:9000/some/path';
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('throws S3OperationError carrying the mapped hint, code, and original cause', async () => {
+    const { uploadBinary, S3OperationError } = await import('./s3Storage');
+    const original = Object.assign(new Error('nope'), { name: 'NoSuchBucket' });
+    s3SendMock.mockRejectedValueOnce(original);
+
+    const err = await uploadBinary('/tmp/binary', 'software/org-1/cat-2/ver-3/setup.msi').catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(S3OperationError);
+    const opErr = err as InstanceType<typeof S3OperationError>;
+    expect(opErr.failureCode).toBe('bucket_missing');
+    expect(opErr.operation).toBe('uploadBinary');
+    expect(opErr.message).toMatch(/S3_BUCKET/);
+    // Preserved so Sentry still receives the full underlying error.
+    expect(opErr.cause).toBe(original);
+  });
+
+  it('logs the bucket, endpoint host, and key prefix so the fault is greppable', async () => {
+    const { uploadBinary } = await import('./s3Storage');
+    s3SendMock.mockRejectedValueOnce(
+      Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }),
+    );
+
+    await uploadBinary('/tmp/binary', 'software/org-1/cat-2/ver-3/setup.msi').catch(() => {});
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const line = String(consoleErrorSpy.mock.calls[0]![0]);
+    expect(line).toContain('reason=endpoint_refused');
+    expect(line).toContain('providerCode=ECONNREFUSED');
+    expect(line).toContain('bucket=binaries');
+    // HOST only — no scheme, no path, no userinfo.
+    expect(line).toContain('endpoint=minio.internal.example:9000');
+    expect(line).not.toContain('/some/path');
+    expect(line).toContain('keyPrefix=software/org-1/cat-2/ver-3/');
+  });
+
+  it('never writes credentials or the operator-supplied filename into the log', async () => {
+    const { uploadBinary } = await import('./s3Storage');
+    s3SendMock.mockRejectedValueOnce(
+      Object.assign(
+        new Error('AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE StringToSign=PUT/secret-material'),
+        { name: 'SignatureDoesNotMatch' },
+      ),
+    );
+
+    await uploadBinary(
+      '/tmp/binary',
+      'software/org-1/cat-2/ver-3/evil\nINJECTED-LOG-LINE.msi',
+    ).catch(() => {});
+
+    const line = String(consoleErrorSpy.mock.calls[0]![0]);
+    expect(line).not.toContain(FAKE_ACCESS_KEY);
+    expect(line).not.toContain(FAKE_SECRET_KEY);
+    expect(line).not.toContain('StringToSign');
+    expect(line).not.toContain('secret-material');
+    // Final path segment is an operator-supplied filename => untrusted log input.
+    expect(line).not.toContain('INJECTED-LOG-LINE');
+    expect(line).not.toMatch(/[\n\r]/);
+  });
+
+  it('resolves normally when the upload succeeds (no error path regression)', async () => {
+    const { uploadBinary } = await import('./s3Storage');
+
+    await expect(
+      uploadBinary('/tmp/binary', 'software/org-1/cat-2/ver-3/setup.msi'),
+    ).resolves.toBeUndefined();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/s3Storage.test.ts
+++ b/apps/api/src/services/s3Storage.test.ts
@@ -32,6 +32,13 @@ vi.mock('node:fs', () => ({
 
 const ORIGINAL_ENV = { ...process.env };
 
+// Every test here calls `vi.resetModules()` then `await import('./s3Storage')`,
+// so the first one to run pays the cold transform of the @aws-sdk/client-s3
+// graph. On a loaded machine that alone can exceed the 5s default and fail
+// whichever test happens to be first — nothing to do with the assertion. Give
+// the dynamic-import suites headroom instead of letting them flake.
+const IMPORT_TIMEOUT_MS = 30_000;
+
 // Sentry BREEZE-P: S3_ENDPOINT is operator-set (not per-tenant user input),
 // but a scheme-less value used to reach the SDK unmodified and fail opaquely
 // inside @smithy/core's endpoint resolver the first time S3 was used, instead
@@ -39,7 +46,7 @@ const ORIGINAL_ENV = { ...process.env };
 // a bare host ("s3.example.com") throws `TypeError: Invalid URL`, while
 // "minio.local:9000" parses into a URL with an empty host and fails later as
 // a connection error — see coerceS3EndpointUrl.
-describe('s3Storage getS3Client (via uploadBinary)', () => {
+describe('s3Storage getS3Client (via uploadBinary)', { timeout: IMPORT_TIMEOUT_MS }, () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
@@ -98,6 +105,43 @@ describe('s3Storage getS3Client (via uploadBinary)', () => {
     );
     expect(s3ClientCtorMock).not.toHaveBeenCalled();
   });
+
+  // `coerceS3EndpointUrl` quotes the offending value back in its message, and an
+  // S3-compatible endpoint can carry inline credentials. The upload route
+  // returns this error's text to the caller, so the client-facing variant must
+  // name the env var without echoing the value (#2794).
+  it('keeps inline endpoint credentials out of the client-facing message', async () => {
+    process.env.S3_ENDPOINT = 's3://AKIAIOSFODNN7EXAMPLE:sUp3r-s3cr3t@bucket.example.com';
+    const { uploadBinary, S3ConfigError } = await import('./s3Storage');
+
+    const err = (await uploadBinary('/tmp/binary', 'binaries/agent.bin').catch(
+      (e: unknown) => e,
+    )) as InstanceType<typeof S3ConfigError>;
+
+    expect(err).toBeInstanceOf(S3ConfigError);
+    expect(err.clientMessage).toMatch(/S3_ENDPOINT/);
+    expect(err.clientMessage).not.toMatch(/AKIAIOSFODNN7EXAMPLE/);
+    expect(err.clientMessage).not.toMatch(/sUp3r-s3cr3t/);
+  });
+
+  // `message` is not returned to an API caller, but it does reach Sentry and
+  // any logger that prints `err.message`. Neither is a place for a secret, so
+  // the userinfo is stripped at construction — the rest of the bad value stays
+  // so the operator can still see what they typed wrong (#2794).
+  it('redacts inline endpoint credentials from the detailed message too', async () => {
+    process.env.S3_ENDPOINT = 's3://AKIAIOSFODNN7EXAMPLE:sUp3r-s3cr3t@bucket.example.com';
+    const { uploadBinary } = await import('./s3Storage');
+
+    const err = (await uploadBinary('/tmp/binary', 'binaries/agent.bin').catch(
+      (e: unknown) => e,
+    )) as Error;
+
+    expect(err.message).not.toMatch(/AKIAIOSFODNN7EXAMPLE/);
+    expect(err.message).not.toMatch(/sUp3r-s3cr3t/);
+    // Still diagnosable: the env var, the redaction marker, and the host.
+    expect(err.message).toMatch(/Invalid S3_ENDPOINT env var/);
+    expect(err.message).toMatch(/s3:\/\/\*\*\*@bucket\.example\.com/);
+  });
 });
 
 // #2794: every object-storage fault used to propagate to the global error
@@ -105,7 +149,7 @@ describe('s3Storage getS3Client (via uploadBinary)', () => {
 // "Failed to upload version" with no path to a cause. These lock in the mapping
 // from the codes the SDK / Node net+TLS layers actually emit onto hints that
 // name the env var to fix.
-describe('classifyS3Failure', () => {
+describe('classifyS3Failure', { timeout: IMPORT_TIMEOUT_MS }, () => {
   /** An AWS SDK service error: code on `name`, message may echo request detail. */
   function awsError(name: string, extra: Record<string, unknown> = {}): Error {
     const err = new Error(`provider response mentioning ${name}`);
@@ -207,7 +251,7 @@ describe('classifyS3Failure', () => {
   });
 });
 
-describe('uploadBinary object-storage error handling', () => {
+describe('uploadBinary object-storage error handling', { timeout: IMPORT_TIMEOUT_MS }, () => {
   const FAKE_ACCESS_KEY = 'AKIAIOSFODNN7EXAMPLE';
   const FAKE_SECRET_KEY = 'wJalrXUtnFEMI-K7MDENG-bPxRfiCYEXAMPLEKEY';
   let consoleErrorSpy: MockInstance<(...args: unknown[]) => void>;
@@ -287,6 +331,40 @@ describe('uploadBinary object-storage error handling', () => {
     // Final path segment is an operator-supplied filename => untrusted log input.
     expect(line).not.toContain('INJECTED-LOG-LINE');
     expect(line).not.toMatch(/[\n\r]/);
+  });
+
+  // The log line reports the endpoint so an operator can tell which storage
+  // target failed, and it derives that from `URL.host` precisely because host
+  // drops userinfo. An endpoint configured as `https://key:secret@host` must
+  // therefore log as the bare host (#2794).
+  it('logs only the endpoint host when S3_ENDPOINT carries inline credentials', async () => {
+    process.env.S3_ENDPOINT = 'https://AKIAIOSFODNN7EXAMPLE:sUp3r-s3cr3t@minio.internal.example:9000';
+    const { uploadBinary } = await import('./s3Storage');
+    s3SendMock.mockRejectedValueOnce(
+      Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }),
+    );
+
+    await uploadBinary('/tmp/binary', 'software/org-1/cat-2/ver-3/setup.msi').catch(() => {});
+
+    const line = String(consoleErrorSpy.mock.calls[0]![0]);
+    expect(line).toContain('endpoint=minio.internal.example:9000');
+    expect(line).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(line).not.toContain('sUp3r-s3cr3t');
+  });
+
+  it('clamps S3_BUCKET so a stray newline cannot break the log line', async () => {
+    process.env.S3_BUCKET = 'binaries\nFAKE-LOG-LINE';
+    const { uploadBinary } = await import('./s3Storage');
+    s3SendMock.mockRejectedValueOnce(
+      Object.assign(new Error('refused'), { code: 'ECONNREFUSED' }),
+    );
+
+    await uploadBinary('/tmp/binary', 'software/org-1/cat-2/ver-3/setup.msi').catch(() => {});
+
+    const line = String(consoleErrorSpy.mock.calls[0]![0]);
+    expect(line).not.toMatch(/[\n\r]/);
+    // Collapsed onto one field rather than forging a second log record.
+    expect(line).toContain('bucket=binariesFAKE-LOG-LINE endpoint=');
   });
 
   it('resolves normally when the upload succeeds (no error path regression)', async () => {

--- a/apps/api/src/services/s3Storage.ts
+++ b/apps/api/src/services/s3Storage.ts
@@ -13,11 +13,20 @@ let s3Client: S3Client | null = null;
  * Object storage is misconfigured (missing/unparseable env var). The operator
  * has to change `.env` — retrying will never help. Callers map this to a 503,
  * matching the existing `isS3Configured()` gate.
+ *
+ * `message` may quote the offending env var VALUE (credential-redacted) so the
+ * fault is diagnosable in Sentry and the API log. Callers returning anything to
+ * an HTTP client must use `clientMessage`, which names the env var and never
+ * its value — see the S3_ENDPOINT case in `getS3Client`.
  */
 export class S3ConfigError extends Error {
-  constructor(message: string) {
+  /** Curated text safe for an API response body: names the env var, never its value. */
+  readonly clientMessage: string;
+
+  constructor(message: string, clientMessage?: string) {
     super(message);
     this.name = 'S3ConfigError';
+    this.clientMessage = clientMessage ?? message;
   }
 }
 
@@ -48,6 +57,19 @@ function requireBucket(): string {
   return requireEnv('S3_BUCKET');
 }
 
+/**
+ * Strip `user:password@` userinfo out of any URL-ish substring so a
+ * credential-bearing endpoint can't ride along inside an error message. Keeps
+ * the rest of the value, which is the part that makes the fault diagnosable
+ * (wrong scheme, stray quote, trailing slash).
+ *
+ * Matches on `<scheme>://<userinfo>@` rather than parsing, because the values
+ * that reach here are by definition the ones `new URL()` refused.
+ */
+function redactUrlCredentials(text: string): string {
+  return text.replace(/([A-Za-z][A-Za-z0-9+.-]*:\/\/)[^/\s@]*@/g, '$1***@');
+}
+
 function getS3Client(): S3Client {
   if (!s3Client) {
     const accessKeyId = requireEnv('S3_ACCESS_KEY');
@@ -64,7 +86,16 @@ function getS3Client(): S3Client {
       endpoint = coerceS3EndpointUrl(process.env.S3_ENDPOINT);
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      throw new S3ConfigError(`Invalid S3_ENDPOINT env var: ${detail}`);
+      // `coerceS3EndpointUrl` quotes the raw endpoint back in its message, and
+      // an endpoint can carry inline credentials (`s3://key:secret@host`).
+      // Two layers here: `redactUrlCredentials` strips the userinfo so no
+      // secret sits in the Error at all (it would otherwise reach Sentry and
+      // any `err.message` logger), and the client-facing variant drops the
+      // value entirely so an API caller only learns which env var is wrong.
+      throw new S3ConfigError(
+        `Invalid S3_ENDPOINT env var: ${redactUrlCredentials(detail)}`,
+        'The S3_ENDPOINT env var is not a valid URL. Expected a host (s3.example.com) or host:port (minio.local:9000), optionally prefixed with http:// or https://.'
+      );
     }
 
     s3Client = new S3Client({
@@ -309,11 +340,15 @@ function wrapS3Failure(
   const providerCode = sanitizeCode(collectErrorCodes(err).find((c) => c !== 'Error')) ?? 'unknown';
   const httpStatus = findHttpStatus(err) ?? 'none';
   const keyPrefix = s3Key.slice(0, s3Key.lastIndexOf('/') + 1).replace(/[^A-Za-z0-9_./:-]/g, '');
+  // S3_BUCKET is operator-set rather than request input, but it lands in the
+  // same log line as the sanitized fields — clamp it identically so no env
+  // value can break the line format.
+  const safeBucket = bucket.replace(/[^A-Za-z0-9_.-]/g, '').slice(0, 64);
 
   console.error(
     `[s3Storage] ${operation} failed: reason=${classification.code} ` +
       `providerCode=${providerCode} httpStatus=${httpStatus} ` +
-      `bucket=${bucket} endpoint=${describeS3Endpoint()} keyPrefix=${keyPrefix}`
+      `bucket=${safeBucket} endpoint=${describeS3Endpoint()} keyPrefix=${keyPrefix}`
   );
 
   return new S3OperationError(operation, classification, err);

--- a/apps/api/src/services/s3Storage.ts
+++ b/apps/api/src/services/s3Storage.ts
@@ -9,9 +9,38 @@ import { pipeline } from 'node:stream/promises';
 
 let s3Client: S3Client | null = null;
 
+/**
+ * Object storage is misconfigured (missing/unparseable env var). The operator
+ * has to change `.env` — retrying will never help. Callers map this to a 503,
+ * matching the existing `isS3Configured()` gate.
+ */
+export class S3ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'S3ConfigError';
+  }
+}
+
+/**
+ * An object storage request reached the provider (or tried to) and failed.
+ * `message` is a curated, operator-actionable hint — safe to return in an API
+ * response body. Callers map this to a 502.
+ */
+export class S3OperationError extends Error {
+  readonly failureCode: S3FailureCode;
+  readonly operation: string;
+
+  constructor(operation: string, classification: S3FailureClassification, cause: unknown) {
+    super(classification.message, { cause });
+    this.name = 'S3OperationError';
+    this.failureCode = classification.code;
+    this.operation = operation;
+  }
+}
+
 function requireEnv(name: string): string {
   const value = process.env[name];
-  if (!value) throw new Error(`Missing required env var: ${name}`);
+  if (!value) throw new S3ConfigError(`Missing required env var: ${name}`);
   return value;
 }
 
@@ -35,7 +64,7 @@ function getS3Client(): S3Client {
       endpoint = coerceS3EndpointUrl(process.env.S3_ENDPOINT);
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
-      throw new Error(`Invalid S3_ENDPOINT env var: ${detail}`);
+      throw new S3ConfigError(`Invalid S3_ENDPOINT env var: ${detail}`);
     }
 
     s3Client = new S3Client({
@@ -60,6 +89,234 @@ export function isS3Configured(): boolean {
 export function isS3NotFound(err: unknown): boolean {
   const errName = (err as { name?: string }).name;
   return errName === 'NotFound' || errName === 'NoSuchKey';
+}
+
+// ---------------------------------------------------------------------------
+// Object storage failure classification (#2794)
+//
+// Every S3 fault used to escape as a bare `500 Internal Server Error`, so a
+// self-hoster had no path from "Failed to upload version" to a cause. These
+// map the codes the AWS SDK / Node net+TLS layers actually produce onto hints
+// that name the env var to go fix.
+// ---------------------------------------------------------------------------
+
+export type S3FailureCode =
+  | 'credentials_invalid'
+  | 'credentials_signature'
+  | 'bucket_missing'
+  | 'access_denied'
+  | 'region_mismatch'
+  | 'clock_skew'
+  | 'endpoint_refused'
+  | 'endpoint_dns'
+  | 'endpoint_unreachable'
+  | 'endpoint_tls'
+  | 'provider_error'
+  | 'unknown';
+
+export interface S3FailureClassification {
+  /** Stable short code for logs, tests, and support triage. */
+  code: S3FailureCode;
+  /** Operator-actionable hint. Curated text only — never raw provider output. */
+  message: string;
+}
+
+const S3_FAILURE_RULES: ReadonlyArray<{
+  codes: readonly string[];
+  code: S3FailureCode;
+  message: string;
+}> = [
+  {
+    codes: ['InvalidAccessKeyId', 'InvalidAccessKeyID', 'InvalidSecurity', 'InvalidClientTokenId'],
+    code: 'credentials_invalid',
+    message:
+      'Object storage rejected the access key. Check that S3_ACCESS_KEY names a key that exists on the storage provider.',
+  },
+  {
+    codes: ['SignatureDoesNotMatch'],
+    code: 'credentials_signature',
+    message:
+      'Object storage rejected the request signature. Check S3_SECRET_KEY for a typo, a truncated value, or trailing whitespace.',
+  },
+  {
+    codes: ['NoSuchBucket'],
+    code: 'bucket_missing',
+    message:
+      'The configured bucket does not exist on the storage provider. Check S3_BUCKET, and create the bucket if it has not been created yet.',
+  },
+  {
+    codes: ['AccessDenied', 'AllAccessDisabled'],
+    code: 'access_denied',
+    message:
+      'Object storage denied access to the bucket. The credentials are valid but are not allowed to write here — grant s3:PutObject on this bucket. Some providers also return this when the bucket does not exist.',
+  },
+  {
+    codes: ['PermanentRedirect', 'AuthorizationHeaderMalformed', 'IllegalLocationConstraintException'],
+    code: 'region_mismatch',
+    message:
+      'Object storage reported a region mismatch for the bucket. Check that S3_REGION matches the region the bucket was created in.',
+  },
+  {
+    codes: ['RequestTimeTooSkewed'],
+    code: 'clock_skew',
+    message:
+      'Object storage rejected the request because the API server clock is too far from the storage provider clock. Check time sync (NTP) on the API host.',
+  },
+  {
+    codes: ['ECONNREFUSED'],
+    code: 'endpoint_refused',
+    message:
+      'The API server could not connect to the object storage endpoint (connection refused). Check the host and port in S3_ENDPOINT and that the storage service is running.',
+  },
+  {
+    codes: ['ENOTFOUND', 'EAI_AGAIN'],
+    code: 'endpoint_dns',
+    message:
+      'The object storage endpoint hostname could not be resolved. Check S3_ENDPOINT for a typo, and that the name resolves from inside the API container.',
+  },
+  {
+    codes: ['ETIMEDOUT', 'ECONNRESET', 'EPIPE', 'EHOSTUNREACH', 'ENETUNREACH', 'TimeoutError', 'RequestTimeout'],
+    code: 'endpoint_unreachable',
+    message:
+      'The connection to object storage timed out or was reset. Check network reachability and any firewall between the API server and S3_ENDPOINT.',
+  },
+  {
+    codes: [
+      'DEPTH_ZERO_SELF_SIGNED_CERT',
+      'SELF_SIGNED_CERT_IN_CHAIN',
+      'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+      'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+      'ERR_TLS_CERT_ALTNAME_INVALID',
+      'EPROTO',
+    ],
+    code: 'endpoint_tls',
+    message:
+      'The TLS connection to object storage failed. If the endpoint uses a private or self-signed certificate, add its CA to the API container trust store; also check whether S3_ENDPOINT should be http:// rather than https://.',
+  },
+];
+
+/** Codes only recognisable by prefix, e.g. every OpenSSL `CERT_*` variant. */
+const TLS_CODE_PREFIXES = ['CERT_'] as const;
+
+/**
+ * Collect every plausible error code from an error and its `cause` chain. The
+ * SDK surfaces service faults on `name`/`Code` but wraps socket and TLS faults,
+ * where the useful code sits on `code` one or more levels down.
+ */
+function collectErrorCodes(err: unknown, depth = 0): string[] {
+  if (!err || typeof err !== 'object' || depth > 4) return [];
+  const e = err as { name?: unknown; code?: unknown; Code?: unknown; cause?: unknown };
+  const own: string[] = [];
+  for (const raw of [e.name, e.code, e.Code]) {
+    if (typeof raw === 'string' && raw !== '') own.push(raw);
+  }
+  return [...own, ...collectErrorCodes(e.cause, depth + 1)];
+}
+
+function findHttpStatus(err: unknown, depth = 0): number | undefined {
+  if (!err || typeof err !== 'object' || depth > 4) return undefined;
+  const e = err as { $metadata?: { httpStatusCode?: unknown }; cause?: unknown };
+  const status = e.$metadata?.httpStatusCode;
+  if (typeof status === 'number') return status;
+  return findHttpStatus(e.cause, depth + 1);
+}
+
+/**
+ * Provider error codes are a fixed vocabulary, not user or credential data, so
+ * echoing one is safe — but clamp the shape anyway so a hostile or malformed
+ * value can't inject newlines into a log line or smuggle text into a response.
+ */
+function sanitizeCode(code: string | undefined): string | undefined {
+  if (!code) return undefined;
+  const cleaned = code.replace(/[^A-Za-z0-9_.:-]/g, '');
+  return cleaned === '' ? undefined : cleaned.slice(0, 64);
+}
+
+/**
+ * Map an object storage failure onto an operator-actionable hint.
+ *
+ * The returned message is deliberately built from curated strings plus (at
+ * most) a sanitized provider error code. It never includes the raw SDK/provider
+ * message: `SignatureDoesNotMatch` and `AccessDenied` responses can echo the
+ * access key id and the string-to-sign, and this text is returned to an API
+ * caller.
+ */
+export function classifyS3Failure(err: unknown): S3FailureClassification {
+  const codes = collectErrorCodes(err);
+
+  for (const candidate of codes) {
+    const rule = S3_FAILURE_RULES.find((r) => r.codes.includes(candidate));
+    if (rule) return { code: rule.code, message: rule.message };
+    if (TLS_CODE_PREFIXES.some((prefix) => candidate.startsWith(prefix))) {
+      const tls = S3_FAILURE_RULES.find((r) => r.code === 'endpoint_tls')!;
+      return { code: 'endpoint_tls', message: tls.message };
+    }
+  }
+
+  const httpStatus = findHttpStatus(err);
+  if (typeof httpStatus === 'number' && httpStatus >= 500) {
+    return {
+      code: 'provider_error',
+      message: `Object storage returned a server error (HTTP ${httpStatus}). The storage provider is unhealthy or throttling; check its own logs.`,
+    };
+  }
+
+  // `name` is first in the collected list, so it is the most descriptive code
+  // available for an unmapped fault (e.g. MinIO's XMinio* codes).
+  const label = sanitizeCode(codes.find((c) => c !== 'Error' && c !== 'TypeError'));
+  return {
+    code: 'unknown',
+    message: label
+      ? `Object storage rejected the request (${label}). Check the API server logs for the full error.`
+      : 'Object storage rejected the request for an unrecognized reason. Check the API server logs for the full error.',
+  };
+}
+
+/**
+ * Bucket + endpoint HOST for log lines. `URL.host` intentionally drops any
+ * userinfo, path, and query, so an endpoint carrying embedded credentials or a
+ * signed URL cannot leak through this.
+ */
+function describeS3Endpoint(): string {
+  const raw = process.env.S3_ENDPOINT;
+  if (!raw) return 'aws-default';
+  try {
+    const coerced = coerceS3EndpointUrl(raw);
+    return coerced ? new URL(coerced).host : 'aws-default';
+  } catch {
+    return 'unparseable';
+  }
+}
+
+/**
+ * Log an object storage fault with enough context to grep for in
+ * `docker logs breeze-api`, then wrap it for the caller.
+ *
+ * What is logged: our failure code, the sanitized provider code, the HTTP
+ * status, the bucket, the endpoint host, and the key PREFIX. What is
+ * deliberately not logged: the raw provider message (can echo the access key
+ * id and string-to-sign) and the object's final path segment (an
+ * operator-supplied filename, i.e. untrusted log input). The original error is
+ * preserved as `cause` so Sentry still receives full detail.
+ */
+function wrapS3Failure(
+  operation: string,
+  bucket: string,
+  s3Key: string,
+  err: unknown
+): S3OperationError {
+  const classification = classifyS3Failure(err);
+  const providerCode = sanitizeCode(collectErrorCodes(err).find((c) => c !== 'Error')) ?? 'unknown';
+  const httpStatus = findHttpStatus(err) ?? 'none';
+  const keyPrefix = s3Key.slice(0, s3Key.lastIndexOf('/') + 1).replace(/[^A-Za-z0-9_./:-]/g, '');
+
+  console.error(
+    `[s3Storage] ${operation} failed: reason=${classification.code} ` +
+      `providerCode=${providerCode} httpStatus=${httpStatus} ` +
+      `bucket=${bucket} endpoint=${describeS3Endpoint()} keyPrefix=${keyPrefix}`
+  );
+
+  return new S3OperationError(operation, classification, err);
 }
 
 async function computeFileChecksum(filePath: string): Promise<string> {
@@ -96,16 +353,23 @@ export async function uploadBinary(localPath: string, s3Key: string, checksum?: 
   const body = createReadStream(localPath);
   const stat = statSync(localPath);
 
-  await client.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: s3Key,
-      Body: body,
-      ContentLength: stat.size,
-      ContentType: 'application/octet-stream',
-      Metadata: checksum ? { sha256: checksum } : undefined,
-    })
-  );
+  try {
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: s3Key,
+        Body: body,
+        ContentLength: stat.size,
+        ContentType: 'application/octet-stream',
+        Metadata: checksum ? { sha256: checksum } : undefined,
+      })
+    );
+  } catch (err) {
+    // Bare `client.send` used to let every storage fault reach the global error
+    // handler as an opaque 500 (#2794). Classify + log here so both the API
+    // caller and `docker logs breeze-api` get something actionable.
+    throw wrapS3Failure('uploadBinary', bucket, s3Key, err);
+  }
 }
 
 let presignTtlWarned = false;

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -303,7 +303,16 @@ export default function SoftwareVersionManager({
         setUploadProgress(90);
         if (!response.ok) {
           const errData = await response.json().catch(() => ({}));
-          throw new Error(errData.error ?? "Failed to upload version");
+          // Always show the status. Every API failure path returns a JSON body
+          // with an `error` key, so the bare fallback means the response was
+          // not JSON at all — a reverse-proxy 413/502/504 HTML page or a
+          // truncated connection. Including the status makes that case
+          // distinguishable from an API-level failure at a glance (#2794).
+          const detail =
+            typeof errData.error === "string"
+              ? errData.error
+              : "Failed to upload version";
+          throw new Error(`${detail} (HTTP ${response.status})`);
         }
         const newVersionData = await response.json();
         const newVersion = normalizeVersion(


### PR DESCRIPTION
## Problem

Package upload turned **every** object-storage fault into an opaque `500 {error:'Internal Server Error'}`.

`uploadBinary()` was called without a try/catch at `apps/api/src/routes/software.ts:897`, and the function itself did a bare `client.send(new PutObjectCommand(...))` at `apps/api/src/services/s3Storage.ts:99`. Bad credentials, a missing bucket, an unreachable endpoint, a MinIO TLS mismatch, a region mismatch and clock skew were all indistinguishable — a self-hoster saw "Failed to upload version" with nothing actionable, and nothing in the logs unless they had Sentry wired up.

## What changed

**`services/s3Storage.ts`**

- `classifyS3Failure(err)` maps the codes the AWS SDK and the Node net/TLS layers actually emit onto hints that name the env var to go fix. It walks the `cause` chain, because the SDK wraps socket and TLS faults one or more levels down, and matches every OpenSSL `CERT_*` variant by prefix.

  | Provider / socket code | Failure code | Hint names |
  |---|---|---|
  | `InvalidAccessKeyId`, `InvalidSecurity` | `credentials_invalid` | `S3_ACCESS_KEY` |
  | `SignatureDoesNotMatch` | `credentials_signature` | `S3_SECRET_KEY` |
  | `NoSuchBucket` | `bucket_missing` | `S3_BUCKET` |
  | `AccessDenied`, `AllAccessDisabled` | `access_denied` | `s3:PutObject` |
  | `PermanentRedirect`, `AuthorizationHeaderMalformed` | `region_mismatch` | `S3_REGION` |
  | `RequestTimeTooSkewed` | `clock_skew` | NTP on the API host |
  | `ECONNREFUSED` | `endpoint_refused` | `S3_ENDPOINT` host/port |
  | `ENOTFOUND`, `EAI_AGAIN` | `endpoint_dns` | DNS inside the container |
  | `ETIMEDOUT`, `ECONNRESET`, `EPIPE`, … | `endpoint_unreachable` | firewall/reachability |
  | `CERT_*`, `DEPTH_ZERO_SELF_SIGNED_CERT`, `EPROTO`, … | `endpoint_tls` | CA trust store, http:// vs https:// |
  | any 5xx with no known code | `provider_error` | provider health |

- `uploadBinary()` logs the fault and throws `S3OperationError`. Config faults (`requireEnv`, endpoint coercion) now throw `S3ConfigError`.

**`routes/software.ts`** — the upload call is wrapped:

- `S3OperationError` → **502** with the hint plus a `storageFailure` code.
- `S3ConfigError` → **503**, matching the existing `isS3Configured()` gate that already returns `503 {error:'S3 storage is not configured'}`.
- Anything unrecognized → generic 502, never echoing the raw error.

**`SoftwareVersionManager.tsx`** — the upload error now always appends `(HTTP <status>)`. Every API failure path returns a JSON body with an `error` key, so the bare fallback means the response was not JSON at all: a reverse-proxy 413/502/504 HTML page or a truncated connection. Surfacing the status makes that case distinguishable from an API-level failure at a glance.

## Credential safety

This is a self-hoster-facing error path, so the response body and the log line are built from **curated strings plus a sanitized provider error code only**.

- The **raw provider message is never surfaced**. `SignatureDoesNotMatch` and `AccessDenied` response bodies can echo the access key id and the string-to-sign.
- The log carries the bucket, the endpoint **HOST only** (via `URL.host`, which drops userinfo, path and query, so an endpoint with embedded credentials cannot leak), and the key **prefix** — deliberately excluding the final path segment, which is an operator-supplied filename and therefore untrusted log input.
- Provider codes are clamped to `[A-Za-z0-9_.:-]{0,64}` so a malformed value cannot inject a newline into a log line.
- The original error is preserved as `cause`, so Sentry still receives full detail through the existing `captureException`.

There is a test asserting none of the access key, the secret key, `StringToSign`, or an injected filename reaches the log line.

## Tests

- `services/s3Storage.test.ts` — 21 new: table-driven code→hint mapping, `CERT_*` prefix matching, `cause`-chain traversal, 5xx fallback, unmapped-code echo, log-line content, and the credential/log-injection guards.
- `routes/software.test.ts` — 3 new: 502 + `storageFailure`, 503 for config errors, and a generic 502 that does not echo the raw error.

Three existing `vi.mock('../services/s3Storage')` factories (`software.test.ts`, `software_inventory_site_scope.test.ts`, `partner_multi_org_orgid.test.ts`) now re-export the real error classes via `importOriginal`. The route branches on `instanceof`, and a Vitest mock factory that omits an export makes the access throw — without this the new branches would break the two suites that mount `softwareRoutes`.

## Side effect worth knowing

`syncDirectory()` calls `uploadBinary()` and collects `err.message` into `SyncResult.errors`. Those strings become the curated hint rather than the raw SDK message; the provider code now lands in the API log instead.

## Follow-up (deliberately out of scope)

Item 4 of the issue — a **"Test storage connection" button** next to the S3 settings, matching the existing integration test actions — is not included here, to keep this change small. A self-hoster should be able to validate object storage before discovering it is broken via a failed 400MB upload. Worth a separate issue.

Closes #2794

🤖 Generated with [Claude Code](https://claude.com/claude-code)