### PR TITLE
fix(settings): stop a partner-locked field 403ing every org defaults save (#2752)

### DIFF
--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -1040,10 +1040,11 @@ aiRoutes.put(
 
     const body = c.req.valid('json');
 
-    // Enforce partner locks on AI budget fields
-    const budgetFields = Object.keys(body);
-    if (budgetFields.length > 0) {
-      await assertNotLocked(orgId, 'aiBudgets', budgetFields);
+    // Enforce partner locks on AI budget fields. Submitted values are passed so a
+    // field the partner enforces only 403s when the org actually changes it
+    // (issue #2752); re-sending the enforced value is an allowed no-op.
+    if (Object.keys(body).length > 0) {
+      await assertNotLocked(orgId, 'aiBudgets', body);
     }
 
     await updateBudget(orgId, body);

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -2023,6 +2023,61 @@ describe('org routes', () => {
       expect(db.update).not.toHaveBeenCalled();
     });
 
+    // #2752 — the org defaults editor posts the WHOLE category on every save, so a
+    // partner-set `autoEnrollment` was re-submitted even when the operator only
+    // touched the device group. The old presence-only lock check 403'd the entire
+    // request, making every org-level default in the category unsaveable. Echoing
+    // the partner's own value back is a no-op and must be accepted.
+    it('accepts a save that re-sends a partner-locked field unchanged alongside edited fields (200)', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const enforced = { enabled: false, requireApproval: false, sendWelcome: false };
+      primeAcceptSelect([], { defaults: { autoEnrollment: enforced } });
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          settings: {
+            defaults: {
+              autoEnrollment: enforced, // untouched, locked by the partner
+              deviceGroup: 'Contractors', // the field the operator actually changed
+              alertThreshold: 'medium',
+              agentUpdatePolicy: 'manual',
+              maintenanceWindow: '24/7',
+            },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    it('still rejects a save that changes a partner-locked field (403)', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      primeAcceptSelect([], {
+        defaults: { autoEnrollment: { enabled: false, requireApproval: false, sendWelcome: false } },
+      });
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          settings: {
+            defaults: {
+              autoEnrollment: { enabled: true, requireApproval: false, sendWelcome: false },
+              deviceGroup: 'Contractors',
+            },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      // HTTPException surfaces its message as plain text, not a JSON envelope.
+      expect(await res.text()).toContain('defaults.autoEnrollment');
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
     // SR2-05: `security.allowedMfaMethods` is a legacy input alias — it must be
     // folded into the canonical `security.allowedMethods` before the write and
     // never persisted as a second key (the dead spelling the SMS-enable reader

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1421,7 +1421,12 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
     // Enforce partner locks on settings categories (after auth check).
     for (const category of ['security', 'notifications', 'eventLogs', 'defaults', 'branding']) {
       if (settingsObj[category] && typeof settingsObj[category] === 'object') {
-        let fields = Object.keys(settingsObj[category] as Record<string, unknown>);
+        // Pass the submitted VALUES, not just the field names: assertNotLocked
+        // only rejects a locked field whose value actually diverges from the
+        // partner's, so re-submitting the enforced value is a permitted no-op
+        // (issue #2752 — this handler receives the org's whole settings blob on
+        // every save, so a name-only check 403'd untouched categories).
+        let fields = settingsObj[category] as Record<string, unknown>;
         // Issue #2124: `agentVersionPins` is INHERIT-WITH-OVERRIDE, not partner-
         // locked — an org may override the partner's pinned version (that's what
         // lets a partner pilot a new version on one org). So it is deliberately
@@ -1435,11 +1440,10 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
         // (maxEnrollmentLinkTtlMinutes) is deliberately NOT exempt: a ceiling
         // an org can raise is not a ceiling.
         if (category === 'defaults') {
-          fields = fields.filter((f) =>
-            f !== 'agentVersionPins' &&
-            f !== 'defaultEnrollmentTtlMinutes' &&
-            f !== 'defaultEnrollmentDeviceCount',
-          );
+          fields = { ...fields };
+          delete fields.agentVersionPins;
+          delete fields.defaultEnrollmentTtlMinutes;
+          delete fields.defaultEnrollmentDeviceCount;
         }
         await assertNotLocked(id, category, fields);
       }

--- a/apps/api/src/services/effectiveSettings.test.ts
+++ b/apps/api/src/services/effectiveSettings.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HTTPException } from 'hono/http-exception';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+  // readWithPartnerAxisVisibility (#2822) imports these by name; the escape is
+  // a no-op under the unit mock — the fake db.select chain returns the same
+  // rows regardless of RLS context.
+  getCurrentDbAccessContext: vi.fn(() => undefined),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => unknown) => fn()),
+}));
+
+vi.mock('../db/schema/orgs', () => ({
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partner_id', settings: 'organizations.settings' },
+  partners: { id: 'partners.id', settings: 'partners.settings' },
+}));
+
+vi.mock('../db/schema/ai', () => ({
+  aiBudgets: { orgId: 'ai_budgets.org_id' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ a, b })),
+}));
+
+import { db } from '../db';
+import { assertNotLocked } from './effectiveSettings';
+
+/**
+ * assertNotLocked issues two sequential reads, each shaped
+ * `db.select({...}).from(t).where(cond).then(rows => rows[0])`:
+ *   1. the org row (for partnerId)
+ *   2. the partner row (for its settings JSONB)
+ * `.where()` therefore has to return a thenable resolving to a row array.
+ */
+function primeSelect(orgRows: unknown[], partnerRows: unknown[]) {
+  const seq = [orgRows, partnerRows];
+  let call = 0;
+  vi.mocked(db.select).mockImplementation((() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => Promise.resolve(seq[call++] ?? [])),
+    })),
+  })) as never);
+}
+
+/** Partner enforces `defaults.autoEnrollment` with everything switched off. */
+const PARTNER_AUTO_ENROLLMENT_OFF = {
+  defaults: {
+    autoEnrollment: { enabled: false, requireApproval: false, sendWelcome: false },
+  },
+};
+
+describe('assertNotLocked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows a category with no partner-set fields', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: {} }]);
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', { deviceGroup: 'Contractors' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a locked field the org is actually changing', async () => {
+    primeSelect(
+      [{ partnerId: 'partner-1' }],
+      [{ settings: { defaults: { deviceGroup: 'Critical Infrastructure' } } }],
+    );
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', { deviceGroup: 'Contractors' }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('names every diverging field in the 403 message', async () => {
+    primeSelect(
+      [{ partnerId: 'partner-1' }],
+      [{ settings: { defaults: { deviceGroup: 'Contractors', alertThreshold: 'high' } } }],
+    );
+
+    const err = await assertNotLocked('org-1', 'defaults', {
+      deviceGroup: 'Remote Staff',
+      alertThreshold: 'medium',
+    }).catch((e) => e as HTTPException);
+
+    expect(err).toBeInstanceOf(HTTPException);
+    expect((err as HTTPException).status).toBe(403);
+    expect((err as HTTPException).message).toContain('defaults.deviceGroup');
+    expect((err as HTTPException).message).toContain('defaults.alertThreshold');
+  });
+
+  // Issue #2752 — the core regression. The org settings editors PUT the whole
+  // category (indeed the whole settings blob) on every save, so a locked field is
+  // re-submitted even when the operator never touched it. Echoing back the value
+  // the partner already enforces is a no-op and must NOT 403.
+  it('allows re-submitting a locked field with the value the partner already enforces', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: PARTNER_AUTO_ENROLLMENT_OFF }]);
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', {
+        autoEnrollment: { enabled: false, requireApproval: false, sendWelcome: false },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  // The amplification that turned one locked field into a total category lockout:
+  // a no-op locked field must not block the unrelated fields alongside it.
+  it('lets unrelated fields through when a locked field is re-submitted unchanged', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: PARTNER_AUTO_ENROLLMENT_OFF }]);
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', {
+        autoEnrollment: { enabled: false, requireApproval: false, sendWelcome: false },
+        deviceGroup: 'Contractors',
+        alertThreshold: 'medium',
+        agentUpdatePolicy: 'manual',
+        maintenanceWindow: '24/7',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('compares nested objects structurally, not by key order or identity', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: PARTNER_AUTO_ENROLLMENT_OFF }]);
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', {
+        // Same three booleans, declared in a different order.
+        autoEnrollment: { sendWelcome: false, enabled: false, requireApproval: false },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('still rejects a locked object field when any nested value diverges', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: PARTNER_AUTO_ENROLLMENT_OFF }]);
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', {
+        autoEnrollment: { enabled: true, requireApproval: false, sendWelcome: false },
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  // A partner value of `false`/`0`/`''` locks just as hard as a truthy one — the
+  // guard keys on presence-plus-divergence, never on truthiness.
+  it('treats a falsy partner value as enforced', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: { defaults: { deviceGroup: '' } } }]);
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', { deviceGroup: 'Contractors' }),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it('does not treat an absent partner field as locked even when the org sends null', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: { defaults: {} } }]);
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', { autoEnrollment: null }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('works for the aiBudgets pseudo-category', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: { aiBudgets: { monthlyBudgetCents: 5000 } } }]);
+
+    await expect(
+      assertNotLocked('org-1', 'aiBudgets', { monthlyBudgetCents: 5000, dailyBudgetCents: 100 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('404s when the org does not exist', async () => {
+    primeSelect([], []);
+
+    await expect(
+      assertNotLocked('missing-org', 'defaults', { deviceGroup: 'Contractors' }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('404s when the partner does not exist', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], []);
+
+    await expect(
+      assertNotLocked('org-1', 'defaults', { deviceGroup: 'Contractors' }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('accepts an empty patch without touching the partner settings', async () => {
+    primeSelect([{ partnerId: 'partner-1' }], [{ settings: PARTNER_AUTO_ENROLLMENT_OFF }]);
+
+    await expect(assertNotLocked('org-1', 'defaults', {})).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/services/effectiveSettings.ts
+++ b/apps/api/src/services/effectiveSettings.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util';
 import { eq } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { db } from '../db';
@@ -211,14 +212,29 @@ export async function getEffectiveOrgSettings(
 /**
  * Guard for org-level PATCH routes.
  *
- * Loads the partner's settings for the given org and checks whether any of the
- * `patchFields` are locked (i.e. set in the partner's category). Throws a 403
- * HTTPException listing the locked fields if any are found.
+ * `patch` maps each submitted field name to the value the org is trying to write.
+ * A field is rejected only when the partner has set it AND the org is submitting
+ * a *different* value — i.e. the org is genuinely attempting to change a locked
+ * field. Re-submitting the value the partner already mandates is a no-op and is
+ * allowed.
+ *
+ * That distinction matters because the org settings editors PUT the whole
+ * `settings` blob on every save (see handleSaveSettings in OrgSettingsPage), so
+ * every stored category is re-submitted even when the operator only touched one
+ * field. Under the old presence-only test (`field in partnerCat`) a single
+ * partner-set field therefore 403'd the entire request, blocking unrelated
+ * fields the partner never intended to enforce (issue #2752 — `autoEnrollment`
+ * is always present in the `defaults` payload, so it locked the whole category).
+ *
+ * Note this deliberately does NOT change `mergeCategory`/`locked` reporting: a
+ * partner-set field is still advertised as locked, and getOrgAgentUpdateConfig's
+ * presence-based resolution stays in lockstep with it. Only the write guard's
+ * strictness changes, from "field present" to "value actually diverges".
  */
 export async function assertNotLocked(
   orgId: string,
   category: string,
-  patchFields: string[],
+  patch: Record<string, unknown>,
 ): Promise<void> {
   const org = await db
     .select({ partnerId: organizations.partnerId })
@@ -250,7 +266,9 @@ export async function assertNotLocked(
   const partnerSettings = asRecord(partner.settings);
   const partnerCat = asRecord(partnerSettings[category]);
 
-  const lockedFields = patchFields.filter((f) => f in partnerCat);
+  const lockedFields = Object.keys(patch).filter(
+    (f) => f in partnerCat && !isDeepStrictEqual(patch[f], partnerCat[f]),
+  );
 
   if (lockedFields.length > 0) {
     throw new HTTPException(403, {

--- a/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
@@ -255,3 +255,138 @@ describe('OrgDefaultsEditor — enrollment defaults (#2776)', () => {
     ]);
   });
 });
+
+// Issue #2752: this editor was the only org settings editor with no lock
+// awareness — its four siblings (security/notifications/eventLogs/branding) all
+// disable partner-locked fields. Because it always posted the whole category from
+// hard-coded seeds, a partner-set `autoEnrollment` collided with the server-side
+// lock guard and 403'd every save in the category.
+describe('OrgDefaultsEditor — partner locks', () => {
+  const ENFORCED = { enabled: false, requireApproval: false, sendWelcome: false };
+
+  it('disables the auto-enrollment checkboxes and flags them as partner-managed', () => {
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        locked={['defaults.autoEnrollment']}
+        effectiveDefaults={{ autoEnrollment: ENFORCED }}
+      />,
+    );
+
+    expect(screen.getByTestId('auto-enrollment-enabled')).toBeDisabled();
+    expect(screen.getByTestId('auto-enrollment-require-approval')).toBeDisabled();
+    expect(screen.getByTestId('auto-enrollment-send-welcome')).toBeDisabled();
+    expect(screen.getByTestId('auto-enrollment-locked')).toBeInTheDocument();
+  });
+
+  it('seeds a locked field from the effective (partner) value, not the hard-coded default', () => {
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        locked={['defaults.autoEnrollment']}
+        effectiveDefaults={{ autoEnrollment: ENFORCED }}
+      />,
+    );
+
+    // The hard-coded default would have been enabled=true / sendWelcome=true.
+    expect(screen.getByTestId('auto-enrollment-enabled')).not.toBeChecked();
+    expect(screen.getByTestId('auto-enrollment-send-welcome')).not.toBeChecked();
+  });
+
+  it('echoes the partner value back verbatim on save so the write is a permitted no-op', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={onSave}
+        // The org's own stored value diverges from the partner's — it is inert
+        // while the lock holds, and must not be what we post.
+        defaults={{ autoEnrollment: { enabled: true, requireApproval: true, sendWelcome: true } }}
+        locked={['defaults.autoEnrollment']}
+        effectiveDefaults={{ autoEnrollment: ENFORCED }}
+      />,
+    );
+
+    await user.click(screen.getByTestId('save-defaults'));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    expect(onSave.mock.calls[0][0].autoEnrollment).toEqual(ENFORCED);
+  });
+
+  it('leaves unlocked fields editable and org-owned', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={onSave}
+        locked={['defaults.autoEnrollment']}
+        effectiveDefaults={{ autoEnrollment: ENFORCED, deviceGroup: 'Critical Infrastructure' }}
+      />,
+    );
+
+    const group = screen.getByTestId('default-device-group') as HTMLSelectElement;
+    expect(group).toBeEnabled();
+    await user.selectOptions(group, 'Contractors');
+    await user.click(screen.getByTestId('save-defaults'));
+
+    expect(onSave.mock.calls[0][0].deviceGroup).toBe('Contractors');
+    // The locked field still rides along unchanged — that is the payload shape
+    // the API now accepts.
+    expect(onSave.mock.calls[0][0].autoEnrollment).toEqual(ENFORCED);
+  });
+
+  it('never treats agentVersionPins as locked — it is inherit-with-override (#2124)', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={onSave}
+        // The API advertises a partner pin in `locked`, but the org may override it.
+        locked={['defaults.agentVersionPins']}
+        effectiveDefaults={{ agentVersionPins: { agent: '0.87.0' } }}
+        defaults={{ agentVersionPins: { agent: '0.88.0' } }}
+      />,
+    );
+
+    await user.click(screen.getByTestId('save-defaults'));
+    expect(onSave.mock.calls[0][0].agentVersionPins).toEqual({ agent: '0.88.0' });
+  });
+
+  it('locks the maintenance-window controls and preserves the partner string exactly', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={onSave}
+        locked={['defaults.maintenanceWindow']}
+        effectiveDefaults={{ maintenanceWindow: 'Sun 02:00-04:00' }}
+      />,
+    );
+
+    expect(screen.getByTestId('maintenance-mode-always')).toBeDisabled();
+    expect(screen.getByTestId('maintenance-mode-window')).toBeChecked();
+    expect(screen.getByTestId('maintenance-day')).toBeDisabled();
+
+    await user.click(screen.getByTestId('save-defaults'));
+    expect(onSave.mock.calls[0][0].maintenanceWindow).toBe('Sun 02:00-04:00');
+  });
+
+  it('is unaffected when nothing is locked', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<OrgDefaultsEditor organizationName={ORG} onSave={onSave} locked={[]} />);
+
+    expect(screen.getByTestId('auto-enrollment-enabled')).toBeEnabled();
+    expect(screen.queryByTestId('auto-enrollment-locked')).not.toBeInTheDocument();
+    await user.click(screen.getByTestId('save-defaults'));
+    expect(onSave.mock.calls[0][0].autoEnrollment).toEqual({
+      enabled: true,
+      requireApproval: false,
+      sendWelcome: true,
+    });
+  });
+});

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -62,12 +62,31 @@ type OrgDefaultsEditorProps = {
   // there is no lock — an org pin always overrides the partner default.
   pinnableVersions?: PinnableVersions | null;
   partnerPins?: AgentVersionPinsValue;
-  // Partner-locked field paths (`defaults.<field>`) from GET effective-settings.
+  // Issue #2752: dot-path fields the partner has locked (e.g. "defaults.deviceGroup"),
+  // straight from GET /organizations/:id/effective-settings, plus the merged
+  // `defaults` category those locks resolve to. This editor was the only org
+  // settings editor with no lock awareness, which is why a partner-set field
+  // 403'd every save in this category.
   locked?: string[];
+  effectiveDefaults?: DefaultsData;
   // Issue #2776: the partner's enrollment-link lifetime cap, shown read-only.
   // The cap is partner-only — an org can never edit it here (see below).
   partnerMaxEnrollmentTtlMinutes?: number;
 };
+
+// Lockable `defaults` fields. `agentVersionPins` is deliberately absent: it is
+// INHERIT-WITH-OVERRIDE, not partner-locked (issue #2124), even though the
+// `locked` array still advertises it when the partner has pinned a version.
+const LOCKABLE_FIELDS = [
+  'policyDefaults',
+  'deviceGroup',
+  'alertThreshold',
+  'autoEnrollment',
+  'agentUpdatePolicy',
+  'maintenanceWindow',
+] as const;
+
+type LockableField = (typeof LOCKABLE_FIELDS)[number];
 
 const defaultValues: DefaultsData = {
   policyDefaults: {
@@ -130,11 +149,27 @@ export default function OrgDefaultsEditor({
   pinnableVersions,
   partnerPins,
   locked,
+  effectiveDefaults,
   partnerMaxEnrollmentTtlMinutes,
 }: OrgDefaultsEditorProps) {
   const { t } = useTranslation('settings');
-  const isLocked = (field: string) => locked?.includes(`defaults.${field}`) ?? false;
-  const initialData = { ...defaultValues, ...defaults };
+  // Matches the isLocked helper in OrgSecuritySettings / OrgNotificationSettings /
+  // OrgEventLogSettings / OrgBrandingEditor (issue #2752 — this editor was missed).
+  const isLocked = (field: LockableField) => locked?.includes(`defaults.${field}`) ?? false;
+
+  // A locked field's effective value IS the partner's, so seed the control from it
+  // rather than from the org's own (inert) value or the hard-coded default. That
+  // way the disabled control shows what is actually in force.
+  const lockedSeed: DefaultsData = {};
+  if (effectiveDefaults) {
+    if (isLocked('policyDefaults') && effectiveDefaults.policyDefaults) lockedSeed.policyDefaults = effectiveDefaults.policyDefaults;
+    if (isLocked('deviceGroup') && effectiveDefaults.deviceGroup !== undefined) lockedSeed.deviceGroup = effectiveDefaults.deviceGroup;
+    if (isLocked('alertThreshold') && effectiveDefaults.alertThreshold !== undefined) lockedSeed.alertThreshold = effectiveDefaults.alertThreshold;
+    if (isLocked('autoEnrollment') && effectiveDefaults.autoEnrollment) lockedSeed.autoEnrollment = effectiveDefaults.autoEnrollment;
+    if (isLocked('agentUpdatePolicy') && effectiveDefaults.agentUpdatePolicy !== undefined) lockedSeed.agentUpdatePolicy = effectiveDefaults.agentUpdatePolicy;
+    if (isLocked('maintenanceWindow') && effectiveDefaults.maintenanceWindow !== undefined) lockedSeed.maintenanceWindow = effectiveDefaults.maintenanceWindow;
+  }
+  const initialData = { ...defaultValues, ...defaults, ...lockedSeed };
   // Version pins are inherit-with-override (issue #2124): the org can always set
   // its own, which overrides the partner default. No lock.
   const [agentVersionPins, setAgentVersionPins] = useState<AgentVersionPinsValue>(
@@ -248,6 +283,18 @@ export default function OrgDefaultsEditor({
       // org PATCH rejects it with 403 once the partner has set one. Omitting it
       // both drops any stale org-stored cap and keeps Save from 403ing.
     };
+    // Partner-locked fields are enforced server-side and inert on the org row, so
+    // echo the partner's value back verbatim. That keeps the write a permitted
+    // no-op (issue #2752) and sidesteps any client-side canonicalisation — the
+    // maintenance-window round-trip, say — reading as a real change and 403ing
+    // the whole category.
+    if (effectiveDefaults) {
+      for (const field of LOCKABLE_FIELDS) {
+        if (isLocked(field) && field in effectiveDefaults) {
+          (data as Record<string, unknown>)[field] = (effectiveDefaults as Record<string, unknown>)[field];
+        }
+      }
+    }
     onSave?.(data);
   };
 
@@ -283,6 +330,7 @@ export default function OrgDefaultsEditor({
               <span className="font-medium">{t(/* i18n-dynamic */ policy.labelKey)}</span>
               <select
                 value={policyDefaults[policy.id as keyof typeof policyDefaults]}
+                disabled={isLocked('policyDefaults')}
                 onChange={event => {
                   setPolicyDefaults(prev => ({
                     ...prev,
@@ -290,7 +338,7 @@ export default function OrgDefaultsEditor({
                   }));
                   markDirty();
                 }}
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                className={`h-10 w-full rounded-md border bg-background px-3 text-sm ${isLocked('policyDefaults') ? 'opacity-60' : ''}`}
               >
                 {policyOptions.map(option => (
                   <option key={option.value} value={option.value}>
@@ -298,6 +346,9 @@ export default function OrgDefaultsEditor({
                   </option>
                 ))}
               </select>
+              {isLocked('policyDefaults') && (
+                <span className="text-xs text-amber-600 dark:text-amber-400 italic">{t('orgDefaultsEditor.managedByPartner')}</span>
+              )}
             </label>
           ))}
         </div>
@@ -311,11 +362,13 @@ export default function OrgDefaultsEditor({
           </div>
           <select
             value={deviceGroup}
+            disabled={isLocked('deviceGroup')}
+            data-testid="default-device-group"
             onChange={event => {
               setDeviceGroup(event.target.value);
               markDirty();
             }}
-            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            className={`h-10 w-full rounded-md border bg-background px-3 text-sm ${isLocked('deviceGroup') ? 'opacity-60' : ''}`}
           >
             {groupOptions.map(option => (
               <option key={option.value} value={option.value}>
@@ -323,6 +376,9 @@ export default function OrgDefaultsEditor({
               </option>
             ))}
           </select>
+          {isLocked('deviceGroup') && (
+            <span className="text-xs text-amber-600 dark:text-amber-400 italic">{t('orgDefaultsEditor.managedByPartner')}</span>
+          )}
           <p className="text-xs text-muted-foreground">
             {t('orgDefaultsEditor.deviceGroup.description')}
           </p>
@@ -335,11 +391,12 @@ export default function OrgDefaultsEditor({
           </div>
           <select
             value={alertThreshold}
+            disabled={isLocked('alertThreshold')}
             onChange={event => {
               setAlertThreshold(event.target.value);
               markDirty();
             }}
-            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            className={`h-10 w-full rounded-md border bg-background px-3 text-sm ${isLocked('alertThreshold') ? 'opacity-60' : ''}`}
           >
             {alertThresholds.map(option => (
               <option key={option.value} value={option.value}>
@@ -347,6 +404,9 @@ export default function OrgDefaultsEditor({
               </option>
             ))}
           </select>
+          {isLocked('alertThreshold') && (
+            <span className="text-xs text-amber-600 dark:text-amber-400 italic">{t('orgDefaultsEditor.managedByPartner')}</span>
+          )}
           <p className="text-xs text-muted-foreground">
             {t('orgDefaultsEditor.alertSeverity.description')}
           </p>
@@ -359,42 +419,53 @@ export default function OrgDefaultsEditor({
             <Sparkles className="h-4 w-4" />
             {t('orgDefaultsEditor.autoEnrollment.title')}
           </div>
-          <label className="flex items-center justify-between gap-4 text-sm">
+          <label className={`flex items-center justify-between gap-4 text-sm ${isLocked('autoEnrollment') ? 'opacity-60' : ''}`}>
             <span>{t('orgDefaultsEditor.autoEnrollment.enable')}</span>
             <input
               type="checkbox"
               checked={autoEnrollment.enabled}
+              disabled={isLocked('autoEnrollment')}
               onChange={event => {
                 setAutoEnrollment(prev => ({ ...prev, enabled: event.target.checked }));
                 markDirty();
               }}
+              data-testid="auto-enrollment-enabled"
               className="h-4 w-4"
             />
           </label>
-          <label className="flex items-center justify-between gap-4 text-sm">
+          <label className={`flex items-center justify-between gap-4 text-sm ${isLocked('autoEnrollment') ? 'opacity-60' : ''}`}>
             <span>{t('orgDefaultsEditor.autoEnrollment.requireApproval')}</span>
             <input
               type="checkbox"
               checked={autoEnrollment.requireApproval}
+              disabled={isLocked('autoEnrollment')}
               onChange={event => {
                 setAutoEnrollment(prev => ({ ...prev, requireApproval: event.target.checked }));
                 markDirty();
               }}
+              data-testid="auto-enrollment-require-approval"
               className="h-4 w-4"
             />
           </label>
-          <label className="flex items-center justify-between gap-4 text-sm">
+          <label className={`flex items-center justify-between gap-4 text-sm ${isLocked('autoEnrollment') ? 'opacity-60' : ''}`}>
             <span>{t('orgDefaultsEditor.autoEnrollment.sendWelcome')}</span>
             <input
               type="checkbox"
               checked={autoEnrollment.sendWelcome}
+              disabled={isLocked('autoEnrollment')}
               onChange={event => {
                 setAutoEnrollment(prev => ({ ...prev, sendWelcome: event.target.checked }));
                 markDirty();
               }}
+              data-testid="auto-enrollment-send-welcome"
               className="h-4 w-4"
             />
           </label>
+          {isLocked('autoEnrollment') && (
+            <span data-testid="auto-enrollment-locked" className="text-xs text-amber-600 dark:text-amber-400 italic">
+              {t('orgDefaultsEditor.managedByPartner')}
+            </span>
+          )}
         </div>
 
         <div className="space-y-4 rounded-lg border bg-muted/40 p-4">
@@ -404,15 +475,19 @@ export default function OrgDefaultsEditor({
           </div>
           <select
             value={agentUpdatePolicy}
+            disabled={isLocked('agentUpdatePolicy')}
             onChange={event => {
               setAgentUpdatePolicy(event.target.value);
               markDirty();
             }}
-            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            className={`h-10 w-full rounded-md border bg-background px-3 text-sm ${isLocked('agentUpdatePolicy') ? 'opacity-60' : ''}`}
           >
             <option value="auto">{t('orgDefaultsEditor.agentUpdates.automatic')}</option>
             <option value="manual">{t('orgDefaultsEditor.agentUpdates.manual')}</option>
           </select>
+          {isLocked('agentUpdatePolicy') && (
+            <span className="text-xs text-amber-600 dark:text-amber-400 italic">{t('orgDefaultsEditor.managedByPartner')}</span>
+          )}
           <p className="text-xs text-muted-foreground">
             <Trans
               i18nKey="orgDefaultsEditor.agentUpdates.description"
@@ -436,6 +511,7 @@ export default function OrgDefaultsEditor({
                   name="maintenanceWindowMode"
                   value="always"
                   checked={windowMode === 'always'}
+                  disabled={isLocked('maintenanceWindow')}
                   onChange={() => {
                     setWindowMode('always');
                     markDirty();
@@ -451,6 +527,7 @@ export default function OrgDefaultsEditor({
                   name="maintenanceWindowMode"
                   value="window"
                   checked={windowMode === 'window'}
+                  disabled={isLocked('maintenanceWindow')}
                   onChange={() => {
                     setWindowMode('window');
                     markDirty();
@@ -461,6 +538,9 @@ export default function OrgDefaultsEditor({
                 <span>{t('orgDefaultsEditor.maintenance.windowOnly')}</span>
               </label>
             </div>
+            {isLocked('maintenanceWindow') && (
+              <span className="text-xs text-amber-600 dark:text-amber-400 italic">{t('orgDefaultsEditor.managedByPartner')}</span>
+            )}
 
             {windowMode === 'window' && (
               <div className="space-y-2 rounded-md border bg-background/60 p-3">
@@ -473,6 +553,7 @@ export default function OrgDefaultsEditor({
                         setWindowDay(event.target.value);
                         markDirty();
                       }}
+                      disabled={isLocked('maintenanceWindow')}
                       data-testid="maintenance-day"
                       className="h-9 w-full rounded-md border bg-background px-2 text-sm"
                     >
@@ -493,6 +574,7 @@ export default function OrgDefaultsEditor({
                         setWindowStart(event.target.value);
                         markDirty();
                       }}
+                      disabled={isLocked('maintenanceWindow')}
                       data-testid="maintenance-start"
                       className="h-9 w-full rounded-md border bg-background px-2 text-sm"
                     />
@@ -506,6 +588,7 @@ export default function OrgDefaultsEditor({
                         setWindowEnd(event.target.value);
                         markDirty();
                       }}
+                      disabled={isLocked('maintenanceWindow')}
                       data-testid="maintenance-end"
                       className="h-9 w-full rounded-md border bg-background px-2 text-sm"
                     />

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -257,6 +257,10 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
   // Issue #2776: the partner's enrollment-link lifetime cap, for the read-only
   // notice in the defaults editor. Partner-only — the org never edits it.
   const [partnerMaxEnrollmentTtl, setPartnerMaxEnrollmentTtl] = useState<number | undefined>(undefined);
+  // Issue #2752: the merged `defaults` category. OrgDefaultsEditor seeds its
+  // partner-locked fields from this so a disabled control shows the value that is
+  // actually in force (and re-posts it unchanged, which the API accepts).
+  const [effectiveDefaults, setEffectiveDefaults] = useState<Record<string, unknown> | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [copiedOrgId, setCopiedOrgId] = useState(false);
@@ -296,6 +300,7 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
         const effData = await effRes.json();
         const lockedList: string[] = effData.locked || [];
         setLocked(lockedList);
+        setEffectiveDefaults(effData.effective?.defaults);
         // Issue #2124: pins are inherit-with-override, NOT enforced-locked (see the
         // assertNotLocked exemption in the org PATCH). But `locked` still carries
         // `defaults.agentVersionPins` when the PARTNER set one — we use that purely
@@ -724,6 +729,7 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
               partnerPins={partnerPins}
               locked={locked}
               partnerMaxEnrollmentTtlMinutes={partnerMaxEnrollmentTtl}
+              effectiveDefaults={effectiveDefaults}
             />
           </div>
         );

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -738,6 +738,7 @@
     "title": "Standardeinstellungen",
     "description": "Optimieren Sie die Standardrichtlinien und das Registrierungsverhalten für {{organization}}.",
     "save": "Standardeinstellungen speichern",
+    "managedByPartner": "Verwaltet durch Partner",
     "policies": {
       "title": "Standardrichtlinien",
       "fields": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -738,6 +738,7 @@
     "title": "Default settings",
     "description": "Tune the default policies and enrollment behavior for {{organization}}.",
     "save": "Save defaults",
+    "managedByPartner": "Managed by partner",
     "policies": {
       "title": "Default policies",
       "fields": {

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -738,6 +738,7 @@
     "title": "Configuración predeterminada",
     "description": "Ajuste las políticas predeterminadas y el comportamiento de inscripción para {{organization}}.",
     "save": "Guardar valores predeterminados",
+    "managedByPartner": "Gestionado por socio",
     "policies": {
       "title": "Políticas predeterminadas",
       "fields": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -738,6 +738,7 @@
     "title": "Réglages par défaut",
     "description": "Ajustez les politiques par défaut et le comportement d’inscription pour {{organization}}.",
     "save": "Enregistrer les paramètres par défaut",
+    "managedByPartner": "Géré par un partenaire",
     "policies": {
       "title": "Politiques par défaut",
       "fields": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -738,6 +738,7 @@
     "title": "Réglages par défaut",
     "description": "Ajustez les politiques par défaut et le comportement d’inscription pour {{organization}}.",
     "save": "Enregistrer les paramètres par défaut",
+    "managedByPartner": "Géré par un partenaire",
     "policies": {
       "title": "Politiques par défaut",
       "fields": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -738,6 +738,7 @@
     "title": "Impostazioni predefinite",
     "description": "Regola i criteri predefiniti e il comportamento di registrazione per {{organization}}.",
     "save": "Salva predefiniti",
+    "managedByPartner": "Gestito dal partner",
     "policies": {
       "title": "Criteri predefiniti",
       "fields": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -738,6 +738,7 @@
     "title": "Configurações padrão",
     "description": "Ajuste as políticas padrão e o comportamento de cadastro para {{organization}}.",
     "save": "Salvar padrões",
+    "managedByPartner": "Gerenciado pelo parceiro",
     "policies": {
       "title": "Políticas padrão",
       "fields": {


### PR DESCRIPTION
## Problem

`defaults.autoEnrollment` locked permanently at the partner level and blocked **every** org-level save in the `defaults` category.

Two independent defects compounded:

1. **The lock guard was presence-based, not value-based.** `assertNotLocked` tested `field in partnerCat`, so a partner value of `{enabled: false, requireApproval: false, sendWelcome: false}` locked the field exactly as hard as an enabled one.
2. **`OrgDefaultsEditor` was the only org settings editor with no lock awareness.** Its four siblings — `OrgSecuritySettings`, `OrgNotificationSettings`, `OrgEventLogSettings`, `OrgBrandingEditor` — all receive `locked` and disable partner-managed controls. This one never got it, so it rendered enabled controls seeded from hard-coded defaults and posted `autoEnrollment` on every save.

Because `handleSaveSettings` PUTs the **whole** `settings` blob and the editor always emits a complete `autoEnrollment` object, a single locked field 403'd the entire request. Changing the device group, alert severity, agent update policy or maintenance window all failed with:

> The following fields are locked by the partner and cannot be changed: defaults.autoEnrollment

with no way to clear the lock short of editing `partners.settings` in Postgres.

## Fix

**API — `assertNotLocked` compares values, not just names.** It now takes the submitted values and rejects a locked field only when the org's value actually **diverges** from the partner's. Re-submitting the value the partner already enforces is a no-op and is allowed. Comparison is structural (`isDeepStrictEqual`), so nested objects match regardless of key order.

This deliberately does **not** touch `mergeCategory` or the `locked` array: a partner-set field is still advertised as locked, so `getOrgAgentUpdateConfig`'s presence-based resolution stays in lockstep with what the UI is told. Only the write guard's strictness changes.

**Web — `OrgDefaultsEditor` becomes lock-aware**, following the exact pattern its four siblings already use:

- seeds partner-locked fields from the **effective** value (the partner's), not the org's inert one or a hard-coded default, so a disabled control shows what is genuinely in force;
- disables those controls with the same `Managed by partner` affordance;
- echoes the partner's value back verbatim on save, so client-side canonicalisation (the maintenance-window round-trip in particular) cannot read as a change.

`agentVersionPins` stays exempt on both sides — it is inherit-with-override, not partner-locked (#2124).

## Scope — what this does NOT do

The issue proposed two designs for the underlying semantics: value-based locking with a tri-state partner control, or a per-field enforcement flag. **Neither is implemented here** — both are product decisions, and the existing code already flags the second (`orgs.ts`: *"Do NOT 'fix' this back to a lock without a per-field enforcement flag"*).

So one part of the report is still open, and the issue should stay open for it:

> **A partner still cannot _unset_ `defaults.autoEnrollment` from the Partner Settings UI.** Every scalar in `PartnerDefaultsTab` uses `set({ x: e.target.value || undefined })` so the key drops out of `JSON.stringify` and the lock releases. The checkbox group has no equivalent — `set()` always writes a complete object. Giving it one means deciding whether "all three unticked" means *not enforced* or *enforced off*, which changes what an MSP can enforce.

What **is** fixed: the total lockout. Every other field in the category saves again, the lock is visible in the UI instead of surfacing as a mystery 403, and the same amplification is reduced across `security` / `notifications` / `eventLogs` / `branding` / `aiBudgets`, which shared the root cause.

Known remaining gap, unchanged by this PR: the four sibling editors seed locked fields from the org's own stored value rather than the effective one, so a locked field whose stored org value diverges can still 403 those categories. Worth a follow-up; out of scope here.

## Testing

- **New** `apps/api/src/services/effectiveSettings.test.ts` — 13 tests for `assertNotLocked`: no-op resubmission allowed, unrelated fields pass alongside a locked no-op, structural comparison ignores key order, divergence still 403s, falsy partner values still enforce, 404 paths. Verified non-vacuous: 4 of them fail against the old presence-only predicate.
- `apps/api/src/routes/orgs.test.ts` — 2 route-level regressions: a save re-sending the locked field unchanged alongside edited fields returns 200; changing the locked field still returns 403 and does not write.
- `apps/web/.../OrgDefaultsEditor.test.tsx` — 7 tests: controls disabled + flagged, seeded from the effective value, partner value echoed verbatim, unlocked fields stay editable, `agentVersionPins` never treated as locked, maintenance-window string preserved exactly.
- `orgDefaultsEditor.managedByPartner` added to all 7 locales, reusing each locale's existing `managedByPartner` translation.

Closes nothing on its own — see Scope above.

Refs #2752

🤖 Generated with [Claude Code](https://claude.com/claude-code)
