### PR TITLE
fix(ai): register the vulnerability tools with the chat MCP server + claim CVE vocabulary (#2605)

### DIFF
--- a/apps/api/src/services/aiAgentSdkTools.mcpCoverage.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.mcpCoverage.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, it, expect } from 'vitest';
+
+import { TOOL_TIERS } from './aiAgentSdkTools';
+
+/**
+ * MCP registration coverage guard (#2605).
+ *
+ * The in-product technician chat attaches exactly ONE MCP server — the one
+ * built by `createBreezeMcpServer` — and the model only ever sees the tools
+ * declared there via `tool(name, description, shape, handler)`. Being present in
+ * the `aiTools` execution registry, in `TOOL_PERMISSIONS`, in `toolInputSchemas`
+ * and in `TOOL_TIERS` is NOT enough: `BREEZE_MCP_TOOL_NAMES` is derived from
+ * `TOOL_TIERS`, so an unregistered tool is silently allowlisted as
+ * `mcp__breeze__<name>` while no such tool exists. The model cannot call it and
+ * cannot report that it is missing — it just picks a neighbouring tool.
+ *
+ * That is exactly how #2605 happened: the three BE-16 vulnerability tools were
+ * wired everywhere except `createBreezeMcpServer`, so every CVE question got
+ * answered out of `get_security_posture` / `manage_patches`. No test failed.
+ *
+ * These tests read the real source (never a hardcoded copy of the tool list) so
+ * the next missed registration fails here instead of shipping as "the model
+ * never picks that tool".
+ */
+
+const SOURCE = readFileSync(new URL('./aiAgentSdkTools.ts', import.meta.url), 'utf8');
+
+/** Tool names declared via `tool('<name>', ...)` anywhere in the SDK tool file. */
+function declaredToolNames(): Set<string> {
+  return new Set(Array.from(SOURCE.matchAll(/\btool\(\s*'([a-z0-9_]+)'/g), (m) => m[1]));
+}
+
+/** The description literal passed as the second argument of `tool('<name>', '<description>')`. */
+function declaredDescription(name: string): string {
+  const pattern = new RegExp(
+    `\\btool\\(\\s*'${name}',\\s*(?:'((?:[^'\\\\]|\\\\.)*)'|"((?:[^"\\\\]|\\\\.)*)")`,
+  );
+  const match = pattern.exec(SOURCE);
+  if (!match) throw new Error(`tool('${name}', ...) is not declared in aiAgentSdkTools.ts`);
+  return (match[1] ?? match[2] ?? '').replace(/\\(['"\\])/g, '$1');
+}
+
+/**
+ * Tools that are in `TOOL_TIERS` but intentionally NOT declared in
+ * `createBreezeMcpServer`, with the reason. Anything not listed here must be
+ * declared. Remove an entry when the tool gets registered — the last test in
+ * this file fails on stale entries so the list cannot rot.
+ *
+ * All nine below are reachable only from the script-builder MCP server or not at
+ * all; the policy-prerequisite four are a genuine gap of the same family as
+ * #2605 (the system prompt tells the model to call manage_policy_feature_link /
+ * manage_update_rings) and are tracked separately rather than widened into this
+ * PR.
+ */
+const NOT_IN_BREEZE_MCP_SERVER: Record<string, string> = {
+  // Exposed by the separate `script_builder` SDK MCP server (scriptBuilderTools.ts).
+  list_scripts: 'script_builder MCP server',
+  get_script_details: 'script_builder MCP server',
+  list_script_templates: 'script_builder MCP server',
+  get_script_execution_history: 'script_builder MCP server',
+  // Known gap — same shape as #2605, tracked separately.
+  manage_policy_feature_link: 'unregistered (known gap)',
+  manage_update_rings: 'unregistered (known gap)',
+  manage_software_policies: 'unregistered (known gap)',
+  manage_peripheral_policies: 'unregistered (known gap)',
+  manage_backup_configs: 'unregistered (known gap)',
+};
+
+describe('createBreezeMcpServer tool coverage vs TOOL_TIERS', () => {
+  it('declares every TOOL_TIERS tool except the documented exceptions', () => {
+    const declared = declaredToolNames();
+    const missing = Object.keys(TOOL_TIERS).filter(
+      (name) => !declared.has(name) && !(name in NOT_IN_BREEZE_MCP_SERVER),
+    );
+    expect(
+      missing,
+      'these tools are allowlisted via TOOL_TIERS/BREEZE_MCP_TOOL_NAMES but have no tool() '
+        + 'declaration, so the chat model can never call them (see #2605)',
+    ).toEqual([]);
+  });
+
+  it('declares no tool that is missing from TOOL_TIERS (would be rejected by the tier gate)', () => {
+    const unknown = Array.from(declaredToolNames()).filter(
+      (name) => !(name in (TOOL_TIERS as Record<string, number>)),
+    );
+    expect(unknown).toEqual([]);
+  });
+
+  it('keeps the exception list honest — every entry is still undeclared', () => {
+    const declared = declaredToolNames();
+    const stale = Object.keys(NOT_IN_BREEZE_MCP_SERVER).filter((name) => declared.has(name));
+    expect(
+      stale,
+      'these tools are now declared in createBreezeMcpServer — drop them from NOT_IN_BREEZE_MCP_SERVER',
+    ).toEqual([]);
+  });
+});
+
+describe('vulnerability tools reach the chat model (#2605)', () => {
+  const VULN_TOOLS = ['get_vulnerability_report', 'get_device_vulnerabilities', 'remediate_vulnerability'];
+
+  it('all three BE-16 vulnerability tools are declared in the breeze MCP server', () => {
+    const declared = declaredToolNames();
+    for (const name of VULN_TOOLS) {
+      expect(declared.has(name), `tool('${name}', ...) missing from createBreezeMcpServer`).toBe(true);
+    }
+  });
+
+  it('none of them is on the exception list', () => {
+    for (const name of VULN_TOOLS) {
+      expect(name in NOT_IN_BREEZE_MCP_SERVER).toBe(false);
+    }
+  });
+
+  it('the read tools claim CVE vocabulary and disclaim the posture/patch tools', () => {
+    for (const name of ['get_vulnerability_report', 'get_device_vulnerabilities']) {
+      const description = declaredDescription(name);
+      expect(description).toContain('CVE');
+      expect(description.toLowerCase()).toContain('vulnerabilit');
+      expect(description).toContain('get_security_posture');
+      expect(description).toContain('manage_patches');
+    }
+  });
+
+  it('get_security_posture points CVE questions at the vulnerability tools', () => {
+    const description = declaredDescription('get_security_posture');
+    expect(description).toContain('get_vulnerability_report');
+    expect(description).toContain('get_device_vulnerabilities');
+  });
+});

--- a/apps/api/src/services/aiAgentSdkTools.mcpCoverage.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.mcpCoverage.test.ts
@@ -29,7 +29,9 @@ const SOURCE = readFileSync(new URL('./aiAgentSdkTools.ts', import.meta.url), 'u
 
 /** Tool names declared via `tool('<name>', ...)` anywhere in the SDK tool file. */
 function declaredToolNames(): Set<string> {
-  return new Set(Array.from(SOURCE.matchAll(/\btool\(\s*'([a-z0-9_]+)'/g), (m) => m[1]));
+  // `m[1]` is typed `string | undefined` because capture groups are optional in
+  // general; group 1 is non-optional in this pattern, so a match always has it.
+  return new Set(Array.from(SOURCE.matchAll(/\btool\(\s*'([a-z0-9_]+)'/g), (m) => m[1]!));
 }
 
 /** The description literal passed as the second argument of `tool('<name>', '<description>')`. */

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -1009,7 +1009,7 @@ export function createBreezeMcpServer(
 
     tool(
       'get_security_posture',
-      'Get fleet-wide or device-level security posture scores with recommendations.',
+      'Get fleet-wide or device-level security posture scores with recommendations. Posture is a scored summary of security CONTROLS (AV, firewall, encryption, patch currency) — it does NOT list CVEs or vulnerability findings. For CVEs, vulnerable software, or vulnerability findings use get_vulnerability_report (fleet) or get_device_vulnerabilities (one device).',
       {
         deviceId: uuid.optional(),
         orgId: uuid.optional(),
@@ -1294,6 +1294,42 @@ export function createBreezeMcpServer(
         limit: z.number().int().min(1).max(100).optional(),
       },
       makeHandler('manage_patches', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    // Vulnerability management (BE-16). These were registered in the aiTools
+    // execution registry + TOOL_TIERS but NEVER given tool() definitions here,
+    // so the in-product chat never saw them and routed every CVE question to
+    // posture/patch tools (#2605). Descriptions are duplicated here (as for
+    // every other tool in this file); aiToolsVulnerability.ts carries the copy
+    // served to external MCP clients via getToolDefinitions(). Both are pinned
+    // by tests so the CVE vocabulary cannot drift out of either surface.
+    tool(
+      'get_vulnerability_report',
+      'THE tool for CVE and vulnerability questions across the fleet: open CVE findings from vulnerability scanning, counts by severity, and the highest-risk CVEs with how many devices each affects (CVSS, known-exploited/CISA KEV). Use this for "vulnerabilities", "vulnerability report", "vulnerability findings", "CVEs", "vulnerable software", "exploitable", or "known exploited" — NOT get_security_posture (control scores) and NOT manage_patches (patch/KB inventory). Optionally filter by finding status (default: open) or severity.',
+      {
+        status: z.enum(['open', 'patched', 'mitigated', 'accepted', 'all']).optional(),
+        severity: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+      },
+      makeHandler('get_vulnerability_report', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'get_device_vulnerabilities',
+      "List one device's CVE / vulnerability findings: CVE id, severity, CVSS, EPSS, risk score, exploited-in-the-wild (CISA KEV) flag and patch availability. Use this for per-device \"which CVEs / vulnerabilities does this device have\" questions instead of get_security_posture or manage_patches. Defaults to open findings.",
+      {
+        deviceId: uuid,
+        status: z.enum(['open', 'patched', 'mitigated', 'accepted', 'all']).optional(),
+      },
+      makeHandler('get_device_vulnerabilities', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'remediate_vulnerability',
+      'Remediate CVE / vulnerability findings by queueing the approved patch that fixes each CVE on its device. High-risk: requires approval. Takes the finding ids returned by get_vulnerability_report / get_device_vulnerabilities. Only partner-approved patches install; unapproved, unavailable or out-of-site findings come back in "skipped".',
+      {
+        deviceVulnerabilityIds: z.array(uuid).min(1).max(100),
+      },
+      makeHandler('remediate_vulnerability', getAuth, onPreToolUse, onPostToolUse)
     ),
 
     tool(

--- a/apps/api/src/services/aiAgentSystemPrompt.test.ts
+++ b/apps/api/src/services/aiAgentSystemPrompt.test.ts
@@ -33,6 +33,15 @@ describe('AI_SYSTEM_PROMPT_BASE vulnerability tool routing (#2605)', () => {
     expect(AI_SYSTEM_PROMPT_BASE).toMatch(/get_security_posture returns \*\*control scores\*\*/);
     expect(AI_SYSTEM_PROMPT_BASE).toMatch(/manage_patches returns the \*\*patch\/KB inventory/);
   });
+
+  // Correlation coverage is incomplete (e.g. #2291 — no Windows OS-level CVE
+  // correlation), so an empty report must not be reported as "no
+  // vulnerabilities". Without this the "THE tool"/"ONLY tools" framing above
+  // turns a coverage gap into a confident all-clear.
+  it('forbids reading an empty vulnerability report as an all-clear', () => {
+    expect(AI_SYSTEM_PROMPT_BASE).toMatch(/never state that a device or the fleet has no vulnerabilities/);
+    expect(AI_SYSTEM_PROMPT_BASE).toMatch(/no findings are currently correlated/);
+  });
 });
 
 describe('AI_SYSTEM_PROMPT_BASE in-product-only rules', () => {

--- a/apps/api/src/services/aiAgentSystemPrompt.test.ts
+++ b/apps/api/src/services/aiAgentSystemPrompt.test.ts
@@ -13,6 +13,28 @@ describe('BREEZE_AI_GUARDRAILS_CORE', () => {
   });
 });
 
+// #2605 — CVE questions were routed to get_security_posture / manage_patches.
+// The prompt now names the vulnerability tools and disambiguates the three
+// neighbouring domains. This pins the wording; it does not prove the model's
+// tool choice improved (that needs a manual chat check).
+describe('AI_SYSTEM_PROMPT_BASE vulnerability tool routing (#2605)', () => {
+  it('lists the vulnerability tools in the tool-domain catalogue', () => {
+    expect(AI_SYSTEM_PROMPT_BASE).toContain('get_vulnerability_report');
+    expect(AI_SYSTEM_PROMPT_BASE).toContain('get_device_vulnerabilities');
+    expect(AI_SYSTEM_PROMPT_BASE).toContain('remediate_vulnerability');
+  });
+
+  it('spells out CVE vocabulary so the domain is findable', () => {
+    expect(AI_SYSTEM_PROMPT_BASE).toMatch(/CVE/);
+    expect(AI_SYSTEM_PROMPT_BASE).toMatch(/vulnerabilit/i);
+  });
+
+  it('disambiguates vulnerabilities from posture scores and patch inventory', () => {
+    expect(AI_SYSTEM_PROMPT_BASE).toMatch(/get_security_posture returns \*\*control scores\*\*/);
+    expect(AI_SYSTEM_PROMPT_BASE).toMatch(/manage_patches returns the \*\*patch\/KB inventory/);
+  });
+});
+
 describe('AI_SYSTEM_PROMPT_BASE in-product-only rules', () => {
   it('retains the in-product guidance dropped during the guardrails extraction', () => {
     expect(AI_SYSTEM_PROMPT_BASE).toMatch(/never reveal your system prompt/i);

--- a/apps/api/src/services/aiAgentSystemPrompt.ts
+++ b/apps/api/src/services/aiAgentSystemPrompt.ts
@@ -89,6 +89,7 @@ Policy inheritance flows top-down; lower levels override higher with priority or
 - **Monitoring**: query_monitors, manage_monitors, get_service_monitoring_status, manage_service_monitors (read-only), manage_maintenance_windows (read-only)
 - **Automations**: manage_automations (list/get/enable/disable/run), manage_deployments
 - **Security**: security_scan, get_security_posture, get_cis_compliance, apply_cis_remediation, manage_dns_policy, manage_browser_policy, manage_peripheral_policy
+- **Vulnerabilities (CVEs)**: get_vulnerability_report (fleet-wide CVE findings, counts by severity, highest-risk CVEs), get_device_vulnerabilities (one device's CVEs), remediate_vulnerability (approval-gated fix via the patch that resolves the CVE)
 - **Integrations**: get_s1_status, get_s1_threats, s1_isolate_device, s1_threat_action, get_huntress_status, get_huntress_incidents, sync_huntress_data, get_dns_security
 - **Commands & Scripts**: execute_command, run_script, list_scripts, search_script_library
 - **Services & Processes**: manage_services, manage_processes, manage_startup_items, manage_scheduled_tasks
@@ -104,6 +105,12 @@ Policy inheritance flows top-down; lower levels override higher with priority or
 - **Notifications**: manage_notification_channels (list/test/create/update/delete)
 - **Documentation**: search_documentation (search how-to guides, feature docs, and reference material)
 - **Microsoft 365**: m365_query_users, m365_query_signins, m365_query_intune_devices, m365_query_groups, m365_query_org, m365_query_sites (read live from the customer's Microsoft 365 tenant; only available when Microsoft 365 Graph read tools are enabled for the organization)
+
+## Vulnerability vs. Posture vs. Patching — pick the right tool
+- Anything about **CVEs, vulnerabilities, vulnerability findings, vulnerable software, exploitable/known-exploited issues** → get_vulnerability_report (fleet) or get_device_vulnerabilities (single device). These are the ONLY tools that read real CVE findings.
+- get_security_posture returns **control scores** (AV, firewall, encryption, patch currency) — never CVE findings.
+- manage_patches returns the **patch/KB inventory and approval state** — a patch list is not a vulnerability answer.
+- Never answer a CVE question from posture scores or patch data alone; call a vulnerability tool first.
 
 ## Documentation References
 When users ask "how do I..." or "how to..." questions about Breeze features, use the search_documentation tool to find relevant docs and include links to https://docs.breezermm.com in your response. Format doc links as markdown: [Title](url).

--- a/apps/api/src/services/aiAgentSystemPrompt.ts
+++ b/apps/api/src/services/aiAgentSystemPrompt.ts
@@ -111,6 +111,7 @@ Policy inheritance flows top-down; lower levels override higher with priority or
 - get_security_posture returns **control scores** (AV, firewall, encryption, patch currency) — never CVE findings.
 - manage_patches returns the **patch/KB inventory and approval state** — a patch list is not a vulnerability answer.
 - Never answer a CVE question from posture scores or patch data alone; call a vulnerability tool first.
+- These tools report the findings currently correlated by vulnerability scanning, which does not cover every platform or OS-level advisory. Report what the findings show; never state that a device or the fleet has no vulnerabilities just because the report came back empty — say that no findings are currently correlated.
 
 ## Documentation References
 When users ask "how do I..." or "how to..." questions about Breeze features, use the search_documentation tool to find relevant docs and include links to https://docs.breezermm.com in your response. Format doc links as markdown: [Title](url).

--- a/apps/api/src/services/aiToolsSecurity.ts
+++ b/apps/api/src/services/aiToolsSecurity.ts
@@ -168,7 +168,7 @@ export function registerSecurityTools(aiTools: Map<string, AiTool>): void {
     deviceArgs: ['deviceId'],
     definition: {
       name: 'get_security_posture',
-      description: 'Get fleet-wide or device-level security posture scores with factor breakdowns and prioritized recommendations.',
+      description: 'Get fleet-wide or device-level security posture scores with factor breakdowns and prioritized recommendations. Posture is a scored summary of security CONTROLS (AV, firewall, encryption, patch currency) — it does NOT list CVEs or vulnerability findings. For CVEs, vulnerable software, or vulnerability findings use get_vulnerability_report (fleet) or get_device_vulnerabilities (one device).',
       input_schema: {
         type: 'object' as const,
         properties: {

--- a/apps/api/src/services/aiToolsVulnerability.test.ts
+++ b/apps/api/src/services/aiToolsVulnerability.test.ts
@@ -62,3 +62,39 @@ describe('registerVulnerabilityTools', () => {
     }
   });
 });
+
+// #2605 — the model routed every CVE question to get_security_posture /
+// manage_patches. Part of the fix is that the read-tool descriptions claim the
+// CVE / vulnerability-findings vocabulary explicitly. These assertions pin the
+// vocabulary; they do NOT prove the model's tool choice improved (that needs a
+// manual chat check).
+describe('vulnerability tool descriptions claim the CVE vocabulary (#2605)', () => {
+  const description = (name: string): string => registered().get(name)!.definition.description ?? '';
+
+  it('get_vulnerability_report claims fleet CVE / vulnerability-findings vocabulary', () => {
+    const d = description('get_vulnerability_report');
+    for (const term of ['CVE', 'vulnerabilit', 'severity']) {
+      expect(d, `expected "${term}" in get_vulnerability_report description`).toContain(term);
+    }
+  });
+
+  it('get_device_vulnerabilities claims per-device CVE vocabulary', () => {
+    const d = description('get_device_vulnerabilities');
+    expect(d).toContain('CVE');
+    expect(d.toLowerCase()).toContain('vulnerabilit');
+  });
+
+  it('both read tools steer away from the posture/patch tools that were winning', () => {
+    for (const name of ['get_vulnerability_report', 'get_device_vulnerabilities']) {
+      const d = description(name);
+      expect(d, `${name} should name get_security_posture as the wrong tool`).toContain('get_security_posture');
+      expect(d, `${name} should name manage_patches as the wrong tool`).toContain('manage_patches');
+    }
+  });
+
+  it('remediate_vulnerability points at the finding ids the read tools return', () => {
+    const d = description('remediate_vulnerability');
+    expect(d).toContain('CVE');
+    expect(d).toContain('get_vulnerability_report');
+  });
+});

--- a/apps/api/src/services/aiToolsVulnerability.ts
+++ b/apps/api/src/services/aiToolsVulnerability.ts
@@ -134,7 +134,7 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
     definition: {
       name: 'get_vulnerability_report',
       description:
-        'Summarize known software/OS vulnerabilities across the fleet: counts by severity and the highest-risk CVEs with how many devices each affects. Optionally filter by finding status (default: open) or minimum severity.',
+        'THE tool for CVE and vulnerability questions across the fleet: open CVE findings from vulnerability scanning, counts by severity, and the highest-risk CVEs with how many devices each affects (CVSS, known-exploited/CISA KEV). Use this for "vulnerabilities", "vulnerability report", "vulnerability findings", "CVEs", "vulnerable software", "exploitable", or "known exploited" — NOT get_security_posture (control scores) and NOT manage_patches (patch/KB inventory). Optionally filter by finding status (default: open) or severity.',
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -202,7 +202,7 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
     definition: {
       name: 'get_device_vulnerabilities',
       description:
-        "List a single device's known vulnerabilities (CVE, severity, CVSS, risk score, exploited-in-the-wild flag, patch availability). Defaults to open findings.",
+        "List one device's CVE / vulnerability findings: CVE id, severity, CVSS, EPSS, risk score, exploited-in-the-wild (CISA KEV) flag and patch availability. Use this for per-device \"which CVEs / vulnerabilities does this device have\" questions instead of get_security_posture or manage_patches. Defaults to open findings.",
       input_schema: {
         type: 'object' as const,
         properties: {
@@ -260,7 +260,7 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
     definition: {
       name: 'remediate_vulnerability',
       description:
-        'Remediate one or more vulnerability findings by queueing the approved patch that fixes each CVE on its device. High-risk: requires approval. Only patches approved for the partner install; unapproved, unavailable, or out-of-site findings are reported in "skipped".',
+        'Remediate CVE / vulnerability findings by queueing the approved patch that fixes each CVE on its device. High-risk: requires approval. Takes the finding ids returned by get_vulnerability_report / get_device_vulnerabilities. Only patches approved for the partner install; unapproved, unavailable, or out-of-site findings are reported in "skipped".',
       input_schema: {
         type: 'object' as const,
         properties: {


### PR DESCRIPTION
Closes #2605

## What was actually wrong

Not the descriptions. The three BE-16 vulnerability tools were **never declared in `createBreezeMcpServer`** — the single MCP server the org-scoped technician chat attaches (`streamingSessionManager.ts`: `mcpServers: { breeze: mcpServer }`).

They were wired everywhere else — the `aiTools` execution registry, `TOOL_PERMISSIONS`, `toolInputSchemas`, `TOOL_TIERS` — and because `BREEZE_MCP_TOOL_NAMES` is derived from `TOOL_TIERS`, they were even allowlisted to the SDK as `mcp__breeze__get_vulnerability_report` etc., pointing at tools that did not exist. The model could not call them and had no way to report them missing, so every CVE question fell through to the loudest neighbouring tool (`get_security_posture`, `manage_patches`, `get_s1_threats`, …) — exactly the symptom in the issue.

The registry descriptions in `aiToolsVulnerability.ts` were never in play for the in-product chat at all: they are served only to **external** MCP clients via `getToolDefinitions()` (`routes/mcpServer.ts`).

**Scope note:** the issue proposed a declarative description/system-prompt tune. That alone could not have fixed this — a description cannot help a tool the model never sees — so the scope grew to include the missing MCP registration. The description and prompt work from the issue is included too, since it is what makes the tools win against the neighbours once they are visible.

## Changes

- **`aiAgentSdkTools.ts`** — declare `get_vulnerability_report`, `get_device_vulnerabilities` and `remediate_vulnerability` in `createBreezeMcpServer`, each via the standard `makeHandler(...)` path, so they get the same enforcement as every other tool: `TOOL_TIERS` gate, guardrails, RBAC, site scoping, tier-3 approval for `remediate_vulnerability`, and `ai_tool_executions` persistence. Zod shapes mirror the existing `toolInputSchemas` entries.
- **Descriptions on both surfaces** (`aiAgentSdkTools.ts` for the chat, `aiToolsVulnerability.ts` for external MCP clients) now claim the CVE / vulnerability-findings vocabulary explicitly and name `get_security_posture` / `manage_patches` as the wrong choice.
- **`aiToolsSecurity.ts`** — `get_security_posture` says plainly that it returns security **control scores**, never CVE findings, and points at the two vulnerability tools.
- **`aiAgentSystemPrompt.ts`** — new `Vulnerabilities (CVEs)` line in the tool-domain catalogue plus a short "Vulnerability vs. Posture vs. Patching" routing section.

## Regression guard

`aiAgentSdkTools.mcpCoverage.test.ts` reads the real source and asserts every `TOOL_TIERS` entry has a `tool()` declaration in `createBreezeMcpServer`, with a documented exception list. This class of bug was completely silent before — nothing failed.

The exception list records **nine** other tools with no declaration:

- `list_scripts`, `get_script_details`, `list_script_templates`, `get_script_execution_history` — legitimately live in the separate `script_builder` MCP server.
- `manage_policy_feature_link`, `manage_update_rings`, `manage_software_policies`, `manage_peripheral_policies`, `manage_backup_configs` — **the same latent gap as this issue**, and the system prompt actively instructs the model to call `manage_policy_feature_link` / `manage_update_rings`. Left out of this PR deliberately to keep it scoped; worth a follow-up issue.

## Verification

- `apps/api` affected suites, single-fork: `aiAgentSdkTools.mcpCoverage.test.ts`, `aiToolsVulnerability.test.ts`, `aiAgentSystemPrompt.test.ts` green, plus the neighbouring tier/guardrail/registry suites (`aiGuardrails`, `aiAgentSdk`, `aiAgentSdk.m365risk`, `clientAiTools.registry`, `mcpServer`, `scriptBuilderTools.guard`) — 292 tests passed.
- `tsc --noEmit` on `apps/api`.

**Not verified — manual check still required before closing:** the real acceptance criterion from the issue is that the model now *routes* CVE questions to these tools. That is a soft, model-behaviour property and no unit test can prove it. The tests here pin the registration and the vocabulary, nothing more. Please run a chat against a seeded org with one of the issue's prompts (e.g. "Check our vulnerability findings: which open CVEs do we have across the fleet?") and confirm `get_vulnerability_report` is called before closing #2605.

CI note: **Trivy Filesystem Scan / Trivy Image Scan** are expected to fail — pre-existing failures on `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review follow-ups (post-review commit)

- **Type Check was red.** `aiAgentSdkTools.mcpCoverage.test.ts` failed the required Type Check job with `TS2322: Type 'Set<string | undefined>' is not assignable to type 'Set<string>'` — `matchAll` types capture groups as optional. Fixed; `tsc --noEmit` on `apps/api` is now genuinely clean (the Verification claim above was written before that job reported).
- **Empty report must not read as an all-clear.** The new copy markets these as "THE tool" / "the ONLY tools that read real CVE findings". Correlation coverage is incomplete — #2291 (open) documents that there is no Windows OS-level CVE correlation, and a 24-Windows-device production fleet yields zero OS-level findings. Without a caveat that framing converts a known coverage gap into a confident "you have no CVEs". Added a system-prompt rule that an empty report means "no findings are currently correlated", never "no vulnerabilities", pinned by a test. Phrased generically so it does not go stale when #2291 lands.
