### PR TITLE
fix(api): installer bootstrap tokens get an independent TTL, uncapped by the transient parent key

### DIFF
--- a/apps/api/src/__tests__/integration/installerBootstrapTokenTtl.integration.test.ts
+++ b/apps/api/src/__tests__/integration/installerBootstrapTokenTtl.integration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Real-Postgres integration coverage for issueBootstrapTokenForKey's
+ * independent TTL (#2775).
+ *
+ * `installerBootstrapTokenIssuance.ts` is `vi.mock`ed in every route suite
+ * (installer.test.ts, enrollmentKeys.test.ts, etc.), so the actual INSERT —
+ * and in particular the `expiresAt` column it persists — has never executed
+ * against a real database. That gap is exactly how #2775 shipped: the parent
+ * enrollment key created by the Add Device modal is a deliberately transient
+ * 60-minute container, and pre-fix code clamped the child bootstrap token's
+ * expiry to the parent's remaining life, so every installer died in ~60
+ * minutes no matter what TTL the admin picked.
+ *
+ * This test drives the real service function against the test Postgres and
+ * asserts against the row read back from the database — not the service's
+ * return value, which is a local variable and would pass even if the INSERT
+ * itself wrote the wrong value.
+ */
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { enrollmentKeys, installerBootstrapTokens, organizations, partners, sites } from '../../db/schema';
+import { issueBootstrapTokenForKey } from '../../services/installerBootstrapTokenIssuance';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+describe('installer bootstrap token TTL (#2775, real Postgres)', () => {
+  runDb(
+    'a 30-day token issued from a 60-minute parent key persists an expires_at ~30 days out, read back from the DB',
+    async () => {
+      const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      const ids = await withSystemDbAccessContext(async () => {
+        const [partner] = await db
+          .insert(partners)
+          .values({
+            name: `TTL Partner ${unique}`,
+            slug: `ttl-partner-${unique}`,
+            type: 'msp',
+            plan: 'pro',
+            status: 'active',
+          })
+          .returning({ id: partners.id });
+        const [org] = await db
+          .insert(organizations)
+          .values({
+            partnerId: partner!.id,
+            name: `TTL Org ${unique}`,
+            slug: `ttl-org-${unique}`,
+            type: 'customer',
+            status: 'active',
+          })
+          .returning({ id: organizations.id });
+        const [site] = await db
+          .insert(sites)
+          .values({ orgId: org!.id, name: `TTL Site ${unique}` })
+          .returning({ id: sites.id });
+
+        // The Add Device modal's deliberately transient parent: expires in
+        // 60 minutes (PR #739 review finding #1).
+        const [parent] = await db
+          .insert(enrollmentKeys)
+          .values({
+            orgId: org!.id,
+            siteId: site!.id,
+            name: 'transient parent',
+            key: `ttl-parent-key-${unique}`,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            maxUsage: 1,
+          })
+          .returning({ id: enrollmentKeys.id });
+
+        const issued = await issueBootstrapTokenForKey({
+          parentEnrollmentKeyId: parent!.id,
+          createdByUserId: null,
+          maxUsage: 25,
+          ttlMinutes: 43200, // 30 days — admin's chosen expiry
+        });
+
+        return {
+          partnerId: partner!.id,
+          orgId: org!.id,
+          siteId: site!.id,
+          parentId: parent!.id,
+          issuedId: issued.id,
+        };
+      });
+
+      try {
+        const row = await withSystemDbAccessContext(async () => {
+          const [r] = await db
+            .select()
+            .from(installerBootstrapTokens)
+            .where(eq(installerBootstrapTokens.id, ids.issuedId));
+          return r;
+        });
+
+        expect(row).toBeDefined();
+        const ttlMs = new Date(row!.expiresAt).getTime() - Date.now();
+        // 30 days = 2,592,000,000ms. Bounding both sides proves the column
+        // reflects the full 30-day admin-chosen TTL — not the parent's
+        // 60-minute lifetime (the pre-fix clamp bug) and not the 24h
+        // issuance default (bootstrapTokenExpiresAt()).
+        expect(ttlMs).toBeGreaterThan(29 * 24 * 60 * 60 * 1000);
+        expect(ttlMs).toBeLessThan(31 * 24 * 60 * 60 * 1000);
+      } finally {
+        // Clean up every row created above. enrollment_keys ->
+        // installer_bootstrap_tokens is ON DELETE CASCADE, so deleting the
+        // parent key also removes the bootstrap token row.
+        await withSystemDbAccessContext(async () => {
+          await db.delete(enrollmentKeys).where(eq(enrollmentKeys.id, ids.parentId));
+          await db.delete(sites).where(eq(sites.id, ids.siteId));
+          await db.delete(organizations).where(eq(organizations.id, ids.orgId));
+          await db.delete(partners).where(eq(partners.id, ids.partnerId));
+        });
+      }
+    },
+  );
+});

--- a/apps/api/src/jobs/enrollmentKeyCleanup.integration.test.ts
+++ b/apps/api/src/jobs/enrollmentKeyCleanup.integration.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Real-Postgres integration coverage for the #2775 live-bootstrap-token
+ * exemption in the nightly enrollment-key purge sweep
+ * (enrollmentKeyCleanup.ts's `hasNoLiveUnexhaustedBootstrapToken`).
+ *
+ * The mocked unit suite (enrollmentKeyCleanup.test.ts) can only assert the
+ * SHAPE of the generated SQL — it stubs `db.delete/select` entirely, so
+ * `returningMock`'s resolved value is whatever the test tells it to be,
+ * independent of the actual predicate. It cannot prove Postgres itself
+ * EVALUATES the correlated NOT EXISTS subquery correctly per row, and the
+ * failure mode if it doesn't is silent: an admin's 30-day/1-year bootstrap
+ * token gets hard-deleted out from under them when its transient 60-minute
+ * parent key ages past the purge cutoff (or, the opposite bug, an
+ * exhausted/expired-token key never gets swept and the table grows
+ * unbounded).
+ *
+ * This suite drives the REAL delete-worker processor (only BullMQ's
+ * Queue/Worker classes are mocked — the same "capture the processor, invoke
+ * it directly" pattern as quoteSendQueue.integration.test.ts) against real
+ * rows in the test Postgres, covering all four required cases:
+ *   (a) live, unexhausted token            -> key SURVIVES the sweep
+ *   (b) token itself expired                -> key is DELETED
+ *   (c) token fully consumed (>= max_usage) -> key is DELETED
+ *   (d) no bootstrap tokens at all          -> key is DELETED (regression
+ *       guard on the pre-existing behaviour)
+ */
+import '../__tests__/integration/setup';
+
+import { describe, expect, it, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+
+// Mock ONLY BullMQ's Queue/Worker classes and the redis connection helper —
+// this test is about whether Postgres evaluates the DELETE...WHERE predicate
+// correctly, not about BullMQ scheduling mechanics (already covered by the
+// mocked unit suite). No BullMQ Worker/Queue is ever started or connects to
+// Redis; the processor closure passed to `new Worker(...)` is captured here
+// and invoked directly, exactly the payload a real job fire would deliver.
+const capturedProcessor: { current: null | ((job: unknown) => Promise<unknown>) } = {
+  current: null,
+};
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    add = vi.fn();
+    getRepeatableJobs = vi.fn(async () => []);
+    removeRepeatableByKey = vi.fn();
+    close = vi.fn(async () => {});
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: unknown) => Promise<unknown>) {
+      capturedProcessor.current = processor;
+    }
+    on = vi.fn();
+    close = vi.fn(async () => {});
+  },
+  Job: class {},
+}));
+
+vi.mock('../services/redis', () => ({
+  getRedisConnection: vi.fn(() => ({})),
+  getBullMQConnection: vi.fn(() => ({})),
+  isBullMQAvailable: vi.fn(() => true),
+  closeRedis: vi.fn(async () => {}),
+}));
+
+import { db, withSystemDbAccessContext } from '../db';
+import { enrollmentKeys, installerBootstrapTokens, organizations, partners, sites } from '../db/schema';
+import { createEnrollmentKeyCleanupWorker } from './enrollmentKeyCleanup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function createFixture(unique: string) {
+  return withSystemDbAccessContext(async () => {
+    const [partner] = await db
+      .insert(partners)
+      .values({
+        name: `Cleanup Partner ${unique}`,
+        slug: `cleanup-partner-${unique}`,
+        type: 'msp',
+        plan: 'pro',
+        status: 'active',
+      })
+      .returning({ id: partners.id });
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        partnerId: partner!.id,
+        name: `Cleanup Org ${unique}`,
+        slug: `cleanup-org-${unique}`,
+        type: 'customer',
+        status: 'active',
+      })
+      .returning({ id: organizations.id });
+    const [site] = await db
+      .insert(sites)
+      .values({ orgId: org!.id, name: `Cleanup Site ${unique}` })
+      .returning({ id: sites.id });
+    return { partnerId: partner!.id, orgId: org!.id, siteId: site!.id };
+  });
+}
+
+async function cleanupFixture(ids: { partnerId: string; orgId: string; siteId: string }) {
+  await withSystemDbAccessContext(async () => {
+    // enrollment_keys may already be gone (the sweep deleted it) — deleting
+    // by org_id is safe either way, and cascades any surviving bootstrap
+    // token row via ON DELETE CASCADE.
+    await db.delete(enrollmentKeys).where(eq(enrollmentKeys.orgId, ids.orgId));
+    await db.delete(sites).where(eq(sites.id, ids.siteId));
+    await db.delete(organizations).where(eq(organizations.id, ids.orgId));
+    await db.delete(partners).where(eq(partners.id, ids.partnerId));
+  });
+}
+
+async function runSweep() {
+  createEnrollmentKeyCleanupWorker();
+  expect(capturedProcessor.current).toBeTypeOf('function');
+  return capturedProcessor.current!({ name: 'enrollment-key-cleanup', id: 'test' });
+}
+
+async function keyRowExists(id: string): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db.select({ id: enrollmentKeys.id }).from(enrollmentKeys).where(eq(enrollmentKeys.id, id));
+    return !!row;
+  });
+}
+
+async function tokenRowExists(id: string): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({ id: installerBootstrapTokens.id })
+      .from(installerBootstrapTokens)
+      .where(eq(installerBootstrapTokens.id, id));
+    return !!row;
+  });
+}
+
+// The default purge grace period is 7 days (DEFAULT_PURGE_AFTER_DAYS). Every
+// scenario below creates a key that expired 10 days ago — comfortably past
+// that cutoff, so the ONLY thing that can save it from the sweep is the
+// live-bootstrap-token exemption.
+const EXPIRED_PAST_CUTOFF = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+
+describe('enrollment-key cleanup sweep — live bootstrap token exemption (#2775, real Postgres)', () => {
+  runDb('(a) an expired key holding a live, unexhausted bootstrap token SURVIVES the sweep', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ids = await createFixture(unique);
+    try {
+      const { keyId, tokenId } = await withSystemDbAccessContext(async () => {
+        const [key] = await db
+          .insert(enrollmentKeys)
+          .values({
+            orgId: ids.orgId,
+            siteId: ids.siteId,
+            name: 'transient parent',
+            key: `sweep-a-key-${unique}`,
+            expiresAt: EXPIRED_PAST_CUTOFF,
+            maxUsage: 1,
+          })
+          .returning({ id: enrollmentKeys.id });
+        const [token] = await db
+          .insert(installerBootstrapTokens)
+          .values({
+            token: `sweep-a-token-${unique}`,
+            orgId: ids.orgId,
+            parentEnrollmentKeyId: key!.id,
+            siteId: ids.siteId,
+            maxUsage: 25,
+            consumedCount: 0,
+            expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // live: 1 day out
+          })
+          .returning({ id: installerBootstrapTokens.id });
+        return { keyId: key!.id, tokenId: token!.id };
+      });
+
+      await runSweep();
+
+      expect(await keyRowExists(keyId)).toBe(true);
+      expect(await tokenRowExists(tokenId)).toBe(true);
+    } finally {
+      await cleanupFixture(ids);
+    }
+  });
+
+  runDb('(b) an expired key whose token has itself expired is DELETED — liveness is a strict now() boundary', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ids = await createFixture(unique);
+    try {
+      const { keyId } = await withSystemDbAccessContext(async () => {
+        const [key] = await db
+          .insert(enrollmentKeys)
+          .values({
+            orgId: ids.orgId,
+            siteId: ids.siteId,
+            name: 'transient parent',
+            key: `sweep-b-key-${unique}`,
+            expiresAt: EXPIRED_PAST_CUTOFF,
+            maxUsage: 1,
+          })
+          .returning({ id: enrollmentKeys.id });
+        await db.insert(installerBootstrapTokens).values({
+          token: `sweep-b-token-${unique}`,
+          orgId: ids.orgId,
+          parentEnrollmentKeyId: key!.id,
+          siteId: ids.siteId,
+          maxUsage: 25,
+          consumedCount: 0,
+          // expires_at must be strictly after created_at (DB CHECK
+          // installer_bootstrap_tokens_expires_after_created) — backdate
+          // both so the token is unambiguously expired-in-the-past.
+          createdAt: new Date(Date.now() - 30 * 60 * 1000),
+          expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+        });
+        return { keyId: key!.id };
+      });
+
+      await runSweep();
+
+      expect(await keyRowExists(keyId)).toBe(false);
+    } finally {
+      await cleanupFixture(ids);
+    }
+  });
+
+  runDb('(c) an expired key whose token is fully consumed (consumed_count >= max_usage) is DELETED', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ids = await createFixture(unique);
+    try {
+      const { keyId } = await withSystemDbAccessContext(async () => {
+        const [key] = await db
+          .insert(enrollmentKeys)
+          .values({
+            orgId: ids.orgId,
+            siteId: ids.siteId,
+            name: 'transient parent',
+            key: `sweep-c-key-${unique}`,
+            expiresAt: EXPIRED_PAST_CUTOFF,
+            maxUsage: 1,
+          })
+          .returning({ id: enrollmentKeys.id });
+        await db.insert(installerBootstrapTokens).values({
+          token: `sweep-c-token-${unique}`,
+          orgId: ids.orgId,
+          parentEnrollmentKeyId: key!.id,
+          siteId: ids.siteId,
+          maxUsage: 5,
+          consumedCount: 5, // fully exhausted — still "live" by expiry, but not unexhausted
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        });
+        return { keyId: key!.id };
+      });
+
+      await runSweep();
+
+      expect(await keyRowExists(keyId)).toBe(false);
+    } finally {
+      await cleanupFixture(ids);
+    }
+  });
+
+  runDb('(d) an expired key with no bootstrap tokens at all is DELETED — pre-existing behaviour is unchanged', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ids = await createFixture(unique);
+    try {
+      const { keyId } = await withSystemDbAccessContext(async () => {
+        const [key] = await db
+          .insert(enrollmentKeys)
+          .values({
+            orgId: ids.orgId,
+            siteId: ids.siteId,
+            name: 'no tokens ever issued',
+            key: `sweep-d-key-${unique}`,
+            expiresAt: EXPIRED_PAST_CUTOFF,
+            maxUsage: 1,
+          })
+          .returning({ id: enrollmentKeys.id });
+        return { keyId: key!.id };
+      });
+
+      await runSweep();
+
+      expect(await keyRowExists(keyId)).toBe(false);
+    } finally {
+      await cleanupFixture(ids);
+    }
+  });
+});

--- a/apps/api/src/jobs/enrollmentKeyCleanup.test.ts
+++ b/apps/api/src/jobs/enrollmentKeyCleanup.test.ts
@@ -9,6 +9,7 @@ const {
   deleteMock,
   whereMock,
   returningMock,
+  selectMock,
   withSystemDbAccessContextMock,
   capturedWorkerProcessor,
 } = vi.hoisted(() => ({
@@ -20,6 +21,7 @@ const {
   deleteMock: vi.fn(),
   whereMock: vi.fn(),
   returningMock: vi.fn(),
+  selectMock: vi.fn(),
   withSystemDbAccessContextMock: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   capturedWorkerProcessor: { current: null as null | ((job: unknown) => Promise<unknown>) },
 }));
@@ -54,6 +56,7 @@ vi.mock('../db', async (importOriginal) => {
     withSystemDbAccessContext: (fn: () => Promise<unknown>) => withSystemDbAccessContextMock(fn),
     db: {
       delete: (...args: unknown[]) => deleteMock(...(args as [])),
+      select: (...args: unknown[]) => selectMock(...(args as [])),
     },
   };
 });
@@ -68,6 +71,7 @@ vi.mock('../services/sentry', () => ({
   captureException: vi.fn(),
 }));
 
+import { sql } from 'drizzle-orm';
 import {
   __testOnly,
   createEnrollmentKeyCleanupWorker,
@@ -87,6 +91,15 @@ const ORIGINAL_PURGE_DAYS = process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
  * drizzle column objects (which carry a `columnType` + `name`) to their
  * column name instead of recursing into the table they belong to (which is
  * circular).
+ *
+ * Also resolves the correlated NOT EXISTS subquery added for #2775: `and`/
+ * `notExists` embed the subquery as an opaque `SQLWrapper` chunk (an object
+ * exposing only `getSQL()`, per drizzle's own `isSQLWrapper` duck-typing —
+ * `sql/sql.js`), which none of the shape checks above recognize. The
+ * `getSQL` fallback below is checked LAST (after the queryChunks/value/name
+ * branches, which real `SQL`/`Column` instances always satisfy first) so it
+ * only ever fires for this kind of otherwise-unhandled wrapper, then
+ * recurses into whatever real `SQL` object `getSQL()` returns.
  */
 function sqlText(q: unknown): string {
   if (q == null) return '';
@@ -97,6 +110,7 @@ function sqlText(q: unknown): string {
     value?: unknown;
     name?: string;
     columnType?: unknown;
+    getSQL?: () => unknown;
   };
   if (typeof obj.name === 'string' && 'columnType' in obj) {
     return obj.name;
@@ -113,6 +127,9 @@ function sqlText(q: unknown): string {
   if (typeof obj.value === 'string' || typeof obj.value === 'number') {
     return String(obj.value);
   }
+  if (typeof obj.getSQL === 'function') {
+    return sqlText(obj.getSQL());
+  }
   return '';
 }
 
@@ -128,6 +145,21 @@ describe('enrollmentKeyCleanup worker', () => {
     returningMock.mockResolvedValue([]);
     whereMock.mockImplementation(() => ({ returning: returningMock }));
     deleteMock.mockImplementation(() => ({ where: whereMock }));
+    // The exemption subquery (#2775) calls db.select(...).from(...).where(cond)
+    // to build a correlated NOT EXISTS subquery. This never executes for
+    // real here (no Postgres in this suite) — it only needs to satisfy
+    // drizzle's SQLWrapper contract (a `getSQL()` method) so `notExists(...)`
+    // can embed it. Wrapping the REAL `cond` built by production code (via
+    // the real `and`/`eq`/`gt`/`lt` from drizzle-orm, not mocked) in a `sql`
+    // template means the flattened where-clause text below genuinely
+    // reflects what the code built, not a canned stand-in.
+    selectMock.mockImplementation(() => ({
+      from: () => ({
+        where: (cond: unknown) => ({
+          getSQL: () => sql`select 1 from installer_bootstrap_tokens where ${cond}`,
+        }),
+      }),
+    }));
     capturedWorkerProcessor.current = null;
     delete process.env.ENROLLMENT_KEY_CLEANUP_ENABLED;
     delete process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
@@ -269,6 +301,92 @@ describe('enrollmentKeyCleanup worker', () => {
       expect(text).toContain('is not null');
       expect(text).toContain('and');
       expect(text).toContain('<');
+    });
+
+    // #2775 fix-round-1: the enrollment_keys DELETE now exempts any key that
+    // still has a live, unexhausted installer_bootstrap_tokens row pointing
+    // at it (see hasNoLiveUnexhaustedBootstrapToken in enrollmentKeyCleanup.ts).
+    // Like the two tests above, these are SQL-shape assertions on the built
+    // WHERE clause — this suite has no real Postgres, so the mocked
+    // `where()`/`returning()` chain can't itself evaluate a NOT EXISTS
+    // subquery per row (`returningMock`'s resolved value is whatever the
+    // test tells it to be, independent of the predicate). What IS
+    // meaningfully verifiable here — and would fail if the exemption were
+    // removed, miswired to the wrong columns, or bound to the wrong "now" —
+    // is that the generated predicate matches the owner-approved shape for
+    // each of the four required scenarios.
+    describe('live bootstrap token exemption (#2775)', () => {
+      it('(a) a live, unexhausted token exempts its parent key — subquery correlates on parent_enrollment_key_id and requires the TOKEN itself to still be unexpired', async () => {
+        vi.useFakeTimers();
+        const now = new Date('2026-07-10T12:00:00.000Z');
+        vi.setSystemTime(now);
+
+        createEnrollmentKeyCleanupWorker();
+        await capturedWorkerProcessor.current!({ name: 'enrollment-key-cleanup', id: 'j-2775-a' });
+
+        const cond = whereMock.mock.calls[0]![0];
+        const text = sqlText(cond);
+
+        expect(text).toContain('not exists');
+        expect(text).toContain('parent_enrollment_key_id');
+        expect(text).toContain('id'); // correlated column on the outer enrollment_keys row
+        // The token-liveness bound is "now" at call time, not the outer
+        // days-based purge cutoff — proven by both distinct timestamps
+        // appearing, so a 30-day/1-year token isn't accidentally re-clamped
+        // to the 7-day purge window.
+        const expectedCutoff = new Date(now.getTime() - __testOnly.DEFAULT_PURGE_AFTER_DAYS * 86_400_000);
+        expect(text).toContain(expectedCutoff.toISOString());
+        expect(text).toContain(now.toISOString());
+      });
+
+      it('(b) a token whose own expiry has passed does NOT exempt the key — the liveness check is a strict now() boundary, not a grace window', async () => {
+        vi.useFakeTimers();
+        const now = new Date('2026-07-10T12:00:00.000Z');
+        vi.setSystemTime(now);
+
+        createEnrollmentKeyCleanupWorker();
+        await capturedWorkerProcessor.current!({ name: 'enrollment-key-cleanup', id: 'j-2775-b' });
+
+        const cond = whereMock.mock.calls[0]![0];
+        const text = sqlText(cond);
+
+        // Extract the operator immediately preceding the bound "now" value:
+        // must be strict `>`, not `>=` — an expired token (expires_at <= now)
+        // must fail this predicate so NOT EXISTS is satisfied and the key
+        // still gets deleted, exactly as before #2775.
+        const match = text.match(/expires_at\s+(\S+)\s+2026-07-10T12:00:00\.000Z/);
+        expect(match).not.toBeNull();
+        expect(match![1]).toBe('>');
+      });
+
+      it('(c) a fully-consumed token does NOT exempt the key — subquery requires consumed_count < max_usage', async () => {
+        createEnrollmentKeyCleanupWorker();
+        await capturedWorkerProcessor.current!({ name: 'enrollment-key-cleanup', id: 'j-2775-c' });
+
+        const cond = whereMock.mock.calls[0]![0];
+        const text = sqlText(cond);
+
+        expect(text).toContain('consumed_count');
+        expect(text).toContain('max_usage');
+        expect(text).toMatch(/consumed_count\s+<\s+max_usage/);
+      });
+
+      it('(d) a key with no bootstrap tokens at all is still deleted — existing count-reporting behaviour is unchanged with the guard wired in', async () => {
+        returningMock.mockResolvedValue([{ id: 'k1' }, { id: 'k2' }, { id: 'k3' }]);
+        createEnrollmentKeyCleanupWorker();
+
+        const result = await capturedWorkerProcessor.current!({
+          name: 'enrollment-key-cleanup',
+          id: 'j-2775-d',
+        });
+
+        // NOT EXISTS against zero correlated token rows is trivially true in
+        // standard SQL — a key with no bootstrap tokens is unaffected by the
+        // new guard and is deleted exactly as it was pre-#2775.
+        const cond = whereMock.mock.calls[0]![0];
+        expect(sqlText(cond)).toContain('not exists');
+        expect(result).toMatchObject({ deletedCount: 3 });
+      });
     });
 
     it('ignores unknown job names without touching the DB', async () => {

--- a/apps/api/src/jobs/enrollmentKeyCleanup.ts
+++ b/apps/api/src/jobs/enrollmentKeyCleanup.ts
@@ -16,6 +16,20 @@
  * therefore never deleted (explicit `isNotNull` guard makes that intent
  * unambiguous rather than relying only on SQL NULL comparison semantics).
  *
+ * Exemption for live installer tokens (#2775): the Add Device modal's parent
+ * enrollment key is a deliberately transient 60-minute container (PR #739
+ * review finding #1), while the installer_bootstrap_token minted from it can
+ * carry its own independent TTL of up to a year (routes/installer.ts no
+ * longer clamps the child enrollment key to the parent's expiry). Without an
+ * exemption here, this sweep would hard-delete that parent ~7 days after its
+ * own 60-minute expiry — and the CASCADE above would take every outstanding
+ * bootstrap token down with it, silently discarding an admin's 30-day/1-year
+ * selection. The WHERE clause below therefore additionally requires that no
+ * `installer_bootstrap_tokens` row referencing the key is still live (its own
+ * `expires_at` in the future) AND unexhausted (`consumed_count < max_usage`);
+ * such a key is left for a later sweep, once its last token has expired or
+ * been fully consumed.
+ *
  * Scheduling:
  *   - Repeat cron: 04:00 UTC daily (pattern "0 4 * * *")
  *   - `jobId: 'enrollment-key-cleanup'` dedupes the repeatable job across
@@ -42,9 +56,9 @@
  */
 
 import { Queue, Worker, Job } from 'bullmq';
-import { and, isNotNull, lt } from 'drizzle-orm';
+import { and, eq, gt, isNotNull, lt, notExists, sql } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { enrollmentKeys } from '../db/schema';
+import { enrollmentKeys, installerBootstrapTokens } from '../db/schema';
 import { captureException } from '../services/sentry';
 import { getBullMQConnection } from '../services/redis';
 
@@ -69,6 +83,31 @@ function getPurgeAfterDays(): number {
   const parsed = parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_PURGE_AFTER_DAYS;
 }
+
+/**
+ * Correlated NOT EXISTS guard (#2775): evaluates true — i.e. the outer
+ * `enrollmentKeys` row is eligible for the purge — only when NO
+ * `installer_bootstrap_tokens` row still points at it with both `expires_at`
+ * in the future AND `consumed_count < max_usage` (a "live, unexhausted"
+ * token). When such a token does exist, this evaluates false and the AND'd
+ * outer WHERE excludes the key from the DELETE; it survives to a later
+ * sweep, once its last token has expired or been fully consumed. Matches the
+ * `exists`/`notExists` correlated-subquery idiom used by
+ * `services/vulnerabilityCorrelation.ts`.
+ */
+const hasNoLiveUnexhaustedBootstrapToken = () =>
+  notExists(
+    dbModule.db
+      .select({ one: sql`1` })
+      .from(installerBootstrapTokens)
+      .where(
+        and(
+          eq(installerBootstrapTokens.parentEnrollmentKeyId, enrollmentKeys.id),
+          gt(installerBootstrapTokens.expiresAt, new Date()),
+          lt(installerBootstrapTokens.consumedCount, installerBootstrapTokens.maxUsage),
+        ),
+      ),
+  );
 
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   if (typeof dbModule.withSystemDbAccessContext !== 'function') {
@@ -107,7 +146,13 @@ export function createEnrollmentKeyCleanupWorker(): Worker {
 
         const deletedRows = await dbModule.db
           .delete(enrollmentKeys)
-          .where(and(isNotNull(enrollmentKeys.expiresAt), lt(enrollmentKeys.expiresAt, cutoff)))
+          .where(
+            and(
+              isNotNull(enrollmentKeys.expiresAt),
+              lt(enrollmentKeys.expiresAt, cutoff),
+              hasNoLiveUnexhaustedBootstrapToken(),
+            ),
+          )
           .returning({ id: enrollmentKeys.id });
         const deletedCount = deletedRows.length;
 

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -1433,6 +1433,55 @@ describe("POST /:id/bootstrap-token", () => {
     expect(body.error).toContain("expires too soon");
     expect(insertValues).not.toHaveBeenCalled();
   });
+
+  it("honours ttlMinutes on the bootstrap-token route (#2775)", async () => {
+    const parent = makeKeyRow();
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parent]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValue({
+        id: "token-row-uuid-2",
+        token: "ABCDE12345",
+        expiresAt: new Date(Date.now() + 129_600 * 60 * 1000),
+        parentKeyName: "Test Key",
+      } as any);
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/bootstrap-token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxUsage: 3, ttlMinutes: 129_600 }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(issueSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ ttlMinutes: 129_600 }),
+    );
+
+    issueSpy.mockRestore();
+  });
+
+  it("rejects ttlMinutes above the cap on the bootstrap-token route (#2775)", async () => {
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/bootstrap-token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ttlMinutes: 525_601 }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+  });
 });
 
 // ============================================================
@@ -1519,6 +1568,35 @@ describe("GET /:id/installer/macos — app-bundle path", () => {
           },
         ],
       }),
+    );
+  });
+
+  it("passes the ttlMinutes query param through to the bootstrap token (macos app bundle) (#2775)", async () => {
+    const parentRow = makeKeyRow();
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parentRow]),
+        }),
+      }),
+    } as any);
+
+    vi.mocked(fetchMacosInstallerAppZip).mockResolvedValueOnce(
+      Buffer.from("fixture-app-zip"),
+    );
+    vi.mocked(renameAppInZip).mockResolvedValueOnce(
+      Buffer.from("renamed-app-zip"),
+    );
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/installer/macos?count=2&ttlMinutes=10080`,
+      { headers: { authorization: "Bearer jwt" } },
+    );
+
+    expect(res.status).toBe(200);
+    expect(issueSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ maxUsage: 2, ttlMinutes: 10080 }),
     );
   });
 

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -1017,6 +1017,46 @@ describe("GET /public-download/:platform", () => {
     issueSpy.mockRestore();
   });
 
+  it("returns 410 without issuing a bootstrap token when parent key is within the min-remaining window (#2775 fix-round-1)", async () => {
+    // Public/unauthenticated path (shared serveInstaller helper). Before this
+    // guard, a near-dead parent would still mint a bootstrap token — which,
+    // post #2775 fix, gets a full independent TTL uncapped by the parent.
+    // Must refuse outright, and must NOT leak parent-key name/id in the
+    // public error response.
+    const row = makeKeyRow({
+      shortCode: "pubcode1234",
+      installerPlatform: "windows",
+      maxUsage: 1,
+      usageCount: 0,
+      expiresAt: new Date(Date.now() + 30_000),
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([row]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi.spyOn(
+      installerBootstrapTokenIssuance,
+      "issueBootstrapTokenForKey",
+    );
+
+    const res = await app.request(
+      `/enrollment-keys/public-download/windows?h=dlh_${"1".repeat(32)}`,
+    );
+
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toMatch(/expiring too soon/i);
+    expect(body.error).not.toMatch(/Test Key/);
+    expect(issueSpy).not.toHaveBeenCalled();
+
+    issueSpy.mockRestore();
+  });
+
   it("rejects legacy raw token query downloads by default", async () => {
     const res = await app.request(
       `/enrollment-keys/public-download/windows?token=${"a".repeat(64)}`,
@@ -1356,6 +1396,42 @@ describe("POST /:id/bootstrap-token", () => {
     );
 
     expect(res.status).toBe(410);
+  });
+
+  it("refuses to issue a bootstrap token when parent key is within 60s of expiry (#2775 fix-round-1)", async () => {
+    // Parent with only 30s of life left. Before this guard, the route called
+    // issueBootstrapTokenForKey directly, which (post #2775 fix) mints a
+    // fresh, independent TTL uncapped by the parent — so a near-dead parent
+    // would produce a token that outlives it. Refuse outright instead,
+    // matching the /installer-link and /installer/:platform guards.
+    const parent = makeKeyRow({
+      expiresAt: new Date(Date.now() + 30_000),
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parent]),
+        }),
+      }),
+    } as any);
+
+    const insertValues = vi.fn();
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/bootstrap-token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxUsage: 1 }),
+      },
+    );
+
+    expect(res.status).toBe(410);
+    const body = await res.json();
+    expect(body.error).toContain("expires too soon");
+    expect(insertValues).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -1450,6 +1450,16 @@ enrollmentKeyRoutes.post(
       return c.json({ error: "Access denied" }, 403);
     }
 
+    if (parentKeyTooCloseToExpiry(parent.expiresAt)) {
+      return c.json(
+        {
+          error:
+            "Parent enrollment key expires too soon to build an installer — regenerate the key with a longer TTL",
+        },
+        410,
+      );
+    }
+
     try {
       const {
         id: tokenId,
@@ -1805,6 +1815,14 @@ async function serveInstaller(
   if (keyRow.maxUsage !== null && keyRow.usageCount >= keyRow.maxUsage) {
     return c.json(
       { error: "This download link has been used the maximum number of times" },
+      410,
+    );
+  }
+  if (parentKeyTooCloseToExpiry(keyRow.expiresAt)) {
+    // Public/unauthenticated path — no parent-key detail (name, id) in the
+    // response, matching the other rejection messages in this function.
+    return c.json(
+      { error: "This download link is expiring too soon to build an installer" },
       410,
     );
   }

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -1087,6 +1087,7 @@ enrollmentKeyRoutes.get(
             parentEnrollmentKeyId: parentKey.id,
             createdByUserId: auth.user.id,
             maxUsage: childMaxUsage,
+            ttlMinutes: childTtlMinutes,
           });
         } catch (err) {
           if (err instanceof BootstrapTokenIssuanceError) {
@@ -1203,6 +1204,7 @@ enrollmentKeyRoutes.get(
           parentEnrollmentKeyId: parentKey.id,
           createdByUserId: auth.user.id,
           maxUsage: childMaxUsage,
+          ttlMinutes: childTtlMinutes,
           installerPlatform: "windows",
         });
       } catch (err) {
@@ -1417,6 +1419,7 @@ enrollmentKeyRoutes.get(
 
 const bootstrapTokenBodySchema = z.object({
   maxUsage: z.number().int().min(1).max(1000).default(1),
+  ttlMinutes: z.number().int().min(1).max(MAX_TTL_MINUTES).optional(),
 }).strict();
 
 enrollmentKeyRoutes.post(
@@ -1433,7 +1436,7 @@ enrollmentKeyRoutes.post(
   async (c) => {
     const auth = c.get("auth");
     const { id: keyId } = c.req.valid("param");
-    const { maxUsage } = c.req.valid("json");
+    const { maxUsage, ttlMinutes } = c.req.valid("json");
 
     const [parent] = await db
       .select()
@@ -1469,6 +1472,7 @@ enrollmentKeyRoutes.post(
         parentEnrollmentKeyId: parent.id,
         createdByUserId: auth.user.id,
         maxUsage,
+        ttlMinutes,
       });
 
       writeEnrollmentKeyAudit(c, auth, {
@@ -1867,6 +1871,12 @@ async function serveInstaller(
         // insert with `invalid input syntax for type uuid: ""` (500 on /s/:code).
         createdByUserId: keyRow.createdBy ?? null,
         maxUsage: 1,
+        // Short-link downloads carry no per-request picker (the link was
+        // generated once, by an admin who already chose a TTL for the CHILD
+        // key at /installer-link time). There is no ttlMinutes in scope here
+        // to forward, so the bootstrap token deliberately takes the 24h base
+        // rather than inheriting a stale selection. Deliberate — not an
+        // oversight (#2775).
         installerPlatform: "windows",
       });
     } catch (err) {

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -475,6 +475,20 @@ describe('enrollment key routes — installer download', () => {
       expect(db.insert).not.toHaveBeenCalled();
     });
 
+    it('passes the ttlMinutes query param through to the bootstrap token (windows) (#2775)', async () => {
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+
+      const res = await app.request(
+        `/enrollment-keys/${KEY_ID}/installer/windows?count=5&ttlMinutes=43200`,
+        { method: 'GET', headers: { Authorization: 'Bearer token' } },
+      );
+
+      expect(res.status).toBe(200);
+      expect(issueBootstrapTokenForKey).toHaveBeenCalledWith(
+        expect.objectContaining({ maxUsage: 5, ttlMinutes: 43200 }),
+      );
+    });
+
     it('child key honors the ttlMinutes query param (per-link picker) (macos)', async () => {
       const parentKey = makeEnrollmentKey(); // parent: 1h remaining
       mockSelectFromWhereLimit([parentKey]);

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -234,6 +234,89 @@ describe("POST /api/v1/installer/bootstrap", () => {
     expect(res.status).toBe(404);
   });
 
+  it("consumes a live token whose parent key has already expired (#2775)", async () => {
+    // The token itself has 7 days left; the parent enrollment key (the
+    // deliberately transient 60-minute container created by the Add Device
+    // modal) died an hour ago. The token's own expiry is the sole authority —
+    // redemption must still succeed and the child key must get a fresh TTL,
+    // not the parent's dead one.
+    const tokenRow = {
+      id: "t-2775",
+      token: "EEEEEEEEEE",
+      orgId: "o1",
+      parentEnrollmentKeyId: "pk-dead",
+      siteId: "s1",
+      maxUsage: 10,
+      consumedCount: 0,
+      createdBy: "u1",
+      consumedAt: null,
+      expiresAt: new Date(Date.now() + 7 * 24 * 3600_000),
+    };
+    const parentKey = {
+      id: "pk-dead",
+      name: "Acme parent",
+      orgId: "o1",
+      siteId: "s1",
+      keySecretHash: "parent-secret-hash",
+      expiresAt: new Date(Date.now() - 3600_000), // parent: dead an hour ago
+    };
+    const org = { id: "o1", name: "Acme Corp" };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([tokenRow]) }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([parentKey]) }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([org]) }),
+        }),
+      } as any);
+
+    let capturedChildKeyValues: Record<string, unknown> | null = null;
+    vi.mocked(db.insert).mockReturnValue({
+      values: (vals: Record<string, unknown>) => {
+        capturedChildKeyValues = vals;
+        return {
+          returning: () =>
+            Promise.resolve([{ id: "ck-2775", orgId: "o1", siteId: "s1" }]),
+        };
+      },
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: () => ({
+        where: () => ({
+          returning: () =>
+            Promise.resolve([{ ...tokenRow, consumedAt: new Date() }]),
+        }),
+      }),
+    } as any);
+
+    const app = makeApp();
+    const res = await app.request("/api/v1/installer/bootstrap", {
+      method: "POST",
+      headers: { "X-Breeze-Bootstrap-Token": "EEEEEEEEEE" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.enrollmentKey).toMatch(/^[a-f0-9]{64}$/);
+    // Child key gets its own fresh TTL, not the parent's dead one.
+    expect(capturedChildKeyValues).not.toBeNull();
+    const childExpiresAt = (
+      capturedChildKeyValues as unknown as { expiresAt: Date }
+    ).expiresAt;
+    expect(childExpiresAt.getTime()).toBeGreaterThan(Date.now());
+    expect(childExpiresAt.getTime()).toBeGreaterThan(
+      parentKey.expiresAt.getTime(),
+    );
+  });
+
   it("partially-consumed multi-use token still redeems and mints a single-use child key", async () => {
     process.env.PUBLIC_API_URL = "https://us.2breeze.app";
     process.env.AGENT_ENROLLMENT_SECRET = "shared-secret-test";

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -13,23 +13,21 @@ const CHILD_TTL_MIN = Number(
 );
 
 /**
- * Returns the child enrollment key expiry: the earlier of
- *   (a) the parent's own expiry, or
- *   (b) now + CHILD_TTL_MIN
+ * Returns the child enrollment key expiry: now + CHILD_TTL_MIN.
  *
- * This prevents a child key from outliving its parent, which would
- * implicitly extend access for a revoked/expired parent key.
+ * The parent's expiry is deliberately NOT an upper bound. The parent created
+ * by the Add Device modal is a transient 60-minute container (PR #739 review
+ * finding #1); bounding the child by it made a 30-day installer link die in an
+ * hour (#2775). The bootstrap token carries its own independent expiry, which
+ * is checked before this is called — that is the authority on whether the
+ * installer is still valid.
  *
- * Returns null if the parent is already expired — callers should treat
- * null as a signal to reject the request.
+ * Revocation is unaffected: installer_bootstrap_tokens.parent_enrollment_key_id
+ * is ON DELETE CASCADE, so deleting the parent destroys outstanding tokens
+ * before they can ever reach this function.
  */
-function freshChildExpiresAt(parentExpiresAt: Date): Date | null {
-  const now = Date.now();
-  if (parentExpiresAt.getTime() <= now) {
-    return null; // parent already expired — reject
-  }
-  const childTtlMs = CHILD_TTL_MIN * 60 * 1000;
-  return new Date(Math.min(parentExpiresAt.getTime(), now + childTtlMs));
+function freshChildExpiresAt(): Date {
+  return new Date(Date.now() + CHILD_TTL_MIN * 60 * 1000);
 }
 
 function generateChildEnrollmentKey(): string {
@@ -142,22 +140,7 @@ async function redeemBootstrapToken(c: Context, token: string) {
       return null;
     }
 
-    // If the parent has no expiry set, fall back to the child TTL only
-    // (no upper bound from parent). If it does have an expiry, bound by it.
-    const parentExpiresAt = parent.expiresAt
-      ? new Date(parent.expiresAt)
-      : null;
-    const childExpiresAt = parentExpiresAt
-      ? freshChildExpiresAt(parentExpiresAt)
-      : new Date(Date.now() + CHILD_TTL_MIN * 60 * 1000);
-    if (!childExpiresAt) {
-      console.error("[installer] bootstrap 404", {
-        reason: "parent_already_expired",
-        tokenId: row.id,
-        ip,
-      });
-      return null;
-    }
+    const childExpiresAt = freshChildExpiresAt();
 
     // ── 3. INSERT child key BEFORE recording the redemption (C1 reorder) ──
     // If the consume UPDATE loses a race, we'll DELETE this row below.

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -24,7 +24,15 @@ const CHILD_TTL_MIN = Number(
  *
  * Revocation is unaffected: installer_bootstrap_tokens.parent_enrollment_key_id
  * is ON DELETE CASCADE, so deleting the parent destroys outstanding tokens
- * before they can ever reach this function.
+ * before they can ever reach this function. A deliberate admin delete is the
+ * ONLY thing that does this — the scheduled `enrollmentKeyCleanup` sweep job
+ * (jobs/enrollmentKeyCleanup.ts) that hard-purges long-expired enrollment
+ * keys is NOT a second silent ceiling on this TTL: it explicitly exempts any
+ * parent key that still has a live, unexhausted bootstrap token, so a
+ * 30-day/1-year token cannot be cascade-deleted out from under itself by
+ * that job before its own expiry (or full consumption). If you're reading
+ * this because you found that job and are wondering whether it re-clamps
+ * this TTL, it doesn't — see its header comment for the exemption predicate.
  */
 function freshChildExpiresAt(): Date {
   return new Date(Date.now() + CHILD_TTL_MIN * 60 * 1000);

--- a/apps/api/src/services/installerBootstrapTokenIssuance.test.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// This service has never had a direct test — its cap logic has only ever run
+// under `vi.mock` from the route tests, which is precisely why #2775 shipped.
+//
+// Mocked the same way apps/api/src/routes/enrollmentKeys_installer.test.ts
+// does: the service calls `db.select().from(enrollmentKeys).where(...).limit(1)`
+// for the parent lookup (not `db.query.enrollmentKeys.findFirst`), so the
+// mock shape has to match that chain.
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+import { db } from '../db';
+import { issueBootstrapTokenForKey } from './installerBootstrapTokenIssuance';
+
+function mockParent(overrides: Record<string, unknown> = {}) {
+  const parent = {
+    id: 'parent-1',
+    name: 'Add device installer',
+    orgId: 'org-1',
+    siteId: 'site-1',
+    maxUsage: null,
+    usageCount: 0,
+    // deliberately near-dead: the transient 60-min parent, 59 min in
+    expiresAt: new Date(Date.now() + 60_000),
+    ...overrides,
+  };
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([parent]),
+      }),
+    }),
+  } as any);
+  return parent;
+}
+
+function mockInsert() {
+  vi.mocked(db.insert).mockReturnValueOnce({
+    values: (v: Record<string, unknown>) => ({
+      returning: async () => [{ id: 'tok-1', ...v }],
+    }),
+  } as any);
+}
+
+describe('issueBootstrapTokenForKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('honours ttlMinutes even when the parent expires sooner (#2775)', async () => {
+    mockParent();
+    mockInsert();
+
+    const result = await issueBootstrapTokenForKey({
+      parentEnrollmentKeyId: 'parent-1',
+      createdByUserId: 'user-1',
+      maxUsage: 5,
+      ttlMinutes: 10080, // 7 days
+    });
+
+    const ttlMs = result.expiresAt.getTime() - Date.now();
+    expect(ttlMs).toBeGreaterThan(10080 * 60 * 1000 - 60_000);
+  });
+
+  it('falls back to the 24h base TTL when ttlMinutes is omitted', async () => {
+    mockParent();
+    mockInsert();
+
+    const result = await issueBootstrapTokenForKey({
+      parentEnrollmentKeyId: 'parent-1',
+      createdByUserId: 'user-1',
+    });
+
+    const ttlMs = result.expiresAt.getTime() - Date.now();
+    expect(ttlMs).toBeGreaterThan(23 * 60 * 60 * 1000);
+  });
+});

--- a/apps/api/src/services/installerBootstrapTokenIssuance.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.ts
@@ -19,6 +19,12 @@ export interface IssueBootstrapTokenInput {
   createdByUserId: string | null;
   maxUsage?: number;
   installerPlatform?: "windows" | "macos";
+  /**
+   * Absolute lifetime for this token, in minutes, as chosen by the admin in
+   * the Add Device modal. Omitted → the 24h base from bootstrapTokenExpiresAt().
+   * Bounds are enforced upstream by the route Zod schemas (1..525_600).
+   */
+  ttlMinutes?: number;
 }
 
 export interface IssuedBootstrapToken {
@@ -67,15 +73,23 @@ export async function issueBootstrapTokenForKey(
   }
 
   const token = generateBootstrapToken();
-  // Bound the token's TTL by the parent's remaining lifetime. Without this
-  // cap, a token could be valid for 24h on paper while the parent expires
-  // 30s later — recipients would click an "active" link and get 404
-  // (parent_already_expired). Bound conservatively so consume reflects the
-  // real usable window.
-  const baseTokenExpiry = bootstrapTokenExpiresAt();
-  const expiresAt = parent.expiresAt && new Date(parent.expiresAt) < baseTokenExpiry
-    ? new Date(parent.expiresAt)
-    : baseTokenExpiry;
+  // The token gets a fresh, independent lifetime — it is NOT bounded by the
+  // parent's remaining life. The parent created by the Add Device modal is a
+  // deliberately transient 60-minute container (PR #739 review finding #1),
+  // so capping to it made every installer die in an hour whatever the admin
+  // picked (#2775). This mirrors the identical correction already made for
+  // child enrollment keys — see CHILD_ENROLLMENT_KEY_TTL_MINUTES in
+  // routes/enrollmentKeys.ts.
+  //
+  // Revocation does NOT depend on this cap: installer_bootstrap_tokens
+  // .parent_enrollment_key_id is ON DELETE CASCADE, so deleting the parent
+  // key still destroys every outstanding token immediately.
+  //
+  // Freshness at ISSUE time is still enforced by the caller via
+  // parentKeyTooCloseToExpiry().
+  const expiresAt = input.ttlMinutes !== undefined
+    ? new Date(Date.now() + input.ttlMinutes * 60 * 1000)
+    : bootstrapTokenExpiresAt();
 
   const [row] = await db.insert(installerBootstrapTokens).values({
     token,

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -123,6 +123,13 @@ export default defineConfig({
       // list). NOT the same file as the co-located mocked unit suite
       // `mfaStepUpGrant.test.ts`, which stays on this runner.
       'src/services/mfaStepUpGrant.integration.test.ts',
+      // Enrollment-key cleanup sweep real-DB test (#2775 live-bootstrap-token
+      // exemption): imports `__tests__/integration/setup` (real postgres pool
+      // + autoMigrate) and lives in src/jobs/ outside the
+      // `src/__tests__/integration/**` glob, so the no-DB unit runner would
+      // fail it on connect. Belongs to vitest.integration.config.ts
+      // (registered in its include list).
+      'src/jobs/enrollmentKeyCleanup.integration.test.ts',
     ],
     setupFiles: ['src/__tests__/setup.ts'],
     coverage: {

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -153,6 +153,13 @@ export default defineConfig({
       // (real Redis; no Postgres fixtures used). Belongs to
       // vitest.integration.config.ts, not the no-Redis unit runner.
       'src/services/mfaStepUpGrant.integration.test.ts',
+      // Co-located real-DB integration test for the #2775 live-bootstrap-token
+      // exemption in the nightly enrollment-key purge sweep: proves Postgres
+      // itself evaluates the correlated NOT EXISTS subquery per row (the
+      // mocked unit suite only asserts the generated SQL's shape). Only
+      // BullMQ's Queue/Worker classes are mocked; imports
+      // `__tests__/integration/setup` (real postgres pool + autoMigrate).
+      'src/jobs/enrollmentKeyCleanup.integration.test.ts',
     ],
     exclude: [
       // Uses fresh request-pool modules and manages its own temporary role;


### PR DESCRIPTION
## What

An admin could pick "30 days" in the Add Device modal and the installer still died in ~60 minutes. `issueBootstrapTokenForKey` set the token's expiry to `min(parent.expiresAt, now + 24h)`, and the modal deliberately creates a **transient 60-minute parent** enrollment key.

- `IssueBootstrapTokenInput` gains `ttlMinutes`; the token now gets a fresh, independent lifetime instead of inheriting the parent's remaining life. This applies to bootstrap tokens the same correction already made for child enrollment keys (see the comment at `enrollmentKeys.ts:91-96`).
- Threads the picker's value through the three issuance call sites.
- Removes the consume-time clamp in `routes/installer.ts` that re-capped the minted child key to the parent and 404'd `parent_already_expired`.
- Closes two previously-unguarded issue paths so all four call sites now check `parentKeyTooCloseToExpiry`.
- Exempts parent keys still holding a live, unexhausted token from the nightly `enrollmentKeyCleanup` purge. Without this the 7-day purge cascaded tokens away and **capped every link at ~7 days regardless of the picker** — the same silent-discard defect, reintroduced by the fix for it.

## ⚠️ Two behaviour changes for release notes

1. **A bootstrap token now outlives its parent key.** The token's own expiry is the sole authority. Revocation still works and is unchanged: `installer_bootstrap_tokens.parent_enrollment_key_id` is `ON DELETE CASCADE`, so deleting the parent destroys outstanding tokens immediately.
2. **Shortening a parent key's expiry via the rotate route no longer kills outstanding installers.** It used to, via the removed `parent_already_expired` check. Operators who relied on that as a kill switch must delete the key instead. This is a genuine loss of capability.

## Testing

`installerBootstrapTokenIssuance.ts` previously had **no direct test at all** — it is `vi.mock`ed in every route suite, which is how this shipped. This adds its first unit tests plus integration tests executed against real Postgres for both the TTL and the purge exemption, each verified red against pre-fix code.

API 17,321 passing / 0 failed · typechecks clean.

Closes #2775

🤖 Generated with [Claude Code](https://claude.com/claude-code)
