### PR TITLE
feat(api): enforce maxEnrollmentLinkTtlMinutes across every enrollment mint path (1/2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -320,6 +320,23 @@ MFA_RECOVERY_CODE_PEPPER=generate-a-random-hex-string-for-production
 RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
 # Default TTL (minutes) for newly created enrollment keys when expiresAt is not provided.
 ENROLLMENT_KEY_DEFAULT_TTL_MINUTES=60
+# Fresh TTL (minutes) given to a "child" enrollment key minted at installer-download,
+# installer-link, or short-code redemption time. Measured from mint time, independent
+# of the parent key's remaining lifetime.
+CHILD_ENROLLMENT_KEY_TTL_MINUTES=1440
+# Base TTL (minutes) for a freshly-issued installer bootstrap token when no explicit
+# ttlMinutes is supplied. The token's own expiry -- not the parent enrollment key's --
+# governs how long an installer has to complete enrollment.
+INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES=1440
+# Minimum remaining lifetime (seconds) a parent enrollment key must have to be used as
+# an installer source. Guards against building an installer from a parent that expires
+# before the download reaches the target machine.
+INSTALLER_PARENT_MIN_REMAINING_SECONDS=60
+# Set to false to disable the daily sweep that purges expired enrollment keys.
+ENROLLMENT_KEY_CLEANUP_ENABLED=true
+# Grace period (days past expiry) before an expired enrollment key is purged by the
+# daily sweep.
+ENROLLMENT_KEY_PURGE_AFTER_DAYS=7
 
 # --------------------------------------------
 # CORS Configuration

--- a/apps/api/src/__tests__/integration/enrollmentDefaultsPartnerCap.integration.test.ts
+++ b/apps/api/src/__tests__/integration/enrollmentDefaultsPartnerCap.integration.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Real-Postgres integration coverage for the partner-axis RLS gap in
+ * getEnrollmentDefaultsForOrg (fix round 1, #2776 task 3.4).
+ *
+ * The bug: `getEnrollmentDefaultsForOrg` reads `partners.settings` via a
+ * `leftJoin`. `partners`' SELECT policy is `breeze_has_partner_access(id)`
+ * (apps/api/migrations/2026-04-11-partners-rls.sql), which evaluates against
+ * `breeze.accessible_partner_ids` — and `computeAccessiblePartnerIds` returns
+ * `[]` for `scope === 'organization'` (apps/api/src/middleware/auth.ts). Every
+ * route that calls this resolver (via assertTtlWithinCap) is
+ * `requireScope("organization", "partner", "system")`, so an org-scoped
+ * caller — exactly the population the cap exists to bind — would silently
+ * get `partnerSettings = null` from the join, `maxTtlMinutes` falling back to
+ * the permissive global default, and the partner's configured cap never
+ * enforced at all.
+ *
+ * A mocked-DB unit test cannot catch this: the mock always returns whatever
+ * row the test stages, with no RLS evaluation. Only a real Postgres
+ * connection running through the actual `breeze_app` role, under a real
+ * `withDbAccessContext` org-scoped RLS session, can prove the join is
+ * visible. This test reproduces the exact ambient context an org-scoped
+ * HTTP request runs under (authMiddleware wraps every request in
+ * `withDbAccessContext` keyed off the caller's auth — see
+ * apps/api/src/middleware/auth.ts:606) and asserts the resolver still
+ * surfaces the partner's cap from inside it.
+ */
+import './setup';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { organizations, partners } from '../../db/schema';
+import { getEnrollmentDefaultsForOrg } from '../../services/enrollmentDefaults';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/** Mirrors authMiddleware's computeAccessiblePartnerIds for scope 'organization': []. */
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const createdOrgIds: string[] = [];
+const createdPartnerIds: string[] = [];
+
+afterEach(async () => {
+  if (createdOrgIds.length === 0 && createdPartnerIds.length === 0) return;
+  await withSystemDbAccessContext(async () => {
+    for (const id of createdOrgIds) {
+      await db.delete(organizations).where(eq(organizations.id, id));
+    }
+    for (const id of createdPartnerIds) {
+      await db.delete(partners).where(eq(partners.id, id));
+    }
+  });
+  createdOrgIds.length = 0;
+  createdPartnerIds.length = 0;
+});
+
+describe('getEnrollmentDefaultsForOrg — partner-cap visibility under org-scoped RLS (fix round 1, #2776)', () => {
+  runDb(
+    "an org-scoped caller (accessiblePartnerIds: []) still resolves the partner's configured TTL cap",
+    async () => {
+      const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      const ids = await withSystemDbAccessContext(async () => {
+        const [partner] = await db
+          .insert(partners)
+          .values({
+            name: `Cap Partner ${unique}`,
+            slug: `cap-partner-${unique}`,
+            type: 'msp',
+            plan: 'pro',
+            status: 'active',
+            settings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } },
+          })
+          .returning({ id: partners.id });
+        const [org] = await db
+          .insert(organizations)
+          .values({
+            partnerId: partner!.id,
+            name: `Cap Org ${unique}`,
+            slug: `cap-org-${unique}`,
+            type: 'customer',
+            status: 'active',
+          })
+          .returning({ id: organizations.id });
+        return { partnerId: partner!.id, orgId: org!.id };
+      });
+      createdPartnerIds.push(ids.partnerId);
+      createdOrgIds.push(ids.orgId);
+
+      // The crux of the reproduction: call the resolver from INSIDE the same
+      // kind of RLS context an org-scoped HTTP request runs under, not from
+      // withSystemDbAccessContext. Pre-fix, getEnrollmentDefaultsForOrg ran
+      // its query directly against whatever context was already ambient —
+      // here, the org-scoped one — so the partners leftJoin would silently
+      // return null and maxTtlMinutes would be the permissive global
+      // default (525_600) instead of the partner's configured 1440.
+      const resolved = await withDbAccessContext(orgContext(ids.orgId), () =>
+        getEnrollmentDefaultsForOrg(ids.orgId),
+      );
+
+      expect(resolved.maxTtlMinutes).toBe(1440);
+    },
+  );
+
+  runDb(
+    'sanity check: the raw partners row IS actually invisible to this org-scoped context (proves the RLS premise, not just the fix)',
+    async () => {
+      const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      const ids = await withSystemDbAccessContext(async () => {
+        const [partner] = await db
+          .insert(partners)
+          .values({
+            name: `Sanity Partner ${unique}`,
+            slug: `sanity-partner-${unique}`,
+            type: 'msp',
+            plan: 'pro',
+            status: 'active',
+          })
+          .returning({ id: partners.id });
+        const [org] = await db
+          .insert(organizations)
+          .values({
+            partnerId: partner!.id,
+            name: `Sanity Org ${unique}`,
+            slug: `sanity-org-${unique}`,
+            type: 'customer',
+            status: 'active',
+          })
+          .returning({ id: organizations.id });
+        return { partnerId: partner!.id, orgId: org!.id };
+      });
+      createdPartnerIds.push(ids.partnerId);
+      createdOrgIds.push(ids.orgId);
+
+      const rows = await withDbAccessContext(orgContext(ids.orgId), () =>
+        db.select({ id: partners.id }).from(partners).where(eq(partners.id, ids.partnerId)),
+      );
+
+      // If this ever starts returning the row, the whole premise of this
+      // bug (and the fix) is gone — the partners RLS policy itself changed
+      // and this test file needs re-evaluating, not just green-lit.
+      expect(rows).toHaveLength(0);
+    },
+  );
+});
+
+/**
+ * Fix round 4 (#2776) — AVAILABILITY. The round-1 escape
+ * (`runOutsideDbContext(withSystemDbAccessContext(...))`) is correct for an
+ * org-scoped caller but catastrophic for a caller that is ALREADY system-scoped:
+ * `withDbAccessContext` opens a real `baseDb.transaction`, so the outer context
+ * pins one pooled connection for its whole callback, and `runOutsideDbContext`
+ * exits the AsyncLocalStorage store so the inner system context does NOT nest —
+ * it borrows a SECOND connection while the first is still held. Every device
+ * enrollment (POST /installer/bootstrap) and every public installer download
+ * traverses such a path. At N concurrent requests >= DB_POOL_MAX, every
+ * connection is held by a request queued for a connection only a peer can
+ * release; postgres-js has no acquire timeout (`connect_timeout` is TCP connect,
+ * not queue wait), so the API stalls indefinitely rather than merely slowing.
+ *
+ * The test below asserts the MECHANISM, not the value — the two code paths
+ * return the identical number, so only transaction visibility can tell them
+ * apart. It writes the partner+org inside an OPEN system transaction and then
+ * calls the resolver from inside that same transaction. Uncommitted rows are
+ * invisible to any other connection, so:
+ *   - reads in the AMBIENT transaction  -> sees the row  -> cap 1440
+ *   - opens a SECOND connection instead -> sees nothing  -> product default 525600
+ * i.e. it fails, loudly and specifically, the moment the second connection
+ * comes back.
+ */
+describe('getEnrollmentDefaultsForOrg — no second pooled connection for a system-scoped caller (fix round 4, #2776)', () => {
+  runDb(
+    'reads inside the caller’s own system transaction (uncommitted rows are visible), rather than on a second connection',
+    async () => {
+      const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      const { resolved, ids } = await withSystemDbAccessContext(async () => {
+        const [partner] = await db
+          .insert(partners)
+          .values({
+            name: `Ambient Partner ${unique}`,
+            slug: `ambient-partner-${unique}`,
+            type: 'msp',
+            plan: 'pro',
+            status: 'active',
+            settings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } },
+          })
+          .returning({ id: partners.id });
+        const [org] = await db
+          .insert(organizations)
+          .values({
+            partnerId: partner!.id,
+            name: `Ambient Org ${unique}`,
+            slug: `ambient-org-${unique}`,
+            type: 'customer',
+            status: 'active',
+          })
+          .returning({ id: organizations.id });
+
+        // Still INSIDE the transaction that wrote these rows, and still
+        // uncommitted: only a read on this very connection can see them.
+        const resolved = await getEnrollmentDefaultsForOrg(org!.id);
+        return { resolved, ids: { partnerId: partner!.id, orgId: org!.id } };
+      });
+
+      createdPartnerIds.push(ids.partnerId);
+      createdOrgIds.push(ids.orgId);
+
+      expect(resolved.maxTtlMinutes).toBe(1440);
+    },
+  );
+});

--- a/apps/api/src/routes/devices.test.ts
+++ b/apps/api/src/routes/devices.test.ts
@@ -24,6 +24,34 @@ vi.mock('../services/enrollmentKeySecurity', () => ({
   generateEnrollmentKey: vi.fn(() => 'ek_test123')
 }));
 
+// Partner-cap enforcement (#2776 task 3.4). Mocked at the wiring level — see
+// enrollmentKeys.test.ts's identically-named helper for rationale.
+const assertTtlWithinCapMock = vi.fn(
+  async (_orgId: string, _ttlMinutes: number | undefined) => null as string | null,
+);
+vi.mock('../services/enrollmentDefaults', () => ({
+  assertTtlWithinCap: (...args: [string, number | undefined]) =>
+    assertTtlWithinCapMock(...args),
+}));
+
+/**
+ * Configure the mocked partner-cap gate for the current test. Mirrors the
+ * real assertTtlWithinCap contract: null when ttlMinutes is undefined or at/
+ * under the cap, an error string naming the cap when it's exceeded. Default
+ * (set in the outer beforeEach) models "no partner cap configured" — the
+ * product-default ceiling of 525_600 minutes.
+ */
+function mockEnrollmentDefaults(opts: { maxTtlMinutes: number }) {
+  assertTtlWithinCapMock.mockImplementation(
+    async (_orgId: string, ttlMinutes: number | undefined) => {
+      if (ttlMinutes === undefined) return null;
+      return ttlMinutes > opts.maxTtlMinutes
+        ? `ttlMinutes exceeds the partner maximum of ${opts.maxTtlMinutes} minutes`
+        : null;
+    },
+  );
+}
+
 vi.mock('../services/permissions', () => ({
   PERMISSIONS: new Proxy({} as Record<string, { resource: string; action: string }>, {
     get(_target, prop: string) {
@@ -200,6 +228,10 @@ describe('device routes', () => {
       where: vi.fn(() => Promise.resolve())
     }) as any);
     vi.mocked(db.execute).mockImplementation(() => Promise.resolve([]) as any);
+    // resetAllMocks above also wipes assertTtlWithinCapMock's implementation —
+    // restore the permissive default (mirrors "no partner cap configured",
+    // i.e. the product-default 525_600-minute ceiling from resolveEnrollmentDefaults).
+    mockEnrollmentDefaults({ maxTtlMinutes: 525_600 });
     app = new Hono();
     app.route('/devices', deviceRoutes);
   });
@@ -441,18 +473,72 @@ describe('device routes', () => {
       expect(res.status).toBe(200);
       expect(expiryMinutesFrom(valuesMock)).toBeGreaterThanOrEqual(1439);
       expect(expiryMinutesFrom(valuesMock)).toBeLessThanOrEqual(1441);
+    });
 
-      // Over-cap ttlMinutes is now REJECTED rather than clamped (#2777) — a
-      // silently reduced expiry is exactly the failure mode #2775 was filed
-      // for. (This sub-case used to assert a 200 with the value clamped to
-      // 525_600; that behaviour is precisely what this fix removes.)
-      captureExpiry();
-      res = await app.request('/devices/onboarding-token', {
+    // #2776 task 3.4 (CRITICAL follow-up): this route used to silently clamp
+    // an over-cap ttlMinutes down to ENROLL_TOKEN_MAX_TTL_MINUTES (365 days)
+    // instead of rejecting it — exactly the silent-discard bypass the
+    // enrollment-defaults plan was written to close. It must now 400 and
+    // name the cap, same as the enrollment-keys mint routes. Since #2777 the
+    // rejection is issued by the request schema itself, before the handler.
+    it('rejects an over-cap ttlMinutes instead of silently clamping it (#2776)', async () => {
+      vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
+      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/devices/onboarding-token', {
         method: 'POST',
         headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
         body: JSON.stringify({ ttlMinutes: 99_999_999 })
       });
+
       expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('525600');
+      // Rejected before the site lookup / insert ever fire.
+      expect(valuesMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an explicit ttlMinutes above a partner-configured cap (#2776)', async () => {
+      mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+      vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
+      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ttlMinutes: 43200 })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('1440');
+      expect(assertTtlWithinCapMock).toHaveBeenCalledWith('org-123', 43200);
+      expect(valuesMock).not.toHaveBeenCalled();
+    });
+
+    it('allows an explicit ttlMinutes at exactly a partner-configured cap (#2776)', async () => {
+      mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+      vi.stubEnv('AGENT_ENROLLMENT_SECRET', '');
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: 'site-1' }])
+          })
+        })
+      } as any);
+      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/devices/onboarding-token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ttlMinutes: 1440 })
+      });
+
+      expect(res.status).toBe(200);
+      expect(valuesMock).toHaveBeenCalled();
     });
 
     it('honours ttlMinutes from the request body', async () => {

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -54,6 +54,7 @@ import { sendCommandToAgent, isAgentConnected, disconnectAgent } from '../agentW
 import { terminateDeviceRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { CommandTypes } from '../../services/commandQueue';
 import { getGlobalEnrollmentSecret } from '../agents/enrollment';
+import { assertTtlWithinCap } from '../../services/enrollmentDefaults';
 import {
   withExtensionDeviceCascade,
   withExtensionDeviceOrgDenormalized,
@@ -327,6 +328,29 @@ coreRoutes.post(
       return c.json({ error: 'Organization ID required. Provide orgId query parameter.' }, 400);
     }
 
+    // Optional caller-supplied multi-use / TTL controls (#1108). A copied CLI
+    // command is frequently pasted onto several machines during a migration;
+    // without these the historical hard-coded single-use token failed on every
+    // machine after the first. Defaults preserve the old single-use, 60-min
+    // behaviour for callers that send no body.
+    const data = c.req.valid('json');
+    const rawCount = Number((data as { count?: unknown }).count);
+    const maxUsage = Number.isFinite(rawCount)
+      ? Math.min(ENROLL_TOKEN_MAX_COUNT, Math.max(1, Math.trunc(rawCount)))
+      : 1;
+    // Explicit-ttl-vs-default is distinguished BEFORE the default is applied:
+    // assertTtlWithinCap must see what the caller actually asked for (an
+    // omitted ttlMinutes stays `undefined`, which the gate never rejects — an
+    // unset value has no chooser to hold to a cap). No coercion or clamping is
+    // needed here: the Zod schema already guarantees an integer in 1..525_600
+    // and REJECTS anything outside it rather than silently reducing it.
+    const explicitTtlMinutes = data.ttlMinutes;
+
+    // Reject (never clamp) a caller-supplied TTL above the partner cap
+    // (#2776 task 3.4). Runs after org resolution — orgId is required.
+    const capError = await assertTtlWithinCap(orgId, explicitTtlMinutes);
+    if (capError) return c.json({ error: capError }, 400);
+
     // Pick the first site in the org for the enrollment key
     const [site] = await db
       .select({ id: sites.id })
@@ -338,17 +362,7 @@ coreRoutes.post(
       return c.json({ error: 'No site found for this organization. Create a site first.' }, 400);
     }
 
-    // Optional caller-supplied multi-use / TTL controls (#1108). A copied CLI
-    // command is frequently pasted onto several machines during a migration;
-    // without these the historical hard-coded single-use token failed on every
-    // machine after the first. Defaults preserve the old single-use, 60-min
-    // behaviour for callers that send no body.
-    const data = c.req.valid('json');
-    const rawCount = Number((data as { count?: unknown }).count);
-    const maxUsage = Number.isFinite(rawCount)
-      ? Math.min(ENROLL_TOKEN_MAX_COUNT, Math.max(1, Math.trunc(rawCount)))
-      : 1;
-    const ttlMinutes = data.ttlMinutes
+    const ttlMinutes = explicitTtlMinutes
       ?? envInt('ENROLLMENT_KEY_DEFAULT_TTL_MINUTES', 60);
 
     const key = `enroll_${randomBytes(24).toString('hex')}`;

--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -121,6 +121,28 @@ vi.mock("../services", () => ({
   getRedis: () => mockGetRedis(),
 }));
 
+// Partner-cap enforcement (#2776 task 3.4). Mocked at the wiring level — the
+// cap-computation/message logic itself is unit-tested directly against
+// resolveEnrollmentDefaults/getEnrollmentDefaultsForOrg, so these route tests
+// only need to prove the route calls assertTtlWithinCap with the right org id
+// and TTL, and reacts correctly to its null/error return.
+const assertTtlWithinCapMock = vi.fn(
+  async (_orgId: string, _ttlMinutes: number | undefined) => null as string | null,
+);
+// clampTtlToCap (fix round 3, #2776): the CLAMP-shaped sibling of
+// assertTtlWithinCap, used by mintChildEnrollmentKey/redeemShortCode/the
+// /s/:code redemption/issueBootstrapTokenForKey for server-constant TTLs on
+// paths with no interactive caller. Permissive default (returns ttlMinutes
+// unchanged) models "no partner cap configured".
+const clampTtlToCapMock = vi.fn(
+  async (_orgId: string, ttlMinutes: number) => ttlMinutes,
+);
+vi.mock("../services/enrollmentDefaults", () => ({
+  assertTtlWithinCap: (...args: [string, number | undefined]) =>
+    assertTtlWithinCapMock(...args),
+  clampTtlToCap: (...args: [string, number]) => clampTtlToCapMock(...args),
+}));
+
 // ============================================================
 // Import after mocks
 // ============================================================
@@ -135,6 +157,25 @@ import { MsiSigningService } from "../services/msiSigning";
 import { fetchMacosInstallerAppZip } from "../services/installerBuilder";
 import { renameAppInZip } from "../services/installerAppZip";
 import * as installerBootstrapTokenIssuance from "../services/installerBootstrapTokenIssuance";
+
+/**
+ * Configure the mocked partner-cap gate for the current test. Mirrors the
+ * real assertTtlWithinCap contract: null when ttlMinutes is undefined or at/
+ * under the cap, an error string naming the cap when it's exceeded.
+ */
+function mockEnrollmentDefaults(opts: { maxTtlMinutes: number }) {
+  assertTtlWithinCapMock.mockImplementation(
+    async (_orgId: string, ttlMinutes: number | undefined) => {
+      if (ttlMinutes === undefined) return null;
+      return ttlMinutes > opts.maxTtlMinutes
+        ? `ttlMinutes exceeds the partner maximum of ${opts.maxTtlMinutes} minutes`
+        : null;
+    },
+  );
+  clampTtlToCapMock.mockImplementation(
+    async (_orgId: string, ttlMinutes: number) => Math.min(ttlMinutes, opts.maxTtlMinutes),
+  );
+}
 
 // ============================================================
 // Helpers
@@ -184,6 +225,18 @@ function makeChildKeyRow(overrides: Record<string, unknown> = {}) {
     ...overrides,
   };
 }
+
+// Runs before every per-describe `vi.clearAllMocks()` (outer beforeEach hooks
+// fire before inner ones), so each test starts from the permissive default —
+// clearAllMocks only wipes call history, not mockImplementation, so a test
+// that calls mockEnrollmentDefaults() would otherwise leak its cap into every
+// later test in the file.
+beforeEach(() => {
+  assertTtlWithinCapMock.mockReset();
+  assertTtlWithinCapMock.mockImplementation(async () => null);
+  clampTtlToCapMock.mockReset();
+  clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) => ttlMinutes);
+});
 
 // ============================================================
 // Tests
@@ -424,6 +477,124 @@ describe("POST /enrollment-keys/:id/installer-link", () => {
     });
     expect(res.status).toBe(429);
   });
+
+  // #2776 task 3.4 — partner-cap enforcement at the mint route.
+  it("rejects a ttlMinutes above the partner cap", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+    const parentRow = makeKeyRow();
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parentRow]),
+        }),
+      }),
+    } as any);
+
+    const insertValues = vi.fn();
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const res = await app.request(`/enrollment-keys/${KEY_ID}/installer-link`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "windows", count: 1, ttlMinutes: 43200 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("1440");
+    expect(insertValues).not.toHaveBeenCalled();
+    // The cap check must run after the parent key load, using its orgId.
+    expect(assertTtlWithinCapMock).toHaveBeenCalledWith(ORG_ID, 43200);
+  });
+
+  it("allows a ttlMinutes at exactly the cap", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+    const parentRow = makeKeyRow();
+    const childRow = makeChildKeyRow();
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([parentRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([childRow]),
+      }),
+    } as any);
+
+    const res = await app.request(`/enrollment-keys/${KEY_ID}/installer-link`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "windows", count: 1, ttlMinutes: 1440 }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  // #2776 final wave — the SEVENTH uncapped mint path. assertTtlWithinCap
+  // returns null for `undefined` by design, so OMITTING ttlMinutes used to
+  // hand the child key the uncapped CHILD_ENROLLMENT_KEY_TTL_MINUTES server
+  // constant (1440) — 24x a 60-minute partner cap, on one of the two
+  // most-used download routes.
+  it("clamps the CHILD_ENROLLMENT_KEY_TTL_MINUTES fallback to the partner cap when ttlMinutes is omitted (#2776)", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 60 });
+    const parentRow = makeKeyRow();
+    const childRow = makeChildKeyRow();
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([parentRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+    let capturedChildValues: Record<string, unknown> | null = null;
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockImplementation((vals: Record<string, unknown>) => {
+        capturedChildValues = vals;
+        return { returning: vi.fn().mockResolvedValue([childRow]) };
+      }),
+    } as any);
+
+    const before = Date.now();
+    const res = await app.request(`/enrollment-keys/${KEY_ID}/installer-link`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform: "windows", count: 1 }),
+    });
+    const after = Date.now();
+
+    expect(res.status).toBe(200);
+    // The uncapped server constant is what gets handed to the clamp...
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+    // ...and the key that actually lands is the 60-minute cap, not 24h.
+    expect(capturedChildValues).not.toBeNull();
+    const expiresAt = (capturedChildValues as unknown as { expiresAt: Date }).expiresAt;
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(after + 61 * 60 * 1000);
+  });
 });
 
 // ============================================================
@@ -547,6 +718,90 @@ describe("GET /s/:code", () => {
     expect(issueSpy.mock.calls[0]?.[0]?.createdByUserId).not.toBe("");
 
     issueSpy.mockRestore();
+  });
+
+  // Fix round 3 (#2776): this route mints its own download child key via
+  // CHILD_ENROLLMENT_KEY_TTL_MINUTES (default 1440) with no interactive
+  // caller (it's the public short-link redemption), so a partner cap below
+  // that default must clamp the minted lifetime down, never reject.
+  it("clamps the download child key's TTL down when the partner cap is below the default", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 60 });
+    const shortLinkRow = makeKeyRow({
+      shortCode: "cappedlink",
+      installerPlatform: "macos",
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([shortLinkRow]),
+        }),
+      }),
+    } as any);
+    const insertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([makeChildKeyRow({ installerPlatform: "macos" })]),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: KEY_ID }]),
+        }),
+      }),
+    } as any);
+    // macOS path with signing disabled falls through to the legacy zip
+    // builder — irrelevant here, only the child-key insert's expiresAt matters.
+    vi.mocked(MsiSigningService.fromEnv).mockReturnValue(null);
+
+    const before = Date.now();
+    const res = await app.request("/s/cappedlink");
+    const after = Date.now();
+
+    expect(res.status).toBe(200);
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    const insertedRow = insertValues.mock.calls[0]![0] as { expiresAt: Date };
+    // Clamped to the 60-minute cap, NOT the 1440-minute (24h) default.
+    expect(insertedRow.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+    expect(insertedRow.expiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+  });
+
+  it("does not shorten the download child key's TTL when the partner cap is above the default (no-op clamp)", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 525_600 });
+    const shortLinkRow = makeKeyRow({
+      shortCode: "generouscap",
+      installerPlatform: "macos",
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([shortLinkRow]),
+        }),
+      }),
+    } as any);
+    const insertValues = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([makeChildKeyRow({ installerPlatform: "macos" })]),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: KEY_ID }]),
+        }),
+      }),
+    } as any);
+    vi.mocked(MsiSigningService.fromEnv).mockReturnValue(null);
+
+    const before = Date.now();
+    const res = await app.request("/s/generouscap");
+    const after = Date.now();
+
+    expect(res.status).toBe(200);
+    const insertedRow = insertValues.mock.calls[0]![0] as { expiresAt: Date };
+    // Unchanged: still the full 1440-minute (24h) default.
+    expect(insertedRow.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 1439 * 60 * 1000);
+    expect(insertedRow.expiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
   });
 
   it("returns 404 for unknown code", async () => {
@@ -1482,6 +1737,67 @@ describe("POST /:id/bootstrap-token", () => {
 
     expect(res.status).toBe(400);
   });
+
+  // #2776 task 3.4 — a value the global schema max would allow (well under
+  // 525_600) can still exceed a lower PARTNER cap, which only the DB-backed
+  // assertTtlWithinCap gate (not the static zod schema) can enforce.
+  it("rejects a ttlMinutes above the partner cap on the bootstrap-token route (#2776)", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+    const parent = makeKeyRow();
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parent]),
+        }),
+      }),
+    } as any);
+
+    const insertValues = vi.fn();
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/bootstrap-token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxUsage: 1, ttlMinutes: 43200 }),
+      },
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("1440");
+    expect(assertTtlWithinCapMock).toHaveBeenCalledWith(ORG_ID, 43200);
+  });
+
+  it("allows a ttlMinutes at exactly the partner cap on the bootstrap-token route (#2776)", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+    const parent = makeKeyRow();
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([parent]),
+        }),
+      }),
+    } as any);
+
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "token-row-uuid-3" }]),
+      }),
+    } as any);
+
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/bootstrap-token`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxUsage: 1, ttlMinutes: 1440 }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+  });
 });
 
 // ============================================================
@@ -1642,6 +1958,51 @@ describe("GET /:id/installer/macos — app-bundle path", () => {
     // The app-bundle path must NOT have been called
     expect(vi.mocked(renameAppInZip)).not.toHaveBeenCalled();
     expect(issueSpy).not.toHaveBeenCalled();
+  });
+
+  // #2776 final wave — same seventh gap on the other download route.
+  it("clamps the CHILD_ENROLLMENT_KEY_TTL_MINUTES fallback to the partner cap when ttlMinutes is omitted (#2776)", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 60 });
+    const parentRow = makeKeyRow();
+    const childRow = makeChildKeyRow({ installerPlatform: "macos" });
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([parentRow]),
+          }),
+        }),
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as any);
+
+    let capturedChildValues: Record<string, unknown> | null = null;
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockImplementation((vals: Record<string, unknown>) => {
+        capturedChildValues = vals;
+        return { returning: vi.fn().mockResolvedValue([childRow]) };
+      }),
+    } as any);
+
+    const before = Date.now();
+    const res = await app.request(
+      `/enrollment-keys/${KEY_ID}/installer/macos?count=1&legacy=1`,
+      { headers: { authorization: "Bearer jwt" } },
+    );
+    const after = Date.now();
+
+    expect(res.status).toBe(200);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+    expect(capturedChildValues).not.toBeNull();
+    const expiresAt = (capturedChildValues as unknown as { expiresAt: Date }).expiresAt;
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(after + 61 * 60 * 1000);
   });
 
   it("falls back to legacy zip when installer app asset is missing (returns null)", async () => {
@@ -1842,5 +2203,130 @@ describe("POST / - siteId ownership validation", () => {
     expect(body.siteId).toBeNull();
     // when no siteId is provided, site lookup should not be called
     expect(db.select).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================
+// POST / - partner cap enforcement (fix round 1, #2776 task 3.4)
+//
+// This route has TWO paths to an expiry — ttlMinutes and an explicit
+// expiresAt (createEnrollmentKeySchema's refine guarantees only one is ever
+// set) — and a parent enrollment key is itself an enrollment credential, so
+// both paths must be gated. Capping only ttlMinutes would leave expiresAt as
+// a wide-open bypass.
+// ============================================================
+describe("POST / - partner cap enforcement (fix round 1, #2776)", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PUBLIC_API_URL = "https://api.example.com";
+    app = new Hono();
+    app.route("/enrollment-keys", enrollmentKeyRoutes);
+  });
+
+  it("rejects a ttlMinutes above the partner cap", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+    const orgId = randomUUID();
+    const insertValues = vi.fn();
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    const res = await app.request("/enrollment-keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId, name: "Test Key", ttlMinutes: 43200 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("1440");
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(assertTtlWithinCapMock).toHaveBeenCalledWith(orgId, 43200);
+  });
+
+  it("allows a ttlMinutes at exactly the partner cap", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+    const orgId = randomUUID();
+    const keyRow = makeKeyRow({ orgId });
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([keyRow]),
+      }),
+    } as any);
+
+    const res = await app.request("/enrollment-keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId, name: "Test Key", ttlMinutes: 1440 }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("rejects an expiresAt whose implied duration exceeds the partner cap (the expiresAt bypass path)", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+    const orgId = randomUUID();
+    const insertValues = vi.fn();
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+    // 30 days out — far above a 1440-minute (24h) cap.
+    const expiresAt = new Date(Date.now() + 43200 * 60 * 1000).toISOString();
+
+    const res = await app.request("/enrollment-keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId, name: "Test Key", expiresAt }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("1440");
+    expect(insertValues).not.toHaveBeenCalled();
+    // The route must derive an implied minutes value from expiresAt and
+    // check IT against the cap — there is no ttlMinutes to check directly.
+    const [, impliedMinutes] = assertTtlWithinCapMock.mock.calls[0]!;
+    expect(impliedMinutes).toBeGreaterThan(43199);
+    expect(impliedMinutes).toBeLessThanOrEqual(43201);
+  });
+
+  it("allows an expiresAt whose implied duration is comfortably under the partner cap", async () => {
+    mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+    const orgId = randomUUID();
+    const keyRow = makeKeyRow({ orgId });
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([keyRow]),
+      }),
+    } as any);
+
+    // 60 minutes out — comfortably under the 1440-minute cap.
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+    const res = await app.request("/enrollment-keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId, name: "Test Key", expiresAt }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("passes undefined to the cap gate when neither ttlMinutes nor expiresAt is supplied (falls back to the deployment default, not a cap violation)", async () => {
+    const orgId = randomUUID();
+    const keyRow = makeKeyRow({ orgId });
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([keyRow]),
+      }),
+    } as any);
+
+    const res = await app.request("/enrollment-keys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ orgId, name: "Test Key" }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(assertTtlWithinCapMock).toHaveBeenCalledWith(orgId, undefined);
   });
 });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -41,6 +41,7 @@ import {
   issueBootstrapTokenForKey,
   BootstrapTokenIssuanceError,
 } from "../services/installerBootstrapTokenIssuance";
+import { assertTtlWithinCap, clampTtlToCap } from "../services/enrollmentDefaults";
 import { captureException } from "../services/sentry";
 
 // ============================================================
@@ -297,6 +298,12 @@ export async function redeemShortCode(
 
     const rawKey = generateEnrollmentKey();
     const tokenHash = hashEnrollmentKey(rawKey);
+    // Clamp (never reject — no interactive caller here) the child's default
+    // TTL to the partner cap (fix round 3, #2776): the cap bounds KEY
+    // LIFETIME, not just interactively-chosen input, so this MCP-invite
+    // redemption path must not hand out a child key longer-lived than the
+    // partner allows just because it uses the server-constant default.
+    const cappedTtlMinutes = await clampTtlToCap(parent.orgId, CHILD_ENROLLMENT_KEY_TTL_MINUTES);
 
     const [child] = await db
       .insert(enrollmentKeys)
@@ -307,7 +314,7 @@ export async function redeemShortCode(
         key: tokenHash,
         keySecretHash: parent.keySecretHash,
         maxUsage: 1,
-        expiresAt: freshChildExpiresAt(),
+        expiresAt: freshChildExpiresAt(cappedTtlMinutes),
         createdBy: null,
         installerPlatform: parent.installerPlatform,
       })
@@ -410,6 +417,26 @@ export async function mintChildEnrollmentKey(
     orgId = org.id;
   }
 
+  // Clamp (never reject — this is a non-interactive helper with no HTTP
+  // request to surface a 400 to) the requested lifetime to the partner cap
+  // (fix round 3, #2776). This function is an exported, general-purpose
+  // helper — its only current caller (send_deployment_invites) hardcodes a
+  // 7-day server constant, but leaving the bound here (rather than trusting
+  // every caller to remember it) is what stops the next caller that threads
+  // a truly dynamic value through `expiresInSeconds` from reopening the
+  // exact escalation this whole plan exists to close.
+  // FLOOR, not ceil, with a 1-minute floor (fix round 4, #2776): the minute
+  // conversion feeds `expiresAt` directly, so rounding UP would LENGTHEN a
+  // sub-minute lifetime (90s -> 120s) in the very function this cap exists to
+  // bound. Rounding down can only shorten, which is the fail-closed direction;
+  // the max(1, ...) keeps a 1-59s request from collapsing to an
+  // already-expired key.
+  const rawTtlMinutes = Math.max(
+    1,
+    Math.floor((input.expiresInSeconds ?? CHILD_ENROLLMENT_KEY_TTL_MINUTES * 60) / 60),
+  );
+  const cappedTtlMinutes = await clampTtlToCap(orgId, rawTtlMinutes);
+
   let siteId = input.siteId;
   if (!siteId) {
     const [site] = await db
@@ -427,10 +454,7 @@ export async function mintChildEnrollmentKey(
   const rawKey = generateEnrollmentKey();
   const keyHash = hashEnrollmentKey(rawKey);
   const shortCode = await allocateShortCode();
-  const expiresAt = new Date(
-    Date.now() +
-      (input.expiresInSeconds ?? CHILD_ENROLLMENT_KEY_TTL_MINUTES * 60) * 1000,
-  );
+  const expiresAt = new Date(Date.now() + cappedTtlMinutes * 60 * 1000);
 
   const [row] = await db
     .insert(enrollmentKeys)
@@ -657,6 +681,25 @@ enrollmentKeyRoutes.post(
       return c.json({ error: "orgId is required" }, 400);
     }
 
+    // Reject (never clamp) a caller-supplied TTL above the partner cap
+    // (fix round 1, #2776 task 3.4). This route has TWO paths to an expiry —
+    // `ttlMinutes` and an explicit `expiresAt` — and createEnrollmentKeySchema's
+    // refine guarantees only one is ever set. Both must be checked: capping
+    // only `ttlMinutes` would leave `expiresAt` as a wide-open bypass (a
+    // parent enrollment key is itself an enrollment credential). For the
+    // `expiresAt` path there's no ttlMinutes to check directly, so the implied
+    // duration from now is computed and checked against the same cap; Math.ceil
+    // rounds UP so a request timed to land exactly at the cap is never
+    // rejected by wall-clock rounding, while a value that's genuinely over the
+    // cap is never rounded down into passing.
+    const impliedTtlMinutes = data.ttlMinutes !== undefined
+      ? data.ttlMinutes
+      : data.expiresAt !== undefined
+        ? Math.ceil((new Date(data.expiresAt).getTime() - Date.now()) / 60_000)
+        : undefined;
+    const capError = await assertTtlWithinCap(orgId, impliedTtlMinutes);
+    if (capError) return c.json({ error: capError }, 400);
+
     // Verify siteId belongs to the target org (if provided)
     if (data.siteId) {
       const [site] = await db
@@ -857,6 +900,21 @@ enrollmentKeyRoutes.post(
       return c.json({ error: "Access denied" }, 403);
     }
 
+    // Reject (never clamp) a caller-supplied expiresAt above the partner cap
+    // (fix round 2, #2776 task 3.4). rotateEnrollmentKeySchema has no
+    // ttlMinutes field — only expiresAt — so there is only one path to gate
+    // here. Rotation re-mints the key value via generateEnrollmentKey(), so
+    // leaving this uncapped would let a caller bound by a short cap create a
+    // key at the cap and immediately rotate it past it — a complete bypass
+    // of the ceiling. An omitted expiresAt falls back to the existing key's
+    // own (already-validated) expiresAt below, which is not a newly-chosen
+    // value, so there's nothing to check in that case.
+    const impliedTtlMinutes = data.expiresAt !== undefined
+      ? Math.ceil((new Date(data.expiresAt).getTime() - Date.now()) / 60_000)
+      : undefined;
+    const capError = await assertTtlWithinCap(existingKey.orgId, impliedTtlMinutes);
+    if (capError) return c.json({ error: capError }, 400);
+
     const rawKey = generateEnrollmentKey();
     const keyHash = hashEnrollmentKey(rawKey);
     const expiresAt = data.expiresAt
@@ -993,6 +1051,11 @@ enrollmentKeyRoutes.get(
     if (!hasAccess) {
       return c.json({ error: "Access denied" }, 403);
     }
+
+    // Reject (never clamp) a caller-supplied TTL above the partner cap.
+    // Must run after the parent key load — parentKey.orgId is required.
+    const capError = await assertTtlWithinCap(parentKey.orgId, childTtlMinutes);
+    if (capError) return c.json({ error: capError }, 400);
 
     // Verify key is still usable
     if (parentKey.expiresAt && new Date(parentKey.expiresAt) < new Date()) {
@@ -1306,9 +1369,27 @@ enrollmentKeyRoutes.get(
       }
     }
 
-    // Generate a child enrollment key. Child gets a FRESH TTL independent
-    // of the parent's remaining lifetime — otherwise late-in-life parents
-    // produce dead-on-arrival installers (see CHILD_ENROLLMENT_KEY_TTL_MINUTES).
+    // The partner cap bounds KEY LIFETIME, not merely caller-supplied input
+    // (#2776 fix round 3 ruling). `assertTtlWithinCap` above already 400s an
+    // EXPLICIT over-cap childTtlMinutes, but it returns null for `undefined`
+    // by design — so an admin who simply OMITS ttlMinutes used to take the
+    // uncapped CHILD_ENROLLMENT_KEY_TTL_MINUTES server constant (1440), which
+    // is 24x a 60-minute partner cap, on the two most-used download routes.
+    // Clamp the fallback too. Deliberately unconditional rather than
+    // `childTtlMinutes ?? await clampTtlToCap(...)`: this plan produced six
+    // one-at-a-time cap gaps precisely because each site assumed some other
+    // site had already checked. Costs one extra settings read on the explicit
+    // path, where it is a same-value no-op.
+    //
+    // The child's TTL is FRESH from mint time, never the parent's remaining
+    // lifetime — otherwise late-in-life parents produce DOA installers.
+    const childExpiresAt = freshChildExpiresAt(
+      await clampTtlToCap(
+        parentKey.orgId,
+        childTtlMinutes ?? CHILD_ENROLLMENT_KEY_TTL_MINUTES,
+      ),
+    );
+
     const rawChildKey = generateEnrollmentKey();
     const childKeyHash = hashEnrollmentKey(rawChildKey);
     const shortCode = await allocateShortCode();
@@ -1322,7 +1403,7 @@ enrollmentKeyRoutes.get(
         key: childKeyHash,
         keySecretHash: parentKey.keySecretHash,
         maxUsage: childMaxUsage,
-        expiresAt: freshChildExpiresAt(childTtlMinutes),
+        expiresAt: childExpiresAt,
         createdBy: auth.user.id,
         shortCode,
         installerPlatform: platform,
@@ -1453,6 +1534,10 @@ enrollmentKeyRoutes.post(
       return c.json({ error: "Access denied" }, 403);
     }
 
+    // Reject (never clamp) a caller-supplied TTL above the partner cap.
+    const capError = await assertTtlWithinCap(parent.orgId, ttlMinutes);
+    if (capError) return c.json({ error: capError }, 400);
+
     if (parentKeyTooCloseToExpiry(parent.expiresAt)) {
       return c.json(
         {
@@ -1535,6 +1620,10 @@ enrollmentKeyRoutes.post(
       return c.json({ error: "Access denied" }, 403);
     }
 
+    // Reject (never clamp) a caller-supplied TTL above the partner cap.
+    const capError = await assertTtlWithinCap(parentKey.orgId, childTtlMinutes);
+    if (capError) return c.json({ error: capError }, 400);
+
     // Verify key is still usable
     if (parentKey.expiresAt && new Date(parentKey.expiresAt) < new Date()) {
       return c.json({ error: "Enrollment key has expired" }, 410);
@@ -1585,7 +1674,27 @@ enrollmentKeyRoutes.post(
       }
     }
 
-    // Generate a child enrollment key with a fresh TTL independent of parent
+    // The partner cap bounds KEY LIFETIME, not merely caller-supplied input
+    // (#2776 fix round 3 ruling). `assertTtlWithinCap` above already 400s an
+    // EXPLICIT over-cap childTtlMinutes, but it returns null for `undefined`
+    // by design — so an admin who simply OMITS ttlMinutes used to take the
+    // uncapped CHILD_ENROLLMENT_KEY_TTL_MINUTES server constant (1440), which
+    // is 24x a 60-minute partner cap, on the two most-used download routes.
+    // Clamp the fallback too. Deliberately unconditional rather than
+    // `childTtlMinutes ?? await clampTtlToCap(...)`: this plan produced six
+    // one-at-a-time cap gaps precisely because each site assumed some other
+    // site had already checked. Costs one extra settings read on the explicit
+    // path, where it is a same-value no-op.
+    //
+    // The child's TTL is FRESH from mint time, never the parent's remaining
+    // lifetime — otherwise late-in-life parents produce DOA installers.
+    const childExpiresAt = freshChildExpiresAt(
+      await clampTtlToCap(
+        parentKey.orgId,
+        childTtlMinutes ?? CHILD_ENROLLMENT_KEY_TTL_MINUTES,
+      ),
+    );
+
     const rawChildKey = generateEnrollmentKey();
     const childKeyHash = hashEnrollmentKey(rawChildKey);
     const shortCode = await allocateShortCode();
@@ -1599,7 +1708,7 @@ enrollmentKeyRoutes.post(
         key: childKeyHash,
         keySecretHash: parentKey.keySecretHash,
         maxUsage: childMaxUsage,
-        expiresAt: freshChildExpiresAt(childTtlMinutes),
+        expiresAt: childExpiresAt,
         createdBy: auth.user.id,
         shortCode,
         installerPlatform: platform,
@@ -2128,6 +2237,13 @@ publicShortLinkRoutes.get("/:code", async (c) => {
     // if the short-link row is near its own expiry.
     const rawToken = generateEnrollmentKey();
     const tokenHash = hashEnrollmentKey(rawToken);
+    // Clamp (never reject — public, unauthenticated redemption path with no
+    // interactive caller) the child's default TTL to the partner cap (fix
+    // round 3, #2776): the cap bounds KEY LIFETIME, not just interactively-
+    // chosen input, so this short-link download must not hand out a child
+    // key longer-lived than the partner allows just because it uses the
+    // server-constant default.
+    const cappedTtlMinutes = await clampTtlToCap(row.orgId, CHILD_ENROLLMENT_KEY_TTL_MINUTES);
 
     const [downloadKey] = await db
       .insert(enrollmentKeys)
@@ -2138,7 +2254,7 @@ publicShortLinkRoutes.get("/:code", async (c) => {
         key: tokenHash,
         keySecretHash: row.keySecretHash,
         maxUsage: 1,
-        expiresAt: freshChildExpiresAt(),
+        expiresAt: freshChildExpiresAt(cappedTtlMinutes),
         createdBy: null,
         installerPlatform: row.installerPlatform,
       })

--- a/apps/api/src/routes/enrollmentKeys_capClamp.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_capClamp.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Direct coverage for two exported helpers in `enrollmentKeys.ts` whose real
+ * implementations had NO prior test coverage — every existing test file that
+ * imports them (`sendDeploymentInvites.test.ts`, `aiGuardrails.bootstrapParity.test.ts`,
+ * `inviteLandingRoutes.test.ts`) mocks them away wholesale as black boxes.
+ * That gap is exactly how the fix-round-3 finding shipped: neither function
+ * had ever run its real TTL arithmetic under test.
+ *
+ * Fix round 3 (#2776): `maxEnrollmentLinkTtlMinutes` is a ceiling on KEY
+ * LIFETIME, not just interactively-chosen caller input. Both helpers here
+ * mint enrollment credentials from a server-constant/parameter default with
+ * no interactive caller to reject — so both must CLAMP (never reject) via
+ * `clampTtlToCap`.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  enrollmentKeys: {
+    id: 'enrollmentKeys.id',
+    orgId: 'enrollmentKeys.orgId',
+    siteId: 'enrollmentKeys.siteId',
+    shortCode: 'enrollmentKeys.shortCode',
+    name: 'enrollmentKeys.name',
+    key: 'enrollmentKeys.key',
+    keySecretHash: 'enrollmentKeys.keySecretHash',
+    maxUsage: 'enrollmentKeys.maxUsage',
+    usageCount: 'enrollmentKeys.usageCount',
+    expiresAt: 'enrollmentKeys.expiresAt',
+    createdAt: 'enrollmentKeys.createdAt',
+    createdBy: 'enrollmentKeys.createdBy',
+    installerPlatform: 'enrollmentKeys.installerPlatform',
+  },
+}));
+
+vi.mock('../db/schema/orgs', () => ({
+  sites: { id: 'sites.id', orgId: 'sites.orgId', createdAt: 'sites.createdAt' },
+  enrollmentKeys: {
+    id: 'enrollmentKeys.id',
+    orgId: 'enrollmentKeys.orgId',
+    siteId: 'enrollmentKeys.siteId',
+    shortCode: 'enrollmentKeys.shortCode',
+  },
+  organizations: { id: 'organizations.id', partnerId: 'organizations.partnerId', createdAt: 'organizations.createdAt' },
+}));
+
+vi.mock('../middleware/auth', () => ({
+  authMiddleware: vi.fn((_c: any, next: any) => next()),
+  requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  requireScope: vi.fn(() => async (_c: any, next: any) => next()),
+  requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
+}));
+
+vi.mock('../services/permissions', () => ({
+  PERMISSIONS: { ORGS_READ: { resource: 'orgs', action: 'read' }, ORGS_WRITE: { resource: 'orgs', action: 'write' } },
+}));
+
+vi.mock('../services/auditService', () => ({ createAuditLogAsync: vi.fn() }));
+
+vi.mock('../services/enrollmentKeySecurity', () => ({
+  hashEnrollmentKey: vi.fn((key: string) => `hashed:${key}`),
+  hashEnrollmentKeyCandidates: vi.fn((key: string) => [`hashed:${key}`]),
+}));
+
+vi.mock('../services/msiSigning', () => ({ MsiSigningService: { fromEnv: vi.fn(() => null) } }));
+
+vi.mock('../services/installerBuilder', () => ({
+  buildMacosInstallerZip: vi.fn(),
+  fetchRegularMsi: vi.fn(),
+  assertMacosInstallerPkgsReachable: vi.fn(),
+  fetchMacosInstallerAppZip: vi.fn(async () => null),
+  serveWindowsBootstrapMsi: vi.fn(),
+}));
+
+vi.mock('../services/installerAppZip', () => ({ renameAppInZip: vi.fn() }));
+
+vi.mock('../services/installerBootstrapTokenIssuance', () => ({
+  issueBootstrapTokenForKey: vi.fn(),
+  BootstrapTokenIssuanceError: class BootstrapTokenIssuanceError extends Error {
+    code: string;
+    constructor(code: string, msg: string) { super(msg); this.code = code; }
+  },
+}));
+
+vi.mock('../services/sentry', () => ({ captureException: vi.fn() }));
+
+// Partner-cap enforcement (#2776 fix round 3). Mocked at the wiring level —
+// see enrollmentKeys.test.ts's identically-named helper for rationale.
+const clampTtlToCapMock = vi.fn(
+  async (_orgId: string, ttlMinutes: number) => ttlMinutes,
+);
+vi.mock('../services/enrollmentDefaults', () => ({
+  clampTtlToCap: (...args: [string, number]) => clampTtlToCapMock(...args),
+}));
+
+import { db } from '../db';
+import { mintChildEnrollmentKey, redeemShortCode } from './enrollmentKeys';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const PARTNER_ID = '22222222-2222-4222-8222-222222222222';
+const SITE_ID = '33333333-3333-4333-8333-333333333333';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clampTtlToCapMock.mockReset();
+  clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) => ttlMinutes);
+});
+
+describe('mintChildEnrollmentKey (fix round 3, #2776)', () => {
+  /** Queue the allocateShortCode uniqueness probe (empty = code is free). */
+  function mockShortCodeProbe() {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+      }),
+    } as any);
+  }
+
+  function mockInsertCapture(): () => any {
+    let captured: any;
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn((v: any) => {
+        captured = v;
+        return { returning: vi.fn().mockResolvedValue([{ id: 'child-1', ...v }]) };
+      }),
+    } as any);
+    return () => captured;
+  }
+
+  it('clamps expiresInSeconds down when the partner cap is below it', async () => {
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 60), // partner cap: 60 minutes
+    );
+    mockShortCodeProbe();
+    const getInserted = mockInsertCapture();
+
+    const before = Date.now();
+    const result = await mintChildEnrollmentKey({
+      partnerId: PARTNER_ID,
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+      expiresInSeconds: 7 * 24 * 60 * 60, // 7 days — the real MCP tool's constant
+    });
+    const after = Date.now();
+
+    // Clamped to the 60-minute cap, NOT the requested 7 days.
+    expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+    expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
+    const inserted = getInserted();
+    expect(inserted.expiresAt.getTime()).toBe(result.expiresAt.getTime());
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 7 * 24 * 60); // seconds -> minutes
+  });
+
+  it('does not change the lifetime when the partner cap is above the requested value (no-op clamp)', async () => {
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 525_600), // generous partner cap
+    );
+    mockShortCodeProbe();
+    const getInserted = mockInsertCapture();
+
+    const before = Date.now();
+    const result = await mintChildEnrollmentKey({
+      partnerId: PARTNER_ID,
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+      expiresInSeconds: 7 * 24 * 60 * 60, // 7 days
+    });
+    const after = Date.now();
+
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + sevenDaysMs - 60_000);
+    expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + sevenDaysMs + 60_000);
+    expect(getInserted().expiresAt.getTime()).toBe(result.expiresAt.getTime());
+  });
+
+  it('clamps the CHILD_ENROLLMENT_KEY_TTL_MINUTES default down when expiresInSeconds is omitted', async () => {
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 60), // partner cap: 60 minutes
+    );
+    mockShortCodeProbe();
+    const getInserted = mockInsertCapture();
+
+    const before = Date.now();
+    const result = await mintChildEnrollmentKey({
+      partnerId: PARTNER_ID,
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+      // no expiresInSeconds — falls back to CHILD_ENROLLMENT_KEY_TTL_MINUTES (1440)
+    });
+    const after = Date.now();
+
+    expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+    expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
+    expect(getInserted().expiresAt.getTime()).toBe(result.expiresAt.getTime());
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+  });
+
+  // Fix round 4 (#2776): the seconds -> minutes conversion used Math.ceil, which
+  // rounds a sub-minute request UP and therefore LENGTHENS the key's lifetime
+  // (90s -> 120s) inside the very function that exists to bound it. Floor is the
+  // only fail-closed direction here.
+  it('rounds a sub-minute expiresInSeconds DOWN, never up (90s must not become 120s)', async () => {
+    mockShortCodeProbe();
+    const getInserted = mockInsertCapture();
+
+    const before = Date.now();
+    const result = await mintChildEnrollmentKey({
+      partnerId: PARTNER_ID,
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+      expiresInSeconds: 90,
+    });
+    const after = Date.now();
+
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1);
+    // 60s, not the 120s Math.ceil produced.
+    expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 60_000);
+    expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + 60_000);
+    expect(result.expiresAt.getTime()).toBeLessThan(before + 90_000);
+    expect(getInserted().expiresAt.getTime()).toBe(result.expiresAt.getTime());
+  });
+
+  it('floors a below-one-minute expiresInSeconds to 1 minute rather than minting an already-expired key', async () => {
+    mockShortCodeProbe();
+    const getInserted = mockInsertCapture();
+
+    const before = Date.now();
+    const result = await mintChildEnrollmentKey({
+      partnerId: PARTNER_ID,
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+      expiresInSeconds: 30,
+    });
+
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1);
+    expect(result.expiresAt.getTime()).toBeGreaterThan(before);
+    expect(getInserted().expiresAt.getTime()).toBe(result.expiresAt.getTime());
+  });
+});
+
+describe('redeemShortCode (fix round 3, #2776)', () => {
+  function mockParentLookup(overrides: Record<string, unknown> = {}) {
+    const parent = {
+      id: 'parent-1',
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+      name: 'Invite parent',
+      keySecretHash: null,
+      maxUsage: null,
+      usageCount: 0,
+      installerPlatform: 'windows',
+      expiresAt: new Date(Date.now() + 3_600_000),
+      ...overrides,
+    };
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([parent]) }),
+      }),
+    } as any);
+    return parent;
+  }
+
+  function mockChildInsertCapture(): () => any {
+    let captured: any;
+    vi.mocked(db.insert).mockReturnValueOnce({
+      values: vi.fn((v: any) => {
+        captured = v;
+        return { returning: vi.fn().mockResolvedValue([{ id: 'child-2', ...v }]) };
+      }),
+    } as any);
+    return () => captured;
+  }
+
+  function mockClaimSuccess() {
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'parent-1' }]) }),
+      }),
+    } as any);
+  }
+
+  it('clamps the invite child key TTL down when the partner cap is below the default', async () => {
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 60), // partner cap: 60 minutes
+    );
+    mockParentLookup();
+    const getInserted = mockChildInsertCapture();
+    mockClaimSuccess();
+
+    const before = Date.now();
+    const result = await redeemShortCode('abc123');
+    const after = Date.now();
+
+    expect(result).not.toBeNull();
+    const inserted = getInserted();
+    expect(inserted.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+    expect(inserted.expiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith(ORG_ID, 1440);
+  });
+
+  it('does not shorten the invite child key TTL when the partner cap is above the default (no-op clamp)', async () => {
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 525_600), // generous partner cap
+    );
+    mockParentLookup();
+    const getInserted = mockChildInsertCapture();
+    mockClaimSuccess();
+
+    const before = Date.now();
+    const result = await redeemShortCode('def456');
+    const after = Date.now();
+
+    expect(result).not.toBeNull();
+    const inserted = getInserted();
+    expect(inserted.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 1439 * 60 * 1000);
+    expect(inserted.expiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
+  });
+});

--- a/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
@@ -85,6 +85,34 @@ vi.mock('../services/rate-limit', () => ({
   rateLimiter: vi.fn(async () => ({ allowed: true, remaining: 10, resetAt: new Date() })),
 }));
 
+// Partner-cap enforcement (#2776 task 3.4, fix round 2). Mocked at the wiring
+// level — see enrollmentKeys.test.ts's identically-named helper for
+// rationale. Permissive by default so every pre-existing test in this file
+// (which predates the cap gate on rotate) keeps passing.
+const assertTtlWithinCapMock = vi.fn(
+  async (_orgId: string, _ttlMinutes: number | undefined) => null as string | null,
+);
+vi.mock('../services/enrollmentDefaults', () => ({
+  assertTtlWithinCap: (...args: [string, number | undefined]) =>
+    assertTtlWithinCapMock(...args),
+}));
+
+/**
+ * Configure the mocked partner-cap gate for the current test. Mirrors the
+ * real assertTtlWithinCap contract: null when ttlMinutes is undefined or at/
+ * under the cap, an error string naming the cap when it's exceeded.
+ */
+function mockEnrollmentDefaults(opts: { maxTtlMinutes: number }) {
+  assertTtlWithinCapMock.mockImplementation(
+    async (_orgId: string, ttlMinutes: number | undefined) => {
+      if (ttlMinutes === undefined) return null;
+      return ttlMinutes > opts.maxTtlMinutes
+        ? `ttlMinutes exceeds the partner maximum of ${opts.maxTtlMinutes} minutes`
+        : null;
+    },
+  );
+}
+
 import { enrollmentKeyRoutes } from './enrollmentKeys';
 import { db } from '../db';
 import { createAuditLogAsync } from '../services/auditService';
@@ -160,6 +188,10 @@ describe('enrollment key routes — get, rotate, delete', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // vi.clearAllMocks clears call history but NOT implementations — restore
+    // the permissive default every test (mirrors the other route suites).
+    assertTtlWithinCapMock.mockReset();
+    assertTtlWithinCapMock.mockImplementation(async () => null);
     mfaGate.deny = false;
     permissionGate.deny = false;
     app = new Hono();
@@ -269,6 +301,69 @@ describe('enrollment key routes — get, rotate, delete', () => {
       });
 
       expect(res.status).toBe(403);
+    });
+
+    // #2776 task 3.4 fix round 2 — a sixth uncapped path: rotate re-mints the
+    // key value via generateEnrollmentKey(), so an uncapped expiresAt here
+    // would let a caller bound by a short partner cap create a key at the
+    // cap and immediately rotate it past it. rotateEnrollmentKeySchema has
+    // no ttlMinutes field (verified: only `maxUsage` and `expiresAt`), so
+    // expiresAt is the only path to cover.
+    it('rejects an expiresAt whose implied duration exceeds the partner cap', async () => {
+      mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+      const updateSet = vi.fn();
+      vi.mocked(db.update).mockReturnValue({ set: updateSet } as any);
+
+      // 30 days out — far above a 1440-minute (24h) cap.
+      const expiresAt = new Date(Date.now() + 43200 * 60 * 1000).toISOString();
+
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/rotate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ expiresAt }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('1440');
+      expect(updateSet).not.toHaveBeenCalled();
+      // The route must derive an implied minutes value from expiresAt and
+      // check IT against the cap — there is no ttlMinutes field on this route.
+      const [, impliedMinutes] = assertTtlWithinCapMock.mock.calls[0]!;
+      expect(impliedMinutes).toBeGreaterThan(43199);
+      expect(impliedMinutes).toBeLessThanOrEqual(43201);
+    });
+
+    it('allows rotating with an expiresAt at or under the partner cap', async () => {
+      mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+      mockUpdateSetWhereReturning([makeEnrollmentKey({ key: 'hashed_newkey' })]);
+
+      // Exactly at the 1440-minute cap.
+      const expiresAt = new Date(Date.now() + 1440 * 60 * 1000).toISOString();
+
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/rotate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ expiresAt }),
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('does not consult the cap when expiresAt is omitted (preserves the existing key\'s own expiry, not a new choice)', async () => {
+      mockSelectFromWhereLimit([makeEnrollmentKey()]);
+      mockUpdateSetWhereReturning([makeEnrollmentKey({ key: 'hashed_newkey' })]);
+
+      const res = await app.request(`/enrollment-keys/${KEY_ID}/rotate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ maxUsage: 5 }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(assertTtlWithinCapMock).toHaveBeenCalledWith(ORG_ID, undefined);
     });
   });
 

--- a/apps/api/src/routes/enrollmentKeys_installer.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_installer.test.ts
@@ -110,6 +110,24 @@ vi.mock('../services/rate-limit', () => ({
   rateLimiter: vi.fn(async () => ({ allowed: true, remaining: 10, resetAt: new Date() })),
 }));
 
+// Partner-cap enforcement (#2776 task 3.4). Mocked at the wiring level — see
+// enrollmentKeys.test.ts's identically-named helper for rationale.
+const assertTtlWithinCapMock = vi.fn(
+  async (_orgId: string, _ttlMinutes: number | undefined) => null as string | null,
+);
+// clampTtlToCap — the CLAMP-shaped sibling. The child-key mint on this route
+// runs it on the CHILD_ENROLLMENT_KEY_TTL_MINUTES fallback, so it must be
+// present here or the route throws. Permissive default (returns ttlMinutes
+// unchanged) models "no partner cap configured".
+const clampTtlToCapMock = vi.fn(
+  async (_orgId: string, ttlMinutes: number) => ttlMinutes,
+);
+vi.mock('../services/enrollmentDefaults', () => ({
+  assertTtlWithinCap: (...args: [string, number | undefined]) =>
+    assertTtlWithinCapMock(...args),
+  clampTtlToCap: (...args: [string, number]) => clampTtlToCapMock(...args),
+}));
+
 import { enrollmentKeyRoutes } from './enrollmentKeys';
 import { db } from '../db';
 import { createAuditLogAsync } from '../services/auditService';
@@ -172,6 +190,25 @@ function mockDeleteWhere() {
   } as any);
 }
 
+/**
+ * Configure the mocked partner-cap gate for the current test. Mirrors the
+ * real assertTtlWithinCap contract: null when ttlMinutes is undefined or at/
+ * under the cap, an error string naming the cap when it's exceeded.
+ */
+function mockEnrollmentDefaults(opts: { maxTtlMinutes: number }) {
+  assertTtlWithinCapMock.mockImplementation(
+    async (_orgId: string, ttlMinutes: number | undefined) => {
+      if (ttlMinutes === undefined) return null;
+      return ttlMinutes > opts.maxTtlMinutes
+        ? `ttlMinutes exceeds the partner maximum of ${opts.maxTtlMinutes} minutes`
+        : null;
+    },
+  );
+  clampTtlToCapMock.mockImplementation(
+    async (_orgId: string, ttlMinutes: number) => Math.min(ttlMinutes, opts.maxTtlMinutes),
+  );
+}
+
 describe('enrollment key routes — installer download', () => {
   let app: Hono;
 
@@ -181,6 +218,14 @@ describe('enrollment key routes — installer download', () => {
     // that set mockReturnValue for fromEnv would otherwise leak into
     // subsequent tests. Explicitly reset fromEnv to "signing disabled".
     vi.mocked(MsiSigningService.fromEnv).mockReturnValue(null);
+    // Same reasoning for the partner-cap gate: reset to the permissive
+    // default every test unless a test opts into mockEnrollmentDefaults().
+    assertTtlWithinCapMock.mockReset();
+    assertTtlWithinCapMock.mockImplementation(async () => null);
+    clampTtlToCapMock.mockReset();
+    clampTtlToCapMock.mockImplementation(
+      async (_orgId: string, ttlMinutes: number) => ttlMinutes,
+    );
     // Default: Windows bootstrap token issuance succeeds.
     vi.mocked(issueBootstrapTokenForKey).mockResolvedValue({
       id: 'tok-1',
@@ -521,6 +566,42 @@ describe('enrollment key routes — installer download', () => {
         { method: 'GET', headers: { Authorization: 'Bearer token' } },
       );
       expect(res.status).toBe(400);
+    });
+
+    // #2776 task 3.4 — a value under the global 525_600 schema max can still
+    // exceed a lower PARTNER cap, which only the DB-backed assertTtlWithinCap
+    // gate (not the static zod schema) can enforce.
+    it('rejects a ttlMinutes above the partner cap (#2776)', async () => {
+      mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+      const parentKey = makeEnrollmentKey();
+      mockSelectFromWhereLimit([parentKey]);
+
+      const res = await app.request(
+        `/enrollment-keys/${KEY_ID}/installer/windows?ttlMinutes=43200`,
+        { method: 'GET', headers: { Authorization: 'Bearer token' } },
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('1440');
+      expect(assertTtlWithinCapMock).toHaveBeenCalledWith(ORG_ID, 43200);
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('allows a ttlMinutes at exactly the partner cap (#2776)', async () => {
+      mockEnrollmentDefaults({ maxTtlMinutes: 1440 });
+      const parentKey = makeEnrollmentKey();
+      mockSelectFromWhereLimit([parentKey]);
+      mockInsertValuesReturning([
+        makeEnrollmentKey({ id: 'child-key-id', name: 'Test Key (installer)', maxUsage: 1 }),
+      ]);
+
+      const res = await app.request(
+        `/enrollment-keys/${KEY_ID}/installer/macos?ttlMinutes=1440`,
+        { method: 'GET', headers: { Authorization: 'Bearer token' } },
+      );
+
+      expect(res.status).toBe(200);
     });
 
     // Query-param validation is enforced by the Hono zValidator middleware

--- a/apps/api/src/routes/enrollmentKeys_list_create.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_list_create.test.ts
@@ -70,6 +70,20 @@ vi.mock('../services/rate-limit', () => ({
   rateLimiter: vi.fn(async () => ({ allowed: true, remaining: 10, resetAt: new Date() })),
 }));
 
+// Partner-cap enforcement (#2776 task 3.4, fix round 1). Mocked at the wiring
+// level — see enrollmentKeys.test.ts's identically-named helper for
+// rationale. None of the tests in this file exercise a partner-configured
+// cap (that's covered in enrollmentKeys.test.ts's dedicated "partner cap
+// enforcement" describe block); this permissive default just keeps every
+// pre-existing test in this file — which predates the cap gate — passing.
+const assertTtlWithinCapMock = vi.fn(
+  async (_orgId: string, _ttlMinutes: number | undefined) => null as string | null,
+);
+vi.mock('../services/enrollmentDefaults', () => ({
+  assertTtlWithinCap: (...args: [string, number | undefined]) =>
+    assertTtlWithinCapMock(...args),
+}));
+
 import { enrollmentKeyRoutes } from './enrollmentKeys';
 import { db } from '../db';
 import { createAuditLogAsync } from '../services/auditService';
@@ -155,6 +169,10 @@ describe('enrollment key routes — list & create', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // vi.clearAllMocks clears call history but NOT implementations — restore
+    // the permissive default every test (mirrors the other route suites).
+    assertTtlWithinCapMock.mockReset();
+    assertTtlWithinCapMock.mockImplementation(async () => null);
     app = new Hono();
     app.route('/enrollment-keys', enrollmentKeyRoutes);
   });

--- a/apps/api/src/routes/installer.test.ts
+++ b/apps/api/src/routes/installer.test.ts
@@ -19,6 +19,19 @@ vi.mock("../services/enrollmentKeySecurity", () => ({
   hashEnrollmentKeyCandidates: vi.fn((k: string) => [`hashed:${k}`]),
 }));
 
+// Partner-cap enforcement (#2776 fix round 3). Mocked at the wiring level —
+// see enrollmentKeys.test.ts's identically-named-pattern helper for
+// rationale. Permissive default (returns ttlMinutes unchanged) models "no
+// partner cap configured", so every pre-existing test in this file (which
+// predates the cap clamp) keeps passing without needing to stage an extra
+// db.select call for the org⋈partner join.
+const clampTtlToCapMock = vi.fn(
+  async (_orgId: string, ttlMinutes: number) => ttlMinutes,
+);
+vi.mock("../services/enrollmentDefaults", () => ({
+  clampTtlToCap: (...args: [string, number]) => clampTtlToCapMock(...args),
+}));
+
 // ============================================================
 // Imports after mocks
 // ============================================================
@@ -35,6 +48,10 @@ function makeApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // vi.clearAllMocks clears call history but NOT implementations — restore
+  // the permissive default every test.
+  clampTtlToCapMock.mockReset();
+  clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) => ttlMinutes);
   delete process.env.MACOS_INSTALLER_ALLOW_LEGACY_GET_BOOTSTRAP;
   delete process.env.AGENT_BACKUP_SERVER_URL;
 });
@@ -315,6 +332,164 @@ describe("POST /api/v1/installer/bootstrap", () => {
     expect(childExpiresAt.getTime()).toBeGreaterThan(
       parentKey.expiresAt.getTime(),
     );
+  });
+
+  // Fix round 3 (#2776): this is the hottest of all the redemption paths —
+  // every device enrollment goes through it — and it uses the
+  // CHILD_ENROLLMENT_KEY_TTL_MINUTES server-constant default with no
+  // interactive caller (the token IS the auth), so a partner cap below the
+  // default must CLAMP the minted child's lifetime down, never reject.
+  it("clamps the child key TTL down when the partner cap is below the CHILD_ENROLLMENT_KEY_TTL_MINUTES default", async () => {
+    const tokenRow = {
+      id: "t-cap-low", token: "FFFFFFFFFF", orgId: "o-cap", parentEnrollmentKeyId: "pk-cap",
+      siteId: "s-cap", maxUsage: 1, consumedCount: 0, createdBy: "u1", consumedAt: null,
+      expiresAt: new Date(Date.now() + 7 * 24 * 3600_000),
+    };
+    const parentKey = {
+      id: "pk-cap", name: "Cap parent", orgId: "o-cap", siteId: "s-cap",
+      keySecretHash: null, expiresAt: new Date(Date.now() + 3600_000),
+    };
+    const org = { id: "o-cap", name: "Cap Org" };
+
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 60), // partner cap: 60 minutes
+    );
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([tokenRow]) }) }) } as any)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([parentKey]) }) }) } as any)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([org]) }) }) } as any);
+
+    let capturedChildKeyValues: Record<string, unknown> | null = null;
+    vi.mocked(db.insert).mockReturnValue({
+      values: (vals: Record<string, unknown>) => {
+        capturedChildKeyValues = vals;
+        return { returning: () => Promise.resolve([{ id: "ck-cap-low", orgId: "o-cap", siteId: "s-cap" }]) };
+      },
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: () => ({ where: () => ({ returning: () => Promise.resolve([{ ...tokenRow, consumedAt: new Date() }]) }) }),
+    } as any);
+
+    const before = Date.now();
+    const app = makeApp();
+    const res = await app.request("/api/v1/installer/bootstrap", {
+      method: "POST",
+      headers: { "X-Breeze-Bootstrap-Token": "FFFFFFFFFF" },
+    });
+    const after = Date.now();
+
+    expect(res.status).toBe(200);
+    expect(capturedChildKeyValues).not.toBeNull();
+    const childExpiresAt = (capturedChildKeyValues as unknown as { expiresAt: Date }).expiresAt;
+    // Clamped to the 60-minute cap, NOT the 1440-minute (24h) default.
+    expect(childExpiresAt.getTime()).toBeGreaterThanOrEqual(before + 59 * 60 * 1000);
+    expect(childExpiresAt.getTime()).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 5_000);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith("o-cap", 1440);
+  });
+
+  it("does not shorten the child key TTL when the partner cap is above the CHILD_ENROLLMENT_KEY_TTL_MINUTES default (no-op clamp)", async () => {
+    const tokenRow = {
+      id: "t-cap-high", token: "GGGGGGGGGG", orgId: "o-cap2", parentEnrollmentKeyId: "pk-cap2",
+      siteId: "s-cap2", maxUsage: 1, consumedCount: 0, createdBy: "u1", consumedAt: null,
+      expiresAt: new Date(Date.now() + 7 * 24 * 3600_000),
+    };
+    const parentKey = {
+      id: "pk-cap2", name: "Cap2 parent", orgId: "o-cap2", siteId: "s-cap2",
+      keySecretHash: null, expiresAt: new Date(Date.now() + 3600_000),
+    };
+    const org = { id: "o-cap2", name: "Cap2 Org" };
+
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 525_600), // generous partner cap
+    );
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([tokenRow]) }) }) } as any)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([parentKey]) }) }) } as any)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([org]) }) }) } as any);
+
+    let capturedChildKeyValues: Record<string, unknown> | null = null;
+    vi.mocked(db.insert).mockReturnValue({
+      values: (vals: Record<string, unknown>) => {
+        capturedChildKeyValues = vals;
+        return { returning: () => Promise.resolve([{ id: "ck-cap-high", orgId: "o-cap2", siteId: "s-cap2" }]) };
+      },
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: () => ({ where: () => ({ returning: () => Promise.resolve([{ ...tokenRow, consumedAt: new Date() }]) }) }),
+    } as any);
+
+    const before = Date.now();
+    const app = makeApp();
+    const res = await app.request("/api/v1/installer/bootstrap", {
+      method: "POST",
+      headers: { "X-Breeze-Bootstrap-Token": "GGGGGGGGGG" },
+    });
+    const after = Date.now();
+
+    expect(res.status).toBe(200);
+    expect(capturedChildKeyValues).not.toBeNull();
+    const childExpiresAt = (capturedChildKeyValues as unknown as { expiresAt: Date }).expiresAt;
+    // Unchanged: still the full 1440-minute (24h) default.
+    expect(childExpiresAt.getTime()).toBeGreaterThanOrEqual(before + 1439 * 60 * 1000);
+    expect(childExpiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
+  });
+
+  // #2776 regression. docker-compose threads CHILD_ENROLLMENT_KEY_TTL_MINUTES
+  // in as `${CHILD_ENROLLMENT_KEY_TTL_MINUTES:-}`, which `docker compose
+  // config` renders as `VAR: ""` when the operator hasn't set it — the
+  // container sees it SET to an empty string, not absent. The old
+  // `Number(process.env.X ?? 24 * 60)` read yielded 0 there (`??` doesn't fire
+  // on '', Number('') === 0), so every redeemed child enrollment key was born
+  // already expired and agent enrollment stopped working entirely on upgrade.
+  it("an EMPTY CHILD_ENROLLMENT_KEY_TTL_MINUTES falls back to 24h, not 0 (#2776)", async () => {
+    vi.stubEnv("CHILD_ENROLLMENT_KEY_TTL_MINUTES", "");
+    process.env.PUBLIC_API_URL = "https://us.2breeze.app";
+
+    const tokenRow = {
+      id: "t-empty-env", token: "HHHHHHHHHH", orgId: "o-env", parentEnrollmentKeyId: "pk-env",
+      siteId: "s-env", maxUsage: 1, consumedCount: 0, createdBy: "u1", consumedAt: null,
+      expiresAt: new Date(Date.now() + 7 * 24 * 3600_000),
+    };
+    const parentKey = {
+      id: "pk-env", name: "Env parent", orgId: "o-env", siteId: "s-env",
+      keySecretHash: null, expiresAt: new Date(Date.now() + 3600_000),
+    };
+    const org = { id: "o-env", name: "Env Org" };
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([tokenRow]) }) }) } as any)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([parentKey]) }) }) } as any)
+      .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([org]) }) }) } as any);
+
+    let capturedChildKeyValues: Record<string, unknown> | null = null;
+    vi.mocked(db.insert).mockReturnValue({
+      values: (vals: Record<string, unknown>) => {
+        capturedChildKeyValues = vals;
+        return { returning: () => Promise.resolve([{ id: "ck-env", orgId: "o-env", siteId: "s-env" }]) };
+      },
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: () => ({ where: () => ({ returning: () => Promise.resolve([{ ...tokenRow, consumedAt: new Date() }]) }) }),
+    } as any);
+
+    const before = Date.now();
+    const res = await makeApp().request("/api/v1/installer/bootstrap", {
+      method: "POST",
+      headers: { "X-Breeze-Bootstrap-Token": "HHHHHHHHHH" },
+    });
+    const after = Date.now();
+
+    expect(res.status).toBe(200);
+    // The value handed to the cap clamp is the 24h default, never 0.
+    expect(clampTtlToCapMock).toHaveBeenCalledWith("o-env", 1440);
+    const childExpiresAt = (capturedChildKeyValues as unknown as { expiresAt: Date }).expiresAt;
+    expect(childExpiresAt.getTime()).toBeGreaterThan(after);
+    expect(childExpiresAt.getTime()).toBeGreaterThanOrEqual(before + 1439 * 60 * 1000);
+    expect(childExpiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
+
+    vi.unstubAllEnvs();
   });
 
   it("partially-consumed multi-use token still redeems and mints a single-use child key", async () => {

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -7,13 +7,30 @@ import { enrollmentKeys, organizations } from "../db/schema/orgs";
 import { hashEnrollmentKey } from "../services/enrollmentKeySecurity";
 import { BOOTSTRAP_TOKEN_PATTERN } from "../services/installerBootstrapToken";
 import { getTrustedClientIp } from "../services/clientIp";
-
-const CHILD_TTL_MIN = Number(
-  process.env.CHILD_ENROLLMENT_KEY_TTL_MINUTES ?? 24 * 60,
-);
+import { clampTtlToCap } from "../services/enrollmentDefaults";
+import { envInt } from "../utils/envInt";
 
 /**
- * Returns the child enrollment key expiry: now + CHILD_TTL_MIN.
+ * Base lifetime for a child enrollment key minted at redemption, in minutes.
+ *
+ * Read via `envInt`, never `Number(process.env.X ?? default)`: compose threads
+ * this in as `${CHILD_ENROLLMENT_KEY_TTL_MINUTES:-}`, which renders as the
+ * empty STRING when the operator hasn't set it. `??` doesn't fire on `''` and
+ * `Number('') === 0`, so the naive form made every redeemed child enrollment
+ * key expire the instant it was minted — agent enrollment stopped working
+ * entirely on any self-host that pulled the release without adding the key to
+ * its .env (#2776).
+ *
+ * Resolved per call rather than at module load so the fallback is directly
+ * testable; the env is fixed at boot in production, so this is the same value
+ * every time.
+ */
+export function childEnrollmentKeyTtlMinutes(): number {
+  return envInt("CHILD_ENROLLMENT_KEY_TTL_MINUTES", 24 * 60);
+}
+
+/**
+ * Returns the child enrollment key expiry: now + childEnrollmentKeyTtlMinutes().
  *
  * The parent's expiry is deliberately NOT an upper bound. The parent created
  * by the Add Device modal is a transient 60-minute container (PR #739 review
@@ -33,9 +50,15 @@ const CHILD_TTL_MIN = Number(
  * that job before its own expiry (or full consumption). If you're reading
  * this because you found that job and are wondering whether it re-clamps
  * this TTL, it doesn't — see its header comment for the exemption predicate.
+ *
+ * `ttlMinutes`, when supplied, overrides the env default — used to pass an
+ * already partner-cap-clamped value (fix round 3, #2776; see the call site
+ * below) without duplicating the "now + minutes" arithmetic.
  */
-function freshChildExpiresAt(): Date {
-  return new Date(Date.now() + CHILD_TTL_MIN * 60 * 1000);
+function freshChildExpiresAt(
+  ttlMinutes: number = childEnrollmentKeyTtlMinutes(),
+): Date {
+  return new Date(Date.now() + ttlMinutes * 60 * 1000);
 }
 
 function generateChildEnrollmentKey(): string {
@@ -148,7 +171,18 @@ async function redeemBootstrapToken(c: Context, token: string) {
       return null;
     }
 
-    const childExpiresAt = freshChildExpiresAt();
+    // Clamp (never reject — this is the device-enrollment redemption path;
+    // the token IS the auth, there is no interactive caller to show an
+    // error to) the child's default TTL to the partner cap (fix round 3,
+    // #2776): the cap bounds KEY LIFETIME, not just interactively-chosen
+    // input, so this hot path must not hand out a child key longer-lived
+    // than the partner allows just because it uses the server-constant
+    // default.
+    const cappedTtlMinutes = await clampTtlToCap(
+      row.orgId,
+      childEnrollmentKeyTtlMinutes(),
+    );
+    const childExpiresAt = freshChildExpiresAt(cappedTtlMinutes);
 
     // ── 3. INSERT child key BEFORE recording the redemption (C1 reorder) ──
     // If the consume UPDATE loses a race, we'll DELETE this row below.

--- a/apps/api/src/services/enrollmentDefaults.test.ts
+++ b/apps/api/src/services/enrollmentDefaults.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Tests for getEnrollmentDefaultsForOrg — the DB read that resolves the
+ * effective enrollment link defaults (TTL, device count, TTL cap) for an org
+ * against its partner in a single org⋈partner join (issue #2776).
+ *
+ * Mirrors the mock harness in helpers.agentUpdatePolicy.test.ts: a single-call
+ * db.select chain queue, since the resolver here issues exactly one joined
+ * SELECT. Real schema module is left unmocked (no import-time side effects);
+ * only `../db` needs mocking, since it opens a real Postgres connection at
+ * module load.
+ *
+ * IMPORTANT LIMITATION (fix round 1, #2776): a mocked-DB unit test CANNOT
+ * prove that an org-scoped caller actually sees the partner's cap — that
+ * requires real Postgres RLS to deny/allow the `partners` row, which no mock
+ * can emulate. These tests only prove the WIRING: that the read runs via
+ * runOutsideDbContext(withSystemDbAccessContext(...)) rather than directly
+ * against whatever context is already ambient. The behavioral proof against
+ * a real org-scoped RLS context lives in the integration test:
+ * apps/api/src/__tests__/integration/enrollmentDefaultsPartnerCap.integration.test.ts
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  dbMock,
+  runOutsideDbContextMock,
+  withSystemDbAccessContextMock,
+  getCurrentDbAccessContextMock,
+} = vi.hoisted(() => {
+  let nextResult: unknown[] = [];
+
+  const makeSelectChain = () => {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(nextResult)),
+    };
+    chain.then = (resolve: any, reject: any) => Promise.resolve(nextResult).then(resolve, reject);
+    return chain;
+  };
+
+  const dbMock = {
+    select: vi.fn(() => makeSelectChain()),
+    _setResult(rows: unknown[]) {
+      nextResult = rows;
+    },
+  };
+
+  // Pass-through mocks that still let assertions verify they were invoked —
+  // real behavior (exiting the ALS context, setting RLS GUCs) can't be
+  // exercised without a real DB; see the integration test for that proof.
+  const runOutsideDbContextMock = vi.fn((fn: () => unknown) => fn());
+  const withSystemDbAccessContextMock = vi.fn((fn: () => unknown) => fn());
+  // Ambient DbAccessContext metadata. Default: no context at all (background /
+  // contextless caller), which must take the escape just like an org-scoped one.
+  const getCurrentDbAccessContextMock = vi.fn((): unknown => undefined);
+
+  return {
+    dbMock,
+    runOutsideDbContextMock,
+    withSystemDbAccessContextMock,
+    getCurrentDbAccessContextMock,
+  };
+});
+
+vi.mock('../db', () => ({
+  db: dbMock,
+  runOutsideDbContext: runOutsideDbContextMock,
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
+  getCurrentDbAccessContext: getCurrentDbAccessContextMock,
+}));
+
+import { getEnrollmentDefaultsForOrg, assertTtlWithinCap, clampTtlToCap } from './enrollmentDefaults';
+
+const ORG_ID = '00000000-0000-4000-8000-000000000001';
+
+/** Stand-in for the metadata AsyncLocalStorage store of an active context. */
+function ambientContext(scope: 'system' | 'partner' | 'organization'): unknown {
+  return {
+    scope,
+    orgId: scope === 'organization' ? ORG_ID : null,
+    accessibleOrgIds: scope === 'organization' ? [ORG_ID] : null,
+    accessiblePartnerIds: scope === 'system' ? null : [],
+    userId: null,
+  };
+}
+
+/** Restores the permissive pass-through defaults after vi.clearAllMocks(). */
+function resetDbContextMocks(): void {
+  runOutsideDbContextMock.mockImplementation((fn: () => unknown) => fn());
+  withSystemDbAccessContextMock.mockImplementation((fn: () => unknown) => fn());
+  getCurrentDbAccessContextMock.mockImplementation(() => undefined);
+}
+
+/** Seed the single org⋈partner join row that the resolver reads. */
+function mockJoinRow(opts: { orgSettings?: unknown; partnerSettings?: unknown } = {}): void {
+  dbMock._setResult([
+    { orgSettings: opts.orgSettings ?? null, partnerSettings: opts.partnerSettings ?? null },
+  ]);
+}
+
+describe('getEnrollmentDefaultsForOrg', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbContextMocks();
+  });
+
+  // Fix round 1 (#2776): the partner-axis join must run in a system context,
+  // exited from any ambient request context first — otherwise an org-scoped
+  // caller's empty accessible_partner_ids makes `partners` invisible under
+  // RLS and the cap silently evaporates. This proves the WIRING only (both
+  // helpers are mocked pass-throughs here); the real RLS behavior is proven
+  // against Postgres in the integration test referenced at the top of this file.
+  it('reads the org⋈partner join via runOutsideDbContext(withSystemDbAccessContext(...))', async () => {
+    mockJoinRow({});
+    await getEnrollmentDefaultsForOrg(ORG_ID);
+    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Fix round 4 (#2776) — AVAILABILITY. withDbAccessContext opens a real
+  // transaction, so it pins one pooled connection for its whole callback;
+  // runOutsideDbContext exits the ALS store, so the nested system context does
+  // NOT nest — it takes a SECOND connection while the first is still held. On
+  // paths already inside a system context (POST /installer/bootstrap, /s/:code,
+  // /public-download) that double-hold is pure downside: `partners` is already
+  // visible. At N concurrent requests >= DB_POOL_MAX every connection is held
+  // by a request queued for one only a peer can release, and postgres-js has no
+  // acquire timeout — the API stalls indefinitely.
+  //
+  // These assert the MECHANISM (which context helpers ran), not just the
+  // returned number: the two code paths are indistinguishable by value alone.
+  describe('ambient-context branch', () => {
+    it('reads in the AMBIENT context — opening no second context — when the caller is already system-scoped', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => ambientContext('system'));
+      mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+
+      const r = await getEnrollmentDefaultsForOrg(ORG_ID);
+
+      // Same cap resolved...
+      expect(r.maxTtlMinutes).toBe(1440);
+      // ...via exactly one SELECT on the connection the caller already holds.
+      expect(dbMock.select).toHaveBeenCalledTimes(1);
+      expect(runOutsideDbContextMock).not.toHaveBeenCalled();
+      expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
+    });
+
+    it('still escapes to a fresh system context for an ORG-scoped caller (the round-1 RLS fix must not regress)', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => ambientContext('organization'));
+      mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+
+      const r = await getEnrollmentDefaultsForOrg(ORG_ID);
+
+      expect(r.maxTtlMinutes).toBe(1440);
+      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+      expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('still escapes for a PARTNER-scoped caller (partner scope sees only its OWN partner row, not an arbitrary org’s)', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => ambientContext('partner'));
+      mockJoinRow({});
+
+      await getEnrollmentDefaultsForOrg(ORG_ID);
+
+      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+      expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('still escapes when there is no ambient context at all (background/worker caller)', async () => {
+      getCurrentDbAccessContextMock.mockImplementation(() => undefined);
+      mockJoinRow({});
+
+      await getEnrollmentDefaultsForOrg(ORG_ID);
+
+      expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+      expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('resolves org-over-partner for the TTL default', async () => {
+    mockJoinRow({
+      orgSettings: { defaults: { defaultEnrollmentTtlMinutes: 60 } },
+      partnerSettings: { defaults: { defaultEnrollmentTtlMinutes: 10080 } },
+    });
+    const r = await getEnrollmentDefaultsForOrg(ORG_ID);
+    expect(r.ttlMinutes).toBe(60);
+  });
+
+  it('inherits the partner TTL default when the org has not set one', async () => {
+    mockJoinRow({
+      orgSettings: { defaults: {} },
+      partnerSettings: { defaults: { defaultEnrollmentTtlMinutes: 10080 } },
+    });
+    const r = await getEnrollmentDefaultsForOrg(ORG_ID);
+    expect(r.ttlMinutes).toBe(10080);
+  });
+
+  it('ignores an org attempt to raise the partner cap', async () => {
+    mockJoinRow({
+      orgSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 525600 } },
+      partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } },
+    });
+    const r = await getEnrollmentDefaultsForOrg(ORG_ID);
+    expect(r.maxTtlMinutes).toBe(1440);
+  });
+
+  it('falls back to product defaults when neither org nor partner has settings', async () => {
+    mockJoinRow({});
+    const r = await getEnrollmentDefaultsForOrg(ORG_ID);
+    expect(r).toEqual({ ttlMinutes: 1440, deviceCount: 1, maxTtlMinutes: 525600 });
+  });
+
+  it('falls back to org-local values when there is no partner row (LEFT JOIN null)', async () => {
+    mockJoinRow({
+      orgSettings: { defaults: { defaultEnrollmentTtlMinutes: 60, defaultEnrollmentDeviceCount: 5 } },
+      partnerSettings: null,
+    });
+    const r = await getEnrollmentDefaultsForOrg(ORG_ID);
+    expect(r).toEqual({ ttlMinutes: 60, deviceCount: 5, maxTtlMinutes: 525600 });
+  });
+
+  it('propagates a DB error rather than swallowing it', async () => {
+    dbMock.select.mockImplementationOnce(() => {
+      throw new Error('db down');
+    });
+    await expect(getEnrollmentDefaultsForOrg(ORG_ID)).rejects.toThrow('db down');
+  });
+});
+
+describe('assertTtlWithinCap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbContextMocks();
+  });
+
+  it('returns null (no violation) when ttlMinutes is undefined — an omitted TTL is not a chosen value to reject', async () => {
+    const err = await assertTtlWithinCap(ORG_ID, undefined);
+    expect(err).toBeNull();
+    // Must not even consult the resolver for an absent value.
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects an explicit ttlMinutes above the partner cap, naming the cap', async () => {
+    mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+    const err = await assertTtlWithinCap(ORG_ID, 43200);
+    expect(err).toBe('ttlMinutes exceeds the partner maximum of 1440 minutes');
+  });
+
+  it('allows an explicit ttlMinutes exactly at the cap', async () => {
+    mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+    const err = await assertTtlWithinCap(ORG_ID, 1440);
+    expect(err).toBeNull();
+  });
+
+  it('allows an explicit ttlMinutes under the product-default cap when the partner sets none', async () => {
+    mockJoinRow({});
+    const err = await assertTtlWithinCap(ORG_ID, 129600);
+    expect(err).toBeNull();
+  });
+});
+
+/**
+ * Direct coverage for clampTtlToCap (fix round 4, #2776). Until now every test
+ * that touched it mocked it away, so its own arithmetic — and its "always
+ * returns a number, never rejects" contract — had never actually run under
+ * test. It is the enforcement point for every non-interactive path (device
+ * enrollment redemption, public downloads, MCP invites), so a silent inversion
+ * here would uncap those paths with nothing to catch it.
+ */
+describe('clampTtlToCap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbContextMocks();
+  });
+
+  it('clamps a TTL above the partner cap down to the cap', async () => {
+    mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+    await expect(clampTtlToCap(ORG_ID, 43200)).resolves.toBe(1440);
+  });
+
+  it('leaves a TTL below the cap untouched', async () => {
+    mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+    await expect(clampTtlToCap(ORG_ID, 60)).resolves.toBe(60);
+  });
+
+  it('is a no-op at exactly the cap (boundary is inclusive, matching assertTtlWithinCap)', async () => {
+    mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+    await expect(clampTtlToCap(ORG_ID, 1440)).resolves.toBe(1440);
+  });
+
+  it('falls back to the product-default cap when no partner cap is configured', async () => {
+    mockJoinRow({});
+    await expect(clampTtlToCap(ORG_ID, 129600)).resolves.toBe(129600);
+    mockJoinRow({});
+    await expect(clampTtlToCap(ORG_ID, 999999)).resolves.toBe(525600);
+  });
+
+  it('ignores an org attempt to raise the partner cap', async () => {
+    mockJoinRow({
+      orgSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 525600 } },
+      partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } },
+    });
+    await expect(clampTtlToCap(ORG_ID, 43200)).resolves.toBe(1440);
+  });
+
+  it('returns a number (never throws / never rejects) for an over-cap value — clamp, not reject', async () => {
+    mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 60 } } });
+    const result = await clampTtlToCap(ORG_ID, 525600);
+    expect(typeof result).toBe('number');
+    expect(result).toBe(60);
+  });
+
+  it('resolves the SAME cap regardless of the ambient DB access context', async () => {
+    // The value must not depend on who is asking — only the plumbing used to
+    // read it does (ambient read under system scope, escape otherwise). A
+    // regression that made the cap context-dependent is exactly the round-1
+    // Critical (org-scoped callers silently seeing the permissive global max).
+    const results: number[] = [];
+    for (const scope of ['system', 'partner', 'organization'] as const) {
+      getCurrentDbAccessContextMock.mockImplementation(() => ambientContext(scope));
+      mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+      results.push(await clampTtlToCap(ORG_ID, 43200));
+    }
+    getCurrentDbAccessContextMock.mockImplementation(() => undefined);
+    mockJoinRow({ partnerSettings: { defaults: { maxEnrollmentLinkTtlMinutes: 1440 } } });
+    results.push(await clampTtlToCap(ORG_ID, 43200));
+
+    expect(results).toEqual([1440, 1440, 1440, 1440]);
+  });
+});

--- a/apps/api/src/services/enrollmentDefaults.ts
+++ b/apps/api/src/services/enrollmentDefaults.ts
@@ -1,0 +1,148 @@
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../db';
+import { organizations, partners } from '../db/schema/orgs';
+import { resolveEnrollmentDefaults, type ResolvedEnrollmentDefaults } from '@breeze/shared';
+
+/** Pulls `settings.defaults` out of a JSONB settings blob, tolerating any shape. */
+function extractSettingsDefaults(settings: unknown): Record<string, unknown> {
+  if (!settings || typeof settings !== 'object') return {};
+  const defaults = (settings as Record<string, unknown>).defaults;
+  return defaults && typeof defaults === 'object' ? (defaults as Record<string, unknown>) : {};
+}
+
+/**
+ * Resolve the effective enrollment link defaults (TTL, device count, TTL cap)
+ * for an org, joined against its partner in a single query.
+ *
+ * Deliberately does NOT go through getEffectiveOrgSettings: that service's
+ * mergeCategory makes partner fields win unconditionally and locks them, which
+ * is the correct model for most settings but wrong for these two
+ * inherit-with-override values (org wins when set, partner fills the gap) plus
+ * one partner-only cap. Same reason getOrgAgentUpdateConfig
+ * (apps/api/src/routes/agents/helpers.ts) exists as its own resolver instead of
+ * routing through the generic merge.
+ *
+ * Read in a SYSTEM context, exited from any ambient request context first
+ * (fix round 1, #2776): `partners`' SELECT policy is
+ * `breeze_has_partner_access(id)`, and `computeAccessiblePartnerIds` returns
+ * `[]` for an org-scoped caller (apps/api/src/middleware/auth.ts) — the exact
+ * scope every route calling this (via assertTtlWithinCap) runs under. Under
+ * the request's own RLS context the `partners` leftJoin would silently return
+ * null, `maxTtlMinutes` would fall back to the permissive global default, and
+ * the cap would be inert for precisely the population it exists to bind.
+ * `withSystemDbAccessContext` alone is not enough here: inside an active
+ * request context it is a no-op that inherits the caller's scope, so
+ * `runOutsideDbContext` must exit that context first (same pattern as
+ * `resolveQuoteTaxRate` in quoteService.ts and `readPartnerAllowlist`'s
+ * caller in ipAllowlist.ts). The lookup stays keyed on the caller-supplied
+ * `orgId` alone — escaping RLS here widens visibility of settings columns,
+ * not which org's row can be selected.
+ *
+ * AVAILABILITY (fix round 4, #2776): that escape is taken ONLY when it is
+ * actually needed. `withDbAccessContext` opens a real `baseDb.transaction`
+ * (db/index.ts), so it pins one pooled connection for the whole callback, and
+ * `runOutsideDbContext` exits the AsyncLocalStorage store — meaning the nested
+ * `withSystemDbAccessContext` does NOT nest, it opens a SECOND transaction on a
+ * SECOND pooled connection while the first is still held. Every caller that is
+ * already inside a system context (POST /installer/bootstrap, GET /s/:code,
+ * GET /public-download/:platform, every redemption path) would therefore
+ * double-hold connections for no benefit: `partners` is fully visible in a
+ * system context already. At N concurrent enrollments >= DB_POOL_MAX every
+ * connection ends up held by a request queued for a connection only a peer can
+ * release, and postgres-js has no acquire timeout (`connect_timeout` governs TCP
+ * connect, not queue wait) — so the API stalls indefinitely, not just slowly. A
+ * few hundred agents deployed from one installer link reaches that trivially.
+ * When the ambient context is already system-scoped we therefore read in it;
+ * only org/partner-scoped (and contextless) callers pay the extra connection,
+ * and for them it is mandatory, not optional.
+ */
+export async function getEnrollmentDefaultsForOrg(orgId: string): Promise<ResolvedEnrollmentDefaults> {
+  // LEFT JOIN so a missing partner (shouldn't happen) still returns the org row
+  // and falls back to org-local settings rather than dropping the whole lookup.
+  const readJoin = () =>
+    db
+      .select({ orgSettings: organizations.settings, partnerSettings: partners.settings })
+      .from(organizations)
+      .leftJoin(partners, eq(partners.id, organizations.partnerId))
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+  // `getCurrentDbAccessContext()` reflects the GUCs actually SET LOCAL on the
+  // held transaction: withDbAccessContext is a no-op when a context is already
+  // active (it neither reopens a transaction nor re-sets the metadata), so a
+  // reported scope of 'system' means the session really is running with
+  // breeze.scope = 'system' and `breeze_has_partner_access` short-circuits true.
+  // Anything else — including no context at all — takes the escape.
+  const ambientScope = getCurrentDbAccessContext()?.scope;
+  const rows = ambientScope === 'system'
+    ? await readJoin()
+    : await runOutsideDbContext(() => withSystemDbAccessContext(readJoin));
+  const [row] = rows;
+
+  const orgDefaults = extractSettingsDefaults(row?.orgSettings);
+  const partnerDefaults = extractSettingsDefaults(row?.partnerSettings);
+
+  return resolveEnrollmentDefaults(partnerDefaults, orgDefaults);
+}
+
+/**
+ * Reject — never clamp — an explicitly-requested TTL above the partner
+ * ceiling. Silently reducing a chosen expiry is precisely the failure mode
+ * of #2775; a 400 that names the cap is the only honest response.
+ *
+ * Returns null (no violation) when `ttlMinutes` is undefined: an omitted TTL
+ * falls back to the resolved default, and `resolveEnrollmentDefaults` already
+ * clamps that default to the cap, so there is nothing to reject here — that
+ * case is a different bypass (a stale/lock-exempt org default landing above
+ * the cap), closed at the resolver, not at this gate.
+ *
+ * Shared across every route that mints an enrollment link / bootstrap token
+ * with a caller-supplied ttlMinutes (enrollmentKeys.ts, devices/core.ts) so
+ * the cap can't be bypassed by a route that forgets to call it independently.
+ */
+export async function assertTtlWithinCap(
+  orgId: string,
+  ttlMinutes: number | undefined,
+): Promise<string | null> {
+  if (ttlMinutes === undefined) return null;
+  const { maxTtlMinutes } = await getEnrollmentDefaultsForOrg(orgId);
+  if (ttlMinutes > maxTtlMinutes) {
+    return `ttlMinutes exceeds the partner maximum of ${maxTtlMinutes} minutes`;
+  }
+  return null;
+}
+
+/**
+ * Clamp — never reject — a TTL to the partner ceiling.
+ *
+ * Fix round 3 ruling (#2776): `maxEnrollmentLinkTtlMinutes` is a ceiling on
+ * KEY LIFETIME, not merely on interactively-chosen caller input. A partner
+ * setting a 60-minute cap means nothing minted under them should be usable
+ * longer than 60 minutes — including redemption/download/background paths
+ * whose TTL comes from a server constant (e.g. `CHILD_ENROLLMENT_KEY_TTL_MINUTES`,
+ * `bootstrapTokenExpiresAt()`'s 24h base) rather than a value a human typed
+ * into a form for this specific request.
+ *
+ * Use this — not `assertTtlWithinCap` — on exactly those paths: there is no
+ * interactive caller to show a 400 to (public/unauthenticated downloads,
+ * device-enrollment redemption, internal helper defaults), and silently
+ * reducing a value NOBODY chose for this request is not the silent-discard
+ * defect `assertTtlWithinCap` guards against — that defect is specifically
+ * about overriding an admin's explicit choice.
+ *
+ * Same system-context read as `getEnrollmentDefaultsForOrg` — every caller
+ * of this function is reachable from an org-scoped or fully unauthenticated
+ * route, so the partner-axis RLS gap fixed in round 1 applies identically
+ * here. Costs one DB round trip (the org⋈partner settings join) per call;
+ * callers on hot/unauthenticated paths should call this at most once per
+ * request rather than combined with a separate `assertTtlWithinCap` check.
+ */
+export async function clampTtlToCap(orgId: string, ttlMinutes: number): Promise<number> {
+  const { maxTtlMinutes } = await getEnrollmentDefaultsForOrg(orgId);
+  return Math.min(ttlMinutes, maxTtlMinutes);
+}

--- a/apps/api/src/services/installerBootstrapToken.test.ts
+++ b/apps/api/src/services/installerBootstrapToken.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { generateBootstrapToken, BOOTSTRAP_TOKEN_PATTERN } from './installerBootstrapToken';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import {
+  generateBootstrapToken,
+  bootstrapTokenExpiresAt,
+  BOOTSTRAP_TOKEN_PATTERN,
+} from './installerBootstrapToken';
 
 describe('generateBootstrapToken', () => {
   it('returns a 10-char token of [A-Z0-9]', () => {
@@ -37,5 +41,41 @@ describe('BOOTSTRAP_TOKEN_PATTERN', () => {
     expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQRP4')).toBe(false);   // 9 chars
     expect(BOOTSTRAP_TOKEN_PATTERN.test('A7K2XQRP4NA')).toBe(false); // 11 chars
     expect(BOOTSTRAP_TOKEN_PATTERN.test('A7-2XQRP4N')).toBe(false);
+  });
+});
+
+describe('bootstrapTokenExpiresAt', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  const minutesOut = (d: Date) => Math.round((d.getTime() - Date.now()) / 60_000);
+
+  it('defaults to 24 hours when the env var is unset', () => {
+    expect(minutesOut(bootstrapTokenExpiresAt())).toBe(1440);
+  });
+
+  // #2776 regression. docker-compose threads this var in as
+  // `${INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES:-}`, which `docker compose
+  // config` renders as `VAR: ""` when the operator hasn't set it — the
+  // container sees it SET to an empty string, not absent. The old
+  // `Number(process.env.X ?? 24 * 60)` read gave 0 there (`??` doesn't fire
+  // on '', Number('') === 0), so EVERY bootstrap token was minted already
+  // expired and agent enrollment stopped working on upgrade.
+  it('falls back to 24 hours when the env var is the EMPTY STRING, not 0 (#2776)', () => {
+    vi.stubEnv('INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES', '');
+    const expiresAt = bootstrapTokenExpiresAt();
+    expect(minutesOut(expiresAt)).toBe(1440);
+    expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('falls back to 24 hours for a non-numeric value', () => {
+    vi.stubEnv('INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES', 'forever');
+    expect(minutesOut(bootstrapTokenExpiresAt())).toBe(1440);
+  });
+
+  it('honours an explicit override', () => {
+    vi.stubEnv('INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES', '60');
+    expect(minutesOut(bootstrapTokenExpiresAt())).toBe(60);
   });
 });

--- a/apps/api/src/services/installerBootstrapToken.ts
+++ b/apps/api/src/services/installerBootstrapToken.ts
@@ -1,4 +1,5 @@
 import { randomInt } from 'node:crypto';
+import { envInt } from '../utils/envInt';
 
 /**
  * Canonical shape of a bootstrap token: 10 chars of base36 (uppercase
@@ -27,8 +28,15 @@ export function generateBootstrapToken(): string {
  * for testing; production default is 24 hours which matches the
  * "admin downloads installer, sends to user, user runs sometime
  * within a day" mental model.
+ *
+ * Must go through `envInt`, never `Number(process.env.X ?? default)`:
+ * compose threads this in as `${INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES:-}`,
+ * which renders as the empty STRING when the operator hasn't set it. `??`
+ * doesn't fire on `''` and `Number('') === 0`, so the naive form gave every
+ * bootstrap token a 0-minute TTL — born expired — on any self-host that
+ * pulled this release without adding the key to its .env (#2776).
  */
 export function bootstrapTokenExpiresAt(): Date {
-  const ttlMin = Number(process.env.INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES ?? 24 * 60);
+  const ttlMin = envInt('INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES', 24 * 60);
   return new Date(Date.now() + ttlMin * 60 * 1000);
 }

--- a/apps/api/src/services/installerBootstrapTokenIssuance.test.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.test.ts
@@ -14,6 +14,18 @@ vi.mock('../db', () => ({
   },
 }));
 
+// Partner-cap defensive bound (fix round 3, #2776). Mocked at the wiring
+// level — see enrollmentKeys.test.ts's identically-named-pattern helper for
+// rationale. Permissive default (returns ttlMinutes unchanged) models "no
+// partner cap configured", so every pre-existing test in this file (which
+// predates the cap bound) keeps passing.
+const clampTtlToCapMock = vi.fn(
+  async (_orgId: string, ttlMinutes: number) => ttlMinutes,
+);
+vi.mock('../services/enrollmentDefaults', () => ({
+  clampTtlToCap: (...args: [string, number]) => clampTtlToCapMock(...args),
+}));
+
 import { db } from '../db';
 import { issueBootstrapTokenForKey } from './installerBootstrapTokenIssuance';
 
@@ -50,6 +62,10 @@ function mockInsert() {
 describe('issueBootstrapTokenForKey', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // vi.clearAllMocks clears call history but NOT implementations — restore
+    // the permissive default every test.
+    clampTtlToCapMock.mockReset();
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) => ttlMinutes);
   });
 
   it('honours ttlMinutes even when the parent expires sooner (#2775)', async () => {
@@ -78,5 +94,134 @@ describe('issueBootstrapTokenForKey', () => {
 
     const ttlMs = result.expiresAt.getTime() - Date.now();
     expect(ttlMs).toBeGreaterThan(23 * 60 * 60 * 1000);
+  });
+
+  // Fix round 4 (#2776). The round-3 code computed minutes from rawExpiresAt
+  // and then ALWAYS rebuilt the Date from them, reading the clock a third
+  // time — so an unclamped expiry came back a few milliseconds LATER than the
+  // one the request implied. (The round-3 comment blamed `Math.ceil` producing
+  // 1441 minutes; arithmetically impossible — the quotient is
+  // `requested - elapsed/60000`, always <= requested.) The contract now is an
+  // IDENTITY one: when the cap does not bind, the returned expiry must be the
+  // exact same instant `rawExpiresAt` named, not merely "about right".
+  //
+  // Date.now is stubbed to advance a few ms per call so the three reads inside
+  // the function are distinguishable — that is what makes this discriminating
+  // rather than the previous tolerance-window assertion, which passed against
+  // the pre-fix code too.
+  it('returns the raw expiry byte-identically when the cap does not bind (#2776 round 4)', async () => {
+    mockParent();
+    mockInsert();
+
+    const t0 = Date.now();
+    let nowCalls = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => t0 + nowCalls++ * 7);
+
+    try {
+      const result = await issueBootstrapTokenForKey({
+        parentEnrollmentKeyId: 'parent-1',
+        createdByUserId: 'user-1',
+        ttlMinutes: 1440,
+      });
+
+      // rawExpiresAt is built on the FIRST Date.now() read, i.e. exactly t0.
+      const rawExpiresAt = new Date(t0 + 1440 * 60 * 1000);
+      expect(result.expiresAt.getTime()).toBe(rawExpiresAt.getTime());
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  // The floor + verbatim-passthrough pair has one documented boundary: a cap
+  // exactly one minute below the request is NON-binding, so the token is
+  // issued at the full requested lifetime — up to 60s over the cap. Pinned so
+  // nobody "fixes" the drift-free passthrough without noticing they changed
+  // this, and so the comment in the service can't rot away from the code.
+  it('a cap one minute below the request is non-binding (documented <60s overshoot)', async () => {
+    mockParent();
+    mockInsert();
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 1439),
+    );
+
+    const t0 = Date.now();
+    let nowCalls = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => t0 + nowCalls++ * 7);
+
+    try {
+      const result = await issueBootstrapTokenForKey({
+        parentEnrollmentKeyId: 'parent-1',
+        createdByUserId: 'user-1',
+        ttlMinutes: 1440,
+      });
+
+      // floor(1440 - 7ms) === 1439 === the cap, so the clamp is a no-op and
+      // the full 1440-minute expiry survives.
+      expect(clampTtlToCapMock).toHaveBeenCalledWith('org-1', 1439);
+      expect(result.expiresAt.getTime()).toBe(t0 + 1440 * 60 * 1000);
+      // The overshoot is bounded by one minute — never more.
+      expect(result.expiresAt.getTime() - (t0 + 1439 * 60 * 1000)).toBeLessThanOrEqual(60_000);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  // Fix round 3 (#2776): a defensive CLAMP (never a rejection) so the
+  // partner cap can't be bypassed by a caller that forgets to check it —
+  // in particular serveInstaller's unauthenticated public-download path,
+  // which passes no ttlMinutes at all and had no cap consult anywhere in
+  // its call chain before this fix.
+  it('clamps the 24h base TTL down when the partner cap is below it', async () => {
+    mockParent();
+    mockInsert();
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 60), // partner cap: 60 minutes
+    );
+
+    const result = await issueBootstrapTokenForKey({
+      parentEnrollmentKeyId: 'parent-1',
+      createdByUserId: 'user-1',
+    });
+
+    const ttlMs = result.expiresAt.getTime() - Date.now();
+    expect(ttlMs).toBeGreaterThan(59 * 60 * 1000 - 5_000);
+    expect(ttlMs).toBeLessThanOrEqual(60 * 60 * 1000);
+    expect(clampTtlToCapMock).toHaveBeenCalledWith('org-1', expect.any(Number));
+  });
+
+  it('clamps an explicit ttlMinutes down when it exceeds the partner cap', async () => {
+    mockParent();
+    mockInsert();
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 1440), // partner cap: 24h
+    );
+
+    const result = await issueBootstrapTokenForKey({
+      parentEnrollmentKeyId: 'parent-1',
+      createdByUserId: 'user-1',
+      ttlMinutes: 43200, // 30 days requested
+    });
+
+    const ttlMs = result.expiresAt.getTime() - Date.now();
+    // Clamped to the 1440-minute (24h) cap, NOT the requested 30 days.
+    expect(ttlMs).toBeLessThanOrEqual(1440 * 60 * 1000 + 5_000);
+    expect(ttlMs).toBeGreaterThan(1439 * 60 * 1000);
+  });
+
+  it('does not change the TTL when the partner cap is above it (no-op clamp)', async () => {
+    mockParent();
+    mockInsert();
+    clampTtlToCapMock.mockImplementation(async (_orgId: string, ttlMinutes: number) =>
+      Math.min(ttlMinutes, 525_600), // generous partner cap
+    );
+
+    const result = await issueBootstrapTokenForKey({
+      parentEnrollmentKeyId: 'parent-1',
+      createdByUserId: 'user-1',
+      ttlMinutes: 10080, // 7 days
+    });
+
+    const ttlMs = result.expiresAt.getTime() - Date.now();
+    expect(ttlMs).toBeGreaterThan(10080 * 60 * 1000 - 60_000);
   });
 });

--- a/apps/api/src/services/installerBootstrapTokenIssuance.ts
+++ b/apps/api/src/services/installerBootstrapTokenIssuance.ts
@@ -6,6 +6,7 @@ import {
   generateBootstrapToken,
   bootstrapTokenExpiresAt,
 } from './installerBootstrapToken';
+import { clampTtlToCap } from './enrollmentDefaults';
 
 export interface IssueBootstrapTokenInput {
   parentEnrollmentKeyId: string;
@@ -22,7 +23,10 @@ export interface IssueBootstrapTokenInput {
   /**
    * Absolute lifetime for this token, in minutes, as chosen by the admin in
    * the Add Device modal. Omitted → the 24h base from bootstrapTokenExpiresAt().
-   * Bounds are enforced upstream by the route Zod schemas (1..525_600).
+   * Bounds are enforced upstream by the route Zod schemas (1..525_600) AND,
+   * as of fix round 3 (#2776), by a partner-cap clamp inside this function
+   * (see below) — the schema bound alone says nothing about a partner's
+   * OWN configured ceiling, which can be lower.
    */
   ttlMinutes?: number;
 }
@@ -50,6 +54,10 @@ export class BootstrapTokenIssuanceError extends Error {
  * Caller is responsible for:
  *  - access control (ensureOrgAccess on parentKey.orgId)
  *  - audit logging
+ *  - rejecting (400) an explicitly-chosen over-cap ttlMinutes BEFORE calling
+ *    this (via assertTtlWithinCap) when there's an interactive caller to
+ *    tell. This function only CLAMPS a defensive bound (never rejects) —
+ *    see the cap comment below.
  *
  * Throws BootstrapTokenIssuanceError on parent-key validation failures so
  * the caller can map to its own HTTP shape.
@@ -87,9 +95,60 @@ export async function issueBootstrapTokenForKey(
   //
   // Freshness at ISSUE time is still enforced by the caller via
   // parentKeyTooCloseToExpiry().
-  const expiresAt = input.ttlMinutes !== undefined
+  const rawExpiresAt = input.ttlMinutes !== undefined
     ? new Date(Date.now() + input.ttlMinutes * 60 * 1000)
     : bootstrapTokenExpiresAt();
+
+  // Defensive partner-cap bound (fix round 3, #2776) — a CLAMP, not a
+  // rejection, deliberately: this function has no HTTP request to reject
+  // with a 400, and by design it "delegates to its callers" for validation
+  // (see the class doc above), which is exactly the contract that let one
+  // caller slip through uncapped. Two of the three current callers
+  // (POST /:id/bootstrap-token and the installer-link/installer-download
+  // Windows paths) already reject an over-cap explicit ttlMinutes upstream
+  // via assertTtlWithinCap, so for them this is a same-value no-op. The
+  // THIRD caller — serveInstaller's UNAUTHENTICATED public-download / short-
+  // link path — passes no ttlMinutes at all and had no cap consult anywhere
+  // in its call chain before this fix, so the 24h bootstrapTokenExpiresAt()
+  // base could exceed a partner's configured (lower) cap. Bounding it HERE,
+  // once, means the contract stops depending on every future caller
+  // remembering to check the cap itself.
+  //
+  // Pass `rawExpiresAt` through VERBATIM when the cap does not bind (fix
+  // round 4, #2776).
+  //
+  // What the round-3 code actually did — the round-3 comment described this
+  // backwards, claiming `Math.ceil` produced 1441 minutes. It cannot: the
+  // quotient here is `requestedMinutes - elapsed/60000`, where `elapsed` is
+  // the time between building `rawExpiresAt` and re-reading the clock on the
+  // next line. That is strictly LESS than the requested minutes, so `ceil`
+  // lands back on exactly 1440 and never above it. The real defect was the
+  // unconditional REBUILD on the line after: `new Date(Date.now() + ...)` reads
+  // the clock a third time, so the reconstructed expiry sat a few
+  // MILLISECONDS past `rawExpiresAt`. Tiny, but it is drift in the lengthening
+  // direction inside the function whose job is to bound lifetimes, and it
+  // accumulated nowhere-visible. Keeping `rawExpiresAt` when the cap is
+  // non-binding removes the round trip entirely, so there is no drift of
+  // either sign.
+  //
+  // `floor` (with a 1-minute floor for sub-minute requests) rather than `ceil`
+  // so the minute-quantised value handed to the cap never rounds a request UP
+  // past what was asked for.
+  //
+  // KNOWN BOUNDARY (not a bug worth behaviour-changing, but do not claim the
+  // clamp "only rewrites downwards"): because `rawTtlMinutes` floors, a cap
+  // sitting exactly one minute below the request is NON-binding. Cap 1439 with
+  // a 1440-minute request floors to 1439, `clampTtlToCap` returns 1439, the
+  // `>=` test passes, and the token is issued at the full 1440 — up to 60
+  // seconds OVER the cap. Bounded at <1 minute and irrelevant against the
+  // hour-scale caps this feature exists for; the alternative (rebuilding from
+  // the capped minutes) reintroduces the millisecond drift above on every
+  // single issue, which is the worse trade.
+  const rawTtlMinutes = Math.max(1, Math.floor((rawExpiresAt.getTime() - Date.now()) / 60_000));
+  const cappedTtlMinutes = await clampTtlToCap(parent.orgId, rawTtlMinutes);
+  const expiresAt = cappedTtlMinutes >= rawTtlMinutes
+    ? rawExpiresAt
+    : new Date(Date.now() + cappedTtlMinutes * 60 * 1000);
 
   const [row] = await db.insert(installerBootstrapTokens).values({
     token,

--- a/apps/api/src/utils/envInt.test.ts
+++ b/apps/api/src/utils/envInt.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { envInt } from './envInt';
+
+describe('envInt', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the default when the variable is absent', () => {
+    expect(envInt('__TEST_ENV_INT_ABSENT', 1440)).toBe(1440);
+  });
+
+  // The #2776 regression: `docker compose config` renders an unmapped
+  // `VAR: ${VAR:-}` as `VAR: ""`, so the container sees the variable SET to
+  // an empty string. `Number('') === 0` and `??` does not fire on `''`, so a
+  // naive reader produced a 0-minute TTL — every enrollment token born
+  // expired on any self-host that pulled the release without adding the new
+  // keys to its .env.
+  it('returns the default for an empty string, NOT 0', () => {
+    vi.stubEnv('__TEST_ENV_INT', '');
+    expect(envInt('__TEST_ENV_INT', 1440)).toBe(1440);
+    expect(envInt('__TEST_ENV_INT', 1440)).not.toBe(0);
+  });
+
+  it('returns the default for a whitespace-only value', () => {
+    vi.stubEnv('__TEST_ENV_INT', '   ');
+    expect(envInt('__TEST_ENV_INT', 1440)).toBe(1440);
+  });
+
+  it('returns the default for a non-numeric value', () => {
+    vi.stubEnv('__TEST_ENV_INT', 'forever');
+    expect(envInt('__TEST_ENV_INT', 1440)).toBe(1440);
+  });
+
+  it('parses a valid integer', () => {
+    vi.stubEnv('__TEST_ENV_INT', '60');
+    expect(envInt('__TEST_ENV_INT', 1440)).toBe(60);
+  });
+
+  it('truncates a decimal via parseInt semantics', () => {
+    vi.stubEnv('__TEST_ENV_INT', '90.7');
+    expect(envInt('__TEST_ENV_INT', 1440)).toBe(90);
+  });
+
+  // "0" is a deliberate operator choice, unlike '' — pass it through.
+  it('honours an explicit 0', () => {
+    vi.stubEnv('__TEST_ENV_INT', '0');
+    expect(envInt('__TEST_ENV_INT', 1440)).toBe(0);
+  });
+});

--- a/apps/api/src/utils/envInt.ts
+++ b/apps/api/src/utils/envInt.ts
@@ -1,0 +1,24 @@
+/**
+ * Parse an environment variable as an integer, falling back when it is
+ * absent, EMPTY, or unparseable.
+ *
+ * The empty-string case is the whole reason this exists as a shared helper
+ * (#2776). Our compose files thread every variable in explicitly as
+ * `VAR: ${VAR:-}`, and `docker compose config` renders an unset one as
+ * `VAR: ""` — the container sees the variable SET to an empty string, not
+ * absent. So the obvious-looking reader
+ *
+ * ```ts
+ * const ttl = Number(process.env.SOME_TTL_MINUTES ?? 1440); // WRONG
+ * ```
+ *
+ * silently yields `0`: `??` does not fire on `''`, and `Number('') === 0`.
+ * For a TTL that means every token is born already expired. Use this instead
+ * of hand-rolling `Number(process.env.X ?? default)`.
+ */
+export function envInt(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+}

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -113,6 +113,16 @@ services:
       APP_ENCRYPTION_KEY: ${APP_ENCRYPTION_KEY:?Set APP_ENCRYPTION_KEY in .env}
       MFA_ENCRYPTION_KEY: ${MFA_ENCRYPTION_KEY:?Set MFA_ENCRYPTION_KEY in .env}
       ENROLLMENT_KEY_PEPPER: ${ENROLLMENT_KEY_PEPPER:?Set ENROLLMENT_KEY_PEPPER in .env}
+      # Enrollment link / bootstrap token lifetimes + the expired-key sweep
+      # (#2775, #2776). Baked defaults rather than `:-}`: an unset var rendered
+      # as `VAR: ""` reaches the container SET to an empty string, which a
+      # `Number(process.env.X ?? default)` reader turns into 0 — a 0-minute TTL
+      # mints tokens that are already expired.
+      CHILD_ENROLLMENT_KEY_TTL_MINUTES: ${CHILD_ENROLLMENT_KEY_TTL_MINUTES:-1440}
+      INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES: ${INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES:-1440}
+      INSTALLER_PARENT_MIN_REMAINING_SECONDS: ${INSTALLER_PARENT_MIN_REMAINING_SECONDS:-60}
+      ENROLLMENT_KEY_CLEANUP_ENABLED: ${ENROLLMENT_KEY_CLEANUP_ENABLED:-true}
+      ENROLLMENT_KEY_PURGE_AFTER_DAYS: ${ENROLLMENT_KEY_PURGE_AFTER_DAYS:-7}
       MFA_RECOVERY_CODE_PEPPER: ${MFA_RECOVERY_CODE_PEPPER:?Set MFA_RECOVERY_CODE_PEPPER in .env}
       PATCH_REPORT_STORAGE_PATH: /data/patch-reports
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,6 +249,16 @@ services:
       JWT_ACTIVE_KID: ${JWT_ACTIVE_KID:-}
       WS_TICKET_BIND_IP: ${WS_TICKET_BIND_IP:-}
       ENROLLMENT_KEY_DEFAULT_TTL_MINUTES: ${ENROLLMENT_KEY_DEFAULT_TTL_MINUTES:-}
+      # Real defaults, not `:-}` — an unset var rendered as `VAR: ""` reaches the
+      # container SET to an empty string, and any reader doing
+      # `Number(process.env.X ?? default)` then gets 0 (`??` skips '', and
+      # Number('') is 0). The readers all use utils/envInt now, which treats ''
+      # as absent; these baked defaults are the second line of defence (#2776).
+      CHILD_ENROLLMENT_KEY_TTL_MINUTES: ${CHILD_ENROLLMENT_KEY_TTL_MINUTES:-1440}
+      INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES: ${INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES:-1440}
+      INSTALLER_PARENT_MIN_REMAINING_SECONDS: ${INSTALLER_PARENT_MIN_REMAINING_SECONDS:-60}
+      ENROLLMENT_KEY_CLEANUP_ENABLED: ${ENROLLMENT_KEY_CLEANUP_ENABLED:-true}
+      ENROLLMENT_KEY_PURGE_AFTER_DAYS: ${ENROLLMENT_KEY_PURGE_AFTER_DAYS:-7}
       AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET: ${AUTOMATION_WEBHOOK_ALLOW_LEGACY_SECRET:-}
       # Email — SMTP extras + Mailgun provider
       SMTP_FROM: ${SMTP_FROM:-}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -639,6 +639,12 @@ export interface InheritableDefaultSettings {
     agent?: string;
     watchdog?: string;
   };
+  /** Pre-selected link TTL in the Add Device modal. Inherit-with-override. */
+  defaultEnrollmentTtlMinutes?: number;
+  /** Pre-selected device count in the Add Device modal. Inherit-with-override. */
+  defaultEnrollmentDeviceCount?: number;
+  /** Hard ceiling on link TTL. Partner-only — orgs cannot raise it. */
+  maxEnrollmentLinkTtlMinutes?: number;
 }
 
 export interface InheritableBrandingSettings {

--- a/packages/shared/src/validators/enrollmentDefaults.test.ts
+++ b/packages/shared/src/validators/enrollmentDefaults.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveEnrollmentDefaults,
+  enrollmentDefaultsSchema,
+  enrollmentTtlOptionsWithinCap,
+  enrollmentTtlOptionsIncluding,
+  clampTtlToOfferableOption,
+  ENROLLMENT_TTL_OPTIONS,
+  MAX_ENROLLMENT_TTL_MINUTES,
+} from './enrollmentDefaults.js';
+
+describe('resolveEnrollmentDefaults', () => {
+  it('inherits the partner value when the org has not set one', () => {
+    const r = resolveEnrollmentDefaults(
+      { defaultEnrollmentTtlMinutes: 10080 },
+      {},
+    );
+    expect(r.ttlMinutes).toBe(10080);
+  });
+
+  it('lets an org OVERRIDE the partner value (inherit-with-override)', () => {
+    const r = resolveEnrollmentDefaults(
+      { defaultEnrollmentTtlMinutes: 10080 },
+      { defaultEnrollmentTtlMinutes: 60 },
+    );
+    expect(r.ttlMinutes).toBe(60);
+  });
+
+  it('keys on presence, not truthiness', () => {
+    const r = resolveEnrollmentDefaults(
+      { defaultEnrollmentDeviceCount: 25 },
+      { defaultEnrollmentDeviceCount: 0 },
+    );
+    // 0 is invalid and must be rejected by the schema, but the resolver
+    // itself must not silently fall back to the partner value on a falsy 0
+    expect(r.deviceCount).toBe(0);
+  });
+
+  it('takes the cap from the PARTNER only — an org cannot raise it', () => {
+    const r = resolveEnrollmentDefaults(
+      { maxEnrollmentLinkTtlMinutes: 1440 },
+      { maxEnrollmentLinkTtlMinutes: 525600 },
+    );
+    expect(r.maxTtlMinutes).toBe(1440);
+  });
+
+  it('falls back to product defaults when neither level sets anything', () => {
+    const r = resolveEnrollmentDefaults({}, {});
+    expect(r.ttlMinutes).toBe(1440);
+    expect(r.deviceCount).toBe(1);
+    expect(r.maxTtlMinutes).toBe(525600);
+  });
+
+  // #2776 follow-up: the org's defaultEnrollmentTtlMinutes is lock-exempt and
+  // validated only against the global MAX_ENROLLMENT_TTL_MINUTES, not the
+  // partner cap, so a resolved default can land above maxTtlMinutes. That's
+  // not a value anyone chose for a specific mint request — it's a stale
+  // default — so the resolver clamps it rather than rejecting.
+  it('clamps a resolved org default above the partner cap', () => {
+    const r = resolveEnrollmentDefaults(
+      { maxEnrollmentLinkTtlMinutes: 1440 },
+      { defaultEnrollmentTtlMinutes: 43200 },
+    );
+    expect(r.ttlMinutes).toBe(1440);
+    expect(r.maxTtlMinutes).toBe(1440);
+  });
+
+  it('clamps a resolved partner default above the partner cap after it is lowered', () => {
+    const r = resolveEnrollmentDefaults(
+      { defaultEnrollmentTtlMinutes: 43200, maxEnrollmentLinkTtlMinutes: 1440 },
+      {},
+    );
+    expect(r.ttlMinutes).toBe(1440);
+  });
+
+  it('does not clamp a resolved default that is already within the cap', () => {
+    const r = resolveEnrollmentDefaults(
+      { maxEnrollmentLinkTtlMinutes: 1440 },
+      { defaultEnrollmentTtlMinutes: 60 },
+    );
+    expect(r.ttlMinutes).toBe(60);
+  });
+
+  it('allows a resolved default exactly at the cap (no off-by-one)', () => {
+    const r = resolveEnrollmentDefaults(
+      { maxEnrollmentLinkTtlMinutes: 1440 },
+      { defaultEnrollmentTtlMinutes: 1440 },
+    );
+    expect(r.ttlMinutes).toBe(1440);
+  });
+});
+
+describe('enrollmentDefaultsSchema', () => {
+  it('rejects a TTL above the product maximum', () => {
+    expect(enrollmentDefaultsSchema.safeParse({
+      defaultEnrollmentTtlMinutes: 525601,
+    }).success).toBe(false);
+  });
+
+  it('rejects a zero device count', () => {
+    expect(enrollmentDefaultsSchema.safeParse({
+      defaultEnrollmentDeviceCount: 0,
+    }).success).toBe(false);
+  });
+});
+
+describe('enrollmentTtlOptionsWithinCap', () => {
+  it('drops every option above the cap', () => {
+    expect(enrollmentTtlOptionsWithinCap(43200)).toEqual([60, 1440, 10080, 43200]);
+  });
+
+  it('returns the full set for the product maximum', () => {
+    expect(enrollmentTtlOptionsWithinCap(MAX_ENROLLMENT_TTL_MINUTES)).toEqual([
+      ...ENROLLMENT_TTL_OPTIONS,
+    ]);
+  });
+
+  it('falls back to the cap itself rather than an empty picker', () => {
+    // Only reachable via a direct API PATCH — the partner UI offers canonical
+    // values only. An empty <select> would be worse than one odd label.
+    expect(enrollmentTtlOptionsWithinCap(30)).toEqual([30]);
+  });
+});
+
+describe('clampTtlToOfferableOption', () => {
+  it('leaves a value at or below the cap alone', () => {
+    expect(clampTtlToOfferableOption(10080, 43200)).toBe(10080);
+    expect(clampTtlToOfferableOption(43200, 43200)).toBe(43200);
+  });
+
+  it('folds an over-cap value onto the largest offerable option', () => {
+    expect(clampTtlToOfferableOption(525600, 43200)).toBe(43200);
+  });
+
+  it('never returns a value the picker cannot display as selected', () => {
+    // Cap 20000 is not a canonical option: clamping to it would leave the
+    // select showing nothing, so the largest option BELOW it wins.
+    expect(clampTtlToOfferableOption(525600, 20000)).toBe(10080);
+  });
+
+  it('leaves a non-canonical UNDER-cap value alone rather than snapping it', () => {
+    // Snapping would silently change a value nobody asked to change.
+    // enrollmentTtlOptionsIncluding surfaces it as its own option instead.
+    expect(clampTtlToOfferableOption(20000, 43200)).toBe(20000);
+  });
+
+  it('falls back to the cap when nothing canonical fits under it', () => {
+    expect(clampTtlToOfferableOption(1440, 30)).toBe(30);
+  });
+});
+
+describe('enrollmentTtlOptionsIncluding', () => {
+  it('is a plain pass-through when the value is already canonical', () => {
+    expect(enrollmentTtlOptionsIncluding(43200, 10080)).toEqual([60, 1440, 10080, 43200]);
+  });
+
+  it('is a plain pass-through when there is no current value', () => {
+    expect(enrollmentTtlOptionsIncluding(43200)).toEqual([60, 1440, 10080, 43200]);
+  });
+
+  it('surfaces a stored OVER-cap value so the select can display what is stored', () => {
+    // The settings editors must never rewrite this on save — resolveEnrollmentDefaults
+    // clamps it at read time, which is where clamping belongs.
+    expect(enrollmentTtlOptionsIncluding(1440, 525600)).toEqual([60, 1440, 525600]);
+  });
+
+  it('surfaces a non-canonical UNDER-cap value in sort order', () => {
+    // Without this the <select> would match no option, display "1 hour", and
+    // still submit 20000.
+    expect(enrollmentTtlOptionsIncluding(43200, 20000)).toEqual([60, 1440, 10080, 20000, 43200]);
+  });
+
+  it('composes with the sub-canonical cap fallback', () => {
+    expect(enrollmentTtlOptionsIncluding(30, 30)).toEqual([30]);
+    expect(enrollmentTtlOptionsIncluding(30, 525600)).toEqual([30, 525600]);
+  });
+});

--- a/packages/shared/src/validators/enrollmentDefaults.ts
+++ b/packages/shared/src/validators/enrollmentDefaults.ts
@@ -1,0 +1,156 @@
+import { z } from 'zod';
+
+export const MAX_ENROLLMENT_TTL_MINUTES = 525_600; // 365 days
+export const MAX_ENROLLMENT_DEVICE_COUNT = 1000;
+
+/** Selectable TTLs, in minutes. Mirrors the Add Device modal's option set. */
+export const ENROLLMENT_TTL_OPTIONS = [60, 1440, 10080, 43200, 129600, 525600] as const;
+
+/**
+ * i18n key per option, so the Add Device modal and both settings tabs render
+ * one option set from one source. Keys match the existing literals already in
+ * the `devices` namespace (apps/web/src/locales/*\/devices.json) — do not mint
+ * parallel ones.
+ */
+export const ENROLLMENT_TTL_I18N_KEYS: Record<number, string> = {
+  60: 'addDeviceModal.n1Hour',
+  1440: 'addDeviceModal.n24Hours',
+  10080: 'addDeviceModal.n7Days',
+  43200: 'addDeviceModal.n30Days',
+  129600: 'addDeviceModal.n90Days',
+  525600: 'addDeviceModal.n1Year',
+};
+
+/**
+ * The selectable TTLs a picker may offer under `maxTtlMinutes`.
+ *
+ * Every TTL picker (Add Device installer tab, Add Device CLI tab, the org
+ * defaults editor) MUST render this rather than `ENROLLMENT_TTL_OPTIONS`
+ * directly. Offering an option above the cap is the silent-discard defect this
+ * whole feature exists to remove: the write path rejects it with a 400, or the
+ * read path clamps it, and either way the operator's choice is not what they
+ * chose.
+ *
+ * A cap below every canonical option (only reachable by PATCHing the setting
+ * through the API — the partner UI itself only offers canonical values) would
+ * otherwise leave an empty picker, so the cap itself becomes the sole option.
+ * Callers must therefore be able to label a non-canonical value: check
+ * `ENROLLMENT_TTL_I18N_KEYS[minutes]` before using it.
+ */
+export function enrollmentTtlOptionsWithinCap(maxTtlMinutes: number): number[] {
+  const allowed = ENROLLMENT_TTL_OPTIONS.filter(minutes => minutes <= maxTtlMinutes);
+  return allowed.length > 0 ? [...allowed] : [maxTtlMinutes];
+}
+
+/**
+ * The option list a TTL picker should actually render.
+ *
+ * `enrollmentTtlOptionsWithinCap` alone is not enough, because the value a
+ * picker is *showing* is not always one of the canonical options:
+ *
+ *  - A settings editor may hold a stored value above the cap. That value is
+ *    legitimate — `defaultEnrollmentTtlMinutes` is lock-exempt, and
+ *    `resolveEnrollmentDefaults` clamps it at READ time, which is where
+ *    clamping belongs. Rewriting it on save would destroy the operator's
+ *    original intent (and silently, since these editors rebuild the whole
+ *    defaults blob on any save).
+ *  - An API-set default may be a non-canonical minute count under the cap
+ *    (e.g. 20000). Filtering it out would leave the `<select>` matching no
+ *    option, so the browser would display the FIRST option while the state —
+ *    and therefore the request — still carried 20000. That display/submit
+ *    divergence is the same class of defect this feature exists to remove.
+ *
+ * So: offerable options, plus `currentValue` when it is set and not already
+ * among them, ascending. Callers must be able to label a non-canonical value —
+ * check `ENROLLMENT_TTL_I18N_KEYS[minutes]` and fall back to a minutes string.
+ *
+ * Note this can legitimately return a value ABOVE `maxTtlMinutes` (the stored
+ * over-cap case). That is correct for the settings editors, which describe
+ * stored intent. A picker that MINTS something — the Add Device modal — must
+ * additionally run its value through `clampTtlToOfferableOption` first, so it
+ * never offers a lifetime the mint routes will reject with a 400.
+ */
+export function enrollmentTtlOptionsIncluding(
+  maxTtlMinutes: number,
+  currentValue?: number,
+): number[] {
+  const options = enrollmentTtlOptionsWithinCap(maxTtlMinutes);
+  if (currentValue === undefined || options.includes(currentValue)) return options;
+  return [...options, currentValue].sort((a, b) => a - b);
+}
+
+/**
+ * Fold an OVER-cap TTL down onto the offerable set for `maxTtlMinutes`.
+ *
+ * Values at or below the cap are returned unchanged — including non-canonical
+ * ones, which are meant to be rendered via `enrollmentTtlOptionsIncluding`
+ * rather than snapped to a neighbouring option. Snapping them would silently
+ * alter a value nobody asked to change; surfacing them as their own option
+ * keeps display and submission identical, which is the actual requirement.
+ *
+ * Only for pickers that mint a credential, where an over-cap value would be
+ * rejected by the server. Settings editors must NOT use this: a stored
+ * over-cap default is clamped at read time and must survive a save intact.
+ */
+export function clampTtlToOfferableOption(ttlMinutes: number, maxTtlMinutes: number): number {
+  if (ttlMinutes <= maxTtlMinutes) return ttlMinutes;
+  const options = enrollmentTtlOptionsWithinCap(maxTtlMinutes);
+  return options[options.length - 1]!;
+}
+
+/** Product fallbacks when neither partner nor org has expressed a preference. */
+export const PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES = 1440;
+export const PRODUCT_DEFAULT_ENROLLMENT_DEVICE_COUNT = 1;
+
+export const enrollmentDefaultsSchema = z.object({
+  defaultEnrollmentTtlMinutes: z.number().int().min(1).max(MAX_ENROLLMENT_TTL_MINUTES).optional(),
+  defaultEnrollmentDeviceCount: z.number().int().min(1).max(MAX_ENROLLMENT_DEVICE_COUNT).optional(),
+  maxEnrollmentLinkTtlMinutes: z.number().int().min(1).max(MAX_ENROLLMENT_TTL_MINUTES).optional(),
+});
+
+export interface ResolvedEnrollmentDefaults {
+  ttlMinutes: number;
+  deviceCount: number;
+  maxTtlMinutes: number;
+}
+
+type Defaults = Record<string, unknown>;
+
+/**
+ * Partner→org resolution for enrollment defaults.
+ *
+ * The two default VALUES are inherit-with-override: an org-set value wins for
+ * that org, an unset org inherits the partner's. Keyed on presence (`in`), not
+ * truthiness — same contract as agentVersionPins in getOrgAgentUpdateConfig
+ * (apps/api/src/routes/agents/helpers.ts).
+ *
+ * The CAP is partner-only. A ceiling an org can raise is not a ceiling, so the
+ * org's value is ignored entirely here and rejected at write time by the lock.
+ *
+ * `ttlMinutes` is clamped to `maxTtlMinutes` before returning. The org's
+ * `defaultEnrollmentTtlMinutes` is lock-exempt (an org may set its own
+ * preferred default above what the partner later lowers the cap to — the
+ * write path only validates it against the global `MAX_ENROLLMENT_TTL_MINUTES`,
+ * never against the partner cap), so a resolved default can legitimately land
+ * above the cap. That's not a value anyone chose *for this mint request* —
+ * it's a stale/lock-exempt default — so clamping here (rather than the
+ * route-level reject-with-400 for an explicit ttlMinutes) is correct: a
+ * ceiling a stale default can silently outrank is not a ceiling.
+ */
+export function resolveEnrollmentDefaults(
+  partnerDefaults: Defaults,
+  orgDefaults: Defaults,
+): ResolvedEnrollmentDefaults {
+  const pick = (field: string, fallback: number): number => {
+    const raw = field in orgDefaults ? orgDefaults[field] : partnerDefaults[field];
+    return typeof raw === 'number' ? raw : fallback;
+  };
+  const rawCap = partnerDefaults.maxEnrollmentLinkTtlMinutes;
+  const maxTtlMinutes = typeof rawCap === 'number' ? rawCap : MAX_ENROLLMENT_TTL_MINUTES;
+  const ttlMinutes = pick('defaultEnrollmentTtlMinutes', PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES);
+  return {
+    ttlMinutes: Math.min(ttlMinutes, maxTtlMinutes),
+    deviceCount: pick('defaultEnrollmentDeviceCount', PRODUCT_DEFAULT_ENROLLMENT_DEVICE_COUNT),
+    maxTtlMinutes,
+  };
+}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -25,6 +25,7 @@ export * from './quotes';
 export * from './contractTemplates';
 export * from './maintenanceWindow';
 export * from './agentVersionPins';
+export * from './enrollmentDefaults';
 export * from './softwareDetection';
 
 // ============================================


### PR DESCRIPTION
## What

Part 1 of 2 for #2776. Adds the `maxEnrollmentLinkTtlMinutes` ceiling and enforces it across **every** path that mints or extends an enrollment credential.

> **Merge this before #2776b, and note it has no producer yet.** Nothing can SET a cap until 3b adds the write path and UI, so this resolves to the global 525,600 default — inert but correct, and safe to merge alone. Inverting the order would ship a settings screen whose ceiling isn't enforced.

- Shared types, bounds, and `resolveEnrollmentDefaults` (`packages/shared`).
- `getEnrollmentDefaultsForOrg` — a dedicated org⋈partner resolver. It deliberately does **not** go through `getEffectiveOrgSettings`, whose `mergeCategory` makes partner fields win unconditionally; that is wrong for the two inherit-with-override values. Same reason `getOrgAgentUpdateConfig` exists.
- Enforcement at all mint paths, with a deliberate split: a **caller-supplied** TTL over the cap is **rejected with 400** naming the cap; a **server-constant** TTL over the cap is **clamped** (redemption and download paths have no interactive user, and failing them closed would break enrollment outright).

## Why this is its own PR

This half is where every serious finding in the epic lived — it took four fix rounds and seven separately-discovered gaps. It touches two unauthenticated public download routes, MCP invite minting, key rotation, and the bootstrap-token issuance service. Bundled with the settings UI it is the half that gets skimmed.

## Ruling worth knowing while reviewing

`maxEnrollmentLinkTtlMinutes` is a ceiling on **key lifetime**, not merely on what an admin may request. A partner setting 1 hour means nothing minted under them stays usable longer — including MCP-generated deployment invites and the child credentials minted at redemption. Practical consequence: a short cap also shortens the window a machine has to *complete* enrollment after redeeming, not just to download.

## Two findings worth a careful read

- **RLS.** The cap read was initially inert for org-scoped callers: `partners` SELECT is `breeze_has_partner_access(id)` and `computeAccessiblePartnerIds` returns `[]` for org scope, so `maxTtlMinutes` silently fell back to the global max — for exactly the population the ceiling exists to bound. Every route/service test mocks the DB, so the whole unit suite passed against a control that did nothing. Fixed with a system-context read, proven by an integration test running as `breeze_app` in an org-scoped context.
- **Connection pressure.** That system-context read initially took a **second pooled connection** while the request held its first, on `POST /installer/bootstrap` — the path every device enrollment traverses. postgres-js has no acquire timeout, so a mass-enrollment burst could have hung the whole API. Now branches to an ambient read when already system-scoped: that path holds exactly 1 connection.

## Testing

API 17,312 passing / 0 failed · web 4,473 · shared 1,308 · typechecks clean. Integration tests executed against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
