### PR TITLE
feat(web,api): partner/org enrollment defaults + settings UI (2/2)

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1938,7 +1938,15 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
         parameters: [
           { $ref: '#/components/parameters/pageParam' },
           { $ref: '#/components/parameters/limitParam' },
-          { name: 'orgId', in: 'query', required: true, schema: { type: 'string', format: 'uuid' } }
+          { name: 'orgId', in: 'query', required: true, schema: { type: 'string', format: 'uuid' } },
+          {
+            name: 'includeEnrollmentDefaults',
+            in: 'query',
+            required: false,
+            description:
+              "Set to '1' to also resolve the org's enrollment link defaults into the response. Off by default: it costs an extra settings read that holds a second pooled connection.",
+            schema: { type: 'string', enum: ['1', 'true'] }
+          }
         ],
         responses: {
           '200': {
@@ -1949,7 +1957,18 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
                   type: 'object',
                   properties: {
                     data: { type: 'array', items: { $ref: '#/components/schemas/Site' } },
-                    pagination: { $ref: '#/components/schemas/Pagination' }
+                    pagination: { $ref: '#/components/schemas/Pagination' },
+                    enrollmentDefaults: {
+                      type: 'object',
+                      description:
+                        "The org's resolved enrollment link defaults. Present only when includeEnrollmentDefaults is set AND a single org is in scope. Rides along on this response so the Add Device modal can seed its pickers without a second round trip; omitted if the settings read fails.",
+                      properties: {
+                        ttlMinutes: { type: 'integer' },
+                        deviceCount: { type: 'integer' },
+                        maxTtlMinutes: { type: 'integer' }
+                      },
+                      required: ['ttlMinutes', 'deviceCount', 'maxTtlMinutes']
+                    }
                   }
                 }
               }

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -13,6 +13,17 @@ vi.mock('../services/clientIp', () => ({
   getTrustedClientIpOrUndefined: vi.fn()
 }));
 
+// GET /orgs/sites rides the org's resolved enrollment defaults along for the
+// Add Device modal (#2776). Mocked so these route tests don't depend on the
+// org⋈partner settings join.
+vi.mock('../services/enrollmentDefaults', () => ({
+  getEnrollmentDefaultsForOrg: vi.fn(async () => ({
+    ttlMinutes: 10080,
+    deviceCount: 25,
+    maxTtlMinutes: 43200
+  }))
+}));
+
 vi.mock('../services/ipAllowlist', () => ({
   clearPartnerAllowlistCache: vi.fn(),
   ipAllowlistMode: vi.fn(() => 'enforce'),
@@ -185,6 +196,7 @@ vi.mock('../middleware/auth', () => ({
 import { inArray } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../db';
 import { sites } from '../db/schema';
+import { getEnrollmentDefaultsForOrg } from '../services/enrollmentDefaults';
 import { authMiddleware } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { clearPartnerAllowlistCache, readPartnerAllowlist } from '../services/ipAllowlist';
@@ -1939,6 +1951,72 @@ describe('org routes', () => {
       expect(db.update).toHaveBeenCalled();
     });
 
+    // issue #2776: defaultEnrollmentTtlMinutes/defaultEnrollmentDeviceCount are
+    // inherit-with-override, same contract as agentVersionPins above — a
+    // partner-set value must NOT block an org override via assertNotLocked.
+    it('lets an org override the partner TTL default without a 403', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      primeAcceptSelect([], { defaults: { defaultEnrollmentTtlMinutes: 10080 } });
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { defaultEnrollmentTtlMinutes: 60 } } })
+      });
+
+      expect(res.status).toBe(200);
+      expect(db.update).toHaveBeenCalled();
+    });
+
+    // maxEnrollmentLinkTtlMinutes is the hard ceiling — partner-only, deliberately
+    // NOT exempt from assertNotLocked. An org attempting to raise it must 403.
+    it('403s when an org tries to set the partner-owned cap', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      primeAcceptSelect([], { defaults: { maxEnrollmentLinkTtlMinutes: 129600 } });
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { maxEnrollmentLinkTtlMinutes: 525600 } } })
+      });
+
+      expect(res.status).toBe(403);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // The org `settings` blob is z.any() — nothing structurally validates it
+    // except the explicit enrollmentDefaultsSchema.safeParse check added for
+    // issue #2776. An out-of-range value must 400 before any DB work.
+    it('400s on an out-of-range org enrollment default (org settings are z.any())', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { defaultEnrollmentTtlMinutes: 525601 } } })
+      });
+
+      expect(res.status).toBe(400);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // Carried-forward edge case from the Task 3.1 review: `'field' in obj` is
+    // true even when the value is explicitly `null`, which would make the
+    // resolver fall through to the product default instead of the partner's
+    // value. A stored null must be unreachable — reject it at write time.
+    it('400s on a null enrollment default value instead of storing it', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+
+      const res = await app.request('/orgs/organizations/org-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: { defaultEnrollmentTtlMinutes: null } } })
+      });
+
+      expect(res.status).toBe(400);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
     // SR2-05: `security.allowedMfaMethods` is a legacy input alias — it must be
     // folded into the canonical `security.allowedMethods` before the write and
     // never persisted as a second key (the dead spelling the SMS-enable reader
@@ -2069,6 +2147,29 @@ describe('org routes', () => {
       })
     }) as any;
 
+  // The three db.select calls GET /orgs/sites makes for one page of results:
+  // count, the page itself, then the grouped device counts.
+  const mockSitesPage = () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: 1 }])
+        })
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockReturnValue({
+                orderBy: vi.fn().mockResolvedValue([{ id: 'site-1' }])
+              })
+            })
+          })
+        })
+      } as any)
+      .mockReturnValueOnce(mockSiteDeviceCounts([{ siteId: 'site-1', count: 4 }]));
+  };
+
   describe('GET /orgs/sites', () => {
     it('should return sites with pagination', async () => {
       setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
@@ -2140,6 +2241,74 @@ describe('org routes', () => {
       const res = await app.request('/orgs/sites?orgId=11111111-1111-1111-1111-111111111111');
 
       expect(res.status).toBe(403);
+    });
+
+    it('carries the org\'s resolved enrollment defaults for the Add Device modal (#2776)', async () => {
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+      mockSitesPage();
+
+      const res = await app.request(
+        '/orgs/sites?orgId=11111111-1111-1111-1111-111111111111&includeEnrollmentDefaults=1'
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Seeds the modal's pickers without a second round trip on the
+      // device-add path.
+      expect(body.enrollmentDefaults).toEqual({
+        ttlMinutes: 10080,
+        deviceCount: 25,
+        maxTtlMinutes: 43200
+      });
+      expect(getEnrollmentDefaultsForOrg).toHaveBeenCalledWith(
+        '11111111-1111-1111-1111-111111111111'
+      );
+    });
+
+    it('does NOT resolve enrollment defaults unless the caller opts in', async () => {
+      // The resolver escapes to a system context, taking a SECOND pooled
+      // connection while this request still holds the first. postgres-js has no
+      // acquire timeout, so at N concurrent requests >= DB_POOL_MAX the API
+      // stalls indefinitely. This route fires on org switch, on Discovery, and
+      // on every Add Device modal open — so only the caller that needs the
+      // values pays for them.
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+      mockSitesPage();
+
+      const res = await app.request('/orgs/sites?orgId=11111111-1111-1111-1111-111111111111');
+
+      expect(res.status).toBe(200);
+      expect('enrollmentDefaults' in (await res.json())).toBe(false);
+      expect(getEnrollmentDefaultsForOrg).not.toHaveBeenCalled();
+    });
+
+    it('omits enrollment defaults when no single org is in scope', async () => {
+      // A cross-org list has no one org whose defaults would be correct.
+      setAuthContext({ scope: 'system' });
+      mockSitesPage();
+
+      const res = await app.request('/orgs/sites?includeEnrollmentDefaults=1');
+
+      expect(res.status).toBe(200);
+      expect('enrollmentDefaults' in (await res.json())).toBe(false);
+      expect(getEnrollmentDefaultsForOrg).not.toHaveBeenCalled();
+    });
+
+    it('still serves the site list when the enrollment-defaults read fails', async () => {
+      setAuthContext({ scope: 'organization', orgId: '11111111-1111-1111-1111-111111111111' });
+      mockSitesPage();
+      vi.mocked(getEnrollmentDefaultsForOrg).mockRejectedValueOnce(new Error('pg down'));
+
+      const res = await app.request(
+        '/orgs/sites?orgId=11111111-1111-1111-1111-111111111111&includeEnrollmentDefaults=1'
+      );
+
+      // A settings read must never take down a sites list — the client falls
+      // back to the product defaults.
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toHaveLength(1);
+      expect('enrollmentDefaults' in body).toBe(false);
     });
 
     it('should return empty list for partner with no accessible orgs', async () => {
@@ -3034,6 +3203,60 @@ describe('org routes', () => {
       const body = await res.json();
       expect(body.error).toContain('9.9.9');
       expect(db.update).not.toHaveBeenCalled();
+    });
+
+    // issue #2776: the partner `defaults` Zod block has no `.passthrough()`, so
+    // unlisted keys are silently stripped rather than rejected — a partner PATCH
+    // would appear to succeed while discarding the values unless all three
+    // enrollment fields are listed explicitly in the schema.
+    it('persists partner enrollment defaults through PATCH /partners/me', async () => {
+      setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+      const currentPartner = { id: 'partner-123', name: 'Acme MSP', settings: {} };
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([])
+            }),
+            limit: vi.fn().mockResolvedValue([currentPartner])
+          })
+        })
+      } as any);
+      // Capture the ACTUAL settings object the handler sends to db.update rather
+      // than trusting a hardcoded mock return value — otherwise this test can't
+      // distinguish "persisted" from "silently stripped by zod then echoed back
+      // by the mock" (the exact trap this task calls out: the partner `defaults`
+      // block has no `.passthrough()`).
+      let capturedUpdateData: any;
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockImplementation((data: any) => {
+          capturedUpdateData = data;
+          return {
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{
+                ...currentPartner,
+                settings: data.settings,
+              }])
+            })
+          };
+        })
+      } as any);
+
+      const res = await app.request('/orgs/partners/me', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ settings: { defaults: {
+          defaultEnrollmentTtlMinutes: 10080,
+          maxEnrollmentLinkTtlMinutes: 43200,
+        } } }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(capturedUpdateData.settings.defaults.defaultEnrollmentTtlMinutes).toBe(10080);
+      expect(capturedUpdateData.settings.defaults.maxEnrollmentLinkTtlMinutes).toBe(43200);
+      const body = await res.json();
+      expect(body.settings.defaults.defaultEnrollmentTtlMinutes).toBe(10080);
+      expect(body.settings.defaults.maxEnrollmentLinkTtlMinutes).toBe(43200);
     });
 
     it('accepts a valid branding update within size limits', async () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -27,8 +27,9 @@ import { applyOrganizationOrder, sanitizeOrganizationOrder } from '../services/o
 import { captureException } from '../services/sentry';
 import { encryptColumnValueForWrite } from '../services/encryptedColumnRegistry';
 import { escapeLike } from '../utils/sql';
-import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE, normalizeVersionPin, PINNABLE_COMPONENTS, agentVersionPinsSchema } from '@breeze/shared';
-import type { IpAllowlistStatus, SupportedLocale } from '@breeze/shared';
+import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE, normalizeVersionPin, PINNABLE_COMPONENTS, agentVersionPinsSchema, enrollmentDefaultsSchema } from '@breeze/shared';
+import type { IpAllowlistStatus, ResolvedEnrollmentDefaults, SupportedLocale } from '@breeze/shared';
+import { getEnrollmentDefaultsForOrg } from '../services/enrollmentDefaults';
 import { isValidIpOrCidr } from '../services/ipMatch';
 import { seedSystemTicketStatuses } from '../services/ticketConfigService';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
@@ -196,7 +197,11 @@ const listSitesSchema = z.object({
   orgId: z.string().guid().optional(),
   organizationId: z.string().guid().optional(), // Alias for orgId (frontend compatibility)
   page: z.string().optional(),
-  limit: z.string().optional()
+  limit: z.string().optional(),
+  // Opt-in: resolve and attach the org's enrollment defaults (#2776). Costs an
+  // extra org⋈partner settings read that runs in an escaped system context, so
+  // it is OFF by default — see the call site for the pool-exhaustion reason.
+  includeEnrollmentDefaults: z.enum(['1', 'true']).optional()
 });
 
 // IANA timezone validation lives in @breeze/shared (`isValidIanaTimezone`) so
@@ -542,6 +547,12 @@ const partnerSettingsSchema = z.object({
     // the "version must be registered" check needs a DB lookup and is done in
     // the handler via validateAgentVersionPins (same as the org PATCH path).
     agentVersionPins: agentVersionPinsSchema.optional(),
+    // Enrollment link defaults/cap (issue #2776). Spread the shared schema's
+    // shape rather than redefining bounds here — this block has no
+    // `.passthrough()`, so without these three keys listed explicitly a
+    // partner PATCH carrying them would have them silently stripped, not
+    // rejected.
+    ...enrollmentDefaultsSchema.shape,
   }).optional(),
   branding: z.object({
     logoUrl: z.string().max(400_000, 'Logo data exceeds maximum size (400 KB)').optional(),
@@ -1390,6 +1401,21 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
       if (pinError) {
         return c.json({ error: pinError }, 400);
       }
+
+      // Enrollment link defaults/cap (issue #2776) — same reason as the window
+      // and pin checks above: the org `settings` blob is z.any(), so nothing
+      // validates these three fields structurally until here. A `null` value is
+      // rejected (not treated as "clear my override") rather than stored: the
+      // schema's fields are optional-only, not nullable, so `null` fails parse
+      // and this 400s before reaching the DB — keeping the resolver's `'field'
+      // in obj` presence check safe from a stored null that would otherwise
+      // fall through to the product default instead of the partner's value.
+      const enrollmentParsed = enrollmentDefaultsSchema.safeParse(
+        (defaults as Record<string, unknown>) ?? {},
+      );
+      if (!enrollmentParsed.success) {
+        return c.json({ error: 'Invalid enrollment defaults', details: enrollmentParsed.error.issues }, 400);
+      }
     }
 
     // Enforce partner locks on settings categories (after auth check).
@@ -1402,8 +1428,18 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
         // exempt from the lock model here; a partner pin is only a default, and
         // getOrgAgentUpdateConfig resolves org-over-partner. Do NOT "fix" this
         // back to a lock without a per-field enforcement flag.
+        //
+        // Issue #2776: the two enrollment default VALUES are likewise
+        // inherit-with-override — a partner sets a house default, an org may
+        // deviate for a customer with different staging needs. The CAP
+        // (maxEnrollmentLinkTtlMinutes) is deliberately NOT exempt: a ceiling
+        // an org can raise is not a ceiling.
         if (category === 'defaults') {
-          fields = fields.filter((f) => f !== 'agentVersionPins');
+          fields = fields.filter((f) =>
+            f !== 'agentVersionPins' &&
+            f !== 'defaultEnrollmentTtlMinutes' &&
+            f !== 'defaultEnrollmentDeviceCount',
+          );
         }
         await assertNotLocked(id, category, fields);
       }
@@ -1525,7 +1561,7 @@ orgRoutes.delete('/organizations/:id', requireScope('partner', 'system'), requir
 
 orgRoutes.get('/sites', requireScope('organization', 'partner', 'system'), requireSiteRead, zValidator('query', listSitesSchema), async (c) => {
   const auth = c.get('auth') as AuthContext;
-  const { orgId, organizationId, ...pagination } = c.req.valid('query');
+  const { orgId, organizationId, includeEnrollmentDefaults, ...pagination } = c.req.valid('query');
 
   // Precedence: the explicit `organizationId` (the resource the page is
   // managing) MUST win over `orgId`. `orgId` may be an *ambient* value the web
@@ -1621,9 +1657,56 @@ orgRoutes.get('/sites', requireScope('organization', 'partner', 'system'), requi
     deviceCount: deviceCountBySite.get(site.id) ?? 0
   }));
 
+  // Ride the org's resolved enrollment defaults along on this response (#2776).
+  //
+  // The Add Device modal needs the partner/org default TTL + device count and
+  // the partner TTL cap to seed its pickers, and it is on the device-add hot
+  // path — a dedicated GET would be a second round trip on every open. This
+  // sites list IS the org read that modal already performs (orgStore.fetchSites
+  // fires from the modal's open effect, always with `organizationId=<current>`),
+  // so the values arrive with data the client is already waiting on.
+  //
+  // Deliberately NOT hung off GET /organizations, the other candidate: that
+  // route returns a LIST, so resolving per row would be one org⋈partner join
+  // per organization on a partner-wide fetch, and its organization-scope branch
+  // returns a name-only projection that carries no settings at all.
+  //
+  // OPT-IN, and that is load-bearing — not a nicety. getEnrollmentDefaultsForOrg
+  // runs its join in a system context reached via runOutsideDbContext, which
+  // opens a SECOND transaction on a SECOND pooled connection while this
+  // request's own withDbAccessContext transaction still holds the first. The
+  // hazard is cross-request, not self-deadlock: at N concurrent requests >=
+  // DB_POOL_MAX (default 30; the US region sits nearer 25) every connection is
+  // held by a request queued for a connection only a peer can release, and
+  // postgres-js has NO acquire timeout — `connect_timeout` governs the TCP
+  // connect, not the queue wait — so the API stalls indefinitely rather than
+  // degrading. This is the same failure mode as the HIGH finding fixed in
+  // #2776 round 4. GET /orgs/sites is not low-frequency admin traffic: it fires
+  // on every org switch, on the Discovery page, and on every Add Device modal
+  // open. So only the caller that actually needs the values asks for them
+  // (orgStore.fetchSites); every other caller pays exactly nothing.
+  //
+  // Also requires a single org in scope — an unfiltered cross-org sites list has
+  // no one org whose defaults would be correct. Soft-fails to an omitted field
+  // (the client falls back to the product defaults) rather than 500ing a sites
+  // list over a settings read, matching the org-ordering read above.
+  let enrollmentDefaults: ResolvedEnrollmentDefaults | undefined;
+  if (includeEnrollmentDefaults && effectiveOrgId) {
+    try {
+      enrollmentDefaults = await getEnrollmentDefaultsForOrg(effectiveOrgId);
+    } catch (err) {
+      console.error('[orgs.sites.enrollmentDefaults] Failed to resolve enrollment defaults', {
+        orgId: effectiveOrgId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      captureException(err, c);
+    }
+  }
+
   return c.json({
     data: dataWithCounts,
-    pagination: { page, limit, total: Number(count) }
+    pagination: { page, limit, total: Number(count) },
+    ...(enrollmentDefaults && { enrollmentDefaults })
   });
 });
 

--- a/apps/docs/src/content/docs/agents/enrollment-keys.mdx
+++ b/apps/docs/src/content/docs/agents/enrollment-keys.mdx
@@ -92,6 +92,16 @@ Short codes are convenient for sharing in email, chat, or printed runbooks. The 
 
 In the dashboard, the enrollment key list shows each key's short code in a **Short code** column with a copy-to-clipboard button — this replaces the previous always-masked KEY column, which never revealed anything useful. A **Hide expired** toggle above the list filters out keys that have already expired.
 
+### Installer Bootstrap Tokens
+
+Every installer download, installer-link generation, or short-code redemption mints an `installer_bootstrap_tokens` row: a single-use-by-default token embedded in the installer that authenticates its first-run `/bootstrap` call, independent of the interactive enrollment key that produced it.
+
+<Aside type="tip" title="A bootstrap token now outlives its parent enrollment key (#2775)">
+  Previously, an installer's usable life was capped to its parent enrollment key's *remaining* life, and redemption returned `404` once the parent expired — so a 30-day installer link minted from the Add Device modal's transient ~60-minute parent key died in under an hour. As of this release, the bootstrap token's own `expiresAt` is the sole authority on whether an installer can still enroll a device; the parent key's expiry is no longer checked at redemption time. Revocation still works exactly as before: deleting the parent enrollment key cascade-deletes (`ON DELETE CASCADE`) every outstanding bootstrap token immediately, so a deliberate delete remains an effective kill switch.
+</Aside>
+
+The token's TTL defaults to `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` (24 hours) or the admin's chosen link expiry, clamped to the partner's `maxEnrollmentLinkTtlMinutes` cap if one is set — see [Partner & Organization Enrollment Defaults](#partner--organization-enrollment-defaults). The daily purge sweep also will not delete a parent enrollment key while it still has a live, unexhausted bootstrap token outstanding, even past the key's own grace period — see [Automatic Purge of Expired Keys](#automatic-purge-of-expired-keys).
+
 ---
 
 ## Enrollment Key Lifecycle
@@ -214,6 +224,10 @@ curl -X POST https://breeze.yourdomain.com/api/v1/enrollment-keys/KEY_UUID/rotat
 
 The old key value is immediately invalidated. The response includes the new `key` field.
 
+<Aside type="danger" title="Shortening expiry via rotate no longer revokes outstanding installers">
+  Rotating a key to an earlier `expiresAt` used to also kill any installer bootstrap tokens issued from it, via a `parent_already_expired` check enforced at redemption time. That check has been removed (#2775) now that a bootstrap token's own expiry is authoritative — see [Installer Bootstrap Tokens](#installer-bootstrap-tokens). **If you were relying on shortening a key's expiry as a kill switch for installers already in the field, it no longer works** — this is a genuine loss of capability, not a bug. Outstanding installers keep working until their own bootstrap token expires. To revoke them immediately, delete the enrollment key instead: cascade-delete removes its bootstrap tokens right away.
+</Aside>
+
 ---
 
 ### Deleting a Key
@@ -228,6 +242,8 @@ curl -X DELETE https://breeze.yourdomain.com/api/v1/enrollment-keys/KEY_UUID \
 ### Automatic Purge of Expired Keys
 
 Expired enrollment keys are hard-deleted automatically by a daily sweep that runs at **04:00 UTC**. A key is only purged once it has been expired for a grace period of `ENROLLMENT_KEY_PURGE_AFTER_DAYS` days (default **7**), so a recently expired key remains visible long enough to audit or rotate. Keys with no expiration date are never auto-purged. Set `ENROLLMENT_KEY_CLEANUP_ENABLED=false` to disable the sweep entirely.
+
+A key is also skipped by the sweep — even past its grace period — while it still has a live, unexhausted [installer bootstrap token](#installer-bootstrap-tokens) outstanding, so a long-lived installer link (30 days, 1 year) cannot be purged out from under itself before its own token expires or is fully consumed.
 
 Installer bootstrap tokens and deployment invites that reference a purged key are cascade-deleted along with it.
 
@@ -349,11 +365,55 @@ All management endpoints require `organizations:read` for listing/viewing and `o
 
 ---
 
+## Partner & Organization Enrollment Defaults
+
+Partners and organizations can configure three settings that shape enrollment link and installer TTLs without touching environment variables per-deployment. All three live under `settings.defaults` on the partner or organization record.
+
+| Setting | Scope | Behavior |
+|---|---|---|
+| `defaultEnrollmentTtlMinutes` | Partner default, **inherit-with-override** by org | Pre-selects the link/installer expiry in the **Add Device** dialog. A partner sets a house default; an individual organization may override it with its own default. |
+| `defaultEnrollmentDeviceCount` | Partner default, **inherit-with-override** by org | Same inherit-with-override pattern, for the default device count on a new link. |
+| `maxEnrollmentLinkTtlMinutes` | **Partner only** | A hard ceiling on enrollment key/installer lifetime for every organization under that partner. An organization cannot raise it — there is no org-level equivalent field. |
+
+Partners configure all three from their partner settings page (`PATCH /partners/me`); organizations override the first two from their own org settings page (`PATCH /orgs/organizations/:id`). See [Partner Management](/reference/partner-management/#updating-partner-settings-self-service) for the general settings-PATCH mechanics.
+
+<Aside type="caution" title="The cap is a ceiling on key lifetime, not just on requests">
+  `maxEnrollmentLinkTtlMinutes` bounds how long any key or token minted under that partner may remain usable — it is not merely a limit on what an admin is allowed to type into a form. If a partner sets a one-hour cap, **nothing** minted under any of that partner's organizations — an explicit `ttlMinutes` from an admin, a redemption-time child key, an installer bootstrap token, or an MCP-generated deployment invite — stays valid for longer than an hour, regardless of which code path created it.
+</Aside>
+
+### Rejected vs. clamped
+
+The cap is enforced two different ways, depending on whether there's an interactive caller present to show an error to:
+
+- **An explicit request above the cap is REJECTED with 400, not silently reduced.** `POST /enrollment-keys`, `POST /enrollment-keys/:id/rotate`, the installer / installer-link download routes, and the device onboarding-token route all validate an explicit `ttlMinutes` (or `expiresAt`) against the partner's cap before doing anything else. A caller asking for more than the cap allows gets `400` with `{ "error": "ttlMinutes exceeds the partner maximum of <N> minutes" }` — the key is never created with a shorter TTL as a fallback.
+- **A system-picked TTL is CLAMPED to the cap instead of rejected**, because there is no request to reject and no user to show an error to. This applies to:
+  - the fresh child enrollment key minted when an installer is redeemed (`/s/:code`, `/bootstrap`),
+  - the child enrollment key embedded in an installer download or installer link when the admin didn't pass an explicit `ttlMinutes` (`GET /enrollment-keys/:id/installer/:platform`, `POST /enrollment-keys/:id/installer-link`) — it falls back to the deployment default, which is then clamped,
+  - the base TTL of a freshly-issued [installer bootstrap token](#installer-bootstrap-tokens) when the admin didn't choose an explicit expiry, and
+  - deployment invites generated by the AI/MCP `send_deployment_invites` tool.
+
+  In the dashboard, the **Link expires in** picker in the Add Device modal also hides any preset longer than the effective cap (for example, a 24-hour cap removes the 7-day/30-day/90-day/1-year options), so most admins never hit the 400 path at all — it exists for direct API/script callers and forged requests.
+
+### The practical consequence: this also shortens the completion window, not just the download window
+
+A short cap doesn't just limit how long an installer link is downloadable. After an installer is run, it redeems its embedded bootstrap token and is issued a brand-new, single-use child enrollment key — and that child key's TTL is *also* clamped to the same partner cap. So a one-hour cap gives a machine **one hour from redemption** to complete the actual `POST /api/v1/agents/enroll` call, on top of however long the bootstrap token itself was valid for download.
+
+In normal operation that gap is seconds. It stops being seconds — and starts producing "invalid or expired enrollment key" support tickets — whenever something delays the agent's first enrollment call after the installer runs: disk-imaging pipelines, a reboot baked into the install sequence, MDM-staged rollouts, or a machine that sits offline for a while right after setup. If enrollment fails on a machine that "was definitely installed within the download window," check whether a partner cap is also clamping the post-redemption completion window.
+
+### "Never expires" is not offered
+
+There is no option to mint a key or installer link that never expires, by design. `installer_bootstrap_tokens.expires_at` is `NOT NULL` with a `CHECK (expires_at > created_at)` constraint at the database level — supporting "never" would need a migration to make the column nullable, plus null-handling added through issuance, the `/bootstrap` consume path, the daily purge sweep, and the expiry countdown in the dashboard UI. That is tracked as a follow-up, not implemented here.
+
+---
+
 ## Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` | `60` | Default time-to-live for new enrollment keys when `expiresAt` is not specified. |
+| `CHILD_ENROLLMENT_KEY_TTL_MINUTES` | `1440` | Fresh TTL (minutes) given to a "child" enrollment key minted at installer-download, installer-link, or short-code redemption time, measured from mint time rather than the parent key's remaining lifetime. Clamped to the partner's `maxEnrollmentLinkTtlMinutes` cap. |
+| `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` | `1440` | Base TTL (minutes) for a freshly-issued [installer bootstrap token](#installer-bootstrap-tokens) when no explicit `ttlMinutes` is supplied. The token's own expiry, not the parent enrollment key's, governs how long an installer has to complete enrollment. |
+| `INSTALLER_PARENT_MIN_REMAINING_SECONDS` | `60` | Minimum remaining lifetime (seconds) a parent enrollment key must have to be used as an installer source. Guards against building an installer from a parent that expires before the download reaches the target machine. |
 | `ENROLLMENT_KEY_PEPPER` | -- | Pepper used for SHA-256 hashing of enrollment keys. Falls back to `APP_ENCRYPTION_KEY`, `SECRET_ENCRYPTION_KEY`, or `JWT_SECRET`. |
 | `AGENT_ENROLLMENT_SECRET` | -- | Static secret that gates the enrollment endpoint in production. If empty or unset, the gate is skipped in non-production environments. |
 | `ENROLLMENT_KEY_CLEANUP_ENABLED` | `true` | Set to `false` to disable the daily sweep that purges expired keys. |

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -54,6 +54,9 @@ In production, Breeze runs request handlers as an unprivileged, row-level-securi
 | `ENROLLMENT_KEY_PEPPER` | — | Yes | HMAC pepper for enrollment key hashing |
 | `MFA_RECOVERY_CODE_PEPPER` | — | Yes | HMAC pepper for recovery code hashing |
 | `ENROLLMENT_KEY_DEFAULT_TTL_MINUTES` | `60` | | Default enrollment key expiry |
+| `CHILD_ENROLLMENT_KEY_TTL_MINUTES` | `1440` | | Fresh TTL (minutes) given to a "child" enrollment key minted at installer-download, installer-link, or short-code redemption time, measured from mint time rather than the parent key's remaining lifetime |
+| `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` | `1440` | | Base TTL (minutes) for a freshly-issued installer bootstrap token when no explicit `ttlMinutes` is supplied. The token's own expiry, not the parent enrollment key's, governs how long an installer has to complete enrollment — see [Enrollment Keys](/agents/enrollment-keys/#installer-bootstrap-tokens) |
+| `INSTALLER_PARENT_MIN_REMAINING_SECONDS` | `60` | | Minimum remaining lifetime (seconds) a parent enrollment key must have to be used as an installer source. Guards against building an installer from a parent that expires before the download reaches the target machine |
 | `ENROLLMENT_KEY_CLEANUP_ENABLED` | `true` | | Set to `false` to disable the daily sweep that purges expired enrollment keys |
 | `ENROLLMENT_KEY_PURGE_AFTER_DAYS` | `7` | | Grace period (days past expiry) before an expired enrollment key is purged |
 | `SESSION_SECRET` | — | Yes | Session signing secret |

--- a/apps/web/src/components/devices/AddDeviceModal.test.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.test.tsx
@@ -505,3 +505,157 @@ describe('AddDeviceModal', () => {
       .toBe('application/json');
   });
 });
+
+describe('AddDeviceModal — resolved enrollment defaults (#2776)', () => {
+  const optionLabels = (testId: string): (string | null)[] =>
+    Array.from((screen.getByTestId(testId) as HTMLSelectElement).options).map(
+      (o) => o.textContent,
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setOrgStore();
+  });
+
+  it('pre-selects the partner/org default TTL and count, and hides options above the cap', async () => {
+    setOrgStore({
+      enrollmentDefaults: { ttlMinutes: 10080, deviceCount: 25, maxTtlMinutes: 43200 },
+    });
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect((screen.getByTestId('link-ttl') as HTMLSelectElement).value).toBe('10080');
+    });
+    expect((screen.getByTestId('device-count') as HTMLInputElement).value).toBe('25');
+
+    // 90 days and 1 year are above the 30-day cap and must not be offerable.
+    expect(optionLabels('link-ttl')).toEqual(['1 hour', '24 hours', '7 days', '30 days']);
+  });
+
+  it('falls back to the product defaults when the store has not resolved them yet', () => {
+    setOrgStore({ enrollmentDefaults: null });
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+
+    expect((screen.getByTestId('link-ttl') as HTMLSelectElement).value).toBe('1440');
+    expect((screen.getByTestId('device-count') as HTMLInputElement).value).toBe('1');
+    expect(optionLabels('link-ttl')).toEqual([
+      '1 hour',
+      '24 hours',
+      '7 days',
+      '30 days',
+      '90 days',
+      '1 year',
+    ]);
+  });
+
+  it('clamps a resolved default that sits above the cap instead of submitting a 400', async () => {
+    // The server resolver clamps, but a tab left open across a cap change (or
+    // any future resolver bug) must not put an over-cap value on the wire.
+    // Cap deliberately != the old hard-coded 1440, so this cannot pass on the
+    // pre-change component.
+    setOrgStore({
+      enrollmentDefaults: { ttlMinutes: 525600, deviceCount: 1, maxTtlMinutes: 10080 },
+    });
+
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/enrollment-keys') {
+        return makeJsonResponse({ id: 'key-cap', key: 'raw' }, true, 201);
+      }
+      return makeJsonResponse(null, true);
+    });
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect((screen.getByTestId('link-ttl') as HTMLSelectElement).value).toBe('10080');
+    });
+
+    fireEvent.click(getDownloadButton());
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(2);
+    });
+    expect(String(fetchWithAuthMock.mock.calls[1][0])).toContain('ttlMinutes=10080');
+  });
+
+  it('seeds the CLI tab from the same defaults while keeping its state independent', async () => {
+    setOrgStore({
+      enrollmentDefaults: { ttlMinutes: 10080, deviceCount: 25, maxTtlMinutes: 43200 },
+    });
+    fetchWithAuthMock.mockResolvedValue(
+      makeJsonResponse({ token: 'cli-token', maxUsage: 25 }),
+    );
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('tab-cli'));
+
+    await waitFor(() => {
+      expect(screen.getByText('cli-token')).toBeDefined();
+    });
+
+    expect((screen.getByTestId('cli-link-ttl') as HTMLSelectElement).value).toBe('10080');
+    expect((screen.getByTestId('cli-device-count') as HTMLInputElement).value).toBe('25');
+    expect(optionLabels('cli-link-ttl')).toEqual(['1 hour', '24 hours', '7 days', '30 days']);
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      '/devices/onboarding-token',
+      expect.objectContaining({
+        body: JSON.stringify({ count: 25, ttlMinutes: 10080 }),
+      }),
+    );
+
+    // Seeded from the same resolved default, but still its own state: changing
+    // the CLI expiry must not move the installer tab's.
+    fireEvent.change(screen.getByTestId('cli-link-ttl'), { target: { value: '60' } });
+    fireEvent.click(screen.getByTestId('tab-installer'));
+    expect((screen.getByTestId('link-ttl') as HTMLSelectElement).value).toBe('10080');
+  });
+
+  it('renders a non-canonical resolved default as its own option so display matches what is submitted', async () => {
+    // 20000 is under the 43200 cap but is not a canonical option. Filtering it
+    // out would leave the select matching nothing — the browser shows "1 hour"
+    // while the download URL still carries 20000.
+    setOrgStore({
+      enrollmentDefaults: { ttlMinutes: 20000, deviceCount: 1, maxTtlMinutes: 43200 },
+    });
+
+    fetchWithAuthMock.mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === '/enrollment-keys') {
+        return makeJsonResponse({ id: 'key-nc', key: 'raw' }, true, 201);
+      }
+      return makeJsonResponse(null, true);
+    });
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect((screen.getByTestId('link-ttl') as HTMLSelectElement).value).toBe('20000');
+    });
+    expect(
+      [...(screen.getByTestId('link-ttl') as HTMLSelectElement).options].map(o => o.value),
+    ).toEqual(['60', '1440', '10080', '20000', '43200']);
+
+    // What is displayed is what goes on the wire.
+    fireEvent.click(getDownloadButton());
+    await waitFor(() => {
+      expect(fetchWithAuthMock).toHaveBeenCalledTimes(2);
+    });
+    expect(String(fetchWithAuthMock.mock.calls[1][0])).toContain('ttlMinutes=20000');
+  });
+
+  it('offers the cap itself when it sits below every canonical option', async () => {
+    setOrgStore({
+      enrollmentDefaults: { ttlMinutes: 30, deviceCount: 1, maxTtlMinutes: 30 },
+    });
+
+    render(<AddDeviceModal isOpen onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect((screen.getByTestId('link-ttl') as HTMLSelectElement).value).toBe('30');
+    });
+    expect(optionLabels('link-ttl')).toEqual(['in about 30 minutes']);
+  });
+});

--- a/apps/web/src/components/devices/AddDeviceModal.tsx
+++ b/apps/web/src/components/devices/AddDeviceModal.tsx
@@ -13,6 +13,14 @@ import { buildInstallCommands } from "@/lib/installCommands";
 import { navigateTo } from "@/lib/navigation";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
+import {
+  clampTtlToOfferableOption,
+  enrollmentTtlOptionsIncluding,
+  ENROLLMENT_TTL_I18N_KEYS,
+  MAX_ENROLLMENT_TTL_MINUTES,
+  PRODUCT_DEFAULT_ENROLLMENT_DEVICE_COUNT,
+  PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES,
+} from "@breeze/shared";
 
 function detectUserOS(): "windows" | "macos" | "linux" {
   if (typeof navigator === "undefined") return "linux";
@@ -99,11 +107,43 @@ export default function AddDeviceModal({
   // modal has to distinguish "still loading", "load failed", and "genuinely no
   // sites" — otherwise a failed fetch looks identical to an unconfigured org and
   // nudges the user to create a duplicate site.
-  const { currentOrgId, sites, fetchSites, isLoading: sitesLoading, error: sitesError } = useOrgStore();
+  const {
+    currentOrgId,
+    sites,
+    fetchSites,
+    isLoading: sitesLoading,
+    error: sitesError,
+    enrollmentDefaults,
+  } = useOrgStore();
   const orgSites = useMemo(
     () => sites.filter((s) => s.orgId === currentOrgId),
     [sites, currentOrgId],
   );
+
+  // The partner/org enrollment defaults ride along on the sites response
+  // (#2776); until that resolves — or if the API soft-failed the settings read
+  // — fall back to the product defaults and the global ceiling, which is
+  // exactly the behaviour this modal had before defaults existed.
+  const defaultTtlMinutes =
+    enrollmentDefaults?.ttlMinutes ?? PRODUCT_DEFAULT_ENROLLMENT_TTL_MINUTES;
+  const defaultDeviceCount =
+    enrollmentDefaults?.deviceCount ?? PRODUCT_DEFAULT_ENROLLMENT_DEVICE_COUNT;
+  const maxTtlMinutes =
+    enrollmentDefaults?.maxTtlMinutes ?? MAX_ENROLLMENT_TTL_MINUTES;
+  // ONE option set for both tabs and both settings editors, filtered to what
+  // the partner cap actually permits. Offering a longer lifetime than the
+  // server will mint is the silent-discard defect this work removes: the mint
+  // routes 400 an over-cap ttlMinutes outright.
+  //
+  // The per-tab option lists live below, next to the state they depend on.
+  // Canonical options carry a `devices` namespace key shared with both settings
+  // editors. A cap set below every canonical option (API-only — the partner UI
+  // offers canonical values) surfaces as the raw cap, labelled with the existing
+  // pluralised minutes string rather than a new key in seven locales.
+  const ttlOptionLabel = (minutes: number): string =>
+    ENROLLMENT_TTL_I18N_KEYS[minutes]
+      ? t(/* i18n-dynamic */ ENROLLMENT_TTL_I18N_KEYS[minutes])
+      : t("addDeviceModal.expiryMinutes", { count: minutes });
 
   // Sites are fetched lazily now that the org switcher no longer preloads
   // them; make sure the site picker has data when the modal opens.
@@ -121,16 +161,24 @@ export default function AddDeviceModal({
     userOS === "macos" ? "macos" : "windows",
   );
   const [selectedSiteId, setSelectedSiteId] = useState("");
-  const [deviceCount, setDeviceCount] = useState(1);
+  const [deviceCount, setDeviceCount] = useState(defaultDeviceCount);
   // Lifetime of the installer / shared link the admin distributes. Sent to
   // the child-key mint routes (installer download + installer-link), where
   // the server resolves it to a fresh absolute expiry measured from mint
-  // time — not the transient parent key. 24h is the product default (it
-  // happens to coincide with the server's CHILD_ENROLLMENT_KEY_TTL_MINUTES
-  // fallback, but is set explicitly here, not inherited). "Never expires"
-  // is intentionally omitted until the partner-level cap
-  // (maxEnrollmentLinkTtlMinutes) lands in a sibling PR.
-  const [ttlMinutes, setTtlMinutes] = useState<number>(1440);
+  // time — not the transient parent key. Seeded from the partner/org resolved
+  // default and bounded by the partner cap (`maxEnrollmentLinkTtlMinutes`,
+  // shipped in #2776 — see services/enrollmentDefaults.ts); the product
+  // fallback when neither is set is still 24h.
+  //
+  // "Never expires" stays deliberately unimplemented, and is NOT merely a UI
+  // omission: `installer_bootstrap_tokens.expires_at` is NOT NULL with a
+  // CHECK (expires_at > created_at). Offering it needs a migration to relax
+  // both, plus null-handling through issuance
+  // (services/installerBootstrapTokenIssuance.ts), the consume path, the
+  // enrollment-key cleanup job (which sweeps on expires_at), and every expiry
+  // renderer here. A cap-exempt, never-expiring installer credential is also a
+  // policy decision, not just a schema one.
+  const [ttlMinutes, setTtlMinutes] = useState<number>(defaultTtlMinutes);
   const [downloading, setDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string>();
   const [downloadSuccess, setDownloadSuccess] = useState(false);
@@ -151,11 +199,32 @@ export default function AddDeviceModal({
   // #1108: how many machines this CLI token may enroll, and its real expiry,
   // both reported by the server so the UI never advertises a stale single-use
   // token as good for the whole fleet.
-  const [cliDeviceCount, setCliDeviceCount] = useState(1);
-  // Independent of the installer tab's ttlMinutes: the CLI command is
-  // typically pasted into a GPO/imaging script that runs later, so its
-  // useful default is longer than a hand-carried installer's.
-  const [cliTtlMinutes, setCliTtlMinutes] = useState<number>(1440);
+  const [cliDeviceCount, setCliDeviceCount] = useState(defaultDeviceCount);
+  // Independent of the installer tab's ttlMinutes. Both seed from the SAME
+  // resolved default (#2776), but the CLI command is typically pasted into a
+  // GPO/imaging script that runs later while an installer is hand-carried, so
+  // the two are kept as separate state: retuning one tab's expiry must never
+  // move the other's.
+  const [cliTtlMinutes, setCliTtlMinutes] = useState<number>(defaultTtlMinutes);
+  // Each tab renders its own option list, passing its OWN current value so a
+  // non-canonical one (an API-set default of, say, 20000 under a 43200 cap) is
+  // rendered as its own option. Without that the <select> matches nothing, the
+  // browser displays the first option ("1 hour") and the download URL still
+  // carries 20000 — display and submission disagreeing, which is the very
+  // defect this task removes. Over-cap values cannot reach here: both are
+  // folded down by the clamp effect below before any render uses them.
+  //
+  // Declared after the state they read, not up with `maxTtlMinutes` — a
+  // useMemo body runs during render, so referencing `ttlMinutes` above its
+  // `useState` would hit the temporal dead zone.
+  const ttlOptions = useMemo(
+    () => enrollmentTtlOptionsIncluding(maxTtlMinutes, ttlMinutes),
+    [maxTtlMinutes, ttlMinutes],
+  );
+  const cliTtlOptions = useMemo(
+    () => enrollmentTtlOptionsIncluding(maxTtlMinutes, cliTtlMinutes),
+    [maxTtlMinutes, cliTtlMinutes],
+  );
   const [tokenMaxUsage, setTokenMaxUsage] = useState<number | null>(null);
   const [tokenExpiresAt, setTokenExpiresAt] = useState<string | null>(null);
   const [selectedOS, setSelectedOS] = useState<"windows" | "macos" | "linux">(
@@ -193,13 +262,12 @@ export default function AddDeviceModal({
     if (isOpen) {
       setDownloadError(undefined);
       setDownloadSuccess(false);
-      setDeviceCount(1);
-      setTtlMinutes(1440);
+      // deviceCount / ttlMinutes / cliDeviceCount / cliTtlMinutes are reset by
+      // the seeding effect below instead — they come from the resolved
+      // partner/org defaults, which may still be in flight when this runs.
       setCliInitialized(false);
       setOnboardingToken("");
       setTokenError(undefined);
-      setCliDeviceCount(1);
-      setCliTtlMinutes(1440);
       setTokenMaxUsage(null);
       setTokenExpiresAt(null);
       setGeneratedLink("");
@@ -207,6 +275,38 @@ export default function AddDeviceModal({
       setLinkCopied(false);
     }
   }, [isOpen]);
+
+  // Seed the pickers from the resolved partner/org defaults (#2776). Separate
+  // from the reset effect above because the defaults arrive asynchronously with
+  // the sites response, so this must re-seed once they land instead of leaving
+  // the operator on the product fallback. Keeping it out of the reset effect
+  // also stops a late arrival from clearing `cliInitialized` and re-minting a
+  // CLI token that already exists.
+  //
+  // The dep array keys on the three PRIMITIVE values, not the
+  // `enrollmentDefaults` object: Zustand hands back a fresh object on every
+  // sites fetch, so an object dep would let any unrelated refetch re-seed over
+  // an edit the operator had already made. Keying on numbers makes a refetch
+  // carrying identical values a no-op.
+  //
+  // Both tabs seed from the SAME default but into their own state, so a later
+  // edit on one tab never follows through to the other.
+  useEffect(() => {
+    if (!isOpen) return;
+    setDeviceCount(defaultDeviceCount);
+    setCliDeviceCount(defaultDeviceCount);
+    setTtlMinutes(clampTtlToOfferableOption(defaultTtlMinutes, maxTtlMinutes));
+    setCliTtlMinutes(clampTtlToOfferableOption(defaultTtlMinutes, maxTtlMinutes));
+  }, [isOpen, defaultTtlMinutes, defaultDeviceCount, maxTtlMinutes]);
+
+  // Belt-and-braces against a stale selection outliving a cap change: if the
+  // cap tightens under a value the operator already picked (or a resolved
+  // default lands above it), fold it down to the largest still-offerable
+  // option rather than posting a ttlMinutes the mint routes will 400.
+  useEffect(() => {
+    setTtlMinutes((prev) => clampTtlToOfferableOption(prev, maxTtlMinutes));
+    setCliTtlMinutes((prev) => clampTtlToOfferableOption(prev, maxTtlMinutes));
+  }, [maxTtlMinutes]);
 
   // Guards against overlapping CLI token fetches (the auto-init effect racing a
   // manual "Generate new token", or a fast double-click). A ref, not state, so
@@ -695,6 +795,7 @@ export default function AddDeviceModal({
                   </label>
                   <input
                     id="device-count"
+                    data-testid="device-count"
                     type="number"
                     value={deviceCount}
                     onChange={(e) =>
@@ -732,14 +833,11 @@ export default function AddDeviceModal({
                     className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
                     data-testid="link-ttl"
                   >
-                    <option value={60}>{t("addDeviceModal.n1Hour")}</option>
-                    <option value={1440}>{t("addDeviceModal.n24Hours")}</option>
-                    <option value={10080}>{t("addDeviceModal.n7Days")}</option>
-                    <option value={43200}>{t("addDeviceModal.n30Days")}</option>
-                    <option value={129600}>
-                      {t("addDeviceModal.n90Days")}
-                    </option>
-                    <option value={525600}>{t("addDeviceModal.n1Year")}</option>
+                    {ttlOptions.map((minutes) => (
+                      <option key={minutes} value={minutes}>
+                        {ttlOptionLabel(minutes)}
+                      </option>
+                    ))}
                   </select>
                   <p className="mt-1 text-xs text-muted-foreground">
                     {t(
@@ -982,6 +1080,7 @@ export default function AddDeviceModal({
                         </label>
                         <input
                           id="cli-device-count"
+                          data-testid="cli-device-count"
                           type="number"
                           min={1}
                           max={1000}
@@ -1014,22 +1113,11 @@ export default function AddDeviceModal({
                           }}
                           className="rounded-md border bg-background px-2 py-1 text-sm"
                         >
-                          <option value={60}>{t("addDeviceModal.n1Hour")}</option>
-                          <option value={1440}>
-                            {t("addDeviceModal.n24Hours")}
-                          </option>
-                          <option value={10080}>
-                            {t("addDeviceModal.n7Days")}
-                          </option>
-                          <option value={43200}>
-                            {t("addDeviceModal.n30Days")}
-                          </option>
-                          <option value={129600}>
-                            {t("addDeviceModal.n90Days")}
-                          </option>
-                          <option value={525600}>
-                            {t("addDeviceModal.n1Year")}
-                          </option>
+                          {cliTtlOptions.map((minutes) => (
+                            <option key={minutes} value={minutes}>
+                              {ttlOptionLabel(minutes)}
+                            </option>
+                          ))}
                         </select>
                       </div>
                       <button

--- a/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.test.tsx
@@ -108,3 +108,150 @@ describe('OrgDefaultsEditor — maintenance window', () => {
     expect(screen.queryByTestId('maintenance-stored-invalid')).not.toBeInTheDocument();
   });
 });
+
+describe('OrgDefaultsEditor — enrollment defaults (#2776)', () => {
+  it('includes the enrollment defaults in the saved payload', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<OrgDefaultsEditor organizationName={ORG} onSave={onSave} locked={[]} />);
+
+    await user.selectOptions(screen.getByTestId('org-default-enrollment-ttl'), '10080');
+    const count = screen.getByTestId('org-default-enrollment-device-count');
+    await user.clear(count);
+    await user.type(count, '25');
+    await user.click(screen.getByTestId('save-defaults'));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultEnrollmentTtlMinutes: 10080,
+        defaultEnrollmentDeviceCount: 25,
+      }),
+    );
+  });
+
+  it('hydrates the stored org values', () => {
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        defaults={{ defaultEnrollmentTtlMinutes: 43200, defaultEnrollmentDeviceCount: 7 }}
+      />,
+    );
+    expect((screen.getByTestId('org-default-enrollment-ttl') as HTMLSelectElement).value).toBe('43200');
+    expect((screen.getByTestId('org-default-enrollment-device-count') as HTMLInputElement).value).toBe('7');
+  });
+
+  it('omits an unset enrollment default from the payload so the partner value is inherited', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<OrgDefaultsEditor organizationName={ORG} onSave={onSave} />);
+
+    await user.click(screen.getByTestId('save-defaults'));
+
+    const payload = onSave.mock.calls[0][0];
+    expect(payload.defaultEnrollmentTtlMinutes).toBeUndefined();
+    expect(payload.defaultEnrollmentDeviceCount).toBeUndefined();
+  });
+
+  it('never offers an editable link-lifetime cap — the cap is partner-only', () => {
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={vi.fn()}
+        locked={['defaults.maxEnrollmentLinkTtlMinutes']}
+        partnerMaxEnrollmentTtlMinutes={1440}
+      />,
+    );
+    expect(screen.queryByTestId('org-max-enrollment-ttl')).toBeNull();
+    expect(screen.getByTestId('org-max-enrollment-ttl-readonly')).toBeInTheDocument();
+  });
+
+  it('does not surface a cap notice when the partner has not set one', () => {
+    render(<OrgDefaultsEditor organizationName={ORG} onSave={vi.fn()} locked={[]} />);
+    expect(screen.queryByTestId('org-max-enrollment-ttl-readonly')).toBeNull();
+  });
+
+  it('never sends maxEnrollmentLinkTtlMinutes, even when the org blob still carries a stale one', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={onSave}
+        defaults={{ maxEnrollmentLinkTtlMinutes: 525600 }}
+        locked={['defaults.maxEnrollmentLinkTtlMinutes']}
+        partnerMaxEnrollmentTtlMinutes={60}
+      />,
+    );
+
+    await user.click(screen.getByTestId('save-defaults'));
+    // Sending it back would 403 against the partner lock (assertNotLocked).
+    expect('maxEnrollmentLinkTtlMinutes' in onSave.mock.calls[0][0]).toBe(false);
+  });
+
+  it('offers only TTL options at or below the partner cap', () => {
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={vi.fn()}
+        locked={['defaults.maxEnrollmentLinkTtlMinutes']}
+        partnerMaxEnrollmentTtlMinutes={10080}
+      />,
+    );
+
+    const select = screen.getByTestId('org-default-enrollment-ttl') as HTMLSelectElement;
+    const values = Array.from(select.options).map(o => o.value);
+    // '' is the "inherit from partner" entry; 30 days / 90 days / 1 year are
+    // above the 7-day cap and would be silently clamped at read time.
+    expect(values).toEqual(['', '60', '1440', '10080']);
+  });
+
+  it('shows a stored over-cap default as its own option instead of misreporting it', () => {
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={vi.fn()}
+        defaults={{ defaultEnrollmentTtlMinutes: 525600 }}
+        locked={['defaults.maxEnrollmentLinkTtlMinutes']}
+        partnerMaxEnrollmentTtlMinutes={1440}
+      />,
+    );
+
+    const select = screen.getByTestId('org-default-enrollment-ttl') as HTMLSelectElement;
+    // The stored value is what is displayed — dropping it would leave the
+    // select on the blank "inherit" entry, reporting an override as absent.
+    expect(select.value).toBe('525600');
+    expect([...select.options].map(o => o.value)).toEqual(['', '60', '1440', '525600']);
+  });
+
+  it('never rewrites a stored over-cap default when an unrelated field is saved', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(
+      <OrgDefaultsEditor
+        organizationName={ORG}
+        onSave={onSave}
+        defaults={{ defaultEnrollmentTtlMinutes: 525600 }}
+        locked={['defaults.maxEnrollmentLinkTtlMinutes']}
+        partnerMaxEnrollmentTtlMinutes={1440}
+      />,
+    );
+
+    // This editor rebuilds the WHOLE defaults blob on save, so clamping here
+    // would let someone editing their maintenance window silently destroy an
+    // enrollment preference they never touched — irreversibly, if the partner
+    // later raises the cap. resolveEnrollmentDefaults clamps at read time.
+    await user.click(screen.getByTestId('maintenance-mode-window'));
+    await user.click(screen.getByTestId('save-defaults'));
+
+    expect(onSave.mock.calls[0][0].defaultEnrollmentTtlMinutes).toBe(525600);
+  });
+
+  it('leaves the full option set when the partner has set no cap', () => {
+    render(<OrgDefaultsEditor organizationName={ORG} onSave={vi.fn()} locked={[]} />);
+
+    const select = screen.getByTestId('org-default-enrollment-ttl') as HTMLSelectElement;
+    expect(Array.from(select.options).map(o => o.value)).toEqual([
+      '', '60', '1440', '10080', '43200', '129600', '525600',
+    ]);
+  });
+});

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import '@/lib/i18n';
-import { Bell, Layers, RefreshCcw, Save, ShieldCheck, Sparkles } from 'lucide-react';
+import { Bell, KeyRound, Layers, RefreshCcw, Save, ShieldCheck, Sparkles } from 'lucide-react';
 import AgentVersionPinSelectors, {
   type PinnableVersions,
   type AgentVersionPinsValue,
 } from './AgentVersionPinSelectors';
+import type { InheritableDefaultSettings } from '@breeze/shared';
 import {
   MAINTENANCE_WINDOW_ALWAYS,
   MAINTENANCE_DAYS,
+  ENROLLMENT_TTL_I18N_KEYS,
+  MAX_ENROLLMENT_DEVICE_COUNT,
+  MAX_ENROLLMENT_TTL_MINUTES,
+  enrollmentTtlOptionsIncluding,
   isValidMaintenanceWindow,
   parseMaintenanceWindow,
   formatMaintenanceWindow,
@@ -40,19 +45,12 @@ function deriveWindowState(raw: string | undefined): WindowState {
   return { mode: 'always', day: '', start: '02:00', end: '04:00' };
 }
 
-type DefaultsData = {
-  policyDefaults?: Record<string, string>;
-  deviceGroup?: string;
-  alertThreshold?: string;
-  autoEnrollment?: {
-    enabled: boolean;
-    requireApproval: boolean;
-    sendWelcome: boolean;
-  };
-  agentUpdatePolicy?: string;
-  maintenanceWindow?: string;
-  agentVersionPins?: { agent?: string; watchdog?: string };
-};
+// The shape of `organizations.settings.defaults`. This deliberately ALIASES the
+// shared type rather than restating it: this editor rebuilds the whole object
+// on save (see handleSave), so a field this type doesn't know about is dropped
+// on every save with no error. Add new fields to InheritableDefaultSettings in
+// packages/shared and wire them into handleSave — never re-fork this type.
+type DefaultsData = InheritableDefaultSettings;
 
 type OrgDefaultsEditorProps = {
   organizationName: string;
@@ -64,6 +62,11 @@ type OrgDefaultsEditorProps = {
   // there is no lock — an org pin always overrides the partner default.
   pinnableVersions?: PinnableVersions | null;
   partnerPins?: AgentVersionPinsValue;
+  // Partner-locked field paths (`defaults.<field>`) from GET effective-settings.
+  locked?: string[];
+  // Issue #2776: the partner's enrollment-link lifetime cap, shown read-only.
+  // The cap is partner-only — an org can never edit it here (see below).
+  partnerMaxEnrollmentTtlMinutes?: number;
 };
 
 const defaultValues: DefaultsData = {
@@ -126,8 +129,11 @@ export default function OrgDefaultsEditor({
   onSave,
   pinnableVersions,
   partnerPins,
+  locked,
+  partnerMaxEnrollmentTtlMinutes,
 }: OrgDefaultsEditorProps) {
   const { t } = useTranslation('settings');
+  const isLocked = (field: string) => locked?.includes(`defaults.${field}`) ?? false;
   const initialData = { ...defaultValues, ...defaults };
   // Version pins are inherit-with-override (issue #2124): the org can always set
   // its own, which overrides the partner default. No lock.
@@ -153,6 +159,16 @@ export default function OrgDefaultsEditor({
     typeof initialData.maintenanceWindow === 'string' &&
     initialData.maintenanceWindow.trim() !== '' &&
     !isValidMaintenanceWindow(initialData.maintenanceWindow);
+  // Issue #2776: both VALUES are inherit-with-override — `undefined` means "no
+  // org override, follow the partner", so they are deliberately absent from
+  // `defaultValues` (seeding one would silently pin this org to the product
+  // default the first time defaults are saved).
+  const [enrollmentTtlMinutes, setEnrollmentTtlMinutes] = useState<number | undefined>(
+    initialData.defaultEnrollmentTtlMinutes,
+  );
+  const [enrollmentDeviceCount, setEnrollmentDeviceCount] = useState<number | undefined>(
+    initialData.defaultEnrollmentDeviceCount,
+  );
   const [windowMode, setWindowMode] = useState<WindowMode>(initialWindow.mode);
   const [windowDay, setWindowDay] = useState(initialWindow.day);
   const [windowStart, setWindowStart] = useState(initialWindow.start);
@@ -168,6 +184,32 @@ export default function OrgDefaultsEditor({
     windowMode === 'window' && !builtWindow
       ? t('orgDefaultsEditor.maintenance.errors.invalidWindow')
       : null;
+
+  // The partner cap is surfaced read-only: an org that could raise it wouldn't
+  // be capped at all. `locked` carries `defaults.maxEnrollmentLinkTtlMinutes`
+  // whenever the partner set one; the effective value may lag it by a fetch, so
+  // an unknown value still renders the (valueless) notice rather than nothing.
+  const showEnrollmentCap =
+    isLocked('maxEnrollmentLinkTtlMinutes') || typeof partnerMaxEnrollmentTtlMinutes === 'number';
+  const formatTtlMinutes = (minutes: number): string =>
+    ENROLLMENT_TTL_I18N_KEYS[minutes]
+      ? t(/* i18n-dynamic */ `devices:${ENROLLMENT_TTL_I18N_KEYS[minutes]}`)
+      : t('orgDefaultsEditor.enrollment.capMinutes', { minutes });
+
+  // Only lifetimes at or below the partner cap are SELECTABLE: picking "7 days"
+  // under a 1-hour cap would promise a lifetime the resolver clamps away.
+  //
+  // But an ALREADY-STORED value above the cap is included as its own option, so
+  // the select shows what is actually stored. It is deliberately not rewritten:
+  // `defaultEnrollmentTtlMinutes` is lock-exempt, resolveEnrollmentDefaults
+  // clamps it on every read, and handleSave below rebuilds the WHOLE defaults
+  // blob — so clamping here would let someone editing their maintenance window
+  // silently and irreversibly destroy an enrollment preference they never
+  // touched, with no way back if the partner later raises the cap.
+  const ttlOptions = enrollmentTtlOptionsIncluding(
+    partnerMaxEnrollmentTtlMinutes ?? MAX_ENROLLMENT_TTL_MINUTES,
+    enrollmentTtlMinutes,
+  );
 
   const markDirty = () => {
     onDirty?.();
@@ -191,6 +233,20 @@ export default function OrgDefaultsEditor({
       agentUpdatePolicy,
       maintenanceWindow: builtWindow,
       agentVersionPins,
+      // `undefined` serializes away entirely, which is what "inherit from the
+      // partner" means to the resolver (it keys on key presence, not value).
+      //
+      // Persisted verbatim, never clamped to the partner cap. This editor
+      // rebuilds the entire blob on every save, so a save triggered by an
+      // unrelated field must not rewrite this one. The cap is applied at read
+      // time by resolveEnrollmentDefaults; the select shows the stored value
+      // honestly (see ttlOptions above) so nothing is hidden either way.
+      defaultEnrollmentTtlMinutes: enrollmentTtlMinutes,
+      defaultEnrollmentDeviceCount: enrollmentDeviceCount,
+      // maxEnrollmentLinkTtlMinutes is intentionally NOT rebuilt here. It is a
+      // partner-only ceiling: the resolver ignores an org-set value, and the
+      // org PATCH rejects it with 403 once the partner has set one. Omitting it
+      // both drops any stale org-stored cap and keeps Save from 403ing.
     };
     onSave?.(data);
   };
@@ -470,6 +526,67 @@ export default function OrgDefaultsEditor({
             </p>
           </div>
         </div>
+      </div>
+
+      {/* Enrollment defaults (#2776). Both values are inherit-with-override;
+          the lifetime CAP is partner-only and therefore read-only here. */}
+      <div className="space-y-4 rounded-lg border bg-muted/40 p-4">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <KeyRound className="h-4 w-4" />
+          {t('orgDefaultsEditor.enrollment.title')}
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="space-y-2 text-sm">
+            <span className="font-medium">{t('orgDefaultsEditor.enrollment.ttl')}</span>
+            <select
+              value={enrollmentTtlMinutes ?? ''}
+              onChange={event => {
+                setEnrollmentTtlMinutes(event.target.value ? Number(event.target.value) : undefined);
+                markDirty();
+              }}
+              data-testid="org-default-enrollment-ttl"
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            >
+              <option value="">{t('orgDefaultsEditor.enrollment.inherit')}</option>
+              {ttlOptions.map(minutes => (
+                <option key={minutes} value={minutes}>
+                  {formatTtlMinutes(minutes)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-2 text-sm">
+            <span className="font-medium">{t('orgDefaultsEditor.enrollment.deviceCount')}</span>
+            <input
+              type="number"
+              min={1}
+              max={MAX_ENROLLMENT_DEVICE_COUNT}
+              value={enrollmentDeviceCount ?? ''}
+              onChange={event => {
+                setEnrollmentDeviceCount(event.target.value ? Number(event.target.value) : undefined);
+                markDirty();
+              }}
+              placeholder={t('orgDefaultsEditor.enrollment.inherit')}
+              data-testid="org-default-enrollment-device-count"
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            />
+          </label>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t('orgDefaultsEditor.enrollment.description')}
+        </p>
+        {showEnrollmentCap && (
+          <p
+            data-testid="org-max-enrollment-ttl-readonly"
+            className="text-xs text-amber-600 dark:text-amber-400"
+          >
+            {typeof partnerMaxEnrollmentTtlMinutes === 'number'
+              ? t('orgDefaultsEditor.enrollment.capNotice', {
+                  value: formatTtlMinutes(partnerMaxEnrollmentTtlMinutes),
+                })
+              : t('orgDefaultsEditor.enrollment.capNoticeUnknown')}
+          </p>
+        )}
       </div>
 
       <AgentVersionPinSelectors

--- a/apps/web/src/components/settings/OrgSettingsPage.tsx
+++ b/apps/web/src/components/settings/OrgSettingsPage.tsx
@@ -254,6 +254,9 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
   // effective pins (shown when `defaults.agentVersionPins` is partner-locked).
   const [pinnableVersions, setPinnableVersions] = useState<PinnableVersions | null>(null);
   const [partnerPins, setPartnerPins] = useState<AgentVersionPinsValue | undefined>(undefined);
+  // Issue #2776: the partner's enrollment-link lifetime cap, for the read-only
+  // notice in the defaults editor. Partner-only — the org never edits it.
+  const [partnerMaxEnrollmentTtl, setPartnerMaxEnrollmentTtl] = useState<number | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [copiedOrgId, setCopiedOrgId] = useState(false);
@@ -302,6 +305,17 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
         setPartnerPins(
           lockedList.includes('defaults.agentVersionPins')
             ? effData.effective?.defaults?.agentVersionPins
+            : undefined,
+        );
+        // Same signal for the enrollment cap (#2776): `locked` is what tells us
+        // the value came from the PARTNER. Without that check the merged value
+        // could be the org's own stale cap, which the resolver ignores — showing
+        // it as "your partner caps you at X" would be a lie.
+        const effectiveCap = effData.effective?.defaults?.maxEnrollmentLinkTtlMinutes;
+        setPartnerMaxEnrollmentTtl(
+          lockedList.includes('defaults.maxEnrollmentLinkTtlMinutes') &&
+            typeof effectiveCap === 'number'
+            ? effectiveCap
             : undefined,
         );
       } else {
@@ -702,9 +716,14 @@ export default function OrgSettingsPage({ orgId: propOrgId }: OrgSettingsPagePro
               organizationName={displayOrg.name}
               defaults={orgDetails?.settings?.defaults}
               onDirty={handleDirty}
-              onSave={(data) => handleSave('defaults', data)}
+              // The editor now emits the shared `InheritableDefaultSettings`
+              // interface, which (unlike a type alias) has no implicit index
+              // signature — spread it into a plain record for the save helper.
+              onSave={(data) => handleSave('defaults', { ...data })}
               pinnableVersions={pinnableVersions}
               partnerPins={partnerPins}
+              locked={locked}
+              partnerMaxEnrollmentTtlMinutes={partnerMaxEnrollmentTtl}
             />
           </div>
         );

--- a/apps/web/src/components/settings/PartnerDefaultsTab.test.tsx
+++ b/apps/web/src/components/settings/PartnerDefaultsTab.test.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { InheritableDefaultSettings } from '@breeze/shared';
+import { ENROLLMENT_TTL_OPTIONS } from '@breeze/shared';
+
+import PartnerDefaultsTab from './PartnerDefaultsTab';
+
+/**
+ * The tab is fully controlled by PartnerSettingsPage, so a bare `vi.fn()`
+ * onChange leaves every input frozen at its initial value — multi-keystroke
+ * typing would then report only the last character. This harness holds the
+ * state the real parent holds and forwards each value to the spy.
+ */
+function ControlledTab({ onChange, initial = {} }: {
+  onChange: (data: InheritableDefaultSettings) => void;
+  initial?: InheritableDefaultSettings;
+}) {
+  const [data, setData] = useState<InheritableDefaultSettings>(initial);
+  return (
+    <PartnerDefaultsTab
+      data={data}
+      onChange={next => {
+        setData(next);
+        onChange(next);
+      }}
+    />
+  );
+}
+
+describe('PartnerDefaultsTab — enrollment defaults (#2776)', () => {
+  it('renders the shared TTL option set (plus the not-set option) for both TTL fields', () => {
+    render(<PartnerDefaultsTab data={{}} onChange={vi.fn()} />);
+
+    for (const testId of ['partner-enrollment-ttl', 'partner-max-enrollment-ttl']) {
+      const select = screen.getByTestId(testId) as HTMLSelectElement;
+      expect([...select.options].map(o => o.value)).toEqual([
+        '',
+        ...ENROLLMENT_TTL_OPTIONS.map(String),
+      ]);
+    }
+  });
+
+  it('filters the DEFAULT TTL to the partner\'s own cap while the cap picker keeps the full range', () => {
+    render(
+      <PartnerDefaultsTab
+        data={{ maxEnrollmentLinkTtlMinutes: 10080 }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    // The default is clamped to the cap by resolveEnrollmentDefaults, so
+    // offering a longer one here would advertise a lifetime no link gets.
+    expect(
+      [...(screen.getByTestId('partner-enrollment-ttl') as HTMLSelectElement).options].map(
+        o => o.value,
+      ),
+    ).toEqual(['', '60', '1440', '10080']);
+
+    // The cap picker defines the cap — it must stay unfiltered.
+    expect(
+      [...(screen.getByTestId('partner-max-enrollment-ttl') as HTMLSelectElement).options].map(
+        o => o.value,
+      ),
+    ).toEqual(['', ...ENROLLMENT_TTL_OPTIONS.map(String)]);
+  });
+
+  it('shows a stored over-cap default as its own option rather than a clamped one', () => {
+    render(
+      <PartnerDefaultsTab
+        data={{ defaultEnrollmentTtlMinutes: 525600, maxEnrollmentLinkTtlMinutes: 1440 }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    // This component is controlled and never rewrites `data`, so displaying a
+    // clamped value would mean showing "1 hour" while the parent persists
+    // 525600.
+    const select = screen.getByTestId('partner-enrollment-ttl') as HTMLSelectElement;
+    expect(select.value).toBe('525600');
+    expect([...select.options].map(o => o.value)).toEqual(['', '60', '1440', '525600']);
+  });
+
+  it('emits the three enrollment fields as numbers', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ControlledTab onChange={onChange} />);
+
+    await user.selectOptions(screen.getByTestId('partner-enrollment-ttl'), '10080');
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ defaultEnrollmentTtlMinutes: 10080 }),
+    );
+
+    await user.selectOptions(screen.getByTestId('partner-max-enrollment-ttl'), '60');
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ maxEnrollmentLinkTtlMinutes: 60 }),
+    );
+
+    await user.type(screen.getByTestId('partner-enrollment-device-count'), '25');
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ defaultEnrollmentDeviceCount: 25 }),
+    );
+  });
+
+  it('hydrates stored values and clears a field back to not-set', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ControlledTab
+        onChange={onChange}
+        initial={{ defaultEnrollmentTtlMinutes: 1440, defaultEnrollmentDeviceCount: 5, maxEnrollmentLinkTtlMinutes: 43200 }}
+      />,
+    );
+
+    expect((screen.getByTestId('partner-enrollment-ttl') as HTMLSelectElement).value).toBe('1440');
+    expect((screen.getByTestId('partner-enrollment-device-count') as HTMLInputElement).value).toBe('5');
+    expect((screen.getByTestId('partner-max-enrollment-ttl') as HTMLSelectElement).value).toBe('43200');
+
+    await user.selectOptions(screen.getByTestId('partner-max-enrollment-ttl'), '');
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ maxEnrollmentLinkTtlMinutes: undefined }),
+    );
+  });
+});

--- a/apps/web/src/components/settings/PartnerDefaultsTab.tsx
+++ b/apps/web/src/components/settings/PartnerDefaultsTab.tsx
@@ -1,5 +1,12 @@
 import type { InheritableDefaultSettings } from '@breeze/shared';
-import { isValidMaintenanceWindow } from '@breeze/shared';
+import {
+  ENROLLMENT_TTL_I18N_KEYS,
+  ENROLLMENT_TTL_OPTIONS,
+  MAX_ENROLLMENT_DEVICE_COUNT,
+  MAX_ENROLLMENT_TTL_MINUTES,
+  enrollmentTtlOptionsIncluding,
+  isValidMaintenanceWindow,
+} from '@breeze/shared';
 import AgentVersionPinSelectors, { type PinnableVersions } from './AgentVersionPinSelectors';
 import { Trans, useTranslation } from 'react-i18next';
 import '@/lib/i18n';
@@ -19,6 +26,34 @@ export default function PartnerDefaultsTab({ data, onChange, pinnableVersions }:
 
   const maintenanceWindow = data.maintenanceWindow ?? '';
   const maintenanceWindowInvalid = maintenanceWindow.trim() !== '' && !isValidMaintenanceWindow(maintenanceWindow);
+
+  // One option set for the Add Device modal and both settings tabs (#2776).
+  // The labels are the existing `devices` namespace strings — this component
+  // reads the `settings` namespace, so they carry an explicit ns prefix rather
+  // than being duplicated into a parallel `settings` key set.
+  const renderTtlOptions = (minutesList: readonly number[]) =>
+    minutesList.map(minutes => (
+      <option key={minutes} value={minutes}>
+        {ENROLLMENT_TTL_I18N_KEYS[minutes]
+          ? t(/* i18n-dynamic */ `devices:${ENROLLMENT_TTL_I18N_KEYS[minutes]}`)
+          // Non-canonical minute value (an API-set cap). Reuses the org
+          // editor's existing bare-minutes string rather than minting a
+          // parallel partner key in all seven locales.
+          : t('orgDefaultsEditor.enrollment.capMinutes', { minutes })}
+      </option>
+    ));
+
+  // The cap picker itself must offer the full range — it is the thing being
+  // defined. The DEFAULT picker must not: resolveEnrollmentDefaults clamps the
+  // resolved default to the cap, so offering "1 year" under a 1-hour cap would
+  // advertise a lifetime no link ever gets (the same silent discard #2776 is
+  // about, just self-inflicted rather than inherited).
+  //
+  // An already-stored over-cap default is still shown as its own option rather
+  // than clamped for display. This component is controlled — it never rewrites
+  // `data`, it only renders it — so displaying a clamped value while the parent
+  // saved the raw one would mean showing "1 hour" and persisting 525600.
+  const partnerCap = data.maxEnrollmentLinkTtlMinutes ?? MAX_ENROLLMENT_TTL_MINUTES;
 
   return (
     <div className="space-y-6">
@@ -131,6 +166,81 @@ export default function PartnerDefaultsTab({ data, onChange, pinnableVersions }:
               className="h-4 w-4 rounded border"
             />
             <label className="text-sm font-medium">{t('partnerDefaults.autoEnrollment.sendWelcome')}</label>
+          </div>
+        </div>
+      </div>
+
+      {/* Enrollment link defaults + the partner-only lifetime cap (#2776) */}
+      <div className="space-y-4 rounded-lg border bg-muted/40 p-4">
+        <p className="text-sm font-medium">{t('partnerDefaults.enrollment.title')}</p>
+        <div className="grid gap-6 sm:grid-cols-2">
+          <div className="space-y-2">
+            <label htmlFor="partner-enrollment-ttl" className="text-sm font-medium">
+              {t('partnerDefaults.enrollment.ttl')}
+            </label>
+            <select
+              id="partner-enrollment-ttl"
+              data-testid="partner-enrollment-ttl"
+              value={data.defaultEnrollmentTtlMinutes ?? ''}
+              onChange={e => set({
+                defaultEnrollmentTtlMinutes: e.target.value ? Number(e.target.value) : undefined,
+              })}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            >
+              <option value="">{t('partnerDefaults.notSet')}</option>
+              {renderTtlOptions(
+                enrollmentTtlOptionsIncluding(partnerCap, data.defaultEnrollmentTtlMinutes),
+              )}
+            </select>
+            <p className="text-xs text-muted-foreground">
+              {t('partnerDefaults.enrollment.ttlHint')}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="partner-enrollment-device-count" className="text-sm font-medium">
+              {t('partnerDefaults.enrollment.deviceCount')}
+            </label>
+            <input
+              id="partner-enrollment-device-count"
+              data-testid="partner-enrollment-device-count"
+              type="number"
+              min={1}
+              max={MAX_ENROLLMENT_DEVICE_COUNT}
+              value={data.defaultEnrollmentDeviceCount ?? ''}
+              onChange={e => set({
+                defaultEnrollmentDeviceCount: e.target.value ? Number(e.target.value) : undefined,
+              })}
+              placeholder={t('partnerDefaults.notSet')}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              {t('partnerDefaults.enrollment.deviceCountHint')}
+            </p>
+          </div>
+
+          <div className="space-y-2 sm:col-span-2">
+            <label htmlFor="partner-max-enrollment-ttl" className="text-sm font-medium">
+              {t('partnerDefaults.enrollment.maxTtl')}
+            </label>
+            <select
+              id="partner-max-enrollment-ttl"
+              data-testid="partner-max-enrollment-ttl"
+              value={data.maxEnrollmentLinkTtlMinutes ?? ''}
+              onChange={e => set({
+                maxEnrollmentLinkTtlMinutes: e.target.value ? Number(e.target.value) : undefined,
+              })}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm sm:max-w-xs"
+            >
+              <option value="">{t('partnerDefaults.notSet')}</option>
+              {renderTtlOptions(ENROLLMENT_TTL_OPTIONS)}
+            </select>
+            <p className="text-xs text-muted-foreground">
+              {t('partnerDefaults.enrollment.maxTtlHint')}
+            </p>
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              {t('partnerDefaults.enrollment.maxTtlWarning')}
+            </p>
           </div>
         </div>
       </div>

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -111,7 +111,9 @@ const namespaceDuplicateBaselines = {
     'reports.json': 43,
     'scripts.json': 60,
     'security.json': 144,
-    'settings.json': 143,
+    // +1: orgDefaultsEditor.enrollment.capMinutes — "{{minutes}} minutes" is
+    // spelled identically in French.
+    'settings.json': 144,
     'tickets.json': 21,
     'vulnerabilities.json': 15,
   },
@@ -141,7 +143,9 @@ const namespaceDuplicateBaselines = {
     'reports.json': 43,
     'scripts.json': 60,
     'security.json': 144,
-    'settings.json': 148,
+    // +1: orgDefaultsEditor.enrollment.capMinutes — "{{minutes}} minutes" is
+    // spelled identically in French.
+    'settings.json': 149,
     'tickets.json': 20,
     'vulnerabilities.json': 15,
   },

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -142,6 +142,16 @@
       "enable": "Aktivieren Sie die automatische Registrierung für neue Geräte",
       "requireApproval": "Erfordert die Genehmigung des Administrators",
       "sendWelcome": "Willkommensbenachrichtigung senden"
+    },
+    "enrollment": {
+      "title": "Geräteregistrierung",
+      "ttl": "Standardgültigkeit von Links",
+      "ttlHint": "Legt vorab fest, wie lange neue Registrierungslinks und Installer gültig bleiben. Organisationen können einen abweichenden Standard wählen.",
+      "deviceCount": "Standardanzahl Geräte pro Link",
+      "deviceCountHint": "Wie viele Rechner ein Registrierungslink standardmäßig registrieren darf. Organisationen können einen abweichenden Standard wählen.",
+      "maxTtl": "Maximale Gültigkeit von Links",
+      "maxTtlHint": "Eine Obergrenze für die Lebensdauer von Schlüsseln, nicht nur dafür, was ein Administrator anfordern darf: Nichts, was unter diesem Partner ausgestellt wird, bleibt länger nutzbar — Registrierungslinks, MCP-Bereitstellungseinladungen und die untergeordneten Anmeldedaten, die beim Einlösen eines Installers ausgestellt werden.",
+      "maxTtlWarning": "Organisationen können diesen Wert nicht erhöhen. Eine kurze Obergrenze verkürzt auch die Zeit, die ein Rechner nach dem Einlösen eines Links zum Abschluss der Registrierung hat — nicht nur die Zeit zum Herunterladen."
     }
   },
   "partnerEventLogs": {
@@ -796,6 +806,16 @@
         "invalidWindow": "Geben Sie ein gültiges Fenster ein – Start- und Endzeit müssen unterschiedlich sein.",
         "storedInvalid": "Ihr gespeichertes Wartungsfenster war ungültig und wird ignoriert, sodass Agenten derzeit jederzeit Aktualisierungen durchführen können. Wählen Sie unten eine gültige Einstellung aus und speichern Sie sie, um das Problem zu beheben."
       }
+    },
+    "enrollment": {
+      "title": "Geräteregistrierung",
+      "ttl": "Standardgültigkeit von Links",
+      "deviceCount": "Standardanzahl Geräte pro Link",
+      "inherit": "Vom Partner übernehmen",
+      "description": "Wählt Gültigkeit und Geräteanzahl im Dialog „Gerät hinzufügen“ vorab aus. Belassen Sie ein Feld auf „Vom Partner übernehmen“, um dem Standard Ihres Partners zu folgen.",
+      "capNotice": "Ihr Partner begrenzt die Gültigkeit von Registrierungslinks auf {{value}}. Links, MCP-Bereitstellungseinladungen und vom Installer ausgestellte Anmeldedaten funktionieren danach nicht mehr — ein Rechner muss die Registrierung also ebenfalls innerhalb dieses Zeitraums abschließen.",
+      "capNoticeUnknown": "Ihr Partner legt eine maximale Gültigkeit für Registrierungslinks fest. Links und vom Installer ausgestellte Anmeldedaten funktionieren danach nicht mehr — ein Rechner muss die Registrierung also ebenfalls innerhalb dieses Zeitraums abschließen.",
+      "capMinutes": "{{minutes}} Minuten"
     }
   },
   "orgEventLogSettings": {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -142,6 +142,16 @@
       "enable": "Enable auto-enrollment for new devices",
       "requireApproval": "Require admin approval",
       "sendWelcome": "Send welcome notification"
+    },
+    "enrollment": {
+      "title": "Device enrollment",
+      "ttl": "Default link expiry",
+      "ttlHint": "Pre-selects how long new enrollment links and installers stay valid. Organizations can pick a different default for themselves.",
+      "deviceCount": "Default devices per link",
+      "deviceCountHint": "How many machines one enrollment link may enroll by default. Organizations can pick a different default for themselves.",
+      "maxTtl": "Maximum link lifetime",
+      "maxTtlHint": "A ceiling on key lifetime, not just on what an admin may request: nothing minted under this partner stays usable for longer — enrollment links, MCP deployment invites, and the child credentials issued when an installer is redeemed.",
+      "maxTtlWarning": "Organizations cannot raise this. A short cap also shortens the time a machine has to finish enrolling after redeeming a link, not just the time to download it."
     }
   },
   "partnerEventLogs": {
@@ -796,6 +806,16 @@
         "invalidWindow": "Enter a valid window — start and end times must differ.",
         "storedInvalid": "Your saved maintenance window was invalid and is being ignored, so agents may currently update at any time. Choose a valid setting below and save to fix it."
       }
+    },
+    "enrollment": {
+      "title": "Device enrollment",
+      "ttl": "Default link expiry",
+      "deviceCount": "Default devices per link",
+      "inherit": "Inherit from partner",
+      "description": "Pre-selects the expiry and device count in the Add Device dialog. Leave a field on “Inherit from partner” to follow your partner’s default.",
+      "capNotice": "Your partner caps enrollment link lifetime at {{value}}. Links, MCP deployment invites, and installer-issued credentials all stop working once that elapses, so a machine also has to finish enrolling inside that window.",
+      "capNoticeUnknown": "Your partner sets a maximum enrollment link lifetime. Links and installer-issued credentials stop working once it elapses, so a machine also has to finish enrolling inside that window.",
+      "capMinutes": "{{minutes}} minutes"
     }
   },
   "orgEventLogSettings": {

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -142,6 +142,16 @@
       "enable": "Habilitar la inscripción automática para nuevos dispositivos",
       "requireApproval": "Requerir aprobación del administrador",
       "sendWelcome": "Enviar notificación de bienvenida"
+    },
+    "enrollment": {
+      "title": "Inscripción de dispositivos",
+      "ttl": "Vigencia predeterminada del enlace",
+      "ttlHint": "Preselecciona cuánto tiempo siguen siendo válidos los nuevos enlaces de inscripción e instaladores. Las organizaciones pueden elegir un valor predeterminado distinto.",
+      "deviceCount": "Dispositivos predeterminados por enlace",
+      "deviceCountHint": "Cuántas máquinas puede inscribir un enlace de inscripción de forma predeterminada. Las organizaciones pueden elegir un valor predeterminado distinto.",
+      "maxTtl": "Vigencia máxima del enlace",
+      "maxTtlHint": "Es un límite sobre la vida útil de la clave, no solo sobre lo que un administrador puede solicitar: nada emitido bajo este partner sigue siendo utilizable por más tiempo — enlaces de inscripción, invitaciones de implementación de MCP y las credenciales secundarias emitidas al canjear un instalador.",
+      "maxTtlWarning": "Las organizaciones no pueden aumentarlo. Un límite corto también reduce el tiempo que tiene una máquina para terminar de inscribirse después de canjear un enlace, no solo el tiempo para descargarlo."
     }
   },
   "partnerEventLogs": {
@@ -796,6 +806,16 @@
         "invalidWindow": "Ingrese una ventana válida: las horas de inicio y finalización deben diferir.",
         "storedInvalid": "Su ventana de mantenimiento guardada no era válida y se está ignorando, por lo que los agentes pueden actualizar en cualquier momento. Elija una configuración válida a continuación y guárdela para solucionarla."
       }
+    },
+    "enrollment": {
+      "title": "Inscripción de dispositivos",
+      "ttl": "Vigencia predeterminada del enlace",
+      "deviceCount": "Dispositivos predeterminados por enlace",
+      "inherit": "Heredar del partner",
+      "description": "Preselecciona la vigencia y la cantidad de dispositivos en el cuadro de diálogo Agregar dispositivo. Deje un campo en «Heredar del partner» para seguir el valor predeterminado de su partner.",
+      "capNotice": "Su partner limita la vigencia de los enlaces de inscripción a {{value}}. Los enlaces, las invitaciones de implementación de MCP y las credenciales emitidas por el instalador dejan de funcionar cuando transcurre ese plazo, por lo que la máquina también debe terminar de inscribirse dentro de esa ventana.",
+      "capNoticeUnknown": "Su partner define una vigencia máxima para los enlaces de inscripción. Los enlaces y las credenciales emitidas por el instalador dejan de funcionar cuando transcurre ese plazo, por lo que la máquina también debe terminar de inscribirse dentro de esa ventana.",
+      "capMinutes": "{{minutes}} minutos"
     }
   },
   "orgEventLogSettings": {

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -142,6 +142,16 @@
       "enable": "Activez l’inscription automatique pour les nouveaux appareils",
       "requireApproval": "Exigez l’approbation de l’administrateur",
       "sendWelcome": "Envoyer une notification de bienvenue"
+    },
+    "enrollment": {
+      "title": "Inscription des appareils",
+      "ttl": "Durée de validité par défaut du lien",
+      "ttlHint": "Présélectionne la durée de validité des nouveaux liens d’inscription et programmes d’installation. Les organisations peuvent choisir une autre valeur par défaut.",
+      "deviceCount": "Nombre d’appareils par lien par défaut",
+      "deviceCountHint": "Nombre de machines qu’un lien d’inscription peut inscrire par défaut. Les organisations peuvent choisir une autre valeur par défaut.",
+      "maxTtl": "Durée de vie maximale du lien",
+      "maxTtlHint": "Un plafond sur la durée de vie des clés, et pas seulement sur ce qu’un administrateur peut demander : rien de ce qui est émis sous ce partenaire ne demeure utilisable plus longtemps — liens d’inscription, invitations de déploiement MCP et identifiants enfants émis lors de l’utilisation d’un programme d’installation.",
+      "maxTtlWarning": "Les organisations ne peuvent pas l’augmenter. Un plafond court réduit aussi le temps dont dispose une machine pour terminer son inscription après avoir utilisé un lien, et pas seulement le temps de téléchargement."
     }
   },
   "partnerEventLogs": {
@@ -796,6 +806,16 @@
         "invalidWindow": "Entrez une fenêtre valide — les heures de début et de fin doivent différer.",
         "storedInvalid": "Votre fenêtre de maintenance enregistrée était invalide et est ignorée, donc les agents peuvent actuellement mettre à jour à tout moment. Choisissez un réglage valide ci-dessous et enregistrez pour corriger le problème."
       }
+    },
+    "enrollment": {
+      "title": "Inscription des appareils",
+      "ttl": "Durée de validité par défaut du lien",
+      "deviceCount": "Nombre d’appareils par lien par défaut",
+      "inherit": "Hériter du partenaire",
+      "description": "Présélectionne la durée de validité et le nombre d’appareils dans la boîte de dialogue Ajouter un appareil. Laissez un champ sur « Hériter du partenaire » pour suivre la valeur par défaut de votre partenaire.",
+      "capNotice": "Votre partenaire plafonne la durée de vie des liens d’inscription à {{value}}. Les liens, les invitations de déploiement MCP et les identifiants émis par le programme d’installation cessent de fonctionner une fois ce délai écoulé : une machine doit donc aussi terminer son inscription dans cette fenêtre.",
+      "capNoticeUnknown": "Votre partenaire définit une durée de vie maximale pour les liens d’inscription. Les liens et les identifiants émis par le programme d’installation cessent de fonctionner une fois ce délai écoulé : une machine doit donc aussi terminer son inscription dans cette fenêtre.",
+      "capMinutes": "{{minutes}} minutes"
     }
   },
   "orgEventLogSettings": {

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -142,6 +142,16 @@
       "enable": "Activez l’inscription automatique pour les nouveaux appareils",
       "requireApproval": "Exigez l’approbation de l’administrateur",
       "sendWelcome": "Envoyer une notification de bienvenue"
+    },
+    "enrollment": {
+      "title": "Inscription des appareils",
+      "ttl": "Durée de validité par défaut du lien",
+      "ttlHint": "Présélectionne la durée de validité des nouveaux liens d’inscription et programmes d’installation. Les organisations peuvent choisir une autre valeur par défaut.",
+      "deviceCount": "Nombre d’appareils par lien par défaut",
+      "deviceCountHint": "Nombre de machines qu’un lien d’inscription peut inscrire par défaut. Les organisations peuvent choisir une autre valeur par défaut.",
+      "maxTtl": "Durée de vie maximale du lien",
+      "maxTtlHint": "Un plafond sur la durée de vie des clés, et pas seulement sur ce qu’un administrateur peut demander : rien de ce qui est émis sous ce partenaire ne reste utilisable plus longtemps — liens d’inscription, invitations de déploiement MCP et identifiants enfants émis lors de l’utilisation d’un programme d’installation.",
+      "maxTtlWarning": "Les organisations ne peuvent pas l’augmenter. Un plafond court réduit aussi le temps dont dispose une machine pour terminer son inscription après avoir utilisé un lien, et pas seulement le temps de téléchargement."
     }
   },
   "partnerEventLogs": {
@@ -796,6 +806,16 @@
         "invalidWindow": "Entrez une fenêtre valide — les heures de début et de fin doivent différer.",
         "storedInvalid": "Votre fenêtre de maintenance enregistrée était invalide et est ignorée, donc les agents peuvent actuellement mettre à jour à tout moment. Choisissez un réglage valide ci-dessous et enregistrez pour corriger le problème."
       }
+    },
+    "enrollment": {
+      "title": "Inscription des appareils",
+      "ttl": "Durée de validité par défaut du lien",
+      "deviceCount": "Nombre d’appareils par lien par défaut",
+      "inherit": "Hériter du partenaire",
+      "description": "Présélectionne la durée de validité et le nombre d’appareils dans la boîte de dialogue Ajouter un appareil. Laissez un champ sur « Hériter du partenaire » pour suivre la valeur par défaut de votre partenaire.",
+      "capNotice": "Votre partenaire plafonne la durée de vie des liens d’inscription à {{value}}. Les liens, les invitations de déploiement MCP et les identifiants émis par le programme d’installation cessent de fonctionner une fois ce délai écoulé : une machine doit donc aussi terminer son inscription dans cette fenêtre.",
+      "capNoticeUnknown": "Votre partenaire définit une durée de vie maximale pour les liens d’inscription. Les liens et les identifiants émis par le programme d’installation cessent de fonctionner une fois ce délai écoulé : une machine doit donc aussi terminer son inscription dans cette fenêtre.",
+      "capMinutes": "{{minutes}} minutes"
     }
   },
   "orgEventLogSettings": {

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -142,6 +142,16 @@
       "enable": "Abilita la registrazione automatica per i nuovi dispositivi",
       "requireApproval": "Richiedi approvazione amministratore",
       "sendWelcome": "Invia notifica di benvenuto"
+    },
+    "enrollment": {
+      "title": "Registrazione dispositivi",
+      "ttl": "Validità predefinita del link",
+      "ttlHint": "Preseleziona per quanto tempo restano validi i nuovi link di registrazione e gli installer. Le org possono scegliere un valore predefinito diverso.",
+      "deviceCount": "Dispositivi predefiniti per link",
+      "deviceCountHint": "Quanti computer può registrare un singolo link di registrazione per impostazione predefinita. Le org possono scegliere un valore predefinito diverso.",
+      "maxTtl": "Durata massima del link",
+      "maxTtlHint": "È un tetto sulla durata delle chiavi, non solo su ciò che un amministratore può richiedere: nulla di emesso sotto questo partner resta utilizzabile più a lungo — link di registrazione, inviti di distribuzione MCP e le credenziali figlie emesse quando un installer viene riscattato.",
+      "maxTtlWarning": "Le org non possono aumentarlo. Un tetto breve accorcia anche il tempo a disposizione di un computer per completare la registrazione dopo aver riscattato un link, non solo il tempo per scaricarlo."
     }
   },
   "partnerEventLogs": {
@@ -796,6 +806,16 @@
         "invalidWindow": "Inserisci una finestra valida: ora di inizio e ora di fine devono essere diverse.",
         "storedInvalid": "La finestra di manutenzione salvata non era valida e viene ignorata, quindi gli agent potrebbero attualmente aggiornarsi in qualsiasi momento. Scegli un'impostazione valida qui sotto e salva per correggerla."
       }
+    },
+    "enrollment": {
+      "title": "Registrazione dispositivi",
+      "ttl": "Validità predefinita del link",
+      "deviceCount": "Dispositivi predefiniti per link",
+      "inherit": "Eredita dal partner",
+      "description": "Preseleziona la validità e il numero di dispositivi nella finestra Aggiungi dispositivo. Lascia un campo su «Eredita dal partner» per seguire il valore predefinito del partner.",
+      "capNotice": "Il tuo partner limita la durata dei link di registrazione a {{value}}. Link, inviti di distribuzione MCP e credenziali emesse dall’installer smettono di funzionare allo scadere, quindi anche il computer deve completare la registrazione entro quella finestra.",
+      "capNoticeUnknown": "Il tuo partner imposta una durata massima per i link di registrazione. I link e le credenziali emesse dall’installer smettono di funzionare allo scadere, quindi anche il computer deve completare la registrazione entro quella finestra.",
+      "capMinutes": "{{minutes}} minuti"
     }
   },
   "orgEventLogSettings": {

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -142,6 +142,16 @@
       "enable": "Ativar registro automático para novos dispositivos",
       "requireApproval": "Exigir aprovação do administrador",
       "sendWelcome": "Enviar notificação de boas-vindas"
+    },
+    "enrollment": {
+      "title": "Registro de dispositivos",
+      "ttl": "Validade padrão do link",
+      "ttlHint": "Pré-seleciona por quanto tempo novos links de registro e instaladores continuam válidos. As organizações podem escolher um padrão diferente.",
+      "deviceCount": "Dispositivos padrão por link",
+      "deviceCountHint": "Quantas máquinas um link de registro pode registrar por padrão. As organizações podem escolher um padrão diferente.",
+      "maxTtl": "Validade máxima do link",
+      "maxTtlHint": "É um teto para o tempo de vida das chaves, não apenas para o que um administrador pode solicitar: nada emitido sob este parceiro continua utilizável por mais tempo — links de registro, convites de implantação do MCP e as credenciais filhas emitidas quando um instalador é resgatado.",
+      "maxTtlWarning": "As organizações não podem aumentá-lo. Um teto curto também encurta o tempo que uma máquina tem para concluir o registro depois de resgatar um link, não apenas o tempo para baixá-lo."
     }
   },
   "partnerEventLogs": {
@@ -796,6 +806,16 @@
         "invalidWindow": "Informe uma janela válida — os horários de início e fim devem ser diferentes.",
         "storedInvalid": "A janela de manutenção salva era inválida e está sendo ignorada; portanto, os agentes podem estar atualizando a qualquer momento. Escolha uma configuração válida abaixo e salve para corrigir."
       }
+    },
+    "enrollment": {
+      "title": "Registro de dispositivos",
+      "ttl": "Validade padrão do link",
+      "deviceCount": "Dispositivos padrão por link",
+      "inherit": "Herdar do parceiro",
+      "description": "Pré-seleciona a validade e a quantidade de dispositivos na caixa de diálogo Adicionar dispositivo. Deixe um campo em “Herdar do parceiro” para seguir o padrão do seu parceiro.",
+      "capNotice": "Seu parceiro limita a validade dos links de registro a {{value}}. Links, convites de implantação do MCP e credenciais emitidas pelo instalador param de funcionar depois disso, então a máquina também precisa concluir o registro dentro dessa janela.",
+      "capNoticeUnknown": "Seu parceiro define uma validade máxima para os links de registro. Links e credenciais emitidas pelo instalador param de funcionar depois disso, então a máquina também precisa concluir o registro dentro dessa janela.",
+      "capMinutes": "{{minutes}} minutos"
     }
   },
   "orgEventLogSettings": {

--- a/apps/web/src/stores/orgStore.test.ts
+++ b/apps/web/src/stores/orgStore.test.ts
@@ -67,7 +67,9 @@ describe('org store', () => {
     await flushAsync();
 
     expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/organizations?partnerId=partner-1');
-    expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/sites?organizationId=org-1');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      '/orgs/sites?organizationId=org-1&includeEnrollmentDefaults=1'
+    );
     expect(useOrgStore.getState().currentOrgId).toBe('org-1');
     expect(useOrgStore.getState().sites).toHaveLength(1);
     expect(getCurrentOrganization()?.id).toBe('org-1');
@@ -209,8 +211,48 @@ describe('org store', () => {
 
     await useOrgStore.getState().fetchSites();
 
-    expect(fetchWithAuthMock).toHaveBeenCalledWith('/orgs/sites?organizationId=org-1');
+    expect(fetchWithAuthMock).toHaveBeenCalledWith(
+      '/orgs/sites?organizationId=org-1&includeEnrollmentDefaults=1'
+    );
     expect(useOrgStore.getState().sites.map((s) => s.id)).toEqual(['site-1']);
+  });
+
+  it('captures the enrollment defaults riding along on the sites response (#2776)', async () => {
+    useOrgStore.setState({ currentOrgId: 'org-1' });
+
+    fetchWithAuthMock.mockResolvedValueOnce(
+      makeResponse({
+        data: [],
+        enrollmentDefaults: { ttlMinutes: 10080, deviceCount: 25, maxTtlMinutes: 43200 }
+      })
+    );
+
+    await useOrgStore.getState().fetchSites();
+
+    // No second round trip — the Add Device modal reads these straight off the
+    // store when it opens. This store is the ONLY caller that opts in to the
+    // extra settings read, so other GET /orgs/sites callers pay nothing.
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchWithAuthMock.mock.calls[0][0])).toContain(
+      'includeEnrollmentDefaults=1'
+    );
+    expect(useOrgStore.getState().enrollmentDefaults).toEqual({
+      ttlMinutes: 10080,
+      deviceCount: 25,
+      maxTtlMinutes: 43200
+    });
+  });
+
+  it('drops the previous org\'s enrollment defaults when the selection changes', () => {
+    useOrgStore.setState({
+      currentOrgId: 'org-1',
+      enrollmentDefaults: { ttlMinutes: 10080, deviceCount: 25, maxTtlMinutes: 43200 }
+    });
+
+    // Showing org-1's cap while minting a link for org-2 would be a
+    // cross-tenant misstatement.
+    useOrgStore.getState().selectOrganization('org-2');
+    expect(useOrgStore.getState().enrollmentDefaults).toBeNull();
   });
 
   it('sets error when organization fetch fails', async () => {

--- a/apps/web/src/stores/orgStore.ts
+++ b/apps/web/src/stores/orgStore.ts
@@ -1,3 +1,4 @@
+import type { ResolvedEnrollmentDefaults } from '@breeze/shared';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { fetchWithAuth, registerOrgIdProvider } from './auth';
@@ -49,6 +50,15 @@ interface OrgState {
   partners: Partner[];
   organizations: Organization[];
   sites: Site[];
+  /**
+   * The current org's resolved enrollment defaults (TTL, device count, partner
+   * TTL cap), delivered on the GET /orgs/sites response rather than by a
+   * dedicated fetch — the Add Device modal is on the device-add hot path and
+   * already waits on that request (#2776). Null until the first sites fetch for
+   * the selected org resolves, or when the API soft-failed the settings read;
+   * consumers must fall back to the shared product defaults.
+   */
+  enrollmentDefaults: ResolvedEnrollmentDefaults | null;
   isLoading: boolean;
   error: string | null;
   /**
@@ -95,6 +105,7 @@ export const useOrgStore = create<OrgState>()(
       partners: [],
       organizations: [],
       sites: [],
+      enrollmentDefaults: null,
       isLoading: false,
       error: null,
       organizationsLoaded: false,
@@ -110,7 +121,8 @@ export const useOrgStore = create<OrgState>()(
           // The new partner's org list hasn't loaded yet — back to the
           // "loading" shape until the refetch below resolves.
           organizationsLoaded: false,
-          sites: []
+          sites: [],
+          enrollmentDefaults: null
         });
         // Fetch organizations for the new partner
         get().fetchOrganizations();
@@ -124,6 +136,9 @@ export const useOrgStore = create<OrgState>()(
         set({
           currentOrgId: orgId,
           sites: [],
+          // Belongs to the org we just left — never show one org's cap while
+          // minting a link for another.
+          enrollmentDefaults: null,
           allOrgs: false,
           // Remember the concrete org so the "Current" pill can return to it.
           lastOrgId: orgId
@@ -132,14 +147,14 @@ export const useOrgStore = create<OrgState>()(
       },
 
       selectAllOrgs: () => {
-        set({ currentOrgId: null, sites: [], allOrgs: true });
+        set({ currentOrgId: null, sites: [], enrollmentDefaults: null, allOrgs: true });
       },
 
       resetSelection: () => {
         // Clear WITHOUT asserting fleet intent: currentOrgId null + allOrgs
         // false is the transient/unresolved shape, distinct from an explicit
         // All-orgs choice.
-        set({ currentOrgId: null, sites: [], allOrgs: false });
+        set({ currentOrgId: null, sites: [], enrollmentDefaults: null, allOrgs: false });
       },
 
       setOrganization: (orgId) => {
@@ -248,13 +263,21 @@ export const useOrgStore = create<OrgState>()(
       fetchSites: async () => {
         const { currentOrgId } = get();
         if (!currentOrgId) {
-          set({ sites: [] });
+          set({ sites: [], enrollmentDefaults: null });
           return;
         }
 
         set({ isLoading: true, error: null });
         try {
-          const response = await fetchWithAuth(`/orgs/sites?organizationId=${currentOrgId}`);
+          // `includeEnrollmentDefaults=1` opts this ONE caller into the extra
+          // org⋈partner settings read (#2776). It is opt-in because that read
+          // takes a second pooled connection while this request holds the
+          // first, and GET /orgs/sites is called from several places — see the
+          // pool-exhaustion note at the route. This store is the only consumer
+          // of `enrollmentDefaults`, so it is the only caller that asks.
+          const response = await fetchWithAuth(
+            `/orgs/sites?organizationId=${currentOrgId}&includeEnrollmentDefaults=1`,
+          );
           if (!response.ok) {
             throw new Error('Failed to fetch sites');
           }
@@ -266,8 +289,14 @@ export const useOrgStore = create<OrgState>()(
               : Array.isArray(data)
                 ? data
                 : [];
+          // #2776: the API rides the org's resolved enrollment defaults along
+          // on this response. Absent when the settings read soft-failed server
+          // side — keep the previous value rather than blanking a good one.
+          const enrollmentDefaults = (data?.enrollmentDefaults ??
+            get().enrollmentDefaults) as ResolvedEnrollmentDefaults | null;
           set({
             sites,
+            enrollmentDefaults,
             isLoading: false
           });
         } catch (error) {
@@ -291,6 +320,7 @@ export const useOrgStore = create<OrgState>()(
           organizations: [],
           organizationsLoaded: false,
           sites: [],
+          enrollmentDefaults: null,
           error: null
         });
       }


### PR DESCRIPTION
## What

Part 2 of 2 for #2776 — **stacked on #2776a, merge that first.** Adds the settings that make the cap and defaults settable.

There was no partner- or org-level default for enrollment link expiry or device count. Both were hardcoded, and the Add Device modal made you pick fresh every time. The only trace of the intended feature was a comment at `AddDeviceModal.tsx:130-132` promising `maxEnrollmentLinkTtlMinutes` would land "in a sibling PR" — that PR never landed.

- Three fields on `InheritableDefaultSettings`, stored in the existing schemaless `settings` JSONB (**no migration**).
- **Split lock semantics:** the two default *values* are inherit-with-override (a partner sets a house default, an org may deviate — joining `agentVersionPins` in the lock exemption); the *cap* is partner-locked, because a ceiling an org can raise is not a ceiling.
- Settings UI on both the partner and org tabs; org scope gets a read-only notice of the inherited cap rather than an editable control that would 403.
- Add Device modal seeds its pickers from the resolved defaults and filters every option list to values at or below the cap.
- Docs for the three settings plus five previously-undocumented env vars.

## Two traps this had to work around

`OrgDefaultsEditor` keeps a duplicated local `DefaultsData` type and rebuilds the whole object in `handleSave`, so a field missing there is dropped on every save with no error. And `OrgSettingsPage` wasn't passing `locked` to it, so a partner-locked field would 403 with no UI affordance. Both fixed.

Neither editor rewrites a stored value on save — an earlier revision clamped on save, which meant editing your *maintenance window* silently rewrote your stored enrollment TTL down to the current cap, permanently. The display is made honest instead; clamping happens at read time where it belongs.

## Deliberately not done

**"Never expires"** — `installer_bootstrap_tokens.expires_at` is `NOT NULL` with `CHECK (expires_at > created_at)`, so it needs a migration plus null-handling through issuance, the consume path, the cleanup job and the expiry UI. The dangling comment is now replaced with an accurate note. 1 year remains the maximum.

## Note for reviewers

The TTL option labels live in the `devices` i18n namespace and are consumed here via an explicit `devices:` prefix from `useTranslation('settings')` components. That is a **new pattern** in this repo — existing cross-namespace use is `common:`. The alternative was duplicating six labels into `settings` and guaranteeing drift.

## Testing

API 17,321 passing / 0 failed · web 4,496 · shared 1,308 · typechecks clean · docs build clean.

Closes #2776

🤖 Generated with [Claude Code](https://claude.com/claude-code)
