### PR TITLE
fix(portal): post accept-invite to the portal-scoped route (#2824)

### DIFF
--- a/apps/portal/src/components/portal/AcceptInviteForm.test.tsx
+++ b/apps/portal/src/components/portal/AcceptInviteForm.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+// `astro:transitions/client` is a virtual module Vite cannot resolve under vitest,
+// and it is reachable from the api/navigation import chain — mock it out, as
+// NewTicketForm.test.tsx does.
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+import AcceptInviteForm from './AcceptInviteForm';
+
+// `buildPortalApiUrl` is deliberately NOT mocked: the whole point of this test is
+// to pin the literal path the browser posts to. Issue #2824 — the form posted to
+// `/auth/accept-invite`, which resolves to the ADMIN accept-invite route. That
+// route reads a different Redis namespace (`invite:*`, not `portal:invite:*`) and
+// only ever looks the id up in `users`, so a perfectly valid portal invite came
+// back "Invalid or expired invite token" and every portal invite was unusable.
+// Every sibling portal auth call (`login`, `logout`, `forgot-password`,
+// `reset-password`) already carries the `/portal` prefix.
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true })
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+  cleanup();
+});
+
+async function submitValidPassword() {
+  render(<AcceptInviteForm token="invite-token-abc" />);
+  fireEvent.input(screen.getByLabelText(/new password/i), { target: { value: 'Password123' } });
+  fireEvent.input(screen.getByLabelText(/confirm password/i), { target: { value: 'Password123' } });
+  fireEvent.submit(screen.getByRole('button'));
+  await waitFor(() => expect(globalThis.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled());
+  return (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+}
+
+describe('AcceptInviteForm — posts to the portal-scoped accept-invite route (#2824)', () => {
+  it('posts to /api/v1/portal/auth/accept-invite', async () => {
+    const [url] = await submitValidPassword();
+    expect(url).toBe('/api/v1/portal/auth/accept-invite');
+  });
+
+  it('does NOT post to the admin /api/v1/auth/accept-invite route', async () => {
+    const [url] = await submitValidPassword();
+    expect(url).not.toBe('/api/v1/auth/accept-invite');
+  });
+
+  it('sends the invite token in the body', async () => {
+    const [, init] = await submitValidPassword();
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
+      token: 'invite-token-abc'
+    });
+  });
+});

--- a/apps/portal/src/components/portal/AcceptInviteForm.tsx
+++ b/apps/portal/src/components/portal/AcceptInviteForm.tsx
@@ -46,7 +46,7 @@ export default function AcceptInviteForm({ token }: AcceptInviteFormProps) {
     setError(null);
 
     try {
-      const response = await fetch(buildPortalApiUrl('/auth/accept-invite'), {
+      const response = await fetch(buildPortalApiUrl('/portal/auth/accept-invite'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
Fixes #2824.

## Root cause

`AcceptInviteForm` posted to `/auth/accept-invite`. `buildPortalApiUrl` does no `/portal` injection — it returns `${apiBase}/api/v1${path}` — so that resolved to `/api/v1/auth/accept-invite`, the **admin** accept-invite route (`routes/auth/invite.ts`).

That route reads a different Redis namespace (`invite:*`, written by the admin invite flow) and looks the id up in `users`. A portal invite token is stored under `portal:invite:<hash>` (`PORTAL_REDIS_KEYS.inviteToken`) and references `portal_users`, so the admin handler never found it and returned `400 Invalid or expired invite token` — with the token present and unexpired in Redis and the `portal_users` row sitting in `invited`. Every portal user invite was unusable.

Worth noting for the reporter: the handler was not querying the wrong table. **The wrong handler was being called.** The admin route fails at the Redis lookup and never reaches a table read at all, which is why the symptom looked table-shaped from the outside.

The portal already has a correct handler at `routes/portal/auth.ts` (mounted at `/portal`, `index.ts:908`) that reads `PORTAL_REDIS_KEYS.inviteToken` and resolves against `portal_users`. It was simply never being called.

## The change

One line. Every sibling portal auth call already carries the prefix — `/portal/auth/login`, `/logout`, `/forgot-password`, `/reset-password` (`lib/auth.ts:133,189,214,244`) — and `api.test.ts:22` already pins `buildPortalApiUrl('/portal/auth/login')` → `/api/v1/portal/auth/login`. This call site was the only one missing it.

## Test

Adds `AcceptInviteForm.test.tsx`, which pins the literal posted path. `buildPortalApiUrl` is deliberately **not** mocked, so the assertion covers the real resolution rather than a stub.

**Negative-controlled** — reverting the one-line change fails it with:

```
AssertionError: expected '/api/v1/auth/accept-invite' to be '/api/v1/portal/auth/accept-invite'
AssertionError: expected '/api/v1/auth/accept-invite' not to be '/api/v1/auth/accept-invite'
```

so it genuinely catches the regression rather than passing vacuously.

## Verification

`vitest run` on the portal package: **3/3 new tests pass**, 79/79 across the suite.

Two local-only caveats, both from a scoped `--filter @breeze/portal...` install rather than this branch: `NewTicketForm.test.tsx` fails to load (`Failed to resolve import "zod"` from `packages/shared`) and `astro check` reports one pre-existing implicit-`any` in `TicketFormFields.tsx:80` — a file this PR does not touch. Both `Type Check` and `Test Portal` are green on `main` in CI, so CI is the authority on those.

Trivy is red here as it is on every PR right now — CVE-2026-14257 (brace-expansion), pre-existing on `main` and tracked in #2820.
