### PR TITLE
fix(api): escape partner-axis reads to a system RLS context (#2822)

### DIFF
--- a/apps/api/src/__tests__/integration/partnerAxisSystemContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerAxisSystemContext.integration.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Real-Postgres coverage for the partner-axis system-context sweep (#2822).
+ *
+ * THE BUG CLASS. Partner-axis tables (`partners`, `authenticator_policies`,
+ * `patch_policies`, … — the full list is `PARTNER_TENANT_TABLES` in
+ * rls-coverage.integration.test.ts) are gated by
+ * `breeze_has_partner_access(<partner column>)`, which evaluates against the
+ * `breeze.accessible_partner_ids` GUC. `computeAccessiblePartnerIds`
+ * (apps/api/src/middleware/auth.ts) returns `[]` for `scope === 'organization'`,
+ * and agentAuth / clientAiAuth / portal auth / org-scoped OAuth bearers all set
+ * `accessiblePartnerIds: []` too. Under those contexts the read returns ZERO
+ * ROWS — it does NOT raise — so the caller's value silently collapses to a
+ * default, an empty list, or a spurious 404, for exactly the population the
+ * feature was meant to serve.
+ *
+ * WHY THIS FILE HAS TO BE AN INTEGRATION TEST. A mocked-DB unit test is
+ * structurally incapable of catching this: the mock returns whatever row the
+ * test stages, with no RLS evaluation at all, so the entire unit suite passes
+ * against a control that does nothing. Only a real Postgres connection through
+ * the actual unprivileged `breeze_app` role, inside a genuine `withDbAccessContext`
+ * org-scoped session, can prove the read is visible. Every test below therefore
+ * reproduces the exact ambient context an org-scoped HTTP request runs under
+ * (authMiddleware wraps every request in `withDbAccessContext` keyed off the
+ * caller's auth) and asserts the fixed resolver still surfaces the partner data.
+ *
+ * The first test is the PREMISE PROOF: it asserts the raw partner-axis rows
+ * really are invisible in that context. Without it, a later change that quietly
+ * widened the RLS policy would make every other test here pass vacuously.
+ */
+import './setup';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import {
+  db,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
+import {
+  authenticatorPolicies,
+  devices,
+  organizations,
+  partners,
+  patchPolicies,
+  sites,
+} from '../../db/schema';
+import { loadPartnerPolicy, isEnforcing } from '../../services/authenticatorPolicy';
+import { resolveDeviceTimezone } from '../../services/featureConfigResolver';
+import { getEffectiveOrgSettings } from '../../services/effectiveSettings';
+import { resolveMlFeatureFlagForOrg } from '../../services/mlFeatureFlags';
+import { resolvePatchPolicyReference } from '../../services/configPolicyPatching';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/**
+ * Exactly what `buildDbAccessContext` produces for a JWT whose scope is
+ * 'organization': `accessiblePartnerIds` is `[]` even though `currentPartnerId`
+ * is populated. `partners` has no `breeze_current_partner_id()` read branch
+ * (apps/api/migrations/2026-04-11-partners-rls.sql), so that GUC buys nothing
+ * on this axis — which is precisely the trap.
+ */
+function orgContext(orgId: string, partnerId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId: partnerId,
+  };
+}
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+interface Fixture {
+  partnerId: string;
+  orgId: string;
+  siteId: string;
+  deviceId: string;
+  ringId: string;
+}
+
+let fx: Fixture;
+
+beforeEach(async () => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  fx = await withSystemDbAccessContext(async () => {
+    const [partner] = await db
+      .insert(partners)
+      .values({
+        name: `PAX Partner ${unique}`,
+        slug: `pax-partner-${unique}`,
+        type: 'msp',
+        plan: 'pro',
+        status: 'active',
+        // First-class partner timezone (#1318) — the value resolveDeviceTimezone
+        // must surface. Deliberately NOT 'UTC' so the fallback is distinguishable
+        // from a real hit.
+        timezone: 'America/Chicago',
+        settings: {
+          security: { sessionTimeoutMinutes: 15 },
+          mlFeatureFlags: { 'ml.rca.enabled': true },
+        },
+      })
+      .returning({ id: partners.id });
+
+    const [org] = await db
+      .insert(organizations)
+      .values({
+        partnerId: partner!.id,
+        name: `PAX Org ${unique}`,
+        slug: `pax-org-${unique}`,
+        type: 'customer',
+        status: 'active',
+        settings: {},
+      })
+      .returning({ id: organizations.id });
+
+    const [site] = await db
+      .insert(sites)
+      .values({ orgId: org!.id, name: `PAX Site ${unique}`, timezone: '' })
+      .returning({ id: sites.id });
+
+    const [device] = await db
+      .insert(devices)
+      .values({
+        orgId: org!.id,
+        siteId: site!.id,
+        agentId: `pax-agent-${unique}`,
+        hostname: `pax-host-${unique}`,
+        osType: 'windows',
+        osVersion: '11',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+      })
+      .returning({ id: devices.id });
+
+    await db.insert(authenticatorPolicies).values({
+      partnerId: partner!.id,
+      requireEnrollment: true,
+      // Already in force — no grace window — so `isEnforcing` hinges purely on
+      // whether the row was readable.
+      enforceFrom: new Date(Date.now() - 86_400_000),
+      floorOverrides: {},
+    });
+
+    const [ring] = await db
+      .insert(patchPolicies)
+      .values({ partnerId: partner!.id, kind: 'ring', name: `PAX Ring ${unique}` })
+      .returning({ id: patchPolicies.id });
+
+    return {
+      partnerId: partner!.id,
+      orgId: org!.id,
+      siteId: site!.id,
+      deviceId: device!.id,
+      ringId: ring!.id,
+    };
+  });
+});
+
+afterEach(async () => {
+  if (!fx) return;
+  await withSystemDbAccessContext(async () => {
+    await db.delete(devices).where(eq(devices.id, fx.deviceId));
+    await db.delete(sites).where(eq(sites.id, fx.siteId));
+    await db.delete(patchPolicies).where(eq(patchPolicies.id, fx.ringId));
+    await db.delete(authenticatorPolicies).where(eq(authenticatorPolicies.partnerId, fx.partnerId));
+    await db.delete(organizations).where(eq(organizations.id, fx.orgId));
+    await db.delete(partners).where(eq(partners.id, fx.partnerId));
+  });
+  fx = undefined as unknown as Fixture;
+});
+
+describe('#2822 premise — partner-axis rows really are invisible to an org-scoped context', () => {
+  runDb('raw SELECTs on partners / authenticator_policies / patch_policies return ZERO rows, without raising', async () => {
+    await withDbAccessContext(orgContext(fx.orgId, fx.partnerId), async () => {
+      // Sanity: the org row itself IS visible, so a zero result below is RLS on
+      // the partner axis and not a broken fixture or a dead connection.
+      const orgRows = await db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, fx.orgId));
+      expect(orgRows).toHaveLength(1);
+
+      expect(
+        await db.select({ id: partners.id }).from(partners).where(eq(partners.id, fx.partnerId)),
+      ).toHaveLength(0);
+
+      expect(
+        await db
+          .select({ partnerId: authenticatorPolicies.partnerId })
+          .from(authenticatorPolicies)
+          .where(eq(authenticatorPolicies.partnerId, fx.partnerId)),
+      ).toHaveLength(0);
+
+      expect(
+        await db
+          .select({ id: patchPolicies.id })
+          .from(patchPolicies)
+          .where(eq(patchPolicies.id, fx.ringId)),
+      ).toHaveLength(0);
+    });
+  });
+});
+
+describe('#2822 — loadPartnerPolicy (step-up MFA fail-open, highest severity)', () => {
+  runDb('an org-scoped caller resolves the partner policy, so step-up enforcement is NOT silently skipped', async () => {
+    const policy = await withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
+      loadPartnerPolicy(fx.partnerId),
+    );
+
+    // Pre-fix this was null, `isEnforcing(null, …)` was false, and an org-scoped
+    // technician could approve a critical JIT-admin elevation with a bare L1
+    // session tap while a partner-scoped technician on the same row got 403.
+    expect(policy).not.toBeNull();
+    expect(policy!.requireEnrollment).toBe(true);
+    expect(isEnforcing(policy, new Date())).toBe(true);
+  });
+
+  runDb('still resolves under a system context (the skip-the-escape branch is not a regression)', async () => {
+    const policy = await withDbAccessContext(SYSTEM_CTX, () => loadPartnerPolicy(fx.partnerId));
+    expect(policy?.requireEnrollment).toBe(true);
+  });
+
+  runDb('and with no ambient context at all (background/worker callers)', async () => {
+    const policy = await loadPartnerPolicy(fx.partnerId);
+    expect(policy?.requireEnrollment).toBe(true);
+  });
+});
+
+describe('#2822 — resolveDeviceTimezone', () => {
+  runDb("an org-scoped caller resolves the PARTNER's timezone instead of falling through to UTC", async () => {
+    const tz = await withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
+      resolveDeviceTimezone(fx.deviceId),
+    );
+    // Site tz is '' and the org sets none, so the partner is the only non-UTC
+    // candidate in the explicit -> site -> org -> partner -> UTC chain. Pre-fix
+    // this returned 'UTC', meaning the same device resolved a DIFFERENT
+    // maintenance window depending on whether the scheduler (system) or an
+    // org-scoped UI action triggered the job.
+    expect(tz).toBe('America/Chicago');
+  });
+
+  runDb('resolves identically under a system context — org and scheduler now agree', async () => {
+    const tz = await withDbAccessContext(SYSTEM_CTX, () => resolveDeviceTimezone(fx.deviceId));
+    expect(tz).toBe('America/Chicago');
+  });
+});
+
+describe('#2822 — getEffectiveOrgSettings', () => {
+  runDb('an org-scoped caller gets partner-inherited settings instead of a spurious 404', async () => {
+    const result = await withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
+      getEffectiveOrgSettings(fx.orgId),
+    );
+    // Pre-fix this threw HTTPException 404 "Partner not found" for an org admin
+    // looking at their OWN org — GET /orgs/organizations/:id/effective-settings
+    // is requireScope('organization','partner','system').
+    expect(result.effective.security).toMatchObject({ sessionTimeoutMinutes: 15 });
+    // The partner set it, so the field must come back LOCKED.
+    expect(result.locked).toContain('security.sessionTimeoutMinutes');
+  });
+});
+
+describe('#2822 — resolveMlFeatureFlagForOrg', () => {
+  runDb('an org-scoped caller sees the partner-enabled ML flag, not a false org_not_found', async () => {
+    const resolution = await withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
+      resolveMlFeatureFlagForOrg(fx.orgId, 'ml.rca.enabled'),
+    );
+    // Pre-fix the innerJoin on the invisible `partners` row erased the whole
+    // result row and this returned { enabled: false, source: 'org_not_found' } —
+    // a statement that was false on both counts.
+    expect(resolution.source).not.toBe('org_not_found');
+    expect(resolution.enabled).toBe(true);
+  });
+});
+
+describe('#2822 — resolvePatchPolicyReference', () => {
+  runDb('an org-scoped caller resolves a valid update ring instead of missing_target', async () => {
+    const resolution = await withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
+      resolvePatchPolicyReference(fx.partnerId, fx.ringId),
+    );
+    // Pre-fix: classification 'missing_target', valid false — so the UI reported
+    // a perfectly good ring as invalid (400 on POST /:id/patch-job) while the
+    // system-scoped scheduler happily ran that same job.
+    expect(resolution.classification).toBe('valid_ring');
+    expect(resolution.valid).toBe(true);
+    expect(resolution.ringId).toBe(fx.ringId);
+  });
+
+  runDb('a ring belonging to ANOTHER partner is still rejected — the escape did not widen reach', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const other = await withSystemDbAccessContext(async () => {
+      const [p] = await db
+        .insert(partners)
+        .values({
+          name: `PAX Other ${unique}`,
+          slug: `pax-other-${unique}`,
+          type: 'msp',
+          plan: 'pro',
+          status: 'active',
+        })
+        .returning({ id: partners.id });
+      const [r] = await db
+        .insert(patchPolicies)
+        .values({ partnerId: p!.id, kind: 'ring', name: `PAX Other Ring ${unique}` })
+        .returning({ id: patchPolicies.id });
+      return { partnerId: p!.id, ringId: r!.id };
+    });
+
+    try {
+      // The caller's own partnerId, but a ring id owned by someone else. The
+      // system-context escape must NOT make this resolve: the query is still
+      // self-tenanted by the caller-derived partnerId.
+      const resolution = await withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
+        resolvePatchPolicyReference(fx.partnerId, other.ringId),
+      );
+      expect(resolution.classification).toBe('missing_target');
+      expect(resolution.valid).toBe(false);
+    } finally {
+      await withSystemDbAccessContext(async () => {
+        await db.delete(patchPolicies).where(eq(patchPolicies.id, other.ringId));
+        await db.delete(partners).where(eq(partners.id, other.partnerId));
+      });
+    }
+  });
+});

--- a/apps/api/src/__tests__/integration/partnerAxisSystemContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerAxisSystemContext.integration.test.ts
@@ -45,30 +45,39 @@ import {
   patchPolicies,
   sites,
 } from '../../db/schema';
+import { buildDbAccessContext } from '../../middleware/auth';
 import { loadPartnerPolicy, isEnforcing } from '../../services/authenticatorPolicy';
 import { resolveDeviceTimezone } from '../../services/featureConfigResolver';
-import { getEffectiveOrgSettings } from '../../services/effectiveSettings';
+import { getEffectiveOrgSettings, assertNotLocked } from '../../services/effectiveSettings';
 import { resolveMlFeatureFlagForOrg } from '../../services/mlFeatureFlags';
 import { resolvePatchPolicyReference } from '../../services/configPolicyPatching';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
 /**
- * Exactly what `buildDbAccessContext` produces for a JWT whose scope is
- * 'organization': `accessiblePartnerIds` is `[]` even though `currentPartnerId`
- * is populated. `partners` has no `breeze_current_partner_id()` read branch
- * (apps/api/migrations/2026-04-11-partners-rls.sql), so that GUC buys nothing
- * on this axis — which is precisely the trap.
+ * The context a real org-scoped JWT request runs under.
+ *
+ * Built with the PRODUCTION builder rather than a hand-rolled literal, on
+ * purpose: `buildDbAccessContext` is what `authMiddleware` calls, so if
+ * `computeAccessiblePartnerIds` ever changes for org scope this fixture changes
+ * with it. A literal would keep asserting `accessiblePartnerIds: []` forever and
+ * every test below would go on passing against a context production no longer
+ * produces — the same hand-rolled-context drift this PR fixes in
+ * `aiAgentSdkTools.ts`.
+ *
+ * Note it yields `accessiblePartnerIds: []` even though `currentPartnerId` IS
+ * populated: `partners` has no `breeze_current_partner_id()` read branch
+ * (apps/api/migrations/2026-04-11-partners-rls.sql), so that GUC buys nothing on
+ * this axis — which is precisely the trap.
  */
 function orgContext(orgId: string, partnerId: string): DbAccessContext {
-  return {
+  return buildDbAccessContext({
     scope: 'organization',
     orgId,
     accessibleOrgIds: [orgId],
-    accessiblePartnerIds: [],
+    partnerId,
     userId: null,
-    currentPartnerId: partnerId,
-  };
+  });
 }
 
 const SYSTEM_CTX: DbAccessContext = {
@@ -268,6 +277,29 @@ describe('#2822 — getEffectiveOrgSettings', () => {
     expect(result.effective.security).toMatchObject({ sessionTimeoutMinutes: 15 });
     // The partner set it, so the field must come back LOCKED.
     expect(result.locked).toContain('security.sessionTimeoutMinutes');
+  });
+});
+
+describe('#2822 — assertNotLocked (a WRITE gate, so a wrong answer is worse than a read)', () => {
+  runDb('an org-scoped caller is still blocked from writing a partner-LOCKED field', async () => {
+    // Reached from PUT /ai/budget, which is
+    // requireScope('organization','partner','system'). Pre-fix the partner read
+    // returned zero rows and this threw 404 "Partner not found" before it could
+    // decide anything — so the gate never actually ran for org callers. Now it
+    // resolves and correctly refuses: the partner set security.sessionTimeoutMinutes.
+    await expect(
+      withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
+        assertNotLocked(fx.orgId, 'security', ['sessionTimeoutMinutes']),
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+  });
+
+  runDb('an org-scoped caller may still write a field the partner has NOT set', async () => {
+    await expect(
+      withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
+        assertNotLocked(fx.orgId, 'security', ['someUnlockedField']),
+      ),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/apps/api/src/__tests__/integration/reliabilityScoringProjection.integration.test.ts
+++ b/apps/api/src/__tests__/integration/reliabilityScoringProjection.integration.test.ts
@@ -179,15 +179,27 @@ describe('reliability scoring — projected read golden value (integration)', ()
     expect(row!.trendDirection).toBe('stable');
   });
 
-  // #1105 regression lock: computeAndPersistDeviceReliability MUST run under a
-  // system context. Its ml-feature-flag gate reads `organizations INNER JOIN
-  // partners`, and under an ORG-scoped RLS context the partners row is invisible
-  // (breeze_has_partner_access is false for org tokens) → the join yields nothing
-  // → the flag resolves `org_not_found` → the compute silently no-ops and persists
-  // NOTHING. This is exactly why the ingest route's Redis-outage fallback opens a
-  // fresh system context instead of reusing its org context. If a future change
-  // "simplifies" that back to org scope, this test fails.
-  it('silently no-ops (persists nothing) when run under an org-scoped context', async () => {
+  // WAS a #1105 regression lock asserting the OPPOSITE: that an org-scoped
+  // compute "silently no-ops (persists nothing)". That assertion encoded the
+  // #2822 bug as the expected behaviour. The ml-feature-flag gate read
+  // `organizations INNER JOIN partners`; `partners` is partner-axis, an
+  // org-scoped context has accessiblePartnerIds = [], so the invisible partner
+  // row erased the whole joined row and the flag resolved `org_not_found` — a
+  // statement that was false on both counts (the org exists and the feature may
+  // well be enabled). #2822 splits that read so the org half stays under RLS and
+  // only the partner half is escaped, so the gate now answers honestly and the
+  // compute proceeds.
+  //
+  // The #1105 protection is NOT lost, because it never actually lived here. What
+  // matters for #1105 is CALLER DISCIPLINE — that the two production callers open
+  // a system context — and that is asserted directly, on the callers, in
+  // routes/agents/reliability.test.ts ("...falls back to an inline compute in a
+  // fresh SYSTEM context", which pins `fallbackScope === 'system'` AND
+  // `runOutsideDbContext` having been called) and in jobs/reliabilityWorker.test.ts.
+  // Those guards hold regardless of what an org-scoped compute happens to do, so
+  // they are strictly stronger than inferring caller discipline from a symptom.
+  // No production path invokes this under an org context.
+  it('computes and persists under an org-scoped context now that the flag gate no longer lies (#2822)', async () => {
     const orgContext = {
       scope: 'organization' as const,
       orgId,
@@ -197,11 +209,16 @@ describe('reliability scoring — projected read golden value (integration)', ()
     };
 
     const ok = await withDbAccessContext(orgContext, () => computeAndPersistDeviceReliability(deviceId));
-    expect(ok).toBe(false);
+    expect(ok).toBe(true);
 
     const rows = await withSystemDbAccessContext(() =>
       getTestDb().select().from(deviceReliability).where(eq(deviceReliability.deviceId, deviceId)).limit(1),
     );
-    expect(rows).toHaveLength(0);
+    expect(rows).toHaveLength(1);
+    // Tenant-correct: the row lands under the caller's OWN org. The write still
+    // runs under org-scoped RLS, so this is the device's own tenant, not a
+    // system-scope escape hatch that could write anywhere.
+    expect(rows[0]!.deviceId).toBe(deviceId);
+    expect(rows[0]!.orgId).toBe(orgId);
   });
 });

--- a/apps/api/src/db/partnerAxisRead.ts
+++ b/apps/api/src/db/partnerAxisRead.ts
@@ -1,0 +1,57 @@
+import {
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from './index';
+
+/**
+ * Run a read of a PARTNER-AXIS table in a system RLS context (issue #2822).
+ *
+ * Partner-axis tables (`partners`, and everything in `PARTNER_TENANT_TABLES` in
+ * `apps/api/src/__tests__/integration/rls-coverage.integration.test.ts`) are
+ * gated by `breeze_has_partner_access(...)`, which evaluates against the
+ * `breeze.accessible_partner_ids` GUC. `computeAccessiblePartnerIds`
+ * (apps/api/src/middleware/auth.ts) returns `[]` for `scope === 'organization'`,
+ * and agentAuth / clientAiAuth / portal auth / org-scoped OAuth bearers all set
+ * `accessiblePartnerIds: []` too. Under those contexts the read returns ZERO
+ * ROWS — it does not raise — so the value silently collapses to a default, an
+ * empty list, or a spurious 404, for exactly the population the feature was
+ * meant to serve. A mocked-DB unit test cannot see this; only real Postgres can.
+ *
+ * Callers must keep the lookup hard-pinned to an id that came from the verified
+ * auth context (e.g. `auth.partnerId`) or from a row already resolved under the
+ * caller's own RLS context. Escaping RLS here widens which COLUMNS of the
+ * caller's own partner are legible; it must never widen WHICH partner row can
+ * be selected. Do not feed client-supplied ids through this helper.
+ *
+ * AVAILABILITY: the escape is taken ONLY when it is actually needed.
+ * `withDbAccessContext` opens a real `baseDb.transaction`, pinning one pooled
+ * connection for the whole callback, and `runOutsideDbContext` exits the
+ * AsyncLocalStorage store — so the nested `withSystemDbAccessContext` does not
+ * nest, it opens a SECOND transaction on a SECOND pooled connection while the
+ * first is still held. A caller that is already system-scoped gains nothing
+ * (partner-axis tables are fully visible to it) and would double-hold
+ * connections against the 25-connection US ceiling, where postgres-js has no
+ * acquire timeout. Same skip branch as `getEnrollmentDefaultsForOrg`
+ * (services/enrollmentDefaults.ts, #2818) and `withPartnerWideVisibility`
+ * (services/featureConfigResolver.ts).
+ */
+export async function readWithPartnerAxisVisibility<T>(fn: () => Promise<T>): Promise<T> {
+  // `getCurrentDbAccessContext()` reflects the GUCs actually SET LOCAL on the
+  // held transaction, so a reported scope of 'system' means the session really
+  // is running with breeze.scope = 'system' and breeze_has_partner_access
+  // short-circuits true. Anything else — including no context at all — takes
+  // the escape.
+  //
+  // Note for test authors: these are named imports on purpose. A unit suite
+  // whose `vi.mock('../db')` factory omits any of the three will fail loudly
+  // with "No <name> export is defined on the mock" rather than silently
+  // skipping the escape and reintroducing #2822. Add them to the factory:
+  //   getCurrentDbAccessContext: vi.fn(() => undefined),
+  //   runOutsideDbContext: vi.fn((fn) => fn()),
+  //   withSystemDbAccessContext: vi.fn(async (fn) => fn()),
+  const ambientScope = getCurrentDbAccessContext()?.scope;
+
+  if (ambientScope === 'system') return fn();
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -352,7 +352,13 @@ export function dbAccessContextFromAuth(auth: AuthContext): DbAccessContext {
     orgId: auth.orgId,
     accessibleOrgIds: auth.accessibleOrgIds,
     partnerId: auth.partnerId,
-    userId: auth.user.id,
+    // Optional-chained on purpose: `AuthContext.user` is typed non-optional,
+    // but API-key-derived contexts are built by hand elsewhere in the codebase
+    // and `routes/devices/provision.ts` already guards `auth.user?.id`. Since
+    // #2822 routed the AI-tool handlers through this builder, an unguarded
+    // dereference here would turn a missing `user` into a TypeError inside
+    // every tool call rather than a benign null user id.
+    userId: auth.user?.id ?? null,
   });
 }
 

--- a/apps/api/src/routes/agents/reliability.test.ts
+++ b/apps/api/src/routes/agents/reliability.test.ts
@@ -137,12 +137,22 @@ describe('agent reliability ingestion route', () => {
     expect(vi.mocked(enqueueDeviceReliabilityComputation)).toHaveBeenCalledWith('device-1');
     expect(vi.mocked(captureException)).toHaveBeenCalledWith(expect.any(Error));
     expect(vi.mocked(computeAndPersistDeviceReliability)).toHaveBeenCalledWith('device-1');
-    // #1105 Critical fix: the inline fallback reads the ml-feature-flag gate
-    // (an `organizations INNER JOIN partners` — needs partner-axis visibility) and
-    // writes deviceReliability. It MUST run under a *system* context: an org context
-    // can't see the partner row, so the flag gate would resolve `org_not_found` and
-    // the compute would silently no-op. Mirrors the worker (runOutsideDbContext +
-    // withSystemDbAccessContext), not an org-scoped wrap.
+    // #1105: the inline fallback must run OUTSIDE the request's transaction and
+    // in a fresh system context, mirroring the worker (runOutsideDbContext +
+    // withSystemDbAccessContext) rather than reusing an org-scoped wrap.
+    //
+    // These three assertions ARE the #1105 guard. They pin caller discipline
+    // directly, on the caller, which is why they survived #2822 unchanged when
+    // the symptom-based lock in reliabilityScoringProjection.integration.test.ts
+    // had to be inverted. Keep them that way: do NOT weaken this to inferring
+    // the context from downstream behaviour.
+    //
+    // (Historical note: the original rationale here was that an org context
+    // "can't see the partner row, so the flag gate would resolve org_not_found
+    // and the compute would silently no-op". #2822 fixed that lie — the gate now
+    // answers honestly under an org context — so that is no longer WHY a system
+    // context is required. The surviving reasons are the #1105 connection-hold
+    // discipline and parity with the worker path.)
     expect(fallbackScope).toBe('system');
     expect(vi.mocked(runOutsideDbContext)).toHaveBeenCalled();
     expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalled();

--- a/apps/api/src/routes/clientAi/admin.test.ts
+++ b/apps/api/src/routes/clientAi/admin.test.ts
@@ -40,6 +40,9 @@ vi.mock('../../config/env', () => ({
 }));
 
 vi.mock('../../db', () => ({
+  getCurrentDbAccessContext: vi.fn(() => undefined),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   db: { select: dbSelectMock, insert: dbInsertMock, delete: dbDeleteMock },
 }));
 

--- a/apps/api/src/routes/clientAi/admin.ts
+++ b/apps/api/src/routes/clientAi/admin.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { eq } from 'drizzle-orm';
 import { db } from '../../db';
+import { readWithPartnerAxisVisibility } from '../../db/partnerAxisRead';
 import { clientAiOrgPolicies, clientAiTenantMappings } from '../../db/schema/clientAi';
 import { partners } from '../../db/schema/orgs';
 import { authMiddleware, requireMfa, requirePermission } from '../../middleware/auth';
@@ -49,11 +50,24 @@ clientAiAdminRoutes.use('*', async (c, next) => {
   }
   const auth = c.get('auth');
   if (auth?.partnerId) {
-    const [partner] = await db
-      .select({ aiForOfficeEnabled: partners.aiForOfficeEnabled })
-      .from(partners)
-      .where(eq(partners.id, auth.partnerId))
-      .limit(1);
+    const partnerId = auth.partnerId;
+    // Read under a SYSTEM context (#2822). This group applies authMiddleware
+    // only — no requireScope — and every route below routes through
+    // resolveScopedOrgId, which explicitly supports ORGANIZATION scope. An
+    // org-scoped caller carries a non-null auth.partnerId but
+    // accessiblePartnerIds = [], so the ambient-context read returned zero rows
+    // and this gate 404'd the entire /client-ai/admin surface for every
+    // org-scoped user even when their partner's entitlement was ON — a fail-
+    // closed outage indistinguishable from the genuine "not enabled" response.
+    // Pinned to the verified JWT's partnerId, so this does not widen which
+    // partner is legible.
+    const [partner] = await readWithPartnerAxisVisibility(() =>
+      db
+        .select({ aiForOfficeEnabled: partners.aiForOfficeEnabled })
+        .from(partners)
+        .where(eq(partners.id, partnerId))
+        .limit(1)
+    );
     if (!partner?.aiForOfficeEnabled) {
       return c.json({ error: 'Breeze AI for Office is not enabled' }, 404);
     }

--- a/apps/api/src/routes/devices/provision.test.ts
+++ b/apps/api/src/routes/devices/provision.test.ts
@@ -9,6 +9,11 @@ const { authMiddlewareMock, requireScopeMock, requirePermissionMock, requireMfaM
   requireMfaMock: vi.fn(() => async (_c: any, next: any) => next()),
 }));
 
+// The partner device-limit check reads `partners` through
+// `readWithPartnerAxisVisibility` (#2822), which needs these three context
+// helpers. Without them vitest throws "No <name> export is defined on the mock"
+// the moment a test drives a non-null partnerId — which is exactly how the cap
+// tests below stay honest rather than silently skipping the code.
 vi.mock('../../db', () => ({
   db: {
     select: vi.fn(),
@@ -17,6 +22,13 @@ vi.mock('../../db', () => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+  getCurrentDbAccessContext: vi.fn(() => ({
+    scope: 'organization',
+    orgId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    accessibleOrgIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+  })),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../../middleware/auth', () => ({
@@ -128,23 +140,46 @@ function mockSelectRows(rows: any[]) {
 }
 
 function mockTransactionSuccess(insertedRow: any) {
-  vi.mocked(db.transaction).mockImplementation(async (cb: any) => {
-    const tx = {
-      select: vi.fn().mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{ id: ORG_ID, partnerId: null }]),
-          }),
-        }),
-      }),
-      insert: vi.fn().mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([insertedRow]),
-        }),
-      }),
-    };
-    return cb(tx);
+  const txInsert = vi.fn().mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([insertedRow]),
+    }),
   });
+  vi.mocked(db.transaction).mockImplementation(async (cb: any) => cb({ insert: txInsert }));
+  return { txInsert };
+}
+
+/** Stages the target-org lookup that precedes the device-limit check. */
+function mockTargetOrg(partnerId: string | null) {
+  mockSelectRows([{ id: ORG_ID, partnerId }]);
+}
+
+/**
+ * Stages the reads the partner device-limit block makes inside its system
+ * context (#2822): the `partners.maxDevices` lookup, then — only when a cap
+ * exists — the partner-wide active-device count.
+ */
+function mockPartnerCap(opts: { maxDevices: number | null; activeCount?: number }) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn().mockResolvedValue([{ maxDevices: opts.maxDevices }]),
+      })),
+    })),
+  } as any);
+
+  if (opts.maxDevices == null) return;
+
+  // The `partnerOrgIds` subquery: db.select().from().where(), never awaited.
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn(() => ({ where: vi.fn(() => ({})) })),
+  } as any);
+  // The count: db.select().from().where() awaited directly (no .limit()).
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn(() => ({
+      where: vi.fn().mockResolvedValue([{ count: opts.activeCount ?? 0 }]),
+    })),
+  } as any);
 }
 
 /** Mocks `db.insert(...).values(...)` resolving successfully (handle persist). */
@@ -210,10 +245,114 @@ describe('POST /devices/provision', () => {
     });
   });
 
+  // BEHAVIOUR CHANGE (#2822). The partner `max_devices` cap used to be INERT for
+  // org-scoped callers: `partners` is partner-axis, an org-scoped caller has
+  // accessiblePartnerIds = [], the read returned zero rows, `maxDevices`
+  // collapsed to null and the whole block was skipped. So the same action was
+  // capped for a partner admin and uncapped for an org admin — a silent,
+  // scope-dependent bypass of a billing/entitlement control. These tests pin the
+  // enforcement that now actually happens.
+  describe('partner device limit', () => {
+    const PARTNER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+    it('rejects with 403 DEVICE_LIMIT_REACHED when the partner fleet is at the cap', async () => {
+      mockSelectRows([{ id: SITE_ID }]);   // site-in-org check
+      mockSelectRows([]);                   // hostname collision (none)
+      mockTargetOrg(PARTNER_ID);
+      mockPartnerCap({ maxDevices: 5, activeCount: 5 });
+      const { txInsert } = mockTransactionSuccess({ id: 'should-not-be-created' });
+
+      const res = await app.request('/devices/provision', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify(BASE_BODY),
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toMatchObject({
+        code: 'DEVICE_LIMIT_REACHED',
+        currentDevices: 5,
+        maxDevices: 5,
+      });
+      // The cap is checked BEFORE the insert transaction opens, so no device
+      // row is created and no transaction is even started.
+      expect(txInsert).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+
+    it('allows provisioning while the partner fleet is below the cap', async () => {
+      mockSelectRows([{ id: SITE_ID }]);
+      mockSelectRows([]);
+      mockTargetOrg(PARTNER_ID);
+      mockPartnerCap({ maxDevices: 5, activeCount: 4 });
+      mockTransactionSuccess({
+        id: 'device-under-cap',
+        orgId: ORG_ID,
+        siteId: SITE_ID,
+        hostname: BASE_BODY.hostname,
+        agentId: 'agent-prov-1',
+        status: 'pending',
+      });
+      mockInsertSuccess();
+
+      const res = await app.request('/devices/provision', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify(BASE_BODY),
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('skips the fleet count entirely when the partner has no cap set', async () => {
+      mockSelectRows([{ id: SITE_ID }]);
+      mockSelectRows([]);
+      mockTargetOrg(PARTNER_ID);
+      // maxDevices null → mockPartnerCap stages ONLY the partners lookup. If the
+      // resolver did not short-circuit it would consume the credential-handle
+      // insert mock next and the request would not reach 201 — so this asserts
+      // the early return, not just the status code.
+      mockPartnerCap({ maxDevices: null });
+      mockTransactionSuccess({
+        id: 'device-uncapped',
+        orgId: ORG_ID,
+        siteId: SITE_ID,
+        hostname: BASE_BODY.hostname,
+        agentId: 'agent-prov-1',
+        status: 'pending',
+      });
+      mockInsertSuccess();
+
+      const res = await app.request('/devices/provision', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify(BASE_BODY),
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('404s when the target org row does not resolve', async () => {
+      mockSelectRows([{ id: SITE_ID }]);
+      mockSelectRows([]);
+      mockSelectRows([]); // target org lookup finds nothing
+
+      const res = await app.request('/devices/provision', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer t', 'Content-Type': 'application/json' },
+        body: JSON.stringify(BASE_BODY),
+      });
+
+      expect(res.status).toBe(404);
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+  });
+
   describe('happy path', () => {
     it('creates a device and returns a one-time fetch URL (no inline secrets)', async () => {
       mockSelectRows([{ id: SITE_ID }]);     // site-in-org check
       mockSelectRows([]);                     // hostname collision check (none)
+      mockTargetOrg(null);                    // target org (no partner → no cap)
       mockTransactionSuccess({
         id: 'device-prov-id',
         orgId: ORG_ID,
@@ -269,6 +408,7 @@ describe('POST /devices/provision', () => {
         setAuth();
         mockSelectRows([{ id: SITE_ID }]);
         mockSelectRows([]);
+        mockTargetOrg(null);
         mockTransactionSuccess({
           id: `device-${os}`,
           orgId: ORG_ID,
@@ -405,6 +545,7 @@ describe('POST /devices/provision', () => {
       setAuth({ allowedSiteIds: [SITE_ID] });
       mockSelectRows([{ id: SITE_ID }]); // site-in-org check
       mockSelectRows([]);                 // hostname collision (none)
+      mockTargetOrg(null);                // target org (no partner → no cap)
       mockTransactionSuccess({
         id: 'device-in-scope',
         orgId: ORG_ID,
@@ -431,6 +572,7 @@ describe('POST /devices/provision', () => {
       setAuth(); // no allowedSiteIds → unrestricted
       mockSelectRows([{ id: SITE_ID }]);
       mockSelectRows([]);
+      mockTargetOrg(null);
       mockTransactionSuccess({
         id: 'device-unrestricted',
         orgId: ORG_ID,

--- a/apps/api/src/routes/devices/provision.ts
+++ b/apps/api/src/routes/devices/provision.ts
@@ -14,6 +14,7 @@ import {
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../../services/permissions';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
+import { captureException } from '../../services/sentry';
 import { provisionDeviceSchema } from './schemas';
 import { generateAgentId, generateApiKey, issueMtlsCertForDevice } from '../agents/helpers';
 import { getActiveTrustKeyset } from '../../services/manifestSigning';
@@ -152,75 +153,95 @@ provisionRoutes.post(
     // lgtm[js/insufficient-password-hash]
     const helperTokenHash = createHash('sha256').update(helperApiKey).digest('hex');
 
-    // ----------- device limit check + insert (TOCTOU-safe in a transaction) -----------
+    // ----------- partner device-limit check, then insert -----------
+    //
+    // The cap check runs BEFORE the insert transaction opens, not inside it.
+    //
+    // WHY IT MOVED (#2822): the `partners` read must run in a SYSTEM context.
+    // Inside `db.transaction` that meant `runOutsideDbContext` opening a SECOND
+    // pooled connection while the insert transaction still held the first
+    // (runOutsideDbContext does not close the outer transaction). Hoisting it
+    // out removes the double-hold entirely — nothing between the org lookup and
+    // the cap check writes anything, so there is nothing to keep in the
+    // transaction.
+    //
+    // WHY IT NEEDS THE SYSTEM CONTEXT AT ALL: this route is
+    // requireScope('organization','partner','system'), and for an ORG-scoped
+    // caller accessiblePartnerIds = [], so under the request's own RLS context
+    //   - the `partners` read returned zero rows, `maxDevices` collapsed to
+    //     null, and the whole cap block was skipped — an org admin could
+    //     provision past the partner's max_devices without limit, while the
+    //     identical call from a partner admin was capped;
+    //   - the `partnerOrgIds` subquery over `organizations` only saw the
+    //     caller's own accessible orgs, so even once a cap resolved, the fleet
+    //     count under-reported and the cap under-enforced.
+    // (enrollment.ts has always been correct here because it runs its whole
+    // flow inside withSystemDbAccessContext.)
+    //
+    // The org row itself is still read under the CALLER'S context, so RLS
+    // decides which org is legible; `org.partnerId` therefore comes from a row
+    // the caller could already see and cannot be aimed at a foreign partner.
+    //
+    // NOT TOCTOU-SAFE, and never was: the count takes no lock, so two
+    // concurrent provisions at the cap boundary can both observe
+    // `activeCount === maxDevices - 1` and both insert. That race predates this
+    // change (separate requests are separate transactions under READ COMMITTED
+    // regardless of where the count runs); moving the check out of the insert
+    // transaction does not widen it. Enforcing it strictly would need a lock on
+    // the partner row or a DB-level constraint — tracked, not solved here.
+    const [targetOrg] = await db
+      .select({ id: organizations.id, partnerId: organizations.partnerId })
+      .from(organizations)
+      .where(eq(organizations.id, data.orgId))
+      .limit(1);
+
+    if (!targetOrg) {
+      return c.json({ error: 'Target organization not found' }, 404);
+    }
+
+    const orgPartnerId = targetOrg.partnerId;
+    const deviceLimit = orgPartnerId
+      ? await readWithPartnerAxisVisibility(async () => {
+        const [partner] = await db
+          .select({ maxDevices: partners.maxDevices })
+          .from(partners)
+          .where(eq(partners.id, orgPartnerId))
+          .limit(1);
+        const maxDevices = partner?.maxDevices ?? null;
+        if (maxDevices == null) return null;
+
+        const partnerOrgIds = db
+          .select({ id: organizations.id })
+          .from(organizations)
+          .where(eq(organizations.partnerId, orgPartnerId));
+        const [countResult] = await db
+          .select({ count: sql<number>`count(*)` })
+          .from(devices)
+          .where(
+            and(
+              sql`${devices.orgId} IN (${partnerOrgIds})`,
+              ne(devices.status, 'decommissioned'),
+            ),
+          );
+        return { maxDevices, activeCount: Number(countResult?.count ?? 0) };
+      })
+      : null;
+
+    if (deviceLimit && deviceLimit.activeCount >= deviceLimit.maxDevices) {
+      return c.json(
+        {
+          error: 'Device limit reached',
+          code: 'DEVICE_LIMIT_REACHED',
+          currentDevices: deviceLimit.activeCount,
+          maxDevices: deviceLimit.maxDevices,
+        },
+        403,
+      );
+    }
+
     let device: typeof devices.$inferSelect | undefined;
     try {
       device = await db.transaction(async (tx) => {
-        const [org] = await tx
-          .select({ id: organizations.id, partnerId: organizations.partnerId })
-          .from(organizations)
-          .where(eq(organizations.id, data.orgId))
-          .limit(1);
-
-        if (!org) {
-          throw new Error('Target organization not found');
-        }
-
-        // Partner device-limit check (mirrors enrollment.ts, which runs its
-        // whole flow inside withSystemDbAccessContext).
-        //
-        // Both halves MUST run in a SYSTEM context (#2822). `tx` here is a
-        // SAVEPOINT on the request's own transaction, so it inherits the
-        // caller's RLS GUCs. This route is requireScope('organization',
-        // 'partner', 'system'), and for an ORG-scoped caller
-        // accessiblePartnerIds = []:
-        //   - the `partners` read returned zero rows, so `maxDevices` collapsed
-        //     to null and the entire cap block was skipped — an org admin could
-        //     provision past the partner's max_devices without limit, while the
-        //     identical call from a partner admin was capped;
-        //   - the `partnerOrgIds` subquery over `organizations` only saw the
-        //     caller's own accessible orgs, so even once the cap resolved the
-        //     fleet count under-reported and the cap under-enforced.
-        // `org.partnerId` comes from the `organizations` row already resolved
-        // under the caller's own RLS context above, so this does not let a
-        // caller aim the lookup at a partner it cannot see.
-        //
-        // The escape opens a second pooled connection while this transaction
-        // still holds the first (runOutsideDbContext does not close the outer
-        // transaction). That is accepted here — provisioning is a low-rate
-        // admin action, not a hot path — and it is skipped entirely when the
-        // caller is already system-scoped.
-        const orgPartnerId = org.partnerId;
-        const limit = orgPartnerId
-          ? await readWithPartnerAxisVisibility(async () => {
-            const [partner] = await db
-              .select({ maxDevices: partners.maxDevices })
-              .from(partners)
-              .where(eq(partners.id, orgPartnerId))
-              .limit(1);
-            const maxDevices = partner?.maxDevices ?? null;
-            if (maxDevices == null) return null;
-
-            const partnerOrgIds = db
-              .select({ id: organizations.id })
-              .from(organizations)
-              .where(eq(organizations.partnerId, orgPartnerId));
-            const [countResult] = await db
-              .select({ count: sql<number>`count(*)` })
-              .from(devices)
-              .where(
-                and(
-                  sql`${devices.orgId} IN (${partnerOrgIds})`,
-                  ne(devices.status, 'decommissioned'),
-                ),
-              );
-            return { maxDevices, activeCount: Number(countResult?.count ?? 0) };
-          })
-          : null;
-        if (limit && limit.activeCount >= limit.maxDevices) {
-          throw new HttpDeviceLimitError(limit.activeCount, limit.maxDevices);
-        }
-
         const [inserted] = await tx
           .insert(devices)
           .values({
@@ -260,18 +281,13 @@ provisionRoutes.post(
         return inserted;
       });
     } catch (err) {
-      if (err instanceof HttpDeviceLimitError) {
-        return c.json(
-          {
-            error: 'Device limit reached',
-            code: 'DEVICE_LIMIT_REACHED',
-            currentDevices: err.current,
-            maxDevices: err.max,
-          },
-          403,
-        );
-      }
+      // The cap check no longer throws through here — it returns 403 directly
+      // above — so anything reaching this catch is a genuine insert failure.
+      // Route it to Sentry as well as stdout: a DB fault here (including pool
+      // exhaustion from the partner-axis escape) is otherwise invisible outside
+      // the droplet's logs.
       console.error('[devices.provision] insert failed:', err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
       return c.json({ error: 'Failed to provision device' }, 500);
     }
 
@@ -442,8 +458,3 @@ provisionRoutes.get('/provision/fetch/:token', async (c) => {
   return c.json({ success: true, config: row.credentials }, 200);
 });
 
-class HttpDeviceLimitError extends Error {
-  constructor(public current: number, public max: number) {
-    super('device limit reached');
-  }
-}

--- a/apps/api/src/routes/devices/provision.ts
+++ b/apps/api/src/routes/devices/provision.ts
@@ -3,6 +3,7 @@ import { zValidator } from '../../lib/validation';
 import { and, eq, isNull, ne, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db } from '../../db';
+import { readWithPartnerAxisVisibility } from '../../db/partnerAxisRead';
 import { devices, organizations, sites, partners, provisionCredentialHandles } from '../../db/schema';
 import {
   authMiddleware,
@@ -165,34 +166,59 @@ provisionRoutes.post(
           throw new Error('Target organization not found');
         }
 
-        // Partner device-limit check (mirrors enrollment.ts:415-449)
-        let maxDevices: number | null = null;
-        if (org.partnerId) {
-          const [partner] = await tx
-            .select({ maxDevices: partners.maxDevices })
-            .from(partners)
-            .where(eq(partners.id, org.partnerId))
-            .limit(1);
-          maxDevices = partner?.maxDevices ?? null;
-        }
-        if (maxDevices != null && org.partnerId) {
-          const partnerOrgIds = tx
-            .select({ id: organizations.id })
-            .from(organizations)
-            .where(eq(organizations.partnerId, org.partnerId));
-          const [countResult] = await tx
-            .select({ count: sql<number>`count(*)` })
-            .from(devices)
-            .where(
-              and(
-                sql`${devices.orgId} IN (${partnerOrgIds})`,
-                ne(devices.status, 'decommissioned'),
-              ),
-            );
-          const activeCount = Number(countResult?.count ?? 0);
-          if (activeCount >= maxDevices) {
-            throw new HttpDeviceLimitError(activeCount, maxDevices);
-          }
+        // Partner device-limit check (mirrors enrollment.ts, which runs its
+        // whole flow inside withSystemDbAccessContext).
+        //
+        // Both halves MUST run in a SYSTEM context (#2822). `tx` here is a
+        // SAVEPOINT on the request's own transaction, so it inherits the
+        // caller's RLS GUCs. This route is requireScope('organization',
+        // 'partner', 'system'), and for an ORG-scoped caller
+        // accessiblePartnerIds = []:
+        //   - the `partners` read returned zero rows, so `maxDevices` collapsed
+        //     to null and the entire cap block was skipped — an org admin could
+        //     provision past the partner's max_devices without limit, while the
+        //     identical call from a partner admin was capped;
+        //   - the `partnerOrgIds` subquery over `organizations` only saw the
+        //     caller's own accessible orgs, so even once the cap resolved the
+        //     fleet count under-reported and the cap under-enforced.
+        // `org.partnerId` comes from the `organizations` row already resolved
+        // under the caller's own RLS context above, so this does not let a
+        // caller aim the lookup at a partner it cannot see.
+        //
+        // The escape opens a second pooled connection while this transaction
+        // still holds the first (runOutsideDbContext does not close the outer
+        // transaction). That is accepted here — provisioning is a low-rate
+        // admin action, not a hot path — and it is skipped entirely when the
+        // caller is already system-scoped.
+        const orgPartnerId = org.partnerId;
+        const limit = orgPartnerId
+          ? await readWithPartnerAxisVisibility(async () => {
+            const [partner] = await db
+              .select({ maxDevices: partners.maxDevices })
+              .from(partners)
+              .where(eq(partners.id, orgPartnerId))
+              .limit(1);
+            const maxDevices = partner?.maxDevices ?? null;
+            if (maxDevices == null) return null;
+
+            const partnerOrgIds = db
+              .select({ id: organizations.id })
+              .from(organizations)
+              .where(eq(organizations.partnerId, orgPartnerId));
+            const [countResult] = await db
+              .select({ count: sql<number>`count(*)` })
+              .from(devices)
+              .where(
+                and(
+                  sql`${devices.orgId} IN (${partnerOrgIds})`,
+                  ne(devices.status, 'decommissioned'),
+                ),
+              );
+            return { maxDevices, activeCount: Number(countResult?.count ?? 0) };
+          })
+          : null;
+        if (limit && limit.activeCount >= limit.maxDevices) {
+          throw new HttpDeviceLimitError(limit.activeCount, limit.maxDevices);
         }
 
         const [inserted] = await tx

--- a/apps/api/src/routes/mcpServer.bootstrapCarveout.test.ts
+++ b/apps/api/src/routes/mcpServer.bootstrapCarveout.test.ts
@@ -48,6 +48,7 @@ vi.mock('../middleware/bearerTokenAuth', () => ({
 }));
 
 vi.mock('../db', () => ({
+  getCurrentDbAccessContext: vi.fn(() => undefined),
   db: new Proxy({}, {
     get: (_target, property) => state.db[property as string],
   }),

--- a/apps/api/src/routes/mcpServer.bootstrapLifecycle.test.ts
+++ b/apps/api/src/routes/mcpServer.bootstrapLifecycle.test.ts
@@ -82,6 +82,12 @@ vi.mock('../db', () => ({
   withDbAccessContext: vi.fn((_ctx: any, fn: any) => fn()),
   withSystemDbAccessContext: vi.fn((fn: any) => fn()),
   runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+  // The bootstrap billing-email read goes through readWithPartnerAxisVisibility
+  // (#2822), which probes the ambient scope. This suite only started needing the
+  // export once the swallowing try/catch around that read was removed — before
+  // that, the missing-export error was silently absorbed into partnerAdminEmail
+  // = '', which is precisely the failure mode the removal exists to prevent.
+  getCurrentDbAccessContext: vi.fn(() => undefined),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -1394,20 +1394,23 @@ async function dispatchBootstrapAuthTool(
   // success. The narrow escalation of this one pinned single-column lookup is
   // deliberate: it does NOT widen accessiblePartnerIds, which those middlewares
   // withhold on purpose.
-  let partnerAdminEmail = '';
-  try {
-    const partnerId = auth.partnerId;
-    const [row] = await readWithPartnerAxisVisibility(() =>
-      db
-        .select({ billingEmail: partners.billingEmail })
-        .from(partners)
-        .where(eq(partners.id, partnerId))
-        .limit(1)
-    );
-    partnerAdminEmail = row?.billingEmail ?? '';
-  } catch (err) {
-    console.error('[MCP] Failed to load partner billing email:', err);
-  }
+  //
+  // Deliberately NOT wrapped in a try/catch. The catch that used to be here
+  // never actually fired — RLS returns zero rows without raising, so the ''
+  // came from `row?.billingEmail ?? ''`, not from an exception. Now that the
+  // read is correct, the only way it can throw is a genuine DB fault, and
+  // swallowing that would degrade to the exact same '' the rest of this fix
+  // exists to eliminate. A DB fault is not a business outcome; let it surface
+  // through the JSON-RPC error path.
+  const partnerId = auth.partnerId;
+  const [row] = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({ billingEmail: partners.billingEmail })
+      .from(partners)
+      .where(eq(partners.id, partnerId))
+      .limit(1)
+  );
+  const partnerAdminEmail = row?.billingEmail ?? '';
 
   const bootstrapCtx = {
     ip: requestIp(c),

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -27,6 +27,7 @@ import { bearerTokenAuthMiddleware, resolvePartnerAccessibleOrgIds } from '../mi
 import { getToolDefinitions, executeTool, getToolTier } from '../services/aiTools';
 import { checkGuardrails, checkToolPermission, checkToolRateLimit, checkPermissionRequirement } from '../services/aiGuardrails';
 import { db } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { devices, alerts, scripts, automations, partners, organizations } from '../db/schema';
 import { eq, and, asc, desc, inArray, isNull, or, getTableColumns, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
@@ -1380,13 +1381,29 @@ async function dispatchBootstrapAuthTool(
   }
 
   // Look up partner billing email (used as the admin email in invite templates).
+  //
+  // Read under a SYSTEM context (#2822). Both non-partner-scoped principals that
+  // reach this dispatcher deliberately carry accessiblePartnerIds = []: an
+  // org-scoped OAuth bearer (bearerTokenAuth.ts, MCP-OAUTH-06) and any X-API-Key
+  // whose source is not `mcp_provisioning` (apiKeyAuth.ts). Both still resolve a
+  // non-null auth.partnerId, so the ambient-context read returned zero rows —
+  // and RLS does not raise, so the try/catch never fired and partnerAdminEmail
+  // silently became ''. Downstream that produced an email notification channel
+  // with an empty target (modules/mcpInvites/tools/configureDefaults.ts) and
+  // deployment invites rendered with a blank admin contact, both reporting
+  // success. The narrow escalation of this one pinned single-column lookup is
+  // deliberate: it does NOT widen accessiblePartnerIds, which those middlewares
+  // withhold on purpose.
   let partnerAdminEmail = '';
   try {
-    const [row] = await db
-      .select({ billingEmail: partners.billingEmail })
-      .from(partners)
-      .where(eq(partners.id, auth.partnerId))
-      .limit(1);
+    const partnerId = auth.partnerId;
+    const [row] = await readWithPartnerAxisVisibility(() =>
+      db
+        .select({ billingEmail: partners.billingEmail })
+        .from(partners)
+        .where(eq(partners.id, partnerId))
+        .limit(1)
+    );
     partnerAdminEmail = row?.billingEmail ?? '';
   } catch (err) {
     console.error('[MCP] Failed to load partner billing email:', err);

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -122,7 +122,13 @@ vi.mock('../db', () => ({
     })
   },
   runOutsideDbContext: vi.fn((fn: () => any) => fn()),
-  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn())
+  withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn()),
+  // PATCH /orgs/organizations/:id calls assertNotLocked, whose partner-axis
+  // read now goes through readWithPartnerAxisVisibility (#2822). That helper
+  // probes the ambient scope, so the factory must export it — `undefined`
+  // (no ambient context) makes it take the escape, which these pass-through
+  // stubs then flatten.
+  getCurrentDbAccessContext: vi.fn(() => undefined)
 }));
 
 vi.mock('../services/ticketConfigService', () => ({

--- a/apps/api/src/routes/partner.test.ts
+++ b/apps/api/src/routes/partner.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
 vi.mock('../db', () => ({
+  // GET /partner/me reads `partners` through readWithPartnerAxisVisibility
+  // (#2822); the helper probes the ambient scope, so the factory must export it.
+  getCurrentDbAccessContext: vi.fn(() => undefined),
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
@@ -11,6 +14,10 @@ vi.mock('../db', () => ({
 }));
 
 vi.mock('../db/schema', () => ({
+  partners: {
+    id: 'id', name: 'name', slug: 'slug', status: 'status', settings: 'settings'
+  },
+  partnerUsers: { userId: 'userId', partnerId: 'partnerId' },
   organizations: {
     id: 'id',
     name: 'name',
@@ -26,23 +33,29 @@ vi.mock('../db/schema', () => ({
   }
 }));
 
+// Mutable so a test can swap in an ORGANIZATION-scoped caller — the population
+// GET /partner/me was silently 404ing for (#2822).
+const currentAuth: { value: Record<string, unknown> } = {
+  value: {
+    user: { id: 'user-123', email: 'partner@example.com', name: 'Partner User' },
+    scope: 'partner',
+    orgId: null,
+    partnerId: 'partner-123',
+    accessibleOrgIds: ['org-123'],
+    canAccessOrg: (orgId: string) => orgId === 'org-123'
+  },
+};
+
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
-    c.set('auth', {
-      user: { id: 'user-123', email: 'partner@example.com', name: 'Partner User' },
-      scope: 'partner',
-      orgId: null,
-      partnerId: 'partner-123',
-      accessibleOrgIds: ['org-123'],
-      canAccessOrg: (orgId: string) => orgId === 'org-123'
-    });
+    c.set('auth', currentAuth.value);
     return next();
   }),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
   requireScope: vi.fn(() => async (_c: any, next: any) => next())
 }));
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { partnerRoutes } from './partner';
 
 describe('partner routes', () => {
@@ -50,8 +63,78 @@ describe('partner routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    currentAuth.value = {
+      user: { id: 'user-123', email: 'partner@example.com', name: 'Partner User' },
+      scope: 'partner',
+      orgId: null,
+      partnerId: 'partner-123',
+      accessibleOrgIds: ['org-123'],
+      canAccessOrg: (orgId: string) => orgId === 'org-123',
+    };
     app = new Hono();
     app.route('/partner', partnerRoutes);
+  });
+
+  describe('GET /partner/me', () => {
+    // `partners` is partner-axis and an ORG-scoped JWT carries a non-null
+    // partnerId but accessiblePartnerIds = []. This route has authMiddleware and
+    // NO requireScope, and is exempt from partnerGuard so the client can ask
+    // "what is my partner's status?" while that partner is inactive. Pre-#2822
+    // the read returned zero rows and every org-scoped user got a bare 404 —
+    // which apps/web's AccountInactiveGuard swallows (`if (!res.ok) return
+    // null`), so suspended-tenant users were never redirected.
+    it('resolves the partner for an ORG-scoped caller (was a silent 404)', async () => {
+      currentAuth.value = {
+        user: { id: 'user-456', email: 'orguser@example.com', name: 'Org User' },
+        scope: 'organization',
+        orgId: 'org-123',
+        partnerId: 'partner-123',
+        accessibleOrgIds: ['org-123'],
+        canAccessOrg: (orgId: string) => orgId === 'org-123',
+      };
+
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: 'partner-123',
+              name: 'Acme MSP',
+              slug: 'acme',
+              status: 'suspended',
+              settings: { statusMessage: 'Billing on hold' },
+            }]),
+          }),
+        }),
+      } as any);
+
+      const res = await app.request('/partner/me', {
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        id: 'partner-123',
+        status: 'suspended',
+        statusMessage: 'Billing on hold',
+      });
+      // The escape must actually be taken for an org-scoped caller.
+      expect(runOutsideDbContext).toHaveBeenCalled();
+      expect(withSystemDbAccessContext).toHaveBeenCalled();
+    });
+
+    it('404s when the partner row genuinely does not exist', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      } as any);
+
+      const res = await app.request('/partner/me', {
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(404);
+    });
   });
 
   it('returns partner dashboard customer payload', async () => {

--- a/apps/api/src/routes/partner.ts
+++ b/apps/api/src/routes/partner.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { db } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { organizations, devices, partners, partnerUsers } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { PERMISSIONS } from '../services/permissions';
@@ -31,12 +32,28 @@ partnerRoutes.get('/me', async (c) => {
   if (!partnerId) {
     return c.json({ error: 'No partner association' }, 404);
   }
+  // Narrowed copy so the closure below keeps the non-null type.
+  const resolvedPartnerId = partnerId;
 
-  const [partner] = await db
-    .select({ id: partners.id, name: partners.name, slug: partners.slug, status: partners.status, settings: partners.settings })
-    .from(partners)
-    .where(eq(partners.id, partnerId))
-    .limit(1);
+  // Read under a SYSTEM context (#2822). This route is gated by authMiddleware
+  // ONLY — no requireScope — and is explicitly exempt from partnerGuard
+  // (index.ts) so the client can still ask "what is my partner's status?" while
+  // that partner is inactive. An ORGANIZATION-scoped JWT carries a non-null
+  // partnerId (routes/auth/helpers.ts fills it from organizations.partnerId),
+  // so it reaches this read with accessiblePartnerIds = [] and the `partners`
+  // SELECT policy filters the row out — turning every org-scoped call into a
+  // spurious 404, which the web AccountInactiveGuard swallows (`if (!res.ok)
+  // return null`), so those users are never told their tenant is suspended.
+  // `partnerId` here is either the verified JWT claim or the caller's own
+  // partner_users row — never client input — so escalating this one
+  // pinned-by-id lookup does not widen which partner is legible.
+  const [partner] = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({ id: partners.id, name: partners.name, slug: partners.slug, status: partners.status, settings: partners.settings })
+      .from(partners)
+      .where(eq(partners.id, resolvedPartnerId))
+      .limit(1)
+  );
 
   if (!partner) {
     return c.json({ error: 'Partner not found' }, 404);

--- a/apps/api/src/services/aiAgentSdkTools.sessionAware.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.sessionAware.test.ts
@@ -32,6 +32,7 @@ vi.mock('./aiToolsM365', () => ({
   registerM365Tools: vi.fn(),
 }));
 
+import { withDbAccessContext } from '../db';
 import { __test__ } from './aiAgentSdkTools';
 
 const { makeSessionAwareHandler } = __test__;
@@ -127,6 +128,46 @@ describe('makeSessionAwareHandler (M365 enforcement routing)', () => {
     expect(sessionHandler).toHaveBeenCalledWith({ userIdentifier: 'jane@x.com' }, fakeAuth, 'sess-123');
     expect(res.isError).toBeUndefined();
     expect(firstText(res)).toBe(JSON.stringify({ data: { display: 'Jane' } }));
+  });
+
+  // (5) ROOT CAUSE REGRESSION GUARD (#2822). The handler used to hand
+  // withDbAccessContext a hand-rolled literal carrying only scope/orgId/
+  // accessibleOrgIds. `serializeAccessibleIds` maps an absent list to '' ->
+  // ARRAY[]::uuid[] for any non-system scope, so `breeze_has_partner_access`
+  // was FALSE and `breeze_current_partner_id()` NULL for EVERY AI tool call —
+  // and because makeHandler calls runOutsideDbContext first, that literal was
+  // the ONLY context Postgres saw. Partner-axis tables (scripts, alert
+  // templates, catalog, update rings, integrations) all read as empty with a
+  // 200, including for a partner-scope MSP admin entitled to the rows.
+  //
+  // Asserted with a PARTNER-scope auth on purpose: for organization scope
+  // `computeAccessiblePartnerIds` legitimately returns [], so an org-scoped
+  // fixture cannot tell the canonical builder apart from the broken literal.
+  it('builds the tool DB context via dbAccessContextFromAuth, carrying the partner axis', async () => {
+    const partnerAuth = {
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: null,
+      partnerId: 'partner-1',
+      user: { id: 'user-1' },
+    } as any;
+    getAuth = vi.fn(() => partnerAuth);
+    getActiveSession = vi.fn(() => ({ breezeSessionId: 'sess-123', auth: partnerAuth }) as any);
+
+    const handler = makeSessionAwareHandler(
+      'm365_lookup_user', getAuth, getActiveSession, sessionHandler, onPreToolUse, onPostToolUse,
+    );
+    await handler({ userIdentifier: 'jane@x.com' });
+
+    expect(withDbAccessContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'partner',
+        accessiblePartnerIds: ['partner-1'],
+        currentPartnerId: 'partner-1',
+        userId: 'user-1',
+      }),
+      expect.any(Function),
+    );
   });
 
   // (4) No active session -> no_active_session error, handler & enforcement skipped.

--- a/apps/api/src/services/aiAgentSdkTools.sessionAware.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.sessionAware.test.ts
@@ -38,7 +38,18 @@ const { makeSessionAwareHandler } = __test__;
 
 type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
 
-const fakeAuth = { scope: 'organization', orgId: 'org-1', accessibleOrgIds: ['org-1'] } as any;
+// `user` and `partnerId` are part of the real AuthContext and are now load-
+// bearing: the handler builds its DB context with `dbAccessContextFromAuth`
+// (#2822), which reads `auth.user.id` and `auth.partnerId`. The previous stub
+// omitted both, which was only survivable while the handler hand-rolled a
+// partial DbAccessContext — the very defect #2822 fixes.
+const fakeAuth = {
+  scope: 'organization',
+  orgId: 'org-1',
+  accessibleOrgIds: ['org-1'],
+  partnerId: 'partner-1',
+  user: { id: 'user-1' },
+} as any;
 const fakeSession = { breezeSessionId: 'sess-123', auth: fakeAuth } as any;
 
 const firstText = (res: ToolResult) => res.content[0]?.text ?? '';

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod';
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import type { AuthContext } from '../middleware/auth';
+import { dbAccessContextFromAuth } from '../middleware/auth';
 import { db, withDbAccessContext, runOutsideDbContext } from '../db';
 import type { DbAccessContext } from '../db';
 import { eq } from 'drizzle-orm';
@@ -300,11 +301,21 @@ function makeHandler(
       const auth = getAuth();
       // Use the user's actual auth scope instead of system context so that
       // RLS policies and DB-level tenant isolation are enforced.
-      const dbContext: DbAccessContext = {
-        scope: auth.scope as DbAccessContext['scope'],
-        orgId: auth.orgId ?? null,
-        accessibleOrgIds: auth.accessibleOrgIds ?? null,
-      };
+      //
+      // Built via the canonical `dbAccessContextFromAuth` (#2822). The literal
+      // this replaced omitted `accessiblePartnerIds`, `currentPartnerId` and
+      // `userId`; `serializeAccessibleIds` maps an absent list to '' →
+      // `ARRAY[]::uuid[]` for any non-system scope, so `breeze_has_partner_access`
+      // was FALSE and `breeze_current_partner_id()` NULL for EVERY AI tool call —
+      // including a partner-scope MSP admin's, who is entitled to the rows. And
+      // because `makeHandler` deliberately calls `runOutsideDbContext` first,
+      // there was no ambient context to fall back on: this literal was the only
+      // context Postgres saw. Result was a silent partner-axis blackout (scripts,
+      // alert templates, catalog, update rings, integrations all reported empty
+      // with a 200) across the whole chat surface. Same builder the request path
+      // and `jobs/intentReleaseWorker.ts` use, so the re-entered context is
+      // identical to the one authMiddleware opened — not wider.
+      const dbContext: DbAccessContext = dbAccessContextFromAuth(auth);
       const result = await withToolTimeout(
         withDbAccessContext(dbContext, () => executeTool(toolName, args, auth)),
         toolTimeout,
@@ -461,12 +472,11 @@ function makeSessionAwareHandler(
     }
     try {
       const auth = getAuth();
-      // Use the user's actual auth scope so RLS / DB-level tenant isolation is enforced.
-      const dbContext: DbAccessContext = {
-        scope: auth.scope as DbAccessContext['scope'],
-        orgId: auth.orgId ?? null,
-        accessibleOrgIds: auth.accessibleOrgIds ?? null,
-      };
+      // Use the user's actual auth scope so RLS / DB-level tenant isolation is
+      // enforced. Canonical builder — see the note on the sibling literal in
+      // `makeHandler` above for why the hand-rolled object was a partner-axis
+      // blackout (#2822).
+      const dbContext: DbAccessContext = dbAccessContextFromAuth(auth);
       const result = await withToolTimeout(
         withDbAccessContext(dbContext, () => sessionHandler(args, auth, session.breezeSessionId)),
         toolTimeout,

--- a/apps/api/src/services/authenticatorAssurance.ts
+++ b/apps/api/src/services/authenticatorAssurance.ts
@@ -83,7 +83,18 @@ export type DecidedFactor =
  * `graceDowngrade`. Kept out of the discriminated union so those post-build
  * writes stay legal regardless of which factor arm was chosen. */
 export interface AssuranceDecisionShared {
-  /** Level the policy would require for this approval (telemetry / future gate). */
+  /**
+   * Level the policy would require for this approval (telemetry / future gate).
+   *
+   * ONLY MEANINGFUL ON AN APPROVE. On a deny/report this is the Breeze default
+   * floor with the partner's raise-only overrides NOT applied, because the
+   * partner policy is deliberately not loaded on that path (#2822 review — a DB
+   * fault must never stop a technician REFUSING; see the note at the assignment
+   * site). No caller reads this field today. If you start recording it on a deny
+   * audit row or returning it from a deny response, load the policy for that
+   * path first, or you will under-report the partner floor with nothing to catch
+   * it.
+   */
   requiredLevel: AssuranceLevel;
   /** Phase 4: under-assured but allowed because enforcement is off / in grace. */
   graceDowngrade?: boolean;

--- a/apps/api/src/services/authenticatorAssurance.ts
+++ b/apps/api/src/services/authenticatorAssurance.ts
@@ -215,10 +215,21 @@ export async function assertApprovalAssurance(input: {
   // 2. Apply the partner policy floor (raise-only) to the REQUIRED level, then
   //    enforce — but ONLY for an approve. A deny/report is always allowed
   //    through (spec §12 fail-safe): a technician must never be unable to REFUSE.
-  const policy = await loadPartnerPolicy(input.partnerId ?? null);
+  //
+  // The policy load is gated on `isApprove` so the fail-safe actually holds
+  // (#2822 review). `loadPartnerPolicy` now takes a system-context DB escape,
+  // which introduces a real failure mode (pool exhaustion, transaction abort)
+  // where previously the org-scoped read just returned zero rows. Both callers
+  // — routes/pam.ts and routes/approvals.ts — re-classify ANY throw out of this
+  // function as an assertion failure and return 401, so loading the policy
+  // unconditionally would make a transient DB fault block a technician from
+  // REFUSING a request. That is exactly the state spec §12 says must never
+  // occur. A deny therefore never touches the partner policy at all.
+  const isApprove = (input.decision ?? 'approved') === 'approved';
+  const policy = isApprove ? await loadPartnerPolicy(input.partnerId ?? null) : null;
   decision.requiredLevel = requiredAssurance(input.riskTier, policy?.floorOverrides ?? null);
 
-  if ((input.decision ?? 'approved') === 'approved' && decision.decidedAssuranceLevel < decision.requiredLevel) {
+  if (isApprove && decision.decidedAssuranceLevel < decision.requiredLevel) {
     if (isEnforcing(policy, new Date())) {
       throw new StepUpRequiredError(decision.requiredLevel, decision.decidedAssuranceLevel);
     }

--- a/apps/api/src/services/authenticatorPolicy.test.ts
+++ b/apps/api/src/services/authenticatorPolicy.test.ts
@@ -7,7 +7,10 @@ const dbMock = vi.hoisted(() => {
   const select = vi.fn(() => ({ from }));
   return { select, from, where, limit };
 });
-vi.mock('../db', () => ({ db: { select: dbMock.select } }));
+vi.mock('../db', () => ({
+  getCurrentDbAccessContext: vi.fn(() => undefined),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()), db: { select: dbMock.select } }));
 vi.mock('../db/schema', () => ({ authenticatorPolicies: { partnerId: 'partner_id' } }));
 
 import { loadPartnerPolicy, isEnforcing, validateRaiseOnly } from './authenticatorPolicy';

--- a/apps/api/src/services/authenticatorPolicy.ts
+++ b/apps/api/src/services/authenticatorPolicy.ts
@@ -1,18 +1,42 @@
 import { eq } from 'drizzle-orm';
 import { db } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { authenticatorPolicies } from '../db/schema';
 import { DEFAULT_ASSURANCE_FLOOR, type AssuranceFloorOverrides, type RiskTier } from '@breeze/shared';
 
 export type PartnerAuthenticatorPolicy = typeof authenticatorPolicies.$inferSelect;
 
-/** Load a partner's approval-security policy, or null when none / no partner. */
+/**
+ * Load a partner's approval-security policy, or null when none / no partner.
+ *
+ * Read under a SYSTEM context (#2822). `authenticator_policies` is partner-axis
+ * (`breeze_has_partner_access(partner_id)`), and both approval surfaces that
+ * consume this admit ORGANIZATION scope — `routes/pam.ts` is
+ * requireScope('organization','partner','system') and `routes/approvals.ts` has
+ * no requireScope at all. An org-scoped JWT carries a partnerId, so the lookup
+ * *looks* right, but accessiblePartnerIds is [] and the row came back empty.
+ * `isEnforcing(null, now)` is false and `resolveAssuranceFloor` falls back to
+ * DEFAULT_ASSURANCE_FLOOR, so an org-scoped technician could approve a critical
+ * JIT-admin elevation with a bare L1 session tap while a partner-scoped
+ * technician on the identical row got 403 step_up_required — a silent step-up
+ * MFA fail-open, recorded in the audit row as an ordinary `graceDowngrade`.
+ * `partnerId` is server-derived from the caller's auth context, never client
+ * input, so this pinned lookup does not widen which partner is legible.
+ *
+ * NOTE: `isEnforcing(null, …) === false` remains a deliberate fail-OPEN for a
+ * partner that genuinely has no policy row. This fix makes the read honest; it
+ * does not change that default. Whether an unreadable policy should instead
+ * fail CLOSED is a separate decision (tracked on #2822).
+ */
 export async function loadPartnerPolicy(partnerId: string | null): Promise<PartnerAuthenticatorPolicy | null> {
   if (!partnerId) return null;
-  const [row] = await db
-    .select()
-    .from(authenticatorPolicies)
-    .where(eq(authenticatorPolicies.partnerId, partnerId))
-    .limit(1);
+  const [row] = await readWithPartnerAxisVisibility(() =>
+    db
+      .select()
+      .from(authenticatorPolicies)
+      .where(eq(authenticatorPolicies.partnerId, partnerId))
+      .limit(1)
+  );
   return row ?? null;
 }
 

--- a/apps/api/src/services/configPolicyPatching.ts
+++ b/apps/api/src/services/configPolicyPatching.ts
@@ -2,6 +2,7 @@ import { and, eq, isNull, SQL } from 'drizzle-orm';
 import type { z } from 'zod';
 import { patchInlineSettingsSchema, policyAppRuleSchema } from '@breeze/shared/validators';
 import { db } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { captureException } from './sentry';
 import {
   configurationPolicies,
@@ -197,19 +198,30 @@ export async function resolvePatchPolicyReference(
     };
   }
 
-  const [patchPolicy] = await db
-    .select({
-      id: patchPolicies.id,
-      kind: patchPolicies.kind,
-      name: patchPolicies.name,
-      categoryRules: patchPolicies.categoryRules,
-      categories: patchPolicies.categories,
-      excludeCategories: patchPolicies.excludeCategories,
-      autoApprove: patchPolicies.autoApprove,
-    })
-    .from(patchPolicies)
-    .where(and(eq(patchPolicies.id, featurePolicyId), eq(patchPolicies.partnerId, partnerId)))
-    .limit(1);
+  // System context (#2822). `patch_policies` is partner-axis, and the four
+  // routes in routes/configurationPolicies/patchJobs.ts that consume this are
+  // requireScope('organization','partner','system'). Under an org-scoped
+  // caller the read returned zero rows and fell through to
+  // `classification: 'missing_target', valid: false` — so the UI reported a
+  // perfectly good update ring as "invalid" (400 on POST /:id/patch-job,
+  // `ok: 0` on GET /patch-inventory) while the scheduler, which runs
+  // system-scoped, happily executed that same job. Self-tenanted by the
+  // caller-derived `partnerId`, so no cross-partner reach.
+  const [patchPolicy] = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({
+        id: patchPolicies.id,
+        kind: patchPolicies.kind,
+        name: patchPolicies.name,
+        categoryRules: patchPolicies.categoryRules,
+        categories: patchPolicies.categories,
+        excludeCategories: patchPolicies.excludeCategories,
+        autoApprove: patchPolicies.autoApprove,
+      })
+      .from(patchPolicies)
+      .where(and(eq(patchPolicies.id, featurePolicyId), eq(patchPolicies.partnerId, partnerId)))
+      .limit(1)
+  );
 
   if (patchPolicy) {
     if (patchPolicy.kind === 'ring') {

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -1,4 +1,5 @@
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import {
   configurationPolicies,
   configPolicyFeatureLinks,
@@ -2043,17 +2044,25 @@ export async function validateFeaturePolicyExists(
       return { valid: false, error: `Update ring "${featurePolicyId}" not found — organization has no partner` };
     }
 
-    const [ring] = await db
-      .select({ id: patchPolicies.id })
-      .from(patchPolicies)
-      .where(
-        and(
-          eq(patchPolicies.id, featurePolicyId),
-          eq(patchPolicies.partnerId, partnerId),
-          eq(patchPolicies.kind, 'ring')
+    // System context, for the same reason the `backup` branch below already
+    // does it (#2822): `patch_policies` is partner-axis, so an org-scoped
+    // caller (accessiblePartnerIds = []) sees zero rows and a perfectly valid
+    // ring link is rejected as `not found for this partner`. The lookup is
+    // self-tenanted by the `partnerId` derived from the config policy's own
+    // owner above, so escaping RLS here cannot reach another partner's rings.
+    const [ring] = await readWithPartnerAxisVisibility(() =>
+      db
+        .select({ id: patchPolicies.id })
+        .from(patchPolicies)
+        .where(
+          and(
+            eq(patchPolicies.id, featurePolicyId),
+            eq(patchPolicies.partnerId, partnerId),
+            eq(patchPolicies.kind, 'ring')
+          )
         )
-      )
-      .limit(1);
+        .limit(1)
+    );
 
     if (!ring) {
       return { valid: false, error: `Update ring "${featurePolicyId}" not found for this partner` };

--- a/apps/api/src/services/effectiveSettings.ts
+++ b/apps/api/src/services/effectiveSettings.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
 import { HTTPException } from 'hono/http-exception';
 import { db } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { organizations, partners } from '../db/schema/orgs';
 import { aiBudgets } from '../db/schema/ai';
 
@@ -128,11 +129,22 @@ export async function getEffectiveOrgSettings(
     throw new HTTPException(404, { message: 'Organization not found' });
   }
 
-  const partner = await db
-    .select({ settings: partners.settings })
-    .from(partners)
-    .where(eq(partners.id, org.partnerId))
-    .then((rows) => rows[0]);
+  // System context (#2822). `partners` is partner-axis
+  // (`breeze_has_partner_access(id)`) and `computeAccessiblePartnerIds` returns
+  // [] for scope 'organization', but GET /orgs/organizations/:id/effective-settings
+  // is requireScope('organization','partner','system') and even has an explicit
+  // org-scope branch — org callers are intended. Under the ambient context the
+  // read returned zero rows and this threw 404 "Partner not found" for an org
+  // admin looking at their OWN org's settings. Pinned to the partnerId of an
+  // `organizations` row already resolved under the caller's own RLS context,
+  // so it cannot reach a partner the caller can't already see through its org.
+  const partner = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({ settings: partners.settings })
+      .from(partners)
+      .where(eq(partners.id, org.partnerId))
+      .then((rows) => rows[0])
+  );
 
   if (!partner) {
     throw new HTTPException(404, { message: 'Partner not found' });
@@ -218,11 +230,18 @@ export async function assertNotLocked(
     throw new HTTPException(404, { message: 'Organization not found' });
   }
 
-  const partner = await db
-    .select({ settings: partners.settings })
-    .from(partners)
-    .where(eq(partners.id, org.partnerId))
-    .then((rows) => rows[0]);
+  // System context (#2822). Reached from PUT /ai/budget, which is
+  // requireScope('organization','partner','system'): the ambient-context read
+  // returned zero rows for an org-scoped admin, so this 404'd "Partner not
+  // found" and the budget update never ran. Same pinning argument as
+  // getEffectiveOrgSettings above.
+  const partner = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({ settings: partners.settings })
+      .from(partners)
+      .where(eq(partners.id, org.partnerId))
+      .then((rows) => rows[0])
+  );
 
   if (!partner) {
     throw new HTTPException(404, { message: 'Partner not found' });
@@ -263,12 +282,22 @@ export async function getEffectiveAiBudget(
     throw new HTTPException(404, { message: 'Organization not found' });
   }
 
+  // The `partners` half runs in a system context (#2822). Callers
+  // (services/aiCostTracker.ts checkBudget / checkAiRateLimit) wrap this in a
+  // bare `withSystemDbAccessContext`, which is a NO-OP inside a request — it
+  // inherits the caller's org scope — so under an org-scoped AI chat session
+  // the read returned zero rows and every turn failed with "Unable to verify
+  // budget. Please try again." Pinned to the org's own partnerId; the
+  // `ai_budgets` half deliberately stays in the caller's context (it is
+  // org-axis and RLS must keep guarding it).
   const [partner, orgBudgetRow] = await Promise.all([
-    db
-      .select({ settings: partners.settings })
-      .from(partners)
-      .where(eq(partners.id, org.partnerId))
-      .then((rows) => rows[0]),
+    readWithPartnerAxisVisibility(() =>
+      db
+        .select({ settings: partners.settings })
+        .from(partners)
+        .where(eq(partners.id, org.partnerId))
+        .then((rows) => rows[0])
+    ),
     db
       .select()
       .from(aiBudgets)

--- a/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
+++ b/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { selectMock, systemDepth, selectDepths } = vi.hoisted(() => ({
+const { selectMock, systemDepth, selectDepths, systemStats } = vi.hoisted(() => ({
   selectMock: vi.fn(),
   // Depth of the simulated system DB access context, and the depth each
   // db.select() ran at — lets a test prove a query executed INSIDE
   // withSystemDbAccessContext (the only way RLS shows partner-wide rows).
   systemDepth: { value: 0 },
   selectDepths: [] as number[],
+  // Peak simultaneous system contexts. Each one is a real
+  // `baseDb.transaction` holding its own pooled connection, so this is the
+  // connection-hold guard: it must stay at 1 no matter how many devices the
+  // resolver fans out over (#2822 / #1105 class).
+  systemStats: { maxDepth: 0 },
 }));
 
 function makeSelectChain(
@@ -64,33 +69,49 @@ function findEqValue(condition: unknown, column: unknown): unknown {
   return undefined;
 }
 
-vi.mock('../db', () => ({
-  db: {
-    select: (...args: unknown[]) => {
-      selectDepths.push(systemDepth.value);
-      return selectMock(...(args as []));
-    },
-  },
+// Async factory so the mock can model the REAL AsyncLocalStorage semantics of
+// db/index.ts. A plain shared counter is NOT good enough: with `Promise.all`,
+// one branch entering a system context would make a concurrent sibling's
+// `getCurrentDbAccessContext()` report 'system' and skip its own escape — so a
+// per-item connection fan-out would look like a single shared context and the
+// connection-hold guard below would pass vacuously. With ALS, a reader sees
+// 'system' only when IT is genuinely inside the context.
+vi.mock('../db', async () => {
+  const { AsyncLocalStorage } = await import('node:async_hooks');
+  const systemAls = new AsyncLocalStorage<true>();
 
-  runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
-  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
-  // Track nesting so a test can assert WHICH queries ran system-scoped.
-  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
-    systemDepth.value += 1;
-    try {
-      return await fn();
-    } finally {
-      systemDepth.value -= 1;
-    }
-  }),
-  // Default: an org-scoped request context (the case that cannot see
-  // partner-wide policy rows and must therefore escalate).
-  getCurrentDbAccessContext: vi.fn(() =>
-    systemDepth.value > 0
-      ? { scope: 'system', orgId: null, accessibleOrgIds: null }
-      : { scope: 'organization', orgId: 'org-a', accessibleOrgIds: ['org-a'] }
-  ),
-}));
+  return {
+    db: {
+      select: (...args: unknown[]) => {
+        selectDepths.push(systemAls.getStore() ? 1 : 0);
+        return selectMock(...(args as []));
+      },
+    },
+
+    runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) =>
+      systemAls.exit(() => fn())
+    ),
+    withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+    // `systemDepth` counts SIMULTANEOUS system contexts — each one is a real
+    // `baseDb.transaction` holding its own pooled connection in production.
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
+      systemDepth.value += 1;
+      systemStats.maxDepth = Math.max(systemStats.maxDepth, systemDepth.value);
+      try {
+        return await systemAls.run(true, fn);
+      } finally {
+        systemDepth.value -= 1;
+      }
+    }),
+    // Default: an org-scoped request context (the case that cannot see
+    // partner-wide policy rows and must therefore escalate).
+    getCurrentDbAccessContext: vi.fn(() =>
+      systemAls.getStore()
+        ? { scope: 'system', orgId: null, accessibleOrgIds: null }
+        : { scope: 'organization', orgId: 'org-a', accessibleOrgIds: ['org-a'] }
+    ),
+  };
+});
 
 vi.mock('../db/schema', () => ({
   configurationPolicies: {
@@ -200,8 +221,13 @@ const dbMock = dbModule as unknown as {
 describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks does NOT drain a mockReturnValueOnce queue. An unconsumed
+    // entry would shift every select in the NEXT test by one and produce a
+    // baffling `null` result, so reset the implementation outright.
+    selectMock.mockReset();
     systemDepth.value = 0;
     selectDepths.length = 0;
+    systemStats.maxDepth = 0;
   });
 
   it('keeps partner-level backup assignments constrained to the requested org', async () => {
@@ -291,29 +317,111 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
       .mockReturnValueOnce(makeSelectChain([]))
       // organization-level device expansion
       .mockReturnValueOnce(makeSelectChain([{ id: 'device-org-a' }]))
-      // resolveDeviceTimezone
+      // resolveDeviceTimezone issues TWO selects (#2822): the device/org/site
+      // read, then the partner-axis read pinned to that org's partnerId.
       .mockReturnValueOnce(
-        makeSelectChain([{ timezone: 'UTC', orgSettings: { timezone: 'UTC' } }])
-      );
+        makeSelectChain([{ siteTimezone: null, orgSettings: { timezone: 'UTC' }, partnerId }])
+      )
+      .mockReturnValueOnce(makeSelectChain([{ timezone: 'UTC', settings: {} }]));
 
     const result = await resolveAllBackupAssignedDevices(orgId);
 
     expect(result).toHaveLength(1);
-    // TWO escapes, not one (#2822): the config-policy join, plus
-    // resolveDeviceTimezone's `partners` join — which is partner-axis and was
-    // silently resolving to UTC for org-scoped callers. They are sequential,
-    // never nested, so at most one extra pooled connection is held at a time.
+    // TWO escapes, not one (#2822): the config-policy join, plus the single
+    // context that wraps the whole timezone fan-out (resolveDeviceTimezone's
+    // `partners` join is partner-axis and was silently resolving to UTC for
+    // org-scoped callers). Never 1 + N — see the two-device test below.
     expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
     expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
-    // select #0 = org→partner lookup, #1 = the config-policy join, #2 = org
-    // default destination, #3 = device expansion, #4 (last) = resolveDeviceTimezone.
-    // ONLY the two partner-axis reads are escalated: widening the whole resolver
-    // to system scope would let a caller see devices RLS denies them.
-    expect(selectDepths[0]).toBe(0);
-    expect(selectDepths[1]).toBe(1);
-    expect(selectDepths.slice(2, -1).every((depth) => depth === 0)).toBe(true);
-    expect(selectDepths[selectDepths.length - 1]).toBe(1);
+    // Exact topology, asserted as a whole array rather than by index: a
+    // `.slice(...).every(...)` goes vacuously true if a select is ever removed,
+    // which would silently retire this guard.
+    // #0 org→partner lookup | #1 config-policy join (system) | #2 org default
+    // destination | #3 device expansion | #4,#5 resolveDeviceTimezone's
+    // device+partner reads, both inside the ONE hoisted fan-out context.
+    // Device EXPANSION (#3) stays caller-scoped — that is the read RLS must
+    // keep guarding; widening it would let a caller see devices RLS denies.
+    expect(selectDepths).toEqual([0, 1, 0, 0, 1, 1]);
+    expect(systemStats.maxDepth).toBe(1);
     // Context must be closed again once the read completes.
+    expect(systemDepth.value).toBe(0);
+  });
+
+  // CONNECTION-HOLD GUARD (#2822 review, #1105 class). resolveDeviceTimezone
+  // takes a partner-axis escape, and every escape is a real
+  // `baseDb.transaction` holding its own pooled connection. Resolving
+  // timezones per device inside a bare `Promise.all` therefore costs N
+  // SIMULTANEOUS connections — and this resolver runs on org-scoped REQUEST
+  // routes (routes/backup/{jobs,dashboard,hyperv,mssql}.ts,
+  // readinessCalculator.ts), where the skip-when-system branch does not fire.
+  // Against the 25-connection ceiling, with no postgres-js acquire timeout,
+  // that is a hang rather than an error.
+  //
+  // The single-device test above CANNOT see this — with N=1, "one escape per
+  // device" and "one escape total" are the same number. This test uses TWO
+  // devices specifically so the escape count stops scaling with N.
+  it('takes ONE system context for the whole timezone fan-out, not one per device', async () => {
+    const orgId = 'org-a';
+    const partnerId = 'partner-1';
+
+    selectMock
+      .mockReturnValueOnce(makeSelectChain([{ partnerId }]))
+      .mockReturnValueOnce(
+        makeSelectChain([
+          {
+            backupSettings: {
+              schedule: { frequency: 'daily', time: '01:00' },
+              destinationConfigId: 'config-1',
+            },
+            featureLinkId: 'feature-1',
+            featurePolicyId: null,
+            profileSelections: null,
+            assignmentLevel: 'organization',
+            assignmentTargetId: orgId,
+            assignmentPriority: 1,
+            assignmentCreatedAt: new Date('2026-04-01T00:00:00Z'),
+          },
+        ])
+      )
+      // org default destination lookup
+      .mockReturnValueOnce(makeSelectChain([]))
+      // organization-level device expansion — TWO devices
+      .mockReturnValueOnce(
+        makeSelectChain([{ id: 'device-org-a' }, { id: 'device-org-b' }])
+      )
+      // resolveDeviceTimezone runs under `Promise.all`, so the two devices'
+      // selects INTERLEAVE and a `mockReturnValueOnce` queue would hand device
+      // B the row meant for device A's partner read. Use a persistent
+      // implementation returning a row that satisfies both the device/org/site
+      // read and the partner read, so the mock is order-independent.
+      .mockImplementation(() =>
+        makeSelectChain([{
+          siteTimezone: null,
+          orgSettings: { timezone: 'UTC' },
+          partnerId,
+          timezone: 'UTC',
+          settings: {},
+        }])
+      );
+
+    const result = await resolveAllBackupAssignedDevices(orgId);
+
+    expect(result).toHaveLength(2);
+    // Still 2 with two devices — the count does not scale with N. Pre-fix this
+    // was 3 (1 policy join + 1 per device) and would keep climbing.
+    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
+    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
+    // The real assertion: never more than one system transaction — and
+    // therefore never more than one extra pooled connection — at any instant.
+    expect(systemStats.maxDepth).toBe(1);
+    // #0 org→partner | #1 policy join (system) | #2 org default destination |
+    // #3 device expansion (CALLER — the read RLS must keep guarding). Every
+    // select after that is a timezone read inside the single hoisted context.
+    // Asserted as a prefix + tail property rather than an exact array because
+    // the interleaved fan-out makes the tail length order-dependent.
+    expect(selectDepths.slice(0, 4)).toEqual([0, 1, 0, 0]);
+    expect(selectDepths.length).toBeGreaterThan(4);
+    expect(selectDepths.slice(4).every((d) => d === 1)).toBe(true);
     expect(systemDepth.value).toBe(0);
   });
 });
@@ -321,8 +429,13 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
 describe('resolveBackupConfigForDevice partner-wide visibility', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks does NOT drain a mockReturnValueOnce queue. An unconsumed
+    // entry would shift every select in the NEXT test by one and produce a
+    // baffling `null` result, so reset the implementation outright.
+    selectMock.mockReset();
     systemDepth.value = 0;
     selectDepths.length = 0;
+    systemStats.maxDepth = 0;
   });
 
   it('reads the config-policy join in a system context while the device hierarchy stays caller-scoped', async () => {
@@ -360,23 +473,25 @@ describe('resolveBackupConfigForDevice partner-wide visibility', () => {
           },
         ])
       )
-      // resolveDeviceTimezone
+      // resolveDeviceTimezone: device/org/site in the CALLER'S context, then
+      // the partner-axis read escaped on its own (#2822).
       .mockReturnValueOnce(
-        makeSelectChain([{ timezone: 'UTC', orgSettings: { timezone: 'UTC' } }])
-      );
+        makeSelectChain([{ siteTimezone: null, orgSettings: { timezone: 'UTC' }, partnerId: 'partner-1' }])
+      )
+      .mockReturnValueOnce(makeSelectChain([{ timezone: 'UTC', settings: {} }]));
 
     const resolved = await resolveBackupConfigForDevice('device-1');
 
     expect(resolved).toMatchObject({ featureLinkId: 'feature-1', configId: 'config-1' });
     // Two escapes: the policy join and resolveDeviceTimezone's partner-axis
-    // join (#2822). Sequential, so never two connections held at once.
+    // read (#2822), taken one after the other — never nested.
     expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
     expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
-    // selects 0-2 = device hierarchy (caller context), 3 = policy join (system),
-    // 4 = resolveDeviceTimezone (system).
-    expect(selectDepths.slice(0, 3)).toEqual([0, 0, 0]);
-    expect(selectDepths[3]).toBe(1);
-    expect(selectDepths[4]).toBe(1);
+    expect(systemStats.maxDepth).toBe(1);
+    // 0-2 device hierarchy (caller) | 3 policy join (system) | 4 timezone
+    // device/org/site read (CALLER — RLS still selects the device) | 5 the
+    // partner-axis read (system).
+    expect(selectDepths).toEqual([0, 0, 0, 1, 0, 1]);
     expect(systemDepth.value).toBe(0);
   });
 });

--- a/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
+++ b/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
@@ -270,8 +270,17 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
             .map((row) => ({ id: row.id }));
         })
       )
-      .mockReturnValueOnce(
-        makeSelectChain([{ timezone: 'UTC', orgSettings: { timezone: 'UTC' } }])
+      // Timezone resolution now issues a shared org->partner lookup plus one
+      // device read each; a persistent implementation keeps this
+      // order-independent.
+      .mockImplementation(() =>
+        makeSelectChain([{
+          siteTimezone: null,
+          orgSettings: { timezone: 'UTC' },
+          partnerId: 'partner-1',
+          timezone: 'UTC',
+          settings: {},
+        }])
       );
 
     const result = await resolveAllBackupAssignedDevices(orgId);
@@ -317,12 +326,17 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
       .mockReturnValueOnce(makeSelectChain([]))
       // organization-level device expansion
       .mockReturnValueOnce(makeSelectChain([{ id: 'device-org-a' }]))
-      // resolveDeviceTimezone issues TWO selects (#2822): the device/org/site
-      // read, then the partner-axis read pinned to that org's partnerId.
-      .mockReturnValueOnce(
-        makeSelectChain([{ siteTimezone: null, orgSettings: { timezone: 'UTC' }, partnerId }])
-      )
-      .mockReturnValueOnce(makeSelectChain([{ timezone: 'UTC', settings: {} }]));
+      // Timezone resolution: ONE shared org->partner lookup for the batch
+      // (2 selects), then one device/org/site read per device.
+      .mockImplementation(() =>
+        makeSelectChain([{
+          siteTimezone: null,
+          orgSettings: { timezone: 'UTC' },
+          partnerId,
+          timezone: 'UTC',
+          settings: {},
+        }])
+      );
 
     const result = await resolveAllBackupAssignedDevices(orgId);
 
@@ -336,12 +350,12 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
     // Exact topology, asserted as a whole array rather than by index: a
     // `.slice(...).every(...)` goes vacuously true if a select is ever removed,
     // which would silently retire this guard.
-    // #0 org→partner lookup | #1 config-policy join (system) | #2 org default
-    // destination | #3 device expansion | #4,#5 resolveDeviceTimezone's
-    // device+partner reads, both inside the ONE hoisted fan-out context.
-    // Device EXPANSION (#3) stays caller-scoped — that is the read RLS must
-    // keep guarding; widening it would let a caller see devices RLS denies.
-    expect(selectDepths).toEqual([0, 1, 0, 0, 1, 1]);
+    // #0 org→partner lookup | #1 config-policy join (SYSTEM) | #2 org default
+    // destination | #3 device expansion | #4 the batch org lookup | #5 the ONE
+    // shared partners read (SYSTEM) | #6 the per-device site/org read.
+    // Everything except the two partner-axis reads is caller-scoped — device
+    // EXPANSION (#3) especially, since that is the read RLS must keep guarding.
+    expect(selectDepths).toEqual([0, 1, 0, 0, 0, 1, 0]);
     expect(systemStats.maxDepth).toBe(1);
     // Context must be closed again once the read completes.
     expect(systemDepth.value).toBe(0);
@@ -408,20 +422,23 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
 
     expect(result).toHaveLength(2);
     // Still 2 with two devices — the count does not scale with N. Pre-fix this
-    // was 3 (1 policy join + 1 per device) and would keep climbing.
+    // was 3 (1 policy join + 1 per device) and would keep climbing. The partner
+    // timezone is now resolved once for the whole batch, so there is also only
+    // ONE `partners` read rather than N identical ones.
     expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
     expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
     // The real assertion: never more than one system transaction — and
     // therefore never more than one extra pooled connection — at any instant.
     expect(systemStats.maxDepth).toBe(1);
-    // #0 org→partner | #1 policy join (system) | #2 org default destination |
-    // #3 device expansion (CALLER — the read RLS must keep guarding). Every
-    // select after that is a timezone read inside the single hoisted context.
-    // Asserted as a prefix + tail property rather than an exact array because
-    // the interleaved fan-out makes the tail length order-dependent.
+    // #0 org→partner | #1 policy join (SYSTEM) | #2 org default destination |
+    // #3 device expansion (CALLER — the read RLS must keep guarding) | #4 the
+    // batch org lookup | #5 the ONE shared partners read (SYSTEM) | #6,#7 the
+    // per-device site/org reads (CALLER).
+    //
+    // The key property: exactly ONE depth-1 select in the timezone tail no
+    // matter how many devices there are. Pre-fix this was one per device.
     expect(selectDepths.slice(0, 4)).toEqual([0, 1, 0, 0]);
-    expect(selectDepths.length).toBeGreaterThan(4);
-    expect(selectDepths.slice(4).every((d) => d === 1)).toBe(true);
+    expect(selectDepths.slice(4).filter((d) => d === 1)).toHaveLength(1);
     expect(systemDepth.value).toBe(0);
   });
 });

--- a/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
+++ b/apps/api/src/services/featureConfigResolver.backupAssignments.test.ts
@@ -299,14 +299,20 @@ describe('resolveAllBackupAssignedDevices tenancy scoping', () => {
     const result = await resolveAllBackupAssignedDevices(orgId);
 
     expect(result).toHaveLength(1);
-    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(1);
-    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(1);
-    // select #0 = org→partner lookup, #1 = the config-policy join, rest = device
-    // expansion + timezone. ONLY the policy join is escalated: widening the whole
-    // resolver to system scope would let a caller see devices RLS denies them.
+    // TWO escapes, not one (#2822): the config-policy join, plus
+    // resolveDeviceTimezone's `partners` join — which is partner-axis and was
+    // silently resolving to UTC for org-scoped callers. They are sequential,
+    // never nested, so at most one extra pooled connection is held at a time.
+    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
+    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
+    // select #0 = org→partner lookup, #1 = the config-policy join, #2 = org
+    // default destination, #3 = device expansion, #4 (last) = resolveDeviceTimezone.
+    // ONLY the two partner-axis reads are escalated: widening the whole resolver
+    // to system scope would let a caller see devices RLS denies them.
     expect(selectDepths[0]).toBe(0);
     expect(selectDepths[1]).toBe(1);
-    expect(selectDepths.slice(2).every((depth) => depth === 0)).toBe(true);
+    expect(selectDepths.slice(2, -1).every((depth) => depth === 0)).toBe(true);
+    expect(selectDepths[selectDepths.length - 1]).toBe(1);
     // Context must be closed again once the read completes.
     expect(systemDepth.value).toBe(0);
   });
@@ -362,11 +368,15 @@ describe('resolveBackupConfigForDevice partner-wide visibility', () => {
     const resolved = await resolveBackupConfigForDevice('device-1');
 
     expect(resolved).toMatchObject({ featureLinkId: 'feature-1', configId: 'config-1' });
-    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(1);
-    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(1);
-    // selects 0-2 = device hierarchy (caller context), 3 = policy join (system).
+    // Two escapes: the policy join and resolveDeviceTimezone's partner-axis
+    // join (#2822). Sequential, so never two connections held at once.
+    expect(dbMock.withSystemDbAccessContext).toHaveBeenCalledTimes(2);
+    expect(dbMock.runOutsideDbContext).toHaveBeenCalledTimes(2);
+    // selects 0-2 = device hierarchy (caller context), 3 = policy join (system),
+    // 4 = resolveDeviceTimezone (system).
     expect(selectDepths.slice(0, 3)).toEqual([0, 0, 0]);
     expect(selectDepths[3]).toBe(1);
+    expect(selectDepths[4]).toBe(1);
     expect(systemDepth.value).toBe(0);
   });
 });

--- a/apps/api/src/services/featureConfigResolver.timezone.test.ts
+++ b/apps/api/src/services/featureConfigResolver.timezone.test.ts
@@ -11,6 +11,12 @@ let mockRow: Record<string, unknown> | undefined;
 //     .where(...).limit(1)
 // The partners join is a LEFT join (#1318 review) so an RLS-invisible partner
 // row under org scope leaves the device row intact instead of dropping it.
+//
+// The three db-context helpers back `readWithPartnerAxisVisibility` (#2822),
+// which now wraps this query so the partner columns are actually legible to an
+// org-scoped caller. They are pass-throughs here — this suite asserts the
+// precedence chain, not the RLS escape; that is proved against real Postgres in
+// __tests__/integration/partnerAxisSystemContext.integration.test.ts.
 vi.mock('../db', () => {
   const limit = vi.fn(() => Promise.resolve(mockRow ? [mockRow] : []));
   const where = vi.fn(() => ({ limit }));
@@ -19,7 +25,12 @@ vi.mock('../db', () => {
   const innerJoinOrgs = vi.fn(() => ({ leftJoin: leftJoinPartners }));
   const from = vi.fn(() => ({ innerJoin: innerJoinOrgs }));
   const select = vi.fn(() => ({ from }));
-  return { db: { select } };
+  return {
+    db: { select },
+    getCurrentDbAccessContext: vi.fn(() => undefined),
+    runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+    withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  };
 });
 
 // The resolver imports many schema tables; a thin stub keeps the module load

--- a/apps/api/src/services/featureConfigResolver.timezone.test.ts
+++ b/apps/api/src/services/featureConfigResolver.timezone.test.ts
@@ -6,25 +6,58 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let mockRow: Record<string, unknown> | undefined;
 
-// Join chain mirrors resolveDeviceTimezone's query exactly:
-//   from(devices).innerJoin(organizations).leftJoin(partners).leftJoin(sites)
-//     .where(...).limit(1)
-// The partners join is a LEFT join (#1318 review) so an RLS-invisible partner
-// row under org scope leaves the device row intact instead of dropping it.
+// resolveDeviceTimezone issues TWO queries (#2822), and the split is the point:
+//   1. from(devices).innerJoin(organizations).leftJoin(sites).where().limit(1)
+//      — runs in the CALLER'S context, so RLS still decides which device is
+//        legible. Escaping this half too would demote device isolation on the
+//        backup/patch paths to app-layer-only.
+//   2. from(partners).where(id = org.partnerId).limit(1)
+//      — runs inside readWithPartnerAxisVisibility, because `partners` is
+//        partner-axis and an org-scoped caller has accessiblePartnerIds = [].
+//        Previously this was a leftJoin in query 1, which kept the device row
+//        alive but left the partner COLUMNS null — the silent fall-through to
+//        site -> org -> 'UTC' that #2822 fixes.
 //
-// The three db-context helpers back `readWithPartnerAxisVisibility` (#2822),
-// which now wraps this query so the partner columns are actually legible to an
-// org-scoped caller. They are pass-throughs here — this suite asserts the
-// precedence chain, not the RLS escape; that is proved against real Postgres in
-// __tests__/integration/partnerAxisSystemContext.integration.test.ts.
+// The mock dispatches on the table handed to `.from()` rather than on call
+// order, so it stays correct if the two reads are ever reordered.
+//
+// The db-context helpers are pass-throughs here — this suite asserts the
+// precedence chain, not the RLS escape; the escape is proved against real
+// Postgres in __tests__/integration/partnerAxisSystemContext.integration.test.ts.
 vi.mock('../db', () => {
-  const limit = vi.fn(() => Promise.resolve(mockRow ? [mockRow] : []));
-  const where = vi.fn(() => ({ limit }));
-  const leftJoinSites = vi.fn(() => ({ where }));
-  const leftJoinPartners = vi.fn(() => ({ leftJoin: leftJoinSites }));
-  const innerJoinOrgs = vi.fn(() => ({ leftJoin: leftJoinPartners }));
-  const from = vi.fn(() => ({ innerJoin: innerJoinOrgs }));
-  const select = vi.fn(() => ({ from }));
+  const deviceLimit = vi.fn(() =>
+    Promise.resolve(
+      mockRow
+        ? [{
+          siteTimezone: mockRow.siteTimezone,
+          orgSettings: mockRow.orgSettings,
+          partnerId: mockRow.partnerId ?? 'partner-1',
+        }]
+        : []
+    )
+  );
+  // `partnerTimezone: null` + `partnerSettings: null` models "no partner row"
+  // (deleted, or — pre-fix — RLS-invisible).
+  const partnerLimit = vi.fn(() =>
+    Promise.resolve(
+      mockRow && !(mockRow.partnerTimezone == null && mockRow.partnerSettings == null)
+        ? [{ timezone: mockRow.partnerTimezone, settings: mockRow.partnerSettings }]
+        : []
+    )
+  );
+
+  const select = vi.fn(() => ({
+    from: vi.fn((table: { id?: string } | undefined) =>
+      table?.id === 'partners.id'
+        ? { where: vi.fn(() => ({ limit: partnerLimit })) }
+        : {
+          innerJoin: vi.fn(() => ({
+            leftJoin: vi.fn(() => ({ where: vi.fn(() => ({ limit: deviceLimit })) })),
+          })),
+        }
+    ),
+  }));
+
   return {
     db: { select },
     getCurrentDbAccessContext: vi.fn(() => undefined),
@@ -114,11 +147,11 @@ describe('resolveDeviceTimezone (#1318 partner fallback)', () => {
     expect(await resolveDeviceTimezone('dev-1')).toBe('Asia/Tokyo');
   });
 
-  it('org-scoped (partner RLS-invisible): still resolves the org tz, not UTC', async () => {
-    // Under an org-scoped request the partners SELECT policy is false, so the
-    // leftJoin yields null partner columns. The device row must survive (left
-    // join, not inner) and resolve through site -> org. An inner join here would
-    // drop the row entirely and regress to 'UTC'.
+  it('no partner row: still resolves the org tz, not UTC', async () => {
+    // A missing partner row (deleted tenant, or — pre-#2822 — an RLS-invisible
+    // one) must leave the device row intact and resolve through site -> org.
+    // The partner read is a SEPARATE query now, so its absence can no longer
+    // drop the device row at all; this pins that the fall-through still works.
     mockRow = {
       siteTimezone: null,
       orgSettings: { timezone: 'America/Denver' },
@@ -128,7 +161,7 @@ describe('resolveDeviceTimezone (#1318 partner fallback)', () => {
     expect(await resolveDeviceTimezone('dev-1')).toBe('America/Denver');
   });
 
-  it('org-scoped (partner RLS-invisible): still resolves the site tz, not UTC', async () => {
+  it('no partner row: still resolves the site tz, not UTC', async () => {
     mockRow = {
       siteTimezone: 'America/Chicago',
       orgSettings: {},

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -403,7 +403,48 @@ function partnerTimezoneFrom(
   return canonicalColumn;
 }
 
-export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
+/**
+ * The partner timezone for an org, resolved with ONE partner-axis escape.
+ *
+ * Split out so a batch resolver can pay for the escape once instead of per
+ * device — every device in an org shares the same partner, so the per-device
+ * read is identical N times over (#2822 review). Pinned to the partnerId of an
+ * `organizations` row read under the CALLER'S context, so RLS still decides
+ * which org is legible and this cannot be aimed at a foreign partner.
+ *
+ * Returns `undefined` (not null) when the org has no partner, so a caller can
+ * tell "not looked up" from "looked up, no partner tz".
+ */
+export async function resolvePartnerTimezoneForOrg(orgId: string): Promise<string | null> {
+  const [org] = await db
+    .select({ partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  if (!org?.partnerId) return null;
+  const orgPartnerId = org.partnerId;
+
+  const [partner] = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({ timezone: partners.timezone, settings: partners.settings })
+      .from(partners)
+      .where(eq(partners.id, orgPartnerId))
+      .limit(1)
+  );
+
+  return partnerTimezoneFrom(partner?.timezone, partner?.settings);
+}
+
+export async function resolveDeviceTimezone(
+  deviceId: string,
+  /**
+   * Pre-resolved partner timezone, for batch callers that already paid for the
+   * partner read once. When supplied, the per-device partner-axis escape is
+   * skipped entirely — that is the whole point.
+   */
+  opts?: { partnerTz?: string | null },
+): Promise<string> {
   // The device/site/org half stays in the CALLER'S context so RLS still decides
   // which device is legible; only the partner row is escaped (#2822).
   //
@@ -432,17 +473,13 @@ export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
   // Escaped separately, pinned to the partnerId of an `organizations` row the
   // caller could already see. Escaping the whole join instead would make the
   // DEVICE row selectable system-wide, demoting device isolation on this path
-  // to app-layer-only — which CLAUDE.md forbids — even though today's three
-  // callers all resolve the device under the caller's context first.
-  const [partner] = row?.partnerId
-    ? await readWithPartnerAxisVisibility(() =>
-      db
-        .select({ timezone: partners.timezone, settings: partners.settings })
-        .from(partners)
-        .where(eq(partners.id, row.partnerId))
-        .limit(1)
-    )
-    : [];
+  // to app-layer-only — which CLAUDE.md forbids — even though today's callers
+  // all resolve the device under the caller's context first.
+  //
+  // Skipped when a batch caller already resolved it (`opts.partnerTz`).
+  const partnerTz = opts?.partnerTz !== undefined
+    ? opts.partnerTz
+    : await resolvePartnerTimezoneForDeviceRow(row?.partnerId ?? null);
 
   const orgTimezone =
     row?.orgSettings && typeof row.orgSettings === 'object'
@@ -463,8 +500,21 @@ export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
   return resolveEffectiveTimezone({
     siteTz: row?.siteTimezone,
     orgTz: typeof orgTimezone === 'string' ? orgTimezone : null,
-    partnerTz: partnerTimezoneFrom(partner?.timezone, partner?.settings),
+    partnerTz,
   });
+}
+
+/** The partner-axis half of resolveDeviceTimezone, for the single-device path. */
+async function resolvePartnerTimezoneForDeviceRow(partnerId: string | null): Promise<string | null> {
+  if (!partnerId) return null;
+  const [partner] = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({ timezone: partners.timezone, settings: partners.settings })
+      .from(partners)
+      .where(eq(partners.id, partnerId))
+      .limit(1)
+  );
+  return partnerTimezoneFrom(partner?.timezone, partner?.settings);
 }
 
 export async function resolvePatchConfigDetailsForDevice(
@@ -1608,26 +1658,31 @@ export async function resolveAllBackupAssignedDevices(
     }
   }
 
-  // ONE system context for the whole fan-out (#2822). `resolveDeviceTimezone`
-  // now takes a partner-axis escape of its own, and each escape opens a fresh
-  // `baseDb.transaction` on its own pooled connection. Left bare inside this
-  // `Promise.all` that is N SIMULTANEOUS connection acquires — one per assigned
-  // device — on top of the caller's own held request transaction. This resolver
-  // is called from org-scoped REQUEST routes (routes/backup/{jobs,dashboard,
-  // hyperv,mssql}.ts, routes/backup/readinessCalculator.ts), where the
-  // skip-when-system branch does NOT fire, so an org with a few dozen
-  // backup-assigned devices loading the backup dashboard would exhaust the
-  // 25-connection pool — and postgres-js has no acquire timeout, so it hangs
-  // rather than erroring (#1105 class).
+  // Timezones resolved with ONE partner-axis escape for the whole batch (#2822).
   //
-  // Entering the system context ONCE here makes every nested
-  // `readWithPartnerAxisVisibility` observe `scope === 'system'` and take its
-  // skip branch, so the whole fan-out costs exactly one extra connection
-  // regardless of device count. Device expansion above already happened in the
-  // caller's context, so RLS still decided which devices are in `seen`.
+  // `resolveDeviceTimezone` takes an escape of its own, and each escape is a
+  // real `baseDb.transaction` on its own pooled connection. Called per device
+  // inside a bare `Promise.all` that is N SIMULTANEOUS connection acquires, on
+  // top of the caller's own held request transaction. This resolver runs on
+  // org-scoped REQUEST routes (routes/backup/{jobs,dashboard,hyperv,mssql}.ts,
+  // routes/backup/readinessCalculator.ts) where the skip-when-system branch does
+  // NOT fire, so an org with a few dozen backup-assigned devices loading the
+  // backup dashboard would exhaust the 25-connection pool — and postgres-js has
+  // no acquire timeout, so it hangs rather than erroring (#1105 class).
+  //
+  // Every device here belongs to `orgId`, so they all share ONE partner and one
+  // partner timezone. Resolving it once and passing it down means the batch
+  // costs a single escape AND avoids N redundant identical `partners` reads
+  // serialized inside a held transaction (which would trip the
+  // DB_CONTEXT_HELD_WARN_MS tripwire on large orgs). Device expansion above
+  // already happened in the caller's context, so RLS still decided which devices
+  // are in `seen`, and the per-device site/org reads stay caller-scoped.
   const entries = Array.from(seen.values());
-  const timezones = await readWithPartnerAxisVisibility(() =>
-    Promise.all(entries.map((entry) => resolveDeviceTimezone(entry.deviceId)))
+  if (entries.length === 0) return [];
+
+  const partnerTz = await resolvePartnerTimezoneForOrg(orgId);
+  const timezones = await Promise.all(
+    entries.map((entry) => resolveDeviceTimezone(entry.deviceId, { partnerTz })),
   );
 
   return entries.map((entry, i) => ({ ...entry, resolvedTimezone: timezones[i]! }));

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -4,6 +4,7 @@ import {
   runOutsideDbContext,
   withSystemDbAccessContext,
 } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import {
   configurationPolicies,
   configPolicyFeatureLinks,
@@ -403,7 +404,21 @@ function partnerTimezoneFrom(
 }
 
 export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
-  const [row] = await db
+  // System context (#2822). The leftJoin below keeps the DEVICE row alive when
+  // the partner is RLS-invisible, but it does not make the partner's timezone
+  // legible: under an org-scoped caller `partnerTimezone`/`partnerSettings`
+  // simply came back null and the chain silently fell through to
+  // site -> org -> 'UTC'. Every caller of this resolver
+  // (resolvePatchConfigDetailsForDevice, resolveBackupConfigForDevice,
+  // resolveAllBackupAssignedDevices) is reached from
+  // requireScope('organization','partner','system') routes AND from the
+  // system-scoped scheduler — so the SAME device resolved a different
+  // maintenance window depending on who triggered the job, with no error
+  // anywhere. `withPartnerWideVisibility` (same skip-when-system shape) is
+  // already applied to the sibling policy joins in this file; this resolver was
+  // missed. Pinned by the caller-supplied deviceId — device visibility itself is
+  // still gated upstream by the caller's own context.
+  const [row] = await readWithPartnerAxisVisibility(() => db
     .select({
       siteTimezone: sites.timezone,
       orgSettings: organizations.settings,
@@ -425,7 +440,7 @@ export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
     .leftJoin(partners, eq(organizations.partnerId, partners.id))
     .leftJoin(sites, eq(devices.siteId, sites.id))
     .where(eq(devices.id, deviceId))
-    .limit(1);
+    .limit(1));
 
   const orgTimezone =
     row?.orgSettings && typeof row.orgSettings === 'object'

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -404,43 +404,45 @@ function partnerTimezoneFrom(
 }
 
 export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
-  // System context (#2822). The leftJoin below keeps the DEVICE row alive when
-  // the partner is RLS-invisible, but it does not make the partner's timezone
-  // legible: under an org-scoped caller `partnerTimezone`/`partnerSettings`
-  // simply came back null and the chain silently fell through to
-  // site -> org -> 'UTC'. Every caller of this resolver
-  // (resolvePatchConfigDetailsForDevice, resolveBackupConfigForDevice,
-  // resolveAllBackupAssignedDevices) is reached from
-  // requireScope('organization','partner','system') routes AND from the
-  // system-scoped scheduler — so the SAME device resolved a different
+  // The device/site/org half stays in the CALLER'S context so RLS still decides
+  // which device is legible; only the partner row is escaped (#2822).
+  //
+  // leftJoin (not inner) on sites: a device may have no site. The `partners`
+  // join was previously here as a leftJoin so that an RLS-invisible partner
+  // could not drop the whole device row (#1318) — but that only prevented a
+  // regression, it never made the partner's timezone legible. Under an
+  // org-scoped caller `partnerTimezone`/`partnerSettings` simply came back null
+  // and the chain silently fell through to site -> org -> 'UTC'. Callers reach
+  // this from requireScope('organization','partner','system') routes AND from
+  // the system-scoped scheduler, so the SAME device resolved a DIFFERENT
   // maintenance window depending on who triggered the job, with no error
-  // anywhere. `withPartnerWideVisibility` (same skip-when-system shape) is
-  // already applied to the sibling policy joins in this file; this resolver was
-  // missed. Pinned by the caller-supplied deviceId — device visibility itself is
-  // still gated upstream by the caller's own context.
-  const [row] = await readWithPartnerAxisVisibility(() => db
+  // anywhere.
+  const [row] = await db
     .select({
       siteTimezone: sites.timezone,
       orgSettings: organizations.settings,
-      partnerTimezone: partners.timezone,
-      partnerSettings: partners.settings,
+      partnerId: organizations.partnerId,
     })
     .from(devices)
     .innerJoin(organizations, eq(devices.orgId, organizations.id))
-    // leftJoin (not inner) on partners: the partners SELECT RLS policy is
-    // breeze_has_partner_access(id), which is FALSE for an ORG-scoped request
-    // (computeAccessiblePartnerIds returns [] for org scope). An inner join
-    // would make the partner row RLS-invisible and drop the ENTIRE device row,
-    // sending resolveDeviceTimezone down its missing-row branch -> 'UTC', a
-    // regression of the prior site->org->UTC behavior. With a left join the
-    // device row survives, partnerTimezone is simply null, and
-    // resolveEffectiveTimezone falls through site -> org -> UTC. For
-    // system/partner-scoped requests the partner row is visible and contributes
-    // to the chain as intended (#1318).
-    .leftJoin(partners, eq(organizations.partnerId, partners.id))
     .leftJoin(sites, eq(devices.siteId, sites.id))
     .where(eq(devices.id, deviceId))
-    .limit(1));
+    .limit(1);
+
+  // Escaped separately, pinned to the partnerId of an `organizations` row the
+  // caller could already see. Escaping the whole join instead would make the
+  // DEVICE row selectable system-wide, demoting device isolation on this path
+  // to app-layer-only — which CLAUDE.md forbids — even though today's three
+  // callers all resolve the device under the caller's context first.
+  const [partner] = row?.partnerId
+    ? await readWithPartnerAxisVisibility(() =>
+      db
+        .select({ timezone: partners.timezone, settings: partners.settings })
+        .from(partners)
+        .where(eq(partners.id, row.partnerId))
+        .limit(1)
+    )
+    : [];
 
   const orgTimezone =
     row?.orgSettings && typeof row.orgSettings === 'object'
@@ -461,7 +463,7 @@ export async function resolveDeviceTimezone(deviceId: string): Promise<string> {
   return resolveEffectiveTimezone({
     siteTz: row?.siteTimezone,
     orgTz: typeof orgTimezone === 'string' ? orgTimezone : null,
-    partnerTz: partnerTimezoneFrom(row?.partnerTimezone, row?.partnerSettings),
+    partnerTz: partnerTimezoneFrom(partner?.timezone, partner?.settings),
   });
 }
 
@@ -1606,14 +1608,29 @@ export async function resolveAllBackupAssignedDevices(
     }
   }
 
-  const resolved = await Promise.all(
-    Array.from(seen.values()).map(async (entry) => ({
-      ...entry,
-      resolvedTimezone: await resolveDeviceTimezone(entry.deviceId),
-    }))
+  // ONE system context for the whole fan-out (#2822). `resolveDeviceTimezone`
+  // now takes a partner-axis escape of its own, and each escape opens a fresh
+  // `baseDb.transaction` on its own pooled connection. Left bare inside this
+  // `Promise.all` that is N SIMULTANEOUS connection acquires — one per assigned
+  // device — on top of the caller's own held request transaction. This resolver
+  // is called from org-scoped REQUEST routes (routes/backup/{jobs,dashboard,
+  // hyperv,mssql}.ts, routes/backup/readinessCalculator.ts), where the
+  // skip-when-system branch does NOT fire, so an org with a few dozen
+  // backup-assigned devices loading the backup dashboard would exhaust the
+  // 25-connection pool — and postgres-js has no acquire timeout, so it hangs
+  // rather than erroring (#1105 class).
+  //
+  // Entering the system context ONCE here makes every nested
+  // `readWithPartnerAxisVisibility` observe `scope === 'system'` and take its
+  // skip branch, so the whole fan-out costs exactly one extra connection
+  // regardless of device count. Device expansion above already happened in the
+  // caller's context, so RLS still decided which devices are in `seen`.
+  const entries = Array.from(seen.values());
+  const timezones = await readWithPartnerAxisVisibility(() =>
+    Promise.all(entries.map((entry) => resolveDeviceTimezone(entry.deviceId)))
   );
 
-  return resolved;
+  return entries.map((entry, i) => ({ ...entry, resolvedTimezone: timezones[i]! }));
 }
 
 export async function resolveBackupProtectionForDevice(

--- a/apps/api/src/services/mlFeatureFlags.test.ts
+++ b/apps/api/src/services/mlFeatureFlags.test.ts
@@ -5,7 +5,15 @@ const { dbSelect, withSystemDbAccessContext } = vi.hoisted(() => ({
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
 }));
 
+// `resolveMlFeatureFlagForOrg` now escapes to a system context through
+// `readWithPartnerAxisVisibility` (#2822) rather than calling
+// `withSystemDbAccessContext` directly — which was a no-op inside a request.
+// The hoisted spy stays wired so the existing "runs in a system context"
+// assertions keep exercising the real call, and the two new exports the helper
+// needs are added as pass-throughs.
 vi.mock('../db', () => ({
+  getCurrentDbAccessContext: vi.fn(() => undefined),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
   db: { select: dbSelect },
   withSystemDbAccessContext,
 }));

--- a/apps/api/src/services/mlFeatureFlags.test.ts
+++ b/apps/api/src/services/mlFeatureFlags.test.ts
@@ -42,6 +42,7 @@ import {
   isMlFeatureEnabledForOrg,
   resolveMlFeatureFlag,
   resolveMlFeatureFlagForOrg,
+  resolveAllMlFeatureFlagsForOrg,
 } from './mlFeatureFlags';
 
 const ORIGINAL_ENV = { ...process.env };
@@ -207,6 +208,53 @@ describe('mlFeatureFlags', () => {
       defaultEnabled: true,
       source: 'global_kill_switch',
     });
+  });
+
+  // #2822 review: resolving all flags must cost TWO queries, not two per flag.
+  // Independently escaping each of the 11 ML_FEATURE_FLAGS under `Promise.all`
+  // meant 11 SIMULTANEOUS system transactions — 11 pooled connections on top of
+  // the request's own — for one GET /config/ml-feature-flags. Against the
+  // 25-connection ceiling that is a hang, not a slowdown (postgres-js has no
+  // acquire timeout). `resolveMlFeatureFlag` is pure, so the inputs load once.
+  it('resolves ALL flags from a single org+partner load (no per-flag fan-out)', async () => {
+    mockOrgSettingsRow({
+      orgSettings: { mlFeatureFlags: { 'ml.rca.enabled': true } },
+      orgType: 'customer',
+      partnerSettings: {},
+      partnerType: 'msp',
+    });
+
+    const all = await resolveAllMlFeatureFlagsForOrg('org-1');
+
+    expect(all['ml.rca.enabled']).toMatchObject({ enabled: true, source: 'org_settings' });
+    // Exactly 2 selects total — organizations, then partners — regardless of
+    // how many flags exist. mockOrgSettingsRow stages exactly those two, so a
+    // third call would return undefined and throw.
+    expect(dbSelect).toHaveBeenCalledTimes(2);
+    // And exactly ONE partner-axis escape for the whole batch.
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports org_not_found for every flag when the partner row is unreadable', async () => {
+    // Preserves the old innerJoin semantics: a missing partner row means no
+    // result at all, rather than silently resolving against partner defaults.
+    dbSelect.mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([
+            { settings: {}, type: 'customer', partnerId: 'partner-1' },
+          ]),
+        })),
+      })),
+    } as any);
+    dbSelect.mockReturnValueOnce({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([]) })),
+      })),
+    } as any);
+
+    const resolution = await resolveMlFeatureFlagForOrg('org-1', 'ml.rca.enabled');
+    expect(resolution).toMatchObject({ enabled: false, source: 'org_not_found' });
   });
 
   it('rejects unknown flag names at runtime', () => {

--- a/apps/api/src/services/mlFeatureFlags.test.ts
+++ b/apps/api/src/services/mlFeatureFlags.test.ts
@@ -46,13 +46,39 @@ import {
 
 const ORIGINAL_ENV = { ...process.env };
 
-function mockOrgSettingsRow(row: unknown | null) {
+/**
+ * `resolveMlFeatureFlagForOrg` issues TWO queries (#2822): the `organizations`
+ * read stays in the CALLER'S context so RLS still decides which org resolves,
+ * and only the partner-axis `partners` read is escaped to a system context.
+ * (Escaping the old `organizations INNER JOIN partners` wholesale would have
+ * made any org id selectable system-wide for a caller-supplied `?orgId=`.)
+ *
+ * The fixture keeps the original single-row shape and this helper fans it out
+ * across the two calls, so the existing cases read unchanged.
+ */
+function mockOrgSettingsRow(row: (Record<string, unknown>) | null) {
+  // 1. organizations — caller context.
   dbSelect.mockReturnValueOnce({
     from: vi.fn(() => ({
-      innerJoin: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn().mockResolvedValue(row ? [row] : []),
-        })),
+      where: vi.fn(() => ({
+        limit: vi.fn().mockResolvedValue(
+          row
+            ? [{ settings: row.orgSettings, type: row.orgType, partnerId: 'partner-1' }]
+            : []
+        ),
+      })),
+    })),
+  } as any);
+
+  if (!row) return; // no org => the partner read is never issued
+
+  // 2. partners — inside readWithPartnerAxisVisibility.
+  dbSelect.mockReturnValueOnce({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn().mockResolvedValue([
+          { settings: row.partnerSettings, type: row.partnerType },
+        ]),
       })),
     })),
   } as any);

--- a/apps/api/src/services/mlFeatureFlags.ts
+++ b/apps/api/src/services/mlFeatureFlags.ts
@@ -163,32 +163,46 @@ export async function resolveMlFeatureFlagForOrg(
   // partner-axis `partners` table — the invisible partner row erased the ENTIRE
   // result row, and the function reported every ML feature as
   // `{ enabled: false, source: 'org_not_found' }`, a statement that is false on
-  // both counts. Pinned by the caller-supplied orgId; the join only widens which
-  // COLUMNS resolve, not which org is selected.
-  return readWithPartnerAxisVisibility(async () => {
-    const [row] = await db
-      .select({
-        orgSettings: organizations.settings,
-        orgType: organizations.type,
-        partnerSettings: partners.settings,
-        partnerType: partners.type,
-      })
-      .from(organizations)
-      .innerJoin(partners, eq(organizations.partnerId, partners.id))
-      .where(eq(organizations.id, orgId))
-      .limit(1);
+  // both counts.
+  //
+  // The org read stays in the CALLER'S context and the partner read is escaped
+  // separately (the split `effectiveSettings.ts` already uses). Escaping the
+  // whole `organizations INNER JOIN partners` instead would make the ORG row
+  // selectable system-wide, demoting org isolation on this path to app-layer-only
+  // — which CLAUDE.md forbids — for a caller-supplied `?orgId=`. RLS must stay
+  // the thing that decides WHICH org resolves; the escape only makes the
+  // partner's COLUMNS legible.
+  const [org] = await db
+    .select({ settings: organizations.settings, type: organizations.type, partnerId: organizations.partnerId })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
 
-    if (!row) {
-      const defaultEnabled = defaultMlFeatureFlagValue(flag);
-      return { flag, enabled: false, defaultEnabled, source: 'org_not_found' };
-    }
+  if (!org) {
+    const defaultEnabled = defaultMlFeatureFlagValue(flag);
+    return { flag, enabled: false, defaultEnabled, source: 'org_not_found' };
+  }
 
-    return resolveMlFeatureFlag(flag, {
-      orgSettings: row.orgSettings,
-      orgType: row.orgType,
-      partnerSettings: row.partnerSettings,
-      partnerType: row.partnerType,
-    });
+  const [partner] = await readWithPartnerAxisVisibility(() =>
+    db
+      .select({ settings: partners.settings, type: partners.type })
+      .from(partners)
+      .where(eq(partners.id, org.partnerId))
+      .limit(1)
+  );
+
+  // Preserves the old innerJoin semantics: no partner row => treat as
+  // org_not_found rather than silently resolving against partner defaults.
+  if (!partner) {
+    const defaultEnabled = defaultMlFeatureFlagValue(flag);
+    return { flag, enabled: false, defaultEnabled, source: 'org_not_found' };
+  }
+
+  return resolveMlFeatureFlag(flag, {
+    orgSettings: org.settings,
+    orgType: org.type,
+    partnerSettings: partner.settings,
+    partnerType: partner.type,
   });
 }
 
@@ -209,8 +223,26 @@ export async function shouldProduceMlOutput(
 export async function resolveAllMlFeatureFlagsForOrg(
   orgId: string,
 ): Promise<Record<MlFeatureFlagName, MlFeatureFlagResolution>> {
-  const entries = await Promise.all(
-    ML_FEATURE_FLAGS.map(async (flag) => [flag, await resolveMlFeatureFlagForOrg(orgId, flag)] as const),
+  // ONE system context for the whole fan-out (#2822 review). There are 11
+  // ML_FEATURE_FLAGS and this resolves them concurrently, so leaving each
+  // `resolveMlFeatureFlagForOrg` to take its own partner-axis escape would open
+  // 11 SIMULTANEOUS `baseDb.transaction`s — 11 pooled connections — on top of
+  // the request's own held connection, for a single
+  // `GET /config/ml-feature-flags`. Against the 25-connection ceiling that is a
+  // self-deadlock: postgres-js has no acquire timeout, so the requests hang
+  // rather than error (#1105 class). Entering once here makes every nested
+  // escape observe `scope === 'system'` and take its skip branch, so the whole
+  // fan-out costs exactly one extra connection.
+  //
+  // The org read inside each resolver is then system-scoped too. That is safe
+  // ONLY because this function takes a single `orgId` that its callers have
+  // already gated (routes/config.ts checks `auth.canAccessOrg`) — it is not a
+  // per-flag widening. Callers that resolve a single flag keep the org read
+  // under RLS.
+  const entries = await readWithPartnerAxisVisibility(() =>
+    Promise.all(
+      ML_FEATURE_FLAGS.map(async (flag) => [flag, await resolveMlFeatureFlagForOrg(orgId, flag)] as const),
+    ),
   );
   return Object.fromEntries(entries) as Record<MlFeatureFlagName, MlFeatureFlagResolution>;
 }

--- a/apps/api/src/services/mlFeatureFlags.ts
+++ b/apps/api/src/services/mlFeatureFlags.ts
@@ -150,38 +150,39 @@ export function resolveMlFeatureFlag(
   return { flag, enabled, defaultEnabled, source };
 }
 
-export async function resolveMlFeatureFlagForOrg(
-  orgId: string,
-  flag: MlFeatureFlagName,
-): Promise<MlFeatureFlagResolution> {
-  assertMlFeatureFlagName(flag);
-
-  // `withSystemDbAccessContext` alone was a NO-OP here (#2822): inside a request
-  // it early-returns and inherits the caller's context. `GET /config/ml-feature-flags`
-  // and routes/alerts/correlations.ts are requireScope('organization',…), so an
-  // org-scoped caller (accessiblePartnerIds = []) hit an innerJoin on the
-  // partner-axis `partners` table — the invisible partner row erased the ENTIRE
-  // result row, and the function reported every ML feature as
-  // `{ enabled: false, source: 'org_not_found' }`, a statement that is false on
-  // both counts.
-  //
-  // The org read stays in the CALLER'S context and the partner read is escaped
-  // separately (the split `effectiveSettings.ts` already uses). Escaping the
-  // whole `organizations INNER JOIN partners` instead would make the ORG row
-  // selectable system-wide, demoting org isolation on this path to app-layer-only
-  // — which CLAUDE.md forbids — for a caller-supplied `?orgId=`. RLS must stay
-  // the thing that decides WHICH org resolves; the escape only makes the
-  // partner's COLUMNS legible.
+/**
+ * The org + partner settings `resolveMlFeatureFlag` needs, or null when either
+ * row is unreadable.
+ *
+ * TWO queries, deliberately split (#2822):
+ *  - `organizations` runs in the CALLER'S context, so RLS still decides which
+ *    org is legible. This matters because `GET /config/ml-feature-flags` takes
+ *    a caller-supplied `?orgId=`; escaping the old
+ *    `organizations INNER JOIN partners` wholesale would have made ANY org id
+ *    selectable and demoted this path to app-layer-only isolation, which
+ *    CLAUDE.md forbids.
+ *  - `partners` is partner-axis, so it needs the system escape: an org-scoped
+ *    caller has accessiblePartnerIds = [], the row came back empty, the old
+ *    innerJoin erased the ENTIRE result row, and every ML feature was reported
+ *    as `{ enabled: false, source: 'org_not_found' }` — false on both counts.
+ *    (`withSystemDbAccessContext` alone was a no-op here: inside a request it
+ *    early-returns and inherits the caller's context.)
+ *
+ * Factored out so `resolveAllMlFeatureFlagsForOrg` can pay for it ONCE.
+ */
+async function loadMlFlagInputs(orgId: string): Promise<{
+  orgSettings: unknown;
+  orgType: string | null;
+  partnerSettings: unknown;
+  partnerType: string | null;
+} | null> {
   const [org] = await db
     .select({ settings: organizations.settings, type: organizations.type, partnerId: organizations.partnerId })
     .from(organizations)
     .where(eq(organizations.id, orgId))
     .limit(1);
 
-  if (!org) {
-    const defaultEnabled = defaultMlFeatureFlagValue(flag);
-    return { flag, enabled: false, defaultEnabled, source: 'org_not_found' };
-  }
+  if (!org) return null;
 
   const [partner] = await readWithPartnerAxisVisibility(() =>
     db
@@ -191,19 +192,31 @@ export async function resolveMlFeatureFlagForOrg(
       .limit(1)
   );
 
-  // Preserves the old innerJoin semantics: no partner row => treat as
-  // org_not_found rather than silently resolving against partner defaults.
-  if (!partner) {
-    const defaultEnabled = defaultMlFeatureFlagValue(flag);
-    return { flag, enabled: false, defaultEnabled, source: 'org_not_found' };
-  }
+  // Preserves the old innerJoin semantics: no partner row => no result at all,
+  // rather than silently resolving against partner defaults.
+  if (!partner) return null;
 
-  return resolveMlFeatureFlag(flag, {
+  return {
     orgSettings: org.settings,
     orgType: org.type,
     partnerSettings: partner.settings,
     partnerType: partner.type,
-  });
+  };
+}
+
+export async function resolveMlFeatureFlagForOrg(
+  orgId: string,
+  flag: MlFeatureFlagName,
+): Promise<MlFeatureFlagResolution> {
+  assertMlFeatureFlagName(flag);
+
+  const inputs = await loadMlFlagInputs(orgId);
+  if (!inputs) {
+    const defaultEnabled = defaultMlFeatureFlagValue(flag);
+    return { flag, enabled: false, defaultEnabled, source: 'org_not_found' };
+  }
+
+  return resolveMlFeatureFlag(flag, inputs);
 }
 
 export async function isMlFeatureEnabledForOrg(
@@ -223,26 +236,32 @@ export async function shouldProduceMlOutput(
 export async function resolveAllMlFeatureFlagsForOrg(
   orgId: string,
 ): Promise<Record<MlFeatureFlagName, MlFeatureFlagResolution>> {
-  // ONE system context for the whole fan-out (#2822 review). There are 11
-  // ML_FEATURE_FLAGS and this resolves them concurrently, so leaving each
-  // `resolveMlFeatureFlagForOrg` to take its own partner-axis escape would open
-  // 11 SIMULTANEOUS `baseDb.transaction`s — 11 pooled connections — on top of
-  // the request's own held connection, for a single
-  // `GET /config/ml-feature-flags`. Against the 25-connection ceiling that is a
-  // self-deadlock: postgres-js has no acquire timeout, so the requests hang
-  // rather than error (#1105 class). Entering once here makes every nested
-  // escape observe `scope === 'system'` and take its skip branch, so the whole
-  // fan-out costs exactly one extra connection.
+  // TWO queries total, not 2 per flag (#2822 review). `resolveMlFeatureFlag` is
+  // pure — given the org/partner settings it touches no DB — so the 11
+  // ML_FEATURE_FLAGS share one `loadMlFlagInputs` call.
   //
-  // The org read inside each resolver is then system-scoped too. That is safe
-  // ONLY because this function takes a single `orgId` that its callers have
-  // already gated (routes/config.ts checks `auth.canAccessOrg`) — it is not a
-  // per-flag widening. Callers that resolve a single flag keep the org read
-  // under RLS.
-  const entries = await readWithPartnerAxisVisibility(() =>
-    Promise.all(
-      ML_FEATURE_FLAGS.map(async (flag) => [flag, await resolveMlFeatureFlagForOrg(orgId, flag)] as const),
-    ),
-  );
+  // This also removes the need for a system context around the fan-out.
+  // Resolving each flag independently would have taken 11 partner-axis escapes,
+  // and under `Promise.all` those are 11 SIMULTANEOUS `baseDb.transaction`s —
+  // 11 pooled connections on top of the request's own — for a single
+  // `GET /config/ml-feature-flags`. Against the 25-connection ceiling that is a
+  // self-deadlock, not a slowdown: postgres-js has no acquire timeout, so the
+  // requests hang rather than error (#1105 class). Hoisting one shared context
+  // would have fixed the count but system-scoped the org read too; loading the
+  // inputs once fixes both, and keeps the org read under RLS.
+  const inputs = await loadMlFlagInputs(orgId);
+
+  const entries = ML_FEATURE_FLAGS.map((flag) => [
+    flag,
+    inputs
+      ? resolveMlFeatureFlag(flag, inputs)
+      : {
+        flag,
+        enabled: false,
+        defaultEnabled: defaultMlFeatureFlagValue(flag),
+        source: 'org_not_found' as const,
+      },
+  ] as const);
+
   return Object.fromEntries(entries) as Record<MlFeatureFlagName, MlFeatureFlagResolution>;
 }

--- a/apps/api/src/services/mlFeatureFlags.ts
+++ b/apps/api/src/services/mlFeatureFlags.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
-import { db, withSystemDbAccessContext } from '../db';
+import { db } from '../db';
+import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { organizations, partners } from '../db/schema';
 import { mlFeatureGloballyDisabled } from '../config/env';
 
@@ -155,7 +156,16 @@ export async function resolveMlFeatureFlagForOrg(
 ): Promise<MlFeatureFlagResolution> {
   assertMlFeatureFlagName(flag);
 
-  return withSystemDbAccessContext(async () => {
+  // `withSystemDbAccessContext` alone was a NO-OP here (#2822): inside a request
+  // it early-returns and inherits the caller's context. `GET /config/ml-feature-flags`
+  // and routes/alerts/correlations.ts are requireScope('organization',…), so an
+  // org-scoped caller (accessiblePartnerIds = []) hit an innerJoin on the
+  // partner-axis `partners` table — the invisible partner row erased the ENTIRE
+  // result row, and the function reported every ML feature as
+  // `{ enabled: false, source: 'org_not_found' }`, a statement that is false on
+  // both counts. Pinned by the caller-supplied orgId; the join only widens which
+  // COLUMNS resolve, not which org is selected.
+  return readWithPartnerAxisVisibility(async () => {
     const [row] = await db
       .select({
         orgSettings: organizations.settings,

--- a/apps/api/src/services/scriptBuilderTools.ts
+++ b/apps/api/src/services/scriptBuilderTools.ts
@@ -8,6 +8,7 @@
 import { z } from 'zod';
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import type { AuthContext } from '../middleware/auth';
+import { dbAccessContextFromAuth } from '../middleware/auth';
 import { executeTool } from './aiTools';
 import { withDbAccessContext, runOutsideDbContext } from '../db';
 import type { AiToolTier } from '@breeze/shared/types/ai';
@@ -89,14 +90,17 @@ function makeExistingHandler(
       // when an AsyncLocalStorage store already exists — and the SDK MCP
       // dispatch chain leaves a stale store behind, which would cause the
       // inner call to inherit whatever scope happened to be on the stack.
+      // Built via the canonical `dbAccessContextFromAuth` (#2822): the literal
+      // this replaced omitted `accessiblePartnerIds` / `currentPartnerId` /
+      // `userId`, and since `runOutsideDbContext` discards the ambient context
+      // first, that partial object was the only context Postgres saw — leaving
+      // `breeze_has_partner_access` FALSE for every script-builder tool call,
+      // even a partner-scope admin's. Partner-wide scripts, script categories
+      // and tags all read as empty with a 200.
       const result = await withTimeout(
         runOutsideDbContext(() =>
           withDbAccessContext(
-            {
-              scope: auth.scope,
-              orgId: auth.orgId,
-              accessibleOrgIds: auth.accessibleOrgIds,
-            },
+            dbAccessContextFromAuth(auth),
             () => executeTool(toolName, args, auth),
           ),
         ),


### PR DESCRIPTION
## What

Repo-wide audit of partner-axis reads executed on the ambient request DB context, plus fixes for the root cause and the highest-severity sites.

`partners` and every table in `PARTNER_TENANT_TABLES` are gated by `breeze_has_partner_access(...)`, which evaluates against `breeze.accessible_partner_ids`. `computeAccessiblePartnerIds` returns `[]` for `scope === 'organization'`; agentAuth, clientAiAuth, portal auth and org-scoped OAuth bearers all set `accessiblePartnerIds: []` too. **RLS returns zero rows rather than erroring**, so the value silently collapses to a default, an empty list, or a spurious 404 — for exactly the population the feature was meant to serve.

Adds `readWithPartnerAxisVisibility` (`apps/api/src/db/partnerAxisRead.ts`) — `runOutsideDbContext` + `withSystemDbAccessContext`, **including the skip-when-already-system branch** so a system-scoped caller never double-holds a pooled connection against the 25-connection US ceiling.

## Root cause fixed at source

`services/aiAgentSdkTools.ts` (×2) and `services/scriptBuilderTools.ts` hand-rolled a partial `DbAccessContext` that omitted `accessiblePartnerIds`, `currentPartnerId` and `userId`. Because those handlers call `runOutsideDbContext` first, that literal was the **only** context Postgres saw — a partner-axis blackout across every AI tool, **including for a partner-scope MSP admin who is entitled to the rows**. Now built via the canonical `dbAccessContextFromAuth`.

## Sites fixed

| Site | Observable symptom before |
|---|---|
| `routes/partner.ts` `GET /partner/me` | 404 for every org-scoped user; web `AccountInactiveGuard` swallows it (`if (!res.ok) return null`), so suspended-tenant users are never redirected |
| `routes/clientAi/admin.ts` entitlement gate | 404 on the whole AI-for-Office admin surface for org-scoped users with the partner flag **on** |
| `routes/mcpServer.ts` bootstrap | `partnerAdminEmail` silently `''` → email notification channel created with an empty target, reported as success |
| `routes/devices/provision.ts` | partner `max_devices` cap **inert** for org-scoped callers (both the cap read and the partner fleet count) |
| `services/authenticatorPolicy.ts` | **step-up MFA silently failed OPEN** — org-scoped tech could approve a critical JIT-admin elevation at L1 while a partner-scoped tech got 403 |
| `services/effectiveSettings.ts` ×3 | 404 "Partner not found" on an org admin's **own** org; `PUT /ai/budget` unusable at org scope; AI chat turns failing "Unable to verify budget" |
| `services/mlFeatureFlags.ts` | every ML feature reported disabled with a false `source: 'org_not_found'` |
| `services/featureConfigResolver.ts` `resolveDeviceTimezone` | partner timezone dropped, so the same device resolved a **different maintenance window** depending on whether the scheduler or an org-scoped UI action triggered the job |
| `services/configPolicyPatching.ts`, `services/configurationPolicy.ts` | valid update rings rejected as "not found for this partner" while the system-scoped scheduler ran them fine |

Every escape stays pinned to an id from the verified auth context or from a row already resolved under the caller's own RLS context. **This widens which COLUMNS are legible, never which partner row can be selected.**

## Behaviour change worth calling out

`POST /devices/provision` now actually enforces the partner device cap for org-scoped callers. Previously the cap was skipped entirely for them, so an org admin could provision past `max_devices` while the identical call from a partner admin was capped. This matches the enrollment twin, which has always been correct.

## Tests

New real-Postgres suite: `apps/api/src/__tests__/integration/partnerAxisSystemContext.integration.test.ts`, running as `breeze_app` inside a genuine org-scoped `withDbAccessContext` — the exact ambient context an org-scoped HTTP request runs under. A mocked-DB test is structurally incapable of catching this class, which is the whole point of the issue.

It leads with a **premise proof** (raw `partners` / `authenticator_policies` / `patch_policies` SELECTs return zero rows in that context, while the org row itself is visible) so the remaining cases cannot pass vacuously, then asserts each fixed resolver surfaces the partner data, plus a **cross-partner negative** proving the escape did not widen reach.

**Verified non-vacuous:** stubbing the helper to a pass-through fails 6 of the 10 cases — precisely the org-scoped ones.

- Integration: 10 passed
- Affected + dependent unit suites: 85 files / 1000+ tests passed (single-fork)
- `tsc --noEmit` clean

## Deliberate: one regression lock is inverted — please read this bit

`apps/api/src/__tests__/integration/reliabilityScoringProjection.integration.test.ts` carried a **#1105 regression lock** asserting that `computeAndPersistDeviceReliability` *"silently no-ops (persists nothing) when run under an org-scoped context"*. This PR **inverts** it. That is intentional, not collateral damage.

**Why it had to change.** That assertion encoded the #2822 bug as the expected behaviour. The ml-feature-flag gate read `organizations INNER JOIN partners`; `partners` is partner-axis, an org-scoped context has `accessiblePartnerIds = []`, so the invisible partner row erased the whole joined row and the flag resolved `org_not_found` — false on both counts (the org exists, and the feature may well be enabled). This PR splits that read so the org half stays under RLS and only the partner half is escaped. The gate now answers honestly, so the compute proceeds and the old assertion can no longer hold.

**Why #1105 is still protected.** The protection never actually lived in that assertion. What matters for #1105 is **caller discipline** — that the production callers open a system context — and that is pinned *directly, on the callers*:

- `apps/api/src/routes/agents/reliability.test.ts:146-147` asserts `fallbackScope === 'system'` **and** that `runOutsideDbContext` was called, for the Redis-outage inline fallback.
- `apps/api/src/jobs/reliabilityWorker.test.ts` covers the worker path.

Both still pass, unchanged. Those guards hold regardless of what an org-scoped compute happens to do, so they are strictly **stronger** than inferring caller discipline from a symptom. No production path invokes this under an org context — `routes/agents/reliability.ts:117` already does `runOutsideDbContext(() => withSystemDbAccessContext(...))` explicitly.

**What the rewrite adds.** It pins **tenant correctness**, which the old test could not: the persisted row's `deviceId` and `orgId` must be the caller's own. The write still runs under org-scoped RLS, so this is the device's own tenant — not a system-scope escape hatch that could write anywhere.

I also swept for sibling tests pinning the same inert behaviour (anything asserting a partner-axis read returns nothing / resolves `org_not_found` / no-ops under an org context). This was the only one; the four other integration suites that exercise the changed services all pass unchanged.

## Audit findings NOT fixed here

The sweep found roughly 50 sites. The rest are enumerated in a comment on #2822 with severity and reasoning — several need a ruling rather than a mechanical fix (e.g. `deleteTenant`, where the zero-row read is currently the *only* thing enforcing partner scope; the AI catalog/Huntress tools, where escaping would genuinely widen what an org caller sees; an `alert_rules` RLS policy gap that needs a migration). Splitting them out keeps this PR reviewable.

Closes #2822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

