### PR TITLE
feat(billing): normalize the invoice editor onto the quote save grammar

### DIFF
--- a/apps/web/src/components/billing/InvoiceActions.savepending.test.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.savepending.test.tsx
@@ -58,7 +58,7 @@ describe('InvoiceActions — savePending gating', () => {
     // Visible reason for the hold (both a hint paragraph and the button title).
     expect(screen.getByTestId('invoice-issue-saving-hint')).toBeInTheDocument();
     expect(screen.getByTestId('invoice-issue')).toHaveAttribute(
-      'aria-describedby', 'invoice-issue-saving-hint-header',
+      'aria-describedby', 'invoice-issue-held-hint-header',
     );
 
     // Clicking Issue while saving queues it — nothing fires yet.
@@ -113,7 +113,57 @@ describe('InvoiceActions — savePending gating', () => {
     rerender(<InvoiceActions detail={detail()} variant="header" savePending={false} saveFailureNonce={1} />);
 
     // The queue was dropped by the failure — quiescence fires nothing.
-    await new Promise((r) => setTimeout(r, 0));
+    await act(async () => {});
+    await waitFor(() => expect(screen.queryByTestId('invoice-issue-saving-hint')).not.toBeInTheDocument());
+    expect(issuePosted()).toBe(false);
+  });
+
+  it('cancels a queued Issue when the failure and quiescence arrive in the SAME render', async () => {
+    // The dangerous shape: one commit in which the nonce bumps AND savePending
+    // goes false. Splitting these across two rerenders proves nothing — the
+    // first is inert while savePending is still true, so the assertion passes
+    // even if the guard is ordered wrongly. Both props must flip at once.
+    const { rerender } = render(
+      <InvoiceActions detail={detail()} variant="header" savePending saveFailureNonce={0} />,
+    );
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    expect(issuePosted()).toBe(false);
+
+    rerender(<InvoiceActions detail={detail()} variant="header" savePending={false} saveFailureNonce={1} />);
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    await act(async () => {});
+    expect(issuePosted()).toBe(false);
+  });
+
+  it('refuses (does not queue) an Issue click when a field failed to save and stays dirty', async () => {
+    // Queueing here would wait on a save that is never coming. The hint and the
+    // toast must name the field instead of promising a save in progress.
+    render(<InvoiceActions detail={detail()} variant="header" unsavedFieldLabel="Notes" />);
+
+    expect(screen.queryByTestId('invoice-issue-saving-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoice-issue-unsaved-hint')).toHaveTextContent('Notes');
+
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warning', message: expect.stringContaining('Notes') }),
+    ));
+    // No queue, no spinner, and above all no POST.
+    expect(issuePosted()).toBe(false);
+  });
+
+  it('re-checks the visible-lines precondition before firing a queued Issue', async () => {
+    // The queue can outlive the gate: flushing the deferred delete of the last
+    // customer-visible line is itself what the Issue click triggered.
+    const withLine = detail();
+    const { rerender } = render(<InvoiceActions detail={withLine} variant="header" savePending />);
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+
+    const emptied = detail();
+    emptied.lines = [{ ...visibleLine, customerVisible: false }];
+    rerender(<InvoiceActions detail={emptied} variant="header" savePending={false} />);
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' })));
     expect(issuePosted()).toBe(false);
   });
 

--- a/apps/web/src/components/billing/InvoiceActions.savepending.test.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.savepending.test.tsx
@@ -1,0 +1,138 @@
+// Save-quiescence gating on the Issue buttons (the quote editor's Send
+// contract, normalized onto invoices): while the editor reports pending edits,
+// an Issue click is never dead — it queues and fires the moment the editor goes
+// quiescent, with a visible hint explaining the hold.
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceActions from './InvoiceActions';
+import type { InvoiceDetail } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToastMock = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToastMock(a) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const visibleLine: InvoiceDetail['lines'][number] = {
+  id: 'line-1', invoiceId: 'inv-1', sourceType: 'manual', parentLineId: null, catalogItemId: null,
+  name: null, description: 'Consulting', quantity: '2.00', unitPrice: '50.00', costBasis: null, revenueAllocation: null,
+  taxable: false, customerVisible: true, lineTotal: '100.00', isUnapprovedTime: false, sortOrder: 1,
+};
+
+function detail(): InvoiceDetail {
+  return {
+    invoice: {
+      id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '100.00', taxRate: null,
+      taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
+      notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
+    },
+    lines: [visibleLine],
+  };
+}
+
+const issuePosted = () =>
+  fetchMock.mock.calls.some((c) => String(c[0]) === '/invoices/inv-1/issue' && (c[1] as RequestInit)?.method === 'POST');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock.mockImplementation(async () => json({ data: {} }));
+});
+
+describe('InvoiceActions — savePending gating', () => {
+  it('shows the saving hint and holds an Issue click until quiescence, then fires it', async () => {
+    const { rerender } = render(<InvoiceActions detail={detail()} variant="header" savePending />);
+
+    // Visible reason for the hold (both a hint paragraph and the button title).
+    expect(screen.getByTestId('invoice-issue-saving-hint')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-issue')).toHaveAttribute(
+      'aria-describedby', 'invoice-issue-saving-hint-header',
+    );
+
+    // Clicking Issue while saving queues it — nothing fires yet.
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    expect(issuePosted()).toBe(false);
+
+    // The editor goes quiescent → the queued Issue fires without a second click.
+    rerender(<InvoiceActions detail={detail()} variant="header" savePending={false} />);
+    await waitFor(() => expect(issuePosted()).toBe(true));
+  });
+
+  it('holds an Issue & Send click until quiescence, then opens the confirm dialog (never auto-sends)', async () => {
+    const { rerender } = render(<InvoiceActions detail={detail()} variant="header" savePending />);
+
+    fireEvent.click(screen.getByTestId('invoice-issue-send'));
+    expect(screen.queryByTestId('invoice-issue-send-confirm')).not.toBeInTheDocument();
+    expect(issuePosted()).toBe(false);
+
+    rerender(<InvoiceActions detail={detail()} variant="header" savePending={false} />);
+    // Quiescence opens the CONFIRM dialog — the email still needs an explicit yes.
+    await waitFor(() => expect(screen.getByTestId('invoice-issue-send-confirm')).toBeInTheDocument());
+    expect(issuePosted()).toBe(false);
+  });
+
+  it('renders no saving hint and issues immediately when savePending is false', async () => {
+    render(<InvoiceActions detail={detail()} variant="header" />);
+    expect(screen.queryByTestId('invoice-issue-saving-hint')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    await waitFor(() => expect(issuePosted()).toBe(true));
+  });
+
+  it('flushes deferred deletions when Issue is clicked while saving', () => {
+    const onIssueWhilePending = vi.fn();
+    render(<InvoiceActions detail={detail()} variant="header" savePending onIssueWhilePending={onIssueWhilePending} />);
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    expect(onIssueWhilePending).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a queued Issue when a save FAILURE is reported — quiescence after a failure must not issue', async () => {
+    // A failed delete-flush restores its rows and a failed line blur-save
+    // clears its in-flight key: both read as "quiet". Firing the queue then
+    // would number an invoice that contradicts what the user last saw.
+    const { rerender } = render(
+      <InvoiceActions detail={detail()} variant="header" savePending saveFailureNonce={0} />,
+    );
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    expect(issuePosted()).toBe(false);
+
+    // The failure signal lands (nonce bump), then the editor goes quiescent.
+    rerender(<InvoiceActions detail={detail()} variant="header" savePending saveFailureNonce={1} />);
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    rerender(<InvoiceActions detail={detail()} variant="header" savePending={false} saveFailureNonce={1} />);
+
+    // The queue was dropped by the failure — quiescence fires nothing.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(issuePosted()).toBe(false);
+  });
+
+  it('drops a queued Issue after a bounded wait when a save stays in flight, with an honest still-saving toast', async () => {
+    // With failures handled by the nonce signal, the timeout is the slow-save
+    // backstop — its copy must not claim a failure nobody saw.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      render(<InvoiceActions detail={detail()} variant="header" savePending />);
+      fireEvent.click(screen.getByTestId('invoice-issue'));
+      expect(issuePosted()).toBe(false);
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(15_000); });
+
+      expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+      // The queue is gone: even if the editor later goes quiescent, nothing fires.
+      expect(issuePosted()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/components/billing/InvoiceActions.savepending.test.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.savepending.test.tsx
@@ -152,6 +152,35 @@ describe('InvoiceActions — savePending gating', () => {
     expect(issuePosted()).toBe(false);
   });
 
+  it('re-checks the unsaved-field refusal before firing a queued Issue', async () => {
+    // The click gate tests savePending FIRST, so a click during a deferred
+    // delete queues even while an earlier failed price save keeps a field
+    // dirty (its nonce bump happened BEFORE the click, so the captured nonce
+    // never changes). When the flush succeeds and the editor goes quiet, the
+    // queue must re-check the label and refuse — firing would issue the
+    // invoice at the pre-edit money.
+    const { rerender } = render(
+      <InvoiceActions detail={detail()} variant="header" savePending unsavedFieldLabel="Notes" />,
+    );
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    expect(issuePosted()).toBe(false);
+
+    // Quiescence arrives with the field STILL flagged unsaved.
+    rerender(
+      <InvoiceActions detail={detail()} variant="header" savePending={false} unsavedFieldLabel="Notes" />,
+    );
+
+    // The refusal surfaces exactly like an immediate click's would — a warning
+    // naming the field — and above all no POST.
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warning', message: expect.stringContaining('Notes') }),
+    ));
+    await act(async () => {});
+    expect(issuePosted()).toBe(false);
+    // The queue is gone (no spinner promising a fire that isn't coming).
+    expect(screen.getByTestId('invoice-issue').querySelector('.animate-spin')).toBeNull();
+  });
+
   it('re-checks the visible-lines precondition before firing a queued Issue', async () => {
     // The queue can outlive the gate: flushing the deferred delete of the last
     // customer-visible line is itself what the Issue click triggered.

--- a/apps/web/src/components/billing/InvoiceActions.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.tsx
@@ -13,6 +13,13 @@ import { type InvoiceDetail as InvoiceDetailData, formatMoney } from './invoiceT
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
+/** An Issue click parked until the editor goes quiet. `atFailureNonce` is the
+ *  failure count observed at click time; any change to it means a save failed
+ *  while we were waiting, so the queue cancels instead of firing. Holding it in
+ *  the queue makes that a data comparison rather than a dependency on the order
+ *  two effects observe two props. */
+type QueuedIssue = { kind: 'issue' | 'issueSend'; atFailureNonce: number };
+
 interface Props {
   detail: InvoiceDetailData;
   onChanged?: () => void;
@@ -25,11 +32,16 @@ interface Props {
    * when the header owns the actions (mirrors QuoteActions).
    */
   variant: 'rail' | 'header';
-  /** True while the editor has in-flight saves, dirty blur-to-save fields, or
-   *  deferred line deletions awaiting their undo window. Issue must not race a
-   *  pending save: it would snapshot and number an invoice that's missing the
-   *  user's just-typed edit (mirrors QuoteActions.savePending). */
+  /** True while the editor has work genuinely IN FLIGHT — an open mutation or a
+   *  deferred line deletion awaiting its undo window. Issue must not race it: it
+   *  would snapshot and number an invoice that's missing the user's just-typed
+   *  edit. This state resolves on its own, so a click queues and waits. */
   savePending?: boolean;
+  /** Translated label of a field holding an edit that is dirty with NOTHING in
+   *  flight — its save failed, or never fired. Waiting cannot clear this, so
+   *  Issue refuses and names the field rather than queueing behind a save that
+   *  is never coming. Null when everything is clean or genuinely saving. */
+  unsavedFieldLabel?: string | null;
   /** Bumped by the workspace on every editor save FAILURE. A failure can still
    *  produce "quiescence" (restored rows / cleared in-flight keys), so a
    *  queued Issue must cancel on this signal rather than fire. */
@@ -49,7 +61,7 @@ interface Props {
  * the detail view's busy state with the payment mutations and belongs with the
  * issued-lifecycle rail, not the header.
  */
-export default function InvoiceActions({ detail, onChanged, variant, savePending = false, saveFailureNonce = 0, onIssueWhilePending }: Props) {
+export default function InvoiceActions({ detail, onChanged, variant, savePending = false, unsavedFieldLabel = null, saveFailureNonce = 0, onIssueWhilePending }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const { invoice, lines } = detail;
@@ -74,7 +86,12 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
   // itself blurs the dirty field (starting its save), so the action is queued
   // to fire the moment the editor goes quiescent — one click to the money
   // moment, never a dead one (the quote editor's Send contract).
-  const [queuedWhenQuiet, setQueuedWhenQuiet] = useState<null | 'issue' | 'issueSend'>(null);
+  //
+  // The queue CAPTURES the failure nonce it was created at. "Has a save failed
+  // since I clicked?" is then a question about data this component holds, not
+  // about the order in which two effects happen to observe two independently
+  // updated props.
+  const [queued, setQueued] = useState<QueuedIssue | null>(null);
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
 
   const isDraft = invoice.status === 'draft';
@@ -119,44 +136,53 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
     }
   }, [issuing, invoice.id, refresh, t]);
 
-  // Cancel a queued Issue the moment a save FAILS. This must run BEFORE the
-  // quiescence effect below (effects run in definition order): a failed
-  // delete-flush restores its rows and a failed line blur-save clears its
-  // in-flight key, both of which read as "quiet" — firing then would issue an
-  // invoice that contradicts what the user last saw on screen.
-  const seenFailureNonce = useRef(saveFailureNonce);
+  // One effect resolves the queue, in strict priority: failed → cancel;
+  // still working → keep waiting; preconditions lapsed → refuse; otherwise fire.
+  //
+  // Cancelling on a CHANGED nonce (rather than on a separately-ordered effect)
+  // is what makes this safe. A failed delete-flush restores its rows and a
+  // failed line blur-save clears its in-flight key, so both read as "quiet" —
+  // firing then would issue an invoice contradicting what the user last saw.
+  // The previous shape split this across two effects and relied on `savePending`
+  // arriving one commit after the nonce (the editor reports it through an
+  // effect). That happened to hold, but nothing stated it: deriving the pending
+  // signal synchronously would have silently armed a same-commit race on an
+  // irreversible money action.
   useEffect(() => {
-    if (saveFailureNonce === seenFailureNonce.current) return;
-    seenFailureNonce.current = saveFailureNonce;
-    if (!queuedWhenQuiet) return;
-    setQueuedWhenQuiet(null);
-    showToast({ type: 'error', message: t('invoiceActions.issueCanceledSaveFailed') });
-  }, [saveFailureNonce, queuedWhenQuiet, t]);
-
-  // Fire the queued Issue action once the editor reports quiescence. Plain
-  // Issue runs directly (it's reversible via Void); Issue & Send opens its
-  // confirm dialog — the user still confirms the email before anything sends.
-  useEffect(() => {
-    if (!queuedWhenQuiet || savePending) return;
-    const queued = queuedWhenQuiet;
-    setQueuedWhenQuiet(null);
-    if (queued === 'issue') void issue(false);
+    if (!queued) return;
+    if (saveFailureNonce !== queued.atFailureNonce) {
+      setQueued(null);
+      showToast({ type: 'error', message: t('invoiceActions.issueCanceledSaveFailed') });
+      return;
+    }
+    if (savePending) return;
+    setQueued(null);
+    // The button's own gate is re-checked here: the queue can outlive it. The
+    // last customer-visible line may have been sitting in its undo window, and
+    // the flush this very click triggered is what deleted it for good.
+    if (!hasVisibleLines) {
+      showToast({ type: 'warning', message: t('invoiceActions.noVisibleLineHint') });
+      return;
+    }
+    // Plain Issue runs directly (it's reversible via Void); Issue & Send opens
+    // its confirm dialog — the user still confirms the email before it sends.
+    if (queued.kind === 'issue') void issue(false);
     else setIssueSendOpen(true);
-  }, [queuedWhenQuiet, savePending, issue]);
+  }, [queued, saveFailureNonce, savePending, hasVisibleLines, issue, t]);
 
-  // Slow-save backstop: with failures handled by the nonce above, the only way
-  // a queue waits this long is a save that is genuinely still in flight (or a
-  // pending-state bug). Drop the queued action after a bounded wait with an
-  // honest "still saving" explanation — never claim a failure we didn't see.
-  // Cleared automatically when quiescence fires the queue.
+  // Slow-save backstop: with failures handled above, the only way a queue waits
+  // this long is a save that is genuinely still in flight (or a pending-state
+  // bug). Drop the queued action after a bounded wait with an honest "still
+  // saving" explanation — never claim a failure we didn't see. Cleared
+  // automatically when the effect above fires or cancels the queue.
   useEffect(() => {
-    if (!queuedWhenQuiet) return;
+    if (!queued) return;
     const timer = setTimeout(() => {
-      setQueuedWhenQuiet(null);
+      setQueued(null);
       showToast({ type: 'warning', message: t('invoiceActions.issueCanceledStillSaving') });
     }, 15_000);
     return () => clearTimeout(timer);
-  }, [queuedWhenQuiet, t]);
+  }, [queued, t]);
 
   const remove = useCallback(async () => {
     if (deleting) return;
@@ -193,6 +219,15 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
   if (!canIssue && !canDownload && !canDelete) return null;
 
   const issueDisabled = issuing || !hasVisibleLines;
+  // Why the money-buttons are held, if they are. 'saving' resolves on its own
+  // and a click queues behind it; 'unsaved' never will, so a click refuses and
+  // names the field. Order matters: a field mid-save is dirty AND in flight.
+  const heldReason: 'saving' | 'unsaved' | null = savePending ? 'saving' : unsavedFieldLabel ? 'unsaved' : null;
+  const heldHintId = `invoice-issue-held-hint-${variant}`;
+  // Refuse a click that can only ever wait on a save that isn't coming.
+  const refuseForUnsaved = () => {
+    showToast({ type: 'warning', message: t('invoiceActions.issueBlockedUnsaved', { field: unsavedFieldLabel }) });
+  };
 
   return (
     <>
@@ -205,18 +240,20 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
             <button
               type="button"
               onClick={() => {
-                if (savePending) { onIssueWhilePending?.(); setQueuedWhenQuiet('issue'); return; }
+                if (savePending) { onIssueWhilePending?.(); setQueued({ kind: 'issue', atFailureNonce: saveFailureNonce }); return; }
+                if (unsavedFieldLabel) { refuseForUnsaved(); return; }
                 void issue(false);
               }}
               disabled={issueDisabled}
               aria-describedby={
                 !hasVisibleLines ? `invoice-no-visible-hint-${variant}`
-                  : savePending ? `invoice-issue-saving-hint-${variant}`
+                  : heldReason ? heldHintId
                   : undefined
               }
               title={
                 !hasVisibleLines ? t('invoiceActions.noVisibleLineHint')
-                  : savePending ? t('invoiceActions.savingTitle')
+                  : heldReason === 'saving' ? t('invoiceActions.savingTitle')
+                  : heldReason === 'unsaved' ? t('invoiceActions.unsavedTitle', { field: unsavedFieldLabel })
                   : undefined
               }
               data-testid="invoice-issue"
@@ -227,28 +264,30 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
                   queued click awaiting quiescence. Plain savePending (a dirty
                   field, maybe one whose save failed and stays dirty by design)
                   gets the static hint below, never an infinite spinner. */}
-              {(issuing || queuedWhenQuiet !== null) && (
+              {(issuing || queued !== null) && (
                 <Loader2 className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 animate-spin" aria-hidden="true" />
               )}
-              <span className={issuing || queuedWhenQuiet !== null ? 'opacity-30' : ''}>
+              <span className={issuing || queued !== null ? 'opacity-30' : ''}>
                 {issuing ? t('invoiceActions.issuing') : t('invoiceActions.issue')}
               </span>
             </button>
             <button
               type="button"
               onClick={() => {
-                if (savePending) { onIssueWhilePending?.(); setQueuedWhenQuiet('issueSend'); return; }
+                if (savePending) { onIssueWhilePending?.(); setQueued({ kind: 'issueSend', atFailureNonce: saveFailureNonce }); return; }
+                if (unsavedFieldLabel) { refuseForUnsaved(); return; }
                 setIssueSendOpen(true);
               }}
               disabled={issueDisabled}
               aria-describedby={
                 !hasVisibleLines ? `invoice-no-visible-hint-${variant}`
-                  : savePending ? `invoice-issue-saving-hint-${variant}`
+                  : heldReason ? heldHintId
                   : undefined
               }
               title={
                 !hasVisibleLines ? t('invoiceActions.noVisibleLineHint')
-                  : savePending ? t('invoiceActions.savingTitle')
+                  : heldReason === 'saving' ? t('invoiceActions.savingTitle')
+                  : heldReason === 'unsaved' ? t('invoiceActions.unsavedTitle', { field: unsavedFieldLabel })
                   : undefined
               }
               data-testid="invoice-issue-send"
@@ -257,10 +296,10 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
               {/* Overlay spinner while a queued click settles or the issue is in
                   flight; the label always defines the button's size (mirrors the
                   quote Send button). See the spinner note on plain Issue above. */}
-              {(issuing || queuedWhenQuiet !== null) && (
+              {(issuing || queued !== null) && (
                 <Loader2 className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 animate-spin" aria-hidden="true" />
               )}
-              <span className={issuing || queuedWhenQuiet !== null ? 'opacity-30' : ''}>
+              <span className={issuing || queued !== null ? 'opacity-30' : ''}>
                 {issuing ? t('invoiceActions.issuing') : t('invoiceActions.issueAndSend')}
               </span>
             </button>
@@ -301,15 +340,20 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
             {t('invoiceActions.noVisibleLineHint')}
           </p>
         )}
-        {canIssue && hasVisibleLines && savePending && (
+        {canIssue && hasVisibleLines && heldReason && (
           // Same placement rules as the no-visible-lines hint above: the user must
           // be able to SEE why the money-buttons are held, not just hover for it.
+          // The two reasons get different copy and different testids — telling a
+          // user "Saving changes…" about a field that already failed to save is
+          // advice they can follow forever without getting anywhere.
           <p
-            id={`invoice-issue-saving-hint-${variant}`}
-            data-testid="invoice-issue-saving-hint"
+            id={heldHintId}
+            data-testid={heldReason === 'saving' ? 'invoice-issue-saving-hint' : 'invoice-issue-unsaved-hint'}
             className={header ? 'basis-full text-xs text-muted-foreground text-right' : 'text-center text-xs text-muted-foreground'}
           >
-            {t('invoiceActions.savingHint')}
+            {heldReason === 'saving'
+              ? t('invoiceActions.savingHint')
+              : t('invoiceActions.unsavedHint', { field: unsavedFieldLabel })}
           </p>
         )}
       </div>

--- a/apps/web/src/components/billing/InvoiceActions.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Loader2 } from 'lucide-react';
 import '../../lib/i18n';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
@@ -24,6 +25,19 @@ interface Props {
    * when the header owns the actions (mirrors QuoteActions).
    */
   variant: 'rail' | 'header';
+  /** True while the editor has in-flight saves, dirty blur-to-save fields, or
+   *  deferred line deletions awaiting their undo window. Issue must not race a
+   *  pending save: it would snapshot and number an invoice that's missing the
+   *  user's just-typed edit (mirrors QuoteActions.savePending). */
+  savePending?: boolean;
+  /** Bumped by the workspace on every editor save FAILURE. A failure can still
+   *  produce "quiescence" (restored rows / cleared in-flight keys), so a
+   *  queued Issue must cancel on this signal rather than fire. */
+  saveFailureNonce?: number;
+  /** Called when Issue is clicked while savePending — lets the workspace flush
+   *  the editor's deferred deletions (undo grace window) immediately, so the
+   *  held Issue fires as soon as the DELETE lands (mirrors onSendWhilePending). */
+  onIssueWhilePending?: () => void;
 }
 
 /**
@@ -35,7 +49,7 @@ interface Props {
  * the detail view's busy state with the payment mutations and belongs with the
  * issued-lifecycle rail, not the header.
  */
-export default function InvoiceActions({ detail, onChanged, variant }: Props) {
+export default function InvoiceActions({ detail, onChanged, variant, savePending = false, saveFailureNonce = 0, onIssueWhilePending }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const { invoice, lines } = detail;
@@ -56,6 +70,11 @@ export default function InvoiceActions({ detail, onChanged, variant }: Props) {
   const [issueSendOpen, setIssueSendOpen] = useState(false);
   const [delOpen, setDelOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  // During savePending an Issue click's job is the prerequisite: the click
+  // itself blurs the dirty field (starting its save), so the action is queued
+  // to fire the moment the editor goes quiescent — one click to the money
+  // moment, never a dead one (the quote editor's Send contract).
+  const [queuedWhenQuiet, setQueuedWhenQuiet] = useState<null | 'issue' | 'issueSend'>(null);
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
 
   const isDraft = invoice.status === 'draft';
@@ -99,6 +118,45 @@ export default function InvoiceActions({ detail, onChanged, variant }: Props) {
       setIssueSendOpen(false);
     }
   }, [issuing, invoice.id, refresh, t]);
+
+  // Cancel a queued Issue the moment a save FAILS. This must run BEFORE the
+  // quiescence effect below (effects run in definition order): a failed
+  // delete-flush restores its rows and a failed line blur-save clears its
+  // in-flight key, both of which read as "quiet" — firing then would issue an
+  // invoice that contradicts what the user last saw on screen.
+  const seenFailureNonce = useRef(saveFailureNonce);
+  useEffect(() => {
+    if (saveFailureNonce === seenFailureNonce.current) return;
+    seenFailureNonce.current = saveFailureNonce;
+    if (!queuedWhenQuiet) return;
+    setQueuedWhenQuiet(null);
+    showToast({ type: 'error', message: t('invoiceActions.issueCanceledSaveFailed') });
+  }, [saveFailureNonce, queuedWhenQuiet, t]);
+
+  // Fire the queued Issue action once the editor reports quiescence. Plain
+  // Issue runs directly (it's reversible via Void); Issue & Send opens its
+  // confirm dialog — the user still confirms the email before anything sends.
+  useEffect(() => {
+    if (!queuedWhenQuiet || savePending) return;
+    const queued = queuedWhenQuiet;
+    setQueuedWhenQuiet(null);
+    if (queued === 'issue') void issue(false);
+    else setIssueSendOpen(true);
+  }, [queuedWhenQuiet, savePending, issue]);
+
+  // Slow-save backstop: with failures handled by the nonce above, the only way
+  // a queue waits this long is a save that is genuinely still in flight (or a
+  // pending-state bug). Drop the queued action after a bounded wait with an
+  // honest "still saving" explanation — never claim a failure we didn't see.
+  // Cleared automatically when quiescence fires the queue.
+  useEffect(() => {
+    if (!queuedWhenQuiet) return;
+    const timer = setTimeout(() => {
+      setQueuedWhenQuiet(null);
+      showToast({ type: 'warning', message: t('invoiceActions.issueCanceledStillSaving') });
+    }, 15_000);
+    return () => clearTimeout(timer);
+  }, [queuedWhenQuiet, t]);
 
   const remove = useCallback(async () => {
     if (deleting) return;
@@ -146,25 +204,65 @@ export default function InvoiceActions({ detail, onChanged, variant }: Props) {
           <>
             <button
               type="button"
-              onClick={() => void issue(false)}
+              onClick={() => {
+                if (savePending) { onIssueWhilePending?.(); setQueuedWhenQuiet('issue'); return; }
+                void issue(false);
+              }}
               disabled={issueDisabled}
-              aria-describedby={!hasVisibleLines ? `invoice-no-visible-hint-${variant}` : undefined}
-              title={!hasVisibleLines ? t('invoiceActions.noVisibleLineHint') : undefined}
+              aria-describedby={
+                !hasVisibleLines ? `invoice-no-visible-hint-${variant}`
+                  : savePending ? `invoice-issue-saving-hint-${variant}`
+                  : undefined
+              }
+              title={
+                !hasVisibleLines ? t('invoiceActions.noVisibleLineHint')
+                  : savePending ? t('invoiceActions.savingTitle')
+                  : undefined
+              }
               data-testid="invoice-issue"
-              className={`${btnBase} border hover:bg-muted disabled:opacity-50`}
+              className={`${btnBase} relative border hover:bg-muted disabled:opacity-50`}
             >
-              {issuing ? t('invoiceActions.issuing') : t('invoiceActions.issue')}
+              {/* Spinner = a promise of forthcoming completion, so it renders
+                  only while something WILL complete: an in-flight issue or a
+                  queued click awaiting quiescence. Plain savePending (a dirty
+                  field, maybe one whose save failed and stays dirty by design)
+                  gets the static hint below, never an infinite spinner. */}
+              {(issuing || queuedWhenQuiet !== null) && (
+                <Loader2 className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 animate-spin" aria-hidden="true" />
+              )}
+              <span className={issuing || queuedWhenQuiet !== null ? 'opacity-30' : ''}>
+                {issuing ? t('invoiceActions.issuing') : t('invoiceActions.issue')}
+              </span>
             </button>
             <button
               type="button"
-              onClick={() => setIssueSendOpen(true)}
+              onClick={() => {
+                if (savePending) { onIssueWhilePending?.(); setQueuedWhenQuiet('issueSend'); return; }
+                setIssueSendOpen(true);
+              }}
               disabled={issueDisabled}
-              aria-describedby={!hasVisibleLines ? `invoice-no-visible-hint-${variant}` : undefined}
-              title={!hasVisibleLines ? t('invoiceActions.noVisibleLineHint') : undefined}
+              aria-describedby={
+                !hasVisibleLines ? `invoice-no-visible-hint-${variant}`
+                  : savePending ? `invoice-issue-saving-hint-${variant}`
+                  : undefined
+              }
+              title={
+                !hasVisibleLines ? t('invoiceActions.noVisibleLineHint')
+                  : savePending ? t('invoiceActions.savingTitle')
+                  : undefined
+              }
               data-testid="invoice-issue-send"
-              className={`${btnBase} bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50`}
+              className={`${btnBase} relative bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50`}
             >
-              {issuing ? t('invoiceActions.issuing') : t('invoiceActions.issueAndSend')}
+              {/* Overlay spinner while a queued click settles or the issue is in
+                  flight; the label always defines the button's size (mirrors the
+                  quote Send button). See the spinner note on plain Issue above. */}
+              {(issuing || queuedWhenQuiet !== null) && (
+                <Loader2 className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 animate-spin" aria-hidden="true" />
+              )}
+              <span className={issuing || queuedWhenQuiet !== null ? 'opacity-30' : ''}>
+                {issuing ? t('invoiceActions.issuing') : t('invoiceActions.issueAndSend')}
+              </span>
             </button>
           </>
         )}
@@ -201,6 +299,17 @@ export default function InvoiceActions({ detail, onChanged, variant }: Props) {
             className={header ? 'basis-full text-xs text-muted-foreground text-right' : 'text-center text-xs text-muted-foreground'}
           >
             {t('invoiceActions.noVisibleLineHint')}
+          </p>
+        )}
+        {canIssue && hasVisibleLines && savePending && (
+          // Same placement rules as the no-visible-lines hint above: the user must
+          // be able to SEE why the money-buttons are held, not just hover for it.
+          <p
+            id={`invoice-issue-saving-hint-${variant}`}
+            data-testid="invoice-issue-saving-hint"
+            className={header ? 'basis-full text-xs text-muted-foreground text-right' : 'text-center text-xs text-muted-foreground'}
+          >
+            {t('invoiceActions.savingHint')}
           </p>
         )}
       </div>

--- a/apps/web/src/components/billing/InvoiceActions.tsx
+++ b/apps/web/src/components/billing/InvoiceActions.tsx
@@ -136,6 +136,14 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
     }
   }, [issuing, invoice.id, refresh, t]);
 
+  // Refuse a click (or a queued click reaching quiescence) that can only ever
+  // wait on a save that isn't coming — name the field instead. Hoisted above
+  // the queue effect so both the immediate-click refusal and the queue's
+  // re-check share one toast/message.
+  const refuseForUnsaved = useCallback(() => {
+    showToast({ type: 'warning', message: t('invoiceActions.issueBlockedUnsaved', { field: unsavedFieldLabel }) });
+  }, [unsavedFieldLabel, t]);
+
   // One effect resolves the queue, in strict priority: failed → cancel;
   // still working → keep waiting; preconditions lapsed → refuse; otherwise fire.
   //
@@ -157,6 +165,16 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
     }
     if (savePending) return;
     setQueued(null);
+    // The unsaved-field refusal is re-checked here too: the click gate tests
+    // savePending FIRST, so a click during a deferred delete queues even while
+    // an earlier failed save (nonce already captured at click time — no new
+    // bump is coming) keeps a field dirty. Quiescence cannot clear that field,
+    // so firing would issue the invoice at the pre-edit money. Refuse and name
+    // the field, exactly as an immediate click would have.
+    if (unsavedFieldLabel) {
+      refuseForUnsaved();
+      return;
+    }
     // The button's own gate is re-checked here: the queue can outlive it. The
     // last customer-visible line may have been sitting in its undo window, and
     // the flush this very click triggered is what deleted it for good.
@@ -168,7 +186,7 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
     // its confirm dialog — the user still confirms the email before it sends.
     if (queued.kind === 'issue') void issue(false);
     else setIssueSendOpen(true);
-  }, [queued, saveFailureNonce, savePending, hasVisibleLines, issue, t]);
+  }, [queued, saveFailureNonce, savePending, unsavedFieldLabel, refuseForUnsaved, hasVisibleLines, issue, t]);
 
   // Slow-save backstop: with failures handled above, the only way a queue waits
   // this long is a save that is genuinely still in flight (or a pending-state
@@ -224,10 +242,6 @@ export default function InvoiceActions({ detail, onChanged, variant, savePending
   // names the field. Order matters: a field mid-save is dirty AND in flight.
   const heldReason: 'saving' | 'unsaved' | null = savePending ? 'saving' : unsavedFieldLabel ? 'unsaved' : null;
   const heldHintId = `invoice-issue-held-hint-${variant}`;
-  // Refuse a click that can only ever wait on a save that isn't coming.
-  const refuseForUnsaved = () => {
-    showToast({ type: 'warning', message: t('invoiceActions.issueBlockedUnsaved', { field: unsavedFieldLabel }) });
-  };
 
   return (
     <>

--- a/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
@@ -63,6 +63,10 @@ const stripePayment = {
 beforeEach(() => {
   vi.clearAllMocks();
   state.permissions = [];
+  // Pre-enable the persisted cost/margin preference so margin visibility below
+  // is decided purely by the permission gate under test, not the toggle default.
+  localStorage.clear();
+  localStorage.setItem('breeze:quote-editor-show-margin', '1');
   fetchMock.mockImplementation(async (input: string) => {
     if (input.endsWith('/payments')) return json({ data: [stripePayment] });
     return json({ data: {} });
@@ -83,7 +87,9 @@ describe('InvoiceDetail — permission gating', () => {
     expect(screen.queryByTestId('invoice-payment-void-p1')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-payment-form')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoice-payment-submit')).not.toBeInTheDocument();
-    // But cost/margin IS a read affordance — invoices:read sees the margin panel.
+    // But cost/margin IS a read affordance — invoices:read sees the margin panel
+    // (with the persisted internal-view preference on) and its toggle.
+    expect(screen.getByTestId('invoice-detail-toggle-margin')).toBeInTheDocument();
     expect(screen.getByTestId('invoice-margin')).toBeInTheDocument();
   });
 

--- a/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.permissions.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import InvoiceDetail from './InvoiceDetail';
 import type { InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
 import { fetchWithAuth } from '../../stores/auth';
+import { _resetShowMarginMemoryForTests } from './billingUi';
 
 type Perm = { resource: string; action: string };
 
@@ -66,6 +67,10 @@ beforeEach(() => {
   // Pre-enable the persisted cost/margin preference so margin visibility below
   // is decided purely by the permission gate under test, not the toggle default.
   localStorage.clear();
+  // The memory mirror deliberately outlives localStorage.clear(), so a suite
+  // that ever clicks a MarginToggle would leak the preference into its
+  // neighbours without this.
+  _resetShowMarginMemoryForTests();
   localStorage.setItem('breeze:quote-editor-show-margin', '1');
   fetchMock.mockImplementation(async (input: string) => {
     if (input.endsWith('/payments')) return json({ data: [stripePayment] });

--- a/apps/web/src/components/billing/InvoiceDetail.test.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import InvoiceDetail from './InvoiceDetail';
 import type { InvoiceDetail as InvoiceDetailData } from './invoiceTypes';
+import { _resetShowMarginMemoryForTests } from './billingUi';
 import { fetchWithAuth } from '../../stores/auth';
 
 vi.mock('../../stores/auth', () => ({
@@ -50,30 +51,42 @@ const issued: InvoiceDetailData = {
 describe('InvoiceDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The cost/margin toggle persists to localStorage (plus an in-memory
+    // mirror that survives storage clears) — reset both so each test starts
+    // from the default (internal view OFF).
+    localStorage.clear();
+    _resetShowMarginMemoryForTests();
     fetchMock.mockImplementation(async (input: string) => {
       if (input.endsWith('/payments')) return json({ data: [] });
       return json({ data: {} });
     });
   });
 
-  it('hides cost/margin and hidden components until accounting view is on', async () => {
+  it('hides cost/margin, hidden components and the margin panel until the internal view is on — and persists the choice', async () => {
     render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
 
-    // Customer view: hidden bundle child not rendered, no per-line cost/margin
-    // columns. (Scoped to the table headers — the internal margin summary panel
-    // carries its own "Cost" label and is always visible to readers.)
+    // Customer view (default): hidden bundle child not rendered, no per-line
+    // cost/margin columns, and no margin summary panel — "no margin on screen"
+    // is the default until the operator opts in.
     expect(screen.queryByTestId('invoice-detail-line-l2')).not.toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Cost' })).not.toBeInTheDocument();
     expect(screen.queryByRole('columnheader', { name: 'Margin' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-margin')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('invoice-accounting-toggle'));
+    fireEvent.click(screen.getByTestId('invoice-detail-toggle-margin'));
     expect(screen.getByTestId('invoice-detail-line-l2')).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Cost' })).toBeInTheDocument();
     expect(screen.getByRole('columnheader', { name: 'Margin' })).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-margin')).toBeInTheDocument();
+    // The preference persists under the SAME key the quote surfaces use, so
+    // "hide cost & margin" holds across the whole billing area.
+    expect(localStorage.getItem('breeze:quote-editor-show-margin')).toBe('1');
   });
 
   it('renders the internal margin summary (billed-only, one-time, excludes tax)', async () => {
+    // Internal view pre-enabled via the persisted preference.
+    localStorage.setItem('breeze:quote-editor-show-margin', '1');
     render(<InvoiceDetail detail={issued} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
 
@@ -103,6 +116,7 @@ describe('InvoiceDetail', () => {
         { ...lines[1], id: 'c1', parentLineId: 'p1', costBasis: '10.00', revenueAllocation: '40.00', customerVisible: true, quantity: '1.00', unitPrice: '0.00', lineTotal: '0.00' },
       ],
     };
+    localStorage.setItem('breeze:quote-editor-show-margin', '1');
     render(<InvoiceDetail detail={bundle} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
     expect(screen.getByTestId('invoice-margin-cost')).toHaveTextContent('$80.00');
@@ -115,6 +129,7 @@ describe('InvoiceDetail', () => {
       ...issued,
       lines: [{ ...lines[0], costBasis: null }],
     };
+    localStorage.setItem('breeze:quote-editor-show-margin', '1');
     render(<InvoiceDetail detail={noCost} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
     expect(screen.getByTestId('invoice-margin-missing-cost')).toHaveTextContent('1 line missing a cost');
@@ -201,6 +216,42 @@ describe('InvoiceDetail', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
     expect(screen.getByTestId('invoice-stripe-nudge')).toBeInTheDocument();
     expect(screen.queryByTestId('invoice-pay-link')).not.toBeInTheDocument();
+  });
+
+  it('shows a dashed empty state with an Editor CTA on an empty draft (no CTA once issued)', async () => {
+    const emptyDraft: InvoiceDetailData = {
+      ...issued,
+      invoice: { ...issued.invoice, status: 'draft', invoiceNumber: null },
+      lines: [],
+    };
+    const { rerender } = render(<InvoiceDetail detail={emptyDraft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    // No bare table header — a dashed card explains the state and routes to the
+    // Editor (mirrors QuoteDetail's empty state).
+    expect(screen.queryByTestId('invoice-detail-lines')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoice-detail-empty')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-detail-empty-edit')).toBeInTheDocument();
+
+    // Issued + empty: state renders, but the CTA is gone — there is no Editor
+    // tab to send the user to once the invoice has left draft.
+    rerender(<InvoiceDetail detail={{ ...issued, lines: [] }} onChanged={vi.fn()} />);
+    expect(screen.getByTestId('invoice-detail-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-detail-empty-edit')).not.toBeInTheDocument();
+  });
+
+  it('explains an all-internal invoice instead of rendering a bare table when the internal view is off', async () => {
+    const allHidden: InvoiceDetailData = {
+      ...issued,
+      lines: [{ ...lines[0], customerVisible: false }],
+    };
+    render(<InvoiceDetail detail={allHidden} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-detail')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-detail-all-hidden')).toBeInTheDocument();
+
+    // Turning the internal view on reveals the hidden line and drops the notice.
+    fireEvent.click(screen.getByTestId('invoice-detail-toggle-margin'));
+    expect(screen.queryByTestId('invoice-detail-all-hidden')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoice-detail-line-l1')).toBeInTheDocument();
   });
 
   it('badges Stripe payments as Online and hides manual void on them', async () => {

--- a/apps/web/src/components/billing/InvoiceDetail.tsx
+++ b/apps/web/src/components/billing/InvoiceDetail.tsx
@@ -26,7 +26,7 @@ import {
 } from './invoiceTypes';
 import { StatusPill } from './shared/StatusPill';
 import InvoiceActions from './InvoiceActions';
-import { MarginPanel } from './billingUi';
+import { MarginPanel, MarginToggle, useShowMargin } from './billingUi';
 import { computeChargeNow } from '@breeze/shared';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -50,7 +50,15 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
     : t(/* i18n-dynamic */ `invoice.status.${invoice.status}`);
   const stripeConnected = detail.stripeConnected === true;
 
-  const [accountingView, setAccountingView] = useState(false);
+  // The billing-wide persisted "internal costs on screen?" preference — the SAME
+  // key the quote editor/detail toggles write, so "hide cost & margin" holds
+  // when a screen-sharing tech moves between a quote and an invoice. It gates
+  // the cost/margin columns, the hidden (internal-only) lines, and the margin
+  // panel as one internal view (previously the margin panel rendered
+  // unconditionally for anyone with read access, and the per-line "Accounting
+  // view" checkbox was a separate, unpersisted control — so hiding margin on a
+  // quote didn't carry over here).
+  const [showMargin, toggleMargin] = useShowMargin();
   const [payments, setPayments] = useState<InvoicePayment[]>([]);
   const [paymentsError, setPaymentsError] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -96,18 +104,18 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
 
   const refresh = useCallback(() => { onChanged(); void loadPayments(); }, [onChanged, loadPayments]);
 
-  // In customer view, hide cost/margin columns and hidden bundle children.
-  const visibleLines = useMemo(
-    () => (accountingView ? lines : lines.filter((l) => l.customerVisible)),
-    [accountingView, lines],
-  );
-
   // Cost/margin is an internal read affordance, visible to anyone who can read
   // the invoice (the same read-level gate the quote rails use for `quotes:read`;
-  // cost is a read affordance, not a write one). Independent of the per-line
-  // Accounting view toggle below, which defaults off. Uses the shared cents math
+  // cost is a read affordance, not a write one). Uses the shared cents math
   // so the figure is rounded + labelled identically to a quote's.
   const canSeeMargin = can('invoices', 'read');
+  const internalView = canSeeMargin && showMargin;
+
+  // In customer view, hide cost/margin columns and hidden bundle children.
+  const visibleLines = useMemo(
+    () => (internalView ? lines : lines.filter((l) => l.customerVisible)),
+    [internalView, lines],
+  );
   const profit = useMemo(() => computeInvoiceProfit(lines), [lines]);
 
   const lineMargin = (l: InvoiceLine): string => {
@@ -302,34 +310,61 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
 
   return (
     <div className="space-y-6" data-testid="invoice-detail">
-      <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
-        {/* Lines + accounting toggle */}
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox" checked={accountingView}
-                onChange={(e) => setAccountingView(e.target.checked)}
-                data-testid="invoice-accounting-toggle"
-              />
-              {t('invoiceDetail.accountingView')}
-            </label>
-          </div>
+      {/* xl (not lg): matches the editor tab and QuoteDetail — below xl the rail
+          stacks under the content so the lines table isn't starved into sideways
+          scrolling. min-w-0 lets this 1fr track shrink below the table's content
+          width so the page doesn't scroll horizontally on a phone. */}
+      <div className="grid gap-6 xl:grid-cols-[1fr_300px]">
+        {/* Lines + internal-view toggle */}
+        <div className="min-w-0 space-y-4">
+          {canSeeMargin && lines.length > 0 && (
+            <div className="flex items-center justify-end">
+              <MarginToggle show={showMargin} onToggle={toggleMargin} testId="invoice-detail-toggle-margin" />
+            </div>
+          )}
+          {lines.length === 0 ? (
+            <div className="rounded-lg border border-dashed bg-card p-8 text-center" data-testid="invoice-detail-empty">
+              <p className="text-sm text-muted-foreground">{t('invoiceDetail.empty')}</p>
+              {invoice.status === 'draft' && can('invoices', 'write') && (
+                <button
+                  type="button"
+                  onClick={() => { if (typeof window !== 'undefined') window.location.hash = '#editor'; }}
+                  data-testid="invoice-detail-empty-edit"
+                  className="mt-3 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                >
+                  {t('invoiceDetail.addContentInEditor')}
+                </button>
+              )}
+            </div>
+          ) : (
           <div className="rounded-lg border bg-card shadow-xs">
-            <table className="w-full text-sm" data-testid="invoice-detail-lines">
+            {/* Labeled, keyboard-reachable scroll region: the internal view runs
+                to 7 columns, well past a phone viewport — scroll inside the card
+                instead of bleeding past its rounded edge (QuoteDetail pattern). */}
+            <div className="overflow-x-auto" role="region" aria-label={t('invoiceDetail.linesScrollAria')} tabIndex={0}>
+            <table className="w-full min-w-[32rem] text-sm" data-testid="invoice-detail-lines">
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="px-3 py-2 font-medium">{t('invoiceDetail.lines.description')}</th>
                   <th className="px-3 py-2 text-right font-medium">{t('invoiceDetail.lines.qty')}</th>
                   <th className="px-3 py-2 text-right font-medium">{t('invoiceDetail.lines.price')}</th>
-                  {accountingView && <th className="px-3 py-2 text-right font-medium">{t('invoiceDetail.lines.cost')}</th>}
-                  {accountingView && <th className="px-3 py-2 text-right font-medium">{t('invoiceDetail.lines.margin')}</th>}
+                  {internalView && <th className="px-3 py-2 text-right font-medium">{t('invoiceDetail.lines.cost')}</th>}
+                  {internalView && <th className="px-3 py-2 text-right font-medium">{t('invoiceDetail.lines.margin')}</th>}
                   {showTax && <th className="px-3 py-2 text-right font-medium">{t('invoiceDetail.lines.tax')}</th>}
                   <th className="px-3 py-2 text-right font-medium">{t('invoiceDetail.lines.total')}</th>
                 </tr>
               </thead>
               <tbody>
-                {visibleLines.map((l) => {
+                {visibleLines.length === 0 ? (
+                  // Lines exist but every one is internal-only and the internal
+                  // view is off — say so instead of rendering a bare header.
+                  <tr>
+                    <td colSpan={4 + (showTax ? 1 : 0)} className="px-3 py-6 text-center text-sm text-muted-foreground" data-testid="invoice-detail-all-hidden">
+                      {t('invoiceDetail.lines.allHidden')}
+                    </td>
+                  </tr>
+                ) : (
+                visibleLines.map((l) => {
                   const tax = showTax ? lineTaxAmount(l.lineTotal, l.taxable, invoice.taxRate) : null;
                   return (
                   <tr
@@ -341,24 +376,30 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
                       <span className={l.parentLineId ? '' : 'font-medium text-foreground'}>
                         {l.parentLineId ? <span aria-hidden="true">↳ </span> : ''}{lineTitle(l)}
                       </span>
-                      {accountingView && !l.customerVisible ? t('invoiceDetail.lines.hiddenMarker') : ''}
+                      {internalView && !l.customerVisible ? t('invoiceDetail.lines.hiddenMarker') : ''}
                       {lineBlurb(l) && <div className="text-xs text-muted-foreground">{lineBlurb(l)}</div>}
                     </td>
                     <td className="px-3 py-2 text-right">{l.quantity}</td>
                     <td className="px-3 py-2 text-right">{formatMoney(l.unitPrice, currency)}</td>
-                    {accountingView && <td className="px-3 py-2 text-right">{l.costBasis == null ? '—' : formatMoney(l.costBasis, currency)}</td>}
-                    {accountingView && <td className="px-3 py-2 text-right">{lineMargin(l)}</td>}
+                    {internalView && <td className="px-3 py-2 text-right">{l.costBasis == null ? '—' : formatMoney(l.costBasis, currency)}</td>}
+                    {internalView && <td className="px-3 py-2 text-right">{lineMargin(l)}</td>}
                     {showTax && <td className="px-3 py-2 text-right text-muted-foreground">{tax === null ? '—' : formatMoney(tax, currency)}</td>}
                     <td className="px-3 py-2 text-right">{formatMoney(l.lineTotal, currency)}</td>
                   </tr>
                   );
-                })}
+                })
+                )}
               </tbody>
             </table>
+            </div>
           </div>
+          )}
         </div>
 
-        {/* Right rail: summary + payments + actions */}
+        {/* Right rail: summary + payments + actions. The summary card keeps the
+            shadow and the large Balance-Due figure so it reads as the anchor; the
+            surrounding from/terms/payments cards are flatter (border only) so the
+            rail isn't a stack of equal-weight boxes (mirrors QuoteDetail). */}
         <div className="space-y-4">
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-detail-summary">
             <div className="mb-3 flex items-center justify-between">
@@ -440,13 +481,15 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
             )}
             {/* Internal margin summary — profitability stays visible after the
                 invoice is issued and the Editor tab disappears (same reason
-                QuoteDetail renders it). Never reaches the customer document. */}
-            {canSeeMargin && <MarginPanel profit={profit} currency={currency} idPrefix="invoice" />}
+                QuoteDetail renders it). Never reaches the customer document.
+                Gated on the SAME persisted toggle as the cost/margin columns so
+                "hide cost & margin" holds across the whole surface. */}
+            {internalView && <MarginPanel profit={profit} currency={currency} idPrefix="invoice" />}
           </div>
 
           {/* Seller From block */}
           {invoice.sellerSnapshot && (
-            <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-detail-from">
+            <div className="rounded-lg border bg-card p-4" data-testid="invoice-detail-from">
               <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('invoiceDetail.from')}</h3>
               <div className="space-y-0.5 text-sm">
                 {invoice.sellerSnapshot.name && (
@@ -470,7 +513,7 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
 
           {/* Terms & Conditions */}
           {invoice.termsAndConditions && (
-            <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-detail-terms">
+            <div className="rounded-lg border bg-card p-4" data-testid="invoice-detail-terms">
               <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('invoiceDetail.terms')}</h3>
               <p className="whitespace-pre-wrap text-sm text-muted-foreground">{invoice.termsAndConditions}</p>
             </div>
@@ -505,7 +548,7 @@ export default function InvoiceDetail({ detail, onChanged, actionsInHeader = fal
           </div>
 
           {/* Payments */}
-          <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-payments">
+          <div className="rounded-lg border bg-card p-4" data-testid="invoice-payments">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('invoiceDetail.payments.title')}</h3>
             {paymentsError ? (
               <p className="text-sm text-destructive" data-testid="invoice-payments-error">

--- a/apps/web/src/components/billing/InvoiceEditor.lastsaved.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.lastsaved.test.tsx
@@ -95,7 +95,7 @@ describe('InvoiceEditor — autosave hint + last-saved indicator', () => {
     expect(screen.queryByTestId('invoice-editor-last-saved')).not.toBeInTheDocument();
   });
 
-  it('reports pending edits to the workspace: true while dirty/in-flight, false once settled and on unmount', async () => {
+  it('reports pending edits to the workspace: true only while a save is IN FLIGHT, false once settled and on unmount', async () => {
     let resolvePatch!: (v: Response) => void;
     const patchPromise = new Promise<Response>((resolve) => { resolvePatch = resolve; });
     fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
@@ -109,15 +109,18 @@ describe('InvoiceEditor — autosave hint + last-saved indicator', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
     expect(onPending).toHaveBeenLastCalledWith(false);
 
-    // Typing makes the notes field dirty — pending flips true immediately (the
-    // Issue gate must hold from the first keystroke, not from blur).
+    // Typing alone is NOT "pending". Pending means a request is on its way and
+    // will resolve; a dirty field makes no such promise, and reporting it here
+    // is what let a failed save keep claiming "Saving changes…" forever. The
+    // Issue gate still holds from the first keystroke, because the click itself
+    // blurs the field and the resulting save lands in `pending` first.
     const textarea = screen.getByTestId('invoice-notes');
     fireEvent.change(textarea, { target: { value: 'Edited' } });
-    await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(true));
+    expect(onPending).toHaveBeenLastCalledWith(false);
 
-    // Blur starts the save; while the PATCH is in flight it stays pending.
+    // Blur starts the save; while the PATCH is in flight it IS pending.
     fireEvent.blur(textarea);
-    expect(onPending).toHaveBeenLastCalledWith(true);
+    await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(true));
 
     resolvePatch(json({ data: {} }));
     await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(false));
@@ -126,5 +129,46 @@ describe('InvoiceEditor — autosave hint + last-saved indicator', () => {
     onPending.mockClear();
     unmount();
     expect(onPending).toHaveBeenLastCalledWith(false);
+  });
+
+  it('reports a FAILED save as an unsaved field, not as pending — and clears it when the retry succeeds', async () => {
+    // The bug this pins: a failed notes PATCH left notesDirty true forever, so
+    // the header showed "Saving changes… Issue unlocks when everything is
+    // saved" over a save that had already given up. Pending must go false (no
+    // request is coming) while the field is named as unsaved instead.
+    let failNext = true;
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') {
+        if (failNext) return json({ error: 'boom' }, false, 500);
+        return json({ data: {} });
+      }
+      return json({ data: {} });
+    });
+    const onPending = vi.fn();
+    const onUnsaved = vi.fn();
+
+    render(
+      <InvoiceEditor
+        detail={draft()}
+        onChanged={vi.fn()}
+        onPendingEditsChange={onPending}
+        onUnsavedEditsChange={onUnsaved}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('invoice-notes');
+    fireEvent.change(textarea, { target: { value: 'Edited' } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => expect(onUnsaved).toHaveBeenLastCalledWith('Notes'));
+    expect(onPending).toHaveBeenLastCalledWith(false);
+
+    // Retrying the same field succeeds → the block lifts.
+    failNext = false;
+    fireEvent.change(textarea, { target: { value: 'Edited again' } });
+    fireEvent.blur(textarea);
+    await waitFor(() => expect(onUnsaved).toHaveBeenLastCalledWith(null));
   });
 });

--- a/apps/web/src/components/billing/InvoiceEditor.lastsaved.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.lastsaved.test.tsx
@@ -1,0 +1,130 @@
+// The quiet "Saving…" / "Saved 2:41 PM" sync indicator near the autosave hint
+// (InvoiceEditor.tsx — the quote editor's save-language, normalized onto
+// invoices). Uses the notes-field PATCH as the mutation under test — same
+// runScoped path every other editor mutation goes through. Also pins the
+// onPendingEditsChange contract the workspace's Issue gating relies on.
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceEditor from './InvoiceEditor';
+import type { InvoiceDetail } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../shared/Toast', () => ({ showToast: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function draft(): InvoiceDetail {
+  return {
+    invoice: {
+      id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', amountPaid: '0.00', balance: '0.00', billToName: 'Acme',
+      notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
+    },
+    lines: [],
+  };
+}
+
+describe('InvoiceEditor — autosave hint + last-saved indicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      return json({ data: {} });
+    });
+  });
+
+  it('is absent before any save, shows "Saving…" while the mutation is in flight, then "Saved <time>" once it settles', async () => {
+    let resolvePatch!: (v: Response) => void;
+    const patchPromise = new Promise<Response>((resolve) => { resolvePatch = resolve; });
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') return patchPromise;
+      return json({ data: {} });
+    });
+
+    render(<InvoiceEditor detail={draft()} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    // The autosave hint renders for writers from the start…
+    expect(screen.getByTestId('invoice-editor-autosave-hint')).toBeInTheDocument();
+    // …but nothing has saved yet this session — the indicator renders nothing at
+    // all (never an empty "Saved" line) rather than blocking anything.
+    expect(screen.queryByTestId('invoice-editor-last-saved')).not.toBeInTheDocument();
+
+    const textarea = screen.getByTestId('invoice-notes');
+    fireEvent.change(textarea, { target: { value: 'Thanks for your business' } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => expect(screen.getByTestId('invoice-editor-last-saved')).toHaveTextContent('Saving'));
+
+    resolvePatch(json({ data: {} }));
+
+    await waitFor(() => expect(screen.getByTestId('invoice-editor-last-saved')).toHaveTextContent(/Saved/));
+    expect(screen.getByTestId('invoice-editor-last-saved')).not.toHaveTextContent('Saving');
+  });
+
+  it('does NOT stamp "Saved" when the save fails — the indicator must never lie on a money document', async () => {
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') return json({ error: { message: 'boom' } }, false, 500);
+      return json({ data: {} });
+    });
+    const onSaveFailure = vi.fn();
+    render(<InvoiceEditor detail={draft()} onChanged={vi.fn()} onSaveFailure={onSaveFailure} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('invoice-notes');
+    fireEvent.change(textarea, { target: { value: 'Doomed edit' } });
+    fireEvent.blur(textarea);
+
+    await waitFor(() => expect(onSaveFailure).toHaveBeenCalled());
+    // No successful save this session → no "Saved <time>" line at all.
+    expect(screen.queryByTestId('invoice-editor-last-saved')).not.toBeInTheDocument();
+  });
+
+  it('reports pending edits to the workspace: true while dirty/in-flight, false once settled and on unmount', async () => {
+    let resolvePatch!: (v: Response) => void;
+    const patchPromise = new Promise<Response>((resolve) => { resolvePatch = resolve; });
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') return patchPromise;
+      return json({ data: {} });
+    });
+    const onPending = vi.fn();
+
+    const { unmount } = render(<InvoiceEditor detail={draft()} onChanged={vi.fn()} onPendingEditsChange={onPending} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+    expect(onPending).toHaveBeenLastCalledWith(false);
+
+    // Typing makes the notes field dirty — pending flips true immediately (the
+    // Issue gate must hold from the first keystroke, not from blur).
+    const textarea = screen.getByTestId('invoice-notes');
+    fireEvent.change(textarea, { target: { value: 'Edited' } });
+    await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(true));
+
+    // Blur starts the save; while the PATCH is in flight it stays pending.
+    fireEvent.blur(textarea);
+    expect(onPending).toHaveBeenLastCalledWith(true);
+
+    resolvePatch(json({ data: {} }));
+    await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(false));
+
+    // Unmount clears the flag so a stale `true` can't lock the header actions.
+    onPending.mockClear();
+    unmount();
+    expect(onPending).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import InvoiceEditor from './InvoiceEditor';
 import type { InvoiceDetail } from './invoiceTypes';
 import { fetchWithAuth } from '../../stores/auth';
+import { _resetShowMarginMemoryForTests } from './billingUi';
 
 type Perm = { resource: string; action: string };
 
@@ -53,6 +54,10 @@ beforeEach(() => {
   // Pre-enable the persisted cost/margin preference so margin visibility below
   // is decided purely by the permission gate under test, not the toggle default.
   localStorage.clear();
+  // The memory mirror deliberately outlives localStorage.clear(), so a suite
+  // that ever clicks a MarginToggle would leak the preference into its
+  // neighbours without this.
+  _resetShowMarginMemoryForTests();
   localStorage.setItem('breeze:quote-editor-show-margin', '1');
   fetchMock.mockImplementation(async (input: string) => {
     if (input.startsWith('/catalog')) return json({ data: [] });

--- a/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.permissions.test.tsx
@@ -50,6 +50,10 @@ const draft: InvoiceDetail = {
 beforeEach(() => {
   vi.clearAllMocks();
   state.permissions = [];
+  // Pre-enable the persisted cost/margin preference so margin visibility below
+  // is decided purely by the permission gate under test, not the toggle default.
+  localStorage.clear();
+  localStorage.setItem('breeze:quote-editor-show-margin', '1');
   fetchMock.mockImplementation(async (input: string) => {
     if (input.startsWith('/catalog')) return json({ data: [] });
     return json({ data: {} });

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -46,6 +46,9 @@ const manualLine: InvoiceDetail['lines'][number] = {
 describe('InvoiceEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Margin visibility persists to localStorage — start each test from the
+    // default (hidden); tests that need the panel opt in explicitly.
+    localStorage.clear();
     fetchMock.mockImplementation(async (input: string) => {
       if (input.startsWith('/catalog')) return json({ data: [] });
       return json({ data: {} });
@@ -130,6 +133,9 @@ describe('InvoiceEditor', () => {
   });
 
   it('renders the internal margin summary from line costs', async () => {
+    // The panel honors the billing-wide persisted "show cost & margin"
+    // preference — pre-enable it (default is hidden).
+    localStorage.setItem('breeze:quote-editor-show-margin', '1');
     const costedLine = { ...manualLine, id: 'line-c', costBasis: '30.00', quantity: '2.00', unitPrice: '50.00', lineTotal: '100.00' };
     render(<InvoiceEditor detail={draft([costedLine])} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
@@ -141,6 +147,7 @@ describe('InvoiceEditor', () => {
   });
 
   it('flags a missing cost in the margin summary', async () => {
+    localStorage.setItem('breeze:quote-editor-show-margin', '1');
     // manualLine has costBasis null → excluded from net and counted as missing.
     render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());

--- a/apps/web/src/components/billing/InvoiceEditor.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import InvoiceEditor from './InvoiceEditor';
 import type { InvoiceDetail } from './invoiceTypes';
 import { fetchWithAuth } from '../../stores/auth';
+import { _resetShowMarginMemoryForTests } from './billingUi';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -49,6 +50,10 @@ describe('InvoiceEditor', () => {
     // Margin visibility persists to localStorage — start each test from the
     // default (hidden); tests that need the panel opt in explicitly.
     localStorage.clear();
+    // The memory mirror deliberately outlives localStorage.clear(), so a suite
+    // that ever clicks a MarginToggle would leak the preference into its
+    // neighbours without this.
+    _resetShowMarginMemoryForTests();
     fetchMock.mockImplementation(async (input: string) => {
       if (input.startsWith('/catalog')) return json({ data: [] });
       return json({ data: {} });
@@ -354,5 +359,62 @@ describe('InvoiceEditor', () => {
       });
     });
     expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success', message: 'Terms saved' }));
+  });
+
+  it('tells "catalog is empty" apart from "catalog failed to load", and offers a retry', async () => {
+    // Rendering the empty state on a failed load sends a tech off to re-create
+    // items that already exist — and the rejection used to be voided entirely,
+    // so there was no toast either.
+    let fail = true;
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/catalog')) {
+        // A 200 with an unparseable body — the shape a proxy/truncation
+        // produces, and the one an `!res.ok` check alone sails straight past.
+        if (fail) return ({ ok: true, status: 200, statusText: 'OK', json: () => Promise.reject(new Error('bad json')) }) as unknown as Response;
+        return json({ data: [{ id: 'cat-1', name: 'Widget', unitPrice: '10.00', isBundle: false }] });
+      }
+      return json({ data: {} });
+    });
+    render(<InvoiceEditor detail={draft([])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-catalog-error')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-catalog-empty')).not.toBeInTheDocument();
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+
+    fail = false;
+    fireEvent.click(screen.getByTestId('invoice-catalog-retry'));
+    await waitFor(() => expect(screen.getByTestId('invoice-catalog-picker')).toBeInTheDocument());
+    expect(screen.queryByTestId('invoice-catalog-error')).not.toBeInTheDocument();
+  });
+
+  it('namespaces its unsaved-hint ids with the invoice prefix so quote ids cannot collide', async () => {
+    // unsavedHintId takes three same-typed strings and the invoice side hand
+    // types the prefix at every call site, so a swap or a typo compiles fine.
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    const qty = screen.getByTestId('invoice-line-qty-line-1');
+    fireEvent.change(qty, { target: { value: '7' } });
+
+    await waitFor(() => expect(document.getElementById('invoice-line-qty-unsaved-line-1')).toBeInTheDocument());
+    expect(qty.getAttribute('aria-describedby')).toContain('invoice-line-qty-unsaved-line-1');
+    // The quote namespace must be untouched by the invoice editor.
+    expect(document.getElementById('quote-line-qty-unsaved-line-1')).toBeNull();
+  });
+
+  it('does not stamp "Saved" when an add-line entry fails validation', async () => {
+    // Validation early-returns used to run INSIDE runScoped, where a plain
+    // `return` is indistinguishable from a completed save — so a rejected
+    // quantity produced an error toast AND a fresh "Saved 3:14 PM".
+    render(<InvoiceEditor detail={draft([])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-add-mode-manual'));
+    fireEvent.change(screen.getByTestId('invoice-manual-desc'), { target: { value: 'Thing' } });
+    fireEvent.change(screen.getByTestId('invoice-manual-qty'), { target: { value: 'abc' } });
+    fireEvent.click(screen.getByTestId('invoice-add-line-submit'));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith('/lines') && (c[1] as RequestInit)?.method === 'POST')).toBe(false);
+    expect(screen.queryByTestId('invoice-editor-last-saved')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -5,7 +5,10 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { usePermissions } from '../../lib/permissions';
-import { UnsavedBadge, MarginPanel } from './billingUi';
+import { formatTime } from '../../lib/dateTimeFormat';
+import { showToast } from '../shared/Toast';
+import { UnsavedBadge, MarginPanel, useShowMargin } from './billingUi';
+import { useSavedFlash, SrSaved, fieldRing, unsavedHintId, UnsavedFieldHint } from './shared/saveCues';
 import {
   type InvoiceDetail,
   type InvoiceLine,
@@ -23,52 +26,82 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 interface Props {
   detail: InvoiceDetail;
   onChanged: () => void;
+  /** Reports "is anything still saving / sitting dirty?" to the workspace so
+   *  the header's Issue buttons can wait for quiescence instead of issuing an
+   *  invoice that's missing a just-typed edit (mirrors the quote editor). */
+  onPendingEditsChange?: (hasPendingEdits: boolean) => void;
+  /** Reports every save FAILURE. Quiescence alone is not a safe Issue signal:
+   *  a failed delete-flush restores its rows and a failed line blur-save
+   *  clears its in-flight key, both of which read as "quiet" — the workspace
+   *  forwards this to InvoiceActions so a queued Issue is canceled instead. */
+  onSaveFailure?: () => void;
+  /** Registers a "flush deferred deletions NOW" hook with the workspace, so a
+   *  held Issue fires as soon as the deferred DELETE lands instead of waiting
+   *  out the undo grace window (mirrors the quote editor's Send bridge). */
+  onRegisterPendingDeleteFlush?: (flush: (() => void) | null) => void;
+  /** Controlled cost/margin visibility from the workspace's header toggle;
+   *  standalone mounts (tests) fall back to the shared persisted hook. */
+  showMargin?: boolean;
 }
 
 type AddMode = 'catalog' | 'manual';
 
-// ── Save-grammar helpers (byte-similar local copies of QuoteEditor's — kept
-//    inline per CLAUDE.md; a later pass may extract them to shared/). ─────────
+// Grace window for undo-able line deletion: the line leaves the UI instantly,
+// but the DELETE fires only after this window (or on Issue/unmount/page-hide),
+// so a fat-fingered Remove on a money document is recoverable.
+const UNDO_GRACE_MS = 6000;
 
-// A transient "Saved" cue for a blur-to-save field. Returns the on-flag (drives
-// the SR live region + green ring) and a trigger; clears its timer on unmount so
-// a late fire can't setState a gone node.
-function useSavedFlash(): [boolean, () => void] {
-  const [on, setOn] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
-  const flash = useCallback(() => {
-    setOn(true);
-    if (timer.current) clearTimeout(timer.current);
-    timer.current = setTimeout(() => setOn(false), 1500);
-  }, []);
-  return [on, flash];
-}
+/** One deferred line deletion awaiting its grace window. `memberIds` includes
+ *  bundle children — the server FK-cascades them, so they hide and restore as
+ *  one unit with their parent. */
+type PendingDelete = { id: string; memberIds: string[]; timer: ReturnType<typeof setTimeout> };
 
-// Visually-hidden polite live region — announces a transient "Saved" to screen
-// readers, pairing with the dirty-ring clearing that sighted users see. The
-// single per-field announcer (no toast) so SR users hear "Saved" once.
-function SrSaved({ show, label, testId }: { show: boolean; label: string; testId?: string }) {
-  // role="status" already implies aria-live="polite" — don't double it.
-  return <span role="status" className="sr-only" data-testid={testId}>{show ? label : ''}</span>;
-}
-
-// A field's save-state outline: amber while unsaved, a brief green pulse when it
-// lands, nothing at rest. It's a box-shadow (ring), so it never reflows
-// neighbours. Pair with a constant `transition-shadow` on the field.
-function fieldRing(dirty: boolean, saved: boolean): string {
-  return dirty ? 'ring-1 ring-warning' : saved ? 'ring-1 ring-success' : '';
-}
-
-export default function InvoiceEditor({ detail, onChanged }: Props) {
+export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange, onSaveFailure, onRegisterPendingDeleteFlush, showMargin }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const canWrite = can('invoices', 'write');
   // Cost/margin is a read affordance (mirrors InvoiceDetail + the quote rails'
-  // `quotes:read` gate) — anyone who can read the invoice sees it.
+  // `quotes:read` gate) — anyone who can read the invoice sees it, but ONLY
+  // while the persisted "show cost & margin" preference is on: the margin panel
+  // must honor "no margin on screen" here exactly as it does on every quote
+  // surface (a screen-sharing tech who hid margin on a quote must not have it
+  // reappear the moment a draft invoice opens).
   const canSeeMargin = can('invoices', 'read');
-  const { invoice, lines } = detail;
+  const [fallbackShowMargin] = useShowMargin();
+  const effectiveShowMargin = showMargin ?? fallbackShowMargin;
+  const { invoice, lines: serverLines } = detail;
   const currency = invoice.currencyCode;
+
+  // ---- undo-able deletion (deferred DELETE + grace window) -----------------
+  // Confirming a line removal hides it here and starts a grace timer; the real
+  // DELETE fires when the timer lapses, on Issue (via the workspace flush
+  // bridge), on unmount, or on page-hide — never lost, always undoable inside
+  // the window. Mirrors the quote editor's model.
+  const pendingDeleteEntries = useRef<Map<string, PendingDelete>>(new Map());
+  // Two hidden-row sets with different contracts: `pending` rows await their
+  // DELETE (they block Issue via hasPendingEdits and can still be undone);
+  // `flushed` rows' DELETE already SUCCEEDED, so they stay hidden but must NOT
+  // hold Issue — coupling their clearance to the refetch would let one failed
+  // quiet reload brick the Issue buttons over a deletion that actually landed.
+  const [pendingDeletedLineIds, setPendingDeletedLineIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [flushedDeletedLineIds, setFlushedDeletedLineIds] = useState<ReadonlySet<string>>(() => new Set());
+  const lines = useMemo(
+    () => serverLines.filter((l) => !pendingDeletedLineIds.has(l.id) && !flushedDeletedLineIds.has(l.id)),
+    [serverLines, pendingDeletedLineIds, flushedDeletedLineIds],
+  );
+  // Retire hidden ids once the refetch actually drops the rows, so the sets
+  // can't grow stale entries across reloads.
+  useEffect(() => {
+    const present = new Set(serverLines.map((l) => l.id));
+    const trim = (s: ReadonlySet<string>): ReadonlySet<string> => {
+      if (s.size === 0) return s;
+      const n = new Set([...s].filter((id) => present.has(id)));
+      return n.size === s.size ? s : n;
+    };
+    setPendingDeletedLineIds(trim);
+    setFlushedDeletedLineIds(trim);
+  }, [serverLines]);
+
   const profit = useMemo(() => computeInvoiceProfit(lines), [lines]);
 
   // Per-item "saving" state, keyed so one in-flight mutation never freezes the
@@ -79,6 +112,10 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const inFlight = useRef<Set<string>>(new Set());
   const [pending, setPending] = useState<ReadonlySet<string>>(() => new Set());
   const isPending = useCallback((key: string) => pending.has(key), [pending]);
+  // Timestamp of the last successful mutation, for the quiet "Saved 2:41 PM"
+  // indicator near the autosave hint — null until this session's first save
+  // (nothing to report before that; the indicator itself stays unrendered).
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
 
   // Run a scoped mutation: mark the key pending, run, surface failures via the
   // standard handleActionError path, and always clear the key. Returns whether
@@ -90,16 +127,18 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
       setPending((s) => { const n = new Set(s); n.add(key); return n; });
       try {
         await fn();
+        setLastSavedAt(Date.now());
         return true;
       } catch (err) {
         handleActionError(err, errMsg);
+        onSaveFailure?.();
         return false;
       } finally {
         inFlight.current.delete(key);
         setPending((s) => { const n = new Set(s); n.delete(key); return n; });
       }
     },
-    [],
+    [onSaveFailure],
   );
 
   const [notes, setNotes] = useState(invoice.notes ?? '');
@@ -108,6 +147,21 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
   const [terms, setTerms] = useState(invoice.termsAndConditions ?? '');
   const [termsDirty, setTermsDirty] = useState(false);
   const [termsSaved, flashTermsSaved] = useSavedFlash();
+
+  // Surface "is anything still saving / sitting dirty?" to the workspace so the
+  // header Issue buttons can wait for quiescence. Pending covers every in-flight
+  // mutation (line/add/remove/notes/terms); the dirty flags cover the rail's
+  // blur-to-save fields. Per-line dirty state isn't lifted — clicking Issue
+  // blurs the focused field, whose commit lands in `pending` before the action
+  // fires (mirrors the quote editor's contract). Deferred deletions count too:
+  // their DELETE hasn't fired yet, so Issue must not snapshot an invoice the
+  // user has visibly already trimmed (clicking Issue also flushes them — see
+  // onRegisterPendingDeleteFlush).
+  const hasPendingEdits = pending.size > 0 || notesDirty || termsDirty || pendingDeletedLineIds.size > 0;
+  useEffect(() => { onPendingEditsChange?.(hasPendingEdits); }, [hasPendingEdits, onPendingEditsChange]);
+  // Clear on unmount so a stale `true` can't lock Issue after the editor is gone
+  // (e.g. the invoice was just issued and the tab switched).
+  useEffect(() => () => onPendingEditsChange?.(false), [onPendingEditsChange]);
 
   // Add-line form
   const [addMode, setAddMode] = useState<AddMode>('catalog');
@@ -222,17 +276,116 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
     }, t('invoiceEditor.errors.updateLine')),
   [runScoped, invoice.id, refresh, t]);
 
-  const removeLine = useCallback((lineId: string) =>
+  // The real DELETE — only ever reached through the deferred-deletion lifecycle
+  // below. No success toast: the undo toast at removal time already told the
+  // user. keepalive so a flush fired from pagehide survives the page teardown.
+  const deleteLine = useCallback((lineId: string) =>
     runScoped(`remove-${lineId}`, async () => {
       await runAction({
-        request: () => fetchWithAuth(`/invoices/${invoice.id}/lines/${lineId}`, { method: 'DELETE' }),
+        request: () => fetchWithAuth(`/invoices/${invoice.id}/lines/${lineId}`, { method: 'DELETE', keepalive: true }),
         errorFallback: t('invoiceEditor.errors.removeLine'),
-        successMessage: t('invoiceEditor.success.lineRemoved'),
         onUnauthorized: UNAUTHORIZED,
       });
       refresh();
     }, t('invoiceEditor.errors.removeLine')),
   [runScoped, invoice.id, refresh, t]);
+
+  // undo → cancel the timer, unhide (nothing was ever sent).
+  const undoLineDelete = useCallback((lineId: string) => {
+    const entry = pendingDeleteEntries.current.get(lineId);
+    if (!entry) {
+      // Already flushed (e.g. an Issue click landed the DELETE before the undo
+      // toast expired) — the deletion is real now. Say so: a silently dead
+      // Undo click reads as "the app ate my line back... or did it?"
+      showToast({ type: 'warning', message: t('invoiceEditor.undo.tooLate') });
+      return;
+    }
+    clearTimeout(entry.timer);
+    pendingDeleteEntries.current.delete(lineId);
+    setPendingDeletedLineIds((s) => {
+      const n = new Set(s);
+      for (const id of entry.memberIds) n.delete(id);
+      return n;
+    });
+  }, [t]);
+
+  // flush → fire the real DELETE; on failure the line is honestly restored (it
+  // IS still there) on top of the delete path's own error toast.
+  const flushLineDelete = useCallback(async (lineId: string) => {
+    const entry = pendingDeleteEntries.current.get(lineId);
+    if (!entry) return; // undone, or another flush already owns it
+    clearTimeout(entry.timer);
+    pendingDeleteEntries.current.delete(lineId);
+    const ok = await deleteLine(lineId);
+    // Success or failure, the ids leave the PENDING set (they no longer hold
+    // Issue): success promotes them to the flushed set so they stay hidden
+    // until the refetch drops the rows; failure just unhides them.
+    setPendingDeletedLineIds((s) => {
+      const n = new Set(s);
+      for (const id of entry.memberIds) n.delete(id);
+      return n;
+    });
+    if (ok) {
+      setFlushedDeletedLineIds((s) => {
+        const n = new Set(s);
+        for (const id of entry.memberIds) n.add(id);
+        return n;
+      });
+    }
+  }, [deleteLine]);
+
+  const startLineDelete = useCallback((lineId: string) => {
+    if (pendingDeleteEntries.current.has(lineId)) return;
+    // Bundle children ride with their parent (the server cascade deletes them),
+    // so they hide — and restore — as one unit.
+    const memberIds = [lineId, ...serverLines.filter((l) => l.parentLineId === lineId).map((l) => l.id)];
+    const timer = setTimeout(() => { void flushLineDelete(lineId); }, UNDO_GRACE_MS);
+    pendingDeleteEntries.current.set(lineId, { id: lineId, memberIds, timer });
+    setPendingDeletedLineIds((s) => {
+      const n = new Set(s);
+      for (const id of memberIds) n.add(id);
+      return n;
+    });
+    showToast({
+      type: 'undo',
+      message: t('invoiceEditor.undo.lineDeleted'),
+      duration: UNDO_GRACE_MS,
+      onUndo: () => undoLineDelete(lineId),
+    });
+  }, [serverLines, flushLineDelete, undoLineDelete, t]);
+
+  // Flush every deferred deletion immediately. Issue (via the workspace),
+  // unmount and page-hide all route through here — the grace window is a UI
+  // nicety, never a way for a confirmed deletion to be lost or to outlive the
+  // editor.
+  const flushAllPendingDeletes = useCallback(() => {
+    for (const e of [...pendingDeleteEntries.current.values()]) void flushLineDelete(e.id);
+  }, [flushLineDelete]);
+  const flushAllRef = useRef(flushAllPendingDeletes);
+  useEffect(() => { flushAllRef.current = flushAllPendingDeletes; }, [flushAllPendingDeletes]);
+  useEffect(() => {
+    // Two teardown signals, deliberately layered:
+    // - visibilitychange→hidden fires while the page is still alive, so the
+    //   full request path (including a token refresh, which is NOT keepalive)
+    //   can complete and failures restore + toast normally. This is the
+    //   primary flush for tab switches and most navigations.
+    // - pagehide (not beforeunload: pagehide also fires on bfcache
+    //   navigations) is the last resort for hard teardowns; the DELETE goes
+    //   out with keepalive so it survives the page being torn down.
+    const onVisibilityHidden = () => { if (document.visibilityState === 'hidden') flushAllRef.current(); };
+    const onPageHide = () => flushAllRef.current();
+    document.addEventListener('visibilitychange', onVisibilityHidden);
+    window.addEventListener('pagehide', onPageHide);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityHidden);
+      window.removeEventListener('pagehide', onPageHide);
+      flushAllRef.current();
+    };
+  }, []);
+  useEffect(() => {
+    onRegisterPendingDeleteFlush?.(flushAllPendingDeletes);
+    return () => onRegisterPendingDeleteFlush?.(null);
+  }, [onRegisterPendingDeleteFlush, flushAllPendingDeletes]);
 
   const saveNotes = useCallback(async () => {
     if (!notesDirty) return;
@@ -276,6 +429,25 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
 
   return (
     <div className="space-y-6" data-testid="invoice-editor">
+      {/* Autosave hint + quiet sync indicator — same save-language strip as the
+          quote editor, so "how do I save?" has one answer across billing. */}
+      {canWrite && (
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-xs text-muted-foreground" data-testid="invoice-editor-autosave-hint">
+            {t('invoiceEditor.autosaveHint')}
+          </p>
+          {/* "Saving…" while any mutation is in flight, else "Saved 2:41 PM" once
+              this session has saved at least once. Purely informational — never
+              disables Issue or any other control. */}
+          {(pending.size > 0 || lastSavedAt !== null) && (
+            <p className="text-xs text-muted-foreground" data-testid="invoice-editor-last-saved">
+              {pending.size > 0
+                ? t('invoiceEditor.lastSaved.saving')
+                : t('invoiceEditor.lastSaved.saved', { time: formatTime(lastSavedAt as number, { hour: '2-digit', minute: '2-digit' }) })}
+            </p>
+          )}
+        </div>
+      )}
       {unapprovedCount > 0 && (
         <div
           className="rounded-md border border-warning/40 bg-warning/15 px-4 py-3 text-sm text-[hsl(36_92%_28%)] dark:text-warning"
@@ -285,11 +457,19 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
         </div>
       )}
 
-      <div className="grid gap-6 lg:grid-cols-[1fr_300px]">
+      {/* xl (not lg): matches the quote editor — below xl the rail stacks under
+          the content so the lines table isn't starved into sideways scrolling.
+          min-w-0 lets the 1fr track shrink below the table's content width. */}
+      <div className="grid gap-6 xl:grid-cols-[1fr_300px]">
         {/* Lines */}
-        <div className="space-y-4">
+        <div className="min-w-0 space-y-4">
           <div className="rounded-lg border bg-card shadow-xs">
-            <table className="w-full text-sm" data-testid="invoice-editor-lines">
+            {/* Labeled, keyboard-reachable scroll region: the row's fixed-width
+                inputs set a min-content width beyond phone viewports, so the
+                table scrolls inside the card instead of bleeding past its
+                rounded edge (same pattern as QuoteDetail's LineTable). */}
+            <div className="overflow-x-auto" role="region" aria-label={t('invoiceEditor.linesScrollAria')} tabIndex={0}>
+            <table className="w-full min-w-[40rem] text-sm" data-testid="invoice-editor-lines">
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
                   <th className="px-3 py-2 font-medium">{t('invoiceEditor.table.item')}</th>
@@ -317,12 +497,13 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                       currency={currency}
                       isPending={isPending}
                       onPatch={patchLine}
-                      onRemove={removeLine}
+                      onRemove={startLineDelete}
                     />
                   ))
                 )}
               </tbody>
             </table>
+            </div>
           </div>
 
           {/* Add line */}
@@ -436,8 +617,10 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
           )}
         </div>
 
-        {/* Summary + bill-to + notes + actions */}
-        <div className="space-y-4">
+        {/* Summary + bill-to + notes + actions. Sticky on xl so the totals you're
+            building against stay visible while scrolling the lines; below xl this
+            column stacks under the table. */}
+        <div className="space-y-4 xl:sticky xl:top-4 xl:self-start">
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-summary">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('invoiceEditor.summary.title')}</h3>
             <dl className="space-y-1 text-sm">
@@ -451,10 +634,11 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
                 <a href="/settings/billing" className="underline hover:text-foreground">{t('invoiceEditor.summary.setTaxRate')}</a>.
               </p>
             )}
-            {/* Internal margin summary — at-a-glance profitability while building the
-                invoice (the per-line cost/margin breakdown lives in InvoiceDetail's
-                Accounting view). Reuses the shared quote math; never customer-facing. */}
-            {canSeeMargin && <MarginPanel profit={profit} currency={currency} idPrefix="invoice" />}
+            {/* Internal margin summary — at-a-glance profitability while building
+                the invoice. Gated on the SAME persisted "show cost & margin"
+                preference as every quote surface, so "no margin on screen" holds
+                across the whole billing area. Never customer-facing. */}
+            {canSeeMargin && effectiveShowMargin && <MarginPanel profit={profit} currency={currency} idPrefix="invoice" />}
           </div>
 
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-bill-to">
@@ -487,7 +671,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               disabled={!canWrite || isPending('notes')}
               data-testid="invoice-notes"
               rows={3}
-              className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(notesDirty, notesSaved)}`}
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(notesDirty, notesSaved)}`}
               placeholder={t('invoiceEditor.notes.placeholder')}
             />
           </div>
@@ -504,7 +688,7 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               disabled={!canWrite || isPending('terms')}
               data-testid="invoice-terms"
               rows={3}
-              className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(termsDirty, termsSaved)}`}
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(termsDirty, termsSaved)}`}
               placeholder={t('invoiceEditor.terms.placeholder')}
             />
           </div>
@@ -513,6 +697,28 @@ export default function InvoiceEditor({ detail, onChanged }: Props) {
               workspace header (InvoiceActions) so they're reachable from any tab
               — mirrors the quote editor, which carries no Send button of its own. */}
         </div>
+      </div>
+
+      {/* Below xl the summary rail stacks under the lines table, which would
+          break the edit→see-total loop mid-task — so a slim summary stays pinned
+          to the viewport bottom (sticky bottom releases once you scroll down to
+          the real rail). aria-hidden: purely a visual affordance; the rail's
+          figures are the canonical ones (mirrors the quote editor's sticky bar). */}
+      <div
+        aria-hidden="true"
+        data-testid="invoice-totals-sticky"
+        className="sticky bottom-2 z-10 flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 rounded-lg border bg-card px-4 py-2 text-sm shadow-md xl:hidden"
+      >
+        <span className="flex items-baseline gap-2">
+          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{t('invoiceEditor.summary.total')}</span>
+          <span className="text-base font-semibold tabular-nums" data-testid="invoice-totals-sticky-total">{formatMoney(invoice.total, currency)}</span>
+        </span>
+        {Number(invoice.taxTotal) > 0 && (
+          <span className="flex items-baseline gap-1 text-muted-foreground">
+            <span className="text-xs">{t('invoiceEditor.summary.tax')}</span>
+            <span className="font-medium tabular-nums">{formatMoney(invoice.taxTotal, currency)}</span>
+          </span>
+        )}
       </div>
     </div>
   );
@@ -649,35 +855,44 @@ function LineRow({
           <input
             type="text" value={name} disabled={!canWrite || isPending(nameKey)}
             aria-label={t('invoiceEditor.fields.lineName')} placeholder={t('invoiceEditor.fields.name')}
+            aria-describedby={nameDirty ? unsavedHintId('invoice-line', line.id, 'name') : undefined}
             onChange={(e) => { setName(e.target.value); nameEdited.current = true; }}
             onBlur={commitName}
             data-testid={`invoice-line-name-${line.id}`}
-            className={`h-8 w-full rounded-md border bg-background px-2 text-sm font-medium transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(nameDirty, saved)}`}
+            className={`h-8 w-full rounded-md border bg-background px-2 text-sm font-medium transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(nameDirty, saved)}`}
           />
+          <UnsavedFieldHint id={unsavedHintId('invoice-line', line.id, 'name')} show={nameDirty} />
         </td>
         <td className="px-3 py-2 text-right">
           <input
             type="number" min="0" step="0.01" value={qty} disabled={!canWrite || isPending(qtyKey)}
             aria-label={t('invoiceEditor.fields.quantity')}
+            aria-describedby={qtyDirty ? unsavedHintId('invoice-line', line.id, 'qty') : undefined}
             onChange={(e) => { setQty(e.target.value); qtyEdited.current = true; }}
             onBlur={commitQty}
             data-testid={`invoice-line-qty-${line.id}`}
-            className={`h-8 w-20 rounded-md border bg-background px-2 text-right text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(qtyDirty, saved)}`}
+            className={`h-8 w-20 rounded-md border bg-background px-2 text-right text-sm transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(qtyDirty, saved)}`}
           />
+          <UnsavedFieldHint id={unsavedHintId('invoice-line', line.id, 'qty')} show={qtyDirty} />
         </td>
         <td className="px-3 py-2 text-right">
           <input
             type="number" min="0" step="0.01" value={price} disabled={!canWrite || isPending(priceKey)}
             aria-label={t('invoiceEditor.fields.unitPrice')}
+            aria-describedby={priceDirty ? unsavedHintId('invoice-line', line.id, 'price') : undefined}
             onChange={(e) => { setPrice(e.target.value); priceEdited.current = true; }}
             onBlur={commitPrice}
             data-testid={`invoice-line-price-${line.id}`}
-            className={`h-8 w-24 rounded-md border bg-background px-2 text-right text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(priceDirty, saved)}`}
+            className={`h-8 w-24 rounded-md border bg-background px-2 text-right text-sm transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(priceDirty, saved)}`}
           />
+          <UnsavedFieldHint id={unsavedHintId('invoice-line', line.id, 'price')} show={priceDirty} />
         </td>
         <td className="px-3 py-2 text-center">
           <input
             type="checkbox" checked={line.taxable} disabled={!canWrite || isPending(taxableKey)}
+            // Explicit name: header-cell inference doesn't survive the
+            // two-<tr>-per-line table structure for screen readers.
+            aria-label={t('invoiceEditor.fields.taxable')}
             onChange={(e) => void edit({ taxable: e.target.checked }, taxableKey)}
             data-testid={`invoice-line-taxable-${line.id}`}
           />
@@ -685,6 +900,9 @@ function LineRow({
         <td className="px-3 py-2 text-center">
           <input
             type="checkbox" checked={line.customerVisible} disabled={!canWrite || isPending(visibleKey)}
+            // The abbreviated "Cust" column header only explains itself via a
+            // title tooltip — give AT users the full meaning directly.
+            aria-label={t('invoiceEditor.table.customerVisibleTitle')}
             onChange={(e) => void edit({ customerVisible: e.target.checked }, visibleKey)}
             data-testid={`invoice-line-visible-${line.id}`}
           />
@@ -715,12 +933,14 @@ function LineRow({
             disabled={!canWrite || isPending(descKey)}
             aria-label={t('invoiceEditor.fields.lineDescription')}
             placeholder={t('invoiceEditor.fields.descriptionOptional')}
+            aria-describedby={descDirty ? unsavedHintId('invoice-line', line.id, 'desc') : undefined}
             onChange={(e) => { setDesc(e.target.value); descEdited.current = true; autoGrowDesc(); }}
             onBlur={commitDesc}
             rows={2}
             data-testid={`invoice-line-desc-${line.id}`}
-            className={`min-h-8 w-full resize-y overflow-hidden rounded-md border bg-background px-2 py-1 text-sm text-muted-foreground transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(descDirty, saved)}`}
+            className={`min-h-8 w-full resize-y overflow-hidden rounded-md border bg-background px-2 py-1 text-sm text-muted-foreground transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(descDirty, saved)}`}
           />
+          <UnsavedFieldHint id={unsavedHintId('invoice-line', line.id, 'desc')} show={descDirty} />
         </td>
       </tr>
       {children.map((ch) => (

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -26,10 +26,17 @@ const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 interface Props {
   detail: InvoiceDetail;
   onChanged: () => void;
-  /** Reports "is anything still saving / sitting dirty?" to the workspace so
-   *  the header's Issue buttons can wait for quiescence instead of issuing an
-   *  invoice that's missing a just-typed edit (mirrors the quote editor). */
+  /** Reports "is work actually IN FLIGHT?" — an open mutation or a deferred
+   *  deletion whose DELETE hasn't fired yet. The header's Issue buttons wait on
+   *  this, because it is the only state that resolves on its own. Deliberately
+   *  NOT true for a merely-dirty field: see onUnsavedEditsChange. */
   onPendingEditsChange?: (hasPendingEdits: boolean) => void;
+  /** Reports a field holding an edit that is dirty with NOTHING in flight —
+   *  i.e. its save failed, or never fired. Waiting cannot clear this, so the
+   *  header must refuse the Issue and name the field instead of promising the
+   *  user that a save is on its way. Null when everything is clean or genuinely
+   *  saving. The string is a translated field label. */
+  onUnsavedEditsChange?: (unsavedFieldLabel: string | null) => void;
   /** Reports every save FAILURE. Quiescence alone is not a safe Issue signal:
    *  a failed delete-flush restores its rows and a failed line blur-save
    *  clears its in-flight key, both of which read as "quiet" — the workspace
@@ -53,10 +60,12 @@ const UNDO_GRACE_MS = 6000;
 
 /** One deferred line deletion awaiting its grace window. `memberIds` includes
  *  bundle children — the server FK-cascades them, so they hide and restore as
- *  one unit with their parent. */
-type PendingDelete = { id: string; memberIds: string[]; timer: ReturnType<typeof setTimeout> };
+ *  one unit with their parent. Keyed by the parent line id in
+ *  `pendingDeleteEntries`; the id is NOT repeated here, so an entry can't be
+ *  filed under a key that disagrees with it. */
+type PendingDelete = { memberIds: string[]; timer: ReturnType<typeof setTimeout> };
 
-export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange, onSaveFailure, onRegisterPendingDeleteFlush, showMargin }: Props) {
+export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange, onUnsavedEditsChange, onSaveFailure, onRegisterPendingDeleteFlush, showMargin }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const canWrite = can('invoices', 'write');
@@ -116,6 +125,12 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
   // indicator near the autosave hint — null until this session's first save
   // (nothing to report before that; the indicator itself stays unrendered).
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
+  // Keys whose most recent save attempt FAILED, cleared when one succeeds.
+  // Dirty-ness alone cannot be the "you have unsaved work" signal: after a
+  // SUCCESSFUL save the local value legitimately differs from the server copy
+  // until the refetch lands, so "dirty with nothing in flight" is also the
+  // normal happy path for one round-trip. Failure is unambiguous.
+  const [failedKeys, setFailedKeys] = useState<ReadonlySet<string>>(() => new Set());
 
   // Run a scoped mutation: mark the key pending, run, surface failures via the
   // standard handleActionError path, and always clear the key. Returns whether
@@ -128,9 +143,11 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
       try {
         await fn();
         setLastSavedAt(Date.now());
+        setFailedKeys((s) => { if (!s.has(key)) return s; const n = new Set(s); n.delete(key); return n; });
         return true;
       } catch (err) {
         handleActionError(err, errMsg);
+        setFailedKeys((s) => { if (s.has(key)) return s; const n = new Set(s); n.add(key); return n; });
         onSaveFailure?.();
         return false;
       } finally {
@@ -148,20 +165,56 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
   const [termsDirty, setTermsDirty] = useState(false);
   const [termsSaved, flashTermsSaved] = useSavedFlash();
 
-  // Surface "is anything still saving / sitting dirty?" to the workspace so the
-  // header Issue buttons can wait for quiescence. Pending covers every in-flight
-  // mutation (line/add/remove/notes/terms); the dirty flags cover the rail's
-  // blur-to-save fields. Per-line dirty state isn't lifted — clicking Issue
-  // blurs the focused field, whose commit lands in `pending` before the action
-  // fires (mirrors the quote editor's contract). Deferred deletions count too:
-  // their DELETE hasn't fired yet, so Issue must not snapshot an invoice the
-  // user has visibly already trimmed (clicking Issue also flushes them — see
-  // onRegisterPendingDeleteFlush).
-  const hasPendingEdits = pending.size > 0 || notesDirty || termsDirty || pendingDeletedLineIds.size > 0;
+  // Per-line dirty fields, reported up from each LineRow. This MUST be lifted:
+  // a line field whose save failed keeps its local value (nothing reverts it)
+  // while runScoped's `finally` clears its in-flight key — so `pending` alone
+  // reads as perfectly quiet while an amber "unsaved" border sits on a quantity.
+  // Leaving it unlifted let Issue number an invoice at the pre-edit money.
+  const [dirtyLineKeys, setDirtyLineKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const reportLineDirty = useCallback((key: string, dirty: boolean) => {
+    setDirtyLineKeys((s) => {
+      if (dirty === s.has(key)) return s; // no-op keeps the reference stable
+      const n = new Set(s);
+      if (dirty) n.add(key); else n.delete(key);
+      return n;
+    });
+  }, []);
+
+  // Two DIFFERENT questions, deliberately kept apart — conflating them is what
+  // produced both a false "Saving changes…" and an Issue that skipped a failed
+  // edit:
+  //
+  // - hasPendingEdits: work is genuinely IN FLIGHT (an open mutation, or a
+  //   deferred deletion whose DELETE hasn't fired). This resolves on its own,
+  //   so a queued Issue may legitimately wait for it. Deferred deletions count:
+  //   Issue must not snapshot an invoice the user has visibly already trimmed
+  //   (clicking Issue also flushes them — see onRegisterPendingDeleteFlush).
+  // - unsavedFieldLabel: a field whose save FAILED and which is still dirty.
+  //   Waiting will never clear it, so the header refuses the Issue and names
+  //   the field.
+  //
+  // The second signal is the intersection of "last attempt failed" and "still
+  // differs from the server", and it needs both halves. Failure alone would
+  // keep blocking after the user reverts the field by hand (the commit path
+  // short-circuits on an unchanged value, so no fresh attempt ever clears the
+  // flag). Dirty alone would fire during the one round-trip between a
+  // successful save and its refetch, refusing an Issue that is perfectly valid.
+  //
+  // A field that is mid-save is dirty AND in flight; `pending.size > 0` is
+  // checked first so that reads as "saving", not as "stuck".
+  const hasPendingEdits = pending.size > 0 || pendingDeletedLineIds.size > 0;
+  const unsavedFieldLabel = useMemo(() => {
+    if (pending.size > 0) return null; // something is genuinely on its way
+    if (failedKeys.has('notes') && notesDirty) return t('invoiceEditor.notes.title');
+    if (failedKeys.has('terms') && termsDirty) return t('invoiceEditor.terms.title');
+    for (const key of failedKeys) if (dirtyLineKeys.has(key)) return t('invoiceEditor.unsavedField.lines');
+    return null;
+  }, [pending.size, failedKeys, notesDirty, termsDirty, dirtyLineKeys, t]);
   useEffect(() => { onPendingEditsChange?.(hasPendingEdits); }, [hasPendingEdits, onPendingEditsChange]);
-  // Clear on unmount so a stale `true` can't lock Issue after the editor is gone
-  // (e.g. the invoice was just issued and the tab switched).
-  useEffect(() => () => onPendingEditsChange?.(false), [onPendingEditsChange]);
+  useEffect(() => { onUnsavedEditsChange?.(unsavedFieldLabel); }, [unsavedFieldLabel, onUnsavedEditsChange]);
+  // Clear BOTH on unmount so a stale signal can't lock Issue after the editor is
+  // gone (e.g. the invoice was just issued and the tab switched).
+  useEffect(() => () => { onPendingEditsChange?.(false); onUnsavedEditsChange?.(null); }, [onPendingEditsChange, onUnsavedEditsChange]);
 
   // Add-line form
   const [addMode, setAddMode] = useState<AddMode>('catalog');
@@ -171,18 +224,31 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
   const [manualPrice, setManualPrice] = useState('0.00');
   const [manualTaxable, setManualTaxable] = useState(false);
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
+  const [catalogFailed, setCatalogFailed] = useState(false);
   const [picked, setPicked] = useState<CatalogItem | null>(null);
   const [pickQty, setPickQty] = useState('1');
 
   useEffect(() => { setNotes(invoice.notes ?? ''); setNotesDirty(false); }, [invoice.notes]);
   useEffect(() => { setTerms(invoice.termsAndConditions ?? ''); setTermsDirty(false); }, [invoice.termsAndConditions]);
 
+  // An empty catalog and a BROKEN catalog need different copy: rendering "No
+  // catalog items — add in catalog" because the response failed to parse sends
+  // the user off to create items that already exist. Everything that can throw
+  // is inside the try, including the JSON parse (a 200 with a truncated body
+  // rejects there), and the rejection is surfaced rather than voided away.
   const loadCatalog = useCallback(async () => {
-    const res = await listCatalog({ isActive: true, limit: 200 });
-    if (res.status === 401) return UNAUTHORIZED();
-    if (!res.ok) { handleActionError(new Error(res.statusText), t('invoiceEditor.errors.loadCatalog')); return; }
-    const body = (await res.json()) as { data: CatalogItem[] };
-    setCatalog(body.data ?? []);
+    try {
+      const res = await listCatalog({ isActive: true, limit: 200 });
+      if (res.status === 401) return UNAUTHORIZED();
+      if (!res.ok) throw new Error(res.statusText);
+      const body = (await res.json().catch(() => null)) as { data?: CatalogItem[] } | null;
+      if (!body || !Array.isArray(body.data)) throw new Error('malformed catalog response');
+      setCatalog(body.data);
+      setCatalogFailed(false);
+    } catch (err) {
+      handleActionError(err, t('invoiceEditor.errors.loadCatalog'));
+      setCatalogFailed(true);
+    }
   }, [t]);
 
   useEffect(() => { void loadCatalog(); }, [loadCatalog]);
@@ -202,23 +268,27 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
 
   const refresh = useCallback(() => onChanged(), [onChanged]);
 
-  const addLine = useCallback(() =>
-    runScoped('addLine', async () => {
-      if (addMode === 'manual') {
-        // A line needs at least a title (name) or a description (mirrors the API refine).
-        if (!manualName.trim() && !manualDesc.trim()) return;
-        // Guard qty/price with the same rules as the inline commit path so a bad
-        // manual entry is explained, not silently coerced (Number('abc') → NaN).
-        const q = Number(manualQty);
-        const p = Number(manualPrice);
-        if (!Number.isFinite(q) || q <= 0) {
-          handleActionError(new Error('invalid quantity'), t('invoiceEditor.errors.quantityGreaterThanZero'));
-          return;
-        }
-        if (!Number.isFinite(p) || p < 0) {
-          handleActionError(new Error('invalid price'), t('invoiceEditor.errors.nonNegativeUnitPrice'));
-          return;
-        }
+  // Validation runs OUTSIDE runScoped. Inside it, a plain `return` is
+  // indistinguishable from a completed save, so runScoped would stamp the
+  // "Saved <time>" indicator on an entry it had just rejected — a success cue on
+  // a money document at the exact moment of a failure.
+  const addLine = useCallback(async () => {
+    if (addMode === 'manual') {
+      // A line needs at least a title (name) or a description (mirrors the API refine).
+      if (!manualName.trim() && !manualDesc.trim()) return;
+      // Guard qty/price with the same rules as the inline commit path so a bad
+      // manual entry is explained, not silently coerced (Number('abc') → NaN).
+      const q = Number(manualQty);
+      const p = Number(manualPrice);
+      if (!Number.isFinite(q) || q <= 0) {
+        handleActionError(new Error('invalid quantity'), t('invoiceEditor.errors.quantityGreaterThanZero'));
+        return;
+      }
+      if (!Number.isFinite(p) || p < 0) {
+        handleActionError(new Error('invalid price'), t('invoiceEditor.errors.nonNegativeUnitPrice'));
+        return;
+      }
+      await runScoped('addLine', async () => {
         await runAction({
           request: () => fetchWithAuth(`/invoices/${invoice.id}/lines`, {
             method: 'POST',
@@ -235,29 +305,33 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
           onUnauthorized: UNAUTHORIZED,
         });
         setManualName(''); setManualDesc(''); setManualQty('1'); setManualPrice('0.00'); setManualTaxable(false);
-      } else {
-        if (!picked) return;
-        const pq = Number(pickQty);
-        if (!Number.isFinite(pq) || pq <= 0) {
-          handleActionError(new Error('invalid quantity'), t('invoiceEditor.errors.quantityGreaterThanZero'));
-          return;
-        }
-        const path = picked.isBundle
-          ? `/invoices/${invoice.id}/lines/bundle`
-          : `/invoices/${invoice.id}/lines/catalog`;
-        const body = picked.isBundle
-          ? { bundleId: picked.id, quantity: pq }
-          : { catalogItemId: picked.id, quantity: pq };
-        await runAction({
-          request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify(body) }),
-          errorFallback: t('invoiceEditor.errors.addLine'),
-          successMessage: t('invoiceEditor.success.lineAdded'),
-          onUnauthorized: UNAUTHORIZED,
-        });
-        setPicked(null); setPickQty('1');
-      }
+        refresh();
+      }, t('invoiceEditor.errors.addLine'));
+      return;
+    }
+    if (!picked) return;
+    const pq = Number(pickQty);
+    if (!Number.isFinite(pq) || pq <= 0) {
+      handleActionError(new Error('invalid quantity'), t('invoiceEditor.errors.quantityGreaterThanZero'));
+      return;
+    }
+    const path = picked.isBundle
+      ? `/invoices/${invoice.id}/lines/bundle`
+      : `/invoices/${invoice.id}/lines/catalog`;
+    const body = picked.isBundle
+      ? { bundleId: picked.id, quantity: pq }
+      : { catalogItemId: picked.id, quantity: pq };
+    await runScoped('addLine', async () => {
+      await runAction({
+        request: () => fetchWithAuth(path, { method: 'POST', body: JSON.stringify(body) }),
+        errorFallback: t('invoiceEditor.errors.addLine'),
+        successMessage: t('invoiceEditor.success.lineAdded'),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      setPicked(null); setPickQty('1');
       refresh();
-    }, t('invoiceEditor.errors.addLine')),
+    }, t('invoiceEditor.errors.addLine'));
+  },
   [runScoped, addMode, manualName, manualDesc, manualQty, manualPrice, manualTaxable, picked, pickQty, invoice.id, refresh, t]);
 
   // Inline edit of an existing line. `scopeKey` is per-field so one in-flight
@@ -311,9 +385,9 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
 
   // flush → fire the real DELETE; on failure the line is honestly restored (it
   // IS still there) on top of the delete path's own error toast.
-  const flushLineDelete = useCallback(async (lineId: string) => {
+  const flushLineDelete = useCallback(async (lineId: string): Promise<boolean> => {
     const entry = pendingDeleteEntries.current.get(lineId);
-    if (!entry) return; // undone, or another flush already owns it
+    if (!entry) return true; // undone, or another flush already owns it — not a failure
     clearTimeout(entry.timer);
     pendingDeleteEntries.current.delete(lineId);
     const ok = await deleteLine(lineId);
@@ -332,6 +406,7 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
         return n;
       });
     }
+    return ok;
   }, [deleteLine]);
 
   const startLineDelete = useCallback((lineId: string) => {
@@ -340,7 +415,7 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
     // so they hide — and restore — as one unit.
     const memberIds = [lineId, ...serverLines.filter((l) => l.parentLineId === lineId).map((l) => l.id)];
     const timer = setTimeout(() => { void flushLineDelete(lineId); }, UNDO_GRACE_MS);
-    pendingDeleteEntries.current.set(lineId, { id: lineId, memberIds, timer });
+    pendingDeleteEntries.current.set(lineId, { memberIds, timer });
     setPendingDeletedLineIds((s) => {
       const n = new Set(s);
       for (const id of memberIds) n.add(id);
@@ -359,8 +434,25 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
   // nicety, never a way for a confirmed deletion to be lost or to outlive the
   // editor.
   const flushAllPendingDeletes = useCallback(() => {
-    for (const e of [...pendingDeleteEntries.current.values()]) void flushLineDelete(e.id);
-  }, [flushLineDelete]);
+    const ids = [...pendingDeleteEntries.current.keys()];
+    if (ids.length === 0) return;
+    void (async () => {
+      const results = await Promise.all(ids.map((id) => flushLineDelete(id)));
+      const failed = results.filter((ok) => !ok).length;
+      // A PARTIAL flush is the case that silently misleads: the deletions that
+      // landed are permanent (their undo toasts are spent, and deleteLine has no
+      // success toast of its own), the failed one's row is back, and the only
+      // other thing the user sees is a generic "Issue was canceled". Read
+      // together those say "nothing happened", which is wrong in both
+      // directions. An all-or-nothing outcome needs no extra narration.
+      if (failed > 0 && failed < results.length) {
+        showToast({
+          type: 'warning',
+          message: t('invoiceEditor.undo.partialFlush', { applied: results.length - failed, failed }),
+        });
+      }
+    })();
+  }, [flushLineDelete, t]);
   const flushAllRef = useRef(flushAllPendingDeletes);
   useEffect(() => { flushAllRef.current = flushAllPendingDeletes; }, [flushAllPendingDeletes]);
   useEffect(() => {
@@ -498,6 +590,7 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
                       isPending={isPending}
                       onPatch={patchLine}
                       onRemove={startLineDelete}
+                      onDirtyChange={reportLineDirty}
                     />
                   ))
                 )}
@@ -600,6 +693,18 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
                   {t('invoiceEditor.addLine.add')}
                 </button>
               </div>
+            ) : catalogFailed ? (
+              <p className="text-sm text-muted-foreground" data-testid="invoice-catalog-error">
+                {t('invoiceEditor.addLine.catalogLoadFailed')}{' '}
+                <button
+                  type="button"
+                  onClick={() => void loadCatalog()}
+                  className="underline hover:text-foreground"
+                  data-testid="invoice-catalog-retry"
+                >
+                  {t('invoiceEditor.addLine.retry')}
+                </button>
+              </p>
             ) : catalog.length === 0 ? (
               <p className="text-sm text-muted-foreground" data-testid="invoice-catalog-empty">
                 {t('invoiceEditor.addLine.noCatalogItems')}{' '}
@@ -725,7 +830,7 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
 }
 
 function LineRow({
-  line, children, currency, isPending, onPatch, onRemove,
+  line, children, currency, isPending, onPatch, onRemove, onDirtyChange,
 }: {
   line: InvoiceLine;
   children: InvoiceLine[];
@@ -733,6 +838,10 @@ function LineRow({
   isPending: (key: string) => boolean;
   onPatch: (lineId: string, patch: Record<string, unknown>, scopeKey: string) => Promise<boolean>;
   onRemove: (lineId: string) => void;
+  /** Reports this row's per-field dirty state to the editor, which folds it into
+   *  the Issue gate. Without it a line edit whose PATCH failed is invisible to
+   *  the header — see the hasPendingEdits comment. */
+  onDirtyChange: (key: string, dirty: boolean) => void;
 }) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
@@ -796,6 +905,21 @@ function LineRow({
   const descDirty = desc.trim() !== (line.description ?? '');
   const qtyDirty = Number(qty) !== Number(line.quantity);
   const priceDirty = Number(price) !== Number(line.unitPrice);
+
+  // Report each field's dirty state up so the header's Issue gate can see it.
+  // The unmount cleanup is load-bearing: a row that disappears (deleted, or
+  // dropped by a refetch) while dirty would otherwise pin the invoice's
+  // "unsaved" state to a field that no longer exists, blocking Issue forever.
+  useEffect(() => { onDirtyChange(nameKey, nameDirty); }, [onDirtyChange, nameKey, nameDirty]);
+  useEffect(() => { onDirtyChange(descKey, descDirty); }, [onDirtyChange, descKey, descDirty]);
+  useEffect(() => { onDirtyChange(qtyKey, qtyDirty); }, [onDirtyChange, qtyKey, qtyDirty]);
+  useEffect(() => { onDirtyChange(priceKey, priceDirty); }, [onDirtyChange, priceKey, priceDirty]);
+  useEffect(() => () => {
+    onDirtyChange(nameKey, false);
+    onDirtyChange(descKey, false);
+    onDirtyChange(qtyKey, false);
+    onDirtyChange(priceKey, false);
+  }, [onDirtyChange, nameKey, descKey, qtyKey, priceKey]);
 
   const commitName = () => {
     if (!canWrite) return;

--- a/apps/web/src/components/billing/InvoiceEditor.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.tsx
@@ -16,6 +16,7 @@ import {
   lineTitle,
   computeInvoiceProfit,
 } from './invoiceTypes';
+import { toCents, fromCents } from '@breeze/shared';
 import CatalogItemPicker from '../catalog/CatalogItemPicker';
 import PolishButton from '../catalog/PolishButton';
 import { listCatalog, type CatalogItem } from '../../lib/api/catalog';
@@ -112,6 +113,40 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
   }, [serverLines]);
 
   const profit = useMemo(() => computeInvoiceProfit(lines), [lines]);
+
+  // The figures the summary rail + sticky bar render: optimistic recompute
+  // while any deletion is hidden client-side (sitting in its undo window, or
+  // flushed but not yet dropped by the refetch) — the server totals still
+  // include those lines, so for that window Subtotal/Tax/Total would
+  // contradict the table the user is looking at (the quote editor's
+  // optimisticTotals pattern). The math mirrors the API's
+  // computeInvoiceTotals (services/invoiceMath.ts) EXACTLY: sum the persisted
+  // lineTotal over customer-visible lines — bundle children persist
+  // lineTotal '0.00', so recomputing qty×price here would double-count them —
+  // then tax = taxable basis × the invoice's committed rate, one
+  // round-half-up at the cent boundary. Same inputs, same rounding: the
+  // optimistic figures can never settle different from the next GET.
+  const optimisticTotals = useMemo(() => {
+    if (pendingDeletedLineIds.size === 0 && flushedDeletedLineIds.size === 0) return null;
+    let subtotalCents = 0;
+    let taxableCents = 0;
+    for (const l of lines) {
+      if (!l.customerVisible) continue;
+      const c = toCents(l.lineTotal);
+      subtotalCents += c;
+      if (l.taxable) taxableCents += c;
+    }
+    const rate = invoice.taxRate ? Number(invoice.taxRate) : 0;
+    const taxCents = Math.floor(taxableCents * rate + 0.5);
+    return {
+      subtotal: fromCents(subtotalCents),
+      taxTotal: fromCents(taxCents),
+      total: fromCents(subtotalCents + taxCents),
+    };
+  }, [pendingDeletedLineIds, flushedDeletedLineIds, lines, invoice.taxRate]);
+  const railSubtotal = optimisticTotals?.subtotal ?? invoice.subtotal;
+  const railTax = optimisticTotals?.taxTotal ?? invoice.taxTotal;
+  const railTotal = optimisticTotals?.total ?? invoice.total;
 
   // Per-item "saving" state, keyed so one in-flight mutation never freezes the
   // rest of the editor. Keys: 'notes', 'terms', 'addLine', `qty-<lineId>`,
@@ -729,9 +764,9 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
           <div className="rounded-lg border bg-card p-4 shadow-xs" data-testid="invoice-summary">
             <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('invoiceEditor.summary.title')}</h3>
             <dl className="space-y-1 text-sm">
-              <div className="flex justify-between"><dt className="text-muted-foreground">{t('invoiceEditor.summary.subtotal')}</dt><dd data-testid="invoice-subtotal">{formatMoney(invoice.subtotal, currency)}</dd></div>
-              <div className="flex justify-between"><dt className="text-muted-foreground">{t('invoiceEditor.summary.tax')}{!noTaxRate ? ` (${formatPercent(Number(invoice.taxRate), { minimumFractionDigits: 2, maximumFractionDigits: 2 })})` : ''}</dt><dd data-testid="invoice-tax">{formatMoney(invoice.taxTotal, currency)}</dd></div>
-              <div className="flex justify-between border-t pt-1 font-semibold"><dt>{t('invoiceEditor.summary.total')}</dt><dd data-testid="invoice-total">{formatMoney(invoice.total, currency)}</dd></div>
+              <div className="flex justify-between"><dt className="text-muted-foreground">{t('invoiceEditor.summary.subtotal')}</dt><dd data-testid="invoice-subtotal">{formatMoney(railSubtotal, currency)}</dd></div>
+              <div className="flex justify-between"><dt className="text-muted-foreground">{t('invoiceEditor.summary.tax')}{!noTaxRate ? ` (${formatPercent(Number(invoice.taxRate), { minimumFractionDigits: 2, maximumFractionDigits: 2 })})` : ''}</dt><dd data-testid="invoice-tax">{formatMoney(railTax, currency)}</dd></div>
+              <div className="flex justify-between border-t pt-1 font-semibold"><dt>{t('invoiceEditor.summary.total')}</dt><dd data-testid="invoice-total">{formatMoney(railTotal, currency)}</dd></div>
             </dl>
             {hasTaxableLine && noTaxRate && (
               <p className="mt-3 text-xs text-muted-foreground" data-testid="invoice-tax-rate-hint">
@@ -816,12 +851,12 @@ export default function InvoiceEditor({ detail, onChanged, onPendingEditsChange,
       >
         <span className="flex items-baseline gap-2">
           <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{t('invoiceEditor.summary.total')}</span>
-          <span className="text-base font-semibold tabular-nums" data-testid="invoice-totals-sticky-total">{formatMoney(invoice.total, currency)}</span>
+          <span className="text-base font-semibold tabular-nums" data-testid="invoice-totals-sticky-total">{formatMoney(railTotal, currency)}</span>
         </span>
-        {Number(invoice.taxTotal) > 0 && (
+        {Number(railTax) > 0 && (
           <span className="flex items-baseline gap-1 text-muted-foreground">
             <span className="text-xs">{t('invoiceEditor.summary.tax')}</span>
-            <span className="font-medium tabular-nums">{formatMoney(invoice.taxTotal, currency)}</span>
+            <span className="font-medium tabular-nums">{formatMoney(railTax, currency)}</span>
           </span>
         )}
       </div>

--- a/apps/web/src/components/billing/InvoiceEditor.undodelete.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.undodelete.test.tsx
@@ -1,0 +1,207 @@
+// Deferred line deletion with an undo grace window (the quote editor's delete
+// model, normalized onto invoices): Remove hides the row instantly and shows an
+// undo toast; the real DELETE fires only when the grace window lapses (or on
+// flush/unmount) — a fat-fingered Remove on a money document is recoverable.
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import InvoiceEditor from './InvoiceEditor';
+import type { InvoiceDetail } from './invoiceTypes';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+const showToast = vi.fn();
+vi.mock('../shared/Toast', () => ({ showToast: (a: unknown) => showToast(a) }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+const manualLine: InvoiceDetail['lines'][number] = {
+  id: 'line-1', invoiceId: 'inv-1', sourceType: 'manual', parentLineId: null, catalogItemId: null,
+  name: 'Consulting', description: null, quantity: '2.00', unitPrice: '50.00', costBasis: null, revenueAllocation: null,
+  taxable: false, customerVisible: true, lineTotal: '100.00', isUnapprovedTime: false, sortOrder: 1,
+};
+
+function draft(lines: InvoiceDetail['lines']): InvoiceDetail {
+  return {
+    invoice: {
+      id: 'inv-1', invoiceNumber: null, orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, dueDate: null, sentAt: null, subtotal: '100.00', taxRate: null,
+      taxTotal: '0.00', total: '100.00', amountPaid: '0.00', balance: '100.00', billToName: 'Acme',
+      notes: '', termsAndConditions: null, sellerSnapshot: null, createdAt: '2026-06-01T00:00:00Z',
+    },
+    lines,
+  };
+}
+
+const deletePosted = () =>
+  fetchMock.mock.calls.some((c) => String(c[0]) === '/invoices/inv-1/lines/line-1' && (c[1] as RequestInit)?.method === 'DELETE');
+
+const lastUndoToast = () => {
+  const call = [...showToast.mock.calls].reverse().find((c) => (c[0] as { type: string }).type === 'undo');
+  expect(call, 'expected an undo toast').toBeTruthy();
+  return call![0] as { onUndo: () => void };
+};
+
+describe('InvoiceEditor — undo-able line deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      return json({ data: {} });
+    });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('hides the row immediately with an undo toast — the DELETE waits for the grace window', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-1'));
+
+    // Gone from the UI at once, but nothing sent yet — still undoable.
+    expect(screen.queryByTestId('invoice-line-line-1')).not.toBeInTheDocument();
+    expect(deletePosted()).toBe(false);
+    lastUndoToast();
+
+    // Grace window lapses → the real DELETE fires.
+    await act(async () => { await vi.advanceTimersByTimeAsync(6000); });
+    expect(deletePosted()).toBe(true);
+  });
+
+  it('undo restores the row and the DELETE never fires', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-1'));
+    act(() => { lastUndoToast().onUndo(); });
+
+    expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument();
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+    expect(deletePosted()).toBe(false);
+  });
+
+  it('reports pending edits while a deletion sits in its grace window, and quiesces on flush success WITHOUT needing a refetch', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onPending = vi.fn();
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} onPendingEditsChange={onPending} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+    expect(onPending).toHaveBeenLastCalledWith(false);
+
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-1'));
+    await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(true));
+
+    // Flush lands the DELETE. Quiescence must arrive from the DELETE success
+    // alone — onChanged here is a bare mock (no refetch ever happens), which is
+    // exactly the "quiet reload failed" shape: coupling quiescence to the
+    // refetch would leave Issue held forever over a deletion that landed.
+    await act(async () => { await vi.advanceTimersByTimeAsync(6000); });
+    expect(deletePosted()).toBe(true);
+    await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(false));
+    // The row stays hidden even though the (never-refetched) server data still
+    // contains it — it IS deleted server-side.
+    expect(screen.queryByTestId('invoice-line-line-1')).not.toBeInTheDocument();
+  });
+
+  it('restores the row and surfaces the error when the deferred DELETE fails', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1/lines/line-1' && opts?.method === 'DELETE') return json({ error: { message: 'boom' } }, false, 500);
+      return json({ data: {} });
+    });
+    const onSaveFailure = vi.fn();
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} onSaveFailure={onSaveFailure} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-1'));
+    expect(screen.queryByTestId('invoice-line-line-1')).not.toBeInTheDocument();
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(6000); });
+
+    // The DELETE didn't land: the row honestly reappears (it still exists
+    // server-side — a silently-hidden zombie line would be billed on Issue),
+    // and the failure is reported so a queued Issue cancels.
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+    expect(onSaveFailure).toHaveBeenCalled();
+  });
+
+  it('bundle children hide and restore as one unit with their parent', async () => {
+    const child: InvoiceDetail['lines'][number] = {
+      ...manualLine, id: 'line-child', parentLineId: 'line-1', name: 'Component', unitPrice: '0.00', lineTotal: '0.00',
+    };
+    render(<InvoiceEditor detail={draft([manualLine, child])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+    expect(screen.getByTestId('invoice-line-child-line-child')).toBeInTheDocument();
+
+    // Removing the parent hides the child too (the server FK-cascades it).
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-1'));
+    expect(screen.queryByTestId('invoice-line-line-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoice-line-child-line-child')).not.toBeInTheDocument();
+    expect(deletePosted()).toBe(false);
+
+    // Undo restores the whole unit.
+    act(() => { lastUndoToast().onUndo(); });
+    expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-line-child-line-child')).toBeInTheDocument();
+  });
+
+  it('an Undo click after the DELETE already flushed gets a "too late" notice, not silence', async () => {
+    let flush: (() => void) | null = null;
+    render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} onRegisterPendingDeleteFlush={(f) => { flush = f; }} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-1'));
+    const undoToast = lastUndoToast();
+    act(() => { flush!(); });
+    await waitFor(() => expect(deletePosted()).toBe(true));
+
+    showToast.mockClear();
+    act(() => { undoToast.onUndo(); });
+    expect(showToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+    // The line does not come back — the deletion is real.
+    expect(screen.queryByTestId('invoice-line-line-1')).not.toBeInTheDocument();
+  });
+
+  it('unmount flushes a pending deletion instead of losing it', async () => {
+    const { unmount } = render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-1'));
+    expect(deletePosted()).toBe(false);
+
+    unmount();
+    expect(deletePosted()).toBe(true);
+  });
+
+  it('the workspace flush hook fires pending DELETEs immediately (held Issue path)', async () => {
+    let flush: (() => void) | null = null;
+    render(
+      <InvoiceEditor
+        detail={draft([manualLine])}
+        onChanged={vi.fn()}
+        onRegisterPendingDeleteFlush={(f) => { flush = f; }}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-1')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-1'));
+    expect(deletePosted()).toBe(false);
+    act(() => { flush!(); });
+    expect(deletePosted()).toBe(true);
+  });
+});

--- a/apps/web/src/components/billing/InvoiceEditor.undodelete.test.tsx
+++ b/apps/web/src/components/billing/InvoiceEditor.undodelete.test.tsx
@@ -160,6 +160,48 @@ describe('InvoiceEditor — undo-able line deletion', () => {
     expect(screen.getByTestId('invoice-line-child-line-child')).toBeInTheDocument();
   });
 
+  it('optimistically excludes a deleted line from Subtotal/Tax/Total during the undo window (and restores them on undo)', async () => {
+    // The deferred DELETE hides the row and updates margin instantly, but the
+    // server totals still include the line until the flush + refetch land. For
+    // the whole undo window the rail/sticky bar must render totals computed
+    // from the VISIBLE lines — a money document whose Total contradicts its
+    // own line table reads as broken (the quote editor's optimisticTotals
+    // contract, carried over).
+    const taxed: InvoiceDetail['lines'][number] = {
+      ...manualLine, id: 'line-2', name: 'Hardware', quantity: '1.00', unitPrice: '50.00',
+      lineTotal: '50.00', taxable: true,
+    };
+    const detail = draft([manualLine, taxed]);
+    detail.invoice.subtotal = '150.00';
+    detail.invoice.taxRate = '0.10000';
+    detail.invoice.taxTotal = '5.00';
+    detail.invoice.total = '155.00';
+    render(<InvoiceEditor detail={detail} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('invoice-line-line-2')).toBeInTheDocument());
+
+    // At rest the rail renders the authoritative server figures.
+    expect(screen.getByTestId('invoice-subtotal')).toHaveTextContent('$150.00');
+    expect(screen.getByTestId('invoice-tax')).toHaveTextContent('$5.00');
+    expect(screen.getByTestId('invoice-total')).toHaveTextContent('$155.00');
+
+    fireEvent.click(screen.getByTestId('invoice-line-remove-line-2'));
+
+    // The line is hidden and the totals immediately exclude it — including the
+    // tax it carried and the sticky mobile bar's total.
+    expect(screen.queryByTestId('invoice-line-line-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoice-subtotal')).toHaveTextContent('$100.00');
+    expect(screen.getByTestId('invoice-tax')).toHaveTextContent('$0.00');
+    expect(screen.getByTestId('invoice-total')).toHaveTextContent('$100.00');
+    expect(screen.getByTestId('invoice-totals-sticky-total')).toHaveTextContent('$100.00');
+
+    // Undo restores the row AND the authoritative server totals.
+    act(() => { lastUndoToast().onUndo(); });
+    expect(screen.getByTestId('invoice-line-line-2')).toBeInTheDocument();
+    expect(screen.getByTestId('invoice-subtotal')).toHaveTextContent('$150.00');
+    expect(screen.getByTestId('invoice-tax')).toHaveTextContent('$5.00');
+    expect(screen.getByTestId('invoice-total')).toHaveTextContent('$155.00');
+  });
+
   it('an Undo click after the DELETE already flushed gets a "too late" notice, not silence', async () => {
     let flush: (() => void) | null = null;
     render(<InvoiceEditor detail={draft([manualLine])} onChanged={vi.fn()} onRegisterPendingDeleteFlush={(f) => { flush = f; }} />);

--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -168,19 +168,52 @@ describe('InvoiceWorkspace', () => {
     render(<InvoiceWorkspace id="inv-1" />);
     await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
 
-    // Dirty the notes field → the header shows the saving hint.
+    // Edit + blur → the PATCH is genuinely in flight → the header shows the
+    // saving hint. (Typing alone is not "saving": nothing has been sent yet.)
     fireEvent.change(screen.getByTestId('invoice-notes'), { target: { value: 'Edited' } });
+    fireEvent.blur(screen.getByTestId('invoice-notes'));
     await waitFor(() => expect(screen.getByTestId('invoice-issue-saving-hint')).toBeInTheDocument());
 
     // Clicking Issue queues (nothing fires while the save is pending)…
     fireEvent.click(screen.getByTestId('invoice-issue'));
     expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith('/issue'))).toBe(false);
 
-    // …the blur-save starts and lands → quiescence → the queued Issue fires.
-    fireEvent.blur(screen.getByTestId('invoice-notes'));
+    // …the save lands → quiescence → the queued Issue fires.
     resolvePatch(json({ data: {} }));
     await waitFor(() =>
       expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith('/issue') && (c[1] as RequestInit)?.method === 'POST')).toBe(true),
     );
+  });
+
+  it('does NOT fire a queued Issue when the pending save fails — the whole point of the failure nonce', async () => {
+    // Both halves of this are unit-tested in isolation and never meet there:
+    // the editor proves it reports a failure, InvoiceActions proves it cancels
+    // on one. This is the wiring. Deleting `saveFailureNonce` from the
+    // InvoiceActions element below must fail HERE, or the prop is unguarded.
+    let rejectPatch!: (v: Response) => void;
+    const patchPromise = new Promise<Response>((resolve) => { rejectPatch = resolve; });
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') return patchPromise;
+      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') return json({ data: { id: 'inv-1', status: 'sent' } });
+      if (input === '/invoices/inv-1/payments') return json({ data: [] });
+      if (input === '/invoices/inv-1') return json({ data: invoice({}) });
+      return json({ data: {} });
+    });
+    render(<InvoiceWorkspace id="inv-1" />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('invoice-notes'), { target: { value: 'Edited' } });
+    fireEvent.blur(screen.getByTestId('invoice-notes'));
+    await waitFor(() => expect(screen.getByTestId('invoice-issue-saving-hint')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+
+    // The save FAILS. The in-flight key clears, so the editor now looks quiet —
+    // firing the queue here would number the invoice without the edit.
+    rejectPatch(json({ error: 'boom' }, false, 500));
+
+    await waitFor(() => expect(screen.getByTestId('invoice-issue-unsaved-hint')).toBeInTheDocument());
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith('/issue') && (c[1] as RequestInit)?.method === 'POST')).toBe(false);
   });
 });

--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import InvoiceWorkspace from './InvoiceWorkspace';
+import { _resetShowMarginMemoryForTests } from './billingUi';
 import { fetchWithAuth } from '../../stores/auth';
 
 vi.mock('../../stores/auth', () => ({
@@ -48,7 +49,14 @@ function invoice(over: Record<string, unknown>) {
 }
 
 describe('InvoiceWorkspace', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The margin preference persists to localStorage plus an in-memory mirror
+    // that survives storage clears — reset both to isolate every test from its
+    // neighbours' toggles.
+    localStorage.clear();
+    _resetShowMarginMemoryForTests();
+  });
 
   it('renders a draft as the editor with a "Draft invoice" header', async () => {
     fetchMock.mockImplementation(async (input: string) => {
@@ -56,7 +64,7 @@ describe('InvoiceWorkspace', () => {
       if (input === '/invoices/inv-1') return json({ data: invoice({}) });
       return json({ data: {} });
     });
-    render(<InvoiceWorkspace invoiceId="inv-1" />);
+    render(<InvoiceWorkspace id="inv-1" />);
     await waitFor(() => expect(screen.getByTestId('invoice-workspace-title')).toHaveTextContent('Draft invoice'));
     expect(screen.getByTestId('invoice-editor')).toBeInTheDocument();
   });
@@ -66,7 +74,7 @@ describe('InvoiceWorkspace', () => {
       if (input === '/invoices/inv-1') return json(null, false, 500);
       return json({ data: {} });
     });
-    render(<InvoiceWorkspace invoiceId="inv-1" />);
+    render(<InvoiceWorkspace id="inv-1" />);
     await waitFor(() => expect(screen.getByTestId('invoice-workspace-error')).toBeInTheDocument());
   });
 
@@ -90,7 +98,7 @@ describe('InvoiceWorkspace', () => {
       return json({ data: {} });
     });
 
-    render(<InvoiceWorkspace invoiceId="inv-1" />);
+    render(<InvoiceWorkspace id="inv-1" />);
     await waitFor(() => expect(screen.getByTestId('invoice-workspace-title')).toHaveTextContent('Draft invoice'));
 
     fireEvent.click(screen.getByTestId('invoice-issue'));
@@ -98,5 +106,81 @@ describe('InvoiceWorkspace', () => {
     await waitFor(() => expect(screen.getByTestId('invoice-workspace-title')).toHaveTextContent('INV-2026-0002'));
     // The draft editor is gone once issued — the read-only detail takes over.
     expect(screen.queryByTestId('invoice-editor')).not.toBeInTheDocument();
+  });
+
+  it('keeps the draft editor MOUNTED (hidden, not unmounted) while another tab is active', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1') return json({ data: invoice({}) });
+      return json({ data: {} });
+    });
+    render(<InvoiceWorkspace id="inv-1" />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    // Half-typed editor state (an add-line name) that unmounting would discard.
+    fireEvent.click(screen.getByTestId('invoice-add-mode-manual'));
+    fireEvent.change(screen.getByTestId('invoice-manual-name'), { target: { value: 'Half-typed line' } });
+
+    fireEvent.click(screen.getByTestId('invoice-tab-preview'));
+    // The editor is still in the DOM (hidden via CSS), so its local state — and
+    // the savePending gate — survive a "just checking the preview" round-trip.
+    expect(screen.getByTestId('invoice-editor')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('invoice-tab-editor'));
+    expect(screen.getByTestId('invoice-manual-name')).toHaveValue('Half-typed line');
+  });
+
+  it('offers the cost/margin toggle in the pinned header on the Editor tab, gating the margin panel', async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1') return json({ data: invoice({}) });
+      return json({ data: {} });
+    });
+    render(<InvoiceWorkspace id="inv-1" />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    // Default is "no margin on screen": panel hidden, header toggle available.
+    expect(screen.queryByTestId('invoice-margin')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('invoice-editor-toggle-internal'));
+    expect(screen.getByTestId('invoice-margin')).toBeInTheDocument();
+    // Persists under the billing-wide key shared with the quote surfaces.
+    expect(localStorage.getItem('breeze:quote-editor-show-margin')).toBe('1');
+
+    fireEvent.click(screen.getByTestId('invoice-editor-toggle-internal'));
+    expect(screen.queryByTestId('invoice-margin')).not.toBeInTheDocument();
+  });
+
+  // End-to-end quiescence wiring: the editor's dirty state must reach the
+  // header's Issue gate THROUGH the workspace (savePending / onPendingEditsChange
+  // / the queue). Both endpoints are unit-tested; this pins the plumbing —
+  // deleting any of the threaded props should fail here.
+  it('holds a header Issue click while the editor is dirty, then fires it when the save settles', async () => {
+    let resolvePatch!: (v: Response) => void;
+    const patchPromise = new Promise<Response>((resolve) => { resolvePatch = resolve; });
+    fetchMock.mockImplementation(async (input: string, opts?: RequestInit) => {
+      if (input.startsWith('/catalog')) return json({ data: [] });
+      if (input === '/invoices/inv-1' && opts?.method === 'PATCH') return patchPromise;
+      if (input === '/invoices/inv-1/issue' && opts?.method === 'POST') return json({ data: { id: 'inv-1', status: 'sent' } });
+      if (input === '/invoices/inv-1/payments') return json({ data: [] });
+      if (input === '/invoices/inv-1') return json({ data: invoice({}) });
+      return json({ data: {} });
+    });
+    render(<InvoiceWorkspace id="inv-1" />);
+    await waitFor(() => expect(screen.getByTestId('invoice-editor')).toBeInTheDocument());
+
+    // Dirty the notes field → the header shows the saving hint.
+    fireEvent.change(screen.getByTestId('invoice-notes'), { target: { value: 'Edited' } });
+    await waitFor(() => expect(screen.getByTestId('invoice-issue-saving-hint')).toBeInTheDocument());
+
+    // Clicking Issue queues (nothing fires while the save is pending)…
+    fireEvent.click(screen.getByTestId('invoice-issue'));
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith('/issue'))).toBe(false);
+
+    // …the blur-save starts and lands → quiescence → the queued Issue fires.
+    fireEvent.blur(screen.getByTestId('invoice-notes'));
+    resolvePatch(json({ data: {} }));
+    await waitFor(() =>
+      expect(fetchMock.mock.calls.some((c) => String(c[0]).endsWith('/issue') && (c[1] as RequestInit)?.method === 'POST')).toBe(true),
+    );
   });
 });

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -39,9 +39,13 @@ export default function InvoiceWorkspace({ id }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [tab, setTab] = useState<Tab>('editor');
-  // True while the editor has an in-flight save or a dirty rail field — the
-  // header Issue buttons wait for quiescence so they can't race a blur-save.
+  // True while the editor has work genuinely in flight — the header Issue
+  // buttons wait for quiescence so they can't race a blur-save.
   const [editorSavePending, setEditorSavePending] = useState(false);
+  // Label of a field left dirty with nothing in flight (its save failed, or
+  // never fired). Kept separate from editorSavePending because the two need
+  // opposite handling: one is worth waiting for, the other never resolves.
+  const [editorUnsavedField, setEditorUnsavedField] = useState<string | null>(null);
   // Monotonic count of editor save FAILURES. A failed save can still produce
   // "quiescence" (a failed delete-flush restores its rows; a failed line
   // blur-save clears its in-flight key), so InvoiceActions must cancel a
@@ -182,6 +186,7 @@ export default function InvoiceWorkspace({ id }: Props) {
             onChanged={reload}
             variant="header"
             savePending={editorSavePending}
+            unsavedFieldLabel={editorUnsavedField}
             saveFailureNonce={saveFailureNonce}
             onIssueWhilePending={flushEditorPendingDeletes}
           />
@@ -202,6 +207,7 @@ export default function InvoiceWorkspace({ id }: Props) {
             detail={detail}
             onChanged={() => void reload()}
             onPendingEditsChange={setEditorSavePending}
+            onUnsavedEditsChange={setEditorUnsavedField}
             onSaveFailure={reportSaveFailure}
             onRegisterPendingDeleteFlush={registerPendingDeleteFlush}
             showMargin={showMargin}

--- a/apps/web/src/components/billing/InvoiceWorkspace.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../lib/i18n';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { DocumentWorkspace, type DocumentTab } from './shared/DocumentWorkspace';
 import { StatusPill } from './shared/StatusPill';
+import { MarginToggle, useShowMargin } from './billingUi';
 import InvoiceEditor from './InvoiceEditor';
 import InvoiceDetail from './InvoiceDetail';
 import InvoiceDocumentPreview from './InvoiceDocument';
@@ -22,7 +23,7 @@ const TAB_LABELS: { value: Tab; labelKey: string }[] = [
 ];
 
 interface Props {
-  invoiceId?: string;
+  id?: string;
 }
 
 function readTab(isDraft: boolean): Tab {
@@ -32,23 +33,49 @@ function readTab(isDraft: boolean): Tab {
   return isDraft ? 'editor' : 'detail';
 }
 
-export default function InvoiceWorkspace({ invoiceId }: Props) {
+export default function InvoiceWorkspace({ id }: Props) {
   const { t } = useTranslation('billing');
   const [detail, setDetail] = useState<InvoiceDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
   const [tab, setTab] = useState<Tab>('editor');
+  // True while the editor has an in-flight save or a dirty rail field — the
+  // header Issue buttons wait for quiescence so they can't race a blur-save.
+  const [editorSavePending, setEditorSavePending] = useState(false);
+  // Monotonic count of editor save FAILURES. A failed save can still produce
+  // "quiescence" (a failed delete-flush restores its rows; a failed line
+  // blur-save clears its in-flight key), so InvoiceActions must cancel a
+  // queued Issue on failure — waiting for quiet alone would issue an invoice
+  // that contradicts what the user last saw.
+  const [saveFailureNonce, setSaveFailureNonce] = useState(0);
+  const reportSaveFailure = useCallback(() => setSaveFailureNonce((n) => n + 1), []);
+  // Cost/margin visibility is workspace state so the toggle can live in the
+  // pinned header while the editor's margin panel consumes it (mirrors
+  // QuoteWorkspace; the shared hook keeps the Detail tab's pill in sync).
+  const [showMargin, toggleShowMargin] = useShowMargin();
+  // Bridge between the editor's deferred deletions (undo grace window) and the
+  // header's Issue: the editor registers a "flush now" hook, and InvoiceActions
+  // calls it when Issue is clicked while edits are pending — so a held Issue
+  // fires as soon as the deferred DELETE lands instead of waiting out the
+  // remainder of the undo window (mirrors QuoteWorkspace's Send bridge).
+  const pendingDeleteFlushRef = useRef<(() => void) | null>(null);
+  const registerPendingDeleteFlush = useCallback((flush: (() => void) | null) => {
+    pendingDeleteFlushRef.current = flush;
+  }, []);
+  const flushEditorPendingDeletes = useCallback(() => {
+    pendingDeleteFlushRef.current?.();
+  }, []);
 
   // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
   // so the editor stays mounted — a full-page spinner would remount the form and
   // discard the user's in-progress local state and cursor position. Only the
   // initial load shows the spinner / replaces the view on error.
   const fetchDetail = useCallback(async (quiet = false) => {
-    if (!invoiceId) { setError(t('invoiceWorkspace.errors.missingId')); setLoading(false); return; }
+    if (!id) { setError(t('invoiceWorkspace.errors.missingId')); setLoading(false); return; }
     try {
       if (!quiet) setLoading(true);
       setError(undefined);
-      const res = await fetchWithAuth(`/invoices/${invoiceId}`);
+      const res = await fetchWithAuth(`/invoices/${id}`);
       if (res.status === 401) return UNAUTHORIZED();
       if (res.status === 404) { if (!quiet) setError(t('invoiceWorkspace.errors.notFound')); return; }
       if (!res.ok) throw new Error(t('invoiceWorkspace.errors.loadFailed'));
@@ -61,7 +88,7 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
     } finally {
       if (!quiet) setLoading(false);
     }
-  }, [invoiceId, t]);
+  }, [id, t]);
 
   const load = useCallback(() => fetchDetail(false), [fetchDetail]);
   const reload = useCallback(() => fetchDetail(true), [fetchDetail]);
@@ -142,13 +169,44 @@ export default function InvoiceWorkspace({ invoiceId }: Props) {
       // money-moment) and Download are reachable from any tab, not buried inside
       // the Editor tab. The Detail tab suppresses its rail copy (actionsInHeader)
       // so the two never render at once.
-      actions={<InvoiceActions detail={detail} onChanged={reload} variant="header" />}
+      // The cost/margin toggle joins the header actions while the Editor tab is
+      // up, so the "no margin on screen" control is available without scrolling
+      // (same placement + testid grammar as QuoteWorkspace).
+      actions={
+        <>
+          {isDraft && activeTab === 'editor' && (
+            <MarginToggle show={showMargin} onToggle={toggleShowMargin} testId="invoice-editor-toggle-internal" size="md" />
+          )}
+          <InvoiceActions
+            detail={detail}
+            onChanged={reload}
+            variant="header"
+            savePending={editorSavePending}
+            saveFailureNonce={saveFailureNonce}
+            onIssueWhilePending={flushEditorPendingDeletes}
+          />
+        </>
+      }
       tabs={tabs}
       activeTab={activeTab}
       onTabChange={selectTab}
     >
-      {activeTab === 'editor' && isDraft && (
-        <InvoiceEditor detail={detail} onChanged={() => void reload()} />
+      {/* The editor stays MOUNTED across tab switches (hidden, not unmounted):
+          unmounting discarded any half-typed add-line input the moment a tech
+          flipped to Preview "just to check" — brutal mid-flow data loss.
+          Hidden-but-mounted also keeps the savePending gate live while
+          previewing (mirrors QuoteWorkspace). */}
+      {isDraft && (
+        <div className={activeTab === 'editor' ? '' : 'hidden'}>
+          <InvoiceEditor
+            detail={detail}
+            onChanged={() => void reload()}
+            onPendingEditsChange={setEditorSavePending}
+            onSaveFailure={reportSaveFailure}
+            onRegisterPendingDeleteFlush={registerPendingDeleteFlush}
+            showMargin={showMargin}
+          />
+        </div>
       )}
       {activeTab === 'preview' && (
         <InvoiceDocumentPreview detail={detail} />

--- a/apps/web/src/components/billing/billingUi.showmargin.test.tsx
+++ b/apps/web/src/components/billing/billingUi.showmargin.test.tsx
@@ -1,0 +1,58 @@
+// The billing-wide "show cost & margin" preference must stay coherent across
+// every mounted consumer: same-page instances sync via a custom event (the
+// browser's `storage` event only fires in OTHER tabs), and other tabs sync via
+// `storage`. Removing either channel makes "no margin on screen" a per-widget
+// promise — the exact leak the hook exists to prevent.
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MarginToggle, useShowMargin, SHOW_INTERNAL_MARGIN_KEY, _resetShowMarginMemoryForTests } from './billingUi';
+
+// Two independent hook consumers on one page — e.g. the workspace header
+// toggle and a Detail tab's pill.
+function Consumer({ id }: { id: string }) {
+  const [show, toggle] = useShowMargin();
+  return (
+    <div>
+      <MarginToggle show={show} onToggle={toggle} testId={`toggle-${id}`} />
+      <span data-testid={`state-${id}`}>{show ? 'on' : 'off'}</span>
+    </div>
+  );
+}
+
+describe('useShowMargin — cross-instance sync', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetShowMarginMemoryForTests();
+  });
+
+  it('flipping one instance updates every other instance on the page', async () => {
+    render(<><Consumer id="a" /><Consumer id="b" /></>);
+    expect(screen.getByTestId('state-a')).toHaveTextContent('off');
+    expect(screen.getByTestId('state-b')).toHaveTextContent('off');
+
+    fireEvent.click(screen.getByTestId('toggle-a'));
+    expect(screen.getByTestId('state-a')).toHaveTextContent('on');
+    // The sibling hears about it via the deferred sync event.
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.getByTestId('state-b')).toHaveTextContent('on');
+    expect(localStorage.getItem(SHOW_INTERNAL_MARGIN_KEY)).toBe('1');
+
+    fireEvent.click(screen.getByTestId('toggle-b'));
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.getByTestId('state-a')).toHaveTextContent('off');
+    expect(screen.getByTestId('state-b')).toHaveTextContent('off');
+  });
+
+  it('a storage event from another tab syncs mounted instances', () => {
+    render(<Consumer id="a" />);
+    expect(screen.getByTestId('state-a')).toHaveTextContent('off');
+
+    // Another tab persisted "on" — the storage event carries it here.
+    localStorage.setItem(SHOW_INTERNAL_MARGIN_KEY, '1');
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: SHOW_INTERNAL_MARGIN_KEY, newValue: '1' }));
+    });
+    expect(screen.getByTestId('state-a')).toHaveTextContent('on');
+  });
+});

--- a/apps/web/src/components/billing/billingUi.showmargin.test.tsx
+++ b/apps/web/src/components/billing/billingUi.showmargin.test.tsx
@@ -4,7 +4,7 @@
 // `storage`. Removing either channel makes "no margin on screen" a per-widget
 // promise — the exact leak the hook exists to prevent.
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MarginToggle, useShowMargin, SHOW_INTERNAL_MARGIN_KEY, _resetShowMarginMemoryForTests } from './billingUi';
 
@@ -54,5 +54,42 @@ describe('useShowMargin — cross-instance sync', () => {
       window.dispatchEvent(new StorageEvent('storage', { key: SHOW_INTERNAL_MARGIN_KEY, newValue: '1' }));
     });
     expect(screen.getByTestId('state-a')).toHaveTextContent('on');
+  });
+
+  it('keeps instances in sync when localStorage THROWS (private mode / blocked storage)', async () => {
+    // This is the branch the memory mirror exists for, and it is the one that
+    // matters most: a tech screen-sharing in a private window who hides margin
+    // must not have it reappear in the sibling widget. If the sync event were
+    // conditional on a successful write, "hide" would become per-widget here.
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => { throw new Error('blocked'); });
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('blocked'); });
+    try {
+      render(<><Consumer id="a" /><Consumer id="b" /></>);
+      expect(screen.getByTestId('state-a')).toHaveTextContent('off');
+
+      fireEvent.click(screen.getByTestId('toggle-a'));
+      await act(async () => { await Promise.resolve(); });
+
+      expect(screen.getByTestId('state-a')).toHaveTextContent('on');
+      expect(screen.getByTestId('state-b')).toHaveTextContent('on');
+      expect(setItem).toHaveBeenCalled(); // it tried; the throw was absorbed
+    } finally {
+      getItem.mockRestore();
+      setItem.mockRestore();
+    }
+  });
+
+  it('a healthy but EMPTY storage wins over a stale memory mirror', async () => {
+    // Preferring the mirror on a merely-absent key would resurrect a cleared
+    // preference. Absent means default-off, and only an access throw hands
+    // authority to the mirror.
+    render(<Consumer id="a" />);
+    fireEvent.click(screen.getByTestId('toggle-a'));
+    await act(async () => { await Promise.resolve(); });
+    expect(screen.getByTestId('state-a')).toHaveTextContent('on');
+
+    localStorage.clear(); // the mirror still says "on"
+    act(() => { window.dispatchEvent(new StorageEvent('storage', { key: SHOW_INTERNAL_MARGIN_KEY, newValue: null })); });
+    expect(screen.getByTestId('state-a')).toHaveTextContent('off');
   });
 });

--- a/apps/web/src/components/billing/billingUi.tsx
+++ b/apps/web/src/components/billing/billingUi.tsx
@@ -1,11 +1,115 @@
 // Shared presentational helpers for the quote + invoice billing UI, so copy and
 // affordances can't drift between the editor and detail/document surfaces.
 
-import { AlertTriangle } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { AlertTriangle, Eye, EyeOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import '../../lib/i18n';
 import { marginPct, type QuoteProfit } from '@breeze/shared';
 import { formatMoney } from './quotes/quoteTypes';
+
+/**
+ * The ONE persisted "internal costs on screen?" preference for the whole billing
+ * area. Its contract is "no margin on screen": when a screen-sharing tech hides
+ * cost & margin it must STAY hidden across tabs and across quote/invoice
+ * surfaces — a per-surface preference would leak margin the moment they open the
+ * other document type. (The key name predates the invoice adoption; it's kept so
+ * existing saved preferences survive.)
+ */
+export const SHOW_INTERNAL_MARGIN_KEY = 'breeze:quote-editor-show-margin';
+
+// Same-page sync channel between hook instances: the `storage` event only fires
+// in OTHER browser tabs, so without this a workspace-header toggle and a Detail
+// pill on the same page would drift apart — "hide cost & margin" that leaves a
+// second copy of the margin on screen is a broken promise.
+const SHOW_MARGIN_EVENT = 'breeze:show-margin-change';
+
+// In-memory fallback for restricted-storage contexts (private mode, blocked
+// third-party storage): when localStorage is unusable the preference still has
+// to stay coherent across every mounted instance for the life of the page —
+// "hide cost & margin" that leaves a second copy of the margin on screen is
+// the exact broken promise this hook exists to prevent. Session-only by nature.
+let memoryShowMargin: boolean | null = null;
+
+/** Test-only: the memory mirror outlives `localStorage.clear()` (that's its
+ *  job), so suites that toggle the preference reset it between tests — same
+ *  pattern as Toast's `_resetToastQueueForTests`. */
+export function _resetShowMarginMemoryForTests() {
+  memoryShowMargin = null;
+}
+
+function readShowMargin(): boolean {
+  try {
+    // Healthy storage is the single source of truth — including "key absent"
+    // meaning the default (off). The memory mirror takes over only when
+    // storage ACCESS throws (private mode / blocked storage); preferring it on
+    // a merely-absent key would let a stale mirror override a cleared pref.
+    if (typeof localStorage !== 'undefined') return localStorage.getItem(SHOW_INTERNAL_MARGIN_KEY) === '1';
+  } catch { /* storage unusable — fall through to the memory mirror */ }
+  return memoryShowMargin ?? false;
+}
+
+/** Read + flip the persisted cost/margin visibility preference. Every mounted
+ *  instance stays in sync: same-page via SHOW_MARGIN_EVENT, cross-tab via the
+ *  browser's `storage` event. */
+export function useShowMargin(): [boolean, () => void] {
+  const [showMargin, setShowMargin] = useState(readShowMargin);
+  useEffect(() => {
+    const sync = () => setShowMargin(readShowMargin());
+    window.addEventListener('storage', sync);
+    window.addEventListener(SHOW_MARGIN_EVENT, sync);
+    return () => {
+      window.removeEventListener('storage', sync);
+      window.removeEventListener(SHOW_MARGIN_EVENT, sync);
+    };
+  }, []);
+  const toggleMargin = useCallback(() => {
+    setShowMargin((v) => {
+      const next = !v;
+      // The memory mirror is written unconditionally and the sibling-sync event
+      // ALWAYS dispatches — even when localStorage is unavailable — so every
+      // instance on the page agrees regardless of storage health. The dispatch
+      // is deferred to a microtask so listeners re-read state after this
+      // updater's writes have landed (and a StrictMode double-invoke stays
+      // idempotent: same value written, same event fired).
+      memoryShowMargin = next;
+      try { localStorage.setItem(SHOW_INTERNAL_MARGIN_KEY, next ? '1' : '0'); } catch { /* memory mirror carries it */ }
+      queueMicrotask(() => window.dispatchEvent(new Event(SHOW_MARGIN_EVENT)));
+      return next;
+    });
+  }, []);
+  return [showMargin, toggleMargin];
+}
+
+/**
+ * The toggle that flips the preference — one control vocabulary for
+ * "show/hide internal costs" across the billing surfaces: the detail rails
+ * (`sm`) and the quote workspace's pinned header (`md`). The quote editor's
+ * toolbar keeps an uncontrolled fallback copy only for standalone
+ * mounts/tests; in the app the workspace header owns the control.
+ */
+export function MarginToggle({ show, onToggle, testId, size = 'sm' }: { show: boolean; onToggle: () => void; testId: string; size?: 'sm' | 'md' }) {
+  const { t } = useTranslation('billing');
+  // 'sm' — the quiet inline pill on the detail surfaces (h-7 / 28px: the
+  // smallest hit target that clears WCAG 2.5.8's 24px floor with margin — this
+  // pill gates the most sensitive data on screen and must not be the hardest
+  // thing to hit). 'md' — sized to sit among the workspace header's action
+  // buttons. One component so the control reads identically everywhere.
+  const look = size === 'md' ? 'gap-1.5 px-3 py-2 text-sm' : 'h-7 gap-1 px-2.5 text-xs';
+  const icon = size === 'md' ? 'h-4 w-4' : 'h-3.5 w-3.5';
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={show}
+      data-testid={testId}
+      className={`inline-flex shrink-0 items-center rounded-md border font-medium transition-colors hover:bg-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${look} ${show ? 'border-primary/40 bg-primary/10 text-primary' : 'text-muted-foreground'}`}
+    >
+      {show ? <EyeOff className={icon} aria-hidden="true" /> : <Eye className={icon} aria-hidden="true" />}
+      {show ? t('billingUi.hideCostMargin') : t('billingUi.showCostMargin')}
+    </button>
+  );
+}
 
 /**
  * Inline "Unsaved" affordance for blur-saved fields (terms / notes). Shown while
@@ -22,7 +126,7 @@ export function UnsavedBadge({ show, testId = 'unsaved-badge' }: { show: boolean
       // when a blur-save fails and the edit stays dirty — is announced, not just
       // shown. Dark-amber text (not the ~2:1 bright warning) keeps it readable.
       role="status"
-      className="inline-flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide text-warning-foreground dark:text-warning"
+      className="inline-flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-warning-foreground dark:text-warning"
       data-testid={testId}
     >
       <span className="h-1.5 w-1.5 rounded-full bg-warning" aria-hidden="true" />

--- a/apps/web/src/components/billing/quotes/DistributorLookup.tsx
+++ b/apps/web/src/components/billing/quotes/DistributorLookup.tsx
@@ -240,7 +240,7 @@ export default function DistributorLookup({ blockId, busy, onImportAdd }: Distri
               {lifecycle && (
                 <span
                   data-testid={`quote-distributor-eol-${p.synnexSku}`}
-                  className="rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive"
+                  className="rounded-full border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive"
                 >
                   {lifecycle === 'eol'
                     ? t('quotes.distributorLookup.endOfLife')
@@ -250,7 +250,7 @@ export default function DistributorLookup({ blockId, busy, onImportAdd }: Distri
               {outOfStock && (
                 <span
                   data-testid={`quote-distributor-oos-${p.synnexSku}`}
-                  className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-400"
+                  className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400"
                 >
                   {t('quotes.distributorLookup.outOfStock')}
                 </span>
@@ -292,7 +292,7 @@ export default function DistributorLookup({ blockId, busy, onImportAdd }: Distri
                 onClick={() => { if (parsed != null) onImportAdd(p, parsed); }}
                 disabled={busy || parsed == null}
                 data-testid={`quote-distributor-add-${p.synnexSku}`}
-                className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
               >
                 {t('quotes.distributorLookup.importAndAdd')}
               </button>

--- a/apps/web/src/components/billing/quotes/Pax8ProductLookup.tsx
+++ b/apps/web/src/components/billing/quotes/Pax8ProductLookup.tsx
@@ -142,7 +142,7 @@ export default function Pax8ProductLookup({ blockId, busy, onImportAdd }: Props)
                 onClick={() => { if (parsed != null && term) onImportAdd(p, term, parsed); }}
                 disabled={busy || parsed == null || !term}
                 data-testid={`pax8-product-add-${p.pax8ProductId}`}
-                className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
               >
                 {t('quotes.pax8ProductLookup.importAndAdd')}
               </button>

--- a/apps/web/src/components/billing/quotes/QuoteActions.clone.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.clone.test.tsx
@@ -70,7 +70,7 @@ describe('QuoteActions cloning', () => {
 
     openCloneDialog();
     // The dialog defaults to the source company and a "Clone of …" title.
-    expect(screen.getByTestId('quote-clone-org')).toHaveValue('org-1');
+    expect(screen.getByTestId('quote-clone-org-trigger')).toHaveTextContent('Acme');
     expect(screen.getByTestId('quote-clone-title')).toHaveValue('Clone of Q-2026-000001');
     fireEvent.click(screen.getByTestId('quote-clone-confirm'));
 
@@ -89,7 +89,9 @@ describe('QuoteActions cloning', () => {
     render(<QuoteActions detail={detail} variant="header" />);
 
     openCloneDialog();
-    fireEvent.change(screen.getByTestId('quote-clone-org'), { target: { value: 'org-2' } });
+    // The company picker is a typeahead combobox: open it, pick the org.
+    fireEvent.click(screen.getByTestId('quote-clone-org-trigger'));
+    fireEvent.click(screen.getByTestId('quote-clone-org-option-org-2'));
     // Retargeting surfaces the billing/tax consequences before confirming.
     expect(screen.getByTestId('quote-clone-retarget-hint')).toBeInTheDocument();
     fireEvent.change(screen.getByTestId('quote-clone-title'), { target: { value: 'Beta rollout' } });

--- a/apps/web/src/components/billing/quotes/QuoteActions.margincheck.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.margincheck.test.tsx
@@ -2,11 +2,15 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteActions from './QuoteActions';
+import { SHOW_INTERNAL_MARGIN_KEY } from '../billingUi';
+import { fetchWithAuth } from '../../../stores/auth';
 import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
 
 // Task 3 of the quote-editor UX pass: a NON-BLOCKING send-time notice when the
 // profit estimate is incomplete (some billed line has no cost) — visible only
-// to users who can already see margin (quotes:read), and never disabling Send.
+// to users who can already see margin (quotes:read) AND currently have the
+// "show cost & margin" preference on (the toggle's contract is "no margin on
+// screen", and the send dialog is a screen too), never disabling Send.
 const state = vi.hoisted(() => ({ canSeeMargin: true }));
 vi.mock('../../../lib/permissions', () => ({
   usePermissions: () => ({ can: (resource: string, action: string) => {
@@ -62,6 +66,14 @@ beforeEach(() => {
   vi.clearAllMocks();
   scheduleQuoteSendMock.mockResolvedValue({ data: { sendScheduledAt: '2099-01-01T00:00:00Z' } });
   state.canSeeMargin = true;
+  // Re-pin the org-prefill response: the no-contact-hint tests below override
+  // the implementation, and clearAllMocks does not restore implementations.
+  vi.mocked(fetchWithAuth).mockImplementation(async () =>
+    ({ ok: true, json: async () => ({ billingContact: { email: 'ap@customer.example' } }) }) as unknown as Response);
+  // The notice is additionally gated on the persisted margin-visibility
+  // preference (default off) — turn it on so the permission cases below test
+  // what they mean to test.
+  localStorage.setItem(SHOW_INTERNAL_MARGIN_KEY, '1');
 });
 
 describe('QuoteActions — send-time incomplete-profit notice', () => {
@@ -91,6 +103,44 @@ describe('QuoteActions — send-time incomplete-profit notice', () => {
     await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
 
     expect(screen.queryByTestId('quote-send-missing-cost-notice')).not.toBeInTheDocument();
+  });
+
+  it('is absent while "Hide cost & margin" is on — the toggle governs the send dialog too', async () => {
+    // A tech hides margin precisely because a client is watching the screen;
+    // the send dialog is the moment the client is MOST likely watching, so the
+    // internal cost-tracking notice must honor the same contract.
+    localStorage.setItem(SHOW_INTERNAL_MARGIN_KEY, '0');
+    render(<QuoteActions detail={draft([lineMissingCost])} onChanged={vi.fn()} variant="rail" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-send-missing-cost-notice')).not.toBeInTheDocument();
+  });
+
+  // ---- the "why is To empty" hint (no-billing-contact) ---------------------
+  // The contract is precise: the hint renders only when the org lookup
+  // SUCCEEDS with no email — a failed lookup must stay silent, because
+  // "unknown" is not "absent" and the hint would be a false claim.
+  it('explains an empty To when the org confirmably has no billing contact, until an address is typed', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      ({ ok: true, json: async () => ({ billingContact: null }) }) as unknown as Response);
+
+    render(<QuoteActions detail={draft([lineWithCost])} onChanged={vi.fn()} variant="rail" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-to-no-contact')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId('quote-send-to'), { target: { value: 'ap@customer.example' } });
+    expect(screen.queryByTestId('quote-send-to-no-contact')).not.toBeInTheDocument();
+  });
+
+  it('stays silent about billing contacts when the org lookup fails', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () => { throw new Error('network'); });
+
+    render(<QuoteActions detail={draft([lineWithCost])} onChanged={vi.fn()} variant="rail" />);
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-send-to-no-contact')).not.toBeInTheDocument();
   });
 
   it('sending still works with the notice showing', async () => {

--- a/apps/web/src/components/billing/quotes/QuoteActions.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.test.tsx
@@ -187,6 +187,32 @@ describe('QuoteActions — header variant', () => {
     expect(screen.queryByTestId('quote-send-confirm')).not.toBeInTheDocument();
   });
 
+  it('re-checks the unsaved-field refusal before opening a queued Send composer', async () => {
+    // The click gate tests savePending FIRST, so a click during a deferred
+    // delete queues even while an earlier failed save keeps a field dirty
+    // (its nonce bump happened BEFORE the click, so the captured nonce never
+    // changes). When the editor goes quiet the queue must re-check the label
+    // and refuse — opening the composer would quote a stale total.
+    const { rerender } = render(
+      <QuoteActions detail={sendable()} onChanged={vi.fn()} variant="header" savePending unsavedFieldLabel="Terms & Conditions" />,
+    );
+    await waitFor(() => expect(screen.getByTestId('quote-actions-header')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send'));
+    expect(screen.queryByTestId('quote-send-confirm')).not.toBeInTheDocument();
+
+    // Quiescence arrives with the field STILL flagged unsaved.
+    rerender(
+      <QuoteActions detail={sendable()} onChanged={vi.fn()} variant="header" savePending={false} unsavedFieldLabel="Terms & Conditions" />,
+    );
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warning', message: expect.stringContaining('Terms & Conditions') }),
+    ));
+    await act(async () => {});
+    expect(screen.queryByTestId('quote-send-confirm')).not.toBeInTheDocument();
+  });
+
   it('does not spin the Send button on a bare savePending — only on a queued click', async () => {
     // A spinner promises forthcoming completion. Spinning on savePending meant
     // a field left dirty by a failed save spun indefinitely.

--- a/apps/web/src/components/billing/quotes/QuoteActions.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import QuoteActions from './QuoteActions';
@@ -21,6 +21,8 @@ vi.mock('../../../stores/auth', () => ({
 }));
 vi.mock('../../../lib/api/quotes', () => ({ sendQuote: vi.fn(), deleteQuote: vi.fn(), quotePdfUrl: vi.fn().mockReturnValue('/quotes/q-1/pdf') }));
 vi.mock('../../shared/ConfirmDialog', () => ({ ConfirmDialog: () => null }));
+const showToastMock = vi.fn();
+vi.mock('../../shared/Toast', () => ({ showToast: (a: unknown) => showToastMock(a) }));
 
 function draft(extra: Partial<QuoteDetailData['quote']> = {}): QuoteDetailData {
   return {
@@ -35,6 +37,21 @@ function draft(extra: Partial<QuoteDetailData['quote']> = {}): QuoteDetailData {
     },
     blocks: [],
     lines: [],
+  };
+}
+
+/** A draft that Send will actually arm: one customer-visible line. */
+function sendable(): QuoteDetailData {
+  return {
+    ...draft(),
+    blocks: [{ id: 'b-1', quoteId: 'q-1', orgId: 'org-1', blockType: 'line_items', content: {}, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z' }],
+    lines: [{
+      id: 'l-1', quoteId: 'q-1', blockId: 'b-1', orgId: 'org-1', sourceType: 'manual',
+      catalogItemId: null, parentLineId: null, unitCost: null, sku: null, partNumber: null,
+      name: 'Support', description: null, quantity: '1.00', unitPrice: '100.00', taxable: false,
+      customerVisible: true, lineTotal: '100.00', recurrence: 'one_time', termMonths: null,
+      billingFrequency: null, sortOrder: 0, createdAt: '2026-06-01T00:00:00Z',
+    }],
   };
 }
 
@@ -113,5 +130,73 @@ describe('QuoteActions — header variant', () => {
     // Quiescence arrives → the queued composer opens without another click.
     rerender(<QuoteActions detail={withLine} onChanged={vi.fn()} variant="header" savePending={false} />);
     await waitFor(() => expect(screen.getByTestId('quote-send-confirm')).toBeInTheDocument());
+  });
+
+  it('cancels a queued Send when a save FAILURE arrives with quiescence in the same render', async () => {
+    // The quote side had no failure signal at all: a blur-save that failed
+    // cleared its in-flight key, which read as "quiet", and the composer opened
+    // over a stale total. Both props flip in ONE rerender — split across two,
+    // the assertion would pass even with the guard ordered wrongly.
+    const { rerender } = render(
+      <QuoteActions detail={sendable()} onChanged={vi.fn()} variant="header" savePending saveFailureNonce={0} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('quote-actions-header')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('quote-send'));
+    expect(screen.queryByTestId('quote-send-confirm')).not.toBeInTheDocument();
+
+    rerender(
+      <QuoteActions detail={sendable()} onChanged={vi.fn()} variant="header" savePending={false} saveFailureNonce={1} />,
+    );
+
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' })));
+    await act(async () => {});
+    expect(screen.queryByTestId('quote-send-confirm')).not.toBeInTheDocument();
+  });
+
+  it('drops a queued Send after 10s with honest still-saving copy, not a claimed failure', async () => {
+    // The old copy ("check your connection and try again") asserted a failure
+    // nobody observed — failures are handled by the nonce above, so anything
+    // reaching this timer is genuinely still in flight.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      render(<QuoteActions detail={sendable()} onChanged={vi.fn()} variant="header" savePending />);
+      await waitFor(() => expect(screen.getByTestId('quote-actions-header')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('quote-send'));
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+
+      expect(showToastMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+      expect(screen.queryByTestId('quote-send-confirm')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('refuses a Send click for a field that failed to save, instead of queueing forever', async () => {
+    render(<QuoteActions detail={sendable()} onChanged={vi.fn()} variant="header" unsavedFieldLabel="Terms & Conditions" />);
+    await waitFor(() => expect(screen.getByTestId('quote-actions-header')).toBeInTheDocument());
+
+    expect(screen.queryByTestId('quote-send-saving-hint')).not.toBeInTheDocument();
+    expect(screen.getByTestId('quote-send-unsaved-hint')).toHaveTextContent('Terms & Conditions');
+
+    fireEvent.click(screen.getByTestId('quote-send'));
+    await waitFor(() => expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warning', message: expect.stringContaining('Terms & Conditions') }),
+    ));
+    expect(screen.queryByTestId('quote-send-confirm')).not.toBeInTheDocument();
+  });
+
+  it('does not spin the Send button on a bare savePending — only on a queued click', async () => {
+    // A spinner promises forthcoming completion. Spinning on savePending meant
+    // a field left dirty by a failed save spun indefinitely.
+    render(<QuoteActions detail={sendable()} onChanged={vi.fn()} variant="header" savePending />);
+    await waitFor(() => expect(screen.getByTestId('quote-actions-header')).toBeInTheDocument());
+
+    const send = screen.getByTestId('quote-send');
+    expect(send.querySelector('.animate-spin')).toBeNull();
+
+    fireEvent.click(send); // now something WILL complete
+    expect(send.querySelector('.animate-spin')).not.toBeNull();
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -321,6 +321,14 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     setSendMessage('');
   }, [sending]);
 
+  // Refuse a click (or a queued click reaching quiescence) for a field that
+  // already failed to save — waiting can never clear it, so name the field.
+  // Hoisted so the immediate-click refusal and the queue's re-check share one
+  // toast/message.
+  const refuseForUnsaved = useCallback(() => {
+    showToast({ type: 'warning', message: t('quotes.actions.sendBlockedUnsaved', { field: unsavedFieldLabel }) });
+  }, [unsavedFieldLabel, t]);
+
   // Resolve the queued Send in strict priority: failed → cancel; still working
   // → wait; otherwise open. Cancelling on a CHANGED failure nonce (captured at
   // click time) is what makes quiescence safe to trust — a failed blur-save
@@ -335,8 +343,18 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     }
     if (savePending) return;
     setQueued(null);
+    // The unsaved-field refusal is re-checked here too: the click gate tests
+    // savePending FIRST, so a click during a deferred delete queues even while
+    // an earlier failed save (its nonce bump already captured at click time)
+    // keeps a field dirty. Quiescence cannot clear that field — opening the
+    // composer would quote a stale total. Refuse and name the field, exactly
+    // as an immediate click would have.
+    if (unsavedFieldLabel) {
+      refuseForUnsaved();
+      return;
+    }
     openSend();
-  }, [queued, saveFailureNonce, savePending, openSend, t]);
+  }, [queued, saveFailureNonce, savePending, unsavedFieldLabel, refuseForUnsaved, openSend, t]);
 
   // Escape hatch for a hung save: the queued-open above normally fires within a
   // blur-save round-trip. If the editor is still not quiescent after 10s the
@@ -684,10 +702,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
               if (savePending) { onSendWhilePending?.(); setQueued({ atFailureNonce: saveFailureNonce }); return; }
               // A field that already failed to save will never go quiet on its
               // own — say which one instead of parking the click forever.
-              if (unsavedFieldLabel) {
-                showToast({ type: 'warning', message: t('quotes.actions.sendBlockedUnsaved', { field: unsavedFieldLabel }) });
-                return;
-              }
+              if (unsavedFieldLabel) { refuseForUnsaved(); return; }
               openSend();
             }}
             disabled={sending || isEmpty}

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { AlertTriangle, Loader2, MoreHorizontal } from 'lucide-react';
 import '../../../lib/i18n';
 import { navigateTo } from '@/lib/navigation';
@@ -15,6 +15,8 @@ import { isValidEmail } from '@/lib/email';
 import { cloneQuote, deleteQuote, sendQuote, type SendQuoteOptions, type QuoteSendEmailReason } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { Dialog } from '../../shared/Dialog';
+import { OrgCombobox } from '../shared/OrgCombobox';
+import { useShowMargin } from '../billingUi';
 import { computeQuoteProfit, type QuoteProfit } from '@breeze/shared';
 import { useQuotePdfDownload } from './useQuoteImage';
 import { type Quote, type QuoteDetail as QuoteDetailData, formatMoney } from './quoteTypes';
@@ -213,6 +215,11 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   // margin visibility, same as MarginPanel: an org-scoped/read-only-cost user
   // must never see this notice imply a permission they don't have.
   const canSeeMargin = can('quotes', 'read');
+  // ALSO gated on the "no margin on screen" preference: a tech who hit "Hide
+  // cost & margin" for a screen-share must not have internal cost tracking
+  // revealed by the send dialog — the moment a client is most likely watching.
+  // The toggle's contract is EVERY internal-economics surface, this included.
+  const [showMarginPref] = useShowMargin();
   const profit = useMemo<QuoteProfit>(
     () => computeQuoteProfit(lines.map((l) => ({
       quantity: l.quantity,
@@ -245,7 +252,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
 
   // Open the composer with fresh fields, then prefill/support-fetch in the
   // background. All three fetches are best-effort: the composer stays usable
-  // (and the server keeps its own billing-contact fallback) when any fail.
+  // when any fail (the user types the recipient — Send blocks on a valid To).
   const openSend = useCallback(() => {
     setSendTo('');
     setSendCc('');
@@ -254,6 +261,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     setIncludePdf(true);
     setSignature(null);
     setStripeStatus(null);
+    setToPrefillMissing(false);
     setSendOpen(true);
     void (async () => {
       try {
@@ -263,6 +271,13 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
         const email = org.billingContact?.email?.trim();
         // Functional update so a slow response never clobbers a typed address.
         if (email) setSendTo((cur) => cur || email);
+        // A CONFIRMED absence (the fetch succeeded and there is no contact)
+        // earns an explanation under the To field — at 9pm an empty To with no
+        // "why" forces the owner to recall an address from memory. A failed
+        // fetch stays silent: unknown is not absent, and claiming "no billing
+        // contact" on a lookup error would be false. (The user must type a
+        // recipient either way — the composer never submits an empty To.)
+        else setToPrefillMissing(true);
       } catch { /* leave To empty — the user types the recipient */ }
     })();
     // Signature + Stripe status are partner-level support data. The endpoints
@@ -302,6 +317,75 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     openSend();
   }, [openWhenQuiet, savePending, openSend]);
 
+  // Escape hatch for a hung save: the queued-open above normally fires within a
+  // blur-save round-trip. If the editor is still not quiescent after 10s the
+  // request has almost certainly stalled — cancel the queued Send and say so,
+  // instead of leaving "Saving changes…" up indefinitely (which at 9pm reads
+  // as "the app is broken").
+  useEffect(() => {
+    if (!openWhenQuiet) return;
+    const timer = setTimeout(() => {
+      setOpenWhenQuiet(false);
+      showToast({ message: t('quotes.actions.savingTimeout'), type: 'error' });
+    }, 10_000);
+    return () => clearTimeout(timer);
+  }, [openWhenQuiet, t]);
+
+  // The options of the last scheduled send, kept so "Send now" can cancel the
+  // delayed job and dispatch the SAME composed email immediately. null after a
+  // reload — the composed fields live only in this session, so the button
+  // simply isn't offered and the window plays out normally.
+  const [lastSendOpts, setLastSendOpts] = useState<SendQuoteOptions | null>(null);
+  const [sendingNow, setSendingNow] = useState(false);
+  const sendNow = useCallback(async () => {
+    if (sendingNow || !lastSendOpts) return;
+    setSendingNow(true);
+    try {
+      // Cancel first — only a confirmed cancellation may re-dispatch, so the
+      // customer can never receive the email twice. The cancel step carries
+      // its OWN error copy: if the DELETE fails the schedule is still live
+      // and the window-expiry send WILL fire — "could not send" here would
+      // assert the exact opposite of what happens next.
+      let canceled = false;
+      try {
+        const result = await runAction<{ data?: { canceled?: boolean } }>({
+          request: () => cancelScheduledSend(quote.id),
+          errorFallback: t('quotes.actions.sendNowCancelError'),
+          onUnauthorized: UNAUTHORIZED,
+        });
+        canceled = result?.data?.canceled === true;
+      } catch (err) {
+        handleActionError(err, t('quotes.actions.sendNowCancelError'));
+        return;
+      }
+      if (!canceled) {
+        // The window fired server-side first; the worker owns the send.
+        // Acknowledge the click — the draft→sent flip can land 5-10s later
+        // (BullMQ's delayed-job scan), and a silently re-armed "Send
+        // proposal" button in that gap reads as a dead click.
+        showToast({ message: t('quotes.actions.sendNowAlready'), type: 'success' });
+        refresh();
+        return;
+      }
+      await runAction({
+        request: () => sendQuote(quote.id, lastSendOpts),
+        errorFallback: t('quotes.actions.sendError'),
+        onUnauthorized: UNAUTHORIZED,
+      });
+      // The refresh lands the draft→sent flip; the post-flip effect below
+      // surfaces the same honest delivered/not-delivered outcome as a
+      // window-expiry send.
+      refresh();
+    } catch (err) {
+      // A failed immediate send after a successful cancel leaves an ordinary
+      // draft — refresh restores the plain Send button for a retry.
+      handleActionError(err, t('quotes.actions.sendError'));
+      refresh();
+    } finally {
+      setSendingNow(false);
+    }
+  }, [sendingNow, lastSendOpts, quote.id, refresh, t]);
+
   const toParsed = useMemo(() => parseAddressList(sendTo), [sendTo]);
   const ccParsed = useMemo(() => parseAddressList(sendCc), [sendCc]);
   const toError =
@@ -322,6 +406,9 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   // reason under the To field (the same visible-reason pattern the header
   // button uses) instead of a silently dead disabled button.
   const [toMissing, setToMissing] = useState(false);
+  // Set when the org lookup confirmed there is NO billing contact to prefill
+  // from — drives the "why is To empty" explanation with a link to fix it.
+  const [toPrefillMissing, setToPrefillMissing] = useState(false);
   const toInputRef = useRef<HTMLInputElement>(null);
 
   const send = useCallback(async () => {
@@ -354,6 +441,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
         errorFallback: t('quotes.actions.sendError'),
         onUnauthorized: UNAUTHORIZED,
       });
+      setLastSendOpts(opts);
       setSendOpen(false);
       setSendMessage('');
       refresh();
@@ -518,18 +606,36 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             Gated on quotes:send; only a draft can be sent. An empty quote can't. */}
         {canSend && scheduleLive && (
           <>
+            {/* The ticking chip is aria-hidden: with role="status" it announced
+                every second of the 30s window to screen readers. The one-shot
+                announcement lives in the always-mounted live region below. */}
             <span
               className="inline-flex items-center gap-1.5 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-sm font-medium text-warning-foreground dark:text-warning"
               data-testid="quote-send-countdown"
-              role="status"
+              aria-hidden="true"
             >
               <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
               {t('quotes.actions.sendingIn', { seconds: Math.max(0, Math.ceil(((scheduledAtMs ?? 0) - nowMs) / 1000)) })}
             </span>
+            {/* Power path: cancel the delayed job and dispatch the composed
+                email immediately — batching ten quotes shouldn't cost five
+                minutes of countdowns. Offered only in the session that
+                composed the send (lastSendOpts survives no reload). */}
+            {lastSendOpts && (
+              <button
+                type="button"
+                onClick={() => void sendNow()}
+                disabled={sendingNow || undoing}
+                data-testid="quote-send-now"
+                className={`${btnBase} border font-medium hover:bg-muted disabled:opacity-50`}
+              >
+                {sendingNow ? t('quotes.actions.sending') : t('quotes.actions.sendNow')}
+              </button>
+            )}
             <button
               type="button"
               onClick={() => void undoSend()}
-              disabled={undoing}
+              disabled={undoing || sendingNow}
               data-testid="quote-send-undo"
               className={`${btnBase} border font-medium hover:bg-muted disabled:opacity-50`}
             >
@@ -537,6 +643,12 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             </button>
           </>
         )}
+        {/* One-shot SR announcement of the undo window (text appears when the
+            schedule goes live, announced once) — mounted unconditionally so
+            the live region exists before its content changes. */}
+        <span role="status" className="sr-only" data-testid="quote-send-countdown-sr">
+          {canSend && scheduleLive ? t('quotes.actions.sendScheduled', { orgName }) : ''}
+        </span>
         {canSend && !scheduleLive && (
           <button
             type="button"
@@ -563,7 +675,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
                 : undefined
             }
             data-testid="quote-send"
-            className={`${btnBase} relative bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50`}
+            className={`${btnBase} relative bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50`}
           >
             {/* Overlay spinner: while edits settle (or a send is in flight) the
                 label fades under a dead-centered spinner. The label always
@@ -698,7 +810,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
       </div>
 
       {/* Send composer — a lightweight email-client dialog. To is prefilled from
-          the org billing contact (best-effort; the server keeps its own fallback),
+          the org billing contact (best-effort; Send blocks until a valid To),
           Subject left blank means the server default, and the partner's email
           signature / Stripe-connect status are support data loaded only under a
           partner-scoped session (not because the endpoints reject org tokens). */}
@@ -729,7 +841,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             tech may genuinely not know every cost yet) — it's a heads-up, not a
             gate. Reuses MarginPanel's own copy (billingUi.margin.missingCost) so
             the wording can't drift between the rail and this dialog. */}
-        {canSeeMargin && profit.linesMissingCost > 0 && (
+        {canSeeMargin && showMarginPref && profit.linesMissingCost > 0 && (
           <p className="mt-2 flex items-start gap-1 rounded-md border border-warning/40 bg-warning/10 px-2 py-1 text-xs text-warning-foreground dark:text-warning" data-testid="quote-send-missing-cost-notice">
             <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" aria-hidden="true" />
             <span>{t('billingUi.margin.missingCost', { count: profit.linesMissingCost })}</span>
@@ -752,7 +864,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
               placeholder={t('quotes.actions.sendConfirm.toPlaceholder')}
               aria-invalid={toError != null}
               data-testid="quote-send-to"
-              className="min-w-0 flex-1 border-0 bg-transparent py-2 text-sm focus:outline-hidden disabled:opacity-60"
+              className="min-w-0 flex-1 rounded-sm border-0 bg-transparent py-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
             />
             {!ccOpen && (
               <button
@@ -778,7 +890,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
                 disabled={sending}
                 aria-invalid={ccError != null}
                 data-testid="quote-send-cc"
-                className="min-w-0 flex-1 border-0 bg-transparent py-2 text-sm focus:outline-hidden disabled:opacity-60"
+                className="min-w-0 flex-1 rounded-sm border-0 bg-transparent py-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
               />
             </div>
           )}
@@ -801,10 +913,22 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
                   : t('quotes.actions.sendConfirm.subjectPlaceholderNoNumber')
               }
               data-testid="quote-send-subject"
-              className="min-w-0 flex-1 border-0 bg-transparent py-2 text-sm focus:outline-hidden disabled:opacity-60"
+              className="min-w-0 flex-1 rounded-sm border-0 bg-transparent py-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
             />
           </div>
         </div>
+        {toPrefillMissing && toParsed.emails.length === 0 && !toError && (
+          // The org lookup confirmed no billing contact exists — say WHY the To
+          // field is empty and link the fix, instead of demanding an address
+          // from memory.
+          <p className="mt-1 text-xs text-muted-foreground" data-testid="quote-send-to-no-contact">
+            <Trans
+              i18nKey="quotes.actions.sendConfirm.noBillingContactHint"
+              t={t}
+              components={{ orgLink: <a href={`/settings/organizations/${quote.orgId}`} className="underline hover:text-foreground" /> }}
+            />
+          </p>
+        )}
         {toError && (
           <p id="quote-send-to-error" className="mt-1 text-xs text-destructive" data-testid="quote-send-to-error">{toError}</p>
         )}
@@ -861,12 +985,24 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             data-testid="quote-send-payment-warning"
           >
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-            <span>{t('quotes.actions.sendConfirm.paymentWarningDeposit')}</span>
+            {/* "Connect Stripe" is a real link, not directions to retype — the
+                fix is one click away from the moment the gap is discovered. */}
+            <span>
+              <Trans
+                i18nKey="quotes.actions.sendConfirm.paymentWarningDeposit"
+                t={t}
+                components={{ integrationsLink: <a href="/integrations" className="underline hover:opacity-80" /> }}
+              />
+            </span>
           </div>
         )}
         {!hasDeposit && stripeStatus === 'disconnected' && (
           <p className="mt-2 text-xs text-muted-foreground" data-testid="quote-send-payment-note">
-            {t('quotes.actions.sendConfirm.paymentNoteNoStripe')}
+            <Trans
+              i18nKey="quotes.actions.sendConfirm.paymentNoteNoStripe"
+              t={t}
+              components={{ integrationsLink: <a href="/integrations" className="underline hover:text-foreground" /> }}
+            />
           </p>
         )}
         {stripeStatus === 'connected' && (
@@ -890,7 +1026,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             disabled={sending}
             aria-describedby={toMissing ? 'quote-send-to-missing' : toError ? 'quote-send-to-error' : undefined}
             data-testid="quote-send-confirm"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90 disabled:opacity-50"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
           >
             {sending ? t('quotes.actions.sending') : t('quotes.actions.sendProposal')}
           </button>
@@ -925,17 +1061,16 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             <span className="mb-1 block text-sm font-medium text-foreground">
               {t('quotes.actions.cloneDialog.companyLabel')}
             </span>
-            <select
+            {/* Typeahead, not a native select: an MSP with 150 orgs needs to
+                search for the clone target, not scroll a browser list. */}
+            <OrgCombobox
+              options={orgOptions}
               value={cloneOrgId}
-              onChange={(e) => setCloneOrgId(e.target.value)}
+              onSelect={setCloneOrgId}
               disabled={cloning}
-              data-testid="quote-clone-org"
-              className="h-9 w-full rounded-md border bg-background px-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60"
-            >
-              {orgOptions.map((o) => (
-                <option key={o.id} value={o.id}>{o.name}</option>
-              ))}
-            </select>
+              label={t('quotes.actions.cloneDialog.companyLabel')}
+              testId="quote-clone-org"
+            />
           </label>
           {cloneOrgId !== quote.orgId && (
             <p className="text-xs text-muted-foreground" data-testid="quote-clone-retarget-hint">
@@ -972,7 +1107,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             onClick={() => void clone()}
             disabled={cloning || savePending}
             data-testid="quote-clone-confirm"
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90 disabled:opacity-50"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
           >
             {cloning ? t('quotes.actions.cloning') : t('quotes.actions.cloneDialog.confirm')}
           </button>

--- a/apps/web/src/components/billing/quotes/QuoteActions.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteActions.tsx
@@ -15,7 +15,7 @@ import { isValidEmail } from '@/lib/email';
 import { cloneQuote, deleteQuote, sendQuote, type SendQuoteOptions, type QuoteSendEmailReason } from '../../../lib/api/quotes';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
 import { Dialog } from '../../shared/Dialog';
-import { OrgCombobox } from '../shared/OrgCombobox';
+import { OrgCombobox, orgComboboxOptions } from '../shared/OrgCombobox';
 import { useShowMargin } from '../billingUi';
 import { computeQuoteProfit, type QuoteProfit } from '@breeze/shared';
 import { useQuotePdfDownload } from './useQuoteImage';
@@ -124,6 +124,14 @@ interface Props {
    *  held (with a "Saving changes…" hint) until the quote is quiescent, so the
    *  confirm dialog can't quote a stale total or race a blur-save server-side. */
   savePending?: boolean;
+  /** Translated label of a field whose save failed and is still dirty. Waiting
+   *  cannot clear it, so Send refuses and names the field rather than queueing
+   *  behind a save that is never coming. */
+  unsavedFieldLabel?: string | null;
+  /** Bumped by the workspace on every editor save FAILURE. A failure can still
+   *  produce "quiescence" (restored rows / cleared in-flight keys), so a queued
+   *  Send must cancel on this rather than open a composer for a stale total. */
+  saveFailureNonce?: number;
   /** Called when Send is clicked while savePending — lets the workspace flush
    *  deferred work immediately (the editor's undo-grace deletions) so the held
    *  Send opens as soon as those land instead of waiting out a grace window. */
@@ -136,7 +144,7 @@ interface Props {
  * Detail rail and the workspace header can't drift in behavior or copy; the
  * data-testids are stable across both variants.
  */
-export default function QuoteActions({ detail, onChanged, variant, savePending = false, onSendWhilePending }: Props) {
+export default function QuoteActions({ detail, onChanged, variant, savePending = false, unsavedFieldLabel = null, saveFailureNonce = 0, onSendWhilePending }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const organizations = useOrgStore((s) => s.organizations);
@@ -174,9 +182,14 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
   // Focus-on-open + arrow-key cycling for the menu items (Tab closes).
   const { listRef: menuListRef, onKeyDown: onMenuListKeyDown } = useMenuKeyboard(menuOpen, () => setMenuOpen(false));
   const refresh = useCallback(() => onChanged?.(), [onChanged]);
+  // Why Send is held, if it is. 'saving' resolves on its own and a click queues
+  // behind it; 'unsaved' never will, so a click refuses and names the field.
+  const heldReason: 'saving' | 'unsaved' | null = savePending ? 'saving' : unsavedFieldLabel ? 'unsaved' : null;
   // A Send click that lands while edits are settling queues the composer to
-  // open on quiescence (see the header Send onClick).
-  const [openWhenQuiet, setOpenWhenQuiet] = useState(false);
+  // open on quiescence (see the header Send onClick). It captures the failure
+  // nonce it was created at, so "did a save fail while I waited?" is a data
+  // comparison rather than a dependency on effect ordering.
+  const [queued, setQueued] = useState<{ atFailureNonce: number } | null>(null);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -241,14 +254,11 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
 
   // Company choices for the clone dialog: the partner's org list, with the
   // quote's own org prepended if it isn't loaded (e.g. All-orgs scope) so the
-  // select always has a valid default.
-  const orgOptions = useMemo(() => {
-    const sorted = [...organizations].sort((a, b) => a.name.localeCompare(b.name));
-    if (!sorted.some((o) => o.id === quote.orgId)) {
-      sorted.unshift({ id: quote.orgId, name: orgName } as (typeof sorted)[number]);
-    }
-    return sorted;
-  }, [organizations, quote.orgId, orgName]);
+  // picker always has a valid default.
+  const orgOptions = useMemo(
+    () => orgComboboxOptions(organizations, quote.orgId, orgName),
+    [organizations, quote.orgId, orgName],
+  );
 
   // Open the composer with fresh fields, then prefill/support-fetch in the
   // background. All three fetches are best-effort: the composer stays usable
@@ -311,25 +321,38 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
     setSendMessage('');
   }, [sending]);
 
+  // Resolve the queued Send in strict priority: failed → cancel; still working
+  // → wait; otherwise open. Cancelling on a CHANGED failure nonce (captured at
+  // click time) is what makes quiescence safe to trust — a failed blur-save
+  // clears its in-flight key and a failed delete-flush restores its rows, so
+  // both look exactly like "done" from here. Mirrors InvoiceActions.
   useEffect(() => {
-    if (!openWhenQuiet || savePending) return;
-    setOpenWhenQuiet(false);
+    if (!queued) return;
+    if (saveFailureNonce !== queued.atFailureNonce) {
+      setQueued(null);
+      showToast({ message: t('quotes.actions.sendCanceledSaveFailed'), type: 'error' });
+      return;
+    }
+    if (savePending) return;
+    setQueued(null);
     openSend();
-  }, [openWhenQuiet, savePending, openSend]);
+  }, [queued, saveFailureNonce, savePending, openSend, t]);
 
   // Escape hatch for a hung save: the queued-open above normally fires within a
   // blur-save round-trip. If the editor is still not quiescent after 10s the
   // request has almost certainly stalled — cancel the queued Send and say so,
   // instead of leaving "Saving changes…" up indefinitely (which at 9pm reads
-  // as "the app is broken").
+  // as "the app is broken"). A warning, not an error, and worded as "still
+  // saving": failures are handled above, so this path never saw one, and
+  // claiming otherwise would assert a failure nobody observed.
   useEffect(() => {
-    if (!openWhenQuiet) return;
+    if (!queued) return;
     const timer = setTimeout(() => {
-      setOpenWhenQuiet(false);
-      showToast({ message: t('quotes.actions.savingTimeout'), type: 'error' });
+      setQueued(null);
+      showToast({ message: t('quotes.actions.savingTimeout'), type: 'warning' });
     }, 10_000);
     return () => clearTimeout(timer);
-  }, [openWhenQuiet, t]);
+  }, [queued, t]);
 
   // The options of the last scheduled send, kept so "Send now" can cancel the
   // delayed job and dispatch the SAME composed email immediately. null after a
@@ -658,7 +681,13 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
               // the composer to open the moment the editor goes quiescent —
               // one click to the money moment, never a dead one. Deferred
               // deletions (undo grace window) flush now for the same reason.
-              if (savePending) { onSendWhilePending?.(); setOpenWhenQuiet(true); return; }
+              if (savePending) { onSendWhilePending?.(); setQueued({ atFailureNonce: saveFailureNonce }); return; }
+              // A field that already failed to save will never go quiet on its
+              // own — say which one instead of parking the click forever.
+              if (unsavedFieldLabel) {
+                showToast({ type: 'warning', message: t('quotes.actions.sendBlockedUnsaved', { field: unsavedFieldLabel }) });
+                return;
+              }
               openSend();
             }}
             disabled={sending || isEmpty}
@@ -666,26 +695,30 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             // variants) so AT announces the reason when the button takes focus.
             aria-describedby={
               isEmpty ? `quote-send-empty-hint-${variant}`
-                : savePending ? `quote-send-saving-hint-${variant}`
+                : heldReason ? `quote-send-held-hint-${variant}`
                 : undefined
             }
             title={
               isEmpty ? t('quotes.actions.emptyHint')
-                : savePending ? t('quotes.actions.savingTitle')
+                : heldReason === 'saving' ? t('quotes.actions.savingTitle')
+                : heldReason === 'unsaved' ? t('quotes.actions.unsavedTitle', { field: unsavedFieldLabel })
                 : undefined
             }
             data-testid="quote-send"
             className={`${btnBase} relative bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50`}
           >
-            {/* Overlay spinner: while edits settle (or a send is in flight) the
-                label fades under a dead-centered spinner. The label always
-                defines the button's size and sits truly centered — the earlier
-                reserved-slot approach kept the width stable but left the text
-                permanently off-center. */}
-            {(sending || savePending) && (
+            {/* Overlay spinner: the label fades under a dead-centered spinner.
+                The label always defines the button's size and sits truly
+                centered — the earlier reserved-slot approach kept the width
+                stable but left the text permanently off-center.
+                A spinner promises forthcoming completion, so it renders only
+                while something WILL complete: an in-flight send or a queued
+                click awaiting quiescence. Spinning on bare `savePending` meant a
+                field left dirty by a failed save spun forever. */}
+            {(sending || queued !== null) && (
               <Loader2 className="absolute left-1/2 top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 animate-spin" aria-hidden="true" />
             )}
-            <span className={sending || savePending ? 'opacity-30' : ''}>
+            <span className={sending || queued !== null ? 'opacity-30' : ''}>
               {t('quotes.actions.sendProposal')}
             </span>
           </button>
@@ -796,15 +829,19 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             {t('quotes.actions.emptyHint')}
           </p>
         )}
-        {canSend && !isEmpty && savePending && (
+        {canSend && !isEmpty && heldReason && (
           // Same placement rules as the empty-quote hint above: the user must be
           // able to SEE why the money-button is held, not just hover for it.
+          // Two reasons, two messages — "Saving changes…" over a field that
+          // already gave up is advice the user can follow indefinitely.
           <p
-            id={`quote-send-saving-hint-${variant}`}
-            data-testid="quote-send-saving-hint"
+            id={`quote-send-held-hint-${variant}`}
+            data-testid={heldReason === 'saving' ? 'quote-send-saving-hint' : 'quote-send-unsaved-hint'}
             className={header ? 'basis-full text-xs text-muted-foreground text-right' : 'text-center text-xs text-muted-foreground'}
           >
-            {t('quotes.actions.savingHint')}
+            {heldReason === 'saving'
+              ? t('quotes.actions.savingHint')
+              : t('quotes.actions.unsavedHint', { field: unsavedFieldLabel })}
           </p>
         )}
       </div>
@@ -925,7 +962,11 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
             <Trans
               i18nKey="quotes.actions.sendConfirm.noBillingContactHint"
               t={t}
-              components={{ orgLink: <a href={`/settings/organizations/${quote.orgId}`} className="underline hover:text-foreground" /> }}
+              // #billing, not the bare org route: the billing-contact field
+              // lives under that tab and OrgSettingsPage defaults to General, so
+              // an undeep link drops the user on a page with no visible field —
+              // exactly the fix this hint promises to point at.
+              components={{ orgLink: <a href={`/settings/organizations/${quote.orgId}#billing`} className="underline hover:text-foreground" /> }}
             />
           </p>
         )}
@@ -1057,7 +1098,12 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
         </h3>
         <p className="mt-1 text-sm text-muted-foreground">{t('quotes.actions.cloneDialog.message')}</p>
         <div className="mt-4 space-y-3">
-          <label className="block">
+          {/* A <div>, NOT a <label>: OrgCombobox renders its popover inline, so a
+              label wrapper would make the trigger its implicit control and a
+              click anywhere on the popover's own chrome (padding, cap note, the
+              no-results text) would forward to the trigger and close the picker
+              mid-search. The combobox carries its own aria-label. */}
+          <div className="block">
             <span className="mb-1 block text-sm font-medium text-foreground">
               {t('quotes.actions.cloneDialog.companyLabel')}
             </span>
@@ -1071,7 +1117,7 @@ export default function QuoteActions({ detail, onChanged, variant, savePending =
               label={t('quotes.actions.cloneDialog.companyLabel')}
               testId="quote-clone-org"
             />
-          </label>
+          </div>
           {cloneOrgId !== quote.orgId && (
             <p className="text-xs text-muted-foreground" data-testid="quote-clone-retarget-hint">
               {t('quotes.actions.cloneDialog.retargetHint')}

--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -671,14 +671,25 @@ export function BlockCard({
                     </p>
                   )
                 ) : (
-                  <CatalogItemPicker
-                    items={catalog}
-                    includeBundles={false}
-                    onSelect={(it) => onAddCatalog(block.id, it)}
-                    testId={`quote-catalog-picker-${block.id}`}
-                    placeholder={t('quotes.editor.catalog.searchPlaceholder')}
-                    disabled={addLineBusy}
-                  />
+                  <>
+                    <CatalogItemPicker
+                      items={catalog}
+                      includeBundles={false}
+                      onSelect={(it) => onAddCatalog(block.id, it)}
+                      testId={`quote-catalog-picker-${block.id}`}
+                      placeholder={t('quotes.editor.catalog.searchPlaceholder')}
+                      disabled={addLineBusy}
+                    />
+                    {/* The editor loads the catalog with limit=200; hitting the
+                        cap means a bigger catalog is silently truncated — say
+                        so instead of letting search-misses read as "not in the
+                        catalog". */}
+                    {catalog.length >= 200 && (
+                      <p className="mt-1 text-xs text-muted-foreground" data-testid={`quote-catalog-cap-note-${block.id}`}>
+                        {t('quotes.editor.catalog.capNote', { count: 200 })}
+                      </p>
+                    )}
+                  </>
                 )
               ) : (
                 <div className="space-y-3">
@@ -884,7 +895,7 @@ export function BlockCard({
                       disabled={addLineBusy || (!name.trim() && !desc.trim())}
                       aria-busy={addLineBusy}
                       data-testid={`quote-manual-add-${block.id}`}
-                      className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                      className="inline-flex h-9 items-center justify-center gap-1.5 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
                     >
                       {addLineBusy && <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />}
                       {addLineBusy ? t('quotes.editor.actions.adding') : t('quotes.editor.actions.addLine')}

--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -341,7 +341,10 @@ export function BlockCard({
             <div
               onBlur={() => void commitRich()}
               data-testid={`quote-block-rich-input-${block.id}`}
-              className={`rounded-md transition-shadow ${fieldRing(richDraft !== html, blockSaved)}`}
+              // `border` is required, not decorative: fieldRing emits border-COLOR
+              // only, and Tailwind's preflight leaves width at 0 — without it the
+              // dirty/saved cue on this block renders nothing.
+              className={`rounded-md border border-transparent transition-colors ${fieldRing(richDraft !== html, blockSaved)}`}
             >
               <RichTextEditor
                 value={richDraft}

--- a/apps/web/src/components/billing/quotes/QuoteBulkBar.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBulkBar.tsx
@@ -159,7 +159,7 @@ export function QuoteBulkBar({ count, busy, onSetMarkup, onSetCost, onSetTaxable
             onClick={apply}
             disabled={busy}
             data-testid="quote-bulk-apply"
-            className="inline-flex h-8 items-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            className="inline-flex h-8 items-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
           >
             {t('quotes.editor.bulk.apply')}
           </button>

--- a/apps/web/src/components/billing/quotes/QuoteContractBlockEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteContractBlockEditor.tsx
@@ -180,7 +180,7 @@ export function ContractBlockEditor({
             onClick={() => void commit()}
             disabled={busy}
             data-testid={`quote-block-contract-save-${block.id}`}
-            className="inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+            className="inline-flex h-8 items-center justify-center rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
           >
             {t('quotes.editor.contract.saveVariables')}
           </button>

--- a/apps/web/src/components/billing/quotes/QuoteDetail.send.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.send.test.tsx
@@ -239,11 +239,112 @@ describe('QuoteDetail — send proposal', () => {
 
     expect(screen.queryByTestId('quote-send')).not.toBeInTheDocument();
     expect(screen.getByTestId('quote-send-countdown')).toBeInTheDocument();
+    // The ticking chip is visual-only (a per-second live region narrated the
+    // whole window to screen readers); the one-shot announcement carries the
+    // org name in the always-mounted status region.
+    expect(screen.getByTestId('quote-send-countdown')).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('quote-send-countdown-sr')).toHaveTextContent('Acme');
+    // Send now is session-scoped: without a compose in THIS session there are
+    // no options to replay, so the button must not be offered — synthesizing
+    // send options after a reload would email content the user never reviewed.
+    expect(screen.queryByTestId('quote-send-now')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('quote-send-undo'));
     await waitFor(() => {
       expect(cancelScheduledSend).toHaveBeenCalledWith('q-1');
       expect(onChanged).toHaveBeenCalled();
+    });
+  });
+
+  /** Compose with overrides, confirm (schedules), then land the schedule in
+   *  props the way the real app's refetch would — same component instance, so
+   *  the session's lastSendOpts survive and Send now renders. Returns the
+   *  exact options the schedule call received. */
+  async function composeAndSchedule(rerender: ReturnType<typeof render>['rerender'], onChanged: () => void) {
+    await openComposer();
+    fireEvent.change(screen.getByTestId('quote-send-subject'), { target: { value: 'Custom subject' } });
+    fireEvent.click(screen.getByTestId('quote-send-confirm'));
+    await waitFor(() => expect(quotesApi.scheduleQuoteSend).toHaveBeenCalledTimes(1));
+    const scheduledOpts = vi.mocked(quotesApi.scheduleQuoteSend).mock.calls[0]![1];
+    rerender(<QuoteDetail
+      detail={{
+        ...filledDraft,
+        quote: { ...filledDraft.quote, sendScheduledAt: new Date(Date.now() + 25_000).toISOString() },
+      }}
+      onChanged={onChanged}
+    />);
+    await waitFor(() => expect(screen.getByTestId('quote-send-now')).toBeInTheDocument());
+    return scheduledOpts;
+  }
+
+  it('Send now cancels the schedule, then dispatches the SAME composed options exactly once', async () => {
+    const cancelScheduledSend = vi.mocked(quotesApi.cancelScheduledSend);
+    cancelScheduledSend.mockResolvedValue(resp({ data: { canceled: true } }));
+    vi.mocked(quotesApi.sendQuote).mockResolvedValue(resp({ data: {} }));
+    const onChanged = vi.fn();
+
+    const { rerender } = render(<QuoteDetail detail={filledDraft} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    const scheduledOpts = await composeAndSchedule(rerender, onChanged);
+
+    fireEvent.click(screen.getByTestId('quote-send-now'));
+    await waitFor(() => {
+      expect(cancelScheduledSend).toHaveBeenCalledWith('q-1');
+      // The immediate dispatch replays EXACTLY what the user reviewed and
+      // confirmed — a drift here mails the wrong recipients/subject.
+      expect(quotesApi.sendQuote).toHaveBeenCalledWith('q-1', scheduledOpts);
+    });
+    // No second schedule: cancel→send, never re-schedule.
+    expect(quotesApi.scheduleQuoteSend).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('Send now with canceled:false NEVER dispatches a second email, and acknowledges the click', async () => {
+    const { showToast } = await import('../../shared/Toast');
+    const cancelScheduledSend = vi.mocked(quotesApi.cancelScheduledSend);
+    // The window fired server-side first — the worker owns the send. A
+    // re-dispatch here would email the customer TWICE.
+    cancelScheduledSend.mockResolvedValue(resp({ data: { canceled: false } }));
+    const onChanged = vi.fn();
+
+    const { rerender } = render(<QuoteDetail detail={filledDraft} onChanged={onChanged} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    await composeAndSchedule(rerender, onChanged);
+
+    fireEvent.click(screen.getByTestId('quote-send-now'));
+    await waitFor(() => expect(cancelScheduledSend).toHaveBeenCalledWith('q-1'));
+    expect(quotesApi.sendQuote).not.toHaveBeenCalled();
+    // The click is acknowledged — the draft→sent flip can land 5-10s later,
+    // and a silently re-armed Send button reads as a dead click.
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'success',
+        message: expect.stringContaining('on its way'),
+      }));
+    });
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it('Send now with a FAILED cancel dispatches nothing and says the schedule still stands', async () => {
+    const { showToast } = await import('../../shared/Toast');
+    const cancelScheduledSend = vi.mocked(quotesApi.cancelScheduledSend);
+    // The DELETE dies on the network: the schedule is STILL LIVE and the
+    // window send WILL fire — the copy must say that, not "could not send".
+    // (A thrown request makes runAction toast the step's errorFallback; a
+    // non-ok response would toast the server's own error message instead.)
+    cancelScheduledSend.mockRejectedValue(new Error('network down'));
+
+    const { rerender } = render(<QuoteDetail detail={filledDraft} onChanged={vi.fn()} />);
+    await waitFor(() => expect(screen.getByTestId('quote-detail')).toBeInTheDocument());
+    await composeAndSchedule(rerender, vi.fn());
+
+    fireEvent.click(screen.getByTestId('quote-send-now'));
+    await waitFor(() => expect(cancelScheduledSend).toHaveBeenCalledWith('q-1'));
+    expect(quotesApi.sendQuote).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('will still send as scheduled'),
+      }));
     });
   });
 

--- a/apps/web/src/components/billing/quotes/QuoteDetail.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDetail.tsx
@@ -1,13 +1,12 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Eye, EyeOff } from 'lucide-react';
 import '../../../lib/i18n';
 import { usePermissions } from '../../../lib/permissions';
 import { useOrgStore } from '../../../stores/orgStore';
 import { quoteImageUrl } from '../../../lib/api/quotes';
 import { useAuthedImage } from './useQuoteImage';
 import QuoteActions, { QuoteSendOutcomeBanners } from './QuoteActions';
-import { RecurringBillingNote, MarginPanel } from '../billingUi';
+import { RecurringBillingNote, MarginPanel, MarginToggle, useShowMargin } from '../billingUi';
 import { computeQuoteProfit, type QuoteProfit } from '@breeze/shared';
 import {
   type QuoteDetail as QuoteDetailData,
@@ -45,22 +44,13 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
   // sees it. Gating on read (not write) keeps cost visibility consistent with the
   // editor's read-only line rows, which show the cost band to read users too.
   const canSeeMargin = can('quotes', 'read');
-  // Same persisted preference the editor's "Show cost & margin" toggle writes.
-  // That toggle's contract is "no margin on screen" — it must hold when a
-  // screen-sharing tech switches tabs, so Detail reads (and can flip) the same
-  // key. Detail needs its own control anyway: for non-draft quotes the editor
-  // tab (and its toggle) doesn't exist.
-  const SHOW_INTERNAL_KEY = 'breeze:quote-editor-show-margin';
-  const [showMargin, setShowMargin] = useState(
-    () => typeof localStorage !== 'undefined' && localStorage.getItem(SHOW_INTERNAL_KEY) === '1',
-  );
-  const toggleMargin = useCallback(() => {
-    setShowMargin((v) => {
-      const next = !v;
-      try { localStorage.setItem(SHOW_INTERNAL_KEY, next ? '1' : '0'); } catch { /* private mode — session-only */ }
-      return next;
-    });
-  }, []);
+  // Same persisted preference the editor's "Show cost & margin" toggle writes
+  // (shared billing-wide via useShowMargin). That toggle's contract is "no
+  // margin on screen" — it must hold when a screen-sharing tech switches tabs
+  // or opens an invoice, so Detail reads (and can flip) the same key. Detail
+  // needs its own control anyway: for non-draft quotes the editor tab (and its
+  // toggle) doesn't exist.
+  const [showMargin, toggleMargin] = useShowMargin();
   const organizations = useOrgStore((s) => s.organizations);
   const { quote, blocks, lines } = detail;
   const currency = quote.currencyCode;
@@ -128,7 +118,7 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
                   type="button"
                   onClick={() => { if (typeof window !== 'undefined') window.location.hash = '#editor'; }}
                   data-testid="quote-detail-empty-edit"
-                  className="mt-3 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                  className="mt-3 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
                 >
                   {t('quotes.detail.addContentInEditor')}
                 </button>
@@ -224,16 +214,7 @@ export default function QuoteDetail({ detail, onChanged, actionsInHeader }: Prop
             <div className="mb-2 flex items-center justify-between gap-2">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('quotes.detail.totals.title')}</h3>
               {canSeeMargin && (
-                <button
-                  type="button"
-                  onClick={toggleMargin}
-                  aria-pressed={showMargin}
-                  data-testid="quote-detail-toggle-margin"
-                  className={`inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors hover:bg-muted ${showMargin ? 'border-primary/40 bg-primary/10 text-primary' : 'text-muted-foreground'}`}
-                >
-                  {showMargin ? <EyeOff className="h-3 w-3" aria-hidden="true" /> : <Eye className="h-3 w-3" aria-hidden="true" />}
-                  {showMargin ? t('quotes.editor.actions.hideCostMargin') : t('quotes.editor.actions.showCostMargin')}
-                </button>
+                <MarginToggle show={showMargin} onToggle={toggleMargin} testId="quote-detail-toggle-margin" />
               )}
             </div>
             <dl className="space-y-1 text-sm tabular-nums">

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -107,6 +107,15 @@ interface Props {
    *  Send until the quote is quiescent, so the irreversible money-moment
    *  can't race a blur-save. */
   onPendingEditsChange?: (hasPendingEdits: boolean) => void;
+  /** Reports every save FAILURE. Quiescence alone is not a safe Send signal: a
+   *  failed blur-save clears its in-flight key and a failed delete-flush
+   *  restores its rows, both of which read as "quiet" — QuoteActions cancels a
+   *  queued Send on this rather than opening a composer for a stale total. */
+  onSaveFailure?: () => void;
+  /** Reports a field whose save failed and is still dirty (translated label), or
+   *  null. Waiting cannot clear it, so Send names the field instead of showing
+   *  "Saving changes…" about a save that is never coming. */
+  onUnsavedEditsChange?: (unsavedFieldLabel: string | null) => void;
   /** Hands the workspace an imperative "flush deferred deletions now" hook
    *  (called with null on unmount). QuoteActions invokes it when Send is
    *  clicked during the undo grace window, so the held Send fires as soon as
@@ -121,7 +130,7 @@ interface Props {
 }
 
 
-export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, onRegisterPendingDeleteFlush, showInternal: showInternalProp, onToggleInternal }: Props) {
+export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, onSaveFailure, onUnsavedEditsChange, onRegisterPendingDeleteFlush, showInternal: showInternalProp, onToggleInternal }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const canWrite = can('quotes', 'write');
@@ -231,6 +240,10 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   // indicator near the autosave hint — null until this session's first save
   // (nothing to report before that; the indicator itself stays unrendered).
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
+  // Keys whose most recent save attempt FAILED, cleared when one succeeds. Used
+  // with a still-dirty check to tell "this never saved" apart from the normal
+  // gap between a successful save and its refetch.
+  const [failedKeys, setFailedKeys] = useState<ReadonlySet<string>>(() => new Set());
 
   // Run a scoped mutation: mark the key pending, run, surface failures via the
   // standard handleActionError path, and always clear the key. Returns whether
@@ -243,16 +256,19 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
       try {
         await fn();
         setLastSavedAt(Date.now());
+        setFailedKeys((s) => { if (!s.has(key)) return s; const n = new Set(s); n.delete(key); return n; });
         return true;
       } catch (err) {
         handleActionError(err, errMsg);
+        setFailedKeys((s) => { if (s.has(key)) return s; const n = new Set(s); n.add(key); return n; });
+        onSaveFailure?.();
         return false;
       } finally {
         inFlight.current.delete(key);
         setPending((s) => { const n = new Set(s); n.delete(key); return n; });
       }
     },
-    [],
+    [onSaveFailure],
   );
 
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
@@ -268,15 +284,15 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   const [termsSaved, flashTermsSaved] = useSavedFlash();
   const canCatalogWrite = can('catalog', 'write');
 
-  // Surface "is anything still saving / sitting dirty?" to the workspace so the
-  // Send button can wait for quiescence. Pending covers every in-flight mutation
-  // (line/block/terms/add/remove); the terms dirty flag covers the rail's
-  // blur-to-save field. Per-line dirty state isn't lifted — clicking Send blurs
-  // the focused field, whose commit lands in `pending` before the dialog opens.
-  // Deferred deletions count too: their DELETE hasn't fired yet, so a Send
-  // must not snapshot a quote the user has visibly already trimmed (clicking
-  // Send also flushes them immediately — see onRegisterPendingDeleteFlush).
-  const hasPendingEdits = pending.size > 0 || termsDirty
+  // Two separate questions, mirroring the invoice editor (see the long note
+  // there). hasPendingEdits = work genuinely IN FLIGHT, which resolves on its
+  // own and which a queued Send may wait for. Deferred deletions count: their
+  // DELETE hasn't fired yet, so a Send must not snapshot a quote the user has
+  // visibly already trimmed (clicking Send also flushes them immediately — see
+  // onRegisterPendingDeleteFlush). A merely-dirty field is NOT in flight: on
+  // failure it stays dirty forever, and reporting it here is what used to pin
+  // "Saving changes…" up over a save that had already given up.
+  const hasPendingEdits = pending.size > 0
     || pendingDeletedLineIds.size > 0 || pendingDeletedBlockIds.size > 0;
   useEffect(() => { onPendingEditsChange?.(hasPendingEdits); }, [hasPendingEdits, onPendingEditsChange]);
   // Clear on unmount so a stale `true` can't lock Send after the editor is gone
@@ -607,6 +623,23 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
       return { ...m, [id]: draft };
     });
   }, []);
+  // A field whose save failed AND which still diverges from the server. Both
+  // halves are required: failure alone keeps blocking after the user reverts by
+  // hand (the commit path short-circuits on an unchanged value, so nothing
+  // clears the flag), and divergence alone fires during the round-trip between
+  // a successful save and its refetch. `lineDrafts` is the per-line divergence
+  // signal the rail already maintains, including its own unmount cleanup.
+  const unsavedFieldLabel = useMemo(() => {
+    if (pending.size > 0) return null;
+    if (failedKeys.has('terms') && termsDirty) return t('quotes.editor.terms.title');
+    for (const id of Object.keys(lineDrafts)) {
+      if (failedKeys.has(pendingKey.line(id))) return t('quotes.editor.unsavedField.lines');
+    }
+    return null;
+  }, [pending.size, failedKeys, termsDirty, lineDrafts, t]);
+  useEffect(() => { onUnsavedEditsChange?.(unsavedFieldLabel); }, [unsavedFieldLabel, onUnsavedEditsChange]);
+  useEffect(() => () => onUnsavedEditsChange?.(null), [onUnsavedEditsChange]);
+
   // Drop drafts for lines that no longer exist (removed) so a stale draft can't
   // skew the rail after a delete.
   useEffect(() => {
@@ -2725,7 +2758,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
               disabled={!canWrite || isPending('terms')}
               data-testid="quote-terms"
               rows={3}
-              className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(termsDirty, termsSaved)}`}
+              className={`w-full rounded-md border bg-background px-3 py-2 text-sm transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60 ${fieldRing(termsDirty, termsSaved)}`}
               placeholder={t('quotes.editor.terms.placeholder')}
             />
             <SrSaved show={termsSaved} testId="quote-terms-saved" />

--- a/apps/web/src/components/billing/quotes/QuoteEditor.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.tsx
@@ -39,7 +39,7 @@ import PolishButton from '../../catalog/PolishButton';
 import { BlockCard, QuoteImagePreview } from './QuoteBlockCard';
 import { QuoteBulkBar } from './QuoteBulkBar';
 import { UnassignedLines } from './QuoteUnassignedLines';
-import { UNAUTHORIZED, type LineUpdate, SrSaved, fieldRing, pendingKey, useSavedFlash } from './quoteEditorShared';
+import { UNAUTHORIZED, type LineUpdate, SrSaved, fieldRing, pendingKey, useSavedFlash, useShowInternalMargin } from './quoteEditorShared';
 import { useMenuKeyboard } from '../shared/menuKeyboard';
 import { UnsavedBadge, RecurringBillingNote, MarginPanel } from '../billingUi';
 import {
@@ -112,10 +112,16 @@ interface Props {
    *  clicked during the undo grace window, so the held Send fires as soon as
    *  the DELETE lands instead of waiting out the rest of the window. */
   onRegisterPendingDeleteFlush?: (flush: (() => void) | null) => void;
+  /** Controlled cost/margin visibility: when provided (the workspace renders
+   *  the toggle in the pinned header, next to Send), the editor consumes the
+   *  value and drops its own toolbar toggle. When absent the editor
+   *  self-manages via useShowInternalMargin (standalone mounts / tests). */
+  showInternal?: boolean;
+  onToggleInternal?: () => void;
 }
 
 
-export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, onRegisterPendingDeleteFlush }: Props) {
+export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, onRegisterPendingDeleteFlush, showInternal: showInternalProp, onToggleInternal }: Props) {
   const { t } = useTranslation('billing');
   const { can } = usePermissions();
   const canWrite = can('quotes', 'write');
@@ -124,22 +130,13 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
   // Margin summary is gated the same way QuoteDetail gates it — on quotes:read —
   // rather than on write, which would hide the aggregate while showing the parts.
   const canSeeMargin = can('quotes', 'read');
-  // "Show cost & margin" governs EVERY internal-economics surface — the per-line
-  // cost/markup bands AND the rail's Margin panel — so one toggle honestly means
-  // "no margin on screen" (a tech screen-sharing with a client must be able to
-  // trust it). Collapsed by default; the choice persists per browser so daily
-  // margin-watchers aren't re-toggling on every quote.
-  const SHOW_INTERNAL_KEY = 'breeze:quote-editor-show-margin';
-  const [showInternal, setShowInternalState] = useState(
-    () => typeof localStorage !== 'undefined' && localStorage.getItem(SHOW_INTERNAL_KEY) === '1',
-  );
-  const setShowInternal = useCallback((updater: (v: boolean) => boolean) => {
-    setShowInternalState((v) => {
-      const next = updater(v);
-      try { localStorage.setItem(SHOW_INTERNAL_KEY, next ? '1' : '0'); } catch { /* private mode — session-only */ }
-      return next;
-    });
-  }, []);
+  // Cost/margin visibility: controlled by the workspace when the props are
+  // supplied (toggle lives in the pinned header), self-managed otherwise. See
+  // useShowInternalMargin for what the flag governs and why it persists.
+  const [fallbackShowInternal, toggleFallbackShowInternal] = useShowInternalMargin();
+  const internalControlled = showInternalProp !== undefined;
+  const showInternal = showInternalProp ?? fallbackShowInternal;
+  const toggleShowInternal = onToggleInternal ?? toggleFallbackShowInternal;
   const { quote, blocks: serverBlocks, lines: serverLines } = detail;
   const currency = quote.currencyCode;
 
@@ -2064,7 +2061,7 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                             </li>
                           ))}
                         </ul>
-                        <p className="mt-1 text-[11px] text-muted-foreground">{t('quotes.editor.contract.autoHint')}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">{t('quotes.editor.contract.autoHint')}</p>
                       </div>
                     )}
 
@@ -2146,10 +2143,12 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
 
   return (
     <div className="space-y-6" data-testid="quote-editor">
-      {/* The autosave hint is writer-only, but the cost/margin toggle is offered to
-          everyone who can see the editor: read-only users also have per-line cost
-          bands and deserve the same collapse control (ml-auto keeps it right-aligned
-          whether or not the hint renders). */}
+      {/* The cost/margin toggle renders here only when the editor self-manages it
+          (standalone mounts / tests) — in the workspace the toggle sits in the
+          pinned header instead, so the toolbar row collapses entirely for a
+          read-only user there. ml-auto keeps the toggle right-aligned whether or
+          not the writer-only hint renders. */}
+      {(canWrite || !internalControlled) && (
       <div className="flex flex-wrap items-center gap-2">
         {canWrite && (
           <p className="text-xs text-muted-foreground" data-testid="quote-editor-autosave-hint">
@@ -2179,17 +2178,20 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
             {t('quotes.editor.coverPage.enable')}
           </label>
         )}
-        <button
-          type="button"
-          onClick={() => setShowInternal((v) => !v)}
-          aria-pressed={showInternal}
-          data-testid="quote-editor-toggle-internal"
-          className={`ml-auto inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-muted ${showInternal ? 'border-primary/40 bg-primary/10 text-primary' : ''}`}
-        >
-          {showInternal ? <EyeOff className="h-3.5 w-3.5" aria-hidden="true" /> : <Eye className="h-3.5 w-3.5" aria-hidden="true" />}
-          {showInternal ? t('quotes.editor.actions.hideCostMargin') : t('quotes.editor.actions.showCostMargin')}
-        </button>
+        {!internalControlled && (
+          <button
+            type="button"
+            onClick={toggleShowInternal}
+            aria-pressed={showInternal}
+            data-testid="quote-editor-toggle-internal"
+            className={`ml-auto inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors hover:bg-muted ${showInternal ? 'border-primary/40 bg-primary/10 text-primary' : ''}`}
+          >
+            {showInternal ? <EyeOff className="h-3.5 w-3.5" aria-hidden="true" /> : <Eye className="h-3.5 w-3.5" aria-hidden="true" />}
+            {showInternal ? t('quotes.editor.actions.hideCostMargin') : t('quotes.editor.actions.showCostMargin')}
+          </button>
+        )}
       </div>
+      )}
       {/* Cover page: a toolbar toggle, not a permanent card — the once-per-quote
           setup stays out of the daily compose path. Fields appear only while
           enabled. */}
@@ -2675,13 +2677,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
           {sortedBlocks.length >= 2 && (
             <nav
               aria-label={t('quotes.editor.outline.aria')}
+              aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"
               data-testid="quote-outline"
               className="rounded-lg border bg-card p-3 shadow-xs"
             >
-              <h2
-                className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-                title={t('quotes.editor.outline.shortcutHint')}
-              >
+              <h2 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 {t('quotes.editor.outline.title')}
               </h2>
               <ul className="space-y-0.5">
@@ -2703,6 +2703,11 @@ export default function QuoteEditor({ detail, onChanged, onPendingEditsChange, o
                   </li>
                 ))}
               </ul>
+              {/* Visible, not a hover `title`: a shortcut nobody can discover
+                  by keyboard or touch may as well not exist. */}
+              <p className="mt-1.5 text-xs text-muted-foreground/80" data-testid="quote-outline-shortcut-hint">
+                {t('quotes.editor.outline.shortcutHint')}
+              </p>
             </nav>
           )}
 
@@ -2879,7 +2884,7 @@ function InsertGap({ index, active, onToggle, label, dropActive, onDragOver, onD
         onClick={onToggle}
         aria-expanded={active}
         data-testid={`quote-insert-section-${index}`}
-        className={`inline-flex items-center gap-1 rounded-full border bg-card px-2.5 py-0.5 text-[11px] font-medium transition-opacity focus:opacity-100 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${
+        className={`inline-flex items-center gap-1 rounded-full border bg-card px-2.5 py-0.5 text-xs font-medium transition-opacity focus:opacity-100 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring ${
           active ? 'border-primary/40 text-primary opacity-100' : 'text-muted-foreground opacity-0 hover:text-foreground group-hover/gap:opacity-100'
         }`}
       >

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.customer.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.customer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { QuoteHeaderMeta } from './QuoteHeaderMeta';
+import { QuoteCustomerSwitcher } from './QuoteHeaderMeta';
 import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
 import { fetchWithAuth } from '../../../stores/auth';
 
@@ -63,25 +63,31 @@ const customerPatchCalls = () =>
   fetchMock.mock.calls.filter((c) => c[0] === '/quotes/q-1' && (c[1] as RequestInit | undefined)?.method === 'PATCH'
     && String((c[1] as RequestInit).body).includes('orgId'));
 
-describe('QuoteHeaderMeta customer reassignment', () => {
+describe('QuoteCustomerSwitcher customer reassignment', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fetchMock.mockImplementation(async () => json({ data: {} }));
   });
 
-  // Reassignment clears site + bill-to and swaps the tax basis, so a select
-  // change stages a confirm step — the PATCH only fires after the user confirms.
+  /** The switcher is a typeahead combobox: open the trigger, click an option. */
+  function pickCustomer(orgId: string) {
+    fireEvent.click(screen.getByTestId('quote-customer-trigger'));
+    fireEvent.click(screen.getByTestId(`quote-customer-option-${orgId}`));
+  }
+
+  // Reassignment clears site + bill-to and swaps the tax basis, so a pick
+  // stages a confirm step — the PATCH only fires after the user confirms.
   it('changing the customer confirms, then PATCHes { orgId } and refreshes the detail', async () => {
     const onChanged = vi.fn();
-    render(<QuoteHeaderMeta detail={detail()} onChanged={onChanged} />);
+    render(<QuoteCustomerSwitcher detail={detail()} onChanged={onChanged} />);
 
-    const select = screen.getByTestId('quote-customer');
-    expect(select).toHaveValue('org-1');
-    fireEvent.change(select, { target: { value: 'org-2' } });
+    const trigger = screen.getByTestId('quote-customer-trigger');
+    expect(trigger).toHaveTextContent('Acme');
+    pickCustomer('org-2');
 
-    // Nothing saved yet — the select still shows the current customer.
+    // Nothing saved yet — the trigger still shows the current customer.
     expect(customerPatchCalls()).toHaveLength(0);
-    expect(select).toHaveValue('org-1');
+    expect(trigger).toHaveTextContent('Acme');
 
     fireEvent.click(screen.getByTestId('quote-customer-confirm'));
     await waitFor(() => expect(customerPatchCalls()).toHaveLength(1));
@@ -90,56 +96,63 @@ describe('QuoteHeaderMeta customer reassignment', () => {
   });
 
   it('cancelling the confirm leaves the customer unchanged and PATCHes nothing', async () => {
-    render(<QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} />);
+    render(<QuoteCustomerSwitcher detail={detail()} onChanged={vi.fn()} />);
 
-    const select = screen.getByTestId('quote-customer');
-    fireEvent.change(select, { target: { value: 'org-2' } });
+    pickCustomer('org-2');
     fireEvent.click(screen.getByText('Cancel'));
 
     await waitFor(() => expect(screen.queryByTestId('quote-customer-confirm')).not.toBeInTheDocument());
     expect(customerPatchCalls()).toHaveLength(0);
-    expect(select).toHaveValue('org-1');
+    expect(screen.getByTestId('quote-customer-trigger')).toHaveTextContent('Acme');
   });
 
   it('re-selecting the current customer is a no-op', () => {
-    render(<QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} />);
+    render(<QuoteCustomerSwitcher detail={detail()} onChanged={vi.fn()} />);
 
-    fireEvent.change(screen.getByTestId('quote-customer'), { target: { value: 'org-1' } });
+    pickCustomer('org-1');
 
     expect(screen.queryByTestId('quote-customer-confirm')).not.toBeInTheDocument();
     expect(customerPatchCalls()).toHaveLength(0);
   });
 
-  // The select clips a long org name at max-w-56 with no other way to read it —
-  // `title` is the mouse-hover escape hatch, so it must carry the actual
-  // selected name rather than generic static help copy.
-  it("the select's title carries the selected organization's full name", () => {
-    render(<QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} />);
+  it('filters the option list by the typed query', () => {
+    render(<QuoteCustomerSwitcher detail={detail()} onChanged={vi.fn()} />);
 
-    const select = screen.getByTestId('quote-customer');
-    expect(select).toHaveAttribute('title', 'Acme');
+    fireEvent.click(screen.getByTestId('quote-customer-trigger'));
+    fireEvent.change(screen.getByTestId('quote-customer-search'), { target: { value: 'beta' } });
 
-    fireEvent.change(select, { target: { value: 'org-2' } });
-    fireEvent.click(screen.getByTestId('quote-customer-confirm'));
-    // The select snaps to the new value optimistically on confirm; its title
-    // follows the same selection, not the stale one.
-    return waitFor(() => expect(select).toHaveAttribute('title', 'Beta Corp'));
+    expect(screen.getByTestId('quote-customer-option-org-2')).toBeInTheDocument();
+    expect(screen.queryByTestId('quote-customer-option-org-1')).not.toBeInTheDocument();
   });
 
-  it('snaps the select back when the move fails', async () => {
+  // The trigger truncates a long org name — `title` is the mouse-hover escape
+  // hatch, so it must carry the actual selected name.
+  it("the trigger's title carries the selected organization's full name", async () => {
+    render(<QuoteCustomerSwitcher detail={detail()} onChanged={vi.fn()} />);
+
+    const trigger = screen.getByTestId('quote-customer-trigger');
+    expect(trigger).toHaveAttribute('title', 'Acme');
+
+    pickCustomer('org-2');
+    fireEvent.click(screen.getByTestId('quote-customer-confirm'));
+    // The trigger snaps to the new value optimistically on confirm; its title
+    // follows the same selection, not the stale one.
+    await waitFor(() => expect(trigger).toHaveAttribute('title', 'Beta Corp'));
+  });
+
+  it('snaps the trigger back when the move fails', async () => {
     fetchMock.mockImplementation(async (path, init) => {
       if (path === '/quotes/q-1' && (init as RequestInit | undefined)?.method === 'PATCH') {
         return json({ error: 'Organization not found' }, false, 404);
       }
       return json({ data: {} });
     });
-    render(<QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} />);
+    render(<QuoteCustomerSwitcher detail={detail()} onChanged={vi.fn()} />);
 
-    const select = screen.getByTestId('quote-customer');
-    fireEvent.change(select, { target: { value: 'org-2' } });
+    pickCustomer('org-2');
     fireEvent.click(screen.getByTestId('quote-customer-confirm'));
 
     await waitFor(() => expect(customerPatchCalls()).toHaveLength(1));
-    await waitFor(() => expect(select).toHaveValue('org-1'));
+    await waitFor(() => expect(screen.getByTestId('quote-customer-trigger')).toHaveTextContent('Acme'));
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.title.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.title.test.tsx
@@ -1,0 +1,95 @@
+// The quote title is a blur-to-save field in the workspace HEADER, so its
+// reported state feeds the Send gate directly. It reported `busy || dirty` as
+// "pending" and cleared `dirty` only on success — so one failed PATCH pinned
+// "Saving changes… Send unlocks when everything is saved." over the Send button
+// for the rest of the session, describing a save that had already given up.
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { QuoteHeaderMeta } from './QuoteHeaderMeta';
+import type { QuoteDetail as QuoteDetailData } from './quoteTypes';
+import { fetchWithAuth } from '../../../stores/auth';
+
+vi.mock('../../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+  registerOrgIdProvider: vi.fn(),
+  useAuthStore: Object.assign(
+    (selector: (s: { user: { permissions: { resource: string; action: string }[] } }) => unknown) =>
+      selector({ user: { permissions: [{ resource: '*', action: '*' }] } }),
+    { getState: () => ({ tokens: null }) },
+  ),
+}));
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+vi.mock('../../shared/Toast', () => ({ showToast: vi.fn() }));
+vi.mock('../../../stores/orgStore', () => ({
+  useOrgStore: (sel: (s: { organizations: unknown[] }) => unknown) => sel({ organizations: [] }),
+}));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+const json = (payload: unknown, ok = true, status = ok ? 200 : 500): Response =>
+  ({ ok, status, statusText: ok ? 'OK' : 'ERR', json: vi.fn().mockResolvedValue(payload) }) as unknown as Response;
+
+function detail(): QuoteDetailData {
+  return {
+    quote: {
+      id: 'q-1', quoteNumber: 'Q-1', partnerId: 'p-1', orgId: 'org-1', siteId: null, status: 'draft',
+      currencyCode: 'USD', issueDate: null, expiryDate: null, subtotal: '0.00', taxRate: null,
+      taxTotal: '0.00', total: '0.00', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00',
+      annualRecurringTotal: '0.00', dueOnAcceptanceTotal: '0.00', billToName: null, introNotes: null,
+      terms: null, termsAndConditions: null, sellerSnapshot: null, acceptedAt: null, declinedAt: null,
+      convertedAt: null, convertedInvoiceId: null, sentAt: null, viewedAt: null,
+      createdBy: null, createdAt: '2026-06-01T00:00:00Z', updatedAt: '2026-06-01T00:00:00Z',
+    },
+    blocks: [],
+    lines: [],
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('QuoteHeaderMeta — title save reporting', () => {
+  it('a dirty title is not "pending"; only the in-flight PATCH is', async () => {
+    let resolvePatch!: (v: Response) => void;
+    fetchMock.mockImplementation(async () => new Promise<Response>((r) => { resolvePatch = r; }));
+    const onPending = vi.fn();
+
+    render(<QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} onPendingChange={onPending} />);
+    expect(onPending).toHaveBeenLastCalledWith(false);
+
+    const input = screen.getByTestId('quote-title');
+    fireEvent.change(input, { target: { value: 'Renewal' } });
+    // Typing has sent nothing. The Send gate still holds, because the Send
+    // click itself blurs this field and the resulting save lands first.
+    expect(onPending).toHaveBeenLastCalledWith(false);
+
+    fireEvent.blur(input);
+    await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(true));
+
+    resolvePatch(json({ data: {} }));
+    await waitFor(() => expect(onPending).toHaveBeenLastCalledWith(false));
+  });
+
+  it('a FAILED title save reports an unsaved field and stops claiming to be saving', async () => {
+    let fail = true;
+    fetchMock.mockImplementation(async () => (fail ? json({ error: 'no' }, false, 500) : json({ data: {} })));
+    const onPending = vi.fn();
+    const onUnsaved = vi.fn();
+
+    render(
+      <QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} onPendingChange={onPending} onUnsavedChange={onUnsaved} />,
+    );
+
+    const input = screen.getByTestId('quote-title');
+    fireEvent.change(input, { target: { value: 'Renewal' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => expect(onUnsaved).toHaveBeenLastCalledWith('Quote title'));
+    expect(onPending).toHaveBeenLastCalledWith(false);
+
+    // A successful retry lifts the block.
+    fail = false;
+    fireEvent.change(input, { target: { value: 'Renewal v2' } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(onUnsaved).toHaveBeenLastCalledWith(null));
+  });
+});

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.title.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.title.test.tsx
@@ -92,4 +92,27 @@ describe('QuoteHeaderMeta — title save reporting', () => {
     fireEvent.blur(input);
     await waitFor(() => expect(onUnsaved).toHaveBeenLastCalledWith(null));
   });
+
+  it('a FAILED title save bumps the workspace failure nonce (onSaveFailure); a success does not', async () => {
+    // Without this signal a queued Send saw only "quiet" once titleBusy
+    // cleared, and the composer opened carrying the stale title. The nonce is
+    // what cancels it (same contract as QuoteEditor's onSaveFailure).
+    let fail = true;
+    fetchMock.mockImplementation(async () => (fail ? json({ error: 'no' }, false, 500) : json({ data: {} })));
+    const onSaveFailure = vi.fn();
+
+    render(<QuoteHeaderMeta detail={detail()} onChanged={vi.fn()} onSaveFailure={onSaveFailure} />);
+
+    const input = screen.getByTestId('quote-title');
+    fireEvent.change(input, { target: { value: 'Renewal' } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(onSaveFailure).toHaveBeenCalledTimes(1));
+
+    // A successful save reports nothing — the nonce only counts FAILURES.
+    fail = false;
+    fireEvent.change(input, { target: { value: 'Renewal v2' } });
+    fireEvent.blur(input);
+    await waitFor(() => expect(screen.getByTestId('quote-title')).not.toBeDisabled());
+    expect(onSaveFailure).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
@@ -20,25 +20,30 @@ import { fetchWithAuth } from '../../../stores/auth';
 import { runAction } from '../../../lib/runAction';
 import { useOrgStore } from '../../../stores/orgStore';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
-import { OrgCombobox } from '../shared/OrgCombobox';
+import { OrgCombobox, orgComboboxOptions } from '../shared/OrgCombobox';
 import { type QuoteDetail as QuoteDetailData } from './quoteTypes';
 import { UNAUTHORIZED, SrSaved, fieldRing, seamless, useSavedFlash } from './quoteEditorShared';
 
 interface Props {
   detail: QuoteDetailData;
   onChanged: () => void;
-  /** Reports in-flight/dirty state so the workspace can hold Send (merged with
-   *  the editor's own savePending). */
+  /** Reports IN-FLIGHT state so the workspace can hold Send (merged with the
+   *  editor's own savePending). Deliberately not true for a merely-dirty
+   *  field — see the note on the effects below. */
   onPendingChange?: (pending: boolean) => void;
+  /** Reports a translated field label when this surface's save FAILED and the
+   *  field is still dirty, so Send can name it instead of waiting forever. */
+  onUnsavedChange?: (label: string | null) => void;
 }
 
-export function QuoteHeaderMeta({ detail, onChanged, onPendingChange }: Props) {
+export function QuoteHeaderMeta({ detail, onChanged, onPendingChange, onUnsavedChange }: Props) {
   const { t } = useTranslation('billing');
   const { quote } = detail;
 
   const [title, setTitle] = useState(quote.title ?? '');
   const [titleDirty, setTitleDirty] = useState(false);
   const [titleBusy, setTitleBusy] = useState(false);
+  const [titleFailed, setTitleFailed] = useState(false);
   const [titleSaved, flashTitleSaved] = useSavedFlash();
   useEffect(() => { setTitle(quote.title ?? ''); setTitleDirty(false); }, [quote.title]);
 
@@ -54,16 +59,29 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange }: Props) {
         onUnauthorized: UNAUTHORIZED,
       });
       setTitleDirty(false);
+      setTitleFailed(false);
       flashTitleSaved();
       onChanged();
-    } catch { /* runAction toasted */ } finally {
+    } catch {
+      // runAction toasted. The field STAYS dirty (nothing reverted it), so
+      // record the failure — reporting dirty as "pending" is what used to pin
+      // "Saving changes…" over the Send button for the rest of the session.
+      setTitleFailed(true);
+    } finally {
       setTitleBusy(false);
     }
   }, [titleDirty, title, quote.id, flashTitleSaved, onChanged, t]);
 
-  const pending = titleBusy || titleDirty;
-  useEffect(() => { onPendingChange?.(pending); }, [pending, onPendingChange]);
+  // Pending means IN FLIGHT only. A dirty title is not a promise of a save: the
+  // Send gate still holds from the first keystroke because clicking Send blurs
+  // this field first, and that blur-save lands in `titleBusy` before the click
+  // handler runs.
+  useEffect(() => { onPendingChange?.(titleBusy); }, [titleBusy, onPendingChange]);
   useEffect(() => () => onPendingChange?.(false), [onPendingChange]);
+  // Failed AND still dirty — see the same pairing in InvoiceEditor.
+  const unsavedLabel = !titleBusy && titleFailed && titleDirty ? t('quotes.editor.title.label') : null;
+  useEffect(() => { onUnsavedChange?.(unsavedLabel); }, [unsavedLabel, onUnsavedChange]);
+  useEffect(() => () => onUnsavedChange?.(null), [onUnsavedChange]);
 
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2" data-testid="quote-header-meta">
@@ -94,16 +112,14 @@ export function QuoteCustomerSwitcher({ detail, onChanged, onPendingChange }: Pr
   const { quote } = detail;
 
   const organizations = useOrgStore((s) => s.organizations);
-  const orgOptions = useMemo(() => {
-    const sorted = [...organizations].sort((a, b) => a.name.localeCompare(b.name));
-    if (!sorted.some((o) => o.id === quote.orgId)) {
-      sorted.unshift({
-        id: quote.orgId,
-        name: detail.billTo?.name?.trim() || quote.orgId.slice(0, 8),
-      } as (typeof sorted)[number]);
-    }
-    return sorted;
-  }, [organizations, quote.orgId, detail.billTo?.name]);
+  const orgOptions = useMemo(
+    () => orgComboboxOptions(
+      organizations,
+      quote.orgId,
+      detail.billTo?.name?.trim() || quote.orgId.slice(0, 8),
+    ),
+    [organizations, quote.orgId, detail.billTo?.name],
+  );
 
   const [customerOrgId, setCustomerOrgId] = useState(quote.orgId);
   const [customerBusy, setCustomerBusy] = useState(false);

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
@@ -34,9 +34,14 @@ interface Props {
   /** Reports a translated field label when this surface's save FAILED and the
    *  field is still dirty, so Send can name it instead of waiting forever. */
   onUnsavedChange?: (label: string | null) => void;
+  /** Reports every save FAILURE (the workspace bumps its failure nonce). A
+   *  failed title PATCH still reads as "quiet" once titleBusy clears, so a
+   *  queued Send must be canceled by this signal rather than open a composer
+   *  carrying a stale title (same contract as QuoteEditor's onSaveFailure). */
+  onSaveFailure?: () => void;
 }
 
-export function QuoteHeaderMeta({ detail, onChanged, onPendingChange, onUnsavedChange }: Props) {
+export function QuoteHeaderMeta({ detail, onChanged, onPendingChange, onUnsavedChange, onSaveFailure }: Props) {
   const { t } = useTranslation('billing');
   const { quote } = detail;
 
@@ -67,10 +72,13 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange, onUnsavedC
       // record the failure — reporting dirty as "pending" is what used to pin
       // "Saving changes…" over the Send button for the rest of the session.
       setTitleFailed(true);
+      // …and bump the workspace failure nonce: a Send queued behind this save
+      // sees only "quiet" when titleBusy clears, and must cancel instead.
+      onSaveFailure?.();
     } finally {
       setTitleBusy(false);
     }
-  }, [titleDirty, title, quote.id, flashTitleSaved, onChanged, t]);
+  }, [titleDirty, title, quote.id, flashTitleSaved, onChanged, onSaveFailure, t]);
 
   // Pending means IN FLIGHT only. A dirty title is not a promise of a save: the
   // Send gate still holds from the first keystroke because clicking Send blurs

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
@@ -1,10 +1,18 @@
-// The workspace header's identity row for a DRAFT quote: the page title IS the
-// editable quote title (seamless h1-styled input, blur-save, same amber/green
-// save language as every other field), with the customer selector beside it —
-// replacing the editor's former title/customer strip so the once-per-quote
-// setup no longer occupies a band above the canvas. Rendered into
-// DocumentWorkspace's titleSlot by QuoteWorkspace; non-draft quotes keep the
-// plain read-only h1.
+// The workspace header's identity chrome for a DRAFT quote, in two pieces:
+//
+//   QuoteHeaderMeta       — the page title IS the editable quote title
+//                           (seamless h1-styled input, blur-save, same
+//                           amber/green save language as every other field).
+//                           Rendered into DocumentWorkspace's titleSlot.
+//   QuoteCustomerSwitcher — the customer (organization) selector, rendered
+//                           into DocumentWorkspace's metaSlot on its OWN line
+//                           under the title. It used to sit inline between the
+//                           title and the status pill, which squeezed the
+//                           title and left the select floating mis-aligned in
+//                           the header row.
+//
+// Non-draft quotes keep the plain read-only h1 and no switcher. Each piece
+// reports its own pending state; QuoteWorkspace ORs them into the Send gate.
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
@@ -12,6 +20,7 @@ import { fetchWithAuth } from '../../../stores/auth';
 import { runAction } from '../../../lib/runAction';
 import { useOrgStore } from '../../../stores/orgStore';
 import { ConfirmDialog } from '../../shared/ConfirmDialog';
+import { OrgCombobox } from '../shared/OrgCombobox';
 import { type QuoteDetail as QuoteDetailData } from './quoteTypes';
 import { UNAUTHORIZED, SrSaved, fieldRing, seamless, useSavedFlash } from './quoteEditorShared';
 
@@ -27,7 +36,6 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange }: Props) {
   const { t } = useTranslation('billing');
   const { quote } = detail;
 
-  // ---- editable title (h1) -------------------------------------------------
   const [title, setTitle] = useState(quote.title ?? '');
   const [titleDirty, setTitleDirty] = useState(false);
   const [titleBusy, setTitleBusy] = useState(false);
@@ -53,7 +61,38 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange }: Props) {
     }
   }, [titleDirty, title, quote.id, flashTitleSaved, onChanged, t]);
 
-  // ---- customer (organization) reassignment --------------------------------
+  const pending = titleBusy || titleDirty;
+  useEffect(() => { onPendingChange?.(pending); }, [pending, onPendingChange]);
+  useEffect(() => () => onPendingChange?.(false), [onPendingChange]);
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-2" data-testid="quote-header-meta">
+      {/* NOT an <h1> wrapper: "heading level 1, edit text" is a confusing AT
+          announcement. DocumentWorkspace renders an sr-only h1 with the
+          document identity whenever a titleSlot replaces the visual heading. */}
+      <div className="min-w-0 flex-1">
+        <input
+          type="text"
+          value={title}
+          maxLength={200}
+          placeholder={quote.quoteNumber ?? t('quotes.editor.title.placeholder')}
+          aria-label={t('quotes.editor.title.label')}
+          onChange={(e) => { setTitle(e.target.value); setTitleDirty(true); }}
+          onBlur={() => void saveTitle()}
+          disabled={titleBusy}
+          data-testid="quote-title"
+          className={`w-full rounded-md border bg-transparent px-2 py-0.5 text-xl font-semibold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(titleDirty, titleSaved))}`}
+        />
+      </div>
+      <SrSaved show={titleSaved} testId="quote-title-saved" />
+    </div>
+  );
+}
+
+export function QuoteCustomerSwitcher({ detail, onChanged, onPendingChange }: Props) {
+  const { t } = useTranslation('billing');
+  const { quote } = detail;
+
   const organizations = useOrgStore((s) => s.organizations);
   const orgOptions = useMemo(() => {
     const sorted = [...organizations].sort((a, b) => a.name.localeCompare(b.name));
@@ -67,11 +106,6 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange }: Props) {
   }, [organizations, quote.orgId, detail.billTo?.name]);
 
   const [customerOrgId, setCustomerOrgId] = useState(quote.orgId);
-  // The select's `title` is a mouse-hover tooltip — the ONLY way to read a long
-  // org name once the select's own max-w-56 clips it. Falls back to the
-  // generic help copy only when nothing resolves (shouldn't happen in
-  // practice: customerOrgId always defaults to the quote's own org).
-  const selectedOrgName = orgOptions.find((o) => o.id === customerOrgId)?.name?.trim();
   const [customerBusy, setCustomerBusy] = useState(false);
   useEffect(() => { setCustomerOrgId(quote.orgId); }, [quote.orgId]);
   // Reassignment clears site + bill-to and re-resolves tax, so a select change
@@ -105,44 +139,29 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange }: Props) {
     })();
   }, [quote.id, quote.orgId, orgOptions, onChanged, t]);
 
-  const pending = titleBusy || titleDirty || customerBusy;
-  useEffect(() => { onPendingChange?.(pending); }, [pending, onPendingChange]);
+  useEffect(() => { onPendingChange?.(customerBusy); }, [customerBusy, onPendingChange]);
   useEffect(() => () => onPendingChange?.(false), [onPendingChange]);
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-2" data-testid="quote-header-meta">
-      <h1 className="min-w-0 flex-1">
-        <input
-          type="text"
-          value={title}
-          maxLength={200}
-          placeholder={quote.quoteNumber ?? t('quotes.editor.title.placeholder')}
-          aria-label={t('quotes.editor.title.label')}
-          onChange={(e) => { setTitle(e.target.value); setTitleDirty(true); }}
-          onBlur={() => void saveTitle()}
-          disabled={titleBusy}
-          data-testid="quote-title"
-          className={`w-full rounded-md border bg-transparent px-2 py-0.5 text-xl font-semibold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(titleDirty, titleSaved))}`}
-        />
-      </h1>
-      <SrSaved show={titleSaved} testId="quote-title-saved" />
-      <select
+    <div className="mt-0.5 flex min-w-0 items-center gap-1" data-testid="quote-header-customer">
+      <span className="shrink-0 text-xs text-muted-foreground" aria-hidden="true">
+        {t('quotes.editor.customer.label')}:
+      </span>
+      {/* Typeahead, not a native select: an MSP with 150 orgs needs to search
+          for the customer, not scroll an unsearchable browser list. A pick
+          only STAGES the change — the warning confirm below commits it. */}
+      <OrgCombobox
+        options={orgOptions}
         value={customerOrgId}
-        aria-label={t('quotes.editor.customer.label')}
-        title={selectedOrgName || t('quotes.editor.customer.help')}
-        onChange={(e) => {
-          const id = e.target.value;
+        onSelect={(id) => {
           if (id === customerOrgId) return;
           setPendingCustomer({ id, name: orgOptions.find((o) => o.id === id)?.name ?? '' });
         }}
         disabled={customerBusy}
-        data-testid="quote-customer"
-        className="h-8 max-w-56 shrink-0 rounded-md border border-transparent bg-transparent px-2 text-sm text-muted-foreground transition-colors hover:border-border focus:border-border focus:outline-hidden disabled:opacity-60"
-      >
-        {orgOptions.map((o) => (
-          <option key={o.id} value={o.id}>{o.name}</option>
-        ))}
-      </select>
+        label={t('quotes.editor.customer.label')}
+        variant="seamless"
+        testId="quote-customer"
+      />
 
       <ConfirmDialog
         open={pendingCustomer !== null}

--- a/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
@@ -1038,7 +1038,7 @@ export function EditableLineRow({
           aria-invalid={fieldErrors.qty ? true : undefined}
           aria-describedby={describedByIds(fieldErrors.qty && `quote-line-qty-error-${line.id}`, qtyDirty && unsavedHintId(line.id, 'qty'))}
           data-testid={`quote-line-qty-${line.id}`}
-          className={`h-9 w-14 rounded-md border bg-transparent px-2 text-right text-sm tabular-nums transition-colors focus:outline-hidden disabled:opacity-60 ${fieldErrors.qty ? 'border-destructive' : seamless(fieldRing(qtyDirty, saved))}`}
+          className={`h-9 w-14 rounded-md border bg-transparent px-2 text-right text-sm tabular-nums transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(qtyDirty, saved), !!fieldErrors.qty)}`}
         />
         <UnsavedFieldHint id={unsavedHintId(line.id, 'qty')} show={qtyDirty} />
       </td>
@@ -1055,7 +1055,7 @@ export function EditableLineRow({
           aria-describedby={describedByIds(fieldErrors.price && `quote-line-price-error-${line.id}`, priceDirty && unsavedHintId(line.id, 'price'))}
           data-testid={`quote-line-price-${line.id}`}
           style={{ width: growWidth(priceDisplay, 8, 16) }}
-          className={`h-9 rounded-md border bg-transparent px-2 text-right text-sm tabular-nums transition-colors focus:outline-hidden disabled:opacity-60 ${fieldErrors.price ? 'border-destructive' : seamless(fieldRing(priceDirty, saved))}`}
+          className={`h-9 rounded-md border bg-transparent px-2 text-right text-sm tabular-nums transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(priceDirty, saved), !!fieldErrors.price)}`}
         />
         <UnsavedFieldHint id={unsavedHintId(line.id, 'price')} show={priceDirty} />
         {/* Billing cadence belongs with the price ("$1,499.00 /mo"), so its
@@ -1469,7 +1469,7 @@ export function EditableLineRow({
               title={t('quotes.editor.line.skuHelp')}
               aria-describedby={describedByIds(`quote-line-sku-help-${line.id}`, skuDirty && unsavedHintId(line.id, 'sku'))}
               data-testid={`quote-line-sku-${line.id}`}
-              className={`h-6 w-28 rounded border bg-background px-1 text-foreground transition-shadow ${fieldRing(skuDirty, saved)}`}
+              className={`h-6 w-28 rounded border bg-background px-1 text-foreground transition-colors ${fieldRing(skuDirty, saved)}`}
             />
             <span id={`quote-line-sku-help-${line.id}`} className="sr-only">{t('quotes.editor.line.skuHelp')}</span>
             <UnsavedFieldHint id={unsavedHintId(line.id, 'sku')} show={skuDirty} />
@@ -1484,7 +1484,7 @@ export function EditableLineRow({
               title={t('quotes.editor.line.partNumberHelp')}
               aria-describedby={describedByIds(`quote-line-partnumber-help-${line.id}`, partDirty && unsavedHintId(line.id, 'pn'))}
               data-testid={`quote-line-partnumber-${line.id}`}
-              className={`h-6 w-28 rounded border bg-background px-1 text-foreground transition-shadow ${fieldRing(partDirty, saved)}`}
+              className={`h-6 w-28 rounded border bg-background px-1 text-foreground transition-colors ${fieldRing(partDirty, saved)}`}
             />
             <span id={`quote-line-partnumber-help-${line.id}`} className="sr-only">{t('quotes.editor.line.partNumberHelp')}</span>
             <UnsavedFieldHint id={unsavedHintId(line.id, 'pn')} show={partDirty} />
@@ -1506,11 +1506,14 @@ export function EditableLineRow({
               data-testid={`quote-line-cost-${line.id}`}
               style={{ width: growWidth(costDisplay, 6, 14) }}
               // Priority: validation error (destructive) > unsaved edit (amber
-              // dirty ring) > a genuinely missing cost (warning tint — Task 2's
-              // "distinct from the amber dirty ring" treatment, using the same
+              // dirty border) > a genuinely missing cost (warning tint —
+              // "distinct from the amber dirty border" treatment, using the same
               // warning token family at lower opacity so it reads as related but
               // not identical) > saved flash / rest.
-              className={`h-6 rounded border bg-background px-1 text-right tabular-nums text-foreground transition-shadow ${
+              // The transition names both channels because this field is the one
+              // place they mix: the error branch is a ring (box-shadow) while
+              // every other branch is border-color.
+              className={`h-6 rounded border bg-background px-1 text-right tabular-nums text-foreground transition-[border-color,box-shadow] ${
                 fieldErrors.cost
                   ? 'border-destructive ring-1 ring-destructive'
                   : costDirty

--- a/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteLineRows.tsx
@@ -1176,7 +1176,7 @@ export function EditableLineRow({
               </button>
               {moveTargets.length > 0 && !line.parentLineId && (
                 <>
-                  <p className="mt-1 border-t px-3 pb-0.5 pt-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{t('quotes.editor.actions.moveTo')}</p>
+                  <p className="mt-1 border-t px-3 pb-0.5 pt-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{t('quotes.editor.actions.moveTo')}</p>
                   {moveTargets.map((t) => (
                     <button
                       key={t.id}
@@ -1410,7 +1410,7 @@ export function EditableLineRow({
                 onClick={attachImageFromUrl}
                 disabled={imageBusy || fieldBusy('image') || !imageUrlDraft.trim()}
                 data-testid={`quote-line-image-url-fetch-${line.id}`}
-                className="inline-flex h-8 items-center rounded-md bg-primary px-2 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                className="inline-flex h-8 items-center rounded-md bg-primary px-2 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
               >
                 {t('quotes.editor.actions.fetch')}
               </button>

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -9,7 +9,9 @@ import QuoteEditor from './QuoteEditor';
 import QuoteDetail from './QuoteDetail';
 import QuoteDocumentPreview from './QuoteDocument';
 import QuoteActions, { QuoteSendOutcomeBanners } from './QuoteActions';
-import { QuoteHeaderMeta } from './QuoteHeaderMeta';
+import { QuoteCustomerSwitcher, QuoteHeaderMeta } from './QuoteHeaderMeta';
+import { MarginToggle } from '../billingUi';
+import { useShowInternalMargin } from './quoteEditorShared';
 import { useOrgStore } from '../../../stores/orgStore';
 import { STATUS_ROLES, type QuoteDetail as QuoteDetailData, resolveQuoteOrgName } from './quoteTypes';
 
@@ -44,9 +46,13 @@ export default function QuoteWorkspace({ id }: Props) {
   // True while the editor has an in-flight save or a dirty rail field — the
   // header Send button waits for quiescence so it can't race a blur-save.
   const [editorSavePending, setEditorSavePending] = useState(false);
-  // The header's editable title/customer (drafts) report their own pending
-  // state; Send waits for BOTH surfaces to be quiescent.
-  const [headerSavePending, setHeaderSavePending] = useState(false);
+  // The header's editable title and the customer switcher (drafts) each report
+  // their own pending state; Send waits for ALL surfaces to be quiescent.
+  const [titleSavePending, setTitleSavePending] = useState(false);
+  const [customerSavePending, setCustomerSavePending] = useState(false);
+  // Cost/margin visibility is workspace state so the toggle can live in the
+  // pinned header (next to Send) while the editor's internal surfaces consume it.
+  const [showInternal, toggleShowInternal] = useShowInternalMargin();
   // Bridge between the editor's deferred deletions (undo grace window) and the
   // header's Send: the editor registers a "flush now" hook, and QuoteActions
   // calls it when Send is clicked while edits are pending — so a held Send
@@ -61,9 +67,9 @@ export default function QuoteWorkspace({ id }: Props) {
   }, []);
 
   // A `quiet` reload (after an inline edit) refetches without flipping `loading`,
-  // so the editor stays mounted — a full-page spinner would remount the form and
-  // discard the user's in-progress local state and cursor position. Only the
-  // initial load shows the spinner / replaces the view on error.
+  // so the editor stays mounted — a full-page loading state would remount the
+  // form and discard the user's in-progress local state and cursor position.
+  // Only the initial load shows the skeleton / replaces the view on error.
   const fetchDetail = useCallback(async (quiet = false) => {
     if (!id) { setError(t('quotes.workspace.errors.missingId')); setLoading(false); return; }
     try {
@@ -109,9 +115,38 @@ export default function QuoteWorkspace({ id }: Props) {
   }, []);
 
   if (loading) {
+    // Skeleton, not a spinner: sketches the workspace shape (back link, title
+    // row + actions, tabs, canvas + rail) so the load reads as the page
+    // assembling rather than a blank wait. aria-busy + the sr-only status give
+    // AT users the same signal.
     return (
-      <div className="flex items-center justify-center py-16" data-testid="quote-workspace-loading">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      <div aria-busy="true" data-testid="quote-workspace-loading">
+        <span role="status" className="sr-only">{t('quotes.workspace.loading')}</span>
+        <div className="animate-pulse" aria-hidden="true">
+          <div className="h-3 w-16 rounded bg-muted" />
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <div className="h-7 w-72 max-w-[50%] rounded bg-muted" />
+            <div className="flex gap-2">
+              <div className="h-9 w-28 rounded-md bg-muted" />
+              <div className="h-9 w-28 rounded-md bg-muted" />
+            </div>
+          </div>
+          <div className="mt-5 flex gap-4 border-b pb-2">
+            <div className="h-4 w-14 rounded bg-muted" />
+            <div className="h-4 w-14 rounded bg-muted" />
+            <div className="h-4 w-14 rounded bg-muted" />
+          </div>
+          <div className="mt-6 flex gap-6">
+            <div className="min-w-0 flex-1 space-y-4">
+              <div className="h-40 rounded-lg border bg-muted/40" />
+              <div className="h-40 rounded-lg border bg-muted/40" />
+            </div>
+            <div className="hidden w-72 shrink-0 space-y-4 lg:block">
+              <div className="h-56 rounded-lg border bg-muted/40" />
+              <div className="h-24 rounded-lg border bg-muted/40" />
+            </div>
+          </div>
+        </div>
       </div>
     );
   }
@@ -159,13 +194,24 @@ export default function QuoteWorkspace({ id }: Props) {
       backHref="/billing/quotes"
       backLabel={t('quotes.workspace.backLabel')}
       title={detail.quote.title?.trim() || detail.quote.quoteNumber || t('quotes.workspace.draftTitle')}
-      // Drafts get the editable identity row (title input + customer select) in
-      // place of the static h1 — the editor no longer carries a title strip.
-      titleSlot={isDraft ? <QuoteHeaderMeta detail={detail} onChanged={() => void reload()} onPendingChange={setHeaderSavePending} /> : undefined}
+      // Drafts get the editable title in place of the static h1, with the
+      // customer switcher on its own meta line below — inline next to the title
+      // it squeezed the h1 and floated mis-aligned against the status pill.
+      titleSlot={isDraft ? <QuoteHeaderMeta detail={detail} onChanged={() => void reload()} onPendingChange={setTitleSavePending} /> : undefined}
+      metaSlot={isDraft ? <QuoteCustomerSwitcher detail={detail} onChanged={() => void reload()} onPendingChange={setCustomerSavePending} /> : undefined}
       statusPill={statusPill}
       // Primary actions live in the header so Send (the money-moment) and Download
-      // are reachable from any tab, not buried inside the Detail tab.
-      actions={<QuoteActions detail={detail} onChanged={reload} variant="header" savePending={editorSavePending || headerSavePending} onSendWhilePending={flushEditorPendingDeletes} />}
+      // are reachable from any tab, not buried inside the Detail tab. The
+      // cost/margin toggle joins them while the Editor tab is up, so the
+      // "no margin on screen" control is available without scrolling.
+      actions={
+        <>
+          {isDraft && activeTab === 'editor' && (
+            <MarginToggle show={showInternal} onToggle={toggleShowInternal} testId="quote-editor-toggle-internal" size="md" />
+          )}
+          <QuoteActions detail={detail} onChanged={reload} variant="header" savePending={editorSavePending || titleSavePending || customerSavePending} onSendWhilePending={flushEditorPendingDeletes} />
+        </>
+      }
       tabs={tabs}
       activeTab={activeTab}
       onTabChange={selectTab}
@@ -189,7 +235,7 @@ export default function QuoteWorkspace({ id }: Props) {
           while previewing. */}
       {isDraft && (
         <div className={activeTab === 'editor' ? '' : 'hidden'}>
-          <QuoteEditor detail={detail} onChanged={() => void reload()} onPendingEditsChange={setEditorSavePending} onRegisterPendingDeleteFlush={registerPendingDeleteFlush} />
+          <QuoteEditor detail={detail} onChanged={() => void reload()} onPendingEditsChange={setEditorSavePending} onRegisterPendingDeleteFlush={registerPendingDeleteFlush} showInternal={showInternal} onToggleInternal={toggleShowInternal} />
         </div>
       )}
       {activeTab === 'preview' && (

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -204,7 +204,7 @@ export default function QuoteWorkspace({ id }: Props) {
       // Drafts get the editable title in place of the static h1, with the
       // customer switcher on its own meta line below — inline next to the title
       // it squeezed the h1 and floated mis-aligned against the status pill.
-      titleSlot={isDraft ? <QuoteHeaderMeta detail={detail} onChanged={() => void reload()} onPendingChange={setTitleSavePending} onUnsavedChange={setTitleUnsavedField} /> : undefined}
+      titleSlot={isDraft ? <QuoteHeaderMeta detail={detail} onChanged={() => void reload()} onPendingChange={setTitleSavePending} onUnsavedChange={setTitleUnsavedField} onSaveFailure={reportSaveFailure} /> : undefined}
       metaSlot={isDraft ? <QuoteCustomerSwitcher detail={detail} onChanged={() => void reload()} onPendingChange={setCustomerSavePending} /> : undefined}
       statusPill={statusPill}
       // Primary actions live in the header so Send (the money-moment) and Download

--- a/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteWorkspace.tsx
@@ -50,6 +50,13 @@ export default function QuoteWorkspace({ id }: Props) {
   // their own pending state; Send waits for ALL surfaces to be quiescent.
   const [titleSavePending, setTitleSavePending] = useState(false);
   const [customerSavePending, setCustomerSavePending] = useState(false);
+  // Monotonic count of editor save FAILURES, and the label of a field left
+  // dirty by one. A failed save still produces "quiescence", so Send needs both
+  // to tell "on its way" from "gave up" (mirrors InvoiceWorkspace).
+  const [saveFailureNonce, setSaveFailureNonce] = useState(0);
+  const reportSaveFailure = useCallback(() => setSaveFailureNonce((n) => n + 1), []);
+  const [editorUnsavedField, setEditorUnsavedField] = useState<string | null>(null);
+  const [titleUnsavedField, setTitleUnsavedField] = useState<string | null>(null);
   // Cost/margin visibility is workspace state so the toggle can live in the
   // pinned header (next to Send) while the editor's internal surfaces consume it.
   const [showInternal, toggleShowInternal] = useShowInternalMargin();
@@ -197,7 +204,7 @@ export default function QuoteWorkspace({ id }: Props) {
       // Drafts get the editable title in place of the static h1, with the
       // customer switcher on its own meta line below — inline next to the title
       // it squeezed the h1 and floated mis-aligned against the status pill.
-      titleSlot={isDraft ? <QuoteHeaderMeta detail={detail} onChanged={() => void reload()} onPendingChange={setTitleSavePending} /> : undefined}
+      titleSlot={isDraft ? <QuoteHeaderMeta detail={detail} onChanged={() => void reload()} onPendingChange={setTitleSavePending} onUnsavedChange={setTitleUnsavedField} /> : undefined}
       metaSlot={isDraft ? <QuoteCustomerSwitcher detail={detail} onChanged={() => void reload()} onPendingChange={setCustomerSavePending} /> : undefined}
       statusPill={statusPill}
       // Primary actions live in the header so Send (the money-moment) and Download
@@ -209,7 +216,7 @@ export default function QuoteWorkspace({ id }: Props) {
           {isDraft && activeTab === 'editor' && (
             <MarginToggle show={showInternal} onToggle={toggleShowInternal} testId="quote-editor-toggle-internal" size="md" />
           )}
-          <QuoteActions detail={detail} onChanged={reload} variant="header" savePending={editorSavePending || titleSavePending || customerSavePending} onSendWhilePending={flushEditorPendingDeletes} />
+          <QuoteActions detail={detail} onChanged={reload} variant="header" savePending={editorSavePending || titleSavePending || customerSavePending} unsavedFieldLabel={editorUnsavedField ?? titleUnsavedField} saveFailureNonce={saveFailureNonce} onSendWhilePending={flushEditorPendingDeletes} />
         </>
       }
       tabs={tabs}
@@ -235,7 +242,7 @@ export default function QuoteWorkspace({ id }: Props) {
           while previewing. */}
       {isDraft && (
         <div className={activeTab === 'editor' ? '' : 'hidden'}>
-          <QuoteEditor detail={detail} onChanged={() => void reload()} onPendingEditsChange={setEditorSavePending} onRegisterPendingDeleteFlush={registerPendingDeleteFlush} showInternal={showInternal} onToggleInternal={toggleShowInternal} />
+          <QuoteEditor detail={detail} onChanged={() => void reload()} onPendingEditsChange={setEditorSavePending} onSaveFailure={reportSaveFailure} onUnsavedEditsChange={setEditorUnsavedField} onRegisterPendingDeleteFlush={registerPendingDeleteFlush} showInternal={showInternal} onToggleInternal={toggleShowInternal} />
         </div>
       )}
       {activeTab === 'preview' && (

--- a/apps/web/src/components/billing/quotes/QuotesPage.tsx
+++ b/apps/web/src/components/billing/quotes/QuotesPage.tsx
@@ -381,7 +381,7 @@ export function QuotesPage() {
             type="button"
             onClick={openCreate}
             data-testid="quotes-create-open"
-            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+            className="inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
           >
             {t('quotes.page.newQuote')}
           </button>
@@ -483,7 +483,7 @@ export function QuotesPage() {
                 <button
                   type="button"
                   onClick={openCreate}
-                  className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+                  className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:bg-primary/90"
                   data-testid="quotes-empty-new"
                 >
                   {t('quotes.page.newQuote')}
@@ -776,7 +776,7 @@ export function QuotesPage() {
               onClick={() => void submitCreate()}
               disabled={!newOrgId || creating}
               data-testid="quotes-create-submit"
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 disabled:opacity-50"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
             >
               {creating ? t('quotes.page.create.working') : t('quotes.page.create.submit')}
             </button>

--- a/apps/web/src/components/billing/quotes/quoteEditorShared.tsx
+++ b/apps/web/src/components/billing/quotes/quoteEditorShared.tsx
@@ -1,14 +1,31 @@
 // Shared plumbing for the quote editor's split modules (QuoteEditor hub +
 // QuoteLineRows / QuoteBlockCard / QuoteContractBlockEditor). Extracted when
-// the pre-split QuoteEditor.tsx approached 4,000 lines — one save-language
-// implementation, one place for the field-state styling contract.
-import { useCallback, useEffect, useRef, useState } from 'react';
+// the pre-split QuoteEditor.tsx approached 4,000 lines. The save-language
+// itself (dirty border / saved pulse / SR cues) now lives in shared/saveCues,
+// where the invoice editor uses the same implementation — this module keeps the
+// quote-specific pieces and re-exports the rest so quote call sites are stable.
 import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
 import { navigateTo } from '@/lib/navigation';
+import {
+  SrSaved as SharedSrSaved,
+  unsavedHintId as sharedUnsavedHintId,
+} from '../shared/saveCues';
 import type { QuoteLineRecurrence } from './quoteTypes';
 
+export { useSavedFlash, fieldRing, seamless, UnsavedFieldHint } from '../shared/saveCues';
+
 export const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
+
+// "Show cost & margin" governs EVERY internal-economics surface — the per-line
+// cost/markup bands AND the rail's Margin panel — so one toggle honestly means
+// "no margin on screen" (a tech screen-sharing with a client must be able to
+// trust it). Collapsed by default; the choice persists per browser so daily
+// margin-watchers aren't re-toggling on every quote. The implementation is
+// billingUi's useShowMargin — ONE storage key and persistence rule across
+// every quote and invoice surface — re-exported here under a name matching
+// the quote editor's `showInternal` vocabulary.
+export { useShowMargin as useShowInternalMargin } from '../billingUi';
 
 /** Builders for the editor's pending-scope keys. The producer (QuoteEditor's
  *  runScoped) and the consumers (BlockCard/EditableLineRow's isPending) live
@@ -48,68 +65,14 @@ export type LineUpdate = Partial<{
 // runAction successMessage. Per-field toasts were a storm during editing and
 // double-announced alongside SrSaved, so they were removed.
 
-// A transient "Saved" cue for blur-to-save fields outside the row grid (the
-// rail's terms field, the header title in QuoteHeaderMeta).
-// BlockCard and EditableLineRow replicate this same pattern inline rather than
-// calling the hook. Returns the on-flag (drives the SR live region) and a
-// trigger; clears its timer on unmount so a late fire can't setState a gone node.
-export function useSavedFlash(): [boolean, () => void] {
-  const [on, setOn] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
-  const flash = useCallback(() => {
-    setOn(true);
-    if (timer.current) clearTimeout(timer.current);
-    timer.current = setTimeout(() => setOn(false), 1500);
-  }, []);
-  return [on, flash];
-}
-
-// Visually-hidden polite live region — announces a transient "Saved" to screen
-// readers without taking visual space, pairing with the dirty-ring clearing that
-// sighted users see. The single per-field announcer (no toast), so SR users hear
-// "Saved" once, not twice. testId lets tests assert the cue fired.
+// Quote-flavored SrSaved: same shared live region, with the quote editor's
+// default "Saved" label so the many existing call sites don't each pass one.
 export function SrSaved({ show, label, testId }: { show: boolean; label?: string; testId?: string }) {
   const { t } = useTranslation('billing');
-  // role="status" already implies aria-live="polite" — don't double it.
-  return <span role="status" className="sr-only" data-testid={testId}>{show ? (label ?? t('quotes.editor.status.saved')) : ''}</span>;
+  return <SharedSrSaved show={show} label={label ?? t('quotes.editor.status.saved')} testId={testId} />;
 }
 
-// A field's save-state signal: amber BORDER while the edit is unsaved, a brief
-// green border pulse when it lands, nothing at rest. Border-color (not a ring):
-// the focus ring occupies the box-shadow channel, so a ring-based dirty signal
-// was painted over by focus on exactly the field being edited — the one moment
-// the signal matters. Border-color composes with the focus ring, never reflows
-// (the border is always present, only its color changes), and uses the
-// warning-strong indicator token (>=3:1 non-text on a light card).
-export function fieldRing(dirty: boolean, saved: boolean): string {
-  return dirty ? 'border-warning-strong' : saved ? 'border-success' : '';
-}
-
-// Seamless (document-styled) field border: at rest the border is invisible so
-// the value reads as document text; hover/focus reveal the field. A state color
-// (dirty amber / saved green / error red) REPLACES the base set rather than
-// stacking on it, so two border-color utilities never compete.
-export function seamless(state: string): string {
-  return state || 'border-transparent hover:border-border focus:border-border';
-}
-
-// The amber dirty ring (fieldRing) is a COLOR-only signal — a screen-reader
-// user tabbing through a pricing-table row gets no equivalent cue that a field
-// holds an unsaved edit. `unsavedHintId` builds a stable id for a field's
-// SR-only "Unsaved" description; wire it to the field's `aria-describedby`
-// while dirty and render `<UnsavedFieldHint id={that id} show={dirty} />`
-// immediately after the field. Deliberately NOT a visible badge (per-field
-// badges across a long pricing table were noisy) and NOT an aria-live
-// announcement (a live region would fire on every keystroke) — just parity for
-// AT users at the moment they land on the field, same as sighted users see the
-// border the moment they look at it.
+// Quote-prefixed ids for the SR-only "Unsaved" field descriptions.
 export function unsavedHintId(lineId: string, field: string): string {
-  return `quote-line-${field}-unsaved-${lineId}`;
-}
-
-export function UnsavedFieldHint({ id, show }: { id: string; show: boolean }) {
-  const { t } = useTranslation('billing');
-  if (!show) return null;
-  return <span id={id} className="sr-only">{t('billingUi.unsaved')}</span>;
+  return sharedUnsavedHintId('quote-line', lineId, field);
 }

--- a/apps/web/src/components/billing/shared/DocumentWorkspace.test.tsx
+++ b/apps/web/src/components/billing/shared/DocumentWorkspace.test.tsx
@@ -82,4 +82,39 @@ describe('DocumentWorkspace', () => {
     expect(panel).toHaveAttribute('aria-labelledby', 'doc-tab-editor');
     expect(screen.getByTestId('panel-body')).toBeInTheDocument();
   });
+
+  it('a titleSlot replaces the visible h1 but the document keeps an sr-only one', () => {
+    // The slot is an editable input. Wrapping that in an <h1> announces
+    // "heading level 1, edit text", which is neither — so the visible heading
+    // steps aside and an sr-only h1 preserves the document structure. Losing
+    // that leaves the page with no h1 at all.
+    renderWs({ titleSlot: <input data-testid="title-input" defaultValue="THING-1" /> });
+
+    expect(screen.getByTestId('title-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('doc-workspace-title')).not.toBeInTheDocument();
+
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1).toHaveTextContent('THING-1');
+    expect(h1).toHaveClass('sr-only');
+  });
+
+  it('renders metaSlot below the title row', () => {
+    renderWs({
+      titleSlot: <input data-testid="title-input" defaultValue="THING-1" />,
+      metaSlot: <span data-testid="meta-slot">Customer: Acme</span>,
+    });
+    const meta = screen.getByTestId('meta-slot');
+    expect(meta).toBeInTheDocument();
+    // Below the title row, not inside it — the switcher used to sit inline and
+    // squeeze the title.
+    expect(screen.getByTestId('title-input').compareDocumentPosition(meta))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('keeps the visible h1 when no titleSlot is given', () => {
+    renderWs({ metaSlot: <span data-testid="meta-slot">meta</span> });
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1).toHaveAttribute('data-testid', 'doc-workspace-title');
+    expect(h1).not.toHaveClass('sr-only');
+  });
 });

--- a/apps/web/src/components/billing/shared/DocumentWorkspace.tsx
+++ b/apps/web/src/components/billing/shared/DocumentWorkspace.tsx
@@ -17,9 +17,13 @@ export interface DocumentWorkspaceProps {
   backLabel: string;
   title: string;
   /** Replaces the plain h1 with caller-provided identity chrome (e.g. the quote
-   *  workspace's editable title + customer selector for drafts). The `title`
-   *  string is still required as the fallback/document identity. */
+   *  workspace's editable title input for drafts). The `title` string is still
+   *  required as the fallback/document identity. */
   titleSlot?: ReactNode;
+  /** Rendered on its own line directly under the title row (e.g. the quote
+   *  workspace's customer switcher) — metadata that belongs with the document
+   *  identity but must not squeeze the title or the status pill. */
+  metaSlot?: ReactNode;
   statusPill?: ReactNode;
   actions?: ReactNode;
   tabs: DocumentTab[];
@@ -48,6 +52,7 @@ export function DocumentWorkspace({
   backLabel,
   title,
   titleSlot,
+  metaSlot,
   statusPill,
   actions,
   tabs,
@@ -104,23 +109,36 @@ export function DocumentWorkspace({
           of scrolled content show through above it. -top-4/-top-6 pin the bar
           flush with main's true top edge; its own pt re-covers the zone. */}
       <div className="sticky -top-4 z-20 -mx-4 -mt-4 bg-background px-4 pt-4 md:-top-6 md:-mx-6 md:-mt-6 md:px-6 md:pt-6">
-        <div className="flex flex-wrap items-start justify-between gap-3">
+        {/* Back link on its own line, THEN title + actions as one row: the
+            actions cluster aligns with the title it acts on, not with the tiny
+            back link above it. */}
+        <a
+          href={backHref}
+          aria-label={t('shared.documentWorkspace.backAria', { label: backLabel.toLowerCase() })}
+          className="text-xs text-muted-foreground hover:underline"
+        >
+          <span aria-hidden="true">←</span> {backLabel}
+        </a>
+        <div className="mt-1 flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
           <div className="min-w-0 flex-1">
-            <a
-              href={backHref}
-              aria-label={t('shared.documentWorkspace.backAria', { label: backLabel.toLowerCase() })}
-              className="text-xs text-muted-foreground hover:underline"
-            >
-              <span aria-hidden="true">←</span> {backLabel}
-            </a>
             <div className="flex items-center gap-2 min-w-0">
-              {titleSlot ?? (
+              {titleSlot ? (
+                <>
+                  {/* The slot replaces the VISUAL heading (e.g. with an editable
+                      title input), so the document identity keeps an sr-only h1
+                      — an <h1>-wrapped input announces as "heading, edit text",
+                      which reads as neither. */}
+                  <h1 className="sr-only">{title}</h1>
+                  {titleSlot}
+                </>
+              ) : (
                 <h1 className="truncate text-xl font-semibold" data-testid={`${idPrefix}-workspace-title`}>
                   {title}
                 </h1>
               )}
               {statusPill}
             </div>
+            {metaSlot}
           </div>
           {actions && (
             // Right-aligned cluster; the caller renders any disabled-reason hint on

--- a/apps/web/src/components/billing/shared/OrgCombobox.test.tsx
+++ b/apps/web/src/components/billing/shared/OrgCombobox.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { OrgCombobox, type OrgComboboxOption } from './OrgCombobox';
+import { OrgCombobox, orgComboboxOptions, type OrgComboboxOption } from './OrgCombobox';
 
 // The dangerous surface here is index-based selection under filtering: Enter
 // picks results[active], so if the active index ever stops resetting on a
@@ -98,8 +98,103 @@ describe('OrgCombobox', () => {
     expect(screen.getByTestId('orgbox-cap-note')).toBeInTheDocument();
     expect(screen.getByTestId('orgbox-list').querySelectorAll('[role="option"]')).toHaveLength(50);
 
+    // The note is DESCRIBED to the focused search input, not just drawn beside
+    // it — focus is in the search field, so an undescribed <p> reaches nobody.
+    const search = screen.getByTestId('orgbox-search');
+    expect(search).toHaveAttribute('aria-describedby', screen.getByTestId('orgbox-cap-note').id);
+
     // Narrowing below the cap removes the note.
-    fireEvent.change(screen.getByTestId('orgbox-search'), { target: { value: 'Acme' } });
+    fireEvent.change(search, { target: { value: 'Acme' } });
     expect(screen.queryByTestId('orgbox-cap-note')).not.toBeInTheDocument();
+    expect(screen.getByTestId('orgbox-search')).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('Enter and Space open the closed trigger, not just ArrowDown', () => {
+    setup();
+    fireEvent.keyDown(screen.getByTestId('orgbox-trigger'), { key: 'Enter' });
+    expect(screen.getByTestId('orgbox-popover')).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByTestId('orgbox-search'), { key: 'Escape' });
+    fireEvent.keyDown(screen.getByTestId('orgbox-trigger'), { key: ' ' });
+    expect(screen.getByTestId('orgbox-popover')).toBeInTheDocument();
+  });
+
+  it('reopening resets the query and the active index', () => {
+    // A retained filter would show a partial list that looks like the whole
+    // one, and a retained index would point Enter at a row the user can't see.
+    const onSelect = setup();
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    fireEvent.change(screen.getByTestId('orgbox-search'), { target: { value: 'zen' } });
+    fireEvent.keyDown(screen.getByTestId('orgbox-search'), { key: 'Escape' });
+
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    expect(screen.getByTestId('orgbox-search')).toHaveValue('');
+    expect(screen.getByTestId('orgbox-list').querySelectorAll('[role="option"]')).toHaveLength(4);
+    fireEvent.keyDown(screen.getByTestId('orgbox-search'), { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith('org-1'); // top of the reset list
+  });
+
+  it('arrow navigation is audible: the combobox is the search input and activedescendant tracks the cursor', () => {
+    // The failure this guards is silent, not visible — a bg-muted highlight
+    // moves while AT announces nothing, and Enter then commits a customer
+    // reassignment the user was never told about.
+    setup();
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    const search = screen.getByTestId('orgbox-search');
+
+    // The combobox role belongs to the element that HOLDS FOCUS.
+    expect(search).toHaveAttribute('role', 'combobox');
+    expect(screen.getByTestId('orgbox-trigger')).not.toHaveAttribute('role', 'combobox');
+
+    const optionAt = (i: number) => screen.getByTestId('orgbox-list').querySelectorAll('[role="option"]')[i];
+    expect(search).toHaveAttribute('aria-activedescendant', optionAt(0)!.id);
+    expect(optionAt(0)).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    expect(search).toHaveAttribute('aria-activedescendant', optionAt(1)!.id);
+    // aria-selected follows the CURSOR, not the committed value (org-1).
+    expect(optionAt(1)).toHaveAttribute('aria-selected', 'true');
+    expect(optionAt(0)).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('does not point aria-controls at a list that is not rendered', () => {
+    setup();
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    const search = screen.getByTestId('orgbox-search');
+    expect(search).toHaveAttribute('aria-controls', screen.getByTestId('orgbox-list').id);
+
+    fireEvent.change(search, { target: { value: 'nomatch' } });
+    expect(screen.queryByTestId('orgbox-list')).not.toBeInTheDocument();
+    expect(search).not.toHaveAttribute('aria-controls');
+    expect(search).not.toHaveAttribute('aria-activedescendant');
+  });
+
+  it('renders the raw id rather than a blank when value is not in options', () => {
+    // Loud beats empty: a blank trigger is indistinguishable from "no customer
+    // selected" on a money document.
+    render(<OrgCombobox options={orgs} value="org-missing" onSelect={vi.fn()} label="Customer" testId="orphan" />);
+    expect(screen.getByTestId('orphan-trigger')).toHaveTextContent('org-missing');
+  });
+});
+
+describe('orgComboboxOptions', () => {
+  it('sorts by name and leaves a present selection alone', () => {
+    const out = orgComboboxOptions([{ id: 'b', name: 'Beta' }, { id: 'a', name: 'Acme' }], 'a', 'ignored');
+    expect(out.map((o) => o.id)).toEqual(['a', 'b']);
+  });
+
+  it('prepends a missing selection so `value ∈ options` always holds', () => {
+    // The All-orgs / cross-partner case: the store never loaded this org, and
+    // without the prepend the trigger has nothing to render.
+    const out = orgComboboxOptions([{ id: 'b', name: 'Beta' }], 'ghost', 'Ghost Co');
+    expect(out[0]).toEqual({ id: 'ghost', name: 'Ghost Co' });
+    expect(out.some((o) => o.id === 'ghost')).toBe(true);
+  });
+
+  it('narrows to {id, name} so callers need no cast to satisfy the option type', () => {
+    // Both call sites previously hand-rolled this and ended in an `as` cast
+    // fabricating a partial Organization. Mapping down is what removes it.
+    const out = orgComboboxOptions([{ id: 'a', name: 'Acme', extra: 'dropped' } as never], 'a', 'x');
+    expect(Object.keys(out[0]!).sort()).toEqual(['id', 'name']);
   });
 });

--- a/apps/web/src/components/billing/shared/OrgCombobox.test.tsx
+++ b/apps/web/src/components/billing/shared/OrgCombobox.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { OrgCombobox, type OrgComboboxOption } from './OrgCombobox';
+
+// The dangerous surface here is index-based selection under filtering: Enter
+// picks results[active], so if the active index ever stops resetting on a
+// query change, a typed filter + Enter would select a stale index into a
+// DIFFERENT list — and both consumers (customer reassignment, clone target)
+// turn that into a quote pointed at the wrong company.
+
+const orgs: OrgComboboxOption[] = [
+  { id: 'org-1', name: 'Acme' },
+  { id: 'org-2', name: 'Beta Corp' },
+  { id: 'org-3', name: 'Beta Industries' },
+  { id: 'org-4', name: 'Zenith' },
+];
+
+function setup(options: OrgComboboxOption[] = orgs) {
+  const onSelect = vi.fn();
+  render(<OrgCombobox options={options} value="org-1" onSelect={onSelect} label="Customer" testId="orgbox" />);
+  return onSelect;
+}
+
+describe('OrgCombobox', () => {
+  it('opens on trigger click showing the current selection, and picks by click', () => {
+    const onSelect = setup();
+    expect(screen.getByTestId('orgbox-trigger')).toHaveTextContent('Acme');
+
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    fireEvent.click(screen.getByTestId('orgbox-option-org-4'));
+
+    expect(onSelect).toHaveBeenCalledWith('org-4');
+    expect(screen.queryByTestId('orgbox-popover')).not.toBeInTheDocument();
+  });
+
+  it('ArrowDown on the closed trigger opens the popover', () => {
+    setup();
+    fireEvent.keyDown(screen.getByTestId('orgbox-trigger'), { key: 'ArrowDown' });
+    expect(screen.getByTestId('orgbox-popover')).toBeInTheDocument();
+  });
+
+  it('typing a filter then Enter selects the TOP VISIBLE match, not a stale index', () => {
+    const onSelect = setup();
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    const search = screen.getByTestId('orgbox-search');
+
+    // Move the active index down in the unfiltered list first, THEN filter —
+    // the index must reset to the filtered list's top.
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.change(search, { target: { value: 'zen' } });
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('org-4');
+  });
+
+  it('ArrowDown navigates the filtered list and Enter picks the highlighted option', () => {
+    const onSelect = setup();
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    const search = screen.getByTestId('orgbox-search');
+
+    fireEvent.change(search, { target: { value: 'beta' } });
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith('org-3');
+  });
+
+  it('Escape closes without selecting and returns focus to the trigger', () => {
+    const onSelect = setup();
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    fireEvent.keyDown(screen.getByTestId('orgbox-search'), { key: 'Escape' });
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('orgbox-popover')).not.toBeInTheDocument();
+    expect(screen.getByTestId('orgbox-trigger')).toHaveFocus();
+  });
+
+  it('a filter with no matches shows the no-results message and Enter selects nothing', () => {
+    const onSelect = setup();
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    const search = screen.getByTestId('orgbox-search');
+
+    fireEvent.change(search, { target: { value: 'nomatch' } });
+    expect(screen.getByTestId('orgbox-noresults')).toBeInTheDocument();
+    fireEvent.keyDown(search, { key: 'Enter' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('announces truncation past 50 results instead of silently dropping orgs', () => {
+    const many = Array.from({ length: 60 }, (_, i) => ({ id: `o-${i}`, name: `Org ${String(i).padStart(2, '0')}` }));
+    const onSelect = vi.fn();
+    render(<OrgCombobox options={[{ id: 'org-1', name: 'Acme' }, ...many]} value="org-1" onSelect={onSelect} label="Customer" testId="orgbox" />);
+
+    fireEvent.click(screen.getByTestId('orgbox-trigger'));
+    // An org past position 50 must not read as "not a valid target".
+    expect(screen.getByTestId('orgbox-cap-note')).toBeInTheDocument();
+    expect(screen.getByTestId('orgbox-list').querySelectorAll('[role="option"]')).toHaveLength(50);
+
+    // Narrowing below the cap removes the note.
+    fireEvent.change(screen.getByTestId('orgbox-search'), { target: { value: 'Acme' } });
+    expect(screen.queryByTestId('orgbox-cap-note')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/billing/shared/OrgCombobox.tsx
+++ b/apps/web/src/components/billing/shared/OrgCombobox.tsx
@@ -1,8 +1,21 @@
-// Typeahead organization picker — a select-shaped combobox for surfaces where a
-// native <select> stops scaling (an MSP with 150 orgs gets an unsearchable
-// browser list, with long names readable only via a hover tooltip). The trigger
-// shows the current org as real, truncating text; opening it reveals a search
-// input over a filtered listbox. Modeled on CatalogItemPicker's ARIA pattern.
+// Typeahead organization picker — a select-shaped disclosure for surfaces where
+// a native <select> stops scaling: an MSP with 150 orgs gets an unsearchable
+// browser list. Long names still truncate to a `title` tooltip, same as before;
+// what changes is that the list became searchable. The trigger shows the current
+// org as real text that truncates; opening it reveals a search input over a
+// filtered listbox.
+//
+// ARIA shape: this is NOT CatalogItemPicker's inline-input combobox — the
+// trigger has to show the selected org at rest, so the text input lives inside
+// the popup. The combobox role therefore belongs to the SEARCH INPUT (the
+// element that actually holds focus while the user types and arrows), not to the
+// trigger, which is a plain disclosure button. Arrow keys move
+// `aria-activedescendant` across options whose `aria-selected` tracks the
+// keyboard cursor — the committed org is conveyed by the trigger's own
+// accessible name, not by aria-selected. Getting this backwards (aria-selected
+// on the committed value, no activedescendant) makes arrow navigation
+// completely silent to assistive tech, which on the quote header means
+// committing a customer reassignment the user was never told about.
 import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -15,7 +28,8 @@ export interface OrgComboboxOption {
 
 interface Props {
   options: OrgComboboxOption[];
-  /** Selected org id — must be present in `options` (callers prepend it). */
+  /** Selected org id — must be present in `options`. Build the array with
+   *  `orgComboboxOptions()` below, which guarantees it. */
   value: string;
   onSelect: (id: string) => void;
   disabled?: boolean;
@@ -29,6 +43,29 @@ interface Props {
 
 const MAX_RESULTS = 50;
 
+/**
+ * Builds an options array that satisfies the `value ∈ options` invariant: sorts
+ * by name and prepends the selected org when the caller's list doesn't contain
+ * it (an All-orgs scope that hasn't loaded it, a cross-partner quote, ...).
+ *
+ * This exists as a function because both call sites had hand-rolled the same
+ * six-line prepend, each ending in an `as` cast that fabricated a partial
+ * Organization to satisfy the array's element type. Mapping down to `{id, name}`
+ * is what removes the need for the cast — the wide type was never wanted here.
+ */
+export function orgComboboxOptions(
+  orgs: readonly { id: string; name: string }[],
+  selectedId: string,
+  selectedFallbackName: string,
+): OrgComboboxOption[] {
+  const sorted = orgs
+    .map((o) => ({ id: o.id, name: o.name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return sorted.some((o) => o.id === selectedId)
+    ? sorted
+    : [{ id: selectedId, name: selectedFallbackName }, ...sorted];
+}
+
 export function OrgCombobox({ options, value, onSelect, disabled, label, variant = 'field', testId }: Props) {
   const { t } = useTranslation('billing');
   const [open, setOpen] = useState(false);
@@ -38,15 +75,19 @@ export function OrgCombobox({ options, value, onSelect, disabled, label, variant
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const listId = useId();
+  const capNoteId = useId();
+  const optionId = (id: string) => `${listId}-opt-${id}`;
 
   const selected = options.find((o) => o.id === value);
 
   const { results, truncated } = useMemo(() => {
     const q = query.trim().toLowerCase();
     const matches = options.filter((o) => !q || o.name.toLowerCase().includes(q));
-    // Truncation must be ANNOUNCED (see the cap-note row below): an org past
-    // position 50 silently missing from the browse list reads as "not a valid
-    // target" — the exact failure this component exists to prevent.
+    // Truncation must be ANNOUNCED, not merely drawn: an org past position 50
+    // silently missing from the browse list reads as "not a valid target" — the
+    // exact failure this component exists to prevent. Focus sits in the search
+    // field, so the cap note is wired to its aria-describedby below; a bare <p>
+    // beside it would never reach a screen-reader user.
     return { results: matches.slice(0, MAX_RESULTS), truncated: matches.length > MAX_RESULTS };
   }, [options, query]);
 
@@ -84,12 +125,12 @@ export function OrgCombobox({ options, value, onSelect, disabled, label, variant
 
   return (
     <div ref={wrapRef} className={`relative ${variant === 'field' ? 'w-full' : 'min-w-0'}`} data-testid={testId}>
+      {/* A disclosure button, not the combobox — the combobox is the search
+          input this opens (see the ARIA note at the top of the file). */}
       <button
         ref={triggerRef}
         type="button"
-        role="combobox"
         aria-expanded={open}
-        aria-controls={listId}
         aria-haspopup="listbox"
         aria-label={label}
         title={selected?.name}
@@ -101,7 +142,10 @@ export function OrgCombobox({ options, value, onSelect, disabled, label, variant
         data-testid={`${testId}-trigger`}
         className={`inline-flex min-w-0 items-center transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 ${triggerLook}`}
       >
-        <span className="min-w-0 flex-1 truncate text-left">{selected?.name ?? ''}</span>
+        {/* Falling back to the raw id is deliberately ugly: a blank trigger is
+            indistinguishable from "no customer", so a violated `value ∈ options`
+            invariant should look broken rather than look empty. */}
+        <span className="min-w-0 flex-1 truncate text-left">{selected?.name ?? value}</span>
         <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
       </button>
       {open && (
@@ -115,21 +159,32 @@ export function OrgCombobox({ options, value, onSelect, disabled, label, variant
               onKeyDown={onSearchKeyDown}
               placeholder={t('billingUi.orgCombobox.searchPlaceholder')}
               aria-label={t('billingUi.orgCombobox.searchPlaceholder')}
-              aria-controls={listId}
+              role="combobox"
+              aria-expanded
+              // Only reference ids that are actually in the DOM: the list is not
+              // rendered on a no-match query, and a dangling aria-controls on an
+              // expanded combobox is worse than none.
+              aria-controls={results.length > 0 ? listId : undefined}
+              aria-activedescendant={results[active] ? optionId(results[active].id) : undefined}
+              aria-describedby={truncated ? capNoteId : undefined}
               aria-autocomplete="list"
               data-testid={`${testId}-search`}
               className="h-8 w-full rounded-sm border-0 bg-transparent px-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
             />
           </div>
           {truncated && (
-            <p className="border-b px-3 py-1.5 text-xs text-muted-foreground" data-testid={`${testId}-cap-note`}>
+            <p id={capNoteId} className="border-b px-3 py-1.5 text-xs text-muted-foreground" data-testid={`${testId}-cap-note`}>
               {t('billingUi.orgCombobox.capNote', { count: MAX_RESULTS })}
             </p>
           )}
           {results.length > 0 ? (
             <ul id={listId} role="listbox" aria-label={label} className="max-h-64 overflow-auto py-1" data-testid={`${testId}-list`}>
               {results.map((o, idx) => (
-                <li key={o.id} role="option" aria-selected={o.id === value}>
+                // aria-selected tracks the KEYBOARD cursor, not the committed
+                // value — that is what makes arrow navigation audible. The
+                // committed org is already carried by the trigger's accessible
+                // name, and is shown here visually by the bold weight.
+                <li key={o.id} id={optionId(o.id)} role="option" aria-selected={idx === active}>
                   <button
                     type="button"
                     tabIndex={-1}

--- a/apps/web/src/components/billing/shared/OrgCombobox.tsx
+++ b/apps/web/src/components/billing/shared/OrgCombobox.tsx
@@ -1,0 +1,158 @@
+// Typeahead organization picker — a select-shaped combobox for surfaces where a
+// native <select> stops scaling (an MSP with 150 orgs gets an unsearchable
+// browser list, with long names readable only via a hover tooltip). The trigger
+// shows the current org as real, truncating text; opening it reveals a search
+// input over a filtered listbox. Modeled on CatalogItemPicker's ARIA pattern.
+import { useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import '../../../lib/i18n';
+
+export interface OrgComboboxOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  options: OrgComboboxOption[];
+  /** Selected org id — must be present in `options` (callers prepend it). */
+  value: string;
+  onSelect: (id: string) => void;
+  disabled?: boolean;
+  /** Accessible name for the trigger (e.g. "Customer"). */
+  label: string;
+  /** Trigger look: 'seamless' for the header meta line (borderless until
+   *  hover/focus), 'field' for form rows (always-bordered input look). */
+  variant?: 'seamless' | 'field';
+  testId: string;
+}
+
+const MAX_RESULTS = 50;
+
+export function OrgCombobox({ options, value, onSelect, disabled, label, variant = 'field', testId }: Props) {
+  const { t } = useTranslation('billing');
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const listId = useId();
+
+  const selected = options.find((o) => o.id === value);
+
+  const { results, truncated } = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const matches = options.filter((o) => !q || o.name.toLowerCase().includes(q));
+    // Truncation must be ANNOUNCED (see the cap-note row below): an org past
+    // position 50 silently missing from the browse list reads as "not a valid
+    // target" — the exact failure this component exists to prevent.
+    return { results: matches.slice(0, MAX_RESULTS), truncated: matches.length > MAX_RESULTS };
+  }, [options, query]);
+
+  useEffect(() => { setActive(0); }, [query]);
+  // Focus lands in the search field on open; the list resets to the top.
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setActive(0);
+    searchRef.current?.focus();
+    const onDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+
+  const choose = (id: string) => {
+    setOpen(false);
+    triggerRef.current?.focus();
+    onSelect(id);
+  };
+
+  const onSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') { e.preventDefault(); setOpen(false); triggerRef.current?.focus(); return; }
+    if (e.key === 'ArrowDown') { e.preventDefault(); setActive((a) => Math.min(a + 1, results.length - 1)); return; }
+    if (e.key === 'ArrowUp') { e.preventDefault(); setActive((a) => Math.max(a - 1, 0)); return; }
+    if (e.key === 'Enter' && results[active]) { e.preventDefault(); choose(results[active].id); }
+  };
+
+  const triggerLook =
+    variant === 'seamless'
+      ? 'h-7 max-w-72 gap-1 rounded-md border border-transparent bg-transparent px-1.5 text-sm text-muted-foreground hover:border-border focus:border-border'
+      : 'h-9 w-full gap-2 rounded-md border bg-background px-3 text-sm';
+
+  return (
+    <div ref={wrapRef} className={`relative ${variant === 'field' ? 'w-full' : 'min-w-0'}`} data-testid={testId}>
+      <button
+        ref={triggerRef}
+        type="button"
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-haspopup="listbox"
+        aria-label={label}
+        title={selected?.name}
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        onKeyDown={(e) => {
+          if (!open && (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); setOpen(true); }
+        }}
+        data-testid={`${testId}-trigger`}
+        className={`inline-flex min-w-0 items-center transition-colors focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 ${triggerLook}`}
+      >
+        <span className="min-w-0 flex-1 truncate text-left">{selected?.name ?? ''}</span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-30 mt-1 w-72 max-w-[80vw] rounded-md border bg-card shadow-lg" data-testid={`${testId}-popover`}>
+          <div className="border-b p-1.5">
+            <input
+              ref={searchRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={onSearchKeyDown}
+              placeholder={t('billingUi.orgCombobox.searchPlaceholder')}
+              aria-label={t('billingUi.orgCombobox.searchPlaceholder')}
+              aria-controls={listId}
+              aria-autocomplete="list"
+              data-testid={`${testId}-search`}
+              className="h-8 w-full rounded-sm border-0 bg-transparent px-2 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </div>
+          {truncated && (
+            <p className="border-b px-3 py-1.5 text-xs text-muted-foreground" data-testid={`${testId}-cap-note`}>
+              {t('billingUi.orgCombobox.capNote', { count: MAX_RESULTS })}
+            </p>
+          )}
+          {results.length > 0 ? (
+            <ul id={listId} role="listbox" aria-label={label} className="max-h-64 overflow-auto py-1" data-testid={`${testId}-list`}>
+              {results.map((o, idx) => (
+                <li key={o.id} role="option" aria-selected={o.id === value}>
+                  <button
+                    type="button"
+                    tabIndex={-1}
+                    onMouseEnter={() => setActive(idx)}
+                    onClick={() => choose(o.id)}
+                    title={o.name}
+                    data-testid={`${testId}-option-${o.id}`}
+                    className={`block w-full truncate px-3 py-1.5 text-left text-sm ${idx === active ? 'bg-muted' : ''} ${o.id === value ? 'font-medium' : ''}`}
+                  >
+                    {o.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="px-3 py-2 text-xs text-muted-foreground" data-testid={`${testId}-noresults`}>
+              {t('billingUi.orgCombobox.noResults')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default OrgCombobox;

--- a/apps/web/src/components/billing/shared/saveCues.test.tsx
+++ b/apps/web/src/components/billing/shared/saveCues.test.tsx
@@ -1,0 +1,143 @@
+// The save-grammar itself. Every consumer's test asserts that a cue APPEARS;
+// none of them advance a clock, so the 1500ms clear and the unmount teardown —
+// the two things this module owns outright — were unguarded. A `setTimeout(…,
+// 15000)` typo would have passed the entire suite with a "Saved" badge stuck on
+// screen for fifteen seconds.
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useSavedFlash, SrSaved, fieldRing, seamless, unsavedHintId } from './saveCues';
+
+function Harness() {
+  const [on, flash] = useSavedFlash();
+  return (
+    <>
+      <button type="button" onClick={flash} data-testid="flash">flash</button>
+      <SrSaved show={on} label="Saved" testId="cue" />
+    </>
+  );
+}
+
+afterEach(() => { vi.useRealTimers(); });
+
+describe('useSavedFlash', () => {
+  it('shows the cue on flash and clears it after 1500ms', async () => {
+    // Fully controlled fake time. `shouldAdvanceTime` also ticks with REAL
+    // time, so advancing to 1_499 can cross 1_500 under a loaded full-suite run
+    // — a flaky boundary on the one assertion that gives this test its value.
+    vi.useFakeTimers();
+    render(<Harness />);
+    expect(screen.getByTestId('cue')).toHaveTextContent('');
+
+    act(() => { screen.getByTestId('flash').click(); });
+    expect(screen.getByTestId('cue')).toHaveTextContent('Saved');
+
+    // Just before the window closes it is still up…
+    await act(async () => { await vi.advanceTimersByTimeAsync(1_499); });
+    expect(screen.getByTestId('cue')).toHaveTextContent('Saved');
+
+    // …and it clears on its own, with no further interaction.
+    await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+    expect(screen.getByTestId('cue')).toHaveTextContent('');
+  });
+
+  it('re-flashing restarts the window rather than letting the first timer clear it early', async () => {
+    vi.useFakeTimers();
+    render(<Harness />);
+
+    act(() => { screen.getByTestId('flash').click(); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(1_000); });
+    act(() => { screen.getByTestId('flash').click(); });
+
+    // The first timer would have fired here; the restart must have cancelled it.
+    await act(async () => { await vi.advanceTimersByTimeAsync(600); });
+    expect(screen.getByTestId('cue')).toHaveTextContent('Saved');
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(900); });
+    expect(screen.getByTestId('cue')).toHaveTextContent('');
+  });
+
+  it('clears its timer on unmount so a late fire cannot setState a gone node', async () => {
+    vi.useFakeTimers();
+    const errors: unknown[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...a) => { errors.push(a); });
+    try {
+      const { unmount } = render(<Harness />);
+      act(() => { screen.getByTestId('flash').click(); });
+      unmount();
+      await act(async () => { await vi.advanceTimersByTimeAsync(2_000); });
+      expect(errors).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('SrSaved', () => {
+  it('is a live region whose CONTENT swaps — the span must not mount/unmount', () => {
+    // A conditionally-mounted live region announces nothing: AT has to be
+    // observing the node before its text changes.
+    const { rerender } = render(<SrSaved show={false} label="Saved" testId="cue" />);
+    const node = screen.getByTestId('cue');
+    expect(node).toHaveAttribute('role', 'status');
+    // role="status" already implies aria-live=polite; doubling it is redundant.
+    expect(node).not.toHaveAttribute('aria-live');
+    expect(node).toHaveTextContent('');
+
+    rerender(<SrSaved show label="Saved" testId="cue" />);
+    expect(screen.getByTestId('cue')).toBe(node); // same node, new content
+    expect(node).toHaveTextContent('Saved');
+  });
+});
+
+describe('fieldRing', () => {
+  it('emits border-COLOR classes only, so a caller without a border width renders nothing', () => {
+    // Pins the precondition documented in saveCues: these are colours, and
+    // Tailwind's preflight leaves border-width at 0. A call site that drops its
+    // `border` utility silently loses the cue — which is exactly what happened
+    // to the rich-text block card in the ring→border migration.
+    expect(fieldRing(true, false)).toBe('border-warning-strong');
+    expect(fieldRing(false, true)).toBe('border-success');
+    expect(fieldRing(false, false)).toBe('');
+    for (const cls of [fieldRing(true, false), fieldRing(false, true)]) {
+      expect(cls).not.toMatch(/\bborder-\d|\bring-/);
+    }
+  });
+
+  it('gives dirty precedence over saved — the pair is reachable, not nonsense', () => {
+    // flashSaved() holds `saved` for 1500ms, during which the user can type
+    // again. Unsaved work outranks a stale confirmation.
+    expect(fieldRing(true, true)).toBe('border-warning-strong');
+  });
+});
+
+describe('seamless', () => {
+  it('always carries a focus-visible ring, including in the invalid state', () => {
+    // These fields set focus:outline-hidden, so this ring is the ONLY focus
+    // indicator. The invalid branch used to be written as a caller-side ternary
+    // that bypassed seamless entirely, leaving the one field a keyboard user is
+    // trying to fix with no indicator at all.
+    for (const cls of [seamless(''), seamless('border-warning-strong'), seamless('', true), seamless('border-warning-strong', true)]) {
+      expect(cls).toContain('focus-visible:ring-2');
+      expect(cls).toContain('focus-visible:ring-ring');
+    }
+  });
+
+  it('lets one border-color win: state replaces the base set, invalid replaces state', () => {
+    expect(seamless('')).toContain('border-transparent');
+    expect(seamless('border-warning-strong')).not.toContain('border-transparent');
+    expect(seamless('border-warning-strong', true)).toContain('border-destructive');
+    expect(seamless('border-warning-strong', true)).not.toContain('border-warning-strong');
+  });
+});
+
+describe('unsavedHintId', () => {
+  it('namespaces by surface so the quote and invoice editors cannot collide', () => {
+    // All three params are strings, so a swapped argument compiles cleanly —
+    // exact-string assertions are the only thing that catches it.
+    expect(unsavedHintId('quote-line', 'line-1', 'qty')).toBe('quote-line-qty-unsaved-line-1');
+    expect(unsavedHintId('invoice-line', 'line-1', 'qty')).toBe('invoice-line-qty-unsaved-line-1');
+    expect(unsavedHintId('quote-line', 'line-1', 'qty'))
+      .not.toBe(unsavedHintId('invoice-line', 'line-1', 'qty'));
+  });
+});

--- a/apps/web/src/components/billing/shared/saveCues.tsx
+++ b/apps/web/src/components/billing/shared/saveCues.tsx
@@ -1,8 +1,14 @@
-// The billing editors' shared save-grammar: quiet blur-to-save cues (dirty
-// border / green "saved" pulse / SR-only announcements) used by both the quote
-// editor modules and the invoice editor. Extracted from quoteEditorShared so the
-// invoice editor stops carrying stale byte-similar local copies — one styling
-// contract, one place it evolves.
+// The shared save-grammar: quiet blur-to-save cues (dirty border / green "saved"
+// pulse / SR-only announcements). Extracted from quoteEditorShared, which had
+// been copied into the invoice editor and the contract editor; both copies had
+// since drifted, and the contract one still carried the ring-based version this
+// file exists to replace.
+//
+// Every consumer now routes here — the quote modules via the thin
+// `quoteEditorShared` adapters (which only inject the quote's default label and
+// id prefix), the invoice editor and `contracts/ContractEditor` directly. One
+// styling contract, one place it evolves. Adding a fourth copy is how the last
+// three diverged; extend this file instead.
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../../../lib/i18n';
@@ -35,24 +41,45 @@ export function SrSaved({ show, label, testId }: { show: boolean; label: string;
 // green border pulse when it lands, nothing at rest. Border-color (not a ring):
 // the focus ring occupies the box-shadow channel, so a ring-based dirty signal
 // was painted over by focus on exactly the field being edited — the one moment
-// the signal matters. Border-color composes with the focus ring, never reflows
-// (the border is always present, only its color changes), and uses the
-// warning-strong indicator token (>=3:1 non-text on a light card). Pair with a
-// constant `transition-colors` on the field.
+// the signal matters. Border-color composes with the focus ring instead.
+//
+// PRECONDITION: the field must already carry a `border` WIDTH utility. These are
+// border-COLOR classes only, and Tailwind 4's preflight leaves `border-width: 0`
+// on every element (this app's `@layer base` re-declares only `border-color`) —
+// so on an element without one, the cue renders nothing at all and does so
+// silently. That is not hypothetical: it is how the rich-text block card lost
+// its cue in the ring→border migration. Given the width, the border is always
+// present and only its color changes, so the signal never reflows. Pair with a
+// constant `transition-colors` (NOT `transition-shadow` — border-color is not in
+// the shadow property set, so the amber→green change would snap).
+//
+// Amber uses `warning-strong` (~4.6:1 on light, >=3:1 dark) because plain
+// `--warning` is ~2.3:1, below the 3:1 non-text minimum. The green branch uses
+// plain `--success` (~4.5:1 light / ~4.0:1 dark), which also clears it — and it
+// is a transient confirmation backed by SrSaved, so it is not load-bearing.
 export function fieldRing(dirty: boolean, saved: boolean): string {
   return dirty ? 'border-warning-strong' : saved ? 'border-success' : '';
 }
 
 // Seamless (document-styled) field border: at rest the border is invisible so
 // the value reads as document text; hover/focus reveal the field. A state color
-// (dirty amber / saved green / error red) REPLACES the base set rather than
-// stacking on it, so two border-color utilities never compete. The
-// focus-visible ring is unconditional: the revealed border alone is a sub-3:1
-// change against the page background, invisible to a keyboard user tabbing
-// through — and the ring lives in the box-shadow channel, so it composes with
-// the border-color save signal instead of painting over it.
-export function seamless(state: string): string {
-  return `${state || 'border-transparent hover:border-border focus:border-border'} focus-visible:ring-2 focus-visible:ring-ring`;
+// REPLACES the base set rather than stacking on it, so two border-color
+// utilities never compete. The focus-visible ring is unconditional: the revealed
+// border alone is a sub-3:1 change against the page background, invisible to a
+// keyboard user tabbing through — and the ring lives in the box-shadow channel,
+// so it composes with the border-color save signal instead of painting over it.
+//
+// `invalid` is a parameter rather than something callers branch around, because
+// branching around it is what callers did — `invalid ? 'border-destructive' :
+// seamless(...)` reads as a legal refactor, but it drops the focus ring from the
+// one field a keyboard user is actively trying to fix (these inputs all set
+// `focus:outline-hidden`, so nothing else supplies an indicator). Taking the
+// error state here means the bypass has no reason to exist.
+export function seamless(state: string, invalid = false): string {
+  const border = invalid
+    ? 'border-destructive'
+    : state || 'border-transparent hover:border-border focus:border-border';
+  return `${border} focus-visible:ring-2 focus-visible:ring-ring`;
 }
 
 // The amber dirty border (fieldRing) is a COLOR-only signal — a screen-reader

--- a/apps/web/src/components/billing/shared/saveCues.tsx
+++ b/apps/web/src/components/billing/shared/saveCues.tsx
@@ -1,0 +1,77 @@
+// The billing editors' shared save-grammar: quiet blur-to-save cues (dirty
+// border / green "saved" pulse / SR-only announcements) used by both the quote
+// editor modules and the invoice editor. Extracted from quoteEditorShared so the
+// invoice editor stops carrying stale byte-similar local copies — one styling
+// contract, one place it evolves.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '../../../lib/i18n';
+
+// A transient "Saved" cue for blur-to-save fields. Returns the on-flag (drives
+// the SR live region + green border pulse) and a trigger; clears its timer on
+// unmount so a late fire can't setState a gone node.
+export function useSavedFlash(): [boolean, () => void] {
+  const [on, setOn] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+  const flash = useCallback(() => {
+    setOn(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setOn(false), 1500);
+  }, []);
+  return [on, flash];
+}
+
+// Visually-hidden polite live region — announces a transient "Saved" to screen
+// readers without taking visual space, pairing with the dirty-border clearing
+// that sighted users see. The single per-field announcer (no toast), so SR users
+// hear "Saved" once, not twice. testId lets tests assert the cue fired.
+export function SrSaved({ show, label, testId }: { show: boolean; label: string; testId?: string }) {
+  // role="status" already implies aria-live="polite" — don't double it.
+  return <span role="status" className="sr-only" data-testid={testId}>{show ? label : ''}</span>;
+}
+
+// A field's save-state signal: amber BORDER while the edit is unsaved, a brief
+// green border pulse when it lands, nothing at rest. Border-color (not a ring):
+// the focus ring occupies the box-shadow channel, so a ring-based dirty signal
+// was painted over by focus on exactly the field being edited — the one moment
+// the signal matters. Border-color composes with the focus ring, never reflows
+// (the border is always present, only its color changes), and uses the
+// warning-strong indicator token (>=3:1 non-text on a light card). Pair with a
+// constant `transition-colors` on the field.
+export function fieldRing(dirty: boolean, saved: boolean): string {
+  return dirty ? 'border-warning-strong' : saved ? 'border-success' : '';
+}
+
+// Seamless (document-styled) field border: at rest the border is invisible so
+// the value reads as document text; hover/focus reveal the field. A state color
+// (dirty amber / saved green / error red) REPLACES the base set rather than
+// stacking on it, so two border-color utilities never compete. The
+// focus-visible ring is unconditional: the revealed border alone is a sub-3:1
+// change against the page background, invisible to a keyboard user tabbing
+// through — and the ring lives in the box-shadow channel, so it composes with
+// the border-color save signal instead of painting over it.
+export function seamless(state: string): string {
+  return `${state || 'border-transparent hover:border-border focus:border-border'} focus-visible:ring-2 focus-visible:ring-ring`;
+}
+
+// The amber dirty border (fieldRing) is a COLOR-only signal — a screen-reader
+// user tabbing through a pricing-table row gets no equivalent cue that a field
+// holds an unsaved edit. `unsavedHintId` builds a stable id for a field's
+// SR-only "Unsaved" description; wire it to the field's `aria-describedby`
+// while dirty and render `<UnsavedFieldHint id={that id} show={dirty} />`
+// immediately after the field. Deliberately NOT a visible badge (per-field
+// badges across a long pricing table were noisy) and NOT an aria-live
+// announcement (a live region would fire on every keystroke) — just parity for
+// AT users at the moment they land on the field, same as sighted users see the
+// border the moment they look at it. `prefix` namespaces the ids per surface
+// ('quote-line' / 'invoice-line') so the two editors can't collide.
+export function unsavedHintId(prefix: string, lineId: string, field: string): string {
+  return `${prefix}-${field}-unsaved-${lineId}`;
+}
+
+export function UnsavedFieldHint({ id, show }: { id: string; show: boolean }) {
+  const { t } = useTranslation('billing');
+  if (!show) return null;
+  return <span id={id} className="sr-only">{t('billingUi.unsaved')}</span>;
+}

--- a/apps/web/src/components/contracts/ContractEditor.tsx
+++ b/apps/web/src/components/contracts/ContractEditor.tsx
@@ -6,6 +6,11 @@ import '@/lib/i18n';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { ConfirmDialog } from '../shared/ConfirmDialog';
+// The billing save-grammar, shared rather than re-copied. The local copy this
+// replaces had drifted to `ring-1 ring-warning` — a box-shadow signal the focus
+// ring painted over on the field being edited, in a token documented at ~2.3:1
+// (below the 3:1 non-text minimum). See shared/saveCues for the full rationale.
+import { SrSaved, fieldRing } from '../billing/shared/saveCues';
 import {
   createContract,
   updateContract,
@@ -49,23 +54,6 @@ const INTERVAL_PRESETS = [
   { value: 3, label: 'contracts.shared.cadence.quarterly' },
   { value: 12, label: 'contracts.shared.cadence.annual' },
 ];
-
-// ── Save-grammar helpers (byte-similar local copies of the invoice/quote
-//    editors' — kept inline per CLAUDE.md; a later pass may extract them). ──────
-
-// Visually-hidden polite live region — announces a transient "Saved" to screen
-// readers, pairing with the amber→green dirty-ring cue sighted users see.
-function SrSaved({ show, label = '', testId }: { show: boolean; label?: string; testId?: string }) {
-  // role="status" already implies aria-live="polite" — don't double it.
-  return <span role="status" className="sr-only" data-testid={testId}>{show ? label : ''}</span>;
-}
-
-// A field's save-state outline: amber while unsaved, a brief green pulse when it
-// lands, nothing at rest. It's a box-shadow (ring), so it never reflows
-// neighbours. Pair with a constant `transition-shadow` on the field.
-function fieldRing(dirty: boolean, saved: boolean): string {
-  return dirty ? 'ring-1 ring-warning' : saved ? 'ring-1 ring-success' : '';
-}
 
 interface Props {
   /** Present in edit mode (existing draft/active contract); absent when creating. */
@@ -595,12 +583,14 @@ export default function ContractEditor({ detail, presetOrgId, onChanged }: Props
     [sites],
   );
 
-  // Shared field chrome. `transition-shadow` pairs with fieldRing's box-shadow so
-  // the amber→green cue animates without reflowing neighbours; `disabled:opacity-60`
-  // renders the read-only (no contracts:write) and non-draft schedule states.
-  const baseInput = 'h-10 rounded-md border bg-background px-3 text-sm text-foreground transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60';
+  // Shared field chrome. `transition-colors` pairs with fieldRing's border-color
+  // cue (border-color is not in the shadow property set, so `transition-shadow`
+  // would make the amber→green change snap); the `border` width is what lets a
+  // color-only cue render at all. `disabled:opacity-60` renders the read-only
+  // (no contracts:write) and non-draft schedule states.
+  const baseInput = 'h-10 rounded-md border bg-background px-3 text-sm text-foreground transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60';
   const dateInput = `${baseInput} dark:[color-scheme:dark] [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-60 hover:[&::-webkit-calendar-picker-indicator]:opacity-100`;
-  const areaInput = 'rounded-md border bg-background px-3 py-2 text-sm text-foreground transition-shadow focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60';
+  const areaInput = 'rounded-md border bg-background px-3 py-2 text-sm text-foreground transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring disabled:opacity-60';
   const legendCls = 'mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground';
 
   return (

--- a/apps/web/src/components/layout/ContextScopeLine.test.tsx
+++ b/apps/web/src/components/layout/ContextScopeLine.test.tsx
@@ -86,4 +86,22 @@ describe('ContextScopeLine', () => {
     render(<ContextScopeLine />);
     expect(screen.queryByTestId('context-scope-line')).toBeNull();
   });
+
+  it('renders nothing on a quote DETAIL page even in fleet view (single-document suppression)', () => {
+    // The document names its customer in its own header, and the line is the
+    // only scroll-away content above the workspace's pinned chrome.
+    stubPathname('/billing/quotes/q-1');
+    mockStoreState.currentOrgId = null;
+    mockStoreState.allOrgs = true;
+    render(<ContextScopeLine />);
+    expect(screen.queryByTestId('context-scope-line')).toBeNull();
+  });
+
+  it('still states fleet view on the quotes LIST page', () => {
+    stubPathname('/billing/quotes');
+    mockStoreState.currentOrgId = null;
+    mockStoreState.allOrgs = true;
+    render(<ContextScopeLine />);
+    expect(screen.getByTestId('context-scope-line').getAttribute('data-kind')).toBe('fleet');
+  });
 });

--- a/apps/web/src/components/layout/ContextScopeLine.tsx
+++ b/apps/web/src/components/layout/ContextScopeLine.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Globe, Library, Building2 } from 'lucide-react';
-import { getRouteScope } from '../../lib/routeScope';
+import { getRouteScope, isSingleDocumentRoute } from '../../lib/routeScope';
 import { useOrgStore } from '../../stores/orgStore';
 import { useOrgScope } from '@/hooks/useOrgScope';
 import { useTranslation } from 'react-i18next';
@@ -32,6 +32,10 @@ export default function ContextScopeLine() {
   }, []);
 
   if (!pathname) return null;
+  // Quote/invoice detail pages: the document names its customer, and this line
+  // is the only scroll-away content above their pinned header chrome — see
+  // isSingleDocumentRoute.
+  if (isSingleDocumentRoute(pathname)) return null;
   const kind = getRouteScope(pathname);
   // Explicit fleet view only — the hook's discriminated union keeps the
   // transient/loading and error states from reading as fleet.

--- a/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
+++ b/apps/web/src/lib/__tests__/no-silent-mutations.test.ts
@@ -110,6 +110,13 @@ const TARGET_GLOBS = [
   'src/components/contracts/ContractDocumentsSection.tsx',
   'src/components/contracts/TemplatesTab.tsx',
   'src/components/settings/PartnerCompanyTab.tsx',
+  // Invoice/quote money-moment hosts (issue / send / delete / title / line
+  // mutations): every mutation already routes through runAction, but the files
+  // sat outside the guarded set — a future bare mutation on the highest-stakes
+  // billing surfaces would have shipped with zero CI signal (PR #2829 review).
+  'src/components/billing/InvoiceActions.tsx',
+  'src/components/billing/quotes/QuoteHeaderMeta.tsx',
+  'src/components/billing/quotes/QuoteLineRows.tsx',
 ];
 
 const absoluteFiles: string[] = TARGET_GLOBS.map((rel) => resolve(WEB_ROOT, '..', rel));
@@ -301,7 +308,7 @@ describe('migration backlog integrity', () => {
 // ─── Main guard ─────────────────────────────────────────────────────────────
 describe('no silent mutations in targeted set', () => {
   it('finds files to scan', () => {
-    expect(absoluteFiles.length).toBe(76);
+    expect(absoluteFiles.length).toBe(79);
     for (const f of absoluteFiles) {
       expect(() => statSync(f)).not.toThrow();
     }

--- a/apps/web/src/lib/routeScope.test.ts
+++ b/apps/web/src/lib/routeScope.test.ts
@@ -1,7 +1,27 @@
 import { describe, it, expect } from 'vitest';
 import { readdirSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
-import { getRouteScope, isGlobalScopeRoute, ROUTE_SCOPES } from './routeScope';
+import { getRouteScope, isGlobalScopeRoute, isSingleDocumentRoute, ROUTE_SCOPES } from './routeScope';
+
+describe('isSingleDocumentRoute', () => {
+  it('matches quote and invoice DETAIL pages only', () => {
+    expect(isSingleDocumentRoute('/billing/quotes/q-1')).toBe(true);
+    expect(isSingleDocumentRoute('/billing/quotes/q-1/')).toBe(true);
+    expect(isSingleDocumentRoute('/billing/invoices/abc-123')).toBe(true);
+  });
+  it('does NOT match the list pages — the fleet scope line is load-bearing there', () => {
+    expect(isSingleDocumentRoute('/billing/quotes')).toBe(false);
+    expect(isSingleDocumentRoute('/billing/invoices')).toBe(false);
+    expect(isSingleDocumentRoute('/billing')).toBe(false);
+  });
+  it('does NOT match deeper sub-paths (a loosened [^/]+ would over-suppress)', () => {
+    expect(isSingleDocumentRoute('/billing/quotes/q-1/edit')).toBe(false);
+    expect(isSingleDocumentRoute('/billing/other/q-1')).toBe(false);
+  });
+  it('leaves the org-or-all classification untouched (orgId injection must not change)', () => {
+    expect(getRouteScope('/billing/quotes/q-1')).toBe('org-or-all');
+  });
+});
 
 describe('isGlobalScopeRoute', () => {
   it('treats the script library, new, and detail routes as global', () => {

--- a/apps/web/src/lib/routeScope.ts
+++ b/apps/web/src/lib/routeScope.ts
@@ -146,6 +146,18 @@ export function getRouteScope(pathname: string): RouteScopeKind | null {
 }
 
 /**
+ * Single-DOCUMENT workspace pages (quote/invoice detail). They keep their
+ * org-or-all classification (orgId injection etc.), but ContextScopeLine skips
+ * the fleet line here: the page's subject is one document whose customer is
+ * named right in its header, so "Showing all organizations" adds nothing — and
+ * as the only scroll-away content above the workspace's pinned header chrome,
+ * it was what made that header travel before locking.
+ */
+export function isSingleDocumentRoute(pathname: string): boolean {
+  return /^\/billing\/(quotes|invoices)\/[^/]+$/.test(normalize(pathname));
+}
+
+/**
  * Back-compat predicate used by the org-id injection chokepoint
  * (stores/orgStore.ts registerOrgIdProvider): catalog routes ignore the org
  * selector entirely, so no orgId is injected. Injection semantics are

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -543,7 +543,8 @@
         "addSome": "Fügen Sie einige zum Produktkatalog hinzu",
         "empty": "Keine Katalogartikel.",
         "loadError": "Der Katalog konnte nicht geladen werden. Öffnen Sie den Editor erneut, um es noch einmal zu versuchen – Ihre vorhandenen Elemente sind sicher.",
-        "searchPlaceholder": "Katalog nach Name oder SKU durchsuchen"
+        "searchPlaceholder": "Katalog nach Name oder SKU durchsuchen",
+        "capNote": "Es werden die ersten {{count}} Katalogartikel angezeigt – suchen Sie, um weitere zu finden."
       },
       "categories": {
         "hardware": "Hardware",
@@ -719,7 +720,7 @@
         "labelPlaceholder": "Tabellenbeschriftung (optional, z. B. Monatliche Leistungen)",
         "notTaxable": "Nicht steuerpflichtig",
         "qty": "Menge",
-        "recurrence": "Wiederholung",
+        "recurrence": "Abrechnung",
         "scrollAria": "Preistabelle – scrollen Sie auf schmalen Bildschirmen seitwärts für Gesamtsummen und Zeilenaktionen; bei langen Abschnitten scrollt sie vertikal mit fixierter Kopfzeile",
         "showSubtotal": "Zwischensummenzeile anzeigen",
         "tax": "Steuer",
@@ -828,12 +829,12 @@
         "ccToggle": "Cc",
         "includePdfLabel": "Angebots-PDF anhängen",
         "invalidEmail": "Ungültige E-Mail-Adresse: {{addresses}}",
-        "message": "Wir senden dieses Angebot per E-Mail an {{orgName}} und markieren es als „Gesendet“ – {{amount}} fällig bei Annahme. Dies kann nicht rückgängig gemacht werden.",
+        "message": "Wir senden dieses Angebot per E-Mail an {{orgName}} und markieren es als „Gesendet“ – {{amount}} fällig bei Annahme. Nach dem Bestätigen haben Sie 30 Sekunden Zeit, um den Versand rückgängig zu machen.",
         "messageLabel": "Persönliche Nachricht hinzufügen (optional)",
         "messagePlaceholder": "Fügen Sie eine kurze Notiz hinzu – sie erscheint in der E-Mail über dem Zusage-Link.",
         "paymentEnabled": "Online-Zahlung ist aktiviert – der Kunde kann nach der Annahme per Karte zahlen.",
-        "paymentNoteNoStripe": "Bei Annahme hat der Kunde keine Online-Zahlungsoption. Verbinden Sie Stripe unter Einstellungen → Integrationen, um eine anzubieten.",
-        "paymentWarningDeposit": "Für dieses Angebot ist eine Anzahlung konfiguriert, aber Kunden können noch nicht online zahlen – verbinden Sie Stripe unter Einstellungen → Integrationen, damit die Anzahlung bei Annahme eingezogen werden kann.",
+        "paymentNoteNoStripe": "Bei Annahme hat der Kunde keine Online-Zahlungsoption. Verbinden Sie Stripe unter <integrationsLink>Einstellungen → Integrationen</integrationsLink>, um eine anzubieten.",
+        "paymentWarningDeposit": "Für dieses Angebot ist eine Anzahlung konfiguriert, aber Kunden können noch nicht online zahlen – verbinden Sie Stripe unter <integrationsLink>Einstellungen → Integrationen</integrationsLink>, damit die Anzahlung bei Annahme eingezogen werden kann.",
         "recipientRequired": "Geben Sie mindestens einen Empfänger ein, um zu senden.",
         "signaturePreviewLabel": "Signatur (festgelegt unter Einstellungen → Branding):",
         "subjectLabel": "Betreff",
@@ -843,7 +844,8 @@
         "toLabel": "An",
         "toPlaceholder": "Empfänger hinzufügen…",
         "tooManyRecipients": "Verwenden Sie höchstens {{max}} Adressen.",
-        "zeroTotalWarning": "Dieses Angebot beträgt $0.00 — prüfen Sie vor dem Senden, ob die Positionen bepreist sind."
+        "zeroTotalWarning": "Dieses Angebot beträgt $0.00 — prüfen Sie vor dem Senden, ob die Positionen bepreist sind.",
+        "noBillingContactHint": "Für diese Organisation ist kein Rechnungskontakt hinterlegt – geben Sie eine E-Mail-Adresse ein oder ergänzen Sie eine in den <orgLink>Organisationseinstellungen</orgLink>."
       },
       "sendEmailWarning": {
         "noBillingContact": "Vorschlag als Gesendet markiert, aber es wurde keine E-Mail zugestellt — {{orgName}} hat keine Rechnungskontakt-E-Mail. Fügen Sie eine in den Organisationseinstellungen hinzu oder teilen Sie den Annahme-Link manuell.",
@@ -860,7 +862,11 @@
       "undoError": "Das Senden konnte nicht abgebrochen werden.",
       "undoSend": "Senden rückgängig",
       "undoSuccess": "Senden abgebrochen — das Angebot bleibt ein Entwurf.",
-      "undoTooLate": "Zu spät zum Rückgängigmachen — das Angebot wurde bereits gesendet."
+      "undoTooLate": "Zu spät zum Rückgängigmachen — das Angebot wurde bereits gesendet.",
+      "sendNow": "Jetzt senden",
+      "savingTimeout": "Das Speichern dauert zu lange – prüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "sendNowCancelError": "Sofortversand nicht möglich – das Angebot wird weiterhin wie geplant gesendet.",
+      "sendNowAlready": "Bereits unterwegs – das Angebot wird gerade gesendet."
     },
     "detail": {
       "addContentInEditor": "Fügen Sie Inhalte im Editor hinzu",
@@ -889,7 +895,7 @@
         "item": "Artikel",
         "noLines": "Keine Positionen in dieser Tabelle.",
         "qty": "Menge",
-        "recurrence": "Wiederholung",
+        "recurrence": "Abrechnung",
         "tax": "Steuer",
         "total": "Insgesamt",
         "unitPrice": "Stückpreis"
@@ -1111,7 +1117,8 @@
         "editor": "Herausgeber",
         "preview": "Vorschau",
         "detail": "Detailansicht"
-      }
+      },
+      "loading": "Angebot wird geladen…"
     }
   },
   "billingUi": {
@@ -1130,7 +1137,14 @@
       "perMonth": "/Mo",
       "perYear": "/Jahr"
     },
-    "unsaved": "Nicht gespeichert"
+    "unsaved": "Nicht gespeichert",
+    "showCostMargin": "Kosten und Marge anzeigen",
+    "hideCostMargin": "Kosten und Marge ausblenden",
+    "orgCombobox": {
+      "searchPlaceholder": "Organisationen durchsuchen…",
+      "noResults": "Keine passenden Organisationen.",
+      "capNote": "Es werden die ersten {{count}} Treffer angezeigt – tippen Sie weiter, um einzugrenzen."
+    }
   },
   "bulk": {
     "bulkActionBar": {
@@ -1194,7 +1208,6 @@
     "saved": "Gespeichert",
     "success": {
       "lineAdded": "Position hinzugefügt",
-      "lineRemoved": "Position entfernt",
       "notesSaved": "Notizen gespeichert",
       "termsSaved": "Begriffe gespeichert"
     },
@@ -1222,7 +1235,17 @@
     },
     "unapprovedTime": "{{count}} Positionen verweisen auf nicht genehmigte Zeiten. Vor dem Ausstellen prüfen.",
     "unapprovedTime_one": "{{count}} Position verweist auf nicht genehmigte Zeit. Vor dem Ausstellen prüfen.",
-    "unapprovedTime_other": "{{count}} Positionen verweisen auf nicht genehmigte Zeiten. Vor dem Ausstellen prüfen."
+    "unapprovedTime_other": "{{count}} Positionen verweisen auf nicht genehmigte Zeiten. Vor dem Ausstellen prüfen.",
+    "autosaveHint": "Änderungen werden automatisch gespeichert. Ein bernsteinfarbener Rahmen markiert eine ungespeicherte Änderung.",
+    "lastSaved": {
+      "saved": "Gespeichert um {{time}} Uhr",
+      "saving": "Wird gespeichert…"
+    },
+    "undo": {
+      "lineDeleted": "Position gelöscht",
+      "tooLate": "Rückgängig nicht mehr möglich – diese Position wurde bereits gelöscht."
+    },
+    "linesScrollAria": "Rechnungspositionen – scrollen Sie seitwärts für weitere Spalten"
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1248,10 +1271,13 @@
     "issueSuccess": "Rechnung ausgestellt",
     "issuing": "Wird ausgestellt…",
     "noVisibleLineHint": "Mindestens eine für Kunden sichtbare Position zum Ausstellen hinzufügen.",
-    "preparing": "Vorbereiten…"
+    "preparing": "Vorbereiten…",
+    "savingHint": "Änderungen werden gespeichert… Ausstellen wird freigegeben, sobald alles gespeichert ist.",
+    "savingTitle": "Ihre Änderungen werden gespeichert – Ausstellen wird freigegeben, sobald alles gespeichert ist.",
+    "issueCanceledSaveFailed": "Eine Änderung konnte nicht gespeichert werden, daher wurde das Ausstellen abgebrochen. Korrigieren Sie das markierte Feld und versuchen Sie es erneut.",
+    "issueCanceledStillSaving": "Ihre Änderungen werden noch gespeichert – das Ausstellen wurde abgebrochen. Versuchen Sie es erneut, sobald alles gespeichert ist."
   },
   "invoiceDetail": {
-    "accountingView": "Buchhaltungsansicht (Kosten, Marge, versteckte Komponenten)",
     "deposit": {
       "duePrefix": "Anzahlung von",
       "dueSuffix": "fällig – {{paid}} von {{total}} bezahlt.",
@@ -1272,7 +1298,8 @@
       "price": "Preis",
       "qty": "Menge",
       "tax": "Steuer",
-      "total": "Insgesamt"
+      "total": "Insgesamt",
+      "allHidden": "Alle Positionen sind nur intern. Verwenden Sie „Kosten und Marge anzeigen“, um sie einzublenden."
     },
     "paymentMethods": {
       "cash": "Bargeld",
@@ -1344,7 +1371,10 @@
       "reissuedSuccess": "Rechnung storniert und als Entwurf neu ausgestellt",
       "success": "Rechnung storniert",
       "title": "Rechnung stornieren"
-    }
+    },
+    "empty": "Diese Rechnung hat noch keine Positionen.",
+    "addContentInEditor": "Positionen im Editor hinzufügen",
+    "linesScrollAria": "Rechnungspositionen – scrollen Sie seitwärts für weitere Spalten"
   },
   "invoiceDocument": {
     "billTo": "Bill zu",

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -795,6 +795,9 @@
         "noTargets": "Fügen Sie einen Preisabschnitt hinzu und verschieben Sie diese Positionen dann dorthin.",
         "qtyPrice": "{{qty}} × {{price}}",
         "title": "Nicht zugeordnete Positionen"
+      },
+      "unsavedField": {
+        "lines": "Positionen"
       }
     },
     "actions": {
@@ -864,9 +867,13 @@
       "undoSuccess": "Senden abgebrochen — das Angebot bleibt ein Entwurf.",
       "undoTooLate": "Zu spät zum Rückgängigmachen — das Angebot wurde bereits gesendet.",
       "sendNow": "Jetzt senden",
-      "savingTimeout": "Das Speichern dauert zu lange – prüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "savingTimeout": "Ihre Änderungen werden noch gespeichert — das Senden wurde abgebrochen. Versuchen Sie es erneut, sobald alles gespeichert ist.",
       "sendNowCancelError": "Sofortversand nicht möglich – das Angebot wird weiterhin wie geplant gesendet.",
-      "sendNowAlready": "Bereits unterwegs – das Angebot wird gerade gesendet."
+      "sendNowAlready": "Bereits unterwegs – das Angebot wird gerade gesendet.",
+      "sendCanceledSaveFailed": "Eine Änderung konnte nicht gespeichert werden, daher wurde das Senden abgebrochen. Korrigieren Sie das markierte Feld und versuchen Sie es erneut.",
+      "sendBlockedUnsaved": "„{{field}}“ enthält eine nicht gespeicherte Änderung. Korrigieren Sie sie dort und senden Sie dann.",
+      "unsavedHint": "„{{field}}“ enthält eine nicht gespeicherte Änderung — Senden wird freigegeben, sobald sie gespeichert ist.",
+      "unsavedTitle": "„{{field}}“ enthält eine nicht gespeicherte Änderung — Senden wird freigegeben, sobald sie gespeichert ist."
     },
     "detail": {
       "addContentInEditor": "Fügen Sie Inhalte im Editor hinzu",
@@ -1172,7 +1179,9 @@
       "manualLine": "Manuelle Position",
       "noCatalogItems": "Keine Katalogartikel.",
       "searchCatalog": "Katalog nach Name oder SKU durchsuchen",
-      "sourceAria": "Positionsquelle hinzufügen"
+      "sourceAria": "Positionsquelle hinzufügen",
+      "catalogLoadFailed": "Der Katalog konnte nicht geladen werden, daher können keine Artikel angezeigt werden.",
+      "retry": "Erneut versuchen"
     },
     "billTo": {
       "addInSettings": "Fügen Sie eine in den Organisationseinstellungen hinzu",
@@ -1243,9 +1252,13 @@
     },
     "undo": {
       "lineDeleted": "Position gelöscht",
-      "tooLate": "Rückgängig nicht mehr möglich – diese Position wurde bereits gelöscht."
+      "tooLate": "Rückgängig nicht mehr möglich – diese Position wurde bereits gelöscht.",
+      "partialFlush": "{{applied}} Löschung(en) wurden übernommen; {{failed}} sind fehlgeschlagen und wurden wiederhergestellt."
     },
-    "linesScrollAria": "Rechnungspositionen – scrollen Sie seitwärts für weitere Spalten"
+    "linesScrollAria": "Rechnungspositionen – scrollen Sie seitwärts für weitere Spalten",
+    "unsavedField": {
+      "lines": "Positionen"
+    }
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1275,7 +1288,10 @@
     "savingHint": "Änderungen werden gespeichert… Ausstellen wird freigegeben, sobald alles gespeichert ist.",
     "savingTitle": "Ihre Änderungen werden gespeichert – Ausstellen wird freigegeben, sobald alles gespeichert ist.",
     "issueCanceledSaveFailed": "Eine Änderung konnte nicht gespeichert werden, daher wurde das Ausstellen abgebrochen. Korrigieren Sie das markierte Feld und versuchen Sie es erneut.",
-    "issueCanceledStillSaving": "Ihre Änderungen werden noch gespeichert – das Ausstellen wurde abgebrochen. Versuchen Sie es erneut, sobald alles gespeichert ist."
+    "issueCanceledStillSaving": "Ihre Änderungen werden noch gespeichert – das Ausstellen wurde abgebrochen. Versuchen Sie es erneut, sobald alles gespeichert ist.",
+    "issueBlockedUnsaved": "„{{field}}“ enthält eine nicht gespeicherte Änderung. Korrigieren Sie sie dort und stellen Sie dann aus.",
+    "unsavedHint": "„{{field}}“ enthält eine nicht gespeicherte Änderung — Ausstellen wird freigegeben, sobald sie gespeichert ist.",
+    "unsavedTitle": "„{{field}}“ enthält eine nicht gespeicherte Änderung — Ausstellen wird freigegeben, sobald sie gespeichert ist."
   },
   "invoiceDetail": {
     "deposit": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -795,6 +795,9 @@
         "noTargets": "Add a pricing section, then move these lines into it.",
         "qtyPrice": "{{qty}} × {{price}}",
         "title": "Unassigned lines"
+      },
+      "unsavedField": {
+        "lines": "Line items"
       }
     },
     "actions": {
@@ -864,9 +867,13 @@
       "undoSuccess": "Send canceled — the quote is still a draft.",
       "undoTooLate": "Too late to undo — the proposal was already sent.",
       "sendNow": "Send now",
-      "savingTimeout": "Changes are taking too long to save — check your connection and try again.",
+      "savingTimeout": "Still saving your changes — Send was canceled. Try again once everything is saved.",
       "sendNowCancelError": "Couldn't send immediately — the proposal will still send as scheduled.",
-      "sendNowAlready": "Already on its way — the proposal is being sent now."
+      "sendNowAlready": "Already on its way — the proposal is being sent now.",
+      "sendCanceledSaveFailed": "A change failed to save, so Send was canceled. Fix the highlighted field and try again.",
+      "sendBlockedUnsaved": "“{{field}}” has a change that hasn’t saved. Fix it there, then Send.",
+      "unsavedHint": "“{{field}}” has an unsaved change — Send unlocks once it saves.",
+      "unsavedTitle": "“{{field}}” has an unsaved change — Send unlocks once it saves."
     },
     "detail": {
       "addContentInEditor": "Add content in the Editor",
@@ -1172,7 +1179,9 @@
       "manualLine": "Manual line",
       "noCatalogItems": "No catalog items.",
       "searchCatalog": "Search catalog by name or SKU",
-      "sourceAria": "Add line source"
+      "sourceAria": "Add line source",
+      "catalogLoadFailed": "The catalog couldn't be loaded, so no items can be shown.",
+      "retry": "Try again"
     },
     "billTo": {
       "addInSettings": "Add one in Organization settings",
@@ -1243,9 +1252,13 @@
     },
     "undo": {
       "lineDeleted": "Line deleted",
-      "tooLate": "Too late to undo — that line was already deleted."
+      "tooLate": "Too late to undo — that line was already deleted.",
+      "partialFlush": "{{applied}} line deletion(s) were applied; {{failed}} failed and were restored."
     },
-    "linesScrollAria": "Invoice lines — scroll sideways for more columns"
+    "linesScrollAria": "Invoice lines — scroll sideways for more columns",
+    "unsavedField": {
+      "lines": "Line items"
+    }
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1275,7 +1288,10 @@
     "savingHint": "Saving changes… Issue unlocks when everything is saved.",
     "savingTitle": "Saving your changes — Issue unlocks when everything is saved.",
     "issueCanceledSaveFailed": "A change failed to save, so Issue was canceled. Fix the highlighted field and try again.",
-    "issueCanceledStillSaving": "Still saving your changes — Issue was canceled. Try again once everything is saved."
+    "issueCanceledStillSaving": "Still saving your changes — Issue was canceled. Try again once everything is saved.",
+    "issueBlockedUnsaved": "“{{field}}” has a change that hasn’t saved. Fix it there, then Issue.",
+    "unsavedHint": "“{{field}}” has an unsaved change — Issue unlocks once it saves.",
+    "unsavedTitle": "“{{field}}” has an unsaved change — Issue unlocks once it saves."
   },
   "invoiceDetail": {
     "deposit": {

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -543,7 +543,8 @@
         "addSome": "Add some in Product Catalog",
         "empty": "No catalog items.",
         "loadError": "Couldn't load the catalog. Reopen the editor to retry — your existing items are safe.",
-        "searchPlaceholder": "Search catalog by name or SKU"
+        "searchPlaceholder": "Search catalog by name or SKU",
+        "capNote": "Showing the first {{count}} catalog items — search to find the rest."
       },
       "categories": {
         "hardware": "Hardware",
@@ -719,7 +720,7 @@
         "labelPlaceholder": "Table label (optional, e.g. Monthly services)",
         "notTaxable": "Not taxable",
         "qty": "Qty",
-        "recurrence": "Recurrence",
+        "recurrence": "Billing",
         "scrollAria": "Pricing table — scrolls sideways on narrow screens for totals and row actions, and vertically (with the header pinned) once a section grows long",
         "showSubtotal": "Show subtotal row",
         "tax": "Tax",
@@ -828,12 +829,12 @@
         "ccToggle": "Cc",
         "includePdfLabel": "Attach the proposal PDF",
         "invalidEmail": "Invalid email address: {{addresses}}",
-        "message": "We'll email this proposal to {{orgName}} and mark it Sent — {{amount}} due on acceptance. This can't be undone.",
+        "message": "We'll email this proposal to {{orgName}} and mark it Sent — {{amount}} due on acceptance. You'll have 30 seconds to undo after confirming.",
         "messageLabel": "Add a personal message (optional)",
         "messagePlaceholder": "Include a short note — it appears in the email above the accept link.",
         "paymentEnabled": "Online payment is enabled — the customer can pay by card after accepting.",
-        "paymentNoteNoStripe": "When the customer accepts, they won't have an online payment option. Connect Stripe in Settings → Integrations to offer one.",
-        "paymentWarningDeposit": "This proposal asks for a deposit, but customers can't pay online yet — connect Stripe in Settings → Integrations so the deposit can be collected on acceptance.",
+        "paymentNoteNoStripe": "When the customer accepts, they won't have an online payment option. Connect Stripe in <integrationsLink>Settings → Integrations</integrationsLink> to offer one.",
+        "paymentWarningDeposit": "This proposal asks for a deposit, but customers can't pay online yet — connect Stripe in <integrationsLink>Settings → Integrations</integrationsLink> so the deposit can be collected on acceptance.",
         "recipientRequired": "Enter at least one recipient to send.",
         "signaturePreviewLabel": "Signature (set in Settings → Branding):",
         "subjectLabel": "Subject",
@@ -843,7 +844,8 @@
         "toLabel": "To",
         "toPlaceholder": "Add recipient…",
         "tooManyRecipients": "Use at most {{max}} addresses.",
-        "zeroTotalWarning": "This quote totals $0.00 — check that its items are priced before sending."
+        "zeroTotalWarning": "This quote totals $0.00 — check that its items are priced before sending.",
+        "noBillingContactHint": "No billing contact is saved for this organization — enter an email, or add one in the <orgLink>organization settings</orgLink>."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposal marked Sent, but no email was delivered — {{orgName}} has no billing contact email. Add one in the organization settings, or share the accept link manually.",
@@ -860,7 +862,11 @@
       "undoError": "Could not cancel the send.",
       "undoSend": "Undo send",
       "undoSuccess": "Send canceled — the quote is still a draft.",
-      "undoTooLate": "Too late to undo — the proposal was already sent."
+      "undoTooLate": "Too late to undo — the proposal was already sent.",
+      "sendNow": "Send now",
+      "savingTimeout": "Changes are taking too long to save — check your connection and try again.",
+      "sendNowCancelError": "Couldn't send immediately — the proposal will still send as scheduled.",
+      "sendNowAlready": "Already on its way — the proposal is being sent now."
     },
     "detail": {
       "addContentInEditor": "Add content in the Editor",
@@ -889,7 +895,7 @@
         "item": "Item",
         "noLines": "No lines in this table.",
         "qty": "Qty",
-        "recurrence": "Recurrence",
+        "recurrence": "Billing",
         "tax": "Tax",
         "total": "Total",
         "unitPrice": "Unit price"
@@ -1111,7 +1117,8 @@
         "editor": "Editor",
         "preview": "Preview",
         "detail": "Details"
-      }
+      },
+      "loading": "Loading quote…"
     }
   },
   "billingUi": {
@@ -1130,7 +1137,14 @@
       "perMonth": "/mo",
       "perYear": "/yr"
     },
-    "unsaved": "Unsaved"
+    "unsaved": "Unsaved",
+    "showCostMargin": "Show cost & margin",
+    "hideCostMargin": "Hide cost & margin",
+    "orgCombobox": {
+      "searchPlaceholder": "Search organizations…",
+      "noResults": "No matching organizations.",
+      "capNote": "Showing the first {{count}} matches — keep typing to narrow."
+    }
   },
   "bulk": {
     "bulkActionBar": {
@@ -1194,7 +1208,6 @@
     "saved": "Saved",
     "success": {
       "lineAdded": "Line added",
-      "lineRemoved": "Line removed",
       "notesSaved": "Notes saved",
       "termsSaved": "Terms saved"
     },
@@ -1222,7 +1235,17 @@
     },
     "unapprovedTime": "{{count}} lines reference unapproved time. Review before issuing.",
     "unapprovedTime_one": "{{count}} line reference unapproved time. Review before issuing.",
-    "unapprovedTime_other": "{{count}} lines reference unapproved time. Review before issuing."
+    "unapprovedTime_other": "{{count}} lines reference unapproved time. Review before issuing.",
+    "autosaveHint": "Changes save automatically. An amber outline marks an unsaved edit.",
+    "lastSaved": {
+      "saved": "Saved {{time}}",
+      "saving": "Saving…"
+    },
+    "undo": {
+      "lineDeleted": "Line deleted",
+      "tooLate": "Too late to undo — that line was already deleted."
+    },
+    "linesScrollAria": "Invoice lines — scroll sideways for more columns"
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1248,10 +1271,13 @@
     "issueSuccess": "Invoice issued",
     "issuing": "Issuing…",
     "noVisibleLineHint": "Add at least one customer-visible line to issue.",
-    "preparing": "Preparing…"
+    "preparing": "Preparing…",
+    "savingHint": "Saving changes… Issue unlocks when everything is saved.",
+    "savingTitle": "Saving your changes — Issue unlocks when everything is saved.",
+    "issueCanceledSaveFailed": "A change failed to save, so Issue was canceled. Fix the highlighted field and try again.",
+    "issueCanceledStillSaving": "Still saving your changes — Issue was canceled. Try again once everything is saved."
   },
   "invoiceDetail": {
-    "accountingView": "Accounting view (cost, margin, hidden components)",
     "deposit": {
       "duePrefix": "Deposit of",
       "dueSuffix": "due — {{paid}} of {{total}} paid.",
@@ -1272,7 +1298,8 @@
       "price": "Price",
       "qty": "Qty",
       "tax": "Tax",
-      "total": "Total"
+      "total": "Total",
+      "allHidden": "All lines are internal-only. Use “Show cost & margin” to view them."
     },
     "paymentMethods": {
       "cash": "Cash",
@@ -1344,7 +1371,10 @@
       "reissuedSuccess": "Invoice voided and reissued as a draft",
       "success": "Invoice voided",
       "title": "Void invoice"
-    }
+    },
+    "empty": "This invoice has no lines yet.",
+    "addContentInEditor": "Add lines in the Editor",
+    "linesScrollAria": "Invoice lines — scroll sideways for more columns"
   },
   "invoiceDocument": {
     "billTo": "Bill to",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -543,7 +543,8 @@
         "addSome": "Agregue algunos en el catálogo de productos",
         "empty": "Sin artículos de catálogo.",
         "loadError": "No se pudo cargar el catálogo. Vuelva a abrir el editor para volver a intentarlo: sus elementos existentes están seguros.",
-        "searchPlaceholder": "Buscar catálogo por nombre o SKU"
+        "searchPlaceholder": "Buscar catálogo por nombre o SKU",
+        "capNote": "Se muestran los primeros {{count}} artículos del catálogo: busca para encontrar el resto."
       },
       "categories": {
         "hardware": "Hardware",
@@ -719,7 +720,7 @@
         "labelPlaceholder": "Etiqueta de tabla (opcional, por ejemplo, servicios mensuales)",
         "notTaxable": "No sujeto a impuestos",
         "qty": "Cantidad",
-        "recurrence": "Recurrencia",
+        "recurrence": "Facturación",
         "scrollAria": "Tabla de precios: desplácese hacia los lados en pantallas angostas para ver totales y acciones de fila; en secciones largas, se desplaza verticalmente con el encabezado fijo",
         "showSubtotal": "Mostrar fila de subtotal",
         "tax": "Impuesto",
@@ -828,12 +829,12 @@
         "ccToggle": "Cc",
         "includePdfLabel": "Adjuntar el PDF de la propuesta",
         "invalidEmail": "Dirección de correo no válida: {{addresses}}",
-        "message": "Enviaremos esta propuesta por correo electrónico a {{orgName}} y la marcaremos como Enviada - {{amount}} al momento de su aceptación. Esto no se puede deshacer.",
+        "message": "Enviaremos esta propuesta por correo electrónico a {{orgName}} y la marcaremos como Enviada - {{amount}} al momento de su aceptación. Tendrás 30 segundos para deshacer después de confirmar.",
         "messageLabel": "Agregar un mensaje personal (opcional)",
         "messagePlaceholder": "Incluye una nota breve: aparecerá en el correo, encima del enlace para aceptar.",
         "paymentEnabled": "El pago en línea está habilitado: el cliente puede pagar con tarjeta después de aceptar.",
-        "paymentNoteNoStripe": "Cuando el cliente acepte, no tendrá una opción de pago en línea. Conecta Stripe en Configuración → Integraciones para ofrecerla.",
-        "paymentWarningDeposit": "Esta propuesta solicita un depósito, pero los clientes aún no pueden pagar en línea: conecta Stripe en Configuración → Integraciones para poder cobrar el depósito al aceptar.",
+        "paymentNoteNoStripe": "Cuando el cliente acepte, no tendrá una opción de pago en línea. Conecta Stripe en <integrationsLink>Configuración → Integraciones</integrationsLink> para ofrecerla.",
+        "paymentWarningDeposit": "Esta propuesta solicita un depósito, pero los clientes aún no pueden pagar en línea: conecta Stripe en <integrationsLink>Configuración → Integraciones</integrationsLink> para poder cobrar el depósito al aceptar.",
         "recipientRequired": "Ingresa al menos un destinatario para enviar.",
         "signaturePreviewLabel": "Firma (configurada en Configuración → Marca):",
         "subjectLabel": "Asunto",
@@ -843,7 +844,8 @@
         "toLabel": "Para",
         "toPlaceholder": "Agregar destinatario…",
         "tooManyRecipients": "Usa como máximo {{max}} direcciones.",
-        "zeroTotalWarning": "Esta cotización totaliza $0.00 — verifica que sus ítems tengan precio antes de enviar."
+        "zeroTotalWarning": "Esta cotización totaliza $0.00 — verifica que sus ítems tengan precio antes de enviar.",
+        "noBillingContactHint": "Esta organización no tiene un contacto de facturación guardado: ingresa un correo o agrega uno en la <orgLink>configuración de la organización</orgLink>."
       },
       "sendEmailWarning": {
         "noBillingContact": "La propuesta se marcó como Enviada, pero no se entregó ningún correo — {{orgName}} no tiene correo de contacto de facturación. Agregue uno en la configuración de la organización o comparta el enlace de aceptación manualmente.",
@@ -860,7 +862,11 @@
       "undoError": "No se pudo cancelar el envío.",
       "undoSend": "Deshacer envío",
       "undoSuccess": "Envío cancelado — la cotización sigue siendo un borrador.",
-      "undoTooLate": "Demasiado tarde para deshacer — la propuesta ya se envió."
+      "undoTooLate": "Demasiado tarde para deshacer — la propuesta ya se envió.",
+      "sendNow": "Enviar ahora",
+      "savingTimeout": "Guardar los cambios está tardando demasiado: revisa tu conexión e inténtalo de nuevo.",
+      "sendNowCancelError": "No se pudo enviar de inmediato: la propuesta se enviará igualmente según lo programado.",
+      "sendNowAlready": "Ya está en camino: la propuesta se está enviando ahora."
     },
     "detail": {
       "addContentInEditor": "Agregar contenido en el Editor",
@@ -889,7 +895,7 @@
         "item": "Artículo",
         "noLines": "No hay líneas en esta tabla.",
         "qty": "Cantidad",
-        "recurrence": "Recurrencia",
+        "recurrence": "Facturación",
         "tax": "Impuesto",
         "total": "Total",
         "unitPrice": "Precio unitario"
@@ -1111,7 +1117,8 @@
         "editor": "Editor",
         "preview": "Vista previa",
         "detail": "Detalles"
-      }
+      },
+      "loading": "Cargando cotización…"
     }
   },
   "billingUi": {
@@ -1130,7 +1137,14 @@
       "perMonth": "/mo",
       "perYear": "/yr"
     },
-    "unsaved": "No guardado"
+    "unsaved": "No guardado",
+    "showCostMargin": "Mostrar costo y margen",
+    "hideCostMargin": "Ocultar costo y margen",
+    "orgCombobox": {
+      "searchPlaceholder": "Buscar organizaciones…",
+      "noResults": "No hay organizaciones que coincidan.",
+      "capNote": "Se muestran las primeras {{count}} coincidencias: sigue escribiendo para acotar."
+    }
   },
   "bulk": {
     "bulkActionBar": {
@@ -1194,7 +1208,6 @@
     "saved": "Guardado",
     "success": {
       "lineAdded": "Línea agregada",
-      "lineRemoved": "Línea eliminada",
       "notesSaved": "Notas guardadas",
       "termsSaved": "Términos guardados"
     },
@@ -1222,7 +1235,17 @@
     },
     "unapprovedTime": "Las líneas {{count}} hacen referencia a horas no aprobadas. Revisar antes de emitir.",
     "unapprovedTime_one": "{{count}} referencia de línea hora no aprobada. Revisar antes de emitir.",
-    "unapprovedTime_other": "Las líneas {{count}} hacen referencia a horas no aprobadas. Revisar antes de emitir."
+    "unapprovedTime_other": "Las líneas {{count}} hacen referencia a horas no aprobadas. Revisar antes de emitir.",
+    "autosaveHint": "Los cambios se guardan automáticamente. Un contorno ámbar marca una edición sin guardar.",
+    "lastSaved": {
+      "saved": "Guardado a las {{time}}",
+      "saving": "Guardando…"
+    },
+    "undo": {
+      "lineDeleted": "Línea eliminada",
+      "tooLate": "Ya no se puede deshacer: esa línea ya fue eliminada."
+    },
+    "linesScrollAria": "Líneas de la factura: desplácese hacia los lados para ver más columnas"
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1248,10 +1271,13 @@
     "issueSuccess": "Factura emitida",
     "issuing": "Emitiendo…",
     "noVisibleLineHint": "Agregue al menos una línea visible para el cliente para emitir.",
-    "preparing": "Preparando…"
+    "preparing": "Preparando…",
+    "savingHint": "Guardando cambios… Emitir se desbloqueará cuando todo esté guardado.",
+    "savingTitle": "Guardando sus cambios: Emitir se desbloqueará cuando todo esté guardado.",
+    "issueCanceledSaveFailed": "Un cambio no se pudo guardar, por lo que se canceló la emisión. Corrija el campo resaltado e inténtelo de nuevo.",
+    "issueCanceledStillSaving": "Sus cambios aún se están guardando; la emisión se canceló. Inténtelo de nuevo cuando todo esté guardado."
   },
   "invoiceDetail": {
-    "accountingView": "Vista contable (costo, margen, componentes ocultos)",
     "deposit": {
       "duePrefix": "Depósito de",
       "dueSuffix": "vencido — {{paid}} de {{total}} pagado.",
@@ -1272,7 +1298,8 @@
       "price": "Precio",
       "qty": "Cantidad",
       "tax": "Impuesto",
-      "total": "Total"
+      "total": "Total",
+      "allHidden": "Todas las líneas son solo internas. Use “Mostrar costo y margen” para verlas."
     },
     "paymentMethods": {
       "cash": "Efectivo",
@@ -1344,7 +1371,10 @@
       "reissuedSuccess": "Factura anulada y reemitida como borrador",
       "success": "Factura anulada",
       "title": "factura anulada"
-    }
+    },
+    "empty": "Esta factura aún no tiene líneas.",
+    "addContentInEditor": "Agregar líneas en el Editor",
+    "linesScrollAria": "Líneas de la factura: desplácese hacia los lados para ver más columnas"
   },
   "invoiceDocument": {
     "billTo": "Cobrar a",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -795,6 +795,9 @@
         "noTargets": "Agrega una sección de precios y luego mueve estas líneas a ella.",
         "qtyPrice": "{{qty}} × {{price}}",
         "title": "Líneas sin asignar"
+      },
+      "unsavedField": {
+        "lines": "Líneas"
       }
     },
     "actions": {
@@ -864,9 +867,13 @@
       "undoSuccess": "Envío cancelado — la cotización sigue siendo un borrador.",
       "undoTooLate": "Demasiado tarde para deshacer — la propuesta ya se envió.",
       "sendNow": "Enviar ahora",
-      "savingTimeout": "Guardar los cambios está tardando demasiado: revisa tu conexión e inténtalo de nuevo.",
+      "savingTimeout": "Aún se están guardando los cambios: se canceló el envío. Inténtelo de nuevo cuando todo esté guardado.",
       "sendNowCancelError": "No se pudo enviar de inmediato: la propuesta se enviará igualmente según lo programado.",
-      "sendNowAlready": "Ya está en camino: la propuesta se está enviando ahora."
+      "sendNowAlready": "Ya está en camino: la propuesta se está enviando ahora.",
+      "sendCanceledSaveFailed": "Un cambio no se pudo guardar, por lo que se canceló el envío. Corrija el campo resaltado e inténtelo de nuevo.",
+      "sendBlockedUnsaved": "«{{field}}» tiene un cambio sin guardar. Corríjalo allí y luego envíe.",
+      "unsavedHint": "«{{field}}» tiene un cambio sin guardar: enviar se desbloqueará cuando se guarde.",
+      "unsavedTitle": "«{{field}}» tiene un cambio sin guardar: enviar se desbloqueará cuando se guarde."
     },
     "detail": {
       "addContentInEditor": "Agregar contenido en el Editor",
@@ -1172,7 +1179,9 @@
       "manualLine": "linea manual",
       "noCatalogItems": "Sin artículos de catálogo.",
       "searchCatalog": "Buscar catálogo por nombre o SKU",
-      "sourceAria": "Agregar fuente de línea"
+      "sourceAria": "Agregar fuente de línea",
+      "catalogLoadFailed": "No se pudo cargar el catálogo, por lo que no se pueden mostrar artículos.",
+      "retry": "Reintentar"
     },
     "billTo": {
       "addInSettings": "Agregar uno en la configuración de la organización",
@@ -1243,9 +1252,13 @@
     },
     "undo": {
       "lineDeleted": "Línea eliminada",
-      "tooLate": "Ya no se puede deshacer: esa línea ya fue eliminada."
+      "tooLate": "Ya no se puede deshacer: esa línea ya fue eliminada.",
+      "partialFlush": "Se aplicaron {{applied}} eliminación(es); {{failed}} fallaron y se restauraron."
     },
-    "linesScrollAria": "Líneas de la factura: desplácese hacia los lados para ver más columnas"
+    "linesScrollAria": "Líneas de la factura: desplácese hacia los lados para ver más columnas",
+    "unsavedField": {
+      "lines": "Líneas"
+    }
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1275,7 +1288,10 @@
     "savingHint": "Guardando cambios… Emitir se desbloqueará cuando todo esté guardado.",
     "savingTitle": "Guardando sus cambios: Emitir se desbloqueará cuando todo esté guardado.",
     "issueCanceledSaveFailed": "Un cambio no se pudo guardar, por lo que se canceló la emisión. Corrija el campo resaltado e inténtelo de nuevo.",
-    "issueCanceledStillSaving": "Sus cambios aún se están guardando; la emisión se canceló. Inténtelo de nuevo cuando todo esté guardado."
+    "issueCanceledStillSaving": "Sus cambios aún se están guardando; la emisión se canceló. Inténtelo de nuevo cuando todo esté guardado.",
+    "issueBlockedUnsaved": "«{{field}}» tiene un cambio sin guardar. Corríjalo allí y luego emita.",
+    "unsavedHint": "«{{field}}» tiene un cambio sin guardar: emitir se desbloqueará cuando se guarde.",
+    "unsavedTitle": "«{{field}}» tiene un cambio sin guardar: emitir se desbloqueará cuando se guarde."
   },
   "invoiceDetail": {
     "deposit": {

--- a/apps/web/src/locales/fr-CA/billing.json
+++ b/apps/web/src/locales/fr-CA/billing.json
@@ -523,7 +523,8 @@
         "addSome": "Ajoutez-en dans Product Catalog",
         "empty": "Aucun article dans le catalogue.",
         "loadError": "Impossible de charger le catalogue. Rouvrez l'éditeur pour réessayer : vos articles existants sont conservés.",
-        "searchPlaceholder": "Rechercher par nom ou SKU dans le catalogue"
+        "searchPlaceholder": "Rechercher par nom ou SKU dans le catalogue",
+        "capNote": "Affichage des {{count}} premiers articles du catalogue — recherchez pour trouver les autres."
       },
       "categories": {
         "hardware": "Matériel",
@@ -687,7 +688,7 @@
         "labelPlaceholder": "Libellé du tableau (facultatif, ex. Services mensuels)",
         "notTaxable": "Non taxable",
         "qty": "Qté",
-        "recurrence": "Récurrence",
+        "recurrence": "Facturation",
         "scrollAria": "Tableau de prix — faites défiler horizontalement sur écrans étroits pour les totaux et les actions de ligne",
         "showSubtotal": "Afficher la ligne de sous-total",
         "tax": "Taxe",
@@ -794,6 +795,9 @@
         "noTargets": "Ajoutez une section de prix, puis déplacez ces lignes vers celle-ci.",
         "qtyPrice": "{{qty}} × {{price}}",
         "title": "Lignes non affectées"
+      },
+      "unsavedField": {
+        "lines": "Lignes"
       }
     },
     "actions": {
@@ -828,12 +832,12 @@
         "ccToggle": "Cc",
         "includePdfLabel": "Joindre le PDF de la proposition",
         "invalidEmail": "Adresse courriel non valide : {{addresses}}",
-        "message": "Nous enverrons cette proposition par courriel à {{orgName}} et la marquerons Envoyée — {{amount}} dû à l'acceptation. Cette action est irréversible.",
+        "message": "Nous enverrons cette proposition par courriel à {{orgName}} et la marquerons Envoyée — {{amount}} dû à l'acceptation. Vous aurez 30 secondes pour annuler après confirmation.",
         "messageLabel": "Ajouter un message personnel (facultatif)",
         "messagePlaceholder": "Ajoutez une courte note : elle apparaît dans le courriel, au-dessus du lien d'acceptation.",
         "paymentEnabled": "Le paiement en ligne est activé — le client peut payer par carte après acceptation.",
-        "paymentNoteNoStripe": "À l'acceptation, le client n'aura pas d'option de paiement en ligne. Connectez Stripe dans Paramètres → Intégrations pour en proposer une.",
-        "paymentWarningDeposit": "Cette proposition demande un acompte, mais les clients ne peuvent pas encore payer en ligne — connectez Stripe dans Paramètres → Intégrations pour encaisser l'acompte à l'acceptation.",
+        "paymentNoteNoStripe": "À l'acceptation, le client n'aura pas d'option de paiement en ligne. Connectez Stripe dans <integrationsLink>Paramètres → Intégrations</integrationsLink> pour en proposer une.",
+        "paymentWarningDeposit": "Cette proposition demande un acompte, mais les clients ne peuvent pas encore payer en ligne — connectez Stripe dans <integrationsLink>Paramètres → Intégrations</integrationsLink> pour encaisser l'acompte à l'acceptation.",
         "recipientRequired": "Saisissez au moins un destinataire pour envoyer.",
         "signaturePreviewLabel": "Signature (définie dans Paramètres → Image de marque) :",
         "subjectLabel": "Objet",
@@ -843,7 +847,8 @@
         "toLabel": "À",
         "toPlaceholder": "Ajouter un destinataire…",
         "tooManyRecipients": "Utilisez au maximum {{max}} adresses.",
-        "zeroTotalWarning": "Ce devis totalise $0.00 — vérifiez que ses lignes sont tarifées avant l'envoi."
+        "zeroTotalWarning": "Ce devis totalise $0.00 — vérifiez que ses lignes sont tarifées avant l'envoi.",
+        "noBillingContactHint": "Aucun contact de facturation n'est enregistré pour cette organisation — saisissez une adresse courriel ou ajoutez-en une dans les <orgLink>paramètres de l'organisation</orgLink>."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposition marquée comme Envoyée, mais aucun courriel n'a été remis — {{orgName}} n'a pas d'adresse courriel de contact de facturation. Ajoutez-en une dans les paramètres de l'organisation ou partagez le lien d'acceptation manuellement.",
@@ -860,7 +865,15 @@
       "undoError": "Impossible d'annuler l'envoi.",
       "undoSend": "Annuler l'envoi",
       "undoSuccess": "Envoi annulé — le devis reste un brouillon.",
-      "undoTooLate": "Trop tard pour annuler — la proposition a déjà été envoyée."
+      "undoTooLate": "Trop tard pour annuler — la proposition a déjà été envoyée.",
+      "sendNow": "Envoyer maintenant",
+      "savingTimeout": "Vos modifications sont encore en cours d'enregistrement — l'envoi a été annulé. Réessayez une fois tout enregistré.",
+      "sendNowCancelError": "Envoi immédiat impossible — la proposition sera tout de même envoyée comme prévu.",
+      "sendNowAlready": "Déjà en route — la proposition est en cours d'envoi.",
+      "sendCanceledSaveFailed": "Une modification n'a pas pu être enregistrée, l'envoi a donc été annulé. Corrigez le champ signalé et réessayez.",
+      "sendBlockedUnsaved": "« {{field}} » contient une modification non enregistrée. Corrigez-la, puis envoyez.",
+      "unsavedHint": "« {{field}} » contient une modification non enregistrée — l'envoi sera disponible une fois enregistrée.",
+      "unsavedTitle": "« {{field}} » contient une modification non enregistrée — l'envoi sera disponible une fois enregistrée."
     },
     "detail": {
       "addContentInEditor": "Ajouter du contenu dans l'Éditeur",
@@ -889,7 +902,7 @@
         "item": "Article",
         "noLines": "Aucune ligne dans ce tableau.",
         "qty": "Qté",
-        "recurrence": "Récurrence",
+        "recurrence": "Facturation",
         "tax": "Taxe",
         "total": "Total",
         "unitPrice": "Prix unitaire"
@@ -1111,7 +1124,8 @@
         "editor": "Éditeur",
         "preview": "Aperçu",
         "detail": "Détail"
-      }
+      },
+      "loading": "Chargement du devis…"
     }
   },
   "billingUi": {
@@ -1130,7 +1144,14 @@
       "perMonth": "/mois",
       "perYear": "/an"
     },
-    "unsaved": "Non enregistré"
+    "unsaved": "Non enregistré",
+    "showCostMargin": "Afficher coût et marge",
+    "hideCostMargin": "Masquer coût et marge",
+    "orgCombobox": {
+      "searchPlaceholder": "Rechercher des organisations…",
+      "noResults": "Aucune organisation correspondante.",
+      "capNote": "Affichage des {{count}} premières correspondances — continuez à taper pour affiner."
+    }
   },
   "bulk": {
     "bulkActionBar": {
@@ -1158,7 +1179,9 @@
       "manualLine": "Ligne manuelle",
       "noCatalogItems": "Aucun article dans le catalogue.",
       "searchCatalog": "Rechercher par nom ou SKU dans le catalogue",
-      "sourceAria": "Source d'ajout de ligne"
+      "sourceAria": "Source d'ajout de ligne",
+      "catalogLoadFailed": "Le catalogue n'a pas pu être chargé, aucun article ne peut donc être affiché.",
+      "retry": "Réessayer"
     },
     "billTo": {
       "addInSettings": "Ajoutez-en un dans les paramètres de l'organisation",
@@ -1194,7 +1217,6 @@
     "saved": "Enregistré",
     "success": {
       "lineAdded": "Ligne ajoutée",
-      "lineRemoved": "Ligne supprimée",
       "notesSaved": "Notes enregistrées",
       "termsSaved": "Conditions enregistrées"
     },
@@ -1222,7 +1244,21 @@
     },
     "unapprovedTime": "{{count}} lignes référencent du temps non approuvé. Vérifiez avant émission.",
     "unapprovedTime_one": "{{count}} ligne référence du temps non approuvé. Vérifiez avant émission.",
-    "unapprovedTime_other": "{{count}} lignes référencent du temps non approuvé. Vérifiez avant émission."
+    "unapprovedTime_other": "{{count}} lignes référencent du temps non approuvé. Vérifiez avant émission.",
+    "autosaveHint": "Les modifications sont enregistrées automatiquement. Un contour ambre signale une modification non enregistrée.",
+    "lastSaved": {
+      "saved": "Enregistré à {{time}}",
+      "saving": "Enregistrement…"
+    },
+    "undo": {
+      "lineDeleted": "Ligne supprimée",
+      "tooLate": "Trop tard pour annuler — cette ligne a déjà été supprimée.",
+      "partialFlush": "{{applied}} suppression(s) de ligne appliquée(s) ; {{failed}} ont échoué et ont été restaurées."
+    },
+    "linesScrollAria": "Lignes de la facture — faites défiler horizontalement pour plus de colonnes",
+    "unsavedField": {
+      "lines": "Lignes"
+    }
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1248,10 +1284,16 @@
     "issueSuccess": "Facture émise",
     "issuing": "Émission…",
     "noVisibleLineHint": "Ajoutez au moins une ligne visible par le client pour émettre.",
-    "preparing": "Préparation…"
+    "preparing": "Préparation…",
+    "savingHint": "Enregistrement des modifications… L'émission sera disponible une fois tout enregistré.",
+    "savingTitle": "Enregistrement de vos modifications — l'émission sera disponible une fois tout enregistré.",
+    "issueCanceledSaveFailed": "Une modification n'a pas pu être enregistrée, l'émission a donc été annulée. Corrigez le champ signalé et réessayez.",
+    "issueCanceledStillSaving": "Vos modifications sont toujours en cours d'enregistrement — l'émission a été annulée. Réessayez une fois tout enregistré.",
+    "issueBlockedUnsaved": "« {{field}} » contient une modification non enregistrée. Corrigez-la, puis émettez.",
+    "unsavedHint": "« {{field}} » contient une modification non enregistrée — l'émission sera disponible une fois enregistrée.",
+    "unsavedTitle": "« {{field}} » contient une modification non enregistrée — l'émission sera disponible une fois enregistrée."
   },
   "invoiceDetail": {
-    "accountingView": "Vue comptable (coût, marge, composants masqués)",
     "deposit": {
       "duePrefix": "Acompte de",
       "dueSuffix": "dû — {{paid}} sur {{total}} payé.",
@@ -1272,7 +1314,8 @@
       "price": "Prix",
       "qty": "Qté",
       "tax": "Taxe",
-      "total": "Total"
+      "total": "Total",
+      "allHidden": "Toutes les lignes sont internes uniquement. Utilisez « Afficher coût et marge » pour les voir."
     },
     "paymentMethods": {
       "cash": "Espèces",
@@ -1344,7 +1387,10 @@
       "reissuedSuccess": "Facture annulée et réémise en brouillon",
       "success": "Facture annulée",
       "title": "Annuler la facture"
-    }
+    },
+    "empty": "Cette facture n'a encore aucune ligne.",
+    "addContentInEditor": "Ajouter des lignes dans l'Éditeur",
+    "linesScrollAria": "Lignes de la facture — faites défiler horizontalement pour plus de colonnes"
   },
   "invoiceDocument": {
     "billTo": "Facturer à",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -795,6 +795,9 @@
         "noTargets": "Ajoutez une section tarifaire, puis déplacez-y ces lignes.",
         "qtyPrice": "{{qty}} × {{price}}",
         "title": "Lignes non affectées"
+      },
+      "unsavedField": {
+        "lines": "Lignes"
       }
     },
     "actions": {
@@ -864,9 +867,13 @@
       "undoSuccess": "Envoi annulé — le devis reste un brouillon.",
       "undoTooLate": "Trop tard pour annuler — la proposition a déjà été envoyée.",
       "sendNow": "Envoyer maintenant",
-      "savingTimeout": "L'enregistrement des modifications prend trop de temps — vérifiez votre connexion et réessayez.",
+      "savingTimeout": "Vos modifications sont encore en cours d’enregistrement — l’envoi a été annulé. Réessayez une fois tout enregistré.",
       "sendNowCancelError": "Envoi immédiat impossible — la proposition sera tout de même envoyée comme prévu.",
-      "sendNowAlready": "Déjà en route — la proposition est en cours d'envoi."
+      "sendNowAlready": "Déjà en route — la proposition est en cours d'envoi.",
+      "sendCanceledSaveFailed": "Une modification n’a pas pu être enregistrée, l’envoi a donc été annulé. Corrigez le champ signalé et réessayez.",
+      "sendBlockedUnsaved": "« {{field}} » contient une modification non enregistrée. Corrigez-la puis envoyez.",
+      "unsavedHint": "« {{field}} » contient une modification non enregistrée — l’envoi sera disponible une fois enregistrée.",
+      "unsavedTitle": "« {{field}} » contient une modification non enregistrée — l’envoi sera disponible une fois enregistrée."
     },
     "detail": {
       "addContentInEditor": "Ajouter du contenu dans l'Éditeur",
@@ -1172,7 +1179,9 @@
       "manualLine": "Ligne manuelle",
       "noCatalogItems": "Aucun article dans le catalogue.",
       "searchCatalog": "Rechercher par nom ou SKU dans le catalogue",
-      "sourceAria": "Source d'ajout de ligne"
+      "sourceAria": "Source d'ajout de ligne",
+      "catalogLoadFailed": "Le catalogue n’a pas pu être chargé, aucun article ne peut donc être affiché.",
+      "retry": "Réessayer"
     },
     "billTo": {
       "addInSettings": "Ajoutez-en un dans les paramètres de l'organisation",
@@ -1243,9 +1252,13 @@
     },
     "undo": {
       "lineDeleted": "Ligne supprimée",
-      "tooLate": "Trop tard pour annuler — cette ligne a déjà été supprimée."
+      "tooLate": "Trop tard pour annuler — cette ligne a déjà été supprimée.",
+      "partialFlush": "{{applied}} suppression(s) appliquée(s) ; {{failed}} ont échoué et ont été restaurées."
     },
-    "linesScrollAria": "Lignes de la facture — faites défiler horizontalement pour plus de colonnes"
+    "linesScrollAria": "Lignes de la facture — faites défiler horizontalement pour plus de colonnes",
+    "unsavedField": {
+      "lines": "Lignes"
+    }
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1275,7 +1288,10 @@
     "savingHint": "Enregistrement des modifications… L'émission sera disponible une fois tout enregistré.",
     "savingTitle": "Enregistrement de vos modifications — l'émission sera disponible une fois tout enregistré.",
     "issueCanceledSaveFailed": "Une modification n'a pas pu être enregistrée, l'émission a donc été annulée. Corrigez le champ signalé et réessayez.",
-    "issueCanceledStillSaving": "Vos modifications sont toujours en cours d'enregistrement — l'émission a été annulée. Réessayez une fois tout enregistré."
+    "issueCanceledStillSaving": "Vos modifications sont toujours en cours d'enregistrement — l'émission a été annulée. Réessayez une fois tout enregistré.",
+    "issueBlockedUnsaved": "« {{field}} » contient une modification non enregistrée. Corrigez-la puis émettez.",
+    "unsavedHint": "« {{field}} » contient une modification non enregistrée — l’émission sera disponible une fois enregistrée.",
+    "unsavedTitle": "« {{field}} » contient une modification non enregistrée — l’émission sera disponible une fois enregistrée."
   },
   "invoiceDetail": {
     "deposit": {

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -543,7 +543,8 @@
         "addSome": "Ajoutez-en dans Product Catalog",
         "empty": "Aucun article dans le catalogue.",
         "loadError": "Impossible de charger le catalogue. Rouvrez l'éditeur pour réessayer : vos articles existants sont conservés.",
-        "searchPlaceholder": "Rechercher par nom ou SKU dans le catalogue"
+        "searchPlaceholder": "Rechercher par nom ou SKU dans le catalogue",
+        "capNote": "Affichage des {{count}} premiers articles du catalogue — recherchez pour trouver les autres."
       },
       "categories": {
         "hardware": "Matériel",
@@ -719,7 +720,7 @@
         "labelPlaceholder": "Libellé du tableau (facultatif, ex. Services mensuels)",
         "notTaxable": "Non taxable",
         "qty": "Qté",
-        "recurrence": "Récurrence",
+        "recurrence": "Facturation",
         "scrollAria": "Tableau de prix — faites défiler horizontalement sur écrans étroits pour les totaux et les actions de ligne ; pour les sections longues, défilement vertical avec l'en-tête fixe",
         "showSubtotal": "Afficher la ligne de sous-total",
         "tax": "Taxe",
@@ -828,12 +829,12 @@
         "ccToggle": "Cc",
         "includePdfLabel": "Joindre le PDF de la proposition",
         "invalidEmail": "Adresse e-mail non valide : {{addresses}}",
-        "message": "Nous enverrons cette proposition par e-mail à {{orgName}} et la marquerons Envoyée — {{amount}} dû à l'acceptation. Cette action est irréversible.",
+        "message": "Nous enverrons cette proposition par e-mail à {{orgName}} et la marquerons Envoyée — {{amount}} dû à l'acceptation. Vous aurez 30 secondes pour annuler après confirmation.",
         "messageLabel": "Ajouter un message personnel (facultatif)",
         "messagePlaceholder": "Ajoutez une courte note : elle apparaît dans l'e-mail, au-dessus du lien d'acceptation.",
         "paymentEnabled": "Le paiement en ligne est activé — le client peut payer par carte après acceptation.",
-        "paymentNoteNoStripe": "À l'acceptation, le client n'aura pas d'option de paiement en ligne. Connectez Stripe dans Paramètres → Intégrations pour en proposer une.",
-        "paymentWarningDeposit": "Cette proposition demande un acompte, mais les clients ne peuvent pas encore payer en ligne — connectez Stripe dans Paramètres → Intégrations pour encaisser l'acompte à l'acceptation.",
+        "paymentNoteNoStripe": "À l'acceptation, le client n'aura pas d'option de paiement en ligne. Connectez Stripe dans <integrationsLink>Paramètres → Intégrations</integrationsLink> pour en proposer une.",
+        "paymentWarningDeposit": "Cette proposition demande un acompte, mais les clients ne peuvent pas encore payer en ligne — connectez Stripe dans <integrationsLink>Paramètres → Intégrations</integrationsLink> pour encaisser l'acompte à l'acceptation.",
         "recipientRequired": "Saisissez au moins un destinataire pour envoyer.",
         "signaturePreviewLabel": "Signature (définie dans Paramètres → Image de marque) :",
         "subjectLabel": "Objet",
@@ -843,7 +844,8 @@
         "toLabel": "À",
         "toPlaceholder": "Ajouter un destinataire…",
         "tooManyRecipients": "Utilisez au maximum {{max}} adresses.",
-        "zeroTotalWarning": "Ce devis totalise $0.00 — vérifiez que ses lignes sont tarifées avant l'envoi."
+        "zeroTotalWarning": "Ce devis totalise $0.00 — vérifiez que ses lignes sont tarifées avant l'envoi.",
+        "noBillingContactHint": "Aucun contact de facturation n'est enregistré pour cette organisation — saisissez un e-mail ou ajoutez-en un dans les <orgLink>paramètres de l'organisation</orgLink>."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposition marquée comme Envoyée, mais aucun e-mail n'a été remis — {{orgName}} n'a pas d'adresse e-mail de contact de facturation. Ajoutez-en une dans les paramètres de l'organisation ou partagez le lien d'acceptation manuellement.",
@@ -860,7 +862,11 @@
       "undoError": "Impossible d'annuler l'envoi.",
       "undoSend": "Annuler l'envoi",
       "undoSuccess": "Envoi annulé — le devis reste un brouillon.",
-      "undoTooLate": "Trop tard pour annuler — la proposition a déjà été envoyée."
+      "undoTooLate": "Trop tard pour annuler — la proposition a déjà été envoyée.",
+      "sendNow": "Envoyer maintenant",
+      "savingTimeout": "L'enregistrement des modifications prend trop de temps — vérifiez votre connexion et réessayez.",
+      "sendNowCancelError": "Envoi immédiat impossible — la proposition sera tout de même envoyée comme prévu.",
+      "sendNowAlready": "Déjà en route — la proposition est en cours d'envoi."
     },
     "detail": {
       "addContentInEditor": "Ajouter du contenu dans l'Éditeur",
@@ -889,7 +895,7 @@
         "item": "Article",
         "noLines": "Aucune ligne dans ce tableau.",
         "qty": "Qté",
-        "recurrence": "Récurrence",
+        "recurrence": "Facturation",
         "tax": "Taxe",
         "total": "Total",
         "unitPrice": "Prix unitaire"
@@ -1111,7 +1117,8 @@
         "editor": "Éditeur",
         "preview": "Aperçu",
         "detail": "Détails"
-      }
+      },
+      "loading": "Chargement du devis…"
     }
   },
   "billingUi": {
@@ -1130,7 +1137,14 @@
       "perMonth": "/mois",
       "perYear": "/an"
     },
-    "unsaved": "Non enregistré"
+    "unsaved": "Non enregistré",
+    "showCostMargin": "Afficher coût et marge",
+    "hideCostMargin": "Masquer coût et marge",
+    "orgCombobox": {
+      "searchPlaceholder": "Rechercher des organisations…",
+      "noResults": "Aucune organisation correspondante.",
+      "capNote": "Affichage des {{count}} premières correspondances — continuez à taper pour affiner."
+    }
   },
   "bulk": {
     "bulkActionBar": {
@@ -1194,7 +1208,6 @@
     "saved": "Enregistré",
     "success": {
       "lineAdded": "Ligne ajoutée",
-      "lineRemoved": "Ligne supprimée",
       "notesSaved": "Notes enregistrées",
       "termsSaved": "Conditions enregistrées"
     },
@@ -1222,7 +1235,17 @@
     },
     "unapprovedTime": "{{count}} lignes référencent du temps non approuvé. Vérifiez avant émission.",
     "unapprovedTime_one": "{{count}} ligne référence du temps non approuvé. Vérifiez avant émission.",
-    "unapprovedTime_other": "{{count}} lignes référencent du temps non approuvé. Vérifiez avant émission."
+    "unapprovedTime_other": "{{count}} lignes référencent du temps non approuvé. Vérifiez avant émission.",
+    "autosaveHint": "Les modifications sont enregistrées automatiquement. Un contour ambre signale une modification non enregistrée.",
+    "lastSaved": {
+      "saved": "Enregistré à {{time}}",
+      "saving": "Enregistrement…"
+    },
+    "undo": {
+      "lineDeleted": "Ligne supprimée",
+      "tooLate": "Trop tard pour annuler — cette ligne a déjà été supprimée."
+    },
+    "linesScrollAria": "Lignes de la facture — faites défiler horizontalement pour plus de colonnes"
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1248,10 +1271,13 @@
     "issueSuccess": "Facture émise",
     "issuing": "Émission…",
     "noVisibleLineHint": "Ajoutez au moins une ligne visible par le client pour émettre.",
-    "preparing": "Préparation…"
+    "preparing": "Préparation…",
+    "savingHint": "Enregistrement des modifications… L'émission sera disponible une fois tout enregistré.",
+    "savingTitle": "Enregistrement de vos modifications — l'émission sera disponible une fois tout enregistré.",
+    "issueCanceledSaveFailed": "Une modification n'a pas pu être enregistrée, l'émission a donc été annulée. Corrigez le champ signalé et réessayez.",
+    "issueCanceledStillSaving": "Vos modifications sont toujours en cours d'enregistrement — l'émission a été annulée. Réessayez une fois tout enregistré."
   },
   "invoiceDetail": {
-    "accountingView": "Vue comptable (coût, marge, composants masqués)",
     "deposit": {
       "duePrefix": "Acompte de",
       "dueSuffix": "dû — {{paid}} sur {{total}} payé.",
@@ -1272,7 +1298,8 @@
       "price": "Prix",
       "qty": "Qté",
       "tax": "Taxe",
-      "total": "Total"
+      "total": "Total",
+      "allHidden": "Toutes les lignes sont internes uniquement. Utilisez « Afficher coût et marge » pour les voir."
     },
     "paymentMethods": {
       "cash": "Espèces",
@@ -1344,7 +1371,10 @@
       "reissuedSuccess": "Facture annulée et réémise en brouillon",
       "success": "Facture annulée",
       "title": "Annuler la facture"
-    }
+    },
+    "empty": "Cette facture n'a encore aucune ligne.",
+    "addContentInEditor": "Ajouter des lignes dans l'Éditeur",
+    "linesScrollAria": "Lignes de la facture — faites défiler horizontalement pour plus de colonnes"
   },
   "invoiceDocument": {
     "billTo": "Facturer à",

--- a/apps/web/src/locales/it-IT/billing.json
+++ b/apps/web/src/locales/it-IT/billing.json
@@ -523,7 +523,8 @@
         "addSome": "Aggiungine alcuni nel Catalogo prodotti",
         "empty": "Nessun elemento di catalogo.",
         "loadError": "Impossibile caricare il catalogo. Riapri l'editor per riprovare: gli elementi esistenti sono al sicuro.",
-        "searchPlaceholder": "Cerca nel catalogo per nome o SKU"
+        "searchPlaceholder": "Cerca nel catalogo per nome o SKU",
+        "capNote": "Vengono mostrati i primi {{count}} articoli del catalogo — cerca per trovare gli altri."
       },
       "categories": {
         "hardware": "Hardware",
@@ -687,7 +688,7 @@
         "labelPlaceholder": "Etichetta tabella (facoltativa, es. Servizi mensili)",
         "notTaxable": "Non imponibile",
         "qty": "Qtà",
-        "recurrence": "Ricorrenza",
+        "recurrence": "Fatturazione",
         "scrollAria": "Tabella prezzi — scorri lateralmente su schermi stretti per totali e azioni riga",
         "showSubtotal": "Mostra riga subtotale",
         "tax": "Imposta",
@@ -794,6 +795,9 @@
         "noTargets": "Aggiungi una tabella prezzi, poi sposta queste righe al suo interno.",
         "qtyPrice": "{{qty}} × {{price}}",
         "title": "Righe non assegnate"
+      },
+      "unsavedField": {
+        "lines": "Righe"
       }
     },
     "actions": {
@@ -828,12 +832,12 @@
         "ccToggle": "Cc",
         "includePdfLabel": "Allega il PDF della proposta",
         "invalidEmail": "Indirizzo email non valido: {{addresses}}",
-        "message": "Invieremo questa proposta via email a {{orgName}} e la contrassegneremo come Inviata — {{amount}} dovuto all'accettazione. L'operazione non può essere annullata.",
+        "message": "Invieremo questa proposta via email a {{orgName}} e la contrassegneremo come Inviata — {{amount}} dovuto all'accettazione. Avrai 30 secondi per annullare dopo la conferma.",
         "messageLabel": "Aggiungi un messaggio personale (facoltativo)",
         "messagePlaceholder": "Includi una breve nota: apparirà nell'email sopra il link di accettazione.",
         "paymentEnabled": "Il pagamento online è abilitato: il cliente può pagare con carta dopo l'accettazione.",
-        "paymentNoteNoStripe": "Quando il cliente accetta, non avrà un'opzione di pagamento online. Collega Stripe in Impostazioni → Integrazioni per offrirne una.",
-        "paymentWarningDeposit": "Questa proposta richiede un acconto, ma i clienti non possono ancora pagare online: collega Stripe in Impostazioni → Integrazioni così l'acconto può essere incassato all'accettazione.",
+        "paymentNoteNoStripe": "Quando il cliente accetta, non avrà un'opzione di pagamento online. Collega Stripe in <integrationsLink>Impostazioni → Integrazioni</integrationsLink> per offrirne una.",
+        "paymentWarningDeposit": "Questa proposta richiede un acconto, ma i clienti non possono ancora pagare online: collega Stripe in <integrationsLink>Impostazioni → Integrazioni</integrationsLink> così l'acconto può essere incassato all'accettazione.",
         "recipientRequired": "Inserisci almeno un destinatario per l'invio.",
         "signaturePreviewLabel": "Firma (impostata in Impostazioni → Branding):",
         "subjectLabel": "Oggetto",
@@ -843,7 +847,8 @@
         "toLabel": "A",
         "toPlaceholder": "Aggiungi destinatario…",
         "tooManyRecipients": "Usa al massimo {{max}} indirizzi.",
-        "zeroTotalWarning": "Il totale di questo preventivo è $0.00: verifica che gli elementi abbiano un prezzo prima dell'invio."
+        "zeroTotalWarning": "Il totale di questo preventivo è $0.00: verifica che gli elementi abbiano un prezzo prima dell'invio.",
+        "noBillingContactHint": "Nessun contatto di fatturazione è salvato per questa organizzazione — inserisci un'email oppure aggiungine uno nelle <orgLink>impostazioni dell'organizzazione</orgLink>."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposta contrassegnata come Inviata, ma nessuna email è stata consegnata: {{orgName}} non ha un'email di contatto per la fatturazione. Aggiungine una nelle impostazioni dell'organizzazione oppure condividi manualmente il link di accettazione.",
@@ -860,7 +865,15 @@
       "undoError": "Impossibile annullare l'invio.",
       "undoSend": "Annulla invio",
       "undoSuccess": "Invio annullato: il preventivo è ancora una bozza.",
-      "undoTooLate": "Troppo tardi per annullare: la proposta è già stata inviata."
+      "undoTooLate": "Troppo tardi per annullare: la proposta è già stata inviata.",
+      "sendNow": "Invia ora",
+      "savingTimeout": "Le modifiche sono ancora in fase di salvataggio — l'invio è stato annullato. Riprova quando tutto è salvato.",
+      "sendNowCancelError": "Invio immediato non riuscito — la proposta verrà comunque inviata come pianificato.",
+      "sendNowAlready": "Già in viaggio — la proposta è in fase di invio.",
+      "sendCanceledSaveFailed": "Una modifica non è stata salvata, quindi l'invio è stato annullato. Correggi il campo evidenziato e riprova.",
+      "sendBlockedUnsaved": "\"{{field}}\" contiene una modifica non salvata. Correggila lì, poi invia.",
+      "unsavedHint": "\"{{field}}\" contiene una modifica non salvata — l'invio si sblocca una volta salvata.",
+      "unsavedTitle": "\"{{field}}\" contiene una modifica non salvata — l'invio si sblocca una volta salvata."
     },
     "detail": {
       "addContentInEditor": "Aggiungi contenuto nell'Editor",
@@ -889,7 +902,7 @@
         "item": "Elemento",
         "noLines": "Nessuna riga in questa tabella.",
         "qty": "Qtà",
-        "recurrence": "Ricorrenza",
+        "recurrence": "Fatturazione",
         "tax": "Imposta",
         "total": "Totale",
         "unitPrice": "Prezzo unitario"
@@ -1111,7 +1124,8 @@
         "editor": "Editor",
         "preview": "Anteprima",
         "detail": "Dettaglio"
-      }
+      },
+      "loading": "Caricamento del preventivo…"
     }
   },
   "billingUi": {
@@ -1130,7 +1144,14 @@
       "perMonth": "/mese",
       "perYear": "/anno"
     },
-    "unsaved": "Non salvato"
+    "unsaved": "Non salvato",
+    "showCostMargin": "Mostra costo e margine",
+    "hideCostMargin": "Nascondi costo e margine",
+    "orgCombobox": {
+      "searchPlaceholder": "Cerca organizzazioni…",
+      "noResults": "Nessuna organizzazione corrispondente.",
+      "capNote": "Vengono mostrate le prime {{count}} corrispondenze — continua a digitare per restringere."
+    }
   },
   "bulk": {
     "bulkActionBar": {
@@ -1158,7 +1179,9 @@
       "manualLine": "Riga manuale",
       "noCatalogItems": "Nessun elemento di catalogo.",
       "searchCatalog": "Cerca nel catalogo per nome o SKU",
-      "sourceAria": "Origine aggiunta riga"
+      "sourceAria": "Origine aggiunta riga",
+      "catalogLoadFailed": "Il catalogo non è stato caricato, quindi non è possibile mostrare alcun articolo.",
+      "retry": "Riprova"
     },
     "billTo": {
       "addInSettings": "Aggiungine uno nelle impostazioni dell'organizzazione",
@@ -1194,7 +1217,6 @@
     "saved": "Salvato",
     "success": {
       "lineAdded": "Riga aggiunta",
-      "lineRemoved": "Riga rimossa",
       "notesSaved": "Note salvate",
       "termsSaved": "Termini salvati"
     },
@@ -1222,7 +1244,21 @@
     },
     "unapprovedTime": "{{count}} righe fanno riferimento a tempo non approvato. Rivedi prima dell'emissione.",
     "unapprovedTime_one": "{{count}} riga fa riferimento a tempo non approvato. Rivedi prima dell'emissione.",
-    "unapprovedTime_other": "{{count}} righe fanno riferimento a tempo non approvato. Rivedi prima dell'emissione."
+    "unapprovedTime_other": "{{count}} righe fanno riferimento a tempo non approvato. Rivedi prima dell'emissione.",
+    "autosaveHint": "Le modifiche vengono salvate automaticamente. Un contorno ambra segnala una modifica non salvata.",
+    "lastSaved": {
+      "saved": "Salvato {{time}}",
+      "saving": "Salvataggio…"
+    },
+    "undo": {
+      "lineDeleted": "Riga eliminata",
+      "tooLate": "Troppo tardi per annullare — quella riga è già stata eliminata.",
+      "partialFlush": "{{applied}} eliminazione/i di riga applicata/e; {{failed}} non riuscite e ripristinate."
+    },
+    "linesScrollAria": "Righe della fattura — scorri lateralmente per altre colonne",
+    "unsavedField": {
+      "lines": "Righe"
+    }
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1248,10 +1284,16 @@
     "issueSuccess": "Fattura emessa",
     "issuing": "Emissione…",
     "noVisibleLineHint": "Aggiungi almeno una riga visibile al cliente per emettere.",
-    "preparing": "Preparazione…"
+    "preparing": "Preparazione…",
+    "savingHint": "Salvataggio delle modifiche… L'emissione si sblocca quando tutto è salvato.",
+    "savingTitle": "Salvataggio delle modifiche — l'emissione si sblocca quando tutto è salvato.",
+    "issueCanceledSaveFailed": "Una modifica non è stata salvata, quindi l'emissione è stata annullata. Correggi il campo evidenziato e riprova.",
+    "issueCanceledStillSaving": "Le modifiche sono ancora in fase di salvataggio — l'emissione è stata annullata. Riprova quando tutto è salvato.",
+    "issueBlockedUnsaved": "\"{{field}}\" contiene una modifica non salvata. Correggila lì, poi emetti.",
+    "unsavedHint": "\"{{field}}\" contiene una modifica non salvata — l'emissione si sblocca una volta salvata.",
+    "unsavedTitle": "\"{{field}}\" contiene una modifica non salvata — l'emissione si sblocca una volta salvata."
   },
   "invoiceDetail": {
-    "accountingView": "Vista contabile (costo, margine, componenti nascosti)",
     "deposit": {
       "duePrefix": "Acconto di",
       "dueSuffix": "dovuto — {{paid}} di {{total}} pagati.",
@@ -1272,7 +1314,8 @@
       "price": "Prezzo",
       "qty": "Qtà",
       "tax": "Imposta",
-      "total": "Totale"
+      "total": "Totale",
+      "allHidden": "Tutte le righe sono solo interne. Usa \"Mostra costo e margine\" per vederle."
     },
     "paymentMethods": {
       "cash": "Contanti",
@@ -1344,7 +1387,10 @@
       "reissuedSuccess": "Fattura stornata e riemessa come bozza",
       "success": "Fattura stornata",
       "title": "Storna fattura"
-    }
+    },
+    "empty": "Questa fattura non ha ancora righe.",
+    "addContentInEditor": "Aggiungi righe nell'Editor",
+    "linesScrollAria": "Righe della fattura — scorri lateralmente per altre colonne"
   },
   "invoiceDocument": {
     "billTo": "Fattura a",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -543,7 +543,8 @@
         "addSome": "Adicione alguns no Catálogo de Produtos",
         "empty": "Nenhum item de catálogo.",
         "loadError": "Não foi possível carregar o catálogo. Reabra o editor para tentar novamente — seus itens existentes estão seguros.",
-        "searchPlaceholder": "Pesquisar catálogo por nome ou SKU"
+        "searchPlaceholder": "Pesquisar catálogo por nome ou SKU",
+        "capNote": "Mostrando os primeiros {{count}} itens do catálogo — pesquise para encontrar o restante."
       },
       "categories": {
         "hardware": "Hardware",
@@ -719,7 +720,7 @@
         "labelPlaceholder": "Rótulo da tabela (opcional, ex.: Serviços mensais)",
         "notTaxable": "Não tributável",
         "qty": "Qtd.",
-        "recurrence": "Recorrência",
+        "recurrence": "Cobrança",
         "scrollAria": "Tabela de preços — role lateralmente em telas estreitas para ver totais e ações da linha; em seções longas, role verticalmente com o cabeçalho fixo",
         "showSubtotal": "Mostrar linha de subtotal",
         "tax": "Imposto",
@@ -828,12 +829,12 @@
         "ccToggle": "Cc",
         "includePdfLabel": "Anexar o PDF da proposta",
         "invalidEmail": "Endereço de e-mail inválido: {{addresses}}",
-        "message": "Enviaremos esta proposta por e-mail para {{orgName}} e a marcaremos como Enviada — {{amount}} devidos na aceitação. Não é possível desfazer esta ação.",
+        "message": "Enviaremos esta proposta por e-mail para {{orgName}} e a marcaremos como Enviada — {{amount}} devidos na aceitação. Você terá 30 segundos para desfazer após confirmar.",
         "messageLabel": "Adicionar uma mensagem pessoal (opcional)",
         "messagePlaceholder": "Inclua uma breve nota — ela aparece no e-mail, acima do link de aceitação.",
         "paymentEnabled": "O pagamento on-line está ativado — o cliente pode pagar com cartão após aceitar.",
-        "paymentNoteNoStripe": "Quando o cliente aceitar, não haverá opção de pagamento on-line. Conecte o Stripe em Configurações → Integrações para oferecê-la.",
-        "paymentWarningDeposit": "Esta proposta pede um depósito, mas os clientes ainda não podem pagar on-line — conecte o Stripe em Configurações → Integrações para cobrar o depósito na aceitação.",
+        "paymentNoteNoStripe": "Quando o cliente aceitar, não haverá opção de pagamento on-line. Conecte o Stripe em <integrationsLink>Configurações → Integrações</integrationsLink> para oferecê-la.",
+        "paymentWarningDeposit": "Esta proposta pede um depósito, mas os clientes ainda não podem pagar on-line — conecte o Stripe em <integrationsLink>Configurações → Integrações</integrationsLink> para cobrar o depósito na aceitação.",
         "recipientRequired": "Informe pelo menos um destinatário para enviar.",
         "signaturePreviewLabel": "Assinatura (definida em Configurações → Marca):",
         "subjectLabel": "Assunto",
@@ -843,7 +844,8 @@
         "toLabel": "Para",
         "toPlaceholder": "Adicionar destinatário…",
         "tooManyRecipients": "Use no máximo {{max}} endereços.",
-        "zeroTotalWarning": "Este orçamento totaliza $0.00 — verifique se os itens têm preço antes de enviar."
+        "zeroTotalWarning": "Este orçamento totaliza $0.00 — verifique se os itens têm preço antes de enviar.",
+        "noBillingContactHint": "Esta organização não tem um contato de cobrança salvo — digite um e-mail ou adicione um nas <orgLink>configurações da organização</orgLink>."
       },
       "sendEmailWarning": {
         "noBillingContact": "Proposta marcada como Enviada, mas nenhum e-mail foi entregue — {{orgName}} não tem e-mail de contato de cobrança. Adicione um nas configurações da organização ou compartilhe o link de aceitação manualmente.",
@@ -860,7 +862,11 @@
       "undoError": "Não foi possível cancelar o envio.",
       "undoSend": "Desfazer envio",
       "undoSuccess": "Envio cancelado — o orçamento continua um rascunho.",
-      "undoTooLate": "Tarde demais para desfazer — a proposta já foi enviada."
+      "undoTooLate": "Tarde demais para desfazer — a proposta já foi enviada.",
+      "sendNow": "Enviar agora",
+      "savingTimeout": "Salvar as alterações está demorando demais — verifique sua conexão e tente novamente.",
+      "sendNowCancelError": "Não foi possível enviar imediatamente — a proposta ainda será enviada conforme agendado.",
+      "sendNowAlready": "Já está a caminho — a proposta está sendo enviada agora."
     },
     "detail": {
       "addContentInEditor": "Adicionar conteúdo no Editor",
@@ -889,7 +895,7 @@
         "item": "Item",
         "noLines": "Nenhuma linha nesta tabela.",
         "qty": "Qtd.",
-        "recurrence": "Recorrência",
+        "recurrence": "Cobrança",
         "tax": "Imposto",
         "total": "Total",
         "unitPrice": "Preço unitário"
@@ -1102,7 +1108,8 @@
         "editor": "Editor",
         "preview": "Visualização",
         "detail": "Detalhes"
-      }
+      },
+      "loading": "Carregando orçamento…"
     },
     "status": {
       "draft": "Rascunho",
@@ -1130,7 +1137,14 @@
       "perMonth": "/mês",
       "perYear": "/ano"
     },
-    "unsaved": "Não salvo"
+    "unsaved": "Não salvo",
+    "showCostMargin": "Mostrar custo e margem",
+    "hideCostMargin": "Ocultar custo e margem",
+    "orgCombobox": {
+      "searchPlaceholder": "Pesquisar organizações…",
+      "noResults": "Nenhuma organização correspondente.",
+      "capNote": "Mostrando as primeiras {{count}} correspondências — continue digitando para refinar."
+    }
   },
   "bulk": {
     "bulkActionBar": {
@@ -1194,7 +1208,6 @@
     "saved": "Salvo",
     "success": {
       "lineAdded": "Linha adicionada",
-      "lineRemoved": "Linha removida",
       "notesSaved": "Observações salvas",
       "termsSaved": "Termos salvos"
     },
@@ -1222,7 +1235,17 @@
     },
     "unapprovedTime": "{{count}} linhas fazem referência a horas não aprovadas. Revise antes de emitir.",
     "unapprovedTime_one": "{{count}} linha faz referência a horas não aprovadas. Revise antes de emitir.",
-    "unapprovedTime_other": "{{count}} linhas fazem referência a horas não aprovadas. Revise antes de emitir."
+    "unapprovedTime_other": "{{count}} linhas fazem referência a horas não aprovadas. Revise antes de emitir.",
+    "autosaveHint": "As alterações são salvas automaticamente. Um contorno âmbar marca uma edição não salva.",
+    "lastSaved": {
+      "saved": "Salvo às {{time}}",
+      "saving": "Salvando…"
+    },
+    "undo": {
+      "lineDeleted": "Linha excluída",
+      "tooLate": "Tarde demais para desfazer — essa linha já foi excluída."
+    },
+    "linesScrollAria": "Linhas da fatura — role para os lados para ver mais colunas"
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1248,10 +1271,13 @@
     "issueSuccess": "Fatura emitida",
     "issuing": "Emitindo…",
     "noVisibleLineHint": "Adicione pelo menos uma linha visível ao cliente para emitir.",
-    "preparing": "Preparando…"
+    "preparing": "Preparando…",
+    "savingHint": "Salvando alterações… A emissão será liberada quando tudo estiver salvo.",
+    "savingTitle": "Salvando suas alterações — a emissão será liberada quando tudo estiver salvo.",
+    "issueCanceledSaveFailed": "Uma alteração não pôde ser salva, então a emissão foi cancelada. Corrija o campo destacado e tente novamente.",
+    "issueCanceledStillSaving": "Suas alterações ainda estão sendo salvas — a emissão foi cancelada. Tente novamente quando tudo estiver salvo."
   },
   "invoiceDetail": {
-    "accountingView": "Visão contábil (custo, margem e componentes ocultos)",
     "deposit": {
       "duePrefix": "Entrada de",
       "dueSuffix": "devida — {{paid}} de {{total}} pagos.",
@@ -1272,7 +1298,8 @@
       "price": "Preço",
       "qty": "Qtd.",
       "tax": "Imposto",
-      "total": "Total"
+      "total": "Total",
+      "allHidden": "Todas as linhas são apenas internas. Use “Mostrar custo e margem” para vê-las."
     },
     "paymentMethods": {
       "cash": "Dinheiro",
@@ -1344,7 +1371,10 @@
       "reissuedSuccess": "Fatura anulada e reemitida como rascunho",
       "success": "Fatura anulada",
       "title": "Anular fatura"
-    }
+    },
+    "empty": "Esta fatura ainda não tem linhas.",
+    "addContentInEditor": "Adicionar linhas no Editor",
+    "linesScrollAria": "Linhas da fatura — role para os lados para ver mais colunas"
   },
   "invoiceDocument": {
     "billTo": "Faturar para",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -795,6 +795,9 @@
         "noTargets": "Adicione uma seção de preços e depois mova estas linhas para ela.",
         "qtyPrice": "{{qty}} × {{price}}",
         "title": "Linhas não atribuídas"
+      },
+      "unsavedField": {
+        "lines": "Itens"
       }
     },
     "actions": {
@@ -864,9 +867,13 @@
       "undoSuccess": "Envio cancelado — o orçamento continua um rascunho.",
       "undoTooLate": "Tarde demais para desfazer — a proposta já foi enviada.",
       "sendNow": "Enviar agora",
-      "savingTimeout": "Salvar as alterações está demorando demais — verifique sua conexão e tente novamente.",
+      "savingTimeout": "Suas alterações ainda estão sendo salvas — o envio foi cancelado. Tente novamente quando tudo estiver salvo.",
       "sendNowCancelError": "Não foi possível enviar imediatamente — a proposta ainda será enviada conforme agendado.",
-      "sendNowAlready": "Já está a caminho — a proposta está sendo enviada agora."
+      "sendNowAlready": "Já está a caminho — a proposta está sendo enviada agora.",
+      "sendCanceledSaveFailed": "Uma alteração não pôde ser salva, então o envio foi cancelado. Corrija o campo destacado e tente novamente.",
+      "sendBlockedUnsaved": "“{{field}}” tem uma alteração não salva. Corrija-a e depois envie.",
+      "unsavedHint": "“{{field}}” tem uma alteração não salva — o envio será liberado quando ela for salva.",
+      "unsavedTitle": "“{{field}}” tem uma alteração não salva — o envio será liberado quando ela for salva."
     },
     "detail": {
       "addContentInEditor": "Adicionar conteúdo no Editor",
@@ -1172,7 +1179,9 @@
       "manualLine": "Linha manual",
       "noCatalogItems": "Nenhum item de catálogo.",
       "searchCatalog": "Pesquisar no catálogo por nome ou SKU",
-      "sourceAria": "Origem da linha a adicionar"
+      "sourceAria": "Origem da linha a adicionar",
+      "catalogLoadFailed": "Não foi possível carregar o catálogo, então nenhum item pode ser exibido.",
+      "retry": "Tentar novamente"
     },
     "billTo": {
       "addInSettings": "Adicione um contato nas configurações da organização",
@@ -1243,9 +1252,13 @@
     },
     "undo": {
       "lineDeleted": "Linha excluída",
-      "tooLate": "Tarde demais para desfazer — essa linha já foi excluída."
+      "tooLate": "Tarde demais para desfazer — essa linha já foi excluída.",
+      "partialFlush": "{{applied}} exclusão(ões) aplicada(s); {{failed}} falharam e foram restauradas."
     },
-    "linesScrollAria": "Linhas da fatura — role para os lados para ver mais colunas"
+    "linesScrollAria": "Linhas da fatura — role para os lados para ver mais colunas",
+    "unsavedField": {
+      "lines": "Itens"
+    }
   },
   "invoiceActions": {
     "deleteConfirm": {
@@ -1275,7 +1288,10 @@
     "savingHint": "Salvando alterações… A emissão será liberada quando tudo estiver salvo.",
     "savingTitle": "Salvando suas alterações — a emissão será liberada quando tudo estiver salvo.",
     "issueCanceledSaveFailed": "Uma alteração não pôde ser salva, então a emissão foi cancelada. Corrija o campo destacado e tente novamente.",
-    "issueCanceledStillSaving": "Suas alterações ainda estão sendo salvas — a emissão foi cancelada. Tente novamente quando tudo estiver salvo."
+    "issueCanceledStillSaving": "Suas alterações ainda estão sendo salvas — a emissão foi cancelada. Tente novamente quando tudo estiver salvo.",
+    "issueBlockedUnsaved": "“{{field}}” tem uma alteração não salva. Corrija-a e depois emita.",
+    "unsavedHint": "“{{field}}” tem uma alteração não salva — a emissão será liberada quando ela for salva.",
+    "unsavedTitle": "“{{field}}” tem uma alteração não salva — a emissão será liberada quando ela for salva."
   },
   "invoiceDetail": {
     "deposit": {

--- a/apps/web/src/pages/billing/invoices/[id].astro
+++ b/apps/web/src/pages/billing/invoices/[id].astro
@@ -6,5 +6,5 @@ const { id } = Astro.params;
 ---
 
 <DashboardLayout title="Invoice">
-  <InvoiceWorkspace invoiceId={id} client:load />
+  <InvoiceWorkspace id={id} client:load />
 </DashboardLayout>


### PR DESCRIPTION
Brings the **Invoice** editor/detail/workspace onto the same save/UX grammar the **Quote** side already had, de-duplicates the two, and fixes the save-gate bugs that surfaced once both surfaces were compared side by side.

Two commits: the normalization, then the fixes from a full multi-agent review of it.

## The normalization

**New shared modules**
- `billing/shared/saveCues.tsx` — the blur-to-save grammar (`useSavedFlash`, `SrSaved`, `fieldRing`, `seamless`, `unsavedHintId`), lifted out of `quoteEditorShared`. The dirty signal moved from a ring to border-color because the focus ring occupies the box-shadow channel and was painting over the cue on exactly the field being edited.
- `billing/shared/OrgCombobox.tsx` — typeahead org picker replacing a native `<select>`, which stops scaling at MSP org counts.

**Invoices** — autosave hint + last-saved indicator, undo line-delete, show/hide cost & margin, aria label on the horizontally scrolling lines table.

**Quotes** — send-dialog warnings ($0 total, no Stripe, missing billing contact, deposit-without-Stripe), undo-send / send-now, save-timeout copy.

All five locales updated in parity.

## The fixes

The review found a pair of opposite bugs sharing one cause: the editors reported *"a field is dirty"* and *"a save is in flight"* as the same signal.

- A **failed line save** left an amber "unsaved" border while its in-flight key cleared — so the editor read as quiet and Issue stayed enabled, numbering the invoice at the pre-edit money.
- A **failed notes/terms save** left the field dirty forever, pinning *"Saving changes… Issue unlocks when everything is saved"* over a save that had already given up, with no way out and no pointer to the field.

The gate is now two signals: `savePending` (in flight, resolves on its own → a click queues behind it) and `unsavedFieldLabel` (save failed and the field is still dirty → the click is refused and the field is named).

That second signal is the **intersection** of "last attempt failed" and "still differs from the server", and needs both halves. Failure alone keeps blocking after the user reverts by hand — the commit path short-circuits on an unchanged value, so no fresh attempt ever clears the flag. Dirty alone fires during the round-trip between a successful save and its refetch, refusing an Issue that is perfectly valid.

The same bug existed twice more on the quote side (`QuoteEditor` terms, `QuoteHeaderMeta` title); both fixed identically. `QuoteActions` also gains the failure nonce and the spinner rule it never received — its queued Send fired on post-failure quiescence, and it spun forever on a dirty field.

**Also**
- Queued Issue/Send capture `atFailureNonce` rather than relying on two effects observing two props in a lucky order. The old comment credited *"effects run in definition order"*; what actually protected it was `savePending` lagging by one commit. Right code, wrong reason, one refactor away from a race on an irreversible money action.
- The queue re-checks `hasVisibleLines` before firing — flushing the deferred delete of the last visible line is itself what the click triggered.
- A partial delete-flush reports what landed instead of only "canceled".
- `runScoped` no longer stamps "Saved 3:14 PM" on add-line validation failures.
- `loadCatalog` guards its parse; an empty picker and a broken one now read differently.
- `QuoteBlockCard`'s dirty/saved cue rendered **nothing** — `fieldRing` emits border-color and the element carried no border width. `seamless(state, invalid)` stops the error branch dropping the only focus indicator on an invalid field. Five quote sites moved off `transition-shadow`.
- `OrgCombobox`: the combobox role moves to the search input (the element that holds focus), `aria-activedescendant` added, `aria-selected` tracks the cursor — arrow navigation was silent to assistive tech. The clone dialog's `<label>` wrapper became a `<div>`: a click on the popover's own chrome forwarded to the trigger and closed it mid-search. `orgComboboxOptions()` replaces a duplicated prepend and its two unsound casts.
- The no-billing-contact hint deep-links to `#billing`; without it the user landed on General with no field in sight.
- `ContractEditor` migrates onto `shared/saveCues`, dropping a third divergent copy still on `ring-1 ring-warning` (~2.3:1, below the 3:1 non-text minimum).
- Comments asserting rationale the code didn't implement are corrected: the border-width precondition, the `transition-colors` pairing, "one place it evolves", the CatalogItemPicker claim.

## Testing

- **503 files / 4531 tests pass**, run twice to rule out flakes
- `tsc --noEmit` clean
- Locale parity: **1213 keys × 5 locales**, no drift

New: `shared/saveCues.test.tsx` (the 1500ms expiry and unmount teardown shipped untested) and `QuoteHeaderMeta.title.test.tsx`. Added coverage for the same-render failure+quiescence race, the failed-delete-flush cancel, the quote 10s backstop, `DocumentWorkspace`'s slots, the margin memory mirror under blocked storage, and the catalog error state.

**Reviewer note:** three existing tests encoded the old contract (dirty ⇒ "saving") and were rewritten rather than preserved. That's a deliberate behavior change and the right place to push back if you disagree with it.

Scope: `apps/web` only — no API, schema, migrations, or cascade lists touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
