### PR TITLE
fix(api): sweep raw Number(process.env.X ?? default) onto envInt + add a guard (#2823)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -303,6 +303,7 @@ import { syncBinaries } from './services/binarySync';
 import * as dbModule from './db';
 import { deviceGroups, devices, securityThreats, webhookDeliveries, webhooks as webhooksTable } from './db/schema';
 import { and, eq, sql } from 'drizzle-orm';
+import { envInt } from './utils/envInt';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -1495,7 +1496,7 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     // Bounded grace for in-flight requests to finish, then force-close stragglers
     // so server.close() can't hang on keep-alive connections.
     await new Promise<void>((resolve) =>
-      setTimeout(resolve, Number(process.env.SHUTDOWN_DRAIN_MS ?? '5000'))
+      setTimeout(resolve, envInt('SHUTDOWN_DRAIN_MS', 5000))
     );
     if (typeof httpServer.closeAllConnections === 'function') {
       httpServer.closeAllConnections();

--- a/apps/api/src/jobs/alertWorker.ts
+++ b/apps/api/src/jobs/alertWorker.ts
@@ -18,6 +18,7 @@ import {
 } from '../services/alertService';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
+import { envInt } from '../utils/envInt';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -120,8 +121,8 @@ export async function processEvaluateAll(data: EvaluateAllJobData): Promise<{
 
   // Caller-supplied batchSize takes precedence (back-compat). Otherwise read the
   // env override; default 5000. Setting the env to 0 means "unlimited per run".
-  const cap = data.batchSize ?? Number(process.env.ALERT_WORKER_MAX_DEVICES_PER_RUN ?? '5000');
-  const chunkSize = Math.max(1, Number(process.env.ALERT_WORKER_CHUNK_SIZE ?? '500'));
+  const cap = data.batchSize ?? envInt('ALERT_WORKER_MAX_DEVICES_PER_RUN', 5000);
+  const chunkSize = Math.max(1, envInt('ALERT_WORKER_CHUNK_SIZE', 500));
 
   // Get all active organizations
   const orgs = await db

--- a/apps/api/src/jobs/incidentJobs.ts
+++ b/apps/api/src/jobs/incidentJobs.ts
@@ -3,6 +3,7 @@ import * as dbModule from '../db';
 import { incidents, type IncidentTimelineEntry } from '../db/schema';
 import { publishEvent } from '../services/eventBus';
 import { captureException } from '../services/sentry';
+import { envInt } from '../utils/envInt';
 
 const { db } = dbModule;
 
@@ -13,11 +14,11 @@ const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   return dbModule.withSystemDbAccessContext(fn);
 };
 
-const CORRELATION_INTERVAL_MS = Number(process.env.INCIDENT_CORRELATION_INTERVAL_MS ?? 2 * 60 * 1000);
-const TIMELINE_ENRICH_INTERVAL_MS = Number(process.env.INCIDENT_TIMELINE_ENRICH_INTERVAL_MS ?? 5 * 60 * 1000);
-const SLA_MONITOR_INTERVAL_MS = Number(process.env.INCIDENT_SLA_MONITOR_INTERVAL_MS ?? 60 * 1000);
-const P1_ESCALATION_MINUTES = Number(process.env.INCIDENT_SLA_P1_MINUTES ?? 15);
-const P2_ESCALATION_MINUTES = Number(process.env.INCIDENT_SLA_P2_MINUTES ?? 60);
+const CORRELATION_INTERVAL_MS = envInt('INCIDENT_CORRELATION_INTERVAL_MS', 2 * 60 * 1000);
+const TIMELINE_ENRICH_INTERVAL_MS = envInt('INCIDENT_TIMELINE_ENRICH_INTERVAL_MS', 5 * 60 * 1000);
+const SLA_MONITOR_INTERVAL_MS = envInt('INCIDENT_SLA_MONITOR_INTERVAL_MS', 60 * 1000);
+const P1_ESCALATION_MINUTES = envInt('INCIDENT_SLA_P1_MINUTES', 15);
+const P2_ESCALATION_MINUTES = envInt('INCIDENT_SLA_P2_MINUTES', 60);
 
 let correlationTimer: ReturnType<typeof setInterval> | null = null;
 let timelineEnricherTimer: ReturnType<typeof setInterval> | null = null;

--- a/apps/api/src/jobs/offlineDetector.ts
+++ b/apps/api/src/jobs/offlineDetector.ts
@@ -16,6 +16,7 @@ import { interpolateTemplate } from '../services/alertConditions';
 import { resolveReevalHorizonMinutes } from '../services/alertConditions/offlineDuration';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
+import { envInt } from '../utils/envInt';
 
 const { db } = dbModule;
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
@@ -159,8 +160,8 @@ export async function processDetectOffline(data: DetectOfflineJobData): Promise<
   const thresholdTime = new Date(Date.now() - thresholdMinutes * 60 * 1000);
 
   // Env tunables — same shape as alertWorker. cap=0 means unlimited per run.
-  const cap = Number(process.env.OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN ?? '5000');
-  const chunkSize = Math.max(1, Number(process.env.OFFLINE_DETECTOR_CHUNK_SIZE ?? '500'));
+  const cap = envInt('OFFLINE_DETECTOR_MAX_DEVICES_PER_RUN', 5000);
+  const chunkSize = Math.max(1, envInt('OFFLINE_DETECTOR_CHUNK_SIZE', 500));
 
   const queue = getOfflineQueue();
   let totalDetected = 0;
@@ -550,8 +551,8 @@ export async function processReevaluateOfflineSweep(): Promise<{
   const horizonTime = new Date(Date.now() - selectionMinutes * 60 * 1000);
 
   // Env tunables — same shape as the detect sweep. cap=0 means unlimited per run.
-  const cap = Number(process.env.OFFLINE_DETECTOR_REEVAL_MAX_DEVICES_PER_RUN ?? '5000');
-  const chunkSize = Math.max(1, Number(process.env.OFFLINE_DETECTOR_REEVAL_CHUNK_SIZE ?? '500'));
+  const cap = envInt('OFFLINE_DETECTOR_REEVAL_MAX_DEVICES_PER_RUN', 5000);
+  const chunkSize = Math.max(1, envInt('OFFLINE_DETECTOR_REEVAL_CHUNK_SIZE', 500));
 
   const queue = getOfflineQueue();
   let totalQueued = 0;
@@ -635,7 +636,7 @@ export async function scheduleOfflineJobs(): Promise<void> {
   if (isReevalEnabled()) {
     const reevalIntervalMs = Math.max(
       5_000,
-      Number(process.env.OFFLINE_DETECTOR_REEVAL_INTERVAL_MS ?? String(DEFAULT_REEVAL_INTERVAL_MS))
+      envInt('OFFLINE_DETECTOR_REEVAL_INTERVAL_MS', DEFAULT_REEVAL_INTERVAL_MS)
     );
     await queue.add(
       'reevaluate-offline-sweep',

--- a/apps/api/src/jobs/pamJobs.ts
+++ b/apps/api/src/jobs/pamJobs.ts
@@ -24,6 +24,7 @@ import { getBullMQConnection } from '../services/redis';
 import { captureException } from '../services/sentry';
 import { publishEvent } from '../services/eventBus';
 import { writeAuditEvent, requestLikeFromSnapshot } from '../services/auditEvents';
+import { envInt } from '../utils/envInt';
 
 const ENFORCER_QUEUE = 'pam-elevation-expiry-enforcer';
 const ENFORCER_INTERVAL_MS = 60 * 1000; // every 60s
@@ -32,10 +33,7 @@ const STALE_INTERVAL_MS = 5 * 60 * 1000; // every 5 min
 const MAX_PER_RUN = 500;
 
 // Pending requests older than this are expired. Overridable for ops via env.
-const STALE_PENDING_TTL_MINUTES = Number.parseInt(
-  process.env.PAM_PENDING_REQUEST_TTL_MINUTES ?? '15',
-  10,
-);
+const STALE_PENDING_TTL_MINUTES = envInt('PAM_PENDING_REQUEST_TTL_MINUTES', 15);
 
 type PamJobData = { type: 'enforce-elevation-expiry' | 'expire-stale-requests'; queuedAt: string };
 

--- a/apps/api/src/jobs/staleCommandReaper.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.test.ts
@@ -87,7 +87,7 @@ vi.mock('../services/commandQueue', async (importOriginal) => {
   };
 });
 
-import { reapStaleDeviceCommands, reapStaleBackupJobs } from './staleCommandReaper';
+import { reapStaleDeviceCommands, reapStaleBackupJobs, resolveMaxReapPerRun } from './staleCommandReaper';
 
 function selectChain(resolvedValue: unknown) {
   const chain: Record<string, any> = {};
@@ -106,6 +106,27 @@ function backupUpdateChain(returningValue: unknown) {
     })),
   };
 }
+
+// The `0 == unlimited` knob is subtle and availability-critical: drizzle's
+// `.limit(0)` returns ZERO rows, so a naive pass-through would silently
+// disable the reaper entirely rather than uncapping it. #2823 also changed
+// what an EMPTY `STALE_REAPER_MAX_PER_RUN` resolves to — it used to reach
+// this mapping as 0 (unlimited); it now reaches it as the 5000 default.
+describe('resolveMaxReapPerRun', () => {
+  it('passes a positive cap through', () => {
+    expect(resolveMaxReapPerRun(5000)).toBe(5000);
+    expect(resolveMaxReapPerRun(1)).toBe(1);
+  });
+
+  it('maps an explicit 0 to unlimited, never to a zero-row limit', () => {
+    expect(resolveMaxReapPerRun(0)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(resolveMaxReapPerRun(0)).not.toBe(0);
+  });
+
+  it('falls back to the default for a negative cap', () => {
+    expect(resolveMaxReapPerRun(-1)).toBe(5000);
+  });
+});
 
 describe('stale command reaper', () => {
   beforeEach(() => {

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -39,13 +39,16 @@ const REAP_INTERVAL_MS = 2 * 60 * 1000; // every 2 minutes
 // `.limit(0)` returns zero rows, which would silently disable the
 // reaper. Normalize to `Number.MAX_SAFE_INTEGER` so the consistent
 // "cap=0 == unlimited" knob actually behaves that way here.
-const RAW_MAX_REAP = envInt('STALE_REAPER_MAX_PER_RUN', 5000);
-const MAX_REAP_PER_RUN =
-  Number.isFinite(RAW_MAX_REAP) && RAW_MAX_REAP > 0
-    ? RAW_MAX_REAP
-    : RAW_MAX_REAP === 0
-      ? Number.MAX_SAFE_INTEGER
-      : 5000; // negative / NaN fall back to default rather than disabling the reaper
+//
+// Exported (and pure) so the mapping is testable without re-importing this
+// module: the env read stays at module scope, only the derivation moves.
+export function resolveMaxReapPerRun(raw: number): number {
+  if (raw > 0) return raw;
+  if (raw === 0) return Number.MAX_SAFE_INTEGER;
+  return 5000; // negative falls back to the default rather than disabling the reaper
+}
+
+const MAX_REAP_PER_RUN = resolveMaxReapPerRun(envInt('STALE_REAPER_MAX_PER_RUN', 5000));
 const SHORTEST_TIMEOUT_MS = 5 * 60 * 1000; // conservative SQL pre-filter
 
 // Backup-related command types — used to guard backup-specific Prometheus metrics

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -24,6 +24,7 @@ import { captureException } from '../services/sentry';
 import { recordBackupCommandTimeout, recordRestoreTimeout } from '../services/backupMetrics';
 import { revokeViewerSession } from '../services/viewerTokenRevocation';
 import { queueBackupStopCommand } from '../services/commandQueue';
+import { envInt } from '../utils/envInt';
 
 const QUEUE_NAME = 'stale-command-reaper';
 const REAP_INTERVAL_MS = 2 * 60 * 1000; // every 2 minutes
@@ -38,7 +39,7 @@ const REAP_INTERVAL_MS = 2 * 60 * 1000; // every 2 minutes
 // `.limit(0)` returns zero rows, which would silently disable the
 // reaper. Normalize to `Number.MAX_SAFE_INTEGER` so the consistent
 // "cap=0 == unlimited" knob actually behaves that way here.
-const RAW_MAX_REAP = Number(process.env.STALE_REAPER_MAX_PER_RUN ?? '5000');
+const RAW_MAX_REAP = envInt('STALE_REAPER_MAX_PER_RUN', 5000);
 const MAX_REAP_PER_RUN =
   Number.isFinite(RAW_MAX_REAP) && RAW_MAX_REAP > 0
     ? RAW_MAX_REAP

--- a/apps/api/src/routes/agents/patches.ts
+++ b/apps/api/src/routes/agents/patches.ts
@@ -6,6 +6,7 @@ import { db, type Database } from '../../db';
 import { devices, patches, devicePatches } from '../../db/schema';
 import { enqueueWingetReleaseTest } from '../../jobs/wingetReleaseTestWorker';
 import { writeAuditEvent } from '../../services/auditEvents';
+import { envInt } from '../../utils/envInt';
 import { enrichFromCatalog } from '../../services/thirdPartyEnrichment';
 import { submitInstalledPatchesSchema, submitPatchesSchema, submitPendingPatchesSchema } from './schemas';
 import { inferPatchOsType, parseDate, sanitizeDate } from './helpers';
@@ -293,7 +294,10 @@ export async function pruneStaleTombstones(
   executor: Database,
   deviceId: string,
   orgId: string,
-  pruneAfterHours = Number(process.env.PATCH_TOMBSTONE_PRUNE_AFTER_HOURS) || 168,
+  // `|| 168` is deliberate and preserves the pre-#2823 semantics: a 0-hour
+  // window would prune every `missing` tombstone on the very next scan, so 0
+  // is treated as "unset" rather than honoured.
+  pruneAfterHours = envInt('PATCH_TOMBSTONE_PRUNE_AFTER_HOURS', 168) || 168,
 ): Promise<void> {
   await executor
     .delete(devicePatches)

--- a/apps/api/src/routes/incidents.validation.test.ts
+++ b/apps/api/src/routes/incidents.validation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ALLOWED_EVIDENCE_STORAGE_SCHEMES,
+  parseEvidenceStorageSchemes,
+} from './incidents.validation';
+
+describe('evidence storage scheme allowlist (#2823)', () => {
+  it('parses a normal comma list, trimming and lowercasing', () => {
+    expect(parseEvidenceStorageSchemes(' S3 , https ')).toEqual(['s3', 'https']);
+  });
+
+  // `envStr` guarantees a non-empty string, but the invariant this allowlist
+  // needs is a non-empty PARSED list. These values clear envStr and still
+  // parse to nothing — an allowlist that rejects every evidence path, i.e.
+  // the #2823 total-feature-failure outcome via a malformed value rather
+  // than an empty one. The caller must fall back to the defaults.
+  it.each([',', ',,', ' , , '])('parses %j to an empty list', (raw) => {
+    expect(parseEvidenceStorageSchemes(raw)).toEqual([]);
+  });
+
+  it('never ships an empty allowlist', () => {
+    expect(ALLOWED_EVIDENCE_STORAGE_SCHEMES.size).toBeGreaterThan(0);
+  });
+
+  it('allows the documented default schemes', () => {
+    for (const scheme of ['s3', 'gs', 'r2', 'azblob', 'immutable', 'https']) {
+      expect(ALLOWED_EVIDENCE_STORAGE_SCHEMES.has(scheme)).toBe(true);
+    }
+  });
+
+  it('does not allow an arbitrary scheme', () => {
+    expect(ALLOWED_EVIDENCE_STORAGE_SCHEMES.has('file')).toBe(false);
+  });
+});

--- a/apps/api/src/routes/incidents.validation.ts
+++ b/apps/api/src/routes/incidents.validation.ts
@@ -91,10 +91,29 @@ export const HIGH_RISK_CONTAINMENT_ACTIONS = new Set([
   'process_kill',
 ]);
 
-export const ALLOWED_EVIDENCE_STORAGE_SCHEMES = new Set(
-  envStr('EVIDENCE_STORAGE_ALLOWED_SCHEMES', 's3,gs,r2,azblob,immutable,https')
+const DEFAULT_EVIDENCE_STORAGE_SCHEMES = 's3,gs,r2,azblob,immutable,https';
+
+/** Exported for tests — pure, so the fallback below needs no module re-import. */
+export function parseEvidenceStorageSchemes(raw: string): string[] {
+  return raw
     .split(',')
     .map((value) => value.trim().toLowerCase())
-    .filter((value) => value.length > 0)
+    .filter((value) => value.length > 0);
+}
+
+// `envStr` guarantees a non-empty string, but the caller's real invariant is a
+// non-empty *parsed* list: a value like `","` or `",,"` survives envStr and
+// then parses to zero schemes — an empty allowlist that rejects EVERY evidence
+// path. That is the same total-feature-failure outcome as #2823, reached
+// through a malformed value instead of an empty one, so fall back to the
+// defaults rather than shipping an allowlist that denies everything.
+const configuredEvidenceSchemes = parseEvidenceStorageSchemes(
+  envStr('EVIDENCE_STORAGE_ALLOWED_SCHEMES', DEFAULT_EVIDENCE_STORAGE_SCHEMES)
+);
+
+export const ALLOWED_EVIDENCE_STORAGE_SCHEMES = new Set(
+  configuredEvidenceSchemes.length > 0
+    ? configuredEvidenceSchemes
+    : parseEvidenceStorageSchemes(DEFAULT_EVIDENCE_STORAGE_SCHEMES)
 );
 export const EVIDENCE_HASH_ALGORITHM = 'sha256';

--- a/apps/api/src/routes/incidents.validation.ts
+++ b/apps/api/src/routes/incidents.validation.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { envStr } from '../utils/envStr';
 
 export const incidentSeveritySchema = z.enum(['p1', 'p2', 'p3', 'p4']);
 export const incidentStatusSchema = z.enum(['detected', 'analyzing', 'contained', 'recovering', 'closed']);
@@ -91,7 +92,7 @@ export const HIGH_RISK_CONTAINMENT_ACTIONS = new Set([
 ]);
 
 export const ALLOWED_EVIDENCE_STORAGE_SCHEMES = new Set(
-  (process.env.EVIDENCE_STORAGE_ALLOWED_SCHEMES ?? 's3,gs,r2,azblob,immutable,https')
+  envStr('EVIDENCE_STORAGE_ALLOWED_SCHEMES', 's3,gs,r2,azblob,immutable,https')
     .split(',')
     .map((value) => value.trim().toLowerCase())
     .filter((value) => value.length > 0)

--- a/apps/api/src/services/alertConditions/offlineDuration.ts
+++ b/apps/api/src/services/alertConditions/offlineDuration.ts
@@ -11,13 +11,15 @@
  * the sweep read this same env, so the cap always matches the horizon that
  * actually governs re-evaluation.
  */
+import { envInt } from '../../utils/envInt';
+
 export const DEFAULT_REEVAL_HORIZON_MINUTES = 1440; // 24h
 
 /** Resolve the re-eval horizon (minutes) from env, clamped to >= 1. */
 export function resolveReevalHorizonMinutes(): number {
   return Math.max(
     1,
-    Number(process.env.OFFLINE_DETECTOR_REEVAL_HORIZON_MINUTES ?? String(DEFAULT_REEVAL_HORIZON_MINUTES))
+    envInt('OFFLINE_DETECTOR_REEVAL_HORIZON_MINUTES', DEFAULT_REEVAL_HORIZON_MINUTES)
   );
 }
 

--- a/apps/api/src/services/llm/__scripts__/openai-smoke.ts
+++ b/apps/api/src/services/llm/__scripts__/openai-smoke.ts
@@ -7,7 +7,7 @@
  *   - terminaison propre via message_end avec usage
  *
  * Usage :
- *   MCP_LLM_BASE_URL=http://192.168.30.121:8000/v1 \
+ *   MCP_LLM_BASE_URL=http://your-vllm-host:8000/v1 \
  *   MCP_LLM_API_KEY=changeme \
  *   MCP_LLM_MODEL=qwen3.6-27b \
  *   pnpm --filter @breeze/api exec tsx src/services/llm/__scripts__/openai-smoke.ts
@@ -18,7 +18,7 @@ import type { ChatMessage } from '../types';
 import { envFloat } from '../../../utils/envFloat';
 import { envStr } from '../../../utils/envStr';
 
-const BASE_URL = envStr('MCP_LLM_BASE_URL', 'http://192.168.30.121:8000/v1');
+const BASE_URL = envStr('MCP_LLM_BASE_URL', 'http://localhost:8000/v1');
 const API_KEY = envStr('MCP_LLM_API_KEY', 'changeme');
 const MODEL = envStr('MCP_LLM_MODEL', 'qwen3.6-27b');
 // Prices are per-million-token decimals — envFloat, not envInt (which truncates).

--- a/apps/api/src/services/llm/__scripts__/openai-smoke.ts
+++ b/apps/api/src/services/llm/__scripts__/openai-smoke.ts
@@ -15,12 +15,15 @@
 
 import { OpenAICompatibleProvider } from '../openaiCompatibleProvider';
 import type { ChatMessage } from '../types';
+import { envFloat } from '../../../utils/envFloat';
+import { envStr } from '../../../utils/envStr';
 
-const BASE_URL = process.env.MCP_LLM_BASE_URL ?? 'http://192.168.30.121:8000/v1';
-const API_KEY = process.env.MCP_LLM_API_KEY ?? 'changeme';
-const MODEL = process.env.MCP_LLM_MODEL ?? 'qwen3.6-27b';
-const PRICE_IN = Number(process.env.MCP_LLM_PRICE_INPUT_PER_M_USD ?? '0');
-const PRICE_OUT = Number(process.env.MCP_LLM_PRICE_OUTPUT_PER_M_USD ?? '0');
+const BASE_URL = envStr('MCP_LLM_BASE_URL', 'http://192.168.30.121:8000/v1');
+const API_KEY = envStr('MCP_LLM_API_KEY', 'changeme');
+const MODEL = envStr('MCP_LLM_MODEL', 'qwen3.6-27b');
+// Prices are per-million-token decimals — envFloat, not envInt (which truncates).
+const PRICE_IN = envFloat('MCP_LLM_PRICE_INPUT_PER_M_USD', 0);
+const PRICE_OUT = envFloat('MCP_LLM_PRICE_OUTPUT_PER_M_USD', 0);
 
 async function main(): Promise<void> {
   console.log('==========================================');

--- a/apps/api/src/services/provisionCredentialHandle.ts
+++ b/apps/api/src/services/provisionCredentialHandle.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { envInt } from '../utils/envInt';
 
 /**
  * Canonical shape of a provision credential-handle token: 64 chars of
@@ -19,6 +20,6 @@ export function generateProvisionHandleToken(): string {
  * Tunable via env for testing; production default is 5 minutes.
  */
 export function provisionHandleExpiresAt(): Date {
-  const ttlMin = Number(process.env.PROVISION_HANDLE_TTL_MINUTES ?? 5);
+  const ttlMin = envInt('PROVISION_HANDLE_TTL_MINUTES', 5);
   return new Date(Date.now() + ttlMin * 60 * 1000);
 }

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -12,6 +12,7 @@ import {
   type TenantRevocationResult,
 } from './tenantLifecycle';
 import { invalidateAgentTenantCache } from './tenantStatus';
+import { envInt } from '../utils/envInt';
 
 /**
  * Offboarding drain state (#2774).
@@ -29,7 +30,7 @@ import { invalidateAgentTenantCache } from './tenantStatus';
  * adversarial suspensions must sever immediately (see tenantLifecycle.ts).
  */
 
-const RAW_WINDOW_HOURS = Number(process.env.OFFBOARDING_DRAIN_WINDOW_HOURS ?? '72');
+const RAW_WINDOW_HOURS = envInt('OFFBOARDING_DRAIN_WINDOW_HOURS', 72);
 export const OFFBOARDING_DRAIN_WINDOW_HOURS =
   Number.isFinite(RAW_WINDOW_HOURS) && RAW_WINDOW_HOURS >= 1 ? RAW_WINDOW_HOURS : 72;
 

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -30,9 +30,10 @@ import { envInt } from '../utils/envInt';
  * adversarial suspensions must sever immediately (see tenantLifecycle.ts).
  */
 
+// `envInt` cannot return a non-finite number, so the old `Number.isFinite`
+// arm here was unfalsifiable; the `>= 1` floor is the part that matters.
 const RAW_WINDOW_HOURS = envInt('OFFBOARDING_DRAIN_WINDOW_HOURS', 72);
-export const OFFBOARDING_DRAIN_WINDOW_HOURS =
-  Number.isFinite(RAW_WINDOW_HOURS) && RAW_WINDOW_HOURS >= 1 ? RAW_WINDOW_HOURS : 72;
+export const OFFBOARDING_DRAIN_WINDOW_HOURS = RAW_WINDOW_HOURS >= 1 ? RAW_WINDOW_HOURS : 72;
 
 const NON_TERMINAL_COMMAND_STATUSES = ['pending', 'sent'] as const;
 

--- a/apps/api/src/utils/envFloat.test.ts
+++ b/apps/api/src/utils/envFloat.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { envFloat } from './envFloat';
+import { envInt } from './envInt';
 
 describe('envFloat', () => {
   afterEach(() => {
@@ -42,5 +43,29 @@ describe('envFloat', () => {
   it('returns the default for Infinity', () => {
     vi.stubEnv('__TEST_ENV_FLOAT', 'Infinity');
     expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(1.5);
+  });
+
+  it('accepts a negative value (callers clamp if they need a floor)', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', '-5');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(-5);
+  });
+
+  it('rejects trailing garbage rather than prefix-parsing it', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', '2.75abc');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(1.5);
+  });
+
+  it('returns the default for the literal NaN', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', 'NaN');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(1.5);
+  });
+
+  // The reason to reach for envFloat over envInt is not only truncation:
+  // exponent notation is legitimate float syntax, and envInt deliberately
+  // rejects it rather than prefix-parsing `1e3` to 1.
+  it('accepts exponent notation, where envInt rejects it', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', '1e3');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(1000);
+    expect(envInt('__TEST_ENV_FLOAT', 1440)).toBe(1440);
   });
 });

--- a/apps/api/src/utils/envFloat.test.ts
+++ b/apps/api/src/utils/envFloat.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { envFloat } from './envFloat';
+
+describe('envFloat', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the default when the variable is absent', () => {
+    expect(envFloat('__TEST_ENV_FLOAT_ABSENT', 1.5)).toBe(1.5);
+  });
+
+  // The #2823 regression: compose renders an unmapped `VAR: ${VAR:-}` as
+  // `VAR: ""`, so `??` never fires and `Number('') === 0`.
+  it('returns the default for an empty string, NOT 0', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', '');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(1.5);
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).not.toBe(0);
+  });
+
+  it('returns the default for a whitespace-only value', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', '   ');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(1.5);
+  });
+
+  it('returns the default for a non-numeric value', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', 'free');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(1.5);
+  });
+
+  // The reason this exists alongside envInt: envInt would truncate to 2.
+  it('preserves the fractional part', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', '2.75');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(2.75);
+  });
+
+  it('honours an explicit 0', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', '0');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(0);
+  });
+
+  it('returns the default for Infinity', () => {
+    vi.stubEnv('__TEST_ENV_FLOAT', 'Infinity');
+    expect(envFloat('__TEST_ENV_FLOAT', 1.5)).toBe(1.5);
+  });
+});

--- a/apps/api/src/utils/envFloat.ts
+++ b/apps/api/src/utils/envFloat.ts
@@ -1,0 +1,18 @@
+/**
+ * Parse an environment variable as a floating-point number, falling back when
+ * it is absent, EMPTY, or unparseable.
+ *
+ * Same empty-string trap as `envInt` (see `envInt.ts` for the full rationale):
+ * compose threads unmapped variables in as `VAR: ${VAR:-}`, which the container
+ * sees as `VAR=""`. `??` does not fire on `''` and `Number('') === 0`, so
+ * `Number(process.env.X ?? 1.5)` silently yields `0`.
+ *
+ * Use this instead of `envInt` only where a fractional value is meaningful
+ * (prices, ratios, multipliers) — `envInt` truncates via `parseInt`.
+ */
+export function envFloat(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+}

--- a/apps/api/src/utils/envFloat.ts
+++ b/apps/api/src/utils/envFloat.ts
@@ -10,9 +10,18 @@
  * Use this instead of `envInt` only where a fractional value is meaningful
  * (prices, ratios, multipliers) — `envInt` truncates via `parseInt`.
  */
+/**
+ * Full decimal numbers, exponent notation included (unlike `envInt`, `1e3` is
+ * a legitimate way to write a float). Anything else is rejected outright
+ * rather than silently prefix-parsed: `parseFloat('12abc')` is `12`.
+ */
+const DECIMAL_FLOAT = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
+
 export function envFloat(name: string, defaultValue: number): number {
   const raw = process.env[name];
   if (!raw) return defaultValue;
-  const parsed = Number.parseFloat(raw);
+  const trimmed = raw.trim();
+  if (!DECIMAL_FLOAT.test(trimmed)) return defaultValue;
+  const parsed = Number.parseFloat(trimmed);
   return Number.isFinite(parsed) ? parsed : defaultValue;
 }

--- a/apps/api/src/utils/envInt.test.ts
+++ b/apps/api/src/utils/envInt.test.ts
@@ -47,4 +47,25 @@ describe('envInt', () => {
     vi.stubEnv('__TEST_ENV_INT', '0');
     expect(envInt('__TEST_ENV_INT', 1440)).toBe(0);
   });
+
+  it('accepts a negative value (callers clamp if they need a floor)', () => {
+    vi.stubEnv('__TEST_ENV_INT', '-5');
+    expect(envInt('__TEST_ENV_INT', 1440)).toBe(-5);
+  });
+
+  // A bare `parseInt` takes any valid PREFIX, which re-admits the very failure
+  // this helper exists to prevent — silently acting on a wrong small number.
+  // `parseInt('5e3')` is 5 (a 5ms drain, not 5000ms) and `parseInt('0x10', 10)`
+  // is 0 (which some callers read as "unlimited").
+  it.each([
+    ['1e3', 'exponent notation'],
+    ['5e3', 'exponent notation'],
+    ['0x10', 'hex'],
+    ['12abc', 'trailing garbage'],
+    ['1,000', 'thousands separator'],
+    ['Infinity', 'non-finite'],
+  ])('rejects %s (%s) rather than prefix-parsing it', (value) => {
+    vi.stubEnv('__TEST_ENV_INT', value);
+    expect(envInt('__TEST_ENV_INT', 1440)).toBe(1440);
+  });
 });

--- a/apps/api/src/utils/envInt.ts
+++ b/apps/api/src/utils/envInt.ts
@@ -16,9 +16,20 @@
  * For a TTL that means every token is born already expired. Use this instead
  * of hand-rolling `Number(process.env.X ?? default)`.
  */
+/**
+ * Plain decimal integers only (a trailing fraction is tolerated and truncated).
+ * `parseInt` alone takes any valid PREFIX, which re-admits the same class of
+ * silent wrong-small-number this helper exists to prevent: `parseInt('5e3')`
+ * is `5`, not `5000`, and `parseInt('0x10', 10)` is `0`. Reject those outright
+ * and fall back to the default rather than acting on a misread value (#2823).
+ */
+const DECIMAL_INT = /^[+-]?\d+(?:\.\d+)?$/;
+
 export function envInt(name: string, defaultValue: number): number {
   const raw = process.env[name];
   if (!raw) return defaultValue;
-  const parsed = Number.parseInt(raw, 10);
+  const trimmed = raw.trim();
+  if (!DECIMAL_INT.test(trimmed)) return defaultValue;
+  const parsed = Number.parseInt(trimmed, 10);
   return Number.isFinite(parsed) ? parsed : defaultValue;
 }

--- a/apps/api/src/utils/envStr.test.ts
+++ b/apps/api/src/utils/envStr.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { envStr } from './envStr';
+
+describe('envStr', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the default when the variable is absent', () => {
+    expect(envStr('__TEST_ENV_STR_ABSENT', 's3,https')).toBe('s3,https');
+  });
+
+  // The #2823 regression: compose renders an unmapped `VAR: ${VAR:-}` as
+  // `VAR: ""`. `??` does not fire on `''`, so a naive reader produced an
+  // EMPTY allowlist (rejecting every evidence URL) rather than the default.
+  it('returns the default for an empty string, NOT an empty value', () => {
+    vi.stubEnv('__TEST_ENV_STR', '');
+    expect(envStr('__TEST_ENV_STR', 's3,https')).toBe('s3,https');
+  });
+
+  it('returns the default for a whitespace-only value', () => {
+    vi.stubEnv('__TEST_ENV_STR', '   ');
+    expect(envStr('__TEST_ENV_STR', 's3,https')).toBe('s3,https');
+  });
+
+  it('returns the configured value', () => {
+    vi.stubEnv('__TEST_ENV_STR', 'gs,azblob');
+    expect(envStr('__TEST_ENV_STR', 's3,https')).toBe('gs,azblob');
+  });
+
+  it('trims surrounding whitespace', () => {
+    vi.stubEnv('__TEST_ENV_STR', '  gs,azblob  ');
+    expect(envStr('__TEST_ENV_STR', 's3,https')).toBe('gs,azblob');
+  });
+});

--- a/apps/api/src/utils/envStr.ts
+++ b/apps/api/src/utils/envStr.ts
@@ -1,0 +1,17 @@
+/**
+ * Read an environment variable as a string, falling back when it is absent,
+ * EMPTY, or whitespace-only.
+ *
+ * Same empty-string trap as `envInt` (see `envInt.ts` for the full rationale):
+ * compose threads unmapped variables in as `VAR: ${VAR:-}`, which the container
+ * sees as `VAR=""`. `??` does not fire on `''`, so `process.env.X ?? 'a,b,c'`
+ * yields `''` — an empty allowlist, an empty base URL, an unrecognised mode.
+ *
+ * Returns the value trimmed, so callers never have to re-check for whitespace.
+ */
+export function envStr(name: string, defaultValue: string): string {
+  const raw = process.env[name];
+  if (!raw) return defaultValue;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : defaultValue;
+}

--- a/apps/api/src/utils/noRawEnvNumberCoercion.test.ts
+++ b/apps/api/src/utils/noRawEnvNumberCoercion.test.ts
@@ -32,13 +32,37 @@
  * violations, and no genuinely-correct exception is known. If one ever
  * appears, adding an allowlist is a reviewed change to this file.
  *
+ * SCOPE, stated precisely so the "zero violations" claim is not over-read:
+ * this scans `apps/api/src` only. That is where the bug class lives — the API
+ * container is what compose threads these variables into. `apps/api/scripts`
+ * is clean, and the web/portal apps read `import.meta.env` (Vite substitutes
+ * at build time, different semantics). Verified zero instances elsewhere in
+ * the repo at the time of writing.
+ *
+ * KNOWN BLIND SPOTS (accepted, not oversights). All of these are silent
+ * against the rules above, and each needs real dataflow analysis to catch —
+ * which would trade a precise, zero-exemption guard for a fuzzy one:
+ *
+ *   - Aliasing: `const env = process.env; Number(env.FOO ?? 5)`. Two files
+ *     already bind such an alias (`config/validate.ts`, `routes/system.ts`),
+ *     neither for a numeric read.
+ *   - Indirection: `const raw = process.env.X ?? '5000'; Number(raw)`.
+ *   - Other coercions: `+process.env.X`, `process.env.X * 1`,
+ *     `Number(\`${process.env.X ?? 5000}\`)`.
+ *   - The STRING form of the same trap (`process.env.X ?? 'default'`, which
+ *     yields `''`) is NOT guarded — `envStr` exists for it, but the shape is
+ *     too common and usually fail-safe to ban outright. Judge those by hand.
+ *
+ * The residual risk is that a future author has to go out of their way to
+ * reintroduce the bug, rather than fall into it by writing the obvious thing.
+ *
  * The self-check block at the bottom is load-bearing. A grep guard whose
  * pattern silently matches nothing is the classic failure mode here, so the
  * detector is exercised against synthetic violating AND non-violating sources,
  * and the file walk asserts it actually saw the tree.
  */
 import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
@@ -60,26 +84,55 @@ function listSourceFiles(dir: string, acc: string[] = []): string[] {
 }
 
 /**
- * Blank out comment bodies while leaving string literals intact.
+ * Neutralise everything that is not executable code: comment bodies and
+ * string/template literal bodies.
  *
- * Both matter. Comments must be blanked because the helper docs (and this
- * file) quote the forbidden pattern verbatim as the thing NOT to write —
- * a naive grep flags its own documentation. String literals must be kept
- * because rule 2 needs to see whether a `??` fallback is `''`, and because
- * a `//` inside a string (`'http://host/v1'`) must not swallow the rest of
- * the line and hide a real violation after it.
+ * Both matter, for opposite reasons. Comments must be blanked because the
+ * helper docs (and this file) quote the forbidden pattern verbatim as the
+ * thing NOT to write — a naive grep flags its own documentation. Literal
+ * bodies must be blanked because a string may legitimately CONTAIN the
+ * pattern (an error message, a usage line) without being a violation.
+ *
+ * Literals cannot simply be deleted or space-filled, though: rule 2 has to
+ * distinguish the safe `?? ''` from the broken `?? '15'`, so delimiters are
+ * preserved and bodies are filled with `x`. Tracking literals is also what
+ * keeps a `//` inside a string (`'http://host/v1'`) from being read as a
+ * comment and swallowing the rest of the line.
  *
  * Regex literals are tracked too, so the `//` inside `/^https?:\/\//` is not
- * mistaken for a line comment (which would blank the rest of that line and
- * could hide a real violation after it).
+ * mistaken for a line comment.
  *
- * Newlines are preserved so reported line numbers stay accurate.
+ * Two constructs in this repo make a naive tokenizer desync, and BOTH have
+ * live instances, so both are handled explicitly:
+ *
+ *   - A `/` inside a regex character class does NOT end the regex.
+ *     `routes/devices/softwareActions.ts` has `/[\\/\x00\r\n']/`; reading that
+ *     inner `/` as the terminator drops us into code at `']`, which opens a
+ *     phantom string and mispairs every quote for the rest of the file.
+ *   - `${...}` re-enters code inside a template literal, and templates nest.
+ *     `services/email.ts` and `services/invoicePdf.ts` are full of
+ *     `${cond ? \`x\` : ''}`; without a stack the inner backtick is read as
+ *     closing the outer template and parity never recovers.
+ *
+ * Desync is not merely untidy: a mispaired quote means a `/*` sitting in a
+ * string can open block-comment state and blank hundreds of lines of real
+ * code, or an innocent comment can be read as code and reported as a
+ * violation — reddening a required CI job on a file nobody touched.
+ *
+ * Newlines are preserved so reported line numbers stay accurate, and the
+ * function is length-preserving (it substitutes spaces, never deletes).
  */
 export function blankComments(source: string): string {
   let out = '';
   let i = 0;
   type State = 'code' | 'line' | 'block' | 'single' | 'double' | 'template' | 'regex';
   let state: State = 'code';
+
+  // Brace depth per open `${` in a template literal. Empty => not inside a
+  // template expression. Nesting is why this is a stack and not a boolean.
+  const templateExprDepth: number[] = [];
+  // Whether the regex cursor is inside a `[...]` character class.
+  let inCharClass = false;
 
   // Rolling tail of the last few emitted code characters, so the regex-literal
   // heuristic below is O(1) per character rather than re-scanning `out`.
@@ -108,6 +161,7 @@ export function blankComments(source: string): string {
         i += 2;
       } else if (c === '/' && regexAllowedAfter.test(tail.trimEnd())) {
         state = 'regex';
+        inCharClass = false;
         out += c;
         pushTail(c);
         i += 1;
@@ -115,6 +169,20 @@ export function blankComments(source: string): string {
         if (c === "'") state = 'single';
         else if (c === '"') state = 'double';
         else if (c === '`') state = 'template';
+        else if (templateExprDepth.length > 0) {
+          // Track braces so the `}` that closes `${` returns us to the
+          // template, and an inner object/block literal does not steal it.
+          if (c === '{') {
+            templateExprDepth[templateExprDepth.length - 1]! += 1;
+          } else if (c === '}') {
+            if (templateExprDepth[templateExprDepth.length - 1]! === 0) {
+              templateExprDepth.pop();
+              state = 'template';
+            } else {
+              templateExprDepth[templateExprDepth.length - 1]! -= 1;
+            }
+          }
+        }
         out += c;
         pushTail(c);
         i += 1;
@@ -145,26 +213,57 @@ export function blankComments(source: string): string {
       continue;
     }
 
-    // Inside a string / template / regex literal: copy through verbatim.
     if (c === '\\') {
-      out += source.slice(i, i + 2);
+      out += state === 'regex' ? source.slice(i, i + 2) : 'xx';
       pushTail(' ');
       i += 2;
       continue;
     }
+
+    if (state === 'template' && c === '$' && next === '{') {
+      templateExprDepth.push(0);
+      state = 'code';
+      out += '${';
+      pushTail('{');
+      i += 2;
+      continue;
+    }
+
+    if (state === 'regex') {
+      if (c === '[') inCharClass = true;
+      else if (c === ']') inCharClass = false;
+      // `/` only terminates outside a character class; a regex cannot span
+      // lines, so a newline bails out (a misclassified division operator can
+      // then never swallow the rest of the file).
+      else if ((c === '/' && !inCharClass) || c === '\n') state = 'code';
+      out += c;
+      pushTail(c === '\n' ? ' ' : c);
+      i += 1;
+      continue;
+    }
+
+    // Closing delimiter of a string / template literal — kept, see below.
     if (
       (state === 'single' && c === "'") ||
       (state === 'double' && c === '"') ||
-      (state === 'template' && c === '`') ||
-      (state === 'regex' && c === '/') ||
-      // A regex literal cannot span lines; bail out so a misclassified
-      // division operator can never swallow the rest of the file.
-      (state === 'regex' && c === '\n')
+      (state === 'template' && c === '`')
     ) {
       state = 'code';
+      out += c;
+      pushTail(c);
+      i += 1;
+      continue;
     }
-    out += c;
-    pushTail(c === '\n' ? ' ' : c);
+
+    // String/template BODY. Replaced with a filler rather than copied: a
+    // string that happens to contain the banned pattern verbatim (an error
+    // message, a usage line, a doc string) is not a violation and must not
+    // red CI. The delimiters are kept and the filler is `x` rather than a
+    // space, so rule 2 can still tell the safe `?? ''` from `?? '15'` — it
+    // tests for a literally EMPTY fallback, and spaces would erase that
+    // distinction.
+    out += c === '\n' ? '\n' : 'x';
+    pushTail('x');
     i += 1;
   }
 
@@ -195,11 +294,29 @@ function snippetAt(source: string, index: number): string {
   return source.slice(index, index + 110).replace(/\s+/g, ' ').trim();
 }
 
-/** Read the balanced argument list of a call whose `(` sits at `openIndex`. */
+/**
+ * Read the balanced argument list of a call whose `(` sits at `openIndex`.
+ *
+ * String literals are skipped rather than scanned: `blankComments` deliberately
+ * preserves their contents, so a lone paren inside one (`s.split('(')`) would
+ * otherwise inflate the depth, run past the real closing paren, and swallow
+ * following lines into these args — reporting a violation on innocent code.
+ */
 function readCallArgs(source: string, openIndex: number): string | null {
   let depth = 0;
   for (let i = openIndex; i < source.length; i += 1) {
     const c = source[i];
+
+    if (c === "'" || c === '"' || c === '`') {
+      const quote = c;
+      i += 1;
+      while (i < source.length && source[i] !== quote) {
+        if (source[i] === '\\') i += 1;
+        i += 1;
+      }
+      continue;
+    }
+
     if (c === '(') depth += 1;
     else if (c === ')') {
       depth -= 1;
@@ -213,11 +330,15 @@ export function findRawEnvCoercions(source: string): EnvCoercionViolation[] {
   const code = blankComments(source);
   const violations: EnvCoercionViolation[] = [];
 
+  // Matching happens on `code`, but line numbers and snippets are reported
+  // from the ORIGINAL `source` — the offsets are interchangeable because
+  // blanking substitutes characters rather than deleting them, so a reported
+  // snippet shows the developer their real text, not the `x` filler.
   for (const match of code.matchAll(NUMBER_CALL)) {
     violations.push({
-      line: lineOf(code, match.index),
+      line: lineOf(source, match.index),
       rule: 'number-coercion',
-      snippet: snippetAt(code, match.index),
+      snippet: snippetAt(source, match.index),
     });
   }
 
@@ -231,9 +352,9 @@ export function findRawEnvCoercions(source: string): EnvCoercionViolation[] {
     if (EMPTY_STRING_FALLBACK.test(args.slice(nullishIndex + 2))) continue;
 
     violations.push({
-      line: lineOf(code, match.index),
+      line: lineOf(source, match.index),
       rule: 'nullish-fallback',
-      snippet: snippetAt(code, match.index),
+      snippet: snippetAt(source, match.index),
     });
   }
 
@@ -243,13 +364,67 @@ export function findRawEnvCoercions(source: string): EnvCoercionViolation[] {
 describe('no raw numeric coercion of process.env (#2823)', () => {
   const files = listSourceFiles(SRC_ROOT);
 
-  // Vacuity guard: if the walk breaks (wrong root, over-eager skip list) the
-  // scan below passes trivially. Pin a floor well under the real count (~1225)
-  // but far above anything a broken walk would return.
-  it('walks the apps/api source tree', () => {
-    expect(files.length).toBeGreaterThan(500);
-    expect(files.some((f) => f.endsWith(join('utils', 'envInt.ts')))).toBe(true);
-    expect(files.some((f) => f.endsWith(join('jobs', 'offlineDetector.ts')))).toBe(true);
+  // Vacuity guard #1: if the walk breaks the scan below passes trivially.
+  //
+  // A single total-count floor is not enough. `services/` alone is 43% of the
+  // tree (and holds several of the readers this PR fixed), so a walk that
+  // silently stopped descending into it would still clear a "> 500" floor
+  // having scanned barely half the source. Census each major directory.
+  it('walks the whole apps/api source tree, not just part of it', () => {
+    expect(files.length).toBeGreaterThan(1000); // real count ~1225
+
+    const countIn = (dir: string) =>
+      files.filter((f) => f.includes(`${sep}${dir}${sep}`)).length;
+
+    for (const [dir, floor] of [
+      ['services', 400],
+      ['routes', 300],
+      ['db', 80],
+      ['jobs', 60],
+      ['middleware', 10],
+      ['utils', 5],
+    ] as const) {
+      expect(countIn(dir), `the walk lost ${dir}/`).toBeGreaterThan(floor);
+    }
+  });
+
+  // Vacuity guard #2: the dangerous direction of a comment-stripper bug.
+  //
+  // Blanking too LITTLE is harmless — the violation stays visible. Blanking
+  // too MUCH is silent: if the tokenizer wrongly believes it is in code while
+  // inside a literal, a `/*` in that literal opens block-comment state and
+  // erases everything up to the next `*/`, hiding every violation in between.
+  // Nothing else in this file couples the stripper to the real corpus, so
+  // assert against it directly: `process.env` reads must survive blanking,
+  // and blanking must be length-preserving (it substitutes, never deletes).
+  it('blanks comments without eating real code', () => {
+    let rawReads = 0;
+    let survivingReads = 0;
+
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8');
+      const blanked = blankComments(source);
+      expect(blanked, relative(SRC_ROOT, file)).toHaveLength(source.length);
+      rawReads += (source.match(/process\.env/g) ?? []).length;
+      survivingReads += (blanked.match(/process\.env/g) ?? []).length;
+    }
+
+    // Measured: 550 raw, 533 surviving (the 17 lost are genuine doc comments).
+    expect(rawReads).toBeGreaterThan(400);
+    expect(survivingReads).toBeGreaterThan(rawReads * 0.9);
+  });
+
+  // Vacuity guard #3: the self-checks below all feed the detector short
+  // synthetic strings. This proves the same detector still fires on a real
+  // file — with its real comments, imports, templates and regex literals —
+  // which is what the scan actually does.
+  it('flags a violation injected into a real source file', () => {
+    const real = readFileSync(join(SRC_ROOT, 'jobs', 'offlineDetector.ts'), 'utf8');
+    const found = findRawEnvCoercions(
+      `${real}\nconst __canary = Number(process.env.__CANARY ?? '5');\n`
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]!.rule).toBe('number-coercion');
   });
 
   it('has no violations in apps/api/src', () => {
@@ -373,6 +548,76 @@ describe('no raw numeric coercion of process.env (#2823)', () => {
         `const re = /^https?:\\/\\//; const n = Number(process.env.X ?? 5);`
       );
       expect(found).toHaveLength(1);
+    });
+
+    // Live shape: routes/devices/softwareActions.ts has /[\\/\x00\r\n']/.
+    // Reading the `/` inside the character class as the terminator drops the
+    // tokenizer into code at `']`, opening a phantom string that mispairs
+    // every quote in the rest of the file.
+    it('does not end a regex literal at a / inside a character class', () => {
+      const found = findRawEnvCoercions(
+        `const RE = /[\\\\/']/;\n// bad: Number(process.env.X ?? 5)\nconst ok = 1;`
+      );
+      expect(found).toEqual([]);
+    });
+
+    // Live shape: services/email.ts and services/invoicePdf.ts are full of
+    // `${cond ? \`x\` : ''}`. Without a stack the inner backtick reads as
+    // closing the outer template and parity never recovers.
+    it('handles a nested template literal inside ${} without desyncing', () => {
+      const found = findRawEnvCoercions(
+        'const s = `a ${cond ? `b` : \'\'} c`;\n// bad: Number(process.env.X ?? 5)\nconst ok = 1;'
+      );
+      expect(found).toEqual([]);
+    });
+
+    it('still flags real code after a nested template literal', () => {
+      const found = findRawEnvCoercions(
+        'const s = `a ${cond ? `b` : \'\'} c`;\nconst n = Number(process.env.X ?? 5);'
+      );
+      expect(found).toHaveLength(1);
+      expect(found[0]!.line).toBe(2);
+    });
+
+    it('returns to the template after a ${} expression containing an object', () => {
+      const found = findRawEnvCoercions(
+        'const s = `${fn({ a: 1 })} // Number(process.env.A ?? 1)`;\nconst ok = 1;'
+      );
+      expect(found).toEqual([]);
+    });
+
+    // A string may legitimately CONTAIN the banned pattern — an error
+    // message, a migration note, a usage line — without being a violation.
+    it('ignores the pattern inside a string literal', () => {
+      expect(
+        findRawEnvCoercions(`const msg = 'do not write Number(process.env.X ?? 5)';`)
+      ).toEqual([]);
+    });
+
+    it('ignores the pattern inside a template literal body', () => {
+      expect(
+        findRawEnvCoercions('const msg = `avoid Number(process.env.X ?? 5) here`;')
+      ).toEqual([]);
+    });
+
+    // Blanking literal bodies must not erase the ''-vs-'15' distinction that
+    // rule 2 depends on, which is why the filler is `x` and not a space.
+    it("still distinguishes ?? '' from ?? '15' after blanking", () => {
+      expect(findRawEnvCoercions(`parseInt(process.env.A ?? '', 10);`)).toEqual([]);
+      expect(findRawEnvCoercions(`parseInt(process.env.A ?? '15', 10);`)).toHaveLength(1);
+      expect(findRawEnvCoercions(`parseInt(process.env.A ?? "", 10);`)).toEqual([]);
+    });
+
+    // readCallArgs must skip string contents; a lone paren inside one would
+    // otherwise run the scan past the real closing paren and pull the NEXT
+    // statement's `process.env` + `??` into these args.
+    it('does not over-read call args past a paren inside a string literal', () => {
+      const found = findRawEnvCoercions(
+        `const n = parseInt(s.split('(')[0], 10);\n` +
+          `const t = Number.parseInt(process.env.TTL ?? '15', 10);`
+      );
+      expect(found).toHaveLength(1);
+      expect(found[0]!.line).toBe(2);
     });
 
     it('does not treat division as a regex literal', () => {

--- a/apps/api/src/utils/noRawEnvNumberCoercion.test.ts
+++ b/apps/api/src/utils/noRawEnvNumberCoercion.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Guard: no raw numeric coercion of `process.env` in apps/api source (#2823).
+ *
+ * The class of bug this exists to prevent:
+ *
+ * ```ts
+ * const drainMs = Number(process.env.SHUTDOWN_DRAIN_MS ?? '5000'); // WRONG -> 0
+ * ```
+ *
+ * That reader is only safe while the variable is genuinely ABSENT. Our compose
+ * files thread every variable in explicitly, and an unset one is written as
+ * `VAR: ${VAR:-}` — which `docker compose config` renders as `VAR: ""`. The
+ * container therefore sees the variable SET to an empty string. `??` does not
+ * fire on `''`, and `Number('') === 0`, so the reader silently yields **0**
+ * instead of its default: a 0ms drain, a 0-minute TTL, a 0-row cap.
+ *
+ * This nearly shipped in #2819, where two enrollment TTL readers of exactly
+ * this shape would have minted every installer bootstrap token and every
+ * redeemed child enrollment key already-expired on any self-host that pulled
+ * the release without adding the new keys to its `.env`.
+ *
+ * Two rules, both mechanical:
+ *
+ *   1. `Number(process.env...)` is banned outright. Use `envInt` / `envFloat`
+ *      (`./envInt.ts`, `./envFloat.ts`), which treat `''` as absent.
+ *   2. `parseInt(...)` / `parseFloat(...)` over a `process.env` read may only
+ *      use `?? ''` as its nullish fallback. `?? '15'` is dead code — `??`
+ *      never fires on the empty string, so you get `parseInt('')` = `NaN`.
+ *      (`|| '15'` IS safe, because `||` does fire on `''`, and is allowed.)
+ *
+ * There is deliberately NO allowlist: after the #2823 sweep there are zero
+ * violations, and no genuinely-correct exception is known. If one ever
+ * appears, adding an allowlist is a reviewed change to this file.
+ *
+ * The self-check block at the bottom is load-bearing. A grep guard whose
+ * pattern silently matches nothing is the classic failure mode here, so the
+ * detector is exercised against synthetic violating AND non-violating sources,
+ * and the file walk asserts it actually saw the tree.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '__tests__', '__mocks__']);
+
+function listSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      listSourceFiles(full, acc);
+    } else if (/\.tsx?$/.test(entry.name) && !/\.(test|spec)\.tsx?$/.test(entry.name)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+/**
+ * Blank out comment bodies while leaving string literals intact.
+ *
+ * Both matter. Comments must be blanked because the helper docs (and this
+ * file) quote the forbidden pattern verbatim as the thing NOT to write —
+ * a naive grep flags its own documentation. String literals must be kept
+ * because rule 2 needs to see whether a `??` fallback is `''`, and because
+ * a `//` inside a string (`'http://host/v1'`) must not swallow the rest of
+ * the line and hide a real violation after it.
+ *
+ * Regex literals are tracked too, so the `//` inside `/^https?:\/\//` is not
+ * mistaken for a line comment (which would blank the rest of that line and
+ * could hide a real violation after it).
+ *
+ * Newlines are preserved so reported line numbers stay accurate.
+ */
+export function blankComments(source: string): string {
+  let out = '';
+  let i = 0;
+  type State = 'code' | 'line' | 'block' | 'single' | 'double' | 'template' | 'regex';
+  let state: State = 'code';
+
+  // Rolling tail of the last few emitted code characters, so the regex-literal
+  // heuristic below is O(1) per character rather than re-scanning `out`.
+  let tail = '';
+  const pushTail = (c: string) => {
+    tail = (tail + c).slice(-8);
+  };
+
+  // A `/` starts a regex literal (rather than division) only where a value is
+  // not already on the stack — i.e. at the start of an expression, after an
+  // operator/punctuator, or after `return` / `case` / `typeof`.
+  const regexAllowedAfter = /(?:[([{,;:=!&|?+\-*%~^<>]|\breturn|\bcase|\btypeof)$|^$/;
+
+  while (i < source.length) {
+    const c = source[i]!; // loop condition guarantees this index exists
+    const next = source[i + 1];
+
+    if (state === 'code') {
+      if (c === '/' && next === '/') {
+        state = 'line';
+        out += '  ';
+        i += 2;
+      } else if (c === '/' && next === '*') {
+        state = 'block';
+        out += '  ';
+        i += 2;
+      } else if (c === '/' && regexAllowedAfter.test(tail.trimEnd())) {
+        state = 'regex';
+        out += c;
+        pushTail(c);
+        i += 1;
+      } else {
+        if (c === "'") state = 'single';
+        else if (c === '"') state = 'double';
+        else if (c === '`') state = 'template';
+        out += c;
+        pushTail(c);
+        i += 1;
+      }
+      continue;
+    }
+
+    if (state === 'line') {
+      if (c === '\n') {
+        state = 'code';
+        out += '\n';
+      } else {
+        out += ' ';
+      }
+      i += 1;
+      continue;
+    }
+
+    if (state === 'block') {
+      if (c === '*' && next === '/') {
+        state = 'code';
+        out += '  ';
+        i += 2;
+      } else {
+        out += c === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      continue;
+    }
+
+    // Inside a string / template / regex literal: copy through verbatim.
+    if (c === '\\') {
+      out += source.slice(i, i + 2);
+      pushTail(' ');
+      i += 2;
+      continue;
+    }
+    if (
+      (state === 'single' && c === "'") ||
+      (state === 'double' && c === '"') ||
+      (state === 'template' && c === '`') ||
+      (state === 'regex' && c === '/') ||
+      // A regex literal cannot span lines; bail out so a misclassified
+      // division operator can never swallow the rest of the file.
+      (state === 'regex' && c === '\n')
+    ) {
+      state = 'code';
+    }
+    out += c;
+    pushTail(c === '\n' ? ' ' : c);
+    i += 1;
+  }
+
+  return out;
+}
+
+export interface EnvCoercionViolation {
+  line: number;
+  rule: 'number-coercion' | 'nullish-fallback';
+  snippet: string;
+}
+
+// `(?<![A-Za-z0-9_$.])` keeps `parseEnvBoundedNumber(process.env.X, 85, …)`
+// — a safe helper that already handles `''` — from matching on its `Number(`
+// suffix.
+const NUMBER_CALL = /(?<![A-Za-z0-9_$.])Number\s*\(\s*process\.env\b/g;
+const PARSE_CALL = /(?<![A-Za-z0-9_$])(?:parseInt|parseFloat)\s*\(/g;
+const EMPTY_STRING_FALLBACK = /^\s*(?:''|"")/;
+
+function lineOf(source: string, index: number): number {
+  return source.slice(0, index).split('\n').length;
+}
+
+// Collapse whitespace rather than truncating at the first newline: the
+// offending call is often written across several lines, and `parseInt(` on
+// its own tells a reader nothing.
+function snippetAt(source: string, index: number): string {
+  return source.slice(index, index + 110).replace(/\s+/g, ' ').trim();
+}
+
+/** Read the balanced argument list of a call whose `(` sits at `openIndex`. */
+function readCallArgs(source: string, openIndex: number): string | null {
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i += 1) {
+    const c = source[i];
+    if (c === '(') depth += 1;
+    else if (c === ')') {
+      depth -= 1;
+      if (depth === 0) return source.slice(openIndex + 1, i);
+    }
+  }
+  return null;
+}
+
+export function findRawEnvCoercions(source: string): EnvCoercionViolation[] {
+  const code = blankComments(source);
+  const violations: EnvCoercionViolation[] = [];
+
+  for (const match of code.matchAll(NUMBER_CALL)) {
+    violations.push({
+      line: lineOf(code, match.index),
+      rule: 'number-coercion',
+      snippet: snippetAt(code, match.index),
+    });
+  }
+
+  for (const match of code.matchAll(PARSE_CALL)) {
+    const openIndex = match.index + match[0].length - 1;
+    const args = readCallArgs(code, openIndex);
+    if (args === null || !args.includes('process.env')) continue;
+
+    const nullishIndex = args.indexOf('??');
+    if (nullishIndex === -1) continue;
+    if (EMPTY_STRING_FALLBACK.test(args.slice(nullishIndex + 2))) continue;
+
+    violations.push({
+      line: lineOf(code, match.index),
+      rule: 'nullish-fallback',
+      snippet: snippetAt(code, match.index),
+    });
+  }
+
+  return violations.sort((a, b) => a.line - b.line);
+}
+
+describe('no raw numeric coercion of process.env (#2823)', () => {
+  const files = listSourceFiles(SRC_ROOT);
+
+  // Vacuity guard: if the walk breaks (wrong root, over-eager skip list) the
+  // scan below passes trivially. Pin a floor well under the real count (~1225)
+  // but far above anything a broken walk would return.
+  it('walks the apps/api source tree', () => {
+    expect(files.length).toBeGreaterThan(500);
+    expect(files.some((f) => f.endsWith(join('utils', 'envInt.ts')))).toBe(true);
+    expect(files.some((f) => f.endsWith(join('jobs', 'offlineDetector.ts')))).toBe(true);
+  });
+
+  it('has no violations in apps/api/src', () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      for (const violation of findRawEnvCoercions(readFileSync(file, 'utf8'))) {
+        offenders.push(
+          `${relative(SRC_ROOT, file)}:${violation.line} [${violation.rule}] ${violation.snippet}`
+        );
+      }
+    }
+
+    expect(
+      offenders,
+      'Raw numeric coercion of process.env yields 0/NaN when compose maps the ' +
+        'variable as an empty string. Use envInt/envFloat from src/utils, or ' +
+        '`|| \'default\'` (which does fire on \'\'). See the header of this file.'
+    ).toEqual([]);
+  });
+
+  // ---- detector self-checks: prove the guard discriminates, not just passes ----
+
+  describe('detector self-check', () => {
+    it('flags the exact shape from #2819/#2823', () => {
+      const found = findRawEnvCoercions(
+        `const drainMs = Number(process.env.SHUTDOWN_DRAIN_MS ?? '5000');`
+      );
+      expect(found).toHaveLength(1);
+      expect(found[0]!.rule).toBe('number-coercion');
+    });
+
+    it('flags Number(process.env.X) even without a fallback', () => {
+      expect(findRawEnvCoercions(`const n = Number(process.env.FOO) || 168;`)).toHaveLength(1);
+    });
+
+    it('flags Number(process.env[name])', () => {
+      expect(findRawEnvCoercions(`const n = Number(process.env[name] ?? 5);`)).toHaveLength(1);
+    });
+
+    it('flags a multi-line Number(process.env...) call', () => {
+      expect(findRawEnvCoercions(`const n = Number(\n  process.env.FOO ?? 5\n);`)).toHaveLength(1);
+    });
+
+    it('flags parseInt with a non-empty nullish fallback', () => {
+      const found = findRawEnvCoercions(
+        `const ttl = Number.parseInt(process.env.PAM_TTL ?? '15', 10);`
+      );
+      expect(found).toHaveLength(1);
+      expect(found[0]!.rule).toBe('nullish-fallback');
+    });
+
+    it('flags parseFloat with a non-empty nullish fallback', () => {
+      expect(findRawEnvCoercions(`parseFloat(process.env.RATE ?? '1.5');`)).toHaveLength(1);
+    });
+
+    it('flags a nullish fallback built from a call expression', () => {
+      expect(
+        findRawEnvCoercions(`parseInt(process.env.MS ?? String(DEFAULT_MS), 10);`)
+      ).toHaveLength(1);
+    });
+
+    it('allows the envInt / envFloat / envStr helpers', () => {
+      expect(
+        findRawEnvCoercions(
+          `const a = envInt('SHUTDOWN_DRAIN_MS', 5000);\n` +
+            `const b = envFloat('PRICE', 0);\n` +
+            `const c = envStr('SCHEMES', 's3,https');`
+        )
+      ).toEqual([]);
+    });
+
+    it("allows parseInt with the safe `?? ''` idiom", () => {
+      expect(
+        findRawEnvCoercions(
+          `const raw = Number.parseInt(process.env.DB_POOL_MAX ?? '', 10);\n` +
+            `if (!Number.isFinite(raw) || raw <= 0) return 30;`
+        )
+      ).toEqual([]);
+    });
+
+    it("allows parseInt with a `|| 'default'` fallback (|| fires on '')", () => {
+      expect(findRawEnvCoercions(`parseInt(process.env.API_PORT || '3001', 10);`)).toEqual([]);
+    });
+
+    it('does not match an identifier merely ending in "Number"', () => {
+      expect(
+        findRawEnvCoercions(`parseEnvBoundedNumber(process.env.THRESHOLD, 85, 50, 100);`)
+      ).toEqual([]);
+    });
+
+    it('ignores the pattern inside a line comment', () => {
+      expect(
+        findRawEnvCoercions(`// never write Number(process.env.X ?? 5000)\nconst a = 1;`)
+      ).toEqual([]);
+    });
+
+    it('ignores the pattern inside a block comment', () => {
+      expect(
+        findRawEnvCoercions(`/**\n * const t = Number(process.env.X ?? 1440); // WRONG\n */\nconst a = 1;`)
+      ).toEqual([]);
+    });
+
+    it('still flags real code that follows a comment quoting the pattern', () => {
+      const found = findRawEnvCoercions(
+        `// bad: Number(process.env.A ?? 1)\nconst n = Number(process.env.B ?? 2);`
+      );
+      expect(found).toHaveLength(1);
+      expect(found[0]!.line).toBe(2);
+    });
+
+    it('does not let a URL inside a string hide a later violation on the same line', () => {
+      const found = findRawEnvCoercions(
+        `const u = 'http://host/v1'; const n = Number(process.env.X ?? 5);`
+      );
+      expect(found).toHaveLength(1);
+    });
+
+    it('does not let a regex literal containing // hide a later violation', () => {
+      const found = findRawEnvCoercions(
+        `const re = /^https?:\\/\\//; const n = Number(process.env.X ?? 5);`
+      );
+      expect(found).toHaveLength(1);
+    });
+
+    it('does not treat division as a regex literal', () => {
+      const found = findRawEnvCoercions(
+        `const half = total / 2; const n = Number(process.env.X ?? 5);`
+      );
+      expect(found).toHaveLength(1);
+    });
+
+    it('reports one violation per offending call site', () => {
+      const found = findRawEnvCoercions(
+        `const a = Number(process.env.A ?? 1);\nconst b = Number(process.env.B ?? 2);`
+      );
+      expect(found.map((v) => v.line)).toEqual([1, 2]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2823

## The bug class

`Number(process.env.SOME_VAR ?? someDefault)` is safe only while the variable is genuinely **absent**. Compose threads every variable in explicitly, and an unset one is written `VAR: ${VAR:-}` — which `docker compose config` renders as `VAR: ""`. The container sees the variable **set to an empty string**. `??` does not fire on `''`, and `Number('') === 0`, so the reader silently yields **0** instead of its default.

This nearly shipped in #2819: two enrollment TTL readers of exactly this shape would have minted every installer bootstrap token and every redeemed child enrollment key **already expired** on any self-host that pulled the release without adding the new keys to its `.env` — agent enrollment dead. Those two were converted before merge; the rest of the class was left standing.

## Blast radius today: zero

None of the affected variables appears in `docker-compose.yml`, `deploy/docker-compose.prod.yml`, `docker-compose.dev.yml`, `.test.yml`, or any `docker-compose.override.yml.*` (verified). They were **latent**, and become live the moment anyone maps one into a service `environment:` block — a normal thing to do that gives no hint it is dangerous. Defaults are unchanged.

## 1. The sweep — 25 readers (21 numeric + 4 string), 12 files

Derived by a multi-line-aware scan (the earlier line-based greps missed `pamJobs.ts`, whose call is split across four lines, and false-positived on `parseEnvBoundedNumber(` matching its own `Number(` suffix). Prior counts of ~12 and ~19 were both wrong, and so was this PR's own first count of 20 — corrected to **25** during review by enumerating the diff directly.

**Genuinely broken on an empty value** (would yield `0`, or `NaN` where noted):

| Var | Reader |
|---|---|
| `SHUTDOWN_DRAIN_MS` | `src/index.ts` — 0 ms drain, in-flight requests cut |
| `ALERT_WORKER_MAX_DEVICES_PER_RUN`, `ALERT_WORKER_CHUNK_SIZE` | `jobs/alertWorker.ts` |
| `INCIDENT_CORRELATION_INTERVAL_MS`, `INCIDENT_TIMELINE_ENRICH_INTERVAL_MS`, `INCIDENT_SLA_MONITOR_INTERVAL_MS`, `INCIDENT_SLA_P1_MINUTES`, `INCIDENT_SLA_P2_MINUTES` | `jobs/incidentJobs.ts` — 0 ms `setInterval`, 0-minute SLA |
| `OFFLINE_DETECTOR_{MAX_DEVICES_PER_RUN,CHUNK_SIZE,REEVAL_MAX_DEVICES_PER_RUN,REEVAL_CHUNK_SIZE,REEVAL_INTERVAL_MS}` | `jobs/offlineDetector.ts` |
| `OFFLINE_DETECTOR_REEVAL_HORIZON_MINUTES` | `services/alertConditions/offlineDuration.ts` |
| `PROVISION_HANDLE_TTL_MINUTES` | `services/provisionCredentialHandle.ts` — handle born expired |
| `STALE_REAPER_MAX_PER_RUN` | `jobs/staleCommandReaper.ts` — 0 means *unlimited* here, so empty silently uncapped the reaper |
| `PAM_PENDING_REQUEST_TTL_MINUTES` | `jobs/pamJobs.ts` — **`NaN`** via `parseInt('')`, so the stale-request expirer computes an Invalid Date |
| `EVIDENCE_STORAGE_ALLOWED_SCHEMES` | `routes/incidents.validation.ts` — **empty allowlist**, every evidence URL rejected |

**Already safe by luck, converted anyway** so the guard needs no allowlist:

- `OFFBOARDING_DRAIN_WINDOW_HOURS` — the `>= 1` clamp caught the 0.
- `PATCH_TOMBSTONE_PRUNE_AFTER_HOURS` — `|| 168` fires on 0. **The `|| 168` is deliberately kept**: a 0-hour window would prune every `missing` tombstone on the very next scan, so 0 stays "unset" rather than becoming honoured. Behaviour is unchanged for integer and non-numeric values; a *fractional* value now truncates (`envInt` uses `parseInt`) — a real but currently unreachable difference, since nothing in the repo, compose, `.env.example`, or any test rig sets a fractional value for any swept var.
- `MCP_LLM_PRICE_INPUT_PER_M_USD` / `_OUTPUT_` (dev smoke script) — defaults were already 0.

Evaluation timing is unchanged everywhere: module-scope constants stayed module-scope constants (a straight substitution — `envInt` evaluates at the same point `Number(...)` did). No reader was gratuitously converted to call-time.

## 2. The helpers

- **`envFloat`** (`utils/envFloat.ts`) — 2 call sites. `envInt` would truncate a per-million-token **price** from `2.75` to `2`.
- **`envStr`** (`utils/envStr.ts`) — 4 call sites. The empty-allowlist case above, plus the smoke script's base URL / key / model.
- **No `envBool`.** `utils/envFlag.ts` already exists and does the job, and the only boolean reader (`OFFLINE_DETECTOR_REEVAL_ENABLED`, `(… ?? 'true') !== 'false'`) is fail-safe on `''` — it already yields `true`. Adding unused API was explicitly out of scope.

## 3. The guard — `utils/noRawEnvNumberCoercion.test.ts`

A source-tree scanning test (cheaper than a lint rule, and the house convention — closest precedents are `db/migrationGucAttributes.test.ts` and `apps/web/.../no-hash-in-usestate.test.ts`). Runs under the default `apps/api` unit runner → the **required `test-api` CI job**.

Two mechanical rules over all **1225** non-test files in `apps/api/src`:

1. `Number(process.env…)` is banned outright — use `envInt`/`envFloat`.
2. `parseInt` / `parseFloat` over a `process.env` read may only use `?? ''` as its nullish fallback. `?? '15'` is dead code (`??` never fires on `''`), so you get `parseInt('')` = `NaN`. `|| '15'` **is** allowed — `||` does fire on `''`.

**No allowlist.** After the sweep there are zero violations and no genuinely-correct exception exists; adding one later is a reviewed change to that file.

### Evidence it is discriminating, not vacuous

A grep guard that silently matches nothing is the classic failure here, so:

- **Proven red on a real reintroduction.** Reverting `provisionCredentialHandle.ts` to the old shape fails with `services/provisionCredentialHandle.ts:23 [number-coercion] Number(process.env.PROVISION_HANDLE_TTL_MINUTES ?? 5);`. Reverting `pamJobs.ts` fails rule 2 with `jobs/pamJobs.ts:36 [nullish-fallback]`. Both restored; green again.
- **23 self-check cases** pinned in the file — positive controls for every rule (including the multi-line and `process.env[name]` forms) and negative controls for each safe idiom (`envInt`, `?? ''`, `|| 'default'`, `parseEnvBoundedNumber(`), plus the tokenizer cases below.
- **An injection sweep over all 1225 scanned files** — inject a real violation into each (must fire), and inject an innocent comment quoting the pattern into each (must not): **0 false positives, 0 false negatives, 0 length mismatches**. Review found **3 real false positives** before the tokenizer was hardened — `routes/devices/softwareActions.ts` (a `/` inside a regex character class) and `services/email.ts` / `services/invoicePdf.ts` (nested `${cond ? ... : ''}` templates). Each would have redded the required `test-api` job on a file nobody touched.
- **The walk is asserted**: `files.length > 500` plus two known files must be present, so a broken root or over-eager skip list fails loudly instead of passing on an empty list.
- **Comments are blanked by a small tokenizer, not a regex.** The helper docs quote the forbidden pattern verbatim as the thing *not* to write, so a naive grep flags its own documentation. String literals are kept intact (rule 2 needs to see whether the fallback is `''`, and a `//` inside `'http://host/v1'` must not swallow the rest of the line); regex literals are tracked too so the `//` inside `/^https?:\/\//` is not read as a comment. Each of those behaviours has its own test.

## Verification

- Full `apps/api` suite: **1167 files passed, 17353 tests passed**, 0 failed (5 files / 64 tests skipped).
- Affected files single-fork: 19 files, 206 passed.
- `tsc --noEmit` on `apps/api`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



