### PR TITLE
test(api): pin the deployment_invites purge-cascade invariant — no exemption needed (#2821)

### DIFF
--- a/apps/api/src/jobs/enrollmentKeyCleanup.integration.test.ts
+++ b/apps/api/src/jobs/enrollmentKeyCleanup.integration.test.ts
@@ -23,6 +23,12 @@
  *   (c) token fully consumed (>= max_usage) -> key is DELETED
  *   (d) no bootstrap tokens at all          -> key is DELETED (regression
  *       guard on the pre-existing behaviour)
+ *
+ * Cases (e)-(g) pin the `deployment_invites` cascade lifetime (#2821). That
+ * issue asked whether invites need the same exemption bootstrap tokens got.
+ * They do NOT, and these tests are what makes that answer durable rather than
+ * a one-time reading of the code — see the describe block's own comment for
+ * the invariant and for the two ways a future change could break it.
  */
 import '../__tests__/integration/setup';
 
@@ -64,7 +70,14 @@ vi.mock('../services/redis', () => ({
 }));
 
 import { db, withSystemDbAccessContext } from '../db';
-import { enrollmentKeys, installerBootstrapTokens, organizations, partners, sites } from '../db/schema';
+import {
+  deploymentInvites,
+  enrollmentKeys,
+  installerBootstrapTokens,
+  organizations,
+  partners,
+  sites,
+} from '../db/schema';
 import { createEnrollmentKeyCleanupWorker } from './enrollmentKeyCleanup';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
@@ -131,6 +144,54 @@ async function tokenRowExists(id: string): Promise<boolean> {
       .from(installerBootstrapTokens)
       .where(eq(installerBootstrapTokens.id, id));
     return !!row;
+  });
+}
+
+async function inviteRowExists(id: string): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({ id: deploymentInvites.id })
+      .from(deploymentInvites)
+      .where(eq(deploymentInvites.id, id));
+    return !!row;
+  });
+}
+
+/**
+ * Seed an `enrollment_keys` row with the given expiry plus a
+ * `deployment_invites` row cascading off it — the exact pair the MCP tool
+ * `send_deployment_invites` creates (mintChildEnrollmentKey -> insert invite
+ * referencing that key's id).
+ */
+async function createInviteFixture(
+  ids: { partnerId: string; orgId: string; siteId: string },
+  unique: string,
+  expiresAt: Date,
+): Promise<{ keyId: string; inviteId: string }> {
+  return withSystemDbAccessContext(async () => {
+    const [key] = await db
+      .insert(enrollmentKeys)
+      .values({
+        orgId: ids.orgId,
+        siteId: ids.siteId,
+        name: `mcp-invite invitee-${unique}@example.com`,
+        key: `sweep-inv-key-${unique}`,
+        shortCode: unique.slice(-10),
+        expiresAt,
+        maxUsage: 1,
+      })
+      .returning({ id: enrollmentKeys.id });
+    const [invite] = await db
+      .insert(deploymentInvites)
+      .values({
+        partnerId: ids.partnerId,
+        orgId: ids.orgId,
+        enrollmentKeyId: key!.id,
+        invitedEmail: `invitee-${unique}@example.com`,
+        status: 'sent',
+      })
+      .returning({ id: deploymentInvites.id });
+    return { keyId: key!.id, inviteId: invite!.id };
   });
 }
 
@@ -279,6 +340,105 @@ describe('enrollment-key cleanup sweep — live bootstrap token exemption (#2775
       await runSweep();
 
       expect(await keyRowExists(keyId)).toBe(false);
+    } finally {
+      await cleanupFixture(ids);
+    }
+  });
+});
+
+/**
+ * #2821 asked whether `deployment_invites` — which also carries ON DELETE
+ * CASCADE against `enrollment_keys` — needs the same exemption the
+ * bootstrap-token case (a)-(d) above got for #2775.
+ *
+ * It does not, and the reason is structural rather than incidental. #2775 was
+ * reachable because an `installer_bootstrap_tokens` row has its OWN
+ * `expires_at`, decoupled from the transient 60-minute parent key it hangs
+ * off: the child could still be live long after the parent aged past the
+ * purge cutoff. `deployment_invites` has NO expiry column at all
+ * (db/schema/deploymentInvites.ts) — an invite is redeemable exactly while
+ * its one `enrollment_keys` row is, because both `peekShortCode` and
+ * `redeemShortCode` (routes/enrollmentKeys.ts) gate on that same
+ * `expires_at`. And the sweep's cutoff is EXPIRY-relative
+ * (`expires_at < now() - purgeAfterDays`), never age-relative, with
+ * `getPurgeAfterDays()` clamping to >= 1. So the purge can only ever reach a
+ * key that stopped working at least a full grace period earlier, whatever
+ * TTL the invite was minted with.
+ *
+ * The invariant these three cases pin: THE SWEEP NEVER DELETES AN ENROLLMENT
+ * KEY A DEPLOYMENT INVITE COULD STILL REDEEM. Two plausible future changes
+ * would break it and are exactly what (e)/(f) are here to catch — making the
+ * purge age-relative (keying on `created_at`), or giving `deployment_invites`
+ * its own independent `expires_at` the way bootstrap tokens have. (g) is the
+ * control: it proves the CASCADE is genuinely wired, so (e)/(f) can't pass
+ * vacuously because invites are somehow untouched by key deletion.
+ */
+describe('enrollment-key cleanup sweep — deployment_invites cascade lifetime (#2821, real Postgres)', () => {
+  runDb('(e) a LIVE invite key survives the sweep even when its TTL far exceeds the purge window', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ids = await createFixture(unique);
+    try {
+      // 30-day TTL — deliberately much longer than both the MCP tool's
+      // 7-day CHILD_KEY_TTL_SECONDS and the 7-day purge grace period. This
+      // is the precise scenario #2821 hypothesised as a silent-death bug.
+      // It is not one: the cutoff is expiry-relative, so a key that has not
+      // expired is unreachable by the DELETE no matter how long it lives.
+      const { keyId, inviteId } = await createInviteFixture(
+        ids,
+        unique,
+        new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      );
+
+      await runSweep();
+
+      expect(await keyRowExists(keyId)).toBe(true);
+      expect(await inviteRowExists(inviteId)).toBe(true);
+    } finally {
+      await cleanupFixture(ids);
+    }
+  });
+
+  runDb('(f) an invite key that expired INSIDE the grace window survives with its invite row intact', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ids = await createFixture(unique);
+    try {
+      // Expired 1 day ago: already unredeemable, but not yet past the
+      // 7-day grace period, so the row is still held for a later sweep.
+      const { keyId, inviteId } = await createInviteFixture(
+        ids,
+        unique,
+        new Date(Date.now() - 24 * 60 * 60 * 1000),
+      );
+
+      await runSweep();
+
+      expect(await keyRowExists(keyId)).toBe(true);
+      expect(await inviteRowExists(inviteId)).toBe(true);
+    } finally {
+      await cleanupFixture(ids);
+    }
+  });
+
+  runDb('(g) an invite key expired BEYOND the grace window is purged and cascades its invite row away', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ids = await createFixture(unique);
+    try {
+      // Expired 10 days ago — 3 days past the cutoff, and 10 days after the
+      // invite stopped being redeemable. Deleting it is correct, not the
+      // silent death #2821 was worried about. Asserting the invite row goes
+      // WITH it is what proves the ON DELETE CASCADE is real, which is what
+      // makes (e) and (f) meaningful assertions rather than vacuous ones.
+      const { keyId, inviteId } = await createInviteFixture(
+        ids,
+        unique,
+        EXPIRED_PAST_CUTOFF,
+      );
+      expect(await inviteRowExists(inviteId)).toBe(true);
+
+      await runSweep();
+
+      expect(await keyRowExists(keyId)).toBe(false);
+      expect(await inviteRowExists(inviteId)).toBe(false);
     } finally {
       await cleanupFixture(ids);
     }

--- a/apps/api/src/jobs/enrollmentKeyCleanup.integration.test.ts
+++ b/apps/api/src/jobs/enrollmentKeyCleanup.integration.test.ts
@@ -24,15 +24,16 @@
  *   (d) no bootstrap tokens at all          -> key is DELETED (regression
  *       guard on the pre-existing behaviour)
  *
- * Cases (e)-(g) pin the `deployment_invites` cascade lifetime (#2821). That
+ * Cases (e)-(h) pin the `deployment_invites` cascade lifetime (#2821). That
  * issue asked whether invites need the same exemption bootstrap tokens got.
  * They do NOT, and these tests are what makes that answer durable rather than
- * a one-time reading of the code — see the describe block's own comment for
- * the invariant and for the two ways a future change could break it.
+ * a one-time reading of the code — see the second describe block's comment
+ * for the invariant, for what each case actually discriminates, and for the
+ * one future change that would defeat the whole suite.
  */
 import '../__tests__/integration/setup';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { eq } from 'drizzle-orm';
 
 // Mock ONLY BullMQ's Queue/Worker classes and the redis connection helper —
@@ -158,15 +159,23 @@ async function inviteRowExists(id: string): Promise<boolean> {
 }
 
 /**
- * Seed an `enrollment_keys` row with the given expiry plus a
- * `deployment_invites` row cascading off it — the exact pair the MCP tool
- * `send_deployment_invites` creates (mintChildEnrollmentKey -> insert invite
- * referencing that key's id).
+ * Seed an `enrollment_keys` row plus a `deployment_invites` row cascading off
+ * it — the same SHAPE the MCP tool `send_deployment_invites` creates
+ * (mintChildEnrollmentKey -> insert invite referencing that key's id). Not
+ * byte-identical to production: `key` here is a readable literal rather than a
+ * `hashEnrollmentKey` digest, and `invitedByApiKeyId` is left null to avoid
+ * dragging an `api_keys` fixture in. Neither column appears in the sweep's
+ * predicate, so neither can affect the outcome.
+ *
+ * `createdAt` is settable on purpose. Leaving every fixture at `defaultNow()`
+ * would mean no row in this file is ever OLD-BUT-LIVE, and an age-relative
+ * purge arm (see the describe block) could then be added without any test
+ * noticing. Backdating is what makes that mutation detectable.
  */
 async function createInviteFixture(
   ids: { partnerId: string; orgId: string; siteId: string },
   unique: string,
-  expiresAt: Date,
+  opts: { expiresAt: Date | null; createdAt?: Date },
 ): Promise<{ keyId: string; inviteId: string }> {
   return withSystemDbAccessContext(async () => {
     const [key] = await db
@@ -176,8 +185,12 @@ async function createInviteFixture(
         siteId: ids.siteId,
         name: `mcp-invite invitee-${unique}@example.com`,
         key: `sweep-inv-key-${unique}`,
-        shortCode: unique.slice(-10),
-        expiresAt,
+        // 10 chars, alphanumeric only — `allocateShortCode`'s alphabet has no
+        // '-', so strip the separator rather than ship a code production
+        // could never mint.
+        shortCode: unique.replace(/-/g, '').slice(-10),
+        expiresAt: opts.expiresAt,
+        ...(opts.createdAt ? { createdAt: opts.createdAt } : {}),
         maxUsage: 1,
       })
       .returning({ id: enrollmentKeys.id });
@@ -195,11 +208,65 @@ async function createInviteFixture(
   });
 }
 
+/**
+ * A sacrificial key that is unambiguously past the cutoff and has no children,
+ * so the sweep MUST delete it. Seeded alongside a survive-case fixture and
+ * asserted gone in the same run, it proves the DELETE actually matched rows —
+ * without it, a survive-assertion would also pass if the sweep silently
+ * matched NOTHING (wrong DB context, swallowed predicate error).
+ *
+ * Deliberately not an assertion on the processor's returned `deletedCount`:
+ * the sweep is system-wide with no tenant filter, so that number also counts
+ * unrelated rows and is not deterministic under a shared test database.
+ */
+async function createCanaryKey(
+  ids: { orgId: string; siteId: string },
+  unique: string,
+): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const [key] = await db
+      .insert(enrollmentKeys)
+      .values({
+        orgId: ids.orgId,
+        siteId: ids.siteId,
+        name: 'canary — must be swept',
+        key: `sweep-canary-${unique}`,
+        expiresAt: EXPIRED_PAST_CUTOFF,
+        maxUsage: 1,
+      })
+      .returning({ id: enrollmentKeys.id });
+    return key!.id;
+  });
+}
+
 // The default purge grace period is 7 days (DEFAULT_PURGE_AFTER_DAYS). Every
 // scenario below creates a key that expired 10 days ago — comfortably past
 // that cutoff, so the ONLY thing that can save it from the sweep is the
 // live-bootstrap-token exemption.
 const EXPIRED_PAST_CUTOFF = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+
+// Pin the grace period for the whole file rather than inheriting whatever the
+// ambient environment has. `vitest.integration.config.ts` loads the repo-root
+// `.env.test`, so an operator setting ENROLLMENT_KEY_PURGE_AFTER_DAYS=1 there
+// would silently break case (f), whose expired-1-day-ago fixture is computed a
+// few milliseconds before the worker's own cutoff. The mocked sibling suite
+// (enrollmentKeyCleanup.test.ts) already save/restores this var; mirroring it
+// here decouples all of (a)-(h) from the environment.
+const PINNED_PURGE_AFTER_DAYS = '7';
+let previousPurgeAfterDays: string | undefined;
+
+beforeAll(() => {
+  previousPurgeAfterDays = process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
+  process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS = PINNED_PURGE_AFTER_DAYS;
+});
+
+afterAll(() => {
+  if (previousPurgeAfterDays === undefined) {
+    delete process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS;
+  } else {
+    process.env.ENROLLMENT_KEY_PURGE_AFTER_DAYS = previousPurgeAfterDays;
+  }
+});
 
 describe('enrollment-key cleanup sweep — live bootstrap token exemption (#2775, real Postgres)', () => {
   runDb('(a) an expired key holding a live, unexhausted bootstrap token SURVIVES the sweep', async () => {
@@ -365,32 +432,60 @@ describe('enrollment-key cleanup sweep — live bootstrap token exemption (#2775
  * key that stopped working at least a full grace period earlier, whatever
  * TTL the invite was minted with.
  *
- * The invariant these three cases pin: THE SWEEP NEVER DELETES AN ENROLLMENT
- * KEY A DEPLOYMENT INVITE COULD STILL REDEEM. Two plausible future changes
- * would break it and are exactly what (e)/(f) are here to catch — making the
- * purge age-relative (keying on `created_at`), or giving `deployment_invites`
- * its own independent `expires_at` the way bootstrap tokens have. (g) is the
- * control: it proves the CASCADE is genuinely wired, so (e)/(f) can't pass
- * vacuously because invites are somehow untouched by key deletion.
+ * The invariant: THE SWEEP NEVER DELETES AN ENROLLMENT KEY A DEPLOYMENT
+ * INVITE COULD STILL REDEEM.
+ *
+ * What each case actually discriminates (verified by mutating
+ * enrollmentKeyCleanup.ts and watching these go red — not assumed):
+ *   (e) the only redeemable-key case in the file. Its key is LIVE but
+ *       BACKDATED 30 days, which is what catches an age-relative purge:
+ *       both `lt(createdAt, cutoff)` replacing the expiry guard AND an
+ *       additive `or(lt(expiresAt, cutoff), lt(createdAt, cutoff))` arm.
+ *       An additive arm is the realistic regression — the sweep's docblock
+ *       advertises that long-TTL keys are never reclaimed, so an ops-pressure
+ *       "cap it by age" patch lands exactly there. Also fails if the
+ *       expiry-window guard is dropped entirely.
+ *   (f) NOT an invariant case: a key that expired 1 day ago is already
+ *       unredeemable. It is a grace-window retention guard — the only
+ *       inside-the-window case in the file — and fails if the grace period
+ *       is removed (`cutoff = now()`), which is exactly what the on-demand
+ *       purge route does.
+ *   (g) the cascade control: proves the ON DELETE CASCADE is genuinely
+ *       wired, so (e)/(f) aren't passing merely because invites are
+ *       untouched by key deletion.
+ *   (h) the strongest form of the invariant — a NULL-expiry key is
+ *       redeemable FOREVER (`peekShortCode` permits it), so it must never be
+ *       swept. Fails if the `isNotNull` guard is dropped.
+ *
+ * Each survive-case also seeds a canary key that MUST die in the same sweep,
+ * so "the row survived" can never be satisfied by a sweep that matched
+ * nothing at all.
+ *
+ * !! LIMIT OF THIS SUITE !! If `deployment_invites` ever gains its own
+ * independent `expires_at` — the decoupling that made #2775 real — NONE of
+ * these cases will catch the resulting bug, and (g) would actively bless it
+ * by asserting the invite is cascaded away. Whoever adds that column must add
+ * a case pinning invite-expiry > key-expiry at the same time.
  */
 describe('enrollment-key cleanup sweep — deployment_invites cascade lifetime (#2821, real Postgres)', () => {
-  runDb('(e) a LIVE invite key survives the sweep even when its TTL far exceeds the purge window', async () => {
+  runDb('(e) an OLD but still-redeemable invite key survives — long TTL and age are both irrelevant to an expiry-relative cutoff', async () => {
     const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const ids = await createFixture(unique);
     try {
-      // 30-day TTL — deliberately much longer than both the MCP tool's
-      // 7-day CHILD_KEY_TTL_SECONDS and the 7-day purge grace period. This
-      // is the precise scenario #2821 hypothesised as a silent-death bug.
-      // It is not one: the cutoff is expiry-relative, so a key that has not
-      // expired is unreachable by the DELETE no matter how long it lives.
-      const { keyId, inviteId } = await createInviteFixture(
-        ids,
-        unique,
-        new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
-      );
+      // The realistic shape of #2821's fear: an invite SENT 30 DAYS AGO that
+      // is still redeemable for another 30. Backdating `created_at` is
+      // load-bearing — with it left at now(), an additive age-relative purge
+      // arm would sail past this test while hard-deleting exactly this row in
+      // production.
+      const { keyId, inviteId } = await createInviteFixture(ids, unique, {
+        createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      });
+      const canaryId = await createCanaryKey(ids, `${unique}-canary`);
 
       await runSweep();
 
+      expect(await keyRowExists(canaryId)).toBe(false); // the sweep really ran
       expect(await keyRowExists(keyId)).toBe(true);
       expect(await inviteRowExists(inviteId)).toBe(true);
     } finally {
@@ -398,20 +493,20 @@ describe('enrollment-key cleanup sweep — deployment_invites cascade lifetime (
     }
   });
 
-  runDb('(f) an invite key that expired INSIDE the grace window survives with its invite row intact', async () => {
+  runDb('(f) an invite key that expired INSIDE the grace window is retained (already unredeemable, but not yet purgeable)', async () => {
     const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const ids = await createFixture(unique);
     try {
       // Expired 1 day ago: already unredeemable, but not yet past the
       // 7-day grace period, so the row is still held for a later sweep.
-      const { keyId, inviteId } = await createInviteFixture(
-        ids,
-        unique,
-        new Date(Date.now() - 24 * 60 * 60 * 1000),
-      );
+      const { keyId, inviteId } = await createInviteFixture(ids, unique, {
+        expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+      const canaryId = await createCanaryKey(ids, `${unique}-canary`);
 
       await runSweep();
 
+      expect(await keyRowExists(canaryId)).toBe(false); // the sweep really ran
       expect(await keyRowExists(keyId)).toBe(true);
       expect(await inviteRowExists(inviteId)).toBe(true);
     } finally {
@@ -428,17 +523,41 @@ describe('enrollment-key cleanup sweep — deployment_invites cascade lifetime (
       // silent death #2821 was worried about. Asserting the invite row goes
       // WITH it is what proves the ON DELETE CASCADE is real, which is what
       // makes (e) and (f) meaningful assertions rather than vacuous ones.
-      const { keyId, inviteId } = await createInviteFixture(
-        ids,
-        unique,
-        EXPIRED_PAST_CUTOFF,
-      );
+      const { keyId, inviteId } = await createInviteFixture(ids, unique, {
+        expiresAt: EXPIRED_PAST_CUTOFF,
+      });
       expect(await inviteRowExists(inviteId)).toBe(true);
 
       await runSweep();
 
       expect(await keyRowExists(keyId)).toBe(false);
       expect(await inviteRowExists(inviteId)).toBe(false);
+    } finally {
+      await cleanupFixture(ids);
+    }
+  });
+
+  runDb('(h) an invite key with NULL expiry is never swept — it is redeemable forever', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ids = await createFixture(unique);
+    try {
+      // `peekShortCode` only rejects on `expiresAt && expiresAt < now`, so a
+      // NULL-expiry key stays redeemable indefinitely — the strongest form of
+      // the invariant. Not reachable today (mintChildEnrollmentKey always sets
+      // an expiry), which is precisely why it is worth pinning: nothing else
+      // would notice if the `isNotNull` guard were dropped and every
+      // never-expiring invite link vanished at once.
+      const { keyId, inviteId } = await createInviteFixture(ids, unique, {
+        createdAt: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000),
+        expiresAt: null,
+      });
+      const canaryId = await createCanaryKey(ids, `${unique}-canary`);
+
+      await runSweep();
+
+      expect(await keyRowExists(canaryId)).toBe(false); // the sweep really ran
+      expect(await keyRowExists(keyId)).toBe(true);
+      expect(await inviteRowExists(inviteId)).toBe(true);
     } finally {
       await cleanupFixture(ids);
     }

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -153,11 +153,12 @@ export default defineConfig({
       // (real Redis; no Postgres fixtures used). Belongs to
       // vitest.integration.config.ts, not the no-Redis unit runner.
       'src/services/mfaStepUpGrant.integration.test.ts',
-      // Co-located real-DB integration test for the #2775 live-bootstrap-token
-      // exemption in the nightly enrollment-key purge sweep: proves Postgres
-      // itself evaluates the correlated NOT EXISTS subquery per row (the
-      // mocked unit suite only asserts the generated SQL's shape). Only
-      // BullMQ's Queue/Worker classes are mocked; imports
+      // Co-located real-DB integration test for the nightly enrollment-key
+      // purge sweep: the #2775 live-bootstrap-token exemption (proving
+      // Postgres itself evaluates the correlated NOT EXISTS subquery per row,
+      // where the mocked unit suite only asserts the generated SQL's shape)
+      // AND the #2821 deployment_invites cascade lifetime. Only BullMQ's
+      // Queue/Worker classes are mocked; imports
       // `__tests__/integration/setup` (real postgres pool + autoMigrate).
       'src/jobs/enrollmentKeyCleanup.integration.test.ts',
     ],


### PR DESCRIPTION
Closes #2821

## Verdict: no exemption needed — the bug is not reachable

#2821 asked whether `deployment_invites`, which also cascades off `enrollment_keys`, needs the live-child exemption that #2817 added for installer bootstrap tokens (#2775). **It does not.** Adding one would be dead code. This PR ships the guard test instead of a dead predicate branch.

### Why #2775 was reachable and this is not

| | `installer_bootstrap_tokens` (#2775 — real bug) | `deployment_invites` (#2821) |
|---|---|---|
| Own `expires_at`? | **Yes** — independent of the parent key | **No such column at all** |
| Parent key lifetime | transient, 60 min | the invite's *only* lifetime |
| Child live after parent expires? | **Yes**, up to a year | Impossible — same row |

An `installer_bootstrap_tokens` row carries its own `expires_at`, decoupled from the transient 60-minute parent it hangs off, so the child could still be live long after the parent aged past the purge cutoff. That decoupling is the entire bug.

`deployment_invites` has no expiry column (`apps/api/src/db/schema/deploymentInvites.ts`). An invite is redeemable exactly while its single `enrollment_keys` row is, because both `peekShortCode` (`routes/enrollmentKeys.ts:262`) and `redeemShortCode` (`:295`) gate on that same `expires_at`. There is no second lifetime to strand.

### The premise conflates two different quantities

The issue reasons that a TTL longer than `ENROLLMENT_KEY_PURGE_AFTER_DAYS` is dangerous, and notes the MCP tool's 7-day `CHILD_KEY_TTL_SECONDS` sits "exactly on the boundary". But the sweep's cutoff is **expiry-relative**, not age-relative:

```ts
const cutoff = new Date(Date.now() - purgeAfterDays * 86_400_000);
// ... lt(enrollmentKeys.expiresAt, cutoff)
```

TTL and grace period are **additive, not comparable**. A 7-day invite expires at T+7d and becomes purgeable at T+14d — a full grace period after it stopped working. `getPurgeAfterDays()` clamps to `> 0`, so even the most aggressive configuration purges no earlier than expiry + 1 day.

### Writer enumeration (step 1 of the issue, done exhaustively)

- **One** production writer inserts `deployment_invites`: `send_deployment_invites` (`modules/mcpInvites/tools/sendDeploymentInvites.ts:153`), minting at `min(7d, partner maxEnrollmentLinkTtlMinutes)`.
- **Nothing** anywhere updates `deployment_invites.enrollment_key_id` after insert — the only `.set()` calls write `{status, clickedAt}` and `{status, enrolledAt, deviceId}`.
- `enrollment_keys` has **no self-referential parent column**, so there is no second-order cascade path into an invite.

## What this PR ships

The invariant, pinned as a test:

> **The sweep never deletes an enrollment key a deployment invite could still redeem.**

Four real-Postgres cases join the existing `(a)`–`(d)` bootstrap-token suite, driving the real captured Worker processor against real rows:

- **(e)** key **backdated 30 days** but still live for another 30 → **survives**. The only redeemable-key case in the file, and the one that catches an age-relative purge.
- **(f)** key expired *inside* the grace window → **retained**. Explicitly **not** an invariant case — a key that expired a day ago is already unredeemable — it is a grace-window retention guard.
- **(g)** key expired *beyond* the grace window → purged, invite cascaded. The cascade control.
- **(h)** **NULL-expiry** key → never swept. `peekShortCode` permits NULL expiry, so such a key is redeemable *forever* — the strongest form of the invariant.

Every survive-case also seeds a **canary key that must die in the same sweep**, so "the row survived" can never be satisfied by a sweep that matched nothing at all.

`ENROLLMENT_KEY_PURGE_AFTER_DAYS` is pinned for the file (mirroring the mocked sibling suite), since (f)'s fixture sits one day inside a seven-day window.

## The first cut of this test was defective — and that is the main lesson

Review caught that the original `(e)`/`(f)` **claimed** to catch an age-relative purge and did not. Every fixture left `created_at` at `defaultNow()`, so no row was ever *old-but-live*. Verified empirically, not argued: this mutation passed **all 7** original cases —

```ts
or(lt(enrollmentKeys.expiresAt, cutoff), lt(enrollmentKeys.createdAt, cutoff))
```

— while in production it hard-deletes a 10-day-old key with a 30-day TTL and a live invite on it: exactly the silent death #2821 feared. A guard test whose docblock overclaims its coverage is worse than no test, because the next engineer reads that docblock to decide whether they are protected. Backdating `(e)`'s `created_at` is what closes it.

### Mutation matrix (corrected suite)

| Mutation to `enrollmentKeyCleanup.ts` | Result |
|---|---|
| **A** — expiry-window guard removed | **(e), (f) fail** |
| **B** — grace period removed (`cutoff = now()`) | **(f) fails** |
| **C** — additive age-relative arm | **(e) fails** — *was 7/7 green before* |
| **D** — `isNotNull` guard removed | **(h) fails** |
| *unmutated* | **8/8 pass** |

All mutations reverted; `git diff` confirms `enrollmentKeyCleanup.ts` is **unchanged** by this PR.

### Known limit, stated in the code

If `deployment_invites` ever gains its own independent `expires_at` — the decoupling that made #2775 real — **none** of these cases catch the resulting bug, and **(g) would actively bless it** by asserting the invite is cascaded away. That warning is in the describe block so whoever adds the column sees it.

## Scope check

Test-only — no table structure touched, so no cascade/allowlist registration is required. Verified rather than assumed: `deployment_invites` is already present in `CORE_ORG_CASCADE_DELETE_ORDER`, `CORE_DEVICE_CASCADE_DELETE_TABLES` (×2) and the RLS coverage allowlist.

## Verification

- `enrollmentKeyCleanup.integration.test.ts` — **8/8 pass** against real Postgres
- `enrollmentKeyCleanup.test.ts` + `sendDeploymentInvites.test.ts` — **26/26 pass**
- `tsc --noEmit` on `apps/api` — clean (exit 0)

## Related finding — filed separately as #2832, not fixed here

`POST /enrollment-keys/purge-expired` has **no** bootstrap-token exemption at all, so #2817's fix is incomplete on the on-demand path the cleanup job's own header names as its counterpart. Reachable **60 minutes** after key creation (vs the job's 7 days) via a one-click **"Delete expired"** button in `EnrollmentKeyManager.tsx`, with zero test coverage and a code comment that now asserts the opposite of the truth. Filed on its own rather than smuggled into a PR that closes a "no bug here" investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
