### PR TITLE
fix(reports): enforce tenant and site scope across the report authority (security wave 2)

### DIFF
--- a/apps/api/migrations/2026-08-06-a-report-site-scope.sql
+++ b/apps/api/migrations/2026-08-06-a-report-site-scope.sql
@@ -1,0 +1,148 @@
+-- Persist immutable site-scope provenance for report definitions and runs.
+-- All columns remain nullable during the mixed-version old-writer window.
+
+ALTER TABLE reports
+  ADD COLUMN IF NOT EXISTS execution_scope_version integer,
+  ADD COLUMN IF NOT EXISTS execution_scope_kind varchar(32),
+  ADD COLUMN IF NOT EXISTS execution_scope_site_ids uuid[],
+  ADD COLUMN IF NOT EXISTS execution_scope_user_id uuid,
+  ADD COLUMN IF NOT EXISTS execution_scope_fingerprint varchar(64),
+  ADD COLUMN IF NOT EXISTS execution_scope_captured_at timestamptz;
+
+ALTER TABLE report_runs
+  ADD COLUMN IF NOT EXISTS execution_scope_version integer,
+  ADD COLUMN IF NOT EXISTS execution_scope_kind varchar(32),
+  ADD COLUMN IF NOT EXISTS execution_scope_site_ids uuid[],
+  ADD COLUMN IF NOT EXISTS execution_scope_user_id uuid,
+  ADD COLUMN IF NOT EXISTS execution_scope_fingerprint varchar(64),
+  ADD COLUMN IF NOT EXISTS execution_scope_captured_at timestamptz;
+
+DO $$
+DECLARE
+  classified_count bigint;
+BEGIN
+  UPDATE reports
+  SET execution_scope_version = 1,
+      execution_scope_kind = 'legacy_unscoped',
+      execution_scope_site_ids = NULL,
+      execution_scope_user_id = created_by,
+      execution_scope_fingerprint = encode(
+        sha256(convert_to(
+          '{"version":1,"kind":"legacy_unscoped","orgId":"' || org_id::text || '"}',
+          'UTF8'
+        )),
+        'hex'
+      ),
+      execution_scope_captured_at = CURRENT_TIMESTAMP
+  WHERE execution_scope_version IS NULL
+    AND execution_scope_kind IS NULL
+    AND execution_scope_site_ids IS NULL
+    AND execution_scope_user_id IS NULL
+    AND execution_scope_fingerprint IS NULL
+    AND execution_scope_captured_at IS NULL;
+
+  GET DIAGNOSTICS classified_count = ROW_COUNT;
+  RAISE WARNING 'classified % historical reports as legacy_unscoped', classified_count;
+END $$;
+
+DO $$
+DECLARE
+  classified_count bigint;
+BEGIN
+  UPDATE report_runs AS run
+  SET execution_scope_version = 1,
+      execution_scope_kind = 'legacy_unscoped',
+      execution_scope_site_ids = NULL,
+      execution_scope_user_id = report.created_by,
+      execution_scope_fingerprint = encode(
+        sha256(convert_to(
+          '{"version":1,"kind":"legacy_unscoped","orgId":"' || report.org_id::text || '"}',
+          'UTF8'
+        )),
+        'hex'
+      ),
+      execution_scope_captured_at = CURRENT_TIMESTAMP
+  FROM reports AS report
+  WHERE run.report_id = report.id
+    AND run.execution_scope_version IS NULL
+    AND run.execution_scope_kind IS NULL
+    AND run.execution_scope_site_ids IS NULL
+    AND run.execution_scope_user_id IS NULL
+    AND run.execution_scope_fingerprint IS NULL
+    AND run.execution_scope_captured_at IS NULL;
+
+  GET DIAGNOSTICS classified_count = ROW_COUNT;
+  RAISE WARNING 'classified % historical report runs as legacy_unscoped', classified_count;
+END $$;
+
+ALTER TABLE reports DROP CONSTRAINT IF EXISTS reports_execution_scope_shape_chk;
+ALTER TABLE reports ADD CONSTRAINT reports_execution_scope_shape_chk CHECK ((
+  (
+    execution_scope_version IS NULL
+    AND execution_scope_kind IS NULL
+    AND execution_scope_site_ids IS NULL
+    AND execution_scope_user_id IS NULL
+    AND execution_scope_fingerprint IS NULL
+    AND execution_scope_captured_at IS NULL
+  )
+  OR
+  (
+    execution_scope_version = 1
+    AND execution_scope_fingerprint IS NOT NULL
+    AND execution_scope_captured_at IS NOT NULL
+    AND (
+      (
+        execution_scope_kind = 'restricted'
+        AND execution_scope_site_ids IS NOT NULL
+        AND execution_scope_user_id IS NOT NULL
+      )
+      OR
+      (
+        execution_scope_kind = 'unrestricted'
+        AND execution_scope_site_ids IS NULL
+        AND execution_scope_user_id IS NOT NULL
+      )
+      OR
+      (
+        execution_scope_kind = 'legacy_unscoped'
+        AND execution_scope_site_ids IS NULL
+      )
+    )
+  )
+) IS TRUE);
+
+ALTER TABLE report_runs DROP CONSTRAINT IF EXISTS report_runs_execution_scope_shape_chk;
+ALTER TABLE report_runs ADD CONSTRAINT report_runs_execution_scope_shape_chk CHECK ((
+  (
+    execution_scope_version IS NULL
+    AND execution_scope_kind IS NULL
+    AND execution_scope_site_ids IS NULL
+    AND execution_scope_user_id IS NULL
+    AND execution_scope_fingerprint IS NULL
+    AND execution_scope_captured_at IS NULL
+  )
+  OR
+  (
+    execution_scope_version = 1
+    AND execution_scope_fingerprint IS NOT NULL
+    AND execution_scope_captured_at IS NOT NULL
+    AND (
+      (
+        execution_scope_kind = 'restricted'
+        AND execution_scope_site_ids IS NOT NULL
+        AND execution_scope_user_id IS NOT NULL
+      )
+      OR
+      (
+        execution_scope_kind = 'unrestricted'
+        AND execution_scope_site_ids IS NULL
+        AND execution_scope_user_id IS NOT NULL
+      )
+      OR
+      (
+        execution_scope_kind = 'legacy_unscoped'
+        AND execution_scope_site_ids IS NULL
+      )
+    )
+  )
+) IS TRUE);

--- a/apps/api/src/__tests__/helpers/routeScan.ts
+++ b/apps/api/src/__tests__/helpers/routeScan.ts
@@ -102,6 +102,20 @@ const CANONICAL_GATE_NAMES = [
   // tickets routes, alerts create-from-alert, and aiToolsTicketing.
   'ticketSiteScopeCondition',
   'deviceInSiteScope',
+  // Report-data alert aggregates (Wave 2 tenant/site scope). Both emit the
+  // device-site predicate itself — `alertsDeviceSiteCondition` returns
+  // `inArray(devices.siteId, …)` for a restricted scope, and
+  // `alertsMultiOrgDeviceCondition` composes one `(org AND site)` branch per
+  // authorized organization. They are file-local to routes/reports/data.ts
+  // today, exactly as ticketSiteScopeCondition/deviceInSiteScope once were.
+  //
+  // Deliberately NOT listed: `resolveRequestReportAuthority(Map)`. Those
+  // RESOLVE a scope but do not APPLY it, so accepting them as gate tokens
+  // would let a future handler resolve authority, never build a predicate,
+  // and still scan clean — the exact false negative this detector exists to
+  // prevent.
+  'alertsDeviceSiteCondition',
+  'alertsMultiOrgDeviceCondition',
   // NOTE: `getDeviceWithOrgCheck` (routes/remote/helpers.ts) is a cross-file
   // site-aware resolver, but it is deliberately NOT listed as a gate token.
   // It gates only the code path where a deviceId is supplied — e.g.

--- a/apps/api/src/__tests__/integration/report-site-scope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/report-site-scope.integration.test.ts
@@ -1124,7 +1124,7 @@ describe('Wave 2 · definition + template pages report exact visible totals', ()
     const token = f.siteAUser.token;
     const ghost = randomUUID();
 
-    const probes: Array<[string, () => Promise<Response>]> = [];
+    const probes: Array<[string, () => Response | Promise<Response>]> = [];
     for (const [label, id] of [
       ['hidden-other-site', hidden.otherSite],
       ['hidden-unrestricted', hidden.unrestricted],

--- a/apps/api/src/__tests__/integration/report-site-scope.integration.test.ts
+++ b/apps/api/src/__tests__/integration/report-site-scope.integration.test.ts
@@ -1,0 +1,2489 @@
+/**
+ * Wave 2 release gate — tenant, site, and mixed-version isolation for reports.
+ *
+ * Everything here runs against REAL PostgreSQL under
+ * `vitest.integration.config.ts`. Route traffic goes through the production
+ * middleware chain (authMiddleware -> requireScope -> requirePermission) on the
+ * unprivileged `breeze_app` pool, so forced RLS is live for every assertion.
+ * Fixtures are seeded through the BYPASSRLS superuser pool, which means every
+ * hidden row physically exists and is reachable by a pre-wave (org-only) query
+ * — a vacuous "nothing was there anyway" pass is impossible.
+ *
+ * Non-vacuity is asserted explicitly rather than assumed:
+ *
+ *  - Cross-tenant forge: the SAME insert is proven to succeed as the superuser
+ *    and from its own organization's context, so the RLS rejection cannot be a
+ *    typo or a missing column.
+ *  - Hidden rows: each visibility test also asserts the tenant-only (pre-wave)
+ *    count, so the gap between "org can reach it" and "the route returns it" is
+ *    measured, not asserted in the abstract.
+ *  - "Selects no payload" / "issues no query": proven by REVOKEing the relevant
+ *    SELECT privilege from `breeze_app` for the duration of the request. A denied
+ *    path must still answer 404/403/zero-safe; the positive control proves the
+ *    revoke actually bites by making the authorized path fail.
+ *
+ * Fixture topology (rebuilt per test — setup.ts TRUNCATEs on beforeEach):
+ *
+ *   Partner P1
+ *     Org A  sites A1, A2   — partner user has NO organization_users row (partner fallback)
+ *     Org B  sites B1, B2   — partner user HAS an organization_users row restricted to B1
+ *     Org D  site  D1       — partner user's membership role lacks reports:read (denied)
+ *     Org E  site  E1       — partner user's membership has site_ids = '{}' (restricted-empty)
+ *   Partner P2
+ *     Org F  site  F1       — wholly inaccessible to every P1 principal
+ */
+import './setup';
+
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { and, eq, sql } from 'drizzle-orm';
+
+import { getAppDb, getTestDb } from './setup';
+import {
+  createOrganization,
+  createPartner,
+  createRole,
+  createSite,
+  createUser,
+  grantRolePermissions,
+} from './db-utils';
+import { createAccessToken, type TokenPayload } from '../../services/jwt';
+import { clearPermissionCache } from '../../services/permissions';
+import { withSystemDbAccessContext } from '../../db';
+import {
+  alertRules,
+  alertTemplates,
+  alerts,
+  devices,
+  organizationUsers,
+  partnerUsers,
+  reportRuns,
+  reports,
+  users,
+} from '../../db/schema';
+import { reportRoutes } from '../../routes/reports';
+import type { AuthContext } from '../../middleware/auth';
+import {
+  decodeSiteScope,
+  resolveLiveReportAuthority,
+  resolveRequestReportAuthority,
+  resolveRequestReportAuthorityMap,
+  siteScopeFingerprint,
+  type PersistedSiteScopeColumns,
+} from '../../services/siteScope';
+import { previousBaselineFor } from '../../services/reportGenerationService';
+
+// The scheduled-report worker's email hop must be observable: a denied run has
+// to reach ZERO delivery attempts, and the positive control has to reach one.
+// Only `getEmailService` is replaced; every other export stays real.
+const emailProbe = vi.hoisted(() => ({ calls: 0 }));
+vi.mock('../../services/email', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../services/email')>();
+  return {
+    ...actual,
+    getEmailService: () => {
+      emailProbe.calls += 1;
+      return null;
+    },
+  };
+});
+
+// Imported AFTER the mock declaration for readability; vitest hoists vi.mock
+// above every import, so the worker still sees the probed email service.
+import { findDueReports, processRunScheduledReport } from '../../jobs/reportScheduleWorker';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
+const REPORT_PERMS = [
+  { resource: 'reports', action: 'read' },
+  { resource: 'reports', action: 'write' },
+  { resource: 'reports', action: 'export' },
+  { resource: 'reports', action: 'delete' },
+];
+const MIGRATION_FILE = '2026-08-06-a-report-site-scope.sql';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/reports', reportRoutes);
+  return app;
+}
+
+function authed(token: string, init: RequestInit = {}): RequestInit {
+  return {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...JSON_HEADERS,
+      ...(init.headers as Record<string, string> | undefined),
+    },
+  };
+}
+
+// ───────────────────────────── raw SQL helpers ─────────────────────────────
+
+/**
+ * postgres.js refuses a JS `Date` bound through a raw `sql` template (drizzle
+ * tags it with the timestamp OID and the driver then expects a string), so raw
+ * inserts pass the naive-UTC literal drizzle itself writes for `timestamp`
+ * columns.
+ */
+function naiveUtc(value: Date): string {
+  return value.toISOString().slice(0, 23).replace('T', ' ');
+}
+
+async function rawRows<T = Record<string, unknown>>(
+  query: ReturnType<typeof sql>,
+): Promise<T[]> {
+  const result = await getTestDb().execute(query);
+  return result as unknown as T[];
+}
+
+async function scalar<T>(query: ReturnType<typeof sql>): Promise<T> {
+  const rows = await rawRows<Record<string, T>>(query);
+  const first = rows[0];
+  if (!first) throw new Error('scalar(): query returned no rows');
+  return Object.values(first)[0] as T;
+}
+
+/**
+ * Run `fn` with `breeze_app`'s SELECT privilege on `table` removed (optionally
+ * keeping every column except `exceptColumn`). Used to prove a code path never
+ * touches a table/column: if it did, the request would fail with
+ * `permission denied` instead of the expected not-found/zero-safe answer.
+ */
+async function withoutSelectPrivilege<T>(
+  table: string,
+  fn: () => Promise<T>,
+  exceptColumn?: string,
+): Promise<T> {
+  const db = getTestDb();
+  await db.execute(sql.raw(`REVOKE SELECT ON ${table} FROM breeze_app`));
+  if (exceptColumn) {
+    await db.execute(
+      sql.raw(`DO $$
+        DECLARE cols text;
+        BEGIN
+          SELECT string_agg(quote_ident(column_name), ', ')
+            INTO cols
+            FROM information_schema.columns
+           WHERE table_schema = 'public'
+             AND table_name = '${table}'
+             AND column_name <> '${exceptColumn}';
+          EXECUTE format('GRANT SELECT (%s) ON ${table} TO breeze_app', cols);
+        END $$;`),
+    );
+  }
+  try {
+    return await fn();
+  } finally {
+    await db.execute(sql.raw(`REVOKE ALL ON ${table} FROM breeze_app`));
+    await db.execute(
+      sql.raw(
+        `GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON ${table} TO breeze_app`,
+      ),
+    );
+  }
+}
+
+const SCOPE_SHAPE_CHECK = () => `((
+  (
+    execution_scope_version IS NULL
+    AND execution_scope_kind IS NULL
+    AND execution_scope_site_ids IS NULL
+    AND execution_scope_user_id IS NULL
+    AND execution_scope_fingerprint IS NULL
+    AND execution_scope_captured_at IS NULL
+  )
+  OR
+  (
+    execution_scope_version = 1
+    AND execution_scope_fingerprint IS NOT NULL
+    AND execution_scope_captured_at IS NOT NULL
+    AND (
+      (execution_scope_kind = 'restricted' AND execution_scope_site_ids IS NOT NULL AND execution_scope_user_id IS NOT NULL)
+      OR (execution_scope_kind = 'unrestricted' AND execution_scope_site_ids IS NULL AND execution_scope_user_id IS NOT NULL)
+      OR (execution_scope_kind = 'legacy_unscoped' AND execution_scope_site_ids IS NULL)
+    )
+  )
+) IS TRUE)`.replace(/\s+/g, ' ');
+
+/** Re-create the migration's shape CHECK constraints if a previous test dropped them. */
+async function ensureScopeShapeConstraints(): Promise<void> {
+  for (const table of ['reports', 'report_runs'] as const) {
+    const constraint = `${table}_execution_scope_shape_chk`;
+    const present = await scalar<number>(sql`
+      SELECT count(*)::int FROM pg_constraint WHERE conname = ${constraint}
+    `);
+    if (present === 0) {
+      await getTestDb().execute(
+        sql.raw(
+          `ALTER TABLE ${table} ADD CONSTRAINT ${constraint} CHECK ${SCOPE_SHAPE_CHECK()}`,
+        ),
+      );
+    }
+  }
+}
+
+/** Drop both shape CHECKs, run `fn`, then delete the rows it created and restore them. */
+async function withoutScopeShapeConstraints<T>(
+  fn: () => Promise<T>,
+): Promise<T> {
+  const db = getTestDb();
+  for (const table of ['reports', 'report_runs'] as const) {
+    await db.execute(
+      sql.raw(
+        `ALTER TABLE ${table} DROP CONSTRAINT IF EXISTS ${table}_execution_scope_shape_chk`,
+      ),
+    );
+  }
+  try {
+    return await fn();
+  } finally {
+    // Malformed rows would fail re-validation; they have served their purpose.
+    await db.execute(sql`
+      DELETE FROM report_runs
+       WHERE execution_scope_version IS NOT NULL AND execution_scope_version <> 1
+    `);
+    await db.execute(sql`
+      DELETE FROM report_runs
+       WHERE execution_scope_version = 1
+         AND (execution_scope_kind IS NULL
+              OR (execution_scope_kind = 'restricted' AND execution_scope_site_ids IS NULL))
+    `);
+    await db.execute(sql`
+      DELETE FROM reports
+       WHERE execution_scope_version IS NOT NULL AND execution_scope_version <> 1
+    `);
+    await db.execute(sql`
+      DELETE FROM reports
+       WHERE execution_scope_version = 1
+         AND (execution_scope_kind IS NULL
+              OR (execution_scope_kind = 'restricted' AND execution_scope_site_ids IS NULL))
+    `);
+    await ensureScopeShapeConstraints();
+  }
+}
+
+// ───────────────────────────── scope fixtures ─────────────────────────────
+
+type ScopeShape =
+  | { kind: 'unrestricted'; userId: string }
+  | { kind: 'restricted'; userId: string; siteIds: string[] }
+  | { kind: 'legacy'; userId?: string | null }
+  | { kind: 'null' };
+
+function provenanceValues(orgId: string, shape: ScopeShape) {
+  const capturedAt = new Date('2026-07-01T00:00:00.000Z');
+  switch (shape.kind) {
+    case 'unrestricted':
+      return {
+        executionScopeVersion: 1,
+        executionScopeKind: 'unrestricted' as const,
+        executionScopeSiteIds: null,
+        executionScopeUserId: shape.userId,
+        executionScopeFingerprint: siteScopeFingerprint({
+          version: 1,
+          kind: 'unrestricted',
+          orgId,
+        }),
+        executionScopeCapturedAt: capturedAt,
+      };
+    case 'restricted': {
+      const siteIds = [...new Set(shape.siteIds)].sort((a, b) => a.localeCompare(b));
+      return {
+        executionScopeVersion: 1,
+        executionScopeKind: 'restricted' as const,
+        executionScopeSiteIds: siteIds,
+        executionScopeUserId: shape.userId,
+        executionScopeFingerprint: siteScopeFingerprint({
+          version: 1,
+          kind: 'restricted',
+          orgId,
+          siteIds,
+        }),
+        executionScopeCapturedAt: capturedAt,
+      };
+    }
+    case 'legacy':
+      return {
+        executionScopeVersion: 1,
+        executionScopeKind: 'legacy_unscoped' as const,
+        executionScopeSiteIds: null,
+        executionScopeUserId: shape.userId ?? null,
+        executionScopeFingerprint: siteScopeFingerprint({
+          version: 1,
+          kind: 'legacy_unscoped',
+          orgId,
+        }),
+        executionScopeCapturedAt: capturedAt,
+      };
+    case 'null':
+      return {
+        executionScopeVersion: null,
+        executionScopeKind: null,
+        executionScopeSiteIds: null,
+        executionScopeUserId: null,
+        executionScopeFingerprint: null,
+        executionScopeCapturedAt: null,
+      };
+  }
+}
+
+interface SeedReportOptions {
+  orgId: string;
+  name: string;
+  scope: ScopeShape;
+  createdBy?: string | null;
+  schedule?: 'one_time' | 'daily' | 'weekly' | 'monthly';
+  config?: Record<string, unknown>;
+  updatedAt?: Date;
+  type?: 'device_inventory' | 'alert_summary' | 'compliance';
+}
+
+async function seedReport(options: SeedReportOptions): Promise<string> {
+  const at = options.updatedAt ?? new Date();
+  const [row] = await getTestDb()
+    .insert(reports)
+    .values({
+      orgId: options.orgId,
+      name: options.name,
+      type: options.type ?? 'device_inventory',
+      config: options.config ?? {},
+      schedule: options.schedule ?? 'one_time',
+      format: 'csv',
+      createdBy: options.createdBy ?? null,
+      createdAt: at,
+      updatedAt: at,
+      ...provenanceValues(options.orgId, options.scope),
+    })
+    .returning({ id: reports.id });
+  if (!row) throw new Error('seedReport: no row returned');
+  return row.id;
+}
+
+interface SeedRunOptions {
+  reportId: string;
+  orgId: string;
+  scope: ScopeShape;
+  createdAt?: Date;
+  status?: 'pending' | 'running' | 'completed' | 'failed';
+  result?: Record<string, unknown> | null;
+}
+
+async function seedRun(options: SeedRunOptions): Promise<string> {
+  const at = options.createdAt ?? new Date();
+  const [row] = await getTestDb()
+    .insert(reportRuns)
+    .values({
+      reportId: options.reportId,
+      status: options.status ?? 'completed',
+      startedAt: at,
+      completedAt: at,
+      createdAt: at,
+      rowCount: 1,
+      result: options.result ?? { rows: [{ hostname: 'seeded' }], rowCount: 1 },
+      ...provenanceValues(options.orgId, options.scope),
+    })
+    .returning({ id: reportRuns.id });
+  if (!row) throw new Error('seedRun: no row returned');
+  return row.id;
+}
+
+// ───────────────────────────── core fixture ─────────────────────────────
+
+interface Principal {
+  id: string;
+  email: string;
+  token: string;
+}
+
+interface Fixture {
+  partner1: string;
+  partner2: string;
+  orgA: string;
+  orgB: string;
+  orgD: string;
+  orgE: string;
+  orgF: string;
+  siteA1: string;
+  siteA2: string;
+  siteB1: string;
+  siteB2: string;
+  siteD1: string;
+  siteE1: string;
+  siteF1: string;
+  roleOrgA: string;
+  roleOrgB: string;
+  roleOrgD: string;
+  roleOrgE: string;
+  roleOrgF: string;
+  rolePartner: string;
+  siteAUser: Principal;
+  unrestrictedUser: Principal;
+  emptyScopeUser: Principal;
+  partnerUser: Principal;
+  systemUser: Principal;
+  foreignUser: Principal;
+  deviceA1: string;
+  deviceA2: string;
+  deviceB1: string;
+  deviceB2: string;
+  deviceD1: string;
+  deviceE1: string;
+}
+
+let deviceSeq = 0;
+
+async function seedDevice(orgId: string, siteId: string, hostname: string): Promise<string> {
+  deviceSeq += 1;
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId: `agent-w2-${deviceSeq}-${Date.now()}`,
+      hostname,
+      displayName: hostname,
+      osType: 'windows',
+      osVersion: '11',
+      osBuild: '22631',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'online',
+      enrolledAt: new Date(),
+      lastSeenAt: new Date(),
+    })
+    .returning({ id: devices.id });
+  if (!row) throw new Error('seedDevice: no row returned');
+  return row.id;
+}
+
+async function addOrgMembership(
+  userId: string,
+  orgId: string,
+  roleId: string,
+  siteIds: string[] | null,
+): Promise<void> {
+  await getTestDb().insert(organizationUsers).values({ userId, orgId, roleId, siteIds });
+}
+
+async function mintToken(args: {
+  userId: string;
+  email: string;
+  roleId: string | null;
+  orgId: string | null;
+  partnerId: string | null;
+  scope: 'organization' | 'partner' | 'system';
+}): Promise<string> {
+  const payload: Omit<TokenPayload, 'type'> = {
+    sub: args.userId,
+    email: args.email,
+    roleId: args.roleId,
+    orgId: args.orgId,
+    partnerId: args.partnerId,
+    scope: args.scope,
+    mfa: false,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  };
+  return createAccessToken(payload);
+}
+
+async function buildFixture(): Promise<Fixture> {
+  const partner1 = (await createPartner())!;
+  const partner2 = (await createPartner())!;
+
+  const orgA = (await createOrganization({ partnerId: partner1.id }))!;
+  const orgB = (await createOrganization({ partnerId: partner1.id }))!;
+  const orgD = (await createOrganization({ partnerId: partner1.id }))!;
+  const orgE = (await createOrganization({ partnerId: partner1.id }))!;
+  const orgF = (await createOrganization({ partnerId: partner2.id }))!;
+
+  const siteA1 = (await createSite({ orgId: orgA.id, name: 'Site A1' }))!;
+  const siteA2 = (await createSite({ orgId: orgA.id, name: 'Site A2' }))!;
+  const siteB1 = (await createSite({ orgId: orgB.id, name: 'Site B1' }))!;
+  const siteB2 = (await createSite({ orgId: orgB.id, name: 'Site B2' }))!;
+  const siteD1 = (await createSite({ orgId: orgD.id, name: 'Site D1' }))!;
+  const siteE1 = (await createSite({ orgId: orgE.id, name: 'Site E1' }))!;
+  const siteF1 = (await createSite({ orgId: orgF.id, name: 'Site F1' }))!;
+
+  const roleOrgA = (await createRole({ scope: 'organization', orgId: orgA.id, partnerId: partner1.id }))!;
+  const roleOrgB = (await createRole({ scope: 'organization', orgId: orgB.id, partnerId: partner1.id }))!;
+  const roleOrgD = (await createRole({ scope: 'organization', orgId: orgD.id, partnerId: partner1.id }))!;
+  const roleOrgE = (await createRole({ scope: 'organization', orgId: orgE.id, partnerId: partner1.id }))!;
+  const roleOrgF = (await createRole({ scope: 'organization', orgId: orgF.id, partnerId: partner2.id }))!;
+  const rolePartner = (await createRole({ scope: 'partner', partnerId: partner1.id }))!;
+
+  await grantRolePermissions(roleOrgA.id, REPORT_PERMS);
+  await grantRolePermissions(roleOrgB.id, REPORT_PERMS);
+  // Org D's membership role deliberately carries NO reports permission.
+  await grantRolePermissions(roleOrgD.id, [{ resource: 'devices', action: 'read' }]);
+  await grantRolePermissions(roleOrgE.id, REPORT_PERMS);
+  await grantRolePermissions(roleOrgF.id, REPORT_PERMS);
+  await grantRolePermissions(rolePartner.id, REPORT_PERMS);
+
+  const siteAUserRow = (await createUser({ partnerId: partner1.id, orgId: orgA.id, email: `site-a-${randomUUID()}@example.com` }))!;
+  const unrestrictedRow = (await createUser({ partnerId: partner1.id, orgId: orgA.id, email: `unres-${randomUUID()}@example.com` }))!;
+  const emptyRow = (await createUser({ partnerId: partner1.id, orgId: orgA.id, email: `empty-${randomUUID()}@example.com` }))!;
+  const partnerRow = (await createUser({ partnerId: partner1.id, orgId: null, email: `partner-${randomUUID()}@example.com` }))!;
+  const systemRow = (await createUser({ partnerId: partner1.id, orgId: null, email: `system-${randomUUID()}@example.com` }))!;
+  const foreignRow = (await createUser({ partnerId: partner2.id, orgId: orgF.id, email: `foreign-${randomUUID()}@example.com` }))!;
+
+  await getTestDb()
+    .update(users)
+    .set({ isPlatformAdmin: true })
+    .where(eq(users.id, systemRow.id));
+
+  await addOrgMembership(siteAUserRow.id, orgA.id, roleOrgA.id, [siteA1.id]);
+  await addOrgMembership(unrestrictedRow.id, orgA.id, roleOrgA.id, null);
+  await addOrgMembership(emptyRow.id, orgA.id, roleOrgA.id, []);
+  await addOrgMembership(foreignRow.id, orgF.id, roleOrgF.id, null);
+
+  // Partner principal: NO membership in Org A (fallback), a Site-B1 membership
+  // in Org B, a permissionless membership in Org D, an empty set in Org E.
+  await getTestDb().insert(partnerUsers).values({
+    userId: partnerRow.id,
+    partnerId: partner1.id,
+    roleId: rolePartner.id,
+    orgAccess: 'all',
+  });
+  await addOrgMembership(partnerRow.id, orgB.id, roleOrgB.id, [siteB1.id]);
+  await addOrgMembership(partnerRow.id, orgD.id, roleOrgD.id, null);
+  await addOrgMembership(partnerRow.id, orgE.id, roleOrgE.id, []);
+
+  // A system-scope token still resolves RBAC through a real membership
+  // (requirePermission reads partner/org axis); `accessibleOrgIds` stays null
+  // and `is_platform_admin` is what makes the site axis unrestricted.
+  await getTestDb().insert(partnerUsers).values({
+    userId: systemRow.id,
+    partnerId: partner1.id,
+    roleId: rolePartner.id,
+    orgAccess: 'all',
+  });
+
+  const deviceA1 = await seedDevice(orgA.id, siteA1.id, 'host-a1');
+  const deviceA2 = await seedDevice(orgA.id, siteA2.id, 'host-a2');
+  const deviceB1 = await seedDevice(orgB.id, siteB1.id, 'host-b1');
+  const deviceB2 = await seedDevice(orgB.id, siteB2.id, 'host-b2');
+  const deviceD1 = await seedDevice(orgD.id, siteD1.id, 'host-d1');
+  const deviceE1 = await seedDevice(orgE.id, siteE1.id, 'host-e1');
+
+  return {
+    partner1: partner1.id,
+    partner2: partner2.id,
+    orgA: orgA.id,
+    orgB: orgB.id,
+    orgD: orgD.id,
+    orgE: orgE.id,
+    orgF: orgF.id,
+    siteA1: siteA1.id,
+    siteA2: siteA2.id,
+    siteB1: siteB1.id,
+    siteB2: siteB2.id,
+    siteD1: siteD1.id,
+    siteE1: siteE1.id,
+    siteF1: siteF1.id,
+    roleOrgA: roleOrgA.id,
+    roleOrgB: roleOrgB.id,
+    roleOrgD: roleOrgD.id,
+    roleOrgE: roleOrgE.id,
+    roleOrgF: roleOrgF.id,
+    rolePartner: rolePartner.id,
+    siteAUser: {
+      id: siteAUserRow.id,
+      email: siteAUserRow.email,
+      token: await mintToken({
+        userId: siteAUserRow.id,
+        email: siteAUserRow.email,
+        roleId: roleOrgA.id,
+        orgId: orgA.id,
+        partnerId: partner1.id,
+        scope: 'organization',
+      }),
+    },
+    unrestrictedUser: {
+      id: unrestrictedRow.id,
+      email: unrestrictedRow.email,
+      token: await mintToken({
+        userId: unrestrictedRow.id,
+        email: unrestrictedRow.email,
+        roleId: roleOrgA.id,
+        orgId: orgA.id,
+        partnerId: partner1.id,
+        scope: 'organization',
+      }),
+    },
+    emptyScopeUser: {
+      id: emptyRow.id,
+      email: emptyRow.email,
+      token: await mintToken({
+        userId: emptyRow.id,
+        email: emptyRow.email,
+        roleId: roleOrgA.id,
+        orgId: orgA.id,
+        partnerId: partner1.id,
+        scope: 'organization',
+      }),
+    },
+    partnerUser: {
+      id: partnerRow.id,
+      email: partnerRow.email,
+      token: await mintToken({
+        userId: partnerRow.id,
+        email: partnerRow.email,
+        roleId: rolePartner.id,
+        orgId: null,
+        partnerId: partner1.id,
+        scope: 'partner',
+      }),
+    },
+    systemUser: {
+      id: systemRow.id,
+      email: systemRow.email,
+      token: await mintToken({
+        userId: systemRow.id,
+        email: systemRow.email,
+        roleId: rolePartner.id,
+        orgId: null,
+        partnerId: partner1.id,
+        scope: 'system',
+      }),
+    },
+    foreignUser: {
+      id: foreignRow.id,
+      email: foreignRow.email,
+      token: await mintToken({
+        userId: foreignRow.id,
+        email: foreignRow.email,
+        roleId: roleOrgF.id,
+        orgId: orgF.id,
+        partnerId: partner2.id,
+        scope: 'organization',
+      }),
+    },
+    deviceA1,
+    deviceA2,
+    deviceB1,
+    deviceB2,
+    deviceD1,
+    deviceE1,
+  };
+}
+
+/** Minimal AuthContext for direct resolver assertions (only these fields are read). */
+function fakeAuth(args: {
+  userId: string;
+  scope: 'organization' | 'partner' | 'system';
+  orgId?: string | null;
+  accessibleOrgIds: string[] | null;
+}): AuthContext {
+  return {
+    user: { id: args.userId },
+    scope: args.scope,
+    orgId: args.orgId ?? null,
+    accessibleOrgIds: args.accessibleOrgIds,
+    canAccessOrg: (orgId: string) =>
+      args.accessibleOrgIds === null || args.accessibleOrgIds.includes(orgId),
+  } as unknown as AuthContext;
+}
+
+beforeEach(async () => {
+  await clearPermissionCache();
+  await ensureScopeShapeConstraints();
+  emailProbe.calls = 0;
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Database-level tenant isolation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Wave 2 · forced RLS blocks cross-organization report forgery', () => {
+  runDb('breeze_app cannot forge a report or run into another organization', async () => {
+    const f = await buildFixture();
+    const appDb = getAppDb();
+
+    // Parent report in Org A, seeded as the superuser so it definitely exists.
+    const reportA = await seedReport({
+      orgId: f.orgA,
+      name: 'A owned',
+      scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id },
+    });
+
+    // ── Positive control 1: the statement itself is valid (superuser insert). ──
+    const okId = await scalar<string>(sql`
+      INSERT INTO reports (org_id, name, type, config, schedule, format)
+      VALUES (${f.orgA}::uuid, 'superuser control', 'device_inventory', '{}'::jsonb, 'one_time', 'csv')
+      RETURNING id
+    `);
+    expect(okId).toBeTruthy();
+
+    // ── Positive control 2: breeze_app CAN insert into its OWN organization. ──
+    const selfInsert = await appDb.transaction(async (tx) => {
+      await tx.execute(sql`select set_config('breeze.scope', 'organization', true)`);
+      await tx.execute(sql`select set_config('breeze.org_id', ${f.orgB}, true)`);
+      await tx.execute(sql`select set_config('breeze.accessible_org_ids', ${f.orgB}, true)`);
+      const rows = await tx.execute(sql`
+        INSERT INTO reports (org_id, name, type, config, schedule, format)
+        VALUES (${f.orgB}::uuid, 'own org', 'device_inventory', '{}'::jsonb, 'one_time', 'csv')
+        RETURNING id
+      `);
+      return rows as unknown as Array<{ id: string }>;
+    });
+    expect(selfInsert).toHaveLength(1);
+
+    // ── The forge: Org B's context inserting an Org A row. ──
+    let forgeError: unknown;
+    try {
+      await appDb.transaction(async (tx) => {
+        await tx.execute(sql`select set_config('breeze.scope', 'organization', true)`);
+        await tx.execute(sql`select set_config('breeze.org_id', ${f.orgB}, true)`);
+        await tx.execute(sql`select set_config('breeze.accessible_org_ids', ${f.orgB}, true)`);
+        await tx.execute(sql`
+          INSERT INTO reports (org_id, name, type, config, schedule, format)
+          VALUES (${f.orgA}::uuid, 'forged', 'device_inventory', '{}'::jsonb, 'one_time', 'csv')
+        `);
+      });
+    } catch (err) {
+      forgeError = err;
+    }
+    const forgeMessage =
+      (forgeError as { cause?: { message?: string }; message?: string })?.cause?.message ??
+      (forgeError as { message?: string })?.message ??
+      '';
+    expect(forgeMessage).toContain('new row violates row-level security policy');
+
+    // ── Same for report_runs, whose policy joins through its parent report. ──
+    let runForgeError: unknown;
+    try {
+      await appDb.transaction(async (tx) => {
+        await tx.execute(sql`select set_config('breeze.scope', 'organization', true)`);
+        await tx.execute(sql`select set_config('breeze.org_id', ${f.orgB}, true)`);
+        await tx.execute(sql`select set_config('breeze.accessible_org_ids', ${f.orgB}, true)`);
+        await tx.execute(sql`
+          INSERT INTO report_runs (report_id, status)
+          VALUES (${reportA}::uuid, 'pending')
+        `);
+      });
+    } catch (err) {
+      runForgeError = err;
+    }
+    const runForgeMessage =
+      (runForgeError as { cause?: { message?: string }; message?: string })?.cause?.message ??
+      (runForgeError as { message?: string })?.message ??
+      '';
+    expect(runForgeMessage).toContain('new row violates row-level security policy');
+
+    // Positive control 3: the SAME run insert succeeds from Org A's context,
+    // proving the rejection above was the policy and not a bad statement.
+    const runOk = await appDb.transaction(async (tx) => {
+      await tx.execute(sql`select set_config('breeze.scope', 'organization', true)`);
+      await tx.execute(sql`select set_config('breeze.org_id', ${f.orgA}, true)`);
+      await tx.execute(sql`select set_config('breeze.accessible_org_ids', ${f.orgA}, true)`);
+      const rows = await tx.execute(sql`
+        INSERT INTO report_runs (report_id, status)
+        VALUES (${reportA}::uuid, 'pending')
+        RETURNING id
+      `);
+      return rows as unknown as Array<{ id: string }>;
+    });
+    expect(runOk).toHaveLength(1);
+
+    // Nothing forged actually landed.
+    const forgedCount = await scalar<number>(sql`
+      SELECT count(*)::int FROM reports WHERE name = 'forged'
+    `);
+    expect(forgedCount).toBe(0);
+  });
+
+  runDb('report_runs keeps its parent-join policy and both tables force RLS', async () => {
+    const rows = await rawRows<{ relname: string; relrowsecurity: boolean; relforcerowsecurity: boolean }>(sql`
+      SELECT relname, relrowsecurity, relforcerowsecurity
+        FROM pg_class WHERE relname IN ('reports', 'report_runs')
+    `);
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.relrowsecurity).toBe(true);
+      expect(row.relforcerowsecurity).toBe(true);
+    }
+    const runPolicies = await rawRows<{ policyname: string; qual: string | null; with_check: string | null }>(sql`
+      SELECT policyname, qual, with_check FROM pg_policies WHERE tablename = 'report_runs'
+    `);
+    expect(runPolicies.length).toBeGreaterThanOrEqual(4);
+    for (const policy of runPolicies) {
+      const predicate = `${policy.qual ?? ''}${policy.with_check ?? ''}`;
+      expect(predicate).toContain('FROM reports');
+      expect(predicate).toContain('breeze_has_org_access');
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Live authority resolution
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Wave 2 · exact live report authority comes only from current state', () => {
+  runDb('organization membership site_ids alone decides the site axis', async () => {
+    const f = await buildFixture();
+
+    const restricted = await resolveLiveReportAuthority(f.siteAUser.id, f.orgA, 'read');
+    expect(restricted.ok).toBe(true);
+    expect(restricted.ok && restricted.authority.scope).toEqual({
+      version: 1,
+      kind: 'restricted',
+      orgId: f.orgA,
+      siteIds: [f.siteA1],
+    });
+
+    const unrestricted = await resolveLiveReportAuthority(f.unrestrictedUser.id, f.orgA, 'read');
+    expect(unrestricted.ok && unrestricted.authority.scope).toEqual({
+      version: 1,
+      kind: 'unrestricted',
+      orgId: f.orgA,
+    });
+
+    const empty = await resolveLiveReportAuthority(f.emptyScopeUser.id, f.orgA, 'read');
+    expect(empty).toEqual({ ok: false, reason: 'empty_scope' });
+
+    // NULL and '{}' must stay distinguishable end to end.
+    expect(unrestricted.ok && unrestricted.authority.fingerprint).not.toEqual(
+      restricted.ok && restricted.authority.fingerprint,
+    );
+  });
+
+  runDb('organization membership overrides broader partner authority', async () => {
+    const f = await buildFixture();
+
+    // Org A: no organization_users row -> partner fallback, unrestricted.
+    const fallback = await resolveLiveReportAuthority(f.partnerUser.id, f.orgA, 'read');
+    expect(fallback.ok && fallback.authority.scope).toEqual({
+      version: 1,
+      kind: 'unrestricted',
+      orgId: f.orgA,
+    });
+
+    // Org B: organization_users row restricted to B1 wins over org_access='all'.
+    const orgAxis = await resolveLiveReportAuthority(f.partnerUser.id, f.orgB, 'read');
+    expect(orgAxis.ok && orgAxis.authority.scope).toEqual({
+      version: 1,
+      kind: 'restricted',
+      orgId: f.orgB,
+      siteIds: [f.siteB1],
+    });
+
+    // Org D: the membership role lacks reports:read; the partner role must NOT rescue it.
+    const denied = await resolveLiveReportAuthority(f.partnerUser.id, f.orgD, 'read');
+    expect(denied).toEqual({ ok: false, reason: 'permission_removed' });
+
+    // Org E: membership with an empty site set.
+    const emptySet = await resolveLiveReportAuthority(f.partnerUser.id, f.orgE, 'read');
+    expect(emptySet).toEqual({ ok: false, reason: 'empty_scope' });
+
+    // Org F belongs to another partner entirely.
+    const foreign = await resolveLiveReportAuthority(f.partnerUser.id, f.orgF, 'read');
+    expect(foreign.ok).toBe(false);
+  });
+
+  runDb('system (platform-admin) authority is unrestricted; a removed user is denied', async () => {
+    const f = await buildFixture();
+
+    const system = await resolveLiveReportAuthority(f.systemUser.id, f.orgB, 'read');
+    expect(system.ok && system.authority.scope).toEqual({
+      version: 1,
+      kind: 'unrestricted',
+      orgId: f.orgB,
+    });
+
+    await getTestDb()
+      .update(users)
+      .set({ status: 'disabled' })
+      .where(eq(users.id, f.siteAUser.id));
+    expect(await resolveLiveReportAuthority(f.siteAUser.id, f.orgA, 'read')).toEqual({
+      ok: false,
+      reason: 'user_inactive',
+    });
+  });
+
+  runDb('roles are a permission source only — no role table carries site IDs', async () => {
+    const f = await buildFixture();
+
+    const roleSiteColumns = await rawRows<{ table_name: string; column_name: string }>(sql`
+      SELECT table_name, column_name FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name IN ('roles', 'role_permissions', 'permissions')
+         AND column_name ILIKE '%site%'
+    `);
+    expect(roleSiteColumns).toEqual([]);
+
+    // The role IS the permission source: revoking reports:read denies outright…
+    await getTestDb().execute(sql`
+      DELETE FROM role_permissions rp
+       USING permissions p
+       WHERE rp.permission_id = p.id
+         AND rp.role_id = ${f.roleOrgA}::uuid
+         AND p.resource = 'reports' AND p.action = 'read'
+    `);
+    expect(await resolveLiveReportAuthority(f.siteAUser.id, f.orgA, 'read')).toEqual({
+      ok: false,
+      reason: 'permission_removed',
+    });
+
+    // …but it never supplies site IDs: restoring it returns the SAME site set.
+    await grantRolePermissions(f.roleOrgA, [{ resource: 'reports', action: 'read' }]);
+    await grantRolePermissions(f.roleOrgA, [{ resource: 'devices', action: 'write' }]);
+    const afterRoleChange = await resolveLiveReportAuthority(f.siteAUser.id, f.orgA, 'read');
+    expect(afterRoleChange.ok && afterRoleChange.authority.scope).toEqual({
+      version: 1,
+      kind: 'restricted',
+      orgId: f.orgA,
+      siteIds: [f.siteA1],
+    });
+
+    // …only organization_users.site_ids can.
+    await getTestDb()
+      .update(organizationUsers)
+      .set({ siteIds: null })
+      .where(and(eq(organizationUsers.userId, f.siteAUser.id), eq(organizationUsers.orgId, f.orgA)));
+    const afterSiteChange = await resolveLiveReportAuthority(f.siteAUser.id, f.orgA, 'read');
+    expect(afterSiteChange.ok && afterSiteChange.authority.scope).toEqual({
+      version: 1,
+      kind: 'unrestricted',
+      orgId: f.orgA,
+    });
+  });
+
+  runDb('resolveRequestReportAuthorityMap answers per organization, never reusing one decision', async () => {
+    const f = await buildFixture();
+    const auth = fakeAuth({
+      userId: f.partnerUser.id,
+      scope: 'partner',
+      accessibleOrgIds: [f.orgA, f.orgB, f.orgD, f.orgE],
+    });
+
+    const map = await resolveRequestReportAuthorityMap(
+      auth,
+      [f.orgA, f.orgB, f.orgD, f.orgE, f.orgF],
+      'read',
+    );
+
+    expect(map.get(f.orgA)).toMatchObject({ ok: true });
+    expect((map.get(f.orgA) as { authority: { scope: unknown } }).authority.scope).toEqual({
+      version: 1,
+      kind: 'unrestricted',
+      orgId: f.orgA,
+    });
+    expect((map.get(f.orgB) as { authority: { scope: unknown } }).authority.scope).toEqual({
+      version: 1,
+      kind: 'restricted',
+      orgId: f.orgB,
+      siteIds: [f.siteB1],
+    });
+    expect(map.get(f.orgD)).toEqual({ ok: false, reason: 'permission_removed' });
+    expect(map.get(f.orgE)).toEqual({ ok: false, reason: 'empty_scope' });
+    expect(map.get(f.orgF)).toEqual({ ok: false, reason: 'organization_inaccessible' });
+
+    // An org token can never widen to another organization.
+    const orgAuth = fakeAuth({
+      userId: f.siteAUser.id,
+      scope: 'organization',
+      orgId: f.orgA,
+      accessibleOrgIds: [f.orgA],
+    });
+    expect(await resolveRequestReportAuthority(orgAuth, f.orgB, 'read')).toEqual({
+      ok: false,
+      reason: 'organization_inaccessible',
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Definition lists / templates / known-ID parity (exact organization)
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function seedDefinitionMatrix(f: Fixture) {
+  const base = Date.parse('2026-07-20T12:00:00.000Z');
+  const at = (minutes: number) => new Date(base - minutes * 60_000);
+
+  const visible: string[] = [];
+  for (let i = 0; i < 5; i += 1) {
+    visible.push(
+      await seedReport({
+        orgId: f.orgA,
+        name: `visible-a1-${i}`,
+        scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+        createdBy: f.siteAUser.id,
+        updatedAt: at(i),
+      }),
+    );
+  }
+
+  const hidden = {
+    otherSite: await seedReport({
+      orgId: f.orgA,
+      name: 'hidden-a2',
+      scope: { kind: 'restricted', userId: f.unrestrictedUser.id, siteIds: [f.siteA2] },
+      createdBy: f.unrestrictedUser.id,
+      updatedAt: at(10),
+    }),
+    unrestricted: await seedReport({
+      orgId: f.orgA,
+      name: 'hidden-unrestricted',
+      scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id },
+      createdBy: f.unrestrictedUser.id,
+      updatedAt: at(11),
+    }),
+    legacy: await seedReport({
+      orgId: f.orgA,
+      name: 'hidden-legacy',
+      scope: { kind: 'legacy', userId: f.unrestrictedUser.id },
+      createdBy: f.unrestrictedUser.id,
+      updatedAt: at(12),
+    }),
+    oldWriter: await seedReport({
+      orgId: f.orgA,
+      name: 'hidden-old-writer',
+      scope: { kind: 'null' },
+      createdBy: f.unrestrictedUser.id,
+      updatedAt: at(13),
+    }),
+    superset: await seedReport({
+      orgId: f.orgA,
+      name: 'hidden-superset',
+      scope: {
+        kind: 'restricted',
+        userId: f.unrestrictedUser.id,
+        siteIds: [f.siteA1, f.siteA2],
+      },
+      createdBy: f.unrestrictedUser.id,
+      updatedAt: at(14),
+    }),
+    otherOrg: await seedReport({
+      orgId: f.orgB,
+      name: 'hidden-org-b',
+      scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] },
+      createdBy: f.partnerUser.id,
+      updatedAt: at(15),
+    }),
+  };
+
+  return { visible, hidden };
+}
+
+describe('Wave 2 · definition + template pages report exact visible totals', () => {
+  runDb('restricted caller sees 2/2/1 pages with total=5 on main and template lists', async () => {
+    const f = await buildFixture();
+    const { visible, hidden } = await seedDefinitionMatrix(f);
+    const app = buildApp();
+
+    // Non-vacuity: a pre-wave, org-only predicate reaches every Org A row.
+    const orgOnlyCount = await scalar<number>(
+      sql`SELECT count(*)::int FROM reports WHERE org_id = ${f.orgA}::uuid`,
+    );
+    expect(orgOnlyCount).toBe(10);
+
+    for (const listPath of ['/reports', '/reports/templates']) {
+      const seen: string[] = [];
+      for (const [page, expected] of [[1, 2], [2, 2], [3, 1]] as const) {
+        const res = await app.request(
+          `${listPath}?limit=2&page=${page}`,
+          authed(f.siteAUser.token),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          data: Array<{ id: string }>;
+          pagination: { total: number };
+        };
+        expect(body.data).toHaveLength(expected);
+        expect(body.pagination.total).toBe(5);
+        seen.push(...body.data.map((row) => row.id));
+      }
+      expect(new Set(seen)).toEqual(new Set(visible));
+      for (const hiddenId of Object.values(hidden)) {
+        expect(seen).not.toContain(hiddenId);
+      }
+      // Page 4 is empty but still reports the same total — no scope oracle.
+      const page4 = await app.request(`${listPath}?limit=2&page=4`, authed(f.siteAUser.token));
+      const page4Body = (await page4.json()) as {
+        data: unknown[];
+        pagination: { total: number };
+      };
+      expect(page4Body.data).toHaveLength(0);
+      expect(page4Body.pagination.total).toBe(5);
+    }
+  });
+
+  runDb('hidden definition UUIDs are indistinguishable from nonexistent ones', async () => {
+    const f = await buildFixture();
+    const { hidden } = await seedDefinitionMatrix(f);
+    const app = buildApp();
+    const token = f.siteAUser.token;
+    const ghost = randomUUID();
+
+    const probes: Array<[string, () => Promise<Response>]> = [];
+    for (const [label, id] of [
+      ['hidden-other-site', hidden.otherSite],
+      ['hidden-unrestricted', hidden.unrestricted],
+      ['hidden-legacy', hidden.legacy],
+      ['hidden-old-writer', hidden.oldWriter],
+      ['hidden-superset', hidden.superset],
+      ['hidden-other-org', hidden.otherOrg],
+      ['nonexistent', ghost],
+    ] as const) {
+      probes.push([`GET ${label}`, () => app.request(`/reports/${id}`, authed(token))]);
+      probes.push([
+        `PUT ${label}`,
+        () =>
+          app.request(
+            `/reports/${id}`,
+            authed(token, { method: 'PUT', body: JSON.stringify({ name: 'pwn' }) }),
+          ),
+      ]);
+      probes.push([
+        `POST reauthorize ${label}`,
+        () => app.request(`/reports/${id}/reauthorize`, authed(token, { method: 'POST' })),
+      ]);
+      probes.push([
+        `DELETE ${label}`,
+        () => app.request(`/reports/${id}`, authed(token, { method: 'DELETE' })),
+      ]);
+    }
+
+    const observed: Array<[string, number, string]> = [];
+    for (const [label, run] of probes) {
+      const res = await run();
+      observed.push([label, res.status, await res.text()]);
+    }
+
+    const distinct = new Set(observed.map(([, status, body]) => `${status}|${body}`));
+    expect([...distinct]).toEqual(['404|{"error":"Report not found"}']);
+  });
+
+  runDb('deleting a hidden definition mutates neither reports nor report_runs', async () => {
+    const f = await buildFixture();
+    const { hidden } = await seedDefinitionMatrix(f);
+    const app = buildApp();
+
+    const hiddenRunA = await seedRun({
+      reportId: hidden.otherSite,
+      orgId: f.orgA,
+      scope: { kind: 'restricted', userId: f.unrestrictedUser.id, siteIds: [f.siteA2] },
+    });
+    const hiddenRunB = await seedRun({
+      reportId: hidden.unrestricted,
+      orgId: f.orgA,
+      scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id },
+    });
+
+    const beforeReports = await scalar<number>(sql`SELECT count(*)::int FROM reports`);
+    const beforeRuns = await scalar<number>(sql`SELECT count(*)::int FROM report_runs`);
+    const beforeUpdatedAt = await rawRows<{ id: string; updated_at: Date }>(
+      sql`SELECT id, updated_at FROM reports ORDER BY id`,
+    );
+
+    for (const id of Object.values(hidden)) {
+      const res = await app.request(`/reports/${id}`, authed(f.siteAUser.token, { method: 'DELETE' }));
+      expect(res.status).toBe(404);
+    }
+
+    expect(await scalar<number>(sql`SELECT count(*)::int FROM reports`)).toBe(beforeReports);
+    expect(await scalar<number>(sql`SELECT count(*)::int FROM report_runs`)).toBe(beforeRuns);
+    const afterUpdatedAt = await rawRows<{ id: string; updated_at: Date }>(
+      sql`SELECT id, updated_at FROM reports ORDER BY id`,
+    );
+    expect(JSON.stringify(afterUpdatedAt)).toEqual(JSON.stringify(beforeUpdatedAt));
+    expect(
+      await scalar<number>(
+        sql`SELECT count(*)::int FROM report_runs WHERE id IN (${hiddenRunA}::uuid, ${hiddenRunB}::uuid)`,
+      ),
+    ).toBe(2);
+  });
+
+  runDb('a denied known-ID read never selects the definition config payload', async () => {
+    const f = await buildFixture();
+    const { visible, hidden } = await seedDefinitionMatrix(f);
+    const app = buildApp();
+
+    await withoutSelectPrivilege(
+      'reports',
+      async () => {
+        // Denied path: must still be a clean 404 — it never reads `config`.
+        const denied = await app.request(
+          `/reports/${hidden.otherSite}`,
+          authed(f.siteAUser.token),
+        );
+        expect(denied.status).toBe(404);
+        expect(await denied.json()).toEqual({ error: 'Report not found' });
+
+        // Positive control: the AUTHORIZED path does read `config`, so with the
+        // column revoked it fails loudly. This proves the revoke actually bites.
+        const authorized = await app.request(`/reports/${visible[0]}`, authed(f.siteAUser.token));
+        expect(authorized.status).toBeGreaterThanOrEqual(500);
+      },
+      'config',
+    );
+  });
+
+  runDb('an unrestricted caller still sees legacy and old-writer definitions', async () => {
+    const f = await buildFixture();
+    const { visible, hidden } = await seedDefinitionMatrix(f);
+    const app = buildApp();
+
+    const res = await app.request('/reports?limit=100', authed(f.unrestrictedUser.token));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ id: string }>; pagination: { total: number } };
+    const ids = body.data.map((row) => row.id);
+    expect(body.pagination.total).toBe(10);
+    for (const id of visible) expect(ids).toContain(id);
+    expect(ids).toContain(hidden.legacy);
+    expect(ids).toContain(hidden.oldWriter);
+    expect(ids).toContain(hidden.unrestricted);
+    expect(ids).toContain(hidden.superset);
+    expect(ids).not.toContain(hidden.otherOrg);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Partner / system multi-organization definition + template lists
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Wave 2 · partner and system multi-organization definition lists', () => {
+  runDb('partner list without orgId applies one per-organization composite predicate', async () => {
+    const f = await buildFixture();
+    const base = Date.parse('2026-07-20T12:00:00.000Z');
+    const at = (m: number) => new Date(base - m * 60_000);
+
+    // Three Org A definitions — visible through unrestricted partner fallback.
+    const a1 = await seedReport({ orgId: f.orgA, name: 'a-unres', scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id }, updatedAt: at(0) });
+    const a2 = await seedReport({ orgId: f.orgA, name: 'a-restricted', scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] }, updatedAt: at(1) });
+    const a3 = await seedReport({ orgId: f.orgA, name: 'a-legacy', scope: { kind: 'legacy', userId: f.unrestrictedUser.id }, updatedAt: at(2) });
+    // Two Org B definitions restricted to B1 — visible through the B1 membership.
+    const b1 = await seedReport({ orgId: f.orgB, name: 'b1-one', scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] }, updatedAt: at(3) });
+    const b2 = await seedReport({ orgId: f.orgB, name: 'b1-two', scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] }, updatedAt: at(4) });
+
+    // Everything below must be absent.
+    const excluded = {
+      bSiteB2: await seedReport({ orgId: f.orgB, name: 'b2', scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB2] }, updatedAt: at(5) }),
+      bUnrestricted: await seedReport({ orgId: f.orgB, name: 'b-unres', scope: { kind: 'unrestricted', userId: f.partnerUser.id }, updatedAt: at(6) }),
+      bLegacy: await seedReport({ orgId: f.orgB, name: 'b-legacy', scope: { kind: 'legacy', userId: f.partnerUser.id }, updatedAt: at(7) }),
+      bOldWriter: await seedReport({ orgId: f.orgB, name: 'b-null', scope: { kind: 'null' }, updatedAt: at(8) }),
+      dDenied: await seedReport({ orgId: f.orgD, name: 'd-denied', scope: { kind: 'unrestricted', userId: f.partnerUser.id }, updatedAt: at(9) }),
+      eEmpty: await seedReport({ orgId: f.orgE, name: 'e-empty', scope: { kind: 'unrestricted', userId: f.partnerUser.id }, updatedAt: at(10) }),
+      fForeign: await seedReport({ orgId: f.orgF, name: 'f-foreign', scope: { kind: 'unrestricted', userId: f.foreignUser.id }, updatedAt: at(11) }),
+    };
+
+    const app = buildApp();
+    const expectedVisible = new Set([a1, a2, a3, b1, b2]);
+
+    for (const listPath of ['/reports', '/reports/templates']) {
+      const seen: string[] = [];
+      for (const [page, count] of [[1, 2], [2, 2], [3, 1]] as const) {
+        const res = await app.request(
+          `${listPath}?limit=2&page=${page}`,
+          authed(f.partnerUser.token),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          data: Array<{ id: string }>;
+          pagination: { total: number };
+        };
+        expect(body.data).toHaveLength(count);
+        expect(body.pagination.total).toBe(5);
+        seen.push(...body.data.map((row) => row.id));
+      }
+      expect(new Set(seen)).toEqual(expectedVisible);
+      for (const id of Object.values(excluded)) expect(seen).not.toContain(id);
+    }
+
+    // An explicit orgId derives ONE membership-first scope: Org B's B1 membership
+    // beats the partner fallback even though the caller is a partner principal.
+    const explicitB = await app.request(
+      `/reports?limit=100&orgId=${f.orgB}`,
+      authed(f.partnerUser.token),
+    );
+    const explicitBody = (await explicitB.json()) as {
+      data: Array<{ id: string }>;
+      pagination: { total: number };
+    };
+    expect(explicitBody.pagination.total).toBe(2);
+    expect(new Set(explicitBody.data.map((r) => r.id))).toEqual(new Set([b1, b2]));
+
+    // Denied and inaccessible organizations 403 rather than silently widening.
+    expect((await app.request(`/reports?orgId=${f.orgD}`, authed(f.partnerUser.token))).status).toBe(403);
+    expect((await app.request(`/reports?orgId=${f.orgE}`, authed(f.partnerUser.token))).status).toBe(403);
+    expect((await app.request(`/reports?orgId=${f.orgF}`, authed(f.partnerUser.token))).status).toBe(403);
+  });
+
+  runDb('system list without orgId uses the unrestricted predicate and excludes malformed rows', async () => {
+    const f = await buildFixture();
+    const base = Date.parse('2026-07-20T12:00:00.000Z');
+    const at = (m: number) => new Date(base - m * 60_000);
+
+    const visible = [
+      await seedReport({ orgId: f.orgA, name: 's-a-unres', scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id }, updatedAt: at(0) }),
+      await seedReport({ orgId: f.orgA, name: 's-a-restricted', scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] }, updatedAt: at(1) }),
+      await seedReport({ orgId: f.orgB, name: 's-b-legacy', scope: { kind: 'legacy', userId: f.partnerUser.id }, updatedAt: at(2) }),
+      await seedReport({ orgId: f.orgB, name: 's-b-null', scope: { kind: 'null' }, updatedAt: at(3) }),
+      await seedReport({ orgId: f.orgF, name: 's-f-unres', scope: { kind: 'unrestricted', userId: f.foreignUser.id }, updatedAt: at(4) }),
+    ];
+
+    const app = buildApp();
+
+    // The migration's CHECK constraint is the first line of defence: a malformed
+    // provenance row cannot even be written while it is in place.
+    await expect(
+      getTestDb().execute(sql`
+        INSERT INTO reports (org_id, name, type, execution_scope_version, execution_scope_kind,
+                             execution_scope_fingerprint, execution_scope_captured_at, execution_scope_user_id)
+        VALUES (${f.orgA}::uuid, 'bad-version', 'device_inventory', 2, 'unrestricted',
+                repeat('a', 64), now(), ${f.siteAUser.id}::uuid)
+      `),
+    ).rejects.toThrow();
+
+    // Drop it to exercise the SQL predicate's own rejection of malformed rows
+    // (defence in depth for a database restored without the constraint).
+    await withoutScopeShapeConstraints(async () => {
+      const malformed = [
+        await scalar<string>(sql`
+          INSERT INTO reports (org_id, name, type, execution_scope_version, execution_scope_kind,
+                               execution_scope_fingerprint, execution_scope_captured_at, execution_scope_user_id, updated_at)
+          VALUES (${f.orgA}::uuid, 'malformed-v2', 'device_inventory', 2, 'unrestricted',
+                  repeat('a', 64), now(), ${f.siteAUser.id}::uuid, ${naiveUtc(at(5))}::timestamp)
+          RETURNING id
+        `),
+        await scalar<string>(sql`
+          INSERT INTO reports (org_id, name, type, execution_scope_version, execution_scope_kind,
+                               execution_scope_site_ids, execution_scope_fingerprint,
+                               execution_scope_captured_at, execution_scope_user_id, updated_at)
+          VALUES (${f.orgB}::uuid, 'malformed-partial', 'device_inventory', 1, 'restricted',
+                  NULL, repeat('b', 64), now(), ${f.partnerUser.id}::uuid, ${naiveUtc(at(6))}::timestamp)
+          RETURNING id
+        `),
+      ];
+
+      const totalRows = await scalar<number>(sql`SELECT count(*)::int FROM reports`);
+      expect(totalRows).toBe(7);
+
+      const seen: string[] = [];
+      for (const [page, count] of [[1, 2], [2, 2], [3, 1]] as const) {
+        const res = await app.request(
+          `/reports?limit=2&page=${page}`,
+          authed(f.systemUser.token),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          data: Array<{ id: string }>;
+          pagination: { total: number };
+        };
+        expect(body.data).toHaveLength(count);
+        expect(body.pagination.total).toBe(5);
+        seen.push(...body.data.map((r) => r.id));
+      }
+      expect(new Set(seen)).toEqual(new Set(visible));
+      for (const id of malformed) expect(seen).not.toContain(id);
+
+      // Same shape on the template list.
+      const templates = await app.request('/reports/templates?limit=2&page=1', authed(f.systemUser.token));
+      const templateBody = (await templates.json()) as { pagination: { total: number } };
+      expect(templateBody.pagination.total).toBe(5);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. Run visibility, pagination, download, baselines
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function seedRunMatrix(f: Fixture) {
+  const parent = await seedReport({
+    orgId: f.orgA,
+    name: 'run-parent',
+    scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+    createdBy: f.siteAUser.id,
+  });
+  const base = Date.parse('2026-07-20T12:00:00.000Z');
+  const at = (m: number) => new Date(base - m * 60_000);
+
+  const visible: string[] = [];
+  const hidden: string[] = [];
+  // Interleave visible A1 runs with hidden ones so a naive limit/offset over an
+  // unfiltered set would slice the wrong rows.
+  for (let i = 0; i < 5; i += 1) {
+    visible.push(
+      await seedRun({
+        reportId: parent,
+        orgId: f.orgA,
+        scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+        createdAt: at(i * 2),
+        result: { rows: [{ hostname: 'host-a1' }], rowCount: 1, summary: { marker: `v${i}` } },
+      }),
+    );
+    hidden.push(
+      await seedRun({
+        reportId: parent,
+        orgId: f.orgA,
+        scope: { kind: 'restricted', userId: f.unrestrictedUser.id, siteIds: [f.siteA2] },
+        createdAt: at(i * 2 + 1),
+        result: { rows: [{ hostname: 'host-a2-SECRET' }], rowCount: 1 },
+      }),
+    );
+  }
+  hidden.push(
+    await seedRun({
+      reportId: parent,
+      orgId: f.orgA,
+      scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id },
+      createdAt: at(20),
+      result: { rows: [{ hostname: 'ORG-WIDE-SECRET' }], rowCount: 1 },
+    }),
+    await seedRun({
+      reportId: parent,
+      orgId: f.orgA,
+      scope: { kind: 'legacy', userId: f.unrestrictedUser.id },
+      createdAt: at(21),
+      result: { rows: [{ hostname: 'LEGACY-SECRET' }], rowCount: 1 },
+    }),
+    await seedRun({
+      reportId: parent,
+      orgId: f.orgA,
+      scope: { kind: 'null' },
+      createdAt: at(22),
+      result: { rows: [{ hostname: 'OLD-WRITER-SECRET' }], rowCount: 1 },
+    }),
+  );
+
+  return { parent, visible, hidden };
+}
+
+describe('Wave 2 · run lists, known-ID access, downloads, and baselines', () => {
+  runDb('five visible runs interleaved with hidden runs page 2/2/1 with total=5', async () => {
+    const f = await buildFixture();
+    const { visible, hidden } = await seedRunMatrix(f);
+    const app = buildApp();
+
+    // Non-vacuity: the pre-wave, org-only join reaches all 13 rows.
+    const orgOnly = await scalar<number>(sql`
+      SELECT count(*)::int FROM report_runs r
+        JOIN reports p ON p.id = r.report_id
+       WHERE p.org_id = ${f.orgA}::uuid
+    `);
+    expect(orgOnly).toBe(13);
+
+    const seen: string[] = [];
+    for (const [page, count] of [[1, 2], [2, 2], [3, 1]] as const) {
+      const res = await app.request(`/reports/runs?limit=2&page=${page}`, authed(f.siteAUser.token));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        data: Array<{ id: string }>;
+        pagination: { total: number };
+      };
+      expect(body.data).toHaveLength(count);
+      expect(body.pagination.total).toBe(5);
+      seen.push(...body.data.map((r) => r.id));
+    }
+    expect(new Set(seen)).toEqual(new Set(visible));
+    for (const id of hidden) expect(seen).not.toContain(id);
+  });
+
+  runDb('a Site A caller cannot fetch or download a Site B / hidden run by UUID', async () => {
+    const f = await buildFixture();
+    const { visible, hidden } = await seedRunMatrix(f);
+
+    // A run in a different organization entirely.
+    const orgBReport = await seedReport({
+      orgId: f.orgB,
+      name: 'b-parent',
+      scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] },
+    });
+    const orgBRun = await seedRun({
+      reportId: orgBReport,
+      orgId: f.orgB,
+      scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] },
+      result: { rows: [{ hostname: 'host-b1-SECRET' }], rowCount: 1 },
+    });
+
+    const app = buildApp();
+    const ghost = randomUUID();
+    const bodies = new Set<string>();
+    for (const id of [...hidden, orgBRun, ghost]) {
+      const detail = await app.request(`/reports/runs/${id}`, authed(f.siteAUser.token));
+      expect(detail.status).toBe(404);
+      bodies.add(`${detail.status}|${await detail.text()}`);
+      const download = await app.request(
+        `/reports/runs/${id}/download`,
+        authed(f.siteAUser.token),
+      );
+      expect(download.status).toBe(404);
+      bodies.add(`${download.status}|${await download.text()}`);
+    }
+    expect([...bodies]).toEqual(['404|{"error":"Report run not found"}']);
+
+    // Positive control: an authorized run downloads fine and never contains
+    // another site's row content.
+    const ok = await app.request(`/reports/runs/${visible[0]}/download`, authed(f.siteAUser.token));
+    expect(ok.status).toBe(200);
+    const csv = await ok.text();
+    expect(csv).toContain('host-a1');
+    expect(csv).not.toContain('SECRET');
+  });
+
+  runDb('a denied run fetch/download never selects the stored result payload', async () => {
+    const f = await buildFixture();
+    const { visible, hidden } = await seedRunMatrix(f);
+    const app = buildApp();
+
+    await withoutSelectPrivilege(
+      'report_runs',
+      async () => {
+        for (const id of hidden) {
+          const detail = await app.request(`/reports/runs/${id}`, authed(f.siteAUser.token));
+          expect(detail.status).toBe(404);
+          const download = await app.request(
+            `/reports/runs/${id}/download`,
+            authed(f.siteAUser.token),
+          );
+          expect(download.status).toBe(404);
+        }
+        // Positive control: the authorized download DOES read `result`, so with
+        // the column revoked it must fail — proving the revoke is effective.
+        const authorized = await app.request(
+          `/reports/runs/${visible[0]}/download`,
+          authed(f.siteAUser.token),
+        );
+        expect(authorized.status).toBeGreaterThanOrEqual(500);
+      },
+      'result',
+    );
+  });
+
+  runDb('baseline lookup never crosses scope fingerprints', async () => {
+    const f = await buildFixture();
+    const parent = await seedReport({
+      orgId: f.orgA,
+      name: 'baseline-parent',
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdBy: f.siteAUser.id,
+    });
+
+    // Older run with the CALLER's fingerprint; newer run with a foreign one.
+    await seedRun({
+      reportId: parent,
+      orgId: f.orgA,
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      result: { rows: [], rowCount: 0, summary: { marker: 'A1-BASELINE' }, generatedAt: '2026-07-01T00:00:00.000Z' },
+    });
+    await seedRun({
+      reportId: parent,
+      orgId: f.orgA,
+      scope: { kind: 'restricted', userId: f.unrestrictedUser.id, siteIds: [f.siteA2] },
+      createdAt: new Date('2026-07-10T00:00:00.000Z'),
+      result: { rows: [], rowCount: 0, summary: { marker: 'A2-BASELINE' }, generatedAt: '2026-07-10T00:00:00.000Z' },
+    });
+
+    // The newest completed run overall is the A2 one — a fingerprint-blind
+    // lookup would return it.
+    const newestOverall = await scalar<string>(sql`
+      SELECT (result->'summary'->>'marker') FROM report_runs
+       WHERE report_id = ${parent}::uuid AND status = 'completed'
+       ORDER BY completed_at DESC LIMIT 1
+    `);
+    expect(newestOverall).toBe('A2-BASELINE');
+
+    const app = buildApp();
+    const res = await app.request(
+      `/reports/${parent}/generate`,
+      authed(f.siteAUser.token, { method: 'POST' }),
+    );
+    expect(res.status).toBe(200);
+    const { runId } = (await res.json()) as { runId: string };
+
+    const marker = await scalar<string | null>(sql`
+      SELECT (result->'previous'->'summary'->>'marker') FROM report_runs WHERE id = ${runId}::uuid
+    `);
+    expect(marker).toBe('A1-BASELINE');
+
+    // And direct service-level proof for the same invariant.
+    const a2Fingerprint = siteScopeFingerprint({
+      version: 1,
+      kind: 'restricted',
+      orgId: f.orgA,
+      siteIds: [f.siteA2],
+    });
+    await withSystemDbAccessContext(async () => {
+      const a2Baseline = await previousBaselineFor(parent, a2Fingerprint);
+      expect(a2Baseline?.summary?.marker).toBe('A2-BASELINE');
+    });
+  });
+
+  runDb('generated run output and download contain only the caller\'s site', async () => {
+    const f = await buildFixture();
+    const parent = await seedReport({
+      orgId: f.orgA,
+      name: 'gen-parent',
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdBy: f.siteAUser.id,
+    });
+    const app = buildApp();
+
+    const res = await app.request(
+      `/reports/${parent}/generate`,
+      authed(f.siteAUser.token, { method: 'POST' }),
+    );
+    expect(res.status).toBe(200);
+    const { runId } = (await res.json()) as { runId: string };
+
+    const stored = await rawRows<{ kind: string; site_ids: string[]; result: { rows: Array<{ hostname: string }> } }>(sql`
+      SELECT execution_scope_kind AS kind, execution_scope_site_ids AS site_ids, result
+        FROM report_runs WHERE id = ${runId}::uuid
+    `);
+    expect(stored[0]!.kind).toBe('restricted');
+    expect(stored[0]!.site_ids).toEqual([f.siteA1]);
+    const hostnames = stored[0]!.result.rows.map((r) => r.hostname);
+    expect(hostnames).toEqual(['host-a1']);
+
+    const download = await app.request(`/reports/runs/${runId}/download`, authed(f.siteAUser.token));
+    expect(download.status).toBe(200);
+    const csv = await download.text();
+    expect(csv).toContain('host-a1');
+    expect(csv).not.toContain('host-a2');
+  });
+
+  runDb('unrestricted creation, execution, and download remain unchanged', async () => {
+    const f = await buildFixture();
+    const app = buildApp();
+
+    const created = await app.request(
+      '/reports',
+      authed(f.unrestrictedUser.token, {
+        method: 'POST',
+        body: JSON.stringify({ name: 'unrestricted report', type: 'device_inventory' }),
+      }),
+    );
+    expect(created.status).toBe(201);
+    const definition = (await created.json()) as {
+      id: string;
+      executionScopeKind: string;
+      executionScopeSiteIds: string[] | null;
+      executionScopeUserId: string;
+    };
+    expect(definition.executionScopeKind).toBe('unrestricted');
+    expect(definition.executionScopeSiteIds).toBeNull();
+    expect(definition.executionScopeUserId).toBe(f.unrestrictedUser.id);
+
+    const generated = await app.request(
+      `/reports/${definition.id}/generate`,
+      authed(f.unrestrictedUser.token, { method: 'POST' }),
+    );
+    expect(generated.status).toBe(200);
+    const { runId } = (await generated.json()) as { runId: string };
+
+    const download = await app.request(
+      `/reports/runs/${runId}/download`,
+      authed(f.unrestrictedUser.token),
+    );
+    expect(download.status).toBe(200);
+    const csv = await download.text();
+    expect(csv).toContain('host-a1');
+    expect(csv).toContain('host-a2');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. Partner / system multi-organization run lists
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Wave 2 · partner and system multi-organization run lists', () => {
+  runDb('partner run list without orgId uses the per-organization composite', async () => {
+    const f = await buildFixture();
+    const base = Date.parse('2026-07-20T12:00:00.000Z');
+    const at = (m: number) => new Date(base - m * 60_000);
+
+    const parentA = await seedReport({ orgId: f.orgA, name: 'pa', scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id } });
+    const parentB = await seedReport({ orgId: f.orgB, name: 'pb', scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] } });
+    const parentD = await seedReport({ orgId: f.orgD, name: 'pd', scope: { kind: 'unrestricted', userId: f.partnerUser.id } });
+    const parentE = await seedReport({ orgId: f.orgE, name: 'pe', scope: { kind: 'unrestricted', userId: f.partnerUser.id } });
+    const parentF = await seedReport({ orgId: f.orgF, name: 'pf', scope: { kind: 'unrestricted', userId: f.foreignUser.id } });
+
+    const visible = [
+      await seedRun({ reportId: parentA, orgId: f.orgA, scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id }, createdAt: at(0) }),
+      await seedRun({ reportId: parentA, orgId: f.orgA, scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] }, createdAt: at(1) }),
+      await seedRun({ reportId: parentA, orgId: f.orgA, scope: { kind: 'legacy', userId: f.unrestrictedUser.id }, createdAt: at(2) }),
+      await seedRun({ reportId: parentB, orgId: f.orgB, scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] }, createdAt: at(3) }),
+      await seedRun({ reportId: parentB, orgId: f.orgB, scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] }, createdAt: at(4) }),
+    ];
+    const excluded = [
+      await seedRun({ reportId: parentB, orgId: f.orgB, scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB2] }, createdAt: at(5) }),
+      await seedRun({ reportId: parentB, orgId: f.orgB, scope: { kind: 'unrestricted', userId: f.partnerUser.id }, createdAt: at(6) }),
+      await seedRun({ reportId: parentB, orgId: f.orgB, scope: { kind: 'legacy', userId: f.partnerUser.id }, createdAt: at(7) }),
+      await seedRun({ reportId: parentB, orgId: f.orgB, scope: { kind: 'null' }, createdAt: at(8) }),
+      await seedRun({ reportId: parentD, orgId: f.orgD, scope: { kind: 'unrestricted', userId: f.partnerUser.id }, createdAt: at(9) }),
+      await seedRun({ reportId: parentE, orgId: f.orgE, scope: { kind: 'unrestricted', userId: f.partnerUser.id }, createdAt: at(10) }),
+      await seedRun({ reportId: parentF, orgId: f.orgF, scope: { kind: 'unrestricted', userId: f.foreignUser.id }, createdAt: at(11) }),
+    ];
+
+    const app = buildApp();
+    const seen: string[] = [];
+    for (const [page, count] of [[1, 2], [2, 2], [3, 1]] as const) {
+      const res = await app.request(
+        `/reports/runs?limit=2&page=${page}`,
+        authed(f.partnerUser.token),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        data: Array<{ id: string }>;
+        pagination: { total: number };
+      };
+      expect(body.data).toHaveLength(count);
+      expect(body.pagination.total).toBe(5);
+      seen.push(...body.data.map((r) => r.id));
+    }
+    expect(new Set(seen)).toEqual(new Set(visible));
+    for (const id of excluded) expect(seen).not.toContain(id);
+  });
+
+  runDb('system run list without orgId applies the unrestricted predicate across organizations', async () => {
+    const f = await buildFixture();
+    const base = Date.parse('2026-07-20T12:00:00.000Z');
+    const at = (m: number) => new Date(base - m * 60_000);
+
+    const parentA = await seedReport({ orgId: f.orgA, name: 'sa', scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id } });
+    const parentF = await seedReport({ orgId: f.orgF, name: 'sf', scope: { kind: 'unrestricted', userId: f.foreignUser.id } });
+
+    const visible = [
+      await seedRun({ reportId: parentA, orgId: f.orgA, scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id }, createdAt: at(0) }),
+      await seedRun({ reportId: parentA, orgId: f.orgA, scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] }, createdAt: at(1) }),
+      await seedRun({ reportId: parentA, orgId: f.orgA, scope: { kind: 'legacy', userId: f.unrestrictedUser.id }, createdAt: at(2) }),
+      await seedRun({ reportId: parentA, orgId: f.orgA, scope: { kind: 'null' }, createdAt: at(3) }),
+      await seedRun({ reportId: parentF, orgId: f.orgF, scope: { kind: 'unrestricted', userId: f.foreignUser.id }, createdAt: at(4) }),
+    ];
+
+    const app = buildApp();
+    await withoutScopeShapeConstraints(async () => {
+      const malformed = await scalar<string>(sql`
+        INSERT INTO report_runs (report_id, status, execution_scope_version, execution_scope_kind,
+                                 execution_scope_fingerprint, execution_scope_captured_at,
+                                 execution_scope_user_id, created_at)
+        VALUES (${parentA}::uuid, 'completed', 3, 'unrestricted', repeat('c', 64), now(),
+                ${f.unrestrictedUser.id}::uuid, ${naiveUtc(at(5))}::timestamp)
+        RETURNING id
+      `);
+
+      const seen: string[] = [];
+      for (const [page, count] of [[1, 2], [2, 2], [3, 1]] as const) {
+        const res = await app.request(
+          `/reports/runs?limit=2&page=${page}`,
+          authed(f.systemUser.token),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          data: Array<{ id: string }>;
+          pagination: { total: number };
+        };
+        expect(body.data).toHaveLength(count);
+        expect(body.pagination.total).toBe(5);
+        seen.push(...body.data.map((r) => r.id));
+      }
+      expect(new Set(seen)).toEqual(new Set(visible));
+      expect(seen).not.toContain(malformed);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. Cross-organization known-ID rebinding
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Wave 2 · cross-organization known-ID fetch and download rebind authority', () => {
+  runDb('an Org B Site-B1 membership overrides partner fallback for exact rows', async () => {
+    const f = await buildFixture();
+
+    const bParent = await seedReport({ orgId: f.orgB, name: 'b-parent', scope: { kind: 'unrestricted', userId: f.partnerUser.id } });
+    const b1Definition = await seedReport({ orgId: f.orgB, name: 'b1-def', scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] } });
+    const b2Definition = await seedReport({ orgId: f.orgB, name: 'b2-def', scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB2] } });
+    const b1Run = await seedRun({ reportId: b1Definition, orgId: f.orgB, scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] } });
+    const b2Run = await seedRun({ reportId: b2Definition, orgId: f.orgB, scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB2] } });
+
+    const aDefinition = await seedReport({ orgId: f.orgA, name: 'a-def', scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id } });
+    const aRun = await seedRun({ reportId: aDefinition, orgId: f.orgA, scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id } });
+
+    const fDefinition = await seedReport({ orgId: f.orgF, name: 'f-def', scope: { kind: 'unrestricted', userId: f.foreignUser.id } });
+    const fRun = await seedRun({ reportId: fDefinition, orgId: f.orgF, scope: { kind: 'unrestricted', userId: f.foreignUser.id } });
+
+    const app = buildApp();
+    const token = f.partnerUser.token;
+
+    // Allowed: Org A via unrestricted partner fallback (no membership there).
+    expect((await app.request(`/reports/${aDefinition}`, authed(token))).status).toBe(200);
+    expect((await app.request(`/reports/runs/${aRun}`, authed(token))).status).toBe(200);
+    expect((await app.request(`/reports/runs/${aRun}/download`, authed(token))).status).toBe(200);
+
+    // Allowed: Org B rows inside Site B1.
+    expect((await app.request(`/reports/${b1Definition}`, authed(token))).status).toBe(200);
+    expect((await app.request(`/reports/runs/${b1Run}`, authed(token))).status).toBe(200);
+
+    // Denied: Org B rows outside Site B1, the Org B unrestricted definition,
+    // the other partner's rows, and a nonexistent UUID — all identical.
+    const ghost = randomUUID();
+    const definitionBodies = new Set<string>();
+    for (const id of [b2Definition, bParent, fDefinition, ghost]) {
+      const res = await app.request(`/reports/${id}`, authed(token));
+      definitionBodies.add(`${res.status}|${await res.text()}`);
+    }
+    expect([...definitionBodies]).toEqual(['404|{"error":"Report not found"}']);
+
+    const runBodies = new Set<string>();
+    for (const id of [b2Run, fRun, ghost]) {
+      const detail = await app.request(`/reports/runs/${id}`, authed(token));
+      runBodies.add(`${detail.status}|${await detail.text()}`);
+      const download = await app.request(`/reports/runs/${id}/download`, authed(token));
+      runBodies.add(`${download.status}|${await download.text()}`);
+    }
+    expect([...runBodies]).toEqual(['404|{"error":"Report run not found"}']);
+
+    // System authority is unrestricted everywhere, including the other partner.
+    for (const id of [b2Definition, bParent, fDefinition, aDefinition]) {
+      expect((await app.request(`/reports/${id}`, authed(f.systemUser.token))).status).toBe(200);
+    }
+    for (const id of [b2Run, fRun, aRun]) {
+      expect((await app.request(`/reports/runs/${id}`, authed(f.systemUser.token))).status).toBe(200);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. GET /reports/:id recentRuns
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Wave 2 · report detail embeds only authorized recent runs', () => {
+  runDb('returns the five newest authorized runs and never embeds a result', async () => {
+    const f = await buildFixture();
+    const parent = await seedReport({
+      orgId: f.orgA,
+      name: 'detail-parent',
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdBy: f.siteAUser.id,
+    });
+    const base = Date.parse('2026-07-20T12:00:00.000Z');
+    const at = (m: number) => new Date(base - m * 60_000);
+
+    const authorized: string[] = [];
+    for (let i = 0; i < 7; i += 1) {
+      authorized.push(
+        await seedRun({
+          reportId: parent,
+          orgId: f.orgA,
+          scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+          createdAt: at(i * 2),
+        }),
+      );
+      await seedRun({
+        reportId: parent,
+        orgId: f.orgA,
+        scope: { kind: 'restricted', userId: f.unrestrictedUser.id, siteIds: [f.siteA2] },
+        createdAt: at(i * 2 + 1),
+        result: { rows: [{ hostname: 'host-a2-SECRET' }], rowCount: 1 },
+      });
+    }
+
+    const app = buildApp();
+    const res = await app.request(`/reports/${parent}`, authed(f.siteAUser.token));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { recentRuns: Array<Record<string, unknown>> };
+    expect(body.recentRuns).toHaveLength(5);
+    expect(body.recentRuns.map((r) => r.id)).toEqual(authorized.slice(0, 5));
+    for (const run of body.recentRuns) {
+      expect(run).not.toHaveProperty('result');
+    }
+    expect(JSON.stringify(body)).not.toContain('SECRET');
+  });
+
+  runDb('partner Org B detail excludes B2/unrestricted/legacy despite Org A fallback', async () => {
+    const f = await buildFixture();
+    const parent = await seedReport({
+      orgId: f.orgB,
+      name: 'b-detail',
+      scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] },
+    });
+    const base = Date.parse('2026-07-20T12:00:00.000Z');
+    const at = (m: number) => new Date(base - m * 60_000);
+
+    const allowed = await seedRun({
+      reportId: parent,
+      orgId: f.orgB,
+      scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB1] },
+      createdAt: at(0),
+    });
+    const excluded = [
+      await seedRun({ reportId: parent, orgId: f.orgB, scope: { kind: 'restricted', userId: f.partnerUser.id, siteIds: [f.siteB2] }, createdAt: at(1) }),
+      await seedRun({ reportId: parent, orgId: f.orgB, scope: { kind: 'unrestricted', userId: f.partnerUser.id }, createdAt: at(2) }),
+      await seedRun({ reportId: parent, orgId: f.orgB, scope: { kind: 'legacy', userId: f.partnerUser.id }, createdAt: at(3) }),
+      await seedRun({ reportId: parent, orgId: f.orgB, scope: { kind: 'null' }, createdAt: at(4) }),
+    ];
+
+    const app = buildApp();
+    const res = await app.request(`/reports/${parent}`, authed(f.partnerUser.token));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { recentRuns: Array<{ id: string }> };
+    expect(body.recentRuns.map((r) => r.id)).toEqual([allowed]);
+    for (const id of excluded) {
+      expect(body.recentRuns.map((r) => r.id)).not.toContain(id);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. Ad-hoc generation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Wave 2 · ad-hoc generation carries an explicit immutable authority', () => {
+  runDb('restricted ad-hoc output excludes other sites and rejects out-of-scope filters', async () => {
+    const f = await buildFixture();
+    const app = buildApp();
+
+    const res = await app.request(
+      '/reports/generate',
+      authed(f.siteAUser.token, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'device_inventory' }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { rows: Array<{ hostname: string }> } };
+    expect(body.data.rows.map((r) => r.hostname)).toEqual(['host-a1']);
+
+    // An explicitly requested foreign site is refused, not silently intersected.
+    const outOfScope = await app.request(
+      '/reports/generate',
+      authed(f.siteAUser.token, {
+        method: 'POST',
+        body: JSON.stringify({
+          type: 'device_inventory',
+          config: { filters: { siteIds: [f.siteA2] } },
+        }),
+      }),
+    );
+    expect(outOfScope.status).toBe(403);
+
+    // Non-vacuity: the unrestricted caller in the same org sees both hosts.
+    const wide = await app.request(
+      '/reports/generate',
+      authed(f.unrestrictedUser.token, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'device_inventory' }),
+      }),
+    );
+    const wideBody = (await wide.json()) as { data: { rows: Array<{ hostname: string }> } };
+    expect(wideBody.data.rows.map((r) => r.hostname).sort()).toEqual(['host-a1', 'host-a2']);
+  });
+
+  runDb('restricted-empty ad-hoc generation issues no device query at all', async () => {
+    const f = await buildFixture();
+    const app = buildApp();
+
+    await withoutSelectPrivilege('devices', async () => {
+      const denied = await app.request(
+        '/reports/generate',
+        authed(f.emptyScopeUser.token, {
+          method: 'POST',
+          body: JSON.stringify({ type: 'device_inventory' }),
+        }),
+      );
+      expect(denied.status).toBe(403);
+
+      // Positive control: the unrestricted caller DOES query devices, so with
+      // SELECT revoked the same request fails.
+      const control = await app.request(
+        '/reports/generate',
+        authed(f.unrestrictedUser.token, {
+          method: 'POST',
+          body: JSON.stringify({ type: 'device_inventory' }),
+        }),
+      );
+      expect(control.status).toBeGreaterThanOrEqual(500);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 10. /reports/data/alerts-summary aggregates
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function seedAlerts(f: Fixture) {
+  const db = getTestDb();
+  const [template] = await db
+    .insert(alertTemplates)
+    .values({
+      name: 'w2-template',
+      conditions: {},
+      severity: 'critical',
+      titleTemplate: 't',
+      messageTemplate: 'm',
+    })
+    .returning({ id: alertTemplates.id });
+
+  const ruleFor = async (orgId: string, name: string) => {
+    const [rule] = await db
+      .insert(alertRules)
+      .values({
+        orgId,
+        templateId: template!.id,
+        name,
+        targetType: 'all',
+        targetId: orgId,
+      })
+      .returning({ id: alertRules.id });
+    return rule!.id;
+  };
+
+  const ruleA = await ruleFor(f.orgA, 'rule-a');
+  const ruleB = await ruleFor(f.orgB, 'rule-b');
+  const ruleD = await ruleFor(f.orgD, 'rule-d');
+  const ruleE = await ruleFor(f.orgE, 'rule-e');
+
+  const now = new Date();
+  await db.insert(alerts).values([
+    { ruleId: ruleA, deviceId: f.deviceA1, orgId: f.orgA, severity: 'critical', status: 'active', title: 'a1', triggeredAt: now },
+    { ruleId: ruleA, deviceId: f.deviceA2, orgId: f.orgA, severity: 'high', status: 'active', title: 'a2', triggeredAt: now },
+    { ruleId: ruleB, deviceId: f.deviceB1, orgId: f.orgB, severity: 'medium', status: 'acknowledged', title: 'b1', triggeredAt: now },
+    { ruleId: ruleB, deviceId: f.deviceB2, orgId: f.orgB, severity: 'low', status: 'resolved', title: 'b2', triggeredAt: now },
+    { ruleId: ruleD, deviceId: f.deviceD1, orgId: f.orgD, severity: 'info', status: 'active', title: 'd1', triggeredAt: now },
+    { ruleId: ruleE, deviceId: f.deviceE1, orgId: f.orgE, severity: 'critical', status: 'active', title: 'e1', triggeredAt: now },
+  ]);
+}
+
+interface AlertsSummaryBody {
+  data: {
+    bySeverity: Record<string, number>;
+    byStatus: Record<string, number>;
+    byDay: Array<{ date: string; count: number }>;
+    topRules: Array<{ ruleName: string; count: number }>;
+  };
+  total: number;
+}
+
+describe('Wave 2 · alerts-summary aggregates respect the exact per-organization scope', () => {
+  runDb('exact restricted organization returns Site A-only values in every aggregate', async () => {
+    const f = await buildFixture();
+    await seedAlerts(f);
+    const app = buildApp();
+
+    const res = await app.request('/reports/data/alerts-summary', authed(f.siteAUser.token));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AlertsSummaryBody;
+    expect(body.total).toBe(1);
+    expect(body.data.bySeverity).toEqual({ critical: 1 });
+    expect(body.data.byStatus).toEqual({ active: 1 });
+    expect(body.data.byDay.reduce((sum, d) => sum + d.count, 0)).toBe(1);
+    expect(body.data.topRules.map((r) => r.ruleName)).toEqual(['rule-a']);
+    expect(body.data.topRules[0]!.count).toBe(1);
+
+    // Non-vacuity: the same org, unrestricted, sees both A alerts.
+    const wide = await app.request('/reports/data/alerts-summary', authed(f.unrestrictedUser.token));
+    const wideBody = (await wide.json()) as AlertsSummaryBody;
+    expect(wideBody.total).toBe(2);
+    expect(wideBody.data.bySeverity).toEqual({ critical: 1, high: 1 });
+  });
+
+  runDb('partner no-orgId aggregates cover Org A wholly and Org B only at Site B1', async () => {
+    const f = await buildFixture();
+    await seedAlerts(f);
+    const app = buildApp();
+
+    const res = await app.request('/reports/data/alerts-summary', authed(f.partnerUser.token));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AlertsSummaryBody;
+
+    expect(body.total).toBe(3);
+    expect(body.data.bySeverity).toEqual({ critical: 1, high: 1, medium: 1 });
+    expect(body.data.byStatus).toEqual({ active: 2, acknowledged: 1 });
+    expect(body.data.byDay.reduce((sum, d) => sum + d.count, 0)).toBe(3);
+    expect(new Set(body.data.topRules.map((r) => r.ruleName))).toEqual(new Set(['rule-a', 'rule-b']));
+    // Org D (denied) and Org E (restricted-empty) contribute nothing; if Org E's
+    // critical alert leaked, critical would be 2 and rule-e would appear.
+    expect(body.data.topRules.map((r) => r.ruleName)).not.toContain('rule-d');
+    expect(body.data.topRules.map((r) => r.ruleName)).not.toContain('rule-e');
+
+    // Non-vacuity: the system caller sees every alert in the fixture.
+    const system = await app.request('/reports/data/alerts-summary', authed(f.systemUser.token));
+    const systemBody = (await system.json()) as AlertsSummaryBody;
+    expect(systemBody.total).toBe(6);
+
+    // An explicit organization derives ONE membership-first scope.
+    const explicitB = await app.request(
+      `/reports/data/alerts-summary?orgId=${f.orgB}`,
+      authed(f.partnerUser.token),
+    );
+    const explicitBody = (await explicitB.json()) as AlertsSummaryBody;
+    expect(explicitBody.total).toBe(1);
+    expect(explicitBody.data.bySeverity).toEqual({ medium: 1 });
+  });
+
+  runDb('restricted-empty authority answers zero-safe without touching alerts', async () => {
+    const f = await buildFixture();
+    await seedAlerts(f);
+    const app = buildApp();
+
+    await withoutSelectPrivilege('alerts', async () => {
+      const empty = await app.request(
+        '/reports/data/alerts-summary',
+        authed(f.emptyScopeUser.token),
+      );
+      expect(empty.status).toBe(200);
+      expect(await empty.json()).toEqual({
+        data: { bySeverity: {}, byStatus: {}, byDay: [], topRules: [] },
+        total: 0,
+      });
+
+      // Positive control: an authorized caller DOES query alerts.
+      const control = await app.request(
+        '/reports/data/alerts-summary',
+        authed(f.unrestrictedUser.token),
+      );
+      expect(control.status).toBeGreaterThanOrEqual(500);
+    });
+  });
+
+  runDb('devices.site_id is NOT NULL — a "null-site" device row is unrepresentable', async () => {
+    const nullable = await scalar<string>(sql`
+      SELECT is_nullable FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name = 'devices' AND column_name = 'site_id'
+    `);
+    expect(nullable).toBe('NO');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 11. Scheduled execution gates
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function runScheduled(reportId: string): Promise<void> {
+  await withSystemDbAccessContext(() =>
+    processRunScheduledReport({
+      type: 'run-scheduled-report',
+      reportId,
+      occurrenceKey: 1,
+    }),
+  );
+}
+
+describe('Wave 2 · scheduled execution fails closed before any side effect', () => {
+  runDb('a scheduled run completes and delivers while the creator keeps a common site', async () => {
+    const f = await buildFixture();
+    const reportId = await seedReport({
+      orgId: f.orgA,
+      name: 'scheduled-ok',
+      schedule: 'daily',
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdBy: f.siteAUser.id,
+      config: { emailRecipients: ['ops@example.com'] },
+    });
+
+    await runScheduled(reportId);
+
+    const runs = await rawRows<{ status: string; kind: string; site_ids: string[]; result: { rows: Array<{ hostname: string }> } | null }>(sql`
+      SELECT status, execution_scope_kind AS kind, execution_scope_site_ids AS site_ids, result
+        FROM report_runs WHERE report_id = ${reportId}::uuid
+    `);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.status).toBe('completed');
+    expect(runs[0]!.kind).toBe('restricted');
+    expect(runs[0]!.site_ids).toEqual([f.siteA1]);
+    expect(runs[0]!.result!.rows.map((r) => r.hostname)).toEqual(['host-a1']);
+    expect(emailProbe.calls).toBe(1);
+  });
+
+  runDb('narrowing the creator to no common site blocks the run before output or email', async () => {
+    const f = await buildFixture();
+    const reportId = await seedReport({
+      orgId: f.orgA,
+      name: 'scheduled-narrowed',
+      schedule: 'daily',
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdBy: f.siteAUser.id,
+      config: { emailRecipients: ['ops@example.com'] },
+    });
+
+    await getTestDb()
+      .update(organizationUsers)
+      .set({ siteIds: [f.siteA2] })
+      .where(and(eq(organizationUsers.userId, f.siteAUser.id), eq(organizationUsers.orgId, f.orgA)));
+
+    await runScheduled(reportId);
+
+    const runs = await rawRows<{ status: string; error_message: string | null; result: unknown; output_url: string | null }>(sql`
+      SELECT status, error_message, result, output_url FROM report_runs WHERE report_id = ${reportId}::uuid
+    `);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.status).toBe('failed');
+    expect(runs[0]!.error_message).toBe('scope_no_intersection');
+    expect(runs[0]!.result).toBeNull();
+    expect(runs[0]!.output_url).toBeNull();
+    expect(emailProbe.calls).toBe(0);
+
+    const lastGenerated = await scalar<Date | null>(
+      sql`SELECT last_generated_at FROM reports WHERE id = ${reportId}::uuid`,
+    );
+    expect(lastGenerated).toBeNull();
+  });
+
+  runDb('removing the creator membership blocks execution', async () => {
+    const f = await buildFixture();
+    const reportId = await seedReport({
+      orgId: f.orgA,
+      name: 'scheduled-removed',
+      schedule: 'daily',
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdBy: f.siteAUser.id,
+      config: { emailRecipients: ['ops@example.com'] },
+    });
+
+    await getTestDb()
+      .delete(organizationUsers)
+      .where(and(eq(organizationUsers.userId, f.siteAUser.id), eq(organizationUsers.orgId, f.orgA)));
+
+    await runScheduled(reportId);
+
+    const runs = await rawRows<{ status: string; error_message: string | null }>(sql`
+      SELECT status, error_message FROM report_runs WHERE report_id = ${reportId}::uuid
+    `);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.status).toBe('failed');
+    expect(runs[0]!.error_message).toBe('scope_membership_removed');
+    expect(emailProbe.calls).toBe(0);
+  });
+
+  runDb('a disabled creator blocks execution', async () => {
+    const f = await buildFixture();
+    const reportId = await seedReport({
+      orgId: f.orgA,
+      name: 'scheduled-disabled',
+      schedule: 'daily',
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdBy: f.siteAUser.id,
+    });
+
+    await getTestDb()
+      .update(users)
+      .set({ status: 'disabled' })
+      .where(eq(users.id, f.siteAUser.id));
+
+    await runScheduled(reportId);
+
+    const runs = await rawRows<{ status: string; error_message: string | null }>(sql`
+      SELECT status, error_message FROM report_runs WHERE report_id = ${reportId}::uuid
+    `);
+    expect(runs[0]!.status).toBe('failed');
+    expect(runs[0]!.error_message).toBe('scope_user_inactive');
+  });
+
+  runDb('legacy and old-writer schedules never execute and are never marked due', async () => {
+    const f = await buildFixture();
+    const legacyId = await seedReport({
+      orgId: f.orgA,
+      name: 'scheduled-legacy',
+      schedule: 'daily',
+      scope: { kind: 'legacy', userId: f.unrestrictedUser.id },
+      createdBy: f.unrestrictedUser.id,
+    });
+    const oldWriterId = await seedReport({
+      orgId: f.orgA,
+      name: 'scheduled-old-writer',
+      schedule: 'daily',
+      scope: { kind: 'null' },
+      createdBy: f.unrestrictedUser.id,
+    });
+    const executableId = await seedReport({
+      orgId: f.orgA,
+      name: 'scheduled-executable',
+      schedule: 'daily',
+      scope: { kind: 'unrestricted', userId: f.unrestrictedUser.id },
+      createdBy: f.unrestrictedUser.id,
+    });
+
+    // The all-null row decodes as legacy_unscoped rather than throwing.
+    const oldWriterRow = await rawRows<PersistedSiteScopeColumns & { org_id: string }>(sql`
+      SELECT org_id,
+             execution_scope_version AS "executionScopeVersion",
+             execution_scope_kind AS "executionScopeKind",
+             execution_scope_site_ids AS "executionScopeSiteIds",
+             execution_scope_user_id AS "executionScopeUserId",
+             execution_scope_fingerprint AS "executionScopeFingerprint",
+             execution_scope_captured_at AS "executionScopeCapturedAt"
+        FROM reports WHERE id = ${oldWriterId}::uuid
+    `);
+    expect(decodeSiteScope(oldWriterRow[0]!, f.orgA)).toEqual({
+      version: 1,
+      kind: 'legacy_unscoped',
+      orgId: f.orgA,
+    });
+
+    const due = await withSystemDbAccessContext(() =>
+      findDueReports(new Date('2026-07-21T12:00:00.000Z')),
+    );
+    const dueIds = due.map((d) => d.id);
+    expect(dueIds).not.toContain(legacyId);
+    expect(dueIds).not.toContain(oldWriterId);
+    expect(dueIds).toContain(executableId);
+
+    // Even if forced, neither produces output.
+    for (const [id, reason] of [
+      [legacyId, 'scope_legacy_unscoped'],
+      [oldWriterId, 'scope_legacy_unscoped'],
+    ] as const) {
+      await runScheduled(id);
+      const runs = await rawRows<{ status: string; error_message: string | null; result: unknown }>(sql`
+        SELECT status, error_message, result FROM report_runs WHERE report_id = ${id}::uuid
+      `);
+      expect(runs).toHaveLength(1);
+      expect(runs[0]!.status).toBe('failed');
+      expect(runs[0]!.error_message).toBe(reason);
+      expect(runs[0]!.result).toBeNull();
+    }
+    expect(emailProbe.calls).toBe(0);
+  });
+
+  runDb('reauthorization is the only way a legacy schedule becomes executable', async () => {
+    const f = await buildFixture();
+    const legacyId = await seedReport({
+      orgId: f.orgA,
+      name: 'scheduled-legacy-reauth',
+      schedule: 'daily',
+      scope: { kind: 'legacy', userId: f.unrestrictedUser.id },
+      createdBy: f.unrestrictedUser.id,
+    });
+    const app = buildApp();
+
+    // A restricted caller may not reauthorize a legacy definition.
+    expect(
+      (await app.request(`/reports/${legacyId}/reauthorize`, authed(f.siteAUser.token, { method: 'POST' }))).status,
+    ).toBe(404);
+
+    const res = await app.request(
+      `/reports/${legacyId}/reauthorize`,
+      authed(f.unrestrictedUser.token, { method: 'POST' }),
+    );
+    expect(res.status).toBe(200);
+    const updated = (await res.json()) as {
+      executionScopeKind: string;
+      executionScopeUserId: string;
+    };
+    expect(updated.executionScopeKind).toBe('unrestricted');
+    expect(updated.executionScopeUserId).toBe(f.unrestrictedUser.id);
+
+    const due = await withSystemDbAccessContext(() =>
+      findDueReports(new Date('2026-07-21T12:00:00.000Z')),
+    );
+    expect(due.map((d) => d.id)).toContain(legacyId);
+
+    await runScheduled(legacyId);
+    const runs = await rawRows<{ status: string }>(
+      sql`SELECT status FROM report_runs WHERE report_id = ${legacyId}::uuid`,
+    );
+    expect(runs.map((r) => r.status)).toEqual(['completed']);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 12. Migration + mixed-version invariants
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('Wave 2 · migration is idempotent and the shape CHECK holds', () => {
+  runDb('reapplying the expansion migration changes neither schema nor rows', async () => {
+    const f = await buildFixture();
+    await seedReport({
+      orgId: f.orgA,
+      name: 'idempotency-restricted',
+      scope: { kind: 'restricted', userId: f.siteAUser.id, siteIds: [f.siteA1] },
+      createdBy: f.siteAUser.id,
+    });
+    const oldWriter = await seedReport({
+      orgId: f.orgA,
+      name: 'idempotency-old-writer',
+      scope: { kind: 'null' },
+      createdBy: f.unrestrictedUser.id,
+    });
+    await seedRun({ reportId: oldWriter, orgId: f.orgA, scope: { kind: 'null' } });
+
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const migrationPath = path.resolve(here, '../../../migrations', MIGRATION_FILE);
+    const migrationSql = await readFile(migrationPath, 'utf8');
+
+    const snapshotSchema = () => rawRows(sql`
+      SELECT table_name, column_name, data_type, is_nullable
+        FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name IN ('reports', 'report_runs')
+       ORDER BY table_name, column_name
+    `);
+    const snapshotConstraints = () => rawRows(sql`
+      SELECT conname, pg_get_constraintdef(oid) AS definition
+        FROM pg_constraint
+       WHERE conrelid IN ('reports'::regclass, 'report_runs'::regclass)
+       ORDER BY conname
+    `);
+    const snapshotRows = async () => ({
+      reports: await rawRows(sql`
+        SELECT id, execution_scope_version, execution_scope_kind, execution_scope_site_ids,
+               execution_scope_user_id, execution_scope_fingerprint, execution_scope_captured_at
+          FROM reports ORDER BY id
+      `),
+      runs: await rawRows(sql`
+        SELECT id, execution_scope_version, execution_scope_kind, execution_scope_site_ids,
+               execution_scope_user_id, execution_scope_fingerprint, execution_scope_captured_at
+          FROM report_runs ORDER BY id
+      `),
+    });
+
+    // First (re)application backfills the all-null rows to legacy_unscoped.
+    await getTestDb().execute(sql.raw(migrationSql));
+    const schemaBefore = await snapshotSchema();
+    const constraintsBefore = await snapshotConstraints();
+    const rowsBefore = await snapshotRows();
+
+    expect(
+      (rowsBefore.reports as Array<{ id: string; execution_scope_kind: string }>).find(
+        (r) => r.id === oldWriter,
+      )?.execution_scope_kind,
+    ).toBe('legacy_unscoped');
+
+    // Second application must be a strict no-op.
+    await getTestDb().execute(sql.raw(migrationSql));
+
+    expect(await snapshotSchema()).toEqual(schemaBefore);
+    expect(await snapshotConstraints()).toEqual(constraintsBefore);
+    expect(await snapshotRows()).toEqual(rowsBefore);
+
+    const backfilled = await scalar<number>(sql`
+      SELECT count(*)::int FROM reports
+       WHERE execution_scope_kind = 'legacy_unscoped'
+         AND execution_scope_fingerprint = encode(
+           sha256(convert_to('{"version":1,"kind":"legacy_unscoped","orgId":"' || org_id::text || '"}', 'UTF8')), 'hex')
+    `);
+    expect(backfilled).toBeGreaterThan(0);
+  });
+
+  runDb('the shape CHECK rejects every partial provenance combination', async () => {
+    const f = await buildFixture();
+    const forbidden = [
+      sql`INSERT INTO reports (org_id, name, type, execution_scope_version) VALUES (${f.orgA}::uuid, 'p1', 'device_inventory', 1)`,
+      sql`INSERT INTO reports (org_id, name, type, execution_scope_kind) VALUES (${f.orgA}::uuid, 'p2', 'device_inventory', 'unrestricted')`,
+      sql`INSERT INTO reports (org_id, name, type, execution_scope_version, execution_scope_kind, execution_scope_fingerprint, execution_scope_captured_at) VALUES (${f.orgA}::uuid, 'p3', 'device_inventory', 1, 'unrestricted', repeat('a', 64), now())`,
+      sql`INSERT INTO reports (org_id, name, type, execution_scope_version, execution_scope_kind, execution_scope_site_ids, execution_scope_user_id, execution_scope_fingerprint, execution_scope_captured_at) VALUES (${f.orgA}::uuid, 'p4', 'device_inventory', 1, 'unrestricted', ARRAY[${f.siteA1}::uuid], ${f.siteAUser.id}::uuid, repeat('a', 64), now())`,
+      sql`INSERT INTO reports (org_id, name, type, execution_scope_version, execution_scope_kind, execution_scope_user_id, execution_scope_fingerprint, execution_scope_captured_at) VALUES (${f.orgA}::uuid, 'p5', 'device_inventory', 1, 'restricted', ${f.siteAUser.id}::uuid, repeat('a', 64), now())`,
+      sql`INSERT INTO reports (org_id, name, type, execution_scope_version, execution_scope_kind, execution_scope_user_id, execution_scope_fingerprint, execution_scope_captured_at) VALUES (${f.orgA}::uuid, 'p6', 'device_inventory', 2, 'unrestricted', ${f.siteAUser.id}::uuid, repeat('a', 64), now())`,
+      sql`INSERT INTO reports (org_id, name, type, execution_scope_version, execution_scope_kind, execution_scope_user_id, execution_scope_fingerprint, execution_scope_captured_at) VALUES (${f.orgA}::uuid, 'p7', 'device_inventory', 1, 'bogus', ${f.siteAUser.id}::uuid, repeat('a', 64), now())`,
+    ];
+
+    for (const statement of forbidden) {
+      await expect(getTestDb().execute(statement)).rejects.toThrow();
+    }
+    expect(
+      await scalar<number>(sql`SELECT count(*)::int FROM reports WHERE name LIKE 'p_'`),
+    ).toBe(0);
+  });
+});

--- a/apps/api/src/__tests__/integration/securityComplianceReport.integration.test.ts
+++ b/apps/api/src/__tests__/integration/securityComplianceReport.integration.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { db, withDbAccessContext, withSystemDbAccessContext } from '../../db';
 import { devices, deviceVulnerabilities, vulnerabilities } from '../../db/schema';
 import { generateSecurityCompliancePostureReport } from '../../services/securityComplianceReport';
+import { siteScopeFingerprint, type ReportExecutionAuthority } from '../../services/siteScope';
 import { loadOpenVulnerabilityCounts } from '../../services/securityComplianceReportVulnerabilities';
 import { setupTestEnvironment } from './db-utils';
 
@@ -104,9 +105,20 @@ describe('security compliance report vulnerability isolation', () => {
         userId: envA.user.id,
       },
       async () => {
+        const scope = {
+          version: 1 as const,
+          kind: 'unrestricted' as const,
+          orgId: envA.organization.id,
+        };
+        const authority: ReportExecutionAuthority = {
+          scope,
+          principalUserId: envA.user.id,
+          capturedAt: new Date(),
+          fingerprint: siteScopeFingerprint(scope),
+        };
         const result = await generateSecurityCompliancePostureReport(envA.organization.id, {
           includeCis: false,
-        });
+        }, authority);
         const vulnerabilityCounts = await loadOpenVulnerabilityCounts([
           seeded.deviceA,
           seeded.deviceB,

--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -183,9 +183,12 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
   // per-device rows), so no cross-site device data is disclosed (returns
   // re-verified 2026-05-31). NB: totals still span the org incl. other
   // sites — site-scoping the aggregates themselves is a separate product call.
+  // routes/metrics.ts:GET / and GET /trends were exempted here as org-wide
+  // aggregates with the note that site-scoping them was "a separate product
+  // call". Wave 2 made that call: GET / now applies the allowed-site
+  // predicate to every aggregate and GET /trends denies site-restricted
+  // callers outright, so the ratchet correctly demands these entries go.
   'routes/huntress.ts:GET /status',
-  'routes/metrics.ts:GET /',
-  'routes/metrics.ts:GET /trends',
   'routes/sentinelOne.ts:GET /status',
   'routes/softwarePolicies.ts:GET /compliance/overview',
   'routes/updateRings.ts:GET /:id/compliance',
@@ -220,8 +223,6 @@ const SITE_SCOPE_INPUT_EXEMPT_USER_SESSION_OK: ReadonlySet<string> = new Set<str
   // re-verification test (added in #1041) accepts them. (Site-scoping the
   // aggregate totals themselves is a separate product call.)
   'routes/huntress.ts:GET /status',
-  'routes/metrics.ts:GET /',
-  'routes/metrics.ts:GET /trends',
   'routes/sentinelOne.ts:GET /status',
   'routes/softwarePolicies.ts:GET /compliance/overview',
   'routes/updateRings.ts:GET /:id/compliance',

--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -9,7 +9,7 @@ import {
   partitionLedgerRows,
 } from './autoMigrate';
 import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -256,6 +256,22 @@ describe('CHECKSUM_RECONCILIATIONS', () => {
       expect(rec.to).toMatch(/^[0-9a-f]{64}$/);
       expect(rec.reason.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('core migration ordering', () => {
+  const migrationsDir = path.resolve(__dirname, '../../migrations');
+
+  it('discovers the report site-scope migration exactly once in lexical order', () => {
+    const filenames = readdirSync(migrationsDir)
+      .filter((filename) => /^\d{4}-.*\.sql$/.test(filename))
+      .sort((a, b) => a.localeCompare(b));
+    const ledgerNames = planMigrations(filenames).map((migration) => migration.ledgerName);
+    const reserved = '2026-08-06-a-report-site-scope.sql';
+
+    expect(ledgerNames.filter((filename) => filename === reserved)).toHaveLength(1);
+    expect(ledgerNames).toEqual([...ledgerNames].sort((a, b) => a.localeCompare(b)));
+    expect(ledgerNames.at(-1)).toBe(reserved);
   });
 });
 

--- a/apps/api/src/db/schema/reports.test.ts
+++ b/apps/api/src/db/schema/reports.test.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect } from 'vitest';
-import { reportTypeEnum } from './reports';
+import { getTableColumns } from 'drizzle-orm';
+import { reportRuns, reports, reportTypeEnum } from './reports';
+
+const executionScopeColumns = [
+  'executionScopeVersion',
+  'executionScopeKind',
+  'executionScopeSiteIds',
+  'executionScopeUserId',
+  'executionScopeFingerprint',
+  'executionScopeCapturedAt',
+] as const;
+
+describe('report execution scope provenance', () => {
+  it.each([
+    ['reports', reports],
+    ['report_runs', reportRuns],
+  ])('exposes all six nullable execution-scope columns on %s', (_name, table) => {
+    const columns = getTableColumns(table);
+
+    for (const columnName of executionScopeColumns) {
+      expect(columns).toHaveProperty(columnName);
+      expect(columns[columnName].notNull).toBe(false);
+    }
+  });
+});
 
 describe('reportTypeEnum', () => {
   it('includes the security & compliance posture type', () => {

--- a/apps/api/src/db/schema/reports.ts
+++ b/apps/api/src/db/schema/reports.ts
@@ -38,6 +38,12 @@ export const reports = pgTable('reports', {
   format: reportFormatEnum('format').notNull().default('csv'),
   lastGeneratedAt: timestamp('last_generated_at'),
   createdBy: uuid('created_by').references(() => users.id),
+  executionScopeVersion: integer('execution_scope_version'),
+  executionScopeKind: varchar('execution_scope_kind', { length: 32 }),
+  executionScopeSiteIds: uuid('execution_scope_site_ids').array(),
+  executionScopeUserId: uuid('execution_scope_user_id'),
+  executionScopeFingerprint: varchar('execution_scope_fingerprint', { length: 64 }),
+  executionScopeCapturedAt: timestamp('execution_scope_captured_at', { withTimezone: true }),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull()
 });
@@ -52,5 +58,11 @@ export const reportRuns = pgTable('report_runs', {
   errorMessage: text('error_message'),
   rowCount: integer('row_count'),
   result: jsonb('result'),
+  executionScopeVersion: integer('execution_scope_version'),
+  executionScopeKind: varchar('execution_scope_kind', { length: 32 }),
+  executionScopeSiteIds: uuid('execution_scope_site_ids').array(),
+  executionScopeUserId: uuid('execution_scope_user_id'),
+  executionScopeFingerprint: varchar('execution_scope_fingerprint', { length: 64 }),
+  executionScopeCapturedAt: timestamp('execution_scope_captured_at', { withTimezone: true }),
   createdAt: timestamp('created_at').defaultNow().notNull()
 });

--- a/apps/api/src/jobs/reportScheduleWorker.test.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.test.ts
@@ -17,10 +17,17 @@ vi.mock('../db/schema', () => ({
   reports: {
     id: 'reports.id',
     orgId: 'reports.org_id',
+    createdBy: 'reports.created_by',
     schedule: 'reports.schedule',
     lastGeneratedAt: 'reports.last_generated_at',
     config: 'reports.config',
     updatedAt: 'reports.updated_at',
+    executionScopeVersion: 'reports.execution_scope_version',
+    executionScopeKind: 'reports.execution_scope_kind',
+    executionScopeSiteIds: 'reports.execution_scope_site_ids',
+    executionScopeUserId: 'reports.execution_scope_user_id',
+    executionScopeFingerprint: 'reports.execution_scope_fingerprint',
+    executionScopeCapturedAt: 'reports.execution_scope_captured_at',
   },
   reportRuns: {
     id: 'report_runs.id',
@@ -42,10 +49,53 @@ vi.mock('../db/schema', () => ({
 type PreviousBaseline = { generatedAt: string | null; summary?: Record<string, unknown> } | undefined;
 
 const generateReportMock = vi.fn();
-const previousBaselineForMock = vi.fn<() => Promise<PreviousBaseline>>(async () => undefined);
+const reportExecutionPreflightMock = vi.fn();
+const previousBaselineForMock = vi.fn<
+  (reportId: string, fingerprint: string) => Promise<PreviousBaseline>
+>(async () => undefined);
 vi.mock('../services/reportGenerationService', () => ({
   generateReport: (...args: unknown[]) => generateReportMock(...(args as [])),
-  previousBaselineFor: (...args: unknown[]) => previousBaselineForMock(...(args as [])),
+  assertReportExecutionPreflight: (...args: unknown[]) =>
+    reportExecutionPreflightMock(...args),
+  previousBaselineFor: (...args: unknown[]) =>
+    previousBaselineForMock(...(args as [string, string])),
+}));
+
+const scopeState = vi.hoisted(() => ({
+  liveResult: null as any,
+  decodedScope: null as any,
+  intersection: null as any,
+  decodeError: null as Error | null,
+}));
+const resolveLiveReportAuthorityMock = vi.fn(
+  async (_userId: string, _orgId: string, _action: 'read') => scopeState.liveResult,
+);
+const decodeSiteScopeMock = vi.fn((_row: unknown, _orgId: string) => {
+  if (scopeState.decodeError) throw scopeState.decodeError;
+  return scopeState.decodedScope;
+});
+const intersectSiteScopesMock = vi.fn(
+  (_persistedScope: unknown, _currentScope: unknown) => scopeState.intersection,
+);
+vi.mock('../services/siteScope', () => ({
+  resolveLiveReportAuthority: (...args: unknown[]) =>
+    resolveLiveReportAuthorityMock(...(args as [string, string, 'read'])),
+  decodeSiteScope: (...args: unknown[]) =>
+    decodeSiteScopeMock(...(args as [unknown, string])),
+  intersectSiteScopes: (...args: unknown[]) =>
+    intersectSiteScopesMock(...(args as [unknown, unknown])),
+  siteScopeFingerprint: vi.fn((scope: { kind: string }) =>
+    scope.kind === 'restricted' ? 'a'.repeat(64) : 'f'.repeat(64)
+  ),
+  persistedSiteScopeValues: vi.fn((authority: any) => ({
+    executionScopeVersion: 1,
+    executionScopeKind: authority.scope.kind,
+    executionScopeSiteIds:
+      authority.scope.kind === 'restricted' ? authority.scope.siteIds : null,
+    executionScopeUserId: authority.principalUserId,
+    executionScopeFingerprint: authority.fingerprint,
+    executionScopeCapturedAt: authority.capturedAt,
+  })),
 }));
 
 const sendEmailMock = vi.fn();
@@ -118,9 +168,11 @@ function selectChain(rows: unknown[]) {
 }
 
 function insertChain(rows: unknown[]) {
-  const chain: Record<string, unknown> = {};
-  chain.values = vi.fn(() => chain);
-  chain.returning = vi.fn(async () => rows);
+  const chain = {
+    values: vi.fn(),
+    returning: vi.fn(async () => rows),
+  };
+  chain.values.mockReturnValue(chain);
   return chain;
 }
 
@@ -133,8 +185,45 @@ function updateChain() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  selectMock.mockReset();
+  insertMock.mockReset();
+  updateMock.mockReset();
+  generateReportMock.mockReset();
+  reportExecutionPreflightMock.mockReset();
+  previousBaselineForMock.mockReset();
+  sendEmailMock.mockReset();
+  loadReportBrandingForOrgMock.mockReset();
+  loadReportBrandingForOrgMock.mockResolvedValue({
+    name: 'Olive MSP',
+    logoDataUrl: null,
+    logoAspect: null,
+  });
   pdfRender.shouldThrow = false;
   previousBaselineForMock.mockResolvedValue(undefined);
+  scopeState.decodeError = null;
+  scopeState.decodedScope = {
+    version: 1,
+    kind: 'unrestricted',
+    orgId: ORG_ID,
+  };
+  scopeState.intersection = {
+    version: 1,
+    kind: 'unrestricted',
+    orgId: ORG_ID,
+  };
+  scopeState.liveResult = {
+    ok: true,
+    authority: {
+      scope: {
+        version: 1,
+        kind: 'unrestricted',
+        orgId: ORG_ID,
+      },
+      principalUserId: '44444444-4444-4444-8444-444444444444',
+      capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+      fingerprint: 'f'.repeat(64),
+    },
+  };
 });
 
 // ─── Occurrence math (pure) ──────────────────────────────────────────────────
@@ -244,6 +333,7 @@ describe('findDueReports', () => {
         },
       ]),
     );
+    selectMock.mockReturnValueOnce(selectChain([{ count: 0 }]));
 
     const due = await findDueReports(now);
     expect(due).toEqual([{ id: REPORT_ID, occurrenceKey: 202607010900 }]);
@@ -266,8 +356,27 @@ describe('findDueReports', () => {
         },
       ]),
     );
+    selectMock.mockReturnValueOnce(selectChain([{ count: 0 }]));
 
     expect(await findDueReports(now)).toEqual([]);
+  });
+
+  it('observes legacy/null schedules skipped by the complete-scope polling gate', async () => {
+    selectMock
+      .mockReturnValueOnce(selectChain([]))
+      .mockReturnValueOnce(selectChain([{ count: 2 }]));
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      expect(await findDueReports(new Date('2026-07-01T15:00:00Z')))
+        .toEqual([]);
+      expect(consoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('scope reauthorization'),
+        expect.objectContaining({ count: 2 }),
+      );
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 });
 
@@ -283,6 +392,12 @@ describe('processRunScheduledReport', () => {
     schedule: 'daily',
     config: { schedule: { time: '09:00' }, emailRecipients: ['ops@example.com', 'not-an-email'] },
     lastGeneratedAt: null,
+    executionScopeVersion: 1,
+    executionScopeKind: 'unrestricted',
+    executionScopeSiteIds: null,
+    executionScopeUserId: '44444444-4444-4444-8444-444444444444',
+    executionScopeFingerprint: 'f'.repeat(64),
+    executionScopeCapturedAt: new Date('2026-07-24T12:00:00.000Z'),
   };
 
   it('stores a completed run, stamps lastGeneratedAt, and emails valid recipients with a CSV', async () => {
@@ -296,7 +411,31 @@ describe('processRunScheduledReport', () => {
 
     await processRunScheduledReport({ type: 'run-scheduled-report', reportId: REPORT_ID, occurrenceKey: 202607010900 });
 
-    expect(generateReportMock).toHaveBeenCalledWith('device_inventory', ORG_ID, report.config, undefined);
+    expect(resolveLiveReportAuthorityMock).toHaveBeenCalledWith(
+      report.executionScopeUserId,
+      ORG_ID,
+      'read',
+    );
+    expect(generateReportMock).toHaveBeenCalledWith(
+      'device_inventory',
+      ORG_ID,
+      report.config,
+      expect.objectContaining({
+        scope: expect.objectContaining({ kind: 'unrestricted', orgId: ORG_ID }),
+        principalUserId: report.executionScopeUserId,
+        fingerprint: 'f'.repeat(64),
+      }),
+    );
+    expect(runInsert.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionScopeVersion: 1,
+        executionScopeKind: 'unrestricted',
+        executionScopeSiteIds: null,
+        executionScopeUserId: report.executionScopeUserId,
+        executionScopeFingerprint: 'f'.repeat(64),
+        executionScopeCapturedAt: expect.any(Date),
+      }),
+    );
     // First update stamps reports.lastGeneratedAt, second completes the run.
     expect(updates[0]!.set).toHaveBeenCalledWith(expect.objectContaining({ lastGeneratedAt: expect.any(Date) }));
     expect(updates[1]!.set).toHaveBeenCalledWith(
@@ -312,6 +451,54 @@ describe('processRunScheduledReport', () => {
     expect(mail.subject).toContain('Nightly inventory');
     expect(mail.attachments).toHaveLength(1);
     expect(mail.attachments[0]!.filename).toMatch(/device_inventory-report-.*\.csv/);
+  });
+
+  it('rejects an out-of-authority saved config before running insert, baseline, generation, update, or delivery', async () => {
+    const restricted = {
+      version: 1 as const,
+      kind: 'restricted' as const,
+      orgId: ORG_ID,
+      siteIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    };
+    const scopedReport = {
+      ...report,
+      config: {
+        filters: { siteIds: ['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'] },
+      },
+      executionScopeKind: 'restricted',
+      executionScopeSiteIds: restricted.siteIds,
+    };
+    selectMock.mockReturnValueOnce(selectChain([scopedReport]));
+    scopeState.decodedScope = restricted;
+    scopeState.intersection = restricted;
+    scopeState.liveResult = {
+      ok: true,
+      authority: {
+        ...scopeState.liveResult.authority,
+        scope: restricted,
+      },
+    };
+    reportExecutionPreflightMock.mockImplementationOnce(() => {
+      throw new Error('outside authority');
+    });
+    const failedInsert = insertChain([{ id: RUN_ID }]);
+    insertMock.mockReturnValueOnce(failedInsert);
+
+    await processRunScheduledReport({
+      type: 'run-scheduled-report',
+      reportId: REPORT_ID,
+      occurrenceKey: 202607010900,
+    });
+
+    expect(reportExecutionPreflightMock).toHaveBeenCalled();
+    expect(failedInsert.values).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      errorMessage: 'scope_config_outside_authority',
+    }));
+    expect(generateReportMock).not.toHaveBeenCalled();
+    expect(previousBaselineForMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
   });
 
   it('marks the run failed (and still stamps lastGeneratedAt) when generation throws', async () => {
@@ -342,6 +529,136 @@ describe('processRunScheduledReport', () => {
     expect(generateReportMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['inactive creator', { ok: false, reason: 'user_inactive' }],
+    ['removed membership', { ok: false, reason: 'membership_removed' }],
+    ['removed report permission', { ok: false, reason: 'permission_removed' }],
+    ['restricted-empty live scope', { ok: false, reason: 'empty_scope' }],
+  ])('fails closed for %s before generation, baseline, storage, delivery, or success audit', async (_name, liveResult) => {
+    selectMock.mockReturnValueOnce(selectChain([report]));
+    scopeState.liveResult = liveResult;
+    const failedInsert = insertChain([{ id: RUN_ID }]);
+    insertMock.mockReturnValueOnce(failedInsert);
+
+    await processRunScheduledReport({
+      type: 'run-scheduled-report',
+      reportId: REPORT_ID,
+      occurrenceKey: 202607010900,
+    });
+
+    expect(failedInsert.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reportId: REPORT_ID,
+        status: 'failed',
+        errorMessage: expect.stringMatching(/^scope_[a-z_]+$/),
+      }),
+    );
+    const failedValues = failedInsert.values.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(failedValues).not.toHaveProperty('result');
+    expect(generateReportMock).not.toHaveBeenCalled();
+    expect(previousBaselineForMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(loadReportBrandingForOrgMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['legacy_unscoped definition', { decodedScope: { version: 1, kind: 'legacy_unscoped', orgId: ORG_ID } }],
+    ['malformed partial definition scope', { decodeError: new Error('partial scope') }],
+    ['empty persisted/current intersection', { intersection: { version: 1, kind: 'restricted', orgId: ORG_ID, siteIds: [] } }],
+  ])('fails closed for %s before generation or delivery', async (_name, state) => {
+    selectMock.mockReturnValueOnce(selectChain([report]));
+    if ('decodedScope' in state) scopeState.decodedScope = state.decodedScope;
+    if ('decodeError' in state) scopeState.decodeError = state.decodeError;
+    if ('intersection' in state) scopeState.intersection = state.intersection;
+    const failedInsert = insertChain([{ id: RUN_ID }]);
+    insertMock.mockReturnValueOnce(failedInsert);
+
+    await processRunScheduledReport({
+      type: 'run-scheduled-report',
+      reportId: REPORT_ID,
+      occurrenceKey: 202607010900,
+    });
+
+    expect(failedInsert.values).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed' }),
+    );
+    expect(generateReportMock).not.toHaveBeenCalled();
+    expect(previousBaselineForMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when live authority cannot be verified', async () => {
+    selectMock.mockReturnValueOnce(selectChain([report]));
+    resolveLiveReportAuthorityMock.mockRejectedValueOnce(new Error('database unavailable'));
+    const failedInsert = insertChain([{ id: RUN_ID }]);
+    insertMock.mockReturnValueOnce(failedInsert);
+
+    await processRunScheduledReport({
+      type: 'run-scheduled-report',
+      reportId: REPORT_ID,
+      occurrenceKey: 202607010900,
+    });
+
+    expect(failedInsert.values).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', errorMessage: 'scope_unverifiable' }),
+    );
+    expect(generateReportMock).not.toHaveBeenCalled();
+    expect(previousBaselineForMock).not.toHaveBeenCalled();
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the narrowed immutable intersection for the run, baseline, and generator', async () => {
+    const restricted = {
+      version: 1 as const,
+      kind: 'restricted' as const,
+      orgId: ORG_ID,
+      siteIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    };
+    scopeState.decodedScope = {
+      ...restricted,
+      siteIds: [
+        'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      ],
+    };
+    scopeState.liveResult = {
+      ok: true,
+      authority: {
+        ...scopeState.liveResult.authority,
+        scope: restricted,
+        fingerprint: 'a'.repeat(64),
+      },
+    };
+    scopeState.intersection = restricted;
+    selectMock.mockReturnValueOnce(selectChain([{ ...report, config: {} }]));
+    const runInsert = insertChain([{ id: RUN_ID }]);
+    insertMock.mockReturnValueOnce(runInsert);
+    updateMock.mockReturnValueOnce(updateChain()).mockReturnValueOnce(updateChain());
+    generateReportMock.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await processRunScheduledReport({
+      type: 'run-scheduled-report',
+      reportId: REPORT_ID,
+      occurrenceKey: 202607010900,
+    });
+
+    expect(runInsert.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionScopeKind: 'restricted',
+        executionScopeSiteIds: restricted.siteIds,
+        executionScopeFingerprint: 'a'.repeat(64),
+      }),
+    );
+    expect(previousBaselineForMock).toHaveBeenCalledWith(REPORT_ID, 'a'.repeat(64));
+    expect(generateReportMock).toHaveBeenCalledWith(
+      'device_inventory',
+      ORG_ID,
+      {},
+      expect.objectContaining({ scope: restricted, fingerprint: 'a'.repeat(64) }),
+    );
+  });
+
   it('includes a trend line in the email when a previous baseline exists', async () => {
     const postureReport = {
       ...report,
@@ -365,7 +682,10 @@ describe('processRunScheduledReport', () => {
 
     await processRunScheduledReport({ type: 'run-scheduled-report', reportId: REPORT_ID, occurrenceKey: 202607010900 });
 
-    expect(previousBaselineForMock).toHaveBeenCalledWith(REPORT_ID);
+    expect(previousBaselineForMock).toHaveBeenCalledWith(
+      REPORT_ID,
+      'f'.repeat(64),
+    );
     // The stored snapshot carries the baseline forward so the download path
     // (and any future re-render) reflects the same trend as this email.
     expect(updates[1]!.set).toHaveBeenCalledWith(
@@ -530,6 +850,12 @@ describe('scheduled report failure handling', () => {
     schedule: 'daily',
     config: { schedule: { time: '09:00' }, emailRecipients: ['ops@example.com'] },
     lastGeneratedAt: null,
+    executionScopeVersion: 1,
+    executionScopeKind: 'unrestricted',
+    executionScopeSiteIds: null,
+    executionScopeUserId: '44444444-4444-4444-8444-444444444444',
+    executionScopeFingerprint: 'f'.repeat(64),
+    executionScopeCapturedAt: new Date('2026-07-24T12:00:00.000Z'),
   };
 
   const arrangeFailingRun = () => {
@@ -580,6 +906,7 @@ describe('scheduled report failure handling', () => {
         { id: second.id, schedule: 'daily', lastGeneratedAt: null, config: second.config, orgSettings: null, partnerTimezone: null, partnerSettings: null },
       ]),
     );
+    selectMock.mockReturnValueOnce(selectChain([{ count: 0 }]));
     // report 1: load -> throws during generation
     selectMock.mockReturnValueOnce(selectChain([report]));
     insertMock.mockReturnValueOnce(insertChain([{ id: RUN_ID }]));

--- a/apps/api/src/jobs/reportScheduleWorker.ts
+++ b/apps/api/src/jobs/reportScheduleWorker.ts
@@ -20,12 +20,27 @@
  *   other queue workers.
  */
 
-import { and, eq, ne } from 'drizzle-orm';
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  ne,
+  not,
+  or,
+  sql,
+} from 'drizzle-orm';
 import { Job, Queue, Worker } from 'bullmq';
 
 import * as dbModule from '../db';
 import { reports, reportRuns, organizations, partners } from '../db/schema';
-import { generateReport, previousBaselineFor, type ReportResult } from '../services/reportGenerationService';
+import {
+  assertReportExecutionPreflight,
+  generateReport,
+  previousBaselineFor,
+  type ReportResult,
+} from '../services/reportGenerationService';
 import { getEmailService } from '../services/email';
 import { renderLayout, renderButton, renderParagraph, escapeHtml } from '../services/emailLayout';
 import { getBullMQConnection, isRedisAvailable } from '../services/redis';
@@ -43,6 +58,15 @@ import type { PostureSummary, ExecutiveSummary } from '@breeze/shared';
 import { loadReportBrandingForOrg } from '../services/reportBranding';
 import { captureException } from '../services/sentry';
 import { attachWorkerObservability } from './workerObservability';
+import {
+  decodeSiteScope,
+  intersectSiteScopes,
+  persistedSiteScopeValues,
+  resolveLiveReportAuthority,
+  siteScopeFingerprint,
+  type PersistedSiteScopeColumns,
+  type ReportExecutionAuthority,
+} from '../services/siteScope';
 
 // Re-exported so the occurrence-math tests colocated with this worker keep
 // importing from here; the implementation lives in @breeze/shared so the web
@@ -124,6 +148,23 @@ function timezoneFor(
 }
 
 export async function findDueReports(now: Date): Promise<Array<{ id: string; occurrenceKey: number }>> {
+  const completeExecutableScope = and(
+    eq(reports.executionScopeVersion, 1),
+    inArray(reports.executionScopeKind, ['unrestricted', 'restricted']),
+    isNotNull(reports.executionScopeUserId),
+    isNotNull(reports.executionScopeFingerprint),
+    isNotNull(reports.executionScopeCapturedAt),
+    or(
+      and(
+        eq(reports.executionScopeKind, 'unrestricted'),
+        isNull(reports.executionScopeSiteIds),
+      ),
+      and(
+        eq(reports.executionScopeKind, 'restricted'),
+        isNotNull(reports.executionScopeSiteIds),
+      ),
+    ),
+  )!;
   const rows = await db
     .select({
       id: reports.id,
@@ -137,7 +178,19 @@ export async function findDueReports(now: Date): Promise<Array<{ id: string; occ
     .from(reports)
     .innerJoin(organizations, eq(reports.orgId, organizations.id))
     .leftJoin(partners, eq(organizations.partnerId, partners.id))
-    .where(ne(reports.schedule, 'one_time'));
+    .where(and(ne(reports.schedule, 'one_time'), completeExecutableScope));
+
+  const [skipped] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(reports)
+    .where(and(ne(reports.schedule, 'one_time'), not(completeExecutableScope)));
+  const skippedCount = Number(skipped?.count ?? 0);
+  if (skippedCount > 0) {
+    console.warn(
+      '[ReportScheduleWorker] Scheduled reports require scope reauthorization',
+      { count: skippedCount },
+    );
+  }
 
   const due: Array<{ id: string; occurrenceKey: number }> = [];
   for (const row of rows) {
@@ -340,9 +393,93 @@ export async function processRunScheduledReport(
 
   const config = (report.config ?? {}) as Record<string, unknown>;
 
+  const deny = async (reason: string): Promise<void> => {
+    await db
+      .insert(reportRuns)
+      .values({
+        reportId: report.id,
+        status: 'failed',
+        completedAt: new Date(),
+        errorMessage: reason,
+      })
+      .returning();
+  };
+
+  let persistedScope;
+  try {
+    persistedScope = decodeSiteScope(
+      report as unknown as PersistedSiteScopeColumns,
+      report.orgId,
+    );
+  } catch {
+    await deny('scope_unverifiable');
+    return;
+  }
+  if (persistedScope.kind === 'legacy_unscoped') {
+    await deny('scope_legacy_unscoped');
+    return;
+  }
+
+  if (!report.executionScopeUserId) {
+    await deny('scope_unverifiable');
+    return;
+  }
+
+  let liveResult;
+  try {
+    liveResult = await resolveLiveReportAuthority(
+      report.executionScopeUserId,
+      report.orgId,
+      'read',
+    );
+  } catch {
+    await deny('scope_unverifiable');
+    return;
+  }
+  if (!liveResult.ok || liveResult.authority.scope.kind === 'legacy_unscoped') {
+    await deny(`scope_${liveResult.ok ? 'unverifiable_scope' : liveResult.reason}`);
+    return;
+  }
+
+  const effectiveScope = intersectSiteScopes(
+    persistedScope,
+    liveResult.authority.scope,
+  );
+  if (!effectiveScope) {
+    await deny('scope_no_intersection');
+    return;
+  }
+  if (effectiveScope.kind === 'legacy_unscoped') {
+    await deny('scope_legacy_unscoped');
+    return;
+  }
+  if (effectiveScope.kind === 'restricted' && effectiveScope.siteIds.length === 0) {
+    await deny('scope_empty');
+    return;
+  }
+
+  const executionAuthority: ReportExecutionAuthority = {
+    scope: effectiveScope,
+    principalUserId: liveResult.authority.principalUserId,
+    capturedAt: liveResult.authority.capturedAt,
+    fingerprint: siteScopeFingerprint(effectiveScope),
+  };
+
+  try {
+    assertReportExecutionPreflight(report.orgId, config, executionAuthority);
+  } catch {
+    await deny('scope_config_outside_authority');
+    return;
+  }
+
   const [run] = await db
     .insert(reportRuns)
-    .values({ reportId: report.id, status: 'running', startedAt: new Date() })
+    .values({
+      reportId: report.id,
+      status: 'running',
+      startedAt: new Date(),
+      ...persistedSiteScopeValues(executionAuthority),
+    })
     .returning();
   if (!run) throw new Error(`Failed to create run for scheduled report ${report.id}`);
 
@@ -354,10 +491,16 @@ export async function processRunScheduledReport(
     .where(eq(reports.id, report.id));
 
   try {
-    // System context: scheduled runs execute with full org scope (no user
-    // site-permission filter — parity with a report owner generating it).
-    const result = await generateReport(report.type, report.orgId, config, undefined);
-    const previous = await previousBaselineFor(report.id);
+    const previous = await previousBaselineFor(
+      report.id,
+      executionAuthority.fingerprint,
+    );
+    const result = await generateReport(
+      report.type,
+      report.orgId,
+      config,
+      executionAuthority,
+    );
     if (previous) result.previous = previous;
     const rows = Array.isArray(result.rows) ? result.rows : [];
     const rowCount = result.rowCount ?? rows.length;

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -3,7 +3,30 @@ import { Hono } from 'hono';
 
 const selectMock = vi.hoisted(() => vi.fn());
 
+// Site scope carried by `c.get('permissions')`. `undefined` is unrestricted,
+// `[]` is restricted-to-no-sites; the two must never be conflated.
+const permissionState = vi.hoisted(() => ({
+  permissions: undefined as { allowedSiteIds?: string[] } | undefined,
+}));
+
 vi.mock('../services', () => ({}));
+
+// Structural stand-ins for the condition builders so tests can inspect the
+// predicate tree the route hands to Drizzle. Everything else (sql, avg,
+// pg-core column construction) keeps its real implementation.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    and: (...conditions: unknown[]) => ({
+      op: 'and',
+      conditions: conditions.filter(Boolean),
+    }),
+    eq: (column: unknown, value: unknown) => ({ op: 'eq', column, value }),
+    gte: (column: unknown, value: unknown) => ({ op: 'gte', column, value }),
+    inArray: (column: unknown, values: unknown) => ({ op: 'inArray', column, values }),
+  };
+});
 
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
@@ -27,6 +50,7 @@ vi.mock('../middleware/auth', () => ({
       scope: 'system',
       orgId: 'org-123'
     });
+    c.set('permissions', permissionState.permissions);
     return next();
   }),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
@@ -35,6 +59,7 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import { authMiddleware } from '../middleware/auth';
+import { devices } from '../db/schema';
 import {
   metricsMiddleware,
   metricsRoutes,
@@ -91,6 +116,86 @@ function mockRawTrendRows(selectMock: ReturnType<typeof vi.fn>, rows: unknown[])
   });
 }
 
+/** Finds a `{op, column, value}` node anywhere in a mocked condition tree. */
+function findCondition(condition: any, op: string, column: unknown): any | undefined {
+  if (!condition || typeof condition !== 'object') return undefined;
+  if (condition.op === 'and' || condition.op === 'or') {
+    for (const child of condition.conditions ?? []) {
+      const found = findCondition(child, op, column);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  return condition.op === op && condition.column === column ? condition : undefined;
+}
+
+type ScopedRow = { siteId: string | null };
+
+function rowAllowedByCondition(row: ScopedRow, condition: any): boolean {
+  const siteFilter = findCondition(condition, 'inArray', devices.siteId);
+  if (!siteFilter) return true;
+  return row.siteId !== null && (siteFilter.values as string[]).includes(row.siteId);
+}
+
+/**
+ * Mocks the three aggregate queries `GET /metrics/` issues (device status
+ * counts, active remote sessions, 30-day remote sessions) and records the
+ * WHERE condition each one received.
+ */
+function mockCurrentMetricsQueries(
+  deviceRows: Array<ScopedRow & { status: string }>,
+  activeSessionRows: ScopedRow[],
+  recentSessionRows: ScopedRow[]
+): any[] {
+  const captured: any[] = [];
+
+  selectMock
+    .mockReturnValueOnce({
+      from: () => ({
+        where: (condition: any) => {
+          captured.push(condition);
+          const visible = deviceRows.filter((row) => rowAllowedByCondition(row, condition));
+          const byStatus = new Map<string, number>();
+          for (const row of visible) {
+            byStatus.set(row.status, (byStatus.get(row.status) ?? 0) + 1);
+          }
+          return {
+            groupBy: () =>
+              Promise.resolve(
+                [...byStatus.entries()].map(([status, count]) => ({ status, count }))
+              ),
+          };
+        },
+      }),
+    })
+    .mockReturnValueOnce({
+      from: () => ({
+        innerJoin: () => ({
+          where: (condition: any) => {
+            captured.push(condition);
+            return Promise.resolve([
+              { count: activeSessionRows.filter((row) => rowAllowedByCondition(row, condition)).length },
+            ]);
+          },
+        }),
+      }),
+    })
+    .mockReturnValueOnce({
+      from: () => ({
+        innerJoin: () => ({
+          where: (condition: any) => {
+            captured.push(condition);
+            return Promise.resolve([
+              { count: recentSessionRows.filter((row) => rowAllowedByCondition(row, condition)).length },
+            ]);
+          },
+        }),
+      }),
+    });
+
+  return captured;
+}
+
 function getMetricLine(metrics: string, name: string, labels?: Record<string, string>): string | undefined {
   const labelText = labels ? `{${Object.entries(labels).map(([k, v]) => `${k}="${v}"`).join(',')}}` : '';
   return metrics
@@ -109,6 +214,7 @@ describe('metrics routes', () => {
         where: () => Promise.resolve([{ count: 0 }]),
       }),
     });
+    permissionState.permissions = undefined;
     process.env.NODE_ENV = 'test';
     process.env.METRICS_SCRAPE_TOKEN = 'test-scrape-token';
     delete process.env.METRICS_INCLUDE_ORG_ID;
@@ -446,5 +552,146 @@ describe('metrics routes', () => {
       process.env.NODE_ENV = prevNodeEnv;
       resetMetricsForTesting();
     }
+  });
+
+  describe('GET / current metrics site scope', () => {
+    const SITE_A = '22222222-2222-2222-2222-222222222222';
+    const SITE_B = '33333333-3333-3333-3333-333333333333';
+
+    const deviceRows = [
+      { status: 'online', siteId: SITE_A },
+      { status: 'offline', siteId: SITE_B },
+      { status: 'online', siteId: null },
+    ];
+    const activeSessionRows = [
+      { siteId: SITE_A },
+      { siteId: SITE_B },
+      { siteId: null },
+    ];
+    const recentSessionRows = [
+      { siteId: SITE_A },
+      { siteId: SITE_A },
+      { siteId: SITE_B },
+      { siteId: null },
+    ];
+
+    it('excludes other-site and null-site devices and remote sessions for a restricted caller', async () => {
+      permissionState.permissions = { allowedSiteIds: [SITE_A] };
+      const captured = mockCurrentMetricsQueries(deviceRows, activeSessionRows, recentSessionRows);
+
+      const res = await app.request('/', { headers: { Authorization: 'Bearer token' } });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.devices).toEqual({ total: 1, online: 1, offline: 0, pending: 0 });
+      expect(body.data.remoteSessions).toBe(1);
+      expect(body.data.sessions).toBe(2);
+      expect(body.data.business_metrics).toEqual({
+        devices_total: 1,
+        devices_active: 1,
+        devices_pending: 0,
+      });
+
+      // Every aggregate — including both remote-session counts, which must
+      // join through devices — carries the same allowed-site predicate.
+      expect(captured).toHaveLength(3);
+      for (const condition of captured) {
+        const siteFilter = findCondition(condition, 'inArray', devices.siteId);
+        expect(siteFilter).toBeDefined();
+        expect(siteFilter.values).toEqual([SITE_A]);
+      }
+    });
+
+    it('returns zero-safe metrics without issuing any select for a restricted-empty caller', async () => {
+      permissionState.permissions = { allowedSiteIds: [] };
+      mockCurrentMetricsQueries(deviceRows, activeSessionRows, recentSessionRows);
+
+      const res = await app.request('/', { headers: { Authorization: 'Bearer token' } });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        data: {
+          uptime: 0,
+          remoteSessions: 0,
+          sessions: 0,
+          devices: { total: 0, online: 0, offline: 0, pending: 0 },
+          business_metrics: {
+            devices_total: 0,
+            devices_active: 0,
+            devices_pending: 0,
+          },
+        },
+      });
+      expect(selectMock).not.toHaveBeenCalled();
+    });
+
+    it('leaves the unrestricted query chains unchanged', async () => {
+      const captured = mockCurrentMetricsQueries(deviceRows, activeSessionRows, recentSessionRows);
+
+      const res = await app.request('/', { headers: { Authorization: 'Bearer token' } });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.devices).toEqual({ total: 3, online: 2, offline: 1, pending: 0 });
+      expect(body.data.remoteSessions).toBe(3);
+      expect(body.data.sessions).toBe(4);
+
+      expect(captured).toHaveLength(3);
+      for (const condition of captured) {
+        expect(findCondition(condition, 'inArray', devices.siteId)).toBeUndefined();
+      }
+    });
+  });
+
+  describe('GET /trends site scope', () => {
+    const SITE_A = '22222222-2222-2222-2222-222222222222';
+
+    it('denies a site-restricted caller before any aggregate query', async () => {
+      permissionState.permissions = { allowedSiteIds: [SITE_A] };
+
+      const res = await app.request('/trends?range=7d', {
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({
+        error: 'Trend metrics are unavailable for site-restricted users',
+        code: 'SITE_SCOPED_TRENDS_UNAVAILABLE',
+      });
+      expect(selectMock).not.toHaveBeenCalled();
+    });
+
+    it('denies a restricted-empty caller before any aggregate query', async () => {
+      permissionState.permissions = { allowedSiteIds: [] };
+
+      const res = await app.request('/trends?range=7d', {
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({
+        error: 'Trend metrics are unavailable for site-restricted users',
+        code: 'SITE_SCOPED_TRENDS_UNAVAILABLE',
+      });
+      expect(selectMock).not.toHaveBeenCalled();
+    });
+
+    it('still serves an unrestricted caller', async () => {
+      const { db } = await import('../db');
+      const trendSelectMock = vi.mocked(db.select);
+      mockRollupTrendRows(trendSelectMock, [
+        { bucket: new Date('2026-06-18T00:00:00.000Z'), metricName: 'cpu_percent', value: 20 },
+        { bucket: new Date('2026-06-18T00:00:00.000Z'), metricName: 'ram_percent', value: 70 },
+      ]);
+
+      const res = await app.request('/trends?range=7d', {
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual([
+        { timestamp: '2026-06-18T00:00:00.000Z', cpu: 20, memory: 70 },
+      ]);
+    });
   });
 });

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -13,7 +13,7 @@ import { db } from '../db';
 import { deviceMetrics, devices, metricRollups, recoveryReadiness as recoveryReadinessTable, remoteSessions } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
-import { PERMISSIONS } from '../services/permissions';
+import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { BACKUP_LOW_READINESS_THRESHOLD } from './backup/constants';
 import {
   recordBackupCommandTimeout,
@@ -841,6 +841,23 @@ async function metricsResponse(c: any): Promise<Response> {
   });
 }
 
+/** Current-metric response shape with every aggregate zeroed. */
+function emptyDashboardMetrics() {
+  return {
+    data: {
+      uptime: 0,
+      remoteSessions: 0,
+      sessions: 0,
+      devices: { total: 0, online: 0, offline: 0, pending: 0 },
+      business_metrics: {
+        devices_total: 0,
+        devices_active: 0,
+        devices_pending: 0
+      }
+    }
+  };
+}
+
 metricsRoutes.get('/', authMiddleware, requireScope('organization', 'partner', 'system'), requireMetricsRead, async (c) => {
   const auth = c.get('auth');
   const orgCondition =
@@ -850,10 +867,23 @@ metricsRoutes.get('/', authMiddleware, requireScope('organization', 'partner', '
         ? eq(devices.orgId, auth.orgId)
         : undefined;
 
+  // `allowedSiteIds` is populated by requirePermission. `undefined` is
+  // unrestricted; `[]` is restricted to no sites and must never widen into
+  // an unscoped aggregate.
+  const perms = c.get('permissions') as UserPermissions | undefined;
+  const allowedSiteIds = perms?.allowedSiteIds;
+  if (allowedSiteIds !== undefined && allowedSiteIds.length === 0) {
+    return c.json(emptyDashboardMetrics());
+  }
+  const siteCondition =
+    allowedSiteIds === undefined ? undefined : inArray(devices.siteId, allowedSiteIds);
+
   try {
-    const deviceStatusCondition = orgCondition
-      ? and(sql`${devices.status} != 'decommissioned'`, orgCondition)
-      : sql`${devices.status} != 'decommissioned'`;
+    const deviceStatusCondition = and(
+      sql`${devices.status} != 'decommissioned'`,
+      orgCondition,
+      siteCondition
+    );
     const statusCounts = await db
       .select({
         status: devices.status,
@@ -879,9 +909,13 @@ metricsRoutes.get('/', authMiddleware, requireScope('organization', 'partner', '
     const enrolledTotal = total - pending;
     const uptime = enrolledTotal > 0 ? Math.round((online / enrolledTotal) * 1000) / 10 : 0;
 
-    const activeSessionCondition = orgCondition
-      ? and(eq(remoteSessions.status, 'active'), orgCondition)
-      : eq(remoteSessions.status, 'active');
+    // Remote-session counts join through devices, so the same site predicate
+    // applies to them.
+    const activeSessionCondition = and(
+      eq(remoteSessions.status, 'active'),
+      orgCondition,
+      siteCondition
+    );
     const [sessionRow] = await db
       .select({ count: sql<number>`count(*)` })
       .from(remoteSessions)
@@ -890,9 +924,11 @@ metricsRoutes.get('/', authMiddleware, requireScope('organization', 'partner', '
     const activeSessions = Number(sessionRow?.count ?? 0);
 
     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-    const totalSessionCondition = orgCondition
-      ? and(gte(remoteSessions.createdAt, thirtyDaysAgo), orgCondition)
-      : gte(remoteSessions.createdAt, thirtyDaysAgo);
+    const totalSessionCondition = and(
+      gte(remoteSessions.createdAt, thirtyDaysAgo),
+      orgCondition,
+      siteCondition
+    );
     const [totalSessionRow] = await db
       .select({ count: sql<number>`count(*)` })
       .from(remoteSessions)
@@ -920,6 +956,21 @@ metricsRoutes.get('/', authMiddleware, requireScope('organization', 'partner', '
 });
 
 metricsRoutes.get('/trends', authMiddleware, requireScope('organization', 'partner', 'system'), requireMetricsRead, async (c) => {
+  // Trend metrics aggregate `metric_rollups`, which is pre-aggregated per
+  // organization and carries no site axis. There is no safe site predicate to
+  // apply, so a site-restricted caller (including restricted-empty) is denied
+  // outright before any aggregate query rather than served org-wide data.
+  const trendPerms = c.get('permissions') as UserPermissions | undefined;
+  if (trendPerms?.allowedSiteIds !== undefined) {
+    return c.json(
+      {
+        error: 'Trend metrics are unavailable for site-restricted users',
+        code: 'SITE_SCOPED_TRENDS_UNAVAILABLE'
+      },
+      403
+    );
+  }
+
   const auth = c.get('auth');
   const orgCondition =
     typeof auth?.orgCondition === 'function'

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -31,6 +31,9 @@ const siteScopeState = vi.hoisted(() => {
     exactPredicate: { op: 'definitionScope', mode: 'exact' },
     compositePredicate: { op: 'definitionScope', mode: 'composite' },
     systemPredicate: { op: 'definitionScope', mode: 'system' },
+    exactRunPredicate: { op: 'runScope', mode: 'exact' },
+    compositeRunPredicate: { op: 'runScope', mode: 'composite' },
+    systemRunPredicate: { op: 'runScope', mode: 'system' },
     result: {
       ok: true,
       authority: {
@@ -56,6 +59,12 @@ vi.mock('../services/siteScope', () => ({
   reportDefinitionScopeSqlPredicate: vi.fn(() => siteScopeState.exactPredicate),
   reportDefinitionMultiOrgScopeSqlPredicate: vi.fn(() => siteScopeState.compositePredicate),
   unrestrictedReportDefinitionScopeSqlPredicate: vi.fn(() => siteScopeState.systemPredicate),
+  reportRunScopeSqlPredicate: vi.fn(() => siteScopeState.exactRunPredicate),
+  reportRunMultiOrgScopeSqlPredicate: vi.fn(() => siteScopeState.compositeRunPredicate),
+  unrestrictedReportRunScopeSqlPredicate: vi.fn(() => siteScopeState.systemRunPredicate),
+  siteScopeFingerprint: vi.fn((scope: any) =>
+    scope.kind === 'restricted' ? 'a'.repeat(64) : 'f'.repeat(64)
+  ),
   persistedSiteScopeValues: vi.fn((authority: any) => ({
     executionScopeVersion: 1,
     executionScopeKind: authority.scope.kind,
@@ -67,6 +76,9 @@ vi.mock('../services/siteScope', () => ({
     executionScopeCapturedAt: authority.capturedAt
   })),
   decodeSiteScope: vi.fn((row: any, orgId: string) => {
+    if (row.executionScopeKind === undefined) {
+      return siteScopeState.result.authority.scope;
+    }
     if (row.executionScopeVersion === null) {
       return { version: 1, kind: 'legacy_unscoped', orgId };
     }
@@ -92,6 +104,17 @@ vi.mock('../services/securityComplianceReport', () => ({
     generatedAt: 'x'
   }))
 }));
+
+vi.mock('../services/reportGenerationService', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../services/reportGenerationService')
+  >();
+  return {
+    ...actual,
+    generateReport: vi.fn(actual.generateReport),
+    previousBaselineFor: vi.fn(actual.previousBaselineFor),
+  };
+});
 
 vi.mock('drizzle-orm', () => ({
   and: (...conditions: any[]) => ({ op: 'and', conditions }),
@@ -158,7 +181,13 @@ vi.mock('../db/schema', () => ({
     errorMessage: 'reportRuns.errorMessage',
     rowCount: 'reportRuns.rowCount',
     result: 'reportRuns.result',
-    createdAt: 'reportRuns.createdAt'
+    createdAt: 'reportRuns.createdAt',
+    executionScopeVersion: 'reportRuns.executionScopeVersion',
+    executionScopeKind: 'reportRuns.executionScopeKind',
+    executionScopeSiteIds: 'reportRuns.executionScopeSiteIds',
+    executionScopeUserId: 'reportRuns.executionScopeUserId',
+    executionScopeFingerprint: 'reportRuns.executionScopeFingerprint',
+    executionScopeCapturedAt: 'reportRuns.executionScopeCapturedAt'
   },
   devices: {
     id: 'devices.id',
@@ -256,12 +285,17 @@ import { generateReport } from '../services/reportGenerationService';
 import { generateSecurityCompliancePostureReport } from '../services/securityComplianceReport';
 import { writeRouteAudit } from '../services/auditEvents';
 import {
+  decodeSiteScope,
   isSiteScopeSubset,
+  intersectSiteScopes,
   reportDefinitionMultiOrgScopeSqlPredicate,
   reportDefinitionScopeSqlPredicate,
+  reportRunMultiOrgScopeSqlPredicate,
+  reportRunScopeSqlPredicate,
   resolveRequestReportAuthority,
   resolveRequestReportAuthorityMap,
-  unrestrictedReportDefinitionScopeSqlPredicate
+  unrestrictedReportDefinitionScopeSqlPredicate,
+  unrestrictedReportRunScopeSqlPredicate
 } from '../services/siteScope';
 
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
@@ -426,6 +460,22 @@ function mockGenerateDeviceInventoryQuery(rows: Array<{ hostname: string; siteId
   } as any);
 }
 
+function scopedRunRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'run-1',
+    reportId: 'rep-1',
+    orgId: ORG_ID,
+    status: 'completed',
+    executionScopeVersion: 1,
+    executionScopeKind: 'unrestricted',
+    executionScopeSiteIds: null,
+    executionScopeUserId: '44444444-4444-4444-8444-444444444444',
+    executionScopeFingerprint: 'f'.repeat(64),
+    executionScopeCapturedAt: new Date('2026-07-25T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
 describe('GET /reports/runs/:id/download', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -440,11 +490,12 @@ describe('GET /reports/runs/:id/download', () => {
     vi.mocked(db.select)
       // getReportRunWithOrgCheck → run row (with orgId for access check)
       .mockReturnValueOnce(selectChain([
-        { id: 'run-1', reportId: 'rep-1', status: 'completed', orgId: ORG_ID }
+        scopedRunRow()
       ]))
       // download handler → result + report meta
       .mockReturnValueOnce(selectChain([
         {
+          ...scopedRunRow(),
           result: { rows: [{ hostname: 'pc-1', os: 'windows' }], rowCount: 1 },
           reportType: 'device_inventory',
           reportName: 'Inventory',
@@ -464,9 +515,9 @@ describe('GET /reports/runs/:id/download', () => {
   it('returns 409 when the run is not completed', async () => {
     const app = new Hono();
     app.route('/reports', reportRoutes);
-    vi.mocked(db.select).mockReturnValueOnce(selectChain([
-      { id: 'run-1', reportId: 'rep-1', status: 'pending', orgId: ORG_ID }
-    ]));
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([scopedRunRow({ status: 'pending' })]))
+      .mockReturnValueOnce(selectChain([scopedRunRow({ status: 'pending' })]));
     const res = await app.request('/reports/runs/run-1/download');
     expect(res.status).toBe(409);
   });
@@ -475,8 +526,8 @@ describe('GET /reports/runs/:id/download', () => {
     const app = new Hono();
     app.route('/reports', reportRoutes);
     vi.mocked(db.select)
-      .mockReturnValueOnce(selectChain([{ id: 'run-1', reportId: 'rep-1', status: 'completed', orgId: ORG_ID }]))
-      .mockReturnValueOnce(selectChain([{ result: { summary: {} }, reportType: 'executive_summary', reportName: 'Exec', reportFormat: 'csv' }]));
+      .mockReturnValueOnce(selectChain([scopedRunRow()]))
+      .mockReturnValueOnce(selectChain([{ ...scopedRunRow(), result: { summary: {} }, reportType: 'executive_summary', reportName: 'Exec', reportFormat: 'csv' }]));
     const res = await app.request('/reports/runs/run-1/download');
     expect(res.status).toBe(409);
   });
@@ -484,9 +535,7 @@ describe('GET /reports/runs/:id/download', () => {
   it('returns 404 for a run the caller cannot access', async () => {
     const app = new Hono();
     app.route('/reports', reportRoutes);
-    vi.mocked(db.select).mockReturnValueOnce(selectChain([
-      { id: 'run-1', reportId: 'rep-1', status: 'completed', orgId: 'deadbeef-0000-0000-0000-000000000000' }
-    ]));
+    vi.mocked(db.select).mockReturnValueOnce(selectChain([]));
     const res = await app.request('/reports/runs/run-1/download');
     expect(res.status).toBe(404);
   });
@@ -495,8 +544,8 @@ describe('GET /reports/runs/:id/download', () => {
     const app = new Hono();
     app.route('/reports', reportRoutes);
     vi.mocked(db.select)
-      .mockReturnValueOnce(selectChain([{ id: 'run-1', reportId: 'rep-1', status: 'completed', orgId: ORG_ID }]))
-      .mockReturnValueOnce(selectChain([{ result: { rows: [{ hostname: 'pc-1' }], rowCount: 1 }, reportType: 'device_inventory', reportName: 'Inventory', reportFormat: 'pdf' }]));
+      .mockReturnValueOnce(selectChain([scopedRunRow()]))
+      .mockReturnValueOnce(selectChain([{ ...scopedRunRow(), result: { rows: [{ hostname: 'pc-1' }], rowCount: 1 }, reportType: 'device_inventory', reportName: 'Inventory', reportFormat: 'pdf' }]));
     const res = await app.request('/reports/runs/run-1/download?format=pdf');
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('application/json');
@@ -546,9 +595,24 @@ describe('generateReport dispatch — security_compliance_posture', () => {
   });
 
   it('routes to the posture generator', async () => {
-    await generateReport('security_compliance_posture', 'org-1', {}, undefined);
+    const executionAuthority = {
+      scope: { version: 1 as const, kind: 'unrestricted' as const, orgId: 'org-1' },
+      principalUserId: 'user-1',
+      capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+      fingerprint: 'f'.repeat(64),
+    };
+    await generateReport(
+      'security_compliance_posture',
+      'org-1',
+      {},
+      executionAuthority,
+    );
 
-    expect(generateSecurityCompliancePostureReport).toHaveBeenCalledWith('org-1', {}, undefined);
+    expect(generateSecurityCompliancePostureReport).toHaveBeenCalledWith(
+      'org-1',
+      {},
+      executionAuthority,
+    );
   });
 });
 
@@ -1657,38 +1721,19 @@ describe('reports routes', () => {
 
   it('should return run details with export URL', async () => {
     vi.mocked(db.select)
-      .mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          innerJoin: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([{
-                id: 'run-1',
-                reportId: 'report-1',
-                status: 'completed',
-                startedAt: new Date('2024-01-01T00:00:00Z'),
-                completedAt: new Date('2024-01-01T00:01:00Z'),
-                outputUrl: '/api/reports/runs/run-1/download',
-                errorMessage: null,
-                rowCount: 12,
-                createdAt: new Date('2024-01-01T00:00:00Z'),
-                orgId: ORG_ID
-              }])
-            })
-          })
-        })
-      } as any)
-      .mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([{
-              id: 'report-1',
-              name: 'Device Inventory',
-              type: 'device_inventory',
-              format: 'csv'
-            }])
-          })
-        })
-      } as any);
+      .mockReturnValueOnce(selectChain([scopedRunRow({ reportId: 'report-1' })]))
+      .mockReturnValueOnce(selectChain([scopedRunRow({
+        reportId: 'report-1',
+        startedAt: new Date('2024-01-01T00:00:00Z'),
+        completedAt: new Date('2024-01-01T00:01:00Z'),
+        outputUrl: '/api/reports/runs/run-1/download',
+        errorMessage: null,
+        rowCount: 12,
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        reportName: 'Device Inventory',
+        reportType: 'device_inventory',
+        reportFormat: 'csv',
+      })]));
 
     const res = await app.request('/reports/runs/run-1', {
       method: 'GET',
@@ -1833,6 +1878,15 @@ describe('reports routes', () => {
 
     it('returns 403 when a site-restricted caller filters to an out-of-scope siteId', async () => {
       permissionState.permissions = { allowedSiteIds: [SITE_ALLOWED] };
+      siteScopeState.result = {
+        ok: true,
+        authority: {
+          scope: { version: 1, kind: 'restricted', orgId: ORG_ID, siteIds: [SITE_ALLOWED] },
+          principalUserId: 'user-123',
+          capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+          fingerprint: 'a'.repeat(64),
+        },
+      };
       mockGenerateDeviceInventoryQuery(rows);
 
       const res = await app.request('/reports/generate', {
@@ -1850,6 +1904,15 @@ describe('reports routes', () => {
 
     it('narrows generated device inventory rows to caller allowed sites', async () => {
       permissionState.permissions = { allowedSiteIds: [SITE_ALLOWED] };
+      siteScopeState.result = {
+        ok: true,
+        authority: {
+          scope: { version: 1, kind: 'restricted', orgId: ORG_ID, siteIds: [SITE_ALLOWED] },
+          principalUserId: 'user-123',
+          capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+          fingerprint: 'a'.repeat(64),
+        },
+      };
       mockGenerateDeviceInventoryQuery(rows);
 
       const res = await app.request('/reports/generate', {
@@ -1879,5 +1942,716 @@ describe('reports routes', () => {
       expect(body.data.rows).toHaveLength(2);
       expect(body.data.rowCount).toBe(2);
     });
+  });
+});
+
+describe('report run immutable scope enforcement', () => {
+  const USER_ID = '44444444-4444-4444-8444-444444444444';
+  const ORG_A = ORG_ID;
+  const ORG_B = '66666666-6666-4666-8666-666666666666';
+  const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const REPORT_ID = '77777777-7777-4777-8777-777777777777';
+  const RUN_ID = '88888888-8888-4888-8888-888888888888';
+  const MISSING_RUN_ID = '99999999-9999-4999-8999-999999999999';
+  const CAPTURED_AT = new Date('2026-07-25T12:00:00.000Z');
+
+  function authority(
+    kind: 'unrestricted' | 'restricted',
+    siteIds: string[] = [],
+    orgId = ORG_A,
+  ) {
+    return {
+      ok: true,
+      authority: {
+        scope: kind === 'restricted'
+          ? { version: 1, kind, orgId, siteIds }
+          : { version: 1, kind, orgId },
+        principalUserId: USER_ID,
+        capturedAt: CAPTURED_AT,
+        fingerprint: kind === 'restricted'
+          ? 'a'.repeat(64)
+          : 'f'.repeat(64),
+      },
+    };
+  }
+
+  function definitionMetadata(overrides: Record<string, unknown> = {}) {
+    return {
+      id: REPORT_ID,
+      orgId: ORG_A,
+      executionScopeVersion: 1,
+      executionScopeKind: 'restricted',
+      executionScopeSiteIds: [SITE_A],
+      executionScopeUserId: USER_ID,
+      executionScopeFingerprint: 'a'.repeat(64),
+      executionScopeCapturedAt: CAPTURED_AT,
+      ...overrides,
+    };
+  }
+
+  function definition(overrides: Record<string, unknown> = {}) {
+    return {
+      ...definitionMetadata(),
+      name: 'Scoped Inventory',
+      type: 'device_inventory',
+      config: {},
+      schedule: 'one_time',
+      format: 'csv',
+      ...overrides,
+    };
+  }
+
+  function runMetadata(overrides: Record<string, unknown> = {}) {
+    return {
+      id: RUN_ID,
+      reportId: REPORT_ID,
+      orgId: ORG_A,
+      executionScopeVersion: 1,
+      executionScopeKind: 'restricted',
+      executionScopeSiteIds: [SITE_A],
+      executionScopeUserId: USER_ID,
+      executionScopeFingerprint: 'a'.repeat(64),
+      executionScopeCapturedAt: CAPTURED_AT,
+      ...overrides,
+    };
+  }
+
+  function conditionContainsIdentity(condition: any, target: unknown): boolean {
+    if (condition === target) return true;
+    if (!condition || !Array.isArray(condition.conditions)) return false;
+    return condition.conditions.some((child: unknown) =>
+      conditionContainsIdentity(child, target)
+    );
+  }
+
+  function conditionValues(condition: any, column: string): unknown[] {
+    if (!condition) return [];
+    if (Array.isArray(condition.conditions)) {
+      return condition.conditions.flatMap((child: unknown) =>
+        conditionValues(child, column)
+      );
+    }
+    if (condition.column !== column) return [];
+    return condition.values ?? [condition.value];
+  }
+
+  function capturedSelectChain(rows: unknown[], captured: unknown[]) {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      where: vi.fn((condition: unknown) => {
+        captured.push(condition);
+        return chain;
+      }),
+      orderBy: vi.fn(() => chain),
+      groupBy: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      offset: vi.fn(() => chain),
+      for: vi.fn(() => chain),
+      then: (resolve: (value: unknown[]) => unknown, reject: (reason: unknown) => unknown) =>
+        Promise.resolve(rows).then(resolve, reject),
+    };
+    return chain;
+  }
+
+  function conditionalRecentRunsChain(
+    authorizedRows: unknown[],
+    hiddenRows: unknown[],
+    capturedConditions: unknown[],
+    capturedProjections: unknown[],
+  ) {
+    let condition: unknown;
+    let limit = Number.POSITIVE_INFINITY;
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn((value: unknown) => {
+        condition = value;
+        capturedConditions.push(value);
+        return chain;
+      }),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn((value: number) => {
+        limit = value;
+        return chain;
+      }),
+      then: (resolve: (value: unknown[]) => unknown, reject: (reason: unknown) => unknown) => {
+        capturedProjections.push(condition);
+        const rows = conditionContainsIdentity(
+          condition,
+          siteScopeState.exactRunPredicate,
+        )
+          ? authorizedRows
+          : hiddenRows;
+        return Promise.resolve(rows.slice(0, limit)).then(resolve, reject);
+      },
+    };
+    return chain;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.auth = authState.makeDefault();
+    permissionState.deny = false;
+    permissionState.permissions = undefined;
+    siteScopeState.result = authority('unrestricted') as any;
+    siteScopeState.mapResult = new Map();
+    vi.mocked(isSiteScopeSubset).mockReturnValue(true);
+    vi.mocked(intersectSiteScopes).mockImplementation(
+      (persisted: any) => persisted,
+    );
+    vi.mocked(generateReport).mockResolvedValue({
+      rows: [{ hostname: 'site-a-device' }],
+      rowCount: 1,
+    });
+  });
+
+  it('intersects definition/current scope, persists one immutable run snapshot, and passes that exact authority into generation', async () => {
+    const app = new Hono();
+    app.route('/reports', reportRoutes);
+    siteScopeState.result = authority('restricted', [SITE_A]) as any;
+    const narrowedScope = {
+      version: 1 as const,
+      kind: 'restricted' as const,
+      orgId: ORG_A,
+      siteIds: [SITE_A],
+    };
+    vi.mocked(intersectSiteScopes).mockReturnValue(narrowedScope);
+    const insertedValues: any[] = [];
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definitionMetadata()]))
+      .mockReturnValueOnce(selectChain([definition()]));
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn((values: unknown) => {
+        insertedValues.push(values);
+        return {
+          returning: vi.fn().mockResolvedValue([{
+            id: RUN_ID,
+            reportId: REPORT_ID,
+            status: 'pending',
+          }]),
+        };
+      }),
+    } as any);
+
+    const res = await app.request(`/reports/${REPORT_ID}/generate`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(200);
+    expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG_A,
+      'read',
+    );
+    expect(intersectSiteScopes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        version: 1,
+        kind: 'restricted',
+        orgId: ORG_A,
+        siteIds: [SITE_A],
+      }),
+      expect.objectContaining(narrowedScope),
+    );
+    expect(insertedValues).toEqual([
+      expect.objectContaining({
+        reportId: REPORT_ID,
+        status: 'pending',
+        executionScopeVersion: 1,
+        executionScopeKind: 'restricted',
+        executionScopeSiteIds: [SITE_A],
+        executionScopeUserId: USER_ID,
+        executionScopeFingerprint: 'a'.repeat(64),
+        executionScopeCapturedAt: CAPTURED_AT,
+      }),
+    ]);
+    expect(generateReport).toHaveBeenCalledWith(
+      'device_inventory',
+      ORG_A,
+      {},
+      expect.objectContaining({
+        scope: narrowedScope,
+        principalUserId: USER_ID,
+        capturedAt: CAPTURED_AT,
+        fingerprint: 'a'.repeat(64),
+      }),
+    );
+  });
+
+  it('rejects restricted-empty live authority before insert, generation, baseline, mutation, or success audit', async () => {
+    const app = new Hono();
+    app.route('/reports', reportRoutes);
+    siteScopeState.result = { ok: false, reason: 'empty_scope' } as any;
+    vi.mocked(db.select).mockReturnValueOnce(
+      selectChain([definitionMetadata()]),
+    );
+
+    const res = await app.request(`/reports/${REPORT_ID}/generate`, {
+      method: 'POST',
+    });
+
+    expect([403, 404]).toContain(res.status);
+    expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+      expect.anything(),
+      ORG_A,
+      'read',
+    );
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(generateReport).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('rejects a saved config outside the immutable authority before insert, audit, or mutation', async () => {
+    const app = new Hono();
+    app.route('/reports', reportRoutes);
+    siteScopeState.result = authority('restricted', [SITE_A]) as any;
+    const narrowedScope = {
+      version: 1 as const,
+      kind: 'restricted' as const,
+      orgId: ORG_A,
+      siteIds: [SITE_A],
+    };
+    vi.mocked(intersectSiteScopes).mockReturnValue(narrowedScope);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definitionMetadata()]))
+      .mockReturnValueOnce(selectChain([definition({
+        config: { filters: { siteIds: [SITE_B] } },
+      })]));
+
+    const res = await app.request(`/reports/${REPORT_ID}/generate`, {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(generateReport).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      mode: 'organization exact scope',
+      configure: () => {
+        authState.auth = authState.makeDefault();
+        siteScopeState.result = authority('restricted', [SITE_A]) as any;
+      },
+      predicate: () => siteScopeState.exactRunPredicate,
+      resolver: () => resolveRequestReportAuthority,
+    },
+    {
+      mode: 'partner per-organization composite scope',
+      configure: () => {
+        authState.auth = {
+          ...authState.makeDefault(),
+          scope: 'partner',
+          partnerId: 'partner-a',
+          orgId: null,
+          accessibleOrgIds: [ORG_A, ORG_B],
+          canAccessOrg: (orgId: string) =>
+            orgId === ORG_A || orgId === ORG_B,
+        };
+        siteScopeState.mapResult = new Map([
+          [ORG_A, authority('unrestricted', [], ORG_A)],
+          [ORG_B, authority('restricted', [SITE_B], ORG_B)],
+        ]) as any;
+      },
+      predicate: () => siteScopeState.compositeRunPredicate,
+      resolver: () => resolveRequestReportAuthorityMap,
+    },
+    {
+      mode: 'system unrestricted provenance scope',
+      configure: () => {
+        authState.auth = {
+          ...authState.makeDefault(),
+          scope: 'system',
+          partnerId: null,
+          orgId: null,
+          accessibleOrgIds: [],
+          canAccessOrg: () => true,
+        };
+      },
+      predicate: () => siteScopeState.systemRunPredicate,
+      resolver: () => unrestrictedReportRunScopeSqlPredicate,
+    },
+  ])(
+    'uses one $mode predicate for count/page and exact 2/2/1 pagination',
+    async ({ configure, predicate, resolver }) => {
+      configure();
+      const visiblePages = [
+        [{ id: 'visible-1' }, { id: 'visible-2' }],
+        [{ id: 'visible-3' }, { id: 'visible-4' }],
+        [{ id: 'visible-5' }],
+      ];
+      const capturedConditions: unknown[] = [];
+
+      for (let index = 0; index < visiblePages.length; index += 1) {
+        vi.mocked(db.select)
+          .mockReturnValueOnce(
+            capturedSelectChain([{ count: 5 }], capturedConditions),
+          )
+          .mockReturnValueOnce(
+            capturedSelectChain(visiblePages[index]!, capturedConditions),
+          );
+        const app = new Hono();
+        app.route('/reports', reportRoutes);
+        const res = await app.request(
+          `/reports/runs?page=${index + 1}&limit=2`,
+        );
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.data).toEqual(visiblePages[index]);
+        expect(body.pagination).toEqual({
+          page: index + 1,
+          limit: 2,
+          total: 5,
+        });
+      }
+
+      expect(resolver()).toHaveBeenCalled();
+      expect(capturedConditions).toHaveLength(6);
+      for (const condition of capturedConditions) {
+        expect(
+          conditionContainsIdentity(condition, predicate()),
+        ).toBe(true);
+      }
+      expect(capturedConditions[0]).toBe(capturedConditions[1]);
+      expect(capturedConditions[2]).toBe(capturedConditions[3]);
+      expect(capturedConditions[4]).toBe(capturedConditions[5]);
+    },
+  );
+
+  it('omits denied and restricted-empty partner organizations from the run composite', async () => {
+    const app = new Hono();
+    app.route('/reports', reportRoutes);
+    authState.auth = {
+      ...authState.makeDefault(),
+      scope: 'partner',
+      partnerId: 'partner-a',
+      orgId: null,
+      accessibleOrgIds: [ORG_A, ORG_B],
+      canAccessOrg: (orgId: string) =>
+        orgId === ORG_A || orgId === ORG_B,
+    };
+    siteScopeState.mapResult = new Map([
+      [ORG_A, { ok: false, reason: 'permission_removed' }],
+      [ORG_B, { ok: false, reason: 'empty_scope' }],
+    ]) as any;
+    const capturedConditions: unknown[] = [];
+    vi.mocked(db.select)
+      .mockReturnValueOnce(
+        capturedSelectChain([{ count: 0 }], capturedConditions),
+      )
+      .mockReturnValueOnce(capturedSelectChain([], capturedConditions));
+
+    const res = await app.request('/reports/runs?limit=2');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      data: [],
+      pagination: { total: 0 },
+    });
+    expect(reportRunMultiOrgScopeSqlPredicate).toHaveBeenCalledWith(
+      'reports.orgId',
+      expect.anything(),
+      [],
+    );
+  });
+
+  it('filters recentRuns in SQL before limiting and never materializes hidden result payloads', async () => {
+    const app = new Hono();
+    app.route('/reports', reportRoutes);
+    siteScopeState.result = authority('restricted', [SITE_A]) as any;
+    const authorizedRows = [1, 2, 3, 4, 5].map((value) => ({
+      id: `site-a-${value}`,
+      reportId: REPORT_ID,
+      status: 'completed',
+      rowCount: value,
+      createdAt: new Date(`2026-07-2${value}T00:00:00.000Z`),
+    }));
+    const hiddenRows = [
+      {
+        id: 'site-b-hidden',
+        reportId: REPORT_ID,
+        status: 'completed',
+        result: { rows: [{ secret: 'site-b' }] },
+        createdAt: new Date('2026-07-31T00:00:00.000Z'),
+      },
+      ...authorizedRows,
+    ];
+    const capturedConditions: unknown[] = [];
+    const observedConditions: unknown[] = [];
+    const projections: unknown[] = [];
+    vi.mocked(db.select).mockImplementation((projection?: unknown) => {
+      projections.push(projection);
+      if (projections.length === 1) {
+        return selectChain([definitionMetadata()]) as any;
+      }
+      if (projections.length === 2) {
+        return selectChain([definition()]) as any;
+      }
+      return conditionalRecentRunsChain(
+        authorizedRows,
+        hiddenRows,
+        capturedConditions,
+        observedConditions,
+      ) as any;
+    });
+
+    const res = await app.request(`/reports/${REPORT_ID}`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.recentRuns).toHaveLength(5);
+    expect(body.recentRuns.map((run: any) => run.id)).toEqual(
+      authorizedRows.map((run) => run.id),
+    );
+    expect(JSON.stringify(body.recentRuns)).not.toContain('site-b');
+    expect(reportRunScopeSqlPredicate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        kind: 'restricted',
+        siteIds: [SITE_A],
+      }),
+    );
+    expect(
+      conditionContainsIdentity(
+        capturedConditions[0],
+        siteScopeState.exactRunPredicate,
+      ),
+    ).toBe(true);
+    expect(projections[2]).toBeDefined();
+    expect(Object.values(projections[2] as Record<string, unknown>))
+      .not.toContain('reportRuns.result');
+  });
+
+  it.each([
+    {
+      route: (id: string) => `/reports/runs/${id}`,
+      action: 'read',
+    },
+    {
+      route: (id: string) => `/reports/runs/${id}/download?format=json`,
+      action: 'export',
+    },
+  ])(
+    'uses metadata-only exact-row rebinding and a predicate-guarded payload lookup for $action',
+    async ({ route, action }) => {
+      const app = new Hono();
+      app.route('/reports', reportRoutes);
+      siteScopeState.result = authority('restricted', [SITE_A]) as any;
+      const projections: unknown[] = [];
+      const conditions: unknown[] = [];
+      vi.mocked(db.select).mockImplementation((projection?: unknown) => {
+        projections.push(projection);
+        if (projections.length === 1) {
+          return capturedSelectChain([{
+            ...runMetadata(),
+            status: 'completed',
+            createdAt: CAPTURED_AT,
+          }], conditions) as any;
+        }
+        return capturedSelectChain([{
+          ...runMetadata(),
+          status: 'completed',
+          createdAt: CAPTURED_AT,
+          reportName: 'Scoped Inventory',
+          reportType: 'device_inventory',
+          reportFormat: 'json',
+          result: { rows: [{ hostname: 'site-a-device' }] },
+        }], conditions) as any;
+      });
+
+      const res = await app.request(route(RUN_ID));
+
+      expect(res.status).toBe(200);
+      expect(Object.values(projections[0] as Record<string, unknown>))
+        .not.toContain('reportRuns.result');
+      expect(Object.keys(projections[0] as Record<string, unknown>).sort())
+        .toEqual([
+          'executionScopeCapturedAt',
+          'executionScopeFingerprint',
+          'executionScopeKind',
+          'executionScopeSiteIds',
+          'executionScopeUserId',
+          'executionScopeVersion',
+          'id',
+          'orgId',
+          'reportId',
+        ]);
+      expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+        expect.anything(),
+        ORG_A,
+        action,
+      );
+      expect(decodeSiteScope).toHaveBeenCalledWith(
+        expect.objectContaining({ id: RUN_ID }),
+        ORG_A,
+      );
+      expect(isSiteScopeSubset).toHaveBeenCalled();
+      expect(reportRunScopeSqlPredicate).toHaveBeenCalled();
+      expect(
+        conditionContainsIdentity(
+          conditions[1],
+          siteScopeState.exactRunPredicate,
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    {
+      mode: 'partner',
+      configure: () => {
+        authState.auth = {
+          ...authState.makeDefault(),
+          scope: 'partner',
+          partnerId: 'partner-a',
+          orgId: null,
+          accessibleOrgIds: [ORG_A, ORG_B],
+          canAccessOrg: (orgId: string) =>
+            orgId === ORG_A || orgId === ORG_B,
+        };
+      },
+    },
+    {
+      mode: 'system',
+      configure: () => {
+        authState.auth = {
+          ...authState.makeDefault(),
+          scope: 'system',
+          partnerId: null,
+          orgId: null,
+          accessibleOrgIds: [],
+          canAccessOrg: () => true,
+        };
+      },
+    },
+  ])(
+    '$mode known-ID access rebinds to the target organization instead of reusing list scope',
+    async ({ configure }) => {
+      configure();
+      const app = new Hono();
+      app.route('/reports', reportRoutes);
+      siteScopeState.result = authority(
+        'restricted',
+        [SITE_B],
+        ORG_B,
+      ) as any;
+      vi.mocked(db.select)
+        .mockReturnValueOnce(capturedSelectChain([{
+          ...runMetadata({ orgId: ORG_B, executionScopeSiteIds: [SITE_B] }),
+          status: 'completed',
+        }], []))
+        .mockReturnValueOnce(capturedSelectChain([{
+          ...runMetadata({ orgId: ORG_B, executionScopeSiteIds: [SITE_B] }),
+          status: 'completed',
+          reportName: 'B1 inventory',
+          reportType: 'device_inventory',
+          reportFormat: 'json',
+        }], []));
+
+      const res = await app.request(`/reports/runs/${RUN_ID}`);
+
+      expect(res.status).toBe(200);
+      expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+        expect.anything(),
+        ORG_B,
+        'read',
+      );
+      expect(resolveRequestReportAuthorityMap).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      route: (id: string) => `/reports/runs/${id}`,
+      action: 'read',
+    },
+    {
+      route: (id: string) => `/reports/runs/${id}/download?format=json`,
+      action: 'export',
+    },
+  ])(
+    'makes a known Site B $action response identical to a nonexistent run and selects no hidden payload',
+    async ({ route }) => {
+      const app = new Hono();
+      app.route('/reports', reportRoutes);
+      siteScopeState.result = authority('restricted', [SITE_A]) as any;
+      vi.mocked(isSiteScopeSubset).mockReturnValue(false);
+      const projections: unknown[] = [];
+      vi.mocked(db.select).mockImplementation((projection?: unknown) => {
+        projections.push(projection);
+        if (projections.length === 1) {
+          return selectChain([{
+            ...runMetadata({
+              executionScopeSiteIds: [SITE_B],
+              executionScopeFingerprint: 'b'.repeat(64),
+            }),
+            status: 'completed',
+          }]) as any;
+        }
+        return selectChain([{
+          ...runMetadata({
+            executionScopeSiteIds: [SITE_B],
+            executionScopeFingerprint: 'b'.repeat(64),
+          }),
+          status: 'completed',
+          result: { rows: [{ secret: 'site-b' }] },
+          reportType: 'device_inventory',
+          reportName: 'Hidden',
+          reportFormat: 'json',
+        }]) as any;
+      });
+
+      const hidden = await app.request(route(RUN_ID));
+      const hiddenBody = await hidden.text();
+
+      projections.length = 0;
+      vi.mocked(db.select).mockReset();
+      vi.mocked(db.select).mockReturnValueOnce(selectChain([]));
+      const missing = await app.request(route(MISSING_RUN_ID));
+      const missingBody = await missing.text();
+
+      expect(hidden.status).toBe(missing.status);
+      expect(hiddenBody).toBe(missingBody);
+      expect(hidden.status).toBe(404);
+      expect(projections).toHaveLength(0);
+    },
+  );
+
+  it('binds report/status filters alongside the same immutable run predicate', async () => {
+    const app = new Hono();
+    app.route('/reports', reportRoutes);
+    const capturedConditions: unknown[] = [];
+    vi.mocked(db.select)
+      .mockReturnValueOnce(
+        capturedSelectChain([{ count: 1 }], capturedConditions),
+      )
+      .mockReturnValueOnce(
+        capturedSelectChain([{ id: RUN_ID }], capturedConditions),
+      );
+
+    const res = await app.request(
+      `/reports/runs?reportId=${REPORT_ID}&status=completed`,
+    );
+
+    expect(res.status).toBe(200);
+    for (const condition of capturedConditions) {
+      expect(
+        conditionContainsIdentity(
+          condition,
+          siteScopeState.exactRunPredicate,
+        ),
+      ).toBe(true);
+      expect(conditionValues(condition, 'reportRuns.reportId'))
+        .toContain(REPORT_ID);
+      expect(conditionValues(condition, 'reportRuns.status'))
+        .toContain('completed');
+    }
   });
 });

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -22,7 +22,67 @@ const authState = vi.hoisted(() => {
   return { makeDefault, auth: makeDefault() as ReturnType<typeof makeDefault> };
 });
 
+const siteScopeState = vi.hoisted(() => {
+  const orgId = '11111111-1111-1111-1111-111111111111';
+  const userId = '44444444-4444-4444-8444-444444444444';
+  const capturedAt = new Date('2026-07-25T12:00:00.000Z');
+  const unrestrictedScope = { version: 1, kind: 'unrestricted', orgId } as const;
+  return {
+    exactPredicate: { op: 'definitionScope', mode: 'exact' },
+    compositePredicate: { op: 'definitionScope', mode: 'composite' },
+    systemPredicate: { op: 'definitionScope', mode: 'system' },
+    result: {
+      ok: true,
+      authority: {
+        scope: unrestrictedScope,
+        principalUserId: userId,
+        capturedAt,
+        fingerprint: 'f'.repeat(64)
+      }
+    } as any,
+    mapResult: new Map() as Map<string, any>
+  };
+});
+
 vi.mock('../services', () => ({}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeRouteAudit: vi.fn()
+}));
+
+vi.mock('../services/siteScope', () => ({
+  resolveRequestReportAuthority: vi.fn(async () => siteScopeState.result),
+  resolveRequestReportAuthorityMap: vi.fn(async () => siteScopeState.mapResult),
+  reportDefinitionScopeSqlPredicate: vi.fn(() => siteScopeState.exactPredicate),
+  reportDefinitionMultiOrgScopeSqlPredicate: vi.fn(() => siteScopeState.compositePredicate),
+  unrestrictedReportDefinitionScopeSqlPredicate: vi.fn(() => siteScopeState.systemPredicate),
+  persistedSiteScopeValues: vi.fn((authority: any) => ({
+    executionScopeVersion: 1,
+    executionScopeKind: authority.scope.kind,
+    executionScopeSiteIds: authority.scope.kind === 'restricted'
+      ? [...new Set(authority.scope.siteIds)].sort()
+      : null,
+    executionScopeUserId: authority.principalUserId,
+    executionScopeFingerprint: authority.fingerprint,
+    executionScopeCapturedAt: authority.capturedAt
+  })),
+  decodeSiteScope: vi.fn((row: any, orgId: string) => {
+    if (row.executionScopeVersion === null) {
+      return { version: 1, kind: 'legacy_unscoped', orgId };
+    }
+    if (row.executionScopeKind === 'restricted') {
+      return {
+        version: 1,
+        kind: 'restricted',
+        orgId,
+        siteIds: row.executionScopeSiteIds ?? []
+      };
+    }
+    return { version: 1, kind: row.executionScopeKind, orgId };
+  }),
+  isSiteScopeSubset: vi.fn(() => true),
+  intersectSiteScopes: vi.fn((persisted: any) => persisted)
+}));
 
 vi.mock('../services/securityComplianceReport', () => ({
   generateSecurityCompliancePostureReport: vi.fn(async () => ({
@@ -64,7 +124,8 @@ vi.mock('../db', () => ({
     })),
     delete: vi.fn(() => ({
       where: vi.fn(() => Promise.resolve())
-    }))
+    })),
+    transaction: vi.fn()
   },
   runOutsideDbContext: vi.fn((fn: () => any) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => any) => fn())
@@ -79,7 +140,13 @@ vi.mock('../db/schema', () => ({
     schedule: 'reports.schedule',
     format: 'reports.format',
     updatedAt: 'reports.updatedAt',
-    lastGeneratedAt: 'reports.lastGeneratedAt'
+    lastGeneratedAt: 'reports.lastGeneratedAt',
+    executionScopeVersion: 'reports.executionScopeVersion',
+    executionScopeKind: 'reports.executionScopeKind',
+    executionScopeSiteIds: 'reports.executionScopeSiteIds',
+    executionScopeUserId: 'reports.executionScopeUserId',
+    executionScopeFingerprint: 'reports.executionScopeFingerprint',
+    executionScopeCapturedAt: 'reports.executionScopeCapturedAt'
   },
   reportRuns: {
     id: 'reportRuns.id',
@@ -187,6 +254,15 @@ import { db } from '../db';
 import { reportRoutes } from './reports';
 import { generateReport } from '../services/reportGenerationService';
 import { generateSecurityCompliancePostureReport } from '../services/securityComplianceReport';
+import { writeRouteAudit } from '../services/auditEvents';
+import {
+  isSiteScopeSubset,
+  reportDefinitionMultiOrgScopeSqlPredicate,
+  reportDefinitionScopeSqlPredicate,
+  resolveRequestReportAuthority,
+  resolveRequestReportAuthorityMap,
+  unrestrictedReportDefinitionScopeSqlPredicate
+} from '../services/siteScope';
 
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const SITE_ALLOWED = '22222222-2222-2222-2222-222222222222';
@@ -197,7 +273,7 @@ const DEVICE_DENIED = '55555555-5555-5555-5555-555555555555';
 /** A thenable that resolves to `rows` and supports any drizzle chain method. */
 function selectChain(rows: any) {
   const p: any = Promise.resolve(rows);
-  for (const m of ['from', 'where', 'innerJoin', 'leftJoin', 'orderBy', 'groupBy', 'limit', 'offset']) {
+  for (const m of ['from', 'where', 'innerJoin', 'leftJoin', 'orderBy', 'groupBy', 'limit', 'offset', 'for']) {
     p[m] = () => p;
   }
   return p;
@@ -476,6 +552,756 @@ describe('generateReport dispatch — security_compliance_posture', () => {
   });
 });
 
+describe('report definition scope enforcement', () => {
+  const USER_ID = '44444444-4444-4444-8444-444444444444';
+  const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+  const REPORT_ID = '77777777-7777-4777-8777-777777777777';
+  const MISSING_ID = '88888888-8888-4888-8888-888888888888';
+  const CAPTURED_AT = new Date('2026-07-25T12:00:00.000Z');
+
+  function authority(kind: 'unrestricted' | 'restricted', siteIds?: string[]) {
+    return {
+      ok: true,
+      authority: {
+        scope: kind === 'restricted'
+          ? { version: 1, kind, orgId: ORG_ID, siteIds: siteIds ?? [] }
+          : { version: 1, kind, orgId: ORG_ID },
+        principalUserId: USER_ID,
+        capturedAt: CAPTURED_AT,
+        fingerprint: kind === 'restricted' ? 'a'.repeat(64) : 'f'.repeat(64)
+      }
+    };
+  }
+
+  function definitionMetadata(overrides: Record<string, unknown> = {}) {
+    return {
+      id: REPORT_ID,
+      orgId: ORG_ID,
+      executionScopeVersion: 1,
+      executionScopeKind: 'unrestricted',
+      executionScopeSiteIds: null,
+      executionScopeUserId: USER_ID,
+      executionScopeFingerprint: 'f'.repeat(64),
+      executionScopeCapturedAt: CAPTURED_AT,
+      ...overrides
+    };
+  }
+
+  function conditionContainsIdentity(condition: any, target: unknown): boolean {
+    if (condition === target) return true;
+    if (!condition || !Array.isArray(condition.conditions)) return false;
+    return condition.conditions.some((child: unknown) =>
+      conditionContainsIdentity(child, target)
+    );
+  }
+
+  function mockDefinitionPage(
+    rows: unknown[],
+    total: number,
+    capturedConditions: unknown[]
+  ) {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            capturedConditions.push(condition);
+            return Promise.resolve([{ count: total }]);
+          })
+        })
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            capturedConditions.push(condition);
+            return {
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  offset: vi.fn().mockResolvedValue(rows)
+                })
+              })
+            };
+          })
+        })
+      } as any);
+  }
+
+  function mockPredicateFilteredDefinitionPage(
+    sourceRows: Array<{ id: string }>,
+    visibleIds: readonly string[],
+    expectedPredicate: unknown,
+    capturedConditions: unknown[],
+  ) {
+    const visibleIdSet = new Set(visibleIds);
+    const rowsFor = (condition: unknown) =>
+      conditionContainsIdentity(condition, expectedPredicate)
+        ? sourceRows.filter((row) => visibleIdSet.has(row.id))
+        : sourceRows;
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            capturedConditions.push(condition);
+            return Promise.resolve([{ count: rowsFor(condition).length }]);
+          })
+        })
+      } as any)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            capturedConditions.push(condition);
+            return {
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn((limit: number) => ({
+                  offset: vi.fn((offset: number) =>
+                    Promise.resolve(rowsFor(condition).slice(offset, offset + limit))
+                  )
+                }))
+              })
+            };
+          })
+        })
+      } as any);
+  }
+
+  function app() {
+    return new Hono().route('/reports', reportRoutes);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permissionState.deny = false;
+    permissionState.last = null;
+    permissionState.permissions = undefined;
+    authState.auth = authState.makeDefault();
+    siteScopeState.result = authority('unrestricted');
+    siteScopeState.mapResult = new Map();
+    vi.mocked(db.select).mockReset();
+    vi.mocked(db.transaction).mockImplementation(async (callback: any) =>
+      callback(db as any)
+    );
+  });
+
+  it.each([
+    {
+      name: 'unrestricted',
+      resolved: authority('unrestricted'),
+      expectedKind: 'unrestricted',
+      expectedSiteIds: null
+    },
+    {
+      name: 'restricted with normalized sites',
+      resolved: authority('restricted', [SITE_B, SITE_A, SITE_B]),
+      expectedKind: 'restricted',
+      expectedSiteIds: [SITE_A, SITE_B]
+    }
+  ])('snapshots $name authority on create', async ({
+    resolved,
+    expectedKind,
+    expectedSiteIds
+  }) => {
+    siteScopeState.result = resolved;
+    let inserted: any;
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn((values) => {
+        inserted = values;
+        return {
+          returning: vi.fn().mockResolvedValue([{
+            id: REPORT_ID,
+            ...values
+          }])
+        };
+      })
+    } as any);
+
+    const response = await app().request('/reports', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Scoped report',
+        type: 'device_inventory'
+      })
+    });
+
+    expect(response.status).toBe(201);
+    expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+      authState.auth,
+      ORG_ID,
+      'write'
+    );
+    expect(inserted).toMatchObject({
+      executionScopeVersion: 1,
+      executionScopeKind: expectedKind,
+      executionScopeSiteIds: expectedSiteIds,
+      executionScopeUserId: USER_ID,
+      executionScopeCapturedAt: CAPTURED_AT
+    });
+  });
+
+  it('rejects restricted-empty creation before insert or audit', async () => {
+    siteScopeState.result = {
+      ok: false,
+      reason: 'empty_scope'
+    };
+
+    const response = await app().request('/reports', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Blocked report',
+        type: 'device_inventory'
+      })
+    });
+
+    expect(response.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '/templates'])(
+    'reuses one exact definition predicate for count and page on %s',
+    async (suffix) => {
+      const captured: unknown[] = [];
+      mockDefinitionPage([{ id: REPORT_ID }], 1, captured);
+
+      const response = await app().request(`/reports${suffix}?page=1&limit=2`);
+
+      expect(response.status).toBe(200);
+      expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+        authState.auth,
+        ORG_ID,
+        'read'
+      );
+      expect(reportDefinitionScopeSqlPredicate).toHaveBeenCalledTimes(1);
+      expect(captured).toHaveLength(2);
+      expect(conditionContainsIdentity(captured[0], siteScopeState.exactPredicate)).toBe(true);
+      expect(conditionContainsIdentity(captured[1], siteScopeState.exactPredicate)).toBe(true);
+      const body = await response.json();
+      expect(body.pagination).toEqual({ page: 1, limit: 2, total: 1 });
+    }
+  );
+
+  it.each(['', '/templates'])(
+    'keeps exact visible totals and 2/2/1 page boundaries on %s',
+    async (suffix) => {
+      const visibleIds = ['visible-1', 'visible-2', 'visible-3', 'visible-4', 'visible-5'];
+      const hiddenIds = ['hidden-site-b', 'hidden-unrestricted', 'hidden-legacy', 'hidden-malformed'];
+      const sourceRows = [
+        { id: visibleIds[0]! },
+        { id: hiddenIds[0]! },
+        { id: visibleIds[1]! },
+        { id: hiddenIds[1]! },
+        { id: visibleIds[2]! },
+        { id: hiddenIds[2]! },
+        { id: visibleIds[3]! },
+        { id: hiddenIds[3]! },
+        { id: visibleIds[4]! },
+      ];
+      const expectedPageIds = [
+        visibleIds.slice(0, 2),
+        visibleIds.slice(2, 4),
+        visibleIds.slice(4),
+      ];
+
+      for (let index = 0; index < expectedPageIds.length; index += 1) {
+        const captured: unknown[] = [];
+        mockPredicateFilteredDefinitionPage(
+          sourceRows,
+          visibleIds,
+          siteScopeState.exactPredicate,
+          captured,
+        );
+        const response = await app().request(
+          `/reports${suffix}?page=${index + 1}&limit=2`
+        );
+        const body = await response.json();
+        expect(response.status).toBe(200);
+        expect(body.data.map((row: any) => row.id)).toEqual(
+          expectedPageIds[index],
+        );
+        expect(body.pagination.total).toBe(5);
+        expect(body.data.map((row: any) => row.id)).not.toEqual(
+          expect.arrayContaining(hiddenIds)
+        );
+        expect(captured).toHaveLength(2);
+        expect(captured.every((condition) =>
+          conditionContainsIdentity(condition, siteScopeState.exactPredicate)
+        )).toBe(true);
+      }
+    }
+  );
+
+  it('uses one partner-composite predicate for a no-org list', async () => {
+    const orgB = '99999999-9999-4999-8999-999999999999';
+    authState.auth = {
+      ...authState.makeDefault(),
+      scope: 'partner',
+      partnerId: '55555555-5555-4555-8555-555555555555',
+      orgId: null,
+      accessibleOrgIds: [ORG_ID, orgB],
+      canAccessOrg: () => true
+    };
+    siteScopeState.mapResult = new Map([
+      [ORG_ID, authority('unrestricted')],
+      [orgB, {
+        ok: true,
+        authority: {
+          ...authority('restricted', [SITE_B]).authority,
+          scope: { version: 1, kind: 'restricted', orgId: orgB, siteIds: [SITE_B] }
+        }
+      }]
+    ]);
+    const captured: unknown[] = [];
+    mockDefinitionPage([{ id: 'org-a' }, { id: 'org-b1' }], 5, captured);
+
+    const response = await app().request('/reports?page=1&limit=2');
+
+    expect(response.status).toBe(200);
+    expect(resolveRequestReportAuthorityMap).toHaveBeenCalledWith(
+      authState.auth,
+      [ORG_ID, orgB],
+      'read'
+    );
+    expect(reportDefinitionMultiOrgScopeSqlPredicate).toHaveBeenCalledTimes(1);
+    expect(captured.every((condition) =>
+      conditionContainsIdentity(condition, siteScopeState.compositePredicate)
+    )).toBe(true);
+    expect(reportDefinitionScopeSqlPredicate).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '/templates'])(
+    'keeps partner-composite visible totals and 2/2/1 page boundaries on %s',
+    async (suffix) => {
+      const orgB = '99999999-9999-4999-8999-999999999999';
+      authState.auth = {
+        ...authState.makeDefault(),
+        scope: 'partner',
+        partnerId: '55555555-5555-4555-8555-555555555555',
+        orgId: null,
+        accessibleOrgIds: [ORG_ID, orgB],
+        canAccessOrg: () => true
+      };
+      const orgBResult: any = {
+        ok: true,
+        authority: {
+          ...authority('restricted', [SITE_B]).authority,
+          scope: {
+            version: 1,
+            kind: 'restricted',
+            orgId: orgB,
+            siteIds: [SITE_B]
+          }
+        }
+      };
+      siteScopeState.mapResult = new Map([
+        [ORG_ID, authority('unrestricted')],
+        [orgB, orgBResult]
+      ]);
+      const visibleIds = [
+        'org-a-1',
+        'org-b-site-b1-1',
+        'org-a-2',
+        'org-b-site-b1-2',
+        'org-a-3'
+      ];
+      const hiddenIds = [
+        'org-b-unrestricted',
+        'org-b-site-b2',
+        'legacy',
+        'malformed',
+        'denied-org',
+        'inaccessible-org'
+      ];
+      const sourceRows = [
+        { id: visibleIds[0]! },
+        { id: hiddenIds[0]! },
+        { id: visibleIds[1]! },
+        { id: hiddenIds[1]! },
+        { id: visibleIds[2]! },
+        { id: hiddenIds[2]! },
+        { id: visibleIds[3]! },
+        { id: hiddenIds[3]! },
+        { id: hiddenIds[4]! },
+        { id: visibleIds[4]! },
+        { id: hiddenIds[5]! }
+      ];
+      const expectedPages = [
+        visibleIds.slice(0, 2),
+        visibleIds.slice(2, 4),
+        visibleIds.slice(4)
+      ];
+
+      for (let index = 0; index < expectedPages.length; index += 1) {
+        const captured: unknown[] = [];
+        mockPredicateFilteredDefinitionPage(
+          sourceRows,
+          visibleIds,
+          siteScopeState.compositePredicate,
+          captured,
+        );
+        const response = await app().request(
+          `/reports${suffix}?page=${index + 1}&limit=2`,
+        );
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.data.map((row: any) => row.id)).toEqual(
+          expectedPages[index],
+        );
+        expect(body.pagination.total).toBe(5);
+        expect(body.data.map((row: any) => row.id)).not.toEqual(
+          expect.arrayContaining(hiddenIds),
+        );
+        expect(captured.every((condition) =>
+          conditionContainsIdentity(
+            condition,
+            siteScopeState.compositePredicate,
+          )
+        )).toBe(true);
+      }
+
+      expect(reportDefinitionMultiOrgScopeSqlPredicate).toHaveBeenCalledWith(
+        'reports.orgId',
+        expect.anything(),
+        [
+          authority('unrestricted').authority.scope,
+          orgBResult.authority.scope
+        ],
+      );
+    }
+  );
+
+  it('uses the unrestricted provenance predicate for a system no-org list', async () => {
+    authState.auth = {
+      ...authState.makeDefault(),
+      scope: 'system',
+      orgId: null,
+      accessibleOrgIds: null as any,
+      canAccessOrg: () => true
+    };
+    const captured: unknown[] = [];
+    mockDefinitionPage([{ id: 'system-visible' }], 5, captured);
+
+    const response = await app().request('/reports/templates?page=1&limit=2');
+
+    expect(response.status).toBe(200);
+    expect(unrestrictedReportDefinitionScopeSqlPredicate).toHaveBeenCalledTimes(1);
+    expect(captured.every((condition) =>
+      conditionContainsIdentity(condition, siteScopeState.systemPredicate)
+    )).toBe(true);
+    expect(resolveRequestReportAuthorityMap).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '/templates'])(
+    'keeps system visible totals and 2/2/1 page boundaries on %s',
+    async (suffix) => {
+      authState.auth = {
+        ...authState.makeDefault(),
+        scope: 'system',
+        orgId: null,
+        accessibleOrgIds: null as any,
+        canAccessOrg: () => true
+      };
+      const visibleIds = [
+        'system-org-a-1',
+        'system-org-b-1',
+        'system-org-a-2',
+        'system-org-c-1',
+        'system-org-b-2'
+      ];
+      const hiddenIds = ['system-malformed-1', 'system-malformed-2'];
+      const sourceRows = [
+        { id: visibleIds[0]! },
+        { id: hiddenIds[0]! },
+        { id: visibleIds[1]! },
+        { id: visibleIds[2]! },
+        { id: hiddenIds[1]! },
+        { id: visibleIds[3]! },
+        { id: visibleIds[4]! }
+      ];
+      const expectedPages = [
+        visibleIds.slice(0, 2),
+        visibleIds.slice(2, 4),
+        visibleIds.slice(4)
+      ];
+
+      for (let index = 0; index < expectedPages.length; index += 1) {
+        const captured: unknown[] = [];
+        mockPredicateFilteredDefinitionPage(
+          sourceRows,
+          visibleIds,
+          siteScopeState.systemPredicate,
+          captured,
+        );
+        const response = await app().request(
+          `/reports${suffix}?page=${index + 1}&limit=2`,
+        );
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.data.map((row: any) => row.id)).toEqual(
+          expectedPages[index],
+        );
+        expect(body.pagination.total).toBe(5);
+        expect(body.data.map((row: any) => row.id)).not.toEqual(
+          expect.arrayContaining(hiddenIds),
+        );
+        expect(captured.every((condition) =>
+          conditionContainsIdentity(condition, siteScopeState.systemPredicate)
+        )).toBe(true);
+      }
+    }
+  );
+
+  it('performs a metadata-only lookup before a predicate-guarded known-ID read', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definitionMetadata()]))
+      .mockReturnValueOnce(selectChain([{
+        ...definitionMetadata(),
+        name: 'Visible report',
+        type: 'device_inventory',
+        config: {}
+      }]))
+      .mockReturnValueOnce(selectChain([]));
+
+    const response = await app().request(`/reports/${REPORT_ID}`);
+
+    expect(response.status).toBe(200);
+    const metadataProjection = vi.mocked(db.select).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(metadataProjection)).toEqual([
+      'id',
+      'orgId',
+      'executionScopeVersion',
+      'executionScopeKind',
+      'executionScopeSiteIds',
+      'executionScopeUserId',
+      'executionScopeFingerprint',
+      'executionScopeCapturedAt'
+    ]);
+    expect(metadataProjection).not.toHaveProperty('config');
+    expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+      authState.auth,
+      ORG_ID,
+      'read'
+    );
+  });
+
+  it('hides a known ID when metadata is not a subset of current authority', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(selectChain([definitionMetadata()]));
+    vi.mocked(isSiteScopeSubset).mockReturnValueOnce(false);
+
+    const response = await app().request(`/reports/${REPORT_ID}`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Report not found' });
+    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('hides a known ID when the predicate-guarded second lookup loses the row', async () => {
+    let guardedCondition: unknown;
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definitionMetadata()]))
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn((condition) => {
+            guardedCondition = condition;
+            return { limit: vi.fn().mockResolvedValue([]) };
+          })
+        })
+      } as any);
+
+    const response = await app().request(`/reports/${REPORT_ID}`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Report not found' });
+    expect(conditionContainsIdentity(
+      guardedCondition,
+      siteScopeState.exactPredicate,
+    )).toBe(true);
+    expect(db.select).toHaveBeenCalledTimes(2);
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { method: 'GET', suffix: '', body: undefined, action: 'read' },
+    { method: 'PUT', suffix: '', body: { name: 'Nope' }, action: 'write' },
+    { method: 'DELETE', suffix: '', body: undefined, action: 'delete' },
+    { method: 'POST', suffix: '/reauthorize', body: undefined, action: 'write' }
+  ])(
+    'makes a hidden $method $suffix definition indistinguishable from nonexistent',
+    async ({ method, suffix, body, action }) => {
+      siteScopeState.result = { ok: false, reason: 'permission_removed' };
+      vi.mocked(db.select).mockReturnValueOnce(selectChain([definitionMetadata()]));
+
+      const hiddenResponse = await app().request(`/reports/${REPORT_ID}${suffix}`, {
+        method,
+        headers: body ? { 'content-type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined
+      });
+      const hiddenPayload = await hiddenResponse.text();
+
+      vi.mocked(db.select).mockReset();
+      vi.mocked(db.select).mockReturnValueOnce(selectChain([]));
+      const missingResponse = await app().request(`/reports/${MISSING_ID}${suffix}`, {
+        method,
+        headers: body ? { 'content-type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined
+      });
+
+      expect(hiddenResponse.status).toBe(404);
+      expect(missingResponse.status).toBe(hiddenResponse.status);
+      expect(await missingResponse.text()).toBe(hiddenPayload);
+      expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+        authState.auth,
+        ORG_ID,
+        action
+      );
+      expect(db.update).not.toHaveBeenCalled();
+      expect(db.delete).not.toHaveBeenCalled();
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    { method: 'PUT', suffix: '', body: { name: 'Nope' }, action: 'write' },
+    { method: 'DELETE', suffix: '', body: undefined, action: 'delete' },
+    { method: 'POST', suffix: '/reauthorize', body: undefined, action: 'write' }
+  ])(
+    'does not mutate when the guarded $method $suffix lock lookup loses the row',
+    async ({ method, suffix, body, action }) => {
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectChain([definitionMetadata()]))
+        .mockReturnValueOnce(selectChain([]));
+
+      const response = await app().request(`/reports/${REPORT_ID}${suffix}`, {
+        method,
+        headers: body ? { 'content-type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined
+      });
+
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: 'Report not found' });
+      expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+        authState.auth,
+        ORG_ID,
+        action,
+      );
+      expect(reportDefinitionScopeSqlPredicate).toHaveBeenCalledTimes(1);
+      expect(db.update).not.toHaveBeenCalled();
+      expect(db.delete).not.toHaveBeenCalled();
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    }
+  );
+
+  it('returns SCOPE_CHANGED without mutation when metadata changes before reauthorization lock', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definitionMetadata()]))
+      .mockReturnValueOnce(selectChain([
+        definitionMetadata({ executionScopeFingerprint: 'b'.repeat(64) })
+      ]));
+
+    const response = await app().request(`/reports/${REPORT_ID}/reauthorize`, {
+      method: 'POST'
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'Report scope changed',
+      code: 'SCOPE_CHANGED'
+    });
+    expect(db.update).not.toHaveBeenCalled();
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('rolls back run deletion when the guarded definition delete loses its row', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([definitionMetadata()]))
+      .mockReturnValueOnce(selectChain([definitionMetadata()]));
+    let rolledBack = false;
+    vi.mocked(db.transaction).mockImplementation(async (callback: any) => {
+      try {
+        return await callback(db as any);
+      } catch (error) {
+        rolledBack = true;
+        throw error;
+      }
+    });
+    let guardedDeleteCondition: unknown;
+    vi.mocked(db.delete)
+      .mockReturnValueOnce({
+        where: vi.fn().mockResolvedValue(undefined)
+      } as any)
+      .mockReturnValueOnce({
+        where: vi.fn((condition) => {
+          guardedDeleteCondition = condition;
+          return { returning: vi.fn().mockResolvedValue([]) };
+        })
+      } as any);
+
+    const response = await app().request(`/reports/${REPORT_ID}`, {
+      method: 'DELETE'
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'Report not found' });
+    expect(db.delete).toHaveBeenCalledTimes(2);
+    expect(conditionContainsIdentity(
+      guardedDeleteCondition,
+      siteScopeState.exactPredicate,
+    )).toBe(true);
+    expect(rolledBack).toBe(true);
+    expect(writeRouteAudit).not.toHaveBeenCalled();
+  });
+
+  it('reauthorizes with a fresh complete authority snapshot atomically', async () => {
+    const metadata = definitionMetadata({
+      executionScopeKind: 'legacy_unscoped',
+      executionScopeUserId: null
+    });
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([metadata]))
+      .mockReturnValueOnce(selectChain([metadata]));
+    let updatedValues: any;
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn((values) => {
+        updatedValues = values;
+        return {
+          where: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{
+              ...definitionMetadata(),
+              ...values
+            }])
+          })
+        };
+      })
+    } as any);
+
+    const response = await app().request(`/reports/${REPORT_ID}/reauthorize`, {
+      method: 'POST'
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+      authState.auth,
+      ORG_ID,
+      'write'
+    );
+    expect(updatedValues).toMatchObject({
+      executionScopeVersion: 1,
+      executionScopeKind: 'unrestricted',
+      executionScopeSiteIds: null,
+      executionScopeUserId: USER_ID,
+      executionScopeFingerprint: 'f'.repeat(64),
+      executionScopeCapturedAt: CAPTURED_AT
+    });
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('reports routes', () => {
   let app: Hono;
 
@@ -486,9 +1312,22 @@ describe('reports routes', () => {
     permissionState.last = null;
     permissionState.permissions = undefined;
     authState.auth = authState.makeDefault();
+    siteScopeState.result = {
+      ok: true,
+      authority: {
+        scope: { version: 1, kind: 'unrestricted', orgId: ORG_ID },
+        principalUserId: '44444444-4444-4444-8444-444444444444',
+        capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+        fingerprint: 'f'.repeat(64)
+      }
+    };
+    siteScopeState.mapResult = new Map();
     const { reportRoutes } = await import('./reports');
     app = new Hono();
     app.route('/reports', reportRoutes);
+    vi.mocked(db.transaction).mockImplementation(async (callback: any) =>
+      callback(db as any)
+    );
   });
 
   it('requires reports:export for report data routes', async () => {
@@ -534,14 +1373,26 @@ describe('reports routes', () => {
     /** Records the WHERE condition the handler builds so tests can assert scoping. */
     function captureTemplatesSelect(rows: any) {
       let captured: any;
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn((condition) => {
-            captured = condition;
-            return { orderBy: vi.fn().mockResolvedValue(rows) };
+      vi.mocked(db.select)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: rows.length }])
           })
-        })
-      } as any);
+        } as any)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn((condition) => {
+              captured = condition;
+              return {
+                orderBy: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    offset: vi.fn().mockResolvedValue(rows)
+                  })
+                })
+              };
+            })
+          })
+        } as any);
       return () => captured;
     }
 
@@ -583,6 +1434,10 @@ describe('reports routes', () => {
         orgId: null,
         accessibleOrgIds: [ORG_ID],
         canAccessOrg: (orgId: string) => orgId === ORG_ID
+      };
+      siteScopeState.result = {
+        ok: false,
+        reason: 'organization_inaccessible'
       };
 
       const res = await app.request(`/reports/templates?orgId=${OTHER_ORG}`, {
@@ -642,7 +1497,7 @@ describe('reports routes', () => {
       ).toBe(true);
     });
 
-    it('short-circuits a partner caller with no accessible orgs to an empty list (no DB read)', async () => {
+    it('returns an exact zero page for a partner caller with no accessible orgs', async () => {
       authState.auth = {
         ...authState.makeDefault(),
         scope: 'partner',
@@ -651,6 +1506,8 @@ describe('reports routes', () => {
         accessibleOrgIds: [],
         canAccessOrg: () => false
       };
+      siteScopeState.mapResult = new Map();
+      captureTemplatesSelect([]);
 
       const res = await app.request('/reports/templates', {
         method: 'GET',
@@ -660,22 +1517,28 @@ describe('reports routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data).toEqual([]);
-      // Contract the web consumer depends on: empty result without querying.
-      expect(db.select).not.toHaveBeenCalled();
+      expect(body.pagination.total).toBe(0);
+      expect(reportDefinitionMultiOrgScopeSqlPredicate).toHaveBeenCalledWith(
+        'reports.orgId',
+        expect.anything(),
+        []
+      );
     });
   });
 
   it('should generate a saved report run', async () => {
+    const report = {
+      id: 'report-1',
+      orgId: ORG_ID,
+      name: 'Device Inventory',
+      type: 'device_inventory',
+      config: {},
+      schedule: 'daily',
+      format: 'csv'
+    };
     vi.mocked(db.select)
-      .mockReturnValueOnce(selectChain([{
-        id: 'report-1',
-        orgId: ORG_ID,
-        name: 'Device Inventory',
-        type: 'device_inventory',
-        config: {},
-        schedule: 'daily',
-        format: 'csv'
-      }]))
+      .mockReturnValueOnce(selectChain([report])) // metadata lookup
+      .mockReturnValueOnce(selectChain([report])) // predicate-guarded definition lookup
       .mockReturnValueOnce(selectChain([])) // generator query (device_inventory rows)
       .mockReturnValueOnce(selectChain([])); // previousBaselineFor: no prior completed run
 
@@ -706,16 +1569,18 @@ describe('reports routes', () => {
       set: (v: any) => { setArgs.push(v); return { where: () => Promise.resolve() }; }
     } as any);
 
+    const report = {
+      id: 'report-1',
+      orgId: ORG_ID,
+      name: 'Device Inventory',
+      type: 'device_inventory',
+      config: {},
+      schedule: 'daily',
+      format: 'csv'
+    };
     vi.mocked(db.select)
-      .mockReturnValueOnce(selectChain([{
-        id: 'report-1',
-        orgId: ORG_ID,
-        name: 'Device Inventory',
-        type: 'device_inventory',
-        config: {},
-        schedule: 'daily',
-        format: 'csv'
-      }]))
+      .mockReturnValueOnce(selectChain([report])) // metadata lookup
+      .mockReturnValueOnce(selectChain([report])) // predicate-guarded definition lookup
       .mockReturnValueOnce(selectChain([])) // generator query (device_inventory rows)
       .mockReturnValueOnce(selectChain([{
         summary: { postureScore: 74 },
@@ -752,24 +1617,27 @@ describe('reports routes', () => {
   });
 
   it('should update a report schedule', async () => {
-    vi.mocked(db.select).mockReturnValueOnce({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{
-            id: 'report-1',
-            orgId: ORG_ID,
-            name: 'Ops Summary',
-            schedule: 'monthly'
-          }])
-        })
-      })
-    } as any);
+    const metadata = {
+      id: 'report-1',
+      orgId: ORG_ID,
+      executionScopeVersion: 1,
+      executionScopeKind: 'unrestricted',
+      executionScopeSiteIds: null,
+      executionScopeUserId: '44444444-4444-4444-8444-444444444444',
+      executionScopeFingerprint: 'f'.repeat(64),
+      executionScopeCapturedAt: new Date('2026-07-25T12:00:00.000Z')
+    };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([metadata]))
+      .mockReturnValueOnce(selectChain([metadata]));
 
     vi.mocked(db.update).mockReturnValue({
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([{
             id: 'report-1',
+            orgId: ORG_ID,
+            name: 'Ops Summary',
             schedule: 'weekly'
           }])
         })

--- a/apps/api/src/routes/reports.test.ts
+++ b/apps/api/src/routes/reports.test.ts
@@ -118,6 +118,7 @@ vi.mock('../services/reportGenerationService', async (importOriginal) => {
 
 vi.mock('drizzle-orm', () => ({
   and: (...conditions: any[]) => ({ op: 'and', conditions }),
+  or: (...conditions: any[]) => ({ op: 'or', conditions }),
   eq: (column: unknown, value: unknown) => ({ op: 'eq', column, value }),
   inArray: (column: unknown, values: unknown[]) => ({ op: 'inArray', column, values }),
   gte: (column: unknown, value: unknown) => ({ op: 'gte', column, value }),
@@ -446,6 +447,121 @@ function mockMetricsQueries(
         })
       })
     } as any);
+}
+
+type SummaryAlert = {
+  orgId: string;
+  siteId: string | null;
+  severity: string;
+  status: string;
+  day: string;
+  ruleId: string;
+  ruleName: string;
+};
+
+/**
+ * Evaluates a mocked WHERE tree against one seeded alert. Date bounds always
+ * pass (fixtures sit inside every window); organization and device-site
+ * predicates are the interesting axes.
+ */
+function alertMatches(alert: SummaryAlert, condition: any): boolean {
+  if (!condition) return true;
+  if (condition.op === 'and') {
+    return condition.conditions.every((child: any) => alertMatches(alert, child));
+  }
+  if (condition.op === 'or') {
+    return condition.conditions.some((child: any) => alertMatches(alert, child));
+  }
+  if (condition.op === 'eq') {
+    if (condition.column === 'alerts.orgId' || condition.column === 'devices.orgId') {
+      return alert.orgId === condition.value;
+    }
+    if (condition.column === 'devices.siteId') {
+      return alert.siteId === condition.value;
+    }
+    return true;
+  }
+  if (condition.op === 'inArray') {
+    if (condition.column === 'alerts.orgId' || condition.column === 'devices.orgId') {
+      return (condition.values as string[]).includes(alert.orgId);
+    }
+    if (condition.column === 'devices.siteId') {
+      return alert.siteId !== null && (condition.values as string[]).includes(alert.siteId);
+    }
+    return true;
+  }
+  return true;
+}
+
+/** The device-scope branch the alerts-summary handler conjoins into every aggregate. */
+function findDeviceScopeNode(condition: any): any {
+  const children = condition?.op === 'and' ? condition.conditions : [condition];
+  return children.find(
+    (child: any) =>
+      child?.op === 'or' ||
+      ((child?.op === 'inArray' || child?.op === 'eq') && child.column === 'devices.siteId')
+  );
+}
+
+function countBy(rows: SummaryAlert[], key: 'severity' | 'status' | 'day'): Array<[string, number]> {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    counts.set(row[key], (counts.get(row[key]) ?? 0) + 1);
+  }
+  return [...counts.entries()];
+}
+
+/**
+ * Mocks the five alerts-summary aggregates in handler order (severity, status,
+ * day, top rules, total) and records each query's join conditions and WHERE
+ * tree so tests can prove one shared device predicate reaches all of them.
+ */
+function mockAlertsSummaryQueries(rows: SummaryAlert[]) {
+  const captured: any[] = [];
+  const joins: any[][] = [[], [], [], [], []];
+  const projections: Array<(visible: SummaryAlert[]) => any[]> = [
+    (visible) => countBy(visible, 'severity').map(([severity, count]) => ({ severity, count })),
+    (visible) => countBy(visible, 'status').map(([status, count]) => ({ status, count })),
+    (visible) =>
+      countBy(visible, 'day')
+        .sort((left, right) => left[0].localeCompare(right[0]))
+        .map(([date, count]) => ({ date, count })),
+    (visible) => {
+      const byRule = new Map<string, { ruleId: string; ruleName: string; count: number }>();
+      for (const row of visible) {
+        const existing = byRule.get(row.ruleId);
+        if (existing) existing.count += 1;
+        else byRule.set(row.ruleId, { ruleId: row.ruleId, ruleName: row.ruleName, count: 1 });
+      }
+      return [...byRule.values()].sort((left, right) => right.count - left.count).slice(0, 10);
+    },
+    (visible) => [{ count: visible.length }]
+  ];
+
+  projections.forEach((project, index) => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: () => {
+        const node: any = {};
+        node.innerJoin = (_table: unknown, condition: unknown) => {
+          joins[index]!.push(condition);
+          return node;
+        };
+        node.where = (condition: any) => {
+          captured.push(condition);
+          const promise: any = Promise.resolve(
+            project(rows.filter((row) => alertMatches(row, condition)))
+          );
+          promise.groupBy = () => promise;
+          promise.orderBy = () => promise;
+          promise.limit = () => promise;
+          return promise;
+        };
+        return node;
+      }
+    } as any);
+  });
+
+  return { captured, joins };
 }
 
 function mockGenerateDeviceInventoryQuery(rows: Array<{ hostname: string; siteId: string }>) {
@@ -1867,6 +1983,273 @@ describe('reports routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data.topCpu).toHaveLength(2);
+    });
+  });
+
+  describe('GET /reports/data/alerts-summary site scope', () => {
+    const ORG_B = '66666666-6666-4666-8666-666666666666';
+    const ORG_C = '77777777-7777-4777-8777-777777777777';
+    const SITE_B1 = '88888888-8888-4888-8888-888888888888';
+    const SITE_B2 = '99999999-9999-4999-8999-999999999999';
+    const SITE_C = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const USER_ID = '44444444-4444-4444-8444-444444444444';
+    const CAPTURED_AT = new Date('2026-07-25T12:00:00.000Z');
+    const EMPTY_SUMMARY = {
+      data: { bySeverity: {}, byStatus: {}, byDay: [], topRules: [] },
+      total: 0
+    };
+
+    const orgAlerts: SummaryAlert[] = [
+      { orgId: ORG_ID, siteId: SITE_ALLOWED, severity: 'critical', status: 'open', day: '2026-07-01', ruleId: 'rule-1', ruleName: 'Rule One' },
+      { orgId: ORG_ID, siteId: SITE_ALLOWED, severity: 'warning', status: 'open', day: '2026-07-02', ruleId: 'rule-1', ruleName: 'Rule One' },
+      { orgId: ORG_ID, siteId: SITE_DENIED, severity: 'critical', status: 'resolved', day: '2026-07-01', ruleId: 'rule-2', ruleName: 'Rule Two' },
+      { orgId: ORG_ID, siteId: null, severity: 'info', status: 'open', day: '2026-07-03', ruleId: 'rule-3', ruleName: 'Rule Three' }
+    ];
+
+    const multiOrgAlerts: SummaryAlert[] = [
+      { orgId: ORG_ID, siteId: SITE_ALLOWED, severity: 'critical', status: 'open', day: '2026-07-01', ruleId: 'rule-a', ruleName: 'Rule A' },
+      { orgId: ORG_ID, siteId: null, severity: 'warning', status: 'open', day: '2026-07-02', ruleId: 'rule-a', ruleName: 'Rule A' },
+      { orgId: ORG_B, siteId: SITE_B1, severity: 'critical', status: 'resolved', day: '2026-07-02', ruleId: 'rule-b1', ruleName: 'Rule B1' },
+      { orgId: ORG_B, siteId: SITE_B2, severity: 'info', status: 'open', day: '2026-07-03', ruleId: 'rule-b2', ruleName: 'Rule B2' },
+      { orgId: ORG_B, siteId: null, severity: 'info', status: 'open', day: '2026-07-03', ruleId: 'rule-b3', ruleName: 'Rule B3' },
+      { orgId: ORG_C, siteId: SITE_C, severity: 'critical', status: 'open', day: '2026-07-04', ruleId: 'rule-c', ruleName: 'Rule C' }
+    ];
+
+    function restrictedAuthority(orgId: string, siteIds: string[]) {
+      return {
+        ok: true,
+        authority: {
+          scope: { version: 1, kind: 'restricted', orgId, siteIds },
+          principalUserId: USER_ID,
+          capturedAt: CAPTURED_AT,
+          fingerprint: 'a'.repeat(64)
+        }
+      };
+    }
+
+    function unrestrictedAuthority(orgId: string) {
+      return {
+        ok: true,
+        authority: {
+          scope: { version: 1, kind: 'unrestricted', orgId },
+          principalUserId: USER_ID,
+          capturedAt: CAPTURED_AT,
+          fingerprint: 'f'.repeat(64)
+        }
+      };
+    }
+
+    function usePartnerAuth(orgIds: string[]) {
+      authState.auth = {
+        ...authState.makeDefault(),
+        scope: 'partner',
+        partnerId: 'partner-1',
+        orgId: null,
+        accessibleOrgIds: orgIds,
+        canAccessOrg: (orgId: string) => orgIds.includes(orgId)
+      };
+    }
+
+    it('returns only Site A values in every aggregate component for a restricted caller', async () => {
+      siteScopeState.result = restrictedAuthority(ORG_ID, [SITE_ALLOWED]);
+      const { captured, joins } = mockAlertsSummaryQueries(orgAlerts);
+
+      const res = await app.request('/reports/data/alerts-summary');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.bySeverity).toEqual({ critical: 1, warning: 1 });
+      expect(body.data.byStatus).toEqual({ open: 2 });
+      expect(body.data.byDay).toEqual([
+        { date: '2026-07-01', count: 1 },
+        { date: '2026-07-02', count: 1 }
+      ]);
+      expect(body.data.topRules).toEqual([
+        { ruleId: 'rule-1', ruleName: 'Rule One', count: 2 }
+      ]);
+      expect(body.total).toBe(2);
+
+      expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+        authState.auth,
+        ORG_ID,
+        'export'
+      );
+
+      // All five aggregates join alerts to devices and reuse one predicate.
+      expect(captured).toHaveLength(5);
+      expect(joins).toHaveLength(5);
+      for (const queryJoins of joins) {
+        expect(queryJoins).toContainEqual({
+          op: 'eq',
+          column: 'alerts.deviceId',
+          value: 'devices.id'
+        });
+      }
+      const scopeNodes = captured.map(findDeviceScopeNode);
+      for (const node of scopeNodes) {
+        expect(node).toEqual({
+          op: 'inArray',
+          column: 'devices.siteId',
+          values: [SITE_ALLOWED]
+        });
+        expect(node).toBe(scopeNodes[0]);
+      }
+    });
+
+    it('returns 403 for a denied siteId before any query', async () => {
+      siteScopeState.result = restrictedAuthority(ORG_ID, [SITE_ALLOWED]);
+      mockAlertsSummaryQueries(orgAlerts);
+
+      const res = await app.request(`/reports/data/alerts-summary?siteId=${SITE_DENIED}`);
+
+      expect(res.status).toBe(403);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('returns the zero-safe shape with zero queries for a restricted-empty caller', async () => {
+      siteScopeState.result = { ok: false, reason: 'empty_scope' };
+      mockAlertsSummaryQueries(orgAlerts);
+
+      const res = await app.request('/reports/data/alerts-summary');
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(EMPTY_SUMMARY);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('leaves an unrestricted caller unchanged', async () => {
+      const { captured } = mockAlertsSummaryQueries(orgAlerts);
+
+      const res = await app.request('/reports/data/alerts-summary');
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.bySeverity).toEqual({ critical: 2, warning: 1, info: 1 });
+      expect(body.data.byStatus).toEqual({ open: 3, resolved: 1 });
+      expect(body.data.byDay).toHaveLength(3);
+      expect(body.data.topRules).toHaveLength(3);
+      expect(body.total).toBe(4);
+      for (const condition of captured) {
+        expect(findDeviceScopeNode(condition)).toBeUndefined();
+      }
+    });
+
+    it('derives one exact-organization scope from an explicit orgId even for a broader partner', async () => {
+      usePartnerAuth([ORG_ID, ORG_B]);
+      siteScopeState.result = restrictedAuthority(ORG_B, [SITE_B1]);
+      const { captured } = mockAlertsSummaryQueries(multiOrgAlerts);
+
+      const res = await app.request(`/reports/data/alerts-summary?orgId=${ORG_B}`);
+
+      expect(res.status).toBe(200);
+      expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+        authState.auth,
+        ORG_B,
+        'export'
+      );
+      expect(resolveRequestReportAuthorityMap).not.toHaveBeenCalled();
+      const body = await res.json();
+      expect(body.data.bySeverity).toEqual({ critical: 1 });
+      expect(body.data.byStatus).toEqual({ resolved: 1 });
+      expect(body.data.topRules).toEqual([
+        { ruleId: 'rule-b1', ruleName: 'Rule B1', count: 1 }
+      ]);
+      expect(body.total).toBe(1);
+      for (const condition of captured) {
+        expect(findDeviceScopeNode(condition)).toEqual({
+          op: 'inArray',
+          column: 'devices.siteId',
+          values: [SITE_B1]
+        });
+      }
+    });
+
+    it('builds one per-organization composite predicate for a partner without orgId', async () => {
+      usePartnerAuth([ORG_ID, ORG_B, ORG_C]);
+      siteScopeState.mapResult = new Map<string, any>([
+        [ORG_ID, unrestrictedAuthority(ORG_ID)],
+        [ORG_B, restrictedAuthority(ORG_B, [SITE_B1])],
+        [ORG_C, { ok: false, reason: 'permission_removed' }]
+      ]);
+      const { captured } = mockAlertsSummaryQueries(multiOrgAlerts);
+
+      const res = await app.request('/reports/data/alerts-summary');
+
+      expect(res.status).toBe(200);
+      expect(resolveRequestReportAuthorityMap).toHaveBeenCalledWith(
+        authState.auth,
+        [ORG_ID, ORG_B, ORG_C],
+        'export'
+      );
+      const body = await res.json();
+      // Organization A is unrestricted through partner fallback; Organization B
+      // contributes only its Site B1 row; Organization C is denied entirely.
+      expect(body.data.bySeverity).toEqual({ critical: 2, warning: 1 });
+      expect(body.data.byStatus).toEqual({ open: 2, resolved: 1 });
+      expect(body.data.byDay).toEqual([
+        { date: '2026-07-01', count: 1 },
+        { date: '2026-07-02', count: 2 }
+      ]);
+      expect(body.data.topRules).toEqual([
+        { ruleId: 'rule-a', ruleName: 'Rule A', count: 2 },
+        { ruleId: 'rule-b1', ruleName: 'Rule B1', count: 1 }
+      ]);
+      expect(body.total).toBe(3);
+
+      const scopeNodes = captured.map(findDeviceScopeNode);
+      expect(scopeNodes[0]).toEqual({
+        op: 'or',
+        conditions: [
+          { op: 'eq', column: 'devices.orgId', value: ORG_ID },
+          {
+            op: 'and',
+            conditions: [
+              { op: 'eq', column: 'devices.orgId', value: ORG_B },
+              { op: 'inArray', column: 'devices.siteId', values: [SITE_B1] }
+            ]
+          }
+        ]
+      });
+      for (const node of scopeNodes) {
+        expect(node).toBe(scopeNodes[0]);
+      }
+    });
+
+    it('returns the zero-safe shape with zero queries when no organization branch is authorized', async () => {
+      usePartnerAuth([ORG_ID, ORG_B]);
+      siteScopeState.mapResult = new Map<string, any>([
+        [ORG_ID, { ok: false, reason: 'permission_removed' }],
+        [ORG_B, { ok: false, reason: 'empty_scope' }]
+      ]);
+      mockAlertsSummaryQueries(multiOrgAlerts);
+
+      const res = await app.request('/reports/data/alerts-summary');
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(EMPTY_SUMMARY);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('is unrestricted per row for a system caller without orgId', async () => {
+      authState.auth = {
+        ...authState.makeDefault(),
+        scope: 'system',
+        orgId: null,
+        accessibleOrgIds: [],
+        canAccessOrg: () => true
+      };
+      const { captured } = mockAlertsSummaryQueries(multiOrgAlerts);
+
+      const res = await app.request('/reports/data/alerts-summary');
+
+      expect(res.status).toBe(200);
+      expect(resolveRequestReportAuthority).not.toHaveBeenCalled();
+      expect(resolveRequestReportAuthorityMap).not.toHaveBeenCalled();
+      const body = await res.json();
+      expect(body.total).toBe(6);
+      for (const condition of captured) {
+        expect(findDeviceScopeNode(condition)).toBeUndefined();
+      }
     });
   });
 

--- a/apps/api/src/routes/reports/core.ts
+++ b/apps/api/src/routes/reports/core.ts
@@ -1,17 +1,189 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
-import { and, eq, sql, desc, inArray } from 'drizzle-orm';
+import { and, eq, sql, desc, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { reports, reportRuns } from '../../db/schema';
-import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
+import {
+  authMiddleware,
+  requirePermission,
+  requireScope,
+  type AuthContext,
+} from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
-import { getPagination, ensureOrgAccess, getReportWithOrgCheck } from './helpers';
+import {
+  getPagination,
+  ensureOrgAccess,
+  getReportWithOrgCheck,
+  reportDefinitionMetadataProjection,
+  tenantAuthorizedReportCondition,
+} from './helpers';
+import {
+  decodeSiteScope,
+  intersectSiteScopes,
+  isSiteScopeSubset,
+  persistedSiteScopeValues,
+  reportDefinitionMultiOrgScopeSqlPredicate,
+  reportDefinitionScopeSqlPredicate,
+  resolveRequestReportAuthority,
+  resolveRequestReportAuthorityMap,
+  unrestrictedReportDefinitionScopeSqlPredicate,
+  type LiveSiteScopeV1,
+  type PersistedSiteScopeColumns,
+  type ReportAction,
+} from '../../services/siteScope';
 import { listReportsSchema, createReportSchema, updateReportSchema } from './schemas';
 
 export const coreRoutes = new Hono();
 
 coreRoutes.use('*', authMiddleware);
+
+const REPORT_NOT_FOUND = { error: 'Report not found' } as const;
+
+type DefinitionListScopeResult =
+  | { ok: true; tenantCondition?: SQL<unknown>; definitionScopePredicate: SQL<unknown> }
+  | { ok: false; error: string };
+
+function liveScopeOf(
+  result: Awaited<ReturnType<typeof resolveRequestReportAuthority>>,
+): LiveSiteScopeV1 | null {
+  if (!result.ok || result.authority.scope.kind === 'legacy_unscoped') {
+    return null;
+  }
+  return result.authority.scope;
+}
+
+async function resolveDefinitionListScope(
+  auth: AuthContext,
+  explicitOrgId?: string,
+): Promise<DefinitionListScopeResult> {
+  const exactOrgId = auth.scope === 'organization'
+    ? auth.orgId
+    : explicitOrgId;
+
+  if (auth.scope === 'organization' && !exactOrgId) {
+    return { ok: false, error: 'Organization context required' };
+  }
+
+  if (exactOrgId) {
+    const result = await resolveRequestReportAuthority(auth, exactOrgId, 'read');
+    const scope = liveScopeOf(result);
+    if (!scope) {
+      return { ok: false, error: 'Access to this organization denied' };
+    }
+    return {
+      ok: true,
+      tenantCondition: eq(reports.orgId, exactOrgId),
+      definitionScopePredicate: reportDefinitionScopeSqlPredicate(reports, scope),
+    };
+  }
+
+  if (auth.scope === 'partner') {
+    const orgIds = auth.accessibleOrgIds ?? [];
+    const authorityMap = await resolveRequestReportAuthorityMap(
+      auth,
+      orgIds,
+      'read',
+    );
+    const scopes: LiveSiteScopeV1[] = [];
+    for (const result of authorityMap.values()) {
+      const scope = liveScopeOf(result);
+      if (scope) scopes.push(scope);
+    }
+    return {
+      ok: true,
+      tenantCondition: orgIds.length > 0
+        ? inArray(reports.orgId, orgIds)
+        : sql<unknown>`FALSE`,
+      definitionScopePredicate: reportDefinitionMultiOrgScopeSqlPredicate(
+        reports.orgId,
+        reports,
+        scopes,
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    definitionScopePredicate:
+      unrestrictedReportDefinitionScopeSqlPredicate(reports),
+  };
+}
+
+function persistedMetadataMatches(
+  left: PersistedSiteScopeColumns,
+  right: PersistedSiteScopeColumns,
+): boolean {
+  return (
+    left.executionScopeVersion === right.executionScopeVersion &&
+    left.executionScopeKind === right.executionScopeKind &&
+    JSON.stringify(left.executionScopeSiteIds) ===
+      JSON.stringify(right.executionScopeSiteIds) &&
+    left.executionScopeUserId === right.executionScopeUserId &&
+    left.executionScopeFingerprint === right.executionScopeFingerprint &&
+    left.executionScopeCapturedAt?.getTime() ===
+      right.executionScopeCapturedAt?.getTime()
+  );
+}
+
+async function loadLockedDefinition(
+  tx: Pick<typeof db, 'select'>,
+  reportId: string,
+  auth: AuthContext,
+  action: Exclude<ReportAction, 'read' | 'export'>,
+) {
+  const [metadata] = await tx
+    .select(reportDefinitionMetadataProjection)
+    .from(reports)
+    .where(tenantAuthorizedReportCondition(reportId, auth))
+    .limit(1);
+  if (!metadata) return null;
+
+  const authorityResult = await resolveRequestReportAuthority(
+    auth,
+    metadata.orgId,
+    action,
+  );
+  if (!authorityResult.ok) return null;
+  const currentScope = liveScopeOf(authorityResult);
+  if (!currentScope) return null;
+
+  const definitionScopePredicate = reportDefinitionScopeSqlPredicate(
+    reports,
+    currentScope,
+  );
+  const [locked] = await tx
+    .select(reportDefinitionMetadataProjection)
+    .from(reports)
+    .where(
+      and(
+        eq(reports.id, reportId),
+        eq(reports.orgId, metadata.orgId),
+        definitionScopePredicate,
+      ),
+    )
+    .limit(1)
+    .for('update');
+  if (!locked) return null;
+
+  try {
+    const storedScope = decodeSiteScope(
+      locked as PersistedSiteScopeColumns,
+      locked.orgId,
+    );
+    if (!isSiteScopeSubset(storedScope, currentScope)) return null;
+    return {
+      metadata,
+      locked,
+      storedScope,
+      currentScope,
+      authority: authorityResult.authority,
+      definitionScopePredicate,
+    };
+  } catch {
+    return null;
+  }
+}
 
 // GET /reports - List saved reports
 coreRoutes.get(
@@ -23,35 +195,15 @@ coreRoutes.get(
     const auth = c.get('auth');
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
+    const scopeResult = await resolveDefinitionListScope(auth, query.orgId);
+    if (!scopeResult.ok) {
+      return c.json({ error: scopeResult.error }, 403);
+    }
 
-    // Build conditions array
-    const conditions: ReturnType<typeof eq>[] = [];
-
-    // Filter by org access based on scope
-    if (auth.scope === 'organization') {
-      if (!auth.orgId) {
-        return c.json({ error: 'Organization context required' }, 403);
-      }
-      conditions.push(eq(reports.orgId, auth.orgId));
-    } else if (auth.scope === 'partner') {
-      if (query.orgId) {
-        const hasAccess = await ensureOrgAccess(query.orgId, auth);
-        if (!hasAccess) {
-          return c.json({ error: 'Access to this organization denied' }, 403);
-        }
-        conditions.push(eq(reports.orgId, query.orgId));
-      } else {
-        const orgIds = auth.accessibleOrgIds ?? [];
-        if (orgIds.length === 0) {
-          return c.json({
-            data: [],
-            pagination: { page, limit, total: 0 }
-          });
-        }
-        conditions.push(inArray(reports.orgId, orgIds));
-      }
-    } else if (auth.scope === 'system' && query.orgId) {
-      conditions.push(eq(reports.orgId, query.orgId));
+    const definitionScopePredicate = scopeResult.definitionScopePredicate;
+    const conditions: SQL<unknown>[] = [definitionScopePredicate];
+    if (scopeResult.tenantCondition) {
+      conditions.push(scopeResult.tenantCondition);
     }
 
     // Additional filters
@@ -63,7 +215,7 @@ coreRoutes.get(
       conditions.push(eq(reports.schedule, query.schedule));
     }
 
-    const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+    const whereCondition = and(...conditions);
 
     // Get total count
     const countResult = await db
@@ -101,42 +253,37 @@ coreRoutes.get(
   async (c) => {
     const auth = c.get('auth');
     const query = c.req.valid('query');
-
-    // Mirror the list endpoint's org-access scoping.
-    const conditions: ReturnType<typeof eq>[] = [];
-
-    if (auth.scope === 'organization') {
-      if (!auth.orgId) {
-        return c.json({ error: 'Organization context required' }, 403);
-      }
-      conditions.push(eq(reports.orgId, auth.orgId));
-    } else if (auth.scope === 'partner') {
-      if (query.orgId) {
-        const hasAccess = await ensureOrgAccess(query.orgId, auth);
-        if (!hasAccess) {
-          return c.json({ error: 'Access to this organization denied' }, 403);
-        }
-        conditions.push(eq(reports.orgId, query.orgId));
-      } else {
-        const orgIds = auth.accessibleOrgIds ?? [];
-        if (orgIds.length === 0) {
-          return c.json({ data: [] });
-        }
-        conditions.push(inArray(reports.orgId, orgIds));
-      }
-    } else if (auth.scope === 'system' && query.orgId) {
-      conditions.push(eq(reports.orgId, query.orgId));
+    const { page, limit, offset } = getPagination(query);
+    const scopeResult = await resolveDefinitionListScope(auth, query.orgId);
+    if (!scopeResult.ok) {
+      return c.json({ error: scopeResult.error }, 403);
     }
 
-    const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+    const definitionScopePredicate = scopeResult.definitionScopePredicate;
+    const conditions: SQL<unknown>[] = [definitionScopePredicate];
+    if (scopeResult.tenantCondition) {
+      conditions.push(scopeResult.tenantCondition);
+    }
+    const whereCondition = and(...conditions);
+
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(reports)
+      .where(whereCondition);
+    const total = Number(countResult[0]?.count ?? 0);
 
     const templates = await db
       .select()
       .from(reports)
       .where(whereCondition)
-      .orderBy(desc(reports.updatedAt));
+      .orderBy(desc(reports.updatedAt))
+      .limit(limit)
+      .offset(offset);
 
-    return c.json({ data: templates });
+    return c.json({
+      data: templates,
+      pagination: { page, limit, total },
+    });
   }
 );
 
@@ -211,6 +358,20 @@ coreRoutes.post(
       return c.json({ error: 'orgId is required' }, 400);
     }
 
+    const authorityResult = await resolveRequestReportAuthority(
+      auth,
+      orgId!,
+      'write',
+    );
+    if (!authorityResult.ok) {
+      return c.json({ error: 'Report scope is not authorized' }, 403);
+    }
+    const currentScope = liveScopeOf(authorityResult);
+    if (!currentScope) {
+      return c.json({ error: 'Report scope is not authorized' }, 403);
+    }
+
+    const scopeValues = persistedSiteScopeValues(authorityResult.authority);
     const [report] = await db
       .insert(reports)
       .values({
@@ -220,7 +381,8 @@ coreRoutes.post(
         config: data.config,
         schedule: data.schedule,
         format: data.format,
-        createdBy: auth.user.id
+        createdBy: auth.user.id,
+        ...scopeValues,
       })
       .returning();
 
@@ -252,36 +414,129 @@ coreRoutes.put(
       return c.json({ error: 'No updates provided' }, 400);
     }
 
-    const report = await getReportWithOrgCheck(reportId, auth);
-    if (!report) {
-      return c.json({ error: 'Report not found' }, 404);
-    }
-
-    // Build updates object
     const updates: Record<string, unknown> = { updatedAt: new Date() };
-
     if (data.name !== undefined) updates.name = data.name;
     if (data.config !== undefined) updates.config = data.config;
     if (data.schedule !== undefined) updates.schedule = data.schedule;
     if (data.format !== undefined) updates.format = data.format;
 
-    const [updated] = await db
-      .update(reports)
-      .set(updates)
-      .where(eq(reports.id, reportId))
-      .returning();
+    const mutation = await db.transaction(async (tx) => {
+      const locked = await loadLockedDefinition(
+        tx,
+        reportId,
+        auth,
+        'write',
+      );
+      if (!locked) return null;
 
+      const effectiveScope = intersectSiteScopes(
+        locked.storedScope,
+        locked.currentScope,
+      );
+      if (!effectiveScope) return null;
+
+      const [updated] = await tx
+        .update(reports)
+        .set(updates)
+        .where(
+          and(
+            eq(reports.id, reportId),
+            eq(reports.orgId, locked.locked.orgId),
+            locked.definitionScopePredicate,
+          ),
+        )
+        .returning();
+      if (!updated) return null;
+      return { updated, locked: locked.locked };
+    });
+
+    if (!mutation) {
+      return c.json(REPORT_NOT_FOUND, 404);
+    }
     writeRouteAudit(c, {
-      orgId: report.orgId,
+      orgId: mutation.locked.orgId,
       action: 'report.update',
       resourceType: 'report',
-      resourceId: updated?.id ?? reportId,
-      resourceName: updated?.name ?? report.name,
+      resourceId: mutation.updated.id,
+      resourceName: mutation.updated.name,
       details: { changedFields: Object.keys(data) }
     });
 
-    return c.json(updated);
+    return c.json(mutation.updated);
   }
+);
+
+// POST /reports/:id/reauthorize - Explicitly replace stored scope provenance
+coreRoutes.post(
+  '/:id/reauthorize',
+  requireScope('organization', 'partner', 'system'),
+  requirePermission(PERMISSIONS.REPORTS_WRITE.resource, PERMISSIONS.REPORTS_WRITE.action),
+  async (c) => {
+    const auth = c.get('auth');
+    const reportId = c.req.param('id')!;
+
+    const result = await db.transaction(async (tx) => {
+      const locked = await loadLockedDefinition(
+        tx,
+        reportId,
+        auth,
+        'write',
+      );
+      if (!locked) return { kind: 'not_found' as const };
+
+      if (
+        locked.storedScope.kind === 'legacy_unscoped' &&
+        locked.currentScope.kind !== 'unrestricted'
+      ) {
+        return { kind: 'not_found' as const };
+      }
+
+      if (
+        !persistedMetadataMatches(
+          locked.metadata as PersistedSiteScopeColumns,
+          locked.locked as PersistedSiteScopeColumns,
+        )
+      ) {
+        return { kind: 'changed' as const };
+      }
+
+      const scopeValues = persistedSiteScopeValues(locked.authority);
+      const [updated] = await tx
+        .update(reports)
+        .set({
+          ...scopeValues,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(reports.id, reportId),
+            eq(reports.orgId, locked.locked.orgId),
+            locked.definitionScopePredicate,
+          ),
+        )
+        .returning();
+
+      return updated
+        ? { kind: 'updated' as const, updated }
+        : { kind: 'changed' as const };
+    });
+
+    if (result.kind === 'not_found') {
+      return c.json(REPORT_NOT_FOUND, 404);
+    }
+    if (result.kind === 'changed') {
+      return c.json({ error: 'Report scope changed', code: 'SCOPE_CHANGED' }, 409);
+    }
+
+    writeRouteAudit(c, {
+      orgId: result.updated.orgId,
+      action: 'report.reauthorize',
+      resourceType: 'report',
+      resourceId: result.updated.id,
+      resourceName: result.updated.name,
+    });
+    return c.json(result.updated);
+  },
 );
 
 // DELETE /reports/:id - Delete report
@@ -293,27 +548,52 @@ coreRoutes.delete(
     const auth = c.get('auth');
     const reportId = c.req.param('id')!;
 
-    const report = await getReportWithOrgCheck(reportId, auth);
-    if (!report) {
-      return c.json({ error: 'Report not found' }, 404);
+    const deleted = await db.transaction(async (tx) => {
+      const locked = await loadLockedDefinition(
+        tx,
+        reportId,
+        auth,
+        'delete',
+      );
+      if (!locked) return null;
+
+      await tx
+        .delete(reportRuns)
+        .where(eq(reportRuns.reportId, reportId));
+
+      const deletedRows = await tx
+        .delete(reports)
+        .where(
+          and(
+            eq(reports.id, reportId),
+            eq(reports.orgId, locked.locked.orgId),
+            locked.definitionScopePredicate,
+          ),
+        )
+        .returning();
+      if (deletedRows.length !== 1) {
+        throw new Error('REPORT_DELETE_SCOPE_CHANGED');
+      }
+      return deletedRows[0]!;
+    }).catch((error) => {
+      if (
+        error instanceof Error &&
+        error.message === 'REPORT_DELETE_SCOPE_CHANGED'
+      ) {
+        return null;
+      }
+      throw error;
+    });
+
+    if (!deleted) {
+      return c.json(REPORT_NOT_FOUND, 404);
     }
-
-    // Delete associated runs first
-    await db
-      .delete(reportRuns)
-      .where(eq(reportRuns.reportId, reportId));
-
-    // Delete the report
-    await db
-      .delete(reports)
-      .where(eq(reports.id, reportId));
-
     writeRouteAudit(c, {
-      orgId: report.orgId,
+      orgId: deleted.orgId,
       action: 'report.delete',
       resourceType: 'report',
-      resourceId: report.id,
-      resourceName: report.name
+      resourceId: deleted.id,
+      resourceName: deleted.name
     });
 
     return c.json({ success: true });

--- a/apps/api/src/routes/reports/core.ts
+++ b/apps/api/src/routes/reports/core.ts
@@ -25,6 +25,7 @@ import {
   persistedSiteScopeValues,
   reportDefinitionMultiOrgScopeSqlPredicate,
   reportDefinitionScopeSqlPredicate,
+  reportRunScopeSqlPredicate,
   resolveRequestReportAuthority,
   resolveRequestReportAuthorityMap,
   unrestrictedReportDefinitionScopeSqlPredicate,
@@ -308,11 +309,40 @@ coreRoutes.get(
       return c.json({ error: 'Report not found' }, 404);
     }
 
+    const authorityResult = await resolveRequestReportAuthority(
+      auth,
+      report.orgId,
+      'read',
+    );
+    if (!authorityResult.ok || authorityResult.authority.scope.kind === 'legacy_unscoped') {
+      return c.json({ error: 'Report not found' }, 404);
+    }
+    const runScopePredicate = reportRunScopeSqlPredicate(
+      reportRuns,
+      authorityResult.authority.scope,
+    );
+
     // Get recent runs for this report
     const recentRuns = await db
-      .select()
+      .select({
+        id: reportRuns.id,
+        reportId: reportRuns.reportId,
+        status: reportRuns.status,
+        startedAt: reportRuns.startedAt,
+        completedAt: reportRuns.completedAt,
+        outputUrl: reportRuns.outputUrl,
+        errorMessage: reportRuns.errorMessage,
+        rowCount: reportRuns.rowCount,
+        createdAt: reportRuns.createdAt,
+        executionScopeVersion: reportRuns.executionScopeVersion,
+        executionScopeKind: reportRuns.executionScopeKind,
+        executionScopeSiteIds: reportRuns.executionScopeSiteIds,
+        executionScopeUserId: reportRuns.executionScopeUserId,
+        executionScopeFingerprint: reportRuns.executionScopeFingerprint,
+        executionScopeCapturedAt: reportRuns.executionScopeCapturedAt,
+      })
       .from(reportRuns)
-      .where(eq(reportRuns.reportId, reportId))
+      .where(and(eq(reportRuns.reportId, reportId), runScopePredicate))
       .orderBy(desc(reportRuns.createdAt))
       .limit(5);
 

--- a/apps/api/src/routes/reports/data.ts
+++ b/apps/api/src/routes/reports/data.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
-import { and, eq, sql, desc, gte, lte, inArray, type SQL } from 'drizzle-orm';
+import { and, eq, or, sql, desc, gte, lte, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import {
   devices,
@@ -12,12 +12,71 @@ import {
 } from '../../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../../services/permissions';
+import {
+  resolveRequestReportAuthority,
+  resolveRequestReportAuthorityMap,
+  type LiveSiteScopeV1,
+} from '../../services/siteScope';
 import { ensureOrgAccess, getOrgIdsForAuth } from './helpers';
 import { dataQuerySchema } from './schemas';
 
 export const dataRoutes = new Hono();
 
 dataRoutes.use('*', authMiddleware);
+
+/** Zero-safe alerts-summary payload, returned before any database call. */
+function emptyAlertsSummary() {
+  return {
+    data: { bySeverity: {}, byStatus: {}, byDay: [], topRules: [] },
+    total: 0
+  };
+}
+
+function normalizeSiteIdList(siteIds: readonly string[]): string[] {
+  return [...new Set(siteIds)].sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Device-level site condition for one exact-organization live scope.
+ * `unrestricted` adds no predicate; `restricted` binds its normalized UUIDs.
+ */
+function alertsDeviceSiteCondition(scope: LiveSiteScopeV1): SQL | undefined {
+  return scope.kind === 'restricted'
+    ? inArray(devices.siteId, normalizeSiteIdList(scope.siteIds))
+    : undefined;
+}
+
+/**
+ * One parameterized device predicate of `(devices.org_id = orgX AND
+ * siteCondition(scopeX))` branches for a partner multi-organization request.
+ * Denied and restricted-empty organizations get no branch at all, so an empty
+ * scope list returns `null` and the caller must answer zero-safe without
+ * querying. One organization's site set is never applied to another's rows.
+ */
+function alertsMultiOrgDeviceCondition(
+  scopes: readonly LiveSiteScopeV1[]
+): SQL | null {
+  const scopesByOrgId = new Map<string, LiveSiteScopeV1>();
+  for (const scope of scopes) {
+    if (scope.kind === 'restricted' && scope.siteIds.length === 0) continue;
+    if (!scopesByOrgId.has(scope.orgId)) scopesByOrgId.set(scope.orgId, scope);
+  }
+
+  const branches = [...scopesByOrgId.values()]
+    .sort((left, right) => left.orgId.localeCompare(right.orgId))
+    .map((scope) => {
+      const orgCondition = eq(devices.orgId, scope.orgId);
+      const siteCondition = alertsDeviceSiteCondition(scope);
+      return siteCondition ? and(orgCondition, siteCondition)! : orgCondition;
+    });
+
+  if (branches.length === 0) return null;
+  return branches.length === 1 ? branches[0]! : or(...branches)!;
+}
+
+function scopeAdmitsSite(scope: LiveSiteScopeV1, siteId: string): boolean {
+  return scope.kind === 'unrestricted' || scope.siteIds.includes(siteId);
+}
 
 function emptyMetricsData() {
   return {
@@ -225,20 +284,82 @@ dataRoutes.get(
 
     const orgIds = await getOrgIdsForAuth(auth);
     if (orgIds !== null && orgIds.length === 0) {
-      return c.json({ data: { bySeverity: {}, byStatus: {}, byDay: [], topRules: [] }, total: 0 });
+      return c.json(emptyAlertsSummary());
     }
-
-    // Build conditions
-    const conditions: ReturnType<typeof eq>[] = [];
 
     if (query.orgId) {
       const hasAccess = await ensureOrgAccess(query.orgId, auth);
       if (!hasAccess) {
         return c.json({ error: 'Access to this organization denied' }, 403);
       }
+    }
+
+    // ── Authority mode: resolved once, before any aggregate query ───────────
+    // Organization tokens and any request naming an explicit organization
+    // derive one exact-organization scope so an organization membership's
+    // site_ids beats a broader partner fallback. A partner without an explicit
+    // organization gets one composite per-organization predicate. A system
+    // caller without an explicit organization is unrestricted per row.
+    let deviceScopeCondition: SQL | undefined;
+    const exactOrgId =
+      query.orgId ?? (auth.scope === 'organization' ? auth.orgId ?? undefined : undefined);
+
+    if (exactOrgId) {
+      const authorityResult = await resolveRequestReportAuthority(auth, exactOrgId, 'export');
+      if (!authorityResult.ok) {
+        return authorityResult.reason === 'empty_scope'
+          ? c.json(emptyAlertsSummary())
+          : c.json({ error: 'Access to this organization denied' }, 403);
+      }
+      const scope = authorityResult.authority.scope;
+      if (scope.kind === 'legacy_unscoped') {
+        return c.json({ error: 'Access to this organization denied' }, 403);
+      }
+      if (query.siteId && !scopeAdmitsSite(scope, query.siteId)) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      deviceScopeCondition = alertsDeviceSiteCondition(scope);
+    } else if (auth.scope === 'organization') {
+      // Organization token without an organization: nothing is authorized.
+      return c.json(emptyAlertsSummary());
+    } else if (auth.scope === 'partner') {
+      const authorityMap = await resolveRequestReportAuthorityMap(auth, orgIds ?? [], 'export');
+      const authorizedScopes: LiveSiteScopeV1[] = [];
+      for (const result of authorityMap.values()) {
+        if (!result.ok) continue;
+        const scope = result.authority.scope;
+        if (scope.kind === 'legacy_unscoped') continue;
+        authorizedScopes.push(scope);
+      }
+      const compositeCondition = alertsMultiOrgDeviceCondition(authorizedScopes);
+      if (!compositeCondition) {
+        return c.json(emptyAlertsSummary());
+      }
+      if (
+        query.siteId &&
+        !authorizedScopes.some((scope) => scopeAdmitsSite(scope, query.siteId!))
+      ) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      deviceScopeCondition = compositeCondition;
+    }
+
+    // Build conditions. `deviceScopeCondition` is a single object reused by
+    // every aggregate below — never re-expressed per query.
+    const conditions: SQL[] = [];
+
+    if (query.orgId) {
       conditions.push(eq(alerts.orgId, query.orgId));
     } else if (orgIds) {
       conditions.push(inArray(alerts.orgId, orgIds));
+    }
+
+    if (deviceScopeCondition) {
+      conditions.push(deviceScopeCondition);
+    }
+
+    if (query.siteId) {
+      conditions.push(eq(devices.siteId, query.siteId));
     }
 
     if (query.startDate) {
@@ -258,6 +379,7 @@ dataRoutes.get(
         count: sql<number>`count(*)`
       })
       .from(alerts)
+      .innerJoin(devices, eq(alerts.deviceId, devices.id))
       .where(whereCondition)
       .groupBy(alerts.severity);
 
@@ -268,6 +390,7 @@ dataRoutes.get(
         count: sql<number>`count(*)`
       })
       .from(alerts)
+      .innerJoin(devices, eq(alerts.deviceId, devices.id))
       .where(whereCondition)
       .groupBy(alerts.status);
 
@@ -281,11 +404,8 @@ dataRoutes.get(
         count: sql<number>`count(*)`
       })
       .from(alerts)
-      .where(
-        conditions.length > 0
-          ? and(...conditions, gte(alerts.triggeredAt, thirtyDaysAgo))
-          : gte(alerts.triggeredAt, thirtyDaysAgo)
-      )
+      .innerJoin(devices, eq(alerts.deviceId, devices.id))
+      .where(and(...conditions, gte(alerts.triggeredAt, thirtyDaysAgo)))
       .groupBy(sql`date_trunc('day', ${alerts.triggeredAt})`)
       .orderBy(sql`date_trunc('day', ${alerts.triggeredAt})`);
 
@@ -298,6 +418,7 @@ dataRoutes.get(
       })
       .from(alerts)
       .innerJoin(alertRules, eq(alerts.ruleId, alertRules.id))
+      .innerJoin(devices, eq(alerts.deviceId, devices.id))
       .where(whereCondition)
       .groupBy(alerts.ruleId, alertRules.name)
       .orderBy(desc(sql`count(*)`))
@@ -307,6 +428,7 @@ dataRoutes.get(
     const countResult = await db
       .select({ count: sql<number>`count(*)` })
       .from(alerts)
+      .innerJoin(devices, eq(alerts.deviceId, devices.id))
       .where(whereCondition);
 
     return c.json({

--- a/apps/api/src/routes/reports/generate.ts
+++ b/apps/api/src/routes/reports/generate.ts
@@ -2,8 +2,13 @@ import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
-import { generateReport, siteScopeRequestAllowed, type ReportResult } from '../../services/reportGenerationService';
-import { PERMISSIONS, type UserPermissions } from '../../services/permissions';
+import {
+  generateReport,
+  UnexecutableReportScopeError,
+  type ReportResult,
+} from '../../services/reportGenerationService';
+import { PERMISSIONS } from '../../services/permissions';
+import { resolveRequestReportAuthority } from '../../services/siteScope';
 import { ensureOrgAccess } from './helpers';
 import { generateReportSchema } from './schemas';
 
@@ -48,13 +53,29 @@ generateRoutes.post(
 
     // Generate report data based on type
     const config = data.config || {};
-    const perms = c.get('permissions') as UserPermissions | undefined;
-
-    if (!(await siteScopeRequestAllowed(orgId!, config, perms))) {
+    const authorityResult = await resolveRequestReportAuthority(
+      auth,
+      orgId!,
+      'read',
+    );
+    if (!authorityResult.ok) {
       return c.json({ error: 'Device not found or access denied' }, 403);
     }
 
-    const reportData: ReportResult = await generateReport(data.type, orgId!, config, perms);
+    let reportData: ReportResult;
+    try {
+      reportData = await generateReport(
+        data.type,
+        orgId!,
+        config,
+        authorityResult.authority,
+      );
+    } catch (error) {
+      if (error instanceof UnexecutableReportScopeError) {
+        return c.json({ error: 'Device not found or access denied' }, 403);
+      }
+      throw error;
+    }
 
     writeRouteAudit(c, {
       orgId: orgId ?? auth.orgId,

--- a/apps/api/src/routes/reports/helpers.ts
+++ b/apps/api/src/routes/reports/helpers.ts
@@ -1,7 +1,14 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { reports, reportRuns } from '../../db/schema';
 import type { AuthContext } from '../../middleware/auth';
+import {
+  decodeSiteScope,
+  isSiteScopeSubset,
+  reportDefinitionScopeSqlPredicate,
+  resolveRequestReportAuthority,
+  type PersistedSiteScopeColumns,
+} from '../../services/siteScope';
 
 export { getPagination } from '../../utils/pagination';
 
@@ -23,24 +30,102 @@ export async function ensureOrgAccess(
 
 export async function getReportWithOrgCheck(
   reportId: string,
-  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>
+  auth: AuthContext,
 ) {
+  const metadataCondition = tenantAuthorizedReportCondition(reportId, auth);
+  const [metadata] = await db
+    .select(reportDefinitionMetadataProjection)
+    .from(reports)
+    .where(metadataCondition)
+    .limit(1);
+
+  if (!metadata) {
+    return null;
+  }
+
+  const authorityResult = await resolveRequestReportAuthority(
+    auth,
+    metadata.orgId,
+    'read',
+  );
+  if (!authorityResult.ok || authorityResult.authority.scope.kind === 'legacy_unscoped') {
+    return null;
+  }
+
+  try {
+    const storedScope = decodeSiteScope(
+      metadata as unknown as PersistedSiteScopeColumns,
+      metadata.orgId,
+    );
+    if (!isSiteScopeSubset(storedScope, authorityResult.authority.scope)) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  const scopePredicate = reportDefinitionScopeSqlPredicate(
+    reports,
+    authorityResult.authority.scope,
+  );
   const [report] = await db
     .select()
     .from(reports)
-    .where(eq(reports.id, reportId))
+    .where(
+      and(
+        eq(reports.id, reportId),
+        eq(reports.orgId, metadata.orgId),
+        scopePredicate,
+      ),
+    )
     .limit(1);
 
-  if (!report) {
+  if (!report) return null;
+
+  try {
+    const storedScope = decodeSiteScope(
+      report as unknown as PersistedSiteScopeColumns,
+      report.orgId,
+    );
+    return isSiteScopeSubset(storedScope, authorityResult.authority.scope)
+      ? report
+      : null;
+  } catch {
     return null;
   }
+}
 
-  const hasAccess = await ensureOrgAccess(report.orgId, auth);
-  if (!hasAccess) {
-    return null;
+export const reportDefinitionMetadataProjection = {
+  id: reports.id,
+  orgId: reports.orgId,
+  executionScopeVersion: reports.executionScopeVersion,
+  executionScopeKind: reports.executionScopeKind,
+  executionScopeSiteIds: reports.executionScopeSiteIds,
+  executionScopeUserId: reports.executionScopeUserId,
+  executionScopeFingerprint: reports.executionScopeFingerprint,
+  executionScopeCapturedAt: reports.executionScopeCapturedAt,
+};
+
+export function tenantAuthorizedReportCondition(
+  reportId: string,
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds'>,
+): SQL<unknown> {
+  const idCondition = eq(reports.id, reportId);
+
+  if (auth.scope === 'organization') {
+    return auth.orgId
+      ? and(idCondition, eq(reports.orgId, auth.orgId))!
+      : sql<unknown>`FALSE`;
   }
 
-  return report;
+  if (auth.scope === 'partner') {
+    const orgIds = auth.accessibleOrgIds ?? [];
+    return orgIds.length > 0
+      ? and(idCondition, inArray(reports.orgId, orgIds))!
+      : sql<unknown>`FALSE`;
+  }
+
+  return idCondition;
 }
 
 export async function getReportRunWithOrgCheck(

--- a/apps/api/src/routes/reports/helpers.ts
+++ b/apps/api/src/routes/reports/helpers.ts
@@ -6,8 +6,12 @@ import {
   decodeSiteScope,
   isSiteScopeSubset,
   reportDefinitionScopeSqlPredicate,
+  reportRunScopeSqlPredicate,
   resolveRequestReportAuthority,
+  type LiveSiteScopeV1,
   type PersistedSiteScopeColumns,
+  type ReportAction,
+  type ReportExecutionAuthority,
 } from '../../services/siteScope';
 
 export { getPagination } from '../../utils/pagination';
@@ -130,37 +134,72 @@ export function tenantAuthorizedReportCondition(
 
 export async function getReportRunWithOrgCheck(
   runId: string,
-  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>
+  auth: AuthContext,
+  action: ReportAction,
 ) {
-  const [run] = await db
-    .select({
-      id: reportRuns.id,
-      reportId: reportRuns.reportId,
-      status: reportRuns.status,
-      startedAt: reportRuns.startedAt,
-      completedAt: reportRuns.completedAt,
-      outputUrl: reportRuns.outputUrl,
-      errorMessage: reportRuns.errorMessage,
-      rowCount: reportRuns.rowCount,
-      createdAt: reportRuns.createdAt,
-      orgId: reports.orgId
-    })
+  const tenantConditions: SQL<unknown>[] = [eq(reportRuns.id, runId)];
+  if (auth.scope === 'organization') {
+    if (!auth.orgId) return null;
+    tenantConditions.push(eq(reports.orgId, auth.orgId));
+  } else if (auth.scope === 'partner') {
+    const orgIds = auth.accessibleOrgIds ?? [];
+    if (orgIds.length === 0) return null;
+    tenantConditions.push(inArray(reports.orgId, orgIds));
+  }
+
+  const [metadata] = await db
+    .select(reportRunMetadataProjection)
     .from(reportRuns)
     .innerJoin(reports, eq(reportRuns.reportId, reports.id))
-    .where(eq(reportRuns.id, runId))
+    .where(and(...tenantConditions))
     .limit(1);
 
-  if (!run) {
+  if (!metadata) return null;
+
+  const authorityResult = await resolveRequestReportAuthority(
+    auth,
+    metadata.orgId,
+    action,
+  );
+  if (!authorityResult.ok || authorityResult.authority.scope.kind === 'legacy_unscoped') {
     return null;
   }
 
-  const hasAccess = await ensureOrgAccess(run.orgId, auth);
-  if (!hasAccess) {
+  try {
+    const storedScope = decodeSiteScope(
+      metadata as unknown as PersistedSiteScopeColumns,
+      metadata.orgId,
+    );
+    if (!isSiteScopeSubset(storedScope, authorityResult.authority.scope)) {
+      return null;
+    }
+  } catch {
     return null;
   }
 
-  return run;
+  return {
+    metadata,
+    authority: authorityResult.authority as ReportExecutionAuthority & {
+      scope: LiveSiteScopeV1;
+    },
+    runScopePredicate: reportRunScopeSqlPredicate(
+      reportRuns,
+      authorityResult.authority.scope,
+    ),
+  };
 }
+
+export const reportRunMetadataProjection = {
+  id: reportRuns.id,
+  reportId: reportRuns.reportId,
+  orgId: reports.orgId,
+  executionScopeVersion: reportRuns.executionScopeVersion,
+  executionScopeKind: reportRuns.executionScopeKind,
+  executionScopeSiteIds: reportRuns.executionScopeSiteIds,
+  executionScopeUserId: reportRuns.executionScopeUserId,
+  executionScopeFingerprint: reportRuns.executionScopeFingerprint,
+  executionScopeCapturedAt: reportRuns.executionScopeCapturedAt,
+};
 
 export async function getOrgIdsForAuth(
   auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds'>

--- a/apps/api/src/routes/reports/runs.ts
+++ b/apps/api/src/routes/reports/runs.ts
@@ -1,16 +1,36 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
-import { and, eq, sql, desc, inArray } from 'drizzle-orm';
+import { and, eq, sql, desc, inArray, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { reports, reportRuns } from '../../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
-import { generateReport, previousBaselineFor, siteScopeRequestAllowed, type ReportResult } from '../../services/reportGenerationService';
+import {
+  assertReportExecutionPreflight,
+  generateReport,
+  previousBaselineFor,
+  UnexecutableReportScopeError,
+  type ReportResult,
+} from '../../services/reportGenerationService';
 import { rowsToCsv, rowsToTsv } from '@breeze/shared';
-import { getPagination, ensureOrgAccess, getReportWithOrgCheck, getReportRunWithOrgCheck } from './helpers';
+import { getPagination, getReportWithOrgCheck, getReportRunWithOrgCheck } from './helpers';
 import { downloadQuerySchema, listRunsSchema } from './schemas';
-import type { UserPermissions } from '../../services/permissions';
+import {
+  decodeSiteScope,
+  intersectSiteScopes,
+  isSiteScopeSubset,
+  persistedSiteScopeValues,
+  reportRunMultiOrgScopeSqlPredicate,
+  reportRunScopeSqlPredicate,
+  resolveRequestReportAuthority,
+  resolveRequestReportAuthorityMap,
+  siteScopeFingerprint,
+  unrestrictedReportRunScopeSqlPredicate,
+  type LiveSiteScopeV1,
+  type PersistedSiteScopeColumns,
+  type ReportExecutionAuthority,
+} from '../../services/siteScope';
 
 export const runsRoutes = new Hono();
 
@@ -30,13 +50,60 @@ runsRoutes.post(
       return c.json({ error: 'Report not found' }, 404);
     }
 
+    const liveResult = await resolveRequestReportAuthority(
+      auth,
+      report.orgId,
+      'read',
+    );
+    if (!liveResult.ok || liveResult.authority.scope.kind === 'legacy_unscoped') {
+      return c.json({ error: 'Access to report scope denied' }, 403);
+    }
+
+    let executionAuthority: ReportExecutionAuthority;
+    try {
+      const persistedScope = decodeSiteScope(
+        report as unknown as PersistedSiteScopeColumns,
+        report.orgId,
+      );
+      const effectiveScope = intersectSiteScopes(
+        persistedScope,
+        liveResult.authority.scope,
+      );
+      if (
+        !effectiveScope
+        || effectiveScope.kind === 'legacy_unscoped'
+        || (effectiveScope.kind === 'restricted' && effectiveScope.siteIds.length === 0)
+      ) {
+        return c.json({ error: 'Access to report scope denied' }, 403);
+      }
+      executionAuthority = {
+        scope: effectiveScope,
+        principalUserId: liveResult.authority.principalUserId,
+        capturedAt: liveResult.authority.capturedAt,
+        fingerprint: siteScopeFingerprint(effectiveScope),
+      };
+    } catch {
+      return c.json({ error: 'Report not found' }, 404);
+    }
+
+    const config = (report.config ?? {}) as Record<string, unknown>;
+    try {
+      assertReportExecutionPreflight(report.orgId, config, executionAuthority);
+    } catch (error) {
+      if (error instanceof UnexecutableReportScopeError) {
+        return c.json({ error: 'Access to report scope denied' }, 403);
+      }
+      throw error;
+    }
+
     // Create a new report run
     const [run] = await db
       .insert(reportRuns)
       .values({
         reportId: report.id,
         status: 'pending',
-        startedAt: new Date()
+        startedAt: new Date(),
+        ...persistedSiteScopeValues(executionAuthority),
       })
       .returning();
 
@@ -53,25 +120,22 @@ runsRoutes.post(
       details: { reportId: report.id }
     });
 
-    const perms = c.get('permissions') as UserPermissions | undefined;
-    const config = (report.config ?? {}) as Record<string, unknown>;
-
-    if (!(await siteScopeRequestAllowed(report.orgId, config, perms))) {
-      await db
-        .update(reportRuns)
-        .set({ status: 'failed', completedAt: new Date(), errorMessage: 'Access to report scope denied' })
-        .where(eq(reportRuns.id, run.id));
-      return c.json({ error: 'Access to report scope denied' }, 403);
-    }
-
     await db
       .update(reports)
       .set({ lastGeneratedAt: new Date(), updatedAt: new Date() })
       .where(eq(reports.id, reportId));
 
     try {
-      const result = await generateReport(report.type, report.orgId, config, perms);
-      const previous = await previousBaselineFor(report.id);
+      const result = await generateReport(
+        report.type,
+        report.orgId,
+        config,
+        executionAuthority,
+      );
+      const previous = await previousBaselineFor(
+        report.id,
+        executionAuthority.fingerprint,
+      );
       if (previous) result.previous = previous;
       const rowCount = result.rowCount ?? (Array.isArray(result.rows) ? result.rows.length : 0);
       await db
@@ -110,25 +174,50 @@ runsRoutes.get(
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
 
-    // Build conditions array
-    const conditions: ReturnType<typeof eq>[] = [];
+    const conditions: SQL<unknown>[] = [];
+    let runScopePredicate: SQL<unknown>;
 
-    // Filter by org access based on scope
     if (auth.scope === 'organization') {
       if (!auth.orgId) {
         return c.json({ error: 'Organization context required' }, 403);
       }
+      const result = await resolveRequestReportAuthority(auth, auth.orgId, 'read');
+      if (!result.ok || result.authority.scope.kind === 'legacy_unscoped') {
+        return c.json({ data: [], pagination: { page, limit, total: 0 } });
+      }
       conditions.push(eq(reports.orgId, auth.orgId));
+      runScopePredicate = reportRunScopeSqlPredicate(
+        reportRuns,
+        result.authority.scope,
+      );
     } else if (auth.scope === 'partner') {
       const orgIds = auth.accessibleOrgIds ?? [];
-      if (orgIds.length === 0) {
-        return c.json({
-          data: [],
-          pagination: { page, limit, total: 0 }
-        });
+      const authorityMap = await resolveRequestReportAuthorityMap(
+        auth,
+        orgIds,
+        'read',
+      );
+      const scopes: LiveSiteScopeV1[] = [];
+      for (const result of authorityMap.values()) {
+        if (result.ok && result.authority.scope.kind !== 'legacy_unscoped') {
+          scopes.push(result.authority.scope);
+        }
       }
-      conditions.push(inArray(reports.orgId, orgIds));
+      conditions.push(
+        orgIds.length > 0
+          ? inArray(reports.orgId, orgIds)
+          : sql<unknown>`FALSE`,
+      );
+      runScopePredicate = reportRunMultiOrgScopeSqlPredicate(
+        reports.orgId,
+        reportRuns,
+        scopes,
+      );
+    } else {
+      runScopePredicate = unrestrictedReportRunScopeSqlPredicate(reportRuns);
     }
+
+    conditions.push(runScopePredicate);
 
     // Additional filters
     if (query.reportId) {
@@ -189,25 +278,43 @@ runsRoutes.get(
     const runId = c.req.param('id')!;
     const { format: requestedFormat } = c.req.valid('query');
 
-    const run = await getReportRunWithOrgCheck(runId, auth);
-    if (!run) {
+    const access = await getReportRunWithOrgCheck(runId, auth, 'export');
+    if (!access) {
       return c.json({ error: 'Report run not found' }, 404);
-    }
-    if (run.status !== 'completed') {
-      return c.json({ error: 'Report run is not completed' }, 409);
     }
 
     const [row] = await db
       .select({
+        id: reportRuns.id,
+        reportId: reportRuns.reportId,
+        orgId: reports.orgId,
+        status: reportRuns.status,
         result: reportRuns.result,
         reportType: reports.type,
         reportName: reports.name,
-        reportFormat: reports.format
+        reportFormat: reports.format,
+        executionScopeVersion: reportRuns.executionScopeVersion,
+        executionScopeKind: reportRuns.executionScopeKind,
+        executionScopeSiteIds: reportRuns.executionScopeSiteIds,
+        executionScopeUserId: reportRuns.executionScopeUserId,
+        executionScopeFingerprint: reportRuns.executionScopeFingerprint,
+        executionScopeCapturedAt: reportRuns.executionScopeCapturedAt,
       })
       .from(reportRuns)
       .innerJoin(reports, eq(reportRuns.reportId, reports.id))
-      .where(eq(reportRuns.id, runId))
+      .where(and(
+        eq(reportRuns.id, runId),
+        eq(reports.orgId, access.metadata.orgId),
+        access.runScopePredicate,
+      ))
       .limit(1);
+
+    if (!row || !runPayloadMatchesAuthority(row, access.authority.scope)) {
+      return c.json({ error: 'Report run not found' }, 404);
+    }
+    if (row.status !== 'completed') {
+      return c.json({ error: 'Report run is not completed' }, 409);
+    }
 
     const result = (row?.result ?? null) as ReportResult | null;
     const rows = Array.isArray(result?.rows) ? (result!.rows as unknown[]) : [];
@@ -245,26 +352,68 @@ runsRoutes.get(
     const auth = c.get('auth');
     const runId = c.req.param('id')!;
 
-    const run = await getReportRunWithOrgCheck(runId, auth);
-    if (!run) {
+    const access = await getReportRunWithOrgCheck(runId, auth, 'read');
+    if (!access) {
       return c.json({ error: 'Report run not found' }, 404);
     }
 
-    // Get the associated report
-    const [report] = await db
-      .select()
-      .from(reports)
-      .where(eq(reports.id, run.reportId))
+    const [run] = await db
+      .select({
+        id: reportRuns.id,
+        reportId: reportRuns.reportId,
+        orgId: reports.orgId,
+        status: reportRuns.status,
+        startedAt: reportRuns.startedAt,
+        completedAt: reportRuns.completedAt,
+        outputUrl: reportRuns.outputUrl,
+        errorMessage: reportRuns.errorMessage,
+        rowCount: reportRuns.rowCount,
+        createdAt: reportRuns.createdAt,
+        executionScopeVersion: reportRuns.executionScopeVersion,
+        executionScopeKind: reportRuns.executionScopeKind,
+        executionScopeSiteIds: reportRuns.executionScopeSiteIds,
+        executionScopeUserId: reportRuns.executionScopeUserId,
+        executionScopeFingerprint: reportRuns.executionScopeFingerprint,
+        executionScopeCapturedAt: reportRuns.executionScopeCapturedAt,
+        reportName: reports.name,
+        reportType: reports.type,
+        reportFormat: reports.format,
+      })
+      .from(reportRuns)
+      .innerJoin(reports, eq(reportRuns.reportId, reports.id))
+      .where(and(
+        eq(reportRuns.id, runId),
+        eq(reports.orgId, access.metadata.orgId),
+        access.runScopePredicate,
+      ))
       .limit(1);
+
+    if (!run || !runPayloadMatchesAuthority(run, access.authority.scope)) {
+      return c.json({ error: 'Report run not found' }, 404);
+    }
 
     return c.json({
       ...run,
-      report: report ? {
-        id: report.id,
-        name: report.name,
-        type: report.type,
-        format: report.format
-      } : null
+      report: {
+        id: run.reportId,
+        name: run.reportName,
+        type: run.reportType,
+        format: run.reportFormat,
+      },
     });
   }
 );
+
+function runPayloadMatchesAuthority(
+  row: { orgId: string },
+  currentScope: LiveSiteScopeV1,
+): boolean {
+  try {
+    return isSiteScopeSubset(
+      decodeSiteScope(row as unknown as PersistedSiteScopeColumns, row.orgId),
+      currentScope,
+    );
+  } catch {
+    return false;
+  }
+}

--- a/apps/api/src/services/aiToolsFleet.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleet.siteScope.test.ts
@@ -1,6 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
-const { deleteSpy } = vi.hoisted(() => ({ deleteSpy: vi.fn() }));
+const { deleteSpy, reportScopeMocks, reportPreflightMock } = vi.hoisted(() => ({
+  deleteSpy: vi.fn(),
+  reportPreflightMock: vi.fn(),
+  reportScopeMocks: {
+    resolveRequestReportAuthority: vi.fn(),
+    resolveRequestReportAuthorityMap: vi.fn(),
+    decodeSiteScope: vi.fn(),
+    isSiteScopeSubset: vi.fn(),
+    intersectSiteScopes: vi.fn(),
+    siteScopeFingerprint: vi.fn(),
+    persistedSiteScopeValues: vi.fn(),
+    reportDefinitionScopeSqlPredicate: vi.fn(),
+    reportDefinitionMultiOrgScopeSqlPredicate: vi.fn(),
+    unrestrictedReportDefinitionScopeSqlPredicate: vi.fn(),
+    reportRunScopeSqlPredicate: vi.fn(),
+    reportRunMultiOrgScopeSqlPredicate: vi.fn(),
+    unrestrictedReportRunScopeSqlPredicate: vi.fn(),
+  },
+}));
 vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: any) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
@@ -17,20 +37,31 @@ vi.mock('./automationRuntime', async (importOriginal) => {
 });
 vi.mock('./reportGenerationService', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./reportGenerationService')>();
-  return { ...actual, siteScopeRequestAllowed: vi.fn() };
+  return {
+    ...actual,
+    assertReportExecutionPreflight: (...args: unknown[]) => reportPreflightMock(...args),
+  };
 });
+vi.mock('./siteScope', () => reportScopeMocks);
 
 import { db } from '../db';
 import { registerFleetTools } from './aiToolsFleet';
 import { checkAutomationTargetsWithinSiteScope } from './automationRuntime';
-import { siteScopeRequestAllowed } from './reportGenerationService';
+import {
+  reportRunScopeSqlPredicate,
+  resolveRequestReportAuthority,
+} from './siteScope';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 
 const mockCheck = checkAutomationTargetsWithinSiteScope as unknown as ReturnType<typeof vi.fn>;
-const mockSiteScopeReq = siteScopeRequestAllowed as unknown as ReturnType<typeof vi.fn>;
 
-const mockDb = db as unknown as { select: ReturnType<typeof vi.fn>; insert: ReturnType<typeof vi.fn> };
+const mockDb = db as unknown as {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  transaction: ReturnType<typeof vi.fn>;
+};
 function handlerFor(name: string): AiTool['handler'] {
   const reg = new Map<string, AiTool>();
   registerFleetTools(reg);
@@ -44,6 +75,20 @@ function makeAuth(allowedSiteIds?: string[]): AuthContext {
     allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
   };
 }
+
+reportScopeMocks.resolveRequestReportAuthority.mockImplementation(
+  async (auth: AuthContext, orgId: string) => ({
+    ok: true,
+    authority: {
+      scope: auth.allowedSiteIds === undefined
+        ? { version: 1, kind: 'unrestricted', orgId }
+        : { version: 1, kind: 'restricted', orgId, siteIds: auth.allowedSiteIds },
+      principalUserId: auth.user.id,
+      capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+      fingerprint: auth.allowedSiteIds === undefined ? 'f'.repeat(64) : 'a'.repeat(64),
+    },
+  }),
+);
 
 describe('manage_patches — per-device site scoping', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -140,17 +185,24 @@ describe('report data device_inventory — site narrowing', () => {
 
   it('site-restricted caller with no in-scope devices gets empty inventory', async () => {
     let inventoryRan = false;
+    let inventoryCondition: SQL | undefined;
     mockDb.select.mockImplementation((cols?: unknown) => {
       if (cols && typeof cols === 'object' && 'id' in (cols as object) && 'siteId' in (cols as object) && Object.keys(cols as object).length === 2) {
         return { from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-FORBIDDEN' }]) }) };
       }
       inventoryRan = true;
-      return { from: () => ({ leftJoin: () => ({ where: () => ({ orderBy: () => ({ limit: () => Promise.resolve([]) }) }) }) }) };
+      return { from: () => ({ leftJoin: () => ({ where: (condition: SQL) => {
+        inventoryCondition = condition;
+        return { orderBy: () => ({ limit: () => Promise.resolve([]) }) };
+      } }) }) };
     });
     const r = await handlerFor('generate_report')({ action: 'data', reportType: 'device_inventory' }, makeAuth(['site-A']));
     const parsed = JSON.parse(r);
     expect(parsed.showing).toBe(0);
-    expect(inventoryRan).toBe(false);
+    expect(inventoryRan).toBe(true);
+    const rendered = new PgDialect().sqlToQuery(inventoryCondition!);
+    expect(rendered.params).toContain('site-A');
+    expect(rendered.params).not.toContain('site-FORBIDDEN');
   });
 });
 
@@ -304,29 +356,186 @@ describe('SR5-05 manage_automations — target site scoping', () => {
 
 // ── SR5-06: generate_report (history/download scope gate) ──────────────────────
 describe('SR5-06 generate_report — run scope gating', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reportScopeMocks.resolveRequestReportAuthority.mockResolvedValue({
+      ok: true,
+      authority: {
+        scope: { version: 1, kind: 'unrestricted', orgId: 'org-1' },
+        principalUserId: 'u1',
+        capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+        fingerprint: 'f'.repeat(64),
+      },
+    });
+    reportScopeMocks.decodeSiteScope.mockReturnValue({
+      version: 1,
+      kind: 'unrestricted',
+      orgId: 'org-1',
+    });
+    reportScopeMocks.isSiteScopeSubset.mockReturnValue(true);
+    reportScopeMocks.reportRunScopeSqlPredicate.mockReturnValue({
+      op: 'run-scope',
+    });
+  });
 
-  const runRow = { id: 'run1', reportId: 'rep1', status: 'completed', reportOrgId: 'org-1', reportConfig: {}, outputUrl: 'u', reportName: 'N', reportType: 't', reportFormat: 'csv', rowCount: 1, completedAt: null };
+  const runRow = {
+    id: 'run1',
+    reportId: 'rep1',
+    status: 'completed',
+    orgId: 'org-1',
+    reportOrgId: 'org-1',
+    outputUrl: 'u',
+    reportName: 'N',
+    reportType: 't',
+    reportFormat: 'csv',
+    rowCount: 1,
+    completedAt: null,
+    executionScopeVersion: 1,
+    executionScopeKind: 'unrestricted',
+    executionScopeSiteIds: null,
+    executionScopeUserId: 'u1',
+    executionScopeFingerprint: 'f'.repeat(64),
+    executionScopeCapturedAt: new Date('2026-07-25T12:00:00.000Z'),
+  };
+
+  const definitionRow = {
+    id: 'rep1',
+    orgId: 'org-1',
+    name: 'Scoped report',
+    type: 'device_inventory',
+    config: { filters: { siteIds: ['site-B'] } },
+    executionScopeVersion: 1,
+    executionScopeKind: 'unrestricted',
+    executionScopeSiteIds: null,
+    executionScopeUserId: 'u1',
+    executionScopeFingerprint: 'f'.repeat(64),
+    executionScopeCapturedAt: new Date('2026-07-25T12:00:00.000Z'),
+  };
+
+  function definitionSelectChain() {
+    return {
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([definitionRow]) }),
+      }),
+    };
+  }
 
   it('download denies when the report scope exceeds the caller sites', async () => {
-    mockSiteScopeReq.mockResolvedValue(false);
+    reportScopeMocks.resolveRequestReportAuthority.mockResolvedValueOnce({
+      ok: false,
+      reason: 'permission_removed',
+    });
     mockDb.select.mockReturnValue({ from: () => ({ innerJoin: () => ({ where: () => ({ limit: () => Promise.resolve([runRow]) }) }) }) });
     const r = await handlerFor('generate_report')({ action: 'download', reportRunId: 'run1' }, makeAuth(['site-A']));
-    expect(r).toContain('report scope denied');
+    expect(r).toContain('Report run not found');
+    expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+      expect.anything(),
+      'org-1',
+      'export',
+    );
+    expect(reportRunScopeSqlPredicate).not.toHaveBeenCalled();
   });
 
   it('download allows an unrestricted caller (no regression)', async () => {
-    mockSiteScopeReq.mockResolvedValue(true);
     mockDb.select.mockReturnValue({ from: () => ({ innerJoin: () => ({ where: () => ({ limit: () => Promise.resolve([runRow]) }) }) }) });
     const r = await handlerFor('generate_report')({ action: 'download', reportRunId: 'run1' }, makeAuth(undefined));
     expect(JSON.parse(r).outputUrl).toBe('u');
+    expect(resolveRequestReportAuthority).toHaveBeenCalledWith(
+      expect.anything(),
+      'org-1',
+      'export',
+    );
+    expect(reportRunScopeSqlPredicate).toHaveBeenCalled();
   });
 
   it('report data alert_summary zeroes out for a zero-site restricted caller', async () => {
+    reportScopeMocks.resolveRequestReportAuthority.mockResolvedValueOnce({
+      ok: true,
+      authority: {
+        scope: { version: 1, kind: 'restricted', orgId: 'org-1', siteIds: [] },
+        principalUserId: 'u1',
+        capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+        fingerprint: 'a'.repeat(64),
+      },
+    });
     // resolveSiteAllowedDeviceIds → org devices, all filtered out by the empty allowlist.
     mockDb.select.mockReturnValue({ from: () => ({ where: () => Promise.resolve([{ id: 'd1', siteId: 'site-A' }]) }) });
     const r = await handlerFor('generate_report')({ action: 'data', reportType: 'alert_summary' }, makeAuth([]));
     expect(JSON.parse(r).data.total).toBe(0);
+  });
+
+  it('does not report update success when the guarded definition mutation loses its scope race', async () => {
+    reportScopeMocks.reportDefinitionScopeSqlPredicate.mockReturnValue({ op: 'definition-scope' });
+    mockDb.select.mockReturnValue(definitionSelectChain());
+    const returning = vi.fn(async () => []);
+    mockDb.update.mockReturnValue({
+      set: () => ({ where: () => ({ returning }) }),
+    });
+
+    const result = JSON.parse(await handlerFor('generate_report')(
+      { action: 'update', reportId: 'rep1', name: 'Renamed' },
+      makeAuth(undefined),
+    ));
+
+    expect(returning).toHaveBeenCalled();
+    expect(result.success).not.toBe(true);
+  });
+
+  it('rejects saved generation config before inserting a run or updating the definition', async () => {
+    const restrictedScope = {
+      version: 1,
+      kind: 'restricted',
+      orgId: 'org-1',
+      siteIds: ['site-A'],
+    };
+    reportScopeMocks.resolveRequestReportAuthority.mockResolvedValue({
+      ok: true,
+      authority: {
+        scope: restrictedScope,
+        principalUserId: 'u1',
+        capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+        fingerprint: 'a'.repeat(64),
+      },
+    });
+    reportScopeMocks.decodeSiteScope.mockReturnValue(restrictedScope);
+    reportScopeMocks.intersectSiteScopes.mockReturnValue(restrictedScope);
+    reportScopeMocks.isSiteScopeSubset.mockReturnValue(true);
+    reportScopeMocks.siteScopeFingerprint.mockReturnValue('a'.repeat(64));
+    mockDb.select.mockReturnValue(definitionSelectChain());
+    reportPreflightMock.mockImplementationOnce(() => {
+      throw new Error('outside authority');
+    });
+
+    const result = JSON.parse(await handlerFor('generate_report')(
+      { action: 'generate', reportId: 'rep1' },
+      makeAuth(['site-A']),
+    ));
+
+    expect(reportPreflightMock).toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(result.success).not.toBe(true);
+  });
+
+  it('rolls back run deletion when the guarded definition delete loses its scope race', async () => {
+    reportScopeMocks.reportDefinitionScopeSqlPredicate.mockReturnValue({ op: 'definition-scope' });
+    mockDb.select.mockReturnValue(definitionSelectChain());
+    const definitionReturning = vi.fn(async () => []);
+    let deleteCall = 0;
+    const txDelete = vi.fn(() => ++deleteCall === 1
+      ? { where: () => Promise.resolve([]) }
+      : { where: () => ({ returning: definitionReturning }) });
+    mockDb.transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => fn({
+      delete: txDelete,
+    }));
+
+    const result = JSON.parse(await handlerFor('generate_report')(
+      { action: 'delete', reportId: 'rep1' },
+      makeAuth(undefined),
+    ));
+
+    expect(definitionReturning).toHaveBeenCalled();
+    expect(result.success).not.toBe(true);
   });
 });
 

--- a/apps/api/src/services/aiToolsFleet.ts
+++ b/apps/api/src/services/aiToolsFleet.ts
@@ -64,7 +64,24 @@ import type { UserPermissions } from './permissions';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from './partnerWideAccess';
 import { deviceSiteDenied, deviceIdSiteDenied, resolveSiteAllowedDeviceIds } from './aiToolsSiteScope';
 import { checkAutomationTargetsWithinSiteScope } from './automationRuntime';
-import { siteScopeRequestAllowed } from './reportGenerationService';
+import { assertReportExecutionPreflight } from './reportGenerationService';
+import {
+  decodeSiteScope,
+  intersectSiteScopes,
+  isSiteScopeSubset,
+  persistedSiteScopeValues,
+  reportDefinitionMultiOrgScopeSqlPredicate,
+  reportDefinitionScopeSqlPredicate,
+  reportRunScopeSqlPredicate,
+  resolveRequestReportAuthority,
+  resolveRequestReportAuthorityMap,
+  siteScopeFingerprint,
+  unrestrictedReportDefinitionScopeSqlPredicate,
+  type LiveSiteScopeV1,
+  type PersistedSiteScopeColumns,
+  type ReportAction,
+  type ReportExecutionAuthority,
+} from './siteScope';
 import { upsertPatchApproval, resolvePartnerIdForOrg } from '../routes/patches/helpers';
 import { sanitizeThrownToolError } from './aiToolErrors';
 
@@ -82,6 +99,146 @@ function getOrgId(auth: AuthContext): string | null {
 
 function orgWhere(auth: AuthContext, orgIdCol: ReturnType<typeof sql.raw> | any): SQL | undefined {
   return auth.orgCondition(orgIdCol) ?? undefined;
+}
+
+const aiReportDefinitionMetadataProjection = {
+  id: reports.id,
+  orgId: reports.orgId,
+  executionScopeVersion: reports.executionScopeVersion,
+  executionScopeKind: reports.executionScopeKind,
+  executionScopeSiteIds: reports.executionScopeSiteIds,
+  executionScopeUserId: reports.executionScopeUserId,
+  executionScopeFingerprint: reports.executionScopeFingerprint,
+  executionScopeCapturedAt: reports.executionScopeCapturedAt,
+};
+
+const aiReportRunMetadataProjection = {
+  id: reportRuns.id,
+  reportId: reportRuns.reportId,
+  orgId: reports.orgId,
+  executionScopeVersion: reportRuns.executionScopeVersion,
+  executionScopeKind: reportRuns.executionScopeKind,
+  executionScopeSiteIds: reportRuns.executionScopeSiteIds,
+  executionScopeUserId: reportRuns.executionScopeUserId,
+  executionScopeFingerprint: reportRuns.executionScopeFingerprint,
+  executionScopeCapturedAt: reportRuns.executionScopeCapturedAt,
+};
+
+async function aiLiveReportAuthority(
+  auth: AuthContext,
+  orgId: string,
+  action: ReportAction,
+): Promise<
+  (Omit<ReportExecutionAuthority, 'scope'> & { scope: LiveSiteScopeV1 }) | null
+> {
+  const result = await resolveRequestReportAuthority(auth, orgId, action);
+  if (!result.ok || result.authority.scope.kind === 'legacy_unscoped') return null;
+  return result.authority as Omit<ReportExecutionAuthority, 'scope'> & {
+    scope: LiveSiteScopeV1;
+  };
+}
+
+async function aiReportDefinitionAccess(
+  auth: AuthContext,
+  reportId: string,
+  action: ReportAction,
+) {
+  const metadataConditions: SQL[] = [eq(reports.id, reportId)];
+  const tenantCondition = orgWhere(auth, reports.orgId);
+  if (tenantCondition) metadataConditions.push(tenantCondition);
+  const [metadata] = await db
+    .select(aiReportDefinitionMetadataProjection)
+    .from(reports)
+    .where(and(...metadataConditions))
+    .limit(1);
+  if (!metadata) return null;
+
+  const authority = await aiLiveReportAuthority(auth, metadata.orgId, action);
+  if (!authority) return null;
+  try {
+    const storedScope = decodeSiteScope(
+      metadata as unknown as PersistedSiteScopeColumns,
+      metadata.orgId,
+    );
+    if (!isSiteScopeSubset(storedScope, authority.scope)) return null;
+  } catch {
+    return null;
+  }
+
+  const predicate = reportDefinitionScopeSqlPredicate(reports, authority.scope);
+  const [report] = await db
+    .select()
+    .from(reports)
+    .where(and(
+      eq(reports.id, reportId),
+      eq(reports.orgId, metadata.orgId),
+      predicate,
+    ))
+    .limit(1);
+  if (!report) return null;
+
+  try {
+    const storedScope = decodeSiteScope(
+      report as unknown as PersistedSiteScopeColumns,
+      report.orgId,
+    );
+    if (!isSiteScopeSubset(storedScope, authority.scope)) return null;
+  } catch {
+    return null;
+  }
+  return { report, authority, predicate };
+}
+
+async function aiReportRunAccess(
+  auth: AuthContext,
+  runId: string,
+  action: ReportAction,
+) {
+  const metadataConditions: SQL[] = [eq(reportRuns.id, runId)];
+  const tenantCondition = orgWhere(auth, reports.orgId);
+  if (tenantCondition) metadataConditions.push(tenantCondition);
+  const [metadata] = await db
+    .select(aiReportRunMetadataProjection)
+    .from(reportRuns)
+    .innerJoin(reports, eq(reportRuns.reportId, reports.id))
+    .where(and(...metadataConditions))
+    .limit(1);
+  if (!metadata) return null;
+
+  const authority = await aiLiveReportAuthority(auth, metadata.orgId, action);
+  if (!authority) return null;
+  try {
+    const storedScope = decodeSiteScope(
+      metadata as unknown as PersistedSiteScopeColumns,
+      metadata.orgId,
+    );
+    if (!isSiteScopeSubset(storedScope, authority.scope)) return null;
+  } catch {
+    return null;
+  }
+  return {
+    metadata,
+    authority,
+    predicate: reportRunScopeSqlPredicate(reportRuns, authority.scope),
+  };
+}
+
+async function aiAuthorityDeviceIds(
+  orgId: string,
+  authority: ReportExecutionAuthority,
+): Promise<string[] | null> {
+  if (authority.scope.kind === 'unrestricted') return null;
+  if (authority.scope.kind !== 'restricted' || authority.scope.siteIds.length === 0) {
+    return [];
+  }
+  const rows = await db
+    .select({ id: devices.id })
+    .from(devices)
+    .where(and(
+      eq(devices.orgId, orgId),
+      inArray(devices.siteId, authority.scope.siteIds),
+    ));
+  return rows.map((row) => row.id);
 }
 
 // Dual-axis access for alert_rules (#2128): org-owned rules the caller can
@@ -150,10 +307,8 @@ function automationWhere(auth: AuthContext): SQL | undefined {
 // Site-axis helpers (app-layer authz — RLS does NOT enforce site)
 // ============================================
 
-// Minimal UserPermissions view for reused site-scope helpers that only read
-// `allowedSiteIds` (reportGenerationService.siteScopeRequestAllowed,
-// automationRuntime.checkAutomationTargetsWithinSiteScope). Undefined for
-// unrestricted callers so those helpers no-op.
+// Minimal UserPermissions view for the automation target helper, which reads
+// only `allowedSiteIds`. Undefined lets that helper no-op for unrestricted callers.
 function siteScopePerms(auth: AuthContext): UserPermissions | undefined {
   return auth.allowedSiteIds ? ({ allowedSiteIds: auth.allowedSiteIds } as UserPermissions) : undefined;
 }
@@ -1836,8 +1991,41 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'list') {
         const conditions: SQL[] = [];
-        const oc = orgWhere(auth, reports.orgId);
-        if (oc) conditions.push(oc);
+        let definitionPredicate: SQL;
+        if (auth.scope === 'organization') {
+          if (!auth.orgId) return JSON.stringify({ error: 'Organization context required' });
+          const authority = await aiLiveReportAuthority(auth, auth.orgId, 'read');
+          if (!authority) {
+            return JSON.stringify({ reports: [], showing: 0 });
+          }
+          conditions.push(eq(reports.orgId, auth.orgId));
+          definitionPredicate = reportDefinitionScopeSqlPredicate(
+            reports,
+            authority.scope,
+          );
+        } else if (auth.scope === 'partner') {
+          const orgIds = auth.accessibleOrgIds ?? [];
+          const authorityMap = await resolveRequestReportAuthorityMap(
+            auth,
+            orgIds,
+            'read',
+          );
+          const scopes: LiveSiteScopeV1[] = [];
+          for (const result of authorityMap.values()) {
+            if (result.ok && result.authority.scope.kind !== 'legacy_unscoped') {
+              scopes.push(result.authority.scope);
+            }
+          }
+          if (orgIds.length > 0) conditions.push(inArray(reports.orgId, orgIds));
+          definitionPredicate = reportDefinitionMultiOrgScopeSqlPredicate(
+            reports.orgId,
+            reports,
+            scopes,
+          );
+        } else {
+          definitionPredicate = unrestrictedReportDefinitionScopeSqlPredicate(reports);
+        }
+        conditions.push(definitionPredicate);
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
         const rows = await db.select({
@@ -1861,19 +2049,57 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (!orgId) return JSON.stringify({ error: 'Organization context required' });
 
         let reportDef;
+        let executionAuthority: ReportExecutionAuthority | null = null;
         if (input.reportId) {
-          const conditions: SQL[] = [eq(reports.id, input.reportId as string)];
-          const oc = orgWhere(auth, reports.orgId);
-          if (oc) conditions.push(oc);
-          [reportDef] = await db.select().from(reports).where(and(...conditions)).limit(1);
-          if (!reportDef) return JSON.stringify({ error: 'Report not found or access denied' });
+          const access = await aiReportDefinitionAccess(
+            auth,
+            input.reportId as string,
+            'read',
+          );
+          if (!access) return JSON.stringify({ error: 'Report not found or access denied' });
+          reportDef = access.report;
+          try {
+            const persistedScope = decodeSiteScope(
+              reportDef as unknown as PersistedSiteScopeColumns,
+              reportDef.orgId,
+            );
+            const effectiveScope = intersectSiteScopes(
+              persistedScope,
+              access.authority.scope,
+            );
+            if (
+              !effectiveScope
+              || effectiveScope.kind === 'legacy_unscoped'
+              || (effectiveScope.kind === 'restricted' && effectiveScope.siteIds.length === 0)
+            ) {
+              return JSON.stringify({ error: 'Report not found or access denied' });
+            }
+            executionAuthority = {
+              scope: effectiveScope,
+              principalUserId: access.authority.principalUserId,
+              capturedAt: access.authority.capturedAt,
+              fingerprint: siteScopeFingerprint(effectiveScope),
+            };
+          } catch {
+            return JSON.stringify({ error: 'Report not found or access denied' });
+          }
+        } else {
+          executionAuthority = await aiLiveReportAuthority(auth, orgId, 'read');
+          if (
+            !executionAuthority
+            || executionAuthority.scope.kind === 'legacy_unscoped'
+            || (executionAuthority.scope.kind === 'restricted'
+              && executionAuthority.scope.siteIds.length === 0)
+          ) {
+            return JSON.stringify({ error: 'Access to report scope denied' });
+          }
         }
 
-        // Site axis: a site-restricted caller must not enqueue a report whose
-        // config scope (siteIds / posture sites / deviceIds) exceeds their sites
-        // (mirrors routes/reports/runs.ts:59 via siteScopeRequestAllowed).
-        if (reportDef && !(await siteScopeRequestAllowed(reportDef.orgId, (reportDef.config ?? {}) as Record<string, unknown>, siteScopePerms(auth)))) {
-          return JSON.stringify({ error: 'Access to report scope denied' });
+        const reportConfig = (reportDef?.config ?? input.config ?? {}) as Record<string, unknown>;
+        try {
+          assertReportExecutionPreflight(orgId, reportConfig, executionAuthority);
+        } catch {
+          return JSON.stringify({ error: 'Report not found or access denied' });
         }
 
         // Only create a run record if we have a saved report definition
@@ -1884,6 +2110,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           const [run] = await db.insert(reportRuns).values({
             reportId,
             status: 'pending',
+            ...persistedSiteScopeValues(executionAuthority),
           }).returning();
           runId = run?.id ?? null;
           await db.update(reports).set({ lastGeneratedAt: new Date() }).where(eq(reports.id, reportId));
@@ -1900,6 +2127,10 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
       if (action === 'data') {
         if (!input.reportType) return JSON.stringify({ error: 'reportType is required' });
         if (!orgId) return JSON.stringify({ error: 'Organization context required' });
+        const executionAuthority = await aiLiveReportAuthority(auth, orgId, 'read');
+        if (!executionAuthority) {
+          return JSON.stringify({ error: 'Access to report scope denied' });
+        }
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 50), 100);
         const reportType = input.reportType as string;
@@ -1908,12 +2139,13 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           const inventoryConditions: SQL[] = [eq(devices.orgId, orgId)];
           // Site axis: a site-restricted caller may only enumerate devices in
           // their allowed sites (RLS does NOT enforce site).
-          if (auth.allowedSiteIds) {
-            const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
-            if (!allowed || allowed.length === 0) {
+          if (executionAuthority.scope.kind === 'restricted') {
+            if (executionAuthority.scope.siteIds.length === 0) {
               return JSON.stringify({ reportType, data: [], showing: 0 });
             }
-            inventoryConditions.push(inArray(devices.id, allowed));
+            inventoryConditions.push(
+              inArray(devices.siteId, executionAuthority.scope.siteIds),
+            );
           }
           const rows = await db.select({
             id: devices.id,
@@ -1936,8 +2168,8 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (reportType === 'alert_summary') {
           const summaryConditions: SQL[] = [eq(alerts.orgId, orgId)];
           // Site axis: mirror device_inventory — narrow to in-scope devices.
-          if (auth.allowedSiteIds) {
-            const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+          if (executionAuthority.scope.kind === 'restricted') {
+            const allowed = await aiAuthorityDeviceIds(orgId, executionAuthority);
             if (!allowed || allowed.length === 0) {
               return JSON.stringify({ reportType, data: { total: 0, active: 0, critical: 0, high: 0, resolved24h: 0 } });
             }
@@ -1965,8 +2197,8 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           // in-scope devices. Added to the JOIN condition (not WHERE) so policies
           // still appear with in-scope counts rather than being dropped entirely.
           let complianceJoin: SQL = eq(automationPolicies.id, automationPolicyCompliance.policyId);
-          if (auth.allowedSiteIds) {
-            const allowed = await resolveSiteAllowedDeviceIds(orgId, auth);
+          if (executionAuthority.scope.kind === 'restricted') {
+            const allowed = await aiAuthorityDeviceIds(orgId, executionAuthority);
             if (!allowed || allowed.length === 0) {
               return JSON.stringify({ reportType, data: [] });
             }
@@ -1993,6 +2225,13 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'create') {
         if (!orgId) return JSON.stringify({ error: 'Organization context required' });
+        const authority = await aiLiveReportAuthority(auth, orgId, 'write');
+        if (
+          !authority
+          || (authority.scope.kind === 'restricted' && authority.scope.siteIds.length === 0)
+        ) {
+          return JSON.stringify({ error: 'Access to report scope denied' });
+        }
         const [report] = await db.insert(reports).values({
           orgId,
           name: input.name as string,
@@ -2001,6 +2240,7 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           schedule: (input.schedule as 'one_time' | 'daily' | 'weekly' | 'monthly') ?? 'one_time',
           format: (input.format as 'csv' | 'pdf' | 'excel') ?? 'csv',
           createdBy: auth.user.id,
+          ...persistedSiteScopeValues(authority),
         }).returning();
 
         return JSON.stringify({ success: true, reportId: report?.id, name: report?.name });
@@ -2008,12 +2248,13 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'update') {
         if (!input.reportId) return JSON.stringify({ error: 'reportId is required' });
-        const conditions: SQL[] = [eq(reports.id, input.reportId as string)];
-        const oc = orgWhere(auth, reports.orgId);
-        if (oc) conditions.push(oc);
-
-        const [existing] = await db.select().from(reports).where(and(...conditions)).limit(1);
-        if (!existing) return JSON.stringify({ error: 'Report not found or access denied' });
+        const access = await aiReportDefinitionAccess(
+          auth,
+          input.reportId as string,
+          'write',
+        );
+        if (!access) return JSON.stringify({ error: 'Report not found or access denied' });
+        const existing = access.report;
 
         const updates: Record<string, unknown> = { updatedAt: new Date() };
         if (typeof input.name === 'string') updates.name = input.name;
@@ -2021,44 +2262,78 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
         if (typeof input.schedule === 'string') updates.schedule = input.schedule;
         if (typeof input.format === 'string') updates.format = input.format;
 
-        await db.update(reports).set(updates).where(eq(reports.id, existing.id));
+        const updated = await db.update(reports).set(updates).where(and(
+          eq(reports.id, existing.id),
+          eq(reports.orgId, existing.orgId),
+          access.predicate,
+        )).returning({ id: reports.id });
+        if (updated.length !== 1) {
+          return JSON.stringify({ error: 'Report not found or access denied' });
+        }
         return JSON.stringify({ success: true, message: `Report "${existing.name}" updated` });
       }
 
       if (action === 'delete') {
         if (!input.reportId) return JSON.stringify({ error: 'reportId is required' });
-        const conditions: SQL[] = [eq(reports.id, input.reportId as string)];
-        const oc = orgWhere(auth, reports.orgId);
-        if (oc) conditions.push(oc);
+        const access = await aiReportDefinitionAccess(
+          auth,
+          input.reportId as string,
+          'delete',
+        );
+        if (!access) return JSON.stringify({ error: 'Report not found or access denied' });
+        const existing = access.report;
 
-        const [existing] = await db.select().from(reports).where(and(...conditions)).limit(1);
-        if (!existing) return JSON.stringify({ error: 'Report not found or access denied' });
-
-        await db.transaction(async (tx) => {
+        const deleted = await db.transaction(async (tx) => {
           await tx.delete(reportRuns).where(eq(reportRuns.reportId, existing.id));
-          await tx.delete(reports).where(eq(reports.id, existing.id));
+          const deletedRows = await tx.delete(reports).where(and(
+            eq(reports.id, existing.id),
+            eq(reports.orgId, existing.orgId),
+            access.predicate,
+          )).returning({ id: reports.id });
+          if (deletedRows.length !== 1) {
+            throw new Error('AI_REPORT_DELETE_SCOPE_CHANGED');
+          }
+          return deletedRows[0];
+        }).catch((error) => {
+          if (error instanceof Error && error.message === 'AI_REPORT_DELETE_SCOPE_CHANGED') {
+            return null;
+          }
+          throw error;
         });
+        if (!deleted) {
+          return JSON.stringify({ error: 'Report not found or access denied' });
+        }
         return JSON.stringify({ success: true, message: `Report "${existing.name}" deleted` });
       }
 
       if (action === 'history') {
         if (!input.reportId) return JSON.stringify({ error: 'reportId is required' });
-        const conditions: SQL[] = [eq(reports.id, input.reportId as string)];
-        const oc = orgWhere(auth, reports.orgId);
-        if (oc) conditions.push(oc);
-
-        const [report] = await db.select().from(reports).where(and(...conditions)).limit(1);
-        if (!report) return JSON.stringify({ error: 'Report not found or access denied' });
-        // Site axis: deny run history for a report whose scope exceeds the
-        // caller's sites (mirrors routes/reports/runs.ts:59).
-        if (!(await siteScopeRequestAllowed(report.orgId, (report.config ?? {}) as Record<string, unknown>, siteScopePerms(auth)))) {
-          return JSON.stringify({ error: 'Access to report scope denied' });
-        }
+        const access = await aiReportDefinitionAccess(
+          auth,
+          input.reportId as string,
+          'read',
+        );
+        if (!access) return JSON.stringify({ error: 'Report not found or access denied' });
+        const report = access.report;
+        const runPredicate = reportRunScopeSqlPredicate(
+          reportRuns,
+          access.authority.scope,
+        );
 
         const limit = Math.min(Math.max(1, Number(input.limit) || 25), 100);
-        const runs = await db.select()
+        const runs = await db.select({
+          id: reportRuns.id,
+          reportId: reportRuns.reportId,
+          status: reportRuns.status,
+          startedAt: reportRuns.startedAt,
+          completedAt: reportRuns.completedAt,
+          outputUrl: reportRuns.outputUrl,
+          errorMessage: reportRuns.errorMessage,
+          rowCount: reportRuns.rowCount,
+          createdAt: reportRuns.createdAt,
+        })
           .from(reportRuns)
-          .where(eq(reportRuns.reportId, report.id))
+          .where(and(eq(reportRuns.reportId, report.id), runPredicate))
           .orderBy(desc(reportRuns.createdAt))
           .limit(limit);
 
@@ -2067,6 +2342,12 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
 
       if (action === 'download') {
         if (!input.reportRunId) return JSON.stringify({ error: 'reportRunId is required' });
+        const access = await aiReportRunAccess(
+          auth,
+          input.reportRunId as string,
+          'export',
+        );
+        if (!access) return JSON.stringify({ error: 'Report run not found' });
 
         const [run] = await db.select({
           id: reportRuns.id,
@@ -2082,29 +2363,32 @@ export function registerFleetTools(aiTools: Map<string, AiTool>): void {
           reportType: reports.type,
           reportFormat: reports.format,
           reportOrgId: reports.orgId,
-          reportConfig: reports.config,
+          executionScopeVersion: reportRuns.executionScopeVersion,
+          executionScopeKind: reportRuns.executionScopeKind,
+          executionScopeSiteIds: reportRuns.executionScopeSiteIds,
+          executionScopeUserId: reportRuns.executionScopeUserId,
+          executionScopeFingerprint: reportRuns.executionScopeFingerprint,
+          executionScopeCapturedAt: reportRuns.executionScopeCapturedAt,
         }).from(reportRuns)
           .innerJoin(reports, eq(reportRuns.reportId, reports.id))
-          .where(eq(reportRuns.id, input.reportRunId as string))
+          .where(and(
+            eq(reportRuns.id, input.reportRunId as string),
+            eq(reports.orgId, access.metadata.orgId),
+            access.predicate,
+          ))
           .limit(1);
 
         if (!run) return JSON.stringify({ error: 'Report run not found' });
-
-        // Verify org access via the parent report
-        const oc = orgWhere(auth, reports.orgId);
-        if (oc) {
-          const [accessible] = await db.select({ id: reports.id })
-            .from(reports)
-            .where(and(eq(reports.id, run.reportId), oc))
-            .limit(1);
-          if (!accessible) return JSON.stringify({ error: 'Report not found or access denied' });
-        }
-
-        // Site axis: deny download of a run whose report scope exceeds the
-        // caller's sites (mirrors routes/reports/runs.ts:59). The output URL /
-        // result would otherwise expose out-of-site device data.
-        if (!(await siteScopeRequestAllowed(run.reportOrgId, (run.reportConfig ?? {}) as Record<string, unknown>, siteScopePerms(auth)))) {
-          return JSON.stringify({ error: 'Access to report scope denied' });
+        try {
+          const storedScope = decodeSiteScope(
+            run as unknown as PersistedSiteScopeColumns,
+            run.reportOrgId,
+          );
+          if (!isSiteScopeSubset(storedScope, access.authority.scope)) {
+            return JSON.stringify({ error: 'Report run not found' });
+          }
+        } catch {
+          return JSON.stringify({ error: 'Report run not found' });
         }
 
         if (run.status !== 'completed') {

--- a/apps/api/src/services/reportGenerationService.execSummary.test.ts
+++ b/apps/api/src/services/reportGenerationService.execSummary.test.ts
@@ -4,6 +4,7 @@ vi.mock('../db', () => ({ db: { select: vi.fn() } }));
 
 import { db } from '../db';
 import { generateExecutiveSummaryReport } from './reportGenerationService';
+import type { ReportExecutionAuthority } from './siteScope';
 
 /** Thenable that resolves to `rows` and supports any drizzle chain method. */
 function selectChain(rows: unknown[]) {
@@ -15,6 +16,12 @@ function selectChain(rows: unknown[]) {
 }
 
 const ORG = '00000000-0000-0000-0000-000000000001';
+const AUTHORITY: ReportExecutionAuthority = {
+  scope: { version: 1, kind: 'unrestricted', orgId: ORG },
+  principalUserId: '11111111-1111-4111-8111-111111111111',
+  capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+  fingerprint: 'f'.repeat(64),
+};
 
 /**
  * The generator issues selects in this fixed order (with perms undefined, so
@@ -43,24 +50,26 @@ describe('generateExecutiveSummaryReport', () => {
   it('populates org identity alongside the existing numeric summary', async () => {
     mockGeneratorQueries();
 
-    const result = await generateExecutiveSummaryReport(ORG, {});
+    const result = await generateExecutiveSummaryReport(ORG, {}, AUTHORITY);
+    expect(result.summary).toBeDefined();
+    const summary = result.summary!;
 
-    expect(result.summary.org).toEqual({ id: ORG, name: 'Acme Corp' });
-    expect(result.summary.devices).toEqual({
+    expect(summary.org).toEqual({ id: ORG, name: 'Acme Corp' });
+    expect(summary.devices).toEqual({
       total: 5,
       online: 3,
       offline: 2,
       healthPercentage: 60
     });
-    expect(result.summary.alerts).toEqual({
+    expect(summary.alerts).toEqual({
       total: 10,
       critical: 2,
       high: 3,
       resolved: 5,
       resolutionRate: 50
     });
-    expect(result.summary.osDistribution).toEqual({ windows: 5 });
-    expect(result.summary.siteBreakdown).toEqual([{ site: 'HQ', count: 5 }]);
+    expect(summary.osDistribution).toEqual({ windows: 5 });
+    expect(summary.siteBreakdown).toEqual([{ site: 'HQ', count: 5 }]);
     expect(typeof result.generatedAt).toBe('string');
   });
 
@@ -70,8 +79,9 @@ describe('generateExecutiveSummaryReport', () => {
     m.mockReturnValueOnce(selectChain([])); // organizations: no row found
     m.mockReturnValue(selectChain([]));
 
-    const result = await generateExecutiveSummaryReport(ORG, {});
+    const result = await generateExecutiveSummaryReport(ORG, {}, AUTHORITY);
+    expect(result.summary).toBeDefined();
 
-    expect(result.summary.org).toEqual({ id: ORG, name: '' });
+    expect(result.summary!.org).toEqual({ id: ORG, name: '' });
   });
 });

--- a/apps/api/src/services/reportGenerationService.previous.test.ts
+++ b/apps/api/src/services/reportGenerationService.previous.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 vi.mock('../db', () => ({ db: { select: vi.fn() } }));
 
@@ -6,18 +8,28 @@ import { db } from '../db';
 import { previousBaselineFor } from './reportGenerationService';
 
 const REPORT_ID = '00000000-0000-0000-0000-000000000001';
+const SCOPE_FINGERPRINT = 'a'.repeat(64);
+const OTHER_SCOPE_FINGERPRINT = 'b'.repeat(64);
+const whereConditions: unknown[] = [];
 
 /** Thenable that resolves to `rows` and supports any drizzle chain method. */
 function selectChain(rows: unknown[]) {
   const p: any = Promise.resolve(rows);
-  for (const m of ['from', 'where', 'orderBy', 'limit']) {
+  for (const m of ['from', 'orderBy', 'limit']) {
     p[m] = () => p;
   }
+  p.where = (condition: unknown) => {
+    whereConditions.push(condition);
+    return p;
+  };
   return p;
 }
 
 describe('previousBaselineFor', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    whereConditions.length = 0;
+  });
 
   it('returns the prior completed run\'s generatedAt + summary', async () => {
     const m = vi.mocked(db.select);
@@ -31,9 +43,14 @@ describe('previousBaselineFor', () => {
       ]),
     );
 
-    const previous = await previousBaselineFor(REPORT_ID);
+    const previous = await previousBaselineFor(REPORT_ID, SCOPE_FINGERPRINT);
 
     expect(previous).toEqual({ generatedAt: '2026-06-01T09:00:00Z', summary: { postureScore: 74 } });
+    const rendered = new PgDialect().sqlToQuery(whereConditions[0] as SQL);
+    expect(rendered.params).toContain(REPORT_ID);
+    expect(rendered.params).toContain('completed');
+    expect(rendered.params).toContain(SCOPE_FINGERPRINT);
+    expect(rendered.params).not.toContain(OTHER_SCOPE_FINGERPRINT);
   });
 
   it('falls back to completedAt when the stored result has no generatedAt', async () => {
@@ -48,7 +65,7 @@ describe('previousBaselineFor', () => {
       ]),
     );
 
-    const previous = await previousBaselineFor(REPORT_ID);
+    const previous = await previousBaselineFor(REPORT_ID, SCOPE_FINGERPRINT);
 
     expect(previous).toEqual({ generatedAt: '2026-06-01T09:05:00.000Z', summary: { postureScore: 74 } });
   });
@@ -57,9 +74,24 @@ describe('previousBaselineFor', () => {
     const m = vi.mocked(db.select);
     m.mockReturnValueOnce(selectChain([]));
 
-    const previous = await previousBaselineFor(REPORT_ID);
+    const previous = await previousBaselineFor(REPORT_ID, SCOPE_FINGERPRINT);
 
     expect(previous).toBeUndefined();
+  });
+
+  it('does not fall back to a completed run from another immutable scope fingerprint', async () => {
+    const m = vi.mocked(db.select);
+    m.mockReturnValueOnce(selectChain([]));
+
+    const previous = await previousBaselineFor(
+      REPORT_ID,
+      SCOPE_FINGERPRINT,
+    );
+
+    expect(previous).toBeUndefined();
+    const rendered = new PgDialect().sqlToQuery(whereConditions[0] as SQL);
+    expect(rendered.params).toContain(SCOPE_FINGERPRINT);
+    expect(rendered.params).not.toContain(OTHER_SCOPE_FINGERPRINT);
   });
 
   it('returns undefined when the prior run has no summary', async () => {
@@ -70,7 +102,7 @@ describe('previousBaselineFor', () => {
       ]),
     );
 
-    const previous = await previousBaselineFor(REPORT_ID);
+    const previous = await previousBaselineFor(REPORT_ID, SCOPE_FINGERPRINT);
 
     expect(previous).toBeUndefined();
   });
@@ -81,7 +113,7 @@ describe('previousBaselineFor', () => {
       selectChain([{ summary: null, generatedAt: null, completedAt: new Date('2026-06-01T09:05:00Z') }]),
     );
 
-    const previous = await previousBaselineFor(REPORT_ID);
+    const previous = await previousBaselineFor(REPORT_ID, SCOPE_FINGERPRINT);
 
     expect(previous).toBeUndefined();
   });
@@ -93,7 +125,7 @@ describe('previousBaselineFor', () => {
     });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const previous = await previousBaselineFor(REPORT_ID);
+    const previous = await previousBaselineFor(REPORT_ID, SCOPE_FINGERPRINT);
 
     expect(previous).toBeUndefined();
     expect(consoleError).toHaveBeenCalledWith(

--- a/apps/api/src/services/reportGenerationService.test.ts
+++ b/apps/api/src/services/reportGenerationService.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+import { db } from '../db';
+import type { ReportExecutionAuthority } from './siteScope';
+import {
+  generateReport,
+  type ReportType,
+} from './reportGenerationService';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ORG_ID = '22222222-2222-4222-8222-222222222222';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const REPORT_TYPES: readonly ReportType[] = [
+  'device_inventory',
+  'software_inventory',
+  'alert_summary',
+  'compliance',
+  'performance',
+  'executive_summary',
+  'security_compliance_posture',
+];
+
+const capturedWhere: SQL[] = [];
+
+function selectChain(rows: unknown[] = []) {
+  const chain: any = Promise.resolve(rows);
+  for (const method of [
+    'from',
+    'innerJoin',
+    'leftJoin',
+    'orderBy',
+    'groupBy',
+    'limit',
+  ]) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.where = vi.fn((condition: SQL) => {
+    capturedWhere.push(condition);
+    return chain;
+  });
+  return chain;
+}
+
+function authority(
+  kind: 'unrestricted' | 'restricted',
+  siteIds: string[] = [],
+  orgId = ORG_ID,
+): ReportExecutionAuthority {
+  return {
+    scope: kind === 'restricted'
+      ? { version: 1, kind, orgId, siteIds }
+      : { version: 1, kind, orgId },
+    principalUserId: USER_ID,
+    capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+    fingerprint: kind === 'restricted' ? 'a'.repeat(64) : 'f'.repeat(64),
+  };
+}
+
+function renderedParams(): unknown[] {
+  const dialect = new PgDialect();
+  return capturedWhere.flatMap((condition) =>
+    dialect.sqlToQuery(condition).params
+  );
+}
+
+describe('generateReport mandatory execution authority', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedWhere.length = 0;
+    vi.mocked(db.select).mockReturnValue(selectChain([]));
+  });
+
+  it('rejects a missing authority before the first report query', async () => {
+    await expect(
+      generateReport(
+        'device_inventory',
+        ORG_ID,
+        {},
+        undefined as never,
+      ),
+    ).rejects.toThrow(/authority|scope/i);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('rejects an authority for another organization before querying', async () => {
+    await expect(
+      generateReport(
+        'device_inventory',
+        ORG_ID,
+        {},
+        authority('unrestricted', [], OTHER_ORG_ID),
+      ),
+    ).rejects.toThrow(/organization|scope/i);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it.each(REPORT_TYPES)(
+    '%s returns its zero-safe shape for restricted-empty without querying',
+    async (type) => {
+      const result = await generateReport(
+        type,
+        ORG_ID,
+        {},
+        authority('restricted', []),
+      );
+
+      expect(db.select).not.toHaveBeenCalled();
+      if (type === 'executive_summary') {
+        expect(result.summary).toMatchObject({
+          devices: { total: 0 },
+          alerts: { total: 0 },
+        });
+      } else {
+        expect(result.rows).toEqual([]);
+        expect(result.rowCount).toBe(0);
+      }
+    },
+  );
+
+  it.each(REPORT_TYPES)(
+    '%s binds the exact restricted site scope and never Site B',
+    async (type) => {
+      await generateReport(
+        type,
+        ORG_ID,
+        {},
+        authority('restricted', [SITE_A]),
+      );
+
+      const params = renderedParams();
+      expect(params).toContain(SITE_A);
+      expect(params).not.toContain(SITE_B);
+    },
+  );
+
+  it.each(REPORT_TYPES)(
+    '%s preserves unrestricted generation without a site predicate',
+    async (type) => {
+      await generateReport(
+        type,
+        ORG_ID,
+        {},
+        authority('unrestricted'),
+      );
+
+      expect(renderedParams()).not.toContain(SITE_A);
+      expect(renderedParams()).not.toContain(SITE_B);
+    },
+  );
+});

--- a/apps/api/src/services/reportGenerationService.ts
+++ b/apps/api/src/services/reportGenerationService.ts
@@ -11,8 +11,8 @@ import {
   organizations,
   reportRuns
 } from '../db/schema';
-import { canAccessSite, type UserPermissions } from './permissions';
 import type { ExecutiveSummary } from '@breeze/shared';
+import type { ReportExecutionAuthority } from './siteScope';
 
 export type ReportType =
   | 'device_inventory'
@@ -43,7 +43,10 @@ export type ReportResult = {
  * throws: this sits in the success path of both generation call sites, so a
  * lookup failure must degrade to "no baseline" rather than fail an otherwise
  * good run. */
-export async function previousBaselineFor(reportId: string): Promise<ReportResult['previous']> {
+export async function previousBaselineFor(
+  reportId: string,
+  scopeFingerprint: string,
+): Promise<ReportResult['previous']> {
   try {
     const [prior] = await db
       .select({
@@ -52,7 +55,11 @@ export async function previousBaselineFor(reportId: string): Promise<ReportResul
         completedAt: reportRuns.completedAt,
       })
       .from(reportRuns)
-      .where(and(eq(reportRuns.reportId, reportId), eq(reportRuns.status, 'completed')))
+      .where(and(
+        eq(reportRuns.reportId, reportId),
+        eq(reportRuns.status, 'completed'),
+        eq(reportRuns.executionScopeFingerprint, scopeFingerprint),
+      ))
       .orderBy(desc(reportRuns.completedAt))
       .limit(1);
     if (!prior?.summary || typeof prior.summary !== 'object') return undefined;
@@ -66,15 +73,24 @@ export async function previousBaselineFor(reportId: string): Promise<ReportResul
   }
 }
 
-export async function resolveSiteAllowedDeviceIds(orgId: string, perms: UserPermissions | undefined): Promise<string[] | null> {
-  if (!perms?.allowedSiteIds) return null;
+export async function resolveSiteAllowedDeviceIds(
+  orgId: string,
+  authority: ReportExecutionAuthority,
+): Promise<string[] | null> {
+  assertExecutableAuthority(orgId, authority);
+  if (authority.scope.kind === 'unrestricted') return null;
+  if (authority.scope.kind !== 'restricted') {
+    throw new UnexecutableReportScopeError();
+  }
+  if (authority.scope.siteIds.length === 0) return [];
   const orgDevices = await db
     .select({ id: devices.id, siteId: devices.siteId })
     .from(devices)
-    .where(eq(devices.orgId, orgId));
-  return orgDevices
-    .filter((d) => typeof d.siteId === 'string' && canAccessSite(perms, d.siteId))
-    .map((d) => d.id);
+    .where(and(
+      eq(devices.orgId, orgId),
+      inArray(devices.siteId, authority.scope.siteIds),
+    ));
+  return orgDevices.map((device) => device.id);
 }
 
 function asStringArray(value: unknown): string[] | null {
@@ -89,43 +105,78 @@ function emptyRowsReport() {
   return { rows: [], rowCount: 0 };
 }
 
-function addAllowedSiteCondition(conditions: SQL[], perms: UserPermissions | undefined): boolean {
-  if (!perms?.allowedSiteIds) return false;
-  if (perms.allowedSiteIds.length === 0) return true;
-  conditions.push(inArray(devices.siteId, perms.allowedSiteIds));
+function addAllowedSiteCondition(
+  conditions: SQL[],
+  authority: ReportExecutionAuthority,
+): boolean {
+  if (authority.scope.kind === 'unrestricted') return false;
+  if (authority.scope.kind !== 'restricted') {
+    throw new UnexecutableReportScopeError();
+  }
+  if (authority.scope.siteIds.length === 0) return true;
+  conditions.push(inArray(devices.siteId, authority.scope.siteIds));
   return false;
 }
 
-export async function siteScopeRequestAllowed(
+export class UnexecutableReportScopeError extends Error {
+  constructor(message = 'Report execution authority is not executable') {
+    super(message);
+    this.name = 'UnexecutableReportScopeError';
+  }
+}
+
+function assertExecutableAuthority(
   orgId: string,
+  authority: ReportExecutionAuthority | null | undefined,
+): asserts authority is ReportExecutionAuthority {
+  if (!authority || !authority.scope) {
+    throw new UnexecutableReportScopeError('Report execution authority is required');
+  }
+  if (authority.scope.orgId !== orgId) {
+    throw new UnexecutableReportScopeError('Report execution authority organization mismatch');
+  }
+  if (authority.scope.kind === 'legacy_unscoped') {
+    throw new UnexecutableReportScopeError('Legacy report scope cannot execute');
+  }
+}
+
+function assertRequestedScopeWithinAuthority(
   config: Record<string, unknown>,
-  perms: UserPermissions | undefined
-): Promise<boolean> {
-  if (!perms?.allowedSiteIds) return true;
+  authority: ReportExecutionAuthority,
+): void {
+  if (authority.scope.kind === 'unrestricted') return;
+  if (authority.scope.kind !== 'restricted') {
+    throw new UnexecutableReportScopeError();
+  }
+  const restrictedScope = authority.scope;
 
   const filters = filtersFor(config);
   const siteIds = asStringArray(filters.siteIds);
-  if (siteIds?.some((siteId) => !canAccessSite(perms, siteId))) {
-    return false;
+  if (siteIds?.some((siteId) => !restrictedScope.siteIds.includes(siteId))) {
+    throw new UnexecutableReportScopeError('Requested site is outside report execution authority');
   }
 
   const postureSiteIds = asStringArray(config.sites);
-  if (postureSiteIds?.some((siteId) => !canAccessSite(perms, siteId))) {
-    return false;
+  if (postureSiteIds?.some((siteId) => !restrictedScope.siteIds.includes(siteId))) {
+    throw new UnexecutableReportScopeError('Requested site is outside report execution authority');
   }
-
-  const deviceIds = asStringArray(filters.deviceIds);
-  if (deviceIds && deviceIds.length > 0) {
-    const allowedDeviceIds = await resolveSiteAllowedDeviceIds(orgId, perms);
-    if (deviceIds.some((deviceId) => !allowedDeviceIds?.includes(deviceId))) {
-      return false;
-    }
-  }
-
-  return true;
 }
 
-export async function generateDeviceInventoryReport(orgId: string, config: Record<string, unknown>, perms?: UserPermissions) {
+export function assertReportExecutionPreflight(
+  orgId: string,
+  config: Record<string, unknown>,
+  authority: ReportExecutionAuthority | null | undefined,
+): asserts authority is ReportExecutionAuthority {
+  assertExecutableAuthority(orgId, authority);
+  assertRequestedScopeWithinAuthority(config, authority);
+}
+
+export async function generateDeviceInventoryReport(
+  orgId: string,
+  config: Record<string, unknown>,
+  authority: ReportExecutionAuthority,
+) {
+  assertExecutableAuthority(orgId, authority);
   const conditions: SQL[] = [eq(devices.orgId, orgId)];
 
   const filters = config.filters as Record<string, unknown> | undefined;
@@ -133,7 +184,7 @@ export async function generateDeviceInventoryReport(orgId: string, config: Recor
     conditions.push(inArray(devices.siteId, filters.siteIds));
   }
 
-  if (addAllowedSiteCondition(conditions, perms)) {
+  if (addAllowedSiteCondition(conditions, authority)) {
     return emptyRowsReport();
   }
 
@@ -166,7 +217,12 @@ export async function generateDeviceInventoryReport(orgId: string, config: Recor
   return { rows: data, rowCount: data.length };
 }
 
-export async function generateSoftwareInventoryReport(orgId: string, config: Record<string, unknown>, perms?: UserPermissions) {
+export async function generateSoftwareInventoryReport(
+  orgId: string,
+  config: Record<string, unknown>,
+  authority: ReportExecutionAuthority,
+) {
+  assertExecutableAuthority(orgId, authority);
   const conditions: SQL[] = [eq(devices.orgId, orgId)];
 
   const filters = config.filters as Record<string, unknown> | undefined;
@@ -174,7 +230,7 @@ export async function generateSoftwareInventoryReport(orgId: string, config: Rec
     conditions.push(inArray(devices.id, filters.deviceIds));
   }
 
-  if (addAllowedSiteCondition(conditions, perms)) {
+  if (addAllowedSiteCondition(conditions, authority)) {
     return emptyRowsReport();
   }
 
@@ -196,7 +252,12 @@ export async function generateSoftwareInventoryReport(orgId: string, config: Rec
   return { rows: data, rowCount: data.length };
 }
 
-export async function generateAlertSummaryReport(orgId: string, config: Record<string, unknown>, perms?: UserPermissions) {
+export async function generateAlertSummaryReport(
+  orgId: string,
+  config: Record<string, unknown>,
+  authority: ReportExecutionAuthority,
+) {
+  assertExecutableAuthority(orgId, authority);
   const conditions: SQL[] = [eq(alerts.orgId, orgId)];
 
   const dateRange = config.dateRange as Record<string, string> | undefined;
@@ -212,7 +273,7 @@ export async function generateAlertSummaryReport(orgId: string, config: Record<s
     conditions.push(inArray(alerts.severity, filters.severity));
   }
 
-  const allowedDeviceIds = await resolveSiteAllowedDeviceIds(orgId, perms);
+  const allowedDeviceIds = await resolveSiteAllowedDeviceIds(orgId, authority);
   if (allowedDeviceIds) {
     if (allowedDeviceIds.length === 0) {
       return { rows: [], rowCount: 0, summary: {} };
@@ -256,7 +317,12 @@ export async function generateAlertSummaryReport(orgId: string, config: Record<s
   };
 }
 
-export async function generateComplianceReport(orgId: string, config: Record<string, unknown>, perms?: UserPermissions) {
+export async function generateComplianceReport(
+  orgId: string,
+  config: Record<string, unknown>,
+  authority: ReportExecutionAuthority,
+) {
+  assertExecutableAuthority(orgId, authority);
   const conditions: SQL[] = [eq(devices.orgId, orgId)];
 
   const filters = config.filters as Record<string, unknown> | undefined;
@@ -264,7 +330,7 @@ export async function generateComplianceReport(orgId: string, config: Record<str
     conditions.push(inArray(devices.siteId, filters.siteIds));
   }
 
-  if (addAllowedSiteCondition(conditions, perms)) {
+  if (addAllowedSiteCondition(conditions, authority)) {
     return {
       rows: [],
       rowCount: 0,
@@ -322,9 +388,14 @@ export async function generateComplianceReport(orgId: string, config: Record<str
   };
 }
 
-export async function generatePerformanceReport(orgId: string, config: Record<string, unknown>, perms?: UserPermissions) {
+export async function generatePerformanceReport(
+  orgId: string,
+  config: Record<string, unknown>,
+  authority: ReportExecutionAuthority,
+) {
+  assertExecutableAuthority(orgId, authority);
   const deviceConditions: SQL[] = [eq(devices.orgId, orgId)];
-  if (addAllowedSiteCondition(deviceConditions, perms)) {
+  if (addAllowedSiteCondition(deviceConditions, authority)) {
     return emptyRowsReport();
   }
 
@@ -382,7 +453,15 @@ export async function generatePerformanceReport(orgId: string, config: Record<st
   return { rows, rowCount: rows.length };
 }
 
-export async function generateExecutiveSummaryReport(orgId: string, config: Record<string, unknown>, perms?: UserPermissions) {
+export async function generateExecutiveSummaryReport(
+  orgId: string,
+  config: Record<string, unknown>,
+  authority: ReportExecutionAuthority,
+) {
+  assertExecutableAuthority(orgId, authority);
+  if (authority.scope.kind === 'restricted' && authority.scope.siteIds.length === 0) {
+    return zeroSafeReport('executive_summary', orgId);
+  }
   const [orgRow] = await db
     .select({ id: organizations.id, name: organizations.name })
     .from(organizations)
@@ -391,7 +470,7 @@ export async function generateExecutiveSummaryReport(orgId: string, config: Reco
 
   const dateRange = config.dateRange as Record<string, string> | undefined;
   const deviceConditions: SQL[] = [eq(devices.orgId, orgId)];
-  const emptyDeviceScope = addAllowedSiteCondition(deviceConditions, perms);
+  const emptyDeviceScope = addAllowedSiteCondition(deviceConditions, authority);
   const deviceWhereCondition = and(...deviceConditions);
 
   // Device stats
@@ -415,7 +494,7 @@ export async function generateExecutiveSummaryReport(orgId: string, config: Reco
     alertConditions.push(lte(alerts.triggeredAt, new Date(dateRange.end)));
   }
 
-  const allowedDeviceIds = await resolveSiteAllowedDeviceIds(orgId, perms);
+  const allowedDeviceIds = await resolveSiteAllowedDeviceIds(orgId, authority);
   if (allowedDeviceIds) {
     alertConditions.push(inArray(alerts.deviceId, allowedDeviceIds));
   }
@@ -490,26 +569,71 @@ export async function generateReport(
   type: ReportType,
   orgId: string,
   config: Record<string, unknown>,
-  perms?: UserPermissions
+  authority: ReportExecutionAuthority,
 ): Promise<ReportResult> {
+  assertReportExecutionPreflight(orgId, config, authority);
+  if (authority.scope.kind === 'restricted' && authority.scope.siteIds.length === 0) {
+    return zeroSafeReport(type, orgId);
+  }
+
   switch (type) {
     case 'device_inventory':
-      return generateDeviceInventoryReport(orgId, config, perms);
+      return generateDeviceInventoryReport(orgId, config, authority);
     case 'software_inventory':
-      return generateSoftwareInventoryReport(orgId, config, perms);
+      return generateSoftwareInventoryReport(orgId, config, authority);
     case 'alert_summary':
-      return generateAlertSummaryReport(orgId, config, perms);
+      return generateAlertSummaryReport(orgId, config, authority);
     case 'compliance':
-      return generateComplianceReport(orgId, config, perms);
+      return generateComplianceReport(orgId, config, authority);
     case 'performance':
-      return generatePerformanceReport(orgId, config, perms);
+      return generatePerformanceReport(orgId, config, authority);
     case 'executive_summary':
-      return generateExecutiveSummaryReport(orgId, config, perms);
+      return generateExecutiveSummaryReport(orgId, config, authority);
     case 'security_compliance_posture': {
       const { generateSecurityCompliancePostureReport } = await import('./securityComplianceReport');
-      return generateSecurityCompliancePostureReport(orgId, config, perms);
+      return generateSecurityCompliancePostureReport(orgId, config, authority);
     }
-    default:
-      throw new Error(`Invalid report type: ${type}`);
+    default: {
+      const exhaustive: never = type;
+      throw new Error(`Invalid report type: ${String(exhaustive)}`);
+    }
+  }
+}
+
+function zeroSafeReport(type: ReportType, orgId: string): ReportResult {
+  switch (type) {
+    case 'alert_summary':
+      return { rows: [], rowCount: 0, summary: {} };
+    case 'compliance':
+      return {
+        rows: [],
+        rowCount: 0,
+        summary: {
+          totalDevices: 0,
+          compliantDevices: 0,
+          nonCompliantDevices: 0,
+          complianceRate: 100,
+        },
+      };
+    case 'executive_summary':
+      return {
+        summary: {
+          org: { id: orgId, name: '' },
+          devices: { total: 0, online: 0, offline: 0, healthPercentage: 100 },
+          alerts: { total: 0, critical: 0, high: 0, resolved: 0, resolutionRate: 100 },
+          osDistribution: {},
+          siteBreakdown: [],
+        },
+        generatedAt: new Date().toISOString(),
+      };
+    case 'device_inventory':
+    case 'software_inventory':
+    case 'performance':
+    case 'security_compliance_posture':
+      return emptyRowsReport();
+    default: {
+      const exhaustive: never = type;
+      throw new Error(`Invalid report type: ${String(exhaustive)}`);
+    }
   }
 }

--- a/apps/api/src/services/securityComplianceReport.test.ts
+++ b/apps/api/src/services/securityComplianceReport.test.ts
@@ -5,13 +5,14 @@ const vulnerabilityMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../db', () => ({ db: { select: vi.fn() } }));
-vi.mock('./reportGenerationService', () => ({
-  resolveSiteAllowedDeviceIds: vi.fn(async () => null)
-}));
+vi.mock('./reportGenerationService', () => ({}));
 vi.mock('./securityComplianceReportVulnerabilities', () => vulnerabilityMocks);
 
 import { db } from '../db';
-import { generateSecurityCompliancePostureReport } from './securityComplianceReport';
+import {
+  generateSecurityCompliancePostureReport as generateSecurityCompliancePostureReportWithAuthority,
+} from './securityComplianceReport';
+import type { ReportExecutionAuthority } from './siteScope';
 
 /** Thenable that resolves to `rows` and supports any drizzle chain method. */
 function selectChain(rows: any) {
@@ -23,6 +24,31 @@ function selectChain(rows: any) {
 }
 
 const ORG = '00000000-0000-0000-0000-000000000001';
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function authority(siteIds?: string[]): ReportExecutionAuthority {
+  return {
+    scope: siteIds === undefined
+      ? { version: 1, kind: 'unrestricted', orgId: ORG }
+      : { version: 1, kind: 'restricted', orgId: ORG, siteIds },
+    principalUserId: USER_ID,
+    capturedAt: new Date('2026-07-25T12:00:00.000Z'),
+    fingerprint: siteIds === undefined ? 'f'.repeat(64) : 'a'.repeat(64),
+  };
+}
+
+function generateSecurityCompliancePostureReport(
+  orgId: string,
+  config: Record<string, unknown>,
+  executionAuthority: ReportExecutionAuthority = authority(),
+) {
+  return generateSecurityCompliancePostureReportWithAuthority(
+    orgId,
+    config,
+    executionAuthority,
+  );
+}
 
 /**
  * The generator issues selects in this fixed order:
@@ -96,6 +122,36 @@ describe('generateSecurityCompliancePostureReport', () => {
     ]);
     expect(rows['pc-1']).toMatchObject({ openVulnHigh: 2, openVulnCritical: 1 });
     expect(rows['pc-2']).toMatchObject({ openVulnHigh: 1, openVulnCritical: 0 });
+  });
+
+  it('does not query or expose organization-wide posture evidence to a site-restricted caller', async () => {
+    const sequences = [
+      [{ id: ORG, name: 'Acme Co', partnerId: 'p1' }],
+      [{ id: 'dev-a', hostname: 'site-a-device', osType: 'windows', siteName: 'Site A' }],
+      [], // security_status
+      [], // s1_agents
+      [], // huntress_agents
+      [], // outstanding device patches
+      [], // patch-assessed device set
+    ];
+    const select = vi.mocked(db.select);
+    select.mockReset();
+    for (const rows of sequences) select.mockReturnValueOnce(selectChain(rows));
+    select.mockReturnValue(selectChain([]));
+
+    const result = await generateSecurityCompliancePostureReport(
+      ORG,
+      { includeCis: false },
+      authority([SITE_A]),
+    );
+    const summary = result.summary as any;
+
+    expect(select).toHaveBeenCalledTimes(sequences.length);
+    expect(summary.controls).not.toHaveProperty('identityProviderConnected');
+    expect(summary.controls).not.toHaveProperty('backupConfigured');
+    expect(summary.controls).not.toHaveProperty('dnsFilteringActive');
+    expect(summary).not.toHaveProperty('privilegedAccess');
+    expect(summary).not.toHaveProperty('postureScore');
   });
 
   it('merges managed EDR with native AV and flags unprotected devices', async () => {
@@ -465,10 +521,12 @@ describe('generateSecurityCompliancePostureReport', () => {
   });
 
   it('returns empty rows but a valid summary when no devices in scope', async () => {
-    const svc = await import('./reportGenerationService');
-    vi.mocked(svc.resolveSiteAllowedDeviceIds).mockResolvedValueOnce([]);
     mockGeneratorQueries();
-    const r = await generateSecurityCompliancePostureReport(ORG, { backupRequired: false });
+    const r = await generateSecurityCompliancePostureReport(
+      ORG,
+      { backupRequired: false },
+      authority([]),
+    );
     expect(r.rows).toEqual([]);
     expect((r.summary as any).deviceCount).toBe(0);
     expect((r.summary as any).controls.backupRequired).toBe(false);

--- a/apps/api/src/services/securityComplianceReport.ts
+++ b/apps/api/src/services/securityComplianceReport.ts
@@ -24,8 +24,8 @@ import {
 } from '../db/schema';
 import { securityCompliancePostureConfigSchema } from '../routes/reports/schemas';
 import type { PostureSummary } from '@breeze/shared';
-import { canAccessSite, type UserPermissions } from './permissions';
-import { resolveSiteAllowedDeviceIds, type ReportResult } from './reportGenerationService';
+import type { ReportResult } from './reportGenerationService';
+import type { ReportExecutionAuthority } from './siteScope';
 import {
   buildSecurityProductInventory,
   categoryForEndpointProvider,
@@ -92,7 +92,8 @@ function emptySummary(
   orgRow: { id: string; name: string } | undefined,
   generatedAt: string,
   includeCis = true,
-  backupRequired = true
+  backupRequired = true,
+  includeOrgWideEvidence = true,
 ) {
   return {
     org: { id: orgRow?.id ?? '', name: orgRow?.name ?? 'Unknown' },
@@ -116,23 +117,25 @@ function emptySummary(
       cisAvgPassRate: null,
       cisIncluded: includeCis,
       cisAssessedCount: 0,
-      identityProviderConnected: false,
       backupRequired,
-      backupConfigured: false,
-      backupEncrypted: null,
-      dnsFilteringActive: false,
-      dnsFilteringSyncStatus: null
+      ...(includeOrgWideEvidence ? {
+        identityProviderConnected: false,
+        backupConfigured: false,
+        backupEncrypted: null,
+        dnsFilteringActive: false,
+        dnsFilteringSyncStatus: null,
+      } : {}),
     },
-    privilegedAccess: {
+    ...(includeOrgWideEvidence ? { privilegedAccess: {
       uacInterceptionEnabled: false,
       activePamRules: 0,
       elevationsInWindow: 0,
       elevationsApproved: 0,
       elevationsDenied: 0,
       mfaStepUpEnforced: false
-    },
+    } } : {}),
     securityProducts: [],
-    postureScore: null
+    ...(includeOrgWideEvidence ? { postureScore: null } : {}),
   } satisfies PostureSummary;
 }
 
@@ -152,16 +155,38 @@ function prettyDnsProvider(p: string): string {
 export async function generateSecurityCompliancePostureReport(
   orgId: string,
   rawConfig: Record<string, unknown>,
-  perms?: UserPermissions
+  authority: ReportExecutionAuthority,
 ): Promise<ReportResult> {
   const cfg = securityCompliancePostureConfigSchema.parse(rawConfig ?? {});
   const generatedAt = new Date().toISOString();
 
-  if (perms?.allowedSiteIds && cfg.sites.some((siteId) => !canAccessSite(perms, siteId))) {
+  if (!authority || authority.scope.orgId !== orgId) {
+    throw new Error('Report execution authority organization mismatch');
+  }
+  if (authority.scope.kind === 'legacy_unscoped') {
+    throw new Error('Legacy report scope cannot execute');
+  }
+  const restrictedScope = authority.scope.kind === 'restricted'
+    ? authority.scope
+    : null;
+  if (restrictedScope && cfg.sites.some((siteId) => !restrictedScope.siteIds.includes(siteId))) {
     throw new Error('Requested site is outside the caller scope');
   }
 
-  const allowedDeviceIds = await resolveSiteAllowedDeviceIds(orgId, perms);
+  if (restrictedScope && restrictedScope.siteIds.length === 0) {
+    return {
+      rows: [],
+      rowCount: 0,
+      generatedAt,
+      summary: emptySummary(
+        { id: orgId, name: 'Unknown' },
+        generatedAt,
+        cfg.includeCis,
+        cfg.backupRequired,
+        false,
+      ),
+    };
+  }
 
   const [orgRow] = await db
     .select({ id: organizations.id, name: organizations.name, partnerId: organizations.partnerId })
@@ -169,21 +194,12 @@ export async function generateSecurityCompliancePostureReport(
     .where(eq(organizations.id, orgId))
     .limit(1);
 
-  if (allowedDeviceIds?.length === 0) {
-    return {
-      rows: [],
-      rowCount: 0,
-      generatedAt,
-      summary: emptySummary(orgRow, generatedAt, cfg.includeCis, cfg.backupRequired)
-    };
-  }
-
   const deviceConditions = [eq(devices.orgId, orgId)];
   if (cfg.sites.length > 0) {
     deviceConditions.push(inArray(devices.siteId, cfg.sites));
   }
-  if (allowedDeviceIds) {
-    deviceConditions.push(inArray(devices.id, allowedDeviceIds));
+  if (authority.scope.kind === 'restricted') {
+    deviceConditions.push(inArray(devices.siteId, authority.scope.siteIds));
   }
 
   const deviceRows = await db
@@ -203,7 +219,13 @@ export async function generateSecurityCompliancePostureReport(
       rows: [],
       rowCount: 0,
       generatedAt,
-      summary: emptySummary(orgRow, generatedAt, cfg.includeCis, cfg.backupRequired)
+      summary: emptySummary(
+        orgRow,
+        generatedAt,
+        cfg.includeCis,
+        cfg.backupRequired,
+        authority.scope.kind === 'unrestricted',
+      )
     };
   }
 
@@ -255,67 +277,97 @@ export async function generateSecurityCompliancePostureReport(
 
   const vulnByDevice = await loadOpenVulnerabilityCounts(deviceIds);
 
-  const [dns] = await db
-    .select({ isActive: dnsFilterIntegrations.isActive, provider: dnsFilterIntegrations.provider, lastSyncStatus: dnsFilterIntegrations.lastSyncStatus })
-    .from(dnsFilterIntegrations)
-    .where(and(eq(dnsFilterIntegrations.orgId, orgId), eq(dnsFilterIntegrations.isActive, true)))
-    .limit(1);
-  const [backup] = await db
-    .select({ isActive: backupConfigs.isActive, provider: backupConfigs.provider, encryption: backupConfigs.encryption })
-    .from(backupConfigs)
-    .where(and(eq(backupConfigs.orgId, orgId), eq(backupConfigs.isActive, true)))
-    .limit(1);
-  const [c2c] = await db
-    .select({ status: c2cConnections.status, provider: c2cConnections.provider })
-    .from(c2cConnections)
-    .where(and(eq(c2cConnections.orgId, orgId), eq(c2cConnections.status, 'active')))
-    .limit(1);
-  const [m365] = await db
-    .select({ status: m365Connections.status })
-    .from(m365Connections)
-    .where(and(eq(m365Connections.orgId, orgId), eq(m365Connections.status, 'active')))
-    .limit(1);
-  const [google] = await db
-    .select({ status: googleWorkspaceConnections.status })
-    .from(googleWorkspaceConnections)
-    .where(and(eq(googleWorkspaceConnections.orgId, orgId), eq(googleWorkspaceConnections.status, 'active')))
-    .limit(1);
+  const includeOrgWideEvidence = authority.scope.kind === 'unrestricted';
+  const orgWideEvidence = includeOrgWideEvidence
+    ? await (async () => {
+      const [dns] = await db
+        .select({ isActive: dnsFilterIntegrations.isActive, provider: dnsFilterIntegrations.provider, lastSyncStatus: dnsFilterIntegrations.lastSyncStatus })
+        .from(dnsFilterIntegrations)
+        .where(and(eq(dnsFilterIntegrations.orgId, orgId), eq(dnsFilterIntegrations.isActive, true)))
+        .limit(1);
+      const [backup] = await db
+        .select({ isActive: backupConfigs.isActive, provider: backupConfigs.provider, encryption: backupConfigs.encryption })
+        .from(backupConfigs)
+        .where(and(eq(backupConfigs.orgId, orgId), eq(backupConfigs.isActive, true)))
+        .limit(1);
+      const [c2c] = await db
+        .select({ status: c2cConnections.status, provider: c2cConnections.provider })
+        .from(c2cConnections)
+        .where(and(eq(c2cConnections.orgId, orgId), eq(c2cConnections.status, 'active')))
+        .limit(1);
+      const [m365] = await db
+        .select({ status: m365Connections.status })
+        .from(m365Connections)
+        .where(and(eq(m365Connections.orgId, orgId), eq(m365Connections.status, 'active')))
+        .limit(1);
+      const [google] = await db
+        .select({ status: googleWorkspaceConnections.status })
+        .from(googleWorkspaceConnections)
+        .where(and(eq(googleWorkspaceConnections.orgId, orgId), eq(googleWorkspaceConnections.status, 'active')))
+        .limit(1);
 
-  const [pamCfg] = await db
-    .select({ uacInterceptionEnabled: pamOrgConfig.uacInterceptionEnabled })
-    .from(pamOrgConfig)
-    .where(eq(pamOrgConfig.orgId, orgId))
-    .limit(1);
-  const pamRuleRows = await db
-    .select({ id: pamRules.id })
-    .from(pamRules)
-    .where(and(eq(pamRules.orgId, orgId), eq(pamRules.enabled, true)));
-  const windowStart = new Date(Date.now() - cfg.windowDays * 86400000);
-  const elevationRows = await db
-    .select({ approvedAt: elevationRequests.approvedAt, deniedByUserId: elevationRequests.deniedByUserId })
-    .from(elevationRequests)
-    .where(and(eq(elevationRequests.orgId, orgId), gte(elevationRequests.requestedAt, windowStart)));
+      const [pamCfg] = await db
+        .select({ uacInterceptionEnabled: pamOrgConfig.uacInterceptionEnabled })
+        .from(pamOrgConfig)
+        .where(eq(pamOrgConfig.orgId, orgId))
+        .limit(1);
+      const pamRuleRows = await db
+        .select({ id: pamRules.id })
+        .from(pamRules)
+        .where(and(eq(pamRules.orgId, orgId), eq(pamRules.enabled, true)));
+      const windowStart = new Date(Date.now() - cfg.windowDays * 86400000);
+      const elevationRows = await db
+        .select({ approvedAt: elevationRequests.approvedAt, deniedByUserId: elevationRequests.deniedByUserId })
+        .from(elevationRequests)
+        .where(and(eq(elevationRequests.orgId, orgId), gte(elevationRequests.requestedAt, windowStart)));
+
+      let mfaStepUpEnforced = false;
+      if (orgRow?.partnerId) {
+        const [authPol] = await db
+          .select({ requireEnrollment: authenticatorPolicies.requireEnrollment, enforceFrom: authenticatorPolicies.enforceFrom })
+          .from(authenticatorPolicies)
+          .where(eq(authenticatorPolicies.partnerId, orgRow.partnerId))
+          .limit(1);
+        mfaStepUpEnforced =
+          Boolean(authPol?.requireEnrollment) &&
+          (!authPol?.enforceFrom || new Date(authPol.enforceFrom).getTime() <= Date.now());
+      }
+
+      const [postureRow] = await db
+        .select({ overallScore: securityPostureOrgSnapshots.overallScore })
+        .from(securityPostureOrgSnapshots)
+        .where(eq(securityPostureOrgSnapshots.orgId, orgId))
+        .orderBy(desc(securityPostureOrgSnapshots.capturedAt))
+        .limit(1);
+
+      return { dns, backup, c2c, m365, google, pamCfg, pamRuleRows, elevationRows, mfaStepUpEnforced, postureRow };
+    })()
+    : {
+      dns: undefined,
+      backup: undefined,
+      c2c: undefined,
+      m365: undefined,
+      google: undefined,
+      pamCfg: undefined,
+      pamRuleRows: [],
+      elevationRows: [],
+      mfaStepUpEnforced: false,
+      postureRow: undefined,
+    };
+  const {
+    dns,
+    backup,
+    c2c,
+    m365,
+    google,
+    pamCfg,
+    pamRuleRows,
+    elevationRows,
+    mfaStepUpEnforced,
+    postureRow,
+  } = orgWideEvidence;
   const elevationsApproved = elevationRows.filter((e) => e.approvedAt != null).length;
   const elevationsDenied = elevationRows.filter((e) => e.deniedByUserId != null).length;
-
-  let mfaStepUpEnforced = false;
-  if (orgRow?.partnerId) {
-    const [authPol] = await db
-      .select({ requireEnrollment: authenticatorPolicies.requireEnrollment, enforceFrom: authenticatorPolicies.enforceFrom })
-      .from(authenticatorPolicies)
-      .where(eq(authenticatorPolicies.partnerId, orgRow.partnerId))
-      .limit(1);
-    mfaStepUpEnforced =
-      Boolean(authPol?.requireEnrollment) &&
-      (!authPol?.enforceFrom || new Date(authPol.enforceFrom).getTime() <= Date.now());
-  }
-
-  const [postureRow] = await db
-    .select({ overallScore: securityPostureOrgSnapshots.overallScore })
-    .from(securityPostureOrgSnapshots)
-    .where(eq(securityPostureOrgSnapshots.orgId, orgId))
-    .orderBy(desc(securityPostureOrgSnapshots.capturedAt))
-    .limit(1);
 
   // CIS hardening pass-rate per device (latest scan), optional via config.includeCis.
   // Uses the result's aggregate columns directly — no findings-jsonb parsing needed.
@@ -516,16 +568,18 @@ export async function generateSecurityCompliancePostureReport(
         cisAvgPassRate,
         cisIncluded: cfg.includeCis,
         cisAssessedCount: cisByDevice.size,
-        // Proves an identity provider is CONNECTED, not that MFA is enforced.
-        // Real MFA enforcement is privilegedAccess.mfaStepUpEnforced.
-        identityProviderConnected: Boolean(m365 || google),
         backupRequired: cfg.backupRequired,
-        backupConfigured: Boolean(backup || c2c),
-        backupEncrypted: backup ? Boolean(backup.encryption) : null,
-        dnsFilteringActive: dnsActive,
-        dnsFilteringSyncStatus: dnsSyncStatus
+        ...(includeOrgWideEvidence ? {
+          // Proves an identity provider is CONNECTED, not that MFA is enforced.
+          // Real MFA enforcement is privilegedAccess.mfaStepUpEnforced.
+          identityProviderConnected: Boolean(m365 || google),
+          backupConfigured: Boolean(backup || c2c),
+          backupEncrypted: backup ? Boolean(backup.encryption) : null,
+          dnsFilteringActive: dnsActive,
+          dnsFilteringSyncStatus: dnsSyncStatus,
+        } : {}),
       },
-      privilegedAccess: {
+      ...(includeOrgWideEvidence ? { privilegedAccess: {
         uacInterceptionEnabled: Boolean(pamCfg?.uacInterceptionEnabled),
         activePamRules: pamRuleRows.length,
         windowDays: cfg.windowDays,
@@ -533,9 +587,9 @@ export async function generateSecurityCompliancePostureReport(
         elevationsApproved,
         elevationsDenied,
         mfaStepUpEnforced
-      },
+      } } : {}),
       securityProducts,
-      postureScore: postureRow?.overallScore ?? null
+      ...(includeOrgWideEvidence ? { postureScore: postureRow?.overallScore ?? null } : {}),
   } satisfies PostureSummary;
 
   return { rows, rowCount: rows.length, generatedAt, summary };

--- a/apps/api/src/services/siteScope.test.ts
+++ b/apps/api/src/services/siteScope.test.ts
@@ -1,0 +1,454 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  decodeSiteScope,
+  intersectSiteScopes,
+  isSiteScopeSubset,
+  normalizeSiteIds,
+  persistedSiteScopeValues,
+  siteScopeFingerprint,
+  siteScopeFromPermissions,
+  type PersistedSiteScopeColumns,
+  type ReportExecutionAuthority,
+  type SiteScopeV1,
+} from './siteScope';
+
+const ORG_A = '11111111-1111-1111-1111-111111111111';
+const ORG_B = '22222222-2222-2222-2222-222222222222';
+const SITE_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const SITE_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const SITE_C = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+const CAPTURED_AT = new Date('2026-07-25T12:34:56.000Z');
+
+const unrestricted = (orgId = ORG_A): SiteScopeV1 => ({
+  version: 1,
+  kind: 'unrestricted',
+  orgId,
+});
+
+const restricted = (
+  siteIds: string[],
+  orgId = ORG_A,
+): SiteScopeV1 => ({
+  version: 1,
+  kind: 'restricted',
+  orgId,
+  siteIds,
+});
+
+const legacy = (orgId = ORG_A): SiteScopeV1 => ({
+  version: 1,
+  kind: 'legacy_unscoped',
+  orgId,
+});
+
+function persisted(
+  overrides: Partial<PersistedSiteScopeColumns> = {},
+): PersistedSiteScopeColumns {
+  const scope = restricted([SITE_A]);
+  return {
+    executionScopeVersion: 1,
+    executionScopeKind: 'restricted',
+    executionScopeSiteIds: [SITE_A],
+    executionScopeUserId: USER_ID,
+    executionScopeFingerprint: siteScopeFingerprint(scope),
+    executionScopeCapturedAt: CAPTURED_AT,
+    ...overrides,
+  };
+}
+
+describe('canonical site-scope algebra', () => {
+  it('sorts and deduplicates restricted IDs without mutating the input', () => {
+    const input = [SITE_B, SITE_A, SITE_B];
+
+    expect(normalizeSiteIds(input)).toEqual([SITE_A, SITE_B]);
+    expect(input).toEqual([SITE_B, SITE_A, SITE_B]);
+  });
+
+  it.each([
+    {
+      name: 'undefined permissions remain unrestricted',
+      allowedSiteIds: undefined,
+      expected: unrestricted(),
+    },
+    {
+      name: 'an empty permission set remains restricted-empty',
+      allowedSiteIds: [],
+      expected: restricted([]),
+    },
+    {
+      name: 'restricted permissions are normalized',
+      allowedSiteIds: [SITE_B, SITE_A, SITE_B],
+      expected: restricted([SITE_A, SITE_B]),
+    },
+  ])('$name', ({ allowedSiteIds, expected }) => {
+    expect(
+      siteScopeFromPermissions(ORG_A, {
+        permissions: [],
+        partnerId: null,
+        orgId: ORG_A,
+        roleId: 'role-id',
+        scope: 'organization',
+        allowedSiteIds,
+      }),
+    ).toEqual(expected);
+  });
+
+  it('represents unrestricted and restricted-empty with different kinds and fingerprints', () => {
+    const openScope = unrestricted();
+    const emptyScope = restricted([]);
+
+    expect(openScope.kind).not.toBe(emptyScope.kind);
+    expect(siteScopeFingerprint(openScope)).not.toBe(siteScopeFingerprint(emptyScope));
+  });
+
+  it.each([
+    {
+      name: 'unrestricted intersect unrestricted returns current',
+      persistedScope: unrestricted(),
+      currentScope: unrestricted(),
+      expected: unrestricted(),
+    },
+    {
+      name: 'unrestricted intersect restricted returns current',
+      persistedScope: unrestricted(),
+      currentScope: restricted([SITE_B, SITE_A, SITE_B]),
+      expected: restricted([SITE_A, SITE_B]),
+    },
+    {
+      name: 'unrestricted intersect restricted-empty preserves restricted-empty',
+      persistedScope: unrestricted(),
+      currentScope: restricted([]),
+      expected: restricted([]),
+    },
+    {
+      name: 'restricted intersect unrestricted returns persisted restriction',
+      persistedScope: restricted([SITE_B, SITE_A, SITE_B]),
+      currentScope: unrestricted(),
+      expected: restricted([SITE_A, SITE_B]),
+    },
+    {
+      name: 'restricted intersect restricted returns the sorted set intersection',
+      persistedScope: restricted([SITE_C, SITE_B, SITE_A]),
+      currentScope: restricted([SITE_B, SITE_C]),
+      expected: restricted([SITE_B, SITE_C]),
+    },
+    {
+      name: 'restricted-empty intersect unrestricted remains restricted-empty',
+      persistedScope: restricted([]),
+      currentScope: unrestricted(),
+      expected: restricted([]),
+    },
+    {
+      name: 'disjoint restricted scopes fail closed',
+      persistedScope: restricted([SITE_A]),
+      currentScope: restricted([SITE_B]),
+      expected: null,
+    },
+    {
+      name: 'legacy persisted scope fails closed',
+      persistedScope: legacy(),
+      currentScope: unrestricted(),
+      expected: null,
+    },
+    {
+      name: 'legacy persisted scope with restricted current fails closed',
+      persistedScope: legacy(),
+      currentScope: restricted([SITE_A]),
+      expected: null,
+    },
+    {
+      name: 'legacy intersect legacy fails closed',
+      persistedScope: legacy(),
+      currentScope: legacy(),
+      expected: null,
+    },
+    {
+      name: 'legacy current scope fails closed',
+      persistedScope: unrestricted(),
+      currentScope: legacy(),
+      expected: null,
+    },
+    {
+      name: 'restricted intersect legacy fails closed',
+      persistedScope: restricted([SITE_A]),
+      currentScope: legacy(),
+      expected: null,
+    },
+    {
+      name: 'different organizations fail closed',
+      persistedScope: restricted([SITE_A], ORG_A),
+      currentScope: unrestricted(ORG_B),
+      expected: null,
+    },
+  ])('$name', ({ persistedScope, currentScope, expected }) => {
+    expect(intersectSiteScopes(persistedScope, currentScope)).toEqual(expected);
+  });
+
+  it.each([
+    {
+      name: 'restricted is a subset of unrestricted',
+      candidate: restricted([SITE_A]),
+      current: unrestricted(),
+      expected: true,
+    },
+    {
+      name: 'unrestricted is not a subset of restricted',
+      candidate: unrestricted(),
+      current: restricted([SITE_A]),
+      expected: false,
+    },
+    {
+      name: 'a narrower restricted set is a subset',
+      candidate: restricted([SITE_A]),
+      current: restricted([SITE_B, SITE_A]),
+      expected: true,
+    },
+    {
+      name: 'restricted-empty is a subset of a live restricted scope',
+      candidate: restricted([]),
+      current: restricted([SITE_A]),
+      expected: true,
+    },
+    {
+      name: 'a foreign site is not a subset',
+      candidate: restricted([SITE_B]),
+      current: restricted([SITE_A]),
+      expected: false,
+    },
+    {
+      name: 'a different organization is not a subset',
+      candidate: restricted([SITE_A], ORG_B),
+      current: unrestricted(ORG_A),
+      expected: false,
+    },
+    {
+      name: 'legacy candidate is visible to an unrestricted same-organization caller',
+      candidate: legacy(),
+      current: unrestricted(),
+      expected: true,
+    },
+    {
+      name: 'legacy current scope fails closed',
+      candidate: unrestricted(),
+      current: legacy(),
+      expected: false,
+    },
+  ])('$name', ({ candidate, current, expected }) => {
+    expect(isSiteScopeSubset(candidate, current)).toBe(expected);
+  });
+});
+
+describe('siteScopeFingerprint', () => {
+  it('hashes deterministic stable JSON with normalized site IDs', () => {
+    const expected = createHash('sha256')
+      .update(
+        JSON.stringify({
+          version: 1,
+          kind: 'restricted',
+          orgId: ORG_A,
+          siteIds: [SITE_A, SITE_B],
+        }),
+      )
+      .digest('hex');
+
+    expect(siteScopeFingerprint(restricted([SITE_B, SITE_A, SITE_B]))).toBe(expected);
+    expect(siteScopeFingerprint(restricted([SITE_A, SITE_B]))).toBe(expected);
+  });
+
+  it.each([
+    unrestricted(),
+    restricted([]),
+    restricted([SITE_A]),
+    legacy(),
+  ])('is deterministic for $kind', (scope) => {
+    expect(siteScopeFingerprint(scope)).toBe(siteScopeFingerprint(scope));
+    expect(siteScopeFingerprint(scope)).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+describe('persisted site-scope columns', () => {
+  it.each([
+    {
+      name: 'unrestricted authority',
+      scope: unrestricted(),
+      expectedSiteIds: null,
+    },
+    {
+      name: 'restricted authority',
+      scope: restricted([SITE_B, SITE_A, SITE_B]),
+      expectedSiteIds: [SITE_A, SITE_B],
+    },
+    {
+      name: 'restricted-empty authority',
+      scope: restricted([]),
+      expectedSiteIds: [],
+    },
+  ])('encodes a complete $name', ({ scope, expectedSiteIds }) => {
+    const normalizedScope =
+      scope.kind === 'restricted'
+        ? restricted(scope.siteIds)
+        : scope;
+    const authority: ReportExecutionAuthority = {
+      scope,
+      principalUserId: USER_ID,
+      capturedAt: CAPTURED_AT,
+      fingerprint: siteScopeFingerprint(normalizedScope),
+    };
+
+    expect(persistedSiteScopeValues(authority)).toEqual({
+      executionScopeVersion: 1,
+      executionScopeKind: normalizedScope.kind,
+      executionScopeSiteIds: expectedSiteIds,
+      executionScopeUserId: USER_ID,
+      executionScopeFingerprint: authority.fingerprint,
+      executionScopeCapturedAt: CAPTURED_AT,
+    });
+  });
+
+  it('decodes an all-null old-writer row as legacy_unscoped for the supplied organization', () => {
+    expect(
+      decodeSiteScope(
+        {
+          executionScopeVersion: null,
+          executionScopeKind: null,
+          executionScopeSiteIds: null,
+          executionScopeUserId: null,
+          executionScopeFingerprint: null,
+          executionScopeCapturedAt: null,
+        },
+        ORG_A,
+      ),
+    ).toEqual(legacy());
+  });
+
+  it.each([
+    {
+      name: 'complete unrestricted',
+      row: persisted({
+        executionScopeKind: 'unrestricted',
+        executionScopeSiteIds: null,
+        executionScopeFingerprint: siteScopeFingerprint(unrestricted()),
+      }),
+      expected: unrestricted(),
+    },
+    {
+      name: 'complete restricted',
+      row: persisted({
+        executionScopeSiteIds: [SITE_B, SITE_A, SITE_B],
+        executionScopeFingerprint: siteScopeFingerprint(restricted([SITE_A, SITE_B])),
+      }),
+      expected: restricted([SITE_A, SITE_B]),
+    },
+    {
+      name: 'complete restricted-empty',
+      row: persisted({
+        executionScopeSiteIds: [],
+        executionScopeFingerprint: siteScopeFingerprint(restricted([])),
+      }),
+      expected: restricted([]),
+    },
+    {
+      name: 'complete legacy with nullable initiating user',
+      row: persisted({
+        executionScopeKind: 'legacy_unscoped',
+        executionScopeSiteIds: null,
+        executionScopeUserId: null,
+        executionScopeFingerprint: siteScopeFingerprint(legacy()),
+      }),
+      expected: legacy(),
+    },
+  ])('decodes a $name row', ({ row, expected }) => {
+    expect(decodeSiteScope(row, ORG_A)).toEqual(expected);
+  });
+
+  it.each([
+    ['executionScopeVersion', 1],
+    ['executionScopeKind', 'restricted'],
+    ['executionScopeSiteIds', []],
+    ['executionScopeUserId', USER_ID],
+    ['executionScopeFingerprint', 'f'.repeat(64)],
+    ['executionScopeCapturedAt', CAPTURED_AT],
+  ] as const)('rejects an all-null row with only %s populated', (field, value) => {
+    expect(() =>
+      decodeSiteScope(
+        {
+          executionScopeVersion: null,
+          executionScopeKind: null,
+          executionScopeSiteIds: null,
+          executionScopeUserId: null,
+          executionScopeFingerprint: null,
+          executionScopeCapturedAt: null,
+          [field]: value,
+        },
+        ORG_A,
+      ),
+    ).toThrow(/partial|invalid|malformed/i);
+  });
+
+  it.each([
+    {
+      name: 'unknown version',
+      row: persisted({ executionScopeVersion: 2 }),
+    },
+    {
+      name: 'unknown kind',
+      row: persisted({ executionScopeKind: 'unknown' as 'restricted' }),
+    },
+    {
+      name: 'restricted without a site array',
+      row: persisted({ executionScopeSiteIds: null }),
+    },
+    {
+      name: 'restricted without a user',
+      row: persisted({ executionScopeUserId: null }),
+    },
+    {
+      name: 'unrestricted with a site array',
+      row: persisted({
+        executionScopeKind: 'unrestricted',
+        executionScopeSiteIds: [],
+      }),
+    },
+    {
+      name: 'unrestricted without a user',
+      row: persisted({
+        executionScopeKind: 'unrestricted',
+        executionScopeSiteIds: null,
+        executionScopeUserId: null,
+      }),
+    },
+    {
+      name: 'legacy with a site array',
+      row: persisted({
+        executionScopeKind: 'legacy_unscoped',
+        executionScopeSiteIds: [],
+      }),
+    },
+    {
+      name: 'missing fingerprint',
+      row: persisted({ executionScopeFingerprint: null }),
+    },
+    {
+      name: 'missing capture time',
+      row: persisted({ executionScopeCapturedAt: null }),
+    },
+    {
+      name: 'invalid capture time',
+      row: persisted({ executionScopeCapturedAt: new Date(Number.NaN) }),
+    },
+    {
+      name: 'malformed fingerprint',
+      row: persisted({ executionScopeFingerprint: 'not-a-sha256-digest' }),
+    },
+    {
+      name: 'fingerprint for a different scope',
+      row: persisted({
+        executionScopeFingerprint: siteScopeFingerprint(restricted([SITE_B])),
+      }),
+    },
+  ])('rejects $name', ({ row }) => {
+    expect(() => decodeSiteScope(row, ORG_A)).toThrow(/partial|invalid|malformed/i);
+  });
+});

--- a/apps/api/src/services/siteScope.test.ts
+++ b/apps/api/src/services/siteScope.test.ts
@@ -2,7 +2,8 @@ import { createHash } from 'node:crypto';
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import type { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { reports } from '../db/schema';
+import { reportRuns, reports } from '../db/schema';
+import * as siteScopeModule from './siteScope';
 
 const liveDbState = vi.hoisted(() => ({
   rows: [] as Array<unknown[] | Error>,
@@ -627,6 +628,169 @@ describe('report definition scope SQL predicates', () => {
 
     expect(rendered.params).toContain(ORG_A);
     expect(rendered.params).not.toContain(ORG_B);
+  });
+});
+
+describe('report run scope SQL predicates', () => {
+  const task5SiteScope = siteScopeModule as unknown as {
+    reportRunScopeSqlPredicate: (
+      columns: typeof reportRuns,
+      scope: LiveSiteScopeV1,
+    ) => SQL;
+    unrestrictedReportRunScopeSqlPredicate: (
+      columns: typeof reportRuns,
+    ) => SQL;
+    reportRunMultiOrgScopeSqlPredicate: (
+      rowOrgId: typeof reports.orgId,
+      columns: typeof reportRuns,
+      scopes: readonly LiveSiteScopeV1[],
+    ) => SQL;
+  };
+
+  it.each([
+    {
+      name: 'unrestricted admits complete unrestricted, restricted, legacy, and all-null rows',
+      scope: unrestricted(),
+      expectedKinds: ['unrestricted', 'restricted', 'legacy_unscoped'],
+      expectedSql: ['is null', 'is not null'],
+      forbiddenSql: ['<@'],
+    },
+    {
+      name: 'restricted admits only complete restricted subset rows',
+      scope: restricted([SITE_B, SITE_A, SITE_B]),
+      expectedKinds: ['restricted'],
+      expectedSql: ['<@', 'array['],
+      forbiddenSql: [],
+    },
+    {
+      name: 'restricted-empty remains a valid bound subset',
+      scope: restricted([]),
+      expectedKinds: ['restricted'],
+      expectedSql: ['<@', 'array[]::uuid[]'],
+      forbiddenSql: [],
+    },
+  ])(
+    '$name',
+    ({ scope, expectedKinds, expectedSql, forbiddenSql }) => {
+      const rendered = renderSql(
+        task5SiteScope.reportRunScopeSqlPredicate(reportRuns, scope),
+      );
+
+      for (const fragment of expectedSql) {
+        expect(rendered.sql.toLowerCase()).toContain(fragment);
+      }
+      for (const fragment of forbiddenSql) {
+        expect(rendered.sql.toLowerCase()).not.toContain(fragment);
+      }
+      expect(rendered.sql).not.toContain(ORG_A);
+      expect(rendered.sql).not.toContain(SITE_A);
+      expect(rendered.sql).not.toContain(SITE_B);
+      for (const kind of expectedKinds) {
+        expect(rendered.params).toContain(kind);
+      }
+      if (scope.kind === 'restricted') {
+        for (const siteId of normalizeSiteIds(scope.siteIds)) {
+          expect(rendered.params).toContain(siteId);
+        }
+      }
+    },
+  );
+
+  it('rejects unrestricted, legacy, all-null, foreign-site, partial, invalid-kind, and invalid-version rows from the restricted SQL branch', () => {
+    const rendered = renderSql(
+      task5SiteScope.reportRunScopeSqlPredicate(
+        reportRuns,
+        restricted([SITE_A]),
+      ),
+    );
+
+    expect(rendered.params).toContain('restricted');
+    expect(rendered.params).not.toContain('unrestricted');
+    expect(rendered.params).not.toContain('legacy_unscoped');
+    expect(rendered.sql.toLowerCase()).toContain('<@');
+    expect(rendered.sql.toLowerCase()).toContain('is not null');
+    expect(rendered.sql.toLowerCase()).not.toContain(' or ');
+    expect(rendered.params).toContain(SITE_A);
+    expect(rendered.params).not.toContain(SITE_B);
+  });
+
+  it('fails closed for a forced runtime legacy caller scope', () => {
+    const rendered = renderSql(
+      task5SiteScope.reportRunScopeSqlPredicate(
+        reportRuns,
+        legacy() as unknown as LiveSiteScopeV1,
+      ),
+    );
+
+    expect(rendered.sql.toLowerCase()).toContain('false');
+    expect(rendered.params).toEqual([]);
+  });
+
+  it('exposes exactly the same unrestricted run branch without a fabricated organization', () => {
+    const exact = renderSql(
+      task5SiteScope.reportRunScopeSqlPredicate(
+        reportRuns,
+        unrestricted(),
+      ),
+    );
+    const system = renderSql(
+      task5SiteScope.unrestrictedReportRunScopeSqlPredicate(reportRuns),
+    );
+
+    expect(system).toEqual(exact);
+    expect(system.sql).not.toContain(ORG_A);
+  });
+
+  it('builds bound per-organization run branches for unrestricted A and Site B1-restricted B', () => {
+    const rendered = renderSql(
+      task5SiteScope.reportRunMultiOrgScopeSqlPredicate(
+        reports.orgId,
+        reportRuns,
+        [
+          unrestricted(ORG_A),
+          restricted([SITE_B, SITE_A, SITE_B], ORG_B),
+        ],
+      ),
+    );
+
+    expect(rendered.sql.toLowerCase()).toContain(' or ');
+    expect(rendered.sql.toLowerCase()).toContain('<@');
+    for (const value of [ORG_A, ORG_B, SITE_A, SITE_B]) {
+      expect(rendered.sql).not.toContain(value);
+      expect(rendered.params).toContain(value);
+    }
+  });
+
+  it('deduplicates run organizations/sites and omits restricted-empty organizations', () => {
+    const rendered = renderSql(
+      task5SiteScope.reportRunMultiOrgScopeSqlPredicate(
+        reports.orgId,
+        reportRuns,
+        [
+          restricted([SITE_B, SITE_A, SITE_B], ORG_A),
+          restricted([SITE_A, SITE_B], ORG_A),
+          restricted([], ORG_B),
+        ],
+      ),
+    );
+
+    expect(rendered.params.filter((value) => value === ORG_A)).toHaveLength(1);
+    expect(rendered.params.filter((value) => value === ORG_B)).toHaveLength(0);
+    expect(rendered.params.filter((value) => value === SITE_A)).toHaveLength(1);
+    expect(rendered.params.filter((value) => value === SITE_B)).toHaveLength(1);
+  });
+
+  it('returns SQL FALSE when no organization has a successful non-empty run scope', () => {
+    const rendered = renderSql(
+      task5SiteScope.reportRunMultiOrgScopeSqlPredicate(
+        reports.orgId,
+        reportRuns,
+        [],
+      ),
+    );
+
+    expect(rendered.sql.toLowerCase()).toContain('false');
+    expect(rendered.params).toEqual([]);
   });
 });
 

--- a/apps/api/src/services/siteScope.test.ts
+++ b/apps/api/src/services/siteScope.test.ts
@@ -1,17 +1,65 @@
 import { createHash } from 'node:crypto';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { reports } from '../db/schema';
+
+const liveDbState = vi.hoisted(() => ({
+  rows: [] as Array<unknown[] | Error>,
+  projections: [] as unknown[],
+  fromTables: [] as unknown[],
+  whereConditions: [] as unknown[],
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn((projection?: unknown) => {
+      liveDbState.projections.push(projection);
+      const result = liveDbState.rows.shift() ?? [];
+      const promise = result instanceof Error
+        ? Promise.reject(result)
+        : Promise.resolve(result);
+      const chain: any = {
+        from: vi.fn((table: unknown) => {
+          liveDbState.fromTables.push(table);
+          return chain;
+        }),
+        innerJoin: vi.fn(() => chain),
+        where: vi.fn((condition: unknown) => {
+          liveDbState.whereConditions.push(condition);
+          return chain;
+        }),
+        limit: vi.fn(() => chain),
+        then: promise.then.bind(promise),
+      };
+      return chain;
+    }),
+  },
+  runOutsideDbContext: vi.fn((callback: () => unknown) => callback()),
+  withSystemDbAccessContext: vi.fn((callback: () => unknown) => callback()),
+}));
+
 import {
   decodeSiteScope,
   intersectSiteScopes,
   isSiteScopeSubset,
   normalizeSiteIds,
   persistedSiteScopeValues,
+  reportDefinitionMultiOrgScopeSqlPredicate,
+  reportDefinitionScopeSqlPredicate,
+  resolveLiveReportAuthority,
+  resolveRequestReportAuthority,
+  resolveRequestReportAuthorityMap,
   siteScopeFingerprint,
   siteScopeFromPermissions,
+  unrestrictedReportDefinitionScopeSqlPredicate,
+  type LiveSiteScopeV1,
   type PersistedSiteScopeColumns,
+  type ReportAction,
   type ReportExecutionAuthority,
   type SiteScopeV1,
 } from './siteScope';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 
 const ORG_A = '11111111-1111-1111-1111-111111111111';
 const ORG_B = '22222222-2222-2222-2222-222222222222';
@@ -21,7 +69,7 @@ const SITE_C = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 const USER_ID = '33333333-3333-4333-8333-333333333333';
 const CAPTURED_AT = new Date('2026-07-25T12:34:56.000Z');
 
-const unrestricted = (orgId = ORG_A): SiteScopeV1 => ({
+const unrestricted = (orgId = ORG_A): LiveSiteScopeV1 => ({
   version: 1,
   kind: 'unrestricted',
   orgId,
@@ -30,7 +78,7 @@ const unrestricted = (orgId = ORG_A): SiteScopeV1 => ({
 const restricted = (
   siteIds: string[],
   orgId = ORG_A,
-): SiteScopeV1 => ({
+): LiveSiteScopeV1 => ({
   version: 1,
   kind: 'restricted',
   orgId,
@@ -56,6 +104,11 @@ function persisted(
     executionScopeCapturedAt: CAPTURED_AT,
     ...overrides,
   };
+}
+
+function renderSql(condition: SQL): { sql: string; params: unknown[] } {
+  const rendered = new PgDialect().sqlToQuery(condition);
+  return { sql: rendered.sql, params: rendered.params };
 }
 
 describe('canonical site-scope algebra', () => {
@@ -450,5 +503,846 @@ describe('persisted site-scope columns', () => {
     },
   ])('rejects $name', ({ row }) => {
     expect(() => decodeSiteScope(row, ORG_A)).toThrow(/partial|invalid|malformed/i);
+  });
+});
+
+describe('report definition scope SQL predicates', () => {
+  it.each([
+    {
+      name: 'unrestricted includes complete and old-writer shapes',
+      scope: unrestricted() as LiveSiteScopeV1,
+      includes: ['is null', 'is not null'],
+      excludes: ['<@'],
+      expectedKinds: ['unrestricted', 'restricted', 'legacy_unscoped'],
+    },
+    {
+      name: 'restricted uses only the complete subset branch',
+      scope: restricted([SITE_B, SITE_A, SITE_B]) as LiveSiteScopeV1,
+      includes: ['<@', 'array['],
+      excludes: [],
+      expectedKinds: ['restricted'],
+    },
+    {
+      name: 'restricted-empty remains a bound subset check',
+      scope: restricted([]) as LiveSiteScopeV1,
+      includes: ['<@', 'array[]::uuid[]'],
+      excludes: [],
+      expectedKinds: ['restricted'],
+    },
+  ])('$name', ({ scope, includes, excludes, expectedKinds }) => {
+    const rendered = renderSql(reportDefinitionScopeSqlPredicate(reports, scope));
+
+    for (const fragment of includes) {
+      expect(rendered.sql.toLowerCase()).toContain(fragment);
+    }
+    for (const fragment of excludes) {
+      expect(rendered.sql.toLowerCase()).not.toContain(fragment);
+    }
+    expect(rendered.sql).not.toContain(ORG_A);
+    expect(rendered.sql).not.toContain(SITE_A);
+    expect(rendered.sql).not.toContain(SITE_B);
+    for (const kind of expectedKinds) {
+      expect(rendered.params).toContain(kind);
+    }
+    if (scope.kind === 'restricted') {
+      for (const siteId of normalizeSiteIds(scope.siteIds)) {
+        expect(rendered.params).toContain(siteId);
+      }
+    }
+  });
+
+  it('fails closed for a forced legacy live caller value', () => {
+    const rendered = renderSql(
+      reportDefinitionScopeSqlPredicate(
+        reports,
+        legacy() as unknown as LiveSiteScopeV1,
+      ),
+    );
+
+    expect(rendered.sql.toLowerCase()).toContain('false');
+    expect(rendered.params).toEqual([]);
+  });
+
+  it('exposes the same unrestricted branch without a fabricated organization', () => {
+    const exact = renderSql(
+      reportDefinitionScopeSqlPredicate(reports, unrestricted()),
+    );
+    const system = renderSql(
+      unrestrictedReportDefinitionScopeSqlPredicate(reports),
+    );
+
+    expect(system).toEqual(exact);
+    expect(system.sql).not.toContain(ORG_A);
+  });
+
+  it('builds bound per-organization branches', () => {
+    const rendered = renderSql(
+      reportDefinitionMultiOrgScopeSqlPredicate(reports.orgId, reports, [
+        unrestricted(ORG_A),
+        restricted([SITE_B, SITE_A, SITE_B], ORG_B),
+      ]),
+    );
+
+    expect(rendered.sql.toLowerCase()).toContain(' or ');
+    expect(rendered.sql.toLowerCase()).toContain('<@');
+    expect(rendered.sql).not.toContain(ORG_A);
+    expect(rendered.sql).not.toContain(ORG_B);
+    expect(rendered.sql).not.toContain(SITE_A);
+    expect(rendered.sql).not.toContain(SITE_B);
+    expect(rendered.params).toContain(ORG_A);
+    expect(rendered.params).toContain(ORG_B);
+    expect(rendered.params).toContain(SITE_A);
+    expect(rendered.params).toContain(SITE_B);
+  });
+
+  it('deduplicates organizations and site IDs before binding', () => {
+    const rendered = renderSql(
+      reportDefinitionMultiOrgScopeSqlPredicate(reports.orgId, reports, [
+        restricted([SITE_B, SITE_A, SITE_B], ORG_A),
+        restricted([SITE_A, SITE_B], ORG_A),
+      ]),
+    );
+
+    expect(rendered.params.filter((value) => value === ORG_A)).toHaveLength(1);
+    expect(rendered.params.filter((value) => value === SITE_A)).toHaveLength(1);
+    expect(rendered.params.filter((value) => value === SITE_B)).toHaveLength(1);
+  });
+
+  it('returns SQL FALSE for an empty multi-organization scope list', () => {
+    const rendered = renderSql(
+      reportDefinitionMultiOrgScopeSqlPredicate(reports.orgId, reports, []),
+    );
+
+    expect(rendered.sql.toLowerCase()).toContain('false');
+    expect(rendered.params).toEqual([]);
+  });
+
+  it('omits restricted-empty organizations from a composite predicate', () => {
+    const rendered = renderSql(
+      reportDefinitionMultiOrgScopeSqlPredicate(reports.orgId, reports, [
+        unrestricted(ORG_A),
+        restricted([], ORG_B),
+      ]),
+    );
+
+    expect(rendered.params).toContain(ORG_A);
+    expect(rendered.params).not.toContain(ORG_B);
+  });
+});
+
+describe('live report authority resolution', () => {
+  const PARTNER_A = '44444444-4444-4444-8444-444444444444';
+  const PARTNER_B = '55555555-5555-4555-8555-555555555555';
+  const ROLE_ORG = '66666666-6666-4666-8666-666666666666';
+  const ROLE_PARTNER = '77777777-7777-4777-8777-777777777777';
+
+  function queueRows(...rows: Array<unknown[] | Error>) {
+    liveDbState.rows.push(...rows);
+  }
+
+  function activeUser(overrides: Record<string, unknown> = {}) {
+    return {
+      id: USER_ID,
+      status: 'active',
+      isPlatformAdmin: false,
+      partnerId: PARTNER_A,
+      ...overrides,
+    };
+  }
+
+  function organization(id = ORG_A, partnerId = PARTNER_A) {
+    return { id, partnerId };
+  }
+
+  function orgMembership(siteIds: string[] | null, roleId: string | null = ROLE_ORG) {
+    return { roleId, siteIds };
+  }
+
+  function permission(
+    action: ReportAction,
+    scope: 'organization' | 'partner' = 'organization',
+  ) {
+    return {
+      resource: 'reports',
+      action,
+      roleScope: scope,
+      roleIsSystem: false,
+      roleOrgId: scope === 'organization' ? ORG_A : null,
+      rolePartnerId: PARTNER_A,
+    };
+  }
+
+  function requestAuth(overrides: Record<string, unknown> = {}) {
+    return {
+      user: {
+        id: USER_ID,
+        email: 'security@example.com',
+        name: 'Security User',
+        isPlatformAdmin: false,
+      },
+      token: {},
+      partnerId: PARTNER_A,
+      orgId: ORG_A,
+      scope: 'organization',
+      accessibleOrgIds: [ORG_A],
+      orgCondition: vi.fn(),
+      canAccessOrg: (orgId: string) => orgId === ORG_A,
+      ...overrides,
+    } as any;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    liveDbState.rows.length = 0;
+    liveDbState.projections.length = 0;
+    liveDbState.fromTables.length = 0;
+    liveDbState.whereConditions.length = 0;
+  });
+
+  it('requires an explicit report action on every resolver', () => {
+    expectTypeOf<Parameters<typeof resolveLiveReportAuthority>['length']>()
+      .toEqualTypeOf<3>();
+    expectTypeOf<Parameters<typeof resolveRequestReportAuthority>['length']>()
+      .toEqualTypeOf<3>();
+    expectTypeOf<Parameters<typeof resolveRequestReportAuthorityMap>['length']>()
+      .toEqualTypeOf<3>();
+    expectTypeOf(resolveLiveReportAuthority).parameter(2).toEqualTypeOf<ReportAction>();
+    expectTypeOf(resolveRequestReportAuthority).parameter(2).toEqualTypeOf<ReportAction>();
+    expectTypeOf(resolveRequestReportAuthorityMap).parameter(2).toEqualTypeOf<ReportAction>();
+  });
+
+  it.each([
+    {
+      name: 'organization NULL sites are unrestricted',
+      siteIds: null,
+      expected: unrestricted(),
+    },
+    {
+      name: 'organization sites are normalized and restricted',
+      siteIds: [SITE_B, SITE_A, SITE_B],
+      expected: restricted([SITE_A, SITE_B]),
+    },
+  ])('$name', async ({ siteIds, expected }) => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [orgMembership(siteIds)],
+      [permission('read')],
+    );
+
+    const result = await resolveLiveReportAuthority(USER_ID, ORG_A, 'read');
+
+    expect(result).toMatchObject({
+      ok: true,
+      authority: {
+        scope: expected,
+        principalUserId: USER_ID,
+      },
+    });
+    if (result.ok) {
+      expect(result.authority.fingerprint).toBe(siteScopeFingerprint(expected));
+      expect(result.authority.capturedAt).toBeInstanceOf(Date);
+    }
+  });
+
+  it('returns empty_scope for an authoritative restricted-empty organization membership', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [orgMembership([])],
+      [permission('read')],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'empty_scope' });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(4);
+  });
+
+  it('never falls through to broader partner authority when an organization row lacks permission', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [orgMembership([SITE_A])],
+      [],
+      [{ roleId: ROLE_PARTNER, orgAccess: 'all', orgIds: null }],
+      [permission('read', 'partner')],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'permission_removed' });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(4);
+    expect(liveDbState.rows).toHaveLength(2);
+  });
+
+  it('fails closed when an organization membership points at a role owned by another organization', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [orgMembership([SITE_A])],
+      [{
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'organization',
+        roleIsSystem: false,
+        roleOrgId: ORG_B,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'permission_removed' });
+  });
+
+  it('fails closed when duplicate organization memberships exist', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [orgMembership(null), orgMembership([SITE_A])],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'unverifiable_scope' });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(3);
+  });
+
+  it('accepts a system-defined organization role with no tenant owner', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [orgMembership([SITE_A])],
+      [{
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'organization',
+        roleIsSystem: true,
+        roleOrgId: null,
+        rolePartnerId: null,
+      }],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toMatchObject({
+        ok: true,
+        authority: { scope: restricted([SITE_A]) },
+      });
+  });
+
+  it.each([
+    {
+      name: 'all organizations',
+      orgAccess: 'all',
+      orgIds: null,
+    },
+    {
+      name: 'an admitted selected organization',
+      orgAccess: 'selected',
+      orgIds: [ORG_B, ORG_A],
+    },
+  ])('uses unrestricted partner fallback for $name', async ({ orgAccess, orgIds }) => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [],
+      [{ roleId: ROLE_PARTNER, orgAccess, orgIds }],
+      [permission('read', 'partner')],
+    );
+
+    const result = await resolveLiveReportAuthority(USER_ID, ORG_A, 'read');
+
+    expect(result).toMatchObject({
+      ok: true,
+      authority: { scope: unrestricted() },
+    });
+  });
+
+  it.each([
+    {
+      name: 'org_access none',
+      membership: { roleId: ROLE_PARTNER, orgAccess: 'none', orgIds: null },
+      userPartnerId: PARTNER_A,
+      orgPartnerId: PARTNER_A,
+      expected: 'organization_inaccessible',
+    },
+    {
+      name: 'selected list misses the organization',
+      membership: { roleId: ROLE_PARTNER, orgAccess: 'selected', orgIds: [ORG_B] },
+      userPartnerId: PARTNER_A,
+      orgPartnerId: PARTNER_A,
+      expected: 'organization_inaccessible',
+    },
+    {
+      name: 'partner membership was removed',
+      membership: null,
+      userPartnerId: PARTNER_A,
+      orgPartnerId: PARTNER_A,
+      expected: 'membership_removed',
+    },
+    {
+      name: 'organization belongs to another partner',
+      membership: null,
+      userPartnerId: PARTNER_A,
+      orgPartnerId: PARTNER_B,
+      expected: 'organization_inaccessible',
+    },
+  ])('denies partner fallback when $name', async ({
+    membership,
+    userPartnerId,
+    orgPartnerId,
+    expected,
+  }) => {
+    queueRows(
+      [activeUser({ partnerId: userPartnerId })],
+      [organization(ORG_A, orgPartnerId)],
+      [],
+      ...(userPartnerId === orgPartnerId
+        ? [membership ? [membership] : []]
+        : []),
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: expected });
+  });
+
+  it('denies partner fallback without exactly reports:<action>', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [],
+      [{ roleId: ROLE_PARTNER, orgAccess: 'all', orgIds: null }],
+      [permission('read', 'partner')],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'delete'))
+      .resolves.toEqual({ ok: false, reason: 'permission_removed' });
+    const renderedPermissionWhere = renderSql(
+      liveDbState.whereConditions.at(-1) as SQL,
+    );
+    expect(renderedPermissionWhere.params).toContain('delete');
+    expect(renderedPermissionWhere.params).not.toContain('read');
+  });
+
+  it('fails closed when duplicate partner memberships exist', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [],
+      [
+        { roleId: ROLE_PARTNER, orgAccess: 'all', orgIds: null },
+        { roleId: ROLE_PARTNER, orgAccess: 'none', orgIds: null },
+      ],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'unverifiable_scope' });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(4);
+  });
+
+  it.each<ReportAction>(['read', 'write', 'export', 'delete'])(
+    'checks the exact reports:%s grant',
+    async (action) => {
+      queueRows(
+        [activeUser()],
+        [organization()],
+        [orgMembership(null)],
+        [permission(action)],
+      );
+
+      const result = await resolveLiveReportAuthority(USER_ID, ORG_A, action);
+
+      expect(result.ok).toBe(true);
+      const renderedPermissionWhere = renderSql(
+        liveDbState.whereConditions.at(-1) as SQL,
+      );
+      expect(renderedPermissionWhere.params).toContain('reports');
+      expect(renderedPermissionWhere.params).toContain(action);
+    },
+  );
+
+  it('returns unrestricted for current scheduled platform authority', async () => {
+    queueRows(
+      [activeUser({ isPlatformAdmin: true })],
+      [organization()],
+    );
+
+    const result = await resolveLiveReportAuthority(USER_ID, ORG_A, 'read');
+
+    expect(result).toMatchObject({
+      ok: true,
+      authority: { scope: unrestricted() },
+    });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(2);
+  });
+
+  it('requires current platform-admin proof for a system request', async () => {
+    queueRows(
+      [activeUser({ isPlatformAdmin: false })],
+      [organization()],
+      [],
+      [],
+    );
+    const auth = requestAuth({
+      scope: 'system',
+      orgId: null,
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+      user: {
+        id: USER_ID,
+        email: 'security@example.com',
+        name: 'Security User',
+        isPlatformAdmin: true,
+      },
+    });
+
+    await expect(resolveRequestReportAuthority(auth, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'membership_removed' });
+  });
+
+  it('returns unrestricted for a system request with current platform-admin proof', async () => {
+    queueRows(
+      [activeUser({ isPlatformAdmin: true })],
+      [organization()],
+    );
+    const auth = requestAuth({
+      scope: 'system',
+      orgId: null,
+      accessibleOrgIds: null,
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthority(auth, ORG_A, 'read');
+
+    expect(result).toMatchObject({
+      ok: true,
+      authority: { scope: unrestricted() },
+    });
+  });
+
+  it('rejects an inaccessible request organization before the authorization callback', async () => {
+    const auth = requestAuth({
+      accessibleOrgIds: [],
+      canAccessOrg: () => false,
+    });
+
+    await expect(resolveRequestReportAuthority(auth, ORG_B, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'organization_inaccessible' });
+    expect(runOutsideDbContext).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContext).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'inactive user',
+      rows: [[activeUser({ status: 'disabled' })]],
+      expected: 'user_inactive',
+    },
+    {
+      name: 'missing organization',
+      rows: [[activeUser()], []],
+      expected: 'organization_inaccessible',
+    },
+    {
+      name: 'missing organization role',
+      rows: [[activeUser()], [organization()], [orgMembership(null, null)]],
+      expected: 'permission_removed',
+    },
+    {
+      name: 'no organization or partner membership',
+      rows: [[activeUser()], [organization()], [], []],
+      expected: 'membership_removed',
+    },
+    {
+      name: 'database inconsistency',
+      rows: [new Error('database unavailable')],
+      expected: 'unverifiable_scope',
+    },
+  ])('returns a bounded denial for $name', async ({ rows, expected }) => {
+    queueRows(...(rows as Array<unknown[] | Error>));
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: expected });
+  });
+
+  it('selects site IDs only from organization membership, never from roles', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [orgMembership([SITE_A])],
+      [permission('read')],
+    );
+
+    await resolveLiveReportAuthority(USER_ID, ORG_A, 'read');
+
+    const projectionKeys = liveDbState.projections.flatMap((projection) =>
+      projection && typeof projection === 'object'
+        ? Object.keys(projection)
+        : []
+    );
+    expect(projectionKeys).toContain('siteIds');
+    expect(projectionKeys).not.toEqual(
+      expect.arrayContaining(['roleSiteIds', 'allowedSiteIds'])
+    );
+  });
+
+  it('batch-resolves each organization independently with membership precedence', async () => {
+    queueRows(
+      [activeUser()],
+      [organization(ORG_A), organization(ORG_B)],
+      [{ orgId: ORG_B, roleId: ROLE_ORG, siteIds: [SITE_B, SITE_B] }],
+      [{
+        roleId: ROLE_ORG,
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'organization',
+        roleIsSystem: false,
+        roleOrgId: ORG_B,
+        rolePartnerId: PARTNER_A,
+      }],
+      [{
+        partnerId: PARTNER_A,
+        roleId: ROLE_PARTNER,
+        orgAccess: 'all',
+        orgIds: null,
+      }],
+      [{
+        roleId: ROLE_PARTNER,
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'partner',
+        roleIsSystem: false,
+        roleOrgId: null,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A, ORG_B],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_B, ORG_A, ORG_B],
+      'read',
+    );
+
+    expect(result.get(ORG_A)).toMatchObject({
+      ok: true,
+      authority: { scope: unrestricted(ORG_A) },
+    });
+    expect(result.get(ORG_B)).toMatchObject({
+      ok: true,
+      authority: { scope: restricted([SITE_B], ORG_B) },
+    });
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(6);
+  });
+
+  it('keeps an empty organization membership denied in the batch and never falls through', async () => {
+    queueRows(
+      [activeUser()],
+      [organization(ORG_A), organization(ORG_B)],
+      [{ orgId: ORG_B, roleId: ROLE_ORG, siteIds: [] }],
+      [{
+        roleId: ROLE_ORG,
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'organization',
+        roleIsSystem: false,
+        roleOrgId: ORG_B,
+        rolePartnerId: PARTNER_A,
+      }],
+      [{
+        partnerId: PARTNER_A,
+        roleId: ROLE_PARTNER,
+        orgAccess: 'all',
+        orgIds: null,
+      }],
+      [{
+        roleId: ROLE_PARTNER,
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'partner',
+        roleIsSystem: false,
+        roleOrgId: null,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A, ORG_B],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_A, ORG_B],
+      'read',
+    );
+
+    expect(result.get(ORG_A)?.ok).toBe(true);
+    expect(result.get(ORG_B)).toEqual({ ok: false, reason: 'empty_scope' });
+  });
+
+  it('fails a batched organization branch closed when its role belongs to another organization', async () => {
+    queueRows(
+      [activeUser()],
+      [organization(ORG_B)],
+      [{ orgId: ORG_B, roleId: ROLE_ORG, siteIds: [SITE_B] }],
+      [{
+        roleId: ROLE_ORG,
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'organization',
+        roleIsSystem: false,
+        roleOrgId: ORG_A,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_B],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_B],
+      'read',
+    );
+
+    expect(result.get(ORG_B)).toEqual({
+      ok: false,
+      reason: 'permission_removed',
+    });
+  });
+
+  it('fails only the affected batch branch closed on duplicate organization memberships', async () => {
+    queueRows(
+      [activeUser()],
+      [organization(ORG_A), organization(ORG_B)],
+      [
+        { orgId: ORG_B, roleId: ROLE_ORG, siteIds: null },
+        { orgId: ORG_B, roleId: ROLE_ORG, siteIds: [SITE_B] },
+      ],
+      [{
+        partnerId: PARTNER_A,
+        roleId: ROLE_PARTNER,
+        orgAccess: 'all',
+        orgIds: null,
+      }],
+      [{
+        roleId: ROLE_PARTNER,
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'partner',
+        roleIsSystem: false,
+        roleOrgId: null,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A, ORG_B],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_A, ORG_B],
+      'read',
+    );
+
+    expect(result.get(ORG_A)?.ok).toBe(true);
+    expect(result.get(ORG_B)).toEqual({
+      ok: false,
+      reason: 'unverifiable_scope',
+    });
+  });
+
+  it('fails all affected batch branches closed on duplicate partner memberships', async () => {
+    queueRows(
+      [activeUser()],
+      [organization(ORG_A), organization(ORG_B)],
+      [],
+      [
+        {
+          partnerId: PARTNER_A,
+          roleId: ROLE_PARTNER,
+          orgAccess: 'all',
+          orgIds: null,
+        },
+        {
+          partnerId: PARTNER_A,
+          roleId: ROLE_PARTNER,
+          orgAccess: 'selected',
+          orgIds: [ORG_A],
+        },
+      ],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A, ORG_B],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_A, ORG_B],
+      'read',
+    );
+
+    expect(result.get(ORG_A)).toEqual({
+      ok: false,
+      reason: 'unverifiable_scope',
+    });
+    expect(result.get(ORG_B)).toEqual({
+      ok: false,
+      reason: 'unverifiable_scope',
+    });
+  });
+
+  it('accepts a system-defined partner role in the batched fallback', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [],
+      [{
+        partnerId: PARTNER_A,
+        roleId: ROLE_PARTNER,
+        orgAccess: 'all',
+        orgIds: null,
+      }],
+      [{
+        roleId: ROLE_PARTNER,
+        resource: 'reports',
+        action: 'read',
+        roleScope: 'partner',
+        roleIsSystem: true,
+        roleOrgId: null,
+        rolePartnerId: null,
+      }],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_A],
+      'read',
+    );
+
+    expect(result.get(ORG_A)).toMatchObject({
+      ok: true,
+      authority: { scope: unrestricted() },
+    });
   });
 });

--- a/apps/api/src/services/siteScope.ts
+++ b/apps/api/src/services/siteScope.ts
@@ -18,7 +18,7 @@ import {
   roles,
   users,
 } from '../db/schema';
-import type { reports } from '../db/schema';
+import type { reportRuns, reports } from '../db/schema';
 import {
   db,
   runOutsideDbContext,
@@ -411,8 +411,8 @@ export function persistedSiteScopeValues(
   }
 }
 
-type ReportDefinitionScopeColumns = Pick<
-  typeof reports,
+type ReportScopeColumns = Pick<
+  typeof reports | typeof reportRuns,
   | 'executionScopeVersion'
   | 'executionScopeKind'
   | 'executionScopeSiteIds'
@@ -435,7 +435,7 @@ function uuidArraySql(siteIds: readonly string[]): SQL<unknown> {
 }
 
 function completeVersionOneBase(
-  columns: ReportDefinitionScopeColumns,
+  columns: ReportScopeColumns,
 ): SQL<unknown> {
   return and(
     eq(columns.executionScopeVersion, 1),
@@ -446,7 +446,7 @@ function completeVersionOneBase(
 }
 
 function unrestrictedDefinitionPredicate(
-  columns: ReportDefinitionScopeColumns,
+  columns: ReportScopeColumns,
 ): SQL<unknown> {
   const completeBase = completeVersionOneBase(columns);
   return or(
@@ -479,7 +479,7 @@ function unrestrictedDefinitionPredicate(
 }
 
 function definitionScopePredicate(
-  columns: ReportDefinitionScopeColumns,
+  columns: ReportScopeColumns,
   currentScope: LiveSiteScopeV1,
 ): SQL<unknown> {
   switch (currentScope.kind) {
@@ -500,21 +500,68 @@ function definitionScopePredicate(
 }
 
 export function reportDefinitionScopeSqlPredicate(
-  columns: ReportDefinitionScopeColumns,
+  columns: ReportScopeColumns,
   currentScope: LiveSiteScopeV1,
 ): SQL<unknown> {
   return definitionScopePredicate(columns, currentScope);
 }
 
 export function unrestrictedReportDefinitionScopeSqlPredicate(
-  columns: ReportDefinitionScopeColumns,
+  columns: ReportScopeColumns,
 ): SQL<unknown> {
   return unrestrictedDefinitionPredicate(columns);
 }
 
 export function reportDefinitionMultiOrgScopeSqlPredicate(
   rowOrgId: typeof reports.orgId,
-  columns: ReportDefinitionScopeColumns,
+  columns: ReportScopeColumns,
+  authorizedScopes: readonly LiveSiteScopeV1[],
+): SQL<unknown> {
+  const scopesByOrgId = new Map<string, LiveSiteScopeV1>();
+
+  for (const scope of authorizedScopes) {
+    assertNonEmptyString(scope.orgId, 'organization ID');
+    if (scope.kind === 'restricted' && scope.siteIds.length === 0) {
+      continue;
+    }
+    if (!scopesByOrgId.has(scope.orgId)) {
+      scopesByOrgId.set(
+        scope.orgId,
+        scope.kind === 'restricted'
+          ? { ...scope, siteIds: normalizeSiteIds(scope.siteIds) }
+          : scope,
+      );
+    }
+  }
+
+  const branches = [...scopesByOrgId.values()]
+    .sort((left, right) => left.orgId.localeCompare(right.orgId))
+    .map((scope) =>
+      and(
+        eq(rowOrgId, scope.orgId),
+        definitionScopePredicate(columns, scope),
+      )!,
+    );
+
+  return branches.length === 0 ? sqlFalse() : or(...branches)!;
+}
+
+export function reportRunScopeSqlPredicate(
+  columns: ReportScopeColumns,
+  currentScope: LiveSiteScopeV1,
+): SQL<unknown> {
+  return definitionScopePredicate(columns, currentScope);
+}
+
+export function unrestrictedReportRunScopeSqlPredicate(
+  columns: ReportScopeColumns,
+): SQL<unknown> {
+  return unrestrictedDefinitionPredicate(columns);
+}
+
+export function reportRunMultiOrgScopeSqlPredicate(
+  rowOrgId: typeof reports.orgId,
+  columns: ReportScopeColumns,
   authorizedScopes: readonly LiveSiteScopeV1[],
 ): SQL<unknown> {
   const scopesByOrgId = new Map<string, LiveSiteScopeV1>();

--- a/apps/api/src/services/siteScope.ts
+++ b/apps/api/src/services/siteScope.ts
@@ -1,0 +1,385 @@
+import { createHash } from 'node:crypto';
+import type { UserPermissions } from './permissions';
+
+export type SiteScopeV1 =
+  | { version: 1; kind: 'unrestricted'; orgId: string }
+  | { version: 1; kind: 'restricted'; orgId: string; siteIds: string[] }
+  | { version: 1; kind: 'legacy_unscoped'; orgId: string };
+
+export type LiveSiteScopeV1 = Exclude<SiteScopeV1, { kind: 'legacy_unscoped' }>;
+
+export interface PersistedSiteScopeColumns {
+  executionScopeVersion: number | null;
+  executionScopeKind: 'unrestricted' | 'restricted' | 'legacy_unscoped' | null;
+  executionScopeSiteIds: string[] | null;
+  executionScopeUserId: string | null;
+  executionScopeFingerprint: string | null;
+  executionScopeCapturedAt: Date | null;
+}
+
+export interface ReportExecutionAuthority {
+  scope: SiteScopeV1;
+  principalUserId: string;
+  capturedAt: Date;
+  fingerprint: string;
+}
+
+export type LiveReportAuthorityResult =
+  | { ok: true; authority: ReportExecutionAuthority }
+  | {
+      ok: false;
+      reason:
+        | 'user_inactive'
+        | 'membership_removed'
+        | 'permission_removed'
+        | 'organization_inaccessible'
+        | 'empty_scope'
+        | 'unverifiable_scope';
+    };
+
+function assertNever(value: never): never {
+  throw new Error(`unsupported site scope kind: ${String(value)}`);
+}
+
+function assertNonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`invalid ${field}`);
+  }
+}
+
+function assertValidDate(value: unknown): asserts value is Date {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new Error('invalid execution scope capture time');
+  }
+}
+
+export function normalizeSiteIds(siteIds: readonly string[]): string[] {
+  if (!Array.isArray(siteIds)) {
+    throw new Error('invalid site ID array');
+  }
+
+  const normalized = new Set<string>();
+  for (const siteId of siteIds) {
+    assertNonEmptyString(siteId, 'site ID');
+    normalized.add(siteId);
+  }
+
+  return [...normalized].sort((left, right) => left.localeCompare(right));
+}
+
+function normalizeScope(scope: SiteScopeV1): SiteScopeV1 {
+  assertNonEmptyString(scope.orgId, 'organization ID');
+
+  switch (scope.kind) {
+    case 'unrestricted':
+      return { version: 1, kind: 'unrestricted', orgId: scope.orgId };
+    case 'restricted':
+      return {
+        version: 1,
+        kind: 'restricted',
+        orgId: scope.orgId,
+        siteIds: normalizeSiteIds(scope.siteIds),
+      };
+    case 'legacy_unscoped':
+      return { version: 1, kind: 'legacy_unscoped', orgId: scope.orgId };
+    default:
+      return assertNever(scope);
+  }
+}
+
+export function siteScopeFromPermissions(
+  orgId: string,
+  permissions: UserPermissions,
+): SiteScopeV1 {
+  assertNonEmptyString(orgId, 'organization ID');
+
+  if (permissions.allowedSiteIds === undefined) {
+    return { version: 1, kind: 'unrestricted', orgId };
+  }
+
+  return {
+    version: 1,
+    kind: 'restricted',
+    orgId,
+    siteIds: normalizeSiteIds(permissions.allowedSiteIds),
+  };
+}
+
+export function siteScopeFingerprint(scope: SiteScopeV1): string {
+  const normalized = normalizeScope(scope);
+  let stableValue: Record<string, unknown>;
+
+  switch (normalized.kind) {
+    case 'unrestricted':
+      stableValue = {
+        version: normalized.version,
+        kind: normalized.kind,
+        orgId: normalized.orgId,
+      };
+      break;
+    case 'restricted':
+      stableValue = {
+        version: normalized.version,
+        kind: normalized.kind,
+        orgId: normalized.orgId,
+        siteIds: normalized.siteIds,
+      };
+      break;
+    case 'legacy_unscoped':
+      stableValue = {
+        version: normalized.version,
+        kind: normalized.kind,
+        orgId: normalized.orgId,
+      };
+      break;
+    default:
+      return assertNever(normalized);
+  }
+
+  return createHash('sha256').update(JSON.stringify(stableValue)).digest('hex');
+}
+
+export function intersectSiteScopes(
+  persisted: SiteScopeV1,
+  current: SiteScopeV1,
+): SiteScopeV1 | null {
+  const normalizedPersisted = normalizeScope(persisted);
+  const normalizedCurrent = normalizeScope(current);
+
+  if (normalizedPersisted.orgId !== normalizedCurrent.orgId) {
+    return null;
+  }
+
+  switch (normalizedPersisted.kind) {
+    case 'unrestricted':
+      switch (normalizedCurrent.kind) {
+        case 'unrestricted':
+        case 'restricted':
+          return normalizedCurrent;
+        case 'legacy_unscoped':
+          return null;
+        default:
+          return assertNever(normalizedCurrent);
+      }
+    case 'restricted':
+      switch (normalizedCurrent.kind) {
+        case 'unrestricted':
+          return normalizedPersisted;
+        case 'restricted': {
+          const currentSiteIds = new Set(normalizedCurrent.siteIds);
+          const siteIds = normalizedPersisted.siteIds.filter((siteId) =>
+            currentSiteIds.has(siteId),
+          );
+          return siteIds.length === 0
+            ? null
+            : {
+                version: 1,
+                kind: 'restricted',
+                orgId: normalizedPersisted.orgId,
+                siteIds,
+              };
+        }
+        case 'legacy_unscoped':
+          return null;
+        default:
+          return assertNever(normalizedCurrent);
+      }
+    case 'legacy_unscoped':
+      return null;
+    default:
+      return assertNever(normalizedPersisted);
+  }
+}
+
+export function isSiteScopeSubset(
+  candidate: SiteScopeV1,
+  current: SiteScopeV1,
+): boolean {
+  const normalizedCandidate = normalizeScope(candidate);
+  const normalizedCurrent = normalizeScope(current);
+
+  if (normalizedCandidate.orgId !== normalizedCurrent.orgId) {
+    return false;
+  }
+
+  switch (normalizedCandidate.kind) {
+    case 'unrestricted':
+      switch (normalizedCurrent.kind) {
+        case 'unrestricted':
+          return true;
+        case 'restricted':
+        case 'legacy_unscoped':
+          return false;
+        default:
+          return assertNever(normalizedCurrent);
+      }
+    case 'restricted':
+      switch (normalizedCurrent.kind) {
+        case 'unrestricted':
+          return true;
+        case 'restricted': {
+          const currentSiteIds = new Set(normalizedCurrent.siteIds);
+          return normalizedCandidate.siteIds.every((siteId) =>
+            currentSiteIds.has(siteId),
+          );
+        }
+        case 'legacy_unscoped':
+          return false;
+        default:
+          return assertNever(normalizedCurrent);
+      }
+    case 'legacy_unscoped':
+      switch (normalizedCurrent.kind) {
+        case 'unrestricted':
+          return true;
+        case 'restricted':
+        case 'legacy_unscoped':
+          return false;
+        default:
+          return assertNever(normalizedCurrent);
+      }
+    default:
+      return assertNever(normalizedCandidate);
+  }
+}
+
+function allPersistedValuesAreNull(row: PersistedSiteScopeColumns): boolean {
+  return (
+    row.executionScopeVersion === null &&
+    row.executionScopeKind === null &&
+    row.executionScopeSiteIds === null &&
+    row.executionScopeUserId === null &&
+    row.executionScopeFingerprint === null &&
+    row.executionScopeCapturedAt === null
+  );
+}
+
+function assertCompletePersistedBase(row: PersistedSiteScopeColumns): void {
+  if (
+    row.executionScopeVersion !== 1 ||
+    row.executionScopeFingerprint === null ||
+    row.executionScopeFingerprint.length === 0 ||
+    row.executionScopeCapturedAt === null
+  ) {
+    throw new Error('partial or invalid persisted site scope');
+  }
+  assertValidDate(row.executionScopeCapturedAt);
+}
+
+function validateDecodedScopeFingerprint(
+  row: PersistedSiteScopeColumns,
+  scope: SiteScopeV1,
+): SiteScopeV1 {
+  const fingerprint = row.executionScopeFingerprint;
+  if (
+    fingerprint === null ||
+    !/^[a-f0-9]{64}$/.test(fingerprint) ||
+    fingerprint !== siteScopeFingerprint(scope)
+  ) {
+    throw new Error('invalid persisted site scope fingerprint');
+  }
+  return scope;
+}
+
+export function decodeSiteScope(
+  row: PersistedSiteScopeColumns,
+  orgId: string,
+): SiteScopeV1 {
+  assertNonEmptyString(orgId, 'organization ID');
+
+  if (allPersistedValuesAreNull(row)) {
+    return { version: 1, kind: 'legacy_unscoped', orgId };
+  }
+
+  assertCompletePersistedBase(row);
+
+  switch (row.executionScopeKind) {
+    case 'unrestricted':
+      if (
+        row.executionScopeSiteIds !== null ||
+        row.executionScopeUserId === null
+      ) {
+        throw new Error('partial or invalid persisted unrestricted site scope');
+      }
+      assertNonEmptyString(row.executionScopeUserId, 'execution scope user ID');
+      return validateDecodedScopeFingerprint(row, {
+        version: 1,
+        kind: 'unrestricted',
+        orgId,
+      });
+    case 'restricted':
+      if (
+        row.executionScopeSiteIds === null ||
+        row.executionScopeUserId === null
+      ) {
+        throw new Error('partial or invalid persisted restricted site scope');
+      }
+      assertNonEmptyString(row.executionScopeUserId, 'execution scope user ID');
+      return validateDecodedScopeFingerprint(row, {
+        version: 1,
+        kind: 'restricted',
+        orgId,
+        siteIds: normalizeSiteIds(row.executionScopeSiteIds),
+      });
+    case 'legacy_unscoped':
+      if (row.executionScopeSiteIds !== null) {
+        throw new Error('partial or invalid persisted legacy site scope');
+      }
+      if (row.executionScopeUserId !== null) {
+        assertNonEmptyString(row.executionScopeUserId, 'execution scope user ID');
+      }
+      return validateDecodedScopeFingerprint(row, {
+        version: 1,
+        kind: 'legacy_unscoped',
+        orgId,
+      });
+    case null:
+      throw new Error('partial or invalid persisted site scope');
+    default:
+      throw new Error('invalid persisted site scope kind');
+  }
+}
+
+export function persistedSiteScopeValues(
+  authority: ReportExecutionAuthority,
+): PersistedSiteScopeColumns {
+  const scope = normalizeScope(authority.scope);
+  assertNonEmptyString(authority.principalUserId, 'principal user ID');
+  assertValidDate(authority.capturedAt);
+
+  if (authority.fingerprint !== siteScopeFingerprint(scope)) {
+    throw new Error('invalid execution scope fingerprint');
+  }
+
+  switch (scope.kind) {
+    case 'unrestricted':
+      return {
+        executionScopeVersion: 1,
+        executionScopeKind: scope.kind,
+        executionScopeSiteIds: null,
+        executionScopeUserId: authority.principalUserId,
+        executionScopeFingerprint: authority.fingerprint,
+        executionScopeCapturedAt: authority.capturedAt,
+      };
+    case 'restricted':
+      return {
+        executionScopeVersion: 1,
+        executionScopeKind: scope.kind,
+        executionScopeSiteIds: scope.siteIds,
+        executionScopeUserId: authority.principalUserId,
+        executionScopeFingerprint: authority.fingerprint,
+        executionScopeCapturedAt: authority.capturedAt,
+      };
+    case 'legacy_unscoped':
+      return {
+        executionScopeVersion: 1,
+        executionScopeKind: scope.kind,
+        executionScopeSiteIds: null,
+        executionScopeUserId: authority.principalUserId,
+        executionScopeFingerprint: authority.fingerprint,
+        executionScopeCapturedAt: authority.capturedAt,
+      };
+    default:
+      return assertNever(scope);
+  }
+}

--- a/apps/api/src/services/siteScope.ts
+++ b/apps/api/src/services/siteScope.ts
@@ -1,4 +1,30 @@
 import { createHash } from 'node:crypto';
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
+import {
+  organizations,
+  organizationUsers,
+  partnerUsers,
+  permissions,
+  rolePermissions,
+  roles,
+  users,
+} from '../db/schema';
+import type { reports } from '../db/schema';
+import {
+  db,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../db';
+import type { AuthContext } from '../middleware/auth';
 import type { UserPermissions } from './permissions';
 
 export type SiteScopeV1 =
@@ -7,6 +33,7 @@ export type SiteScopeV1 =
   | { version: 1; kind: 'legacy_unscoped'; orgId: string };
 
 export type LiveSiteScopeV1 = Exclude<SiteScopeV1, { kind: 'legacy_unscoped' }>;
+export type ReportAction = 'read' | 'write' | 'export' | 'delete';
 
 export interface PersistedSiteScopeColumns {
   executionScopeVersion: number | null;
@@ -382,4 +409,806 @@ export function persistedSiteScopeValues(
     default:
       return assertNever(scope);
   }
+}
+
+type ReportDefinitionScopeColumns = Pick<
+  typeof reports,
+  | 'executionScopeVersion'
+  | 'executionScopeKind'
+  | 'executionScopeSiteIds'
+  | 'executionScopeUserId'
+  | 'executionScopeFingerprint'
+  | 'executionScopeCapturedAt'
+>;
+
+function sqlFalse(): SQL<unknown> {
+  return sql<unknown>`FALSE`;
+}
+
+function uuidArraySql(siteIds: readonly string[]): SQL<unknown> {
+  return siteIds.length === 0
+    ? sql<unknown>`ARRAY[]::uuid[]`
+    : sql<unknown>`ARRAY[${sql.join(
+        siteIds.map((siteId) => sql`${siteId}::uuid`),
+        sql`, `,
+      )}]`;
+}
+
+function completeVersionOneBase(
+  columns: ReportDefinitionScopeColumns,
+): SQL<unknown> {
+  return and(
+    eq(columns.executionScopeVersion, 1),
+    isNotNull(columns.executionScopeUserId),
+    isNotNull(columns.executionScopeFingerprint),
+    isNotNull(columns.executionScopeCapturedAt),
+  )!;
+}
+
+function unrestrictedDefinitionPredicate(
+  columns: ReportDefinitionScopeColumns,
+): SQL<unknown> {
+  const completeBase = completeVersionOneBase(columns);
+  return or(
+    and(
+      completeBase,
+      eq(columns.executionScopeKind, 'unrestricted'),
+      isNull(columns.executionScopeSiteIds),
+    ),
+    and(
+      completeBase,
+      eq(columns.executionScopeKind, 'restricted'),
+      isNotNull(columns.executionScopeSiteIds),
+    ),
+    and(
+      eq(columns.executionScopeVersion, 1),
+      eq(columns.executionScopeKind, 'legacy_unscoped'),
+      isNull(columns.executionScopeSiteIds),
+      isNotNull(columns.executionScopeFingerprint),
+      isNotNull(columns.executionScopeCapturedAt),
+    ),
+    and(
+      isNull(columns.executionScopeVersion),
+      isNull(columns.executionScopeKind),
+      isNull(columns.executionScopeSiteIds),
+      isNull(columns.executionScopeUserId),
+      isNull(columns.executionScopeFingerprint),
+      isNull(columns.executionScopeCapturedAt),
+    ),
+  )!;
+}
+
+function definitionScopePredicate(
+  columns: ReportDefinitionScopeColumns,
+  currentScope: LiveSiteScopeV1,
+): SQL<unknown> {
+  switch (currentScope.kind) {
+    case 'unrestricted':
+      return unrestrictedDefinitionPredicate(columns);
+    case 'restricted': {
+      const normalizedSiteIds = normalizeSiteIds(currentScope.siteIds);
+      return and(
+        completeVersionOneBase(columns),
+        eq(columns.executionScopeKind, 'restricted'),
+        isNotNull(columns.executionScopeSiteIds),
+        sql`${columns.executionScopeSiteIds} <@ ${uuidArraySql(normalizedSiteIds)}`,
+      )!;
+    }
+    default:
+      return sqlFalse();
+  }
+}
+
+export function reportDefinitionScopeSqlPredicate(
+  columns: ReportDefinitionScopeColumns,
+  currentScope: LiveSiteScopeV1,
+): SQL<unknown> {
+  return definitionScopePredicate(columns, currentScope);
+}
+
+export function unrestrictedReportDefinitionScopeSqlPredicate(
+  columns: ReportDefinitionScopeColumns,
+): SQL<unknown> {
+  return unrestrictedDefinitionPredicate(columns);
+}
+
+export function reportDefinitionMultiOrgScopeSqlPredicate(
+  rowOrgId: typeof reports.orgId,
+  columns: ReportDefinitionScopeColumns,
+  authorizedScopes: readonly LiveSiteScopeV1[],
+): SQL<unknown> {
+  const scopesByOrgId = new Map<string, LiveSiteScopeV1>();
+
+  for (const scope of authorizedScopes) {
+    assertNonEmptyString(scope.orgId, 'organization ID');
+    if (scope.kind === 'restricted' && scope.siteIds.length === 0) {
+      continue;
+    }
+    if (!scopesByOrgId.has(scope.orgId)) {
+      scopesByOrgId.set(
+        scope.orgId,
+        scope.kind === 'restricted'
+          ? { ...scope, siteIds: normalizeSiteIds(scope.siteIds) }
+          : scope,
+      );
+    }
+  }
+
+  const branches = [...scopesByOrgId.values()]
+    .sort((left, right) => left.orgId.localeCompare(right.orgId))
+    .map((scope) =>
+      and(
+        eq(rowOrgId, scope.orgId),
+        definitionScopePredicate(columns, scope),
+      )!,
+    );
+
+  return branches.length === 0 ? sqlFalse() : or(...branches)!;
+}
+
+function denied(
+  reason: Exclude<LiveReportAuthorityResult, { ok: true }>['reason'],
+): LiveReportAuthorityResult {
+  return { ok: false, reason };
+}
+
+function liveAuthority(
+  scope: LiveSiteScopeV1,
+  principalUserId: string,
+  capturedAt = new Date(),
+): LiveReportAuthorityResult {
+  return {
+    ok: true,
+    authority: {
+      scope,
+      principalUserId,
+      capturedAt,
+      fingerprint: siteScopeFingerprint(scope),
+    },
+  };
+}
+
+async function roleGrantsReportAction(
+  roleId: string,
+  action: ReportAction,
+  expectedRole:
+    | {
+        scope: 'organization';
+        orgId: string;
+        partnerId: string;
+      }
+    | {
+        scope: 'partner';
+        partnerId: string;
+      },
+): Promise<boolean> {
+  const rows = await db
+    .select({
+      resource: permissions.resource,
+      action: permissions.action,
+      roleScope: roles.scope,
+      roleIsSystem: roles.isSystem,
+      roleOrgId: roles.orgId,
+      rolePartnerId: roles.partnerId,
+    })
+    .from(rolePermissions)
+    .innerJoin(roles, eq(rolePermissions.roleId, roles.id))
+    .innerJoin(
+      permissions,
+      eq(rolePermissions.permissionId, permissions.id),
+    )
+    .where(
+      and(
+        eq(rolePermissions.roleId, roleId),
+        eq(permissions.resource, 'reports'),
+        eq(permissions.action, action),
+        eq(roles.scope, expectedRole.scope),
+        or(
+          eq(roles.isSystem, true),
+          expectedRole.scope === 'organization'
+            ? eq(roles.orgId, expectedRole.orgId)
+            : eq(roles.partnerId, expectedRole.partnerId),
+        ),
+      ),
+    );
+
+  return rows.some(
+    (row) =>
+      row.resource === 'reports' &&
+      row.action === action &&
+      row.roleScope === expectedRole.scope &&
+      (row.roleIsSystem ||
+        (expectedRole.scope === 'organization'
+          ? row.roleOrgId === expectedRole.orgId
+          : row.rolePartnerId === expectedRole.partnerId)),
+  );
+}
+
+function partnerMembershipAdmitsOrg(
+  membership: {
+    orgAccess: 'all' | 'selected' | 'none';
+    orgIds: string[] | null;
+  },
+  orgId: string,
+): boolean {
+  switch (membership.orgAccess) {
+    case 'all':
+      return true;
+    case 'selected':
+      return membership.orgIds?.includes(orgId) ?? false;
+    case 'none':
+      return false;
+    default:
+      return false;
+  }
+}
+
+async function resolveExactReportAuthorityInSystemContext(
+  userId: string,
+  orgId: string,
+  action: ReportAction,
+  allowPlatformAuthority: boolean,
+): Promise<LiveReportAuthorityResult> {
+  const [user] = await db
+    .select({
+      id: users.id,
+      status: users.status,
+      isPlatformAdmin: users.isPlatformAdmin,
+      partnerId: users.partnerId,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  if (!user || user.status !== 'active') {
+    return denied('user_inactive');
+  }
+
+  const [organization] = await db
+    .select({
+      id: organizations.id,
+      partnerId: organizations.partnerId,
+    })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  if (!organization) {
+    return denied('organization_inaccessible');
+  }
+
+  if (allowPlatformAuthority && user.isPlatformAdmin) {
+    return liveAuthority(
+      { version: 1, kind: 'unrestricted', orgId },
+      user.id,
+    );
+  }
+
+  const organizationMemberships = await db
+    .select({
+      roleId: organizationUsers.roleId,
+      siteIds: organizationUsers.siteIds,
+    })
+    .from(organizationUsers)
+    .where(
+      and(
+        eq(organizationUsers.userId, user.id),
+        eq(organizationUsers.orgId, orgId),
+      ),
+    )
+    .limit(2);
+  if (organizationMemberships.length > 1) {
+    return denied('unverifiable_scope');
+  }
+  const organizationMembership = organizationMemberships[0];
+
+  if (organizationMembership) {
+    if (
+      !organizationMembership.roleId ||
+      !(await roleGrantsReportAction(
+        organizationMembership.roleId,
+        action,
+        {
+          scope: 'organization',
+          orgId,
+          partnerId: organization.partnerId,
+        },
+      ))
+    ) {
+      return denied('permission_removed');
+    }
+
+    if (organizationMembership.siteIds === null) {
+      return liveAuthority(
+        { version: 1, kind: 'unrestricted', orgId },
+        user.id,
+      );
+    }
+
+    const siteIds = normalizeSiteIds(organizationMembership.siteIds);
+    if (siteIds.length === 0) {
+      return denied('empty_scope');
+    }
+    return liveAuthority(
+      { version: 1, kind: 'restricted', orgId, siteIds },
+      user.id,
+    );
+  }
+
+  if (organization.partnerId !== user.partnerId) {
+    return denied('organization_inaccessible');
+  }
+
+  const partnerMemberships = await db
+    .select({
+      roleId: partnerUsers.roleId,
+      orgAccess: partnerUsers.orgAccess,
+      orgIds: partnerUsers.orgIds,
+    })
+    .from(partnerUsers)
+    .where(
+      and(
+        eq(partnerUsers.userId, user.id),
+        eq(partnerUsers.partnerId, organization.partnerId),
+      ),
+    )
+    .limit(2);
+  if (partnerMemberships.length > 1) {
+    return denied('unverifiable_scope');
+  }
+  const partnerMembership = partnerMemberships[0];
+  if (!partnerMembership) {
+    return denied('membership_removed');
+  }
+  if (!partnerMembershipAdmitsOrg(partnerMembership, orgId)) {
+    return denied('organization_inaccessible');
+  }
+  if (
+    !partnerMembership.roleId ||
+    !(await roleGrantsReportAction(partnerMembership.roleId, action, {
+      scope: 'partner',
+      partnerId: organization.partnerId,
+    }))
+  ) {
+    return denied('permission_removed');
+  }
+
+  return liveAuthority(
+    { version: 1, kind: 'unrestricted', orgId },
+    user.id,
+  );
+}
+
+async function resolveExactReportAuthority(
+  userId: string,
+  orgId: string,
+  action: ReportAction,
+  allowPlatformAuthority: boolean,
+): Promise<LiveReportAuthorityResult> {
+  try {
+    return await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        resolveExactReportAuthorityInSystemContext(
+          userId,
+          orgId,
+          action,
+          allowPlatformAuthority,
+        ),
+      ),
+    );
+  } catch {
+    return denied('unverifiable_scope');
+  }
+}
+
+export async function resolveLiveReportAuthority(
+  userId: string,
+  orgId: string,
+  action: ReportAction,
+): Promise<LiveReportAuthorityResult> {
+  return resolveExactReportAuthority(userId, orgId, action, true);
+}
+
+function requestAuthAdmitsOrg(auth: AuthContext, orgId: string): boolean {
+  if (auth.scope === 'organization') {
+    return auth.orgId === orgId && auth.canAccessOrg(orgId);
+  }
+  if (auth.scope === 'partner') {
+    return (
+      (auth.accessibleOrgIds?.includes(orgId) ?? false) &&
+      auth.canAccessOrg(orgId)
+    );
+  }
+  return auth.scope === 'system' && auth.canAccessOrg(orgId);
+}
+
+export async function resolveRequestReportAuthority(
+  auth: AuthContext,
+  orgId: string,
+  action: ReportAction,
+): Promise<LiveReportAuthorityResult> {
+  if (!requestAuthAdmitsOrg(auth, orgId)) {
+    return denied('organization_inaccessible');
+  }
+  return resolveExactReportAuthority(
+    auth.user.id,
+    orgId,
+    action,
+    auth.scope === 'system',
+  );
+}
+
+type BatchOrganization = {
+  id: string;
+  partnerId: string;
+};
+
+type BatchOrganizationMembership = {
+  orgId: string;
+  roleId: string;
+  siteIds: string[] | null;
+};
+
+type BatchPartnerMembership = {
+  partnerId: string;
+  roleId: string;
+  orgAccess: 'all' | 'selected' | 'none';
+  orgIds: string[] | null;
+};
+
+type BatchPermissionGrant = {
+  roleId: string;
+  resource: string;
+  action: string;
+  roleScope: 'system' | 'partner' | 'organization';
+  roleIsSystem: boolean;
+  roleOrgId: string | null;
+  rolePartnerId: string | null;
+};
+
+function batchRoleGrantsReportAction(
+  rows: readonly BatchPermissionGrant[],
+  roleId: string,
+  action: ReportAction,
+  expectedRole:
+    | { scope: 'organization'; orgId: string }
+    | { scope: 'partner'; partnerId: string },
+): boolean {
+  return rows.some(
+    (row) =>
+      row.roleId === roleId &&
+      row.resource === 'reports' &&
+      row.action === action &&
+      row.roleScope === expectedRole.scope &&
+      (row.roleIsSystem ||
+        (expectedRole.scope === 'organization'
+          ? row.roleOrgId === expectedRole.orgId
+          : row.rolePartnerId === expectedRole.partnerId)),
+  );
+}
+
+async function resolveRequestReportAuthorityMapInSystemContext(
+  auth: AuthContext,
+  accessibleOrgIds: readonly string[],
+  action: ReportAction,
+  result: Map<string, LiveReportAuthorityResult>,
+): Promise<void> {
+  const [user] = await db
+    .select({
+      id: users.id,
+      status: users.status,
+      isPlatformAdmin: users.isPlatformAdmin,
+      partnerId: users.partnerId,
+    })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  if (!user || user.status !== 'active') {
+    for (const orgId of accessibleOrgIds) {
+      result.set(orgId, denied('user_inactive'));
+    }
+    return;
+  }
+
+  const organizationRows = await db
+    .select({
+      id: organizations.id,
+      partnerId: organizations.partnerId,
+    })
+    .from(organizations)
+    .where(inArray(organizations.id, [...accessibleOrgIds]));
+  const organizationsById = new Map(
+    (organizationRows as BatchOrganization[]).map((organization) => [
+      organization.id,
+      organization,
+    ]),
+  );
+
+  if (auth.scope === 'system' && user.isPlatformAdmin) {
+    const capturedAt = new Date();
+    for (const orgId of accessibleOrgIds) {
+      result.set(
+        orgId,
+        organizationsById.has(orgId)
+          ? liveAuthority(
+              { version: 1, kind: 'unrestricted', orgId },
+              user.id,
+              capturedAt,
+            )
+          : denied('organization_inaccessible'),
+      );
+    }
+    return;
+  }
+
+  const existingOrgIds = accessibleOrgIds.filter((orgId) =>
+    organizationsById.has(orgId),
+  );
+  const organizationMembershipRows = existingOrgIds.length === 0
+    ? []
+    : await db
+        .select({
+          orgId: organizationUsers.orgId,
+          roleId: organizationUsers.roleId,
+          siteIds: organizationUsers.siteIds,
+        })
+        .from(organizationUsers)
+        .where(
+          and(
+            eq(organizationUsers.userId, user.id),
+            inArray(organizationUsers.orgId, [...existingOrgIds]),
+          ),
+        );
+  const organizationMembershipsByOrgId = new Map<
+    string,
+    BatchOrganizationMembership
+  >();
+  const organizationMembershipOrgIds = new Set<string>();
+  const duplicateOrganizationMembershipOrgIds = new Set<string>();
+  for (
+    const membership of
+      organizationMembershipRows as BatchOrganizationMembership[]
+  ) {
+    if (organizationMembershipOrgIds.has(membership.orgId)) {
+      duplicateOrganizationMembershipOrgIds.add(membership.orgId);
+      organizationMembershipsByOrgId.delete(membership.orgId);
+      continue;
+    }
+    organizationMembershipOrgIds.add(membership.orgId);
+    organizationMembershipsByOrgId.set(membership.orgId, membership);
+  }
+
+  const organizationRoleIds = normalizeSiteIds(
+    [...organizationMembershipsByOrgId.values()]
+      .map((membership) => membership.roleId)
+      .filter(Boolean),
+  );
+  const organizationPermissionRows = organizationRoleIds.length === 0
+    ? []
+    : await db
+        .select({
+          roleId: rolePermissions.roleId,
+          resource: permissions.resource,
+          action: permissions.action,
+          roleScope: roles.scope,
+          roleIsSystem: roles.isSystem,
+          roleOrgId: roles.orgId,
+          rolePartnerId: roles.partnerId,
+        })
+        .from(rolePermissions)
+        .innerJoin(roles, eq(rolePermissions.roleId, roles.id))
+        .innerJoin(
+          permissions,
+          eq(rolePermissions.permissionId, permissions.id),
+        )
+        .where(
+          and(
+            inArray(rolePermissions.roleId, organizationRoleIds),
+            eq(permissions.resource, 'reports'),
+            eq(permissions.action, action),
+          ),
+        );
+
+  const fallbackPartnerIds = normalizeSiteIds(
+    existingOrgIds
+      .filter((orgId) => !organizationMembershipOrgIds.has(orgId))
+      .map((orgId) => organizationsById.get(orgId)!.partnerId)
+      .filter((partnerId) => partnerId === user.partnerId),
+  );
+  const partnerMembershipRows = fallbackPartnerIds.length === 0
+    ? []
+    : await db
+        .select({
+          partnerId: partnerUsers.partnerId,
+          roleId: partnerUsers.roleId,
+          orgAccess: partnerUsers.orgAccess,
+          orgIds: partnerUsers.orgIds,
+        })
+        .from(partnerUsers)
+        .where(
+          and(
+            eq(partnerUsers.userId, user.id),
+            inArray(partnerUsers.partnerId, fallbackPartnerIds),
+          ),
+        );
+  const partnerMembershipsByPartnerId = new Map<
+    string,
+    BatchPartnerMembership
+  >();
+  const partnerMembershipPartnerIds = new Set<string>();
+  const duplicatePartnerMembershipPartnerIds = new Set<string>();
+  for (
+    const membership of partnerMembershipRows as BatchPartnerMembership[]
+  ) {
+    if (partnerMembershipPartnerIds.has(membership.partnerId)) {
+      duplicatePartnerMembershipPartnerIds.add(membership.partnerId);
+      partnerMembershipsByPartnerId.delete(membership.partnerId);
+      continue;
+    }
+    partnerMembershipPartnerIds.add(membership.partnerId);
+    partnerMembershipsByPartnerId.set(membership.partnerId, membership);
+  }
+
+  const partnerRoleIds = normalizeSiteIds(
+    [...partnerMembershipsByPartnerId.values()]
+      .map((membership) => membership.roleId)
+      .filter(Boolean),
+  );
+  const partnerPermissionRows = partnerRoleIds.length === 0
+    ? []
+    : await db
+        .select({
+          roleId: rolePermissions.roleId,
+          resource: permissions.resource,
+          action: permissions.action,
+          roleScope: roles.scope,
+          roleIsSystem: roles.isSystem,
+          roleOrgId: roles.orgId,
+          rolePartnerId: roles.partnerId,
+        })
+        .from(rolePermissions)
+        .innerJoin(roles, eq(rolePermissions.roleId, roles.id))
+        .innerJoin(
+          permissions,
+          eq(rolePermissions.permissionId, permissions.id),
+        )
+        .where(
+          and(
+            inArray(rolePermissions.roleId, partnerRoleIds),
+            eq(permissions.resource, 'reports'),
+            eq(permissions.action, action),
+          ),
+        );
+
+  const capturedAt = new Date();
+  for (const orgId of accessibleOrgIds) {
+    const organization = organizationsById.get(orgId);
+    if (!organization) {
+      result.set(orgId, denied('organization_inaccessible'));
+      continue;
+    }
+
+    const organizationMembership =
+      organizationMembershipsByOrgId.get(orgId);
+    if (duplicateOrganizationMembershipOrgIds.has(orgId)) {
+      result.set(orgId, denied('unverifiable_scope'));
+      continue;
+    }
+    if (organizationMembership) {
+      if (
+        !organizationMembership.roleId ||
+        !batchRoleGrantsReportAction(
+          organizationPermissionRows as BatchPermissionGrant[],
+          organizationMembership.roleId,
+          action,
+          { scope: 'organization', orgId },
+        )
+      ) {
+        result.set(orgId, denied('permission_removed'));
+        continue;
+      }
+      if (organizationMembership.siteIds === null) {
+        result.set(
+          orgId,
+          liveAuthority(
+            { version: 1, kind: 'unrestricted', orgId },
+            user.id,
+            capturedAt,
+          ),
+        );
+        continue;
+      }
+      const siteIds = normalizeSiteIds(organizationMembership.siteIds);
+      result.set(
+        orgId,
+        siteIds.length === 0
+          ? denied('empty_scope')
+          : liveAuthority(
+              { version: 1, kind: 'restricted', orgId, siteIds },
+              user.id,
+              capturedAt,
+            ),
+      );
+      continue;
+    }
+
+    if (organization.partnerId !== user.partnerId) {
+      result.set(orgId, denied('organization_inaccessible'));
+      continue;
+    }
+    const partnerMembership = partnerMembershipsByPartnerId.get(
+      organization.partnerId,
+    );
+    if (
+      duplicatePartnerMembershipPartnerIds.has(organization.partnerId)
+    ) {
+      result.set(orgId, denied('unverifiable_scope'));
+      continue;
+    }
+    if (!partnerMembership) {
+      result.set(orgId, denied('membership_removed'));
+      continue;
+    }
+    if (!partnerMembershipAdmitsOrg(partnerMembership, orgId)) {
+      result.set(orgId, denied('organization_inaccessible'));
+      continue;
+    }
+    if (
+      !partnerMembership.roleId ||
+      !batchRoleGrantsReportAction(
+        partnerPermissionRows as BatchPermissionGrant[],
+        partnerMembership.roleId,
+        action,
+        { scope: 'partner', partnerId: organization.partnerId },
+      )
+    ) {
+      result.set(orgId, denied('permission_removed'));
+      continue;
+    }
+    result.set(
+      orgId,
+      liveAuthority(
+        { version: 1, kind: 'unrestricted', orgId },
+        user.id,
+        capturedAt,
+      ),
+    );
+  }
+}
+
+export async function resolveRequestReportAuthorityMap(
+  auth: AuthContext,
+  orgIds: readonly string[],
+  action: ReportAction,
+): Promise<ReadonlyMap<string, LiveReportAuthorityResult>> {
+  const requestedOrgIds = normalizeSiteIds(orgIds);
+  const result = new Map<string, LiveReportAuthorityResult>();
+  const accessibleOrgIds = requestedOrgIds.filter((orgId) =>
+    requestAuthAdmitsOrg(auth, orgId),
+  );
+  const accessibleSet = new Set(accessibleOrgIds);
+  for (const orgId of requestedOrgIds) {
+    if (!accessibleSet.has(orgId)) {
+      result.set(orgId, denied('organization_inaccessible'));
+    }
+  }
+  if (accessibleOrgIds.length === 0) {
+    return result;
+  }
+
+  try {
+    await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        resolveRequestReportAuthorityMapInSystemContext(
+          auth,
+          accessibleOrgIds,
+          action,
+          result,
+        ),
+      ),
+    );
+  } catch {
+    for (const orgId of accessibleOrgIds) {
+      result.set(orgId, denied('unverifiable_scope'));
+    }
+  }
+  return result;
 }

--- a/apps/web/src/components/analytics/AnalyticsPage.siteScope.test.tsx
+++ b/apps/web/src/components/analytics/AnalyticsPage.siteScope.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AnalyticsPage from './AnalyticsPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+// `AnalyticsPage`, `QueryBuilder` and `DashboardGrid` all read the API through
+// this one helper, so mocking it here controls every request the page makes.
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: vi.fn() }));
+
+const fetchMock = vi.mocked(fetchWithAuth);
+
+// jsdom has no ResizeObserver; recharts' ResponsiveContainer (executive summary
+// trend line, performance chart, OS pie) constructs one as soon as it mounts.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub;
+
+const jsonResponse = (
+  payload: unknown,
+  init: { status?: number; statusText?: string } = {}
+): Response => {
+  const status = init.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: init.statusText ?? (status === 200 ? 'OK' : 'Error'),
+    text: async () => JSON.stringify(payload),
+    json: async () => payload
+  } as unknown as Response;
+};
+
+/** Shape returned by `GET /metrics` for a caller who can see current metrics. */
+const CURRENT_METRICS = {
+  data: {
+    uptime: 99.5,
+    remoteSessions: 3,
+    sessions: 3,
+    devices: { total: 10, online: 9, offline: 1, pending: 0 },
+    business_metrics: { devices_total: 10, devices_active: 9, devices_pending: 0 }
+  }
+};
+
+/** Shape returned by `GET /metrics/trends` for an unrestricted caller. */
+const TRENDS_PAYLOAD = {
+  data: [
+    { timestamp: '2026-07-01T00:00:00.000Z', cpu: 41, memory: 62 },
+    { timestamp: '2026-07-02T00:00:00.000Z', cpu: 44, memory: 65 }
+  ]
+};
+
+/**
+ * The exact body `GET /metrics/trends` returns for a site-restricted caller
+ * (apps/api/src/routes/metrics.ts). `metric_rollups` has no site axis, so the
+ * API denies the aggregate outright rather than leaking org-wide numbers.
+ */
+const SITE_SCOPED_DENIAL = {
+  error: 'Trend metrics are unavailable for site-restricted users',
+  code: 'SITE_SCOPED_TRENDS_UNAVAILABLE'
+};
+
+const routeFetch = (trendsResponse: () => Response) => {
+  fetchMock.mockImplementation(async (input: unknown) => {
+    const url = String(input);
+    if (url.startsWith('/metrics/trends')) return trendsResponse();
+    if (url.startsWith('/metrics')) return jsonResponse(CURRENT_METRICS);
+    if (url.startsWith('/analytics/os-distribution')) {
+      return jsonResponse({ data: [{ name: 'Windows 11', value: 7 }] });
+    }
+    if (url.startsWith('/alerts/summary')) {
+      return jsonResponse({ data: { bySeverity: { critical: 1, high: 2, medium: 0, low: 0 } } });
+    }
+    return jsonResponse({});
+  });
+};
+
+/**
+ * Waits for the page to finish loading, then asserts the current-metric cards
+ * rendered real values. The "Updated <time>" stamp is set only after every
+ * analytics request has settled, so anchoring on it guarantees the trends
+ * response has already been applied when the callers assert below.
+ */
+const waitForLoadedPage = async () => {
+  await screen.findByText(/^Updated /);
+  expect(screen.getByText('Fleet uptime')).toBeInTheDocument();
+  expect(screen.getByText('Sessions in range')).toBeInTheDocument();
+  expect(screen.getByText('99.50%')).toBeInTheDocument();
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AnalyticsPage site-scoped trends', () => {
+  it('renders current-metric cards without the performance card or an error banner when trends are denied', async () => {
+    routeFetch(() => jsonResponse(SITE_SCOPED_DENIAL, { status: 403, statusText: 'Forbidden' }));
+
+    render(<AnalyticsPage />);
+    await waitForLoadedPage();
+
+    // The one card backed by /metrics/trends is omitted...
+    expect(screen.queryByText('Performance Trend')).not.toBeInTheDocument();
+    expect(screen.queryByText('CPU and memory utilization')).not.toBeInTheDocument();
+
+    // ...and the expected denial is not reported as a page-wide failure.
+    expect(screen.queryByText(/Unable to load/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Failed to load analytics data/)).not.toBeInTheDocument();
+
+    // Every other card still renders.
+    expect(screen.getByText('OS Distribution')).toBeInTheDocument();
+    expect(screen.getByText('Alert Statistics')).toBeInTheDocument();
+    expect(screen.getByText('Policy Compliance')).toBeInTheDocument();
+  });
+
+  it('renders the performance card for an unrestricted caller', async () => {
+    routeFetch(() => jsonResponse(TRENDS_PAYLOAD));
+
+    render(<AnalyticsPage />);
+    await waitForLoadedPage();
+
+    expect(screen.getByText('Performance Trend')).toBeInTheDocument();
+    expect(screen.getByText('CPU and memory utilization')).toBeInTheDocument();
+    expect(screen.queryByText(/Unable to load/)).not.toBeInTheDocument();
+  });
+
+  it('still surfaces an error banner when trends fail for any other reason', async () => {
+    routeFetch(() => jsonResponse({ error: 'boom' }, { status: 500, statusText: 'Server Error' }));
+
+    render(<AnalyticsPage />);
+    await waitForLoadedPage();
+
+    expect(screen.getByText('Unable to load: performance')).toBeInTheDocument();
+    // A generic failure is not an authorization denial: the card stays put.
+    expect(screen.getByText('Performance Trend')).toBeInTheDocument();
+  });
+
+  it('treats a 403 with a different code as an ordinary failure', async () => {
+    routeFetch(() =>
+      jsonResponse({ error: 'Forbidden', code: 'SOME_OTHER_CODE' }, { status: 403, statusText: 'Forbidden' })
+    );
+
+    render(<AnalyticsPage />);
+    await waitForLoadedPage();
+
+    expect(screen.getByText('Unable to load: performance')).toBeInTheDocument();
+    expect(screen.getByText('Performance Trend')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/analytics/AnalyticsPage.tsx
+++ b/apps/web/src/components/analytics/AnalyticsPage.tsx
@@ -335,6 +335,46 @@ const fetchJson = async (url: string) => {
   }
 };
 
+/**
+ * Code `GET /metrics/trends` returns when the caller is site-restricted.
+ * `metric_rollups` is pre-aggregated per organization and carries no site axis,
+ * so the API denies the whole aggregate rather than serving org-wide numbers to
+ * a user who may only see some sites.
+ */
+const SITE_SCOPED_TRENDS_CODE = 'SITE_SCOPED_TRENDS_UNAVAILABLE';
+
+type TrendsResult =
+  | { unavailable: true }
+  | { unavailable: false; data: unknown };
+
+/**
+ * Reads `/metrics/trends`, inspecting the response before generic parsing so the
+ * documented site-scope denial can be told apart from an ordinary failure. The
+ * denial is an expected state for restricted users — every other failure still
+ * throws and is reported through the page's normal error handling.
+ */
+const fetchTrends = async (url: string): Promise<TrendsResult> => {
+  const response = await fetchWithAuth(url);
+  const text = await response.text();
+  let payload: unknown = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      payload = null;
+    }
+  }
+
+  if (!response.ok) {
+    if (response.status === 403 && getRecord(payload).code === SITE_SCOPED_TRENDS_CODE) {
+      return { unavailable: true };
+    }
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+
+  return { unavailable: false, data: payload };
+};
+
 interface AnalyticsPageProps {
   timezone?: string;
 }
@@ -350,6 +390,9 @@ export default function AnalyticsPage({ timezone }: AnalyticsPageProps) {
     sessions: 0
   });
   const [performanceData, setPerformanceData] = useState<PerformancePoint[]>([]);
+  // True only for the documented site-scope denial: the trend card is hidden
+  // instead of rendered empty, and the denial is not counted as a page error.
+  const [performanceUnavailable, setPerformanceUnavailable] = useState(false);
   const [osDistribution, setOsDistribution] = useState<OsDistributionPoint[]>([]);
   const [alertRows, setAlertRows] = useState<AlertRow[]>([]);
   const [complianceStats, setComplianceStats] = useState<ComplianceStats>({ complianceRate: 0 });
@@ -443,10 +486,17 @@ export default function AnalyticsPage({ timezone }: AnalyticsPageProps) {
         })(),
         (async () => {
           try {
-            const trendsData = await fetchJson(withQuery('/metrics/trends'));
-            setPerformanceData(normalizePerformanceData(trendsData));
+            const trends = await fetchTrends(withQuery('/metrics/trends'));
+            if (trends.unavailable) {
+              setPerformanceUnavailable(true);
+              setPerformanceData([]);
+              return;
+            }
+            setPerformanceUnavailable(false);
+            setPerformanceData(normalizePerformanceData(trends.data));
           } catch (err) {
             errors.push('performance');
+            setPerformanceUnavailable(false);
             setPerformanceData([]);
           }
         })(),
@@ -711,8 +761,13 @@ export default function AnalyticsPage({ timezone }: AnalyticsPageProps) {
   }), []);
 
   const filteredLayout = useMemo(
-    () => dashboardLayouts[selectedDashboard] ?? dashboardLayouts.operations,
-    [dashboardLayouts, selectedDashboard]
+    () => {
+      const layout = dashboardLayouts[selectedDashboard] ?? dashboardLayouts.operations;
+      // Drop only the trend card; every other card on the dashboard is still
+      // backed by a site-scoped endpoint the restricted caller may read.
+      return performanceUnavailable ? layout.filter(item => item.i !== 'performance') : layout;
+    },
+    [dashboardLayouts, performanceUnavailable, selectedDashboard]
   );
 
   const widgetMap = useMemo(() => {
@@ -825,6 +880,12 @@ export default function AnalyticsPage({ timezone }: AnalyticsPageProps) {
         rowHeight={64}
         gap={12}
         renderItem={item => {
+          // DashboardGrid mirrors `layout` into its own state, so the filtered
+          // layout only reaches it on the next commit. Refuse to render the
+          // trend card here too, so a denied caller never sees it at all.
+          if (performanceUnavailable && item.i === 'performance') {
+            return null;
+          }
           if (isInitialLoading) {
             return <div className="h-full w-full animate-pulse rounded-lg border bg-muted/40" />;
           }


### PR DESCRIPTION
Security remediation Wave 2 — tenant/site scope. Defines a canonical site-scope authority for reports, persists execution-scope provenance on definitions and runs, resolves report authority live per action, gates run creation/visibility/download/baselines on it, fails scheduled work closed before generation or delivery, routes AI tool report paths through the same authority, and enforces site scope on metric aggregates and analytics trends.

Plan: docs/superpowers/plans/security-auth/2026-07-23-security-remediation-wave-02-tenant-site-scope.md (lands with the program docs PR).

Full API suite run green locally (17,425 tests) on top of the wave verification sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)