### PR TITLE
fix(ci): govulncheck allowlist for GO-2026-5051 + repair Type Check on main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,9 +70,11 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
+      # Allowlist wrapper: fails on any symbol-level finding not in
+      # scripts/security/govulncheck-allowlist.txt (reviewed, unfixable-only
+      # exceptions with code-level mitigations).
       - name: Run govulncheck
-        working-directory: agent
-        run: CGO_ENABLED=0 govulncheck ./...
+        run: bash scripts/security/run-govulncheck.sh
 
   cargo-audit:
     name: Cargo Audit

--- a/agent/internal/workspaceindex/fs_smb.go
+++ b/agent/internal/workspaceindex/fs_smb.go
@@ -67,16 +67,28 @@ type smbFS struct {
 	closeErr   error
 }
 
-func (s *smbFS) ReadDir(name string) ([]fs.DirEntry, error) {
+func (s *smbFS) ReadDir(name string) (entries []fs.DirEntry, err error) {
 	sharePath, err := s.resolve(name)
 	if err != nil {
 		return nil, s.redactError("readdir", name, err)
 	}
+	// GO-2026-5051: go-smb2's ReadDir can panic (out-of-bounds read) on a
+	// malformed server response, and no fixed release exists. A hostile or
+	// buggy SMB server must not be able to crash the agent, so contain the
+	// panic here and surface it as an ordinary error. Drop this guard and the
+	// matching entry in scripts/security/govulncheck-allowlist.txt when
+	// go-smb2 ships a fix.
+	defer func() {
+		if r := recover(); r != nil {
+			entries = nil
+			err = s.redactError("readdir", sharePath, fmt.Errorf("smb readdir panicked: %v", r))
+		}
+	}()
 	infos, err := s.share.ReadDir(sharePath)
 	if err != nil {
 		return nil, s.redactError("readdir", sharePath, err)
 	}
-	entries := make([]fs.DirEntry, len(infos))
+	entries = make([]fs.DirEntry, len(infos))
 	for i, info := range infos {
 		entries[i] = smbDirEntry{info: info}
 	}

--- a/agent/internal/workspaceindex/fs_smb_test.go
+++ b/agent/internal/workspaceindex/fs_smb_test.go
@@ -142,6 +142,31 @@ func TestSMBFSReadErrorDoesNotExposePassword(t *testing.T) {
 	}
 }
 
+// GO-2026-5051: go-smb2's ReadDir can panic on a malformed server response.
+// The recover guard must turn that into an error — never a crash — and the
+// error must not leak the credential.
+func TestSMBFSReadDirContainsLibraryPanic(t *testing.T) {
+	const password = "top-secret-password"
+	fys := &smbFS{
+		share:      &fakeSMBShare{readDirPanic: "slice bounds out of range using " + password},
+		credential: Credential{Password: password},
+	}
+
+	entries, err := fys.ReadDir(".")
+	if err == nil {
+		t.Fatal("ReadDir succeeded, want error from contained panic")
+	}
+	if entries != nil {
+		t.Fatalf("ReadDir entries = %v, want nil after contained panic", entries)
+	}
+	if !strings.Contains(err.Error(), "panicked") {
+		t.Fatalf("ReadDir error %q does not identify the contained panic", err)
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("ReadDir error %q contains password", err)
+	}
+}
+
 func TestSMBFSCloseCleansUpAndZeroesRetainedCredential(t *testing.T) {
 	domain := "EXAMPLE"
 	share := &fakeSMBShare{}
@@ -169,6 +194,7 @@ type fakeSMBShare struct {
 	entries      []os.FileInfo
 	statInfo     os.FileInfo
 	readDirErr   error
+	readDirPanic string
 	readDirPath  string
 	lstatPath    string
 	umountCalls  int
@@ -179,6 +205,9 @@ type fakeSMBShare struct {
 func (f *fakeSMBShare) ReadDir(name string) ([]os.FileInfo, error) {
 	f.readDirCalls++
 	f.readDirPath = name
+	if f.readDirPanic != "" {
+		panic(f.readDirPanic)
+	}
 	return f.entries, f.readDirErr
 }
 

--- a/apps/api/src/__tests__/integration/partnerAxisSystemContext.integration.test.ts
+++ b/apps/api/src/__tests__/integration/partnerAxisSystemContext.integration.test.ts
@@ -286,10 +286,13 @@ describe('#2822 — assertNotLocked (a WRITE gate, so a wrong answer is worse th
     // requireScope('organization','partner','system'). Pre-fix the partner read
     // returned zero rows and this threw 404 "Partner not found" before it could
     // decide anything — so the gate never actually ran for org callers. Now it
-    // resolves and correctly refuses: the partner set security.sessionTimeoutMinutes.
+    // resolves and correctly refuses: the partner set security.sessionTimeoutMinutes
+    // to 15, and the org submits a DIVERGING value (#2752 made assertNotLocked
+    // value-aware — echoing the partner's own value back is a permitted no-op,
+    // so the block only fires on an actual change).
     await expect(
       withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
-        assertNotLocked(fx.orgId, 'security', ['sessionTimeoutMinutes']),
+        assertNotLocked(fx.orgId, 'security', { sessionTimeoutMinutes: 60 }),
       ),
     ).rejects.toMatchObject({ status: 403 });
   });
@@ -297,7 +300,7 @@ describe('#2822 — assertNotLocked (a WRITE gate, so a wrong answer is worse th
   runDb('an org-scoped caller may still write a field the partner has NOT set', async () => {
     await expect(
       withDbAccessContext(orgContext(fx.orgId, fx.partnerId), () =>
-        assertNotLocked(fx.orgId, 'security', ['someUnlockedField']),
+        assertNotLocked(fx.orgId, 'security', { someUnlockedField: 'org-value' }),
       ),
     ).resolves.toBeUndefined();
   });

--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -86,7 +86,11 @@ const LOCKABLE_FIELDS = [
   'maintenanceWindow',
 ] as const;
 
-type LockableField = (typeof LOCKABLE_FIELDS)[number];
+// `maxEnrollmentLinkTtlMinutes` is not an editable field of this form (the cap
+// is partner-only, surfaced as a read-only notice — issue #2776), but it does
+// arrive via `locked`, so the lock helper must accept it alongside the
+// seedable editor fields.
+type LockableField = (typeof LOCKABLE_FIELDS)[number] | 'maxEnrollmentLinkTtlMinutes';
 
 const defaultValues: DefaultsData = {
   policyDefaults: {

--- a/scripts/security/govulncheck-allowlist.txt
+++ b/scripts/security/govulncheck-allowlist.txt
@@ -1,0 +1,17 @@
+# Reviewed govulncheck exceptions — agent Go module.
+#
+# An entry here suppresses a SYMBOL-LEVEL govulncheck finding in CI. The bar
+# for adding one is high: the advisory must have NO fixed release to upgrade
+# to, the call site must carry a code-level mitigation, and a tracking issue
+# must exist to remove the entry the moment a fixed release ships. A finding
+# with an available fix must be fixed by upgrading, never listed here.
+#
+# Format: one OSV id per line; '#' starts a comment.
+
+# go-smb2 ReadDir out-of-bounds read / panic. Fixed in: N/A (no patched
+# release of github.com/hirochachacha/go-smb2 exists). Mitigated by the
+# recover guard in agent/internal/workspaceindex/fs_smb.go (smbFS.ReadDir),
+# which contains the panic and surfaces it as a redacted error. Remove this
+# entry and that guard's allowlist reference when a fixed go-smb2 ships.
+# Tracking: #2860
+GO-2026-5051

--- a/scripts/security/run-govulncheck.sh
+++ b/scripts/security/run-govulncheck.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Run govulncheck over the agent Go module with a reviewed allowlist of
+# unfixable advisories (govulncheck-allowlist.txt documents the bar an entry
+# must clear: no fixed release exists + code-level mitigation + tracking
+# issue). Fails on any symbol-level finding not in the allowlist, and warns
+# when an allowlist entry has gone stale so it gets removed.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+allowlist_file="$repo_root/scripts/security/govulncheck-allowlist.txt"
+out_file="$(mktemp)"
+trap 'rm -f "$out_file"' EXIT
+
+cd "$repo_root/agent"
+# JSON mode exits 0 even with findings; a non-zero exit here is an
+# operational failure (build error, network), which set -e propagates.
+CGO_ENABLED=0 govulncheck -format json ./... > "$out_file"
+
+# Symbol-level findings only (a trace entry with a function) — the same set
+# plain `govulncheck ./...` fails on ("Your code is affected by ...").
+found="$(jq -r 'select(.finding != null) | .finding | select(.trace[0].function != null) | .osv' "$out_file" | sort -u)"
+allow="$(grep -vE '^[[:space:]]*(#|$)' "$allowlist_file" | sort -u || true)"
+
+fail=0
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  if grep -qxF "$id" <<<"$allow"; then
+    echo "ALLOWLISTED $id — reviewed exception, see scripts/security/govulncheck-allowlist.txt"
+  else
+    echo "FAIL $id — symbol-level vulnerability not in the allowlist" >&2
+    fail=1
+  fi
+done <<<"$found"
+
+# Stale allowlist entries are noise that erodes trust in the list — surface
+# them (non-fatal) so they get removed once the underlying advisory is fixed.
+while IFS= read -r id; do
+  [ -z "$id" ] && continue
+  if ! grep -qxF "$id" <<<"$found"; then
+    echo "WARN stale allowlist entry $id no longer reported — remove it from govulncheck-allowlist.txt"
+  fi
+done <<<"$allow"
+
+if [ "$fail" -ne 0 ]; then
+  echo "govulncheck found unallowlisted vulnerabilities; run 'govulncheck ./...' in agent/ for detail" >&2
+  exit 1
+fi
+echo "govulncheck: no unallowlisted symbol-level vulnerabilities."


### PR DESCRIPTION
Fixes both checks currently red on main:

**1. Go Vulnerability Check / Security Scanning — red repo-wide since GO-2026-5051 published.** OOB read + panic in `go-smb2` `ReadDir` (v1.1.0), reached from `smbFS.ReadDir` in the workspace indexer. **Fixed in: N/A** — no patched release exists, so no bump can clear it.
- recover guard in `smbFS.ReadDir` contains the panic and surfaces it as a redacted error (+ test proving panic → error, no credential leak)
- CI runs govulncheck through `scripts/security/run-govulncheck.sh`: fails on any symbol-level finding **not** in `scripts/security/govulncheck-allowlist.txt`; stale entries WARN. Allowlist bar (documented in the file): no fixed release + code mitigation + tracking issue. Tracking: #2860.
- verified: wrapper exit 0 with the entry, exit 1 without; `go test -race ./internal/workspaceindex/` green

**2. Type Check — red since #2811 merged.** #2828's integration suite called `assertNotLocked` with the old `string[]` signature; #2811 made it value-based. Both green alone, incompatible together (no combined CI on admin merges). Updated the two call sites; the 403 case now submits a genuinely diverging value.

`apps/api` `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)