### PR TITLE
fix(ci): repair smoke-binary-source workflows

### DIFF
--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -125,6 +125,13 @@ jobs:
           # Required in production by the Wave 3 live-authorization epoch
           # rollout — compat until the fleet drains version-one writers.
           EVENT_PERMISSION_EPOCH_MODE: compat
+          # Wave 4 remote-access runtime config (#2842) — required at
+          # production boot by getRemoteWsRuntimeConfig(). Values match the
+          # CI stack in ci.yml; irrelevant to the binary-download path this
+          # smoke exercises, but the API refuses to start without them.
+          REMOTE_ACCESS_ADMISSION_MODE: open
+          REMOTE_WS_AUTH_MODE: post_upgrade
+          REMOTE_WS_REDIS_TOPOLOGY: standalone-single-primary
           TRUSTED_PROXY_CIDRS: 127.0.0.1/32
           CORS_ALLOWED_ORIGINS: http://localhost:3001
           TRUST_PROXY_HEADERS: "false"

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -115,6 +115,13 @@ jobs:
           # Required in production by the Wave 3 live-authorization epoch
           # rollout — compat until the fleet drains version-one writers.
           EVENT_PERMISSION_EPOCH_MODE: compat
+          # Wave 4 remote-access runtime config (#2842) — required at
+          # production boot by getRemoteWsRuntimeConfig(). Values match the
+          # CI stack in ci.yml; irrelevant to the binary-download path this
+          # smoke exercises, but the API refuses to start without them.
+          REMOTE_ACCESS_ADMISSION_MODE: open
+          REMOTE_WS_AUTH_MODE: post_upgrade
+          REMOTE_WS_REDIS_TOPOLOGY: standalone-single-primary
           TRUSTED_PROXY_CIDRS: 127.0.0.1/32
           CORS_ALLOWED_ORIGINS: http://localhost:3001
           TRUST_PROXY_HEADERS: "false"


### PR DESCRIPTION
## Root cause

`smoke-binary-source-github` and `smoke-binary-source-local` have failed on every main push since 406b466af (security wave 4, #2842, merged 2026-07-27 ~15:57 UTC). The last green run was e6e00ef88 (wave 3).

Wave 4 introduced `getRemoteWsRuntimeConfig()` in `apps/api/src/config/env.ts`, whose `requiredEnum` helper hard-requires three env vars whenever `NODE_ENV=production`:

- `REMOTE_ACCESS_ADMISSION_MODE` (`open` | `closed`)
- `REMOTE_WS_AUTH_MODE` (`post_upgrade` | `pre_upgrade`)
- `REMOTE_WS_REDIS_TOPOLOGY` (`standalone-single-primary`)

Both smoke jobs boot the API with `NODE_ENV=production`, so every run died at startup with:

```
Error: REMOTE_ACCESS_ADMISSION_MODE is required
```

before the binary-download path was ever exercised. Wave 4 updated the compose env in `ci.yml` (and `docker-compose.yml` / `deploy/.env.example`) but missed these two standalone workflows.

## Fix

Add the three vars to the `Boot API` step env of both workflows, using the same values `ci.yml` already uses for the CI stack (`open` / `post_upgrade` / `standalone-single-primary`). They are irrelevant to the binary-download path these smokes assert, but the API refuses to start without them.

No assertion was weakened — the download-path checks (#646 server-relative URL, #625 signed-manifest 200) are untouched.

## Verification

- `actionlint` clean on both workflows; YAML parse verified.
- Simulated `requiredEnum` with the exact new env values — accepts all three (and I confirmed no other production-boot-required env was added between e6e00ef88 and main; the remaining new throws are runtime-path, not boot).
- Both workflows trigger on `pull_request` for their own workflow file paths, so this PR's CI runs the repaired smokes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)