### PR TITLE
fix(web): hide Linked Profiles tab on unlinked devices (#2865)

### DIFF
--- a/apps/web/src/components/devices/DeviceDetailPage.tsx
+++ b/apps/web/src/components/devices/DeviceDetailPage.tsx
@@ -105,6 +105,12 @@ export default function DeviceDetailPage({ deviceId }: DeviceDetailPageProps) {
         pendingReboot: data.pendingReboot === true,
         desktopAccess: data.desktopAccess ?? undefined,
         remoteAccessPolicy: data.remoteAccessPolicy ?? undefined,
+        // Link-group membership (#2138/#2308). Carried through so the detail
+        // page can hide the Linked Profiles tab on an unlinked device (#2865)
+        // without a second fetch — the detail endpoint already returns both
+        // columns (neither is in SENSITIVE_DEVICE_FIELDS).
+        linkGroupId: data.linkGroupId ?? null,
+        linkGroupRole: data.linkGroupRole ?? null,
       };
 
       setDevice(transformedDevice);

--- a/apps/web/src/components/devices/DeviceDetails.linkedProfiles.test.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.linkedProfiles.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import DeviceDetails from './DeviceDetails';
+import type { Device } from './DeviceList';
+
+const fetchWithAuthMock = vi.hoisted(() => vi.fn());
+vi.mock('../../stores/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../stores/auth')>();
+  return { ...actual, fetchWithAuth: fetchWithAuthMock };
+});
+
+const useExtensionSlotDescriptorsMock = vi.hoisted(() => vi.fn());
+vi.mock('../extensions/ExtensionSlotHost', () => ({
+  useExtensionSlotDescriptors: (...a: unknown[]) => useExtensionSlotDescriptorsMock(...a),
+  default: () => <div data-testid="extension-slot-host-stub" />,
+}));
+
+// Stubbed so these tests assert tab *visibility* and panel mounting only —
+// the tab's own loading/empty/denied states are covered in
+// DeviceLinkedProfilesTab.test.tsx.
+vi.mock('./DeviceLinkedProfilesTab', () => ({
+  default: ({ deviceId }: { deviceId: string }) => (
+    <div data-testid="linked-profiles-tab-stub" data-device-id={deviceId} />
+  ),
+}));
+
+const baseDevice: Device = {
+  id: 'device-1',
+  hostname: 'edge-01',
+  os: 'windows',
+  osVersion: '11',
+  status: 'online',
+  cpuPercent: 58,
+  ramPercent: 71,
+  uptimeSeconds: 3600,
+  lastSeen: '2026-02-09T10:00:00.000Z',
+  orgId: 'org-1',
+  orgName: 'Org One',
+  siteId: 'site-1',
+  siteName: 'HQ',
+  agentVersion: '1.0.0',
+  pendingReboot: false,
+  lastUser: 'jdoe',
+  displayName: 'Edge 01',
+} as Device;
+
+const makeJsonResponse = (payload: unknown, ok = true, status = ok ? 200 : 404): Response =>
+  ({
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'ERROR',
+    json: vi.fn().mockResolvedValue(payload),
+  }) as unknown as Response;
+
+// jsdom reports zero widths, so OverflowTabs collapses everything past the
+// first tab into the "More" dropdown. Open it to read the whole strip.
+async function tabLabels(): Promise<string[]> {
+  const user = userEvent.setup();
+  await user.click(await screen.findByText('More'));
+  const dropdown = (await screen.findByText('Details')).closest('div')!;
+  return within(dropdown)
+    .getAllByRole('button')
+    .map((b) => b.textContent ?? '');
+}
+
+beforeEach(() => {
+  fetchWithAuthMock.mockReset();
+  fetchWithAuthMock.mockResolvedValue(makeJsonResponse({}, false, 404));
+  useExtensionSlotDescriptorsMock.mockReset();
+  useExtensionSlotDescriptorsMock.mockReturnValue([]);
+  window.location.hash = '';
+});
+
+afterEach(() => {
+  window.location.hash = '';
+  vi.clearAllMocks();
+});
+
+describe('DeviceDetails Linked Profiles tab visibility (#2865)', () => {
+  it('omits the tab when the device is not in a link group', async () => {
+    render(<DeviceDetails device={baseDevice} />);
+    const labels = await tabLabels();
+    expect(labels.some((l) => l.includes('Details'))).toBe(true);
+    expect(labels.some((l) => l.includes('Linked Profiles'))).toBe(false);
+  });
+
+  it('omits the tab when linkGroupId is explicitly null', async () => {
+    render(<DeviceDetails device={{ ...baseDevice, linkGroupId: null }} />);
+    const labels = await tabLabels();
+    expect(labels.some((l) => l.includes('Linked Profiles'))).toBe(false);
+  });
+
+  it('shows the tab for a multi-boot peer (linkGroupId set, no role)', async () => {
+    render(<DeviceDetails device={{ ...baseDevice, linkGroupId: 'group-1' }} />);
+    const labels = await tabLabels();
+    expect(labels.some((l) => l.includes('Linked Profiles'))).toBe(true);
+  });
+
+  it('shows the tab for a vm_host group member', async () => {
+    render(
+      <DeviceDetails
+        device={{ ...baseDevice, linkGroupId: 'group-1', linkGroupRole: 'guest' }}
+      />,
+    );
+    const labels = await tabLabels();
+    expect(labels.some((l) => l.includes('Linked Profiles'))).toBe(true);
+  });
+});
+
+describe('DeviceDetails #linked-profiles deep link (#2865)', () => {
+  it('mounts the panel when the device is linked', async () => {
+    window.location.hash = 'linked-profiles';
+    render(<DeviceDetails device={{ ...baseDevice, linkGroupId: 'group-1' }} />);
+
+    const stub = await screen.findByTestId('linked-profiles-tab-stub');
+    expect(stub.dataset.deviceId).toBe('device-1');
+  });
+
+  it('falls back to Overview on an unlinked device instead of a blank content area', async () => {
+    window.location.hash = 'linked-profiles';
+    render(<DeviceDetails device={baseDevice} />);
+
+    // The header always renders; the assertion that matters is that the
+    // linked-profiles panel did NOT mount and Overview took its place.
+    await screen.findByText('Edge 01');
+    expect(screen.queryByTestId('linked-profiles-tab-stub')).not.toBeInTheDocument();
+    // Overview's Activity rail is Overview-only, so its presence proves the
+    // fallback selected Overview rather than leaving no panel mounted.
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.queryByText('Linked Profiles')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/devices/DeviceDetails.tsx
+++ b/apps/web/src/components/devices/DeviceDetails.tsx
@@ -236,7 +236,7 @@ export default function DeviceDetails({
   // Never throws — a registry failure or zero enabled contributions simply
   // appends no extension tabs (see useExtensionSlotDescriptors).
   const extensionTabDescriptors = useExtensionSlotDescriptors("device.detail.tabs", 1);
-  const [activeTab, setActiveTab] = useHashState<Tab>("overview", tabFromHash);
+  const [hashTab, setActiveTab] = useHashState<Tab>("overview", tabFromHash);
   const [focusedAnomalyId, setFocusedAnomalyId] = useHashState<
     string | undefined
   >(undefined, anomalyIdFromHash);
@@ -278,6 +278,19 @@ export default function DeviceDetails({
   const effectiveTimezone =
     timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+  // Linked Profiles only means something for a device that is actually in a
+  // link group — a multi-boot peer, or a member of a vm_host group (#2865).
+  // Everything else would land on a two-paragraph "not part of a linked group"
+  // explainer, so the tab is omitted entirely rather than rendered dead.
+  const isLinked = device.linkGroupId != null;
+
+  // `tabFromHash` validates against the static VALID_TABS list and cannot know
+  // about linkage, so a `#linked-profiles` deep link on an unlinked device
+  // would otherwise select a tab that has no button and no panel — a blank
+  // content area. Resolve it back to Overview here, where linkage is known.
+  const activeTab: Tab =
+    hashTab === "linked-profiles" && !isLinked ? "overview" : hashTab;
+
   const tabs: {
     id: Tab;
     label: string;
@@ -297,12 +310,16 @@ export default function DeviceDetails({
       icon: <Info className="h-4 w-4" />,
       title: t("deviceDetails.osNetworkAndSystemDetails"),
     },
-    {
-      id: "linked-profiles",
-      label: t("deviceDetails.linkedProfiles"),
-      icon: <Link2 className="h-4 w-4" />,
-      title: t("deviceDetails.multiBootOsProfilesLinkedTo"),
-    },
+    ...(isLinked
+      ? [
+          {
+            id: "linked-profiles" as Tab,
+            label: t("deviceDetails.linkedProfiles"),
+            icon: <Link2 className="h-4 w-4" />,
+            title: t("deviceDetails.multiBootOsProfilesLinkedTo"),
+          },
+        ]
+      : []),
     // --- Monitoring ---
     {
       id: "performance",


### PR DESCRIPTION
## Summary

- Hide the device detail **Linked Profiles** tab unless the device is actually in a link group (`linkGroupId` set — multi-boot peer or `vm_host` member). Previously it rendered for every device, so on the vast majority it was a dead tab leading to a two-paragraph "not part of a linked group" explainer, while pushing useful tabs into the width-based **More** overflow.
- Carry `linkGroupId` / `linkGroupRole` through `DeviceDetailPage`'s response transform. The detail endpoint already returned both (neither is in `SENSITIVE_DEVICE_FIELDS`) — the hand-written mapping just dropped them, so no extra fetch is needed.
- Resolve a `#linked-profiles` deep link on an unlinked device back to Overview. `tabFromHash` validates against the static `VALID_TABS` list and can't know about linkage, so without this the hash selected a tab with no button *and* no panel — a blank content area.

Closes #2865

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / build / tooling
- [ ] Other:

## Testing

- [x] Existing tests pass (`pnpm test` / `make test`)
- [x] Added new tests
- [ ] Manual testing (describe below)

New suite `DeviceDetails.linkedProfiles.test.tsx` (6 tests, all green) covers both directions so the assertions aren't vacuous:

- tab omitted when `linkGroupId` is absent, and when explicitly `null`
- tab shown for a multi-boot peer (`linkGroupId`, no role) and for a `vm_host` member (`linkGroupRole: 'guest'`)
- `#linked-profiles` deep link mounts the panel on a linked device
- `#linked-profiles` deep link on an unlinked device falls back to Overview rather than a blank content area

Regression + typecheck:

- `vitest run DeviceDetails.extensions.test.tsx DeviceLinkedProfilesTab.test.tsx useHashState.test.ts` — 30 passed
- `tsc --noEmit` clean; `astro check` — 0 errors (the two `ts(6133)` warnings are pre-existing in `src/lib/api/vulnerabilities.ts`, untouched here)

## Checklist

- [x] My code follows the project's code style
- [x] I have reviewed my own changes
- [ ] I have tested on the relevant platforms
- [x] No secrets, credentials, or personal data included

Web-only change; no schema, migration, or tenancy surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aut3FwrbFEBWCsDfSVx7hA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aut3FwrbFEBWCsDfSVx7hA)_