### PR TITLE
fix(web): org defaults device-group select rendered raw i18n keys

### DIFF
--- a/apps/web/src/components/settings/OrgDefaultsEditor.tsx
+++ b/apps/web/src/components/settings/OrgDefaultsEditor.tsx
@@ -124,11 +124,13 @@ const policyOptions = [
   { value: 'lenient', labelKey: 'orgDefaultsEditor.policies.options.lenient' },
 ];
 
+// Key casing matches the locale files (PascalCase leaf), which all seven
+// locales share — the camelCase spelling rendered raw keys in the select.
 const groupOptions = [
-  { value: 'All Managed Devices', labelKey: 'orgDefaultsEditor.deviceGroup.options.allManagedDevices' },
-  { value: 'Critical Infrastructure', labelKey: 'orgDefaultsEditor.deviceGroup.options.criticalInfrastructure' },
-  { value: 'Remote Staff', labelKey: 'orgDefaultsEditor.deviceGroup.options.remoteStaff' },
-  { value: 'Contractors', labelKey: 'orgDefaultsEditor.deviceGroup.options.contractors' },
+  { value: 'All Managed Devices', labelKey: 'orgDefaultsEditor.deviceGroup.options.AllManagedDevices' },
+  { value: 'Critical Infrastructure', labelKey: 'orgDefaultsEditor.deviceGroup.options.CriticalInfrastructure' },
+  { value: 'Remote Staff', labelKey: 'orgDefaultsEditor.deviceGroup.options.RemoteStaff' },
+  { value: 'Contractors', labelKey: 'orgDefaultsEditor.deviceGroup.options.Contractors' },
 ];
 const alertThresholds = [
   { value: 'critical', labelKey: 'orgDefaultsEditor.alertSeverity.options.critical' },


### PR DESCRIPTION
Found live during the pre-release QA pass: the **Default device group** select in Organization settings rendered raw key paths (`orgDefaultsEditor.deviceGroup.options.allManagedDevices`) instead of labels.

Cause: the component's `labelKey`s use a camelCase leaf while all seven locale files ship PascalCase (`options.AllManagedDevices`). Pre-existing (pre-dates today's merges — verified the mismatch exists at the #2819 merge-base).

Fix: component-side rename to PascalCase (single consumer; seven locale files already agree). Verified live in the wt-stack — options now render translated, and a defaults save persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)