### PR TITLE
fix(reports): honor '*' wildcard grants in report authority checks (#2874)

### DIFF
--- a/apps/api/src/services/permissionMatching.test.ts
+++ b/apps/api/src/services/permissionMatching.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { permissionGrantMatches } from './permissionMatching';
+
+describe('permissionGrantMatches', () => {
+  it.each([
+    { grant: { resource: 'reports', action: 'read' }, resource: 'reports', action: 'read', expected: true },
+    { grant: { resource: '*', action: '*' }, resource: 'reports', action: 'read', expected: true },
+    { grant: { resource: '*', action: 'read' }, resource: 'reports', action: 'read', expected: true },
+    { grant: { resource: 'reports', action: '*' }, resource: 'reports', action: 'delete', expected: true },
+    { grant: { resource: 'devices', action: '*' }, resource: 'reports', action: 'read', expected: false },
+    { grant: { resource: '*', action: 'write' }, resource: 'reports', action: 'read', expected: false },
+    { grant: { resource: 'reports', action: 'read' }, resource: 'reports', action: 'write', expected: false },
+    { grant: { resource: 'reports', action: 'read' }, resource: 'devices', action: 'read', expected: false },
+  ])(
+    '$grant.resource|$grant.action vs $resource:$action -> $expected',
+    ({ grant, resource, action, expected }) => {
+      expect(permissionGrantMatches(grant, resource, action)).toBe(expected);
+    },
+  );
+
+  it('never treats a concrete resource as a prefix wildcard', () => {
+    expect(permissionGrantMatches({ resource: 'report', action: '*' }, 'reports', 'read')).toBe(false);
+    expect(permissionGrantMatches({ resource: 'reports', action: 'rea' }, 'reports', 'read')).toBe(false);
+  });
+});

--- a/apps/api/src/services/permissionMatching.ts
+++ b/apps/api/src/services/permissionMatching.ts
@@ -1,0 +1,20 @@
+// Canonical grant-matching semantics, shared by every permission check in
+// the platform: a permission row matches a required resource/action when it
+// names it exactly OR carries the '*' wildcard on that axis.
+//
+// This lives in its own dependency-free module (no db/schema imports) so that
+// enforcement paths like services/siteScope.ts can share it without pulling in
+// the full permission-resolver module graph. A literal-equality divergence in
+// the report-authority path locked wildcard-only super-roles (e.g. the seeded
+// Partner Admin's single `*|*` grant) out of all report actions (#2874) —
+// never re-implement this comparison with plain equality.
+export function permissionGrantMatches(
+  grant: { resource: string; action: string },
+  resource: string,
+  action: string,
+): boolean {
+  return (
+    (grant.resource === resource || grant.resource === '*') &&
+    (grant.action === action || grant.action === '*')
+  );
+}

--- a/apps/api/src/services/permissionMatching.ts
+++ b/apps/api/src/services/permissionMatching.ts
@@ -1,6 +1,9 @@
-// Canonical grant-matching semantics, shared by every permission check in
-// the platform: a permission row matches a required resource/action when it
-// names it exactly OR carries the '*' wildcard on that axis.
+// Canonical grant-matching semantics: a permission row matches a required
+// resource/action when it names it exactly OR carries the '*' wildcard on
+// that axis. Shared by services/permissions.ts (hasPermission) and
+// services/siteScope.ts; a few older call sites (e.g.
+// services/remoteWsAuthorization.ts) still inline the same comparison —
+// prefer this helper for new code.
 //
 // This lives in its own dependency-free module (no db/schema imports) so that
 // enforcement paths like services/siteScope.ts can share it without pulling in

--- a/apps/api/src/services/permissions.ts
+++ b/apps/api/src/services/permissions.ts
@@ -3,6 +3,7 @@ import { roles, permissions, rolePermissions, partnerUsers, organizationUsers } 
 import { eq, and } from 'drizzle-orm';
 import { getRedis } from './redis';
 import { PERMISSION_GRANTS } from '@breeze/shared';
+import { permissionGrantMatches } from './permissionMatching';
 
 export interface Permission {
   resource: string;
@@ -212,8 +213,7 @@ export function hasPermission(
   action: string
 ): boolean {
   return userPerms.permissions.some(
-    p => (p.resource === resource || p.resource === '*') &&
-         (p.action === action || p.action === '*')
+    p => permissionGrantMatches(p, resource, action)
   );
 }
 

--- a/apps/api/src/services/siteScope.test.ts
+++ b/apps/api/src/services/siteScope.test.ts
@@ -1619,7 +1619,56 @@ describe('live report authority resolution', () => {
     });
   });
 
-  // #2874: the batched resolver shares the wildcard semantics.
+  // #2874: the batched resolver shares the wildcard semantics — on BOTH of
+  // its branches. The org-membership branch runs a separate permission query
+  // (its own SQL filter) from the partner fallback, so each needs its own
+  // rendered-WHERE wildcard guard.
+  it('honors a *|* grant on a batched organization membership', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [{ orgId: ORG_A, roleId: ROLE_ORG, siteIds: null }],
+      [{
+        roleId: ROLE_ORG,
+        resource: '*',
+        action: '*',
+        roleScope: 'organization',
+        roleIsSystem: false,
+        roleOrgId: ORG_A,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_A],
+      'read',
+    );
+
+    expect(result.get(ORG_A)).toMatchObject({
+      ok: true,
+      authority: { scope: unrestricted() },
+    });
+    // Every accessible org has a membership, so no partner fallback queries
+    // run and the last captured WHERE is the org-branch permission query —
+    // the one whose SQL filter must let the two '*' params through.
+    expect(vi.mocked(db.select)).toHaveBeenCalledTimes(4);
+    const renderedPermissionWhere = renderSql(
+      liveDbState.whereConditions.at(-1) as SQL,
+    );
+    expect(renderedPermissionWhere.params).toContain('reports');
+    expect(renderedPermissionWhere.params).toContain('read');
+    expect(
+      renderedPermissionWhere.params.filter((param) => param === '*'),
+    ).toHaveLength(2);
+  });
+
   it('honors a *|* grant in the batched partner fallback', async () => {
     queueRows(
       [activeUser()],

--- a/apps/api/src/services/siteScope.test.ts
+++ b/apps/api/src/services/siteScope.test.ts
@@ -1122,6 +1122,115 @@ describe('live report authority resolution', () => {
     },
   );
 
+  // #2874: the report authority check must honor '*' wildcard grants the same
+  // way the canonical resolver (services/permissions.ts hasPermission) does.
+  // The seeded Partner Admin role carries a single `*|*` row and nothing else.
+  it.each([
+    { name: '*|* (Partner Admin shape)', resource: '*', action: '*' },
+    { name: 'wildcard resource with exact action', resource: '*', action: 'read' },
+    { name: 'exact resource with wildcard action', resource: 'reports', action: '*' },
+  ])(
+    'grants partner fallback authority via a $name grant',
+    async ({ resource, action }) => {
+      queueRows(
+        [activeUser()],
+        [organization()],
+        [],
+        [{ roleId: ROLE_PARTNER, orgAccess: 'all', orgIds: null }],
+        [{
+          resource,
+          action,
+          roleScope: 'partner',
+          roleIsSystem: false,
+          roleOrgId: null,
+          rolePartnerId: PARTNER_A,
+        }],
+      );
+
+      const result = await resolveLiveReportAuthority(USER_ID, ORG_A, 'read');
+
+      expect(result).toMatchObject({
+        ok: true,
+        authority: { scope: unrestricted() },
+      });
+      // The SQL filter must let wildcard rows through — a JS-only match would
+      // pass this mock but never see the row against a real database.
+      const renderedPermissionWhere = renderSql(
+        liveDbState.whereConditions.at(-1) as SQL,
+      );
+      expect(renderedPermissionWhere.params).toContain('reports');
+      expect(renderedPermissionWhere.params).toContain('read');
+      expect(
+        renderedPermissionWhere.params.filter((param) => param === '*'),
+      ).toHaveLength(2);
+    },
+  );
+
+  it('a *|* grant does not widen a restricted organization membership beyond its sites', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [orgMembership([SITE_A])],
+      [{
+        resource: '*',
+        action: '*',
+        roleScope: 'organization',
+        roleIsSystem: false,
+        roleOrgId: ORG_A,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'write'))
+      .resolves.toMatchObject({
+        ok: true,
+        authority: { scope: restricted([SITE_A]) },
+      });
+  });
+
+  it.each([
+    { name: 'unrelated resource with wildcard action', resource: 'devices', action: '*' },
+    { name: 'wildcard resource with a different action', resource: '*', action: 'write' },
+  ])('still denies partner fallback for a $name grant', async ({ resource, action }) => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [],
+      [{ roleId: ROLE_PARTNER, orgAccess: 'all', orgIds: null }],
+      [{
+        resource,
+        action,
+        roleScope: 'partner',
+        roleIsSystem: false,
+        roleOrgId: null,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'permission_removed' });
+  });
+
+  it('a wildcard grant on a role owned by another partner is still rejected', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [],
+      [{ roleId: ROLE_PARTNER, orgAccess: 'all', orgIds: null }],
+      [{
+        resource: '*',
+        action: '*',
+        roleScope: 'partner',
+        roleIsSystem: false,
+        roleOrgId: null,
+        rolePartnerId: PARTNER_B,
+      }],
+    );
+
+    await expect(resolveLiveReportAuthority(USER_ID, ORG_A, 'read'))
+      .resolves.toEqual({ ok: false, reason: 'permission_removed' });
+  });
+
   it('returns unrestricted for current scheduled platform authority', async () => {
     queueRows(
       [activeUser({ isPlatformAdmin: true })],
@@ -1507,6 +1616,93 @@ describe('live report authority resolution', () => {
     expect(result.get(ORG_A)).toMatchObject({
       ok: true,
       authority: { scope: unrestricted() },
+    });
+  });
+
+  // #2874: the batched resolver shares the wildcard semantics.
+  it('honors a *|* grant in the batched partner fallback', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [],
+      [{
+        partnerId: PARTNER_A,
+        roleId: ROLE_PARTNER,
+        orgAccess: 'all',
+        orgIds: null,
+      }],
+      [{
+        roleId: ROLE_PARTNER,
+        resource: '*',
+        action: '*',
+        roleScope: 'partner',
+        roleIsSystem: false,
+        roleOrgId: null,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_A],
+      'read',
+    );
+
+    expect(result.get(ORG_A)).toMatchObject({
+      ok: true,
+      authority: { scope: unrestricted() },
+    });
+    const renderedPermissionWhere = renderSql(
+      liveDbState.whereConditions.at(-1) as SQL,
+    );
+    expect(
+      renderedPermissionWhere.params.filter((param) => param === '*'),
+    ).toHaveLength(2);
+  });
+
+  it('still denies an unrelated wildcard-action grant in the batched fallback', async () => {
+    queueRows(
+      [activeUser()],
+      [organization()],
+      [],
+      [{
+        partnerId: PARTNER_A,
+        roleId: ROLE_PARTNER,
+        orgAccess: 'all',
+        orgIds: null,
+      }],
+      [{
+        roleId: ROLE_PARTNER,
+        resource: 'devices',
+        action: '*',
+        roleScope: 'partner',
+        roleIsSystem: false,
+        roleOrgId: null,
+        rolePartnerId: PARTNER_A,
+      }],
+    );
+    const auth = requestAuth({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [ORG_A],
+      canAccessOrg: () => true,
+    });
+
+    const result = await resolveRequestReportAuthorityMap(
+      auth,
+      [ORG_A],
+      'read',
+    );
+
+    expect(result.get(ORG_A)).toEqual({
+      ok: false,
+      reason: 'permission_removed',
     });
   });
 });

--- a/apps/api/src/services/siteScope.ts
+++ b/apps/api/src/services/siteScope.ts
@@ -26,6 +26,7 @@ import {
 } from '../db';
 import type { AuthContext } from '../middleware/auth';
 import type { UserPermissions } from './permissions';
+import { permissionGrantMatches } from './permissionMatching';
 
 export type SiteScopeV1 =
   | { version: 1; kind: 'unrestricted'; orgId: string }
@@ -647,8 +648,10 @@ async function roleGrantsReportAction(
     .where(
       and(
         eq(rolePermissions.roleId, roleId),
-        eq(permissions.resource, 'reports'),
-        eq(permissions.action, action),
+        // '*' rows must survive the SQL filter so wildcard super-roles
+        // (Partner Admin's `*|*`) are honored — see permissionGrantMatches.
+        inArray(permissions.resource, ['reports', '*']),
+        inArray(permissions.action, [action, '*']),
         eq(roles.scope, expectedRole.scope),
         or(
           eq(roles.isSystem, true),
@@ -661,8 +664,7 @@ async function roleGrantsReportAction(
 
   return rows.some(
     (row) =>
-      row.resource === 'reports' &&
-      row.action === action &&
+      permissionGrantMatches(row, 'reports', action) &&
       row.roleScope === expectedRole.scope &&
       (row.roleIsSystem ||
         (expectedRole.scope === 'organization'
@@ -922,8 +924,7 @@ function batchRoleGrantsReportAction(
   return rows.some(
     (row) =>
       row.roleId === roleId &&
-      row.resource === 'reports' &&
-      row.action === action &&
+      permissionGrantMatches(row, 'reports', action) &&
       row.roleScope === expectedRole.scope &&
       (row.roleIsSystem ||
         (expectedRole.scope === 'organization'
@@ -1049,8 +1050,8 @@ async function resolveRequestReportAuthorityMapInSystemContext(
         .where(
           and(
             inArray(rolePermissions.roleId, organizationRoleIds),
-            eq(permissions.resource, 'reports'),
-            eq(permissions.action, action),
+            inArray(permissions.resource, ['reports', '*']),
+            inArray(permissions.action, [action, '*']),
           ),
         );
 
@@ -1120,8 +1121,8 @@ async function resolveRequestReportAuthorityMapInSystemContext(
         .where(
           and(
             inArray(rolePermissions.roleId, partnerRoleIds),
-            eq(permissions.resource, 'reports'),
-            eq(permissions.action, action),
+            inArray(permissions.resource, ['reports', '*']),
+            inArray(permissions.action, [action, '*']),
           ),
         );
 


### PR DESCRIPTION
## Summary

`roleGrantsReportAction` and the two batched report-authority checks in `apps/api/src/services/siteScope.ts` filtered role permissions with literal `resource = 'reports' AND action = <action>` predicates. A role whose permissions are expressed as a single `*|*` wildcard row — the seeded **Partner Admin** super-role's natural shape — never matched, resolved zero report grants, and was fail-closed out of every report action with `403 Report scope is not authorized`.

## Fix

- **New `apps/api/src/services/permissionMatching.ts`** — extracts the canonical wildcard matching semantics (previously inlined in `hasPermission`, `services/permissions.ts`) into a dependency-free shared module, so enforcement paths can share it without pulling the full permission-resolver module graph (which would break the many test files that mock `../db` with a partial export set).
- `services/permissions.ts` `hasPermission` now delegates to the shared matcher (no behavior change).
- `services/siteScope.ts`: the three SQL filters now use `inArray(permissions.resource, ['reports', '*'])` / `inArray(permissions.action, [action, '*'])` so wildcard rows survive the query, and both JS post-filters use `permissionGrantMatches(row, 'reports', action)`.

**Not weakened:** site-scope enforcement is untouched. Wildcard grants flow through the same membership/site-scope algebra — a restricted org membership still yields a restricted scope, cross-tenant role-ownership checks still reject roles owned by another org/partner, and unrelated grants still deny.

## Tests

- New: `*|*` → allowed on the partner fallback (Partner Admin shape), `*|action` and `reports|*` variants, `*|*` in the batched resolver, SQL-param assertions proving the `'*'` values reach the query (a JS-only fix would pass the row-queue mock but never see the row on a real DB), restricted membership + `*|*` stays site-restricted, unrelated `devices|*` and mismatched `*|write` still denied, wildcard on a foreign-partner role still rejected, and a `permissionMatching.test.ts` unit table (incl. no-prefix-matching).
- Existing explicit `reports:<action>` allow/deny and out-of-scope deny tests unchanged and green.
- Injection-verified: reverting only `siteScope.ts` makes exactly the 5 new authority tests fail.
- `vitest run` on `siteScope.test.ts`, `permissionMatching.test.ts`, `permissions.test.ts`, `routes/reports.test.ts`, `routes/reports/runs.audit.test.ts`: 266 passed. `tsc --noEmit` clean.

Closes #2874

🤖 Generated with [Claude Code](https://claude.com/claude-code)