### PR TITLE
fix(agent): detached self-uninstall teardown — agent no longer kills its own service mid-sequence (#2878)

### DIFF
--- a/agent/internal/heartbeat/handlers_uninstall.go
+++ b/agent/internal/heartbeat/handlers_uninstall.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -15,10 +16,39 @@ func init() {
 	handlerRegistry[tools.CmdSelfUninstall] = handleSelfUninstall
 }
 
-// handleSelfUninstall performs a best-effort service uninstall and cleanup.
-// The handler sends back a success result before triggering the actual
-// uninstall so the API receives acknowledgement. The process will exit
-// as part of the service teardown.
+// uninstallHelperDelaySeconds is how long the detached teardown helper sleeps
+// before stopping the agent's own service. It must be long enough for the
+// command result (submitted right after this handler returns) to reach the API
+// and for the agent to stop accepting new commands, but short enough that a
+// reboot or watchdog reinstall racing the teardown is unlikely.
+const uninstallHelperDelaySeconds = 5
+
+// handleSelfUninstall uninstalls the agent from the machine.
+//
+// The teardown is split into two phases (#2878):
+//
+//   - Phase 1 runs in-process BEFORE the result is acked: neutralize the
+//     watchdog (so it cannot respawn the agent mid-teardown), remove every
+//     artifact that is safe to remove while the agent is still running, and
+//     hand the self-referential steps — stopping/deleting the agent's OWN
+//     service and removing its own binary — to a detached helper process that
+//     survives this process's death.
+//
+//   - Phase 2 is the detached helper, which runs the self-referential steps
+//     after a short delay, by which point the result has been submitted.
+//
+// The previous implementation ran the whole sequence in-process and stopped
+// the agent's own service FIRST — on Windows `sc.exe stop BreezeAgent` killed
+// this very process before `sc.exe delete`, the watchdog teardown, or config
+// removal ever ran, leaving the machine fully installed (watchdog running,
+// auto-start service, severed token → permanent 401 hammering, the #2796
+// stranded-traffic scenario) while the offboarding drain recorded a clean
+// uninstall. macOS (`launchctl bootout` of its own daemon first) and Linux
+// (`systemctl stop` of its own unit first) had the same self-kill-first bug.
+//
+// If phase 1 cannot hand the teardown off, the machine is NOT going to
+// uninstall itself, so the command reports failure — the offboarding drain
+// must not count this device as cleanly uninstalled.
 func handleSelfUninstall(h *Heartbeat, cmd Command) tools.CommandResult {
 	start := time.Now()
 
@@ -28,54 +58,102 @@ func handleSelfUninstall(h *Heartbeat, cmd Command) tools.CommandResult {
 		"removeConfig", removeConfig,
 	)
 
-	// Schedule the actual uninstall to happen after we return the result.
-	// This gives processCommand time to submit the result back to the API.
+	if err := prepareSelfUninstall(removeConfig); err != nil {
+		log.Error("self-uninstall preparation failed — teardown NOT handed off, agent remains installed",
+			"error", err.Error(),
+		)
+		return tools.NewErrorResult(
+			fmt.Errorf("self-uninstall failed before teardown handoff (agent remains installed): %w", err),
+			time.Since(start).Milliseconds(),
+		)
+	}
+
+	// Shut down gracefully once the result has had time to be submitted. The
+	// detached helper stops the service as its first act, so on a normal
+	// service install the process exits via the service manager's stop control;
+	// the explicit Stop/os.Exit below is a backstop for non-service (dev) runs.
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				log.Error("panic during self-uninstall", "panic", fmt.Sprint(r))
+				log.Error("panic during self-uninstall shutdown", "panic", fmt.Sprint(r))
 			}
 		}()
 
-		// Brief delay so the command result can be submitted
+		// Brief delay so the command result can be submitted.
 		time.Sleep(2 * time.Second)
-
-		if err := performSelfUninstall(removeConfig); err != nil {
-			log.Error("self-uninstall partially failed", "error", err.Error())
-			// Even if uninstall fails, shut down the agent
-		}
-
-		// Signal the agent to stop. This triggers the graceful shutdown path.
 		h.StopAcceptingCommands()
-		h.Stop()
 
-		// If we're still alive after Stop (e.g., not running as a service),
-		// force exit.
+		// Give the detached helper time to stop the service (the normal exit
+		// path). If we are still alive well past its delay — e.g. not running
+		// under a service manager — stop and exit ourselves.
+		time.Sleep(time.Duration(uninstallHelperDelaySeconds+10) * time.Second)
+		h.Stop()
 		time.Sleep(5 * time.Second)
 		os.Exit(0)
 	}()
 
 	return tools.NewSuccessResult(map[string]string{
-		"message": "self-uninstall scheduled",
+		"message": "self-uninstall initiated: watchdog neutralized, detached teardown handed off",
 	}, time.Since(start).Milliseconds())
 }
 
-// performSelfUninstall does the platform-specific service removal.
-func performSelfUninstall(removeConfig bool) error {
+// prepareSelfUninstall does the platform-specific phase-1 teardown and hands
+// the self-referential steps to a detached helper. It returns an error only
+// when the handoff itself fails; individual best-effort cleanup failures are
+// logged but do not abort the uninstall.
+func prepareSelfUninstall(removeConfig bool) error {
 	switch runtime.GOOS {
 	case "darwin":
-		return selfUninstallDarwin(removeConfig)
+		return prepareSelfUninstallDarwin(removeConfig)
 	case "linux":
-		return selfUninstallLinux(removeConfig)
+		return prepareSelfUninstallLinux(removeConfig)
 	case "windows":
-		return selfUninstallWindows(removeConfig)
+		return prepareSelfUninstallWindows(removeConfig)
 	default:
 		return fmt.Errorf("unsupported OS for self-uninstall: %s", runtime.GOOS)
 	}
 }
 
-// selfUninstallDarwin removes the launchd service, plists, and binary on macOS.
-func selfUninstallDarwin(removeConfig bool) error {
+// removeFileLogged removes path, logging (but not failing on) errors other
+// than the file already being absent.
+func removeFileLogged(path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Warn("self-uninstall: failed to remove file", "path", path, "error", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// macOS
+// ---------------------------------------------------------------------------
+
+// darwinUninstallScriptOptions captures the inputs to the detached shell
+// script that removes the agent's own launchd daemon on macOS. Extracted so
+// the script text can be unit-tested without spawning a shell.
+type darwinUninstallScriptOptions struct {
+	Label        string // launchd label of the agent daemon (bootout kills this process)
+	PlistPath    string // the agent daemon's plist
+	BinaryPath   string // the agent binary
+	DelaySeconds int
+}
+
+// buildDarwinUninstallScript renders the detached teardown script for macOS.
+// Everything except the agent's own daemon was already removed in-process by
+// prepareSelfUninstallDarwin; this script only performs the steps that would
+// kill the process issuing them.
+func buildDarwinUninstallScript(opts darwinUninstallScriptOptions) string {
+	lines := []string{
+		fmt.Sprintf("sleep %d", opts.DelaySeconds),
+		fmt.Sprintf("launchctl bootout system/%s || launchctl unload %s", shQuote(opts.Label), shQuote(opts.PlistPath)),
+		fmt.Sprintf("rm -f %s", shQuote(opts.PlistPath)),
+		fmt.Sprintf("rm -f %s", shQuote(opts.BinaryPath)),
+	}
+	return strings.Join(lines, "\n")
+}
+
+// prepareSelfUninstallDarwin removes the watchdog, user helper, plists, the
+// watchdog binary, and (optionally) config in-process, then hands the removal
+// of the agent's own daemon + binary to a detached shell.
+func prepareSelfUninstallDarwin(removeConfig bool) error {
 	const (
 		label            = "com.breeze.agent"
 		userLabel        = "com.breeze.agent-user"
@@ -88,58 +166,69 @@ func selfUninstallDarwin(removeConfig bool) error {
 		configDir        = "/Library/Application Support/Breeze"
 	)
 
-	var errs []string
-
-	// Bootout the daemon (this will kill us, but we try anyway)
-	if err := exec.Command("launchctl", "bootout", "system/"+label).Run(); err != nil {
-		log.Warn("launchctl bootout failed, trying legacy unload", "error", err.Error())
-		if err2 := exec.Command("launchctl", "unload", plistDst).Run(); err2 != nil {
-			errs = append(errs, fmt.Sprintf("daemon unload: %s", err2.Error()))
-		}
+	// Watchdog FIRST — it must be gone before anything stops the agent, or it
+	// may respawn/reinstall the agent mid-teardown.
+	if err := exec.Command("launchctl", "bootout", "system/"+watchdogLabel).Run(); err != nil {
+		log.Warn("launchctl bootout watchdog failed, trying legacy unload", "error", err.Error())
+		_ = exec.Command("launchctl", "unload", watchdogPlistDst).Run()
 	}
-
-	// Remove user helper
 	if err := exec.Command("launchctl", "bootout", "system/"+userLabel).Run(); err != nil {
 		_ = exec.Command("launchctl", "unload", userPlistDst).Run()
 	}
-	if err := exec.Command("launchctl", "bootout", "system/"+watchdogLabel).Run(); err != nil {
-		_ = exec.Command("launchctl", "unload", watchdogPlistDst).Run()
-	}
 
-	// Remove plists
-	if err := os.Remove(plistDst); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Sprintf("remove %s: %s", plistDst, err.Error()))
-	}
-	if err := os.Remove(userPlistDst); err != nil && !os.IsNotExist(err) {
-		log.Warn("failed to remove user plist", "error", err.Error())
-	}
-	if err := os.Remove(watchdogPlistDst); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Sprintf("remove %s: %s", watchdogPlistDst, err.Error()))
-	}
+	removeFileLogged(watchdogPlistDst)
+	removeFileLogged(userPlistDst)
+	removeFileLogged(watchdogBinary)
 
-	// Remove binary
-	if err := os.Remove(binaryPath); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Sprintf("remove binary: %s", err.Error()))
-	}
-	if err := os.Remove(watchdogBinary); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Sprintf("remove watchdog binary: %s", err.Error()))
-	}
-
-	// Optionally remove config
 	if removeConfig {
 		if err := os.RemoveAll(configDir); err != nil {
-			errs = append(errs, fmt.Sprintf("remove config: %s", err.Error()))
+			log.Warn("self-uninstall: failed to remove config dir", "path", configDir, "error", err.Error())
 		}
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("partial failure: %s", strings.Join(errs, "; "))
+	// Booting out our own daemon kills this process, so it (and the removal of
+	// our own plist/binary) runs from a detached session after we exit.
+	script := buildDarwinUninstallScript(darwinUninstallScriptOptions{
+		Label:        label,
+		PlistPath:    plistDst,
+		BinaryPath:   binaryPath,
+		DelaySeconds: uninstallHelperDelaySeconds,
+	})
+	if err := startDetachedProcess("/bin/sh", "-c", script); err != nil {
+		return fmt.Errorf("spawn detached teardown helper: %w", err)
 	}
 	return nil
 }
 
-// selfUninstallLinux removes the systemd service, unit files, and binary on Linux.
-func selfUninstallLinux(removeConfig bool) error {
+// ---------------------------------------------------------------------------
+// Linux
+// ---------------------------------------------------------------------------
+
+// linuxUninstallScriptOptions captures the inputs to the detached shell script
+// that removes the agent's own systemd unit on Linux.
+type linuxUninstallScriptOptions struct {
+	ServiceName  string // the agent's own unit (stopping it kills this process)
+	UnitPath     string
+	BinaryPath   string
+	DelaySeconds int
+}
+
+// buildLinuxUninstallScript renders the detached teardown script for Linux.
+func buildLinuxUninstallScript(opts linuxUninstallScriptOptions) string {
+	lines := []string{
+		fmt.Sprintf("sleep %d", opts.DelaySeconds),
+		fmt.Sprintf("systemctl stop %s", shQuote(opts.ServiceName)),
+		fmt.Sprintf("rm -f %s", shQuote(opts.UnitPath)),
+		"systemctl daemon-reload",
+		fmt.Sprintf("rm -f %s", shQuote(opts.BinaryPath)),
+	}
+	return strings.Join(lines, "\n")
+}
+
+// prepareSelfUninstallLinux removes the watchdog, unit files, the watchdog
+// binary, and (optionally) config in-process, then hands the stop + removal of
+// the agent's own unit + binary to a detached shell.
+func prepareSelfUninstallLinux(removeConfig bool) error {
 	const (
 		serviceName     = "breeze-agent"
 		watchdogService = "breeze-watchdog"
@@ -151,81 +240,127 @@ func selfUninstallLinux(removeConfig bool) error {
 		configDir       = "/etc/breeze"
 	)
 
-	var errs []string
-
-	// Stop and disable the service
-	if err := exec.Command("systemctl", "stop", serviceName).Run(); err != nil {
-		log.Warn("systemctl stop failed", "error", err.Error())
-		errs = append(errs, fmt.Sprintf("stop service: %s", err.Error()))
-	}
-	if err := exec.Command("systemctl", "disable", serviceName).Run(); err != nil {
-		log.Warn("systemctl disable failed", "error", err.Error())
-	}
+	// Watchdog FIRST (see prepareSelfUninstallDarwin).
 	if err := exec.Command("systemctl", "stop", watchdogService).Run(); err != nil {
 		log.Warn("systemctl stop watchdog failed", "error", err.Error())
 	}
 	if err := exec.Command("systemctl", "disable", watchdogService).Run(); err != nil {
 		log.Warn("systemctl disable watchdog failed", "error", err.Error())
 	}
-
-	// Remove unit files
-	if err := os.Remove(unitDst); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Sprintf("remove %s: %s", unitDst, err.Error()))
-	}
-	if err := os.Remove(watchdogUnitDst); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Sprintf("remove %s: %s", watchdogUnitDst, err.Error()))
-	}
-	if err := os.Remove(userUnitDst); err != nil && !os.IsNotExist(err) {
-		log.Warn("failed to remove user unit", "error", err.Error())
+	// Disabling (not stopping!) our own service is safe while running and
+	// prevents an auto-start if the host reboots mid-teardown.
+	if err := exec.Command("systemctl", "disable", serviceName).Run(); err != nil {
+		log.Warn("systemctl disable agent failed", "error", err.Error())
 	}
 
-	// Reload systemd
-	_ = exec.Command("systemctl", "daemon-reload").Run()
+	removeFileLogged(watchdogUnitDst)
+	removeFileLogged(userUnitDst)
+	removeFileLogged(watchdogBinary)
 
-	// Remove binary
-	if err := os.Remove(binaryPath); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Sprintf("remove binary: %s", err.Error()))
-	}
-	if err := os.Remove(watchdogBinary); err != nil && !os.IsNotExist(err) {
-		errs = append(errs, fmt.Sprintf("remove watchdog binary: %s", err.Error()))
-	}
-
-	// Optionally remove config
 	if removeConfig {
 		if err := os.RemoveAll(configDir); err != nil {
-			errs = append(errs, fmt.Sprintf("remove config: %s", err.Error()))
+			log.Warn("self-uninstall: failed to remove config dir", "path", configDir, "error", err.Error())
 		}
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("partial failure: %s", strings.Join(errs, "; "))
+	// Stopping our own unit kills this process (systemd SIGTERMs the cgroup),
+	// so it runs from a detached session after we exit. The agent's own unit
+	// file must survive until then so the stop is clean.
+	script := buildLinuxUninstallScript(linuxUninstallScriptOptions{
+		ServiceName:  serviceName,
+		UnitPath:     unitDst,
+		BinaryPath:   binaryPath,
+		DelaySeconds: uninstallHelperDelaySeconds,
+	})
+	if err := startDetachedProcess("/bin/sh", "-c", script); err != nil {
+		return fmt.Errorf("spawn detached teardown helper: %w", err)
 	}
 	return nil
 }
 
-// selfUninstallWindows removes the Windows service and binary.
-// Note: Uses sc.exe rather than the SCM API (golang.org/x/sys/windows/svc/mgr)
-// to avoid the complexity of deleting a service from within its own process context.
-func selfUninstallWindows(removeConfig bool) error {
+// shQuote single-quotes s for POSIX sh, escaping embedded single quotes.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// ---------------------------------------------------------------------------
+// Windows
+// ---------------------------------------------------------------------------
+
+// windowsUninstallScriptOptions captures the inputs to the detached PowerShell
+// helper that tears down the agent's own service on Windows. Extracted (like
+// updater.buildRestartScript) so the script text can be unit-tested without
+// spawning PowerShell.
+type windowsUninstallScriptOptions struct {
+	ServiceName         string
+	WatchdogServiceName string
+	AgentBinaryPath     string
+	WatchdogBinaryPath  string
+	ConfigDir           string // empty = skip config removal regardless of RemoveConfig
+	RemoveConfig        bool
+	DelaySeconds        int
+}
+
+// buildWindowsUninstallScript renders the detached PowerShell teardown script.
+// Ordering is load-bearing:
+//
+//  1. Stop-Service on the agent (waits for Stopped — this is what kills the
+//     agent process, AFTER the command result has been submitted),
+//  2. delete both service registrations,
+//  3. kill lingering sibling helper processes that could hold file locks,
+//  4. remove the binaries (unlocked once the processes are gone),
+//  5. remove config last (the agent's open log handles are released by then),
+//  6. the script deletes itself.
+//
+// Removal steps use -ErrorAction SilentlyContinue: by this point the process
+// that could report errors is gone, so best-effort is all there is.
+func buildWindowsUninstallScript(opts windowsUninstallScriptOptions) string {
+	lines := []string{
+		fmt.Sprintf("Start-Sleep -Seconds %d", opts.DelaySeconds),
+		fmt.Sprintf("Stop-Service -Name '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.ServiceName)),
+		fmt.Sprintf("sc.exe delete '%s' | Out-Null", psQuote(opts.ServiceName)),
+		// Re-assert the watchdog teardown: phase 1 already stopped/deleted it,
+		// but sc.exe stop is asynchronous — if it was still STOP_PENDING when
+		// phase 1's delete ran, the delete may not have taken.
+		fmt.Sprintf("sc.exe stop '%s' | Out-Null", psQuote(opts.WatchdogServiceName)),
+		fmt.Sprintf("sc.exe delete '%s' | Out-Null", psQuote(opts.WatchdogServiceName)),
+		"Get-Process -Name 'breeze-user-helper','breeze-desktop-helper','breeze-watchdog' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue",
+		"Start-Sleep -Seconds 1",
+		fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.WatchdogBinaryPath)),
+		fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.AgentBinaryPath)),
+	}
+	if opts.RemoveConfig && opts.ConfigDir != "" {
+		lines = append(lines,
+			fmt.Sprintf("Remove-Item -Path '%s' -Recurse -Force -ErrorAction SilentlyContinue", psQuote(opts.ConfigDir)),
+		)
+	}
+	lines = append(lines, "Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue")
+	return strings.Join(lines, "\r\n")
+}
+
+// psQuote escapes s for inclusion inside a single-quoted PowerShell string.
+func psQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// prepareSelfUninstallWindows neutralizes the watchdog in-process, then hands
+// the full self-referential teardown (stop + delete own service, binary and
+// config removal) to a detached PowerShell helper.
+//
+// The agent binary, the watchdog binary, and the config dir (which holds the
+// agent's open log files) are all locked while their processes run, so ALL
+// file removal happens in the detached helper after the processes are gone —
+// unlike the Unix paths, where in-process removal of non-self files is safe.
+func prepareSelfUninstallWindows(removeConfig bool) error {
 	const (
 		serviceName         = "BreezeAgent"
 		watchdogServiceName = "BreezeWatchdog"
 	)
 
-	var errs []string
-
-	// Stop the service via sc.exe
-	if err := exec.Command("sc.exe", "stop", serviceName).Run(); err != nil {
-		log.Warn("sc.exe stop failed", "error", err.Error())
-		errs = append(errs, fmt.Sprintf("stop service: %s", err.Error()))
-	}
-	time.Sleep(2 * time.Second)
-
-	// Delete the service registration
-	if err := exec.Command("sc.exe", "delete", serviceName).Run(); err != nil {
-		log.Warn("sc.exe delete failed", "error", err.Error())
-		errs = append(errs, fmt.Sprintf("delete service: %s", err.Error()))
-	}
+	// Watchdog FIRST — it must be unable to respawn the agent once the helper
+	// stops the agent service. sc.exe delete on a STOP_PENDING service marks it
+	// delete-pending, which completes when it stops; the helper re-asserts both
+	// steps anyway.
 	if err := exec.Command("sc.exe", "stop", watchdogServiceName).Run(); err != nil {
 		log.Warn("sc.exe stop watchdog failed", "error", err.Error())
 	}
@@ -233,30 +368,48 @@ func selfUninstallWindows(removeConfig bool) error {
 		log.Warn("sc.exe delete watchdog failed", "error", err.Error())
 	}
 
-	// Remove binary — get our own path first
 	exePath, err := os.Executable()
-	if err == nil {
-		// Schedule deletion after process exits (Windows locks running executables).
-		// Pass the entire command as a single string so cmd.exe interprets the
-		// shell operators (>, &) correctly.
-		delCmd := fmt.Sprintf(`ping 127.0.0.1 -n 3 >NUL & del /f "%s"`, exePath)
-		if err := exec.Command("cmd", "/C", delCmd).Start(); err != nil {
-			log.Warn("failed to schedule binary cleanup", "path", exePath, "error", err.Error())
-		}
+	if err != nil {
+		return fmt.Errorf("resolve own executable path: %w", err)
 	}
 
-	// Optionally remove config
-	if removeConfig {
-		configDir := os.Getenv("ProgramData")
-		if configDir != "" {
-			if err := os.RemoveAll(configDir + "\\Breeze"); err != nil {
-				errs = append(errs, fmt.Sprintf("remove config: %s", err.Error()))
-			}
-		}
+	configDir := ""
+	if programData := os.Getenv("ProgramData"); programData != "" {
+		configDir = filepath.Join(programData, "Breeze")
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("partial failure: %s", strings.Join(errs, "; "))
+	script := buildWindowsUninstallScript(windowsUninstallScriptOptions{
+		ServiceName:         serviceName,
+		WatchdogServiceName: watchdogServiceName,
+		AgentBinaryPath:     exePath,
+		// The watchdog is installed as a sibling of the agent binary (see
+		// serviceinstall.InstallProtectedBinary / sessionbroker allowlist).
+		WatchdogBinaryPath: filepath.Join(filepath.Dir(exePath), "breeze-watchdog.exe"),
+		ConfigDir:          configDir,
+		RemoveConfig:       removeConfig,
+		DelaySeconds:       uninstallHelperDelaySeconds,
+	})
+
+	scriptFile, err := os.CreateTemp("", "breeze-uninstall-*.ps1")
+	if err != nil {
+		return fmt.Errorf("create uninstall helper script: %w", err)
+	}
+	if _, err := scriptFile.WriteString(script); err != nil {
+		scriptFile.Close()
+		os.Remove(scriptFile.Name())
+		return fmt.Errorf("write uninstall helper script: %w", err)
+	}
+	if err := scriptFile.Close(); err != nil {
+		os.Remove(scriptFile.Name())
+		return fmt.Errorf("close uninstall helper script: %w", err)
+	}
+
+	if err := startDetachedProcess("powershell.exe",
+		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+		"-File", scriptFile.Name(),
+	); err != nil {
+		os.Remove(scriptFile.Name())
+		return fmt.Errorf("spawn detached teardown helper: %w", err)
 	}
 	return nil
 }

--- a/agent/internal/heartbeat/handlers_uninstall.go
+++ b/agent/internal/heartbeat/handlers_uninstall.go
@@ -58,20 +58,38 @@ func handleSelfUninstall(h *Heartbeat, cmd Command) tools.CommandResult {
 		"removeConfig", removeConfig,
 	)
 
-	if err := prepareSelfUninstall(removeConfig); err != nil {
-		log.Error("self-uninstall preparation failed — teardown NOT handed off, agent remains installed",
+	if err := prepareSelfUninstallFn(removeConfig); err != nil {
+		log.Error("self-uninstall preparation failed — teardown NOT handed off, agent service remains installed",
 			"error", err.Error(),
 		)
 		return tools.NewErrorResult(
-			fmt.Errorf("self-uninstall failed before teardown handoff (agent remains installed): %w", err),
+			fmt.Errorf("self-uninstall failed before teardown handoff — agent service remains installed and auto-start; watchdog/helper artifacts may already be partially removed, retry required: %w", err),
 			time.Since(start).Milliseconds(),
 		)
 	}
 
-	// Shut down gracefully once the result has had time to be submitted. The
-	// detached helper stops the service as its first act, so on a normal
-	// service install the process exits via the service manager's stop control;
-	// the explicit Stop/os.Exit below is a backstop for non-service (dev) runs.
+	scheduleSelfUninstallShutdownFn(h)
+
+	return tools.NewSuccessResult(map[string]string{
+		"message": "self-uninstall initiated: detached teardown handed off",
+	}, time.Since(start).Milliseconds())
+}
+
+// prepareSelfUninstallFn and scheduleSelfUninstallShutdownFn are seams so the
+// handler's result contract (error result when the handoff fails, success
+// result otherwise, no shutdown scheduled on failure) is unit-testable without
+// touching a real service manager or exiting the test process.
+var (
+	prepareSelfUninstallFn          = prepareSelfUninstall
+	scheduleSelfUninstallShutdownFn = scheduleSelfUninstallShutdown
+)
+
+// scheduleSelfUninstallShutdown shuts the agent down gracefully once the
+// result has had time to be submitted. The detached helper stops the service
+// after its delay, so on a normal service install the process exits via the
+// service manager's stop control; the explicit Stop/os.Exit below is a
+// backstop for non-service (dev) runs and blocked helpers.
+func scheduleSelfUninstallShutdown(h *Heartbeat) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -85,16 +103,18 @@ func handleSelfUninstall(h *Heartbeat, cmd Command) tools.CommandResult {
 
 		// Give the detached helper time to stop the service (the normal exit
 		// path). If we are still alive well past its delay — e.g. not running
-		// under a service manager — stop and exit ourselves.
+		// under a service manager, or the helper was blocked (EDR/AV killing a
+		// service-spawned PowerShell is realistic on managed endpoints) — log
+		// loudly and stop ourselves. The log line is the only in-band evidence
+		// that the handed-off teardown may not have run.
 		time.Sleep(time.Duration(uninstallHelperDelaySeconds+10) * time.Second)
+		log.Warn("agent still running after detached teardown helper's deadline — helper may have been blocked; stopping self (service registration may survive)",
+			"helperDelaySeconds", uninstallHelperDelaySeconds,
+		)
 		h.Stop()
 		time.Sleep(5 * time.Second)
 		os.Exit(0)
 	}()
-
-	return tools.NewSuccessResult(map[string]string{
-		"message": "self-uninstall initiated: watchdog neutralized, detached teardown handed off",
-	}, time.Since(start).Milliseconds())
 }
 
 // prepareSelfUninstall does the platform-specific phase-1 teardown and hands
@@ -130,22 +150,34 @@ func removeFileLogged(path string) {
 // script that removes the agent's own launchd daemon on macOS. Extracted so
 // the script text can be unit-tested without spawning a shell.
 type darwinUninstallScriptOptions struct {
-	Label        string // launchd label of the agent daemon (bootout kills this process)
-	PlistPath    string // the agent daemon's plist
-	BinaryPath   string // the agent binary
-	DelaySeconds int
+	Label           string // launchd label of the agent daemon (bootout kills this process)
+	WatchdogLabel   string // launchd label of the watchdog daemon
+	WatchdogProcess string // watchdog process name for the pkill re-assert
+	PlistPath       string // the agent daemon's plist
+	BinaryPath      string // the agent binary
+	ConfigDir       string // empty = skip config removal regardless of RemoveConfig
+	RemoveConfig    bool
+	DelaySeconds    int
 }
 
 // buildDarwinUninstallScript renders the detached teardown script for macOS.
-// Everything except the agent's own daemon was already removed in-process by
-// prepareSelfUninstallDarwin; this script only performs the steps that would
-// kill the process issuing them.
+// Phase 1 already neutralized the watchdog in-process; the script re-asserts
+// it (bootout + pkill) BEFORE stopping the agent daemon as a backstop, so a
+// watchdog that survived phase 1 cannot respawn the agent mid-teardown.
+// Config removal happens here — after the agent process is dead — so the
+// still-running agent cannot resurrect files (logs, sockets, state) under a
+// freshly-deleted directory.
 func buildDarwinUninstallScript(opts darwinUninstallScriptOptions) string {
 	lines := []string{
 		fmt.Sprintf("sleep %d", opts.DelaySeconds),
+		fmt.Sprintf("launchctl bootout system/%s", shQuote(opts.WatchdogLabel)),
+		fmt.Sprintf("pkill -x %s", shQuote(opts.WatchdogProcess)),
 		fmt.Sprintf("launchctl bootout system/%s || launchctl unload %s", shQuote(opts.Label), shQuote(opts.PlistPath)),
 		fmt.Sprintf("rm -f %s", shQuote(opts.PlistPath)),
 		fmt.Sprintf("rm -f %s", shQuote(opts.BinaryPath)),
+	}
+	if opts.RemoveConfig && opts.ConfigDir != "" {
+		lines = append(lines, fmt.Sprintf("rm -rf %s", shQuote(opts.ConfigDir)))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -176,23 +208,30 @@ func prepareSelfUninstallDarwin(removeConfig bool) error {
 		_ = exec.Command("launchctl", "unload", userPlistDst).Run()
 	}
 
+	// Disable our own daemon (safe while running) so that if the detached
+	// helper never runs — blocked, reboot inside the window — the host comes
+	// back with the agent NOT auto-starting into permanent 401s (#2796).
+	if err := exec.Command("launchctl", "disable", "system/"+label).Run(); err != nil {
+		log.Warn("launchctl disable agent failed", "error", err.Error())
+	}
+
 	removeFileLogged(watchdogPlistDst)
 	removeFileLogged(userPlistDst)
 	removeFileLogged(watchdogBinary)
 
-	if removeConfig {
-		if err := os.RemoveAll(configDir); err != nil {
-			log.Warn("self-uninstall: failed to remove config dir", "path", configDir, "error", err.Error())
-		}
-	}
-
-	// Booting out our own daemon kills this process, so it (and the removal of
-	// our own plist/binary) runs from a detached session after we exit.
+	// Booting out our own daemon kills this process, so it (plus the removal
+	// of our own plist/binary and the config dir — which holds live logs,
+	// sockets, and state files this process would otherwise resurrect) runs
+	// from a detached session after we exit.
 	script := buildDarwinUninstallScript(darwinUninstallScriptOptions{
-		Label:        label,
-		PlistPath:    plistDst,
-		BinaryPath:   binaryPath,
-		DelaySeconds: uninstallHelperDelaySeconds,
+		Label:           label,
+		WatchdogLabel:   watchdogLabel,
+		WatchdogProcess: "breeze-watchdog",
+		PlistPath:       plistDst,
+		BinaryPath:      binaryPath,
+		ConfigDir:       configDir,
+		RemoveConfig:    removeConfig,
+		DelaySeconds:    uninstallHelperDelaySeconds,
 	})
 	if err := startDetachedProcess("/bin/sh", "-c", script); err != nil {
 		return fmt.Errorf("spawn detached teardown helper: %w", err)
@@ -207,20 +246,32 @@ func prepareSelfUninstallDarwin(removeConfig bool) error {
 // linuxUninstallScriptOptions captures the inputs to the detached shell script
 // that removes the agent's own systemd unit on Linux.
 type linuxUninstallScriptOptions struct {
-	ServiceName  string // the agent's own unit (stopping it kills this process)
-	UnitPath     string
-	BinaryPath   string
-	DelaySeconds int
+	ServiceName     string // the agent's own unit (stopping it kills this process)
+	WatchdogService string
+	WatchdogProcess string // watchdog process name for the pkill re-assert
+	UnitPath        string
+	BinaryPath      string
+	ConfigDir       string // empty = skip config removal regardless of RemoveConfig
+	RemoveConfig    bool
+	DelaySeconds    int
 }
 
 // buildLinuxUninstallScript renders the detached teardown script for Linux.
+// The watchdog re-assert (stop + pkill) comes BEFORE the agent stop so a
+// watchdog that survived phase 1 cannot respawn the agent mid-teardown, and
+// config removal comes after the agent is dead (see the darwin builder).
 func buildLinuxUninstallScript(opts linuxUninstallScriptOptions) string {
 	lines := []string{
 		fmt.Sprintf("sleep %d", opts.DelaySeconds),
+		fmt.Sprintf("systemctl stop %s", shQuote(opts.WatchdogService)),
+		fmt.Sprintf("pkill -x %s", shQuote(opts.WatchdogProcess)),
 		fmt.Sprintf("systemctl stop %s", shQuote(opts.ServiceName)),
 		fmt.Sprintf("rm -f %s", shQuote(opts.UnitPath)),
 		"systemctl daemon-reload",
 		fmt.Sprintf("rm -f %s", shQuote(opts.BinaryPath)),
+	}
+	if opts.RemoveConfig && opts.ConfigDir != "" {
+		lines = append(lines, fmt.Sprintf("rm -rf %s", shQuote(opts.ConfigDir)))
 	}
 	return strings.Join(lines, "\n")
 }
@@ -257,23 +308,32 @@ func prepareSelfUninstallLinux(removeConfig bool) error {
 	removeFileLogged(userUnitDst)
 	removeFileLogged(watchdogBinary)
 
-	if removeConfig {
-		if err := os.RemoveAll(configDir); err != nil {
-			log.Warn("self-uninstall: failed to remove config dir", "path", configDir, "error", err.Error())
-		}
-	}
-
-	// Stopping our own unit kills this process (systemd SIGTERMs the cgroup),
-	// so it runs from a detached session after we exit. The agent's own unit
-	// file must survive until then so the stop is clean.
+	// Stopping our own unit kills this process, so it (plus unit/binary/config
+	// removal) runs from a detached helper after we exit.
+	//
+	// CRITICAL: Setsid alone is NOT enough on Linux. A Setsid'd child still
+	// lives in the breeze-agent.service CGROUP, and the unit runs
+	// KillMode=mixed — when `systemctl stop breeze-agent` runs, systemd
+	// SIGTERMs the main process and then SIGKILLs every remaining process in
+	// the cgroup at TimeoutStopSec (see internal/agentapp/systemd_unit.go), so
+	// a plain /bin/sh helper would die mid-script right after issuing the stop
+	// — recreating the #2878 false success on Linux. `systemd-run` registers
+	// the helper as a transient unit in its OWN cgroup, outside the kill
+	// radius — the same escape used by tools.spawnDelayedRestart
+	// (internal/remote/tools/agent_restart_linux.go). --collect garbage-
+	// collects the transient unit even if the script fails.
 	script := buildLinuxUninstallScript(linuxUninstallScriptOptions{
-		ServiceName:  serviceName,
-		UnitPath:     unitDst,
-		BinaryPath:   binaryPath,
-		DelaySeconds: uninstallHelperDelaySeconds,
+		ServiceName:     serviceName,
+		WatchdogService: watchdogService,
+		WatchdogProcess: "breeze-watchdog",
+		UnitPath:        unitDst,
+		BinaryPath:      binaryPath,
+		ConfigDir:       configDir,
+		RemoveConfig:    removeConfig,
+		DelaySeconds:    uninstallHelperDelaySeconds,
 	})
-	if err := startDetachedProcess("/bin/sh", "-c", script); err != nil {
-		return fmt.Errorf("spawn detached teardown helper: %w", err)
+	if err := startDetachedProcess("systemd-run", "--quiet", "--collect", "--", "/bin/sh", "-c", script); err != nil {
+		return fmt.Errorf("spawn detached teardown helper (systemd-run transient unit): %w", err)
 	}
 	return nil
 }
@@ -304,37 +364,40 @@ type windowsUninstallScriptOptions struct {
 // buildWindowsUninstallScript renders the detached PowerShell teardown script.
 // Ordering is load-bearing:
 //
-//  1. Stop-Service on the agent (waits for Stopped — this is what kills the
+//  1. re-assert the watchdog teardown FIRST (phase 1 already stopped/deleted
+//     it, but sc.exe stop is asynchronous — a watchdog that survived phase 1
+//     must be dead before the agent stops or it may respawn it),
+//  2. Stop-Service on the agent (waits for Stopped — this is what kills the
 //     agent process, AFTER the command result has been submitted),
-//  2. delete both service registrations,
-//  3. kill lingering sibling helper processes that could hold file locks,
-//  4. remove the binaries (unlocked once the processes are gone),
-//  5. remove config last (the agent's open log handles are released by then),
-//  6. the script deletes itself.
+//  3. delete both service registrations,
+//  4. kill lingering sibling processes that could hold file locks (including
+//     any watchdog-respawned agent),
+//  5. remove the binaries (unlocked once the processes are gone),
+//  6. remove config last (the agent's open log handles are released by then),
+//  7. the script deletes itself.
 //
-// Removal steps use -ErrorAction SilentlyContinue: by this point the process
-// that could report errors is gone, so best-effort is all there is.
+// Removal steps use -LiteralPath (never -Path: `[`/`]` in an install path
+// would be glob-expanded into a silent no-op) and -ErrorAction
+// SilentlyContinue: by this point the process that could report errors is
+// gone, so best-effort is all there is.
 func buildWindowsUninstallScript(opts windowsUninstallScriptOptions) string {
 	lines := []string{
 		fmt.Sprintf("Start-Sleep -Seconds %d", opts.DelaySeconds),
-		fmt.Sprintf("Stop-Service -Name '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.ServiceName)),
-		fmt.Sprintf("sc.exe delete '%s' | Out-Null", psQuote(opts.ServiceName)),
-		// Re-assert the watchdog teardown: phase 1 already stopped/deleted it,
-		// but sc.exe stop is asynchronous — if it was still STOP_PENDING when
-		// phase 1's delete ran, the delete may not have taken.
 		fmt.Sprintf("sc.exe stop '%s' | Out-Null", psQuote(opts.WatchdogServiceName)),
 		fmt.Sprintf("sc.exe delete '%s' | Out-Null", psQuote(opts.WatchdogServiceName)),
-		"Get-Process -Name 'breeze-user-helper','breeze-desktop-helper','breeze-watchdog' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue",
+		fmt.Sprintf("Stop-Service -Name '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.ServiceName)),
+		fmt.Sprintf("sc.exe delete '%s' | Out-Null", psQuote(opts.ServiceName)),
+		"Get-Process -Name 'breeze-agent','breeze-user-helper','breeze-desktop-helper','breeze-watchdog' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue",
 		"Start-Sleep -Seconds 1",
-		fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.WatchdogBinaryPath)),
-		fmt.Sprintf("Remove-Item -Path '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.AgentBinaryPath)),
+		fmt.Sprintf("Remove-Item -LiteralPath '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.WatchdogBinaryPath)),
+		fmt.Sprintf("Remove-Item -LiteralPath '%s' -Force -ErrorAction SilentlyContinue", psQuote(opts.AgentBinaryPath)),
 	}
 	if opts.RemoveConfig && opts.ConfigDir != "" {
 		lines = append(lines,
-			fmt.Sprintf("Remove-Item -Path '%s' -Recurse -Force -ErrorAction SilentlyContinue", psQuote(opts.ConfigDir)),
+			fmt.Sprintf("Remove-Item -LiteralPath '%s' -Recurse -Force -ErrorAction SilentlyContinue", psQuote(opts.ConfigDir)),
 		)
 	}
-	lines = append(lines, "Remove-Item -Path $PSCommandPath -Force -ErrorAction SilentlyContinue")
+	lines = append(lines, "Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue")
 	return strings.Join(lines, "\r\n")
 }
 
@@ -368,6 +431,20 @@ func prepareSelfUninstallWindows(removeConfig bool) error {
 		log.Warn("sc.exe delete watchdog failed", "error", err.Error())
 	}
 
+	// Disable our own service's auto-start and clear its SCM recovery actions
+	// (both safe while running) so that if the detached helper never runs —
+	// EDR blocking a service-spawned PowerShell, a temp cleaner, a reboot
+	// inside the window — the backstop os.Exit doesn't get treated as a crash
+	// and restarted, and the host doesn't reboot back into permanent 401
+	// hammering (#2796). Worst case degrades to "stopped + disabled, binary
+	// on disk" instead of "alive and stranded".
+	if err := exec.Command("sc.exe", "config", serviceName, "start=", "disabled").Run(); err != nil {
+		log.Warn("sc.exe config start=disabled failed", "error", err.Error())
+	}
+	if err := exec.Command("sc.exe", "failure", serviceName, "reset=", "0", "actions=", "").Run(); err != nil {
+		log.Warn("sc.exe failure reset failed", "error", err.Error())
+	}
+
 	exePath, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve own executable path: %w", err)
@@ -395,12 +472,12 @@ func prepareSelfUninstallWindows(removeConfig bool) error {
 		return fmt.Errorf("create uninstall helper script: %w", err)
 	}
 	if _, err := scriptFile.WriteString(script); err != nil {
-		scriptFile.Close()
-		os.Remove(scriptFile.Name())
+		_ = scriptFile.Close()
+		_ = os.Remove(scriptFile.Name())
 		return fmt.Errorf("write uninstall helper script: %w", err)
 	}
 	if err := scriptFile.Close(); err != nil {
-		os.Remove(scriptFile.Name())
+		_ = os.Remove(scriptFile.Name())
 		return fmt.Errorf("close uninstall helper script: %w", err)
 	}
 
@@ -408,7 +485,7 @@ func prepareSelfUninstallWindows(removeConfig bool) error {
 		"-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
 		"-File", scriptFile.Name(),
 	); err != nil {
-		os.Remove(scriptFile.Name())
+		_ = os.Remove(scriptFile.Name())
 		return fmt.Errorf("spawn detached teardown helper: %w", err)
 	}
 	return nil

--- a/agent/internal/heartbeat/handlers_uninstall_detach_unix.go
+++ b/agent/internal/heartbeat/handlers_uninstall_detach_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package heartbeat
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// startDetachedProcess launches name/args in its own session (Setsid) and
+// releases the handle so the child is not waited on and survives this process
+// being killed by launchd/systemd when the agent's own service is stopped
+// (#2878). Same detach pattern as tools.agent_restart_darwin.
+func startDetachedProcess(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	_ = cmd.Process.Release()
+	return nil
+}

--- a/agent/internal/heartbeat/handlers_uninstall_detach_windows.go
+++ b/agent/internal/heartbeat/handlers_uninstall_detach_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package heartbeat
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// startDetachedProcess launches name/args in a new process group and releases
+// the handle so the child is not waited on and survives the SCM stopping this
+// service's process. Same pattern as updater.RestartWithHelper — the child
+// must outlive the agent so it can tear the agent's own service down (#2878).
+func startDetachedProcess(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	_ = cmd.Process.Release()
+	return nil
+}

--- a/agent/internal/heartbeat/handlers_uninstall_test.go
+++ b/agent/internal/heartbeat/handlers_uninstall_test.go
@@ -1,14 +1,18 @@
 package heartbeat
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
 )
 
 // orderedIndex returns the index of needle in haystack, failing the test when
 // it is absent. Used to assert that teardown steps appear in a load-bearing
-// order (#2878: the agent's own service stop must come after the ack delay,
-// and deletes/removals must come after the stop that unlocks them).
+// order (#2878: the agent's own service stop must come after the ack delay
+// and after the watchdog re-assert, and deletes/removals must come after the
+// stop that unlocks them).
 func orderedIndex(t *testing.T, haystack, needle string) int {
 	t.Helper()
 	idx := strings.Index(haystack, needle)
@@ -51,18 +55,28 @@ func TestBuildWindowsUninstallScript(t *testing.T) {
 		wantPresent []string
 	}{
 		{
-			name: "full teardown ordering: delay, stop own service, delete registrations, kill helpers, remove binaries, config last, self-delete",
+			name: "full teardown ordering: delay, watchdog re-assert, stop own service, delete registrations, kill processes, remove binaries, config last, self-delete",
 			opts: base,
 			wantOrder: []string{
 				"Start-Sleep -Seconds 5",
+				"sc.exe stop 'BreezeWatchdog'",
+				"sc.exe delete 'BreezeWatchdog'",
 				"Stop-Service -Name 'BreezeAgent' -Force",
 				"sc.exe delete 'BreezeAgent'",
-				"sc.exe delete 'BreezeWatchdog'",
 				"Stop-Process -Force",
-				`Remove-Item -Path 'C:\Program Files\Breeze\breeze-watchdog.exe' -Force`,
-				`Remove-Item -Path 'C:\Program Files\Breeze\breeze-agent.exe' -Force`,
-				`Remove-Item -Path 'C:\ProgramData\Breeze' -Recurse -Force`,
-				"Remove-Item -Path $PSCommandPath -Force",
+				`Remove-Item -LiteralPath 'C:\Program Files\Breeze\breeze-watchdog.exe' -Force`,
+				`Remove-Item -LiteralPath 'C:\Program Files\Breeze\breeze-agent.exe' -Force`,
+				`Remove-Item -LiteralPath 'C:\ProgramData\Breeze' -Recurse -Force`,
+				"Remove-Item -LiteralPath $PSCommandPath -Force",
+			},
+			// -Path would glob-expand [ ] in install paths into a silent no-op.
+			wantAbsent: []string{"Remove-Item -Path"},
+		},
+		{
+			name: "kill list covers a watchdog-respawned agent and lock-holding siblings",
+			opts: base,
+			wantPresent: []string{
+				"Get-Process -Name 'breeze-agent','breeze-user-helper','breeze-desktop-helper','breeze-watchdog'",
 			},
 		},
 		{
@@ -76,7 +90,7 @@ func TestBuildWindowsUninstallScript(t *testing.T) {
 			wantOrder: []string{
 				"Stop-Service -Name 'BreezeAgent'",
 				"sc.exe delete 'BreezeAgent'",
-				"Remove-Item -Path $PSCommandPath",
+				"Remove-Item -LiteralPath $PSCommandPath",
 			},
 		},
 		{
@@ -87,7 +101,7 @@ func TestBuildWindowsUninstallScript(t *testing.T) {
 				return o
 			}(),
 			wantAbsent:  []string{"-Recurse"},
-			wantPresent: []string{"Remove-Item -Path $PSCommandPath"},
+			wantPresent: []string{"Remove-Item -LiteralPath $PSCommandPath"},
 		},
 		{
 			name: "single quotes in paths are doubled for PowerShell",
@@ -98,14 +112,6 @@ func TestBuildWindowsUninstallScript(t *testing.T) {
 			}(),
 			wantPresent: []string{`'C:\O''Brien\breeze-agent.exe'`},
 			wantAbsent:  []string{`'C:\O'Brien`},
-		},
-		{
-			name: "watchdog re-assert: stop before delete",
-			opts: base,
-			wantOrder: []string{
-				"sc.exe stop 'BreezeWatchdog'",
-				"sc.exe delete 'BreezeWatchdog'",
-			},
 		},
 	}
 
@@ -130,10 +136,11 @@ func TestBuildWindowsUninstallScript(t *testing.T) {
 }
 
 // The false-success bug (#2878): the agent must never stop its own service
-// before the ack delay, and the detached script must never touch the watchdog
-// AGENT-RESPAWN path after the agent binary is already gone. Assert the two
-// invariants that reproduce the field failure directly.
-func TestBuildWindowsUninstallScript_SelfStopComesAfterDelay(t *testing.T) {
+// before the ack delay, the watchdog must be re-asserted dead before the
+// agent stops (or it may respawn it), and the service must be deleted before
+// its binary is removed (a still-registered auto-start service with a missing
+// binary is the residual ghost observed in QA).
+func TestBuildWindowsUninstallScript_SelfStopComesAfterDelayAndWatchdog(t *testing.T) {
 	script := buildWindowsUninstallScript(windowsUninstallScriptOptions{
 		ServiceName:         "BreezeAgent",
 		WatchdogServiceName: "BreezeWatchdog",
@@ -143,48 +150,63 @@ func TestBuildWindowsUninstallScript_SelfStopComesAfterDelay(t *testing.T) {
 	})
 	assertOrder(t, script,
 		"Start-Sleep -Seconds 7",
+		"sc.exe stop 'BreezeWatchdog'",
 		"Stop-Service -Name 'BreezeAgent'",
 	)
-	// The service must be deleted before its binary is removed — deleting the
-	// registration of a still-registered service with a missing binary would
-	// leave an auto-start ghost (the residual state observed in QA).
 	assertOrder(t, script,
 		"sc.exe delete 'BreezeAgent'",
-		`Remove-Item -Path 'C:\pf\breeze-agent.exe'`,
+		`Remove-Item -LiteralPath 'C:\pf\breeze-agent.exe'`,
 	)
 }
 
 func TestBuildDarwinUninstallScript(t *testing.T) {
 	base := darwinUninstallScriptOptions{
-		Label:        "com.breeze.agent",
-		PlistPath:    "/Library/LaunchDaemons/com.breeze.agent.plist",
-		BinaryPath:   "/usr/local/bin/breeze-agent",
-		DelaySeconds: 5,
+		Label:           "com.breeze.agent",
+		WatchdogLabel:   "com.breeze.watchdog",
+		WatchdogProcess: "breeze-watchdog",
+		PlistPath:       "/Library/LaunchDaemons/com.breeze.agent.plist",
+		BinaryPath:      "/usr/local/bin/breeze-agent",
+		ConfigDir:       "/Library/Application Support/Breeze",
+		RemoveConfig:    true,
+		DelaySeconds:    5,
 	}
 
 	tests := []struct {
-		name      string
-		opts      darwinUninstallScriptOptions
-		wantOrder []string
+		name       string
+		opts       darwinUninstallScriptOptions
+		wantOrder  []string
+		wantAbsent []string
 	}{
 		{
-			name: "ordering: delay, bootout own daemon (with unload fallback), remove plist, remove binary",
+			name: "ordering: delay, watchdog re-assert (bootout + pkill), bootout own daemon, remove plist, remove binary, config last",
 			opts: base,
 			wantOrder: []string{
 				"sleep 5",
+				"launchctl bootout system/'com.breeze.watchdog'",
+				"pkill -x 'breeze-watchdog'",
 				"launchctl bootout system/'com.breeze.agent' || launchctl unload '/Library/LaunchDaemons/com.breeze.agent.plist'",
 				"rm -f '/Library/LaunchDaemons/com.breeze.agent.plist'",
 				"rm -f '/usr/local/bin/breeze-agent'",
+				"rm -rf '/Library/Application Support/Breeze'",
 			},
 		},
 		{
+			name: "removeConfig=false omits config removal",
+			opts: func() darwinUninstallScriptOptions {
+				o := base
+				o.RemoveConfig = false
+				return o
+			}(),
+			wantOrder:  []string{"rm -f '/usr/local/bin/breeze-agent'"},
+			wantAbsent: []string{"rm -rf"},
+		},
+		{
 			name: "single quotes in paths are escaped for sh",
-			opts: darwinUninstallScriptOptions{
-				Label:        "com.breeze.agent",
-				PlistPath:    "/tmp/o'brien.plist",
-				BinaryPath:   "/usr/local/bin/breeze-agent",
-				DelaySeconds: 5,
-			},
+			opts: func() darwinUninstallScriptOptions {
+				o := base
+				o.PlistPath = "/tmp/o'brien.plist"
+				return o
+			}(),
 			wantOrder: []string{`rm -f '/tmp/o'\''brien.plist'`},
 		},
 	}
@@ -193,33 +215,56 @@ func TestBuildDarwinUninstallScript(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			script := buildDarwinUninstallScript(tt.opts)
 			assertOrder(t, script, tt.wantOrder...)
+			for _, frag := range tt.wantAbsent {
+				if strings.Contains(script, frag) {
+					t.Errorf("script unexpectedly contains %q\nscript:\n%s", frag, script)
+				}
+			}
 		})
 	}
 }
 
 func TestBuildLinuxUninstallScript(t *testing.T) {
 	base := linuxUninstallScriptOptions{
-		ServiceName:  "breeze-agent",
-		UnitPath:     "/etc/systemd/system/breeze-agent.service",
-		BinaryPath:   "/usr/local/bin/breeze-agent",
-		DelaySeconds: 5,
+		ServiceName:     "breeze-agent",
+		WatchdogService: "breeze-watchdog",
+		WatchdogProcess: "breeze-watchdog",
+		UnitPath:        "/etc/systemd/system/breeze-agent.service",
+		BinaryPath:      "/usr/local/bin/breeze-agent",
+		ConfigDir:       "/etc/breeze",
+		RemoveConfig:    true,
+		DelaySeconds:    5,
 	}
 
 	tests := []struct {
-		name      string
-		opts      linuxUninstallScriptOptions
-		wantOrder []string
+		name       string
+		opts       linuxUninstallScriptOptions
+		wantOrder  []string
+		wantAbsent []string
 	}{
 		{
-			name: "ordering: delay, stop own unit, remove unit, daemon-reload, remove binary",
+			name: "ordering: delay, watchdog re-assert, stop own unit, remove unit, daemon-reload, remove binary, config last",
 			opts: base,
 			wantOrder: []string{
 				"sleep 5",
+				"systemctl stop 'breeze-watchdog'",
+				"pkill -x 'breeze-watchdog'",
 				"systemctl stop 'breeze-agent'",
 				"rm -f '/etc/systemd/system/breeze-agent.service'",
 				"systemctl daemon-reload",
 				"rm -f '/usr/local/bin/breeze-agent'",
+				"rm -rf '/etc/breeze'",
 			},
+		},
+		{
+			name: "removeConfig=false omits config removal",
+			opts: func() linuxUninstallScriptOptions {
+				o := base
+				o.RemoveConfig = false
+				return o
+			}(),
+			wantOrder:  []string{"rm -f '/usr/local/bin/breeze-agent'"},
+			wantAbsent: []string{"rm -rf"},
 		},
 	}
 
@@ -227,6 +272,105 @@ func TestBuildLinuxUninstallScript(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			script := buildLinuxUninstallScript(tt.opts)
 			assertOrder(t, script, tt.wantOrder...)
+			for _, frag := range tt.wantAbsent {
+				if strings.Contains(script, frag) {
+					t.Errorf("script unexpectedly contains %q\nscript:\n%s", frag, script)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleSelfUninstall_ResultContract pins the handler's core promise
+// (#2878): when the detached teardown cannot be handed off, the command must
+// report FAILURE — the offboarding drain must never count a machine that will
+// remain installed as a clean uninstall — and no shutdown may be scheduled.
+// On success, the ack says "initiated"/"handed off", never "completed".
+func TestHandleSelfUninstall_ResultContract(t *testing.T) {
+	origPrepare := prepareSelfUninstallFn
+	origSchedule := scheduleSelfUninstallShutdownFn
+	t.Cleanup(func() {
+		prepareSelfUninstallFn = origPrepare
+		scheduleSelfUninstallShutdownFn = origSchedule
+	})
+
+	tests := []struct {
+		name             string
+		prepareErr       error
+		payload          map[string]any
+		wantStatus       string
+		wantErrFragment  string
+		wantMsgFragment  string
+		wantShutdown     bool
+		wantRemoveConfig bool
+	}{
+		{
+			name:             "handoff failure returns failed result and schedules no shutdown",
+			prepareErr:       errors.New("spawn detached teardown helper: exec blocked"),
+			payload:          map[string]any{},
+			wantStatus:       "failed",
+			wantErrFragment:  "agent service remains installed",
+			wantShutdown:     false,
+			wantRemoveConfig: true,
+		},
+		{
+			name:             "handoff success returns completed result saying initiated, schedules shutdown, honors removeConfig=false",
+			prepareErr:       nil,
+			payload:          map[string]any{"removeConfig": false},
+			wantStatus:       "completed",
+			wantMsgFragment:  "self-uninstall initiated",
+			wantShutdown:     true,
+			wantRemoveConfig: false,
+		},
+		{
+			name:             "removeConfig defaults to true",
+			prepareErr:       nil,
+			payload:          map[string]any{},
+			wantStatus:       "completed",
+			wantShutdown:     true,
+			wantRemoveConfig: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotRemoveConfig *bool
+			prepareSelfUninstallFn = func(removeConfig bool) error {
+				gotRemoveConfig = &removeConfig
+				return tt.prepareErr
+			}
+			shutdownScheduled := false
+			scheduleSelfUninstallShutdownFn = func(h *Heartbeat) {
+				shutdownScheduled = true
+			}
+
+			result := handleSelfUninstall(&Heartbeat{}, Command{
+				ID:      "cmd-1",
+				Type:    tools.CmdSelfUninstall,
+				Payload: tt.payload,
+			})
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("Status = %q, want %q (result: %+v)", result.Status, tt.wantStatus, result)
+			}
+			if tt.wantErrFragment != "" && !strings.Contains(result.Error, tt.wantErrFragment) {
+				t.Errorf("Error %q missing fragment %q", result.Error, tt.wantErrFragment)
+			}
+			if tt.wantMsgFragment != "" && !strings.Contains(result.Stdout, tt.wantMsgFragment) {
+				t.Errorf("Stdout %q missing fragment %q", result.Stdout, tt.wantMsgFragment)
+			}
+			if tt.wantStatus == "completed" && strings.Contains(result.Stdout, "uninstall completed") {
+				t.Errorf("success ack must claim initiation, not completion: %q", result.Stdout)
+			}
+			if shutdownScheduled != tt.wantShutdown {
+				t.Errorf("shutdownScheduled = %v, want %v", shutdownScheduled, tt.wantShutdown)
+			}
+			if gotRemoveConfig == nil {
+				t.Fatal("prepare was never called")
+			}
+			if *gotRemoveConfig != tt.wantRemoveConfig {
+				t.Errorf("removeConfig = %v, want %v", *gotRemoveConfig, tt.wantRemoveConfig)
+			}
 		})
 	}
 }

--- a/agent/internal/heartbeat/handlers_uninstall_test.go
+++ b/agent/internal/heartbeat/handlers_uninstall_test.go
@@ -1,0 +1,265 @@
+package heartbeat
+
+import (
+	"strings"
+	"testing"
+)
+
+// orderedIndex returns the index of needle in haystack, failing the test when
+// it is absent. Used to assert that teardown steps appear in a load-bearing
+// order (#2878: the agent's own service stop must come after the ack delay,
+// and deletes/removals must come after the stop that unlocks them).
+func orderedIndex(t *testing.T, haystack, needle string) int {
+	t.Helper()
+	idx := strings.Index(haystack, needle)
+	if idx < 0 {
+		t.Fatalf("script missing expected fragment %q\nscript:\n%s", needle, haystack)
+	}
+	return idx
+}
+
+func assertOrder(t *testing.T, script string, fragments ...string) {
+	t.Helper()
+	last := -1
+	lastFrag := ""
+	for _, frag := range fragments {
+		idx := orderedIndex(t, script, frag)
+		if idx <= last {
+			t.Errorf("expected %q to appear after %q\nscript:\n%s", frag, lastFrag, script)
+		}
+		last = idx
+		lastFrag = frag
+	}
+}
+
+func TestBuildWindowsUninstallScript(t *testing.T) {
+	base := windowsUninstallScriptOptions{
+		ServiceName:         "BreezeAgent",
+		WatchdogServiceName: "BreezeWatchdog",
+		AgentBinaryPath:     `C:\Program Files\Breeze\breeze-agent.exe`,
+		WatchdogBinaryPath:  `C:\Program Files\Breeze\breeze-watchdog.exe`,
+		ConfigDir:           `C:\ProgramData\Breeze`,
+		RemoveConfig:        true,
+		DelaySeconds:        5,
+	}
+
+	tests := []struct {
+		name        string
+		opts        windowsUninstallScriptOptions
+		wantOrder   []string
+		wantAbsent  []string
+		wantPresent []string
+	}{
+		{
+			name: "full teardown ordering: delay, stop own service, delete registrations, kill helpers, remove binaries, config last, self-delete",
+			opts: base,
+			wantOrder: []string{
+				"Start-Sleep -Seconds 5",
+				"Stop-Service -Name 'BreezeAgent' -Force",
+				"sc.exe delete 'BreezeAgent'",
+				"sc.exe delete 'BreezeWatchdog'",
+				"Stop-Process -Force",
+				`Remove-Item -Path 'C:\Program Files\Breeze\breeze-watchdog.exe' -Force`,
+				`Remove-Item -Path 'C:\Program Files\Breeze\breeze-agent.exe' -Force`,
+				`Remove-Item -Path 'C:\ProgramData\Breeze' -Recurse -Force`,
+				"Remove-Item -Path $PSCommandPath -Force",
+			},
+		},
+		{
+			name: "removeConfig=false omits config removal but keeps the rest",
+			opts: func() windowsUninstallScriptOptions {
+				o := base
+				o.RemoveConfig = false
+				return o
+			}(),
+			wantAbsent: []string{`'C:\ProgramData\Breeze'`},
+			wantOrder: []string{
+				"Stop-Service -Name 'BreezeAgent'",
+				"sc.exe delete 'BreezeAgent'",
+				"Remove-Item -Path $PSCommandPath",
+			},
+		},
+		{
+			name: "empty ConfigDir skips config removal even when RemoveConfig is true",
+			opts: func() windowsUninstallScriptOptions {
+				o := base
+				o.ConfigDir = ""
+				return o
+			}(),
+			wantAbsent:  []string{"-Recurse"},
+			wantPresent: []string{"Remove-Item -Path $PSCommandPath"},
+		},
+		{
+			name: "single quotes in paths are doubled for PowerShell",
+			opts: func() windowsUninstallScriptOptions {
+				o := base
+				o.AgentBinaryPath = `C:\O'Brien\breeze-agent.exe`
+				return o
+			}(),
+			wantPresent: []string{`'C:\O''Brien\breeze-agent.exe'`},
+			wantAbsent:  []string{`'C:\O'Brien`},
+		},
+		{
+			name: "watchdog re-assert: stop before delete",
+			opts: base,
+			wantOrder: []string{
+				"sc.exe stop 'BreezeWatchdog'",
+				"sc.exe delete 'BreezeWatchdog'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := buildWindowsUninstallScript(tt.opts)
+			if len(tt.wantOrder) > 0 {
+				assertOrder(t, script, tt.wantOrder...)
+			}
+			for _, frag := range tt.wantPresent {
+				if !strings.Contains(script, frag) {
+					t.Errorf("script missing %q\nscript:\n%s", frag, script)
+				}
+			}
+			for _, frag := range tt.wantAbsent {
+				if strings.Contains(script, frag) {
+					t.Errorf("script unexpectedly contains %q\nscript:\n%s", frag, script)
+				}
+			}
+		})
+	}
+}
+
+// The false-success bug (#2878): the agent must never stop its own service
+// before the ack delay, and the detached script must never touch the watchdog
+// AGENT-RESPAWN path after the agent binary is already gone. Assert the two
+// invariants that reproduce the field failure directly.
+func TestBuildWindowsUninstallScript_SelfStopComesAfterDelay(t *testing.T) {
+	script := buildWindowsUninstallScript(windowsUninstallScriptOptions{
+		ServiceName:         "BreezeAgent",
+		WatchdogServiceName: "BreezeWatchdog",
+		AgentBinaryPath:     `C:\pf\breeze-agent.exe`,
+		WatchdogBinaryPath:  `C:\pf\breeze-watchdog.exe`,
+		DelaySeconds:        7,
+	})
+	assertOrder(t, script,
+		"Start-Sleep -Seconds 7",
+		"Stop-Service -Name 'BreezeAgent'",
+	)
+	// The service must be deleted before its binary is removed — deleting the
+	// registration of a still-registered service with a missing binary would
+	// leave an auto-start ghost (the residual state observed in QA).
+	assertOrder(t, script,
+		"sc.exe delete 'BreezeAgent'",
+		`Remove-Item -Path 'C:\pf\breeze-agent.exe'`,
+	)
+}
+
+func TestBuildDarwinUninstallScript(t *testing.T) {
+	base := darwinUninstallScriptOptions{
+		Label:        "com.breeze.agent",
+		PlistPath:    "/Library/LaunchDaemons/com.breeze.agent.plist",
+		BinaryPath:   "/usr/local/bin/breeze-agent",
+		DelaySeconds: 5,
+	}
+
+	tests := []struct {
+		name      string
+		opts      darwinUninstallScriptOptions
+		wantOrder []string
+	}{
+		{
+			name: "ordering: delay, bootout own daemon (with unload fallback), remove plist, remove binary",
+			opts: base,
+			wantOrder: []string{
+				"sleep 5",
+				"launchctl bootout system/'com.breeze.agent' || launchctl unload '/Library/LaunchDaemons/com.breeze.agent.plist'",
+				"rm -f '/Library/LaunchDaemons/com.breeze.agent.plist'",
+				"rm -f '/usr/local/bin/breeze-agent'",
+			},
+		},
+		{
+			name: "single quotes in paths are escaped for sh",
+			opts: darwinUninstallScriptOptions{
+				Label:        "com.breeze.agent",
+				PlistPath:    "/tmp/o'brien.plist",
+				BinaryPath:   "/usr/local/bin/breeze-agent",
+				DelaySeconds: 5,
+			},
+			wantOrder: []string{`rm -f '/tmp/o'\''brien.plist'`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := buildDarwinUninstallScript(tt.opts)
+			assertOrder(t, script, tt.wantOrder...)
+		})
+	}
+}
+
+func TestBuildLinuxUninstallScript(t *testing.T) {
+	base := linuxUninstallScriptOptions{
+		ServiceName:  "breeze-agent",
+		UnitPath:     "/etc/systemd/system/breeze-agent.service",
+		BinaryPath:   "/usr/local/bin/breeze-agent",
+		DelaySeconds: 5,
+	}
+
+	tests := []struct {
+		name      string
+		opts      linuxUninstallScriptOptions
+		wantOrder []string
+	}{
+		{
+			name: "ordering: delay, stop own unit, remove unit, daemon-reload, remove binary",
+			opts: base,
+			wantOrder: []string{
+				"sleep 5",
+				"systemctl stop 'breeze-agent'",
+				"rm -f '/etc/systemd/system/breeze-agent.service'",
+				"systemctl daemon-reload",
+				"rm -f '/usr/local/bin/breeze-agent'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := buildLinuxUninstallScript(tt.opts)
+			assertOrder(t, script, tt.wantOrder...)
+		})
+	}
+}
+
+func TestShQuote(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"o'brien", `'o'\''brien'`},
+		{"", "''"},
+	}
+	for _, tt := range tests {
+		if got := shQuote(tt.in); got != tt.want {
+			t.Errorf("shQuote(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPsQuote(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "plain"},
+		{"o'brien", "o''brien"},
+		{`C:\path`, `C:\path`},
+	}
+	for _, tt := range tests {
+		if got := psQuote(tt.in); got != tt.want {
+			t.Errorf("psQuote(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (release blocker — #2878)

Windows `self_uninstall` was a **false success**. `performSelfUninstall` ran `sc.exe stop BreezeAgent` — its **own** service — as the first teardown step. SCM killed the agent process (and the uninstall goroutine) ~2s after command receipt, before `sc.exe delete`, watchdog teardown, binary-removal scheduling, or config removal ever ran. Residual state observed in the 2026-07-27 pre-release QA sweep on a real Windows Server 2022 VM: BreezeAgent still registered + AUTO_START, **BreezeWatchdog still RUNNING**, binary + `C:\ProgramData\Breeze` + severed token present → reboot into permanent 401 hammering (the #2796 stranded-traffic class) while the offboarding drain (#2774/#2781) reported a clean fleet.

The same self-kill-first ordering existed on macOS (`launchctl bootout system/com.breeze.agent` first) and Linux (`systemctl stop breeze-agent` first).

## Fix

Two-phase teardown on all three platforms:

**Phase 1 — in-process, before the ack:**
- Neutralize the **watchdog first** (stop + delete/bootout/disable) so it can't respawn or reinstall the agent mid-teardown.
- Remove everything safe to touch while the agent is running (Unix: watchdog/user-helper units & plists, watchdog binary, config dir).
- Spawn a **detached helper** that owns the self-referential steps — `CREATE_NEW_PROCESS_GROUP` PowerShell on Windows, `Setsid`'d `/bin/sh` on Unix, `Process.Release()`'d — the same detach pattern as `updater.RestartWithHelper`.

**Phase 2 — detached helper, after the agent process dies:**
- Stop own service (this is what finally kills the agent, after the result was submitted), delete the service registration(s), remove binaries, remove config, script self-deletes. On Windows **all** file removal lives here because running processes hold locks on the binaries and open log files.

**Honest ack:** if the detached handoff can't be launched, the handler returns an **error result** — the offboarding drain no longer counts a device that will remain installed as a completed uninstall. The success message reports "initiated / handed off", not completed.

## Tests

- Script construction extracted into pure builders (`buildWindowsUninstallScript`, `buildDarwinUninstallScript`, `buildLinuxUninstallScript`) with **table-driven tests** asserting the load-bearing ordering: ack delay → own-service stop → service delete → binary removal → config removal → script self-delete; watchdog stop-before-delete; sh/PowerShell quoting (`O'Brien` paths).
- `go test -race ./...`: **exit 0, 64 packages ok, 0 FAIL**.
- Cross-compiles clean for `GOOS=windows` and `GOOS=linux`.

Closes #2878

🤖 Generated with [Claude Code](https://claude.com/claude-code)