### PR TITLE
fix(api): make suspended→offboarding reachable via the org lifecycle API (#2879)

### DIFF
--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -138,6 +138,9 @@ vi.mock('../services/ticketConfigService', () => ({
 vi.mock('../db/schema', () => ({
   partners: {},
   organizations: {},
+  // #2879 — the suspended-org lifecycle override re-reads the caller's raw
+  // partner_users.org_ids selection under a system context.
+  partnerUsers: { userId: {}, partnerId: {}, orgIds: {} },
   // Give sites.id a recognizable sentinel so the site-allowlist test can assert
   // inArray was called against the sites.id column specifically.
   sites: { id: { __column: 'sites.id' }, orgId: { __column: 'sites.orgId' } },
@@ -225,7 +228,7 @@ describe('org routes', () => {
   let app: Hono;
 
   const setAuthContext = (overrides: Partial<{
-    user: { id: string; email: string; name: string };
+    user: { id: string; email: string; name: string; isPlatformAdmin?: boolean };
     token: Record<string, unknown>;
     partnerId: string | null;
     orgId: string | null;
@@ -1780,6 +1783,247 @@ describe('org routes', () => {
       });
 
       expect(res.status).toBe(404);
+    });
+
+    // #2879 — suspended orgs are excluded from accessibleOrgIds, which made
+    // suspended→offboarding (and reactivation) unreachable for the partner
+    // that suspended the org. A narrow override lets a partner admin apply a
+    // STATUS-ONLY lifecycle transition to a suspended org it owns; everything
+    // else stays 404.
+    describe('suspended-org lifecycle override (#2879)', () => {
+      // db.select mock for one .select().from().where().limit() call.
+      const selectLimitOnce = (rows: unknown[]) => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue(rows)
+          })
+        })
+      });
+
+      const mockUpdateReturning = (rows: unknown[]) => {
+        const returning = vi.fn().mockResolvedValue(rows);
+        vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ returning })
+          })
+        } as any);
+        return returning;
+      };
+
+      // Partner admin whose accessible set does NOT include the suspended org
+      // (that's the bug's precondition — computeAccessibleOrgIds filtered it out).
+      const setSuspendedOrgPartnerContext = (
+        partnerOrgAccess: 'all' | 'selected' | 'none' = 'all'
+      ) => {
+        setAuthContext({
+          scope: 'partner',
+          partnerId: 'partner-123',
+          accessibleOrgIds: ['org-1'],
+          partnerOrgAccess
+        });
+      };
+
+      const patchOrg = (orgId: string, body: Record<string, unknown>) =>
+        app.request(`/orgs/organizations/${orgId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+
+      it('lets the owning partner admin move a suspended org to offboarding', async () => {
+        setSuspendedOrgPartnerContext('all');
+        // Ownership probe: suspended org under the caller's partner.
+        vi.mocked(db.select).mockReturnValueOnce(
+          selectLimitOnce([{ partnerId: 'partner-123', status: 'suspended' }]) as any
+        );
+        mockUpdateReturning([{ id: 'org-suspended', name: 'O', status: 'offboarding' }]);
+
+        const res = await patchOrg('org-suspended', { status: 'offboarding' });
+
+        expect(res.status).toBe(200);
+        expect(beginOrganizationOffboarding).toHaveBeenCalledWith('org-suspended', 'user-123');
+        // The override write must escape the partner RLS context (which cannot
+        // see the suspended org) into a fresh system-scope transaction.
+        expect(withSystemDbAccessContext).toHaveBeenCalled();
+      });
+
+      it('lets the owning partner admin reactivate a suspended org to active', async () => {
+        setSuspendedOrgPartnerContext('all');
+        vi.mocked(db.select).mockReturnValueOnce(
+          selectLimitOnce([{ partnerId: 'partner-123', status: 'suspended' }]) as any
+        );
+        mockUpdateReturning([{ id: 'org-suspended', name: 'O', status: 'active' }]);
+
+        const res = await patchOrg('org-suspended', { status: 'active' });
+
+        expect(res.status).toBe(200);
+        expect(restoreOrganizationTenantAccess).toHaveBeenCalledWith('org-suspended');
+      });
+
+      it('denies the override for a cross-partner suspended org (404, no write)', async () => {
+        setSuspendedOrgPartnerContext('all');
+        vi.mocked(db.select).mockReturnValueOnce(
+          selectLimitOnce([{ partnerId: 'partner-OTHER', status: 'suspended' }]) as any
+        );
+
+        const res = await patchOrg('org-suspended', { status: 'offboarding' });
+
+        expect(res.status).toBe(404);
+        expect(db.update).not.toHaveBeenCalled();
+        expect(beginOrganizationOffboarding).not.toHaveBeenCalled();
+      });
+
+      it('denies the override when the target org is not actually suspended', async () => {
+        setSuspendedOrgPartnerContext('all');
+        // e.g. an org already flipped to churned out-of-band.
+        vi.mocked(db.select).mockReturnValueOnce(
+          selectLimitOnce([{ partnerId: 'partner-123', status: 'churned' }]) as any
+        );
+
+        const res = await patchOrg('org-invisible', { status: 'offboarding' });
+
+        expect(res.status).toBe(404);
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('does NOT let a non-status edit ride the override — suspended orgs stay unwritable', async () => {
+        setSuspendedOrgPartnerContext('all');
+
+        const res = await patchOrg('org-suspended', { name: 'Renamed while suspended' });
+
+        expect(res.status).toBe(404);
+        expect(db.select).not.toHaveBeenCalled(); // rejected before any DB probe
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('does NOT allow extra fields alongside status on the override', async () => {
+        setSuspendedOrgPartnerContext('all');
+
+        const res = await patchOrg('org-suspended', { status: 'offboarding', name: 'sneaky' });
+
+        expect(res.status).toBe(404);
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('does NOT allow suspended→churned (must drain via offboarding)', async () => {
+        setSuspendedOrgPartnerContext('all');
+
+        const res = await patchOrg('org-suspended', { status: 'churned' });
+
+        expect(res.status).toBe(404);
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('fails closed for a partner user with org_access none', async () => {
+        setSuspendedOrgPartnerContext('none');
+
+        const res = await patchOrg('org-suspended', { status: 'offboarding' });
+
+        expect(res.status).toBe(404);
+        expect(db.select).not.toHaveBeenCalled();
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it("grants a 'selected' user the override only when the org is in their raw selection", async () => {
+        setSuspendedOrgPartnerContext('selected');
+        vi.mocked(db.select)
+          .mockReturnValueOnce(selectLimitOnce([{ partnerId: 'partner-123', status: 'suspended' }]) as any)
+          .mockReturnValueOnce(selectLimitOnce([{ orgIds: ['org-suspended', 'org-1'] }]) as any);
+        mockUpdateReturning([{ id: 'org-suspended', name: 'O', status: 'offboarding' }]);
+
+        const res = await patchOrg('org-suspended', { status: 'offboarding' });
+
+        expect(res.status).toBe(200);
+        expect(beginOrganizationOffboarding).toHaveBeenCalledWith('org-suspended', 'user-123');
+      });
+
+      it("denies a 'selected' user whose selection does not include the org", async () => {
+        setSuspendedOrgPartnerContext('selected');
+        vi.mocked(db.select)
+          .mockReturnValueOnce(selectLimitOnce([{ partnerId: 'partner-123', status: 'suspended' }]) as any)
+          .mockReturnValueOnce(selectLimitOnce([{ orgIds: ['org-1'] }]) as any);
+
+        const res = await patchOrg('org-suspended', { status: 'offboarding' });
+
+        expect(res.status).toBe(404);
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('ordinary read routes still cannot see the suspended org (no visibility widening)', async () => {
+        setSuspendedOrgPartnerContext('all');
+
+        const res = await app.request('/orgs/organizations/org-suspended');
+
+        expect(res.status).toBe(404);
+        expect(db.select).not.toHaveBeenCalled();
+      });
+    });
+
+    // #2879 — a membership-less platform admin has no role row, so plain
+    // requirePermission 403s and system scope could not drive lifecycle
+    // transitions. The update route grants scope=system + isPlatformAdmin
+    // directly (mirroring platformAdminMiddleware's authority model).
+    describe('platform-admin permission bypass on org update (#2879)', () => {
+      it('lets a membership-less platform admin update an org when role permissions resolve to none', async () => {
+        permissionMockState.granted = false; // simulate "No permissions found"
+        setAuthContext({
+          scope: 'system',
+          partnerId: null,
+          user: { id: 'admin-1', email: 'admin@example.com', name: 'Admin', isPlatformAdmin: true }
+        });
+        vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'org-1', name: 'O', status: 'offboarding' }])
+            })
+          })
+        } as any);
+
+        const res = await app.request('/orgs/organizations/org-1', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'offboarding' })
+        });
+
+        expect(res.status).toBe(200);
+        expect(beginOrganizationOffboarding).toHaveBeenCalledWith('org-1', 'admin-1');
+      });
+
+      it('does NOT bypass permissions for a system-scope caller without isPlatformAdmin', async () => {
+        permissionMockState.granted = false;
+        setAuthContext({
+          scope: 'system',
+          partnerId: null,
+          user: { id: 'svc-1', email: 'svc@example.com', name: 'Svc', isPlatformAdmin: false }
+        });
+
+        const res = await app.request('/orgs/organizations/org-1', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'offboarding' })
+        });
+
+        expect(res.status).toBe(403);
+        expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('does NOT bypass permissions for partner scope even for a platform admin flag', async () => {
+        permissionMockState.granted = false;
+        setAuthContext({
+          scope: 'partner',
+          partnerId: 'partner-123',
+          user: { id: 'user-123', email: 'test@example.com', name: 'T', isPlatformAdmin: true }
+        });
+
+        const res = await app.request('/orgs/organizations/org-1', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'offboarding' })
+        });
+
+        expect(res.status).toBe(403);
+        expect(db.update).not.toHaveBeenCalled();
+      });
     });
 
     // issue #1963: the org write path feeds getOrgAgentUpdatePolicy, so a

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -137,7 +137,17 @@ vi.mock('../services/ticketConfigService', () => ({
 
 vi.mock('../db/schema', () => ({
   partners: {},
-  organizations: {},
+  // #2879 — sentinel columns (same pattern as sites.id below) so the
+  // suspended-org override tests can assert the UPDATE's WHERE re-asserts
+  // eq(organizations.status,'suspended') / eq(organizations.partnerId,...)
+  // via the eq spy. Real drizzle eq/isNull build SQL lazily, so plain-object
+  // sentinels are safe — the mocked db never executes them.
+  organizations: {
+    id: { __column: 'organizations.id' },
+    partnerId: { __column: 'organizations.partnerId' },
+    status: { __column: 'organizations.status' },
+    deletedAt: { __column: 'organizations.deletedAt' }
+  },
   // #2879 — the suspended-org lifecycle override re-reads the caller's raw
   // partner_users.org_ids selection under a system context.
   partnerUsers: { userId: {}, partnerId: {}, orgIds: {} },
@@ -161,7 +171,12 @@ vi.mock('drizzle-orm', async (importActual) => {
     // is fully mocked, so the return value is never executed, but the sentinel
     // columns ({ __column: ... }) aren't real Drizzle columns and would make the
     // real inArray throw on introspection.
-    inArray: vi.fn((column: unknown, values: unknown) => ({ __inArray: { column, values } }))
+    inArray: vi.fn((column: unknown, values: unknown) => ({ __inArray: { column, values } })),
+    // #2879 — spy with the REAL implementation so tests can assert the
+    // suspended-org lifecycle override re-asserts its WHERE predicates
+    // (eq(organizations.status,'suspended') / eq(organizations.partnerId,...))
+    // without changing any behavior for the rest of the file.
+    eq: vi.fn(actual.eq)
   };
 });
 
@@ -202,9 +217,9 @@ vi.mock('../middleware/auth', () => ({
   requireMfa: vi.fn(() => async (_c: any, next: any) => next())
 }));
 
-import { inArray } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../db';
-import { sites } from '../db/schema';
+import { organizations, sites } from '../db/schema';
 import { getEnrollmentDefaultsForOrg } from '../services/enrollmentDefaults';
 import { authMiddleware } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
@@ -1836,15 +1851,40 @@ describe('org routes', () => {
         vi.mocked(db.select).mockReturnValueOnce(
           selectLimitOnce([{ partnerId: 'partner-123', status: 'suspended' }]) as any
         );
-        mockUpdateReturning([{ id: 'org-suspended', name: 'O', status: 'offboarding' }]);
+        const returning = mockUpdateReturning([{ id: 'org-suspended', name: 'O', status: 'offboarding' }]);
 
         const res = await patchOrg('org-suspended', { status: 'offboarding' });
 
         expect(res.status).toBe(200);
         expect(beginOrganizationOffboarding).toHaveBeenCalledWith('org-suspended', 'user-123');
-        // The override write must escape the partner RLS context (which cannot
-        // see the suspended org) into a fresh system-scope transaction.
-        expect(withSystemDbAccessContext).toHaveBeenCalled();
+        // The override WRITE must escape the partner RLS context (which cannot
+        // see the suspended org) into its own fresh system-scope transaction —
+        // the ownership probe alone is not enough (in production the UPDATE
+        // would silently match 0 rows → 404, re-opening #2879). Assert ≥2
+        // system-context entries happened BEFORE the UPDATE's returning()
+        // executed (probe + update wrapper); the fire-and-forget audit write
+        // always lands after the update, so it cannot satisfy this.
+        const returningOrder = returning.mock.invocationCallOrder[0]!;
+        const sysCtxEntriesBeforeUpdate = vi.mocked(withSystemDbAccessContext)
+          .mock.invocationCallOrder.filter((order) => order < returningOrder).length;
+        expect(sysCtxEntriesBeforeUpdate).toBeGreaterThanOrEqual(2);
+        // The override UPDATE must re-assert, in its own WHERE, the facts the
+        // probe checked — partner-owned AND still suspended — so a concurrent
+        // change between check and write collapses to 0 rows instead of
+        // resurrecting a churned/reparented org (TOCTOU guard).
+        expect(eq).toHaveBeenCalledWith(organizations.status, 'suspended');
+        expect(eq).toHaveBeenCalledWith(organizations.partnerId, 'partner-123');
+      });
+
+      it('does not add the override predicates on the normal accessible-org path', async () => {
+        setSuspendedOrgPartnerContext('all');
+        // org-1 IS in accessibleOrgIds → normal path, no override.
+        mockUpdateReturning([{ id: 'org-1', name: 'O', status: 'active' }]);
+
+        const res = await patchOrg('org-1', { status: 'active' });
+
+        expect(res.status).toBe(200);
+        expect(eq).not.toHaveBeenCalledWith(organizations.status, 'suspended');
       });
 
       it('lets the owning partner admin reactivate a suspended org to active', async () => {
@@ -1902,6 +1942,10 @@ describe('org routes', () => {
         const res = await patchOrg('org-suspended', { status: 'offboarding', name: 'sneaky' });
 
         expect(res.status).toBe(404);
+        // Rejected on payload shape BEFORE any DB probe — without this pin the
+        // test passes vacuously off the default empty select mock even if the
+        // status-only guard is deleted (mutation-proven in review).
+        expect(db.select).not.toHaveBeenCalled();
         expect(db.update).not.toHaveBeenCalled();
       });
 
@@ -1911,6 +1955,9 @@ describe('org routes', () => {
         const res = await patchOrg('org-suspended', { status: 'churned' });
 
         expect(res.status).toBe(404);
+        // Same vacuity pin as above: churned must be rejected by the exit-status
+        // allowlist itself, before any DB probe.
+        expect(db.select).not.toHaveBeenCalled();
         expect(db.update).not.toHaveBeenCalled();
       });
 
@@ -1929,12 +1976,18 @@ describe('org routes', () => {
         vi.mocked(db.select)
           .mockReturnValueOnce(selectLimitOnce([{ partnerId: 'partner-123', status: 'suspended' }]) as any)
           .mockReturnValueOnce(selectLimitOnce([{ orgIds: ['org-suspended', 'org-1'] }]) as any);
-        mockUpdateReturning([{ id: 'org-suspended', name: 'O', status: 'offboarding' }]);
+        const returning = mockUpdateReturning([{ id: 'org-suspended', name: 'O', status: 'offboarding' }]);
 
         const res = await patchOrg('org-suspended', { status: 'offboarding' });
 
         expect(res.status).toBe(200);
         expect(beginOrganizationOffboarding).toHaveBeenCalledWith('org-suspended', 'user-123');
+        // Same system-context escape pin as the 'all' happy path (probe +
+        // update wrapper both before the UPDATE executed).
+        const returningOrder = returning.mock.invocationCallOrder[0]!;
+        const sysCtxEntriesBeforeUpdate = vi.mocked(withSystemDbAccessContext)
+          .mock.invocationCallOrder.filter((order) => order < returningOrder).length;
+        expect(sysCtxEntriesBeforeUpdate).toBeGreaterThanOrEqual(2);
       });
 
       it("denies a 'selected' user whose selection does not include the org", async () => {
@@ -2023,6 +2076,20 @@ describe('org routes', () => {
 
         expect(res.status).toBe(403);
         expect(db.update).not.toHaveBeenCalled();
+      });
+
+      it('does NOT extend the bypass to other org routes — DELETE still requires role permissions', async () => {
+        permissionMockState.granted = false;
+        setAuthContext({
+          scope: 'system',
+          partnerId: null,
+          user: { id: 'admin-1', email: 'admin@example.com', name: 'Admin', isPlatformAdmin: true }
+        });
+
+        const res = await app.request('/orgs/organizations/org-1', { method: 'DELETE' });
+
+        expect(res.status).toBe(403);
+        expect(db.update).not.toHaveBeenCalled(); // soft-delete write never runs
       });
     });
 

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1619,7 +1619,12 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWriteOrPl
     resourceType: 'organization',
     resourceId: organization.id,
     resourceName: organization.name,
-    details: { changedFields: Object.keys(data) }
+    details: {
+      changedFields: Object.keys(data),
+      // #2879 — flag transitions that used the suspended-org escape hatch so
+      // forensic review of override usage is a single audit-log filter.
+      ...(suspendedLifecycleOverride ? { suspendedLifecycleOverride: true } : {})
+    }
   });
 
   return c.json(organization);

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -5,7 +5,7 @@ import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, eq, ilike, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { partners, organizations, sites, devices, agentVersions } from '../db/schema';
+import { partners, organizations, sites, devices, agentVersions, partnerUsers } from '../db/schema';
 import { authMiddleware, requireMfa, requirePermission, requireScope, requirePartner, type AuthContext } from '../middleware/auth';
 import { writeAuditEvent, writeRouteAudit } from '../services/auditEvents';
 import { getEffectiveOrgSettings, assertNotLocked } from '../services/effectiveSettings';
@@ -1366,13 +1366,105 @@ orgRoutes.get('/organizations/:id/effective-settings',
   }
 );
 
-const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', updateOrganizationSchema), async (c: any) => {
+// #2879 — statuses a partner may move a SUSPENDED org to through the narrow
+// lifecycle exception in updateOrgHandler. Deliberately excludes:
+//   - 'suspended' (no-op),
+//   - 'churned'   (jumping a suspended org straight to churned would skip the
+//                  offboarding drain and strand agents with no self_uninstall
+//                  delivery — the drain reaper flips offboarding→churned),
+//   - 'pending'   (not an exit state).
+const SUSPENDED_LIFECYCLE_EXIT_STATUSES: readonly string[] = ['active', 'trial', 'offboarding'];
+
+/**
+ * #2879 — suspended→offboarding (and suspended→active/trial reactivation) was
+ * unreachable: computeAccessibleOrgIds filters partner visibility to
+ * active/trial orgs, so a suspended org 404s on PATCH /organizations/:id and
+ * the partner can never offboard (or reactivate) a customer it suspended —
+ * a one-way door that made #2808's drain-entry fix dead code on the real path.
+ *
+ * This is a deliberately NARROW override: it only ever authorizes a
+ * status-only payload moving a suspended, partner-owned org to a lifecycle
+ * exit state. Suspended orgs stay invisible to every other route and to
+ * general accessible-org computation — suspension continues to cut off
+ * access everywhere else.
+ */
+async function canApplySuspendedOrgLifecycleTransition(
+  auth: AuthContext,
+  orgId: string,
+  data: Record<string, unknown>
+): Promise<boolean> {
+  // Status-only: nothing else (name/settings/billing) may ride along on the
+  // override — editing a suspended org's data stays blocked.
+  const keys = Object.keys(data);
+  if (keys.length !== 1 || keys[0] !== 'status') return false;
+  if (typeof data.status !== 'string' || !SUSPENDED_LIFECYCLE_EXIT_STATUSES.includes(data.status)) {
+    return false;
+  }
+  if (!auth.partnerId) return false;
+  // partner_users.org_access 'none' (or an unresolved membership) fails closed.
+  if (auth.partnerOrgAccess !== 'all' && auth.partnerOrgAccess !== 'selected') return false;
+
+  // The suspended org is invisible to this request's RLS context (it is
+  // excluded from accessibleOrgIds), so the ownership check must run under a
+  // fresh system-scope transaction. Every predicate is equality-keyed by the
+  // caller's own partnerId/userId, so this can only surface facts about the
+  // caller's own tenant — never another partner's.
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [org] = await db
+        .select({ partnerId: organizations.partnerId, status: organizations.status })
+        .from(organizations)
+        .where(and(eq(organizations.id, orgId), isNull(organizations.deletedAt)))
+        .limit(1);
+      if (!org || org.partnerId !== auth.partnerId || org.status !== 'suspended') {
+        return false;
+      }
+      if (auth.partnerOrgAccess === 'selected') {
+        // 'selected' users only get the override for orgs in their selection
+        // (computeAccessibleOrgIds can't tell us — it already filtered the
+        // suspended org out — so re-read the raw selection list).
+        const [membership] = await db
+          .select({ orgIds: partnerUsers.orgIds })
+          .from(partnerUsers)
+          .where(and(eq(partnerUsers.userId, auth.user.id), eq(partnerUsers.partnerId, auth.partnerId!)))
+          .limit(1);
+        if (!(membership?.orgIds ?? []).includes(orgId)) return false;
+      }
+      return true;
+    })
+  );
+}
+
+// #2879 — a membership-less platform admin resolves no role row in
+// getUserPermissions (permissions derive only from partner/org memberships),
+// so requirePermission 403s ("No permissions found") and system scope cannot
+// drive org lifecycle transitions either. scope='system' is only minted for —
+// and live-bound to — users with isPlatformAdmin=true (authMiddleware SR2-02),
+// and platformAdminMiddleware (/admin/*) already treats that flag as the
+// grant, so this mirrors the established authority model. Applied ONLY to the
+// org update route, not globally.
+const requireOrgWriteOrPlatformAdmin = async (c: Context, next: Next) => {
+  const auth = c.get('auth') as AuthContext | undefined;
+  if (auth?.scope === 'system' && auth.user?.isPlatformAdmin === true) {
+    return next();
+  }
+  return requireOrgWrite(c, next);
+};
+
+const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWriteOrPlatformAdmin, requireMfa(), zValidator('json', updateOrganizationSchema), async (c: any) => {
   const auth = c.get('auth') as AuthContext;
   const id = c.req.param('id')!;
   const data = c.req.valid('json');
 
+  // #2879 — suspended orgs are outside canAccessOrg/accessibleOrgIds, so a
+  // partner-scope status-only lifecycle transition (suspended→offboarding /
+  // reactivation) gets one narrow escape hatch; anything else stays a 404.
+  let suspendedLifecycleOverride = false;
   if (auth.scope === 'partner' && !auth.canAccessOrg(id)) {
-    return c.json({ error: 'Organization not found' }, 404);
+    suspendedLifecycleOverride = await canApplySuspendedOrgLifecycleTransition(auth, id, data);
+    if (!suspendedLifecycleOverride) {
+      return c.json({ error: 'Organization not found' }, 404);
+    }
   }
 
   if (data.settings) {
@@ -1472,13 +1564,31 @@ const updateOrgHandler = [requireScope('partner', 'system'), requireOrgWrite, re
     updates.contractEnd = data.contractEnd ? new Date(data.contractEnd) : null;
   }
 
-  const conditions = and(eq(organizations.id, id), isNull(organizations.deletedAt));
+  // #2879 — the override path re-asserts, in the UPDATE itself, exactly the
+  // facts canApplySuspendedOrgLifecycleTransition checked (partner-owned AND
+  // still suspended), so a concurrent change between check and write can only
+  // produce a 0-row update → 404, never a write to an org that stopped
+  // qualifying. It must also run under a system context: the request's
+  // partner RLS context can't see the suspended org, so the same UPDATE
+  // would silently match 0 rows there.
+  const conditions = suspendedLifecycleOverride
+    ? and(
+        eq(organizations.id, id),
+        eq(organizations.partnerId, auth.partnerId!),
+        eq(organizations.status, 'suspended'),
+        isNull(organizations.deletedAt)
+      )
+    : and(eq(organizations.id, id), isNull(organizations.deletedAt));
 
-  const [organization] = await db
+  const runUpdate = () => db
     .update(organizations)
     .set(updates)
     .where(conditions)
     .returning();
+
+  const [organization] = suspendedLifecycleOverride
+    ? await runOutsideDbContext(() => withSystemDbAccessContext(runUpdate))
+    : await runUpdate();
 
   if (!organization) {
     return c.json({ error: 'Organization not found' }, 404);


### PR DESCRIPTION
## Problem

Found in the 2026-07-27 pre-release QA sweep (#2879): there was **no API path to move an org from `suspended` to `offboarding`**, which made #2808's clear-superseded-suspension fix dead code on the real production path.

- **Partner scope**: `computeAccessibleOrgIds` filters visibility to `active`/`trial` orgs, so a suspended org 404s on `PATCH /organizations/:id`. The partner that suspended a customer for non-payment could never offboard it — or reactivate it (a one-way door).
- **System scope**: a membership-less platform admin resolves no role row in `getUserPermissions` (permissions derive only from partner/org memberships), so `requirePermission` 403s with "No permissions found".

## Fix — two narrow gates, no general visibility widening

**Partner scope — suspended-org lifecycle override** (`canApplySuspendedOrgLifecycleTransition` in `routes/orgs.ts`):
- Applies ONLY to a **status-only** payload moving the org to `active` / `trial` / `offboarding`. `churned` is deliberately excluded (jumping the drain would strand agents with no `self_uninstall` delivery); any other field riding along (name/settings/billing) is rejected — suspended orgs stay unwritable.
- Ownership is verified under a fresh system-scope context (the request's partner RLS context cannot see the org): org must be **suspended**, **owned by the caller's partner**, not deleted; `org_access='selected'` users must additionally have the org in their raw `partner_users.org_ids` selection; `'none'` fails closed.
- The UPDATE itself re-asserts `partner_id = caller's partner AND status = 'suspended'` in its WHERE and runs under a system context — a concurrent change between check and write collapses to 0 rows → 404 (no TOCTOU window).
- Suspended orgs remain invisible to every other route and to general accessible-org computation — suspension continues to cut off access everywhere else (matters for the abuse/suspension workflow).

**System scope — platform-admin grant on the org update route** (`requireOrgWriteOrPlatformAdmin`):
- `scope='system'` is only minted for — and live-bound to (SR2-02) — users with `isPlatformAdmin=true`, and `platformAdminMiddleware` (/admin/*) already treats that flag as the grant. The org update route now mirrors that authority model instead of 403ing. Applied only to this route, not globally.

Deliberately does NOT touch the offboarding entry transaction (`beginOrganizationOffboarding` / `tenantOffboarding.ts`) — the #2877 deadlock fix owns that surface. All post-update lifecycle services already run under their own system contexts, and audit writes escalate internally, so nothing downstream is RLS-dropped.

## Tests

14 new route tests in `apps/api/src/routes/orgs.test.ts`:
- suspended org offboardable + reactivatable by its owning partner admin (override runs under a system context)
- cross-partner suspended org denied, 404 with no write
- non-suspended target denied; status+extra-fields payload denied; non-status edit denied before any DB probe; `churned` denied
- `org_access` none fails closed; `selected` granted only when the org is in the raw selection
- ordinary read routes still cannot see the suspended org (no visibility widening)
- platform-admin bypass: membership-less admin can drive the transition; system-scope caller **without** the flag still 403s; partner scope never bypasses

`vitest run` on all three dependent test files: 219 passed. `tsc --noEmit` clean.

Closes #2879

🤖 Generated with [Claude Code](https://claude.com/claude-code)