### PR TITLE
fix(billing): durable quote response-capability writer + replay backstop (#2875)

### DIFF
--- a/apps/api/src/__tests__/integration/quotesPublicRoutes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quotesPublicRoutes.integration.test.ts
@@ -186,6 +186,9 @@ describe('public quote routes (HTTP, unauthenticated token)', () => {
     // still rejects it — 401 (same shape as the Redis path), quote untouched.
     const replay = await postJson(`/quotes/public/${token}/accept`, { signerName: 'Replay Ray' });
     expect(replay.status).toBe(401);
+    // Cross-route: a decline replay of the consumed accept link is 401 too.
+    await redis!.del(`quote-accept-jti-revoked:${q!.publicResponseJti}`); // backstop re-armed the marker — drop it again
+    expect((await postJson(`/quotes/public/${token}/decline`, { reason: 'flip' })).status).toBe(401);
     const [q2] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
     expect(q2!.status).toBe('converted');
     expect(q2!.publicResponseOutcome).toBe('accepted');
@@ -205,6 +208,9 @@ describe('public quote routes (HTTP, unauthenticated token)', () => {
     expect(redis).toBeTruthy();
     await redis!.del(`quote-accept-jti-revoked:${q!.publicResponseJti}`);
     expect((await postJson(`/quotes/public/${token}/decline`, { reason: 'again' })).status).toBe(401);
+    // The backstop re-arms the Redis marker on a replay — drop it again so the
+    // cross-route accept replay below also proves the DURABLE path, not Redis.
+    await redis!.del(`quote-accept-jti-revoked:${q!.publicResponseJti}`);
     expect((await postJson(`/quotes/public/${token}/accept`, { signerName: 'Flip Flop' })).status).toBe(401);
     const [q2] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
     expect(q2!.status).toBe('declined');

--- a/apps/api/src/__tests__/integration/quotesPublicRoutes.integration.test.ts
+++ b/apps/api/src/__tests__/integration/quotesPublicRoutes.integration.test.ts
@@ -17,6 +17,7 @@ import { db, withSystemDbAccessContext } from '../../db';
 import { quotes, quoteLines } from '../../db/schema/quotes';
 import { createPartner, createOrganization } from './db-utils';
 import { createQuoteAcceptToken } from '../../services/quoteAcceptToken';
+import { getRedis } from '../../services/redis';
 import { quotesPublicRoutes } from '../../routes/quotesPublic';
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
@@ -164,6 +165,50 @@ describe('public quote routes (HTTP, unauthenticated token)', () => {
     // Token revoked post-accept → replay is blocked at the resolve() gate (401, not 409).
     expect((await app().request(`/quotes/public/${token}`)).status).toBe(401);
     expect((await postJson(`/quotes/public/${token}/accept`, { signerName: 'Replay' })).status).toBe(401);
+  });
+
+  // #2875: the durable response-capability columns (2026-08-06-c) are written in
+  // the same transaction as the accept, and act as a replay backstop that holds
+  // even when the Redis jti-revocation marker is lost (flush/failover/TTL).
+  runDb('POST accept consumes the durable response capability; replay is 401 even after the Redis marker is lost', async () => {
+    const { quoteId, token } = await seedQuote({ lines: [{ description: 'Setup', unitPrice: '250.00' }] });
+    const res = await postJson(`/quotes/public/${token}/accept`, { signerName: 'Prospect Pat' });
+    expect(res.status).toBe(200);
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
+    expect(q!.publicResponseJti).toBeTruthy();
+    expect(q!.publicResponseConsumedAt).toBeTruthy();
+    expect(q!.publicResponseOutcome).toBe('accepted');
+    // Simulate a Redis flush: delete the jti revocation marker outright.
+    const redis = getRedis();
+    expect(redis).toBeTruthy();
+    await redis!.del(`quote-accept-jti-revoked:${q!.publicResponseJti}`);
+    // Replay passes the resolve() gate (marker gone) but the durable backstop
+    // still rejects it — 401 (same shape as the Redis path), quote untouched.
+    const replay = await postJson(`/quotes/public/${token}/accept`, { signerName: 'Replay Ray' });
+    expect(replay.status).toBe(401);
+    const [q2] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
+    expect(q2!.status).toBe('converted');
+    expect(q2!.publicResponseOutcome).toBe('accepted');
+  });
+
+  runDb('POST decline consumes the durable response capability; replay (decline OR accept) is 401 even after the Redis marker is lost', async () => {
+    const { quoteId, token } = await seedQuote({ lines: [{ description: 'Setup', unitPrice: '250.00' }] });
+    const res = await postJson(`/quotes/public/${token}/decline`, { reason: 'Budget cut' });
+    expect(res.status).toBe(200);
+    const [q] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
+    expect(q!.status).toBe('declined');
+    expect(q!.publicResponseJti).toBeTruthy();
+    expect(q!.publicResponseConsumedAt).toBeTruthy();
+    expect(q!.publicResponseOutcome).toBe('declined');
+    // Simulate a Redis flush, then replay both mutation routes.
+    const redis = getRedis();
+    expect(redis).toBeTruthy();
+    await redis!.del(`quote-accept-jti-revoked:${q!.publicResponseJti}`);
+    expect((await postJson(`/quotes/public/${token}/decline`, { reason: 'again' })).status).toBe(401);
+    expect((await postJson(`/quotes/public/${token}/accept`, { signerName: 'Flip Flop' })).status).toBe(401);
+    const [q2] = await withSystemDbAccessContext(() => db.select().from(quotes).where(eq(quotes.id, quoteId)));
+    expect(q2!.status).toBe('declined');
+    expect(q2!.declineReason).toBe('Budget cut');
   });
 
   runDb('POST accept requires a signer name (zValidator 400)', async () => {

--- a/apps/api/src/routes/quotesPublic.test.ts
+++ b/apps/api/src/routes/quotesPublic.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 
 // DB mock: select().from().where().limit()/orderBy() resolves to the next queued
 // row set, consumed FIFO in call order. Mirrors the pattern in
@@ -323,6 +325,16 @@ describe('quotesPublic POST /:token/decline + durable response capability', () =
     });
     expect(setArg.publicResponseConsumedAt).toBeInstanceOf(Date);
     expect(revokeQuoteAcceptJti).toHaveBeenCalledWith(JTI);
+
+    // Pin the guarded UPDATE's WHERE content: the write-time status re-check +
+    // non-consumption re-assert are what close the concurrent-accept race, so
+    // their removal must fail this test, not just the queued-rows simulation.
+    const whereCalls = (db as unknown as { where: { mock: { calls: unknown[][] } } }).where.mock.calls;
+    const updateWhere = whereCalls.at(-1)![0] as SQL;
+    const rendered = new PgDialect().sqlToQuery(updateWhere);
+    expect(rendered.sql).toContain('"status" in (');
+    expect(rendered.sql).toContain('"public_response_consumed_at" is null');
+    expect(rendered.params).toEqual(expect.arrayContaining(['sent', 'viewed']));
   });
 
   it('replayed decline 401s off the durable columns when the Redis marker is gone, without writing', async () => {
@@ -337,9 +349,28 @@ describe('quotesPublic POST /:token/decline + durable response capability', () =
       body: JSON.stringify({ reason: 'again' }),
     });
     expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.code).toBe('RESPONSE_CONSUMED');
     const setCalls = (db as unknown as { set: { mock: { calls: unknown[][] } } }).set.mock.calls;
     expect(setCalls).toHaveLength(0); // no UPDATE issued
-    expect(revokeQuoteAcceptJti).not.toHaveBeenCalled();
+    // The lost Redis marker is re-armed so repeat replays die at the resolve() gate.
+    expect(revokeQuoteAcceptJti).toHaveBeenCalledWith(JTI);
+  });
+
+  it('decline 401s when a version-1 row was issued a different jti (v1 forward-compat guard)', async () => {
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'sent',
+      expiryDate: null, publicTokenVersion: 1, publicResponseJti: 'jti-issued-at-send',
+      publicResponseConsumedAt: null, publicResponseOutcome: null,
+    }]); // v1 row: jti persisted at send; presented token carries jti-1
+
+    const res = await app().request(`/quotes/public/${TOKEN}/decline`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'mismatch' }),
+    });
+    expect(res.status).toBe(401);
+    const setCalls = (db as unknown as { set: { mock: { calls: unknown[][] } } }).set.mock.calls;
+    expect(setCalls).toHaveLength(0); // the stored jti is never rewritten
   });
 
   it('decline 409s (not consumed-401) when the row was consumed by a DIFFERENT jti', async () => {
@@ -387,7 +418,8 @@ describe('quotesPublic POST /:token/decline + durable response capability', () =
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.code).toBe('RESPONSE_CONSUMED');
-    expect(revokeQuoteAcceptJti).not.toHaveBeenCalled();
+    // The lost Redis marker is re-armed so repeat replays die at the resolve() gate.
+    expect(revokeQuoteAcceptJti).toHaveBeenCalledWith(JTI);
   });
 });
 

--- a/apps/api/src/routes/quotesPublic.test.ts
+++ b/apps/api/src/routes/quotesPublic.test.ts
@@ -8,7 +8,7 @@ const { dbResults } = vi.hoisted(() => ({ dbResults: [] as unknown[][] }));
 vi.mock('../db', () => {
   const makeChain = () => {
     const chain: Record<string, unknown> = {};
-    for (const m of ['select', 'from', 'where', 'orderBy', 'limit']) chain[m] = vi.fn(() => chain);
+    for (const m of ['select', 'from', 'where', 'orderBy', 'limit', 'update', 'set', 'returning', 'for']) chain[m] = vi.fn(() => chain);
     (chain as { then: unknown }).then = (resolve: (v: unknown) => unknown) => {
       const rows = dbResults.shift() ?? [];
       return Promise.resolve(rows).then(resolve);
@@ -33,7 +33,8 @@ vi.mock('../services/quoteAcceptToken', () => ({
 vi.mock('../services/quoteLifecycle', () => ({ markQuoteViewed: vi.fn() }));
 
 import { quotesPublicRoutes } from './quotesPublic';
-import { verifyQuoteAcceptToken, isQuoteAcceptJtiRevoked } from '../services/quoteAcceptToken';
+import { db } from '../db';
+import { verifyQuoteAcceptToken, isQuoteAcceptJtiRevoked, revokeQuoteAcceptJti } from '../services/quoteAcceptToken';
 import { markQuoteViewed } from '../services/quoteLifecycle';
 
 const QUOTE_ID = '11111111-1111-1111-1111-111111111111';
@@ -280,6 +281,113 @@ describe('quotesPublic GET /:token', () => {
     expect(contractBlock.content.sourceType).toBe('uploaded');
     expect(contractBlock.content.renderedHtml).toBeNull();
     expect(contractBlock.content.fileUrl).toBe(`/quotes/public/${encodeURIComponent(TOKEN)}/contract-file/${BLOCK_ID}`);
+  });
+});
+
+// #2875: the public decline/accept mutations consume the durable response
+// capability (2026-08-06-c columns) and honor it as a replay backstop that
+// holds even when the Redis jti-revocation marker has been lost.
+describe('quotesPublic POST /:token/decline + durable response capability', () => {
+  const JTI = 'jti-1';
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbResults.length = 0;
+    (verifyQuoteAcceptToken as ReturnType<typeof vi.fn>).mockResolvedValue({
+      quoteId: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, jti: JTI,
+    });
+    (isQuoteAcceptJtiRevoked as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (revokeQuoteAcceptJti as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it('decline writes the durable consumption columns in the same UPDATE as the status change', async () => {
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'sent',
+      expiryDate: null, publicResponseJti: null, publicResponseConsumedAt: null, publicResponseOutcome: null,
+    }]); // quote SELECT
+    dbResults.push([{ id: QUOTE_ID }]); // UPDATE ... RETURNING
+
+    const res = await app().request(`/quotes/public/${TOKEN}/decline`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'Budget cut' }),
+    });
+    expect(res.status).toBe(200);
+
+    const setCalls = (db as unknown as { set: { mock: { calls: unknown[][] } } }).set.mock.calls;
+    expect(setCalls).toHaveLength(1);
+    const setArg = setCalls[0]![0] as Record<string, unknown>;
+    expect(setArg).toMatchObject({
+      status: 'declined',
+      declineReason: 'Budget cut',
+      publicResponseJti: JTI,
+      publicResponseOutcome: 'declined',
+    });
+    expect(setArg.publicResponseConsumedAt).toBeInstanceOf(Date);
+    expect(revokeQuoteAcceptJti).toHaveBeenCalledWith(JTI);
+  });
+
+  it('replayed decline 401s off the durable columns when the Redis marker is gone, without writing', async () => {
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'declined',
+      expiryDate: null, publicResponseJti: JTI,
+      publicResponseConsumedAt: new Date('2026-07-27T00:00:00Z'), publicResponseOutcome: 'declined',
+    }]); // quote SELECT — Redis says not revoked (marker lost), durable columns say consumed
+
+    const res = await app().request(`/quotes/public/${TOKEN}/decline`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'again' }),
+    });
+    expect(res.status).toBe(401);
+    const setCalls = (db as unknown as { set: { mock: { calls: unknown[][] } } }).set.mock.calls;
+    expect(setCalls).toHaveLength(0); // no UPDATE issued
+    expect(revokeQuoteAcceptJti).not.toHaveBeenCalled();
+  });
+
+  it('decline 409s (not consumed-401) when the row was consumed by a DIFFERENT jti', async () => {
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'converted',
+      expiryDate: null, publicResponseJti: 'jti-other',
+      publicResponseConsumedAt: new Date('2026-07-27T00:00:00Z'), publicResponseOutcome: 'accepted',
+    }]);
+
+    const res = await app().request(`/quotes/public/${TOKEN}/decline`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('decline 409s when the write-time status re-check matches 0 rows (concurrent accept won the race)', async () => {
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'sent',
+      expiryDate: null, publicResponseJti: null, publicResponseConsumedAt: null, publicResponseOutcome: null,
+    }]); // quote SELECT reads 'sent'…
+    dbResults.push([]); // …but the guarded UPDATE matches 0 rows (status changed underneath)
+
+    const res = await app().request(`/quotes/public/${TOKEN}/decline`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'race' }),
+    });
+    expect(res.status).toBe(409);
+    expect(revokeQuoteAcceptJti).not.toHaveBeenCalled();
+  });
+
+  it('replayed accept 401s off the durable columns when the Redis marker is gone (service backstop through the route)', async () => {
+    dbResults.push([]); // quoteBlocks pre-fetch (accept route) — no contract blocks
+    dbResults.push([{
+      id: QUOTE_ID, orgId: ORG_ID, partnerId: PARTNER_ID, status: 'converted',
+      expiryDate: null, quoteNumber: 'Q-1', currencyCode: 'USD', taxRate: null, siteId: null,
+      publicResponseJti: JTI,
+      publicResponseConsumedAt: new Date('2026-07-27T00:00:00Z'), publicResponseOutcome: 'accepted',
+    }]); // acceptQuote's SELECT ... FOR UPDATE
+
+    const res = await app().request(`/quotes/public/${TOKEN}/accept`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ signerName: 'Replay Ray' }),
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.code).toBe('RESPONSE_CONSUMED');
+    expect(revokeQuoteAcceptJti).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '../lib/validation';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { quotes, quoteBlocks, quoteLines } from '../db/schema/quotes';
 import { partners } from '../db/schema/orgs';
@@ -195,15 +195,32 @@ quotesPublicRoutes.post('/:token/decline', zValidator('param', tokenParam), zVal
   if (!claims) return c.json({ error: 'This link is invalid or has expired' }, 401);
   const result = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
     const [quote] = await db.select().from(quotes).where(and(eq(quotes.id, claims.quoteId), eq(quotes.orgId, claims.orgId))).limit(1);
-    if (!quote || (quote.status !== 'sent' && quote.status !== 'viewed')) return 'bad_state' as const;
+    if (!quote) return 'bad_state' as const;
+    // Durable single-use backstop (#2875, wave-3 schema 2026-08-06-c): this jti
+    // was already consumed on the row → replay, even when the Redis revocation
+    // marker was lost (flush/failover/TTL). Checked BEFORE the status guard so
+    // a replayed link 401s exactly like the Redis resolve() gate does.
+    if (quote.publicResponseConsumedAt != null && quote.publicResponseJti === claims.jti) return 'consumed' as const;
+    if (quote.status !== 'sent' && quote.status !== 'viewed') return 'bad_state' as const;
     // Read-time expiry guard (Phase 3): an expired quote is terminal — mirror the
     // acceptQuote / declineQuoteByActor 410 so the sub-sweep window is covered here too.
     if (isQuoteExpired(quote.expiryDate)) return 'expired' as const;
     const now = new Date();
-    await db.update(quotes).set({ status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now }).where(eq(quotes.id, quote.id));
+    // Consume the durable response capability in the SAME statement as the
+    // decline (#2875): jti + consumed_at + outcome land atomically with the
+    // status change; the Redis revoke below stays the hot-path check. The
+    // status filter re-asserts the guard at write time so a concurrent accept
+    // (which holds a FOR UPDATE lock and flips status to 'converted') can't be
+    // overwritten by this unlocked read-then-write — 0 rows matched → 409.
+    const updated = await db.update(quotes).set({
+      status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now,
+      publicResponseJti: claims.jti, publicResponseConsumedAt: now, publicResponseOutcome: 'declined',
+    }).where(and(eq(quotes.id, quote.id), inArray(quotes.status, ['sent', 'viewed']))).returning({ id: quotes.id });
+    if (updated.length === 0) return 'bad_state' as const;
     return 'ok' as const;
   }));
   if (result === 'expired') return c.json({ error: 'This quote has expired', code: 'QUOTE_EXPIRED' }, 410);
+  if (result === 'consumed') return c.json({ error: 'This link is invalid or has expired' }, 401);
   if (result !== 'ok') return c.json({ error: 'This quote can no longer be declined' }, 409);
   // Consume the single-use token post-commit so a declined link can't be replayed.
   // A failed revoke leaves the link replayable (security-relevant) → capture.

--- a/apps/api/src/routes/quotesPublic.ts
+++ b/apps/api/src/routes/quotesPublic.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '../lib/validation';
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, inArray, isNull } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { quotes, quoteBlocks, quoteLines } from '../db/schema/quotes';
 import { partners } from '../db/schema/orgs';
@@ -182,7 +182,14 @@ quotesPublicRoutes.post('/:token/accept', zValidator('param', tokenParam), zVali
     }
     return c.json({ data: { status: res.quote.status, invoiceNumber: null, payUrl, payDeferred, pax8OrderId: res.pax8OrderId } });
   } catch (err) {
-    if (err instanceof QuoteServiceError) return c.json({ error: err.message, code: err.code }, err.status);
+    if (err instanceof QuoteServiceError) {
+      if (err.code === 'RESPONSE_CONSUMED') {
+        // Durable backstop fired (Redis marker lost): re-arm it so repeat
+        // replays die at the cheap resolve() gate; failure here is benign.
+        try { await revokeQuoteAcceptJti(claims.jti); } catch { /* durable backstop holds */ }
+      }
+      return c.json({ error: err.message, code: err.code }, err.status);
+    }
     // loadContractBlockRenderData throws this for a missing/mismatched pinned version.
     if (err instanceof ContractTemplateServiceError) return c.json({ error: err.message, code: err.code }, err.status);
     throw err;
@@ -201,6 +208,10 @@ quotesPublicRoutes.post('/:token/decline', zValidator('param', tokenParam), zVal
     // marker was lost (flush/failover/TTL). Checked BEFORE the status guard so
     // a replayed link 401s exactly like the Redis resolve() gate does.
     if (quote.publicResponseConsumedAt != null && quote.publicResponseJti === claims.jti) return 'consumed' as const;
+    // Forward-compat guard for the wave-3 v1 model (jti persisted at send with
+    // public_token_version=1): a version-1 row may only be consumed by the jti
+    // it was issued with. Inert for today's version-0 rows.
+    if ((quote.publicTokenVersion ?? 0) !== 0 && quote.publicResponseJti !== claims.jti) return 'consumed' as const;
     if (quote.status !== 'sent' && quote.status !== 'viewed') return 'bad_state' as const;
     // Read-time expiry guard (Phase 3): an expired quote is terminal — mirror the
     // acceptQuote / declineQuoteByActor 410 so the sub-sweep window is covered here too.
@@ -215,12 +226,25 @@ quotesPublicRoutes.post('/:token/decline', zValidator('param', tokenParam), zVal
     const updated = await db.update(quotes).set({
       status: 'declined', declineReason: reason ?? null, declinedAt: now, updatedAt: now,
       publicResponseJti: claims.jti, publicResponseConsumedAt: now, publicResponseOutcome: 'declined',
-    }).where(and(eq(quotes.id, quote.id), inArray(quotes.status, ['sent', 'viewed']))).returning({ id: quotes.id });
+    }).where(and(
+      eq(quotes.id, quote.id),
+      inArray(quotes.status, ['sent', 'viewed']),
+      // Re-assert non-consumption at write time too (belt to the status
+      // strap): a concurrent consumer that somehow left status untouched
+      // still can't be overwritten.
+      isNull(quotes.publicResponseConsumedAt),
+    )).returning({ id: quotes.id });
     if (updated.length === 0) return 'bad_state' as const;
     return 'ok' as const;
   }));
   if (result === 'expired') return c.json({ error: 'This quote has expired', code: 'QUOTE_EXPIRED' }, 410);
-  if (result === 'consumed') return c.json({ error: 'This link is invalid or has expired' }, 401);
+  if (result === 'consumed') {
+    // Re-arm the lost Redis marker so repeat replays die at the cheap
+    // resolve() gate instead of re-reading the row each time; the durable
+    // backstop holds regardless, so a failed re-arm is benign.
+    try { await revokeQuoteAcceptJti(claims.jti); } catch { /* durable backstop holds */ }
+    return c.json({ error: 'This link is invalid or has expired', code: 'RESPONSE_CONSUMED' }, 401);
+  }
   if (result !== 'ok') return c.json({ error: 'This quote can no longer be declined' }, 409);
   // Consume the single-use token post-commit so a declined link can't be replayed.
   // A failed revoke leaves the link replayable (security-relevant) → capture.

--- a/apps/api/src/services/quoteAcceptService.test.ts
+++ b/apps/api/src/services/quoteAcceptService.test.ts
@@ -154,6 +154,73 @@ describe('acceptQuote deposit snapshot', () => {
     expect(setMock.mock.calls[0]![0]).not.toHaveProperty('depositDue');
   });
 
+  // #2875: token-based (public) accepts must claim + consume the durable
+  // response capability (2026-08-06-c columns) in the same quotes update that
+  // flips status→converted; portal accepts (no jti) must leave them untouched.
+  it('public accept (acceptanceTokenJti set) consumes the durable response capability in the quotes update', async () => {
+    queueAcceptHappyPath();
+
+    await acceptQuote({ ...baseParams, acceptanceTokenJti: 'jti-durable-1' });
+
+    const setMock = (db as unknown as Chain).set;
+    // calls[0] = invoices issueFields update; calls[1] = quotes status update.
+    const quotesSet = setMock.mock.calls[1]![0] as Record<string, unknown>;
+    expect(quotesSet).toMatchObject({
+      status: 'converted',
+      publicResponseJti: 'jti-durable-1',
+      publicResponseOutcome: 'accepted',
+    });
+    expect(quotesSet.publicResponseConsumedAt).toBeInstanceOf(Date);
+  });
+
+  it('portal accept (no acceptanceTokenJti) leaves the durable response columns untouched', async () => {
+    queueAcceptHappyPath();
+
+    await acceptQuote(baseParams); // acceptanceTokenJti: null
+
+    const setMock = (db as unknown as Chain).set;
+    const quotesSet = setMock.mock.calls[1]![0] as Record<string, unknown>;
+    expect(quotesSet).toMatchObject({ status: 'converted' });
+    expect(quotesSet).not.toHaveProperty('publicResponseJti');
+    expect(quotesSet).not.toHaveProperty('publicResponseConsumedAt');
+    expect(quotesSet).not.toHaveProperty('publicResponseOutcome');
+  });
+
+  // #2875 durable replay backstop: a jti already consumed on the row is
+  // rejected 401 BEFORE the status guard and before any write — this is what
+  // holds when the Redis revocation marker has been flushed.
+  it('throws 401 RESPONSE_CONSUMED and writes nothing when the jti was already durably consumed', async () => {
+    queueResult([{
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'converted',
+      expiryDate: null, quoteNumber: 'Q-2026-0001', taxRate: null,
+      currencyCode: 'USD', siteId: null,
+      publicResponseJti: 'jti-durable-1',
+      publicResponseConsumedAt: new Date('2026-07-27T00:00:00Z'),
+      publicResponseOutcome: 'accepted',
+    }]); // 1: select quote FOR UPDATE — nothing further should run
+
+    await expect(acceptQuote({ ...baseParams, acceptanceTokenJti: 'jti-durable-1' }))
+      .rejects.toMatchObject({ status: 401, code: 'RESPONSE_CONSUMED' });
+
+    const chain = db as unknown as Chain;
+    expect(chain.insert.mock.calls).toHaveLength(0); // no acceptance/invoice written
+    expect(chain.set.mock.calls).toHaveLength(0);    // no update issued
+  });
+
+  it('a consumed row with a DIFFERENT jti does not trip the backstop (falls through to the status guard)', async () => {
+    queueResult([{
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'converted',
+      expiryDate: null, quoteNumber: 'Q-2026-0001', taxRate: null,
+      currencyCode: 'USD', siteId: null,
+      publicResponseJti: 'jti-someone-else',
+      publicResponseConsumedAt: new Date('2026-07-27T00:00:00Z'),
+      publicResponseOutcome: 'declined',
+    }]);
+
+    await expect(acceptQuote({ ...baseParams, acceptanceTokenJti: 'jti-durable-1' }))
+      .rejects.toMatchObject({ status: 409, code: 'INVALID_STATE' });
+  });
+
   it('stages Phase 5 before the final quote read and exposes the order id', async () => {
     const { quote, line } = queueAcceptHappyPath();
     stagePax8OrderFromQuoteMock.mockResolvedValue({ orderId: 'pax8-order-1', lineCount: 1 });

--- a/apps/api/src/services/quoteAcceptService.test.ts
+++ b/apps/api/src/services/quoteAcceptService.test.ts
@@ -207,6 +207,40 @@ describe('acceptQuote deposit snapshot', () => {
     expect(chain.set.mock.calls).toHaveLength(0);    // no update issued
   });
 
+  // v1 forward-compat guard: once public_token_version=1 rows exist (jti
+  // persisted at send), only the issued jti may consume — a different signed
+  // token must never claim/rewrite the stored jti.
+  it('v1 row with a mismatched jti → 401 RESPONSE_CONSUMED, nothing written', async () => {
+    queueResult([{
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent',
+      expiryDate: null, quoteNumber: 'Q-2026-0001', taxRate: null,
+      currencyCode: 'USD', siteId: null,
+      publicTokenVersion: 1, publicResponseJti: 'jti-issued-at-send',
+      publicResponseConsumedAt: null, publicResponseOutcome: null,
+    }]);
+
+    await expect(acceptQuote({ ...baseParams, acceptanceTokenJti: 'jti-forged' }))
+      .rejects.toMatchObject({ status: 401, code: 'RESPONSE_CONSUMED' });
+
+    const chain = db as unknown as Chain;
+    expect(chain.insert.mock.calls).toHaveLength(0);
+    expect(chain.set.mock.calls).toHaveLength(0);
+  });
+
+  it('v1 row with the ISSUED jti proceeds and consumes normally', async () => {
+    queueAcceptHappyPath({ publicTokenVersion: 1, publicResponseJti: 'jti-issued-at-send', publicResponseConsumedAt: null });
+
+    await acceptQuote({ ...baseParams, acceptanceTokenJti: 'jti-issued-at-send' });
+
+    const setMock = (db as unknown as Chain).set;
+    const quotesSet = setMock.mock.calls[1]![0] as Record<string, unknown>;
+    expect(quotesSet).toMatchObject({
+      status: 'converted',
+      publicResponseJti: 'jti-issued-at-send',
+      publicResponseOutcome: 'accepted',
+    });
+  });
+
   it('a consumed row with a DIFFERENT jti does not trip the backstop (falls through to the status guard)', async () => {
     queueResult([{
       id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'converted',

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -89,6 +89,18 @@ export async function acceptQuote(
   ) {
     throw new QuoteServiceError('This link is invalid or has expired', 401, 'RESPONSE_CONSUMED');
   }
+  // Forward-compat guard for the wave-3 v1 model (response jti persisted at
+  // send with public_token_version=1): a version-1 row may only ever be
+  // consumed by the exact jti it was issued with — a different signed token
+  // must never claim or rewrite the stored response jti. Inert for today's
+  // version-0 rows.
+  if (
+    params.acceptanceTokenJti
+    && (quote.publicTokenVersion ?? 0) !== 0
+    && quote.publicResponseJti !== params.acceptanceTokenJti
+  ) {
+    throw new QuoteServiceError('This link is invalid or has expired', 401, 'RESPONSE_CONSUMED');
+  }
   if (quote.status !== 'sent' && quote.status !== 'viewed') {
     throw new QuoteServiceError(`Cannot accept a quote in status ${quote.status}`, 409, 'INVALID_STATE');
   }

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -77,6 +77,18 @@ export async function acceptQuote(
   // both pass the status guard and each create an invoice (atom-1/C2).
   const [quote] = await db.select().from(quotes).where(eq(quotes.id, params.quoteId)).for('update').limit(1);
   if (!quote) throw new QuoteServiceError('Quote not found', 404, 'QUOTE_NOT_FOUND');
+  // Durable single-use backstop (#2875, wave-3 schema 2026-08-06-c): a
+  // token-based response whose jti was already consumed on this row is a
+  // replay — even when the Redis revocation marker was lost (flush/failover/
+  // TTL). Checked BEFORE the status guard and with a 401 (not 409) so a
+  // replayed link fails exactly like the Redis resolve() gate does.
+  if (
+    params.acceptanceTokenJti
+    && quote.publicResponseConsumedAt != null
+    && quote.publicResponseJti === params.acceptanceTokenJti
+  ) {
+    throw new QuoteServiceError('This link is invalid or has expired', 401, 'RESPONSE_CONSUMED');
+  }
   if (quote.status !== 'sent' && quote.status !== 'viewed') {
     throw new QuoteServiceError(`Cannot accept a quote in status ${quote.status}`, 409, 'INVALID_STATE');
   }
@@ -252,6 +264,19 @@ export async function acceptQuote(
       convertedAt: now,
       convertedInvoiceId: invoice!.id,
       updatedAt: now,
+      // Durable response-capability consumption (#2875): for a token-based
+      // (public) accept, claim + consume the response jti in the SAME
+      // transaction as the status change. Redis stays the hot-path revocation
+      // check; these columns are the durable authority a Redis flush cannot
+      // erase. Portal accepts carry no token and leave them NULL — the quote
+      // status machine already blocks any later public response.
+      ...(params.acceptanceTokenJti
+        ? {
+            publicResponseJti: params.acceptanceTokenJti,
+            publicResponseConsumedAt: now,
+            publicResponseOutcome: 'accepted',
+          }
+        : {}),
     })
     .where(eq(quotes.id, quote.id));
 

--- a/apps/api/src/services/quoteTypes.ts
+++ b/apps/api/src/services/quoteTypes.ts
@@ -42,6 +42,11 @@ export type QuoteServiceErrorCode =
   // partner). Any violation collapses to this single 422 code.
   | 'INVALID_CONTRACT_TEMPLATE'
   | 'INVALID_STATE'
+  // Durable single-use replay backstop (#2875, quoteAcceptService): the public
+  // response token's jti was already consumed on the quote row (2026-08-06-c
+  // columns) — a replayed link, rejected 401 even when the Redis revocation
+  // marker has been lost.
+  | 'RESPONSE_CONSUMED'
   | 'QUOTE_EXPIRED'
   | 'NOT_CONVERTED'
   | 'REORDER_IDS_MISMATCH'
@@ -72,7 +77,7 @@ export type QuoteServiceErrorCode =
 export class QuoteServiceError extends Error {
   constructor(
     message: string,
-    public status: 400 | 403 | 404 | 409 | 410 | 422 | 500 = 400,
+    public status: 400 | 401 | 403 | 404 | 409 | 410 | 422 | 500 = 400,
     public code?: QuoteServiceErrorCode
   ) {
     super(message);

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -179,8 +179,23 @@ export async function apiRequest<T>(
     });
 
     if (response.status === 401) {
+      // Callers that opt out of the login redirect (the public token-gated
+      // quote routes, SSR forwarding) are NOT session-authed: a 401 there is
+      // about the request's own credential (e.g. a consumed/replayed quote
+      // link, #2875), not the portal session. Don't wipe a logged-in user's
+      // auth state over it, and surface the API's real error body instead of
+      // the hardcoded session message.
+      if (config.redirectOnUnauthorized === false) {
+        const body = await response.json().catch(() => ({}));
+        return {
+          error: body?.error || 'Session expired',
+          code: typeof body?.code === 'string' ? body.code : undefined,
+          statusCode: response.status,
+          headers: response.headers
+        };
+      }
       clearAuth();
-      if (config.redirectOnUnauthorized !== false && typeof window !== 'undefined') {
+      if (typeof window !== 'undefined') {
         void navigateTo('/login', { replace: true });
       }
       return {


### PR DESCRIPTION
## Summary

Wave 3 (#2841) shipped the `2026-08-06-c-quote-response-capability.sql` schema (`quotes.public_response_jti/consumed_at/outcome`, `public_token_version`, `public_link_revoked_at`) but not its runtime writer — public quote accept/decline single-use enforcement rested entirely on the Redis `quote-accept-jti-revoked:<jti>` marker, so a Redis flush/failover within the marker's window reopened replay of a public response.

This wires the version-0 consume writer the migration header itself describes ("The first response claims and consumes its signed JTI transactionally") and uses the columns as a durable replay backstop:

- **`acceptQuote`** (`apps/api/src/services/quoteAcceptService.ts`): a token-based (public) accept claims + consumes the response jti in the **same `quotes` UPDATE** that flips `status → converted`. Portal accepts (no token) leave the columns NULL — the status machine already blocks later public responses.
- **Durable backstop, accept**: before the status guard, an `acceptanceTokenJti` that matches an already-consumed `public_response_jti` throws **401 `RESPONSE_CONSUMED`** — same failure shape as the Redis `resolve()` gate — even when the Redis marker is gone.
- **Public decline** (`apps/api/src/routes/quotesPublic.ts`): consumes the capability (`outcome='declined'`) atomically in the decline UPDATE, checks the durable columns before the status guard, and now re-asserts the `sent/viewed` guard in the UPDATE's `WHERE` (+ `RETURNING`) so a concurrent accept that committed after the unlocked read can no longer be overwritten.
- **Redis unchanged**: it stays the hot-path revocation check (`resolve()` gate on all public routes); the DB columns are the durable authority. Public GET/asset routes are untouched, consistent with the wave-3 plan's "read capability stays usable" intent.

### Intent check (per the issue)

The wave-3 plan's fuller design (`quoteResponseCapability.ts`, `QUOTE_RESPONSE_CAPABILITY_MODE`, v1 persist-jti-at-send + fleet-atomic cutover) was **not** implemented in #2841 — only the schema landed. This PR implements the v0 consume semantics the migration header explicitly reserves for existing links, and is forward-compatible with the v1 model: `public_token_version` stays 0, the v1 CHECK constraints are untouched, and a mixed fleet is monotone-safe (old instances keep Redis-only behavior; Redis remains primary everywhere).

## Tests

- `quoteAcceptService.test.ts`: writer emits the three columns in the converted UPDATE (public), omits them (portal); consumed-jti replay → 401 `RESPONSE_CONSUMED` with zero writes; different-jti consumed row falls through to the status guard (409).
- `quotesPublic.test.ts`: decline writes the columns atomically; decline/accept replay with the Redis marker lost → 401, no writes; 0-row guarded decline UPDATE → 409 (race).
- `quotesPublicRoutes.integration.test.ts` (real Postgres + Redis): accept once → columns written; **delete the Redis jti key** (simulated flush) → replayed accept 401, quote untouched; decline path same, including a cross-route accept replay.

Local: affected unit files 27 passed; integration file 11 passed against docker test DB/Redis; `tsc --noEmit` clean.

Closes #2875

🤖 Generated with [Claude Code](https://claude.com/claude-code)