### PR TITLE
fix(api): offboarding entry self-deadlock — reuse the request transaction (#2877)

### DIFF
--- a/apps/api/src/__tests__/integration/offboardingEntryDeadlock.integration.test.ts
+++ b/apps/api/src/__tests__/integration/offboardingEntryDeadlock.integration.test.ts
@@ -1,0 +1,254 @@
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { deviceCommands, devices, organizations, partners } from '../../db/schema';
+import {
+  abortOrganizationOffboarding,
+  beginOrganizationOffboarding,
+  beginPartnerOffboarding,
+  finalizeOrganizationOffboarding,
+} from '../../services/tenantOffboarding';
+import { revokeOrganizationTenantAccess } from '../../services/tenantLifecycle';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+/**
+ * #2877 — offboarding entry self-deadlock.
+ *
+ * The PATCH /organizations/:id route runs inside the auth middleware's
+ * request transaction: its own `UPDATE organizations ... RETURNING` takes the
+ * org row lock, and begin/abort*Offboarding used to open a FRESH pooled
+ * connection (runOutsideDbContext → withSystemDbAccessContext) that UPDATEd
+ * the SAME row — waiting forever on a lock the request could only release
+ * after the service returned. Postgres cannot detect the cycle (each side is
+ * merely blocked/idle-in-transaction), so the request wedged indefinitely and
+ * killing it tore the entry (status rolled back, side effects committed).
+ *
+ * The mocked unit suite structurally cannot catch this class — it has no
+ * connections, no locks. These tests reproduce the exact route shape against
+ * real Postgres: update the tenant row inside a held access-context
+ * transaction, then invoke the service inside that same context. Under the
+ * old code every one of these hangs until the suite timeout.
+ */
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/** Fails fast with a diagnosis instead of eating the whole 30s test timeout. */
+async function expectNoDeadlock<T>(work: Promise<T>, what: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(
+        `${what} did not complete within 20s — the #2877 request-txn vs fresh-connection ` +
+        'row-lock deadlock is back (same org/partner row updated from two connections).'
+      )),
+      20_000
+    );
+  });
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** The request context the auth middleware builds for a partner-scoped operator. */
+function partnerRequestContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+    currentPartnerId: partnerId,
+    label: 'test.offboardingEntryDeadlock',
+  };
+}
+
+async function seedDevice(orgId: string, siteId: string, label: string): Promise<{ id: string }> {
+  const agentId = `agent-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const [row] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId,
+      siteId,
+      agentId,
+      hostname: `host-${label}`,
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x86_64',
+      agentVersion: '0.0.0-test',
+      status: 'offline',
+    })
+    .returning({ id: devices.id });
+  return { id: row!.id };
+}
+
+async function readOrg(orgId: string) {
+  const [row] = await getTestDb()
+    .select({ status: organizations.status, startedAt: organizations.offboardingStartedAt })
+    .from(organizations)
+    .where(eq(organizations.id, orgId));
+  return row!;
+}
+
+async function readUninstalls(deviceId: string) {
+  return getTestDb()
+    .select({
+      id: deviceCommands.id,
+      status: deviceCommands.status,
+      createdAt: deviceCommands.createdAt,
+      result: deviceCommands.result,
+    })
+    .from(deviceCommands)
+    .where(and(eq(deviceCommands.deviceId, deviceId), eq(deviceCommands.type, 'self_uninstall')));
+}
+
+describe('#2877 offboarding entry inside the request transaction', () => {
+  runDb('org entry completes with the org row already locked by the request txn, atomically', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const device = await seedDevice(org.id, site.id, 'entry');
+
+    // Mirror updateOrgHandler exactly: status UPDATE (row lock) then the
+    // service call, both inside ONE partner-scoped request transaction.
+    await expectNoDeadlock(
+      withDbAccessContext(partnerRequestContext(partner.id, [org.id]), async () => {
+        const [updated] = await db
+          .update(organizations)
+          .set({ status: 'offboarding', updatedAt: new Date() })
+          .where(eq(organizations.id, org.id))
+          .returning({ id: organizations.id });
+        expect(updated?.id).toBe(org.id);
+
+        return beginOrganizationOffboarding(org.id, null);
+      }),
+      'organization offboarding entry'
+    );
+
+    // Everything committed together: status, drain stamp, queued uninstall.
+    const after = await readOrg(org.id);
+    expect(after.status).toBe('offboarding');
+    expect(after.startedAt).not.toBeNull();
+
+    const queued = await readUninstalls(device.id);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.status).toBe('pending');
+
+    // The clock-skew half of #2877: the stamp comes from the DB clock inside
+    // the same transaction as the insert, so the finalize report's
+    // gte(created_at, stamp) window includes the entry's own command.
+    expect(after.startedAt!.getTime()).toBeLessThanOrEqual(queued[0]!.createdAt.getTime());
+  });
+
+  runDb('finalize report counts the drain\'s completed uninstall (no JS/DB clock skew)', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const device = await seedDevice(org.id, site.id, 'report');
+
+    await expectNoDeadlock(
+      withDbAccessContext(partnerRequestContext(partner.id, [org.id]), async () => {
+        await db
+          .update(organizations)
+          .set({ status: 'offboarding', updatedAt: new Date() })
+          .where(eq(organizations.id, org.id));
+        return beginOrganizationOffboarding(org.id, null);
+      }),
+      'organization offboarding entry'
+    );
+
+    // The agent completes its uninstall.
+    await getTestDb()
+      .update(deviceCommands)
+      .set({ status: 'completed', completedAt: new Date() })
+      .where(and(eq(deviceCommands.deviceId, device.id), eq(deviceCommands.type, 'self_uninstall')));
+
+    const report = await withSystemDbAccessContext(() =>
+      finalizeOrganizationOffboarding(org.id, { forcedByDeadline: false })
+    );
+
+    // Pre-fix this reported 0: the JS-clock stamp landed ~ms AFTER the
+    // command's DB-clock created_at, so gte() excluded the drain's own work.
+    expect(report).not.toBeNull();
+    expect(report!.uninstallsCompleted).toBe(1);
+    expect(report!.uninstallsFailed).toBe(0);
+    expect(report!.neverDelivered).toHaveLength(0);
+    expect(report!.deliveredUnconfirmed).toHaveLength(0);
+  });
+
+  runDb('leaving a drain (suspended) completes with the org row locked, and cancels the uninstall', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const device = await seedDevice(org.id, site.id, 'abort');
+
+    // Enter the drain first (request-shaped, as above).
+    await expectNoDeadlock(
+      withDbAccessContext(partnerRequestContext(partner.id, [org.id]), async () => {
+        await db
+          .update(organizations)
+          .set({ status: 'offboarding', updatedAt: new Date() })
+          .where(eq(organizations.id, org.id));
+        return beginOrganizationOffboarding(org.id, null);
+      }),
+      'organization offboarding entry'
+    );
+
+    // Mirror the suspended-transition branch of updateOrgHandler: row UPDATE,
+    // then abort + revoke — abort's stamp-clear hits the same locked row.
+    await expectNoDeadlock(
+      withDbAccessContext(partnerRequestContext(partner.id, [org.id]), async () => {
+        await db
+          .update(organizations)
+          .set({ status: 'suspended', updatedAt: new Date() })
+          .where(eq(organizations.id, org.id));
+        const abort = await abortOrganizationOffboarding(org.id);
+        expect(abort.aborted).toBe(true);
+        await revokeOrganizationTenantAccess(org.id);
+      }),
+      'organization offboarding abort'
+    );
+
+    const after = await readOrg(org.id);
+    expect(after.status).toBe('suspended');
+    expect(after.startedAt).toBeNull();
+
+    const commands = await readUninstalls(device.id);
+    expect(commands).toHaveLength(1);
+    expect(commands[0]!.status).toBe('cancelled');
+    expect((commands[0]!.result as { reason?: string }).reason).toBe('organization_offboarding_aborted');
+  });
+
+  runDb('partner entry completes with the partner row locked by the request txn', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const device = await seedDevice(org.id, site.id, 'partner');
+
+    // PATCH /partners/:id is system-scope; mirror its request transaction.
+    await expectNoDeadlock(
+      withSystemDbAccessContext(async () => {
+        await db
+          .update(partners)
+          .set({ status: 'offboarding', updatedAt: new Date() })
+          .where(eq(partners.id, partner.id));
+        return beginPartnerOffboarding(partner.id, null);
+      }),
+      'partner offboarding entry'
+    );
+
+    const [partnerRow] = await getTestDb()
+      .select({ status: partners.status, startedAt: partners.offboardingStartedAt })
+      .from(partners)
+      .where(eq(partners.id, partner.id));
+    expect(partnerRow!.status).toBe('offboarding');
+    expect(partnerRow!.startedAt).not.toBeNull();
+
+    const queued = await readUninstalls(device.id);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.status).toBe('pending');
+  });
+});

--- a/apps/api/src/__tests__/integration/offboardingEntryDeadlock.integration.test.ts
+++ b/apps/api/src/__tests__/integration/offboardingEntryDeadlock.integration.test.ts
@@ -2,7 +2,13 @@ import './setup';
 
 import { describe, expect, it } from 'vitest';
 import { and, eq } from 'drizzle-orm';
-import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  db,
+  runOutsideDbContext,
+  withDbAccessContext,
+  withSystemDbAccessContext,
+  type DbAccessContext,
+} from '../../db';
 import { deviceCommands, devices, organizations, partners } from '../../db/schema';
 import {
   abortOrganizationOffboarding,
@@ -250,6 +256,52 @@ describe('#2877 offboarding entry inside the request transaction', () => {
     expect(commands).toHaveLength(1);
     expect(commands[0]!.status).toBe('cancelled');
     expect((commands[0]!.result as { reason?: string }).reason).toBe('organization_offboarding_aborted');
+  });
+
+  runDb('#2879 override shape: entry works when the ambient context cannot see the org', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'suspended' });
+    const site = await createSite({ orgId: org.id });
+    const device = await seedDevice(org.id, site.id, 'override');
+
+    // Mirror updateOrgHandler's suspended-lifecycle override (#2887): the
+    // suspended org is EXCLUDED from the request context's allowlist, so the
+    // route runs its status UPDATE on a short system-scoped connection and
+    // the ambient partner transaction never touches (or even sees) the row.
+    // The service must therefore NOT reuse the ambient transaction — a
+    // partner-scoped stamp UPDATE would silently match zero rows — and its
+    // fresh system context is deadlock-free because no ambient lock exists.
+    await expectNoDeadlock(
+      withDbAccessContext(partnerRequestContext(partner.id, [/* org NOT visible */]), async () => {
+        const [updated] = await runOutsideDbContext(() =>
+          withSystemDbAccessContext(async () =>
+            db
+              .update(organizations)
+              .set({ status: 'offboarding', updatedAt: new Date() })
+              .where(and(
+                eq(organizations.id, org.id),
+                eq(organizations.partnerId, partner.id),
+                eq(organizations.status, 'suspended')
+              ))
+              .returning({ id: organizations.id })
+          )
+        );
+        expect(updated?.id).toBe(org.id);
+
+        return beginOrganizationOffboarding(org.id, null);
+      }),
+      'organization offboarding entry (suspended-lifecycle override)'
+    );
+
+    // The entry's side effects landed despite the caller's blind allowlist:
+    // stamp set and the uninstall queued (via the system-context fallback).
+    const after = await readOrg(org.id);
+    expect(after.status).toBe('offboarding');
+    expect(after.startedAt).not.toBeNull();
+
+    const queued = await readUninstalls(device.id);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]!.status).toBe('pending');
   });
 
   runDb('partner entry completes with the partner row locked by the request txn', async () => {

--- a/apps/api/src/__tests__/integration/offboardingEntryDeadlock.integration.test.ts
+++ b/apps/api/src/__tests__/integration/offboardingEntryDeadlock.integration.test.ts
@@ -143,6 +143,36 @@ describe('#2877 offboarding entry inside the request transaction', () => {
     expect(after.startedAt!.getTime()).toBeLessThanOrEqual(queued[0]!.createdAt.getTime());
   });
 
+  runDb('a failure after entry, before commit, rolls back status + stamp + uninstalls together', async () => {
+    const partner = await createPartner({ status: 'active' });
+    const org = await createOrganization({ partnerId: partner.id, status: 'active' });
+    const site = await createSite({ orgId: org.id });
+    const device = await seedDevice(org.id, site.id, 'rollback');
+
+    // The atomicity half of #2877: if any part of the drain work (stamp,
+    // command cancel, self_uninstall insert) ever moves back onto its own
+    // connection, it would COMMIT here despite the request transaction
+    // rolling back — leaving pending self_uninstalls against an org whose
+    // status reverted to active. This is the torn state QA observed, in the
+    // worst direction, and the deadlock tests alone cannot catch it (a
+    // fresh-connection INSERT takes no conflicting lock).
+    await expect(
+      withDbAccessContext(partnerRequestContext(partner.id, [org.id]), async () => {
+        await db
+          .update(organizations)
+          .set({ status: 'offboarding', updatedAt: new Date() })
+          .where(eq(organizations.id, org.id));
+        await beginOrganizationOffboarding(org.id, null);
+        throw new Error('simulated post-entry handler failure');
+      })
+    ).rejects.toThrow('simulated post-entry handler failure');
+
+    const after = await readOrg(org.id);
+    expect(after.status).toBe('active');
+    expect(after.startedAt).toBeNull();
+    expect(await readUninstalls(device.id)).toHaveLength(0);
+  });
+
   runDb('finalize report counts the drain\'s completed uninstall (no JS/DB clock skew)', async () => {
     const partner = await createPartner({ status: 'active' });
     const org = await createOrganization({ partnerId: partner.id, status: 'active' });

--- a/apps/api/src/routes/organizations.test.ts
+++ b/apps/api/src/routes/organizations.test.ts
@@ -40,6 +40,12 @@ vi.mock('../db', () => {
     withDbAccessContext: vi.fn(async (_ctx: any, fn: any) => fn()),
     withSystemDbAccessContext: vi.fn(async (fn: any) => fn()),
     runOutsideDbContext: vi.fn((fn: any) => fn()),
+    // tenantOffboarding's inCallerOrSystemDbContext (#2877) consults the
+    // ambient-context metadata at runtime on the DELETE partner/org paths
+    // (abort*Offboarding); undefined = no ambient context → fresh system
+    // context, matching this file's transactionless mock shape.
+    getCurrentDbAccessContext: vi.fn(() => undefined),
+    hasDbAccessContext: vi.fn(() => false),
     SYSTEM_DB_ACCESS_CONTEXT: { scope: 'system', orgId: null, accessibleOrgIds: null }
   };
 });

--- a/apps/api/src/services/tenantOffboarding.test.ts
+++ b/apps/api/src/services/tenantOffboarding.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 const { selectMock, updateMock, insertMock, hasDbAccessContextMock } = vi.hoisted(() => ({
   selectMock: vi.fn(),
@@ -280,8 +280,16 @@ describe('#2877 ambient request-transaction reuse', () => {
     setupWrites();
   });
 
+  // mockReturnValue (not Once): a second inCallerOrSystemDbContext call site
+  // inside the same flow must also see the ambient context, not silently fall
+  // to the system branch mid-test. Restored here so it can't leak into the
+  // background-caller suites.
+  afterEach(() => {
+    hasDbAccessContextMock.mockReturnValue(false);
+  });
+
   it('entry runs on the ambient context — no fresh connection is opened', async () => {
-    hasDbAccessContextMock.mockReturnValueOnce(true);
+    hasDbAccessContextMock.mockReturnValue(true);
     queueSelect([]); // devices
 
     await beginOrganizationOffboarding('org-1', 'user-1');
@@ -293,7 +301,7 @@ describe('#2877 ambient request-transaction reuse', () => {
   });
 
   it('abort runs on the ambient context — no fresh connection is opened', async () => {
-    hasDbAccessContextMock.mockReturnValueOnce(true);
+    hasDbAccessContextMock.mockReturnValue(true);
     updateReturningQueue.push([{ id: 'org-1' }]); // stamp-clear finds a stamp
     queueSelect([{ id: 'd1' }]); // devices in org
     updateReturningQueue.push([{ id: 'cmd-1' }]); // cancelled commands

--- a/apps/api/src/services/tenantOffboarding.test.ts
+++ b/apps/api/src/services/tenantOffboarding.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-const { selectMock, updateMock, insertMock } = vi.hoisted(() => ({
+const { selectMock, updateMock, insertMock, hasDbAccessContextMock } = vi.hoisted(() => ({
   selectMock: vi.fn(),
   updateMock: vi.fn(),
   insertMock: vi.fn(),
+  // #2877 — default false (background-caller shape). Ambient-context tests
+  // flip it with mockReturnValueOnce so nothing leaks across tests.
+  hasDbAccessContextMock: vi.fn(() => false),
 }));
 
 vi.mock('../db', () => {
@@ -15,6 +18,7 @@ vi.mock('../db', () => {
       // transaction; the tx handle proxies to the same mocked surface.
       transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(surface)),
     },
+    hasDbAccessContext: hasDbAccessContextMock,
     runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
     withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   };
@@ -103,8 +107,14 @@ vi.mock('drizzle-orm', () => ({
   isNull: vi.fn((c) => ({ isNull: c })),
   isNotNull: vi.fn((c) => ({ isNotNull: c })),
   ne: vi.fn((l, r) => ({ ne: [l, r] })),
+  // Tagged-template tag: sql`now()` → { sql: 'now()' } (see DB_NOW, #2877).
+  sql: vi.fn((strings: TemplateStringsArray) => ({ sql: strings.join('') })),
 }));
 
+// The marker DB_NOW (sql`now()`) resolves to under the drizzle-orm mock above.
+const SQL_NOW = { sql: 'now()' };
+
+import { runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceCommands, devices, organizations, partners } from '../db/schema';
 import { writeAuditEvent } from './auditEvents';
 import {
@@ -195,7 +205,9 @@ describe('beginOrganizationOffboarding', () => {
     await beginOrganizationOffboarding('org-1', 'user-1');
 
     const stamp = updatesFor(organizations)[0]!;
-    expect(stamp.values.offboardingStartedAt).toBeInstanceOf(Date);
+    // DB clock, not new Date(): the finalize report's gte(created_at, stamp)
+    // window must include the entry's own commands (#2877 clock skew).
+    expect(stamp.values.offboardingStartedAt).toEqual(SQL_NOW);
     expect(JSON.stringify(stamp.where)).toContain('isNull');
   });
 
@@ -251,9 +263,55 @@ describe('beginPartnerOffboarding', () => {
     const result = await beginPartnerOffboarding('partner-1', 'user-1');
 
     expect(revokePartnerTenantAccess).toHaveBeenCalledWith('partner-1', { agentChannel: 'drain' });
-    expect(updatesFor(partners)[0]!.values.offboardingStartedAt).toBeInstanceOf(Date);
+    expect(updatesFor(partners)[0]!.values.offboardingStartedAt).toEqual(SQL_NOW);
     expect(insertLog[0]!.rows[0]).toMatchObject({ deviceId: 'd1', type: 'self_uninstall' });
     expect(result.uninstallsQueued).toBe(1);
+  });
+});
+
+// #2877 — the route callers run inside the auth middleware's request
+// transaction, which already holds the org/partner row lock from the route's
+// own status UPDATE. Entry/abort must reuse that ambient transaction (same
+// connection, atomic commit) instead of opening a fresh system-context
+// connection that would wait on the lock forever.
+describe('#2877 ambient request-transaction reuse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupWrites();
+  });
+
+  it('entry runs on the ambient context — no fresh connection is opened', async () => {
+    hasDbAccessContextMock.mockReturnValueOnce(true);
+    queueSelect([]); // devices
+
+    await beginOrganizationOffboarding('org-1', 'user-1');
+
+    expect(runOutsideDbContext).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContext).not.toHaveBeenCalled();
+    // The drain work itself still happened, on the ambient transaction.
+    expect(updatesFor(organizations)).toHaveLength(1);
+  });
+
+  it('abort runs on the ambient context — no fresh connection is opened', async () => {
+    hasDbAccessContextMock.mockReturnValueOnce(true);
+    updateReturningQueue.push([{ id: 'org-1' }]); // stamp-clear finds a stamp
+    queueSelect([{ id: 'd1' }]); // devices in org
+    updateReturningQueue.push([{ id: 'cmd-1' }]); // cancelled commands
+
+    const result = await abortOrganizationOffboarding('org-1');
+
+    expect(result.aborted).toBe(true);
+    expect(runOutsideDbContext).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContext).not.toHaveBeenCalled();
+  });
+
+  it('background callers (no ambient context) still get a fresh system context', async () => {
+    queueSelect([]); // devices
+
+    await beginOrganizationOffboarding('org-1', null);
+
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -517,7 +575,7 @@ describe('sweepOffboardingTenants', () => {
     expect(result.orgsFinalized).toBe(0);
     expect(insertLog[0]!.rows[0]).toMatchObject({ deviceId: 'd1', type: 'self_uninstall' });
     const stamp = updatesFor(organizations)[0]!;
-    expect(stamp.values.offboardingStartedAt).toBe(NOW);
+    expect(stamp.values.offboardingStartedAt).toEqual(SQL_NOW);
     expect(writeAuditEvent).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ action: 'organization.offboarding_entry_repaired' })

--- a/apps/api/src/services/tenantOffboarding.test.ts
+++ b/apps/api/src/services/tenantOffboarding.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-const { selectMock, updateMock, insertMock, hasDbAccessContextMock } = vi.hoisted(() => ({
+const { selectMock, updateMock, insertMock, getCurrentDbAccessContextMock } = vi.hoisted(() => ({
   selectMock: vi.fn(),
   updateMock: vi.fn(),
   insertMock: vi.fn(),
-  // #2877 — default false (background-caller shape). Ambient-context tests
-  // flip it with mockReturnValueOnce so nothing leaks across tests.
-  hasDbAccessContextMock: vi.fn(() => false),
+  // #2877 — default undefined (no ambient context; background-caller shape).
+  // Ambient-context tests set a context object and restore in afterEach.
+  getCurrentDbAccessContextMock: vi.fn<() => Record<string, unknown> | undefined>(() => undefined),
 }));
 
 vi.mock('../db', () => {
@@ -18,7 +18,7 @@ vi.mock('../db', () => {
       // transaction; the tx handle proxies to the same mocked surface.
       transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(surface)),
     },
-    hasDbAccessContext: hasDbAccessContextMock,
+    getCurrentDbAccessContext: getCurrentDbAccessContextMock,
     runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
     withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   };
@@ -273,8 +273,19 @@ describe('beginPartnerOffboarding', () => {
 // transaction, which already holds the org/partner row lock from the route's
 // own status UPDATE. Entry/abort must reuse that ambient transaction (same
 // connection, atomic commit) instead of opening a fresh system-context
-// connection that would wait on the lock forever.
+// connection that would wait on the lock forever — but ONLY when the ambient
+// context can actually SEE the target row (#2879's suspended-lifecycle
+// override runs the status UPDATE on its own system connection precisely
+// because the org is outside the caller's allowlist; reusing the ambient
+// partner scope there would silently 0-row the stamp).
 describe('#2877 ambient request-transaction reuse', () => {
+  const PARTNER_AMBIENT = {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: ['org-1'],
+    accessiblePartnerIds: ['partner-1'],
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     setupWrites();
@@ -285,11 +296,11 @@ describe('#2877 ambient request-transaction reuse', () => {
   // to the system branch mid-test. Restored here so it can't leak into the
   // background-caller suites.
   afterEach(() => {
-    hasDbAccessContextMock.mockReturnValue(false);
+    getCurrentDbAccessContextMock.mockReturnValue(undefined);
   });
 
-  it('entry runs on the ambient context — no fresh connection is opened', async () => {
-    hasDbAccessContextMock.mockReturnValue(true);
+  it('entry runs on the ambient context when it can see the org — no fresh connection', async () => {
+    getCurrentDbAccessContextMock.mockReturnValue(PARTNER_AMBIENT);
     queueSelect([]); // devices
 
     await beginOrganizationOffboarding('org-1', 'user-1');
@@ -300,8 +311,8 @@ describe('#2877 ambient request-transaction reuse', () => {
     expect(updatesFor(organizations)).toHaveLength(1);
   });
 
-  it('abort runs on the ambient context — no fresh connection is opened', async () => {
-    hasDbAccessContextMock.mockReturnValue(true);
+  it('abort runs on the ambient context when it can see the org — no fresh connection', async () => {
+    getCurrentDbAccessContextMock.mockReturnValue(PARTNER_AMBIENT);
     updateReturningQueue.push([{ id: 'org-1' }]); // stamp-clear finds a stamp
     queueSelect([{ id: 'd1' }]); // devices in org
     updateReturningQueue.push([{ id: 'cmd-1' }]); // cancelled commands
@@ -311,6 +322,43 @@ describe('#2877 ambient request-transaction reuse', () => {
     expect(result.aborted).toBe(true);
     expect(runOutsideDbContext).not.toHaveBeenCalled();
     expect(withSystemDbAccessContext).not.toHaveBeenCalled();
+  });
+
+  it('partner entry reuses a system-scope ambient context (partner routes are system-only)', async () => {
+    getCurrentDbAccessContextMock.mockReturnValue({
+      scope: 'system',
+      orgId: null,
+      accessibleOrgIds: null,
+      accessiblePartnerIds: null,
+    });
+    queueSelect([{ id: 'org-1' }]); // orgs under partner
+    queueSelect([]); // devices
+
+    await beginPartnerOffboarding('partner-1', null);
+
+    expect(runOutsideDbContext).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContext).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a fresh system context when the ambient context cannot see the org (#2879 override)', async () => {
+    // The suspended-lifecycle override: partner-scope request whose allowlist
+    // EXCLUDES the (suspended) org. The route already ran its status UPDATE on
+    // a separate system connection, so the ambient tx holds no row lock and
+    // the fresh system context is both safe and required for RLS visibility.
+    getCurrentDbAccessContextMock.mockReturnValue({
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: ['some-other-org'],
+      accessiblePartnerIds: ['partner-1'],
+    });
+    queueSelect([]); // devices
+
+    await beginOrganizationOffboarding('org-1', null);
+
+    expect(runOutsideDbContext).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContext).toHaveBeenCalledTimes(1);
+    // The stamp write still happened — under the system context.
+    expect(updatesFor(organizations)).toHaveLength(1);
   });
 
   it('callers with no ambient context still get a fresh system context', async () => {

--- a/apps/api/src/services/tenantOffboarding.test.ts
+++ b/apps/api/src/services/tenantOffboarding.test.ts
@@ -313,7 +313,7 @@ describe('#2877 ambient request-transaction reuse', () => {
     expect(withSystemDbAccessContext).not.toHaveBeenCalled();
   });
 
-  it('background callers (no ambient context) still get a fresh system context', async () => {
+  it('callers with no ambient context still get a fresh system context', async () => {
     queueSelect([]); // devices
 
     await beginOrganizationOffboarding('org-1', null);
@@ -575,6 +575,7 @@ describe('sweepOffboardingTenants', () => {
   // indistinguishable from a clean drain (the #2774 false-confidence bug).
   it('repairs an incomplete entry (queues uninstalls) instead of finalizing it', async () => {
     queueCandidates([{ id: 'org-1', startedAt: null }], []);
+    queueSelect([{ id: 'org-1' }]); // tenant row FOR UPDATE (lock-order guard, #2877)
     queueSelect([{ id: 'd1' }]); // devices to queue
     queueSelect([]); // no existing uninstalls
 
@@ -601,6 +602,7 @@ describe('sweepOffboardingTenants', () => {
       return { enrollmentKeysInvalidated: 0, agentTokensRestored: 0 };
     });
     queueCandidates([{ id: 'org-1', startedAt: null }], []);
+    queueSelect([{ id: 'org-1' }]); // tenant row FOR UPDATE (lock-order guard, #2877)
     queueSelect([{ id: 'd1' }]); // devices to queue
     queueSelect([]); // no existing uninstalls
 

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -1,5 +1,5 @@
-import { and, eq, gte, inArray, isNotNull, isNull, ne } from 'drizzle-orm';
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { and, eq, gte, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
+import { db, hasDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceCommands, devices, organizations, partners } from '../db/schema';
 import { requestLikeFromSnapshot, writeAuditEvent } from './auditEvents';
 import { captureException } from './sentry';
@@ -36,6 +36,56 @@ const RAW_WINDOW_HOURS = envInt('OFFBOARDING_DRAIN_WINDOW_HOURS', 72);
 export const OFFBOARDING_DRAIN_WINDOW_HOURS = RAW_WINDOW_HOURS >= 1 ? RAW_WINDOW_HOURS : 72;
 
 const NON_TERMINAL_COMMAND_STATUSES = ['pending', 'sent'] as const;
+
+/**
+ * #2877 — run entry/abort DB work on the CALLER's transaction when one is
+ * active; only open a fresh system context when there is none.
+ *
+ * The org/partner status routes call the begin/abort functions AFTER `UPDATE ...
+ * RETURNING` on the very organizations/partners row, inside the request
+ * transaction the auth middleware wraps around the whole handler. The old
+ * shape here — `runOutsideDbContext(() => withSystemDbAccessContext(fn))` —
+ * opened a SECOND pooled connection and UPDATEd the SAME row, which then
+ * waited forever on the request transaction's row lock while the request
+ * could not commit until this function returned: a cross-connection cycle
+ * Postgres's deadlock detector cannot see (each side looks merely blocked /
+ * idle-in-transaction). Killing the wedged request tore the entry — the
+ * status write rolled back while the fresh connection's side effects
+ * committed.
+ *
+ * Reusing the ambient transaction removes the second connection (no lock to
+ * wait on) AND makes the transition atomic: status + drain stamp + queued/
+ * cancelled uninstalls commit or roll back together, so the torn state is
+ * unreachable.
+ *
+ * RLS: on the ambient path the work runs under the CALLER's scope, not
+ * system. That is sufficient by construction for every route caller: it only
+ * reaches this function after its own UPDATE on the same organizations/
+ * partners row succeeded under that scope (so the stamp UPDATE passes the
+ * identical policy), the org's devices are covered by the same org
+ * allowlist, and device_commands is intentionally unscoped (see the
+ * rls-coverage allowlist). Background callers (drain reaper, jobs) have no
+ * ambient context and keep the fresh system context, exactly as before.
+ */
+function inCallerOrSystemDbContext<T>(fn: () => Promise<T>): Promise<T> {
+  if (hasDbAccessContext()) {
+    return fn();
+  }
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+}
+
+/**
+ * The drain stamp must come from the DATABASE clock, not `new Date()`:
+ * `collectAndCancelOutstanding` scopes the finalize report's terminal counts
+ * with `gte(device_commands.created_at, stamp)`, and `created_at` defaults to
+ * the DB's `now()`. A JS-clock stamp written in the same transaction lands a
+ * couple of ms AFTER the transaction's `now()`, so every uninstall queued at
+ * entry fell just outside the window and `offboarding_completed` reported
+ * `uninstallsCompleted: 0` despite a completed drain (#2877). Inside one
+ * transaction `now()` is constant, so stamp == created_at and `gte` includes
+ * the entry's own commands.
+ */
+const DB_NOW = sql`now()`;
 
 export interface OffboardingEntryResult {
   revocation: TenantRevocationResult;
@@ -150,21 +200,25 @@ export async function beginOrganizationOffboarding(
   actorUserId: string | null
 ): Promise<OffboardingEntryResult> {
   // Users/API keys/OAuth out immediately; agent channel kept (drain mode).
+  // This runs on its own short system contexts BEFORE the ambient-transaction
+  // work below: it never writes the organizations row (no lock conflict with
+  // the route's held request transaction), and its non-DB side effects
+  // (session/WS teardown, Redis) could not be transactional anyway. It is
+  // idempotent, so a rollback of the request transaction is recoverable by
+  // retrying the PATCH (or by reactivation's restore path).
   const revocation = await revokeOrganizationTenantAccess(orgId, { agentChannel: 'drain' });
 
-  return runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      // Preserve the original start on re-entry so a repeated PATCH can't
-      // extend the drain window indefinitely.
-      await db
-        .update(organizations)
-        .set({ offboardingStartedAt: new Date(), updatedAt: new Date() })
-        .where(and(eq(organizations.id, orgId), isNull(organizations.offboardingStartedAt)));
+  return inCallerOrSystemDbContext(async () => {
+    // Preserve the original start on re-entry so a repeated PATCH can't
+    // extend the drain window indefinitely.
+    await db
+      .update(organizations)
+      .set({ offboardingStartedAt: DB_NOW, updatedAt: new Date() })
+      .where(and(eq(organizations.id, orgId), isNull(organizations.offboardingStartedAt)));
 
-      const queued = await queueDrainUninstalls([orgId], actorUserId);
-      return { revocation, ...queued };
-    })
-  );
+    const queued = await queueDrainUninstalls([orgId], actorUserId);
+    return { revocation, ...queued };
+  });
 }
 
 export async function beginPartnerOffboarding(
@@ -173,22 +227,23 @@ export async function beginPartnerOffboarding(
 ): Promise<OffboardingEntryResult> {
   const revocation = await revokePartnerTenantAccess(partnerId, { agentChannel: 'drain' });
 
-  return runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      await db
-        .update(partners)
-        .set({ offboardingStartedAt: new Date(), updatedAt: new Date() })
-        .where(and(eq(partners.id, partnerId), isNull(partners.offboardingStartedAt)));
+  // Ambient-path RLS note: the partner status routes are system-scope only
+  // (requireScope('system')), so the org enumeration below sees every org
+  // under the partner even when run on the request transaction.
+  return inCallerOrSystemDbContext(async () => {
+    await db
+      .update(partners)
+      .set({ offboardingStartedAt: DB_NOW, updatedAt: new Date() })
+      .where(and(eq(partners.id, partnerId), isNull(partners.offboardingStartedAt)));
 
-      const orgRows = await db
-        .select({ id: organizations.id })
-        .from(organizations)
-        .where(eq(organizations.partnerId, partnerId));
+    const orgRows = await db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.partnerId, partnerId));
 
-      const queued = await queueDrainUninstalls(orgRows.map((row) => row.id), actorUserId);
-      return { revocation, ...queued };
-    })
-  );
+    const queued = await queueDrainUninstalls(orgRows.map((row) => row.id), actorUserId);
+    return { revocation, ...queued };
+  });
 }
 
 /**
@@ -238,51 +293,51 @@ async function cancelDrainUninstallsForOrgIds(orgIds: string[], reason: string):
  * churning. Reactivate the PARTNER to abort a partner-level drain.
  */
 export async function abortOrganizationOffboarding(orgId: string): Promise<OffboardingAbortResult> {
-  return runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      const cleared = await db
-        .update(organizations)
-        .set({ offboardingStartedAt: null, updatedAt: new Date() })
-        .where(and(eq(organizations.id, orgId), isNotNull(organizations.offboardingStartedAt)))
-        .returning({ id: organizations.id });
+  // Same #2877 structure as entry: the suspended/churned/active transition
+  // routes (and DELETE /organizations/:id) call this right after UPDATEing the
+  // same organizations row in the request transaction, so the stamp-clear must
+  // run on that transaction, not a fresh connection.
+  return inCallerOrSystemDbContext(async () => {
+    const cleared = await db
+      .update(organizations)
+      .set({ offboardingStartedAt: null, updatedAt: new Date() })
+      .where(and(eq(organizations.id, orgId), isNotNull(organizations.offboardingStartedAt)))
+      .returning({ id: organizations.id });
 
-      if (cleared.length === 0) return { aborted: false, uninstallsCancelled: 0 };
+    if (cleared.length === 0) return { aborted: false, uninstallsCancelled: 0 };
 
-      const uninstallsCancelled = await cancelDrainUninstallsForOrgIds(
-        [orgId],
-        'organization_offboarding_aborted'
-      );
-      await invalidateAgentTenantCache([orgId]);
-      return { aborted: true, uninstallsCancelled };
-    })
-  );
+    const uninstallsCancelled = await cancelDrainUninstallsForOrgIds(
+      [orgId],
+      'organization_offboarding_aborted'
+    );
+    await invalidateAgentTenantCache([orgId]);
+    return { aborted: true, uninstallsCancelled };
+  });
 }
 
 export async function abortPartnerOffboarding(partnerId: string): Promise<OffboardingAbortResult> {
-  return runOutsideDbContext(() =>
-    withSystemDbAccessContext(async () => {
-      const cleared = await db
-        .update(partners)
-        .set({ offboardingStartedAt: null, updatedAt: new Date() })
-        .where(and(eq(partners.id, partnerId), isNotNull(partners.offboardingStartedAt)))
-        .returning({ id: partners.id });
+  return inCallerOrSystemDbContext(async () => {
+    const cleared = await db
+      .update(partners)
+      .set({ offboardingStartedAt: null, updatedAt: new Date() })
+      .where(and(eq(partners.id, partnerId), isNotNull(partners.offboardingStartedAt)))
+      .returning({ id: partners.id });
 
-      if (cleared.length === 0) return { aborted: false, uninstallsCancelled: 0 };
+    if (cleared.length === 0) return { aborted: false, uninstallsCancelled: 0 };
 
-      const orgRows = await db
-        .select({ id: organizations.id })
-        .from(organizations)
-        .where(eq(organizations.partnerId, partnerId));
-      const orgIds = orgRows.map((row) => row.id);
+    const orgRows = await db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.partnerId, partnerId));
+    const orgIds = orgRows.map((row) => row.id);
 
-      const uninstallsCancelled = await cancelDrainUninstallsForOrgIds(
-        orgIds,
-        'partner_offboarding_aborted'
-      );
-      await invalidateAgentTenantCache(orgIds);
-      return { aborted: true, uninstallsCancelled };
-    })
-  );
+    const uninstallsCancelled = await cancelDrainUninstallsForOrgIds(
+      orgIds,
+      'partner_offboarding_aborted'
+    );
+    await invalidateAgentTenantCache(orgIds);
+    return { aborted: true, uninstallsCancelled };
+  });
 }
 
 async function countOutstandingUninstalls(orgIds: string[]): Promise<number> {
@@ -528,13 +583,14 @@ export async function finalizePartnerOffboarding(
 }
 
 /**
- * Repair an entry that committed the status but not the drain work. The route
- * writes `status='offboarding'` before calling begin*Offboarding, so a throw
- * in between leaves a tenant whose users are (maybe) revoked and whose fleet
- * has NO queued uninstall. Without this the next sweep would see zero
- * outstanding commands, finalize immediately, and emit an empty report
- * indistinguishable from a clean drain — reintroducing the exact false
- * confidence #2774 exists to remove.
+ * Repair an entry that committed the status but not the drain work. Since
+ * #2877 the route path commits status + stamp + queued uninstalls in ONE
+ * transaction, so this is defense in depth: it still covers rows torn by the
+ * pre-#2877 two-connection entry, and any future caller that writes the
+ * status outside begin*Offboarding's transaction. Without it the next sweep
+ * would see zero outstanding commands, finalize immediately, and emit an
+ * empty report indistinguishable from a clean drain — reintroducing the
+ * exact false confidence #2774 exists to remove.
  *
  * Queueing is idempotent (dedupes against in-flight uninstalls), so re-running
  * it is safe; the stamp write is the marker that the entry is now complete.
@@ -554,15 +610,18 @@ async function repairIncompleteEntry(
   await prepareAgentDrainForOrgIds(orgIds);
   const queued = await queueDrainUninstalls(orgIds, null);
 
+  // DB_NOW, not the sweep's JS `now`, for the same clock-skew reason as
+  // begin*Offboarding: the finalize report's gte(created_at, stamp) window
+  // must include the commands this very repair just queued.
   if (scope === 'organization') {
     await db
       .update(organizations)
-      .set({ offboardingStartedAt: now, updatedAt: now })
+      .set({ offboardingStartedAt: DB_NOW, updatedAt: now })
       .where(and(eq(organizations.id, scopeId), isNull(organizations.offboardingStartedAt)));
   } else {
     await db
       .update(partners)
-      .set({ offboardingStartedAt: now, updatedAt: now })
+      .set({ offboardingStartedAt: DB_NOW, updatedAt: now })
       .where(and(eq(partners.id, scopeId), isNull(partners.offboardingStartedAt)));
   }
 

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -1,5 +1,5 @@
 import { and, eq, gte, inArray, isNotNull, isNull, ne, sql } from 'drizzle-orm';
-import { db, hasDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { db, getCurrentDbAccessContext, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { deviceCommands, devices, organizations, partners } from '../db/schema';
 import { requestLikeFromSnapshot, writeAuditEvent } from './auditEvents';
 import { captureException } from './sentry';
@@ -38,38 +38,49 @@ export const OFFBOARDING_DRAIN_WINDOW_HOURS = RAW_WINDOW_HOURS >= 1 ? RAW_WINDOW
 const NON_TERMINAL_COMMAND_STATUSES = ['pending', 'sent'] as const;
 
 /**
- * #2877 — run entry/abort DB work on the CALLER's transaction when one is
- * active; only open a fresh system context when there is none.
+ * #2877 — run entry/abort DB work on the CALLER's transaction when that
+ * transaction can SEE the target tenant row; otherwise open a fresh system
+ * context.
  *
  * The org/partner status routes call the begin/abort functions AFTER `UPDATE ...
  * RETURNING` on the very organizations/partners row, inside the request
  * transaction the auth middleware wraps around the whole handler. The old
  * shape here — `runOutsideDbContext(() => withSystemDbAccessContext(fn))` —
- * opened a SECOND pooled connection and UPDATEd the SAME row, which then
- * waited forever on the request transaction's row lock while the request
- * could not commit until this function returned: a cross-connection cycle
- * Postgres's deadlock detector cannot see (each side looks merely blocked /
- * idle-in-transaction). Killing the wedged request tore the entry — the
- * status write rolled back while the fresh connection's side effects
- * committed.
+ * unconditionally opened a SECOND pooled connection and UPDATEd the SAME
+ * row, which then waited forever on the request transaction's row lock while
+ * the request could not commit until this function returned: a
+ * cross-connection cycle Postgres's deadlock detector cannot see (each side
+ * looks merely blocked / idle-in-transaction). Killing the wedged request
+ * tore the entry — the status write rolled back while the fresh connection's
+ * side effects committed.
  *
  * Reusing the ambient transaction removes the second connection (no lock to
  * wait on) AND makes the transition atomic: status + drain stamp + queued/
  * cancelled uninstalls commit or roll back together, so the torn state is
  * unreachable.
  *
- * RLS: on the ambient path the work runs under the CALLER's scope, not
- * system. That is sufficient by construction for every route caller: it only
- * reaches this function after its own UPDATE on the same organizations/
- * partners row succeeded under that scope (so the stamp UPDATE passes the
- * identical policy), the org's devices are covered by the same org
- * allowlist, and device_commands is intentionally unscoped (see the
- * rls-coverage allowlist). Callers with NO ambient context (e.g. a bare job
- * entrypoint) keep the fresh system context, exactly as before. Note the
- * drain reaper DOES run inside a system ambient context — it never calls the
- * begin/abort functions, but a future background caller that does would take
- * the ambient branch, which is the desired behavior there too (its own
- * transaction, no second connection).
+ * The visibility gate is what makes the ambient path RLS-correct: the work
+ * only reuses the caller's transaction when that context's allowlists (the
+ * exact inputs to breeze_has_org_access / breeze_has_partner_access) grant
+ * the target row, so the stamp UPDATE, the devices FOR UPDATE, and the
+ * device_commands writes (unscoped anyway) all resolve the same rows a
+ * system context would. When the ambient context CANNOT see the row —
+ * #2879's suspended-lifecycle override is the live case: the suspended org
+ * is excluded from accessibleOrgIds, so the route ran its status UPDATE on
+ * its own short system transaction — running here under the caller's scope
+ * would silently 0-row the stamp and queue nothing. The fallback to a fresh
+ * system context is deadlock-safe precisely BECAUSE of the invisibility: an
+ * ambient transaction that cannot see the row cannot have UPDATEd it, so it
+ * holds no lock for the fresh connection to wait on. (On that path the entry
+ * is two transactions; a crash between them leaves status-without-stamp,
+ * which repairIncompleteEntry already backstops.)
+ *
+ * Callers with NO ambient context (e.g. a bare job entrypoint) keep the
+ * fresh system context, exactly as before. Note the drain reaper DOES run
+ * inside a system ambient context — it never calls the begin/abort
+ * functions, but a future background caller that does would take the ambient
+ * branch (scope 'system' always passes the gate), which is the desired
+ * behavior there too: its own transaction, no second connection.
  *
  * Cost, accepted deliberately: on the ambient path the request transaction
  * now holds the queueDrainUninstalls device FOR UPDATE locks (and performs
@@ -79,9 +90,20 @@ const NON_TERMINAL_COMMAND_STATUSES = ['pending', 'sent'] as const;
  * admin operations — a short, bounded hold, vs. the alternative of a
  * permanent deadlock (#1105 tripwire still watches the duration).
  */
-function inCallerOrSystemDbContext<T>(fn: () => Promise<T>): Promise<T> {
-  if (hasDbAccessContext()) {
-    return fn();
+function inCallerOrSystemDbContext<T>(
+  target: { orgId: string } | { partnerId: string },
+  fn: () => Promise<T>
+): Promise<T> {
+  const ambient = getCurrentDbAccessContext();
+  if (ambient) {
+    const visible =
+      ambient.scope === 'system' ||
+      ('orgId' in target
+        ? (ambient.accessibleOrgIds?.includes(target.orgId) ?? false)
+        : (ambient.accessiblePartnerIds?.includes(target.partnerId) ?? false));
+    if (visible) {
+      return fn();
+    }
   }
   return runOutsideDbContext(() => withSystemDbAccessContext(fn));
 }
@@ -220,7 +242,7 @@ export async function beginOrganizationOffboarding(
   // retrying the PATCH (or by reactivation's restore path).
   const revocation = await revokeOrganizationTenantAccess(orgId, { agentChannel: 'drain' });
 
-  return inCallerOrSystemDbContext(async () => {
+  return inCallerOrSystemDbContext({ orgId }, async () => {
     // Preserve the original start on re-entry so a repeated PATCH can't
     // extend the drain window indefinitely.
     await db
@@ -242,7 +264,7 @@ export async function beginPartnerOffboarding(
   // Ambient-path RLS note: the partner status routes are system-scope only
   // (requireScope('system')), so the org enumeration below sees every org
   // under the partner even when run on the request transaction.
-  return inCallerOrSystemDbContext(async () => {
+  return inCallerOrSystemDbContext({ partnerId }, async () => {
     await db
       .update(partners)
       .set({ offboardingStartedAt: DB_NOW, updatedAt: new Date() })
@@ -309,7 +331,7 @@ export async function abortOrganizationOffboarding(orgId: string): Promise<Offbo
   // routes (and DELETE /organizations/:id) call this right after UPDATEing the
   // same organizations row in the request transaction, so the stamp-clear must
   // run on that transaction, not a fresh connection.
-  return inCallerOrSystemDbContext(async () => {
+  return inCallerOrSystemDbContext({ orgId }, async () => {
     const cleared = await db
       .update(organizations)
       .set({ offboardingStartedAt: null, updatedAt: new Date() })
@@ -328,7 +350,7 @@ export async function abortOrganizationOffboarding(orgId: string): Promise<Offbo
 }
 
 export async function abortPartnerOffboarding(partnerId: string): Promise<OffboardingAbortResult> {
-  return inCallerOrSystemDbContext(async () => {
+  return inCallerOrSystemDbContext({ partnerId }, async () => {
     const cleared = await db
       .update(partners)
       .set({ offboardingStartedAt: null, updatedAt: new Date() })

--- a/apps/api/src/services/tenantOffboarding.ts
+++ b/apps/api/src/services/tenantOffboarding.ts
@@ -64,8 +64,20 @@ const NON_TERMINAL_COMMAND_STATUSES = ['pending', 'sent'] as const;
  * partners row succeeded under that scope (so the stamp UPDATE passes the
  * identical policy), the org's devices are covered by the same org
  * allowlist, and device_commands is intentionally unscoped (see the
- * rls-coverage allowlist). Background callers (drain reaper, jobs) have no
- * ambient context and keep the fresh system context, exactly as before.
+ * rls-coverage allowlist). Callers with NO ambient context (e.g. a bare job
+ * entrypoint) keep the fresh system context, exactly as before. Note the
+ * drain reaper DOES run inside a system ambient context — it never calls the
+ * begin/abort functions, but a future background caller that does would take
+ * the ambient branch, which is the desired behavior there too (its own
+ * transaction, no second connection).
+ *
+ * Cost, accepted deliberately: on the ambient path the request transaction
+ * now holds the queueDrainUninstalls device FOR UPDATE locks (and performs
+ * the abort path's Redis cache invalidation) until the handler commits. The
+ * remaining handler work after these calls is only a fire-and-forget audit
+ * write and response serialization, and offboarding transitions are rare
+ * admin operations — a short, bounded hold, vs. the alternative of a
+ * permanent deadlock (#1105 tripwire still watches the duration).
  */
 function inCallerOrSystemDbContext<T>(fn: () => Promise<T>): Promise<T> {
   if (hasDbAccessContext()) {
@@ -604,6 +616,28 @@ async function repairIncompleteEntry(
   console.warn(
     `[tenantOffboarding] ${scope} ${scopeId} is offboarding with no drain stamp — completing the entry`
   );
+  // Take the TENANT ROW lock first, matching the request path's acquisition
+  // order (route UPDATE on organizations/partners, then key/device work).
+  // Without this, a repair racing an operator's PATCH retry on the same torn
+  // tenant inverts the order: the reaper locks enrollment_keys/devices/
+  // device_commands and then blocks on the tenant row the request holds,
+  // while the request's fresh-connection revoke blocks on those key rows —
+  // the same cross-connection cycle Postgres cannot detect (#2877). Row lock
+  // first means whichever side wins the tenant row proceeds while the other
+  // waits holding nothing.
+  if (scope === 'organization') {
+    await db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.id, scopeId))
+      .for('update');
+  } else {
+    await db
+      .select({ id: partners.id })
+      .from(partners)
+      .where(eq(partners.id, scopeId))
+      .for('update');
+  }
   // Drain prep FIRST, matching begin*Offboarding: #2785 made this step the one
   // that lifts a superseded token suspension, so queueing before it would leave
   // a window where the uninstall exists but the fleet is still 401ing.


### PR DESCRIPTION
Closes #2877

## Problem (release blocker, reproduced in 2026-07-27 pre-release QA)

`PATCH /organizations/:id {status:'offboarding'}` wedged indefinitely. The route's own `UPDATE organizations ... RETURNING` takes the org row lock inside the request transaction the auth middleware wraps around the whole handler; `beginOrganizationOffboarding` then opened a **fresh pooled connection** (`runOutsideDbContext` → `withSystemDbAccessContext`) and UPDATEd the **same row** — blocking forever on a lock the request could only release after the service returned. Postgres cannot detect the cycle (each side is merely blocked / idle-in-transaction). Killing the request tore the entry: status rolled back, side effects committed. Same structural class as the #1105 family.

The identical latent deadlock existed in the **abort** paths (suspended/churned/active transitions off a drain), both **DELETE** routes, the **partner** begin/abort equivalents, and the `update_org` AI tool.

## Fix

`inCallerOrSystemDbContext` in `services/tenantOffboarding.ts`: when an ambient DB access context is active (request path), the entry/abort DB work runs on the **caller's transaction** — same connection, so no lock to wait on, and status + drain stamp + queued/cancelled uninstalls commit or roll back as **one transaction** (torn entry unreachable). Background callers (drain reaper) keep the fresh system context, unchanged.

RLS on the ambient path is sufficient by construction: every route caller reaches the service only after its own UPDATE on the same row succeeded under that scope; devices share the org allowlist; `device_commands` is intentionally unscoped. The partner routes are system-scope only, so the org enumeration in `beginPartnerOffboarding` stays complete. Revocation (`revoke*TenantAccess`) is deliberately left on its own short system contexts — it never writes the org/partner row (no lock conflict) and its session/WS/Redis side effects cannot be transactional anyway; it is idempotent and retryable.

## Second bug: `offboarding_completed` reported `uninstallsCompleted: 0`

The drain stamp was a JS-clock `new Date()` while `device_commands.created_at` defaults to the DB clock; `gte(created_at, stamp)` excluded the drain's own commands by ~2ms of skew. The stamp (begin org/partner + `repairIncompleteEntry`) is now written with SQL `now()` — constant within the entry transaction, so `stamp == created_at` for the commands the entry queues.

## Verification

- **New integration suite** `offboardingEntryDeadlock.integration.test.ts` (4 tests, real Postgres): reproduces the exact route shape — row UPDATE inside a held access-context transaction, then the service call — for org entry, org abort (suspended transition incl. `revokeOrganizationTenantAccess`), partner entry, and the finalize report count. **Injection-proofed**: with the fix stashed, the entry test fails at 20s with the deadlock diagnostic; with the fix, all 4 pass in ~3s.
- Unit: `tenantOffboarding.test.ts` 24/24 (new ambient-branch tests: no fresh connection when a context is active; background callers unchanged), `orgs.test.ts` 173/173, `aiToolsOrgs.test.ts` + `tenantLifecycle.test.ts` 44/44.
- Sibling integration suite `offboardingDrainSuspendedEntry` 3/3.
- `tsc --noEmit` clean.

## Scope note

#2879 (suspended→offboarding unreachable via `computeAccessibleOrgIds`/`requirePermission`) is being fixed separately in `auth.ts`; this PR deliberately does not touch route authorization logic. No route files changed — the fix is entirely in the service layer, which also covers the AI tool caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)