### PR TITLE
fix(api): add retention for device_metrics and service_process_check_results (#2827)

### DIFF
--- a/apps/api/migrations/2026-07-29-timeseries-retention-brin.sql
+++ b/apps/api/migrations/2026-07-29-timeseries-retention-brin.sql
@@ -1,0 +1,56 @@
+-- @no-transaction
+-- Retention support indexes for the two unbounded time-series tables (#2827).
+--
+-- `device_metrics` and `service_process_check_results` have never had a
+-- retention path, so both grow without bound (observed: 23 GB / 24 GB on a
+-- single self-hosted deployment, ~630 MB/day combined).
+--
+-- The retention workers added alongside this migration prune by
+-- `WHERE "timestamp" < cutoff` in bounded ctid batches, mirroring
+-- `jobs/processSampleRetention.ts`. Neither table has an index that LEADS with
+-- `timestamp`:
+--
+--   device_metrics                 PK (device_id, timestamp)
+--                                  idx (org_id, timestamp DESC)
+--   service_process_check_results  PK (id)
+--                                  idx (device_id), (org_id),
+--                                      (device_id, name, timestamp)
+--
+-- so the prune predicate plans a Seq Scan. Verified on a populated deployment:
+--
+--   Limit  (cost=0.00..3266.51 rows=10000 width=6)
+--     ->  Seq Scan on device_metrics  (cost=0.00..3110591.46 rows=9522680 width=6)
+--   Limit  (cost=0.00..756.46 rows=10000 width=6)
+--     ->  Seq Scan on service_process_check_results  (cost=0.00..3114942.68 rows=41177745 width=6)
+--
+-- Early batches exit the scan quickly because old rows sit early in the heap,
+-- but as the prune advances each batch must walk ever more live tuples to find
+-- BATCH_SIZE old ones — the loop degrades toward a full scan per batch. Against
+-- ~9.5M and ~41M expired rows that is thousands of scans over ~47 GB.
+--
+-- BRIN rather than btree: both tables are append-only and their `timestamp`
+-- column is almost perfectly correlated with physical order (measured
+-- `pg_stats.correlation` = 0.99926 and 0.99960). BRIN is the right structure
+-- for exactly this shape — it stores per-block-range min/max instead of a tuple
+-- per row, so it is kilobytes rather than the hundreds of megabytes a btree
+-- would add to an already-large table, and it builds in a single sequential
+-- heap pass instead of a full sort. Range predicates like `timestamp < cutoff`
+-- are precisely what it accelerates.
+--
+-- Built CONCURRENTLY via autoMigrate's `@no-transaction` lane. A plain
+-- CREATE INDEX holds a SHARE lock on the table for the whole build, and
+-- `device_metrics` takes a write on every agent heartbeat — at ~23 GB that
+-- would stall metric ingestion fleet-wide for the duration of the deploy.
+-- Same reasoning as 2026-05-17-a-devices-scale-indexes.sql.
+--
+-- Idempotent: `IF NOT EXISTS` on both statements, per the no-transaction
+-- idempotency contract (the file must be safe to re-apply if it fails partway
+-- or the ledger INSERT fails). Note that a CONCURRENTLY build interrupted
+-- mid-flight leaves an INVALID index behind, which `IF NOT EXISTS` will then
+-- skip — recovery is an operator `DROP INDEX <name>` before the next deploy.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS device_metrics_timestamp_brin_idx
+  ON device_metrics USING brin ("timestamp");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS spc_results_timestamp_brin_idx
+  ON service_process_check_results USING brin ("timestamp");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -226,6 +226,8 @@ import { initializeUnifiTelemetryWorker } from './jobs/unifiTelemetryWorker';
 import { initializeSnmpRetention, shutdownSnmpRetention } from './jobs/snmpRetention';
 import { initializeReliabilityRetention, shutdownReliabilityRetention } from './jobs/reliabilityRetention';
 import { initializeProcessSampleRetention, shutdownProcessSampleRetention } from './jobs/processSampleRetention';
+import { initializeDeviceMetricsRetention, shutdownDeviceMetricsRetention } from './jobs/deviceMetricsRetention';
+import { initializeServiceProcessCheckRetention, shutdownServiceProcessCheckRetention } from './jobs/serviceProcessCheckRetention';
 import { initializePlaybookRetention, shutdownPlaybookRetention } from './jobs/playbookRetention';
 import { initializePolicyEvaluationWorker, shutdownPolicyEvaluationWorker } from './jobs/policyEvaluationWorker';
 import { initializeAutomationWorker, shutdownAutomationWorker } from './jobs/automationWorker';
@@ -1239,6 +1241,8 @@ async function initializeWorkers(): Promise<void> {
     ['ipHistoryRetention', initializeIPHistoryRetention],
     ['reliabilityRetention', initializeReliabilityRetention],
     ['processSampleRetention', initializeProcessSampleRetention],
+    ['deviceMetricsRetention', initializeDeviceMetricsRetention],
+    ['serviceProcessCheckRetention', initializeServiceProcessCheckRetention],
     ['changeLogRetention', initializeChangeLogRetention],
     ['oauthCleanup', initializeOauthCleanupWorker],
     ['oauthRevocationRetryWorker', async () => { initializeOAuthRevocationRetryWorker(); }],
@@ -1449,6 +1453,8 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
     shutdownMlOutputRetention,
     shutdownReliabilityRetention,
     shutdownProcessSampleRetention,
+    shutdownDeviceMetricsRetention,
+    shutdownServiceProcessCheckRetention,
     shutdownChangeLogRetention,
     shutdownOauthCleanupWorker,
     shutdownOAuthRevocationRetryWorker,

--- a/apps/api/src/jobs/deviceMetricsRetention.test.ts
+++ b/apps/api/src/jobs/deviceMetricsRetention.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Avoid real Redis/DB/Sentry side effects when importing the module under test.
+vi.mock('../db', () => ({ db: {}, withSystemDbAccessContext: (fn: any) => fn() }));
+vi.mock('../services/redis', () => ({ getBullMQConnection: () => ({}) }));
+vi.mock('../services/sentry', () => ({ captureException: () => {} }));
+
+import { extractRowCount, clampRetentionDays, resolveRetentionDays } from './deviceMetricsRetention';
+
+describe('extractRowCount (batched-delete loop termination depends on this)', () => {
+  it('prefers rowCount (node-postgres) over count', () => {
+    expect(extractRowCount({ rowCount: 7, count: 3 })).toBe(7);
+  });
+
+  it('falls back to count (postgres-js DELETE result)', () => {
+    expect(extractRowCount({ count: 5 })).toBe(5);
+  });
+
+  it('falls back to array length when the driver returns rows', () => {
+    expect(extractRowCount([{}, {}, {}])).toBe(3);
+  });
+
+  it('returns 0 for an unrecognized object shape (does not falsely terminate as a partial batch)', () => {
+    expect(extractRowCount({})).toBe(0);
+  });
+
+  it('reports a full batch as the batch size so the loop continues', () => {
+    expect(extractRowCount({ count: 10000 })).toBe(10000);
+  });
+});
+
+describe('clampRetentionDays', () => {
+  it('keeps an in-range value untouched', () => {
+    expect(clampRetentionDays(30)).toBe(30);
+  });
+
+  it('raises anything below one day to one day', () => {
+    expect(clampRetentionDays(0)).toBe(1);
+    expect(clampRetentionDays(-5)).toBe(1);
+  });
+
+  it('caps at one year so a typo cannot disable retention outright', () => {
+    expect(clampRetentionDays(100000)).toBe(365);
+  });
+});
+
+describe('resolveRetentionDays', () => {
+  it('uses the configured value when it parses', () => {
+    expect(resolveRetentionDays('45', 30)).toBe(45);
+  });
+
+  it('falls back when the value is unset', () => {
+    expect(resolveRetentionDays(undefined, 30)).toBe(30);
+    expect(resolveRetentionDays('', 30)).toBe(30);
+  });
+
+  // A clamp alone cannot save this: Math.max(1, NaN) is NaN, which reaches
+  // `new Date(NaN).toISOString()` and throws RangeError on every run.
+  it('falls back on unparseable input rather than producing NaN', () => {
+    const result = resolveRetentionDays('nonsense', 30);
+    expect(Number.isNaN(result)).toBe(false);
+    expect(result).toBe(30);
+  });
+
+  // `=0` reads as "no retention"; clamping to 1 would delete almost everything.
+  it('falls back on zero rather than clamping it to a one-day window', () => {
+    expect(resolveRetentionDays('0', 30)).toBe(30);
+  });
+
+  it('still clamps an out-of-range configured value', () => {
+    expect(resolveRetentionDays('100000', 30)).toBe(365);
+    expect(resolveRetentionDays('-5', 30)).toBe(30);
+  });
+});

--- a/apps/api/src/jobs/deviceMetricsRetention.ts
+++ b/apps/api/src/jobs/deviceMetricsRetention.ts
@@ -1,0 +1,156 @@
+/**
+ * Device-Metrics Retention Worker
+ *
+ * BullMQ worker that prunes old device_metrics in bounded ctid batches.
+ * Default retention: 30 days (configurable via DEVICE_METRICS_RETENTION_DAYS,
+ * clamped to 1..365).
+ *
+ * `device_metrics` is the raw 1-row-per-device-per-heartbeat series. The
+ * history views are served from `metric_rollups`, whose partitions already have
+ * their own retention (`METRIC_ROLLUP_*_RETENTION_DAYS`) — that retention has
+ * never covered this source table, which is why it grew unbounded (#2827).
+ *
+ * Pruning relies on `device_metrics_timestamp_brin_idx`
+ * (migration 2026-07-29-timeseries-retention-brin); without it the predicate
+ * plans a Seq Scan per batch.
+ */
+
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error('[DeviceMetricsRetention] withSystemDbAccessContext is not available — DB module may not have loaded correctly');
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+const QUEUE_NAME = 'device-metrics-retention';
+const BATCH_SIZE = 10000;
+const MAX_RETENTION_DAYS = 365;
+
+export function clampRetentionDays(value: number): number {
+  return Math.min(MAX_RETENTION_DAYS, Math.max(1, value));
+}
+
+/**
+ * Resolve the configured retention window, falling back on anything that isn't
+ * a usable positive number.
+ *
+ * Anything that is not a finite positive number falls back to the default
+ * INSTEAD of being clamped, which matters in two ways:
+ *
+ *  - `parseInt('nonsense', 10)` is NaN, and NaN survives `Math.min`/`Math.max`
+ *    unchanged — a clamp alone would carry it into the cutoff, where
+ *    `new Date(NaN).toISOString()` throws RangeError and the worker dies on
+ *    every run.
+ *  - `0` and negatives read as "no retention"/misconfiguration. Clamping those
+ *    to the 1-day floor would silently prune almost the entire table on the
+ *    next run, so they must fall back rather than clamp.
+ */
+export function resolveRetentionDays(raw: string | undefined, fallback: number): number {
+  const parsed = parseInt(raw || '', 10);
+  return clampRetentionDays(Number.isFinite(parsed) && parsed > 0 ? parsed : fallback);
+}
+
+const DEFAULT_RETENTION_DAYS = resolveRetentionDays(process.env.DEVICE_METRICS_RETENTION_DAYS, 30);
+
+type RetentionJobData = { retentionDays?: number };
+
+/**
+ * postgres-js / drizzle row-count extraction. Mirrors
+ * `processSampleRetention.extractRowCount` — never report 0 when rows were
+ * actually deleted, which would prematurely end the batched-delete loop and
+ * silently leave old rows behind.
+ */
+export function extractRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? (result as unknown[]).length : 0;
+}
+
+let retentionQueue: Queue<RetentionJobData> | null = null;
+let retentionWorker: Worker<RetentionJobData> | null = null;
+
+export function getDeviceMetricsRetentionQueue(): Queue<RetentionJobData> {
+  if (!retentionQueue) {
+    retentionQueue = new Queue<RetentionJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return retentionQueue;
+}
+
+export function createDeviceMetricsRetentionWorker(): Worker<RetentionJobData> {
+  return new Worker<RetentionJobData>(
+    QUEUE_NAME,
+    async (job: Job<RetentionJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        const retentionDays = clampRetentionDays(job.data.retentionDays ?? DEFAULT_RETENTION_DAYS);
+        // postgres-js does not coerce JS Date in template-literal params; pass an ISO string.
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+        const startedAt = Date.now();
+
+        let deleted = 0;
+        for (;;) {
+          const result = await db.execute(sql`
+            DELETE FROM device_metrics
+            WHERE ctid IN (
+              SELECT ctid FROM device_metrics
+              WHERE "timestamp" < ${cutoff}
+              LIMIT ${BATCH_SIZE}
+            )
+          `);
+          const n = extractRowCount(result);
+          deleted += n;
+          if (n < BATCH_SIZE) break;
+        }
+
+        const durationMs = Date.now() - startedAt;
+        console.log(`[DeviceMetricsRetention] Pruned ${deleted} device metrics older than ${retentionDays} days in ${durationMs}ms`);
+        return { retentionDays, deleted, durationMs };
+      });
+    },
+    { connection: getBullMQConnection(), concurrency: 1 }
+  );
+}
+
+export async function initializeDeviceMetricsRetention(): Promise<void> {
+  try {
+    retentionWorker = createDeviceMetricsRetentionWorker();
+    retentionWorker.on('error', (error) => {
+      console.error('[DeviceMetricsRetention] Worker error:', error);
+      captureException(error);
+    });
+    retentionWorker.on('failed', (job, error) => {
+      console.error(`[DeviceMetricsRetention] Job ${job?.id} failed after ${job?.attemptsMade} attempts:`, error);
+      captureException(error);
+    });
+
+    const queue = getDeviceMetricsRetentionQueue();
+    const existing = await queue.getRepeatableJobs();
+    for (const job of existing) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+
+    await queue.add(
+      'cleanup',
+      { retentionDays: DEFAULT_RETENTION_DAYS },
+      { repeat: { every: 24 * 60 * 60 * 1000 }, removeOnComplete: { count: 5 }, removeOnFail: { count: 10 } }
+    );
+
+    console.log('[DeviceMetricsRetention] Retention worker initialized');
+  } catch (error) {
+    console.error('[DeviceMetricsRetention] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownDeviceMetricsRetention(): Promise<void> {
+  if (retentionWorker) { await retentionWorker.close(); retentionWorker = null; }
+  if (retentionQueue) { await retentionQueue.close(); retentionQueue = null; }
+}

--- a/apps/api/src/jobs/serviceProcessCheckRetention.test.ts
+++ b/apps/api/src/jobs/serviceProcessCheckRetention.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Avoid real Redis/DB/Sentry side effects when importing the module under test.
+vi.mock('../db', () => ({ db: {}, withSystemDbAccessContext: (fn: any) => fn() }));
+vi.mock('../services/redis', () => ({ getBullMQConnection: () => ({}) }));
+vi.mock('../services/sentry', () => ({ captureException: () => {} }));
+
+import { extractRowCount, clampRetentionDays, resolveRetentionDays } from './serviceProcessCheckRetention';
+
+describe('extractRowCount (batched-delete loop termination depends on this)', () => {
+  it('prefers rowCount (node-postgres) over count', () => {
+    expect(extractRowCount({ rowCount: 7, count: 3 })).toBe(7);
+  });
+
+  it('falls back to count (postgres-js DELETE result)', () => {
+    expect(extractRowCount({ count: 5 })).toBe(5);
+  });
+
+  it('falls back to array length when the driver returns rows', () => {
+    expect(extractRowCount([{}, {}, {}])).toBe(3);
+  });
+
+  it('returns 0 for an unrecognized object shape (does not falsely terminate as a partial batch)', () => {
+    expect(extractRowCount({})).toBe(0);
+  });
+
+  it('reports a full batch as the batch size so the loop continues', () => {
+    expect(extractRowCount({ count: 10000 })).toBe(10000);
+  });
+});
+
+describe('clampRetentionDays', () => {
+  it('keeps an in-range value untouched', () => {
+    expect(clampRetentionDays(30)).toBe(30);
+  });
+
+  it('raises anything below one day to one day', () => {
+    expect(clampRetentionDays(0)).toBe(1);
+    expect(clampRetentionDays(-5)).toBe(1);
+  });
+
+  it('caps at one year so a typo cannot disable retention outright', () => {
+    expect(clampRetentionDays(100000)).toBe(365);
+  });
+});
+
+describe('resolveRetentionDays', () => {
+  it('uses the configured value when it parses', () => {
+    expect(resolveRetentionDays('45', 14)).toBe(45);
+  });
+
+  it('falls back when the value is unset', () => {
+    expect(resolveRetentionDays(undefined, 14)).toBe(14);
+    expect(resolveRetentionDays('', 14)).toBe(14);
+  });
+
+  // A clamp alone cannot save this: Math.max(1, NaN) is NaN, which reaches
+  // `new Date(NaN).toISOString()` and throws RangeError on every run.
+  it('falls back on unparseable input rather than producing NaN', () => {
+    const result = resolveRetentionDays('nonsense', 14);
+    expect(Number.isNaN(result)).toBe(false);
+    expect(result).toBe(14);
+  });
+
+  // `=0` reads as "no retention"; clamping to 1 would delete almost everything.
+  it('falls back on zero rather than clamping it to a one-day window', () => {
+    expect(resolveRetentionDays('0', 14)).toBe(14);
+  });
+
+  it('still clamps an out-of-range configured value', () => {
+    expect(resolveRetentionDays('100000', 14)).toBe(365);
+    expect(resolveRetentionDays('-5', 14)).toBe(14);
+  });
+});

--- a/apps/api/src/jobs/serviceProcessCheckRetention.ts
+++ b/apps/api/src/jobs/serviceProcessCheckRetention.ts
@@ -1,0 +1,158 @@
+/**
+ * Service/Process Check-Result Retention Worker
+ *
+ * BullMQ worker that prunes old service_process_check_results in bounded ctid
+ * batches. Default retention: 14 days (configurable via
+ * SERVICE_PROCESS_CHECK_RESULTS_RETENTION_DAYS, clamped to 1..365).
+ *
+ * This table is one row per watched service/process per check tick, so it
+ * multiplies by watches-per-device and outgrows even `device_metrics` — it had
+ * no retention path at all before #2827.
+ *
+ * Pruning relies on `spc_results_timestamp_brin_idx`
+ * (migration 2026-07-29-timeseries-retention-brin); without it the predicate
+ * plans a Seq Scan per batch.
+ */
+
+import { Job, Queue, Worker } from 'bullmq';
+import { sql } from 'drizzle-orm';
+
+import * as dbModule from '../db';
+import { getBullMQConnection } from '../services/redis';
+import { captureException } from '../services/sentry';
+
+const { db } = dbModule;
+const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
+  if (typeof dbModule.withSystemDbAccessContext !== 'function') {
+    throw new Error('[ServiceProcessCheckRetention] withSystemDbAccessContext is not available — DB module may not have loaded correctly');
+  }
+  return dbModule.withSystemDbAccessContext(fn);
+};
+
+const QUEUE_NAME = 'service-process-check-retention';
+const BATCH_SIZE = 10000;
+const MAX_RETENTION_DAYS = 365;
+
+export function clampRetentionDays(value: number): number {
+  return Math.min(MAX_RETENTION_DAYS, Math.max(1, value));
+}
+
+/**
+ * Resolve the configured retention window, falling back on anything that isn't
+ * a usable positive number.
+ *
+ * Anything that is not a finite positive number falls back to the default
+ * INSTEAD of being clamped, which matters in two ways:
+ *
+ *  - `parseInt('nonsense', 10)` is NaN, and NaN survives `Math.min`/`Math.max`
+ *    unchanged — a clamp alone would carry it into the cutoff, where
+ *    `new Date(NaN).toISOString()` throws RangeError and the worker dies on
+ *    every run.
+ *  - `0` and negatives read as "no retention"/misconfiguration. Clamping those
+ *    to the 1-day floor would silently prune almost the entire table on the
+ *    next run, so they must fall back rather than clamp.
+ */
+export function resolveRetentionDays(raw: string | undefined, fallback: number): number {
+  const parsed = parseInt(raw || '', 10);
+  return clampRetentionDays(Number.isFinite(parsed) && parsed > 0 ? parsed : fallback);
+}
+
+const DEFAULT_RETENTION_DAYS = resolveRetentionDays(
+  process.env.SERVICE_PROCESS_CHECK_RESULTS_RETENTION_DAYS,
+  14
+);
+
+type RetentionJobData = { retentionDays?: number };
+
+/**
+ * postgres-js / drizzle row-count extraction. Mirrors
+ * `processSampleRetention.extractRowCount` — never report 0 when rows were
+ * actually deleted, which would prematurely end the batched-delete loop and
+ * silently leave old rows behind.
+ */
+export function extractRowCount(result: unknown): number {
+  const raw = result as { rowCount?: number; count?: number };
+  if (typeof raw.rowCount === 'number') return raw.rowCount;
+  if (typeof raw.count === 'number') return raw.count;
+  return Array.isArray(result) ? (result as unknown[]).length : 0;
+}
+
+let retentionQueue: Queue<RetentionJobData> | null = null;
+let retentionWorker: Worker<RetentionJobData> | null = null;
+
+export function getServiceProcessCheckRetentionQueue(): Queue<RetentionJobData> {
+  if (!retentionQueue) {
+    retentionQueue = new Queue<RetentionJobData>(QUEUE_NAME, { connection: getBullMQConnection() });
+  }
+  return retentionQueue;
+}
+
+export function createServiceProcessCheckRetentionWorker(): Worker<RetentionJobData> {
+  return new Worker<RetentionJobData>(
+    QUEUE_NAME,
+    async (job: Job<RetentionJobData>) => {
+      return runWithSystemDbAccess(async () => {
+        const retentionDays = clampRetentionDays(job.data.retentionDays ?? DEFAULT_RETENTION_DAYS);
+        // postgres-js does not coerce JS Date in template-literal params; pass an ISO string.
+        const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000).toISOString();
+        const startedAt = Date.now();
+
+        let deleted = 0;
+        for (;;) {
+          const result = await db.execute(sql`
+            DELETE FROM service_process_check_results
+            WHERE ctid IN (
+              SELECT ctid FROM service_process_check_results
+              WHERE "timestamp" < ${cutoff}
+              LIMIT ${BATCH_SIZE}
+            )
+          `);
+          const n = extractRowCount(result);
+          deleted += n;
+          if (n < BATCH_SIZE) break;
+        }
+
+        const durationMs = Date.now() - startedAt;
+        console.log(`[ServiceProcessCheckRetention] Pruned ${deleted} check results older than ${retentionDays} days in ${durationMs}ms`);
+        return { retentionDays, deleted, durationMs };
+      });
+    },
+    { connection: getBullMQConnection(), concurrency: 1 }
+  );
+}
+
+export async function initializeServiceProcessCheckRetention(): Promise<void> {
+  try {
+    retentionWorker = createServiceProcessCheckRetentionWorker();
+    retentionWorker.on('error', (error) => {
+      console.error('[ServiceProcessCheckRetention] Worker error:', error);
+      captureException(error);
+    });
+    retentionWorker.on('failed', (job, error) => {
+      console.error(`[ServiceProcessCheckRetention] Job ${job?.id} failed after ${job?.attemptsMade} attempts:`, error);
+      captureException(error);
+    });
+
+    const queue = getServiceProcessCheckRetentionQueue();
+    const existing = await queue.getRepeatableJobs();
+    for (const job of existing) {
+      await queue.removeRepeatableByKey(job.key);
+    }
+
+    await queue.add(
+      'cleanup',
+      { retentionDays: DEFAULT_RETENTION_DAYS },
+      { repeat: { every: 24 * 60 * 60 * 1000 }, removeOnComplete: { count: 5 }, removeOnFail: { count: 10 } }
+    );
+
+    console.log('[ServiceProcessCheckRetention] Retention worker initialized');
+  } catch (error) {
+    console.error('[ServiceProcessCheckRetention] Failed to initialize:', error);
+    throw error;
+  }
+}
+
+export async function shutdownServiceProcessCheckRetention(): Promise<void> {
+  if (retentionWorker) { await retentionWorker.close(); retentionWorker = null; }
+  if (retentionQueue) { await retentionQueue.close(); retentionQueue = null; }
+}


### PR DESCRIPTION
fix(api): add retention for device_metrics and service_process_check_results (#2827)

Both tables were written on every heartbeat/check tick and never pruned by
anything, so they grow without bound. On one self-hosted deployment they had
reached ~23 GB and ~24 GB (~630 MB/day combined) with rows dating back to
install day.

The existing retention only covers neighbouring tables: metricRollups prunes
its own output partitions (METRIC_ROLLUP_*_RETENTION_DAYS) but never the raw
source rows, and the optional TimescaleDB setup attaches its 90-day policy to
time_series_metrics, which nothing writes to.

Adds two workers on the established jobs/processSampleRetention.ts template
(bounded ctid batches, system DB context, daily repeatable, concurrency 1),
registered alongside the other retention workers:

  DEVICE_METRICS_RETENTION_DAYS                  default 30
  SERVICE_PROCESS_CHECK_RESULTS_RETENTION_DAYS   default 14

Both clamp to 1..365.

Supporting BRIN indexes (migration 2026-08-06-e)

Neither table has an index that LEADS with "timestamp":

  device_metrics                 PK (device_id, timestamp), idx (org_id, timestamp DESC)
  service_process_check_results  PK (id), idx (device_id), (org_id), (device_id, name, timestamp)

so the prune predicate plans a Seq Scan. Verified on a populated deployment:

  Limit  (cost=0.00..3266.51 rows=10000 width=6)
    ->  Seq Scan on device_metrics  (cost=0.00..3110591.46 rows=9522680 width=6)
  Limit  (cost=0.00..756.46 rows=10000 width=6)
    ->  Seq Scan on service_process_check_results  (cost=0.00..3114942.68 rows=41177745 width=6)

Early batches exit quickly because old rows sit early in the heap, but each
successive batch must walk more live tuples to find BATCH_SIZE old ones, so the
loop degrades toward a full scan per batch — thousands of scans over ~47 GB.

BRIN rather than btree: both tables are append-only and their timestamp column
is almost perfectly correlated with physical order (measured pg_stats
correlation 0.99926 and 0.99960). BRIN stores per-block-range bounds instead of
a tuple per row, so it costs kilobytes rather than the hundreds of megabytes a
btree would add, builds in one sequential heap pass, and accelerates exactly
this kind of range predicate.

Retention-window parsing

resolveRetentionDays() rejects non-positive and unparseable values by falling
back to the default rather than clamping them. Clamping alone is unsafe here in
two ways: parseInt('nonsense') is NaN and NaN survives Math.min/Math.max, so it
reaches new Date(NaN).toISOString() and throws RangeError on every run; and a
misconfigured 0 or negative would clamp to the 1-day floor and prune almost the
entire table on the next pass.

Partitioning device_metrics by month (mirroring metric_rollups) remains the
better long-term shape; retention is the immediate stop-loss.

Testing

- new unit tests for both workers: 26 passed
- full API unit suite: 1206 files, 18377 tests passed, 0 failures
  (2 pre-existing unhandled rejections in services/streamingUpload.test.ts,
  reproduced identically on that file alone and unrelated to this change)
- tsc --noEmit: 0 errors
- autoMigrate ordering regression test passes with the new migration filename
