### PR TITLE
fix(remote): terminal sessions die at 60s (desktop orphan recovery sweeping non-desktop sessions) + silent UI freeze (#2871)

### DIFF
--- a/apps/api/src/routes/terminalWs_keepalive.test.ts
+++ b/apps/api/src/routes/terminalWs_keepalive.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+// Regression coverage for issue #2871: an established, healthy terminal
+// session must outlive the 60s mark. The ping loop runs every 30s and closes
+// the socket when no liveness signal arrived within PING_INTERVAL_MS +
+// PONG_TIMEOUT_MS (40s) — so a session whose pongs are lost dies at exactly
+// the second tick (60s). Liveness comes from either leg: a pong answering a
+// server ping, or a client-initiated ping (both refresh lastPongAt).
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn(), update: vi.fn(), insert: vi.fn() },
+}));
+
+vi.mock('../db/schema', () => ({
+  remoteSessions: { id: 'remoteSessions.id', deviceId: 'remoteSessions.deviceId', status: 'remoteSessions.status' },
+  devices: { id: 'devices.id' },
+  users: { id: 'users.id', status: 'users.status' },
+}));
+
+vi.mock('../services/remoteSessionAuth', () => ({ consumeWsTicket: vi.fn() }));
+
+vi.mock('./agentWs', () => ({
+  sendCommandToAgent: vi.fn(() => true),
+  isAgentConnected: vi.fn(() => true),
+}));
+
+vi.mock('../services/remoteAccessPolicy', () => ({
+  checkRemoteAccess: vi.fn().mockResolvedValue({ allowed: true }),
+}));
+
+vi.mock('../services/redis', () => ({ getRedis: vi.fn(() => ({})) }));
+
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, remaining: 9, resetAt: new Date(Date.now() + 60_000) })),
+}));
+
+vi.mock('./remote/helpers', () => ({
+  logSessionAudit: vi.fn(async () => undefined),
+  getIceServers: vi.fn(() => []),
+}));
+
+vi.mock('../services/viewerTokenRevocation', () => ({
+  isViewerSessionRevoked: vi.fn().mockResolvedValue(false),
+}));
+
+import { db } from '../db';
+import { consumeWsTicket } from '../services/remoteSessionAuth';
+import { sendCommandToAgent, isAgentConnected } from './agentWs';
+import {
+  getActiveTerminalSession,
+  createTerminalWsRoutes,
+  __createTerminalSharedLeasesForTest,
+  __resetTerminalWsForTest,
+  closeTerminalSession,
+} from './terminalWs';
+
+const DEVICE_ID = 'device-xyz';
+const AGENT_ID = 'agent-xyz';
+
+function mockSelectChain(result: unknown) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(result) }),
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(result) }),
+      }),
+    }),
+  } as any;
+}
+
+function mockUpdateNoReturn() {
+  return { set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }) } as any;
+}
+
+function captureWsHandlers(sessionId: string) {
+  let capturedFactory: any;
+  const upgradeWebSocket = vi.fn((factory: any) => {
+    capturedFactory = factory;
+    return (_c: any, _next: any) => {};
+  });
+  const testSharedLeases = __createTerminalSharedLeasesForTest();
+  createTerminalWsRoutes(upgradeWebSocket, { sharedLeases: testSharedLeases });
+  const fakeContext = {
+    req: {
+      param: vi.fn((key: string) => (key === 'id' ? sessionId : undefined)),
+      query: vi.fn((key: string) => (key === 'ticket' ? 'ticket-xyz' : undefined)),
+      header: vi.fn(() => undefined),
+    },
+  };
+  return capturedFactory(fakeContext);
+}
+
+async function openLiveSession(sessionId: string) {
+  const userId = 'user-1';
+  vi.mocked(consumeWsTicket).mockResolvedValue({
+    ok: true as const,
+    sessionId,
+    sessionType: 'terminal' as const,
+    userId,
+    expiresAt: Date.now() + 60_000,
+  });
+  const user = { id: userId, status: 'active' };
+  const session = { id: sessionId, type: 'terminal', userId, status: 'pending', deviceId: DEVICE_ID };
+  const device = { id: DEVICE_ID, agentId: AGENT_ID, hostname: 'h', osType: 'linux', status: 'online', orgId: 'org-1' };
+
+  vi.mocked(db.select)
+    .mockReturnValueOnce(mockSelectChain([user]))
+    .mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ session, device }]) }),
+        }),
+      }),
+    } as any);
+  vi.mocked(isAgentConnected).mockReturnValue(true);
+  vi.mocked(sendCommandToAgent).mockReturnValue(true);
+  vi.mocked(db.update).mockReturnValue(mockUpdateNoReturn() as any);
+
+  const handlers = captureWsHandlers(sessionId);
+
+  // A ws mock that behaves like a healthy browser: every server ping is
+  // answered with a pong routed back through onMessage.
+  const ws: any = {
+    close: vi.fn(),
+    send: vi.fn(),
+  };
+  ws.send.mockImplementation((raw: string) => {
+    try {
+      const msg = JSON.parse(raw);
+      if (msg.type === 'ping') {
+        // Answer asynchronously like a real client would.
+        queueMicrotask(() => {
+          void handlers.onMessage(
+            { data: JSON.stringify({ type: 'pong', timestamp: Date.now() }) } as MessageEvent,
+            ws,
+          );
+        });
+      }
+    } catch {
+      /* not JSON */
+    }
+  });
+
+  await handlers.onOpen({}, ws);
+  return { ws, handlers };
+}
+
+describe('terminal keepalive — healthy session must outlive 60s (#2871)', () => {
+  beforeEach(() => {
+    __resetTerminalWsForTest();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('a client that answers every ping keeps the session alive past 5 minutes', async () => {
+    const sessionId = 'session-keepalive-1';
+    const { ws } = await openLiveSession(sessionId);
+    expect(getActiveTerminalSession(sessionId)).toBeDefined();
+
+    // Walk 5 minutes of fake time in 1s steps so intervals, microtasks, and
+    // the pong round-trips all interleave realistically.
+    for (let s = 0; s < 300; s++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(getActiveTerminalSession(sessionId)).toBeDefined();
+
+    await closeTerminalSession(sessionId);
+  });
+
+  it('client-initiated pings alone keep the session alive even when server pings are never answered', async () => {
+    // Session-1 failure mode from #2871: the server→browser leg loses frames,
+    // so the client never sees a server ping and never pongs. The client's own
+    // periodic {type:'ping'} must still count as liveness (the server updates
+    // lastPongAt when handling it), so the session survives.
+    const sessionId = 'session-keepalive-3';
+    const { ws, handlers } = await openLiveSession(sessionId);
+    // Server→client frames are dropped: no pong autoresponder.
+    ws.send.mockImplementation(() => undefined);
+
+    // Client pings every 20s, mirroring RemoteTerminal's keepalive.
+    const clientPing = setInterval(() => {
+      void handlers.onMessage(
+        { data: JSON.stringify({ type: 'ping' }) } as MessageEvent,
+        ws,
+      );
+    }, 20_000);
+
+    for (let s = 0; s < 180; s++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+
+    clearInterval(clientPing);
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(getActiveTerminalSession(sessionId)).toBeDefined();
+
+    await closeTerminalSession(sessionId);
+  });
+
+  it('a client that never answers pings is closed with 4008 pong timeout', async () => {
+    const sessionId = 'session-keepalive-2';
+    const { ws } = await openLiveSession(sessionId);
+    // Disable the pong autoresponder.
+    ws.send.mockImplementation(() => undefined);
+
+    for (let s = 0; s < 120; s++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+
+    expect(ws.close).toHaveBeenCalledWith(4008, 'Pong timeout');
+  });
+});

--- a/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
@@ -145,8 +145,13 @@ describe('desktop orphan recovery', () => {
     const service = createDesktopSessionOrphanRecoveryService(deps);
 
     await service.recover(session.id, 'background');
-    // Second observation reloads the row; a non-desktop row must not be claimed.
-    vi.mocked(deps.loadSession).mockResolvedValue({ ...session, type: 'terminal' });
+    // Within the second recover() call the row is loaded twice: the entry
+    // check sees a desktop row, but the post-lease-TTL RE-load returns a
+    // non-desktop row. The re-load guard must refuse the claim — this is the
+    // deep checkpoint, distinct from the entry guard covered above.
+    vi.mocked(deps.loadSession)
+      .mockResolvedValueOnce(session)
+      .mockResolvedValueOnce({ ...session, type: 'terminal' });
     deps.setNow!(31_000);
     await expect(service.recover(session.id, 'background')).resolves.toBe('not_orphaned');
 

--- a/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.test.ts
@@ -8,6 +8,7 @@ import {
 
 const session = {
   id: '11111111-1111-4111-8111-111111111111',
+  type: 'desktop',
   deviceId: '22222222-2222-4222-8222-222222222222',
   orgId: '33333333-3333-4333-8333-333333333333',
   userId: '44444444-4444-4444-8444-444444444444',
@@ -118,6 +119,39 @@ describe('desktop orphan recovery', () => {
       sessionId: session.id,
       finalizationId: '55555555-5555-4555-8555-555555555555',
     });
+  });
+
+  it('never claims a live non-desktop session (terminal 60s revocation regression, #2871)', async () => {
+    const deps = dependencies();
+    vi.mocked(deps.loadSession).mockResolvedValue({
+      ...session,
+      type: 'terminal',
+    });
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    // Two passes separated by more than a full lease TTL — the exact cadence
+    // that previously claimed and finalized a healthy live terminal session.
+    await expect(service.recover(session.id, 'background')).resolves.toBe('not_orphaned');
+    deps.setNow!(31_000);
+    await expect(service.recover(session.id, 'background')).resolves.toBe('not_orphaned');
+
+    expect(deps.observeSharedState).not.toHaveBeenCalled();
+    expect(deps.claimOrphanIntent).not.toHaveBeenCalled();
+    expect(deps.finalize).not.toHaveBeenCalled();
+  });
+
+  it('refuses to finalize when the row flips to a non-desktop type between observations', async () => {
+    const deps = dependencies();
+    const service = createDesktopSessionOrphanRecoveryService(deps);
+
+    await service.recover(session.id, 'background');
+    // Second observation reloads the row; a non-desktop row must not be claimed.
+    vi.mocked(deps.loadSession).mockResolvedValue({ ...session, type: 'terminal' });
+    deps.setNow!(31_000);
+    await expect(service.recover(session.id, 'background')).resolves.toBe('not_orphaned');
+
+    expect(deps.claimOrphanIntent).not.toHaveBeenCalled();
+    expect(deps.finalize).not.toHaveBeenCalled();
   });
 
   it('does not treat a recent pending row as orphaned', async () => {

--- a/apps/api/src/services/desktopSessionOrphanRecovery.ts
+++ b/apps/api/src/services/desktopSessionOrphanRecovery.ts
@@ -18,6 +18,15 @@ import {
 
 export interface DesktopOrphanSession {
   id: string;
+  /**
+   * Session type from the remote_sessions row. Orphan recovery is a
+   * DESKTOP-ONLY mechanism: it observes the desktop lease keyspace
+   * (`remote:ws:{desktop:<id>}:*`), so a live terminal session always looks
+   * "absent" to it and would be falsely finalized (revoking its viewer
+   * session ~30-60s after it goes active — issue #2871). Every entry point
+   * must refuse non-desktop rows.
+   */
+  type: string;
   deviceId: string;
   orgId: string;
   userId: string;
@@ -98,6 +107,15 @@ export function createDesktopSessionOrphanRecoveryService(
         firstAbsentObservation.delete(sessionId);
         return 'not_orphaned';
       }
+      // Never treat a non-desktop session as a desktop orphan. Terminal (and
+      // any future non-desktop) sessions keep their lease under a different
+      // keyspace, so the desktop observation below is vacuously "absent" for
+      // them and, unguarded, a healthy live terminal session gets claimed and
+      // finalized (viewer session revoked) within two scan intervals (#2871).
+      if (session.type !== 'desktop') {
+        firstAbsentObservation.delete(sessionId);
+        return 'not_orphaned';
+      }
       if (
         session.status === 'pending'
         && deps.now() - session.createdAt.getTime() < 90_000
@@ -155,7 +173,11 @@ export function createDesktopSessionOrphanRecoveryService(
       // Re-load after the full lease interval. A row that became terminal is
       // never claimed as an orphan.
       const current = await deps.loadSession(sessionId);
-      if (!current || !['pending', 'connecting', 'active'].includes(current.status)) {
+      if (
+        !current
+        || current.type !== 'desktop'
+        || !['pending', 'connecting', 'active'].includes(current.status)
+      ) {
         firstAbsentObservation.delete(sessionId);
         return 'not_orphaned';
       }
@@ -210,6 +232,7 @@ function getProductionService() {
         db
           .select({
             id: remoteSessions.id,
+            type: remoteSessions.type,
             deviceId: remoteSessions.deviceId,
             orgId: remoteSessions.orgId,
             userId: remoteSessions.userId,
@@ -298,6 +321,10 @@ async function scanDesktopSessionOrphans(): Promise<void> {
       .select({ id: remoteSessions.id })
       .from(remoteSessions)
       .where(and(
+        // Desktop-only: this scanner recovers desktop finalization orphans.
+        // Sweeping other session types here is what killed every live
+        // terminal session at ~60s (#2871).
+        eq(remoteSessions.type, 'desktop'),
         inArray(remoteSessions.status, ['pending', 'connecting', 'active']),
         cursor === null ? undefined : gt(remoteSessions.id, cursor),
       ))

--- a/apps/web/src/components/remote/RemoteTerminal.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.test.tsx
@@ -491,4 +491,29 @@ describe('RemoteTerminal keepalive & silent-death watchdog (#2871)', () => {
     expect(screen.getByTestId('terminal-disconnect-overlay')).toBeInTheDocument();
     expect(screen.getByTestId('terminal-overlay-reconnect')).toBeInTheDocument();
   });
+
+  it('the overlay reconnect button actually reconnects after a watchdog teardown', async () => {
+    await openConnected();
+
+    // Kill the session via the silence watchdog, then click the overlay button.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(55_000);
+    });
+    const reconnect = screen.getByTestId('terminal-overlay-reconnect');
+    await act(async () => {
+      reconnect.click();
+    });
+    // Flush the session + ticket fetches and the socket construction.
+    for (let i = 0; i < 5 && MockWebSocket.instances.length < 2; i++) {
+      await act(async () => {});
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+    }
+
+    // A brand-new session and socket — the dead attempt is not reused.
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(sessionPostCount()).toBe(2);
+    expect(ticketPostCount()).toBe(2);
+  });
 });

--- a/apps/web/src/components/remote/RemoteTerminal.test.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.test.tsx
@@ -408,3 +408,87 @@ describe('RemoteTerminal rejected handshake (error/close before open)', () => {
     expect(ticketPostCount()).toBe(1);
   });
 });
+
+describe('RemoteTerminal keepalive & silent-death watchdog (#2871)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Mount, run the 500ms auto-connect delay, and open the socket. */
+  const openConnected = async (): Promise<MockWebSocket> => {
+    renderTerminal();
+    // Interleave microtask flushes (dynamic xterm imports → terminalReady)
+    // with timer advances (the 500ms auto-connect delay) under fake timers.
+    for (let i = 0; i < 5 && MockWebSocket.instances.length === 0; i++) {
+      await act(async () => {});
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600);
+      });
+    }
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const ws = MockWebSocket.instances[0]!;
+    fireConnected(ws);
+    return ws;
+  };
+
+  const sentOfType = (ws: MockWebSocket, type: string) =>
+    ws.sent.filter((raw) => {
+      try {
+        return (JSON.parse(raw) as { type?: string }).type === type;
+      } catch {
+        return false;
+      }
+    });
+
+  it('sends client keepalive pings once the server confirms the session', async () => {
+    const ws = await openConnected();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(21_000);
+    });
+
+    expect(sentOfType(ws, 'ping').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('answers server pings with pongs and stays connected well past 60s', async () => {
+    const ws = await openConnected();
+
+    for (let i = 0; i < 4; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+      act(() => ws.fireMessage({ type: 'ping', timestamp: 0 }));
+    }
+
+    // 2+ minutes in: no disconnect overlay, socket untouched.
+    expect(screen.queryByTestId('terminal-disconnect-overlay')).not.toBeInTheDocument();
+    expect(ws.closeCalls).toBe(0);
+    expect(sentOfType(ws, 'pong').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('surfaces prolonged server silence as a visible disconnect with a retry affordance', async () => {
+    const ws = await openConnected();
+
+    // No server frame at all past the 45s silence deadline.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(55_000);
+    });
+
+    expect(screen.getByTestId('terminal-disconnect-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('terminal-overlay-reconnect')).toBeInTheDocument();
+    // The dead socket was torn down, not left dangling.
+    expect(ws.closeCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows the disconnect overlay when the server closes the socket abnormally (e.g. 4003 revoked)', async () => {
+    const ws = await openConnected();
+
+    act(() => ws.fireClose(4003));
+
+    expect(screen.getByTestId('terminal-disconnect-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('terminal-overlay-reconnect')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/remote/RemoteTerminal.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.tsx
@@ -54,6 +54,12 @@ export type RemoteTerminalProps = {
 // the keepalive survive a lost server→client ping, and expecting *some*
 // server frame (ping, pong, or output) lets the client detect a half-dead
 // connection instead of freezing silently.
+//
+// Contract with apps/api/src/routes/terminalWs.ts (PING_INTERVAL_MS = 30s,
+// PONG_TIMEOUT_MS = 10s): CLIENT_PING_INTERVAL_MS must stay well under the
+// server's 40s deadline, and SERVER_SILENCE_TIMEOUT_MS must stay above the
+// server's ping interval — otherwise healthy idle sessions get killed on
+// whichever side drifted.
 const CLIENT_PING_INTERVAL_MS = 20_000;
 const SERVER_SILENCE_TIMEOUT_MS = 45_000;
 const LIVENESS_CHECK_INTERVAL_MS = 5_000;
@@ -702,25 +708,33 @@ export default function RemoteTerminal({
         />
         {/* Disconnect overlay (issue #2871): a dead session must be unmissable,
             not a silent freeze. Shown for any post-connect terminal state that
-            is no longer live, with an explicit reconnect affordance. */}
+            is no longer live, with an explicit reconnect affordance. The
+            container is pointer-events-none (only the inner panel captures
+            clicks) so the scrollback behind it stays selectable/copyable, and
+            only a genuine failure dims the transcript. */}
         {(status === 'failed' || (status === 'disconnected' && autoConnectAttempted)) && (
           <div
             data-testid="terminal-disconnect-overlay"
-            className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/70"
+            className={cn(
+              'pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center',
+              status === 'failed' && 'bg-black/40'
+            )}
           >
-            <WifiOff className="h-8 w-8 text-red-400" />
-            <span className="text-sm font-medium text-white">
-              {t(/* i18n-dynamic */ statusConfig[status].labelKey)}
-            </span>
-            <button
-              type="button"
-              data-testid="terminal-overlay-reconnect"
-              onClick={connect}
-              className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
-            >
-              <RefreshCw className="h-4 w-4" />
-              {t(status === 'failed' ? 'common:actions.retry' : 'remoteTerminal.reconnect')}
-            </button>
+            <div className="pointer-events-auto flex flex-col items-center gap-3 rounded-lg bg-black/80 px-6 py-4">
+              <WifiOff className="h-8 w-8 text-red-400" />
+              <span className="text-sm font-medium text-white">
+                {t(/* i18n-dynamic */ statusConfig[status].labelKey)}
+              </span>
+              <button
+                type="button"
+                data-testid="terminal-overlay-reconnect"
+                onClick={connect}
+                className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
+              >
+                <RefreshCw className="h-4 w-4" />
+                {status === 'failed' ? t('common:actions.retry') : t('remoteTerminal.reconnect')}
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/apps/web/src/components/remote/RemoteTerminal.tsx
+++ b/apps/web/src/components/remote/RemoteTerminal.tsx
@@ -48,6 +48,16 @@ export type RemoteTerminalProps = {
   className?: string;
 };
 
+// Client-side keepalive (issue #2871). The server pings every 30s and closes
+// the socket when no liveness signal arrives within 40s — but it also accepts
+// a client-initiated {type:'ping'} as liveness. Sending our own pings makes
+// the keepalive survive a lost server→client ping, and expecting *some*
+// server frame (ping, pong, or output) lets the client detect a half-dead
+// connection instead of freezing silently.
+const CLIENT_PING_INTERVAL_MS = 20_000;
+const SERVER_SILENCE_TIMEOUT_MS = 45_000;
+const LIVENESS_CHECK_INTERVAL_MS = 5_000;
+
 const statusConfig: Record<ConnectionStatus, { labelKey: string; color: string; icon: typeof Wifi }> = {
   disconnected: { labelKey: 'remoteTerminal.status.disconnected', color: 'text-gray-500', icon: WifiOff },
   connecting: { labelKey: 'remoteTerminal.status.connecting', color: 'text-yellow-500', icon: Loader2 },
@@ -242,6 +252,20 @@ export default function RemoteTerminal({
       let attemptDisposed = false;
       const disposables: Array<{ dispose: () => void }> = [];
 
+      // Liveness bookkeeping for this attempt. Any frame from the server
+      // (output, connected, ping, pong, error) proves the server→client leg
+      // is alive; the watchdog below turns prolonged silence into a visible
+      // disconnect instead of a frozen terminal.
+      let lastServerFrameAt = Date.now();
+      let keepaliveInterval: ReturnType<typeof setInterval> | null = null;
+      let livenessInterval: ReturnType<typeof setInterval> | null = null;
+      const clearKeepaliveTimers = () => {
+        if (keepaliveInterval) clearInterval(keepaliveInterval);
+        keepaliveInterval = null;
+        if (livenessInterval) clearInterval(livenessInterval);
+        livenessInterval = null;
+      };
+
       /**
        * Tears down exactly this attempt: unhooks terminal input, detaches every
        * socket listener (so a late event is inert), and closes the socket. The
@@ -252,6 +276,7 @@ export default function RemoteTerminal({
         // has already fired (the handshake can fail while they are being wired).
         for (const d of disposables) d.dispose();
         disposables.length = 0;
+        clearKeepaliveTimers();
         if (attemptDisposed) return;
         attemptDisposed = true;
         ws.onopen = null;
@@ -276,10 +301,42 @@ export default function RemoteTerminal({
         terminalRef.current?.writeln(`\x1b[1;32m${t('remoteTerminal.connectedBang')}\x1b[0m`);
         terminalRef.current?.writeln('');
         terminalRef.current?.focus();
+
+        lastServerFrameAt = Date.now();
+        // Client-initiated keepalive: the server records our ping as liveness
+        // (and answers with a pong), so the session survives even if a
+        // server→client ping frame is lost.
+        keepaliveInterval = setInterval(() => {
+          if (serverReady && ws.readyState === WebSocket.OPEN) {
+            try {
+              ws.send(JSON.stringify({ type: 'ping' }));
+            } catch {
+              // A dead socket is surfaced by the liveness watchdog below.
+            }
+          }
+        }, CLIENT_PING_INTERVAL_MS);
+        // Server-silence watchdog: a healthy session receives a server frame
+        // at least every 30s (server ping) plus pong replies to our pings.
+        // Prolonged silence means the connection is dead even if no TCP close
+        // ever arrives — surface it instead of freezing (issue #2871).
+        livenessInterval = setInterval(() => {
+          if (isStale() || attemptDisposed) {
+            clearKeepaliveTimers();
+            return;
+          }
+          if (!serverReady) return;
+          if (Date.now() - lastServerFrameAt <= SERVER_SILENCE_TIMEOUT_MS) return;
+          disposeAttempt();
+          setStatus('failed');
+          setSessionId(null);
+          terminalRef.current?.writeln(`\x1b[1;31m${t('remoteTerminal.errors.closedUnexpectedly')}\x1b[0m`);
+          callOnDisconnect();
+        }, LIVENESS_CHECK_INTERVAL_MS);
       };
 
       ws.onmessage = (event) => {
         if (isStale() || attemptDisposed) return;
+        lastServerFrameAt = Date.now();
         if (terminalRef.current) {
           try {
             const message = JSON.parse(event.data);
@@ -354,6 +411,7 @@ export default function RemoteTerminal({
           handleRejectedHandshake();
           return;
         }
+        clearKeepaliveTimers();
         setStatus('failed');
         setSessionId(null);
         terminalRef.current?.writeln(`\x1b[1;31m${t('remoteTerminal.errors.connection')}\x1b[0m`);
@@ -370,6 +428,7 @@ export default function RemoteTerminal({
           handleRejectedHandshake();
           return;
         }
+        clearKeepaliveTimers();
         if (event.code !== 1000) {
           setStatus('failed');
           setSessionId(null);
@@ -624,42 +683,47 @@ export default function RemoteTerminal({
               <X className="h-4 w-4" />
               {t('remoteTerminal.disconnect')}
             </button>
-          ) : status === 'failed' ? (
-            <button
-              type="button"
-              onClick={connect}
-              className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
-            >
-              <RefreshCw className="h-4 w-4" />
-              {t('common:actions.retry')}
-            </button>
-          ) : status === 'disconnected' && autoConnectAttempted ? (
-            // Shown only after the initial auto-connect has run, i.e. the user
-            // has landed on a real disconnected state (manual Disconnect or a
-            // clean session end) rather than the brief pre-connect window on
-            // mount. Gives an explicit reconnect affordance now that we no
-            // longer auto-reconnect (#2137).
-            <button
-              type="button"
-              onClick={connect}
-              className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
-            >
-              <RefreshCw className="h-4 w-4" />
-              {t('remoteTerminal.reconnect')}
-            </button>
           ) : null}
+          {/* The retry/reconnect affordance lives in the disconnect overlay
+              below (#2871) — a dead session must be unmissable, and a single
+              button avoids duplicate controls for the same action. */}
         </div>
       </div>
 
       {/* Terminal Container */}
-      <div
-        ref={terminalContainerRef}
-        className={cn(
-          'flex-1 u-min-h-px-400 bg-[#1a1b26] text-[#f8f8f2] cursor-text p-2 overflow-hidden',
-          isFullscreen && 'min-h-0'
+      <div className={cn('relative flex-1 flex flex-col', isFullscreen && 'min-h-0')}>
+        <div
+          ref={terminalContainerRef}
+          className={cn(
+            'flex-1 u-min-h-px-400 bg-[#1a1b26] text-[#f8f8f2] cursor-text p-2 overflow-hidden',
+            isFullscreen && 'min-h-0'
+          )}
+          onClick={() => terminalRef.current?.focus()}
+        />
+        {/* Disconnect overlay (issue #2871): a dead session must be unmissable,
+            not a silent freeze. Shown for any post-connect terminal state that
+            is no longer live, with an explicit reconnect affordance. */}
+        {(status === 'failed' || (status === 'disconnected' && autoConnectAttempted)) && (
+          <div
+            data-testid="terminal-disconnect-overlay"
+            className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-black/70"
+          >
+            <WifiOff className="h-8 w-8 text-red-400" />
+            <span className="text-sm font-medium text-white">
+              {t(/* i18n-dynamic */ statusConfig[status].labelKey)}
+            </span>
+            <button
+              type="button"
+              data-testid="terminal-overlay-reconnect"
+              onClick={connect}
+              className="flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              <RefreshCw className="h-4 w-4" />
+              {t(status === 'failed' ? 'common:actions.retry' : 'remoteTerminal.reconnect')}
+            </button>
+          </div>
         )}
-        onClick={() => terminalRef.current?.focus()}
-      />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Root cause (server, the 60s death)

The wave-4 desktop-session **orphan-recovery background scan** (`desktopSessionOrphanRecovery.ts`) selected **all** live `remote_sessions` rows — no `type = 'desktop'` filter. For a live **terminal** session it then observed the **desktop** lease keyspace (`remote:ws:{desktop:<id>}:*`), which never has an owner for a terminal (terminals lease under `{terminal:<id>}`), so the session always looked "absent". After two scan passes one lease-TTL (30s) apart, the scanner claimed the healthy terminal session as a desktop orphan, finalized it, and **revoked its viewer session**. The terminal ping loop (30s cadence) then saw the revocation and closed the socket — `[TerminalWs] Session … revoked mid-session` at almost exactly **onOpen + 60s**, every time.

Evidence from the QA rig (main @ dfcc8f6c6, still running):
- `remote_sessions` row for QA session `d457c361…`: `type=terminal`, `error_message='orphan_recovery'` — written only by the desktop finalization path.
- API log timeline: onOpen 03:53:17.197 → revoked 03:54:17.354 (+60.16s); sibling session a8d0ddc3 died at +60.04s (pong-timeout variant, see below).

### Server fixes
- `scanDesktopSessionOrphans` now scans only `type = 'desktop'` rows.
- `recover()` refuses non-desktop sessions at **both** `loadSession` checkpoints (covers the admission/operator triggers, and a row changing type between observations).

## Web fixes (the silent freeze + the pong-timeout variant)

The sibling QA session died of `pong timeout (60015ms)` — no pong was processed for the full 60s while the browser→server leg demonstrably worked, i.e. the server→client ping frames were lost. And in both deaths the UI froze with no indicator.

- **Client-initiated keepalive pings** every 20s: the server already treats a client `{type:'ping'}` as liveness (refreshes `lastPongAt`) and answers with a pong — so the session now survives even if server→client pings are lost.
- **Server-silence watchdog**: if no server frame (output/ping/pong/connected/error) arrives for 45s, the client tears down the half-dead socket and surfaces the failure instead of freezing (a healthy session sees a server frame at least every 30s).
- **Visible disconnect overlay** over the terminal (`data-testid="terminal-disconnect-overlay"`) with an explicit Retry/Reconnect button, shown for any post-connect dead state — replaces the easy-to-miss header-only affordance (single button, no duplicate controls). No new i18n keys.

## Tests

- `desktopSessionOrphanRecovery.test.ts`: a live non-desktop session is never observed/claimed/finalized across the exact two-pass cadence that previously killed it; a row flipping to non-desktop between observations is also refused.
- `terminalWs_keepalive.test.ts` (new): healthy pong-answering session outlives 5 min; **client-ping-only** session (server pings never answered) outlives 3 min; a fully unresponsive client still dies with 4008 pong timeout; revocation-kill coverage stays in `terminalWs_close_revocation.test.ts`.
- `RemoteTerminal.test.tsx`: client pings sent once connected; server pings answered with pongs and no overlay past 2 min; prolonged silence surfaces overlay + reconnect and closes the socket; abnormal close (4003 revoked) surfaces the overlay. All 14 pass.

## Verification

- Affected API suites (7 files, 64 tests) + adjacent desktop finalization suites (3 files, 23 tests) green, single-worker.
- Web `RemoteTerminal.test.tsx` 14/14 green.
- `tsc --noEmit` clean for both `apps/api` and `apps/web`.

Deliberately **not** touched: the WS relay / `terminal_data` dual-delivery machinery — that is #2870, being fixed in a sibling PR.

Closes #2871

🤖 Generated with [Claude Code](https://claude.com/claude-code)