### PR TITLE
ci(m365): wire the graph-actions executor into CI, Trivy, Dependabot, release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -317,6 +317,21 @@ updates:
     commit-message:
       prefix: "chore(deps):"
 
+  - package-ecosystem: "docker"
+    directory: "/apps/m365-graph-actions-executor"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+    labels:
+      - "dependencies"
+      - "docker"
+      - "m365"
+    commit-message:
+      prefix: "chore(deps):"
+
   # Docker base images for release/security build Dockerfiles
   - package-ecosystem: "docker"
     directory: "/docker"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,32 @@ jobs:
       - name: Run executor tests
         run: pnpm --filter=@breeze/m365-graph-read-executor test:run
 
+  test-m365-graph-actions-executor:
+    name: Test M365 Graph Actions Executor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run executor tests
+        run: pnpm --filter=@breeze/m365-graph-actions-executor test:run
+
   # Real-Postgres apply of every migration against an empty database.
   # Catches ordering bugs (issue #506) and any SQL error the static
   # autoMigrate.test.ts cannot see. Cheap (~1 min) and blocking on PRs.
@@ -682,6 +708,41 @@ jobs:
 
       - name: Verify executor entrypoint exists
         run: test -s apps/m365-graph-read-executor/dist/index.cjs
+
+  build-m365-graph-actions-executor:
+    name: Build M365 Graph Actions Executor
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The root `typecheck` job only covers apps/api and apps/web, so this is
+      # the only tsc pass over the executor sources.
+      - name: Typecheck executor
+        run: pnpm --filter=@breeze/m365-graph-actions-executor exec tsc --noEmit
+
+      - name: Build executor
+        run: pnpm --filter=@breeze/m365-graph-actions-executor build
+
+      - name: Verify executor entrypoint exists
+        run: test -s apps/m365-graph-actions-executor/dist/index.cjs
 
   build-web:
     name: Build Web
@@ -1759,7 +1820,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-api, test-m365-graph-read-executor, test-web, test-portal, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-m365-graph-read-executor, build-web, build-portal, build-agent, test-agent, test-agent-windows, windows-runtime-smoke, integration-test, check-migrations-nonsuperuser, rust-check, smoke-test]
+    needs: [lint, typecheck, test-api, test-m365-graph-read-executor, test-m365-graph-actions-executor, test-web, test-portal, test-office-addin-core, test-excel-addin, test-word-addin, test-powerpoint-addin, test-outlook-addin, security-audit, build-api, build-m365-graph-read-executor, build-m365-graph-actions-executor, build-web, build-portal, build-agent, test-agent, test-agent-windows, windows-runtime-smoke, integration-test, check-migrations-nonsuperuser, rust-check, smoke-test]
     if: ${{ !cancelled() }}
     steps:
       - name: Check all jobs passed
@@ -1768,6 +1829,7 @@ jobs:
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           TEST_API_RESULT: ${{ needs.test-api.result }}
           TEST_M365_GRAPH_READ_EXECUTOR_RESULT: ${{ needs.test-m365-graph-read-executor.result }}
+          TEST_M365_GRAPH_ACTIONS_EXECUTOR_RESULT: ${{ needs.test-m365-graph-actions-executor.result }}
           TEST_WEB_RESULT: ${{ needs.test-web.result }}
           TEST_PORTAL_RESULT: ${{ needs.test-portal.result }}
           TEST_OFFICE_ADDIN_CORE_RESULT: ${{ needs.test-office-addin-core.result }}
@@ -1778,6 +1840,7 @@ jobs:
           SECURITY_AUDIT_RESULT: ${{ needs.security-audit.result }}
           BUILD_API_RESULT: ${{ needs.build-api.result }}
           BUILD_M365_GRAPH_READ_EXECUTOR_RESULT: ${{ needs.build-m365-graph-read-executor.result }}
+          BUILD_M365_GRAPH_ACTIONS_EXECUTOR_RESULT: ${{ needs.build-m365-graph-actions-executor.result }}
           BUILD_WEB_RESULT: ${{ needs.build-web.result }}
           BUILD_PORTAL_RESULT: ${{ needs.build-portal.result }}
           BUILD_AGENT_RESULT: ${{ needs.build-agent.result }}
@@ -1794,6 +1857,7 @@ jobs:
              [[ "${TYPECHECK_RESULT}" != "success" ]] || \
              [[ "${TEST_API_RESULT}" != "success" ]] || \
              [[ "${TEST_M365_GRAPH_READ_EXECUTOR_RESULT}" != "success" ]] || \
+             [[ "${TEST_M365_GRAPH_ACTIONS_EXECUTOR_RESULT}" != "success" ]] || \
              [[ "${TEST_WEB_RESULT}" != "success" ]] || \
              [[ "${TEST_PORTAL_RESULT}" != "success" ]] || \
              [[ "${TEST_OFFICE_ADDIN_CORE_RESULT}" != "success" ]] || \
@@ -1804,6 +1868,7 @@ jobs:
              [[ "${SECURITY_AUDIT_RESULT}" != "success" ]] || \
              [[ "${BUILD_API_RESULT}" != "success" ]] || \
              [[ "${BUILD_M365_GRAPH_READ_EXECUTOR_RESULT}" != "success" ]] || \
+             [[ "${BUILD_M365_GRAPH_ACTIONS_EXECUTOR_RESULT}" != "success" ]] || \
              [[ "${BUILD_WEB_RESULT}" != "success" ]] || \
              [[ "${BUILD_PORTAL_RESULT}" != "success" ]] || \
              [[ "${BUILD_AGENT_RESULT}" != "success" ]] || \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2510,6 +2510,102 @@ jobs:
           path: m365-graph-read-executor-image-digest.txt
           retention-days: 90
 
+  build-docker-m365-graph-actions-executor:
+    name: Build & Push M365 Graph Actions Executor Image
+    runs-on: ubuntu-latest
+    needs: [create-release]
+    if: >-
+      github.ref_type == 'tag'
+      && startsWith(github.ref, 'refs/tags/v')
+      && !cancelled()
+      && needs.create-release.result == 'success'
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      executor-image-digest: ${{ steps.push-executor-digest.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # IMAGE_NAME is ${{ github.repository }} (e.g. LanternOps/breeze), but a
+      # container reference must be lowercase. The api/web jobs launder this
+      # through docker/metadata-action (which lowercases); this job builds the
+      # ref by hand, so lowercase it explicitly.
+      - name: Compute lowercase image base
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          BASE="${REGISTRY}/${IMAGE_NAME}"
+          echo "IMAGE_BASE=${BASE,,}" >> "$GITHUB_ENV"
+
+      # Push by digest only: no release-facing tag exists until this exact
+      # manifest passes the blocking vulnerability scan below.
+      - name: Build and push unadvertised executor digest
+        id: push-executor-digest
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: apps/m365-graph-actions-executor/Dockerfile
+          outputs: type=image,name=${{ env.IMAGE_BASE }}/m365-graph-actions-executor,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan exact executor digest
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_BASE }}/m365-graph-actions-executor@${{ steps.push-executor-digest.outputs.digest }}
+          severity: 'HIGH,CRITICAL'
+          format: 'table'
+          exit-code: '1'
+
+      # Promote the already-scanned manifest. imagetools only creates tag
+      # references; it never rebuilds or mutates the image layers.
+      - name: Promote scanned executor digest
+        env:
+          EXECUTOR_REPOSITORY: ${{ env.IMAGE_BASE }}/m365-graph-actions-executor
+          EXECUTOR_IMAGE_DIGEST: ${{ steps.push-executor-digest.outputs.digest }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          VERSION="${RELEASE_REF_NAME#v}"
+          SHORT_SHA="${RELEASE_SHA::7}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Executor image promotion requires an exact semver release tag" >&2
+            exit 1
+          fi
+          docker buildx imagetools create \
+            --tag "${EXECUTOR_REPOSITORY}:${VERSION}" \
+            --tag "${EXECUTOR_REPOSITORY}:sha-${SHORT_SHA}" \
+            "${EXECUTOR_REPOSITORY}@${EXECUTOR_IMAGE_DIGEST}"
+
+      - name: Record executor digest
+        env:
+          EXECUTOR_IMAGE_DIGEST: ${{ steps.push-executor-digest.outputs.digest }}
+        run: |
+          test -n "$EXECUTOR_IMAGE_DIGEST"
+          printf '%s\n' "$EXECUTOR_IMAGE_DIGEST" > m365-graph-actions-executor-image-digest.txt
+
+      - name: Upload executor digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: m365-graph-actions-executor-image-digest
+          path: m365-graph-actions-executor-image-digest.txt
+          retention-days: 90
+
   build-docker-web:
     name: Build & Push Web Docker Image
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -173,6 +173,9 @@ jobs:
       - name: Build M365 Graph Read Executor image
         run: docker build -f apps/m365-graph-read-executor/Dockerfile -t breeze-m365-graph-read-executor:security-scan .
 
+      - name: Build M365 Graph Actions Executor image
+        run: docker build -f apps/m365-graph-actions-executor/Dockerfile -t breeze-m365-graph-actions-executor:security-scan .
+
       - name: Scan API image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -201,6 +204,14 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: 'breeze-m365-graph-read-executor:security-scan'
+          severity: 'HIGH,CRITICAL'
+          format: 'table'
+          exit-code: '1'
+
+      - name: Scan M365 Graph Actions Executor image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'breeze-m365-graph-actions-executor:security-scan'
           severity: 'HIGH,CRITICAL'
           format: 'table'
           exit-code: '1'


### PR DESCRIPTION
## What

The customer-graph-actions executor shipped in #2628 with **zero CI coverage**. Its read-only sibling has 19 workflow references; this one had none.

Most pointed part: `apps/m365-graph-actions-executor/src` contains **11 test files / 222 tests that no CI job has ever executed**. They pass — they were just never wired up, so they've been protecting nothing.

This is the executor holding customer Graph credentials and performing **mutations**, so it's the one that most warrants the coverage its read-only sibling already has.

## Changes

Mirrors the read executor's wiring, job for job:

| File | Added |
|---|---|
| `ci.yml` | `test-m365-graph-actions-executor` + `build-m365-graph-actions-executor` (tsc `--noEmit`, tsup, entrypoint assert) |
| `ci.yml` | both jobs in `ci-success` `needs`, `env`, **and** the `[[ ]]` gate chain |
| `security.yml` | image build + Trivy HIGH/CRITICAL scan (`exit-code: 1`) |
| `dependabot.yml` | docker entry for the executor base image |
| `release.yml` | push-by-digest → scan that digest → promote scanned manifest |

Two details worth calling out:

- **The root `typecheck` job only covers `apps/api` and `apps/web`.** So the new build job is the *only* tsc pass over these sources — not a redundant one.
- **`deploy/.env.example:211` already tells operators to pin `ghcr.io/lanternops/breeze/m365-graph-actions-executor@sha256:<digest>`** — an image the release pipeline never built. The deploy documentation could not be followed as written. That's why the release job is in scope rather than deferred.

Dependabot's **npm** side already came free from the root workspace entry, so only the docker base-image entry was actually missing. Likewise `pnpm lint` is `turbo run lint`, so ESLint already covered this package — "zero coverage" was true of tests/build/scan/release, not lint.

## Verification

Everything was run locally **before** wiring, so none of these jobs land red on main:

- `pnpm --filter=@breeze/m365-graph-actions-executor test:run` → **222/222 pass** (11 files)
- `tsc --noEmit` → clean
- `pnpm build` → emits non-empty `dist/index.cjs`
- `docker build -f apps/m365-graph-actions-executor/Dockerfile` → exit 0
- `actionlint -shellcheck=` (the exact CI invocation) → clean
- `zizmor==1.25.2 --config .github/zizmor.yml --min-severity medium` → no findings

The `ci-success` gate was **mutation-tested** rather than eyeballed: I extracted the step's script and ran it with each new variable flipped to `failure` in isolation.

| Scenario | Exit |
|---|---|
| all jobs `success` | 0 |
| only `TEST_M365_GRAPH_ACTIONS_EXECUTOR_RESULT=failure` | 1 |
| only `BUILD_M365_GRAPH_ACTIONS_EXECUTOR_RESULT=failure` | 1 |

That matters because adding the `env:` var without adding the `[[ ]]` clause produces a job that reports status but gates nothing — which is indistinguishable from working until the day it needs to block.

## Deliberately not included

The actions-side analogue of `check-m365-graph-read-runtime.sh`. `deploy/docker-compose.prod.yml:463` declares `m365_graph_actions_executor_signing_private_jwk` with the same file-backed secret semantics (uid/gid/mode on the source) that the read-side smoke exists to guard — **so that guard has a real gap on the actions path**. It needs its own probe bundle and compose scaffolding, so it wants a separate PR rather than inflating this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)