### PR TITLE
security(m365): actions signing-secret runtime smoke + hardening-guard parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,6 +623,9 @@ jobs:
       - name: Run M365 signing secret runtime smoke
         run: bash scripts/security/check-m365-graph-read-runtime.sh
 
+      - name: Run M365 actions signing secret runtime smoke
+        run: bash scripts/security/check-m365-graph-actions-runtime.sh
+
       - name: Run relay/edge hardening guard
         run: bash scripts/security/check-relay-edge-hardening.sh
 

--- a/scripts/security/check-m365-graph-actions-runtime.sh
+++ b/scripts/security/check-m365-graph-actions-runtime.sh
@@ -6,13 +6,13 @@ cd "$ROOT_DIR"
 
 NODE_IMAGE='node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd'
 TMP_DIR="$(mktemp -d)"
-PROJECT_NAME="m365-secret-smoke-$RANDOM-$$"
+PROJECT_NAME="m365-actions-secret-smoke-$RANDOM-$$"
 OVERRIDE_FILE="$TMP_DIR/compose.override.yml"
-PROBE_BUNDLE="$TMP_DIR/m365-graph-read-runtime-probe.cjs"
+PROBE_BUNDLE="$TMP_DIR/m365-graph-actions-runtime-probe.cjs"
 PRIVATE_JWK="$TMP_DIR/api-signing-private.jwk"
 
 cleanup() {
-  M365_GRAPH_READ_RUNTIME_PROBE_FILE="$PROBE_BUNDLE" \
+  M365_GRAPH_ACTIONS_RUNTIME_PROBE_FILE="$PROBE_BUNDLE" \
     docker compose --project-name "$PROJECT_NAME" \
       --env-file deploy/compose-config-test.env \
       -f deploy/docker-compose.prod.yml \
@@ -21,12 +21,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-command -v docker >/dev/null || { echo 'docker is required for the M365 secret runtime smoke' >&2; exit 1; }
-command -v pnpm >/dev/null || { echo 'pnpm is required for the M365 secret runtime smoke' >&2; exit 1; }
-docker info >/dev/null 2>&1 || { echo 'a running Docker daemon is required for the M365 secret runtime smoke' >&2; exit 1; }
+command -v docker >/dev/null || { echo 'docker is required for the M365 actions secret runtime smoke' >&2; exit 1; }
+command -v pnpm >/dev/null || { echo 'pnpm is required for the M365 actions secret runtime smoke' >&2; exit 1; }
+docker info >/dev/null 2>&1 || { echo 'a running Docker daemon is required for the M365 actions secret runtime smoke' >&2; exit 1; }
 
-pnpm --filter=@breeze/m365-graph-read-executor exec tsup \
-  ../../scripts/security/m365-graph-read-runtime-probe.ts \
+pnpm --filter=@breeze/m365-graph-actions-executor exec tsup \
+  ../../scripts/security/m365-graph-actions-runtime-probe.ts \
   --format cjs --platform node --target node22 --out-dir "$TMP_DIR" --clean false
 
 umask 077
@@ -50,9 +50,12 @@ NODE
 # LOCAL-RUN CAVEAT (macOS): Docker Desktop's VirtioFS/gRPC-FUSE layer remaps
 # bind-mount ownership to whichever uid/gid the container runs as, so the
 # probe's `uid !== 1001 || gid !== 1001` assertion always observes 1001:1001
-# here and cannot fail. Only the mode assertion is falsifiable on macOS; the
-# ownership half is real ONLY on the Linux CI runner. Do not conclude from a
-# green local run that the ownership check works.
+# here and cannot fail — verified 2026-07-28 by mounting a deliberately
+# root-owned file and reading back uid=1001. Only the mode assertion is
+# falsifiable on macOS. The ownership half is real ONLY on the Linux CI
+# runner, where bind mounts preserve host uid/gid. Do not conclude from a
+# green local run that the ownership check works. The read-profile smoke
+# has the identical limitation.
 docker run --rm --user 0:0 -v "$TMP_DIR:/work" "$NODE_IMAGE" \
   sh -ec 'chown 1001:1001 /work/api-signing-private.jwk && chmod 0400 /work/api-signing-private.jwk'
 
@@ -64,7 +67,7 @@ services:
     entrypoint: ["node", "/runtime-probe.cjs"]
     command: []
     volumes:
-      - \${M365_GRAPH_READ_RUNTIME_PROBE_FILE:?Set runtime probe file}:/runtime-probe.cjs:ro
+      - \${M365_GRAPH_ACTIONS_RUNTIME_PROBE_FILE:?Set runtime probe file}:/runtime-probe.cjs:ro
 secrets:
   # The smoke does not exercise Redis. Replace its environment-backed secret
   # with an inert file-backed mount for this isolated one-shot.
@@ -82,25 +85,25 @@ compose=(
   -f "$OVERRIDE_FILE"
 )
 
-export M365_GRAPH_READ_RUNTIME_PROBE_FILE="$PROBE_BUNDLE"
+export M365_GRAPH_ACTIONS_RUNTIME_PROBE_FILE="$PROBE_BUNDLE"
 
 # The checked production declaration defaults to /dev/null while onboarding is
 # dark. The API's real boot validator must leave the signing file untouched.
-unset M365_GRAPH_READ_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE
+unset M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE
 "${compose[@]}" run --no-deps --rm api
 
 # Enabling onboarding makes the same Compose secret declaration bind the
 # pre-provisioned JWK. The probe runs as the API's numeric uid/gid and imports
 # the real runtime loader; it prints only a stable success message.
-export M365_GRAPH_READ_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE="$PRIVATE_JWK"
+export M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE="$PRIVATE_JWK"
 "${compose[@]}" run --no-deps --rm \
-  -e M365_CUSTOMER_GRAPH_READ_ONBOARDING_ENABLED=true \
-  -e 'M365_CUSTOMER_GRAPH_READ_ONBOARDING_ORG_IDS=*' \
-  -e M365_CUSTOMER_GRAPH_READ_CLIENT_ID=11111111-1111-1111-1111-111111111111 \
-  -e M365_CUSTOMER_GRAPH_READ_CREDENTIAL_VERSION=00000000000000000000000000000000 \
-  -e M365_CUSTOMER_GRAPH_READ_VAULT_REF=akv://vault.example.invalid/m365-customer-graph-read/00000000000000000000000000000000 \
-  -e M365_GRAPH_READ_EXECUTOR_URL=https://executor.example.invalid \
-  -e M365_GRAPH_READ_EXECUTOR_AUDIENCE=m365-graph-read-executor \
-  -e M365_GRAPH_READ_EXECUTOR_SIGNING_KID=m365-runtime-smoke \
+  -e M365_CUSTOMER_GRAPH_ACTIONS_ONBOARDING_ENABLED=true \
+  -e 'M365_CUSTOMER_GRAPH_ACTIONS_ONBOARDING_ORG_IDS=*' \
+  -e M365_CUSTOMER_GRAPH_ACTIONS_CLIENT_ID=11111111-1111-1111-1111-111111111111 \
+  -e M365_CUSTOMER_GRAPH_ACTIONS_CREDENTIAL_VERSION=00000000000000000000000000000000 \
+  -e M365_CUSTOMER_GRAPH_ACTIONS_VAULT_REF=akv://vault.example.invalid/m365-customer-graph-actions/00000000000000000000000000000000 \
+  -e M365_GRAPH_ACTIONS_EXECUTOR_URL=https://executor.example.invalid \
+  -e M365_GRAPH_ACTIONS_EXECUTOR_AUDIENCE=m365-graph-actions-executor \
+  -e M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_KID=m365-runtime-smoke \
   -e PUBLIC_API_URL=https://breeze.example.invalid \
   api

--- a/scripts/security/check-supply-chain-hardening.sh
+++ b/scripts/security/check-supply-chain-hardening.sh
@@ -174,10 +174,28 @@ require_grep '\[\[ "\$\{TEST_M365_GRAPH_READ_EXECUTOR_RESULT\}" != "success" \]\
 require_grep '\[\[ "\$\{BUILD_M365_GRAPH_READ_EXECUTOR_RESULT\}" != "success" \]\]' "$ci_success_block" \
   "ci-success must fail unless the executor build succeeds"
 
+# Same gating for the customer-graph-ACTIONS executor. It holds mutation
+# credentials, so its jobs must be as tamper-evident as the read sibling's.
+# The env var alone is decorative: the `[[ ]]` clause is what actually blocks.
+require_grep 'needs: .*test-m365-graph-actions-executor' "$ci_success_block" \
+  "ci-success must depend on actions-executor tests"
+require_grep 'needs: .*build-m365-graph-actions-executor' "$ci_success_block" \
+  "ci-success must depend on the actions-executor build"
+require_grep 'TEST_M365_GRAPH_ACTIONS_EXECUTOR_RESULT:.*needs\.test-m365-graph-actions-executor\.result' "$ci_success_block" \
+  "ci-success must read the actions-executor test result"
+require_grep 'BUILD_M365_GRAPH_ACTIONS_EXECUTOR_RESULT:.*needs\.build-m365-graph-actions-executor\.result' "$ci_success_block" \
+  "ci-success must read the actions-executor build result"
+require_grep '\[\[ "\$\{TEST_M365_GRAPH_ACTIONS_EXECUTOR_RESULT\}" != "success" \]\]' "$ci_success_block" \
+  "ci-success must fail unless actions-executor tests succeed"
+require_grep '\[\[ "\$\{BUILD_M365_GRAPH_ACTIONS_EXECUTOR_RESULT\}" != "success" \]\]' "$ci_success_block" \
+  "ci-success must fail unless the actions-executor build succeeds"
+
 security_audit_block="$GUARD_TMP_DIR/security-audit.yml"
 extract_yaml_job security-audit .github/workflows/ci.yml "$security_audit_block"
 require_grep 'run: bash scripts/security/check-m365-graph-read-runtime\.sh' "$security_audit_block" \
   "blocking CI must run the real Compose signing-secret runtime smoke"
+require_grep 'run: bash scripts/security/check-m365-graph-actions-runtime\.sh' "$security_audit_block" \
+  "blocking CI must run the real Compose actions signing-secret runtime smoke"
 
 executor_release_block="$GUARD_TMP_DIR/executor-release.yml"
 extract_yaml_job build-docker-m365-graph-read-executor .github/workflows/release.yml "$executor_release_block"
@@ -213,6 +231,33 @@ require_grep 'breeze-m365-graph-read-executor:security-scan' .github/workflows/s
   "security workflow must build and scan the executor image"
 [[ -x scripts/security/check-m365-graph-read-runtime.sh ]] || \
   fail "scripts/security/check-m365-graph-read-runtime.sh must be executable"
+require_grep 'breeze-m365-graph-actions-executor:security-scan' .github/workflows/security.yml \
+  "security workflow must build and scan the actions-executor image"
+[[ -x scripts/security/check-m365-graph-actions-runtime.sh ]] || \
+  fail "scripts/security/check-m365-graph-actions-runtime.sh must be executable"
+
+actions_release_block="$GUARD_TMP_DIR/actions-executor-release.yml"
+extract_yaml_job build-docker-m365-graph-actions-executor .github/workflows/release.yml "$actions_release_block"
+require_grep 'outputs: type=image,name=.*m365-graph-actions-executor,push-by-digest=true,name-canonical=true,push=true' "$actions_release_block" \
+  "release must push an unadvertised actions-executor digest before tagging"
+require_grep 'image-ref:.*m365-graph-actions-executor@\$\{\{ steps\.push-executor-digest\.outputs\.digest \}\}' "$actions_release_block" \
+  "release Trivy scan must target the exact pushed actions-executor digest"
+require_grep "severity: 'HIGH,CRITICAL'" "$actions_release_block" \
+  "release actions-executor scan must block HIGH and CRITICAL findings"
+require_grep "exit-code: '1'" "$actions_release_block" \
+  "release actions-executor scan must be blocking"
+require_grep 'docker buildx imagetools create' "$actions_release_block" \
+  "release must promote the scanned actions-executor digest without rebuilding"
+[[ "$(grep -o -- '--tag' "$actions_release_block" | wc -l | tr -d ' ')" == 2 ]] || \
+  fail "actions-executor release must publish only exact semver and commit-SHA tags"
+reject_grep 'type=raw,value=latest|pattern=\{\{major\}\}|pattern=\{\{major\}\}\.\{\{minor\}\}' "$actions_release_block" \
+  "actions-executor release must not publish latest, major, or minor mutable tags"
+[[ "$(grep -c 'docker/build-push-action@' "$actions_release_block")" == 1 ]] || \
+  fail "actions-executor release must build the image exactly once"
+require_order 'id: push-executor-digest' 'name: Scan exact executor digest' "$actions_release_block" \
+  "actions-executor release must build before scanning"
+require_order 'name: Scan exact executor digest' 'name: Promote scanned executor digest' "$actions_release_block" \
+  "actions-executor release promotion must occur only after its exact digest passes scanning"
 
 for compose in docker-compose.yml deploy/docker-compose.prod.yml; do
   reject_grep '^  m365-graph-read-executor:' "$compose" \
@@ -223,6 +268,14 @@ for compose in docker-compose.yml deploy/docker-compose.prod.yml; do
     "$compose must load the API executor-signing private JWK from a Docker secret"
   require_grep '^  m365_graph_read_executor_signing_private_jwk:' "$compose" \
     "$compose must define the API executor-signing private-JWK secret"
+  reject_grep '^  m365-graph-actions-executor:' "$compose" \
+    "$compose must not deploy the actions executor without an identity-capable private environment"
+  require_grep 'M365_CUSTOMER_GRAPH_ACTIONS_ONBOARDING_ENABLED:[[:space:]]+\$\{M365_CUSTOMER_GRAPH_ACTIONS_ONBOARDING_ENABLED:-false\}' "$compose" \
+    "$compose must keep customer Graph-actions onboarding disabled by default"
+  require_grep 'M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE:[[:space:]]+/run/secrets/m365_graph_actions_executor_signing_private_jwk' "$compose" \
+    "$compose must load the API actions-executor-signing private JWK from a Docker secret"
+  require_grep '^  m365_graph_actions_executor_signing_private_jwk:' "$compose" \
+    "$compose must define the API actions-executor-signing private-JWK secret"
 
   api_block="$GUARD_TMP_DIR/$(basename "$compose").api.yml"
   awk '
@@ -251,6 +304,8 @@ for deployment_template in .env.example deploy/.env.example; do
     "$deployment_template must document the executor tmpfs requirement"
   require_grep 'm365-graph-read-executor@sha256:<digest>' "$deployment_template" \
     "$deployment_template must require a digest-addressed executor image"
+  require_grep 'm365-graph-actions-executor@sha256:<digest>' "$deployment_template" \
+    "$deployment_template must require a digest-addressed actions-executor image"
   require_grep 'numeric owner 1001:1001 and mode 0400' "$deployment_template" \
     "$deployment_template must document standalone Compose file-secret ownership requirements"
 done

--- a/scripts/security/m365-graph-actions-runtime-probe.ts
+++ b/scripts/security/m365-graph-actions-runtime-probe.ts
@@ -1,0 +1,37 @@
+import { statSync } from 'node:fs';
+import {
+  loadM365CustomerGraphActionsRuntimeConfig,
+  validateM365CustomerGraphActionsRuntimeConfigAtBoot,
+} from '../../apps/api/src/services/m365ControlPlane/writeActionRuntimeConfig';
+
+const enabled = ['1', 'true', 'yes', 'on'].includes(
+  (process.env.M365_CUSTOMER_GRAPH_ACTIONS_ONBOARDING_ENABLED ?? '').toLowerCase(),
+);
+
+validateM365CustomerGraphActionsRuntimeConfigAtBoot(process.env);
+
+if (!enabled) {
+  process.stdout.write('m365 actions signing secret dark-config smoke passed\n');
+  process.exit(0);
+}
+
+const secretPath = process.env.M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE;
+if (!secretPath) throw new Error('signing private-JWK file path is missing');
+
+const metadata = statSync(secretPath);
+if (!metadata.isFile() || metadata.uid !== 1001 || metadata.gid !== 1001) {
+  throw new Error('signing private-JWK secret must be a regular file owned by numeric 1001:1001');
+}
+if ((metadata.mode & 0o777) !== 0o400) {
+  throw new Error('signing private-JWK secret must have mode 0400');
+}
+
+const config = loadM365CustomerGraphActionsRuntimeConfig(process.env);
+if (
+  config.executorSigningKid !== 'm365-runtime-smoke'
+  || typeof config.executorSigningPrivateJwk.d !== 'string'
+) {
+  throw new Error('API runtime did not load the expected signing-key descriptor');
+}
+
+process.stdout.write('m365 actions signing secret enabled-config smoke passed\n');


### PR DESCRIPTION
## What

The customer-graph-actions signing secret had **no runtime guard**. `deploy/docker-compose.prod.yml:463` declares `m365_graph_actions_executor_signing_private_jwk` with exactly the file-backed secret semantics — numeric owner `1001:1001`, mode `0400` — that `check-m365-graph-read-runtime.sh` exists to prove for the read profile. Nothing exercised the actions path, and this is the executor holding **mutation** credentials.

This was the follow-up I flagged and deliberately scoped out of #2893.

## Changes

**1. The actions runtime smoke** (`m365-graph-actions-runtime-probe.ts` + `check-m365-graph-actions-runtime.sh`)

Boots the real production Compose declaration twice:
- **dark** — secret must stay untouched at `/dev/null`
- **onboarding enabled** — secret must bind, and the API's own runtime loader must accept the descriptor

Wired into the blocking `security-audit` job.

**2. Hardening-guard parity** (`check-supply-chain-hardening.sh`)

The meta-guard pinned the read executor's entire posture by name and was **completely silent about the actions sibling** — meaning the wiring added in #2893 could be removed without CI noticing. It now pins, for actions:

- `ci-success` needs / env / **gate clauses**
- the `security.yml` image scan
- the release job's push-by-digest → scan-exact-digest → imagetools-promote invariants (exactly 2 tags, no mutable tags, build once, correct ordering)
- the runtime smoke step + the executable bit
- the digest-addressed image in both `.env.example` files
- **that neither compose file may declare an `m365-graph-actions-executor:` service** — this one is a real security property rather than wiring, since the executor requires an identity-capable private environment

## Verification

The smoke passes both paths against real Docker. Every new assertion was **mutation-tested** rather than eyeballed:

| Mutation | Guard result |
|---|---|
| delete the actions runtime smoke step | ❌ "must run the real Compose actions signing-secret runtime smoke" |
| delete the actions TEST gate clause | ❌ "must fail unless actions-executor tests succeed" |
| add an `m365-graph-actions-executor:` compose service | ❌ "must not deploy the actions executor without an identity-capable private environment" |
| restore all three | ✅ green |

And the smoke itself is not vacuous: making the secret world-readable (`0444` instead of `0400`) is rejected by the API's real `parseSigningPrivateJwk` loader — the actual production code path, not a test double.

## One caveat, documented in both scripts

While mutation-testing I found that **on macOS, Docker Desktop's VirtioFS layer remaps bind-mount ownership to the accessing container uid**. I confirmed it directly: mounted a deliberately root-owned file, read back `uid=1001`.

So the probe's `uid/gid !== 1001` assertion **always observes 1001:1001 locally and cannot fail**. Only the mode half is falsifiable on macOS; the ownership half is real *only* on the Linux CI runner, where bind mounts preserve host uid/gid.

My first ownership-mutation run "passed", and that result was meaningless — worth knowing before someone else reads a green local run as proof. The **pre-existing read smoke has the identical limitation**, which is why the note went into it too (comment-only, no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)