### PR TITLE
fix(api): three Sentry issues — authenticator FK 500s (BREEZE-12/13), S3 endpoint save gaps (BREEZE-P), CAS 0-row diagnostics (BREEZE-X)

### DIFF
--- a/apps/api/src/__tests__/integration/authenticatorMobileDeviceResolution.integration.test.ts
+++ b/apps/api/src/__tests__/integration/authenticatorMobileDeviceResolution.integration.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Real-Postgres proof for the X-Breeze-Mobile-Device-Id resolution on
+ * POST /authenticator/devices (Sentry BREEZE-12 / BREEZE-13).
+ *
+ * The bug: the route wrote the header value straight into
+ * `authenticator_devices.mobile_device_id`, which FKs `mobile_devices.id`
+ * (2026-06-14-a-authenticator-foundation.sql). But the header carries
+ * `mobile_devices.device_id` — a VARCHAR per-install id minted on the phone —
+ * not the server-side uuid PK. Every mobile registration therefore 500'd:
+ * 23503 for the uuid-SHAPED per-install id, 22P02 for a non-uuid header.
+ *
+ * The unit suite fully mocks `../db`, so the FK, the uuid cast and RLS are all
+ * structurally invisible to it — which is exactly how this shipped. Only a real
+ * connection can prove:
+ *
+ *   1. the FK really does reject the raw header (negative control — this is the
+ *      500 that shipped), while the resolved id is accepted;
+ *   2. a junk header really is a varchar miss and not a 22P02 cast error;
+ *   3. the ownership predicate does real work, because RLS does NOT supply it:
+ *      `mobile_devices`' SELECT policy
+ *      (2026-04-11-bucket-c-phase-6-user-scoped-rls.sql) has an `OR EXISTS`
+ *      branch that makes a same-tenant colleague's row fully visible to the
+ *      caller. This test seeds exactly that row and asserts the registration
+ *      still resolves to null.
+ *
+ * The route is driven end-to-end through Hono with only the auth middleware and
+ * the auth-audit/step-up helpers mocked; `db` is the real breeze_app pool.
+ */
+import './setup';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { and, eq } from 'drizzle-orm';
+
+let activeAuth: { userId: string; orgId: string; partnerId: string } | null = null;
+
+// Partial mock: only the three gates this route uses are replaced. The rest of
+// the module (requireScope, …) must stay real — other modules pulled in through
+// the services barrel import it at module scope.
+vi.mock('../../middleware/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../middleware/auth')>();
+  const { withDbAccessContext } = await import('../../db');
+  return {
+    ...actual,
+    authMiddleware: (c: any, next: any) => {
+      if (!activeAuth) return c.json({ error: 'Unauthorized' }, 401);
+      c.set('auth', {
+        scope: 'partner',
+        user: { id: activeAuth.userId, email: 'approver@test', name: 'Approver' },
+        orgId: activeAuth.orgId,
+        partnerId: activeAuth.partnerId,
+        token: { mfa: true, sid: 'sid-integration' },
+      });
+      // Same shape the real authMiddleware opens (middleware/auth.ts). userId is
+      // what seeds breeze_current_user_id(), which both authenticator_devices'
+      // and mobile_devices' policies key off.
+      return withDbAccessContext(
+        {
+          scope: 'partner',
+          orgId: null,
+          accessibleOrgIds: [activeAuth.orgId],
+          accessiblePartnerIds: [activeAuth.partnerId],
+          userId: activeAuth.userId,
+        },
+        () => next()
+      );
+    },
+    requirePermission: () => (_c: any, next: any) => next(),
+    requireMfa: () => (_c: any, next: any) => next(),
+  };
+});
+
+const auditCalls: any[] = [];
+
+vi.mock('../../routes/auth/helpers', () => ({
+  writeAuthAudit: (_c: unknown, entry: unknown) => {
+    auditCalls.push(entry);
+  },
+  enforceApproverRegisterStepUp: async () => null,
+  requireCurrentPasswordStepUp: async () => null,
+  userHasStrongerReauthFactor: async () => false,
+}));
+
+import { db, withSystemDbAccessContext } from '../../db';
+import { authenticatorDevices, mobileDevices } from '../../db/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+import { getTestDb } from './setup';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+const createdPartnerIds: string[] = [];
+
+afterEach(async () => {
+  activeAuth = null;
+  auditCalls.length = 0;
+  if (createdPartnerIds.length === 0) return;
+  const adminDb = getTestDb() as any;
+  const { sql } = await import('drizzle-orm');
+  const partnerList = sql.join(createdPartnerIds.map((id) => sql`${id}`), sql`, `);
+  await adminDb.execute(
+    sql`DELETE FROM authenticator_devices WHERE user_id IN (SELECT id FROM users WHERE partner_id IN (${partnerList}))`
+  );
+  await adminDb.execute(
+    sql`DELETE FROM mobile_devices WHERE user_id IN (SELECT id FROM users WHERE partner_id IN (${partnerList}))`
+  );
+  await adminDb.execute(sql`DELETE FROM users WHERE partner_id IN (${partnerList})`);
+  await adminDb.execute(
+    sql`DELETE FROM organizations WHERE partner_id IN (${partnerList})`
+  );
+  await adminDb.execute(sql`DELETE FROM partners WHERE id IN (${partnerList})`);
+  createdPartnerIds.length = 0;
+});
+
+async function buildApp() {
+  // Import AFTER the mocks are registered.
+  const { authenticatorRoutes } = await import('../../routes/authenticator');
+  const app = new Hono();
+  app.route('/authenticator', authenticatorRoutes);
+  return app;
+}
+
+function unique() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** One partner + org + two users in the SAME tenant (caller and a colleague). */
+async function seedTenant() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const caller = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `mdid-caller-${unique()}@example.test`,
+  });
+  const colleague = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `mdid-colleague-${unique()}@example.test`,
+  });
+  createdPartnerIds.push(partner.id);
+  return { partnerId: partner.id, orgId: org.id, caller, colleague };
+}
+
+async function seedMobileDevice(userId: string, deviceId: string): Promise<string> {
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .insert(mobileDevices)
+      .values({ userId, deviceId, platform: 'ios' })
+      .returning({ id: mobileDevices.id })
+  );
+  return row!.id;
+}
+
+const REGISTER_BODY = {
+  registerGrantId: 'g-integration',
+  publicKey: 'pk-integration',
+  label: 'iPhone',
+};
+
+async function register(app: Hono, header?: string) {
+  return app.request('/authenticator/devices', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer access-token',
+      ...(header === undefined ? {} : { 'X-Breeze-Mobile-Device-Id': header }),
+    },
+    body: JSON.stringify(REGISTER_BODY),
+  });
+}
+
+/** The single authenticator_devices row this registration created. */
+async function insertedRow(userId: string) {
+  const rows = await withSystemDbAccessContext(() =>
+    db
+      .select({ id: authenticatorDevices.id, mobileDeviceId: authenticatorDevices.mobileDeviceId })
+      .from(authenticatorDevices)
+      .where(eq(authenticatorDevices.userId, userId))
+  );
+  return rows;
+}
+
+describe('POST /authenticator/devices — X-Breeze-Mobile-Device-Id resolution (real Postgres)', () => {
+  runDb('resolves the per-install header to the caller-owned mobile_devices.id', async () => {
+    const { partnerId, orgId, caller } = await seedTenant();
+    // The app mints a uuid-SHAPED per-install id and stores it in device_id.
+    const perInstallId = `11111111-2222-3333-4444-${Date.now().toString().slice(-12)}`;
+    const mobileRowId = await seedMobileDevice(caller.id, perInstallId);
+    expect(mobileRowId).not.toBe(perInstallId);
+
+    activeAuth = { userId: caller.id, orgId, partnerId };
+    const res = await register(await buildApp(), perInstallId);
+
+    expect(res.status).toBe(201);
+    const rows = await insertedRow(caller.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.mobileDeviceId).toBe(mobileRowId);
+    expect(rows[0]!.mobileDeviceId).not.toBe(perInstallId);
+    expect(auditCalls.at(-1)?.details).toMatchObject({ mobileDeviceId: mobileRowId });
+  });
+
+  runDb(
+    'NEGATIVE CONTROL: writing the raw header into the FK column is the 23503 that shipped',
+    async () => {
+      const { caller } = await seedTenant();
+      const perInstallId = `11111111-2222-3333-4444-${Date.now().toString().slice(-12)}`;
+      await seedMobileDevice(caller.id, perInstallId);
+
+      let cause: string | undefined;
+      try {
+        await withSystemDbAccessContext(() =>
+          db.insert(authenticatorDevices).values({
+            userId: caller.id,
+            kind: 'mobile_hw_key',
+            publicKey: 'pk-fk-control',
+            isPlatformBound: true,
+            // The pre-fix behaviour: the per-install device_id straight into a
+            // column that FKs mobile_devices.id.
+            mobileDeviceId: perInstallId,
+          })
+        );
+      } catch (err) {
+        cause = (err as { cause?: { message?: string } } | undefined)?.cause?.message;
+      }
+
+      expect(cause).toBeDefined();
+      expect(cause).toMatch(/violates foreign key constraint/i);
+    }
+  );
+
+  runDb('a junk non-uuid header is a varchar miss (201 + null), never a 22P02 cast error', async () => {
+    const { partnerId, orgId, caller } = await seedTenant();
+
+    activeAuth = { userId: caller.id, orgId, partnerId };
+    const res = await register(await buildApp(), 'hello');
+
+    expect(res.status).toBe(201);
+    const rows = await insertedRow(caller.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.mobileDeviceId).toBeNull();
+    expect(auditCalls.at(-1)?.details).toMatchObject({ mobileDeviceHeaderUnresolved: 'hello' });
+  });
+
+  runDb(
+    "does not adopt a same-tenant colleague's mobile_devices row — RLS alone would let it through",
+    async () => {
+      const { partnerId, orgId, caller, colleague } = await seedTenant();
+      const perInstallId = `22222222-3333-4444-5555-${Date.now().toString().slice(-12)}`;
+      const colleagueRowId = await seedMobileDevice(colleague.id, perInstallId);
+
+      activeAuth = { userId: caller.id, orgId, partnerId };
+      const app = await buildApp();
+      const res = await register(app, perInstallId);
+
+      expect(res.status).toBe(201);
+      const rows = await insertedRow(caller.id);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.mobileDeviceId).toBeNull();
+      expect(rows[0]!.mobileDeviceId).not.toBe(colleagueRowId);
+
+      // Proof the null above came from the APP-LAYER ownership predicate and not
+      // from RLS: under the caller's own request context, the colleague's row is
+      // visible (the policy's `OR EXISTS` same-tenant branch). Drop
+      // `eq(mobileDevices.userId, ...)` from the route and this row is what the
+      // lookup would return.
+      const { withDbAccessContext } = await import('../../db');
+      const visible = await withDbAccessContext(
+        {
+          scope: 'partner',
+          orgId: null,
+          accessibleOrgIds: [orgId],
+          accessiblePartnerIds: [partnerId],
+          userId: caller.id,
+        },
+        () =>
+          db
+            .select({ id: mobileDevices.id })
+            .from(mobileDevices)
+            .where(eq(mobileDevices.deviceId, perInstallId))
+      );
+      expect(visible.map((r) => r.id)).toEqual([colleagueRowId]);
+
+      // ...and the ownership-scoped form the route actually issues sees nothing.
+      const owned = await withDbAccessContext(
+        {
+          scope: 'partner',
+          orgId: null,
+          accessibleOrgIds: [orgId],
+          accessiblePartnerIds: [partnerId],
+          userId: caller.id,
+        },
+        () =>
+          db
+            .select({ id: mobileDevices.id })
+            .from(mobileDevices)
+            .where(
+              and(eq(mobileDevices.deviceId, perInstallId), eq(mobileDevices.userId, caller.id))
+            )
+      );
+      expect(owned).toEqual([]);
+    }
+  );
+
+  runDb('registers with a null mobile_device_id when the header is absent', async () => {
+    const { partnerId, orgId, caller } = await seedTenant();
+
+    activeAuth = { userId: caller.id, orgId, partnerId };
+    const res = await register(await buildApp());
+
+    expect(res.status).toBe(201);
+    const rows = await insertedRow(caller.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.mobileDeviceId).toBeNull();
+    expect(auditCalls.at(-1)?.details).not.toHaveProperty('mobileDeviceHeaderUnresolved');
+  });
+});

--- a/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/site-scope-coverage.integration.test.ts
@@ -176,6 +176,10 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
   // ---- Not the bug class: platform-admin-only, portal-session auth, or a
   // mobile/OAuth device row (not an RMM device with a site).
   'routes/admin/abuse.ts:POST /partners/:id/suspend-for-abuse',
+  // Resolves a mobile/OAuth device row (mobile_devices, no site_id/org_id) to
+  // scope authenticator registration — already narrowed by userId, tighter
+  // than site-scope, so a site gate is not meaningful here.
+  'routes/authenticator.ts:POST /devices',
   'routes/lifecycle.ts:GET /admin/users/:userId/mobile-devices',
   'routes/lifecycle.ts:GET /me/mobile-devices',
   'routes/mobile.ts:POST /devices',
@@ -218,6 +222,9 @@ const SITE_SCOPE_INPUT_EXEMPT: ReadonlySet<string> = new Set<string>([
 // future regression where a non-user-auth file is migrated to plain user auth.
 const SITE_SCOPE_INPUT_EXEMPT_USER_SESSION_OK: ReadonlySet<string> = new Set<string>([
   // Mobile/OAuth device rows keyed on the user — not RMM devices with a site.
+  // routes/authenticator.ts resolves the row itself — already narrowed by
+  // userId, tighter than site-scope.
+  'routes/authenticator.ts:POST /devices',
   'routes/mobile.ts:POST /devices',
   'routes/mobile.ts:POST /notifications/register',
   'routes/lifecycle.ts:GET /admin/users/:userId/mobile-devices',

--- a/apps/api/src/db/dbWriteExpectingRows.test.ts
+++ b/apps/api/src/db/dbWriteExpectingRows.test.ts
@@ -26,7 +26,8 @@ describe('dbWriteExpectingRows', () => {
     expect(captureMessage).toHaveBeenCalledWith(
       expect.stringContaining('users.last_login_at'),
       'warning',
-      expect.any(Object)
+      expect.any(Object),
+      expect.any(Object),
     );
   });
 
@@ -42,5 +43,73 @@ describe('dbWriteExpectingRows', () => {
     await expect(
       dbWriteExpectingRows('test.label', () => Promise.resolve([]))
     ).resolves.toEqual([]);
+  });
+
+  // BREEZE-X: scrubEvent deletes message/logentry/extra before the event
+  // leaves the process, so the label only survives as a TAG. Without it every
+  // call site collapses into one unfilterable Sentry bucket.
+  it('emits the label as the cas_label tag, not only inside the message', async () => {
+    await dbWriteExpectingRows('users.last_login_at', async () => []);
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      'warning',
+      expect.any(Object),
+      expect.objectContaining({ cas_label: 'users.last_login_at' }),
+    );
+  });
+
+  it('merges resolved diagnostic tags alongside cas_label on the 0-row branch', async () => {
+    await dbWriteExpectingRows(
+      'device_commands.ws_result_terminal_cas',
+      async () => [],
+      async () => ({ prior_status: 'failed:server-timeout' }),
+    );
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      'warning',
+      expect.any(Object),
+      {
+        cas_label: 'device_commands.ws_result_terminal_cas',
+        prior_status: 'failed:server-timeout',
+      },
+    );
+  });
+
+  // The two call sites are hot agent paths under connection-pool pressure
+  // (#1105). The evidence read must be paid for ONLY when the CAS misses.
+  it('never invokes the diagnostic resolver when the write moved rows', async () => {
+    const resolver = vi.fn(async () => ({ prior_status: 'completed' }));
+    await dbWriteExpectingRows(
+      'device_commands.ws_result_terminal_cas',
+      async () => [{ id: 'cmd-1' }],
+      resolver,
+    );
+    expect(resolver).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('still captures with cas_label when the diagnostic resolver throws', async () => {
+    const out = await dbWriteExpectingRows(
+      'device_commands.ws_result_terminal_cas',
+      async () => [],
+      async () => {
+        throw new Error('pool exhausted');
+      },
+    );
+    expect(out).toEqual([]);
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.any(String),
+      'warning',
+      expect.any(Object),
+      { cas_label: 'device_commands.ws_result_terminal_cas' },
+    );
+  });
+
+  // routes/auth/login.ts passes no resolver — its behaviour must not change.
+  it('leaves the two-argument call shape working (routes/auth/login.ts)', async () => {
+    await expect(
+      dbWriteExpectingRows('users.last_login_at', async () => [{ id: 'u-1' }]),
+    ).resolves.toEqual([{ id: 'u-1' }]);
+    expect(captureMessage).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/db/dbWriteExpectingRows.ts
+++ b/apps/api/src/db/dbWriteExpectingRows.ts
@@ -1,18 +1,50 @@
 import { captureMessage } from '../services/sentry';
 
 /**
+ * Resolves extra Sentry TAGS describing why a write moved 0 rows. Invoked ONLY
+ * on the 0-row branch, so the evidence read is never paid for on the happy
+ * path — the callers here sit on hot paths under connection-pool pressure
+ * (#1105). Never let it throw: a diagnostic must not change the outcome of the
+ * write it describes.
+ *
+ * Keys must be in sentry.ts's ALLOWED_TAG_NAMES or they are dropped twice over
+ * (setCallerTags at capture time, pickAllowedTags in the beforeSend scrubber);
+ * values must stay low-cardinality and free of tenant/row identifiers.
+ */
+export type ExpectedRowsDiagnosticTags = () =>
+  | Record<string, string>
+  | Promise<Record<string, string>>;
+
+/**
  * Run a write that MUST move ≥1 row (use `.returning()`) and surface a 0-row
  * result as a Sentry warning (#1379 A2). Catches an RLS regression that lets
  * the context wrapper through but still denies the row — the #1375 class, at
  * the call-site. Opt-in and non-throwing: zero false positives, only wrap
  * sites you KNOW must affect a row (never idempotent upserts).
+ *
+ * The label is emitted as the `cas_label` tag, not just inside the message:
+ * scrubEvent deletes `message`/`logentry`/`extra` before the event leaves the
+ * process, so tags are the only channel that survives — without it every call
+ * site collapses into one untriageable Sentry bucket (BREEZE-X).
  */
-export async function dbWriteExpectingRows<T>(label: string, run: () => Promise<T[]>): Promise<T[]> {
+export async function dbWriteExpectingRows<T>(
+  label: string,
+  run: () => Promise<T[]>,
+  diagnosticTags?: ExpectedRowsDiagnosticTags,
+): Promise<T[]> {
   const rows = await run();
   if (rows.length === 0) {
     const message = `Expected-rows write affected 0 rows: ${label}`;
     console.warn(message);
-    captureMessage(message, 'warning', { label, stack: new Error().stack });
+    let tags: Record<string, string> = { cas_label: label };
+    if (diagnosticTags) {
+      try {
+        tags = { ...tags, ...(await diagnosticTags()) };
+      } catch (err) {
+        console.warn(`[dbWriteExpectingRows] diagnostic tags failed for ${label}:`, err);
+      }
+    }
+    captureMessage(message, 'warning', { label, stack: new Error().stack }, tags);
   }
   return rows;
 }

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -243,8 +243,18 @@ vi.mock('../services/backupResultPersistence', async (importOriginal) => {
   };
 });
 
+// BREEZE-X: only captureMessage is replaced — dbWriteExpectingRows calls it on
+// the 0-row CAS branch and this file drives the real helper. Everything else in
+// services/sentry (captureException, the request-scope helpers) stays real, so
+// this must be a partial mock.
+vi.mock('../services/sentry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/sentry')>();
+  return { ...actual, captureMessage: vi.fn() };
+});
+
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices, deviceCommands } from '../db/schema';
+import { captureMessage } from '../services/sentry';
 import {
   createAgentWsHandlers,
   createAgentWsRoutes,
@@ -2439,6 +2449,117 @@ describe('device_commands access context on the WS result path (#1375)', () => {
     // context — in that exact order. Asserting the full stack (rather than
     // "both are non-zero") is what fails if the two wrappers are ever swapped.
     expect(write.stack).toEqual(['outside', 'system']);
+  });
+});
+
+// BREEZE-X: the terminal CAS above fires a Sentry warning when it moves 0 rows,
+// but the event carried no evidence of WHY the row was already terminal — the
+// REST twin, the stale-command reaper, and the cancellation paths all produce
+// the same anonymous warning. The 0-row branch now re-reads the row and tags
+// the prior status. The read MUST stay on that branch: the sibling suite above
+// pins the exact op sequence ['select','update'] on the happy path, and this
+// is the hot agent path under the #1105 pool pressure.
+describe('BREEZE-X: WS terminal CAS reports why it moved 0 rows', () => {
+  const commandRow = {
+    id: 'cmd-breeze-x',
+    type: 'run_script',
+    payload: {},
+    deviceId: 'device-cas',
+    status: 'sent',
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(runOutsideDbContext).mockImplementation(((fn: any) => fn()) as any);
+    vi.mocked(withSystemDbAccessContext).mockImplementation(((fn: any) => fn()) as any);
+  });
+
+  /**
+   * Drive one command_result frame. `updatedRows` is what the CAS returns
+   * (empty = the branch under test); `priorRow` is what a re-read of the row
+   * would find. Returns every db.select made against device_commands.
+   */
+  async function driveResult(updatedRows: unknown[], priorRow?: unknown) {
+    const { handlers, ws } = await connectedAgent('agent-cas', {
+      deviceId: 'device-cas',
+      orgId: 'org-cas',
+    });
+
+    const commandSelects: unknown[][] = [];
+    vi.mocked(db.select).mockImplementation(((...args: unknown[]) => ({
+      from: vi.fn((table: unknown) => {
+        const isCommandTable = table === deviceCommands;
+        if (isCommandTable) commandSelects.push(args);
+        // First device_commands read is the command lookup; a second one can
+        // only be the 0-row diagnostic re-read.
+        const rows = isCommandTable
+          ? commandSelects.length === 1
+            ? [commandRow]
+            : priorRow === undefined ? [] : [priorRow]
+          : [];
+        return {
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        };
+      }),
+    })) as any);
+
+    vi.mocked(db.update).mockImplementation((() => {
+      const returning = vi.fn().mockResolvedValue(updatedRows);
+      return {
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning }),
+          returning,
+        }),
+      };
+    }) as any);
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '44444444-4444-4444-8444-444444444444',
+        status: 'completed',
+        exitCode: 0,
+        stdout: 'ok',
+      }),
+    } as any, ws as any);
+
+    return commandSelects;
+  }
+
+  it('tags prior_status + cas_label when the CAS moves 0 rows because the reaper timed the command out', async () => {
+    const commandSelects = await driveResult([], {
+      status: 'failed',
+      result: { status: 'timeout', error: 'no response', timedOutBy: 'server' },
+    });
+
+    // The diagnostic re-read happened exactly once.
+    expect(commandSelects).toHaveLength(2);
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(captureMessage).mock.calls[0]![3]).toEqual({
+      cas_label: 'device_commands.ws_result_terminal_cas',
+      prior_status: 'failed:server-timeout',
+    });
+  });
+
+  it('distinguishes a cancellation from the reaper on the same 0-row branch', async () => {
+    await driveResult([], { status: 'cancelled', result: null });
+
+    expect(vi.mocked(captureMessage).mock.calls[0]![3]).toEqual({
+      cas_label: 'device_commands.ws_result_terminal_cas',
+      prior_status: 'cancelled',
+    });
+  });
+
+  it('does NOT re-read the row (or capture anything) when the CAS moves a row', async () => {
+    const commandSelects = await driveResult([{ id: commandRow.id }]);
+
+    // One select only: the command lookup. A second one would be an
+    // unconditional diagnostic read on the hot agent path (#1105).
+    expect(commandSelects).toHaveLength(1);
+    expect(captureMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -5,6 +5,7 @@ import { eq, and, inArray, notInArray, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db, withDbAccessContext, withSystemDbAccessContext, runOutsideDbContext } from '../db';
 import { dbWriteExpectingRows } from '../db/dbWriteExpectingRows';
+import { commandCasPriorStatusTags } from '../services/commandCasDiagnostics';
 import { devices, deviceCommands, discoveryJobs, scriptExecutions, scriptExecutionBatches, remoteSessions, backupJobs, restoreJobs, tunnelSessions } from '../db/schema';
 import {
   handleTerminalOutput,
@@ -1792,32 +1793,45 @@ async function processCommandResult(
     // under an explicit system context", db/index.ts) actually true here.
     //
     // dbWriteExpectingRows (#1379 A2): the SELECT above matched this exact
-    // predicate and returned a row, so a 0-row result here is only *benign*
-    // when another writer (the REST twin in routes/agents/commands.ts, or a
-    // second socket) drove the command terminal in the intervening window.
+    // predicate and returned a row, so a 0-row result here means another writer
+    // drove the command terminal in the intervening window. Several BENIGN
+    // writers can, not just the REST twin:
+    //   - routes/agents/commands.ts (the REST twin) or a second socket — a
+    //     duplicate result: terminal with a real agent result;
+    //   - jobs/staleCommandReaper.ts — fleet-wide and on a schedule; an agent
+    //     replying just past the timeout boundary is exactly this race, and is
+    //     probably the most common non-REST cause;
+    //   - the cancellation paths (admin/abuse.ts, software.ts, scripts.ts,
+    //     cisHardening.ts, discovery.ts, backup/restore.ts, maintenance.ts,
+    //     playbookRetention.ts, backup/verificationScheduled.ts).
     // Every other cause — a contextless/denied write, a future RLS policy on
     // device_commands, a misrouted connection — is a defect that would
-    // otherwise vanish into the console.warn below. Non-throwing, so the stale
-    // -result early-return keeps its existing behaviour.
+    // otherwise vanish into the console.warn below. The prior_status tag
+    // (resolved ONLY on the 0-row branch, so the happy path pays nothing) is
+    // what tells those apart in Sentry. Non-throwing, so the stale-result
+    // early-return keeps its existing behaviour.
     const updatedCommands = await runOutsideDbContext(() =>
       withSystemDbAccessContext(() =>
-        dbWriteExpectingRows('device_commands.ws_result_terminal_cas', () =>
-          db
-            .update(deviceCommands)
-            .set({
-                status: normalizedResult.status === 'completed' ? 'completed' : 'failed',
-                completedAt: new Date(),
-                result: buildStoredCommandResult(command.type, normalizedResult, stdout)
-            })
-            .where(
-              and(
-                eq(deviceCommands.id, result.commandId),
-                eq(deviceCommands.deviceId, resolvedDeviceId!),
-                eq(deviceCommands.targetRole, 'agent'),
-                inArray(deviceCommands.status, ACCEPTED_COMMAND_RESULT_STATUSES)
+        dbWriteExpectingRows(
+          'device_commands.ws_result_terminal_cas',
+          () =>
+            db
+              .update(deviceCommands)
+              .set({
+                  status: normalizedResult.status === 'completed' ? 'completed' : 'failed',
+                  completedAt: new Date(),
+                  result: buildStoredCommandResult(command.type, normalizedResult, stdout)
+              })
+              .where(
+                and(
+                  eq(deviceCommands.id, result.commandId),
+                  eq(deviceCommands.deviceId, resolvedDeviceId!),
+                  eq(deviceCommands.targetRole, 'agent'),
+                  inArray(deviceCommands.status, ACCEPTED_COMMAND_RESULT_STATUSES)
+                )
               )
-            )
-            .returning({ id: deviceCommands.id })
+              .returning({ id: deviceCommands.id }),
+          () => commandCasPriorStatusTags(result.commandId)
         )
       )
     );

--- a/apps/api/src/routes/agents/commands.test.ts
+++ b/apps/api/src/routes/agents/commands.test.ts
@@ -79,8 +79,13 @@ vi.mock('../../services/auditBaselineService', () => ({
 
 vi.mock('../../services/sentry', () => ({
   captureException: vi.fn(),
+  // BREEZE-X: the terminal CAS now runs through dbWriteExpectingRows, which
+  // calls captureMessage on the 0-row branch. Omitting it here would fail the
+  // whole route with "captureMessage is not a function".
+  captureMessage: vi.fn(),
 }));
 
+import { captureMessage } from '../../services/sentry';
 import { commandsRoutes } from './commands';
 
 describe('agent commands routes', () => {
@@ -420,5 +425,72 @@ describe('agent commands routes', () => {
     };
     expect(handlerArg.error).toBe('verify failed [PRIVATE_KEY_REDACTED] end');
     expect(JSON.stringify(handlerArg)).not.toContain('BEGIN PRIVATE KEY');
+  });
+
+  // BREEZE-X: the REST twin of the WS terminal compare-and-set used to return
+  // {success:true} on 0 rows with no signal at all, so a cross-transport race
+  // could not be confirmed from the WS side alone. It now reports with its own
+  // cas_label and the same prior_status evidence.
+  describe('terminal CAS 0-row branch', () => {
+    function queueTerminalCas(updatedRows: unknown[], priorRow?: unknown) {
+      // 1st select: the command pre-read (still non-terminal, so the route
+      // does NOT short-circuit and actually attempts the CAS).
+      selectMock.mockReturnValueOnce(
+        chainMock([
+          {
+            id: commandId,
+            deviceId: 'device-1',
+            type: 'run_script',
+            status: 'sent',
+            targetRole: 'agent',
+          },
+        ])
+      );
+      // 2nd select (0-row branch only): the prior-status diagnostic re-read.
+      selectMock.mockReturnValueOnce(chainMock(priorRow === undefined ? [] : [priorRow]));
+      updateMock.mockReturnValueOnce(chainMock(updatedRows));
+    }
+
+    async function postResult() {
+      return app.request(`/agents/${agentId}/commands/${commandId}/result`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ commandId, status: 'completed', exitCode: 0, stdout: 'ok' }),
+      });
+    }
+
+    it('reports the 0-row CAS to Sentry with cas_label + prior_status', async () => {
+      queueTerminalCas([], {
+        status: 'failed',
+        result: { status: 'timeout', error: 'no response', timedOutBy: 'server' },
+      });
+
+      const res = await postResult();
+
+      // Behaviour is unchanged for the agent — this is observability only.
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({ success: true });
+
+      expect(captureMessage).toHaveBeenCalledTimes(1);
+      const call = vi.mocked(captureMessage).mock.calls[0]!;
+      expect(call[1]).toBe('warning');
+      expect(call[3]).toEqual({
+        cas_label: 'device_commands.rest_result_terminal_cas',
+        prior_status: 'failed:server-timeout',
+      });
+      // Pre-read + the diagnostic re-read, nothing more.
+      expect(selectMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not re-read the row or capture anything when the CAS moves a row', async () => {
+      queueTerminalCas([{ id: commandId }], { status: 'failed', result: null });
+
+      const res = await postResult();
+
+      expect(res.status).toBe(200);
+      expect(captureMessage).not.toHaveBeenCalled();
+      // Only the pre-read: the diagnostic read must stay on the 0-row branch.
+      expect(selectMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/api/src/routes/agents/commands.ts
+++ b/apps/api/src/routes/agents/commands.ts
@@ -3,6 +3,8 @@ import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
 import { and, eq, inArray } from 'drizzle-orm';
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../../db';
+import { dbWriteExpectingRows } from '../../db/dbWriteExpectingRows';
+import { commandCasPriorStatusTags } from '../../services/commandCasDiagnostics';
 import { deviceCommands, deploymentResults } from '../../db/schema';
 import type { AgentAuthContext } from '../../middleware/agentAuth';
 import { writeAuditEvent } from '../../services/auditEvents';
@@ -287,32 +289,44 @@ commandsRoutes.post(
     // write can touch — it makes the guard's invariant in db/index.ts true on
     // this path too. Without it, this route was the largest remaining source of
     // BREEZE-7 events after the WS path was fixed.
-    const updated = await runOutsideDbContext(async () => withSystemDbAccessContext(async () => {
-      const query = db
-        .update(deviceCommands)
-        .set({
-          status: normalizedData.status === 'completed' ? 'completed' : 'failed',
-          completedAt: new Date(),
-          result: buildStoredCommandResult(command.type, normalizedData, stdout),
-          // Credentials ride the payload for some commands (e.g. FileVault
-          // rotation); blank them once the command is terminal.
-          ...(hasSensitivePayload(command.type) ? { payload: null } : {}),
-        })
-        .where(and(
-          eq(deviceCommands.id, commandId),
-          eq(deviceCommands.deviceId, deviceId),
-          eq(deviceCommands.targetRole, agent.role),
-          inArray(deviceCommands.status, ACCEPTED_COMMAND_RESULT_STATUSES)
-        )) as any;
+    //
+    // BREEZE-X: this branch used to return `{success:true}` silently on 0 rows,
+    // so the WS twin's Sentry warning had no REST-side counterpart to correlate
+    // against — you could not confirm a cross-transport race from one side
+    // alone. It gets its own `cas_label` and the same `prior_status` tag. It
+    // should be RARER than the WS twin because the terminal pre-read above
+    // usually short-circuits first — which is itself a useful signal.
+    let updated: unknown;
+    const updatedRows = await runOutsideDbContext(async () => withSystemDbAccessContext(async () =>
+      dbWriteExpectingRows(
+        'device_commands.rest_result_terminal_cas',
+        async () => {
+          const query = db
+            .update(deviceCommands)
+            .set({
+              status: normalizedData.status === 'completed' ? 'completed' : 'failed',
+              completedAt: new Date(),
+              result: buildStoredCommandResult(command.type, normalizedData, stdout),
+              // Credentials ride the payload for some commands (e.g. FileVault
+              // rotation); blank them once the command is terminal.
+              ...(hasSensitivePayload(command.type) ? { payload: null } : {}),
+            })
+            .where(and(
+              eq(deviceCommands.id, commandId),
+              eq(deviceCommands.deviceId, deviceId),
+              eq(deviceCommands.targetRole, agent.role),
+              inArray(deviceCommands.status, ACCEPTED_COMMAND_RESULT_STATUSES)
+            )) as any;
 
-      return typeof query.returning === 'function'
-        ? query.returning({ id: deviceCommands.id })
-        : query;
-    }));
+          updated = typeof query.returning === 'function'
+            ? await query.returning({ id: deviceCommands.id })
+            : await query;
 
-    const updatedRows = Array.isArray(updated)
-      ? updated
-      : [];
+          return Array.isArray(updated) ? updated : [];
+        },
+        () => commandCasPriorStatusTags(commandId)
+      )
+    ));
 
     if (updated === undefined) {
       console.warn(`[agents] command result update returned undefined for ${commandId} — treating as failed update`);

--- a/apps/api/src/routes/authenticator.test.ts
+++ b/apps/api/src/routes/authenticator.test.ts
@@ -15,12 +15,22 @@ const {
   epochsMock,
   authState,
 } = vi.hoisted(() => {
+  // Every `where(...)` expression handed to a select is recorded so tests can
+  // assert on the predicate itself, not just on the rows the mock replays.
+  // Required for the ownership guard on the mobile-device lookup: a test that
+  // only inspects the inserted value would still pass with
+  // `eq(mobileDevices.userId, ...)` deleted.
+  const selectWheres: unknown[] = [];
+
   const makeSelectChain = (rows: unknown[]) => {
     const chain: any = {
       from: vi.fn(() => chain),
       leftJoin: vi.fn(() => chain),
       innerJoin: vi.fn(() => chain),
-      where: vi.fn(() => chain),
+      where: vi.fn((expr: unknown) => {
+        selectWheres.push(expr);
+        return chain;
+      }),
       orderBy: vi.fn(() => chain),
       limit: vi.fn(() => Promise.resolve(rows)),
     };
@@ -32,6 +42,7 @@ const {
   return {
     dbState: {
       selectQueue: [] as unknown[][],
+      selectWheres,
       updateSets: [] as Record<string, unknown>[],
       insertValues: [] as Record<string, unknown>[],
       insertReturning: [] as unknown[],
@@ -139,6 +150,15 @@ vi.mock('../db/schema', () => ({
   authenticatorPolicies: {
     partnerId: 'authenticatorPolicies.partnerId',
   },
+  mobileDevices: {
+    id: 'mobileDevices.id',
+    // NOTE: `deviceId` is the varchar external (per-install) id; `id` is the
+    // server-side uuid PK. Keeping both stubs distinct is what lets the tests
+    // below prove the lookup targets the varchar column.
+    deviceId: 'mobileDevices.deviceId',
+    userId: 'mobileDevices.userId',
+    status: 'mobileDevices.status',
+  },
 }));
 
 vi.mock('../middleware/auth', () => ({
@@ -173,6 +193,38 @@ vi.mock('../services/authenticatorPolicy', async (importOriginal) => {
   return { ...actual, loadPartnerPolicy: vi.fn().mockResolvedValue(null) }; // validateRaiseOnly stays real
 });
 
+/**
+ * Flattens a drizzle SQL expression (as produced by `and(eq(...), eq(...))`)
+ * into the list of literal values it was built from. The suite's schema mock
+ * hands drizzle plain strings as "columns", so both the column stubs and the
+ * bound values land in the result — which is exactly what lets a test assert
+ * that a specific predicate is present in a `where`.
+ */
+function sqlValues(expr: unknown): unknown[] {
+  const out: unknown[] = [];
+  const visit = (node: any): void => {
+    if (node === null || node === undefined) return;
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (typeof node === 'object') {
+      if (Array.isArray(node.queryChunks)) {
+        node.queryChunks.forEach(visit);
+        return;
+      }
+      if ('value' in node) {
+        visit(node.value);
+        return;
+      }
+      return;
+    }
+    out.push(node);
+  };
+  visit(expr);
+  return out;
+}
+
 const deviceRow = {
   id: 'device-1',
   userId: 'user-123',
@@ -197,6 +249,7 @@ describe('approver device routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     dbState.selectQueue = [];
+    dbState.selectWheres.length = 0;
     dbState.updateSets = [];
     dbState.insertValues = [];
     dbState.insertReturning = [deviceRow];
@@ -473,7 +526,40 @@ describe('approver device routes', () => {
     expect(dbState.insertValues).toHaveLength(0);
   });
 
-  it('records the per-install mobileDeviceId from the header on registration', async () => {
+  // --- X-Breeze-Mobile-Device-Id resolution (Sentry BREEZE-12 / BREEZE-13) ---
+  //
+  // The header carries `mobile_devices.device_id` (a varchar per-install id
+  // minted on the phone), NOT `mobile_devices.id` (the uuid PK that
+  // authenticator_devices.mobile_device_id FKs). Writing the header straight
+  // into the FK column 500'd on every mobile registration (23503, or 22P02 for
+  // a non-uuid header). The route must resolve it to an OWNED row instead.
+
+  // Per-install id as the app actually mints it (SecureStore uuid) — uuid-SHAPED
+  // but it is a device_id value, never a mobile_devices.id.
+  const INSTALL_ID = '11111111-2222-3333-4444-555555555555';
+  const OWNED_MOBILE_ROW_ID = '99999999-8888-7777-6666-555555555555';
+
+  async function postMobileRegister(headerValue: string | null, grantId = 'g-mobile-2') {
+    return app.request('/authenticator/devices', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer access-token',
+        ...(headerValue === null ? {} : { 'X-Breeze-Mobile-Device-Id': headerValue }),
+      },
+      body: JSON.stringify({
+        registerGrantId: grantId,
+        kind: 'mobile_hw_key',
+        publicKey: 'pk',
+        label: 'iPhone',
+        isPlatformBound: true,
+      }),
+    });
+  }
+
+  it('resolves the per-install header to the owned mobile_devices row id (never the raw header)', async () => {
+    // The ownership-scoped lookup finds the caller's own row.
+    dbState.selectQueue.push([{ id: OWNED_MOBILE_ROW_ID }]);
     dbState.insertReturning = [
       {
         ...deviceRow,
@@ -481,23 +567,102 @@ describe('approver device routes', () => {
         kind: 'mobile_hw_key',
         credentialId: null,
         lastUsedAt: null,
-        mobileDeviceId: '11111111-2222-3333-4444-555555555555',
+        mobileDeviceId: OWNED_MOBILE_ROW_ID,
       },
     ];
 
-    const res = await app.request('/authenticator/devices', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer access-token',
-        'X-Breeze-Mobile-Device-Id': '11111111-2222-3333-4444-555555555555',
-      },
-      body: JSON.stringify({ registerGrantId: 'g-mobile-2', kind: 'mobile_hw_key', publicKey: 'pk', label: 'iPhone', isPlatformBound: true }),
-    });
+    const res = await postMobileRegister(INSTALL_ID);
 
     expect(res.status).toBe(201);
     const inserted = dbState.insertValues[0];
-    expect(inserted).toMatchObject({ kind: 'mobile_hw_key', mobileDeviceId: '11111111-2222-3333-4444-555555555555' });
+    expect(inserted).toMatchObject({ kind: 'mobile_hw_key', mobileDeviceId: OWNED_MOBILE_ROW_ID });
+    // The raw header must never reach the FK column.
+    expect(inserted?.mobileDeviceId).not.toBe(INSTALL_ID);
+    // Audit records the RESOLVED id, and nothing unresolved to conflate with it.
+    expect(helperMocks.writeAuthAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'auth.authenticator.device.register',
+        details: expect.objectContaining({ mobileDeviceId: OWNED_MOBILE_ROW_ID }),
+      }),
+    );
+    const auditDetails = (helperMocks.writeAuthAudit.mock.calls.at(-1)?.[1] as any).details;
+    expect(auditDetails).not.toHaveProperty('mobileDeviceHeaderUnresolved');
+  });
+
+  it('looks the header up by device_id AND user_id — the ownership predicate is in the where', async () => {
+    dbState.selectQueue.push([{ id: OWNED_MOBILE_ROW_ID }]);
+
+    const res = await postMobileRegister(INSTALL_ID);
+    expect(res.status).toBe(201);
+
+    expect(dbState.selectWheres).toHaveLength(1);
+    const values = sqlValues(dbState.selectWheres[0]);
+    // Matched against the varchar external id — NOT the uuid PK (a uuid-column
+    // comparison is what produced the 22P02 on junk headers).
+    expect(values).toContain('mobileDevices.deviceId');
+    expect(values).toContain(INSTALL_ID);
+    expect(values).not.toContain('mobileDevices.id');
+    // Ownership: RLS does NOT do this for us — mobile_devices' SELECT policy has
+    // an `OR EXISTS` branch letting a same-tenant token read a colleague's row.
+    expect(values).toContain('mobileDevices.userId');
+    expect(values).toContain('user-123');
+  });
+
+  it('returns 201 with mobileDeviceId null when the header matches no mobile_devices row', async () => {
+    dbState.selectQueue.push([]); // no row for this per-install id
+
+    const res = await postMobileRegister(INSTALL_ID);
+
+    expect(res.status).toBe(201);
+    expect(dbState.insertValues[0]).toMatchObject({ kind: 'mobile_hw_key', mobileDeviceId: null });
+    // Forensics: the unresolved header is kept under a DISTINCT key so it can
+    // never again be mistaken for a resolved mobile_devices.id.
+    expect(helperMocks.writeAuthAudit).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          mobileDeviceId: null,
+          mobileDeviceHeaderUnresolved: INSTALL_ID,
+        }),
+      }),
+    );
+  });
+
+  it('never inserts a mobile_devices row owned by a different user', async () => {
+    const OTHER_USERS_ROW_ID = '00000000-dead-beef-0000-000000000001';
+    // The ownership-scoped lookup returns nothing: the row exists, but it
+    // belongs to someone else. (The predicate itself is asserted above — this
+    // case proves the other user's id never leaks into the insert.)
+    dbState.selectQueue.push([]);
+
+    const res = await postMobileRegister(INSTALL_ID);
+
+    expect(res.status).toBe(201);
+    expect(dbState.insertValues[0]).toMatchObject({ mobileDeviceId: null });
+    expect(JSON.stringify(dbState.insertValues)).not.toContain(OTHER_USERS_ROW_ID);
+    // And the query that decided this was ownership-scoped.
+    expect(sqlValues(dbState.selectWheres[0])).toContain('mobileDevices.userId');
+  });
+
+  it('degrades to null (no throw, no 500) for a junk non-uuid header', async () => {
+    dbState.selectQueue.push([]);
+
+    const res = await postMobileRegister('hello');
+
+    expect(res.status).toBe(201);
+    expect(dbState.insertValues[0]).toMatchObject({ mobileDeviceId: null });
+    // 'hello' is compared against a varchar column, so it is a miss — not a
+    // uuid cast error (22P02).
+    expect(sqlValues(dbState.selectWheres[0])).toContain('hello');
+  });
+
+  it('inserts mobileDeviceId null and issues no lookup when the header is absent', async () => {
+    const res = await postMobileRegister(null);
+
+    expect(res.status).toBe(201);
+    expect(dbState.insertValues[0]).toMatchObject({ mobileDeviceId: null });
+    expect(dbState.selectWheres).toHaveLength(0);
   });
 
   it('requires authentication for mobile_hw_key registration', async () => {

--- a/apps/api/src/routes/authenticator.ts
+++ b/apps/api/src/routes/authenticator.ts
@@ -3,7 +3,7 @@ import { zValidator } from '../lib/validation';
 import { and, eq, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import { db } from '../db';
-import { authenticatorDevices, authenticatorPolicies } from '../db/schema';
+import { authenticatorDevices, authenticatorPolicies, mobileDevices } from '../db/schema';
 import { authMiddleware, requirePermission, requireMfa } from '../middleware/auth';
 import { PERMISSIONS } from '../services/permissions';
 import {
@@ -320,7 +320,36 @@ authenticatorRoutes.post(
 
     // Per-install device id is a UX/migration hint only (client-controlled,
     // SR-001) — null when the header is absent.
-    const mobileDeviceId = readMobileDeviceId(c);
+    //
+    // The header carries `mobile_devices.device_id` — the VARCHAR per-install id
+    // minted on the phone — NOT `mobile_devices.id`, the server-side uuid PK that
+    // `authenticator_devices.mobile_device_id` FKs. Conflating the two shipped an
+    // outage: the raw header went straight into the FK column and every mobile
+    // registration 500'd (23503 for a uuid-shaped header, 22P02 for junk) —
+    // Sentry BREEZE-12 / BREEZE-13.
+    //
+    // So: resolve, never trust. The lookup targets the varchar column (a junk
+    // header is a miss, not a cast error) and carries an EXPLICIT ownership
+    // predicate — RLS will not do that for us, because mobile_devices' SELECT
+    // policy has an `OR EXISTS` branch that lets any same-tenant partner/org
+    // token read a colleague's row (same reasoning as the SR-002 guard in
+    // routes/mobile.ts). A miss degrades to null rather than failing the
+    // registration; `mobile_device_id` is never read back anywhere in the API.
+    const mobileDeviceHeader = readMobileDeviceId(c);
+    let mobileDeviceId: string | null = null;
+    if (mobileDeviceHeader) {
+      const [owned] = await db
+        .select({ id: mobileDevices.id })
+        .from(mobileDevices)
+        .where(
+          and(
+            eq(mobileDevices.deviceId, mobileDeviceHeader),
+            eq(mobileDevices.userId, auth.user.id)
+          )
+        )
+        .limit(1);
+      mobileDeviceId = owned?.id ?? null;
+    }
 
     const [inserted] = await db
       .insert(authenticatorDevices)
@@ -352,7 +381,13 @@ authenticatorRoutes.post(
         deviceId: inserted.id,
         kind: 'mobile_hw_key',
         isPlatformBound: true,
+        // The RESOLVED mobile_devices.id (uuid PK), or null. The raw header is
+        // recorded under a deliberately distinct key so the two can never be
+        // conflated again.
         mobileDeviceId,
+        ...(mobileDeviceHeader && !mobileDeviceId
+          ? { mobileDeviceHeaderUnresolved: mobileDeviceHeader }
+          : {}),
       },
     });
 

--- a/apps/api/src/routes/backup/configs.test.ts
+++ b/apps/api/src/routes/backup/configs.test.ts
@@ -755,6 +755,59 @@ describe('backup config routes', () => {
       expect(body.error).not.toBe('Invalid URL');
       expect(s3ClientCtorMock).not.toHaveBeenCalled();
     });
+
+    it('does not persist a blank endpoint string on create (web form initial state)', async () => {
+      // coerceS3EndpointUrl('') returns undefined for a blank endpoint, but
+      // `if (endpoint) details.endpoint = endpoint;` used to leave the raw ''
+      // from the payload sitting in `details` untouched, so blank rows kept
+      // accumulating in provider_config.
+      insertMock.mockReturnValueOnce(chainMock([makeConfig()]));
+
+      const res = await app.request('/backup/configs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Blank endpoint',
+          provider: 's3',
+          details: {
+            bucket: 'backups',
+            region: 'us-east-1',
+            accessKey: 'key',
+            secretKey: 'secret',
+            endpoint: '',
+          },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const insertValues = insertMock.mock.results[0]?.value?.values;
+      const inserted = insertValues.mock.calls[0][0];
+      expect(inserted.providerConfig).not.toHaveProperty('endpoint');
+    });
+
+    it('does not persist a blank endpoint string on update (PATCH)', async () => {
+      selectMock.mockReturnValueOnce(chainMock([makeConfig()]));
+      updateMock.mockReturnValueOnce(chainMock([makeConfig()]));
+
+      const res = await app.request(`/backup/configs/${CONFIG_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          details: {
+            bucket: 'backups',
+            region: 'us-east-1',
+            accessKey: 'key',
+            secretKey: 'secret',
+            endpoint: '',
+          },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const updateValues = updateMock.mock.results[0]?.value?.set;
+      const updated = updateValues.mock.calls[0][0];
+      expect(updated.providerConfig).not.toHaveProperty('endpoint');
+    });
   });
 
   // The org DEFAULT destination is what every partner-wide and profile-linked

--- a/apps/api/src/routes/backup/configs.ts
+++ b/apps/api/src/routes/backup/configs.ts
@@ -235,7 +235,15 @@ configsRoutes.post(
       // fails on every device while this API's own test probe passes.
       const { region, endpoint } = validateS3Details(details);
       if (region) details.region = region;
-      if (endpoint) details.endpoint = endpoint;
+      if (endpoint) {
+        details.endpoint = endpoint;
+      } else {
+        // coerceS3EndpointUrl returns undefined for a blank/absent endpoint
+        // (e.g. the web form's initial ''). Without this, the raw '' from
+        // the payload would survive in `details` and blank rows would keep
+        // accumulating (Sentry BREEZE-P residual gap).
+        delete details.endpoint;
+      }
     }
     const encryption = payload.encryption ?? false;
     try {
@@ -370,7 +378,15 @@ configsRoutes.patch(
           return c.json({ error }, 400);
         }
         if (region) nextProviderConfig.region = region;
-        if (endpoint) nextProviderConfig.endpoint = endpoint;
+        if (endpoint) {
+          nextProviderConfig.endpoint = endpoint;
+        } else {
+          // coerceS3EndpointUrl returns undefined for a blank/absent endpoint.
+          // Without this, the raw '' from the payload would survive in
+          // nextProviderConfig and blank rows would keep accumulating
+          // (Sentry BREEZE-P residual gap).
+          delete nextProviderConfig.endpoint;
+        }
       }
       const nextEncryption = payload.encryption ?? current.encryption;
 

--- a/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
@@ -43,6 +43,8 @@ import { registerPolicyPrereqTools } from './aiToolsPolicyPrereqs';
 
 const PARTNER_ID = '00000000-0000-0000-0000-000000000001';
 const RING_ID = '22222222-2222-2222-2222-222222222222';
+const ORG_ID = '33333333-3333-3333-3333-333333333333';
+const BACKUP_CONFIG_ID = '44444444-4444-4444-4444-444444444444';
 
 function makeAuth() {
   return {
@@ -62,6 +64,26 @@ function getTool() {
   const tool = tools.get('manage_update_rings');
   if (!tool) throw new Error('manage_update_rings tool not registered');
   return tool;
+}
+
+function getBackupConfigsTool() {
+  const tools = new Map<string, any>();
+  registerPolicyPrereqTools(tools);
+  const tool = tools.get('manage_backup_configs');
+  if (!tool) throw new Error('manage_backup_configs tool not registered');
+  return tool;
+}
+
+function makeOrgAuth() {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    scope: 'organization',
+    partnerId: null,
+    orgId: ORG_ID,
+    accessibleOrgIds: [ORG_ID],
+    canAccessOrg: () => true,
+    orgCondition: () => undefined,
+  } as any;
 }
 
 function mockInsertReturns(row: Record<string, unknown>) {
@@ -263,5 +285,148 @@ describe('manage_update_rings autoApprove fail-closed write boundary (#1317)', (
     const written = insertMock.mock.results[0]!.value.values.mock.calls[0][0];
     expect(written.partnerId).toBe(PARTNER_ID);
     expect(written.orgId).toBeUndefined();
+  });
+});
+
+// manage_backup_configs used to write `providerConfig` straight to the DB,
+// bypassing the REST routes' S3 endpoint validation entirely — the one
+// remaining save-time hole in Sentry BREEZE-P. These tests cover routing it
+// through the same validateS3Details helper the REST routes use.
+describe('manage_backup_configs S3 endpoint validation (Sentry BREEZE-P residual gap)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects create with a genuinely malformed S3 endpoint and does NOT write', async () => {
+    const tool = getBackupConfigsTool();
+    const output = await tool.handler(
+      {
+        action: 'create',
+        name: 'S3 backup',
+        type: 'file',
+        provider: 's3',
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'not a valid url with spaces',
+        },
+      },
+      makeOrgAuth()
+    );
+
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toMatch(/not a valid URL/i);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('persists the normalized endpoint on create, not the raw scheme-less value', async () => {
+    mockInsertReturns({ id: BACKUP_CONFIG_ID, name: 'S3 backup' });
+    const tool = getBackupConfigsTool();
+    const output = await tool.handler(
+      {
+        action: 'create',
+        name: 'S3 backup',
+        type: 'file',
+        provider: 's3',
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'minio.internal.example.com:9000',
+        },
+      },
+      makeOrgAuth()
+    );
+
+    expect(JSON.parse(output).success).toBe(true);
+    const written = insertMock.mock.results[0]!.value.values.mock.calls[0][0];
+    expect(written.providerConfig.endpoint).toBe('https://minio.internal.example.com:9000/');
+  });
+
+  it('does not persist a blank endpoint string on create (Sentry BREEZE-P gap (b))', async () => {
+    mockInsertReturns({ id: BACKUP_CONFIG_ID, name: 'S3 backup' });
+    const tool = getBackupConfigsTool();
+    const output = await tool.handler(
+      {
+        action: 'create',
+        name: 'S3 backup',
+        type: 'file',
+        provider: 's3',
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: '',
+        },
+      },
+      makeOrgAuth()
+    );
+
+    expect(JSON.parse(output).success).toBe(true);
+    const written = insertMock.mock.results[0]!.value.values.mock.calls[0][0];
+    expect(written.providerConfig).not.toHaveProperty('endpoint');
+  });
+
+  it('rejects update with a malformed S3 endpoint and does NOT write', async () => {
+    mockSelectReturns({
+      id: BACKUP_CONFIG_ID,
+      orgId: ORG_ID,
+      name: 'S3 backup',
+      provider: 's3',
+      providerConfig: { bucket: 'backups', region: 'us-east-1' },
+    });
+    const tool = getBackupConfigsTool();
+    const output = await tool.handler(
+      {
+        action: 'update',
+        configId: BACKUP_CONFIG_ID,
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'not a valid url with spaces',
+        },
+      },
+      makeOrgAuth()
+    );
+
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toMatch(/not a valid URL/i);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('persists the normalized endpoint on update, not the raw scheme-less value', async () => {
+    mockSelectReturns({
+      id: BACKUP_CONFIG_ID,
+      orgId: ORG_ID,
+      name: 'S3 backup',
+      provider: 's3',
+      providerConfig: { bucket: 'backups', region: 'us-east-1' },
+    });
+    mockUpdate();
+    const tool = getBackupConfigsTool();
+    const output = await tool.handler(
+      {
+        action: 'update',
+        configId: BACKUP_CONFIG_ID,
+        providerConfig: {
+          bucket: 'backups',
+          region: 'us-east-1',
+          accessKey: 'key',
+          secretKey: 'secret',
+          endpoint: 'minio.internal.example.com:9000',
+        },
+      },
+      makeOrgAuth()
+    );
+
+    expect(JSON.parse(output).success).toBe(true);
+    const setArg = updateMock.mock.results[0]!.value.set.mock.calls[0][0];
+    expect(setArg.providerConfig.endpoint).toBe('https://minio.internal.example.com:9000/');
   });
 });

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -19,6 +19,7 @@ import type { AiTool } from './aiTools';
 import { ringAutoApproveSchema, backupProfileSelectionsSchema } from '@breeze/shared/validators';
 import { canManagePartnerWidePolicies } from './partnerWideAccess';
 import { sanitizeThrownToolError } from './aiToolErrors';
+import { validateS3Details } from '../routes/backup/schemas';
 
 /**
  * Defense-in-depth (#1317): the manage_update_rings AI tool writes `autoApprove`
@@ -40,6 +41,34 @@ function validateRingAutoApprove(
     return { error: message };
   }
   return { value: parsed.data as Record<string, unknown> };
+}
+
+/**
+ * manage_backup_configs used to write `providerConfig` straight to the DB,
+ * bypassing the REST routes' S3 endpoint validation entirely (the one
+ * remaining save-time hole in Sentry BREEZE-P). Route s3 configs through the
+ * same `validateS3Details` helper the REST routes use
+ * (routes/backup/schemas.ts) so a malformed/scheme-less endpoint is rejected
+ * here instead of shipping to every agent and only failing later at
+ * probe/backup time — agent/internal/backup/providers/s3.go does no
+ * coercion of its own.
+ */
+function resolveS3ProviderConfig(
+  raw: Record<string, unknown>
+): { value: Record<string, unknown> } | { error: string } {
+  const details: Record<string, unknown> = { ...raw };
+  const { error, region, endpoint } = validateS3Details(details);
+  if (error) return { error };
+  if (region) details.region = region;
+  if (endpoint) {
+    details.endpoint = endpoint;
+  } else {
+    // coerceS3EndpointUrl returns undefined for a blank/absent endpoint.
+    // Without this, a raw '' endpoint would survive in `details` and
+    // accumulate as a blank row (Sentry BREEZE-P residual gap (b)).
+    delete details.endpoint;
+  }
+  return { value: details };
 }
 
 type AiToolTier = 1 | 2 | 3 | 4;
@@ -802,12 +831,19 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
         if (!input.provider) return JSON.stringify({ error: 'provider is required (s3, azure_blob, google_cloud, backblaze, local)' });
         if (!input.providerConfig) return JSON.stringify({ error: 'providerConfig is required (provider-specific settings)' });
 
+        let providerConfig = input.providerConfig as Record<string, unknown>;
+        if (input.provider === 's3') {
+          const resolved = resolveS3ProviderConfig(providerConfig);
+          if ('error' in resolved) return JSON.stringify({ error: resolved.error });
+          providerConfig = resolved.value;
+        }
+
         const rows = await db.insert(backupConfigs).values({
           orgId,
           name: input.name as string,
           type: input.type as any,
           provider: input.provider as any,
-          providerConfig: input.providerConfig as any,
+          providerConfig: providerConfig as any,
           schedule: (input.schedule as any) ?? null,
           retention: (input.retention as any) ?? null,
           compression: input.compression !== false,
@@ -838,7 +874,16 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
         if (typeof input.name === 'string') updates.name = input.name;
         if (typeof input.type === 'string') updates.type = input.type;
         if (typeof input.provider === 'string') updates.provider = input.provider;
-        if (input.providerConfig) updates.providerConfig = input.providerConfig;
+        if (input.providerConfig) {
+          const targetProvider = typeof input.provider === 'string' ? input.provider : existing.provider;
+          if (targetProvider === 's3') {
+            const resolved = resolveS3ProviderConfig(input.providerConfig as Record<string, unknown>);
+            if ('error' in resolved) return JSON.stringify({ error: resolved.error });
+            updates.providerConfig = resolved.value;
+          } else {
+            updates.providerConfig = input.providerConfig;
+          }
+        }
         if (input.schedule) updates.schedule = input.schedule;
         if (input.retention) updates.retention = input.retention;
         if (typeof input.compression === 'boolean') updates.compression = input.compression;

--- a/apps/api/src/services/commandCasDiagnostics.test.ts
+++ b/apps/api/src/services/commandCasDiagnostics.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const selectMock = vi.fn();
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...(args as [])),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  deviceCommands: {
+    id: 'device_commands.id',
+    status: 'device_commands.status',
+    result: 'device_commands.result',
+  },
+}));
+
+import {
+  commandCasPriorStatusTags,
+  priorStatusTagValue,
+  PRIOR_STATUS_LOOKUP_FAILED,
+  PRIOR_STATUS_MISSING,
+  PRIOR_STATUS_UNKNOWN,
+} from './commandCasDiagnostics';
+
+function selectChain(rows: unknown) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+describe('priorStatusTagValue', () => {
+  it('folds the stale-command reaper marker into the status value', () => {
+    expect(
+      priorStatusTagValue({
+        status: 'failed',
+        result: { status: 'timeout', error: 'no response', timedOutBy: 'server' },
+      }),
+    ).toBe('failed:server-timeout');
+  });
+
+  it('reports a plain terminal status for the REST/WS duplicate-result race', () => {
+    expect(priorStatusTagValue({ status: 'completed', result: { exitCode: 0 } })).toBe(
+      'completed',
+    );
+    expect(priorStatusTagValue({ status: 'failed', result: { exitCode: 1 } })).toBe('failed');
+  });
+
+  it('reports cancelled for the cancellation paths', () => {
+    expect(priorStatusTagValue({ status: 'cancelled', result: null })).toBe('cancelled');
+  });
+
+  it('maps a status outside the known set to a bounded sentinel (no passthrough)', () => {
+    expect(priorStatusTagValue({ status: 'weird-new-state', result: null })).toBe(
+      PRIOR_STATUS_UNKNOWN,
+    );
+    expect(priorStatusTagValue({ status: 42, result: null })).toBe(PRIOR_STATUS_UNKNOWN);
+  });
+
+  it('maps an absent row to a bounded sentinel', () => {
+    expect(priorStatusTagValue(undefined)).toBe(PRIOR_STATUS_MISSING);
+  });
+
+  it('tolerates a non-object result without leaking its contents', () => {
+    expect(priorStatusTagValue({ status: 'failed', result: 'raw string' })).toBe('failed');
+    expect(priorStatusTagValue({ status: 'failed', result: ['a'] })).toBe('failed');
+  });
+});
+
+describe('commandCasPriorStatusTags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('re-reads the command by primary key and tags the prior status', async () => {
+    selectMock.mockReturnValueOnce(
+      selectChain([{ status: 'failed', result: { timedOutBy: 'server' } }]),
+    );
+
+    await expect(commandCasPriorStatusTags('cmd-1')).resolves.toEqual({
+      prior_status: 'failed:server-timeout',
+    });
+    expect(selectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws when the diagnostic read fails — the CAS outcome must not change', async () => {
+    selectMock.mockImplementationOnce(() => {
+      throw new Error('pool exhausted');
+    });
+
+    await expect(commandCasPriorStatusTags('cmd-1')).resolves.toEqual({
+      prior_status: PRIOR_STATUS_LOOKUP_FAILED,
+    });
+  });
+
+  it('reports missing when the row is gone', async () => {
+    selectMock.mockReturnValueOnce(selectChain([]));
+
+    await expect(commandCasPriorStatusTags('cmd-1')).resolves.toEqual({
+      prior_status: PRIOR_STATUS_MISSING,
+    });
+  });
+});

--- a/apps/api/src/services/commandCasDiagnostics.ts
+++ b/apps/api/src/services/commandCasDiagnostics.ts
@@ -1,0 +1,95 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../db';
+import { deviceCommands } from '../db/schema';
+
+/**
+ * BREEZE-X: turn a `device_commands` terminal compare-and-set that moved 0 rows
+ * into a self-diagnosing Sentry event.
+ *
+ * The CAS predicate is `status IN ('pending','sent')`, so 0 rows means SOMETHING
+ * ELSE already drove the row terminal. At least three writers can:
+ *
+ *   - the REST/WS twin (`routes/agents/commands.ts` / `routes/agentWs.ts`) —
+ *     a duplicate result on the other transport: `completed`/`failed` with a
+ *     real agent result;
+ *   - `jobs/staleCommandReaper.ts` — fleet-wide and on a schedule, sets
+ *     `status:'failed'` + `result.timedOutBy:'server'`. An agent replying just
+ *     past the timeout boundary lands here;
+ *   - the cancellation paths (admin/abuse, software, scripts, cisHardening,
+ *     discovery, backup/restore, maintenance, playbookRetention,
+ *     backup/verificationScheduled) — `cancelled`.
+ *
+ * Prior `status` (+ the reaper's `timedOutBy` marker) discriminates all three,
+ * which is the whole point: without it the event cannot distinguish a benign
+ * race from a real regression.
+ */
+
+// device_commands.status is a bare varchar(20) with no enum and no CHECK
+// (db/schema/devices.ts), so the value read back is only conventionally
+// bounded. Pin the known set here and map anything else to a sentinel — a tag
+// value must never become an unbounded passthrough of a column.
+const KNOWN_COMMAND_STATUSES = new Set([
+  'pending',
+  'sent',
+  'completed',
+  'failed',
+  'timeout',
+  'cancelled',
+  'expired',
+]);
+
+/** The row is gone entirely (deleted / cascade-erased between CAS and re-read). */
+export const PRIOR_STATUS_MISSING = 'missing';
+/** The row carries a status outside the known set — worth its own Sentry facet. */
+export const PRIOR_STATUS_UNKNOWN = 'unknown';
+/** The diagnostic re-read itself failed; the CAS outcome is unchanged. */
+export const PRIOR_STATUS_LOOKUP_FAILED = 'lookup-failed';
+
+/**
+ * Fold `result->>'timedOutBy'` into the status string rather than spending a
+ * second Sentry tag on it: `failed` from the reaper and `failed` from a
+ * duplicate agent result are the same tag value otherwise.
+ */
+export function priorStatusTagValue(
+  row: { status?: unknown; result?: unknown } | undefined,
+): string {
+  if (!row) return PRIOR_STATUS_MISSING;
+
+  const status =
+    typeof row.status === 'string' && KNOWN_COMMAND_STATUSES.has(row.status)
+      ? row.status
+      : PRIOR_STATUS_UNKNOWN;
+
+  const result = row.result;
+  const timedOutBy =
+    result && typeof result === 'object' && !Array.isArray(result)
+      ? (result as Record<string, unknown>).timedOutBy
+      : undefined;
+
+  if (status === 'failed' && timedOutBy === 'server') return 'failed:server-timeout';
+  return status;
+}
+
+/**
+ * Re-read the command by primary key and describe the state it was already in.
+ *
+ * ONLY call this on the 0-row branch. This is the agent hot path under known
+ * connection-pool pressure (#1105) — an unconditional extra read would cost a
+ * lookup per command result for nothing. Never throws: a diagnostic must not be
+ * able to change the outcome of the write it is describing.
+ */
+export async function commandCasPriorStatusTags(
+  commandId: string,
+): Promise<Record<string, string>> {
+  try {
+    const [row] = await db
+      .select({ status: deviceCommands.status, result: deviceCommands.result })
+      .from(deviceCommands)
+      .where(eq(deviceCommands.id, commandId))
+      .limit(1);
+    return { prior_status: priorStatusTagValue(row) };
+  } catch (err) {
+    console.warn('[commandCas] prior-status lookup failed:', err);
+    return { prior_status: PRIOR_STATUS_LOOKUP_FAILED };
+  }
+}

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -110,6 +110,27 @@ describe('sentry service', () => {
     expect(setTagMock).not.toHaveBeenCalledWith('partner_id', expect.anything());
   });
 
+  // BREEZE-X: the CAS 0-row warning is only self-diagnosing if these two reach
+  // Sentry. They are gated TWICE — setCallerTags here, pickAllowedTags in the
+  // beforeSend scrubber (see the scrubEvent suite below) — and passing one gate
+  // while being dropped by the other is a silent failure.
+  it('captureMessage keeps the BREEZE-X cas_label and prior_status tags', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureMessage } = await import('./sentry');
+    initSentry();
+
+    captureMessage('Expected-rows write affected 0 rows', 'warning', undefined, {
+      cas_label: 'device_commands.ws_result_terminal_cas',
+      prior_status: 'failed:server-timeout',
+    });
+
+    expect(setTagMock).toHaveBeenCalledWith(
+      'cas_label',
+      'device_commands.ws_result_terminal_cas',
+    );
+    expect(setTagMock).toHaveBeenCalledWith('prior_status', 'failed:server-timeout');
+  });
+
   it('captureMessage sets no tags when none are passed (existing callers unaffected)', async () => {
     process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
     const { initSentry, captureMessage } = await import('./sentry');
@@ -322,6 +343,8 @@ describe('scrubEvent', () => {
         scope: 'organization',
         org_id: 'o-1',
         partner_id: 'p-1',
+        cas_label: 'device_commands.ws_result_terminal_cas',
+        prior_status: 'failed:server-timeout',
         path: '/public/quotes/raw-capability',
         arbitrary: 'raw-capability',
       },
@@ -366,6 +389,9 @@ describe('scrubEvent', () => {
       scope: 'organization',
       org_id: 'o-1',
       partner_id: 'p-1',
+      // BREEZE-X: must survive the scrubber too, not just setCallerTags.
+      cas_label: 'device_commands.ws_result_terminal_cas',
+      prior_status: 'failed:server-timeout',
     });
     expect(out.exception).toEqual({
       values: [{

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -31,6 +31,16 @@ const ALLOWED_TAG_NAMES = new Set([
   'scope',
   'org_id',
   'partner_id',
+  // BREEZE-X: a `dbWriteExpectingRows` 0-row warning is only triageable if the
+  // call site (`cas_label`) and the state the row was already in
+  // (`prior_status`) survive the scrubber. Both are enum-ish and bounded by
+  // construction — `cas_label` is a hardcoded string literal at each call
+  // site, `prior_status` comes from a closed status set folded with the
+  // stale-command reaper's `timedOutBy` marker (services/commandCasDiagnostics.ts)
+  // and falls back to a sentinel for anything unrecognised. Neither carries a
+  // tenant, device, or command identifier.
+  'prior_status',
+  'cas_label',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;

--- a/docs/superpowers/plans/open/2026-07-28-sentry-triage-breeze-12-13-p-x.md
+++ b/docs/superpowers/plans/open/2026-07-28-sentry-triage-breeze-12-13-p-x.md
@@ -1,6 +1,24 @@
 # Sentry Triage: BREEZE-12/13, BREEZE-P, BREEZE-X — Implementation Plan
 
-> **Status:** ready-to-grab (3 independent PRs; PR A is the only urgent one)
+> **Status:** implemented 2026-07-28 — all three code changes landed on branch
+> `ToddHebebrand/sentry-bugs`. Three checkboxes remain open on purpose; they are
+> human/controller actions, not code.
+>
+> | PR | Commit | Result |
+> |---|---|---|
+> | A — BREEZE-12/13 | `d7a498e6a` | Reproduced BOTH shipped error shapes (23503 and 22P02) against real Postgres with the fix reverted, then fixed. |
+> | B — BREEZE-P residuals (a)+(b) | `03112c5df` | AI-tool bypass closed, blank-string persist stopped. |
+> | C — BREEZE-X | `2856b5a08` | `prior_status`/`cas_label` tags on both the WS and REST 0-row CAS paths. |
+>
+> Still open (deliberately): the Sentry release check + BREEZE-P resolution (:163);
+> the prod backfill audit query (:184) — needs prod DB access, no migration was
+> written; and "do not resolve BREEZE-X yet" (:279), which stays open until events
+> carrying `prior_status` arrive.
+>
+> Two follow-ups the reviews say to file alongside the merge: the inert
+> `mobileDeviceBlockedMiddleware` gap (see PR A's out-of-scope section), and the
+> unauthenticated `huntress`/`automations` webhook id-cast 500s — same defect class
+> as BREEZE-12/13, but reachable without auth.
 > **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` or
 > `superpowers:executing-plans`. Steps use `- [ ]` checkboxes for tracking.
 
@@ -99,41 +117,41 @@ Three properties this buys, in order of importance:
 
 ### Tasks
 
-- [ ] Read `apps/api/src/routes/authenticator.ts:291-361` and
+- [x] Read `apps/api/src/routes/authenticator.ts:291-361` and
       `apps/api/src/services/mobileDeviceBinding.ts` in full before editing.
-- [ ] **Write the failing tests first** (TDD — this is an auth path):
-  - [ ] Rewrite `apps/api/src/routes/authenticator.test.ts:476-500`. That test
+- [x] **Write the failing tests first** (TDD — this is an auth path):
+  - [x] Rewrite `apps/api/src/routes/authenticator.test.ts:476-500`. That test
         (`records the per-install mobileDeviceId from the header on registration`)
         **currently pins the bug** — it asserts the raw header lands in the insert. It
         must become: header that resolves to an owned row → inserts the row's `id`.
-  - [ ] New: header present, no matching `mobile_devices` row → **201** with
+  - [x] New: header present, no matching `mobile_devices` row → **201** with
         `mobileDeviceId: null` (not 500).
-  - [ ] New: header matches a row owned by a *different* user → **201** with
+  - [x] New: header matches a row owned by a *different* user → **201** with
         `mobileDeviceId: null`, and assert the *other* user's `mobile_devices.id` never
         appears in the insert values.
-  - [ ] New: non-UUID junk header (`'hello'`) → **201**, `mobileDeviceId: null`, no throw.
-  - [ ] New: header absent → 201, `mobileDeviceId: null` (regression guard).
-  - [ ] Assert the ownership predicate is actually in the `where` — the suite's Drizzle
+  - [x] New: non-UUID junk header (`'hello'`) → **201**, `mobileDeviceId: null`, no throw.
+  - [x] New: header absent → 201, `mobileDeviceId: null` (regression guard).
+  - [x] Assert the ownership predicate is actually in the `where` — the suite's Drizzle
         mock (`authenticator.test.ts:91-140`) returns string column stubs, so capture and
         assert on the recorded where-expression. A test that only checks the inserted
         value would still pass if `eq(mobileDevices.userId, ...)` were deleted.
-- [ ] Implement the resolution block. Import `mobileDevices` into `authenticator.ts`
+- [x] Implement the resolution block. Import `mobileDevices` into `authenticator.ts`
       (check for the schema import cycle the comment at `db/schema/authenticatorDevices.ts:44`
       warns about — that comment is why the Drizzle-level `.references()` was omitted).
-- [ ] Audit detail (`:355`): record the **resolved** id. If the raw header is still
+- [x] Audit detail (`:355`): record the **resolved** id. If the raw header is still
       wanted for forensics, log it under a distinct key
       (`mobileDeviceHeaderUnresolved`) so the two are never conflated again.
-- [ ] Add an **integration test** against real Postgres
+- [x] Add an **integration test** against real Postgres
       (`apps/api/src/__tests__/integration/`) that inserts a real `mobile_devices` row and
       registers an authenticator device. The unit suite fully mocks the DB, so the FK,
       the uuid cast, and RLS are all structurally invisible to it — that is exactly how
       this shipped. This test is the one that would have caught it.
-- [ ] Delete-the-line injection proof: revert the `eq(mobileDevices.userId, ...)` line
+- [x] Delete-the-line injection proof: revert the `eq(mobileDevices.userId, ...)` line
       and confirm a test goes red; revert the whole block and confirm several do.
-- [ ] Add a code comment stating plainly that the header is
+- [x] Add a code comment stating plainly that the header is
       `mobile_devices.device_id` (varchar), **not** `mobile_devices.id` (uuid PK) — this
       confusion has now cost one shipped outage and one wrong plan doc.
-- [ ] Full API suite + `pnpm db:check-drift`.
+- [x] Full API suite + `pnpm db:check-drift`.
 
 ### Out of scope — file as a separate issue
 
@@ -165,7 +183,7 @@ ago" (≈2026-07-22) predates that rollout. Existing coverage is good, including
 
 Three residual gaps justify a small follow-up PR:
 
-- [ ] **(a) The AI tool bypasses validation entirely — the one remaining save-time hole.**
+- [x] **(a) The AI tool bypasses validation entirely — the one remaining save-time hole.**
       `manage_backup_configs` (`services/aiToolsPolicyPrereqs.ts:733`) writes
       `providerConfig` raw on both create (`:805-810`, `as any`) and update (`:841`), and
       its schema advertises `endpoint?` at `:743`. Route it through `validateS3Details`
@@ -174,7 +192,7 @@ Three residual gaps justify a small follow-up PR:
       than a 500 — but it still ships a broken endpoint to every agent, and
       `agent/internal/backup/providers/s3.go:262-269` does no coercion of its own.
       Add a test.
-- [ ] **(b) Blank strings still persist.** `configs.ts:238` and `:374` guard with
+- [x] **(b) Blank strings still persist.** `configs.ts:238` and `:374` guard with
       `if (endpoint) details.endpoint = endpoint;`. When input is `''` (the web form's
       initial state — `BackupDestinationSection.tsx:78`), `coerceS3EndpointUrl` returns
       `undefined`, the branch is skipped, and the **raw `''` from the payload survives in
@@ -244,15 +262,15 @@ cancellation (`cancelled`).
 
 ### Tasks
 
-- [ ] Add `prior_status` and `cas_label` to `ALLOWED_TAG_NAMES` (`sentry.ts:25-34`).
+- [x] Add `prior_status` and `cas_label` to `ALLOWED_TAG_NAMES` (`sentry.ts:25-34`).
       Both are low-cardinality enum-ish strings, no PII. Update the pinning tests:
       `sentry.test.ts:75-88` (asserts non-allowlisted tags are dropped), `:90-111`, `:113-122`.
-- [ ] Plumb an optional `tags` argument through `dbWriteExpectingRows`
+- [x] Plumb an optional `tags` argument through `dbWriteExpectingRows`
       (`db/dbWriteExpectingRows.ts`) to `captureMessage`, and emit the label as
       `cas_label` so the issue is groupable at all. Only two call sites —
       `agentWs.ts:1804` and `routes/auth/login.ts:583`. Update
       `dbWriteExpectingRows.test.ts` (4 tests pin the current signature).
-- [ ] On the **0-row branch only**, re-SELECT the row by PK inside the existing system
+- [x] On the **0-row branch only**, re-SELECT the row by PK inside the existing system
       context and tag `prior_status` (plus `timedOutBy` folded into the same tag value,
       e.g. `failed:server-timeout`, to avoid a second allowlist entry).
   - Keep it conditional. `agentWs.test.ts:2351-2430` (`device_commands access context on
@@ -264,16 +282,16 @@ cancellation (`cancelled`).
     when 0 rows match, so it cannot yield the prior status. (`RETURNING OLD.*` is PG18-only.)
     A single-statement CTE works on postgres.js but would replace the Drizzle builder
     every mock in `agentWs.test.ts` is written against — not worth the blast radius.
-- [ ] **Make the REST twin report too.** `routes/agents/commands.ts:321-323` returns
+- [x] **Make the REST twin report too.** `routes/agents/commands.ts:321-323` returns
       `{success:true}` silently on 0 rows and does not use `dbWriteExpectingRows` at all.
       Without a matching signal you cannot confirm the race from the WS side alone. Give
       it its own label (`device_commands.rest_result_terminal_cas`) and the same
       `prior_status` tag. Note it usually short-circuits earlier at `:261-266` on a
       terminal pre-read, so this branch should be rarer still — which is itself
       informative.
-- [ ] Correct the comment at `agentWs.ts:1794-1801` to name the reaper and the
+- [x] Correct the comment at `agentWs.ts:1794-1801` to name the reaper and the
       cancellation paths. As written it tells the next reader that a reaper race is a defect.
-- [ ] Tests: 0-row branch tags the prior status; the extra read does **not** occur on the
+- [x] Tests: 0-row branch tags the prior status; the extra read does **not** occur on the
       happy path; `commands.test.ts` gains its first 0-row CAS test (currently none of
       its 8 tests touch that branch).
 - [ ] **Do not resolve BREEZE-X yet.** Ship, wait for events carrying `prior_status`,

--- a/docs/superpowers/plans/open/2026-07-28-sentry-triage-breeze-12-13-p-x.md
+++ b/docs/superpowers/plans/open/2026-07-28-sentry-triage-breeze-12-13-p-x.md
@@ -1,0 +1,294 @@
+# Sentry Triage: BREEZE-12/13, BREEZE-P, BREEZE-X — Implementation Plan
+
+> **Status:** ready-to-grab (3 independent PRs; PR A is the only urgent one)
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` or
+> `superpowers:executing-plans`. Steps use `- [ ]` checkboxes for tracking.
+
+**Goal:** Close three Sentry issues on evidence, not assumption. PR A fixes a real
+100%-reproduction outage in mobile approver registration. PR B closes the last
+save-time hole in an already-shipped fix. PR C makes an "is this benign?" issue
+answerable instead of arguable.
+
+**Tech Stack:** Hono + Drizzle (API), Vitest (unit + integration), postgres.js.
+Node pinned: prefix `PATH=$HOME/.nvm/versions/node/v22.20.0/bin:$PATH`.
+
+**Adjacent plan:** `open/2026-06-15-authenticator-registration-redesign.md` touches the
+same route. Not blocking — that plan never specified the `mobileDeviceId` resolution,
+and its predecessor spec is where the bug came from (see PR A background).
+
+---
+
+## Triage summary
+
+| Issue | Sentry's framing | What the code actually shows | Action |
+|---|---|---|---|
+| BREEZE-12/13 | intermittent stale-id 500 | **identifier-space mismatch — the route 500s 100% of the time from the iOS app.** Mobile approver registration has never worked in production. | **PR A — fix now** |
+| BREEZE-P | unguarded config path | **already fixed on `main` in v0.99.0**, ~11h after the v0.98.1 tag Sentry reports. Prod is on v0.102.0. Three residual gaps remain. | **PR B — verify + resolve, small follow-up** |
+| BREEZE-X | needs prior-row status attached | correct — and worse: Sentry's scrubber **discards `extra` entirely**, and the `label` was never emitted as a tag. Also the "exactly one benign cause" comment is wrong; there are at least three. | **PR C — observability** |
+
+---
+
+## PR A — BREEZE-12 / BREEZE-13: authenticator device registration 500s
+
+### Background: this is not a stale-id edge case
+
+`apps/api/src/routes/authenticator.ts:323` reads the `X-Breeze-Mobile-Device-Id` header
+and inserts it at `:335` into `authenticator_devices.mobile_device_id`, which FKs
+`mobile_devices.id` (`migrations/2026-06-14-a-authenticator-foundation.sql:36-45`,
+`ON DELETE SET NULL`).
+
+But the header does not carry `mobile_devices.id`. It carries a **per-install UUID
+minted on the phone** (`apps/mobile/src/services/installationId.ts:20-59`, persisted in
+SecureStore) — the same value every other consumer correctly matches against
+`mobile_devices.device_id`, a `varchar` (`middleware/mobileDeviceBlocked.ts:54`,
+`routes/lifecycle.ts:149,187`). `mobile_devices.id` is always server-side
+`gen_random_uuid()` (`db/schema/mobile.ts:10`).
+
+Consequences:
+
+- The header is UUID-*shaped*, so it passes the cast and fails the FK → **23503, every
+  single time**. `apps/mobile/src/services/approverDevice.ts:35,43` sends it on every
+  call to this route, so approver-device registration fails 100% from the phone. The
+  client swallows it (`approverDevice.ts:103-105` → `{status:'failed', reason:'http_500'}`)
+  and **fails open to L1 approvals** — which is why nobody noticed.
+- A forged non-UUID header (`X-Breeze-Mobile-Device-Id: hello`) passes
+  `normalizeDeviceId` (`services/mobileDeviceBinding.ts:18-23` — only trims and caps at
+  255 chars) and produces Postgres **22P02** instead. That is almost certainly the
+  BREEZE-12/13 split: same line, two error shapes.
+- The FK would only ever have proved existence anyway. Nothing checks ownership, and
+  RLS won't: `mobile_devices`' SELECT policy
+  (`migrations/2026-04-11-bucket-c-phase-6-user-scoped-rls.sql:142-182`) has an `OR EXISTS`
+  branch letting any same-tenant partner/org token read a colleague's row. The
+  ownership predicate **must be explicit in the query** — same reasoning as the SR-002
+  guard at `routes/mobile.ts:397-414`.
+
+Origin: commit `d4574d6eb` (#1369). The plan doc specified it wrong too —
+`docs/superpowers/plans/security-auth/2026-06-14-breeze-authenticator-phase3-mobile-authenticator-pin.md:203`.
+
+### Fix shape
+
+Resolve, don't trust. Never let the header value reach the insert.
+
+```ts
+// authenticator.ts, replacing the raw `const mobileDeviceId = readMobileDeviceId(c)`
+const mobileDeviceHeader = readMobileDeviceId(c);
+let mobileDeviceId: string | null = null;
+if (mobileDeviceHeader) {
+  const [owned] = await db
+    .select({ id: mobileDevices.id })
+    .from(mobileDevices)
+    .where(and(
+      eq(mobileDevices.deviceId, mobileDeviceHeader),   // varchar external id, NOT the uuid PK
+      eq(mobileDevices.userId, auth.user.id),           // ownership — RLS does not do this for us
+    ))
+    .limit(1);
+  mobileDeviceId = owned?.id ?? null;                   // degrade to null, never 500
+}
+```
+
+Three properties this buys, in order of importance:
+
+1. **No unvalidated value reaches an FK column** — ever, for any header content. Both
+   23503 and 22P02 become structurally impossible (the lookup targets a `varchar`, so a
+   junk header is a miss, not a cast error).
+2. **Ownership is checked**, not merely existence.
+3. **Registration degrades instead of failing.** For current app builds there is never a
+   match (see the follow-up below), so `null` is the normal path — which is fine:
+   `authenticator_devices.mobile_device_id` is **never read back anywhere in the API**.
+   Its only consumers are this insert and the audit detail at `:355`.
+
+### Tasks
+
+- [ ] Read `apps/api/src/routes/authenticator.ts:291-361` and
+      `apps/api/src/services/mobileDeviceBinding.ts` in full before editing.
+- [ ] **Write the failing tests first** (TDD — this is an auth path):
+  - [ ] Rewrite `apps/api/src/routes/authenticator.test.ts:476-500`. That test
+        (`records the per-install mobileDeviceId from the header on registration`)
+        **currently pins the bug** — it asserts the raw header lands in the insert. It
+        must become: header that resolves to an owned row → inserts the row's `id`.
+  - [ ] New: header present, no matching `mobile_devices` row → **201** with
+        `mobileDeviceId: null` (not 500).
+  - [ ] New: header matches a row owned by a *different* user → **201** with
+        `mobileDeviceId: null`, and assert the *other* user's `mobile_devices.id` never
+        appears in the insert values.
+  - [ ] New: non-UUID junk header (`'hello'`) → **201**, `mobileDeviceId: null`, no throw.
+  - [ ] New: header absent → 201, `mobileDeviceId: null` (regression guard).
+  - [ ] Assert the ownership predicate is actually in the `where` — the suite's Drizzle
+        mock (`authenticator.test.ts:91-140`) returns string column stubs, so capture and
+        assert on the recorded where-expression. A test that only checks the inserted
+        value would still pass if `eq(mobileDevices.userId, ...)` were deleted.
+- [ ] Implement the resolution block. Import `mobileDevices` into `authenticator.ts`
+      (check for the schema import cycle the comment at `db/schema/authenticatorDevices.ts:44`
+      warns about — that comment is why the Drizzle-level `.references()` was omitted).
+- [ ] Audit detail (`:355`): record the **resolved** id. If the raw header is still
+      wanted for forensics, log it under a distinct key
+      (`mobileDeviceHeaderUnresolved`) so the two are never conflated again.
+- [ ] Add an **integration test** against real Postgres
+      (`apps/api/src/__tests__/integration/`) that inserts a real `mobile_devices` row and
+      registers an authenticator device. The unit suite fully mocks the DB, so the FK,
+      the uuid cast, and RLS are all structurally invisible to it — that is exactly how
+      this shipped. This test is the one that would have caught it.
+- [ ] Delete-the-line injection proof: revert the `eq(mobileDevices.userId, ...)` line
+      and confirm a test goes red; revert the whole block and confirm several do.
+- [ ] Add a code comment stating plainly that the header is
+      `mobile_devices.device_id` (varchar), **not** `mobile_devices.id` (uuid PK) — this
+      confusion has now cost one shipped outage and one wrong plan doc.
+- [ ] Full API suite + `pnpm db:check-drift`.
+
+### Out of scope — file as a separate issue
+
+The app never calls `POST /mobile/devices`. Its only row-creating call is
+`/notifications/register` (`apps/mobile/src/services/api.ts:536`), which derives a
+`push-ios-<sha256>` device_id (`routes/mobile.ts:76-82`) — and re-pair can salt it to
+`${deviceId}-${Date.now()}` (`mobile.ts:420`). So **no current iOS build ever has a
+`mobile_devices` row whose `device_id` equals the header.**
+
+That means `mobileDeviceBlockedMiddleware` (`middleware/mobileDeviceBlocked.ts:47-69`)
+is **inert in production** — "block this phone" matches nothing. That is a live security
+gap, larger in impact than the 500, but it is a mobile-client change and does not belong
+in this PR. Recommend filing it before merging PR A so the linkage isn't lost.
+
+---
+
+## PR B — BREEZE-P: S3 endpoint. Already fixed; close the residuals
+
+**The reported bug is fixed on `main`.** Commit `8a17ac804` (2026-07-20 09:37) added
+`coerceS3EndpointUrl` (`packages/shared/src/utils/s3Endpoint.ts:45`) and routed all four
+S3 client construction sites through it. `v0.98.1` — the release Sentry reports — was
+tagged 2026-07-19 22:16, missing it by ~11 hours. `git tag --contains 8a17ac804` →
+v0.99.0…v0.102.0, and prod (US+EU) is on v0.102.0 as of 2026-07-27. "Last seen 6 days
+ago" (≈2026-07-22) predates that rollout. Existing coverage is good, including
+`apps/api/src/routes/backup/configs.test.ts:544` (`describe('S3 endpoint validation (Sentry BREEZE-P)')`).
+
+- [ ] Confirm in Sentry that no event carries release ≥ 0.99.0, then **resolve
+      BREEZE-P in the next release**.
+
+Three residual gaps justify a small follow-up PR:
+
+- [ ] **(a) The AI tool bypasses validation entirely — the one remaining save-time hole.**
+      `manage_backup_configs` (`services/aiToolsPolicyPrereqs.ts:733`) writes
+      `providerConfig` raw on both create (`:805-810`, `as any`) and update (`:841`), and
+      its schema advertises `endpoint?` at `:743`. Route it through `validateS3Details`
+      (`routes/backup/schemas.ts:26-72`) like the REST routes do. Runtime guards now
+      catch the bad value, so this is a deferred failure at probe/backup time rather
+      than a 500 — but it still ships a broken endpoint to every agent, and
+      `agent/internal/backup/providers/s3.go:262-269` does no coercion of its own.
+      Add a test.
+- [ ] **(b) Blank strings still persist.** `configs.ts:238` and `:374` guard with
+      `if (endpoint) details.endpoint = endpoint;`. When input is `''` (the web form's
+      initial state — `BackupDestinationSection.tsx:78`), `coerceS3EndpointUrl` returns
+      `undefined`, the branch is skipped, and the **raw `''` from the payload survives in
+      `details`** and is written. Harmless at runtime (API and Go agent both treat it as
+      absent) but blank rows keep accumulating. Explicitly `delete details.endpoint`
+      when coercion yields `undefined`.
+- [ ] **(c) No backfill exists** — no migration touches `provider_config`. Run the
+      read-only audit first and decide on the evidence; do **not** write a cleanup
+      migration blind:
+      ```sql
+      SELECT id, org_id, provider_config->>'endpoint'
+      FROM backup_configs
+      WHERE provider = 's3' AND provider_config->>'endpoint' IS NOT NULL
+        AND provider_config->>'endpoint' !~ '^https?://';
+      ```
+      If rows exist, the cleanup migration must report row counts per the CLAUDE.md
+      cleanup-statement rule.
+
+Note for whoever touches this: the repo deliberately keeps **three** endpoint parsers
+with different failure modes, documented at `s3Endpoint.ts:26-37`
+(`deriveS3RegionFromEndpoint` fails soft→null, `jobs/backupRetention.ts:529`
+`normalizeS3Endpoint` fails soft→raw because it builds a storage *identity* key and must
+never throw, `coerceS3EndpointUrl` fails loud). They share the default-to-https rule and
+must stay in sync. Do not "consolidate" them.
+
+---
+
+## PR C — BREEZE-X: make the CAS 0-row event self-diagnosing
+
+### The gap is bigger than "no prior status"
+
+`agentWs.ts:1802-1828` wraps the terminal CAS in
+`dbWriteExpectingRows('device_commands.ws_result_terminal_cas', …)`, which on 0 rows
+calls `captureMessage(message, 'warning', { label, stack })`
+(`db/dbWriteExpectingRows.ts:10-18`). But:
+
+- `services/sentry.ts:250-266` contains a literal **`void extra;`** — extras are
+  discarded at capture time. `scrubEvent` (`:142-162`, wired as `beforeSend` at `:193`)
+  then deletes `extra`, `contexts`, `breadcrumbs`, **and `message`/`logentry`**, and
+  rebuilds `tags` through `pickAllowedTags`.
+- `dbWriteExpectingRows` passes **no tags at all**, so
+  `device_commands.ws_result_terminal_cas` is not a Sentry tag — it survives only inside
+  the message string, which the scrubber then deletes.
+
+So adding fields to the `extra` object would change nothing observable. **Tags are the
+only channel**, and the allowlist (`sentry.ts:25-34`:
+`method, route_template, pg_code, rls_deny, user_id, scope, org_id, partner_id`) gates
+both `setCallerTags` and `pickAllowedTags` — both must accept any new name.
+
+### The "exactly one benign cause" comment is also wrong
+
+`agentWs.ts:1794-1801` names only the REST twin. At least two more writers CAS the same
+rows out of `('pending','sent')`:
+
+- **`jobs/staleCommandReaper.ts:229-242`** — fleet-wide, on a schedule, sets
+  `status:'failed'`, `result:{status:'timeout', timedOutBy:'server'}`. An agent replying
+  just past the timeout boundary produces exactly this 0-row CAS. Unmentioned, and the
+  most likely non-REST benign cause.
+- Cancellation paths: `admin/abuse.ts:153-161`, `software.ts:1426`,
+  `scripts.ts:1050,1065`, `cisHardening.ts:948`, `discovery.ts:1018`,
+  `backup/restore.ts:431`, `maintenance.ts:659,669`, `playbookRetention.ts:77`,
+  `backup/verificationScheduled.ts:182`.
+
+Prior `status` + `result->>'timedOutBy'` discriminates all three cleanly: REST twin
+(`completed`/`failed` with a real result), reaper (`failed` + `timedOutBy:'server'`),
+cancellation (`cancelled`).
+
+### Tasks
+
+- [ ] Add `prior_status` and `cas_label` to `ALLOWED_TAG_NAMES` (`sentry.ts:25-34`).
+      Both are low-cardinality enum-ish strings, no PII. Update the pinning tests:
+      `sentry.test.ts:75-88` (asserts non-allowlisted tags are dropped), `:90-111`, `:113-122`.
+- [ ] Plumb an optional `tags` argument through `dbWriteExpectingRows`
+      (`db/dbWriteExpectingRows.ts`) to `captureMessage`, and emit the label as
+      `cas_label` so the issue is groupable at all. Only two call sites —
+      `agentWs.ts:1804` and `routes/auth/login.ts:583`. Update
+      `dbWriteExpectingRows.test.ts` (4 tests pin the current signature).
+- [ ] On the **0-row branch only**, re-SELECT the row by PK inside the existing system
+      context and tag `prior_status` (plus `timedOutBy` folded into the same tag value,
+      e.g. `failed:server-timeout`, to avoid a second allowlist entry).
+  - Keep it conditional. `agentWs.test.ts:2351-2430` (`device_commands access context on
+    the WS result path (#1375)`) asserts the **exact op sequence** `['select','update']`
+    — an unconditional read breaks it. A failure-branch read never fires there.
+  - Cost is one PK lookup on a path that fired 14 times total. The hot agent path is
+    untouched, which matters given the #1105 pool pressure both comments cite.
+  - **Do not** use `UPDATE … RETURNING` — it returns the *new* image and returns nothing
+    when 0 rows match, so it cannot yield the prior status. (`RETURNING OLD.*` is PG18-only.)
+    A single-statement CTE works on postgres.js but would replace the Drizzle builder
+    every mock in `agentWs.test.ts` is written against — not worth the blast radius.
+- [ ] **Make the REST twin report too.** `routes/agents/commands.ts:321-323` returns
+      `{success:true}` silently on 0 rows and does not use `dbWriteExpectingRows` at all.
+      Without a matching signal you cannot confirm the race from the WS side alone. Give
+      it its own label (`device_commands.rest_result_terminal_cas`) and the same
+      `prior_status` tag. Note it usually short-circuits earlier at `:261-266` on a
+      terminal pre-read, so this branch should be rarer still — which is itself
+      informative.
+- [ ] Correct the comment at `agentWs.ts:1794-1801` to name the reaper and the
+      cancellation paths. As written it tells the next reader that a reaper race is a defect.
+- [ ] Tests: 0-row branch tags the prior status; the extra read does **not** occur on the
+      happy path; `commands.test.ts` gains its first 0-row CAS test (currently none of
+      its 8 tests touch that branch).
+- [ ] **Do not resolve BREEZE-X yet.** Ship, wait for events carrying `prior_status`,
+      then close on evidence. That is the entire point of the PR.
+
+`device_commands` has **no `updated_at` and no version/sequence column**
+(`db/schema/devices.ts:404-416`; `status` is a bare `varchar(20)` with no enum or CHECK,
+carrying `pending|sent|completed|failed|timeout|cancelled|expired`). The status predicate
+is the whole concurrency guard. Adding a real CAS token is a separate, larger change —
+not proposed here.
+
+---
+
+## Sequencing
+
+PR A, B, and C are fully independent — different files, no shared state. A is the only
+one with user-visible impact and should go first. B is ~an hour. C should merge early
+regardless, since its value is the wait time afterwards.


### PR DESCRIPTION
Three independent Sentry issues, triaged from the code rather than from the event summaries. Two of the three turned out to be materially different from what Sentry suggested.

| Commit | Sentry issue | Fix |
|---|---|---|
| `d7a498e6a` | BREEZE-12 + BREEZE-13 | Resolve `X-Breeze-Mobile-Device-Id` to an owned `mobile_devices.id`, or null — never write the raw header to the FK column |
| `03112c5df` | BREEZE-P | Close the `manage_backup_configs` S3-endpoint validation bypass; stop blank endpoints persisting |
| `2856b5a08` | BREEZE-X | Attach `prior_status` / `cas_label` tags to the `device_commands` 0-row CAS event, on both the WS and REST paths |

## BREEZE-12/13 — not a stale-id edge case; a 100% failure

`POST /api/v1/authenticator/devices` read the client-controlled `X-Breeze-Mobile-Device-Id` header and inserted it straight into `authenticator_devices.mobile_device_id`, which FKs `mobile_devices.id`.

The header does not carry `mobile_devices.id`. It carries a per-install UUID minted on the phone — the value every *other* consumer correctly matches against `mobile_devices.device_id`, a `varchar`. `mobile_devices.id` is always server-side `gen_random_uuid()`. The two identifier spaces never intersect.

Because the header is UUID-*shaped*, it passed the cast and failed the FK. The iOS app sends it on every call to this route, so **mobile approver-device registration failed 100% of the time in production** — it has never worked. The client swallowed the 500 and failed open to L1 approvals, which is why it went unnoticed. A forged non-UUID header produces `22P02` from the same line instead — a second reachable failure shape, also now impossible. (Correction to an earlier draft of this description: the BREEZE-12/13 split is *not* those two error shapes. Both issues are `pg_code 23503` on the same single event, same trace id — BREEZE-12 is the raw `PostgresError`, BREEZE-13 the `DrizzleQueryError` wrapper.)

The FK only ever proved existence, never ownership. RLS does not close that gap either — the `mobile_devices` SELECT policy has an `OR EXISTS` branch admitting any same-tenant partner/org token, so the ownership predicate has to be explicit in the query.

The fix resolves the header via `device_id` **and** `user_id`, inserts the resolved row's `id` or null, and degrades instead of throwing for any header content.

**Evidence:** the new integration test reverts the fix and reproduces both shipped error shapes against real Postgres — `23503` on `authenticator_devices_mobile_device_id_fkey` and `22P02 invalid input syntax for type uuid: "hello"`. It also seeds a same-tenant colleague's row and demonstrates, in the same test, that RLS *would* return that row while the ownership-scoped query returns nothing. The unit suite fully mocks Drizzle, so the FK, the uuid cast and RLS are all structurally invisible to it — which is exactly how this shipped.

## BREEZE-P — the reported bug was already fixed; this closes the residuals

`coerceS3EndpointUrl` landed in `8a17ac804` (v0.99.0), about 11 hours after the v0.98.1 tag Sentry reports. Prod has been past it since v0.102.0. Two save-time gaps remained:

- `manage_backup_configs` wrote `providerConfig` raw on both create and update with no validation at all, while advertising `endpoint?` in its schema. It now routes through the same `validateS3Details` helper the REST routes use, and persists the normalized value — the Go agent receives this verbatim.
- Blank endpoints survived a truthiness guard (`if (endpoint) details.endpoint = endpoint`), so the raw `''` from the payload stayed in the persisted object on both the create and PATCH paths. The key is now removed when coercion yields `undefined`.

The three deliberately-separate endpoint parsers (different failure modes, documented at `s3Endpoint.ts:26-37`) are untouched.

Not included: the production backfill. No migration was written — the audit query is in the plan doc for a human to run first.

## BREEZE-X — making the event answerable

The issue could not be diagnosed because the event carried no evidence about *why* the row was already terminal. The gap was deeper than "no prior status": `services/sentry.ts` contains a literal `void extra;`, and `scrubEvent` deletes `extra`, `message` and `logentry` — so adding fields to the extra object would have changed nothing observable. `dbWriteExpectingRows` also passed no tags, so the CAS label was never emitted as a tag at all.

Tags are the only surviving channel, so this plumbs an optional `tags` argument through `dbWriteExpectingRows` and adds `prior_status` / `cas_label` to `ALLOWED_TAG_NAMES` — which gates both `setCallerTags` at capture time and `pickAllowedTags` in `beforeSend`. Both gates are pinned by separate tests.

The diagnostic re-SELECT fires **only** on the 0-row branch, by PK, inside the already-open system transaction — the agent WS path is hot and under known pool pressure. `agentWs.test.ts`'s exact-op-sequence assertion (`['select','update']`) passes unmodified and is what catches a regression here.

The REST twin previously returned `{success:true}` silently on 0 rows; it now reports under its own distinct label.

Tag values are bounded to 11 low-cardinality strings with a sentinel for anything unexpected — no identifiers, no free-form text, and the `result` JSONB is only tested for a marker key, never stringified into a value.

The comment claiming exactly one benign cause was wrong and is corrected: `staleCommandReaper` races the same rows fleet-wide on a schedule, and nine cancellation modules do too. `prior_status` plus the folded `timedOutBy` marker separates all three. A prior status of `pending`/`sent` is the signal that it was a *real* defect rather than a benign race, since every benign writer leaves the row terminal.

**BREEZE-X should not be resolved on merge** — ship, wait for events carrying `prior_status`, close on evidence. Note `scrubEvent` still deletes `message`, so it stays one Sentry issue; the tags make it filterable, not newly grouped.

## Verification

- Full `apps/api` unit suite: 18,496 tests passing, 0 failures. `tsc --noEmit` and eslint clean. `pnpm db:check-drift` reports no drift.
- No migrations, no schema changes — so no RLS policy, no `rls-coverage` allowlist entry and no cascade-list registration is owed. Verified by file list, not inference.
- Every task passed a scoped review; the branch then passed a whole-branch review that independently re-ran 14 mutants across all four changed areas (14/14 killed), including one no implementer had tried. No test in this diff is vacuous in a load-bearing way.

## Follow-ups filed separately

- `mobileDeviceBlockedMiddleware` is inert in production: no current iOS build creates a `mobile_devices` row whose `device_id` matches the header, so "block this phone" matches nothing. This PR makes it *more* concealed, since the header now resolves to null silently instead of 500ing.
- The same defect class exists unauthenticated on two webhook routes, which is worse exposure than what this PR fixes.

Plan: `docs/superpowers/plans/open/2026-07-28-sentry-triage-breeze-12-13-p-x.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

