### PR TITLE
feat(auth): add principal-kind discriminator to AuthContext

### DIFF
--- a/apps/api/src/__tests__/integration/intentFanout.integration.test.ts
+++ b/apps/api/src/__tests__/integration/intentFanout.integration.test.ts
@@ -56,6 +56,7 @@ import {
 function requesterAuth(user: { id: string; email: string }, orgId: string, partnerId: string, roleId: string): AuthContext {
   const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
   return {
+    principal: { kind: 'user_session' },
     user: { id: user.id, email: user.email, name: 'Requester', isPlatformAdmin: false },
     token: {
       sub: user.id,

--- a/apps/api/src/__tests__/integration/intentSelfApproveGuard.integration.test.ts
+++ b/apps/api/src/__tests__/integration/intentSelfApproveGuard.integration.test.ts
@@ -61,6 +61,7 @@ function requesterAuth(
 ): AuthContext {
   const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
   return {
+    principal: { kind: 'user_session' },
     user: { id: user.id, email: user.email, name: 'Requester', isPlatformAdmin: false },
     token: {
       sub: user.id,

--- a/apps/api/src/__tests__/integration/secretBearingToolSeal.integration.test.ts
+++ b/apps/api/src/__tests__/integration/secretBearingToolSeal.integration.test.ts
@@ -194,6 +194,7 @@ async function cleanupScenario(s: Scenario) {
 function requesterAuth(s: Scenario): AuthContext {
   const { orgCondition, canAccessOrg } = buildOrgAccessClosures([s.orgId]);
   return {
+    principal: { kind: 'user_session' },
     user: { id: s.requester.id, email: s.requester.email, name: 'Requester', isPlatformAdmin: false },
     token: {
       sub: s.requester.id,

--- a/apps/api/src/jobs/intentReleaseWorkerGoogleHeadless.integration.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorkerGoogleHeadless.integration.test.ts
@@ -101,6 +101,7 @@ function requesterAuth(
 ): AuthContext {
   const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
   return {
+    principal: { kind: 'user_session' },
     user: { id: user.id, email: user.email, name: 'Requester', isPlatformAdmin: false },
     token: {
       sub: user.id,

--- a/apps/api/src/jobs/intentReleaseWorkerM365Headless.integration.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorkerM365Headless.integration.test.ts
@@ -135,6 +135,7 @@ function requesterAuth(
 ): AuthContext {
   const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
   return {
+    principal: { kind: 'user_session' },
     user: { id: user.id, email: user.email, name: 'Requester', isPlatformAdmin: false },
     token: {
       sub: user.id,

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -147,6 +147,7 @@ const unenrolledUser = {
 };
 
 const baseAuth = {
+  principal: { kind: 'user_session' } as const,
   user: {
     id: 'user-123',
     email: 'test@example.com',

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -15,7 +15,59 @@ import { getEffectiveMfaPolicy } from '../services/mfaPolicy';
 import { ipAllowlistGuard } from './ipAllowlistGuard';
 import { isSelfManagedDbContextRoute } from './selfManagedDbContextRoutes';
 
+/**
+ * The transports/actors that can produce an AuthContext.
+ *
+ * - `user_session`  a Breeze user (MSP tech / admin) authenticated
+ *                   interactively via the session JWT. The only kind that can
+ *                   satisfy a "requires a Breeze operator" gate.
+ * - `client_user`   an END-CUSTOMER human in a client surface (AI for Office
+ *                   via Entra SSO). Interactive, but NOT a Breeze operator —
+ *                   kept separate so a gate meaning "a tech" can never be
+ *                   satisfied by a customer's employee.
+ * - `api_key`       an MCP/partner API key. Carries its creator's user id but
+ *                   acts autonomously, with no human present.
+ * - `oauth_grant`   an MCP-OAuth access token acting for a user.
+ * - `agent`         a device agent.
+ * - `helper`        a Breeze Helper desktop session.
+ * - `system`        synthetic contexts built by background jobs, workers, and
+ *                   schedulers that have no external caller at all.
+ */
+export type PrincipalKind =
+  | { kind: 'user_session' }
+  | { kind: 'client_user' }
+  | { kind: 'api_key'; apiKeyId?: string }
+  | { kind: 'oauth_grant'; grantId?: string }
+  | { kind: 'agent'; deviceId?: string }
+  | { kind: 'helper'; deviceId?: string }
+  | { kind: 'system'; reason: string };
+
+/**
+ * Gate for "a human must be doing this". Use instead of hand-written
+ * `principal.kind === 'user_session'` checks so the rule has one definition.
+ *
+ * Deliberately an allowlist of ONE: every other kind acts without a person
+ * present, including `oauth_grant` (which acts *for* a user but not *as* an
+ * interactive session).
+ */
+export function isInteractiveUserSession(auth: Pick<AuthContext, 'principal'>): boolean {
+  return auth.principal.kind === 'user_session';
+}
+
 export interface AuthContext {
+  /**
+   * What KIND of principal this context represents — distinct from WHO it
+   * represents (`user`) and from what it may reach (`scope`).
+   *
+   * This exists because `user.id` cannot answer "is a human doing this?".
+   * An MCP API key is built with `user.id = apiKey.createdBy`
+   * (buildAuthFromApiKey), so a key and the human who minted it are
+   * indistinguishable by identity alone — and MCP deliberately auto-executes
+   * Tier-3 tools without approval. Any gate that must mean "a person, in a
+   * session, right now" needs this discriminator; user identity is not enough.
+   */
+  principal: PrincipalKind;
+
   user: {
     id: string;
     email: string;
@@ -570,6 +622,9 @@ export async function authMiddleware(c: Context, next: Next): Promise<void | Res
   const canAccessSite = siteAccessCheck(allowedSiteIds);
 
   c.set('auth', {
+    // The interactive session JWT path — the one place a real human at a
+    // browser produces an AuthContext.
+    principal: { kind: 'user_session' },
     user: {
       id: user.id,
       email: user.email,

--- a/apps/api/src/middleware/helperAuth.ts
+++ b/apps/api/src/middleware/helperAuth.ts
@@ -120,6 +120,10 @@ export const helperAuth: MiddlewareHandler = async (c, next) => {
   // Set a synthetic auth context for the streaming session manager
   // Helper sessions use a synthetic "device" user identity
   const syntheticAuth: AuthContext = {
+    // A Helper desktop session: authenticated by device credential, not by a
+    // human login. `user.id` is the DEVICE id, so this context never denotes
+    // a person even though it occupies the user slot.
+    principal: { kind: 'helper', deviceId: device.id },
     user: {
       id: device.id, // Use device ID as the "user" ID for helper sessions
       email: `helper@${device.hostname}`,

--- a/apps/api/src/middleware/principalKind.test.ts
+++ b/apps/api/src/middleware/principalKind.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { isInteractiveUserSession, type AuthContext, type PrincipalKind } from './auth';
+
+/**
+ * Contract tests for the principal-kind discriminator.
+ *
+ * The field exists because `user.id` cannot answer "is a human doing this?":
+ * an MCP API key is built with `user.id = apiKey.createdBy`, so a key and the
+ * person who minted it are identical by identity alone. These tests pin the
+ * semantics that gates will rely on; the per-builder assertions (which builder
+ * emits which kind) live beside each builder's own suite.
+ */
+
+function authWith(principal: PrincipalKind): Pick<AuthContext, 'principal'> {
+  return { principal };
+}
+
+describe('isInteractiveUserSession', () => {
+  it('accepts only user_session', () => {
+    expect(isInteractiveUserSession(authWith({ kind: 'user_session' }))).toBe(true);
+  });
+
+  it.each<PrincipalKind>([
+    { kind: 'client_user' },
+    { kind: 'api_key', apiKeyId: 'key-1' },
+    { kind: 'oauth_grant', grantId: 'grant-1' },
+    { kind: 'agent', deviceId: 'device-1' },
+    { kind: 'helper', deviceId: 'device-1' },
+    { kind: 'system', reason: 'test' },
+  ])('rejects $kind', (principal) => {
+    expect(isInteractiveUserSession(authWith(principal))).toBe(false);
+  });
+
+  it('rejects an api_key even when it carries a real human user id', () => {
+    // The exact confusion the discriminator exists to prevent: this context's
+    // `user.id` IS a person (the key's creator), and every identity-based
+    // check would pass. Only the principal kind distinguishes it.
+    const humanWhoMintedTheKey = 'user-abc';
+    const keyAuth = {
+      principal: { kind: 'api_key', apiKeyId: 'key-1' } as PrincipalKind,
+      user: { id: humanWhoMintedTheKey },
+    };
+    const sessionAuth = {
+      principal: { kind: 'user_session' } as PrincipalKind,
+      user: { id: humanWhoMintedTheKey },
+    };
+
+    expect(keyAuth.user.id).toBe(sessionAuth.user.id);
+    expect(isInteractiveUserSession(keyAuth)).toBe(false);
+    expect(isInteractiveUserSession(sessionAuth)).toBe(true);
+  });
+
+  it('rejects client_user, which is interactive but not a Breeze operator', () => {
+    // A customer's employee in the Excel add-in is a real human in a real
+    // session. Gates that mean "an MSP tech" must not accept them, so
+    // client_user is deliberately a separate kind rather than user_session.
+    expect(isInteractiveUserSession(authWith({ kind: 'client_user' }))).toBe(false);
+  });
+});

--- a/apps/api/src/routes/approvalsDecideAtomicity.integration.test.ts
+++ b/apps/api/src/routes/approvalsDecideAtomicity.integration.test.ts
@@ -65,6 +65,7 @@ function requesterAuth(
 ): AuthContext {
   const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
   return {
+    principal: { kind: 'user_session' },
     user: { id: user.id, email: user.email, name: 'Requester', isPlatformAdmin: false },
     token: {
       sub: user.id,

--- a/apps/api/src/routes/backup/jobs.test.ts
+++ b/apps/api/src/routes/backup/jobs.test.ts
@@ -134,6 +134,7 @@ describe('backup jobs routes', () => {
     app = new Hono();
     app.use('*', async (c, next) => {
       c.set('auth', {
+        principal: { kind: 'user_session' },
         user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
         scope: 'organization',
         orgId: 'org-a',

--- a/apps/api/src/routes/backup/restore.test.ts
+++ b/apps/api/src/routes/backup/restore.test.ts
@@ -135,6 +135,7 @@ describe('restore routes', () => {
     app = new Hono();
     app.use('*', async (c, next) => {
       c.set('auth', {
+        principal: { kind: 'user_session' },
         user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
         scope: 'organization',
         orgId: 'org-1',

--- a/apps/api/src/routes/mcpExecutionOrg.test.ts
+++ b/apps/api/src/routes/mcpExecutionOrg.test.ts
@@ -30,6 +30,7 @@ const KEY_ORG = '33333333-3333-4333-8333-333333333333';
 // This is the exact shape an MSP partner-admin OAuth bearer produces.
 function partnerAuth(accessibleOrgIds: string[]): AuthContext {
   return {
+    principal: { kind: 'api_key' },
     user: { id: '44444444-4444-4444-8444-444444444444', email: 'p@msp.example', name: 'P', isPlatformAdmin: false },
     token: {} as AuthContext['token'],
     partnerId: '55555555-5555-4555-8555-555555555555',
@@ -44,6 +45,7 @@ function partnerAuth(accessibleOrgIds: string[]): AuthContext {
 // Org-scoped principal: pinned to a single org.
 function orgAuth(orgId: string): AuthContext {
   return {
+    principal: { kind: 'api_key' },
     user: { id: '66666666-6666-4666-8666-666666666666', email: 'u@org.example', name: 'U', isPlatformAdmin: false },
     token: {} as AuthContext['token'],
     partnerId: null,
@@ -59,6 +61,7 @@ function orgAuth(orgId: string): AuthContext {
 // canAccessOrg returns true for any org and accessibleOrgIds is null.
 function systemAuth(): AuthContext {
   return {
+    principal: { kind: 'api_key' },
     user: { id: '77777777-7777-4777-8777-777777777777', email: 's@breeze.example', name: 'S', isPlatformAdmin: true },
     token: {} as AuthContext['token'],
     partnerId: null,

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -31,7 +31,7 @@ import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { devices, alerts, scripts, automations, partners, organizations } from '../db/schema';
 import { eq, and, asc, desc, inArray, isNull, or, getTableColumns, type SQL } from 'drizzle-orm';
 import type { PgColumn } from 'drizzle-orm/pg-core';
-import type { AuthContext } from '../middleware/auth';
+import type { AuthContext, PrincipalKind } from '../middleware/auth';
 import { siteAccessCheck } from '../middleware/auth';
 import { getUserPermissions } from '../services/permissions';
 import { authorizeHumanApiKeyCreator, authorizeServicePrincipalKey } from '../services/apiKeyAuthorization';
@@ -479,6 +479,7 @@ async function buildCheckedAuthFromApiKey(
     scopes: apiKey.scopes,
     principalType: apiKey.principalType,
     principalId: apiKey.principalId ?? null,
+    oauthGrantId: apiKey.oauthGrantId ?? null,
   });
 
   // SR2-15 fail-closed: buildAuthFromApiKey returns null when the key's creator
@@ -1875,7 +1876,19 @@ async function buildAuthFromApiKey(apiKey: {
   scopes: string[];
   principalType?: string;
   principalId?: string | null;
+  /**
+   * Set when this "API key" is actually an MCP-OAuth bearer grant.
+   * bearerTokenAuth injects OAuth tokens through the SAME apiKey context slot
+   * (id `oauth:<jti>`, keyPrefix `oauth`), so without this the two are
+   * indistinguishable here and an OAuth grant would be labelled `api_key`.
+   * Same discriminator `mcpPrincipalKey` already uses.
+   */
+  oauthGrantId?: string | null;
 }): Promise<AuthContext | null> {
+  const principal: PrincipalKind = apiKey.oauthGrantId
+    ? { kind: 'oauth_grant', grantId: apiKey.oauthGrantId }
+    : { kind: 'api_key', apiKeyId: apiKey.id };
+
   const user = {
     id: apiKey.createdBy,
     email: `apikey-${apiKey.name}@breeze.local`,
@@ -1941,6 +1954,9 @@ async function buildAuthFromApiKey(apiKey: {
     }
     const allowedSiteIds = authz.allowedSiteIds;
     return {
+      // `user` here is the key's CREATOR (apiKey.createdBy), not a caller who
+      // logged in. Without this discriminator the two are indistinguishable.
+      principal,
       user,
       token: {} as AuthContext['token'],
       partnerId,
@@ -1996,6 +2012,7 @@ async function buildAuthFromApiKey(apiKey: {
   };
 
   return {
+    principal,
     user,
     token: {} as AuthContext['token'],
     partnerId: apiKey.partnerId,

--- a/apps/api/src/routes/remote/helpers.ts
+++ b/apps/api/src/routes/remote/helpers.ts
@@ -378,6 +378,7 @@ export const DEFAULT_REMOTE_SESSION_PROMPT_CONFIG: RemoteSessionPromptConfig = {
 // Mirrors the `systemAuth` constant in services/remoteAccessPolicy.ts so internal
 // policy resolution sees every assignment level regardless of the caller scope.
 const promptConfigSystemAuth: AuthContext = {
+  principal: { kind: 'system', reason: 'remote-prompt-config-resolution' },
   user: { id: 'system', email: 'system', name: 'System', isPlatformAdmin: false },
   token: {} as never,
   partnerId: null,

--- a/apps/api/src/services/actionIntents/actorContext.ts
+++ b/apps/api/src/services/actionIntents/actorContext.ts
@@ -122,6 +122,19 @@ async function buildUserOwnedAuthContext(
     };
 
     return {
+      // Derived from intent.SOURCE, never from which actor column happens to
+      // be populated. `intentService` writes `requested_by_user_id` for EVERY
+      // intent — including MCP-created ones, where that id is the key's
+      // creator (`auth.user.id` at intentService.ts) and
+      // `requesting_api_key_id` is left null. So the actor columns cannot
+      // distinguish a chat intent from an API-key intent, and reconstructing
+      // `user_session` from `requestedByUserId` would launder an autonomous
+      // caller into an interactive one at release time. `source` is the only
+      // field that records the difference.
+      principal:
+        intent.source === 'mcp_api'
+          ? { kind: 'api_key', apiKeyId: intent.requestingApiKeyId ?? undefined }
+          : { kind: 'user_session' },
       user: {
         id: user.id,
         email: user.email,

--- a/apps/api/src/services/actionIntents/createIntentAtomicity.integration.test.ts
+++ b/apps/api/src/services/actionIntents/createIntentAtomicity.integration.test.ts
@@ -74,6 +74,7 @@ function requesterAuth(
 ): AuthContext {
   const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
   return {
+    principal: { kind: 'user_session' },
     user: { id: user.id, email: user.email, name: 'Requester', isPlatformAdmin: false },
     token: {
       sub: user.id,

--- a/apps/api/src/services/aiTools.helperScope.test.ts
+++ b/apps/api/src/services/aiTools.helperScope.test.ts
@@ -57,6 +57,7 @@ describe('HELPER_TOOL_SCOPING <-> tool schema consistency (finding A regression 
 
 function helperAuth(deviceId: string): AuthContext {
   return {
+    principal: { kind: 'helper' },
     user: { id: deviceId, email: 'h', name: 'h', isPlatformAdmin: false },
     token: {} as AuthContext['token'],
     partnerId: null,

--- a/apps/api/src/services/aiTools.queryAuditLog.test.ts
+++ b/apps/api/src/services/aiTools.queryAuditLog.test.ts
@@ -15,6 +15,7 @@ import type { AuthContext } from '../middleware/auth';
 
 function makeAuth(): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/aiTools.queryChangeLog.test.ts
+++ b/apps/api/src/services/aiTools.queryChangeLog.test.ts
@@ -15,6 +15,7 @@ import type { AuthContext } from '../middleware/auth';
 
 function makeAuth(): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/aiTools.sentinelOneActions.test.ts
+++ b/apps/api/src/services/aiTools.sentinelOneActions.test.ts
@@ -28,6 +28,7 @@ import {
 
 function makeAuth(): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
     token: { mfa: true } as any,
     partnerId: null,

--- a/apps/api/src/services/aiTools.verifyDeviceAccess.test.ts
+++ b/apps/api/src/services/aiTools.verifyDeviceAccess.test.ts
@@ -50,6 +50,7 @@ function makeAuth(overrides?: Partial<AuthContext>): AuthContext {
       return allowedSiteIds.includes(siteId);
     },
     ...overrides,
+    principal: overrides?.principal ?? { kind: 'user_session' },
   };
 }
 

--- a/apps/api/src/services/aiToolsAgentLogs.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAgentLogs.siteScope.test.ts
@@ -34,6 +34,7 @@ function handlerFor(name: string): AiTool['handler'] {
 }
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
     accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,

--- a/apps/api/src/services/aiToolsAlerts.feedback.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.feedback.test.ts
@@ -43,6 +43,7 @@ function handlerFor(name: string): AiTool['handler'] {
 
 function makeAuth(): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: '11111111-1111-4111-8111-111111111111', email: 'user@example.com', name: 'User', isPlatformAdmin: false },
     token: {} as never,
     partnerId: null,

--- a/apps/api/src/services/aiToolsAlerts.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsAlerts.siteScope.test.ts
@@ -21,6 +21,7 @@ function handlerFor(name: string): AiTool['handler'] {
 }
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
     accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,

--- a/apps/api/src/services/aiToolsBackup.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBackup.siteScope.test.ts
@@ -30,6 +30,7 @@ function handlerFor(name: string): AiTool['handler'] {
 
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/aiToolsBackupShared.test.ts
+++ b/apps/api/src/services/aiToolsBackupShared.test.ts
@@ -12,6 +12,7 @@ const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
 
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/aiToolsBackupVm.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBackupVm.siteScope.test.ts
@@ -24,6 +24,7 @@ function handlerFor(name: string): AiTool['handler'] {
 }
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
     accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,

--- a/apps/api/src/services/aiToolsBrowser.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsBrowser.siteScope.test.ts
@@ -30,6 +30,7 @@ function handlerFor(name: string): AiTool['handler'] {
 
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/aiToolsCatalog.manageCatalog.test.ts
+++ b/apps/api/src/services/aiToolsCatalog.manageCatalog.test.ts
@@ -31,6 +31,7 @@ import type { AuthContext } from '../middleware/auth';
 import { CatalogServiceError } from './catalogService';
 
 const auth: AuthContext = {
+  principal: { kind: 'user_session' },
   user: { id: 'u-1', email: 'user@example.test', name: 'User', isPlatformAdmin: false },
   token: {
     sub: 'u-1',

--- a/apps/api/src/services/aiToolsContracts.manageContracts.test.ts
+++ b/apps/api/src/services/aiToolsContracts.manageContracts.test.ts
@@ -35,6 +35,7 @@ import type { AuthContext } from '../middleware/auth';
 import { ContractServiceError } from './contractTypes';
 
 const auth: AuthContext = {
+  principal: { kind: 'user_session' },
   user: { id: 'u-1', email: 'user@example.test', name: 'User', isPlatformAdmin: false },
   token: {
     sub: 'u-1',

--- a/apps/api/src/services/aiToolsDR.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDR.siteScope.test.ts
@@ -24,6 +24,7 @@ function handlerFor(name: string): AiTool['handler'] {
 
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
     accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,

--- a/apps/api/src/services/aiToolsDevice.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDevice.siteScope.test.ts
@@ -26,6 +26,7 @@ function handlerFor(name: string): AiTool['handler'] {
 }
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
     accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,

--- a/apps/api/src/services/aiToolsFleet.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleet.siteScope.test.ts
@@ -69,6 +69,7 @@ function handlerFor(name: string): AiTool['handler'] {
 }
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
     accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,

--- a/apps/api/src/services/aiToolsFleetStatus.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsFleetStatus.siteScope.test.ts
@@ -30,6 +30,7 @@ function makeAuth(
     accessibleOrgIds: null, orgCondition: () => undefined, canAccessOrg: () => true,
     allowedSiteIds, canAccessSite: (s) => (!allowedSiteIds ? true : !!s && allowedSiteIds.includes(s)),
     ...overrides,
+    principal: overrides?.principal ?? { kind: 'user_session' },
   };
 }
 

--- a/apps/api/src/services/aiToolsHyperv.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsHyperv.siteScope.test.ts
@@ -25,6 +25,7 @@ function handlerFor(name: string): AiTool['handler'] {
 }
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
     accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,

--- a/apps/api/src/services/aiToolsMonitoring.test.ts
+++ b/apps/api/src/services/aiToolsMonitoring.test.ts
@@ -78,6 +78,7 @@ function buildManageMonitors(): (input: Record<string, unknown>, auth: AuthConte
 // Unrestricted org-scope caller.
 function makeUnrestrictedAuth(): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'user-1', email: 'u@example.com', name: 'U', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/aiToolsMssql.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsMssql.siteScope.test.ts
@@ -26,6 +26,7 @@ function handlerFor(name: string): AiTool['handler'] {
 }
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any, partnerId: null, orgId: 'org-1', scope: 'organization',
     accessibleOrgIds: ['org-1'], orgCondition: () => undefined, canAccessOrg: () => true,

--- a/apps/api/src/services/aiToolsPerformance.test.ts
+++ b/apps/api/src/services/aiToolsPerformance.test.ts
@@ -38,6 +38,7 @@ function handlerFor(name: string): AiTool['handler'] {
 
 function makeAuth(): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'user-1', email: 'test@example.com', name: 'Test User', isPlatformAdmin: false },
     token: {} as AuthContext['token'],
     partnerId: null,

--- a/apps/api/src/services/aiToolsQuotes.test.ts
+++ b/apps/api/src/services/aiToolsQuotes.test.ts
@@ -54,6 +54,7 @@ import type { AuthContext } from '../middleware/auth';
 import { QuoteServiceError } from './quoteTypes';
 
 const auth: AuthContext = {
+  principal: { kind: 'user_session' },
   user: { id: 'u-1', email: 'user@example.test', name: 'User', isPlatformAdmin: false },
   token: {
     sub: 'u-1',

--- a/apps/api/src/services/aiToolsRemote.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsRemote.siteScope.test.ts
@@ -42,6 +42,7 @@ function makeAuth(opts: {
 } = {}): AuthContext {
   const { scope = 'organization', allowedSiteIds, orgId = 'org-1' } = opts;
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/aiToolsSecurity.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsSecurity.siteScope.test.ts
@@ -41,6 +41,7 @@ function handlerFor(name: string): AiTool['handler'] {
 
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/aiToolsTicketing.test.ts
+++ b/apps/api/src/services/aiToolsTicketing.test.ts
@@ -91,6 +91,7 @@ import { validateToolInput } from './aiToolSchemas';
 
 // Default auth: partner scope with access to 'o-1'.
 const auth: AuthContext = {
+  principal: { kind: 'user_session' },
   user: { id: 'u-1', email: 'tech@example.com', name: 'Tech User', isPlatformAdmin: false },
   token: {} as never,
   partnerId: 'p-1',

--- a/apps/api/src/services/aiToolsTicketing.writeGaps.test.ts
+++ b/apps/api/src/services/aiToolsTicketing.writeGaps.test.ts
@@ -91,6 +91,7 @@ function getTool(): AiTool {
 
 function makeAuth(canAccessOrg = true): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'user-1', email: 'tech@example.com', name: 'Tech User', isPlatformAdmin: false },
     token: {} as AuthContext['token'],
     partnerId: 'partner-1',

--- a/apps/api/src/services/aiToolsVault.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsVault.siteScope.test.ts
@@ -33,6 +33,7 @@ function handlerFor(name: string): AiTool['handler'] {
 
 function makeAuth(allowedSiteIds?: string[]): AuthContext {
   return {
+    principal: { kind: 'user_session' },
     user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
     token: {} as any,
     partnerId: null,

--- a/apps/api/src/services/clientAiSessions.ts
+++ b/apps/api/src/services/clientAiSessions.ts
@@ -150,6 +150,8 @@ export function buildClientAuthContext(params: {
 }): AuthContext {
   const { clientUserId, orgId, email, name } = params;
   return {
+    // An end-customer human in the Excel add-in, not a Breeze operator.
+    principal: { kind: 'client_user' },
     user: {
       id: clientUserId,
       email,

--- a/apps/api/src/services/deleteTenant.test.ts
+++ b/apps/api/src/services/deleteTenant.test.ts
@@ -54,6 +54,7 @@ function makeAuth(overrides: Partial<AuthContext> = {}): AuthContext {
     orgCondition: () => undefined,
     canAccessOrg: () => true,
     ...overrides,
+    principal: overrides?.principal ?? { kind: 'api_key' },
   };
 }
 

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -66,6 +66,7 @@ export function createSystemAuthContext(): AuthContext {
   };
 
   return {
+    principal: { kind: 'system', reason: 'feature-config-resolution' },
     user: {
       id: '00000000-0000-0000-0000-000000000000',
       email: 'system@breeze.internal',

--- a/apps/api/src/services/remoteAccessPolicy.ts
+++ b/apps/api/src/services/remoteAccessPolicy.ts
@@ -113,6 +113,7 @@ export function invalidateRemoteAccessCache(deviceId?: string): void {
 // ---------------------------------------------------------------------------
 
 const systemAuth: AuthContext = {
+  principal: { kind: 'system', reason: 'remote-access-policy-resolution' },
   user: { id: 'system', email: 'system', name: 'System', isPlatformAdmin: false },
   token: {} as any,
   partnerId: null,


### PR DESCRIPTION
## Why

`AuthContext` could describe **who** a caller is (`user`) and **what** it may reach (`scope`), but not **what kind** of principal it is.

That gap is load-bearing. `buildAuthFromApiKey` sets `user.id = apiKey.createdBy` (`routes/mcpServer.ts`), so an MCP API key and the human who minted it are indistinguishable by identity alone — and MCP deliberately auto-executes Tier-3 tools without approval (`mcpServer.ts:998-999`). Any gate that must mean *"a person, in a session, right now"* had no way to express it.

## What

Adds a required `principal: PrincipalKind` discriminated union, plus `isInteractiveUserSession()` as the single definition of the "a human must be doing this" rule.

**Required, not optional** — deliberately. An optional field would let existing construction sites default to looking human; a required one makes the compiler enumerate them. That turned out to be **9 production sites**, not the ~1000 a raw grep suggests (the rest are assertions and partial mocks).

## Three things the enumeration surfaced

**1. `requesting_api_key_id` is never written by any production path.**
`intentService` writes `requested_by_user_id` for *every* intent — including MCP-sourced ones, where that id is the key's *creator*. So the api-key branch in `buildAuthContextForIntent` is currently unreachable, and the actor columns cannot distinguish a chat intent from a key intent. Reconstructing `user_session` from `requestedByUserId` would launder an autonomous caller into an interactive one at release time. `actorContext` now derives the kind from `intent.source`, which is the only field that records the difference.

**2. MCP-OAuth bearers ride the same `apiKey` context slot as real API keys.**
`bearerTokenAuth.ts` injects them with id `oauth:<jti>` and `keyPrefix: 'oauth'`, so classifying on that slot alone labels every OAuth grant as `api_key`. Threaded `oauthGrantId` into `buildAuthFromApiKey` and branch on it — the same discriminator `mcpPrincipalKey` already uses.

**3. A principal nobody had named.**
`buildClientAuthContext` (AI for Office) is an interactive human — but an end-**customer**, not a Breeze operator. It gets its own `client_user` kind so a gate meaning "an MSP tech" can never be satisfied by a customer's employee. This is the kind of thing the enumeration exercise exists to find.

## Risk

**No behaviour change.** Nothing gates on `principal` yet — gating lands with its consumers, so a regression here is isolable. The field is additive; every existing check is untouched.

## Verification

- Full API suite green: **18,531 passed**, 0 failures.
- `tsc --noEmit` clean across the package.
- Gate proven non-vacuous by injection: forcing `isInteractiveUserSession` to `return true` fails **8 of its 9** tests.

## Context

Prerequisite for the M365 communications-delegated executor (design §6), where a send-as-a-human must never be reachable by an API key its owner minted. But it is a missing authorization primitive rather than a mail feature, so it ships on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)