### PR TITLE
fix(api): 404 instead of 500 on malformed uuid ids in webhook routes and cursors

### DIFF
--- a/apps/api/src/routes/automations.test.ts
+++ b/apps/api/src/routes/automations.test.ts
@@ -16,7 +16,7 @@ vi.mock('../services/automationRuntime', () => ({
   createAutomationRunRecord: vi.fn(async () => ({
     run: {
       id: 'run-1',
-      automationId: 'auto-1',
+      automationId: '11111111-1111-4111-8111-111111111111',
       triggeredBy: 'manual:user-123',
       status: 'running',
       devicesTargeted: 2,
@@ -161,7 +161,7 @@ describe('automations routes', () => {
             orderBy: vi.fn().mockReturnValue({
               limit: vi.fn().mockReturnValue({
                 offset: vi.fn().mockResolvedValue([
-                  { id: 'auto-1', name: 'Automation One' },
+                  { id: '11111111-1111-4111-8111-111111111111', name: 'Automation One' },
                   { id: 'auto-2', name: 'Automation Two' }
                 ])
               })
@@ -187,7 +187,7 @@ describe('automations routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([{
-              id: 'auto-1',
+              id: '11111111-1111-4111-8111-111111111111',
               name: 'Automation One',
               orgId: 'org-123',
               trigger: { type: 'manual' },
@@ -218,23 +218,45 @@ describe('automations routes', () => {
         })
       } as any);
 
-    const res = await app.request('/automations/auto-1', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111', {
       method: 'GET',
       headers: { Authorization: 'Bearer valid-token' }
     });
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.id).toBe('auto-1');
+    expect(body.id).toBe('11111111-1111-4111-8111-111111111111');
     expect(body.recentRuns).toHaveLength(1);
     expect(body.statistics.totalRuns).toBe(3);
+  });
+
+  it('returns 404 without querying the database for a malformed automation id', async () => {
+    const res = await app.request('/automations/not-a-uuid', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Automation not found' });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 without querying the database for a malformed run id', async () => {
+    const res = await app.request('/automations/runs/not-a-uuid', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer valid-token' }
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Automation run not found' });
+    expect(db.select).not.toHaveBeenCalled();
   });
 
   it('should create an automation with trigger configuration', async () => {
     vi.mocked(db.insert).mockReturnValue({
       values: vi.fn().mockReturnValue({
         returning: vi.fn().mockResolvedValue([{
-          id: 'auto-1',
+          id: '11111111-1111-4111-8111-111111111111',
           name: 'Reboot Devices',
           orgId: 'org-123',
           trigger: { type: 'manual' },
@@ -260,7 +282,7 @@ describe('automations routes', () => {
 
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.id).toBe('auto-1');
+    expect(body.id).toBe('11111111-1111-4111-8111-111111111111');
     expect(body.trigger.type).toBe('manual');
   });
 
@@ -308,7 +330,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Automation One',
             orgId: 'org-123',
             enabled: true,
@@ -321,7 +343,7 @@ describe('automations routes', () => {
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             enabled: false,
             trigger: { type: 'manual' }
           }])
@@ -329,7 +351,7 @@ describe('automations routes', () => {
       })
     } as any);
 
-    const res = await app.request('/automations/auto-1', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
       body: JSON.stringify({
@@ -348,7 +370,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1', name: 'Automation One', orgId: 'org-123',
+            id: '11111111-1111-4111-8111-111111111111', name: 'Automation One', orgId: 'org-123',
             enabled: true, conditions: [], trigger: { type: 'manual' },
           }]),
         }),
@@ -359,7 +381,7 @@ describe('automations routes', () => {
       ok: false, outOfScopeDeviceIds: ['dev-out-of-site'], unbounded: false,
     } as any);
 
-    const res = await app.request('/automations/auto-1', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
       body: JSON.stringify({ trigger: { type: 'all' } }),
@@ -376,7 +398,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1', name: 'Automation One', orgId: 'org-123',
+            id: '11111111-1111-4111-8111-111111111111', name: 'Automation One', orgId: 'org-123',
             enabled: true, conditions: [], trigger: { type: 'manual' },
           }]),
         }),
@@ -385,7 +407,7 @@ describe('automations routes', () => {
     vi.mocked(db.update).mockReturnValue({
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: 'auto-1', enabled: false, trigger: { type: 'manual' } }]),
+          returning: vi.fn().mockResolvedValue([{ id: '11111111-1111-4111-8111-111111111111', enabled: false, trigger: { type: 'manual' } }]),
         }),
       }),
     } as any);
@@ -394,7 +416,7 @@ describe('automations routes', () => {
       ok: true, outOfScopeDeviceIds: [], unbounded: false,
     } as any);
 
-    const res = await app.request('/automations/auto-1', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
       body: JSON.stringify({ enabled: false }),
@@ -410,7 +432,7 @@ describe('automations routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([{
-              id: 'auto-1',
+              id: '11111111-1111-4111-8111-111111111111',
               name: 'Automation One',
               orgId: 'org-123'
             }])
@@ -426,7 +448,7 @@ describe('automations routes', () => {
       where: vi.fn().mockResolvedValue(undefined)
     } as any);
 
-    const res = await app.request('/automations/auto-1', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111', {
       method: 'DELETE',
       headers: { Authorization: 'Bearer valid-token' }
     });
@@ -441,7 +463,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Automation One',
             orgId: 'org-123',
             enabled: true,
@@ -452,7 +474,7 @@ describe('automations routes', () => {
       })
     } as any);
 
-    const res = await app.request('/automations/auto-1/trigger', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111/trigger', {
       method: 'POST',
       headers: { Authorization: 'Bearer valid-token' }
     });
@@ -468,7 +490,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Automation One',
             orgId: 'org-123',
             enabled: false,
@@ -478,7 +500,7 @@ describe('automations routes', () => {
       })
     } as any);
 
-    const res = await app.request('/automations/auto-1/trigger', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111/trigger', {
       method: 'POST',
       headers: { Authorization: 'Bearer valid-token' }
     });
@@ -565,7 +587,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Automation One',
             orgId: 'org-123',
             enabled: true,
@@ -576,7 +598,7 @@ describe('automations routes', () => {
       })
     } as any);
 
-    const res = await app.request('/automations/auto-1/trigger', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111/trigger', {
       method: 'POST',
       headers: { Authorization: 'Bearer valid-token' }
     });
@@ -596,7 +618,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Automation One',
             orgId: 'org-123',
             enabled: true,
@@ -607,7 +629,7 @@ describe('automations routes', () => {
       })
     } as any);
 
-    const res = await app.request('/automations/auto-1/run', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111/run', {
       method: 'POST',
       headers: { Authorization: 'Bearer valid-token' }
     });
@@ -622,7 +644,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Automation One',
             orgId: 'org-123',
             enabled: true,
@@ -633,7 +655,7 @@ describe('automations routes', () => {
       })
     } as any);
 
-    const res = await app.request('/automations/auto-1/trigger', {
+    const res = await app.request('/automations/11111111-1111-4111-8111-111111111111/trigger', {
       method: 'POST',
       headers: { Authorization: 'Bearer valid-token' }
     });
@@ -648,7 +670,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Webhook Automation',
             orgId: 'org-123',
             enabled: true,
@@ -662,7 +684,7 @@ describe('automations routes', () => {
 	    const timestamp = String(Math.floor(Date.now() / 1000));
 	    const signature = `sha256=${createHmac('sha256', 'secret-123').update(`${timestamp}.${rawBody}`).digest('hex')}`;
 
-	    const res = await app.request('/automations/webhooks/auto-1', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -684,7 +706,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -698,7 +720,7 @@ describe('automations routes', () => {
 	    const timestamp = String(Math.floor(Date.now() / 1000));
 	    const signature = `sha256=${createHmac('sha256', 'secret-123').update(`${timestamp}.${signedBody}`).digest('hex')}`;
 
-	    const res = await app.request('/automations/webhooks/auto-1', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -717,7 +739,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -727,7 +749,7 @@ describe('automations routes', () => {
 	      })
 	    } as any);
 
-	    const res = await app.request('/automations/webhooks/auto-1', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -748,7 +770,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -761,7 +783,7 @@ describe('automations routes', () => {
 	    const timestamp = String(Math.floor((Date.now() - 10 * 60 * 1000) / 1000));
 	    const signature = `sha256=${createHmac('sha256', 'secret-123').update(`${timestamp}.${rawBody}`).digest('hex')}`;
 
-	    const res = await app.request('/automations/webhooks/auto-1', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -780,7 +802,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -792,7 +814,7 @@ describe('automations routes', () => {
 	    const rawBody = JSON.stringify({ ping: true, id: 'dup' });
 	    const timestamp = String(Math.floor(Date.now() / 1000));
 	    const signature = `sha256=${createHmac('sha256', 'secret-123').update(`${timestamp}.${rawBody}`).digest('hex')}`;
-	    const request = () => app.request('/automations/webhooks/auto-1', {
+	    const request = () => app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -807,12 +829,24 @@ describe('automations routes', () => {
 	    expect((await request()).status).toBe(409);
 	  });
 
+	  it('returns 404 without querying the database for a malformed webhook automation id', async () => {
+	    const res = await app.request('/automations/webhooks/not-a-uuid', {
+	      method: 'POST',
+	      headers: { 'Content-Type': 'application/json' },
+	      body: JSON.stringify({ ping: true })
+	    });
+
+	    expect(res.status).toBe(404);
+	    expect(await res.json()).toEqual({ error: 'Automation not found' });
+	    expect(db.select).not.toHaveBeenCalled();
+	  });
+
 	  it('rejects webhook automations without a configured signing secret', async () => {
 	    vi.mocked(db.select).mockReturnValue({
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -822,7 +856,7 @@ describe('automations routes', () => {
 	      })
 	    } as any);
 
-	    const res = await app.request('/automations/webhooks/auto-1', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -844,7 +878,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -856,7 +890,7 @@ describe('automations routes', () => {
 	    const rawBody = JSON.stringify({ ping: true, id: 'redis-dup' });
 	    const timestamp = String(Math.floor(Date.now() / 1000));
 	    const signature = `sha256=${createHmac('sha256', 'secret-123').update(`${timestamp}.${rawBody}`).digest('hex')}`;
-	    const request = () => app.request('/automations/webhooks/auto-1', {
+	    const request = () => app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -870,7 +904,7 @@ describe('automations routes', () => {
 	    expect((await request()).status).toBe(202);
 	    expect((await request()).status).toBe(409);
 	    expect(redis.set).toHaveBeenCalledWith(
-	      expect.stringMatching(/^automation-webhook-replay:auto-1:/),
+	      expect.stringMatching(/^automation-webhook-replay:11111111-1111-4111-8111-111111111111:/),
 	      '1',
 	      'PX',
 	      5 * 60 * 1000,
@@ -884,7 +918,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -895,7 +929,7 @@ describe('automations routes', () => {
 	      })
 	    } as any);
 
-	    const res = await app.request('/automations/webhooks/auto-1', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -913,7 +947,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -924,7 +958,7 @@ describe('automations routes', () => {
 	      })
 	    } as any);
 
-	    const res = await app.request('/automations/webhooks/auto-1', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
 	      method: 'POST',
 	      headers: {
 	        'Content-Type': 'application/json',
@@ -942,7 +976,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -952,7 +986,7 @@ describe('automations routes', () => {
 	      })
 	    } as any);
 
-	    const res = await app.request('/automations/webhooks/auto-1?secret=secret-123', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111?secret=secret-123', {
 	      method: 'POST',
 	      headers: { 'Content-Type': 'application/json' },
 	      body: JSON.stringify({ ping: true })
@@ -967,7 +1001,7 @@ describe('automations routes', () => {
 	      from: vi.fn().mockReturnValue({
 	        where: vi.fn().mockReturnValue({
 	          limit: vi.fn().mockResolvedValue([{
-	            id: 'auto-1',
+	            id: '11111111-1111-4111-8111-111111111111',
 	            name: 'Webhook Automation',
 	            orgId: 'org-123',
 	            enabled: true,
@@ -977,7 +1011,7 @@ describe('automations routes', () => {
 	      })
 	    } as any);
 
-	    const res = await app.request('/automations/webhooks/auto-1?secret=secret-123', {
+	    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111?secret=secret-123', {
 	      method: 'POST',
 	      headers: { 'Content-Type': 'application/json' },
 	      body: JSON.stringify({ ping: true })
@@ -992,7 +1026,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Webhook Automation',
             orgId: 'org-123',
             enabled: true,
@@ -1002,7 +1036,7 @@ describe('automations routes', () => {
       })
     } as any);
 
-    const res = await app.request('/automations/webhooks/auto-1', {
+    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1025,7 +1059,7 @@ describe('automations routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([{
-              id: 'run-cp-1',
+              id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
               automationId: null,
               configPolicyId: 'policy-1',
               configItemName: 'Patch Policy',
@@ -1044,7 +1078,7 @@ describe('automations routes', () => {
         })
       } as any);
 
-    const res = await app.request('/automations/runs/run-cp-1', {
+    const res = await app.request('/automations/runs/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', {
       method: 'GET',
       headers: { Authorization: 'Bearer valid-token' }
     });
@@ -1063,7 +1097,7 @@ describe('automations routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([{
-              id: 'run-cp-1',
+              id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
               automationId: null,
               configPolicyId: 'policy-1',
               configItemName: 'Patch Policy',
@@ -1083,14 +1117,14 @@ describe('automations routes', () => {
       // Third select: per-device results (#2023).
       .mockReturnValueOnce(deviceResultsSelectMock([]));
 
-    const res = await app.request('/automations/runs/run-cp-1', {
+    const res = await app.request('/automations/runs/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', {
       method: 'GET',
       headers: { Authorization: 'Bearer valid-token' }
     });
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.id).toBe('run-cp-1');
+    expect(body.id).toBe('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa');
     expect(body.configPolicyId).toBe('policy-1');
     expect(body.configItemName).toBe('Patch Policy');
     expect(body.automation).toBeNull();
@@ -1104,7 +1138,7 @@ describe('automations routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([{
-              id: 'run-ab-1',
+              id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
               automationId: 'auto-OTHER',
               configPolicyId: null,
               status: 'running',
@@ -1126,7 +1160,7 @@ describe('automations routes', () => {
         })
       } as any);
 
-    const res = await app.request('/automations/runs/run-ab-1', {
+    const res = await app.request('/automations/runs/bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', {
       method: 'GET',
       headers: { Authorization: 'Bearer valid-token' }
     });
@@ -1145,8 +1179,8 @@ describe('automations routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([{
-              id: 'run-ab-1',
-              automationId: 'auto-1',
+              id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+              automationId: '11111111-1111-4111-8111-111111111111',
               configPolicyId: null,
               status: 'completed',
               logs: [],
@@ -1158,7 +1192,7 @@ describe('automations routes', () => {
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
             limit: vi.fn().mockResolvedValue([{
-              id: 'auto-1',
+              id: '11111111-1111-4111-8111-111111111111',
               name: 'Automation One',
               orgId: 'org-123',
             }])
@@ -1189,17 +1223,17 @@ describe('automations routes', () => {
         },
       ]));
 
-    const res = await app.request('/automations/runs/run-ab-1', {
+    const res = await app.request('/automations/runs/bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', {
       method: 'GET',
       headers: { Authorization: 'Bearer valid-token' }
     });
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.id).toBe('run-ab-1');
+    expect(body.id).toBe('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb');
     expect(body.status).toBe('success');
     expect(body.automation).toEqual({
-      id: 'auto-1',
+      id: '11111111-1111-4111-8111-111111111111',
       name: 'Automation One',
       orgId: 'org-123',
     });
@@ -1231,7 +1265,7 @@ describe('automations routes', () => {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
           limit: vi.fn().mockResolvedValue([{
-            id: 'auto-1',
+            id: '11111111-1111-4111-8111-111111111111',
             name: 'Webhook Automation',
             orgId: 'org-123',
             enabled: true,
@@ -1245,7 +1279,7 @@ describe('automations routes', () => {
     const timestamp = String(Math.floor(Date.now() / 1000));
     const signature = `sha256=${createHmac('sha256', 'secret-123').update(`${timestamp}.${rawBody}`).digest('hex')}`;
 
-    const res = await app.request('/automations/webhooks/auto-1', {
+    const res = await app.request('/automations/webhooks/11111111-1111-4111-8111-111111111111', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1264,7 +1298,7 @@ describe('automations routes', () => {
         orgId: 'org-123',
         action: 'automation.trigger.webhook',
         resourceType: 'automation',
-        resourceId: 'auto-1',
+        resourceId: '11111111-1111-4111-8111-111111111111',
         resourceName: 'Webhook Automation',
         actorType: 'system',
         details: expect.objectContaining({
@@ -1303,7 +1337,7 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
   };
 
   const partnerWideAutomation = {
-    id: 'auto-pw',
+    id: '22222222-2222-4222-8222-222222222222',
     name: 'Partner-wide automation',
     orgId: null,
     partnerId: 'partner-1',
@@ -1397,7 +1431,7 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
   it('an org-scope caller gets 404 for a partner-wide automation (no existence oracle)', async () => {
     mockSelectAutomationOnce(partnerWideAutomation);
 
-    const res = await app.request('/automations/auto-pw', {
+    const res = await app.request('/automations/22222222-2222-4222-8222-222222222222', {
       method: 'GET',
       headers: { Authorization: 'Bearer valid-token' },
     });
@@ -1423,14 +1457,14 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
         }),
       } as any);
 
-    const res = await app.request('/automations/auto-pw', {
+    const res = await app.request('/automations/22222222-2222-4222-8222-222222222222', {
       method: 'GET',
       headers: { Authorization: 'Bearer valid-token' },
     });
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.id).toBe('auto-pw');
+    expect(body.id).toBe('22222222-2222-4222-8222-222222222222');
     expect(body.orgId).toBeNull();
   });
 
@@ -1438,7 +1472,7 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
     mockState.auth = { ...partnerAdminAuth, partnerId: 'partner-2' };
     mockSelectAutomationOnce(partnerWideAutomation);
 
-    const res = await app.request('/automations/auto-pw', {
+    const res = await app.request('/automations/22222222-2222-4222-8222-222222222222', {
       method: 'GET',
       headers: { Authorization: 'Bearer valid-token' },
     });
@@ -1450,7 +1484,7 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
     mockState.auth = partnerSelectedAuth;
     mockSelectAutomationOnce(partnerWideAutomation);
 
-    const res = await app.request('/automations/auto-pw', {
+    const res = await app.request('/automations/22222222-2222-4222-8222-222222222222', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
       body: JSON.stringify({ name: 'Renamed' }),
@@ -1464,7 +1498,7 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
     mockState.auth = partnerSelectedAuth;
     mockSelectAutomationOnce(partnerWideAutomation);
 
-    const res = await app.request('/automations/auto-pw', {
+    const res = await app.request('/automations/22222222-2222-4222-8222-222222222222', {
       method: 'DELETE',
       headers: { Authorization: 'Bearer valid-token' },
     });
@@ -1477,7 +1511,7 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
     mockState.auth = partnerSelectedAuth;
     mockSelectAutomationOnce(partnerWideAutomation);
 
-    const res = await app.request('/automations/auto-pw/trigger', {
+    const res = await app.request('/automations/22222222-2222-4222-8222-222222222222/trigger', {
       method: 'POST',
       headers: { Authorization: 'Bearer valid-token' },
     });
@@ -1497,7 +1531,7 @@ describe('automations routes — partner-wide dual-ownership (#2133)', () => {
       }),
     } as any);
 
-    const res = await app.request('/automations/auto-pw', {
+    const res = await app.request('/automations/22222222-2222-4222-8222-222222222222', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
       body: JSON.stringify({ name: 'Renamed' }),

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -1,5 +1,5 @@
 import { createHash, createHmac, randomUUID, timingSafeEqual } from 'crypto';
-import { Hono, type Context } from 'hono';
+import { Hono, type Context, type Next } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
 import { and, desc, eq, inArray, isNull, or, sql, type SQL } from 'drizzle-orm';
@@ -31,6 +31,7 @@ import {
   canManagePartnerWidePolicies,
   PARTNER_WIDE_WRITE_DENIED_MESSAGE,
 } from '../services/partnerWideAccess';
+import { UUID_REGEX } from '../utils/uuid';
 
 export const automationRoutes = new Hono();
 export const automationWebhookRoutes = new Hono();
@@ -211,6 +212,19 @@ function getPagination(query: { page?: string; limit?: string }) {
 function ensureOrgAccess(orgId: string, auth: AuthContext) {
   return auth.canAccessOrg(orgId);
 }
+
+function requireUuidParam(name: string, notFoundMessage: string) {
+  return async (c: Context, next: Next) => {
+    const value = c.req.param(name);
+    if (!value || !UUID_REGEX.test(value)) {
+      return c.json({ error: notFoundMessage }, 404);
+    }
+    await next();
+  };
+}
+
+const requireValidAutomationId = requireUuidParam('id', 'Automation not found');
+const requireValidRunId = requireUuidParam('runId', 'Automation run not found');
 
 /**
  * Site-scope gate for automations. Site is an app-layer authz axis RLS does not
@@ -559,6 +573,7 @@ automationRoutes.get(
   '/runs/:runId',
   requireScope('organization', 'partner', 'system'),
   requireAutomationRead,
+  requireValidRunId,
   async (c) => {
     const auth = c.get('auth');
     const runId = c.req.param('runId')!;
@@ -627,6 +642,7 @@ automationRoutes.get(
   '/:id',
   requireScope('organization', 'partner', 'system'),
   requireAutomationRead,
+  requireValidAutomationId,
   async (c) => {
     const auth = c.get('auth');
     const automationId = c.req.param('id')!;
@@ -678,6 +694,7 @@ automationRoutes.get(
   '/:id/runs',
   requireScope('organization', 'partner', 'system'),
   requireAutomationRead,
+  requireValidAutomationId,
   zValidator('query', listRunsSchema),
   async (c) => {
     const auth = c.get('auth');
@@ -988,6 +1005,7 @@ automationRoutes.put(
   requireScope('organization', 'partner', 'system'),
   requireAutomationWrite,
   requireMfa(),
+  requireValidAutomationId,
   zValidator('json', updateAutomationSchema),
   handleUpdateAutomation,
 );
@@ -998,6 +1016,7 @@ automationRoutes.patch(
   requireScope('organization', 'partner', 'system'),
   requireAutomationWrite,
   requireMfa(),
+  requireValidAutomationId,
   zValidator('json', updateAutomationSchema),
   handleUpdateAutomation,
 );
@@ -1008,6 +1027,7 @@ automationRoutes.delete(
   requireScope('organization', 'partner', 'system'),
   requireAutomationWrite,
   requireMfa(),
+  requireValidAutomationId,
   async (c) => {
     const auth = c.get('auth');
     const automationId = c.req.param('id')!;
@@ -1128,6 +1148,7 @@ automationRoutes.post(
   requireScope('organization', 'partner', 'system'),
   requireAutomationWrite,
   requireMfa(),
+  requireValidAutomationId,
   async (c) => {
     const auth = c.get('auth');
     const automationId = c.req.param('id')!;
@@ -1140,6 +1161,7 @@ automationRoutes.post(
   requireScope('organization', 'partner', 'system'),
   requireAutomationWrite,
   requireMfa(),
+  requireValidAutomationId,
   async (c) => {
     const auth = c.get('auth');
     const automationId = c.req.param('id')!;
@@ -1153,6 +1175,10 @@ automationRoutes.post(
 
 automationWebhookRoutes.post('/:id', async (c) => {
   const automationId = c.req.param('id')!;
+
+  if (!UUID_REGEX.test(automationId)) {
+    return c.json({ error: 'Automation not found' }, 404);
+  }
 
   const [automation] = await db
     .select()

--- a/apps/api/src/routes/devices/cursor.test.ts
+++ b/apps/api/src/routes/devices/cursor.test.ts
@@ -113,6 +113,10 @@ describe('decodeCursor — null/empty/garbage rejections', () => {
     const bad = Buffer.from(JSON.stringify({ v: 1, sort: 'hostname', sortDir: 'asc', k: 'x' })).toString('base64url');
     expect(decodeCursor(bad)).toBeNull();
   });
+  it('returns null when id is not a UUID', () => {
+    const bad = Buffer.from(JSON.stringify({ v: 1, sort: 'hostname', sortDir: 'asc', k: 'x', id: 'not-a-uuid' })).toString('base64url');
+    expect(decodeCursor(bad)).toBeNull();
+  });
   it('returns null when k is wrong type (object)', () => {
     const bad = Buffer.from(JSON.stringify({ v: 1, sort: 'hostname', sortDir: 'asc', k: { not: 'a string' }, id: 'x' })).toString('base64url');
     expect(decodeCursor(bad)).toBeNull();

--- a/apps/api/src/routes/devices/cursor.ts
+++ b/apps/api/src/routes/devices/cursor.ts
@@ -21,6 +21,7 @@
 
 import { sql, type SQL } from 'drizzle-orm';
 import { devices } from '../../db/schema';
+import { UUID_REGEX } from '../../utils/uuid';
 
 /** Defensive per-response ceiling. The user never bumps into this; it
  *  caps any one HTTP response at ~2-3 MB of JSON for the widest current
@@ -122,7 +123,7 @@ export function decodeCursor(token: string | undefined | null): DevicesCursor | 
   if (typeof p.sort !== 'string' || !DEVICES_SORT_KEYS.includes(p.sort as DevicesSortKey)) return null;
   if (p.sortDir !== 'asc' && p.sortDir !== 'desc') return null;
   if (p.k !== null && typeof p.k !== 'string') return null;
-  if (typeof p.id !== 'string' || p.id.length === 0) return null;
+  if (typeof p.id !== 'string' || !UUID_REGEX.test(p.id)) return null;
   return {
     v: 1,
     sort: p.sort as DevicesSortKey,

--- a/apps/api/src/routes/huntress.test.ts
+++ b/apps/api/src/routes/huntress.test.ts
@@ -112,7 +112,7 @@ vi.mock('../middleware/auth', () => ({
 vi.mock('../jobs/huntressSync', () => ({
   scheduleHuntressSync: vi.fn(async () => 'job-1'),
   ingestHuntressWebhookPayload: vi.fn(async () => ({
-    integrationId: 'integration-1',
+    integrationId: '33333333-3333-4333-8333-333333333333',
     fetchedAgents: 0,
     fetchedIncidents: 0,
     upsertedAgents: 0,
@@ -245,7 +245,7 @@ describe('huntress routes', () => {
       from: vi.fn(() => ({
         where: vi.fn(() => ({
           limit: vi.fn(async () => [{
-	            id: 'integration-1',
+	            id: '33333333-3333-4333-8333-333333333333',
 	            orgId: 'org-1',
 	            accountId: 'acct-123',
 	            webhookSecretEncrypted: 'enc:webhook',
@@ -255,7 +255,7 @@ describe('huntress routes', () => {
       })),
     } as any);
 
-    const res = await app.request('/huntress/webhook?integrationId=integration-1', {
+    const res = await app.request('/huntress/webhook?integrationId=33333333-3333-4333-8333-333333333333', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({}),
@@ -266,12 +266,31 @@ describe('huntress routes', () => {
     expect(String(body.error)).toContain('signature');
   });
 
+  it('treats a non-UUID integration header as absent and returns the no-integration response', async () => {
+    const res = await app.request('/huntress/webhook', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-huntress-integration-id': 'abc',
+        'x-huntress-account-id': 'acct-123',
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({
+      error: 'No active Huntress integration found for webhook payload',
+    });
+    expect(db.select).not.toHaveBeenCalled();
+    expect(findHuntressIntegrationByAccount).toHaveBeenCalledWith('acct-123');
+  });
+
   it('rejects webhook payloads with missing timestamp when signature auth is enabled', async () => {
     vi.mocked(db.select).mockReturnValueOnce({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
           limit: vi.fn(async () => [{
-	            id: 'integration-1',
+	            id: '33333333-3333-4333-8333-333333333333',
 	            orgId: 'org-1',
 	            accountId: 'acct-123',
 	            webhookSecretEncrypted: 'enc:webhook',
@@ -281,7 +300,7 @@ describe('huntress routes', () => {
       })),
     } as any);
 
-    const res = await app.request('/huntress/webhook?integrationId=integration-1', {
+    const res = await app.request('/huntress/webhook?integrationId=33333333-3333-4333-8333-333333333333', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -317,7 +336,7 @@ describe('huntress routes', () => {
       from: vi.fn(() => ({
         where: vi.fn(() => ({
           limit: vi.fn(async () => [{
-            id: 'integration-1',
+            id: '33333333-3333-4333-8333-333333333333',
             orgId: 'org-1',
             accountId: 'acct-stored',
             webhookSecretEncrypted: 'enc:webhook',
@@ -327,7 +346,7 @@ describe('huntress routes', () => {
       })),
     } as any);
 
-    const res = await app.request('/huntress/webhook?integrationId=integration-1', {
+    const res = await app.request('/huntress/webhook?integrationId=33333333-3333-4333-8333-333333333333', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/api/src/routes/huntress.ts
+++ b/apps/api/src/routes/huntress.ts
@@ -30,6 +30,7 @@ import { captureException } from '../services/sentry';
 import { escapeLike } from '../utils/sql';
 import { offlineStatusSqlList, resolvedStatusSqlList } from '../services/huntressConstants';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../services/partnerWideAccess';
+import { UUID_REGEX } from '../utils/uuid';
 
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   if (typeof dbModule.withSystemDbAccessContext !== 'function') {
@@ -235,7 +236,9 @@ huntressRoutes.post('/webhook', async (c) => {
   const accountId = c.req.header('x-huntress-account-id') ?? parsedPayload.accountId;
 
   const integration = await resolveWebhookIntegration({
-    integrationId: integrationId && integrationId !== 'undefined' ? integrationId : null,
+    integrationId: integrationId && integrationId !== 'undefined' && UUID_REGEX.test(integrationId)
+      ? integrationId
+      : null,
     accountId,
   });
   if ('error' in integration) {

--- a/apps/api/src/routes/mobile.cursor.test.ts
+++ b/apps/api/src/routes/mobile.cursor.test.ts
@@ -15,7 +15,7 @@ describe('mobile route cursor helpers', () => {
 
   it('accepts an ISO string for ts and re-emits the same timestamp', () => {
     const iso = '2026-05-17T23:45:00.000Z';
-    const id = 'a-id';
+    const id = 'd1f8e0c4-9c5d-4f8e-9c5d-4f8e9c5d4f8e';
     const encoded = encodeCursor(iso, id);
     const decoded = decodeCursor(encoded ?? undefined);
     expect(decoded?.ts.toISOString()).toBe(iso);
@@ -38,6 +38,11 @@ describe('mobile route cursor helpers', () => {
     expect(decodeCursor(Buffer.from('{"ts":"not-a-date","id":"x"}', 'utf8').toString('base64url'))).toBeNull();
     expect(decodeCursor(Buffer.from('{"ts":1234,"id":"x"}', 'utf8').toString('base64url'))).toBeNull();
     expect(decodeCursor(Buffer.from('{"ts":"2026-05-17T00:00:00Z"}', 'utf8').toString('base64url'))).toBeNull();
+  });
+
+  it('rejects a non-uuid id rather than letting it reach a uuid column', () => {
+    const encoded = encodeCursor(new Date('2026-05-17T23:45:00.000Z'), 'not-a-uuid');
+    expect(decodeCursor(encoded ?? undefined)).toBeNull();
   });
 
   it('uses base64url (no + or /) so cursors are URL-safe', () => {

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
-import { mobileRoutes } from './mobile';
+import { decodeCursor, encodeCursor, mobileRoutes } from './mobile';
 
 // Partial-mock drizzle-orm so `inArray` is a spy while every other operator
 // (and/eq/sql/...) stays real. The /summary site-narrowing tests assert that
@@ -169,6 +169,27 @@ const mockDeleteReturning = (result: unknown) => ({
   where: vi.fn().mockReturnValue({
     returning: vi.fn().mockResolvedValue(result)
   })
+});
+
+describe('mobile cursor decoding', () => {
+  it('returns null when the cursor id is not a UUID', () => {
+    const cursor = Buffer.from(JSON.stringify({
+      ts: '2026-07-28T12:00:00.000Z',
+      id: 'not-a-uuid',
+    })).toString('base64url');
+
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it('decodes a cursor with a valid UUID id', () => {
+    const id = '11111111-1111-4111-8111-111111111111';
+    const cursor = encodeCursor('2026-07-28T12:00:00.000Z', id);
+
+    expect(decodeCursor(cursor!)).toEqual({
+      ts: new Date('2026-07-28T12:00:00.000Z'),
+      id,
+    });
+  });
 });
 
 describe('mobile routes', () => {

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -26,6 +26,7 @@ import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/pe
 import { dispatchWake } from '../services/wakeOnLan';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { emitAlertStateFeedback } from '../services/mlFeedbackEmitters';
+import { UUID_REGEX } from '../utils/uuid';
 
 export const mobileRoutes = new Hono();
 const requireMobileAlertRead = requirePermission(PERMISSIONS.ALERTS_READ.resource, PERMISSIONS.ALERTS_READ.action);
@@ -64,7 +65,7 @@ export function decodeCursor(raw: string | undefined): CursorTuple | null {
   try {
     const json = Buffer.from(raw, 'base64url').toString('utf8');
     const parsed = JSON.parse(json) as { ts?: unknown; id?: unknown };
-    if (typeof parsed.ts !== 'string' || typeof parsed.id !== 'string') return null;
+    if (typeof parsed.ts !== 'string' || typeof parsed.id !== 'string' || !UUID_REGEX.test(parsed.id)) return null;
     const ts = new Date(parsed.ts);
     if (Number.isNaN(ts.getTime())) return null;
     return { ts, id: parsed.id };


### PR DESCRIPTION
Closes #2914

Malformed client-supplied ids reached uuid-typed columns unvalidated, raising Postgres `22P02` through the global error handler as a **500 + Sentry event** — reachable without authentication on two webhook routes. All sites now reject non-UUID-shaped ids at the boundary, reusing the canonical `UUID_REGEX` from `apps/api/src/utils/uuid.ts`.

## Changes

- **`huntress.ts` POST `/webhook`** (unauthenticated): a non-UUID `integrationId` (query param / `x-huntress-integration-id` header / payload) is treated as absent — the route falls through to its existing accountId lookup / 404 "no active integration" path. No other webhook semantics changed.
- **`automations.ts` webhook POST `/:id`** (unauthenticated): non-UUID id returns the existing `404 Automation not found` before the DB query.
- **`automations.ts` authenticated routes**: new `requireUuidParam` middleware guards all seven `/:id` routes **plus `/runs/:runId`** (same defect, not listed in the issue — `runId` went straight into `eq(automationRuns.id, …)`).
- **`devices/cursor.ts` + `mobile.ts` `decodeCursor`**: the cursor `id` field must be UUID-shaped, else the decoder returns null per its documented malformed-input contract (previously any authenticated caller could 500 the device-list and mobile list endpoints with a crafted cursor).

## Testing

- Regression tests added in all four co-located suites: malformed webhook/automation/run ids → 404 with no DB call; non-UUID cursor ids → null; valid-UUID paths still work. Legacy non-UUID test fixtures (`auto-1`, `run-cp-1`, …) converted to UUID fixtures.
- `vitest run` on the four affected suites: 145 passed, 5 skipped.
- CI-form `tsc --noEmit` (8 GB heap): clean.

Implementation delegated to Codex (gpt-5.6-sol, high); `/runs/:runId` gap and test-fixture fallout fixed in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)