### PR TITLE
feat(shared): move the intent canonicalizer to @breeze/shared with frozen conformance vectors

### DIFF
--- a/apps/api/src/services/actionIntents/canonicalize.ts
+++ b/apps/api/src/services/actionIntents/canonicalize.ts
@@ -1,31 +1,12 @@
-import { createHash } from 'crypto';
-
-function sortValue(value: unknown, seen: WeakSet<object>): unknown {
-  if (value === null || typeof value !== 'object') {
-    if (typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint') {
-      throw new TypeError('argument value is not JSON-serializable');
-    }
-    return value;
-  }
-  if (seen.has(value as object)) throw new TypeError('circular argument structure');
-  seen.add(value as object);
-  try {
-    if (Array.isArray(value)) return value.map((item) => sortValue(item, seen));
-    const out: Record<string, unknown> = {};
-    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-      const item = (value as Record<string, unknown>)[key];
-      if (item !== undefined) out[key] = sortValue(item, seen);
-    }
-    return out;
-  } finally {
-    seen.delete(value as object);
-  }
-}
-
-export function canonicalizeArguments(input: Record<string, unknown>): string {
-  return JSON.stringify(sortValue(input, new WeakSet()));
-}
-
-export function computeArgumentDigest(canonical: string): string {
-  return createHash('sha256').update(canonical, 'utf8').digest('hex');
-}
+/**
+ * The canonicalizer moved to `@breeze/shared/canonicalize` so that processes outside the
+ * API — the M365 communications executor, which recomputes an approval digest before it
+ * touches any credential — agree on the bytes rather than each having their own copy.
+ *
+ * This file stays as a re-export so no call site changed in the move. Do not reimplement
+ * anything here: a second implementation turns every digest comparison into a check that
+ * an implementation agrees with itself. `@breeze/shared/canonicalize/vectors` is the
+ * frozen corpus that makes such drift fail, and `canonicalize.vectors.test.ts` runs it
+ * through this import path.
+ */
+export { canonicalizeArguments, computeArgumentDigest } from '@breeze/shared/canonicalize';

--- a/apps/api/src/services/actionIntents/canonicalize.vectors.test.ts
+++ b/apps/api/src/services/actionIntents/canonicalize.vectors.test.ts
@@ -1,0 +1,30 @@
+/**
+ * The API half of the cross-package canonicalizer contract.
+ *
+ * `canonicalize.test.ts` next door still covers behaviour. This file covers *agreement*:
+ * it runs the frozen corpus through the API's own import path, so if anything ever
+ * shadows, wraps, or re-implements the canonicalizer on this side, the stored
+ * `action_intents.argument_digest` values stop matching and this fails.
+ *
+ * The same corpus is executed inside `@breeze/shared` and — once it exists — by the M365
+ * communications executor. Expectations are frozen constants and are never recomputed;
+ * see the header of `vectors.ts` for why that matters.
+ */
+import { describe, it, expect } from 'vitest';
+import { CANONICALIZATION_VECTORS } from '@breeze/shared/canonicalize/vectors';
+import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
+
+describe('canonicalizer conformance (API import path)', () => {
+  it('runs a non-empty corpus', () => {
+    expect(CANONICALIZATION_VECTORS.length).toBeGreaterThan(10);
+  });
+
+  it.each(CANONICALIZATION_VECTORS.map((v) => [v.name, v] as const))(
+    'vector %s produces the frozen digest',
+    (_name, vector) => {
+      const canonical = canonicalizeArguments(vector.input);
+      if (vector.canonical !== undefined) expect(canonical).toBe(vector.canonical);
+      expect(computeArgumentDigest(canonical)).toBe(vector.digest);
+    }
+  );
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,9 @@
     "./validators": "./src/validators/index.ts",
     "./constants": "./src/constants/index.ts",
     "./m365": "./src/m365/index.ts",
-    "./reportPdf": "./src/reportPdf/index.ts"
+    "./reportPdf": "./src/reportPdf/index.ts",
+    "./canonicalize": "./src/canonicalize/index.ts",
+    "./canonicalize/vectors": "./src/canonicalize/vectors.ts"
   },
   "scripts": {
     "test": "vitest",

--- a/packages/shared/src/canonicalize/canonicalize.test.ts
+++ b/packages/shared/src/canonicalize/canonicalize.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { canonicalizeArguments, computeArgumentDigest } from './index';
+import { CANONICALIZATION_VECTORS, BODY_32KIB_ASCII, BODY_32KIB_ASTRAL } from './vectors';
+
+describe('canonicalizeArguments', () => {
+  it('should have identical output for different key orders', () => {
+    const obj1 = { b: 1, a: 2 };
+    const obj2 = { a: 2, b: 1 };
+    expect(canonicalizeArguments(obj1)).toBe(canonicalizeArguments(obj2));
+  });
+
+  it('should sort nested object keys', () => {
+    const obj = { z: { b: 1, a: 2 }, a: 3 };
+    const parsed = JSON.parse(canonicalizeArguments(obj));
+    expect(Object.keys(parsed)).toEqual(['a', 'z']);
+    expect(Object.keys(parsed.z)).toEqual(['a', 'b']);
+  });
+
+  it('should preserve array order', () => {
+    expect(canonicalizeArguments({ arr: [1, 2, 3] })).not.toBe(canonicalizeArguments({ arr: [3, 2, 1] }));
+  });
+
+  it('should drop undefined properties', () => {
+    expect(canonicalizeArguments({ a: 1, b: undefined, c: 2 })).toBe(canonicalizeArguments({ a: 1, c: 2 }));
+  });
+
+  it('should render undefined in arrays as nulls', () => {
+    expect(JSON.parse(canonicalizeArguments({ arr: [1, undefined, 3] })).arr).toEqual([1, null, 3]);
+  });
+
+  it('should throw on circular references', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj.self = obj;
+    expect(() => canonicalizeArguments(obj)).toThrow(TypeError);
+    expect(() => canonicalizeArguments(obj)).toThrow('circular argument structure');
+  });
+
+  it('should allow a shared (non-circular) object instance reused at sibling keys', () => {
+    const shared = { m: 1, n: 2 };
+    const parsed = JSON.parse(canonicalizeArguments({ x: shared, y: shared }));
+    expect(parsed.x).toEqual({ m: 1, n: 2 });
+    expect(parsed.y).toEqual({ m: 1, n: 2 });
+    expect(canonicalizeArguments({ x: shared })).toBe(JSON.stringify({ x: { m: 1, n: 2 } }));
+  });
+
+  it('should allow a shared (non-circular) object instance reused within an array', () => {
+    const shared = { a: 1 };
+    expect(JSON.parse(canonicalizeArguments({ arr: [shared, shared] })).arr).toEqual([{ a: 1 }, { a: 1 }]);
+  });
+
+  it('should allow a deep shared reference reused across sibling subtrees', () => {
+    const sharedLeaf = { id: 'leaf', value: 42 };
+    const obj = {
+      branchA: { nested: { leaf: sharedLeaf } },
+      branchB: { otherNested: { leaf: sharedLeaf } },
+    };
+    expect(() => canonicalizeArguments(obj)).not.toThrow();
+    const parsed = JSON.parse(canonicalizeArguments(obj));
+    expect(parsed.branchA.nested.leaf).toEqual({ id: 'leaf', value: 42 });
+    expect(parsed.branchB.otherNested.leaf).toEqual({ id: 'leaf', value: 42 });
+  });
+
+  it.each([
+    ['functions', { fn: () => {} }],
+    ['symbols', { sym: Symbol('test') }],
+    ['bigints', { big: BigInt(123) }],
+  ])('should throw on %s', (_label, obj) => {
+    expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(TypeError);
+    expect(() => canonicalizeArguments(obj as Record<string, unknown>)).toThrow(
+      'argument value is not JSON-serializable'
+    );
+  });
+
+  it('should handle null and primitive values', () => {
+    const parsed = JSON.parse(canonicalizeArguments({ null: null, str: 'test', num: 42, bool: true }));
+    expect(parsed).toEqual({ bool: true, null: null, num: 42, str: 'test' });
+  });
+
+  it('should handle nested arrays with objects', () => {
+    const parsed = JSON.parse(canonicalizeArguments({ arr: [{ z: 1, a: 2 }, { b: 3, a: 4 }] }));
+    expect(Object.keys(parsed.arr[0])).toEqual(['a', 'z']);
+    expect(Object.keys(parsed.arr[1])).toEqual(['a', 'b']);
+  });
+});
+
+describe('computeArgumentDigest', () => {
+  it('should return a 64-character lowercase hex string', () => {
+    expect(computeArgumentDigest('test')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('should be deterministic for the same input', () => {
+    const canonical = canonicalizeArguments({ a: 1, b: 2 });
+    expect(computeArgumentDigest(canonical)).toBe(computeArgumentDigest(canonical));
+  });
+
+  it('should differ for different inputs', () => {
+    expect(computeArgumentDigest(canonicalizeArguments({ a: 1 }))).not.toBe(
+      computeArgumentDigest(canonicalizeArguments({ a: 2 }))
+    );
+  });
+
+  it('should match for canonically equivalent inputs', () => {
+    expect(computeArgumentDigest(canonicalizeArguments({ b: 1, a: 2 }))).toBe(
+      computeArgumentDigest(canonicalizeArguments({ a: 2, b: 1 }))
+    );
+  });
+
+  it('should handle the empty canonical string', () => {
+    expect(computeArgumentDigest('')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('should differ for different array orders', () => {
+    expect(computeArgumentDigest(canonicalizeArguments({ arr: [1, 2, 3] }))).not.toBe(
+      computeArgumentDigest(canonicalizeArguments({ arr: [3, 2, 1] }))
+    );
+  });
+});
+
+/**
+ * The cross-package contract. These same vectors are executed by `apps/api` and, once it
+ * exists, by the communications executor. Expectations come from the frozen corpus and are
+ * never recomputed — see the header of `vectors.ts`.
+ */
+describe('frozen conformance vectors', () => {
+  it.each(CANONICALIZATION_VECTORS.map((v) => [v.name, v] as const))(
+    'vector %s produces the frozen digest',
+    (_name, vector) => {
+      const canonical = canonicalizeArguments(vector.input);
+      if (vector.canonical !== undefined) expect(canonical).toBe(vector.canonical);
+      expect(computeArgumentDigest(canonical)).toBe(vector.digest);
+    }
+  );
+});
+
+/**
+ * Guards on the corpus itself. A conformance suite is only as good as its inputs, and
+ * several of these vectors would silently degrade into tautologies if their inputs were
+ * "tidied" by an editor or a formatter — a decomposed é normalized to a precomposed one,
+ * a zero-width character stripped, CRLF rewritten to LF on checkout. Each check below
+ * fails loudly in that case instead of leaving a vector that passes against anything.
+ */
+describe('corpus integrity', () => {
+  const byName = new Map(CANONICALIZATION_VECTORS.map((v) => [v.name, v]));
+
+  it('has unique vector names', () => {
+    expect(byName.size).toBe(CANONICALIZATION_VECTORS.length);
+  });
+
+  it('has a distinct digest for every vector', () => {
+    const digests = new Set(CANONICALIZATION_VECTORS.map((v) => v.digest));
+    expect(digests.size).toBe(CANONICALIZATION_VECTORS.length);
+  });
+
+  it('has well-formed frozen digests', () => {
+    for (const v of CANONICALIZATION_VECTORS) expect(v.digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('keeps the normalization vector genuinely un-normalized', () => {
+    const { subject, alt } = byName.get('no-unicode-normalization')!.input as { subject: string; alt: string };
+    // Distinct code points that are canonically equivalent under NFC. If a tool ever
+    // normalizes this file, these two become identical and the vector stops proving
+    // anything at all.
+    expect(subject).not.toBe(alt);
+    expect(subject.normalize('NFC')).toBe(alt.normalize('NFC'));
+    expect([...subject].map((c) => c.codePointAt(0))).toEqual([0x63, 0x61, 0x66, 0xe9]);
+    expect([...alt].map((c) => c.codePointAt(0))).toEqual([0x63, 0x61, 0x66, 0x65, 0x301]);
+  });
+
+  it('keeps the invisible-control characters present', () => {
+    const { subject, body } = byName.get('invisible-controls-survive')!.input as { subject: string; body: string };
+    expect(subject).toContain('​'); // zero-width space
+    expect(subject).toContain('‮'); // right-to-left override
+    expect(body).toContain('﻿'); // BOM / zero-width no-break space
+  });
+
+  it('keeps CRLF and LF distinct rather than incidentally equal', () => {
+    const crlf = byName.get('crlf-preserved')!;
+    const lf = byName.get('lf-only-differs-from-crlf')!;
+    expect((crlf.input as { body: string }).body).toContain('\r\n');
+    expect((lf.input as { body: string }).body).not.toContain('\r');
+    expect(crlf.digest).not.toBe(lf.digest);
+  });
+
+  it('keeps the lone surrogate lone', () => {
+    const body = (byName.get('lone-surrogate-escaped')!.input as { body: string }).body;
+    expect(body).toContain('\uD800');
+    expect(body.codePointAt(6)).toBe(0xd800); // still unpaired, not silently repaired
+  });
+
+  it('sizes the oversized bodies at exactly 32 KiB of UTF-16 code units', () => {
+    expect(BODY_32KIB_ASCII.length).toBe(32 * 1024);
+    expect(BODY_32KIB_ASTRAL.length).toBe(32 * 1024);
+    // Astral filler is surrogate pairs, so code points are half the code units.
+    expect([...BODY_32KIB_ASTRAL].length).toBe(16 * 1024);
+  });
+});

--- a/packages/shared/src/canonicalize/index.ts
+++ b/packages/shared/src/canonicalize/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical JSON serialization and digesting for approval-bound arguments.
+ *
+ * This module is the SINGLE canonicalizer for the action-intent chain. It lives in
+ * `@breeze/shared` rather than in the API because more than one process has to agree
+ * on the bytes: the API computes the digest an approver signs off on, and an executor
+ * recomputes it from the request it received before touching any credential. If either
+ * side reimplements this, the digest check silently degrades from a binding check into
+ * a self-consistency check that always passes. `./vectors` exists to make that drift
+ * fail loudly — see the note there.
+ *
+ * Exposed as the `@breeze/shared/canonicalize` subpath and deliberately NOT re-exported
+ * from the package root: `computeArgumentDigest` pulls in `node:crypto`, and the root
+ * barrel is bundled into the browser via `apps/web`.
+ */
+import { createHash } from 'node:crypto';
+
+function sortValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (value === null || typeof value !== 'object') {
+    if (typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint') {
+      throw new TypeError('argument value is not JSON-serializable');
+    }
+    return value;
+  }
+  if (seen.has(value as object)) throw new TypeError('circular argument structure');
+  seen.add(value as object);
+  try {
+    if (Array.isArray(value)) return value.map((item) => sortValue(item, seen));
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const item = (value as Record<string, unknown>)[key];
+      if (item !== undefined) out[key] = sortValue(item, seen);
+    }
+    return out;
+  } finally {
+    seen.delete(value as object);
+  }
+}
+
+export function canonicalizeArguments(input: Record<string, unknown>): string {
+  return JSON.stringify(sortValue(input, new WeakSet()));
+}
+
+export function computeArgumentDigest(canonical: string): string {
+  return createHash('sha256').update(canonical, 'utf8').digest('hex');
+}

--- a/packages/shared/src/canonicalize/vectors.ts
+++ b/packages/shared/src/canonicalize/vectors.ts
@@ -1,0 +1,183 @@
+/**
+ * Frozen conformance vectors for the canonicalizer.
+ *
+ * WHY THESE ARE HARD-CODED: every `digest` below was computed once and pasted in. They
+ * must NEVER be derived at test time by calling `computeArgumentDigest`, because the
+ * whole point is to catch a *second* implementation drifting from this one. A test that
+ * computes its own expectation passes against any implementation, including a wrong one,
+ * and that is precisely the failure this corpus exists to prevent (design risk #4:
+ * "if the executor ever reimplements canonicalization, every digest check silently
+ * becomes a self-consistency check").
+ *
+ * Consumers: `@breeze/shared` itself, `apps/api` (via `services/actionIntents/canonicalize`),
+ * and — once it exists — the M365 communications executor. Each runs the same corpus
+ * through its own import path.
+ *
+ * CHANGING A DIGEST HERE IS A BREAKING CHANGE. A stored `argument_digest` in
+ * `action_intents` was computed under these bytes; altering canonicalization invalidates
+ * every approved-but-unreleased intent. If a change is genuinely required it needs a
+ * versioned canonicalizer and a migration story, not an edited constant.
+ */
+
+/** Deterministic filler of a given length, built from a repeating non-trivial pattern. */
+function filler(length: number, pattern: string): string {
+  return pattern.repeat(Math.ceil(length / pattern.length)).slice(0, length);
+}
+
+/** 32 KiB of mixed ASCII — the mail-body size ceiling the comms catalog allows. */
+export const BODY_32KIB_ASCII = filler(32 * 1024, 'The quick brown fox jumps over the lazy dog. 0123456789 ');
+
+/**
+ * 32 KiB of astral-plane characters. Length is in UTF-16 code units, so this is
+ * 16384 code points, each a surrogate pair — the case where a byte-oriented and a
+ * code-unit-oriented implementation diverge.
+ */
+export const BODY_32KIB_ASTRAL = filler(32 * 1024, '\u{1F600}\u{1D11E}\u{20BB7}');
+
+export interface CanonicalizationVector {
+  /** Stable identifier; used in test names on both sides. */
+  name: string;
+  /** What this vector pins, and why it would be missed without it. */
+  why: string;
+  input: Record<string, unknown>;
+  /**
+   * Frozen canonical JSON. Omitted only for the oversized vectors, where inlining
+   * 32 KiB of expected output would bury the corpus — those pin the digest alone.
+   */
+  canonical?: string;
+  /** Frozen SHA-256 hex of the canonical form. Never recompute. */
+  digest: string;
+}
+
+export const CANONICALIZATION_VECTORS: readonly CanonicalizationVector[] = [
+  {
+    name: 'empty-object',
+    why: 'Degenerate input; pins that an empty envelope still digests rather than throwing.',
+    input: {},
+    canonical: '{}',
+    digest: '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a',
+  },
+  {
+    name: 'key-order-independent',
+    why: 'The core property: an approver and an executor may serialize the same object with different key insertion order.',
+    input: { subject: 'Re: ticket', to: ['a@example.com'], from: 'tech@msp.example' },
+    canonical: '{"from":"tech@msp.example","subject":"Re: ticket","to":["a@example.com"]}',
+    digest: '1c47931a5550bfa6d540c3b4ae5b9d8b2bbabeae0f23361295e190c9944f55c3',
+  },
+  {
+    name: 'nested-key-order-independent',
+    why: 'Sorting must recurse; a shallow sort passes the previous vector and fails this one.',
+    input: { z: { b: 1, a: 2 }, a: 3 },
+    canonical: '{"a":3,"z":{"a":2,"b":1}}',
+    digest: 'c2438635795c82ca61e79ff7d3296a32531ab55ea2e02178ecb8a9ec064f538f',
+  },
+  {
+    name: 'array-order-significant',
+    why: 'Recipient order must NOT be sorted away — [a,b] and [b,a] are different sends.',
+    input: { to: ['b@example.com', 'a@example.com'] },
+    canonical: '{"to":["b@example.com","a@example.com"]}',
+    digest: 'b18c71dcd35a973cd779defb472df7d69fba8fd6490ec0aa93c03cc4e13f3524',
+  },
+  {
+    name: 'undefined-dropped-at-keys',
+    why: 'An absent optional field and an explicitly-undefined one must digest identically.',
+    input: { a: 1, b: undefined, c: 2 },
+    canonical: '{"a":1,"c":2}',
+    digest: 'fe4fe01ca204b3f3408bd6c7c2b039500701c124753442eeaab96c1dd08257e9',
+  },
+  {
+    name: 'undefined-becomes-null-in-arrays',
+    why: 'Array holes are not dropped, they null out; pins the asymmetry with object keys.',
+    input: { arr: [1, undefined, 3] },
+    canonical: '{"arr":[1,null,3]}',
+    digest: '15b01a2d5507678e45ab33bd75df4b9d03b2dc04fd8f1afd883d7588d1d83ae0',
+  },
+  {
+    name: 'null-and-primitives',
+    why: 'Pins primitive rendering (no number reformatting, no boolean coercion).',
+    input: { nullish: null, str: 'test', num: 42, negZero: -0, bool: true },
+    canonical: '{"bool":true,"negZero":0,"nullish":null,"num":42,"str":"test"}',
+    digest: 'c3f4ad963118114e6bc19fa2de70db45867e3e9b441c4cd44c33baf095df76e1',
+  },
+  {
+    name: 'unicode-non-bmp',
+    why: 'Astral characters in a subject line; a UCS-2-assuming implementation mangles these.',
+    input: { subject: 'Deploy \u{1F680} to \u{1D400}\u{1D401}', body: '\u{20BB7}\u{1F1FA}\u{1F1F8}' },
+    canonical: '{"body":"\u{20BB7}\u{1F1FA}\u{1F1F8}","subject":"Deploy \u{1F680} to \u{1D400}\u{1D401}"}',
+    digest: '0041d9a508f0ca5592cbc5c850168967ebc4138b22520a3f785f120b231e923e',
+  },
+  {
+    name: 'lone-surrogate-escaped',
+    why: 'Well-formed JSON.stringify (ES2019) escapes lone surrogates rather than emitting invalid UTF-8. Pins that behaviour, which differs across languages and older runtimes.',
+    input: { body: 'before\uD800after' },
+    canonical: '{"body":"before\\ud800after"}',
+    digest: 'cdc46fb83cd76b1aef4c9bbd4430070545a122bff2d2186018aa8c5bb2c82a7c',
+  },
+  {
+    name: 'surrogate-adjacent-pair-intact',
+    why: 'A valid pair adjacent to a lone surrogate must not be recombined or split by the escaping path.',
+    input: { body: '😀\uD800😀' },
+    digest: 'b835763094337e2912f14bef1fa8b3e593cc13c92f85a7af2f7d4d9899ec9cb1',
+  },
+  {
+    name: 'crlf-preserved',
+    why: 'Mail bodies carry CRLF. Nothing may normalize line endings — the sent bytes are what was approved.',
+    input: { body: 'line one\r\nline two\r\n' },
+    canonical: '{"body":"line one\\r\\nline two\\r\\n"}',
+    digest: '386c36d8f996ddcb3f85957ead5be1f8f2140c39f7762f5c8ef4b265a06b6f71',
+  },
+  {
+    name: 'lf-only-differs-from-crlf',
+    why: 'Companion to the previous vector: proves the CRLF pin is falsifiable rather than incidentally equal.',
+    input: { body: 'line one\nline two\n' },
+    canonical: '{"body":"line one\\nline two\\n"}',
+    digest: 'ea425c3bf4eed990939c42cd65eb30bdc3b9e75031997c6dcf5f9c7b1c9d1509',
+  },
+  {
+    name: 'no-unicode-normalization',
+    why: 'Precomposed U+00E9 and decomposed e+U+0301 render identically to a human and MUST digest differently — an executor that NFC-normalizes would send content the approver never saw.',
+    input: { subject: 'café', alt: 'café' },
+    canonical: '{"alt":"café","subject":"café"}',
+    digest: 'e4623a12890972c9521acb92692f6ed8ca90b1ad9d95f354b97bc4a026c4682d',
+  },
+  {
+    name: 'invisible-controls-survive',
+    why: 'Zero-width and bidi-override characters are a display-spoofing vector (§5.4 neutralizes them at render time). Canonicalization must carry them verbatim so the digest covers what is actually sent.',
+    input: { subject: 'Invoice​‮fdp.exe', body: 'ok﻿' },
+    digest: 'a504d657bdb8dfb0ed69cce96f32c175686ffa852c50e1e0c32e9fa250e8c1ed',
+  },
+  {
+    name: 'deeply-nested',
+    why: 'Recursion depth; a stack-limited reimplementation fails here rather than in production.',
+    input: { a: { b: { c: { d: { e: { f: { g: { h: 'deep' } } } } } } } },
+    canonical: '{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":"deep"}}}}}}}}',
+    digest: '76e2f0ef7d04c206559d0de4c39f5129f21d35159d1ececae54f2c6e638c1456',
+  },
+  {
+    name: 'body-32kib-ascii',
+    why: 'The catalog size ceiling. Pins that nothing truncates, chunks, or streams differently at scale.',
+    input: { body: BODY_32KIB_ASCII },
+    digest: 'e77253d2e1742fb0d290f22b573cddb2c7df7d2952e918efb77e645a752862ee',
+  },
+  {
+    name: 'body-32kib-astral',
+    why: '32 KiB of surrogate pairs — the worst case for any implementation that conflates code units with characters or bytes.',
+    input: { body: BODY_32KIB_ASTRAL },
+    digest: '3c31c834553a2428273235f5e33d2a715729bc2ed4afb1a23f91309983029173',
+  },
+  {
+    name: 'realistic-send-envelope',
+    why: 'End-to-end shape resembling an actual comms send, so the corpus is not purely synthetic.',
+    input: {
+      action: 'm365.mail.send',
+      version: 1,
+      sender: { upn: 'tech@msp.example', objectId: '00000000-0000-0000-0000-000000000001' },
+      to: ['first@customer.example', 'second@customer.example'],
+      cc: [],
+      bcc: ['archive@msp.example'],
+      subject: 'Maintenance window — Saturday 02:00 UTC',
+      body: 'Hello,\r\n\r\nWe will patch your servers.\r\n\r\nRegards,\r\nThe team\r\n',
+    },
+    digest: 'c139cba98de004ba20a424501a58ec4b89460b3b02503907968d6994fd294c0d',
+  },
+] as const;


### PR DESCRIPTION
Task 1 of the [M365 communications-delegated executor](https://github.com/LanternOps/breeze/pull/2920) (design §14). Pure move plus a conformance corpus — **no behaviour change**, and no call site changed, because the old path re-exports.

## Why it moves

The approval digest is only a *binding* check if the process that computes it and the process that recomputes it agree on the bytes. The comms executor recomputes the digest from the request it received **before touching any credential**, so it needs this code rather than its own copy of it. A second implementation would silently downgrade every digest comparison into a check that an implementation agrees with itself — design risk #4.

## Where it lives, and where it deliberately does not

`@breeze/shared/canonicalize` is a **subpath export, not part of the root barrel**. `computeArgumentDigest` imports `node:crypto`, and the root barrel is bundled into the browser via `apps/web`. `packages/shared` had zero `crypto` imports before this change and still has none on any path `apps/web` can reach.

## The corpus

`@breeze/shared/canonicalize/vectors` carries **hard-coded expected digests that are never recomputed at test time**, executed by both the shared package and `apps/api` through their own import paths. The executor becomes the third consumer at task 8.

It pins the cases where a reimplementation plausibly diverges:

| Vector class | What it catches |
|---|---|
| Astral characters, lone surrogate adjacent to a valid pair | Implementations that conflate code units, code points, and bytes |
| CRLF vs LF, with both frozen | Anything that normalizes line endings — the sent bytes must be the approved bytes |
| 32 KiB bodies, ASCII and all-surrogate-pair | Truncation or chunking that only appears at the size ceiling |
| Array order | Recipient order is not sortable: `[a,b]` and `[b,a]` are different sends |
| **Unicode normalization** | The one most likely to be introduced as a *fix*: precomposed `é` and decomposed `e`+U+0301 render identically to an approver and must digest differently |
| Zero-width / RTL-override / BOM | Display-spoofing characters must ride through canonicalization verbatim so the digest covers what is actually sent |

A `corpus integrity` suite guards the **inputs**, because several vectors degrade into tautologies if an editor or a checkout ever tidies them. It asserts the normalization pair is still distinct-but-NFC-equal at specific code points, the invisible controls are still present, the lone surrogate is still unpaired, and CRLF still differs from LF.

## Verification

Non-vacuity proven by **injection, not inspection**:

| Injected drift | Shared | API |
|---|---|---|
| `String.normalize('NFC')` on every string | 1 failed / 45 passed | 1 failed / 40 passed |
| `.sort()` on every array | 5 failed / 41 passed | 5 failed / 36 passed |
| *(restored)* | 46 passed | 41 passed |

Also green: full `@breeze/shared` suite (1357), `actionIntents` + `aiAgentSdk` + `intentReleaseWorker` API suites (268), `@breeze/shared` typecheck, `@breeze/api` lint, `@breeze/api` build.

## Note for reviewers

Changing a frozen digest is a breaking change, and the header of `vectors.ts` says so: a stored `action_intents.argument_digest` was computed under these bytes, so altering canonicalization invalidates every approved-but-unreleased intent. That needs a versioned canonicalizer and a migration story, not an edited constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)