### PR TITLE
feat(shared): trim communications-delegated to mail-only scopes (v2)

### DIFF
--- a/apps/api/src/services/m365ControlPlane/profiles.test.ts
+++ b/apps/api/src/services/m365ControlPlane/profiles.test.ts
@@ -11,7 +11,8 @@ import {
 const PROFILE_CONTRACTS = [
   {
     id: 'communications-delegated',
-    version: 1,
+    // v2 (2026-07-29): mail-only; the unexercised Teams scopes were dropped.
+    version: 2,
     ownerAxis: 'user',
     authMode: 'delegated',
     credentialDomain: 'communications-delegated',

--- a/packages/shared/src/m365/profiles.test.ts
+++ b/packages/shared/src/m365/profiles.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   M365_PERMISSION_PROFILES,
   canonicalGrantKey,
+  connectionNeedsConsentReconciliation,
 } from './profiles';
 
 const MICROSOFT_GRAPH_RESOURCE_APPLICATION_ID = '00000003-0000-0000-c000-000000000000';
@@ -63,6 +64,55 @@ describe('shared M365 permission profiles', () => {
     expect(profile.applicationPermissions).toEqual(
       CUSTOMER_GRAPH_READ_ASSIGNMENTS.map(({ value }) => value),
     );
+  });
+
+  describe('communications-delegated is mail-only at version 2', () => {
+    const profile = M365_PERMISSION_PROFILES['communications-delegated'];
+
+    it('requests exactly this scope set and no more', () => {
+      // Asserted as an exact set rather than with `toContain`, so ADDING a scope fails too.
+      // A delegated grant is a live credential for a named person's mailbox; every extra
+      // scope widens what a compromised executor could do with it.
+      expect([...profile.delegatedPermissions]).toEqual([
+        'openid',
+        'profile',
+        'offline_access',
+        'User.Read',
+        'Mail.ReadWrite',
+        'Mail.Send',
+      ]);
+    });
+
+    it('is at version 2', () => {
+      expect(profile.version).toBe(2);
+    });
+
+    it('drops the unexercised Teams scopes', () => {
+      for (const scope of ['Chat.ReadWrite', 'ChannelMessage.Read.All', 'ChannelMessage.Send']) {
+        expect(profile.delegatedPermissions).not.toContain(scope);
+      }
+    });
+
+    it('retains offline_access', () => {
+      // Without it there is no refresh token, so no send can ever run headless — the
+      // single most consequential scope in the set, and the easiest to drop while
+      // "trimming to mail-only".
+      expect(profile.delegatedPermissions).toContain('offline_access');
+    });
+
+    it('grants no application permissions at all', () => {
+      // The whole point of the user axis: this profile acts as a person, never as the app.
+      expect(profile.applicationPermissions).toEqual([]);
+      expect('applicationPermissionAssignments' in profile).toBe(false);
+    });
+
+    it('flags every stored v1 row for consent reconciliation', () => {
+      // Existing connections consented under the v1 scope set must be re-consented rather
+      // than silently treated as current.
+      expect(connectionNeedsConsentReconciliation('communications-delegated', 1)).toBe(true);
+      expect(connectionNeedsConsentReconciliation('communications-delegated', 2)).toBe(false);
+      expect(connectionNeedsConsentReconciliation('communications-delegated', 3)).toBe(true);
+    });
   });
 
   it('keeps future application profiles name-only at version 1', () => {

--- a/packages/shared/src/m365/profiles.ts
+++ b/packages/shared/src/m365/profiles.ts
@@ -57,7 +57,13 @@ const MICROSOFT_GRAPH_RESOURCE_APPLICATION_ID = '00000003-0000-0000-c000-0000000
 export const M365_PERMISSION_PROFILES = {
   'communications-delegated': {
     id: 'communications-delegated',
-    version: 1,
+    // v2 (2026-07-29): trimmed to mail-only. v1 also requested Chat.ReadWrite,
+    // ChannelMessage.Read.All and ChannelMessage.Send for a Teams catalog that does not
+    // exist and is not in the first cut. The actions runbook's own principle applies —
+    // consenting scopes nothing exercises "only widens the mutation blast radius" — and
+    // for a *delegated* profile the re-consent cost is one sign-in by one person, the
+    // cheapest re-consent in the system. Teams scopes come back with the Teams catalog.
+    version: 2,
     ownerAxis: 'user',
     authMode: 'delegated',
     credentialDomain: 'communications-delegated',
@@ -65,13 +71,17 @@ export const M365_PERMISSION_PROFILES = {
     delegatedPermissions: [
       'openid',
       'profile',
+      // Load-bearing: without it Microsoft issues no refresh token, and every send would
+      // need an interactive sign-in — which is exactly what the durable release path
+      // cannot do.
       'offline_access',
+      // Covers the consent-time identity probe, GET /me?$select=id,userPrincipalName,mail
+      // (design §4.2). Note the probe deliberately does NOT read /me/mailboxSettings, so
+      // MailboxSettings.Read is not required here.
       'User.Read',
+      // Mail.Read would cover list/get, but draft.create needs write on the mailbox.
       'Mail.ReadWrite',
       'Mail.Send',
-      'Chat.ReadWrite',
-      'ChannelMessage.Read.All',
-      'ChannelMessage.Send',
     ],
     applicationPermissions: [],
   },


### PR DESCRIPTION
Task 3 of the M365 communications-delegated executor. **Stacked on #2922.**

## What and why

v1 of the `communications-delegated` profile requested `Chat.ReadWrite`, `ChannelMessage.Read.All` and `ChannelMessage.Send` for a Teams catalog that does not exist and is not in the first cut. The actions runbook's own principle applies — consenting scopes nothing exercises "only widens the mutation blast radius" — and here those scopes sit on a live delegated credential for a named person's mailbox and Teams presence.

**The re-consent cost is the argument for doing it now.** A delegated profile is re-consented by one sign-in by one person — the cheapest re-consent in the system — and there are no live connections on this profile today. Teams scopes come back with the Teams catalog.

| | v1 | v2 |
|---|---|---|
| `openid`, `profile`, `offline_access` | ✓ | ✓ |
| `User.Read` | ✓ | ✓ |
| `Mail.ReadWrite`, `Mail.Send` | ✓ | ✓ |
| `Chat.ReadWrite` | ✓ | — |
| `ChannelMessage.Read.All` | ✓ | — |
| `ChannelMessage.Send` | ✓ | — |

## Two things worth flagging

**`offline_access` is retained and has its own test.** It is the most consequential scope in the set and the easiest to drop while "trimming to mail-only" — without it Microsoft issues no refresh token, so no send could ever run headless, which is the entire reason the executor exists.

**`MailboxSettings.Read` is deliberately not added,** despite the v2 review flagging its absence. The consent-time identity probe is `GET /me?$select=id,userPrincipalName,mail` (design §4.2), which `User.Read` already covers. The `/me/mailboxSettings` probe that would have needed it is not in the design.

## Verification

- Scopes asserted as an **exact list**, not with `toContain` — so *adding* a scope fails the test too, which is the direction that matters for a permission manifest.
- `connectionNeedsConsentReconciliation` is asserted to flag stored v1 rows (and v3, and not v2).
- Swept for a second copy: `apps/api/src/services/m365ControlPlane/profiles.ts` is a pure `export * from '@breeze/shared/m365'`, so there is nothing to drift. The API's own profile-contract table was updated to v2.
- Migration references to `communications-delegated` are CHECK constraints on the profile **name**, not its version — unaffected.

Green: `@breeze/shared` suite (1448) + typecheck, API m365 route/service suites (430).

🤖 Generated with [Claude Code](https://claude.com/claude-code)