### PR TITLE
feat(api): cancel a partner's subscription when suspended for abuse

### DIFF
--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // We test the platform-admin gate, Zod validation, audit-log shape, and
 // not-found path. The full suspend transaction (multi-statement Drizzle calls
@@ -200,6 +200,13 @@ vi.mock('../../oauth/grantRevocation', () => ({
     refreshTokensRevoked: 0,
     jtisRevoked: 0,
   })),
+}));
+
+// Billing subscription cancel on suspend. vi.hoisted so the stable mock fn is
+// referenceable inside the (hoisted) factory and assertable across calls.
+const billingCancelMock = vi.hoisted(() => vi.fn());
+vi.mock('../../services/breezeBillingClient', () => ({
+  getBreezeBillingClient: () => ({ cancelSubscription: billingCancelMock }),
 }));
 
 // /unsuspend now restores the agent fleet that an orgs.ts-initiated suspend
@@ -899,5 +906,71 @@ describe('admin/abuse — unsuspend agent-fleet restore', () => {
     expect(body.agentRestoreFailed).toBe(true);
     const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
     expect(auditCall.result).toBe('failure');
+  });
+});
+
+describe('admin/abuse — billing subscription cancel on suspend', () => {
+  const originalBillingUrl = process.env.BREEZE_BILLING_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetState();
+    process.env.NODE_ENV = 'test';
+    billingCancelMock.mockResolvedValue({ canceled: true, immediate: true });
+  });
+
+  afterEach(() => {
+    if (originalBillingUrl === undefined) delete process.env.BREEZE_BILLING_URL;
+    else process.env.BREEZE_BILLING_URL = originalBillingUrl;
+  });
+
+  it('cancels the partner subscription immediately and records it in the audit', async () => {
+    process.env.BREEZE_BILLING_URL = 'http://billing.test';
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'stolen-card mass enrollment ring' }),
+    });
+    expect(res.status).toBe(200);
+    // immediate cancellation — the account is terminated for abuse, not downgraded.
+    expect(billingCancelMock).toHaveBeenCalledWith({ partnerId: 'partner-1', immediate: true });
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.result).toBe('success');
+    expect(auditCall.details).toMatchObject({ billingSubscriptionCanceled: true });
+  });
+
+  it('does NOT abort the suspend when billing cancel fails (best-effort) and records the error', async () => {
+    process.env.BREEZE_BILLING_URL = 'http://billing.test';
+    billingCancelMock.mockRejectedValue(new Error('billing 503'));
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'stolen-card mass enrollment ring' }),
+    });
+    // The DB suspend already committed; a billing hiccup must not turn it into a failure.
+    expect(res.status).toBe(200);
+    expect(billingCancelMock).toHaveBeenCalledTimes(1);
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.result).toBe('success');
+    expect(auditCall.details).toMatchObject({
+      billingSubscriptionCanceled: null,
+      billingCancelError: 'billing 503',
+    });
+  });
+
+  it('skips billing entirely when no billing service is configured (self-hosted)', async () => {
+    delete process.env.BREEZE_BILLING_URL;
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/suspend-for-abuse', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ confirmEmail: 'admin@breeze.test', reason: 'stolen-card mass enrollment ring' }),
+    });
+    expect(res.status).toBe(200);
+    expect(billingCancelMock).not.toHaveBeenCalled();
+    const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
+    expect(auditCall.details).toMatchObject({ billingSubscriptionCanceled: null });
   });
 });

--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -935,6 +935,9 @@ describe('admin/abuse — billing subscription cancel on suspend', () => {
     expect(res.status).toBe(200);
     // immediate cancellation — the account is terminated for abuse, not downgraded.
     expect(billingCancelMock).toHaveBeenCalledWith({ partnerId: 'partner-1', immediate: true });
+    const body = await res.json();
+    expect(body.billingSubscriptionCanceled).toBe(true);
+    expect(body.billingCancelFailed).toBeUndefined();
     const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
     expect(auditCall.result).toBe('success');
     expect(auditCall.details).toMatchObject({ billingSubscriptionCanceled: true });
@@ -952,6 +955,11 @@ describe('admin/abuse — billing subscription cancel on suspend', () => {
     // The DB suspend already committed; a billing hiccup must not turn it into a failure.
     expect(res.status).toBe(200);
     expect(billingCancelMock).toHaveBeenCalledTimes(1);
+    // The operator must see the failed cancel in the response — the card is
+    // still live and needs a manual cancel in Stripe.
+    const body = await res.json();
+    expect(body.billingSubscriptionCanceled).toBeNull();
+    expect(body.billingCancelFailed).toBe(true);
     const auditCall = vi.mocked(createAuditLog).mock.calls[0]![0]!;
     expect(auditCall.result).toBe('success');
     expect(auditCall.details).toMatchObject({

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -18,6 +18,7 @@ import { revokeAllPartnerOauthArtifacts } from '../../oauth/grantRevocation';
 import { advanceUserEpochs, revokeAllRefreshFamilies, runPostCommitCleanup } from '../../services/authLifecycle';
 import { restorePartnerTenantAccess } from '../../services/tenantLifecycle';
 import { terminateUserRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
+import { getBreezeBillingClient } from '../../services/breezeBillingClient';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import { captureException } from '../../services/sentry';
 import { requireMfa } from '../../middleware/auth';
@@ -290,6 +291,28 @@ abuseRoutes.post(
       }
     }
 
+    // Cancel the partner's billing subscription so a suspended-for-abuse account
+    // stops billing (a stolen card keeps getting charged otherwise) instead of
+    // waiting for a manual cancel in Stripe. Best-effort like the teardown steps
+    // above — a billing-service hiccup must NOT abort a suspension already
+    // committed to the DB. Never refunds (that stays a manual operator decision).
+    // Skipped entirely on installs with no billing service configured
+    // (self-hosted). Outcome is recorded in the audit trail either way.
+    let billingSubscriptionCanceled: boolean | null = null;
+    let billingCancelError: string | null = null;
+    if (process.env.BREEZE_BILLING_URL) {
+      try {
+        const cancelResult = await getBreezeBillingClient().cancelSubscription({
+          partnerId,
+          immediate: true,
+        });
+        billingSubscriptionCanceled = cancelResult.canceled;
+      } catch (err) {
+        billingCancelError = err instanceof Error ? err.message : String(err);
+        captureException(err, c);
+      }
+    }
+
     const auditResult: 'success' | 'failure' =
       tokenRevocationFailures.length === 0 && oauthRevocationError === null
         ? 'success'
@@ -313,6 +336,8 @@ abuseRoutes.post(
           remoteSessionTeardownFailures,
           oauthGrantsRevoked: oauthRevocationResult?.grantsRevoked ?? 0,
           oauthRefreshTokensRevoked: oauthRevocationResult?.refreshTokensRevoked ?? 0,
+          billingSubscriptionCanceled,
+          ...(billingCancelError !== null ? { billingCancelError } : {}),
           ...(tokenRevocationFailures.length > 0
             ? { tokenRevocationFailures }
             : {}),

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -389,6 +389,8 @@ abuseRoutes.post(
           userCount: result.userCount,
           apiKeyCount: result.apiKeyCount,
           queuedUninstalls: result.deviceCount,
+          billingSubscriptionCanceled,
+          ...(billingCancelError !== null ? { billingCancelFailed: true } : {}),
         },
         500,
       );
@@ -404,6 +406,11 @@ abuseRoutes.post(
       remoteSessionTeardownFailures,
       oauthGrantsRevoked: oauthRevocationResult?.grantsRevoked ?? 0,
       oauthRefreshTokensRevoked: oauthRevocationResult?.refreshTokensRevoked ?? 0,
+      // The whole point of the billing step is "stop charging a stolen card" —
+      // an operator must see a failed cancel in the response, not only in
+      // Sentry/audit, so they can cancel manually in Stripe.
+      billingSubscriptionCanceled,
+      ...(billingCancelError !== null ? { billingCancelFailed: true } : {}),
     });
   }
 );
@@ -515,7 +522,10 @@ abuseRoutes.post(
       userCount: result.userCount,
       agentTokensRestored,
       note:
-        'Devices that received uninstall commands cannot be auto-restored. Re-enrollment required.',
+        'Devices that received uninstall commands cannot be auto-restored. Re-enrollment required.' +
+        (process.env.BREEZE_BILLING_URL
+          ? ' If suspend-for-abuse canceled the subscription, billing is NOT auto-restored — re-create it manually for a wrongly-suspended partner.'
+          : ''),
     });
   }
 );

--- a/apps/api/src/services/breezeBillingClient.test.ts
+++ b/apps/api/src/services/breezeBillingClient.test.ts
@@ -84,4 +84,69 @@ describe('breezeBillingClient', () => {
       expect(JSON.stringify(headers)).not.toContain('Bearer undefined');
     });
   });
+
+  describe('cancelSubscription', () => {
+    const originalKey = process.env.BREEZE_BILLING_API_KEY;
+    afterEach(() => {
+      if (originalKey === undefined) delete process.env.BREEZE_BILLING_API_KEY;
+      else process.env.BREEZE_BILLING_API_KEY = originalKey;
+    });
+
+    it('POSTs to the internal cancel endpoint with immediate=true by default and returns the result', async () => {
+      process.env.BREEZE_BILLING_API_KEY = 's2s-secret-token';
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, canceled: true, stripeSubscriptionId: 'sub_9', immediate: true }),
+      });
+      const client = createBreezeBillingClient({ baseUrl: 'http://billing.local', fetch: fetchMock as any });
+
+      const r = await client.cancelSubscription({ partnerId: 'p1' });
+
+      expect(r).toEqual({ canceled: true, stripeSubscriptionId: 'sub_9', immediate: true });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://billing.local/billing/api/internal/partners/p1/cancel-subscription',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toEqual({ immediate: true });
+      expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer s2s-secret-token');
+    });
+
+    it('passes immediate=false through when explicitly requested', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, canceled: true, stripeSubscriptionId: 'sub_9', immediate: false }),
+      });
+      const client = createBreezeBillingClient({ baseUrl: 'http://billing.local', fetch: fetchMock as any });
+
+      await client.cancelSubscription({ partnerId: 'p1', immediate: false });
+
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      expect(JSON.parse(init.body as string)).toEqual({ immediate: false });
+    });
+
+    it('url-encodes the partner id', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, canceled: false, immediate: true }),
+      });
+      const client = createBreezeBillingClient({ baseUrl: 'http://billing.local', fetch: fetchMock as any });
+
+      await client.cancelSubscription({ partnerId: 'p/1?x' });
+
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        'http://billing.local/billing/api/internal/partners/p%2F1%3Fx/cancel-subscription',
+      );
+    });
+
+    it('throws BILLING_UNAVAILABLE on a non-2xx response', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 502, text: async () => 'bad gateway' });
+      const client = createBreezeBillingClient({ baseUrl: 'http://billing.local', fetch: fetchMock as any });
+
+      await expect(client.cancelSubscription({ partnerId: 'p1' })).rejects.toMatchObject({
+        code: 'BILLING_UNAVAILABLE',
+        message: expect.stringContaining('bad gateway'),
+      });
+    });
+  });
 });

--- a/apps/api/src/services/breezeBillingClient.ts
+++ b/apps/api/src/services/breezeBillingClient.ts
@@ -1,8 +1,26 @@
+export interface CancelSubscriptionResult {
+  /** false when the partner had no subscription (idempotent no-op). */
+  canceled: boolean;
+  stripeSubscriptionId?: string;
+  immediate: boolean;
+}
+
 export interface BreezeBillingClient {
   createSetupIntent(input: {
     partnerId: string;
     returnUrl: string;
   }): Promise<{ setupUrl: string; customerId: string }>;
+
+  /**
+   * Cancel a partner's subscription via breeze-billing's service-to-service
+   * endpoint. Defaults to immediate cancellation (used on abuse suspension).
+   * Never refunds. Idempotent — returns `canceled: false` when there was no
+   * subscription. Throws BillingError on a non-2xx response.
+   */
+  cancelSubscription(input: {
+    partnerId: string;
+    immediate?: boolean;
+  }): Promise<CancelSubscriptionResult>;
 }
 
 export class BillingError extends Error {
@@ -40,6 +58,37 @@ export function createBreezeBillingClient(opts: {
       }
       const json = (await res.json()) as { setup_url: string; customer_id: string };
       return { setupUrl: json.setup_url, customerId: json.customer_id };
+    },
+
+    async cancelSubscription({ partnerId, immediate = true }) {
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      const billingKey = process.env.BREEZE_BILLING_API_KEY;
+      if (billingKey) headers['Authorization'] = `Bearer ${billingKey}`;
+      const res = await doFetch(
+        `${opts.baseUrl}/billing/api/internal/partners/${encodeURIComponent(partnerId)}/cancel-subscription`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ immediate }),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new BillingError(
+          'BILLING_UNAVAILABLE',
+          `Billing service returned ${res.status}: ${body.slice(0, 200)}`,
+        );
+      }
+      const json = (await res.json()) as {
+        canceled: boolean;
+        stripeSubscriptionId?: string;
+        immediate: boolean;
+      };
+      return {
+        canceled: json.canceled,
+        stripeSubscriptionId: json.stripeSubscriptionId,
+        immediate: json.immediate,
+      };
     },
   };
 }


### PR DESCRIPTION
## What
Wires the **suspend-for-abuse** path to breeze-billing's new service-to-service cancel endpoint, so a suspended (likely fraudulent) partner stops billing instead of charging a possibly-stolen card until someone cancels it by hand in Stripe.

This is the **action** half of `invariant.suspended_partner_active_subscription` — detection shipped in v0.102.0, the action was deliberately deferred pending a policy call (refund vs leave). Policy chosen: **cancel, no auto-refund.**

## Changes
- `breezeBillingClient.cancelSubscription({ partnerId, immediate })` → `POST /billing/api/internal/partners/:id/cancel-subscription`, using the same S2S API-key auth as the existing setup-intent call.
- `routes/admin/abuse.ts` calls it **best-effort** in the post-commit section with `immediate: true` (an abuse account is terminated, not gracefully downgraded). A billing hiccup never aborts a suspension already committed to the DB; the outcome (`billingSubscriptionCanceled` / `billingCancelError`) is recorded in the audit trail. Skipped entirely when no billing service is configured (self-hosted).
- **Never refunds** — a plain Stripe cancel does not prorate/refund, and we never ask. Refund-vs-leave stays a manual operator decision.

## Scope note
Covers the dedicated `suspend-for-abuse` route (the abuse path). The umbrella `PATCH /partners/:id` status→suspended path in `orgs.ts` is a separate admin transition and is **not** wired here — flagging for a fast-follow if you want cancellation on that path too.

## Companion / deploy order
Depends on **lanternops/breeze-billing#9** (adds the endpoint). Deploy order: merge + rebuild billing first, then this. **Current live exposure is $0** (all currently-suspended partners were cancelled manually 2026-07-24) — this closes the systemic gap for future suspensions, no urgency.

## Tests
- Client: endpoint URL, body, S2S auth header, partner-id encoding, non-2xx → BILLING_UNAVAILABLE.
- Suspend path: immediate cancel + audit record; best-effort (billing failure does not fail the suspend); skipped when billing unconfigured.
- Changed files green (38 tests); `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)