### PR TITLE
docs: record the tenant-export registration list and the stacked-PR CI gap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ API connects to Postgres as unprivileged `breeze_app`. Every tenant-scoped table
 1. Pick a shape; add policies in the same migration that creates the table — never defer.
 2. Migration must be idempotent (`IF NOT EXISTS` / `DO $$`). Never edit a shipped migration.
 3. Add to the relevant allowlist in `rls-coverage.integration.test.ts` in the same PR (shapes 2-6).
-4. **Register the table in every cascade list that applies (see below). RLS coverage does NOT imply cascade coverage — they are separate contracts, and this step is the one that gets missed.**
+4. **Register the table in every cascade list that applies (see below). RLS coverage does NOT imply cascade coverage — they are separate contracts, and this step is the one that gets missed.** Adding a **column** to an already-registered table is not exempt: see the export-policy row.
 5. Run the contract tests locally (needs real DB).
 6. Verify as `breeze_app`: `docker exec -it breeze-postgres psql -U breeze_app -d breeze` and forge a cross-tenant insert — must fail with `new row violates row-level security policy`.
 
@@ -55,12 +55,22 @@ API connects to Postgres as unprivileged `breeze_app`. Every tenant-scoped table
 | has a `device_id` column | `CORE_DEVICE_CASCADE_DELETE_TABLES` in `routes/devices/core.ts` | `cascadeDelete.test.ts` (**Test API**) |
 | has `device_id` **and** a denormalized `org_id` | also `CORE_DEVICE_ORG_DENORMALIZED_TABLES` (same file) | `moveOrg.coverage.test.ts` (**Test API**) |
 | is append-only (REVOKE DELETE + immutability trigger) | also `AUDIT_ADMIN_REQUIRED_TABLES` in `tenantCascade.ts` | runtime `permission denied` during erasure |
+| is in `CORE_ORG_CASCADE_DELETE_ORDER` — **including when you only add a COLUMN to one** | `CORE_TENANT_EXPORT_POLICY` in `services/tenantExportPolicyRegistry.ts` | `tenant-export-policy.integration.test.ts` + `tenantExportErasureRoundtrip.integration.test.ts` (**Integration Tests**) |
+
+**The export-policy row is the only one that fires on a new column, not just a new table.** Every column of every org-cascade table must be classified, so `ADD COLUMN` on a long-registered table breaks it. Buckets, via `tablePolicy(orgKey, groups)`:
+
+- `included` — ordinary customer data and tenant identifiers (`tenant_id`, `user_id`, monotonic counters).
+- `reviewedIncluded` — the name matches `SUSPICIOUS_NAME_PARTS` (password, hash, token, secret, credential, refresh, …) but is reviewed non-secret.
+- `excludedSensitive` — credential, private-key, or verifier material.
+- `excludedOpen` — **any `json`/`jsonb`/`bytea` column.** Open containers may embed credentials or capabilities, so a jsonb column cannot go in `included` even when its contents look harmless. A scope or grant list *is* a capability list (`m365_connections.observed_grants`, `observed_delegated_scopes`).
+
+A table with no `org_id` needs no entry. Both suites need a live database, so neither can fail in **Test API** — same blind spot as the org cascade list below.
 
 Why this list exists: missing a cascade list is a **latent GDPR org-erasure bug** — the org delete either strands rows under a dead tenant or aborts on an FK violation. It has shipped or blocked CI five times (#1359, #1351, #1365, #2179, #2514). Code review has caught it **0/5**; the contract tests caught it **5/5**. Treat it as a mechanical grep (`grep -rn '<table>' apps/api/src/services/tenantCascade.ts`), not a judgement call.
 
 **Check the FK direction, not just membership.** Ordering is children-before-parents. An FK declared without an explicit `ON DELETE` defaults to `NO ACTION`, so a referencing table must be deleted *first* or the cascade raises an FK violation. Alphabetical order often satisfies this by luck (`api_keys` < `service_principals`) — verify, don't assume. `tenantCascade.integration.test.ts` asserts five properties: alphabetised by `localeCompare` with `organizations` last; every `org_id` table present; no entry naming a non-existent table; every cascade table exactly once; FK children before parents.
 
-Only the device-side lists fail in the **Test API** unit job (they read the Drizzle schema statically). The org cascade list only fails under **Integration Tests**, so a PR on a stale base can go green and then red main after merge.
+Only the device-side lists fail in the **Test API** unit job (they read the Drizzle schema statically). The org cascade list and both export-policy suites only fail under **Integration Tests**, so a PR on a stale base can go green and then red main after merge. Worse for a **stacked** PR: `ci.yml` triggers on `pull_request: branches: [main]`, so a PR based on a sibling branch runs *no* CI at all — only the two `smoke-binary-source-*` workflows, which makes `gh pr checks` read as green. Dispatch it per branch before merging: `gh workflow run CI --ref <branch>`.
 
 For production backfills of `org_id` on hot tables (>1M rows), batch via `UPDATE ... WHERE ctid IN (... LIMIT N)` loops before `SET NOT NULL`. Full narrative and rationale: `docs/superpowers/plans/tenancy-rls/2026-04-11-rls-coverage-gaps.md`.
 


### PR DESCRIPTION
Two gaps in CLAUDE.md's tenancy section, both found on 2026-07-29 by defects that reached a branch and would have reached main. Docs only.

## The fourth registration list

The cascade-registration table named four lists. There is a fifth: `CORE_TENANT_EXPORT_POLICY` in `services/tenantExportPolicyRegistry.ts` — and it is **the only one that fires on a new column rather than a new table.** It classifies every column of every org-cascade table, so `ADD COLUMN` on a table registered years ago fails `tenant-export-policy.integration.test.ts` and `tenantExportErasureRoundtrip.integration.test.ts`.

Nothing in the repo pointed at it. Following the documented steps for three new `m365_connections` columns (#2926) produced a green local run and a red Integration Tests job.

Same GDPR blast radius the section already warns about, by a different mechanism: an unclassified column makes `buildTenantExportPlan` throw, so the org export cannot be produced **at all** — it is not a case of leaking or stranding a few rows.

The bucket rules are now stated rather than left to be inferred from neighbouring entries, because one is counterintuitive:

> `excludedOpen` — **any** `json`/`jsonb`/`bytea` column. A jsonb column cannot go in `included` even when its contents look harmless.

## Stacked PRs run no CI

The closing note said a PR on a stale base can go green and then red main. For a **stacked** PR it is stronger: `ci.yml` triggers on `pull_request: branches: [main]`, so a PR based on a sibling branch gets **no** Test API, Type Check, Integration Tests or Build. Only the two `smoke-binary-source-*` workflows run, because their filters are looser — and `gh pr checks` then prints a short all-pass list that reads as green.

That is how both of today's defects survived review and a local test run. The note now carries the escape hatch that actually found them:

```bash
gh workflow run CI --ref <branch>
```

## Evidence

Dispatching CI on the M365 comms stack, whose PRs all target sibling branches:

| Branch | Result |
|---|---|
| task 4 (#2926) | `Integration Tests (shard 1/4)` failed — 3 unclassified columns |
| task 5 (#2928) | same, inherited |

Both green after the fix. #2921, the only PR in that stack based on `main`, was the only one that had ever had these jobs run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)