### PR TITLE
fix(auth): restore the payment CTA for pending partners + stop trusting payment_method_attached_at

### DIFF
--- a/apps/api/src/middleware/partnerGuard.ts
+++ b/apps/api/src/middleware/partnerGuard.ts
@@ -39,6 +39,7 @@ export async function partnerGuard(c: Context, next: Next) {
           settings: partners.settings,
           emailVerifiedAt: partners.emailVerifiedAt,
           paymentMethodAttachedAt: partners.paymentMethodAttachedAt,
+          billingSubscriptionStatus: partners.billingSubscriptionStatus,
           deletedAt: partners.deletedAt,
         })
         .from(partners)

--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -885,6 +885,39 @@ describe('admin/abuse — unsuspend agent-fleet restore', () => {
     expect(capturedPartnerUpdate!.status).toBe('pending');
   });
 
+  // Regression coverage for the billing-status veto: a card-testing partner
+  // typically carries an incomplete_expired subscription alongside a falsely
+  // written payment stamp (#718). Unsuspend must not trust the stamp when the
+  // billing status contradicts it — the partner lands on 'pending' and has to
+  // complete a real payment.
+  it('unsuspend falls back to pending when billing status contradicts the payment stamp', async () => {
+    txMockState.partner = {
+      id: 'partner-1',
+      status: 'suspended',
+      paymentMethodAttachedAt: new Date(),
+      emailVerifiedAt: new Date(),
+      billingSubscriptionStatus: 'incomplete_expired',
+    };
+
+    const app = buildApp(platformAdminAuth);
+    const res = await app.request('/admin/partners/partner-1/unsuspend', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ reason: 'reinstating but subscription never completed' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('pending');
+    expect(restorePartnerTenantAccess).not.toHaveBeenCalled();
+
+    const capturedPartnerUpdate = txMockState.updates.find(
+      (u) => u.values && 'status' in u.values && !('disabledReason' in u.values),
+    )?.values;
+    expect(capturedPartnerUpdate).toBeDefined();
+    expect(capturedPartnerUpdate!.status).toBe('pending');
+  });
+
   it('returns 500 (does NOT silently 200) when the agent-fleet restore throws', async () => {
     vi.mocked(restorePartnerTenantAccess).mockRejectedValueOnce(new Error('db unavailable'));
     const app = buildApp(platformAdminAuth);

--- a/apps/api/src/routes/admin/abuse.test.ts
+++ b/apps/api/src/routes/admin/abuse.test.ts
@@ -11,6 +11,7 @@ const txMockState = vi.hoisted(() => ({
     status: string;
     paymentMethodAttachedAt: Date | null;
     emailVerifiedAt: Date | null;
+    billingSubscriptionStatus?: string | null;
   },
   partnerDevices: [] as Array<{ id: string }>,
   partnerOrgs: [] as Array<{ id: string }>,

--- a/apps/api/src/routes/admin/abuse.ts
+++ b/apps/api/src/routes/admin/abuse.ts
@@ -19,6 +19,7 @@ import { advanceUserEpochs, revokeAllRefreshFamilies, runPostCommitCleanup } fro
 import { restorePartnerTenantAccess } from '../../services/tenantLifecycle';
 import { terminateUserRemoteSessions, TEARDOWN_FAILED } from '../../services/remoteSessionTeardown';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
+import { billingStatusContradictsPayment } from '../../services/partnerActivation';
 import { captureException } from '../../services/sentry';
 import { requireMfa } from '../../middleware/auth';
 import type { Database } from '../../db';
@@ -399,6 +400,7 @@ abuseRoutes.post(
             id: partners.id,
             paymentMethodAttachedAt: partners.paymentMethodAttachedAt,
             emailVerifiedAt: partners.emailVerifiedAt,
+            billingSubscriptionStatus: partners.billingSubscriptionStatus,
           })
           .from(partners)
           .where(eq(partners.id, partnerId))
@@ -411,8 +413,19 @@ abuseRoutes.post(
         // Preserve the FULL activation gate (email verification AND payment
         // method) — unsuspend must not become the one path that activates an
         // unverified partner. Otherwise route back through pending-activation.
+        //
+        // The billing-status veto matters more here than anywhere else: a
+        // partner suspended for card-testing abuse typically carries an
+        // `incomplete_expired` subscription, and before the veto its (falsely
+        // written) payment stamp would send it straight back to `active` under
+        // an admin's unsuspend. Vetoed partners land on `pending` and must
+        // complete a real payment.
         const newStatus: 'active' | 'pending' =
-          partner.paymentMethodAttachedAt && partner.emailVerifiedAt ? 'active' : 'pending';
+          partner.paymentMethodAttachedAt &&
+          partner.emailVerifiedAt &&
+          !billingStatusContradictsPayment(partner.billingSubscriptionStatus)
+            ? 'active'
+            : 'pending';
 
         await tx
           .update(partners)

--- a/apps/api/src/routes/auth/verifyEmail.test.ts
+++ b/apps/api/src/routes/auth/verifyEmail.test.ts
@@ -131,6 +131,7 @@ import {
   invalidateOpenTokens,
 } from '../../services/emailVerification';
 import { consumePendingRegistration } from '../../services/pendingRegistration';
+import { dispatchHook } from '../../services/partnerHooks';
 import { createPartner } from '../../services/partnerCreate';
 import { writeAuthAudit } from './helpers';
 import { getEmailService } from '../../services/email';
@@ -161,6 +162,31 @@ function primeFinalizeSelects(existingUser: unknown[] = []) {
     .mockReturnValueOnce(selectChain([{ id: 'u-1', email: 'new@corp.com', name: 'A', mfaEnabled: false }]) as never)
     .mockReturnValueOnce(selectChain([{ forceMfa: false }]) as never);
   vi.mocked(db.update).mockReturnValue(updateChain() as never);
+}
+
+/**
+ * As `primeFinalizeSelects`, but returns the `set` spy so a test can inspect
+ * what was written. NOTE: `db.update` is mocked with a single shared chain, so
+ * every UPDATE in the finalizer funnels through ONE `set` mock — assert by
+ * searching `set.mock.calls`, never by call index or count. The finalizer always
+ * issues two email-verification stamps (users, then partners) before any
+ * hook-driven write, so "no settings UPDATE" means "no call carrying settings",
+ * not "no calls at all".
+ */
+function primeFinalizeSelectsWithSetSpy(existingUser: unknown[] = []) {
+  vi.mocked(db.select)
+    .mockReturnValueOnce(selectChain(existingUser) as never)
+    .mockReturnValueOnce(selectChain([{ id: 'p-1', name: 'Acme', slug: 'acme', plan: 'free', status: 'pending', settings: {} }]) as never)
+    .mockReturnValueOnce(selectChain([{ id: 'u-1', email: 'new@corp.com', name: 'A', mfaEnabled: false }]) as never)
+    .mockReturnValueOnce(selectChain([{ forceMfa: false }]) as never);
+  const set = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+  vi.mocked(db.update).mockReturnValue({ set } as never);
+  return set;
+}
+
+/** The UPDATE carrying the inactive-screen banner, if one was issued. */
+function findSettingsWrite(set: ReturnType<typeof vi.fn>) {
+  return set.mock.calls.map((c) => c[0] as Record<string, unknown>).find((arg) => 'settings' in arg);
 }
 
 function selectChain(rows: unknown[]) {
@@ -351,6 +377,146 @@ describe('POST /verify-email — SR2-21 pending-registration finalization (step 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ verified: false, status: 'sign_in' });
     expect(vi.mocked(createPartner)).not.toHaveBeenCalled();
+  });
+
+  // Regression cover for the #542 (2026-05-01) fallout: the banner write used to
+  // be nested inside `hookStatus !== rowStatus`, so once hosted partners were
+  // created `pending` — matching what breeze-billing's hook returns — the
+  // "Choose a Plan" CTA stopped being persisted. The inactive screen then fell
+  // back to "Your account is being set up. Please check back shortly." with no
+  // way to pay, for 144 partners across both regions.
+  describe('registration hook banner', () => {
+    const HOSTED_HOOK = {
+      status: 'pending',
+      message: 'Welcome! Choose a plan to get started with Breeze.',
+      actionUrl: 'https://us.2breeze.app/billing/plans',
+      actionLabel: 'Choose a Plan',
+      redirectUrl: '/billing/plans',
+    };
+
+    it('persists the banner when the hook AGREES with the status already created', async () => {
+      vi.mocked(consumePendingRegistration).mockResolvedValueOnce({ ...PENDING_RECORD });
+      const set = primeFinalizeSelectsWithSetSpy([]);
+      vi.mocked(dispatchHook).mockResolvedValueOnce(HOSTED_HOOK as never);
+
+      const res = await postJson('/verify-email', { token: 'raw' });
+      expect(res.status).toBe(200);
+
+      const settingsWrite = findSettingsWrite(set);
+      expect(settingsWrite).toBeDefined();
+      // Status matched, so the UPDATE must NOT try to change it.
+      expect(settingsWrite).not.toHaveProperty('status');
+      expect((await res.json()).partner.status).toBe('pending');
+    });
+
+    it('applies both the banner and the status when the hook overrides status', async () => {
+      vi.mocked(consumePendingRegistration).mockResolvedValueOnce({ ...PENDING_RECORD });
+      const set = primeFinalizeSelectsWithSetSpy([]);
+      vi.mocked(dispatchHook).mockResolvedValueOnce({ ...HOSTED_HOOK, status: 'active' } as never);
+
+      const res = await postJson('/verify-email', { token: 'raw' });
+      expect(res.status).toBe(200);
+
+      const settingsWrite = findSettingsWrite(set);
+      expect(settingsWrite).toBeDefined();
+      expect(settingsWrite!.status).toBe('active');
+      // effectiveStatus must reach the client, not the pre-hook row status.
+      expect((await res.json()).partner.status).toBe('active');
+    });
+
+    it('keeps the banner but ignores an invalid status', async () => {
+      vi.mocked(consumePendingRegistration).mockResolvedValueOnce({ ...PENDING_RECORD });
+      const set = primeFinalizeSelectsWithSetSpy([]);
+      vi.mocked(dispatchHook).mockResolvedValueOnce({ ...HOSTED_HOOK, status: 'bogus' } as never);
+
+      const res = await postJson('/verify-email', { token: 'raw' });
+      expect(res.status).toBe(200);
+
+      const settingsWrite = findSettingsWrite(set);
+      expect(settingsWrite).toBeDefined();
+      expect(settingsWrite).not.toHaveProperty('status');
+      expect((await res.json()).partner.status).toBe('pending');
+    });
+
+    it('drops a javascript: actionUrl but keeps the rest of the banner', async () => {
+      vi.mocked(consumePendingRegistration).mockResolvedValueOnce({ ...PENDING_RECORD });
+      const set = primeFinalizeSelectsWithSetSpy([]);
+      vi.mocked(dispatchHook).mockResolvedValueOnce({
+        ...HOSTED_HOOK,
+        actionUrl: 'javascript:alert(1)',
+      } as never);
+
+      const res = await postJson('/verify-email', { token: 'raw' });
+      expect(res.status).toBe(200);
+
+      const settingsWrite = findSettingsWrite(set);
+      expect(settingsWrite).toBeDefined();
+      const payload = JSON.stringify(settingsWrite!.settings);
+      expect(payload).not.toContain('javascript:');
+      expect(payload).toContain('statusMessage');
+    });
+
+    it.each([
+      ['//evil.com', 'protocol-relative'],
+      ['/\\evil.com', 'backslash normalized to protocol-relative'],
+      ['https://evil.com/x', 'absolute'],
+      ['/billing /plans', 'embedded control character'],
+    ])('drops an unsafe redirectUrl (%s — %s)', async (redirectUrl) => {
+      vi.mocked(consumePendingRegistration).mockResolvedValueOnce({ ...PENDING_RECORD });
+      primeFinalizeSelectsWithSetSpy([]);
+      vi.mocked(dispatchHook).mockResolvedValueOnce({ ...HOSTED_HOOK, redirectUrl } as never);
+
+      const res = await postJson('/verify-email', { token: 'raw' });
+      expect(res.status).toBe(200);
+      expect(await res.json()).not.toHaveProperty('redirectUrl');
+    });
+
+    it('passes through a safe single-slash redirectUrl', async () => {
+      vi.mocked(consumePendingRegistration).mockResolvedValueOnce({ ...PENDING_RECORD });
+      primeFinalizeSelectsWithSetSpy([]);
+      vi.mocked(dispatchHook).mockResolvedValueOnce(HOSTED_HOOK as never);
+
+      const res = await postJson('/verify-email', { token: 'raw' });
+      expect((await res.json()).redirectUrl).toBe('/billing/plans');
+    });
+
+    it('issues no settings write when the hook returns nothing', async () => {
+      vi.mocked(consumePendingRegistration).mockResolvedValueOnce({ ...PENDING_RECORD });
+      const set = primeFinalizeSelectsWithSetSpy([]);
+      vi.mocked(dispatchHook).mockResolvedValueOnce(null as never);
+
+      const res = await postJson('/verify-email', { token: 'raw' });
+      expect(res.status).toBe(200);
+
+      // The two email-verification stamps still happen; nothing carries settings.
+      expect(findSettingsWrite(set)).toBeUndefined();
+      expect(set.mock.calls.length).toBeGreaterThan(0);
+    });
+
+    it('still returns 200 with the pre-hook status when the banner UPDATE throws', async () => {
+      vi.mocked(consumePendingRegistration).mockResolvedValueOnce({ ...PENDING_RECORD });
+      vi.mocked(db.select)
+        .mockReturnValueOnce(selectChain([]) as never)
+        .mockReturnValueOnce(selectChain([{ id: 'p-1', name: 'Acme', slug: 'acme', plan: 'free', status: 'pending', settings: {} }]) as never)
+        .mockReturnValueOnce(selectChain([{ id: 'u-1', email: 'new@corp.com', name: 'A', mfaEnabled: false }]) as never)
+        .mockReturnValueOnce(selectChain([{ forceMfa: false }]) as never);
+      // First two updates (the email stamps) succeed; the hook write rejects.
+      let call = 0;
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockImplementation(() => ({
+          where: vi.fn().mockImplementation(() => {
+            call += 1;
+            return call > 2 ? Promise.reject(new Error('boom')) : Promise.resolve(undefined);
+          }),
+        })),
+      } as never);
+      vi.mocked(dispatchHook).mockResolvedValueOnce({ ...HOSTED_HOOK, status: 'active' } as never);
+
+      const res = await postJson('/verify-email', { token: 'raw' });
+      expect(res.status).toBe(200);
+      // The write failed, so effectiveStatus must NOT advance to 'active'.
+      expect((await res.json()).partner.status).toBe('pending');
+    });
   });
 });
 

--- a/apps/api/src/routes/auth/verifyEmail.ts
+++ b/apps/api/src/routes/auth/verifyEmail.ts
@@ -50,6 +50,36 @@ function sha256Hex(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
+/**
+ * The hook's `actionUrl` is persisted to `partners.settings` and then served to
+ * clients by BOTH `/partner/me` and the `partnerGuard` 403 body, where it is
+ * rendered as a link. The web island guards with its own `isSafeUrl`, but every
+ * other consumer of that 403 (mobile, future clients) does not — so reject
+ * anything that isn't http(s) at the point of storage rather than trusting each
+ * reader. `javascript:` and `data:` are the payloads that matter here.
+ */
+/**
+ * A hook-supplied redirect target is only safe if it is a single-slash relative
+ * path. `//evil.com` passes a naive `startsWith('/')` and is protocol-relative,
+ * and `/\evil.com` is normalized to the same host by some browsers. Control
+ * characters are rejected so this cannot be smuggled into a header later.
+ * Kept in sync with `apps/web/src/lib/authNext.ts::getSafeNext`.
+ */
+function isSafeRelativeRedirect(url: string | undefined): boolean {
+  if (!url || !url.startsWith('/')) return false;
+  if (url.length > 1 && (url[1] === '/' || url[1] === '\\')) return false;
+  return !/[\x00-\x1F\x7F]/.test(url);
+}
+
+function isSafeHookActionUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export const verifyEmailRoutes = new Hono();
 
 const verifyEmailSchema = z.object({
@@ -461,47 +491,84 @@ async function finalizePendingRegistration(
 
     const VALID_STATUSES = ['pending', 'active', 'suspended', 'churned'] as const;
     let effectiveStatus: PartnerStatus = facts.partnerRow.status;
+
+    // The status override and the inactive-screen banner are INDEPENDENT
+    // contributions to one UPDATE. They used to be one nested block, gated on
+    // `hookResponse.status !== partnerRow.status` — which silently dropped the
+    // banner for every hosted signup from 2026-05-01 (#542) onward: that commit
+    // made the API create hosted partners `pending` itself, and breeze-billing's
+    // hook also returns `pending`, so the statuses matched and the branch never
+    // ran. The banner is the ONLY payment presentation on the web login path
+    // (`stores/auth.ts` → /account/inactive → statusActionUrl), so 144 partners
+    // sat on "Your account is being set up. Please check back shortly." with no
+    // way to pay. Keep these two concerns separate.
+    const updateSet: Record<string, unknown> = {};
+
+    const msgSettings: Record<string, string> = {};
+    if (hookResponse?.message) msgSettings.statusMessage = hookResponse.message;
+    if (hookResponse?.actionUrl && isSafeHookActionUrl(hookResponse.actionUrl)) {
+      msgSettings.statusActionUrl = hookResponse.actionUrl;
+    } else if (hookResponse?.actionUrl) {
+      console.error(
+        `[verify-email] Hook returned a non-http(s) actionUrl for partner ${created.partnerId}; dropping it`,
+      );
+    }
+    if (hookResponse?.actionLabel) msgSettings.statusActionLabel = hookResponse.actionLabel;
+    if (Object.keys(msgSettings).length > 0) {
+      updateSet.settings = sql`COALESCE(${partners.settings}, '{}'::jsonb) || ${JSON.stringify(msgSettings)}::jsonb`;
+    }
+
+    let statusChange: PartnerStatus | null = null;
     if (hookResponse?.status && hookResponse.status !== facts.partnerRow.status) {
       if (!VALID_STATUSES.includes(hookResponse.status as never)) {
         console.error(
           `[verify-email] Hook returned invalid status '${hookResponse.status}' for partner ${created.partnerId}; ignoring`,
         );
       } else {
-        try {
-          const updateSet: Record<string, unknown> = { status: hookResponse.status };
-          if (hookResponse.message || hookResponse.actionUrl || hookResponse.actionLabel) {
-            const msgSettings: Record<string, string | null> = {};
-            if (hookResponse.message) msgSettings.statusMessage = hookResponse.message;
-            if (hookResponse.actionUrl) msgSettings.statusActionUrl = hookResponse.actionUrl;
-            if (hookResponse.actionLabel) msgSettings.statusActionLabel = hookResponse.actionLabel;
-            updateSet.settings = sql`COALESCE(${partners.settings}, '{}'::jsonb) || ${JSON.stringify(msgSettings)}::jsonb`;
-          }
-          await withSystemDbAccessContext(() =>
-            db.update(partners).set(updateSet).where(eq(partners.id, created.partnerId)),
-          );
-          effectiveStatus = hookResponse.status as PartnerStatus;
-        } catch (statusErr) {
-          console.error('[verify-email] hook-status update failed', {
-            partnerId: created.partnerId,
-            error: statusErr instanceof Error ? statusErr.message : String(statusErr),
-          });
-          writeAuditEvent(c, {
-            orgId: null,
-            actorType: 'system',
-            action: 'register-partner.hook-status-update-failed',
-            resourceType: 'partner',
-            resourceId: created.partnerId,
-            resourceName: facts.partnerRow.name,
-            details: { fromStatus: facts.partnerRow.status, toStatus: hookResponse.status },
-            result: 'failure',
-            errorMessage: statusErr instanceof Error ? statusErr.message : String(statusErr),
-          });
-        }
+        statusChange = hookResponse.status as PartnerStatus;
+        updateSet.status = statusChange;
       }
     }
 
-    // Only allow relative redirects from hooks (open-redirect guard).
-    const redirectUrl = hookResponse?.redirectUrl?.startsWith('/') ? hookResponse.redirectUrl : undefined;
+    if (Object.keys(updateSet).length > 0) {
+      updateSet.updatedAt = new Date();
+      try {
+        await withSystemDbAccessContext(() =>
+          db.update(partners).set(updateSet).where(eq(partners.id, created.partnerId)),
+        );
+        if (statusChange) effectiveStatus = statusChange;
+      } catch (statusErr) {
+        console.error('[verify-email] hook status/banner update failed', {
+          partnerId: created.partnerId,
+          error: statusErr instanceof Error ? statusErr.message : String(statusErr),
+        });
+        writeAuditEvent(c, {
+          orgId: null,
+          actorType: 'system',
+          action: 'register-partner.hook-status-update-failed',
+          resourceType: 'partner',
+          resourceId: created.partnerId,
+          resourceName: facts.partnerRow.name,
+          details: {
+            fromStatus: facts.partnerRow.status,
+            // null when this UPDATE carried only banner fields — do not imply a
+            // status transition that was never attempted.
+            toStatus: statusChange,
+            bannerKeys: Object.keys(msgSettings),
+          },
+          result: 'failure',
+          errorMessage: statusErr instanceof Error ? statusErr.message : String(statusErr),
+        });
+      }
+    }
+
+    // Only allow same-origin relative redirects from hooks (open-redirect
+    // guard). A bare leading-slash test is NOT sufficient: `//evil.com` is
+    // protocol-relative and navigates off-origin, and browsers normalize
+    // `/\evil.com` into the same thing. Mirrors apps/web's getSafeNext.
+    const redirectUrl = isSafeRelativeRedirect(hookResponse?.redirectUrl)
+      ? hookResponse!.redirectUrl
+      : undefined;
 
     writeAuthAudit(c, {
       action: 'auth.email_verified',

--- a/apps/api/src/services/emailVerification.ts
+++ b/apps/api/src/services/emailVerification.ts
@@ -344,6 +344,7 @@ export async function consumeVerificationToken(rawToken: string): Promise<Consum
           id: partners.id,
           status: partners.status,
           paymentMethodAttachedAt: partners.paymentMethodAttachedAt,
+          billingSubscriptionStatus: partners.billingSubscriptionStatus,
         })
         .from(partners)
         .where(eq(partners.id, row.partnerId))
@@ -360,6 +361,7 @@ export async function consumeVerificationToken(rawToken: string): Promise<Consum
           status: partnerBefore.status,
           emailVerifiedAt: now,
           paymentMethodAttachedAt: partnerBefore.paymentMethodAttachedAt,
+          billingSubscriptionStatus: partnerBefore.billingSubscriptionStatus,
         });
 
       // Always stamp email_verified_at. When both preconditions are met,

--- a/apps/api/src/services/partnerActivation.test.ts
+++ b/apps/api/src/services/partnerActivation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { shouldActivatePendingPartner, activatePartnerRow } from './partnerActivation';
+import {
+  shouldActivatePendingPartner,
+  activatePartnerRow,
+  billingStatusContradictsPayment,
+} from './partnerActivation';
 
 describe('shouldActivatePendingPartner (#718 reconciliation predicate)', () => {
   const verified = new Date('2026-06-13T00:00:00Z');
@@ -77,6 +81,98 @@ describe('shouldActivatePendingPartner (#718 reconciliation predicate)', () => {
         paymentMethodAttachedAt: '2026-06-13T00:05:00Z',
       }),
     ).toBe(true);
+  });
+
+  // The payment stamp was demonstrably writable without a capture (audited
+  // 2026-07-29: 34 of 55 stamped partners had zero successful Stripe charges,
+  // because an `incomplete_expired` subscription.updated backfilled it). These
+  // cases stop the stamp alone from granting access.
+  describe('billing-status veto', () => {
+    it.each(['incomplete', 'incomplete_expired', 'canceled', 'unpaid', 'paused'])(
+      'does NOT activate when the billing mirror reads %s, despite both preconditions',
+      (billingSubscriptionStatus) => {
+        expect(
+          shouldActivatePendingPartner({
+            status: 'pending',
+            emailVerifiedAt: verified,
+            paymentMethodAttachedAt: paid,
+            billingSubscriptionStatus,
+          }),
+        ).toBe(false);
+      },
+    );
+
+    it.each(['active', 'past_due', 'trialing'])(
+      'still activates when the billing mirror reads %s',
+      (billingSubscriptionStatus) => {
+        expect(
+          shouldActivatePendingPartner({
+            status: 'pending',
+            emailVerifiedAt: verified,
+            paymentMethodAttachedAt: paid,
+            billingSubscriptionStatus,
+          }),
+        ).toBe(true);
+      },
+    );
+
+    // This is a VETO, not a REQUIREMENT — and that distinction is the whole
+    // point of #718. A lost `subscription.updated` webhook leaves the mirror
+    // NULL on a partner who really did pay; requiring a good status would
+    // strand them permanently, which is the exact bug #718 exists to fix.
+    it('activates when the mirror is NULL (never populated / webhook lost)', () => {
+      expect(
+        shouldActivatePendingPartner({
+          status: 'pending',
+          emailVerifiedAt: verified,
+          paymentMethodAttachedAt: paid,
+          billingSubscriptionStatus: null,
+        }),
+      ).toBe(true);
+    });
+
+    it('activates when the field is omitted entirely (caller predates the veto)', () => {
+      expect(
+        shouldActivatePendingPartner({
+          status: 'pending',
+          emailVerifiedAt: verified,
+          paymentMethodAttachedAt: paid,
+        }),
+      ).toBe(true);
+    });
+
+    // Fails open on purpose: an unrecognised future Stripe status must not
+    // silently start locking out paying partners.
+    it('activates on an unrecognised status rather than failing closed', () => {
+      expect(
+        shouldActivatePendingPartner({
+          status: 'pending',
+          emailVerifiedAt: verified,
+          paymentMethodAttachedAt: paid,
+          billingSubscriptionStatus: 'some_future_stripe_status',
+        }),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('billingStatusContradictsPayment', () => {
+  it.each(['incomplete', 'incomplete_expired', 'canceled', 'unpaid', 'paused'])(
+    'contradicts a payment stamp for %s',
+    (status) => {
+      expect(billingStatusContradictsPayment(status)).toBe(true);
+    },
+  );
+
+  it.each(['active', 'past_due', 'trialing', 'unknown_status'])(
+    'does not contradict for %s',
+    (status) => {
+      expect(billingStatusContradictsPayment(status)).toBe(false);
+    },
+  );
+
+  it.each([null, undefined])('does not contradict for %s', (status) => {
+    expect(billingStatusContradictsPayment(status)).toBe(false);
   });
 });
 

--- a/apps/api/src/services/partnerActivation.ts
+++ b/apps/api/src/services/partnerActivation.ts
@@ -30,11 +30,30 @@ import { partners } from '../db/schema';
  *   - NEVER activate on time elapsed. There is no "it's been N days, let them
  *     in" branch anywhere. A failed signup payment correctly stays `pending`.
  *   - NEVER activate on email-verified alone. `payment_method_attached_at` is
- *     written only by breeze-billing on a confirmed Stripe capture, so it is
- *     the proof-of-payment gate. Activating without it would comp a non-payer.
+ *     the proof-of-payment gate; activating without it would comp a non-payer.
  *   - ONLY `pending` partners are eligible. `suspended` / `churned` /
  *     soft-deleted partners are never resurrected by reconciliation — that
  *     would undo the abuse-suspension and #568 mid-session cutoff.
+ *   - A non-entitled `billing_subscription_status` VETOES activation even when
+ *     the payment stamp is present. See below for why this exists.
+ *
+ * WHY THE VETO EXISTS: the comment that used to sit here claimed
+ * `payment_method_attached_at` was "written only by breeze-billing on a
+ * confirmed Stripe capture". That was false. breeze-billing's
+ * `customer.subscription.updated` handler backfilled the stamp with no regard
+ * for `subscription.status`, and Stripe expires an unpaid subscription to
+ * `incomplete_expired` ~23h after creation — firing exactly that event. Audited
+ * 2026-07-29: 34 of 55 partners carrying the stamp had ZERO successful Stripe
+ * charges, and several had been auto-upgraded to a 250-device plan having paid
+ * nothing. The writer is fixed, but the stamp is no longer trusted on its own.
+ *
+ * The veto is deliberately a VETO AND NOT A REQUIREMENT. Requiring a good
+ * billing status would defeat #718 in precisely its target failure mode: the
+ * `checkout.session.completed` webhook lands and stamps payment, then the
+ * `customer.subscription.updated` that would have set the status mirror is lost
+ * — a genuine payer stranded `pending` forever. A NULL / unknown mirror
+ * therefore still passes. This also keeps the predicate safe across a deploy
+ * skew where the API ships before breeze-billing starts populating the mirror.
  *
  * Self-hosted (`IS_HOSTED=false`) partners are created `active` directly by
  * `register-partner`, so they never enter the `pending` state and this
@@ -47,15 +66,61 @@ export interface ReconcilablePartner {
   emailVerifiedAt: Date | string | null;
   paymentMethodAttachedAt: Date | string | null;
   deletedAt?: Date | string | null;
+  /**
+   * Mirror of the raw Stripe subscription status, written by breeze-billing's
+   * `syncSubscriptionStatus`. Optional so existing callers that cannot supply
+   * it keep compiling — but a caller that omits it forfeits the veto, so pass
+   * it wherever the column is available.
+   */
+  billingSubscriptionStatus?: string | null;
+}
+
+/**
+ * Stripe subscription statuses that positively contradict a payment stamp. A
+ * partner whose mirror reads one of these has a subscription that never
+ * captured (or has terminated), so the stamp cannot be trusted regardless of
+ * how it got written.
+ *
+ * Mirrors breeze-billing's `PAYMENT_PROVEN_STATUSES` inversion. `past_due` is
+ * absent (it follows a real capture) and so is `trialing`. Kept as a denylist
+ * rather than an allowlist so an unrecognised future Stripe status fails OPEN
+ * — see the veto-not-requirement rationale in the header.
+ */
+const BILLING_STATUS_VETO = new Set<string>([
+  'incomplete',
+  'incomplete_expired',
+  'canceled',
+  'unpaid',
+  'paused',
+]);
+
+/**
+ * True when the billing mirror positively contradicts a payment stamp, so any
+ * path about to grant access on the strength of that stamp must not.
+ *
+ * Exported because the admin unsuspend path (`routes/admin/abuse.ts`) makes the
+ * same active-vs-pending decision from the same stamp, but cannot reuse
+ * `shouldActivatePendingPartner` — its partner is `suspended`, not `pending`.
+ * A false stamp there is worse than elsewhere: it turns an admin's unsuspend
+ * into a straight-to-active with no payment.
+ */
+export function billingStatusContradictsPayment(
+  billingSubscriptionStatus: string | null | undefined,
+): boolean {
+  return billingSubscriptionStatus != null && BILLING_STATUS_VETO.has(billingSubscriptionStatus);
 }
 
 /**
  * True iff a `pending` partner has independently met BOTH activation
- * preconditions and should be flipped to `active`. Pure — no I/O — so it is
- * trivially testable and reusable from any read path.
+ * preconditions, with no contradicting billing status, and should be flipped to
+ * `active`. Pure — no I/O — so it is trivially testable and reusable from any
+ * read path.
  */
 export function shouldActivatePendingPartner(partner: ReconcilablePartner): boolean {
   if (partner.deletedAt != null) return false;
+  if (billingStatusContradictsPayment(partner.billingSubscriptionStatus)) {
+    return false;
+  }
   return (
     partner.status === 'pending' &&
     partner.emailVerifiedAt != null &&

--- a/apps/web/src/components/auth/VerifyEmailPage.tsx
+++ b/apps/web/src/components/auth/VerifyEmailPage.tsx
@@ -58,7 +58,12 @@ export default function VerifyEmailPage() {
         if (result.user && result.tokens) {
           login(result.user, result.tokens);
           setState({ phase: 'registered' });
-          await navigateTo('/');
+          // A hosted signup is created `pending` and cannot use the dashboard
+          // until it pays, so honour the hook's redirect (/billing/plans) when
+          // there is one. Hard-navigating to '/' instead meant a fresh signup
+          // took an immediate 403 PARTNER_INACTIVE and bounced to the
+          // "account is being set up" screen — with no way to pay.
+          await navigateTo(result.redirectUrl ?? '/');
           return;
         }
         setState({ phase: 'success', autoActivated: !!result.autoActivated });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -9,6 +9,7 @@ import {
   type RegistrationResponseJSON
 } from '@simplewebauthn/browser';
 import { extractApiError } from '@/lib/apiError';
+import { getSafeNext } from '@/lib/authNext';
 import {
   applyAppearancePreferences,
   applyResolvedLocalePreferences,
@@ -984,6 +985,7 @@ export async function apiVerifyEmail(token: string): Promise<{
   user?: User;
   tokens?: Tokens;
   status?: 'sign_in';
+  redirectUrl?: string;
 }> {
   try {
     const response = await fetch(buildApiUrl('/auth/verify-email'), {
@@ -1011,6 +1013,17 @@ export async function apiVerifyEmail(token: string): Promise<{
       autoActivated: data.autoActivated,
       user: data.user,
       tokens: data.tokens,
+      // Where the post-registration hook wants a still-inactive partner to go
+      // (hosted: /billing/plans). Runs through the shared open-redirect guard
+      // rather than a bare `startsWith('/')`, which would admit the
+      // protocol-relative `//evil.com` and the `/\evil.com` form some browsers
+      // normalize to it. `navigateTo` re-applies getSafeNext at the sink, so
+      // this is defence in depth — but the value this function RETURNS must
+      // already be safe, or a future caller that navigates directly inherits a
+      // hole from a field that looks validated.
+      redirectUrl: typeof data.redirectUrl === 'string'
+        ? getSafeNext(data.redirectUrl, '') || undefined
+        : undefined,
     };
   } catch {
     return { success: false, error: 'Network error' };


### PR DESCRIPTION
## Summary

A partner reported setting up an MSP account three days earlier and still seeing *"Your account is being set up. Please check back shortly."* Investigating it surfaced two independent production defects.

**Blocked partners: 70 pending on US + 74 on EU = 144, of which 47 had logged in within 14 days.** They were being shown a message that implies no action is required, with only a Sign Out button and no way to pay.

## ⚠️ Merge order: LanternOps/breeze-billing#10 must deploy FIRST

This is a correctness constraint. This PR restores the "Choose a Plan" CTA. Doing that **before** the billing fix is deployed in a region would *grow* the second bug's exposure: it drives up to 144 stranded partners into checkout, and every abandoned checkout mints an `incomplete` Stripe subscription whose `incomplete_expired` event writes a false payment stamp ~23h later. Those partners already have verified emails, so `partnerGuard` would auto-activate them onto a paid tier on their next login, with no admin in the loop.

Per region: **breeze-billing#10 → stamp backfill → this PR.**

## Bug 1 — the payment CTA (regression from #542, 2026-05-01)

The registration hook was healthy the whole time and returned exactly the right payload:

```json
{"status":"pending","message":"Welcome! Choose a plan to get started with Breeze.",
 "actionUrl":"https://us.2breeze.app/billing/plans","actionLabel":"Choose a Plan",
 "redirectUrl":"/billing/plans"}
```

but the banner write was nested inside `hookStatus !== rowStatus`. #542 added `status: isHosted() ? 'pending' : 'active'` to the registration path without touching that branch, so the API began creating hosted partners `pending` — matching what the hook returns — and the CTA silently stopped being persisted. The block's own comment (*"If hook overrides the partner status (e.g. to 'pending')"*) shows it was written for the prior world where the API created `active`. #2507 later moved it verbatim into `verifyEmail.ts`, carrying the bug forward.

Prod confirms the date: the last partner with a `statusActionUrl` was created **2026-05-06 (US) / 2026-05-05 (EU)**.

The banner and the status override are now independent contributions to one UPDATE.

Separately, the redirect that was supposed to avoid this screen entirely was dead: `apiVerifyEmail` never returned the server's `redirectUrl` and `VerifyEmailPage` hard-navigated to `/`, so a fresh hosted signup took an immediate 403 `PARTNER_INACTIVE` and bounced to the dead-end screen instead of landing on `/billing/plans`. That means the screen was hit *immediately after verifying*, not only on return visits.

## Bug 2 — `payment_method_attached_at` was not proof of payment

Both `partnerActivation.ts` and `partnerGuard.ts` asserted in comments that the timestamp *"is written only by breeze-billing on a confirmed Stripe capture"*. It wasn't — see breeze-billing#10 for the writer. **Audited against live Stripe: 34 of 55 partners carrying the stamp had zero successful charges.** No currently-active partner got in this way, so no revenue leaked.

`shouldActivatePendingPartner` now vetoes activation when the mirrored `billing_subscription_status` contradicts the stamp.

**Deliberately a veto and not a requirement.** Requiring a good billing status would defeat #718 in precisely its target failure mode: `checkout.session.completed` lands and stamps payment, then the `subscription.updated` that would set the mirror is lost, stranding a genuine payer `pending` forever. NULL/unknown therefore still passes — which also keeps the predicate safe across a deploy skew where this ships before breeze-billing populates the mirror.

Wired into all three readers, including **`routes/admin/abuse.ts` unsuspend**, which makes the same active-vs-pending call from the same stamp and can't use the shared predicate because its partner is `suspended`. That's the worst place for a false stamp: a card-testing partner typically carries `incomplete_expired`, so before the veto an admin's unsuspend sent it straight back to `active`.

**This does not disarm the rows already carrying a false stamp** — the mirror is NULL on all of them and the veto lets NULL pass by design. That needs the data backfill, which runs after breeze-billing#10 deploys.

## Hardening

- `actionUrl` is validated http(s) **server-side** before storage. It's served by both `/partner/me` and the `partnerGuard` 403 body; the web island guards with `isSafeUrl`, but other consumers of that 403 don't.
- The `redirectUrl` open-redirect guard was a bare `startsWith('/')`, which admits protocol-relative `//evil.com` and the `/\evil.com` form browsers normalize to it. **Not exploitable** — `navigateTo` already routes every path through `getSafeNext` — but the check was cosmetic while reading as complete. Web now reuses `getSafeNext` rather than hand-rolling one; the API has a mirrored `isSafeRelativeRedirect`.

## Test plan

- [x] `tsc --noEmit` clean; `astro check` 0 errors / 0 warnings; eslint clean incl. `--report-unused-disable-directives`
- [x] Affected API files single-fork: 129/129
- [x] Full API suite: **1212 files / 18,608 tests passed, 0 failures** (the 2 `streamingUpload` unhandled errors reproduce in isolation on untouched code and are pre-existing)
- [x] Web auth components + `no-silent-mutations`: 146/146
- [x] New coverage: banner persists when hook status *equals* current status (the regression); banner + status override together; banner survives an invalid status; `javascript:` actionUrl dropped; no settings write when the hook returns nothing; UPDATE failure still returns 200 without advancing `effectiveStatus`; 5 redirect-guard cases; billing-status veto across all statuses plus NULL/omitted/unknown passing
- [x] TDD verified by reverting each guard and confirming the new tests fail (4 for the banner, 3 for the veto)

## Not covered, still open

- MCP-origin hosted signups never get a banner at all — `dispatchHook('registration')` only fires from this route.
- Admin unsuspend sets status `pending` without a banner, so that cohort re-enters the dead-end.
- The prod data backfill (false stamps + banner for the existing 144).
- Unrelated: `pnpm install --frozen-lockfile` is broken on the pinned Node. `.nvmrc` says 22.20.0 but `jsdom@30.0.1` (#2906, current main) requires `^22.22.2 || ^24.15.0 || >=26.0.0`. Verified here on Node 24.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
