### PR TITLE
feat(m365): comms plan 1 — intent binding + runtime config (tasks 6-7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,6 +183,17 @@ M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_KID=
 # docs/deploy/m365-customer-graph-actions-executor.md for the full executor env.
 M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE=
 
+# M365 communications-delegated (per-USER axis; dark by default)
+M365_COMMS_ONBOARDING_ENABLED=false
+M365_COMMS_ONBOARDING_USER_IDS=
+M365_COMMS_TOOLS_ENABLED=false
+M365_COMMS_TOOLS_USER_IDS=
+M365_COMMS_CLIENT_ID=
+M365_COMMS_EXECUTOR_URL=https://comms-executor.internal/
+M365_COMMS_EXECUTOR_AUDIENCE=m365-communications-executor
+M365_COMMS_EXECUTOR_SIGNING_KID=
+M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE=/run/secrets/m365-comms-executor-signing.jwk
+
 # --------------------------------------------
 # Server Configuration
 # --------------------------------------------

--- a/apps/api/src/__tests__/integration/actionIntentBinding.integration.test.ts
+++ b/apps/api/src/__tests__/integration/actionIntentBinding.integration.test.ts
@@ -1,0 +1,61 @@
+import './setup';
+import { randomUUID } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withSystemDbAccessContext } from '../../db';
+import { actionIntents } from '../../db/schema';
+import { createOrganization, createPartner, createUser } from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+const connectionId = '11111111-1111-4111-8111-111111111111';
+const tenantId = '22222222-2222-4222-8222-222222222222';
+
+describe('action_intents binding columns', () => {
+  runDb('accepts a bound intent and refuses to let either column be mutated', async () => {
+    const fx = await withSystemDbAccessContext(async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const user = await createUser({
+        partnerId: partner.id, orgId: org.id,
+        email: `binding-${Date.now()}@example.com`,
+      });
+      return { org, user };
+    });
+
+    const [row] = await withSystemDbAccessContext(() => db.insert(actionIntents).values({
+      orgId: fx.org.id,
+      requestedByUserId: fx.user.id,
+      originPrincipalKind: 'user_session',
+      source: 'chat',
+      actionName: 'm365_send_mail',
+      arguments: { to: ['a@example.com'], subject: 's', bodyText: 'b' },
+      argumentDigest: 'a'.repeat(64),
+      targetSummary: 'm365_send_mail(to=a@example.com)',
+      impactSummary: 'Send an email',
+      idempotencyKey: `binding-${Date.now()}`,
+      correlationId: randomUUID(),
+      riskTier: 3,
+      connectionId,
+      tenantId,
+      expiresAt: new Date(Date.now() + 3_600_000),
+    }).returning({ id: actionIntents.id }));
+
+    // The immutability trigger already covers both columns
+    // (2026-07-18-action-intents.sql:109-110) — assert it, do not assume it.
+    await expect(withSystemDbAccessContext(() => db.update(actionIntents)
+      .set({ connectionId: '33333333-3333-4333-8333-333333333333' })
+      .where(eq(actionIntents.id, row!.id))))
+      .rejects.toThrow();
+
+    await expect(withSystemDbAccessContext(() => db.update(actionIntents)
+      .set({ tenantId: '44444444-4444-4444-8444-444444444444' })
+      .where(eq(actionIntents.id, row!.id))))
+      .rejects.toThrow();
+
+    const [after] = await withSystemDbAccessContext(() => db.select({
+      connectionId: actionIntents.connectionId,
+      tenantId: actionIntents.tenantId,
+    }).from(actionIntents).where(eq(actionIntents.id, row!.id)));
+    expect(after).toEqual({ connectionId, tenantId });
+  });
+});

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -261,6 +261,53 @@ describe('validateConfig', () => {
     });
   });
 
+  describe('M365 communications-delegated (comms) boot validation', () => {
+    it('fails boot when comms onboarding is enabled without a client id', () => {
+      withEnv({
+        ...validEnv,
+        M365_COMMS_ONBOARDING_ENABLED: 'true',
+        M365_COMMS_CLIENT_ID: '',
+      }, () => {
+        expect(() => validateConfig()).toThrow(/M365_COMMS_CLIENT_ID is required/);
+      });
+    });
+
+    it('fails boot when comms tools are enabled without a user allowlist', () => {
+      // The loader never reads the tools allowlist (it's on the hot
+      // tool-registration path), so the boot validator must check it
+      // explicitly — this proves the call site in validate.ts is wired.
+      const dir = mkdtempSync(join(tmpdir(), 'breeze-m365-comms-boot-'));
+      const signingJwkFile = join(dir, 'signing.jwk');
+      writeFileSync(signingJwkFile, JSON.stringify({
+        kty: 'OKP',
+        crv: 'Ed25519',
+        alg: 'EdDSA',
+        use: 'sig',
+        kid: 'comms-kid-1',
+        x: Buffer.alloc(32, 1).toString('base64url'),
+        d: Buffer.alloc(32, 2).toString('base64url'),
+      }), { mode: 0o600 });
+      chmodSync(signingJwkFile, 0o600);
+
+      try {
+        withEnv({
+          ...validEnv,
+          M365_COMMS_TOOLS_ENABLED: 'true',
+          M365_COMMS_CLIENT_ID: '33333333-3333-4333-8333-333333333333',
+          M365_COMMS_EXECUTOR_URL: 'https://comms-executor.internal.example.test',
+          M365_COMMS_EXECUTOR_AUDIENCE: 'm365-communications-executor',
+          M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE: signingJwkFile,
+          M365_COMMS_EXECUTOR_SIGNING_KID: 'comms-kid-1',
+          PUBLIC_URL: 'https://console.example.test',
+        }, () => {
+          expect(() => validateConfig()).toThrow(/M365_COMMS_TOOLS_USER_IDS/);
+        });
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
   it('rejects production with only the administrator DATABASE_URL', () => {
     withEnv({
       ...validEnv,

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -2,6 +2,7 @@ import { isIP } from 'net';
 import { z } from 'zod';
 import { validateM365CustomerGraphReadRuntimeConfigAtBoot } from '../services/m365ControlPlane/runtimeConfig';
 import { validateM365CustomerGraphActionsRuntimeConfigAtBoot } from '../services/m365ControlPlane/writeActionRuntimeConfig';
+import { validateM365CommunicationsRuntimeConfigAtBoot } from '../services/m365ControlPlane/commsRuntimeConfig';
 import {
   decodePartnerApiCursorSigningKey,
   isRecognizedSelfHostSignal,
@@ -1760,6 +1761,12 @@ export function validateConfig(): AppConfig {
   // (customer-graph-actions): parsed lazily, but validated eagerly at boot
   // when the write-action tools rollout is enabled.
   validateM365CustomerGraphActionsRuntimeConfigAtBoot(env);
+
+  // Same again for the communications-delegated descriptor (per-USER axis).
+  // Deliberately NOT paired with an APP_ENCRYPTION_KEY_ID assertion: comms has
+  // no reveal path and no API-side sealing — the token cache is the
+  // executor's, wrapped under a KEK the API's identity cannot get (§3.2).
+  validateM365CommunicationsRuntimeConfigAtBoot(env);
 
   // APP_ENCRYPTION_KEY_ID is required once Graph write-action tools are enabled:
   // the reset-password reveal seals its temp credential with AAD-bound v3 ciphertext

--- a/apps/api/src/jobs/intentReleaseWorker.test.ts
+++ b/apps/api/src/jobs/intentReleaseWorker.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { canonicalizeArguments, computeArgumentDigest } from '@breeze/shared/canonicalize';
 
 // ---------------------------------------------------------------------------
 // Hoisted shared mock state
@@ -170,6 +171,9 @@ import { M365ConnectionUnavailableError } from '../services/m365ToolsHeadless';
 // the invariant the worker relies on without inventing a parallel harness.
 import { assertNoPlaintextSecret, type SecretToolResult } from '../services/actionIntents/secretBearingTools';
 
+const RUN_SCRIPT_ARGS = { scriptId: 'abc' };
+const RUN_SCRIPT_DIGEST = computeArgumentDigest(canonicalizeArguments(RUN_SCRIPT_ARGS));
+
 function baseIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
   return {
     id: 'intent-1',
@@ -181,8 +185,12 @@ function baseIntent(overrides: Partial<ActionIntent> = {}): ActionIntent {
     requestingClientLabel: null,
     actionName: 'run_script',
     actionVersion: 1,
-    arguments: { scriptId: 'abc' },
-    argumentDigest: 'digest-1',
+    arguments: RUN_SCRIPT_ARGS,
+    // Must be the REAL canonical digest: revalidateApprovedIntentForRelease
+    // recomputes it from `arguments` and refuses with digest_mismatch when the
+    // two disagree (design §5.2). A placeholder string passes the stored-string
+    // comparison but not the recompute.
+    argumentDigest: RUN_SCRIPT_DIGEST,
     targetSummary: 'run_script(scriptId=abc)',
     impactSummary: 'Runs a script',
     reason: null,

--- a/apps/api/src/services/actionIntents/intentService.test.ts
+++ b/apps/api/src/services/actionIntents/intentService.test.ts
@@ -376,6 +376,56 @@ describe('createActionIntent — digest stability', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Connection binding (M365 comms — design §5.2 sender pinning)
+// ---------------------------------------------------------------------------
+
+describe('createActionIntent binding', () => {
+  it('persists connectionId and tenantId when binding is supplied', async () => {
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([]);
+    dbState.insertActionIntentsResults.push([makeIntentRow({ id: 'intent-bind', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
+    dbState.updateActionIntentsResults.push([makeIntentRow({ id: 'intent-bind', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
+    await createActionIntent(makeAuth(), baseInput({
+      toolName: 'm365_send_mail',
+      input: { to: ['a@example.com'], subject: 's', bodyText: 'b' },
+      binding: {
+        connectionId: '11111111-1111-4111-8111-111111111111',
+        tenantId: '22222222-2222-4222-8222-222222222222',
+      },
+    }));
+    const captured = dbState.insertedActionIntentValues[0];
+    expect(captured?.connectionId).toBe('11111111-1111-4111-8111-111111111111');
+    expect(captured?.tenantId).toBe('22222222-2222-4222-8222-222222222222');
+  });
+
+  it('leaves both columns null when binding is omitted', async () => {
+    intentApproversState.resolveIntentApprovers.mockResolvedValueOnce([]);
+    dbState.insertActionIntentsResults.push([makeIntentRow({ id: 'intent-nobind', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
+    dbState.updateActionIntentsResults.push([makeIntentRow({ id: 'intent-nobind', status: 'cancelled', errorCode: 'no_eligible_approvers' })]);
+    await createActionIntent(makeAuth(), baseInput({
+      toolName: 'execute_command',
+      input: { command: 'whoami' },
+    }));
+    const captured = dbState.insertedActionIntentValues[0];
+    expect(captured?.connectionId).toBeNull();
+    expect(captured?.tenantId).toBeNull();
+  });
+
+  it('rejects a non-canonical tenantId before it reaches the uuid column', async () => {
+    // action_intents.tenant_id is a Postgres `uuid`; an uppercase or malformed
+    // GUID raises 22P02 at INSERT. Fail in the service with a typed error.
+    await expect(createActionIntent(makeAuth(), baseInput({
+      toolName: 'm365_send_mail',
+      input: { to: ['a@example.com'], subject: 's', bodyText: 'b' },
+      binding: {
+        connectionId: '11111111-1111-4111-8111-111111111111',
+        tenantId: 'AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA',
+      },
+    }))).rejects.toThrow(/binding\.tenantId must be a canonical lowercase UUID/);
+    expect(dbState.insertedActionIntentValues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Idempotency
 // ---------------------------------------------------------------------------
 

--- a/apps/api/src/services/actionIntents/intentService.ts
+++ b/apps/api/src/services/actionIntents/intentService.ts
@@ -72,6 +72,14 @@ export interface CreateActionIntentInput {
   idempotencyKey?: string;
   /** Resolved via resolveWritableToolOrgId when absent. */
   orgId?: string;
+  /**
+   * Pins the intent to the M365 connection whose credential will perform the
+   * effect (design §5.2). Populates the already-immutable
+   * `action_intents.connection_id` / `tenant_id` columns, which the release
+   * path compares against the freshly-loaded connection on all four binding
+   * fields. Absent for every non-comms tool, which is why it is optional.
+   */
+  binding?: { connectionId: string; tenantId: string };
 }
 
 export type ActionIntentSnapshot = {
@@ -116,6 +124,10 @@ const CHAT_EXPIRY_MS = 5 * 60 * 1000;
 const MCP_EXPIRY_MS = 24 * 60 * 60 * 1000;
 
 const MAX_ARG_VALUE_LEN = 80;
+
+/** Canonical lowercase UUID — the only form the Postgres `uuid` binding
+ * columns may receive (design §5.2; an uppercase GUID would 22P02 at INSERT). */
+const CANONICAL_UUID_LOWER = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 // ---------------------------------------------------------------------------
 // Summary / digest helpers
@@ -222,6 +234,18 @@ export async function createActionIntent(
   const orgId = resolvedOrg.orgId;
   const requesterId = auth.user.id;
 
+  if (input.binding) {
+    // Both columns are Postgres `uuid`. An uppercase or malformed GUID would
+    // raise 22P02 at INSERT, surfacing as a 500 rather than a validation
+    // error, so reject it here.
+    if (!CANONICAL_UUID_LOWER.test(input.binding.connectionId)) {
+      throw new ActionIntentError('binding.connectionId must be a canonical lowercase UUID', 'invalid_binding');
+    }
+    if (!CANONICAL_UUID_LOWER.test(input.binding.tenantId)) {
+      throw new ActionIntentError('binding.tenantId must be a canonical lowercase UUID', 'invalid_binding');
+    }
+  }
+
   const canonical = canonicalizeArguments(input.input);
   const argumentDigest = computeArgumentDigest(canonical);
   const idempotencyKey = input.idempotencyKey ?? deriveIdempotencyKey(requesterId, input.toolName, argumentDigest);
@@ -307,6 +331,8 @@ export async function createActionIntent(
               : auth.principal.kind === 'oauth_grant'
                 ? auth.principal.grantId ?? null
                 : null,
+          connectionId: input.binding?.connectionId ?? null,
+          tenantId: input.binding?.tenantId ?? null,
           source: input.source,
           requestingClientLabel,
           actionName: input.toolName,

--- a/apps/api/src/services/actionIntents/revalidateRelease.test.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { canonicalizeArguments, computeArgumentDigest } from '@breeze/shared/canonicalize';
+
+vi.mock('../aiTools', () => ({ getToolTier: vi.fn(() => 3) }));
+vi.mock('../aiGuardrails', () => ({ checkToolPermission: vi.fn(() => ({ allowed: true })) }));
+vi.mock('../tenantStatus', () => ({ getActiveOrgTenant: vi.fn(async () => ({ status: 'active' })) }));
+vi.mock('./actorContext', () => ({
+  buildAuthContextForIntent: vi.fn(async () => ({
+    scope: 'organization', orgId: 'org-1', accessibleOrgIds: ['org-1'],
+    user: { id: 'user-1' }, principal: { kind: 'user_session' },
+  })),
+}));
+
+import { revalidateApprovedIntentForRelease } from './revalidateRelease';
+
+/** Minimal ActionIntent shape the function actually reads. */
+function intentFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'intent-1',
+    orgId: 'org-1',
+    requestedByUserId: 'user-1',
+    originPrincipalKind: 'user_session',
+    source: 'chat',
+    actionName: 'm365_send_mail',
+    arguments: {},
+    argumentDigest: 'a'.repeat(64),
+    riskTier: 3,
+    ...overrides,
+  } as never;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('revalidateApprovedIntentForRelease digest recompute', () => {
+  it('refuses with digest_mismatch when arguments do not hash to argumentDigest', async () => {
+    // Simulates a write that bypassed the immutability trigger (superuser,
+    // disabled trigger, restore-from-backup). Same error code as the existing
+    // stored-string comparison — no new taxonomy.
+    const args = { to: ['a@example.com'], subject: 's', bodyText: 'b' };
+    const intent = intentFixture({
+      arguments: args,
+      argumentDigest: 'f'.repeat(64),      // deliberately NOT the real digest
+    });
+    const result = await revalidateApprovedIntentForRelease(
+      intent,
+      { boundArgumentDigest: 'f'.repeat(64) },   // approval agrees with the stored digest
+    );
+    expect(result).toEqual({ ok: false, errorCode: 'digest_mismatch' });
+  });
+
+  it('passes the recompute when arguments hash to argumentDigest', async () => {
+    const args = { to: ['a@example.com'], subject: 's', bodyText: 'b' };
+    const digest = computeArgumentDigest(canonicalizeArguments(args));
+    const intent = intentFixture({ arguments: args, argumentDigest: digest });
+    const result = await revalidateApprovedIntentForRelease(
+      intent,
+      { boundArgumentDigest: digest },
+    );
+    // Later checks (tier, actor) are exercised by this file's other tests;
+    // assert only that we did not fail on the digest.
+    if (result.ok === false) expect(result.errorCode).not.toBe('digest_mismatch');
+  });
+});

--- a/apps/api/src/services/actionIntents/revalidateRelease.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.ts
@@ -4,6 +4,7 @@ import { getToolTier } from '../aiTools';
 import { checkToolPermission } from '../aiGuardrails';
 import { getActiveOrgTenant } from '../tenantStatus';
 import { buildAuthContextForIntent } from './actorContext';
+import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
 
 /**
  * Shared release-time revalidation for an approved action intent (spec
@@ -41,6 +42,19 @@ export async function revalidateApprovedIntentForRelease(
   // SAME content the intent currently carries (action_intents content is
   // DB-immutable; this is defense-in-depth).
   if (!winningApproval || winningApproval.boundArgumentDigest !== intent.argumentDigest) {
+    return { ok: false, errorCode: 'digest_mismatch' };
+  }
+  // (a2) Recompute the digest FROM the stored arguments. The comparison above
+  // is two stored strings; it cannot detect a write that changed `arguments`
+  // while leaving `argument_digest` alone. The immutability trigger makes that
+  // unreachable through the app, so this is defense-in-depth against a path
+  // that bypassed it (superuser, disabled trigger, restore). Deliberately
+  // compares against the STORED digest — the value the approval bound — never
+  // a fresh computation used as its own authority (§5.2).
+  const recomputed = computeArgumentDigest(
+    canonicalizeArguments(intent.arguments as Record<string, unknown>),
+  );
+  if (recomputed !== intent.argumentDigest) {
     return { ok: false, errorCode: 'digest_mismatch' };
   }
 

--- a/apps/api/src/services/m365ControlPlane/commsRuntimeConfig.test.ts
+++ b/apps/api/src/services/m365ControlPlane/commsRuntimeConfig.test.ts
@@ -1,0 +1,154 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  loadM365CommsRuntimeConfig,
+  isM365CommsOnboardingEnabledForUser,
+  isM365CommsToolsEnabledForUser,
+  validateM365CommunicationsRuntimeConfigAtBoot,
+} from './commsRuntimeConfig';
+
+const USER_A = '11111111-1111-4111-8111-111111111111';
+const USER_B = '22222222-2222-4222-8222-222222222222';
+
+let tempDir: string;
+let jwkCounter = 0;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'breeze-m365-comms-runtime-'));
+  jwkCounter = 0;
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function validPrivateJwk(kid: string) {
+  return {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    alg: 'EdDSA',
+    use: 'sig',
+    kid,
+    x: Buffer.alloc(32, 1).toString('base64url'),
+    d: Buffer.alloc(32, 2).toString('base64url'),
+  };
+}
+
+/** Mirrors writeActionRuntimeConfig.test.ts's JWK fixture: a temp file with
+ * mode 0600 (or the given mode) containing an Ed25519 private JWK. Returns
+ * the absolute path. */
+function writeJwkFixture(kid: string, mode = 0o600): string {
+  const file = join(tempDir, `comms-signing-${jwkCounter++}.jwk`);
+  writeFileSync(file, JSON.stringify(validPrivateJwk(kid)), { mode: 0o600 });
+  chmodSync(file, mode);
+  return file;
+}
+
+function baseEnv(jwkFile: string) {
+  return {
+    NODE_ENV: 'test',
+    PUBLIC_URL: 'https://app.example.com',
+    M365_COMMS_CLIENT_ID: '33333333-3333-4333-8333-333333333333',
+    M365_COMMS_EXECUTOR_URL: 'https://comms-executor.internal/',
+    M365_COMMS_EXECUTOR_AUDIENCE: 'm365-communications-executor',
+    M365_COMMS_EXECUTOR_SIGNING_KID: 'comms-kid-1',
+    M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE: jwkFile,
+    M365_COMMS_ONBOARDING_ENABLED: 'true',
+    M365_COMMS_ONBOARDING_USER_IDS: `${USER_A},${USER_B}`,
+  } as Record<string, string>;
+}
+
+describe('loadM365CommsRuntimeConfig', () => {
+  it('loads a valid config with a USER allowlist', () => {
+    const env = baseEnv(writeJwkFixture('comms-kid-1'));
+    const cfg = loadM365CommsRuntimeConfig(env);
+    expect(cfg.onboardingUserIds).toEqual([USER_A, USER_B]);
+    expect(cfg.executorAudience).toBe('m365-communications-executor');
+  });
+
+  it('accepts the wildcard allowlist', () => {
+    const env = { ...baseEnv(writeJwkFixture('comms-kid-1')), M365_COMMS_ONBOARDING_USER_IDS: '*' };
+    expect(loadM365CommsRuntimeConfig(env).onboardingUserIds).toBe('*');
+  });
+
+  it('rejects a wrong audience', () => {
+    const env = { ...baseEnv(writeJwkFixture('comms-kid-1')), M365_COMMS_EXECUTOR_AUDIENCE: 'm365-graph-actions-executor' };
+    expect(() => loadM365CommsRuntimeConfig(env)).toThrow(/must equal m365-communications-executor/);
+  });
+
+  it('rejects a non-UUID in the allowlist rather than silently dropping it', () => {
+    const env = { ...baseEnv(writeJwkFixture('comms-kid-1')), M365_COMMS_ONBOARDING_USER_IDS: `${USER_A},not-a-uuid` };
+    expect(() => loadM365CommsRuntimeConfig(env)).toThrow(/M365_COMMS_ONBOARDING_USER_IDS/);
+  });
+
+  it('rejects a JWK file readable by group or other', () => {
+    const env = baseEnv(writeJwkFixture('comms-kid-1', 0o644));
+    expect(() => loadM365CommsRuntimeConfig(env)).toThrow(/permissions must deny group and other access/);
+  });
+
+  it('rejects a JWK whose kid does not match the configured kid', () => {
+    const env = baseEnv(writeJwkFixture('some-other-kid'));
+    expect(() => loadM365CommsRuntimeConfig(env)).toThrow(/M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE/);
+  });
+
+  it('requires no vault vars — the API never touches the comms vault', () => {
+    const env = baseEnv(writeJwkFixture('comms-kid-1'));
+    expect(() => loadM365CommsRuntimeConfig(env)).not.toThrow();
+    expect(Object.keys(env).some((k) => k.includes('VAULT'))).toBe(false);
+  });
+});
+
+describe('per-user gates', () => {
+  it('onboarding gate is false when the flag is off, regardless of allowlist', () => {
+    const env = { ...baseEnv(writeJwkFixture('comms-kid-1')), M365_COMMS_ONBOARDING_ENABLED: 'false' };
+    expect(isM365CommsOnboardingEnabledForUser(USER_A, env)).toBe(false);
+  });
+
+  it('onboarding gate admits an allowlisted user and refuses a non-listed one', () => {
+    const env = baseEnv(writeJwkFixture('comms-kid-1'));
+    expect(isM365CommsOnboardingEnabledForUser(USER_A, env)).toBe(true);
+    expect(isM365CommsOnboardingEnabledForUser('99999999-9999-4999-8999-999999999999', env)).toBe(false);
+  });
+
+  it('tools gate does NOT require the executor envs (hot registration path)', () => {
+    // Only the flag + the tools allowlist. Calling the full loader here would
+    // make every tool registration depend on executor config being present.
+    const env = {
+      NODE_ENV: 'test',
+      M365_COMMS_TOOLS_ENABLED: 'true',
+      M365_COMMS_TOOLS_USER_IDS: USER_A,
+    } as Record<string, string>;
+    expect(isM365CommsToolsEnabledForUser(USER_A, env)).toBe(true);
+    expect(isM365CommsToolsEnabledForUser(USER_B, env)).toBe(false);
+  });
+
+  it('both gates refuse a malformed user id', () => {
+    const env = baseEnv(writeJwkFixture('comms-kid-1'));
+    expect(isM365CommsOnboardingEnabledForUser('not-a-uuid', env)).toBe(false);
+  });
+});
+
+describe('validateM365CommunicationsRuntimeConfigAtBoot', () => {
+  it('is a no-op when both flags are off', () => {
+    expect(() => validateM365CommunicationsRuntimeConfigAtBoot({ NODE_ENV: 'test' })).not.toThrow();
+  });
+
+  it('force-loads when the onboarding flag is on', () => {
+    expect(() => validateM365CommunicationsRuntimeConfigAtBoot({
+      NODE_ENV: 'test', M365_COMMS_ONBOARDING_ENABLED: 'true',
+    })).toThrow(/M365_COMMS_CLIENT_ID is required/);
+  });
+
+  it('validates the TOOLS allowlist even though the loader does not read it', () => {
+    const env = { ...baseEnv(writeJwkFixture('comms-kid-1')), M365_COMMS_TOOLS_ENABLED: 'true' };
+    // M365_COMMS_TOOLS_USER_IDS deliberately absent.
+    expect(() => validateM365CommunicationsRuntimeConfigAtBoot(env)).toThrow(/M365_COMMS_TOOLS_USER_IDS/);
+  });
+});

--- a/apps/api/src/services/m365ControlPlane/commsRuntimeConfig.ts
+++ b/apps/api/src/services/m365ControlPlane/commsRuntimeConfig.ts
@@ -1,0 +1,267 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  openSync,
+  readFileSync,
+} from 'node:fs';
+import { isAbsolute } from 'node:path';
+import type { M365ExecutorSigningPrivateJwk } from './writeActionRuntimeConfig';
+
+// Cloned from writeActionRuntimeConfig.ts (design §10) with two deliberate
+// divergences: the allowlist axis is USERS (not orgs), and there are NO vault
+// vars API-side at all — the client certificate and the token-cache KEK are
+// the executor's, wrapped under a KEK the API's identity cannot get (§3.2).
+
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+export const EXECUTOR_AUDIENCE = 'm365-communications-executor' as const;
+// This string must byte-match the redirect URI registered in Entra — a
+// trailing-slash difference fails code redemption with a generic error.
+const CALLBACK_PATH = '/api/v1/m365/comms-consent/callback';
+const LOCAL_CALLBACK_ORIGIN = 'http://localhost:3001';
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+export interface M365CommsRuntimeConfig {
+  clientId: string;
+  callbackUrl: string;
+  executorUrl: string;
+  executorAudience: typeof EXECUTOR_AUDIENCE;
+  executorSigningPrivateJwk: M365ExecutorSigningPrivateJwk;
+  executorSigningKid: string;
+  onboardingUserIds: '*' | readonly string[];
+}
+
+function flagEnabled(raw: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes((raw ?? '').trim().toLowerCase());
+}
+
+function required(source: Environment, name: string): string {
+  const value = source[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function parseCallbackUrl(source: Environment): string {
+  const configured = [source.PUBLIC_URL, source.PUBLIC_APP_URL, source.PUBLIC_API_URL]
+    .map((value) => value?.trim())
+    .find((value): value is string => Boolean(value));
+  const originInput = configured || (source.NODE_ENV === 'production' ? undefined : LOCAL_CALLBACK_ORIGIN);
+  if (!originInput) {
+    throw new Error(
+      'PUBLIC_URL, PUBLIC_APP_URL, or PUBLIC_API_URL is required for the M365 comms consent callback in production',
+    );
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(originInput);
+  } catch {
+    throw new Error('The configured M365 comms consent callback origin must be a valid HTTP(S) URL');
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+    throw new Error('The configured M365 comms consent callback origin must be a valid HTTP(S) URL');
+  }
+  return `${parsed.origin}${CALLBACK_PATH}`;
+}
+
+function parseExecutorUrl(source: Environment): string {
+  const raw = required(source, 'M365_COMMS_EXECUTOR_URL');
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error('M365_COMMS_EXECUTOR_URL must be a valid HTTPS URL');
+  }
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.username
+    || parsed.password
+    || parsed.pathname !== '/'
+    || parsed.search !== ''
+    || parsed.hash !== ''
+  ) {
+    throw new Error('M365_COMMS_EXECUTOR_URL must be an origin-only HTTPS URL');
+  }
+  return parsed.origin;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isThirtyTwoByteBase64Url(value: unknown): value is string {
+  return typeof value === 'string'
+    && BASE64URL.test(value)
+    && Buffer.from(value, 'base64url').byteLength === 32;
+}
+
+function parseSigningPrivateJwk(source: Environment, expectedKid: string): M365ExecutorSigningPrivateJwk {
+  const file = required(source, 'M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE');
+  if (!isAbsolute(file)) {
+    throw new Error('M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE must be an absolute path');
+  }
+
+  let raw: string;
+  let fd: number | undefined;
+  try {
+    fd = openSync(file, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const metadata = fstatSync(fd);
+    if (!metadata.isFile()) {
+      throw new Error('not a regular file');
+    }
+    if ((metadata.mode & 0o077) !== 0) {
+      throw new Error('permissions must deny group and other access (use mode 0600 or stricter)');
+    }
+    raw = readFileSync(fd, 'utf8');
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'cannot read file';
+    throw new Error(`M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE ${detail}`);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE must contain valid JWK JSON');
+  }
+  if (
+    !isRecord(parsed)
+    || parsed.kty !== 'OKP'
+    || parsed.crv !== 'Ed25519'
+    || !isThirtyTwoByteBase64Url(parsed.x)
+    || !isThirtyTwoByteBase64Url(parsed.d)
+    || (parsed.alg !== undefined && parsed.alg !== 'EdDSA')
+    || (parsed.use !== undefined && parsed.use !== 'sig')
+    || (parsed.kid !== undefined && parsed.kid !== expectedKid)
+  ) {
+    throw new Error(
+      'M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE must contain the configured Ed25519 private signing JWK and matching M365_COMMS_EXECUTOR_SIGNING_KID',
+    );
+  }
+  if (parsed.key_ops !== undefined) {
+    if (!Array.isArray(parsed.key_ops) || !parsed.key_ops.includes('sign')) {
+      throw new Error(
+        'M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE key_ops must permit signing',
+      );
+    }
+  }
+  return parsed as M365ExecutorSigningPrivateJwk;
+}
+
+// The comms allowlists are UUID lists of USERS, not orgs (design §10). Both
+// parsers THROW on a malformed entry rather than filtering it out — a
+// silently-dropped id is a silently-denied user.
+
+function parseCommsOnboardingUserIds(source: Environment): '*' | readonly string[] {
+  const raw = source.M365_COMMS_ONBOARDING_USER_IDS?.trim();
+  if (!raw) {
+    if (!flagEnabled(source.M365_COMMS_ONBOARDING_ENABLED)) return [];
+    throw new Error('M365_COMMS_ONBOARDING_USER_IDS is required when onboarding is enabled');
+  }
+  if (raw === '*') return '*';
+
+  const ids = raw.split(',').map((value) => value.trim());
+  if (ids.some((value) => !CANONICAL_UUID.test(value))) {
+    throw new Error(
+      'M365_COMMS_ONBOARDING_USER_IDS must be literal * or comma-separated canonical UUIDs',
+    );
+  }
+  return [...new Set(ids)];
+}
+
+function parseCommsToolsUserIds(source: Environment): '*' | readonly string[] {
+  const raw = source.M365_COMMS_TOOLS_USER_IDS?.trim();
+  if (!raw) {
+    if (!flagEnabled(source.M365_COMMS_TOOLS_ENABLED)) return [];
+    throw new Error('M365_COMMS_TOOLS_USER_IDS is required when M365 comms tools are enabled');
+  }
+  if (raw === '*') return '*';
+
+  const ids = raw.split(',').map((value) => value.trim());
+  if (ids.some((value) => !CANONICAL_UUID.test(value))) {
+    throw new Error('M365_COMMS_TOOLS_USER_IDS must be literal * or comma-separated canonical UUIDs');
+  }
+  return [...new Set(ids)];
+}
+
+/**
+ * Loads the secret-bearing API-to-executor signing key and the non-secret,
+ * fixed comms descriptor at call time. Nothing is parsed at import time.
+ * There are deliberately NO vault vars here: the API never touches the comms
+ * vault (§10).
+ */
+export function loadM365CommsRuntimeConfig(
+  source: Environment = process.env,
+): M365CommsRuntimeConfig {
+  const clientId = required(source, 'M365_COMMS_CLIENT_ID');
+  if (!CANONICAL_UUID.test(clientId)) {
+    throw new Error('M365_COMMS_CLIENT_ID must be a canonical UUID');
+  }
+
+  const executorAudience = required(source, 'M365_COMMS_EXECUTOR_AUDIENCE');
+  if (executorAudience !== EXECUTOR_AUDIENCE) {
+    throw new Error(`M365_COMMS_EXECUTOR_AUDIENCE must equal ${EXECUTOR_AUDIENCE}`);
+  }
+  const executorSigningKid = required(source, 'M365_COMMS_EXECUTOR_SIGNING_KID');
+
+  return {
+    clientId,
+    callbackUrl: parseCallbackUrl(source),
+    executorUrl: parseExecutorUrl(source),
+    executorAudience,
+    executorSigningPrivateJwk: parseSigningPrivateJwk(source, executorSigningKid),
+    executorSigningKid,
+    onboardingUserIds: parseCommsOnboardingUserIds(source),
+  };
+}
+
+export function isM365CommsOnboardingEnabledForUser(
+  userId: string,
+  source: Environment = process.env,
+): boolean {
+  if (!flagEnabled(source.M365_COMMS_ONBOARDING_ENABLED)) return false;
+  if (!CANONICAL_UUID.test(userId)) return false;
+  const allowlist = loadM365CommsRuntimeConfig(source).onboardingUserIds;
+  return allowlist === '*' || allowlist.includes(userId);
+}
+
+/**
+ * Cheap, side-effect-free gate for whether the M365 communications AI tools
+ * are enabled for a user. Deliberately does NOT call
+ * loadM365CommsRuntimeConfig (which requires all executor envs) — this is
+ * called on hot AI-tool-registration paths, not just at boot. Disabled
+ * unless M365_COMMS_TOOLS_ENABLED is truthy AND the user is allowlisted (or
+ * the allowlist is the literal wildcard).
+ */
+export function isM365CommsToolsEnabledForUser(
+  userId: string,
+  source: Environment = process.env,
+): boolean {
+  if (!flagEnabled(source.M365_COMMS_TOOLS_ENABLED)) return false;
+  if (!CANONICAL_UUID.test(userId)) return false;
+  const allowlist = parseCommsToolsUserIds(source);
+  return allowlist === '*' || allowlist.includes(userId);
+}
+
+export function validateM365CommunicationsRuntimeConfigAtBoot(
+  source: Environment = process.env,
+): void {
+  if (
+    flagEnabled(source.M365_COMMS_ONBOARDING_ENABLED)
+    || flagEnabled(source.M365_COMMS_TOOLS_ENABLED)
+  ) {
+    loadM365CommsRuntimeConfig(source);
+  }
+  if (flagEnabled(source.M365_COMMS_TOOLS_ENABLED)) {
+    // loadM365CommsRuntimeConfig() above does not validate the tools
+    // allowlist (M365_COMMS_TOOLS_USER_IDS) — it's read lazily on the hot
+    // tool-registration path via isM365CommsToolsEnabledForUser. Validate it
+    // explicitly here so a missing/malformed allowlist fails boot instead of
+    // every subsequent tool call.
+    parseCommsToolsUserIds(source);
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,6 +233,20 @@ services:
       M365_GRAPH_ACTIONS_EXECUTOR_AUDIENCE: ${M365_GRAPH_ACTIONS_EXECUTOR_AUDIENCE:-m365-graph-actions-executor}
       M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_KID: ${M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_KID:-}
       M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE: /run/secrets/m365_graph_actions_executor_signing_private_jwk
+      # M365 communications-delegated. Gated per USER, not per org — a delegated
+      # mailbox connection is owned by one human. No vault vars here on purpose:
+      # the API never touches the comms vault (the client certificate and the
+      # token-cache KEK belong to the executor, which is the only identity that
+      # can decrypt the cache).
+      M365_COMMS_ONBOARDING_ENABLED: ${M365_COMMS_ONBOARDING_ENABLED:-false}
+      M365_COMMS_ONBOARDING_USER_IDS: ${M365_COMMS_ONBOARDING_USER_IDS:-}
+      M365_COMMS_TOOLS_ENABLED: ${M365_COMMS_TOOLS_ENABLED:-false}
+      M365_COMMS_TOOLS_USER_IDS: ${M365_COMMS_TOOLS_USER_IDS:-}
+      M365_COMMS_CLIENT_ID: ${M365_COMMS_CLIENT_ID:-}
+      M365_COMMS_EXECUTOR_URL: ${M365_COMMS_EXECUTOR_URL:-}
+      M365_COMMS_EXECUTOR_AUDIENCE: ${M365_COMMS_EXECUTOR_AUDIENCE:-m365-communications-executor}
+      M365_COMMS_EXECUTOR_SIGNING_KID: ${M365_COMMS_EXECUTOR_SIGNING_KID:-}
+      M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE: /run/secrets/m365_comms_executor_signing_private_jwk
       APP_VERSION: ${BREEZE_VERSION:-dev}
       BREEZE_VERSION: ${BREEZE_VERSION:?Set BREEZE_VERSION in .env}
       BINARY_SOURCE: ${BINARY_SOURCE:-github}
@@ -347,6 +361,8 @@ services:
         target: m365_graph_read_executor_signing_private_jwk
       - source: m365_graph_actions_executor_signing_private_jwk
         target: m365_graph_actions_executor_signing_private_jwk
+      - source: m365_comms_executor_signing_private_jwk
+        target: m365_comms_executor_signing_private_jwk
     depends_on:
       binaries-init:
         condition: service_completed_successfully
@@ -544,3 +560,5 @@ secrets:
     file: ${M365_GRAPH_READ_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}
   m365_graph_actions_executor_signing_private_jwk:
     file: ${M365_GRAPH_ACTIONS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}
+  m365_comms_executor_signing_private_jwk:
+    file: ${M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}

--- a/docs/superpowers/plans/integrations/2026-07-29-m365-comms-1-api-binding-config.md
+++ b/docs/superpowers/plans/integrations/2026-07-29-m365-comms-1-api-binding-config.md
@@ -70,8 +70,20 @@ Spec §5.2 ("Sender pinning (change 2)") and §5.2 item 5.
 - Test: `apps/api/src/services/actionIntents/revalidateRelease.test.ts` — **CREATE. `revalidateRelease.ts` has no dedicated unit test today**; it is covered only indirectly through its two callers (`services/aiAgentSdk.test.ts`, `jobs/intentReleaseWorker*Headless.integration.test.ts`). There is no `intentFixture()` helper to reuse — Step 6 builds one.
 - Test: `apps/api/src/__tests__/integration/actionIntentBinding.integration.test.ts` (create)
 
-**⚠️ Known blast radius — two shipped fixtures use a fake digest and WILL fail.**
-`services/aiAgentSdk.test.ts:241` and `services/aiAgentSdk.planMatch.test.ts:118` both set `argumentDigest: 'digest-1'`, which is not `sha256(canonicalize(arguments))` of anything. The recompute added in Step 8 turns both red. That is the check working. **Fix the fixtures to carry a real digest computed from their own `arguments`; do not weaken, skip, or conditionally bypass the recompute.** The worker integration suites already use a correct canonical digest (`intentReleaseWorkerM365Headless.integration.test.ts:20` says so explicitly) and should stay green — if one of them fails, read it before assuming it is a fixture problem.
+**⚠️ Known blast radius — a shipped fixture uses a fake digest and WILL fail.**
+`jobs/intentReleaseWorker.test.ts:185` sets `argumentDigest: 'digest-1'`, which is not `sha256(canonicalize(arguments))` of anything. The recompute added in Step 8 turns **31 tests in that one file** red. That is the check working. Fix by hoisting the arguments and deriving the digest:
+
+```ts
+import { canonicalizeArguments, computeArgumentDigest } from '@breeze/shared/canonicalize';
+
+const RUN_SCRIPT_ARGS = { scriptId: 'abc' };
+const RUN_SCRIPT_DIGEST = computeArgumentDigest(canonicalizeArguments(RUN_SCRIPT_ARGS));
+// then in baseIntent(): arguments: RUN_SCRIPT_ARGS, argumentDigest: RUN_SCRIPT_DIGEST,
+```
+
+**Do not weaken, skip, or conditionally bypass the recompute to keep a fixture green.** The `'stale-digest'` fixture at ~line 459 is the intended `digest_mismatch` case and must stay as it is.
+
+`services/aiAgentSdk.test.ts:241` and `services/aiAgentSdk.planMatch.test.ts:118` also carry `argumentDigest: 'digest-1'`, but both suites mock `revalidateApprovedIntentForRelease` itself, so they never reach the recompute and stay green. Verified, not assumed — 102 passed. The worker *integration* suites already use a correct canonical digest (`intentReleaseWorkerM365Headless.integration.test.ts:20` says so explicitly).
 
 **Interfaces:**
 - Consumes: `canonicalizeArguments`, `computeArgumentDigest` from `./canonicalize` (already imported at `intentService.ts:12`); `ActionIntent` type from `db/schema/actionIntents`.
@@ -649,15 +661,55 @@ M365_COMMS_CLIENT_ID=
 M365_COMMS_EXECUTOR_URL=https://comms-executor.internal/
 M365_COMMS_EXECUTOR_AUDIENCE=m365-communications-executor
 M365_COMMS_EXECUTOR_SIGNING_KID=
-M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE=/run/secrets/m365-comms-executor-signing.jwk
+M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE=/run/secrets/m365_comms_executor_signing_private_jwk
 ```
 
-- [ ] **Step 8: Check the compose bind-mount guard**
+- [ ] **Step 7b: Map every one of those vars into `docker-compose.yml` — `.env.example` alone is a silent no-op**
 
-If Step 7 referenced a new file-shaped path in any tracked compose file, `apps/api/src/config/composeBindMounts.test.ts` (required **Test API** job) will fail when the source does not exist. This plan adds no compose mounts — if you added one, create the file or use an extensionless path.
+**This step is not optional and its omission is a CI failure, not a deploy-time surprise.** `apps/api/src/config/envComposeParity.test.ts` (required **Test API** job) asserts that every var documented in the root `.env.example` actually reaches a container. Compose interpolation only happens for vars listed in a service's `environment:` block — a value in `.env` that is not mapped there never reaches the process, so the var reads as unset at runtime and boot validation silently passes.
 
-Run: `pnpm --filter=@breeze/api exec vitest run src/config/composeBindMounts.test.ts`
-Expected: PASS
+Add to the `api` service `environment:` block in `docker-compose.yml`, after the `M365_GRAPH_ACTIONS_*` entries:
+
+```yaml
+      # M365 communications-delegated. Gated per USER, not per org — a delegated
+      # mailbox connection is owned by one human. No vault vars here on purpose:
+      # the API never touches the comms vault (the client certificate and the
+      # token-cache KEK belong to the executor, which is the only identity that
+      # can decrypt the cache).
+      M365_COMMS_ONBOARDING_ENABLED: ${M365_COMMS_ONBOARDING_ENABLED:-false}
+      M365_COMMS_ONBOARDING_USER_IDS: ${M365_COMMS_ONBOARDING_USER_IDS:-}
+      M365_COMMS_TOOLS_ENABLED: ${M365_COMMS_TOOLS_ENABLED:-false}
+      M365_COMMS_TOOLS_USER_IDS: ${M365_COMMS_TOOLS_USER_IDS:-}
+      M365_COMMS_CLIENT_ID: ${M365_COMMS_CLIENT_ID:-}
+      M365_COMMS_EXECUTOR_URL: ${M365_COMMS_EXECUTOR_URL:-}
+      M365_COMMS_EXECUTOR_AUDIENCE: ${M365_COMMS_EXECUTOR_AUDIENCE:-m365-communications-executor}
+      M365_COMMS_EXECUTOR_SIGNING_KID: ${M365_COMMS_EXECUTOR_SIGNING_KID:-}
+      M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_FILE: /run/secrets/m365_comms_executor_signing_private_jwk
+```
+
+The JWK path is a Docker **secret**, not a bind mount, so it also needs both halves of the secret wiring the siblings use — the `api` service's `secrets:` list:
+
+```yaml
+      - source: m365_comms_executor_signing_private_jwk
+        target: m365_comms_executor_signing_private_jwk
+```
+
+and the top-level `secrets:` block, defaulting to `/dev/null` so dark deployments stay optional:
+
+```yaml
+  m365_comms_executor_signing_private_jwk:
+    file: ${M365_COMMS_EXECUTOR_SIGNING_PRIVATE_JWK_SOURCE_FILE:-/dev/null}
+```
+
+- [ ] **Step 8: Run both compose guards**
+
+```bash
+pnpm --filter=@breeze/api exec vitest run src/config/envComposeParity.test.ts src/config/composeBindMounts.test.ts
+```
+
+Expected: PASS. `envComposeParity` is the one Step 7b satisfies. `composeBindMounts` asserts that a file-shaped, repo-relative bind-mount source exists — this plan adds no bind mounts (the JWK is a secret with a `/dev/null` default, not a mount), so it should be unaffected.
+
+> If `composeBindMounts` fails to load with `TypeError: defineScalarTag is not a function`, that is a local `yaml` dependency resolution problem, not your change — confirm by stashing and re-running. CI resolves it correctly.
 
 - [ ] **Step 9: Typecheck and lint**
 


### PR DESCRIPTION
Implements the merged Plan 1 (#2934): `docs/superpowers/plans/integrations/2026-07-29-m365-comms-1-api-binding-config.md`, tasks 6 and 7.

## What landed

**Task 6 — intent binding + release digest recompute** (`5e67ccf`)
- `CreateActionIntentInput` gains an optional `binding: { connectionId, tenantId }` populating the already-immutable `action_intents.connection_id` / `tenant_id` columns. Both are Postgres `uuid`, so non-canonical GUIDs are rejected in the service (typed `ActionIntentError`, code `invalid_binding`) instead of surfacing as 22P02.
- `revalidateApprovedIntentForRelease` now recomputes the digest from the stored `arguments` and compares it against the **stored** `argument_digest` (defense-in-depth for a write that bypassed the immutability trigger; reuses `digest_mismatch`, no new failure codes, signature unchanged).
- New `revalidateRelease.test.ts` unit suite and `actionIntentBinding.integration.test.ts` proving the immutability trigger rejects mutation of both columns against real Postgres.

**Task 7 — comms runtime config + boot validation** (`7a08e47`)
- `services/m365ControlPlane/commsRuntimeConfig.ts`, cloned from `writeActionRuntimeConfig.ts` with the allowlist axis swapped to **users** and **no vault vars API-side** (the API never touches the comms vault; `APP_ENCRYPTION_KEY_ID` deliberately not asserted — comms has no reveal path).
- `isM365CommsToolsEnabledForUser` reads only the flag + tools allowlist (hot tool-registration path, never the full loader); boot validation checks that allowlist explicitly.
- Wired into `config/validate.ts` with its own wiring tests (onboarding-flag force-load + tools-allowlist branch); comms env block appended to root `.env.example`.

## Test evidence

- `intentService.test.ts`: 33 passed (incl. 3 new binding tests, seen red first)
- `revalidateRelease.test.ts`: 2 passed (mismatch case seen red first)
- `src/services/actionIntents` + `src/services/aiAgentSdk` unit sweep: 18 files, 273 passed
- Integration (Postgres :5433): `actionIntentBinding` 1 passed; blast-radius set (`createIntentAtomicity`, `intentReleaseWorkerM365Headless`, `intentReleaseWorkerGoogleHeadless`, `intentFanout`, `intentSelfApproveGuard`): 5 files, 16 passed
- `commsRuntimeConfig.test.ts`: 14 passed (seen red first)
- `validate.test.ts` + full `m365ControlPlane` sweep: 17 files, 467 passed
- `composeBindMounts.test.ts`: 3 passed
- `tsc --noEmit` (repo root, apps/api tsconfig): clean; eslint on touched files: clean

## Deviations from the plan doc

- **Blast radius did not materialize:** `aiAgentSdk.test.ts` / `aiAgentSdk.planMatch.test.ts` both `vi.mock('./actionIntents/revalidateRelease')` wholesale, so their `argumentDigest: 'digest-1'` fixtures never reach the recompute — both suites stayed green with **no fixture changes**. The recompute was not weakened or bypassed.
- Plan's `captureInsertValues()` / `authFixture()` helpers don't exist in `intentService.test.ts` — used the file's existing `dbState` capture + `makeAuth()`/`baseInput()` style, as the plan instructs for this case.
- Binding validation throws the file's typed `ActionIntentError` (code `invalid_binding`) rather than the plan snippet's bare `Error`; identical messages. `CANONICAL_UUID_LOWER` hoisted to module scope.
- Integration fixture needed the NOT NULL columns `targetSummary`, `impactSummary`, `idempotencyKey`, `correlationId` (plan anticipated this; assertion unchanged).
- Task 7 Step 6's `validateEnvironment(...minimalValidEnv())` harness doesn't exist — used `validate.test.ts`'s `withEnv` + `validateConfig()` harness; added a second wiring test covering the tools-allowlist boot branch.
- `M365ExecutorSigningPrivateJwk` is imported from `writeActionRuntimeConfig.ts` rather than duplicated.
- Environment note: repo `.nvmrc` pins Node 22.20.0 but a dependency's `engines` now requires `^22.22.2` under `engine-strict=true`; install/tests were run with local Node 22.23.2. No repo files changed for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)