### PR TITLE
feat(agent): log which session's helper receives a consent prompt

### DIFF
--- a/agent/internal/heartbeat/consent_gate.go
+++ b/agent/internal/heartbeat/consent_gate.go
@@ -92,6 +92,19 @@ func (h *Heartbeat) requestConsent(sessionID string, prompt *ipc.DesktopPrompt, 
 		return "", false, false
 	}
 
+	// Record which helper the prompt is routed to. On the success path the
+	// broker's send/reply is otherwise silent, so this is the only line that
+	// attributes a ConsentRequest to a specific Windows session — the invariant
+	// that matters when a shadow targets one RDS session among several.
+	log.Info("routing consent prompt to helper",
+		"sessionId", sessionID,
+		"targeted", targetWinSession != "",
+		"winSession", session.WinSessionID,
+		"identity", session.IdentityKey,
+		"role", session.HelperRole,
+		"pid", session.PID,
+	)
+
 	req := ipc.ConsentRequest{
 		SessionID:       sessionID,
 		TechnicianName:  derefString(prompt.TechnicianName),


### PR DESCRIPTION
Follow-up to #2911 (RDS per-session helpers). The consent gate's **success path** was silent: the broker's `SendCommandAndWait` and its reply log nothing, so `requestConsent` never recorded *which* Windows session's helper a `ConsentRequest` was routed to. Only the failure branches (`consent request to helper failed`, `consent helper returned an error`) logged.

This is the exact gap that made the on-rig consent-routing verification lean on in-session window probes and result timing instead of a direct agent-side log line. This PR adds one `log.Info("routing consent prompt to helper", …)` at the routing point in `requestConsent`, recording the resolved helper's `winSession`, `identity` (SID), `role`, `pid`, and whether the prompt was explicitly targeted.

**Observability only — no behavior change.** With this line, a future two-session shadow test can prove the target-session invariant straight from `agent.log` (the line names exactly one Windows session per prompt).

Verified: `go build`/`go vet`/`gofmt` clean; `go test ./internal/heartbeat/ -run 'Consent|Desktop'` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)