### PR TITLE
fix(agent): keep disk inventory when one volume warns on Windows

### DIFF
--- a/agent/internal/collectors/inventory.go
+++ b/agent/internal/collectors/inventory.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"log/slog"
 	"net"
 	"strings"
 
@@ -54,6 +55,9 @@ func (c *InventoryCollector) CollectDisks() ([]DiskInfo, error) {
 	partitions, err := partitionsFn(false)
 	if err != nil && len(partitions) == 0 {
 		return nil, err
+	}
+	if err != nil {
+		slog.Warn("disk.Partitions reported warnings; continuing with enumerated drives", "error", err.Error())
 	}
 
 	var disks []DiskInfo

--- a/agent/internal/collectors/inventory.go
+++ b/agent/internal/collectors/inventory.go
@@ -37,10 +37,22 @@ func NewInventoryCollector() *InventoryCollector {
 	return &InventoryCollector{}
 }
 
+// partitionsFn is disk.Partitions, indirected so tests can simulate the
+// partial-success contract described on CollectDisks.
+var partitionsFn = disk.Partitions
+
 // CollectDisks collects information about all mounted disk drives
 func (c *InventoryCollector) CollectDisks() ([]DiskInfo, error) {
-	partitions, err := disk.Partitions(false)
-	if err != nil {
+	// gopsutil's Windows implementation returns the drives it *did* enumerate
+	// alongside a non-fatal warnings aggregate (`return ret, warnings.Reference()`).
+	// A single unreadable volume — an empty card reader, a disconnected mapped
+	// drive — fails GetVolumeInformation with "Access is denied" and populates
+	// that aggregate, so treating any error as fatal throws away every healthy
+	// disk on the machine and the endpoint reports no disk inventory at all.
+	// Only fail when nothing was enumerated; on Linux/macOS a genuine error
+	// yields no partitions, so that path is unchanged.
+	partitions, err := partitionsFn(false)
+	if err != nil && len(partitions) == 0 {
 		return nil, err
 	}
 

--- a/agent/internal/collectors/inventory_test.go
+++ b/agent/internal/collectors/inventory_test.go
@@ -1,0 +1,73 @@
+package collectors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shirou/gopsutil/v3/disk"
+)
+
+// gopsutil's Windows disk.Partitions returns the drives it could enumerate plus
+// a non-fatal warnings aggregate, so an unreadable volume must not discard the
+// healthy ones. Verified against a fleet where 75 Windows endpoints reported no
+// disk inventory at all because one drive answered "Access is denied".
+func TestCollectDisksPartitionErrorHandling(t *testing.T) {
+	hostPartitions, err := disk.Partitions(false)
+	if err != nil || len(hostPartitions) == 0 {
+		t.Skip("host has no cleanly enumerable partitions to exercise the collector")
+	}
+
+	tests := []struct {
+		name       string
+		partitions []disk.PartitionStat
+		err        error
+		wantErr    bool
+		wantDisks  bool
+	}{
+		{
+			name:       "warning alongside partitions is not fatal",
+			partitions: hostPartitions,
+			err:        errors.New("\tError 0: Access is denied.\n"),
+			wantErr:    false,
+			wantDisks:  true,
+		},
+		{
+			name:       "error with nothing enumerated is fatal",
+			partitions: nil,
+			err:        errors.New("\tError 0: Access is denied.\n"),
+			wantErr:    true,
+		},
+		{
+			name:       "clean enumeration succeeds",
+			partitions: hostPartitions,
+			err:        nil,
+			wantErr:    false,
+			wantDisks:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := partitionsFn
+			t.Cleanup(func() { partitionsFn = original })
+			partitionsFn = func(bool) ([]disk.PartitionStat, error) {
+				return tt.partitions, tt.err
+			}
+
+			disks, err := NewInventoryCollector().CollectDisks()
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error when no partitions were enumerated")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantDisks && len(disks) == 0 {
+				t.Fatal("collector discarded every partition")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`InventoryCollector.CollectDisks` treats any error from `disk.Partitions` as fatal:

```go
partitions, err := disk.Partitions(false)
if err != nil {
    return nil, err
}
```

On Windows that discards good data. gopsutil returns the drives it *did* enumerate **alongside** a non-fatal warnings aggregate:

```go
// gopsutil v3.24.5 — disk/disk_windows.go
return ret, warnings.Reference()
```

So one unreadable volume — an empty card reader, a disconnected mapped drive, a permission-restricted volume — fails `GetVolumeInformation` with `Access is denied`, lands in that aggregate, and the collector throws away **every healthy disk on the machine**. The endpoint reports no disk inventory at all and `sendDiskInventory` logs `failed to collect disk inventory` on every heartbeat.

The logged error is gopsutil's `Warnings.Error()` verbatim, including its leading tab, which is how it can be identified conclusively:

```go
// internal/common/warnings.go
str += fmt.Sprintf("\tError %d: %s\n", i, e.Error())
```

Matching log payload from a self-hosted deployment:

```json
{"error": "\tError 0: Access is denied.\n", "component": "heartbeat"}
```

Devices with more than one such volume log `Error 0`, `Error 1`, `Error 2` — one entry per drive, which is the aggregate filling up.

**Impact measured on one self-hosted fleet:** 75 Windows endpoints, ~5,500 occurrences in 24h, none of them reporting disk inventory.

## Fix

Fail only when nothing was enumerated:

```go
partitions, err := partitionsFn(false)
if err != nil && len(partitions) == 0 {
    return nil, err
}
```

Scope notes:

- `disk/disk_windows.go` is the **only** file in gopsutil v3.24.5 that returns a warnings aggregate, so no other collector is affected.
- On Linux/macOS a genuine error yields no partitions, so that path is unchanged.
- This is the **only** `disk.Partitions` call site in the agent.
- `disk.Partitions` is indirected through a package-level `partitionsFn` var purely so the partial-success contract is testable.

## Tests

New table-driven `TestCollectDisksPartitionErrorHandling` covers all three cases: warning alongside partitions is non-fatal; error with nothing enumerated stays fatal; clean enumeration succeeds.

The test was confirmed to reproduce the bug — reverting the guard fails it with the exact production string:

```
inventory_test.go:66: unexpected error: 	Error 0: Access is denied.
```

- new test: 3/3 pass
- full `internal/collectors` package: pass
- `go vet`, `gofmt -l`: clean
