### PR TITLE
fix(alerts): post-review fixes for the alert-rule ownership consolidation (#2946 follow-up)

### DIFF
--- a/apps/api/migrations/2026-07-30-b-drop-never-firing-metric-alert-rules.sql
+++ b/apps/api/migrations/2026-07-30-b-drop-never-firing-metric-alert-rules.sql
@@ -1,0 +1,139 @@
+-- Forward fix on top of 2026-07-30-alert-rule-ownership-consolidation.sql.
+--
+-- Why a separate file: the consolidation migration shipped mid-review, so the
+-- never-firing-rule cleanup it was reviewed to carry cannot be folded back into
+-- it — `breeze_migrations` keys applied files by checksum, and editing a shipped
+-- migration is forbidden. This runs as its own step instead. The filename sorts
+-- immediately after the consolidation (`alert` < `b` under localeCompare) and is
+-- independent of 2026-07-30-serialize-bulk-config-assignment-target-moves.sql,
+-- which touches unrelated tables.
+--
+-- What it removes: the pre-consolidation Monitoring tab offered a "Network
+-- Usage" metric option, but the threshold evaluator's METRIC_NAME_MAP
+-- (services/alertConditions/utils.ts) has no `network` column to compare
+-- against, so normalizeMetricName() returns NULL and such a rule has never
+-- fired once. The same is true of a metric condition carrying no metric name at
+-- all — normalizeMetricName(undefined) is likewise NULL. Left in place these
+-- rows render on the Alerts tab as a permanently dead rule whose metric the
+-- editor cannot represent, and whose next save the write schema rejects.
+--
+-- Retargeted from the original step-0 design: that version scoped the delete to
+-- rows still hanging off a MONITORING feature link, because it ran before the
+-- consolidation moved them. On any database that has already applied the
+-- consolidation those same rows now sit under an ALERT_RULE link, so this file
+-- matches on the condition shape under ANY feature link instead. That is also
+-- the right net for rules the AI tool or a direct API write created straight
+-- onto the alert_rule link.
+--
+-- What it never removes:
+--   * Multi-condition rules. One bad condition among valid ones still fires on
+--     the valid ones, so the row stays intact and AlertRuleTab flags the bad
+--     condition for the tech instead of the migration guessing.
+--   * Rules an `alerts` row references. alerts.config_policy_id stores the rule
+--     id as a plain uuid with no FK, so deleting one would orphan alert
+--     provenance. Those rows are counted and warned about, and left alone.
+--
+-- Idempotent: after a successful run no matching deletable row remains, so the
+-- delete finds nothing and the mirror rebuild is skipped entirely (updated_at
+-- is not bumped, which keeps the partner-export watermark stable on replay).
+
+-- Run with system scope: config_policy_alert_rules / config_policy_feature_links
+-- / alerts all have FORCE ROW LEVEL SECURITY, and the migration role is not
+-- guaranteed to be a superuser on managed Postgres. Without this the DML below
+-- would silently touch zero rows (transaction-local; autoMigrate wraps the file).
+SELECT set_config('breeze.scope', 'system', true);
+
+DO $$
+DECLARE
+  dropped_unfirable integer := 0;
+  kept_unfirable integer := 0;
+  dropped_names text[];
+  affected_links uuid[];
+  rebuilt_mirrors integer := 0;
+BEGIN
+  -- 1. Delete the never-firing rules, capturing their names (for the forensic
+  --    trail) and their feature links (so step 2 knows which mirrors to rebuild).
+  --
+  --    The correlated EXISTS against `alerts` runs once per candidate row, so an
+  --    empty candidate set — the steady state after this migration has run —
+  --    never touches that table at all.
+  WITH never_firing AS (
+    SELECT r.id, r.name, r.feature_link_id
+    FROM public.config_policy_alert_rules r
+    WHERE jsonb_typeof(r.conditions) = 'array'
+      AND jsonb_array_length(r.conditions) = 1
+      AND jsonb_typeof(r.conditions->0) = 'object'
+      -- 'threshold' is the evaluator's own name for the metric handler
+      -- (handlers/threshold.ts declares it with aliases ['metric']).
+      AND r.conditions->0->>'type' IN ('metric', 'threshold')
+      -- A missing or JSON-null metric collapses to '' and is caught here too:
+      -- it is dead by exactly the same mechanism as metric:'network'.
+      AND COALESCE(r.conditions->0->>'metric', '') NOT IN (
+        'cpu', 'cpuPercent',
+        'ram', 'ramPercent', 'memory',
+        'disk', 'diskPercent',
+        'processCount', 'processes'
+      )
+  ), dropped AS (
+    DELETE FROM public.config_policy_alert_rules r
+    USING never_firing n
+    WHERE r.id = n.id
+      AND NOT EXISTS (SELECT 1 FROM public.alerts a WHERE a.config_policy_id = n.id)
+    RETURNING r.name, r.feature_link_id
+  )
+  SELECT
+    (SELECT count(*) FROM dropped),
+    (SELECT COALESCE(array_agg(DISTINCT name), ARRAY[]::text[]) FROM dropped),
+    (SELECT COALESCE(array_agg(DISTINCT feature_link_id), ARRAY[]::uuid[]) FROM dropped),
+    (SELECT count(*) FROM never_firing n
+       WHERE EXISTS (SELECT 1 FROM public.alerts a WHERE a.config_policy_id = n.id))
+    INTO dropped_unfirable, dropped_names, affected_links, kept_unfirable;
+
+  IF dropped_unfirable > 0 THEN
+    RAISE WARNING 'never-firing alert rules: dropped % rule(s) whose only condition was a metric condition outside the evaluator domain (metric missing or not one of cpu/ram/memory/disk/processCount): %',
+      dropped_unfirable, array_to_string(dropped_names, ', ');
+  END IF;
+  IF kept_unfirable > 0 THEN
+    RAISE WARNING 'never-firing alert rules: LEFT IN PLACE % rule(s) because existing alerts rows reference them. They are NOT deleted; they simply remain and will never fire until a tech replaces the condition',
+      kept_unfirable;
+  END IF;
+
+  -- 2. Rebuild the inline_settings items[] mirror for every alert_rule link that
+  --    lost rows, matching the shape assembleInlineSettings() writes (and the
+  --    consolidation migration's own step 4b).
+  --
+  --    Deliberately a per-link correlated aggregate rather than a
+  --    `GROUP BY feature_link_id` over the rules table: a link whose ONLY rule
+  --    was just deleted has no rows left to group, so the grouped form would
+  --    skip it and strand the deleted rule in the mirror forever.
+  --
+  --    The IS DISTINCT FROM guard means only links whose mirror actually changes
+  --    have updated_at bumped, so a replay is a true no-op.
+  IF array_length(affected_links, 1) IS NOT NULL THEN
+    UPDATE public.config_policy_feature_links al
+    SET inline_settings = jsonb_build_object('items', COALESCE(sub.items, '[]'::jsonb)),
+        updated_at = now()
+    FROM (
+      SELECT l.id AS feature_link_id, (
+        SELECT jsonb_agg(jsonb_build_object(
+          'name', name, 'severity', severity, 'conditions', conditions,
+          'cooldownMinutes', cooldown_minutes, 'autoResolve', auto_resolve,
+          'autoResolveConditions', auto_resolve_conditions,
+          'titleTemplate', title_template, 'messageTemplate', message_template,
+          'sortOrder', sort_order
+        ) ORDER BY sort_order, created_at, id)
+        FROM public.config_policy_alert_rules r
+        WHERE r.feature_link_id = l.id
+      ) AS items
+      FROM public.config_policy_feature_links l
+      WHERE l.id = ANY(affected_links)
+    ) sub
+    WHERE sub.feature_link_id = al.id
+      AND al.feature_type = 'alert_rule'
+      AND al.inline_settings IS DISTINCT FROM jsonb_build_object('items', COALESCE(sub.items, '[]'::jsonb));
+    GET DIAGNOSTICS rebuilt_mirrors = ROW_COUNT;
+    IF rebuilt_mirrors > 0 THEN
+      RAISE WARNING 'never-firing alert rules: rebuilt % alert_rule inline_settings mirror(s)', rebuilt_mirrors;
+    END IF;
+  END IF;
+END $$;

--- a/apps/api/src/__tests__/integration/neverFiringRuleCleanup.integration.test.ts
+++ b/apps/api/src/__tests__/integration/neverFiringRuleCleanup.integration.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Replays 2026-07-30-b-drop-never-firing-metric-alert-rules.sql against seeded
+ * alert rules that the threshold evaluator can never resolve — a single metric
+ * condition naming a metric outside METRIC_NAME_MAP (the retired "Network
+ * Usage" option), or carrying no metric name at all.
+ *
+ * CI databases are migrated schema-fresh in globalSetup, so this migration's
+ * DO-block would otherwise only ever run against zero rows. This suite seeds the
+ * post-consolidation shape (rules under an ALERT_RULE link, which is where the
+ * 2026-07-30 consolidation leaves them) and asserts the contract: dead rules go,
+ * rules with alert provenance stay and are warned about, multi-condition rules
+ * are untouched, the inline_settings mirror is rebuilt, and a replay changes
+ * nothing at all.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run -c vitest.integration.config.ts \
+ *     src/__tests__/integration/neverFiringRuleCleanup.integration.test.ts
+ */
+import './setup';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { asc, eq, inArray, sql } from 'drizzle-orm';
+import postgres from 'postgres';
+import { describe, expect, it } from 'vitest';
+import {
+  alerts,
+  configPolicyAlertRules,
+  configPolicyFeatureLinks,
+  configurationPolicies,
+  devices,
+} from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-07-30-b-drop-never-firing-metric-alert-rules.sql',
+);
+
+const DATABASE_URL =
+  process.env.DATABASE_URL || 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+function migrationText(): string {
+  return readFileSync(MIGRATION_FILE, 'utf8');
+}
+
+async function runMigration() {
+  await getTestDb().execute(sql.raw(migrationText()));
+}
+
+/**
+ * Runs the migration on a short-lived client with the notice handler left in
+ * place, so the RAISE WARNING forensic trail can actually be asserted. The
+ * shared integration client sets `onnotice: () => {}` and would swallow them.
+ */
+async function runMigrationCapturingWarnings(): Promise<string[]> {
+  const warnings: string[] = [];
+  const client = postgres(DATABASE_URL, {
+    max: 1,
+    onnotice: (notice) => {
+      if (notice.message) warnings.push(String(notice.message));
+    },
+  });
+  try {
+    await client.unsafe(migrationText());
+  } finally {
+    await client.end({ timeout: 5 });
+  }
+  return warnings;
+}
+
+const CPU_CONDITIONS = [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 90 }];
+const NETWORK_CONDITIONS = [{ type: 'metric', metric: 'network', operator: 'gt', value: 80 }];
+// The evaluator's own name for the metric handler (handlers/threshold.ts
+// declares it with aliases ['metric']) — the migration must catch it too.
+const THRESHOLD_ALIAS_CONDITIONS = [{ type: 'threshold', metric: 'network', operator: 'gt', value: 80 }];
+// No metric name at all: normalizeMetricName(undefined) is null, so this is dead
+// by exactly the same mechanism.
+const METRICLESS_CONDITIONS = [{ type: 'metric', operator: 'gt', value: 80 }];
+const MIXED_CONDITIONS = [
+  { type: 'metric', metric: 'cpu', operator: 'gt', value: 90 },
+  { type: 'metric', metric: 'network', operator: 'gt', value: 80 },
+];
+
+async function createPolicyWithAlertLink(name: string, inlineSettings: unknown = { items: [] }) {
+  const db = getTestDb();
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner!.id });
+  const [policy] = await db.insert(configurationPolicies).values({
+    orgId: org!.id,
+    partnerId: null,
+    name,
+  }).returning({ id: configurationPolicies.id });
+  const [alertLink] = await db.insert(configPolicyFeatureLinks).values({
+    configPolicyId: policy!.id,
+    featureType: 'alert_rule',
+    inlineSettings: inlineSettings as Record<string, unknown>,
+  }).returning({ id: configPolicyFeatureLinks.id });
+  return { orgId: org!.id, policyId: policy!.id, alertLinkId: alertLink!.id };
+}
+
+async function insertRule(
+  featureLinkId: string,
+  name: string,
+  conditions: unknown,
+  sortOrder: number,
+) {
+  const [row] = await getTestDb().insert(configPolicyAlertRules).values({
+    featureLinkId,
+    name,
+    severity: 'medium',
+    conditions: conditions as Record<string, unknown>[],
+    sortOrder,
+  }).returning({ id: configPolicyAlertRules.id });
+  return row!.id;
+}
+
+async function ruleIdsFor(ids: string[]) {
+  const rows = await getTestDb()
+    .select({ id: configPolicyAlertRules.id })
+    .from(configPolicyAlertRules)
+    .where(inArray(configPolicyAlertRules.id, ids));
+  return rows.map((r) => r.id);
+}
+
+async function linkById(linkId: string) {
+  const [row] = await getTestDb()
+    .select()
+    .from(configPolicyFeatureLinks)
+    .where(eq(configPolicyFeatureLinks.id, linkId));
+  return row;
+}
+
+function mirrorItems(inlineSettings: unknown): Array<Record<string, unknown>> {
+  return (inlineSettings as { items: Array<Record<string, unknown>> }).items;
+}
+
+describe('never-firing metric alert rule cleanup migration (2026-07-30-b)', () => {
+  runDb('drops an unfirable single-condition rule from an alert_rule link', async () => {
+    const { alertLinkId } = await createPolicyWithAlertLink('Policy — network rule');
+    const networkRuleId = await insertRule(alertLinkId, 'Network usage high', NETWORK_CONDITIONS, 0);
+    const aliasRuleId = await insertRule(alertLinkId, 'Network usage (threshold)', THRESHOLD_ALIAS_CONDITIONS, 1);
+    const cpuRuleId = await insertRule(alertLinkId, 'CPU high', CPU_CONDITIONS, 2);
+
+    await runMigration();
+
+    // Gone entirely — not relocated, not left behind.
+    expect(await ruleIdsFor([networkRuleId, aliasRuleId, cpuRuleId])).toEqual([cpuRuleId]);
+  });
+
+  runDb('drops a metric condition carrying no metric name', async () => {
+    const { alertLinkId } = await createPolicyWithAlertLink('Policy — metric-less rule');
+    const metriclessRuleId = await insertRule(alertLinkId, 'Unnamed metric', METRICLESS_CONDITIONS, 0);
+    const cpuRuleId = await insertRule(alertLinkId, 'CPU high', CPU_CONDITIONS, 1);
+
+    await runMigration();
+
+    expect(await ruleIdsFor([metriclessRuleId, cpuRuleId])).toEqual([cpuRuleId]);
+  });
+
+  runDb('leaves a never-firing rule that alerts reference, and says so', async () => {
+    const db = getTestDb();
+    const { orgId, alertLinkId } = await createPolicyWithAlertLink('Policy — referenced network rule');
+    const site = await createSite({ orgId });
+    const [device] = await db.insert(devices).values({
+      orgId,
+      siteId: site!.id,
+      agentId: `agent-neverfiring-${Date.now()}`,
+      hostname: 'neverfiring-host',
+      osType: 'windows',
+      osVersion: '11',
+      architecture: 'x64',
+      agentVersion: '1.0.0',
+    }).returning({ id: devices.id });
+
+    const networkRuleId = await insertRule(alertLinkId, 'Network usage high', NETWORK_CONDITIONS, 0);
+    await db.insert(alerts).values({
+      deviceId: device!.id,
+      orgId,
+      configPolicyId: networkRuleId,
+      configItemName: 'Network usage high',
+      severity: 'medium',
+      title: 'Network usage high on neverfiring-host',
+    });
+
+    const warnings = await runMigrationCapturingWarnings();
+
+    // Alert provenance wins over tidiness: alerts.config_policy_id is a plain
+    // uuid with no FK, so deleting the rule would orphan the alert's origin.
+    expect(await ruleIdsFor([networkRuleId])).toEqual([networkRuleId]);
+    // The warning must say plainly that the row is NOT deleted — an operator
+    // reading "left in place ... moved" (the wording this replaced) cannot tell
+    // whether the rule still exists.
+    expect(
+      warnings.some((w) => w.includes('LEFT IN PLACE') && /\bNOT deleted\b/.test(w)),
+      `expected a LEFT IN PLACE warning, got: ${JSON.stringify(warnings)}`,
+    ).toBe(true);
+    // And it must not be miscounted as dropped.
+    expect(warnings.some((w) => w.includes('Network usage high') && w.includes('dropped'))).toBe(false);
+  });
+
+  runDb('leaves a multi-condition rule intact even when one condition names a bad metric', async () => {
+    const { alertLinkId } = await createPolicyWithAlertLink('Policy — mixed conditions');
+    const mixedRuleId = await insertRule(alertLinkId, 'CPU or network', MIXED_CONDITIONS, 0);
+
+    await runMigration();
+
+    expect(await ruleIdsFor([mixedRuleId])).toEqual([mixedRuleId]);
+    // Conditions untouched — the CPU half still fires, and AlertRuleTab flags
+    // the network half for the tech rather than the migration guessing.
+    const [row] = await getTestDb()
+      .select({ conditions: configPolicyAlertRules.conditions })
+      .from(configPolicyAlertRules)
+      .where(eq(configPolicyAlertRules.id, mixedRuleId));
+    expect(row!.conditions).toEqual(MIXED_CONDITIONS);
+  });
+
+  runDb('rebuilds the inline_settings items mirror for links that lost rows', async () => {
+    const staleMirror = {
+      items: [
+        { name: 'Network usage high', severity: 'medium', conditions: NETWORK_CONDITIONS, sortOrder: 0 },
+        { name: 'CPU high', severity: 'medium', conditions: CPU_CONDITIONS, sortOrder: 1 },
+      ],
+    };
+    const { alertLinkId } = await createPolicyWithAlertLink('Policy — mirror rebuild', staleMirror);
+    await insertRule(alertLinkId, 'Network usage high', NETWORK_CONDITIONS, 0);
+    const cpuRuleId = await insertRule(alertLinkId, 'CPU high', CPU_CONDITIONS, 1);
+
+    await runMigration();
+
+    const link = await linkById(alertLinkId);
+    const items = mirrorItems(link!.inlineSettings);
+    expect(items.map((i) => i.name)).toEqual(['CPU high']);
+    expect(items[0]).toMatchObject({
+      name: 'CPU high',
+      severity: 'medium',
+      conditions: CPU_CONDITIONS,
+      sortOrder: 1,
+    });
+    expect(await ruleIdsFor([cpuRuleId])).toEqual([cpuRuleId]);
+  });
+
+  runDb('empties the mirror when the link loses its only rule', async () => {
+    // The grouped `GROUP BY feature_link_id` form of the rebuild would skip this
+    // link entirely — no rows left to group — and strand the dead rule in the
+    // mirror forever. This is the case that forces the per-link correlated form.
+    const staleMirror = {
+      items: [{ name: 'Network usage high', severity: 'medium', conditions: NETWORK_CONDITIONS, sortOrder: 0 }],
+    };
+    const { alertLinkId } = await createPolicyWithAlertLink('Policy — sole dead rule', staleMirror);
+    await insertRule(alertLinkId, 'Network usage high', NETWORK_CONDITIONS, 0);
+
+    await runMigration();
+
+    const link = await linkById(alertLinkId);
+    expect(link!.inlineSettings).toEqual({ items: [] });
+  });
+
+  runDb('is idempotent — second run changes zero rows, including updated_at', async () => {
+    const db = getTestDb();
+    const { policyId, alertLinkId } = await createPolicyWithAlertLink('Policy — idempotency');
+    await insertRule(alertLinkId, 'Network usage high', NETWORK_CONDITIONS, 0);
+    await insertRule(alertLinkId, 'CPU high', CPU_CONDITIONS, 1);
+
+    await runMigration();
+
+    const snapshot = async () => ({
+      links: await db
+        .select()
+        .from(configPolicyFeatureLinks)
+        .where(eq(configPolicyFeatureLinks.configPolicyId, policyId))
+        .orderBy(asc(configPolicyFeatureLinks.id)),
+      rules: await db
+        .select()
+        .from(configPolicyAlertRules)
+        .where(eq(configPolicyAlertRules.featureLinkId, alertLinkId))
+        .orderBy(asc(configPolicyAlertRules.id)),
+    });
+
+    const before = await snapshot();
+    await runMigration();
+    const after = await snapshot();
+
+    // Deep equality includes updated_at: a replay that rewrote an identical
+    // mirror would still bump it (and the partner-export watermark), which is
+    // what the empty affected-links guard and IS DISTINCT FROM exist to prevent.
+    expect(after).toEqual(before);
+  });
+
+  runDb('leaves an already-clean policy untouched', async () => {
+    const { alertLinkId } = await createPolicyWithAlertLink('Policy — already clean', { items: [] });
+    await insertRule(alertLinkId, 'CPU high', CPU_CONDITIONS, 0);
+
+    // Deliberately stale mirror on a policy with nothing to drop: the migration
+    // must not "helpfully" rebuild it, because it never lost a row.
+    const before = await linkById(alertLinkId);
+    await runMigration();
+    const after = await linkById(alertLinkId);
+    expect(after).toEqual(before);
+  });
+});

--- a/apps/api/src/lib/zodIssues.test.ts
+++ b/apps/api/src/lib/zodIssues.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  describeFirstZodIssue,
+  flattenZodIssues,
+  flattenedZodDetails,
+  zodValidationErrorBody,
+} from './zodIssues';
+
+// A plain (non-discriminated) union nested two levels deep — the exact shape
+// that produced the bare "Invalid input" on the alert-rule write path.
+const memberA = z.object({ type: z.literal('a'), value: z.number() });
+const memberB = z.object({ type: z.literal('b'), label: z.string(), extra: z.string() });
+const nested = z.object({
+  items: z.array(z.object({ conditions: z.array(z.union([memberA, memberB])) })),
+});
+
+describe('flattenZodIssues', () => {
+  it('leaves non-union issues untouched', () => {
+    const error = z.object({ n: z.number() }).safeParse({ n: 'x' }).error!;
+    const flat = flattenZodIssues(error.issues);
+    expect(flat).toHaveLength(1);
+    expect(flat[0]!.path).toEqual(['n']);
+    expect(flat[0]!.message).toContain('expected number');
+  });
+
+  it('replaces an invalid_union with the sub-issues of the nearest-matching option', () => {
+    const error = nested.safeParse({ items: [{ conditions: [{ type: 'a', value: 'nope' }] }] }).error!;
+    // Zod's own view: one issue, no useful message.
+    expect(error.issues).toHaveLength(1);
+    expect(error.issues[0]!.message).toBe('Invalid input');
+
+    const flat = flattenZodIssues(error.issues);
+    // Option A disagrees about ONE field; option B disagrees about three, so A
+    // is the better explanation.
+    expect(flat).toHaveLength(1);
+    expect(flat[0]!.path).toEqual(['items', 0, 'conditions', 0, 'value']);
+    expect(flat[0]!.message).toContain('expected number');
+  });
+
+  it('re-roots sub-issue paths onto the union path so the reported path is absolute', () => {
+    const error = nested.safeParse({ items: [{ conditions: [{ type: 'b', label: 'x' }] }] }).error!;
+    const flat = flattenZodIssues(error.issues);
+    expect(flat.map((i) => i.path.join('.'))).toContain('items.0.conditions.0.extra');
+  });
+
+  it('keeps the discriminator message when a discriminated union matches no option', () => {
+    // `errors` is empty in this case, and the issue's own message names every
+    // accepted value — strictly more useful than any sub-issue would be.
+    const du = z.discriminatedUnion('type', [memberA, memberB]);
+    const error = du.safeParse({ type: 'zzz' }).error!;
+    const flat = flattenZodIssues(error.issues);
+    expect(flat).toHaveLength(1);
+    expect(flat[0]!.message).toMatch(/'a'|"a"/);
+  });
+});
+
+describe('flattenedZodDetails', () => {
+  it('keys fieldErrors by the full dotted path, not just the first segment', () => {
+    const error = nested.safeParse({ items: [{ conditions: [{ type: 'a', value: 'nope' }] }] }).error!;
+    const details = flattenedZodDetails(flattenZodIssues(error.issues));
+    expect(Object.keys(details.fieldErrors)).toEqual(['items.0.conditions.0.value']);
+    expect(details.formErrors).toEqual([]);
+  });
+
+  it('routes path-less issues to formErrors', () => {
+    const schema = z.object({ a: z.number() }).refine(() => false, { message: 'whole object is wrong' });
+    const details = flattenedZodDetails(flattenZodIssues(schema.safeParse({ a: 1 }).error!.issues));
+    expect(details.formErrors).toEqual(['whole object is wrong']);
+  });
+});
+
+describe('zodValidationErrorBody', () => {
+  it('returns error/details/issues all derived from the flattened set', () => {
+    const error = nested.safeParse({ items: [{ conditions: [{ type: 'a', value: 'nope' }] }] }).error!;
+    const body = zodValidationErrorBody('Invalid alert_rule settings', error);
+    expect(body.error).toBe('Invalid alert_rule settings');
+    expect(body.issues[0]!.path).toEqual(['items', 0, 'conditions', 0, 'value']);
+    expect(JSON.stringify(body.details)).not.toContain('"Invalid input"');
+  });
+});
+
+describe('describeFirstZodIssue', () => {
+  it('prefixes the dotted path onto the most specific message', () => {
+    const error = nested.safeParse({ items: [{ conditions: [{ type: 'a', value: 'nope' }] }] }).error!;
+    expect(describeFirstZodIssue(error)).toMatch(/^items\.0\.conditions\.0\.value: /);
+  });
+
+  it('returns null when there are no issues at all', () => {
+    expect(describeFirstZodIssue({ issues: [] })).toBeNull();
+  });
+});

--- a/apps/api/src/lib/zodIssues.ts
+++ b/apps/api/src/lib/zodIssues.ts
@@ -1,0 +1,145 @@
+/**
+ * Zod issue flattening for user- and model-facing validation errors.
+ *
+ * A Zod `union` that fails reports ONE issue: `{ code: 'invalid_union',
+ * message: 'Invalid input' }`, with the per-option sub-issues tucked away in
+ * `issue.errors` (an array of issue arrays, one per union member). Anything
+ * that renders `issues[0].message` — the web client's extractApiError, the AI
+ * tool's error string — therefore shows a bare "Invalid input" and the caller
+ * has no idea which field or value was wrong.
+ *
+ * `flattenZodIssues` replaces each `invalid_union` with the sub-issues of the
+ * option the payload most nearly matched, re-rooted onto the union's own path
+ * so the reported path is absolute (e.g. `items.0.conditions.0.metric`).
+ *
+ * Used by the configuration-policy feature-link HTTP routes and the
+ * `manage_policy_feature_link` AI tool — the two surfaces that validate
+ * alert-rule condition payloads, whose conditions are a union several levels
+ * deep inside `items[]`.
+ */
+
+/** Structural shape of a Zod 4 issue; avoids depending on zod's internal types. */
+export type ZodIssueLike = {
+  code?: string;
+  path?: ReadonlyArray<PropertyKey>;
+  message?: string;
+  /** Present on `invalid_union`: one sub-issue array per union option. */
+  errors?: ReadonlyArray<ReadonlyArray<ZodIssueLike>>;
+};
+
+export type FlatZodIssue = ZodIssueLike & { path: PropertyKey[]; message: string };
+
+/**
+ * Zod's placeholder message when it has nothing specific to say. Anything else
+ * — including "Invalid input: expected number, received string" — names the
+ * actual problem and is preferred.
+ */
+const GENERIC_MESSAGE = 'Invalid input';
+
+function isGeneric(issue: ZodIssueLike): boolean {
+  return (issue.message ?? '').trim() === GENERIC_MESSAGE;
+}
+
+function maxPathDepth(issues: readonly ZodIssueLike[]): number {
+  return issues.reduce((deepest, i) => Math.max(deepest, i.path?.length ?? 0), 0);
+}
+
+/**
+ * Rank two candidate option groups; returns true when `a` is the better
+ * explanation of the failure.
+ *
+ * 1. Fewest issues wins — the option with one complaint matched the payload's
+ *    shape and disagreed about one field; the option with four is a different
+ *    shape entirely and its complaints are noise.
+ * 2. Then deepest path — a nested, specific field beats a top-level one.
+ * 3. Then a non-generic message beats "Invalid input".
+ */
+function isBetterGroup(a: readonly ZodIssueLike[], b: readonly ZodIssueLike[]): boolean {
+  if (a.length !== b.length) return a.length < b.length;
+  const depthA = maxPathDepth(a);
+  const depthB = maxPathDepth(b);
+  if (depthA !== depthB) return depthA > depthB;
+  return a.every((i) => !isGeneric(i)) && b.some(isGeneric);
+}
+
+/**
+ * Flatten `invalid_union` issues into the concrete sub-issues they hide.
+ * Non-union issues pass through unchanged. Recurses, so a union nested inside
+ * a union member is flattened too.
+ */
+export function flattenZodIssues(issues: readonly ZodIssueLike[]): FlatZodIssue[] {
+  const out: FlatZodIssue[] = [];
+  for (const issue of issues) {
+    const prefix = [...(issue.path ?? [])];
+    const groups = (issue.code === 'invalid_union' && Array.isArray(issue.errors) ? issue.errors : [])
+      .map((group) => flattenZodIssues(group ?? []))
+      .filter((group) => group.length > 0);
+
+    if (groups.length === 0) {
+      // Not a union, or a DISCRIMINATED union whose discriminator matched no
+      // option — the latter carries an empty `errors` but a message that names
+      // every accepted value, which is exactly what we want to surface.
+      out.push({ ...issue, path: prefix, message: issue.message ?? GENERIC_MESSAGE });
+      continue;
+    }
+
+    const best = groups.reduce((winner, group) => (isBetterGroup(group, winner) ? group : winner));
+    for (const sub of best) {
+      out.push({ ...sub, path: [...prefix, ...sub.path] });
+    }
+  }
+  return out;
+}
+
+/** `path` rendered the way callers read it: `items.0.conditions.0.metric`. */
+export function formatIssuePath(path: ReadonlyArray<PropertyKey>): string {
+  return path.map((segment) => String(segment)).join('.');
+}
+
+/**
+ * A `{ formErrors, fieldErrors }` payload in the same shape as
+ * `ZodError.flatten()`, but built from FLATTENED issues and keyed by the full
+ * dotted path rather than only the first path segment. `flatten()` buckets
+ * everything nested under `items` into `fieldErrors.items`, which for an
+ * alert-rule payload means every message reads "Invalid input".
+ */
+export function flattenedZodDetails(issues: readonly FlatZodIssue[]): {
+  formErrors: string[];
+  fieldErrors: Record<string, string[]>;
+} {
+  const formErrors: string[] = [];
+  const fieldErrors: Record<string, string[]> = {};
+  for (const issue of issues) {
+    if (issue.path.length === 0) {
+      formErrors.push(issue.message);
+      continue;
+    }
+    const key = formatIssuePath(issue.path);
+    (fieldErrors[key] ??= []).push(issue.message);
+  }
+  return { formErrors, fieldErrors };
+}
+
+/**
+ * Build the JSON body every feature-link validation 400 returns. `issues` and
+ * `details` are both derived from the flattened set so the web client renders
+ * the specific message whichever of the two it happens to read first.
+ */
+export function zodValidationErrorBody(
+  label: string,
+  error: { issues: readonly ZodIssueLike[] }
+): { error: string; details: ReturnType<typeof flattenedZodDetails>; issues: FlatZodIssue[] } {
+  const issues = flattenZodIssues(error.issues);
+  return { error: label, details: flattenedZodDetails(issues), issues };
+}
+
+/**
+ * One-line description of the first (most specific) issue, prefixed with its
+ * path. Used by the AI tool surface, which returns a single error string.
+ */
+export function describeFirstZodIssue(error: { issues: readonly ZodIssueLike[] }): string | null {
+  const [first] = flattenZodIssues(error.issues);
+  if (!first) return null;
+  const path = first.path.length > 0 ? `${formatIssuePath(first.path)}: ` : '';
+  return `${path}${first.message}`;
+}

--- a/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.test.ts
@@ -824,6 +824,69 @@ describe('featureLinks routes', () => {
       expect(updateFeatureLinkMock).not.toHaveBeenCalled();
     });
 
+    // Union flattening (lib/zodIssues.ts). Conditions are a union nested inside
+    // items[], so Zod's own report is a single `invalid_union` whose message is
+    // the useless string "Invalid input" — the tech saw that in a toast with no
+    // hint which field was wrong.
+    it('POST alert_rule with an unknown metric → 400 naming the field and the accepted metrics', async () => {
+      getConfigPolicyMock.mockResolvedValue(STUB_POLICY);
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'alert_rule',
+          inlineSettings: { items: [{ name: 'Bogus', conditions: [{ type: 'metric', metric: 'bogus', operator: 'gt', value: 80 }] }] },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      const issuesText = JSON.stringify(body.issues);
+      expect(issuesText).toContain('cpu');
+      expect(JSON.parse(issuesText).some((i: any) => i.path.join('.') === 'items.0.conditions.0.metric')).toBe(true);
+      // `details` is derived from the same flattened set, so whichever the web
+      // client renders first it never gets the bare placeholder.
+      expect(JSON.stringify(body.details)).toContain('items.0.conditions.0.metric');
+      expect(JSON.stringify(body.details)).not.toMatch(/"Invalid input"/);
+      expect(addFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('PATCH alert_rule with an unknown metric → 400 naming the field', async () => {
+      getConfigPolicyMock.mockResolvedValue({
+        ...STUB_POLICY,
+        featureLinks: [{ id: LINK_ID, featureType: 'alert_rule' }],
+      });
+      const res = await app.request(`/${POLICY_ID}/features/${LINK_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          inlineSettings: { items: [{ name: 'Bogus', conditions: [{ type: 'metric', metric: 'bogus', operator: 'gt', value: 80 }] }] },
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect((body.issues as any[]).some((i) => i.path.join('.') === 'items.0.conditions.0.metric')).toBe(true);
+      expect(JSON.stringify(body.details)).toContain('items.0.conditions.0.metric');
+      expect(updateFeatureLinkMock).not.toHaveBeenCalled();
+    });
+
+    it('POST alert_rule accepts `threshold` as a type alias and canonicalizes it to metric', async () => {
+      getConfigPolicyMock.mockResolvedValue(STUB_POLICY);
+      const res = await app.request(`/${POLICY_ID}/features`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureType: 'alert_rule',
+          inlineSettings: { items: [{ name: 'Legacy threshold', conditions: [{ type: 'threshold', metric: 'cpu', operator: 'gt', value: 90 }] }] },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const [, , , inlineSettings] = addFeatureLinkMock.mock.calls[0] as any[];
+      expect(inlineSettings.items[0].conditions[0].type).toBe('metric');
+    });
+
     it('PATCH monitoring with non-empty alertRules → 400 naming the Alerts feature', async () => {
       getConfigPolicyMock.mockResolvedValue({
         ...STUB_POLICY,

--- a/apps/api/src/routes/configurationPolicies/featureLinks.ts
+++ b/apps/api/src/routes/configurationPolicies/featureLinks.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
+import { zodValidationErrorBody } from '../../lib/zodIssues';
 import type { AuthContext } from '../../middleware/auth';
 import { hasSatisfiedMfa, requirePermission, requireScope } from '../../middleware/auth';
 import {
@@ -130,7 +131,7 @@ featureLinkRoutes.post(
       if (!parsed.success) {
         // `issues` included so the web client (extractApiError) can render the messages.
         return c.json(
-          { error: 'Invalid patch settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          zodValidationErrorBody('Invalid patch settings', parsed.error),
           400
         );
       }
@@ -145,7 +146,7 @@ featureLinkRoutes.post(
       const parsed = schema.safeParse(data.inlineSettings);
       if (!parsed.success) {
         return c.json(
-          { error: 'Invalid backup settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          zodValidationErrorBody('Invalid backup settings', parsed.error),
           400
         );
       }
@@ -156,7 +157,7 @@ featureLinkRoutes.post(
       const parsed = pamInlineSettingsSchema.safeParse(data.inlineSettings);
       if (!parsed.success) {
         return c.json(
-          { error: 'Invalid pam settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          zodValidationErrorBody('Invalid pam settings', parsed.error),
           400
         );
       }
@@ -167,7 +168,7 @@ featureLinkRoutes.post(
       const parsed = remoteAccessInlineSettingsSchema.safeParse(data.inlineSettings);
       if (!parsed.success) {
         return c.json(
-          { error: 'Invalid remote access settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          zodValidationErrorBody('Invalid remote access settings', parsed.error),
           400
         );
       }
@@ -178,7 +179,7 @@ featureLinkRoutes.post(
       const parsed = onedriveHelperInlineSettingsSchema.safeParse(data.inlineSettings);
       if (!parsed.success) {
         return c.json(
-          { error: 'Invalid onedrive_helper settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          zodValidationErrorBody('Invalid onedrive_helper settings', parsed.error),
           400
         );
       }
@@ -198,7 +199,7 @@ featureLinkRoutes.post(
       const parsed = alertRuleInlineSettingsSchema.safeParse(data.inlineSettings);
       if (!parsed.success) {
         return c.json(
-          { error: 'Invalid alert_rule settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          zodValidationErrorBody('Invalid alert_rule settings', parsed.error),
           400
         );
       }
@@ -209,7 +210,7 @@ featureLinkRoutes.post(
       const parsed = monitoringInlineSettingsSchema.safeParse(data.inlineSettings);
       if (!parsed.success) {
         return c.json(
-          { error: 'Invalid monitoring settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+          zodValidationErrorBody('Invalid monitoring settings', parsed.error),
           400
         );
       }
@@ -297,7 +298,7 @@ featureLinkRoutes.patch(
         const parsed = patchInlineSettingsSchema.safeParse(data.inlineSettings ?? {});
         if (!parsed.success) {
           return c.json(
-            { error: 'Invalid patch settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            zodValidationErrorBody('Invalid patch settings', parsed.error),
             400
           );
         }
@@ -317,7 +318,7 @@ featureLinkRoutes.patch(
         const parsed = schema.safeParse(data.inlineSettings);
         if (!parsed.success) {
           return c.json(
-            { error: 'Invalid backup settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            zodValidationErrorBody('Invalid backup settings', parsed.error),
             400
           );
         }
@@ -327,7 +328,7 @@ featureLinkRoutes.patch(
         const parsed = pamInlineSettingsSchema.safeParse(data.inlineSettings);
         if (!parsed.success) {
           return c.json(
-            { error: 'Invalid pam settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            zodValidationErrorBody('Invalid pam settings', parsed.error),
             400
           );
         }
@@ -337,7 +338,7 @@ featureLinkRoutes.patch(
         const parsed = remoteAccessInlineSettingsSchema.safeParse(data.inlineSettings);
         if (!parsed.success) {
           return c.json(
-            { error: 'Invalid remote access settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            zodValidationErrorBody('Invalid remote access settings', parsed.error),
             400
           );
         }
@@ -347,7 +348,7 @@ featureLinkRoutes.patch(
         const parsed = onedriveHelperInlineSettingsSchema.safeParse(data.inlineSettings);
         if (!parsed.success) {
           return c.json(
-            { error: 'Invalid onedrive_helper settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            zodValidationErrorBody('Invalid onedrive_helper settings', parsed.error),
             400
           );
         }
@@ -363,7 +364,7 @@ featureLinkRoutes.patch(
         const parsed = alertRuleInlineSettingsSchema.safeParse(data.inlineSettings);
         if (!parsed.success) {
           return c.json(
-            { error: 'Invalid alert_rule settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            zodValidationErrorBody('Invalid alert_rule settings', parsed.error),
             400
           );
         }
@@ -373,7 +374,7 @@ featureLinkRoutes.patch(
         const parsed = monitoringInlineSettingsSchema.safeParse(data.inlineSettings);
         if (!parsed.success) {
           return c.json(
-            { error: 'Invalid monitoring settings', details: parsed.error.flatten(), issues: parsed.error.issues },
+            zodValidationErrorBody('Invalid monitoring settings', parsed.error),
             400
           );
         }

--- a/apps/api/src/services/aiToolsConfigPolicy.test.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.test.ts
@@ -715,6 +715,81 @@ describe('configuration policy AI tools', () => {
     expect(vi.mocked(addFeatureLink)).toHaveBeenCalledWith(POLICY_ID, 'monitoring', null, raw);
   });
 
+  // Condition payloads are a UNION nested inside items[]. Zod reports a union
+  // failure as one `invalid_union` issue whose own message is a bare "Invalid
+  // input"; the model needs the offending field and value named or it cannot
+  // self-correct. describeFirstZodIssue unwraps it.
+  it('names the offending metric value on an invalid alert_rule condition rather than "Invalid input"', async () => {
+    vi.mocked(getConfigPolicy).mockResolvedValue({
+      id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Org policy',
+    } as any);
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('manage_policy_feature_link')!.handler({
+      action: 'add',
+      configPolicyId: POLICY_ID,
+      featureType: 'alert_rule',
+      inlineSettings: { items: [{ name: 'Bogus', conditions: [{ type: 'metric', metric: 'bogus', operator: 'gt', value: 80 }] }] },
+    }, makeAuth());
+
+    const { error } = JSON.parse(output);
+    expect(error).toContain('items.0.conditions.0.metric');
+    expect(error).toContain('cpu');
+    expect(error).not.toMatch(/— Invalid input$/);
+    expect(vi.mocked(addFeatureLink)).not.toHaveBeenCalled();
+  });
+
+  // The `update` action re-derives featureType from the stored link, so its
+  // validation is a SEPARATE code path from `add` — these two mirror the
+  // add-action cases above.
+  it('rejects an invalid alert_rule payload on the UPDATE action with a specific message', async () => {
+    vi.mocked(getConfigPolicy).mockResolvedValue({
+      id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Org policy',
+    } as any);
+    mockSelectRows([{ featureType: 'alert_rule' }]);
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('manage_policy_feature_link')!.handler({
+      action: 'update',
+      configPolicyId: POLICY_ID,
+      featureLinkId: 'link-1',
+      inlineSettings: { items: [{ name: 'Bogus', conditions: [{ type: 'metric', metric: 'bogus', operator: 'gt', value: 80 }] }] },
+    }, makeAuth());
+
+    const { error } = JSON.parse(output);
+    expect(error).toContain('alert_rule');
+    expect(error).toContain('items.0.conditions.0.metric');
+    expect(error).not.toBe(GENERIC_TOOL_ERROR_MESSAGE);
+    expect(vi.mocked(updateFeatureLink)).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the monitoring write-barrier pointer on the UPDATE action too', async () => {
+    vi.mocked(getConfigPolicy).mockResolvedValue({
+      id: POLICY_ID, orgId: ORG_ID, partnerId: null, name: 'Org policy',
+    } as any);
+    mockSelectRows([{ featureType: 'monitoring' }]);
+
+    const tools = new Map<string, any>();
+    registerConfigPolicyTools(tools);
+
+    const output = await tools.get('manage_policy_feature_link')!.handler({
+      action: 'update',
+      configPolicyId: POLICY_ID,
+      featureLinkId: 'link-1',
+      inlineSettings: {
+        watches: [],
+        alertRules: [{ name: 'High CPU', conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 80 }] }],
+      },
+    }, makeAuth());
+
+    expect(JSON.parse(output).error).toContain('moved to the Alerts feature');
+    expect(vi.mocked(updateFeatureLink)).not.toHaveBeenCalled();
+  });
+
   it('manage_configuration_policy create ownerScope=partner is denied without partner-wide capability', async () => {
     canManagePartnerWidePoliciesMock.mockReturnValue(false);
 

--- a/apps/api/src/services/aiToolsConfigPolicy.ts
+++ b/apps/api/src/services/aiToolsConfigPolicy.ts
@@ -10,6 +10,7 @@ import {
   onedriveHelperInlineSettingsSchema,
 } from '@breeze/shared/validators';
 import { sanitizeThrownToolError } from './aiToolErrors';
+import { describeFirstZodIssue } from '../lib/zodIssues';
 import {
   resolveEffectiveConfig,
   previewEffectiveConfig,
@@ -80,12 +81,13 @@ function validateInlineSettingsForFeature(
 
   const parsed = entry.schema.safeParse(raw);
   if (!parsed.success) {
-    const first = parsed.error.issues[0];
-    if (!first) return { error: `Invalid ${featureType} inline settings.` };
-    // Prefix the field path: alert-rule conditions nest several levels deep, and
-    // a bare "Invalid input" tells the model nothing about which one to fix.
-    const path = Array.isArray(first.path) && first.path.length > 0 ? `${first.path.join('.')}: ` : '';
-    return { error: `Invalid ${featureType} inline settings — ${path}${first.message}` };
+    // describeFirstZodIssue prefixes the field path AND unwraps `invalid_union`
+    // into the offending sub-issue: alert-rule conditions are a union several
+    // levels deep inside items[], and the raw union issue is a bare
+    // "Invalid input" that tells the model nothing about what to fix.
+    const described = describeFirstZodIssue(parsed.error);
+    if (!described) return { error: `Invalid ${featureType} inline settings.` };
+    return { error: `Invalid ${featureType} inline settings — ${described}` };
   }
   return { value: entry.normalize ? parsed.data : raw };
 }
@@ -703,8 +705,8 @@ export function registerConfigPolicyTools(aiTools: Map<string, AiTool>): void {
 
 Inline settings shapes by feature type:
 - patch: { sources: ["os","third_party"], autoApprove: true, autoApproveSeverities: ["critical","important"], scheduleFrequency: "daily"|"weekly"|"monthly", scheduleTime: "02:00", scheduleDayOfWeek?: "tue", scheduleDayOfMonth?: 1, rebootPolicy: "never"|"if_required"|"always"|"maintenance_window" }
-- alert_rule: server-evaluated rules — CPU/RAM/disk thresholds, offline detection, and event log alerts. { items: [{ name, severity: "critical"|"high"|"medium"|"low"|"info" (default "medium"), conditions: 1-10 of [ { type: "metric", metric: "cpu"|"ram"|"memory"|"disk" (aliases "cpuPercent"/"ramPercent"/"diskPercent" and "processCount"/"processes" are also accepted; prefer the short names), operator: "gt"|"gte"|"lt"|"lte"|"eq"|"neq", value: number, durationMinutes?: number (1-10080; sustained window the samples are averaged over, default 1 minute) } | { type: "offline", durationMinutes?: number } | { type: "event_log", category: "security"|"hardware"|"application"|"system", level: "warning"|"error"|"critical", sourcePattern?: string (case-insensitive substring match, NOT a regex), messagePattern?: string, countThreshold?: number (1-10000, default 1), windowMinutes?: number (1-1440, default 15) } ], cooldownMinutes?: number (default 5), autoResolve?: boolean (default false), autoResolveConditions?: same condition shapes or null, titleTemplate?: string, messageTemplate?: string, sortOrder?: number }] } — 'custom' conditions and the extended types (bandwidth_high, disk_io_high, network_errors, patch_compliance, cert_expiry) are rejected on write. When the same threshold is configured in policies at different levels (e.g. org and site), the CLOSEST level to the device wins.
-- monitoring: agent-side service/process watches with auto-restart, delivered via heartbeat — NOT alerting. { checkIntervalSeconds: 60, watches: [{ watchType: "service"|"process", name: "wuauserv", displayName?: "Windows Update", enabled: true, alertOnStop: true, alertAfterConsecutiveFailures: 2, alertSeverity: "critical"|"high"|"medium"|"low"|"info", cpuThresholdPercent?: 90, memoryThresholdMb?: 500, thresholdDurationSeconds: 300, autoRestart: false, maxRestartAttempts: 3, restartCooldownSeconds: 300 }] } — inline settings carry ONLY checkIntervalSeconds/watches now; metric alert rules and event log alerts moved to the alert_rule feature. Sending a non-empty 'alertRules' or 'eventLogAlerts' array is rejected with an error directing you to the alert_rule feature type instead.
+- alert_rule: server-evaluated rules — CPU/RAM/disk thresholds, offline detection, and event log alerts. { items: [{ name, severity: "critical"|"high"|"medium"|"low"|"info" (default "medium"), conditions: 1-10 of [ { type: "metric" ("threshold" is accepted as an alias and canonicalized to "metric"), metric: "cpu"|"ram"|"disk"|"processCount" (these four are canonical; the aliases "cpuPercent"->cpu, "ramPercent"/"memory"->ram, "diskPercent"->disk, "processes"->processCount are accepted but map onto them — prefer the canonical names), operator: "gt"|"gte"|"lt"|"lte"|"eq"|"neq", value: number (a PERCENTAGE 0-100 for cpu/ram/disk; a plain count for processCount), durationMinutes?: number (1-10080; sustained window the samples are averaged over, default 1 minute) } | { type: "offline", durationMinutes?: number } | { type: "event_log", category: "security"|"hardware"|"application"|"system", level: "warning"|"error"|"critical" (matches this level and above), sourcePattern?: string (case-insensitive substring match, NOT a regex), messagePattern?: string, countThreshold?: number (1-10000, default 1), windowMinutes?: number (1-1440, default 15) } ], cooldownMinutes?: number (default 5), autoResolve?: boolean (default false), autoResolveConditions?: same condition shapes or null, titleTemplate?: string, messageTemplate?: string, sortOrder?: number }] } — 'custom' conditions and the extended types (bandwidth_high, disk_io_high, network_errors, patch_compliance, cert_expiry) are rejected on write. When the same threshold is configured in policies at different levels (e.g. org and site), the CLOSEST level to the device wins.
+- monitoring: agent-side service/process watches with auto-restart, delivered via heartbeat — not evaluated by the alert engine; watch failures are recorded and shown in the UI but do not currently raise alerts (alertOnStop/alertSeverity are stored but unused at runtime). { checkIntervalSeconds: 60, watches: [{ watchType: "service"|"process", name: "wuauserv", displayName?: "Windows Update", enabled: true, alertOnStop: true, alertAfterConsecutiveFailures: 2, alertSeverity: "critical"|"high"|"medium"|"low"|"info", cpuThresholdPercent?: 90, memoryThresholdMb?: 500, thresholdDurationSeconds: 300, autoRestart: false, maxRestartAttempts: 3, restartCooldownSeconds: 300 }] } — inline settings carry ONLY checkIntervalSeconds/watches now; metric alert rules and event log alerts moved to the alert_rule feature. Sending a non-empty 'alertRules' or 'eventLogAlerts' array is rejected with an error directing you to the alert_rule feature type instead.
 - maintenance: { recurrence: "once"|"daily"|"weekly"|"monthly", windowStart?: "ISO-8601 (for once)", durationHours: 1-72, timezone: "America/New_York", suppressAlerts: true, suppressPatching: true, suppressAutomations: false, suppressScripts: false, notifyBeforeMinutes?: 15, notifyOnStart: true, notifyOnEnd: true }
 - automation: { items: [{ name, enabled: true, triggerType: "schedule"|"event"|"manual", cronExpression?: "0 2 * * *", timezone?: "America/New_York", eventType?: "device.offline"|"alert.triggered"|"compliance.failed"|"patch.available", actions: [{ type: "run_script"|"send_notification"|"create_alert"|"execute_command", scriptId?|channelId?|severity?|message?|command? }], onFailure: "stop"|"continue"|"notify" }] }
 - event_log: { retentionDays: 30, maxEventsPerCycle: 100, collectCategories: ["security","hardware","application","system"], minimumLevel: "info"|"warning"|"error"|"critical", collectionIntervalMinutes: 15, rateLimitPerHour: 12000 }

--- a/apps/api/src/services/configurationPolicy.test.ts
+++ b/apps/api/src/services/configurationPolicy.test.ts
@@ -26,7 +26,7 @@ import {
   PartnerWideWriteDeniedError,
 } from './configurationPolicy';
 import { db } from '../db';
-import { configPolicyAlertRules } from '../db/schema';
+import { configPolicyAlertRules, configPolicyMonitoringSettings } from '../db/schema';
 
 // Chain for `db.select().from(...).where(...)` awaited directly (links query)
 function selectWhereRows(rows: unknown[]) {
@@ -514,6 +514,128 @@ describe('addFeatureLink — alert_rule inlineSettings service-layer validation'
     });
 
     expect(normalizedRowValues[0].conditions).toEqual([{ type: 'offline', durationMinutes: 10 }]);
+  });
+});
+
+// ============================================================
+// updateFeatureLink PATCH decompose — the replace half of the write path.
+// addFeatureLink only ever inserts; the UPDATE route replaces normalized rows
+// with delete-then-decompose, which is where both a data-loss bug (deleting
+// rows a feature no longer owns) and a torn-state bug (deleting before the
+// payload is known to be valid) can hide.
+// ============================================================
+describe('updateFeatureLink — normalized row replacement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * tx mock for updateFeatureLink: select→existing link, update→returning,
+   * plus recording every `delete(table)` and `insert(table).values(rows)` in
+   * call order so ordering assertions are possible.
+   */
+  function updateTx(existing: Record<string, unknown>) {
+    const calls: Array<{ op: 'delete' | 'insert'; table: unknown; values?: any }> = [];
+    const tx: any = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ limit: vi.fn(() => Promise.resolve([existing])) })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn(() => ({
+            returning: vi.fn(() => Promise.resolve([{ ...existing }])),
+          })),
+        })),
+      })),
+      delete: vi.fn((table: unknown) => {
+        calls.push({ op: 'delete', table });
+        return { where: vi.fn(() => Promise.resolve([])) };
+      }),
+      insert: vi.fn((table: unknown) => ({
+        values: vi.fn((values: any) => {
+          calls.push({ op: 'insert', table, values });
+          // Awaitable AND `.returning()`-able: monitoring's decompose chains
+          // `.returning()` off the settings insert to get the row id.
+          const result: any = Promise.resolve([{ id: 'settings-1' }]);
+          result.returning = vi.fn(() => Promise.resolve([{ id: 'settings-1' }]));
+          return result;
+        }),
+      })),
+    };
+    return { tx, calls };
+  }
+
+  it('deletes the old alert_rule rows, then reinserts them with schema defaults', async () => {
+    const { tx, calls } = updateTx({
+      id: 'link-ar', configPolicyId: 'policy-1', featureType: 'alert_rule',
+      featurePolicyId: null, inlineSettings: { items: [] },
+    });
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    await updateFeatureLink('link-ar', {
+      inlineSettings: {
+        items: [{ name: 'High CPU', conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }] }],
+      },
+    }, 'policy-1');
+
+    expect(calls.map((c) => c.op)).toEqual(['delete', 'insert']);
+    expect(calls[0]!.table).toBe(configPolicyAlertRules);
+    expect(calls[1]!.table).toBe(configPolicyAlertRules);
+
+    const [row] = calls[1]!.values;
+    expect(row).toMatchObject({
+      featureLinkId: 'link-ar',
+      name: 'High CPU',
+      severity: 'medium',
+      cooldownMinutes: 5,
+      autoResolve: false,
+      autoResolveConditions: null,
+      titleTemplate: '{{ruleName}} triggered on {{deviceName}}',
+      messageTemplate: '{{ruleName}} condition met',
+      sortOrder: 0,
+    });
+  });
+
+  it('throws on an invalid alert_rule payload BEFORE deleting or updating anything', async () => {
+    // Regression guard for torn state: decompose is what enforces the
+    // per-feature schema, and it runs AFTER deleteNormalizedRows. Only the
+    // surrounding transaction saved the existing rows; validation must not
+    // depend on every caller remembering to open one.
+    const { tx, calls } = updateTx({
+      id: 'link-ar', configPolicyId: 'policy-1', featureType: 'alert_rule',
+      featurePolicyId: null, inlineSettings: { items: [] },
+    });
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    await expect(updateFeatureLink('link-ar', {
+      inlineSettings: { items: [{ name: 'bad', conditions: [{ type: 'metric', metric: 'network', operator: 'gt', value: 85 }] }] },
+    }, 'policy-1')).rejects.toThrow();
+
+    expect(calls).toEqual([]);
+    expect(tx.update).not.toHaveBeenCalled();
+  });
+
+  it('does NOT delete config_policy_alert_rules when a monitoring link is updated', async () => {
+    // The monitoring decompose path used to WRITE alert rules keyed by the
+    // monitoring link; this branch was its replace-half. With the insert half
+    // gone (2026-07-30 consolidation) a delete here is pure data loss for any
+    // policy the ownership migration has not yet touched — one unrelated save
+    // on the Monitoring tab and the legacy rules are unrecoverable.
+    const { tx, calls } = updateTx({
+      id: 'link-mon', configPolicyId: 'policy-1', featureType: 'monitoring',
+      featurePolicyId: null, inlineSettings: { checkIntervalSeconds: 60, watches: [] },
+    });
+    vi.mocked(db.transaction).mockImplementation(async (fn: any) => fn(tx));
+
+    await updateFeatureLink('link-mon', {
+      inlineSettings: { checkIntervalSeconds: 120, watches: [] },
+    }, 'policy-1');
+
+    const deletedTables = calls.filter((c) => c.op === 'delete').map((c) => c.table);
+    expect(deletedTables).toContain(configPolicyMonitoringSettings);
+    expect(deletedTables).not.toContain(configPolicyAlertRules);
   });
 });
 

--- a/apps/api/src/services/configurationPolicy.ts
+++ b/apps/api/src/services/configurationPolicy.ts
@@ -753,6 +753,44 @@ async function decomposeInlineSettings(
 }
 
 /**
+ * Run the schema parses `decomposeInlineSettings` would run, WITHOUT writing.
+ *
+ * updateFeatureLink replaces normalized rows with delete-then-decompose, and
+ * decompose is where the per-feature schema is enforced — so on an invalid
+ * payload the delete had already run by the time the parse threw. The
+ * transaction rolls that back, but only as long as every caller stays inside
+ * one; asserting up front makes "validation precedes deletion" a property of
+ * the service rather than of its callers, and turns a torn-state bug into a
+ * plain ZodError before any row is touched.
+ *
+ * Mirrors exactly the `case` arms of decomposeInlineSettings that call `.parse`
+ * — the others build their rows defensively from `unknown` and cannot throw.
+ */
+function assertDecomposableInlineSettings(featureType: ConfigFeatureType, settings: unknown): void {
+  // Same early-out as decomposeInlineSettings: nothing to decompose, nothing to check.
+  if (!settings || typeof settings !== 'object') return;
+  switch (featureType) {
+    case 'alert_rule':
+      alertRuleInlineSettingsSchema.parse(settings);
+      break;
+    case 'event_log':
+      eventLogInlineSettingsSchema.parse(settings);
+      break;
+    case 'monitoring':
+      monitoringInlineSettingsSchema.parse(settings);
+      break;
+    case 'remote_access':
+      remoteAccessConsentSettingsSchema.parse(settings);
+      break;
+    case 'onedrive_helper':
+      onedriveHelperInlineSettingsSchema.parse(settings);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
  * Delete existing normalized rows for a feature link.
  * Used before re-decomposing on update.
  */
@@ -784,10 +822,18 @@ async function deleteNormalizedRows(
       await tx.delete(configPolicySensitiveDataSettings).where(eq(configPolicySensitiveDataSettings.featureLinkId, linkId));
       break;
     case 'monitoring': {
-      // Watches cascade-delete from settings, so just delete settings
+      // Watches cascade-delete from settings, so just delete settings.
+      //
+      // Deliberately does NOT touch config_policy_alert_rules. The monitoring
+      // decompose path used to write alert rules keyed by the MONITORING link
+      // and this delete was its replace-half; as of the 2026-07-30 consolidation
+      // the insert half is gone and the alert_rule link is the sole owner. If
+      // 2026-07-30-alert-rule-ownership-consolidation.sql has not run (or a row
+      // slipped past it), a delete here would silently destroy legacy rules on
+      // the next save of an unrelated Monitoring setting, with nothing to
+      // re-create them. Leaving the rows in place keeps them recoverable by a
+      // replay of the migration.
       await tx.delete(configPolicyMonitoringSettings).where(eq(configPolicyMonitoringSettings.featureLinkId, linkId));
-      // Also delete event log alert rules stored under this monitoring feature link
-      await tx.delete(configPolicyAlertRules).where(eq(configPolicyAlertRules.featureLinkId, linkId));
       break;
     }
     case 'backup':
@@ -1191,6 +1237,14 @@ export async function updateFeatureLink(
     if (updates.inlineSettings !== undefined) {
       // Keep JSONB as a compatibility/UI mirror; runtime must read normalized settings.
       setValues.inlineSettings = normalizedInlineSettings;
+    }
+
+    // Validate BEFORE any write. The normalized rows are replaced further down
+    // with delete-then-decompose, and decompose is where the per-feature schema
+    // throws — so without this the delete would already have run against an
+    // invalid payload.
+    if (updates.inlineSettings !== undefined) {
+      assertDecomposableInlineSettings(existing.featureType as ConfigFeatureType, normalizedInlineSettings);
     }
 
     const [updated] = await tx

--- a/apps/docs/src/content/docs/features/alerts.mdx
+++ b/apps/docs/src/content/docs/features/alerts.mdx
@@ -119,12 +119,21 @@ Alert rules define what conditions to watch for and which devices to monitor.
 
 2. Give the rule a **name** and choose a **severity** level.
 
-3. Add one or more **conditions**. Each condition specifies:
-   - **Type** -- metric threshold, status change, or custom condition
-   - **Metric** -- CPU, memory, disk, or network usage
-   - **Operator** -- greater than, less than, equals, etc.
-   - **Threshold value** -- the numeric value that triggers the alert
-   - **Duration** -- the sliding window over which samples are evaluated. The alert fires when the **average** of all samples within this window breaches the threshold (previously every individual sample had to breach). This change makes rules more tolerant of momentary spikes; if you had rules tuned for a single-sample breach, consider shortening the duration or lowering the threshold to preserve the same effective sensitivity.
+3. Add one to ten **conditions**. A rule fires when its conditions are met; each condition is one of three types.
+
+   **Metric threshold** -- compares a collected device metric against a number:
+   - **Metric** -- CPU usage, memory usage, disk usage (all percentages), or process count (a raw count).
+   - **Operator** -- greater than, greater or equal, less than, less or equal, equals, not equals.
+   - **Value** -- the number that triggers the alert. `0`--`100` for the percentage metrics; unbounded for process count.
+   - **Duration** -- the sliding window, in minutes, over which samples are evaluated. The alert fires when the **average** of all samples within this window breaches the threshold (previously every individual sample had to breach). This makes rules more tolerant of momentary spikes; if you had rules tuned for a single-sample breach, consider shortening the duration or lowering the threshold to preserve the same effective sensitivity.
+
+   **Device offline** -- fires when a device has been continuously unreachable for the configured number of minutes. See [Offline Duration](#offline-duration-for-configuration-policy-rules) below for the 24-hour cap.
+
+   **Event log** -- fires on entries the agent collects from the Windows Event Log, macOS unified log, or Linux journal:
+   - **Category** -- security, hardware, application, or system.
+   - **Minimum level** -- warning, error, or critical. The condition matches this level **and above**, so "warning" also matches errors and criticals.
+   - **Source pattern** and **message pattern** (both optional) -- plain text matched as a **case-insensitive substring**, not a regular expression. `login fail` matches "Login Failed for user"; `^Login` matches nothing.
+   - **Count threshold** and **window** -- how many matching events must occur (1--10,000) within how many minutes (1--1,440) before the alert fires. The default, 1 event in 15 minutes, fires on the first match.
 
 4. Choose the **target scope**:
    - **All Devices** -- applies to every device in the organization
@@ -141,6 +150,10 @@ Alert rules define what conditions to watch for and which devices to monitor.
 8. Click **Save**.
 
 </Steps>
+
+<Aside type="caution">
+  Older rules may still carry condition types Breeze no longer evaluates -- `custom`, and a "network usage" metric that never had a metric to compare against. Those are shown read-only with an amber warning on the rule, and the rule cannot be saved until you remove or replace the condition. Agent-side service and process watches are configured separately, on the policy's **Monitoring** tab -- see [Service & Process Monitoring](/features/service-monitoring/).
+</Aside>
 
 ### Testing a Rule
 

--- a/apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.test.tsx
@@ -603,6 +603,231 @@ describe('AlertRuleTab legacy condition types the editor no longer offers', () =
   });
 });
 
+// A metric NAME outside the evaluator's domain is as dead as a retired
+// condition TYPE: the pre-consolidation Monitoring tab offered "Network Usage",
+// normalizeMetricName() resolves it to null, and the write schema now rejects
+// it. Left looking editable, the rule renders as an ordinary CPU threshold and
+// one unrelated tweak silently rewrites it.
+describe('AlertRuleTab flags metrics outside the evaluator domain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue({
+      id: 'link-1',
+      featureType: 'alert_rule',
+      featurePolicyId: null,
+      inlineSettings: {},
+    });
+  });
+
+  const networkCondition = { type: 'metric', metric: 'network', operator: 'gt', value: 80 };
+
+  function renderWithItems(items: Array<Record<string, unknown>>) {
+    render(
+      <AlertRuleTab
+        policyId="policy-1"
+        existingLink={{
+          id: 'link-1',
+          featureType: 'alert_rule',
+          featurePolicyId: null,
+          inlineSettings: { items },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+  }
+
+  it('flags a network-metric rule and renders the condition read-only', () => {
+    renderWithItems([
+      { name: 'Network rule', severity: 'medium', conditions: [networkCondition], cooldownMinutes: 15, autoResolve: false },
+    ]);
+
+    expect(screen.getByTestId('alert-rule-legacy-flag-0')).toBeTruthy();
+    fireEvent.click(screen.getByText('Network rule'));
+
+    const warning = screen.getByTestId('alert-rule-legacy-warning-0');
+    expect(warning.textContent).toContain('network');
+    expect(warning.textContent?.toLowerCase()).toContain('metric');
+
+    // Read-only: no metric/operator dropdowns and no value spinner to nudge.
+    const row = screen.getByTestId('alert-rule-0-condition-0');
+    expect(within(row).queryAllByRole('combobox')).toHaveLength(0);
+    expect(within(row).queryAllByRole('spinbutton')).toHaveLength(0);
+    expect(
+      screen.getByTestId('alert-rule-0-condition-0-readonly-type').textContent
+    ).toContain('network');
+  });
+
+  it('preserves the unsupported condition verbatim when an adjacent rule is edited', async () => {
+    renderWithItems([
+      { name: 'Network rule', severity: 'medium', conditions: [networkCondition], cooldownMinutes: 15, autoResolve: false },
+      {
+        name: 'CPU rule', severity: 'high',
+        conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 80 }],
+        cooldownMinutes: 15, autoResolve: false,
+      },
+    ]);
+
+    fireEvent.click(screen.getByText('CPU rule'));
+    fireEvent.change(controlForLabel('Value (%)') as HTMLInputElement, { target: { value: '95' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    const items = lastSavedItems();
+    expect((items[1]!.conditions as any[])[0]).toMatchObject({ metric: 'cpu', value: 95 });
+    expect((items[0]!.conditions as any[])[0]).toEqual(networkCondition);
+  });
+
+  it('flags a metric condition with NO metric name instead of defaulting it to CPU', async () => {
+    // Same class of dead rule as `network`: normalizeMetricName(undefined) is
+    // null, and 2026-07-30-b-drop-never-firing-metric-alert-rules.sql deletes
+    // it as never-firing. Defaulting
+    // it to "cpu" on load would resurrect it as a live CPU rule on next save.
+    renderWithItems([
+      {
+        name: 'Metric-less rule', severity: 'medium',
+        conditions: [{ type: 'metric', operator: 'gt', value: 80 }],
+        cooldownMinutes: 15, autoResolve: false,
+      },
+    ]);
+
+    expect(screen.getByTestId('alert-rule-legacy-flag-0')).toBeTruthy();
+    fireEvent.click(screen.getByText('Metric-less rule'));
+    expect(screen.getByTestId('alert-rule-legacy-warning-0').textContent).toContain('not set');
+
+    const row = screen.getByTestId('alert-rule-0-condition-0');
+    expect(within(row).queryAllByRole('combobox')).toHaveLength(0);
+    expect(within(row).queryAllByRole('spinbutton')).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    // Still metric-less in the payload — the editor never invented "cpu".
+    expect((lastSavedItems()[0]!.conditions as any[])[0]).not.toHaveProperty('metric');
+  });
+
+  it('treats a legacy `threshold`-typed condition as an ordinary editable metric', async () => {
+    // handlers/threshold.ts calls the metric handler "threshold" (aliases
+    // ['metric']) and the old AI tool docs advertised it, so rows carry it.
+    renderWithItems([
+      {
+        name: 'Legacy threshold', severity: 'high',
+        conditions: [{ type: 'threshold', metric: 'cpu', operator: 'gt', value: 90 }],
+        cooldownMinutes: 15, autoResolve: false,
+      },
+    ]);
+
+    expect(screen.queryByTestId('alert-rule-legacy-flag-0')).toBeNull();
+    fireEvent.click(screen.getByText('Legacy threshold'));
+    expect(metricSelect().value).toBe('cpu');
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect((lastSavedItems()[0]!.conditions as any[])[0]).toMatchObject({ type: 'metric', metric: 'cpu' });
+  });
+});
+
+describe('AlertRuleTab metric value bounds are metric-aware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue({
+      id: 'link-1', featureType: 'alert_rule', featurePolicyId: null, inlineSettings: {},
+    });
+  });
+
+  function renderCondition(condition: Record<string, unknown>, name: string) {
+    render(
+      <AlertRuleTab
+        policyId="policy-1"
+        existingLink={{
+          id: 'link-1', featureType: 'alert_rule', featurePolicyId: null,
+          inlineSettings: {
+            items: [{ name, severity: 'medium', conditions: [condition], cooldownMinutes: 15, autoResolve: false }],
+          },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText(name));
+  }
+
+  it('caps a percentage metric at 100 and clamps an over-range entry', async () => {
+    renderCondition({ type: 'metric', metric: 'cpu', operator: 'gt', value: 80 }, 'CPU rule');
+    const input = controlForLabel('Value (%)') as HTMLInputElement;
+    expect(input.getAttribute('max')).toBe('100');
+
+    fireEvent.change(input, { target: { value: '150' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect((lastSavedItems()[0]!.conditions as any[])[0].value).toBe(100);
+  });
+
+  it('leaves processCount uncapped — it is a count, not a percentage', async () => {
+    renderCondition({ type: 'metric', metric: 'processCount', operator: 'gt', value: 400 }, 'Process rule');
+    const input = controlForLabel('Value (count)') as HTMLInputElement;
+    expect(input.getAttribute('max')).toBeNull();
+
+    fireEvent.change(input, { target: { value: '650' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    expect((lastSavedItems()[0]!.conditions as any[])[0].value).toBe(650);
+  });
+});
+
+// Fields with no control in this editor are still columns on
+// config_policy_alert_rules; the AI tool and the API both write them. A rule
+// that loses its custom templates because someone nudged the severity is silent
+// data loss.
+describe('AlertRuleTab preserves fields it does not render', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue({
+      id: 'link-1', featureType: 'alert_rule', featurePolicyId: null, inlineSettings: {},
+    });
+  });
+
+  it('keeps titleTemplate, messageTemplate, sortOrder and autoResolveConditions across an unrelated edit', async () => {
+    const autoResolveConditions = [{ type: 'metric', metric: 'cpu', operator: 'lt', value: 50 }];
+    render(
+      <AlertRuleTab
+        policyId="policy-1"
+        existingLink={{
+          id: 'link-1', featureType: 'alert_rule', featurePolicyId: null,
+          inlineSettings: {
+            items: [{
+              name: 'Templated rule',
+              severity: 'high',
+              conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 80 }],
+              cooldownMinutes: 15,
+              autoResolve: true,
+              autoResolveConditions,
+              titleTemplate: 'CPU pegged on {{deviceName}}',
+              messageTemplate: 'Sustained CPU above 80% on {{deviceName}}',
+              sortOrder: 7,
+            }],
+          },
+        }}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Templated rule'));
+    // Unrelated edit: bump the severity.
+    fireEvent.click(screen.getByRole('button', { name: 'Critical' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+
+    expect(lastSavedItems()[0]).toMatchObject({
+      severity: 'critical',
+      titleTemplate: 'CPU pegged on {{deviceName}}',
+      messageTemplate: 'Sustained CPU above 80% on {{deviceName}}',
+      sortOrder: 7,
+      autoResolveConditions,
+    });
+  });
+});
+
 // The rule-card header wraps a delete button, so it cannot itself be a native
 // <button>: React logs "In HTML, <button> cannot be a descendant of <button>.
 // This will cause a hydration error." on every expand. It is a role="button"

--- a/apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AlertRuleTab.tsx
@@ -14,6 +14,13 @@ import { handleToggleKeyDown } from "./disclosureKeyboard";
 import FeatureTabShell from "./FeatureTabShell";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
+// The exact metric-name domain the API threshold evaluator resolves
+// (METRIC_NAME_MAP in apps/api/src/services/alertConditions/utils.ts). Imported
+// rather than re-listed so this editor's idea of "evaluable" cannot drift from
+// the schema that accepts the save.
+// (root entry, not the /validators subpath — only the bare specifier is mapped
+// in apps/web/tsconfig.json and vitest.config.ts).
+import { ALERT_METRIC_NAMES } from "@breeze/shared";
 // `offline` is the type understood by the API condition evaluator. The legacy
 // editor emitted `status` with a `duration` field; we normalize those on load
 // (see normalizeConditions) and always emit the `offline`/`durationMinutes`
@@ -40,7 +47,10 @@ type AlertSeverity = "critical" | "high" | "medium" | "low" | "info";
 // `type` is deliberately a plain string: rows saved before this editor existed
 // can carry condition types it no longer offers (`custom`, `bandwidth_high`,
 // `disk_io_high`, `network_errors`, `patch_compliance`, `cert_expiry`). Those
-// are rendered read-only and round-tripped untouched rather than dropped.
+// are rendered read-only and preserved verbatim in tab state — but the server
+// REJECTS them on save, so the rule carrying one cannot be saved at all until
+// the offending condition is removed. That is why they get an amber banner
+// rather than being quietly round-tripped.
 type Condition = {
   type: string;
   metric?: string;
@@ -54,12 +64,21 @@ type Condition = {
   countThreshold?: number;
   windowMinutes?: number;
 };
+// The fields below `autoResolve` have no control in this editor but ARE part of
+// the stored rule (alertRuleItemSchema in @breeze/shared, and columns on
+// config_policy_alert_rules). They are declared so `{...item, ...patch}` in
+// updateItem keeps them in the save payload — an unrelated severity tweak must
+// not silently reset a rule's custom title/message templates or its sort order.
 type AlertItem = {
   name: string;
   severity: AlertSeverity;
   conditions: Condition[];
   cooldownMinutes: number;
   autoResolve: boolean;
+  autoResolveConditions?: Condition[] | null;
+  titleTemplate?: string;
+  messageTemplate?: string;
+  sortOrder?: number;
 };
 const defaultItem: AlertItem = {
   name: "",
@@ -285,6 +304,29 @@ const METRIC_ALIAS_TO_OPTION: Record<string, string> = {
   memory: "ram",
   diskPercent: "disk",
 };
+// A metric name the evaluator cannot resolve (the retired "network" option is
+// the known producer — normalizeMetricName returns null for it, so the rule has
+// never fired) and that the write schema now rejects. Such a condition is
+// rendered read-only and banner-flagged: silently editable would let one
+// unrelated tweak trigger a save the server rejects with no explanation.
+function isSupportedMetric(metric: string | undefined): boolean {
+  return (
+    typeof metric === "string"
+    && (ALERT_METRIC_NAMES as readonly string[]).includes(metric)
+  );
+}
+// Value bounds are metric-dependent: cpu/ram/disk are percentages, but
+// processCount is a raw count and capping it at 100 silently rewrote any
+// "more than 250 processes" rule the AI tool had written. undefined = no cap.
+const METRIC_VALUE_MAX: Record<string, number | undefined> = {
+  cpu: 100, cpuPercent: 100,
+  ram: 100, ramPercent: 100, memory: 100,
+  disk: 100, diskPercent: 100,
+  processCount: undefined, processes: undefined,
+};
+function metricValueMax(metric: string | undefined): number | undefined {
+  return metric ? METRIC_VALUE_MAX[metric] : 100;
+}
 // Migrate a single condition from the legacy `{type:'status', duration}` shape
 // to the canonical `{type:'offline', durationMinutes}` shape the evaluator reads.
 // Legacy persisted shape, before the `status`→`offline` / `duration`→`durationMinutes` rename.
@@ -299,14 +341,29 @@ function normalizeCondition(condition: Condition): Condition {
       durationMinutes: durationMinutes ?? duration ?? 5,
     };
   }
-  if (raw.type === "metric") {
+  // `threshold` is the evaluator's own name for the metric handler
+  // (handlers/threshold.ts, aliases ['metric']) and the pre-consolidation AI
+  // tool docs advertised it, so stored rows carry it. Fold it into `metric`
+  // exactly as `status` folds into `offline` — otherwise the editor would show
+  // it as a retired, un-editable type when the server happily accepts it.
+  if (raw.type === "metric" || raw.type === "threshold") {
     const canonical = raw.metric ? METRIC_ALIAS_TO_OPTION[raw.metric] : undefined;
     // `duration` (seconds) was never read by the metric evaluator; drop it so it
     // can't be mistaken for a sustained window. `durationMinutes` IS honoured
     // and is round-tripped untouched.
     const { duration, ...rest } = raw;
-    if (duration === undefined && !canonical) return condition;
-    return canonical ? { ...rest, metric: canonical } : rest;
+    // Deliberately NO fallback for a missing metric name. A metric condition
+    // with no metric is exactly as dead as one naming "network"
+    // (normalizeMetricName(undefined) → null), and
+    // 2026-07-30-b-drop-never-firing-metric-alert-rules.sql deletes both as
+    // never-firing — defaulting it to "cpu" here would resurrect
+    // it as a live CPU rule on the next save. isEditableCondition() already
+    // returns false for it, so it gets the honest read-only + banner treatment.
+    const metric = canonical ?? rest.metric;
+    // Don't materialize a `metric: undefined` key that wasn't there.
+    return metric === undefined
+      ? { ...rest, type: "metric" }
+      : { ...rest, type: "metric", metric };
   }
   // Every other type — including types this editor no longer offers — is
   // returned untouched so an unrelated edit elsewhere in the rule can't strip
@@ -335,6 +392,15 @@ function loadItems(existingLink: FeatureTabProps["existingLink"]): AlertItem[] {
   }
   return [];
 }
+// A condition this editor can render a form for. Two ways to fail: a condition
+// TYPE it no longer offers, or a metric NAME the evaluator cannot resolve. Both
+// are rejected by the write schema, so both must be surfaced rather than left
+// looking editable.
+function isEditableCondition(condition: Condition): boolean {
+  if (!isEditableConditionType(condition.type)) return false;
+  if (condition.type === "metric") return isSupportedMetric(condition.metric);
+  return true;
+}
 // Condition types the editor can no longer render a form for. Listed on the rule
 // so the tech knows why a save is being rejected and what to remove.
 function unsupportedConditionTypes(item: AlertItem): string[] {
@@ -343,6 +409,26 @@ function unsupportedConditionTypes(item: AlertItem): string[] {
       item.conditions
         .map((c) => c.type)
         .filter((type) => !isEditableConditionType(type)),
+    ),
+  ];
+}
+// A metric condition can also carry NO metric at all — just as dead, and it has
+// to be nameable in the banner rather than silently omitted from it.
+function displayMetricName(metric: string | undefined): string {
+  return metric && metric.length > 0
+    ? metric
+    : i18n.t("policies:configurationPolicies.featureTabs.alertRuleTab.metricNotSet");
+}
+// Metric names outside the evaluator's domain, e.g. the retired "network"
+// option the old Monitoring tab offered. Reported separately from retired TYPES
+// because the remedy differs: pick a supported metric, rather than delete the
+// whole condition.
+function unsupportedConditionMetrics(item: AlertItem): string[] {
+  return [
+    ...new Set(
+      item.conditions
+        .filter((c) => c.type === "metric" && !isSupportedMetric(c.metric))
+        .map((c) => displayMetricName(c.metric)),
     ),
   ];
 }
@@ -565,6 +651,9 @@ export default function AlertRuleTab({
         {items.map((item, index) => {
           const isExpanded = expandedIndex === index;
           const unsupportedTypes = unsupportedConditionTypes(item);
+          const unsupportedMetrics = unsupportedConditionMetrics(item);
+          const hasUnsupported =
+            unsupportedTypes.length > 0 || unsupportedMetrics.length > 0;
           return (
             <div key={index} className="rounded-md border bg-muted/10">
               {/* Collapsed header.
@@ -600,7 +689,7 @@ export default function AlertRuleTab({
                       )}
                   </span>
                   {severityPill(item.severity)}
-                  {unsupportedTypes.length > 0 && (
+                  {hasUnsupported && (
                     <AlertTriangle
                       data-testid={`alert-rule-legacy-flag-${index}`}
                       className="h-4 w-4 shrink-0 text-amber-600"
@@ -637,16 +726,28 @@ export default function AlertRuleTab({
                   className="border-t px-4 pb-4 pt-3 space-y-4"
                 >
                   {/* Legacy condition warning */}
-                  {unsupportedTypes.length > 0 && (
+                  {hasUnsupported && (
                     <div
                       data-testid={`alert-rule-legacy-warning-${index}`}
                       className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700"
                     >
                       <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                      <span>
-                        {i18n.t(
-                          "policies:configurationPolicies.featureTabs.alertRuleTab.thisRuleUsesRetiredConditionTypes",
-                          { types: unsupportedTypes.join(", ") },
+                      <span className="space-y-1">
+                        {unsupportedTypes.length > 0 && (
+                          <span className="block">
+                            {i18n.t(
+                              "policies:configurationPolicies.featureTabs.alertRuleTab.thisRuleUsesRetiredConditionTypes",
+                              { types: unsupportedTypes.join(", ") },
+                            )}
+                          </span>
+                        )}
+                        {unsupportedMetrics.length > 0 && (
+                          <span className="block">
+                            {i18n.t(
+                              "policies:configurationPolicies.featureTabs.alertRuleTab.thisRuleUsesUnsupportedMetrics",
+                              { metrics: unsupportedMetrics.join(", ") },
+                            )}
+                          </span>
                         )}
                       </span>
                     </div>
@@ -721,9 +822,15 @@ export default function AlertRuleTab({
                     </div>
                     <div className="mt-2 space-y-2">
                       {item.conditions.map((condition, ci) => {
-                        const editable = isEditableConditionType(
-                          condition.type,
-                        );
+                        const editable = isEditableCondition(condition);
+                        // A metric condition is un-editable only because of its
+                        // metric NAME — the type itself is fine, so the reason
+                        // shown has to say so or the tech goes looking for a
+                        // retired type that isn't there.
+                        const unsupportedMetric =
+                          condition.type === "metric" && !editable
+                            ? displayMetricName(condition.metric)
+                            : "";
                         return (
                           <div
                             key={ci}
@@ -755,21 +862,31 @@ export default function AlertRuleTab({
                                       ))}
                                     </select>
                                   ) : (
-                                    <p className="mt-1 flex h-8 items-center truncate rounded-md border border-dashed bg-muted/40 px-2 font-mono text-xs text-muted-foreground">
-                                      {condition.type}
+                                    <p
+                                      data-testid={`alert-rule-${index}-condition-${ci}-readonly-type`}
+                                      className="mt-1 flex h-8 items-center truncate rounded-md border border-dashed bg-muted/40 px-2 font-mono text-xs text-muted-foreground"
+                                    >
+                                      {unsupportedMetric
+                                        ? `${condition.type}: ${unsupportedMetric}`
+                                        : condition.type}
                                     </p>
                                   )}
                                 </div>
 
                                 {!editable && (
                                   <p className="self-center text-xs text-muted-foreground sm:col-span-1 md:col-span-3">
-                                    {i18n.t(
-                                      "policies:configurationPolicies.featureTabs.alertRuleTab.thisConditionTypeIsNoLongerEditable",
-                                    )}
+                                    {unsupportedMetric
+                                      ? i18n.t(
+                                          "policies:configurationPolicies.featureTabs.alertRuleTab.thisConditionUsesAnUnsupportedMetric",
+                                          { metric: unsupportedMetric },
+                                        )
+                                      : i18n.t(
+                                          "policies:configurationPolicies.featureTabs.alertRuleTab.thisConditionTypeIsNoLongerEditable",
+                                        )}
                                   </p>
                                 )}
 
-                                {condition.type === "metric" && (
+                                {condition.type === "metric" && editable && (
                                   <>
                                     <div>
                                       <label className="text-xs font-medium text-muted-foreground">
@@ -833,20 +950,34 @@ export default function AlertRuleTab({
                                     </div>
                                     <div>
                                       <label className="text-xs font-medium text-muted-foreground">
-                                        {i18n.t(
-                                          "policies:configurationPolicies.featureTabs.alertRuleTab.value",
-                                        )}
+                                        {metricValueMax(condition.metric) === undefined
+                                          ? i18n.t(
+                                              "policies:configurationPolicies.featureTabs.alertRuleTab.valueCount",
+                                            )
+                                          : i18n.t(
+                                              "policies:configurationPolicies.featureTabs.alertRuleTab.value",
+                                            )}
                                       </label>
                                       <input
                                         type="number"
                                         min={0}
-                                        max={100}
+                                        max={metricValueMax(condition.metric)}
                                         value={condition.value ?? 80}
-                                        onChange={(e) =>
-                                          updateCondition(index, ci, {
-                                            value: Number(e.target.value),
-                                          })
-                                        }
+                                        onChange={(e) => {
+                                          // Clamp the same way the offline
+                                          // duration field does, but against a
+                                          // metric-aware ceiling: processCount
+                                          // is a raw count with no upper bound,
+                                          // so a hard 100 would silently
+                                          // rewrite "over 250 processes".
+                                          const max = metricValueMax(condition.metric);
+                                          const raw = Number(e.target.value);
+                                          const clamped = Math.max(
+                                            0,
+                                            max === undefined ? raw : Math.min(max, raw),
+                                          );
+                                          updateCondition(index, ci, { value: clamped });
+                                        }}
                                         className="mt-1 h-8 w-full rounded-md border bg-background px-2 text-sm"
                                       />
                                     </div>

--- a/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.test.tsx
@@ -154,6 +154,46 @@ describe('MonitoringTab alert-rule consolidation', () => {
     expect(settings.checkIntervalSeconds).toBe(90);
     expect(settings.watches).toHaveLength(1);
   });
+
+  it('tells the tech where the legacy rules went instead of dropping them silently', () => {
+    render(
+      <MonitoringTab
+        policyId="policy-1"
+        existingLink={legacyLink}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />,
+    );
+
+    const notice = screen.getByTestId('monitoring-legacy-alert-rules-notice');
+    // One alertRules entry + one eventLogAlerts entry on the fixture link.
+    expect(notice.textContent).toContain('2');
+    expect(notice.textContent).toContain('Alerts');
+    // Non-blocking: saving the tab still works.
+    expect(
+      (screen.getByRole('button', { name: /^Save$/i }) as HTMLButtonElement).disabled
+    ).toBe(false);
+  });
+
+  it('shows no legacy notice for a link that never carried alert rules', () => {
+    renderTab();
+    expect(screen.queryByTestId('monitoring-legacy-alert-rules-notice')).toBeNull();
+  });
+
+  it('navigates to the Alerts tab from the legacy notice', () => {
+    render(
+      <MonitoringTab
+        policyId="policy-1"
+        existingLink={legacyLink}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />,
+    );
+
+    window.location.hash = '';
+    fireEvent.click(screen.getByTestId('monitoring-legacy-alert-rules-link'));
+    expect(window.location.hash).toBe('#alert_rule');
+  });
 });
 
 describe('MonitoringTab disclosure keyboard toggle (issue #1932)', () => {

--- a/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/MonitoringTab.tsx
@@ -134,6 +134,17 @@ const createSeverityOptions = (): {
 // before the alert consolidation still carries `alertRules`/`eventLogAlerts`,
 // and spreading them back into state would put them straight into the next save
 // payload, which the API now rejects.
+// Counts the legacy alert rules a stored mirror still carries. readSettings
+// drops those keys from tab state (they can no longer be saved), and dropping
+// them silently would look like the tab had eaten the tech's rules — so the
+// count drives a non-blocking info banner pointing at where they went.
+function legacyAlertRuleCount(
+  stored: Record<string, unknown> | null | undefined,
+): number {
+  const raw = (stored ?? {}) as Record<string, unknown>;
+  const count = (value: unknown) => (Array.isArray(value) ? value.length : 0);
+  return count(raw.alertRules) + count(raw.eventLogAlerts);
+}
 function readSettings(
   stored: Record<string, unknown> | null | undefined,
   fallback: MonitoringSettings,
@@ -304,6 +315,7 @@ export default function MonitoringTab({
   );
   // Expanded item tracking: "watches:0"
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const legacyAlertRules = legacyAlertRuleCount(effectiveLink?.inlineSettings);
   const nameInputRef = useRef<HTMLInputElement>(null);
   // Known services for autocomplete
   const [knownServices, setKnownServices] = useState<KnownService[]>([]);
@@ -503,6 +515,33 @@ export default function MonitoringTab({
           )}
         </MonitoringSection>
       </div>
+
+      {/* ── Legacy rules this tab no longer owns (non-blocking) ── */}
+      {legacyAlertRules > 0 && (
+        <div
+          data-testid="monitoring-legacy-alert-rules-notice"
+          className="mt-4 flex items-start gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700"
+        >
+          <Bell className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            {i18n.t(
+              "policies:configurationPolicies.featureTabs.monitoringTab.legacyAlertRulesMovedToAlerts",
+              { count: legacyAlertRules },
+            )}{" "}
+            <button
+              type="button"
+              data-testid="monitoring-legacy-alert-rules-link"
+              onClick={goToAlertsTab}
+              className="font-medium underline underline-offset-2 hover:no-underline"
+            >
+              {i18n.t(
+                "policies:configurationPolicies.featureTabs.monitoringTab.openAlertsFeature",
+              )}{" "}
+              →
+            </button>
+          </span>
+        </div>
+      )}
 
       {/* ── Pointer: server-evaluated alerting lives in the Alerts feature ── */}
       <div className="mt-4">

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -248,7 +248,11 @@
         "thisRuleUsesRetiredConditionTypes": "Diese Regel verwendet noch eingestellte Bedingungstypen ({{types}}). Entfernen Sie diese Bedingungen vor dem Speichern — der Server weist Regeln zurück, die sie enthalten.",
         "textContainedInTheEventSourceCaseInsensitive": "Text, der in der Ereignisquelle enthalten ist (Groß-/Kleinschreibung wird ignoriert)",
         "textContainedInTheEventMessageCaseInsensitive": "Text, der in der Ereignisnachricht enthalten ist (Groß-/Kleinschreibung wird ignoriert)",
-        "eGFailedLogin": "z.B. Anmeldung fehlgeschlagen"
+        "eGFailedLogin": "z.B. Anmeldung fehlgeschlagen",
+        "thisRuleUsesUnsupportedMetrics": "Diese Regel verwendet eine Metrik, die die Alarm-Engine nicht auswerten kann ({{metrics}}). Wählen Sie vor dem Speichern eine unterstützte Metrik – oder entfernen Sie die Bedingung; der Server weist Regeln damit zurück.",
+        "thisConditionUsesAnUnsupportedMetric": "Die Metrik „{{metric}}“ wird von der Alarm-Engine nicht ausgewertet, daher wird diese Bedingung schreibgeschützt angezeigt.",
+        "valueCount": "Wert (Anzahl)",
+        "metricNotSet": "nicht festgelegt"
       },
       "automationTab": {
         "uTC": "UTC",
@@ -808,27 +812,13 @@
         "addAServiceOrProcessToStart": "Fügen Sie einen Dienst oder Prozess hinzu, um die Überwachung zu starten.",
         "alertOnStop2": "Alarm bei Stopp",
         "autoRestart2": "auto-restart",
-        "service2": "Dienst",
         "eGNginxSshd": "z.B. Nginx, SSHD",
         "eGNodeJava": "z.B. Knoten, Java",
-        "process2": "Prozess",
-        "metric2": "metrisch",
-        "status": "Status",
-        "bandwidthHigh2": "bandwidth_high",
-        "networkDirection": "Netzwerkrichtung",
-        "diskIoHigh": "disk_io_high",
-        "diskDirection": "diskDirection",
-        "networkErrors2": "network_errors",
-        "errorType2": "Fehlertyp",
-        "patchCompliance2": "patch_compliance",
-        "certExpiry": "cert_expiry",
-        "custom2": "benutzerdefiniert",
-        "off": "aus",
-        "checkResults": "check_results",
         "monitored": "überwacht",
         "inventory": "Inventar",
         "deviceThresholdsAndEventLogAlertsPointer": "Geräteschwellenwerte und Ereignisprotokollwarnungen werden in der Funktion „Alarme“ dieser Richtlinie konfiguriert.",
-        "openAlertsFeature": "Alarme öffnen"
+        "openAlertsFeature": "Alarme öffnen",
+        "legacyAlertRulesMovedToAlerts": "{{count}} ältere Alarmregel(n) von diesem Tab wurden in die Alarm-Funktion dieser Richtlinie verschoben. Die Überwachung speichert sie nicht mehr."
       },
       "pamTab": {
         "captureWindowsUACElevationPrompts": "Windows-UAC-Aufforderungen zur Rechteerhöhung erfassen",

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -248,7 +248,11 @@
         "thisRuleUsesRetiredConditionTypes": "This rule still uses retired condition types ({{types}}). Remove those conditions before saving — the server rejects rules that contain them.",
         "textContainedInTheEventSourceCaseInsensitive": "Text contained in the event source (case-insensitive)",
         "textContainedInTheEventMessageCaseInsensitive": "Text contained in the event message (case-insensitive)",
-        "eGFailedLogin": "e.g. failed login"
+        "eGFailedLogin": "e.g. failed login",
+        "thisRuleUsesUnsupportedMetrics": "This rule uses a metric the alert engine cannot evaluate ({{metrics}}). Pick a supported metric — or remove the condition — before saving; the server rejects rules that contain it.",
+        "thisConditionUsesAnUnsupportedMetric": "The metric \"{{metric}}\" is not evaluated by the alert engine, so this condition is shown read-only.",
+        "valueCount": "Value (count)",
+        "metricNotSet": "not set"
       },
       "automationTab": {
         "uTC": "UTC",
@@ -808,27 +812,13 @@
         "addAServiceOrProcessToStart": "Add a service or process to start monitoring.",
         "alertOnStop2": "alert on stop",
         "autoRestart2": "auto-restart",
-        "service2": "service",
         "eGNginxSshd": "e.g. nginx, sshd",
         "eGNodeJava": "e.g. node, java",
-        "process2": "process",
-        "metric2": "metric",
-        "status": "status",
-        "bandwidthHigh2": "bandwidth_high",
-        "networkDirection": "networkDirection",
-        "diskIoHigh": "disk_io_high",
-        "diskDirection": "diskDirection",
-        "networkErrors2": "network_errors",
-        "errorType2": "errorType",
-        "patchCompliance2": "patch_compliance",
-        "certExpiry": "cert_expiry",
-        "custom2": "custom",
-        "off": "off",
-        "checkResults": "check_results",
         "monitored": "monitored",
         "inventory": "inventory",
         "deviceThresholdsAndEventLogAlertsPointer": "Device thresholds and event log alerts are configured in the Alerts feature of this policy.",
-        "openAlertsFeature": "Open Alerts"
+        "openAlertsFeature": "Open Alerts",
+        "legacyAlertRulesMovedToAlerts": "{{count}} legacy alert rule(s) saved on this tab were moved to the Alerts feature of this policy. Monitoring no longer stores them."
       },
       "pamTab": {
         "captureWindowsUACElevationPrompts": "Capture Windows UAC elevation prompts",

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -248,7 +248,11 @@
         "thisRuleUsesRetiredConditionTypes": "Esta regla todavía usa tipos de condición retirados ({{types}}). Elimine esas condiciones antes de guardar: el servidor rechaza las reglas que las contienen.",
         "textContainedInTheEventSourceCaseInsensitive": "Texto contenido en la fuente del evento (no distingue mayúsculas)",
         "textContainedInTheEventMessageCaseInsensitive": "Texto contenido en el mensaje del evento (no distingue mayúsculas)",
-        "eGFailedLogin": "p.ej. inicio de sesión fallido"
+        "eGFailedLogin": "p.ej. inicio de sesión fallido",
+        "thisRuleUsesUnsupportedMetrics": "Esta regla usa una métrica que el motor de alertas no puede evaluar ({{metrics}}). Elija una métrica compatible —o elimine la condición— antes de guardar; el servidor rechaza las reglas que la contienen.",
+        "thisConditionUsesAnUnsupportedMetric": "El motor de alertas no evalúa la métrica «{{metric}}», por lo que esta condición se muestra solo de lectura.",
+        "valueCount": "Valor (cantidad)",
+        "metricNotSet": "sin definir"
       },
       "automationTab": {
         "uTC": "UTC",
@@ -808,27 +812,13 @@
         "addAServiceOrProcessToStart": "Agregue un servicio o proceso para comenzar a monitorear.",
         "alertOnStop2": "alerta en parada",
         "autoRestart2": "reinicio automático",
-        "service2": "servicio",
         "eGNginxSshd": "p.ej. nginx, sshd",
         "eGNodeJava": "p.ej. nodo, java",
-        "process2": "proceso",
-        "metric2": "métrico",
-        "status": "estado",
-        "bandwidthHigh2": "bandwidth_high",
-        "networkDirection": "networkDirection",
-        "diskIoHigh": "disk_io_high",
-        "diskDirection": "diskDirection",
-        "networkErrors2": "network_errors",
-        "errorType2": "errorType",
-        "patchCompliance2": "patch_compliance",
-        "certExpiry": "cert_expiry",
-        "custom2": "personalizado",
-        "off": "apagado",
-        "checkResults": "check_results",
         "monitored": "monitoreado",
         "inventory": "inventario",
         "deviceThresholdsAndEventLogAlertsPointer": "Los umbrales de dispositivo y las alertas del registro de eventos se configuran en la función Alertas de esta política.",
-        "openAlertsFeature": "Abrir Alertas"
+        "openAlertsFeature": "Abrir Alertas",
+        "legacyAlertRulesMovedToAlerts": "{{count}} regla(s) de alerta heredada(s) guardadas en esta pestaña se movieron a la función Alertas de esta política. Monitoreo ya no las almacena."
       },
       "pamTab": {
         "captureWindowsUACElevationPrompts": "Capture indicaciones de elevación Windows UAC",

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -248,7 +248,11 @@
         "thisRuleUsesRetiredConditionTypes": "Cette règle utilise encore des types de condition retirés ({{types}}). Supprimez ces conditions avant d’enregistrer — le serveur rejette les règles qui en contiennent.",
         "textContainedInTheEventSourceCaseInsensitive": "Texte contenu dans la source de l’événement (insensible à la casse)",
         "textContainedInTheEventMessageCaseInsensitive": "Texte contenu dans le message de l’événement (insensible à la casse)",
-        "eGFailedLogin": "p. ex. échec d’ouverture de session"
+        "eGFailedLogin": "p. ex. échec d’ouverture de session",
+        "thisRuleUsesUnsupportedMetrics": "Cette règle utilise une métrique que le moteur d'alertes ne peut pas évaluer ({{metrics}}). Choisissez une métrique prise en charge — ou supprimez la condition — avant d'enregistrer; le serveur refuse les règles qui la contiennent.",
+        "thisConditionUsesAnUnsupportedMetric": "La métrique « {{metric}} » n'est pas évaluée par le moteur d'alertes, cette condition est donc affichée en lecture seule.",
+        "valueCount": "Valeur (nombre)",
+        "metricNotSet": "non défini"
       },
       "automationTab": {
         "uTC": "UTC",
@@ -808,27 +812,13 @@
         "addAServiceOrProcessToStart": "Ajoutez un service ou un processus pour commencer à surveiller.",
         "alertOnStop2": "Alerte à l’arrêt",
         "autoRestart2": "Redémarrage automatique",
-        "service2": "Service",
         "eGNginxSshd": "Par exemple nginx, sshd",
         "eGNodeJava": "Par exemple Node, Java",
-        "process2": "Processus",
-        "metric2": "Métrique",
-        "status": "Statut",
-        "bandwidthHigh2": "bandwidth_high",
-        "networkDirection": "réseauDirection",
-        "diskIoHigh": "disk_io_high",
-        "diskDirection": "diskDirection",
-        "networkErrors2": "network_errors",
-        "errorType2": "ErrorType",
-        "patchCompliance2": "patch_compliance",
-        "certExpiry": "cert_expiry",
-        "custom2": "personnalisé",
-        "off": "désactivé",
-        "checkResults": "check_results",
         "monitored": "Surveillé",
         "inventory": "Inventaire",
         "deviceThresholdsAndEventLogAlertsPointer": "Les seuils d’appareil et les alertes du journal d’événements se configurent dans la fonctionnalité Alertes de cette politique.",
-        "openAlertsFeature": "Ouvrir Alertes"
+        "openAlertsFeature": "Ouvrir Alertes",
+        "legacyAlertRulesMovedToAlerts": "{{count}} règle(s) d'alerte héritée(s) enregistrée(s) dans cet onglet ont été déplacées vers la fonction Alertes de cette politique. La surveillance ne les conserve plus."
       },
       "pamTab": {
         "captureWindowsUACElevationPrompts": "Capture Windows Prompts d’élévation UAC",

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -248,7 +248,11 @@
         "thisRuleUsesRetiredConditionTypes": "Cette règle utilise encore des types de condition retirés ({{types}}). Supprimez ces conditions avant d’enregistrer — le serveur rejette les règles qui en contiennent.",
         "textContainedInTheEventSourceCaseInsensitive": "Texte contenu dans la source de l’événement (insensible à la casse)",
         "textContainedInTheEventMessageCaseInsensitive": "Texte contenu dans le message de l’événement (insensible à la casse)",
-        "eGFailedLogin": "par exemple, échec de connexion"
+        "eGFailedLogin": "par exemple, échec de connexion",
+        "thisRuleUsesUnsupportedMetrics": "Cette règle utilise une métrique que le moteur d'alertes ne peut pas évaluer ({{metrics}}). Choisissez une métrique prise en charge — ou supprimez la condition — avant d'enregistrer ; le serveur refuse les règles qui la contiennent.",
+        "thisConditionUsesAnUnsupportedMetric": "La métrique « {{metric}} » n'est pas évaluée par le moteur d'alertes, cette condition est donc affichée en lecture seule.",
+        "valueCount": "Valeur (nombre)",
+        "metricNotSet": "non défini"
       },
       "automationTab": {
         "uTC": "UTC",
@@ -808,27 +812,13 @@
         "addAServiceOrProcessToStart": "Ajoutez un service ou un processus pour commencer à surveiller.",
         "alertOnStop2": "Alerte à l’arrêt",
         "autoRestart2": "Redémarrage automatique",
-        "service2": "Service",
         "eGNginxSshd": "Par exemple nginx, sshd",
         "eGNodeJava": "Par exemple Node, Java",
-        "process2": "Processus",
-        "metric2": "Métrique",
-        "status": "Statut",
-        "bandwidthHigh2": "bandwidth_high",
-        "networkDirection": "réseauDirection",
-        "diskIoHigh": "disk_io_high",
-        "diskDirection": "diskDirection",
-        "networkErrors2": "network_errors",
-        "errorType2": "ErrorType",
-        "patchCompliance2": "patch_compliance",
-        "certExpiry": "cert_expiry",
-        "custom2": "personnalisé",
-        "off": "désactivé",
-        "checkResults": "check_results",
         "monitored": "Surveillé",
         "inventory": "Inventaire",
         "deviceThresholdsAndEventLogAlertsPointer": "Les seuils d’appareil et les alertes du journal d’événements se configurent dans la fonctionnalité Alertes de cette politique.",
-        "openAlertsFeature": "Ouvrir Alertes"
+        "openAlertsFeature": "Ouvrir Alertes",
+        "legacyAlertRulesMovedToAlerts": "{{count}} règle(s) d'alerte héritée(s) enregistrée(s) dans cet onglet ont été déplacées vers la fonctionnalité Alertes de cette politique. La supervision ne les conserve plus."
       },
       "pamTab": {
         "captureWindowsUACElevationPrompts": "Capture Windows Prompts d’élévation UAC",

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -248,7 +248,11 @@
         "thisRuleUsesRetiredConditionTypes": "Questa regola usa ancora tipi di condizione ritirati ({{types}}). Rimuovi quelle condizioni prima di salvare: il server rifiuta le regole che le contengono.",
         "textContainedInTheEventSourceCaseInsensitive": "Testo contenuto nell'origine evento (senza distinzione tra maiuscole e minuscole)",
         "textContainedInTheEventMessageCaseInsensitive": "Testo contenuto nel messaggio evento (senza distinzione tra maiuscole e minuscole)",
-        "eGFailedLogin": "ad es. failed login"
+        "eGFailedLogin": "ad es. failed login",
+        "thisRuleUsesUnsupportedMetrics": "Questa regola usa una metrica che il motore degli avvisi non può valutare ({{metrics}}). Scegli una metrica supportata — o rimuovi la condizione — prima di salvare; il server rifiuta le regole che la contengono.",
+        "thisConditionUsesAnUnsupportedMetric": "La metrica «{{metric}}» non viene valutata dal motore degli avvisi, quindi questa condizione è mostrata in sola lettura.",
+        "valueCount": "Valore (conteggio)",
+        "metricNotSet": "non impostata"
       },
       "automationTab": {
         "uTC": "UTC",
@@ -808,27 +812,13 @@
         "addAServiceOrProcessToStart": "Aggiungi un servizio o un processo per iniziare il monitoraggio.",
         "alertOnStop2": "avvisa all'arresto",
         "autoRestart2": "riavvio automatico",
-        "service2": "service",
         "eGNginxSshd": "ad es. nginx, sshd",
         "eGNodeJava": "ad es. node, java",
-        "process2": "process",
-        "metric2": "metric",
-        "status": "status",
-        "bandwidthHigh2": "bandwidth_high",
-        "networkDirection": "networkDirection",
-        "diskIoHigh": "disk_io_high",
-        "diskDirection": "diskDirection",
-        "networkErrors2": "network_errors",
-        "errorType2": "errorType",
-        "patchCompliance2": "patch_compliance",
-        "certExpiry": "cert_expiry",
-        "custom2": "custom",
-        "off": "off",
-        "checkResults": "check_results",
         "monitored": "monitored",
         "inventory": "inventory",
         "deviceThresholdsAndEventLogAlertsPointer": "Le soglie dei dispositivi e gli avvisi del log eventi si configurano nella funzione Avvisi di questo criterio.",
-        "openAlertsFeature": "Apri Avvisi"
+        "openAlertsFeature": "Apri Avvisi",
+        "legacyAlertRulesMovedToAlerts": "{{count}} regola/e di avviso legacy salvate in questa scheda sono state spostate nella funzione Avvisi di questo criterio. Il monitoraggio non le memorizza più."
       },
       "pamTab": {
         "captureWindowsUACElevationPrompts": "Acquisisci prompt di elevazione UAC di Windows",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -248,7 +248,11 @@
         "thisRuleUsesRetiredConditionTypes": "Esta regra ainda usa tipos de condição descontinuados ({{types}}). Remova essas condições antes de salvar — o servidor rejeita regras que as contenham.",
         "textContainedInTheEventSourceCaseInsensitive": "Texto contido na origem do evento (sem diferenciar maiúsculas)",
         "textContainedInTheEventMessageCaseInsensitive": "Texto contido na mensagem do evento (sem diferenciar maiúsculas)",
-        "eGFailedLogin": "ex.: falha de login"
+        "eGFailedLogin": "ex.: falha de login",
+        "thisRuleUsesUnsupportedMetrics": "Esta regra usa uma métrica que o mecanismo de alertas não consegue avaliar ({{metrics}}). Escolha uma métrica compatível — ou remova a condição — antes de salvar; o servidor rejeita regras que a contenham.",
+        "thisConditionUsesAnUnsupportedMetric": "A métrica \"{{metric}}\" não é avaliada pelo mecanismo de alertas, portanto esta condição é exibida somente para leitura.",
+        "valueCount": "Valor (contagem)",
+        "metricNotSet": "não definida"
       },
       "automationTab": {
         "uTC": "UTC",
@@ -808,27 +812,13 @@
         "addAServiceOrProcessToStart": "Adicione um serviço ou processo para começar a monitorar.",
         "alertOnStop2": "alertar ao parar",
         "autoRestart2": "reinício automático",
-        "service2": "serviço",
         "eGNginxSshd": "ex.: nginx, sshd",
         "eGNodeJava": "ex.: node, java",
-        "process2": "processo",
-        "metric2": "metric",
-        "status": "status",
-        "bandwidthHigh2": "bandwidth_high",
-        "networkDirection": "networkDirection",
-        "diskIoHigh": "disk_io_high",
-        "diskDirection": "diskDirection",
-        "networkErrors2": "network_errors",
-        "errorType2": "errorType",
-        "patchCompliance2": "patch_compliance",
-        "certExpiry": "cert_expiry",
-        "custom2": "custom",
-        "off": "off",
-        "checkResults": "check_results",
         "monitored": "monitored",
         "inventory": "inventory",
         "deviceThresholdsAndEventLogAlertsPointer": "Os limites de dispositivo e os alertas de log de eventos são configurados no recurso Alertas desta política.",
-        "openAlertsFeature": "Abrir Alertas"
+        "openAlertsFeature": "Abrir Alertas",
+        "legacyAlertRulesMovedToAlerts": "{{count}} regra(s) de alerta legada(s) salvas nesta aba foram movidas para o recurso Alertas desta política. O monitoramento não as armazena mais."
       },
       "pamTab": {
         "captureWindowsUACElevationPrompts": "Capturar solicitações de elevação do UAC do Windows",

--- a/packages/shared/src/validators/alertRuleConditions.test.ts
+++ b/packages/shared/src/validators/alertRuleConditions.test.ts
@@ -77,6 +77,29 @@ describe('alertRuleConditionSchema', () => {
   it('rejects a metric condition with no metric name', () => {
     expect(alertRuleConditionSchema.safeParse({ type: 'metric', operator: 'gt', value: 85 }).success).toBe(false);
   });
+
+  it('accepts `threshold` as an alias of `metric` and canonicalizes it', () => {
+    // handlers/threshold.ts declares `type: 'threshold'` with aliases ['metric'],
+    // and the pre-consolidation AI tool description advertised it, so rows exist.
+    const r = alertRuleConditionSchema.safeParse({ type: 'threshold', metric: 'cpu', operator: 'gt', value: 85 });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.type).toBe('metric');
+  });
+
+  it('reports the offending field on a threshold-typed condition, not a bare union error', () => {
+    const r = alertRuleConditionSchema.safeParse({ type: 'threshold', metric: 'bogus', operator: 'gt', value: 85 });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path.join('.') === 'metric')).toBe(true);
+      expect(JSON.stringify(r.error.issues)).not.toContain('Invalid input');
+    }
+  });
+
+  it('names the accepted condition types when `type` is unrecognised', () => {
+    const r = alertRuleConditionSchema.safeParse({ type: 'network', metric: 'network', operator: 'gt', value: 85 });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(JSON.stringify(r.error.issues)).toContain('metric');
+  });
 });
 
 describe('alertRuleInlineSettingsSchema', () => {

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -771,7 +771,12 @@ export const ALERT_METRIC_NAMES = [
 ] as const;
 
 const metricConditionSchema = z.object({
-  type: z.literal('metric'),
+  // `threshold` is the evaluator's OWN canonical name for this handler
+  // (handlers/threshold.ts declares `type: 'threshold'` with `aliases: ['metric']`)
+  // and the pre-consolidation AI tool docs advertised it, so stored rows carry
+  // it. Canonicalize to `metric` — the spelling every other surface (editor,
+  // decompose, docs) uses — exactly as `status` is folded into `offline` below.
+  type: z.enum(['metric', 'threshold']).transform(() => 'metric' as const),
   metric: z.enum(ALERT_METRIC_NAMES),
   // `neq` is included because the evaluator supports it — threshold.ts's own
   // validate() accepts gt/gte/lt/lte/eq/neq. The editor has always offered
@@ -811,7 +816,18 @@ const eventLogConditionSchema = z.object({
   windowMinutes: z.number().int().min(1).max(1440).default(15),
 });
 
-export const alertRuleConditionSchema = z.union([
+// discriminatedUnion, not union: with a plain union every member fails on a
+// malformed condition and Zod surfaces a bare `invalid_union` whose message is
+// "Invalid input" — the HTTP and AI surfaces then tell the caller nothing about
+// WHICH field is wrong. Discriminating on `type` picks exactly one member and
+// reports that member's own issue (e.g. the metric enum message), and an
+// unrecognised `type` gets a message naming every accepted type.
+//
+// Zod 4 supports a discriminator that is an enum with a `.transform()` (the
+// `metric|threshold` and `offline|status` aliases below) and an option that is
+// itself a piped object schema (offline's duration fold) — both are exercised
+// by alertRuleConditions.test.ts, which is what keeps this switch honest.
+export const alertRuleConditionSchema = z.discriminatedUnion('type', [
   metricConditionSchema,
   offlineConditionSchema,
   eventLogConditionSchema,


### PR DESCRIPTION
## Summary

Follow-up to #2946, which was merged while its post-open review fix wave was still in flight — these are the four review commits that missed the squash, ported onto current main. Two Critical and six Important findings from the four-agent review (code-reviewer, test-analyzer, comment-analyzer, silent-failure-hunter), plus assorted minors.

Because the consolidation migration shipped with #2946, the migration-side fixes are restructured as a **new forward-fix migration** (`2026-07-30-b-drop-never-firing-metric-alert-rules.sql`) rather than edits to the shipped file (which this PR does not touch).

## Critical fixes

- **Legacy `metric:"network"` rules would brick the Alerts tab.** The old Monitoring editor offered a "Network Usage" metric the evaluator never supported — such rules never fired, but post-consolidation they hard-fail every save of the policy's Alerts tab with an unactionable error, and the UI rendered them as ordinary editable conditions. The new migration drops never-firing single-condition metric rules (missing/unknown metric name, no alerts referencing them) from **any** feature link — on already-migrated DBs they now live under alert_rule links — with warning counts, and rebuilds the affected mirrors. The UI now amber-flags unsupported metric names with the same read-only treatment as retired condition types.
- **Vestigial delete = silent data loss.** `deleteNormalizedRows`' monitoring case still hard-deleted any `config_policy_alert_rules` rows under a monitoring link on every ordinary Monitoring-tab save. Post-migration that's a no-op, but in an image-before-migrate deployment it silently destroys legacy rules. Removed, with a regression test.

## Important fixes

- `type:"threshold"` (the evaluator's canonical name, previously advertised by the AI tool) is accepted and canonicalized to `metric`, mirroring `status`→`offline`.
- Condition schema switched to a discriminated union + shared issue-flattening helper (`apps/api/src/lib/zodIssues.ts`) wired into all 14 feature-link 400 bodies and the AI tool: errors now name the actual field (`items.0.conditions.0.metric`) instead of a bare "Invalid input".
- **Validation-order bug**: `updateFeatureLink` deleted normalized rows before validating the replacement payload; `assertDecomposableInlineSettings` now runs before any write.
- `alerts.mdx` (cross-linked 3× by #2946 as the authoritative rule-authoring doc) rewritten — it still advertised `custom` and `network usage` and never documented event-log conditions.
- AI tool description accuracy: canonical metric names with alias mapping, event-log level documented as a floor ("this level and above"), and removal of an overclaim — agent-side watch alerting (`alertOnStop`/`alertSeverity`) is delivered but not implemented at runtime in any layer (see #2949).
- PATCH-path service-layer decompose tests and AI-tool `update`-action tests (both were POST/add-only).

## Minors

Retired-condition header comment corrected; metric-aware value bounds (no `max=100` for `processCount`); 15 orphaned i18n keys removed ×7 locales (parity intact); MonitoringTab shows an info banner instead of silently discarding a legacy mirror; `titleTemplate`/`messageTemplate`/`sortOrder`/`autoResolveConditions` declared in the tab's types with a preservation test.

## Known limitations

- The shipped migration's dedupe `UPDATE` seq-scans `alerts` (no index on `config_policy_id`) on the single boot where duplicates exist; deliberately not adding an index to the hottest table for a one-time scan.
- Both migration integration suites run only in the **Integration Tests** job — non-blocking on PRs, required on main. Confirm that job before/after merge.

## Testing

shared 1613 ✓ · api unit 18958 ✓ · web 4717 ✓ · integration: shipped-migration suite (unmodified, against main's file) + new `neverFiringRuleCleanup` suite + partner watermark, 34 ✓ · db:check-drift clean · docs build ✓ · tsc clean (api, web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
