### PR TITLE
fix(viewer): bump event-listener to 5.4.2 for RUSTSEC-2026-0221 (#2972)

### DIFF
--- a/apps/viewer/src-tauri/Cargo.lock
+++ b/apps/viewer/src-tauri/Cargo.lock
@@ -1069,11 +1069,10 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
Closes #2972.

Picking this up since it was unassigned and is blocking `Security Scanning` on main and every open PR — happy to hand it back if you already had a fix in flight.

## Why a bump and not an ignore

A patched release exists. The advisory's own metadata gives the range:

```toml
[versions]
patched = [">= 5.4.2"]
unaffected = ["< 5.1.0"]
```

and `5.4.2` is published and not yanked on crates.io (checked against `/api/v1/crates/event-listener/versions`).

`cargo update -p event-listener --precise 5.4.2` in `apps/viewer/src-tauri` leaves **166 dependencies unchanged**. The entire diff is the version, its checksum, and `concurrent-queue`, which 5.4.2 no longer depends on:

```diff
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
- "concurrent-queue",
   "parking",
   "pin-project-lite",
 ]
```

**Deliberately not done:** no `--ignore RUSTSEC-2026-0221` entry to carry forward, and no relaxing of `--deny warnings`. That flag is what makes an `unsound` (rather than `vulnerability`) advisory fail the job, and it is the reason this surfaced at all — worth keeping as-is.

Scope matches your analysis: only `apps/viewer/src-tauri` is affected, since `apps/helper/src-tauri/Cargo.lock` has no `event-listener` entry and its audit step was already passing.

## Verification caveat — please lean on CI here

I could **not** run `cargo audit` locally. This machine had no Rust toolchain; after installing one, building `cargo-audit` fails in my environment at the linker (`cc` returns `open terminal failed: not a terminal`).

What I did verify:
- `cargo update` resolves cleanly to 5.4.2 with no other dependency movement.
- 5.4.2 satisfies the advisory's published `patched` range.
- The diff is lockfile-only.

CI's `Cargo Audit` job is the authoritative check. If it comes back red, this needs a different approach rather than a rubber stamp.
