### PR TITLE
fix(api): exempt live installer bootstrap tokens from the on-demand enrollment-key purge (#2832)

### DIFF
--- a/apps/api/src/jobs/enrollmentKeyCleanup.ts
+++ b/apps/api/src/jobs/enrollmentKeyCleanup.ts
@@ -28,7 +28,10 @@
  * `installer_bootstrap_tokens` row referencing the key is still live (its own
  * `expires_at` in the future) AND unexhausted (`consumed_count < max_usage`);
  * such a key is left for a later sweep, once its last token has expired or
- * been fully consumed.
+ * been fully consumed. The predicate itself lives in
+ * `services/enrollmentKeyPurgeGuards.ts` because the on-demand purge route
+ * named above needs the identical guard (#2832) — it was missed there for two
+ * releases while it lived inline here.
  *
  * Scheduling:
  *   - Repeat cron: 04:00 UTC daily (pattern "0 4 * * *")
@@ -56,10 +59,11 @@
  */
 
 import { Queue, Worker, Job } from 'bullmq';
-import { and, eq, gt, isNotNull, lt, notExists, sql } from 'drizzle-orm';
+import { and, isNotNull, lt } from 'drizzle-orm';
 import * as dbModule from '../db';
-import { enrollmentKeys, installerBootstrapTokens } from '../db/schema';
+import { enrollmentKeys } from '../db/schema';
 import { captureException } from '../services/sentry';
+import { hasNoLiveUnexhaustedBootstrapToken } from '../services/enrollmentKeyPurgeGuards';
 import { getBullMQConnection } from '../services/redis';
 
 const QUEUE_NAME = 'enrollment-key-cleanup';
@@ -83,31 +87,6 @@ function getPurgeAfterDays(): number {
   const parsed = parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_PURGE_AFTER_DAYS;
 }
-
-/**
- * Correlated NOT EXISTS guard (#2775): evaluates true — i.e. the outer
- * `enrollmentKeys` row is eligible for the purge — only when NO
- * `installer_bootstrap_tokens` row still points at it with both `expires_at`
- * in the future AND `consumed_count < max_usage` (a "live, unexhausted"
- * token). When such a token does exist, this evaluates false and the AND'd
- * outer WHERE excludes the key from the DELETE; it survives to a later
- * sweep, once its last token has expired or been fully consumed. Matches the
- * `exists`/`notExists` correlated-subquery idiom used by
- * `services/vulnerabilityCorrelation.ts`.
- */
-const hasNoLiveUnexhaustedBootstrapToken = () =>
-  notExists(
-    dbModule.db
-      .select({ one: sql`1` })
-      .from(installerBootstrapTokens)
-      .where(
-        and(
-          eq(installerBootstrapTokens.parentEnrollmentKeyId, enrollmentKeys.id),
-          gt(installerBootstrapTokens.expiresAt, new Date()),
-          lt(installerBootstrapTokens.consumedCount, installerBootstrapTokens.maxUsage),
-        ),
-      ),
-  );
 
 const runWithSystemDbAccess = async <T>(fn: () => Promise<T>): Promise<T> => {
   if (typeof dbModule.withSystemDbAccessContext !== 'function') {

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -43,6 +43,7 @@ import {
   BootstrapTokenIssuanceError,
 } from "../services/installerBootstrapTokenIssuance";
 import { assertTtlWithinCap, clampTtlToCap } from "../services/enrollmentDefaults";
+import { hasNoLiveUnexhaustedBootstrapToken } from "../services/enrollmentKeyPurgeGuards";
 import { captureException } from "../services/sentry";
 
 // ============================================================
@@ -962,9 +963,24 @@ enrollmentKeyRoutes.post(
 // POST /enrollment-keys/purge-expired - Bulk hard-delete all expired
 // enrollment keys visible to the caller (org/partner/system scoped, same as
 // the GET / list route). Keys with expiresAt IS NULL are never matched by
-// the `lt` condition below and are therefore never deleted. Hard delete is
-// safe here: installer_bootstrap_tokens and deployment_invites both carry
-// ON DELETE CASCADE against enrollment_keys.
+// the `lt` condition below and are therefore never deleted.
+//
+// Hard delete is NOT unconditionally safe (#2832): installer_bootstrap_tokens
+// and deployment_invites both carry ON DELETE CASCADE against
+// enrollment_keys, and for bootstrap tokens that cascade is exactly the
+// problem. The Add Device modal's parent key is a transient 60-minute
+// container, while the bootstrap token minted from it keeps its own
+// independent TTL of up to a year — so a key becomes purge-eligible here one
+// hour after creation while its installer link is still live for another 30
+// days. This route has no grace period at all (unlike the nightly sweep's
+// 7 days), which makes it the FASTEST path to that data loss: one click on
+// the web UI's "Delete expired" button. The `hasNoLiveUnexhaustedBootstrapToken()`
+// condition below is therefore load-bearing, and is shared verbatim with
+// jobs/enrollmentKeyCleanup.ts via services/enrollmentKeyPurgeGuards.ts.
+//
+// deployment_invites needs no such exemption — it has no independent expiry,
+// so an invite is redeemable exactly while its enrollment key is (#2821,
+// pinned by cases (e)-(h) of jobs/enrollmentKeyCleanup.integration.test.ts).
 //
 // Registered BEFORE the /:id-parameterized routes (GET /:id, POST
 // /:id/rotate, DELETE /:id, etc.) so "purge-expired" is never captured as an
@@ -1004,6 +1020,14 @@ enrollmentKeyRoutes.post(
     // never-expiring keys are never touched.
     conditions.push(
       lt(enrollmentKeys.expiresAt, new Date()) as ReturnType<typeof eq>,
+    );
+
+    // #2832: exempt any key still backing a live, unexhausted installer
+    // bootstrap token — see the route's header comment above and the shared
+    // guard's docblock. Without this, "Delete expired" cascades away
+    // 30-day/1-year installer links whose 60-minute parent key aged out.
+    conditions.push(
+      hasNoLiveUnexhaustedBootstrapToken() as ReturnType<typeof eq>,
     );
 
     const deletedRows = await db

--- a/apps/api/src/routes/enrollmentKeysPurgeExpired.integration.test.ts
+++ b/apps/api/src/routes/enrollmentKeysPurgeExpired.integration.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Real-Postgres coverage for the #2832 live-bootstrap-token exemption on
+ * `POST /enrollment-keys/purge-expired` — the on-demand, tenant-scoped
+ * counterpart to the nightly sweep, and the route behind the web UI's
+ * "Delete expired" button (`EnrollmentKeyManager.tsx`, `delete-expired-keys`).
+ *
+ * #2775 added the exemption to the sweep (`jobs/enrollmentKeyCleanup.ts`).
+ * This route never got it, and it is the WORSE of the two paths:
+ *   - the sweep only touches keys that expired 7+ days ago; this route has NO
+ *     grace period, so a key is eligible the moment it expires,
+ *   - the Add Device modal mints its parent key with the default 60-minute
+ *     TTL, while the bootstrap token minted from it carries its own
+ *     independent TTL of up to 365 days,
+ *   - `installer_bootstrap_tokens.parent_enrollment_key_id` is ON DELETE
+ *     CASCADE.
+ * So one click, 60 minutes after an admin generated a 30-day installer link,
+ * destroyed that link. Redemption then hit the `no_row` branch in
+ * `routes/installer.ts` and the installer 404'd.
+ *
+ * Why this suite and not just the unit tests: `enrollmentKeys_get_rotate_delete.test.ts`
+ * mocks `../db` wholesale, so its `where()` mock returns whatever the test
+ * tells it to regardless of the predicate — it can assert the exemption's SQL
+ * SHAPE but can never prove Postgres EVALUATES the correlated NOT EXISTS
+ * per row. It also cannot see the CASCADE at all. This suite drives the REAL
+ * route (real JWT, real `authMiddleware`, real `breeze_app` RLS context)
+ * against the test database.
+ *
+ * Cases mirror (a)-(d) of `jobs/enrollmentKeyCleanup.integration.test.ts`:
+ *   (a) live, unexhausted token            -> key SURVIVES the purge
+ *   (b) token itself expired                -> key is DELETED
+ *   (c) token fully consumed (>= max_usage) -> key is DELETED
+ *   (d) no bootstrap tokens at all          -> key is DELETED (regression
+ *       guard on the pre-existing behaviour)
+ * plus two properties that are specific to the ROUTE rather than the sweep:
+ *   (e) NO grace period — a key that expired seconds ago with no live token is
+ *       purged immediately. This is the deliberate difference from the sweep's
+ *       7 days, and pinning it is what stops someone "fixing" #2832 by
+ *       smuggling a grace period in here instead of the exemption.
+ *   (f) tenant scope — another org's expired key is untouched by an
+ *       org-scoped caller.
+ *
+ * Co-located with the route per the repo's test-placement convention, so it
+ * must be hand-listed in BOTH `vitest.integration.config.ts` (`include`) and
+ * `vitest.config.ts` (`exclude`). Miss either edit and it silently never runs
+ * in CI, or reds the no-DB unit job on ECONNREFUSED.
+ */
+import '../__tests__/integration/setup';
+
+import { describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+
+import { db, withSystemDbAccessContext } from '../db';
+import { enrollmentKeys, installerBootstrapTokens } from '../db/schema';
+import { createAccessToken, type TokenPayload } from '../services/jwt';
+import { setupTestEnvironment, type TestEnvironment } from '../__tests__/integration/db-utils';
+import { enrollmentKeyRoutes } from './enrollmentKeys';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+/**
+ * The purge route is `requireMfa()`-gated and `setupTestEnvironment` mints its
+ * token with `mfa: false`, so re-mint the same identity with `mfa: true`.
+ * Every other claim is copied from the seeded row's defaults (aep/mep = 1;
+ * `sid` must be non-empty or authMiddleware rejects the access token).
+ */
+async function mfaSatisfiedToken(env: TestEnvironment): Promise<string> {
+  const payload: Omit<TokenPayload, 'type'> = {
+    sub: env.user.id,
+    email: env.user.email,
+    roleId: env.role.id,
+    orgId: env.organization.id,
+    partnerId: env.partner.id,
+    scope: 'organization',
+    mfa: true,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  };
+  return createAccessToken(payload);
+}
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route('/enrollment-keys', enrollmentKeyRoutes);
+  return app;
+}
+
+async function purgeExpired(app: Hono, token: string): Promise<Response> {
+  return app.request('/enrollment-keys/purge-expired', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+/**
+ * An expired parent enrollment key, optionally with one bootstrap token
+ * hanging off it. `expiredMinutesAgo` defaults to 60 — the shape the Add
+ * Device modal actually produces (DEFAULT_ENROLLMENT_KEY_TTL_MINUTES), not a
+ * contrived long-dead row.
+ *
+ * The token always takes the parent's `orgId`, exactly as
+ * `installerBootstrapTokenIssuance.ts` does. That is load-bearing for the RLS
+ * reasoning in the shared guard's docblock: the exemption subquery runs inside
+ * the caller's org-scoped context, so a token stamped with a DIFFERENT org
+ * would be invisible to it and the guard would silently fail open.
+ */
+async function seedKey(opts: {
+  orgId: string;
+  siteId: string;
+  unique: string;
+  expiredMinutesAgo?: number;
+  token?: { expiresAt: Date; createdAt?: Date; maxUsage: number; consumedCount: number };
+}): Promise<{ keyId: string; tokenId: string | null }> {
+  const expiredMinutesAgo = opts.expiredMinutesAgo ?? 60;
+  return withSystemDbAccessContext(async () => {
+    const [key] = await db
+      .insert(enrollmentKeys)
+      .values({
+        orgId: opts.orgId,
+        siteId: opts.siteId,
+        name: `transient parent ${opts.unique}`,
+        key: `purge-key-${opts.unique}`,
+        expiresAt: new Date(Date.now() - expiredMinutesAgo * 60 * 1000),
+        maxUsage: 1,
+      })
+      .returning({ id: enrollmentKeys.id });
+    if (!opts.token) return { keyId: key!.id, tokenId: null };
+    const [token] = await db
+      .insert(installerBootstrapTokens)
+      .values({
+        token: `purge-token-${opts.unique}`,
+        orgId: opts.orgId,
+        parentEnrollmentKeyId: key!.id,
+        siteId: opts.siteId,
+        maxUsage: opts.token.maxUsage,
+        consumedCount: opts.token.consumedCount,
+        ...(opts.token.createdAt ? { createdAt: opts.token.createdAt } : {}),
+        expiresAt: opts.token.expiresAt,
+      })
+      .returning({ id: installerBootstrapTokens.id });
+    return { keyId: key!.id, tokenId: token!.id };
+  });
+}
+
+async function keyRowExists(id: string): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({ id: enrollmentKeys.id })
+      .from(enrollmentKeys)
+      .where(eq(enrollmentKeys.id, id));
+    return !!row;
+  });
+}
+
+async function tokenRowExists(id: string): Promise<boolean> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({ id: installerBootstrapTokens.id })
+      .from(installerBootstrapTokens)
+      .where(eq(installerBootstrapTokens.id, id));
+    return !!row;
+  });
+}
+
+/** One day out — a modest stand-in for the 30-day/1-year links #2832 is about. */
+const TOKEN_LIVE_UNTIL = () => new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+describe('POST /enrollment-keys/purge-expired — live bootstrap token exemption (#2832, real Postgres)', () => {
+  runDb('(a) an expired key holding a live, unexhausted bootstrap token SURVIVES the purge — and so does its token', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const token = await mfaSatisfiedToken(env);
+
+    const { keyId, tokenId } = await seedKey({
+      orgId: env.organization.id,
+      siteId: env.site.id,
+      unique,
+      token: { expiresAt: TOKEN_LIVE_UNTIL(), maxUsage: 25, consumedCount: 0 },
+    });
+    // A same-org key that MUST die in the same request. Without it, the
+    // survive-assertion below would also pass if the DELETE matched nothing at
+    // all (wrong RLS context, swallowed predicate error).
+    const { keyId: canaryId } = await seedKey({
+      orgId: env.organization.id,
+      siteId: env.site.id,
+      unique: `${unique}-canary`,
+    });
+
+    const res = await purgeExpired(makeApp(), token);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; deletedCount: number };
+    expect(body.success).toBe(true);
+    // Org-scoped purge, so the count IS deterministic here (unlike the
+    // system-wide sweep): exactly the canary.
+    expect(body.deletedCount).toBe(1);
+
+    expect(await keyRowExists(canaryId)).toBe(false); // the purge really ran
+    expect(await keyRowExists(keyId)).toBe(true);
+    expect(await tokenRowExists(tokenId!)).toBe(true);
+  });
+
+  runDb('(b) an expired key whose token has itself expired is DELETED — liveness is a strict now() boundary', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const token = await mfaSatisfiedToken(env);
+
+    const { keyId, tokenId } = await seedKey({
+      orgId: env.organization.id,
+      siteId: env.site.id,
+      unique,
+      token: {
+        // expires_at must be strictly after created_at (DB CHECK
+        // installer_bootstrap_tokens_expires_after_created) — backdate both.
+        createdAt: new Date(Date.now() - 30 * 60 * 1000),
+        expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+        maxUsage: 25,
+        consumedCount: 0,
+      },
+    });
+
+    const res = await purgeExpired(makeApp(), token);
+
+    expect(res.status).toBe(200);
+    expect(await keyRowExists(keyId)).toBe(false);
+    // The CASCADE is real: the dead token goes with its parent. This is what
+    // makes case (a)'s token assertion a meaningful one rather than vacuous.
+    expect(await tokenRowExists(tokenId!)).toBe(false);
+  });
+
+  runDb('(c) an expired key whose token is fully consumed (consumed_count >= max_usage) is DELETED', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const token = await mfaSatisfiedToken(env);
+
+    const { keyId } = await seedKey({
+      orgId: env.organization.id,
+      siteId: env.site.id,
+      unique,
+      // Still unexpired, but spent — the arm that would survive if the guard
+      // only checked expiry.
+      token: { expiresAt: TOKEN_LIVE_UNTIL(), maxUsage: 5, consumedCount: 5 },
+    });
+
+    const res = await purgeExpired(makeApp(), token);
+
+    expect(res.status).toBe(200);
+    expect(await keyRowExists(keyId)).toBe(false);
+  });
+
+  runDb('(d) an expired key with no bootstrap tokens at all is DELETED — pre-existing behaviour is unchanged', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const token = await mfaSatisfiedToken(env);
+
+    const { keyId } = await seedKey({
+      orgId: env.organization.id,
+      siteId: env.site.id,
+      unique,
+    });
+
+    const res = await purgeExpired(makeApp(), token);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).deletedCount).toBe(1);
+    expect(await keyRowExists(keyId)).toBe(false);
+  });
+
+  runDb('(e) has NO grace period — a key that expired seconds ago is purged immediately (deliberately unlike the nightly sweep)', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const env = await setupTestEnvironment({ scope: 'organization' });
+    const token = await mfaSatisfiedToken(env);
+
+    // Well inside the sweep's 7-day window — the sweep would retain this row.
+    // This route is on-demand admin hygiene and is supposed to take it.
+    const { keyId } = await seedKey({
+      orgId: env.organization.id,
+      siteId: env.site.id,
+      unique,
+      expiredMinutesAgo: 1,
+    });
+
+    const res = await purgeExpired(makeApp(), token);
+
+    expect(res.status).toBe(200);
+    expect(await keyRowExists(keyId)).toBe(false);
+  });
+
+  runDb('(f) stays inside the caller\'s tenant — another org\'s expired key is untouched', async () => {
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const callerEnv = await setupTestEnvironment({ scope: 'organization' });
+    const otherEnv = await setupTestEnvironment({ scope: 'organization' });
+    const token = await mfaSatisfiedToken(callerEnv);
+
+    const { keyId: ownKeyId } = await seedKey({
+      orgId: callerEnv.organization.id,
+      siteId: callerEnv.site.id,
+      unique: `${unique}-own`,
+    });
+    const { keyId: foreignKeyId } = await seedKey({
+      orgId: otherEnv.organization.id,
+      siteId: otherEnv.site.id,
+      unique: `${unique}-foreign`,
+    });
+
+    const res = await purgeExpired(makeApp(), token);
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).deletedCount).toBe(1);
+    expect(await keyRowExists(ownKeyId)).toBe(false);
+    expect(await keyRowExists(foreignKeyId)).toBe(true);
+  });
+});

--- a/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
 
 // Shared mutable gates so individual tests can flip MFA/permission denial at
 // request time — the route registers `requireMfa()` / `requirePermission()`
@@ -43,6 +44,16 @@ vi.mock('../db/schema', () => ({
     expiresAt: 'enrollmentKeys.expiresAt',
     createdAt: 'enrollmentKeys.createdAt',
     createdBy: 'enrollmentKeys.createdBy',
+  },
+  // Referenced by the #2832 purge exemption
+  // (services/enrollmentKeyPurgeGuards.ts), which the purge-expired route
+  // pulls into its DELETE predicate.
+  installerBootstrapTokens: {
+    id: 'installerBootstrapTokens.id',
+    parentEnrollmentKeyId: 'installerBootstrapTokens.parentEnrollmentKeyId',
+    expiresAt: 'installerBootstrapTokens.expiresAt',
+    consumedCount: 'installerBootstrapTokens.consumedCount',
+    maxUsage: 'installerBootstrapTokens.maxUsage',
   },
 }));
 
@@ -204,6 +215,55 @@ function mockDeleteWhereReturningCapture(rows: any[]): () => any {
     }),
   } as any);
   return () => captured;
+}
+
+/**
+ * The #2832 exemption builds a correlated NOT EXISTS subquery via
+ * `db.select(...).from(...).where(...)`. It never executes here (no Postgres
+ * in this suite) — it only has to satisfy drizzle's `SQLWrapper` duck-typing
+ * (a `getSQL()` method) so `notExists(...)` can embed it. Wrapping the REAL
+ * condition production code built (via the unmocked drizzle `and`/`eq`/`gt`/
+ * `lt`) means the captured WHERE genuinely reflects the generated predicate
+ * rather than a canned stand-in. Mirrors the identical stub in
+ * jobs/enrollmentKeyCleanup.test.ts.
+ *
+ * Registered with `mockReturnValue` (not `...Once`) so it stays in place for
+ * however many times the guard is built, and does not consume the
+ * `mockReturnValueOnce` queue the single-record `db.select` helpers rely on.
+ */
+/**
+ * Flattens a drizzle condition to its static text. The existing purge tests
+ * assert via `JSON.stringify`, which cannot see inside the #2832 exemption:
+ * `notExists()` embeds the subquery as an opaque `SQLWrapper` (an object whose
+ * only own property is a `getSQL` function), and JSON.stringify renders that
+ * as `{}`. Recursing through `getSQL()` is what makes the subquery's columns
+ * assertable. Same approach as jobs/enrollmentKeyCleanup.test.ts's `sqlText`.
+ */
+function sqlText(q: unknown): string {
+  if (q == null) return '';
+  if (typeof q === 'string') return q;
+  if (q instanceof Date) return q.toISOString();
+  const obj = q as {
+    queryChunks?: unknown[];
+    value?: unknown;
+    getSQL?: () => unknown;
+  };
+  if (Array.isArray(obj.queryChunks)) return obj.queryChunks.map(sqlText).join(' ');
+  if (Array.isArray(obj.value)) return (obj.value as unknown[]).map(sqlText).join('');
+  if (obj.value instanceof Date) return obj.value.toISOString();
+  if (typeof obj.value === 'string' || typeof obj.value === 'number') return String(obj.value);
+  if (typeof obj.getSQL === 'function') return sqlText(obj.getSQL());
+  return '';
+}
+
+function mockBootstrapTokenExemptionSubquery() {
+  vi.mocked(db.select).mockReturnValue({
+    from: () => ({
+      where: (cond: unknown) => ({
+        getSQL: () => sql`select 1 from installer_bootstrap_tokens where ${cond}`,
+      }),
+    }),
+  } as any);
 }
 
 describe('enrollment key routes — get, rotate, delete', () => {
@@ -495,6 +555,10 @@ describe('enrollment key routes — get, rotate, delete', () => {
   // POST /purge-expired — Bulk-delete expired enrollment keys in caller scope
   // ============================================
   describe('POST /enrollment-keys/purge-expired', () => {
+    beforeEach(() => {
+      mockBootstrapTokenExemptionSubquery();
+    });
+
     it('purges expired keys within the org-scoped caller\'s org and returns the count', async () => {
       const getCaptured = mockDeleteWhereReturningCapture([
         { id: 'key-1' },
@@ -646,6 +710,40 @@ describe('enrollment key routes — get, rotate, delete', () => {
       // No org-scoping column present — only the expired condition.
       expect(conditionJson).not.toContain('enrollmentKeys.orgId');
       expect(conditionJson).toContain('enrollmentKeys.expiresAt');
+    });
+
+    // #2832: the nightly sweep got the live-bootstrap-token exemption in
+    // #2775; this route — the on-demand counterpart behind the web UI's
+    // "Delete expired" button — did not, and is the FASTER path to the same
+    // data loss (no grace period at all vs. the sweep's 7 days).
+    //
+    // This is a SQL-shape assertion: with `db` mocked there is no Postgres to
+    // evaluate the correlated NOT EXISTS per row. Proof that Postgres actually
+    // spares the right rows lives in
+    // routes/enrollmentKeysPurgeExpired.integration.test.ts. What is
+    // meaningfully verifiable here is that the predicate reaches the DELETE at
+    // all and correlates on the right columns.
+    it('exempts keys still backing a live, unexhausted installer bootstrap token (#2832)', async () => {
+      const getCaptured = mockDeleteWhereReturningCapture([{ id: 'key-1' }]);
+
+      const res = await app.request('/enrollment-keys/purge-expired', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      expect(res.status).toBe(200);
+      const text = sqlText(getCaptured());
+
+      expect(text).toContain('not exists');
+      // Correlated on the outer enrollment_keys row...
+      expect(text).toContain('installerBootstrapTokens.parentEnrollmentKeyId');
+      expect(text).toContain('enrollmentKeys.id');
+      // ...and both liveness arms are present: unexpired AND unexhausted.
+      // Dropping either would silently re-open the cascade for half the
+      // token population.
+      expect(text).toContain('installerBootstrapTokens.expiresAt');
+      expect(text).toContain('installerBootstrapTokens.consumedCount');
+      expect(text).toContain('installerBootstrapTokens.maxUsage');
     });
 
     it('is blocked without MFA (requireMfa)', async () => {

--- a/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
@@ -218,20 +218,6 @@ function mockDeleteWhereReturningCapture(rows: any[]): () => any {
 }
 
 /**
- * The #2832 exemption builds a correlated NOT EXISTS subquery via
- * `db.select(...).from(...).where(...)`. It never executes here (no Postgres
- * in this suite) — it only has to satisfy drizzle's `SQLWrapper` duck-typing
- * (a `getSQL()` method) so `notExists(...)` can embed it. Wrapping the REAL
- * condition production code built (via the unmocked drizzle `and`/`eq`/`gt`/
- * `lt`) means the captured WHERE genuinely reflects the generated predicate
- * rather than a canned stand-in. Mirrors the identical stub in
- * jobs/enrollmentKeyCleanup.test.ts.
- *
- * Registered with `mockReturnValue` (not `...Once`) so it stays in place for
- * however many times the guard is built, and does not consume the
- * `mockReturnValueOnce` queue the single-record `db.select` helpers rely on.
- */
-/**
  * Flattens a drizzle condition to its static text. The existing purge tests
  * assert via `JSON.stringify`, which cannot see inside the #2832 exemption:
  * `notExists()` embeds the subquery as an opaque `SQLWrapper` (an object whose
@@ -256,6 +242,20 @@ function sqlText(q: unknown): string {
   return '';
 }
 
+/**
+ * The #2832 exemption builds a correlated NOT EXISTS subquery via
+ * `db.select(...).from(...).where(...)`. It never executes here (no Postgres
+ * in this suite) — it only has to satisfy drizzle's `SQLWrapper` duck-typing
+ * (a `getSQL()` method) so `notExists(...)` can embed it. Wrapping the REAL
+ * condition production code built (via the unmocked drizzle `and`/`eq`/`gt`/
+ * `lt`) means the captured WHERE genuinely reflects the generated predicate
+ * rather than a canned stand-in. Mirrors the identical stub in
+ * jobs/enrollmentKeyCleanup.test.ts.
+ *
+ * Registered with `mockReturnValue` (not `...Once`) so it stays in place for
+ * however many times the guard is built, and does not consume the
+ * `mockReturnValueOnce` queue the single-record `db.select` helpers rely on.
+ */
 function mockBootstrapTokenExemptionSubquery() {
   vi.mocked(db.select).mockReturnValue({
     from: () => ({

--- a/apps/api/src/routes/installer.ts
+++ b/apps/api/src/routes/installer.ts
@@ -41,15 +41,20 @@ export function childEnrollmentKeyTtlMinutes(): number {
  *
  * Revocation is unaffected: installer_bootstrap_tokens.parent_enrollment_key_id
  * is ON DELETE CASCADE, so deleting the parent destroys outstanding tokens
- * before they can ever reach this function. A deliberate admin delete is the
- * ONLY thing that does this — the scheduled `enrollmentKeyCleanup` sweep job
- * (jobs/enrollmentKeyCleanup.ts) that hard-purges long-expired enrollment
- * keys is NOT a second silent ceiling on this TTL: it explicitly exempts any
- * parent key that still has a live, unexhausted bootstrap token, so a
- * 30-day/1-year token cannot be cascade-deleted out from under itself by
- * that job before its own expiry (or full consumption). If you're reading
- * this because you found that job and are wondering whether it re-clamps
- * this TTL, it doesn't — see its header comment for the exemption predicate.
+ * before they can ever reach this function. A deliberate admin delete of a
+ * SPECIFIC key (DELETE /enrollment-keys/:id) is the ONLY thing that does this.
+ * Neither bulk purge path is a second silent ceiling on this TTL: both the
+ * scheduled `enrollmentKeyCleanup` sweep job (jobs/enrollmentKeyCleanup.ts)
+ * and the on-demand `POST /enrollment-keys/purge-expired` route behind the
+ * web UI's "Delete expired" button share the exemption predicate in
+ * services/enrollmentKeyPurgeGuards.ts, which skips any parent key that still
+ * has a live, unexhausted bootstrap token. So a 30-day/1-year token cannot be
+ * cascade-deleted out from under itself by either before its own expiry (or
+ * full consumption). If you're reading this because you found one of those
+ * purges and are wondering whether it re-clamps this TTL, it doesn't — see
+ * that shared guard's docblock for the predicate. (The route was missing the
+ * guard until #2832; it is the faster of the two paths, since it applies no
+ * grace period on top of the parent's 60-minute expiry.)
  *
  * `ttlMinutes`, when supplied, overrides the env default — used to pass an
  * already partner-cap-clamped value (fix round 3, #2776; see the call site

--- a/apps/api/src/services/enrollmentKeyPurgeGuards.ts
+++ b/apps/api/src/services/enrollmentKeyPurgeGuards.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared purge guards for `enrollment_keys`.
+ *
+ * There are TWO code paths that hard-delete expired enrollment keys, and they
+ * must agree on what "safe to delete" means:
+ *
+ *   1. `jobs/enrollmentKeyCleanup.ts` — the nightly system-wide sweep, which
+ *      only touches keys that expired more than `ENROLLMENT_KEY_PURGE_AFTER_DAYS`
+ *      days ago (default 7).
+ *   2. `routes/enrollmentKeys.ts` — `POST /enrollment-keys/purge-expired`, the
+ *      on-demand tenant-scoped counterpart behind the web UI's "Delete expired"
+ *      button, which has NO grace period: a key is eligible the instant it
+ *      expires.
+ *
+ * The exemption below started life inside (1) for #2775 and was missed on (2)
+ * for #2832 — the route was in fact the *faster* path to the same data loss
+ * (60-minute parent expiry + one click, vs. 7 days). It lives here so a future
+ * change to the predicate cannot land on one path and skip the other.
+ */
+
+import { and, eq, gt, lt, notExists, sql } from 'drizzle-orm';
+import * as dbModule from '../db';
+import { enrollmentKeys, installerBootstrapTokens } from '../db/schema';
+
+/**
+ * Correlated NOT EXISTS guard (#2775, #2832): evaluates true — i.e. the outer
+ * `enrollmentKeys` row is eligible for the purge — only when NO
+ * `installer_bootstrap_tokens` row still points at it with both `expires_at`
+ * in the future AND `consumed_count < max_usage` (a "live, unexhausted"
+ * token). When such a token does exist this evaluates false, the AND'd outer
+ * WHERE excludes the key, and it survives to a later purge once its last token
+ * has expired or been fully consumed.
+ *
+ * Why the guard is needed at all: the Add Device modal's parent enrollment key
+ * is a deliberately transient 60-minute container (PR #739 review finding #1),
+ * while the `installer_bootstrap_tokens` row minted from it carries its OWN
+ * independent TTL of up to a year — `routes/installer.ts` no longer clamps the
+ * child to the parent's expiry. `installer_bootstrap_tokens.parent_enrollment_key_id`
+ * is `ON DELETE CASCADE`, so purging that long-dead parent would silently
+ * destroy an admin's still-valid 30-day/1-year installer link; redemption then
+ * lands on the `no_row` branch in `routes/installer.ts` and the installer 404s.
+ *
+ * RLS note (route path): the subquery is evaluated inside whatever DB access
+ * context the caller is running in, so on the request path it only sees
+ * bootstrap tokens the caller's tenant context permits. That is safe rather
+ * than a hole because `installerBootstrapTokenIssuance.ts` always stamps the
+ * token with `orgId: parent.orgId` — a token is visible exactly when its
+ * parent key is, so the guard can never be blinded to a token attached to a
+ * key the caller is able to delete.
+ *
+ * Uses `dbModule.db` at call time (not a destructured import) so unit suites
+ * that `vi.mock('../db')` see their stub. Matches the `exists`/`notExists`
+ * correlated-subquery idiom in `services/vulnerabilityCorrelation.ts`.
+ */
+export const hasNoLiveUnexhaustedBootstrapToken = () =>
+  notExists(
+    dbModule.db
+      .select({ one: sql`1` })
+      .from(installerBootstrapTokens)
+      .where(
+        and(
+          eq(installerBootstrapTokens.parentEnrollmentKeyId, enrollmentKeys.id),
+          gt(installerBootstrapTokens.expiresAt, new Date()),
+          lt(installerBootstrapTokens.consumedCount, installerBootstrapTokens.maxUsage),
+        ),
+      ),
+  );

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -130,6 +130,13 @@ export default defineConfig({
       // fail it on connect. Belongs to vitest.integration.config.ts
       // (registered in its include list).
       'src/jobs/enrollmentKeyCleanup.integration.test.ts',
+      // On-demand enrollment-key purge route real-DB test (#2832
+      // live-bootstrap-token exemption): imports
+      // `__tests__/integration/setup` (real postgres pool + autoMigrate) and
+      // lives in src/routes/ outside the `src/__tests__/integration/**` glob,
+      // so the no-DB unit runner would fail it on connect. Belongs to
+      // vitest.integration.config.ts (registered in its include list).
+      'src/routes/enrollmentKeysPurgeExpired.integration.test.ts',
     ],
     setupFiles: ['src/__tests__/setup.ts'],
     coverage: {

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -161,6 +161,13 @@ export default defineConfig({
       // Queue/Worker classes are mocked; imports
       // `__tests__/integration/setup` (real postgres pool + autoMigrate).
       'src/jobs/enrollmentKeyCleanup.integration.test.ts',
+      // Co-located real-DB integration test for the ON-DEMAND enrollment-key
+      // purge route (#2832): drives the real POST /enrollment-keys/purge-expired
+      // (real JWT + authMiddleware + breeze_app RLS) to prove Postgres spares
+      // keys still backing a live, unexhausted installer bootstrap token. The
+      // mocked route suite can only assert the predicate's shape and cannot
+      // see the ON DELETE CASCADE at all.
+      'src/routes/enrollmentKeysPurgeExpired.integration.test.ts',
     ],
     exclude: [
       // Uses fresh request-pool modules and manages its own temporary role;

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -576,7 +576,7 @@
     "rotateConfirm": "„{{name}}“ jetzt rotieren? Bestehende Registrierungen funktionieren weiterhin, neue Registrierungen müssen jedoch den neuen Schlüssel verwenden.",
     "rotateKey": "Schlüssel rotieren",
     "deleteExpiredTitle": "Abgelaufene Registrierungsschlüssel löschen",
-    "deleteExpiredConfirm": "Alle abgelaufenen Registrierungsschlüssel löschen? Dies kann nicht rückgängig gemacht werden."
+    "deleteExpiredConfirm": "Alle abgelaufenen Registrierungsschlüssel löschen? Schlüssel, die noch einen aktiven Installer-Downloadlink versorgen, bleiben erhalten. Dies kann nicht rückgängig gemacht werden."
   },
   "inboundEmail": {
     "saveError": "Die Einstellungen für eingehende E-Mails konnten nicht gespeichert werden – Ihre Sitzung erfordert möglicherweise eine erneute Bestätigung für MFA. Wiederholen.",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -576,7 +576,7 @@
     "rotateConfirm": "Rotate \"{{name}}\" now? Existing enrollments will continue to work, but new enrollments must use the new key.",
     "rotateKey": "Rotate Key",
     "deleteExpiredTitle": "Delete expired enrollment keys",
-    "deleteExpiredConfirm": "Delete all expired enrollment keys? This cannot be undone."
+    "deleteExpiredConfirm": "Delete all expired enrollment keys? Keys still backing a live installer download link are kept. This cannot be undone."
   },
   "inboundEmail": {
     "saveError": "Could not save inbound email settings — your session may need MFA re-verification. Retry.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -576,7 +576,7 @@
     "rotateConfirm": "¿Rotar \"{{name}}\" ahora? Las inscripciones existentes seguirán funcionando, pero las nuevas inscripciones deben utilizar la nueva clave.",
     "rotateKey": "Rotar clave",
     "deleteExpiredTitle": "Eliminar claves de inscripción caducadas",
-    "deleteExpiredConfirm": "¿Eliminar todas las claves de inscripción caducadas? Esto no se puede deshacer."
+    "deleteExpiredConfirm": "¿Eliminar todas las claves de inscripción caducadas? Se conservan las claves que aún respaldan un enlace de descarga del instalador activo. Esto no se puede deshacer."
   },
   "inboundEmail": {
     "saveError": "No se pudo guardar la configuración del correo electrónico entrante; es posible que su sesión necesite una nueva verificación MFA. Reintentar.",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -576,7 +576,7 @@
     "rotateConfirm": "Renouveler « {{name}} » maintenant ? Les inscriptions existantes continueront de fonctionner, mais les nouvelles inscriptions devront utiliser la nouvelle clé.",
     "rotateKey": "Renouveler la clé",
     "deleteExpiredTitle": "Supprimer les clés d’inscription expirées",
-    "deleteExpiredConfirm": "Supprimer toutes les clés d’inscription expirées ? Cela ne peut pas être annulé."
+    "deleteExpiredConfirm": "Supprimer toutes les clés d’inscription expirées ? Les clés qui alimentent encore un lien de téléchargement d’installateur actif sont conservées. Cela ne peut pas être annulé."
   },
   "inboundEmail": {
     "saveError": "Impossible d’enregistrer les paramètres des courriels entrants : votre session peut nécessiter une nouvelle vérification MFA. Réessayez.",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -576,7 +576,7 @@
     "rotateConfirm": "Renouveler « {{name}} » maintenant ? Les inscriptions existantes continueront de fonctionner, mais les nouvelles inscriptions devront utiliser la nouvelle clé.",
     "rotateKey": "Renouveler la clé",
     "deleteExpiredTitle": "Supprimer les clés d’inscription expirées",
-    "deleteExpiredConfirm": "Supprimer toutes les clés d’inscription expirées ? Cela ne peut pas être annulé."
+    "deleteExpiredConfirm": "Supprimer toutes les clés d’inscription expirées ? Les clés qui alimentent encore un lien de téléchargement d’installateur actif sont conservées. Cela ne peut pas être annulé."
   },
   "inboundEmail": {
     "saveError": "Impossible d’enregistrer les paramètres des e-mails entrants : votre session peut nécessiter une nouvelle vérification MFA. Réessayez.",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -576,7 +576,7 @@
     "rotateConfirm": "Ruotare \"{{name}}\" ora? Le registrazioni esistenti continueranno a funzionare, ma le nuove registrazioni dovranno usare la nuova chiave.",
     "rotateKey": "Ruota chiave",
     "deleteExpiredTitle": "Elimina chiavi di registrazione scadute",
-    "deleteExpiredConfirm": "Eliminare tutte le chiavi di registrazione scadute? Questa operazione non può essere annullata."
+    "deleteExpiredConfirm": "Eliminare tutte le chiavi di registrazione scadute? Le chiavi che alimentano ancora un link di download del programma di installazione attivo vengono conservate. Questa operazione non può essere annullata."
   },
   "inboundEmail": {
     "saveError": "Impossibile salvare le impostazioni email in ingresso: la sessione potrebbe richiedere una nuova verifica MFA. Riprova.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -576,7 +576,7 @@
     "rotateConfirm": "Rotacionar \"{{name}}\" agora? Os registros existentes continuarão funcionando, mas os novos deverão usar a nova chave.",
     "rotateKey": "Rotacionar chave",
     "deleteExpiredTitle": "Excluir chaves de registro expiradas",
-    "deleteExpiredConfirm": "Excluir todas as chaves de registro expiradas? Esta ação não pode ser desfeita."
+    "deleteExpiredConfirm": "Excluir todas as chaves de registro expiradas? As chaves que ainda sustentam um link de download do instalador ativo são mantidas. Esta ação não pode ser desfeita."
   },
   "inboundEmail": {
     "saveError": "Não foi possível salvar as configurações de e-mail de entrada — talvez sua sessão precise de nova verificação MFA. Tente novamente.",


### PR DESCRIPTION
## What

`POST /enrollment-keys/purge-expired` — the on-demand counterpart to the nightly sweep, and the route behind the web UI's **"Delete expired"** button (`EnrollmentKeyManager.tsx`, `data-testid="delete-expired-keys"`) — hard-deleted every expired enrollment key in the caller's tenant scope with **no live-bootstrap-token exemption and no grace period at all**.

`installer_bootstrap_tokens.parent_enrollment_key_id` is `ON DELETE CASCADE`. The Add Device modal mints its parent key with no TTL, so it falls to `DEFAULT_ENROLLMENT_KEY_TTL_MINUTES` = **60 minutes**, while the bootstrap token minted from it carries its **own independent TTL of up to 365 days** (explicitly not bounded by the parent). So 60 minutes after an admin generated a 30-day installer link, one click destroyed it. Redemption then landed on the `no_row` branch at `routes/installer.ts` and the installer 404'd.

PR #2817 added `hasNoLiveUnexhaustedBootstrapToken()` to the nightly sweep for #2775. The same guard was never added here — and this is the **faster** path to the identical data loss: 60 minutes + one click, versus the sweep's 7-day grace period. Not a security hole (auth is scope + `ORGS_WRITE` + `requireMfa()`); routine admin hygiene that silently destroys live credentials, with blast radius scaling by scope — a system-scoped caller purges every org on the instance.

## Changes

- **`services/enrollmentKeyPurgeGuards.ts` (new)** — the correlated `NOT EXISTS` predicate, lifted out of `jobs/enrollmentKeyCleanup.ts` so the scheduled sweep and the on-demand route cannot drift apart again. Both now import it.
- **`routes/enrollmentKeys.ts`** — pushes the guard into the purge `conditions`, and corrects the header comment that asserted *"Hard delete is safe here: installer_bootstrap_tokens and deployment_invites both carry ON DELETE CASCADE"*. Post-#2817 that CASCADE is precisely why it was **not** safe.
- **`routes/installer.ts`** — its docblock promised readers that *"A deliberate admin delete is the ONLY thing that does this"*, a claim the bulk purge button falsified. Now scoped to `DELETE /enrollment-keys/:id` and pointing at the shared guard both purge paths share.
- **Web confirm copy** — *"Delete all expired enrollment keys? **Keys still backing a live installer download link are kept.** This cannot be undone."* One existing key, updated in all 7 locales, so no parity change.

## Tests

New `apps/api/src/routes/enrollmentKeysPurgeExpired.integration.test.ts` drives the **real route** (real JWT, real `authMiddleware`, real `breeze_app` RLS context) against Postgres. Cases (a)-(d) mirror `enrollmentKeyCleanup.integration.test.ts`; (e)-(f) pin properties specific to this route:

| | case | expected |
|---|---|---|
| a | live, unexhausted token | key **survives**, token survives |
| b | token itself expired | key deleted (and cascades the dead token — proves (a) isn't vacuous) |
| c | token fully consumed (`consumed_count >= max_usage`) | key deleted |
| d | no bootstrap tokens at all | key deleted (pre-existing behaviour) |
| e | expired 1 minute ago, no token | deleted — pins the **deliberate absence** of a grace period, so nobody "fixes" this by smuggling one in instead of the exemption |
| f | another org's expired key | untouched |

Survive-cases seed a same-org canary that must die in the same request, so "the row survived" can never be satisfied by a purge that matched nothing.

Also added a SQL-shape assertion to the mocked `enrollmentKeys_get_rotate_delete.test.ts` suite (its 8 existing purge tests never referenced `installerBootstrapTokens`). Both the new unit assertion and integration case (a) were **confirmed to fail with the guard removed** — not assumed.

- `vitest run src/routes/enrollmentKeysPurgeExpired.integration.test.ts` — 6 passed
- `vitest run src/jobs/enrollmentKeyCleanup.integration.test.ts` — 8 passed (the helper extraction changes nothing for the sweep)
- `vitest run src/routes/enrollmentKeys_get_rotate_delete.test.ts src/jobs/enrollmentKeyCleanup.test.ts` — 39 passed
- web `src/lib/i18n` (96 passed) + `EnrollmentKeyManager.test.tsx` (8 passed); `tsc --noEmit` clean

The new integration file is hand-listed in **both** `vitest.integration.config.ts` (`include`) and `vitest.config.ts` (`exclude`), per the co-located-integration-test convention.

## Deliberately out of scope

`DELETE /enrollment-keys/:id` also lacks the check, and that is correct — cascading tokens on an **explicit single-key delete** is the documented revocation mechanism and must stay.

Worth a separate look though: neither that route's response nor its audit `details` reports **how many live bootstrap tokens the delete just destroyed**, so the intended revocation is unobservable. An admin revoking one key has no way to see that they also killed three outstanding installer links. Flagging, not fixing.

Refs #2832

🤖 Generated with [Claude Code](https://claude.com/claude-code)
