### PR TITLE
fix(api): surface the proxy-trust misconfiguration on the TRANSPORT-001 path (#2987)

### DIFF
--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -314,16 +314,20 @@ const opsAlertDeliveriesTotal = new Counter({
   registers: [register]
 });
 
-// Proxy-trust misconfiguration signal (#2364). Counts occurrences (not unique
-// requests — client-IP resolution can run more than once per request) of
-// forwarded-ip headers arriving from a TCP peer outside TRUSTED_PROXY_CIDRS
-// while proxy-header trust is enabled. A nonzero rate in production means the
-// pinned proxy CIDR is stale and per-IP limits/audit attribution are pooling
-// onto the proxy IP. `services/clientIp.ts` holds the thin recorder (same
-// import-cycle rationale as `abuseMetrics.ts`).
+// Proxy-trust misconfiguration signal (#2364, extended by #2987/TRANSPORT-001).
+// Counts occurrences (not unique requests — the trust gate is evaluated more
+// than once per request: FORCE_HTTPS scheme checks, auth-cookie Secure-flag
+// resolution, mTLS header binding, and client-IP resolution each consult it,
+// so a broken deploy increments this 2-4x per request) of trust-gated forwarded
+// headers (CF-Connecting-IP/X-Forwarded-For/X-Real-IP/X-Forwarded-Proto)
+// arriving from a TCP peer outside TRUSTED_PROXY_CIDRS while proxy-header
+// trust is enabled. A nonzero rate in production means the pinned proxy CIDR
+// is stale: per-IP limits/audit attribution pool onto the proxy IP, and under
+// FORCE_HTTPS every non-health route 308-loops. `services/clientIp.ts` holds
+// the thin recorder (same import-cycle rationale as `abuseMetrics.ts`).
 const proxyTrustUntrustedPeerTotal = new Counter({
   name: 'breeze_proxy_trust_untrusted_peer_total',
-  help: 'Forwarded-ip headers seen from a peer outside TRUSTED_PROXY_CIDRS while proxy trust is enabled (stale-pin signal)',
+  help: 'Trust-gated forwarded headers (client-IP headers or X-Forwarded-Proto) seen from a peer outside TRUSTED_PROXY_CIDRS while proxy trust is enabled (stale-pin signal; increments per gate evaluation, not per request)',
   registers: [register]
 });
 

--- a/apps/api/src/services/clientIp.test.ts
+++ b/apps/api/src/services/clientIp.test.ts
@@ -291,9 +291,11 @@ describe('clientIp', () => {
 
     // TRANSPORT-001 regression: the FORCE_HTTPS redirect calls
     // trustsForwardedHeadersFrom and then short-circuits with a 308, so no
-    // handler downstream ever reaches getTrustedClientIp. Before this, a stale
-    // TRUSTED_PROXY_CIDRS produced a total outage (every non-health route 308s,
-    // /health exempt and still 200) with no log line naming the cause.
+    // handler downstream ever reaches getTrustedClientIp. A stale
+    // TRUSTED_PROXY_CIDRS produces a total outage (every non-health route 308s,
+    // /health exempt and still 200) — that fail-closed behavior is intentional
+    // and unchanged; what this adds is the log line naming the cause, which
+    // previously never fired on this path.
     it('warns when trustsForwardedHeadersFrom rejects an untrusted peer carrying X-Forwarded-Proto', () => {
       const trusted = trustsForwardedHeadersFrom(
         makeContext({ 'x-forwarded-proto': 'https' }, '172.30.0.44'),
@@ -323,6 +325,62 @@ describe('clientIp', () => {
       expect(
         trustsForwardedHeadersFrom(makeContext({ 'x-forwarded-proto': 'https' }, '172.30.0.11')),
       ).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('shares per-peer suppression between trustsForwardedHeadersFrom and getTrustedClientIp', () => {
+      const onForwardedHeadersFromUntrustedPeer = vi.fn();
+      setProxyTrustMetricsRecorder({ onForwardedHeadersFromUntrustedPeer });
+
+      // The real production sequence: middleware trust check first, handler
+      // client-IP resolution second — one log line, both metric increments.
+      trustsForwardedHeadersFrom(makeContext({ 'x-forwarded-for': '198.51.100.1' }, '172.30.0.44'));
+      getTrustedClientIp(
+        makeContext({ 'x-forwarded-for': '198.51.100.1' }, '172.30.0.44'),
+        '172.30.0.44',
+      );
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(onForwardedHeadersFromUntrustedPeer).toHaveBeenCalledTimes(2);
+    });
+
+    it('increments the metrics recorder on every trustsForwardedHeadersFrom rejection, even when the log line is suppressed', () => {
+      const onForwardedHeadersFromUntrustedPeer = vi.fn();
+      setProxyTrustMetricsRecorder({ onForwardedHeadersFromUntrustedPeer });
+      const ctx = () => makeContext({ 'x-forwarded-proto': 'https' }, '172.30.0.44');
+
+      trustsForwardedHeadersFrom(ctx());
+      trustsForwardedHeadersFrom(ctx());
+      trustsForwardedHeadersFrom(ctx());
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(onForwardedHeadersFromUntrustedPeer).toHaveBeenCalledTimes(3);
+    });
+
+    // The TRUST_PROXY_HEADERS=false half of the same outage (#2987): a proxy in
+    // front with trust disabled produces the identical 308 loop, so it gets its
+    // own warning variant — without the untrusted-peer metric, whose meaning
+    // ("peer outside TRUSTED_PROXY_CIDRS while trust is enabled") is unchanged.
+    it('warns when trust is disabled entirely but the request carried proxy-forwarded headers', () => {
+      process.env.TRUST_PROXY_HEADERS = 'false';
+      const onForwardedHeadersFromUntrustedPeer = vi.fn();
+      setProxyTrustMetricsRecorder({ onForwardedHeadersFromUntrustedPeer });
+
+      expect(
+        trustsForwardedHeadersFrom(makeContext({ 'x-forwarded-proto': 'https' }, '172.30.0.44')),
+      ).toBe(false);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0]);
+      expect(message).toContain('[proxy-trust]');
+      expect(message).toContain('TRUST_PROXY_HEADERS');
+      expect(message).toContain('172.30.0.44');
+      expect(onForwardedHeadersFromUntrustedPeer).not.toHaveBeenCalled();
+    });
+
+    it('stays silent when trust is disabled and the request carried no forwarded headers', () => {
+      process.env.TRUST_PROXY_HEADERS = 'false';
+      expect(trustsForwardedHeadersFrom(makeContext({}, '172.30.0.44'))).toBe(false);
       expect(warnSpy).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/services/clientIp.test.ts
+++ b/apps/api/src/services/clientIp.test.ts
@@ -5,6 +5,7 @@ import {
   getImmediatePeerIpOrUndefined,
   isTrustedProxySource,
   setProxyTrustMetricsRecorder,
+  trustsForwardedHeadersFrom,
   _resetProxyTrustWarnStateForTests,
 } from './clientIp';
 import type { RequestLike } from './auditEvents';
@@ -286,6 +287,43 @@ describe('clientIp', () => {
       expect(message).toContain('[proxy-trust]');
       expect(message).toContain('172.30.0.44');
       expect(message).toContain('TRUSTED_PROXY_CIDRS');
+    });
+
+    // TRANSPORT-001 regression: the FORCE_HTTPS redirect calls
+    // trustsForwardedHeadersFrom and then short-circuits with a 308, so no
+    // handler downstream ever reaches getTrustedClientIp. Before this, a stale
+    // TRUSTED_PROXY_CIDRS produced a total outage (every non-health route 308s,
+    // /health exempt and still 200) with no log line naming the cause.
+    it('warns when trustsForwardedHeadersFrom rejects an untrusted peer carrying X-Forwarded-Proto', () => {
+      const trusted = trustsForwardedHeadersFrom(
+        makeContext({ 'x-forwarded-proto': 'https' }, '172.30.0.44'),
+      );
+
+      expect(trusted).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0]);
+      expect(message).toContain('[proxy-trust]');
+      expect(message).toContain('172.30.0.44');
+      expect(message).toContain('TRUSTED_PROXY_CIDRS');
+    });
+
+    it('warns when only forwarded-ip headers are present (no X-Forwarded-Proto)', () => {
+      expect(
+        trustsForwardedHeadersFrom(makeContext({ 'x-forwarded-for': '198.51.100.1' }, '172.30.0.44')),
+      ).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not warn for a bare request carrying no forwarded headers at all', () => {
+      expect(trustsForwardedHeadersFrom(makeContext({}, '172.30.0.44'))).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when the peer IS trusted, and still reports trust', () => {
+      expect(
+        trustsForwardedHeadersFrom(makeContext({ 'x-forwarded-proto': 'https' }, '172.30.0.11')),
+      ).toBe(true);
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('does not warn when the immediate peer is trusted — and headers are honored as before', () => {

--- a/apps/api/src/services/clientIp.ts
+++ b/apps/api/src/services/clientIp.ts
@@ -141,9 +141,12 @@ function getImmediatePeerIp(c: RequestLike, fallback: string): string | undefine
 // always means the pinned proxy IP went stale (proxy container recreated
 // without a static `ipv4_address`) — every per-IP rate limit then pools onto
 // the proxy IP and audit-log IP attribution silently records the proxy as the
-// client. Detect it and warn LOUDLY, rate-limited per peer so a burst can't
-// flood logs. Pure in-memory — no I/O on the hot path. Observability only:
-// the returned IP is unchanged.
+// client. Under FORCE_HTTPS the same stale pin is worse: effectiveRequestScheme
+// stops honoring X-Forwarded-Proto, so every non-health route 308-redirect-loops
+// while /health (exempt) keeps returning 200 (TRANSPORT-001, #2987). Detect it
+// and warn LOUDLY, rate-limited per peer so a burst can't flood logs. Pure
+// in-memory — no I/O on the hot path. Observability only: the returned IP is
+// unchanged.
 
 const UNTRUSTED_PEER_WARN_INTERVAL_MS = 15 * 60 * 1000;
 // Hard cap on tracked peers so a rotating set of source IPs can't grow the
@@ -200,15 +203,15 @@ function hasTrustGatedForwardedHeaders(c: RequestLike): boolean {
   );
 }
 
-function warnForwardedHeadersFromUntrustedPeer(peerIp: string | undefined): void {
-  // Count every occurrence — Prometheus rates are only useful unsampled.
-  proxyTrustMetricsRecorder.onForwardedHeadersFromUntrustedPeer();
-
-  const key = peerIp ?? 'unknown';
+// Rate-limit gate shared by both proxy-trust warning variants below, so a peer
+// that already warned via one path stays suppressed on the other (one log line
+// per peer per window, regardless of which call site fired first). Returns true
+// when a warning should be emitted now and records the emission.
+function shouldEmitProxyTrustWarnNow(key: string): boolean {
   const now = Date.now();
   const lastWarnAt = untrustedPeerLastWarnAt.get(key);
   if (lastWarnAt !== undefined && now - lastWarnAt < UNTRUSTED_PEER_WARN_INTERVAL_MS) {
-    return;
+    return false;
   }
 
   if (!untrustedPeerLastWarnAt.has(key) && untrustedPeerLastWarnAt.size >= UNTRUSTED_PEER_WARN_MAX_TRACKED) {
@@ -219,13 +222,52 @@ function warnForwardedHeadersFromUntrustedPeer(peerIp: string | undefined): void
   if (untrustedPeerLastWarnAt.has(key) || untrustedPeerLastWarnAt.size < UNTRUSTED_PEER_WARN_MAX_TRACKED) {
     untrustedPeerLastWarnAt.set(key, now);
   }
+  return true;
+}
+
+const TRUST_GATED_HEADER_LIST = 'CF-Connecting-IP/X-Forwarded-For/X-Real-IP/X-Forwarded-Proto';
+
+function warnForwardedHeadersFromUntrustedPeer(peerIp: string | undefined): void {
+  // Count every occurrence — Prometheus rates are only useful unsampled.
+  proxyTrustMetricsRecorder.onForwardedHeadersFromUntrustedPeer();
+
+  const key = peerIp ?? 'unknown';
+  if (!shouldEmitProxyTrustWarnNow(key)) {
+    return;
+  }
 
   console.warn(
-    `[proxy-trust] MISCONFIGURATION: request carried forwarded-ip headers (CF-Connecting-IP/X-Forwarded-For/X-Real-IP) `
-    + `from untrusted peer ${key}, which is not in TRUSTED_PROXY_CIDRS — falling back to the socket address. `
+    `[proxy-trust] MISCONFIGURATION: request carried proxy-forwarded headers (${TRUST_GATED_HEADER_LIST}) `
+    + `from untrusted peer ${key}, which is not in TRUSTED_PROXY_CIDRS — ignoring them and falling back to the socket address. `
     + `If this peer is your reverse proxy, TRUSTED_PROXY_CIDRS is likely STALE (proxy container recreated without a `
-    + `static ipv4_address): all per-IP rate limits are pooling onto the proxy IP and audit-log IP attribution is `
-    + `recording the proxy as every client. Fix TRUSTED_PROXY_CIDRS or pin the proxy IP (see docs/operations/DEPLOY_PRODUCTION.md). `
+    + `static ipv4_address): all per-IP rate limits are pooling onto the proxy IP, audit-log IP attribution is `
+    + `recording the proxy as every client, and if FORCE_HTTPS=true every non-health route is stuck in a 308 redirect loop `
+    + `while /health keeps returning 200. Fix TRUSTED_PROXY_CIDRS or pin the proxy IP (see docs/operations/DEPLOY_PRODUCTION.md). `
+    + `Suppressed for this peer for ${UNTRUSTED_PEER_WARN_INTERVAL_MS / 60000} minutes.`,
+  );
+}
+
+// The TRUST_PROXY_HEADERS=false half of the same outage (#2987): with
+// FORCE_HTTPS=true behind a proxy, disabled trust makes effectiveRequestScheme
+// ignore X-Forwarded-Proto exactly like a stale CIDR does — same total 308
+// loop, same green /health, and (before this warning) the same zero log lines.
+// The config validator accepts an explicit `false` and cannot know a proxy is
+// actually in front, so this is only detectable at request time. Deliberately
+// NOT counted in the untrusted-peer metric — that counter's meaning ("peer
+// outside TRUSTED_PROXY_CIDRS while trust is enabled") stays stable — but it
+// shares the per-peer suppression state above.
+function warnForwardedHeadersWithTrustDisabled(peerIp: string | undefined): void {
+  const key = peerIp ?? 'unknown';
+  if (!shouldEmitProxyTrustWarnNow(key)) {
+    return;
+  }
+
+  console.warn(
+    `[proxy-trust] TRUST_PROXY_HEADERS is disabled, but a request from peer ${key} carried proxy-forwarded headers `
+    + `(${TRUST_GATED_HEADER_LIST}), which are being ignored. If this peer is your reverse proxy, forwarded client IPs and `
+    + `X-Forwarded-Proto are NOT honored — and if FORCE_HTTPS=true every non-health route is stuck in a 308 redirect loop `
+    + `while /health keeps returning 200. Set TRUST_PROXY_HEADERS=true and put the proxy in TRUSTED_PROXY_CIDRS. If the API `
+    + `is intentionally exposed directly (no proxy in front), a client sent these headers and this warning can be ignored. `
     + `Suppressed for this peer for ${UNTRUSTED_PEER_WARN_INTERVAL_MS / 60000} minutes.`,
   );
 }
@@ -288,6 +330,12 @@ export function getTrustedClientIpOrUndefined(c: RequestLike): string | undefine
 // (e.g. the auth-cookie Secure flag derives from X-Forwarded-Proto).
 export function trustsForwardedHeadersFrom(c: RequestLike): boolean {
   if (!shouldTrustProxyHeaders()) {
+    // Same 308-loop outage as the untrusted-peer branch below, reached via the
+    // neighboring config value (TRUST_PROXY_HEADERS=false behind a proxy)
+    // instead of a stale CIDR — see warnForwardedHeadersWithTrustDisabled.
+    if (hasTrustGatedForwardedHeaders(c)) {
+      warnForwardedHeadersWithTrustDisabled(getImmediatePeerIp(c, ''));
+    }
     return false;
   }
   const peerIp = getImmediatePeerIp(c, '');

--- a/apps/api/src/services/clientIp.ts
+++ b/apps/api/src/services/clientIp.ts
@@ -182,6 +182,24 @@ function hasForwardedIpHeaders(c: RequestLike): boolean {
   );
 }
 
+/**
+ * Any forwarded header whose value is gated on proxy trust — the IP headers
+ * above plus `X-Forwarded-Proto`.
+ *
+ * `X-Forwarded-Proto` is deliberately NOT in `hasForwardedIpHeaders`, which
+ * exists to answer "did this request carry client-IP attribution". It belongs
+ * here because a peer sending it is just as much evidence of a reverse proxy,
+ * and the FORCE_HTTPS redirect path (TRANSPORT-001) keys off that header
+ * alone — a proxy that forwards only the scheme would otherwise trip the
+ * misconfiguration silently.
+ */
+function hasTrustGatedForwardedHeaders(c: RequestLike): boolean {
+  return (
+    hasForwardedIpHeaders(c)
+    || Boolean(c.req.header('x-forwarded-proto') ?? c.req.header('X-Forwarded-Proto'))
+  );
+}
+
 function warnForwardedHeadersFromUntrustedPeer(peerIp: string | undefined): void {
   // Count every occurrence — Prometheus rates are only useful unsampled.
   proxyTrustMetricsRecorder.onForwardedHeadersFromUntrustedPeer();
@@ -272,7 +290,22 @@ export function trustsForwardedHeadersFrom(c: RequestLike): boolean {
   if (!shouldTrustProxyHeaders()) {
     return false;
   }
-  return isTrustedProxySource(getImmediatePeerIp(c, ''));
+  const peerIp = getImmediatePeerIp(c, '');
+  if (!isTrustedProxySource(peerIp)) {
+    // Same misconfiguration signal getTrustedClientIp emits, and rate-limited
+    // through the same per-peer state. Warning here is not redundant: the
+    // FORCE_HTTPS redirect in middleware/security.ts calls this and then
+    // short-circuits the request with a 308, so no handler downstream ever
+    // reaches getTrustedClientIp to raise it. That combination is silent and
+    // total — a stale TRUSTED_PROXY_CIDRS makes effectiveRequestScheme() read
+    // every request as `http`, so every non-health route 308s while /health
+    // (exempt) keeps returning 200.
+    if (hasTrustGatedForwardedHeaders(c)) {
+      warnForwardedHeadersFromUntrustedPeer(peerIp);
+    }
+    return false;
+  }
+  return true;
 }
 
 // The immediate TCP peer, socket-only — NEVER consults forwarded headers, so


### PR DESCRIPTION
Addresses #2987 (fix 1/2 from that issue — the diagnosability half).

## The gap

`[proxy-trust] MISCONFIGURATION` already exists, and its wording already nails this exact failure, including the stale-CIDR-after-container-recreate case. It simply never fires on the path that matters most.

- `getTrustedClientIp` warns when forwarded headers arrive from an untrusted peer.
- `trustsForwardedHeadersFrom` — the gate TRANSPORT-001 introduced, and what `effectiveRequestScheme` calls — returned the same verdict **silently**.

## Why that gap is a total outage rather than a missing log line

1. A stale or incorrect `TRUSTED_PROXY_CIDRS` makes `trustsForwardedHeadersFrom` false for the reverse proxy.
2. `effectiveRequestScheme` therefore ignores `X-Forwarded-Proto` and falls back to the direct request URL — which, as its own doc comment says, is the internal plain-HTTP proxy→API hop. It reports `http` for **every** request.
3. Under `FORCE_HTTPS`, `securityMiddleware` 308s every non-health route and **short-circuits**, so nothing downstream ever calls `getTrustedClientIp`. The existing warning is structurally unreachable.
4. `/health` is in `HEALTH_CHECK_PATHS` and exempt, so it keeps returning `200` with the new version for the entire outage.

Agents cannot heartbeat and the SPA cannot load, while every signal an operator normally checks stays green. Observed on a proxy-fronted self-hosted deployment upgrading v0.102.0 → v0.103.0: ~50 minutes, zero agent check-ins, `/health` 200 throughout, and the only log evidence was `route=unmatched status=308`, which names neither the cause nor the peer.

## The change

`trustsForwardedHeadersFrom` now emits the same warning — reusing the same per-peer rate-limit state — when it rejects a peer that actually sent trust-gated forwarded headers.

**Trust semantics are unchanged.** It still returns exactly `shouldTrustProxyHeaders() && isTrustedProxySource(peer)`; only the observability differs.

Also adds `hasTrustGatedForwardedHeaders` = `hasForwardedIpHeaders` + `X-Forwarded-Proto`. The scheme header is deliberately kept out of `hasForwardedIpHeaders`, since that predicate answers "did this request carry client-IP attribution" — but a proxy forwarding only the scheme is still a proxy, and the FORCE_HTTPS path keys off that header alone.

A bare request carrying no forwarded headers still does not warn, so a direct client probing the origin cannot spam the log.

## Scope

This is the diagnosability half only. #2987 also suggests a boot-time refusal/warning and a `/health` field reporting trusted-peer observation. Both are more opinionated, so I left them out of this PR — happy to follow up on either if you want them.

## Local verification

- `clientIp.test.ts`: **53 pass**, including 4 new cases — `X-Forwarded-Proto` only, forwarded-ip only, bare request does **not** warn, trusted peer does **not** warn and still reports trust.
- Confirmed the tests catch the regression: reverting the change fails 2 of them.
- Full `@breeze/api` suite: **1225 files, 19100 tests passed, 0 failures**.
- `tsc --noEmit` clean; eslint clean on both changed files.
