### PR TITLE
fix(alerts): remove the unimplemented `custom` alert condition type (#2948)

### DIFF
--- a/apps/api/migrations/2026-08-06-g-drop-custom-alert-conditions.sql
+++ b/apps/api/migrations/2026-08-06-g-drop-custom-alert-conditions.sql
@@ -1,0 +1,166 @@
+-- Cleanup for the retired `custom` alert-condition type (#2948).
+--
+-- The `custom` type was offered by the alert-rule editors but never had a
+-- handler registered in services/alertConditions. conditionRegistry.evaluate()
+-- answers "Unknown condition type: custom" with passed=false, and a root-level
+-- conditions ARRAY is evaluated as an implicit AND (services/alertConditions/
+-- index.ts wraps it in {logic:'and'}), so any rule whose conditions are ALL
+-- `custom` has never fired once and never can. PR #2946 dropped the type from
+-- the config-policy editor and the shared write schema; this file removes what
+-- is already stored, and the same PR-2948 change closes the remaining write
+-- paths (POST/PUT /alerts/rules, POST/PUT /alert-templates/rules, and the
+-- alert-template conditions themselves).
+--
+-- Modelled on 2026-07-30-b-drop-never-firing-metric-alert-rules.sql, which did
+-- the identical job for metric conditions naming a column the evaluator has no
+-- entry for. Same structure, same guards, same forensic warnings.
+--
+-- Scope — deliberately narrow. Only rows with NO evaluable condition at all are
+-- touched:
+--   * conditions is a non-empty ARRAY and EVERY element has type 'custom', or
+--   * conditions is a single OBJECT with type 'custom'.
+-- A rule that MIXES `custom` with a real condition is left alone. Under the
+-- implicit AND such a rule is also dead, but under an explicit {logic:'or'}
+-- group it is not, and the editors already flag the bad condition for the tech.
+-- Guessing on a mixed rule risks silently disabling working alerting; the
+-- unambiguous all-custom case does not.
+--
+-- Two different remedies, because the two tables have different blast radii:
+--   * config_policy_alert_rules rows are DELETED (as in the 07-30-b precedent),
+--     skipping any row an `alerts` row references via the FK-less
+--     alerts.config_policy_id, and rebuilding the inline_settings mirror.
+--   * alert_rules rows are DEACTIVATED, never deleted. alerts.rule_id is a real
+--     FK with no ON DELETE, so deleting would either fail or strand alert
+--     provenance. is_active=false is honest — the rule already did nothing, and
+--     now the UI says so — and a tech can re-point it at a real condition.
+--
+-- Idempotent: after a successful run there is no matching config-policy row
+-- left to delete and no matching active alert_rules row left to deactivate, so
+-- a replay touches nothing and the partner-export watermark stays stable.
+
+-- config_policy_alert_rules / config_policy_feature_links / alerts / alert_rules
+-- all have FORCE ROW LEVEL SECURITY and the migration role is not guaranteed to
+-- be a superuser on managed Postgres. Without the system scope the DML below
+-- would silently affect zero rows. Transaction-local; autoMigrate wraps the file.
+SELECT set_config('breeze.scope', 'system', true);
+
+DO $$
+DECLARE
+  dropped_policy_rules integer := 0;
+  kept_policy_rules integer := 0;
+  dropped_names text[];
+  affected_links uuid[];
+  rebuilt_mirrors integer := 0;
+  deactivated_rules integer := 0;
+BEGIN
+  -- 1. config_policy_alert_rules: delete the all-custom rules.
+  WITH all_custom AS (
+    SELECT r.id, r.name, r.feature_link_id
+    FROM public.config_policy_alert_rules r
+    WHERE (
+        jsonb_typeof(r.conditions) = 'array'
+        AND jsonb_array_length(r.conditions) > 0
+        AND NOT EXISTS (
+          SELECT 1 FROM jsonb_array_elements(r.conditions) e
+          WHERE COALESCE(e->>'type', '') <> 'custom'
+        )
+      )
+      OR (
+        jsonb_typeof(r.conditions) = 'object'
+        AND r.conditions->>'type' = 'custom'
+      )
+  ), dropped AS (
+    DELETE FROM public.config_policy_alert_rules r
+    USING all_custom n
+    WHERE r.id = n.id
+      AND NOT EXISTS (SELECT 1 FROM public.alerts a WHERE a.config_policy_id = n.id)
+    RETURNING r.name, r.feature_link_id
+  )
+  SELECT
+    (SELECT count(*) FROM dropped),
+    (SELECT COALESCE(array_agg(DISTINCT name), ARRAY[]::text[]) FROM dropped),
+    (SELECT COALESCE(array_agg(DISTINCT feature_link_id), ARRAY[]::uuid[]) FROM dropped),
+    (SELECT count(*) FROM all_custom n
+       WHERE EXISTS (SELECT 1 FROM public.alerts a WHERE a.config_policy_id = n.id))
+    INTO dropped_policy_rules, dropped_names, affected_links, kept_policy_rules;
+
+  IF dropped_policy_rules > 0 THEN
+    RAISE WARNING 'custom alert conditions: dropped % config-policy rule(s) whose every condition was the retired ''custom'' type (no evaluator handler, never fired): %',
+      dropped_policy_rules, array_to_string(dropped_names, ', ');
+  END IF;
+  IF kept_policy_rules > 0 THEN
+    RAISE WARNING 'custom alert conditions: LEFT IN PLACE % config-policy rule(s) because existing alerts rows reference them. They are NOT deleted and will never fire until a tech replaces the condition',
+      kept_policy_rules;
+  END IF;
+
+  -- 2. Rebuild the inline_settings items[] mirror for every alert_rule link that
+  --    lost rows, matching the shape assembleInlineSettings() writes. Per-link
+  --    correlated aggregate, not GROUP BY: a link whose ONLY rule was deleted
+  --    has nothing left to group and would otherwise keep the stale mirror.
+  --    The IS DISTINCT FROM guard keeps a replay from bumping updated_at.
+  IF array_length(affected_links, 1) IS NOT NULL THEN
+    UPDATE public.config_policy_feature_links al
+    SET inline_settings = jsonb_build_object('items', COALESCE(sub.items, '[]'::jsonb)),
+        updated_at = now()
+    FROM (
+      SELECT l.id AS feature_link_id, (
+        SELECT jsonb_agg(jsonb_build_object(
+          'name', name, 'severity', severity, 'conditions', conditions,
+          'cooldownMinutes', cooldown_minutes, 'autoResolve', auto_resolve,
+          'autoResolveConditions', auto_resolve_conditions,
+          'titleTemplate', title_template, 'messageTemplate', message_template,
+          'sortOrder', sort_order
+        ) ORDER BY sort_order, created_at, id)
+        FROM public.config_policy_alert_rules r
+        WHERE r.feature_link_id = l.id
+      ) AS items
+      FROM public.config_policy_feature_links l
+      WHERE l.id = ANY(affected_links)
+    ) sub
+    WHERE sub.feature_link_id = al.id
+      AND al.feature_type = 'alert_rule'
+      AND al.inline_settings IS DISTINCT FROM jsonb_build_object('items', COALESCE(sub.items, '[]'::jsonb));
+    GET DIAGNOSTICS rebuilt_mirrors = ROW_COUNT;
+    IF rebuilt_mirrors > 0 THEN
+      RAISE WARNING 'custom alert conditions: rebuilt % alert_rule inline_settings mirror(s)', rebuilt_mirrors;
+    END IF;
+  END IF;
+
+  -- 3. alert_rules (the standalone Alerts > Rules path): deactivate, never
+  --    delete. The effective conditions are the rule's override_settings
+  --    ->'conditions' when present, else the template's own conditions —
+  --    the same precedence formatAlertRuleResponse() and the evaluator use.
+  WITH effective AS (
+    SELECT
+      r.id,
+      r.name,
+      COALESCE(r.override_settings->'conditions', t.conditions) AS conditions
+    FROM public.alert_rules r
+    JOIN public.alert_templates t ON t.id = r.template_id
+    WHERE r.is_active
+  )
+  UPDATE public.alert_rules r
+  SET is_active = false
+  FROM effective e
+  WHERE r.id = e.id
+    AND (
+      (
+        jsonb_typeof(e.conditions) = 'array'
+        AND jsonb_array_length(e.conditions) > 0
+        AND NOT EXISTS (
+          SELECT 1 FROM jsonb_array_elements(e.conditions) x
+          WHERE COALESCE(x->>'type', '') <> 'custom'
+        )
+      )
+      OR (
+        jsonb_typeof(e.conditions) = 'object'
+        AND e.conditions->>'type' = 'custom'
+      )
+    );
+  GET DIAGNOSTICS deactivated_rules = ROW_COUNT;
+
+  IF deactivated_rules > 0 THEN
+    RAISE WARNING 'custom alert conditions: deactivated % alert_rules row(s) whose every effective condition was the retired ''custom'' type. Rows are kept (alerts.rule_id references them); re-enable after pointing them at a supported condition',
+      deactivated_rules;
+  END IF;
+END $$;

--- a/apps/api/migrations/2026-08-06-g-drop-custom-alert-conditions.sql
+++ b/apps/api/migrations/2026-08-06-g-drop-custom-alert-conditions.sql
@@ -8,40 +8,52 @@
 -- `custom` has never fired once and never can. PR #2946 dropped the type from
 -- the config-policy editor and the shared write schema; this file removes what
 -- is already stored, and the same PR-2948 change closes the remaining write
--- paths (POST/PUT /alerts/rules, POST/PUT /alert-templates/rules, and the
--- alert-template conditions themselves).
+-- paths (POST/PUT /alerts/rules, POST/PATCH /alert-templates/rules, and
+-- POST/PATCH /alert-templates).
 --
 -- Modelled on 2026-07-30-b-drop-never-firing-metric-alert-rules.sql, which did
--- the identical job for metric conditions naming a column the evaluator has no
--- entry for. Same structure, same guards, same forensic warnings.
+-- the same job for metric conditions naming a column the evaluator has no entry
+-- for. Same shape for the config-policy delete + mirror rebuild; this file
+-- widens the match (that one required jsonb_array_length = 1) and adds a second
+-- remedy for the standalone alert_rules table.
 --
 -- Scope — deliberately narrow. Only rows with NO evaluable condition at all are
 -- touched:
 --   * conditions is a non-empty ARRAY and EVERY element has type 'custom', or
 --   * conditions is a single OBJECT with type 'custom'.
--- A rule that MIXES `custom` with a real condition is left alone. Under the
--- implicit AND such a rule is also dead, but under an explicit {logic:'or'}
--- group it is not, and the editors already flag the bad condition for the tech.
--- Guessing on a mixed rule risks silently disabling working alerting; the
--- unambiguous all-custom case does not.
+-- A rule that MIXES `custom` with a real condition is left alone. At the ARRAY
+-- root such a rule is also dead (the root array is an implicit AND), but a
+-- nested {logic:'or'} group inside it need not be, and this migration does not
+-- descend into groups to find out. Both editors already flag the bad condition
+-- for the tech, so a human decides. Guessing on a mixed rule risks silently
+-- disabling working alerting; the unambiguous all-custom case does not.
+-- Likewise NOT touched, for the same reason: a group-rooted rule
+-- ({logic:'and', conditions:[{type:'custom'}]}), whose ->>'type' is NULL.
 --
 -- Two different remedies, because the two tables have different blast radii:
 --   * config_policy_alert_rules rows are DELETED (as in the 07-30-b precedent),
 --     skipping any row an `alerts` row references via the FK-less
 --     alerts.config_policy_id, and rebuilding the inline_settings mirror.
 --   * alert_rules rows are DEACTIVATED, never deleted. alerts.rule_id is a real
---     FK with no ON DELETE, so deleting would either fail or strand alert
---     provenance. is_active=false is honest — the rule already did nothing, and
---     now the UI says so — and a tech can re-point it at a real condition.
+--     FK with no ON DELETE (NO ACTION), so a delete would raise an FK violation
+--     outright — the opposite of the FK-less config_policy_id case above, where
+--     the risk is stranding rather than failing. is_active=false is honest: the
+--     rule already did nothing, and now the UI says so.
+--     Re-enabling is gated by retiredConditionReactivationError()
+--     (routes/alerts/helpers.ts) on both the PUT and the toggle route, so this
+--     is not a state a tech can silently undo back into the original bug.
 --
 -- Idempotent: after a successful run there is no matching config-policy row
 -- left to delete and no matching active alert_rules row left to deactivate, so
 -- a replay touches nothing and the partner-export watermark stays stable.
 
--- config_policy_alert_rules / config_policy_feature_links / alerts / alert_rules
--- all have FORCE ROW LEVEL SECURITY and the migration role is not guaranteed to
--- be a superuser on managed Postgres. Without the system scope the DML below
--- would silently affect zero rows. Transaction-local; autoMigrate wraps the file.
+-- alerts, alert_rules and alert_templates have FORCE ROW LEVEL SECURITY;
+-- config_policy_alert_rules and config_policy_feature_links have RLS enabled but
+-- not forced. The migration role is not guaranteed to be a superuser or the table
+-- owner on managed Postgres, so without the system scope the DML below could
+-- silently affect zero rows. Transaction-local; autoMigrate wraps the file.
+-- The DO block below hard-fails if the scope did not take, precisely because a
+-- silently-zero-row run is otherwise indistinguishable from a clean no-op.
 SELECT set_config('breeze.scope', 'system', true);
 
 DO $$
@@ -53,13 +65,28 @@ DECLARE
   rebuilt_mirrors integer := 0;
   deactivated_rules integer := 0;
 BEGIN
+  -- Fail loudly if the system scope did not take. Every warning below is gated
+  -- on a non-zero count, so a run that silently matched nothing because RLS hid
+  -- the rows would otherwise be byte-identical in the logs to a clean no-op —
+  -- the one failure mode the header warns about, made undetectable.
+  IF current_setting('breeze.scope', true) IS DISTINCT FROM 'system' THEN
+    RAISE EXCEPTION 'custom alert conditions: breeze.scope did not take (got %); RLS would silently hide rows',
+      COALESCE(current_setting('breeze.scope', true), '<unset>');
+  END IF;
   -- 1. config_policy_alert_rules: delete the all-custom rules.
   WITH all_custom AS (
     SELECT r.id, r.name, r.feature_link_id
     FROM public.config_policy_alert_rules r
     WHERE (
         jsonb_typeof(r.conditions) = 'array'
-        AND jsonb_array_length(r.conditions) > 0
+        -- `<> '[]'` rather than `jsonb_array_length(...) > 0`: identical here,
+        -- but it cannot raise. jsonb_array_length() throws "cannot get array
+        -- length of a non-array", and it is shielded from the object rows only
+        -- by AND short-circuiting INSIDE this OR expression. Flatten the OR away
+        -- in some future edit and the planner's order_qual_clauses is free to
+        -- reorder by cost, at which point the call hard-fails the migration for
+        -- any tenant holding object-form conditions.
+        AND r.conditions <> '[]'::jsonb
         AND NOT EXISTS (
           SELECT 1 FROM jsonb_array_elements(r.conditions) e
           WHERE COALESCE(e->>'type', '') <> 'custom'
@@ -67,6 +94,7 @@ BEGIN
       )
       OR (
         jsonb_typeof(r.conditions) = 'object'
+        AND NOT (r.conditions ? 'logic')
         AND r.conditions->>'type' = 'custom'
       )
   ), dropped AS (
@@ -134,7 +162,11 @@ BEGIN
     SELECT
       r.id,
       r.name,
-      COALESCE(r.override_settings->'conditions', t.conditions) AS conditions
+      -- NULLIF so a stored JSON `null` under `conditions` falls through to the
+      -- template, matching the JS `overrides.conditions ?? template.conditions`
+      -- precedence. Plain `->` yields jsonb-null (not SQL NULL), which COALESCE
+      -- would keep, leaving the rule unmatched.
+      COALESCE(NULLIF(r.override_settings->'conditions', 'null'::jsonb), t.conditions) AS conditions
     FROM public.alert_rules r
     JOIN public.alert_templates t ON t.id = r.template_id
     WHERE r.is_active
@@ -146,7 +178,8 @@ BEGIN
     AND (
       (
         jsonb_typeof(e.conditions) = 'array'
-        AND jsonb_array_length(e.conditions) > 0
+        -- See the note on the config-policy branch above: exception-safe form.
+        AND e.conditions <> '[]'::jsonb
         AND NOT EXISTS (
           SELECT 1 FROM jsonb_array_elements(e.conditions) x
           WHERE COALESCE(x->>'type', '') <> 'custom'
@@ -154,13 +187,20 @@ BEGIN
       )
       OR (
         jsonb_typeof(e.conditions) = 'object'
+        AND NOT (e.conditions ? 'logic')
         AND e.conditions->>'type' = 'custom'
       )
     );
   GET DIAGNOSTICS deactivated_rules = ROW_COUNT;
 
   IF deactivated_rules > 0 THEN
-    RAISE WARNING 'custom alert conditions: deactivated % alert_rules row(s) whose every effective condition was the retired ''custom'' type. Rows are kept (alerts.rule_id references them); re-enable after pointing them at a supported condition',
+    RAISE WARNING 'custom alert conditions: deactivated % alert_rules row(s) whose every effective condition was the retired ''custom'' type. Rows are kept because alerts.rule_id points at them; re-enable after switching to a supported condition',
       deactivated_rules;
   END IF;
+
+  -- Unconditional, even when every counter is zero: CLAUDE.md requires the
+  -- forensic count to be recorded on a clean run too, and this is the line that
+  -- proves the migration executed under the right scope rather than no-oping.
+  RAISE WARNING 'custom alert conditions: complete — policy_rules_dropped=% policy_rules_kept=% mirrors_rebuilt=% alert_rules_deactivated=%',
+    dropped_policy_rules, kept_policy_rules, rebuilt_mirrors, deactivated_rules;
 END $$;

--- a/apps/api/src/__tests__/integration/customAlertConditionCleanup.integration.test.ts
+++ b/apps/api/src/__tests__/integration/customAlertConditionCleanup.integration.test.ts
@@ -47,8 +47,40 @@ const MIGRATION_FILE = join(
 
 const runDb = it.runIf(!!process.env.DATABASE_URL);
 
+// The one statement that arms the DO block's scope guard. Matched (not just
+// string-replaced) so that if the migration ever stops opening with it, the
+// scope-guard case fails loudly instead of quietly replaying the whole file.
+const SET_SYSTEM_SCOPE_LINE = "SELECT set_config('breeze.scope', 'system', true);";
+
+function migrationSql() {
+  return readFileSync(MIGRATION_FILE, 'utf8');
+}
+
 async function runMigration() {
-  await getTestDb().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+  await getTestDb().execute(sql.raw(migrationSql()));
+}
+
+/** The migration's DO block WITHOUT the set_config line that precedes it. */
+function migrationDoBlockOnly() {
+  const text = migrationSql();
+  expect(text.split(SET_SYSTEM_SCOPE_LINE)).toHaveLength(2);
+  const stripped = text.replace(SET_SYSTEM_SCOPE_LINE, '');
+  expect(stripped).toContain('DO $$');
+  return stripped;
+}
+
+/**
+ * Postgres errors surface through drizzle wrapped in `.cause`, so assert
+ * against the whole chain rather than the top-level message alone.
+ */
+function errorText(error: unknown): string {
+  const parts: string[] = [];
+  let current: unknown = error;
+  while (current instanceof Error) {
+    parts.push(current.message);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return parts.join(' | ');
 }
 
 // The retired type: conditionRegistry.evaluate() has no handler for it, so a
@@ -62,6 +94,33 @@ const MIXED_CONDITIONS = [
   { type: 'custom', expression: 'anything' },
   { type: 'metric', metric: 'cpu', operator: 'gt', value: 90 },
 ];
+// The alert-TEMPLATE routes validate `conditions` as a z.record — an OBJECT,
+// never an array — so this, not the array form, is the dominant stored shape on
+// that path. The migration handles it in a second `jsonb_typeof = 'object'`
+// branch.
+const OBJECT_CUSTOM_CONDITIONS = { type: 'custom', expression: 'cpu > 90 && disk < 10' };
+// An empty conditions array. Deliberately NOT cleaned up: `NOT EXISTS (... WHERE
+// type <> 'custom')` is vacuously TRUE over zero elements, so without the
+// companion `jsonb_array_length(...) > 0` guard EVERY empty-conditions rule in
+// the fleet would be destroyed by a migration that claims to touch only
+// all-custom ones.
+const EMPTY_CONDITIONS: unknown[] = [];
+// A group-rooted tree. `->>'type'` is NULL here and the migration deliberately
+// does not descend into `conditions` groups, so this is untouched even though
+// every leaf is `custom`.
+const GROUP_ROOTED_CONDITIONS = {
+  logic: 'and',
+  conditions: [{ type: 'custom', expression: 'anything' }],
+};
+// Pathological but legal: a group object that ALSO carries a top-level
+// `type: 'custom'`. The object branch's `AND NOT (conditions ? 'logic')` is the
+// only thing keeping this out of the match — without it the migration would
+// delete a rule whose real (group) contents it never inspected.
+const GROUP_WITH_TYPE_CONDITIONS = {
+  logic: 'and',
+  type: 'custom',
+  conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 90 }],
+};
 
 /**
  * Seeds the pre-migration world.
@@ -73,11 +132,21 @@ const MIXED_CONDITIONS = [
  *              mirror must collapse to `{items: []}`.
  *   policy C — alert_rule link owning an all-custom rule that an `alerts` row
  *              references via alerts.config_policy_id: LEFT IN PLACE.
+ *   policy D — alert_rule link of shapes the migration must NOT match: empty
+ *              conditions, a group-rooted tree, and a group that also carries
+ *              type:'custom'. Nothing is lost, so the mirror must not be rebuilt.
+ *   policy E — alert_rule link whose only rule stores conditions as a single
+ *              OBJECT `{type:'custom'}` rather than an array (the shape the
+ *              alert-template routes write): DELETED, mirror collapses to [].
  *
  * alert_rules (standalone Alerts > Rules path):
  *   overrideCustom  — override_settings->'conditions' is all-custom  -> deactivated
  *   templateCustom  — no override conditions, template is all-custom -> deactivated
+ *   objectCustom    — template conditions are a single custom OBJECT -> deactivated
+ *   jsonNullOverride— override_settings is {"conditions": null}      -> deactivated
  *   supported       — template has a metric condition                -> stays active
+ *   emptyConditions — template conditions are `[]`                   -> stays active
+ *   groupRooted     — template conditions are a {logic:…} group      -> stays active
  */
 async function seedScenario() {
   const db = getTestDb();
@@ -108,6 +177,8 @@ async function seedScenario() {
   const policyAId = await insertPolicy('Policy A — mixed survivors');
   const policyBId = await insertPolicy('Policy B — only a custom rule');
   const policyCId = await insertPolicy('Policy C — referenced by an alert');
+  const policyDId = await insertPolicy('Policy D — shapes the migration must not match');
+  const policyEId = await insertPolicy('Policy E — object-form custom conditions');
 
   const insertLink = async (configPolicyId: string, items: unknown[]) => {
     const [link] = await db.insert(configPolicyFeatureLinks).values({
@@ -142,6 +213,14 @@ async function seedScenario() {
   const linkCId = await insertLink(policyCId, [
     mirrorItem('Referenced custom', 'critical', CUSTOM_CONDITIONS, 0),
   ]);
+  const linkDId = await insertLink(policyDId, [
+    mirrorItem('Empty conditions', 'low', EMPTY_CONDITIONS, 0),
+    mirrorItem('Group rooted', 'medium', GROUP_ROOTED_CONDITIONS, 1),
+    mirrorItem('Group carrying type', 'medium', GROUP_WITH_TYPE_CONDITIONS, 2),
+  ]);
+  const linkEId = await insertLink(policyEId, [
+    mirrorItem('Object custom', 'high', OBJECT_CUSTOM_CONDITIONS, 0),
+  ]);
 
   const insertRule = async (
     featureLinkId: string,
@@ -166,6 +245,10 @@ async function seedScenario() {
   const mixedRuleId = await insertRule(linkAId, 'Mixed conditions', 'medium', MIXED_CONDITIONS, 1);
   const loneCustomRuleId = await insertRule(linkBId, 'Lone custom', 'low', CUSTOM_CONDITIONS, 0);
   const referencedRuleId = await insertRule(linkCId, 'Referenced custom', 'critical', CUSTOM_CONDITIONS, 0);
+  const emptyConditionsRuleId = await insertRule(linkDId, 'Empty conditions', 'low', EMPTY_CONDITIONS, 0);
+  const groupRootedRuleId = await insertRule(linkDId, 'Group rooted', 'medium', GROUP_ROOTED_CONDITIONS, 1);
+  const groupWithTypeRuleId = await insertRule(linkDId, 'Group carrying type', 'medium', GROUP_WITH_TYPE_CONDITIONS, 2);
+  const objectCustomRuleId = await insertRule(linkEId, 'Object custom', 'high', OBJECT_CUSTOM_CONDITIONS, 0);
 
   // alerts.config_policy_id stores the RULE id (plain uuid, no FK). Its
   // presence is what keeps referencedRule from being deleted.
@@ -193,6 +276,9 @@ async function seedScenario() {
 
   const customTemplateId = await insertTemplate('Custom template', CUSTOM_CONDITIONS);
   const metricTemplateId = await insertTemplate('Metric template', METRIC_CONDITIONS);
+  const objectCustomTemplateId = await insertTemplate('Object custom template', OBJECT_CUSTOM_CONDITIONS);
+  const emptyTemplateId = await insertTemplate('Empty template', EMPTY_CONDITIONS);
+  const groupRootedTemplateId = await insertTemplate('Group rooted template', GROUP_ROOTED_CONDITIONS);
 
   const insertAlertRule = async (
     name: string,
@@ -229,7 +315,26 @@ async function seedScenario() {
     customTemplateId,
     null,
   );
+  // …(c) and from a template storing a single condition OBJECT — the shape the
+  // alert-template write schema (z.record) actually produces.
+  const objectCustomAlertRuleId = await insertAlertRule(
+    'Template is an object custom condition',
+    objectCustomTemplateId,
+    null,
+  );
+  // …(d) and from the template again when the override stores an explicit JSON
+  // `null` under `conditions`. `->` yields jsonb-null rather than SQL NULL, so
+  // only the NULLIF makes this fall through the way JS `??` does.
+  const jsonNullOverrideRuleId = await insertAlertRule(
+    'Override conditions is JSON null',
+    customTemplateId,
+    { conditions: null, cooldownMinutes: 10 },
+  );
   const supportedRuleId = await insertAlertRule('Supported metric', metricTemplateId, null);
+  // Shapes with no evaluable custom-only match: an empty array (vacuous
+  // NOT EXISTS) and a group-rooted object (->>'type' is NULL).
+  const emptyConditionsAlertRuleId = await insertAlertRule('Empty conditions', emptyTemplateId, null);
+  const groupRootedAlertRuleId = await insertAlertRule('Group rooted', groupRootedTemplateId, null);
   // A custom template whose override REPLACES the conditions with a real one:
   // the override wins, so this must stay active.
   const overrideRescuesRuleId = await insertAlertRule(
@@ -240,20 +345,30 @@ async function seedScenario() {
 
   return {
     orgId: org!.id,
-    policyIds: [policyAId, policyBId, policyCId],
+    policyIds: [policyAId, policyBId, policyCId, policyDId, policyEId],
     linkAId,
     linkBId,
     linkCId,
+    linkDId,
+    linkEId,
     allCustomRuleId,
     mixedRuleId,
     loneCustomRuleId,
     referencedRuleId,
+    emptyConditionsRuleId,
+    groupRootedRuleId,
+    groupWithTypeRuleId,
+    objectCustomRuleId,
     alertId: alertRow!.id,
     overrideCustomRuleId,
     templateCustomRuleId,
     templateCustomNoOverrideRuleId,
+    objectCustomAlertRuleId,
+    jsonNullOverrideRuleId,
     supportedRuleId,
     overrideRescuesRuleId,
+    emptyConditionsAlertRuleId,
+    groupRootedAlertRuleId,
   };
 }
 
@@ -398,6 +513,111 @@ describe('retired `custom` alert-condition cleanup migration (2026-08-06-g)', ()
     expect((await alertRuleById(seed.supportedRuleId))!.isActive).toBe(true);
     // The override supplies a real condition, so the custom template is moot.
     expect((await alertRuleById(seed.overrideRescuesRuleId))!.isActive).toBe(true);
+  });
+
+  runDb('leaves rules whose conditions are an EMPTY array completely alone', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    // `NOT EXISTS (... WHERE type <> 'custom')` is vacuously TRUE over zero
+    // elements, so the companion `jsonb_array_length(...) > 0` guard is the only
+    // thing standing between this migration and silently destroying every
+    // empty-conditions rule in the fleet — a far bigger blast radius than the
+    // all-custom rules it is meant to remove.
+    const [policyRule] = await getTestDb()
+      .select({ id: configPolicyAlertRules.id, conditions: configPolicyAlertRules.conditions })
+      .from(configPolicyAlertRules)
+      .where(eq(configPolicyAlertRules.id, seed.emptyConditionsRuleId));
+    expect(policyRule).toBeDefined();
+    expect(policyRule!.conditions).toEqual(EMPTY_CONDITIONS);
+
+    expect((await alertRuleById(seed.emptyConditionsAlertRuleId))!.isActive).toBe(true);
+  });
+
+  runDb('handles conditions stored as a single OBJECT, not an array', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    // The alert-template write schema validates conditions as a z.record, so the
+    // object form is the dominant shape on that path — the array-only branch
+    // would leave every one of those rules behind.
+    const survivors = await getTestDb()
+      .select({ id: configPolicyAlertRules.id })
+      .from(configPolicyAlertRules)
+      .where(eq(configPolicyAlertRules.id, seed.objectCustomRuleId));
+    expect(survivors).toHaveLength(0);
+    // Link E lost its only rule, so its mirror collapses like link B's.
+    const linkE = await linkById(seed.linkEId);
+    expect(linkE!.inlineSettings).toEqual({ items: [] });
+
+    expect((await alertRuleById(seed.objectCustomAlertRuleId))!.isActive).toBe(false);
+  });
+
+  runDb('does not descend into group-rooted conditions', async () => {
+    const seed = await seedScenario();
+    const beforeD = await linkById(seed.linkDId);
+    await runMigration();
+
+    // `{logic:…, conditions:[…]}` has a NULL `->>'type'`, and the migration
+    // deliberately refuses to evaluate what is inside a group: an {logic:'or'}
+    // branch can keep an otherwise-custom rule alive, so a human decides.
+    // The second row is the pathological case the `NOT (conditions ? 'logic')`
+    // guard exists for — a group that ALSO carries a top-level type:'custom'
+    // would otherwise be deleted on the strength of a field describing nothing.
+    const remaining = await rulesForLink(seed.linkDId);
+    expect(remaining.map((r) => r.id)).toEqual([
+      seed.emptyConditionsRuleId,
+      seed.groupRootedRuleId,
+      seed.groupWithTypeRuleId,
+    ]);
+    expect(remaining[1]!.conditions).toEqual(GROUP_ROOTED_CONDITIONS);
+    expect(remaining[2]!.conditions).toEqual(GROUP_WITH_TYPE_CONDITIONS);
+
+    // Link D lost nothing, so it is outside the affected set — mirror and
+    // updated_at both untouched.
+    expect(await linkById(seed.linkDId)).toEqual(beforeD);
+
+    expect((await alertRuleById(seed.groupRootedAlertRuleId))!.isActive).toBe(true);
+  });
+
+  runDb('treats a JSON-null override as absent and falls through to the template', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    // `override_settings->'conditions'` on `{"conditions": null}` yields
+    // jsonb-null, NOT SQL NULL, so a plain COALESCE would keep it and the rule
+    // would never match. The NULLIF is what mirrors the JS
+    // `overrides.conditions ?? template.conditions` precedence the evaluator and
+    // formatAlertRuleResponse() use.
+    expect((await alertRuleById(seed.jsonNullOverrideRuleId))!.isActive).toBe(false);
+  });
+
+  runDb('raises instead of silently no-oping when breeze.scope is not system', async () => {
+    const seed = await seedScenario();
+    const db = getTestDb();
+
+    // Every RAISE WARNING in the DO block is count-gated, so a run whose DML
+    // matched zero rows because RLS hid them is byte-identical in the logs to a
+    // clean no-op. The guard converts that undetectable failure into a hard
+    // abort. Replay only the DO block, without the set_config line that arms it.
+    let caught: unknown;
+    try {
+      await db.transaction(async (tx) => {
+        await tx.execute(sql`SELECT set_config('breeze.scope', 'organization', true)`);
+        await tx.execute(sql.raw(migrationDoBlockOnly()));
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(errorText(caught)).toMatch(/breeze\.scope did not take/);
+
+    // And the aborted run changed nothing: the all-custom rule is still there.
+    const survivors = await db
+      .select({ id: configPolicyAlertRules.id })
+      .from(configPolicyAlertRules)
+      .where(eq(configPolicyAlertRules.id, seed.allCustomRuleId));
+    expect(survivors).toHaveLength(1);
   });
 
   runDb('is idempotent — a second run changes nothing', async () => {

--- a/apps/api/src/__tests__/integration/customAlertConditionCleanup.integration.test.ts
+++ b/apps/api/src/__tests__/integration/customAlertConditionCleanup.integration.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Replays 2026-08-06-g-drop-custom-alert-conditions.sql against seeded "dirty"
+ * data — rules still storing the retired `custom` condition type, the shape a
+ * pre-#2946 tenant has in production.
+ *
+ * CI databases are migrated schema-fresh in globalSetup, so the migration's
+ * cleanup DO-block would otherwise only ever run against zero rows. This suite
+ * seeds every case the migration distinguishes between, re-runs the migration
+ * file from disk, and asserts the behaviours the cleanup contract depends on:
+ * all-custom config-policy rules deleted, mixed rules untouched, alert-
+ * referenced rules left in place, the inline_settings items[] mirror rebuilt
+ * for links that lost rows, standalone alert_rules deactivated (never deleted)
+ * from either source of effective conditions, and replay being a true no-op.
+ *
+ * Unlike the ownership-consolidation precedent this migration has no
+ * `-- @data-section-end` sentinel: the whole file is one DML section, so it is
+ * replayed verbatim.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run -c vitest.integration.config.ts \
+ *     src/__tests__/integration/customAlertConditionCleanup.integration.test.ts
+ */
+import './setup';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { asc, eq, inArray, sql } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import {
+  alertRules,
+  alertTemplates,
+  alerts,
+  configPolicyAlertRules,
+  configPolicyFeatureLinks,
+  configurationPolicies,
+  devices,
+} from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+import { getTestDb } from './setup';
+
+const MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-08-06-g-drop-custom-alert-conditions.sql',
+);
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function runMigration() {
+  await getTestDb().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+}
+
+// The retired type: conditionRegistry.evaluate() has no handler for it, so a
+// rule made only of these has never fired and never can.
+const CUSTOM_CONDITIONS = [{ type: 'custom', expression: 'cpu > 90 && disk < 10' }];
+const METRIC_CONDITIONS = [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 90 }];
+// A `custom` condition alongside a real one — deliberately NOT cleaned up: under
+// an explicit {logic:'or'} group the rule is still live, and guessing risks
+// silently disabling working alerting.
+const MIXED_CONDITIONS = [
+  { type: 'custom', expression: 'anything' },
+  { type: 'metric', metric: 'cpu', operator: 'gt', value: 90 },
+];
+
+/**
+ * Seeds the pre-migration world.
+ *
+ * config policies:
+ *   policy A — alert_rule link owning an all-custom rule (must be DELETED) and
+ *              a mixed rule (must SURVIVE); stale mirror listing both.
+ *   policy B — alert_rule link whose ONLY rule is all-custom, so the rebuilt
+ *              mirror must collapse to `{items: []}`.
+ *   policy C — alert_rule link owning an all-custom rule that an `alerts` row
+ *              references via alerts.config_policy_id: LEFT IN PLACE.
+ *
+ * alert_rules (standalone Alerts > Rules path):
+ *   overrideCustom  — override_settings->'conditions' is all-custom  -> deactivated
+ *   templateCustom  — no override conditions, template is all-custom -> deactivated
+ *   supported       — template has a metric condition                -> stays active
+ */
+async function seedScenario() {
+  const db = getTestDb();
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner!.id });
+  const site = await createSite({ orgId: org!.id });
+
+  const [device] = await db.insert(devices).values({
+    orgId: org!.id,
+    siteId: site!.id,
+    agentId: `agent-custom-cleanup-${Date.now()}`,
+    hostname: 'custom-cleanup-host',
+    osType: 'windows',
+    osVersion: '11',
+    architecture: 'x64',
+    agentVersion: '1.0.0',
+  }).returning({ id: devices.id });
+
+  const insertPolicy = async (name: string) => {
+    const [policy] = await db.insert(configurationPolicies).values({
+      orgId: org!.id,
+      partnerId: null,
+      name,
+    }).returning({ id: configurationPolicies.id });
+    return policy!.id;
+  };
+
+  const policyAId = await insertPolicy('Policy A — mixed survivors');
+  const policyBId = await insertPolicy('Policy B — only a custom rule');
+  const policyCId = await insertPolicy('Policy C — referenced by an alert');
+
+  const insertLink = async (configPolicyId: string, items: unknown[]) => {
+    const [link] = await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId,
+      featureType: 'alert_rule',
+      inlineSettings: { items },
+    }).returning({ id: configPolicyFeatureLinks.id });
+    return link!.id;
+  };
+
+  const mirrorItem = (name: string, severity: string, conditions: unknown, sortOrder: number) => ({
+    name,
+    severity,
+    conditions,
+    cooldownMinutes: 5,
+    autoResolve: false,
+    autoResolveConditions: null,
+    titleTemplate: '{{ruleName}} triggered on {{deviceName}}',
+    messageTemplate: '{{ruleName}} condition met',
+    sortOrder,
+  });
+
+  // Mirrors seeded to match the rows exactly, so any post-migration difference
+  // is the rebuild and nothing else.
+  const linkAId = await insertLink(policyAId, [
+    mirrorItem('All custom', 'high', CUSTOM_CONDITIONS, 0),
+    mirrorItem('Mixed conditions', 'medium', MIXED_CONDITIONS, 1),
+  ]);
+  const linkBId = await insertLink(policyBId, [
+    mirrorItem('Lone custom', 'low', CUSTOM_CONDITIONS, 0),
+  ]);
+  const linkCId = await insertLink(policyCId, [
+    mirrorItem('Referenced custom', 'critical', CUSTOM_CONDITIONS, 0),
+  ]);
+
+  const insertRule = async (
+    featureLinkId: string,
+    name: string,
+    severity: 'critical' | 'high' | 'medium' | 'low' | 'info',
+    conditions: unknown,
+    sortOrder: number,
+  ) => {
+    const [rule] = await db.insert(configPolicyAlertRules).values({
+      featureLinkId,
+      name,
+      severity,
+      conditions,
+      cooldownMinutes: 5,
+      autoResolve: false,
+      sortOrder,
+    }).returning({ id: configPolicyAlertRules.id });
+    return rule!.id;
+  };
+
+  const allCustomRuleId = await insertRule(linkAId, 'All custom', 'high', CUSTOM_CONDITIONS, 0);
+  const mixedRuleId = await insertRule(linkAId, 'Mixed conditions', 'medium', MIXED_CONDITIONS, 1);
+  const loneCustomRuleId = await insertRule(linkBId, 'Lone custom', 'low', CUSTOM_CONDITIONS, 0);
+  const referencedRuleId = await insertRule(linkCId, 'Referenced custom', 'critical', CUSTOM_CONDITIONS, 0);
+
+  // alerts.config_policy_id stores the RULE id (plain uuid, no FK). Its
+  // presence is what keeps referencedRule from being deleted.
+  const [alertRow] = await db.insert(alerts).values({
+    deviceId: device!.id,
+    orgId: org!.id,
+    configPolicyId: referencedRuleId,
+    configItemName: 'Referenced custom',
+    severity: 'critical',
+    title: 'Referenced custom fired on custom-cleanup-host',
+  }).returning({ id: alerts.id });
+
+  const insertTemplate = async (name: string, conditions: unknown) => {
+    const [template] = await db.insert(alertTemplates).values({
+      orgId: org!.id,
+      partnerId: null,
+      name,
+      conditions,
+      severity: 'high',
+      titleTemplate: '{{ruleName}} triggered on {{deviceName}}',
+      messageTemplate: '{{ruleName}} condition met',
+    }).returning({ id: alertTemplates.id });
+    return template!.id;
+  };
+
+  const customTemplateId = await insertTemplate('Custom template', CUSTOM_CONDITIONS);
+  const metricTemplateId = await insertTemplate('Metric template', METRIC_CONDITIONS);
+
+  const insertAlertRule = async (
+    name: string,
+    templateId: string,
+    overrideSettings: unknown,
+  ) => {
+    const [rule] = await db.insert(alertRules).values({
+      orgId: org!.id,
+      partnerId: null,
+      templateId,
+      name,
+      targetType: 'organization',
+      targetId: org!.id,
+      overrideSettings,
+      isActive: true,
+    }).returning({ id: alertRules.id });
+    return rule!.id;
+  };
+
+  // (a) effective conditions come from the override…
+  const overrideCustomRuleId = await insertAlertRule(
+    'Override is custom',
+    metricTemplateId,
+    { conditions: CUSTOM_CONDITIONS, cooldownMinutes: 10 },
+  );
+  // …(b) and from the joined template when the override has no conditions key.
+  const templateCustomRuleId = await insertAlertRule(
+    'Template is custom',
+    customTemplateId,
+    { cooldownMinutes: 10 },
+  );
+  const templateCustomNoOverrideRuleId = await insertAlertRule(
+    'Template is custom, no override at all',
+    customTemplateId,
+    null,
+  );
+  const supportedRuleId = await insertAlertRule('Supported metric', metricTemplateId, null);
+  // A custom template whose override REPLACES the conditions with a real one:
+  // the override wins, so this must stay active.
+  const overrideRescuesRuleId = await insertAlertRule(
+    'Override rescues a custom template',
+    customTemplateId,
+    { conditions: METRIC_CONDITIONS },
+  );
+
+  return {
+    orgId: org!.id,
+    policyIds: [policyAId, policyBId, policyCId],
+    linkAId,
+    linkBId,
+    linkCId,
+    allCustomRuleId,
+    mixedRuleId,
+    loneCustomRuleId,
+    referencedRuleId,
+    alertId: alertRow!.id,
+    overrideCustomRuleId,
+    templateCustomRuleId,
+    templateCustomNoOverrideRuleId,
+    supportedRuleId,
+    overrideRescuesRuleId,
+  };
+}
+
+async function rulesForLink(linkId: string) {
+  return getTestDb()
+    .select({
+      id: configPolicyAlertRules.id,
+      name: configPolicyAlertRules.name,
+      conditions: configPolicyAlertRules.conditions,
+      sortOrder: configPolicyAlertRules.sortOrder,
+    })
+    .from(configPolicyAlertRules)
+    .where(eq(configPolicyAlertRules.featureLinkId, linkId))
+    .orderBy(asc(configPolicyAlertRules.sortOrder));
+}
+
+async function linkById(linkId: string) {
+  const [row] = await getTestDb()
+    .select()
+    .from(configPolicyFeatureLinks)
+    .where(eq(configPolicyFeatureLinks.id, linkId));
+  return row;
+}
+
+async function mirrorItems(linkId: string) {
+  const link = await linkById(linkId);
+  return (link!.inlineSettings as { items: Array<Record<string, unknown>> }).items;
+}
+
+async function alertRuleById(ruleId: string) {
+  const [row] = await getTestDb()
+    .select({ id: alertRules.id, isActive: alertRules.isActive })
+    .from(alertRules)
+    .where(eq(alertRules.id, ruleId));
+  return row;
+}
+
+describe('retired `custom` alert-condition cleanup migration (2026-08-06-g)', () => {
+  runDb('deletes a config-policy rule whose every condition is `custom`', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    const survivors = await getTestDb()
+      .select({ id: configPolicyAlertRules.id })
+      .from(configPolicyAlertRules)
+      .where(inArray(configPolicyAlertRules.id, [seed.allCustomRuleId, seed.loneCustomRuleId]));
+    expect(survivors).toHaveLength(0);
+  });
+
+  runDb('leaves a rule that mixes `custom` with a supported condition intact', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    const remaining = await rulesForLink(seed.linkAId);
+    expect(remaining.map((r) => r.id)).toEqual([seed.mixedRuleId]);
+    expect(remaining[0]!.name).toBe('Mixed conditions');
+    // Conditions untouched — the migration must not rewrite a mixed rule.
+    expect(remaining[0]!.conditions).toEqual(MIXED_CONDITIONS);
+  });
+
+  runDb('leaves an all-custom rule in place when an alerts row references it', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    const kept = await rulesForLink(seed.linkCId);
+    expect(kept.map((r) => r.id)).toEqual([seed.referencedRuleId]);
+
+    // Alert provenance is untouched too.
+    const [alertRow] = await getTestDb()
+      .select({ configPolicyId: alerts.configPolicyId })
+      .from(alerts)
+      .where(eq(alerts.id, seed.alertId));
+    expect(alertRow!.configPolicyId).toBe(seed.referencedRuleId);
+  });
+
+  runDb('rebuilds the inline_settings items[] mirror for links that lost rows', async () => {
+    const seed = await seedScenario();
+    const beforeC = await linkById(seed.linkCId);
+    await runMigration();
+
+    // Link A: the deleted rule is gone from the mirror, the survivor remains.
+    const itemsA = await mirrorItems(seed.linkAId);
+    expect(itemsA.map((i) => i.name)).toEqual(['Mixed conditions']);
+    expect(itemsA[0]).toMatchObject({
+      name: 'Mixed conditions',
+      severity: 'medium',
+      conditions: MIXED_CONDITIONS,
+      cooldownMinutes: 5,
+      autoResolve: false,
+      autoResolveConditions: null,
+      titleTemplate: '{{ruleName}} triggered on {{deviceName}}',
+      messageTemplate: '{{ruleName}} condition met',
+      sortOrder: 1,
+    });
+
+    // Link B lost its ONLY rule: the correlated aggregate must collapse the
+    // mirror to an empty items[] rather than leaving the stale entry behind.
+    const linkB = await linkById(seed.linkBId);
+    expect(linkB!.inlineSettings).toEqual({ items: [] });
+
+    // Link C lost nothing, so it is outside the affected set and untouched
+    // (including updated_at).
+    const afterC = await linkById(seed.linkCId);
+    expect(afterC).toEqual(beforeC);
+  });
+
+  runDb('deactivates — never deletes — alert_rules whose effective conditions are all custom', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    // (a) conditions from override_settings->'conditions'
+    expect(await alertRuleById(seed.overrideCustomRuleId)).toEqual({
+      id: seed.overrideCustomRuleId,
+      isActive: false,
+    });
+    // (b) conditions from the joined alert_templates row
+    expect(await alertRuleById(seed.templateCustomRuleId)).toEqual({
+      id: seed.templateCustomRuleId,
+      isActive: false,
+    });
+    expect(await alertRuleById(seed.templateCustomNoOverrideRuleId)).toEqual({
+      id: seed.templateCustomNoOverrideRuleId,
+      isActive: false,
+    });
+
+    // The rows still exist — alerts.rule_id is a real FK with no ON DELETE.
+    const stillThere = await getTestDb()
+      .select({ id: alertRules.id })
+      .from(alertRules)
+      .where(inArray(alertRules.id, [
+        seed.overrideCustomRuleId,
+        seed.templateCustomRuleId,
+        seed.templateCustomNoOverrideRuleId,
+      ]));
+    expect(stillThere).toHaveLength(3);
+  });
+
+  runDb('leaves alert_rules with a supported condition active', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    expect((await alertRuleById(seed.supportedRuleId))!.isActive).toBe(true);
+    // The override supplies a real condition, so the custom template is moot.
+    expect((await alertRuleById(seed.overrideRescuesRuleId))!.isActive).toBe(true);
+  });
+
+  runDb('is idempotent — a second run changes nothing', async () => {
+    const seed = await seedScenario();
+    await runMigration();
+
+    const db = getTestDb();
+    const snapshot = async () => ({
+      links: await db
+        .select()
+        .from(configPolicyFeatureLinks)
+        .where(inArray(configPolicyFeatureLinks.configPolicyId, seed.policyIds))
+        .orderBy(asc(configPolicyFeatureLinks.id)),
+      policyRules: await db
+        .select()
+        .from(configPolicyAlertRules)
+        .orderBy(asc(configPolicyAlertRules.id)),
+      alertRules: await db
+        .select()
+        .from(alertRules)
+        .orderBy(asc(alertRules.id)),
+    });
+
+    const before = await snapshot();
+    // A replay that rewrote an identical mirror would still bump updated_at
+    // (and the partner-export watermark) — the IS DISTINCT FROM guard and the
+    // empty affected-links set exist to prevent exactly that, so assert the
+    // captured timestamps explicitly as well as by deep equality.
+    const updatedAtBefore = before.links.map((l) => l.updatedAt);
+
+    await runMigration();
+
+    const after = await snapshot();
+    expect(after.links.map((l) => l.updatedAt)).toEqual(updatedAtBefore);
+    expect(after).toEqual(before);
+  });
+});

--- a/apps/api/src/routes/alertTemplates/conditionTypes.test.ts
+++ b/apps/api/src/routes/alertTemplates/conditionTypes.test.ts
@@ -55,7 +55,15 @@ function makeDb() {
   return { select: () => chain, update: () => chain, insert: () => chain, delete: () => chain };
 }
 
-vi.mock('../../db', () => ({ db: makeDb() }));
+vi.mock('../../db', () => ({
+  db: makeDb(),
+  // The re-activation gate reads alert_templates in a SYSTEM context: an
+  // org-scoped caller cannot see a partner-owned template, and a zero-row read
+  // would look like "no retired conditions". Pass-throughs here so the test
+  // exercises the real query.
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+  withSystemDbAccessContext: (fn: () => unknown) => fn(),
+}));
 vi.mock('../../db/schema', () => ({
   alertRules: { id: 'id', orgId: 'orgId', isActive: 'isActive', templateId: 'templateId' },
   alertTemplates: { id: 'id', orgId: 'orgId', conditions: 'conditions' },
@@ -193,6 +201,40 @@ describe('alert-template condition types (#2948)', () => {
     const res = await request(ruleRoutes, `/alert-templates/rules/${RULE_ID}/toggle`, 'POST', { enabled: true });
 
     expect(res.status).not.toBe(400);
+  });
+
+  it('fails CLOSED when the rule\'s template cannot be read', async () => {
+    // alert_templates SELECT is org-access OR partner-access OR built-in, and an
+    // org token never passes the partner branch — yet an org-owned rule may point
+    // at a partner-owned template. A zero-row read must not read as "nothing
+    // retired", or the gate waves through the rule it exists to stop.
+    dbRef.current = [
+      [{ partnerId: null }],
+      [{ id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, overrideSettings: {} }],
+      [], // template invisible
+    ];
+
+    const res = await request(ruleRoutes, `/alert-templates/rules/${RULE_ID}/toggle`, 'POST', { enabled: true });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toMatch(/could not be read/i);
+  });
+
+  // PATCH accepts `enabled` too, so it is a second re-activation path. It was
+  // ungated while the toggle route two functions below it was gated.
+  it('refuses to re-enable via PATCH, not just via the toggle route', async () => {
+    dbRef.current = [
+      [{ partnerId: null }],
+      [{
+        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID,
+        overrideSettings: { conditions: [{ type: 'custom' }] },
+      }],
+    ];
+
+    const res = await request(ruleRoutes, `/alert-templates/rules/${RULE_ID}`, 'PATCH', { enabled: true });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toMatch(/cannot be re-enabled/i);
   });
 
   it('does not re-check an already-active rule being toggled off', async () => {

--- a/apps/api/src/routes/alertTemplates/conditionTypes.test.ts
+++ b/apps/api/src/routes/alertTemplates/conditionTypes.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression coverage for #2948 on the alert-TEMPLATE routes.
+//
+// These endpoints validate `conditions` as `z.record(z.string(), z.any())` — an
+// OBJECT, never an array — which is a different payload shape from
+// POST /alerts/rules. Two things follow, and both are covered here:
+//
+//   * AlertTemplateEditor posts `{ triggers: [...], thresholdDefaults, ... }`,
+//     so a retired type sits under `conditions.triggers[]`, not at the root. A
+//     structure-aware walk that only recursed on a `conditions` array missed
+//     this entirely and made the guard dead code for the product's own UI.
+//   * The toggle route is the one-click path back to an enabled-but-unfirable
+//     rule after the cleanup migration deactivated it.
+
+const { authRef, dbRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Tess Tech', email: 'tess@org.example' },
+      partnerId: null as string | null,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+  // Rows returned, in call order, by each db.select(...) chain.
+  dbRef: { current: [] as unknown[][] },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+  siteAccessCheck: () => () => true,
+}));
+
+// Chainable + thenable Drizzle stub: every chain method returns `this`, and
+// awaiting it yields the next queued result array.
+function makeDb() {
+  const chain: any = new Proxy(function () {} as any, {
+    get(_t, prop) {
+      if (prop === 'then') {
+        return (resolve: (v: unknown) => void) => resolve(dbRef.current.shift() ?? []);
+      }
+      return () => chain;
+    },
+    apply: () => chain,
+  });
+  return { select: () => chain, update: () => chain, insert: () => chain, delete: () => chain };
+}
+
+vi.mock('../../db', () => ({ db: makeDb() }));
+vi.mock('../../db/schema', () => ({
+  alertRules: { id: 'id', orgId: 'orgId', isActive: 'isActive', templateId: 'templateId' },
+  alertTemplates: { id: 'id', orgId: 'orgId', conditions: 'conditions' },
+  organizations: { id: 'id', partnerId: 'partnerId' },
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('./helpers', () => ({
+  resolveScopedOrgId: vi.fn(() => 'org-1'),
+  parseBoolean: vi.fn(() => undefined),
+}));
+vi.mock('../../utils/pagination', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+}));
+
+import { ruleRoutes } from './rules';
+import { templateRoutes } from './templates';
+
+const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+const TEMPLATE_ID = '11112222-3333-4444-8555-666677778888';
+
+function request(routes: Hono, path: string, method: string, body: unknown) {
+  const app = new Hono();
+  app.route('/alert-templates', routes);
+  return app.request(path, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// The exact envelope AlertTemplateEditor.tsx submits.
+const EDITOR_ENVELOPE = (triggers: unknown[]) => ({
+  triggers,
+  thresholdDefaults: {},
+  notifications: {},
+  escalationRules: [],
+  autoRemediation: {},
+  suppression: {},
+});
+
+describe('alert-template condition types (#2948)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbRef.current = [];
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Tess Tech', email: 'tess@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('rejects a template whose editor-envelope triggers carry the retired type', async () => {
+    const res = await request(templateRoutes, '/alert-templates/templates', 'POST', {
+      name: 'T', severity: 'high',
+      conditions: EDITOR_ENVELOPE([{ type: 'custom', field: 'x', customCondition: '> 1' }]),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toContain('custom');
+  });
+
+  it('accepts the same envelope when its triggers are live types', async () => {
+    // `event` is what the editor actually writes and has no registry handler —
+    // a registry-allowlist guard would have 400'd every template save.
+    const res = await request(templateRoutes, '/alert-templates/templates', 'POST', {
+      name: 'T', severity: 'high',
+      conditions: EDITOR_ENVELOPE([{ type: 'event', eventSource: 'system', pattern: 'disk' }]),
+    });
+
+    expect(res.status).not.toBe(400);
+  });
+
+  it('rejects a retired type on template update', async () => {
+    dbRef.current = [[{ id: TEMPLATE_ID, orgId: 'org-1', partnerId: null, isBuiltIn: false }]];
+
+    const res = await request(templateRoutes, `/alert-templates/templates/${TEMPLATE_ID}`, 'PATCH', {
+      conditions: EDITOR_ENVELOPE([{ type: 'custom' }]),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toContain('custom');
+  });
+
+  it('rejects a retired type in the object-shaped rule override', async () => {
+    const res = await request(ruleRoutes, '/alert-templates/rules', 'POST', {
+      templateId: TEMPLATE_ID, name: 'r',
+      conditions: { type: 'custom', customCondition: 'x' },
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toContain('custom');
+  });
+
+  it('refuses to re-enable a rule the cleanup migration deactivated', async () => {
+    dbRef.current = [
+      // ruleOwnershipConditionForOrg's organizations lookup runs first
+      [{ partnerId: null }],
+      // then the rule lookup — inactive, with all-custom override conditions
+      [{
+        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID,
+        overrideSettings: { conditions: [{ type: 'custom' }] },
+      }],
+    ];
+
+    const res = await request(ruleRoutes, `/alert-templates/rules/${RULE_ID}/toggle`, 'POST', { enabled: true });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('custom');
+    expect(body.error).toMatch(/cannot be re-enabled/i);
+  });
+
+  it('falls back to the template conditions when the rule carries no override', async () => {
+    dbRef.current = [
+      [{ partnerId: null }],
+      [{ id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID, overrideSettings: {} }],
+      [{ conditions: [{ type: 'custom' }] }],
+    ];
+
+    const res = await request(ruleRoutes, `/alert-templates/rules/${RULE_ID}/toggle`, 'POST', { enabled: true });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('still allows re-enabling a rule with a supported condition', async () => {
+    dbRef.current = [
+      [{ partnerId: null }],
+      [{
+        id: RULE_ID, orgId: 'org-1', isActive: false, templateId: TEMPLATE_ID,
+        overrideSettings: { conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }] },
+      }],
+      [{ id: RULE_ID, isActive: true }],
+    ];
+
+    const res = await request(ruleRoutes, `/alert-templates/rules/${RULE_ID}/toggle`, 'POST', { enabled: true });
+
+    expect(res.status).not.toBe(400);
+  });
+
+  it('does not re-check an already-active rule being toggled off', async () => {
+    dbRef.current = [
+      [{ partnerId: null }],
+      [{
+        id: RULE_ID, orgId: 'org-1', isActive: true, templateId: TEMPLATE_ID,
+        overrideSettings: { conditions: [{ type: 'custom' }] },
+      }],
+      [{ id: RULE_ID, isActive: false }],
+    ];
+
+    const res = await request(ruleRoutes, `/alert-templates/rules/${RULE_ID}/toggle`, 'POST', { enabled: false });
+
+    expect(res.status).not.toBe(400);
+  });
+});

--- a/apps/api/src/routes/alertTemplates/rules.ts
+++ b/apps/api/src/routes/alertTemplates/rules.ts
@@ -287,9 +287,22 @@ ruleRoutes.patch(
         return c.json({ error: 'No updates provided' }, 400);
       }
 
+      // Narrower than the /alerts/rules guard on purpose: updateRuleSchema
+      // (./schemas.ts) has no overrideSettings/overrides passthrough, so there
+      // is no second key to smuggle conditions through. Add one and this must
+      // widen to match.
       const updateConditionTypeError = retiredConditionTypeError(updates.conditions);
       if (updateConditionTypeError) {
         return c.json({ error: updateConditionTypeError }, 400);
+      }
+
+      // This route accepts `enabled` too, so it is a second re-activation path
+      // alongside the toggle below — and it carries no conditions either.
+      if (updates.enabled === true && !existing.isActive) {
+        const reactivationError = await retiredConditionReactivationError(existing);
+        if (reactivationError) {
+          return c.json({ error: reactivationError }, 400);
+        }
       }
 
       const setValues: Record<string, unknown> = {};

--- a/apps/api/src/routes/alertTemplates/rules.ts
+++ b/apps/api/src/routes/alertTemplates/rules.ts
@@ -9,6 +9,7 @@ import { listRulesSchema, createRuleSchema, updateRuleSchema, toggleRuleSchema }
 import { resolveScopedOrgId, parseBoolean } from './helpers';
 import { getPagination } from '../../utils/pagination';
 import { PERMISSIONS } from '../../services/permissions';
+import { unsupportedConditionTypeError } from '../../services/alertConditions';
 
 export const ruleRoutes = new Hono();
 
@@ -132,6 +133,13 @@ ruleRoutes.post(
       const data = c.req.valid('json');
       if (data.orgId && data.orgId !== orgId) {
         return c.json({ error: 'Forbidden' }, 403);
+      }
+
+      // #2948 — this route writes the same overrideSettings.conditions the
+      // evaluator reads, so it needs the same boundary as POST /alerts/rules.
+      const createConditionTypeError = unsupportedConditionTypeError(data.conditions);
+      if (createConditionTypeError) {
+        return c.json({ error: createConditionTypeError }, 400);
       }
 
       // Verify template exists and is accessible
@@ -276,6 +284,11 @@ ruleRoutes.patch(
 
       if (Object.keys(updates).length === 0) {
         return c.json({ error: 'No updates provided' }, 400);
+      }
+
+      const updateConditionTypeError = unsupportedConditionTypeError(updates.conditions);
+      if (updateConditionTypeError) {
+        return c.json({ error: updateConditionTypeError }, 400);
       }
 
       const setValues: Record<string, unknown> = {};

--- a/apps/api/src/routes/alertTemplates/rules.ts
+++ b/apps/api/src/routes/alertTemplates/rules.ts
@@ -9,7 +9,8 @@ import { listRulesSchema, createRuleSchema, updateRuleSchema, toggleRuleSchema }
 import { resolveScopedOrgId, parseBoolean } from './helpers';
 import { getPagination } from '../../utils/pagination';
 import { PERMISSIONS } from '../../services/permissions';
-import { unsupportedConditionTypeError } from '../../services/alertConditions';
+import { retiredConditionTypeError } from '../../services/alertConditions';
+import { retiredConditionReactivationError } from '../alerts/helpers';
 
 export const ruleRoutes = new Hono();
 
@@ -137,7 +138,7 @@ ruleRoutes.post(
 
       // #2948 — this route writes the same overrideSettings.conditions the
       // evaluator reads, so it needs the same boundary as POST /alerts/rules.
-      const createConditionTypeError = unsupportedConditionTypeError(data.conditions);
+      const createConditionTypeError = retiredConditionTypeError(data.conditions);
       if (createConditionTypeError) {
         return c.json({ error: createConditionTypeError }, 400);
       }
@@ -286,7 +287,7 @@ ruleRoutes.patch(
         return c.json({ error: 'No updates provided' }, 400);
       }
 
-      const updateConditionTypeError = unsupportedConditionTypeError(updates.conditions);
+      const updateConditionTypeError = retiredConditionTypeError(updates.conditions);
       if (updateConditionTypeError) {
         return c.json({ error: updateConditionTypeError }, 400);
       }
@@ -399,6 +400,15 @@ ruleRoutes.post(
 
       if (existing.orgId === null) {
         return c.json({ error: PARTNER_WIDE_RULE_READONLY_HERE }, 403);
+      }
+
+      // #2948 — same gate as PUT /alerts/rules. Without it this is the one-click
+      // path back to a rule that is enabled, looks healthy, and can never fire.
+      if (enabled && !existing.isActive) {
+        const reactivationError = await retiredConditionReactivationError(existing);
+        if (reactivationError) {
+          return c.json({ error: reactivationError }, 400);
+        }
       }
 
       const [updated] = await db

--- a/apps/api/src/routes/alertTemplates/templates.ts
+++ b/apps/api/src/routes/alertTemplates/templates.ts
@@ -9,7 +9,7 @@ import { listTemplatesSchema, createTemplateSchema, updateTemplateSchema } from 
 import { parseBoolean } from './helpers';
 import { getPagination } from '../../utils/pagination';
 import { PERMISSIONS } from '../../services/permissions';
-import { unsupportedConditionTypeError } from '../../services/alertConditions';
+import { retiredConditionTypeError } from '../../services/alertConditions';
 
 export const templateRoutes = new Hono();
 
@@ -177,8 +177,10 @@ templateRoutes.post(
       const data = c.req.valid('json');
 
       // #2948 — template conditions are the evaluator's fallback when a rule
-      // carries no override, so an unevaluable type is just as dead here.
-      const createConditionTypeError = unsupportedConditionTypeError(data.conditions);
+      // carries no override, so a retired type is just as dead here. The
+      // editor nests its triggers under `conditions.triggers`, which the walk
+      // in retiredConditionTypeError descends into.
+      const createConditionTypeError = retiredConditionTypeError(data.conditions);
       if (createConditionTypeError) {
         return c.json({ error: createConditionTypeError }, 400);
       }
@@ -317,7 +319,7 @@ templateRoutes.patch(
         return c.json({ error: writable.error }, writable.status);
       }
 
-      const updateConditionTypeError = unsupportedConditionTypeError(updates.conditions);
+      const updateConditionTypeError = retiredConditionTypeError(updates.conditions);
       if (updateConditionTypeError) {
         return c.json({ error: updateConditionTypeError }, 400);
       }

--- a/apps/api/src/routes/alertTemplates/templates.ts
+++ b/apps/api/src/routes/alertTemplates/templates.ts
@@ -9,6 +9,7 @@ import { listTemplatesSchema, createTemplateSchema, updateTemplateSchema } from 
 import { parseBoolean } from './helpers';
 import { getPagination } from '../../utils/pagination';
 import { PERMISSIONS } from '../../services/permissions';
+import { unsupportedConditionTypeError } from '../../services/alertConditions';
 
 export const templateRoutes = new Hono();
 
@@ -175,6 +176,13 @@ templateRoutes.post(
       const auth = c.get('auth');
       const data = c.req.valid('json');
 
+      // #2948 — template conditions are the evaluator's fallback when a rule
+      // carries no override, so an unevaluable type is just as dead here.
+      const createConditionTypeError = unsupportedConditionTypeError(data.conditions);
+      if (createConditionTypeError) {
+        return c.json({ error: createConditionTypeError }, 400);
+      }
+
       // Resolve org/partner axes from scope + the requested availability,
       // mirroring Scripts (#1357). partner_id is denormalized onto org rows for
       // RLS consistency; a partner-wide template has org_id NULL.
@@ -307,6 +315,11 @@ templateRoutes.patch(
       const writable = canWriteTemplate(auth, existing);
       if (!writable.ok) {
         return c.json({ error: writable.error }, writable.status);
+      }
+
+      const updateConditionTypeError = unsupportedConditionTypeError(updates.conditions);
+      if (updateConditionTypeError) {
+        return c.json({ error: updateConditionTypeError }, 400);
       }
 
       if (Object.keys(updates).length === 0) {

--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -602,12 +602,34 @@ export async function retiredConditionReactivationError(rule: {
   let conditions = overrides.conditions;
 
   if (conditions === undefined || conditions === null) {
-    const [template] = await db
-      .select({ conditions: alertTemplates.conditions })
-      .from(alertTemplates)
-      .where(eq(alertTemplates.id, rule.templateId))
-      .limit(1);
-    conditions = template?.conditions;
+    // Read in a SYSTEM context, not the caller's. alert_templates SELECT is
+    // `breeze_has_org_access(org_id) OR breeze_has_partner_access(partner_id)
+    // OR is_built_in`, and an org token never passes the partner branch — yet
+    // an org-owned rule is explicitly allowed to point at a partner-owned
+    // template (see the templateDenied check in rules.ts). Reading as the
+    // caller would return zero rows for exactly that combination, and a
+    // "no conditions found" answer reads as "nothing retired" — the gate would
+    // wave through the rule it exists to stop.
+    const [template] = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        db
+          .select({ conditions: alertTemplates.conditions })
+          .from(alertTemplates)
+          .where(eq(alertTemplates.id, rule.templateId))
+          .limit(1)
+      )
+    );
+
+    if (!template) {
+      // Fail CLOSED. "I could not determine this rule's conditions" is not
+      // evidence that they are safe, and the cost of being wrong is asymmetric:
+      // a spurious error on an already-broken rule, versus silently restoring
+      // permanent alerting loss.
+      return 'This alert rule\'s template could not be read, so its conditions cannot be verified. '
+        + 'It cannot be re-enabled until the template is accessible.';
+    }
+
+    conditions = template.conditions;
   }
 
   const error = retiredConditionTypeError(conditions);

--- a/apps/api/src/routes/alerts/helpers.ts
+++ b/apps/api/src/routes/alerts/helpers.ts
@@ -12,6 +12,7 @@ import {
   partners,
 } from '../../db/schema';
 import { siteAccessCheck } from '../../middleware/auth';
+import { retiredConditionTypeError } from '../../services/alertConditions';
 import {
   validateEmailConfig,
   validateWebhookConfig,
@@ -574,4 +575,43 @@ export async function resolveAlertTemplate(params: {
     .returning();
 
   return { template: createdTemplate, created: true };
+}
+
+/**
+ * Guard for the re-activation paths (#2948).
+ *
+ * `2026-08-06-g-drop-custom-alert-conditions.sql` deactivates standalone alert
+ * rules whose every effective condition is the retired `custom` type — it
+ * cannot delete them, because `alerts.rule_id` is a real FK with no
+ * `ON DELETE`. Without this check the obvious reaction to a rule that "turned
+ * itself off after an upgrade" — flipping it back on via the toggle or a
+ * PUT — silently restores the exact pre-fix state: enabled, healthy-looking,
+ * permanently unfirable. Neither of those paths sends `conditions`, so the
+ * write-boundary check on the payload never sees them.
+ *
+ * Resolves the rule's EFFECTIVE conditions with the same precedence
+ * formatAlertRuleResponse and alertService.getApplicableRules use
+ * (`overrides.conditions ?? template.conditions`) and returns an error message
+ * when they are retired, or null when re-activation is safe.
+ */
+export async function retiredConditionReactivationError(rule: {
+  templateId: string;
+  overrideSettings?: unknown;
+}): Promise<string | null> {
+  const overrides = getOverrides(rule.overrideSettings);
+  let conditions = overrides.conditions;
+
+  if (conditions === undefined || conditions === null) {
+    const [template] = await db
+      .select({ conditions: alertTemplates.conditions })
+      .from(alertTemplates)
+      .where(eq(alertTemplates.id, rule.templateId))
+      .limit(1);
+    conditions = template?.conditions;
+  }
+
+  const error = retiredConditionTypeError(conditions);
+  if (!error) return null;
+
+  return `${error} This rule cannot be re-enabled until it is replaced.`;
 }

--- a/apps/api/src/routes/alerts/rules.conditionTypes.test.ts
+++ b/apps/api/src/routes/alerts/rules.conditionTypes.test.ts
@@ -50,7 +50,9 @@ vi.mock('./helpers', () => ({
   // the condition-type guard to prove the guard did NOT fire, without needing a
   // full Drizzle chain stub.
   getAlertRuleWithOrgCheck: vi.fn(async () => undefined),
-  isRecord: vi.fn(() => false),
+  // NOT stubbed to false: the overrideSettings/overrides passthrough merge
+  // depends on it, and stubbing it away hid the bypass this file now covers.
+  isRecord: vi.fn((v: unknown) => v !== null && typeof v === 'object' && !Array.isArray(v)),
   getOverrides: vi.fn(() => ({})),
   normalizeTargetsForRule: vi.fn(() => ({ targetType: 'all', targetId: 'org-1', targetIds: [], targets: { type: 'all', ids: [] } })),
   getNotificationChannelIds: vi.fn(() => []),
@@ -60,9 +62,11 @@ vi.mock('./helpers', () => ({
   // Undefined template => create stops at 500 "Failed to resolve alert
   // template", which is again past the guard.
   resolveAlertTemplate: vi.fn(async () => ({ template: undefined, created: false })),
+  retiredConditionReactivationError: vi.fn(async () => null),
 }));
 
 import { rulesRoutes } from './rules';
+import * as helpers from './helpers';
 
 function makeApp() {
   const app = new Hono();
@@ -113,8 +117,8 @@ describe('alert rule condition types (#2948)', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as { error: string };
     expect(body.error).toContain('custom');
-    // The message must name what IS supported, or the tech has no next step.
-    expect(body.error).toContain('threshold');
+    // The message must tell the tech what to do, not just that it failed.
+    expect(body.error).toMatch(/remove or replace/i);
   });
 
   it('rejects an unregistered type nested inside a condition group', async () => {
@@ -156,5 +160,88 @@ describe('alert rule condition types (#2948)', () => {
     const res = await put({ name: 'renamed' });
 
     expect(res.status).toBe(404);
+  });
+
+  // `overrideSettings` and `overrides` are z.any() passthroughs merged into the
+  // stored overrideSettings, and alertService reads overrides.conditions /
+  // overrides.autoResolveConditions straight back out. A guard on `conditions`
+  // alone is bypassed by moving the same payload one key over.
+  it('rejects a retired type smuggled through overrideSettings', async () => {
+    const res = await post({
+      // Valid top-level conditions, poisoned overrides — the shape that slipped
+      // past a `data.conditions`-only guard. (`conditions` is required by the
+      // create schema when no templateId is given, so it must be present.)
+      ...VALID_RULE,
+      conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }],
+      overrideSettings: { conditions: [{ type: 'custom', customCondition: 'x' }] },
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toContain('custom');
+  });
+
+  it('rejects a retired type smuggled through overrides.autoResolveConditions', async () => {
+    const res = await post({
+      ...VALID_RULE,
+      conditions: [{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }],
+      overrides: { autoResolveConditions: [{ type: 'custom' }] },
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects the same smuggling on update', async () => {
+    const res = await put({ overrideSettings: { conditions: [{ type: 'custom' }] } });
+
+    expect(res.status).toBe(400);
+  });
+
+  // The registry is NOT the set of live condition types. `dns_threat` is a
+  // seeded built-in evaluated by the event-bus subscriber in
+  // services/dnsThreatAlerts.ts; narrowing one is a plain PUT of
+  // override_settings.conditions.categories. A registry-allowlist guard would
+  // 400 that working feature.
+  it('refuses to re-enable a rule the cleanup migration deactivated', async () => {
+    // The migration deactivates alert_rules whose every effective condition is
+    // retired; it cannot delete them (alerts.rule_id is a real FK). Without a
+    // gate here, flipping the rule back on restores the exact pre-#2948 state —
+    // enabled, healthy-looking, unfirable — and this request carries no
+    // `conditions`, so the payload guard never sees it.
+    vi.mocked(helpers.getAlertRuleWithOrgCheck).mockResolvedValue({
+      id: RULE_ID, orgId: 'org-1', partnerId: null, isActive: false,
+      targetType: 'all', targetId: 'org-1',
+      templateId: '11112222-3333-4444-8555-666677778888',
+      overrideSettings: { conditions: [{ type: 'custom' }] },
+    } as never);
+    vi.mocked(helpers.retiredConditionReactivationError).mockResolvedValue(
+      'Retired alert condition type(s): custom. This rule cannot be re-enabled until it is replaced.'
+    );
+
+    const res = await put({ isActive: true });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toMatch(/cannot be re-enabled/i);
+  });
+
+  it('does not gate an already-active rule being edited for another reason', async () => {
+    vi.mocked(helpers.getAlertRuleWithOrgCheck).mockResolvedValue({
+      id: RULE_ID, orgId: 'org-1', partnerId: null, isActive: true,
+      targetType: 'all', targetId: 'org-1',
+      templateId: '11112222-3333-4444-8555-666677778888',
+      overrideSettings: {},
+    } as never);
+
+    await put({ isActive: true, name: 'renamed' });
+
+    expect(helpers.retiredConditionReactivationError).not.toHaveBeenCalled();
+  });
+
+  it('does not block a live push-evaluated type that has no registry handler', async () => {
+    const res = await post({
+      ...VALID_RULE,
+      conditions: [{ type: 'dns_threat', eventType: 'dns.threat.blocked', categories: ['malware'] }],
+    });
+
+    expect(res.status).not.toBe(400);
   });
 });

--- a/apps/api/src/routes/alerts/rules.conditionTypes.test.ts
+++ b/apps/api/src/routes/alerts/rules.conditionTypes.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// Regression coverage for #2948: the `custom` alert-condition type never had a
+// registered evaluator handler, so conditionRegistry.evaluate() answered
+// "Unknown condition type" and — because a root-level conditions array is an
+// implicit AND — the whole rule could never fire. The route accepted it anyway
+// (`conditions: z.any()`), so a tech could save a rule that silently monitored
+// nothing. These endpoints must now reject any condition type with no handler.
+
+const { authRef } = vi.hoisted(() => ({
+  authRef: {
+    current: {
+      scope: 'organization' as string,
+      user: { id: 'u-1', name: 'Tess Tech', email: 'tess@org.example' },
+      partnerId: null as string | null,
+      orgId: 'org-1' as string | null,
+      accessibleOrgIds: null as string[] | null,
+      canAccessOrg: (_id: string) => true as boolean,
+    },
+  },
+}));
+
+vi.mock('../../middleware/auth', () => ({
+  authMiddleware: vi.fn(async (_c: any, next: any) => next()),
+  requireScope: () => async (c: any, next: any) => {
+    c.set('auth', authRef.current);
+    await next();
+  },
+  requirePermission: () => async (_c: any, next: any) => next(),
+  requireMfa: () => async (_c: any, next: any) => next(),
+  siteAccessCheck: () => () => true,
+}));
+
+vi.mock('../../db', () => ({ db: {} }));
+vi.mock('../../db/schema', () => ({
+  alertRules: { id: 'id', orgId: 'orgId', partnerId: 'partnerId', isActive: 'isActive', createdAt: 'createdAt', templateId: 'templateId' },
+  alertTemplates: {}, alerts: {}, devices: {}, deviceGroups: {}, sites: {},
+  organizations: { id: 'id', partnerId: 'partnerId' },
+}));
+vi.mock('../../services/auditEvents', () => ({ writeRouteAudit: vi.fn() }));
+vi.mock('../../services/partnerWideAccess', () => ({
+  canManagePartnerWidePolicies: vi.fn(() => true),
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE: 'denied',
+}));
+vi.mock('./helpers', () => ({
+  getPagination: vi.fn(() => ({ page: 1, limit: 50, offset: 0 })),
+  ensureOrgAccess: vi.fn(() => true),
+  // Returning undefined makes the update route stop at 404 — far enough past
+  // the condition-type guard to prove the guard did NOT fire, without needing a
+  // full Drizzle chain stub.
+  getAlertRuleWithOrgCheck: vi.fn(async () => undefined),
+  isRecord: vi.fn(() => false),
+  getOverrides: vi.fn(() => ({})),
+  normalizeTargetsForRule: vi.fn(() => ({ targetType: 'all', targetId: 'org-1', targetIds: [], targets: { type: 'all', ids: [] } })),
+  getNotificationChannelIds: vi.fn(() => []),
+  containsNotificationBindingOverride: vi.fn(() => false),
+  validateAlertRuleNotificationBindings: vi.fn(async () => null),
+  formatAlertRuleResponse: vi.fn((r: unknown) => r),
+  // Undefined template => create stops at 500 "Failed to resolve alert
+  // template", which is again past the guard.
+  resolveAlertTemplate: vi.fn(async () => ({ template: undefined, created: false })),
+}));
+
+import { rulesRoutes } from './rules';
+
+function makeApp() {
+  const app = new Hono();
+  app.route('/alerts', rulesRoutes);
+  return app;
+}
+
+const RULE_ID = '5d4c3b2a-1111-4222-8333-444455556666';
+
+function post(body: unknown) {
+  return makeApp().request('/alerts/rules', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function put(body: unknown) {
+  return makeApp().request(`/alerts/rules/${RULE_ID}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_RULE = {
+  name: 'CPU high',
+  severity: 'high' as const,
+  targets: { type: 'all' as const, ids: [] },
+};
+
+describe('alert rule condition types (#2948)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authRef.current = {
+      scope: 'organization',
+      user: { id: 'u-1', name: 'Tess Tech', email: 'tess@org.example' },
+      partnerId: null, orgId: 'org-1', accessibleOrgIds: null, canAccessOrg: () => true,
+    } as typeof authRef.current;
+  });
+
+  it('rejects a create whose condition uses the retired `custom` type', async () => {
+    const res = await post({
+      ...VALID_RULE,
+      conditions: [{ type: 'custom', field: 'foo', customCondition: '> 100' }],
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain('custom');
+    // The message must name what IS supported, or the tech has no next step.
+    expect(body.error).toContain('threshold');
+  });
+
+  it('rejects an unregistered type nested inside a condition group', async () => {
+    const res = await post({
+      ...VALID_RULE,
+      conditions: { logic: 'or', conditions: [
+        { type: 'metric', metric: 'cpu', operator: 'gt', value: 85 },
+        { type: 'custom', customCondition: 'x' },
+      ] },
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toContain('custom');
+  });
+
+  it('rejects an update that re-saves a stored `custom` condition', async () => {
+    const res = await put({ conditions: [{ type: 'custom', customCondition: 'x' }] });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toContain('custom');
+  });
+
+  it('lets supported types through the guard', async () => {
+    const res = await post({
+      ...VALID_RULE,
+      conditions: [
+        { type: 'metric', metric: 'cpu', operator: 'gt', value: 85 },
+        { type: 'status', duration: 10 },
+        { type: 'event_log', category: 'system', level: 'error', countThreshold: 1, windowMinutes: 15 },
+      ],
+    });
+
+    // Not 400: the request fails later on the stubbed template resolution,
+    // which proves it got past the condition-type guard.
+    expect(res.status).not.toBe(400);
+  });
+
+  it('leaves an update with no conditions key untouched by the guard', async () => {
+    const res = await put({ name: 'renamed' });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -4,7 +4,7 @@ import { and, eq, sql, desc, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { alertRules, alertTemplates, alerts, devices, deviceGroups, organizations, sites } from '../../db/schema';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
-import { unsupportedConditionTypeError } from '../../services/alertConditions';
+import { retiredConditionTypeError } from '../../services/alertConditions';
 import { requireMfa, requirePermission, requireScope, siteAccessCheck } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
@@ -26,6 +26,7 @@ import {
   validateAlertRuleNotificationBindings,
   formatAlertRuleResponse,
   resolveAlertTemplate,
+  retiredConditionReactivationError,
 } from './helpers';
 
 export const rulesRoutes = new Hono();
@@ -277,9 +278,21 @@ rulesRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
-    // Reject conditions the evaluator has no handler for (#2948). Stored
-    // unchecked, such a rule fails closed forever while presenting as healthy.
-    const createConditionTypeError = unsupportedConditionTypeError(data.conditions);
+    // Reject retired condition types (#2948). Stored unchecked, such a rule
+    // fails closed forever while presenting as a healthy, enabled rule.
+    //
+    // Checked over `overrideSettings`/`overrides` as well as `conditions`, not
+    // just the latter: both are `z.any()` passthroughs that are merged into
+    // baseOverrides below, and `overrides.conditions` /
+    // `overrides.autoResolveConditions` are read straight back out by
+    // alertService (getApplicableRules, evaluateAutoResolveConditions). A
+    // guard on `data.conditions` alone is bypassed by moving the same payload
+    // one key over.
+    const createConditionTypeError = retiredConditionTypeError([
+      data.conditions,
+      data.overrideSettings,
+      data.overrides,
+    ]);
     if (createConditionTypeError) {
       return c.json({ error: createConditionTypeError }, 400);
     }
@@ -463,10 +476,14 @@ rulesRoutes.put(
       return c.json({ error: 'No updates provided' }, 400);
     }
 
-    // #2948 — same boundary as create. Also the mechanism that forces a tech
-    // editing a legacy rule to delete its retired condition rather than
-    // re-saving it verbatim.
-    const updateConditionTypeError = unsupportedConditionTypeError(data.conditions);
+    // #2948 — same boundary as create, over the same three passthrough fields.
+    // Also the mechanism that forces a tech editing a legacy rule to delete its
+    // retired condition rather than re-saving it verbatim.
+    const updateConditionTypeError = retiredConditionTypeError([
+      data.conditions,
+      data.overrideSettings,
+      data.overrides,
+    ]);
     if (updateConditionTypeError) {
       return c.json({ error: updateConditionTypeError }, 400);
     }
@@ -611,6 +628,21 @@ rulesRoutes.put(
 
     const isActive = data.isActive ?? data.enabled ?? data.active;
     if (isActive !== undefined) updates.isActive = isActive;
+
+    // Re-enabling a rule the #2948 cleanup migration switched off must go
+    // through the same boundary. This request carries no `conditions`, so the
+    // payload check above cannot see them — resolve the rule's effective ones.
+    // Only on the false -> true edge: an already-active rule being edited for
+    // some other reason is not made un-saveable by this.
+    if (isActive === true && !rule.isActive) {
+      const reactivationError = await retiredConditionReactivationError({
+        templateId: (updates.templateId as string) ?? rule.templateId,
+        overrideSettings: updates.overrideSettings ?? rule.overrideSettings,
+      });
+      if (reactivationError) {
+        return c.json({ error: reactivationError }, 400);
+      }
+    }
 
     if (Object.keys(updates).length === 0) {
       return c.json({ error: 'No updates provided' }, 400);

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -4,6 +4,7 @@ import { and, eq, sql, desc, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { alertRules, alertTemplates, alerts, devices, deviceGroups, organizations, sites } from '../../db/schema';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
+import { unsupportedConditionTypeError } from '../../services/alertConditions';
 import { requireMfa, requirePermission, requireScope, siteAccessCheck } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
@@ -276,6 +277,13 @@ rulesRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
+    // Reject conditions the evaluator has no handler for (#2948). Stored
+    // unchecked, such a rule fails closed forever while presenting as healthy.
+    const createConditionTypeError = unsupportedConditionTypeError(data.conditions);
+    if (createConditionTypeError) {
+      return c.json({ error: createConditionTypeError }, 400);
+    }
+
     // Ownership axis (#2128). Partner-wide rules evaluate against devices in
     // ALL orgs under the partner (including orgs created later), so creation
     // is gated on the partner-wide capability — same gate as software/security
@@ -453,6 +461,14 @@ rulesRoutes.put(
 
     if (Object.keys(data).length === 0) {
       return c.json({ error: 'No updates provided' }, 400);
+    }
+
+    // #2948 — same boundary as create. Also the mechanism that forces a tech
+    // editing a legacy rule to delete its retired condition rather than
+    // re-saving it verbatim.
+    const updateConditionTypeError = unsupportedConditionTypeError(data.conditions);
+    if (updateConditionTypeError) {
+      return c.json({ error: updateConditionTypeError }, 400);
     }
 
     const rule = await getAlertRuleWithOrgCheck(ruleId, auth);

--- a/apps/api/src/routes/alerts/rules.ts
+++ b/apps/api/src/routes/alerts/rules.ts
@@ -4,7 +4,7 @@ import { and, eq, sql, desc, inArray, isNull, or, type SQL } from 'drizzle-orm';
 import { db } from '../../db';
 import { alertRules, alertTemplates, alerts, devices, deviceGroups, organizations, sites } from '../../db/schema';
 import { canManagePartnerWidePolicies, PARTNER_WIDE_WRITE_DENIED_MESSAGE } from '../../services/partnerWideAccess';
-import { retiredConditionTypeError } from '../../services/alertConditions';
+import { conditionPayloadsFrom, retiredConditionTypeError } from '../../services/alertConditions';
 import { requireMfa, requirePermission, requireScope, siteAccessCheck } from '../../middleware/auth';
 import { writeRouteAudit } from '../../services/auditEvents';
 import { PERMISSIONS } from '../../services/permissions';
@@ -287,11 +287,12 @@ rulesRoutes.post(
     // `overrides.autoResolveConditions` are read straight back out by
     // alertService (getApplicableRules, evaluateAutoResolveConditions). A
     // guard on `data.conditions` alone is bypassed by moving the same payload
-    // one key over.
+    // one key over. Only those two keys are scanned — not the whole blob, whose
+    // `targetIds` can hold thousands of device ids and would truncate the scan.
     const createConditionTypeError = retiredConditionTypeError([
       data.conditions,
-      data.overrideSettings,
-      data.overrides,
+      ...conditionPayloadsFrom(data.overrideSettings),
+      ...conditionPayloadsFrom(data.overrides),
     ]);
     if (createConditionTypeError) {
       return c.json({ error: createConditionTypeError }, 400);
@@ -371,6 +372,18 @@ rulesRoutes.post(
     });
     if (!template) {
       return c.json({ error: 'Failed to resolve alert template' }, 500);
+    }
+
+    // A legacy template can itself be all-`custom`: the cleanup migration
+    // deactivates RULES but never rewrites alert_templates.conditions. Creating
+    // a rule from one with no `conditions` of its own would mint a brand-new
+    // active, healthy-looking, unfirable rule (#2948) — the payload check above
+    // sees nothing because the request carries no conditions.
+    if (data.conditions === undefined) {
+      const templateConditionError = retiredConditionTypeError(template.conditions);
+      if (templateConditionError) {
+        return c.json({ error: templateConditionError }, 400);
+      }
     }
 
     if (!created) {
@@ -481,8 +494,8 @@ rulesRoutes.put(
     // retired condition rather than re-saving it verbatim.
     const updateConditionTypeError = retiredConditionTypeError([
       data.conditions,
-      data.overrideSettings,
-      data.overrides,
+      ...conditionPayloadsFrom(data.overrideSettings),
+      ...conditionPayloadsFrom(data.overrides),
     ]);
     if (updateConditionTypeError) {
       return c.json({ error: updateConditionTypeError }, 400);

--- a/apps/api/src/services/alertConditions/index.test.ts
+++ b/apps/api/src/services/alertConditions/index.test.ts
@@ -16,7 +16,7 @@ vi.mock('./utils', async (importOriginal) => {
 });
 
 import './index';
-import { evaluateConditions } from './index';
+import { evaluateConditions, findUnregisteredConditionTypes, unsupportedConditionTypeError } from './index';
 import { conditionRegistry } from './registry';
 import { offlineHandler } from './handlers/offline';
 
@@ -64,5 +64,69 @@ describe('evaluateConditions context.actualValue (issue #1980)', () => {
     expect(result.context.actualValue).toBeCloseTo(92.33, 1);
     // Must not be the latest sub-threshold sample.
     expect(result.context.actualValue).not.toBe(88);
+  });
+});
+
+describe('findUnregisteredConditionTypes (issue #2948)', () => {
+  it('flags the retired `custom` type, which never had a handler', () => {
+    expect(findUnregisteredConditionTypes([{ type: 'custom', customCondition: 'x' }])).toEqual(['custom']);
+  });
+
+  it('accepts every type the registry actually resolves, aliases included', () => {
+    const supported = [
+      { type: 'metric', metric: 'cpu', operator: 'gt', value: 85 },
+      { type: 'threshold', metric: 'cpuPercent', operator: 'gt', value: 85 },
+      { type: 'status', duration: 10 },
+      { type: 'offline', durationMinutes: 10 },
+      { type: 'event_log', category: 'system', level: 'error' },
+      { type: 'service_stopped', serviceName: 'spooler' },
+      { type: 'cert_expiry', withinDays: 30 },
+    ];
+    expect(findUnregisteredConditionTypes(supported)).toEqual([]);
+  });
+
+  it('walks into nested condition groups', () => {
+    const tree = {
+      logic: 'or',
+      conditions: [
+        { type: 'metric', metric: 'cpu', operator: 'gt', value: 85 },
+        { logic: 'and', conditions: [{ type: 'custom' }, { type: 'made_up' }] },
+      ],
+    };
+    expect(findUnregisteredConditionTypes(tree)).toEqual(['custom', 'made_up']);
+  });
+
+  it('dedupes repeated unknown types', () => {
+    expect(findUnregisteredConditionTypes([{ type: 'custom' }, { type: 'custom' }])).toEqual(['custom']);
+  });
+
+  it('ignores non-object and typeless nodes rather than inventing an error', () => {
+    // A missing/non-string `type` is the per-handler validators' problem, not
+    // this function's — it reports unknown TYPES only.
+    expect(findUnregisteredConditionTypes([null, 'nope', 42, {}, { type: 7 }])).toEqual([]);
+  });
+
+  it('stops recursing on a pathologically deep tree instead of blowing the stack', () => {
+    let node: Record<string, unknown> = { type: 'custom' };
+    for (let i = 0; i < 5000; i++) node = { logic: 'and', conditions: [node] };
+    expect(() => findUnregisteredConditionTypes(node)).not.toThrow();
+  });
+});
+
+describe('unsupportedConditionTypeError (issue #2948)', () => {
+  it('returns null when nothing was supplied', () => {
+    expect(unsupportedConditionTypeError(undefined)).toBeNull();
+    expect(unsupportedConditionTypeError(null)).toBeNull();
+  });
+
+  it('returns null for a supported condition', () => {
+    expect(unsupportedConditionTypeError([{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }])).toBeNull();
+  });
+
+  it('names the offending type and the supported ones', () => {
+    const message = unsupportedConditionTypeError([{ type: 'custom' }]);
+    expect(message).toContain('custom');
+    expect(message).toContain('never fire');
+    expect(message).toContain('offline');
   });
 });

--- a/apps/api/src/services/alertConditions/index.test.ts
+++ b/apps/api/src/services/alertConditions/index.test.ts
@@ -16,7 +16,7 @@ vi.mock('./utils', async (importOriginal) => {
 });
 
 import './index';
-import { evaluateConditions, findUnregisteredConditionTypes, unsupportedConditionTypeError } from './index';
+import { evaluateConditions, findRetiredConditionTypes, retiredConditionTypeError } from './index';
 import { conditionRegistry } from './registry';
 import { offlineHandler } from './handlers/offline';
 
@@ -67,12 +67,48 @@ describe('evaluateConditions context.actualValue (issue #1980)', () => {
   });
 });
 
-describe('findUnregisteredConditionTypes (issue #2948)', () => {
-  it('flags the retired `custom` type, which never had a handler', () => {
-    expect(findUnregisteredConditionTypes([{ type: 'custom', customCondition: 'x' }])).toEqual(['custom']);
+describe('findRetiredConditionTypes (issue #2948)', () => {
+  it('flags the retired `custom` type, which never had an evaluator', () => {
+    expect(findRetiredConditionTypes([{ type: 'custom', customCondition: 'x' }])).toEqual(['custom']);
   });
 
-  it('accepts every type the registry actually resolves, aliases included', () => {
+  it('flags a bare root object, the shape the alert-template routes accept', () => {
+    // Those routes validate `conditions` as z.record — an OBJECT, never an
+    // array — so the un-wrapped shape is the dominant one there.
+    expect(findRetiredConditionTypes({ type: 'custom' })).toEqual(['custom']);
+  });
+
+  it('descends into the alert-template editor envelope (`conditions.triggers`)', () => {
+    // AlertTemplateEditor posts { triggers, thresholdDefaults, notifications,
+    // escalationRules, autoRemediation, suppression }. A walk that only
+    // recursed on a `conditions` array missed this entirely, making the guard
+    // on POST/PATCH /alert-templates dead code for the product's own UI.
+    const payload = {
+      triggers: [{ type: 'event', eventSource: 'x', pattern: 'y' }, { type: 'custom' }],
+      thresholdDefaults: {},
+      suppression: {},
+    };
+    expect(findRetiredConditionTypes(payload)).toEqual(['custom']);
+  });
+
+  it('does NOT flag live types that have no registry handler', () => {
+    // The single most important case in this file. `dns_threat` is a seeded
+    // built-in evaluated by the event-bus subscriber in
+    // services/dnsThreatAlerts.ts, and `event` is what the alert-template
+    // editor writes — neither is in conditionRegistry. A registry-allowlist
+    // guard would 400 both, breaking the documented way to narrow a DNS-threat
+    // rule (editing override_settings.conditions.categories).
+    const live = [
+      { type: 'dns_threat', eventType: 'dns.threat.blocked', categories: ['malware'] },
+      { type: 'event', eventSource: 'system', pattern: 'disk' },
+    ];
+    expect(findRetiredConditionTypes(live)).toEqual([]);
+    for (const condition of live) {
+      expect(conditionRegistry.get(condition.type)).toBeUndefined();
+    }
+  });
+
+  it('accepts every registry-backed type, aliases included', () => {
     const supported = [
       { type: 'metric', metric: 'cpu', operator: 'gt', value: 85 },
       { type: 'threshold', metric: 'cpuPercent', operator: 'gt', value: 85 },
@@ -82,7 +118,7 @@ describe('findUnregisteredConditionTypes (issue #2948)', () => {
       { type: 'service_stopped', serviceName: 'spooler' },
       { type: 'cert_expiry', withinDays: 30 },
     ];
-    expect(findUnregisteredConditionTypes(supported)).toEqual([]);
+    expect(findRetiredConditionTypes(supported)).toEqual([]);
   });
 
   it('walks into nested condition groups', () => {
@@ -90,43 +126,50 @@ describe('findUnregisteredConditionTypes (issue #2948)', () => {
       logic: 'or',
       conditions: [
         { type: 'metric', metric: 'cpu', operator: 'gt', value: 85 },
-        { logic: 'and', conditions: [{ type: 'custom' }, { type: 'made_up' }] },
+        { logic: 'and', conditions: [{ type: 'custom' }] },
       ],
     };
-    expect(findUnregisteredConditionTypes(tree)).toEqual(['custom', 'made_up']);
+    expect(findRetiredConditionTypes(tree)).toEqual(['custom']);
   });
 
-  it('dedupes repeated unknown types', () => {
-    expect(findUnregisteredConditionTypes([{ type: 'custom' }, { type: 'custom' }])).toEqual(['custom']);
+  it('dedupes repeated retired types', () => {
+    expect(findRetiredConditionTypes([{ type: 'custom' }, { type: 'custom' }])).toEqual(['custom']);
   });
 
   it('ignores non-object and typeless nodes rather than inventing an error', () => {
-    // A missing/non-string `type` is the per-handler validators' problem, not
-    // this function's — it reports unknown TYPES only.
-    expect(findUnregisteredConditionTypes([null, 'nope', 42, {}, { type: 7 }])).toEqual([]);
+    expect(findRetiredConditionTypes([null, 'nope', 42, {}, { type: 7 }])).toEqual([]);
   });
 
-  it('stops recursing on a pathologically deep tree instead of blowing the stack', () => {
+  it('truncates a pathologically deep tree instead of blowing the stack', () => {
     let node: Record<string, unknown> = { type: 'custom' };
     for (let i = 0; i < 5000; i++) node = { logic: 'and', conditions: [node] };
-    expect(() => findUnregisteredConditionTypes(node)).not.toThrow();
+    // Documents the deliberate fail-OPEN: past MAX_CONDITION_DEPTH the walk
+    // reports nothing and the write is accepted. The evaluator has no depth
+    // limit and still fails such a condition closed, so this degrades to the
+    // pre-fix behaviour rather than to a false rejection.
+    expect(findRetiredConditionTypes(node)).toEqual([]);
+  });
+
+  it('does not run away on a wide payload', () => {
+    const wide = Array.from({ length: 20000 }, () => ({ type: 'metric', metric: 'cpu' }));
+    expect(findRetiredConditionTypes(wide)).toEqual([]);
   });
 });
 
-describe('unsupportedConditionTypeError (issue #2948)', () => {
+describe('retiredConditionTypeError (issue #2948)', () => {
   it('returns null when nothing was supplied', () => {
-    expect(unsupportedConditionTypeError(undefined)).toBeNull();
-    expect(unsupportedConditionTypeError(null)).toBeNull();
+    expect(retiredConditionTypeError(undefined)).toBeNull();
+    expect(retiredConditionTypeError(null)).toBeNull();
   });
 
   it('returns null for a supported condition', () => {
-    expect(unsupportedConditionTypeError([{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }])).toBeNull();
+    expect(retiredConditionTypeError([{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }])).toBeNull();
   });
 
-  it('names the offending type and the supported ones', () => {
-    const message = unsupportedConditionTypeError([{ type: 'custom' }]);
+  it('names the offending type and says what to do about it', () => {
+    const message = retiredConditionTypeError([{ type: 'custom' }]);
     expect(message).toContain('custom');
     expect(message).toContain('never fire');
-    expect(message).toContain('offline');
+    expect(message).toMatch(/remove or replace/i);
   });
 });

--- a/apps/api/src/services/alertConditions/index.test.ts
+++ b/apps/api/src/services/alertConditions/index.test.ts
@@ -16,7 +16,7 @@ vi.mock('./utils', async (importOriginal) => {
 });
 
 import './index';
-import { evaluateConditions, findRetiredConditionTypes, retiredConditionTypeError } from './index';
+import { conditionPayloadsFrom, evaluateConditions, findRetiredConditionTypes, retiredConditionTypeError } from './index';
 import { conditionRegistry } from './registry';
 import { offlineHandler } from './handlers/offline';
 
@@ -69,13 +69,13 @@ describe('evaluateConditions context.actualValue (issue #1980)', () => {
 
 describe('findRetiredConditionTypes (issue #2948)', () => {
   it('flags the retired `custom` type, which never had an evaluator', () => {
-    expect(findRetiredConditionTypes([{ type: 'custom', customCondition: 'x' }])).toEqual(['custom']);
+    expect(findRetiredConditionTypes([{ type: 'custom', customCondition: 'x' }]).retired).toEqual(['custom']);
   });
 
   it('flags a bare root object, the shape the alert-template routes accept', () => {
     // Those routes validate `conditions` as z.record — an OBJECT, never an
     // array — so the un-wrapped shape is the dominant one there.
-    expect(findRetiredConditionTypes({ type: 'custom' })).toEqual(['custom']);
+    expect(findRetiredConditionTypes({ type: 'custom' }).retired).toEqual(['custom']);
   });
 
   it('descends into the alert-template editor envelope (`conditions.triggers`)', () => {
@@ -88,7 +88,7 @@ describe('findRetiredConditionTypes (issue #2948)', () => {
       thresholdDefaults: {},
       suppression: {},
     };
-    expect(findRetiredConditionTypes(payload)).toEqual(['custom']);
+    expect(findRetiredConditionTypes(payload).retired).toEqual(['custom']);
   });
 
   it('does NOT flag live types that have no registry handler', () => {
@@ -102,7 +102,7 @@ describe('findRetiredConditionTypes (issue #2948)', () => {
       { type: 'dns_threat', eventType: 'dns.threat.blocked', categories: ['malware'] },
       { type: 'event', eventSource: 'system', pattern: 'disk' },
     ];
-    expect(findRetiredConditionTypes(live)).toEqual([]);
+    expect(findRetiredConditionTypes(live).retired).toEqual([]);
     for (const condition of live) {
       expect(conditionRegistry.get(condition.type)).toBeUndefined();
     }
@@ -118,7 +118,7 @@ describe('findRetiredConditionTypes (issue #2948)', () => {
       { type: 'service_stopped', serviceName: 'spooler' },
       { type: 'cert_expiry', withinDays: 30 },
     ];
-    expect(findRetiredConditionTypes(supported)).toEqual([]);
+    expect(findRetiredConditionTypes(supported).retired).toEqual([]);
   });
 
   it('walks into nested condition groups', () => {
@@ -129,30 +129,62 @@ describe('findRetiredConditionTypes (issue #2948)', () => {
         { logic: 'and', conditions: [{ type: 'custom' }] },
       ],
     };
-    expect(findRetiredConditionTypes(tree)).toEqual(['custom']);
+    expect(findRetiredConditionTypes(tree).retired).toEqual(['custom']);
   });
 
   it('dedupes repeated retired types', () => {
-    expect(findRetiredConditionTypes([{ type: 'custom' }, { type: 'custom' }])).toEqual(['custom']);
+    expect(findRetiredConditionTypes([{ type: 'custom' }, { type: 'custom' }]).retired).toEqual(['custom']);
   });
 
   it('ignores non-object and typeless nodes rather than inventing an error', () => {
-    expect(findRetiredConditionTypes([null, 'nope', 42, {}, { type: 7 }])).toEqual([]);
+    expect(findRetiredConditionTypes([null, 'nope', 42, {}, { type: 7 }]).retired).toEqual([]);
   });
 
-  it('truncates a pathologically deep tree instead of blowing the stack', () => {
+  it('reports truncation — never a clean result — on a pathologically deep tree', () => {
     let node: Record<string, unknown> = { type: 'custom' };
     for (let i = 0; i < 5000; i++) node = { logic: 'and', conditions: [node] };
-    // Documents the deliberate fail-OPEN: past MAX_CONDITION_DEPTH the walk
-    // reports nothing and the write is accepted. The evaluator has no depth
-    // limit and still fails such a condition closed, so this degrades to the
-    // pre-fix behaviour rather than to a false rejection.
-    expect(findRetiredConditionTypes(node)).toEqual([]);
+    const scan = findRetiredConditionTypes(node);
+    // The walk cannot reach the retired leaf, so `retired` is empty — but
+    // `truncated` says the answer is inconclusive, and the caller must reject.
+    expect(scan.retired).toEqual([]);
+    expect(scan.truncated).toBe(true);
   });
 
-  it('does not run away on a wide payload', () => {
+  it('reports truncation on a payload wider than the node budget', () => {
     const wide = Array.from({ length: 20000 }, () => ({ type: 'metric', metric: 'cpu' }));
-    expect(findRetiredConditionTypes(wide)).toEqual([]);
+    expect(findRetiredConditionTypes(wide).truncated).toBe(true);
+  });
+
+  it('does not spend node budget on primitives inside arrays', () => {
+    // A flat array of strings was the cheapest way to exhaust the budget and
+    // blank the guard. Arrays of primitives must cost nothing.
+    const padded = { targetIds: Array.from({ length: 20000 }, (_, i) => `device-${i}`), conditions: [{ type: 'custom' }] };
+    const scan = findRetiredConditionTypes(padded);
+    expect(scan.retired).toEqual(['custom']);
+    expect(scan.truncated).toBe(false);
+  });
+
+  it('does not charge a nesting level for the array inside a group', () => {
+    // A `{logic, conditions[]}` level costs ONE, matching the evaluator's own
+    // recursion. Charging the array too halved the usable depth silently.
+    let node: Record<string, unknown> = { type: 'custom' };
+    for (let i = 0; i < 8; i++) node = { logic: 'and', conditions: [node] };
+    expect(findRetiredConditionTypes(node).retired).toEqual(['custom']);
+  });
+});
+
+describe('conditionPayloadsFrom (issue #2948)', () => {
+  it('extracts only the two keys the evaluator reads back', () => {
+    expect(conditionPayloadsFrom({
+      conditions: [{ type: 'custom' }],
+      autoResolveConditions: [{ type: 'metric' }],
+      targetIds: ['a', 'b'],
+      targets: { type: 'all' },
+    })).toEqual([[{ type: 'custom' }], [{ type: 'metric' }]]);
+  });
+
+  it('returns nothing for non-records', () => {
+    for (const v of [null, undefined, 'x', 7, [1, 2]]) expect(conditionPayloadsFrom(v)).toEqual([]);
   });
 });
 
@@ -164,6 +196,13 @@ describe('retiredConditionTypeError (issue #2948)', () => {
 
   it('returns null for a supported condition', () => {
     expect(retiredConditionTypeError([{ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }])).toBeNull();
+  });
+
+  it('fails CLOSED when the payload is too big to scan conclusively', () => {
+    // An inconclusive scan reported as clean re-opens the whole #2948 hole.
+    const huge = Array.from({ length: 20000 }, () => ({ nested: { deep: {} } }));
+    const message = retiredConditionTypeError(huge);
+    expect(message).toMatch(/too large or too deeply nested/i);
   });
 
   it('names the offending type and says what to do about it', () => {

--- a/apps/api/src/services/alertConditions/index.ts
+++ b/apps/api/src/services/alertConditions/index.ts
@@ -286,25 +286,61 @@ export function validateConditions(conditions: unknown): string[] {
 // not worth recursing into.
 const MAX_CONDITION_DEPTH = 10;
 
+// Ceiling on how many nodes the walk will visit, so an oversized or hostile
+// payload can't turn this boundary check into a CPU sink. `/alerts/rules`
+// validates `conditions` as `z.any()` with no size cap of its own.
+const MAX_CONDITION_NODES = 5000;
+
 /**
- * Collect every condition `type` in a conditions tree that has no registered
- * handler.
+ * Condition types that were once writable but have no evaluator behind them.
  *
- * The evaluator fails closed on an unknown type (`conditionRegistry.evaluate`
- * returns `passed: false`), and a root-level array is evaluated as an implicit
- * AND — so a single unknown type makes the whole rule permanently unfirable
- * while still looking healthy in the UI. `custom` was exactly that: an editor
- * option that never had a handler (#2948). Write paths use this to reject such
- * conditions at the boundary instead of storing a rule that can never fire.
+ * **A denylist, deliberately — NOT "every type absent from `conditionRegistry`".**
+ * The registry is not the complete set of live condition types: `dns_threat`
+ * (seeded built-in template, `db/seed.ts`) is evaluated by an event-bus
+ * subscriber in `services/dnsThreatAlerts.ts` that never consults the registry,
+ * and the alert-template editor writes `type: 'event'` triggers. Rejecting
+ * "unregistered" types would 400 those working features — e.g. the documented
+ * way to narrow a DNS-threat rule is editing its `override_settings.conditions
+ * .categories`, which is a plain `PUT /alerts/rules`.
  *
- * Returns the offending type names (deduped, in encounter order); empty means
- * every type in the tree resolves to a handler.
+ * So the failure mode is chosen on purpose: this misses a hypothetical future
+ * dead type rather than breaking a live one. Add an entry here when a type is
+ * retired, alongside a cleanup migration for rows that already carry it.
  */
-export function findUnregisteredConditionTypes(conditions: unknown): string[] {
-  const unregistered = new Set<string>();
+export const RETIRED_CONDITION_TYPES: ReadonlySet<string> = new Set([
+  // #2948 — offered by both alert-rule editors, never had a handler.
+  // `conditionRegistry.evaluate` answered "Unknown condition type: custom" with
+  // passed=false, and a root-level array is evaluated as an implicit AND
+  // (`evaluateConditions` wraps it in `{logic:'and'}`), so a rule carrying one
+  // could never fire. Inside an explicit `or` group it would not be fatal, but
+  // the write boundary rejects it there too: a type with no evaluator is a bug
+  // in the payload either way.
+  'custom',
+]);
+
+/**
+ * Collect every retired condition type appearing anywhere in a conditions
+ * payload.
+ *
+ * The walk is deliberately structure-agnostic — it descends into every nested
+ * object and array rather than only `{logic, conditions[]}` groups. The write
+ * paths this guards accept several different envelopes for the same data: a
+ * bare array (`POST /alerts/rules`), a `{logic, conditions[]}` group, and the
+ * alert-template editor's `{triggers: [...], thresholdDefaults, ...}` object
+ * (`z.record` on those routes, never an array). A structure-aware walk silently
+ * missed the last of those. Over-walking is safe *because* this is a denylist:
+ * the worst case is finding a retired type somewhere unexpected, which is still
+ * a type nobody can evaluate.
+ *
+ * Returns the offending type names, deduped. Empty means the payload is clean.
+ */
+export function findRetiredConditionTypes(conditions: unknown): string[] {
+  const retired = new Set<string>();
+  let visited = 0;
 
   const walk = (node: unknown, depth: number): void => {
-    if (depth > MAX_CONDITION_DEPTH || node === null || typeof node !== 'object') return;
+    if (depth > MAX_CONDITION_DEPTH || ++visited > MAX_CONDITION_NODES) return;
+    if (node === null || typeof node !== 'object') return;
 
     if (Array.isArray(node)) {
       for (const child of node) walk(child, depth + 1);
@@ -312,37 +348,37 @@ export function findUnregisteredConditionTypes(conditions: unknown): string[] {
     }
 
     const record = node as Record<string, unknown>;
-    // Group node: recurse into its children. Checked before `type` so a group
-    // that also carries a stray `type` key is still traversed.
-    if (Array.isArray(record.conditions)) {
-      for (const child of record.conditions) walk(child, depth + 1);
-      return;
+    if (typeof record.type === 'string' && RETIRED_CONDITION_TYPES.has(record.type)) {
+      retired.add(record.type);
     }
-    // Leaf node. A non-string or missing `type` is left to the per-handler
-    // validators / evaluator — this function reports unknown TYPES only.
-    if (typeof record.type === 'string' && !conditionRegistry.get(record.type)) {
-      unregistered.add(record.type);
+    for (const value of Object.values(record)) {
+      if (value !== null && typeof value === 'object') walk(value, depth + 1);
     }
   };
 
   walk(conditions, 0);
-  return [...unregistered];
+  return [...retired];
 }
 
 /**
- * Boundary check for alert-rule / alert-template write paths. Returns a
- * user-facing error message when the payload names a condition type no handler
- * can evaluate, or null when it is safe to store.
+ * Boundary check for the alert-rule / alert-template write paths. Returns a
+ * user-facing error message when the payload carries a retired condition type,
+ * or null when it is safe to store.
+ *
+ * Note the depth/node caps above mean a pathologically nested payload can slip
+ * a retired type past this check. That degrades to the pre-#2948 behaviour —
+ * the evaluator (`evaluateConditionRecursive`, which has no depth limit) still
+ * fails it closed — rather than to a false rejection.
  */
-export function unsupportedConditionTypeError(conditions: unknown): string | null {
+export function retiredConditionTypeError(conditions: unknown): string | null {
   if (conditions === undefined || conditions === null) return null;
 
-  const unregistered = findUnregisteredConditionTypes(conditions);
-  if (unregistered.length === 0) return null;
+  const retired = findRetiredConditionTypes(conditions);
+  if (retired.length === 0) return null;
 
-  return `Unsupported alert condition type(s): ${unregistered.join(', ')}. `
-    + 'A rule containing one can never fire. Supported types: '
-    + `${conditionRegistry.getRegisteredTypes().sort().join(', ')}.`;
+  return `Retired alert condition type(s): ${retired.join(', ')}. `
+    + 'These never had an evaluator behind them, so a rule containing one can never fire. '
+    + 'Remove or replace the condition.';
 }
 
 /**

--- a/apps/api/src/services/alertConditions/index.ts
+++ b/apps/api/src/services/alertConditions/index.ts
@@ -287,21 +287,23 @@ export function validateConditions(conditions: unknown): string[] {
 const MAX_CONDITION_DEPTH = 10;
 
 // Ceiling on how many nodes the walk will visit, so an oversized or hostile
-// payload can't turn this boundary check into a CPU sink. `/alerts/rules`
-// validates `conditions` as `z.any()` with no size cap of its own.
-const MAX_CONDITION_NODES = 5000;
+// payload can't turn this boundary check into a CPU sink. Exceeding it is
+// reported as `truncated` and rejected — never silently treated as clean.
+const MAX_CONDITION_NODES = 2000;
 
 /**
  * Condition types that were once writable but have no evaluator behind them.
  *
  * **A denylist, deliberately — NOT "every type absent from `conditionRegistry`".**
- * The registry is not the complete set of live condition types: `dns_threat`
- * (seeded built-in template, `db/seed.ts`) is evaluated by an event-bus
- * subscriber in `services/dnsThreatAlerts.ts` that never consults the registry,
- * and the alert-template editor writes `type: 'event'` triggers. Rejecting
- * "unregistered" types would 400 those working features — e.g. the documented
- * way to narrow a DNS-threat rule is editing its `override_settings.conditions
- * .categories`, which is a plain `PUT /alerts/rules`.
+ * The registry is not the complete set of live condition types:
+ *   * `dns_threat` is a seeded built-in template (`db/seed.ts`) whose alerts are
+ *     raised directly by `services/dnsThreatAlerts.ts` off the
+ *     `dns.threat.blocked` event. That path inserts alerts itself and never
+ *     evaluates a condition, so the type is live despite having no handler —
+ *     and the seed documents narrowing it via the rule's
+ *     `override_settings.conditions.categories`, i.e. a plain PUT.
+ *   * The alert-template editor writes `type: 'event'` triggers.
+ * Rejecting "unregistered" types would 400 both of those working features.
  *
  * So the failure mode is chosen on purpose: this misses a hypothetical future
  * dead type rather than breaking a live one. Add an entry here when a type is
@@ -318,32 +320,55 @@ export const RETIRED_CONDITION_TYPES: ReadonlySet<string> = new Set([
   'custom',
 ]);
 
+export interface RetiredConditionScan {
+  /** Retired type names found, deduped. */
+  retired: string[];
+  /**
+   * The walk hit its depth or node ceiling and did NOT finish. The result is
+   * therefore inconclusive, not clean — callers must reject rather than accept.
+   */
+  truncated: boolean;
+}
+
 /**
- * Collect every retired condition type appearing anywhere in a conditions
- * payload.
+ * Scan a conditions payload for retired condition types.
  *
- * The walk is deliberately structure-agnostic — it descends into every nested
- * object and array rather than only `{logic, conditions[]}` groups. The write
- * paths this guards accept several different envelopes for the same data: a
- * bare array (`POST /alerts/rules`), a `{logic, conditions[]}` group, and the
- * alert-template editor's `{triggers: [...], thresholdDefaults, ...}` object
+ * The walk is structure-agnostic — it descends into every nested object and
+ * array rather than only `{logic, conditions[]}` groups — because the write
+ * paths accept several envelopes for the same data: a bare array
+ * (`POST /alerts/rules`), a `{logic, conditions[]}` group, a bare object, and
+ * the alert-template editor's `{triggers: [...], thresholdDefaults, ...}`
  * (`z.record` on those routes, never an array). A structure-aware walk silently
  * missed the last of those. Over-walking is safe *because* this is a denylist:
  * the worst case is finding a retired type somewhere unexpected, which is still
  * a type nobody can evaluate.
  *
- * Returns the offending type names, deduped. Empty means the payload is clean.
+ * Callers must pass the condition-bearing values only (see
+ * `conditionPayloadsFrom`), not whole override blobs — a rule targeting several
+ * thousand devices carries a `targetIds` array big enough to exhaust the node
+ * budget on its own, which would truncate the scan of a payload that is
+ * perfectly legitimate.
  */
-export function findRetiredConditionTypes(conditions: unknown): string[] {
+export function findRetiredConditionTypes(conditions: unknown): RetiredConditionScan {
   const retired = new Set<string>();
   let visited = 0;
+  let truncated = false;
 
   const walk = (node: unknown, depth: number): void => {
-    if (depth > MAX_CONDITION_DEPTH || ++visited > MAX_CONDITION_NODES) return;
     if (node === null || typeof node !== 'object') return;
+    if (depth > MAX_CONDITION_DEPTH || ++visited > MAX_CONDITION_NODES) {
+      truncated = true;
+      return;
+    }
 
     if (Array.isArray(node)) {
-      for (const child of node) walk(child, depth + 1);
+      // Arrays don't add a nesting level: a `{logic, conditions[]}` group costs
+      // one level, matching the evaluator's own recursion in
+      // evaluateConditionRecursive. Primitives are skipped before the call so a
+      // long array of strings can't burn the node budget.
+      for (const child of node) {
+        if (child !== null && typeof child === 'object') walk(child, depth);
+      }
       return;
     }
 
@@ -357,28 +382,50 @@ export function findRetiredConditionTypes(conditions: unknown): string[] {
   };
 
   walk(conditions, 0);
-  return [...retired];
+  return { retired: [...retired], truncated };
+}
+
+/**
+ * Pull the condition-bearing values out of an alert-rule overrides object.
+ *
+ * `overrideSettings` / `overrides` are `z.any()` passthroughs carrying targets,
+ * device id lists and notification bindings alongside the two keys the
+ * evaluator actually reads back (`conditions`, `autoResolveConditions` — see
+ * alertService). Handing the whole blob to the scanner both wastes the node
+ * budget and risks truncating on a large-but-legitimate `targetIds`.
+ */
+export function conditionPayloadsFrom(value: unknown): unknown[] {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return [];
+  const record = value as Record<string, unknown>;
+  return [record.conditions, record.autoResolveConditions].filter((v) => v !== undefined);
 }
 
 /**
  * Boundary check for the alert-rule / alert-template write paths. Returns a
- * user-facing error message when the payload carries a retired condition type,
- * or null when it is safe to store.
+ * user-facing error message when the payload carries a retired condition type
+ * — or when it was too large to scan conclusively — and null when it is safe.
  *
- * Note the depth/node caps above mean a pathologically nested payload can slip
- * a retired type past this check. That degrades to the pre-#2948 behaviour —
- * the evaluator (`evaluateConditionRecursive`, which has no depth limit) still
- * fails it closed — rather than to a false rejection.
+ * Fails CLOSED on truncation. An inconclusive scan reported as clean would
+ * re-open exactly the #2948 hole: a stored rule that is enabled, looks healthy,
+ * and can never fire.
  */
 export function retiredConditionTypeError(conditions: unknown): string | null {
   if (conditions === undefined || conditions === null) return null;
 
-  const retired = findRetiredConditionTypes(conditions);
-  if (retired.length === 0) return null;
+  const { retired, truncated } = findRetiredConditionTypes(conditions);
 
-  return `Retired alert condition type(s): ${retired.join(', ')}. `
-    + 'These never had an evaluator behind them, so a rule containing one can never fire. '
-    + 'Remove or replace the condition.';
+  if (retired.length > 0) {
+    return `Retired alert condition type(s): ${retired.join(', ')}. `
+      + 'These never had an evaluator behind them, so a rule containing one can never fire. '
+      + 'Remove or replace the condition.';
+  }
+
+  if (truncated) {
+    return 'Alert conditions are too large or too deeply nested to validate. '
+      + 'Simplify the conditions and try again.';
+  }
+
+  return null;
 }
 
 /**

--- a/apps/api/src/services/alertConditions/index.ts
+++ b/apps/api/src/services/alertConditions/index.ts
@@ -281,6 +281,70 @@ export function validateConditions(conditions: unknown): string[] {
   return errors;
 }
 
+// Deepest nesting a conditions tree is walked to. Groups nest via
+// `{logic, conditions[]}`; anything past this is malformed or hostile and is
+// not worth recursing into.
+const MAX_CONDITION_DEPTH = 10;
+
+/**
+ * Collect every condition `type` in a conditions tree that has no registered
+ * handler.
+ *
+ * The evaluator fails closed on an unknown type (`conditionRegistry.evaluate`
+ * returns `passed: false`), and a root-level array is evaluated as an implicit
+ * AND — so a single unknown type makes the whole rule permanently unfirable
+ * while still looking healthy in the UI. `custom` was exactly that: an editor
+ * option that never had a handler (#2948). Write paths use this to reject such
+ * conditions at the boundary instead of storing a rule that can never fire.
+ *
+ * Returns the offending type names (deduped, in encounter order); empty means
+ * every type in the tree resolves to a handler.
+ */
+export function findUnregisteredConditionTypes(conditions: unknown): string[] {
+  const unregistered = new Set<string>();
+
+  const walk = (node: unknown, depth: number): void => {
+    if (depth > MAX_CONDITION_DEPTH || node === null || typeof node !== 'object') return;
+
+    if (Array.isArray(node)) {
+      for (const child of node) walk(child, depth + 1);
+      return;
+    }
+
+    const record = node as Record<string, unknown>;
+    // Group node: recurse into its children. Checked before `type` so a group
+    // that also carries a stray `type` key is still traversed.
+    if (Array.isArray(record.conditions)) {
+      for (const child of record.conditions) walk(child, depth + 1);
+      return;
+    }
+    // Leaf node. A non-string or missing `type` is left to the per-handler
+    // validators / evaluator — this function reports unknown TYPES only.
+    if (typeof record.type === 'string' && !conditionRegistry.get(record.type)) {
+      unregistered.add(record.type);
+    }
+  };
+
+  walk(conditions, 0);
+  return [...unregistered];
+}
+
+/**
+ * Boundary check for alert-rule / alert-template write paths. Returns a
+ * user-facing error message when the payload names a condition type no handler
+ * can evaluate, or null when it is safe to store.
+ */
+export function unsupportedConditionTypeError(conditions: unknown): string | null {
+  if (conditions === undefined || conditions === null) return null;
+
+  const unregistered = findUnregisteredConditionTypes(conditions);
+  if (unregistered.length === 0) return null;
+
+  return `Unsupported alert condition type(s): ${unregistered.join(', ')}. `
+    + 'A rule containing one can never fire. Supported types: '
+    + `${conditionRegistry.getRegisteredTypes().sort().join(', ')}.`;
+}
+
 /**
  * Interpolate template strings with context values
  * Supports {{variable}} syntax

--- a/apps/docs/src/content/docs/features/alerts.mdx
+++ b/apps/docs/src/content/docs/features/alerts.mdx
@@ -152,7 +152,7 @@ Alert rules define what conditions to watch for and which devices to monitor.
 </Steps>
 
 <Aside type="caution">
-  Older rules may still carry condition types Breeze no longer evaluates -- `custom`, and a "network usage" metric that never had a metric to compare against. Those are shown read-only with an amber warning on the rule, and the rule cannot be saved until you remove or replace the condition. Agent-side service and process watches are configured separately, on the policy's **Monitoring** tab -- see [Service & Process Monitoring](/features/service-monitoring/).
+  Older rules may still carry condition types Breeze no longer evaluates -- `custom`, and a "network usage" metric that never had a metric to compare against. Those are shown read-only with an amber warning on the rule, and the rule cannot be saved until you remove or replace the condition. The API rejects them on write too, so a rule that can never fire cannot be created through the AI assistant or a direct API call either. Agent-side service and process watches are configured separately, on the policy's **Monitoring** tab -- see [Service & Process Monitoring](/features/service-monitoring/).
 </Aside>
 
 ### Testing a Rule

--- a/apps/docs/src/content/docs/features/alerts.mdx
+++ b/apps/docs/src/content/docs/features/alerts.mdx
@@ -152,7 +152,7 @@ Alert rules define what conditions to watch for and which devices to monitor.
 </Steps>
 
 <Aside type="caution">
-  Older rules may still carry condition types Breeze no longer evaluates -- `custom`, and a "network usage" metric that never had a metric to compare against. Those are shown read-only with an amber warning on the rule, and the rule cannot be saved until you remove or replace the condition. The API rejects them on write too, so a rule that can never fire cannot be created through the AI assistant or a direct API call either. Agent-side service and process watches are configured separately, on the policy's **Monitoring** tab -- see [Service & Process Monitoring](/features/service-monitoring/).
+  Older rules may still carry condition types Breeze no longer evaluates -- `custom`, and a "network usage" metric that never had a metric to compare against. Those are shown read-only with a warning on the rule, and the rule cannot be saved until you remove or replace the condition. The retired `custom` **type** is also rejected by the API on write, so a rule using one can't be created through the AI assistant or a direct API call either, and a rule that was disabled because it only contained one can't be re-enabled until it's replaced. Agent-side service and process watches are configured separately, on the policy's **Monitoring** tab -- see [Service & Process Monitoring](/features/service-monitoring/).
 </Aside>
 
 ### Testing a Rule

--- a/apps/web/src/components/alerts/AlertRuleForm.retiredCondition.test.tsx
+++ b/apps/web/src/components/alerts/AlertRuleForm.retiredCondition.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Regression coverage for #2948. The `custom` condition type was offered by
+// this editor but never had a handler registered in the API's condition
+// registry, so `conditionRegistry.evaluate()` answered "Unknown condition type"
+// and — a root-level conditions array being an implicit AND — the whole rule
+// could never fire. The type is gone from the editor, and a stored one is now
+// rendered read-only so the type <select> cannot silently coerce it into a live
+// CPU rule on the next save.
+
+import AlertRuleForm from './AlertRuleForm';
+
+const CUSTOM_CONDITION = { type: 'custom', field: 'reg_key', customCondition: '> 100' };
+const METRIC_CONDITION = { type: 'metric', metric: 'cpu', operator: 'gt', value: 85 };
+
+function renderForm(conditions: unknown[], onSubmit = vi.fn()) {
+  render(
+    <AlertRuleForm
+      onSubmit={onSubmit}
+      defaultValues={{
+        name: 'A rule',
+        severity: 'high',
+        targetType: 'all',
+        targetIds: [],
+        notificationChannelIds: [],
+        cooldownMinutes: 15,
+        autoResolve: false,
+        conditions: conditions as never,
+      }}
+    />
+  );
+  return onSubmit;
+}
+
+describe('AlertRuleForm retired `custom` condition (#2948)', () => {
+  it('no longer offers `custom` in the condition type selector', () => {
+    renderForm([METRIC_CONDITION]);
+
+    const options = screen.getAllByRole('option').map((o) => (o as HTMLOptionElement).value);
+    expect(options).not.toContain('custom');
+    // The types that DO have handlers are still offered.
+    expect(options).toContain('metric');
+    expect(options).toContain('status');
+  });
+
+  it('renders a stored `custom` condition read-only, with its stored value and a warning', () => {
+    renderForm([CUSTOM_CONDITION]);
+
+    const retired = screen.getByTestId('condition-retired-0');
+    expect(retired).toBeTruthy();
+    expect(retired.textContent).toContain('custom');
+    // The tech has to be able to see what they are being asked to delete.
+    expect(retired.textContent).toContain('reg_key');
+    expect(retired.textContent).toContain('> 100');
+    expect(retired.textContent).toMatch(/no longer supported/i);
+    // Crucially: no type <select> for this row, which would have coerced the
+    // stored `custom` to the first option ("metric") on the next save.
+    expect(retired.querySelector('select')).toBeNull();
+  });
+
+  it('blocks the save while a retired condition is present', async () => {
+    const onSubmit = renderForm([METRIC_CONDITION, CUSTOM_CONDITION]);
+
+    fireEvent.submit(screen.getByTestId('condition-retired-1').closest('form')!);
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  it('lets the retired condition be removed even as the only condition', async () => {
+    renderForm([CUSTOM_CONDITION]);
+
+    const removeButtons = screen.getAllByTitle(/remove condition/i) as HTMLButtonElement[];
+    expect(removeButtons).toHaveLength(1);
+    // Without the retired-row exemption this is disabled (fields.length === 1),
+    // leaving the rule permanently unsaveable AND unfixable.
+    expect(removeButtons[0].disabled).toBe(false);
+
+    fireEvent.click(removeButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('condition-retired-0')).toBeNull();
+    });
+  });
+
+  it('still submits a rule whose conditions are all supported', async () => {
+    const onSubmit = renderForm([METRIC_CONDITION]);
+
+    fireEvent.submit(screen.getByRole('button', { name: /save|create/i }).closest('form')!);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    expect(onSubmit.mock.calls[0][0].conditions).toEqual([
+      expect.objectContaining({ type: 'metric', metric: 'cpu', operator: 'gt', value: 85 }),
+    ]);
+  });
+});

--- a/apps/web/src/components/alerts/AlertRuleForm.retiredCondition.test.tsx
+++ b/apps/web/src/components/alerts/AlertRuleForm.retiredCondition.test.tsx
@@ -119,6 +119,35 @@ describe('AlertRuleForm retired `custom` condition (#2948)', () => {
     });
   });
 
+  // Regression for the shape-validation over-reach: `value` is a PERCENT for
+  // metric conditions but Mbps for bandwidth_high and MB/s for disk_io_high, and
+  // a canonical `threshold` names `ramPercent` — all outside the editor's own
+  // enums. Validating those eagerly blocked Save with no visible error and, as
+  // the only condition, left the rule unremovable and permanently uneditable.
+  it.each([
+    ['bandwidth_high (Mbps far above the percent ceiling)', { type: 'bandwidth_high', direction: 'in', operator: 'gt', value: 500 }],
+    ['threshold with a canonical metric name', { type: 'threshold', metric: 'ramPercent', operator: 'gt', value: 90 }],
+  ])('saves a read-only %s condition verbatim instead of silently blocking', async (_name, condition) => {
+    const onSubmit = renderForm([condition]);
+
+    fireEvent.submit(screen.getByTestId('condition-readonly-0').closest('form')!);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    expect(onSubmit.mock.calls[0][0].conditions[0]).toEqual(condition);
+  });
+
+  it('shows a form-level summary when a retired row blocks the save', async () => {
+    // The offending row can be far below the fold; without a summary the Save
+    // click produces no perceptible change anywhere on screen.
+    renderForm([METRIC_CONDITION, CUSTOM_CONDITION]);
+
+    fireEvent.submit(screen.getByTestId('condition-retired-1').closest('form')!);
+
+    expect(await screen.findByText(/at least one condition must be fixed/i)).toBeTruthy();
+  });
+
   it('still submits a rule whose conditions are all supported', async () => {
     const onSubmit = renderForm([METRIC_CONDITION]);
 

--- a/apps/web/src/components/alerts/AlertRuleForm.retiredCondition.test.tsx
+++ b/apps/web/src/components/alerts/AlertRuleForm.retiredCondition.test.tsx
@@ -59,7 +59,7 @@ describe('AlertRuleForm retired `custom` condition (#2948)', () => {
     expect(retired.querySelector('select')).toBeNull();
   });
 
-  it('blocks the save while a retired condition is present', async () => {
+  it('blocks the save while a retired condition is present, and says why on submit', async () => {
     const onSubmit = renderForm([METRIC_CONDITION, CUSTOM_CONDITION]);
 
     fireEvent.submit(screen.getByTestId('condition-retired-1').closest('form')!);
@@ -67,6 +67,40 @@ describe('AlertRuleForm retired `custom` condition (#2948)', () => {
     await waitFor(() => {
       expect(onSubmit).not.toHaveBeenCalled();
     });
+    // A blocked submit that renders nothing new is indistinguishable from a
+    // broken Save button. The refinement's message lives at
+    // errors.conditions[1].type, which the top-level errors.conditions.message
+    // paragraph never reads.
+    const submitError = await screen.findByTestId('condition-error-1');
+    expect(submitError.textContent).toMatch(/custom/);
+  });
+
+  // The registry resolves a dozen condition types and the API accepts all of
+  // them; this form can only render two. The rest must be shown read-only and
+  // round-tripped verbatim — NOT branded "no longer supported" and NOT blocking
+  // the save, which would tell a tech their working offline rule never fired
+  // and refuse to save until they deleted it.
+  it.each([
+    ['offline', { type: 'offline', durationMinutes: 15 }],
+    ['event_log', { type: 'event_log', category: 'system', level: 'error', countThreshold: 3, windowMinutes: 30 }],
+    ['cert_expiry', { type: 'cert_expiry', withinDays: 30 }],
+  ])('renders a supported-but-uneditable %s condition read-only without blocking the save', async (_name, condition) => {
+    const onSubmit = renderForm([condition]);
+
+    const row = screen.getByTestId('condition-readonly-0');
+    expect(row.textContent).toContain(condition.type);
+    expect(row.textContent).not.toMatch(/no longer supported/i);
+    expect(screen.queryByTestId('condition-retired-0')).toBeNull();
+
+    fireEvent.submit(row.closest('form')!);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+    // And every field survives: Zod's default strip mode would have deleted
+    // category/level/windowMinutes/withinDays, turning a working condition into
+    // an unevaluable one on save.
+    expect(onSubmit.mock.calls[0][0].conditions[0]).toEqual(condition);
   });
 
   it('lets the retired condition be removed even as the only condition', async () => {

--- a/apps/web/src/components/alerts/AlertRuleForm.tsx
+++ b/apps/web/src/components/alerts/AlertRuleForm.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import '../../lib/i18n';
+import { i18n } from '../../lib/i18n';
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -11,15 +11,44 @@ import type { AlertSeverity } from './AlertList';
 import type { DeploymentTargetConfig } from '@breeze/shared';
 import { DeviceTargetSelector } from '../filters/DeviceTargetSelector';
 
-const conditionSchema = z.object({
-  type: z.enum(['metric', 'status', 'custom']),
-  metric: z.enum(['cpu', 'ram', 'disk', 'network']).optional(),
-  operator: z.enum(['gt', 'lt', 'gte', 'lte', 'eq', 'neq']).optional(),
-  value: z.coerce.number().min(0).max(100).optional(),
-  duration: z.coerce.number().min(1).optional(),
-  field: z.string().optional(),
-  customCondition: z.string().optional()
-});
+// Condition types this editor can render a form for. `metric` and `status` are
+// the evaluator's `threshold` and `offline` handlers under their legacy aliases
+// (services/alertConditions/handlers/{threshold,offline}.ts). `custom` is NOT
+// here: it never had a registered handler, so the registry answered "Unknown
+// condition type" and the rule — evaluated as an implicit AND — could never
+// fire (#2948). The API now rejects it on write, so the editor must not offer it.
+export const EDITABLE_CONDITION_TYPES = ['metric', 'status'] as const;
+
+function isEditableConditionType(type: string | undefined): boolean {
+  return (EDITABLE_CONDITION_TYPES as readonly string[]).includes(type ?? '');
+}
+
+const conditionSchema = z
+  .object({
+    // Deliberately a string, not an enum over EDITABLE_CONDITION_TYPES: an
+    // already-stored retired type (`custom`) must survive as far as the
+    // superRefine below so the tech gets "remove this condition", not Zod's
+    // generic "Invalid option" with no indication of which row is at fault.
+    type: z.string().min(1),
+    metric: z.enum(['cpu', 'ram', 'disk', 'network']).optional(),
+    operator: z.enum(['gt', 'lt', 'gte', 'lte', 'eq', 'neq']).optional(),
+    value: z.coerce.number().min(0).max(100).optional(),
+    duration: z.coerce.number().min(1).optional(),
+    // Retained read-only: a legacy `custom` condition carries these, and the
+    // retired-condition row renders them so the tech can see what they are
+    // deleting. The editor never writes them.
+    field: z.string().optional(),
+    customCondition: z.string().optional()
+  })
+  .superRefine((condition, ctx) => {
+    if (!isEditableConditionType(condition.type)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['type'],
+        message: i18n.t('alerts:alertRuleForm.retiredConditionBlocksSave', { type: condition.type })
+      });
+    }
+  });
 
 const alertRuleSchema = z.object({
   name: z.string().min(1, 'Rule name is required'),
@@ -88,11 +117,7 @@ const operatorOptions = [
   { value: 'neq' }
 ];
 
-const conditionTypeOptions = [
-  { value: 'metric' },
-  { value: 'status' },
-  { value: 'custom' }
-];
+const conditionTypeOptions = EDITABLE_CONDITION_TYPES.map(value => ({ value }));
 
 export default function AlertRuleForm({
   onSubmit,
@@ -383,10 +408,31 @@ export default function AlertRuleForm({
 
         {fields.length > 0 && (
           <div className="space-y-3">
-            {fields.map((field, index) => (
+            {fields.map((field, index) => {
+              const conditionType = watchConditions?.[index]?.type;
+              // A stored condition whose type this editor no longer offers
+              // (`custom`, #2948). Rendered read-only rather than dropped into
+              // the type <select>, which would silently coerce it to the first
+              // option — resurrecting a dead condition as a live CPU rule.
+              const isRetired = !isEditableConditionType(conditionType);
+              return (
               <div key={field.id} className="rounded-md border bg-muted/20 p-4">
                 <div className="flex items-start gap-3">
                   <GripVertical className="h-5 w-5 text-muted-foreground mt-2.5 cursor-move" />
+                  {isRetired ? (
+                    <div className="flex-1 space-y-1" data-testid={`condition-retired-${index}`}>
+                      <p className="text-xs font-medium text-muted-foreground">{t('alertRuleForm.type')}</p>
+                      <p className="text-sm font-medium">{conditionType}</p>
+                      {watchConditions?.[index]?.customCondition && (
+                        <p className="text-xs text-muted-foreground break-all">
+                          {watchConditions[index]?.field ?? ''} {watchConditions[index]?.customCondition}
+                        </p>
+                      )}
+                      <p className="text-xs text-destructive">
+                        {t('alertRuleForm.retiredConditionWarning', { type: conditionType })}
+                      </p>
+                    </div>
+                  ) : (
                   <div className="flex-1 grid gap-4 sm:grid-cols-2 md:grid-cols-4">
                     <div className="space-y-1">
                       <label className="text-xs font-medium text-muted-foreground">{t('alertRuleForm.type')}</label>
@@ -461,31 +507,15 @@ export default function AlertRuleForm({
                       </div>
                     )}
 
-                    {watchConditions?.[index]?.type === 'custom' && (
-                      <>
-                        <div className="space-y-1">
-                          <label className="text-xs font-medium text-muted-foreground">{t('alertRuleForm.fieldName')}</label>
-                          <input
-                            placeholder={t('alertRuleForm.customField')}
-                            className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                            {...register(`conditions.${index}.field`)}
-                          />
-                        </div>
-                        <div className="space-y-1 sm:col-span-2">
-                          <label className="text-xs font-medium text-muted-foreground">{t('alertRuleForm.condition')}</label>
-                          <input
-                            placeholder={t('alertRuleForm.value100')}
-                            className="h-9 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-                            {...register(`conditions.${index}.customCondition`)}
-                          />
-                        </div>
-                      </>
-                    )}
                   </div>
+                  )}
                   <button
                     type="button"
                     onClick={() => remove(index)}
-                    disabled={fields.length === 1}
+                    // A retired condition is always removable, even as the last
+                    // one: it blocks the save, so keeping it pinned would leave
+                    // the rule permanently uneditable.
+                    disabled={fields.length === 1 && !isRetired}
                     className="flex h-9 w-9 items-center justify-center rounded-md hover:bg-muted text-destructive disabled:opacity-50 disabled:cursor-not-allowed"
                     title={t('alertRuleForm.removeCondition')}
                   >
@@ -493,7 +523,8 @@ export default function AlertRuleForm({
                   </button>
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
 

--- a/apps/web/src/components/alerts/AlertRuleForm.tsx
+++ b/apps/web/src/components/alerts/AlertRuleForm.tsx
@@ -11,6 +11,9 @@ import type { AlertSeverity } from './AlertList';
 import type { DeploymentTargetConfig } from '@breeze/shared';
 import { DeviceTargetSelector } from '../filters/DeviceTargetSelector';
 
+const METRIC_OPTION_VALUES: readonly string[] = ['cpu', 'ram', 'disk', 'network'];
+const OPERATOR_OPTION_VALUES: readonly string[] = ['gt', 'lt', 'gte', 'lte', 'eq', 'neq'];
+
 // Condition types this editor can render a form for. `metric` and `status` are
 // the evaluator's `threshold` and `offline` handlers under their legacy aliases
 // (services/alertConditions/handlers/{threshold,offline}.ts).
@@ -46,10 +49,17 @@ const conditionSchema = z
     // supported one round-trips and a retired one produces "remove this
     // condition" rather than Zod's generic "Invalid option".
     type: z.string().min(1),
-    metric: z.enum(['cpu', 'ram', 'disk', 'network']).optional(),
-    operator: z.enum(['gt', 'lt', 'gte', 'lte', 'eq', 'neq']).optional(),
-    value: z.coerce.number().min(0).max(100).optional(),
-    duration: z.coerce.number().min(1).optional(),
+    // These four are validated by the superRefine below, NOT here, and only for
+    // types this editor renders. A stored condition it can't render carries the
+    // same key names with values outside these bounds — bandwidth_high's `value`
+    // is Mbps and disk_io_high's is MB/s (both routinely > 100), and a canonical
+    // `threshold` names `ramPercent`, outside the metric enum. Validating them
+    // eagerly blocked Save on a perfectly good rule with no visible error, and
+    // (being the only condition) left it unremovable and permanently uneditable.
+    metric: z.string().optional(),
+    operator: z.string().optional(),
+    value: z.coerce.number().optional(),
+    duration: z.coerce.number().optional(),
     // Rendered read-only on a legacy `custom` row so the tech can see what they
     // are being asked to delete. The editor never writes them.
     field: z.string().optional(),
@@ -68,6 +78,26 @@ const conditionSchema = z
         path: ['type'],
         message: i18n.t('alerts:alertRuleForm.retiredConditionBlocksSave', { type: condition.type })
       });
+      return;
+    }
+    // Shape rules apply only to the two types this editor actually renders a
+    // form for. Everything else is round-tripped verbatim.
+    if (!isEditableConditionType(condition.type)) return;
+
+    if (condition.type === 'metric') {
+      if (!METRIC_OPTION_VALUES.includes(condition.metric ?? '')) {
+        ctx.addIssue({ code: 'custom', path: ['metric'], message: i18n.t('alerts:alertRuleForm.invalidMetric') });
+      }
+      if (!OPERATOR_OPTION_VALUES.includes(condition.operator ?? '')) {
+        ctx.addIssue({ code: 'custom', path: ['operator'], message: i18n.t('alerts:alertRuleForm.invalidOperator') });
+      }
+      if (condition.value === undefined || condition.value < 0 || condition.value > 100) {
+        ctx.addIssue({ code: 'custom', path: ['value'], message: i18n.t('alerts:alertRuleForm.invalidValue') });
+      }
+    }
+
+    if (condition.type === 'status' && condition.duration !== undefined && condition.duration < 1) {
+      ctx.addIssue({ code: 'custom', path: ['duration'], message: i18n.t('alerts:alertRuleForm.invalidDuration') });
     }
   });
 
@@ -122,21 +152,9 @@ const targetTypeOptions = [
   { value: 'device' }
 ];
 
-const metricOptions = [
-  { value: 'cpu' },
-  { value: 'ram' },
-  { value: 'disk' },
-  { value: 'network' }
-];
+const metricOptions = METRIC_OPTION_VALUES.map(value => ({ value }));
 
-const operatorOptions = [
-  { value: 'gt' },
-  { value: 'lt' },
-  { value: 'gte' },
-  { value: 'lte' },
-  { value: 'eq' },
-  { value: 'neq' }
-];
+const operatorOptions = OPERATOR_OPTION_VALUES.map(value => ({ value }));
 
 const conditionTypeOptions = EDITABLE_CONDITION_TYPES.map(value => ({ value }));
 
@@ -426,9 +444,18 @@ export default function AlertRuleForm({
         {/* Guarded on `.message`: per-item issues (the retired-type refinement
             below) live at errors.conditions[i].type and leave this top-level
             message undefined, which would otherwise render an empty red <p>. */}
-        {errors.conditions?.message && (
-          <p className="text-sm text-destructive">{errors.conditions.message}</p>
-        )}
+        {(() => {
+          // Per-item issues live at errors.conditions[i].<key> and leave the
+          // array-level `.message` undefined, so a guard on `.message` alone
+          // renders nothing at all when a retired row blocks the save — the
+          // Save click looks inert, especially when the offending row is off
+          // screen. Summarise here and point at the row.
+          const itemIssue = Array.isArray(errors.conditions)
+            && errors.conditions.some((e) => e && Object.values(e).some((v: any) => v?.message));
+          const summary = errors.conditions?.message
+            ?? (itemIssue ? t('alertRuleForm.conditionsBlockSaveSummary') : undefined);
+          return summary ? <p className="text-sm text-destructive">{summary}</p> : null;
+        })()}
 
         {fields.length > 0 && (
           <div className="space-y-3">
@@ -446,7 +473,12 @@ export default function AlertRuleForm({
               // "never triggered an alert" and refuse to save until they delete it.
               const isRetired = isRetiredConditionType(conditionType);
               const isReadOnly = isRetired || !isEditableConditionType(conditionType);
-              const retiredError = errors.conditions?.[index]?.type?.message;
+              // Any error on this row, not just `.type`: the row renders no inputs, so
+      // an issue on another key would otherwise have nowhere at all to appear.
+      const rowErrors = errors.conditions?.[index] as Record<string, { message?: string }> | undefined;
+      const rowError = rowErrors
+        ? Object.values(rowErrors).find(e => e?.message)?.message
+        : undefined;
               return (
               <div key={field.id} className="rounded-md border bg-muted/20 p-4">
                 <div className="flex items-start gap-3">
@@ -471,9 +503,9 @@ export default function AlertRuleForm({
                       {/* Submit-time signal. The always-on warning above does not
                           change when Save is pressed, so without this the click
                           has no visible consequence at all. */}
-                      {retiredError && (
+                      {rowError && (
                         <p className="text-xs font-medium text-destructive" data-testid={`condition-error-${index}`}>
-                          {retiredError}
+                          {rowError}
                         </p>
                       )}
                     </div>
@@ -562,7 +594,7 @@ export default function AlertRuleForm({
                     // the rule permanently uneditable. A merely read-only
                     // condition does NOT block the save, so it keeps the normal
                     // last-condition lock.
-                    disabled={fields.length === 1 && !isRetired}
+                    disabled={fields.length === 1 && !isRetired && !rowError}
                     className="flex h-9 w-9 items-center justify-center rounded-md hover:bg-muted text-destructive disabled:opacity-50 disabled:cursor-not-allowed"
                     title={t('alertRuleForm.removeCondition')}
                   >

--- a/apps/web/src/components/alerts/AlertRuleForm.tsx
+++ b/apps/web/src/components/alerts/AlertRuleForm.tsx
@@ -13,35 +13,56 @@ import { DeviceTargetSelector } from '../filters/DeviceTargetSelector';
 
 // Condition types this editor can render a form for. `metric` and `status` are
 // the evaluator's `threshold` and `offline` handlers under their legacy aliases
-// (services/alertConditions/handlers/{threshold,offline}.ts). `custom` is NOT
-// here: it never had a registered handler, so the registry answered "Unknown
-// condition type" and the rule — evaluated as an implicit AND — could never
-// fire (#2948). The API now rejects it on write, so the editor must not offer it.
+// (services/alertConditions/handlers/{threshold,offline}.ts).
+//
+// This is NOT the set of types the system supports. The registry resolves a
+// dozen (event_log, service_stopped, cert_expiry, patch_compliance, …) and the
+// API accepts all of them on POST /alerts/rules, plus push-evaluated types like
+// `dns_threat` that never touch the registry at all. Anything outside this list
+// is rendered read-only and round-tripped verbatim — see RETIRED_CONDITION_TYPES
+// for the much narrower set that actually blocks a save.
 export const EDITABLE_CONDITION_TYPES = ['metric', 'status'] as const;
+
+// Types that were once writable but have no evaluator behind them. Mirrors
+// RETIRED_CONDITION_TYPES in apps/api/src/services/alertConditions/index.ts —
+// keep the two in step. `custom` never had a registered handler, so the registry
+// answered "Unknown condition type" and the rule, evaluated as an implicit AND,
+// could never fire (#2948). These are the only types that block a save.
+export const RETIRED_CONDITION_TYPES = ['custom'] as const;
 
 function isEditableConditionType(type: string | undefined): boolean {
   return (EDITABLE_CONDITION_TYPES as readonly string[]).includes(type ?? '');
 }
 
+function isRetiredConditionType(type: string | undefined): boolean {
+  return (RETIRED_CONDITION_TYPES as readonly string[]).includes(type ?? '');
+}
+
 const conditionSchema = z
   .object({
-    // Deliberately a string, not an enum over EDITABLE_CONDITION_TYPES: an
-    // already-stored retired type (`custom`) must survive as far as the
-    // superRefine below so the tech gets "remove this condition", not Zod's
-    // generic "Invalid option" with no indication of which row is at fault.
+    // Deliberately a string, not an enum over EDITABLE_CONDITION_TYPES: a
+    // stored type this editor cannot render (`event_log`, `cert_expiry`, a
+    // retired `custom`) must survive as far as the superRefine below, so a
+    // supported one round-trips and a retired one produces "remove this
+    // condition" rather than Zod's generic "Invalid option".
     type: z.string().min(1),
     metric: z.enum(['cpu', 'ram', 'disk', 'network']).optional(),
     operator: z.enum(['gt', 'lt', 'gte', 'lte', 'eq', 'neq']).optional(),
     value: z.coerce.number().min(0).max(100).optional(),
     duration: z.coerce.number().min(1).optional(),
-    // Retained read-only: a legacy `custom` condition carries these, and the
-    // retired-condition row renders them so the tech can see what they are
-    // deleting. The editor never writes them.
+    // Rendered read-only on a legacy `custom` row so the tech can see what they
+    // are being asked to delete. The editor never writes them.
     field: z.string().optional(),
     customCondition: z.string().optional()
   })
+  // passthrough, NOT strip: a condition type this editor cannot render still
+  // carries fields it does not model (event_log's category/level/windowMinutes,
+  // cert_expiry's withinDays). Zod's default strip mode would silently delete
+  // them on save, turning a working condition into an unevaluable one — the
+  // very failure this PR exists to remove.
+  .passthrough()
   .superRefine((condition, ctx) => {
-    if (!isEditableConditionType(condition.type)) {
+    if (isRetiredConditionType(condition.type)) {
       ctx.addIssue({
         code: 'custom',
         path: ['type'],
@@ -402,7 +423,10 @@ export default function AlertRuleForm({
           </button>
         </div>
 
-        {errors.conditions && (
+        {/* Guarded on `.message`: per-item issues (the retired-type refinement
+            below) live at errors.conditions[i].type and leave this top-level
+            message undefined, which would otherwise render an empty red <p>. */}
+        {errors.conditions?.message && (
           <p className="text-sm text-destructive">{errors.conditions.message}</p>
         )}
 
@@ -410,17 +434,28 @@ export default function AlertRuleForm({
           <div className="space-y-3">
             {fields.map((field, index) => {
               const conditionType = watchConditions?.[index]?.type;
-              // A stored condition whose type this editor no longer offers
-              // (`custom`, #2948). Rendered read-only rather than dropped into
-              // the type <select>, which would silently coerce it to the first
-              // option — resurrecting a dead condition as a live CPU rule.
-              const isRetired = !isEditableConditionType(conditionType);
+              // Two different "can't edit this here" cases, deliberately kept
+              // apart (#2948):
+              //   * RETIRED — `custom`. No evaluator has ever existed for it, so
+              //     it is dead data and blocks the save until removed.
+              //   * READ-ONLY — a type this form can't render but the system
+              //     fully supports (event_log, cert_expiry, a canonical
+              //     `offline`, the push-evaluated `dns_threat`). Shown as-is,
+              //     round-tripped verbatim via .passthrough(), save NOT blocked.
+              // Collapsing the two would tell a tech their working offline rule
+              // "never triggered an alert" and refuse to save until they delete it.
+              const isRetired = isRetiredConditionType(conditionType);
+              const isReadOnly = isRetired || !isEditableConditionType(conditionType);
+              const retiredError = errors.conditions?.[index]?.type?.message;
               return (
               <div key={field.id} className="rounded-md border bg-muted/20 p-4">
                 <div className="flex items-start gap-3">
                   <GripVertical className="h-5 w-5 text-muted-foreground mt-2.5 cursor-move" />
-                  {isRetired ? (
-                    <div className="flex-1 space-y-1" data-testid={`condition-retired-${index}`}>
+                  {isReadOnly ? (
+                    <div
+                      className="flex-1 space-y-1"
+                      data-testid={isRetired ? `condition-retired-${index}` : `condition-readonly-${index}`}
+                    >
                       <p className="text-xs font-medium text-muted-foreground">{t('alertRuleForm.type')}</p>
                       <p className="text-sm font-medium">{conditionType}</p>
                       {watchConditions?.[index]?.customCondition && (
@@ -428,9 +463,19 @@ export default function AlertRuleForm({
                           {watchConditions[index]?.field ?? ''} {watchConditions[index]?.customCondition}
                         </p>
                       )}
-                      <p className="text-xs text-destructive">
-                        {t('alertRuleForm.retiredConditionWarning', { type: conditionType })}
+                      <p className={isRetired ? 'text-xs text-destructive' : 'text-xs text-muted-foreground'}>
+                        {isRetired
+                          ? t('alertRuleForm.retiredConditionWarning', { type: conditionType })
+                          : t('alertRuleForm.readOnlyConditionNote', { type: conditionType })}
                       </p>
+                      {/* Submit-time signal. The always-on warning above does not
+                          change when Save is pressed, so without this the click
+                          has no visible consequence at all. */}
+                      {retiredError && (
+                        <p className="text-xs font-medium text-destructive" data-testid={`condition-error-${index}`}>
+                          {retiredError}
+                        </p>
+                      )}
                     </div>
                   ) : (
                   <div className="flex-1 grid gap-4 sm:grid-cols-2 md:grid-cols-4">
@@ -514,7 +559,9 @@ export default function AlertRuleForm({
                     onClick={() => remove(index)}
                     // A retired condition is always removable, even as the last
                     // one: it blocks the save, so keeping it pinned would leave
-                    // the rule permanently uneditable.
+                    // the rule permanently uneditable. A merely read-only
+                    // condition does NOT block the save, so it keeps the normal
+                    // last-condition lock.
                     disabled={fields.length === 1 && !isRetired}
                     className="flex h-9 w-9 items-center justify-center rounded-md hover:bg-muted text-destructive disabled:opacity-50 disabled:cursor-not-allowed"
                     title={t('alertRuleForm.removeCondition')}

--- a/apps/web/src/components/alerts/AlertRuleList.tsx
+++ b/apps/web/src/components/alerts/AlertRuleList.tsx
@@ -14,6 +14,9 @@ export type AlertRuleTarget = {
   names?: string[];
 };
 
+// `custom` is retained for DISPLAY only: it never had an evaluator handler and
+// is no longer creatable (#2948 removed it from the editor and blocked it at
+// the API), but rows stored before that still carry it and must render.
 export type AlertRuleConditionType = 'metric' | 'status' | 'custom';
 export type MetricType = 'cpu' | 'ram' | 'disk' | 'network';
 export type ComparisonOperator = 'gt' | 'lt' | 'gte' | 'lte' | 'eq' | 'neq';

--- a/apps/web/src/locales/de-DE/alerts.json
+++ b/apps/web/src/locales/de-DE/alerts.json
@@ -356,7 +356,12 @@
     },
     "retiredConditionWarning": "Der Bedingungstyp \"{{type}}\" wird nicht mehr unterstützt und hat nie einen Alarm ausgelöst. Entfernen Sie diese Bedingung, um die Regel zu speichern.",
     "retiredConditionBlocksSave": "Nicht unterstützter Bedingungstyp \"{{type}}\" — entfernen Sie diese Bedingung vor dem Speichern.",
-    "readOnlyConditionNote": "Der Bedingungstyp \"{{type}}\" kann hier nicht bearbeitet werden. Er wird unverändert beibehalten."
+    "readOnlyConditionNote": "Der Bedingungstyp \"{{type}}\" kann hier nicht bearbeitet werden. Er wird unverändert beibehalten.",
+    "conditionsBlockSaveSummary": "Mindestens eine Bedingung muss korrigiert werden, bevor die Regel gespeichert werden kann.",
+    "invalidMetric": "Wählen Sie eine Metrik aus.",
+    "invalidOperator": "Wählen Sie einen Operator aus.",
+    "invalidValue": "Geben Sie einen Wert zwischen 0 und 100 ein.",
+    "invalidDuration": "Geben Sie mindestens 1 Minute ein."
   },
   "alertRuleList": {
     "editRule": "Regel bearbeiten",

--- a/apps/web/src/locales/de-DE/alerts.json
+++ b/apps/web/src/locales/de-DE/alerts.json
@@ -355,7 +355,8 @@
       "status": "Statusbedingung"
     },
     "retiredConditionWarning": "Der Bedingungstyp \"{{type}}\" wird nicht mehr unterstützt und hat nie einen Alarm ausgelöst. Entfernen Sie diese Bedingung, um die Regel zu speichern.",
-    "retiredConditionBlocksSave": "Nicht unterstützter Bedingungstyp \"{{type}}\" — entfernen Sie diese Bedingung vor dem Speichern."
+    "retiredConditionBlocksSave": "Nicht unterstützter Bedingungstyp \"{{type}}\" — entfernen Sie diese Bedingung vor dem Speichern.",
+    "readOnlyConditionNote": "Der Bedingungstyp \"{{type}}\" kann hier nicht bearbeitet werden. Er wird unverändert beibehalten."
   },
   "alertRuleList": {
     "editRule": "Regel bearbeiten",

--- a/apps/web/src/locales/de-DE/alerts.json
+++ b/apps/web/src/locales/de-DE/alerts.json
@@ -292,10 +292,6 @@
     "value": "Wert (%)",
     "offlineDurationMinutes": "Offline-Dauer (Minuten)",
     "alertWhenDeviceIsOfflineForThis": "Warnung, wenn das Gerät so viele Minuten lang offline ist",
-    "fieldName": "Feldname",
-    "customField": "custom_field",
-    "condition": "Zustand",
-    "value100": "Wert > 100",
     "removeCondition": "Bedingung entfernen",
     "noConditionsDefinedClickAddConditionTo": "Keine Bedingungen definiert. Klicken Sie auf „Bedingung hinzufügen“, um eine zu erstellen.",
     "notificationChannels": "Benachrichtigungskanäle",
@@ -356,9 +352,10 @@
     },
     "conditionTypeOption": {
       "metric": "Metrische Bedingung",
-      "status": "Statusbedingung",
-      "custom": "Benutzerdefiniertes Feld"
-    }
+      "status": "Statusbedingung"
+    },
+    "retiredConditionWarning": "Der Bedingungstyp \"{{type}}\" wird nicht mehr unterstützt und hat nie einen Alarm ausgelöst. Entfernen Sie diese Bedingung, um die Regel zu speichern.",
+    "retiredConditionBlocksSave": "Nicht unterstützter Bedingungstyp \"{{type}}\" — entfernen Sie diese Bedingung vor dem Speichern."
   },
   "alertRuleList": {
     "editRule": "Regel bearbeiten",

--- a/apps/web/src/locales/en/alerts.json
+++ b/apps/web/src/locales/en/alerts.json
@@ -356,7 +356,12 @@
     },
     "retiredConditionWarning": "The \"{{type}}\" condition type is no longer supported and never triggered an alert. Remove this condition to save the rule.",
     "retiredConditionBlocksSave": "Unsupported condition type \"{{type}}\" — remove this condition before saving.",
-    "readOnlyConditionNote": "The \"{{type}}\" condition type can’t be edited here. It is kept exactly as stored."
+    "readOnlyConditionNote": "The \"{{type}}\" condition type can’t be edited here. It is kept exactly as stored.",
+    "conditionsBlockSaveSummary": "At least one condition must be fixed before this rule can be saved.",
+    "invalidMetric": "Select a metric.",
+    "invalidOperator": "Select an operator.",
+    "invalidValue": "Enter a value between 0 and 100.",
+    "invalidDuration": "Enter at least 1 minute."
   },
   "alertRuleList": {
     "editRule": "Edit rule",

--- a/apps/web/src/locales/en/alerts.json
+++ b/apps/web/src/locales/en/alerts.json
@@ -355,7 +355,8 @@
       "status": "Status Condition"
     },
     "retiredConditionWarning": "The \"{{type}}\" condition type is no longer supported and never triggered an alert. Remove this condition to save the rule.",
-    "retiredConditionBlocksSave": "Unsupported condition type \"{{type}}\" — remove this condition before saving."
+    "retiredConditionBlocksSave": "Unsupported condition type \"{{type}}\" — remove this condition before saving.",
+    "readOnlyConditionNote": "The \"{{type}}\" condition type can’t be edited here. It is kept exactly as stored."
   },
   "alertRuleList": {
     "editRule": "Edit rule",

--- a/apps/web/src/locales/en/alerts.json
+++ b/apps/web/src/locales/en/alerts.json
@@ -292,10 +292,6 @@
     "value": "Value (%)",
     "offlineDurationMinutes": "Offline Duration (minutes)",
     "alertWhenDeviceIsOfflineForThis": "Alert when device is offline for this many minutes",
-    "fieldName": "Field Name",
-    "customField": "custom_field",
-    "condition": "Condition",
-    "value100": "value > 100",
     "removeCondition": "Remove condition",
     "noConditionsDefinedClickAddConditionTo": "No conditions defined. Click \"Add Condition\" to create one.",
     "notificationChannels": "Notification Channels",
@@ -356,9 +352,10 @@
     },
     "conditionTypeOption": {
       "metric": "Metric Condition",
-      "status": "Status Condition",
-      "custom": "Custom Field"
-    }
+      "status": "Status Condition"
+    },
+    "retiredConditionWarning": "The \"{{type}}\" condition type is no longer supported and never triggered an alert. Remove this condition to save the rule.",
+    "retiredConditionBlocksSave": "Unsupported condition type \"{{type}}\" — remove this condition before saving."
   },
   "alertRuleList": {
     "editRule": "Edit rule",

--- a/apps/web/src/locales/es-419/alerts.json
+++ b/apps/web/src/locales/es-419/alerts.json
@@ -356,7 +356,12 @@
     },
     "retiredConditionWarning": "El tipo de condición \"{{type}}\" ya no es compatible y nunca activó una alerta. Elimine esta condición para guardar la regla.",
     "retiredConditionBlocksSave": "Tipo de condición no compatible \"{{type}}\": elimine esta condición antes de guardar.",
-    "readOnlyConditionNote": "El tipo de condición \"{{type}}\" no se puede editar aquí. Se conserva tal como está almacenado."
+    "readOnlyConditionNote": "El tipo de condición \"{{type}}\" no se puede editar aquí. Se conserva tal como está almacenado.",
+    "conditionsBlockSaveSummary": "Se debe corregir al menos una condición antes de guardar esta regla.",
+    "invalidMetric": "Seleccione una métrica.",
+    "invalidOperator": "Seleccione un operador.",
+    "invalidValue": "Ingrese un valor entre 0 y 100.",
+    "invalidDuration": "Ingrese al menos 1 minuto."
   },
   "alertRuleList": {
     "editRule": "Editar regla",

--- a/apps/web/src/locales/es-419/alerts.json
+++ b/apps/web/src/locales/es-419/alerts.json
@@ -355,7 +355,8 @@
       "status": "Condición de estado"
     },
     "retiredConditionWarning": "El tipo de condición \"{{type}}\" ya no es compatible y nunca activó una alerta. Elimine esta condición para guardar la regla.",
-    "retiredConditionBlocksSave": "Tipo de condición no compatible \"{{type}}\": elimine esta condición antes de guardar."
+    "retiredConditionBlocksSave": "Tipo de condición no compatible \"{{type}}\": elimine esta condición antes de guardar.",
+    "readOnlyConditionNote": "El tipo de condición \"{{type}}\" no se puede editar aquí. Se conserva tal como está almacenado."
   },
   "alertRuleList": {
     "editRule": "Editar regla",

--- a/apps/web/src/locales/es-419/alerts.json
+++ b/apps/web/src/locales/es-419/alerts.json
@@ -292,10 +292,6 @@
     "value": "Valor (%)",
     "offlineDurationMinutes": "Duración sin conexión (minutos)",
     "alertWhenDeviceIsOfflineForThis": "Alerta cuando el dispositivo está desconectado durante tantos minutos",
-    "fieldName": "Nombre del campo",
-    "customField": "custom_field",
-    "condition": "Condición",
-    "value100": "valor > 100",
     "removeCondition": "Eliminar condición",
     "noConditionsDefinedClickAddConditionTo": "No hay condiciones definidas. Haga clic en \"Agregar condición\" para crear una.",
     "notificationChannels": "Canales de notificación",
@@ -356,9 +352,10 @@
     },
     "conditionTypeOption": {
       "metric": "Condición métrica",
-      "status": "Condición de estado",
-      "custom": "Campo personalizado"
-    }
+      "status": "Condición de estado"
+    },
+    "retiredConditionWarning": "El tipo de condición \"{{type}}\" ya no es compatible y nunca activó una alerta. Elimine esta condición para guardar la regla.",
+    "retiredConditionBlocksSave": "Tipo de condición no compatible \"{{type}}\": elimine esta condición antes de guardar."
   },
   "alertRuleList": {
     "editRule": "Editar regla",

--- a/apps/web/src/locales/fr-CA/alerts.json
+++ b/apps/web/src/locales/fr-CA/alerts.json
@@ -355,7 +355,8 @@
       "status": "État"
     },
     "retiredConditionWarning": "Le type de condition « {{type}} » n'est plus pris en charge et n'a jamais déclenché d'alerte. Supprimez cette condition pour enregistrer la règle.",
-    "retiredConditionBlocksSave": "Type de condition non pris en charge « {{type}} » — supprimez cette condition avant d'enregistrer."
+    "retiredConditionBlocksSave": "Type de condition non pris en charge « {{type}} » — supprimez cette condition avant d'enregistrer.",
+    "readOnlyConditionNote": "Le type de condition « {{type}} » ne peut pas être modifié ici. Il est conservé tel quel."
   },
   "alertRuleList": {
     "editRule": "Modifier la règle",

--- a/apps/web/src/locales/fr-CA/alerts.json
+++ b/apps/web/src/locales/fr-CA/alerts.json
@@ -292,10 +292,6 @@
     "value": "Valeur ( %)",
     "offlineDurationMinutes": "Durée hors ligne (minutes)",
     "alertWhenDeviceIsOfflineForThis": "Alertez lorsque l’appareil est hors ligne pendant ce nombre de minutes",
-    "fieldName": "Nom du champ",
-    "customField": "custom_field",
-    "condition": "État",
-    "value100": "valeur > 100",
     "removeCondition": "Supprimer la condition",
     "noConditionsDefinedClickAddConditionTo": "Aucune condition définie. Cliquez sur « Ajouter une condition » pour en créer une.",
     "notificationChannels": "Canaux de notification",
@@ -356,9 +352,10 @@
     },
     "conditionTypeOption": {
       "metric": "Condition métrique",
-      "status": "État",
-      "custom": "Champ personnalisé"
-    }
+      "status": "État"
+    },
+    "retiredConditionWarning": "Le type de condition « {{type}} » n'est plus pris en charge et n'a jamais déclenché d'alerte. Supprimez cette condition pour enregistrer la règle.",
+    "retiredConditionBlocksSave": "Type de condition non pris en charge « {{type}} » — supprimez cette condition avant d'enregistrer."
   },
   "alertRuleList": {
     "editRule": "Modifier la règle",

--- a/apps/web/src/locales/fr-CA/alerts.json
+++ b/apps/web/src/locales/fr-CA/alerts.json
@@ -356,7 +356,12 @@
     },
     "retiredConditionWarning": "Le type de condition « {{type}} » n'est plus pris en charge et n'a jamais déclenché d'alerte. Supprimez cette condition pour enregistrer la règle.",
     "retiredConditionBlocksSave": "Type de condition non pris en charge « {{type}} » — supprimez cette condition avant d'enregistrer.",
-    "readOnlyConditionNote": "Le type de condition « {{type}} » ne peut pas être modifié ici. Il est conservé tel quel."
+    "readOnlyConditionNote": "Le type de condition « {{type}} » ne peut pas être modifié ici. Il est conservé tel quel.",
+    "conditionsBlockSaveSummary": "Au moins une condition doit être corrigée avant d’enregistrer cette règle.",
+    "invalidMetric": "Sélectionnez une métrique.",
+    "invalidOperator": "Sélectionnez un opérateur.",
+    "invalidValue": "Saisissez une valeur entre 0 et 100.",
+    "invalidDuration": "Saisissez au moins 1 minute."
   },
   "alertRuleList": {
     "editRule": "Modifier la règle",

--- a/apps/web/src/locales/fr-FR/alerts.json
+++ b/apps/web/src/locales/fr-FR/alerts.json
@@ -355,7 +355,8 @@
       "status": "État"
     },
     "retiredConditionWarning": "Le type de condition « {{type}} » n'est plus pris en charge et n'a jamais déclenché d'alerte. Supprimez cette condition pour enregistrer la règle.",
-    "retiredConditionBlocksSave": "Type de condition non pris en charge « {{type}} » — supprimez cette condition avant d'enregistrer."
+    "retiredConditionBlocksSave": "Type de condition non pris en charge « {{type}} » — supprimez cette condition avant d'enregistrer.",
+    "readOnlyConditionNote": "Le type de condition « {{type}} » ne peut pas être modifié ici. Il est conservé tel quel."
   },
   "alertRuleList": {
     "editRule": "Modifier la règle",

--- a/apps/web/src/locales/fr-FR/alerts.json
+++ b/apps/web/src/locales/fr-FR/alerts.json
@@ -292,10 +292,6 @@
     "value": "Valeur ( %)",
     "offlineDurationMinutes": "Durée hors ligne (minutes)",
     "alertWhenDeviceIsOfflineForThis": "Alertez lorsque l’appareil est hors ligne pendant ce nombre de minutes",
-    "fieldName": "Nom du champ",
-    "customField": "custom_field",
-    "condition": "État",
-    "value100": "valeur > 100",
     "removeCondition": "Supprimer la condition",
     "noConditionsDefinedClickAddConditionTo": "Aucune condition définie. Cliquez sur « Ajouter une condition » pour en créer une.",
     "notificationChannels": "Canaux de notification",
@@ -356,9 +352,10 @@
     },
     "conditionTypeOption": {
       "metric": "Condition métrique",
-      "status": "État",
-      "custom": "Champ personnalisé"
-    }
+      "status": "État"
+    },
+    "retiredConditionWarning": "Le type de condition « {{type}} » n'est plus pris en charge et n'a jamais déclenché d'alerte. Supprimez cette condition pour enregistrer la règle.",
+    "retiredConditionBlocksSave": "Type de condition non pris en charge « {{type}} » — supprimez cette condition avant d'enregistrer."
   },
   "alertRuleList": {
     "editRule": "Modifier la règle",

--- a/apps/web/src/locales/fr-FR/alerts.json
+++ b/apps/web/src/locales/fr-FR/alerts.json
@@ -356,7 +356,12 @@
     },
     "retiredConditionWarning": "Le type de condition « {{type}} » n'est plus pris en charge et n'a jamais déclenché d'alerte. Supprimez cette condition pour enregistrer la règle.",
     "retiredConditionBlocksSave": "Type de condition non pris en charge « {{type}} » — supprimez cette condition avant d'enregistrer.",
-    "readOnlyConditionNote": "Le type de condition « {{type}} » ne peut pas être modifié ici. Il est conservé tel quel."
+    "readOnlyConditionNote": "Le type de condition « {{type}} » ne peut pas être modifié ici. Il est conservé tel quel.",
+    "conditionsBlockSaveSummary": "Au moins une condition doit être corrigée avant d’enregistrer cette règle.",
+    "invalidMetric": "Sélectionnez une métrique.",
+    "invalidOperator": "Sélectionnez un opérateur.",
+    "invalidValue": "Saisissez une valeur entre 0 et 100.",
+    "invalidDuration": "Saisissez au moins 1 minute."
   },
   "alertRuleList": {
     "editRule": "Modifier la règle",

--- a/apps/web/src/locales/it-IT/alerts.json
+++ b/apps/web/src/locales/it-IT/alerts.json
@@ -355,7 +355,8 @@
       "status": "Condizione stato"
     },
     "retiredConditionWarning": "Il tipo di condizione \"{{type}}\" non è più supportato e non ha mai attivato un avviso. Rimuovi questa condizione per salvare la regola.",
-    "retiredConditionBlocksSave": "Tipo di condizione non supportato \"{{type}}\" — rimuovi questa condizione prima di salvare."
+    "retiredConditionBlocksSave": "Tipo di condizione non supportato \"{{type}}\" — rimuovi questa condizione prima di salvare.",
+    "readOnlyConditionNote": "Il tipo di condizione \"{{type}}\" non può essere modificato qui. Viene mantenuto così com’è."
   },
   "alertRuleList": {
     "editRule": "Modifica regola",

--- a/apps/web/src/locales/it-IT/alerts.json
+++ b/apps/web/src/locales/it-IT/alerts.json
@@ -356,7 +356,12 @@
     },
     "retiredConditionWarning": "Il tipo di condizione \"{{type}}\" non è più supportato e non ha mai attivato un avviso. Rimuovi questa condizione per salvare la regola.",
     "retiredConditionBlocksSave": "Tipo di condizione non supportato \"{{type}}\" — rimuovi questa condizione prima di salvare.",
-    "readOnlyConditionNote": "Il tipo di condizione \"{{type}}\" non può essere modificato qui. Viene mantenuto così com’è."
+    "readOnlyConditionNote": "Il tipo di condizione \"{{type}}\" non può essere modificato qui. Viene mantenuto così com’è.",
+    "conditionsBlockSaveSummary": "Almeno una condizione deve essere corretta prima di salvare questa regola.",
+    "invalidMetric": "Seleziona una metrica.",
+    "invalidOperator": "Seleziona un operatore.",
+    "invalidValue": "Inserisci un valore tra 0 e 100.",
+    "invalidDuration": "Inserisci almeno 1 minuto."
   },
   "alertRuleList": {
     "editRule": "Modifica regola",

--- a/apps/web/src/locales/it-IT/alerts.json
+++ b/apps/web/src/locales/it-IT/alerts.json
@@ -292,10 +292,6 @@
     "value": "Valore (%)",
     "offlineDurationMinutes": "Durata offline (minuti)",
     "alertWhenDeviceIsOfflineForThis": "Genera un avviso quando il dispositivo resta offline per questo numero di minuti",
-    "fieldName": "Nome campo",
-    "customField": "custom_field",
-    "condition": "Condizione",
-    "value100": "value > 100",
     "removeCondition": "Rimuovi condizione",
     "noConditionsDefinedClickAddConditionTo": "Nessuna condizione definita. Fai clic su \"Aggiungi condizione\" per crearne una.",
     "notificationChannels": "Canali di notifica",
@@ -356,9 +352,10 @@
     },
     "conditionTypeOption": {
       "metric": "Condizione metrica",
-      "status": "Condizione stato",
-      "custom": "Campo personalizzato"
-    }
+      "status": "Condizione stato"
+    },
+    "retiredConditionWarning": "Il tipo di condizione \"{{type}}\" non è più supportato e non ha mai attivato un avviso. Rimuovi questa condizione per salvare la regola.",
+    "retiredConditionBlocksSave": "Tipo di condizione non supportato \"{{type}}\" — rimuovi questa condizione prima di salvare."
   },
   "alertRuleList": {
     "editRule": "Modifica regola",

--- a/apps/web/src/locales/pt-BR/alerts.json
+++ b/apps/web/src/locales/pt-BR/alerts.json
@@ -355,7 +355,8 @@
       "status": "Condição de status"
     },
     "retiredConditionWarning": "O tipo de condição \"{{type}}\" não é mais compatível e nunca disparou um alerta. Remova esta condição para salvar a regra.",
-    "retiredConditionBlocksSave": "Tipo de condição não compatível \"{{type}}\" — remova esta condição antes de salvar."
+    "retiredConditionBlocksSave": "Tipo de condição não compatível \"{{type}}\" — remova esta condição antes de salvar.",
+    "readOnlyConditionNote": "O tipo de condição \"{{type}}\" não pode ser editado aqui. Ele é mantido exatamente como está."
   },
   "alertRuleList": {
     "editRule": "Editar regra",

--- a/apps/web/src/locales/pt-BR/alerts.json
+++ b/apps/web/src/locales/pt-BR/alerts.json
@@ -356,7 +356,12 @@
     },
     "retiredConditionWarning": "O tipo de condição \"{{type}}\" não é mais compatível e nunca disparou um alerta. Remova esta condição para salvar a regra.",
     "retiredConditionBlocksSave": "Tipo de condição não compatível \"{{type}}\" — remova esta condição antes de salvar.",
-    "readOnlyConditionNote": "O tipo de condição \"{{type}}\" não pode ser editado aqui. Ele é mantido exatamente como está."
+    "readOnlyConditionNote": "O tipo de condição \"{{type}}\" não pode ser editado aqui. Ele é mantido exatamente como está.",
+    "conditionsBlockSaveSummary": "Pelo menos uma condição precisa ser corrigida antes de salvar esta regra.",
+    "invalidMetric": "Selecione uma métrica.",
+    "invalidOperator": "Selecione um operador.",
+    "invalidValue": "Informe um valor entre 0 e 100.",
+    "invalidDuration": "Informe pelo menos 1 minuto."
   },
   "alertRuleList": {
     "editRule": "Editar regra",

--- a/apps/web/src/locales/pt-BR/alerts.json
+++ b/apps/web/src/locales/pt-BR/alerts.json
@@ -292,10 +292,6 @@
     "value": "Valor (%)",
     "offlineDurationMinutes": "Tempo offline (minutos)",
     "alertWhenDeviceIsOfflineForThis": "Alertar quando o dispositivo permanecer offline por este número de minutos",
-    "fieldName": "Nome do campo",
-    "customField": "custom_field",
-    "condition": "Condição",
-    "value100": "value > 100",
     "removeCondition": "Remover condição",
     "noConditionsDefinedClickAddConditionTo": "Nenhuma condição definida. Clique em \"Adicionar condição\" para criar uma.",
     "notificationChannels": "Canais de notificação",
@@ -356,9 +352,10 @@
     },
     "conditionTypeOption": {
       "metric": "Condição de métrica",
-      "status": "Condição de status",
-      "custom": "Campo personalizado"
-    }
+      "status": "Condição de status"
+    },
+    "retiredConditionWarning": "O tipo de condição \"{{type}}\" não é mais compatível e nunca disparou um alerta. Remova esta condição para salvar a regra.",
+    "retiredConditionBlocksSave": "Tipo de condição não compatível \"{{type}}\" — remova esta condição antes de salvar."
   },
   "alertRuleList": {
     "editRule": "Editar regra",


### PR DESCRIPTION
Closes #2948

## Decision: remove, not implement

`custom` was offered by the alert-rule editors but **never had a handler registered** in `apps/api/src/services/alertConditions/`. `conditionRegistry.evaluate()` answered `Unknown condition type: custom` with `passed: false`, and a root-level conditions array is evaluated as an implicit AND (`evaluateConditions` wraps it in `{logic:'and'}`) — so a rule whose conditions were all `custom` **could never fire**, while presenting in the UI as a healthy, enabled rule.

Implementing it was rejected on the evidence:

- The stored shape is `{ field, customCondition }` where `customCondition` is an **unparsed free-text expression** (the editor's own placeholder was `value > 100`) over a field namespace that does not exist. Giving it semantics means designing an expression language and a safe evaluator for it — a spec and a design review, not an issue fix.
- PR #2946 already ruled the type dead on the config-policy side: dropped from `AlertRuleTab`, rejected by the shared `alertRuleConditionSchema`, and documented as retired.
- Every capability a `custom` condition might plausibly want already has a real handler (`threshold`, `offline`, `event_log`, `service_stopped`, `process_stopped`, `process_cpu_high`, `process_memory_high`, `bandwidth_high`, `disk_io_high`, `network_errors`, `patch_compliance`, `cert_expiry`).

What #2946 did **not** cover — and what this PR closes — is the *standalone* Alerts → Rules path: `AlertRuleForm` still offered `custom`, and `POST/PUT /alerts/rules` accepted `conditions: z.any()` unvalidated. A tech could create a never-firing rule today.

## What changed

**Web** — `apps/web/src/components/alerts/AlertRuleForm.tsx`
- `custom` removed from the condition-type selector; its `field` / `customCondition` inputs are gone.
- A **stored** `custom` condition renders read-only with its value and an amber-style warning, mirroring `AlertRuleTab`. This matters: left in the type `<select>`, a value with no matching `<option>` shows the first option, so the next save would have silently rewritten a dead `custom` condition into a live CPU rule.
- The retired row is always removable, even as the only condition — otherwise the rule is unsaveable *and* unfixable.
- Zod `superRefine` blocks the save while a retired type is present, with a message naming it.
- 7 locales updated (new warning keys, dead `conditionTypeOption.custom` + the four custom-editor labels removed).

**API** — new `findUnregisteredConditionTypes()` / `unsupportedConditionTypeError()` in `services/alertConditions/index.ts`, wired into every write path that stores conditions the evaluator reads:
- `POST /alerts/rules`, `PUT /alerts/rules/:id`
- `POST /alert-templates/rules`, `PUT /alert-templates/rules/:id`
- `POST /alert-templates`, `PUT /alert-templates/:id` (template conditions are the evaluator's fallback when a rule carries no override)

It rejects **any** type with no registered handler, not just `custom` — the general defect was "unknown type accepted, then silently never fires". 400 with a message naming the offending type and the supported ones. Depth-capped tree walk over both array and `{logic, conditions[]}` group forms.

**Migration** — `apps/api/migrations/2026-08-06-g-drop-custom-alert-conditions.sql`, modelled directly on `2026-07-30-b-drop-never-firing-metric-alert-rules.sql` (same structure, guards, and forensic `RAISE WARNING` counts):
- `config_policy_alert_rules`: **deletes** rows with no evaluable condition at all, skipping any row an `alerts` row references via the FK-less `alerts.config_policy_id`, then rebuilds the `inline_settings` `items[]` mirror per affected link (`IS DISTINCT FROM` guard keeps replay from bumping `updated_at` / the partner-export watermark).
- `alert_rules`: **deactivates, never deletes** — `alerts.rule_id` is a real FK with no `ON DELETE`, so a delete would fail or strand alert provenance. `is_active = false` is honest: the rule already did nothing, and now the UI says so. Effective conditions resolve as `override_settings->'conditions'` else the joined template's, the same precedence the evaluator uses.
- **Scope is deliberately narrow**: only rows where *every* condition is `custom` (or a single `custom` object). A rule that mixes `custom` with a real condition is left alone — dead under an implicit AND but not under an explicit `{logic:'or'}` group, and the editors already flag it for the tech. Guessing there risks silently disabling working alerting.
- Runs under `set_config('breeze.scope','system')` — the affected tables are FORCE RLS and the migration role is not guaranteed superuser on managed Postgres.

**Docs** — `features/alerts.mdx` already described the read-only + warning behaviour under "Creating Alert Rules"; the docs were ahead of the code for the standalone editor. Added that the API now rejects these on write as well.

## Testing

- `apps/api` unit — `services/alertConditions/index.test.ts` (+11 cases: `custom` flagged, every registered type and alias accepted, nested-group walk, dedupe, typeless/non-object nodes ignored, 5000-deep tree does not blow the stack) and new `routes/alerts/rules.conditionTypes.test.ts` (create/update 400s, nested group, supported types pass the guard, absent `conditions` untouched).
- **Affected API suites single-fork: 25 files / 335 tests passed** (`src/routes/alerts`, `src/routes/alerts.test.ts`, `src/routes/alertTemplates`, `src/services/alertConditions`, `src/db/autoMigrate.test.ts`).
- **Integration against real Postgres: 7/7** — new `customAlertConditionCleanup.integration.test.ts` replays the migration against seeded dirty data and proves all-custom deletion, mixed-rule preservation, alerts-referenced rows left in place, mirror rebuild (including a link whose only rule was deleted → `{"items":[]}`), `alert_rules` deactivate-not-delete from **both** override and template condition sources, supported rules left active, and replay being a true no-op. Verified non-vacuous: stubbing out the migration run turns the four change-asserting cases red.
- **Web: 19 files / 279 tests passed** (`src/components/alerts`, `src/lib/i18n` incl. locale parity, `no-silent-mutations`), including new `AlertRuleForm.retiredCondition.test.tsx` (5 cases).
- `packages/shared` validators: 37 files / 1125 tests passed.
- `tsc --noEmit` clean for both `apps/api` and `apps/web`. No `.astro` files changed.

## Known adjacent gap (not fixed here)

`AlertRuleForm` still offers a **`network`** metric option, which `METRIC_NAME_MAP` has no column for — the same never-firing class, already cleaned up on the config-policy side by `2026-07-30-b` and flagged read-only by `AlertRuleTab`. It is a metric *name* problem, not a condition *type* problem, so it is out of scope for #2948; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)