### PR TITLE
fix(agent/backup): skip permanently-failing files without the 30s retry backoff (#2997)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1140,6 +1140,22 @@ jobs:
           CGO_ENABLED: "0"
         run: go test ./internal/sessionbroker ./internal/eventlog ./internal/logging ./internal/state ./internal/watchdog ./cmd/breeze-watchdog
 
+      # internal/backup is the third instance of the same gap: its
+      # upload_error_class_codes_windows_test.go pins the Win32 permanent-error
+      # codes (#2997) against golang.org/x/sys/windows, and those codes drive
+      # ~300 of the 316 field failures that fix targets — yet the package
+      # cannot join the list above while its pre-existing Windows reds stand
+      # (#2523). A -run filter selects only the classification tests, so this
+      # gate is green today and still catches a typo'd code. It caught one in
+      # review: 0x17C is ERROR_CLOUD_FILE_INVALID_REQUEST, not the
+      # ERROR_CLOUD_FILE_ACCESS_DENIED (395) the OneDrive case needs.
+      # Drop the filter when #2523 lands and add the package above.
+      - name: Run Windows backup error-classification tests
+        working-directory: agent
+        env:
+          CGO_ENABLED: "0"
+        run: go test ./internal/backup -run 'TestPermanentWindowsErrnoConstantsMatchWin32|TestClassifyPermanentUploadError|TestLookupPermanentWindowsErrno'
+
       # -race requires cgo, which remote/desktop cannot satisfy on Windows, so
       # this covers only packages that do not import it (heartbeat and agentapp
       # do, transitively). Same package set as the step above: sessionbroker is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1150,11 +1150,24 @@ jobs:
       # review: 0x17C is ERROR_CLOUD_FILE_INVALID_REQUEST, not the
       # ERROR_CLOUD_FILE_ACCESS_DENIED (395) the OneDrive case needs.
       # Drop the filter when #2523 lands and add the package above.
+      #
+      # The PASS-count assertion is not belt-and-braces: `go test -run` exits 0
+      # with "[no tests to run]" when the regex matches nothing, so a rename
+      # would silently void the only check the Win32 table has anywhere — the
+      # same vacuous-guard failure this repo has hit before. Counting top-level
+      # PASS lines makes that a red, not a green.
       - name: Run Windows backup error-classification tests
         working-directory: agent
         env:
           CGO_ENABLED: "0"
-        run: go test ./internal/backup -run 'TestPermanentWindowsErrnoConstantsMatchWin32|TestClassifyPermanentUploadError|TestLookupPermanentWindowsErrno'
+        shell: pwsh
+        run: |
+          $out = go test ./internal/backup -run 'TestPermanentWindowsErrnoConstantsMatchWin32|TestClassifyPermanentUploadError|TestLookupPermanentWindowsErrno' -v 2>&1
+          $exit = $LASTEXITCODE
+          $out | ForEach-Object { Write-Host $_ }
+          if ($exit -ne 0) { throw "go test failed (exit $exit)" }
+          $passes = @($out | Select-String -Pattern '^--- PASS: Test').Count
+          if ($passes -lt 4) { throw "expected at least 4 top-level PASS lines, got $passes - the -run filter matched nothing" }
 
       # -race requires cgo, which remote/desktop cannot satisfy on Windows, so
       # this covers only packages that do not import it (heartbeat and agentapp

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -459,27 +459,46 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		uploadStart := time.Now()
 		uploadErr := attemptFileUpload(ctx, provider, file, backupPath)
 		if uploadErr != nil && !errors.Is(uploadErr, errBackupStopped) {
-			// Exactly one retry, only for a non-cancel failure (including a
-			// per-file deadline expiry, which attemptFileUpload has already
-			// converted to a plain error). Job-context cancel during the
-			// backoff wait aborts immediately — never retried.
-			//
-			// Warn, not debug: a single retry is the first observable symptom
-			// of a stalling destination, and it is the point at which we have
-			// already burned the full per-file deadline.
-			log.Warn("file upload failed, retrying once",
-				"path", file.sourcePath,
-				"bytes", file.size,
-				"elapsedMs", time.Since(uploadStart).Milliseconds(),
-				"deadlineMs", deadline.Milliseconds(),
-				"retryDelayMs", uploadRetryDelay.Milliseconds(),
-				"error", uploadErr.Error(),
-			)
-			select {
-			case <-ctx.Done():
-				uploadErr = errBackupStopped
-			case <-time.After(uploadRetryDelay):
-				uploadErr = attemptFileUpload(ctx, provider, file, backupPath)
+			if reason, permanent := classifyPermanentUploadError(uploadErr); permanent {
+				// The source is locked by a live process, already gone, or an
+				// unhydratable cloud placeholder. A retry cannot change that,
+				// so skip immediately instead of burning uploadRetryDelay on a
+				// foregone conclusion — a real 123,600-file C:\Users run spent
+				// 2h38m of its 2h41m asleep here for 316 such files (#2997).
+				//
+				// This ONLY removes the sleep. The file falls through to the
+				// same skip-and-continue block below: counted in
+				// UploadFailures (and so job.ErrorCount), job carries on.
+				log.Warn("file upload failed permanently, skipping without retry",
+					"path", file.sourcePath,
+					"bytes", file.size,
+					"elapsedMs", time.Since(uploadStart).Milliseconds(),
+					"reason", reason,
+					"error", uploadErr.Error(),
+				)
+			} else {
+				// Exactly one retry, only for a non-cancel failure (including a
+				// per-file deadline expiry, which attemptFileUpload has already
+				// converted to a plain error). Job-context cancel during the
+				// backoff wait aborts immediately — never retried.
+				//
+				// Warn, not debug: a single retry is the first observable symptom
+				// of a stalling destination, and it is the point at which we have
+				// already burned the full per-file deadline.
+				log.Warn("file upload failed, retrying once",
+					"path", file.sourcePath,
+					"bytes", file.size,
+					"elapsedMs", time.Since(uploadStart).Milliseconds(),
+					"deadlineMs", deadline.Milliseconds(),
+					"retryDelayMs", uploadRetryDelay.Milliseconds(),
+					"error", uploadErr.Error(),
+				)
+				select {
+				case <-ctx.Done():
+					uploadErr = errBackupStopped
+				case <-time.After(uploadRetryDelay):
+					uploadErr = attemptFileUpload(ctx, provider, file, backupPath)
+				}
 			}
 		}
 		if uploadErr != nil {

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -459,7 +459,7 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		uploadStart := time.Now()
 		uploadErr := attemptFileUpload(ctx, provider, file, backupPath)
 		if uploadErr != nil && !errors.Is(uploadErr, errBackupStopped) {
-			if reason, permanent := classifyPermanentUploadError(uploadErr); permanent {
+			if reason, permanent := classifyPermanentUploadError(uploadErr, file.sourcePath); permanent {
 				// The source is locked by a live process, already gone, or an
 				// unhydratable cloud placeholder. A retry cannot change that,
 				// so skip immediately instead of burning uploadRetryDelay on a

--- a/agent/internal/backup/upload_error_class.go
+++ b/agent/internal/backup/upload_error_class.go
@@ -18,20 +18,26 @@ import (
 // GPUCache, WebView2 leveldb), 16 not-found on cache files that vanished
 // between scan and upload. A separate OneDrive repro burned 630s of backoff on
 // 21 cloud-only placeholders: the backup helper runs as SYSTEM and cannot
-// hydrate a user's placeholder, so ERROR_CLOUD_FILE_ACCESS_DENIED (0x8007017C,
-// Win32 code 0x17C) is deterministic there by construction.
+// hydrate a user's placeholder, so ERROR_CLOUD_FILE_ACCESS_DENIED is
+// deterministic there by construction.
 //
 // The codes are declared here, platform-independently, so the table stays
 // unit-testable on macOS/Linux; only the syscall.Errno -> table lookup is
 // Windows-gated (permanentUploadErrno, in the _windows/_other files).
 // upload_error_class_codes_windows_test.go asserts each value against its
-// golang.org/x/sys/windows constant when the suite runs on Windows.
+// golang.org/x/sys/windows constant, and CI runs that file on Windows.
 const (
-	winErrFileNotFound          uintptr = 2     // ERROR_FILE_NOT_FOUND
-	winErrPathNotFound          uintptr = 3     // ERROR_PATH_NOT_FOUND
-	winErrSharingViolation      uintptr = 32    // ERROR_SHARING_VIOLATION
-	winErrLockViolation         uintptr = 33    // ERROR_LOCK_VIOLATION
-	winErrCloudFileAccessDenied uintptr = 0x17C // ERROR_CLOUD_FILE_ACCESS_DENIED
+	winErrFileNotFound     uintptr = 2  // ERROR_FILE_NOT_FOUND
+	winErrPathNotFound     uintptr = 3  // ERROR_PATH_NOT_FOUND
+	winErrSharingViolation uintptr = 32 // ERROR_SHARING_VIOLATION
+	winErrLockViolation    uintptr = 33 // ERROR_LOCK_VIOLATION
+	// ERROR_CLOUD_FILE_ACCESS_DENIED, HRESULT 0x8007018B. NOTE: #2997 quotes
+	// the HRESULT as 0x8007017C, whose Win32 code (380) is actually
+	// ERROR_CLOUD_FILE_INVALID_REQUEST. The message logged in that repro —
+	// "Access to the cloud file is denied." — is emitted only by 395, and Go
+	// renders the message from the errno it holds, so 395 is the code that
+	// actually occurred and 0x8007017C is a transcription slip in the report.
+	winErrCloudFileAccessDenied uintptr = 0x18B // 395
 )
 
 // permanentWindowsErrnos maps each permanent Win32 code to its symbolic name,
@@ -63,7 +69,8 @@ func lookupPermanentWindowsErrno(code uintptr) (string, bool) {
 
 // classifyPermanentUploadError reports whether a per-file upload failure is
 // permanent — i.e. re-attempting the same file cannot change the outcome — and
-// returns a short reason for the log line.
+// returns a short reason for the log line. sourcePath is the file being backed
+// up, and is required: see the source-attribution step below.
 //
 // Callers use this ONLY to decide whether to spend uploadRetryDelay before the
 // single retry. It never changes what happens to the file: a permanent failure
@@ -73,7 +80,7 @@ func lookupPermanentWindowsErrno(code uintptr) (string, bool) {
 //
 // Conservative by design: anything unrecognised is treated as transient and
 // keeps its retry, so a misclassification costs 30s rather than a lost file.
-func classifyPermanentUploadError(err error) (string, bool) {
+func classifyPermanentUploadError(err error, sourcePath string) (string, bool) {
 	if err == nil {
 		return "", false
 	}
@@ -85,10 +92,27 @@ func classifyPermanentUploadError(err error) (string, bool) {
 		errors.Is(err, context.DeadlineExceeded) {
 		return "", false
 	}
+	// Only a failure attributable to the SOURCE file can be permanent, so the
+	// chain must contain an *fs.PathError naming it. Every provider opens the
+	// source with os.Open(localPath) and wraps the result with %w
+	// (providers/{s3,azure,gcs,b2}.go, providers/local.go), so a real
+	// source-read failure always carries one.
+	//
+	// This guard is load-bearing, not defensive: LocalProvider also creates the
+	// DESTINATION per file (os.MkdirAll/os.Create, providers/local.go), and a
+	// destination on a UNC path or mapped drive that drops mid-run returns
+	// ERROR_PATH_NOT_FOUND / ENOENT. Without the check, a 20-second share blip
+	// would classify every remaining file permanent and drain the rest of the
+	// backup at memory speed with zero retries — turning the 30s backoff, which
+	// is the only thing absorbing short destination outages, into mass data
+	// loss. An unrecognised error shape simply keeps its retry.
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) || pathErr.Path != sourcePath {
+		return "", false
+	}
 	// Windows-only: the Win32 codes above, matched numerically off the
-	// syscall.Errno in the chain (os.File read/open failures surface as
-	// *fs.PathError, which CompressFile wraps with %w, so errors.As reaches it).
-	if name, ok := permanentUploadErrno(err); ok {
+	// syscall.Errno the *fs.PathError carries.
+	if name, ok := permanentUploadErrno(pathErr.Err); ok {
 		return name, true
 	}
 	// Portable: a source file that no longer exists. Covers ENOENT on Unix and
@@ -97,7 +121,7 @@ func classifyPermanentUploadError(err error) (string, bool) {
 	// fs.ErrNotExist. This is the branch that makes the fix meaningful on the
 	// agent's Unix builds too — a temp/cache file that vanishes between scan
 	// and upload is just as unretryable there.
-	if errors.Is(err, fs.ErrNotExist) {
+	if errors.Is(pathErr, fs.ErrNotExist) {
 		return "file not found", true
 	}
 	return "", false

--- a/agent/internal/backup/upload_error_class.go
+++ b/agent/internal/backup/upload_error_class.go
@@ -1,0 +1,104 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+)
+
+// Win32 system error codes (winerror.h) that make a per-file upload failure
+// PERMANENT: the source cannot be read on this attempt or any subsequent one,
+// so the single 30s retry in createSnapshotWithProgress is pure wasted
+// wall-clock (#2997).
+//
+// Field evidence from a 123,600-file C:\Users run on 0.103.0: 316 files were
+// skipped after retry, 2h38m of a 2h41m run was spent asleep in the backoff,
+// and every one of those errors was in this set — 254 ERROR_SHARING_VIOLATION
+// and 54 ERROR_LOCK_VIOLATION on live browser caches (Chrome/Edge Cache_Data,
+// GPUCache, WebView2 leveldb), 16 not-found on cache files that vanished
+// between scan and upload. A separate OneDrive repro burned 630s of backoff on
+// 21 cloud-only placeholders: the backup helper runs as SYSTEM and cannot
+// hydrate a user's placeholder, so ERROR_CLOUD_FILE_ACCESS_DENIED (0x8007017C,
+// Win32 code 0x17C) is deterministic there by construction.
+//
+// The codes are declared here, platform-independently, so the table stays
+// unit-testable on macOS/Linux; only the syscall.Errno -> table lookup is
+// Windows-gated (permanentUploadErrno, in the _windows/_other files).
+// upload_error_class_codes_windows_test.go asserts each value against its
+// golang.org/x/sys/windows constant when the suite runs on Windows.
+const (
+	winErrFileNotFound          uintptr = 2     // ERROR_FILE_NOT_FOUND
+	winErrPathNotFound          uintptr = 3     // ERROR_PATH_NOT_FOUND
+	winErrSharingViolation      uintptr = 32    // ERROR_SHARING_VIOLATION
+	winErrLockViolation         uintptr = 33    // ERROR_LOCK_VIOLATION
+	winErrCloudFileAccessDenied uintptr = 0x17C // ERROR_CLOUD_FILE_ACCESS_DENIED
+)
+
+// permanentWindowsErrnos maps each permanent Win32 code to its symbolic name,
+// which is logged as the skip `reason` so a support reader can tell a locked
+// browser cache from an unhydratable OneDrive placeholder without decoding a
+// localized message string. Deliberately NOT keyed on error text: the Windows
+// messages in the field logs are localized, so string matching would silently
+// stop classifying anything on a non-English host.
+//
+// Deliberately excluded (still retried): ERROR_ACCESS_DENIED (5), which can be
+// a transient AV/indexer hold rather than a structural denial, and the rest of
+// the ERROR_CLOUD_FILE_* family, which includes genuinely retryable states
+// (e.g. ERROR_CLOUD_FILE_NETWORK_UNAVAILABLE). Widening the set is a separate,
+// evidence-led change.
+var permanentWindowsErrnos = map[uintptr]string{
+	winErrFileNotFound:          "ERROR_FILE_NOT_FOUND",
+	winErrPathNotFound:          "ERROR_PATH_NOT_FOUND",
+	winErrSharingViolation:      "ERROR_SHARING_VIOLATION",
+	winErrLockViolation:         "ERROR_LOCK_VIOLATION",
+	winErrCloudFileAccessDenied: "ERROR_CLOUD_FILE_ACCESS_DENIED",
+}
+
+// lookupPermanentWindowsErrno reports whether a Win32 error code is one that a
+// per-file upload retry cannot recover from, along with its symbolic name.
+func lookupPermanentWindowsErrno(code uintptr) (string, bool) {
+	name, ok := permanentWindowsErrnos[code]
+	return name, ok
+}
+
+// classifyPermanentUploadError reports whether a per-file upload failure is
+// permanent — i.e. re-attempting the same file cannot change the outcome — and
+// returns a short reason for the log line.
+//
+// Callers use this ONLY to decide whether to spend uploadRetryDelay before the
+// single retry. It never changes what happens to the file: a permanent failure
+// takes the same skip-and-continue path as any other per-file failure, is
+// appended to Snapshot.UploadFailures (and so to job.ErrorCount), and never
+// aborts the job. Only the sleep goes away.
+//
+// Conservative by design: anything unrecognised is treated as transient and
+// keeps its retry, so a misclassification costs 30s rather than a lost file.
+func classifyPermanentUploadError(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	// Cancellation and deadline expiry are lifecycle signals, not source-file
+	// verdicts. They are handled by the caller's own errBackupStopped branch;
+	// classifying them here would be wrong even though they never recur.
+	if errors.Is(err, errBackupStopped) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return "", false
+	}
+	// Windows-only: the Win32 codes above, matched numerically off the
+	// syscall.Errno in the chain (os.File read/open failures surface as
+	// *fs.PathError, which CompressFile wraps with %w, so errors.As reaches it).
+	if name, ok := permanentUploadErrno(err); ok {
+		return name, true
+	}
+	// Portable: a source file that no longer exists. Covers ENOENT on Unix and
+	// (redundantly with the table above) ERROR_FILE_NOT_FOUND /
+	// ERROR_PATH_NOT_FOUND on Windows, since syscall.Errno.Is maps both to
+	// fs.ErrNotExist. This is the branch that makes the fix meaningful on the
+	// agent's Unix builds too — a temp/cache file that vanishes between scan
+	// and upload is just as unretryable there.
+	if errors.Is(err, fs.ErrNotExist) {
+		return "file not found", true
+	}
+	return "", false
+}

--- a/agent/internal/backup/upload_error_class_codes_windows_test.go
+++ b/agent/internal/backup/upload_error_class_codes_windows_test.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package backup
+
+import (
+	"fmt"
+	"io/fs"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// The permanent-error codes are declared as plain numbers in
+// upload_error_class.go so the table stays unit-testable on macOS/Linux (where
+// golang.org/x/sys/windows does not build). This test is the other half of
+// that trade: on Windows it pins each literal to the real constant, so a typo
+// in the table cannot go unnoticed forever.
+func TestPermanentWindowsErrnoConstantsMatchWin32(t *testing.T) {
+	tests := []struct {
+		name string
+		got  uintptr
+		want windows.Errno
+	}{
+		{"ERROR_FILE_NOT_FOUND", winErrFileNotFound, windows.ERROR_FILE_NOT_FOUND},
+		{"ERROR_PATH_NOT_FOUND", winErrPathNotFound, windows.ERROR_PATH_NOT_FOUND},
+		{"ERROR_SHARING_VIOLATION", winErrSharingViolation, windows.ERROR_SHARING_VIOLATION},
+		{"ERROR_LOCK_VIOLATION", winErrLockViolation, windows.ERROR_LOCK_VIOLATION},
+		{"ERROR_CLOUD_FILE_ACCESS_DENIED", winErrCloudFileAccessDenied, windows.ERROR_CLOUD_FILE_ACCESS_DENIED},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != uintptr(tc.want) {
+				t.Fatalf("%s = %d, want %d", tc.name, tc.got, uintptr(tc.want))
+			}
+		})
+	}
+}
+
+// A real Windows errno must reach the classifier through the *fs.PathError +
+// %w wrapping the upload path applies. Windows-only because syscall.Errno
+// values are platform-specific.
+func TestClassifyPermanentUploadError_RealWindowsErrno(t *testing.T) {
+	err := fmt.Errorf("failed to compress file: %w", &fs.PathError{
+		Op:   "read",
+		Path: `C:\Users\u\AppData\Local\Google\Chrome\User Data\Default\Cache\Cache_Data\f_00a1`,
+		Err:  syscall.Errno(windows.ERROR_SHARING_VIOLATION),
+	})
+	name, ok := classifyPermanentUploadError(err)
+	if !ok {
+		t.Fatalf("want ERROR_SHARING_VIOLATION classified permanent, got transient")
+	}
+	if name != "ERROR_SHARING_VIOLATION" {
+		t.Fatalf("reason = %q, want ERROR_SHARING_VIOLATION", name)
+	}
+}

--- a/agent/internal/backup/upload_error_class_codes_windows_test.go
+++ b/agent/internal/backup/upload_error_class_codes_windows_test.go
@@ -41,16 +41,28 @@ func TestPermanentWindowsErrnoConstantsMatchWin32(t *testing.T) {
 // %w wrapping the upload path applies. Windows-only because syscall.Errno
 // values are platform-specific.
 func TestClassifyPermanentUploadError_RealWindowsErrno(t *testing.T) {
-	err := fmt.Errorf("failed to compress file: %w", &fs.PathError{
-		Op:   "read",
-		Path: `C:\Users\u\AppData\Local\Google\Chrome\User Data\Default\Cache\Cache_Data\f_00a1`,
-		Err:  syscall.Errno(windows.ERROR_SHARING_VIOLATION),
-	})
-	name, ok := classifyPermanentUploadError(err)
-	if !ok {
-		t.Fatalf("want ERROR_SHARING_VIOLATION classified permanent, got transient")
-	}
-	if name != "ERROR_SHARING_VIOLATION" {
-		t.Fatalf("reason = %q, want ERROR_SHARING_VIOLATION", name)
+	const src = `C:\Users\u\AppData\Local\Google\Chrome\User Data\Default\Cache\Cache_Data\f_00a1`
+	for _, tc := range []struct {
+		name  string
+		errno windows.Errno
+	}{
+		{"ERROR_SHARING_VIOLATION", windows.ERROR_SHARING_VIOLATION},
+		{"ERROR_LOCK_VIOLATION", windows.ERROR_LOCK_VIOLATION},
+		{"ERROR_CLOUD_FILE_ACCESS_DENIED", windows.ERROR_CLOUD_FILE_ACCESS_DENIED},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := fmt.Errorf("failed to compress file: %w", &fs.PathError{
+				Op:   "read",
+				Path: src,
+				Err:  syscall.Errno(tc.errno),
+			})
+			name, ok := classifyPermanentUploadError(err, src)
+			if !ok {
+				t.Fatalf("want %s classified permanent, got transient", tc.name)
+			}
+			if name != tc.name {
+				t.Fatalf("reason = %q, want %q", name, tc.name)
+			}
+		})
 	}
 }

--- a/agent/internal/backup/upload_error_class_other.go
+++ b/agent/internal/backup/upload_error_class_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package backup
+
+// permanentUploadErrno is a deliberate no-op off Windows.
+//
+// The codes in permanentWindowsErrnos are Win32 values and collide with
+// unrelated POSIX errnos — 32 is EPIPE and 33 is EDOM on Linux/darwin, both of
+// which are ordinary I/O failures that must keep their retry. Matching the
+// Win32 table against a Unix syscall.Errno would silently drop files from
+// backups on macOS and Linux hosts, so it is never attempted here.
+//
+// Unix permanence is covered by the portable fs.ErrNotExist branch in
+// classifyPermanentUploadError; the lock/sharing/cloud-placeholder failure
+// modes this fix targets are Windows-only by nature.
+func permanentUploadErrno(error) (string, bool) { return "", false }

--- a/agent/internal/backup/upload_error_class_test.go
+++ b/agent/internal/backup/upload_error_class_test.go
@@ -156,6 +156,7 @@ func TestPerFileUploadRetry_PermanentError_StillCountedAndJobContinues(t *testin
 }
 
 func TestClassifyPermanentUploadError(t *testing.T) {
+	const src = `C:\Users\u\AppData\Local\Google\Chrome\User Data\Default\Cache\Cache_Data\f_00a1`
 	tests := []struct {
 		name string
 		err  error
@@ -168,21 +169,63 @@ func TestClassifyPermanentUploadError(t *testing.T) {
 		{name: "deadline exceeded is never permanent", err: context.DeadlineExceeded, want: false},
 		{name: "generic transient upload error", err: errors.New("UploadPart: RequestTimeout"), want: false},
 		{name: "connection reset is transient", err: syscall.ECONNRESET, want: false},
-		{name: "vanished source file", err: notFoundErr("C:\\Users\\u\\AppData\\Local\\Google\\Chrome\\Cache\\f_00a1"), want: true},
+		{name: "vanished source file", err: notFoundErr(src), want: true},
 		{
 			name: "vanished source file surfaced by the compression layer",
-			err:  fmt.Errorf("failed to compress file: %w", &fs.PathError{Op: "read", Path: "x", Err: syscall.ENOENT}),
+			err:  fmt.Errorf("failed to compress file: %w", &fs.PathError{Op: "read", Path: src, Err: syscall.ENOENT}),
 			want: true,
 		},
-		{name: "bare fs.ErrNotExist", err: fs.ErrNotExist, want: true},
+		// A bare sentinel carries no path, so it cannot be attributed to the
+		// source and must keep its retry.
+		{name: "bare fs.ErrNotExist is not attributable to the source", err: fs.ErrNotExist, want: false},
+		// The destination-outage guard. LocalProvider creates the destination
+		// per file; a UNC/mapped-drive target that drops mid-run returns
+		// ENOENT from os.MkdirAll. Classifying that permanent would drain the
+		// remaining files out of the backup with zero retries.
+		{
+			name: "vanished DESTINATION directory stays transient",
+			err:  fmt.Errorf("failed to create backup directory: %w", &fs.PathError{Op: "mkdir", Path: `\\nas\backups\snap`, Err: syscall.ENOENT}),
+			want: false,
+		},
+		{
+			name: "unwritable DESTINATION file stays transient",
+			err:  fmt.Errorf("failed to create destination file: %w", &fs.PathError{Op: "open", Path: `\\nas\backups\snap\f_00a1.gz`, Err: syscall.ENOENT}),
+			want: false,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, got := classifyPermanentUploadError(tc.err)
+			_, got := classifyPermanentUploadError(tc.err, src)
 			if got != tc.want {
 				t.Fatalf("classifyPermanentUploadError(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+// A destination-side failure must keep the full retry: it is the only thing
+// absorbing a short NAS/UNC outage, and skipping it would drop every remaining
+// file in the run.
+func TestPerFileUploadRetry_DestinationError_StillWaitsAndRetries(t *testing.T) {
+	const delay = 200 * time.Millisecond
+	restore := setUploadRetryDelayForTest(delay)
+	defer restore()
+
+	src := writeTempFile(t, "a")
+	destErr := fmt.Errorf("failed to create backup directory: %w",
+		&fs.PathError{Op: "mkdir", Path: `\\nas\backups\snap`, Err: syscall.ENOENT})
+	p := newFixedErrorProvider(destErr)
+	files := []backupFile{{sourcePath: src, snapshotPath: "a", size: 1}}
+
+	start := time.Now()
+	if _, err := CreateSnapshotContext(context.Background(), p, files); err == nil {
+		t.Fatal("want an error when the destination is unreachable, got nil")
+	}
+	if elapsed := time.Since(start); elapsed < delay {
+		t.Fatalf("destination error skipped the retry backoff: elapsed %s, want >= %s", elapsed, delay)
+	}
+	if got := p.callCount(src); got != 2 {
+		t.Fatalf("want 2 upload attempts for a destination error (initial + one retry), got %d", got)
 	}
 }
 
@@ -200,10 +243,13 @@ func TestLookupPermanentWindowsErrno(t *testing.T) {
 		{name: "lock violation", code: 33, wantName: "ERROR_LOCK_VIOLATION", want: true},
 		{name: "file not found", code: 2, wantName: "ERROR_FILE_NOT_FOUND", want: true},
 		{name: "path not found", code: 3, wantName: "ERROR_PATH_NOT_FOUND", want: true},
-		{name: "cloud file access denied (OneDrive placeholder)", code: 0x17C, wantName: "ERROR_CLOUD_FILE_ACCESS_DENIED", want: true},
+		{name: "cloud file access denied (OneDrive placeholder)", code: 395, wantName: "ERROR_CLOUD_FILE_ACCESS_DENIED", want: true},
 		{name: "success is not a failure", code: 0, want: false},
 		{name: "plain access denied stays retryable", code: 5, want: false},
 		{name: "network name deleted stays retryable", code: 64, want: false},
+		// 380 is ERROR_CLOUD_FILE_INVALID_REQUEST, not ACCESS_DENIED — the
+		// HRESULT quoted in #2997 (0x8007017C) points here by mistake.
+		{name: "cloud file invalid request stays retryable", code: 380, want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/agent/internal/backup/upload_error_class_test.go
+++ b/agent/internal/backup/upload_error_class_test.go
@@ -1,0 +1,219 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fixedErrorProvider fails every UploadContext call for the paths in failFor
+// (or for every path when failFor is nil) with a caller-supplied error, and
+// counts the attempts per source path. It models the shape of the field
+// failures in #2997: the same error every time, so the retry cannot help.
+type fixedErrorProvider struct {
+	mu      sync.Mutex
+	err     error
+	failFor map[string]bool
+	calls   map[string]int
+}
+
+func newFixedErrorProvider(err error, failFor ...string) *fixedErrorProvider {
+	p := &fixedErrorProvider{err: err, calls: map[string]int{}}
+	if len(failFor) > 0 {
+		p.failFor = map[string]bool{}
+		for _, path := range failFor {
+			p.failFor[path] = true
+		}
+	}
+	return p
+}
+
+func (p *fixedErrorProvider) UploadContext(_ context.Context, localPath, _ string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls[localPath]++
+	if p.failFor == nil || p.failFor[localPath] {
+		return p.err
+	}
+	return nil
+}
+
+func (p *fixedErrorProvider) Upload(localPath, remotePath string) error {
+	return p.UploadContext(context.Background(), localPath, remotePath)
+}
+
+func (p *fixedErrorProvider) Download(string, string) error { return nil }
+func (p *fixedErrorProvider) List(string) ([]string, error) { return nil, nil }
+func (p *fixedErrorProvider) Delete(string) error           { return nil }
+
+func (p *fixedErrorProvider) callCount(localPath string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls[localPath]
+}
+
+// notFoundErr is the shape a vanished source file produces on every platform:
+// a *fs.PathError wrapping ENOENT (ERROR_FILE_NOT_FOUND on Windows), wrapped
+// again by the compression layer exactly as CompressFile does.
+func notFoundErr(path string) error {
+	return fmt.Errorf("failed to open source file: %w", &fs.PathError{Op: "open", Path: path, Err: syscall.ENOENT})
+}
+
+// A permanent per-file error must skip immediately. The whole point of #2997:
+// a real 123,600-file C:\Users run spent 2h38m of its 2h41m asleep in this
+// backoff for 316 files that could never have succeeded.
+func TestPerFileUploadRetry_PermanentError_SkipsWithoutBackoff(t *testing.T) {
+	restore := setUploadRetryDelayForTest(30 * time.Second) // the real production delay
+	defer restore()
+
+	src := writeTempFile(t, "a")
+	p := newFixedErrorProvider(notFoundErr(src))
+	files := []backupFile{{sourcePath: src, snapshotPath: "a", size: 1}}
+
+	start := time.Now()
+	_, err := CreateSnapshotContext(context.Background(), p, files)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("want an error when the only file fails permanently, got nil")
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("permanent error slept in the retry backoff: elapsed %s (retry delay is 30s)", elapsed)
+	}
+	if got := p.callCount(src); got != 1 {
+		t.Fatalf("want exactly 1 upload attempt for a permanent error (no retry), got %d", got)
+	}
+}
+
+// The 30s retry must survive for genuinely transient failures — the two S3
+// UploadPart/PutObject errors in the same field log SHOULD still be retried.
+func TestPerFileUploadRetry_TransientError_StillWaitsAndRetries(t *testing.T) {
+	const delay = 200 * time.Millisecond
+	restore := setUploadRetryDelayForTest(delay)
+	defer restore()
+
+	src := writeTempFile(t, "a")
+	p := newFixedErrorProvider(errors.New("UploadPart: RequestTimeout: your socket connection timed out"))
+	files := []backupFile{{sourcePath: src, snapshotPath: "a", size: 1}}
+
+	start := time.Now()
+	_, err := CreateSnapshotContext(context.Background(), p, files)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("want an error when the only file fails twice, got nil")
+	}
+	if elapsed < delay {
+		t.Fatalf("transient error did not wait out the retry backoff: elapsed %s, want >= %s", elapsed, delay)
+	}
+	if got := p.callCount(src); got != 2 {
+		t.Fatalf("want exactly 2 upload attempts for a transient error (initial + one retry), got %d", got)
+	}
+}
+
+// Skipping without the backoff must not change what the run reports: the file
+// is still dropped from the snapshot, still counted in UploadFailures (which
+// becomes job.ErrorCount), and must NOT abort the job.
+func TestPerFileUploadRetry_PermanentError_StillCountedAndJobContinues(t *testing.T) {
+	restore := setUploadRetryDelayForTest(30 * time.Second)
+	defer restore()
+
+	good := writeTempFile(t, "good")
+	bad := writeTempFile(t, "bad")
+	p := newFixedErrorProvider(notFoundErr(bad), bad)
+	files := []backupFile{
+		{sourcePath: good, snapshotPath: "good", size: 4},
+		{sourcePath: bad, snapshotPath: "bad", size: 3},
+	}
+
+	start := time.Now()
+	snap, err := CreateSnapshotContext(context.Background(), p, files)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("a permanent per-file failure must not abort the job, got %v", err)
+	}
+	if snap == nil {
+		t.Fatal("want a snapshot for a partial-success run, got nil")
+	}
+	if len(snap.Files) != 1 {
+		t.Fatalf("want 1 uploaded file, got %d", len(snap.Files))
+	}
+	if len(snap.UploadFailures) != 1 {
+		t.Fatalf("want the skipped file counted in UploadFailures, got %d", len(snap.UploadFailures))
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("permanent error slept in the retry backoff: elapsed %s", elapsed)
+	}
+	if got := p.callCount(bad); got != 1 {
+		t.Fatalf("want exactly 1 upload attempt for the permanently-failing file, got %d", got)
+	}
+}
+
+func TestClassifyPermanentUploadError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "job cancel is never permanent", err: errBackupStopped, want: false},
+		{name: "wrapped job cancel is never permanent", err: fmt.Errorf("upload: %w", errBackupStopped), want: false},
+		{name: "context canceled is never permanent", err: context.Canceled, want: false},
+		{name: "deadline exceeded is never permanent", err: context.DeadlineExceeded, want: false},
+		{name: "generic transient upload error", err: errors.New("UploadPart: RequestTimeout"), want: false},
+		{name: "connection reset is transient", err: syscall.ECONNRESET, want: false},
+		{name: "vanished source file", err: notFoundErr("C:\\Users\\u\\AppData\\Local\\Google\\Chrome\\Cache\\f_00a1"), want: true},
+		{
+			name: "vanished source file surfaced by the compression layer",
+			err:  fmt.Errorf("failed to compress file: %w", &fs.PathError{Op: "read", Path: "x", Err: syscall.ENOENT}),
+			want: true,
+		},
+		{name: "bare fs.ErrNotExist", err: fs.ErrNotExist, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, got := classifyPermanentUploadError(tc.err)
+			if got != tc.want {
+				t.Fatalf("classifyPermanentUploadError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// The Win32 code table is declared platform-independently precisely so it can
+// be asserted here, on any OS. See upload_error_class_other.go for why the
+// table must never be applied to a Unix errno.
+func TestLookupPermanentWindowsErrno(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     uintptr
+		wantName string
+		want     bool
+	}{
+		{name: "sharing violation (live browser cache)", code: 32, wantName: "ERROR_SHARING_VIOLATION", want: true},
+		{name: "lock violation", code: 33, wantName: "ERROR_LOCK_VIOLATION", want: true},
+		{name: "file not found", code: 2, wantName: "ERROR_FILE_NOT_FOUND", want: true},
+		{name: "path not found", code: 3, wantName: "ERROR_PATH_NOT_FOUND", want: true},
+		{name: "cloud file access denied (OneDrive placeholder)", code: 0x17C, wantName: "ERROR_CLOUD_FILE_ACCESS_DENIED", want: true},
+		{name: "success is not a failure", code: 0, want: false},
+		{name: "plain access denied stays retryable", code: 5, want: false},
+		{name: "network name deleted stays retryable", code: 64, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			name, ok := lookupPermanentWindowsErrno(tc.code)
+			if ok != tc.want {
+				t.Fatalf("lookupPermanentWindowsErrno(%d) ok = %v, want %v", tc.code, ok, tc.want)
+			}
+			if ok && name != tc.wantName {
+				t.Fatalf("lookupPermanentWindowsErrno(%d) name = %q, want %q", tc.code, name, tc.wantName)
+			}
+		})
+	}
+}

--- a/agent/internal/backup/upload_error_class_windows.go
+++ b/agent/internal/backup/upload_error_class_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package backup
+
+import (
+	"errors"
+	"syscall"
+)
+
+// permanentUploadErrno matches the Win32 code carried by a failed source-file
+// read/open against permanentWindowsErrnos. os.File operations surface as
+// *fs.PathError wrapping a syscall.Errno, and the upload path wraps that with
+// %w (CompressFile, attemptFileUpload), so errors.As reaches the errno through
+// the whole chain.
+func permanentUploadErrno(err error) (string, bool) {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return "", false
+	}
+	return lookupPermanentWindowsErrno(uintptr(errno))
+}

--- a/agent/internal/backup/upload_error_class_windows.go
+++ b/agent/internal/backup/upload_error_class_windows.go
@@ -8,10 +8,10 @@ import (
 )
 
 // permanentUploadErrno matches the Win32 code carried by a failed source-file
-// read/open against permanentWindowsErrnos. os.File operations surface as
-// *fs.PathError wrapping a syscall.Errno, and the upload path wraps that with
-// %w (CompressFile, attemptFileUpload), so errors.As reaches the errno through
-// the whole chain.
+// read/open against permanentWindowsErrnos. Callers pass the *fs.PathError's
+// Err (see classifyPermanentUploadError), which is normally a syscall.Errno
+// directly; errors.As is used rather than a type assertion so a provider that
+// wraps it further still classifies.
 func permanentUploadErrno(err error) (string, bool) {
 	var errno syscall.Errno
 	if !errors.As(err, &errno) {


### PR DESCRIPTION
Refs #2997

## Problem

`agent/internal/backup/snapshot.go` classified a failed per-file upload on exactly one axis — "was this a job cancel?". Every other error was assumed transient, got a 30 s sleep, and one retry:

```go
if uploadErr != nil && !errors.Is(uploadErr, errBackupStopped) {
    log.Warn("file upload failed, retrying once", ..., "retryDelayMs", 30000)
    case <-time.After(uploadRetryDelay):   // uploadRetryDelay = 30s
```

Many of those errors are permanent by construction, so the retry could never succeed and the run paid 30 s per file for nothing.

**Field evidence** (0.103.0, real customer `C:\Users` run, 123,600 files):

| | |
|---|---|
| Run elapsed | `elapsedMs=9669582` — **2 h 41 m** |
| Files skipped after retry | **316** |
| Retry sleep | 316 x 30 s = **9,480 s (2 h 38 m)** |
| Actual work | **~3 minutes** |

**98% of the run was the backoff.** Error breakdown across that log:

```
254  ERROR_SHARING_VIOLATION    live browser caches (Chrome/Edge Cache_Data, GPUCache, WebView2 leveldb)
 54  ERROR_LOCK_VIOLATION       "another process has locked a portion of the file"
 14  ERROR_FILE_NOT_FOUND       existed at scan, gone by upload
  2  ERROR_PATH_NOT_FOUND
  2  genuine S3 UploadPart/PutObject failures  <- these SHOULD still retry
```

The originally-reported OneDrive case is the same bug with a different trigger: 21 cloud-only placeholders took 637 s to back up 85 bytes, because the backup helper runs as SYSTEM and cannot hydrate a user's placeholder.

## Change

`classifyPermanentUploadError` now gates the backoff. Permanent → log and skip immediately, no sleep, no retry. Everything else keeps the existing 30 s retry.

**Only the delay goes away.** A permanent failure falls through to the exact same skip-and-continue block: appended to `Snapshot.UploadFailures` (and so counted in `job.ErrorCount`), job carries on. Nothing about what the run *reports* changes.

Permanent set (exactly the five in the issue thread):

| Code | Name | Why it can't recover |
|---|---|---|
| 32 | `ERROR_SHARING_VIOLATION` | live process holds the file; not clearing in 30 s |
| 33 | `ERROR_LOCK_VIOLATION` | byte-range lock held by another process |
| 2 | `ERROR_FILE_NOT_FOUND` | file is gone; retrying a vanished cache file is definitionally pointless |
| 3 | `ERROR_PATH_NOT_FOUND` | same |
| 395 (0x18B) | `ERROR_CLOUD_FILE_ACCESS_DENIED` | SYSTEM cannot hydrate a user's placeholder, by construction |

> ⚠️ **One correction to the issue.** #2997 quotes the cloud error as HRESULT `0x8007017C`, but Win32 code `0x17C` (380) is `ERROR_CLOUD_FILE_INVALID_REQUEST`. `ERROR_CLOUD_FILE_ACCESS_DENIED` is **395 / 0x18B** (`golang.org/x/sys/windows/zerrors_windows.go:446`). The message in the repro — "Access to the cloud file is denied." — is emitted only by 395, and Go renders the message from the errno it holds, so 395 is what actually occurred and the HRESULT in the report is a transcription slip. This PR uses 395; 380 is deliberately **not** in the table. Worth a sanity check against the raw repro if it's still to hand — with the wrong constant the OneDrive case would not have been fixed at all.

### Design notes

- **Error-code based, never string matching.** The Windows messages in the field logs are localized; matching on text would silently stop classifying on a non-English host.
- **Source-attributed.** Classification requires an `*fs.PathError` in the chain whose `.Path` is the file being backed up. This is load-bearing, not defensive: `LocalProvider` also creates the *destination* per file, so a backup target on a UNC path or mapped drive that drops mid-run returns `ERROR_PATH_NOT_FOUND`/`ENOENT`. Without the guard a 20-second share blip would classify every remaining file permanent and drain the rest of the backup at memory speed with zero retries — the backoff is the only thing absorbing short destination outages. Covered by `TestPerFileUploadRetry_DestinationError_StillWaitsAndRetries`.
- **Conservative default.** Anything unrecognised is treated as transient and keeps its retry, so a misclassification costs 30 s rather than a dropped file.
- **Cancel/deadline are never "permanent"** — they are lifecycle signals handled by the caller's own `errBackupStopped` branch.
- **Deliberately excluded**, still retried: `ERROR_ACCESS_DENIED` (5), which can be a transient AV/indexer hold, and the rest of the `ERROR_CLOUD_FILE_*` family, which includes genuinely retryable states like `ERROR_CLOUD_FILE_NETWORK_UNAVAILABLE`. Widening the set is a separate, evidence-led change.
- **Considered and declined:** giving sharing/lock violations a *short* (1–2 s) retry instead of none. A sharing violation is in principle a statement about this instant, but the 30 s retry already recovered **0 of 316** in the field, so a shorter one would recover less for added complexity — and an in-use file is not lost: it never enters the manifest, so `decideFile` re-uploads it on the next run.
- **Platform split.** The Win32 code table is declared platform-independently (`upload_error_class.go`) so it stays unit-testable on macOS/Linux; only the `syscall.Errno` → table lookup is Windows-gated. The non-Windows shim is a deliberate no-op: the Win32 values collide with unrelated POSIX errnos (32 is `EPIPE`, 33 is `EDOM`), and matching them against a Unix errno would silently drop files from macOS/Linux backups. Unix permanence is covered by the portable `fs.ErrNotExist` branch.

## Files

- `agent/internal/backup/upload_error_class.go` — code table + `classifyPermanentUploadError` (new)
- `agent/internal/backup/upload_error_class_windows.go` — `errors.As` → `syscall.Errno` → table (new)
- `agent/internal/backup/upload_error_class_other.go` — documented no-op (new)
- `agent/internal/backup/snapshot.go` — gate the retry on the classifier
- `agent/internal/backup/upload_error_class_test.go` — new tests
- `agent/internal/backup/upload_error_class_codes_windows_test.go` — pins each literal to its `golang.org/x/sys/windows` constant, plus real-errno end-to-end classification
- `.github/workflows/ci.yml` — run those Windows tests (see below)

## Tests

Written first (TDD — this ships to customer machines). New coverage:

- `TestPerFileUploadRetry_PermanentError_SkipsWithoutBackoff` — with the **real 30 s** `uploadRetryDelay` in place, the run finishes in well under 5 s and makes exactly **1** upload attempt.
- `TestPerFileUploadRetry_TransientError_StillWaitsAndRetries` — asserts elapsed >= `uploadRetryDelay` and exactly **2** attempts. The S3 case is not regressed.
- `TestPerFileUploadRetry_DestinationError_StillWaitsAndRetries` — a destination-side `ENOENT` keeps its full retry.
- `TestPerFileUploadRetry_PermanentError_StillCountedAndJobContinues` — partial-success run: 1 file uploaded, 1 in `UploadFailures`, no job abort, no sleep.
- `TestClassifyPermanentUploadError` — table: cancel / `context.Canceled` / `DeadlineExceeded` / generic S3 error / `ECONNRESET` / destination `PathError`s stay transient; source not-found through both wrap shapes is permanent.
- `TestLookupPermanentWindowsErrno` — table: the five codes permanent with correct names; 0, `ERROR_ACCESS_DENIED` (5), 64 and 380 stay retryable.

All three permanent-path tests were confirmed **non-vacuous** by reverting the `snapshot.go` hunk: they fail with `elapsed 30.0s`.

### CI: the Windows tests previously ran on no platform

`test-agent-windows` uses an explicit package list and `internal/backup` is excluded on pre-existing reds (#2523), while `go build` never compiles `_test.go` — so the Win32 table, which drives ~300 of the 316 field failures, had **zero executed coverage**. That is verbatim the gap that job's own comment says to watch for, and it is why the wrong cloud-file constant survived the first pass. Added a `-run`-filtered step (green today, drop the filter when #2523 lands), with a PASS-count assertion because `go test -run` exits 0 on "[no tests to run]" and a rename would otherwise silently void the only check the table has.

```
cd agent && go test -race ./internal/backup/...   # all 7 packages ok
cd agent && go vet ./...                          # exit 0
GOOS=windows go vet ./internal/backup/            # exit 0
```
CI: Test Agent, Test Agent (race), **Test Agent (Windows)**, Lint Agent (Go), and all four Build Agent targets green. (`Cargo Audit` is red — pre-existing on `main`, Rust, unrelated to this Go-only change.)

## Not in scope

Out of the 0.103.0 backup cluster, this PR fixes only the retry cost. Left to their own issues: #2999 (VSS — the upstream cause of the sharing violations; with VSS working those files would have been readable), #2998 (helper death), #3000 (status threshold), #3001 (result payload size). Also not done here, from the issue's suggestion list: placeholder detection during scan, a first-class "N cloud-only files skipped" result field, browser-cache default exclusion presets, and the backup docs section. A reviewer also noted the skip `reason` is logged but not folded into `summarizeUploadFailures`, so the job Warning still can't distinguish "316 locked browser caches" from other causes — deliberately left alone to keep `backup.go` free of conflicts with #3001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)