### PR TITLE
fix(agent): report backup helper death instead of waiting for the stale reaper (#2998)

### DIFF
--- a/agent/internal/sessionbroker/backup.go
+++ b/agent/internal/sessionbroker/backup.go
@@ -1,6 +1,7 @@
 package sessionbroker
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,12 +12,33 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/backupipc"
 	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/logging"
 )
 
 const (
 	backupHelperSpawnTimeout = 15 * time.Second
 	backupHelperIdleTimeout  = 30 * time.Minute
 )
+
+// backupHelperDiedError is the terminal error reported for a backup run whose
+// helper process disappeared mid-run (#2998). It is a fixed string so support
+// and the server can separate "the helper died" from a genuinely stalled
+// upload — the stale-backup reaper's "no progress reported for 15 minutes"
+// (apps/api/src/jobs/staleCommandReaper.ts) is what a run used to get instead,
+// 15 minutes late and describing the wrong failure.
+const backupHelperDiedError = "backup helper exited unexpectedly"
+
+// backupRunCommandType is the wire value of the backup command that runs a
+// backup, duplicated here as a literal because internal/remote/tools (which
+// declares CmdBackupRun) imports this package — taking the constant from there
+// would be an import cycle. It must stay in step with tools.CmdBackupRun and
+// with the helper's own literal in cmd/breeze-backup/main.go.
+const backupRunCommandType = "backup_run"
+
+// backupLog carries component=backup rather than component=sessionbroker so
+// helper-death warnings land in the same shipped bucket as the rest of the
+// backup subsystem (default log_shipping_level is warn).
+var backupLog = logging.L("backup")
 
 // backupHelperScopes defines allowed IPC scopes for the backup helper.
 var backupHelperScopes = []string{"backup"}
@@ -41,6 +63,17 @@ type backupHelper struct {
 	process    *os.Process
 	binaryPath string
 	spawning   bool
+
+	// activeRunCommandID is the command id of an async backup_run that the
+	// helper acked but has not yet delivered a terminal result for. It is the
+	// only signal that a run is still in flight, and therefore the gate on
+	// synthesizing a failure when the helper dies (#2998).
+	//
+	// Only the async flow is tracked. On the legacy synchronous path the
+	// forwarder is still blocked in Session.SendCommand, which errors out when
+	// the session closes and reports the failure itself — tracking it here too
+	// would double-report the same command.
+	activeRunCommandID string
 }
 
 // GetOrSpawnBackupHelper returns the existing backup helper session or spawns a new one.
@@ -175,7 +208,9 @@ func (b *Broker) StopBackupHelper() {
 func (b *Broker) ForwardBackupCommand(commandID, commandType string, payload []byte, timeout time.Duration, async bool) (*ipc.Envelope, error) {
 	b.mu.RLock()
 	var session *Session
+	var bh *backupHelper
 	if b.backup != nil {
+		bh = b.backup
 		session = b.backup.session
 	}
 	b.mu.RUnlock()
@@ -192,5 +227,142 @@ func (b *Broker) ForwardBackupCommand(commandID, commandType string, payload []b
 		Async:       async,
 	}
 
-	return session.SendCommand(commandID, backupipc.TypeBackupCommand, req, timeout)
+	env, err := session.SendCommand(commandID, backupipc.TypeBackupCommand, req, timeout)
+
+	// An async backup_run leaves the run executing inside the helper after the
+	// ack returns, with the terminal result promised as a later unsolicited
+	// envelope. Record it so a helper death before that result can be reported
+	// (#2998). Anything the caller already turns into a command failure — a
+	// send/timeout error, an unparseable ack, or an ack that says the run did
+	// not start — is deliberately NOT tracked: the failure is reported by the
+	// forwarder's return value instead.
+	if async && commandType == backupRunCommandType && bh != nil && err == nil && ackStartedRun(env) {
+		bh.mu.Lock()
+		bh.activeRunCommandID = commandID
+		bh.mu.Unlock()
+	}
+
+	return env, err
+}
+
+// ackStartedRun reports whether an async backup_run ack means the run is now
+// executing in the helper. It mirrors what the heartbeat forwarder does with
+// the same envelope (forwardToBackupHelper): an ack it cannot parse, or one
+// carrying Success=false, becomes the command's failure result there.
+func ackStartedRun(env *ipc.Envelope) bool {
+	if env == nil {
+		return false
+	}
+	var ack backupipc.BackupCommandResult
+	if err := json.Unmarshal(env.Payload, &ack); err != nil {
+		return false
+	}
+	return ack.Success
+}
+
+// noteBackupRunResult clears the in-flight run once its terminal result has
+// been forwarded to the server, so a subsequent helper disconnect stays a
+// no-op instead of reporting a second, contradictory result (#2998).
+//
+// Only the unsolicited terminal result reaches this: the async ack is a reply
+// to the request envelope and is consumed by Session.HandleResponse, never
+// reaching dispatchHelperMessage.
+func (b *Broker) noteBackupRunResult(env *ipc.Envelope) {
+	b.mu.RLock()
+	bh := b.backup
+	b.mu.RUnlock()
+	if bh == nil || env == nil {
+		return
+	}
+
+	var result backupipc.BackupCommandResult
+	if err := json.Unmarshal(env.Payload, &result); err != nil {
+		// Unparseable here means unparseable in the heartbeat handler too, so
+		// the server learns nothing from it — keep the run tracked so the
+		// disconnect still reports a terminal failure.
+		backupLog.Warn("unparseable terminal backup result, keeping run tracked",
+			"error", err.Error())
+		return
+	}
+	if result.CommandID == "" {
+		return
+	}
+
+	bh.mu.Lock()
+	if bh.activeRunCommandID == result.CommandID {
+		bh.activeRunCommandID = ""
+	}
+	bh.mu.Unlock()
+}
+
+// reportBackupHelperDeath synthesizes a terminal backup_result when the backup
+// helper disconnects with a run still in flight (#2998).
+//
+// Before this, the disconnect only cleared local state: the server never
+// learned the run had ended, so the job sat "running" until the 15-minute
+// stale-backup reaper failed it with "no progress reported for 15 minutes" —
+// a misleading cause for a process that died in ~2 seconds.
+//
+// The synthetic result is pushed through the same onMessage sink a genuine
+// unsolicited result uses, so it inherits the heartbeat's delivery path
+// including the outbox that survives a WS gap.
+func (b *Broker) reportBackupHelperDeath(session *Session) {
+	b.mu.RLock()
+	bh := b.backup
+	b.mu.RUnlock()
+	if bh == nil || session == nil {
+		return
+	}
+
+	bh.mu.Lock()
+	current := bh.session
+	commandID := bh.activeRunCommandID
+	// A different live session means the run belongs to the helper that
+	// replaced this one; failing it here would kill a backup that is still
+	// executing. A nil current session is this session's own teardown (the
+	// shutdown path clears it before the disconnect lands), and the run is
+	// dead either way, so that case still reports.
+	superseded := current != nil && current != session
+	if !superseded && commandID != "" {
+		bh.activeRunCommandID = ""
+	}
+	bh.mu.Unlock()
+
+	if commandID == "" {
+		return
+	}
+	if superseded {
+		backupLog.Warn("backup helper session disconnected while another session owns the in-flight run",
+			"sessionId", session.SessionID, "commandId", commandID)
+		return
+	}
+
+	backupLog.Warn("backup helper exited with a run in flight, failing the job",
+		"sessionId", session.SessionID,
+		"commandId", commandID,
+		"error", backupHelperDiedError,
+	)
+
+	if b.onMessage == nil {
+		backupLog.Error("no message handler wired, cannot report backup helper death",
+			"commandId", commandID)
+		return
+	}
+
+	payload, err := json.Marshal(backupipc.BackupCommandResult{
+		CommandID: commandID,
+		Success:   false,
+		Stderr:    backupHelperDiedError,
+	})
+	if err != nil {
+		backupLog.Error("failed to encode backup helper death result",
+			"commandId", commandID, "error", err.Error())
+		return
+	}
+
+	b.onMessage(session, &ipc.Envelope{
+		ID:      commandID + "-helper-death",
+		Type:    backupipc.TypeBackupResult,
+		Payload: payload,
+	})
 }

--- a/agent/internal/sessionbroker/backup.go
+++ b/agent/internal/sessionbroker/backup.go
@@ -83,13 +83,6 @@ type backupHelper struct {
 	// the session closes and reports the failure itself — tracking it here too
 	// would double-report the same command.
 	activeRuns map[string]backupRunState
-
-	// deadSession is the last session whose death was reported. It closes the
-	// window where a forwarder is mid-flight while the helper dies: the
-	// forwarder consults it to decide whether the run it just started is
-	// already doomed. Holding one dead *Session is deliberate — the pointer is
-	// the identity, and it is replaced on the next death.
-	deadSession *Session
 }
 
 // backupRunState distinguishes a run whose forwarder is still blocked waiting
@@ -107,6 +100,17 @@ const (
 	backupRunPendingAck backupRunState = iota
 	// backupRunExecuting: the helper acked; the terminal result is still owed.
 	backupRunExecuting
+	// backupRunDoomed: the helper died while this run was still pending-ack.
+	// The death path leaves this tombstone instead of reporting, because the
+	// forwarder is the one that must fail the command; the forwarder consumes
+	// the tombstone when it resumes.
+	//
+	// The doom signal has to be per-command, not per-session: "my entry is
+	// gone" is ambiguous on its own — it also happens when the genuine
+	// terminal result was delivered and the helper then exited normally, and
+	// failing the command in THAT case would contradict a success the server
+	// already recorded.
+	backupRunDoomed
 )
 
 // GetOrSpawnBackupHelper returns the existing backup helper session or spawns a new one.
@@ -290,30 +294,35 @@ func (b *Broker) ForwardBackupCommand(commandID, commandType string, payload []b
 		return env, err
 	}
 
-	// The helper confirmed the run. Promote it to executing — but only if the
-	// entry is still there. It can have vanished two ways, and they need
-	// opposite answers:
+	// The helper confirmed the run. What happened to the entry in the meantime
+	// decides who owns this command's outcome:
 	//
-	//   - the terminal result already arrived (a run that failed in
-	//     microseconds): the server has been told, so re-adding the id would
-	//     strand a false failure for the next disconnect. Leave it gone.
-	//   - the helper died and the death path cleared the map: it deliberately
-	//     did NOT report this command (still pending-ack), so this call must
-	//     fail it instead. That keeps helper-death reporting exactly-once in
-	//     every interleaving.
+	//   - gone: the terminal result already arrived (a run that finished or
+	//     failed in microseconds) and the server has been told. Re-adding the
+	//     id would strand a false failure for the next disconnect, and
+	//     returning an error here would contradict a result already recorded.
+	//     Stay silent.
+	//   - doomed: the helper died while this run was still pending-ack. The
+	//     death path deliberately did not report it, so this call must fail it.
+	//   - otherwise: promote to executing; the death path owns it from here.
+	//
+	// Those three answers are what make helper-death reporting exactly-once in
+	// every interleaving of this goroutine and the RecvLoop goroutine.
 	bh.mu.Lock()
-	if _, stillTracked := bh.activeRuns[commandID]; stillTracked {
+	state, stillTracked := bh.activeRuns[commandID]
+	switch {
+	case !stillTracked:
+		bh.mu.Unlock()
+		return env, nil
+	case state == backupRunDoomed:
+		delete(bh.activeRuns, commandID)
+		bh.mu.Unlock()
+		return env, fmt.Errorf("%s", backupHelperDiedError)
+	default:
 		bh.activeRuns[commandID] = backupRunExecuting
 		bh.mu.Unlock()
 		return env, nil
 	}
-	doomed := bh.deadSession == session
-	bh.mu.Unlock()
-
-	if doomed {
-		return env, fmt.Errorf("%s", backupHelperDiedError)
-	}
-	return env, nil
 }
 
 // ackStartedRun reports whether an async backup_run ack means the run is now
@@ -397,22 +406,30 @@ func (b *Broker) reportBackupHelperDeath(session *Session) {
 	// executing. A nil current session is this session's own teardown (the
 	// shutdown path clears it before the disconnect lands), and the runs are
 	// dead either way, so that case still reports.
+	//
+	// The map is deliberately left untouched on the superseded branch. Any
+	// residue from the superseded session is then attributed to the next
+	// session's death — accepted, because reaching this branch at all requires
+	// a replacement helper to register in the window between RecvLoop
+	// returning and this report, and mis-attributing is strictly better than
+	// failing the live helper's runs.
 	superseded := bh.session != nil && bh.session != session
 	var commandIDs []string
 	stillTracked := len(bh.activeRuns)
 	if !superseded {
 		// Report only the runs the helper confirmed it was executing. A run
-		// still awaiting its ack is the forwarder's to fail — it is blocked in
-		// SendCommand, which errors when the session closes. Clearing the map
-		// wholesale (both states) is what tells that forwarder its entry is
-		// gone, so it fails the command instead of promoting a dead run.
+		// still awaiting its ack is the forwarder's to fail — it is either
+		// blocked in SendCommand (which errors when the session closes) or
+		// about to resume and find the tombstone left here. Reporting those
+		// too would double-fail the command.
 		for id, state := range bh.activeRuns {
 			if state == backupRunExecuting {
 				commandIDs = append(commandIDs, id)
+				delete(bh.activeRuns, id)
+				continue
 			}
+			bh.activeRuns[id] = backupRunDoomed
 		}
-		bh.activeRuns = nil
-		bh.deadSession = session
 	}
 	bh.mu.Unlock()
 	b.mu.RUnlock()

--- a/agent/internal/sessionbroker/backup.go
+++ b/agent/internal/sessionbroker/backup.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,17 +66,48 @@ type backupHelper struct {
 	binaryPath string
 	spawning   bool
 
-	// activeRunCommandID is the command id of an async backup_run that the
-	// helper acked but has not yet delivered a terminal result for. It is the
-	// only signal that a run is still in flight, and therefore the gate on
-	// synthesizing a failure when the helper dies (#2998).
+	// activeRuns holds every async backup_run this helper is executing, keyed
+	// by command id. It is the gate on synthesizing a failure when the helper
+	// dies (#2998), and it is a MAP rather than a single slot because
+	// concurrent runs on one device are a normal shape, not a corner case: a
+	// profile fan-out dispatches one job per selection and both `file` and
+	// `system_image` resolve to commandType backup_run
+	// (apps/api/src/jobs/backupWorker.ts), the agent dispatches commands from a
+	// worker pool, and the helper runs each in its own goroutine
+	// (cmd/breeze-backup/main.go). A single slot would let the second run
+	// overwrite the first and leave the first stranded for the 15-minute
+	// reaper — the very bug #2998 fixes.
 	//
 	// Only the async flow is tracked. On the legacy synchronous path the
 	// forwarder is still blocked in Session.SendCommand, which errors out when
 	// the session closes and reports the failure itself — tracking it here too
 	// would double-report the same command.
-	activeRunCommandID string
+	activeRuns map[string]backupRunState
+
+	// deadSession is the last session whose death was reported. It closes the
+	// window where a forwarder is mid-flight while the helper dies: the
+	// forwarder consults it to decide whether the run it just started is
+	// already doomed. Holding one dead *Session is deliberate — the pointer is
+	// the identity, and it is replaced on the next death.
+	deadSession *Session
 }
+
+// backupRunState distinguishes a run whose forwarder is still blocked waiting
+// for the helper's ack from one the helper has confirmed it is executing.
+//
+// The distinction is what makes helper-death reporting exactly-once. A run
+// still awaiting its ack must NOT be reported by the death path, because its
+// forwarder is about to return an error (Session.SendCommand fails when the
+// session closes) and the heartbeat reports that failure itself. Only a
+// confirmed-running command has nobody else left to report it.
+type backupRunState int
+
+const (
+	// backupRunPendingAck: recorded before the request was sent, ack not yet seen.
+	backupRunPendingAck backupRunState = iota
+	// backupRunExecuting: the helper acked; the terminal result is still owed.
+	backupRunExecuting
+)
 
 // GetOrSpawnBackupHelper returns the existing backup helper session or spawns a new one.
 func (b *Broker) GetOrSpawnBackupHelper(binaryPath string) (*Session, error) {
@@ -227,22 +260,60 @@ func (b *Broker) ForwardBackupCommand(commandID, commandType string, payload []b
 		Async:       async,
 	}
 
-	env, err := session.SendCommand(commandID, backupipc.TypeBackupCommand, req, timeout)
-
-	// An async backup_run leaves the run executing inside the helper after the
-	// ack returns, with the terminal result promised as a later unsolicited
-	// envelope. Record it so a helper death before that result can be reported
-	// (#2998). Anything the caller already turns into a command failure — a
-	// send/timeout error, an unparseable ack, or an ack that says the run did
-	// not start — is deliberately NOT tracked: the failure is reported by the
-	// forwarder's return value instead.
-	if async && commandType == backupRunCommandType && bh != nil && err == nil && ackStartedRun(env) {
-		bh.mu.Lock()
-		bh.activeRunCommandID = commandID
-		bh.mu.Unlock()
+	tracked := async && commandType == backupRunCommandType && bh != nil
+	if !tracked {
+		return session.SendCommand(commandID, backupipc.TypeBackupCommand, req, timeout)
 	}
 
-	return env, err
+	// Record BEFORE sending, not after. The helper's terminal result is
+	// delivered by the RecvLoop goroutine and can land before this goroutine
+	// resumes from SendCommand — recording afterwards would re-add a command
+	// that already finished, and the next disconnect would then fail an
+	// already-completed job (#2998 review). Recording first means every
+	// dispatch of this command id is ordered after the entry exists.
+	bh.mu.Lock()
+	if bh.activeRuns == nil {
+		bh.activeRuns = make(map[string]backupRunState)
+	}
+	bh.activeRuns[commandID] = backupRunPendingAck
+	bh.mu.Unlock()
+
+	env, err := session.SendCommand(commandID, backupipc.TypeBackupCommand, req, timeout)
+
+	// Nothing started: drop the entry. The forwarder's own error/failed-ack
+	// return is what reports this command's failure, so the death path must
+	// not report it a second time.
+	if err != nil || !ackStartedRun(env) {
+		bh.mu.Lock()
+		delete(bh.activeRuns, commandID)
+		bh.mu.Unlock()
+		return env, err
+	}
+
+	// The helper confirmed the run. Promote it to executing — but only if the
+	// entry is still there. It can have vanished two ways, and they need
+	// opposite answers:
+	//
+	//   - the terminal result already arrived (a run that failed in
+	//     microseconds): the server has been told, so re-adding the id would
+	//     strand a false failure for the next disconnect. Leave it gone.
+	//   - the helper died and the death path cleared the map: it deliberately
+	//     did NOT report this command (still pending-ack), so this call must
+	//     fail it instead. That keeps helper-death reporting exactly-once in
+	//     every interleaving.
+	bh.mu.Lock()
+	if _, stillTracked := bh.activeRuns[commandID]; stillTracked {
+		bh.activeRuns[commandID] = backupRunExecuting
+		bh.mu.Unlock()
+		return env, nil
+	}
+	doomed := bh.deadSession == session
+	bh.mu.Unlock()
+
+	if doomed {
+		return env, fmt.Errorf("%s", backupHelperDiedError)
+	}
+	return env, nil
 }
 
 // ackStartedRun reports whether an async backup_run ack means the run is now
@@ -289,9 +360,7 @@ func (b *Broker) noteBackupRunResult(env *ipc.Envelope) {
 	}
 
 	bh.mu.Lock()
-	if bh.activeRunCommandID == result.CommandID {
-		bh.activeRunCommandID = ""
-	}
+	delete(bh.activeRuns, result.CommandID)
 	bh.mu.Unlock()
 }
 
@@ -307,62 +376,88 @@ func (b *Broker) noteBackupRunResult(env *ipc.Envelope) {
 // unsolicited result uses, so it inherits the heartbeat's delivery path
 // including the outbox that survives a WS gap.
 func (b *Broker) reportBackupHelperDeath(session *Session) {
+	if session == nil {
+		return
+	}
+
+	// bh.session is written under b.mu (SetBackupSession, ClearBackupSession,
+	// registerNonLifecycleSession), so it must be read under b.mu too — this
+	// value decides whether a customer's run gets failed, and an unsynchronized
+	// read of it would be a genuine data race. b.mu -> bh.mu is the lock order
+	// used everywhere else in this file, so nesting them here is safe.
 	b.mu.RLock()
 	bh := b.backup
-	b.mu.RUnlock()
-	if bh == nil || session == nil {
+	if bh == nil {
+		b.mu.RUnlock()
 		return
 	}
-
 	bh.mu.Lock()
-	current := bh.session
-	commandID := bh.activeRunCommandID
-	// A different live session means the run belongs to the helper that
-	// replaced this one; failing it here would kill a backup that is still
+	// A different live session means the runs belong to the helper that
+	// replaced this one; failing them here would kill backups that are still
 	// executing. A nil current session is this session's own teardown (the
-	// shutdown path clears it before the disconnect lands), and the run is
+	// shutdown path clears it before the disconnect lands), and the runs are
 	// dead either way, so that case still reports.
-	superseded := current != nil && current != session
-	if !superseded && commandID != "" {
-		bh.activeRunCommandID = ""
+	superseded := bh.session != nil && bh.session != session
+	var commandIDs []string
+	stillTracked := len(bh.activeRuns)
+	if !superseded {
+		// Report only the runs the helper confirmed it was executing. A run
+		// still awaiting its ack is the forwarder's to fail — it is blocked in
+		// SendCommand, which errors when the session closes. Clearing the map
+		// wholesale (both states) is what tells that forwarder its entry is
+		// gone, so it fails the command instead of promoting a dead run.
+		for id, state := range bh.activeRuns {
+			if state == backupRunExecuting {
+				commandIDs = append(commandIDs, id)
+			}
+		}
+		bh.activeRuns = nil
+		bh.deadSession = session
 	}
 	bh.mu.Unlock()
+	b.mu.RUnlock()
 
-	if commandID == "" {
-		return
-	}
 	if superseded {
-		backupLog.Warn("backup helper session disconnected while another session owns the in-flight run",
-			"sessionId", session.SessionID, "commandId", commandID)
+		if stillTracked > 0 {
+			backupLog.Warn("backup helper session disconnected while another session owns the in-flight runs",
+				"sessionId", session.SessionID, "runs", stillTracked)
+		}
 		return
 	}
-
-	backupLog.Warn("backup helper exited with a run in flight, failing the job",
-		"sessionId", session.SessionID,
-		"commandId", commandID,
-		"error", backupHelperDiedError,
-	)
+	if len(commandIDs) == 0 {
+		return
+	}
+	// Deterministic order so a multi-run fan-out reports predictably.
+	sort.Strings(commandIDs)
 
 	if b.onMessage == nil {
 		backupLog.Error("no message handler wired, cannot report backup helper death",
-			"commandId", commandID)
+			"sessionId", session.SessionID, "commandIds", strings.Join(commandIDs, ","))
 		return
 	}
 
-	payload, err := json.Marshal(backupipc.BackupCommandResult{
-		CommandID: commandID,
-		Success:   false,
-		Stderr:    backupHelperDiedError,
-	})
-	if err != nil {
-		backupLog.Error("failed to encode backup helper death result",
-			"commandId", commandID, "error", err.Error())
-		return
-	}
+	for _, commandID := range commandIDs {
+		backupLog.Warn("backup helper exited with a run in flight, failing the job",
+			"sessionId", session.SessionID,
+			"commandId", commandID,
+			"error", backupHelperDiedError,
+		)
 
-	b.onMessage(session, &ipc.Envelope{
-		ID:      commandID + "-helper-death",
-		Type:    backupipc.TypeBackupResult,
-		Payload: payload,
-	})
+		payload, err := json.Marshal(backupipc.BackupCommandResult{
+			CommandID: commandID,
+			Success:   false,
+			Stderr:    backupHelperDiedError,
+		})
+		if err != nil {
+			backupLog.Error("failed to encode backup helper death result",
+				"commandId", commandID, "error", err.Error())
+			continue
+		}
+
+		b.onMessage(session, &ipc.Envelope{
+			ID:      commandID + "-helper-death",
+			Type:    backupipc.TypeBackupResult,
+			Payload: payload,
+		})
+	}
 }

--- a/agent/internal/sessionbroker/backup_death_test.go
+++ b/agent/internal/sessionbroker/backup_death_test.go
@@ -1,0 +1,310 @@
+package sessionbroker
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/backupipc"
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+// backupDeathRig wires a Broker to a piped backup-helper session the way a live
+// agent does: the session carries the "backup" scope and the backup role, is
+// registered as the current backup session, and its RecvLoop dispatches through
+// the real Broker.dispatchHelperMessage. That means an unsolicited terminal
+// backup_result travels the production path (RecvLoop -> dispatchHelperMessage
+// -> onMessage), so the tests below exercise wiring rather than a mock.
+type backupDeathRig struct {
+	broker    *Broker
+	session   *Session
+	helper    *ipc.Conn
+	forwarded chan *ipc.Envelope
+}
+
+func newBackupDeathRig(t *testing.T) *backupDeathRig {
+	t.Helper()
+
+	brokerSide, helperSide := net.Pipe()
+	rig := &backupDeathRig{
+		helper:    ipc.NewConn(helperSide),
+		forwarded: make(chan *ipc.Envelope, 8),
+	}
+
+	rig.session = &Session{
+		SessionID:     "backup-death-test",
+		AllowedScopes: []string{"backup"},
+		HelperRole:    backupipc.HelperRoleBackup,
+		conn:          ipc.NewConn(brokerSide),
+		pending:       make(map[string]pendingResponse),
+		done:          make(chan struct{}),
+	}
+	rig.broker = &Broker{
+		sessions:   make(map[string]*Session),
+		byIdentity: make(map[string][]*Session),
+		onMessage: func(_ *Session, env *ipc.Envelope) {
+			rig.forwarded <- env
+		},
+	}
+	rig.session.broker = rig.broker
+	rig.broker.sessions[rig.session.SessionID] = rig.session
+	rig.broker.SetBackupSession(rig.session)
+
+	go rig.session.RecvLoop(rig.broker.dispatchHelperMessage)
+
+	t.Cleanup(func() {
+		_ = helperSide.Close()
+		_ = brokerSide.Close()
+	})
+	return rig
+}
+
+// ackNextCommand plays the helper side of one forwarded backup command: it
+// reads the request and replies on the request's envelope id, mirroring
+// breeze-backup's async ack (cmd/breeze-backup/main.go). ackSuccess=false
+// models a helper that refused to start the run.
+func (r *backupDeathRig) ackNextCommand(ackSuccess bool) {
+	go func() {
+		env, err := r.helper.Recv()
+		if err != nil {
+			return
+		}
+		var req backupipc.BackupCommandRequest
+		if err := json.Unmarshal(env.Payload, &req); err != nil {
+			return
+		}
+		ack := backupipc.BackupCommandResult{
+			CommandID: req.CommandID,
+			Success:   ackSuccess,
+			Stdout:    `{"started":true}`,
+		}
+		_ = r.helper.SendTyped(env.ID, backupipc.TypeBackupResult, ack)
+	}()
+}
+
+// startAsyncRun forwards an async backup_run and waits for the helper's ack,
+// leaving the run in flight exactly as it is after a real backup_run command.
+func (r *backupDeathRig) startAsyncRun(t *testing.T, commandID string, ackSuccess bool) {
+	t.Helper()
+	r.ackNextCommand(ackSuccess)
+	if _, err := r.broker.ForwardBackupCommand(commandID, "backup_run", nil, 5*time.Second, true); err != nil {
+		t.Fatalf("ForwardBackupCommand: %v", err)
+	}
+}
+
+// killHelper simulates breeze-backup.exe being terminated: the helper end of
+// the pipe goes away, RecvLoop hits EOF and returns.
+func (r *backupDeathRig) killHelper() {
+	_ = r.helper.Close()
+}
+
+func (r *backupDeathRig) nextForwarded(t *testing.T) *ipc.Envelope {
+	t.Helper()
+	select {
+	case env := <-r.forwarded:
+		return env
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a forwarded envelope")
+		return nil
+	}
+}
+
+func (r *backupDeathRig) expectNoForwarded(t *testing.T) {
+	t.Helper()
+	select {
+	case env := <-r.forwarded:
+		t.Fatalf("expected no forwarded envelope, got type=%q payload=%s", env.Type, string(env.Payload))
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func decodeBackupResult(t *testing.T, env *ipc.Envelope) backupipc.BackupCommandResult {
+	t.Helper()
+	if env.Type != backupipc.TypeBackupResult {
+		t.Fatalf("envelope type = %q, want %q", env.Type, backupipc.TypeBackupResult)
+	}
+	var result backupipc.BackupCommandResult
+	if err := json.Unmarshal(env.Payload, &result); err != nil {
+		t.Fatalf("unmarshal backup result: %v", err)
+	}
+	return result
+}
+
+// TestBackupHelperDeath_ActiveRun_ReportsTerminalFailure is the #2998 headline:
+// when breeze-backup dies mid-run the disconnect must synthesize a terminal
+// backup_result so the server fails the job in seconds, instead of leaving it
+// "running" for the 15-minute stale reaper to mislabel as "no progress".
+func TestBackupHelperDeath_ActiveRun_ReportsTerminalFailure(t *testing.T) {
+	rig := newBackupDeathRig(t)
+	rig.startAsyncRun(t, "cmd-run-1", true)
+
+	rig.killHelper()
+	rig.broker.finishHelperSession(rig.session)
+
+	result := decodeBackupResult(t, rig.nextForwarded(t))
+	if result.CommandID != "cmd-run-1" {
+		t.Errorf("CommandID = %q, want cmd-run-1", result.CommandID)
+	}
+	if result.Success {
+		t.Error("expected Success=false for a helper that died mid-run")
+	}
+	if result.Stderr != backupHelperDiedError {
+		t.Errorf("Stderr = %q, want %q", result.Stderr, backupHelperDiedError)
+	}
+	rig.expectNoForwarded(t)
+}
+
+// TestBackupHelperDeath_NoActiveRun_ReportsNothing guards the normal case: a
+// helper that exits when nothing is running must not fabricate a failed job.
+func TestBackupHelperDeath_NoActiveRun_ReportsNothing(t *testing.T) {
+	rig := newBackupDeathRig(t)
+
+	rig.killHelper()
+	rig.broker.finishHelperSession(rig.session)
+
+	rig.expectNoForwarded(t)
+}
+
+// TestBackupHelperDeath_AfterTerminalResult_DoesNotDoubleReport proves the
+// disconnect is a no-op once the helper has already delivered its terminal
+// result — the ordinary end of every successful async run, where the helper
+// sends the result and then exits.
+func TestBackupHelperDeath_AfterTerminalResult_DoesNotDoubleReport(t *testing.T) {
+	rig := newBackupDeathRig(t)
+	rig.startAsyncRun(t, "cmd-run-2", true)
+
+	// Helper delivers the real terminal result on a fresh envelope id, exactly
+	// as sendUnsolicitedResult does in cmd/breeze-backup/main.go.
+	genuine := backupipc.BackupCommandResult{
+		CommandID: "cmd-run-2",
+		Success:   true,
+		Stdout:    `{"filesBackedUp":48000}`,
+	}
+	if err := rig.helper.SendTyped("cmd-run-2-final-1", backupipc.TypeBackupResult, genuine); err != nil {
+		t.Fatalf("send terminal result: %v", err)
+	}
+
+	got := decodeBackupResult(t, rig.nextForwarded(t))
+	if !got.Success || got.CommandID != "cmd-run-2" {
+		t.Fatalf("unexpected genuine result: %+v", got)
+	}
+
+	rig.killHelper()
+	rig.broker.finishHelperSession(rig.session)
+
+	rig.expectNoForwarded(t)
+}
+
+// TestBackupHelperDeath_SyncCommandInFlight_ReportsNothing keeps the synthetic
+// failure off the legacy synchronous path. There the caller is still blocked in
+// Session.SendCommand, which errors out when the session closes, and the
+// heartbeat forwarder turns that into the command's failure result — reporting
+// again here would double-report the same command.
+func TestBackupHelperDeath_SyncCommandInFlight_ReportsNothing(t *testing.T) {
+	rig := newBackupDeathRig(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := rig.broker.ForwardBackupCommand("cmd-sync-1", "backup_run", nil, 5*time.Second, false)
+		done <- err
+	}()
+
+	// Let the request reach the helper side before killing it.
+	if _, err := rig.helper.Recv(); err != nil {
+		t.Fatalf("helper Recv: %v", err)
+	}
+
+	rig.killHelper()
+	rig.broker.finishHelperSession(rig.session)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the synchronous forward to fail when the session closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the synchronous forward to fail")
+	}
+	rig.expectNoForwarded(t)
+}
+
+// TestBackupHelperDeath_AckReportedFailure_ReportsNothing covers a helper that
+// rejects the run in its ack: the forwarder already returns that failure as the
+// command result, so the run was never in flight and the later disconnect must
+// stay silent.
+func TestBackupHelperDeath_AckReportedFailure_ReportsNothing(t *testing.T) {
+	rig := newBackupDeathRig(t)
+	rig.startAsyncRun(t, "cmd-run-3", false)
+
+	rig.killHelper()
+	rig.broker.finishHelperSession(rig.session)
+
+	rig.expectNoForwarded(t)
+}
+
+// TestBackupHelperDeath_NonBackupRole_ReportsNothing pins the role gate: a user
+// helper disconnecting must never touch the backup reporting path, even while a
+// backup run is in flight on the separate backup session.
+func TestBackupHelperDeath_NonBackupRole_ReportsNothing(t *testing.T) {
+	rig := newBackupDeathRig(t)
+	rig.startAsyncRun(t, "cmd-run-4", true)
+
+	other := &Session{
+		SessionID: "user-helper-1",
+		conn:      ipc.NewConn(newDiscardPipeConn(t)),
+		pending:   make(map[string]pendingResponse),
+		done:      make(chan struct{}),
+	}
+	rig.broker.finishHelperSession(other)
+
+	rig.expectNoForwarded(t)
+}
+
+// TestBackupHelperDeath_StaleSession_ReportsNothing prevents the worst failure
+// mode: a superseded backup session must not fail the run owned by the session
+// that replaced it.
+func TestBackupHelperDeath_StaleSession_ReportsNothing(t *testing.T) {
+	rig := newBackupDeathRig(t)
+	rig.startAsyncRun(t, "cmd-run-5", true)
+
+	stale := &Session{
+		SessionID:     "backup-stale",
+		AllowedScopes: []string{"backup"},
+		HelperRole:    backupipc.HelperRoleBackup,
+		conn:          ipc.NewConn(newDiscardPipeConn(t)),
+		pending:       make(map[string]pendingResponse),
+		done:          make(chan struct{}),
+	}
+	rig.broker.finishHelperSession(stale)
+
+	rig.expectNoForwarded(t)
+
+	// The live session still owns the run, so its own death still reports.
+	rig.killHelper()
+	rig.broker.finishHelperSession(rig.session)
+	result := decodeBackupResult(t, rig.nextForwarded(t))
+	if result.CommandID != "cmd-run-5" || result.Success {
+		t.Fatalf("unexpected result after live-session death: %+v", result)
+	}
+}
+
+// newDiscardPipeConn returns one end of a pipe whose peer is drained and
+// discarded, so writes on it never block a test.
+func newDiscardPipeConn(t *testing.T) net.Conn {
+	t.Helper()
+	a, b := net.Pipe()
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			if _, err := b.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		_ = a.Close()
+		_ = b.Close()
+	})
+	return a
+}

--- a/agent/internal/sessionbroker/backup_death_test.go
+++ b/agent/internal/sessionbroker/backup_death_test.go
@@ -3,7 +3,7 @@ package sessionbroker
 import (
 	"encoding/json"
 	"net"
-	"sync"
+	"runtime"
 	"testing"
 	"time"
 
@@ -27,8 +27,53 @@ type backupDeathRig struct {
 
 func newBackupDeathRig(t *testing.T) *backupDeathRig {
 	t.Helper()
-
 	brokerSide, helperSide := net.Pipe()
+	return newBackupDeathRigOn(t, brokerSide, helperSide)
+}
+
+// newBufferedBackupDeathRig uses a kernel-buffered loopback pair instead of the
+// synchronous net.Pipe, so the helper can queue an ack, a terminal result and a
+// close without waiting for the broker to read each one. That is what a real
+// unix-socket helper does, and it is the only way to drive the interleaving
+// where RecvLoop consumes everything before the forwarding goroutine resumes.
+func newBufferedBackupDeathRig(t *testing.T) *backupDeathRig {
+	t.Helper()
+	brokerSide, helperSide := newLoopbackConnPair(t)
+	return newBackupDeathRigOn(t, brokerSide, helperSide)
+}
+
+func newLoopbackConnPair(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen loopback: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	type accepted struct {
+		conn net.Conn
+		err  error
+	}
+	accepts := make(chan accepted, 1)
+	go func() {
+		conn, err := listener.Accept()
+		accepts <- accepted{conn: conn, err: err}
+	}()
+
+	dialed, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial loopback: %v", err)
+	}
+	got := <-accepts
+	if got.err != nil {
+		t.Fatalf("accept loopback: %v", got.err)
+	}
+	return got.conn, dialed
+}
+
+func newBackupDeathRigOn(t *testing.T, brokerSide, helperSide net.Conn) *backupDeathRig {
+	t.Helper()
+
 	rig := &backupDeathRig{
 		helper:       ipc.NewConn(helperSide),
 		forwarded:    make(chan *ipc.Envelope, 8),
@@ -198,19 +243,16 @@ func TestBackupHelperDeath_ActiveRun_ReportsTerminalFailure(t *testing.T) {
 // leave the others stranded for the reaper, i.e. #2998 unfixed for fan-out.
 func TestBackupHelperDeath_ConcurrentRuns_ReportsEveryRun(t *testing.T) {
 	rig := newBackupDeathRig(t)
-	rig.serveAcks(2, true)
 
-	var wg sync.WaitGroup
-	for _, id := range []string{"cmd-run-a", "cmd-run-b"} {
-		wg.Add(1)
-		go func(commandID string) {
-			defer wg.Done()
-			if _, err := rig.broker.ForwardBackupCommand(commandID, "backup_run", nil, 5*time.Second, true); err != nil {
-				t.Errorf("ForwardBackupCommand(%s): %v", commandID, err)
-			}
-		}(id)
-	}
-	wg.Wait()
+	// The two dispatches are serialized, not raced. What this test needs is
+	// two runs tracked SIMULTANEOUSLY, which sequential starts give; racing the
+	// sends instead would trip a pre-existing ipc.Conn defect — Send assigns
+	// env.Seq outside c.mu (internal/ipc/protocol.go), so concurrent senders on
+	// one Conn can reach the wire out of sequence and the peer rejects the
+	// frame as a replay. That is a real bug for the production fan-out this
+	// test models, but it belongs to the ipc package, not to #2998.
+	rig.startAsyncRun(t, "cmd-run-a", true)
+	rig.startAsyncRun(t, "cmd-run-b", true)
 
 	rig.killHelper(t)
 
@@ -330,6 +372,62 @@ func TestBackupHelperDeath_AckThenImmediateDeath_ReportsExactlyOnce(t *testing.T
 	}
 }
 
+// TestBackupHelperDeath_TerminalResultThenDeathDuringForward_NoContradiction
+// pins the interleaving that a per-session "is the helper dead" flag gets
+// wrong. The helper acks, delivers a genuine SUCCESS result, and exits — all
+// while the forwarding goroutine is still between SendCommand and its
+// bookkeeping. When it resumes, its tracking entry is gone and the helper is
+// dead, but the run is NOT a casualty: the server already has the real result.
+// Failing the command here would overwrite a recorded success with a bogus
+// "backup helper exited unexpectedly".
+func TestBackupHelperDeath_TerminalResultThenDeathDuringForward_NoContradiction(t *testing.T) {
+	// Single-threaded scheduling makes the forwarding goroutine reliably lose
+	// the race to RecvLoop, which is the whole point of the test.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(1))
+
+	for i := 0; i < 40; i++ {
+		rig := newBufferedBackupDeathRig(t)
+
+		go func() {
+			env, err := rig.helper.Recv()
+			if err != nil {
+				return
+			}
+			var req backupipc.BackupCommandRequest
+			if err := json.Unmarshal(env.Payload, &req); err != nil {
+				return
+			}
+			ack := backupipc.BackupCommandResult{CommandID: req.CommandID, Success: true, Stdout: `{"started":true}`}
+			_ = rig.helper.SendTyped(env.ID, backupipc.TypeBackupResult, ack)
+
+			// The real terminal result, then a normal exit.
+			done := backupipc.BackupCommandResult{CommandID: req.CommandID, Success: true, Stdout: `{"filesBackedUp":12}`}
+			_ = rig.helper.SendTyped(req.CommandID+"-final", backupipc.TypeBackupResult, done)
+			_ = rig.helper.Close()
+		}()
+
+		_, err := rig.broker.ForwardBackupCommand("cmd-finished", "backup_run", nil, 5*time.Second, true)
+		if err != nil {
+			t.Fatalf("iteration %d: forward failed a run that completed successfully: %v", i, err)
+		}
+
+		select {
+		case <-rig.disconnected:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for the session teardown to complete")
+		}
+
+		result := decodeBackupResult(t, rig.nextForwarded(t))
+		if !result.Success || result.CommandID != "cmd-finished" {
+			t.Fatalf("iteration %d: expected the genuine success result, got %+v", i, result)
+		}
+		rig.expectNoForwarded(t)
+		if n := rig.trackedRuns(); n != 0 {
+			t.Fatalf("iteration %d: %d runs left tracked after a completed run", i, n)
+		}
+	}
+}
+
 // TestBackupHelperDeath_SyncCommandInFlight_ReportsNothing keeps the synthetic
 // failure off the legacy synchronous path. There the caller is still blocked in
 // Session.SendCommand, which errors out when the session closes, and the
@@ -360,6 +458,41 @@ func TestBackupHelperDeath_SyncCommandInFlight_ReportsNothing(t *testing.T) {
 		t.Fatal("timed out waiting for the synchronous forward to fail")
 	}
 	rig.expectNoForwarded(t)
+}
+
+// TestBackupHelperDeath_DeathBeforeAck_ForwarderOwnsTheFailure covers the
+// helper dying with the request delivered but never acked. The forward is still
+// blocked in SendCommand, which errors when the session closes, and the
+// heartbeat turns that into the command's failure — so the death path must stay
+// silent. Reporting it here as well would fail the same command twice.
+func TestBackupHelperDeath_DeathBeforeAck_ForwarderOwnsTheFailure(t *testing.T) {
+	rig := newBackupDeathRig(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := rig.broker.ForwardBackupCommand("cmd-unacked", "backup_run", nil, 5*time.Second, true)
+		done <- err
+	}()
+
+	// Request reaches the helper, which dies without acking.
+	if _, err := rig.helper.Recv(); err != nil {
+		t.Fatalf("helper Recv: %v", err)
+	}
+	rig.killHelper(t)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the forward to fail when the session closed before the ack")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the forward to fail")
+	}
+
+	rig.expectNoForwarded(t)
+	if n := rig.trackedRuns(); n != 0 {
+		t.Errorf("tracked runs after an unacked death = %d, want 0", n)
+	}
 }
 
 // TestBackupHelperDeath_AckReportedFailure_ReportsNothing covers a helper that

--- a/agent/internal/sessionbroker/backup_death_test.go
+++ b/agent/internal/sessionbroker/backup_death_test.go
@@ -3,6 +3,7 @@ package sessionbroker
 import (
 	"encoding/json"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,16 +12,17 @@ import (
 )
 
 // backupDeathRig wires a Broker to a piped backup-helper session the way a live
-// agent does: the session carries the "backup" scope and the backup role, is
-// registered as the current backup session, and its RecvLoop dispatches through
-// the real Broker.dispatchHelperMessage. That means an unsolicited terminal
-// backup_result travels the production path (RecvLoop -> dispatchHelperMessage
-// -> onMessage), so the tests below exercise wiring rather than a mock.
+// agent does. Crucially the session is driven by the SAME goroutine shape as
+// production — RecvLoop followed by finishHelperSession, exactly as
+// Broker.handleConnection does — so the tests exercise the wiring rather than
+// calling the cleanup by hand. Killing the helper end of the pipe is the whole
+// trigger; no test reaches in and invokes the reporting path itself.
 type backupDeathRig struct {
-	broker    *Broker
-	session   *Session
-	helper    *ipc.Conn
-	forwarded chan *ipc.Envelope
+	broker       *Broker
+	session      *Session
+	helper       *ipc.Conn
+	forwarded    chan *ipc.Envelope
+	disconnected chan struct{}
 }
 
 func newBackupDeathRig(t *testing.T) *backupDeathRig {
@@ -28,8 +30,9 @@ func newBackupDeathRig(t *testing.T) *backupDeathRig {
 
 	brokerSide, helperSide := net.Pipe()
 	rig := &backupDeathRig{
-		helper:    ipc.NewConn(helperSide),
-		forwarded: make(chan *ipc.Envelope, 8),
+		helper:       ipc.NewConn(helperSide),
+		forwarded:    make(chan *ipc.Envelope, 8),
+		disconnected: make(chan struct{}),
 	}
 
 	rig.session = &Session{
@@ -51,7 +54,12 @@ func newBackupDeathRig(t *testing.T) *backupDeathRig {
 	rig.broker.sessions[rig.session.SessionID] = rig.session
 	rig.broker.SetBackupSession(rig.session)
 
-	go rig.session.RecvLoop(rig.broker.dispatchHelperMessage)
+	// The production shape: handleConnection's tail, verbatim.
+	go func() {
+		rig.session.RecvLoop(rig.broker.dispatchHelperMessage)
+		rig.broker.finishHelperSession(rig.session)
+		close(rig.disconnected)
+	}()
 
 	t.Cleanup(func() {
 		_ = helperSide.Close()
@@ -60,43 +68,50 @@ func newBackupDeathRig(t *testing.T) *backupDeathRig {
 	return rig
 }
 
-// ackNextCommand plays the helper side of one forwarded backup command: it
-// reads the request and replies on the request's envelope id, mirroring
-// breeze-backup's async ack (cmd/breeze-backup/main.go). ackSuccess=false
-// models a helper that refused to start the run.
-func (r *backupDeathRig) ackNextCommand(ackSuccess bool) {
+// serveAcks plays the helper side for n forwarded commands, replying on each
+// request's envelope id the way breeze-backup's async ack does
+// (cmd/breeze-backup/main.go). ackSuccess=false models a refused run.
+func (r *backupDeathRig) serveAcks(n int, ackSuccess bool) {
 	go func() {
-		env, err := r.helper.Recv()
-		if err != nil {
-			return
+		for i := 0; i < n; i++ {
+			env, err := r.helper.Recv()
+			if err != nil {
+				return
+			}
+			var req backupipc.BackupCommandRequest
+			if err := json.Unmarshal(env.Payload, &req); err != nil {
+				return
+			}
+			ack := backupipc.BackupCommandResult{
+				CommandID: req.CommandID,
+				Success:   ackSuccess,
+				Stdout:    `{"started":true}`,
+			}
+			_ = r.helper.SendTyped(env.ID, backupipc.TypeBackupResult, ack)
 		}
-		var req backupipc.BackupCommandRequest
-		if err := json.Unmarshal(env.Payload, &req); err != nil {
-			return
-		}
-		ack := backupipc.BackupCommandResult{
-			CommandID: req.CommandID,
-			Success:   ackSuccess,
-			Stdout:    `{"started":true}`,
-		}
-		_ = r.helper.SendTyped(env.ID, backupipc.TypeBackupResult, ack)
 	}()
 }
 
 // startAsyncRun forwards an async backup_run and waits for the helper's ack,
-// leaving the run in flight exactly as it is after a real backup_run command.
+// leaving the run in flight exactly as a real backup_run command does.
 func (r *backupDeathRig) startAsyncRun(t *testing.T, commandID string, ackSuccess bool) {
 	t.Helper()
-	r.ackNextCommand(ackSuccess)
+	r.serveAcks(1, ackSuccess)
 	if _, err := r.broker.ForwardBackupCommand(commandID, "backup_run", nil, 5*time.Second, true); err != nil {
-		t.Fatalf("ForwardBackupCommand: %v", err)
+		t.Fatalf("ForwardBackupCommand(%s): %v", commandID, err)
 	}
 }
 
 // killHelper simulates breeze-backup.exe being terminated: the helper end of
-// the pipe goes away, RecvLoop hits EOF and returns.
-func (r *backupDeathRig) killHelper() {
+// the pipe goes away, RecvLoop hits EOF, and the production cleanup runs.
+func (r *backupDeathRig) killHelper(t *testing.T) {
+	t.Helper()
 	_ = r.helper.Close()
+	select {
+	case <-r.disconnected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the session teardown to complete")
+	}
 }
 
 func (r *backupDeathRig) nextForwarded(t *testing.T) *ipc.Envelope {
@@ -110,13 +125,28 @@ func (r *backupDeathRig) nextForwarded(t *testing.T) *ipc.Envelope {
 	}
 }
 
+// expectNoForwarded is called only after killHelper has confirmed teardown
+// finished, and the reporting path is synchronous within it, so anything the
+// disconnect would have sent is already queued.
 func (r *backupDeathRig) expectNoForwarded(t *testing.T) {
 	t.Helper()
 	select {
 	case env := <-r.forwarded:
 		t.Fatalf("expected no forwarded envelope, got type=%q payload=%s", env.Type, string(env.Payload))
-	case <-time.After(250 * time.Millisecond):
+	default:
 	}
+}
+
+func (r *backupDeathRig) trackedRuns() int {
+	r.broker.mu.RLock()
+	bh := r.broker.backup
+	r.broker.mu.RUnlock()
+	if bh == nil {
+		return 0
+	}
+	bh.mu.Lock()
+	defer bh.mu.Unlock()
+	return len(bh.activeRuns)
 }
 
 func decodeBackupResult(t *testing.T, env *ipc.Envelope) backupipc.BackupCommandResult {
@@ -131,6 +161,19 @@ func decodeBackupResult(t *testing.T, env *ipc.Envelope) backupipc.BackupCommand
 	return result
 }
 
+func assertHelperDeathResult(t *testing.T, result backupipc.BackupCommandResult, wantCommandID string) {
+	t.Helper()
+	if result.CommandID != wantCommandID {
+		t.Errorf("CommandID = %q, want %q", result.CommandID, wantCommandID)
+	}
+	if result.Success {
+		t.Error("expected Success=false for a helper that died mid-run")
+	}
+	if result.Stderr != backupHelperDiedError {
+		t.Errorf("Stderr = %q, want %q", result.Stderr, backupHelperDiedError)
+	}
+}
+
 // TestBackupHelperDeath_ActiveRun_ReportsTerminalFailure is the #2998 headline:
 // when breeze-backup dies mid-run the disconnect must synthesize a terminal
 // backup_result so the server fails the job in seconds, instead of leaving it
@@ -139,20 +182,51 @@ func TestBackupHelperDeath_ActiveRun_ReportsTerminalFailure(t *testing.T) {
 	rig := newBackupDeathRig(t)
 	rig.startAsyncRun(t, "cmd-run-1", true)
 
-	rig.killHelper()
-	rig.broker.finishHelperSession(rig.session)
+	rig.killHelper(t)
 
-	result := decodeBackupResult(t, rig.nextForwarded(t))
-	if result.CommandID != "cmd-run-1" {
-		t.Errorf("CommandID = %q, want cmd-run-1", result.CommandID)
+	assertHelperDeathResult(t, decodeBackupResult(t, rig.nextForwarded(t)), "cmd-run-1")
+	rig.expectNoForwarded(t)
+	if got := rig.trackedRuns(); got != 0 {
+		t.Errorf("tracked runs after death = %d, want 0", got)
 	}
-	if result.Success {
-		t.Error("expected Success=false for a helper that died mid-run")
+}
+
+// TestBackupHelperDeath_ConcurrentRuns_ReportsEveryRun covers the shape a
+// profile fan-out produces: several backup_run commands executing on one helper
+// at once (file + system_image both dispatch as backup_run). Every one of them
+// must be failed, not just the most recent — tracking only the latest would
+// leave the others stranded for the reaper, i.e. #2998 unfixed for fan-out.
+func TestBackupHelperDeath_ConcurrentRuns_ReportsEveryRun(t *testing.T) {
+	rig := newBackupDeathRig(t)
+	rig.serveAcks(2, true)
+
+	var wg sync.WaitGroup
+	for _, id := range []string{"cmd-run-a", "cmd-run-b"} {
+		wg.Add(1)
+		go func(commandID string) {
+			defer wg.Done()
+			if _, err := rig.broker.ForwardBackupCommand(commandID, "backup_run", nil, 5*time.Second, true); err != nil {
+				t.Errorf("ForwardBackupCommand(%s): %v", commandID, err)
+			}
+		}(id)
 	}
-	if result.Stderr != backupHelperDiedError {
-		t.Errorf("Stderr = %q, want %q", result.Stderr, backupHelperDiedError)
+	wg.Wait()
+
+	rig.killHelper(t)
+
+	got := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		result := decodeBackupResult(t, rig.nextForwarded(t))
+		assertHelperDeathResult(t, result, result.CommandID)
+		got[result.CommandID] = true
+	}
+	if !got["cmd-run-a"] || !got["cmd-run-b"] {
+		t.Fatalf("expected both runs failed, got %v", got)
 	}
 	rig.expectNoForwarded(t)
+	if n := rig.trackedRuns(); n != 0 {
+		t.Errorf("tracked runs after death = %d, want 0", n)
+	}
 }
 
 // TestBackupHelperDeath_NoActiveRun_ReportsNothing guards the normal case: a
@@ -160,16 +234,15 @@ func TestBackupHelperDeath_ActiveRun_ReportsTerminalFailure(t *testing.T) {
 func TestBackupHelperDeath_NoActiveRun_ReportsNothing(t *testing.T) {
 	rig := newBackupDeathRig(t)
 
-	rig.killHelper()
-	rig.broker.finishHelperSession(rig.session)
+	rig.killHelper(t)
 
 	rig.expectNoForwarded(t)
 }
 
 // TestBackupHelperDeath_AfterTerminalResult_DoesNotDoubleReport proves the
 // disconnect is a no-op once the helper has already delivered its terminal
-// result — the ordinary end of every successful async run, where the helper
-// sends the result and then exits.
+// result — the ordinary end of every async run, where the helper sends the
+// result and then exits.
 func TestBackupHelperDeath_AfterTerminalResult_DoesNotDoubleReport(t *testing.T) {
 	rig := newBackupDeathRig(t)
 	rig.startAsyncRun(t, "cmd-run-2", true)
@@ -190,10 +263,71 @@ func TestBackupHelperDeath_AfterTerminalResult_DoesNotDoubleReport(t *testing.T)
 		t.Fatalf("unexpected genuine result: %+v", got)
 	}
 
-	rig.killHelper()
-	rig.broker.finishHelperSession(rig.session)
+	rig.killHelper(t)
 
 	rig.expectNoForwarded(t)
+	if n := rig.trackedRuns(); n != 0 {
+		t.Errorf("tracked runs after terminal result = %d, want 0", n)
+	}
+}
+
+// TestBackupHelperDeath_AckThenImmediateDeath_ReportsExactlyOnce pins the
+// interleaving that matters most in the field: a run that dies microseconds
+// after acking (bad VSS snapshot, OOM, missing repository). The terminal
+// failure must be reported EXACTLY once — either synthesized by the disconnect,
+// or returned as an error from the forward, which the heartbeat turns into the
+// command's failure result. Never both (duplicate) and never neither (the job
+// strands for the 15-minute reaper, i.e. #2998 unfixed).
+func TestBackupHelperDeath_AckThenImmediateDeath_ReportsExactlyOnce(t *testing.T) {
+	for i := 0; i < 60; i++ {
+		rig := newBackupDeathRig(t)
+
+		// Ack and die in the same breath, with no synchronization against the
+		// forwarding goroutine.
+		go func() {
+			env, err := rig.helper.Recv()
+			if err != nil {
+				return
+			}
+			var req backupipc.BackupCommandRequest
+			if err := json.Unmarshal(env.Payload, &req); err != nil {
+				return
+			}
+			ack := backupipc.BackupCommandResult{CommandID: req.CommandID, Success: true, Stdout: `{"started":true}`}
+			_ = rig.helper.SendTyped(env.ID, backupipc.TypeBackupResult, ack)
+			_ = rig.helper.Close()
+		}()
+
+		_, err := rig.broker.ForwardBackupCommand("cmd-race", "backup_run", nil, 5*time.Second, true)
+
+		select {
+		case <-rig.disconnected:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for the session teardown to complete")
+		}
+
+		reported := 0
+		for {
+			select {
+			case env := <-rig.forwarded:
+				assertHelperDeathResult(t, decodeBackupResult(t, env), "cmd-race")
+				reported++
+				continue
+			default:
+			}
+			break
+		}
+
+		switch {
+		case err != nil && reported != 0:
+			t.Fatalf("iteration %d: double report — forward errored (%v) AND %d synthetic failures", i, err, reported)
+		case err == nil && reported != 1:
+			t.Fatalf("iteration %d: forward succeeded but %d synthetic failures reported, want exactly 1", i, reported)
+		}
+		if n := rig.trackedRuns(); n != 0 {
+			t.Fatalf("iteration %d: %d runs left tracked after death — a later disconnect would fail a finished job", i, n)
+		}
+	}
 }
 
 // TestBackupHelperDeath_SyncCommandInFlight_ReportsNothing keeps the synthetic
@@ -215,8 +349,7 @@ func TestBackupHelperDeath_SyncCommandInFlight_ReportsNothing(t *testing.T) {
 		t.Fatalf("helper Recv: %v", err)
 	}
 
-	rig.killHelper()
-	rig.broker.finishHelperSession(rig.session)
+	rig.killHelper(t)
 
 	select {
 	case err := <-done:
@@ -237,15 +370,18 @@ func TestBackupHelperDeath_AckReportedFailure_ReportsNothing(t *testing.T) {
 	rig := newBackupDeathRig(t)
 	rig.startAsyncRun(t, "cmd-run-3", false)
 
-	rig.killHelper()
-	rig.broker.finishHelperSession(rig.session)
+	rig.killHelper(t)
 
 	rig.expectNoForwarded(t)
+	if n := rig.trackedRuns(); n != 0 {
+		t.Errorf("tracked runs after a refused ack = %d, want 0", n)
+	}
 }
 
 // TestBackupHelperDeath_NonBackupRole_ReportsNothing pins the role gate: a user
-// helper disconnecting must never touch the backup reporting path, even while a
-// backup run is in flight on the separate backup session.
+// helper disconnecting must never touch the backup reporting path. The live
+// backup run is then failed by its own helper's death, proving the run was
+// genuinely tracked the whole time rather than the assertion passing vacuously.
 func TestBackupHelperDeath_NonBackupRole_ReportsNothing(t *testing.T) {
 	rig := newBackupDeathRig(t)
 	rig.startAsyncRun(t, "cmd-run-4", true)
@@ -257,8 +393,10 @@ func TestBackupHelperDeath_NonBackupRole_ReportsNothing(t *testing.T) {
 		done:      make(chan struct{}),
 	}
 	rig.broker.finishHelperSession(other)
-
 	rig.expectNoForwarded(t)
+
+	rig.killHelper(t)
+	assertHelperDeathResult(t, decodeBackupResult(t, rig.nextForwarded(t)), "cmd-run-4")
 }
 
 // TestBackupHelperDeath_StaleSession_ReportsNothing prevents the worst failure
@@ -276,17 +414,13 @@ func TestBackupHelperDeath_StaleSession_ReportsNothing(t *testing.T) {
 		pending:       make(map[string]pendingResponse),
 		done:          make(chan struct{}),
 	}
-	rig.broker.finishHelperSession(stale)
+	rig.broker.reportBackupHelperDeath(stale)
 
 	rig.expectNoForwarded(t)
 
 	// The live session still owns the run, so its own death still reports.
-	rig.killHelper()
-	rig.broker.finishHelperSession(rig.session)
-	result := decodeBackupResult(t, rig.nextForwarded(t))
-	if result.CommandID != "cmd-run-5" || result.Success {
-		t.Fatalf("unexpected result after live-session death: %+v", result)
-	}
+	rig.killHelper(t)
+	assertHelperDeathResult(t, decodeBackupResult(t, rig.nextForwarded(t)), "cmd-run-5")
 }
 
 // newDiscardPipeConn returns one end of a pipe whose peer is drained and

--- a/agent/internal/sessionbroker/backup_death_wiring_test.go
+++ b/agent/internal/sessionbroker/backup_death_wiring_test.go
@@ -1,0 +1,88 @@
+package sessionbroker
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestHandleConnectionRoutesDisconnectThroughFinishHelperSession pins the one
+// wire the rest of backup_death_test.go cannot reach.
+//
+// Broker.handleConnection is only entered after a full IPC handshake (peer
+// credential check, HMAC session key, binary hash allowlist), which no unit
+// test can stand up, so every behavioral test drives the session through the
+// same RecvLoop-then-finishHelperSession pair by hand. That leaves exactly one
+// uncovered edge: if handleConnection stopped calling finishHelperSession, the
+// backup-helper death report (#2998) would silently stop firing in production
+// while the whole suite stayed green — the original bug, reintroduced.
+//
+// So assert it structurally: after handleConnection's RecvLoop call, the
+// function must hand off to finishHelperSession. A deferred call counts.
+func TestHandleConnectionRoutesDisconnectThroughFinishHelperSession(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "broker.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse broker.go: %v", err)
+	}
+
+	fn := findFuncDecl(file, "handleConnection")
+	if fn == nil {
+		t.Fatal("handleConnection not found in broker.go — update this guard if it was renamed")
+	}
+
+	var callsRecvLoop, callsFinish bool
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "RecvLoop":
+			callsRecvLoop = true
+		case "finishHelperSession":
+			callsFinish = true
+		}
+		return true
+	})
+
+	if !callsRecvLoop {
+		t.Error("handleConnection no longer calls RecvLoop — this guard is stale, revisit it")
+	}
+	if !callsFinish {
+		t.Fatal("handleConnection does not call finishHelperSession: a dying backup helper " +
+			"would stop reporting its in-flight runs and the job would sit `running` until " +
+			"the 15-minute stale reaper (regression of #2998)")
+	}
+
+	// finishHelperSession is only worth reaching if it still reports the death.
+	finish := findFuncDecl(file, "finishHelperSession")
+	if finish == nil {
+		t.Fatal("finishHelperSession not found in broker.go")
+	}
+	var reports bool
+	ast.Inspect(finish, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == "reportBackupHelperDeath" {
+			reports = true
+		}
+		return true
+	})
+	if !reports {
+		t.Fatal("finishHelperSession no longer calls reportBackupHelperDeath (regression of #2998)")
+	}
+}
+
+func findFuncDecl(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}

--- a/agent/internal/sessionbroker/broker.go
+++ b/agent/internal/sessionbroker/broker.go
@@ -2271,9 +2271,21 @@ func (b *Broker) handleConnection(rawConn net.Conn) {
 	// Start receive loop — blocks until disconnect
 	session.RecvLoop(b.dispatchHelperMessage)
 
-	// Clean up after disconnect
+	b.finishHelperSession(session)
+}
+
+// finishHelperSession performs post-disconnect cleanup for a helper session.
+// Every way a session can end funnels through here, because they all work by
+// closing the transport, which returns RecvLoop above.
+//
+// Split out of handleConnection so the backup-death reporting path (#2998) is
+// exercisable without standing up a full IPC handshake.
+func (b *Broker) finishHelperSession(session *Session) {
 	b.removeSession(session)
 	if session.HelperRole == backupipc.HelperRoleBackup {
+		// Report before clearing the session pointer: the report has to see
+		// that this session is the one that owns the in-flight run.
+		b.reportBackupHelperDeath(session)
 		b.ClearBackupSession()
 	}
 	log.Info("user helper disconnected", "uid", session.UID, "sessionId", session.SessionID)
@@ -2854,6 +2866,13 @@ func (b *Broker) dispatchHelperMessage(s *Session, env *ipc.Envelope) {
 			log.Warn("dropping unauthorized backup helper message",
 				"type", env.Type, "sessionId", s.SessionID, "role", s.HelperRole)
 			return
+		}
+		// A terminal result retires the in-flight run, so a helper exit right
+		// after it (the normal end of every async backup) reports nothing
+		// further (#2998). Cleared before the forward: the handler may block
+		// on a websocket send, and the run must already be untracked by then.
+		if env.Type == backupipc.TypeBackupResult {
+			b.noteBackupRunResult(env)
 		}
 		if b.onMessage != nil {
 			b.onMessage(s, env)


### PR DESCRIPTION
**Refs #2998**

## Problem

When `breeze-backup.exe` dies mid-run the agent detects it in ~2 seconds via IPC EOF, and tells nobody. The `backup_jobs` row stays `running` until the stale-backup reaper fails it 15 minutes later with *"no progress reported for 15 minutes"* — which describes a wedged upload, not a dead process.

From the live repro in the issue (Windows Server 2022, 0.103.0, 2026-08-01):

```
21:42:56  breeze-backup.exe killed  -> job stuck at 6454/48000 files
21:58:10  reaped: "[stale-backup-reaper] Backup stalled: no progress reported for 15 minutes"
```

Agent-side the death was already unambiguous two seconds after the kill — at INFO, on disk only:

```
14:42:54 level=INFO msg="session recv loop ended"  component=sessionbroker error="ipc: read header: EOF"
14:42:54 level=INFO msg="user helper disconnected" component=sessionbroker sessionId=backup-6984
```

The backup branch of the post-disconnect cleanup in `handleConnection` cleared local state only — no path from there to a terminal `backup_result` on the WebSocket. The helper is not respawned, so the run is definitively over at that point.

## Fix (agent-only, `internal/sessionbroker`)

The broker tracks every **async `backup_run`** the helper is executing. If the session ends with any of them still in flight, the disconnect synthesizes a failed `backup_result` per run with `stderr = "backup helper exited unexpectedly"`, pushed through the same `onMessage` sink a genuine unsolicited result uses — so it inherits the heartbeat's delivery path, including the outbox that survives a WS gap. It logs at **WARN with `component=backup`**, so it ships at the default `log_shipping_level: warn` instead of sitting on disk at INFO.

Server-side, `backupResultPersistence.ts:454` writes a failed result's `error` into `backup_jobs.error_log`, so the run carries the accurate cause within seconds.

### Exactly-once, by construction

The hard part is not detecting the death — it is making sure each command gets **exactly one** terminal outcome when the forwarding goroutine and the RecvLoop goroutine race. Each run carries a state:

| State | Meaning | Who owns failing it |
|---|---|---|
| `pendingAck` | recorded **before** the send; ack not yet seen | the forwarder — `SendCommand` errors when the session closes |
| `executing` | the helper acked; terminal result still owed | the disconnect path |
| `doomed` | the helper died while still `pendingAck` | the forwarder, which consumes the tombstone |

- **Recorded before the send**, because the terminal result is delivered by the RecvLoop goroutine and can land before the forwarder resumes from `SendCommand`. Recording afterwards could re-add a command that already finished (arming a false failure on the next disconnect) or miss a helper that died right after acking.
- **Promotion is conditional.** A missing entry unambiguously means "already reported — stay silent"; a `doomed` entry means "the death path deliberately skipped you, fail it yourself". That distinction has to be per-command: a per-session "is the helper dead" flag cannot tell a completed run from a doomed one, and would overwrite a recorded success with a bogus helper-death failure.
- **A map, not a single slot.** Concurrent `backup_run`s on one device are a designed shape: a profile fan-out dispatches one job per selection and both `file` and `system_image` resolve to `commandType: backup_run` (`jobs/backupWorker.ts`), the agent dispatches from a worker pool, and the helper runs each command in its own goroutine. A single slot let the second run overwrite the first, leaving the rest stranded for the reaper — #2998 unfixed for the common shape.
- **Only async `backup_run` is tracked.** The legacy synchronous path leaves the forwarder blocked in `SendCommand`, and `forwardToBackupHelper` already turns its error into the command's failure.
- **A superseded session never ends a run owned by the session that replaced it.** A `nil` current session still reports — that is this session's own teardown (e.g. `StopBackupHelper` during agent shutdown), where the run really is dead.
- `bh.session` is read under `b.mu` (where it is written), with `b.mu -> bh.mu` nesting, the lock order already used throughout the file.

`handleConnection`'s cleanup tail moved into `Broker.finishHelperSession`. Every way a session can end funnels through it, since they all work by closing the transport and returning `RecvLoop`.

## Not done here (follow-ups)

- **Reaper message split.** The issue's optional item 2 — a distinct reaper message / `error_log` marker separating "helper died" from "no progress" — is not included. That server-side change lives in `apps/api/src/jobs/staleCommandReaper.ts:854-861`. It is largely obviated for this failure mode now that the accurate cause reaches `error_log` in seconds and the reaper never fires for it, but the two rules remain indistinguishable for runs that genuinely stall.
- **`ipc.Conn.Send` assigns `env.Seq` outside `c.mu`** (`internal/ipc/protocol.go:134` vs the lock at `:146`), so two goroutines sending on one Conn can reach the wire out of sequence and the peer rejects the frame as a replay. That makes the production fan-out this PR handles able to desync a helper's IPC stream. Out of scope — it is a shared hot path used by every helper and needs its own PR — but worth filing.

## Tests

`agent/internal/sessionbroker/backup_death_test.go` drives a piped backup-helper session through the production goroutine shape (`RecvLoop` then `finishHelperSession`, exactly as `handleConnection` does). Killing the helper end of the pipe is the whole trigger; no test invokes the reporting path by hand.

| Test | Proves |
|---|---|
| `ActiveRun_ReportsTerminalFailure` | helper death mid-run reports `Success=false` + the exact error, once |
| `ConcurrentRuns_ReportsEveryRun` | a fan-out fails **every** tracked run, not just the newest |
| `NoActiveRun_ReportsNothing` | a helper exiting with nothing running fabricates no failure |
| `AfterTerminalResult_DoesNotDoubleReport` | the ordinary end of a successful async run stays a single result |
| `AckThenImmediateDeath_ReportsExactlyOnce` | 60 live races: exactly one failure — never two, never zero — and nothing left tracked |
| `TerminalResultThenDeathDuringForward_NoContradiction` | 40 iterations, `GOMAXPROCS=1`, loopback transport: a completed run is never overwritten by a synthetic failure |
| `DeathBeforeAck_ForwarderOwnsTheFailure` | an unacked run is failed by the forwarder, and the death path stays silent |
| `SyncCommandInFlight_ReportsNothing` | the legacy sync path still reports via its own `SendCommand` error only |
| `AckReportedFailure_ReportsNothing` | a run the helper refused was never in flight |
| `NonBackupRole_ReportsNothing` | user-helper disconnects never touch this path (and the live run still reports after) |
| `StaleSession_ReportsNothing` | a superseded session cannot fail the live session's run |

`backup_death_wiring_test.go` adds a `go/ast` guard that `handleConnection` still routes its disconnect through `finishHelperSession`, which still calls `reportBackupHelperDeath`. `handleConnection` is only entered after a full IPC handshake (peer credentials, HMAC key, binary hash allowlist) that no unit test can stand up, so without it the hook could be unwired with the whole suite still green — verified: it is the only test that fails when the call is removed.

Every behavior is mutation-verified. Five mutants, each reds a different test: report only one run; record after send; unwire `finishHelperSession`; treat a missing entry as doomed; report `pendingAck` runs on death.

```
go test -race ./internal/sessionbroker/... ./internal/backup/...   ok (all packages, -count=3)
go test -race ./internal/heartbeat/...                            ok
go vet ./...                                                      clean
GOOS=windows go build ./... && vet && test -c                     clean
gofmt -l internal/sessionbroker/                                  clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
