### PR TITLE
fix(agent): bound the backup result payload to the IPC frame (#3001)

### DIFF
--- a/agent/cmd/breeze-backup/exec_vault.go
+++ b/agent/cmd/breeze-backup/exec_vault.go
@@ -130,9 +130,11 @@ func emitVaultAutoSyncResult(conn *ipc.Conn, snapshotID string, syncResult *back
 		result.Stderr = fmt.Sprintf("failed to marshal vault sync result: %v", err)
 	}
 
-	if err := conn.SendTyped(result.CommandID, backupipc.TypeBackupResult, result); err != nil {
-		slog.Warn("failed to emit vault auto-sync result", "snapshotId", snapshotID, "error", err.Error())
-	}
+	// Bounded like every other backup result (#3001): syncErr is
+	// errors.Join(<one entry per failed file>), so a vault sync over the same
+	// 123k-file set that produced the original 64 MB result yields a
+	// multi-megabyte Stderr and the identical "message too large" drop.
+	_ = sendBackupResult(conn, result.CommandID, result)
 }
 
 // autoSyncToVault parses the backup_run result to extract the snapshot ID and

--- a/agent/cmd/breeze-backup/main.go
+++ b/agent/cmd/breeze-backup/main.go
@@ -501,9 +501,12 @@ func handleBackupCommand(conn *ipc.Conn, env *ipc.Envelope, mgr *backup.BackupMa
 		result := executeCommand(req, mgr, vaultState, conn, commandCanceller)
 		result.CommandID = req.CommandID
 		result.DurationMs = time.Since(start).Milliseconds()
-		if err := sendUnsolicitedResult(conn, result); err != nil {
-			slog.Error("failed to send final backup result", "commandId", req.CommandID, "error", err.Error())
-		}
+		// sendUnsolicitedResult bounds the payload before sending: an oversize
+		// terminal result used to be dropped outright, leaving a SUCCEEDED
+		// backup stuck `running` until the stale-backup reaper failed it
+		// (#3001). Send failures are logged inside sendBackupResult under
+		// component=backup so they ship server-side.
+		_ = sendUnsolicitedResult(conn, result)
 		return
 	}
 
@@ -518,9 +521,10 @@ func handleBackupCommand(conn *ipc.Conn, env *ipc.Envelope, mgr *backup.BackupMa
 	result.CommandID = req.CommandID
 	result.DurationMs = time.Since(start).Milliseconds()
 
-	if err := conn.SendTyped(env.ID, backupipc.TypeBackupResult, result); err != nil {
-		slog.Error("failed to send result", "commandId", req.CommandID, "error", err.Error())
-	}
+	// Same oversize guard as the async path above: the synchronous reply is
+	// what resolves the agent's pending request, so dropping it strands the
+	// command until its forward wait times out (#3001).
+	_ = sendBackupResult(conn, env.ID, result)
 }
 
 // sendUnsolicitedResult sends a terminal backup_result envelope that is not
@@ -531,9 +535,12 @@ func handleBackupCommand(conn *ipc.Conn, env *ipc.Envelope, mgr *backup.BackupMa
 // broker's session.pending map and instead falls through
 // dispatchHelperMessage to the heartbeat's unsolicited-result handler (see
 // heartbeat.go, case backupipc.TypeBackupResult).
+//
+// It goes through sendBackupResult so the payload is bounded to the IPC frame
+// first — see result_bounds.go and #3001.
 func sendUnsolicitedResult(conn *ipc.Conn, result backupipc.BackupCommandResult) error {
 	id := fmt.Sprintf("%s-final-%d", result.CommandID, time.Now().UnixNano())
-	return conn.SendTyped(id, backupipc.TypeBackupResult, result)
+	return sendBackupResult(conn, id, result)
 }
 
 func executeCommand(req backupipc.BackupCommandRequest, mgr *backup.BackupManager, vaultState *vaultManagerRef, conn *ipc.Conn, commandCanceller *activeCommandCanceller) backupipc.BackupCommandResult {

--- a/agent/cmd/breeze-backup/result_bounds.go
+++ b/agent/cmd/breeze-backup/result_bounds.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/breeze-rmm/agent/internal/backupipc"
 	"github.com/breeze-rmm/agent/internal/ipc"
@@ -51,25 +53,32 @@ const (
 // (backupResultPersistence reads snapshot.id / .timestamp / .size).
 var snapshotIdentityKeys = []string{"id", "timestamp", "size", "formatVersion", "baseSnapshotId"}
 
-// resultIdentityKeys are the top-level result fields kept in the reduced tier —
-// the terminal status and the counters the server persists. Notably errorCount
-// survives even when every individual failure detail is gone.
-var resultIdentityKeys = []string{
-	"id", "jobId", "snapshotId", "status", "backupType",
-	"startedAt", "completedAt",
-	"filesBackedUp", "bytesBackedUp",
-	"referencedFiles", "referencedBytes",
-	"errorCount", "warning",
-}
+// bulkFieldThreshold is the encoded size past which a top-level container
+// (array/object) field counts as "bulk" and is dropped ahead of the scalars.
+// Anything under it is cheaper to keep than to reason about.
+const bulkFieldThreshold = 4 * 1024
 
 // fitBackupResultToIPC returns result bounded so its marshalled payload fits
 // resultPayloadBudget, degrading in tiers and stopping at the first that fits:
 //
-//  1. always: truncate the free-text warning/stderr fields;
-//  2. drop the per-file snapshot index (snapshot.files), keeping snapshot
-//     identity — this is what actually blows the budget on a real run;
-//  3. reduce stdout to the terminal-status identity fields only;
+//  1. always: truncate the free-text stderr field (cheap, no JSON parse);
+//  2. empty the per-file snapshot index, cap the warning text, and drop any
+//     other bulk container field — this is what actually blows the budget;
+//  3. reduce stdout to its SCALAR fields plus the snapshot's identity;
 //  4. last resort: a hand-built minimal status object.
+//
+// Tiers 2 and 3 are deliberately shape-agnostic — they drop bulk containers and
+// keep scalars rather than matching an enumerated field list. Every command has
+// its own body (backup.BackupJob, backup.RestoreResult, verify results, …) and
+// the unbounded field is always a per-file array (Snapshot.Files,
+// RestoreResult.FailedFiles, …) while the fields the server persists are always
+// summary scalars. An enumerated keep-list would silently zero
+// filesRestored/filesFailed on the paths it forgot; keeping every scalar cannot.
+//
+// A stdout that is not a JSON object at all (e.g. backup_list's array) cannot be
+// summarised this way, so it degrades to an explicit failure instead of a
+// success with an empty body — an empty snapshot list read as "no backups" is
+// worse than a loud error.
 //
 // The second return value describes what was dropped, and is "" when the result
 // was already within budget. It is non-empty exactly when the caller should log
@@ -81,7 +90,8 @@ func fitBackupResultToIPC(result backupipc.BackupCommandResult) (backupipc.Backu
 	// detail BEFORE marshalling is the primary fix; the tiers below are the
 	// defensive net behind it. Stderr is the unbounded one on this path: a hard
 	// failure routes errors.Join(<every per-file error>) through
-	// fail(err.Error()), which nothing caps.
+	// fail(err.Error()), which nothing caps — as does the vault auto-sync
+	// result, whose Stderr joins one entry per failed file.
 	if truncated, dropped := truncateText(result.Stderr, maxResultTextBytes); dropped > 0 {
 		result.Stderr = truncated
 		notes = append(notes, fmt.Sprintf("stderr truncated (%d bytes dropped)", dropped))
@@ -90,32 +100,42 @@ func fitBackupResultToIPC(result backupipc.BackupCommandResult) (backupipc.Backu
 		return result, joinNotes(notes)
 	}
 
-	// Tier 2 — drop the per-file snapshot index and cap the warning text. Only
-	// reached when the result is actually oversize, so the ordinary path never
-	// pays for parsing a multi-megabyte stdout.
-	//
-	// The index is dropped whole rather than truncated: the server sets
-	// hasIndexedFiles from snapshot.files.length, so a partial index would
-	// present as a complete browsable file list that is silently missing
-	// entries.
-	if stdout, warnDropped := boundStdoutWarning(result.Stdout); warnDropped > 0 {
-		result.Stdout = stdout
-		notes = append(notes, fmt.Sprintf("warning truncated (%d bytes dropped)", warnDropped))
-	}
-	if reduced, dropped, ok := dropSnapshotFiles(result.Stdout); ok {
-		result.Stdout = reduced
-		if dropped > 0 {
-			notes = append(notes, fmt.Sprintf("snapshot file index dropped (%d entries, result exceeded the %d byte IPC limit)", dropped, ipc.MaxMessageSize))
-		}
-		if fits(result) {
-			return result, joinNotes(notes)
-		}
+	// Only reached when the result is actually oversize, so the ordinary path
+	// never pays for parsing a multi-megabyte stdout.
+	obj, isObject := decodeStdoutObject(result.Stdout)
+	if !isObject {
+		notes = append(notes, "result body could not be summarised and was replaced with an oversize failure")
+		return oversizeFailureResult(result), joinNotes(notes)
 	}
 
-	// Tier 3 — terminal status + counters only.
-	if reduced, ok := reduceToIdentity(result.Stdout); ok {
+	// Tier 2 — cap the warning text, empty the per-file snapshot index, and
+	// drop any other bulk container.
+	//
+	// The snapshot index is emptied rather than truncated: the server derives
+	// hasIndexedFiles from snapshot.files.length, so a partial index would
+	// present as a complete browsable file list silently missing entries. It is
+	// emptied rather than removed because the server's stale-row cleanup is
+	// gated on the KEY being present (`if (snapshot && result.snapshot?.files)`
+	// in backupResultPersistence.ts) — omitting it would leave a previous
+	// delivery's file rows in place while hasIndexedFiles flipped to false.
+	if dropped := boundObjectWarning(obj); dropped > 0 {
+		notes = append(notes, fmt.Sprintf("warning truncated (%d bytes dropped)", dropped))
+	}
+	if entries, ok := emptySnapshotFiles(obj); ok {
+		notes = append(notes, fmt.Sprintf("snapshot file index dropped (%d entries)", entries))
+	}
+	for _, key := range dropBulkFields(obj) {
+		notes = append(notes, fmt.Sprintf("%s dropped (bulk field)", key))
+	}
+	result.Stdout = encodeStdoutObject(obj, result.Stdout)
+	if fits(result) {
+		return result, joinNotes(notes)
+	}
+
+	// Tier 3 — scalar fields plus the snapshot identity only.
+	if reduced, ok := reduceToScalars(result.Stdout); ok {
 		result.Stdout = reduced
-		notes = append(notes, "result reduced to terminal status only")
+		notes = append(notes, "result reduced to summary scalars only")
 		if fits(result) {
 			return result, joinNotes(notes)
 		}
@@ -175,7 +195,16 @@ func fits(result backupipc.BackupCommandResult) bool {
 	if len(result.Stdout)+len(result.Stderr)+len(result.CommandID) > resultPayloadBudget {
 		return false
 	}
-	return marshalledSize(result) <= resultPayloadBudget
+	size := marshalledSize(result)
+	// A result that cannot be marshalled at all is not "fitting" — treating
+	// marshalledSize's -1 sentinel as a small size would return an unsendable
+	// payload from a function whose contract is that the send will succeed.
+	// (BackupCommandResult is only strings/bool/int64, so this is unreachable
+	// today; it is guarded so it stays unreachable if the type grows a field.)
+	if size < 0 {
+		return false
+	}
+	return size <= resultPayloadBudget
 }
 
 // marshalledSize returns the marshalled byte length of result, or -1 when it
@@ -230,104 +259,147 @@ func encodeStdoutObject(obj map[string]json.RawMessage, fallback string) string 
 	return string(data)
 }
 
-// boundStdoutWarning truncates the result's `warning` field in place, returning
-// the rewritten stdout and how many bytes were dropped.
-func boundStdoutWarning(stdout string) (string, int) {
-	obj, ok := decodeStdoutObject(stdout)
-	if !ok {
-		return stdout, 0
-	}
+// boundObjectWarning truncates the object's `warning` field in place, returning
+// how many bytes were dropped.
+func boundObjectWarning(obj map[string]json.RawMessage) int {
 	raw, present := obj["warning"]
 	if !present {
-		return stdout, 0
+		return 0
 	}
 	var warning string
 	if err := json.Unmarshal(raw, &warning); err != nil {
-		return stdout, 0
+		return 0
 	}
 	truncated, dropped := truncateText(warning, maxResultTextBytes)
 	if dropped == 0 {
-		return stdout, 0
+		return 0
 	}
 	obj["warning"] = mustRawString(truncated)
-	return encodeStdoutObject(obj, stdout), dropped
+	return dropped
 }
 
-// dropSnapshotFiles removes snapshot.files, keeping the snapshot's identity
-// fields, and records the drop in the result's `warning` so it is visible
-// server-side (the warning is persisted to the job's errorLog) rather than only
-// in a log line on the endpoint. Reports the number of entries dropped and
-// whether stdout was a JSON object at all.
-func dropSnapshotFiles(stdout string) (string, int, bool) {
-	obj, ok := decodeStdoutObject(stdout)
-	if !ok {
-		return stdout, 0, false
-	}
+// emptySnapshotFiles replaces snapshot.files with an empty array and records
+// the drop in the result's `warning`, so it is visible server-side (the warning
+// is persisted to the job's errorLog) rather than only in an endpoint log line.
+// Reports the number of entries dropped and whether anything was dropped.
+func emptySnapshotFiles(obj map[string]json.RawMessage) (int, bool) {
 	rawSnap, present := obj["snapshot"]
 	if !present {
-		return stdout, 0, true
+		return 0, false
 	}
 	var snap map[string]json.RawMessage
 	if err := json.Unmarshal(rawSnap, &snap); err != nil || snap == nil {
-		return stdout, 0, true
+		return 0, false
+	}
+	raw, hasFiles := snap["files"]
+	if !hasFiles {
+		return 0, false
 	}
 	var files []json.RawMessage
-	if raw, hasFiles := snap["files"]; hasFiles {
-		if err := json.Unmarshal(raw, &files); err != nil {
-			files = nil
-		}
+	if err := json.Unmarshal(raw, &files); err != nil || len(files) == 0 {
+		return 0, false
 	}
-	if len(files) == 0 {
-		return stdout, 0, true
-	}
-
-	kept := make(map[string]json.RawMessage, len(snapshotIdentityKeys))
-	for _, key := range snapshotIdentityKeys {
-		if v, exists := snap[key]; exists {
-			kept[key] = v
-		}
-	}
-	rawKept, err := json.Marshal(kept)
+	snap["files"] = json.RawMessage("[]")
+	rebuilt, err := json.Marshal(snap)
 	if err != nil {
-		return stdout, 0, true
+		return 0, false
 	}
-	obj["snapshot"] = rawKept
+	obj["snapshot"] = rebuilt
 	obj["warning"] = mustRawString(appendResultWarning(obj["warning"], fmt.Sprintf(
 		"snapshot file index omitted (%d entries): the result exceeded the %d byte agent IPC limit, so per-file restore browsing is unavailable for this snapshot",
 		len(files), ipc.MaxMessageSize)))
-	return encodeStdoutObject(obj, stdout), len(files), true
+	return len(files), true
 }
 
-// reduceToIdentity strips stdout down to the terminal-status identity fields.
-func reduceToIdentity(stdout string) (string, bool) {
+// dropBulkFields removes every top-level container field whose encoded size
+// exceeds bulkFieldThreshold — the per-file arrays (restore's failedFiles /
+// warnings, verify's failedFiles) that are unbounded for the same reason
+// Snapshot.Files is. `snapshot` is exempt: emptySnapshotFiles already handled
+// its bulk and the rest of it is the identity the server needs. Returns the
+// keys dropped, sorted for a deterministic note, and records them in `warning`.
+func dropBulkFields(obj map[string]json.RawMessage) []string {
+	var dropped []string
+	for key, raw := range obj {
+		if key == "snapshot" || len(raw) <= bulkFieldThreshold {
+			continue
+		}
+		if !isJSONContainer(raw) {
+			continue
+		}
+		delete(obj, key)
+		dropped = append(dropped, key)
+	}
+	if len(dropped) == 0 {
+		return nil
+	}
+	sort.Strings(dropped)
+	obj["warning"] = mustRawString(appendResultWarning(obj["warning"], fmt.Sprintf(
+		"detail field(s) omitted (%s): the result exceeded the %d byte agent IPC limit",
+		strings.Join(dropped, ", "), ipc.MaxMessageSize)))
+	return dropped
+}
+
+// isJSONContainer reports whether raw encodes a JSON array or object — the only
+// shapes that can grow without bound. Scalars are always kept: they are the
+// summary counters the server persists (filesRestored, filesFailed, errorCount).
+func isJSONContainer(raw json.RawMessage) bool {
+	for _, b := range raw {
+		switch b {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '[', '{':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// reduceToScalars strips stdout down to its scalar fields plus the snapshot's
+// identity. Keeping every scalar — rather than an enumerated allow-list — is
+// what stops this tier from silently zeroing a counter the server reads
+// (filesRestored, filesFailed, errorCount, …) on a command shape it never
+// anticipated.
+func reduceToScalars(stdout string) (string, bool) {
 	obj, ok := decodeStdoutObject(stdout)
 	if !ok {
 		return stdout, false
 	}
-	kept := make(map[string]json.RawMessage, len(resultIdentityKeys)+1)
-	for _, key := range resultIdentityKeys {
-		if v, exists := obj[key]; exists {
-			kept[key] = v
+	var containers []string
+	kept := make(map[string]json.RawMessage, len(obj))
+	for key, raw := range obj {
+		if isJSONContainer(raw) {
+			containers = append(containers, key)
+			continue
 		}
+		kept[key] = raw
 	}
 	// Keep the snapshot's identity — without it the server records no
 	// providerSnapshotId and the successful run yields no restore point.
 	if rawSnap, present := obj["snapshot"]; present {
 		var snap map[string]json.RawMessage
 		if err := json.Unmarshal(rawSnap, &snap); err == nil && snap != nil {
-			identity := make(map[string]json.RawMessage, len(snapshotIdentityKeys))
+			identity := make(map[string]json.RawMessage, len(snapshotIdentityKeys)+1)
 			for _, key := range snapshotIdentityKeys {
 				if v, exists := snap[key]; exists {
 					identity[key] = v
 				}
 			}
+			identity["files"] = json.RawMessage("[]")
 			if rawIdentity, err := json.Marshal(identity); err == nil {
 				kept["snapshot"] = rawIdentity
 			}
 		}
 	}
-	// A pathological identity field (e.g. a megabyte-long snapshot id) would
-	// keep this tier over budget; bound every retained string.
+	if len(containers) > 0 {
+		sort.Strings(containers)
+		kept["warning"] = mustRawString(appendResultWarning(kept["warning"], fmt.Sprintf(
+			"detail field(s) omitted (%s): the result exceeded the %d byte agent IPC limit",
+			strings.Join(containers, ", "), ipc.MaxMessageSize)))
+	}
+	// A pathological scalar (e.g. a megabyte-long snapshot id) would keep this
+	// tier over budget; bound every retained string.
 	for key, raw := range kept {
 		var s string
 		if err := json.Unmarshal(raw, &s); err != nil {
@@ -338,6 +410,24 @@ func reduceToIdentity(stdout string) (string, bool) {
 		}
 	}
 	return encodeStdoutObject(kept, stdout), true
+}
+
+// oversizeFailureResult replaces a result whose body cannot be summarised (a
+// stdout that is not a JSON object, e.g. backup_list's array) with an explicit
+// failure. A terminal status still lands — the point of #3001 — but an empty
+// body is never handed back under Success: true, where the server would read it
+// as a complete, empty answer.
+func oversizeFailureResult(result backupipc.BackupCommandResult) backupipc.BackupCommandResult {
+	// Size is captured before the fields are cleared — reporting it after would
+	// print the size of the replacement, not of what was dropped.
+	original := len(result.Stdout) + len(result.Stderr)
+	result.Stdout = ""
+	result.Success = false
+	result.Stderr = fmt.Sprintf(
+		"backup helper result exceeded the %d byte agent IPC limit (%d bytes) and could not be summarised; the command may have succeeded but its output could not be delivered",
+		ipc.MaxMessageSize, original)
+	result.CommandID, _ = truncateText(result.CommandID, maxLastResortFieldBytes)
+	return result
 }
 
 // lastResortStdout builds a minimal terminal-status object from whatever can

--- a/agent/cmd/breeze-backup/result_bounds.go
+++ b/agent/cmd/breeze-backup/result_bounds.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/breeze-rmm/agent/internal/backupipc"
+	"github.com/breeze-rmm/agent/internal/ipc"
+	"github.com/breeze-rmm/agent/internal/logging"
+)
+
+// Issue #3001: a backup run's terminal result is unbounded, but the IPC frame
+// is not. A 123k-file run produced a 64 MB result against the 16 MiB
+// ipc.MaxMessageSize cap; conn.Send rejected it, the result was dropped
+// entirely, and the backup_jobs row stayed `running` until the stale-backup
+// reaper failed it 15 minutes later — for a backup that had SUCCEEDED.
+//
+// The failure mode scales perversely: the bigger/worse a run goes, the more
+// likely its outcome never arrives. So the terminal status is treated as the
+// one thing that must always land. Everything else (per-file index, warning
+// text, stderr detail) is dropped in tiers until the payload fits.
+//
+// Deliberately NOT fixed by raising ipc.MaxMessageSize: the payload has to be
+// bounded regardless, and a bigger cap only moves the cliff.
+
+const (
+	// resultEnvelopeHeadroom reserves room for the ipc.Envelope fields wrapped
+	// around the marshalled result payload (id, seq, type, hmac) plus slack.
+	// Payload is a json.RawMessage, so the envelope adds those fields' bytes
+	// without re-escaping the payload itself.
+	resultEnvelopeHeadroom = 64 * 1024
+
+	// resultPayloadBudget is the largest marshalled BackupCommandResult we will
+	// hand to conn.Send.
+	resultPayloadBudget = ipc.MaxMessageSize - resultEnvelopeHeadroom
+
+	// maxResultTextBytes caps free-text fields (warning, stderr) that are built
+	// by joining per-file errors. summarizeUploadFailures already caps the
+	// number of detail entries it renders, but a hard-failed run routes
+	// errors.Join(<every per-file error>) straight through fail(err.Error()),
+	// which nothing bounds. Both land in DB text columns and the UI.
+	maxResultTextBytes = 8 * 1024
+
+	// maxLastResortFieldBytes bounds every string in the last-resort result so
+	// the "always fits" postcondition is total, not merely likely.
+	maxLastResortFieldBytes = 1024
+)
+
+// snapshotIdentityKeys are the snapshot fields kept when the per-file index is
+// dropped: enough for the server to record a usable restore point
+// (backupResultPersistence reads snapshot.id / .timestamp / .size).
+var snapshotIdentityKeys = []string{"id", "timestamp", "size", "formatVersion", "baseSnapshotId"}
+
+// resultIdentityKeys are the top-level result fields kept in the reduced tier —
+// the terminal status and the counters the server persists. Notably errorCount
+// survives even when every individual failure detail is gone.
+var resultIdentityKeys = []string{
+	"id", "jobId", "snapshotId", "status", "backupType",
+	"startedAt", "completedAt",
+	"filesBackedUp", "bytesBackedUp",
+	"referencedFiles", "referencedBytes",
+	"errorCount", "warning",
+}
+
+// fitBackupResultToIPC returns result bounded so its marshalled payload fits
+// resultPayloadBudget, degrading in tiers and stopping at the first that fits:
+//
+//  1. always: truncate the free-text warning/stderr fields;
+//  2. drop the per-file snapshot index (snapshot.files), keeping snapshot
+//     identity — this is what actually blows the budget on a real run;
+//  3. reduce stdout to the terminal-status identity fields only;
+//  4. last resort: a hand-built minimal status object.
+//
+// The second return value describes what was dropped, and is "" when the result
+// was already within budget. It is non-empty exactly when the caller should log
+// loudly — a degraded result is a real (if survivable) loss of detail.
+func fitBackupResultToIPC(result backupipc.BackupCommandResult) (backupipc.BackupCommandResult, string) {
+	var notes []string
+
+	// Tier 1 — always applied, and cheap (no JSON parse). Bounding the failure
+	// detail BEFORE marshalling is the primary fix; the tiers below are the
+	// defensive net behind it. Stderr is the unbounded one on this path: a hard
+	// failure routes errors.Join(<every per-file error>) through
+	// fail(err.Error()), which nothing caps.
+	if truncated, dropped := truncateText(result.Stderr, maxResultTextBytes); dropped > 0 {
+		result.Stderr = truncated
+		notes = append(notes, fmt.Sprintf("stderr truncated (%d bytes dropped)", dropped))
+	}
+	if fits(result) {
+		return result, joinNotes(notes)
+	}
+
+	// Tier 2 — drop the per-file snapshot index and cap the warning text. Only
+	// reached when the result is actually oversize, so the ordinary path never
+	// pays for parsing a multi-megabyte stdout.
+	//
+	// The index is dropped whole rather than truncated: the server sets
+	// hasIndexedFiles from snapshot.files.length, so a partial index would
+	// present as a complete browsable file list that is silently missing
+	// entries.
+	if stdout, warnDropped := boundStdoutWarning(result.Stdout); warnDropped > 0 {
+		result.Stdout = stdout
+		notes = append(notes, fmt.Sprintf("warning truncated (%d bytes dropped)", warnDropped))
+	}
+	if reduced, dropped, ok := dropSnapshotFiles(result.Stdout); ok {
+		result.Stdout = reduced
+		if dropped > 0 {
+			notes = append(notes, fmt.Sprintf("snapshot file index dropped (%d entries, result exceeded the %d byte IPC limit)", dropped, ipc.MaxMessageSize))
+		}
+		if fits(result) {
+			return result, joinNotes(notes)
+		}
+	}
+
+	// Tier 3 — terminal status + counters only.
+	if reduced, ok := reduceToIdentity(result.Stdout); ok {
+		result.Stdout = reduced
+		notes = append(notes, "result reduced to terminal status only")
+		if fits(result) {
+			return result, joinNotes(notes)
+		}
+	}
+
+	// Tier 4 — last resort. Every field is bounded by construction, so this
+	// always fits: a terminal status must land even when nothing else can.
+	notes = append(notes, "result replaced with a minimal terminal status")
+	result.Stdout = lastResortStdout(result.Stdout)
+	result.Stderr, _ = truncateText(result.Stderr, maxLastResortFieldBytes)
+	result.CommandID, _ = truncateText(result.CommandID, maxLastResortFieldBytes)
+	return result, joinNotes(notes)
+}
+
+// sendBackupResult sends a terminal backup_result envelope, bounding the
+// payload first so an oversize result degrades instead of being dropped.
+//
+// A dropped terminal result is invisible server-side — the job just stops
+// reporting — so both the degradation and any residual send failure are logged
+// at ERROR under component=backup, which puts them above the default warn
+// log-shipping threshold and therefore on the server.
+func sendBackupResult(conn *ipc.Conn, envelopeID string, result backupipc.BackupCommandResult) error {
+	log := logging.L("backup")
+	fitted, degraded := fitBackupResultToIPC(result)
+	if degraded != "" {
+		// Sizes are reported from the raw fields rather than a full marshal of
+		// the original: re-marshalling tens of megabytes just to populate a log
+		// field is not worth it at the tail of a backup run.
+		log.Error("backup result payload exceeded the IPC limit and was degraded to fit",
+			"commandId", result.CommandID,
+			"degraded", degraded,
+			"originalStdoutBytes", len(result.Stdout),
+			"originalStderrBytes", len(result.Stderr),
+			"sentBytes", marshalledSize(fitted),
+			"limitBytes", ipc.MaxMessageSize,
+		)
+	}
+	if err := conn.SendTyped(envelopeID, backupipc.TypeBackupResult, fitted); err != nil {
+		log.Error("failed to send backup result — the job will have no terminal status server-side",
+			"commandId", result.CommandID,
+			"envelopeId", envelopeID,
+			"sentBytes", marshalledSize(fitted),
+			"error", err.Error(),
+		)
+		return err
+	}
+	return nil
+}
+
+// --- helpers ---
+
+// fits reports whether result's marshalled payload is within budget. The raw
+// text fields are checked first as a cheap lower bound — JSON string encoding
+// never shrinks its input — so an oversize result is rejected without
+// marshalling tens of megabytes on the endpoint.
+func fits(result backupipc.BackupCommandResult) bool {
+	if len(result.Stdout)+len(result.Stderr)+len(result.CommandID) > resultPayloadBudget {
+		return false
+	}
+	return marshalledSize(result) <= resultPayloadBudget
+}
+
+// marshalledSize returns the marshalled byte length of result, or -1 when it
+// cannot be marshalled at all (which conn.Send would reject anyway).
+func marshalledSize(result backupipc.BackupCommandResult) int {
+	data, err := json.Marshal(result)
+	if err != nil {
+		return -1
+	}
+	return len(data)
+}
+
+// truncateText clips s to at most max bytes on a UTF-8 rune boundary, returning
+// the clipped string and how many bytes were dropped. The head is kept: for a
+// joined per-file error list the first entries are the representative sample.
+func truncateText(s string, max int) (string, int) {
+	if len(s) <= max {
+		return s, 0
+	}
+	dropped := len(s) - max
+	cut := max
+	// Back off to a rune boundary so the field stays valid UTF-8 (invalid
+	// UTF-8 would be re-encoded by json.Marshal as replacement chars).
+	for cut > 0 && !utf8Start(s[cut]) {
+		cut--
+	}
+	return s[:cut] + fmt.Sprintf("… (+%d bytes truncated)", dropped), dropped
+}
+
+// utf8Start reports whether b can start a UTF-8 encoded rune (i.e. it is not a
+// 10xxxxxx continuation byte).
+func utf8Start(b byte) bool { return b&0xC0 != 0x80 }
+
+// decodeStdoutObject parses stdout as a JSON object. Non-object stdout (a bare
+// string, an array, a non-JSON blob) is left to the caller's fallback tiers.
+func decodeStdoutObject(stdout string) (map[string]json.RawMessage, bool) {
+	if stdout == "" {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &obj); err != nil || obj == nil {
+		return nil, false
+	}
+	return obj, true
+}
+
+func encodeStdoutObject(obj map[string]json.RawMessage, fallback string) string {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return fallback
+	}
+	return string(data)
+}
+
+// boundStdoutWarning truncates the result's `warning` field in place, returning
+// the rewritten stdout and how many bytes were dropped.
+func boundStdoutWarning(stdout string) (string, int) {
+	obj, ok := decodeStdoutObject(stdout)
+	if !ok {
+		return stdout, 0
+	}
+	raw, present := obj["warning"]
+	if !present {
+		return stdout, 0
+	}
+	var warning string
+	if err := json.Unmarshal(raw, &warning); err != nil {
+		return stdout, 0
+	}
+	truncated, dropped := truncateText(warning, maxResultTextBytes)
+	if dropped == 0 {
+		return stdout, 0
+	}
+	obj["warning"] = mustRawString(truncated)
+	return encodeStdoutObject(obj, stdout), dropped
+}
+
+// dropSnapshotFiles removes snapshot.files, keeping the snapshot's identity
+// fields, and records the drop in the result's `warning` so it is visible
+// server-side (the warning is persisted to the job's errorLog) rather than only
+// in a log line on the endpoint. Reports the number of entries dropped and
+// whether stdout was a JSON object at all.
+func dropSnapshotFiles(stdout string) (string, int, bool) {
+	obj, ok := decodeStdoutObject(stdout)
+	if !ok {
+		return stdout, 0, false
+	}
+	rawSnap, present := obj["snapshot"]
+	if !present {
+		return stdout, 0, true
+	}
+	var snap map[string]json.RawMessage
+	if err := json.Unmarshal(rawSnap, &snap); err != nil || snap == nil {
+		return stdout, 0, true
+	}
+	var files []json.RawMessage
+	if raw, hasFiles := snap["files"]; hasFiles {
+		if err := json.Unmarshal(raw, &files); err != nil {
+			files = nil
+		}
+	}
+	if len(files) == 0 {
+		return stdout, 0, true
+	}
+
+	kept := make(map[string]json.RawMessage, len(snapshotIdentityKeys))
+	for _, key := range snapshotIdentityKeys {
+		if v, exists := snap[key]; exists {
+			kept[key] = v
+		}
+	}
+	rawKept, err := json.Marshal(kept)
+	if err != nil {
+		return stdout, 0, true
+	}
+	obj["snapshot"] = rawKept
+	obj["warning"] = mustRawString(appendResultWarning(obj["warning"], fmt.Sprintf(
+		"snapshot file index omitted (%d entries): the result exceeded the %d byte agent IPC limit, so per-file restore browsing is unavailable for this snapshot",
+		len(files), ipc.MaxMessageSize)))
+	return encodeStdoutObject(obj, stdout), len(files), true
+}
+
+// reduceToIdentity strips stdout down to the terminal-status identity fields.
+func reduceToIdentity(stdout string) (string, bool) {
+	obj, ok := decodeStdoutObject(stdout)
+	if !ok {
+		return stdout, false
+	}
+	kept := make(map[string]json.RawMessage, len(resultIdentityKeys)+1)
+	for _, key := range resultIdentityKeys {
+		if v, exists := obj[key]; exists {
+			kept[key] = v
+		}
+	}
+	// Keep the snapshot's identity — without it the server records no
+	// providerSnapshotId and the successful run yields no restore point.
+	if rawSnap, present := obj["snapshot"]; present {
+		var snap map[string]json.RawMessage
+		if err := json.Unmarshal(rawSnap, &snap); err == nil && snap != nil {
+			identity := make(map[string]json.RawMessage, len(snapshotIdentityKeys))
+			for _, key := range snapshotIdentityKeys {
+				if v, exists := snap[key]; exists {
+					identity[key] = v
+				}
+			}
+			if rawIdentity, err := json.Marshal(identity); err == nil {
+				kept["snapshot"] = rawIdentity
+			}
+		}
+	}
+	// A pathological identity field (e.g. a megabyte-long snapshot id) would
+	// keep this tier over budget; bound every retained string.
+	for key, raw := range kept {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			continue
+		}
+		if bounded, dropped := truncateText(s, maxResultTextBytes); dropped > 0 {
+			kept[key] = mustRawString(bounded)
+		}
+	}
+	return encodeStdoutObject(kept, stdout), true
+}
+
+// lastResortStdout builds a minimal terminal-status object from whatever can
+// still be recovered from stdout. Every field is bounded by construction.
+func lastResortStdout(stdout string) string {
+	minimal := map[string]string{}
+	if obj, ok := decodeStdoutObject(stdout); ok {
+		for _, key := range []string{"id", "jobId", "status", "snapshotId"} {
+			var s string
+			if raw, exists := obj[key]; exists && json.Unmarshal(raw, &s) == nil {
+				minimal[key], _ = truncateText(s, maxLastResortFieldBytes)
+			}
+		}
+		if rawSnap, exists := obj["snapshot"]; exists {
+			var snap struct {
+				ID string `json:"id"`
+			}
+			if json.Unmarshal(rawSnap, &snap) == nil && snap.ID != "" {
+				minimal["snapshotId"], _ = truncateText(snap.ID, maxLastResortFieldBytes)
+			}
+		}
+	}
+	minimal["warning"] = fmt.Sprintf(
+		"backup result exceeded the %d byte agent IPC limit and was reduced to a terminal status; detail was dropped",
+		ipc.MaxMessageSize)
+	data, err := json.Marshal(minimal)
+	if err != nil {
+		return `{"warning":"backup result could not be encoded"}`
+	}
+	return string(data)
+}
+
+// appendResultWarning appends fragment to an existing JSON-encoded warning,
+// joining with "; " — mirroring the agent-side appendWarning convention.
+func appendResultWarning(existing json.RawMessage, fragment string) string {
+	var current string
+	if len(existing) > 0 {
+		_ = json.Unmarshal(existing, &current)
+	}
+	if current == "" {
+		return fragment
+	}
+	bounded, _ := truncateText(current, maxResultTextBytes)
+	return bounded + "; " + fragment
+}
+
+// mustRawString encodes s as a JSON string. json.Marshal of a string cannot
+// fail, so the error branch is unreachable and returns a valid empty string.
+func mustRawString(s string) json.RawMessage {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return json.RawMessage(`""`)
+	}
+	return data
+}
+
+func joinNotes(notes []string) string {
+	switch len(notes) {
+	case 0:
+		return ""
+	case 1:
+		return notes[0]
+	}
+	out := notes[0]
+	for _, n := range notes[1:] {
+		out += "; " + n
+	}
+	return out
+}

--- a/agent/cmd/breeze-backup/result_bounds_test.go
+++ b/agent/cmd/breeze-backup/result_bounds_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup"
+	"github.com/breeze-rmm/agent/internal/backupipc"
+	"github.com/breeze-rmm/agent/internal/ipc"
+)
+
+const (
+	// fieldReportFileCount / fieldReportErrorCount are the customer's actual
+	// numbers from #3001 (123,284 files / 35.4 GB / 317 per-file errors), used
+	// by the reproduction test.
+	fieldReportFileCount  = 123284
+	fieldReportErrorCount = 317
+	// oversizeFileCount is the smaller fixture the behavioural tests use: it
+	// still marshals well past ipc.MaxMessageSize (~25 MB) while keeping these
+	// tests off multi-megabyte re-marshals under -race.
+	oversizeFileCount = 60000
+)
+
+// buildLargeRunJob synthesises a completed backup_run job shaped like the field
+// report in issue #3001: backed-up files each carrying an absolute Windows
+// source path, a snapshot-prefixed backup path and a SHA-256 checksum, plus a
+// few hundred per-file upload failures.
+func buildLargeRunJob(files, failures int) *backup.BackupJob {
+	snap := &backup.Snapshot{
+		ID:            "snapshot-20260801T125517Z-5edfcd7e",
+		Timestamp:     time.Date(2026, 8, 1, 12, 55, 17, 0, time.UTC),
+		Size:          35421941515,
+		FormatVersion: 2,
+		Files:         make([]backup.SnapshotFile, 0, files),
+	}
+	for i := 0; i < files; i++ {
+		src := fmt.Sprintf(`C:\Users\jdoe\AppData\Local\Microsoft\Edge\User Data\Default\Cache\Cache_Data\f_%06x`, i)
+		snap.Files = append(snap.Files, backup.SnapshotFile{
+			SourcePath: src,
+			BackupPath: "snapshot-20260801T125517Z-5edfcd7e/C_/Users/jdoe/AppData/Local/Microsoft/Edge/User Data/Default/Cache/Cache_Data/f_" + fmt.Sprintf("%06x", i),
+			Size:       int64(4096 + i),
+			ModTime:    time.Date(2026, 7, 14, 9, 12, 33, 0, time.UTC),
+			Checksum:   strings.Repeat("a", 64),
+		})
+	}
+	uploadFailures := make([]error, 0, failures)
+	for i := 0; i < failures; i++ {
+		uploadFailures = append(uploadFailures, fmt.Errorf(
+			`upload %s: The process cannot access the file because it is being used by another process.`,
+			fmt.Sprintf(`C:\Users\jdoe\AppData\Local\Packages\Microsoft.Windows.Search_cw5n1h2txyewy\LocalState\AppIconCache\100\locked_%04d.dat`, i)))
+	}
+	snap.UploadFailures = uploadFailures
+
+	job := &backup.BackupJob{
+		ID:              "job-20260801T125454Z-1f91465e",
+		StartedAt:       time.Date(2026, 8, 1, 12, 54, 54, 0, time.UTC),
+		CompletedAt:     time.Date(2026, 8, 1, 16, 36, 3, 0, time.UTC),
+		Snapshot:        snap,
+		FilesBackedUp:   files,
+		BytesBackedUp:   35421941515,
+		Status:          "completed",
+		ErrorCount:      failures,
+		Warning:         fmt.Sprintf("%d of %d files failed to upload: ...", failures, files),
+		ReferencedFiles: 121798,
+		ReferencedBytes: 34929299357,
+	}
+	return job
+}
+
+func mustRunResult(t *testing.T, job *backup.BackupJob) backupipc.BackupCommandResult {
+	t.Helper()
+	data, err := json.Marshal(job)
+	if err != nil {
+		t.Fatalf("marshal job: %v", err)
+	}
+	return backupipc.BackupCommandResult{
+		CommandID: "822e0c7f-7e35-43e6-b0fc-0912a5c0d221",
+		Success:   true,
+		Stdout:    string(data),
+	}
+}
+
+func payloadSize(t *testing.T, result backupipc.BackupCommandResult) int {
+	t.Helper()
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	return len(data)
+}
+
+// TestUnboundedRunResultExceedsIPCLimit reproduces #3001: the terminal result
+// for a large run does not fit the IPC frame, so conn.Send rejects it and the
+// backup_jobs row is left `running` until the stale-backup reaper fails it —
+// even though the run succeeded.
+//
+// It also pins WHICH field is responsible. The issue text blames the 317-entry
+// per-file failure list, but Snapshot.UploadFailures is `json:"-"` and never
+// reaches the wire; the payload is dominated by the per-file snapshot manifest
+// (Snapshot.Files), one entry per backed-up file.
+func TestUnboundedRunResultExceedsIPCLimit(t *testing.T) {
+	job := buildLargeRunJob(fieldReportFileCount, fieldReportErrorCount)
+	result := mustRunResult(t, job)
+
+	if got := payloadSize(t, result); got <= ipc.MaxMessageSize {
+		t.Fatalf("expected the unbounded result to exceed the IPC cap, got %d <= %d", got, ipc.MaxMessageSize)
+	}
+
+	// Failure detail is not what blows the budget: with the file index removed
+	// the same job marshals comfortably under the cap.
+	noFiles := *job
+	snapCopy := *job.Snapshot
+	snapCopy.Files = nil
+	noFiles.Snapshot = &snapCopy
+	if got := payloadSize(t, mustRunResult(t, &noFiles)); got > ipc.MaxMessageSize {
+		t.Fatalf("expected the file index to be the dominant field, but the result is still %d bytes without it", got)
+	}
+}
+
+// TestFitBackupResultBoundsLargeRun is the core contract: whatever the run
+// produced, the result handed to conn.Send fits the frame.
+func TestFitBackupResultBoundsLargeRun(t *testing.T) {
+	job := buildLargeRunJob(oversizeFileCount, fieldReportErrorCount)
+	fitted, degraded := fitBackupResultToIPC(mustRunResult(t, job))
+
+	if degraded == "" {
+		t.Fatal("expected fitBackupResultToIPC to report that it degraded the payload")
+	}
+	if got := payloadSize(t, fitted); got > resultPayloadBudget {
+		t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
+	}
+}
+
+// TestFitBackupResultPreservesTerminalStatus pins the fields that decide
+// whether the server records a completed job with a usable restore point:
+// terminal status, snapshot id, and the byte/file counters must all survive
+// truncation. Losing error detail is acceptable; losing the fact that the
+// backup succeeded is not.
+func TestFitBackupResultPreservesTerminalStatus(t *testing.T) {
+	job := buildLargeRunJob(oversizeFileCount, fieldReportErrorCount)
+	fitted, _ := fitBackupResultToIPC(mustRunResult(t, job))
+
+	if !fitted.Success {
+		t.Error("expected Success to survive truncation")
+	}
+	if fitted.CommandID != "822e0c7f-7e35-43e6-b0fc-0912a5c0d221" {
+		t.Errorf("expected commandId to survive truncation, got %q", fitted.CommandID)
+	}
+
+	var out struct {
+		ID            string `json:"id"`
+		Status        string `json:"status"`
+		FilesBackedUp int    `json:"filesBackedUp"`
+		BytesBackedUp int64  `json:"bytesBackedUp"`
+		ErrorCount    int    `json:"errorCount"`
+		Warning       string `json:"warning"`
+		Snapshot      struct {
+			ID   string `json:"id"`
+			Size int64  `json:"size"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal([]byte(fitted.Stdout), &out); err != nil {
+		t.Fatalf("fitted stdout is not valid JSON: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("expected status completed, got %q", out.Status)
+	}
+	if out.Snapshot.ID != "snapshot-20260801T125517Z-5edfcd7e" {
+		t.Errorf("expected snapshot id to survive, got %q", out.Snapshot.ID)
+	}
+	if out.ID != "job-20260801T125454Z-1f91465e" {
+		t.Errorf("expected job id to survive, got %q", out.ID)
+	}
+	if out.FilesBackedUp != oversizeFileCount {
+		t.Errorf("expected filesBackedUp %d, got %d", oversizeFileCount, out.FilesBackedUp)
+	}
+	if out.BytesBackedUp != 35421941515 {
+		t.Errorf("expected bytesBackedUp 35421941515, got %d", out.BytesBackedUp)
+	}
+	if out.Snapshot.Size != 35421941515 {
+		t.Errorf("expected snapshot size to survive, got %d", out.Snapshot.Size)
+	}
+	// The total error count is the whole point of the errorCount column: it
+	// must survive even when every individual failure detail is dropped.
+	if out.ErrorCount != fieldReportErrorCount {
+		t.Errorf("expected errorCount %d to survive, got %d", fieldReportErrorCount, out.ErrorCount)
+	}
+	// The user must be able to tell that the file index was dropped rather
+	// than silently believe the snapshot has no indexed files.
+	if !strings.Contains(out.Warning, "file index") {
+		t.Errorf("expected the warning to record the dropped file index, got %q", out.Warning)
+	}
+}
+
+// TestFitBackupResultKeepsFileIndexWhenItFits guards against over-truncation:
+// an ordinary run must still ship its per-file index, which is what the server
+// turns into the browsable restore file list.
+func TestFitBackupResultKeepsFileIndexWhenItFits(t *testing.T) {
+	job := buildLargeRunJob(500, 0)
+	fitted, degraded := fitBackupResultToIPC(mustRunResult(t, job))
+
+	if degraded != "" {
+		t.Errorf("expected no degradation for a small run, got %q", degraded)
+	}
+	var out struct {
+		Snapshot struct {
+			Files []struct {
+				SourcePath string `json:"sourcePath"`
+			} `json:"files"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal([]byte(fitted.Stdout), &out); err != nil {
+		t.Fatalf("fitted stdout is not valid JSON: %v", err)
+	}
+	if len(out.Snapshot.Files) != 500 {
+		t.Errorf("expected all 500 file entries to survive, got %d", len(out.Snapshot.Files))
+	}
+}
+
+// TestFitBackupResultBoundsOversizeStderr covers the failure-path twin of the
+// same bug: a hard failure returns errors.Join of every per-file error through
+// fail(err.Error()), which is unbounded for the same reason.
+func TestFitBackupResultBoundsOversizeStderr(t *testing.T) {
+	huge := strings.Repeat("open C:\\Users\\jdoe\\file.dat: access is denied; ", 900000)
+	result := backupipc.BackupCommandResult{CommandID: "cmd-1", Success: false, Stderr: huge}
+
+	fitted, degraded := fitBackupResultToIPC(result)
+	if degraded == "" {
+		t.Error("expected an oversize stderr to be reported as degraded")
+	}
+	if got := payloadSize(t, fitted); got > resultPayloadBudget {
+		t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
+	}
+	if fitted.Stderr == "" {
+		t.Error("expected a truncated stderr, not an empty one")
+	}
+	if !strings.HasPrefix(fitted.Stderr, "open C:\\Users\\jdoe\\file.dat") {
+		t.Errorf("expected the leading stderr detail to be kept, got %.80q", fitted.Stderr)
+	}
+}
+
+// TestFitBackupResultAlwaysFits is the total-postcondition test: no matter how
+// pathological the payload, the returned result fits the frame, because a
+// terminal status must always land.
+func TestFitBackupResultAlwaysFits(t *testing.T) {
+	cases := map[string]backupipc.BackupCommandResult{
+		"non-json stdout": {
+			CommandID: "cmd-1",
+			Success:   true,
+			Stdout:    strings.Repeat("x", ipc.MaxMessageSize+1024),
+		},
+		"json array stdout": {
+			CommandID: "cmd-2",
+			Success:   true,
+			Stdout:    "[" + strings.Repeat(`"`+strings.Repeat("y", 1024)+`",`, 20000) + `"tail"]`,
+		},
+		"giant warning only": {
+			CommandID: "cmd-3",
+			Success:   true,
+			Stdout:    `{"status":"completed","snapshot":{"id":"snap-1"},"warning":"` + strings.Repeat("w", ipc.MaxMessageSize) + `"}`,
+		},
+		"empty": {CommandID: "cmd-4", Success: true},
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			fitted, _ := fitBackupResultToIPC(in)
+			if got := payloadSize(t, fitted); got > resultPayloadBudget {
+				t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
+			}
+			if fitted.CommandID != in.CommandID {
+				t.Errorf("expected commandId %q to survive, got %q", in.CommandID, fitted.CommandID)
+			}
+			if fitted.Success != in.Success {
+				t.Errorf("expected success %v to survive, got %v", in.Success, fitted.Success)
+			}
+		})
+	}
+}
+
+// TestSendBackupResultDeliversOversizeRun is the end-to-end proof over a real
+// ipc.Conn pair: before the fix conn.SendTyped returned "message too large" and
+// the agent received nothing at all. Now a terminal result arrives.
+func TestSendBackupResultDeliversOversizeRun(t *testing.T) {
+	serverNC, clientNC := net.Pipe()
+	defer serverNC.Close()
+	defer clientNC.Close()
+
+	sender := ipc.NewConn(clientNC)
+	receiver := ipc.NewConn(serverNC)
+
+	job := buildLargeRunJob(oversizeFileCount, fieldReportErrorCount)
+	result := mustRunResult(t, job)
+
+	sendErr := make(chan error, 1)
+	go func() { sendErr <- sendBackupResult(sender, "env-1", result) }()
+
+	receiver.SetReadDeadline(time.Now().Add(30 * time.Second))
+	env, err := receiver.Recv()
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	if err := <-sendErr; err != nil {
+		t.Fatalf("sendBackupResult: %v", err)
+	}
+	if env.Type != backupipc.TypeBackupResult {
+		t.Fatalf("expected %s envelope, got %s", backupipc.TypeBackupResult, env.Type)
+	}
+
+	var got backupipc.BackupCommandResult
+	if err := json.Unmarshal(env.Payload, &got); err != nil {
+		t.Fatalf("unmarshal result payload: %v", err)
+	}
+	if !got.Success {
+		t.Error("expected the delivered result to report success")
+	}
+	var out struct {
+		Status     string `json:"status"`
+		ErrorCount int    `json:"errorCount"`
+		Snapshot   struct {
+			ID string `json:"id"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal([]byte(got.Stdout), &out); err != nil {
+		t.Fatalf("delivered stdout is not valid JSON: %v", err)
+	}
+	if out.Status != "completed" || out.Snapshot.ID == "" || out.ErrorCount != fieldReportErrorCount {
+		t.Errorf("terminal status did not survive delivery: status=%q snapshotId=%q errorCount=%d",
+			out.Status, out.Snapshot.ID, out.ErrorCount)
+	}
+}

--- a/agent/cmd/breeze-backup/result_bounds_test.go
+++ b/agent/cmd/breeze-backup/result_bounds_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,6 +72,35 @@ func buildLargeRunJob(files, failures int) *backup.BackupJob {
 	return job
 }
 
+// Building and marshalling a 60k-entry manifest costs ~5s under -race, and
+// several tests need the identical input, so the marshalled stdout is built
+// once per package run. The fixtures are treated strictly read-only (Go strings
+// are immutable and fitBackupResultToIPC takes its argument by value).
+var (
+	oversizeRunOnce   sync.Once
+	oversizeRunStdout string
+	fieldRunOnce      sync.Once
+	fieldRunJob       *backup.BackupJob
+)
+
+// oversizeRunResult returns a backup_run result whose marshalled manifest is
+// comfortably past ipc.MaxMessageSize (~25 MB).
+func oversizeRunResult(t *testing.T) backupipc.BackupCommandResult {
+	t.Helper()
+	oversizeRunOnce.Do(func() {
+		data, err := json.Marshal(buildLargeRunJob(oversizeFileCount, fieldReportErrorCount))
+		if err != nil {
+			panic(err)
+		}
+		oversizeRunStdout = string(data)
+	})
+	return backupipc.BackupCommandResult{
+		CommandID: "822e0c7f-7e35-43e6-b0fc-0912a5c0d221",
+		Success:   true,
+		Stdout:    oversizeRunStdout,
+	}
+}
+
 func mustRunResult(t *testing.T, job *backup.BackupJob) backupipc.BackupCommandResult {
 	t.Helper()
 	data, err := json.Marshal(job)
@@ -103,7 +133,8 @@ func payloadSize(t *testing.T, result backupipc.BackupCommandResult) int {
 // reaches the wire; the payload is dominated by the per-file snapshot manifest
 // (Snapshot.Files), one entry per backed-up file.
 func TestUnboundedRunResultExceedsIPCLimit(t *testing.T) {
-	job := buildLargeRunJob(fieldReportFileCount, fieldReportErrorCount)
+	fieldRunOnce.Do(func() { fieldRunJob = buildLargeRunJob(fieldReportFileCount, fieldReportErrorCount) })
+	job := fieldRunJob
 	result := mustRunResult(t, job)
 
 	if got := payloadSize(t, result); got <= ipc.MaxMessageSize {
@@ -124,8 +155,7 @@ func TestUnboundedRunResultExceedsIPCLimit(t *testing.T) {
 // TestFitBackupResultBoundsLargeRun is the core contract: whatever the run
 // produced, the result handed to conn.Send fits the frame.
 func TestFitBackupResultBoundsLargeRun(t *testing.T) {
-	job := buildLargeRunJob(oversizeFileCount, fieldReportErrorCount)
-	fitted, degraded := fitBackupResultToIPC(mustRunResult(t, job))
+	fitted, degraded := fitBackupResultToIPC(oversizeRunResult(t))
 
 	if degraded == "" {
 		t.Fatal("expected fitBackupResultToIPC to report that it degraded the payload")
@@ -141,8 +171,7 @@ func TestFitBackupResultBoundsLargeRun(t *testing.T) {
 // truncation. Losing error detail is acceptable; losing the fact that the
 // backup succeeded is not.
 func TestFitBackupResultPreservesTerminalStatus(t *testing.T) {
-	job := buildLargeRunJob(oversizeFileCount, fieldReportErrorCount)
-	fitted, _ := fitBackupResultToIPC(mustRunResult(t, job))
+	fitted, _ := fitBackupResultToIPC(oversizeRunResult(t))
 
 	if !fitted.Success {
 		t.Error("expected Success to survive truncation")
@@ -241,6 +270,17 @@ func TestFitBackupResultBoundsOversizeStderr(t *testing.T) {
 	if !strings.HasPrefix(fitted.Stderr, "open C:\\Users\\jdoe\\file.dat") {
 		t.Errorf("expected the leading stderr detail to be kept, got %.80q", fitted.Stderr)
 	}
+	// Pin that TIER 1 did this, not tier 4's last-resort clamp. Without these
+	// two assertions the test passes with tier 1 deleted — tier 4 rescues it
+	// at a 16x smaller cap — and tier 1 is the "bound the detail before
+	// marshalling" half of the fix, so it must be independently required.
+	if len(fitted.Stderr) < maxResultTextBytes {
+		t.Errorf("expected ~%d bytes of stderr retained by tier 1, got %d (tier 4 clamp?)",
+			maxResultTextBytes, len(fitted.Stderr))
+	}
+	if !strings.HasPrefix(degraded, "stderr truncated") {
+		t.Errorf("expected the tier-1 stderr note, got %q", degraded)
+	}
 }
 
 // TestFitBackupResultAlwaysFits is the total-postcondition test: no matter how
@@ -312,8 +352,7 @@ func TestSendBackupResultDeliversOversizeRun(t *testing.T) {
 	sender := ipc.NewConn(clientNC)
 	receiver := ipc.NewConn(serverNC)
 
-	job := buildLargeRunJob(oversizeFileCount, fieldReportErrorCount)
-	result := mustRunResult(t, job)
+	result := oversizeRunResult(t)
 
 	sendErr := make(chan error, 1)
 	go func() { sendErr <- sendBackupResult(sender, "env-1", result) }()
@@ -454,8 +493,7 @@ func TestFitBackupResultRejectsUnsummarisableBody(t *testing.T) {
 // would leave a previous delivery's backup_snapshot_files rows in place while
 // hasIndexedFiles flipped to false — two states that then disagree.
 func TestEmptySnapshotFilesKeepsTheFilesKey(t *testing.T) {
-	job := buildLargeRunJob(oversizeFileCount, fieldReportErrorCount)
-	fitted, _ := fitBackupResultToIPC(mustRunResult(t, job))
+	fitted, _ := fitBackupResultToIPC(oversizeRunResult(t))
 
 	var out map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(fitted.Stdout), &out); err != nil {
@@ -516,5 +554,142 @@ func TestFitBackupResultDropsOversizeSystemStateManifest(t *testing.T) {
 	}
 	if !strings.Contains(out.Warning, "systemStateManifest") {
 		t.Errorf("expected the persisted warning to name the dropped manifest, got %q", out.Warning)
+	}
+}
+
+// TestFitBackupResultReducesToScalars exercises TIER 3, which tier 2 hides
+// whenever the bulk sits in one big container. Here the bulk is spread across
+// many containers that are each individually under bulkFieldThreshold, so tier
+// 2 drops nothing and tier 3 is what has to save the terminal status.
+//
+// Without this the whole reduceToScalars path is unexecuted: it could return an
+// empty object, or lose status/snapshotId/errorCount, with the suite still green.
+func TestFitBackupResultReducesToScalars(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`{"id":"job-1","status":"completed","filesBackedUp":42,"bytesBackedUp":999,` +
+		`"errorCount":317,"snapshot":{"id":"snapshot-1","size":999}`)
+	// Each container is just under the bulk threshold, so tier 2 skips them all.
+	chunk := strings.Repeat(`"x",`, 800) + `"x"`
+	for i := 0; i < 6000; i++ {
+		fmt.Fprintf(&b, `,"detail%04d":[%s]`, i, chunk)
+	}
+	b.WriteString("}")
+	in := backupipc.BackupCommandResult{CommandID: "cmd-scalars", Success: true, Stdout: b.String()}
+	if len(in.Stdout) <= resultPayloadBudget {
+		t.Fatalf("fixture must be oversize, got %d bytes", len(in.Stdout))
+	}
+
+	fitted, degraded := fitBackupResultToIPC(in)
+	if got := payloadSize(t, fitted); got > resultPayloadBudget {
+		t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
+	}
+	if !strings.Contains(degraded, "summary scalars") {
+		t.Fatalf("expected tier 3 to be the tier that fired, got %q", degraded)
+	}
+	if !fitted.Success {
+		t.Error("expected success to survive tier 3")
+	}
+	var out struct {
+		ID            string          `json:"id"`
+		Status        string          `json:"status"`
+		FilesBackedUp int             `json:"filesBackedUp"`
+		BytesBackedUp int64           `json:"bytesBackedUp"`
+		ErrorCount    int             `json:"errorCount"`
+		Warning       string          `json:"warning"`
+		Detail0000    json.RawMessage `json:"detail0000"`
+		Snapshot      struct {
+			ID string `json:"id"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal([]byte(fitted.Stdout), &out); err != nil {
+		t.Fatalf("fitted stdout is not valid JSON: %v", err)
+	}
+	if out.Status != "completed" || out.ID != "job-1" || out.Snapshot.ID != "snapshot-1" {
+		t.Errorf("terminal identity did not survive tier 3: id=%q status=%q snapshotId=%q",
+			out.ID, out.Status, out.Snapshot.ID)
+	}
+	if out.FilesBackedUp != 42 || out.BytesBackedUp != 999 {
+		t.Errorf("counters did not survive tier 3: files=%d bytes=%d", out.FilesBackedUp, out.BytesBackedUp)
+	}
+	if out.ErrorCount != 317 {
+		t.Errorf("expected errorCount 317 to survive tier 3, got %d", out.ErrorCount)
+	}
+	if len(out.Detail0000) != 0 {
+		t.Error("expected the container fields to be dropped by tier 3")
+	}
+	if !strings.Contains(out.Warning, "detail0000") {
+		t.Errorf("expected tier 3 to record the omitted fields in the persisted warning, got %.120q", out.Warning)
+	}
+}
+
+// TestFitBackupResultLastResortRecoversStatus exercises TIER 4's salvage branch
+// on an object body. Every existing tier-4 case has non-object stdout, so
+// lastResortStdout's recovery loop never runs and could return nothing at all
+// with the suite still green — yet recovering status/snapshotId is the entire
+// reason tier 4 exists.
+//
+// The fixture survives tier 3 because it is all scalars: tier 3 keeps every
+// scalar (clamped to maxResultTextBytes), and thousands of clamped scalars are
+// still over budget.
+func TestFitBackupResultLastResortRecoversStatus(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`{"id":"job-9","status":"completed","snapshotId":"snapshot-9"`)
+	blob := strings.Repeat("z", 12*1024)
+	for i := 0; i < 3000; i++ {
+		fmt.Fprintf(&b, `,"note%04d":"%s"`, i, blob)
+	}
+	b.WriteString("}")
+	in := backupipc.BackupCommandResult{CommandID: "cmd-lastresort", Success: true, Stdout: b.String()}
+
+	fitted, degraded := fitBackupResultToIPC(in)
+	if got := payloadSize(t, fitted); got > resultPayloadBudget {
+		t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
+	}
+	if !strings.Contains(degraded, "minimal terminal status") {
+		t.Fatalf("expected tier 4 to be the tier that fired, got %q", degraded)
+	}
+	var out struct {
+		ID         string `json:"id"`
+		Status     string `json:"status"`
+		SnapshotID string `json:"snapshotId"`
+		Warning    string `json:"warning"`
+	}
+	if err := json.Unmarshal([]byte(fitted.Stdout), &out); err != nil {
+		t.Fatalf("fitted stdout is not valid JSON: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("expected tier 4 to recover status, got %q", out.Status)
+	}
+	if out.SnapshotID != "snapshot-9" {
+		t.Errorf("expected tier 4 to recover snapshotId, got %q", out.SnapshotID)
+	}
+	if out.ID != "job-9" {
+		t.Errorf("expected tier 4 to recover the job id, got %q", out.ID)
+	}
+	if !strings.Contains(out.Warning, "IPC limit") {
+		t.Errorf("expected tier 4 to explain itself in the warning, got %q", out.Warning)
+	}
+}
+
+// TestSendBackupResultReportsSendFailure pins that a residual send failure is
+// still returned (and therefore logged) rather than swallowed. Both call sites
+// discard the error with `_ =`, so this log line is the only remaining evidence
+// that a terminal status never reached the server.
+func TestSendBackupResultReportsSendFailure(t *testing.T) {
+	serverNC, clientNC := net.Pipe()
+	if err := serverNC.Close(); err != nil {
+		t.Fatalf("close receiver: %v", err)
+	}
+	if err := clientNC.Close(); err != nil {
+		t.Fatalf("close sender: %v", err)
+	}
+
+	err := sendBackupResult(ipc.NewConn(clientNC), "env-dead", backupipc.BackupCommandResult{
+		CommandID: "cmd-dead",
+		Success:   true,
+		Stdout:    `{"status":"completed","snapshot":{"id":"snapshot-1"}}`,
+	})
+	if err == nil {
+		t.Fatal("expected a send over a closed connection to return an error, not be swallowed")
 	}
 }

--- a/agent/cmd/breeze-backup/result_bounds_test.go
+++ b/agent/cmd/breeze-backup/result_bounds_test.go
@@ -247,35 +247,55 @@ func TestFitBackupResultBoundsOversizeStderr(t *testing.T) {
 // pathological the payload, the returned result fits the frame, because a
 // terminal status must always land.
 func TestFitBackupResultAlwaysFits(t *testing.T) {
-	cases := map[string]backupipc.BackupCommandResult{
+	cases := map[string]struct {
+		in backupipc.BackupCommandResult
+		// summarisable is true when the body is a JSON object, so the tiers can
+		// reduce it while keeping Success. A body that is not an object cannot
+		// be summarised and is deliberately delivered as an explicit failure
+		// rather than as a success with an empty body.
+		summarisable bool
+	}{
 		"non-json stdout": {
-			CommandID: "cmd-1",
-			Success:   true,
-			Stdout:    strings.Repeat("x", ipc.MaxMessageSize+1024),
+			in: backupipc.BackupCommandResult{
+				CommandID: "cmd-1",
+				Success:   true,
+				Stdout:    strings.Repeat("x", ipc.MaxMessageSize+1024),
+			},
 		},
 		"json array stdout": {
-			CommandID: "cmd-2",
-			Success:   true,
-			Stdout:    "[" + strings.Repeat(`"`+strings.Repeat("y", 1024)+`",`, 20000) + `"tail"]`,
+			in: backupipc.BackupCommandResult{
+				CommandID: "cmd-2",
+				Success:   true,
+				Stdout:    "[" + strings.Repeat(`"`+strings.Repeat("y", 1024)+`",`, 20000) + `"tail"]`,
+			},
 		},
 		"giant warning only": {
-			CommandID: "cmd-3",
-			Success:   true,
-			Stdout:    `{"status":"completed","snapshot":{"id":"snap-1"},"warning":"` + strings.Repeat("w", ipc.MaxMessageSize) + `"}`,
+			in: backupipc.BackupCommandResult{
+				CommandID: "cmd-3",
+				Success:   true,
+				Stdout:    `{"status":"completed","snapshot":{"id":"snap-1"},"warning":"` + strings.Repeat("w", ipc.MaxMessageSize) + `"}`,
+			},
+			summarisable: true,
 		},
-		"empty": {CommandID: "cmd-4", Success: true},
+		"empty": {
+			in:           backupipc.BackupCommandResult{CommandID: "cmd-4", Success: true},
+			summarisable: true,
+		},
 	}
-	for name, in := range cases {
+	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			fitted, _ := fitBackupResultToIPC(in)
+			fitted, _ := fitBackupResultToIPC(tc.in)
 			if got := payloadSize(t, fitted); got > resultPayloadBudget {
 				t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
 			}
-			if fitted.CommandID != in.CommandID {
-				t.Errorf("expected commandId %q to survive, got %q", in.CommandID, fitted.CommandID)
+			if fitted.CommandID != tc.in.CommandID {
+				t.Errorf("expected commandId %q to survive, got %q", tc.in.CommandID, fitted.CommandID)
 			}
-			if fitted.Success != in.Success {
-				t.Errorf("expected success %v to survive, got %v", in.Success, fitted.Success)
+			if tc.summarisable && !fitted.Success {
+				t.Error("expected a summarisable body to keep its success status")
+			}
+			if !tc.summarisable && fitted.Success {
+				t.Error("expected an unsummarisable oversize body to degrade to a failure")
 			}
 		})
 	}
@@ -286,8 +306,8 @@ func TestFitBackupResultAlwaysFits(t *testing.T) {
 // the agent received nothing at all. Now a terminal result arrives.
 func TestSendBackupResultDeliversOversizeRun(t *testing.T) {
 	serverNC, clientNC := net.Pipe()
-	defer serverNC.Close()
-	defer clientNC.Close()
+	defer func() { _ = serverNC.Close() }()
+	defer func() { _ = clientNC.Close() }()
 
 	sender := ipc.NewConn(clientNC)
 	receiver := ipc.NewConn(serverNC)
@@ -298,7 +318,9 @@ func TestSendBackupResultDeliversOversizeRun(t *testing.T) {
 	sendErr := make(chan error, 1)
 	go func() { sendErr <- sendBackupResult(sender, "env-1", result) }()
 
-	receiver.SetReadDeadline(time.Now().Add(30 * time.Second))
+	if err := receiver.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
 	env, err := receiver.Recv()
 	if err != nil {
 		t.Fatalf("recv: %v", err)
@@ -330,5 +352,169 @@ func TestSendBackupResultDeliversOversizeRun(t *testing.T) {
 	if out.Status != "completed" || out.Snapshot.ID == "" || out.ErrorCount != fieldReportErrorCount {
 		t.Errorf("terminal status did not survive delivery: status=%q snapshotId=%q errorCount=%d",
 			out.Status, out.Snapshot.ID, out.ErrorCount)
+	}
+}
+
+// TestFitBackupResultPreservesRestoreScalars is the regression guard for the
+// review finding that an enumerated keep-list would silently zero the counters
+// the server persists. A partial restore's oversize failedFiles array must be
+// dropped WITHOUT zeroing filesRestored / bytesRestored / filesFailed, which
+// restoreResultPersistence reads straight into the restore job row.
+func TestFitBackupResultPreservesRestoreScalars(t *testing.T) {
+	failed := make([]string, 0, 200000)
+	for i := 0; i < 200000; i++ {
+		failed = append(failed, fmt.Sprintf(`C:\Users\jdoe\Documents\archive\report_%06d.docx: access is denied`, i))
+	}
+	restore := backup.RestoreResult{
+		SnapshotID:    "snapshot-20260801T125517Z-5edfcd7e",
+		Status:        "partial",
+		FilesRestored: 98211,
+		BytesRestored: 27412998811,
+		FilesFailed:   len(failed),
+		FailedFiles:   failed,
+		Error:         "restore completed partially",
+	}
+	data, err := json.Marshal(restore)
+	if err != nil {
+		t.Fatalf("marshal restore result: %v", err)
+	}
+	in := backupipc.BackupCommandResult{CommandID: "restore-1", Success: true, Stdout: string(data)}
+
+	fitted, degraded := fitBackupResultToIPC(in)
+	if degraded == "" {
+		t.Fatal("expected an oversize restore result to be reported as degraded")
+	}
+	if got := payloadSize(t, fitted); got > resultPayloadBudget {
+		t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
+	}
+	if !fitted.Success {
+		t.Error("a restore that ran must not be flipped to failure just because its detail was oversize")
+	}
+
+	var out backup.RestoreResult
+	if err := json.Unmarshal([]byte(fitted.Stdout), &out); err != nil {
+		t.Fatalf("fitted stdout is not valid JSON: %v", err)
+	}
+	if out.Status != "partial" {
+		t.Errorf("expected status partial, got %q", out.Status)
+	}
+	if out.SnapshotID != "snapshot-20260801T125517Z-5edfcd7e" {
+		t.Errorf("expected snapshotId to survive, got %q", out.SnapshotID)
+	}
+	if out.FilesRestored != 98211 {
+		t.Errorf("expected filesRestored 98211 to survive, got %d", out.FilesRestored)
+	}
+	if out.BytesRestored != 27412998811 {
+		t.Errorf("expected bytesRestored to survive, got %d", out.BytesRestored)
+	}
+	if out.FilesFailed != 200000 {
+		t.Errorf("expected filesFailed 200000 to survive, got %d", out.FilesFailed)
+	}
+	if len(out.FailedFiles) != 0 {
+		t.Errorf("expected the failedFiles array to be dropped, got %d entries", len(out.FailedFiles))
+	}
+	if out.Error != "restore completed partially" {
+		t.Errorf("expected the error scalar to survive, got %q", out.Error)
+	}
+}
+
+// TestFitBackupResultRejectsUnsummarisableBody pins that a body we cannot
+// summarise (backup_list returns a top-level JSON ARRAY) degrades to an
+// explicit failure rather than an empty success. An empty snapshot list read as
+// "this device has no backups" is worse than a loud error.
+func TestFitBackupResultRejectsUnsummarisableBody(t *testing.T) {
+	entry := `{"id":"snapshot-20260801T125517Z-5edfcd7e","size":35421941515},`
+	in := backupipc.BackupCommandResult{
+		CommandID: "list-1",
+		Success:   true,
+		Stdout:    "[" + strings.Repeat(entry, 400000) + `{"id":"tail"}]`,
+	}
+
+	fitted, degraded := fitBackupResultToIPC(in)
+	if degraded == "" {
+		t.Fatal("expected an oversize list result to be reported as degraded")
+	}
+	if got := payloadSize(t, fitted); got > resultPayloadBudget {
+		t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
+	}
+	if fitted.Success {
+		t.Error("an unsummarisable oversize body must not be delivered as a success")
+	}
+	if fitted.Stdout != "" {
+		t.Errorf("expected an empty stdout, got %.80q", fitted.Stdout)
+	}
+	if !strings.Contains(fitted.Stderr, "IPC limit") {
+		t.Errorf("expected the stderr to explain the oversize, got %.120q", fitted.Stderr)
+	}
+}
+
+// TestEmptySnapshotFilesKeepsTheFilesKey pins that the dropped index is an
+// EMPTY ARRAY, not an absent key. The server's stale-row cleanup is gated on
+// key presence (`if (snapshot && result.snapshot?.files)`), so omitting the key
+// would leave a previous delivery's backup_snapshot_files rows in place while
+// hasIndexedFiles flipped to false — two states that then disagree.
+func TestEmptySnapshotFilesKeepsTheFilesKey(t *testing.T) {
+	job := buildLargeRunJob(oversizeFileCount, fieldReportErrorCount)
+	fitted, _ := fitBackupResultToIPC(mustRunResult(t, job))
+
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(fitted.Stdout), &out); err != nil {
+		t.Fatalf("fitted stdout is not valid JSON: %v", err)
+	}
+	var snap map[string]json.RawMessage
+	if err := json.Unmarshal(out["snapshot"], &snap); err != nil {
+		t.Fatalf("fitted snapshot is not valid JSON: %v", err)
+	}
+	raw, present := snap["files"]
+	if !present {
+		t.Fatal("expected snapshot.files to be present as an empty array, not omitted")
+	}
+	var files []json.RawMessage
+	if err := json.Unmarshal(raw, &files); err != nil {
+		t.Fatalf("snapshot.files is not an array: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected snapshot.files to be empty, got %d entries", len(files))
+	}
+}
+
+// TestFitBackupResultDropsOversizeSystemStateManifest covers a system_image run
+// whose bulk is the system-state manifest rather than the file index: it must
+// be dropped, and the drop must be recorded in the warning the server persists
+// — a BMR restore point with a silently-null manifest is not usable.
+func TestFitBackupResultDropsOversizeSystemStateManifest(t *testing.T) {
+	manifest := `{"platform":"windows","artifacts":[` +
+		strings.Repeat(`{"name":"registry-hive","path":"C:\\Windows\\System32\\config\\SOFTWARE","bytes":123456},`, 200000) +
+		`{"name":"tail"}]}`
+	stdout := `{"id":"job-1","status":"completed","filesBackedUp":12,"bytesBackedUp":345,` +
+		`"snapshot":{"id":"snapshot-1","size":345},"systemStateManifest":` + manifest + `}`
+	in := backupipc.BackupCommandResult{CommandID: "sysimage-1", Success: true, Stdout: stdout}
+
+	fitted, degraded := fitBackupResultToIPC(in)
+	if got := payloadSize(t, fitted); got > resultPayloadBudget {
+		t.Fatalf("fitted payload is %d bytes, over the %d budget", got, resultPayloadBudget)
+	}
+	if !strings.Contains(degraded, "systemStateManifest") {
+		t.Errorf("expected the degradation note to name systemStateManifest, got %q", degraded)
+	}
+	var out struct {
+		Status              string          `json:"status"`
+		Warning             string          `json:"warning"`
+		SystemStateManifest json.RawMessage `json:"systemStateManifest"`
+		Snapshot            struct {
+			ID string `json:"id"`
+		} `json:"snapshot"`
+	}
+	if err := json.Unmarshal([]byte(fitted.Stdout), &out); err != nil {
+		t.Fatalf("fitted stdout is not valid JSON: %v", err)
+	}
+	if len(out.SystemStateManifest) != 0 {
+		t.Error("expected the oversize systemStateManifest to be dropped")
+	}
+	if out.Status != "completed" || out.Snapshot.ID != "snapshot-1" {
+		t.Errorf("terminal status did not survive: status=%q snapshotId=%q", out.Status, out.Snapshot.ID)
+	}
+	if !strings.Contains(out.Warning, "systemStateManifest") {
+		t.Errorf("expected the persisted warning to name the dropped manifest, got %q", out.Warning)
 	}
 }


### PR DESCRIPTION
Refs #3001

## Problem

A backup run's terminal IPC result is unbounded; the frame is capped at `ipc.MaxMessageSize` (16 MiB, `agent/internal/ipc/message.go:105`, enforced at `protocol.go:142`). The field-reported run — 123,284 files, 35.4 GB, 317 per-file errors — produced a **64,405,054 byte** result. `conn.Send` rejected it, the result was dropped outright, and the `backup_jobs` row stayed `running` until the stale-backup reaper failed it 15 minutes later. **The backup had succeeded.**

Perverse scaling: the more files a run protects, the more likely its outcome never arrives.

## Correction to the issue's stated root cause

The issue attributes the 64 MB to the 317-entry per-file failure list. **That is not possible** — `Snapshot.UploadFailures` is `json:"-"` (`agent/internal/backup/snapshot.go:77`) and never reaches the wire. 317 entries would be ~63 KB regardless.

The dominant field is the **per-file snapshot manifest**, `Snapshot.Files` — one `SnapshotFile` per backed-up file (absolute source path + snapshot-prefixed backup path + SHA-256 checksum + modTime). 64,405,054 / 123,284 = **522 bytes/entry**, which matches that shape exactly. `TestUnboundedRunResultExceedsIPCLimit` pins both halves: the full job exceeds the cap, and removing only the file index brings it back under.

`summarizeUploadFailures` was already doing its job — the warning string was never the problem.

## Fix

`fitBackupResultToIPC` (new `agent/cmd/breeze-backup/result_bounds.go`) degrades in tiers, stopping at the first that fits:

1. **Always, and cheap (no JSON parse): truncate `stderr`.** This is the genuinely unbounded text field on this path — a hard failure routes `errors.Join(<every per-file error>)` straight through `fail(err.Error())`, which nothing capped.
2. **Drop `snapshot.files` whole; cap the `warning` text.** Dropped whole rather than truncated on purpose: the server derives `hasIndexedFiles` from `snapshot.files.length` (`backupResultPersistence.ts:537`), so a truncated index would present as a *complete* browsable file list that is silently missing entries. The drop is appended to the result's `warning`, which the server persists to the job's `errorLog` — so it is visible in the UI, not just in a log line on the endpoint.
3. **Reduce stdout to the terminal-status identity fields** (job id, status, snapshot identity, counters, `errorCount`).
4. **Last resort: a minimal status object, bounded by construction** — so the "always fits" postcondition is total.

Terminal status, job id, snapshot id, `filesBackedUp`/`bytesBackedUp` and the total `errorCount` survive every tier. Losing error detail is acceptable; losing the fact that the backup succeeded is not.

Both send sites — the async unsolicited result and the synchronous reply — now go through `sendBackupResult`, which logs degradation **and** any residual send failure at `ERROR` under `component=backup`. Previously it was one *untagged* `slog.Error` line, which ships as component `unknown`; `component=backup` is what makes it filterable via the diagnostic-logs API, and `ERROR` clears the default `warn` log-shipping threshold so it reaches the server.

The ordinary path pays nothing: the cheap raw-length pre-check in `fits` short-circuits before any marshal, and the JSON-rewriting tiers only run when the result is actually oversize.

**`ipc.MaxMessageSize` is deliberately unchanged** — the payload has to be bounded regardless, and raising the cap only moves the cliff.

## Tests

`agent/cmd/breeze-backup/result_bounds_test.go`, written failing first:

- `TestUnboundedRunResultExceedsIPCLimit` — reproduces the field payload and pins `Snapshot.Files` (not the failure list) as the dominant field.
- `TestFitBackupResultBoundsLargeRun` — a run with hundreds of failures and a 25 MB+ manifest marshals under the budget.
- `TestFitBackupResultPreservesTerminalStatus` — status, job id, snapshot id, counters and `errorCount=317` all survive truncation, and the warning records the dropped index.
- `TestFitBackupResultKeepsFileIndexWhenItFits` — no over-truncation: an ordinary run still ships its full file index.
- `TestFitBackupResultBoundsOversizeStderr` — the failure-path twin of the same bug.
- `TestFitBackupResultAlwaysFits` — total postcondition over non-JSON, JSON-array, giant-warning and empty payloads.
- `TestSendBackupResultDeliversOversizeRun` — end-to-end over a real `ipc.Conn` pair: a terminal result now arrives where `SendTyped` previously returned `message too large` and the agent received nothing.

```
go vet ./...                                        clean
go test -race ./internal/backup/... ./internal/ipc/...   ok (8 packages)
go test -race ./cmd/breeze-backup/ ./internal/backupipc/...  ok
```

## Follow-up (not in this PR)

Restore-browsing for very large snapshots now degrades to "no file index" instead of a dropped job. A chunked/streamed file-index upload would restore full browsing for those snapshots; that needs a server-side schema change and is out of scope here.

Scope kept tight and localized per the parallel work on #2997 (`snapshot.go`), #2998, #2999 and #3000 (same completion path in `backup.go`) — this PR touches neither `agent/internal/backup/` nor `apps/api/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)