### PR TITLE
fix(security): bump event-listener to 5.4.2 for RUSTSEC-2026-0221 (unblocks Cargo Audit on all PRs)

### DIFF
--- a/apps/viewer/src-tauri/Cargo.lock
+++ b/apps/viewer/src-tauri/Cargo.lock
@@ -1069,11 +1069,10 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Why

`Cargo Audit` has been red on **every open PR and on `main`** since RUSTSEC-2026-0221 was published against `event-listener`. It is currently gating the four backup PRs (#3002, #3003, #3004, #3005), none of which touch Rust.

## Dependency path

`event-listener` reaches `breeze-viewer` transitively:

```
event-listener 5.4.1
├── zbus 5.13.2
│   └── tauri-plugin-single-instance 2.4.3
│       └── breeze-viewer 0.10.0
└── event-listener-strategy 0.5.4
    └── async-lock 3.4.2 / async-process 2.5.0
        └── zbus 5.13.2
```

## Fix

`5.4.2` is a **semver-compatible patch**, so this is a lockfile-only change. No `.cargo/audit.toml` allowlist entry needed — worth noting because the existing allowlist is for advisories genuinely unfixable from our side (Tauri's GTK3 stack, the html5ever chain). This one is just a bump, so it should not join that list.

`apps/helper/src-tauri/Cargo.lock` does not contain `event-listener` and is unchanged.

## Verification

Ran the exact commands from `.github/workflows/security.yml`:

| | |
|---|---|
| `apps/viewer/src-tauri` → `cargo audit --deny warnings` | **exit 0** |
| `apps/helper/src-tauri` → `cargo audit --deny warnings` | **exit 0** |

Advisory DB at 1,178 advisories; viewer scan covers 588 crate dependencies, helper 544.

Note that `Rust Check (Tauri apps)` exists precisely because PR CI only runs the advisory scan and not a compile — see the comment at `ci.yml:1385`. That job should exercise this lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)