### PR TITLE
fix(api): stop agentWs command_result from double-holding pooled DB connections (#3021)

### DIFF
--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -262,8 +262,8 @@ vi.mock('../services/sentry', async (importOriginal) => {
   return { ...actual, captureMessage: vi.fn() };
 });
 
-import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
-import { devices, deviceCommands } from '../db/schema';
+import { db, runOutsideDbContext, withSystemDbAccessContext, withDbAccessContext } from '../db';
+import { devices, deviceCommands, scriptExecutions } from '../db/schema';
 import { captureMessage } from '../services/sentry';
 import {
   createAgentWsHandlers,
@@ -2461,6 +2461,165 @@ describe('device_commands access context on the WS result path (#1375)', () => {
     // context — in that exact order. Asserting the full stack (rather than
     // "both are non-zero") is what fails if the two wrappers are ever swapped.
     expect(write.stack).toEqual(['outside', 'system']);
+  });
+});
+
+// #3021: the command_result message must NOT run under a message-level org
+// context. The old `runWithAgentDbAccess('agentWs.commandResult', ...)` wrap
+// held one pooled connection idle-in-transaction for the whole message while
+// the nested `runOutsideDbContext(() => withSystemDbAccessContext(...))` steps
+// inside processCommandResult (lookup CAS, lifecycle recheck, audit write)
+// each acquired a SECOND connection — two pool slots per command result, the
+// same defect #2765 fixed on the HTTP /commands route. The fix scopes the org
+// context to exactly the pieces that need ambient tenant RLS (the per-type
+// handler dispatch and the orphaned-result branches), so no org transaction is
+// ever open while a fresh system context acquires.
+//
+// Same caveat as the #1375 suite above: `../db` is mocked wholesale, so this
+// pins WRAPPER COMPOSITION at the call sites, not real pool behaviour.
+describe('#3021: command_result opens no message-level org context', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('runs the device_commands steps with no enclosing org context and the per-type handler under a short org wrap', async () => {
+    // Open first, before the wrapper/DB spies below, so the handshake's own
+    // traffic can never land in `observed`.
+    const { handlers, ws } = await connectedAgent('agent-3021', { deviceId: 'device-3021', orgId: 'org-3021' });
+
+    // Track the ACTIVE WRAPPER STACK at the moment of every DB call. An
+    // `org:*` frame present during the deviceCommands select/update or the
+    // devices lifecycle recheck is the #3021 bug re-introduced: an org
+    // transaction held open while other work runs (and, for the CAS, while a
+    // nested system context acquires a second pooled connection).
+    const stack: string[] = [];
+    const orgContexts: Array<Record<string, unknown>> = [];
+
+    vi.mocked(withDbAccessContext).mockImplementation((async (ctx: any, fn: any) => {
+      orgContexts.push(ctx);
+      stack.push(`org:${ctx.label}`);
+      try {
+        return await fn();
+      } finally {
+        stack.pop();
+      }
+    }) as any);
+    vi.mocked(runOutsideDbContext).mockImplementation((async (fn: any) => {
+      stack.push('outside');
+      try {
+        return await fn();
+      } finally {
+        stack.pop();
+      }
+    }) as any);
+    vi.mocked(withSystemDbAccessContext).mockImplementation((async (fn: any) => {
+      stack.push('system');
+      try {
+        return await fn();
+      } finally {
+        stack.pop();
+      }
+    }) as any);
+
+    const observed: Array<{ op: 'select' | 'update'; table: unknown; stack: string[] }> = [];
+    const record = (op: 'select' | 'update', table: unknown) => {
+      observed.push({ op, table, stack: [...stack] });
+    };
+
+    // A `script`-type command with an executionId payload so the dispatch
+    // reaches handleScriptResult, whose scriptExecutions update NEEDS ambient
+    // tenant RLS — the piece that proves the short handler wrap exists.
+    const commandRow = {
+      id: 'cmd-3021',
+      type: 'script',
+      payload: { executionId: 'exec-3021' },
+      deviceId: 'device-3021',
+    };
+    vi.mocked(db.select).mockImplementation((() => ({
+      from: vi.fn((table: unknown) => {
+        record('select', table);
+        const rows = table === deviceCommands ? [commandRow] : [];
+        return {
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        };
+      }),
+    })) as any);
+    vi.mocked(db.update).mockImplementation(((table: unknown) => {
+      record('update', table);
+      const returning = vi.fn().mockResolvedValue([{ id: 'row-1', scriptId: 'script-1' }]);
+      return {
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning }),
+          returning,
+        }),
+      };
+    }) as any);
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '44444444-4444-4444-8444-444444444444',
+        status: 'completed',
+        exitCode: 0,
+        stdout: 'ok',
+      }),
+    } as any, ws as any);
+
+    // The deviceCommands lookup + terminal CAS keep their #1375 composition —
+    // and, new with #3021, have NO enclosing `org:*` frame.
+    const commandOps = observed.filter((o) => o.table === deviceCommands);
+    expect(commandOps.map((o) => o.op)).toEqual(['select', 'update']);
+    expect(commandOps.find((o) => o.op === 'select')!.stack).toEqual(['outside']);
+    expect(commandOps.find((o) => o.op === 'update')!.stack).toEqual(['outside', 'system']);
+
+    // The devices lifecycle recheck likewise runs outside any org context.
+    const deviceReads = observed.filter((o) => o.table === devices && o.op === 'select');
+    expect(deviceReads.length).toBeGreaterThan(0);
+    for (const read of deviceReads) {
+      expect(read.stack).toEqual(['outside', 'system']);
+    }
+
+    // The per-type handler's tenant-RLS write runs under EXACTLY the short
+    // labelled org wrap — present (RLS visibility preserved) and alone on the
+    // stack (no system context nested inside an org transaction).
+    const scriptOps = observed.filter((o) => o.table === scriptExecutions);
+    expect(scriptOps.map((o) => o.op)).toEqual(['update']);
+    expect(scriptOps[0]!.stack).toEqual(['org:agentWs.commandResult.handler']);
+
+    // The short wrap carries the authenticated agent's org, and no context
+    // anywhere in the message used the removed message-level label.
+    const handlerCtx = orgContexts.find((c) => c.label === 'agentWs.commandResult.handler');
+    expect(handlerCtx).toMatchObject({ scope: 'organization', orgId: 'org-3021', accessibleOrgIds: ['org-3021'] });
+    expect(orgContexts.map((c) => c.label)).not.toContain('agentWs.commandResult');
+
+    expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  it('wraps a non-UUID orphaned result in the short orphaned org context, not a message-level wrap', async () => {
+    const { handlers, ws } = await connectedAgent('agent-3021b', { deviceId: 'device-3021b', orgId: 'org-3021b' });
+
+    const orgLabels: string[] = [];
+    vi.mocked(withDbAccessContext).mockImplementation((async (ctx: any, fn: any) => {
+      orgLabels.push(ctx.label);
+      return fn();
+    }) as any);
+    vi.mocked(db.select).mockReturnValue(selectAgentDevice([]) as any);
+    vi.mocked(db.update).mockReturnValue(updateResult() as any);
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: 'mon-monitor-3021-1',
+        status: 'completed',
+        result: { monitorId: 'monitor-3021', status: 'online', responseMs: 5 },
+      }),
+    } as any, ws as any);
+
+    expect(orgLabels).toContain('agentWs.commandResult.orphaned');
+    expect(orgLabels).not.toContain('agentWs.commandResult');
   });
 });
 

--- a/apps/api/src/routes/agentWs.test.ts
+++ b/apps/api/src/routes/agentWs.test.ts
@@ -1056,11 +1056,12 @@ describe('agent websocket command results', () => {
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
   });
 
-  // BREEZE-H: the command_result handler runs inside a held org-scoped
-  // transaction; BullMQ enqueues must be wrapped in runOutsideDbContext so
-  // the #1105 tripwire in bullmqQueue passes and nested DB work routes to
-  // the pool (the wrap does not release the outer transaction's connection —
-  // dispatching after the context closes is the deeper #1105 fix).
+  // BREEZE-H: the orphaned monitor branch runs inside a SHORT org-scoped
+  // transaction (agentWs.commandResult.orphaned since #3021); BullMQ enqueues
+  // must still be wrapped in runOutsideDbContext so the #1105 tripwire in
+  // bullmqQueue passes and nested DB work routes to the pool (the wrap does
+  // not release the outer transaction's connection — dispatching after the
+  // context closes is the deeper #1105 fix).
   it('enqueues an accepted monitor result via runOutsideDbContext (#1105, BREEZE-H)', async () => {
     const preValidatedAgent = { deviceId: 'device-123', orgId: 'org-123' };
 
@@ -2349,8 +2350,10 @@ describe('#2434 — secret redaction on non-device_commands persistence surfaces
 });
 
 // #1375 / BREEZE-7: the device_commands lookup + terminal compare-and-set on the
-// WS result path deliberately run OUTSIDE the held org-scoped transaction (fresh
-// snapshot visibility), but for a long time they ran with NO DB access context at
+// WS result path deliberately run OUTSIDE any ambient org-scoped transaction
+// (since #3021 there normally is none — runOutsideDbContext is kept as defense
+// and for fresh-snapshot visibility if a caller reintroduces one), but for a
+// long time they ran with NO DB access context at
 // all — tripping the contextless-write guard in db/index.ts on every fresh
 // process and flooding Sentry. device_commands has no RLS so the write always
 // landed; the bug was the false invariant + the noise. The fix nests
@@ -2468,7 +2471,7 @@ describe('device_commands access context on the WS result path (#1375)', () => {
 // context. The old `runWithAgentDbAccess('agentWs.commandResult', ...)` wrap
 // held one pooled connection idle-in-transaction for the whole message while
 // the nested `runOutsideDbContext(() => withSystemDbAccessContext(...))` steps
-// inside processCommandResult (lookup CAS, lifecycle recheck, audit write)
+// inside processCommandResult (terminal CAS, lifecycle recheck, audit write)
 // each acquired a SECOND connection — two pool slots per command result, the
 // same defect #2765 fixed on the HTTP /commands route. The fix scopes the org
 // context to exactly the pieces that need ambient tenant RLS (the per-type
@@ -2596,6 +2599,111 @@ describe('#3021: command_result opens no message-level org context', () => {
     expect(orgContexts.map((c) => c.label)).not.toContain('agentWs.commandResult');
 
     expect(ws.send).toHaveBeenCalledWith(expect.stringContaining('"ack"'));
+  });
+
+  it('runs the deviceId-less fallback lookup under outside+system so the RLS-guarded devices join cannot silently 0-row', async () => {
+    // deviceId deliberately absent: this is the one lookup branch whose
+    // composition changed with #3021. Pre-fix it read `devices` through the
+    // ambient message-level org context; post-fix it MUST carry its own
+    // explicit system context — with no ambient context, a bare-pool read of
+    // RLS-guarded `devices` returns 0 rows without error and misroutes a
+    // legitimate result to the orphaned path.
+    const { handlers, ws } = await connectedAgent('agent-3021c', {
+      deviceId: undefined as unknown as string,
+      orgId: 'org-3021c',
+    });
+
+    const stack: string[] = [];
+    vi.mocked(withDbAccessContext).mockImplementation((async (ctx: any, fn: any) => {
+      stack.push(`org:${ctx.label}`);
+      try {
+        return await fn();
+      } finally {
+        stack.pop();
+      }
+    }) as any);
+    vi.mocked(runOutsideDbContext).mockImplementation((async (fn: any) => {
+      stack.push('outside');
+      try {
+        return await fn();
+      } finally {
+        stack.pop();
+      }
+    }) as any);
+    vi.mocked(withSystemDbAccessContext).mockImplementation((async (fn: any) => {
+      stack.push('system');
+      try {
+        return await fn();
+      } finally {
+        stack.pop();
+      }
+    }) as any);
+
+    const observed: Array<{ op: 'select' | 'update'; table: unknown; stack: string[] }> = [];
+    const record = (op: 'select' | 'update', table: unknown) => {
+      observed.push({ op, table, stack: [...stack] });
+    };
+
+    const commandRow = {
+      id: 'cmd-3021c',
+      type: 'script',
+      payload: { executionId: 'exec-3021c' },
+      deviceId: 'device-3021c',
+      targetRole: 'agent',
+    };
+    vi.mocked(db.select).mockImplementation((() => ({
+      from: vi.fn((table: unknown) => {
+        record('select', table);
+        return {
+          // Plain where().limit() — the devices lifecycle recheck; empty
+          // result fails open.
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          // The fallback lookup joins deviceCommands -> devices and resolves
+          // the owned command + deviceId.
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue(
+                table === deviceCommands ? [{ command: commandRow, deviceId: 'device-3021c' }] : []
+              ),
+            }),
+          }),
+        };
+      }),
+    })) as any);
+    vi.mocked(db.update).mockImplementation(((table: unknown) => {
+      record('update', table);
+      const returning = vi.fn().mockResolvedValue([{ id: 'row-1', scriptId: 'script-1' }]);
+      return {
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning }),
+          returning,
+        }),
+      };
+    }) as any);
+
+    await handlers.onMessage({
+      data: JSON.stringify({
+        type: 'command_result',
+        commandId: '55555555-5555-4555-8555-555555555555',
+        status: 'completed',
+        exitCode: 0,
+        stdout: 'ok',
+      }),
+    } as any, ws as any);
+
+    // The fallback lookup ran under exactly outside+system — dropping either
+    // wrapper (or swapping the order, which would exit the context just
+    // opened) fails this exact-stack assertion.
+    const commandOps = observed.filter((o) => o.table === deviceCommands);
+    expect(commandOps.map((o) => o.op)).toEqual(['select', 'update']);
+    expect(commandOps.find((o) => o.op === 'select')!.stack).toEqual(['outside', 'system']);
+
+    // And the result was honored as an owned command (terminal CAS +
+    // handler dispatch), not misrouted to the orphaned path.
+    expect(commandOps.find((o) => o.op === 'update')!.stack).toEqual(['outside', 'system']);
+    const scriptOps = observed.filter((o) => o.table === scriptExecutions);
+    expect(scriptOps.map((o) => o.op)).toEqual(['update']);
+    expect(scriptOps[0]!.stack).toEqual(['org:agentWs.commandResult.handler']);
   });
 
   it('wraps a non-UUID orphaned result in the short orphaned org context, not a message-level wrap', async () => {

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1698,12 +1698,24 @@ export async function processOrphanedCommandResult(
  * paths like processCommandResult can scope individual operations instead of
  * running under a message-long wrap.
  *
- * #3021: contexts opened through this helper must NEVER enclose a nested
- * `withSystemDbAccessContext` (or any other context-opening helper) —
- * `runOutsideDbContext` only exits the AsyncLocalStorage, it does NOT release
- * this context's pooled connection, so nesting holds two connections at once
- * and self-amplifies pool pressure (the #1105 class; see #2765 for the HTTP
- * twin). Keep the wrapped work to plain ambient-`db` operations.
+ * #3021: be deliberate about context-opening helpers nested under this wrap —
+ * there are two DISTINCT failure modes:
+ *
+ * - a BARE nested `withSystemDbAccessContext` opens nothing:
+ *   withDbAccessContext early-returns when a context is already active
+ *   (db/index.ts), so the "system" work silently runs inside THIS org
+ *   transaction under org RLS (one connection, wrong-scope hazard).
+ * - the `runOutsideDbContext(() => withSystemDbAccessContext(...))` form
+ *   genuinely opens a second context, but runOutsideDbContext does NOT
+ *   release this context's pooled connection — two connections held at
+ *   once, the #1105 class (#2765 is the HTTP twin).
+ *
+ * The direct callees under the #3021 command-result wraps use neither form.
+ * Indirect residues remain (e.g. publishEvent subscribers open system
+ * contexts after exiting the ALS, and some desktop-path callees use the
+ * outside+system form) — those still double-hold briefly, a known #1105
+ * follow-up, now bounded by short per-operation wraps instead of a
+ * message-long one.
  */
 async function runWithAgentOrgDbAccess<T>(label: string, orgId: string, fn: () => Promise<T>): Promise<T> {
   return withDbAccessContext(
@@ -1726,11 +1738,20 @@ async function runWithAgentOrgDbAccess<T>(label: string, orgId: string, fn: () =
  * Process command result from agent.
  *
  * #3021: deliberately NOT wrapped in a message-level org context by the
- * `command_result` case (the WS twin of #2765). The lookup, lifecycle
- * recheck, terminal CAS, and audit write below each manage their own
- * short-lived context, and the per-type handler dispatch gets its own
- * org-scoped wrap — so no step ever acquires a second pooled connection
- * while another context's connection is held open (#1105).
+ * `command_result` case (the WS twin of #2765). The primary device_commands
+ * lookup deliberately runs contextless on the bare pool (no RLS on that
+ * table); the fallback lookup, lifecycle recheck, terminal CAS, and audit
+ * write each manage their own short-lived context; and the per-type handler
+ * dispatch and orphaned branches get their own short org-scoped wraps — so
+ * no step on this path directly acquires a second pooled connection while
+ * another context's connection is held open (#1105).
+ *
+ * Trade-off (deliberate): the terminal CAS commits independently, so a
+ * failure AFTER it (e.g. a handler wrap failing to open under pool
+ * exhaustion) reaches the function-level catch with the command row already
+ * terminal and the ack still sent — the agent won't redeliver, and the
+ * downstream org-table transition is left to the stale-timeout sweeps. The
+ * catch logs + Sentry-captures, so this is loud, not silent.
  */
 async function processCommandResult(
   agentId: string,

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1177,12 +1177,13 @@ export async function processOrphanedCommandResult(
         details: monitorData as Record<string, unknown>
       };
       if (isRedisAvailable()) {
-        // Command results are processed inside a held org-scoped transaction
-        // (runWithAgentDbAccess). runOutsideDbContext exits the ALS context so
-        // instrumented-queue tripwires pass and any nested DB work routes to
-        // the pool — it does NOT release the outer transaction's connection,
-        // which stays held for the (normally short) Redis round-trips; the
-        // full fix is dispatching enqueues after the context closes (#1105).
+        // Orphaned results run inside a SHORT org-scoped transaction
+        // (agentWs.commandResult.orphaned, #3021). runOutsideDbContext exits
+        // the ALS context so instrumented-queue tripwires pass and any nested
+        // DB work routes to the pool — it does NOT release the outer
+        // transaction's connection, which stays held for the (normally short)
+        // Redis round-trips; the full fix is dispatching enqueues after the
+        // context closes (#1105).
         await runOutsideDbContext(() =>
           enqueueMonitorCheckResult(monitorId, checkResult, {
             actorType: 'agent',
@@ -1691,13 +1692,51 @@ export async function processOrphanedCommandResult(
 }
 
 /**
- * Process command result from agent
+ * Open a SHORT org-scoped DB access context for one agent-message DB
+ * operation. Module-level twin of the per-connection `runWithAgentDbAccess`
+ * closure in createAgentWsHandlers (which delegates here) so module-level
+ * paths like processCommandResult can scope individual operations instead of
+ * running under a message-long wrap.
+ *
+ * #3021: contexts opened through this helper must NEVER enclose a nested
+ * `withSystemDbAccessContext` (or any other context-opening helper) —
+ * `runOutsideDbContext` only exits the AsyncLocalStorage, it does NOT release
+ * this context's pooled connection, so nesting holds two connections at once
+ * and self-amplifies pool pressure (the #1105 class; see #2765 for the HTTP
+ * twin). Keep the wrapped work to plain ambient-`db` operations.
+ */
+async function runWithAgentOrgDbAccess<T>(label: string, orgId: string, fn: () => Promise<T>): Promise<T> {
+  return withDbAccessContext(
+    {
+      scope: 'organization',
+      orgId,
+      accessibleOrgIds: [orgId],
+      // Agents are org-scoped; they have no access to partner-level tables.
+      accessiblePartnerIds: [],
+      // Agents don't browse the catalog as org users; null disables the
+      // partner-wide read branch (safe).
+      currentPartnerId: null,
+      label
+    },
+    fn
+  );
+}
+
+/**
+ * Process command result from agent.
+ *
+ * #3021: deliberately NOT wrapped in a message-level org context by the
+ * `command_result` case (the WS twin of #2765). The lookup, lifecycle
+ * recheck, terminal CAS, and audit write below each manage their own
+ * short-lived context, and the per-type handler dispatch gets its own
+ * org-scoped wrap — so no step ever acquires a second pooled connection
+ * while another context's connection is held open (#1105).
  */
 async function processCommandResult(
   agentId: string,
   result: z.infer<typeof commandResultSchema>,
-  deviceId?: string,
-  orgId?: string
+  deviceId: string | undefined,
+  orgId: string
 ): Promise<void> {
   try {
     // #2434 chokepoint — FIRST statement, so "any agent result that enters this
@@ -1723,8 +1762,14 @@ async function processCommandResult(
 
     // Non-UUID command IDs (for example mon-* and snmp-*) are dispatched directly
     // over WebSocket and do not have a device_commands row.
+    // Short org wrap (#3021): the orphaned branches read/write RLS-guarded
+    // org tables (discovery jobs, snmp devices, backup/restore jobs) through
+    // the ambient db, so they need the tenant context the removed
+    // message-level wrap used to provide.
     if (!UUID_REGEX.test(result.commandId)) {
-      await processOrphanedCommandResult(agentId, deviceId ?? '', result);
+      await runWithAgentOrgDbAccess('agentWs.commandResult.orphaned', orgId, () =>
+        processOrphanedCommandResult(agentId, deviceId ?? '', result)
+      );
       return;
     }
 
@@ -1735,10 +1780,12 @@ async function processCommandResult(
     let resolvedDeviceId: string | undefined = deviceId;
 
     if (resolvedDeviceId) {
-      // Query device_commands OUTSIDE the current transaction context.
-      // device_commands has no RLS; leaving the held org-scoped transaction
-      // guarantees visibility of rows committed by the dispatcher after this
-      // transaction began.
+      // Query device_commands OUTSIDE any ambient transaction context.
+      // device_commands has no RLS. Since #3021 removed the message-level org
+      // wrap there normally IS no ambient context here, but runOutsideDbContext
+      // is kept as defense: if a future caller reintroduces one, escaping it
+      // preserves fresh-snapshot visibility of rows the dispatcher committed
+      // after that transaction began.
       //
       // The READ deliberately stays on the bare pool while the write below
       // takes an explicit system context. Only insert/update/delete are
@@ -1770,31 +1817,44 @@ async function processCommandResult(
       );
       command = row;
     } else {
-      // Fallback: resolve deviceId from agentId via devices table
-      const [ownedCommand] = await db
-        .select({
-          command: deviceCommands,
-          deviceId: devices.id
-        })
-        .from(deviceCommands)
-        .innerJoin(devices, eq(deviceCommands.deviceId, devices.id))
-        .where(
-          and(
-            eq(deviceCommands.id, result.commandId),
-            eq(devices.agentId, agentId),
-            eq(deviceCommands.targetRole, 'agent'),
-            inArray(deviceCommands.status, ACCEPTED_COMMAND_RESULT_STATUSES)
-          )
+      // Fallback: resolve deviceId from agentId via devices table. `devices`
+      // IS RLS-guarded, so with no ambient tenant context (#3021) this join
+      // genuinely needs an explicit system context — a bare-pool read would
+      // silently return 0 rows and misroute the result to the orphaned path.
+      // System (not org) scope matches isAgentDeviceStillAuthorized: the
+      // predicate binds devices.agentId to the socket's authenticated agent,
+      // so tenancy is enforced by the key, not the context.
+      const [ownedCommand] = await runOutsideDbContext(() =>
+        withSystemDbAccessContext(() =>
+          db
+            .select({
+              command: deviceCommands,
+              deviceId: devices.id
+            })
+            .from(deviceCommands)
+            .innerJoin(devices, eq(deviceCommands.deviceId, devices.id))
+            .where(
+              and(
+                eq(deviceCommands.id, result.commandId),
+                eq(devices.agentId, agentId),
+                eq(deviceCommands.targetRole, 'agent'),
+                inArray(deviceCommands.status, ACCEPTED_COMMAND_RESULT_STATUSES)
+              )
+            )
+            .limit(1)
         )
-        .limit(1);
+      );
       command = ownedCommand?.command;
       resolvedDeviceId = ownedCommand?.deviceId;
     }
 
     if (!command || !resolvedDeviceId) {
       // Discovery and SNMP commands are dispatched directly via WebSocket
-      // without creating a deviceCommands record. Handle them here.
-      await processOrphanedCommandResult(agentId, deviceId ?? '', result);
+      // without creating a deviceCommands record. Handle them here (short org
+      // wrap for the same reason as the non-UUID branch above, #3021).
+      await runWithAgentOrgDbAccess('agentWs.commandResult.orphaned', orgId, () =>
+        processOrphanedCommandResult(agentId, deviceId ?? '', result)
+      );
       return;
     }
 
@@ -1920,7 +1980,11 @@ async function processCommandResult(
         const rejectedHandler = commandResultHandlers[command.type];
         if (rejectedHandler) {
           try {
-            await rejectedHandler({ agentId, command, result: normalizedResult, resolvedDeviceId: resolvedDeviceId!, stdout });
+            // Short org wrap (#3021): handlers touch RLS-guarded org tables
+            // through the ambient db (same as the happy-path dispatch below).
+            await runWithAgentOrgDbAccess('agentWs.commandResult.handler', orgId, () =>
+              rejectedHandler({ agentId, command, result: normalizedResult, resolvedDeviceId: resolvedDeviceId!, stdout })
+            );
           } catch (handlerErr) {
             console.error(`[AgentWs] Failed to finalize rejected ${command.type} result ${result.commandId}:`, handlerErr);
             captureException(handlerErr);
@@ -1939,14 +2003,18 @@ async function processCommandResult(
     if (DR_COMMAND_TYPES.has(command.type) && typeof commandPayload.drExecutionId === 'string') {
       try {
         const { handleDrCommandResult } = await import('./backup/drResultHandler');
-        await handleDrCommandResult({
-          commandId: result.commandId,
-          commandType: command.type,
-          deviceId: resolvedDeviceId,
-          status: normalizedResult.status,
-          result: normalizedResult.result,
-          payload: commandPayload,
-        });
+        // Short org wrap (#3021): DR result persistence reads/writes
+        // RLS-guarded org tables through the ambient db.
+        await runWithAgentOrgDbAccess('agentWs.commandResult.drResult', orgId, () =>
+          handleDrCommandResult({
+            commandId: result.commandId,
+            commandType: command.type,
+            deviceId: resolvedDeviceId!,
+            status: normalizedResult.status,
+            result: normalizedResult.result,
+            payload: commandPayload,
+          })
+        );
       } catch (err) {
         console.error(`[AgentWs] Failed to persist DR result state for ${result.commandId}:`, err);
         captureException(err);
@@ -1955,8 +2023,8 @@ async function processCommandResult(
       try {
         const { enqueueDrExecutionReconcile } = await import('../jobs/drExecutionWorker');
         const drExecutionId = commandPayload.drExecutionId as string;
-        // Exit the held org-scoped transaction context for the Redis
-        // round-trips (#1105) — see the note on the monitor-result branch.
+        // No ambient context here since #3021; runOutsideDbContext kept so the
+        // instrumented-queue tripwire stays satisfied if one is reintroduced.
         await runOutsideDbContext(() => enqueueDrExecutionReconcile(drExecutionId));
       } catch (err) {
         console.error(`[AgentWs] Failed to enqueue DR reconciliation for ${result.commandId}:`, err);
@@ -1964,10 +2032,16 @@ async function processCommandResult(
       }
     }
 
-    // Dispatch to per-command-type handler if one is registered
+    // Dispatch to per-command-type handler if one is registered.
+    // Short org wrap (#3021): handlers read/write RLS-guarded org tables
+    // (script_executions, discovery_jobs, backup/restore jobs, …) through the
+    // ambient db, so they need the tenant context — but ONLY they do, which is
+    // why the wrap sits here instead of around the whole message.
     const handler = commandResultHandlers[command.type];
     if (handler) {
-      await handler({ agentId, command, result: normalizedResult, resolvedDeviceId: resolvedDeviceId!, stdout });
+      await runWithAgentOrgDbAccess('agentWs.commandResult.handler', orgId, () =>
+        handler({ agentId, command, result: normalizedResult, resolvedDeviceId: resolvedDeviceId!, stdout })
+      );
     }
   } catch (error) {
     console.error(`[AgentWs] Failed to process command result for ${agentId}:`, error);
@@ -1996,20 +2070,7 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
    * sessionId) — they become a Sentry tag and part of the grouping message.
    */
   const runWithAgentDbAccess = async <T>(label: string, fn: () => Promise<T>): Promise<T> => {
-    return withDbAccessContext(
-      {
-        scope: 'organization',
-        orgId: agentDb.orgId,
-        accessibleOrgIds: [agentDb.orgId],
-        // Agents are org-scoped; they have no access to partner-level tables.
-        accessiblePartnerIds: [],
-        // Agents don't browse the catalog as org users; null disables the
-        // partner-wide read branch (safe).
-        currentPartnerId: null,
-        label
-      },
-      fn
-    );
+    return runWithAgentOrgDbAccess(label, agentDb.orgId, fn);
   };
 
   // The delivery epoch this handler set owns, stamped when its socket is
@@ -2543,8 +2604,16 @@ export function createAgentWsHandlers(agentId: string, preValidatedAgent: AgentD
               );
               return;
             }
-            await runWithAgentDbAccess('agentWs.commandResult', async () =>
-              processCommandResult(agentId, parsed.data as z.infer<typeof commandResultSchema>, authenticatedAgent.deviceId, authenticatedAgent.orgId)
+            // #3021: NO message-level org wrap here (the WS twin of #2765).
+            // processCommandResult manages its own short-lived contexts — the
+            // old request-long wrap held one pooled connection idle-in-
+            // transaction while the nested system contexts inside acquired a
+            // second, doubling pool pressure per command result (#1105).
+            await processCommandResult(
+              agentId,
+              parsed.data as z.infer<typeof commandResultSchema>,
+              authenticatedAgent.deviceId,
+              authenticatedAgent.orgId
             );
             ws.send(JSON.stringify({
               type: 'ack',


### PR DESCRIPTION
## Problem

Every agent `command_result` over the WebSocket held **two pooled DB connections at once**: the message-level `runWithAgentDbAccess('agentWs.commandResult', ...)` wrap opened an org-scoped transaction for the whole message, and the nested `runOutsideDbContext(() => withSystemDbAccessContext(...))` steps inside `processCommandResult` (device_commands terminal CAS, lifecycle recheck, audit write) each acquired a second connection while the org connection sat idle-in-transaction. `runOutsideDbContext` only exits the AsyncLocalStorage — it never releases the outer transaction's connection. This is the WS twin of the HTTP `/commands` poll fixed in #2765, and it surfaces in production as the steady ~9.9s `agentWs.commandResult` held-connection warnings (#1105) in both regions.

## Fix

Drop the message-level org wrap; `processCommandResult` now manages its own short contexts:

- **Already self-managed, now un-nested:** the bare-pool `device_commands` lookup, the `outside(system(...))` terminal CAS, `isAgentDeviceStillAuthorized`, and the fire-and-forget audit write each run with no enclosing org transaction.
- **New explicit system context:** the deviceId-less fallback lookup joins RLS-guarded `devices`; with no ambient context a bare-pool read would silently return 0 rows and misroute the result to the orphaned path. Tenancy stays enforced by the authenticated `agentId` key (same shape as `isAgentDeviceStillAuthorized`).
- **New short org wraps where ambient tenant RLS is genuinely needed:** per-type handler dispatch (`agentWs.commandResult.handler`, both the happy path and the validation-rejected finalization), DR result persistence (`agentWs.commandResult.drResult`), and both orphaned-result branches (`agentWs.commandResult.orphaned`), via a module-level `runWithAgentOrgDbAccess` helper the per-connection closure now delegates to.
- **No direct double-hold remains:** nothing under the new wraps uses the `runOutside(system(...))` combo directly (`withSystemDbAccessContext` alone early-returns inside an active context; checked agentWs handlers, `verificationService`, `backupResultPersistence`, `drResultHandler`, `agents/helpers`, vault/software services). **Known residual (pre-existing, not a regression):** `publishEvent` subscribers (webhook delivery, automation worker) open system contexts after exiting the ALS, so command types that publish events still double-hold briefly — now bounded by the short handler wrap instead of the whole message. Tracked as a #1105 follow-up.

## Deliberate semantics changes (called out from review)

- **DR persistence and the per-type handler are no longer one transaction** (`vm_restore_from_backup` / `vm_instant_boot` / `bmr_recover` are in both `DR_COMMAND_TYPES` and `commandResultHandlers`). Previously a throwing handler rolled back `handleDrCommandResult`'s writes; now DR state commits independently — consistent with the DR reconcile enqueue that already fired regardless.
- **Post-CAS failure is terminal-with-ack:** the terminal CAS commits under its own context, so a later failure (e.g. a handler wrap failing to open under pool exhaustion) reaches the function-level catch with the row already terminal and the ack sent — the downstream org-table transition is left to the stale-timeout sweeps. Logged + Sentry-captured, so loud rather than silent. Documented on the function docstring.

## Sibling check (from the issue)

`agentWs.backupProgress` keeps its message wrap: `applyBackupProgress` reads/writes RLS tables through the ambient db and opens no nested system context, so it holds exactly one connection — not the same defect.

## Tests

- New `#3021` suite (3 tests) pins wrapper composition: no `org` frame around the `device_commands` select/CAS or the `devices` recheck; handler dispatch under exactly the short labelled org wrap with the agent's orgId; the deviceId-less fallback lookup under exactly `outside+system` (the silent-0-row branch) with the result honored rather than misrouted; orphaned results under `.orphaned`; the removed message-level label asserted absent. Review verified the suite fails against pre-fix code (not vacuous).
- `pnpm exec vitest run src/routes/agentWs.test.ts`: 90/90 pass (87 existing incl. #1375 / BREEZE-X / BREEZE-H, + 3 new).
- `tsc --noEmit` clean on apps/api.

Closes #3021

🤖 Generated with [Claude Code](https://claude.com/claude-code)