### PR TITLE
fix(api): stop event-loop starvation masquerading as a Postgres CONNECT_TIMEOUT (#3022)

### DIFF
--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -32,6 +32,17 @@ const client = postgres(requestDatabaseConfig.url, {
   max: getDbPoolMax(),
   idle_timeout: 20,
   max_lifetime: 60 * 30,
+  // #3022. This timer is a plain setTimeout inside the driver, so it expires
+  // when the main thread is too busy to run the socket callbacks just as
+  // readily as when the handshake actually fails — see
+  // services/postgresConnectTimeout.ts, which classifies the two apart.
+  //
+  // The literal is duplicated as POSTGRES_CONNECT_TIMEOUT_SECONDS there rather
+  // than imported from there: importing would pull the classifier and the
+  // event-loop monitor into this module's graph, and this module is the one
+  // db/requestDatabasePool.test.ts re-imports under a hard 15s budget. The two
+  // values are pinned together by a contract test in that classifier's suite,
+  // so they cannot drift silently.
   connect_timeout: 10,
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -160,7 +160,21 @@ import { extensionsAdminRoutes } from './routes/extensionsAdmin';
 import { extensionsWebRoutes } from './routes/extensionsWeb';
 import { internalSyntheticRoutes } from './routes/internal/synthetic';
 import { bootstrapPlatformAdmins } from './services/platformAdminBootstrap';
-import { captureException, flushSentry, initSentry } from './services/sentry';
+import {
+  captureException,
+  captureMessage,
+  flushSentry,
+  initSentry,
+  setConnectTimeoutClassifier,
+} from './services/sentry';
+import {
+  getEventLoopLagStats,
+  getEventLoopStarvationThresholdMs,
+  startEventLoopMonitor,
+  stopEventLoopMonitor,
+} from './services/eventLoopMonitor';
+import { createStarvationReporter } from './services/eventLoopStarvationReporter';
+import { diagnoseConnectTimeout } from './services/postgresConnectTimeout';
 import { isBenignRejection, isRecoverablePostgresConnectionTeardown } from './services/rejectionSuppressions';
 import { partnerGuard } from './middleware/partnerGuard';
 import { API_VERSION } from './version';
@@ -463,10 +477,18 @@ app.get('/health/ready', async (c) => {
 
   const allOk = Object.values(checks).every((v) => v === 'ok');
 
+  // #3022 — event-loop lag is REPORTED here but deliberately does NOT feed
+  // `allOk`. Starvation is a load symptom, and failing readiness under load
+  // would pull the instance out of rotation, push its traffic onto the
+  // remaining instances, and starve those in turn. The whole point of surfacing
+  // it is to make the condition diagnosable, not to act on it automatically.
+  const eventLoop = getEventLoopLagStats();
+
   return c.json(
     {
       status: allOk ? 'ready' : 'not_ready',
-      checks
+      checks,
+      eventLoop
     },
     allOk ? 200 : 503
   );
@@ -1031,6 +1053,18 @@ app.onError((err, c) => {
     );
   }
 
+  // #3022 — say out loud what a CONNECT_TIMEOUT actually means before the raw
+  // error is logged. The driver's own message is `write CONNECT_TIMEOUT
+  // <host>:<port>`, which reads as a database or network fault and sent the
+  // original investigation after both; the loop being blocked produces a
+  // byte-identical error. Console-side only (the Sentry tags are set in
+  // captureException) so the explanation is present even when Sentry is
+  // disabled, which is the self-hosted default.
+  const connectTimeout = diagnoseConnectTimeout(err);
+  if (connectTimeout) {
+    console.error(connectTimeout.message);
+  }
+
   // Route unhandled errors to Sentry. Per-route `captureException(err, c)`
   // calls only cover routes with explicit try/catch — anything that throws
   // and falls through to onError was previously invisible to Sentry.
@@ -1401,6 +1435,10 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
   console.log(`[shutdown] Received ${signal}, shutting down gracefully...`);
 
   getWebhookWorker().stop();
+  // The sampler is already unref'd, so this is tidiness rather than a
+  // requirement — it just stops starvation warnings from being emitted about a
+  // process that is deliberately winding down and no longer serving traffic.
+  stopEventLoopMonitor();
   if (auditRetryInterval) {
     clearInterval(auditRetryInterval);
     auditRetryInterval = null;
@@ -1637,6 +1675,27 @@ async function bootstrap(): Promise<void> {
   // (migrations, seeds, self-tests) and the global onError/unhandledRejection
   // handlers are actually captured. No-op unless SENTRY_DSN is set.
   initSentry();
+
+  // #3022 — start measuring event-loop lag immediately after Sentry, and before
+  // migrations/startup checks, so a stall is observable for the whole life of
+  // the process rather than only once it is serving traffic. The monitor is a
+  // native histogram plus one unref'd interval; it holds nothing open and adds
+  // no per-request work. Reports go to the console always, and to Sentry on a
+  // throttle (a single stall produces a run of breaching samples, and this repo
+  // has twice had an unthrottled recurring warning exhaust the event quota).
+  startEventLoopMonitor({
+    onSample: createStarvationReporter({
+      thresholdMs: getEventLoopStarvationThresholdMs,
+      capture: (message, tags) => captureMessage(message, 'warning', undefined, tags),
+    }),
+  });
+
+  // Inject the CONNECT_TIMEOUT classifier into the Sentry layer. It is wired
+  // here rather than imported by services/sentry.ts so that module stays a leaf
+  // — see setConnectTimeoutClassifier for the import-graph reason. Must follow
+  // startEventLoopMonitor: before the monitor runs, every diagnosis correctly
+  // reports 'unknown' rather than guessing.
+  setConnectTimeoutClassifier(diagnoseConnectTimeout);
 
   // Validate configuration before anything else — fail fast on missing/insecure secrets.
   // The validated config is stored as a singleton; retrieve later via getConfig().

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -174,7 +174,7 @@ import {
   stopEventLoopMonitor,
 } from './services/eventLoopMonitor';
 import { createStarvationReporter } from './services/eventLoopStarvationReporter';
-import { diagnoseConnectTimeout } from './services/postgresConnectTimeout';
+import { safeDiagnoseConnectTimeout } from './services/postgresConnectTimeout';
 import { isBenignRejection, isRecoverablePostgresConnectionTeardown } from './services/rejectionSuppressions';
 import { partnerGuard } from './middleware/partnerGuard';
 import { API_VERSION } from './version';
@@ -1060,7 +1060,11 @@ app.onError((err, c) => {
   // byte-identical error. Console-side only (the Sentry tags are set in
   // captureException) so the explanation is present even when Sentry is
   // disabled, which is the self-hosted default.
-  const connectTimeout = diagnoseConnectTimeout(err);
+  //
+  // Must be the never-throwing variant: this runs INSIDE onError and ahead of
+  // captureException, so a throw here would cost the request its JSON 500 and
+  // stop the original error from ever being reported.
+  const connectTimeout = safeDiagnoseConnectTimeout(err);
   if (connectTimeout) {
     console.error(connectTimeout.message);
   }
@@ -1683,19 +1687,36 @@ async function bootstrap(): Promise<void> {
   // no per-request work. Reports go to the console always, and to Sentry on a
   // throttle (a single stall produces a run of breaching samples, and this repo
   // has twice had an unthrottled recurring warning exhaust the event quota).
-  startEventLoopMonitor({
+  const eventLoopMonitor = startEventLoopMonitor({
     onSample: createStarvationReporter({
       thresholdMs: getEventLoopStarvationThresholdMs,
       capture: (message, tags) => captureMessage(message, 'warning', undefined, tags),
     }),
   });
+  // Say whether the instance can see its own loop, and at what settings. Without
+  // this line a disabled or mistuned monitor is completely silent: every
+  // CONNECT_TIMEOUT diagnosis degrades to "unknown" and the only other evidence
+  // is a Prometheus series nobody is alerting on yet. Printing the effective
+  // interval also makes a misparsed env var (parseInt('2s') === 2) visible.
+  if (eventLoopMonitor) {
+    console.log(
+      `[event-loop] Lag monitor started (interval ${eventLoopMonitor.intervalMs}ms, `
+      + `starvation threshold ${getEventLoopStarvationThresholdMs()}ms)`,
+    );
+  } else {
+    console.warn(
+      '[event-loop] Lag monitor DISABLED via EVENT_LOOP_MONITOR_DISABLED — Postgres '
+      + 'CONNECT_TIMEOUT errors will report cause "unknown" because starvation can be '
+      + 'neither ruled in nor out (#3022).',
+    );
+  }
 
   // Inject the CONNECT_TIMEOUT classifier into the Sentry layer. It is wired
   // here rather than imported by services/sentry.ts so that module stays a leaf
   // — see setConnectTimeoutClassifier for the import-graph reason. Must follow
   // startEventLoopMonitor: before the monitor runs, every diagnosis correctly
   // reports 'unknown' rather than guessing.
-  setConnectTimeoutClassifier(diagnoseConnectTimeout);
+  setConnectTimeoutClassifier(safeDiagnoseConnectTimeout);
 
   // Validate configuration before anything else — fail fast on missing/insecure secrets.
   // The validated config is stored as a singleton; retrieve later via getConfig().

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -174,7 +174,10 @@ import {
   stopEventLoopMonitor,
 } from './services/eventLoopMonitor';
 import { createStarvationReporter } from './services/eventLoopStarvationReporter';
-import { safeDiagnoseConnectTimeout } from './services/postgresConnectTimeout';
+import {
+  getConnectTimeoutStarvationThresholdMs,
+  safeDiagnoseConnectTimeout,
+} from './services/postgresConnectTimeout';
 import { isBenignRejection, isRecoverablePostgresConnectionTeardown } from './services/rejectionSuppressions';
 import { partnerGuard } from './middleware/partnerGuard';
 import { API_VERSION } from './version';
@@ -1699,10 +1702,25 @@ async function bootstrap(): Promise<void> {
   // is a Prometheus series nobody is alerting on yet. Printing the effective
   // interval also makes a misparsed env var (parseInt('2s') === 2) visible.
   if (eventLoopMonitor) {
+    // Both thresholds are printed because they can differ: the warn threshold is
+    // the operator's knob, while CONNECT_TIMEOUT attribution caps it at the
+    // connect budget so a raised warn value cannot mis-attribute a timeout.
+    // Printing only the former would advertise 15000ms while diagnosis applied
+    // 10000ms.
     console.log(
       `[event-loop] Lag monitor started (interval ${eventLoopMonitor.intervalMs}ms, `
-      + `starvation threshold ${getEventLoopStarvationThresholdMs()}ms)`,
+      + `warn threshold ${getEventLoopStarvationThresholdMs()}ms, `
+      + `CONNECT_TIMEOUT attribution threshold ${getConnectTimeoutStarvationThresholdMs()}ms)`,
     );
+    // A sampling interval coarser than the warn threshold leaves a blind spot
+    // one interval wide, which degrades every diagnosis in it to "unknown".
+    if (eventLoopMonitor.intervalMs > getEventLoopStarvationThresholdMs()) {
+      console.warn(
+        `[event-loop] EVENT_LOOP_MONITOR_INTERVAL_MS (${eventLoopMonitor.intervalMs}ms) exceeds the `
+        + `starvation threshold (${getEventLoopStarvationThresholdMs()}ms). Stalls shorter than one `
+        + `sampling interval cannot be observed, so CONNECT_TIMEOUT causes will report "unknown" (#3022).`,
+      );
+    }
   } else {
     console.warn(
       '[event-loop] Lag monitor DISABLED via EVENT_LOOP_MONITOR_DISABLED — Postgres '

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -168,7 +168,6 @@ import {
   setConnectTimeoutClassifier,
 } from './services/sentry';
 import {
-  getEventLoopLagStats,
   getEventLoopStarvationThresholdMs,
   startEventLoopMonitor,
   stopEventLoopMonitor,
@@ -480,18 +479,21 @@ app.get('/health/ready', async (c) => {
 
   const allOk = Object.values(checks).every((v) => v === 'ok');
 
-  // #3022 — event-loop lag is REPORTED here but deliberately does NOT feed
-  // `allOk`. Starvation is a load symptom, and failing readiness under load
-  // would pull the instance out of rotation, push its traffic onto the
-  // remaining instances, and starve those in turn. The whole point of surfacing
-  // it is to make the condition diagnosable, not to act on it automatically.
-  const eventLoop = getEventLoopLagStats();
-
+  // #3022 — event-loop lag is deliberately NOT reported here. This endpoint is
+  // unauthenticated (see HEALTH_CHECK_PATHS in middleware/security.ts), and the
+  // lag stats are a live load gradient plus the starvation threshold itself,
+  // which would let an unauthenticated prober measure whether its own load is
+  // starving the instance. What this endpoint already exposes is binary
+  // availability; a tunable pressure readout is a different thing.
+  //
+  // Nothing is lost by the omission: the same numbers are on the auth-gated
+  // /metrics as Prometheus gauges, and the starvation reporter logs to the
+  // console unconditionally. Load balancers — the actual consumers here — read
+  // the status code, not the body.
   return c.json(
     {
       status: allOk ? 'ready' : 'not_ready',
-      checks,
-      eventLoop
+      checks
     },
     allOk ? 200 : 503
   );

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -294,11 +294,11 @@ describe('metrics routes', () => {
       return res.text();
     }
 
-    it('publishes all four series even with no monitor running', async () => {
+    it('publishes every series even with no monitor running', async () => {
       const body = await scrape();
       expect(body).toContain('# TYPE breeze_nodejs_eventloop_lag_max_seconds gauge');
       expect(body).toContain('# TYPE breeze_nodejs_eventloop_lag_window_max_seconds gauge');
-      expect(body).toContain('# TYPE breeze_nodejs_eventloop_lag_mean_seconds gauge');
+      expect(body).toContain('# TYPE breeze_nodejs_eventloop_lag_window_mean_seconds gauge');
       expect(body).toContain('# TYPE breeze_nodejs_eventloop_starved gauge');
       // The one that keeps a blind instance from reading as a healthy one.
       expect(getMetricLine(body, 'breeze_nodejs_eventloop_monitored')).toBe(
@@ -318,8 +318,8 @@ describe('metrics routes', () => {
       expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_max_seconds')).toBe(
         'breeze_nodejs_eventloop_lag_max_seconds 2.5',
       );
-      expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_mean_seconds')).toBe(
-        'breeze_nodejs_eventloop_lag_mean_seconds 0.04',
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_window_mean_seconds')).toBe(
+        'breeze_nodejs_eventloop_lag_window_mean_seconds 0.04',
       );
       expect(getMetricLine(body, 'breeze_nodejs_eventloop_starved')).toBe(
         'breeze_nodejs_eventloop_starved 1',
@@ -343,6 +343,12 @@ describe('metrics routes', () => {
       );
       expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_window_max_seconds')).toBe(
         'breeze_nodejs_eventloop_lag_window_max_seconds 9',
+      );
+      // The mean must be named for the same time base as the window max, not
+      // read as the partner of the instantaneous max — otherwise a recovered
+      // loop publishes a max below its mean.
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_window_mean_seconds')).toBe(
+        'breeze_nodejs_eventloop_lag_window_mean_seconds 0.011',
       );
     });
 

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  EventLoopLagMonitor,
+  stopEventLoopMonitor,
+  __setEventLoopMonitorForTests,
+} from '../services/eventLoopMonitor';
 import { Hono } from 'hono';
 
 const selectMock = vi.hoisted(() => vi.fn());
@@ -203,6 +208,42 @@ function getMetricLine(metrics: string, name: string, labels?: Record<string, st
     .find((line) => line.startsWith(`${name}${labelText} `));
 }
 
+/**
+ * Install a real EventLoopLagMonitor driven by a fake clock and a fake
+ * histogram, so the gauges are exercised through the genuine
+ * getEventLoopLagStats / readLatestEventLoopLag path rather than a stub of it.
+ */
+function installFakeMonitor(first: {
+  maxLagMs: number;
+  meanLagMs: number;
+  /** Wall-clock to advance past the sample, simulating a still-blocked loop. */
+  advanceAfterSampleMs?: number;
+}): { pushSample: (s: { maxLagMs: number; meanLagMs: number }) => void } {
+  const NS = 1e6;
+  const histogram = { max: 0, mean: 0, enable: () => true, disable: () => true, reset() { this.max = 0; this.mean = 0; } };
+  let now = 5_000_000;
+  const sampleIntervalMs = 1_000;
+  const monitor = new EventLoopLagMonitor({
+    sampleIntervalMs,
+    now: () => now,
+    createHistogram: () => histogram as never,
+  });
+  monitor.start();
+
+  const push = (sample: { maxLagMs: number; meanLagMs: number }) => {
+    histogram.max = sample.maxLagMs * NS;
+    histogram.mean = sample.meanLagMs * NS;
+    now += sampleIntervalMs;
+    monitor.sampleNow();
+  };
+
+  push(first);
+  if (first.advanceAfterSampleMs) now += first.advanceAfterSampleMs;
+
+  __setEventLoopMonitorForTests(monitor);
+  return { pushSample: push };
+}
+
 describe('metrics routes', () => {
   let app: Hono;
 
@@ -234,6 +275,90 @@ describe('metrics routes', () => {
     expect(body).toContain('# HELP http_requests_total Total number of HTTP requests');
     expect(body).toContain('http_requests_in_flight 0');
     expect(body).toContain('agent_heartbeat_total{status="success"} 0');
+  });
+
+  // #3022 — these four gauges are the durable production artifact of the
+  // event-loop work. Without a test, deleting the `updateEventLoopMetrics()`
+  // call leaves them pinned at their initialize-time zeros, and every dashboard
+  // reads a perfectly healthy loop forever.
+  describe('event-loop gauges (#3022)', () => {
+    afterEach(() => {
+      stopEventLoopMonitor();
+      __setEventLoopMonitorForTests(null);
+      delete process.env.EVENT_LOOP_STARVATION_WARN_MS;
+    });
+
+    async function scrape(): Promise<string> {
+      const res = await app.request('/metrics', { headers: { Authorization: 'Bearer token' } });
+      expect(res.status).toBe(200);
+      return res.text();
+    }
+
+    it('publishes all four series even with no monitor running', async () => {
+      const body = await scrape();
+      expect(body).toContain('# TYPE breeze_nodejs_eventloop_lag_max_seconds gauge');
+      expect(body).toContain('# TYPE breeze_nodejs_eventloop_lag_window_max_seconds gauge');
+      expect(body).toContain('# TYPE breeze_nodejs_eventloop_lag_mean_seconds gauge');
+      expect(body).toContain('# TYPE breeze_nodejs_eventloop_starved gauge');
+      // The one that keeps a blind instance from reading as a healthy one.
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_monitored')).toBe(
+        'breeze_nodejs_eventloop_monitored 0',
+      );
+    });
+
+    it('tracks a running monitor and reports lag in SECONDS', async () => {
+      process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+      installFakeMonitor({ maxLagMs: 2_500, meanLagMs: 40 });
+
+      const body = await scrape();
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_monitored')).toBe(
+        'breeze_nodejs_eventloop_monitored 1',
+      );
+      // 2500ms -> 2.5s. A ms value here would be 1000x off in every dashboard.
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_max_seconds')).toBe(
+        'breeze_nodejs_eventloop_lag_max_seconds 2.5',
+      );
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_mean_seconds')).toBe(
+        'breeze_nodejs_eventloop_lag_mean_seconds 0.04',
+      );
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_starved')).toBe(
+        'breeze_nodejs_eventloop_starved 1',
+      );
+    });
+
+    it('clears `starved` once the loop recovers, rather than smearing the spike', async () => {
+      process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+      const monitor = installFakeMonitor({ maxLagMs: 9_000, meanLagMs: 20 });
+      // A later, healthy interval. The 9s spike stays the window high-water
+      // mark, but the instantaneous gauge must fall back to the current value —
+      // otherwise `starved == 1 for 1m` fires on a momentary blip.
+      monitor.pushSample({ maxLagMs: 5, meanLagMs: 2 });
+
+      const body = await scrape();
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_starved')).toBe(
+        'breeze_nodejs_eventloop_starved 0',
+      );
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_max_seconds')).toBe(
+        'breeze_nodejs_eventloop_lag_max_seconds 0.005',
+      );
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_window_max_seconds')).toBe(
+        'breeze_nodejs_eventloop_lag_window_max_seconds 9',
+      );
+    });
+
+    it('reports a stall that is still in flight, so a mid-stall scrape is not healthy', async () => {
+      process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+      installFakeMonitor({ maxLagMs: 3, meanLagMs: 1, advanceAfterSampleMs: 8_000 });
+
+      const body = await scrape();
+      // 8s elapsed since the last sample, 1s of which is the scheduled interval.
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_lag_max_seconds')).toBe(
+        'breeze_nodejs_eventloop_lag_max_seconds 7',
+      );
+      expect(getMetricLine(body, 'breeze_nodejs_eventloop_starved')).toBe(
+        'breeze_nodejs_eventloop_starved 1',
+      );
+    });
   });
 
   it('registers the action-intents counter on the live registry', async () => {

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -13,7 +13,7 @@ import { db } from '../db';
 import { deviceMetrics, devices, metricRollups, recoveryReadiness as recoveryReadinessTable, remoteSessions } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
-import { getEventLoopLagStats } from '../services/eventLoopMonitor';
+import { getEventLoopLagStats, readLatestEventLoopLag } from '../services/eventLoopMonitor';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { BACKUP_LOW_READINESS_THRESHOLD } from './backup/constants';
 import {
@@ -393,12 +393,28 @@ const nodejsVersionInfoGauge = new Gauge({
 // #3022 — event-loop lag as a scrapable series. This is the metric whose
 // absence made the original incident a manual investigation: three unrelated
 // Sentry signatures, all downstream of a stalled main thread, and nothing in
-// the dashboards that showed the stall itself. Seconds (not ms) to match
-// Prometheus base-unit convention and the upstream `nodejs_eventloop_lag_*`
-// naming, so existing alert expressions transfer.
+// the dashboards that showed the stall itself.
+//
+// Seconds, per Prometheus base-unit convention. The `breeze_` prefix is
+// deliberate — prom-client's `collectDefaultMetrics()` is not called anywhere in
+// this API, so there is no upstream `nodejs_eventloop_lag_*` series to collide
+// with or to inherit alert rules from. These are ours and are named as such.
+//
+// `_lag_max_seconds` is INSTANTANEOUS (last completed sampling interval plus any
+// in-flight stall), matching upstream's reset-per-collection semantics. Feeding
+// it from the retained high-water mark instead would keep a 1.2s blip elevated
+// for the full retention window, so `starved == 1 for 1m` would fire on a
+// momentary spike and `max_over_time` would count one stall many times. The
+// high-water mark is still published, under a name that says so.
 const eventLoopLagMaxGauge = new Gauge({
   name: 'breeze_nodejs_eventloop_lag_max_seconds',
-  help: 'Worst event-loop delay observed in the retained sampling window',
+  help: 'Event-loop delay over the last completed sampling interval, including any in-flight stall',
+  registers: [register]
+});
+
+const eventLoopLagWindowMaxGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_lag_window_max_seconds',
+  help: 'Worst event-loop delay retained across the whole sampling window (high-water mark)',
   registers: [register]
 });
 
@@ -408,19 +424,20 @@ const eventLoopLagMeanGauge = new Gauge({
   registers: [register]
 });
 
+// Derived from the INSTANTANEOUS lag so it clears as soon as the loop recovers.
 // Exposed as its own series rather than left to a `> threshold` alert
-// expression so the API's own starvation threshold — which is configurable via
+// expression so the API's own starvation threshold — configurable via
 // EVENT_LOOP_STARVATION_WARN_MS — stays the single definition of "starved",
 // instead of being restated (and drifting) in the alerting rules.
 const eventLoopStarvedGauge = new Gauge({
   name: 'breeze_nodejs_eventloop_starved',
-  help: '1 when event-loop lag is at or above the configured starvation threshold, else 0',
+  help: '1 when the current event-loop lag is at or above the configured starvation threshold, else 0',
   registers: [register]
 });
 
 // 0 whenever the monitor is disabled or not yet started. Without this, the
-// three gauges above sit at 0 in exactly that case and read as a perfectly
-// healthy loop — alert on `monitored == 0` to catch a blind instance.
+// gauges above sit at 0 in exactly that case and read as a perfectly healthy
+// loop — alert on `monitored == 0` to catch a blind instance.
 const eventLoopMonitoredGauge = new Gauge({
   name: 'breeze_nodejs_eventloop_monitored',
   help: '1 when event-loop lag instrumentation is running, else 0',
@@ -465,6 +482,7 @@ function initializeMetricDefaults(): void {
   // rule referencing them is never querying a metric that does not exist yet.
   eventLoopMonitoredGauge.set(0);
   eventLoopLagMaxGauge.set(0);
+  eventLoopLagWindowMaxGauge.set(0);
   eventLoopLagMeanGauge.set(0);
   eventLoopStarvedGauge.set(0);
 }
@@ -521,13 +539,17 @@ function updateProcessMetrics(): void {
 
 function updateEventLoopMetrics(): void {
   const stats = getEventLoopLagStats();
+  const latest = readLatestEventLoopLag();
   eventLoopMonitoredGauge.set(stats.monitored ? 1 : 0);
-  // `worstLagMs` rather than `maxLagMs`: it folds in a stall that is still in
-  // flight and therefore has not been recorded as a sample yet. A scrape that
-  // lands mid-stall must not report the loop as healthy.
-  eventLoopLagMaxGauge.set(stats.worstLagMs / 1000);
+  // `worstLagMs` on both, rather than the sampled max: it folds in a stall that
+  // is still in flight and has therefore not been recorded as a sample yet. A
+  // scrape landing mid-stall must not report the loop as healthy.
+  eventLoopLagMaxGauge.set(latest.worstLagMs / 1000);
+  eventLoopLagWindowMaxGauge.set(stats.worstLagMs / 1000);
   eventLoopLagMeanGauge.set(stats.meanLagMs / 1000);
-  eventLoopStarvedGauge.set(stats.starved ? 1 : 0);
+  eventLoopStarvedGauge.set(
+    latest.monitored && latest.worstLagMs >= stats.starvationThresholdMs ? 1 : 0,
+  );
 }
 
 function upsertCounterState(state: Map<string, CounterValue>, labels: Record<string, string>, amount = 1): void {

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -418,8 +418,13 @@ const eventLoopLagWindowMaxGauge = new Gauge({
   registers: [register]
 });
 
-const eventLoopLagMeanGauge = new Gauge({
-  name: 'breeze_nodejs_eventloop_lag_mean_seconds',
+// Named `_window_` to match its time base. It summarises the retained window,
+// while `_lag_max_seconds` is instantaneous — leaving it as a bare `_lag_mean_`
+// made the two read as a matched max/mean pair that they are not, and a
+// recovered loop could publish a max BELOW its mean (0.005 vs 0.011), which on
+// a dashboard reads as an instrumentation bug.
+const eventLoopLagWindowMeanGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_lag_window_mean_seconds',
   help: 'Mean event-loop delay across the retained sampling window',
   registers: [register]
 });
@@ -483,7 +488,7 @@ function initializeMetricDefaults(): void {
   eventLoopMonitoredGauge.set(0);
   eventLoopLagMaxGauge.set(0);
   eventLoopLagWindowMaxGauge.set(0);
-  eventLoopLagMeanGauge.set(0);
+  eventLoopLagWindowMeanGauge.set(0);
   eventLoopStarvedGauge.set(0);
 }
 
@@ -546,7 +551,14 @@ function updateEventLoopMetrics(): void {
   // scrape landing mid-stall must not report the loop as healthy.
   eventLoopLagMaxGauge.set(latest.worstLagMs / 1000);
   eventLoopLagWindowMaxGauge.set(stats.worstLagMs / 1000);
-  eventLoopLagMeanGauge.set(stats.meanLagMs / 1000);
+  eventLoopLagWindowMeanGauge.set(stats.meanLagMs / 1000);
+  // Uses the RAW EVENT_LOOP_STARVATION_WARN_MS, not the connect-window cap that
+  // services/postgresConnectTimeout.ts applies. Deliberate: this gauge tracks
+  // "is the loop unhealthy by the operator's own definition", whereas the cap
+  // exists solely so a raised warn threshold cannot mis-attribute a specific
+  // Postgres timeout. With EVENT_LOOP_STARVATION_WARN_MS above 10s the two can
+  // disagree for the same stall — the gauge reads 0 while Sentry says
+  // event-loop-starvation — and that is the intended reading of each.
   eventLoopStarvedGauge.set(
     latest.monitored && latest.worstLagMs >= stats.starvationThresholdMs ? 1 : 0,
   );

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -13,6 +13,7 @@ import { db } from '../db';
 import { deviceMetrics, devices, metricRollups, recoveryReadiness as recoveryReadinessTable, remoteSessions } from '../db/schema';
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
+import { getEventLoopLagStats } from '../services/eventLoopMonitor';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { BACKUP_LOW_READINESS_THRESHOLD } from './backup/constants';
 import {
@@ -389,6 +390,43 @@ const nodejsVersionInfoGauge = new Gauge({
   registers: [register]
 });
 
+// #3022 — event-loop lag as a scrapable series. This is the metric whose
+// absence made the original incident a manual investigation: three unrelated
+// Sentry signatures, all downstream of a stalled main thread, and nothing in
+// the dashboards that showed the stall itself. Seconds (not ms) to match
+// Prometheus base-unit convention and the upstream `nodejs_eventloop_lag_*`
+// naming, so existing alert expressions transfer.
+const eventLoopLagMaxGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_lag_max_seconds',
+  help: 'Worst event-loop delay observed in the retained sampling window',
+  registers: [register]
+});
+
+const eventLoopLagMeanGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_lag_mean_seconds',
+  help: 'Mean event-loop delay across the retained sampling window',
+  registers: [register]
+});
+
+// Exposed as its own series rather than left to a `> threshold` alert
+// expression so the API's own starvation threshold — which is configurable via
+// EVENT_LOOP_STARVATION_WARN_MS — stays the single definition of "starved",
+// instead of being restated (and drifting) in the alerting rules.
+const eventLoopStarvedGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_starved',
+  help: '1 when event-loop lag is at or above the configured starvation threshold, else 0',
+  registers: [register]
+});
+
+// 0 whenever the monitor is disabled or not yet started. Without this, the
+// three gauges above sit at 0 in exactly that case and read as a perfectly
+// healthy loop — alert on `monitored == 0` to catch a blind instance.
+const eventLoopMonitoredGauge = new Gauge({
+  name: 'breeze_nodejs_eventloop_monitored',
+  help: '1 when event-loop lag instrumentation is running, else 0',
+  registers: [register]
+});
+
 function initializeMetricDefaults(): void {
   httpRequestsInFlight.set(0);
   devicesActiveGauge.set(0);
@@ -423,6 +461,12 @@ function initializeMetricDefaults(): void {
   extensionJobsTotal.labels('unknown', 'unknown').inc(0);
   extensionJobOutcomeTotal.labels('unknown', 'unknown', 'success').inc(0);
   nodejsVersionInfoGauge.labels(process.version).set(1);
+  // Publish the event-loop series from process start so a dashboard or alert
+  // rule referencing them is never querying a metric that does not exist yet.
+  eventLoopMonitoredGauge.set(0);
+  eventLoopLagMaxGauge.set(0);
+  eventLoopLagMeanGauge.set(0);
+  eventLoopStarvedGauge.set(0);
 }
 
 initializeMetricDefaults();
@@ -472,6 +516,18 @@ function normalizeMetricLabel(value: string, fallback: string): string {
 
 function updateProcessMetrics(): void {
   processStartTimeGauge.set(Math.floor(Date.now() / 1000 - process.uptime()));
+  updateEventLoopMetrics();
+}
+
+function updateEventLoopMetrics(): void {
+  const stats = getEventLoopLagStats();
+  eventLoopMonitoredGauge.set(stats.monitored ? 1 : 0);
+  // `worstLagMs` rather than `maxLagMs`: it folds in a stall that is still in
+  // flight and therefore has not been recorded as a sample yet. A scrape that
+  // lands mid-stall must not report the loop as healthy.
+  eventLoopLagMaxGauge.set(stats.worstLagMs / 1000);
+  eventLoopLagMeanGauge.set(stats.meanLagMs / 1000);
+  eventLoopStarvedGauge.set(stats.starved ? 1 : 0);
 }
 
 function upsertCounterState(state: Map<string, CounterValue>, labels: Record<string, string>, amount = 1): void {

--- a/apps/api/src/services/eventLoopMonitor.test.ts
+++ b/apps/api/src/services/eventLoopMonitor.test.ts
@@ -202,6 +202,7 @@ describe('EventLoopLagMonitor', () => {
     // The bug this guards: `monitored: true` with a lag of 0 during the first
     // 10s after boot means "not observed", not "did not happen". Reading it as
     // health produces a confident, WRONG connectivity verdict.
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
     const { monitor, setNow } = makeMonitor({ sampleIntervalMs: 1_000 });
     monitor.start(); // t = 1_000_000
 
@@ -212,16 +213,31 @@ describe('EventLoopLagMonitor', () => {
     expect(monitor.read(10_000).coversWindow).toBe(true);
   });
 
-  it('coversWindow is false when sampling is coarser than the window', () => {
-    // A 12s stall under a 30s interval is invisible: no sample records it, and
-    // inFlightLagMs subtracts a full 30s interval and reads 0.
-    const { monitor, setNow } = makeMonitor({ sampleIntervalMs: 30_000 });
+  it.each([
+    ['coarser than the window', 30_000],
+    ['inside the window but coarser than the starvation threshold', 9_000],
+  ])('coversWindow is false when sampling is %s', (_label, sampleIntervalMs) => {
+    // The blind spot is the current, not-yet-recorded interval, and it is one
+    // INTERVAL wide — not one window wide. At a 9s interval an 8.5s stall fits
+    // entirely inside it: no sample records it and inFlightLagMs subtracts a
+    // full 9s and reads 0. Guarding only `interval > window` left that case
+    // reporting a confident "connectivity".
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    const { monitor, setNow } = makeMonitor({ sampleIntervalMs });
     monitor.start();
 
     setNow(1_600_000); // long uptime — only the interval width disqualifies it
     const reading = monitor.read(10_000);
     expect(reading.monitored).toBe(true);
     expect(reading.coversWindow).toBe(false);
+  });
+
+  it('coversWindow is true when sampling is at least as fine as the threshold', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    const { monitor, setNow } = makeMonitor({ sampleIntervalMs: 1_000 });
+    monitor.start();
+    setNow(1_600_000);
+    expect(monitor.read(10_000).coversWindow).toBe(true);
   });
 
   it('latest() reports the last completed interval, not the retained high-water mark', () => {

--- a/apps/api/src/services/eventLoopMonitor.test.ts
+++ b/apps/api/src/services/eventLoopMonitor.test.ts
@@ -198,6 +198,51 @@ describe('EventLoopLagMonitor', () => {
     expect(monitor.read(10_000).inFlightLagMs).toBe(0);
   });
 
+  it('coversWindow is false until the monitor has run for the full window', () => {
+    // The bug this guards: `monitored: true` with a lag of 0 during the first
+    // 10s after boot means "not observed", not "did not happen". Reading it as
+    // health produces a confident, WRONG connectivity verdict.
+    const { monitor, setNow } = makeMonitor({ sampleIntervalMs: 1_000 });
+    monitor.start(); // t = 1_000_000
+
+    setNow(1_009_999);
+    expect(monitor.read(10_000).coversWindow).toBe(false);
+
+    setNow(1_010_000);
+    expect(monitor.read(10_000).coversWindow).toBe(true);
+  });
+
+  it('coversWindow is false when sampling is coarser than the window', () => {
+    // A 12s stall under a 30s interval is invisible: no sample records it, and
+    // inFlightLagMs subtracts a full 30s interval and reads 0.
+    const { monitor, setNow } = makeMonitor({ sampleIntervalMs: 30_000 });
+    monitor.start();
+
+    setNow(1_600_000); // long uptime — only the interval width disqualifies it
+    const reading = monitor.read(10_000);
+    expect(reading.monitored).toBe(true);
+    expect(reading.coversWindow).toBe(false);
+  });
+
+  it('latest() reports the last completed interval, not the retained high-water mark', () => {
+    const { monitor, histogram, setNow } = makeMonitor({ sampleIntervalMs: 1_000 });
+    monitor.start();
+
+    histogram.setLagMs(9_000);
+    setNow(1_001_000);
+    monitor.sampleNow();
+
+    histogram.setLagMs(4);
+    setNow(1_002_000);
+    monitor.sampleNow();
+
+    setNow(1_002_500);
+    // The 9s spike is still the window high-water mark...
+    expect(monitor.stats().worstLagMs).toBe(9_000);
+    // ...but the loop has recovered, and the instantaneous gauge must say so.
+    expect(monitor.latest().worstLagMs).toBe(4);
+  });
+
   it('prunes samples beyond the retention window', () => {
     const { monitor, histogram, setNow } = makeMonitor({ retentionMs: 5_000 });
     monitor.start();
@@ -277,16 +322,70 @@ describe('EventLoopLagMonitor', () => {
     monitor.stop();
   });
 
-  it('start() is idempotent and does not replace a running histogram', () => {
-    const { monitor, histogram } = makeMonitor();
+  it('start() is idempotent and does not build a second histogram', () => {
+    // The factory MUST mint a fresh instance per call. Returning one shared fake
+    // makes this test vacuous: `histogram.max` survives a rebuild, so deleting
+    // the idempotence guard still passes while production silently discards
+    // recorded data and leaks a second setInterval that stop() never clears.
+    const built: FakeHistogram[] = [];
+    let now = 1_000_000;
+    const monitor = new EventLoopLagMonitor({
+      sampleIntervalMs: 1_000,
+      now: () => now,
+      createHistogram: () => {
+        const h = new FakeHistogram();
+        built.push(h);
+        return h.asIntervalHistogram();
+      },
+    });
+    activeMonitors.push(monitor);
+
     monitor.start();
-    histogram.setLagMs(1_234);
+    built[0]!.setLagMs(1_234);
+    monitor.start();
     monitor.start();
 
-    // A second start() that rebuilt the histogram would silently discard
-    // whatever the loop had already recorded.
-    expect(histogram.max).toBe(1_234 * NS_PER_MS);
+    expect(built).toHaveLength(1);
+    expect(built[0]!.max).toBe(1_234 * NS_PER_MS);
     expect(monitor.running).toBe(true);
+  });
+
+  it('stats() reports starvation from an in-flight stall alone', () => {
+    // The path the Prometheus gauge and /health/ready both take. read() has its
+    // own in-flight coverage; stats() computes its own max independently, and a
+    // scrape landing mid-stall is exactly the one that must not read healthy.
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    const { monitor, histogram, setNow } = makeMonitor({ sampleIntervalMs: 1_000 });
+    monitor.start();
+
+    histogram.setLagMs(5);
+    setNow(1_001_000);
+    monitor.sampleNow();
+    expect(monitor.stats().starved).toBe(false);
+
+    // Loop blocks; no further sample can be recorded.
+    setNow(1_009_000);
+    const stats = monitor.stats();
+    expect(stats.maxLagMs).toBe(5);
+    expect(stats.inFlightLagMs).toBe(7_000);
+    expect(stats.worstLagMs).toBe(7_000);
+    expect(stats.starved).toBe(true);
+  });
+
+  it.each([
+    [1_000, 0],
+    [1_001, 1],
+    [1_600, 600],
+  ])('in-flight lag at exactly %ims since the last sample is %ims', (elapsed, expected) => {
+    // Boundary: inFlight must be 0 at exactly one interval and 1 at one ms past.
+    // An off-by-one skews every mid-stall reading in the same direction.
+    const { monitor, histogram, setNow } = makeMonitor({ sampleIntervalMs: 1_000 });
+    monitor.start();
+    histogram.setLagMs(0);
+    setNow(1_001_000);
+    monitor.sampleNow();
+    setNow(1_001_000 + elapsed);
+    expect(monitor.read(10_000).inFlightLagMs).toBe(expected);
   });
 });
 
@@ -376,6 +475,21 @@ describe('module singleton', () => {
     expect(started).not.toBeNull();
     expect(readEventLoopLag(10_000).monitored).toBe(true);
     expect(getEventLoopLagStats().monitored).toBe(true);
+  });
+
+  it('EVENT_LOOP_MONITOR_DISABLED accepts every documented truthy spelling', () => {
+    for (const value of ['1', 'true', 'YES', ' on ']) {
+      process.env.EVENT_LOOP_MONITOR_DISABLED = value;
+      expect(startEventLoopMonitor(), `value ${value}`).toBeNull();
+    }
+    process.env.EVENT_LOOP_MONITOR_DISABLED = 'false';
+    expect(startEventLoopMonitor()).not.toBeNull();
+  });
+
+  it('startEventLoopMonitor is idempotent across calls', () => {
+    const first = startEventLoopMonitor({ sampleIntervalMs: 50 });
+    const second = startEventLoopMonitor({ sampleIntervalMs: 50 });
+    expect(second).toBe(first);
   });
 
   it('honours EVENT_LOOP_STARVATION_WARN_MS and falls back on a bad value', () => {

--- a/apps/api/src/services/eventLoopMonitor.test.ts
+++ b/apps/api/src/services/eventLoopMonitor.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { IntervalHistogram } from 'node:perf_hooks';
+import {
+  EventLoopLagMonitor,
+  bucketEventLoopLag,
+  getEventLoopLagStats,
+  getEventLoopStarvationThresholdMs,
+  readEventLoopLag,
+  startEventLoopMonitor,
+  stopEventLoopMonitor,
+  __setEventLoopMonitorForTests,
+} from './eventLoopMonitor';
+
+const NS_PER_MS = 1e6;
+
+/**
+ * Minimal stand-in for the native histogram. Only the four members the monitor
+ * touches are implemented; everything else is absent by design so a future
+ * dependency on another member fails loudly in the type checker rather than
+ * silently reading undefined.
+ */
+class FakeHistogram {
+  max = 0;
+  mean = 0;
+  enabled = false;
+  resetCount = 0;
+
+  enable(): boolean {
+    this.enabled = true;
+    return true;
+  }
+
+  disable(): boolean {
+    this.enabled = false;
+    return true;
+  }
+
+  reset(): void {
+    this.resetCount += 1;
+    this.max = 0;
+    this.mean = 0;
+  }
+
+  /** Set the values the next sample will read, in milliseconds. */
+  setLagMs(maxMs: number, meanMs = maxMs): void {
+    this.max = maxMs * NS_PER_MS;
+    this.mean = meanMs * NS_PER_MS;
+  }
+
+  asIntervalHistogram(): IntervalHistogram {
+    return this as unknown as IntervalHistogram;
+  }
+}
+
+interface Harness {
+  monitor: EventLoopLagMonitor;
+  histogram: FakeHistogram;
+  setNow: (ms: number) => void;
+}
+
+/**
+ * Every monitor built here is stopped in afterEach. start() arms a real
+ * setInterval, and vitest shares one worker process across test files — a
+ * leaked sampler keeps firing under whatever runs next, which is exactly how a
+ * suite becomes flaky for files that never touched this module.
+ */
+const activeMonitors: EventLoopLagMonitor[] = [];
+
+function stopActiveMonitors(): void {
+  while (activeMonitors.length > 0) {
+    activeMonitors.pop()!.stop();
+  }
+}
+
+function makeMonitor(options: { sampleIntervalMs?: number; retentionMs?: number } = {}): Harness {
+  const histogram = new FakeHistogram();
+  let now = 1_000_000;
+  const monitor = new EventLoopLagMonitor({
+    sampleIntervalMs: options.sampleIntervalMs ?? 1_000,
+    retentionMs: options.retentionMs ?? 120_000,
+    now: () => now,
+    createHistogram: () => histogram.asIntervalHistogram(),
+  });
+  activeMonitors.push(monitor);
+  return { monitor, histogram, setNow: (ms) => { now = ms; } };
+}
+
+describe('EventLoopLagMonitor', () => {
+  afterEach(() => {
+    stopActiveMonitors();
+    stopEventLoopMonitor();
+    __setEventLoopMonitorForTests(null);
+    delete process.env.EVENT_LOOP_STARVATION_WARN_MS;
+    delete process.env.EVENT_LOOP_MONITOR_DISABLED;
+  });
+
+  it('reports unmonitored until started, and never reports a stopped monitor as healthy', () => {
+    const { monitor } = makeMonitor();
+
+    const before = monitor.read(10_000);
+    expect(before.monitored).toBe(false);
+    expect(before.worstLagMs).toBe(0);
+
+    monitor.start();
+    expect(monitor.read(10_000).monitored).toBe(true);
+
+    monitor.stop();
+    // The distinction that matters: lag 0 + monitored false means "no evidence",
+    // and every consumer must branch on `monitored`, not on the zero.
+    expect(monitor.read(10_000).monitored).toBe(false);
+  });
+
+  it('converts histogram nanoseconds to milliseconds and resets between samples', () => {
+    const { monitor, histogram, setNow } = makeMonitor();
+    monitor.start();
+
+    histogram.setLagMs(2_500, 40);
+    setNow(1_001_000);
+    const sample = monitor.sampleNow();
+
+    expect(sample).toEqual({ atMs: 1_001_000, maxLagMs: 2_500, meanLagMs: 40 });
+    // Reset is what makes each sample cover only its own interval; without it a
+    // single early spike would pin `max` high forever and every later window
+    // would falsely read as starved.
+    expect(histogram.resetCount).toBe(1);
+    expect(histogram.max).toBe(0);
+  });
+
+  it('normalises the empty-histogram sentinels (Infinity max, NaN mean) to zero', () => {
+    const { monitor, histogram, setNow } = makeMonitor();
+    monitor.start();
+
+    // What a native histogram that recorded nothing actually returns.
+    histogram.max = Infinity;
+    histogram.mean = Number.NaN;
+    setNow(1_001_000);
+
+    const sample = monitor.sampleNow();
+    expect(sample?.maxLagMs).toBe(0);
+    expect(sample?.meanLagMs).toBe(0);
+    // NaN >= threshold is false, so an unnormalised value would read as
+    // "healthy" by accident. Assert the normalisation is deliberate.
+    expect(Number.isFinite(sample!.maxLagMs)).toBe(true);
+  });
+
+  it('returns the worst sampled lag inside the window and ignores older samples', () => {
+    const { monitor, histogram, setNow } = makeMonitor();
+    monitor.start();
+
+    histogram.setLagMs(8_000);
+    setNow(1_001_000);
+    monitor.sampleNow();
+
+    for (let i = 2; i <= 20; i += 1) {
+      // Re-arm each interval: sampleNow() resets the histogram, so a single
+      // setLagMs before the loop would only reach the first iteration.
+      histogram.setLagMs(30);
+      setNow(1_000_000 + i * 1_000);
+      monitor.sampleNow();
+    }
+
+    // t=1_020_000. The 8s spike landed at t=1_001_000, i.e. 19s ago.
+    setNow(1_020_000);
+    expect(monitor.read(30_000).sampledMaxLagMs).toBe(8_000);
+    expect(monitor.read(10_000).sampledMaxLagMs).toBe(30);
+  });
+
+  it('surfaces an in-flight stall that has not been sampled yet', () => {
+    const { monitor, histogram, setNow } = makeMonitor({ sampleIntervalMs: 1_000 });
+    monitor.start();
+
+    histogram.setLagMs(5);
+    setNow(1_001_000);
+    monitor.sampleNow();
+
+    // The loop blocks for 8s. The sampler cannot run — it is a timer, and
+    // timers are exactly what a blocked loop does not deliver. This is the
+    // ordering that matters: postgres.js's connect timer may fire before ours,
+    // in which case the stall has not been recorded as a sample yet and only
+    // the in-flight figure can reveal it.
+    setNow(1_009_000);
+    const reading = monitor.read(10_000);
+
+    expect(reading.sampledMaxLagMs).toBe(5);
+    // 8s elapsed since the last sample, 1s of which was the scheduled interval.
+    expect(reading.inFlightLagMs).toBe(7_000);
+    expect(reading.worstLagMs).toBe(7_000);
+  });
+
+  it('does not report in-flight lag while the sampler is keeping up', () => {
+    const { monitor, histogram, setNow } = makeMonitor({ sampleIntervalMs: 1_000 });
+    monitor.start();
+    histogram.setLagMs(3);
+    setNow(1_001_000);
+    monitor.sampleNow();
+
+    setNow(1_001_600);
+    expect(monitor.read(10_000).inFlightLagMs).toBe(0);
+  });
+
+  it('prunes samples beyond the retention window', () => {
+    const { monitor, histogram, setNow } = makeMonitor({ retentionMs: 5_000 });
+    monitor.start();
+    histogram.setLagMs(100);
+
+    for (let i = 1; i <= 30; i += 1) {
+      setNow(1_000_000 + i * 1_000);
+      monitor.sampleNow();
+    }
+
+    // Bounded memory is the point: an always-on sampler must not accumulate
+    // forever in a long-lived API process.
+    expect(monitor.stats().sampleCount).toBeLessThanOrEqual(6);
+  });
+
+  it('flags starvation in stats() once lag reaches the configured threshold', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    const { monitor, histogram, setNow } = makeMonitor();
+    monitor.start();
+
+    histogram.setLagMs(999);
+    setNow(1_001_000);
+    monitor.sampleNow();
+    setNow(1_001_500);
+    expect(monitor.stats().starved).toBe(false);
+
+    histogram.setLagMs(1_000);
+    setNow(1_002_000);
+    monitor.sampleNow();
+    setNow(1_002_500);
+    const stats = monitor.stats();
+    expect(stats.starved).toBe(true);
+    expect(stats.maxLagMs).toBe(1_000);
+    expect(stats.starvationThresholdMs).toBe(1_000);
+  });
+
+  it('invokes onSample for every completed sample', () => {
+    const histogram = new FakeHistogram();
+    let now = 1_000_000;
+    const seen: number[] = [];
+    const monitor = new EventLoopLagMonitor({
+      sampleIntervalMs: 1_000,
+      now: () => now,
+      createHistogram: () => histogram.asIntervalHistogram(),
+      onSample: (s) => seen.push(s.maxLagMs),
+    });
+    monitor.start();
+
+    histogram.setLagMs(42);
+    now = 1_001_000;
+    monitor.sampleNow();
+    histogram.setLagMs(7);
+    now = 1_002_000;
+    monitor.sampleNow();
+
+    expect(seen).toEqual([42, 7]);
+    monitor.stop();
+  });
+
+  it('keeps sampling when the onSample consumer throws', () => {
+    const histogram = new FakeHistogram();
+    let now = 1_000_000;
+    const monitor = new EventLoopLagMonitor({
+      sampleIntervalMs: 1_000,
+      now: () => now,
+      createHistogram: () => histogram.asIntervalHistogram(),
+      onSample: () => { throw new Error('sentry transport exploded'); },
+    });
+    monitor.start();
+
+    histogram.setLagMs(5_000);
+    now = 1_001_000;
+    // A throwing reporter must not kill the interval callback — the monitor
+    // would go silent at exactly the moment it is needed.
+    expect(() => monitor.sampleNow()).not.toThrow();
+    expect(monitor.read(10_000).sampledMaxLagMs).toBe(5_000);
+    monitor.stop();
+  });
+
+  it('start() is idempotent and does not replace a running histogram', () => {
+    const { monitor, histogram } = makeMonitor();
+    monitor.start();
+    histogram.setLagMs(1_234);
+    monitor.start();
+
+    // A second start() that rebuilt the histogram would silently discard
+    // whatever the loop had already recorded.
+    expect(histogram.max).toBe(1_234 * NS_PER_MS);
+    expect(monitor.running).toBe(true);
+  });
+});
+
+describe('EventLoopLagMonitor against a real blocked loop', () => {
+  afterEach(() => {
+    stopActiveMonitors();
+    stopEventLoopMonitor();
+    __setEventLoopMonitorForTests(null);
+  });
+
+  it('records a genuine synchronous stall via the native histogram', async () => {
+    // The load-bearing assumption of this whole module: perf_hooks'
+    // monitorEventLoopDelay is a libuv-level timer, so it keeps accumulating
+    // while JS is blocked and reports the full delay on the first tick after
+    // the loop frees up. If that were not true, nothing here could observe the
+    // starvation it exists to detect — so prove it against a real stall rather
+    // than only against the fake histogram used everywhere else in this file.
+    const monitor = new EventLoopLagMonitor({ sampleIntervalMs: 10_000, resolutionMs: 10 });
+    monitor.start();
+
+    // Let the histogram arm itself before blocking.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const blockUntil = Date.now() + 250;
+    while (Date.now() < blockUntil) {
+      // Busy-wait: a real pegged main thread, not a fake clock.
+    }
+
+    // Yield once so the libuv timer gets its post-stall tick in.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const sample = monitor.sampleNow();
+    expect(sample).not.toBeNull();
+    // Allow generous slack for CI scheduling noise; the assertion is that a
+    // 250ms block is visible at all, not its precise magnitude.
+    expect(sample!.maxLagMs).toBeGreaterThan(100);
+
+    monitor.stop();
+  });
+});
+
+describe('bucketEventLoopLag', () => {
+  it.each([
+    [0, 'under-1s'],
+    [999, 'under-1s'],
+    [1_000, '1s-5s'],
+    [4_999, '1s-5s'],
+    [5_000, '5s-10s'],
+    [9_999, '5s-10s'],
+    [10_000, 'over-10s'],
+    [60_000, 'over-10s'],
+  ])('buckets %ims as %s', (lagMs, expected) => {
+    expect(bucketEventLoopLag(lagMs)).toBe(expected);
+  });
+
+  it('returns "unknown" when nothing was monitored', () => {
+    expect(bucketEventLoopLag(50_000, false)).toBe('unknown');
+  });
+});
+
+describe('module singleton', () => {
+  beforeEach(() => {
+    stopEventLoopMonitor();
+    __setEventLoopMonitorForTests(null);
+  });
+
+  afterEach(() => {
+    stopEventLoopMonitor();
+    __setEventLoopMonitorForTests(null);
+    delete process.env.EVENT_LOOP_MONITOR_DISABLED;
+    delete process.env.EVENT_LOOP_STARVATION_WARN_MS;
+  });
+
+  it('reports unmonitored readings when no monitor is installed', () => {
+    expect(readEventLoopLag(10_000).monitored).toBe(false);
+    expect(getEventLoopLagStats().monitored).toBe(false);
+  });
+
+  it('EVENT_LOOP_MONITOR_DISABLED opts out without pretending the loop is healthy', () => {
+    process.env.EVENT_LOOP_MONITOR_DISABLED = 'true';
+    expect(startEventLoopMonitor()).toBeNull();
+    expect(readEventLoopLag(10_000).monitored).toBe(false);
+  });
+
+  it('starts a real monitor and reads through the singleton accessors', () => {
+    const started = startEventLoopMonitor({ sampleIntervalMs: 50 });
+    expect(started).not.toBeNull();
+    expect(readEventLoopLag(10_000).monitored).toBe(true);
+    expect(getEventLoopLagStats().monitored).toBe(true);
+  });
+
+  it('honours EVENT_LOOP_STARVATION_WARN_MS and falls back on a bad value', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '250';
+    expect(getEventLoopStarvationThresholdMs()).toBe(250);
+
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = 'not-a-number';
+    expect(getEventLoopStarvationThresholdMs()).toBe(1_000);
+
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '0';
+    expect(getEventLoopStarvationThresholdMs()).toBe(1_000);
+  });
+});

--- a/apps/api/src/services/eventLoopMonitor.ts
+++ b/apps/api/src/services/eventLoopMonitor.ts
@@ -331,8 +331,35 @@ export class EventLoopLagMonitor {
    */
   private coversWindow(nowMs: number, windowMs: number): boolean {
     if (this.startedAtMs === 0) return false;
-    if (this.sampleIntervalMs > windowMs) return false;
+    if (this.sampleIntervalMs > this.blindSpotBudgetMs(windowMs)) return false;
     return nowMs - this.startedAtMs >= windowMs;
+  }
+
+  /**
+   * Largest sampling interval whose blind spot is still tolerable for a query
+   * about `windowMs`.
+   *
+   * The blind spot is the CURRENT, not-yet-recorded interval: a stall that
+   * starts and ends inside it is captured by no sample, and `inFlightLagMs`
+   * subtracts a full interval so it reads 0. That hole is `sampleIntervalMs`
+   * wide — it is NOT bounded by `windowMs`. Comparing the interval against the
+   * window alone (the first version of this guard) therefore only caught the
+   * extreme case: at a 9s interval and a 10s window, an 8.5s stall sitting
+   * inside one interval still produced `coversWindow: true` and a confident
+   * "the event loop stayed healthy, check database reachability".
+   *
+   * The invariant that actually holds is `sampleIntervalMs <= starvation
+   * threshold`: a stall big enough to matter then necessarily crosses an
+   * interval boundary and becomes visible, either as a delayed sample or as
+   * in-flight lag. The window is kept as a second bound so a query narrower
+   * than the threshold is judged on its own terms.
+   *
+   * Note the shipped defaults satisfy this only by coincidence
+   * (DEFAULT_SAMPLE_INTERVAL_MS === DEFAULT_STARVATION_MS === 1000), which is
+   * exactly why it is enforced rather than assumed.
+   */
+  private blindSpotBudgetMs(windowMs: number): number {
+    return Math.min(windowMs, getEventLoopStarvationThresholdMs());
   }
 
   /**

--- a/apps/api/src/services/eventLoopMonitor.ts
+++ b/apps/api/src/services/eventLoopMonitor.ts
@@ -1,0 +1,430 @@
+/**
+ * Event-loop lag instrumentation (#3022).
+ *
+ * Why this exists: the API is a single-threaded Node process, so every timer it
+ * arms is really a promise about *scheduling*, not about elapsed wall-clock
+ * work. postgres.js arms `connect_timeout` with a plain `setTimeout`
+ * (`connection.js:1042-1054`, started in `connect()` and cancelled only on
+ * ReadyForQuery), which means the 10s budget covers socket create → TCP → SSL →
+ * auth → ReadyForQuery *and* every socket callback in between. When the main
+ * thread is pegged, none of those callbacks get scheduled and the driver reports
+ * `write CONNECT_TIMEOUT <host>:<port>` — a connection fault that never
+ * happened. The database and the network are healthy the whole time.
+ *
+ * That misattribution is the expensive part: the incident in #3022 presented as
+ * three unrelated Sentry signatures (CONNECT_TIMEOUT, a `nextWrite` TypeError
+ * from the teardown race, and a patch-scheduler sweep failure) with no way to
+ * tell from telemetry alone that they were one starvation event. This module
+ * makes the loop's own health a first-class, queryable signal so the next
+ * occurrence is diagnosable from metrics instead of by hand.
+ *
+ * Measurement source is `perf_hooks.monitorEventLoopDelay`, a libuv-level timer
+ * that records the delta between when it was due and when it actually ran. It
+ * keeps accumulating while JS is blocked, so a 12s stall shows up as a ~12s
+ * `max` on the first tick after the loop frees up. Overhead is a native
+ * histogram update every `resolution` ms — negligible next to request work.
+ *
+ * NOTE ON DELIBERATE NON-GOALS: this module measures and reports. It does not
+ * raise `connect_timeout` (per #3022 that lengthens the failing request without
+ * fixing anything) and it does not retry, shed load, or otherwise change request
+ * behaviour. Reducing the per-request main-thread work that causes the stall is
+ * separate work.
+ */
+
+import { monitorEventLoopDelay, type IntervalHistogram } from 'node:perf_hooks';
+
+const NS_PER_MS = 1e6;
+
+/** How often the histogram is snapshotted into the retained window. */
+const DEFAULT_SAMPLE_INTERVAL_MS = 1_000;
+/** How much sample history to retain for window queries. */
+const DEFAULT_RETENTION_MS = 120_000;
+/**
+ * Resolution of the underlying libuv sampling timer. 20ms keeps the histogram
+ * meaningful for ordinary request latency without the monitor itself becoming
+ * loop pressure.
+ */
+const DEFAULT_RESOLUTION_MS = 20;
+/**
+ * Lag at or above which the loop is considered starved. A whole second of
+ * blocked loop is already pathological for an API that answers agent traffic in
+ * tens of milliseconds; below that, a spike is more likely GC or a chunky-but-
+ * bounded handler. This is a "the loop is definitely unhealthy" marker, not a
+ * proof that any particular timeout was caused by it — callers should report the
+ * measured lag alongside the verdict rather than asserting causation.
+ */
+const DEFAULT_STARVATION_MS = 1_000;
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = Number.parseInt(process.env[name] ?? '', 10);
+  if (!Number.isFinite(raw) || raw <= 0) {
+    return fallback;
+  }
+  return raw;
+}
+
+/**
+ * Lag at or above which a reading is treated as event-loop starvation.
+ * Tunable via `EVENT_LOOP_STARVATION_WARN_MS`.
+ */
+export function getEventLoopStarvationThresholdMs(): number {
+  return readPositiveIntEnv('EVENT_LOOP_STARVATION_WARN_MS', DEFAULT_STARVATION_MS);
+}
+
+/**
+ * Bounded lag bands. Used wherever the lag becomes a Sentry tag: a tag carrying
+ * raw milliseconds takes a distinct value on every event, which fills the tag
+ * index with singletons and is useless for Sentry's "break down by". The exact
+ * figure always travels in the log line instead.
+ */
+export type EventLoopLagBucket = 'unknown' | 'under-1s' | '1s-5s' | '5s-10s' | 'over-10s';
+
+export function bucketEventLoopLag(lagMs: number, monitored = true): EventLoopLagBucket {
+  if (!monitored) return 'unknown';
+  if (lagMs >= 10_000) return 'over-10s';
+  if (lagMs >= 5_000) return '5s-10s';
+  if (lagMs >= 1_000) return '1s-5s';
+  return 'under-1s';
+}
+
+/** One snapshot of the delay histogram, covering the interval since the previous sample. */
+export interface EventLoopLagSample {
+  /** `Date.now()` at which the sample was taken. */
+  atMs: number;
+  /** Worst delay observed during this sample's interval, in ms. */
+  maxLagMs: number;
+  /** Mean delay observed during this sample's interval, in ms. */
+  meanLagMs: number;
+}
+
+/** Answer to "how badly was the loop blocked over the last N ms?". */
+export interface EventLoopLagReading {
+  /**
+   * False when no monitor is running (monitor disabled, or a unit test that
+   * never started one). Callers MUST treat this as "unknown" and must not
+   * conclude anything from the zeroed lag fields — failing open to "not
+   * starved" would silently re-create the misattribution this module exists to
+   * remove.
+   */
+  monitored: boolean;
+  /** Worst lag recorded by a completed sample inside the window, in ms. */
+  sampledMaxLagMs: number;
+  /**
+   * Lag that has accrued since the last completed sample and has therefore not
+   * been recorded yet, in ms. This is what catches a stall that is still in
+   * progress — or one that just ended, when the timer being diagnosed happened
+   * to fire before the monitor's own sampling timer got its turn.
+   */
+  inFlightLagMs: number;
+  /** `max(sampledMaxLagMs, inFlightLagMs)` — the figure to reason about. */
+  worstLagMs: number;
+  /** How many completed samples fell inside the window. */
+  sampleCount: number;
+}
+
+export interface EventLoopLagStats {
+  monitored: boolean;
+  /** Width of the retained history actually summarised here, in ms. */
+  windowMs: number;
+  sampleCount: number;
+  /** Worst single delay across the retained window, in ms. */
+  maxLagMs: number;
+  /** Mean of the per-sample means across the retained window, in ms. */
+  meanLagMs: number;
+  inFlightLagMs: number;
+  worstLagMs: number;
+  /** True when `worstLagMs` is at or above the starvation threshold. */
+  starved: boolean;
+  starvationThresholdMs: number;
+}
+
+const UNMONITORED_READING: EventLoopLagReading = Object.freeze({
+  monitored: false,
+  sampledMaxLagMs: 0,
+  inFlightLagMs: 0,
+  worstLagMs: 0,
+  sampleCount: 0,
+});
+
+export interface EventLoopLagMonitorOptions {
+  sampleIntervalMs?: number;
+  retentionMs?: number;
+  resolutionMs?: number;
+  /** Injected for tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Injected for tests. Defaults to `perf_hooks.monitorEventLoopDelay`. */
+  createHistogram?: (opts: { resolution: number }) => IntervalHistogram;
+  /**
+   * Called with every completed sample. The production wiring uses this to emit
+   * a throttled warning; tests use it to assert without real timers.
+   */
+  onSample?: (sample: EventLoopLagSample) => void;
+}
+
+/**
+ * Records event-loop delay into a bounded ring of per-interval samples and
+ * answers windowed "worst lag" questions about them.
+ *
+ * Timers and the clock are injectable so the window arithmetic is unit-testable
+ * without blocking a real event loop for seconds at a time. `sampleNow()` is
+ * public for exactly that reason — production drives it from an interval.
+ */
+export class EventLoopLagMonitor {
+  private readonly sampleIntervalMs: number;
+  private readonly retentionMs: number;
+  private readonly resolutionMs: number;
+  private readonly now: () => number;
+  private readonly createHistogram: (opts: { resolution: number }) => IntervalHistogram;
+  private readonly onSample?: (sample: EventLoopLagSample) => void;
+
+  private histogram: IntervalHistogram | null = null;
+  private timer: NodeJS.Timeout | null = null;
+  private samples: EventLoopLagSample[] = [];
+  /**
+   * When the current (not yet recorded) sampling interval began. Seeded at
+   * `start()` so in-flight lag is meaningful before the first sample lands.
+   */
+  private intervalStartedAtMs = 0;
+
+  constructor(options: EventLoopLagMonitorOptions = {}) {
+    this.sampleIntervalMs = options.sampleIntervalMs
+      ?? readPositiveIntEnv('EVENT_LOOP_MONITOR_INTERVAL_MS', DEFAULT_SAMPLE_INTERVAL_MS);
+    this.retentionMs = options.retentionMs ?? DEFAULT_RETENTION_MS;
+    this.resolutionMs = options.resolutionMs ?? DEFAULT_RESOLUTION_MS;
+    this.now = options.now ?? Date.now;
+    this.createHistogram = options.createHistogram ?? monitorEventLoopDelay;
+    this.onSample = options.onSample;
+  }
+
+  get running(): boolean {
+    return this.histogram !== null;
+  }
+
+  /** Idempotent. Safe to call from a boot path that may run twice. */
+  start(): void {
+    if (this.histogram) return;
+    this.histogram = this.createHistogram({ resolution: this.resolutionMs });
+    this.histogram.enable();
+    this.intervalStartedAtMs = this.now();
+    this.samples = [];
+
+    // `unref()` so the monitor never holds the process open during shutdown —
+    // an observability timer must not be the reason a container refuses to exit.
+    const timer = setInterval(() => this.sampleNow(), this.sampleIntervalMs);
+    timer.unref?.();
+    this.timer = timer;
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.histogram) {
+      this.histogram.disable();
+      this.histogram = null;
+    }
+    this.samples = [];
+    this.intervalStartedAtMs = 0;
+  }
+
+  /**
+   * Snapshot the histogram into the retained window and reset it so the next
+   * sample covers only the next interval. Returns the recorded sample, or null
+   * when the monitor is not running.
+   */
+  sampleNow(): EventLoopLagSample | null {
+    const histogram = this.histogram;
+    if (!histogram) return null;
+
+    const atMs = this.now();
+    // `max` is Infinity and `mean` is NaN on a histogram that recorded nothing
+    // (possible for the very first tick, or with a resolution coarser than the
+    // interval). Normalise to 0 rather than letting a non-finite value leak into
+    // a comparison — `NaN >= threshold` is false, which would read as "healthy"
+    // by accident rather than by decision.
+    const sample: EventLoopLagSample = {
+      atMs,
+      maxLagMs: finiteMs(histogram.max),
+      meanLagMs: finiteMs(histogram.mean),
+    };
+    histogram.reset();
+    this.intervalStartedAtMs = atMs;
+
+    this.samples.push(sample);
+    this.pruneTo(atMs);
+
+    // An observability hook must never break the sampler that feeds it: if the
+    // consumer throws (Sentry transport hiccup, logger misconfiguration) the
+    // interval callback would otherwise die as an unhandled rejection and the
+    // monitor would go quiet exactly when it matters.
+    if (this.onSample) {
+      try {
+        this.onSample(sample);
+      } catch {
+        // Intentionally ignored — see above.
+      }
+    }
+
+    return sample;
+  }
+
+  /** Worst lag over the last `windowMs`, including any stall still in flight. */
+  read(windowMs: number): EventLoopLagReading {
+    if (!this.histogram) return UNMONITORED_READING;
+
+    const nowMs = this.now();
+    const cutoff = nowMs - windowMs;
+    let sampledMaxLagMs = 0;
+    let sampleCount = 0;
+    for (const sample of this.samples) {
+      if (sample.atMs < cutoff) continue;
+      sampleCount += 1;
+      if (sample.maxLagMs > sampledMaxLagMs) sampledMaxLagMs = sample.maxLagMs;
+    }
+
+    const inFlightLagMs = this.inFlightLagMs(nowMs);
+    return {
+      monitored: true,
+      sampledMaxLagMs,
+      inFlightLagMs,
+      worstLagMs: Math.max(sampledMaxLagMs, inFlightLagMs),
+      sampleCount,
+    };
+  }
+
+  /** Summary of the whole retained window, for the health endpoint. */
+  stats(): EventLoopLagStats {
+    const starvationThresholdMs = getEventLoopStarvationThresholdMs();
+    if (!this.histogram) {
+      return {
+        monitored: false,
+        windowMs: this.retentionMs,
+        sampleCount: 0,
+        maxLagMs: 0,
+        meanLagMs: 0,
+        inFlightLagMs: 0,
+        worstLagMs: 0,
+        starved: false,
+        starvationThresholdMs,
+      };
+    }
+
+    const nowMs = this.now();
+    this.pruneTo(nowMs);
+    let maxLagMs = 0;
+    let meanTotal = 0;
+    for (const sample of this.samples) {
+      if (sample.maxLagMs > maxLagMs) maxLagMs = sample.maxLagMs;
+      meanTotal += sample.meanLagMs;
+    }
+    const sampleCount = this.samples.length;
+    const inFlightLagMs = this.inFlightLagMs(nowMs);
+    const worstLagMs = Math.max(maxLagMs, inFlightLagMs);
+
+    return {
+      monitored: true,
+      windowMs: this.retentionMs,
+      sampleCount,
+      maxLagMs: round2(maxLagMs),
+      meanLagMs: sampleCount > 0 ? round2(meanTotal / sampleCount) : 0,
+      inFlightLagMs: round2(inFlightLagMs),
+      worstLagMs: round2(worstLagMs),
+      starved: worstLagMs >= starvationThresholdMs,
+      starvationThresholdMs,
+    };
+  }
+
+  /**
+   * How long the current sampling interval has overrun its scheduled length.
+   * Zero while the sampler is keeping up; grows in real time while the loop is
+   * blocked, which is what makes an in-progress stall observable at all.
+   */
+  private inFlightLagMs(nowMs: number): number {
+    if (this.intervalStartedAtMs === 0) return 0;
+    return Math.max(0, nowMs - this.intervalStartedAtMs - this.sampleIntervalMs);
+  }
+
+  private pruneTo(nowMs: number): void {
+    const cutoff = nowMs - this.retentionMs;
+    // Samples are appended in time order, so dropping the leading run is enough.
+    let firstKept = 0;
+    while (firstKept < this.samples.length && this.samples[firstKept]!.atMs < cutoff) {
+      firstKept += 1;
+    }
+    if (firstKept > 0) {
+      this.samples = this.samples.slice(firstKept);
+    }
+  }
+}
+
+function finiteMs(nanoseconds: number): number {
+  if (!Number.isFinite(nanoseconds) || nanoseconds <= 0) return 0;
+  return nanoseconds / NS_PER_MS;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide singleton
+// ---------------------------------------------------------------------------
+
+let monitor: EventLoopLagMonitor | null = null;
+
+/**
+ * Start the process-wide monitor. Idempotent — a second call is a no-op rather
+ * than a second histogram. Set `EVENT_LOOP_MONITOR_DISABLED` to a truthy value
+ * to opt out entirely (readings then report `monitored: false`, which every
+ * consumer treats as "unknown", never as "healthy").
+ */
+export function startEventLoopMonitor(
+  options: EventLoopLagMonitorOptions = {},
+): EventLoopLagMonitor | null {
+  if (isEventLoopMonitorDisabled()) return null;
+  if (!monitor) {
+    monitor = new EventLoopLagMonitor(options);
+  }
+  monitor.start();
+  return monitor;
+}
+
+export function stopEventLoopMonitor(): void {
+  monitor?.stop();
+  monitor = null;
+}
+
+const DISABLED_VALUES = new Set(['1', 'true', 'yes', 'on']);
+function isEventLoopMonitorDisabled(): boolean {
+  return DISABLED_VALUES.has((process.env.EVENT_LOOP_MONITOR_DISABLED ?? '').trim().toLowerCase());
+}
+
+/** TEST ONLY. Install a monitor built with injected clock/histogram. */
+export function __setEventLoopMonitorForTests(next: EventLoopLagMonitor | null): void {
+  monitor = next;
+}
+
+/**
+ * Worst event-loop lag over the last `windowMs`. Returns an unmonitored reading
+ * when no monitor is running — callers must not read that as "healthy".
+ */
+export function readEventLoopLag(windowMs: number): EventLoopLagReading {
+  return monitor?.read(windowMs) ?? UNMONITORED_READING;
+}
+
+/** Retained-window summary for health/diagnostic endpoints. */
+export function getEventLoopLagStats(): EventLoopLagStats {
+  if (monitor) return monitor.stats();
+  return {
+    monitored: false,
+    windowMs: 0,
+    sampleCount: 0,
+    maxLagMs: 0,
+    meanLagMs: 0,
+    inFlightLagMs: 0,
+    worstLagMs: 0,
+    starved: false,
+    starvationThresholdMs: getEventLoopStarvationThresholdMs(),
+  };
+}

--- a/apps/api/src/services/eventLoopMonitor.ts
+++ b/apps/api/src/services/eventLoopMonitor.ts
@@ -107,6 +107,22 @@ export interface EventLoopLagReading {
    * remove.
    */
   monitored: boolean;
+  /**
+   * False when a monitor IS running but cannot vouch for the whole window, so a
+   * lag of 0 means "not observed" rather than "did not happen". Two reachable
+   * cases, and `monitored` alone catches neither:
+   *
+   *   1. The monitor has been up for less than `windowMs` — every diagnosis in
+   *      the first 10s after boot or after a restart of the singleton.
+   *   2. `sampleIntervalMs > windowMs`. Sampling coarser than the window leaves
+   *      a blind spot exactly one interval wide: a stall that ends before the
+   *      next sample is not recorded, and `inFlightLagMs` (which subtracts a
+   *      full interval) still reads 0. A 12s stall under a 30s interval is
+   *      invisible.
+   *
+   * Treat false the same as `monitored: false` — unknown, never healthy.
+   */
+  coversWindow: boolean;
   /** Worst lag recorded by a completed sample inside the window, in ms. */
   sampledMaxLagMs: number;
   /**
@@ -140,6 +156,7 @@ export interface EventLoopLagStats {
 
 const UNMONITORED_READING: EventLoopLagReading = Object.freeze({
   monitored: false,
+  coversWindow: false,
   sampledMaxLagMs: 0,
   inFlightLagMs: 0,
   worstLagMs: 0,
@@ -180,6 +197,8 @@ export class EventLoopLagMonitor {
   private histogram: IntervalHistogram | null = null;
   private timer: NodeJS.Timeout | null = null;
   private samples: EventLoopLagSample[] = [];
+  /** Wall clock at start(), so read() can tell how much window it can vouch for. */
+  private startedAtMs = 0;
   /**
    * When the current (not yet recorded) sampling interval began. Seeded at
    * `start()` so in-flight lag is meaningful before the first sample lands.
@@ -200,12 +219,18 @@ export class EventLoopLagMonitor {
     return this.histogram !== null;
   }
 
+  /** Effective sampling interval, for the boot log. */
+  get intervalMs(): number {
+    return this.sampleIntervalMs;
+  }
+
   /** Idempotent. Safe to call from a boot path that may run twice. */
   start(): void {
     if (this.histogram) return;
     this.histogram = this.createHistogram({ resolution: this.resolutionMs });
     this.histogram.enable();
     this.intervalStartedAtMs = this.now();
+    this.startedAtMs = this.intervalStartedAtMs;
     this.samples = [];
 
     // `unref()` so the monitor never holds the process open during shutdown —
@@ -226,6 +251,7 @@ export class EventLoopLagMonitor {
     }
     this.samples = [];
     this.intervalStartedAtMs = 0;
+    this.startedAtMs = 0;
   }
 
   /**
@@ -286,10 +312,54 @@ export class EventLoopLagMonitor {
     const inFlightLagMs = this.inFlightLagMs(nowMs);
     return {
       monitored: true,
+      coversWindow: this.coversWindow(nowMs, windowMs),
       sampledMaxLagMs,
       inFlightLagMs,
       worstLagMs: Math.max(sampledMaxLagMs, inFlightLagMs),
       sampleCount,
+    };
+  }
+
+  /**
+   * Whether this monitor can account for the whole of the last `windowMs`.
+   *
+   * Requires both that it has been running at least that long, and that it
+   * samples at least as often as the window is wide — sampling coarser than the
+   * window leaves an interval-wide hole that neither a recorded sample nor the
+   * in-flight figure can fill. Callers must degrade to "unknown" when this is
+   * false rather than reading the accompanying zeros as health.
+   */
+  private coversWindow(nowMs: number, windowMs: number): boolean {
+    if (this.startedAtMs === 0) return false;
+    if (this.sampleIntervalMs > windowMs) return false;
+    return nowMs - this.startedAtMs >= windowMs;
+  }
+
+  /**
+   * Lag attributable to the most recent completed sampling interval, folded with
+   * any stall still in flight.
+   *
+   * This is the *instantaneous* figure, as distinct from `stats()`, which is a
+   * high-water mark over the whole retained window. Prometheus wants this one:
+   * a gauge fed from a 120s high-water mark keeps reporting a 1.2s blip for two
+   * minutes after the loop recovered, so `starved == 1 for 1m` fires on a
+   * momentary spike and `max_over_time` counts the same stall repeatedly.
+   */
+  latest(): EventLoopLagReading {
+    if (!this.histogram) return UNMONITORED_READING;
+    const nowMs = this.now();
+    const last = this.samples[this.samples.length - 1];
+    const sampledMaxLagMs = last?.maxLagMs ?? 0;
+    const inFlightLagMs = this.inFlightLagMs(nowMs);
+    return {
+      monitored: true,
+      // One interval is by definition covered once a sample exists; before the
+      // first sample only the in-flight figure speaks, so say so.
+      coversWindow: last !== undefined,
+      sampledMaxLagMs,
+      inFlightLagMs,
+      worstLagMs: Math.max(sampledMaxLagMs, inFlightLagMs),
+      sampleCount: last ? 1 : 0,
     };
   }
 
@@ -413,12 +483,22 @@ export function readEventLoopLag(windowMs: number): EventLoopLagReading {
   return monitor?.read(windowMs) ?? UNMONITORED_READING;
 }
 
+/**
+ * Instantaneous lag (last completed interval + any in-flight stall). Use for
+ * Prometheus gauges; use getEventLoopLagStats for the retained-window summary.
+ */
+export function readLatestEventLoopLag(): EventLoopLagReading {
+  return monitor?.latest() ?? UNMONITORED_READING;
+}
+
 /** Retained-window summary for health/diagnostic endpoints. */
 export function getEventLoopLagStats(): EventLoopLagStats {
   if (monitor) return monitor.stats();
   return {
     monitored: false,
-    windowMs: 0,
+    // Same windowMs the running path reports, so consumers of /health/ready see
+    // a stable field shape rather than a 0 that looks like a distinct state.
+    windowMs: DEFAULT_RETENTION_MS,
     sampleCount: 0,
     maxLagMs: 0,
     meanLagMs: 0,

--- a/apps/api/src/services/eventLoopMonitorWiring.test.ts
+++ b/apps/api/src/services/eventLoopMonitorWiring.test.ts
@@ -74,26 +74,26 @@ describe('event-loop monitor bootstrap wiring (index.ts)', () => {
     expect(indexSource).toMatch(/stopEventLoopMonitor\s*\(/);
   });
 
-  it('reports event-loop lag on /health/ready without gating readiness on it', () => {
-    // Readiness must NOT flip on starvation: pulling a loaded instance out of
-    // rotation pushes its traffic onto its peers and starves them in turn.
-    expect(indexSource).toMatch(/getEventLoopLagStats\s*\(/);
+  it('keeps event-loop telemetry off the unauthenticated /health/ready', () => {
+    // /health/ready is in HEALTH_CHECK_PATHS (middleware/security.ts) — it
+    // answers without auth. The lag stats are a live load gradient plus the
+    // starvation threshold itself, so publishing them there hands an
+    // unauthenticated prober a readout of whether its own load is starving the
+    // instance. Binary availability is what belongs on this endpoint; the
+    // numbers live on the auth-gated /metrics, and the starvation reporter
+    // logs to the console regardless.
+    //
+    // Asserting absence (rather than deleting the test with the code) is the
+    // point: the block reads as harmless diagnostics, so the obvious future
+    // edit is to add it back.
     const readyBlock = indexSource.slice(
       indexSource.indexOf("app.get('/health/ready'"),
       indexSource.indexOf("app.get('/ready'"),
     );
     expect(readyBlock.length).toBeGreaterThan(0);
-    expect(readyBlock).toContain('eventLoop');
-    // `allOk` must be computed from `checks` alone, and the lag stats must be
-    // read AFTER it — so no future edit can fold starvation into `checks`
-    // (e.g. `checks.eventLoop = stats.starved ? 'error' : 'ok'`) and silently
-    // start shedding traffic from a merely-busy instance. Ordering is the
-    // structural guarantee; a keyword blocklist is not.
-    const allOkAt = readyBlock.indexOf('const allOk = Object.values(checks)');
-    const statsAt = readyBlock.indexOf('getEventLoopLagStats(');
-    expect(allOkAt).toBeGreaterThan(-1);
-    expect(statsAt).toBeGreaterThan(allOkAt);
-    expect(readyBlock).not.toMatch(/checks\.\w*[eE]vent[lL]oop/);
+    expect(readyBlock).toContain('const allOk = Object.values(checks)');
+    expect(readyBlock).not.toMatch(/getEventLoopLagStats/);
+    expect(readyBlock).not.toMatch(/[eE]vent[lL]oop\s*[,:}]/);
     expect(readyBlock).not.toMatch(/starved/);
   });
 });

--- a/apps/api/src/services/eventLoopMonitorWiring.test.ts
+++ b/apps/api/src/services/eventLoopMonitorWiring.test.ts
@@ -39,7 +39,25 @@ describe('event-loop monitor bootstrap wiring (index.ts)', () => {
     // drag the event-loop monitor into the graph of every error-reporting
     // module). That inversion only works if boot actually performs the
     // injection — otherwise the tags are silently never set.
-    expect(indexSource).toMatch(/setConnectTimeoutClassifier\s*\(\s*diagnoseConnectTimeout\s*\)/);
+    // The SAFE variant specifically: this classifier runs on error paths, and
+    // in Hono's onError a throw would cost the request its 500 and stop the
+    // original error reaching Sentry.
+    expect(indexSource).toMatch(
+      /setConnectTimeoutClassifier\s*\(\s*safeDiagnoseConnectTimeout\s*\)/,
+    );
+    expect(indexSource).not.toMatch(/setConnectTimeoutClassifier\s*\(\s*diagnoseConnectTimeout\s*\)/);
+  });
+
+  it('uses the never-throwing classifier inside app.onError', () => {
+    expect(indexSource).toMatch(/const connectTimeout = safeDiagnoseConnectTimeout\(err\)/);
+  });
+
+  it('announces at boot whether the monitor is running', () => {
+    // A monitor that never starts is otherwise completely silent: diagnoses
+    // degrade to "unknown" and nothing says why. The log also prints the
+    // effective interval, which is what makes a misparsed env var visible.
+    expect(indexSource).toMatch(/\[event-loop\] Lag monitor started/);
+    expect(indexSource).toMatch(/\[event-loop\] Lag monitor DISABLED/);
   });
 
   it('stops the monitor on graceful shutdown', () => {
@@ -56,8 +74,16 @@ describe('event-loop monitor bootstrap wiring (index.ts)', () => {
     );
     expect(readyBlock.length).toBeGreaterThan(0);
     expect(readyBlock).toContain('eventLoop');
-    // `allOk` is computed from `checks` only.
-    expect(readyBlock).toMatch(/const allOk = Object\.values\(checks\)/);
-    expect(readyBlock).not.toMatch(/allOk\s*&&\s*.*starved/);
+    // `allOk` must be computed from `checks` alone, and the lag stats must be
+    // read AFTER it — so no future edit can fold starvation into `checks`
+    // (e.g. `checks.eventLoop = stats.starved ? 'error' : 'ok'`) and silently
+    // start shedding traffic from a merely-busy instance. Ordering is the
+    // structural guarantee; a keyword blocklist is not.
+    const allOkAt = readyBlock.indexOf('const allOk = Object.values(checks)');
+    const statsAt = readyBlock.indexOf('getEventLoopLagStats(');
+    expect(allOkAt).toBeGreaterThan(-1);
+    expect(statsAt).toBeGreaterThan(allOkAt);
+    expect(readyBlock).not.toMatch(/checks\.\w*[eE]vent[lL]oop/);
+    expect(readyBlock).not.toMatch(/starved/);
   });
 });

--- a/apps/api/src/services/eventLoopMonitorWiring.test.ts
+++ b/apps/api/src/services/eventLoopMonitorWiring.test.ts
@@ -58,6 +58,16 @@ describe('event-loop monitor bootstrap wiring (index.ts)', () => {
     // effective interval, which is what makes a misparsed env var visible.
     expect(indexSource).toMatch(/\[event-loop\] Lag monitor started/);
     expect(indexSource).toMatch(/\[event-loop\] Lag monitor DISABLED/);
+    // Both thresholds: the warn knob and the capped attribution threshold can
+    // differ, and printing only the former advertises a value diagnosis does
+    // not use.
+    expect(indexSource).toMatch(/getConnectTimeoutStarvationThresholdMs\(\)/);
+  });
+
+  it('warns when the sampling interval is coarser than the starvation threshold', () => {
+    // That configuration leaves a blind spot one sampling interval wide, in
+    // which a stall is unobservable and every diagnosis degrades to "unknown".
+    expect(indexSource).toMatch(/EVENT_LOOP_MONITOR_INTERVAL_MS \(\$\{eventLoopMonitor\.intervalMs\}ms\) exceeds/);
   });
 
   it('stops the monitor on graceful shutdown', () => {

--- a/apps/api/src/services/eventLoopMonitorWiring.test.ts
+++ b/apps/api/src/services/eventLoopMonitorWiring.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Boot-wiring guards for the #3022 instrumentation.
+ *
+ * These read `index.ts` as text for the same reason the existing
+ * "sentry bootstrap wiring" suite does: `index.ts` starts servers, workers and
+ * migrations on import, so it cannot be imported in a unit test, and it is
+ * excluded from coverage. That combination is exactly how `initSentry` once sat
+ * defined-but-never-called while every `captureException` in the codebase
+ * silently no-op'd in production.
+ *
+ * The same failure mode is available here and would be quieter still: an
+ * unstarted monitor reports `monitored: false`, which every consumer correctly
+ * treats as "unknown". Nothing breaks, no test fails — the API just goes
+ * permanently blind to the condition this work exists to surface.
+ */
+describe('event-loop monitor bootstrap wiring (index.ts)', () => {
+  const indexSource = readFileSync(
+    fileURLToPath(new URL('../index.ts', import.meta.url)),
+    'utf-8',
+  );
+
+  it('starts the event-loop monitor during startup', () => {
+    expect(indexSource).toMatch(/startEventLoopMonitor\s*\(/);
+  });
+
+  it('feeds samples to the starvation reporter', () => {
+    // Without this the monitor still answers queries, but a stall produces no
+    // log line and no Sentry event of its own — leaving starvation visible only
+    // as a tag on some *other* error, which is the gap #3022 describes.
+    expect(indexSource).toMatch(/createStarvationReporter\s*\(/);
+  });
+
+  it('injects the CONNECT_TIMEOUT classifier into the Sentry layer', () => {
+    // services/sentry.ts deliberately does not import the classifier (it would
+    // drag the event-loop monitor into the graph of every error-reporting
+    // module). That inversion only works if boot actually performs the
+    // injection — otherwise the tags are silently never set.
+    expect(indexSource).toMatch(/setConnectTimeoutClassifier\s*\(\s*diagnoseConnectTimeout\s*\)/);
+  });
+
+  it('stops the monitor on graceful shutdown', () => {
+    expect(indexSource).toMatch(/stopEventLoopMonitor\s*\(/);
+  });
+
+  it('reports event-loop lag on /health/ready without gating readiness on it', () => {
+    // Readiness must NOT flip on starvation: pulling a loaded instance out of
+    // rotation pushes its traffic onto its peers and starves them in turn.
+    expect(indexSource).toMatch(/getEventLoopLagStats\s*\(/);
+    const readyBlock = indexSource.slice(
+      indexSource.indexOf("app.get('/health/ready'"),
+      indexSource.indexOf("app.get('/ready'"),
+    );
+    expect(readyBlock.length).toBeGreaterThan(0);
+    expect(readyBlock).toContain('eventLoop');
+    // `allOk` is computed from `checks` only.
+    expect(readyBlock).toMatch(/const allOk = Object\.values\(checks\)/);
+    expect(readyBlock).not.toMatch(/allOk\s*&&\s*.*starved/);
+  });
+});

--- a/apps/api/src/services/eventLoopStarvationReporter.test.ts
+++ b/apps/api/src/services/eventLoopStarvationReporter.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createStarvationReporter, getStarvationCaptureThrottleMs } from './eventLoopStarvationReporter';
+import type { EventLoopLagSample } from './eventLoopMonitor';
+
+function sample(maxLagMs: number, atMs = 0): EventLoopLagSample {
+  return { atMs, maxLagMs, meanLagMs: maxLagMs / 2 };
+}
+
+interface Harness {
+  report: ReturnType<typeof createStarvationReporter>;
+  warns: string[];
+  captures: Array<{ message: string; tags: Record<string, string> }>;
+  setNow: (ms: number) => void;
+}
+
+function makeReporter(opts: { thresholdMs?: number; throttleMs?: number } = {}): Harness {
+  const warns: string[] = [];
+  const captures: Array<{ message: string; tags: Record<string, string> }> = [];
+  let now = 0;
+  const report = createStarvationReporter({
+    thresholdMs: () => opts.thresholdMs ?? 1_000,
+    throttleMs: () => opts.throttleMs ?? 300_000,
+    now: () => now,
+    warn: (m) => warns.push(m),
+    capture: (message, tags) => captures.push({ message, tags }),
+  });
+  return { report, warns, captures, setNow: (ms) => { now = ms; } };
+}
+
+describe('createStarvationReporter', () => {
+  afterEach(() => {
+    delete process.env.EVENT_LOOP_STARVATION_THROTTLE_MS;
+  });
+
+  it('ignores samples below the threshold', () => {
+    const { report, warns, captures } = makeReporter({ thresholdMs: 1_000 });
+    report(sample(0));
+    report(sample(999));
+    expect(warns).toEqual([]);
+    expect(captures).toEqual([]);
+  });
+
+  it('warns at the threshold and names the CONNECT_TIMEOUT connection', () => {
+    const { report, warns } = makeReporter({ thresholdMs: 1_000 });
+    report(sample(1_000));
+
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('[event-loop]');
+    expect(warns[0]).toContain('1000ms');
+    // The link to CONNECT_TIMEOUT is the payload of this log line: it is what
+    // lets whoever reads it connect a starvation warning to the DB errors
+    // appearing alongside it.
+    expect(warns[0]).toContain('CONNECT_TIMEOUT');
+  });
+
+  it('warns on EVERY breaching sample — logs stay complete', () => {
+    const { report, warns } = makeReporter();
+    for (let i = 0; i < 5; i += 1) report(sample(4_000, i));
+    // A stall spans multiple sample intervals. Throttling the log too would
+    // hide the stall's duration, which is the one thing the log conveys.
+    expect(warns).toHaveLength(5);
+  });
+
+  it('throttles the Sentry capture across a burst', () => {
+    const { report, warns, captures, setNow } = makeReporter({ throttleMs: 300_000 });
+
+    setNow(0);
+    report(sample(4_000));
+    setNow(1_000);
+    report(sample(4_000));
+    setNow(2_000);
+    report(sample(4_000));
+
+    expect(warns).toHaveLength(3);
+    // One stall must cost one event, not one per second. This repo has twice
+    // had an unthrottled recurring warning exhaust the Sentry quota and drop
+    // ALL error reporting org-wide (#1894, BREEZE-H).
+    expect(captures).toHaveLength(1);
+  });
+
+  it('captures again once the throttle window elapses', () => {
+    const { report, captures, setNow } = makeReporter({ throttleMs: 300_000 });
+    setNow(0);
+    report(sample(4_000));
+    setNow(299_999);
+    report(sample(4_000));
+    expect(captures).toHaveLength(1);
+
+    setNow(300_000);
+    report(sample(4_000));
+    expect(captures).toHaveLength(2);
+  });
+
+  it('throttleMs of 0 disables throttling', () => {
+    const { report, captures, setNow } = makeReporter({ throttleMs: 0 });
+    setNow(0);
+    report(sample(4_000));
+    report(sample(4_000));
+    expect(captures).toHaveLength(2);
+  });
+
+  it('tags the capture with a bounded lag bucket, never raw milliseconds', () => {
+    const { report, captures } = makeReporter();
+    report(sample(7_500));
+    expect(captures[0]!.tags).toEqual({ event_loop_lag_bucket: '5s-10s' });
+  });
+
+  it('reset() clears throttle state', () => {
+    const { report, captures, setNow } = makeReporter({ throttleMs: 300_000 });
+    setNow(0);
+    report(sample(4_000));
+    report.reset();
+    report(sample(4_000));
+    expect(captures).toHaveLength(2);
+  });
+
+  it('works with no capture sink configured (Sentry disabled)', () => {
+    const warns: string[] = [];
+    const report = createStarvationReporter({
+      thresholdMs: () => 1_000,
+      warn: (m) => warns.push(m),
+    });
+    // Self-hosted deployments run without SENTRY_DSN; the console warning is
+    // the entire signal there and must not depend on a capture sink existing.
+    expect(() => report(sample(9_000))).not.toThrow();
+    expect(warns).toHaveLength(1);
+  });
+});
+
+describe('getStarvationCaptureThrottleMs', () => {
+  afterEach(() => {
+    delete process.env.EVENT_LOOP_STARVATION_THROTTLE_MS;
+  });
+
+  it('defaults to five minutes', () => {
+    expect(getStarvationCaptureThrottleMs()).toBe(300_000);
+  });
+
+  it('accepts 0 as "never throttle"', () => {
+    process.env.EVENT_LOOP_STARVATION_THROTTLE_MS = '0';
+    expect(getStarvationCaptureThrottleMs()).toBe(0);
+  });
+
+  it('falls back on a negative or unparseable value', () => {
+    process.env.EVENT_LOOP_STARVATION_THROTTLE_MS = '-1';
+    expect(getStarvationCaptureThrottleMs()).toBe(300_000);
+    process.env.EVENT_LOOP_STARVATION_THROTTLE_MS = 'soon';
+    expect(getStarvationCaptureThrottleMs()).toBe(300_000);
+  });
+});

--- a/apps/api/src/services/eventLoopStarvationReporter.ts
+++ b/apps/api/src/services/eventLoopStarvationReporter.ts
@@ -1,0 +1,94 @@
+/**
+ * Turns event-loop samples into an operator-visible signal (#3022).
+ *
+ * The point of reporting starvation on its own — rather than only as an
+ * annotation on some other error — is that starvation does not reliably produce
+ * an error at all. In the #3022 incident it surfaced through three different
+ * signatures (a Postgres CONNECT_TIMEOUT, a `nextWrite` TypeError from the
+ * driver's teardown race, and a patch-scheduler sweep failure), none of which
+ * names the loop, and it can equally produce nothing but slow responses. A
+ * direct "the loop was blocked for N ms" line is the only signal that appears
+ * in every one of those cases.
+ *
+ * Throttling is not optional here. This repo has twice had a recurring
+ * warning exhaust the Sentry event quota and silently drop ALL error reporting
+ * org-wide (#1894 for the held-context warning, BREEZE-H for the tripwire), and
+ * a starvation event is by nature a burst — one stall produces a run of
+ * consecutive breaching samples. So the Sentry capture is rate-limited while
+ * `console.warn` stays unthrottled, matching `shouldCaptureHeldContext` in
+ * `db/index.ts`.
+ */
+
+import { bucketEventLoopLag, type EventLoopLagSample } from './eventLoopMonitor';
+
+const DEFAULT_CAPTURE_THROTTLE_MS = 5 * 60_000;
+
+export interface StarvationReporterOptions {
+  /** Lag at or above which a sample is reported. */
+  thresholdMs: () => number;
+  /** Minimum gap between Sentry captures; 0 disables throttling. */
+  throttleMs?: () => number;
+  now?: () => number;
+  warn?: (message: string) => void;
+  capture?: (message: string, tags: Record<string, string>) => void;
+}
+
+export interface StarvationReporter {
+  (sample: EventLoopLagSample): void;
+  /** TEST ONLY — clears the throttle state. */
+  reset(): void;
+}
+
+export function getStarvationCaptureThrottleMs(): number {
+  const raw = Number.parseInt(process.env.EVENT_LOOP_STARVATION_THROTTLE_MS ?? '', 10);
+  if (!Number.isFinite(raw) || raw < 0) {
+    return DEFAULT_CAPTURE_THROTTLE_MS;
+  }
+  return raw;
+}
+
+/**
+ * Build a sample consumer that warns on every breaching sample and captures a
+ * throttled subset to Sentry. Every dependency is injectable so the throttle
+ * arithmetic is unit-testable without real timers or a live Sentry client.
+ */
+export function createStarvationReporter(options: StarvationReporterOptions): StarvationReporter {
+  const {
+    thresholdMs,
+    throttleMs = getStarvationCaptureThrottleMs,
+    now = Date.now,
+    warn = (message) => console.warn(message),
+    capture,
+  } = options;
+
+  let lastCaptureAtMs: number | null = null;
+
+  const report = ((sample: EventLoopLagSample): void => {
+    const threshold = thresholdMs();
+    if (sample.maxLagMs < threshold) return;
+
+    const lagMs = Math.round(sample.maxLagMs);
+    const message =
+      `[event-loop] Main thread blocked for up to ${lagMs}ms (>= ${threshold}ms). While blocked, `
+      + `no socket callback and no timer runs — in-flight Postgres handshakes can exceed `
+      + `connect_timeout and be reported as CONNECT_TIMEOUT even though the database and the `
+      + `network are healthy (#3022).`;
+
+    warn(message);
+
+    if (!capture) return;
+    const gap = throttleMs();
+    const at = now();
+    if (gap > 0 && lastCaptureAtMs !== null && at - lastCaptureAtMs < gap) {
+      return;
+    }
+    lastCaptureAtMs = at;
+    capture(message, { event_loop_lag_bucket: bucketEventLoopLag(lagMs) });
+  }) as StarvationReporter;
+
+  report.reset = () => {
+    lastCaptureAtMs = null;
+  };
+
+  return report;
+}

--- a/apps/api/src/services/postgresConnectTimeout.test.ts
+++ b/apps/api/src/services/postgresConnectTimeout.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  CONNECT_TIMEOUT_CODE,
+  POSTGRES_CONNECT_TIMEOUT_SECONDS,
+  diagnoseConnectTimeout,
+  isPostgresConnectTimeout,
+} from './postgresConnectTimeout';
+import type { EventLoopLagReading } from './eventLoopMonitor';
+
+/** The exact error shape postgres.js builds in `Errors.connection()`. */
+function connectTimeoutError(): Error {
+  return Object.assign(new Error('write CONNECT_TIMEOUT db.internal:5432'), {
+    code: CONNECT_TIMEOUT_CODE,
+    errno: CONNECT_TIMEOUT_CODE,
+    address: 'db.internal',
+    port: 5432,
+  });
+}
+
+/** How Drizzle presents the same failure: own `.code` undefined, driver on `.cause`. */
+function drizzleWrapped(cause: Error): Error {
+  return Object.assign(new Error('Failed query: select 1'), { cause });
+}
+
+function reading(overrides: Partial<EventLoopLagReading> = {}): EventLoopLagReading {
+  const worstLagMs = overrides.worstLagMs ?? 0;
+  return {
+    monitored: true,
+    sampledMaxLagMs: worstLagMs,
+    inFlightLagMs: 0,
+    worstLagMs,
+    sampleCount: 1,
+    ...overrides,
+  };
+}
+
+describe('isPostgresConnectTimeout', () => {
+  afterEach(() => {
+    delete process.env.EVENT_LOOP_STARVATION_WARN_MS;
+  });
+
+  it('matches the raw driver error', () => {
+    expect(isPostgresConnectTimeout(connectTimeoutError())).toBe(true);
+  });
+
+  it('matches through the Drizzle .cause chain', () => {
+    // The whole reason pgErrorCode walks `.cause`: a top-level `.code` check
+    // misses every timeout raised inside a Drizzle query.
+    expect(isPostgresConnectTimeout(drizzleWrapped(connectTimeoutError()))).toBe(true);
+  });
+
+  it('does not match other postgres connection errors', () => {
+    for (const code of ['CONNECTION_CLOSED', 'CONNECTION_ENDED', 'ECONNRESET', '23505']) {
+      expect(isPostgresConnectTimeout(Object.assign(new Error(code), { code }))).toBe(false);
+    }
+  });
+
+  it('does not match non-errors or undefined', () => {
+    expect(isPostgresConnectTimeout(undefined)).toBe(false);
+    expect(isPostgresConnectTimeout(null)).toBe(false);
+    expect(isPostgresConnectTimeout('CONNECT_TIMEOUT')).toBe(false);
+    expect(isPostgresConnectTimeout(new Error('plain'))).toBe(false);
+  });
+});
+
+describe('diagnoseConnectTimeout', () => {
+  afterEach(() => {
+    delete process.env.EVENT_LOOP_STARVATION_WARN_MS;
+  });
+
+  it('returns null for anything that is not a connect timeout', () => {
+    expect(diagnoseConnectTimeout(new Error('boom'), reading())).toBeNull();
+    expect(diagnoseConnectTimeout(undefined, reading())).toBeNull();
+  });
+
+  it('blames the event loop when lag reaches the threshold', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    const d = diagnoseConnectTimeout(connectTimeoutError(), reading({ worstLagMs: 11_500 }))!;
+
+    expect(d.cause).toBe('event-loop-starvation');
+    expect(d.worstLagMs).toBe(11_500);
+    expect(d.lagBucket).toBe('over-10s');
+    expect(d.windowMs).toBe(POSTGRES_CONNECT_TIMEOUT_SECONDS * 1_000);
+    // The message must state the measurement and steer AWAY from the DB, since
+    // sending the investigation at the database is the failure mode #3022 is about.
+    expect(d.message).toContain('11500ms');
+    expect(d.message).toMatch(/NOT a database or network fault/);
+  });
+
+  it('blames connectivity when the loop was healthy', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    const d = diagnoseConnectTimeout(connectTimeoutError(), reading({ worstLagMs: 12 }))!;
+
+    expect(d.cause).toBe('connectivity');
+    expect(d.lagBucket).toBe('under-1s');
+    expect(d.message).toMatch(/handshake itself failed/);
+  });
+
+  it('treats the threshold as inclusive', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    expect(diagnoseConnectTimeout(connectTimeoutError(), reading({ worstLagMs: 1_000 }))!.cause)
+      .toBe('event-loop-starvation');
+    expect(diagnoseConnectTimeout(connectTimeoutError(), reading({ worstLagMs: 999 }))!.cause)
+      .toBe('connectivity');
+  });
+
+  it('reports "unknown" — never "connectivity" — when no monitor is running', () => {
+    // This is the important negative case. Falling back to "connectivity"
+    // without evidence would silently reproduce the misdiagnosis this module
+    // exists to prevent, and would do it with the authority of a verdict.
+    const d = diagnoseConnectTimeout(
+      connectTimeoutError(),
+      reading({ monitored: false, worstLagMs: 0 }),
+    )!;
+
+    expect(d.cause).toBe('unknown');
+    expect(d.lagBucket).toBe('unknown');
+    expect(d.message).toMatch(/could not be ruled in or out/);
+    expect(d.message).not.toMatch(/handshake itself failed/);
+  });
+
+  it('honours a tuned starvation threshold', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '5000';
+    const d = diagnoseConnectTimeout(connectTimeoutError(), reading({ worstLagMs: 2_000 }))!;
+    expect(d.cause).toBe('connectivity');
+    expect(d.starvationThresholdMs).toBe(5_000);
+  });
+
+  it('diagnoses a Drizzle-wrapped timeout identically', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    const d = diagnoseConnectTimeout(
+      drizzleWrapped(connectTimeoutError()),
+      reading({ worstLagMs: 6_000 }),
+    )!;
+    expect(d.cause).toBe('event-loop-starvation');
+    expect(d.lagBucket).toBe('5s-10s');
+  });
+
+  it('rounds sub-millisecond lag rather than leaking a float into the tag/message', () => {
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '1000';
+    const d = diagnoseConnectTimeout(
+      connectTimeoutError(),
+      reading({ worstLagMs: 1_234.5678 }),
+    )!;
+    expect(d.worstLagMs).toBe(1_235);
+    expect(d.message).toContain('1235ms');
+  });
+
+  it('falls back to the live monitor when no reading is injected', () => {
+    // No monitor is started in this suite, so the singleton reports unmonitored
+    // — which must surface as 'unknown', proving the production call path
+    // (diagnoseConnectTimeout(err) with one argument) is wired to the monitor.
+    const d = diagnoseConnectTimeout(connectTimeoutError())!;
+    expect(d.cause).toBe('unknown');
+  });
+
+  it('keeps connect_timeout at 10s — raising it alone is explicitly not the fix', () => {
+    // Guards the #3022 conclusion against a well-meaning "just bump the
+    // timeout" edit: a longer budget only makes the failing request hold its
+    // slot for longer while the loop is still starved.
+    expect(POSTGRES_CONNECT_TIMEOUT_SECONDS).toBe(10);
+  });
+});
+
+describe('connect_timeout drift guard', () => {
+  it('matches the literal actually passed to the postgres.js pool', () => {
+    // db/index.ts deliberately does NOT import POSTGRES_CONNECT_TIMEOUT_SECONDS
+    // — that edge would drag this module and the event-loop monitor into the DB
+    // module's import graph (see the comment at the pool config). The cost of
+    // that decision is a duplicated literal, so pin the two together here:
+    // if they drift, the classifier inspects a window that is not the budget
+    // that expired, and every verdict it produces is measured over the wrong
+    // interval.
+    const source = readFileSync(
+      fileURLToPath(new URL('../db/index.ts', import.meta.url)),
+      'utf8',
+    );
+    const match = source.match(/connect_timeout:\s*(\d+)\s*,/);
+    expect(match, 'connect_timeout not found in db/index.ts pool config').not.toBeNull();
+    expect(Number(match![1])).toBe(POSTGRES_CONNECT_TIMEOUT_SECONDS);
+  });
+});

--- a/apps/api/src/services/postgresConnectTimeout.test.ts
+++ b/apps/api/src/services/postgresConnectTimeout.test.ts
@@ -6,6 +6,7 @@ import {
   POSTGRES_CONNECT_TIMEOUT_SECONDS,
   diagnoseConnectTimeout,
   isPostgresConnectTimeout,
+  safeDiagnoseConnectTimeout,
 } from './postgresConnectTimeout';
 import type { EventLoopLagReading } from './eventLoopMonitor';
 
@@ -28,6 +29,7 @@ function reading(overrides: Partial<EventLoopLagReading> = {}): EventLoopLagRead
   const worstLagMs = overrides.worstLagMs ?? 0;
   return {
     monitored: true,
+    coversWindow: true,
     sampledMaxLagMs: worstLagMs,
     inFlightLagMs: 0,
     worstLagMs,
@@ -117,15 +119,39 @@ describe('diagnoseConnectTimeout', () => {
 
     expect(d.cause).toBe('unknown');
     expect(d.lagBucket).toBe('unknown');
-    expect(d.message).toMatch(/could not be ruled in or out/);
+    expect(d.message).toMatch(/neither ruled in nor out/);
     expect(d.message).not.toMatch(/handshake itself failed/);
   });
 
-  it('honours a tuned starvation threshold', () => {
+  it('honours a tuned starvation threshold below the connect window', () => {
     process.env.EVENT_LOOP_STARVATION_WARN_MS = '5000';
     const d = diagnoseConnectTimeout(connectTimeoutError(), reading({ worstLagMs: 2_000 }))!;
     expect(d.cause).toBe('connectivity');
     expect(d.starvationThresholdMs).toBe(5_000);
+  });
+
+  it('caps the threshold at the connect window so a full-window stall can never read as connectivity', () => {
+    // EVENT_LOOP_STARVATION_WARN_MS is a warning-volume knob. An operator
+    // quieting a noisy instance must not be able to make a 12s stall — which
+    // alone consumed the whole 10s budget — report "the event loop stayed
+    // healthy, check database reachability".
+    process.env.EVENT_LOOP_STARVATION_WARN_MS = '15000';
+    const d = diagnoseConnectTimeout(connectTimeoutError(), reading({ worstLagMs: 12_000 }))!;
+    expect(d.cause).toBe('event-loop-starvation');
+    expect(d.starvationThresholdMs).toBe(10_000);
+  });
+
+  it('reports "unknown" when a running monitor cannot vouch for the whole window', () => {
+    // monitored: true but coversWindow: false — the monitor booted less than
+    // 10s ago, or samples more coarsely than the window is wide. Its zero means
+    // "not observed", and must never be read as "the loop was fine".
+    const d = diagnoseConnectTimeout(
+      connectTimeoutError(),
+      reading({ monitored: true, coversWindow: false, worstLagMs: 0 }),
+    )!;
+    expect(d.cause).toBe('unknown');
+    expect(d.lagBucket).toBe('unknown');
+    expect(d.message).not.toMatch(/handshake itself failed/);
   });
 
   it('diagnoses a Drizzle-wrapped timeout identically', () => {
@@ -180,5 +206,24 @@ describe('connect_timeout drift guard', () => {
     const match = source.match(/connect_timeout:\s*(\d+)\s*,/);
     expect(match, 'connect_timeout not found in db/index.ts pool config').not.toBeNull();
     expect(Number(match![1])).toBe(POSTGRES_CONNECT_TIMEOUT_SECONDS);
+  });
+});
+
+describe('safeDiagnoseConnectTimeout', () => {
+  it('returns null instead of throwing when the error resists inspection', () => {
+    // Both production call sites run while an error is already in flight; in
+    // Hono's onError a throw would cost the request its JSON 500 AND stop the
+    // original error from ever reaching Sentry.
+    const hostile = {
+      get code(): string { throw new Error('exploding getter'); },
+    };
+    expect(() => safeDiagnoseConnectTimeout(hostile)).not.toThrow();
+    expect(safeDiagnoseConnectTimeout(hostile)).toBeNull();
+  });
+
+  it('agrees with diagnoseConnectTimeout on well-behaved errors', () => {
+    const err = connectTimeoutError();
+    expect(safeDiagnoseConnectTimeout(err)?.cause).toBe(diagnoseConnectTimeout(err)?.cause);
+    expect(safeDiagnoseConnectTimeout(new Error('unrelated'))).toBeNull();
   });
 });

--- a/apps/api/src/services/postgresConnectTimeout.ts
+++ b/apps/api/src/services/postgresConnectTimeout.ts
@@ -1,0 +1,158 @@
+/**
+ * Tells apart the two very different things postgres.js reports with the same
+ * `CONNECT_TIMEOUT` error (#3022).
+ *
+ * The driver arms `connect_timeout` with a plain `setTimeout`
+ * (`postgres/src/connection.js:1042-1054`), starts it in `connect()` right after
+ * the socket is created (`:343`), and cancels it only on ReadyForQuery (`:552`).
+ * So the budget covers socket create → TCP → SSL → auth → ReadyForQuery, and
+ * every one of those steps needs the event loop to run a socket callback. Two
+ * unrelated conditions therefore produce a byte-identical error:
+ *
+ *   1. The handshake genuinely failed — the DB is down, unreachable, refusing,
+ *      or too slow. A real connectivity fault.
+ *   2. The handshake was fine but this process never got scheduled. The main
+ *      thread was pegged, the socket callbacks queued up behind it, and the
+ *      timer fired on a connection that was never actually in trouble.
+ *
+ * Case 2 is what #3022 turned out to be, and the driver's message —
+ * `write CONNECT_TIMEOUT <host>:<port>` — actively points investigation at the
+ * database and the network, both of which measured healthy throughout. Naming
+ * the cause at the point the error is reported is most of the fix: it turns a
+ * multi-hour "is the DB failing over?" hunt into a line that says the loop was
+ * blocked for N ms.
+ *
+ * This module deliberately does NOT change control flow. It does not retry, it
+ * does not remap the HTTP status, and it does not raise `connect_timeout` —
+ * per #3022 a longer timeout just lengthens the failing request. It classifies
+ * and describes; that is all.
+ *
+ * WHY IT LIVES IN services/ AND NOT db/: `services/sentry.ts` calls it, and
+ * `db/index.ts` imports `services/sentry.ts`. Putting the classifier under db/
+ * therefore created a `services → db` back-edge that dragged the whole db
+ * subtree (schema, drizzle, the pool) into the module graph of anything that
+ * reports an error — slow enough to push db/requestDatabasePool.test.ts past
+ * its timeout. Nothing here needs the db module; it reads a driver error's
+ * `code` and the event-loop monitor. Keep the dependency direction db → services.
+ */
+
+import { pgErrorCode } from '../utils/pgErrors';
+import {
+  bucketEventLoopLag,
+  getEventLoopStarvationThresholdMs,
+  readEventLoopLag,
+  type EventLoopLagBucket,
+  type EventLoopLagReading,
+} from './eventLoopMonitor';
+
+/**
+ * postgres.js `connect_timeout`, in seconds — the single source of truth,
+ * imported by the pool config in `db/index.ts`.
+ *
+ * Deliberately left at 10 (see the module docblock): #3022 concluded that
+ * raising it alone is not a fix, because a starved loop simply fails ten
+ * seconds later while holding the request slot for longer.
+ */
+export const POSTGRES_CONNECT_TIMEOUT_SECONDS = 10;
+
+/** The driver's `code`/`errno` for a connect-phase timeout. */
+export const CONNECT_TIMEOUT_CODE = 'CONNECT_TIMEOUT';
+
+export type ConnectTimeoutCause =
+  /** The loop was measurably blocked; the timeout is an artefact of that. */
+  | 'event-loop-starvation'
+  /** The loop was healthy, so the handshake really did fail. */
+  | 'connectivity'
+  /** No event-loop monitor was running, so there is nothing to conclude. */
+  | 'unknown';
+
+export interface ConnectTimeoutDiagnosis {
+  cause: ConnectTimeoutCause;
+  /** Worst event-loop lag observed across the connect window, in ms. */
+  worstLagMs: number;
+  /** The window that was examined, in ms (the connect budget). */
+  windowMs: number;
+  starvationThresholdMs: number;
+  /** Bounded, low-cardinality lag band — safe to use as a Sentry tag. */
+  lagBucket: EventLoopLagBucket;
+  /** Operator-facing one-liner. Always states the measurement, never just the verdict. */
+  message: string;
+}
+
+/**
+ * True for a postgres.js connect-phase timeout, including one wrapped by
+ * Drizzle (whose own `.code` is undefined — the driver's fields live on
+ * `.cause`, which `pgErrorCode` walks).
+ */
+export function isPostgresConnectTimeout(err: unknown): boolean {
+  return pgErrorCode(err) === CONNECT_TIMEOUT_CODE;
+}
+
+/**
+ * Classify a thrown error. Returns null when it is not a connect timeout, so
+ * callers can use it as their branch condition directly.
+ *
+ * `reading` is injectable for tests; production omits it and the current
+ * process-wide monitor is consulted over the connect window.
+ */
+export function diagnoseConnectTimeout(
+  err: unknown,
+  reading?: EventLoopLagReading,
+): ConnectTimeoutDiagnosis | null {
+  if (!isPostgresConnectTimeout(err)) return null;
+
+  const windowMs = POSTGRES_CONNECT_TIMEOUT_SECONDS * 1_000;
+  const lag = reading ?? readEventLoopLag(windowMs);
+  const starvationThresholdMs = getEventLoopStarvationThresholdMs();
+  const worstLagMs = Math.round(lag.worstLagMs);
+
+  // Fail to 'unknown', never to 'connectivity'. Without a monitor there is no
+  // evidence either way, and quietly asserting "the database was unreachable"
+  // is precisely the misdirection this module exists to remove.
+  const cause: ConnectTimeoutCause = !lag.monitored
+    ? 'unknown'
+    : worstLagMs >= starvationThresholdMs
+      ? 'event-loop-starvation'
+      : 'connectivity';
+
+  return {
+    cause,
+    worstLagMs,
+    windowMs,
+    starvationThresholdMs,
+    lagBucket: bucketEventLoopLag(worstLagMs, lag.monitored),
+    message: describe(cause, worstLagMs, windowMs, starvationThresholdMs),
+  };
+}
+
+function describe(
+  cause: ConnectTimeoutCause,
+  worstLagMs: number,
+  windowMs: number,
+  thresholdMs: number,
+): string {
+  const prefix =
+    `[db] Postgres CONNECT_TIMEOUT after ${windowMs}ms. That budget is measured in-process `
+    + `and covers socket create → TCP → SSL → auth, so it also expires when this process `
+    + `simply never gets scheduled (#3022).`;
+
+  switch (cause) {
+    case 'event-loop-starvation':
+      return (
+        `${prefix} The event loop was blocked for up to ${worstLagMs}ms inside that window `
+        + `(>= ${thresholdMs}ms) — treat this as main-thread starvation, NOT a database or `
+        + `network fault. Look for CPU-bound request work, not for a DB incident.`
+      );
+    case 'connectivity':
+      return (
+        `${prefix} The event loop stayed healthy (worst lag ${worstLagMs}ms < ${thresholdMs}ms), `
+        + `so the handshake itself failed — check database reachability, TLS, and auth.`
+      );
+    case 'unknown':
+      return (
+        `${prefix} No event-loop monitor was running, so starvation could not be ruled in or `
+        + `out. Enable it (unset EVENT_LOOP_MONITOR_DISABLED) before concluding this was a `
+        + `database fault.`
+      );
+  }
+}

--- a/apps/api/src/services/postgresConnectTimeout.ts
+++ b/apps/api/src/services/postgresConnectTimeout.ts
@@ -103,13 +103,31 @@ export function diagnoseConnectTimeout(
 
   const windowMs = POSTGRES_CONNECT_TIMEOUT_SECONDS * 1_000;
   const lag = reading ?? readEventLoopLag(windowMs);
-  const starvationThresholdMs = getEventLoopStarvationThresholdMs();
   const worstLagMs = Math.round(lag.worstLagMs);
 
-  // Fail to 'unknown', never to 'connectivity'. Without a monitor there is no
-  // evidence either way, and quietly asserting "the database was unreachable"
-  // is precisely the misdirection this module exists to remove.
-  const cause: ConnectTimeoutCause = !lag.monitored
+  // Capped at the connect budget on purpose. EVENT_LOOP_STARVATION_WARN_MS is a
+  // *warning volume* knob — an operator quieting a noisy instance may raise it
+  // freely, and has no reason to think that touches error attribution. Used
+  // uncapped it does: at 15000 a 12s stall that demonstrably consumed the entire
+  // 10s budget would be reported as `connectivity` — "the event loop stayed
+  // healthy, check database reachability" — which is the precise misdirection
+  // this module exists to remove, restated with the authority of a verdict.
+  //
+  // A stall at least as long as the window is sufficient on its own to explain
+  // the timeout, so no configuration may classify it as anything else.
+  const starvationThresholdMs = Math.min(getEventLoopStarvationThresholdMs(), windowMs);
+
+  // Fail to 'unknown', never to 'connectivity'. Without evidence covering the
+  // window, quietly asserting "the database was unreachable" is precisely the
+  // misdirection this module exists to remove.
+  //
+  // `coversWindow` matters as much as `monitored` here: a monitor that is
+  // running but has been up for less than the connect budget — or that samples
+  // more coarsely than the budget is wide — reports a lag of 0 meaning "not
+  // observed", not "did not happen". Reading that as health would produce a
+  // confident, wrong verdict with MORE authority than the bare driver error.
+  const evidence = lag.monitored && lag.coversWindow;
+  const cause: ConnectTimeoutCause = !evidence
     ? 'unknown'
     : worstLagMs >= starvationThresholdMs
       ? 'event-loop-starvation'
@@ -120,7 +138,7 @@ export function diagnoseConnectTimeout(
     worstLagMs,
     windowMs,
     starvationThresholdMs,
-    lagBucket: bucketEventLoopLag(worstLagMs, lag.monitored),
+    lagBucket: bucketEventLoopLag(worstLagMs, evidence),
     message: describe(cause, worstLagMs, windowMs, starvationThresholdMs),
   };
 }
@@ -150,9 +168,31 @@ function describe(
       );
     case 'unknown':
       return (
-        `${prefix} No event-loop monitor was running, so starvation could not be ruled in or `
-        + `out. Enable it (unset EVENT_LOOP_MONITOR_DISABLED) before concluding this was a `
-        + `database fault.`
+        `${prefix} No event-loop measurement covers that window — the monitor is disabled, has `
+        + `not been running for a full ${windowMs}ms yet, is shutting down, or samples more `
+        + `coarsely than the window is wide (EVENT_LOOP_MONITOR_INTERVAL_MS). Starvation could `
+        + `be neither ruled in nor out, so do NOT conclude this was a database fault.`
       );
+  }
+}
+
+/**
+ * Never-throwing wrapper. Both production call sites — `services/sentry.ts`'s
+ * captureException and the Hono `app.onError` handler — run while an error is
+ * already in flight, and in `onError` a throw would cost the request its JSON
+ * 500 AND prevent the original error from ever reaching Sentry. `pgErrorCode`
+ * walks `.cause` and reads `.code` off arbitrary objects, so a hostile or exotic
+ * error with a throwing getter is not purely hypothetical.
+ *
+ * Use this, not `diagnoseConnectTimeout`, anywhere the caller is itself an
+ * error path.
+ */
+export function safeDiagnoseConnectTimeout(err: unknown): ConnectTimeoutDiagnosis | null {
+  try {
+    return diagnoseConnectTimeout(err);
+  } catch {
+    // Diagnosis is commentary on someone else's failure; it must never become
+    // the failure. Silence here costs two Sentry tags and a log line.
+    return null;
   }
 }

--- a/apps/api/src/services/postgresConnectTimeout.ts
+++ b/apps/api/src/services/postgresConnectTimeout.ts
@@ -55,6 +55,27 @@ import {
  */
 export const POSTGRES_CONNECT_TIMEOUT_SECONDS = 10;
 
+/**
+ * The lag at or above which a CONNECT_TIMEOUT is attributed to the event loop.
+ *
+ * Capped at the connect budget on purpose. EVENT_LOOP_STARVATION_WARN_MS is a
+ * *warning volume* knob — an operator quieting a noisy instance may raise it
+ * freely, and has no reason to think that touches error attribution. Used
+ * uncapped it does: at 15000 a 12s stall that demonstrably consumed the entire
+ * 10s budget would be reported as `connectivity` — "the event loop stayed
+ * healthy, check database reachability" — which is the precise misdirection
+ * this module exists to remove, restated with the authority of a verdict.
+ *
+ * A stall at least as long as the window is sufficient on its own to explain
+ * the timeout, so no configuration may classify it as anything else.
+ */
+export function getConnectTimeoutStarvationThresholdMs(): number {
+  return Math.min(
+    getEventLoopStarvationThresholdMs(),
+    POSTGRES_CONNECT_TIMEOUT_SECONDS * 1_000,
+  );
+}
+
 /** The driver's `code`/`errno` for a connect-phase timeout. */
 export const CONNECT_TIMEOUT_CODE = 'CONNECT_TIMEOUT';
 
@@ -105,17 +126,7 @@ export function diagnoseConnectTimeout(
   const lag = reading ?? readEventLoopLag(windowMs);
   const worstLagMs = Math.round(lag.worstLagMs);
 
-  // Capped at the connect budget on purpose. EVENT_LOOP_STARVATION_WARN_MS is a
-  // *warning volume* knob — an operator quieting a noisy instance may raise it
-  // freely, and has no reason to think that touches error attribution. Used
-  // uncapped it does: at 15000 a 12s stall that demonstrably consumed the entire
-  // 10s budget would be reported as `connectivity` — "the event loop stayed
-  // healthy, check database reachability" — which is the precise misdirection
-  // this module exists to remove, restated with the authority of a verdict.
-  //
-  // A stall at least as long as the window is sufficient on its own to explain
-  // the timeout, so no configuration may classify it as anything else.
-  const starvationThresholdMs = Math.min(getEventLoopStarvationThresholdMs(), windowMs);
+  const starvationThresholdMs = getConnectTimeoutStarvationThresholdMs();
 
   // Fail to 'unknown', never to 'connectivity'. Without evidence covering the
   // window, quietly asserting "the database was unreachable" is precisely the

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -131,6 +131,58 @@ describe('sentry service', () => {
     expect(setTagMock).toHaveBeenCalledWith('prior_status', 'failed:server-timeout');
   });
 
+  // #3022: a CONNECT_TIMEOUT already arrives tagged `pg_code:CONNECT_TIMEOUT`,
+  // but that bucket mixes two unrelated failures — a handshake that really
+  // failed, and a main thread too busy to run the socket callbacks. These tags
+  // split it. Like the BREEZE-X pair above they are gated TWICE (setTag here,
+  // pickAllowedTags in the beforeSend scrubber), so both gates are asserted.
+  it('captureException tags a Postgres CONNECT_TIMEOUT with its likely cause', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureException, setConnectTimeoutClassifier } = await import('./sentry');
+    const { diagnoseConnectTimeout } = await import('./postgresConnectTimeout');
+    initSentry();
+    setConnectTimeoutClassifier(diagnoseConnectTimeout);
+
+    captureException(Object.assign(new Error('write CONNECT_TIMEOUT db:5432'), {
+      code: 'CONNECT_TIMEOUT',
+    }));
+
+    expect(setTagMock).toHaveBeenCalledWith('pg_code', 'CONNECT_TIMEOUT');
+    expect(setTagMock).toHaveBeenCalledWith('connect_timeout_cause', expect.any(String));
+    expect(setTagMock).toHaveBeenCalledWith('event_loop_lag_bucket', expect.any(String));
+    setConnectTimeoutClassifier(null);
+  });
+
+  it('captureException leaves non-timeout errors untagged by the #3022 classifier', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureException, setConnectTimeoutClassifier } = await import('./sentry');
+    const { diagnoseConnectTimeout } = await import('./postgresConnectTimeout');
+    initSentry();
+    setConnectTimeoutClassifier(diagnoseConnectTimeout);
+
+    captureException(Object.assign(new Error('duplicate key'), { code: '23505' }));
+
+    expect(setTagMock).toHaveBeenCalledWith('pg_code', '23505');
+    expect(setTagMock).not.toHaveBeenCalledWith('connect_timeout_cause', expect.anything());
+    expect(setTagMock).not.toHaveBeenCalledWith('event_loop_lag_bucket', expect.anything());
+    setConnectTimeoutClassifier(null);
+  });
+
+  it('captureException omits the #3022 tags when no classifier is registered', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry, captureException } = await import('./sentry');
+    initSentry();
+
+    // The classifier is injected at boot (index.ts). Until then the tags are
+    // omitted rather than guessed — an unwired process must not claim a cause.
+    captureException(Object.assign(new Error('write CONNECT_TIMEOUT db:5432'), {
+      code: 'CONNECT_TIMEOUT',
+    }));
+
+    expect(setTagMock).toHaveBeenCalledWith('pg_code', 'CONNECT_TIMEOUT');
+    expect(setTagMock).not.toHaveBeenCalledWith('connect_timeout_cause', expect.anything());
+  });
+
   it('captureMessage sets no tags when none are passed (existing callers unaffected)', async () => {
     process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
     const { initSentry, captureMessage } = await import('./sentry');
@@ -345,6 +397,8 @@ describe('scrubEvent', () => {
         partner_id: 'p-1',
         cas_label: 'device_commands.ws_result_terminal_cas',
         prior_status: 'failed:server-timeout',
+        connect_timeout_cause: 'event-loop-starvation',
+        event_loop_lag_bucket: 'over-10s',
         path: '/public/quotes/raw-capability',
         arbitrary: 'raw-capability',
       },
@@ -392,6 +446,11 @@ describe('scrubEvent', () => {
       // BREEZE-X: must survive the scrubber too, not just setCallerTags.
       cas_label: 'device_commands.ws_result_terminal_cas',
       prior_status: 'failed:server-timeout',
+      // #3022: same double gate — a CONNECT_TIMEOUT tagged in captureException
+      // but dropped here would leave the starvation-vs-connectivity split
+      // invisible in Sentry, which is the entire point of adding it.
+      connect_timeout_cause: 'event-loop-starvation',
+      event_loop_lag_bucket: 'over-10s',
     });
     expect(out.exception).toEqual({
       values: [{

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -148,8 +148,12 @@ describe('sentry service', () => {
     }));
 
     expect(setTagMock).toHaveBeenCalledWith('pg_code', 'CONNECT_TIMEOUT');
-    expect(setTagMock).toHaveBeenCalledWith('connect_timeout_cause', expect.any(String));
-    expect(setTagMock).toHaveBeenCalledWith('event_loop_lag_bucket', expect.any(String));
+    // Assert the VALUES, not just that some string arrived. No monitor is
+    // started in this suite, so the honest verdict is 'unknown' — and
+    // `expect.any(String)` would pass just as happily on a regression that
+    // reported a confident 'connectivity' with no evidence behind it.
+    expect(setTagMock).toHaveBeenCalledWith('connect_timeout_cause', 'unknown');
+    expect(setTagMock).toHaveBeenCalledWith('event_loop_lag_bucket', 'unknown');
     setConnectTimeoutClassifier(null);
   });
 

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -279,8 +279,11 @@ export function captureException(
     // a request — in the original incident the loudest signature in Sentry was
     // the patch scheduler, not any route. captureException is the one chokepoint
     // every path already goes through, so tagging it here covers all of them.
-    // Best-effort: diagnosis never throws, but a telemetry helper must not be
-    // able to swallow the exception it was called to report.
+    // The injected classifier is expected to be the never-throwing
+    // `safeDiagnoseConnectTimeout`, but this is the last line before an error
+    // report is emitted, so it is guarded here too: a classifier fault must cost
+    // two tags, never the report itself. `Sentry.captureException` below is
+    // deliberately outside the try.
     try {
       const diagnosis = connectTimeoutClassifier?.(err) ?? null;
       if (diagnosis) {

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -2,6 +2,9 @@ import * as Sentry from '@sentry/node';
 import type { Context } from 'hono';
 import { API_VERSION } from '../version';
 import { pgErrorCode } from '../utils/pgErrors';
+// TYPE-ONLY on purpose — erased at build time, so this adds no runtime import
+// edge. See setConnectTimeoutClassifier below for why that matters.
+import type { ConnectTimeoutDiagnosis } from './postgresConnectTimeout';
 import {
   UNMATCHED_ROUTE_LABEL,
   safeMatchedRouteLabel,
@@ -22,6 +25,27 @@ const RLS_DENY_SQLSTATE = '42501';
 
 let initialized = false;
 
+/**
+ * #3022 CONNECT_TIMEOUT classifier, injected at boot rather than imported.
+ *
+ * This module is imported by ~120 others, `db/index.ts` among them. A static
+ * import back to the classifier therefore pulls it — and the event-loop monitor
+ * behind it — into the module graph of everything that merely reports an error,
+ * including the DB module itself. That measurably slowed module evaluation and
+ * pushed `db/requestDatabasePool.test.ts` (a hard 15s budget on a dynamic
+ * `import('./index')`) over its timeout. Inverting the dependency keeps
+ * `services/sentry` a leaf, matching how the metrics recorders are wired
+ * (`setBackupMetricsRecorder`, `setS1MetricsRecorder`, …).
+ *
+ * Unset means "not wired yet" — the tags are simply omitted, never guessed.
+ */
+type ConnectTimeoutClassifier = (err: unknown) => ConnectTimeoutDiagnosis | null;
+let connectTimeoutClassifier: ConnectTimeoutClassifier | null = null;
+
+export function setConnectTimeoutClassifier(classifier: ConnectTimeoutClassifier | null): void {
+  connectTimeoutClassifier = classifier;
+}
+
 const ALLOWED_TAG_NAMES = new Set([
   'method',
   'route_template',
@@ -41,6 +65,14 @@ const ALLOWED_TAG_NAMES = new Set([
   // tenant, device, or command identifier.
   'prior_status',
   'cas_label',
+  // #3022: a Postgres CONNECT_TIMEOUT is already tagged `pg_code:CONNECT_TIMEOUT`,
+  // but that alone says nothing about WHY — the driver reports the identical
+  // error whether the handshake failed or this process was simply never
+  // scheduled to run the socket callbacks. These two split that bucket in
+  // Sentry. Both are closed sets by construction (see ConnectTimeoutCause and
+  // bucketEventLoopLag); neither carries a tenant, device, or host identifier.
+  'connect_timeout_cause',
+  'event_loop_lag_bucket',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;
@@ -240,6 +272,23 @@ export function captureException(
       if (sqlState === RLS_DENY_SQLSTATE) {
         scope.setTag('rls_deny', true);
       }
+    }
+
+    // #3022. Tagged HERE rather than in the HTTP error handler because a
+    // CONNECT_TIMEOUT is just as likely to surface from a BullMQ worker as from
+    // a request — in the original incident the loudest signature in Sentry was
+    // the patch scheduler, not any route. captureException is the one chokepoint
+    // every path already goes through, so tagging it here covers all of them.
+    // Best-effort: diagnosis never throws, but a telemetry helper must not be
+    // able to swallow the exception it was called to report.
+    try {
+      const diagnosis = connectTimeoutClassifier?.(err) ?? null;
+      if (diagnosis) {
+        scope.setTag('connect_timeout_cause', diagnosis.cause);
+        scope.setTag('event_loop_lag_bucket', diagnosis.lagBucket);
+      }
+    } catch {
+      // Classification is diagnostic only — never let it displace the report.
     }
 
     Sentry.captureException(err);


### PR DESCRIPTION
## What this fixes

`postgres.js` arms `connect_timeout` with a plain `setTimeout` (`connection.js:1042-1054`), starts it in `connect()` (`:343`) and cancels it only on ReadyForQuery (`:552`). The 10s budget therefore covers socket create → TCP → SSL → auth → ReadyForQuery, and **every one of those steps depends on the event loop being able to run a socket callback**. A pegged main thread expires that timer with the database and the network both healthy, and the driver reports `write CONNECT_TIMEOUT <host>:<port>` — a connection fault that never happened.

Per #3022 that misattribution is most of why the incident took so long to pin down: three unrelated Sentry signatures (`CONNECT_TIMEOUT`, the `nextWrite` `TypeError` from the driver teardown race, and a `[PatchScheduler]` sweep failure), all downstream of one stall, and nothing in telemetry naming the loop.

This PR makes the loop's own health a first-class, queryable signal and stops the driver's error from pointing investigation at the wrong subsystem.

## What it does

| Area | Change |
|---|---|
| `services/eventLoopMonitor.ts` | `perf_hooks.monitorEventLoopDelay` sampled into a bounded window. Reports the worst **sampled** lag *and* any stall **still in flight** |
| `services/postgresConnectTimeout.ts` | Classifies a CONNECT_TIMEOUT as `event-loop-starvation` / `connectivity` / `unknown` |
| Sentry | New `connect_timeout_cause` + `event_loop_lag_bucket` tags, set in `captureException` |
| Prometheus | `breeze_nodejs_eventloop_lag_{max,mean}_seconds`, `_starved`, `_monitored` |
| `/health/ready` | Reports lag (does **not** gate readiness on it) |
| Startup | Throttled `[event-loop] Main thread blocked for up to Nms` warning |

### Design decisions worth reviewing

- **In-flight lag is tracked separately from sampled lag.** When the loop is blocked, the sampler is a timer too, so it cannot run either. If the driver's connect timer fires before the monitor's sampler gets its turn, the stall is not yet in the ring buffer — only the in-flight figure reveals it. Both are folded into `worstLagMs`.
- **No monitor ⇒ `unknown`, never `connectivity`.** Falling back to "the handshake failed" without evidence would silently re-create the exact misdiagnosis this PR removes, and do it with the authority of a verdict. `monitored: false` is propagated everywhere, including a dedicated `_monitored` metric so a blind instance cannot read as a healthy one.
- **Tagged in `captureException`, not in `app.onError`.** In the original incident the loudest signature was the patch scheduler, not any route. `captureException` is the one chokepoint every path (routes, workers, process handlers) already goes through.
- **Readiness is deliberately not gated on lag.** Starvation is a load symptom; failing readiness under load would pull the instance from rotation, push its traffic onto peers, and starve those in turn.
- **`connect_timeout` stays at 10s.** The issue is explicit that raising it alone only lengthens the failing request. A drift guard pins the pool literal to the classifier's constant so the inspected window always equals the budget that expired.
- **Sentry capture is throttled, console is not.** One stall produces a run of breaching samples. This repo has twice had an unthrottled recurring warning exhaust the org's event quota and silently drop all error reporting (#1894, BREEZE-H).

### One structural change worth calling out

`services/sentry.ts` receives the classifier through `setConnectTimeoutClassifier(...)` instead of importing it. A static import pulled the classifier and the event-loop monitor into the module graph of **every module that reports an error** — `db/index.ts` among them — which measurably slowed module evaluation and pushed `db/requestDatabasePool.test.ts` (a hard 15s budget on a dynamic `import('./index')`) past its timeout. That regression was caught locally and is fixed by the inversion, which matches how the metrics recorders are already wired (`setBackupMetricsRecorder`, `setS1MetricsRecorder`, …). Measured on the same 7-file set: **20.6s and failing → 6.9s and green**.

## Scope: this is the second half of the issue, not the first

#3022 proposes two explicitly "separable pieces". This PR implements the second (stop the misattribution + add instrumentation) in full.

It does **not** implement the first (reduce main-thread work on the auth-rejection path), because every available option changes auth or security semantics and needs a design decision rather than a guess:

- A **negative auth cache** would suppress re-verification of a just-promoted pending token for the cache TTL — a real auth-timing behaviour change.
- A **pre-auth rate limit** on `/api/v1/agents/` reverses a deliberate skip in `globalRateLimit.ts:25`, and the existing per-org ceiling is already a known fleet-size constraint.
- **Skipping the fallback audit** on rejected requests is not available: `index.ts:794` deliberately records 401/403 as `result: 'denied'`, which is a security signal.

For the record, the issue's load claim checks out exactly: every agent 401/403 beyond a missing/malformed bearer costs a `devices` SELECT inside a `withSystemDbAccessContext` transaction (BEGIN + 6 `set_config` + SELECT + COMMIT), with no positive or negative cache; mutating rejected requests on non-excluded paths pay a second device SELECT plus an audit insert. The token hashing itself is `createHash('sha256')` and is not the CPU culprit.

**`Refs #3022` rather than `Closes` on purpose** — the issue should stay open for the first half. Happy to change that if you'd rather split it into a follow-up issue.

## Verification

- `vitest run` on the affected files, single worker: **83 passed** (`eventLoopMonitor`, `eventLoopStarvationReporter`, `postgresConnectTimeout`, `eventLoopMonitorWiring`, `sentry`, `requestDatabasePool`).
- Metrics/gateway suites: **63 passed**. DB context suites (`contextlessWriteGuard`, `heldContextCaptureThrottle`, `dbWriteExpectingRows`, `requestDatabasePool`): green.
- `tsc --noEmit` clean; `eslint` clean on all changed files.
- The load-bearing assumption — that `monitorEventLoopDelay` keeps accumulating while JS is blocked — is proven against a **real 250ms busy-wait**, not only against the fake histogram used elsewhere in the suite.
- No tenancy, RLS, migration, or cascade surface touched, so the contract suites are not implicated.

## Risk

Low. Nothing changes request control flow: no retry, no status remap, no timeout change. The monitor is a native histogram plus one `unref()`'d interval. Worst case if the monitor never starts, every consumer reports `unknown`/`monitored: false` and behaviour is exactly as today.

Two new env knobs, both optional: `EVENT_LOOP_STARVATION_WARN_MS` (default 1000), `EVENT_LOOP_STARVATION_THROTTLE_MS` (default 300000), plus `EVENT_LOOP_MONITOR_DISABLED` to opt out.

Refs #3022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
