### PR TITLE
fix(ai-tools): validate MCP billing/contract/catalog payloads; fix void delete_draft return

### DIFF
--- a/apps/api/src/services/aiToolsBilling.manageInvoices.test.ts
+++ b/apps/api/src/services/aiToolsBilling.manageInvoices.test.ts
@@ -211,11 +211,13 @@ describe('manage_invoices', () => {
   });
 
   it('record_payment calls recordPayment with the payment payload and actor', async () => {
+    // receivedAt is validated against recordPaymentSchema's isoDate (YYYY-MM-DD),
+    // the same shape the POST /invoices/:id/payments route enforces.
     const payment = {
       amount: 125,
       method: 'card',
       reference: 'ch_123',
-      receivedAt: '2026-07-01T10:00:00.000Z',
+      receivedAt: '2026-07-01',
     };
 
     const out = await getTool().handler(
@@ -255,11 +257,66 @@ describe('manage_invoices', () => {
     );
 
     const out = await getTool().handler(
-      { action: 'record_payment', invoiceId: 'inv-1', payment: { amount: 999 } },
+      {
+        action: 'record_payment',
+        invoiceId: 'inv-1',
+        payment: { amount: 999, method: 'card', receivedAt: '2026-07-01' },
+      },
       auth,
     );
 
     expect(JSON.parse(out)).toEqual({ error: 'Payment exceeds balance', code: 'OVERPAYMENT' });
+  });
+
+  it('record_payment with an incomplete payload returns a structured VALIDATION_ERROR instead of reaching recordPayment (BUG1 sibling fix)', async () => {
+    const out = await getTool().handler(
+      { action: 'record_payment', invoiceId: 'inv-1', payment: { amount: 999 } },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(invoiceService.recordPayment).not.toHaveBeenCalled();
+  });
+
+  it('add_manual_line with a missing quantity/unitPrice returns a structured VALIDATION_ERROR (BUG1 sibling fix)', async () => {
+    const out = await getTool().handler(
+      { action: 'add_manual_line', invoiceId: 'inv-1', line: { name: 'Widget', taxable: false } },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(invoiceService.addManualLine).not.toHaveBeenCalled();
+  });
+
+  it('update_line with an invalid patch field returns a structured VALIDATION_ERROR (BUG1 sibling fix)', async () => {
+    const out = await getTool().handler(
+      { action: 'update_line', invoiceId: 'inv-1', lineId: 'line-1', patch: { quantity: 'not-a-number' } },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(invoiceService.updateLine).not.toHaveBeenCalled();
+  });
+
+  it('update_header with an invalid patch field returns a structured VALIDATION_ERROR (BUG1 sibling fix)', async () => {
+    const out = await getTool().handler(
+      { action: 'update_header', invoiceId: 'inv-1', patch: { dueDate: 'not-a-date' } },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(invoiceService.updateInvoice).not.toHaveBeenCalled();
+  });
+
+  it('delete_draft awaits deleteDraftInvoice and returns {"ok":true} instead of the string "undefined" (BUG2 fix)', async () => {
+    const out = await getTool().handler({ action: 'delete_draft', invoiceId: 'inv-1' }, auth);
+
+    expect(invoiceService.deleteDraftInvoice).toHaveBeenCalledWith('inv-1', actor);
+    expect(JSON.parse(out)).toEqual({ ok: true });
   });
 
   it('re-throws non-service errors from service actions', async () => {

--- a/apps/api/src/services/aiToolsBilling.ts
+++ b/apps/api/src/services/aiToolsBilling.ts
@@ -18,8 +18,14 @@
  * Tier 3 actions.
  */
 
-import { INVOICE_STATUSES } from '@breeze/shared';
-import type { ManualLineInput, RecordPaymentInput } from '@breeze/shared';
+import { z } from 'zod';
+import {
+  INVOICE_STATUSES,
+  manualLineSchema,
+  updateLineSchema,
+  updateInvoiceSchema,
+  recordPaymentSchema
+} from '@breeze/shared';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool, AiToolTier } from './aiTools';
 import {
@@ -47,9 +53,6 @@ import { computeContractEstimate, getContract } from './contractService';
 import { toCents } from './invoiceMath';
 import { missingParamsJson, zodErrorToJson } from './aiToolValidation';
 
-type UpdateInvoiceLinePatch = Parameters<typeof updateLine>[2];
-type UpdateInvoiceHeaderPatch = Parameters<typeof updateInvoice>[1];
-
 function actorFromAuth(auth: AuthContext): InvoiceActor {
   return {
     userId: auth.user.id,
@@ -68,6 +71,18 @@ function serviceErrorToJson(err: unknown): string | null {
   }
   return null;
 }
+
+// Payload parsers wrap the value under its param name so ZodError paths are
+// self-describing ("line.quantity: ...", "payment.receivedAt: ..."). These
+// are the SAME schemas the HTTP invoice routes validate with — one source of
+// truth. Without this, a malformed manage_invoices call skipped validation
+// entirely (the type-cast reached invoiceService with no Zod layer at all)
+// and died as an opaque DB constraint 500 instead of a structured
+// VALIDATION_ERROR the model could act on.
+const manualLinePayload = z.object({ line: manualLineSchema });
+const lineUpdatePayload = z.object({ patch: updateLineSchema });
+const headerUpdatePayload = z.object({ patch: updateInvoiceSchema });
+const paymentPayload = z.object({ payment: recordPaymentSchema });
 
 /**
  * Adds a derived `depositPaid` boolean (amountPaid >= depositDue, compared in
@@ -248,7 +263,11 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
               actor
             ));
           case 'add_manual_line':
-            return JSON.stringify(await addManualLine(String(input.invoiceId), input.line as ManualLineInput, actor));
+            return JSON.stringify(await addManualLine(
+              String(input.invoiceId),
+              manualLinePayload.parse({ line: input.line }).line,
+              actor
+            ));
           case 'add_catalog_line':
             return JSON.stringify(await addCatalogLine(String(input.invoiceId), String(input.catalogItemId), Number(input.quantity), actor));
           case 'add_bundle_line':
@@ -279,13 +298,28 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
             }, actor));
           }
           case 'update_line':
-            return JSON.stringify(await updateLine(String(input.invoiceId), String(input.lineId), input.patch as UpdateInvoiceLinePatch, actor));
+            return JSON.stringify(await updateLine(
+              String(input.invoiceId),
+              String(input.lineId),
+              lineUpdatePayload.parse({ patch: input.patch }).patch,
+              actor
+            ));
           case 'remove_line':
             return JSON.stringify(await removeLine(String(input.invoiceId), String(input.lineId), actor));
           case 'update_header':
-            return JSON.stringify(await updateInvoice(String(input.invoiceId), input.patch as UpdateInvoiceHeaderPatch, actor));
+            return JSON.stringify(await updateInvoice(
+              String(input.invoiceId),
+              headerUpdatePayload.parse({ patch: input.patch }).patch,
+              actor
+            ));
           case 'delete_draft':
-            return JSON.stringify(await deleteDraftInvoice(String(input.invoiceId), actor));
+            // deleteDraftInvoice returns Promise<void>; stringifying the await
+            // directly produced the string "undefined" (not JSON), which the
+            // MCP layer rejected as a tool failure AFTER the delete already
+            // committed — matches aiToolsContracts.ts's delete_draft/remove_line
+            // and aiToolsQuotes.ts's delete_draft/delete_block pattern.
+            await deleteDraftInvoice(String(input.invoiceId), actor);
+            return JSON.stringify({ ok: true });
           case 'assemble_from_org':
             return JSON.stringify(await assembleDraftFromOrg(
               { orgId: String(input.orgId), siteId: s('siteId'), from: String(input.from), to: String(input.to) },
@@ -298,7 +332,11 @@ export function registerBillingTools(aiTools: Map<string, AiTool>): void {
           case 'void':
             return JSON.stringify(await voidInvoice(String(input.invoiceId), String(input.reason), { reissue: Boolean(input.reissue) }, actor));
           case 'record_payment':
-            return JSON.stringify(await recordPayment(String(input.invoiceId), input.payment as RecordPaymentInput, actor));
+            return JSON.stringify(await recordPayment(
+              String(input.invoiceId),
+              paymentPayload.parse({ payment: input.payment }).payment,
+              actor
+            ));
           case 'void_payment':
             return JSON.stringify(await voidPayment(String(input.paymentId), actor));
           case 'create_pay_link':

--- a/apps/api/src/services/aiToolsCatalog.manageCatalog.test.ts
+++ b/apps/api/src/services/aiToolsCatalog.manageCatalog.test.ts
@@ -129,8 +129,16 @@ describe('manage_catalog', () => {
   });
 
   it('set_bundle_components passes components through to setBundleComponents with actor', async () => {
+    // componentItemId is validated as a UUID (bundleComponentSchema); the fake
+    // "cat-1"-style ids used elsewhere in this file are only ever String()-coerced
+    // path params, never parsed against a guid schema, so they stay untouched.
     const components = [
-      { componentItemId: 'cat-1', quantity: 2, showOnInvoice: true, revenueAllocation: 50 },
+      {
+        componentItemId: '11111111-1111-1111-1111-111111111111',
+        quantity: 2,
+        showOnInvoice: true,
+        revenueAllocation: 50,
+      },
     ];
 
     const out = await getTool().handler(
@@ -144,6 +152,43 @@ describe('manage_catalog', () => {
       actor,
     );
     expect(JSON.parse(out)).toEqual({ item: { id: 'bundle-1' }, components: [] });
+  });
+
+  it('create_item with an invalid item payload returns a structured VALIDATION_ERROR (BUG1 sibling fix)', async () => {
+    const out = await getTool().handler(
+      { action: 'create_item', item: { name: 'Missing required fields' } },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(catalogService.createCatalogItem).not.toHaveBeenCalled();
+  });
+
+  it('set_org_price with a non-numeric unitPrice returns a structured VALIDATION_ERROR (BUG1 sibling fix)', async () => {
+    const out = await getTool().handler(
+      { action: 'set_org_price', catalogId: 'cat-1', orgId: 'org-1', override: { unitPrice: 'free' } },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(catalogService.setOrgPriceOverride).not.toHaveBeenCalled();
+  });
+
+  it('set_bundle_components with a non-UUID componentItemId returns a structured VALIDATION_ERROR (BUG1 sibling fix)', async () => {
+    const out = await getTool().handler(
+      {
+        action: 'set_bundle_components',
+        catalogId: 'bundle-1',
+        components: [{ componentItemId: 'not-a-uuid', quantity: 2 }],
+      },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(catalogService.setBundleComponents).not.toHaveBeenCalled();
   });
 
   it('returns a JSON error when a service action rejects with CatalogServiceError', async () => {

--- a/apps/api/src/services/aiToolsCatalog.ts
+++ b/apps/api/src/services/aiToolsCatalog.ts
@@ -12,11 +12,12 @@
  */
 
 import { and, asc, eq, ilike, or, sql } from 'drizzle-orm';
-import type {
-  BundleComponentInput,
-  CreateCatalogItemInput,
-  OrgPriceOverrideInput,
-  UpdateCatalogItemInput
+import { z } from 'zod';
+import {
+  createCatalogItemSchema,
+  updateCatalogItemSchema,
+  orgPriceOverrideSchema,
+  setBundleComponentsSchema
 } from '@breeze/shared';
 import { db } from '../db';
 import { catalogItems, catalogBundleComponents } from '../db/schema';
@@ -64,6 +65,17 @@ function serviceErrorToJson(err: unknown): string | null {
   }
   return null;
 }
+
+// Payload parsers wrap the value under its param name so ZodError paths are
+// self-describing ("item.unitPrice: ...", "override.unitPrice: ..."). These
+// are the SAME schemas the HTTP catalog routes validate with — one source of
+// truth. Without this, a malformed manage_catalog call skipped validation
+// entirely (the type-cast reached catalogService with no Zod layer at all)
+// and died as an opaque DB constraint 500 instead of a structured
+// VALIDATION_ERROR the model could act on.
+const createItemPayload = z.object({ item: createCatalogItemSchema });
+const updateItemPayload = z.object({ item: updateCatalogItemSchema });
+const overridePayload = z.object({ override: orgPriceOverrideSchema });
 
 type CatalogItemRow = typeof catalogItems.$inferSelect;
 
@@ -434,11 +446,14 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
       try {
         switch (action) {
           case 'create_item':
-            return JSON.stringify(await createCatalogItem(input.item as CreateCatalogItemInput, actor));
+            return JSON.stringify(await createCatalogItem(
+              createItemPayload.parse({ item: input.item }).item,
+              actor
+            ));
           case 'update_item':
             return JSON.stringify(await updateCatalogItem(
               String(input.catalogId),
-              input.item as UpdateCatalogItemInput,
+              updateItemPayload.parse({ item: input.item }).item,
               actor
             ));
           case 'archive_item':
@@ -447,7 +462,7 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
             return JSON.stringify(await setOrgPriceOverride(
               String(input.catalogId),
               String(input.orgId),
-              input.override as OrgPriceOverrideInput,
+              overridePayload.parse({ override: input.override }).override,
               actor
             ));
           case 'remove_org_price':
@@ -459,7 +474,7 @@ export function registerCatalogTools(aiTools: Map<string, AiTool>): void {
           case 'set_bundle_components':
             return JSON.stringify(await setBundleComponents(
               String(input.catalogId),
-              (input.components ?? []) as BundleComponentInput[],
+              setBundleComponentsSchema.parse({ components: input.components ?? [] }).components,
               actor
             ));
           default:

--- a/apps/api/src/services/aiToolsContracts.manageContracts.test.ts
+++ b/apps/api/src/services/aiToolsContracts.manageContracts.test.ts
@@ -69,8 +69,11 @@ describe('manage_contracts', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('create_draft calls createContract with input payload and actor built from auth', async () => {
+    // orgId is validated as a UUID (createContractSchema) — unlike contractId/
+    // lineId elsewhere in this file, which are only ever String()-coerced path
+    // params and never parsed against a guid schema.
     const input = {
-      orgId: 'org-1',
+      orgId: '11111111-1111-1111-1111-111111111111',
       name: 'Managed services',
       billingTiming: 'advance',
       intervalMonths: 1,
@@ -167,5 +170,54 @@ describe('manage_contracts', () => {
     expect(parsed.code).toBe('VALIDATION_ERROR');
     expect(parsed.error).toContain('contractId');
     expect(contractService.activateContract).not.toHaveBeenCalled();
+  });
+
+  // BUG 1: manage_contracts used to type-cast create_draft/update/add_line
+  // payloads straight into the service call with no Zod layer at all — a
+  // malformed payload (e.g. missing billingTiming/intervalMonths) reached
+  // createContract's raw insert and died as an opaque HTTP 500 NOT NULL
+  // violation instead of a structured validation message.
+  it('create_draft with an invalid payload (missing billingTiming/intervalMonths) returns a structured VALIDATION_ERROR instead of throwing', async () => {
+    const out = await getTool().handler(
+      {
+        action: 'create_draft',
+        input: { orgId: 'org-1', name: 'Managed services', startDate: '2026-07-01' },
+      },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(contractService.createContract).not.toHaveBeenCalled();
+  });
+
+  it('update with an invalid patch (bad intervalMonths type) returns a structured VALIDATION_ERROR', async () => {
+    const out = await getTool().handler(
+      {
+        action: 'update',
+        contractId: 'contract-1',
+        patch: { intervalMonths: 'monthly' },
+      },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(contractService.updateContract).not.toHaveBeenCalled();
+  });
+
+  it('add_line with an invalid line (missing unitPrice/taxable) returns a structured VALIDATION_ERROR', async () => {
+    const out = await getTool().handler(
+      {
+        action: 'add_line',
+        contractId: 'contract-1',
+        line: { lineType: 'manual', description: 'Support' },
+      },
+      auth,
+    );
+
+    const parsed = JSON.parse(out);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(contractService.addContractLineToContract).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/aiToolsContracts.ts
+++ b/apps/api/src/services/aiToolsContracts.ts
@@ -18,7 +18,8 @@
  * resume/cancel are approval-gated Tier 3 actions.
  */
 
-import type { ContractLineInput, CreateContractInput, UpdateContractInput } from '@breeze/shared';
+import { z } from 'zod';
+import { createContractSchema, updateContractSchema, contractLineInputSchema } from '@breeze/shared';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool, AiToolTier } from './aiTools';
 import {
@@ -68,6 +69,17 @@ function serviceErrorToJson(err: unknown): string | null {
   }
   return null;
 }
+
+// Payload parsers wrap the value under its param name so ZodError paths are
+// self-describing ("input.billingTiming: ...", "line.lineType: ..."). These
+// are the SAME schemas the HTTP contract routes validate with — one source of
+// truth. Without this, a malformed manage_contracts call skipped validation
+// entirely (the type-cast reached contractService with no Zod layer at all)
+// and died as an opaque DB NOT NULL/constraint 500 instead of a structured
+// VALIDATION_ERROR the model could act on.
+const createPayload = z.object({ input: createContractSchema });
+const patchPayload = z.object({ patch: updateContractSchema });
+const linePayload = z.object({ line: contractLineInputSchema });
 
 export function registerContractTools(aiTools: Map<string, AiTool>): void {
   aiTools.set('list_contracts', {
@@ -186,11 +198,14 @@ export function registerContractTools(aiTools: Map<string, AiTool>): void {
       try {
         switch (action) {
           case 'create_draft':
-            return JSON.stringify(await createContract(input.input as CreateContractInput, actor));
+            return JSON.stringify(await createContract(
+              createPayload.parse({ input: input.input }).input,
+              actor
+            ));
           case 'update':
             return JSON.stringify(await updateContract(
               String(input.contractId),
-              input.patch as UpdateContractInput,
+              patchPayload.parse({ patch: input.patch }).patch,
               actor
             ));
           case 'delete_draft':
@@ -199,7 +214,7 @@ export function registerContractTools(aiTools: Map<string, AiTool>): void {
           case 'add_line':
             return JSON.stringify(await addContractLineToContract(
               String(input.contractId),
-              input.line as ContractLineInput,
+              linePayload.parse({ line: input.line }).line,
               actor
             ));
           case 'remove_line':


### PR DESCRIPTION
## Summary

Live MCP testing of the invoice/contract tools surfaced two defect classes, both fixed here:

1. **Validation bypass on MCP write payloads.** `manage_contracts`, `manage_invoices`, and `manage_catalog` type-cast their object payloads (`input`/`patch`/`line`/`payment`/`item`/`override`/`components`) straight into the service layer. The HTTP routes validate these payloads with shared Zod schemas; the MCP path skipped validation entirely, so a malformed payload (e.g. `create_draft` missing `billingTiming`/`intervalMonths`) died as an opaque HTTP 500 NOT NULL violation instead of a structured `VALIDATION_ERROR` the model can react to. Payloads now parse with the **same shared schemas the routes use**, wrapped under their param name so ZodError paths read `input.billingTiming: ...` / `payment.receivedAt: ...`.

2. **`manage_invoices` `delete_draft` reported failure after succeeding.** It returned `JSON.stringify(await deleteDraftInvoice(...))` — a void call, so the handler returned `undefined` and the MCP layer rejected the result as a generic tool failure *after* the row was already deleted. Now returns `{ok:true}`, matching `manage_contracts`/`manage_quotes`.

Both were reproduced live over MCP before the fix (opaque 500 on bad contract payload; cosmetic delete failure verified via `get_invoice` → `INVOICE_NOT_FOUND`).

## Audit scope

All `aiTools*.ts` payload casts were audited; `manage_quotes` already validates in its service layer and all other `JSON.stringify(await ...)` sites return non-void values — only the sites changed here were affected.

## Tests

- New regression tests: invalid `create_draft`/`update`/`add_line`/`record_payment`/`create_item` payloads return structured `VALIDATION_ERROR` and never reach the service; `delete_draft` returns `{"ok":true}`.
- `vitest run` on the three touched suites: 45 passed. `aiToolsRegistryParity.test.ts` + `aiGuardrails.test.ts`: 118 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)