### PR TITLE
fix(agent/backup): stop VSS from rewriting the system-state staging dir onto a path the snapshot never had (#3026)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1194,7 +1194,7 @@ jobs:
           $out | ForEach-Object { Write-Host $_ }
           if ($exit -ne 0) { throw "go test failed (exit $exit)" }
           $passes = @($out | Select-String -Pattern '^--- PASS: Test').Count
-          if ($passes -ne 11) { throw "expected exactly 11 top-level PASS lines, got $passes - a test in the -run filter was renamed, removed, or added without updating this count" }
+          if ($passes -ne 14) { throw "expected exactly 14 top-level PASS lines, got $passes - a test in the -run filter was renamed, removed, or added without updating this count" }
 
       # -race requires cgo, which remote/desktop cannot satisfy on Windows, so
       # this covers only packages that do not import it (heartbeat and agentapp

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -354,12 +354,14 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 
 	// System state collection: gather OS config, hardware profile, etc.
 	var systemStateErr error
-	// systemStateStagingDir/systemStateStagingIdx let us recover, after any
-	// VSS rewrite below, whichever staging-root value was ACTUALLY walked —
-	// see the assignment right after the VSS rewrite for why the raw
-	// stagingDir returned here isn't necessarily it.
+	// systemStateStagingIdx marks the staging dir's slot in backupPaths so the
+	// VSS rewrite below can leave it alone — it is created after the snapshot
+	// and therefore only exists on the live volume (#3026). Because it is never
+	// rewritten, systemStateStagingDir is simply the path collectSystemState
+	// returned, and it is the same prefix collectBackupFilesFromPaths produces
+	// for markSystemStateFiles to match on.
 	var systemStateStagingDir string
-	systemStateStagingIdx := -1
+	systemStateStagingIdx := noStagingIdx
 	if m.config.SystemStateEnabled {
 		if err := runCtx.Err(); err != nil {
 			return stopBackupRun()
@@ -381,6 +383,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			}
 			// Append staging dir to backup paths so artifacts are included in snapshot
 			systemStateStagingIdx = len(backupPaths)
+			systemStateStagingDir = stagingDir
 			backupPaths = append(backupPaths, stagingDir)
 			defer func() {
 				if removeErr := os.RemoveAll(stagingDir); removeErr != nil {
@@ -393,7 +396,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	// Rewrite paths to shadow copy device paths when VSS is active
 	if vssSession != nil {
 		var unmappedIdx []int
-		backupPaths, unmappedIdx = rewritePathsForVSS(backupPaths, vssSession.ShadowPaths)
+		backupPaths, unmappedIdx = rewritePathsForVSS(backupPaths, vssSession.ShadowPaths, systemStateStagingIdx)
 		if liveReads := reportableLiveReads(backupPaths, unmappedIdx, systemStateStagingIdx); len(liveReads) > 0 {
 			shadowedVolumes := make([]string, 0, len(vssSession.ShadowPaths))
 			for vol := range vssSession.ShadowPaths {
@@ -421,16 +424,6 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			// only VSS signal that reaches the server today.
 			appendWarning(job, "read from the live volume, not the VSS shadow copy: "+summary)
 		}
-	}
-	if systemStateStagingIdx >= 0 && systemStateStagingIdx < len(backupPaths) {
-		// The staging dir's OS temp volume commonly coincides with a
-		// VSS-shadowed backup volume, so rewritePathsForVSS above may have
-		// rewritten it too — capture whichever value was actually walked
-		// (this index in the possibly-rewritten backupPaths) rather than
-		// the pre-rewrite path from collectSystemState, so
-		// markSystemStateFiles below compares against the same sourcePath
-		// prefix collectBackupFilesFromPaths actually produced.
-		systemStateStagingDir = backupPaths[systemStateStagingIdx]
 	}
 
 	if err := runCtx.Err(); err != nil {
@@ -1015,26 +1008,21 @@ func extractVolumes(paths []string) []string {
 	return volumes
 }
 
-// rewritePathsForVSS rewrites source paths to use VSS shadow copy device paths.
-// e.g., "C:\\Users\\data" with shadow "C:" -> "\\\\?\\GLOBALROOT\\...\\Users\\data"
-//
-// The second return value holds the indices of paths that found no shadow root
-// and were left pointing at the live volume. That fallback is deliberate — a
-// volume whose snapshot failed is still worth a best-effort read — but it is
-// also indistinguishable, from the walk onward, from a successful VSS backup.
-// It is how a shadowPaths key-format change would silently reintroduce #2999,
-// so the caller reports it rather than letting it pass unnoticed. Indices, not
-// paths, so the caller can exclude the system-state staging dir it wrote
-// itself (see the call site).
+// noStagingIdx is the stagingIdx sentinel for a run with no system-state
+// staging directory: no index is excluded from the VSS rewrite or from the
+// live-read warning.
+const noStagingIdx = -1
+
 // reportableLiveReads selects, from rewritePathsForVSS's unmapped indices, the paths
 // actually worth reporting.
 //
 // Two exclusions, both deliberate:
 //
 //   - stagingIdx, the system-state staging dir. The agent creates it itself
-//     during this run, so it can only ever be read live. (It is created AFTER
-//     the snapshot, which is a separate problem for the case where it IS
-//     mapped — see the systemStateStagingIdx block in RunBackupContext.)
+//     during this run, after the snapshot, so it is excluded from the rewrite
+//     and can only ever be read live (see rewritePathsForVSS). That makes it an
+//     expected member of the unmapped set on every system_image run, not a
+//     symptom of anything.
 //   - Anything whose volume is not a local drive letter. VSS cannot snapshot a
 //     UNC share, and filepath.VolumeName yields "" for a relative or
 //     drive-rooted path, which extractVolumes never even requests. Reporting
@@ -1079,18 +1067,41 @@ func summarizeLiveReads(paths []string) string {
 		fmt.Sprintf(" (+%d more)", len(paths)-maxUploadFailureDetails)
 }
 
-func rewritePathsForVSS(paths []string, shadowPaths map[string]string) ([]string, []int) {
+// rewritePathsForVSS rewrites source paths to use VSS shadow copy device paths.
+// e.g., "C:\\Users\\data" with shadow "C:" -> "\\\\?\\GLOBALROOT\\...\\Users\\data"
+//
+// stagingIdx (noStagingIdx when the run has none) is the index of the
+// system-state staging directory, which is excluded from the rewrite. It is
+// created by collectSystemState AFTER the shadow copy was taken, so it does
+// not exist inside that point-in-time image — but %TEMP% normally sits on C:,
+// normally one of the shadowed backup volumes, so rewriting it would map it
+// onto a snapshot path that is simply absent. The walk then finds nothing,
+// markSystemStateFiles matches zero files, and the job still reports success
+// with SystemStateManifest set: silent, partial data loss in the default
+// configuration (#3026). The live volume is the only place those artifacts
+// exist, so that is where the path must keep pointing.
+//
+// The second return value holds the indices of paths left pointing at the live
+// volume — those that found no shadow root, plus stagingIdx. The no-shadow-root
+// fallback is deliberate — a volume whose snapshot failed is still worth a
+// best-effort read — but it is also indistinguishable, from the walk onward,
+// from a successful VSS backup. It is how a shadowPaths key-format change would
+// silently reintroduce #2999, so the caller reports it rather than letting it
+// pass unnoticed. Indices, not paths, so the caller can tell an unshadowed user
+// volume (worth a warning) apart from the staging dir it wrote itself (never
+// worth one) — see reportableLiveReads.
+func rewritePathsForVSS(paths []string, shadowPaths map[string]string, stagingIdx int) ([]string, []int) {
 	rewritten := make([]string, len(paths))
 	var unmapped []int
 	for i, p := range paths {
 		vol := filepath.VolumeName(p)
-		if shadow, ok := shadowPaths[vol]; ok {
-			rest := p[len(vol):]
-			rewritten[i] = shadow + rest
-		} else {
+		shadow, ok := shadowPaths[vol]
+		if !ok || i == stagingIdx {
 			rewritten[i] = p // fallback: use original path
 			unmapped = append(unmapped, i)
+			continue
 		}
+		rewritten[i] = shadow + p[len(vol):]
 	}
 	return rewritten, unmapped
 }

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -361,6 +361,13 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	// rewritten, systemStateStagingDir is simply the path collectSystemState
 	// returned, and it is the same prefix collectBackupFilesFromPaths produces
 	// for markSystemStateFiles to match on.
+	//
+	// The index is POSITIONAL and captured immediately before the append below.
+	// Nothing may insert into, reorder, filter or dedupe backupPaths between
+	// that append and rewritePathsForVSS, or the exclusion lands on a real user
+	// path — which would then read live with its warning suppressed, i.e. the
+	// #2999 class this file works to keep visible. If backupPaths ever needs
+	// post-processing, append the staging dir after it instead of moving this.
 	var systemStateStagingDir string
 	systemStateStagingIdx := noStagingIdx
 	if m.config.SystemStateEnabled {
@@ -371,6 +378,14 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		if ssErr != nil {
 			systemStateErr = ssErr
 			log.Warn("system state collection failed, proceeding without", "error", ssErr.Error())
+			// systemStateErr alone only fails the run when there is nothing
+			// else to fall back on (the len(files)==0 branch below). A run that
+			// ALSO has configured file paths keeps going and completes green,
+			// so without this the operator is never told the system state is
+			// absent — the same silent outcome as #3026, reached by a different
+			// route. CollectSystemState only errors when a REQUIRED class
+			// failed, i.e. the capture would not boot at restore time.
+			appendWarning(job, "system state was not collected: "+ssErr.Error())
 		} else {
 			job.SystemStateManifest = manifest
 			// Collection succeeded on all *required* artifacts (missing a
@@ -379,10 +394,19 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			// ...) — surface them as a completion warning so a degraded capture
 			// is visible without discarding an otherwise-usable backup.
 			if len(manifest.IncompleteSteps) > 0 {
-				job.Warning = fmt.Sprintf("system state collection incomplete: %v failed", manifest.IncompleteSteps)
-				log.Warn("system state collection incomplete", "warning", job.Warning)
+				// appendWarning, not a raw assignment: this used to be the
+				// first and only writer of job.Warning, but it is now one of
+				// several (the collection-failure note above, the live-read
+				// note and the uncaptured-artifacts note below). A raw
+				// assignment here silently discards whichever of those ran
+				// first.
+				incomplete := fmt.Sprintf("system state collection incomplete: %v failed", manifest.IncompleteSteps)
+				appendWarning(job, incomplete)
+				log.Warn("system state collection incomplete", "warning", incomplete)
 			}
-			// Append staging dir to backup paths so artifacts are included in snapshot
+			// Append the staging dir to the walked paths so its artifacts land
+			// in the backup manifest. NOT in the VSS shadow copy — the rewrite
+			// below deliberately skips this entry (see rewritePathsForVSS).
 			systemStateStagingIdx = len(backupPaths)
 			systemStateStagingDir = stagingDir
 			backupPaths = append(backupPaths, stagingDir)
@@ -456,19 +480,30 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 	}
 	if systemStateArtifactsMissing(job.SystemStateManifest, markSystemStateFiles(files, systemStateStagingDir)) {
 		// Reached only when the manifest and the collected files disagree, so
-		// it cannot fire on a healthy run. A warning rather than a failure:
-		// the file-path portion of the backup is still valid and worth
-		// keeping, but the run must stop presenting as a complete system
-		// image. appendWarning is the only VSS/system-state signal that
-		// reaches the server (see the live-read warning above).
+		// it cannot fire on a healthy run.
+		//
+		// Warning rather than failure for the JOB: the file-path portion is
+		// still valid and restorable, so failing would throw away good data.
+		// But a warning alone is not enough, because unlike job.VSSMetadata the
+		// manifest DOES survive the trip — it is persisted to
+		// backup_snapshots.system_state_manifest and handed to the bare-metal
+		// recovery paths. Left intact it would advertise a complete system
+		// state on a restore point that holds none of it, which is the #3026
+		// symptom rather than a report of it. So drop the artifact list it can
+		// no longer vouch for, and keep the rest of the manifest (platform, OS
+		// version, hardware profile) — that is inline collector output, still
+		// accurate, and the hardware profile is persisted from here for
+		// recovery planning.
+		artifactCount := len(job.SystemStateManifest.Artifacts)
 		log.Warn("system state manifest was recorded but none of its artifacts were captured; "+
 			"the restore point does not contain the system state it describes",
 			"jobId", job.ID,
-			"artifacts", len(job.SystemStateManifest.Artifacts),
+			"artifacts", artifactCount,
 			"stagingDir", systemStateStagingDir,
 		)
-		appendWarning(job, "system state artifacts were not captured: the manifest describes "+
-			strconv.Itoa(len(job.SystemStateManifest.Artifacts))+" artifacts but none reached the snapshot")
+		job.SystemStateManifest.Artifacts = nil
+		appendWarning(job, "system state artifacts were not captured: the manifest described "+
+			strconv.Itoa(artifactCount)+" artifacts but none reached the snapshot")
 	}
 	if len(files) == 0 {
 		if err := runCtx.Err(); err != nil {
@@ -1034,11 +1069,12 @@ const noStagingIdx = -1
 //
 // Two exclusions, both deliberate:
 //
-//   - stagingIdx, the system-state staging dir. The agent creates it itself
-//     during this run, after the snapshot, so it is excluded from the rewrite
-//     and can only ever be read live (see rewritePathsForVSS). That makes it an
-//     expected member of the unmapped set on every system_image run, not a
-//     symptom of anything.
+//   - stagingIdx, the system-state staging dir (#3025 added this exclusion;
+//     #3026 extended it to the rewrite). The agent creates it itself during
+//     this run, after the snapshot, so it is excluded from the rewrite and can
+//     only ever be read live (see rewritePathsForVSS). That makes it an
+//     expected member of the unmapped set on every run where VSS is active and
+//     system-state collection succeeded, not a symptom of anything.
 //   - Anything whose volume is not a local drive letter. VSS cannot snapshot a
 //     UNC share, and filepath.VolumeName yields "" for a relative or
 //     drive-rooted path, which extractVolumes never even requests. Reporting
@@ -1092,17 +1128,24 @@ func summarizeLiveReads(paths []string) string {
 // not exist inside that point-in-time image — but %TEMP% normally sits on C:,
 // normally one of the shadowed backup volumes, so rewriting it would map it
 // onto a snapshot path that is simply absent. The walk then finds nothing,
-// markSystemStateFiles matches zero files, and the job still reports success
-// with SystemStateManifest set: silent, partial data loss in the default
-// configuration (#3026). The live volume is the only place those artifacts
-// exist, so that is where the path must keep pointing.
+// markSystemStateFiles matches zero files, and a run that also has configured
+// file paths still reports success with SystemStateManifest set: silent,
+// partial data loss (#3026). (A system-state-ONLY run trips the len(files)==0
+// hard-failure guard instead, so it fails loudly rather than silently.) The
+// live volume is the only place those artifacts exist, so that is where the
+// path must keep pointing.
+//
+// Reachable whenever VSS and system-state collection are both on for the same
+// run — an agent.yaml enabling backup_vss_enabled and
+// backup_system_state_enabled, or a system_image run with an explicit vss
+// override. Server-dispatched system_image runs default VSS off (defaultVSS in
+// cmd/breeze-backup/exec_backup.go), so this is opt-in rather than universal.
 //
 // The second return value holds the indices of paths left pointing at the live
 // volume — those that found no shadow root, plus stagingIdx when it is in
-// range. The no-shadow-root
-// fallback is deliberate — a volume whose snapshot failed is still worth a
-// best-effort read — but it is also indistinguishable, from the walk onward,
-// from a successful VSS backup. It is how a shadowPaths key-format change would
+// range. The no-shadow-root fallback is deliberate — a volume whose snapshot
+// failed is still worth a best-effort read — but it is also indistinguishable,
+// from the walk onward, from a successful VSS backup. It is how a shadowPaths key-format change would
 // silently reintroduce #2999, so the caller reports it rather than letting it
 // pass unnoticed. Indices, not paths, so the caller can tell an unshadowed user
 // volume (worth a warning) apart from the staging dir it wrote itself (never

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -453,7 +454,22 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		// backupFile.originalPath doc comment.
 		originalPathsForVSS(files, vssSession.ShadowPaths)
 	}
-	markSystemStateFiles(files, systemStateStagingDir)
+	if systemStateArtifactsMissing(job.SystemStateManifest, markSystemStateFiles(files, systemStateStagingDir)) {
+		// Reached only when the manifest and the collected files disagree, so
+		// it cannot fire on a healthy run. A warning rather than a failure:
+		// the file-path portion of the backup is still valid and worth
+		// keeping, but the run must stop presenting as a complete system
+		// image. appendWarning is the only VSS/system-state signal that
+		// reaches the server (see the live-read warning above).
+		log.Warn("system state manifest was recorded but none of its artifacts were captured; "+
+			"the restore point does not contain the system state it describes",
+			"jobId", job.ID,
+			"artifacts", len(job.SystemStateManifest.Artifacts),
+			"stagingDir", systemStateStagingDir,
+		)
+		appendWarning(job, "system state artifacts were not captured: the manifest describes "+
+			strconv.Itoa(len(job.SystemStateManifest.Artifacts))+" artifacts but none reached the snapshot")
+	}
 	if len(files) == 0 {
 		if err := runCtx.Err(); err != nil {
 			return stopBackupRun()
@@ -1082,7 +1098,8 @@ func summarizeLiveReads(paths []string) string {
 // exist, so that is where the path must keep pointing.
 //
 // The second return value holds the indices of paths left pointing at the live
-// volume — those that found no shadow root, plus stagingIdx. The no-shadow-root
+// volume — those that found no shadow root, plus stagingIdx when it is in
+// range. The no-shadow-root
 // fallback is deliberate — a volume whose snapshot failed is still worth a
 // best-effort read — but it is also indistinguishable, from the walk onward,
 // from a successful VSS backup. It is how a shadowPaths key-format change would

--- a/agent/internal/backup/backup_test.go
+++ b/agent/internal/backup/backup_test.go
@@ -569,6 +569,124 @@ func TestRunBackup_SystemImage_PartialCollectionWarns(t *testing.T) {
 	}
 }
 
+// TestRunBackup_SystemStateManifestWithoutArtifactsWarnsAndDropsArtifacts is
+// the end-to-end guard for #3026's symptom, at the level the bug actually
+// presented: a run that ALSO has configured file paths, so the len(files)==0
+// hard-failure guard never fires and the job completes green.
+//
+// The staging dir is empty here, which is what the walk saw when VSS had
+// rewritten the staging path onto a shadow-device path that predated the
+// snapshot. The manifest still claims two artifacts. That combination must not
+// produce an unqualified success: the operator has to be told, and the manifest
+// must stop advertising artifacts the restore point does not contain — it is
+// persisted server-side and drives the bare-metal recovery paths.
+func TestRunBackup_SystemStateManifestWithoutArtifactsWarnsAndDropsArtifacts(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "doc.txt", "user data that backed up fine")
+
+	// Collection reports artifacts, but nothing of theirs is on disk to walk.
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return &systemstate.SystemStateManifest{
+			Platform:  "test",
+			Artifacts: []systemstate.Artifact{{Name: "registry"}, {Name: "boot"}},
+		}, t.TempDir(), nil
+	})
+
+	mgr := NewBackupManager(BackupConfig{
+		Provider:           newMockProvider(),
+		Paths:              []string{file1},
+		SystemStateEnabled: true,
+	})
+	job, err := mgr.RunBackup()
+	if err != nil {
+		t.Fatalf("the file-path portion is still valid, so the run should complete: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("status = %q, want completed", job.Status)
+	}
+	if !strings.Contains(job.Warning, "system state artifacts were not captured") {
+		t.Errorf("job completed with no warning about the missing system state; warning = %q", job.Warning)
+	}
+	if job.SystemStateManifest == nil {
+		t.Fatal("the manifest should be retained (platform/hardware profile are still accurate), not dropped wholesale")
+	}
+	if len(job.SystemStateManifest.Artifacts) != 0 {
+		t.Errorf("manifest still advertises %d artifacts that never reached the snapshot",
+			len(job.SystemStateManifest.Artifacts))
+	}
+	if job.SystemStateManifest.Platform != "test" {
+		t.Errorf("platform = %q, want the collector's value retained", job.SystemStateManifest.Platform)
+	}
+}
+
+// A healthy run must not trip the detector — otherwise the warning fires on
+// every system_image backup and operators learn to ignore it.
+func TestRunBackup_SystemStateCapturedProducesNoWarning(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "doc.txt", "user data")
+
+	stagingDir := t.TempDir()
+	if err := os.WriteFile(pathpkg.Join(stagingDir, "registry.dat"), []byte("hive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return &systemstate.SystemStateManifest{
+			Platform:  "test",
+			Artifacts: []systemstate.Artifact{{Name: "registry"}},
+		}, stagingDir, nil
+	})
+
+	mgr := NewBackupManager(BackupConfig{
+		Provider:           newMockProvider(),
+		Paths:              []string{file1},
+		SystemStateEnabled: true,
+	})
+	job, err := mgr.RunBackup()
+	if err != nil {
+		t.Fatalf("RunBackup failed: %v", err)
+	}
+	if job.Warning != "" {
+		t.Errorf("healthy system-state run produced warning %q, want none", job.Warning)
+	}
+	if len(job.SystemStateManifest.Artifacts) != 1 {
+		t.Errorf("a captured artifact list must be left intact, got %d", len(job.SystemStateManifest.Artifacts))
+	}
+}
+
+// TestRunBackup_SystemStateCollectionFailureWarnsOnMixedRun covers the sibling
+// route to the same silent outcome: collection fails outright on a run that has
+// configured file paths. systemStateErr only fails the run when there is
+// nothing else to fall back on, so without an explicit warning this completes
+// green with no system state and no signal. CollectSystemState errors only when
+// a REQUIRED class failed, i.e. the capture would not boot at restore time.
+func TestRunBackup_SystemStateCollectionFailureWarnsOnMixedRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := createTempFile(t, tmpDir, "doc.txt", "user data that backed up fine")
+
+	stubCollectSystemState(t, func() (*systemstate.SystemStateManifest, string, error) {
+		return nil, "", fmt.Errorf("registry hive export failed")
+	})
+
+	mgr := NewBackupManager(BackupConfig{
+		Provider:           newMockProvider(),
+		Paths:              []string{file1},
+		SystemStateEnabled: true,
+	})
+	job, err := mgr.RunBackup()
+	if err != nil {
+		t.Fatalf("the file-path portion is still valid, so the run should complete: %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Fatalf("status = %q, want completed", job.Status)
+	}
+	if !strings.Contains(job.Warning, "system state was not collected") {
+		t.Errorf("a failed collection on a mixed run must be surfaced; warning = %q", job.Warning)
+	}
+	if !strings.Contains(job.Warning, "registry hive export failed") {
+		t.Errorf("the warning should carry the collector's reason; warning = %q", job.Warning)
+	}
+}
+
 func TestRunBackup_MultiplePaths(t *testing.T) {
 	tmpDir := t.TempDir()
 	dir1 := pathpkg.Join(tmpDir, "dir1")

--- a/agent/internal/backup/incremental.go
+++ b/agent/internal/backup/incremental.go
@@ -190,6 +190,7 @@ func isUnderDir(p, dir string) bool {
 // (e.g. a test double that reuses a fixed staging path across simulated
 // runs) and gives readers/reviewers a single obvious place the "never
 // referenced" rule lives, matching the design doc's explicit callout.
+//
 // Returns the number of files marked, so the caller can detect a manifest that
 // describes artifacts no collected file was matched to — see
 // systemStateArtifactsMissing.
@@ -214,10 +215,11 @@ func markSystemStateFiles(files []backupFile, stagingDir string) int {
 // The manifest is written from the collector's own return value, so it says
 // nothing about whether the artifacts reached the snapshot. #3026 was one route
 // to that divergence (the staging dir rewritten onto a VSS shadow path that
-// predates it); the walk failing, the staging dir being cleaned early, or a
-// user exclude pattern matching artifact names are others. Each one produces a
-// green job whose restore point is missing the system state it claims. Rather
-// than guard only the route that was fixed, make the outcome itself loud.
+// predates it); the walk failing on the staging root, or a user exclude pattern
+// matching artifact names, are others. On a run that also has configured file
+// paths each one produces a green job whose restore point is missing the system
+// state it claims. Rather than guard only the route that was fixed, make the
+// outcome itself loud.
 //
 // A manifest with no artifacts is not a divergence — there is nothing to match
 // — so it is excluded rather than reported on every such run.

--- a/agent/internal/backup/incremental.go
+++ b/agent/internal/backup/incremental.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/breeze-rmm/agent/internal/backup/providers"
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
 // referenceDecision classifies one walked file against the previous
@@ -189,13 +190,37 @@ func isUnderDir(p, dir string) bool {
 // (e.g. a test double that reuses a fixed staging path across simulated
 // runs) and gives readers/reviewers a single obvious place the "never
 // referenced" rule lives, matching the design doc's explicit callout.
-func markSystemStateFiles(files []backupFile, stagingDir string) {
+// Returns the number of files marked, so the caller can detect a manifest that
+// describes artifacts no collected file was matched to — see
+// systemStateArtifactsMissing.
+func markSystemStateFiles(files []backupFile, stagingDir string) int {
 	if stagingDir == "" {
-		return
+		return 0
 	}
+	marked := 0
 	for i := range files {
 		if isUnderDir(files[i].sourcePath, stagingDir) {
 			files[i].systemState = true
+			marked++
 		}
 	}
+	return marked
+}
+
+// systemStateArtifactsMissing reports the #3026 failure signature: the run
+// recorded a manifest describing system-state artifacts, but not one collected
+// file was matched to the staging directory those artifacts were written to.
+//
+// The manifest is written from the collector's own return value, so it says
+// nothing about whether the artifacts reached the snapshot. #3026 was one route
+// to that divergence (the staging dir rewritten onto a VSS shadow path that
+// predates it); the walk failing, the staging dir being cleaned early, or a
+// user exclude pattern matching artifact names are others. Each one produces a
+// green job whose restore point is missing the system state it claims. Rather
+// than guard only the route that was fixed, make the outcome itself loud.
+//
+// A manifest with no artifacts is not a divergence — there is nothing to match
+// — so it is excluded rather than reported on every such run.
+func systemStateArtifactsMissing(manifest *systemstate.SystemStateManifest, markedFiles int) bool {
+	return manifest != nil && len(manifest.Artifacts) > 0 && markedFiles == 0
 }

--- a/agent/internal/backup/incremental.go
+++ b/agent/internal/backup/incremental.go
@@ -170,10 +170,14 @@ func isUnderDir(p, dir string) bool {
 
 // markSystemStateFiles flags every file in files whose sourcePath falls
 // under stagingDir (the run's system-state staging root — see
-// collectSystemState's call site in RunBackupContext, and note it may have
-// been VSS-rewritten by the time it's passed here; pass whichever value was
-// ACTUALLY walked) as backupFile.systemState = true, so decideFile always
-// uploads them.
+// collectSystemState's call site in RunBackupContext) as
+// backupFile.systemState = true, so decideFile always uploads them.
+//
+// stagingDir is always the live path collectSystemState returned, never a VSS
+// shadow-device path: rewritePathsForVSS deliberately skips the staging index
+// because the dir is created after the snapshot is taken (#3026). That is what
+// keeps this prefix comparable to the sourcePaths collectBackupFilesFromPaths
+// actually produced.
 //
 // This exclusion is defense-in-depth, not strictly load-bearing for
 // correctness in production: CollectSystemState creates a fresh

--- a/agent/internal/backup/incremental_test.go
+++ b/agent/internal/backup/incremental_test.go
@@ -6,6 +6,8 @@ import (
 	pathpkg "path/filepath"
 	"testing"
 	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup/systemstate"
 )
 
 // TestDecideFile is the decision-table unit test: table-driven coverage of
@@ -259,7 +261,10 @@ func TestMarkSystemStateFiles(t *testing.T) {
 		{sourcePath: stagingDir + "-not-actually-inside" + string(pathpkg.Separator) + "f.txt"},
 	}
 
-	markSystemStateFiles(files, stagingDir)
+	if marked := markSystemStateFiles(files, stagingDir); marked != 2 {
+		t.Errorf("markSystemStateFiles marked %d files, want 2 — the count is what "+
+			"systemStateArtifactsMissing uses to detect an uncaptured manifest", marked)
+	}
 
 	if !files[0].systemState {
 		t.Error("file directly under stagingDir should be marked systemState")
@@ -279,8 +284,72 @@ func TestMarkSystemStateFiles(t *testing.T) {
 // system-state collection this run) leaves every file untouched.
 func TestMarkSystemStateFiles_EmptyStagingDirNoOp(t *testing.T) {
 	files := []backupFile{{sourcePath: "/data/a.txt"}}
-	markSystemStateFiles(files, "")
+	if marked := markSystemStateFiles(files, ""); marked != 0 {
+		t.Errorf("markSystemStateFiles with an empty stagingDir marked %d files, want 0", marked)
+	}
 	if files[0].systemState {
 		t.Error("markSystemStateFiles with an empty stagingDir must not mark anything")
+	}
+}
+
+// TestSystemStateArtifactsMissing is the backstop for #3026's SYMPTOM rather
+// than its cause: a job that reports success while the restore point is missing
+// the system state its manifest advertises. #3026 was one route there; the
+// detector has to fire for any of them, and stay silent otherwise.
+func TestSystemStateArtifactsMissing(t *testing.T) {
+	withArtifacts := &systemstate.SystemStateManifest{
+		Artifacts: []systemstate.Artifact{{Name: "registry"}, {Name: "boot"}},
+	}
+
+	tests := []struct {
+		name        string
+		manifest    *systemstate.SystemStateManifest
+		markedFiles int
+		want        bool
+	}{
+		{
+			// The #3026 signature: manifest recorded, staging walk produced
+			// nothing that matched it.
+			name:        "manifest with artifacts but nothing captured is reported",
+			manifest:    withArtifacts,
+			markedFiles: 0,
+			want:        true,
+		},
+		{
+			name:        "manifest with artifacts and files captured is healthy",
+			manifest:    withArtifacts,
+			markedFiles: 2,
+			want:        false,
+		},
+		{
+			// Partial capture is a different problem and deliberately out of
+			// scope here — this detector only claims "none at all".
+			name:        "a single captured file is enough to clear the check",
+			manifest:    withArtifacts,
+			markedFiles: 1,
+			want:        false,
+		},
+		{
+			name:        "no system state collected this run is not a divergence",
+			manifest:    nil,
+			markedFiles: 0,
+			want:        false,
+		},
+		{
+			// Nothing to match, so reporting would fire on every such run and
+			// train operators to ignore the warning.
+			name:        "a manifest describing no artifacts is not a divergence",
+			manifest:    &systemstate.SystemStateManifest{},
+			markedFiles: 0,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := systemStateArtifactsMissing(tt.manifest, tt.markedFiles); got != tt.want {
+				t.Errorf("systemStateArtifactsMissing = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/agent/internal/backup/vss_shadow_path_windows_test.go
+++ b/agent/internal/backup/vss_shadow_path_windows_test.go
@@ -224,9 +224,12 @@ func TestRewritePathsForVSS_ReportsUnmappedPathsRatherThanFailingSilently(t *tes
 // before the fix the rewrite happily mapped the staging dir onto
 // \\?\GLOBALROOT\...\Windows\Temp\breeze-systemstate-XXXX — a path that is not
 // in the snapshot. The walk then found nothing, the stat failure was folded
-// into the aggregate "backup file scan completed with errors" warning, and the
-// job still reported success with SystemStateManifest set. Silent data loss in
-// the DEFAULT configuration.
+// into the aggregate "backup file scan completed with errors" warning, and a
+// run that also had configured file paths still reported success with
+// SystemStateManifest set. (A system-state-only run fails on the len(files)==0
+// guard instead.) Reachable whenever VSS and system-state collection are both
+// enabled for the same run; server-dispatched system_image runs default VSS
+// off, so it is opt-in rather than universal.
 //
 // The index is therefore excluded from the rewrite itself, not merely from the
 // operator warning: the path must keep pointing at the live volume, which is
@@ -360,8 +363,9 @@ func TestRewritePathsForVSS_StagingDirIsNotWarnedAsALiveRead(t *testing.T) {
 	}
 }
 
-// reportableLiveReads is the only new decision this change makes: which
-// unmapped paths an operator actually hears about. The caller that uses it
+// reportableLiveReads decides which unmapped paths an operator actually hears
+// about — the new decision #3025 introduced, alongside the rewrite-side
+// exclusion #3026 added above. The caller that uses it
 // needs an elevated Windows box and a real VSS provider to reach, so this is
 // the level at which that logic can be tested at all. Windows-gated because
 // isLocalVolumePath rests on filepath.VolumeName, which is "" for everything

--- a/agent/internal/backup/vss_shadow_path_windows_test.go
+++ b/agent/internal/backup/vss_shadow_path_windows_test.go
@@ -262,6 +262,17 @@ func TestRewritePathsForVSS_LeavesSystemStateStagingDirUnrewritten(t *testing.T)
 			wantUnmap:   []int{1},
 		},
 		{
+			// A system-state-only run (SystemStateEnabled, no configured
+			// paths) puts the staging dir at index 0, so 0 must be a real
+			// index here and never a second sentinel.
+			name:        "staging dir at index 0 is excluded like any other",
+			paths:       []string{staging},
+			shadowPaths: map[string]string{"C:": shadowRoot},
+			stagingIdx:  0,
+			want:        []string{staging},
+			wantUnmap:   []int{0},
+		},
+		{
 			name:        "no staging dir this run leaves every path eligible for rewrite",
 			paths:       []string{`C:\Users\data`, `C:\Logs`},
 			shadowPaths: map[string]string{"C:": shadowRoot},
@@ -283,6 +294,9 @@ func TestRewritePathsForVSS_LeavesSystemStateStagingDirUnrewritten(t *testing.T)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, unmapped := rewritePathsForVSS(tt.paths, tt.shadowPaths, tt.stagingIdx)
+			if len(got) != len(tt.want) {
+				t.Fatalf("rewritePathsForVSS returned %d paths, want %d", len(got), len(tt.want))
+			}
 			for i := range tt.want {
 				if got[i] != tt.want[i] {
 					t.Errorf("path %d = %q, want %q", i, got[i], tt.want[i])

--- a/agent/internal/backup/vss_shadow_path_windows_test.go
+++ b/agent/internal/backup/vss_shadow_path_windows_test.go
@@ -89,7 +89,7 @@ func TestRewritePathsForVSS_RoutesPathsThroughShadowRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := rewritePathsForVSS([]string{tt.in}, shadowPaths)
+			got, _ := rewritePathsForVSS([]string{tt.in}, shadowPaths, noStagingIdx)
 			if got[0] != tt.want {
 				t.Errorf("rewritePathsForVSS(%q) = %q, want %q", tt.in, got[0], tt.want)
 			}
@@ -129,7 +129,7 @@ func TestRewritePathsForVSS_KeyFormatMatchesExtractVolumes(t *testing.T) {
 		shadowPaths[vol] = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy` + strconv.Itoa(i+1)
 	}
 
-	rewritten, unmapped := rewritePathsForVSS(paths, shadowPaths)
+	rewritten, unmapped := rewritePathsForVSS(paths, shadowPaths, noStagingIdx)
 	if len(unmapped) != 0 {
 		t.Fatalf("every path should route through a shadow copy, but %d fell back to the live volume: %v",
 			len(unmapped), unmapped)
@@ -150,7 +150,7 @@ func TestRewritePathsForVSS_KeyFormatMatchesExtractVolumes(t *testing.T) {
 func TestRewritePathsForVSS_MountPointKeyedShadowMapIsReportedUnmapped(t *testing.T) {
 	shadowPaths := map[string]string{`C:\`: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`}
 
-	rewritten, unmapped := rewritePathsForVSS([]string{`C:\Users\data`}, shadowPaths)
+	rewritten, unmapped := rewritePathsForVSS([]string{`C:\Users\data`}, shadowPaths, noStagingIdx)
 
 	if len(unmapped) != 1 || unmapped[0] != 0 {
 		t.Fatalf("a mount-point-keyed shadow map must leave the path unmapped and reported, got unmapped=%v", unmapped)
@@ -170,7 +170,7 @@ func TestRewritePathsForVSS_RoundTripsThroughOriginalPathsForVSS(t *testing.T) {
 	shadowPaths := map[string]string{"C:": shadowRoot}
 	originals := []string{`C:\Users\data\f.txt`, `C:\`, `C:`}
 
-	rewritten, unmapped := rewritePathsForVSS(originals, shadowPaths)
+	rewritten, unmapped := rewritePathsForVSS(originals, shadowPaths, noStagingIdx)
 	if len(unmapped) != 0 {
 		t.Fatalf("unmapped = %v, want none", unmapped)
 	}
@@ -196,7 +196,7 @@ func TestRewritePathsForVSS_ReportsUnmappedPathsRatherThanFailingSilently(t *tes
 	shadowPaths := map[string]string{"C:": `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`}
 	paths := []string{`C:\shadowed`, `D:\live`, `E:\also-live`}
 
-	rewritten, unmapped := rewritePathsForVSS(paths, shadowPaths)
+	rewritten, unmapped := rewritePathsForVSS(paths, shadowPaths, noStagingIdx)
 
 	if len(unmapped) != 2 {
 		t.Fatalf("unmapped = %v, want the two unshadowed volumes reported", unmapped)
@@ -216,6 +216,136 @@ func TestRewritePathsForVSS_ReportsUnmappedPathsRatherThanFailingSilently(t *tes
 	}
 }
 
+// TestRewritePathsForVSS_LeavesSystemStateStagingDirUnrewritten pins #3026.
+//
+// The staging dir is created by collectSystemState AFTER CreateShadowCopy has
+// already taken the point-in-time image, so it cannot exist inside the
+// snapshot. %TEMP% normally sits on C:, normally a shadowed backup volume, so
+// before the fix the rewrite happily mapped the staging dir onto
+// \\?\GLOBALROOT\...\Windows\Temp\breeze-systemstate-XXXX — a path that is not
+// in the snapshot. The walk then found nothing, the stat failure was folded
+// into the aggregate "backup file scan completed with errors" warning, and the
+// job still reported success with SystemStateManifest set. Silent data loss in
+// the DEFAULT configuration.
+//
+// The index is therefore excluded from the rewrite itself, not merely from the
+// operator warning: the path must keep pointing at the live volume, which is
+// the only place those artifacts exist.
+func TestRewritePathsForVSS_LeavesSystemStateStagingDirUnrewritten(t *testing.T) {
+	const shadowRoot = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`
+	const staging = `C:\Windows\Temp\breeze-systemstate-1234`
+
+	tests := []struct {
+		name        string
+		paths       []string
+		shadowPaths map[string]string
+		stagingIdx  int
+		want        []string
+		wantUnmap   []int
+	}{
+		{
+			// The bug: staging on the SAME volume the snapshot covers.
+			name:        "staging dir on a shadowed volume stays live while user paths are rewritten",
+			paths:       []string{`C:\Users\data`, staging},
+			shadowPaths: map[string]string{"C:": shadowRoot},
+			stagingIdx:  1,
+			want:        []string{shadowRoot + `\Users\data`, staging},
+			wantUnmap:   []int{1},
+		},
+		{
+			// Already correct before the fix, and must stay that way.
+			name:        "staging dir on an unshadowed volume stays live",
+			paths:       []string{`C:\Users\data`, `D:\Temp\breeze-systemstate-1234`},
+			shadowPaths: map[string]string{"C:": shadowRoot},
+			stagingIdx:  1,
+			want:        []string{shadowRoot + `\Users\data`, `D:\Temp\breeze-systemstate-1234`},
+			wantUnmap:   []int{1},
+		},
+		{
+			name:        "no staging dir this run leaves every path eligible for rewrite",
+			paths:       []string{`C:\Users\data`, `C:\Logs`},
+			shadowPaths: map[string]string{"C:": shadowRoot},
+			stagingIdx:  noStagingIdx,
+			want:        []string{shadowRoot + `\Users\data`, shadowRoot + `\Logs`},
+			wantUnmap:   nil,
+		},
+		{
+			// Defensive: a stale index must not silently skip a real user path.
+			name:        "an out-of-range staging index excludes nothing",
+			paths:       []string{`C:\Users\data`},
+			shadowPaths: map[string]string{"C:": shadowRoot},
+			stagingIdx:  7,
+			want:        []string{shadowRoot + `\Users\data`},
+			wantUnmap:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, unmapped := rewritePathsForVSS(tt.paths, tt.shadowPaths, tt.stagingIdx)
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("path %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+			if len(unmapped) != len(tt.wantUnmap) {
+				t.Fatalf("unmapped = %v, want %v", unmapped, tt.wantUnmap)
+			}
+			for i := range unmapped {
+				if unmapped[i] != tt.wantUnmap[i] {
+					t.Errorf("unmapped = %v, want %v", unmapped, tt.wantUnmap)
+				}
+			}
+		})
+	}
+}
+
+// TestRewritePathsForVSS_StagingDirStaysMatchableByMarkSystemStateFiles encodes
+// the downstream symptom of #3026 rather than only the rewrite itself.
+//
+// RunBackupContext passes the walked staging root to markSystemStateFiles,
+// which prefix-matches it against each collected file's sourcePath. Files under
+// the staging dir only ever exist on the live volume, so a shadow-rewritten
+// root matched zero of them — SystemStateManifest was set on a snapshot that
+// carried none of the artifacts it described. Leaving the index unrewritten is
+// what keeps the two ends of that comparison on the same volume.
+func TestRewritePathsForVSS_StagingDirStaysMatchableByMarkSystemStateFiles(t *testing.T) {
+	const shadowRoot = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`
+	const staging = `C:\Windows\Temp\breeze-systemstate-1234`
+	shadowPaths := map[string]string{"C:": shadowRoot}
+
+	rewritten, _ := rewritePathsForVSS([]string{`C:\Users\data`, staging}, shadowPaths, 1)
+	walkedStagingRoot := rewritten[1]
+
+	// The artifact as it exists on disk — collectSystemState wrote it to the
+	// live volume moments ago, after the snapshot was already taken.
+	files := []backupFile{{sourcePath: filepath.Join(staging, "registry", "SOFTWARE.hiv")}}
+	markSystemStateFiles(files, walkedStagingRoot)
+
+	if !files[0].systemState {
+		t.Fatalf("system-state artifact %q was not matched against walked staging root %q — "+
+			"the manifest would be recorded with the artifacts missing (#3026)",
+			files[0].sourcePath, walkedStagingRoot)
+	}
+}
+
+// The exclusion must not trade silent data loss for a warning that fires on
+// every system_image backup. The staging dir is genuinely a live read, so
+// rewritePathsForVSS reports it as unmapped; reportableLiveReads is the layer
+// that knows the agent wrote it itself and drops it from the operator-facing
+// message. This pins that the two compose.
+func TestRewritePathsForVSS_StagingDirIsNotWarnedAsALiveRead(t *testing.T) {
+	const shadowRoot = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`
+	shadowPaths := map[string]string{"C:": shadowRoot}
+	paths := []string{`C:\Users\data`, `C:\Windows\Temp\breeze-systemstate-1234`}
+
+	rewritten, unmapped := rewritePathsForVSS(paths, shadowPaths, 1)
+
+	if got := reportableLiveReads(rewritten, unmapped, 1); len(got) != 0 {
+		t.Errorf("reportableLiveReads = %v, want nothing — the staging dir is an expected live read", got)
+	}
+}
+
 // reportableLiveReads is the only new decision this change makes: which
 // unmapped paths an operator actually hears about. The caller that uses it
 // needs an elevated Windows box and a real VSS provider to reach, so this is
@@ -223,7 +353,7 @@ func TestRewritePathsForVSS_ReportsUnmappedPathsRatherThanFailingSilently(t *tes
 // isLocalVolumePath rests on filepath.VolumeName, which is "" for everything
 // off-Windows — a portable version would assert nothing.
 func TestReportableLiveReads_Selection(t *testing.T) {
-	const noStaging = -1
+	const noStaging = noStagingIdx
 
 	tests := []struct {
 		name       string
@@ -383,7 +513,7 @@ func TestLive_RewrittenShadowPathReadsExclusivelyLockedFile(t *testing.T) {
 	defer p.ReleaseShadowCopy(session) //nolint:errcheck
 
 	// The production rewrite — not a hand-rolled copy of it.
-	rewritten, unmapped := rewritePathsForVSS([]string{target}, session.ShadowPaths)
+	rewritten, unmapped := rewritePathsForVSS([]string{target}, session.ShadowPaths, noStagingIdx)
 	if len(unmapped) != 0 {
 		t.Fatalf("the backup path fell back to the live volume despite an active shadow copy "+
 			"(ShadowPaths=%v) — this is the silent #2999 failure mode", session.ShadowPaths)


### PR DESCRIPTION
## The bug

`RunBackupContext` creates the VSS shadow copy **before** `collectSystemState`
creates its `os.MkdirTemp` staging dir, then appended that dir to `backupPaths`
and let `rewritePathsForVSS` map it onto a shadow-device path.

A shadow copy is a point-in-time image, so a directory created after it was
taken cannot be inside it. `%TEMP%` normally sits on `C:`, so when `C:` is a
shadowed backup volume the rewrite pointed the walk at
`\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopyN\Windows\Temp\breeze-systemstate-XXXX`
— a path absent from the snapshot.

Every downstream signal then swallowed it: the walk found nothing and the stat
failure folded into the aggregate `"backup file scan completed with errors"`
warning; `markSystemStateFiles` matched zero files; `job.SystemStateManifest`
was still set. The job reported **success** with the system-state artifacts
absent from the restore point.

**Correction to the issue's Impact section**, verified against
`defaultVSS` in `agent/cmd/breeze-backup/exec_backup.go`
(`goos == "windows" && !systemImage`): this is **not** the default
configuration. Server-dispatched `system_image` runs default VSS *off*. The bug
needs VSS and system-state collection enabled for the same run — an `agent.yaml`
with both `backup_vss_enabled` and `backup_system_state_enabled`, or a
`system_image` run with an explicit `vss` override. Opt-in, not universal.
Likewise the green-job outcome requires configured file paths: a
system-state-*only* run trips the pre-existing `len(files)==0` hard-failure
guard and fails loudly instead. The comments in the fix say this; the issue body
does not.

## The fix

**1. Exclude the staging index from the rewrite itself**, not merely from
reporting — the suggestion in the issue, and it holds up.
`rewritePathsForVSS` now takes `stagingIdx` (`noStagingIdx` when the run has
none) and leaves that path on the live volume, the only place those artifacts
exist. It still reports the index as unmapped, because "read from the live
volume" is factually what happens — which keeps `reportableLiveReads` (#3025)
meaningful rather than dead: that is the layer that knows the agent wrote the
dir itself and drops it from the operator warning. The fix does not trade
silent data loss for a warning on every `system_image` run.

Two follow-on simplifications, verified rather than assumed:

- The post-rewrite path-recovery block is **deleted**. With the staging path
  never rewritten it could only reproduce what `collectSystemState` returned,
  so `systemStateStagingDir` is assigned there directly.
- `markSystemStateFiles`' doc told callers to "pass whichever value was ACTUALLY
  walked" because of the possible rewrite. That is now wrong; replaced with the
  invariant that makes the prefix comparison valid.

**2. Make the outcome loud, not just this route.** The manifest is written from
the collector's return value and says nothing about whether artifacts reached
the snapshot. `systemStateArtifactsMissing` reports the divergence — a manifest
describing artifacts where zero collected files matched the staging dir — and
the run warns instead of completing clean.

**3. Stop shipping a manifest for artifacts that never landed.** This is the
part a warning alone does not cover, and it came out of review. Unlike
`job.VSSMetadata` (genuinely stripped at parse), `SystemStateManifest` survives:
`resultSchemas.ts:78` accepts it, `backupResultPersistence.ts:669` writes it to
`backup_snapshots.system_state_manifest`, and `bmr.ts` / `recoveryBootstrap.ts`
serve it to the bare-metal recovery paths. Left intact it advertises a complete
system state on a restore point holding none of it. On detection the artifact
list is cleared; platform, OS version and hardware profile are retained (inline
collector output, still accurate — and `hardwareProfile` is persisted *from* the
manifest, so dropping it wholesale would discard good data).

**4. Close the sibling silent route.** `collectSystemState` failing outright
only fails the run via the `len(files)==0` branch, so a run that also has
configured file paths completed **green with no system state and no signal**. It
now appends a warning carrying the collector's reason. `CollectSystemState`
errors only when a *required* class failed, i.e. the capture would not boot at
restore time.

**5.** The `IncompleteSteps` branch wrote `job.Warning` by raw assignment — safe
while it was the only writer, now one of four. Moved to `appendWarning` before
it silently discards one of the others.

## Tests

**Windows-gated** (`filepath.VolumeName` returns `""` off Windows, so a portable
version of these would pass vacuously):

- `TestRewritePathsForVSS_LeavesSystemStateStagingDirUnrewritten` — the
  regression, table-driven: staging on a **shadowed** volume stays live while
  user paths are rewritten (the bug); on an unshadowed volume stays live;
  `noStagingIdx` leaves everything eligible; index **0** is a real index and
  never a second sentinel (the system-state-only run puts staging there); an
  out-of-range index excludes nothing.
- `TestRewritePathsForVSS_StagingDirStaysMatchableByMarkSystemStateFiles` —
  the downstream symptom, not the mechanism: composes the production rewrite
  with the production `markSystemStateFiles`. A shadow-rewritten root matches
  zero artifacts, which is how the manifest got recorded describing artifacts
  the snapshot did not contain.
- `TestRewritePathsForVSS_StagingDirIsNotWarnedAsALiveRead` — the exclusion and
  `reportableLiveReads` compose, so no per-run operator noise.

**Portable**, driving `RunBackupContext` through the `collectSystemState` seam:

- `TestRunBackup_SystemStateManifestWithoutArtifactsWarnsAndDropsArtifacts` —
  manifest claiming artifacts + empty staging dir on a run with file paths:
  completes, warns, clears the artifact list, retains platform.
- `TestRunBackup_SystemStateCapturedProducesNoWarning` — a healthy capture warns
  not at all and keeps its artifacts.
- `TestRunBackup_SystemStateCollectionFailureWarnsOnMixedRun` — a failed
  collection alongside file paths surfaces the collector's reason.
- `TestSystemStateArtifactsMissing` — the detector's threshold, including the
  deliberate exclusions (nil manifest, zero-artifact manifest).
- `markSystemStateFiles`' new count return is asserted in both existing tests.

The five pre-existing `rewritePathsForVSS` call sites take the new
`noStagingIdx` argument; no existing assertions changed.

**CI:** all three Windows-gated names start with `TestRewritePathsForVSS`, so the
existing `-run` regex already selects them; the exact top-level PASS count is
bumped `11` → `14`. The portable tests match no alternative in that filter, so
the count is unaffected by them.

## Verification

- **Windows CI executed the new tests** — `Test Agent (Windows)` green, and the
  `-run` step's exact-count guard passed at 14. All three new tests and every
  subtest show `--- PASS` in the runner log, including
  `staging_dir_on_a_shadowed_volume_stays_live_while_user_paths_are_rewritten`.
- `go test -race ./internal/backup/...` green on darwin (all 7 packages).
- `GOOS=windows go vet` + `go test -c` clean. (Three `possible misuse of
  unsafe.Pointer` notices are pre-existing in `internal/backup/vss/vss_windows.go`,
  untouched here.) `gofmt` clean.
- The 7 pre-existing Windows failures in this package (#2523 — `TestContract*`,
  `TestCollectBackupFiles_CapturesMode`, `TestCreateSnapshot_*`,
  `TestRestoreFromSnapshot_*`) are **unchanged**: none exercises
  `rewritePathsForVSS`, `markSystemStateFiles` or the system-state path, and
  none is selected by the Windows `-run` filter, so this PR adds no new Windows
  reds.

## Deliberately not in this PR

Raised in review, declined with reasons — worth separate issues:

- **Partial system-state capture is still silent.** The detector's threshold is
  "none at all". A per-artifact presence check (intersecting
  `Artifact.Path` against the marked set) would catch an exclude pattern eating
  *some* artifacts, but the path-format assumptions make a false positive — a
  warning on every healthy run — the likely failure mode. Wants its own change.
- **Total VSS failure is quieter than partial VSS failure.** `CreateShadowCopy`
  failing logs only and skips the whole live-read warning block, so a run where
  *every* volume read live says less than one where a single volume did. That is
  the #2999/#3025 lineage, not this one.
- **`lastResortStdout`** (`cmd/breeze-backup/result_bounds.go`) *replaces* rather
  than appends to `warning` at tier 4, destroying these signals on the largest
  runs. Pre-existing (#3001).

Closes #3026

🤖 Generated with [Claude Code](https://claude.com/claude-code)
