### PR TITLE
fix(backup): deliver VSS health to the server end to end (#3027)

### DIFF
--- a/agent/cmd/breeze-backup/backup_run_result_test.go
+++ b/agent/cmd/breeze-backup/backup_run_result_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/backup"
+	"github.com/breeze-rmm/agent/internal/backup/vss"
+)
+
+// #3027: the generic marshalResult discards the job body whenever err != nil, so
+// every hard-failed backup reached the server as Stderr and nothing else. That
+// is the branch where VSS diagnostics matter MOST — "which writer wedged" is the
+// question you ask about a failure — and job.VSSMetadata plus job.Warning were
+// both already populated and both thrown away one frame before the wire.
+func TestMarshalBackupRunResultKeepsDiagnosticsOnFailure(t *testing.T) {
+	job := &backup.BackupJob{
+		ID:            "job-1",
+		Status:        "failed",
+		FilesBackedUp: 12,
+		ErrorCount:    3,
+		Warning:       "VSS shadow copy could not be created",
+		VSSMetadata: &vss.VSSMetadata{
+			ShadowCopyID:       "{set-1}",
+			UnprotectedVolumes: []string{`D:\`},
+			Writers:            []vss.WriterStatus{{Name: "NTDS", State: "failed"}},
+		},
+	}
+
+	result := marshalBackupRunResult(job, errors.New("upload destination unreachable"))
+
+	// The run still fails — the body only adds detail.
+	if result.Success {
+		t.Fatal("a failed run must not be reported as successful")
+	}
+	if !strings.Contains(result.Stderr, "upload destination unreachable") {
+		t.Fatalf("failure reason lost from stderr: %q", result.Stderr)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(result.Stdout), &decoded); err != nil {
+		t.Fatalf("failed run must carry a parseable job body, got %q: %v", result.Stdout, err)
+	}
+	if decoded["vssMetadata"] == nil {
+		t.Errorf("vssMetadata missing from a failed run's body: %s", result.Stdout)
+	}
+	if decoded["warning"] != "VSS shadow copy could not be created" {
+		t.Errorf("warning missing from a failed run's body: %s", result.Stdout)
+	}
+	// The partial counters ride the same body and were lost with it.
+	if decoded["errorCount"] != float64(3) {
+		t.Errorf("errorCount missing from a failed run's body: %s", result.Stdout)
+	}
+}
+
+// A nil job (the early returns before the job exists — no provider, no paths,
+// already running) must still deliver the reason rather than an empty body.
+func TestMarshalBackupRunResultWithNoJob(t *testing.T) {
+	result := marshalBackupRunResult(nil, errors.New("backup provider is required"))
+
+	if result.Success {
+		t.Fatal("expected failure")
+	}
+	if result.Stdout != "" {
+		t.Errorf("expected no body when there is no job, got %q", result.Stdout)
+	}
+	if !strings.Contains(result.Stderr, "backup provider is required") {
+		t.Errorf("failure reason lost: %q", result.Stderr)
+	}
+}
+
+func TestMarshalBackupRunResultSuccessIsUnchanged(t *testing.T) {
+	job := &backup.BackupJob{ID: "job-ok", Status: "completed", FilesBackedUp: 4}
+
+	result := marshalBackupRunResult(job, nil)
+
+	if !result.Success {
+		t.Fatal("a clean run must report success")
+	}
+	if result.Stderr != "" {
+		t.Errorf("success must not carry stderr, got %q", result.Stderr)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(result.Stdout), &decoded); err != nil {
+		t.Fatalf("success body must parse, got %q: %v", result.Stdout, err)
+	}
+	if decoded["filesBackedUp"] != float64(4) {
+		t.Errorf("success body lost its counters: %s", result.Stdout)
+	}
+}

--- a/agent/cmd/breeze-backup/main.go
+++ b/agent/cmd/breeze-backup/main.go
@@ -620,7 +620,7 @@ func executeCommand(req backupipc.BackupCommandRequest, mgr *backup.BackupManage
 				SnapshotID: snapshotID,
 			})
 		})
-		result := marshalResult(mgr.RunBackupContext(ctx, excludes))
+		result := marshalBackupRunResult(mgr.RunBackupContext(ctx, excludes))
 		// Auto-sync to vault after successful backup (async — don't block command response)
 		if result.Success {
 			go autoSyncToVault(result.Stdout, vaultState, conn)
@@ -708,6 +708,37 @@ func ok(stdout string) backupipc.BackupCommandResult {
 
 func fail(msg string) backupipc.BackupCommandResult {
 	return backupipc.BackupCommandResult{Success: false, Stderr: msg}
+}
+
+// marshalBackupRunResult is marshalResult for backup_run specifically, differing
+// on ONE point: a failed run still carries its job body.
+//
+// The generic marshalResult throws `v` away when err != nil, so on every hard
+// failure the server received Stderr and nothing else. That silently defeated
+// #3027 on the branch where the diagnostics matter most: job.VSSMetadata and
+// job.Warning were both built by then — recording, say, that no shadow copy
+// could be created and which writers were wedged — and both were discarded one
+// frame before the wire. The counters (filesBackedUp, errorCount) went with
+// them.
+//
+// Success stays false and Stderr still carries the failure reason, so the server
+// still records the job `failed` (routes/agentWs.ts gates on
+// `result.status === 'completed'`). The body only adds detail to a failure that
+// was going to be a failure regardless. A body that cannot be marshalled is
+// simply omitted — a marshalling problem must never escalate into losing the
+// failure reason itself.
+func marshalBackupRunResult(job *backup.BackupJob, err error) backupipc.BackupCommandResult {
+	if err == nil {
+		return marshalResult(job, nil)
+	}
+	result := fail(err.Error())
+	if job == nil {
+		return result
+	}
+	if data, merr := json.Marshal(job); merr == nil {
+		result.Stdout = string(data)
+	}
+	return result
 }
 
 func marshalResult(v any, err error) backupipc.BackupCommandResult {

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -328,6 +328,15 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 				"elapsedMs", time.Since(vssStart).Milliseconds(),
 				"error", vssErr.Error(),
 			)
+			// #3027: the worst VSS outcome used to be the quietest one. When the
+			// session never starts there is no VSSMetadata to send, so without
+			// this the run reaches the server indistinguishable from a clean
+			// VSS-backed backup — every path read live, every locked file at
+			// risk of being skipped, and nothing anywhere saying so. The
+			// per-path warning further down only fires when a session DID
+			// start, so it cannot cover this branch.
+			appendWarning(job, "VSS shadow copy could not be created; every path was read from the live volume, "+
+				"where in-use files can be skipped or captured torn: "+vssErr.Error())
 		} else {
 			vssSession = session
 			job.VSSMetadata = &vss.VSSMetadata{
@@ -335,8 +344,13 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 				CreationTime: session.CreatedAt,
 				Writers:      session.Writers,
 				ExposedPaths: session.ShadowPaths,
-				Warnings:     session.Warnings,
-				DurationMs:   time.Since(vssStart).Milliseconds(),
+				// Copied, not derived: ExposedPaths lists only the volumes that
+				// succeeded, so a volume with no shadow device is indistinguishable
+				// from one that was never requested. Omitting this was how a
+				// partially-snapshotted run reached the server looking clean.
+				UnprotectedVolumes: session.UnprotectedVolumes,
+				Warnings:           session.Warnings,
+				DurationMs:         time.Since(vssStart).Milliseconds(),
 			}
 			if len(session.Warnings) > 0 {
 				log.Warn("VSS completed with warnings",
@@ -414,11 +428,16 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 				"paths", summary,
 				"shadowedVolumes", strings.Join(shadowedVolumes, ", "),
 			)
-			// The log line alone is endpoint-local. job.VSSMetadata looks like
-			// the richer channel but does not survive the trip: the API's
-			// result schema has no vssMetadata key, so it is stripped at parse,
-			// and the vss_metadata column is never written. job.Warning is the
-			// only VSS signal that reaches the server today.
+			// The log line alone is endpoint-local. Both server-visible channels
+			// are used, deliberately, because they carry different things:
+			// job.VSSMetadata (#3027) is the structured record — per-writer
+			// state, unprotected volumes, shadow paths — persisted to
+			// backup_jobs.vss_metadata for the device tab's VSS panel, while
+			// this warning is the loud, always-rendered summary that survives
+			// even when the IPC bounding drops vssMetadata as a bulk field
+			// (result_bounds.go). The warning also uniquely covers the case
+			// the VSS provider cannot see: VSS reported total success but the
+			// path never matched a shadow root, so UnprotectedVolumes is empty.
 			appendWarning(job, "read from the live volume, not the VSS shadow copy: "+summary)
 		}
 	}

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -335,23 +335,10 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			// risk of being skipped, and nothing anywhere saying so. The
 			// per-path warning further down only fires when a session DID
 			// start, so it cannot cover this branch.
-			appendWarning(job, "VSS shadow copy could not be created; every path was read from the live volume, "+
-				"where in-use files can be skipped or captured torn: "+vssErr.Error())
+			appendWarning(job, vssCreationFailureWarning(vssErr))
 		} else {
 			vssSession = session
-			job.VSSMetadata = &vss.VSSMetadata{
-				ShadowCopyID: session.ID,
-				CreationTime: session.CreatedAt,
-				Writers:      session.Writers,
-				ExposedPaths: session.ShadowPaths,
-				// Copied, not derived: ExposedPaths lists only the volumes that
-				// succeeded, so a volume with no shadow device is indistinguishable
-				// from one that was never requested. Omitting this was how a
-				// partially-snapshotted run reached the server looking clean.
-				UnprotectedVolumes: session.UnprotectedVolumes,
-				Warnings:           session.Warnings,
-				DurationMs:         time.Since(vssStart).Milliseconds(),
-			}
+			job.VSSMetadata = buildVSSMetadata(session, time.Since(vssStart).Milliseconds())
 			if len(session.Warnings) > 0 {
 				log.Warn("VSS completed with warnings",
 					"warningCount", len(session.Warnings),
@@ -390,8 +377,17 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 			// ...) — surface them as a completion warning so a degraded capture
 			// is visible without discarding an otherwise-usable backup.
 			if len(manifest.IncompleteSteps) > 0 {
-				job.Warning = fmt.Sprintf("system state collection incomplete: %v failed", manifest.IncompleteSteps)
-				log.Warn("system state collection incomplete", "warning", job.Warning)
+				// appendWarning, NOT assignment. The VSS block above runs first
+				// and may already have recorded that the shadow copy could not
+				// be created — and a wedged VSS/writer subsystem is exactly what
+				// tends to leave system state incomplete too, so the two
+				// co-occur. Overwriting here destroyed the VSS note on the one
+				// run where both mattered, and job.Warning is the ONLY channel
+				// that outcome has (there is no VSSMetadata when the session
+				// never started).
+				fragment := fmt.Sprintf("system state collection incomplete: %v failed", manifest.IncompleteSteps)
+				appendWarning(job, fragment)
+				log.Warn("system state collection incomplete", "warning", fragment)
 			}
 			// Append staging dir to backup paths so artifacts are included in snapshot
 			systemStateStagingIdx = len(backupPaths)
@@ -782,6 +778,44 @@ func flattenJoinedErrors(err error) []error {
 
 // appendWarning appends fragment to job.Warning, joining with "; " when the
 // job already carries an earlier warning (e.g. a partial system-state note).
+// buildVSSMetadata converts a live VSS session into the metadata block the
+// server persists to backup_jobs.vss_metadata (#3027).
+//
+// Extracted from RunBackupContext's Windows-gated branch so it is directly
+// callable from a portable test — the original inline struct literal copied
+// five of the session's six diagnostic fields and silently dropped
+// UnprotectedVolumes, and nothing could reach it to notice.
+func buildVSSMetadata(session *vss.VSSSession, durationMs int64) *vss.VSSMetadata {
+	if session == nil {
+		return nil
+	}
+	return &vss.VSSMetadata{
+		ShadowCopyID: session.ID,
+		CreationTime: session.CreatedAt,
+		Writers:      session.Writers,
+		ExposedPaths: session.ShadowPaths,
+		// Copied, not derived: ExposedPaths lists only the volumes that
+		// SUCCEEDED, so a volume with no shadow device is indistinguishable
+		// from one that was never requested. Omitting this was how a
+		// partially-snapshotted run reached the server looking clean.
+		UnprotectedVolumes: session.UnprotectedVolumes,
+		Warnings:           session.Warnings,
+		DurationMs:         durationMs,
+	}
+}
+
+// vssCreationFailureWarning is the server-visible note for the worst VSS
+// outcome, which used to be the quietest one: when CreateShadowCopy fails
+// outright there is no VSSMetadata to send at all, so without this the run
+// reaches the server indistinguishable from a clean VSS-backed backup — every
+// path read live, every locked file at risk of being skipped, and nothing
+// anywhere saying so. The per-path warning raised after the shadow-path
+// rewrite only fires when a session DID start, so it cannot cover this branch.
+func vssCreationFailureWarning(vssErr error) string {
+	return "VSS shadow copy could not be created, so every path was read from the live volume, " +
+		"where in-use files can be skipped or captured torn: " + vssErr.Error()
+}
+
 func appendWarning(job *BackupJob, fragment string) {
 	if fragment == "" {
 		return

--- a/agent/internal/backup/vss/types.go
+++ b/agent/internal/backup/vss/types.go
@@ -43,14 +43,25 @@ type VSSSession struct {
 	CreatedAt time.Time      `json:"createdAt"`
 }
 
-// VSSMetadata is the metadata block persisted alongside a backup snapshot.
+// VSSMetadata is the metadata block persisted alongside a backup snapshot. It
+// rides the backup command result's `vssMetadata` key and is persisted to
+// backup_jobs.vss_metadata (see apps/api/src/routes/backup/resultSchemas.ts —
+// the two shapes are pinned together by backupAgentContract.test.ts).
 type VSSMetadata struct {
 	ShadowCopyID string            `json:"shadowCopyId"`
 	CreationTime time.Time         `json:"creationTime"`
 	Writers      []WriterStatus    `json:"writers"`
 	ExposedPaths map[string]string `json:"exposedPaths"`
-	Warnings     []string          `json:"warnings,omitempty"`
-	DurationMs   int64             `json:"durationMs"`
+
+	// UnprotectedVolumes mirrors VSSSession.UnprotectedVolumes and MUST be
+	// carried here: it is the only field that says the snapshot is incomplete.
+	// ExposedPaths alone cannot — it lists what succeeded, never what was
+	// requested, so a volume that resolved no shadow device is simply absent
+	// and reads identically to a volume that was never asked for.
+	UnprotectedVolumes []string `json:"unprotectedVolumes,omitempty"`
+
+	Warnings   []string `json:"warnings,omitempty"`
+	DurationMs int64    `json:"durationMs"`
 }
 
 // Config holds VSS provider configuration.

--- a/agent/internal/backup/vss_metadata_test.go
+++ b/agent/internal/backup/vss_metadata_test.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,60 +11,8 @@ import (
 	"github.com/breeze-rmm/agent/internal/backup/vss"
 )
 
-// buildVSSMetadataFromSession mirrors the struct literal in RunBackupContext,
-// which is buried inside a long Windows-gated run function and cannot be called
-// directly from a portable test.
-//
-// Two guards keep the mirror honest, because a mirror that silently drifts is
-// how the original bug survived review:
-//   - TestVSSMetadataPopulatesEveryField reflects over vss.VSSMetadata and fails
-//     when a newly-added field is left zero here.
-//   - The production literal itself is pinned by source text in
-//     apps/api/src/services/backupAgentContract.test.ts ("backup.go copies
-//     UnprotectedVolumes into VSSMetadata").
-func buildVSSMetadataFromSession(session *vss.VSSSession, durationMs int64) *vss.VSSMetadata {
-	return &vss.VSSMetadata{
-		ShadowCopyID:       session.ID,
-		CreationTime:       session.CreatedAt,
-		Writers:            session.Writers,
-		ExposedPaths:       session.ShadowPaths,
-		UnprotectedVolumes: session.UnprotectedVolumes,
-		Warnings:           session.Warnings,
-		DurationMs:         durationMs,
-	}
-}
-
-// Fails when a field is added to vss.VSSMetadata and the production copy (and
-// this mirror) forget to populate it — the exact shape of the #3027 bug, where
-// the literal copied five fields and dropped the sixth.
-func TestVSSMetadataPopulatesEveryField(t *testing.T) {
-	session := &vss.VSSSession{
-		ID:                 "{set-0}",
-		Volumes:            []string{`C:\`, `D:\`},
-		ShadowPaths:        map[string]string{`C:\`: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`},
-		UnprotectedVolumes: []string{`D:\`},
-		Writers:            []vss.WriterStatus{{Name: "SqlServerWriter", ID: "{a}", State: "stable"}},
-		Warnings:           []string{"something degraded"},
-		CreatedAt:          time.Now().UTC(),
-	}
-
-	value := reflect.ValueOf(*buildVSSMetadataFromSession(session, 42))
-	typ := value.Type()
-	for i := 0; i < typ.NumField(); i++ {
-		if value.Field(i).IsZero() {
-			t.Errorf("VSSMetadata.%s was left at its zero value: the session carries a value for it, "+
-				"so the copy in RunBackupContext is dropping a diagnostic the server needs", typ.Field(i).Name)
-		}
-	}
-}
-
-// A volume that resolved no shadow device is read LIVE, so in-use files on it
-// may be skipped or captured torn. Before #3027 the metadata struct copied five
-// fields and omitted UnprotectedVolumes, so that fact never left the endpoint —
-// and ExposedPaths cannot stand in for it, because it lists only what SUCCEEDED
-// and so looks identical whether D: failed or was never requested.
-func TestVSSMetadataCarriesUnprotectedVolumes(t *testing.T) {
-	session := &vss.VSSSession{
+func sampleVSSSession() *vss.VSSSession {
+	return &vss.VSSSession{
 		ID:                 "{set-1}",
 		Volumes:            []string{`C:\`, `D:\`},
 		ShadowPaths:        map[string]string{`C:\`: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`},
@@ -72,8 +21,34 @@ func TestVSSMetadataCarriesUnprotectedVolumes(t *testing.T) {
 		Warnings:           []string{`volume D:\ has no shadow copy`},
 		CreatedAt:          time.Now().UTC(),
 	}
+}
 
-	meta := buildVSSMetadataFromSession(session, 1200)
+// Fails when a field is added to vss.VSSMetadata and buildVSSMetadata forgets to
+// populate it — the exact shape of the #3027 bug, where the copy took five of
+// the session's six diagnostic fields and dropped the sixth.
+//
+// This asserts against the PRODUCTION function, not a test-local mirror. An
+// earlier version of this suite mirrored the struct literal (it was inline in a
+// long Windows-gated run function); that made the test vacuous, because the
+// mirror could stay complete while production drifted. buildVSSMetadata was
+// extracted so this test actually holds the real code.
+func TestVSSMetadataPopulatesEveryField(t *testing.T) {
+	value := reflect.ValueOf(*buildVSSMetadata(sampleVSSSession(), 42))
+	typ := value.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		if value.Field(i).IsZero() {
+			t.Errorf("VSSMetadata.%s was left at its zero value even though the session carries one: "+
+				"buildVSSMetadata is dropping a diagnostic the server needs", typ.Field(i).Name)
+		}
+	}
+}
+
+// A volume that resolved no shadow device is read LIVE, so in-use files on it
+// may be skipped or captured torn. Before #3027 that fact never left the
+// endpoint — and ExposedPaths cannot stand in for it, because it lists only what
+// SUCCEEDED and so looks identical whether D: failed or was never requested.
+func TestVSSMetadataCarriesUnprotectedVolumes(t *testing.T) {
+	meta := buildVSSMetadata(sampleVSSSession(), 1200)
 
 	if len(meta.UnprotectedVolumes) != 1 || meta.UnprotectedVolumes[0] != `D:\` {
 		t.Fatalf("UnprotectedVolumes not carried into VSSMetadata: got %v", meta.UnprotectedVolumes)
@@ -96,17 +71,14 @@ func TestVSSMetadataCarriesUnprotectedVolumes(t *testing.T) {
 
 // A clean session must not emit the key at all — the server treats presence as
 // evidence of an incomplete snapshot, so an always-present empty array would
-// make every run look like it needed investigating.
+// make every healthy run look like it needed investigating.
 func TestVSSMetadataOmitsUnprotectedVolumesOnACleanSession(t *testing.T) {
-	session := &vss.VSSSession{
-		ID:          "{set-2}",
-		Volumes:     []string{`C:\`},
-		ShadowPaths: map[string]string{`C:\`: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`},
-		Writers:     []vss.WriterStatus{{Name: "SqlServerWriter", ID: "{a}", State: "stable"}},
-		CreatedAt:   time.Now().UTC(),
-	}
+	session := sampleVSSSession()
+	session.UnprotectedVolumes = nil
+	session.Warnings = nil
+	session.ShadowPaths = map[string]string{`C:\`: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`}
 
-	encoded, err := json.Marshal(buildVSSMetadataFromSession(session, 300))
+	encoded, err := json.Marshal(buildVSSMetadata(session, 300))
 	if err != nil {
 		t.Fatalf("marshal VSSMetadata: %v", err)
 	}
@@ -115,22 +87,52 @@ func TestVSSMetadataOmitsUnprotectedVolumesOnACleanSession(t *testing.T) {
 	}
 }
 
-// appendWarning is the only VSS channel that survives the agent's IPC bounding
-// when the result is oversize (result_bounds.go drops vssMetadata as a bulk
-// container), so a total VSS failure — which produces no metadata at all — has
-// to route through it or the run reaches the server looking clean.
-func TestAppendWarningAccumulatesVSSFailures(t *testing.T) {
-	job := &BackupJob{}
-	// Fixtures deliberately free of ';' so the separator count below measures
-	// the join, not the payloads.
-	appendWarning(job, "VSS shadow copy could not be created")
-	appendWarning(job, "read from the live volume, not the VSS shadow copy: C:\\data")
-
-	if !strings.Contains(job.Warning, "could not be created") {
-		t.Fatalf("first warning lost: %q", job.Warning)
+func TestBuildVSSMetadataOnNilSession(t *testing.T) {
+	if meta := buildVSSMetadata(nil, 0); meta != nil {
+		t.Fatalf("nil session must yield nil metadata, got %+v", meta)
 	}
-	if !strings.Contains(job.Warning, "C:\\data") {
-		t.Fatalf("second warning lost: %q", job.Warning)
+}
+
+// The worst VSS outcome is the quietest one: when CreateShadowCopy fails there
+// is no VSSMetadata at all, so job.Warning is the ONLY server-visible channel.
+// Pin that the note names the consequence, not just the error — "VSS failed" on
+// its own does not tell a tech that in-use files may have been skipped.
+func TestVSSCreationFailureWarningNamesTheConsequence(t *testing.T) {
+	warning := vssCreationFailureWarning(errors.New("0x80042308"))
+
+	for _, want := range []string{"live volume", "skipped", "0x80042308"} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("VSS creation-failure warning must mention %q, got %q", want, warning)
+		}
+	}
+}
+
+// Regression: the system-state block ASSIGNED job.Warning rather than appending,
+// so on a run where VSS creation failed AND system state was incomplete — which
+// co-occur, since a wedged writer subsystem causes both — the VSS note was
+// destroyed before it ever left the endpoint.
+func TestSystemStateWarningDoesNotClobberTheVSSWarning(t *testing.T) {
+	job := &BackupJob{}
+	appendWarning(job, vssCreationFailureWarning(errors.New("0x80042308")))
+	appendWarning(job, "system state collection incomplete: [certs] failed")
+
+	if !strings.Contains(job.Warning, "0x80042308") {
+		t.Fatalf("VSS creation failure was clobbered by the system-state warning: %q", job.Warning)
+	}
+	if !strings.Contains(job.Warning, "system state collection incomplete") {
+		t.Fatalf("system-state warning lost: %q", job.Warning)
+	}
+}
+
+func TestAppendWarningJoinsWithASingleSeparator(t *testing.T) {
+	job := &BackupJob{}
+	// Fixtures deliberately free of ';' so the count below measures the join,
+	// not the payloads.
+	appendWarning(job, "first note")
+	appendWarning(job, "second note")
+
+	if job.Warning != "first note; second note" {
+		t.Fatalf("unexpected join, got %q", job.Warning)
 	}
 	if strings.Count(job.Warning, ";") != 1 {
 		t.Fatalf("warnings must join with a single separator, got %q", job.Warning)

--- a/agent/internal/backup/vss_metadata_test.go
+++ b/agent/internal/backup/vss_metadata_test.go
@@ -1,0 +1,138 @@
+package backup
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup/vss"
+)
+
+// buildVSSMetadataFromSession mirrors the struct literal in RunBackupContext,
+// which is buried inside a long Windows-gated run function and cannot be called
+// directly from a portable test.
+//
+// Two guards keep the mirror honest, because a mirror that silently drifts is
+// how the original bug survived review:
+//   - TestVSSMetadataPopulatesEveryField reflects over vss.VSSMetadata and fails
+//     when a newly-added field is left zero here.
+//   - The production literal itself is pinned by source text in
+//     apps/api/src/services/backupAgentContract.test.ts ("backup.go copies
+//     UnprotectedVolumes into VSSMetadata").
+func buildVSSMetadataFromSession(session *vss.VSSSession, durationMs int64) *vss.VSSMetadata {
+	return &vss.VSSMetadata{
+		ShadowCopyID:       session.ID,
+		CreationTime:       session.CreatedAt,
+		Writers:            session.Writers,
+		ExposedPaths:       session.ShadowPaths,
+		UnprotectedVolumes: session.UnprotectedVolumes,
+		Warnings:           session.Warnings,
+		DurationMs:         durationMs,
+	}
+}
+
+// Fails when a field is added to vss.VSSMetadata and the production copy (and
+// this mirror) forget to populate it — the exact shape of the #3027 bug, where
+// the literal copied five fields and dropped the sixth.
+func TestVSSMetadataPopulatesEveryField(t *testing.T) {
+	session := &vss.VSSSession{
+		ID:                 "{set-0}",
+		Volumes:            []string{`C:\`, `D:\`},
+		ShadowPaths:        map[string]string{`C:\`: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`},
+		UnprotectedVolumes: []string{`D:\`},
+		Writers:            []vss.WriterStatus{{Name: "SqlServerWriter", ID: "{a}", State: "stable"}},
+		Warnings:           []string{"something degraded"},
+		CreatedAt:          time.Now().UTC(),
+	}
+
+	value := reflect.ValueOf(*buildVSSMetadataFromSession(session, 42))
+	typ := value.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		if value.Field(i).IsZero() {
+			t.Errorf("VSSMetadata.%s was left at its zero value: the session carries a value for it, "+
+				"so the copy in RunBackupContext is dropping a diagnostic the server needs", typ.Field(i).Name)
+		}
+	}
+}
+
+// A volume that resolved no shadow device is read LIVE, so in-use files on it
+// may be skipped or captured torn. Before #3027 the metadata struct copied five
+// fields and omitted UnprotectedVolumes, so that fact never left the endpoint —
+// and ExposedPaths cannot stand in for it, because it lists only what SUCCEEDED
+// and so looks identical whether D: failed or was never requested.
+func TestVSSMetadataCarriesUnprotectedVolumes(t *testing.T) {
+	session := &vss.VSSSession{
+		ID:                 "{set-1}",
+		Volumes:            []string{`C:\`, `D:\`},
+		ShadowPaths:        map[string]string{`C:\`: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`},
+		UnprotectedVolumes: []string{`D:\`},
+		Writers:            []vss.WriterStatus{{Name: "NTDS", ID: "{w}", State: "failed", LastError: "timed out"}},
+		Warnings:           []string{`volume D:\ has no shadow copy`},
+		CreatedAt:          time.Now().UTC(),
+	}
+
+	meta := buildVSSMetadataFromSession(session, 1200)
+
+	if len(meta.UnprotectedVolumes) != 1 || meta.UnprotectedVolumes[0] != `D:\` {
+		t.Fatalf("UnprotectedVolumes not carried into VSSMetadata: got %v", meta.UnprotectedVolumes)
+	}
+
+	// It must also survive the wire hop the server actually reads.
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal VSSMetadata: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal VSSMetadata: %v", err)
+	}
+	volumes, ok := decoded["unprotectedVolumes"].([]any)
+	if !ok || len(volumes) != 1 || volumes[0] != `D:\` {
+		t.Fatalf(`json key "unprotectedVolumes" missing or wrong: %s`, encoded)
+	}
+}
+
+// A clean session must not emit the key at all — the server treats presence as
+// evidence of an incomplete snapshot, so an always-present empty array would
+// make every run look like it needed investigating.
+func TestVSSMetadataOmitsUnprotectedVolumesOnACleanSession(t *testing.T) {
+	session := &vss.VSSSession{
+		ID:          "{set-2}",
+		Volumes:     []string{`C:\`},
+		ShadowPaths: map[string]string{`C:\`: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1`},
+		Writers:     []vss.WriterStatus{{Name: "SqlServerWriter", ID: "{a}", State: "stable"}},
+		CreatedAt:   time.Now().UTC(),
+	}
+
+	encoded, err := json.Marshal(buildVSSMetadataFromSession(session, 300))
+	if err != nil {
+		t.Fatalf("marshal VSSMetadata: %v", err)
+	}
+	if strings.Contains(string(encoded), "unprotectedVolumes") {
+		t.Fatalf("clean session must omit unprotectedVolumes, got %s", encoded)
+	}
+}
+
+// appendWarning is the only VSS channel that survives the agent's IPC bounding
+// when the result is oversize (result_bounds.go drops vssMetadata as a bulk
+// container), so a total VSS failure — which produces no metadata at all — has
+// to route through it or the run reaches the server looking clean.
+func TestAppendWarningAccumulatesVSSFailures(t *testing.T) {
+	job := &BackupJob{}
+	// Fixtures deliberately free of ';' so the separator count below measures
+	// the join, not the payloads.
+	appendWarning(job, "VSS shadow copy could not be created")
+	appendWarning(job, "read from the live volume, not the VSS shadow copy: C:\\data")
+
+	if !strings.Contains(job.Warning, "could not be created") {
+		t.Fatalf("first warning lost: %q", job.Warning)
+	}
+	if !strings.Contains(job.Warning, "C:\\data") {
+		t.Fatalf("second warning lost: %q", job.Warning)
+	}
+	if strings.Count(job.Warning, ";") != 1 {
+		t.Fatalf("warnings must join with a single separator, got %q", job.Warning)
+	}
+}

--- a/agent/internal/heartbeat/backup_forwarder.go
+++ b/agent/internal/heartbeat/backup_forwarder.go
@@ -29,6 +29,42 @@ func shouldForwardBackupRunAsync(cmdType string, hasAsyncCapability bool) bool {
 	return cmdType == tools.CmdBackupRun && hasAsyncCapability
 }
 
+// backupResultToCommandResult maps the backup helper's IPC result onto the
+// websocket CommandResult the server consumes.
+//
+// The failure arm deliberately carries Stdout. marshalBackupRunResult populates
+// the job body even on a failed backup_run (#3027) so the run's VSS
+// diagnostics, warning text and partial counters survive; discarding it here
+// would simply move the loss one hop later, which is the bug class this issue
+// is about. Status remains "failed" — NewErrorResult sets it, and the server
+// keys the job's terminal status on exactly that (routes/agentWs.ts records
+// `completed` only when `result.status === 'completed'`), so the body can never
+// turn a failed run green. It only adds detail to a failure.
+//
+// Pulled out as a pure function so this mapping is testable without a live
+// websocket/IPC connection, matching shouldForwardBackupRunAsync above.
+func backupResultToCommandResult(result backupipc.BackupCommandResult) tools.CommandResult {
+	if !result.Success {
+		failed := tools.NewErrorResult(fmt.Errorf("%s", result.Stderr), result.DurationMs)
+		// Carried RAW, not json.Marshal'd the way NewSuccessResult encodes the
+		// success body — the two branches genuinely need different encodings,
+		// because toWSCommandResult treats them differently:
+		//
+		//   success: Error == "", so it json.Unmarshals Stdout into `Result`.
+		//            The double encoding means that yields the object TEXT as a
+		//            string, and the server's single JSON.parse turns it into
+		//            the object.
+		//   failure: Error != "", so `Result` is never populated and the server
+		//            falls back to `stdout` — with only ONE parse left. A
+		//            double-encoded body would parse to a string, fail
+		//            backupCommandResultSchema, and be reported as a malformed
+		//            payload. Raw object text is what makes that one parse land.
+		failed.Stdout = result.Stdout
+		return failed
+	}
+	return tools.NewSuccessResult(result.Stdout, result.DurationMs)
+}
+
 // forwardToBackupHelper sends a command to the backup binary via IPC and returns the result.
 func forwardToBackupHelper(h *Heartbeat, cmd Command, timeout time.Duration) tools.CommandResult {
 	start := time.Now()
@@ -59,8 +95,5 @@ func forwardToBackupHelper(h *Heartbeat, cmd Command, timeout time.Duration) too
 		return tools.NewErrorResult(fmt.Errorf("invalid backup result: %w", err), time.Since(start).Milliseconds())
 	}
 
-	if !result.Success {
-		return tools.NewErrorResult(fmt.Errorf("%s", result.Stderr), result.DurationMs)
-	}
-	return tools.NewSuccessResult(result.Stdout, result.DurationMs)
+	return backupResultToCommandResult(result)
 }

--- a/agent/internal/heartbeat/backup_forwarder_test.go
+++ b/agent/internal/heartbeat/backup_forwarder_test.go
@@ -1,8 +1,10 @@
 package heartbeat
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/breeze-rmm/agent/internal/backupipc"
 	"github.com/breeze-rmm/agent/internal/remote/tools"
 )
 
@@ -43,4 +45,79 @@ func TestShouldForwardBackupRunAsync(t *testing.T) {
 			}
 		})
 	}
+}
+
+// #3027: a failed backup run must still deliver its job body. The helper
+// populates Stdout on failure (marshalBackupRunResult) precisely so the run's
+// VSS diagnostics, warning text and partial counters survive; this hop used to
+// discard it, which put the loss back exactly where the issue found it.
+func TestBackupResultToCommandResultKeepsBodyOnFailure(t *testing.T) {
+	body := `{"status":"failed","warning":"VSS shadow copy could not be created","vssMetadata":{"shadowCopyId":"set-1"}}`
+
+	got := backupResultToCommandResult(backupipc.BackupCommandResult{
+		Success:    false,
+		Stdout:     body,
+		Stderr:     "upload destination unreachable",
+		DurationMs: 42,
+	})
+
+	// The run stays failed — the body only adds detail. The server keys the
+	// job's terminal status on exactly this field, so carrying a body can never
+	// turn a failed run green.
+	if got.Status != "failed" {
+		t.Fatalf("a failed backup must stay failed, got status %q", got.Status)
+	}
+	if got.Error != "upload destination unreachable" {
+		t.Errorf("failure reason lost: got %q", got.Error)
+	}
+	// RAW, not double-encoded. toWSCommandResult only populates the parsed
+	// `Result` field when Error == "", so on a failure the server falls back to
+	// `stdout` with a single JSON.parse left to spend. Encoding this the way the
+	// success body is encoded would make that parse yield a string, fail
+	// backupCommandResultSchema, and surface as a malformed payload.
+	if got.Stdout != body {
+		t.Errorf("failure body must be raw object text, got %q", got.Stdout)
+	}
+	// Pin the invariant the server depends on: exactly one parse yields an object.
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(got.Stdout), &decoded); err != nil {
+		t.Fatalf("one parse of the failure stdout must yield an object: %v", err)
+	}
+	if decoded["vssMetadata"] == nil {
+		t.Errorf("VSS diagnostics missing from the failure body: %s", got.Stdout)
+	}
+}
+
+func TestBackupResultToCommandResultSuccessUnchanged(t *testing.T) {
+	body := `{"status":"completed"}`
+
+	got := backupResultToCommandResult(backupipc.BackupCommandResult{
+		Success:    true,
+		Stdout:     body,
+		DurationMs: 7,
+	})
+
+	if got.Status != "completed" {
+		t.Fatalf("expected completed, got %q", got.Status)
+	}
+	if got.Stdout != encodeStdout(t, body) {
+		t.Errorf("success body encoding changed: got %q", got.Stdout)
+	}
+	if got.Error != "" {
+		t.Errorf("success must carry no error, got %q", got.Error)
+	}
+}
+
+// The SUCCESS path runs the helper's stdout through json.Marshal
+// (tools.NewSuccessResult), so its wire value is a JSON string literal rather
+// than raw object text. That asymmetry with the failure path is deliberate —
+// see backupResultToCommandResult — so pin it rather than hard-coding escaped
+// literals in the assertion.
+func encodeStdout(t *testing.T, raw string) string {
+	t.Helper()
+	encoded, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("marshal stdout: %v", err)
+	}
+	return string(encoded)
 }

--- a/agent/internal/heartbeat/backup_outbox_wiring_test.go
+++ b/agent/internal/heartbeat/backup_outbox_wiring_test.go
@@ -55,6 +55,63 @@ func TestHandleBackupResult_NoWSClient_PersistsToOutbox(t *testing.T) {
 	}
 }
 
+// #3027: on the async path — the one every modern backup_run takes — a FAILED
+// terminal result used to deliver stderr and nothing else, because error and
+// body were an either/or. That discarded the job body the helper populates
+// precisely so a failed run keeps its VSS diagnostics, warning text and partial
+// counters. Both must ride together, and the run must still be `failed`.
+func TestHandleBackupResult_FailedRunKeepsItsBody(t *testing.T) {
+	outbox := newBackupResultOutbox(filepath.Join(t.TempDir(), "outbox"))
+	h := &Heartbeat{backupOutbox: outbox} // wsClient intentionally nil
+
+	res := backupipc.BackupCommandResult{
+		CommandID: "cmd-failed",
+		Success:   false,
+		Stderr:    "upload destination unreachable",
+		Stdout:    `{"status":"failed","errorCount":3,"warning":"VSS shadow copy could not be created","vssMetadata":{"shadowCopyId":"set-1","unprotectedVolumes":["D:\\"]}}`,
+	}
+	payload, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := &ipc.Envelope{ID: "e-failed", Type: backupipc.TypeBackupResult, Payload: payload}
+
+	h.handleUserHelperMessage(nil, env)
+
+	var delivered []websocket.CommandResult
+	outbox.Flush(func(r websocket.CommandResult) error {
+		delivered = append(delivered, r)
+		return nil
+	})
+	if len(delivered) != 1 {
+		t.Fatalf("expected exactly one delivered result, got %+v", delivered)
+	}
+	got := delivered[0]
+
+	// A body must never green a failed run — the server reads the job's
+	// terminal status from this field alone.
+	if got.Status != "failed" {
+		t.Fatalf("failed run must stay failed, got %q", got.Status)
+	}
+	if got.Error != "upload destination unreachable" {
+		t.Errorf("failure reason lost: %q", got.Error)
+	}
+
+	body, isObject := got.Result.(map[string]any)
+	if !isObject {
+		t.Fatalf("failed run must carry its job body as a structured result, got %#v", got.Result)
+	}
+	if body["vssMetadata"] == nil {
+		t.Errorf("VSS diagnostics dropped from the failed run: %#v", body)
+	}
+	if body["warning"] != "VSS shadow copy could not be created" {
+		t.Errorf("warning dropped from the failed run: %#v", body)
+	}
+	if body["errorCount"] != float64(3) {
+		t.Errorf("partial counters dropped from the failed run: %#v", body)
+	}
+}
+
 // TestSetWebSocketClient_ReconnectFlushesBackupOutbox proves the flush-on-
 // reconnect wiring end-to-end: SetWebSocketClient points ws.OnConnected at
 // flushBackupResultOutbox, so when the read pump parses the server's

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -932,9 +932,18 @@ func (h *Heartbeat) handleUserHelperMessage(session *sessionbroker.Session, env 
 		if backupResult.Success {
 			result.Status = "completed"
 		}
+		// Error and body are set INDEPENDENTLY, not as an either/or (#3027).
+		// This is the async path every modern backup_run takes, and the old
+		// `else if` meant a failed run delivered its stderr and nothing else —
+		// discarding the job body that marshalBackupRunResult populates
+		// precisely so a failure keeps its VSS diagnostics, warning text and
+		// partial counters. Status is already decided above from
+		// backupResult.Success, and the server reads the job's terminal status
+		// from that field alone, so attaching a body cannot green a failed run.
 		if backupResult.Stderr != "" {
 			result.Error = backupResult.Stderr
-		} else if backupResult.Stdout != "" {
+		}
+		if backupResult.Stdout != "" {
 			var parsed any
 			if err := json.Unmarshal([]byte(backupResult.Stdout), &parsed); err == nil {
 				result.Result = parsed

--- a/apps/api/src/jobs/backupEnqueue.ts
+++ b/apps/api/src/jobs/backupEnqueue.ts
@@ -61,6 +61,11 @@ export interface ProcessResultsResult {
   // forward them or the snapshot loses its type label + BMR restore manifest.
   backupType?: 'file' | 'system_image' | 'database' | 'application';
   systemStateManifest?: Record<string, unknown> | null;
+  // Windows VSS diagnostics (#3027). Must ride the queue payload for the same
+  // reason the manifest does: the persistence layer only writes what arrives
+  // here, and dropping it leaves backup_jobs.vss_metadata permanently NULL.
+  // Typed `unknown` on purpose — see backupProcessResultSchema.
+  vssMetadata?: unknown;
   snapshot?: {
     id: string;
     timestamp?: string;

--- a/apps/api/src/jobs/queueSchemas.test.ts
+++ b/apps/api/src/jobs/queueSchemas.test.ts
@@ -359,4 +359,31 @@ describe('backupProcessResultSchema — agentStatus (#3000)', () => {
     const parsed = backupProcessResultSchema.parse({ status: 'completed', snapshotId: 'snap-1' });
     expect(parsed.agentStatus).toBeUndefined();
   });
+
+  it('carries vssMetadata across the .strict() boundary (#3027)', () => {
+    // The schema is .strict(), so an undeclared top-level key throws inside
+    // enqueueBackupResults BEFORE queue.add — the whole terminal result would
+    // be lost, not just the diagnostics.
+    const parsed = backupProcessResultSchema.parse({
+      status: 'completed',
+      snapshotId: 'snap-1',
+      vssMetadata: { shadowCopyId: 'set-1', unprotectedVolumes: ['D:\\'] },
+    });
+    expect(parsed.vssMetadata).toEqual({ shadowCopyId: 'set-1', unprotectedVolumes: ['D:\\'] });
+  });
+
+  it('never rejects the queue payload over a malformed vssMetadata', () => {
+    // Same reasoning as the ingress schema: this parse throws before the job is
+    // enqueued, so a shape assertion here would discard the snapshot id and
+    // counters over a diagnostics blob. Bounding happens at the DB write.
+    for (const vssMetadata of [{ writers: 'not-an-array' }, 'bare string', 7, [], null]) {
+      const parsed = backupProcessResultSchema.safeParse({
+        status: 'completed',
+        snapshotId: 'snap-1',
+        vssMetadata,
+      });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.snapshotId).toBe('snap-1');
+    }
+  });
 });

--- a/apps/api/src/jobs/queueSchemas.ts
+++ b/apps/api/src/jobs/queueSchemas.ts
@@ -49,6 +49,15 @@ export const backupProcessResultSchema = z.object({
   // still must be declared here or the whole job fails validation.
   backupType: z.enum(['file', 'system_image', 'database', 'application']).optional(),
   systemStateManifest: z.record(z.string(), z.unknown()).nullish(),
+  // Windows VSS diagnostics (#3027), forwarded so persistence can write
+  // backup_jobs.vss_metadata. `z.unknown()` rather than a record for the same
+  // reason as the ingress schema (routes/backup/resultSchemas.ts): this parse
+  // runs inside enqueueBackupResults and THROWS BEFORE queue.add, so a shape
+  // assertion here would discard the entire terminal result — snapshot id,
+  // counters and all — over a diagnostics blob. Validation and bounding happen
+  // in sanitizeVssMetadata at the write. Note the .strict() rule still applies:
+  // the TOP-LEVEL key has to be declared right here or the job dead-letters.
+  vssMetadata: z.unknown().optional(),
   snapshot: backupSnapshotSummarySchema.optional(),
   error: z.string().min(1).optional(),
 }).strict();

--- a/apps/api/src/routes/agentWs.enqueueContract.test.ts
+++ b/apps/api/src/routes/agentWs.enqueueContract.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { backupProcessResultSchema } from '../jobs/queueSchemas';
 
 const source = readFileSync(path.join(__dirname, 'agentWs.ts'), 'utf8');
 
@@ -35,5 +36,55 @@ describe('agentWs enqueue context contract (#1105)', () => {
         `enqueue call at agentWs.ts:${idx + 1} must be wrapped in runOutsideDbContext (#1105):\n${lines[idx]}`
       ).toBe(true);
     }
+  });
+});
+
+/**
+ * Static contract (#3027): the backup `process-results` payload is built by a
+ * HAND-MAINTAINED, key-by-key object literal in agentWs.ts. Every key the queue
+ * schema declares has to appear in it, or that field is silently dropped on the
+ * primary (Redis-up) path while every other test still passes.
+ *
+ * This is not hypothetical — it is how #3027 stayed hidden. `vssMetadata` could
+ * be added to both zod schemas, persisted correctly, projected correctly, and
+ * covered by tests at every individual hop, and STILL never reach the database,
+ * because the one line that forwards it lives in a literal nothing asserts on.
+ * Per-field tests cannot catch that class; only a completeness check can.
+ *
+ * Note the asymmetry that makes the literal the fragile half: the Redis-DOWN
+ * branch a few lines below spreads `...(backupData ?? {})` and is structurally
+ * immune to this failure.
+ */
+describe('agentWs backup enqueue payload completeness (#3027)', () => {
+  // Keys legitimately absent from the literal, with the reason. Adding to this
+  // set must be a deliberate, reviewed decision — that is the whole point.
+  const NOT_IN_LITERAL = new Map<string, string>([
+    ['jobId', 'passed as a positional argument to enqueueBackupResults, not inside the result object'],
+  ]);
+
+  it('forwards every key backupProcessResultSchema declares', () => {
+    const start = source.indexOf('await runOutsideDbContext(() => enqueueBackupResults(');
+    expect(start, 'the backup enqueue call site moved — fix this scan, do not delete it').toBeGreaterThan(-1);
+    // Bound the window to the call, not the rest of the file, so an unrelated
+    // mention of a key elsewhere cannot make this pass vacuously.
+    const literal = source.slice(start, source.indexOf('Redis unavailable', start));
+    expect(literal.length).toBeGreaterThan(0);
+
+    const declaredKeys = Object.keys(backupProcessResultSchema.shape);
+    // Sanity-check the introspection itself, so a zod API change turns this
+    // into a failure rather than an empty, always-green loop.
+    expect(declaredKeys).toContain('vssMetadata');
+    expect(declaredKeys.length).toBeGreaterThanOrEqual(14);
+
+    const missing = declaredKeys.filter(
+      (key) => !NOT_IN_LITERAL.has(key) && !new RegExp(`\\b${key}\\s*:`).test(literal)
+    );
+
+    expect(
+      missing,
+      `agentWs.ts's enqueueBackupResults literal is missing ${missing.join(', ')} — ` +
+        'those fields are declared on the queue schema but never forwarded, so they are ' +
+        'silently dropped on the primary path (#3027).'
+    ).toEqual([]);
   });
 });

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -1617,6 +1617,7 @@ export async function processOrphanedCommandResult(
             referencedBytes: backupData?.referencedBytes,
             backupType: backupData?.backupType,
             systemStateManifest: backupData?.systemStateManifest,
+            vssMetadata: backupData?.vssMetadata,
             snapshot: backupData?.snapshot,
             error: malformedPayloadError || result.error || result.stderr,
           },

--- a/apps/api/src/routes/backup/dashboard.test.ts
+++ b/apps/api/src/routes/backup/dashboard.test.ts
@@ -25,6 +25,7 @@ function chainMock(resolvedValue: unknown = []) {
 
 const selectMock = vi.fn(() => chainMock([]));
 const resolveAllBackupAssignedDevicesMock = vi.fn();
+const resolveBackupConfigForDeviceMock = vi.fn(async () => null as unknown);
 
 vi.mock('../../db', () => ({
   db: {
@@ -65,10 +66,13 @@ vi.mock('../../db/schema', () => ({
     displayName: 'devices.display_name',
     hostname: 'devices.hostname',
   },
+  // `partial` counts as a restore point (#3000) — the status route reads this
+  // to decide lastSuccessAt.
+  RESTORABLE_BACKUP_JOB_STATUSES: ['completed', 'partial'] as const,
 }));
 
 vi.mock('../../services/featureConfigResolver', () => ({
-  resolveBackupConfigForDevice: vi.fn(),
+  resolveBackupConfigForDevice: (...args: unknown[]) => resolveBackupConfigForDeviceMock(...(args as [])),
   resolveAllBackupAssignedDevices: (...args: unknown[]) => resolveAllBackupAssignedDevicesMock(...(args as [])),
 }));
 
@@ -412,6 +416,63 @@ describe('backup dashboard routes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.attentionItems).toEqual([]);
+  });
+
+  describe('GET /status/:deviceId — lastJob VSS metadata (#3027)', () => {
+    function mockStatusQueries(job: Record<string, unknown>) {
+      resolveBackupConfigForDeviceMock.mockResolvedValueOnce(null);
+      selectMock
+        .mockReturnValueOnce(chainMock([{ id: DEVICE_ID, siteId: SITE_A }]))
+        .mockReturnValueOnce(chainMock([job]));
+    }
+
+    function makeJob(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'job-vss',
+        status: 'completed',
+        createdAt: new Date('2026-04-01T00:00:00.000Z'),
+        completedAt: new Date('2026-04-01T00:10:00.000Z'),
+        errorLog: null,
+        vssMetadata: null,
+        ...overrides,
+      };
+    }
+
+    it('includes vssMetadata in the lastJob projection', async () => {
+      // Regression: the projection returned only {id,status,createdAt,completedAt},
+      // so the device tab's VSS panel could never render — showVssStatus was
+      // permanently false regardless of what the agent reported.
+      mockStatusQueries(makeJob({
+        vssMetadata: {
+          shadowCopyId: 'set-1',
+          writers: [{ name: 'NTDS', state: 'failed' }],
+          unprotectedVolumes: ['D:\\'],
+        },
+      }));
+
+      const res = await app.request(`/backup/status/${DEVICE_ID}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.lastJob.vssMetadata).toEqual({
+        shadowCopyId: 'set-1',
+        writers: [{ name: 'NTDS', state: 'failed' }],
+        unprotectedVolumes: ['D:\\'],
+      });
+    });
+
+    it('returns null (not undefined) when the run recorded no VSS metadata', async () => {
+      // The UI gates on `!= null`, so the key has to be present and explicitly
+      // null rather than dropped from the JSON body.
+      mockStatusQueries(makeJob());
+
+      const res = await app.request(`/backup/status/${DEVICE_ID}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.lastJob).toHaveProperty('vssMetadata');
+      expect(body.data.lastJob.vssMetadata).toBeNull();
+    });
   });
 });
 

--- a/apps/api/src/routes/backup/dashboard.test.ts
+++ b/apps/api/src/routes/backup/dashboard.test.ts
@@ -473,6 +473,23 @@ describe('backup dashboard routes', () => {
       expect(body.data.lastJob).toHaveProperty('vssMetadata');
       expect(body.data.lastJob.vssMetadata).toBeNull();
     });
+
+    it('includes errorLog — the ONLY channel a total VSS failure has', async () => {
+      // When the shadow copy could not be created there is no vssMetadata at
+      // all, so the degradation rides the warning into error_log. Without this
+      // the device tab showed a clean green backup for a run that read every
+      // file off the live volume.
+      mockStatusQueries(makeJob({
+        vssMetadata: null,
+        errorLog: 'VSS shadow copy could not be created, so every path was read from the live volume',
+      }));
+
+      const res = await app.request(`/backup/status/${DEVICE_ID}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.lastJob.errorLog).toContain('read from the live volume');
+    });
   });
 });
 

--- a/apps/api/src/routes/backup/dashboard.ts
+++ b/apps/api/src/routes/backup/dashboard.ts
@@ -472,6 +472,13 @@ dashboardRoutes.get('/status/:deviceId', requirePermission(PERMISSIONS.ORGS_READ
             // session — null on every other run, which is why the panel is
             // hidden rather than shown empty.
             vssMetadata: lastJob.vssMetadata ?? null,
+            // #3027: the companion channel, and the ONLY one that exists for
+            // the worst VSS outcome — when the shadow copy could not be created
+            // at all there is no vssMetadata to send, so the degradation rides
+            // the run's warning text into error_log. Without this the device
+            // tab showed a clean, green backup for a run that read every file
+            // off the live volume. Already secret-redacted at write time.
+            errorLog: lastJob.errorLog ?? null,
           }
         : null,
       lastSuccessAt: lastSuccess?.completedAt?.toISOString() ?? null,

--- a/apps/api/src/routes/backup/dashboard.ts
+++ b/apps/api/src/routes/backup/dashboard.ts
@@ -466,6 +466,12 @@ dashboardRoutes.get('/status/:deviceId', requirePermission(PERMISSIONS.ORGS_READ
             status: lastJob.status,
             createdAt: lastJob.createdAt.toISOString(),
             completedAt: lastJob.completedAt?.toISOString() ?? null,
+            // #3027: the device tab's VSS panel keys off this. Bounded and
+            // secret-redacted at write time (sanitizeVssMetadata), and only
+            // ever present on Windows runs that actually started a VSS
+            // session — null on every other run, which is why the panel is
+            // hidden rather than shown empty.
+            vssMetadata: lastJob.vssMetadata ?? null,
           }
         : null,
       lastSuccessAt: lastSuccess?.completedAt?.toISOString() ?? null,

--- a/apps/api/src/routes/backup/resultSchemas.test.ts
+++ b/apps/api/src/routes/backup/resultSchemas.test.ts
@@ -109,3 +109,64 @@ describe('backupCommandResultSchema — agent terminal status (#3000)', () => {
     expect(parsed.status).toBeUndefined();
   });
 });
+
+describe('backupCommandResultSchema — VSS metadata (#3027)', () => {
+  it('keeps the agent-reported vssMetadata instead of stripping it', () => {
+    // Regression: the schema had no vssMetadata key, so zod's default strip
+    // behaviour silently discarded the field at the first server-side parse and
+    // backup_jobs.vss_metadata stayed an orphan column forever.
+    const parsed = backupCommandResultSchema.parse({
+      snapshotId: 'snap-1',
+      status: 'completed',
+      vssMetadata: {
+        shadowCopyId: '{11111111-2222-3333-4444-555555555555}',
+        creationTime: '2026-08-02T00:00:00Z',
+        writers: [
+          { name: 'SqlServerWriter', id: 'w-1', state: 'stable' },
+          { name: 'NTDS', id: 'w-2', state: 'failed', lastError: 'timed out' },
+        ],
+        exposedPaths: { 'C:\\': '\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1' },
+        unprotectedVolumes: ['D:\\'],
+        warnings: ['volume D:\\ has no shadow copy'],
+        durationMs: 4200,
+      },
+    });
+
+    const vss = parsed.vssMetadata as Record<string, unknown>;
+    expect(vss.shadowCopyId).toBe('{11111111-2222-3333-4444-555555555555}');
+    expect(vss.writers).toHaveLength(2);
+    expect(vss.unprotectedVolumes).toEqual(['D:\\']);
+    expect(vss.durationMs).toBe(4200);
+  });
+
+  it('NEVER fails the result over a malformed vssMetadata — that would flip a good backup to failed', () => {
+    // agentWs gates the recorded job status on this parse succeeding
+    // (`result.status === 'completed' && parsedBackup.success`), so rejecting a
+    // diagnostics blob would mark a backup that genuinely succeeded as failed
+    // and strand its snapshot. Every shape must parse; validation happens in
+    // sanitizeVssMetadata, one hop later.
+    for (const vssMetadata of [
+      { writers: 'not-an-array' },
+      'a bare string',
+      42,
+      [],
+      null,
+      { writers: [{ name: { nested: 'object' } }] },
+    ]) {
+      const parsed = backupCommandResultSchema.safeParse({
+        snapshotId: 'snap-1',
+        bytesBackedUp: 42,
+        vssMetadata,
+      });
+      expect(parsed.success).toBe(true);
+      // The fields that matter still survive.
+      expect(parsed.success && parsed.data.snapshotId).toBe('snap-1');
+      expect(parsed.success && parsed.data.bytesBackedUp).toBe(42);
+    }
+  });
+
+  it('leaves vssMetadata undefined for a non-Windows / VSS-disabled run', () => {
+    const parsed = backupCommandResultSchema.parse({ snapshotId: 'snap-1', filesBackedUp: 3 });
+    expect(parsed.vssMetadata).toBeUndefined();
+  });
+});

--- a/apps/api/src/routes/backup/resultSchemas.ts
+++ b/apps/api/src/routes/backup/resultSchemas.ts
@@ -76,6 +76,26 @@ export const backupCommandResultSchema = z.object({
   referencedFiles: z.number().int().nonnegative().optional(),
   backupType: z.enum(['file', 'system_image', 'database', 'application']).optional(),
   systemStateManifest: backupSystemStateManifestResultSchema.optional(),
+  // Windows VSS diagnostics (#3027), persisted to backup_jobs.vss_metadata.
+  // Absent on non-Windows, on a run with VSS disabled, and on any run whose VSS
+  // session failed to start outright — so absence is NOT evidence of a clean
+  // snapshot. Shape as the agent emits it (vss.VSSMetadata, agent/internal/
+  // backup/vss/types.go):
+  //   { shadowCopyId, creationTime, writers: [{name,id,state,lastError}],
+  //     exposedPaths: {volume: shadowPath}, unprotectedVolumes: [volume],
+  //     warnings: [string], durationMs }
+  //
+  // DELIBERATELY `z.unknown()` rather than a modeled object. This field is pure
+  // diagnostics riding the SAME payload as the snapshot id, and this schema's
+  // parse outcome decides whether the whole run is recorded completed or failed
+  // (`result.status === 'completed' && parsedBackup.success` in routes/agentWs.ts).
+  // A typed schema here would let one malformed diagnostics field fail a backup
+  // that actually succeeded — a strictly worse F13 than the one the manifest
+  // comment above describes, because it flips the job status rather than merely
+  // dropping a column. The shape is therefore validated, bounded and redacted
+  // one hop later, field by field, where a bad value can only cost the bad
+  // value: sanitizeVssMetadata in services/backupResultPersistence.ts.
+  vssMetadata: z.unknown().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
   snapshot: backupSnapshotResultSchema.optional(),
 });

--- a/apps/api/src/services/backupAgentContract.test.ts
+++ b/apps/api/src/services/backupAgentContract.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import { backupCommandResultSchema } from '../routes/backup/resultSchemas';
+import { sanitizeVssMetadata } from './backupResultPersistence';
 import {
   BACKUP_SNAPSHOT_ROOT_DIR,
   BACKUP_SNAPSHOT_MANIFEST_KEY,
@@ -144,5 +145,99 @@ describe('backup Go<->TS contract — result JSON round-trips through backupComm
     expect(parsed.errorCount).toBe(0);
     // 0 is distinct from undefined — pin the distinction explicitly.
     expect(parsed.referencedBytes).not.toBeUndefined();
+  });
+});
+
+describe('backup Go<->TS contract — VSS metadata (#3027)', () => {
+  it('the agent VSSMetadata struct still declares every field the API persists', () => {
+    // The API stores this blob field-by-field (sanitizeVssMetadata), so a json
+    // tag renamed on the Go side would silently start writing NULLs into the
+    // parts of vss_metadata the device tab reads. Pin the tags by source text.
+    const src = readRepoFile('agent/internal/backup/vss/types.go');
+    for (const tag of [
+      'shadowCopyId',
+      'creationTime',
+      'writers',
+      'exposedPaths',
+      'unprotectedVolumes',
+      'warnings',
+      'durationMs',
+    ]) {
+      expect(src).toMatch(new RegExp(`json:"${tag}(,omitempty)?"`));
+    }
+  });
+
+  it('backup.go copies UnprotectedVolumes into VSSMetadata — the field that says the snapshot is incomplete', () => {
+    // Regression: the struct literal copied five fields and omitted this one,
+    // so a run whose volumes got no shadow copy reached the server looking
+    // identical to a clean VSS backup. ExposedPaths cannot substitute — it
+    // lists what succeeded, never what was requested.
+    const src = readRepoFile('agent/internal/backup/backup.go');
+    expect(src).toMatch(/UnprotectedVolumes:\s*session\.UnprotectedVolumes/);
+  });
+
+  it('a Windows VSS result round-trips through the schema and the persistence sanitizer', () => {
+    // Exactly as Go's encoding/json emits vss.VSSMetadata on a run where one
+    // volume got no shadow copy and one writer failed — the #2999 shape.
+    const wireJson = JSON.stringify({
+      id: 'job-vss',
+      status: 'completed',
+      filesBackedUp: 10,
+      bytesBackedUp: 2048,
+      snapshot: { id: 'snap-vss' },
+      vssMetadata: {
+        shadowCopyId: '{11111111-2222-3333-4444-555555555555}',
+        creationTime: '2026-08-02T00:00:00Z',
+        writers: [
+          { name: 'SqlServerWriter', id: '{a}', state: 'stable' },
+          { name: 'NTDS', id: '{b}', state: 'failed', lastError: 'writer timed out' },
+        ],
+        exposedPaths: { 'C:\\': '\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1' },
+        unprotectedVolumes: ['D:\\'],
+        warnings: ['volume D:\\ has no shadow copy (0x80042308) — it will be read LIVE'],
+        durationMs: 3120,
+      },
+    });
+
+    const parsed = backupCommandResultSchema.parse(JSON.parse(wireJson));
+    // The snapshot identity must survive alongside the diagnostics.
+    expect(parsed.snapshot?.id).toBe('snap-vss');
+
+    const persisted = sanitizeVssMetadata(parsed.vssMetadata) as Record<string, unknown>;
+    expect(persisted.shadowCopyId).toBe('{11111111-2222-3333-4444-555555555555}');
+    expect(persisted.unprotectedVolumes).toEqual(['D:\\']);
+    expect(persisted.writers).toEqual([
+      { name: 'SqlServerWriter', id: '{a}', state: 'stable' },
+      { name: 'NTDS', id: '{b}', state: 'failed', lastError: 'writer timed out' },
+    ]);
+    expect(persisted.exposedPaths).toEqual({
+      'C:\\': '\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1',
+    });
+    expect(persisted.warnings).toEqual([
+      'volume D:\\ has no shadow copy (0x80042308) — it will be read LIVE',
+    ]);
+    expect(persisted.durationMs).toBe(3120);
+  });
+
+  it('omitempty drops unprotectedVolumes/warnings on a clean run and the sanitizer keeps them absent', () => {
+    const parsed = backupCommandResultSchema.parse(JSON.parse(JSON.stringify({
+      status: 'completed',
+      snapshot: { id: 'snap-clean' },
+      vssMetadata: {
+        shadowCopyId: 'set-clean',
+        creationTime: '2026-08-02T00:00:00Z',
+        writers: [{ name: 'SqlServerWriter', id: '{a}', state: 'stable' }],
+        exposedPaths: { 'C:\\': '\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1' },
+        durationMs: 900,
+      },
+    })));
+
+    const persisted = sanitizeVssMetadata(parsed.vssMetadata) as Record<string, unknown>;
+    // Absent, not empty-array: the UI's "is this snapshot incomplete" check is
+    // a length test, and a fabricated [] would read the same — but a fabricated
+    // warnings [] would make an oversize-truncation note indistinguishable from
+    // a clean run.
+    expect(persisted.unprotectedVolumes).toBeUndefined();
+    expect(persisted.warnings).toBeUndefined();
   });
 });

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -99,6 +99,7 @@ import { db } from '../db';
 import {
   applyBackupCommandResultToJob,
   markBackupJobFailedIfInFlight,
+  sanitizeVssMetadata,
 } from './backupResultPersistence';
 import {
   applyGfsTagsToSnapshot,
@@ -945,5 +946,202 @@ describe('partial backup terminal status (#3000)', () => {
 
     expect(setArgs()).toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
     expect(db.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('VSS metadata persistence (#3027)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    resolveBackupProtectionForDeviceMock.mockReset();
+  });
+
+  function mockSuccessPath() {
+    vi.mocked(db.update)
+      .mockReturnValueOnce(chainMock([{ id: 'job-1', configId: 'config-1', backupType: 'file', backupMode: 'file' }]) as any)
+      .mockReturnValueOnce(chainMock([]) as any)
+      .mockReturnValueOnce(chainMock([]) as any);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(chainMock([]) as any)
+      .mockReturnValueOnce(chainMock([{ featureLinkId: null, policyId: null, deviceId: 'device-1' }]) as any);
+    vi.mocked(db.insert).mockReturnValueOnce(chainMock([{
+      id: 'snapshot-db-1',
+      jobId: 'job-1',
+      snapshotId: 'provider-snap-1',
+    }]) as any);
+    vi.mocked(applyGfsTagsToSnapshot).mockResolvedValue({ daily: true });
+    vi.mocked(resolveGfsConfigForJob).mockResolvedValue(null);
+    vi.mocked(computeExpiresAt).mockReturnValue(null);
+  }
+
+  function setArgs() {
+    return vi.mocked(db.update).mock.results[0]?.value?.set;
+  }
+
+  it('writes vss_metadata on a SUCCESSFUL run — a green job whose volumes were read live is the whole point', async () => {
+    mockSuccessPath();
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'completed',
+      result: {
+        snapshotId: 'provider-snap-1',
+        filesBackedUp: 4,
+        vssMetadata: {
+          shadowCopyId: 'set-1',
+          writers: [{ name: 'NTDS', id: 'w-1', state: 'failed', lastError: 'timed out' }],
+          unprotectedVolumes: ['D:\\'],
+          durationMs: 900,
+        },
+      } as any,
+    });
+
+    expect(setArgs()).toHaveBeenCalledWith(expect.objectContaining({
+      vssMetadata: expect.objectContaining({
+        shadowCopyId: 'set-1',
+        unprotectedVolumes: ['D:\\'],
+        writers: [{ name: 'NTDS', id: 'w-1', state: 'failed', lastError: 'timed out' }],
+      }),
+    }));
+  });
+
+  it('writes vss_metadata on a FAILED run too — writer state is what explains the failure', async () => {
+    vi.mocked(db.update).mockReturnValueOnce(chainMock([{ id: 'job-1', configId: 'config-1' }]) as any);
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'failed',
+      result: {
+        error: 'snapshot creation failed',
+        vssMetadata: { shadowCopyId: 'set-2', writers: [{ name: 'SqlServerWriter', state: 'failed' }] },
+      } as any,
+    });
+
+    expect(setArgs()).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      vssMetadata: expect.objectContaining({ shadowCopyId: 'set-2' }),
+    }));
+  });
+
+  it('leaves the column untouched for a legacy agent that reports no vssMetadata', async () => {
+    mockSuccessPath();
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'completed',
+      result: { snapshotId: 'provider-snap-1', filesBackedUp: 4 } as any,
+    });
+
+    // NOT `vssMetadata: null` — overwriting a previously-recorded blob with NULL
+    // on a retry would destroy the diagnostics we are here to keep.
+    expect(setArgs()).toHaveBeenCalledWith(
+      expect.not.objectContaining({ vssMetadata: expect.anything() }),
+    );
+  });
+});
+
+describe('sanitizeVssMetadata (#3027)', () => {
+  it('returns undefined for absent / non-object input so the column is not written', () => {
+    expect(sanitizeVssMetadata(undefined)).toBeUndefined();
+    expect(sanitizeVssMetadata(null)).toBeUndefined();
+    expect(sanitizeVssMetadata([] as any)).toBeUndefined();
+  });
+
+  it('keeps the modeled fields verbatim when the payload is ordinary', () => {
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      creationTime: '2026-08-02T00:00:00Z',
+      writers: [{ name: 'NTDS', id: 'w-1', state: 'stable' }],
+      exposedPaths: { 'C:\\': '\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1' },
+      unprotectedVolumes: ['D:\\'],
+      warnings: ['volume D:\\ has no shadow copy'],
+      durationMs: 4200,
+    } as any);
+
+    expect(sanitized).toEqual({
+      shadowCopyId: 'set-1',
+      creationTime: '2026-08-02T00:00:00Z',
+      writers: [{ name: 'NTDS', id: 'w-1', state: 'stable' }],
+      exposedPaths: { 'C:\\': '\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1' },
+      unprotectedVolumes: ['D:\\'],
+      warnings: ['volume D:\\ has no shadow copy'],
+      durationMs: 4200,
+    });
+  });
+
+  it('keeps an unmodeled SCALAR but drops an unmodeled CONTAINER', () => {
+    // Same rule the agent's own IPC bounding uses (reduceToScalars): a future
+    // agent field stays forward-compatible without reopening the unbounded hole.
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      providerVersion: '10.0.0',
+      snapshotAttempts: 3,
+      hugeFutureBlob: Array.from({ length: 10 }, (_, i) => `entry-${i}`),
+    } as any) as Record<string, unknown>;
+
+    expect(sanitized.providerVersion).toBe('10.0.0');
+    expect(sanitized.snapshotAttempts).toBe(3);
+    expect(sanitized.hugeFutureBlob).toBeUndefined();
+  });
+
+  it('caps oversized arrays and NAMES what it dropped in warnings', () => {
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      writers: Array.from({ length: 500 }, (_, i) => ({ name: `w-${i}`, state: 'stable' })),
+      unprotectedVolumes: Array.from({ length: 500 }, (_, i) => `V${i}:\\`),
+    } as any) as Record<string, unknown>;
+
+    expect((sanitized.writers as unknown[]).length).toBe(200);
+    expect((sanitized.unprotectedVolumes as unknown[]).length).toBe(200);
+    // Truncation is never silent.
+    expect(sanitized.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('300 additional VSS writer entries were dropped'),
+      expect.stringContaining('300 additional unprotected-volume entries were dropped'),
+    ]));
+  });
+
+  it('drops the bulk containers but KEEPS unprotectedVolumes when the blob is still oversize', async () => {
+    // 200 writers each carrying a max-length lastError blows the byte budget.
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      writers: Array.from({ length: 200 }, (_, i) => ({
+        name: `w-${i}`,
+        state: 'failed',
+        lastError: 'x'.repeat(1024),
+      })),
+      unprotectedVolumes: ['D:\\'],
+    } as any) as Record<string, unknown>;
+
+    expect(sanitized.writers).toBeUndefined();
+    expect(sanitized.exposedPaths).toBeUndefined();
+    // The field that actually says "this snapshot is incomplete" survives.
+    expect(sanitized.unprotectedVolumes).toEqual(['D:\\']);
+    expect(sanitized.shadowCopyId).toBe('set-1');
+    expect(sanitized.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('exceeded the size limit'),
+    ]));
+  });
+
+  it('truncates a pathologically long string rather than storing it', () => {
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'z'.repeat(50_000),
+    } as any) as Record<string, unknown>;
+
+    expect((sanitized.shadowCopyId as string).length).toBeLessThan(1_200);
+    expect(sanitized.shadowCopyId).toContain('[truncated]');
+  });
+
+  it('redacts a secret an agent leaked into a VSS warning', () => {
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      warnings: ['writer failed: -----BEGIN RSA PRIVATE KEY-----\nMIIabc\n-----END RSA PRIVATE KEY-----'],
+    } as any) as Record<string, unknown>;
+
+    expect(JSON.stringify(sanitized)).not.toContain('MIIabc');
   });
 });

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -1043,6 +1043,84 @@ describe('VSS metadata persistence (#3027)', () => {
       expect.not.objectContaining({ vssMetadata: expect.anything() }),
     );
   });
+
+  it('escalates when an agent sends an UNUSABLE vssMetadata instead of dropping it silently', async () => {
+    // `z.unknown()` at both boundaries means nothing upstream rejects garbage —
+    // correct, but absent and present-but-broken must not look identical, or a
+    // fleet-wide agent regression that malformed this field is invisible forever.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockSuccessPath();
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'completed',
+      result: { snapshotId: 'provider-snap-1', vssMetadata: 'not-an-object' } as any,
+    });
+
+    expect(setArgs()).toHaveBeenCalledWith(
+      expect.not.objectContaining({ vssMetadata: expect.anything() }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unusable vssMetadata'));
+    expect(captureExceptionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('unusable vssMetadata') }),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('keeps the degradation warning alongside the failure reason in errorLog', async () => {
+    // A total VSS failure produces NO vssMetadata, so job.Warning is its only
+    // channel. The old `error ?? warning` chain always picked `error` (which is
+    // set on every failure path), so the note explaining WHY the run was
+    // degraded never reached the UI.
+    vi.mocked(db.update).mockReturnValueOnce(chainMock([{ id: 'job-1', configId: 'config-1' }]) as any);
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'failed',
+      result: {
+        error: 'upload destination unreachable',
+        warning: 'VSS shadow copy could not be created, so every path was read from the live volume',
+      } as any,
+    });
+
+    const errorLog = vi.mocked(db.update).mock.results[0]?.value?.set.mock.calls[0][0].errorLog as string;
+    expect(errorLog).toContain('upload destination unreachable');
+    expect(errorLog).toContain('read from the live volume');
+  });
+
+  it('does not duplicate the text when error and warning are identical', async () => {
+    vi.mocked(db.update).mockReturnValueOnce(chainMock([{ id: 'job-1', configId: 'config-1' }]) as any);
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'failed',
+      result: { error: 'disk full', warning: 'disk full' } as any,
+    });
+
+    const errorLog = vi.mocked(db.update).mock.results[0]?.value?.set.mock.calls[0][0].errorLog as string;
+    expect(errorLog).toBe('disk full');
+  });
+
+  it('still falls back to the warning alone when there is no error text', async () => {
+    vi.mocked(db.update).mockReturnValueOnce(chainMock([{ id: 'job-1', configId: 'config-1' }]) as any);
+
+    await applyBackupCommandResultToJob({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      resultStatus: 'failed',
+      result: { warning: 'VSS shadow copy could not be created' } as any,
+    });
+
+    const errorLog = vi.mocked(db.update).mock.results[0]?.value?.set.mock.calls[0][0].errorLog as string;
+    expect(errorLog).toBe('VSS shadow copy could not be created');
+  });
 });
 
 describe('sanitizeVssMetadata (#3027)', () => {
@@ -1074,19 +1152,26 @@ describe('sanitizeVssMetadata (#3027)', () => {
     });
   });
 
-  it('keeps an unmodeled SCALAR but drops an unmodeled CONTAINER', () => {
+  it('keeps an unmodeled SCALAR, drops an unmodeled CONTAINER, and NAMES the drop', () => {
     // Same rule the agent's own IPC bounding uses (reduceToScalars): a future
     // agent field stays forward-compatible without reopening the unbounded hole.
+    // Naming it matters — otherwise a new agent field appears to work in dev
+    // (where you read the agent log) and silently does nothing in production.
     const sanitized = sanitizeVssMetadata({
       shadowCopyId: 'set-1',
       providerVersion: '10.0.0',
       snapshotAttempts: 3,
       hugeFutureBlob: Array.from({ length: 10 }, (_, i) => `entry-${i}`),
+      futureObject: { a: 1 },
     } as any) as Record<string, unknown>;
 
     expect(sanitized.providerVersion).toBe('10.0.0');
     expect(sanitized.snapshotAttempts).toBe(3);
     expect(sanitized.hugeFutureBlob).toBeUndefined();
+    expect(sanitized.futureObject).toBeUndefined();
+    expect(sanitized.warnings).toEqual([
+      'unmodeled VSS field(s) dropped: futureObject, hugeFutureBlob',
+    ]);
   });
 
   it('caps oversized arrays and NAMES what it dropped in warnings', () => {
@@ -1096,25 +1181,85 @@ describe('sanitizeVssMetadata (#3027)', () => {
       unprotectedVolumes: Array.from({ length: 500 }, (_, i) => `V${i}:\\`),
     } as any) as Record<string, unknown>;
 
-    expect((sanitized.writers as unknown[]).length).toBe(200);
-    expect((sanitized.unprotectedVolumes as unknown[]).length).toBe(200);
+    expect((sanitized.writers as unknown[]).length).toBe(24);
+    expect((sanitized.unprotectedVolumes as unknown[]).length).toBe(24);
     // Truncation is never silent.
     expect(sanitized.warnings).toEqual(expect.arrayContaining([
-      expect.stringContaining('300 additional VSS writer entries were dropped'),
-      expect.stringContaining('300 additional unprotected-volume entries were dropped'),
+      expect.stringContaining('476 additional VSS writer entries were dropped'),
+      expect.stringContaining('476 additional unprotected-volume entries were dropped'),
     ]));
   });
 
-  it('drops the bulk containers but KEEPS unprotectedVolumes when the blob is still oversize', async () => {
-    // 200 writers each carrying a max-length lastError blows the byte budget.
+  it('NAMES ill-typed unprotectedVolumes rather than silently reporting a clean snapshot', () => {
+    // The nastiest regression this function can cause: a future agent sends
+    // [{volume:'D:\\'}], the filter reduces it to [], the UI's length check
+    // reads "no unprotected volumes", and a degraded snapshot presents as
+    // clean — #3027's exact failure mode one layer up.
     const sanitized = sanitizeVssMetadata({
       shadowCopyId: 'set-1',
-      writers: Array.from({ length: 200 }, (_, i) => ({
+      unprotectedVolumes: [{ volume: 'D:\\' }, { volume: 'E:\\' }],
+    } as any) as Record<string, unknown>;
+
+    expect(sanitized.unprotectedVolumes).toEqual([]);
+    expect(sanitized.warnings).toEqual([
+      expect.stringContaining('2 unprotected-volume entries were dropped: not strings'),
+    ]);
+    expect(String((sanitized.warnings as string[])[0])).toContain('may have read volumes live');
+  });
+
+  it('NAMES a non-list unprotectedVolumes / writers instead of dropping them quietly', () => {
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      unprotectedVolumes: 'D:\\',
+      writers: 'SqlServerWriter',
+    } as any) as Record<string, unknown>;
+
+    expect(sanitized.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('unprotected-volume detail was dropped'),
+      expect.stringContaining('VSS writer detail was dropped'),
+    ]));
+  });
+
+  it('NAMES ill-typed writer and shadow-path entries', () => {
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      writers: ['SqlServerWriter', 'NTDS', { name: 'Registry', state: 'stable' }],
+      exposedPaths: { 'C:\\': '\\\\?\\GLOBALROOT\\x', 'D:\\': 42 },
+    } as any) as Record<string, unknown>;
+
+    expect((sanitized.writers as unknown[]).length).toBe(1);
+    expect(sanitized.exposedPaths).toEqual({ 'C:\\': '\\\\?\\GLOBALROOT\\x' });
+    expect(sanitized.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('2 VSS writer entries were dropped: not objects'),
+      expect.stringContaining('1 shadow-path entries were dropped: not strings'),
+    ]));
+  });
+
+  it('keeps a scalar `warnings` string instead of erasing it', () => {
+    // It used to be copied by the unmodeled-scalar pass and then deleted by the
+    // warnings merge — the text was not ignored, it was destroyed.
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      warnings: 'volume D:\\ has no shadow copy',
+    } as any) as Record<string, unknown>;
+
+    expect(sanitized.warnings).toEqual(['volume D:\\ has no shadow copy']);
+  });
+
+  it('drops the bulk containers but KEEPS unprotectedVolumes when the blob is still oversize', async () => {
+    // Writers each carrying a max-length lastError blows the byte budget.
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      writers: Array.from({ length: 24 }, (_, i) => ({
         name: `w-${i}`,
         state: 'failed',
         lastError: 'x'.repeat(1024),
       })),
+      exposedPaths: Object.fromEntries(
+        Array.from({ length: 24 }, (_, i) => [`V${i}:\\`, 'y'.repeat(1024)]),
+      ),
       unprotectedVolumes: ['D:\\'],
+      warnings: Array.from({ length: 24 }, () => 'z'.repeat(1024)),
     } as any) as Record<string, unknown>;
 
     expect(sanitized.writers).toBeUndefined();
@@ -1125,6 +1270,38 @@ describe('sanitizeVssMetadata (#3027)', () => {
     expect(sanitized.warnings).toEqual(expect.arrayContaining([
       expect.stringContaining('exceeded the size limit'),
     ]));
+  });
+
+  it('measures the size cap in BYTES, not UTF-16 code units', () => {
+    // A multi-byte payload that is comfortably under the cap by `String.length`
+    // but over it in actual jsonb bytes must still be bounded. Each emoji is
+    // 4 UTF-8 bytes but 2 UTF-16 units.
+    const sanitized = sanitizeVssMetadata({
+      shadowCopyId: 'set-1',
+      writers: Array.from({ length: 24 }, (_, i) => ({
+        name: `w-${i}`,
+        lastError: '🔥'.repeat(512),
+      })),
+      exposedPaths: Object.fromEntries(
+        Array.from({ length: 24 }, (_, i) => [`V${i}:\\`, '🔥'.repeat(512)]),
+      ),
+      unprotectedVolumes: Array.from({ length: 24 }, () => '🔥'.repeat(512)),
+      warnings: Array.from({ length: 24 }, () => '🔥'.repeat(512)),
+    } as any);
+
+    expect(Buffer.byteLength(JSON.stringify(sanitized), 'utf8')).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  it('keeps a bounded unprotectedVolumes even in the pathological last-resort tier', () => {
+    // Discarding it is the one loss that turns a degraded snapshot back into a
+    // clean-looking one, so even the last resort must not.
+    const sanitized = sanitizeVssMetadata({
+      unprotectedVolumes: Array.from({ length: 24 }, () => '🔥'.repeat(512)),
+      warnings: Array.from({ length: 24 }, () => '🔥'.repeat(512)),
+    } as any) as Record<string, unknown>;
+
+    expect(Array.isArray(sanitized.unprotectedVolumes)).toBe(true);
+    expect((sanitized.unprotectedVolumes as unknown[]).length).toBeGreaterThan(0);
   });
 
   it('truncates a pathologically long string rather than storing it', () => {

--- a/apps/api/src/services/backupResultPersistence.test.ts
+++ b/apps/api/src/services/backupResultPersistence.test.ts
@@ -1321,4 +1321,17 @@ describe('sanitizeVssMetadata (#3027)', () => {
 
     expect(JSON.stringify(sanitized)).not.toContain('MIIabc');
   });
+
+  it('redacts on the pathological tier too — every exit must be redacted', () => {
+    // This tier reads fields off the pre-redaction working object, so it is the
+    // one path that could persist agent text raw. A guarantee with an exception
+    // is not a guarantee.
+    const leaked = '-----BEGIN RSA PRIVATE KEY-----\nMIIsecret\n-----END RSA PRIVATE KEY-----';
+    const sanitized = sanitizeVssMetadata({
+      unprotectedVolumes: [leaked, ...Array.from({ length: 23 }, () => '🔥'.repeat(512))],
+      warnings: Array.from({ length: 24 }, () => '🔥'.repeat(512)),
+    } as any) as Record<string, unknown>;
+
+    expect(JSON.stringify(sanitized)).not.toContain('MIIsecret');
+  });
 });

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -72,8 +72,22 @@ function normalizeMetadata(
  * truncating it is strictly better than storing it.
  */
 const MAX_VSS_METADATA_BYTES = 64 * 1024;
-const MAX_VSS_ARRAY_ENTRIES = 200;
 const MAX_VSS_STRING_LENGTH = 1024;
+/**
+ * Deliberately small enough that the two string arrays cannot, together, blow
+ * the total budget: 2 × 24 × (1024 + overhead) stays well under 64 KiB. An
+ * earlier 200 let `unprotectedVolumes` alone reach ~205 KB, which forced the
+ * pathological tier and threw away the very field the tier above it exists to
+ * preserve. 24 is also far more than any real machine reports — a box with 24
+ * unprotected volumes has a bigger problem than a truncated list.
+ */
+const MAX_VSS_ARRAY_ENTRIES = 24;
+
+/** Actual jsonb cost. `String.length` counts UTF-16 code units, so a non-ASCII
+ *  volume label or writer name can be 3× its length in bytes. */
+function jsonByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value) ?? '', 'utf8');
+}
 
 function boundVssString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -82,7 +96,19 @@ function boundVssString(value: unknown): string | undefined {
     : value;
 }
 
-function boundVssStringArray(value: unknown): { entries: string[]; dropped: number } | undefined {
+/**
+ * Bound a string array, reporting BOTH loss modes separately: entries past the
+ * cap, and entries removed because they were not strings.
+ *
+ * The second is the one that matters. `unprotectedVolumes: [{volume:'D:\\'}]`
+ * from a future or buggy agent would otherwise reduce to `[]`, the UI's
+ * `length > 0` check would read "no unprotected volumes", and a degraded
+ * snapshot would present as clean — #3027's exact failure mode, reintroduced a
+ * layer up. Silence is the bug; a note is the fix.
+ */
+function boundVssStringArray(
+  value: unknown,
+): { entries: string[]; dropped: number; illTyped: number } | undefined {
   if (!Array.isArray(value)) return undefined;
   const strings = value.filter((entry): entry is string => typeof entry === 'string');
   return {
@@ -90,6 +116,7 @@ function boundVssStringArray(value: unknown): { entries: string[]; dropped: numb
       .slice(0, MAX_VSS_ARRAY_ENTRIES)
       .map((entry) => boundVssString(entry) as string),
     dropped: Math.max(0, strings.length - MAX_VSS_ARRAY_ENTRIES),
+    illTyped: value.length - strings.length,
   };
 }
 
@@ -99,16 +126,22 @@ function boundVssStringArray(value: unknown): { entries: string[]; dropped: numb
  * a legacy agent (which omits the field entirely) leaves the column untouched
  * rather than overwriting a previously-recorded value with NULL.
  *
- * Rebuilt field-by-field rather than stored verbatim: the zod schema is
- * `.passthrough()`, and passing an arbitrary agent-authored object straight
- * into jsonb would hand back the unbounded surface the caps exist to remove.
- * Unmodeled TOP-LEVEL keys survive only when scalar — the same "keep scalars,
- * drop containers" rule the agent's own IPC bounding uses
- * (`reduceToScalars`, agent/cmd/breeze-backup/result_bounds.go), so a future
- * agent field is forward-compatible without reopening the hole.
+ * Rebuilt field-by-field rather than stored verbatim: the field arrives as
+ * `z.unknown()` at both validation boundaries (deliberately — see the schema
+ * comments), so nothing upstream has constrained its shape or size at all.
+ * Handing an arbitrary agent-authored object straight to jsonb would persist
+ * exactly the unbounded surface these caps exist to remove.
  *
- * Truncation is never silent: whatever is dropped is named in the persisted
- * `warnings` array, which is what the UI renders.
+ * Unmodeled TOP-LEVEL keys survive only when scalar — the same "keep scalars,
+ * drop containers" rule the agent's own IPC bounding uses (`reduceToScalars`,
+ * agent/cmd/breeze-backup/result_bounds.go), so a future agent field is
+ * forward-compatible without reopening the hole.
+ *
+ * NOTHING IS DROPPED SILENTLY. Every loss — count caps, type mismatches,
+ * unmodeled containers, size tiers — is named in the persisted `warnings`
+ * array, which the UI renders. That is not tidiness: this whole issue exists
+ * because a degraded backup reached the server looking clean, and a sanitizer
+ * that quietly reduces `unprotectedVolumes` to `[]` would recreate it here.
  */
 export function sanitizeVssMetadata(
   raw: ParsedBackupCommandResult['vssMetadata'],
@@ -118,21 +151,37 @@ export function sanitizeVssMetadata(
   const source = raw as Record<string, unknown>;
   const notes: string[] = [];
   const out: Record<string, unknown> = {};
+  const MODELED_KEYS = new Set([
+    'shadowCopyId', 'creationTime', 'writers', 'exposedPaths',
+    'unprotectedVolumes', 'warnings', 'durationMs',
+  ]);
 
-  // Unmodeled scalars first so a modeled key always wins the assignment below.
+  // Unmodeled scalars are kept; unmodeled containers are dropped — but NAMED,
+  // so a new agent field that silently does nothing in production is findable
+  // instead of a mystery. Modeled keys are handled below and skipped here so a
+  // modeled key can never be shadowed by this pass.
+  const droppedContainers: string[] = [];
   for (const [key, value] of Object.entries(source)) {
+    if (MODELED_KEYS.has(key)) continue;
     if (value === null || typeof value === 'boolean' || typeof value === 'number') {
       out[key] = value;
     } else if (typeof value === 'string') {
       out[key] = boundVssString(value);
+    } else if (value !== undefined) {
+      droppedContainers.push(key);
     }
+  }
+  if (droppedContainers.length > 0) {
+    notes.push(`unmodeled VSS field(s) dropped: ${droppedContainers.sort().join(', ')}`);
   }
 
   const shadowCopyId = boundVssString(source.shadowCopyId);
   if (shadowCopyId !== undefined) out.shadowCopyId = shadowCopyId;
   const creationTime = boundVssString(source.creationTime);
   if (creationTime !== undefined) out.creationTime = creationTime;
-  if (typeof source.durationMs === 'number') out.durationMs = source.durationMs;
+  if (typeof source.durationMs === 'number' && Number.isFinite(source.durationMs)) {
+    out.durationMs = source.durationMs;
+  }
 
   if (Array.isArray(source.writers)) {
     const writers = source.writers.filter(
@@ -150,6 +199,11 @@ export function sanitizeVssMetadata(
     if (writers.length > MAX_VSS_ARRAY_ENTRIES) {
       notes.push(`${writers.length - MAX_VSS_ARRAY_ENTRIES} additional VSS writer entries were dropped`);
     }
+    if (source.writers.length > writers.length) {
+      notes.push(`${source.writers.length - writers.length} VSS writer entries were dropped: not objects`);
+    }
+  } else if (source.writers !== undefined && source.writers !== null) {
+    notes.push('VSS writer detail was dropped: the agent did not report it as a list');
   }
 
   const unprotected = boundVssStringArray(source.unprotectedVolumes);
@@ -158,24 +212,43 @@ export function sanitizeVssMetadata(
     if (unprotected.dropped > 0) {
       notes.push(`${unprotected.dropped} additional unprotected-volume entries were dropped`);
     }
+    if (unprotected.illTyped > 0) {
+      // Load-bearing: an empty unprotectedVolumes reads as "clean snapshot".
+      notes.push(`${unprotected.illTyped} unprotected-volume entries were dropped: not strings — this run may have read volumes live`);
+    }
+  } else if (source.unprotectedVolumes !== undefined && source.unprotectedVolumes !== null) {
+    notes.push('unprotected-volume detail was dropped: the agent did not report it as a list — this run may have read volumes live');
   }
 
   if (source.exposedPaths && typeof source.exposedPaths === 'object' && !Array.isArray(source.exposedPaths)) {
-    const entries = Object.entries(source.exposedPaths as Record<string, unknown>).filter(
-      (entry): entry is [string, string] => typeof entry[1] === 'string',
-    );
+    const all = Object.entries(source.exposedPaths as Record<string, unknown>);
+    const entries = all.filter((entry): entry is [string, string] => typeof entry[1] === 'string');
     out.exposedPaths = Object.fromEntries(
       entries.slice(0, MAX_VSS_ARRAY_ENTRIES).map(([volume, path]) => [volume, boundVssString(path) as string]),
     );
     if (entries.length > MAX_VSS_ARRAY_ENTRIES) {
       notes.push(`${entries.length - MAX_VSS_ARRAY_ENTRIES} additional shadow-path entries were dropped`);
     }
+    if (all.length > entries.length) {
+      notes.push(`${all.length - entries.length} shadow-path entries were dropped: not strings`);
+    }
   }
 
   const warnings = boundVssStringArray(source.warnings);
   const warningEntries = warnings ? [...warnings.entries] : [];
-  if (warnings && warnings.dropped > 0) {
-    notes.push(`${warnings.dropped} additional VSS warnings were dropped`);
+  if (warnings) {
+    if (warnings.dropped > 0) {
+      notes.push(`${warnings.dropped} additional VSS warnings were dropped`);
+    }
+    if (warnings.illTyped > 0) {
+      notes.push(`${warnings.illTyped} VSS warnings were dropped: not strings`);
+    }
+  } else if (typeof source.warnings === 'string') {
+    // A scalar `warnings` used to be copied by the unmodeled-scalar pass and
+    // then ERASED by finish()'s delete. Keep the text — it is a warning.
+    warningEntries.push(boundVssString(source.warnings) as string);
+  } else if (source.warnings !== undefined && source.warnings !== null) {
+    notes.push('VSS warning text was dropped: the agent did not report it as a list');
   }
 
   const finish = (extraNotes: string[]): Record<string, unknown> => {
@@ -186,7 +259,7 @@ export function sanitizeVssMetadata(
   };
 
   let result = finish([]);
-  if (JSON.stringify(result).length <= MAX_VSS_METADATA_BYTES) return result;
+  if (jsonByteLength(result) <= MAX_VSS_METADATA_BYTES) return result;
 
   // Still oversize: drop the bulk containers, keeping the scalars and the
   // unprotected-volume list (the field that actually says "this snapshot is
@@ -194,11 +267,17 @@ export function sanitizeVssMetadata(
   delete out.writers;
   delete out.exposedPaths;
   result = finish(['VSS writer and shadow-path detail was dropped: the reported metadata exceeded the size limit']);
-  if (JSON.stringify(result).length <= MAX_VSS_METADATA_BYTES) return result;
+  if (jsonByteLength(result) <= MAX_VSS_METADATA_BYTES) return result;
 
-  // Pathological. Keep a marker rather than persisting nothing: "the agent
-  // reported unusable VSS metadata" is itself a finding.
+  // Pathological — only reachable if the caps above were somehow not enough.
+  // Even here, keep `unprotectedVolumes`: discarding it is the one loss that
+  // turns a degraded snapshot back into a clean-looking one, which is the
+  // entire bug class this function guards.
+  const survivingVolumes = Array.isArray(out.unprotectedVolumes)
+    ? (out.unprotectedVolumes as string[]).slice(0, MAX_VSS_ARRAY_ENTRIES)
+    : [];
   return {
+    ...(survivingVolumes.length > 0 ? { unprotectedVolumes: survivingVolumes } : {}),
     warnings: ['VSS metadata was discarded: the reported payload exceeded the size limit'],
   };
 }
@@ -683,7 +762,20 @@ export async function applyBackupCommandResultToJob(params: {
     }
   } else {
     updateData.status = terminalStatus;
-    updateData.errorLog = redactSecretsFromOutput(result.error ?? result.warning ?? 'Unknown error');
+    // Both, not either. `error` is the failure reason; `warning` is the run's
+    // degradation note — on a Windows run that is where "VSS shadow copy could
+    // not be created, every path was read live" lives, and there is no
+    // vssMetadata on that branch to carry it instead. The old `??` chain always
+    // picked `error` (it is populated on every failure path) and discarded the
+    // warning entirely, so the one diagnostic explaining WHY the run was
+    // degraded never reached the UI.
+    const failureParts = [result.error, result.warning].filter(
+      (part): part is string => typeof part === 'string' && part.length > 0
+    );
+    updateData.errorLog = redactSecretsFromOutput(
+      // Dedupe: some paths route the same text to both fields.
+      [...new Set(failureParts)].join('; ') || 'Unknown error'
+    );
     if (result.backupType) {
       updateData.backupType = result.backupType;
     }
@@ -704,6 +796,17 @@ export async function applyBackupCommandResultToJob(params: {
   const vssMetadata = sanitizeVssMetadata(result.vssMetadata);
   if (vssMetadata !== undefined) {
     updateData.vssMetadata = vssMetadata;
+  } else if (result.vssMetadata !== undefined && result.vssMetadata !== null) {
+    // The agent sent SOMETHING and it was unusable (a bare string, a number, an
+    // array). `z.unknown()` at both boundaries means nothing upstream rejected
+    // it, which is correct — but absent and present-but-broken must not look
+    // identical, or a fleet-wide agent regression that malformed this field is
+    // invisible forever. Same treatment as an unmodeled terminal status above.
+    const msg =
+      `[BackupPersistence] Agent sent unusable vssMetadata (${Array.isArray(result.vssMetadata) ? 'array' : typeof result.vssMetadata}) ` +
+      `for job ${jobId} (device ${deviceId}); VSS diagnostics discarded for this run.`;
+    console.warn(msg);
+    captureException(new Error(msg));
   }
 
   // FIX 7: a genuinely-successful backup whose result lands AFTER the stale

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -273,13 +273,19 @@ export function sanitizeVssMetadata(
   // Even here, keep `unprotectedVolumes`: discarding it is the one loss that
   // turns a degraded snapshot back into a clean-looking one, which is the
   // entire bug class this function guards.
+  //
+  // Redacted like every other return: `out` holds pre-redaction values (finish()
+  // returns a redacted COPY and leaves `out` untouched), so reading fields off it
+  // here without redacting would make this the one path that persists agent text
+  // raw. Every exit from this function must be redacted, or the guarantee is not
+  // a guarantee.
   const survivingVolumes = Array.isArray(out.unprotectedVolumes)
     ? (out.unprotectedVolumes as string[]).slice(0, MAX_VSS_ARRAY_ENTRIES)
     : [];
-  return {
+  return redactSecretsDeep({
     ...(survivingVolumes.length > 0 ? { unprotectedVolumes: survivingVolumes } : {}),
     warnings: ['VSS metadata was discarded: the reported payload exceeded the size limit'],
-  };
+  }) as Record<string, unknown>;
 }
 
 function resolveSnapshotEncryptionKeyId(metadata: Record<string, unknown>): string | null {

--- a/apps/api/src/services/backupResultPersistence.ts
+++ b/apps/api/src/services/backupResultPersistence.ts
@@ -23,7 +23,7 @@ import {
   checkBackupProviderCapabilities,
 } from './backupSnapshotStorage';
 import { resolveBackupProtectionForDevice } from './featureConfigResolver';
-import { redactSecretsFromOutput } from './secretRedaction';
+import { redactSecretsDeep, redactSecretsFromOutput } from './secretRedaction';
 
 type SnapshotImmutabilityEnforcement = 'application' | 'provider';
 
@@ -53,6 +53,154 @@ function normalizeMetadata(
   return metadata && typeof metadata === 'object' && !Array.isArray(metadata)
     ? { ...metadata }
     : {};
+}
+
+/**
+ * Bounds on the agent-supplied VSS diagnostics blob persisted to
+ * `backup_jobs.vss_metadata` (#3027).
+ *
+ * The result schema is deliberately permissive (an unmodeled field must never
+ * fail the parse and take the snapshot id down with it — the F13 lesson), so
+ * the bounding lives HERE, at the last hop before the column. It has to: the
+ * only ceiling on the way in is the 5 MB `stdout` cap in agentWs's
+ * `commandResultSchema`, which `backup_run` rides because it is not a
+ * "critical family" and so never reaches the 512 KB structured cap in
+ * `ensureCriticalResultSizeLimits`.
+ *
+ * Real-world size is tiny — a Windows box registers a few dozen VSS writers —
+ * so any result anywhere near these limits is a bug or a hostile agent, and
+ * truncating it is strictly better than storing it.
+ */
+const MAX_VSS_METADATA_BYTES = 64 * 1024;
+const MAX_VSS_ARRAY_ENTRIES = 200;
+const MAX_VSS_STRING_LENGTH = 1024;
+
+function boundVssString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return value.length > MAX_VSS_STRING_LENGTH
+    ? `${value.slice(0, MAX_VSS_STRING_LENGTH)}…[truncated]`
+    : value;
+}
+
+function boundVssStringArray(value: unknown): { entries: string[]; dropped: number } | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((entry): entry is string => typeof entry === 'string');
+  return {
+    entries: strings
+      .slice(0, MAX_VSS_ARRAY_ENTRIES)
+      .map((entry) => boundVssString(entry) as string),
+    dropped: Math.max(0, strings.length - MAX_VSS_ARRAY_ENTRIES),
+  };
+}
+
+/**
+ * Normalize + bound + redact the agent's `vssMetadata` before it becomes a
+ * jsonb column value. Returns `undefined` when there is nothing to persist, so
+ * a legacy agent (which omits the field entirely) leaves the column untouched
+ * rather than overwriting a previously-recorded value with NULL.
+ *
+ * Rebuilt field-by-field rather than stored verbatim: the zod schema is
+ * `.passthrough()`, and passing an arbitrary agent-authored object straight
+ * into jsonb would hand back the unbounded surface the caps exist to remove.
+ * Unmodeled TOP-LEVEL keys survive only when scalar — the same "keep scalars,
+ * drop containers" rule the agent's own IPC bounding uses
+ * (`reduceToScalars`, agent/cmd/breeze-backup/result_bounds.go), so a future
+ * agent field is forward-compatible without reopening the hole.
+ *
+ * Truncation is never silent: whatever is dropped is named in the persisted
+ * `warnings` array, which is what the UI renders.
+ */
+export function sanitizeVssMetadata(
+  raw: ParsedBackupCommandResult['vssMetadata'],
+): Record<string, unknown> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+
+  const source = raw as Record<string, unknown>;
+  const notes: string[] = [];
+  const out: Record<string, unknown> = {};
+
+  // Unmodeled scalars first so a modeled key always wins the assignment below.
+  for (const [key, value] of Object.entries(source)) {
+    if (value === null || typeof value === 'boolean' || typeof value === 'number') {
+      out[key] = value;
+    } else if (typeof value === 'string') {
+      out[key] = boundVssString(value);
+    }
+  }
+
+  const shadowCopyId = boundVssString(source.shadowCopyId);
+  if (shadowCopyId !== undefined) out.shadowCopyId = shadowCopyId;
+  const creationTime = boundVssString(source.creationTime);
+  if (creationTime !== undefined) out.creationTime = creationTime;
+  if (typeof source.durationMs === 'number') out.durationMs = source.durationMs;
+
+  if (Array.isArray(source.writers)) {
+    const writers = source.writers.filter(
+      (writer): writer is Record<string, unknown> =>
+        Boolean(writer) && typeof writer === 'object' && !Array.isArray(writer),
+    );
+    out.writers = writers.slice(0, MAX_VSS_ARRAY_ENTRIES).map((writer) => {
+      const bounded: Record<string, unknown> = {};
+      for (const field of ['name', 'id', 'state', 'lastError'] as const) {
+        const value = boundVssString(writer[field]);
+        if (value !== undefined) bounded[field] = value;
+      }
+      return bounded;
+    });
+    if (writers.length > MAX_VSS_ARRAY_ENTRIES) {
+      notes.push(`${writers.length - MAX_VSS_ARRAY_ENTRIES} additional VSS writer entries were dropped`);
+    }
+  }
+
+  const unprotected = boundVssStringArray(source.unprotectedVolumes);
+  if (unprotected) {
+    out.unprotectedVolumes = unprotected.entries;
+    if (unprotected.dropped > 0) {
+      notes.push(`${unprotected.dropped} additional unprotected-volume entries were dropped`);
+    }
+  }
+
+  if (source.exposedPaths && typeof source.exposedPaths === 'object' && !Array.isArray(source.exposedPaths)) {
+    const entries = Object.entries(source.exposedPaths as Record<string, unknown>).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    );
+    out.exposedPaths = Object.fromEntries(
+      entries.slice(0, MAX_VSS_ARRAY_ENTRIES).map(([volume, path]) => [volume, boundVssString(path) as string]),
+    );
+    if (entries.length > MAX_VSS_ARRAY_ENTRIES) {
+      notes.push(`${entries.length - MAX_VSS_ARRAY_ENTRIES} additional shadow-path entries were dropped`);
+    }
+  }
+
+  const warnings = boundVssStringArray(source.warnings);
+  const warningEntries = warnings ? [...warnings.entries] : [];
+  if (warnings && warnings.dropped > 0) {
+    notes.push(`${warnings.dropped} additional VSS warnings were dropped`);
+  }
+
+  const finish = (extraNotes: string[]): Record<string, unknown> => {
+    const combined = [...warningEntries, ...notes, ...extraNotes];
+    if (combined.length > 0) out.warnings = combined;
+    else delete out.warnings;
+    return redactSecretsDeep(out) as Record<string, unknown>;
+  };
+
+  let result = finish([]);
+  if (JSON.stringify(result).length <= MAX_VSS_METADATA_BYTES) return result;
+
+  // Still oversize: drop the bulk containers, keeping the scalars and the
+  // unprotected-volume list (the field that actually says "this snapshot is
+  // incomplete"). Mirrors the agent's tier-2 bulk-field drop.
+  delete out.writers;
+  delete out.exposedPaths;
+  result = finish(['VSS writer and shadow-path detail was dropped: the reported metadata exceeded the size limit']);
+  if (JSON.stringify(result).length <= MAX_VSS_METADATA_BYTES) return result;
+
+  // Pathological. Keep a marker rather than persisting nothing: "the agent
+  // reported unusable VSS metadata" is itself a finding.
+  return {
+    warnings: ['VSS metadata was discarded: the reported payload exceeded the size limit'],
+  };
 }
 
 function resolveSnapshotEncryptionKeyId(metadata: Record<string, unknown>): string | null {
@@ -543,6 +691,19 @@ export async function applyBackupCommandResultToJob(params: {
 
   if (providerSnapshotId) {
     updateData.snapshotId = providerSnapshotId;
+  }
+
+  // #3027: VSS diagnostics land on BOTH the success and failure branches, on
+  // purpose. A failed run's writer states are the more valuable of the two —
+  // "which writer wedged" is the question you ask about a failure — and a
+  // *successful* run whose volumes were read live is precisely the
+  // "backed up, but every locked file was skipped" case that motivated this.
+  // Only written when the agent reported it: a legacy agent omits the key
+  // entirely, and the column must keep whatever it already held rather than be
+  // overwritten with NULL.
+  const vssMetadata = sanitizeVssMetadata(result.vssMetadata);
+  if (vssMetadata !== undefined) {
+    updateData.vssMetadata = vssMetadata;
   }
 
   // FIX 7: a genuinely-successful backup whose result lands AFTER the stale

--- a/apps/web/src/components/backup/DeviceBackupTab.test.tsx
+++ b/apps/web/src/components/backup/DeviceBackupTab.test.tsx
@@ -473,4 +473,93 @@ describe('DeviceBackupTab', () => {
     expect(within(jobHistoryTable as HTMLTableElement).getByText('Partial')).toBeTruthy();
     expect(within(jobHistoryTable as HTMLTableElement).queryByText('Pending')).toBeNull();
   });
+
+  describe('VSS status panel (#3027)', () => {
+    function mockStatusWithVss(vssMetadata: unknown) {
+      fetchMock.mockImplementation(async (input, init) => {
+        const url = String(input);
+        const method = (init as RequestInit | undefined)?.method ?? 'GET';
+
+        if (url === '/backup/status/device-1') {
+          return makeJsonResponse({
+            data: {
+              protected: true,
+              lastJob: {
+                id: 'job-vss',
+                status: 'completed',
+                createdAt: '2026-03-30T00:00:00Z',
+                completedAt: '2026-03-30T00:10:00Z',
+                vssMetadata,
+              },
+            },
+          });
+        }
+        if (url === '/backup/jobs?deviceId=device-1') return makeJsonResponse({ data: [] });
+        if (url === '/backup/snapshots?deviceId=device-1' && method === 'GET') {
+          return makeJsonResponse({ data: [] });
+        }
+        return makeJsonResponse({}, false, 404);
+      });
+    }
+
+    it('renders the writer table once the API actually returns vssMetadata', async () => {
+      // The panel existed but was unreachable: lastJob's projection omitted
+      // vssMetadata, so showVssStatus was permanently false and this whole
+      // branch was dead code.
+      mockStatusWithVss({
+        shadowCopyId: 'set-1',
+        writers: [
+          { name: 'SqlServerWriter', state: 'stable' },
+          { name: 'NTDS', state: 'failed' },
+        ],
+      });
+
+      render(<DeviceBackupTab deviceId="device-1" />);
+
+      expect(await screen.findByText('SqlServerWriter')).toBeTruthy();
+      expect(screen.getByText('NTDS')).toBeTruthy();
+      // A non-stable writer still raises the existing writer banner.
+      expect(screen.getByText(/writers are not stable/i)).toBeTruthy();
+    });
+
+    it('flags unprotected volumes on a SUCCESSFUL run — "backed up" vs "backed up but read live"', async () => {
+      // The signal that motivated the issue: every writer stable, job green,
+      // and yet a whole volume was read off the live filesystem.
+      mockStatusWithVss({
+        shadowCopyId: 'set-1',
+        writers: [{ name: 'SqlServerWriter', state: 'stable' }],
+        unprotectedVolumes: ['D:\\'],
+      });
+
+      render(<DeviceBackupTab deviceId="device-1" />);
+
+      const banner = await screen.findByTestId('backup-vss-unprotected-volumes');
+      expect(banner.textContent).toContain('D:\\');
+      // Not merely the writer banner, which stays silent here.
+      expect(screen.queryByText(/writers are not stable/i)).toBeNull();
+    });
+
+    it('lists provider warnings carried on the metadata', async () => {
+      mockStatusWithVss({
+        shadowCopyId: 'set-1',
+        writers: [{ name: 'SqlServerWriter', state: 'stable' }],
+        warnings: ['volume D:\\ has no shadow copy (0x80042308)'],
+      });
+
+      render(<DeviceBackupTab deviceId="device-1" />);
+
+      const warnings = await screen.findByTestId('backup-vss-warnings');
+      expect(warnings.textContent).toContain('0x80042308');
+    });
+
+    it('hides the panel entirely when the run reported no VSS metadata (non-Windows / VSS off)', async () => {
+      mockStatusWithVss(null);
+
+      render(<DeviceBackupTab deviceId="device-1" />);
+
+      await screen.findByText('Job History');
+      expect(screen.queryByText('VSS Status')).toBeNull();
+      expect(screen.queryByTestId('backup-vss-unprotected-volumes')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/components/backup/DeviceBackupTab.test.tsx
+++ b/apps/web/src/components/backup/DeviceBackupTab.test.tsx
@@ -475,7 +475,7 @@ describe('DeviceBackupTab', () => {
   });
 
   describe('VSS status panel (#3027)', () => {
-    function mockStatusWithVss(vssMetadata: unknown) {
+    function mockStatusWithVss(vssMetadata: unknown, lastJobExtra: Record<string, unknown> = {}) {
       fetchMock.mockImplementation(async (input, init) => {
         const url = String(input);
         const method = (init as RequestInit | undefined)?.method ?? 'GET';
@@ -490,6 +490,7 @@ describe('DeviceBackupTab', () => {
                 createdAt: '2026-03-30T00:00:00Z',
                 completedAt: '2026-03-30T00:10:00Z',
                 vssMetadata,
+                ...lastJobExtra,
               },
             },
           });
@@ -560,6 +561,44 @@ describe('DeviceBackupTab', () => {
       await screen.findByText('Job History');
       expect(screen.queryByText('VSS Status')).toBeNull();
       expect(screen.queryByTestId('backup-vss-unprotected-volumes')).toBeNull();
+    });
+
+    it('surfaces a total VSS failure, which has NO vssMetadata and so no panel', async () => {
+      // The worst outcome and previously the most invisible: the shadow copy
+      // never started, so there is nothing for the VSS panel to render, and
+      // this tab used to ignore errorLog entirely — a run that read every file
+      // off the live volume displayed as a clean, green backup.
+      mockStatusWithVss(null, {
+        status: 'completed',
+        errorLog: 'VSS shadow copy could not be created, so every path was read from the live volume',
+      });
+
+      render(<DeviceBackupTab deviceId="device-1" />);
+
+      const banner = await screen.findByTestId('backup-last-job-diagnostic');
+      expect(banner.textContent).toContain('read from the live volume');
+      // A successful-but-degraded run is a WARNING, not an error.
+      expect(banner.textContent).toContain('completed with warnings');
+      expect(banner.className).not.toMatch(/destructive/);
+    });
+
+    it('styles the diagnostic as an error when the run actually failed', async () => {
+      mockStatusWithVss(null, { status: 'failed', errorLog: 'upload destination unreachable' });
+
+      render(<DeviceBackupTab deviceId="device-1" />);
+
+      const banner = await screen.findByTestId('backup-last-job-diagnostic');
+      expect(banner.textContent).toContain('Last backup failed');
+      expect(banner.className).toMatch(/destructive/);
+    });
+
+    it('renders no diagnostic banner for a clean run', async () => {
+      mockStatusWithVss(null, { errorLog: null });
+
+      render(<DeviceBackupTab deviceId="device-1" />);
+
+      await screen.findByText('Job History');
+      expect(screen.queryByTestId('backup-last-job-diagnostic')).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/backup/DeviceBackupTab.tsx
+++ b/apps/web/src/components/backup/DeviceBackupTab.tsx
@@ -51,6 +51,11 @@ type BackupJob = {
   totalSize?: number | null;
   errorCount?: number | null;
   vssMetadata?: VssMetadata | null;
+  // Despite the name this is the run's DIAGNOSTIC channel, not strictly errors:
+  // a successful-but-degraded run writes its warning here (e.g. VSS could not
+  // be created, so paths were read live). Rendered accordingly below — labelled
+  // by the job's own status rather than always as an error.
+  errorLog?: string | null;
 };
 
 type Snapshot = {
@@ -393,6 +398,12 @@ export default function DeviceBackupTab({ deviceId, deviceStatus, timezone }: De
   const hasVssWarnings = latestVssWriters.some((writer) => normalizeVssState(writer.state) !== 'stable');
   const unprotectedVolumes = getVssStringList(status?.lastJob?.vssMetadata, 'unprotectedVolumes');
   const vssWarnings = getVssStringList(status?.lastJob?.vssMetadata, 'warnings');
+  // The run's diagnostic text. On a job that did NOT fail this is a degradation
+  // note, not an error — and it is the only channel a total VSS failure has,
+  // since that outcome produces no vssMetadata at all. This tab used to ignore
+  // errorLog entirely, so such a run displayed as a clean green backup.
+  const lastJobDiagnostic = lastJob?.errorLog?.trim() || null;
+  const lastJobFailed = lastJobStatus === 'failed';
   const selectedSnapshot = snapshots.find((snapshot) => snapshot.id === selectedSnapshotId) ?? snapshots[0] ?? null;
   // Prefer the API-reported device zone; fall back to the already-validated
   // zone passed by the parent (never an invalid IANA id). formatDateTime
@@ -560,6 +571,34 @@ export default function DeviceBackupTab({ deviceId, deviceStatus, timezone }: De
           </div>
         )}
       </div>
+
+      {/* Latest-run diagnostic. Rendered whether or not there is VSS metadata:
+          a run whose shadow copy could not be created reports its degradation
+          ONLY here, and that is precisely the run that would otherwise look
+          clean. Styled by the job's real status — a completed-but-degraded run
+          is a warning, not an error (the job list's blanket "error log" framing
+          is what made these easy to dismiss). */}
+      {lastJobDiagnostic && (
+        <div
+          className={cn(
+            'flex items-start gap-2 rounded-lg border p-4 text-sm',
+            lastJobFailed
+              ? 'border-destructive/40 bg-destructive/10 text-destructive'
+              : 'border-warning/40 bg-warning/10 text-warning'
+          )}
+          data-testid="backup-last-job-diagnostic"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <p className="font-medium">
+              {lastJobFailed
+                ? t('deviceBackupTab.lastBackupFailed')
+                : t('deviceBackupTab.lastBackupCompletedWithWarnings')}
+            </p>
+            <p className="mt-1 break-words opacity-90">{lastJobDiagnostic}</p>
+          </div>
+        </div>
+      )}
 
       {/* VSS Status */}
       {showVssStatus && (

--- a/apps/web/src/components/backup/DeviceBackupTab.tsx
+++ b/apps/web/src/components/backup/DeviceBackupTab.tsx
@@ -34,6 +34,11 @@ type VssWriter = {
 
 type VssMetadata = {
   writers?: VssWriter[] | null;
+  // Requested volumes that got NO shadow copy and were therefore read live —
+  // in-use files on them may have been skipped or captured torn. A non-empty
+  // value means the run is NOT a clean snapshot even when it reports success.
+  unprotectedVolumes?: string[] | null;
+  warnings?: string[] | null;
 } | VssWriter[];
 
 type BackupJob = {
@@ -145,6 +150,15 @@ function getVssWriters(vssMetadata: VssMetadata | null | undefined): VssWriter[]
   if (!vssMetadata) return [];
   if (Array.isArray(vssMetadata)) return vssMetadata;
   return Array.isArray(vssMetadata.writers) ? vssMetadata.writers : [];
+}
+
+function getVssStringList(
+  vssMetadata: VssMetadata | null | undefined,
+  key: 'unprotectedVolumes' | 'warnings'
+): string[] {
+  if (!vssMetadata || Array.isArray(vssMetadata)) return [];
+  const value = vssMetadata[key];
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
 }
 
 function normalizeVssState(state: string | null | undefined): keyof typeof vssStateConfig {
@@ -377,6 +391,8 @@ export default function DeviceBackupTab({ deviceId, deviceStatus, timezone }: De
   const latestVssWriters = getVssWriters(status?.lastJob?.vssMetadata);
   const showVssStatus = status?.lastJob?.vssMetadata != null;
   const hasVssWarnings = latestVssWriters.some((writer) => normalizeVssState(writer.state) !== 'stable');
+  const unprotectedVolumes = getVssStringList(status?.lastJob?.vssMetadata, 'unprotectedVolumes');
+  const vssWarnings = getVssStringList(status?.lastJob?.vssMetadata, 'warnings');
   const selectedSnapshot = snapshots.find((snapshot) => snapshot.id === selectedSnapshotId) ?? snapshots[0] ?? null;
   // Prefer the API-reported device zone; fall back to the already-validated
   // zone passed by the parent (never an invalid IANA id). formatDateTime
@@ -553,11 +569,40 @@ export default function DeviceBackupTab({ deviceId, deviceStatus, timezone }: De
             <span className="text-xs text-muted-foreground">{t('deviceBackupTab.latestBackupJob')}</span>
           </div>
 
+          {/* Unprotected volumes outrank the writer states: a writer in a
+              non-stable state MAY have degraded the snapshot, but a volume with
+              no shadow copy definitely was read live. Show it first and loudest. */}
+          {unprotectedVolumes.length > 0 && (
+            <div
+              className="mt-4 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+              data-testid="backup-vss-unprotected-volumes"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                {t('deviceBackupTab.vssUnprotectedVolumes', { volumes: unprotectedVolumes.join(', ') })}
+              </span>
+            </div>
+          )}
+
           {hasVssWarnings && (
             <div className="mt-4 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
               <span>{t('deviceBackupTab.oneOrMoreVssWritersAreNotStable')}</span>
             </div>
+          )}
+
+          {vssWarnings.length > 0 && (
+            <ul
+              className="mt-4 space-y-1 text-sm text-warning"
+              data-testid="backup-vss-warnings"
+            >
+              {vssWarnings.map((warning, index) => (
+                <li key={`${warning}-${index}`} className="flex items-start gap-2">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>{warning}</span>
+                </li>
+              ))}
+            </ul>
           )}
 
           {latestVssWriters.length > 0 ? (

--- a/apps/web/src/locales/de-DE/backup.json
+++ b/apps/web/src/locales/de-DE/backup.json
@@ -172,6 +172,7 @@
     "vssStatus": "VSS-Status",
     "latestBackupJob": "Letzter Sicherungsauftrag",
     "oneOrMoreVssWritersAreNotStable": "Einer oder mehrere VSS-Writer sind nicht stabil. Überprüfen Sie vor der nächsten Ausführung die neuesten Writer-Zustände.",
+    "vssUnprotectedVolumes": "Vom Live-Volume gelesen, nicht von einer VSS-Schattenkopie: {{volumes}}. Auf diesen Volumes verwendete Dateien wurden möglicherweise übersprungen oder in einem inkonsistenten Zustand erfasst.",
     "writer": "VSS-Writer",
     "state": "Status",
     "noVssWriterDetailsWereReportedForThe": "Für die letzte Sicherung wurden keine VSS-Writerdetails gemeldet.",

--- a/apps/web/src/locales/de-DE/backup.json
+++ b/apps/web/src/locales/de-DE/backup.json
@@ -173,6 +173,8 @@
     "latestBackupJob": "Letzter Sicherungsauftrag",
     "oneOrMoreVssWritersAreNotStable": "Einer oder mehrere VSS-Writer sind nicht stabil. Überprüfen Sie vor der nächsten Ausführung die neuesten Writer-Zustände.",
     "vssUnprotectedVolumes": "Vom Live-Volume gelesen, nicht von einer VSS-Schattenkopie: {{volumes}}. Auf diesen Volumes verwendete Dateien wurden möglicherweise übersprungen oder in einem inkonsistenten Zustand erfasst.",
+    "lastBackupFailed": "Letzte Sicherung fehlgeschlagen",
+    "lastBackupCompletedWithWarnings": "Letzte Sicherung mit Warnungen abgeschlossen",
     "writer": "VSS-Writer",
     "state": "Status",
     "noVssWriterDetailsWereReportedForThe": "Für die letzte Sicherung wurden keine VSS-Writerdetails gemeldet.",

--- a/apps/web/src/locales/en/backup.json
+++ b/apps/web/src/locales/en/backup.json
@@ -172,6 +172,7 @@
     "vssStatus": "VSS Status",
     "latestBackupJob": "Latest backup job",
     "oneOrMoreVssWritersAreNotStable": "One or more VSS writers are not stable. Review the latest writer states before the next run.",
+    "vssUnprotectedVolumes": "Read from the live volume, not a VSS shadow copy: {{volumes}}. In-use files on these volumes may have been skipped or captured in an inconsistent state.",
     "writer": "Writer",
     "state": "State",
     "noVssWriterDetailsWereReportedForThe": "No VSS writer details were reported for the latest backup.",

--- a/apps/web/src/locales/en/backup.json
+++ b/apps/web/src/locales/en/backup.json
@@ -173,6 +173,8 @@
     "latestBackupJob": "Latest backup job",
     "oneOrMoreVssWritersAreNotStable": "One or more VSS writers are not stable. Review the latest writer states before the next run.",
     "vssUnprotectedVolumes": "Read from the live volume, not a VSS shadow copy: {{volumes}}. In-use files on these volumes may have been skipped or captured in an inconsistent state.",
+    "lastBackupFailed": "Last backup failed",
+    "lastBackupCompletedWithWarnings": "Last backup completed with warnings",
     "writer": "Writer",
     "state": "State",
     "noVssWriterDetailsWereReportedForThe": "No VSS writer details were reported for the latest backup.",

--- a/apps/web/src/locales/es-419/backup.json
+++ b/apps/web/src/locales/es-419/backup.json
@@ -172,6 +172,7 @@
     "vssStatus": "VSS Estado",
     "latestBackupJob": "Último trabajo de copia de seguridad",
     "oneOrMoreVssWritersAreNotStable": "Uno o más escritores VSS no son estables. Revise los estados del escritor más reciente antes de la siguiente ejecución.",
+    "vssUnprotectedVolumes": "Se leyó del volumen activo, no de una instantánea VSS: {{volumes}}. Los archivos en uso en estos volúmenes pueden haberse omitido o capturado en un estado inconsistente.",
     "writer": "Escritor",
     "state": "Estado",
     "noVssWriterDetailsWereReportedForThe": "No se informaron detalles del escritor VSS para la última copia de seguridad.",

--- a/apps/web/src/locales/es-419/backup.json
+++ b/apps/web/src/locales/es-419/backup.json
@@ -173,6 +173,8 @@
     "latestBackupJob": "Último trabajo de copia de seguridad",
     "oneOrMoreVssWritersAreNotStable": "Uno o más escritores VSS no son estables. Revise los estados del escritor más reciente antes de la siguiente ejecución.",
     "vssUnprotectedVolumes": "Se leyó del volumen activo, no de una instantánea VSS: {{volumes}}. Los archivos en uso en estos volúmenes pueden haberse omitido o capturado en un estado inconsistente.",
+    "lastBackupFailed": "La última copia de seguridad falló",
+    "lastBackupCompletedWithWarnings": "La última copia de seguridad se completó con advertencias",
     "writer": "Escritor",
     "state": "Estado",
     "noVssWriterDetailsWereReportedForThe": "No se informaron detalles del escritor VSS para la última copia de seguridad.",

--- a/apps/web/src/locales/fr-CA/backup.json
+++ b/apps/web/src/locales/fr-CA/backup.json
@@ -172,6 +172,7 @@
     "vssStatus": "Statut VSS",
     "latestBackupJob": "Dernière tâche de sauvegarde",
     "oneOrMoreVssWritersAreNotStable": "Un ou plusieurs rédacteurs VSS ne sont pas stables. Consultez les derniers écrits des auteurs avant la prochaine édition.",
+    "vssUnprotectedVolumes": "Lu à partir du volume actif, et non d’une copie fantôme VSS : {{volumes}}. Les fichiers en cours d’utilisation sur ces volumes peuvent avoir été ignorés ou capturés dans un état incohérent.",
     "writer": "Écrivain",
     "state": "État",
     "noVssWriterDetailsWereReportedForThe": "Aucun détail de l’auteur VSS n’a été rapporté pour la dernière sauvegarde.",

--- a/apps/web/src/locales/fr-CA/backup.json
+++ b/apps/web/src/locales/fr-CA/backup.json
@@ -173,6 +173,8 @@
     "latestBackupJob": "Dernière tâche de sauvegarde",
     "oneOrMoreVssWritersAreNotStable": "Un ou plusieurs rédacteurs VSS ne sont pas stables. Consultez les derniers écrits des auteurs avant la prochaine édition.",
     "vssUnprotectedVolumes": "Lu à partir du volume actif, et non d’une copie fantôme VSS : {{volumes}}. Les fichiers en cours d’utilisation sur ces volumes peuvent avoir été ignorés ou capturés dans un état incohérent.",
+    "lastBackupFailed": "Échec de la dernière sauvegarde",
+    "lastBackupCompletedWithWarnings": "Dernière sauvegarde terminée avec des avertissements",
     "writer": "Écrivain",
     "state": "État",
     "noVssWriterDetailsWereReportedForThe": "Aucun détail de l’auteur VSS n’a été rapporté pour la dernière sauvegarde.",

--- a/apps/web/src/locales/fr-FR/backup.json
+++ b/apps/web/src/locales/fr-FR/backup.json
@@ -172,6 +172,7 @@
     "vssStatus": "Statut VSS",
     "latestBackupJob": "Dernière tâche de sauvegarde",
     "oneOrMoreVssWritersAreNotStable": "Un ou plusieurs rédacteurs VSS ne sont pas stables. Consultez les derniers écrits des auteurs avant la prochaine édition.",
+    "vssUnprotectedVolumes": "Lu à partir du volume actif, et non d’une copie fantôme VSS : {{volumes}}. Les fichiers en cours d’utilisation sur ces volumes peuvent avoir été ignorés ou capturés dans un état incohérent.",
     "writer": "Écrivain",
     "state": "État",
     "noVssWriterDetailsWereReportedForThe": "Aucun détail de l’auteur VSS n’a été rapporté pour la dernière sauvegarde.",

--- a/apps/web/src/locales/fr-FR/backup.json
+++ b/apps/web/src/locales/fr-FR/backup.json
@@ -173,6 +173,8 @@
     "latestBackupJob": "Dernière tâche de sauvegarde",
     "oneOrMoreVssWritersAreNotStable": "Un ou plusieurs rédacteurs VSS ne sont pas stables. Consultez les derniers écrits des auteurs avant la prochaine édition.",
     "vssUnprotectedVolumes": "Lu à partir du volume actif, et non d’une copie fantôme VSS : {{volumes}}. Les fichiers en cours d’utilisation sur ces volumes peuvent avoir été ignorés ou capturés dans un état incohérent.",
+    "lastBackupFailed": "Échec de la dernière sauvegarde",
+    "lastBackupCompletedWithWarnings": "Dernière sauvegarde terminée avec des avertissements",
     "writer": "Écrivain",
     "state": "État",
     "noVssWriterDetailsWereReportedForThe": "Aucun détail de l’auteur VSS n’a été rapporté pour la dernière sauvegarde.",

--- a/apps/web/src/locales/it-IT/backup.json
+++ b/apps/web/src/locales/it-IT/backup.json
@@ -173,6 +173,8 @@
     "latestBackupJob": "Ultimo processo di backup",
     "oneOrMoreVssWritersAreNotStable": "Uno o più writer VSS non sono stabili. Rivedi gli ultimi stati dei writer prima della prossima esecuzione.",
     "vssUnprotectedVolumes": "Letto dal volume attivo, non da una copia shadow VSS: {{volumes}}. I file in uso su questi volumi potrebbero essere stati ignorati o acquisiti in uno stato incoerente.",
+    "lastBackupFailed": "Ultimo backup non riuscito",
+    "lastBackupCompletedWithWarnings": "Ultimo backup completato con avvisi",
     "writer": "Writer",
     "state": "Stato",
     "noVssWriterDetailsWereReportedForThe": "Non sono stati riportati dettagli dei writer VSS per l'ultimo backup.",

--- a/apps/web/src/locales/it-IT/backup.json
+++ b/apps/web/src/locales/it-IT/backup.json
@@ -172,6 +172,7 @@
     "vssStatus": "Stato VSS",
     "latestBackupJob": "Ultimo processo di backup",
     "oneOrMoreVssWritersAreNotStable": "Uno o più writer VSS non sono stabili. Rivedi gli ultimi stati dei writer prima della prossima esecuzione.",
+    "vssUnprotectedVolumes": "Letto dal volume attivo, non da una copia shadow VSS: {{volumes}}. I file in uso su questi volumi potrebbero essere stati ignorati o acquisiti in uno stato incoerente.",
     "writer": "Writer",
     "state": "Stato",
     "noVssWriterDetailsWereReportedForThe": "Non sono stati riportati dettagli dei writer VSS per l'ultimo backup.",

--- a/apps/web/src/locales/pt-BR/backup.json
+++ b/apps/web/src/locales/pt-BR/backup.json
@@ -172,6 +172,7 @@
     "vssStatus": "Status do VSS",
     "latestBackupJob": "Job de backup mais recente",
     "oneOrMoreVssWritersAreNotStable": "Um ou mais VSS writers não estão estáveis. Revise os estados mais recentes dos writers antes da próxima execução.",
+    "vssUnprotectedVolumes": "Lido do volume ativo, não de uma cópia de sombra VSS: {{volumes}}. Arquivos em uso nesses volumes podem ter sido ignorados ou capturados em um estado inconsistente.",
     "writer": "Gravador",
     "state": "Estado",
     "noVssWriterDetailsWereReportedForThe": "Nenhum detalhe de VSS writer foi relatado para o backup mais recente.",

--- a/apps/web/src/locales/pt-BR/backup.json
+++ b/apps/web/src/locales/pt-BR/backup.json
@@ -173,6 +173,8 @@
     "latestBackupJob": "Job de backup mais recente",
     "oneOrMoreVssWritersAreNotStable": "Um ou mais VSS writers não estão estáveis. Revise os estados mais recentes dos writers antes da próxima execução.",
     "vssUnprotectedVolumes": "Lido do volume ativo, não de uma cópia de sombra VSS: {{volumes}}. Arquivos em uso nesses volumes podem ter sido ignorados ou capturados em um estado inconsistente.",
+    "lastBackupFailed": "O último backup falhou",
+    "lastBackupCompletedWithWarnings": "O último backup foi concluído com avisos",
     "writer": "Gravador",
     "state": "Estado",
     "noVssWriterDetailsWereReportedForThe": "Nenhum detalhe de VSS writer foi relatado para o backup mais recente.",


### PR DESCRIPTION
Closes #3027

## The gap

The agent collects rich VSS diagnostics per backup run and **none of it reached the server**. The issue named four cut points; reviewing the fix surfaced **four more**, all on the failure path. Every one was silent.

| # | Where | What happened |
|---|---|---|
| 1 | `routes/backup/resultSchemas.ts` | `backupCommandResultSchema` had no `vssMetadata` key → zod's default strip discarded it at the first parse |
| 2 | `jobs/queueSchemas.ts` | `backupProcessResultSchema` is `.strict()` and omitted it → it could not have survived the queue hop either |
| 3 | `services/backupResultPersistence.ts` | `applyBackupCommandResultToJob` never wrote `backup_jobs.vss_metadata` — an orphan column since migration `0074` |
| 4 | `routes/backup/dashboard.ts` | the `lastJob` projection returned 4 fields, so `showVssStatus` was permanently `false` and the whole VSS panel was dead code |
| 5 | `agent/internal/backup/backup.go` | `VSSSession.UnprotectedVolumes` was dropped when building `VSSMetadata` — the literal copied five of six fields |
| 6 | `agent/internal/backup/backup.go` | the system-state block **assigned** `job.Warning` instead of appending, destroying the VSS note whenever both degraded (they co-occur — a wedged writer subsystem causes both) |
| 7 | `agent/cmd/breeze-backup/main.go` | `marshalResult` discards the job body whenever `err != nil`, so **every hard failure** reached the server as stderr and nothing else |
| 8 | `agent/internal/heartbeat/{backup_forwarder,heartbeat}.go` | two further hops dropped the body on failure — the forwarder's error mapping, and the async handler's `else if` treating stderr and body as either/or |

Cut 5 matters most: `ExposedPaths` lists what **succeeded**, never what was **requested**, so a volume that resolved no shadow device reads identically to one that was never asked for. Cuts 6–8 meant the fix, as first written, did not actually hold on the failure branch it claimed to cover — "which writer wedged" is precisely the question you ask about a failure.

## Direction chosen — (a), make the channel work

Per the CLAUDE.md advisor-quorum rule, I formed a position and then got an independent read-only Codex `xhigh` opinion. **We agreed on (a)**, for the same reasons:

- VSS health is what distinguishes *"backed up"* from *"backed up but every locked file was skipped"* — the #2999 field failure.
- `job.Warning` is one free-text string. It cannot carry per-writer state, so under (b) "which writer wedged" stays permanently unanswerable. (b) would delete a working UI panel and a column to formalise a lossy workaround.
- No new column, migration, RLS change, or cascade/export registration was needed.

## Failure isolation — the load-bearing decision

`vssMetadata` is typed **`z.unknown()` at BOTH validation boundaries, deliberately**:

- `backupCommandResultSchema` — its parse outcome decides whether the run is recorded completed or failed (`result.status === 'completed' && parsedBackup.success`).
- `backupProcessResultSchema` — parsed inside `enqueueBackupResults` **before** `queue.add`, so a throw discards the whole terminal result.

My first draft used a typed zod object; review caught that one malformed diagnostics field would then fail a backup that actually **succeeded** and strand its snapshot — strictly worse than the F13 bug the schema comments warn about, because it flips job status rather than dropping a column. All validation, bounding and redaction moved to `sanitizeVssMetadata`, where a bad value can only cost that value.

### `sanitizeVssMetadata`

Rebuilds the blob field by field rather than storing it verbatim:

- **Caps**: 24 array entries, 1 KiB per string, 64 KiB serialized — measured with `Buffer.byteLength`, not `String.length` (a non-ASCII payload is up to 3× its UTF-16 length). The entry cap is small enough that the two string arrays *cannot together* exceed the total budget; at the original 200 they could reach ~205 KB each, forcing the pathological tier and discarding the very field the tier above preserves.
- **Unmodeled keys**: keeps top-level **scalars**, drops **containers** — the rule the agent's own IPC bounding uses (`reduceToScalars`, `result_bounds.go`) — so a future agent field stays forward-compatible without reopening the hole.
- **Redaction**: `redactSecretsDeep`, matching existing treatment of agent-supplied jsonb.
- **Nothing is dropped silently.** Count caps, type mismatches, non-list shapes, unmodeled containers and size tiers all name themselves in the persisted `warnings`. This is not tidiness: a sanitizer that quietly reduced `unprotectedVolumes: [{volume:'D:\\'}]` to `[]` would make the UI report a clean snapshot — this issue's exact failure mode, one layer up.
- **The last-resort tier still keeps `unprotectedVolumes`.** Discarding it is the one loss that turns a degraded snapshot back into a clean-looking one.
- An **unusable** blob (bare string, number, array) now logs + `captureException`. `z.unknown()` means nothing upstream rejects garbage — correct — but absent and present-but-broken must not look identical, or a fleet-wide agent regression is invisible forever.

The only ceiling on the way in is agentWs's **5 MB stdout cap**: `backup_run` is not a "critical family", so it never reaches the 512 KB structured cap.

### One subtlety worth flagging for review

The success and failure branches use **different stdout encodings**, deliberately. `toWSCommandResult` unmarshals `Stdout` into the structured `Result` field **only when `Error == ""`**. So success carries a double-encoded body (the agent peels one layer, the server's single `JSON.parse` yields the object), while failure never populates `Result` and the server falls back to `stdout` with one parse left — meaning the body must be **raw** object text. Getting this backwards turns every failed backup into a "malformed result" rather than a failure with diagnostics. Pinned by tests on both branches.

Neither change can green a failed run: `Status` is decided from `BackupCommandResult.Success` before either hop, and the server derives the job's terminal status from that field alone.

## Reconciliation with #3025

**Kept, not replaced.** Not redundant: `job.Warning` survives the IPC bounding that drops `vssMetadata` as a bulk field, and it uniquely covers the case the VSS provider **cannot see** — VSS reported total success but the path never matched a shadow root, so `UnprotectedVolumes` is empty. `vssMetadata` is the structured record; the warning is the loud summary. The stale in-tree comment documenting the severed channel was rewritten.

## Tenancy

No new column and no migration, so **nothing to register**. `vss_metadata` already exists (`0074-vss-metadata.sql`) and is already **`excludedOpen`** in `CORE_TENANT_EXPORT_POLICY` — verified still correct and deliberately not weakened (jsonb, can name volumes and paths). `backup_jobs` already carries forced org RLS and is already in all cascade lists. Independently re-verified by the code reviewer.

## Changes per layer

**Agent (Go)** — `VSSMetadata.UnprotectedVolumes` added; the metadata build extracted to `buildVSSMetadata` (it was inline in a Windows-gated function, which forced the test to *mirror* it); a server-visible warning when the VSS session fails to start at all; `appendWarning` instead of assignment in the system-state block; `marshalBackupRunResult` carrying the job body on failure; the forwarder and async handler both carrying it onward.

**API** — `vssMetadata` on both schemas as `z.unknown()`; forwarded through `ProcessResultsResult` and the agentWs literal; `sanitizeVssMetadata` + the column write on both branches; `errorLog` combined with the warning on failure (the old `error ?? warning` chain always picked `error`, so the note explaining *why* a run was degraded never reached the UI); `vssMetadata` and `errorLog` in the `lastJob` projection.

**Web** — an `unprotectedVolumes` banner ranked **above** the writer banner (a non-stable writer *may* have degraded the snapshot; a volume with no shadow copy definitely was read live); a provider-warnings list; and a diagnostic banner reading `errorLog`, styled by the job's real status — a completed-but-degraded run is a **warning**, not an error. Without it a total VSS failure rendered nothing at all, since that outcome produces no metadata and "no VSS panel" also describes a Linux box. i18n keys added to all 7 locales.

## Tests

Highlight: **`agentWs.enqueueContract.test.ts` gains a completeness contract** — every key `backupProcessResultSchema` declares must appear in agentWs's hand-maintained forwarding literal. That literal was the one hop with **zero** coverage: deleting the `vssMetadata` line left 202/202 green while the feature did nothing in production. Verified by mutation (the test fails with the line removed). It retires the bug class, not just this instance — the same hole existed for `systemStateManifest` and `referencedBytes`.

Also: Go reflection test now run against **production** `buildVSSMetadata` rather than a mirror (removing the field from the real literal previously left the Go suite green); failure-path body carry at all three agent hops; the warning-clobber regression; every new sanitizer note; byte-accurate capping; the escalation path; `errorLog` combination and dedupe; and the degraded-vs-failed banner styling.

**Results:** 251 API tests green (10 files, serial), 35 web green, full `go test -race ./...` clean, `go vet` clean, Windows cross-compile clean, `tsc --noEmit` clean, `astro check` 0 errors, eslint clean.

Not run: RLS/integration contract suites (separate configs, need a live DB) — this PR adds no column, migration or policy, so neither contract's inputs changed.

## Residual risk

- **No end-to-end run against a real Windows endpoint.** The wire shape is pinned in both directions and each hop is tested, but the first live confirmation will be a real multi-volume backup on Windows — ideally one forced to fail, to exercise the failure-path body carry.
- **Field agents are unchanged until they update.** `unprotectedVolumes` will be absent from older agents' payloads; the sanitizer and UI both treat that as "not reported", never "none". Absence of VSS metadata is never evidence of a clean snapshot.
- **Out of scope, worth its own issue:** Codex suggested binding `orgId`/`deviceId` into the `applyBackupCommandResultToJob` UPDATE predicate (it currently keys on job id + status alone, under a system context). A genuine defence-in-depth improvement, but it changes a tenancy-sensitive predicate on paths this PR does not otherwise touch (reconcile, provider-backed, hyperv, mssql).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
