### PR TITLE
fix(ai-tools): repair 40 dead MCP tools; gate all Tier-3 actions behind interactive approval over MCP

### DIFF
--- a/apps/api/src/routes/mcpServer.approvalGate.test.ts
+++ b/apps/api/src/routes/mcpServer.approvalGate.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// MCP interactive-approval-only gate (user decision, 2026-08-02): ALL Tier 3
+// tools now require interactive approval, unconditionally, including tools
+// that predate this change (execute_command, etc.) — MCP has no interactive
+// approval surface, so it fails closed on the SAME effective-tier resolution
+// tools/call already computes (Math.max(baseTier, checkGuardrails(...).tier),
+// honoring TIER1/2/3_ACTIONS per-action escalation/downgrade). One small
+// extras constant (MCP_APPROVAL_REQUIRED_EXTRA_TOOLS) additionally gates
+// collect_evidence, whose Tier 2 in-app rating understates its risk over an
+// unattended transport. This suite reuses the lightweight ledger-based
+// harness from mcpServer.effectiveTier.test.ts (real checkGuardrails, stubbed
+// RBAC/rate-limit) rather than the raw-db-chain harness in mcpServer.test.ts.
+
+const testState = vi.hoisted(() => ({
+  scopes: ['ai:read', 'ai:write', 'ai:execute'] as string[],
+}));
+
+const mocks = vi.hoisted(() => ({
+  executeTool: vi.fn(),
+  getToolDefinitions: vi.fn(),
+  getToolTier: vi.fn(),
+  ledgerBegin: vi.fn(),
+  ledgerComplete: vi.fn(),
+  writeAuditEvent: vi.fn(),
+}));
+
+vi.mock('../services/mcpToolExecutionLedger', () => ({
+  beginMcpToolExecutionLedger: (...args: any[]) => mocks.ledgerBegin(...args),
+  completeMcpToolExecutionLedger: (...args: any[]) => mocks.ledgerComplete(...args),
+}));
+
+vi.mock('../services/auditEvents', () => ({
+  writeAuditEvent: (...args: any[]) => mocks.writeAuditEvent(...args),
+  requestLikeFromSnapshot: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: { select: vi.fn(() => { throw new Error('Unexpected db.select call'); }) },
+  withDbAccessContext: vi.fn((_ctx: any, fn: any) => fn()),
+  withSystemDbAccessContext: vi.fn((fn: any) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => any) => fn()),
+}));
+
+vi.mock('../db/schema', async () => {
+  const { boolean, jsonb, pgTable, text, timestamp } = await import('drizzle-orm/pg-core');
+  return {
+    devices: pgTable('test_devices', {
+      id: text('id'), orgId: text('org_id'), siteId: text('site_id'), hostname: text('hostname'),
+      status: text('status', { enum: ['online', 'offline'] }), osType: text('os_type'),
+      osVersion: text('os_version'), agentVersion: text('agent_version'), lastSeenAt: timestamp('last_seen_at'),
+    }),
+    alerts: pgTable('test_alerts', {
+      id: text('id'), orgId: text('org_id'), title: text('title'), severity: text('severity'),
+      status: text('status', { enum: ['active', 'resolved'] }), deviceId: text('device_id'),
+      triggeredAt: timestamp('triggered_at'),
+    }),
+    scripts: pgTable('test_scripts', {
+      id: text('id'), orgId: text('org_id'), partnerId: text('partner_id'), name: text('name'),
+      description: text('description'), language: text('language'), category: text('category'),
+      deletedAt: timestamp('deleted_at'),
+    }),
+    automations: pgTable('test_automations', {
+      id: text('id'), orgId: text('org_id'), partnerId: text('partner_id'), name: text('name'),
+      description: text('description'), enabled: boolean('enabled'), trigger: jsonb('trigger'),
+    }),
+    organizations: pgTable('test_organizations', {
+      id: text('id'), partnerId: text('partner_id'), createdAt: timestamp('created_at'),
+    }),
+    partners: pgTable('test_partners', { id: text('id'), billingEmail: text('billing_email') }),
+  };
+});
+
+vi.mock('../middleware/apiKeyAuth', () => ({
+  apiKeyAuthMiddleware: async (c: any, next: any) => {
+    c.set('apiKey', {
+      id: 'key-1',
+      orgId: 'org-1',
+      partnerId: 'partner-1',
+      name: 'test',
+      keyPrefix: 'brz_test',
+      scopes: testState.scopes,
+      rateLimit: 1000,
+      createdBy: 'user-1',
+    });
+    c.set('apiKeyOrgId', 'org-1');
+    await next();
+  },
+  requireApiKeyScope: () => async (_c: any, next: any) => next(),
+}));
+
+vi.mock('../services/aiTools', () => ({
+  getToolDefinitions: (...args: any[]) => mocks.getToolDefinitions(...args),
+  executeTool: (...args: any[]) => mocks.executeTool(...args),
+  getToolTier: (...args: any[]) => mocks.getToolTier(...args),
+}));
+
+vi.mock('../services/redis', () => ({ getRedis: () => null }));
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: vi.fn(async () => ({ allowed: true, resetAt: new Date(Date.now() + 60000) })),
+}));
+vi.mock('../middleware/bearerTokenAuth', () => ({
+  bearerTokenAuthMiddleware: async () => {
+    throw new Error('should not be called without a Bearer header');
+  },
+  resolvePartnerAccessibleOrgIds: async () => [],
+}));
+
+vi.mock('../services/tenantStatus', () => ({
+  getActiveOrgTenant: vi.fn(async () => null),
+  assertActiveTenantContext: vi.fn(),
+  TenantInactiveError: class TenantInactiveError extends Error {},
+}));
+
+vi.mock('../services/recoveryBootstrap', () => ({
+  resolveServerUrl: (requestUrl?: string) => requestUrl ? new URL(requestUrl).origin : 'http://localhost:3001',
+}));
+
+vi.mock('./mcpExecutionOrg', () => ({
+  resolveMcpExecutionOrgId: () => 'org-1',
+  resolveMcpExecutionContext: async () => ({ orgId: 'org-1' }),
+  McpExecutionOrgError: class McpExecutionOrgError extends Error {},
+}));
+
+// Real checkGuardrails (and real TIER1/2/3_ACTIONS) so effective-tier
+// resolution behaves exactly as production does — this is the unit under
+// test. RBAC/rate-limit stubbed since they're orthogonal to this gate.
+vi.mock('../services/aiGuardrails', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/aiGuardrails')>();
+  return {
+    ...actual,
+    checkToolPermission: vi.fn(async () => null),
+    checkToolRateLimit: vi.fn(async () => null),
+    checkPermissionRequirement: vi.fn(async () => null),
+  };
+});
+
+// Must cover every permission API_KEY_SCOPE_POLICIES (apps/api/src/services/apiKeyScopes.ts)
+// maps ai:read/ai:write/ai:execute to, or authorizeHumanApiKeyCreator's live
+// scope-delegation re-clamp denies the request before it ever reaches the
+// tier gate under test here (checkToolPermission/RBAC is stubbed separately
+// below — this baseline only has to satisfy the SCOPE re-clamp).
+const FULL_PERMISSIONS_BASELINE = [
+  { resource: 'devices', action: 'read' },
+  { resource: 'devices', action: 'write' },
+  { resource: 'devices', action: 'execute' },
+  { resource: 'alerts', action: 'read' },
+  { resource: 'alerts', action: 'write' },
+  { resource: 'scripts', action: 'read' },
+  { resource: 'scripts', action: 'write' },
+  { resource: 'scripts', action: 'execute' },
+  { resource: 'automations', action: 'read' },
+  { resource: 'automations', action: 'write' },
+];
+
+vi.mock('../services/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/permissions')>();
+  return {
+    ...actual,
+    getUserPermissions: vi.fn(async () => ({
+      permissions: FULL_PERMISSIONS_BASELINE,
+      partnerId: null,
+      orgId: 'org-1',
+      roleId: 'role-1',
+      scope: 'organization' as const,
+      allowedSiteIds: undefined,
+    })),
+  };
+});
+
+import { mcpServerRoutes } from './mcpServer';
+import { checkGuardrails } from '../services/aiGuardrails';
+
+// Real JSON schemas for the multiplexed tools these tests target, trimmed to
+// just the `action` enum the gate inspects (mirrors the real registry
+// definitions in aiToolsScripts.ts / aiToolsBilling.ts).
+const REGISTRY_OPERATIONS_SCHEMA = {
+  type: 'object',
+  properties: {
+    action: { type: 'string', enum: ['read_key', 'get_value', 'set_value', 'create_key', 'delete_key'] },
+  },
+};
+const MANAGE_INVOICES_SCHEMA = {
+  type: 'object',
+  properties: {
+    action: {
+      type: 'string',
+      enum: [
+        'create_draft', 'add_manual_line', 'add_catalog_line', 'add_bundle_line', 'add_contract_line',
+        'update_line', 'remove_line', 'update_header', 'delete_draft',
+        'assemble_from_org', 'assemble_from_ticket',
+        'issue', 'void', 'record_payment', 'void_payment', 'create_pay_link',
+      ],
+    },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  testState.scopes = ['ai:read', 'ai:write', 'ai:execute'];
+  mocks.executeTool.mockReset().mockResolvedValue(JSON.stringify({ ok: true }));
+  mocks.getToolDefinitions.mockReset().mockReturnValue([]);
+  mocks.getToolTier.mockReset().mockReturnValue(undefined);
+  mocks.ledgerBegin.mockReset().mockResolvedValue({ id: 'ledger-1' });
+  mocks.ledgerComplete.mockReset().mockResolvedValue(undefined);
+  mocks.writeAuditEvent.mockReset();
+});
+
+async function callTool(toolName: string, args: Record<string, unknown>, scopes?: string[]) {
+  if (scopes) testState.scopes = scopes;
+  const res = await mcpServerRoutes.request('/message', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'X-API-Key': 'brz_test' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: toolName, arguments: args },
+    }),
+  });
+  return res;
+}
+
+async function listTools() {
+  const res = await mcpServerRoutes.request('/message', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'X-API-Key': 'brz_test' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+  });
+  return res;
+}
+
+describe('MCP interactive-approval-only gate (all Tier 3, tier-driven)', () => {
+  // (a) A flat Tier 3 tool — absent from tools/list, denied on tools/call.
+  describe('flat Tier 3 tool (execute_command) — wholly gated', () => {
+    beforeEach(() => {
+      mocks.getToolDefinitions.mockReturnValue([
+        { name: 'execute_command', description: 'Execute a system command.', input_schema: {} },
+        { name: 'query_devices', description: 'List devices.', input_schema: {} },
+      ]);
+      mocks.getToolTier.mockImplementation((name: string) => {
+        if (name === 'execute_command') return 3;
+        if (name === 'query_devices') return 1;
+        return undefined;
+      });
+    });
+
+    it('is absent from tools/list', async () => {
+      const res = await listTools();
+      const body = await res.json();
+      const names = body.result.tools.map((t: any) => t.name);
+      expect(names).not.toContain('execute_command');
+      expect(names).toContain('query_devices');
+    });
+
+    it('tools/call returns MCP_APPROVAL_REQUIRED without executing (this is a NEW denial — execute_command used to auto-execute)', async () => {
+      const res = await callTool('execute_command', { deviceId: 'dev-1', commandType: 'list_processes' });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.result.isError).toBe(true);
+      const payload = JSON.parse(body.result.content[0].text);
+      expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+      expect(mocks.executeTool).not.toHaveBeenCalled();
+    });
+
+    it('is denied even for a caller with full scopes — not a scope-insufficiency error', async () => {
+      const res = await callTool('execute_command', { deviceId: 'dev-1', commandType: 'list_processes' }, ['ai:read']);
+      const body = await res.json();
+      const payload = JSON.parse(body.result.content[0].text);
+      expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+      expect(mocks.executeTool).not.toHaveBeenCalled();
+    });
+  });
+
+  // (b) registry_operations — mixed multiplexer: writes Tier 3, reads not.
+  describe('registry_operations — mixed multiplexer (base tier 1)', () => {
+    beforeEach(() => {
+      mocks.getToolDefinitions.mockReturnValue([
+        { name: 'registry_operations', description: 'Read or modify the registry.', input_schema: REGISTRY_OPERATIONS_SCHEMA },
+      ]);
+      mocks.getToolTier.mockImplementation((name: string) => (name === 'registry_operations' ? 1 : undefined));
+    });
+
+    it('stays listed (mixed tool), with a description note naming the gated write actions', async () => {
+      const res = await listTools();
+      const body = await res.json();
+      const tool = body.result.tools.find((t: any) => t.name === 'registry_operations');
+      expect(tool).toBeDefined();
+      expect(tool.description).toContain('set_value');
+      expect(tool.description).toContain('create_key');
+      expect(tool.description).toContain('delete_key');
+      expect(tool.description).toContain('not available over MCP');
+      // Reads are not gated — must not be listed as requiring the web app.
+      expect(tool.description).not.toContain('"get_value"');
+      expect(tool.description).not.toContain('"read_key"');
+    });
+
+    it('action:"set_value" (escalates to Tier 3) returns MCP_APPROVAL_REQUIRED without executing', async () => {
+      const res = await callTool('registry_operations', {
+        action: 'set_value', deviceId: 'dev-1', keyPath: 'HKLM\\Software\\Foo', valueName: 'Bar', valueData: '1',
+      });
+      const body = await res.json();
+      expect(body.result.isError).toBe(true);
+      const payload = JSON.parse(body.result.content[0].text);
+      expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+      expect(mocks.executeTool).not.toHaveBeenCalled();
+    });
+
+    it('action:"get_value" (stays Tier 1) proceeds past the gate to the normal handler path', async () => {
+      const res = await callTool('registry_operations', {
+        action: 'get_value', deviceId: 'dev-1', keyPath: 'HKLM\\Software\\Foo', valueName: 'Bar',
+      }, ['ai:read']);
+      const body = await res.json();
+      expect(body.error).toBeUndefined();
+      expect(mocks.executeTool).toHaveBeenCalledWith(
+        'registry_operations',
+        expect.objectContaining({ action: 'get_value' }),
+        expect.anything(),
+      );
+    });
+  });
+
+  // (c) manage_invoices — mixed multiplexer: issue/void/payment Tier 3, drafting is not.
+  describe('manage_invoices — mixed multiplexer (draft actions stay usable)', () => {
+    beforeEach(() => {
+      mocks.getToolDefinitions.mockReturnValue([
+        { name: 'manage_invoices', description: 'Create and manage invoices.', input_schema: MANAGE_INVOICES_SCHEMA },
+      ]);
+      // manage_invoices base tier is 1 in the real registry (billing draft ops
+      // auto-execute; issue/void/payment escalate via TIER3_ACTIONS).
+      mocks.getToolTier.mockImplementation((name: string) => (name === 'manage_invoices' ? 1 : undefined));
+    });
+
+    it('stays listed with a description note naming the gated finalize/payment actions', async () => {
+      const res = await listTools();
+      const body = await res.json();
+      const tool = body.result.tools.find((t: any) => t.name === 'manage_invoices');
+      expect(tool).toBeDefined();
+      expect(tool.description).toContain('issue');
+      expect(tool.description).toContain('void');
+      expect(tool.description).toContain('record_payment');
+      expect(tool.description).toContain('void_payment');
+    });
+
+    it('action:"issue" (escalates to Tier 3) returns MCP_APPROVAL_REQUIRED without executing', async () => {
+      const res = await callTool('manage_invoices', { action: 'issue', invoiceId: 'inv-1' });
+      const body = await res.json();
+      expect(body.result.isError).toBe(true);
+      const payload = JSON.parse(body.result.content[0].text);
+      expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+      expect(mocks.executeTool).not.toHaveBeenCalled();
+    });
+
+    it('action:"create_draft" (the automation surface) proceeds past the gate — drafting must keep working', async () => {
+      const res = await callTool('manage_invoices', { action: 'create_draft', orgId: 'org-1' }, ['ai:read', 'ai:write']);
+      const body = await res.json();
+      expect(body.error).toBeUndefined();
+      expect(mocks.executeTool).toHaveBeenCalledWith(
+        'manage_invoices',
+        expect.objectContaining({ action: 'create_draft' }),
+        expect.anything(),
+      );
+    });
+  });
+
+  // (d) A plain Tier 2 tool proceeds fully ungated.
+  describe('Tier 2 tools proceed ungated', () => {
+    it('manage_tags {action: "add"} (Tier 2) is not gated — needs only ai:write, not approval', async () => {
+      mocks.getToolDefinitions.mockReturnValue([
+        { name: 'manage_tags', description: 'Manage device tags.', input_schema: { type: 'object', properties: { action: { type: 'string', enum: ['list', 'add', 'remove'] } } } },
+      ]);
+      mocks.getToolTier.mockImplementation((name: string) => (name === 'manage_tags' ? 2 : undefined));
+
+      const res = await callTool('manage_tags', { action: 'add', deviceId: 'dev-1', tags: ['x'] }, ['ai:read', 'ai:write']);
+      const body = await res.json();
+      expect(body.error).toBeUndefined();
+      expect(mocks.executeTool).toHaveBeenCalledWith('manage_tags', expect.objectContaining({ action: 'add' }), expect.anything());
+    });
+
+    it('acknowledge_network_device (Tier 2) is not gated', async () => {
+      mocks.getToolDefinitions.mockReturnValue([
+        { name: 'acknowledge_network_device', description: 'Acknowledge a network change event.', input_schema: {} },
+      ]);
+      mocks.getToolTier.mockImplementation((name: string) => (name === 'acknowledge_network_device' ? 2 : undefined));
+
+      const res = await callTool('acknowledge_network_device', { eventId: 'evt-1' }, ['ai:read', 'ai:write']);
+      const body = await res.json();
+      expect(body.error).toBeUndefined();
+      expect(mocks.executeTool).toHaveBeenCalledWith('acknowledge_network_device', expect.anything(), expect.anything());
+    });
+  });
+
+  // (e) collect_evidence — gated via the extras constant despite Tier 2.
+  describe('collect_evidence — sub-Tier-3 extra (Tier 2 understates its risk)', () => {
+    beforeEach(() => {
+      mocks.getToolDefinitions.mockReturnValue([
+        { name: 'collect_evidence', description: 'Collect forensic evidence.', input_schema: {} },
+        { name: 'query_devices', description: 'List devices.', input_schema: {} },
+      ]);
+      mocks.getToolTier.mockImplementation((name: string) => {
+        if (name === 'collect_evidence') return 2;
+        if (name === 'query_devices') return 1;
+        return undefined;
+      });
+    });
+
+    it('is absent from tools/list despite being Tier 2', async () => {
+      const res = await listTools();
+      const body = await res.json();
+      const names = body.result.tools.map((t: any) => t.name);
+      expect(names).not.toContain('collect_evidence');
+      expect(names).toContain('query_devices');
+    });
+
+    it('tools/call returns MCP_APPROVAL_REQUIRED without executing', async () => {
+      const res = await callTool('collect_evidence', {
+        incidentId: 'inc-1', deviceId: 'dev-1', evidenceTypes: ['screenshot'],
+      }, ['ai:read', 'ai:write']);
+      const body = await res.json();
+      expect(body.result.isError).toBe(true);
+      const payload = JSON.parse(body.result.content[0].text);
+      expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+      expect(mocks.executeTool).not.toHaveBeenCalled();
+    });
+  });
+
+  // (f) The gate lives ONLY in the MCP route — the shared in-app guardrail
+  // service still reports Tier 3 tools as ALLOWED (the in-app approval flow,
+  // not a blanket denial, is what gates them there).
+  describe('in-app (non-MCP) path is untouched — no gate outside the MCP route', () => {
+    beforeEach(() => {
+      // checkGuardrails (real, via importOriginal) reads getToolTier from
+      // '../services/aiTools' for its base-tier fallback — give it the same
+      // base tiers the real registry carries for these two tools.
+      mocks.getToolTier.mockImplementation((name: string) => {
+        if (name === 'execute_containment') return 3;
+        if (name === 'collect_evidence') return 2;
+        return undefined;
+      });
+    });
+
+    it('the real checkGuardrails still ALLOWS a Tier 3 tool (execute_containment) — the MCP deny is route-only', () => {
+      const result = checkGuardrails('execute_containment', {
+        incidentId: 'inc-1', deviceId: 'dev-1', actionType: 'process_kill',
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.tier).toBe(3);
+      expect(result.requiresApproval).toBe(true);
+    });
+
+    it('the real checkGuardrails still ALLOWS collect_evidence at Tier 2 — the MCP extras gate is route-only', () => {
+      const result = checkGuardrails('collect_evidence', {
+        incidentId: 'inc-1', deviceId: 'dev-1', evidenceTypes: ['screenshot'],
+      });
+      expect(result.allowed).toBe(true);
+      expect(result.tier).toBe(2);
+    });
+  });
+});

--- a/apps/api/src/routes/mcpServer.effectiveTier.test.ts
+++ b/apps/api/src/routes/mcpServer.effectiveTier.test.ts
@@ -278,27 +278,30 @@ describe('MCP tools/call effective-tier gating (FIX 1)', () => {
     expect(body.result?.content?.[0]?.text).toContain('ok');
   });
 
-  // C3 — the audit event records the EFFECTIVE (escalated) tier, not the base
-  // tier. registry_operations base tier 1 + action:'delete_key' → tier 3; the
-  // ledger already asserts tier:3 (in the existing ledger test), so here we
-  // assert the audit-event payload carries details.tier === 3.
-  it('C3: audit event records the escalated effective tier (3), not base tier (1)', async () => {
+  // C3 — user decision 2026-08-02 made ALL Tier 3 unconditionally
+  // approval-required over MCP, so an escalated-to-tier-3 action now never
+  // reaches the ledger/audit path at all (the interactive-approval-only gate
+  // fires first, before ledger/audit — see mcpServer.approvalGate.test.ts for
+  // the full gate suite). What THIS test still needs to prove is narrower:
+  // the effective-tier resolution (Math.max(baseTier, guardrailTier)) is what
+  // feeds that gate — an action-level escalation from a base-tier-1 tool
+  // gates it exactly like a flat base-tier-3 tool would, not like its base
+  // tier. Previously this asserted the escalated tier landed in the audit
+  // payload; that payload no longer exists for a gated call, so this now
+  // asserts the gate itself fires (and, via the "no ledger" check, that it
+  // fires BEFORE the ledger/audit machinery ever runs).
+  it('C3: an action escalated from base tier 1 to effective tier 3 is gated exactly like a flat Tier-3 tool', async () => {
     const res = await callTool(
       ['ai:read', 'ai:execute'],
       'registry_operations',
       { action: 'delete_key', key: 'HKLM\\foo' },
     );
     const body = await res.json();
-    expect(body.error).toBeUndefined();
-    // The route writes two audit events: a request-level 'mcp_request' and the
-    // tool-level 'mcp_tool_execution'. Select the tool-level one and assert it
-    // records the EFFECTIVE (escalated) tier 3, not the base tier 1.
-    const toolAudit = mocks.writeAuditEvent.mock.calls
-      .map((call: any[]) => call[1])
-      .find((p: any) => p?.resourceType === 'mcp_tool_execution');
-    expect(toolAudit).toBeDefined();
-    expect(toolAudit.action).toBe('mcp.tool.registry_operations');
-    expect(toolAudit.details.tier).toBe(3);
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+    expect(mocks.ledgerBegin).not.toHaveBeenCalled();
+    expect(mocks.writeAuditEvent.mock.calls.some((call: any[]) => call[1]?.resourceType === 'mcp_tool_execution')).toBe(false);
   });
 
   // Downgrade-clamp: security_scan base tier 2 + action:'vulnerabilities'
@@ -320,12 +323,21 @@ describe('MCP tools/call effective-tier gating (FIX 1)', () => {
     expect(okBody.error).toBeUndefined();
   });
 
-  it('ai:read key calling a tier-1 tool with a destructive action is DENIED', async () => {
+  // Since 2026-08-02, a destructive escalated action is gated by
+  // MCP_APPROVAL_REQUIRED before the scope check ever runs, so an
+  // under-scoped (ai:read-only) caller and a fully-scoped (ai:execute)
+  // caller now get the IDENTICAL denial for this tool/action — see the
+  // "no scope can reach it" tests further below and the dedicated suite in
+  // mcpServer.approvalGate.test.ts. This test now just pins that the
+  // escalation still denies an ai:read-only caller (via the new gate, not
+  // the old scope message).
+  it('ai:read key calling a tier-1 tool with a destructive action is DENIED (MCP_APPROVAL_REQUIRED)', async () => {
     const res = await callTool(['ai:read'], 'registry_operations', { action: 'delete_key' });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error?.code).toBe(-32603);
-    expect(body.error?.message).toContain('requires ai:execute');
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
   });
 
   it('ai:read key calling a benign read action on the same tool still succeeds', async () => {
@@ -336,38 +348,51 @@ describe('MCP tools/call effective-tier gating (FIX 1)', () => {
     expect(body.result?.content?.[0]?.text).toContain('ok');
   });
 
-  it('manage_processes action:kill is escalated to tier 3 and denied for ai:read', async () => {
+  it('manage_processes action:kill is escalated to tier 3 and gated (MCP_APPROVAL_REQUIRED) for ai:read', async () => {
     const res = await callTool(['ai:read'], 'manage_processes', { action: 'kill', pid: 1234 });
     const body = await res.json();
-    expect(body.error?.code).toBe(-32603);
-    expect(body.error?.message).toContain('requires ai:execute');
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
   });
 
-  it('a true tier-3 tool is unaffected (still denied for ai:read)', async () => {
+  it('a true tier-3 tool is unaffected by scope — still gated (MCP_APPROVAL_REQUIRED) for ai:read', async () => {
     const res = await callTool(['ai:read'], 'run_script', { scriptId: 's1' });
     const body = await res.json();
-    expect(body.error?.code).toBe(-32603);
-    expect(body.error?.message).toContain('requires ai:execute');
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
   });
 
-  it('a true tier-3 tool still executes for ai:execute', async () => {
+  // Reversed 2026-08-02: a flat Tier 3 tool no longer executes over MCP at
+  // all, regardless of scope — ai:execute used to be sufficient; now every
+  // Tier 3 call requires the interactive web app's approval workflow, which
+  // MCP has no surface for.
+  it('a true tier-3 tool no longer executes over MCP even with ai:execute — gated (MCP_APPROVAL_REQUIRED)', async () => {
     const res = await callTool(['ai:read', 'ai:execute'], 'run_script', { scriptId: 's1' });
     const body = await res.json();
-    expect(body.error).toBeUndefined();
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+    expect(mocks.executeTool).not.toHaveBeenCalled();
   });
 
-  it('ledger is created for the escalated destructive action (ai:execute key)', async () => {
+  // Reversed 2026-08-02: the ledger is only ever created for tier>=3 calls
+  // that actually reach runTier3ToolLifecycle — and a tier-3 call (base OR
+  // escalated) never gets that far anymore, the approval gate denies it
+  // first. So the escalated destructive action must NOT create a ledger row,
+  // the inverse of what this test asserted before the policy reversal.
+  it('ledger is NOT created for an escalated-to-tier-3 destructive action (ai:execute key) — gated before the ledger begins', async () => {
     const res = await callTool(
       ['ai:read', 'ai:execute'],
       'registry_operations',
       { action: 'delete_key', key: 'HKLM\\foo' },
     );
     const body = await res.json();
-    expect(body.error).toBeUndefined();
-    expect(mocks.ledgerBegin).toHaveBeenCalledTimes(1);
-    const arg = (mocks.ledgerBegin.mock.calls[0] as any[])[0] as any;
-    expect(arg.tier).toBe(3);
-    expect(arg.toolName).toBe('registry_operations');
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+    expect(mocks.ledgerBegin).not.toHaveBeenCalled();
   });
 
   it('benign read action on a tier-1 tool does NOT create a ledger', async () => {

--- a/apps/api/src/routes/mcpServer.test.ts
+++ b/apps/api/src/routes/mcpServer.test.ts
@@ -500,7 +500,15 @@ describe('MCP transport integration', () => {
     expect(rateLimiter).toHaveBeenCalledWith({}, 'mcp:msg:oauth-grant:grant-stable-1', 120, 60);
   });
 
-  it('production defaults to requiring ai:execute_admin for tier-3 MCP calls', async () => {
+  // Reversed 2026-08-02: ALL Tier 3 MCP calls are now unconditionally
+  // approval-required (MCP_APPROVAL_REQUIRED), fired before the
+  // ai:execute_admin production check below ever runs — the prod
+  // execute_admin requirement still exists in the code (defense-in-depth,
+  // and it still gates tools/list + bootstrap auth tools), but tools/call can
+  // no longer reach it for a Tier 3 tool. This test now pins that the NEW
+  // gate — not the old admin-scope message — is what a production ai:execute
+  // (non-admin) caller actually sees.
+  it('production: a Tier 3 MCP call is gated (MCP_APPROVAL_REQUIRED), not the old ai:execute_admin message', async () => {
     delete process.env.IS_HOSTED;
     process.env.NODE_ENV = 'production';
     delete process.env.MCP_REQUIRE_EXECUTE_ADMIN;
@@ -514,28 +522,6 @@ describe('MCP transport integration', () => {
     testState.aiTools = new Map([['execute_command', { deviceArgs: ['deviceId'] }]]);
     testState.redis = { get: vi.fn(async () => null) };
 
-    const ledgerInsertValues: any[] = [];
-    const ledgerUpdateSet = vi.fn();
-    testState.db = {
-        select: () => ({
-          from: () => ({
-            where: () => ({ limit: async () => [{ partnerId: 'partner-1' }] }),
-          }),
-        }),
-        insert: () => ({
-          values: (value: any) => {
-            ledgerInsertValues.push(value);
-            return { returning: async () => [{ id: 'mcp-exec-1' }] };
-          },
-        }),
-        update: () => ({
-          set: (value: any) => {
-            ledgerUpdateSet(value);
-            return { where: async () => undefined };
-          },
-        }),
-      };
-
     const res = await mcpServerRoutes.request('/message', {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'X-API-Key': 'brz_test' },
@@ -549,11 +535,18 @@ describe('MCP transport integration', () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error?.message).toBe('Tool "execute_command" requires ai:execute_admin scope in production');
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
     expect(executeTool).not.toHaveBeenCalled();
   });
 
-  it('production can explicitly opt out of the execute-admin requirement while keeping the allowlist gate', async () => {
+  // Reversed 2026-08-02: MCP_REQUIRE_EXECUTE_ADMIN=false used to let a Tier 3
+  // tool auto-execute (still subject to the allowlist). It no longer can —
+  // the interactive-approval-only gate is unconditional and does not consult
+  // this env var at all, so opting out of the admin requirement must NOT
+  // resurrect Tier 3 execution over MCP.
+  it('production: opting out of the execute-admin requirement does NOT resurrect Tier 3 execution — still gated', async () => {
     delete process.env.IS_HOSTED;
     process.env.NODE_ENV = 'production';
     process.env.MCP_REQUIRE_EXECUTE_ADMIN = 'false';
@@ -567,28 +560,6 @@ describe('MCP transport integration', () => {
     testState.aiTools = new Map([['execute_command', { deviceArgs: ['deviceId'] }]]);
     testState.redis = { get: vi.fn(async () => null) };
 
-    const ledgerInsertValues: any[] = [];
-    const ledgerUpdateSet = vi.fn();
-    testState.db = {
-        select: () => ({
-          from: () => ({
-            where: () => ({ limit: async () => [{ partnerId: 'partner-1' }] }),
-          }),
-        }),
-        insert: () => ({
-          values: (value: any) => {
-            ledgerInsertValues.push(value);
-            return { returning: async () => [{ id: 'mcp-exec-1' }] };
-          },
-        }),
-        update: () => ({
-          set: (value: any) => {
-            ledgerUpdateSet(value);
-            return { where: async () => undefined };
-          },
-        }),
-      };
-
     const res = await mcpServerRoutes.request('/message', {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'X-API-Key': 'brz_test' },
@@ -602,15 +573,23 @@ describe('MCP transport integration', () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toBeUndefined();
-    expect(executeTool).toHaveBeenCalledWith(
-      'execute_command',
-      {},
-      expect.objectContaining({ partnerId: 'partner-1', orgId: 'org-1' }),
-    );
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+    expect(executeTool).not.toHaveBeenCalled();
   });
 
-  it('writes a sanitized tool-level audit event for successful tier-3 MCP calls', async () => {
+  // Reversed 2026-08-02: this test exercises the audit sanitization pipeline
+  // (writeMcpToolAuditEvent / sanitizeAuditPayload), which runs unconditionally
+  // for every tier. It used to run execute_command at (its real) Tier 3, but a
+  // Tier 3 call no longer reaches this pipeline at all (see
+  // mcpServer.approvalGate.test.ts for that gate). Pinned to a synthetic
+  // Tier 2 here so the sanitization mechanics this test actually cares about
+  // keep real coverage. NOTE: the execution LEDGER (as opposed to the audit
+  // event) only fires for tier>=3 (see runTier3ToolLifecycle), so unlike
+  // before this reversal, this test no longer asserts on ledger rows — that
+  // path is exercised at tier 2 nowhere in this suite because it cannot fire.
+  it('writes a sanitized tool-level audit event for a successful Tier 2 MCP call', async () => {
     delete process.env.IS_HOSTED;
     process.env.NODE_ENV = 'development';
 
@@ -618,7 +597,7 @@ describe('MCP transport integration', () => {
 
     routeMocks.getToolDefinitions.mockReturnValue([{ name: 'execute_command', description: '', input_schema: {} }]);
     routeMocks.executeTool.mockResolvedValue(JSON.stringify({ status: 'completed', stdout: 'token=raw-secret' }));
-    routeMocks.getToolTier.mockImplementation((name: string) => (name === 'execute_command' ? 3 : undefined));
+    routeMocks.getToolTier.mockImplementation((name: string) => (name === 'execute_command' ? 2 : undefined));
     testState.aiTools = new Map([['execute_command', { deviceArgs: ['deviceId'] }]]);
     testState.redis = { get: vi.fn(async () => null) };
     const ledgerInsertValues: any[] = [];
@@ -682,7 +661,7 @@ describe('MCP transport integration', () => {
         result: 'success',
         details: expect.objectContaining({
           toolName: 'execute_command',
-          tier: 3,
+          tier: 2,
           oauthGrantId: 'grant-1',
           target: expect.objectContaining({ deviceId: 'device-1' }),
           arguments: expect.objectContaining({ token: '[REDACTED]' }),
@@ -697,48 +676,25 @@ describe('MCP transport integration', () => {
     expect(JSON.stringify(writeAuditEvent.mock.calls)).not.toContain('raw-token');
     expect(JSON.stringify(writeAuditEvent.mock.calls)).not.toContain('raw-secret');
     // MED-1 regression: the attacker-forged sessionId must not have landed
-    // in the audit or ledger payloads.
+    // in the audit payload.
     expect(JSON.stringify(writeAuditEvent.mock.calls)).not.toContain('mcp-attacker-forged');
-    expect(JSON.stringify(ledgerInsertValues)).not.toContain('mcp-attacker-forged');
-    expect(ledgerInsertValues[1]).toMatchObject({
-      toolName: 'execute_command',
-      status: 'executing',
-      toolInput: expect.objectContaining({
-        source: 'mcp',
-        orgId: 'org-1',
-        toolName: 'execute_command',
-        tier: 3,
-        principal: expect.objectContaining({
-          type: 'api_key',
-          apiKeyId: 'key-1',
-          oauthGrantId: 'grant-1',
-          partnerId: 'partner-1',
-        }),
-        target: expect.objectContaining({ deviceId: 'device-1' }),
-      }),
-    });
-    expect(ledgerUpdateSet).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'completed',
-      toolOutput: expect.objectContaining({
-        source: 'mcp',
-        status: 'success',
-        result: expect.objectContaining({
-          resultKeys: expect.arrayContaining(['status', 'stdout']),
-        }),
-      }),
-    }));
-    expect(JSON.stringify(ledgerInsertValues)).not.toContain('raw-token');
-    expect(JSON.stringify(ledgerUpdateSet.mock.calls)).not.toContain('raw-secret');
+    // No execution ledger at Tier 2 (see the block comment above this test —
+    // beginMcpToolExecutionLedger only fires for tier>=3).
+    expect(ledgerInsertValues).toEqual([]);
+    expect(ledgerUpdateSet).not.toHaveBeenCalled();
   });
 
-  it('writes a failed tool-level audit event when tier-3 MCP execution throws', async () => {
+  // Reversed 2026-08-02: same rationale as the successful-call sanitization
+  // test above — pinned to Tier 2 since a Tier 3 call no longer reaches this
+  // pipeline (executeTool throwing) at all over MCP.
+  it('writes a failed tool-level audit event when a Tier 2 MCP execution throws', async () => {
     delete process.env.IS_HOSTED;
     process.env.NODE_ENV = 'development';
 
     setTestApiKey({ scopes: ['ai:read', 'ai:execute'] });
     routeMocks.getToolDefinitions.mockReturnValue([{ name: 'execute_command', description: '', input_schema: {} }]);
     routeMocks.executeTool.mockRejectedValue(new TypeError('boom with token=raw-secret'));
-    routeMocks.getToolTier.mockImplementation((name: string) => (name === 'execute_command' ? 3 : undefined));
+    routeMocks.getToolTier.mockImplementation((name: string) => (name === 'execute_command' ? 2 : undefined));
     testState.aiTools = new Map([['execute_command', { deviceArgs: ['deviceId'] }]]);
     testState.redis = { get: vi.fn(async () => null) };
     const ledgerInsertValues: any[] = [];
@@ -801,28 +757,11 @@ describe('MCP transport integration', () => {
     );
     expect(JSON.stringify(writeAuditEvent.mock.calls)).not.toContain('hunter2');
     expect(JSON.stringify(writeAuditEvent.mock.calls)).not.toContain('raw-secret');
-    expect(ledgerInsertValues[1]).toMatchObject({
-      toolName: 'execute_command',
-      status: 'executing',
-      toolInput: expect.objectContaining({
-        source: 'mcp',
-        orgId: 'org-1',
-        toolName: 'execute_command',
-        tier: 3,
-        target: expect.objectContaining({ deviceId: 'device-1' }),
-      }),
-    });
-    expect(ledgerUpdateSet).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'failed',
-      errorMessage: 'boom with token=[REDACTED]',
-      toolOutput: expect.objectContaining({
-        source: 'mcp',
-        status: 'failure',
-        errorClass: 'TypeError',
-      }),
-    }));
-    expect(JSON.stringify(ledgerInsertValues)).not.toContain('hunter2');
-    expect(JSON.stringify(ledgerUpdateSet.mock.calls)).not.toContain('raw-secret');
+    // No execution ledger at Tier 2 (beginMcpToolExecutionLedger only fires
+    // for tier>=3 — see the block comment on the successful-call sibling test
+    // above).
+    expect(ledgerInsertValues).toEqual([]);
+    expect(ledgerUpdateSet).not.toHaveBeenCalled();
   });
 
   it('enforces stream-byte limit even when content-length is missing/lying', async () => {
@@ -1188,17 +1127,21 @@ describe('MCP transport integration', () => {
     testState.redis = { get: vi.fn(async () => null) };
   }
 
-  it('C2: escalated tier-3 action NOT in the prod allowlist is denied', async () => {
+  // Reversed 2026-08-02: MCP_EXECUTE_TOOL_ALLOWLIST gates whether a Tier 3
+  // tool can auto-execute in production — a check that no longer matters for
+  // an escalated-to-tier-3 action, because the interactive-approval-only gate
+  // denies it first regardless of allowlist membership. This test now proves
+  // that supersession: even a WILDCARD-permissioned, allowlisted-or-not
+  // caller gets MCP_APPROVAL_REQUIRED, never the old allowlist message.
+  it('C2: an escalated-to-tier-3 action is gated (MCP_APPROVAL_REQUIRED) regardless of the prod allowlist', async () => {
     delete process.env.IS_HOSTED;
     process.env.NODE_ENV = 'production';
     mockKeyWithScopes(['ai:read', 'ai:execute', 'ai:execute_admin']);
     // SR2-15 (Task 3, scope re-clamp): this key's stored scopes include
-    // ai:execute_admin (requires the wildcard ADMIN_ALL grant). The default
-    // getUserPermissions mock deliberately withholds that grant (so the
-    // "key lacks ai:execute_admin" test below stays a real denial); override
-    // it here with a wildcard-permissioned creator so the coarse scope
-    // re-clamp passes and this test can exercise the ACTUAL concern under
-    // test — the MCP_EXECUTE_TOOL_ALLOWLIST gate, not scope delegation.
+    // ai:execute_admin (requires the wildcard ADMIN_ALL grant). Override with
+    // a wildcard-permissioned creator so the coarse scope re-clamp passes —
+    // this test's concern is the interactive-approval-only gate, not scope
+    // delegation.
     routeMocks.getUserPermissions.mockResolvedValue(WILDCARD_PERMISSIONS);
     mockRealGuardrailsWithEscalatedTier1Tools();
 
@@ -1214,10 +1157,16 @@ describe('MCP transport integration', () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error?.message).toContain('not in MCP_EXECUTE_TOOL_ALLOWLIST');
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+    expect(routeMocks.executeTool).not.toHaveBeenCalled();
   });
 
-  it('C2: escalated tier-3 action in the allowlist but key lacks ai:execute_admin is denied', async () => {
+  // Reversed 2026-08-02: same supersession as above — the ai:execute_admin
+  // requirement no longer matters for an escalated-to-tier-3 action, since
+  // the interactive-approval-only gate denies it first regardless of scope.
+  it('C2: an escalated-to-tier-3 action is gated (MCP_APPROVAL_REQUIRED) regardless of the ai:execute_admin requirement', async () => {
     delete process.env.IS_HOSTED;
     process.env.NODE_ENV = 'production';
     delete process.env.MCP_REQUIRE_EXECUTE_ADMIN;
@@ -1236,7 +1185,10 @@ describe('MCP transport integration', () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error?.message).toContain('requires ai:execute_admin');
+    expect(body.result.isError).toBe(true);
+    const payload = JSON.parse(body.result.content[0].text);
+    expect(payload.code).toBe('MCP_APPROVAL_REQUIRED');
+    expect(routeMocks.executeTool).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------

--- a/apps/api/src/routes/mcpServer.ts
+++ b/apps/api/src/routes/mcpServer.ts
@@ -25,7 +25,7 @@ import { MCP_OAUTH_ENABLED, OAUTH_ISSUER } from '../config/env';
 import { apiKeyAuthMiddleware, requireApiKeyScope } from '../middleware/apiKeyAuth';
 import { bearerTokenAuthMiddleware, resolvePartnerAccessibleOrgIds } from '../middleware/bearerTokenAuth';
 import { getToolDefinitions, executeTool, getToolTier } from '../services/aiTools';
-import { checkGuardrails, checkToolPermission, checkToolRateLimit, checkPermissionRequirement } from '../services/aiGuardrails';
+import { checkGuardrails, checkToolPermission, checkToolRateLimit, checkPermissionRequirement, TIER3_ACTIONS } from '../services/aiGuardrails';
 import { db } from '../db';
 import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
 import { devices, alerts, scripts, automations, partners, organizations } from '../db/schema';
@@ -828,6 +828,119 @@ async function handleJsonRpc(
 }
 
 // ============================================
+// MCP interactive-approval-only gate
+// ============================================
+//
+// User decision, 2026-08-02: ALL Tier 3 tools require interactive approval —
+// full stop, no exceptions for tools that predate this change. The MCP
+// server has NO interactive approval surface (the durable action_intents
+// Tier 3 approval workflow is an interactive-web-app-only construct), so
+// rather than continue trusting the API key holder at the scope level (the
+// old model — see the removed "MCP server auto-executes Tier 3 tools without
+// approval" comment that used to sit where the gate below is applied), MCP
+// now fails closed on every Tier 3 call: `tools/call` denies with a
+// structured MCP_APPROVAL_REQUIRED error instead of invoking executeTool,
+// and `tools/list` doesn't advertise a tool that can never actually be
+// invoked over this transport. The in-app (non-MCP) execution path is
+// completely unaffected — this gate lives only in this route, never in
+// aiGuardrails.ts, which still governs the real tier/approval behavior the
+// interactive app's action_intents workflow acts on.
+//
+// The gate reuses the SAME effective-tier resolution `tools/call` already
+// computes (`Math.max(baseTier, checkGuardrails(...).tier)`, honoring
+// TIER1_ACTIONS/TIER2_ACTIONS/TIER3_ACTIONS per-action escalation/downgrade
+// for multiplexed tools) — there is no separate hand-maintained tool list for
+// the tier-3 case, so a future tool that lands at Tier 3 is gated
+// automatically with zero extra wiring.
+//
+// MCP_APPROVAL_REQUIRED_EXTRA_TOOLS exists ONLY for tools whose registered
+// tier UNDERSTATES their risk over an unattended transport like MCP — today
+// that's just collect_evidence (Tier 2 in-app because it goes through the
+// same confirm-before-execute UI as any Tier 2 mutation, but it dispatches a
+// privileged device-side extraction command, including a screenshot, so an
+// unattended MCP caller must not be able to trigger it without human
+// approval the way a Tier 3 call cannot). Do not add tools here to route
+// around normal tier design — fix the tier in aiGuardrails.ts instead if a
+// tool's tier is simply wrong; this constant is a narrow, documented
+// exception, not a second gating mechanism.
+const MCP_APPROVAL_REQUIRED_EXTRA_TOOLS: Record<string, true> = {
+  collect_evidence: true,
+};
+
+const MCP_APPROVAL_REQUIRED_ERROR = {
+  error: 'This action requires interactive approval and cannot be executed over MCP. Run it from the Breeze web app AI assistant, where it goes through the approval workflow.',
+  code: 'MCP_APPROVAL_REQUIRED',
+} as const;
+
+/**
+ * True when `tools/call` must deny this tool/action over MCP instead of
+ * executing it: effective tier 3 (see the constant's block comment for why
+ * this is unconditional and reuses the shared tier resolution), or an
+ * explicit sub-Tier-3 extra.
+ */
+function isMcpApprovalRequired(toolName: string, effectiveTier: number): boolean {
+  return effectiveTier === 3 || MCP_APPROVAL_REQUIRED_EXTRA_TOOLS[toolName] === true;
+}
+
+/**
+ * True when EVERY possible invocation of this tool resolves to a gated tier —
+ * i.e. it can never be successfully called over MCP, so `tools/list` should
+ * not advertise it (the "advertised-but-dead" pattern this payoff exists to
+ * eliminate). Three cases:
+ *   1. A wholly-gated extra (MCP_APPROVAL_REQUIRED_EXTRA_TOOLS) — no action
+ *      of this tool escapes the gate regardless of tier.
+ *   2. A flat Tier 3 tool (base tier 3) — `tools/call`'s effective tier is
+ *      `Math.max(baseTier, guardrailTier)`, which can never fall below the
+ *      base tier, so every action is unconditionally Tier 3.
+ *   3. A multiplexed tool whose `action` enum is fully covered by
+ *      TIER3_ACTIONS for that tool — every value a caller could legally pass
+ *      escalates to Tier 3, even though the tool's base tier is lower.
+ * A tool with base tier <3 and either no `action` enum or at least one action
+ * NOT in TIER3_ACTIONS stays listed — some invocation of it can succeed.
+ */
+function isToolWhollyGatedOverMcp(
+  toolName: string,
+  inputSchema: unknown,
+  getTier: (name: string) => number | undefined,
+): boolean {
+  if (MCP_APPROVAL_REQUIRED_EXTRA_TOOLS[toolName] === true) return true;
+
+  const baseTier = getTier(toolName);
+  if (baseTier === undefined) return false;
+  if (baseTier >= 3) return true;
+
+  const actionEnum = extractActionEnum(inputSchema);
+  if (!actionEnum || actionEnum.length === 0) return false; // not a multiplexer — fixed at base tier <3, never gated
+
+  const tier3Actions = TIER3_ACTIONS[toolName];
+  if (!tier3Actions || tier3Actions.length === 0) return false;
+  return actionEnum.every((action) => tier3Actions.includes(action));
+}
+
+/** Pull the `action` property's JSON-Schema `enum` off a tool's input_schema, if present. */
+function extractActionEnum(inputSchema: unknown): string[] | null {
+  if (!inputSchema || typeof inputSchema !== 'object') return null;
+  const properties = (inputSchema as { properties?: Record<string, unknown> }).properties;
+  const actionProp = properties?.action as { enum?: unknown[] } | undefined;
+  if (!actionProp || !Array.isArray(actionProp.enum)) return null;
+  return actionProp.enum.filter((v): v is string => typeof v === 'string');
+}
+
+/**
+ * Which of a tool's declared actions are gated over MCP — used to append a
+ * "these actions require the web app" note to a mixed multiplexer's
+ * `tools/list` description. Empty for a wholly-gated tool (it's suppressed
+ * entirely, see isToolWhollyGatedOverMcp) and for a tool with no gated
+ * actions at all.
+ */
+function gatedActionsForTool(toolName: string, inputSchema: unknown): string[] {
+  const actionEnum = extractActionEnum(inputSchema);
+  if (!actionEnum) return [];
+  const tier3Actions = new Set(TIER3_ACTIONS[toolName] ?? []);
+  return actionEnum.filter((action) => tier3Actions.has(action));
+}
+
+// ============================================
 // tools/list
 // ============================================
 
@@ -840,6 +953,12 @@ function handleToolsList(id: string | number, scopes: string[]): JsonRpcResponse
 
   // Filter tools based on API key scopes.
   const filteredTools = allTools.filter((tool) => {
+    // A wholly-gated tool (every possible invocation resolves to a gated
+    // tier — see isToolWhollyGatedOverMcp) is never advertised: every call to
+    // it would be denied by the tools/call gate below, so listing it is
+    // exactly the advertised-but-dead pattern this payoff eliminates.
+    if (isToolWhollyGatedOverMcp(tool.name, tool.input_schema, getToolTier)) return false;
+
     const tier = getToolTier(tool.name);
     if (tier === undefined) return false;
 
@@ -847,15 +966,28 @@ function handleToolsList(id: string | number, scopes: string[]): JsonRpcResponse
     if (tier <= 1) return true;
     // Tier 2 (low-risk mutations) = ai:write
     if (tier === 2) return hasWrite;
-    // Tier 3+ (destructive) = ai:execute
+    // Tier 3+ (destructive) = ai:execute. (A FLAT Tier 3 tool never reaches
+    // here — isToolWhollyGatedOverMcp already suppressed it above — but a
+    // multiplexer whose base tier is <3 can still surface here if only SOME
+    // of its actions escalate to Tier 3, and those callers need ai:execute
+    // to reach the tools/call gate at all, same as before this payoff.)
     return hasExecute && (!requireExecuteAdmin || hasExecuteAdmin);
   });
 
-  const result = filteredTools.map((tool) => ({
-    name: tool.name,
-    description: tool.description ?? '',
-    inputSchema: tool.input_schema,
-  }));
+  const result = filteredTools.map((tool) => {
+    // A mixed multiplexer (some but not all actions gated over MCP) stays
+    // listed — its ungated actions (typically reads/drafts) still work —
+    // but its MCP-visible description gains a note about which don't.
+    const gatedActions = gatedActionsForTool(tool.name, tool.input_schema);
+    const description = gatedActions.length > 0
+      ? `${tool.description ?? ''} (Actions ${gatedActions.map((a) => `"${a}"`).join(', ')} require interactive approval and are not available over MCP — use the Breeze web app AI assistant for those.)`
+      : tool.description ?? '';
+    return {
+      name: tool.name,
+      description,
+      inputSchema: tool.input_schema,
+    };
+  });
 
   // Surface bootstrap auth tools (send_deployment_invites, configure_defaults)
   // to authenticated callers with the matching scope. These tools live outside
@@ -954,6 +1086,18 @@ async function handleToolsCall(
   }
   const tier = Math.max(baseTier, guardrailCheck.tier);
 
+  // MCP interactive-approval-only gate (see the block comment above
+  // MCP_APPROVAL_REQUIRED_EXTRA_TOOLS). Deliberately checked BEFORE the scope
+  // gates below — this is an unconditional deny regardless of what scope the
+  // caller holds, not "insufficient scope" (those gates report that
+  // distinctly). executeTool is never reached for a gated tool/action.
+  if (isMcpApprovalRequired(toolName, tier)) {
+    return jsonRpcResult(id, {
+      content: [{ type: 'text', text: JSON.stringify(MCP_APPROVAL_REQUIRED_ERROR) }],
+      isError: true,
+    });
+  }
+
   const hasExecute = scopes.includes('ai:execute');
   const requireExecuteAdmin = shouldRequireExecuteAdminInProd();
   const hasExecuteAdmin = scopes.includes('ai:execute_admin');
@@ -996,8 +1140,14 @@ async function handleToolsCall(
     return jsonRpcError(id, -32000, 'Unable to verify rate limits');
   }
 
-  // MCP server auto-executes Tier 3 tools without approval — the API key holder
-  // is trusted at the scope level. Approval flow is for interactive UI only.
+  // By this point every Tier 3 call (and the sub-Tier-3
+  // MCP_APPROVAL_REQUIRED_EXTRA_TOOLS) has already been denied by the
+  // isMcpApprovalRequired gate above — user decision 2026-08-02 replaced the
+  // old "MCP server auto-executes Tier 3 tools, API key holder trusted at the
+  // scope level" model with a hard fail-closed over MCP, because MCP has no
+  // interactive approval surface. Everything reaching this point is Tier ≤2
+  // (or a Tier 3 action that was itself downgraded by TIER1_ACTIONS/
+  // TIER2_ACTIONS), so auto-execution here is intentional and safe.
 
   // Authoritative execution org (MCP-OAUTH-05): for device-targeted tools this
   // is resolved from the TARGETED DEVICES via the org+site access gate — NOT

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -103,7 +103,7 @@ function decryptWebhookUrl(webhook: typeof webhooksTable.$inferSelect): string {
   }
 }
 
-function toWorkerWebhookConfig(webhook: typeof webhooksTable.$inferSelect): WorkerWebhookConfig {
+export function toWorkerWebhookConfig(webhook: typeof webhooksTable.$inferSelect): WorkerWebhookConfig {
   const retryPolicy = (webhook.retryPolicy ?? undefined) as WorkerWebhookConfig['retryPolicy'];
   let secret: string | undefined;
   if (webhook.secret) {

--- a/apps/api/src/services/aiGuardrails.ts
+++ b/apps/api/src/services/aiGuardrails.ts
@@ -99,7 +99,7 @@ export const TIER3_ACTIONS: Record<string, string[]> = {
   security_scan: ['quarantine', 'remove', 'restore'],
   disk_cleanup: ['execute'],
   manage_startup_items: ['disable', 'enable'],
-  manage_scheduled_tasks: ['run', 'disable', 'enable', 'delete'],
+  manage_scheduled_tasks: ['run', 'disable', 'enable'],
   // Fleet tools — Tier 3 actions (require user approval)
   manage_configuration_policy: ['create', 'update', 'delete'],
   manage_deployments: ['create', 'start', 'cancel'],
@@ -273,7 +273,6 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
     run: { resource: 'devices', action: 'execute' },
     disable: { resource: 'devices', action: 'execute' },
     enable: { resource: 'devices', action: 'execute' },
-    delete: { resource: 'devices', action: 'execute' },
   },
   take_screenshot: { resource: 'devices', action: 'execute' },
   analyze_screen: { resource: 'devices', action: 'execute' },
@@ -505,6 +504,9 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
   manage_notification_channels: {
     list: { resource: 'alerts', action: 'read' },
     test: { resource: 'alerts', action: 'write' },
+    create: { resource: 'alerts', action: 'write' },
+    update: { resource: 'alerts', action: 'write' },
+    delete: { resource: 'alerts', action: 'write' },
   },
   // Saved filter tools
   manage_saved_filters: {
@@ -569,6 +571,99 @@ export const TOOL_PERMISSIONS: Record<string, { resource: string; action: string
   // permissions live in TOOL_EXTRA_PERMISSIONS below.
   send_deployment_invites: { resource: 'devices', action: 'write' },
   configure_defaults: { resource: 'organizations', action: 'write' },
+
+  // Registration-debt payoff: RBAC entries for tools that were registered in
+  // aiTools but had no TOOL_PERMISSIONS entry (legacyPermissionGaps in
+  // aiToolsRegistryParity.test.ts). See that file's history for context.
+  // Incidents (analogy: manage_dr_plan/sync_huntress_data org-write; get_dr_plan_details org-read)
+  create_incident: { resource: 'organizations', action: 'write' },
+  get_incident_timeline: { resource: 'organizations', action: 'read' },
+  generate_incident_report: { resource: 'organizations', action: 'read' },
+  // Device-execute (analogy: s1_isolate_device, execute_command; collect_evidence includes
+  // screenshot => privileged extraction like take_screenshot)
+  execute_containment: { resource: 'devices', action: 'execute' },
+  collect_evidence: { resource: 'devices', action: 'execute' },
+
+  // Policy-prereq family (analogy: manage_backup_profiles per-action map)
+  manage_update_rings: {
+    list: { resource: 'policies', action: 'read' },
+    get: { resource: 'policies', action: 'read' },
+    create: { resource: 'policies', action: 'write' },
+    update: { resource: 'policies', action: 'write' },
+  },
+  manage_backup_configs: {
+    list: { resource: 'policies', action: 'read' },
+    get: { resource: 'policies', action: 'read' },
+    create: { resource: 'policies', action: 'write' },
+    update: { resource: 'policies', action: 'write' },
+  },
+
+  // Device reads (analogy: analyze_boot_performance, query_change_log)
+  get_user_experience_metrics: { resource: 'devices', action: 'read' },
+  get_ip_history: { resource: 'devices', action: 'read' },
+  get_active_users: { resource: 'devices', action: 'read' },
+
+  // Security visibility (analogy: get_security_posture devices:read; PAM entries mirror
+  // routes/pam.ts requirePamRead/Execute)
+  get_dns_security: { resource: 'devices', action: 'read' },
+  manage_dns_policy: { resource: 'devices', action: 'write' },
+  get_browser_security: { resource: 'devices', action: 'read' },
+  manage_browser_policy: {
+    list: { resource: 'devices', action: 'read' },
+    create: { resource: 'devices', action: 'write' },
+    update: { resource: 'devices', action: 'write' },
+    apply: { resource: 'devices', action: 'execute' },   // queues real deviceCommands (parity: apply_cis_remediation)
+  },
+  get_sensitive_data_overview: { resource: 'devices', action: 'read' },
+  remediate_sensitive_data: {
+    encrypt: { resource: 'devices', action: 'execute' },
+    quarantine: { resource: 'devices', action: 'execute' },
+    secure_delete: { resource: 'devices', action: 'execute' },
+    accept_risk: { resource: 'devices', action: 'write' },
+    false_positive: { resource: 'devices', action: 'write' },
+    mark_remediated: { resource: 'devices', action: 'write' },
+  },
+  request_elevation: { resource: 'devices', action: 'execute' },   // routes/pam.ts: respond gates on requirePamExecute; rule auto-approve makes this privilege-granting
+  revoke_elevation: { resource: 'devices', action: 'execute' },    // routes/pam.ts revoke gates on requirePamExecute
+  get_elevation_history: { resource: 'devices', action: 'read' },  // requirePamRead
+
+  // Compliance / software / peripheral (analogy: query_compliance_policies policies:read;
+  // manage_configuration_policy map)
+  get_software_compliance: { resource: 'policies', action: 'read' },
+  manage_software_policies: {
+    list: { resource: 'policies', action: 'read' },
+    get: { resource: 'policies', action: 'read' },
+    create: { resource: 'policies', action: 'write' },
+    update: { resource: 'policies', action: 'write' },
+  },
+  manage_software_policy: {
+    list: { resource: 'policies', action: 'read' },
+    get: { resource: 'policies', action: 'read' },
+    create: { resource: 'policies', action: 'write' },
+    update: { resource: 'policies', action: 'write' },
+    delete: { resource: 'policies', action: 'write' },
+  },
+  remediate_software_violation: { resource: 'devices', action: 'execute' },  // analogy: apply_cis_remediation
+  manage_peripheral_policies: {
+    list: { resource: 'policies', action: 'read' },
+    get: { resource: 'policies', action: 'read' },
+    create: { resource: 'policies', action: 'write' },
+    update: { resource: 'policies', action: 'write' },
+  },
+  manage_peripheral_policy: {
+    create: { resource: 'policies', action: 'write' },
+    update: { resource: 'policies', action: 'write' },
+    disable: { resource: 'policies', action: 'write' },
+    add_exception: { resource: 'policies', action: 'write' },
+    remove_exception: { resource: 'policies', action: 'write' },
+  },
+  get_peripheral_activity: { resource: 'devices', action: 'read' },
+
+  // Network (mirror backing REST routes: networkChanges.ts uses devices:read + alerts:acknowledge;
+  // networkBaselines.ts uses devices:write)
+  get_network_changes: { resource: 'devices', action: 'read' },
+  acknowledge_network_device: { resource: 'alerts', action: 'acknowledge' },
+  configure_network_baseline: { resource: 'devices', action: 'write' },
 };
 
 const TOOL_EXTRA_PERMISSIONS: Record<string, { resource: string; action: string }[]> = {
@@ -676,6 +771,10 @@ const TOOL_RATE_LIMITS: Record<string, { limit: number; windowSeconds: number }>
   sync_huntress_data: { limit: 10, windowSeconds: 300 },
   // User risk tools
   assign_security_training: { limit: 10, windowSeconds: 300 },
+  // Registration-debt payoff: rate limits for newly-permissioned tools.
+  execute_containment: { limit: 5, windowSeconds: 600 },       // mirrors s1_isolate_device
+  collect_evidence: { limit: 10, windowSeconds: 300 },          // mirrors take_screenshot-class dispatch
+  remediate_software_violation: { limit: 10, windowSeconds: 600 }, // mirrors apply_cis_remediation
 };
 
 export interface GuardrailCheck {

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -9,7 +9,7 @@
 import { z } from 'zod';
 import { isIP } from 'node:net';
 import { INVOICE_STATUSES } from '@breeze/shared';
-import { backupProfileSelectionsSchema } from '@breeze/shared/validators';
+import { backupProfileSelectionsSchema, ringAutoApproveSchema } from '@breeze/shared/validators';
 import { fleetToolInputSchemas } from './aiToolSchemasFleet';
 import { backupToolSchemas } from './aiToolSchemasBackup';
 import { m365ToolSchemas } from './aiToolSchemasM365';
@@ -1023,8 +1023,11 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     (data) => !['update', 'delete', 'get'].includes(data.action) || !!data.policyId,
     { message: 'policyId is required for update/delete/get actions' }
   ).refine(
-    (data) => data.action !== 'create' || (!!data.name && !!data.mode && !!data.targetType),
-    { message: 'name, mode, and targetType are required for create action' }
+    // The handler's create branch only reads name/mode (aiToolsCompliance.ts)
+    // — it never reads targetType/targetIds, so requiring targetType here
+    // rejected valid creates for a field the handler ignores.
+    (data) => data.action !== 'create' || (!!data.name && !!data.mode),
+    { message: 'name and mode are required for create action' }
   ),
 
   remediate_software_violation: z.object({
@@ -1272,6 +1275,304 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
   }).refine(
     (d) => !['status', 'summary'].includes(d.action) || !!d.deviceId,
     { message: 'deviceId is required for status/summary actions' },
+  ),
+
+  // Registration-debt payoff: schemas for tools that were registered in
+  // aiTools but had no Zod input schema (legacySchemaGaps in
+  // aiToolsRegistryParity.test.ts). See that file's history for context.
+  query_analytics: z.object({
+    action: z.enum(['sla_compliance', 'capacity_predictions', 'sla_definitions']),
+    slaId: uuid.optional(),
+    deviceId: uuid.optional(),
+    metricType: z.string().max(50).optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  }),
+
+  get_executive_summary: z.object({
+    periodType: z.string().max(20).optional(),
+  }),
+
+  query_psa_status: z.object({
+    connectionId: uuid.optional(),
+  }),
+
+  search_documentation: z.object({
+    query: z.string().min(1).max(500),
+    section: z.enum(['getting-started', 'deploy', 'agents', 'security', 'features', 'monitoring', 'reference']).optional(),
+  }),
+
+  query_webhooks: z.object({
+    status: z.enum(['active', 'disabled', 'error']).optional(),
+    includeDeliveries: z.boolean().optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  }),
+
+  test_webhook: z.object({
+    webhookId: uuid,
+  }),
+
+  manage_notification_channels: z.object({
+    action: z.enum(['list', 'test', 'create', 'update', 'delete']),
+    channelId: uuid.optional(),
+    name: z.string().min(1).max(255).optional(),
+    type: z.enum(['email', 'slack', 'teams', 'webhook', 'pagerduty', 'sms']).optional(),
+    config: z.record(z.string(), z.unknown()).optional(),
+    enabled: z.boolean().optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  }).refine(
+    (d) => !['test', 'update', 'delete'].includes(d.action) || !!d.channelId,
+    { message: 'channelId is required for test/update/delete actions' },
+  ).refine(
+    (d) => d.action !== 'create' || (!!d.name && !!d.type && !!d.config),
+    { message: 'name, type, and config are required for create' },
+  ),
+
+  manage_saved_filters: z.object({
+    action: z.enum(['list', 'get', 'create', 'delete']),
+    filterId: uuid.optional(),
+    name: z.string().min(1).max(255).optional(),
+    description: z.string().max(2000).optional(),
+    conditions: z.record(z.string(), z.unknown()).optional(),
+  }).refine(
+    (d) => !['get', 'delete'].includes(d.action) || !!d.filterId,
+    { message: 'filterId is required for get/delete actions' },
+  ).refine(
+    (d) => d.action !== 'create' || (!!d.name && !!d.conditions),
+    { message: 'name and conditions are required for create' },
+  ),
+
+  query_custom_fields: z.object({
+    action: z.enum(['list_definitions', 'get_device_values']),
+    deviceId: uuid.optional(),
+  }).refine(
+    (d) => d.action !== 'get_device_values' || !!d.deviceId,
+    { message: 'deviceId is required for get_device_values' },
+  ),
+
+  create_incident: z.object({
+    title: z.string().min(1).max(500),
+    classification: z.enum([
+      'malware', 'ransomware', 'phishing', 'data_breach',
+      'unauthorized_access', 'denial_of_service', 'insider_threat', 'other',
+    ]),
+    severity: z.enum(['p1', 'p2', 'p3', 'p4']),
+    summary: z.string().max(5000).optional(),
+    relatedAlertIds: z.array(uuid).max(200).optional(),
+    affectedDeviceIds: z.array(uuid).max(200).optional(),
+  }),
+
+  execute_containment: z.object({
+    incidentId: uuid,
+    deviceId: uuid,
+    actionType: z.enum(['process_kill', 'network_isolation', 'account_disable', 'usb_block']),
+    parameters: z.record(z.string(), z.unknown()).optional(),
+    approvalRef: z.string().max(128).optional(),
+  }),
+
+  collect_evidence: z.object({
+    incidentId: uuid,
+    deviceId: uuid,
+    evidenceTypes: z.array(z.enum(['logs', 'processes', 'connections', 'screenshot'])).min(1),
+  }),
+
+  get_incident_timeline: z.object({
+    incidentId: uuid,
+  }),
+
+  generate_incident_report: z.object({
+    incidentId: uuid,
+  }),
+
+  manage_update_rings: z.object({
+    action: z.enum(['list', 'get', 'create', 'update']),
+    ringId: uuid.optional(),
+    name: z.string().min(1).max(255).optional(),
+    description: z.string().max(2000).optional(),
+    deferralDays: z.number().int().min(0).optional(),
+    deadlineDays: z.number().int().min(0).optional(),
+    gracePeriodHours: z.number().int().min(0).optional(),
+    categories: z.array(z.string()).max(50).optional(),
+    excludeCategories: z.array(z.string()).max(50).optional(),
+    sources: z.array(z.enum(['microsoft', 'apple', 'linux', 'third_party', 'custom'])).optional(),
+    autoApprove: ringAutoApproveSchema.optional(),
+    enabled: z.boolean().optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  }),
+
+  manage_backup_configs: z.object({
+    action: z.enum(['list', 'get', 'create', 'update']),
+    configId: uuid.optional(),
+    name: z.string().min(1).max(200).optional(),
+    type: z.enum(['file', 'system_image', 'database', 'application']).optional(),
+    provider: z.enum(['s3', 'azure_blob', 'google_cloud', 'backblaze', 'local']).optional(),
+    providerConfig: z.record(z.string(), z.unknown()).optional(),
+    schedule: z.record(z.string(), z.unknown()).optional(),
+    retention: z.record(z.string(), z.unknown()).optional(),
+    compression: z.boolean().optional(),
+    encryption: z.boolean().optional(),
+    isActive: z.boolean().optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  }),
+
+  manage_scheduled_tasks: z.object({
+    deviceId: uuid,
+    action: z.enum(['list', 'run', 'disable', 'enable']),
+    taskName: z.string().min(1).max(1024).optional(),
+    search: z.string().max(200).optional(),
+  }).refine(
+    (d) => !['run', 'disable', 'enable'].includes(d.action) || !!d.taskName,
+    { message: 'taskName (full task path) is required for run/disable/enable' },
+  ),
+
+  registry_operations: z.object({
+    action: z.enum(['read_key', 'get_value', 'set_value', 'create_key', 'delete_key']),
+    deviceId: uuid,
+    keyPath: z.string().min(1).max(2048),
+    valueName: z.string().max(255).optional(),
+    valueData: z.string().max(8192).optional(),
+    valueType: z.enum(['REG_SZ', 'REG_DWORD', 'REG_QWORD', 'REG_BINARY', 'REG_EXPAND_SZ', 'REG_MULTI_SZ']).optional(),
+  }).refine(
+    (d) => d.action !== 'get_value' || !!d.valueName,
+    { message: 'valueName is required for get_value' },
+  ).refine(
+    (d) => d.action !== 'set_value' || (!!d.valueName && d.valueData !== undefined),
+    { message: 'valueName and valueData are required for set_value' },
+  ),
+
+  query_agent_versions: z.object({
+    action: z.enum(['list_versions', 'check_upgrades']),
+    platform: z.enum(['windows', 'macos', 'linux']).optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  }),
+
+  trigger_agent_upgrade: z.object({
+    deviceIds: z.array(uuid).min(1).max(50),
+    targetVersion: z.string().max(100).optional(),
+  }),
+
+  trigger_agent_restart: z.object({
+    deviceIds: z.array(uuid).min(1).max(50),
+  }),
+
+  list_remote_sessions: z.object({
+    status: z.enum(['pending', 'connecting', 'active', 'disconnected', 'failed']).optional(),
+    type: z.enum(['terminal', 'desktop', 'file_transfer']).optional(),
+    deviceId: uuid.optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  }),
+
+  create_remote_session: z.object({
+    deviceId: uuid,
+    type: z.enum(['terminal', 'file_transfer']),
+  }),
+
+  manage_tags: z.object({
+    action: z.enum(['list', 'add', 'remove']),
+    deviceId: uuid.optional(),
+    tags: z.array(z.string().min(1).max(100)).max(50).optional(),
+    search: z.string().max(200).optional(),
+  }).refine(
+    (d) => d.action === 'list' || !!d.deviceId,
+    { message: 'deviceId is required for add/remove' },
+  ).refine(
+    (d) => d.action === 'list' || (Array.isArray(d.tags) && d.tags.length > 0),
+    { message: 'tags array is required for add/remove' },
+  ),
+
+  get_browser_security: z.object({
+    orgId: uuid.optional(),
+    deviceId: uuid.optional(),
+    browser: z.enum(['chrome', 'edge', 'firefox', 'safari', 'brave', 'other']).optional(),
+    riskLevel: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+    includeViolations: z.boolean().optional(),
+    limit: z.number().int().min(1).max(500).optional(),
+  }),
+
+  manage_browser_policy: z.object({
+    action: z.enum(['list', 'create', 'update', 'apply']),
+    policyId: uuid.optional(),
+    orgId: uuid.optional(),
+    name: z.string().min(1).max(255).optional(),
+    targetType: z.enum(['org', 'site', 'group', 'device', 'tag']).optional(),
+    targetIds: z.array(z.string().min(1).max(255)).max(500).optional(),   // plain strings: 'tag' targets tag NAMES
+    allowedExtensions: z.array(z.string().min(1).max(255)).max(1000).optional(),
+    blockedExtensions: z.array(z.string().min(1).max(255)).max(1000).optional(),
+    requiredExtensions: z.array(z.string().min(1).max(255)).max(1000).optional(),
+    settings: z.record(z.string(), z.unknown()).optional(),
+    isActive: z.boolean().optional(),
+    deviceIds: z.array(uuid).max(1000).optional(),
+  }),
+
+  query_compliance_policies: z.object({
+    enabled: z.boolean().optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  }),
+
+  get_compliance_status: z.object({
+    policyId: uuid,
+    status: z.enum(['compliant', 'non_compliant', 'pending', 'error']).optional(),
+    deviceId: uuid.optional(),
+    limit: z.number().int().min(1).max(200).optional(),
+  }),
+
+  manage_software_policies: z.object({
+    action: z.enum(['list', 'get', 'create', 'update']),
+    policyId: uuid.optional(),
+    ownerScope: z.enum(['organization', 'partner']).optional(),
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(4000).optional(),
+    mode: z.enum(['allowlist', 'blocklist', 'audit']).optional(),
+    rules: z.object({
+      software: z.array(z.object({
+        name: z.string().min(1).max(500),
+        vendor: z.string().max(200).optional(),
+        minVersion: z.string().max(100).optional(),
+        maxVersion: z.string().max(100).optional(),
+        catalogId: uuid.optional(),
+        reason: z.string().max(1000).optional(),
+      })).max(1000).optional(),
+      allowUnknown: z.boolean().optional(),
+    }).optional(),
+    enforceMode: z.boolean().optional(),
+    remediationOptions: z.object({
+      autoUninstall: z.boolean().optional(),
+      notifyUser: z.boolean().optional(),
+      gracePeriod: z.number().int().min(0).max(2160).optional(),
+      cooldownMinutes: z.number().int().min(1).max(129600).optional(),
+      maintenanceWindowOnly: z.boolean().optional(),
+    }).optional(),
+    isActive: z.boolean().optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  }).refine(
+    (data) => !['get', 'update'].includes(data.action) || !!data.policyId,
+    { message: 'policyId is required for get/update actions' }
+  ).refine(
+    (data) => data.action !== 'create' || (!!data.name && !!data.mode),
+    { message: 'name and mode are required for create action' }
+  ),
+
+  manage_peripheral_policies: z.object({
+    action: z.enum(['list', 'get', 'create', 'update']),
+    policyId: uuid.optional(),
+    name: z.string().min(1).max(200).optional(),
+    deviceClass: z.enum(peripheralDeviceClassEnum.enumValues).optional(),
+    action_type: z.enum(peripheralPolicyActionEnum.enumValues).optional(),
+    exceptions: z.array(z.object({
+      vendor: z.string().max(255).optional(),
+      product: z.string().max(255).optional(),
+      serialNumber: z.string().max(255).optional(),
+      allow: z.boolean().optional(),
+      reason: z.string().max(2000).optional(),
+      expiresAt: z.string().datetime({ offset: true }).optional(),
+    })).max(500).optional(),
+    isActive: z.boolean().optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+  }).refine(
+    (data) => !['get', 'update'].includes(data.action) || !!data.policyId,
+    { message: 'policyId is required for get/update actions' }
+  ).refine(
+    (data) => data.action !== 'create' || (!!data.name && !!data.deviceClass && !!data.action_type),
+    { message: 'name, deviceClass, and action_type are required for create action' }
   ),
 
   // Fleet orchestration tools

--- a/apps/api/src/services/aiToolsDns.siteScope.test.ts
+++ b/apps/api/src/services/aiToolsDns.siteScope.test.ts
@@ -99,3 +99,44 @@ describe('get_dns_security — site narrowing (cross-site enumeration)', () => {
     expect(parsed.source).toBe('raw');
   });
 });
+
+// D.4: manage_dns_policy had NO site-scope guard at all (unlike every sibling
+// write tool) — a site-restricted org user could write org-wide DNS policy.
+describe('manage_dns_policy — site-restricted callers are denied (D.4 fail-closed guard)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const ADD_BLOCK_INPUT = {
+    integrationId: '11111111-1111-1111-1111-111111111111',
+    action: 'add_block',
+    domains: ['bad.example'],
+  };
+
+  it('rejects a site-restricted caller without touching the database', async () => {
+    const r = await handlerFor('manage_dns_policy')(ADD_BLOCK_INPUT, makeAuth(['site-A']));
+    const parsed = JSON.parse(r);
+
+    expect(parsed.error).toMatch(/full-organization access/i);
+    expect(mockDb.select).not.toHaveBeenCalled();
+  });
+
+  it('unrestricted caller is unaffected (no regression) — proceeds past the guard', async () => {
+    mockDb.select.mockImplementation((cols?: unknown) => {
+      // integration lookup
+      if (cols && typeof cols === 'object' && 'orgId' in (cols as object) && Object.keys(cols as object).length === 2) {
+        return chain([{ id: ADD_BLOCK_INPUT.integrationId, orgId: 'org-1' }]);
+      }
+      // policy lookup — none exists yet
+      return chain([]);
+    });
+    (db.insert as ReturnType<typeof vi.fn>).mockReturnValue({
+      values: () => ({ returning: () => Promise.resolve([{ id: 'policy-1', domains: [] }]) }),
+    });
+    (db.update as ReturnType<typeof vi.fn>).mockReturnValue({ set: () => ({ where: () => Promise.resolve(undefined) }) });
+
+    const r = await handlerFor('manage_dns_policy')(ADD_BLOCK_INPUT, makeAuth(undefined));
+    const parsed = JSON.parse(r);
+
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/apps/api/src/services/aiToolsDns.ts
+++ b/apps/api/src/services/aiToolsDns.ts
@@ -391,6 +391,16 @@ export function registerDnsTools(aiTools: Map<string, AiTool>): void {
       }
     },
     handler: async (input, auth) => {
+      // Site axis (app-layer only; RLS does NOT enforce it). DNS policy is
+      // org-wide, and full site-scoping semantics for org-level DNS
+      // integrations is deliberately deferred — fail closed instead of
+      // letting a site-restricted caller write org-wide policy (unlike every
+      // sibling write tool, this handler has no per-row site check to fall
+      // back on).
+      if (auth.allowedSiteIds && auth.canAccessSite) {
+        return JSON.stringify({ error: 'DNS policy management requires full-organization access' });
+      }
+
       const integrationId = input.integrationId as string;
       const action = input.action as 'add_block' | 'remove_block' | 'add_allow' | 'remove_allow';
       const domainsInput = Array.isArray(input.domains) ? input.domains : [];

--- a/apps/api/src/services/aiToolsIntegrations.test.ts
+++ b/apps/api/src/services/aiToolsIntegrations.test.ts
@@ -14,15 +14,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   dbSelect: vi.fn(),
   dbInsert: vi.fn(),
+  dbUpdate: vi.fn(),
   decryptForColumn: vi.fn(),
   redactUrlForLogs: vi.fn(),
+  queueDelivery: vi.fn(),
+  toWorkerWebhookConfig: vi.fn(),
 }));
 
 vi.mock('../db', () => ({
   db: {
     select: mocks.dbSelect,
     insert: mocks.dbInsert,
+    update: mocks.dbUpdate,
   },
+}));
+
+// test_webhook now mirrors routes/webhooks.ts POST /:id/test and actually
+// dispatches to the worker (D.1 fix) — mock the worker + config mapper so
+// these tests exercise the dispatch call without touching Redis/eventBus.
+vi.mock('../workers/webhookDelivery', () => ({
+  getWebhookWorker: () => ({ queueDelivery: mocks.queueDelivery }),
+}));
+
+vi.mock('../routes/webhooks', () => ({
+  toWorkerWebhookConfig: mocks.toWorkerWebhookConfig,
 }));
 
 // Mock the schema so Drizzle column references resolve without a real DB.
@@ -145,6 +160,14 @@ function makeInsertChain(rows: unknown[]) {
   const chain: any = {};
   chain.values = vi.fn(() => chain);
   chain.returning = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+/** Fluent update chain that resolves after .set().where() */
+function makeUpdateChain() {
+  const chain: any = {};
+  chain.set = vi.fn(() => chain);
+  chain.where = vi.fn(() => Promise.resolve(undefined));
   return chain;
 }
 
@@ -280,6 +303,8 @@ describe('aiToolsIntegrations — test_webhook credential masking', () => {
 
     mocks.decryptForColumn.mockImplementation((_table: string, _col: string, val: string) => val);
     mocks.redactUrlForLogs.mockImplementation((url: string) => realRedact(url));
+    mocks.toWorkerWebhookConfig.mockImplementation((w: unknown) => w);
+    mocks.queueDelivery.mockResolvedValue('worker-delivery-id');
   });
 
   it('masks credential-bearing webhookUrl in the test_webhook response', async () => {
@@ -287,7 +312,7 @@ describe('aiToolsIntegrations — test_webhook credential masking', () => {
 
     // First select: fetch the webhook row.
     mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
-      { id: WEBHOOK_ID, name: 'Test Hook', url: credentialUrl },
+      { id: WEBHOOK_ID, orgId: ORG_ID, name: 'Test Hook', url: credentialUrl },
     ]));
 
     // Insert: create delivery record.
@@ -308,6 +333,14 @@ describe('aiToolsIntegrations — test_webhook credential masking', () => {
     expect(result).not.toContain('admin:');
     expect(result).not.toContain('mysecret');
     expect(parsed.webhookUrl).toBe('https://hooks.example.com/test');
+    // D.1: the delivery must actually be dispatched to the worker, not just
+    // inserted as a permanently-'pending' row.
+    expect(mocks.queueDelivery).toHaveBeenCalledTimes(1);
+    expect(mocks.queueDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({ id: WEBHOOK_ID, orgId: ORG_ID }),
+      expect.objectContaining({ orgId: ORG_ID }),
+      DELIVERY_ID,
+    );
   });
 
   it('masks encrypted URL in test_webhook — ciphertext not echoed', async () => {
@@ -317,7 +350,7 @@ describe('aiToolsIntegrations — test_webhook credential masking', () => {
     mocks.decryptForColumn.mockImplementation(() => decryptedUrl);
 
     mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
-      { id: WEBHOOK_ID, name: 'Enc Test Hook', url: encryptedUrl },
+      { id: WEBHOOK_ID, orgId: ORG_ID, name: 'Enc Test Hook', url: encryptedUrl },
     ]));
 
     mocks.dbInsert.mockReturnValueOnce(makeInsertChain([
@@ -345,7 +378,7 @@ describe('aiToolsIntegrations — test_webhook credential masking', () => {
     mocks.redactUrlForLogs.mockImplementation((val: string) => realRedact(val));
 
     mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
-      { id: WEBHOOK_ID, name: 'Broken Hook', url: encryptedUrl },
+      { id: WEBHOOK_ID, orgId: ORG_ID, name: 'Broken Hook', url: encryptedUrl },
     ]));
 
     mocks.dbInsert.mockReturnValueOnce(makeInsertChain([
@@ -371,5 +404,29 @@ describe('aiToolsIntegrations — test_webhook credential masking', () => {
     const parsed = JSON.parse(result);
 
     expect(parsed.error).toMatch(/not found|access denied/i);
+  });
+
+  it('marks the delivery failed (not left permanently pending) when the worker queue rejects', async () => {
+    mocks.dbSelect.mockReturnValueOnce(makeSelectChain([
+      { id: WEBHOOK_ID, orgId: ORG_ID, name: 'Test Hook', url: 'https://hooks.example.com/test' },
+    ]));
+    mocks.dbInsert.mockReturnValueOnce(makeInsertChain([
+      { id: DELIVERY_ID, createdAt: new Date('2026-06-01T00:00:00Z') },
+    ]));
+    const updateChain = makeUpdateChain();
+    mocks.dbUpdate.mockReturnValueOnce(updateChain);
+    mocks.queueDelivery.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    const result = await toolMap.get('test_webhook')!.handler(
+      { webhookId: WEBHOOK_ID },
+      makeAuth(),
+    );
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toMatch(/failed to queue/i);
+    expect(mocks.dbUpdate).toHaveBeenCalledTimes(1);
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', errorMessage: 'redis unavailable' }),
+    );
   });
 });

--- a/apps/api/src/services/aiToolsIntegrations.ts
+++ b/apps/api/src/services/aiToolsIntegrations.ts
@@ -18,6 +18,8 @@ import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { decryptForColumn } from './secretCrypto';
 import { redactUrlForLogs } from './notificationSenders/webhookSender';
+import { getWebhookWorker } from '../workers/webhookDelivery';
+import { toWorkerWebhookConfig } from '../routes/webhooks';
 
 // webhooks.url is encrypted at rest and may embed credentials. Decrypt for
 // display then strip userinfo/query/hash so the AI tool never sees a token.
@@ -243,13 +245,15 @@ export function registerIntegrationTools(aiTools: Map<string, AiTool>): void {
     handler: safeHandler('test_webhook', async (input, auth) => {
       const webhookId = input.webhookId as string;
 
-      // Verify webhook exists and belongs to org
+      // Verify webhook exists and belongs to org. Select the full row — the
+      // worker config mapper needs orgId/secret/headers/events/retryPolicy,
+      // not just id/name/url.
       const conditions: SQL[] = [eq(webhooks.id, webhookId)];
       const orgCond = auth.orgCondition(webhooks.orgId);
       if (orgCond) conditions.push(orgCond);
 
       const [webhook] = await db
-        .select({ id: webhooks.id, name: webhooks.name, url: webhooks.url })
+        .select()
         .from(webhooks)
         .where(and(...conditions))
         .limit(1);
@@ -259,20 +263,61 @@ export function registerIntegrationTools(aiTools: Map<string, AiTool>): void {
       }
 
       // Insert a test delivery record
-      const now = new Date().toISOString();
+      const eventType = 'test';
+      const eventId = `test-${Date.now()}`;
+      const now = new Date();
+      const payload = { test: true, timestamp: now.toISOString() };
       const [delivery] = await db
         .insert(webhookDeliveries)
         .values({
           webhookId: webhook.id,
-          eventType: 'test',
-          eventId: `test-${Date.now()}`,
-          payload: { test: true, timestamp: now },
+          eventType,
+          eventId,
+          payload,
           status: 'pending',
           attempts: 0,
         })
         .returning({ id: webhookDeliveries.id, createdAt: webhookDeliveries.createdAt });
 
       if (!delivery) return JSON.stringify({ error: 'Failed to create test delivery record' });
+
+      // Mirror routes/webhooks.ts POST /:id/test — an inserted 'pending' row
+      // with no worker dispatch never actually sends anything. Queue the
+      // delivery the same way the route does, and mark it 'failed' on a queue
+      // error instead of leaving a permanently-stuck 'pending' row.
+      const event = {
+        id: eventId,
+        type: eventType,
+        orgId: webhook.orgId,
+        source: 'webhook.test',
+        priority: 'normal',
+        payload,
+        metadata: {
+          timestamp: now.toISOString(),
+          userId: auth.user.id,
+        },
+      };
+
+      try {
+        await getWebhookWorker().queueDelivery(toWorkerWebhookConfig(webhook), event as any, delivery.id);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown queue error';
+        await db
+          .update(webhookDeliveries)
+          .set({
+            status: 'failed',
+            attempts: 1,
+            errorMessage,
+            deliveredAt: new Date(),
+          })
+          .where(eq(webhookDeliveries.id, delivery.id));
+
+        return JSON.stringify({
+          error: 'Failed to queue webhook delivery',
+          deliveryId: delivery.id,
+          webhookId: webhook.id,
+        });
+      }
 
       return JSON.stringify({
         success: true,

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -180,7 +180,7 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
           gracePeriodHours: { type: 'number', description: 'Hours after deadline before reboot is forced (default: 4)' },
           categories: { type: 'array', items: { type: 'string' }, description: 'Patch categories to include (e.g. ["critical","important","security"])' },
           excludeCategories: { type: 'array', items: { type: 'string' }, description: 'Patch categories to exclude' },
-          sources: { type: 'array', items: { type: 'string' }, description: 'Patch sources: ["os","third_party"]' },
+          sources: { type: 'array', items: { type: 'string' }, description: 'Patch sources: ["microsoft","apple","linux","third_party","custom"]' },
           autoApprove: { type: 'object', description: 'Auto-approval rules (e.g. { enabled: true, severities: ["critical","important"], deferralDays: 0 }). severities must be a subset of ["critical","important","moderate","low"]. If enabled is true you MUST list at least one severity — an enabled rule with an empty severity set is rejected (it would auto-approve nothing).' },
           enabled: { type: 'boolean', description: 'Whether ring is active (for update)' },
           limit: { type: 'number', description: 'Max results for list (default 25)' },

--- a/apps/api/src/services/aiToolsRegistryParity.test.ts
+++ b/apps/api/src/services/aiToolsRegistryParity.test.ts
@@ -6,72 +6,16 @@ import { TOOL_PERMISSIONS } from './aiGuardrails';
 describe('aiTools registry parity', () => {
   const toolNames = Array.from(aiTools.keys());
 
-  // Pre-existing registered tools missing schemas/permissions; tracked as known debt for a separate follow-up.
-  const legacySchemaGaps = new Set([
-    'query_analytics',
-    'get_executive_summary',
-    'manage_update_rings',
-    'manage_software_policies',
-    'manage_peripheral_policies',
-    'manage_backup_configs',
-    'query_webhooks',
-    'query_psa_status',
-    'test_webhook',
-    'manage_tags',
-    'query_custom_fields',
-    'get_browser_security',
-    'manage_browser_policy',
-    'manage_scheduled_tasks',
-    'registry_operations',
-    'query_compliance_policies',
-    'get_compliance_status',
-    'manage_notification_channels',
-    'create_incident',
-    'execute_containment',
-    'collect_evidence',
-    'get_incident_timeline',
-    'generate_incident_report',
-    'search_documentation',
-    'list_remote_sessions',
-    'create_remote_session',
-    'query_agent_versions',
-    'trigger_agent_upgrade',
-    'trigger_agent_restart',
-    'manage_saved_filters',
-  ]);
+  // Registration-debt payoff: every tool that was ever missing a schema/
+  // permission entry has now been given one — both sets are intentionally
+  // EMPTY. Do NOT add a tool name back into either set as a way to skip
+  // writing its schema/permissions; add the real entry in aiToolSchemas.ts /
+  // aiGuardrails.ts instead. A newly-registered tool with no schema or no
+  // permission entry is exactly the bug this contract test exists to catch.
+  const legacySchemaGaps = new Set<string>([]);
 
-  // Pre-existing registered tools missing schemas/permissions; tracked as known debt for a separate follow-up.
-  const legacyPermissionGaps = new Set([
-    'manage_update_rings',
-    'manage_software_policies',
-    'manage_peripheral_policies',
-    'manage_backup_configs',
-    'get_network_changes',
-    'acknowledge_network_device',
-    'configure_network_baseline',
-    'get_ip_history',
-    'get_sensitive_data_overview',
-    'remediate_sensitive_data',
-    'get_dns_security',
-    'manage_dns_policy',
-    'get_peripheral_activity',
-    'manage_peripheral_policy',
-    'get_browser_security',
-    'manage_browser_policy',
-    'get_software_compliance',
-    'manage_software_policy',
-    'remediate_software_violation',
-    'create_incident',
-    'execute_containment',
-    'collect_evidence',
-    'get_incident_timeline',
-    'generate_incident_report',
-    'get_active_users',
-    'get_user_experience_metrics',
-    'request_elevation',
-    'revoke_elevation',
-    'get_elevation_history',
-  ]);
+  // See legacySchemaGaps above — kept empty on purpose.
+  const legacyPermissionGaps = new Set<string>([]);
 
   it('every registered tool has a Zod input schema, except tracked legacy gaps', () => {
     const missing = toolNames.filter(name => !(name in toolInputSchemas));

--- a/apps/api/src/services/aiToolsScripts.commandTypes.test.ts
+++ b/apps/api/src/services/aiToolsScripts.commandTypes.test.ts
@@ -17,7 +17,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 const mocks = vi.hoisted(() => ({
-  executeCommand: vi.fn(async () => ({ status: 'completed' })),
+  executeCommand: vi.fn(async (..._args: unknown[]) => ({ status: 'completed' })),
 }));
 const { executeCommand } = mocks;
 

--- a/apps/api/src/services/aiToolsScripts.commandTypes.test.ts
+++ b/apps/api/src/services/aiToolsScripts.commandTypes.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression coverage for the class of bug fixed in D.2/D.3 of the MCP
+ * tool-registration-debt payoff: manage_scheduled_tasks and registry_operations
+ * were dispatching INVENTED command-type strings (e.g. 'scheduled_tasks_run',
+ * 'registry_read_key') that do not exist in commandQueue.ts's CommandTypes —
+ * the agent silently rejects/ignores an unrecognized command type, so every
+ * call from these tools was a dead end with zero test coverage catching it.
+ *
+ * This suite asserts the command type strings these two handlers actually
+ * dispatch are real members of CommandTypes (not just plausible-looking
+ * strings), and pins the exact action → CommandTypes mapping so a future edit
+ * can't silently drift back to invented values. `./commandQueue` is only
+ * partially mocked (executeCommand swapped for a spy via importOriginal) so
+ * CommandTypes stays the real, exported source of truth.
+ */
+
+const mocks = vi.hoisted(() => ({
+  executeCommand: vi.fn(async () => ({ status: 'completed' })),
+}));
+const { executeCommand } = mocks;
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+vi.mock('./commandQueue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./commandQueue')>();
+  return { ...actual, executeCommand: mocks.executeCommand };
+});
+
+import { db } from '../db';
+import { CommandTypes } from './commandQueue';
+import { registerScriptTools } from './aiToolsScripts';
+import type { AiTool } from './aiTools';
+import type { AuthContext } from '../middleware/auth';
+
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const REAL_COMMAND_TYPES = new Set<string>(Object.values(CommandTypes));
+
+function toolMap(): Map<string, AiTool> {
+  const map = new Map<string, AiTool>();
+  registerScriptTools(map);
+  return map;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    canAccessSite: () => true,
+  } as unknown as AuthContext;
+}
+
+function mockOnlineDevice() {
+  (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve([
+          { id: DEVICE_ID, hostname: 'dev1', siteId: null, status: 'online', orgId: 'org-1' },
+        ]),
+      }),
+    }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockOnlineDevice();
+});
+
+describe('manage_scheduled_tasks — dispatches real CommandTypes values', () => {
+  const cases: Array<{ action: string; input: Record<string, unknown>; expected: string }> = [
+    { action: 'list', input: {}, expected: CommandTypes.TASKS_LIST },
+    { action: 'run', input: { taskName: '\\Microsoft\\Windows\\Foo\\Bar' }, expected: CommandTypes.TASK_RUN },
+    { action: 'disable', input: { taskName: '\\Microsoft\\Windows\\Foo\\Bar' }, expected: CommandTypes.TASK_DISABLE },
+    { action: 'enable', input: { taskName: '\\Microsoft\\Windows\\Foo\\Bar' }, expected: CommandTypes.TASK_ENABLE },
+  ];
+
+  it.each(cases)('action "$action" dispatches a real, correctly-mapped CommandTypes value', async ({ action, input, expected }) => {
+    const tool = toolMap().get('manage_scheduled_tasks')!;
+    await tool.handler({ deviceId: DEVICE_ID, action, ...input }, makeAuth());
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    const [, commandType] = executeCommand.mock.calls[0]!;
+    expect(REAL_COMMAND_TYPES.has(commandType as string)).toBe(true);
+    expect(commandType).toBe(expected);
+  });
+
+  it('sends the full task path as payload.path (agent reads "path", not "taskName")', async () => {
+    const tool = toolMap().get('manage_scheduled_tasks')!;
+    await tool.handler({ deviceId: DEVICE_ID, action: 'run', taskName: '\\Microsoft\\Windows\\Foo\\Bar' }, makeAuth());
+
+    const [, , payload] = executeCommand.mock.calls[0]!;
+    expect(payload).toEqual({ path: '\\Microsoft\\Windows\\Foo\\Bar' });
+  });
+
+  it('the "delete" action no longer exists (dropped — no agent-side implementation)', async () => {
+    const tool = toolMap().get('manage_scheduled_tasks')!;
+    const result = await tool.handler({ deviceId: DEVICE_ID, action: 'delete', taskName: 'x' }, makeAuth());
+    const parsed = JSON.parse(result);
+
+    expect(parsed.error).toMatch(/unknown action/i);
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe('registry_operations — dispatches real CommandTypes values', () => {
+  const cases: Array<{ action: string; input: Record<string, unknown>; expected: string }> = [
+    { action: 'read_key', input: { keyPath: 'HKLM\\SOFTWARE\\Foo' }, expected: CommandTypes.REGISTRY_VALUES },
+    { action: 'get_value', input: { keyPath: 'HKLM\\SOFTWARE\\Foo', valueName: 'Bar' }, expected: CommandTypes.REGISTRY_GET },
+    { action: 'set_value', input: { keyPath: 'HKLM\\SOFTWARE\\Foo', valueName: 'Bar', valueData: 'baz' }, expected: CommandTypes.REGISTRY_SET },
+    { action: 'create_key', input: { keyPath: 'HKLM\\SOFTWARE\\Foo' }, expected: CommandTypes.REGISTRY_KEY_CREATE },
+    { action: 'delete_key', input: { keyPath: 'HKLM\\SOFTWARE\\Foo' }, expected: CommandTypes.REGISTRY_KEY_DELETE },
+  ];
+
+  it.each(cases)('action "$action" dispatches a real, correctly-mapped CommandTypes value', async ({ action, input, expected }) => {
+    const tool = toolMap().get('registry_operations')!;
+    await tool.handler({ deviceId: DEVICE_ID, action, ...input }, makeAuth());
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    const [, commandType] = executeCommand.mock.calls[0]!;
+    expect(REAL_COMMAND_TYPES.has(commandType as string)).toBe(true);
+    expect(commandType).toBe(expected);
+  });
+
+  it('splits keyPath into {hive, path} — agent reads hive/path, not a combined keyPath', async () => {
+    const tool = toolMap().get('registry_operations')!;
+    await tool.handler(
+      { deviceId: DEVICE_ID, action: 'get_value', keyPath: 'HKLM\\SOFTWARE\\Microsoft\\Windows', valueName: 'Ver' },
+      makeAuth(),
+    );
+
+    const [, , payload] = executeCommand.mock.calls[0]!;
+    expect(payload).toEqual({ hive: 'HKLM', path: 'SOFTWARE\\Microsoft\\Windows', name: 'Ver' });
+  });
+
+  it('defaults to hive HKLM when keyPath carries no recognized hive prefix', async () => {
+    const tool = toolMap().get('registry_operations')!;
+    await tool.handler(
+      { deviceId: DEVICE_ID, action: 'read_key', keyPath: 'SOFTWARE\\NoHivePrefix' },
+      makeAuth(),
+    );
+
+    const [, , payload] = executeCommand.mock.calls[0]!;
+    expect(payload).toEqual({ hive: 'HKLM', path: 'SOFTWARE\\NoHivePrefix' });
+  });
+
+  it('maps valueName/valueData/valueType to name/data/type for set_value', async () => {
+    const tool = toolMap().get('registry_operations')!;
+    await tool.handler(
+      {
+        deviceId: DEVICE_ID,
+        action: 'set_value',
+        keyPath: 'HKCU\\Software\\Foo',
+        valueName: 'Enabled',
+        valueData: '1',
+        valueType: 'REG_DWORD',
+      },
+      makeAuth(),
+    );
+
+    const [, , payload] = executeCommand.mock.calls[0]!;
+    expect(payload).toEqual({ hive: 'HKCU', path: 'Software\\Foo', name: 'Enabled', data: '1', type: 'REG_DWORD' });
+  });
+});

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -46,6 +46,32 @@ async function getCommandQueue() {
 // Shared helpers
 // ============================================
 
+// Known registry hive tokens the agent accepts (internal/remote/tools/registry_windows.go
+// resolveRegistryRoot), long forms first so a long-form prefix isn't mistaken
+// for a truncated short form.
+const REGISTRY_HIVE_PREFIXES = [
+  'HKEY_LOCAL_MACHINE', 'HKEY_CURRENT_USER', 'HKEY_CLASSES_ROOT', 'HKEY_USERS', 'HKEY_CURRENT_CONFIG',
+  'HKLM', 'HKCU', 'HKCR', 'HKU', 'HKCC',
+];
+
+/**
+ * Split a `registry_operations` tool `keyPath` (e.g.
+ * "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion") into the {hive, path}
+ * shape the agent's registry handlers actually read. Defaults to hive "HKLM"
+ * when the path carries no recognized hive prefix, mirroring the agent's own
+ * `GetPayloadString(payload, "hive", "HKLM")` default.
+ */
+export function splitRegistryKeyPath(keyPath: string): { hive: string; path: string } {
+  const upper = keyPath.toUpperCase();
+  for (const prefix of REGISTRY_HIVE_PREFIXES) {
+    if (upper === prefix || upper.startsWith(`${prefix}\\`) || upper.startsWith(`${prefix}:`)) {
+      const rest = keyPath.slice(prefix.length).replace(/^[\\:]+/, '');
+      return { hive: prefix, path: rest };
+    }
+  }
+  return { hive: 'HKLM', path: keyPath };
+}
+
 async function verifyDeviceAccess(
   deviceId: string,
   auth: AuthContext,
@@ -710,17 +736,20 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
     deviceArgs: ['deviceId'],
     definition: {
       name: 'manage_scheduled_tasks',
-      description: 'List, run, enable, disable, or delete Windows scheduled tasks on a device.',
+      description: 'List, run, enable, or disable Windows scheduled tasks on a device.',
       input_schema: {
         type: 'object' as const,
         properties: {
           deviceId: { type: 'string', description: 'The device UUID' },
           action: {
             type: 'string',
-            enum: ['list', 'run', 'disable', 'enable', 'delete'],
+            enum: ['list', 'run', 'disable', 'enable'],
             description: 'Action to perform on scheduled tasks'
           },
-          taskName: { type: 'string', description: 'Task name (required for run/disable/enable/delete)' },
+          taskName: {
+            type: 'string',
+            description: 'Full scheduled-task path (e.g. \\Microsoft\\Windows\\...\\TaskName) — required for run/disable/enable'
+          },
           search: { type: 'string', description: 'Filter task list by name (only for list action)' }
         },
         required: ['deviceId', 'action']
@@ -733,13 +762,12 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       const access = await verifyDeviceAccess(deviceId, auth, true);
       if ('error' in access) return JSON.stringify({ error: access.error });
 
-      const { executeCommand } = await getCommandQueue();
+      const { executeCommand, CommandTypes } = await getCommandQueue();
       const commandTypeMap: Record<string, string> = {
-        list: 'scheduled_tasks_list',
-        run: 'scheduled_tasks_run',
-        disable: 'scheduled_tasks_disable',
-        enable: 'scheduled_tasks_enable',
-        delete: 'scheduled_tasks_delete'
+        list: CommandTypes.TASKS_LIST,
+        run: CommandTypes.TASK_RUN,
+        disable: CommandTypes.TASK_DISABLE,
+        enable: CommandTypes.TASK_ENABLE,
       };
 
       const commandType = commandTypeMap[action];
@@ -750,7 +778,8 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
         if (input.search) payload.search = input.search;
       } else {
         if (!input.taskName) return JSON.stringify({ error: 'taskName is required for this action' });
-        payload.taskName = input.taskName;
+        // Agent reads the full Task Scheduler path from `path`, not `taskName`.
+        payload.path = input.taskName;
       }
 
       const result = await executeCommand(deviceId, commandType, payload, {
@@ -803,26 +832,29 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
       const access = await verifyDeviceAccess(deviceId, auth, true);
       if ('error' in access) return JSON.stringify({ error: access.error });
 
-      const { executeCommand } = await getCommandQueue();
+      const { executeCommand, CommandTypes } = await getCommandQueue();
 
       const commandTypeMap: Record<string, string> = {
-        read_key: 'registry_read_key',
-        get_value: 'registry_get_value',
-        set_value: 'registry_set_value',
-        create_key: 'registry_create_key',
-        delete_key: 'registry_delete_key',
+        read_key: CommandTypes.REGISTRY_VALUES,
+        get_value: CommandTypes.REGISTRY_GET,
+        set_value: CommandTypes.REGISTRY_SET,
+        create_key: CommandTypes.REGISTRY_KEY_CREATE,
+        delete_key: CommandTypes.REGISTRY_KEY_DELETE,
       };
 
       const commandType = commandTypeMap[action];
       if (!commandType) return JSON.stringify({ error: `Unknown action: ${action}` });
 
-      const payload: Record<string, unknown> = {
-        keyPath: input.keyPath,
-      };
+      // Agent reads {hive, path, name, type, data} (internal/remote/tools/registry.go),
+      // not a single keyPath/valueName/valueData/valueType shape. Split the
+      // tool's keyPath into hive + path so the payload matches what the agent
+      // actually parses.
+      const { hive, path } = splitRegistryKeyPath(input.keyPath as string);
+      const payload: Record<string, unknown> = { hive, path };
 
-      if (input.valueName) payload.valueName = input.valueName;
-      if (input.valueData !== undefined) payload.valueData = input.valueData;
-      if (input.valueType) payload.valueType = input.valueType;
+      if (input.valueName) payload.name = input.valueName;
+      if (input.valueData !== undefined) payload.data = input.valueData;
+      if (input.valueType) payload.type = input.valueType;
 
       const result = await executeCommand(deviceId, commandType, payload, {
         userId: auth.user.id,

--- a/apps/web/src/components/ai-risk/tierConfig.ts
+++ b/apps/web/src/components/ai-risk/tierConfig.ts
@@ -192,7 +192,7 @@ export const TIER_DEFINITIONS: TierDefinition[] = [
       { name: 'manage_services (start/stop/restart)', description: 'Mutate device services', category: 'Services & Processes' },
       { name: 'manage_processes (kill)', description: 'Terminate a running process', category: 'Services & Processes' },
       { name: 'manage_startup_items (enable/disable)', description: 'Manage startup items', category: 'Services & Processes' },
-      { name: 'manage_scheduled_tasks (run/disable/enable/delete)', description: 'Mutate scheduled tasks', category: 'Services & Processes' },
+      { name: 'manage_scheduled_tasks (run/disable/enable)', description: 'Mutate scheduled tasks', category: 'Services & Processes' },
       // Remote Access & Control
       { name: 'execute_command', description: 'Execute system commands on device', category: 'Remote Access & Control' },
       { name: 'run_script', description: 'Run scripts on up to 10 devices', category: 'Remote Access & Control' },
@@ -351,7 +351,7 @@ export const RBAC_MAPPINGS: Record<string, string | Record<string, string>> = {
   // Services & startup
   manage_services: 'devices.execute',
   manage_startup_items: 'devices.execute',
-  manage_scheduled_tasks: { list: 'devices.read', run: 'devices.execute', disable: 'devices.execute', enable: 'devices.execute', delete: 'devices.execute' },
+  manage_scheduled_tasks: { list: 'devices.read', run: 'devices.execute', disable: 'devices.execute', enable: 'devices.execute' },
   // Security
   security_scan: { scan: 'devices.execute', status: 'devices.execute', quarantine: 'devices.execute', remove: 'devices.execute', restore: 'devices.execute', vulnerabilities: 'devices.read' },
   get_security_posture: 'devices.read',


### PR DESCRIPTION
## Summary

Pays off the entire AI/MCP tool-registration debt tracked in `aiToolsRegistryParity.test.ts` (both legacy allowlists now **empty** — the parity ratchet is total), and locks the MCP transport out of Tier-3 execution per explicit decision (2026-08-02).

### Registration debt (the ~40 "advertised but dead" tools)
Live MCP testing showed every one of these tools was registered and advertised but fail-closed on every call (`No input schema registered` / `No RBAC permission mapping`). Five read-audit agents produced per-tool specs; every handler proved to be real, working code — zero deregistrations.
- **30 Zod schema entries** added to `toolInputSchemas`, each verified against its handler's actual input reads.
- **28 `TOOL_PERMISSIONS` entries** added, each chosen by analogy with existing tools or the literal backing REST route (PAM elevation tools mirror `routes/pam.ts`'s `requirePamRead`/`requirePamExecute`; network tools mirror `networkChanges.ts`/`networkBaselines.ts` grants). Plus completed `manage_notification_channels`' per-action map (create/update/delete were missing → fail-closed even for admins).
- **3 rate limits** added for the destructive additions (`execute_containment`, `collect_evidence`, `remediate_software_violation`).

### Real bugs found by the audits, fixed here
1. **`manage_scheduled_tasks` / `registry_operations` never worked at any layer** — they dispatched invented command-type strings (`scheduled_tasks_list`, `registry_read_key`, …) that exist nowhere in the Go agent, with wrong payload field names. Now use the real `CommandTypes` constants and agent payload shapes (`path`; `{hive, path, name, type, data}` with hive-prefix parsing). `manage_scheduled_tasks`' `delete` action is **removed** — the agent has no implementation for it. New `aiToolsScripts.commandTypes.test.ts` asserts dispatched command types are real `CommandTypes` members so this drift class can't recur.
2. **`test_webhook` was a dead-end stub** — inserted a `pending` delivery row and never called the worker. Now queues via `getWebhookWorker().queueDelivery(...)` exactly like `POST /webhooks/:id/test`.
3. **`manage_dns_policy` had no site-scope enforcement** (harmless only while dead). Now denies site-restricted callers outright; real site-scoping semantics for org-level DNS integrations is a filed follow-up.
4. **`manage_software_policy`'s schema required `targetType` its handler ignores** — valid creates were rejected. Refine loosened to the handler's actual requirements.

### MCP Tier-3 approval gate (decision 2026-08-02, reverses the 2026-07-29 auto-execute ruling)
`tools/call` now denies **every effective-Tier-3 call** (same `Math.max(baseTier, checkGuardrails().tier)` resolution the route already computed — tier-driven, no hand list) with structured `MCP_APPROVAL_REQUIRED`, plus `collect_evidence` (Tier 2 but privileged unattended device extraction). **37 wholly-gated tools are suppressed from `tools/list`** (no advertised-but-dead surface); **19 mixed multiplexers stay listed** with a description note naming their web-app-only actions. Draft/read automation (e.g. `manage_invoices` `create_draft`) keeps working over MCP. The in-app interactive path — where the durable `action_intents` approval workflow gates Tier 3 — is untouched, with tests asserting both directions.

## Tests
- New: `mcpServer.approvalGate.test.ts` (459 lines: gated/ungated/per-action/tools-list suppression/in-app-unaffected), `aiToolsScripts.commandTypes.test.ts`.
- Extended: parity, guardrails, DNS site-scope, integrations (queueDelivery), mcpServer suites.
- Full API suite: 19,335 passed / 1 pre-existing flake (`noRawEnvNumberCoercion.test.ts` timeout under load, green in isolation).
- Independently re-verified by the orchestrating session: parity + approvalGate + guardrails + commandTypes + tierConfig parity = 151/151 green.

## Follow-ups filed (not in this PR)
DNS-vs-browser policy tier asymmetry · dedicated elevated permission for sensitive-data `accept_risk` · read actions for `manage_dns_policy`/`manage_organizations`/`manage_hyperv_checkpoints` · MCP-initiated durable intents (MCP call creates pending intent → web approval → worker executes) if unattended Tier-3 automation is needed again · script timeout enforcement (601s run vs 120s config) · Pax8 catalog search/import over MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)