### PR TITLE
fix(api): short-link Windows installer downloads honor the installer-link TTL (#3038)

### DIFF
--- a/apps/api/src/routes/enrollmentKeys.test.ts
+++ b/apps/api/src/routes/enrollmentKeys.test.ts
@@ -804,6 +804,228 @@ describe("GET /s/:code", () => {
     expect(insertedRow.expiresAt.getTime()).toBeLessThanOrEqual(after + 1441 * 60 * 1000);
   });
 
+  // #3038: the Windows bootstrap token minted on a short-link download must
+  // inherit the SHORT-LINK row's remaining lifetime — not the 24h base, and
+  // not the freshly-minted download child key's 24h TTL. Otherwise an MSI
+  // downloaded on day 1 of a 30-day link dies after hour 24 with an
+  // unexplained 404, silently discarding the admin's expiry choice.
+  it("windows bootstrap token inherits the short-link row's remaining lifetime (#3038)", async () => {
+    const thirtyDaysMinutes = 30 * 24 * 60;
+    const shortLinkRow = makeKeyRow({
+      shortCode: "longlived12",
+      installerPlatform: "windows",
+      expiresAt: new Date(Date.now() + thirtyDaysMinutes * 60 * 1000),
+    });
+    // The download child key keeps its default fresh 1h expiry from
+    // makeChildKeyRow — proving the ttl comes from the LINK row, not the
+    // transport child key serveInstaller receives.
+    const childRow = makeChildKeyRow({ installerPlatform: "windows" });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([shortLinkRow]),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([childRow]),
+      }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: KEY_ID }]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-ttl-1",
+        token: "LONGLIVED1",
+        expiresAt: new Date(Date.now() + thirtyDaysMinutes * 60 * 1000),
+        parentKeyName: "Test Key",
+      });
+
+    const res = await app.request("/s/longlived12");
+
+    expect(res.status).toBe(200);
+    const ttlMinutes = issueSpy.mock.calls[0]?.[0]?.ttlMinutes;
+    // floor() of the remaining lifetime — at most the full 30 days, and no
+    // more than a couple of minutes of test-elapsed drift below it.
+    expect(ttlMinutes).toBeGreaterThanOrEqual(thirtyDaysMinutes - 2);
+    expect(ttlMinutes).toBeLessThanOrEqual(thirtyDaysMinutes);
+
+    issueSpy.mockRestore();
+  });
+
+  it("windows bootstrap token from a near-expiry short link is short-lived, not the 24h base (#3038)", async () => {
+    const shortLinkRow = makeKeyRow({
+      shortCode: "nearexpiry1",
+      installerPlatform: "windows",
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5 minutes left
+    });
+    const childRow = makeChildKeyRow({ installerPlatform: "windows" });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([shortLinkRow]),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([childRow]),
+      }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: KEY_ID }]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-ttl-2",
+        token: "NEAREXP123",
+        expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+        parentKeyName: "Test Key",
+      });
+
+    const res = await app.request("/s/nearexpiry1");
+
+    expect(res.status).toBe(200);
+    const ttlMinutes = issueSpy.mock.calls[0]?.[0]?.ttlMinutes;
+    // A token still gets minted (the CHECK constraint needs expires_at >
+    // created_at, hence the 1-minute floor), but it dies with the link —
+    // nowhere near the 1440-minute base.
+    expect(ttlMinutes).toBeGreaterThanOrEqual(1);
+    expect(ttlMinutes).toBeLessThanOrEqual(5);
+
+    issueSpy.mockRestore();
+  });
+
+  it("windows bootstrap token falls back to the 24h base when the short link has no expiry (#3038)", async () => {
+    const shortLinkRow = makeKeyRow({
+      shortCode: "noexpiry123",
+      installerPlatform: "windows",
+      expiresAt: null,
+    });
+    const childRow = makeChildKeyRow({ installerPlatform: "windows" });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([shortLinkRow]),
+        }),
+      }),
+    } as any);
+    vi.mocked(db.insert).mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([childRow]),
+      }),
+    } as any);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: KEY_ID }]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-ttl-3",
+        token: "NOEXPIRY12",
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        parentKeyName: "Test Key",
+      });
+
+    const res = await app.request("/s/noexpiry123");
+
+    expect(res.status).toBe(200);
+    // undefined → issueBootstrapTokenForKey's 24h base, NOT an unbounded token.
+    expect(issueSpy.mock.calls[0]?.[0]?.ttlMinutes).toBeUndefined();
+
+    issueSpy.mockRestore();
+  });
+
+  it("partner cap clamps the inherited link lifetime on the windows bootstrap token (#3038, real issuance)", async () => {
+    // Runs the REAL issueBootstrapTokenForKey (no spy) so the cap clamp
+    // inside it is exercised end-to-end from the route: a 30-day link under
+    // a 60-minute partner cap must mint a 60-minute token.
+    mockEnrollmentDefaults({ maxTtlMinutes: 60 });
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+    const shortLinkRow = makeKeyRow({
+      shortCode: "cappedwin12",
+      installerPlatform: "windows",
+      expiresAt: new Date(Date.now() + thirtyDaysMs),
+    });
+    const childRow = makeChildKeyRow({ installerPlatform: "windows" });
+
+    // Same select mock serves both the short-code lookup and the issuance
+    // service's parent-key lookup (the parent it resolves is the download
+    // child key id, but the row shape only needs org/expiry/usage fields).
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([shortLinkRow]),
+        }),
+      }),
+    } as any);
+
+    // First insert: the download child key. Second insert: the bootstrap
+    // token row (from the real issuance service) — capture its values.
+    const insertedValues: Record<string, unknown>[] = [];
+    vi.mocked(db.insert).mockImplementation(
+      () =>
+        ({
+          values: (vals: Record<string, unknown>) => {
+            insertedValues.push(vals);
+            return {
+              returning: vi
+                .fn()
+                .mockResolvedValue(
+                  insertedValues.length === 1
+                    ? [childRow]
+                    : [{ id: "btok-real-1", token: vals.token }],
+                ),
+            };
+          },
+        }) as any,
+    );
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: KEY_ID }]),
+        }),
+      }),
+    } as any);
+
+    const before = Date.now();
+    const res = await app.request("/s/cappedwin12");
+    const after = Date.now();
+
+    expect(res.status).toBe(200);
+    expect(insertedValues).toHaveLength(2);
+    const tokenExpiresAt = (insertedValues[1] as { expiresAt: Date }).expiresAt;
+    // Clamped to the 60-minute cap — not 30 days, not the 24h base.
+    expect(tokenExpiresAt.getTime()).toBeGreaterThanOrEqual(
+      before + 59 * 60 * 1000,
+    );
+    expect(tokenExpiresAt.getTime()).toBeLessThanOrEqual(
+      after + 60 * 60 * 1000 + 5_000,
+    );
+  });
+
   it("returns 404 for unknown code", async () => {
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({
@@ -1190,6 +1412,46 @@ describe("GET /public-download/:platform", () => {
         actorId: "00000000-0000-0000-0000-000000000000",
       }),
     );
+
+    issueSpy.mockRestore();
+  });
+
+  // #3038: on this path the served key IS the installer-link child key the
+  // admin configured, so the bootstrap token inherits ITS remaining lifetime.
+  it("public windows download derives the bootstrap token TTL from the link key's remaining lifetime (#3038)", async () => {
+    const sevenDaysMinutes = 7 * 24 * 60;
+    const row = makeKeyRow({
+      installerPlatform: "windows",
+      maxUsage: 1,
+      usageCount: 0,
+      expiresAt: new Date(Date.now() + sevenDaysMinutes * 60 * 1000),
+    });
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([row]),
+        }),
+      }),
+    } as any);
+
+    const issueSpy = vi
+      .spyOn(installerBootstrapTokenIssuance, "issueBootstrapTokenForKey")
+      .mockResolvedValueOnce({
+        id: "btok-pd-1",
+        token: "PUBDLTTL12",
+        expiresAt: new Date(Date.now() + sevenDaysMinutes * 60 * 1000),
+        parentKeyName: "Test Key",
+      });
+
+    const res = await app.request(
+      `/enrollment-keys/public-download/windows?h=dlh_${"1".repeat(32)}`,
+    );
+
+    expect(res.status).toBe(200);
+    const ttlMinutes = issueSpy.mock.calls[0]?.[0]?.ttlMinutes;
+    expect(ttlMinutes).toBeGreaterThanOrEqual(sevenDaysMinutes - 2);
+    expect(ttlMinutes).toBeLessThanOrEqual(sevenDaysMinutes);
 
     issueSpy.mockRestore();
   });

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -140,6 +140,32 @@ function parentKeyTooCloseToExpiry(expiresAt: Date | null): boolean {
   return remainingMs < INSTALLER_PARENT_MIN_REMAINING_SECONDS * 1000;
 }
 
+/**
+ * Bootstrap-token TTL derived from an installer link's remaining lifetime
+ * (#3038). A Windows MSI downloaded from a share link embeds a bootstrap
+ * token, and that token — not the link — is what the eventual install
+ * redeems. Minting it with the 24h base while the link the admin configured
+ * lives for 30 days silently discards the admin's expiry choice: installs
+ * from a day-1 download die after hour 24 with an unexplained 404 (the same
+ * silent-discard trap as #2775, resurfaced on the download path).
+ *
+ * So: the token inherits the link's remaining lifetime at download time —
+ * never MORE than the link has left (floored to minutes, minimum 1 so the
+ * `expires_at > created_at` CHECK on installer_bootstrap_tokens always
+ * holds), and clamped to the partner's `maxEnrollmentLinkTtlMinutes` cap
+ * inside issueBootstrapTokenForKey. A link with no expiry returns undefined
+ * → the conservative 24h base, NOT an unbounded token.
+ */
+function installerLinkRemainingTtlMinutes(
+  linkExpiresAt: Date | null,
+): number | undefined {
+  if (!linkExpiresAt) return undefined;
+  const remainingMinutes = Math.floor(
+    (linkExpiresAt.getTime() - Date.now()) / 60_000,
+  );
+  return Math.max(1, remainingMinutes);
+}
+
 function getPagination(query: { page?: string; limit?: string }) {
   const page = Math.max(1, Number.parseInt(query.page ?? "1", 10) || 1);
   const limit = Math.min(
@@ -2102,6 +2128,12 @@ export async function checkInstallerSignSpend(
 // per-(short-code OR enrollment-key id) signing budget (i.e. the /s/:code
 // path debited against the short code before the atomic claim). When false
 // (public-download path), we debit here using `keyRow.id` as the bucket key.
+// `linkExpiresAt` — the expiry of the installer LINK the requester followed,
+// which bounds the Windows bootstrap token's lifetime (#3038). Defaults to
+// `keyRow.expiresAt` because on the public-download path `keyRow` IS the
+// installer-link child key; the /s/:code path must pass the short-link row's
+// expiry explicitly, since its `keyRow` is a freshly-minted download key
+// whose 24h TTL says nothing about the link the admin configured.
 async function serveInstaller(
   c: Context,
   keyRow: typeof enrollmentKeys.$inferSelect,
@@ -2109,6 +2141,7 @@ async function serveInstaller(
   rawToken: string,
   cleanupOnFailure = false,
   signSpendBucketChecked = false,
+  linkExpiresAt: Date | null = keyRow.expiresAt,
 ): Promise<Response> {
   // Use getTrustedClientIp so spoofed `X-Forwarded-For` from untrusted
   // clients does not let an attacker open unlimited rate-limit buckets.
@@ -2215,12 +2248,14 @@ async function serveInstaller(
         // insert with `invalid input syntax for type uuid: ""` (500 on /s/:code).
         createdByUserId: keyRow.createdBy ?? null,
         maxUsage: 1,
-        // Short-link downloads carry no per-request picker (the link was
-        // generated once, by an admin who already chose a TTL for the CHILD
-        // key at /installer-link time). There is no ttlMinutes in scope here
-        // to forward, so the bootstrap token deliberately takes the 24h base
-        // rather than inheriting a stale selection. Deliberate — not an
-        // oversight (#2775).
+        // The token inherits the installer link's remaining lifetime (#3038).
+        // This path has no per-request TTL picker — the admin already chose
+        // the expiry when the link was generated, and the token minted into
+        // the downloaded MSI must honor that choice, not silently fall back
+        // to the 24h base (which killed every install after hour 24 of a
+        // 30-day link). undefined (no link expiry) keeps the 24h base;
+        // issueBootstrapTokenForKey clamps to the partner cap either way.
+        ttlMinutes: installerLinkRemainingTtlMinutes(linkExpiresAt),
         installerPlatform: "windows",
       });
     } catch (err) {
@@ -2506,6 +2541,11 @@ publicShortLinkRoutes.get("/:code", async (c) => {
       rawToken,
       true,
       true, // signSpendBucketChecked — debited against short code above
+      // The SHORT-LINK row's expiry, not downloadKey's: the download key is a
+      // fresh 24h transport container, while `row` is the link the admin
+      // configured — its remaining lifetime is what the Windows bootstrap
+      // token must inherit (#3038).
+      row.expiresAt,
     );
   });
 });


### PR DESCRIPTION
## Summary

The `/s/:code` and public-download paths minted every Windows bootstrap token with no `ttlMinutes`, so every token fell to the 24h `INSTALLER_BOOTSTRAP_TOKEN_TTL_MINUTES` base regardless of the link expiry the admin chose. Field consequence: a 30-day share link's MSI, downloaded on day 1, stopped installing after hour 24 with the ambiguous 404 — the same "your expiry selection is silently discarded" trap as #2775, resurfaced on the download path.

Closes #3038

## What changed

- **`serveInstaller` gains a `linkExpiresAt` parameter** (defaults to `keyRow.expiresAt`). The Windows branch derives the bootstrap token TTL from the link's remaining lifetime via a new `installerLinkRemainingTtlMinutes` helper: floored to whole minutes with a 1-minute minimum (so the `expires_at > created_at` CHECK on `installer_bootstrap_tokens` always holds), never more than the link has left.
- **`/s/:code` passes the short-link row's expiry explicitly** — the `keyRow` it hands `serveInstaller` is a freshly-minted 24h transport child key whose TTL says nothing about the link the admin configured.
- **`/public-download/:platform` uses the default** — the key it serves IS the installer-link child key, so its own expiry is the link expiry.
- **Partner cap still binds**: `issueBootstrapTokenForKey` already clamps any `ttlMinutes` to `maxEnrollmentLinkTtlMinutes` (#2776 round 3); the derived lifetime flows through that clamp unchanged.
- **No-expiry links keep the conservative 24h base** (`ttlMinutes: undefined`), not an unbounded token.
- The in-code comment claiming the 24h base was deliberate is replaced with the new contract.

## What did NOT change

- Parent-key TTL semantics and the authenticated download path (`GET /:id/installer/:platform`, `POST /:id/bootstrap-token`), which already honor an explicit `ttlMinutes`.
- macOS child-key TTLs on these paths.
- Long-lived tokens outliving their transient parent keys is already supported infrastructure: redemption (`routes/installer.ts`) only requires the parent row to exist, and the purge guards (`enrollmentKeyPurgeGuards.ts`, #2775/#2832) keep a parent alive while a live unexhausted token points at it.

## Tests

New route tests in `apps/api/src/routes/enrollmentKeys.test.ts`:

- `/s/:code`: 30-day link → token inherits the remaining lifetime (and provably from the LINK row, not the 1h transport child key); 5-minute-remaining link → short token, not the 24h base; no-expiry link → `ttlMinutes` undefined (24h base); 60-minute partner cap vs 30-day link → token minted at 60 minutes, exercised through the REAL `issueBootstrapTokenForKey` (no spy).
- `/public-download`: 7-day link key → token inherits its remaining lifetime.

Verification: `vitest run` on `enrollmentKeys.test.ts`, `enrollmentKeys_installer.test.ts`, `installerBootstrapTokenIssuance.test.ts` (104 passed) plus `enrollmentKeys_{strict,capClamp,get_rotate_delete,list_create}.test.ts` and `installer.test.ts` (77 passed); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)