### PR TITLE
fix(api,web): derive installer capacity and key status from live bootstrap tokens (#3039)

### DIFF
--- a/apps/api/src/__tests__/integration/installerTokenUsageAggregate.integration.test.ts
+++ b/apps/api/src/__tests__/integration/installerTokenUsageAggregate.integration.test.ts
@@ -161,7 +161,17 @@ describe('installer token usage aggregate (#2992, real Postgres)', () => {
         // become two rows.
         expect(usage.size).toBe(1);
 
-        expect(usage.get(ids.withTokensId)).toEqual({ consumed: 4, max: 12 });
+        // Totals span both tokens; the live pair (#3039) is FILTERed to the
+        // unexpired one (token A: 3 / 7). The expired token B (1 / 5) must be
+        // in the totals — the figure stays stable as installers age out — but
+        // OUT of the live cut, or a dead installer reads as free capacity.
+        // Same asymmetry rationale: no swap of the four sources can coincide.
+        expect(usage.get(ids.withTokensId)).toEqual({
+          consumed: 4,
+          max: 12,
+          liveConsumed: 3,
+          liveMax: 7,
+        });
         // A key that never minted an installer is absent, so the route maps it
         // to null and the UI keeps showing usage_count / max_usage.
         expect(usage.get(ids.withoutTokensId)).toBeUndefined();

--- a/apps/api/src/routes/enrollmentKeys.ts
+++ b/apps/api/src/routes/enrollmentKeys.ts
@@ -573,6 +573,30 @@ export interface InstallerTokenUsage {
   consumed: number;
   /** Σ max_usage — total device slots those installers were minted for. */
   max: number;
+  /**
+   * Σ consumed_count over UNEXPIRED tokens only (`expires_at > now()`).
+   * Additive (#3039) — `consumed`/`max` keep their all-tokens semantics so
+   * existing consumers are untouched.
+   */
+  liveConsumed: number;
+  /**
+   * Σ max_usage over UNEXPIRED tokens only. Together with `liveConsumed` this
+   * carries token liveness without a second query:
+   *
+   *   - `liveMax === 0`               → every installer from this key is dead
+   *     (a "0 / 7" total is seven slots nothing can ever redeem again);
+   *   - `liveConsumed < liveMax`      → at least one live, unexhausted token —
+   *     the EXACT predicate `services/enrollmentKeyPurgeGuards.ts` uses to
+   *     spare a key from the purge (per-token `consumed_count` never exceeds
+   *     `max_usage`, so the sum comparison and the per-row EXISTS agree);
+   *   - `liveConsumed >= liveMax > 0` → unexpired installers exist but every
+   *     slot is claimed.
+   *
+   * The UI derives the row's effective status from these instead of the
+   * transient parent key's own expiry (an Add-Device parent lives 60 minutes;
+   * the installer minted from it can live a year).
+   */
+  liveMax: number;
 }
 
 /**
@@ -646,12 +670,15 @@ export function reportsInstallerCapacity(key: { shortCode?: string | null }): bo
  * would otherwise silently flip back to the parent's own "0 / 1" the moment the
  * token aged out, even though those three devices really did enroll.
  *
- * KNOWN LIMIT — this reports slots USED of slots MINTED, and deliberately does
- * not claim the installer is still redeemable. Do not read the row's status
- * badge as covering it: a bootstrap token gets a fresh lifetime independent of
- * its parent (see installerBootstrapTokenIssuance), and the Add-Device parent
- * is a 60-minute container, so an installer routinely outlives the key it was
- * minted from. Surfacing per-token expiry on this line is a separate change.
+ * The totals report slots USED of slots MINTED and make no redeemability
+ * claim; the live* pair (#3039) carries that claim separately, as FILTERed
+ * sums over unexpired tokens in the same grouped query. Both are needed: a
+ * bootstrap token gets a fresh lifetime independent of its parent (see
+ * installerBootstrapTokenIssuance), and the Add-Device parent is a 60-minute
+ * container, so an installer routinely outlives the key it was minted from —
+ * without the live pair a fully-expired installer's "0 / 7" reads as seven
+ * usable slots, and the row badge (parent expiry) contradicts the capacity
+ * line.
  *
  * RLS: `installer_bootstrap_tokens` is a shape-1 (direct org_id) table with
  * enabled + forced policies (`2026-04-19-a-installer-bootstrap-tokens.sql`), so
@@ -688,6 +715,12 @@ export async function fetchInstallerTokenUsage(
           parentEnrollmentKeyId: installerBootstrapTokens.parentEnrollmentKeyId,
           consumed: sql<number>`coalesce(sum(${installerBootstrapTokens.consumedCount}), 0)`,
           max: sql<number>`coalesce(sum(${installerBootstrapTokens.maxUsage}), 0)`,
+          // Liveness cut (#3039): same sums restricted to unexpired tokens.
+          // `expires_at` is NOT NULL on this table, so `> now()` is the whole
+          // predicate — see InstallerTokenUsage for how the pair encodes the
+          // purge-guard's live-token condition.
+          liveConsumed: sql<number>`coalesce(sum(${installerBootstrapTokens.consumedCount}) filter (where ${installerBootstrapTokens.expiresAt} > now()), 0)`,
+          liveMax: sql<number>`coalesce(sum(${installerBootstrapTokens.maxUsage}) filter (where ${installerBootstrapTokens.expiresAt} > now()), 0)`,
         })
         .from(installerBootstrapTokens)
         .where(inArray(installerBootstrapTokens.parentEnrollmentKeyId, keyIds))
@@ -698,6 +731,8 @@ export async function fetchInstallerTokenUsage(
       usage.set(row.parentEnrollmentKeyId, {
         consumed: Number(row.consumed),
         max: Number(row.max),
+        liveConsumed: Number(row.liveConsumed),
+        liveMax: Number(row.liveMax),
       });
     }
   } catch (err) {

--- a/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_get_rotate_delete.test.ts
@@ -309,7 +309,9 @@ describe('enrollment key routes — get, rotate, delete', () => {
     it('reports installer bootstrap-token capacity when the key has minted one', async () => {
       mockSelectFromWhereLimit([makeEnrollmentKey()]);
       mockSelectFromWhereGroupBy([
-        { parentEnrollmentKeyId: KEY_ID, consumed: 3, max: 7 },
+        // liveConsumed/liveMax (#3039): same sums FILTERed to unexpired
+        // tokens, carried through verbatim next to the all-token totals.
+        { parentEnrollmentKeyId: KEY_ID, consumed: 3, max: 7, liveConsumed: 1, liveMax: 4 },
       ]);
 
       const res = await app.request(`/enrollment-keys/${KEY_ID}`, {
@@ -319,7 +321,12 @@ describe('enrollment key routes — get, rotate, delete', () => {
 
       expect(res.status).toBe(200);
       const body = await res.json();
-      expect(body.installerTokens).toEqual({ consumed: 3, max: 7 });
+      expect(body.installerTokens).toEqual({
+        consumed: 3,
+        max: 7,
+        liveConsumed: 1,
+        liveMax: 4,
+      });
       // The key's own budget is reported unchanged — the installer figure is a
       // separate counter, not a rewrite of it.
       expect(body.maxUsage).toBe(10);

--- a/apps/api/src/routes/enrollmentKeys_list_create.test.ts
+++ b/apps/api/src/routes/enrollmentKeys_list_create.test.ts
@@ -143,7 +143,9 @@ function mockSelectFromWhereOrderByLimitOffset(rows: any[]) {
 /**
  * Mock for db.select().from().where().groupBy() — the batched installer
  * bootstrap-token aggregate the list/detail routes run after loading keys
- * (#2992). Rows are `{ parentEnrollmentKeyId, consumed, max }`.
+ * (#2992). Rows are `{ parentEnrollmentKeyId, consumed, max, liveConsumed,
+ * liveMax }` — the live pair being the same sums FILTERed to unexpired tokens
+ * (#3039).
  */
 function mockSelectFromWhereGroupBy(rows: any[]) {
   vi.mocked(db.select).mockReturnValueOnce({
@@ -221,7 +223,7 @@ describe('enrollment key routes — list & create', () => {
         makeEnrollmentKey({ id: 'key-2', name: 'Plain key' }),
       ]);
       mockSelectFromWhereGroupBy([
-        { parentEnrollmentKeyId: KEY_ID, consumed: 3, max: 7 },
+        { parentEnrollmentKeyId: KEY_ID, consumed: 3, max: 7, liveConsumed: 3, liveMax: 7 },
       ]);
 
       const res = await app.request('/enrollment-keys', {
@@ -235,7 +237,12 @@ describe('enrollment key routes — list & create', () => {
       expect(body.data).toHaveLength(2);
       expect(body.pagination.total).toBe(2);
 
-      expect(body.data[0].installerTokens).toEqual({ consumed: 3, max: 7 });
+      expect(body.data[0].installerTokens).toEqual({
+        consumed: 3,
+        max: 7,
+        liveConsumed: 3,
+        liveMax: 7,
+      });
       // A key that never minted an installer reports null, so the UI keeps
       // showing its own usage_count — which IS claimed for short-link and
       // MCP-invite keys.
@@ -253,7 +260,7 @@ describe('enrollment key routes — list & create', () => {
       // Postgres SUM() comes back as a string over the wire; the route must
       // coerce or the UI renders "12" as "0"+"12" style garbage.
       mockSelectFromWhereGroupBy([
-        { parentEnrollmentKeyId: KEY_ID, consumed: '4', max: '12' },
+        { parentEnrollmentKeyId: KEY_ID, consumed: '4', max: '12', liveConsumed: '1', liveMax: '7' },
       ]);
 
       const res = await app.request('/enrollment-keys', {
@@ -262,7 +269,41 @@ describe('enrollment key routes — list & create', () => {
       });
 
       const body = await res.json();
-      expect(body.data[0].installerTokens).toEqual({ consumed: 4, max: 12 });
+      expect(body.data[0].installerTokens).toEqual({
+        consumed: 4,
+        max: 12,
+        liveConsumed: 1,
+        liveMax: 7,
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // #3039 — the liveness cut rides the same aggregate row. A key whose
+    // installers have all expired reports liveMax 0 so the UI can stop
+    // rendering "0 / 7" as seven usable slots (and can derive the row's
+    // effective status from token liveness instead of the transient parent).
+    // ------------------------------------------------------------------
+    it('reports zero live capacity for a key whose installers have all expired', async () => {
+      mockSelectFromWhere([{ count: 1 }]);
+      mockSelectFromWhereOrderByLimitOffset([makeEnrollmentKey()]);
+      mockSelectFromWhereGroupBy([
+        { parentEnrollmentKeyId: KEY_ID, consumed: 3, max: 7, liveConsumed: 0, liveMax: 0 },
+      ]);
+
+      const res = await app.request('/enrollment-keys', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      const body = await res.json();
+      // The historical totals survive (those three devices really enrolled);
+      // the live pair is what withdraws the capacity claim.
+      expect(body.data[0].installerTokens).toEqual({
+        consumed: 3,
+        max: 7,
+        liveConsumed: 0,
+        liveMax: 0,
+      });
     });
 
     it('skips the aggregate query entirely when the page is empty', async () => {
@@ -321,8 +362,8 @@ describe('enrollment key routes — list & create', () => {
       // The id-list filter is killed separately, by the transaction assertion
       // in the all-short-link test below.
       mockSelectFromWhereGroupBy([
-        { parentEnrollmentKeyId: KEY_ID, consumed: 0, max: 5 },
-        { parentEnrollmentKeyId: 'key-link', consumed: 0, max: 3 },
+        { parentEnrollmentKeyId: KEY_ID, consumed: 0, max: 5, liveConsumed: 0, liveMax: 5 },
+        { parentEnrollmentKeyId: 'key-link', consumed: 0, max: 3, liveConsumed: 0, liveMax: 3 },
       ]);
 
       const res = await app.request('/enrollment-keys', {
@@ -334,7 +375,12 @@ describe('enrollment key routes — list & create', () => {
       const body = await res.json();
       // Add-Device parent (no short_code) still reports genuine capacity —
       // kills the "suppress everything" mutant.
-      expect(body.data[0].installerTokens).toEqual({ consumed: 0, max: 5 });
+      expect(body.data[0].installerTokens).toEqual({
+        consumed: 0,
+        max: 5,
+        liveConsumed: 0,
+        liveMax: 5,
+      });
       expect(body.data[1].installerTokens).toBeNull();
       // …and its own counters, which ARE atomically claimed on /s/:code, are
       // left to tell the story.

--- a/apps/web/src/components/settings/EnrollmentKeyManager.test.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.test.tsx
@@ -78,7 +78,12 @@ interface Row {
   expiresAt: string | null;
   createdBy: string | null;
   createdAt: string;
-  installerTokens?: { consumed: number; max: number } | null;
+  installerTokens?: {
+    consumed: number;
+    max: number;
+    liveConsumed?: number;
+    liveMax?: number;
+  } | null;
 }
 
 const PAST = new Date(Date.now() - 86_400_000).toISOString();
@@ -386,6 +391,136 @@ describe('EnrollmentKeyManager — create form site selector', () => {
 
       await screen.findByTestId('key-usage-k-legacy');
       expect(screen.queryByTestId('key-installer-usage-k-legacy')).toBeNull();
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // #3039 — live vs expired installer capacity, and token-derived row status.
+  //
+  // The Add-Device parent key is a 60-minute container while the bootstrap
+  // token minted from it can live a year, so neither the parent's expiry nor
+  // the all-token capacity sum tells the truth on its own: a fully-expired
+  // installer rendered "0 / 7" (reads as seven usable slots), and the badge
+  // said Expired while the installer was still enrolling devices.
+  // ------------------------------------------------------------------
+  describe('installer capacity liveness (#3039)', () => {
+    it('marks a fully-expired installer instead of rendering its slots as usable', async () => {
+      routeFetch([
+        makeRow({
+          id: 'k-dead',
+          usageCount: 0,
+          maxUsage: 1,
+          expiresAt: FUTURE,
+          installerTokens: { consumed: 0, max: 7, liveConsumed: 0, liveMax: 0 },
+        }),
+      ]);
+      render(<EnrollmentKeyManager />);
+
+      const cell = await screen.findByTestId('key-installer-usage-k-dead');
+      // Totals stay (stable historical figure) but the expired marker
+      // withdraws the capacity claim.
+      expect(cell.textContent).toContain('0 / 7');
+      expect(cell.textContent?.toLowerCase()).toContain('expired');
+    });
+
+    it('splits live and expired slots when only some installers are still redeemable', async () => {
+      routeFetch([
+        makeRow({
+          id: 'k-mixed',
+          usageCount: 0,
+          maxUsage: 1,
+          installerTokens: { consumed: 4, max: 12, liveConsumed: 1, liveMax: 7 },
+        }),
+      ]);
+      render(<EnrollmentKeyManager />);
+
+      const cell = await screen.findByTestId('key-installer-usage-k-mixed');
+      expect(cell.textContent).toContain('1 / 7');
+      expect(cell.textContent?.toLowerCase()).toContain('live');
+      // 12 − 7 = 5 dead slots, called out rather than folded into capacity.
+      expect(cell.textContent).toContain('5');
+    });
+
+    it('keeps the row Active when the parent expired but its installer is live', async () => {
+      routeFetch([
+        makeRow({
+          id: 'k-outlives',
+          usageCount: 0,
+          maxUsage: 1,
+          siteId: 'site-a', // the Download gate needs a site — without one the
+          // button never renders and the assertion below would pass vacuously
+          expiresAt: PAST, // transient Add-Device parent, long dead
+          installerTokens: { consumed: 2, max: 7, liveConsumed: 2, liveMax: 7 },
+        }),
+        // Positive control: a live parent with a site DOES get the Download
+        // action — proves the absence assertion below isn't a translation or
+        // markup artifact.
+        makeRow({ id: 'k-live-parent', siteId: 'site-a', expiresAt: FUTURE }),
+      ]);
+      render(<EnrollmentKeyManager />);
+
+      await screen.findByTestId('key-installer-usage-k-outlives');
+      expect(screen.getAllByText('Active').length).toBe(2);
+      expect(screen.queryByText('Expired')).toBeNull();
+      // But the Download action follows the PARENT key, which the installer
+      // routes 410 on once expired — a live token must not re-enable it. Only
+      // the control row (live parent) may offer it.
+      expect(screen.getAllByText('Download')).toHaveLength(1);
+    });
+
+    it('shows Expired when both the parent and every installer token are dead', async () => {
+      routeFetch([
+        makeRow({
+          id: 'k-all-dead',
+          usageCount: 0,
+          maxUsage: 1,
+          expiresAt: PAST,
+          installerTokens: { consumed: 3, max: 7, liveConsumed: 0, liveMax: 0 },
+        }),
+      ]);
+      render(<EnrollmentKeyManager />);
+
+      await screen.findByTestId('key-installer-usage-k-all-dead');
+      expect(screen.getByText('Expired')).toBeTruthy();
+      expect(screen.queryByText('Active')).toBeNull();
+    });
+
+    it('shows Exhausted when unexpired installers exist but every slot is claimed', async () => {
+      routeFetch([
+        makeRow({
+          id: 'k-full',
+          usageCount: 0,
+          maxUsage: 1,
+          expiresAt: PAST,
+          installerTokens: { consumed: 7, max: 7, liveConsumed: 7, liveMax: 7 },
+        }),
+      ]);
+      render(<EnrollmentKeyManager />);
+
+      await screen.findByTestId('key-installer-usage-k-full');
+      expect(screen.getByText('Exhausted')).toBeTruthy();
+    });
+
+    it('falls back to parent-based status when the API omits the live fields', async () => {
+      // A legacy response must not have its expired badge flipped by guessing
+      // every token alive.
+      routeFetch([
+        makeRow({
+          id: 'k-legacy-status',
+          usageCount: 0,
+          maxUsage: 1,
+          expiresAt: PAST,
+          installerTokens: { consumed: 2, max: 7 },
+        }),
+      ]);
+      render(<EnrollmentKeyManager />);
+
+      await screen.findByTestId('key-installer-usage-k-legacy-status');
+      expect(screen.getByText('Expired')).toBeTruthy();
+      // The capacity line still renders in its pre-liveness form.
+      expect(
+        screen.getByTestId('key-installer-usage-k-legacy-status').textContent,
+      ).toContain('2 / 7');
     });
   });
 });

--- a/apps/web/src/components/settings/EnrollmentKeyManager.tsx
+++ b/apps/web/src/components/settings/EnrollmentKeyManager.tsx
@@ -40,8 +40,21 @@ interface EnrollmentKey {
    *      the sum would count clicks and render a denominator that grows on
    *      every click and never reaches the key's real budget. See
    *      `reportsInstallerCapacity` in routes/enrollmentKeys.ts.
+   *
+   * `liveConsumed` / `liveMax` (#3039) are the same sums over UNEXPIRED tokens
+   * only. They drive two things below: the capacity line marks dead slots
+   * instead of rendering an expired installer as "0 / 7" free capacity, and
+   * `getKeyStatus` derives the row's effective status from token liveness once
+   * the parent key itself is dead (the Add-Device parent is a 60-minute
+   * container; its installer can live a year). Optional so a response predating
+   * the field degrades to the old all-live rendering.
    */
-  installerTokens?: { consumed: number; max: number } | null;
+  installerTokens?: {
+    consumed: number;
+    max: number;
+    liveConsumed?: number;
+    liveMax?: number;
+  } | null;
 }
 
 interface CreateFormValues {
@@ -376,10 +389,64 @@ export default function EnrollmentKeyManager() {
   const isExhausted = (key: EnrollmentKey) =>
     key.maxUsage !== null && key.usageCount >= key.maxUsage;
 
+  /**
+   * Normalized liveness cut of a key's installer capacity, or null when the
+   * key has no installer figure at all. Falls back to treating every token as
+   * live when the API predates the live* fields, which reproduces the old
+   * behavior exactly.
+   */
+  const installerLiveness = (key: EnrollmentKey) => {
+    const tokens = key.installerTokens;
+    if (!tokens || tokens.max <= 0) return null;
+    return {
+      ...tokens,
+      liveConsumed: tokens.liveConsumed ?? tokens.consumed,
+      liveMax: tokens.liveMax ?? tokens.max,
+    };
+  };
+
+  const STATUS_STYLES = {
+    expired: { key: 'expired', active: false, className: 'bg-red-500/10 text-red-400 border-red-500/30' },
+    exhausted: { key: 'exhausted', active: false, className: 'bg-amber-500/10 text-amber-400 border-amber-500/30' },
+    active: { key: 'active', active: true, className: 'bg-green-500/10 text-green-400 border-green-500/30' },
+  } as const;
+
+  /**
+   * Whether the parent key ITSELF is still a redeemable credential (CLI
+   * enroll, and the gate the authenticated installer-download routes apply —
+   * they 410 on an expired key). Deliberately separate from the row's
+   * effective status below: the Download button must follow THIS, not the
+   * token-derived badge, or an expired parent with a live installer would
+   * offer a download that can only 410.
+   */
+  const isParentActive = (key: EnrollmentKey) => !isExpired(key) && !isExhausted(key);
+
+  /**
+   * Effective row status (#3039). The parent key's own expiry wins while the
+   * parent is alive, but once it is dead a key that minted installers is
+   * judged by its tokens — the things that actually enroll. Without this an
+   * Add-Device row flips to "Expired" 60 minutes in while its installer keeps
+   * enrolling devices for months (and vice versa: a dead installer under a
+   * live-looking row).
+   */
   const getKeyStatus = (key: EnrollmentKey) => {
-    if (isExpired(key)) return { key: 'expired', active: false, className: 'bg-red-500/10 text-red-400 border-red-500/30' };
-    if (isExhausted(key)) return { key: 'exhausted', active: false, className: 'bg-amber-500/10 text-amber-400 border-amber-500/30' };
-    return { key: 'active', active: true, className: 'bg-green-500/10 text-green-400 border-green-500/30' };
+    if (isParentActive(key)) return STATUS_STYLES.active;
+    const tokens = key.installerTokens;
+    // Only trust token liveness when the API actually reported it — a legacy
+    // response without the live* fields falls through to the parent-based
+    // status rather than guessing every token alive.
+    if (
+      tokens &&
+      tokens.max > 0 &&
+      tokens.liveMax !== undefined &&
+      tokens.liveConsumed !== undefined
+    ) {
+      if (tokens.liveConsumed < tokens.liveMax) return STATUS_STYLES.active;
+      if (tokens.liveMax > 0) return STATUS_STYLES.exhausted;
+      return STATUS_STYLES.expired;
+    }
+    if (isExpired(key)) return STATUS_STYLES.expired;
+    return STATUS_STYLES.exhausted;
   };
 
   if (loading) {
@@ -568,17 +635,47 @@ export default function EnrollmentKeyManager() {
                           CLI or MCP-invite key has no tokens at all and only the
                           line above means anything.
                         */}
-                        {key.installerTokens && (
-                          <div
-                            className="text-xs text-muted-foreground"
-                            data-testid={`key-installer-usage-${key.id}`}
-                          >
-                            {t('enrollmentKeys.installerUsage', {
-                              consumed: key.installerTokens.consumed,
-                              max: key.installerTokens.max,
-                            })}
-                          </div>
-                        )}
+                        {(() => {
+                          /*
+                            #3039 — the line distinguishes live from expired
+                            capacity so a dead installer cannot read as free
+                            slots:
+                              - all tokens live  → "Installer devices C / M"
+                                (unchanged);
+                              - none live        → the totals plus an explicit
+                                expired marker — the historical count stays
+                                (those devices really did enroll) but the
+                                capacity claim is withdrawn;
+                              - mixed            → live figures first, dead
+                                slots called out ("L / N live · K expired").
+                          */
+                          const live = installerLiveness(key);
+                          if (!live) return null;
+                          const label =
+                            live.liveMax >= live.max
+                              ? t('enrollmentKeys.installerUsage', {
+                                  consumed: live.consumed,
+                                  max: live.max,
+                                })
+                              : live.liveMax === 0
+                                ? t('enrollmentKeys.installerUsageExpired', {
+                                    consumed: live.consumed,
+                                    max: live.max,
+                                  })
+                                : t('enrollmentKeys.installerUsageMixed', {
+                                    liveConsumed: live.liveConsumed,
+                                    liveMax: live.liveMax,
+                                    expired: live.max - live.liveMax,
+                                  });
+                          return (
+                            <div
+                              className="text-xs text-muted-foreground"
+                              data-testid={`key-installer-usage-${key.id}`}
+                            >
+                              {label}
+                            </div>
+                          );
+                        })()}
                       </td>
                       <td className="px-4 py-3 text-muted-foreground">
                         {key.expiresAt
@@ -590,8 +687,13 @@ export default function EnrollmentKeyManager() {
                       </td>
                       <td className="px-4 py-3 text-right">
                         <div className="relative inline-flex items-center gap-1">
-                          {/* Download Installer Dropdown - only for active keys with siteId */}
-                          {status.active && key.siteId && (
+                          {/* Download Installer Dropdown — gated on the PARENT
+                              key being redeemable, not the token-derived row
+                              status: the authenticated installer routes 410 on
+                              an expired key, so a row kept "Active" by a live
+                              installer token must not offer a download that
+                              can only fail. */}
+                          {isParentActive(key) && key.siteId && (
                             <div className="relative">
                               <button
                                 type="button"

--- a/apps/web/src/locales/de-DE/settings.json
+++ b/apps/web/src/locales/de-DE/settings.json
@@ -543,6 +543,8 @@
     "deleteExpired": "Abgelaufene löschen",
     "shortCode": "Kurzcode",
     "installerUsage": "Installer-Geräte {{consumed}} / {{max}}",
+    "installerUsageExpired": "Installer-Geräte {{consumed}} / {{max}} (abgelaufen)",
+    "installerUsageMixed": "Installer-Geräte {{liveConsumed}} / {{liveMax}} aktiv · {{expired}} abgelaufen",
     "usage": "Nutzung",
     "expires": "Läuft ab",
     "empty": "Keine Registrierungsschlüssel gefunden. Erstellen Sie zunächst einen Schlüssel.",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -543,6 +543,8 @@
     "deleteExpired": "Delete expired",
     "shortCode": "Short code",
     "installerUsage": "Installer devices {{consumed}} / {{max}}",
+    "installerUsageExpired": "Installer devices {{consumed}} / {{max}} (expired)",
+    "installerUsageMixed": "Installer devices {{liveConsumed}} / {{liveMax}} live · {{expired}} expired",
     "usage": "Usage",
     "expires": "Expires",
     "empty": "No enrollment keys found. Create one to get started.",

--- a/apps/web/src/locales/es-419/settings.json
+++ b/apps/web/src/locales/es-419/settings.json
@@ -543,6 +543,8 @@
     "deleteExpired": "Eliminar caducado",
     "shortCode": "código corto",
     "installerUsage": "Dispositivos del instalador {{consumed}} / {{max}}",
+    "installerUsageExpired": "Dispositivos del instalador {{consumed}} / {{max}} (expirado)",
+    "installerUsageMixed": "Dispositivos del instalador {{liveConsumed}} / {{liveMax}} activos · {{expired}} expirados",
     "usage": "Uso",
     "expires": "Vence",
     "empty": "No se encontraron claves de inscripción. Cree uno para comenzar.",

--- a/apps/web/src/locales/fr-CA/settings.json
+++ b/apps/web/src/locales/fr-CA/settings.json
@@ -543,6 +543,8 @@
     "deleteExpired": "Supprimer les clés expirées",
     "shortCode": "Code court",
     "installerUsage": "Appareils de l’installateur {{consumed}} / {{max}}",
+    "installerUsageExpired": "Appareils de l’installateur {{consumed}} / {{max}} (expiré)",
+    "installerUsageMixed": "Appareils de l’installateur {{liveConsumed}} / {{liveMax}} actifs · {{expired}} expirés",
     "usage": "Utilisation",
     "expires": "Expiration",
     "empty": "Aucune clé d’inscription trouvée. Créez-en un pour commencer.",

--- a/apps/web/src/locales/fr-FR/settings.json
+++ b/apps/web/src/locales/fr-FR/settings.json
@@ -543,6 +543,8 @@
     "deleteExpired": "Supprimer les clés expirées",
     "shortCode": "Code court",
     "installerUsage": "Appareils de l’installateur {{consumed}} / {{max}}",
+    "installerUsageExpired": "Appareils de l’installateur {{consumed}} / {{max}} (expiré)",
+    "installerUsageMixed": "Appareils de l’installateur {{liveConsumed}} / {{liveMax}} actifs · {{expired}} expirés",
     "usage": "Utilisation",
     "expires": "Expiration",
     "empty": "Aucune clé d’inscription trouvée. Créez-en un pour commencer.",

--- a/apps/web/src/locales/it-IT/settings.json
+++ b/apps/web/src/locales/it-IT/settings.json
@@ -543,6 +543,8 @@
     "deleteExpired": "Elimina scadute",
     "shortCode": "Codice breve",
     "installerUsage": "Dispositivi del programma di installazione {{consumed}} / {{max}}",
+    "installerUsageExpired": "Dispositivi del programma di installazione {{consumed}} / {{max}} (scaduto)",
+    "installerUsageMixed": "Dispositivi del programma di installazione {{liveConsumed}} / {{liveMax}} attivi · {{expired}} scaduti",
     "usage": "Utilizzo",
     "expires": "Scade",
     "empty": "Nessuna chiave di registrazione trovata. Creane una per iniziare.",

--- a/apps/web/src/locales/pt-BR/settings.json
+++ b/apps/web/src/locales/pt-BR/settings.json
@@ -543,6 +543,8 @@
     "deleteExpired": "Excluir expiradas",
     "shortCode": "Código curto",
     "installerUsage": "Dispositivos do instalador {{consumed}} / {{max}}",
+    "installerUsageExpired": "Dispositivos do instalador {{consumed}} / {{max}} (expirado)",
+    "installerUsageMixed": "Dispositivos do instalador {{liveConsumed}} / {{liveMax}} ativos · {{expired}} expirados",
     "usage": "Uso",
     "expires": "Expira",
     "empty": "Nenhuma chave de registro encontrada. Crie uma para começar.",


### PR DESCRIPTION
## What

The Enrollment Keys list's installer capacity figure (added in #2993) sums `consumed_count`/`max_usage` across **all** bootstrap tokens, so a fully-expired installer renders as "0 / 7" — reading as seven usable slots — and the row's status badge reflects the transient parent key (60-min TTL on the Add-Device path) rather than the tokens that actually enroll.

## How

- **API** (`fetchInstallerTokenUsage`): additive `liveConsumed`/`liveMax` — the same sums restricted to unexpired tokens via `FILTER (WHERE expires_at > now())` in the existing grouped query. `consumed`/`max` keep their all-tokens semantics; response is backward-compatible. `liveConsumed < liveMax` is deliberately the same live-token predicate `services/enrollmentKeyPurgeGuards.ts` uses.
- **Web** (`EnrollmentKeyManager`): capacity line marks dead slots instead of presenting them as free; the row's effective status derives from token liveness once the parent key is dead (active / exhausted / expired). The Download button continues to follow the parent key's own redeemability — that is what the authenticated download routes gate on (they 410 on an expired parent), so a live-token badge must not offer a download that can only fail.
- Legacy API responses without the new fields degrade to the previous all-live rendering.
- Locale keys added to all seven locales.

## Testing

- `enrollmentKeys_list_create.test.ts`, `enrollmentKeys_get_rotate_delete.test.ts` — 48 passing (live-cut aggregation, additive shape).
- `EnrollmentKeyManager.test.tsx` — 19 passing (dead-slot rendering, status derivation incl. legacy-response fallback, download gating).
- `installerTokenUsageAggregate.integration.test.ts` extended for the FILTERed sums (runs in Integration Tests, needs live DB).

Closes #3039

🤖 Generated with [Claude Code](https://claude.com/claude-code)