### PR TITLE
fix(agent): stop desktop lease renewal from renewing after release

### DIFF
--- a/agent/internal/heartbeat/handlers_desktop_lease.go
+++ b/agent/internal/heartbeat/handlers_desktop_lease.go
@@ -186,6 +186,15 @@ func (h *Heartbeat) startDesktopLeaseRenewal(sessionID string) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				// A cancelled ctx and a fired ticker are both ready cases, and
+				// select picks between ready cases at random — so without this
+				// check the goroutine can run further renewal rounds after
+				// releaseDesktopLeases() has already cancelled it and released
+				// the roles, re-extending a TTL that was just released and
+				// leaving the helper to linger instead of being reaped.
+				if ctx.Err() != nil {
+					return
+				}
 				if !h.helperSessionPresent(sysKey) {
 					gone++
 					if gone >= 2 {


### PR DESCRIPTION
Closes #3048.

`releaseDesktopLeases` (`handlers_desktop_lease.go:112`) cancels the renewal context and then releases the roles. The renewal goroutine (`:179`) selects over `ctx.Done()` and `ticker.C`, and when both are ready Go picks between them at random — so after cancellation the goroutine can still take the ticker branch and call `RenewLease` on roles that were just released, re-extending a TTL that should have been reaped. Nothing releases it again, so the helper lingers for the remainder of the lease TTL.

## The change

A `ctx.Err()` check at the top of the ticker branch, so a cancelled context always wins. It can only make the goroutine stop earlier after cancellation, and is a no-op while the lease is live — deliberately shaped that way, for the reason in the next section.

## How it surfaced

An intermittent `Test Agent (race)` failure on #2970:

```
--- FAIL: TestDesktopLeaseRenewalRenewsUntilReleased (0.09s)
    handlers_desktop_lease_test.go:283: renewal kept running after release (4 -> 8)
```

No `DATA RACE` was reported — despite the job name it is an ordinary assertion failure. That PR touched no Go files and its `agent/` tree was byte-identical to its parent, which passed the same job.

The numbers argue against a plain tolerance problem: the test allows `+2` and sleeps 50ms after release, so a goroutine that never stopped would show about 10 ticks x 2 roles = ~+20. `+4` means it did stop, two rounds later than the ordering the test assumes.

Production paces renewal at one minute, so the real-world window is narrow but nonzero; the test shrinks the tick to 5ms, which is why it shows up there first.

## Reproduction caveat

I could not reproduce this locally — roughly 1500 runs of the test, including at `GOMAXPROCS=1` and under CPU contention, all passed. The failure needs a tick buffered at the instant of cancellation, which takes a loaded runner and a slow `-race` build; an idle machine finishes each renewal round well inside the 5ms tick, so `ctx.Done()` wins deterministically.

So this fix is reasoned from the select semantics plus the CI evidence, not from a local repro. That is exactly why it is scoped to a strict no-op unless the context is already cancelled, rather than something more invasive like having release join the goroutine — which would add an RPC-latency stall to every release path in exchange for a bug I cannot demonstrate on demand.

I have deliberately not touched the test's tolerance. With the ordering fixed the existing assertion should hold on its own, and loosening it would only hide a recurrence.

## Verification

`go vet` clean. `internal/heartbeat` passes under `-race`, including 50 consecutive runs of the lease tests. Since the flake is load-dependent, CI here is the real check — if `Test Agent (race)` is green this is at least no worse, but a single green run cannot prove the flake is gone.