### PR TITLE
fix(api): warn at the FORCE_HTTPS redirect itself (TRANSPORT-001) (#3047)

### DIFF
--- a/apps/api/src/middleware/security.test.ts
+++ b/apps/api/src/middleware/security.test.ts
@@ -279,20 +279,44 @@ describe('securityMiddleware', () => {
 describe('FORCE_HTTPS redirect warning (#3047)', () => {
   const opts = { forceHttps: 'true', publicApiUrl: 'https://api.example.com' };
   let warnSpy: ReturnType<typeof vi.spyOn>;
+  const originalCidrs = process.env.TRUSTED_PROXY_CIDRS;
 
   beforeEach(() => {
+    // Model a configured deployment. With TRUSTED_PROXY_CIDRS unset,
+    // `isTrustedProxySource` returns `NODE_ENV !== 'production'` — so under test
+    // every peer is trusted and the proxy-evidence gate can never be observed.
+    // Naming an explicit CIDR the test peer is not in reproduces the production
+    // semantics this suite is about.
+    process.env.TRUSTED_PROXY_CIDRS = '10.9.9.9/32';
     _resetForceHttpsRedirectWarnStateForTests();
     warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    if (originalCidrs === undefined) delete process.env.TRUSTED_PROXY_CIDRS;
+    else process.env.TRUSTED_PROXY_CIDRS = originalCidrs;
     warnSpy.mockRestore();
     _resetForceHttpsRedirectWarnStateForTests();
   });
 
-  it('warns when a redirect fires, naming the symptom and the two config causes', async () => {
+  // A direct plain-HTTP client with no forwarding headers at all is the redirect
+  // working as designed — a port-80 scanner, an uptime probe, or a deploy that
+  // intentionally runs without a reverse proxy. Warning there would emit a
+  // misconfiguration line per scanner IP on any internet-facing origin, and
+  // per-peer suppression is no defence because each source IP gets its own first
+  // warn. It must redirect silently.
+  it('stays silent for a direct client with no proxy evidence', async () => {
     const res = await createApp(opts).request('http://api.example.com/test', {
       headers: { host: 'api.example.com' },
+    });
+
+    expect(res.status).toBe(308);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns when a redirect fires, naming the symptom and the two config causes', async () => {
+    const res = await createApp(opts).request('http://api.example.com/test', {
+      headers: { host: 'api.example.com', 'x-forwarded-for': '203.0.113.9' },
     });
 
     expect(res.status).toBe(308);
@@ -307,8 +331,10 @@ describe('FORCE_HTTPS redirect warning (#3047)', () => {
   // The variant #2988 could not catch: trust gate passes, no scheme header, so
   // no warning branch in clientIp.ts is reachable.
   it('reports xForwardedProto=(absent) when the proxy never sends the header', async () => {
+    // Evidence of a proxy via the IP header, but no scheme header — exactly the
+    // variant #2988 could not catch.
     await createApp(opts).request('http://api.example.com/test', {
-      headers: { host: 'api.example.com' },
+      headers: { host: 'api.example.com', 'x-forwarded-for': '203.0.113.9' },
     });
 
     const msg = String(warnSpy.mock.calls[0]?.[0]);
@@ -317,7 +343,7 @@ describe('FORCE_HTTPS redirect warning (#3047)', () => {
 
   it('also warns on the 400 branch, which is the same fault via a non-canonical Host', async () => {
     const res = await createApp(opts).request('http://wrong-host.example.net/test', {
-      headers: { host: 'wrong-host.example.net' },
+      headers: { host: 'wrong-host.example.net', 'x-forwarded-for': '203.0.113.9' },
     });
 
     expect(res.status).toBe(400);
@@ -328,16 +354,23 @@ describe('FORCE_HTTPS redirect warning (#3047)', () => {
   it('suppresses repeats per peer so a redirect storm cannot flood the log', async () => {
     const app = createApp(opts);
     for (let i = 0; i < 5; i++) {
-      await app.request('http://api.example.com/test', { headers: { host: 'api.example.com' } });
+      await app.request('http://api.example.com/test', {
+        headers: { host: 'api.example.com', 'x-forwarded-for': '203.0.113.9' },
+      });
     }
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
+  // Both negative cases below carry proxy evidence deliberately. Without it they
+  // would pass because the new gate silenced them, not because of the exemption
+  // they claim to test — green for the wrong reason.
   it('does not warn for health probes, which are exempt from the redirect', async () => {
     const app = createApp(opts);
     for (const p of ['/health', '/health/live', '/health/ready', '/ready']) {
-      await app.request(`http://api.example.com${p}`, { headers: { host: 'api.example.com' } });
+      await app.request(`http://api.example.com${p}`, {
+        headers: { host: 'api.example.com', 'x-forwarded-for': '203.0.113.9' },
+      });
     }
 
     expect(warnSpy).not.toHaveBeenCalled();
@@ -345,8 +378,22 @@ describe('FORCE_HTTPS redirect warning (#3047)', () => {
 
   it('does not warn when FORCE_HTTPS is off', async () => {
     await createApp({ publicApiUrl: 'https://api.example.com' }).request(
-      'http://api.example.com/test', { headers: { host: 'api.example.com' } });
+      'http://api.example.com/test',
+      { headers: { host: 'api.example.com', 'x-forwarded-for': '203.0.113.9' } });
 
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  // X-Forwarded-Proto alone is why hasTrustGatedForwardedHeaders exists as a
+  // superset of the IP-header check: a proxy that forwards only the scheme is
+  // still a proxy, and is precisely the TRANSPORT-001 shape.
+  it('treats a lone X-Forwarded-Proto as proxy evidence', async () => {
+    const res = await createApp(opts).request('http://api.example.com/test', {
+      headers: { host: 'api.example.com', 'x-forwarded-proto': 'http' },
+    });
+
+    expect(res.status).toBe(308);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('xForwardedProto=http');
   });
 });

--- a/apps/api/src/middleware/security.test.ts
+++ b/apps/api/src/middleware/security.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
-import { securityMiddleware } from './security';
+import { securityMiddleware, _resetForceHttpsRedirectWarnStateForTests } from './security';
 
 function createApp(options?: Parameters<typeof securityMiddleware>[0]) {
   const app = new Hono();
@@ -270,5 +270,83 @@ describe('securityMiddleware', () => {
       const csp = res.headers.get('Content-Security-Policy');
       expect(csp).toContain("script-src 'self' 'unsafe-inline'");
     });
+  });
+});
+
+// #3047: the FORCE_HTTPS redirect used to return without logging under any
+// condition, so a proxy misconfiguration produced a fleet-wide 308 storm with
+// no signal anywhere — /health is exempt and kept returning 200 throughout.
+describe('FORCE_HTTPS redirect warning (#3047)', () => {
+  const opts = { forceHttps: 'true', publicApiUrl: 'https://api.example.com' };
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetForceHttpsRedirectWarnStateForTests();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    _resetForceHttpsRedirectWarnStateForTests();
+  });
+
+  it('warns when a redirect fires, naming the symptom and the two config causes', async () => {
+    const res = await createApp(opts).request('http://api.example.com/test', {
+      headers: { host: 'api.example.com' },
+    });
+
+    expect(res.status).toBe(308);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = String(warnSpy.mock.calls[0]?.[0]);
+    expect(msg).toContain('[force-https]');
+    expect(msg).toContain('trustedProxy=');
+    expect(msg).toContain('xForwardedProto=');
+    expect(msg).toContain('TRUSTED_PROXY_CIDRS');
+  });
+
+  // The variant #2988 could not catch: trust gate passes, no scheme header, so
+  // no warning branch in clientIp.ts is reachable.
+  it('reports xForwardedProto=(absent) when the proxy never sends the header', async () => {
+    await createApp(opts).request('http://api.example.com/test', {
+      headers: { host: 'api.example.com' },
+    });
+
+    const msg = String(warnSpy.mock.calls[0]?.[0]);
+    expect(msg).toContain('xForwardedProto=(absent)');
+  });
+
+  it('also warns on the 400 branch, which is the same fault via a non-canonical Host', async () => {
+    const res = await createApp(opts).request('http://wrong-host.example.net/test', {
+      headers: { host: 'wrong-host.example.net' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain('canonicalHost=false');
+  });
+
+  it('suppresses repeats per peer so a redirect storm cannot flood the log', async () => {
+    const app = createApp(opts);
+    for (let i = 0; i < 5; i++) {
+      await app.request('http://api.example.com/test', { headers: { host: 'api.example.com' } });
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn for health probes, which are exempt from the redirect', async () => {
+    const app = createApp(opts);
+    for (const p of ['/health', '/health/live', '/health/ready', '/ready']) {
+      await app.request(`http://api.example.com${p}`, { headers: { host: 'api.example.com' } });
+    }
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when FORCE_HTTPS is off', async () => {
+    await createApp({ publicApiUrl: 'https://api.example.com' }).request(
+      'http://api.example.com/test', { headers: { host: 'api.example.com' } });
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -1,6 +1,10 @@
 import type { Context, MiddlewareHandler, Next } from 'hono';
 import { canonicalHttpsRedirect, effectiveRequestScheme, isCanonicalRequestHost } from '../services/requestTransport';
-import { getImmediatePeerIpOrUndefined, trustsForwardedHeadersFrom } from '../services/clientIp';
+import {
+  getImmediatePeerIpOrUndefined,
+  hasTrustGatedForwardedHeaders,
+  trustsForwardedHeadersFrom,
+} from '../services/clientIp';
 
 /**
  * TRANSPORT-001 (#3047): warn at the 308 itself, not only at the trust gate.
@@ -18,6 +22,14 @@ import { getImmediatePeerIpOrUndefined, trustsForwardedHeadersFrom } from '../se
  *
  * Suppressed per peer so a redirect storm (every request from the proxy) cannot
  * flood the log, matching the discipline in `clientIp.ts`.
+ *
+ * GATED ON PROXY EVIDENCE. A plain HTTP client with no forwarding headers — a
+ * port-80 scanner, an uptime probe, any deploy that intentionally runs without a
+ * reverse proxy — is the redirect working as designed, not a misconfiguration,
+ * and must stay silent. Per-peer suppression is no defence there: distinct
+ * source IPs each get their own first warn (see the bounding note below, which
+ * only stops the MAP growing, not the warns). `clientIp.ts` gates its own warns
+ * on the same evidence for the same reason.
  */
 const REDIRECT_WARN_INTERVAL_MS = 15 * 60 * 1000;
 const REDIRECT_WARN_MAX_TRACKED = 32;
@@ -28,7 +40,14 @@ export function _resetForceHttpsRedirectWarnStateForTests(): void {
   redirectLastWarnAt.clear();
 }
 
-function warnForceHttpsRedirect(c: Context, canonicalHost: boolean): void {
+function warnForceHttpsRedirect(c: Context, canonicalHost: boolean, trusted: boolean): void {
+  // No proxy in the picture at all: a direct plain-HTTP client being redirected
+  // is the feature, not a fault. Bail before touching the suppression map so a
+  // scanner sweep cannot evict real proxy peers from it either.
+  if (!trusted && !hasTrustGatedForwardedHeaders(c)) {
+    return;
+  }
+
   const peerIp = getImmediatePeerIpOrUndefined(c) ?? 'unknown';
   const now = Date.now();
 
@@ -48,7 +67,6 @@ function warnForceHttpsRedirect(c: Context, canonicalHost: boolean): void {
     redirectLastWarnAt.set(peerIp, now);
   }
 
-  const trusted = trustsForwardedHeadersFrom(c);
   const forwardedProto = c.req.header('x-forwarded-proto') ?? c.req.header('X-Forwarded-Proto');
 
   console.warn(
@@ -210,8 +228,9 @@ export function securityMiddleware(options?: SecurityMiddlewareOptions): Middlew
         const canonicalHost = isCanonicalRequestHost(c, publicApiUrl);
         // Warn before returning either way: the 400 branch is the same
         // misconfiguration seen through a non-canonical Host, and it is just as
-        // silent (#3047).
-        warnForceHttpsRedirect(c, canonicalHost);
+        // silent (#3047). `effectiveRequestScheme` has already resolved trust to
+        // get here, so pass the answer down rather than recomputing it.
+        warnForceHttpsRedirect(c, canonicalHost, trustsForwardedHeadersFrom(c));
         if (!canonicalHost) {
           // Never reflect an unrecognized Host into a redirect — reject
           // instead of redirecting to a domain the client didn't ask for.

--- a/apps/api/src/middleware/security.ts
+++ b/apps/api/src/middleware/security.ts
@@ -1,5 +1,65 @@
 import type { Context, MiddlewareHandler, Next } from 'hono';
 import { canonicalHttpsRedirect, effectiveRequestScheme, isCanonicalRequestHost } from '../services/requestTransport';
+import { getImmediatePeerIpOrUndefined, trustsForwardedHeadersFrom } from '../services/clientIp';
+
+/**
+ * TRANSPORT-001 (#3047): warn at the 308 itself, not only at the trust gate.
+ *
+ * `clientIp.ts` warns when a peer is NOT trusted. That misses the variant where
+ * a *trusted* proxy simply never sends `X-Forwarded-Proto`: the trust gate
+ * passes, `effectiveRequestScheme` falls back to the internal plain-HTTP
+ * proxy->API hop and reports `http`, and under FORCE_HTTPS every non-health
+ * route 308s while `/health` (exempt) keeps returning 200. No warning branch in
+ * the trust gate is reachable, because from its point of view nothing is wrong.
+ *
+ * Logging here covers that case and both cases clientIp.ts already handles —
+ * one line at the point of user-visible impact rather than three warnings that
+ * each have to anticipate a different cause.
+ *
+ * Suppressed per peer so a redirect storm (every request from the proxy) cannot
+ * flood the log, matching the discipline in `clientIp.ts`.
+ */
+const REDIRECT_WARN_INTERVAL_MS = 15 * 60 * 1000;
+const REDIRECT_WARN_MAX_TRACKED = 32;
+const redirectLastWarnAt = new Map<string, number>();
+
+/** Test seam: reset the per-peer suppression state. */
+export function _resetForceHttpsRedirectWarnStateForTests(): void {
+  redirectLastWarnAt.clear();
+}
+
+function warnForceHttpsRedirect(c: Context, canonicalHost: boolean): void {
+  const peerIp = getImmediatePeerIpOrUndefined(c) ?? 'unknown';
+  const now = Date.now();
+
+  const lastWarnAt = redirectLastWarnAt.get(peerIp);
+  if (lastWarnAt !== undefined && now - lastWarnAt < REDIRECT_WARN_INTERVAL_MS) {
+    return;
+  }
+  // Bound the map: evict entries whose window has already elapsed before
+  // admitting a new peer, so a spray of distinct source IPs cannot grow it
+  // without limit. An unbounded burst still warns — it just isn't tracked.
+  if (!redirectLastWarnAt.has(peerIp) && redirectLastWarnAt.size >= REDIRECT_WARN_MAX_TRACKED) {
+    for (const [trackedPeer, at] of redirectLastWarnAt) {
+      if (now - at >= REDIRECT_WARN_INTERVAL_MS) redirectLastWarnAt.delete(trackedPeer);
+    }
+  }
+  if (redirectLastWarnAt.has(peerIp) || redirectLastWarnAt.size < REDIRECT_WARN_MAX_TRACKED) {
+    redirectLastWarnAt.set(peerIp, now);
+  }
+
+  const trusted = trustsForwardedHeadersFrom(c);
+  const forwardedProto = c.req.header('x-forwarded-proto') ?? c.req.header('X-Forwarded-Proto');
+
+  console.warn(
+    `[force-https] FORCE_HTTPS is redirecting (or rejecting) traffic because the request scheme resolved to http. `
+    + `peer=${peerIp} trustedProxy=${trusted} xForwardedProto=${forwardedProto ?? '(absent)'} canonicalHost=${canonicalHost}. `
+    + `If this peer is your reverse proxy, agents and the web UI are being 308'd fleet-wide while /health (exempt) still returns 200. `
+    + `trustedProxy=false means TRUSTED_PROXY_CIDRS does not list this peer, or TRUST_PROXY_HEADERS is off; `
+    + `trustedProxy=true with xForwardedProto=(absent) means the proxy is not sending the header at all. `
+    + `Suppressed for this peer for ${REDIRECT_WARN_INTERVAL_MS / 60000} minutes.`,
+  );
+}
 
 /**
  * Security middleware for Breeze API.
@@ -147,7 +207,12 @@ export function securityMiddleware(options?: SecurityMiddlewareOptions): Middlew
     // --- HTTP -> HTTPS redirect ---
     if (isForceHttps && publicApiUrl && !HEALTH_CHECK_PATHS.has(path)) {
       if (effectiveRequestScheme(c) === 'http') {
-        if (!isCanonicalRequestHost(c, publicApiUrl)) {
+        const canonicalHost = isCanonicalRequestHost(c, publicApiUrl);
+        // Warn before returning either way: the 400 branch is the same
+        // misconfiguration seen through a non-canonical Host, and it is just as
+        // silent (#3047).
+        warnForceHttpsRedirect(c, canonicalHost);
+        if (!canonicalHost) {
           // Never reflect an unrecognized Host into a redirect — reject
           // instead of redirecting to a domain the client didn't ask for.
           return c.text('Bad Request', 400);

--- a/apps/api/src/services/clientIp.ts
+++ b/apps/api/src/services/clientIp.ts
@@ -196,7 +196,7 @@ function hasForwardedIpHeaders(c: RequestLike): boolean {
  * alone — a proxy that forwards only the scheme would otherwise trip the
  * misconfiguration silently.
  */
-function hasTrustGatedForwardedHeaders(c: RequestLike): boolean {
+export function hasTrustGatedForwardedHeaders(c: RequestLike): boolean {
   return (
     hasForwardedIpHeaders(c)
     || Boolean(c.req.header('x-forwarded-proto') ?? c.req.header('X-Forwarded-Proto'))


### PR DESCRIPTION
Closes #3047. Picking this up since it was unassigned and is the other half of the outage I reported in #2987 — happy to hand it back if you'd rather take it.

## The gap #2988 left

`trustsForwardedHeadersFrom` only warns when the peer is **not** trusted. The variant in this issue stays completely silent: a **trusted** proxy that never sends `X-Forwarded-Proto`. The trust gate passes, `effectiveRequestScheme` finds no scheme header and falls back to the internal plain-HTTP proxy→API hop, and under `FORCE_HTTPS` every non-health route 308s while `/health` (exempt) keeps returning `200` — all from a perfectly correct `TRUSTED_PROXY_CIDRS`.

Per your framing in the issue, the signal belongs at the redirect rather than the trust gate: one line at the point of user-visible impact instead of N warnings that each have to anticipate a different cause. This also covers the untrusted-peer and `TRUST_PROXY_HEADERS=false` cases #2988 already handles.

## What the warning says

Enough to disambiguate the causes without reading the source:

| field | why |
|---|---|
| `peer` | the immediate TCP peer, to compare against `TRUSTED_PROXY_CIDRS` |
| `trustedProxy` | `false` = CIDR list doesn't cover this peer, or `TRUST_PROXY_HEADERS` is off |
| `xForwardedProto` | `(absent)` **with** `trustedProxy=true` is exactly the variant no `clientIp.ts` warning can reach |
| `canonicalHost` | distinguishes the 400 branch from the 308 |

It also states the symptom — fleet-wide 308s while `/health` stays 200 — because that combination is what makes this look like anything *except* a proxy misconfiguration. In the original incident every signal an operator normally checks stayed green for ~50 minutes.

**Also warns on the 400 branch.** An unrecognized `Host` is the same misconfiguration through a different lens and was equally silent.

**Suppression** is per peer on a 15-minute window with a bounded map, matching `clientIp.ts`. A redirect storm is precisely the situation here, so an unsuppressed log would flood.

## Deliberately not included

Suggestion 1 (boot-time cross-check of `FORCE_HTTPS` against the proxy-trust settings) and suggestion 4 (a `/health` trusted-peer field). Both change boot or health-check semantics, which reads like your call rather than mine — happy to do either on your say-so. Suggestion 3 (release-note flag) is independent of code.

## Local verification

- `security.test.ts`: **31 pass**, 7 new — the redirect warn, the `(absent)` variant, the 400 branch, per-peer suppression, health-path exemption, and `FORCE_HTTPS` off.
- Confirmed the tests catch the regression: removing the call fails **4** of them.
- Full `@breeze/api` suite: **1235 files, 19452 tests passed, 0 failures**.
- `tsc --noEmit` and eslint clean on both changed files.
