### PR TITLE
docs: document the event-loop lag monitor + add a running next-release draft

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -66,7 +66,17 @@ Before proceeding, verify the new release has the **same asset families** as the
 
 ## Step 1 — Source the content (PRs + git only)
 
-Release content comes from **merged PRs and git history only** — never blog posts, design docs, or product docs (those describe *planned*, not *shipped*, work).
+**Read `docs/release-notes/next-release-draft.md` FIRST.** It is the running
+scratch list where operator-visible details get written down at the moment
+they're introduced — new env vars, new log lines, new metrics, behaviour changes
+— rather than being reconstructed from a commit subject weeks later. Fold each
+entry into the body below (most of it belongs in Self-Hosting / Upgrade Notes),
+then **clear the file in the same PR that publishes the release**, so a stale
+entry can't be shipped twice. It is a supplement to the git history, not a
+replacement: still do the `$PREV..$NEW` sweep, because anything nobody thought to
+write down only exists there.
+
+Release content otherwise comes from **merged PRs and git history only** — never blog posts, design docs, or product docs (those describe *planned*, not *shipped*, work).
 
 ```bash
 git -C ~/breeze log --oneline $PREV..$NEW
@@ -309,6 +319,7 @@ Rolling the fleet is a user-facing change — get Todd's go-ahead before promoti
 
 ## Quick checklist
 
+- [ ] `docs/release-notes/next-release-draft.md` read and folded into the body — then cleared
 - [ ] `git diff $PREV..HEAD --stat` + migrations reviewed — blast radius understood
 - [ ] Tag pushed (off main for full release / off $PREV for surgical hotfix)
 - [ ] **Build finished green + ALL artifacts present** (signed MSI, notarized macOS, manifest+sigs, checksums) — asset count matches prior release; do not publish/roll out before this

--- a/.env.example
+++ b/.env.example
@@ -445,6 +445,14 @@ METRICS_SCRAPE_IP_ALLOWLIST=
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=changeme
 
+# Event-loop lag monitor. On by default; these are tuning knobs, not requirements.
+# It is what makes a stalled main thread visible as a stall instead of as a
+# misleading Postgres "write CONNECT_TIMEOUT". Disabling it downgrades every
+# CONNECT_TIMEOUT diagnosis to "unknown".
+# EVENT_LOOP_MONITOR_INTERVAL_MS=1000
+# EVENT_LOOP_STARVATION_WARN_MS=1000
+# EVENT_LOOP_MONITOR_DISABLED=
+
 # Platform-operator abuse alerts (all optional; unset = feature disabled)
 # OPS_ALERT_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook
 # OPS_ALERT_EMAIL=ops@your-domain.example.com

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -194,6 +194,34 @@ The Breeze stack includes a [coturn](https://github.com/coturn/coturn) TURN serv
 | `LOKI_PORT` | `3100` | Loki log aggregation API port (monitoring stack) |
 | `DEVICE_METRICS_RETENTION_DAYS` | `30` | Retention for the raw `device_metrics` series, clamped to 1–365. History charts are served from `metric_rollups` and are unaffected. **On first run after upgrading, older raw metrics are pruned — set this before starting the new version if you need more than 30 days.** |
 
+### Event-loop lag monitor
+
+The API samples its own event-loop delay so that a stalled main thread shows up
+as a stalled main thread. Without it, a stall surfaces as unrelated downstream
+errors — most confusingly a Postgres `write CONNECT_TIMEOUT <host>:<port>`, which
+names the database even though the database and the network were both healthy.
+The monitor runs by default; you do not need to set any of these.
+
+| Variable | Default | Description |
+|---|---|---|
+| `EVENT_LOOP_MONITOR_INTERVAL_MS` | `1000` | Sampling interval for event-loop delay. Values above `EVENT_LOOP_STARVATION_WARN_MS` leave a blind spot one interval wide — stalls shorter than one interval cannot be observed and are reported as cause `unknown`. The API logs a startup warning if you configure it that way. |
+| `EVENT_LOOP_STARVATION_WARN_MS` | `1000` | Lag at or above which a reading counts as starvation. Drives the `[event-loop] Main thread blocked…` warning and the `breeze_nodejs_eventloop_starved` gauge. |
+| `EVENT_LOOP_MONITOR_DISABLED` | — | Set to `1`, `true`, `yes`, or `on` to turn the monitor off. With it off, every Postgres `CONNECT_TIMEOUT` is classified `unknown`, because starvation can be neither ruled in nor out. |
+
+At startup the API prints one line stating whether it can see its own loop and at
+what settings — `[event-loop] Lag monitor started (interval …ms, warn threshold
+…ms, CONNECT_TIMEOUT attribution threshold …ms)`, or a warning if the monitor is
+disabled. The two thresholds can differ: `CONNECT_TIMEOUT` attribution caps its
+own threshold at the 10s connect budget, so raising the warn threshold above 10s
+cannot cause a timeout to be mis-attributed.
+
+Lag is exported on `/metrics/scrape` (see [Monitoring Stack](/monitoring/stack/#event-loop-metrics)).
+It is deliberately **not** reported by `/health/ready`: that endpoint is
+unauthenticated, and a live load gradient plus the configured threshold would let
+an unauthenticated prober measure whether its own traffic is starving the
+instance. Readiness is also not gated on lag — starvation is a load symptom, and
+failing readiness under load would shift traffic onto peers and starve those too.
+
 ## Sentry
 
 Both API and web Sentry integrations are off by default. Leave the DSN variables blank to disable. See [Error Tracking & Privacy](/security/error-tracking/) for what gets collected and how scrubbing works.

--- a/apps/docs/src/content/docs/monitoring/stack.mdx
+++ b/apps/docs/src/content/docs/monitoring/stack.mdx
@@ -167,6 +167,32 @@ Rules are evaluated every 30 seconds (API and infrastructure groups) or every 60
 | `pg_database_size_bytes` | Gauge | Database size in bytes |
 | `pg_settings_max_connections` | Gauge | PostgreSQL max allowed connections |
 
+### Event-Loop Metrics
+
+The API exports its own event-loop delay so a stalled main thread is visible as
+such, rather than only as the downstream errors it causes (see
+[Event-loop lag monitor](/deploy/environment/#event-loop-lag-monitor) for the
+tuning variables). All five series are published from process start, so an alert
+rule referencing them never queries a metric that does not exist yet.
+
+| Metric | Type | Description |
+|---|---|---|
+| `breeze_nodejs_eventloop_monitored` | Gauge | `1` when the instrumentation is running, `0` when it is disabled or not yet started |
+| `breeze_nodejs_eventloop_lag_max_seconds` | Gauge | Delay over the last completed sampling interval, including any stall still in flight (instantaneous) |
+| `breeze_nodejs_eventloop_lag_window_max_seconds` | Gauge | Worst delay retained across the whole sampling window (high-water mark) |
+| `breeze_nodejs_eventloop_lag_window_mean_seconds` | Gauge | Mean delay across the retained sampling window |
+| `breeze_nodejs_eventloop_starved` | Gauge | `1` while the current lag is at or above `EVENT_LOOP_STARVATION_WARN_MS`, else `0` |
+
+Two things to know before writing alert rules against these:
+
+- **Alert on `breeze_nodejs_eventloop_monitored == 0`.** When the monitor is off,
+  the other four gauges sit at `0` — which is indistinguishable from a perfectly
+  healthy loop. This series is what separates the two cases.
+- **`_lag_max_seconds` is instantaneous, `_lag_window_max_seconds` is not.** Use
+  the instantaneous series (or `breeze_nodejs_eventloop_starved`) for "is it
+  stalled right now"; the window max stays elevated for the retention window, so
+  a `max_over_time` on it counts one stall many times.
+
 ## Log Aggregation with Loki
 
 Promtail scrapes Docker container logs and ships them to Loki. Loki stores logs for 14 days by default (configurable via `retention_period` in `monitoring/loki-config.yml`).

--- a/apps/docs/src/content/docs/reference/troubleshooting.mdx
+++ b/apps/docs/src/content/docs/reference/troubleshooting.mdx
@@ -112,6 +112,39 @@ docker compose -f docker/docker-compose.prod.yml exec postgres \
   psql -U breeze -c "SELECT * FROM pg_stat_activity WHERE state = 'active';"
 ```
 
+### Postgres `write CONNECT_TIMEOUT` while the database is healthy
+
+A `write CONNECT_TIMEOUT <host>:<port>` error does **not** always mean the
+database or the network failed. The driver's 10s connect budget covers socket
+creation, TCP, TLS, authentication, and the first ready-for-query — every one of
+which needs the API's event loop to run a socket callback. A saturated main
+thread expires that timer with Postgres and the network both fine, and the error
+then points at the wrong subsystem.
+
+**Check** whether the loop was starved at the time:
+
+```bash
+# Is the loop stalled right now? (1 = at or above the starvation threshold)
+curl -H "Authorization: Bearer $METRICS_SCRAPE_TOKEN" \
+  https://breeze.yourdomain.com/metrics/scrape | grep breeze_nodejs_eventloop
+
+# Did the API log a stall? (throttled; one line per run of breaching samples)
+docker compose logs api | grep '\[event-loop\]'
+```
+
+If `breeze_nodejs_eventloop_monitored` is `0`, the monitor is off and the other
+gauges are meaningless — the API cannot tell starvation from connectivity, and
+reports the cause as `unknown`. See
+[Event-loop lag monitor](/deploy/environment/#event-loop-lag-monitor).
+
+When Sentry is configured, the same verdict arrives as a `connect_timeout_cause`
+tag on the error (`event-loop-starvation`, `connectivity`, or `unknown`), with an
+`event_loop_lag_bucket` tag alongside it.
+
+**Fix**: treat it as load, not as a connection fault — the usual causes are a
+CPU-bound request path or a burst of agent traffic. Raising `connect_timeout`
+alone only lengthens the failing request; it does not unstall the loop.
+
 ### Redis memory growing
 
 **Check**:

--- a/docs/release-notes/next-release-draft.md
+++ b/docs/release-notes/next-release-draft.md
@@ -1,0 +1,59 @@
+# Next release — draft notes
+
+Running scratch list for the next tag. **`/release` Step 1 reads this file** and
+folds each entry into the GitHub Release body (mostly Self-Hosting / Upgrade
+Notes), then clears it in the same PR that publishes the release.
+
+Add an entry the moment you introduce something an operator or self-hoster would
+notice — a new env var, a new log line, a new metric, a changed default, a
+behaviour change. A commit subject weeks later will not carry it.
+
+Last release: **v0.103.0** (2026-07-31).
+
+---
+
+## Event-loop lag monitor (#3022, PR #3024)
+
+The API now samples its own event-loop delay, so a stalled main thread is
+reported as a stalled main thread instead of as a Postgres `write CONNECT_TIMEOUT
+<host>:<port>` — a connection fault that never happened. Nothing is required of
+operators; the monitor is on by default.
+
+### New environment variables (API, all optional)
+
+| Variable | Default | Effect |
+|---|---|---|
+| `EVENT_LOOP_MONITOR_INTERVAL_MS` | `1000` | Sampling interval. Above the warn threshold it leaves a blind spot one interval wide; the API warns at boot when configured that way. |
+| `EVENT_LOOP_STARVATION_WARN_MS` | `1000` | Lag at or above which a reading counts as starvation. Drives the warning log and `breeze_nodejs_eventloop_starved`. |
+| `EVENT_LOOP_MONITOR_DISABLED` | unset | Truthy (`1`/`true`/`yes`/`on`) disables the monitor. Every Postgres CONNECT_TIMEOUT then reports cause `unknown`. |
+
+### New log lines
+
+- `[event-loop] Lag monitor started (interval Nms, warn threshold Nms, CONNECT_TIMEOUT attribution threshold Nms)` — at boot. Two thresholds, because CONNECT_TIMEOUT attribution caps its own at the 10s connect budget.
+- `[event-loop] EVENT_LOOP_MONITOR_INTERVAL_MS (Nms) exceeds the starvation threshold (Nms)…` — boot warning; stalls shorter than one interval report `unknown`.
+- `[event-loop] Lag monitor DISABLED via EVENT_LOOP_MONITOR_DISABLED…` — boot warning.
+- `[event-loop] Main thread blocked for up to Nms (>= Nms)…` — runtime, throttled.
+
+### New Prometheus gauges (`/metrics/scrape`)
+
+- `breeze_nodejs_eventloop_monitored` (0/1 — alert on `0`; a blind instance would otherwise read as a healthy one)
+- `breeze_nodejs_eventloop_lag_max_seconds` (instantaneous, includes an in-flight stall)
+- `breeze_nodejs_eventloop_lag_window_max_seconds` (high-water mark)
+- `breeze_nodejs_eventloop_lag_window_mean_seconds`
+- `breeze_nodejs_eventloop_starved` (0/1)
+
+### Also operator-visible
+
+- New Sentry tags `connect_timeout_cause` (`event-loop-starvation` / `connectivity` / `unknown`) and `event_loop_lag_bucket`.
+- `connect_timeout` stays at 10s.
+- Lag is deliberately **not** on `/health/ready` (unauthenticated endpoint; a live load gradient plus the threshold would let a prober measure whether its own load is starving the instance), and readiness is **not** gated on lag (failing readiness under load would shift traffic onto peers and starve those too).
+
+Docs already updated: `deploy/environment.mdx`, `monitoring/stack.mdx`,
+`reference/troubleshooting.mdx`, `.env.example`.
+
+### Follow-up (not release content)
+
+#3022 stays open — this shipped the instrumentation half only. Reducing
+main-thread work on the agent auth-rejection path is unimplemented and needs a
+design decision: a negative auth cache, a pre-auth rate limit, or skipping the
+fallback audit all change auth/security semantics.


### PR DESCRIPTION
The event-loop monitor (#3022, PR #3024) landed after the v0.103.0 tag and introduced **three env vars, four log lines, and five Prometheus gauges** — none of which were documented anywhere in `docs/`, `apps/docs/`, or `.env.example`.

## Docs

| File | Change |
|---|---|
| `deploy/environment.mdx` | New **Event-loop lag monitor** subsection under Monitoring: `EVENT_LOOP_MONITOR_INTERVAL_MS`, `EVENT_LOOP_STARVATION_WARN_MS`, `EVENT_LOOP_MONITOR_DISABLED`, the boot log lines, why the two printed thresholds differ, and why lag is deliberately absent from `/health/ready` |
| `monitoring/stack.mdx` | The five `breeze_nodejs_eventloop_*` gauges, plus the two things that bite when alerting on them |
| `reference/troubleshooting.mdx` | A Performance Issues entry for a Postgres `write CONNECT_TIMEOUT` raised while the database is healthy — the symptom this instrumentation exists to explain |
| `.env.example` | The three variables, commented, with a note on what disabling the monitor costs |

Two points from the implementation that are easy to get wrong and are called out explicitly:

- **Alert on `breeze_nodejs_eventloop_monitored == 0`.** With the monitor off the other four gauges sit at `0`, which is indistinguishable from a perfectly healthy loop.
- **`_lag_max_seconds` is instantaneous; `_lag_window_max_seconds` is a high-water mark.** A `max_over_time` on the latter counts one stall many times.

## Process: a running next-release draft

`docs/release-notes/next-release-draft.md` is new. It is a scratch list for operator-visible details — new env vars, log lines, metrics, changed defaults — written down *when introduced* rather than reconstructed from a commit subject weeks later. This PR seeds it with the event-loop entry.

`/release` Step 1 now reads it first and clears it in the publishing PR, and it is on the release checklist. It **supplements** the `$PREV..$NEW` git sweep rather than replacing it: anything nobody thought to write down still only exists in the history.

## Verification

- `pnpm --filter @breeze/docs build` — green, 149 pages.
- Both new cross-page anchors (`/deploy/environment/#event-loop-lag-monitor`, `/monitoring/stack/#event-loop-metrics`) confirmed present as `id=` attributes in the built HTML.
- Every documented name, default, and log string was read off `origin/main` rather than the PR description. Note that #3024's description says `/health/ready` reports lag; the merged code deliberately does **not**, and the docs follow the code.

Refs #3022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)