### PR TITLE
fix(api): make pnpm db:migrate actually run autoMigrate() (#3065)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "build": "tsup",
     "clean": "rm -rf dist",
     "db:check-drift": "tsx scripts/check-drift.ts",
-    "db:migrate": "tsx src/db/autoMigrate.ts",
+    "db:migrate": "tsx scripts/migrate.ts",
     "db:seed": "tsx src/db/seed.ts",
     "db:seed:e2e": "tsx src/db/seedE2eFixtures.ts",
     "check:migrations": "tsx scripts/check-migrations.ts",

--- a/apps/api/scripts/migrate.ts
+++ b/apps/api/scripts/migrate.ts
@@ -1,0 +1,21 @@
+// Dedicated entrypoint for `pnpm db:migrate` (#3065).
+//
+// autoMigrate.ts is a library module imported by the API boot path
+// (databaseStartup), so it must not self-execute — and an "am I the main
+// module?" guard comparing import.meta.url against process.argv[1] fails
+// open on paths needing URL percent-encoding (spaces, non-ASCII), symlinked
+// checkouts, and Windows, silently reproducing the #3065 exit-0 no-op. A
+// dedicated entry file that calls autoMigrate() unconditionally has no such
+// failure mode (same structure as scripts/check-drift.ts for db:check-drift).
+//
+// process.exit is required: autoMigrate's auto-seed step opens the shared
+// pool from src/db/index, which would otherwise hold the event loop open
+// forever after a successful run.
+import { autoMigrate } from '../src/db/autoMigrate';
+
+autoMigrate()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('[auto-migrate] Migration failed:', err);
+    process.exit(1);
+  });

--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -272,6 +272,36 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS bar_idx ON t (b);`;
   });
 });
 
+describe('db:migrate entrypoint (#3065)', () => {
+  // `pnpm db:migrate` executes a file directly via tsx. That file must
+  // self-invoke autoMigrate() when run as the main module — otherwise the
+  // script imports the module, exits 0, and silently applies nothing.
+  const apiRoot = path.resolve(__dirname, '..', '..');
+
+  it('package.json db:migrate points at an existing TypeScript entrypoint', () => {
+    const pkg = JSON.parse(readFileSync(path.join(apiRoot, 'package.json'), 'utf8'));
+    const script: string = pkg.scripts['db:migrate'];
+    expect(script).toMatch(/^tsx /);
+    const entrypoint = script.replace(/^tsx\s+/, '').trim();
+    expect(readFileSync(path.join(apiRoot, entrypoint), 'utf8').length).toBeGreaterThan(0);
+  });
+
+  it('the entrypoint invokes autoMigrate() under a direct-execution guard', () => {
+    const pkg = JSON.parse(readFileSync(path.join(apiRoot, 'package.json'), 'utf8'));
+    const entrypoint = (pkg.scripts['db:migrate'] as string).replace(/^tsx\s+/, '').trim();
+    const source = readFileSync(path.join(apiRoot, entrypoint), 'utf8');
+
+    // Direct-execution guard (same pattern as seed.ts / seedE2eFixtures.ts).
+    const guardIndex = source.indexOf('import.meta.url === `file://${process.argv[1]}`');
+    expect(guardIndex).toBeGreaterThan(-1);
+
+    // The guard must actually call autoMigrate() and exit non-zero on failure.
+    const afterGuard = source.slice(guardIndex);
+    expect(afterGuard).toContain('autoMigrate()');
+    expect(afterGuard).toContain('process.exit(1)');
+  });
+});
+
 describe('CHECKSUM_RECONCILIATIONS', () => {
   const migrationsDir = path.resolve(__dirname, '../../migrations');
 

--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -273,32 +273,44 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS bar_idx ON t (b);`;
 });
 
 describe('db:migrate entrypoint (#3065)', () => {
-  // `pnpm db:migrate` executes a file directly via tsx. That file must
-  // self-invoke autoMigrate() when run as the main module — otherwise the
-  // script imports the module, exits 0, and silently applies nothing.
+  // `pnpm db:migrate` executes a dedicated entry file via tsx. That file must
+  // unconditionally invoke autoMigrate() — the original bug was the script
+  // pointing at the library module itself, which only exports the function,
+  // so the command exited 0 having applied nothing. A conditional
+  // "am I the main module?" guard is not acceptable here either: comparing
+  // import.meta.url to process.argv[1] fails open on percent-encodable or
+  // symlinked paths, silently reproducing the same no-op.
   const apiRoot = path.resolve(__dirname, '..', '..');
 
-  it('package.json db:migrate points at an existing TypeScript entrypoint', () => {
+  function resolveEntrypoint(): { entrypoint: string; source: string } {
     const pkg = JSON.parse(readFileSync(path.join(apiRoot, 'package.json'), 'utf8'));
     const script: string = pkg.scripts['db:migrate'];
     expect(script).toMatch(/^tsx /);
     const entrypoint = script.replace(/^tsx\s+/, '').trim();
-    expect(readFileSync(path.join(apiRoot, entrypoint), 'utf8').length).toBeGreaterThan(0);
+    return { entrypoint, source: readFileSync(path.join(apiRoot, entrypoint), 'utf8') };
+  }
+
+  it('package.json db:migrate points at a dedicated entry file, not the library module', () => {
+    const { entrypoint, source } = resolveEntrypoint();
+    expect(source.length).toBeGreaterThan(0);
+    // The library module must stay import-safe for the API boot path, so the
+    // script may not point straight at it.
+    expect(path.basename(entrypoint)).not.toBe('autoMigrate.ts');
   });
 
-  it('the entrypoint invokes autoMigrate() under a direct-execution guard', () => {
-    const pkg = JSON.parse(readFileSync(path.join(apiRoot, 'package.json'), 'utf8'));
-    const entrypoint = (pkg.scripts['db:migrate'] as string).replace(/^tsx\s+/, '').trim();
-    const source = readFileSync(path.join(apiRoot, entrypoint), 'utf8');
+  it('the entrypoint invokes autoMigrate() unconditionally and exits by outcome', () => {
+    const { source } = resolveEntrypoint();
 
-    // Direct-execution guard (same pattern as seed.ts / seedE2eFixtures.ts).
-    const guardIndex = source.indexOf('import.meta.url === `file://${process.argv[1]}`');
-    expect(guardIndex).toBeGreaterThan(-1);
-
-    // The guard must actually call autoMigrate() and exit non-zero on failure.
-    const afterGuard = source.slice(guardIndex);
-    expect(afterGuard).toContain('autoMigrate()');
-    expect(afterGuard).toContain('process.exit(1)');
+    // Invokes the runner (not just imports it)...
+    expect(source).toContain('autoMigrate()');
+    // ...must not hide the call behind a main-module guard (fails open on
+    // percent-encoded/symlinked paths — the silent-no-op failure mode again).
+    expect(source).not.toContain('import.meta.url ===');
+    // Success must exit 0 explicitly (the auto-seed step opens the shared
+    // pool, which would otherwise hold the event loop open forever)...
+    expect(source).toContain('process.exit(0)');
+    // ...and failure must exit non-zero.
+    expect(source).toContain('process.exit(1)');
   });
 });
 

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -621,3 +621,17 @@ export async function autoMigrate(): Promise<void> {
     await client.end();
   }
 }
+
+// Run if executed directly (`pnpm db:migrate`). Without this guard the package
+// script merely imports the module and exits 0 having applied nothing (#3065).
+// process.exit is required: seed() (step 8) opens the shared pool from
+// ./index, which would otherwise hold the event loop open forever.
+const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+if (isMainModule) {
+  autoMigrate()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error('[auto-migrate] Migration failed:', err);
+      process.exit(1);
+    });
+}

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -621,17 +621,3 @@ export async function autoMigrate(): Promise<void> {
     await client.end();
   }
 }
-
-// Run if executed directly (`pnpm db:migrate`). Without this guard the package
-// script merely imports the module and exits 0 having applied nothing (#3065).
-// process.exit is required: seed() (step 8) opens the shared pool from
-// ./index, which would otherwise hold the event loop open forever.
-const isMainModule = import.meta.url === `file://${process.argv[1]}`;
-if (isMainModule) {
-  autoMigrate()
-    .then(() => process.exit(0))
-    .catch((err) => {
-      console.error('[auto-migrate] Migration failed:', err);
-      process.exit(1);
-    });
-}


### PR DESCRIPTION
## Summary
`pnpm db:migrate` ran `tsx src/db/autoMigrate.ts`, which only defines/exports `autoMigrate()` — no invocation. The command exited 0 having applied nothing, so anyone following the documented dev workflow (or `scripts/prod/deploy.sh` step 4) silently got a stale schema; only the API boot path actually applied migrations.

## Fix
- New dedicated entry file `apps/api/scripts/migrate.ts` (same structure as `scripts/check-drift.ts` for `db:check-drift`): unconditionally awaits `autoMigrate()`, `process.exit(0)` on success, logs + `process.exit(1)` on failure. `db:migrate` now points at it.
- `process.exit` is deliberate — autoMigrate's auto-seed step opens the shared pool from `db/index`, which would otherwise hold the event loop open and hang the command after success.
- A first iteration used the `seed.ts`-style main-module guard (`import.meta.url === \`file://${process.argv[1]}\``); review verified empirically that it fails open (silent exit-0 no-op — the exact #3065 failure mode) on paths needing URL percent-encoding, symlinked checkouts, and Windows. The dedicated entry file has zero such failure modes and keeps the library module import-safe for the API boot path (`databaseStartup`).

## Regression guard
New `db:migrate entrypoint (#3065)` block in `apps/api/src/db/autoMigrate.test.ts`: resolves the entrypoint from `package.json`'s `db:migrate` script and asserts it is a dedicated file (not the library module), calls `autoMigrate()` with no main-module guard, and exits 0/1 by outcome. Runs in the required Test API job.

## Verification
- `pnpm exec vitest run src/db/autoMigrate.test.ts` — 56 passed (includes the 2 new tests).
- `tsc --noEmit` clean on apps/api.
- Live against the local dev DB (`postgresql://breeze:breeze@localhost:5432/breeze`, all migrations already applied): `pnpm db:migrate` enumerates the migrations dir, detects `normal` state, verifies checksums, prints `All migrations already applied` / `Database already seeded`, and terminates on its own with exit 0 (previously: no runner output at all, vacuous exit 0). Error path also observed live: with the DB unreachable it printed the full stack via the `.catch` and exited non-zero.

No migration files created or modified.

Closes #3065

🤖 Generated with [Claude Code](https://claude.com/claude-code)