### PR TITLE
fix(security): scrub transaction events too, so a sampled trace cannot ship a live API key (#3077)

### DIFF
--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -482,6 +482,100 @@ describe('scrubEvent', () => {
   });
 });
 
+describe('scrubTransactionEvent (#3077)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    initMock.mockClear();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  // A transaction event as `requestDataIntegration()` builds it: the SDK copies
+  // the request header bag verbatim onto EVERY event type, and only applies its
+  // own SENSITIVE_KEY_SNIPPETS deny list on the span-attribute path — so the
+  // event body is where a live `brz_` credential rides out.
+  const transactionEvent = () => ({
+    type: 'transaction',
+    release: '1.2.3',
+    transaction: 'GET /api/devices/:id',
+    request: {
+      method: 'GET',
+      url: 'https://example.test/api/devices/1?token=raw-capability',
+      query_string: 'token=raw-capability',
+      headers: {
+        'X-API-Key': 'brz_raw-capability',
+        Authorization: 'Bearer raw-capability',
+        COOKIE: 'session=raw-capability',
+        'user-agent': 'sdk',
+      },
+      data: { token: 'raw-capability' },
+      cookies: { session: 'raw-capability' },
+    },
+    contexts: {
+      trace: { trace_id: 'abc123', span_id: 'def456', op: 'http.server' },
+      runtime: { name: 'node', version: 'raw-capability' },
+      os: { name: 'raw-capability' },
+    },
+    breadcrumbs: [{ message: 'raw-capability' }],
+    extra: { apiKey: 'brz_raw-capability' },
+    tags: { method: 'GET', org_id: 'o-1', arbitrary: 'raw-capability' },
+    spans: [{ span_id: 'def456', op: 'db.query' }],
+  });
+
+  it('strips the api key (and every other header) from a sampled transaction', async () => {
+    const { scrubTransactionEvent } = await import('./sentry');
+    const out = scrubTransactionEvent(transactionEvent() as any);
+
+    expect(out.request).toEqual({ method: 'GET' });
+    expect(out.extra).toBeUndefined();
+    expect(out.breadcrumbs).toBeUndefined();
+    expect(out.tags).toEqual({ method: 'GET', org_id: 'o-1' });
+    expect(JSON.stringify(out)).not.toContain('raw-capability');
+    expect(JSON.stringify(out)).not.toContain('brz_');
+  });
+
+  it('keeps contexts.trace so the transaction stays a valid event', async () => {
+    // Reusing scrubEvent here would delete `contexts` outright and silently
+    // disable tracing rather than secure it — a transaction event without
+    // contexts.trace is rejected.
+    const { scrubTransactionEvent } = await import('./sentry');
+    const out = scrubTransactionEvent(transactionEvent() as any);
+
+    expect(out.contexts).toEqual({
+      trace: { trace_id: 'abc123', span_id: 'def456', op: 'http.server' },
+    });
+    expect(out.transaction).toBe('GET /api/devices/:id');
+    expect(out.spans).toEqual([{ span_id: 'def456', op: 'db.query' }]);
+  });
+
+  it('does not throw on sparse or trace-less events', async () => {
+    const { scrubTransactionEvent } = await import('./sentry');
+    expect(() => scrubTransactionEvent({} as any)).not.toThrow();
+    expect(() => scrubTransactionEvent({ request: {} } as any)).not.toThrow();
+    expect(scrubTransactionEvent({ contexts: {} } as any).contexts).toBeUndefined();
+  });
+
+  it('is wired as beforeSendTransaction, which beforeSend never covers', async () => {
+    process.env.SENTRY_DSN = 'https://abc@o1.ingest.us.sentry.io/2';
+    const { initSentry } = await import('./sentry');
+    initSentry();
+
+    const initArg = initMock.mock.calls[0]![0] as {
+      beforeSend?: (e: unknown) => unknown;
+      beforeSendTransaction?: (e: unknown) => unknown;
+    };
+    expect(typeof initArg.beforeSend).toBe('function');
+    expect(typeof initArg.beforeSendTransaction).toBe('function');
+
+    const scrubbed = initArg.beforeSendTransaction!(transactionEvent() as any) as any;
+    expect(scrubbed.request).toEqual({ method: 'GET' });
+    expect(JSON.stringify(scrubbed)).not.toContain('brz_');
+  });
+});
+
 describe('sentry bootstrap wiring (index.ts)', () => {
   const indexSource = readFileSync(
     fileURLToPath(new URL('../index.ts', import.meta.url)),

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -203,6 +203,52 @@ export function scrubEvent<T extends Record<string, any>>(event: T): T {
   return event;
 }
 
+/**
+ * #3077: the same rebuild for TRANSACTION events, which `beforeSend` never sees.
+ *
+ * `@sentry/core` dispatches the two hooks by event type — `beforeSend` for error
+ * events, `beforeSendTransaction` for transactions — so `scrubEvent` above ran on
+ * exactly half the outbound traffic. Meanwhile `requestDataIntegration()` is a
+ * default node integration whose `processEvent` fires on EVERY event type and
+ * copies the request header bag verbatim into `event.request.headers`; the SDK's
+ * own `SENSITIVE_KEY_SNIPPETS` deny list (which would have caught `x-api-key`)
+ * is only applied on the span-attribute path, not to the event body. So a
+ * sampled transaction on an api-key route shipped a live `brz_` credential with
+ * no error involved at all — and `.env.example` ships
+ * `SENTRY_TRACES_SAMPLE_RATE=0.1`, so sampling is on for anyone who copies it.
+ *
+ * This deliberately does NOT reuse `scrubEvent`: that one deletes `contexts`,
+ * and a transaction event without `contexts.trace` is invalid — reusing it would
+ * silently disable tracing rather than secure it. Instead `contexts` is narrowed
+ * to `trace` alone, which is the field the event format requires and the only one
+ * carrying no host or tenant detail (`nodeContextIntegration` fills the rest with
+ * server metadata).
+ *
+ * `event.spans[].data` is left alone: those attributes already pass through the
+ * SDK's `filterKeyValueData` + `SENSITIVE_KEY_SNIPPETS` in
+ * `httpHeadersToSpanAttributes`, so header values arrive pre-redacted there.
+ */
+export function scrubTransactionEvent<T extends Record<string, any>>(event: T): T {
+  const mutableEvent = event as Record<string, any>;
+  // Same allowlist rebuild as scrubEvent: drops headers, url, query_string and
+  // the request body in one move rather than denying known-bad header names.
+  mutableEvent.request =
+    typeof mutableEvent.request?.method === 'string'
+      ? { method: mutableEvent.request.method }
+      : undefined;
+  delete mutableEvent.extra;
+  delete mutableEvent.breadcrumbs;
+  const trace = mutableEvent.contexts?.trace;
+  mutableEvent.contexts = trace ? { trace } : undefined;
+  mutableEvent.tags = pickAllowedTags(mutableEvent.tags);
+  mutableEvent.user =
+    typeof mutableEvent.user?.id === 'string' &&
+    isBoundedTagValue(mutableEvent.user.id)
+      ? { id: mutableEvent.user.id }
+      : undefined;
+  return event;
+}
+
 function parseSampleRate(raw: string | undefined): number {
   if (!raw) return 0;
   const parsed = Number(raw);
@@ -232,7 +278,8 @@ export function initSentry(): void {
     release: API_VERSION,
     tracesSampleRate,
     profilesSampleRate: parseSampleRate(process.env.SENTRY_PROFILES_SAMPLE_RATE),
-    beforeSend: (event) => scrubEvent(event)
+    beforeSend: (event) => scrubEvent(event),
+    beforeSendTransaction: (event) => scrubTransactionEvent(event)
   });
 
   initialized = true;


### PR DESCRIPTION
Closes #3077 — though not where the issue expected, so the reasoning is worth a read before merging. Full trace is in [my comment on the issue](https://github.com/LanternOps/breeze/issues/3077#issuecomment-5170387635).

## The filed case no longer reproduces

The scrubber quoted in #3077 (`sentry.ts:24-30`, the `authorization`/`cookie` header loop, and the `extra` scrubber with the `brz_` prefix check) was removed by #2843 (`a50769487`) on 2026-07-27. `scrubEvent` now rebuilds the surface from an allowlist rather than denying known-bad names — `request` becomes `{ method }` and `extra` is deleted outright. Adding `x-api-key` to a header allowlist would have been a no-op against code that no longer exists.

## But the credential does leave, on the transaction path

`Sentry.init` set `beforeSend` only, and `@sentry/core` dispatches the two hooks by event type (`client.js:735-793`):

```js
if (isErrorEvent(processedEvent) && beforeSend) return beforeSend(processedEvent, hint);
if (isTransactionEvent(processedEvent)) { ... if (beforeSendTransaction) return beforeSendTransaction(processedEvent, hint); }
```

There was no `beforeSendTransaction` in the repo, so `scrubEvent` ran on exactly half the outbound traffic.

Transaction events carry the headers all the same. `requestDataIntegration()` is a default node integration (`@sentry/node-core` `getDefaultIntegrations`), its `processEvent` fires on every event type, and `extractNormalizedRequestData` copies the header bag verbatim:

```js
const headers = { ...normalizedRequest.headers };
if (include.headers) { requestData.headers = headers; ... }
```

`include.headers` resolves to `dataCollection.httpHeaders.request !== false`; with `sendDefaultPii` unset that value is an object (`{ deny: PII_HEADER_SNIPPETS }`), so it is truthy. The SDK's `SENSITIVE_KEY_SNIPPETS` deny list — which does contain `key` and would have caught `x-api-key` — is applied only on the span-attribute path via `httpHeadersToSpanAttributes`, never to the event body.

Net: every sampled request on an API-key route shipped a live `brz_` / `brz_sp_` credential, plus the full url, query string and request body. **No error required** — that is worse than the case as filed, which needed an unhandled 500. And `.env.example:614` ships `SENTRY_TRACES_SAMPLE_RATE=0.1`, so sampling is on for anyone who copied it (compose defaults to `0`, so this bites `.env.example` users specifically).

## The change

`scrubTransactionEvent` applies the same allowlist rebuild as `scrubEvent`: `request` reduced to `{ method }`, `extra` and `breadcrumbs` dropped, tags picked from `ALLOWED_TAG_NAMES`, `user` narrowed to a bounded id.

It deliberately is **not** `scrubEvent` itself. That one does `delete mutableEvent.contexts`, and a transaction event without `contexts.trace` is invalid — reusing it would have silently disabled tracing rather than secured it. So `contexts` is narrowed to `trace` alone, which also drops the `nodeContextIntegration` server metadata.

`event.spans[].data` is left alone: those attributes already pass through the SDK's `filterKeyValueData` + `SENSITIVE_KEY_SNIPPETS`, so header values arrive pre-redacted there.

Four tests alongside the existing `scrubEvent` harness: the api-key strip, the `contexts.trace` survival guard (the one that catches a future "just reuse scrubEvent" refactor), sparse-event safety, and a wiring assertion that `beforeSendTransaction` is actually passed to `Sentry.init` — the gap here was a missing hook, not a bad hook, so the wiring is the thing worth pinning.

## Operator note

This closes the path going forward only. Any deployment that has run with a nonzero `SENTRY_TRACES_SAMPLE_RATE` should treat retained **transaction** events, not just error events, as a place a live key may already be sitting — those keys want rotating. That is your "worth checking during the fix" point, and the transaction path makes it a larger set than the issue assumed.

## Local gate

Node 22.23.2, all green:

- `tsc --noEmit` — clean, exit 0
- `vitest run` in `apps/api` — **1240 files / 19504 tests passed, 0 failed** (5 files / 61 tests skipped)
- `eslint` on both changed files — clean

No dependency, lockfile, Go, or container surface touched, so the Trivy / govulncheck / audit inputs are unchanged from `main`.
