### PR TITLE
fix(api): evaluate pending partners in the billing abuse detectors

### DIFF
--- a/apps/api/src/__tests__/integration/abuseSignalsAggregates.integration.test.ts
+++ b/apps/api/src/__tests__/integration/abuseSignalsAggregates.integration.test.ts
@@ -1,6 +1,9 @@
 /**
- * Real-DB integration test for `loadPartnerAggregates()` (the abuse-signals
- * sweep's fleet-grouped aggregation query — apps/api/src/services/abuseSignals/heuristics.ts).
+ * Real-DB integration tests for the abuse-signals sweep's hand-written loader
+ * SQL: `loadPartnerAggregates()` (heuristics.ts) and
+ * `loadBillingIdentityAggregates()` (billingIdentity.ts). Both decide WHICH
+ * partners get evaluated at all, and the two answer that question differently
+ * on purpose — see the billing describe block.
  *
  * The heavy lifting here is a hand-written multi-CTE raw SQL query (org →
  * device joins, an org_id-NULL-attributed audit_logs branch for partner-admin
@@ -18,6 +21,11 @@ import { eq } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../../db';
 import { partners, devices, auditLogs, partnerAbuseSignals } from '../../db/schema';
 import { loadPartnerAggregates } from '../../services/abuseSignals/heuristics';
+import {
+  loadBillingIdentityAggregates,
+  computeBillingIdentitySignals,
+} from '../../services/abuseSignals/billingIdentity';
+import { loadSignalConfig } from '../../services/abuseSignals/config';
 import { createPartner, createOrganization, createSite, createUser } from './db-utils';
 import { getTestDb } from './setup';
 
@@ -163,5 +171,111 @@ describe('loadPartnerAggregates (real DB)', () => {
 
     expect(row).toBeDefined();
     expect(row!.deviceCount).toBe(0);
+  });
+
+  it('excludes a PENDING partner — RMM heuristics are device/session-shaped and structurally meaningless pre-activation', async () => {
+    const partner = await createPartner({ status: 'pending' });
+
+    const aggregates = await withSystemDbAccessContext(() => loadPartnerAggregates());
+
+    expect(aggregates.some((a) => a.partnerId === partner.id)).toBe(false);
+  });
+});
+
+/**
+ * Billing-identity scope. Unlike the RMM detectors above, this one evaluates
+ * 'pending' partners as well as 'active' ones: the partners.billing_* snapshot
+ * is written by payment-provider webhooks independently of the signup gate, and
+ * card testing is a PRE-activation act by construction — the attacker is trying
+ * cards precisely because they have not got in yet, so the partner never leaves
+ * 'pending'. An active-only scope made that shape permanently invisible.
+ */
+describe('loadBillingIdentityAggregates (real DB) — evaluated scope', () => {
+  const setBillingSnapshot = async (
+    partnerId: string,
+    values: Partial<typeof partners.$inferInsert>,
+  ) => {
+    await getTestDb().update(partners).set(values).where(eq(partners.id, partnerId));
+  };
+
+  it('evaluates a PENDING partner carrying billing evidence, and fires all three billing signals', async () => {
+    // Shape taken from a real US-prod account that accumulated 35 failed
+    // billing attempts across 4 declined cards in one afternoon and never
+    // produced a single signal, because it sat at status='pending' forever.
+    const pending = await createPartner({ status: 'pending', name: 'Admintecho Widgets' });
+    // A previously-suspended partner sharing the same card. It must stay in the
+    // fingerprint correlation corpus (corpus rule) while never being evaluated
+    // itself — that combination is the whole point of the shared-fingerprint
+    // signal, and it only pays off if the NEW (still pending) signup can be
+    // attributed.
+    const suspended = await createPartner({ status: 'suspended', name: 'Prior Shop' });
+
+    const now = new Date();
+    const fingerprint = `fp_${randomUUID().replace(/-/g, '')}`;
+    await setBillingSnapshot(pending.id, {
+      billingCardholderName: 'Yevgeny Unrelated',
+      billingCardFingerprint: fingerprint,
+      billingDistinctPaymentMethods: 4,
+      billingPaymentMethodsFirstSeenAt: new Date(now.getTime() - 11 * 60 * 1000),
+      billingPaymentMethodsLastSeenAt: new Date(now.getTime() - 2 * 60 * 1000),
+      billingFailedAttempts: 35,
+      billingIdentitySyncedAt: now,
+    });
+    await setBillingSnapshot(suspended.id, { billingCardFingerprint: fingerprint });
+
+    const result = await withSystemDbAccessContext(() => loadBillingIdentityAggregates());
+
+    const agg = result.aggregates.find((a) => a.partnerId === pending.id);
+    expect(agg).toBeDefined();
+    expect(agg!.distinctPaymentMethods).toBe(4);
+    expect(agg!.failedAttempts).toBe(35);
+    // Scanned => open rows for this partner can stale-resolve on evidence.
+    expect(result.scannedPartnerIds).toContain(pending.id);
+
+    // Scope was widened to 'pending', NOT to already-actioned statuses.
+    expect(result.aggregates.some((a) => a.partnerId === suspended.id)).toBe(false);
+    // ...but the suspended partner is still in the correlation corpus.
+    expect(result.sharedFingerprints.get(fingerprint)).toBe(2);
+
+    const signals = computeBillingIdentitySignals(
+      result.aggregates,
+      result.sharedFingerprints,
+      loadSignalConfig(),
+    ).filter((s) => s.partnerId === pending.id);
+
+    expect(signals.map((s) => s.signalKey).sort()).toEqual([
+      'billing.card_testing',
+      'billing.cardholder_name_mismatch',
+      'billing.shared_card_fingerprint',
+    ]);
+    expect(signals.every((s) => s.severity === 'alert')).toBe(true);
+  });
+
+  it('keeps a PENDING partner in scope once its billing snapshot is cleared but a billing.* row is still open, so the row resolves on evidence', async () => {
+    const pending = await createPartner({ status: 'pending', name: 'Cleared Snapshot Co' });
+
+    // Snapshot cleared by the billing service: none of the first three OR arms
+    // match, so only the open-signal EXISTS arm can keep this partner scoped.
+    await withSystemDbAccessContext(() =>
+      db.insert(partnerAbuseSignals).values({
+        partnerId: pending.id,
+        signalKey: 'billing.card_testing',
+        severity: 'alert',
+        score: 100,
+        evidence: {},
+      }),
+    );
+
+    const result = await withSystemDbAccessContext(() => loadBillingIdentityAggregates());
+
+    expect(result.scannedPartnerIds).toContain(pending.id);
+    // No evidence this sweep => no signal, and persistSignals will stale-resolve
+    // the open row because the partner is in evaluatedPartnerIds.
+    const signals = computeBillingIdentitySignals(
+      result.aggregates,
+      result.sharedFingerprints,
+      loadSignalConfig(),
+    ).filter((s) => s.partnerId === pending.id);
+    expect(signals).toEqual([]);
   });
 });

--- a/apps/api/src/services/abuseSignals/billingIdentity.ts
+++ b/apps/api/src/services/abuseSignals/billingIdentity.ts
@@ -24,7 +24,26 @@ import type { ComputedSignal } from './types';
 // Cross-tenant corpus rule (mirrors rmm.shared_installer_host): fingerprints
 // are correlated over ALL partners regardless of status — a suspended partner
 // must stay in the corpus or the re-signup it is correlated with goes unseen —
-// but signals are only attributed to active, non-deleted partners.
+// but signals are only attributed to non-deleted partners in the evaluated
+// scope.
+//
+// Evaluated scope is 'active' OR 'pending', unlike the RMM detectors, which are
+// active-only. Billing evidence is written by payment-provider webhooks and is
+// completely independent of the signup gate, so it accrues to accounts that
+// never activate: card testing is by definition a PRE-activation act — the
+// attacker is trying cards precisely because they have not got in yet, so the
+// partner sits at 'pending' forever and an active-only scope can never see it.
+// The same holds for the other two: a mismatched cardholder name on a partner
+// that never activated is the same evidence, and a shared fingerprint's most
+// valuable case is a suspended partner's card resurfacing on a NEW signup —
+// which is 'pending' at exactly the moment we need to attribute it. Excluding
+// pending would keep the old partner in the corpus while making the new one
+// unflaggable, defeating the corpus rule itself.
+//
+// Deliberately NOT widened to suspended/churned/offboarding/deleted: those are
+// already-actioned accounts (invariant.suspended_partner_active_subscription
+// covers the one billing condition that still matters for them), and attributing
+// fresh signals to them would re-open rows an operator has already dispositioned.
 //
 // Coverage caveat: wallet/Link-style payments expose no card fingerprint, so
 // billing_card_fingerprint is frequently NULL. NULL is "unknown" and can never
@@ -62,7 +81,7 @@ export interface BillingIdentityAggregate {
 }
 
 export interface BillingIdentityResult {
-  /** Aggregates for partners in the evaluated (active, non-deleted) scope only. */
+  /** Aggregates for partners in the evaluated (active-or-pending, non-deleted) scope only. */
   aggregates: BillingIdentityAggregate[];
   /** fingerprint -> distinct partner count (>= 2), computed over the FULL corpus. */
   sharedFingerprints: Map<string, number>;
@@ -420,14 +439,22 @@ export async function loadBillingIdentityAggregates(): Promise<BillingIdentityRe
         p.billing_failed_attempts,
         p.billing_identity_synced_at
       FROM partners p
-      WHERE p.deleted_at IS NULL AND p.status = 'active'
+      -- 'pending' is in scope here (and only here — the RMM detectors stay
+      -- active-only): billing evidence arrives from provider webhooks
+      -- independently of the signup gate, and card testing is a pre-activation
+      -- act by construction. See the header for the full rationale.
+      WHERE p.deleted_at IS NULL AND p.status IN ('active', 'pending')
         AND (
           p.billing_cardholder_name IS NOT NULL
           OR p.billing_card_fingerprint IS NOT NULL
           OR p.billing_distinct_payment_methods > 0
           -- Keep re-evaluating partners with an open billing signal even after
           -- the billing service clears the snapshot, so the row resolves on
-          -- evidence rather than being stranded open by scope exit.
+          -- evidence rather than being stranded open by scope exit. This arm
+          -- is what makes the pending->active transition non-thrashing: both
+          -- statuses are in scope, so a row opened while pending keeps being
+          -- re-scored (and stays open) after activation instead of resolving
+          -- and immediately re-firing.
           OR EXISTS (
             SELECT 1 FROM partner_abuse_signals pas
             WHERE pas.partner_id = p.id AND pas.resolved_at IS NULL


### PR DESCRIPTION
## The bug

`loadBillingIdentityAggregates()` builds its `scoped` CTE with
`WHERE p.deleted_at IS NULL AND p.status = 'active'`. A partner that never
activated therefore could never be attributed **any** billing signal —
`billing.card_testing`, `billing.cardholder_name_mismatch`, or
`billing.shared_card_fingerprint`.

Verified against live US prod (2026-08-03): a partner accumulated
`billing_failed_attempts = 35` across at least four distinct declined cards in a
single afternoon and produced **zero** signals. It has 0 devices, 0 scripts, 0
enrollment keys and never logged in — the only real exposure is provider-side
(Radar reputation, dispute risk), but the detector silence is the bug we can fix.

## Why `pending` belongs in the billing scope — all three signals

The RMM detectors are active-only for a good reason: they are shaped around
devices, sessions, commands and script executions, none of which a pending
partner can produce. The billing detectors are not like that. The
`partners.billing_*` snapshot is written exclusively by the separate billing
service from payment-provider webhooks, **completely independently of the signup
gate**. Evidence accrues to accounts that never activate.

- **`billing.card_testing`** — card testing is a *pre-activation act by
  construction*. The attacker is trying cards precisely because they have not
  got in yet. The partner is `pending` while the burst happens and, if the cards
  keep declining, it stays `pending` forever. An active-only scope means this
  signal can only ever fire for someone who already succeeded, which is the one
  case where it teaches least.
- **`billing.cardholder_name_mismatch`** — a cardholder name sharing no token
  with the account identity is the same evidence at any account status. Nothing
  about the scorer depends on activation, and the detector is already documented
  as never age-decayed for exactly this reason.
- **`billing.shared_card_fingerprint`** — this is the strongest case, and it
  cuts against leaving it out. The corpus query deliberately has *no* status
  filter so a suspended partner stays correlatable. But the whole payoff of that
  rule is catching the **re-signup** that reuses the card — and a re-signup is
  `pending` at exactly the moment we need to attribute it. Keeping the old
  partner in the corpus while making the new one unflaggable defeats the corpus
  rule itself.

**Nothing structurally impossible is being flagged.** All three signals read only
`partners.billing_*` columns; none touches devices, orgs, scripts, or sessions.
That is the test that separates this from the RMM detectors, where widening
scope really would flag a partner for something it cannot do.

**Not widened to `suspended` / `churned` / `offboarding` / soft-deleted.** Those
are already-actioned accounts; attributing fresh billing signals to them would
re-open rows an operator has already dispositioned, and the one billing condition
that still matters for them is already covered by
`invariant.suspended_partner_active_subscription`. The existing "attribute only
to non-deleted partners in the evaluated scope" rule remains the safety boundary.

## What changed

- `apps/api/src/services/abuseSignals/billingIdentity.ts:442` — `scoped` CTE
  `p.status = 'active'` → `p.status IN ('active', 'pending')`, plus header and
  inline rationale.
- **The fingerprint correlation corpus query (first query in the function) is
  untouched** — it still has no status filter at all, on purpose.

## Stale-resolve coherence

`scannedPartnerIds` is derived from `aggregates`, and `runAbuseSweep` folds it
into `evaluatedPartnerIds`, which is what lets `persistSignals` auto-resolve open
rows. Widening the scope makes pending partners *eligible* for stale resolution
rather than stranding their rows open — a strict improvement.

The `EXISTS (... partner_abuse_signals ... resolved_at IS NULL ... signal_key
LIKE 'billing.%')` arm keeps its original intent and gains one: because both
`pending` and `active` are now in scope, a row opened while pending keeps being
re-scored across the pending→active transition instead of falling out of scope,
resolving, and immediately re-firing. There is no new thrash path. A partner that
fires while pending and is later suspended leaves scope and its row is left open
rather than resolved — identical to today's behaviour for any partner leaving
scope, and deliberate (resolving on scope exit is not resolving on evidence).

## Sibling detectors — audited, only the billing one was wrong

| Detector | Scope today | Correct? | Changed |
|---|---|---|---|
| `heuristics.ts` (`loadPartnerAggregates`, L39) | `deleted_at IS NULL AND status = 'active'` | Yes for 7 of 8 signals — all are device/session/command/script-volume shaped and structurally impossible pre-activation. `invariant.inactive_partner_with_agents` already covers the "pending partner somehow has devices" case at score 100. | No (added a regression test pinning the exclusion) |
| `scriptContent.ts` (`inScope`, L519) | `partner_status === 'active' && !partner_deleted` | Yes. Scripts and script executions require an authenticated session a pending partner does not have. Host extraction and the shared-host corpus already run over **all** partners regardless of status, so the correlation value is preserved. | No |
| `invariants.ts` | Explicitly non-active: `status IN ('pending','suspended')` for `inactive_partner_with_agents`, `status <> 'active'` for `suspended_partner_active_subscription`; the two `status = 'active'` queries are checking activation invariants, where `'active'` *is* the predicate. | Yes — already correct in both directions | No |
| `index.ts` (sweep) / `runAbuseDigest` | No partner-status filter of its own; digest counts new partners with `deleted_at IS NULL` only | Yes — scope is owned by each loader, and the digest deliberately counts all new signups | No |

### One arguable secondary gap, deliberately not changed here

`fraud.failed_login_cluster` lives in `heuristics.ts` and *can* attribute to a
pending partner: the `logins` CTE joins `audit_logs.actor_id → users.id` and
reads `u.partner_id`, so credential-stuffing against a pending partner's admin
user is representable. It is currently unreachable because the `scoped` CTE is
active-only. I left it alone: it is outside this fix's remit, the prod case that
motivated this PR had zero login activity, and unlike the billing family it has
no evidence behind it yet. Worth a separate issue rather than a speculative
widening bundled into a billing fix.

## Tests

`apps/api/src/__tests__/integration/abuseSignalsAggregates.integration.test.ts`
(real Postgres — the loader is hand-written multi-CTE SQL that the mocked unit
tests cannot exercise):

- **`evaluates a PENDING partner carrying billing evidence, and fires all three
  billing signals`** — reproduces the prod shape (pending, 35 failed attempts, 4
  distinct payment methods 9 minutes apart, unrelated cardholder name), plus a
  `suspended` partner sharing the same fingerprint. Asserts the pending partner
  is in `aggregates` and `scannedPartnerIds`, the suspended partner is **not** in
  `aggregates` but **is** still in `sharedFingerprints` (count 2), and that all
  three signals fire at `alert`.
- **`keeps a PENDING partner in scope once its billing snapshot is cleared but a
  billing.* row is still open`** — pins the stale-resolve `EXISTS` arm for the
  pending case.
- **`excludes a PENDING partner`** on `loadPartnerAggregates` — pins the RMM
  detectors' active-only scope so a future sweeping edit cannot quietly widen it.

Both new billing tests fail on the pre-fix query
(`expected undefined to be defined`, `expected [] to include <id>`) and pass
after.

### Results

- `vitest run src/services/abuseSignals` — **8 files, 125 tests passed**
- `pnpm --filter @breeze/api test` (full API unit suite) — **1240 files passed /
  5 skipped, 19500 tests passed / 61 skipped**
- `vitest run --config vitest.integration.config.ts
  src/__tests__/integration/abuseSignalsAggregates.integration.test.ts` —
  **5 passed** (2 of them red before the fix)
- `tsc --noEmit -p apps/api/tsconfig.json` — clean (Node 22.23.2,
  `--max-old-space-size=8192`)

### Contract suites

No new table, no new column, no migration — this is a query-scope change to one
existing `SELECT`. The RLS coverage, tenant-cascade, and tenant-export-policy
contract suites are unaffected and were **not** run. Stating that explicitly
rather than implying they passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
