### PR TITLE
fix(ai): give the vision/desktop tools at least the agent round-trip budget (#3091)

### DIFF
--- a/apps/api/src/services/aiToolsRemote.timeout.test.ts
+++ b/apps/api/src/services/aiToolsRemote.timeout.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #3096 review finding: the PR raised the vision-tool budget in toolTimeouts.ts,
+// but take_screenshot / analyze_screen / computer_control called executeCommand
+// with a hardcoded `timeoutMs: 30000` — the raised budget never reached
+// commandQueue's single-shot waitForCommandResult, so analyze_screen still died
+// at ~30s regardless of what getToolTimeout() returned. This suite asserts the
+// two never drift apart again: whatever toolTimeouts.ts says for a given tool is
+// exactly what reaches executeCommand's `timeoutMs` option.
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn: any) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: { select: vi.fn() },
+}));
+
+vi.mock('./commandQueue', () => ({
+  executeCommand: vi.fn(async () => ({
+    status: 'completed',
+    stdout: JSON.stringify({ imageBase64: 'AA==' }),
+  })),
+}));
+
+import { db } from '../db';
+import { executeCommand } from './commandQueue';
+import { registerRemoteTools } from './aiToolsRemote';
+import { getToolTimeout } from './toolTimeouts';
+import type { AuthContext } from '../middleware/auth';
+import type { AiTool } from './aiTools';
+
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+
+function createQueryChain(rows: any[]) {
+  const chain: any = {};
+  chain.from = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.limit = vi.fn(() => Promise.resolve(rows));
+  return chain;
+}
+
+function handlerFor(name: string): AiTool['handler'] {
+  const reg = new Map<string, AiTool>();
+  registerRemoteTools(reg);
+  return reg.get(name)!.handler;
+}
+
+function makeAuth(): AuthContext {
+  return {
+    principal: { kind: 'user_session' },
+    user: { id: 'user-1', email: 'a@b.c', name: 'A', isPlatformAdmin: false },
+    token: {} as any,
+    partnerId: null,
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    orgCondition: () => undefined,
+    canAccessOrg: () => true,
+    allowedSiteIds: undefined,
+    canAccessSite: () => true,
+  } as AuthContext;
+}
+
+const mockDb = db as unknown as { select: ReturnType<typeof vi.fn> };
+const mockExecuteCommand = executeCommand as unknown as ReturnType<typeof vi.fn>;
+
+describe('aiToolsRemote — timeoutMs threads through to executeCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.select.mockImplementation(() =>
+      createQueryChain([
+        { id: DEVICE_ID, status: 'online', siteId: null, hostname: 'host-1', orgId: 'org-1' },
+      ])
+    );
+    mockExecuteCommand.mockResolvedValue({
+      status: 'completed',
+      stdout: JSON.stringify({ imageBase64: 'AA==' }),
+    });
+  });
+
+  it('take_screenshot passes getToolTimeout("take_screenshot"), not a hardcoded 30s', async () => {
+    await handlerFor('take_screenshot')({ deviceId: DEVICE_ID }, makeAuth());
+    expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
+    const [, , , options] = mockExecuteCommand.mock.calls[0]!;
+    expect(options.timeoutMs).toBe(getToolTimeout('take_screenshot'));
+  });
+
+  it('analyze_screen passes getToolTimeout("analyze_screen"), not a hardcoded 30s', async () => {
+    await handlerFor('analyze_screen')({ deviceId: DEVICE_ID }, makeAuth());
+    expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
+    const [, , , options] = mockExecuteCommand.mock.calls[0]!;
+    expect(options.timeoutMs).toBe(getToolTimeout('analyze_screen'));
+  });
+
+  it('computer_control passes getToolTimeout("computer_control"), not a hardcoded 30s', async () => {
+    await handlerFor('computer_control')({ deviceId: DEVICE_ID, action: 'screenshot' }, makeAuth());
+    expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
+    const [, , , options] = mockExecuteCommand.mock.calls[0]!;
+    expect(options.timeoutMs).toBe(getToolTimeout('computer_control'));
+  });
+
+  it('all three vision/desktop tools get at least the agent round-trip budget end to end', async () => {
+    // Guards the whole chain, not just the constant table: the value that
+    // ACTUALLY reaches executeCommand must be >= execute_command's budget,
+    // matching the invariant asserted in toolTimeouts.test.ts against the
+    // source-of-truth table alone.
+    const agentRoundTrip = getToolTimeout('execute_command');
+    for (const [tool, input] of [
+      ['take_screenshot', { deviceId: DEVICE_ID }],
+      ['analyze_screen', { deviceId: DEVICE_ID }],
+      ['computer_control', { deviceId: DEVICE_ID, action: 'screenshot' }],
+    ] as const) {
+      mockExecuteCommand.mockClear();
+      await handlerFor(tool)(input, makeAuth());
+      const [, , , options] = mockExecuteCommand.mock.calls[0]!;
+      expect(options.timeoutMs, `${tool} timeoutMs`).toBeGreaterThanOrEqual(agentRoundTrip);
+    }
+  });
+});

--- a/apps/api/src/services/aiToolsRemote.ts
+++ b/apps/api/src/services/aiToolsRemote.ts
@@ -20,6 +20,7 @@ import { eq, and, desc, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { resolveSiteAllowedDeviceIds, SITE_SCOPE_EMPTY_NOTE } from './aiToolsSiteScope';
+import { getToolTimeout } from './toolTimeouts';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -80,7 +81,7 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
       const { executeCommand } = await getCommandQueue();
       const result = await executeCommand(deviceId, 'take_screenshot', {
         monitor: input.monitor ?? 0
-      }, { userId: auth.user.id, timeoutMs: 30000 });
+      }, { userId: auth.user.id, timeoutMs: getToolTimeout('take_screenshot') });
 
       if (result.status !== 'completed') {
         return JSON.stringify({ error: result.error || 'Screenshot capture failed' });
@@ -138,7 +139,7 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
       const { executeCommand } = await getCommandQueue();
       const result = await executeCommand(deviceId, 'take_screenshot', {
         monitor: input.monitor ?? 0
-      }, { userId: auth.user.id, timeoutMs: 30000 });
+      }, { userId: auth.user.id, timeoutMs: getToolTimeout('analyze_screen') });
 
       if (result.status !== 'completed') {
         return JSON.stringify({ error: result.error || 'Screenshot capture failed' });
@@ -224,7 +225,7 @@ export function registerRemoteTools(aiTools: Map<string, AiTool>): void {
         monitor: input.monitor ?? 0,
         captureAfter: input.captureAfter ?? true,
         captureDelayMs: input.captureDelayMs ?? 500,
-      }, { userId: auth.user.id, timeoutMs: 30000 });
+      }, { userId: auth.user.id, timeoutMs: getToolTimeout('computer_control') });
 
       if (result.status !== 'completed') {
         return JSON.stringify({ error: result.error || 'Computer action failed' });

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -35,7 +35,37 @@ const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h hard limit
 const EVICTION_INTERVAL_MS = 60 * 1000; // Check every 60s
 const MAX_ACTIVE_SESSIONS = 200;
 const EVENT_RING_BUFFER_SIZE = 100;
-const SDK_TURN_TIMEOUT_MS = 6 * 60 * 1000; // 6 min per-turn timeout (accounts for tool approval waits up to 5 min)
+/**
+ * 6 min per-turn timeout. Sized to accept a single approval wait
+ * (`waitForApproval`, aiAgentSdk.ts, 300_000ms = 5 min) plus headroom for
+ * execution — but the two are NOT bounded to fit together, and this handler
+ * does not reach into the pending call to stop it.
+ *
+ * #3096 review (raising the vision-tool budget in toolTimeouts.ts to 120s):
+ * approval-wait fully resolves BEFORE `withToolTimeout` starts
+ * (aiAgentSdkTools.ts onPreToolUse vs. the executeTool wrapper), so the two
+ * budgets stack rather than overlap. Worst case for a tier-3 vision/desktop
+ * tool call is now approval wait (up to 5 min) + execution (up to 120s) =
+ * up to 7 min — past this 6-min ceiling.
+ *
+ * When that happens today, `startTurnTimeout`'s callback (below) publishes
+ * `error` + `done` and sets `state = 'idle'`, but does NOT abort
+ * `session.abortController` or otherwise unblock the in-flight
+ * `waitForApproval` poll — only `remove()` does that. `runBackgroundProcessor`'s
+ * `for await` loop only stops on `state === 'closing' | 'closed'`, so once the
+ * approval/tool call eventually settles, its SDK messages (tool_result,
+ * closing assistant text, `result`) still get processed and published into a
+ * turn the client was already told had ended.
+ *
+ * This is a known gap, not a new one from #3091/#3096 — the same overlap
+ * already existed for two stacked ordinary approval waits before the vision
+ * budget was ever raised. It has a proper fix in progress: PR #3104 (Closes
+ * #3089) introduces a shared per-cycle `APPROVAL_WAIT_BUDGET_MS` that resets
+ * at the same `message_start` point as this timeout, so cumulative approval
+ * blocking is bounded to fit inside the turn window. That PR is not merged as
+ * of this comment — do not assume the overlap is handled until it lands.
+ */
+const SDK_TURN_TIMEOUT_MS = 6 * 60 * 1000;
 const MCP_PREFIX = 'mcp__breeze__';
 // Use the directly-imported runOutsideDbContext (see commandQueue.ts for explanation).
 const runOutsideDbContextSafe = runOutsideDbContext;

--- a/apps/api/src/services/toolTimeouts.test.ts
+++ b/apps/api/src/services/toolTimeouts.test.ts
@@ -3,7 +3,7 @@ import { getToolTimeout, withToolTimeout } from './toolTimeouts';
 
 describe('getToolTimeout', () => {
   it('returns the override for a known slow tool', () => {
-    expect(getToolTimeout('take_screenshot')).toBe(30_000);
+    expect(getToolTimeout('take_screenshot')).toBe(120_000);
   });
   it('returns the override for command execution tools', () => {
     expect(getToolTimeout('execute_command')).toBe(120_000);
@@ -24,9 +24,34 @@ describe('getToolTimeout', () => {
     expect(getToolTimeout('network_discovery')).toBe(120_000);
   });
   it('returns the override for desktop/vision tools', () => {
-    expect(getToolTimeout('take_screenshot')).toBe(30_000);
-    expect(getToolTimeout('analyze_screen')).toBe(30_000);
-    expect(getToolTimeout('computer_control')).toBe(30_000);
+    expect(getToolTimeout('take_screenshot')).toBe(120_000);
+    expect(getToolTimeout('analyze_screen')).toBe(120_000);
+    expect(getToolTimeout('computer_control')).toBe(120_000);
+  });
+
+  // #3091: analyze_screen timed out at 30s on prod. The table had drifted into
+  // giving the three slowest tools the SHORTEST budget in it — shorter even than
+  // the default an unlisted tool gets. Assert the invariant, not just the three
+  // numbers, so a future override can't silently reintroduce the same shape.
+  it('never gives a listed tool less time than the unlisted default', () => {
+    const defaultTimeout = getToolTimeout('some_unknown_tool');
+    for (const toolName of [
+      'execute_command', 'run_script', 'analyze_disk_usage', 'disk_cleanup',
+      'security_scan', 'apply_cis_remediation', 'manage_patches',
+      'network_discovery', 'take_screenshot', 'analyze_screen',
+      'computer_control', 'generate_report',
+    ]) {
+      expect.soft(getToolTimeout(toolName)).toBeGreaterThanOrEqual(defaultTimeout);
+    }
+  });
+
+  it('gives the vision tools at least the agent round-trip budget', () => {
+    // They do everything execute_command does (agent round-trip) and then
+    // WebRTC negotiation, capture, and a vision pass on top.
+    const agentRoundTrip = getToolTimeout('execute_command');
+    expect(getToolTimeout('take_screenshot')).toBeGreaterThanOrEqual(agentRoundTrip);
+    expect(getToolTimeout('analyze_screen')).toBeGreaterThanOrEqual(agentRoundTrip);
+    expect(getToolTimeout('computer_control')).toBeGreaterThanOrEqual(agentRoundTrip);
   });
   it('returns the override for report generation', () => {
     expect(getToolTimeout('generate_report')).toBe(90_000);

--- a/apps/api/src/services/toolTimeouts.ts
+++ b/apps/api/src/services/toolTimeouts.ts
@@ -24,10 +24,21 @@ const TOOL_TIMEOUT_OVERRIDES: Record<string, number> = {
   manage_patches: 180_000,
   // Network discovery — port scanning is slow
   network_discovery: 120_000,
-  // Desktop / vision — WebRTC setup + capture
-  take_screenshot: 30_000,
-  analyze_screen: 30_000,
-  computer_control: 30_000,
+  // Desktop / vision — WebRTC negotiation + capture + (for analyze_screen) a
+  // model vision pass. #3091: these were 30_000, the only three entries in this
+  // table that LOWERED the budget below the 60s default — so the slowest tools
+  // here got less time than an unlisted one. `analyze_screen` duly timed out on
+  // prod at 30s while ordinary `execute_command` round-trips to the same device
+  // in the same window were taking 40s to 6min. They do an agent round-trip like
+  // `execute_command` and then more, so they get at least its budget.
+  //
+  // The timeout covers execution only: `withToolTimeout` wraps the `executeTool`
+  // call in `aiAgentSdkTools.ts`, and approval resolution happens earlier in the
+  // handler — so approval latency never ate into the 30s, and raising this is a
+  // real increase in execution budget rather than a wider window for waiting.
+  take_screenshot: 120_000,
+  analyze_screen: 120_000,
+  computer_control: 120_000,
   // Report generation — aggregates across many devices
   generate_report: 90_000,
 };


### PR DESCRIPTION
Closes #3091.

## What was wrong

`take_screenshot`, `analyze_screen` and `computer_control` sat at `30_000` in `TOOL_TIMEOUT_OVERRIDES` — and they were **the only three entries in the table that lowered the budget below the 60s default**. Every other override raises it (`execute_command` 120s, `manage_patches` 180s, disk ops 90s). So the three slowest tools in the system had the tightest budget in the file, tighter than an unlisted tool gets for free.

That is what bit prod on 2026-08-03: `Tool execution timed out after 30000ms: analyze_screen`, while ordinary `execute_command` round-trips to the same device in the same window were taking 40s to 6min.

All three do an agent round-trip exactly like `execute_command`, and then more on top — screen capture (reusing an already-active capturer) and, for `analyze_screen`, a model vision pass. (Earlier revisions of this description also cited WebRTC negotiation here — that was wrong. `take_screenshot`/`computer_action` reuse an existing `desktop.ScreenCapturer` and never touch the WebRTC/ICE path; the 5s ICE-gather timeout belongs exclusively to `start_desktop` Remote Desktop streaming sessions, agent/internal/remote/desktop/session.go:22.) They now get `execute_command`'s 120s.

## Update: the original fix was largely inert — closing the gap

A follow-up review found the first version of this PR only raised the number in `toolTimeouts.ts`; it never reached the code path that actually enforces the timeout, so `analyze_screen` would still have died at ~30s in production. Root cause: `aiToolsRemote.ts` called `executeCommand(...)` for all three tools with a **second, hardcoded** `timeoutMs: 30000`, which flows straight into `commandQueue.ts`'s single-shot `waitForCommandResult` — the 120s raised in `toolTimeouts.ts` only ever bounded the *outer* `withToolTimeout` wrapper around the whole tool handler (`aiAgentSdkTools.ts`), not the inner command wait that actually returns first.

Fixed by importing `getToolTimeout` from `toolTimeouts.ts` (the single source of truth already used by the outer wrapper) into `aiToolsRemote.ts` and using it for the `timeoutMs` passed to `executeCommand` at all three call sites (`take_screenshot`, `analyze_screen`, `computer_control`) — no second constant. Added `aiToolsRemote.timeout.test.ts`, which mocks `commandQueue.executeCommand` and asserts the `timeoutMs` it actually receives equals `getToolTimeout(<toolName>)` for each of the three tools, plus an end-to-end invariant test tying that to `execute_command`'s budget. No prior test anywhere asserted this consistency — the two numbers were free to drift, and they had.

## Known gap (documented, not fixed here): turn-timeout interaction

With the vision-tool budget now real at 120s, worst case for one of these tools is a 5-minute approval wait (`waitForApproval`, `aiAgentSdk.ts`) followed by up to 120s of execution — up to ~7 minutes, past the 6-minute `SDK_TURN_TIMEOUT_MS` in `streamingSessionManager.ts`. Approval-wait resolution happens entirely before `withToolTimeout` starts, so the two budgets stack rather than overlap; this is real, not theoretical.

Checked whether the turn-timeout handler already settles a still-pending approval/tool wait cleanly before publishing `error` + `done` to the client. As implemented on `main` today, it does **not**: `startTurnTimeout`'s callback only publishes the terminal events and sets `state = 'idle'` — it does not abort `session.abortController` or otherwise unblock the in-flight wait (only `remove()` does that). `runBackgroundProcessor`'s loop only stops on `state === 'closing' | 'closed'`, so if the approval/tool call eventually settles, its later SDK messages still get published into a turn the client was already told had ended. This is a pre-existing gap (the same overlap already existed for two stacked ordinary approval waits before this PR), not something this PR introduces or worsens in kind — but raising the vision-tool budget does make the single-tool worst case newly reachable.

The proper fix is already in flight as a separate PR: **#3104** (for issue #3089) adds a shared per-cycle `APPROVAL_WAIT_BUDGET_MS` that resets at the same `message_start` point as the turn timeout, bounding cumulative approval wait to fit inside the turn window. Per this PR's scope, the budget structure isn't being touched here — the math and the current (unclean) behavior are documented in a comment at the `SDK_TURN_TIMEOUT_MS` definition in `streamingSessionManager.ts` instead, flagged for prioritization alongside #3104.

## Known gap (not fixed here, agent-side): service/headless mode has its own ~30s ceiling

Independently of everything above, in service/headless mode the Go agent routes `take_screenshot`/`computer_action` through the user-helper IPC channel with a 15s timeout × 2 attempts ≈ 30s ceiling (`agent/internal/heartbeat/handlers_screenshot.go:60`). That's a separate ceiling *beneath* the API-side one fixed here, and it hits exactly the fleet-managed-service deployment mode this timeout was raised for. This PR does not touch Go code. Filing a follow-up issue for the agent-side ceiling; full resolution for service-mode agents needs that agent-side fix too.

## Tests

The obvious test here is "assert the three new numbers", which would pass and teach nothing. The interesting property is the shape the table had drifted into, so the tests assert that instead:

- **no listed tool may get less than the unlisted default** — the invariant that was violated
- **the vision tools get at least the agent round-trip budget** — tied to `execute_command` rather than hardcoded, so they track it if it moves
- **the timeout that reaches `executeCommand` matches `getToolTimeout()`** — new, closes the gap that made the original fix inert

A future override cannot silently reintroduce the same shape, and the timeout can't silently stop reaching the command wait again either.

## Local gate

Node 22.23.2:

- `tsc --noEmit` (apps/api, `NODE_OPTIONS=--max-old-space-size=8192` — default heap OOMs on this checkout) — clean, exit 0
- `eslint` on all changed files — clean
- `vitest run` targeted: `aiToolsRemote.timeout.test.ts`, `aiToolsRemote.test.ts`, `aiToolsRemote.siteScope.test.ts`, `toolTimeouts.test.ts` — **29/29 passed**

No dependency, lockfile, Go, or container surface touched.

## Not addressed here

The other eight issues from that session review are left alone deliberately. #3093 (2KB truncation) and #3095 (zero token counters) need the investigation you flagged rather than a guess; #3087 (device-bound org scoping) is a tenancy-shaped correctness fix that wants design review, not a quick patch; #3088/#3089 are policy and streaming-architecture calls that are yours to make (#3089 is now in flight as #3104). Happy to take any of them if you want to point me at one.

