### PR TITLE
fix(ai): record SDK session usage for partner-scoped users + fallback token accumulation (#3095)

### DIFF
--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -20,7 +20,7 @@ import { eq, and } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiStreamEvent, AiApprovalMode } from '@breeze/shared/types/ai';
 import { AsyncEventQueue } from '../utils/asyncQueue';
-import { recordUsageFromSdkResult } from './aiCostTracker';
+import { recordUsageFromSdkResult, calculateCostCents } from './aiCostTracker';
 import { sanitizeErrorForClient } from './aiAgent';
 import { captureException } from './sentry';
 import { createBreezeMcpServer, BREEZE_MCP_TOOL_NAMES } from './aiAgentSdkTools';
@@ -928,23 +928,52 @@ export class StreamingSessionManager {
       if (hasTokens(session.pendingTurnUsage)) {
         const abandoned = session.pendingTurnUsage;
         session.pendingTurnUsage = emptyPendingTurnUsage();
-        withDbAccessContext(
-          { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
-          () => recordUsageFromSdkResult(session.breezeSessionId, session.orgId, {
-            total_cost_usd: 0,
-            usage: {
-              input_tokens: abandoned.inputTokens,
-              output_tokens: abandoned.outputTokens,
-              cache_read_input_tokens: abandoned.cacheReadInputTokens,
-              cache_creation_input_tokens: abandoned.cacheCreationInputTokens,
-            },
-            num_turns: 1,
-            model: session.model,
-          })
-        ).catch((err) => {
+        // Awaited (not fire-and-forget): the most common abandoned-turn trigger
+        // is process shutdown (deploy/SIGTERM), where an untracked promise can
+        // be killed before it settles — silently, since even the .catch would
+        // never run. Awaiting ties the write into processorPromise so it can
+        // be drained; failures are logged, never re-credited (the underlying
+        // writes are non-idempotent += increments, retry would double-count).
+        try {
+          await withDbAccessContext(
+            { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+            () => recordUsageFromSdkResult(session.breezeSessionId, session.orgId, {
+              total_cost_usd: 0,
+              usage: {
+                input_tokens: abandoned.inputTokens,
+                output_tokens: abandoned.outputTokens,
+                cache_read_input_tokens: abandoned.cacheReadInputTokens,
+                cache_creation_input_tokens: abandoned.cacheCreationInputTokens,
+              },
+              num_turns: 1,
+              model: session.model,
+            })
+          );
+        } catch (err) {
           captureException(err);
           console.error('[StreamingSessionManager] Failed to record abandoned-turn usage:', err);
-        });
+        }
+        // Mirror the result path's per-user hook (AI for Office): without this,
+        // abandoned-turn spend would reach the org ledger but never the
+        // client_ai_usage buckets that back per-user caps and invoicing.
+        if (session.recordExtraUsage) {
+          try {
+            await session.recordExtraUsage({
+              inputTokens: abandoned.inputTokens,
+              outputTokens: abandoned.outputTokens,
+              costCents: calculateCostCents(
+                session.model,
+                abandoned.inputTokens,
+                abandoned.outputTokens,
+                abandoned.cacheReadInputTokens,
+                abandoned.cacheCreationInputTokens
+              ),
+            });
+          } catch (err) {
+            captureException(err);
+            console.error('[StreamingSessionManager] recordExtraUsage failed for abandoned turn:', err);
+          }
+        }
       }
 
       // Always clean up the session from the map after the processor exits

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -229,6 +229,22 @@ export class SessionEventBus {
 
 export type SessionState = 'initializing' | 'ready' | 'processing' | 'idle' | 'closing' | 'closed';
 
+/** Token usage accumulated across the model API calls of a single turn. */
+export interface PendingTurnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+}
+
+function emptyPendingTurnUsage(): PendingTurnUsage {
+  return { inputTokens: 0, outputTokens: 0, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 };
+}
+
+function hasTokens(u: PendingTurnUsage): boolean {
+  return u.inputTokens > 0 || u.outputTokens > 0 || u.cacheReadInputTokens > 0 || u.cacheCreationInputTokens > 0;
+}
+
 /** Immutable audit snapshot extracted from the HTTP request context */
 export interface AuditSnapshot {
   ip: string | undefined;
@@ -265,6 +281,14 @@ export interface ActiveSession {
   mcpPrefix: string;
   /** FIFO queue of toolUseIds from content_block_start for postToolUse correlation */
   toolUseIdQueue: string[];
+  /**
+   * Per-turn usage accumulated from the SDK's `assistant` messages (one per
+   * underlying model API call). Used as the fallback token source when the
+   * `result` message arrives with missing/zero usage (#3095), and flushed if a
+   * turn is abandoned without ever producing a `result` (teardown, crash).
+   * Reset after every flush.
+   */
+  pendingTurnUsage: PendingTurnUsage;
   /** Promise that resolves when background processor finishes */
   readonly processorPromise: Promise<void>;
   /** Timer for per-turn timeout; cleared when 'result' arrives */
@@ -409,6 +433,7 @@ export class StreamingSessionManager {
       mcpServer: null as unknown as McpSdkServerConfigWithInstance, // set below
       mcpPrefix: MCP_PREFIX, // updated below if custom factory
       toolUseIdQueue: [],
+      pendingTurnUsage: emptyPendingTurnUsage(),
       processorPromise: Promise.resolve(),
       turnTimeoutId: null,
       approvalMode,
@@ -671,6 +696,24 @@ export class StreamingSessionManager {
           }
 
           case 'assistant': {
+            // Accumulate per-API-call usage as the fallback token source for
+            // this turn's cost recording (#3095). Each SDK assistant message
+            // wraps one model API response whose `usage` is authoritative for
+            // that call; the turn's `result` message *should* aggregate these,
+            // but has been observed arriving with missing/zero usage.
+            const apiUsage = message.message.usage as {
+              input_tokens?: number;
+              output_tokens?: number;
+              cache_read_input_tokens?: number | null;
+              cache_creation_input_tokens?: number | null;
+            } | undefined;
+            if (apiUsage) {
+              session.pendingTurnUsage.inputTokens += apiUsage.input_tokens ?? 0;
+              session.pendingTurnUsage.outputTokens += apiUsage.output_tokens ?? 0;
+              session.pendingTurnUsage.cacheReadInputTokens += apiUsage.cache_read_input_tokens ?? 0;
+              session.pendingTurnUsage.cacheCreationInputTokens += apiUsage.cache_creation_input_tokens ?? 0;
+            }
+
             const assistantContent = message.message.content
               .filter((b: { type: string }) => b.type === 'text')
               .map((b: { type: string; text?: string }) => b.text ?? '')
@@ -743,7 +786,12 @@ export class StreamingSessionManager {
             this.clearTurnTimeout(session);
 
             const resultMsg = message as SDKResultMessage;
-            const orgId = session.auth.orgId;
+            // #3095: use the session's canonical org id (from the aiSessions DB
+            // row — always set), NOT `auth.orgId`, which is null for partner-
+            // and system-scoped users. The old guard on `auth.orgId` silently
+            // skipped usage recording for EVERY turn of every session run by a
+            // partner-scoped technician, leaving ai_sessions token counters at 0.
+            const orgId = session.orgId;
 
             if (!orgId) {
               console.warn('[StreamingSessionManager] Skipping usage recording — no orgId on session', session.breezeSessionId);
@@ -753,30 +801,48 @@ export class StreamingSessionManager {
             }
 
             // Extract usage with defensive checks — SDK types say usage is non-nullable
-            // but in practice it may be missing, leaving sessions with 0 tokens
+            // but in practice it may be missing/zero. Fall back to the usage
+            // accumulated from this turn's assistant messages (#3095).
+            const sdkUsage = resultMsg.usage as {
+              input_tokens?: number;
+              output_tokens?: number;
+              cache_read_input_tokens?: number | null;
+              cache_creation_input_tokens?: number | null;
+            } | undefined;
+            const sdkReported: PendingTurnUsage = {
+              inputTokens: sdkUsage?.input_tokens ?? 0,
+              outputTokens: sdkUsage?.output_tokens ?? 0,
+              // Cache tokens are billed separately (read ~0.1x input, write ~1.25x
+              // input). Capture them so the token-based fallback doesn't undercount
+              // cost on cached requests when the SDK reports $0.
+              cacheReadInputTokens: sdkUsage?.cache_read_input_tokens ?? 0,
+              cacheCreationInputTokens: sdkUsage?.cache_creation_input_tokens ?? 0,
+            };
+            const effectiveUsage = hasTokens(sdkReported) ? sdkReported : session.pendingTurnUsage;
+            // Consumed (or superseded by the SDK's own numbers) — reset for the next turn.
+            session.pendingTurnUsage = emptyPendingTurnUsage();
+
             const usageData = {
               total_cost_usd: resultMsg.total_cost_usd ?? 0,
               usage: {
-                input_tokens: resultMsg.usage?.input_tokens ?? 0,
-                output_tokens: resultMsg.usage?.output_tokens ?? 0,
-                // Cache tokens are billed separately (read ~0.1x input, write ~1.25x
-                // input). Capture them so the token-based fallback doesn't undercount
-                // cost on cached requests when the SDK reports $0.
-                cache_read_input_tokens: resultMsg.usage?.cache_read_input_tokens ?? 0,
-                cache_creation_input_tokens: resultMsg.usage?.cache_creation_input_tokens ?? 0,
+                input_tokens: effectiveUsage.inputTokens,
+                output_tokens: effectiveUsage.outputTokens,
+                cache_read_input_tokens: effectiveUsage.cacheReadInputTokens,
+                cache_creation_input_tokens: effectiveUsage.cacheCreationInputTokens,
               },
               num_turns: resultMsg.num_turns ?? 0,
               // Model id for token-based cost fallback when the SDK reports $0.
               model: session.model,
             };
 
-            if (!resultMsg.usage || (!resultMsg.usage.input_tokens && !resultMsg.usage.output_tokens)) {
-              console.warn('[StreamingSessionManager] Result message has no/empty usage:', {
+            if (!hasTokens(sdkReported)) {
+              console.warn('[StreamingSessionManager] Result message has no/empty usage — using accumulated assistant-message usage:', {
                 sessionId: session.breezeSessionId,
                 subtype: resultMsg.subtype,
                 hasUsage: !!resultMsg.usage,
                 totalCostUsd: resultMsg.total_cost_usd,
-                keys: Object.keys(resultMsg),
+                fallbackInputTokens: effectiveUsage.inputTokens,
+                fallbackOutputTokens: effectiveUsage.outputTokens,
               });
             }
 
@@ -854,6 +920,33 @@ export class StreamingSessionManager {
       session.eventBus.publish({ type: 'error', message: sanitizeErrorForClient(err) });
       session.eventBus.publish({ type: 'done' });
     } finally {
+      // Flush usage from a turn that never produced a `result` message
+      // (teardown mid-turn, subprocess crash, iterator error) so the tokens
+      // already spent on model API calls still land in the session counters
+      // and org cost aggregates (#3095). Zero after a normal turn — the
+      // accumulator is reset when each `result` is recorded.
+      if (hasTokens(session.pendingTurnUsage)) {
+        const abandoned = session.pendingTurnUsage;
+        session.pendingTurnUsage = emptyPendingTurnUsage();
+        withDbAccessContext(
+          { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+          () => recordUsageFromSdkResult(session.breezeSessionId, session.orgId, {
+            total_cost_usd: 0,
+            usage: {
+              input_tokens: abandoned.inputTokens,
+              output_tokens: abandoned.outputTokens,
+              cache_read_input_tokens: abandoned.cacheReadInputTokens,
+              cache_creation_input_tokens: abandoned.cacheCreationInputTokens,
+            },
+            num_turns: 1,
+            model: session.model,
+          })
+        ).catch((err) => {
+          captureException(err);
+          console.error('[StreamingSessionManager] Failed to record abandoned-turn usage:', err);
+        });
+      }
+
       // Always clean up the session from the map after the processor exits
       this.clearTurnTimeout(session);
       if (this.sessions.has(session.breezeSessionId)) {

--- a/apps/api/src/services/streamingSessionManager.usage.test.ts
+++ b/apps/api/src/services/streamingSessionManager.usage.test.ts
@@ -1,0 +1,221 @@
+/**
+ * #3095 — ai_sessions token counters recorded 0 for real sessions.
+ *
+ * Root cause: the background processor's `result` handler read
+ * `session.auth.orgId`, which is null for partner- and system-scoped users,
+ * and silently skipped usage recording for every turn of their sessions.
+ * These tests pin the fix (use the canonical `session.orgId` from the DB row)
+ * plus the fallback accumulation of per-API-call assistant usage for turns
+ * whose `result` arrives with missing/zero usage, and the flush for turns
+ * abandoned without a `result`.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+
+const { queryMock, recordUsageMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  recordUsageMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+    insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })),
+  },
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('./aiCostTracker', () => ({ recordUsageFromSdkResult: recordUsageMock }));
+vi.mock('./aiAgent', () => ({ sanitizeErrorForClient: (e: unknown) => String(e) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('./aiAgentSdkTools', () => ({
+  createBreezeMcpServer: vi.fn(() => ({ type: 'sdk' })),
+  BREEZE_MCP_TOOL_NAMES: ['mcp__breeze__query_devices'],
+}));
+vi.mock('./aiAgentSdk', () => ({
+  createSessionPreToolUse: vi.fn(() => vi.fn()),
+  createSessionPostToolUse: vi.fn(() => vi.fn()),
+}));
+vi.mock('./aiToolOutput', () => ({
+  redactAiToolOutputText: (s: string) => s,
+  redactSensitiveToolInput: (i: unknown) => i,
+}));
+vi.mock('./clientIp', () => ({ getTrustedClientIpOrUndefined: () => undefined }));
+
+import { StreamingSessionManager } from './streamingSessionManager';
+import type { AuthContext } from '../middleware/auth';
+
+const ORG = '0c0c0c0c-1111-4222-8333-444455556666';
+
+const DB_SESSION = {
+  orgId: ORG,
+  sdkSessionId: null,
+  model: 'claude-sonnet-4-5-20250929',
+  maxTurns: 50,
+  turnCount: 0,
+  systemPrompt: null,
+};
+
+/** Partner-scoped technician: orgId is null on the auth context (the #3095 trigger). */
+const PARTNER_AUTH = {
+  orgId: null,
+  partnerId: 'aaaaaaaa-1111-4222-8333-444455556666',
+  scope: 'partner',
+  accessibleOrgIds: [ORG],
+  user: { id: 'beefbeef-1111-4222-8333-444455556666', email: 'tech@msp.example.com' },
+} as unknown as AuthContext;
+
+function assistantMsg(usage: Record<string, number>, text = 'hello') {
+  return {
+    type: 'assistant',
+    message: { content: [{ type: 'text', text }], usage },
+  };
+}
+
+function resultMsg(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'result',
+    subtype: 'success',
+    total_cost_usd: 0,
+    usage: { input_tokens: 0, output_tokens: 0 },
+    num_turns: 1,
+    ...overrides,
+  };
+}
+
+function mockSdkQuery(messages: unknown[]) {
+  queryMock.mockImplementation(() => ({
+    async *[Symbol.asyncIterator]() {
+      yield* messages as never[];
+    },
+    interrupt: vi.fn(),
+    close: vi.fn(),
+  }));
+}
+
+let manager: StreamingSessionManager;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  manager = new StreamingSessionManager();
+});
+
+afterEach(() => {
+  manager.shutdown();
+});
+
+async function runSession(sessionId: string, messages: unknown[]) {
+  mockSdkQuery(messages);
+  const session = await manager.getOrCreate(sessionId, DB_SESSION, PARTNER_AUTH, undefined, 'PROMPT', undefined);
+  await session.processorPromise;
+  return session;
+}
+
+describe('result usage recording — partner-scoped sessions (#3095)', () => {
+  it('records non-zero usage using the canonical session orgId even when auth.orgId is null', async () => {
+    await runSession('sess-partner', [
+      resultMsg({ total_cost_usd: 0.03, usage: { input_tokens: 100, output_tokens: 50 } }),
+    ]);
+
+    expect(recordUsageMock).toHaveBeenCalledTimes(1);
+    expect(recordUsageMock).toHaveBeenCalledWith('sess-partner', ORG, expect.objectContaining({
+      total_cost_usd: 0.03,
+      usage: expect.objectContaining({ input_tokens: 100, output_tokens: 50 }),
+    }));
+  });
+
+  it('records usage on error-subtype results too (turns that die on tool errors)', async () => {
+    await runSession('sess-err', [
+      {
+        ...resultMsg({ usage: { input_tokens: 70, output_tokens: 20 } }),
+        subtype: 'error_during_execution',
+        errors: ['tool blew up'],
+      },
+    ]);
+
+    expect(recordUsageMock).toHaveBeenCalledTimes(1);
+    expect(recordUsageMock).toHaveBeenCalledWith('sess-err', ORG, expect.objectContaining({
+      usage: expect.objectContaining({ input_tokens: 70, output_tokens: 20 }),
+    }));
+  });
+});
+
+describe('fallback accumulation from assistant messages', () => {
+  it('sums per-API-call assistant usage when the result usage is empty', async () => {
+    await runSession('sess-fallback', [
+      assistantMsg({ input_tokens: 1200, output_tokens: 80, cache_read_input_tokens: 300 }),
+      assistantMsg({ input_tokens: 1500, output_tokens: 40, cache_creation_input_tokens: 200 }),
+      resultMsg(), // zero usage from the SDK
+    ]);
+
+    expect(recordUsageMock).toHaveBeenCalledTimes(1);
+    expect(recordUsageMock).toHaveBeenCalledWith('sess-fallback', ORG, expect.objectContaining({
+      usage: {
+        input_tokens: 2700,
+        output_tokens: 120,
+        cache_read_input_tokens: 300,
+        cache_creation_input_tokens: 200,
+      },
+    }));
+  });
+
+  it('prefers SDK-reported result usage over the accumulator when present', async () => {
+    await runSession('sess-sdk-wins', [
+      assistantMsg({ input_tokens: 999, output_tokens: 999 }),
+      resultMsg({ usage: { input_tokens: 100, output_tokens: 50 } }),
+    ]);
+
+    expect(recordUsageMock).toHaveBeenCalledWith('sess-sdk-wins', ORG, expect.objectContaining({
+      usage: expect.objectContaining({ input_tokens: 100, output_tokens: 50 }),
+    }));
+  });
+
+  it('resets the accumulator between turns (multi-turn sessions)', async () => {
+    await runSession('sess-multiturn', [
+      assistantMsg({ input_tokens: 100, output_tokens: 10 }),
+      resultMsg(),
+      assistantMsg({ input_tokens: 40, output_tokens: 5 }),
+      resultMsg(),
+    ]);
+
+    expect(recordUsageMock).toHaveBeenCalledTimes(2);
+    expect(recordUsageMock).toHaveBeenNthCalledWith(1, 'sess-multiturn', ORG, expect.objectContaining({
+      usage: expect.objectContaining({ input_tokens: 100, output_tokens: 10 }),
+    }));
+    expect(recordUsageMock).toHaveBeenNthCalledWith(2, 'sess-multiturn', ORG, expect.objectContaining({
+      usage: expect.objectContaining({ input_tokens: 40, output_tokens: 5 }),
+    }));
+  });
+
+  it('flushes accumulated usage when the turn ends without a result message', async () => {
+    await runSession('sess-abandoned', [
+      assistantMsg({ input_tokens: 500, output_tokens: 60 }),
+      // no result — subprocess died / stream closed mid-turn
+    ]);
+
+    expect(recordUsageMock).toHaveBeenCalledTimes(1);
+    expect(recordUsageMock).toHaveBeenCalledWith('sess-abandoned', ORG, expect.objectContaining({
+      usage: expect.objectContaining({ input_tokens: 500, output_tokens: 60 }),
+      num_turns: 1,
+    }));
+  });
+
+  it('does not double-record when a completed turn is followed by teardown', async () => {
+    await runSession('sess-clean', [
+      assistantMsg({ input_tokens: 100, output_tokens: 10 }),
+      resultMsg({ usage: { input_tokens: 100, output_tokens: 10 } }),
+    ]);
+
+    // Only the result-driven record; the finally-flush sees an empty accumulator.
+    expect(recordUsageMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/services/streamingSessionManager.usage.test.ts
+++ b/apps/api/src/services/streamingSessionManager.usage.test.ts
@@ -11,9 +11,10 @@
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 
-const { queryMock, recordUsageMock } = vi.hoisted(() => ({
+const { queryMock, recordUsageMock, calculateCostCentsMock } = vi.hoisted(() => ({
   queryMock: vi.fn(),
   recordUsageMock: vi.fn(() => Promise.resolve()),
+  calculateCostCentsMock: vi.fn(() => 42),
 }));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
@@ -34,7 +35,10 @@ vi.mock('../db', () => ({
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
 }));
 
-vi.mock('./aiCostTracker', () => ({ recordUsageFromSdkResult: recordUsageMock }));
+vi.mock('./aiCostTracker', () => ({
+  recordUsageFromSdkResult: recordUsageMock,
+  calculateCostCents: calculateCostCentsMock,
+}));
 vi.mock('./aiAgent', () => ({ sanitizeErrorForClient: (e: unknown) => String(e) }));
 vi.mock('./sentry', () => ({ captureException: vi.fn() }));
 vi.mock('./aiAgentSdkTools', () => ({
@@ -52,6 +56,7 @@ vi.mock('./aiToolOutput', () => ({
 vi.mock('./clientIp', () => ({ getTrustedClientIpOrUndefined: () => undefined }));
 
 import { StreamingSessionManager } from './streamingSessionManager';
+import { withDbAccessContext } from '../db';
 import type { AuthContext } from '../middleware/auth';
 
 const ORG = '0c0c0c0c-1111-4222-8333-444455556666';
@@ -92,9 +97,10 @@ function resultMsg(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function mockSdkQuery(messages: unknown[]) {
+function mockSdkQuery(messages: unknown[], gate: Promise<void> = Promise.resolve()) {
   queryMock.mockImplementation(() => ({
     async *[Symbol.asyncIterator]() {
+      await gate;
       yield* messages as never[];
     },
     interrupt: vi.fn(),
@@ -131,6 +137,11 @@ describe('result usage recording — partner-scoped sessions (#3095)', () => {
       total_cost_usd: 0.03,
       usage: expect.objectContaining({ input_tokens: 100, output_tokens: 50 }),
     }));
+    // The RLS db-access context must also be built from the DB-row org, not auth.orgId (null).
+    expect(vi.mocked(withDbAccessContext)).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: 'organization', orgId: ORG }),
+      expect.any(Function),
+    );
   });
 
   it('records usage on error-subtype results too (turns that die on tool errors)', async () => {
@@ -207,6 +218,26 @@ describe('fallback accumulation from assistant messages', () => {
       usage: expect.objectContaining({ input_tokens: 500, output_tokens: 60 }),
       num_turns: 1,
     }));
+  });
+
+  it('feeds abandoned-turn usage to the per-user recordExtraUsage hook (client sessions)', async () => {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((r) => (releaseGate = r));
+    mockSdkQuery([assistantMsg({ input_tokens: 500, output_tokens: 60 })], gate);
+
+    const session = await manager.getOrCreate('sess-abandoned-extra', DB_SESSION, PARTNER_AUTH, undefined, 'PROMPT', undefined);
+    const recordExtraUsage = vi.fn(() => Promise.resolve());
+    session.recordExtraUsage = recordExtraUsage;
+
+    releaseGate();
+    await session.processorPromise;
+
+    // Org ledger and per-user ledger both get the abandoned turn's tokens.
+    expect(recordUsageMock).toHaveBeenCalledWith('sess-abandoned-extra', ORG, expect.objectContaining({
+      usage: expect.objectContaining({ input_tokens: 500, output_tokens: 60 }),
+    }));
+    expect(recordExtraUsage).toHaveBeenCalledWith({ inputTokens: 500, outputTokens: 60, costCents: 42 });
+    expect(calculateCostCentsMock).toHaveBeenCalledWith('claude-sonnet-4-5-20250929', 500, 60, 0, 0);
   });
 
   it('does not double-record when a completed turn is followed by teardown', async () => {


### PR DESCRIPTION
## Root cause

All-zero `ai_sessions` token counters on the SDK path were caused by the streaming processor's `result` handler reading `session.auth.orgId`:

```ts
const orgId = session.auth.orgId;
if (!orgId) {
  console.warn('... Skipping usage recording — no orgId on session', ...);
```

`AuthContext.orgId` is `string | null` and is **null for partner- and system-scoped users** — i.e. every MSP technician. So every turn of every session they ran hit the skip branch and recorded nothing, healthy or not. The `ActiveSession.orgId` field's own doc comment already said to use it (not `auth.orgId`) in background callbacks; the result handler was the one place that didn't.

## Changes (`apps/api/src/services/streamingSessionManager.ts`)

- **Use the canonical `session.orgId`** (captured from the `ai_sessions` row at creation, always set) in the result handler for both the guard and `recordUsageFromSdkResult`.
- **Fallback token accumulation**: per-API-call usage from SDK `assistant` messages is accumulated into a per-turn accumulator; when the `result` message arrives with missing/zero usage (already observed in practice — the code carried a defensive warn for it), the accumulated tokens are recorded instead. SDK-reported result usage still wins when non-zero.
- **Abandoned-turn flush**: if the processor exits without a `result` (teardown mid-turn, subprocess crash), non-zero accumulated usage is flushed to `recordUsageFromSdkResult` so spent tokens still reach the session counters and org cost aggregates.
- Accumulator resets on every flush, so multi-turn sessions never double-count; the existing `recordUsageFromSdkResult` `+=` semantics cover multi-turn totals.

## Tests

New `streamingSessionManager.usage.test.ts` (mocked SDK `query`, mocked cost tracker):

- partner-scoped auth (`orgId: null`) session records non-zero input/output tokens against the DB-row org — direct #3095 regression
- error-subtype results (turns dying on tool errors) still record usage
- empty result usage falls back to summed assistant-message usage incl. cache tokens
- SDK result usage preferred when present
- accumulator resets between turns (multi-turn)
- turn without a `result` flushes accumulated usage exactly once
- completed turn + teardown does not double-record

`vitest run` on the three streamingSessionManager suites: 20 passed. `tsc --noEmit` clean.

Closes #3095

🤖 Generated with [Claude Code](https://claude.com/claude-code)