### PR TITLE
fix(ai): stop the chat turn from blocking on the slowest pending approval (#3089)

### DIFF
--- a/apps/api/src/routes/ai-flagging.test.ts
+++ b/apps/api/src/routes/ai-flagging.test.ts
@@ -105,6 +105,7 @@ vi.mock('../services/streamingSessionManager', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
   abortActivePlan: vi.fn(),
 }));
 

--- a/apps/api/src/routes/ai.m365session.test.ts
+++ b/apps/api/src/routes/ai.m365session.test.ts
@@ -91,6 +91,7 @@ vi.mock('../services/streamingSessionManager', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
   abortActivePlan: vi.fn(),
 }));
 

--- a/apps/api/src/routes/ai.ticket.test.ts
+++ b/apps/api/src/routes/ai.ticket.test.ts
@@ -169,6 +169,7 @@ vi.mock('../services/streamingSessionManager', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
   abortActivePlan: vi.fn(),
 }));
 

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -23,7 +23,7 @@ import {
   resolveDefaultModel,
   sanitizeErrorForClient,
 } from '../services/aiAgent';
-import { runPreFlightChecks, abortActivePlan } from '../services/aiAgentSdk';
+import { runPreFlightChecks, abortActivePlan, settleApprovalWaits, waitForTurnToSettle } from '../services/aiAgentSdk';
 import { sanitizeThrownToolError } from '../services/aiToolErrors';
 import { streamingSessionManager } from '../services/streamingSessionManager';
 import { getUsageSummary, updateBudget, getSessionHistory, recordUsage } from '../services/aiCostTracker';
@@ -53,6 +53,11 @@ import { draftTicketFromTranscript, ThinTranscriptError } from '../services/aiTi
 import { createTicketFromChatSchema, type AiTicketDraft } from '@breeze/shared';
 import { deviceInSiteScope } from './tickets/siteScope';
 import { timeActorFrom } from './timeEntries/timeEntries';
+
+// How long a new message will wait for a turn that was blocked on approvals
+// to conclude after settleApprovalWaits() (#3089) — covers the model emitting
+// its closing message. Past this, fall back to the pre-existing 409.
+const TURN_SETTLE_WAIT_MS = 15_000;
 
 // Provider check that tolerates an unvalidated config: route unit tests never
 // call validateConfig(), and getConfig() throws in that state. Without a
@@ -626,7 +631,20 @@ aiRoutes.post(
 
     // Concurrent message guard — atomic check-and-set
     if (!streamingSessionManager.tryTransitionToProcessing(activeSession)) {
-      return c.json({ error: 'A message is already being processed for this session' }, 409);
+      // #3089: when the in-flight turn is blocked ONLY on pending tool
+      // approvals, the assistant used to go mute — the user's message bounced
+      // with a 409 while the model sat waiting up to 5 minutes per approval.
+      // Settle those waits instead: the blocked tool calls return promptly
+      // with an approval-pending result (tier-3 intents stay pending and are
+      // executed by the durable release worker once decided), the model
+      // concludes the turn, and this message then proceeds normally. If the
+      // session is busy for any other reason (model actively working), or the
+      // turn doesn't conclude in time, fall back to the 409 as before.
+      const settled = settleApprovalWaits(activeSession);
+      const turnConcluded = settled && await waitForTurnToSettle(activeSession, TURN_SETTLE_WAIT_MS);
+      if (!turnConcluded || !streamingSessionManager.tryTransitionToProcessing(activeSession)) {
+        return c.json({ error: 'A message is already being processed for this session' }, 409);
+      }
     }
 
     writeRouteAudit(c, {

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -23,7 +23,7 @@ import {
   resolveDefaultModel,
   sanitizeErrorForClient,
 } from '../services/aiAgent';
-import { runPreFlightChecks, abortActivePlan, settleApprovalWaits, waitForTurnToSettle } from '../services/aiAgentSdk';
+import { runPreFlightChecks, abortActivePlan, settleBlockedTurnForNewMessage } from '../services/aiAgentSdk';
 import { sanitizeThrownToolError } from '../services/aiToolErrors';
 import { streamingSessionManager } from '../services/streamingSessionManager';
 import { getUsageSummary, updateBudget, getSessionHistory, recordUsage } from '../services/aiCostTracker';
@@ -53,11 +53,6 @@ import { draftTicketFromTranscript, ThinTranscriptError } from '../services/aiTi
 import { createTicketFromChatSchema, type AiTicketDraft } from '@breeze/shared';
 import { deviceInSiteScope } from './tickets/siteScope';
 import { timeActorFrom } from './timeEntries/timeEntries';
-
-// How long a new message will wait for a turn that was blocked on approvals
-// to conclude after settleApprovalWaits() (#3089) — covers the model emitting
-// its closing message. Past this, fall back to the pre-existing 409.
-const TURN_SETTLE_WAIT_MS = 15_000;
 
 // Provider check that tolerates an unvalidated config: route unit tests never
 // call validateConfig(), and getConfig() throws in that state. Without a
@@ -639,11 +634,14 @@ aiRoutes.post(
       // executed by the durable release worker once decided), the model
       // concludes the turn, and this message then proceeds normally. If the
       // session is busy for any other reason (model actively working), or the
-      // turn doesn't conclude in time, fall back to the 409 as before.
-      const settled = settleApprovalWaits(activeSession);
-      const turnConcluded = settled && await waitForTurnToSettle(activeSession, TURN_SETTLE_WAIT_MS);
-      if (!turnConcluded || !streamingSessionManager.tryTransitionToProcessing(activeSession)) {
-        return c.json({ error: 'A message is already being processed for this session' }, 409);
+      // turn doesn't conclude in time, fall back to a 409 as before.
+      const settle = await settleBlockedTurnForNewMessage(activeSession);
+      if (settle !== 'concluded' || !streamingSessionManager.tryTransitionToProcessing(activeSession)) {
+        return c.json({
+          error: settle === 'not_blocked_on_approvals'
+            ? 'A message is already being processed for this session'
+            : 'The assistant is wrapping up the previous turn — please try again in a moment',
+        }, 409);
       }
     }
 

--- a/apps/api/src/routes/ai_admin.test.ts
+++ b/apps/api/src/routes/ai_admin.test.ts
@@ -111,6 +111,7 @@ vi.mock('../services/streamingSessionManager', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
   abortActivePlan: vi.fn(),
 }));
 

--- a/apps/api/src/routes/ai_admin_sessions_permission.test.ts
+++ b/apps/api/src/routes/ai_admin_sessions_permission.test.ts
@@ -68,6 +68,7 @@ vi.mock('../services/streamingSessionManager', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
   abortActivePlan: vi.fn(),
 }));
 

--- a/apps/api/src/routes/ai_plans.test.ts
+++ b/apps/api/src/routes/ai_plans.test.ts
@@ -105,6 +105,7 @@ vi.mock('../services/streamingSessionManager', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
   abortActivePlan: vi.fn(),
 }));
 

--- a/apps/api/src/routes/ai_sessions_actions.test.ts
+++ b/apps/api/src/routes/ai_sessions_actions.test.ts
@@ -106,6 +106,7 @@ vi.mock('../services/streamingSessionManager', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
   abortActivePlan: vi.fn(),
 }));
 
@@ -131,7 +132,7 @@ import {
 } from '../services/aiAgent';
 import { getUsageSummary, updateBudget, getSessionHistory } from '../services/aiCostTracker';
 import { streamingSessionManager } from '../services/streamingSessionManager';
-import { runPreFlightChecks, abortActivePlan } from '../services/aiAgentSdk';
+import { runPreFlightChecks, abortActivePlan, settleBlockedTurnForNewMessage } from '../services/aiAgentSdk';
 
 const ORG_ID = 'org-111';
 const SESSION_ID = '11111111-1111-1111-1111-111111111111';
@@ -239,6 +240,105 @@ describe('AI routes', () => {
       });
 
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ============================================
+  // POST /sessions/:id/messages — concurrent-message guard settle path (#3089)
+  // ============================================
+  describe('POST /ai/sessions/:id/messages — approval-blocked turn settling', () => {
+    function mockPreflightOk() {
+      vi.mocked(runPreFlightChecks).mockResolvedValue({
+        ok: true,
+        session: {
+          id: SESSION_ID,
+          orgId: ORG_ID,
+          sdkSessionId: null,
+          model: 'claude-sonnet-4-5-20250929',
+          maxTurns: 50,
+          turnCount: 0,
+          systemPrompt: 'sp',
+          title: 'existing title',
+        },
+        sanitizedContent: 'hello there',
+        systemPrompt: 'sp',
+        maxBudgetUsd: undefined,
+      } as any);
+    }
+
+    function makeActiveSession() {
+      return {
+        breezeSessionId: SESSION_ID,
+        orgId: ORG_ID,
+        state: 'processing',
+        inputController: { pushMessage: vi.fn() },
+        eventBus: {
+          subscribe: vi.fn(() => (async function* () {
+            yield { type: 'done' };
+          })()),
+          unsubscribe: vi.fn(),
+          publish: vi.fn(),
+        },
+      } as any;
+    }
+
+    function postMessage() {
+      return app.request(`/ai/sessions/${SESSION_ID}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ content: 'hello there' }),
+      });
+    }
+
+    it('409s untouched when the session is busy for a non-approval reason', async () => {
+      mockPreflightOk();
+      vi.mocked(streamingSessionManager.getOrCreate).mockResolvedValue(makeActiveSession());
+      vi.mocked(streamingSessionManager.tryTransitionToProcessing).mockReturnValue(false);
+      vi.mocked(settleBlockedTurnForNewMessage).mockResolvedValue('not_blocked_on_approvals');
+
+      const res = await postMessage();
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe('A message is already being processed for this session');
+      // The message was never queued into the turn.
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('proceeds with the message when the blocked turn settles and concludes', async () => {
+      mockPreflightOk();
+      const activeSession = makeActiveSession();
+      vi.mocked(streamingSessionManager.getOrCreate).mockResolvedValue(activeSession);
+      // Busy on first check; free after the settled turn concluded.
+      vi.mocked(streamingSessionManager.tryTransitionToProcessing)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+      vi.mocked(settleBlockedTurnForNewMessage).mockResolvedValue('concluded');
+      vi.mocked(db.insert).mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) } as any);
+
+      const res = await postMessage();
+
+      expect(res.status).toBe(200);
+      await res.text(); // drain the SSE stream (generator yields done and ends)
+      expect(settleBlockedTurnForNewMessage).toHaveBeenCalledWith(activeSession);
+      expect(activeSession.inputController.pushMessage).toHaveBeenCalledWith('hello there');
+      expect(streamingSessionManager.startTurnTimeout).toHaveBeenCalledWith(activeSession);
+    });
+
+    it('409s with a wrapping-up message when the settled turn does not conclude in time', async () => {
+      mockPreflightOk();
+      vi.mocked(streamingSessionManager.getOrCreate).mockResolvedValue(makeActiveSession());
+      vi.mocked(streamingSessionManager.tryTransitionToProcessing).mockReturnValue(false);
+      vi.mocked(settleBlockedTurnForNewMessage).mockResolvedValue('still_processing');
+
+      const res = await postMessage();
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toMatch(/wrapping up the previous turn/);
+      // Short-circuit: no second transition attempt once settling failed.
+      expect(vi.mocked(streamingSessionManager.tryTransitionToProcessing)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/routes/ai_sessions_crud.test.ts
+++ b/apps/api/src/routes/ai_sessions_crud.test.ts
@@ -105,6 +105,7 @@ vi.mock('../services/streamingSessionManager', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
   abortActivePlan: vi.fn(),
 }));
 

--- a/apps/api/src/routes/approvals.test.ts
+++ b/apps/api/src/routes/approvals.test.ts
@@ -589,7 +589,10 @@ describe('POST /approvals/:id/approve', () => {
         where: vi.fn().mockResolvedValue([{ ...linkedRow, status: 'pending' }]),
       }),
     } as any);
-    const aiSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const aiReturning = vi.fn().mockResolvedValue([{ id: 'exec-42' }]);
+    const aiSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: aiReturning }),
+    });
     const approvalReturning = vi.fn().mockResolvedValue([linkedRow]);
     const approvalSet = vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({ returning: approvalReturning }),
@@ -604,6 +607,42 @@ describe('POST /approvals/:id/approve', () => {
     expect(aiSet).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'approved', approvedBy: TEST_USER.id }),
     );
+  });
+
+  it('logs a lost-race warning (not an error) when the ai_tool_executions mirror CAS matches zero rows, and still returns 200 (#3089 review finding)', async () => {
+    // The execution row was already closed out (settled/timed out) between
+    // the approval_requests CAS and this mirror — status='pending' guard
+    // correctly refuses to resurrect it. approval_requests is still the
+    // source of truth and correctly recorded THIS decision, so the decide
+    // call must still succeed; only the mirror silently lost the race.
+    const linkedRow = { ...updatedRow, executionId: 'exec-42' };
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ ...linkedRow, status: 'pending' }]),
+      }),
+    } as any);
+    const aiReturning = vi.fn().mockResolvedValue([]);
+    const aiSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: aiReturning }),
+    });
+    const approvalReturning = vi.fn().mockResolvedValue([linkedRow]);
+    const approvalSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: approvalReturning }),
+    });
+    vi.mocked(db.update)
+      .mockReturnValueOnce({ set: approvalSet } as any)
+      .mockReturnValueOnce({ set: aiSet } as any);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const res = await buildApp().request('/approvals/a1/approve', { method: 'POST' });
+
+    expect(res.status).toBe(200);
+    expect(aiReturning).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ai_tool_executions mirror lost the race'),
+      'exec-42',
+    );
+    warnSpy.mockRestore();
   });
 });
 
@@ -1040,7 +1079,10 @@ describe('POST /approvals/:id/deny', () => {
         where: vi.fn().mockResolvedValue([{ ...deniedRow, status: 'pending' }]),
       }),
     } as any);
-    const aiSet = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const aiReturning = vi.fn().mockResolvedValue([{ id: 'exec-77' }]);
+    const aiSet = vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ returning: aiReturning }),
+    });
     const approvalReturning = vi.fn().mockResolvedValue([deniedRow]);
     const approvalSet = vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({ returning: approvalReturning }),

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -714,7 +714,7 @@ async function decideHandler(
   if (updated?.executionId) {
     const aiStatus = status === 'approved' ? 'approved' : 'rejected';
     try {
-      await db
+      const mirrored = await db
         .update(aiToolExecutions)
         .set({ status: aiStatus, approvedBy: userId, approvedAt: new Date() })
         // Guarded on 'pending' (#3089): a settled approval wait marks the
@@ -726,7 +726,19 @@ async function decideHandler(
         .where(and(
           eq(aiToolExecutions.id, updated.executionId),
           eq(aiToolExecutions.status, 'pending'),
-        ));
+        ))
+        .returning({ id: aiToolExecutions.id });
+      if (mirrored.length === 0) {
+        // Lost the race, not a query failure: the execution row was already
+        // closed out (settled/timed out) between the approval_requests CAS
+        // above and this mirror — same first-wins posture as the elevation
+        // and intent mirrors below. approval_requests is still the source of
+        // truth for the mobile UI and correctly records this approver's
+        // decision, but the underlying tool call is already gone and will
+        // NOT run despite the 'approved' response below — worth a distinct
+        // log line so this isn't mistaken for the mirror simply failing.
+        console.warn('[approvals] ai_tool_executions mirror lost the race (execution already settled):', updated.executionId);
+      }
     } catch (err) {
       console.error('[approvals] Failed to mirror status to ai_tool_executions:', err);
       // Non-fatal: the approval_request row is the source of truth for the

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -717,7 +717,16 @@ async function decideHandler(
       await db
         .update(aiToolExecutions)
         .set({ status: aiStatus, approvedBy: userId, approvedAt: new Date() })
-        .where(eq(aiToolExecutions.id, updated.executionId));
+        // Guarded on 'pending' (#3089): a settled approval wait marks the
+        // execution row 'rejected' without touching this approval_requests
+        // row first in every failure mode (the two writes aren't atomic), so
+        // a decide that squeaked past the approval_requests CAS must not
+        // resurrect a closed execution row as a stranded 'approved' that the
+        // legacy bridge (no durable worker) would never run.
+        .where(and(
+          eq(aiToolExecutions.id, updated.executionId),
+          eq(aiToolExecutions.status, 'pending'),
+        ));
     } catch (err) {
       console.error('[approvals] Failed to mirror status to ai_tool_executions:', err);
       // Non-fatal: the approval_request row is the source of truth for the

--- a/apps/api/src/routes/clientAi/sessions.create.test.ts
+++ b/apps/api/src/routes/clientAi/sessions.create.test.ts
@@ -45,6 +45,10 @@ const {
   applyDlpMock: vi.fn(),
 }));
 
+vi.mock('../../services/aiAgentSdk', () => ({
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
+}));
+
 vi.mock('../../middleware/clientAiAuth', () => ({
   clientAiAuthMiddleware: (c: any, next: any) => {
     if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/api/src/routes/clientAi/sessions.events-toolresults.test.ts
+++ b/apps/api/src/routes/clientAi/sessions.events-toolresults.test.ts
@@ -37,6 +37,10 @@ const {
   applyDlpMock: vi.fn(),
 }));
 
+vi.mock('../../services/aiAgentSdk', () => ({
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
+}));
+
 vi.mock('../../middleware/clientAiAuth', () => ({
   clientAiAuthMiddleware: (c: any, next: any) => {
     if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/api/src/routes/clientAi/sessions.history.test.ts
+++ b/apps/api/src/routes/clientAi/sessions.history.test.ts
@@ -37,6 +37,10 @@ const {
   applyDlpMock: vi.fn(),
 }));
 
+vi.mock('../../services/aiAgentSdk', () => ({
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
+}));
+
 vi.mock('../../middleware/clientAiAuth', () => ({
   clientAiAuthMiddleware: (c: any, next: any) => {
     if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/api/src/routes/clientAi/sessions.lifecycle.test.ts
+++ b/apps/api/src/routes/clientAi/sessions.lifecycle.test.ts
@@ -37,6 +37,10 @@ const {
   applyDlpMock: vi.fn(),
 }));
 
+vi.mock('../../services/aiAgentSdk', () => ({
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
+}));
+
 vi.mock('../../middleware/clientAiAuth', () => ({
   clientAiAuthMiddleware: (c: any, next: any) => {
     if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/api/src/routes/clientAi/sessions.messages.test.ts
+++ b/apps/api/src/routes/clientAi/sessions.messages.test.ts
@@ -37,6 +37,10 @@ const {
   applyDlpMock: vi.fn(),
 }));
 
+vi.mock('../../services/aiAgentSdk', () => ({
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
+}));
+
 vi.mock('../../middleware/clientAiAuth', () => ({
   clientAiAuthMiddleware: (c: any, next: any) => {
     if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/api/src/routes/clientAi/sessions.outlook-roundtrip.test.ts
+++ b/apps/api/src/routes/clientAi/sessions.outlook-roundtrip.test.ts
@@ -49,6 +49,10 @@ const {
   applyDlpMock: vi.fn(),
 }));
 
+vi.mock('../../services/aiAgentSdk', () => ({
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
+}));
+
 vi.mock('../../middleware/clientAiAuth', () => ({
   clientAiAuthMiddleware: (c: any, next: any) => {
     if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/api/src/routes/clientAi/sessions.powerpoint-roundtrip.test.ts
+++ b/apps/api/src/routes/clientAi/sessions.powerpoint-roundtrip.test.ts
@@ -50,6 +50,10 @@ const {
   applyDlpMock: vi.fn(),
 }));
 
+vi.mock('../../services/aiAgentSdk', () => ({
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
+}));
+
 vi.mock('../../middleware/clientAiAuth', () => ({
   clientAiAuthMiddleware: (c: any, next: any) => {
     if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/api/src/routes/clientAi/sessions.ts
+++ b/apps/api/src/routes/clientAi/sessions.ts
@@ -29,6 +29,7 @@ import {
   streamingSessionManager,
   type ActiveSession,
 } from '../../services/streamingSessionManager';
+import { settleBlockedTurnForNewMessage } from '../../services/aiAgentSdk';
 import { writeAuditEvent } from '../../services/auditEvents';
 import { checkBillingCredits } from '../../services/aiCostTracker';
 import {
@@ -590,9 +591,18 @@ clientAiSessionRoutes.post(
       throw err;
     }
 
-    // Concurrent message guard — atomic check-and-set (ai.ts:467 convention).
+    // Concurrent message guard — atomic check-and-set (ai.ts convention). If
+    // the turn is blocked only on pending approval waits, settle them so the
+    // assistant can conclude and answer this message (#3089 — shared helper).
     if (!streamingSessionManager.tryTransitionToProcessing(activeSession)) {
-      return c.json({ error: 'A message is already being processed for this session' }, 409);
+      const settle = await settleBlockedTurnForNewMessage(activeSession);
+      if (settle !== 'concluded' || !streamingSessionManager.tryTransitionToProcessing(activeSession)) {
+        return c.json({
+          error: settle === 'not_blocked_on_approvals'
+            ? 'A message is already being processed for this session'
+            : 'The assistant is wrapping up the previous turn — please try again in a moment',
+        }, 409);
+      }
     }
 
     // Persist the REDACTED form only: result.text + result.redactions

--- a/apps/api/src/routes/clientAi/sessions.word-roundtrip.test.ts
+++ b/apps/api/src/routes/clientAi/sessions.word-roundtrip.test.ts
@@ -47,6 +47,10 @@ const {
   applyDlpMock: vi.fn(),
 }));
 
+vi.mock('../../services/aiAgentSdk', () => ({
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
+}));
+
 vi.mock('../../middleware/clientAiAuth', () => ({
   clientAiAuthMiddleware: (c: any, next: any) => {
     if (!c.req.header('authorization')) return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/api/src/routes/helper/helperApprove.removed.test.ts
+++ b/apps/api/src/routes/helper/helperApprove.removed.test.ts
@@ -93,6 +93,7 @@ vi.mock('../../services', () => ({
 vi.mock('../../services/aiAgentSdk', () => ({
   createSessionPreToolUse: vi.fn(),
   createSessionPostToolUse: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
 }));
 
 import { helperRoutes } from './index';

--- a/apps/api/src/routes/helper/index.test.ts
+++ b/apps/api/src/routes/helper/index.test.ts
@@ -91,6 +91,7 @@ vi.mock('../../services', () => ({
 vi.mock('../../services/aiAgentSdk', () => ({
   createSessionPreToolUse: vi.fn(),
   createSessionPostToolUse: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
 }));
 
 // Keep the real declaration schema + name helpers (used at route-construction

--- a/apps/api/src/routes/helper/index.ts
+++ b/apps/api/src/routes/helper/index.ts
@@ -32,7 +32,7 @@ import { sanitizeUserMessage } from '../../services/aiInputSanitizer';
 import { storeScreenshot } from '../../services/screenshotStorage';
 import { checkBudget, getRemainingBudgetUsd } from '../../services/aiCostTracker';
 import { getRedis, rateLimiter } from '../../services';
-import { createSessionPreToolUse, createSessionPostToolUse } from '../../services/aiAgentSdk';
+import { createSessionPreToolUse, createSessionPostToolUse, settleBlockedTurnForNewMessage } from '../../services/aiAgentSdk';
 import { helperAuth, type HelperDevice } from '../../middleware/helperAuth';
 import type { ActiveSession } from '../../services/streamingSessionManager';
 
@@ -288,9 +288,18 @@ helperRoutes.post(
       mcpServerFactory as Parameters<typeof streamingSessionManager.getOrCreate>[7],
     );
 
-    // Concurrent message guard
+    // Concurrent message guard. If the turn is blocked only on pending
+    // approval waits (PAM-gated helper tools), settle them so the assistant
+    // can conclude and answer this message (#3089 — shared helper, see ai.ts).
     if (!streamingSessionManager.tryTransitionToProcessing(activeSession)) {
-      return c.json({ error: 'A message is already being processed for this session' }, 409);
+      const settle = await settleBlockedTurnForNewMessage(activeSession);
+      if (settle !== 'concluded' || !streamingSessionManager.tryTransitionToProcessing(activeSession)) {
+        return c.json({
+          error: settle === 'not_blocked_on_approvals'
+            ? 'A message is already being processed for this session'
+            : 'The assistant is wrapping up the previous turn — please try again in a moment',
+        }, 409);
+      }
     }
 
     // Save user message

--- a/apps/api/src/routes/scriptAi.ts
+++ b/apps/api/src/routes/scriptAi.ts
@@ -16,7 +16,7 @@ import {
   updateEditorContext,
   closeScriptBuilderSession,
 } from '../services/scriptBuilderService';
-import { runPreFlightChecks } from '../services/aiAgentSdk';
+import { runPreFlightChecks, settleBlockedTurnForNewMessage } from '../services/aiAgentSdk';
 import { streamingSessionManager } from '../services/streamingSessionManager';
 import { handleApproval } from '../services/aiAgent';
 import { writeRouteAudit } from '../services/auditEvents';
@@ -214,9 +214,18 @@ scriptAiRoutes.post(
       }),
     );
 
-    // Concurrent message guard - atomic check-and-set
+    // Concurrent message guard - atomic check-and-set. If the turn is blocked
+    // only on pending approval waits, settle them so the assistant can
+    // conclude and answer this message (#3089 — shared helper, see ai.ts).
     if (!streamingSessionManager.tryTransitionToProcessing(activeSession)) {
-      return c.json({ error: 'A message is already being processed for this session' }, 409);
+      const settle = await settleBlockedTurnForNewMessage(activeSession);
+      if (settle !== 'concluded' || !streamingSessionManager.tryTransitionToProcessing(activeSession)) {
+        return c.json({
+          error: settle === 'not_blocked_on_approvals'
+            ? 'A message is already being processed for this session'
+            : 'The assistant is wrapping up the previous turn — please try again in a moment',
+        }, 409);
+      }
     }
 
     writeRouteAudit(c, {

--- a/apps/api/src/routes/scriptAi_messages_approve.test.ts
+++ b/apps/api/src/routes/scriptAi_messages_approve.test.ts
@@ -44,6 +44,7 @@ vi.mock('../services/scriptBuilderService', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
 }));
 
 vi.mock('../services/streamingSessionManager', () => ({

--- a/apps/api/src/routes/scriptAi_sessions.test.ts
+++ b/apps/api/src/routes/scriptAi_sessions.test.ts
@@ -44,6 +44,7 @@ vi.mock('../services/scriptBuilderService', () => ({
 
 vi.mock('../services/aiAgentSdk', () => ({
   runPreFlightChecks: vi.fn(),
+  settleBlockedTurnForNewMessage: vi.fn(() => Promise.resolve('not_blocked_on_approvals')),
 }));
 
 vi.mock('../services/streamingSessionManager', () => ({

--- a/apps/api/src/services/aiAgent.authz.test.ts
+++ b/apps/api/src/services/aiAgent.authz.test.ts
@@ -146,7 +146,8 @@ describe('handleApproval owner-binding (SR5-10)', () => {
       { id: 'exec-1', status: 'pending', sessionId: 's1' },
       { id: 's1', orgId: 'org-1', userId: 'victim' },
     );
-    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const returningSpy = vi.fn().mockResolvedValue([{ id: 'exec-1' }]);
+    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: returningSpy }) });
     updateMock.mockReturnValue({ set: setSpy });
 
     const ok = await handleApproval('exec-1', true, auth('victim'), 's1');
@@ -155,6 +156,24 @@ describe('handleApproval owner-binding (SR5-10)', () => {
     expect(setSpy).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'approved', approvedBy: 'victim' }),
     );
+  });
+
+  it('returns false when the CAS updates zero rows (row settled/decided concurrently — #3089)', async () => {
+    // The pre-check SELECT saw 'pending', but by the time the guarded UPDATE
+    // ran, a settle (or the waitForApproval timeout writer) had already moved
+    // the row out of 'pending'. Reporting true here would tell the UI an
+    // action was approved that nothing will ever execute.
+    stubExecutionThenSession(
+      { id: 'exec-1', status: 'pending', sessionId: 's1' },
+      { id: 's1', orgId: 'org-1', userId: 'victim' },
+    );
+    const returningSpy = vi.fn().mockResolvedValue([]);
+    const setSpy = vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: returningSpy }) });
+    updateMock.mockReturnValue({ set: setSpy });
+
+    const ok = await handleApproval('exec-1', true, auth('victim'), 's1');
+
+    expect(ok).toBe(false);
   });
 });
 

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -439,16 +439,27 @@ export async function handleApproval(
     return false;
   }
 
-  await db
+  // CAS, not a blind update: the pre-check SELECT above races the settle
+  // paths (#3089 — settleApprovalWaits marks a settled wait's row 'rejected'
+  // the moment a new message/interrupt arrives) and the waitForApproval
+  // timeout writer. Without the status guard, an Approve click landing just
+  // after a settle would flip 'rejected' back to a stranded 'approved' that
+  // nothing will ever execute — while this function reports success to the
+  // UI. Zero rows updated means we lost such a race: report failure honestly.
+  const [updated] = await db
     .update(aiToolExecutions)
     .set({
       status: approved ? 'approved' : 'rejected',
       approvedBy: auth.user.id,
       approvedAt: new Date()
     })
-    .where(eq(aiToolExecutions.id, executionId));
+    .where(and(
+      eq(aiToolExecutions.id, executionId),
+      eq(aiToolExecutions.status, 'pending'),
+    ))
+    .returning({ id: aiToolExecutions.id });
 
-  return true;
+  return !!updated;
 }
 
 /**

--- a/apps/api/src/services/aiAgentSdk.approvalWait.test.ts
+++ b/apps/api/src/services/aiAgentSdk.approvalWait.test.ts
@@ -40,7 +40,7 @@ vi.mock('../db/schema', () => ({
   aiActionPlans: {},
   devices: {},
   deviceSessions: {},
-  approvalRequests: { id: 'id' },
+  approvalRequests: { id: 'approval_requests.id', status: 'approval_requests.status' },
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -322,7 +322,7 @@ describe('settleApprovalWaits (#3089)', () => {
       description: 'Take screenshot',
     } as any);
     mockInsertReturning({ id: 'exec-4' });
-    const { set } = mockUpdateChain();
+    const { set, where } = mockUpdateChain();
     vi.mocked(waitForApproval).mockImplementation(
       (_id: string, _timeoutMs: number, signal?: AbortSignal) =>
         new Promise((resolve) => {
@@ -339,13 +339,85 @@ describe('settleApprovalWaits (#3089)', () => {
 
     const result = await resultPromise;
     expect(result).toEqual({ allowed: false, error: 'Tool execution was rejected or timed out' });
-    // The still-pending ledger row was closed out (guarded on status='pending')
-    // so a later Approve click cannot flip it to a stranded 'approved' this
-    // legacy bridge would never execute.
+    // The still-pending ledger row was closed out — WITH the status='pending'
+    // CAS guard, so a genuine reject/timeout row is never overwritten — and a
+    // later Approve click cannot flip it to a stranded 'approved' this legacy
+    // bridge would never execute.
     expect(set).toHaveBeenCalledWith({
       status: 'rejected',
       errorMessage: 'Approval wait ended before a decision was made',
     });
+    expect(where).toHaveBeenCalledWith({
+      _and: [{ _eq: ['id', 'exec-4'] }, { _eq: ['status', 'pending'] }],
+    });
+    // The linked mobile approval_requests row is CAS'd out of 'pending' too,
+    // closing the mobile decide → stranded-'approved' race at the source.
+    expect(set).toHaveBeenCalledWith({ status: 'expired' });
+    expect(where).toHaveBeenCalledWith({
+      _and: [
+        { _eq: ['approval_requests.id', 'exec-4'] },
+        { _eq: ['approval_requests.status', 'pending'] },
+      ],
+    });
+    expect(session.pendingApprovalWaits).toBe(0);
+  });
+
+  it('a zero-budget tier-2 approval never runs the ceremony (no mobile push, no UI card) and self-closes honestly', async () => {
+    vi.mocked(checkGuardrails).mockReturnValue({
+      allowed: true,
+      tier: 2,
+      requiresApproval: true,
+      description: 'Take screenshot',
+    } as any);
+    const { values } = mockInsertReturning({ id: 'exec-5' });
+    const { set, where } = mockUpdateChain();
+    // A sibling approval (or a settle) already exhausted this cycle's budget.
+    const session = makeActiveSession({ approvalWaitDeadline: Date.now() - 1_000 });
+
+    const result = await createSessionPreToolUse(session)('take_screenshot', { deviceId: 'd-1' });
+
+    expect(result.allowed).toBe(false);
+    expect((result as { error: string }).error).toMatch(/approval window for this turn has ended/);
+    // No dead-on-arrival ceremony: only the ledger-row insert ran — no
+    // approval_requests row, no push, no approval_required card, no wait.
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(mockDispatchApprovalPushToTokens).not.toHaveBeenCalled();
+    expect(session.eventBus.publish).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'approval_required' }),
+    );
+    expect(waitForApproval).not.toHaveBeenCalled();
+    // The ledger row is closed out honestly (CAS on status='pending').
+    expect(set).toHaveBeenCalledWith({
+      status: 'rejected',
+      errorMessage: "Approval not requested — this turn's approval wait budget was already exhausted",
+    });
+    expect(where).toHaveBeenCalledWith({
+      _and: [{ _eq: ['id', 'exec-5'] }, { _eq: ['status', 'pending'] }],
+    });
+    expect(session.pendingApprovalWaits).toBe(0);
+  });
+
+  it('helper/PAM approvals draw from the same shared budget (zero remaining → zero wait)', async () => {
+    vi.mocked(checkGuardrails).mockReturnValue({
+      allowed: true,
+      tier: 3,
+      requiresApproval: true,
+      description: 'Execute command',
+    } as any);
+    mockInsertReturning({ id: 'exec-h9' });
+    mockUpdateChain();
+    const { decideHelperToolAction } = await import('./pamToolActionGovernance');
+    vi.mocked(decideHelperToolAction).mockResolvedValue('prompt' as any);
+    vi.mocked(waitForApproval).mockResolvedValue(false);
+    const session = makeActiveSession({
+      auth: { ...makeAuth(), helperDeviceId: 'dev-9' },
+      approvalWaitDeadline: Date.now() - 1_000,
+    });
+
+    const result = await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
+
+    expect(result.allowed).toBe(false);
+    expect(waitForApproval).toHaveBeenCalledWith('exec-h9', 0, expect.any(AbortSignal));
     expect(session.pendingApprovalWaits).toBe(0);
   });
 });

--- a/apps/api/src/services/aiAgentSdk.approvalWait.test.ts
+++ b/apps/api/src/services/aiAgentSdk.approvalWait.test.ts
@@ -1,0 +1,370 @@
+/**
+ * #3089 — the chat turn must not block indefinitely on pending approvals.
+ *
+ * Covers the shared per-cycle approval-wait budget (beginApprovalWait via the
+ * tier-3/tier-2 flows), settleApprovalWaits (new-user-message / interrupt
+ * settling), and waitForTurnToSettle. Mock scaffolding mirrors
+ * aiAgentSdk.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createSessionPreToolUse,
+  settleApprovalWaits,
+  waitForTurnToSettle,
+  APPROVAL_WAIT_BUDGET_MS,
+} from './aiAgentSdk';
+import { db } from '../db';
+import { checkGuardrails, checkToolPermission, checkToolRateLimit } from './aiGuardrails';
+import { waitForApproval } from './aiAgent';
+import type { ActionIntentSnapshot } from './actionIntents/intentService';
+
+// ============================================
+// Mocks (mirrors aiAgentSdk.test.ts)
+// ============================================
+
+vi.mock('../db', () => ({
+  runOutsideDbContext: vi.fn((fn) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  db: {
+    update: vi.fn(),
+    insert: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  aiSessions: { id: 'id', status: 'status', orgId: 'orgId' },
+  aiMessages: {},
+  aiToolExecutions: { id: 'id', status: 'status' },
+  aiActionPlans: {},
+  devices: {},
+  deviceSessions: {},
+  approvalRequests: { id: 'id' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ _eq: args })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  isNull: vi.fn((...args: unknown[]) => ({ _isNull: args })),
+}));
+
+vi.mock('./aiAgent', () => ({
+  getSession: vi.fn(),
+  buildSystemPrompt: vi.fn(),
+  waitForApproval: vi.fn(),
+}));
+
+vi.mock('./aiCostTracker', () => ({
+  checkAiRateLimit: vi.fn(),
+  checkBudget: vi.fn(),
+  getRemainingBudgetUsd: vi.fn(),
+}));
+
+vi.mock('./aiInputSanitizer', () => ({
+  sanitizeUserMessage: vi.fn(),
+  sanitizePageContext: vi.fn(),
+}));
+
+vi.mock('./aiGuardrails', () => ({
+  checkGuardrails: vi.fn(),
+  checkToolPermission: vi.fn(),
+  checkToolRateLimit: vi.fn(),
+}));
+
+vi.mock('./auditEvents', () => ({
+  writeAuditEvent: vi.fn(),
+  requestLikeFromSnapshot: vi.fn(),
+}));
+
+vi.mock('./aiAgentSdkTools', () => ({
+  TOOL_TIERS: {
+    execute_command: 3,
+    take_screenshot: 2,
+  },
+  BREEZE_MCP_TOOL_NAMES: [],
+}));
+
+const mockGetUserPushTokens = vi.fn();
+const mockDispatchApprovalPushToTokens = vi.fn();
+vi.mock('./expoPush', () => ({
+  getUserPushTokens: (...args: unknown[]) => mockGetUserPushTokens(...args),
+  dispatchApprovalPushToTokens: (...args: unknown[]) => mockDispatchApprovalPushToTokens(...args),
+}));
+
+vi.mock('./pamToolActionGovernance', () => ({
+  decideHelperToolAction: vi.fn(),
+}));
+
+const mockCreateActionIntent = vi.fn();
+const mockWaitForIntentDecision = vi.fn();
+const mockTransitionIntent = vi.fn();
+vi.mock('./actionIntents/intentService', () => ({
+  createActionIntent: (...args: unknown[]) => mockCreateActionIntent(...args),
+  waitForIntentDecision: (...args: unknown[]) => mockWaitForIntentDecision(...args),
+  transitionIntent: (...args: unknown[]) => mockTransitionIntent(...args),
+}));
+
+vi.mock('./actionIntents/durableRelease', () => ({
+  requiresDurableRelease: vi.fn(() => false),
+  DURABLE_RELEASE_ONLY_TOOLS: new Set<string>(),
+}));
+
+vi.mock('./actionIntents/revalidateRelease', () => ({
+  revalidateApprovedIntentForRelease: vi.fn(() => Promise.resolve({ ok: true, auth: {} })),
+}));
+
+vi.mock('../db/schema/actionIntents', () => ({
+  actionIntents: { id: 'id', status: 'status' },
+}));
+
+vi.mock('./sentry', () => ({
+  captureException: vi.fn(),
+}));
+
+// ============================================
+// Test helpers
+// ============================================
+
+function makeAuth() {
+  return {
+    user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+    orgId: 'org-1',
+    scope: 'organization',
+    accessibleOrgIds: ['org-1'],
+    canAccessOrg: () => true,
+    orgCondition: () => null,
+  } as any;
+}
+
+function makeActiveSession(overrides: Record<string, unknown> = {}) {
+  return {
+    breezeSessionId: 'session-1',
+    orgId: 'org-1',
+    auth: makeAuth(),
+    approvalMode: 'per_step',
+    isPaused: false,
+    state: 'processing',
+    eventBus: { publish: vi.fn() },
+    abortController: new AbortController(),
+    activePlanId: null,
+    approvedPlanSteps: new Map(),
+    currentPlanStepIndex: 0,
+    toolUseIdQueue: ['tool-use-1'],
+    auditSnapshot: null,
+    allowedTools: undefined,
+    approvalWaitDeadline: null,
+    approvalWaitAbort: null,
+    pendingApprovalWaits: 0,
+    ...overrides,
+  } as any;
+}
+
+function makeIntentSnapshot(overrides: Partial<ActionIntentSnapshot> = {}): ActionIntentSnapshot {
+  return {
+    id: 'intent-1',
+    status: 'pending_approval',
+    actionName: 'execute_command',
+    argumentDigest: 'digest-1',
+    source: 'chat',
+    expiresAt: new Date(Date.now() + 300_000),
+    result: null,
+    errorCode: null,
+    approvalRequestIds: ['appr-1'],
+    requesterApprovalRequestId: null,
+    ...overrides,
+  };
+}
+
+function mockInsertReturning(row: Record<string, unknown>) {
+  const returning = vi.fn().mockResolvedValue([row]);
+  const values = vi.fn().mockReturnValue({ returning });
+  vi.mocked(db.insert).mockReturnValue({ values } as any);
+  return { values, returning };
+}
+
+function mockUpdateChain() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn(() => ({ where }));
+  vi.mocked(db.update).mockReturnValue({ set } as any);
+  return { set, where };
+}
+
+/** Poll until `fn()` is true (waits blocked inside preToolUse are async). */
+async function until(fn: () => boolean, ms = 2000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > ms) throw new Error('until(): condition not met in time');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function tier3Guardrail() {
+  vi.mocked(checkGuardrails).mockReturnValue({
+    allowed: true,
+    tier: 3,
+    requiresApproval: true,
+    description: 'Execute command',
+  } as any);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(checkToolPermission).mockResolvedValue(null as any);
+  vi.mocked(checkToolRateLimit).mockResolvedValue(null as any);
+  mockGetUserPushTokens.mockResolvedValue([]);
+  mockDispatchApprovalPushToTokens.mockResolvedValue(undefined);
+});
+
+// ============================================
+// Shared per-cycle budget
+// ============================================
+
+describe('shared approval-wait budget (#3089)', () => {
+  it('first tier-3 wait of a cycle gets the full budget and sets the shared deadline', async () => {
+    tier3Guardrail();
+    mockInsertReturning({ id: 'exec-1' });
+    mockUpdateChain();
+    mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot());
+    mockWaitForIntentDecision.mockResolvedValue('rejected');
+    const session = makeActiveSession();
+    const before = Date.now();
+
+    await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
+
+    expect(mockWaitForIntentDecision).toHaveBeenCalledWith(
+      'intent-1',
+      APPROVAL_WAIT_BUDGET_MS,
+      expect.any(AbortSignal),
+    );
+    // Deadline is shared session state for the rest of the cycle.
+    expect(session.approvalWaitDeadline).toBeGreaterThanOrEqual(before + APPROVAL_WAIT_BUDGET_MS);
+    // The in-flight counter is balanced once the wait ends.
+    expect(session.pendingApprovalWaits).toBe(0);
+  });
+
+  it('a sibling wait in the same cycle gets zero budget once exhausted and returns pending immediately', async () => {
+    tier3Guardrail();
+    mockInsertReturning({ id: 'exec-2' });
+    mockUpdateChain();
+    mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-2', approvalRequestIds: ['appr-2'] }));
+    mockWaitForIntentDecision.mockResolvedValue('pending_approval');
+    // A sibling approval earlier in this cycle already burned the budget.
+    const session = makeActiveSession({ approvalWaitDeadline: Date.now() - 1_000 });
+
+    const result = await createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
+
+    expect(mockWaitForIntentDecision).toHaveBeenCalledWith('intent-2', 0, expect.any(AbortSignal));
+    expect(result).toEqual({
+      allowed: false,
+      error: 'Approval still pending; this action will complete once approved.',
+    });
+    // The intent is untouched — it stays pending_approval for the durable
+    // release worker to execute once an approver decides.
+    expect(mockTransitionIntent).not.toHaveBeenCalled();
+    // The approval card was still surfaced to the user.
+    expect(session.eventBus.publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'approval_required', executionId: 'exec-2' }),
+    );
+  });
+});
+
+// ============================================
+// settleApprovalWaits
+// ============================================
+
+describe('settleApprovalWaits (#3089)', () => {
+  it('is a no-op returning false when no approval wait is in flight', () => {
+    const session = makeActiveSession();
+    expect(settleApprovalWaits(session)).toBe(false);
+    expect(session.approvalWaitAbort).toBeNull();
+  });
+
+  it('settles an in-flight tier-3 wait: the turn unblocks with an approval-pending result and the intent is left for the worker', async () => {
+    tier3Guardrail();
+    mockInsertReturning({ id: 'exec-3' });
+    mockUpdateChain();
+    mockCreateActionIntent.mockResolvedValue(makeIntentSnapshot({ id: 'intent-3', approvalRequestIds: ['appr-3'] }));
+    // Simulate a real DB-polling wait that only ends when the signal fires.
+    mockWaitForIntentDecision.mockImplementation(
+      (_id: string, _timeoutMs: number, signal: AbortSignal) =>
+        new Promise((resolve) => {
+          if (signal.aborted) return resolve('pending_approval');
+          signal.addEventListener('abort', () => resolve('pending_approval'), { once: true });
+        }),
+    );
+    const session = makeActiveSession();
+
+    const resultPromise = createSessionPreToolUse(session)('execute_command', { deviceId: 'd-1' });
+    await until(() => session.pendingApprovalWaits === 1);
+
+    expect(settleApprovalWaits(session)).toBe(true);
+
+    const result = await resultPromise;
+    expect(result).toEqual({
+      allowed: false,
+      error: 'Approval still pending; this action will complete once approved.',
+    });
+    expect(mockTransitionIntent).not.toHaveBeenCalled();
+    expect(session.pendingApprovalWaits).toBe(0);
+    // Budget is exhausted for the rest of the cycle so a sibling cannot
+    // immediately re-block the turn.
+    expect(session.approvalWaitDeadline).toBeLessThanOrEqual(Date.now());
+    // Nothing left to settle.
+    expect(settleApprovalWaits(session)).toBe(false);
+  });
+
+  it('settles an in-flight tier-2 wait and closes out the pending execution row so a later approve cannot strand it', async () => {
+    vi.mocked(checkGuardrails).mockReturnValue({
+      allowed: true,
+      tier: 2,
+      requiresApproval: true,
+      description: 'Take screenshot',
+    } as any);
+    mockInsertReturning({ id: 'exec-4' });
+    const { set } = mockUpdateChain();
+    vi.mocked(waitForApproval).mockImplementation(
+      (_id: string, _timeoutMs: number, signal?: AbortSignal) =>
+        new Promise((resolve) => {
+          if (signal?.aborted) return resolve(false);
+          signal?.addEventListener('abort', () => resolve(false), { once: true });
+        }),
+    );
+    const session = makeActiveSession();
+
+    const resultPromise = createSessionPreToolUse(session)('take_screenshot', { deviceId: 'd-1' });
+    await until(() => session.pendingApprovalWaits === 1);
+
+    expect(settleApprovalWaits(session)).toBe(true);
+
+    const result = await resultPromise;
+    expect(result).toEqual({ allowed: false, error: 'Tool execution was rejected or timed out' });
+    // The still-pending ledger row was closed out (guarded on status='pending')
+    // so a later Approve click cannot flip it to a stranded 'approved' this
+    // legacy bridge would never execute.
+    expect(set).toHaveBeenCalledWith({
+      status: 'rejected',
+      errorMessage: 'Approval wait ended before a decision was made',
+    });
+    expect(session.pendingApprovalWaits).toBe(0);
+  });
+});
+
+// ============================================
+// waitForTurnToSettle
+// ============================================
+
+describe('waitForTurnToSettle (#3089)', () => {
+  it('resolves true once the session leaves processing', async () => {
+    const session = makeActiveSession({ state: 'processing' });
+    setTimeout(() => { session.state = 'idle'; }, 250);
+
+    await expect(waitForTurnToSettle(session, 3_000)).resolves.toBe(true);
+  });
+
+  it('resolves false when the session is still processing at the deadline', async () => {
+    const session = makeActiveSession({ state: 'processing' });
+
+    await expect(waitForTurnToSettle(session, 300)).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -147,8 +147,29 @@ export async function waitForTurnToSettle(session: ActiveSession, timeoutMs: num
 /**
  * How long the shared route helper below waits for a settled turn to conclude
  * (covers the model emitting its closing message) before giving up.
+ *
+ * KNOWN GAP (#1105-class, flagged in review): all four callers below run
+ * inside the request's ambient withDbAccessContext transaction (set up by
+ * authMiddleware / clientAiAuthMiddleware / helperAuth), and none of the four
+ * routes is registered in middleware/selfManagedDbContextRoutes.ts. This wait
+ * does no DB work itself, but it still pins that transaction's pooled
+ * connection idle-in-transaction for its full duration — runOutsideDbContext
+ * cannot release it (it only re-routes NEW queries to the pool; the
+ * connection itself stays checked out by the outer `baseDb.transaction(...)`
+ * callback until the whole handler returns). A client that keeps resending
+ * a message while a session sits blocked on approval can hold one pooled
+ * connection per in-flight request for up to this long — against the prod
+ * 25-connection ceiling, that's a real amplification risk under the same
+ * class this codebase already fixed for the OIDC/SFTP/notification-test
+ * routes (see selfManagedDbContextRoutes.ts). The correct fix is the same
+ * one: register these four routes as self-managed and have each wrap its own
+ * DB calls in short-lived withDbAccessContext blocks around this wait — out
+ * of scope for this change (touches auth/RLS context on four hot routes,
+ * needs its own dedicated PR + tests). Kept intentionally short here as an
+ * interim bound on the worst case; do not raise this back toward the
+ * original 15s without doing that conversion first.
  */
-export const TURN_SETTLE_WAIT_MS = 15_000;
+export const TURN_SETTLE_WAIT_MS = 3_000;
 
 export type BlockedTurnSettleResult =
   /** Waits were settled and the turn concluded — retry tryTransitionToProcessing. */
@@ -518,6 +539,29 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           helperApprovalWait.end();
         }
         if (!approved) {
+          // Mirrors the tier-2/tier-3 close-out below: on an early settle
+          // (abort signal), waitForApproval returns WITHOUT marking the row,
+          // so a later PAM decision (decideHelperToolAction/pamToolActionGovernance)
+          // would otherwise CAS this still-'pending' row to 'approved' with
+          // nothing left listening on it — a stranded approval that silently
+          // never executes. Guarded on status='pending' so a genuine
+          // reject/timeout (already marked) is a no-op.
+          try {
+            await withDbAccessContext(
+              { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+              () =>
+                db
+                  .update(aiToolExecutions)
+                  .set({ status: 'rejected', errorMessage: 'Approval wait ended before a decision was made' })
+                  .where(and(
+                    eq(aiToolExecutions.id, helperExec!.id),
+                    eq(aiToolExecutions.status, 'pending'),
+                  ))
+            );
+          } catch (err) {
+            captureException(err instanceof Error ? err : new Error(String(err)));
+            console.error('[AI-SDK] Failed to close out settled helper approval record:', helperExec.id, err);
+          }
           return {
             allowed: false,
             error: 'Tool execution was rejected or timed out awaiting administrator approval',
@@ -1227,7 +1271,14 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           // regardless.
           try {
             await withDbAccessContext(
-              { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+              // userId is REQUIRED here, not just orgId: approval_requests is
+              // Shape-6 (user-id-scoped RLS — see routes/approvals.ts's
+              // system-scope note), so without it breeze_current_user_id()
+              // is NULL and the approvalRequests UPDATE below silently
+              // matches zero rows under FORCE RLS — leaving the mobile card
+              // 'pending' so a late mobile Approve can still race past
+              // decideHandler's CAS after this ledger row has already closed.
+              { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId], userId: session.auth.user.id },
               async () => {
                 await db
                   .update(aiToolExecutions)

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -43,6 +43,108 @@ const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const SESSION_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
 
 /**
+ * Total time a single assistant cycle (one assistant message's batch of tool
+ * calls) may spend blocked on approval waits, SHARED across every approval
+ * wait in that cycle (#3089). Matches the action-intent chat expiry (5 min).
+ *
+ * Why shared, not per-wait: the SDK executes sibling tool calls sequentially
+ * inside the same turn, so two pending approvals used to stack their 5-minute
+ * waits (10 min total) past the 6-minute turn timeout
+ * (streamingSessionManager.SDK_TURN_TIMEOUT_MS). The turn timeout then fired
+ * first, publishing error+done to the UI — and the model's eventual closing
+ * message was published into a turn the client had already ended, so sessions
+ * ended with raw approval-pending error rows and no closing assistant message.
+ * With one shared budget, cumulative approval blocking per cycle is <= 5 min,
+ * which always leaves the model headroom to conclude the turn gracefully.
+ * A wait that gives up leaves its tier-3 intent pending_approval — an approver
+ * can still decide it and the durable release worker executes it (spec §6.1).
+ */
+export const APPROVAL_WAIT_BUDGET_MS = 300_000;
+
+/**
+ * Begin an approval wait for this session's current assistant cycle.
+ *
+ * Returns the remaining shared budget as `timeoutMs` (0 when a sibling wait
+ * already exhausted it — callers pass it straight to waitForApproval /
+ * waitForIntentDecision, both of which return immediately on 0), plus a
+ * combined AbortSignal that settles the wait when EITHER the session is torn
+ * down OR settleApprovalWaits() fires (new user message / interrupt). Callers
+ * MUST invoke `end()` (in a finally) so the in-flight counter stays accurate.
+ *
+ * The per-cycle state lives on ActiveSession and is reset by
+ * StreamingSessionManager.startTurnTimeout() at each message_start — the same
+ * point the 6-minute turn timeout resets — preserving the invariant that a
+ * cycle's approval waits always end before the turn timeout fires.
+ */
+function beginApprovalWait(session: ActiveSession): {
+  timeoutMs: number;
+  signal: AbortSignal;
+  end: () => void;
+} {
+  const now = Date.now();
+  if (session.approvalWaitDeadline == null) {
+    session.approvalWaitDeadline = now + APPROVAL_WAIT_BUDGET_MS;
+  }
+  const timeoutMs = Math.max(0, session.approvalWaitDeadline - now);
+  if (!session.approvalWaitAbort) {
+    session.approvalWaitAbort = new AbortController();
+  }
+  const signal = AbortSignal.any([
+    session.abortController.signal,
+    session.approvalWaitAbort.signal,
+  ]);
+  session.pendingApprovalWaits = (session.pendingApprovalWaits ?? 0) + 1;
+  let ended = false;
+  return {
+    timeoutMs,
+    signal,
+    end: () => {
+      if (ended) return;
+      ended = true;
+      session.pendingApprovalWaits = Math.max(0, (session.pendingApprovalWaits ?? 1) - 1);
+    },
+  };
+}
+
+/**
+ * Settle every in-flight approval wait on this session so the current turn can
+ * conclude (#3089). The blocked preToolUse calls return promptly with their
+ * "approval still pending" tool error, the model gets to respond (and address
+ * whatever prompted the settle), and any tier-3 intent stays pending_approval
+ * for the durable release worker to execute once an approver decides.
+ *
+ * Also exhausts the cycle's remaining wait budget so a sibling tool call later
+ * in the SAME cycle cannot immediately re-block the turn — the budget resets
+ * at the next assistant cycle (startTurnTimeout).
+ *
+ * Returns false (and does nothing) when no approval wait is in flight — the
+ * session is busy for some other reason and callers should fall back to their
+ * existing behavior.
+ */
+export function settleApprovalWaits(session: ActiveSession): boolean {
+  if ((session.pendingApprovalWaits ?? 0) === 0) return false;
+  session.approvalWaitDeadline = Date.now();
+  session.approvalWaitAbort?.abort();
+  session.approvalWaitAbort = null;
+  return true;
+}
+
+/**
+ * Wait (bounded) for a session's current turn to conclude after
+ * settleApprovalWaits(). Resolves true once the session leaves 'processing'
+ * (the model emitted its closing message and the SDK published result/done);
+ * false if it is still processing when the timeout elapses.
+ */
+export async function waitForTurnToSettle(session: ActiveSession, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (session.state !== 'processing') return true;
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  return session.state !== 'processing';
+}
+
+/**
  * Tracks the action_intents.id an inline Tier-3 execution is running under,
  * so createSessionPostToolUse can CAS it `executing -> completed|failed` once
  * the tool actually finishes (see the coordination invariant in the T3 block
@@ -716,18 +818,26 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
             intentBacked: true,
           });
 
-          // Block until an approver decides, OR the chat wait window (still 300s
-          // — matches the intent's own 5-minute chat expiry) elapses. Unlike the
+          // Block until an approver decides, OR the cycle's SHARED approval-wait
+          // budget (up to 300s — matches the intent's own 5-minute chat expiry)
+          // elapses, OR the wait is settled early (session teardown, a new user
+          // message, or interrupt — see settleApprovalWaits, #3089). Unlike the
           // old waitForApproval, this NEVER mutates the intent on timeout: giving
           // up here leaves it pending_approval so an approver can still decide it
           // — and the durable release worker (jobs/intentReleaseWorker.ts) will
           // execute it — after this session has moved on or died. This is the
           // new durable capability the design adds (spec §6.1).
-          const decisionStatus = await waitForIntentDecision(
-            intent.id,
-            300_000,
-            session.abortController.signal,
-          );
+          const approvalWait = beginApprovalWait(session);
+          let decisionStatus: Awaited<ReturnType<typeof waitForIntentDecision>>;
+          try {
+            decisionStatus = await waitForIntentDecision(
+              intent.id,
+              approvalWait.timeoutMs,
+              approvalWait.signal,
+            );
+          } finally {
+            approvalWait.end();
+          }
 
           if (decisionStatus === 'pending_approval') {
             return await failMatchedPlanStep(
@@ -929,7 +1039,7 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           }
         } catch { /* non-fatal: fall back to default description */ }
         const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
-        const expiresAt = new Date(Date.now() + 300_000); // matches waitForApproval timeout
+        const expiresAt = new Date(Date.now() + APPROVAL_WAIT_BUDGET_MS); // matches the max approval wait
 
         let approvalRequestId: string | undefined;
         try {
@@ -1009,14 +1119,45 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           deviceContext,
         });
 
-        // Block until user clicks Approve/Reject or 5-min timeout
-        const approved = await waitForApproval(
-          approvalExec.id,
-          300_000,
-          session.abortController.signal,
-        );
+        // Block until user clicks Approve/Reject, the cycle's shared approval
+        // wait budget (up to 5 min) elapses, or the wait is settled early
+        // (session teardown / new user message / interrupt — #3089).
+        const approvalWait = beginApprovalWait(session);
+        let approved: boolean;
+        try {
+          approved = await waitForApproval(
+            approvalExec.id,
+            approvalWait.timeoutMs,
+            approvalWait.signal,
+          );
+        } finally {
+          approvalWait.end();
+        }
 
         if (!approved) {
+          // The wait may have been settled early (abort signal), in which case
+          // waitForApproval returned WITHOUT marking the row — close it out so
+          // a later Approve click can't flip it to a stranded 'approved' that
+          // nothing will ever execute (this legacy bridge has no durable
+          // release worker). Guarded on status='pending' so a genuine reject
+          // (row already 'rejected') or timeout (waitForApproval already
+          // marked it) is a no-op. Best-effort: the tool error below must
+          // surface regardless.
+          try {
+            await withDbAccessContext(
+              { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+              () =>
+                db
+                  .update(aiToolExecutions)
+                  .set({ status: 'rejected', errorMessage: 'Approval wait ended before a decision was made' })
+                  .where(and(
+                    eq(aiToolExecutions.id, approvalExec!.id),
+                    eq(aiToolExecutions.status, 'pending'),
+                  ))
+            );
+          } catch (err) {
+            console.error('[AI-SDK] Failed to close out settled approval record:', approvalExec.id, err);
+          }
           // Not reachable with a non-null matchedPlanStepIndex today (both
           // secret-bearing tools are statically tier 3, so the only way to
           // land in this tier<3 legacy branch with a matched-but-declined

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -145,6 +145,37 @@ export async function waitForTurnToSettle(session: ActiveSession, timeoutMs: num
 }
 
 /**
+ * How long the shared route helper below waits for a settled turn to conclude
+ * (covers the model emitting its closing message) before giving up.
+ */
+export const TURN_SETTLE_WAIT_MS = 15_000;
+
+export type BlockedTurnSettleResult =
+  /** Waits were settled and the turn concluded — retry tryTransitionToProcessing. */
+  | 'concluded'
+  /** No approval wait was in flight — the session is busy doing real work. */
+  | 'not_blocked_on_approvals'
+  /** Waits were settled but the turn is still concluding — retry shortly. */
+  | 'still_processing';
+
+/**
+ * Shared handler for every chat surface's concurrent-message 409 guard
+ * (#3089): when tryTransitionToProcessing fails, call this to settle a turn
+ * that is blocked only on approval waits and give it a moment to conclude, so
+ * the assistant can answer the new message instead of going mute behind the
+ * approval. Used by routes/ai.ts, routes/clientAi/sessions.ts,
+ * routes/scriptAi.ts, and routes/helper/index.ts — keep them in sync through
+ * this helper, not four hand-rolled copies.
+ */
+export async function settleBlockedTurnForNewMessage(
+  session: ActiveSession,
+  timeoutMs = TURN_SETTLE_WAIT_MS,
+): Promise<BlockedTurnSettleResult> {
+  if (!settleApprovalWaits(session)) return 'not_blocked_on_approvals';
+  return (await waitForTurnToSettle(session, timeoutMs)) ? 'concluded' : 'still_processing';
+}
+
+/**
  * Tracks the action_intents.id an inline Tier-3 execution is running under,
  * so createSessionPostToolUse can CAS it `executing -> completed|failed` once
  * the tool actually finishes (see the coordination invariant in the T3 block
@@ -471,12 +502,21 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
         }
 
         // Block until PAM decides (an auto-approved elevation has already
-        // flipped the row, so this returns on the first poll).
-        const approved = await waitForApproval(
-          helperExec.id,
-          300_000,
-          session.abortController.signal,
-        );
+        // flipped the row, so this returns on the first poll). Draws from the
+        // same shared per-cycle approval-wait budget as the tier-2/tier-3
+        // flows (#3089) so stacked helper approvals can't outlive the turn
+        // timeout, and settleApprovalWaits can conclude a blocked helper turn.
+        const helperApprovalWait = beginApprovalWait(session);
+        let approved: boolean;
+        try {
+          approved = await waitForApproval(
+            helperExec.id,
+            helperApprovalWait.timeoutMs,
+            helperApprovalWait.signal,
+          );
+        } finally {
+          helperApprovalWait.end();
+        }
         if (!approved) {
           return {
             allowed: false,
@@ -1039,92 +1079,129 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           }
         } catch { /* non-fatal: fall back to default description */ }
         const riskSummary = m365Summary ?? (description.length > 500 ? `${description.slice(0, 497)}...` : description);
-        const expiresAt = new Date(Date.now() + APPROVAL_WAIT_BUDGET_MS); // matches the max approval wait
 
+        // Begin the (shared-budget) approval wait BEFORE the approval
+        // ceremony: with zero budget left, this legacy bridge would
+        // self-reject instantly (waitForApproval's poll loop never runs on a
+        // 0 timeout), so creating the approval_requests row, dispatching the
+        // mobile push, and rendering the UI card first would advertise an
+        // approval that was already dead on arrival — and unlike tier 3
+        // there is no durable worker on this path to honor a late Approve.
+        // Close out the ledger row honestly and return instead (#3089).
+        const approvalWait = beginApprovalWait(session);
         let approvalRequestId: string | undefined;
+        let approved: boolean;
         try {
-          const [approvalRow] = await withDbAccessContext(
-            {
-              scope: 'organization',
-              orgId: session.orgId,
-              accessibleOrgIds: [session.orgId],
-              userId: session.auth.user.id,
-            },
-            () =>
-              db
-                .insert(approvalRequests)
-                .values({
-                  userId: session.auth.user.id,
-                  executionId: approvalExec!.id,
-                  requestingClientLabel: 'Breeze AI',
-                  requestingMachineLabel: null,
-                  actionLabel,
-                  actionToolName: stripMcpPrefix(toolName),
-                  actionArguments: input as Record<string, unknown>,
-                  riskTier,
-                  riskSummary,
-                  status: 'pending',
-                  // The chat session's originating OAuth client is not yet
-                  // tracked on aiSessions; until that lands, the AI-agent
-                  // path can't be a self-loop with the mobile push target.
-                  // (deriveIsRecursive() with a null requestingClientId
-                  // returns false — explicit here for documentation.)
-                  isRecursive: false,
-                  expiresAt,
-                })
-                .returning({ id: approvalRequests.id })
-          );
-          approvalRequestId = approvalRow?.id;
-        } catch (err) {
-          console.error('[AI-SDK] Failed to create mobile approval_request row:', err);
-          // Non-fatal: SSE approval flow still works for in-app web UI even
-          // without the mobile-readable row. The approve/deny handler simply
-          // won't have an executionId to resolve back to.
-        }
+          if (approvalWait.timeoutMs <= 0) {
+            try {
+              await withDbAccessContext(
+                { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+                () =>
+                  db
+                    .update(aiToolExecutions)
+                    .set({
+                      status: 'rejected',
+                      errorMessage: "Approval not requested — this turn's approval wait budget was already exhausted",
+                    })
+                    .where(and(
+                      eq(aiToolExecutions.id, approvalExec!.id),
+                      eq(aiToolExecutions.status, 'pending'),
+                    ))
+              );
+            } catch (err) {
+              captureException(err instanceof Error ? err : new Error(String(err)));
+              console.error('[AI-SDK] Failed to close out zero-budget approval record:', approvalExec.id, err);
+            }
+            return await failMatchedPlanStep({
+              allowed: false,
+              error: 'This action needs approval, but the approval window for this turn has ended; it was not requested. The user can ask again in a new message.',
+            });
+          }
 
-        // Best-effort push notification to the user's mobile device(s).
-        if (approvalRequestId) {
+          // The mobile card's countdown reflects the wait that will actually
+          // happen — the REMAINING shared budget, not a flat 5 minutes.
+          const expiresAt = new Date(Date.now() + approvalWait.timeoutMs);
+
           try {
-            // Token read happens INSIDE the org DB context; the push network
-            // sends run AFTER it closes so we never hold the transaction open
-            // across the round-trip (#1105). dispatchApprovalPushToTokens fans
-            // out across every provider (Expo relay + native APNs).
-            const tokens = await withDbAccessContext(
+            const [approvalRow] = await withDbAccessContext(
               {
                 scope: 'organization',
                 orgId: session.orgId,
                 accessibleOrgIds: [session.orgId],
                 userId: session.auth.user.id,
               },
-              () => getUserPushTokens(session.auth.user.id),
+              () =>
+                db
+                  .insert(approvalRequests)
+                  .values({
+                    userId: session.auth.user.id,
+                    executionId: approvalExec!.id,
+                    requestingClientLabel: 'Breeze AI',
+                    requestingMachineLabel: null,
+                    actionLabel,
+                    actionToolName: stripMcpPrefix(toolName),
+                    actionArguments: input as Record<string, unknown>,
+                    riskTier,
+                    riskSummary,
+                    status: 'pending',
+                    // The chat session's originating OAuth client is not yet
+                    // tracked on aiSessions; until that lands, the AI-agent
+                    // path can't be a self-loop with the mobile push target.
+                    // (deriveIsRecursive() with a null requestingClientId
+                    // returns false — explicit here for documentation.)
+                    isRecursive: false,
+                    expiresAt,
+                  })
+                  .returning({ id: approvalRequests.id })
             );
-            await dispatchApprovalPushToTokens(tokens, {
-              approvalId: approvalRequestId,
-              actionLabel,
-              requestingClientLabel: 'Breeze AI',
-            });
+            approvalRequestId = approvalRow?.id;
           } catch (err) {
-            console.error('[AI-SDK] Failed to dispatch approval push notification:', err);
+            console.error('[AI-SDK] Failed to create mobile approval_request row:', err);
+            // Non-fatal: SSE approval flow still works for in-app web UI even
+            // without the mobile-readable row. The approve/deny handler simply
+            // won't have an executionId to resolve back to.
           }
-        }
 
-        // Emit approval_required event via session event bus → UI shows Approve/Reject
-        session.eventBus.publish({
-          type: 'approval_required',
-          executionId: approvalExec.id,
-          approvalRequestId,
-          toolName,
-          input,
-          description,
-          deviceContext,
-        });
+          // Best-effort push notification to the user's mobile device(s).
+          if (approvalRequestId) {
+            try {
+              // Token read happens INSIDE the org DB context; the push network
+              // sends run AFTER it closes so we never hold the transaction open
+              // across the round-trip (#1105). dispatchApprovalPushToTokens fans
+              // out across every provider (Expo relay + native APNs).
+              const tokens = await withDbAccessContext(
+                {
+                  scope: 'organization',
+                  orgId: session.orgId,
+                  accessibleOrgIds: [session.orgId],
+                  userId: session.auth.user.id,
+                },
+                () => getUserPushTokens(session.auth.user.id),
+              );
+              await dispatchApprovalPushToTokens(tokens, {
+                approvalId: approvalRequestId,
+                actionLabel,
+                requestingClientLabel: 'Breeze AI',
+              });
+            } catch (err) {
+              console.error('[AI-SDK] Failed to dispatch approval push notification:', err);
+            }
+          }
 
-        // Block until user clicks Approve/Reject, the cycle's shared approval
-        // wait budget (up to 5 min) elapses, or the wait is settled early
-        // (session teardown / new user message / interrupt — #3089).
-        const approvalWait = beginApprovalWait(session);
-        let approved: boolean;
-        try {
+          // Emit approval_required event via session event bus → UI shows Approve/Reject
+          session.eventBus.publish({
+            type: 'approval_required',
+            executionId: approvalExec.id,
+            approvalRequestId,
+            toolName,
+            input,
+            description,
+            deviceContext,
+          });
+
+          // Block until user clicks Approve/Reject, the cycle's shared approval
+          // wait budget (up to 5 min) elapses, or the wait is settled early
+          // (session teardown / new user message / interrupt — #3089).
           approved = await waitForApproval(
             approvalExec.id,
             approvalWait.timeoutMs,
@@ -1141,21 +1218,37 @@ export function createSessionPreToolUse(session: ActiveSession): PreToolUseCallb
           // nothing will ever execute (this legacy bridge has no durable
           // release worker). Guarded on status='pending' so a genuine reject
           // (row already 'rejected') or timeout (waitForApproval already
-          // marked it) is a no-op. Best-effort: the tool error below must
-          // surface regardless.
+          // marked it) is a no-op. The linked mobile approval_requests row is
+          // CAS'd out of 'pending' too — the mobile decide handler
+          // (routes/approvals.ts) only proceeds from 'pending', so this
+          // closes the mobile Approve → stranded-'approved' race at the
+          // source. Best-effort, but a failure here re-opens that race, so it
+          // is captured to Sentry — and the tool error below must surface
+          // regardless.
           try {
             await withDbAccessContext(
               { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
-              () =>
-                db
+              async () => {
+                await db
                   .update(aiToolExecutions)
                   .set({ status: 'rejected', errorMessage: 'Approval wait ended before a decision was made' })
                   .where(and(
                     eq(aiToolExecutions.id, approvalExec!.id),
                     eq(aiToolExecutions.status, 'pending'),
-                  ))
+                  ));
+                if (approvalRequestId) {
+                  await db
+                    .update(approvalRequests)
+                    .set({ status: 'expired' })
+                    .where(and(
+                      eq(approvalRequests.id, approvalRequestId),
+                      eq(approvalRequests.status, 'pending'),
+                    ));
+                }
+              }
             );
           } catch (err) {
+            captureException(err instanceof Error ? err : new Error(String(err)));
             console.error('[AI-SDK] Failed to close out settled approval record:', approvalExec.id, err);
           }
           // Not reachable with a non-null matchedPlanStepIndex today (both

--- a/apps/api/src/services/streamingSessionManager.clientLoop.test.ts
+++ b/apps/api/src/services/streamingSessionManager.clientLoop.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 
-const { queryMock, recordUsageMock, capturedQueryArgs } = vi.hoisted(() => ({
+const { queryMock, recordUsageMock, capturedQueryArgs, settleApprovalWaitsMock } = vi.hoisted(() => ({
   queryMock: vi.fn(),
   recordUsageMock: vi.fn(() => Promise.resolve()),
   capturedQueryArgs: [] as Array<{ prompt: unknown; options: Record<string, unknown> }>,
+  settleApprovalWaitsMock: vi.fn(() => false),
 }));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
@@ -37,6 +38,7 @@ vi.mock('./aiAgentSdkTools', () => ({
 vi.mock('./aiAgentSdk', () => ({
   createSessionPreToolUse: vi.fn(() => vi.fn()),
   createSessionPostToolUse: vi.fn(() => vi.fn()),
+  settleApprovalWaits: settleApprovalWaitsMock,
 }));
 vi.mock('./aiToolOutput', () => ({ redactAiToolOutputText: (s: string) => s }));
 vi.mock('./clientIp', () => ({ getTrustedClientIpOrUndefined: () => undefined }));
@@ -163,5 +165,84 @@ describe('result handling — usage-bearing done + recordExtraUsage', () => {
       type: 'done',
       usage: { inputTokens: 100, outputTokens: 50, costCents: 3 },
     });
+  });
+});
+
+// ============================================
+// #3089 — approval-wait budget lifecycle
+// ============================================
+
+describe('approval-wait budget lifecycle (#3089)', () => {
+  async function createSession(id: string) {
+    const gate = deferred();
+    mockSdkQuery([], gate.promise);
+    const session = await manager.getOrCreate(id, DB_SESSION, AUTH, undefined, 'BASE PROMPT', undefined);
+    return { session, gate };
+  }
+
+  it('initializes the approval-wait fields on a new session', async () => {
+    const { session, gate } = await createSession('sess-wait-init');
+    expect(session.approvalWaitDeadline).toBeNull();
+    expect(session.approvalWaitAbort).toBeNull();
+    expect(session.pendingApprovalWaits).toBe(0);
+    gate.resolve();
+    await session.processorPromise;
+  });
+
+  it('startTurnTimeout resets the shared budget when no wait is in flight', async () => {
+    const { session, gate } = await createSession('sess-wait-reset');
+    session.approvalWaitDeadline = Date.now() + 100_000;
+    session.approvalWaitAbort = new AbortController();
+    session.pendingApprovalWaits = 0;
+
+    manager.startTurnTimeout(session);
+
+    expect(session.approvalWaitDeadline).toBeNull();
+    expect(session.approvalWaitAbort).toBeNull();
+    gate.resolve();
+    await session.processorPromise;
+  });
+
+  it('startTurnTimeout preserves a live budget while a wait is still in flight', async () => {
+    const { session, gate } = await createSession('sess-wait-preserve');
+    const deadline = Date.now() + 100_000;
+    const abort = new AbortController();
+    session.approvalWaitDeadline = deadline;
+    session.approvalWaitAbort = abort;
+    session.pendingApprovalWaits = 1;
+
+    manager.startTurnTimeout(session);
+
+    expect(session.approvalWaitDeadline).toBe(deadline);
+    expect(session.approvalWaitAbort).toBe(abort);
+    gate.resolve();
+    await session.processorPromise;
+  });
+
+  it('startTurnTimeout resets an EXHAUSTED budget even with a wait mid-settle, so later cycles are not poisoned to zero', async () => {
+    const { session, gate } = await createSession('sess-wait-exhausted');
+    session.approvalWaitDeadline = Date.now() - 1_000;
+    session.approvalWaitAbort = new AbortController();
+    session.pendingApprovalWaits = 1;
+
+    manager.startTurnTimeout(session);
+
+    expect(session.approvalWaitDeadline).toBeNull();
+    expect(session.approvalWaitAbort).toBeNull();
+    gate.resolve();
+    await session.processorPromise;
+  });
+
+  it('interrupt() settles in-flight approval waits before interrupting the SDK query', async () => {
+    const { session, gate } = await createSession('sess-wait-interrupt');
+    session.state = 'processing';
+
+    const result = await manager.interrupt('sess-wait-interrupt');
+
+    expect(result.interrupted).toBe(true);
+    expect(settleApprovalWaitsMock).toHaveBeenCalledWith(session);
+    expect(session.query.interrupt).toHaveBeenCalled();
+    gate.resolve();
+    await session.processorPromise;
   });
 });

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -601,15 +601,27 @@ export class StreamingSessionManager {
     // the same point this turn timeout resets, preserving the invariant that
     // a cycle's approval waits (<= 5 min total) always leave headroom for the
     // model to emit its closing message before the 6-min timeout fires.
-    // Guarded: never reset while a wait is actually in flight (shouldn't
-    // happen — waits only run in the tool phase, between assistant messages).
-    if (session.pendingApprovalWaits === 0) {
+    // Guarded: never reset while a wait is actually in flight (waits only run
+    // in the tool phase, between assistant messages) — EXCEPT when the
+    // deadline is already exhausted, where an in-flight wait is settling
+    // within milliseconds anyway and skipping the reset would poison every
+    // later cycle with a permanently zero budget.
+    if (
+      session.pendingApprovalWaits === 0
+      || (session.approvalWaitDeadline ?? Infinity) <= Date.now()
+    ) {
       session.approvalWaitDeadline = null;
       session.approvalWaitAbort = null;
     }
     session.turnTimeoutId = setTimeout(() => {
       if (session.state === 'processing') {
         console.error('[StreamingSessionManager] Turn timeout for session:', session.breezeSessionId);
+        // The timeout can fire while approval waits are still blocked (e.g.
+        // long-running sibling tools delayed the first wait's start past the
+        // headroom window). Settle them so the SDK turn can actually conclude
+        // in the background instead of holding the subprocess for the rest of
+        // the 5-minute wait (#3089).
+        settleApprovalWaits(session);
         session.eventBus.publish({ type: 'error', message: 'AI request timed out. Please try again.' });
         session.eventBus.publish({ type: 'done' });
         session.state = 'idle';

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -24,7 +24,7 @@ import { recordUsageFromSdkResult } from './aiCostTracker';
 import { sanitizeErrorForClient } from './aiAgent';
 import { captureException } from './sentry';
 import { createBreezeMcpServer, BREEZE_MCP_TOOL_NAMES } from './aiAgentSdkTools';
-import { createSessionPreToolUse, createSessionPostToolUse } from './aiAgentSdk';
+import { createSessionPreToolUse, createSessionPostToolUse, settleApprovalWaits } from './aiAgentSdk';
 import type { RequestLike } from './auditEvents';
 import { getTrustedClientIpOrUndefined } from './clientIp';
 import { redactAiToolOutputText, redactSensitiveToolInput } from './aiToolOutput';
@@ -269,6 +269,22 @@ export interface ActiveSession {
   readonly processorPromise: Promise<void>;
   /** Timer for per-turn timeout; cleared when 'result' arrives */
   turnTimeoutId: ReturnType<typeof setTimeout> | null;
+  /**
+   * Epoch-ms deadline SHARED by every approval wait in the current assistant
+   * cycle (#3089) — set by the first wait of the cycle (beginApprovalWait in
+   * aiAgentSdk.ts), reset to null at each message_start via startTurnTimeout.
+   * Guarantees cumulative approval blocking per cycle stays under the turn
+   * timeout so the model can always conclude the turn.
+   */
+  approvalWaitDeadline: number | null;
+  /**
+   * Aborts in-flight approval waits early WITHOUT tearing down the session
+   * (settleApprovalWaits in aiAgentSdk.ts) — fired when a new user message or
+   * an interrupt arrives while the turn is blocked on approvals.
+   */
+  approvalWaitAbort: AbortController | null;
+  /** Count of approval waits currently blocked inside preToolUse. */
+  pendingApprovalWaits: number;
   /** Approval mode for this session (loaded from org's aiBudgets) */
   approvalMode: AiApprovalMode;
   /** Optional MCP allowlist for restricted sessions such as helper chat. */
@@ -411,6 +427,9 @@ export class StreamingSessionManager {
       toolUseIdQueue: [],
       processorPromise: Promise.resolve(),
       turnTimeoutId: null,
+      approvalWaitDeadline: null,
+      approvalWaitAbort: null,
+      pendingApprovalWaits: 0,
       approvalMode,
       allowedTools,
       isPaused: false,
@@ -546,6 +565,11 @@ export class StreamingSessionManager {
     }
 
     try {
+      // Settle any in-flight approval waits first: while a preToolUse approval
+      // wait is blocking an MCP tool handler, query.interrupt() alone cannot
+      // conclude the turn (#3089). The tier-3 intents stay pending_approval
+      // and are still executed by the durable release worker once decided.
+      settleApprovalWaits(session);
       await session.query.interrupt();
       return { interrupted: true };
     } catch (err) {
@@ -573,6 +597,16 @@ export class StreamingSessionManager {
   /** Start the per-turn timeout. Publishes error + done if SDK hangs. */
   startTurnTimeout(session: ActiveSession): void {
     this.clearTurnTimeout(session);
+    // New assistant cycle: reset the shared approval-wait budget (#3089) at
+    // the same point this turn timeout resets, preserving the invariant that
+    // a cycle's approval waits (<= 5 min total) always leave headroom for the
+    // model to emit its closing message before the 6-min timeout fires.
+    // Guarded: never reset while a wait is actually in flight (shouldn't
+    // happen — waits only run in the tool phase, between assistant messages).
+    if (session.pendingApprovalWaits === 0) {
+      session.approvalWaitDeadline = null;
+      session.approvalWaitAbort = null;
+    }
     session.turnTimeoutId = setTimeout(() => {
       if (session.state === 'processing') {
         console.error('[StreamingSessionManager] Turn timeout for session:', session.breezeSessionId);


### PR DESCRIPTION
Closes #3089

## Root cause

`createSessionPreToolUse` blocks each approval-gated tool call inside its MCP tool handler for up to 5 minutes (`waitForIntentDecision` / `waitForApproval`), and the Agent SDK executes sibling tool calls sequentially. Consequences observed in the flagged US-prod sessions:

- A completed sibling tool result was withheld behind a pending `execute_command` approval.
- Two pending approvals stacked their waits to 10 minutes — past the 6-minute `SDK_TURN_TIMEOUT_MS` — so the UI received `error` + `done` first and the model's eventual closing message was published into a turn the client had already ended (sessions ending with raw approval-pending error rows and **no closing assistant message**).
- A user message sent mid-wait bounced off the 409 concurrent-message guard in `routes/ai.ts`, so the assistant was mute while the user typed "i think it got stuck".

## Fix

1. **Shared per-cycle approval-wait budget** (`APPROVAL_WAIT_BUDGET_MS` = 5 min, `beginApprovalWait` in `aiAgentSdk.ts`): all approval waits in one assistant cycle draw from a single budget, so cumulative blocking always ends before the turn timeout and the model gets the tool errors back in time to conclude the turn gracefully. The budget resets at each `message_start` via `startTurnTimeout` — the same point the 6-min turn timeout resets, preserving the headroom invariant.
2. **`settleApprovalWaits()`**: a new user message that hits the concurrent-message guard now settles in-flight approval waits, waits briefly (`waitForTurnToSettle`, 15s) for the turn to conclude, then proceeds normally — the assistant answers instead of 409ing. Tier-3 intents stay `pending_approval` and are **still executed by the durable release worker once an approver decides** (spec §6.1) — no approval capability is lost. The interrupt endpoint settles too, so Stop works while blocked on an approval.
3. **Tier-2 legacy bridge hardening**: a wait that ends without a decision closes out its still-pending `ai_tool_executions` row (guarded on `status='pending'`), so a later Approve click can't flip it to a stranded `approved` that the legacy bridge (which has no durable worker) would never execute.

Not changed: the approval gate itself (nothing executes without approval), the helper/PAM branch, and the tier-3 expiry error message at the `pending_approval` return — that message is #3090's scope and will be fixed separately.

## Test evidence

- New suite `apps/api/src/services/aiAgentSdk.approvalWait.test.ts` (7 tests): full-budget first wait, zero-budget sibling wait returns pending immediately without touching the intent, settle unblocks an in-flight tier-3 wait (intent untouched for the worker), settle closes out a tier-2 pending row, no-op settle, `waitForTurnToSettle` both arms.
- Existing suites green single-fork: `aiAgentSdk.test.ts`, `aiAgentSdk.planMatch.test.ts`, `aiAgentSdk.m365risk.test.ts`, `aiAgentSdkTools.sessionAware.test.ts`, `ai_sessions_actions/crud`, `ai_plans`, `ai.ticket`, `ai.m365session`, `ai_admin`, `ai-flagging` — 200 tests, 0 failures.
- `tsc --noEmit` clean on apps/api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)