### PR TITLE
fix(ai): run device-bound chat tools under the device's org, not the login org (#3087)

### DIFF
--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -617,6 +617,9 @@ aiRoutes.post(
         maxTurns: dbSession.maxTurns,
         turnCount: dbSession.turnCount,
         systemPrompt: dbSession.systemPrompt,
+        // Device-bound sessions narrow tool execution to the device's org
+        // (ai_sessions.org_id), not the login org (#3087).
+        deviceId: dbSession.deviceId,
       },
       auth,
       c,

--- a/apps/api/src/routes/ai_sessions_crud.test.ts
+++ b/apps/api/src/routes/ai_sessions_crud.test.ts
@@ -355,4 +355,62 @@ describe('AI routes', () => {
     });
   });
 
+  // ============================================
+  // POST /sessions/:id/messages
+  // ============================================
+  describe('POST /ai/sessions/:id/messages', () => {
+    it('passes the bound device id from the DB session into streamingSessionManager.getOrCreate (#3087 route wiring)', async () => {
+      // This is the seam that arms the #3087 fix: getOrCreate uses `deviceId`
+      // to decide whether to narrow tool execution to the device's org. If
+      // this route ever stops forwarding it, the whole narrowing mechanism in
+      // streamingSessionManager goes dark even though its unit tests stay green.
+      vi.mocked(runPreFlightChecks).mockResolvedValueOnce({
+        ok: true,
+        session: {
+          id: SESSION_ID,
+          orgId: ORG_ID,
+          sdkSessionId: null,
+          model: 'claude-sonnet-4-5-20250929',
+          maxTurns: 50,
+          turnCount: 0,
+          systemPrompt: null,
+          title: 'Existing title', // truthy — skips the auto-title-generation branch
+          deviceId: 'device-42',
+        } as any,
+        sanitizedContent: 'hello there',
+        systemPrompt: 'SYSTEM PROMPT',
+        maxBudgetUsd: undefined,
+      });
+
+      const fakeActiveSession = {
+        state: 'ready',
+        eventBus: {
+          subscribe: vi.fn(() => (async function* () {})()),
+          unsubscribe: vi.fn(),
+        },
+        inputController: { pushMessage: vi.fn() },
+      };
+      vi.mocked(streamingSessionManager.getOrCreate).mockResolvedValueOnce(fakeActiveSession as any);
+      vi.mocked(streamingSessionManager.tryTransitionToProcessing).mockReturnValueOnce(true);
+
+      const valuesSpy = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.insert).mockReturnValue({ values: valuesSpy } as any);
+
+      await app.request(`/ai/sessions/${SESSION_ID}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ content: 'hello there' }),
+      });
+
+      expect(streamingSessionManager.getOrCreate).toHaveBeenCalledWith(
+        SESSION_ID,
+        expect.objectContaining({ deviceId: 'device-42' }),
+        expect.anything(),
+        expect.anything(),
+        'SYSTEM PROMPT',
+        undefined,
+      );
+    });
+  });
+
 });

--- a/apps/api/src/services/actionIntents/revalidateRelease.ts
+++ b/apps/api/src/services/actionIntents/revalidateRelease.ts
@@ -20,12 +20,15 @@ import { canonicalizeArguments, computeArgumentDigest } from './canonicalize';
  *
  * Returns the freshly-rebuilt actor `auth` on success. Callers decide how to
  * EXECUTE: the worker executes under this rebuilt context; the inline chat path
- * executes under its live `session.auth` (which alone carries the session-aware
- * M365/Google connection context) — but only AFTER this returns ok, i.e. only
- * once the requester's CURRENT authorization has been re-proven. The rebuilt
- * `auth` and `session.auth` describe the same user + org (accessibleOrgIds ===
- * [intent.orgId] === session.orgId), so they are interchangeable for tenant
- * scope; the difference is only that this one reflects live DB state.
+ * executes under its live `session.toolAuth` (which alone carries the
+ * session-aware M365/Google connection context — and, for device-bound
+ * sessions since #3087, is narrowed to the session/device org, whereas
+ * `session.auth` stays the raw login context) — but only AFTER this returns
+ * ok, i.e. only once the requester's CURRENT authorization has been
+ * re-proven. The rebuilt `auth` and `session.toolAuth` describe the same
+ * user + org (accessibleOrgIds === [intent.orgId] === session.orgId), so
+ * they are interchangeable for tenant scope; the difference is only that
+ * this one reflects live DB state.
  *
  * Every failure carries the same `errorCode` the worker has always CASed
  * `executing -> failed` with, so audit/metrics semantics are unchanged.

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -1514,6 +1514,31 @@ describe('createSessionPostToolUse', () => {
     expect(setCall).toBeDefined();
     expect((setCall![0] as any).delegantToolCallId).toBe('tc-456');
   });
+
+  it('attributes the tool-use audit event to the session org, not the (possibly null) login auth.orgId — #3087 regression guard', async () => {
+    // Partner-scope logins carry auth.orgId === null. Before #3087 the audit
+    // write used auth.orgId directly, which left device-bound tool executions
+    // by partner techs with no org attribution on the audit trail.
+    const session = makeActiveSession({
+      orgId: 'session-org',
+      auth: makeAuth({ orgId: null, scope: 'partner' }),
+      auditSnapshot: { requestId: 'req-1' } as any,
+    });
+    const callback = createSessionPostToolUse(session);
+
+    await callback('query_devices', { marker: 'x' }, JSON.stringify({ status: 'completed' }), false, 5);
+
+    // requestLikeFromSnapshot is mocked as a bare vi.fn() in this file (returns
+    // undefined) — assert it directly rather than expect.anything(), which
+    // rejects undefined.
+    expect(mockWriteAuditEvent).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        orgId: 'session-org',
+        action: 'ai.tool.query_devices',
+      }),
+    );
+  });
 });
 
 // ============================================

--- a/apps/api/src/services/aiAgentSdk.test.ts
+++ b/apps/api/src/services/aiAgentSdk.test.ts
@@ -164,7 +164,7 @@ vi.mock('./sentry', () => ({
 
 type TestAuth = {
   user: { id: string; email: string; name: string };
-  orgId: string;
+  orgId: string | null; // null for partner-scope logins — the real AuthContext.orgId type
   scope: string;
   accessibleOrgIds: string[];
   canAccessOrg: (orgId: string) => boolean;

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -1382,7 +1382,9 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
     const safeOutput = compactToolResultForChat(toolName, output);
     const parsedOutput = safeParseJson(safeOutput);
     const sessionId = session.breezeSessionId;
-    const orgId = session.auth.orgId ?? undefined;
+    // Canonical session org (always set) — `auth.orgId` is null for partner-
+    // scope logins, which left tool audit rows without an org attribution.
+    const orgId = session.orgId;
     const guardrailCheck = checkGuardrails(toolName, input);
 
     // Script-builder "apply" tools deliver their payload (code / metadata) to

--- a/apps/api/src/services/aiAgentSdkTools.proposeActionPlan.test.ts
+++ b/apps/api/src/services/aiAgentSdkTools.proposeActionPlan.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * #3087 follow-up (code-review finding, IMPORTANT): `propose_action_plan`
+ * guarded on `session.auth.orgId`, which is null for partner-scope logins —
+ * exactly the population #3087 narrows tool execution for via
+ * `session.toolAuth`/`session.orgId`. That guard hard-failed every plan
+ * proposal ("Action plans require an organization context") for a
+ * partner-scope tech running a device-bound session in hybrid_plan/
+ * action_plan approval mode, even though `session.orgId` (the canonical,
+ * always-set session org) was available the whole time. Every other DB write
+ * in this handler's file already keys off `session.orgId` — this tool was
+ * the odd one out.
+ *
+ * Covers the fix in aiAgentSdkTools.ts's `propose_action_plan` handler:
+ * `const orgId = session.orgId` (not `session.auth.orgId`).
+ */
+
+const { dbInsertMock, dbUpdateMock, withDbAccessContextMock, capturedDbCtx } = vi.hoisted(() => {
+  const capturedDbCtx: unknown[] = [];
+  return {
+    dbInsertMock: vi.fn(),
+    dbUpdateMock: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+    withDbAccessContextMock: vi.fn((ctx: unknown, fn: () => unknown) => {
+      capturedDbCtx.push(ctx);
+      return fn();
+    }),
+    capturedDbCtx,
+  };
+});
+
+vi.mock('../db', () => ({
+  db: { insert: dbInsertMock, update: dbUpdateMock },
+  withDbAccessContext: withDbAccessContextMock,
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+// Auto-approve so the handler runs its full success path (plan row insert +
+// 'executing' status update), rather than stopping at the intermediate
+// "awaiting approval" state — that keeps the assertions below about the
+// FINAL result content meaningful.
+vi.mock('./aiAgent', () => ({ waitForPlanApproval: vi.fn(() => Promise.resolve(true)) }));
+
+vi.mock('./aiToolsM365', () => ({
+  m365LookupUserHandler: vi.fn(),
+  m365RecentSigninsHandler: vi.fn(),
+  m365ListGroupMembershipsHandler: vi.fn(),
+  m365DisableUserHandler: vi.fn(),
+  m365ResetPasswordHandler: vi.fn(),
+  registerM365Tools: vi.fn(),
+}));
+
+vi.mock('./aiToolsGoogle', () => ({
+  googleLookupUserHandler: vi.fn(),
+  googleResetPasswordHandler: vi.fn(),
+  googleSuspendUserHandler: vi.fn(),
+  googleRestoreUserHandler: vi.fn(),
+  googleSignOutHandler: vi.fn(),
+  googleSetForwardingHandler: vi.fn(),
+  googleDisableForwardingHandler: vi.fn(),
+  googleSetVacationHandler: vi.fn(),
+  googleUpdateUserHandler: vi.fn(),
+  googleShareCalendarHandler: vi.fn(),
+  googleOffboardUserHandler: vi.fn(),
+  googleWipeMobileDeviceHandler: vi.fn(),
+  googleSecurityDriftHandler: vi.fn(),
+  googleEmailReportHandler: vi.fn(),
+  googleListUserGroupsHandler: vi.fn(),
+  googleAddToGroupHandler: vi.fn(),
+  googleRemoveFromGroupHandler: vi.fn(),
+  googleMoveOuHandler: vi.fn(),
+  googleRenameUserHandler: vi.fn(),
+  googleResetTwoSvHandler: vi.fn(),
+  googleAddMailDelegateHandler: vi.fn(),
+  googleRemoveMailDelegateHandler: vi.fn(),
+  googleListLicensesHandler: vi.fn(),
+  googleAssignLicenseHandler: vi.fn(),
+  googleRemoveLicenseHandler: vi.fn(),
+}));
+
+import { createBreezeMcpServer } from './aiAgentSdkTools';
+import type { ActiveSession } from './streamingSessionManager';
+import type { AuthContext } from '../middleware/auth';
+
+/** Partner-scope login: orgId is null (partner tokens never carry one). */
+const partnerAuth = {
+  scope: 'partner',
+  orgId: null,
+  partnerId: 'partner-1',
+  accessibleOrgIds: ['session-org', 'sibling-org'],
+  user: { id: 'user-1', email: 'tech@msp.example' },
+} as unknown as AuthContext;
+
+function getRegisteredHandler(name: string) {
+  const session = {
+    breezeSessionId: 'sess-123',
+    orgId: 'session-org', // canonical session org — always set, unlike auth.orgId
+    auth: partnerAuth,
+    toolAuth: partnerAuth,
+    approvalMode: 'action_plan',
+    activePlanId: null,
+    approvedPlanSteps: new Map(),
+    currentPlanStepIndex: 0,
+    eventBus: { publish: vi.fn() },
+  } as unknown as ActiveSession;
+
+  const mcpServer = createBreezeMcpServer(
+    () => session.toolAuth,
+    undefined,
+    undefined,
+    () => session,
+  );
+  // The SDK's tool() handlers are registered on the real (unmocked)
+  // @modelcontextprotocol/sdk McpServer instance; `_registeredTools` is its
+  // internal registry (see node_modules/@modelcontextprotocol/sdk/dist/esm/
+  // server/mcp.js) — the only place the callback is reachable outside the
+  // wire protocol.
+  const registered = (mcpServer.instance as unknown as {
+    _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<unknown> }>;
+  })._registeredTools[name];
+  if (!registered) throw new Error(`tool '${name}' not registered`);
+  return { handler: registered.handler, session };
+}
+
+describe('propose_action_plan — org resolution (#3087 follow-up)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedDbCtx.length = 0;
+  });
+
+  it('creates the plan under session.orgId for a partner-scope login (auth.orgId is null), not a hard failure', async () => {
+    const returning = vi.fn().mockResolvedValue([{ id: 'plan-1' }]);
+    const values = vi.fn().mockReturnValue({ returning });
+    dbInsertMock.mockReturnValue({ values });
+
+    const { handler, session } = getRegisteredHandler('propose_action_plan');
+
+    const result = await handler(
+      {
+        title: 'Patch and reboot',
+        steps: [{ toolName: 'query_devices', input: {}, reasoning: 'find target devices' }],
+      },
+      {},
+    ) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+    // Must NOT be the "Action plans require an organization context" refusal
+    // that fired when the guard read `session.auth.orgId` (null here).
+    expect(result.isError).not.toBe(true);
+    expect(JSON.stringify(result.content)).not.toContain('organization context');
+
+    // The plan row is inserted under the canonical session org.
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'sess-123',
+      orgId: 'session-org',
+      status: 'pending',
+    }));
+
+    // The RLS DB access context for the insert is scoped to the session org too.
+    expect(capturedDbCtx).toContainEqual(expect.objectContaining({
+      scope: 'organization',
+      orgId: 'session-org',
+      accessibleOrgIds: ['session-org'],
+    }));
+
+    // waitForPlanApproval is mocked to auto-approve, so the handler runs
+    // through to its final "approved" result — proving the whole plan
+    // lifecycle (not just the initial insert) works under a partner login.
+    expect(JSON.parse(result.content[0]!.text)).toMatchObject({ result: 'approved', planId: 'plan-1' });
+    expect(session.activePlanId).toBe('plan-1');
+  });
+});

--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -2037,11 +2037,12 @@ export function createBreezeMcpServer(
           status: 'pending' as const,
         }));
 
-        // Guard: partner-scoped users may not have orgId
-        const orgId = session.auth.orgId;
-        if (!orgId) {
-          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Action plans require an organization context' }) }], isError: true };
-        }
+        // Canonical session org (always set) — `session.auth.orgId` is null for
+        // partner-scope logins, which hard-failed every plan proposal for
+        // exactly the population #3087 narrows tool execution for. Every other
+        // DB write in this handler already keys off session.orgId (see
+        // aiAgentSdk.ts's withDbAccessContext calls).
+        const orgId = session.orgId;
 
         // Insert plan record
         let planId: string;

--- a/apps/api/src/services/streamingSessionManager.clientLoop.test.ts
+++ b/apps/api/src/services/streamingSessionManager.clientLoop.test.ts
@@ -166,6 +166,37 @@ describe('result handling — usage-bearing done + recordExtraUsage', () => {
       usage: { inputTokens: 100, outputTokens: 50, costCents: 3 },
     });
   });
+
+  it('records usage against the session org for a partner-scope login (auth.orgId is null) — #3087 regression guard', async () => {
+    // Partner tokens never carry an orgId. Before #3087, the result handler
+    // used `auth.orgId` for usage recording, which silently skipped it
+    // entirely for partner-scope logins. It must use the canonical
+    // session.orgId (dbSession.orgId) instead.
+    const gate = deferred();
+    mockSdkQuery([RESULT_MSG], gate.promise);
+
+    const PARTNER_AUTH = {
+      orgId: null,
+      scope: 'partner',
+      partnerId: '1a1a1a1a-1111-4222-8333-444455556666',
+      accessibleOrgIds: [ORG],
+      user: { id: 'beefbeef-1111-4222-8333-444455556666', email: 'partner.tech@contoso.com' },
+    } as unknown as AuthContext;
+
+    const session = await manager.getOrCreate(
+      'sess-partner-usage', DB_SESSION, PARTNER_AUTH, undefined, 'BASE PROMPT', undefined,
+      undefined, undefined, { injectApprovalModeInstructions: false },
+    );
+
+    gate.resolve();
+    await session.processorPromise;
+
+    expect(recordUsageMock).toHaveBeenCalledWith(
+      'sess-partner-usage',
+      ORG, // session.orgId (dbSession.orgId) — NOT auth.orgId, which is null here
+      expect.objectContaining({ total_cost_usd: 0.03 }),
+    );
+  });
 });
 
 // ============================================

--- a/apps/api/src/services/streamingSessionManager.deviceBoundAuth.test.ts
+++ b/apps/api/src/services/streamingSessionManager.deviceBoundAuth.test.ts
@@ -1,0 +1,275 @@
+/**
+ * #3087 — Device-bound chat sessions must run org-scoped tools under the
+ * DEVICE's org (ai_sessions.org_id), not the login user's org.
+ *
+ * Covers:
+ * - buildDeviceBoundSessionAuth: org-axis narrowing, scope/partner-axis
+ *   preservation (#2822 guard), site-closure preservation, defensive throw.
+ * - getOrCreate wiring: the getAuth() thunk handed to createBreezeMcpServer
+ *   (i.e. what every MCP tool handler sees) is narrowed for device-bound
+ *   sessions — on creation AND on the per-request auth refresh — and left
+ *   untouched for non-device sessions. `session.auth` stays RAW so RBAC
+ *   (checkToolPermission), rate limits, and audit attribution keep resolving
+ *   the login identity/role (a dual-membership partner tech must not flip to
+ *   an org role just because the session is device-bound).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { eq } from 'drizzle-orm';
+
+const { queryMock, capturedMcpArgs } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  capturedMcpArgs: [] as Array<{ getAuth: () => unknown }>,
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
+
+vi.mock('../db', () => ({
+  db: {
+    // Only DB read on this path: the aiBudgets approvalMode lookup.
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([{ approvalMode: 'per_step' }])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+    insert: vi.fn(() => ({ values: vi.fn(() => Promise.resolve()) })),
+  },
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('./aiCostTracker', () => ({ recordUsageFromSdkResult: vi.fn(() => Promise.resolve()) }));
+vi.mock('./aiAgent', () => ({ sanitizeErrorForClient: (e: unknown) => String(e) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('./aiAgentSdkTools', () => ({
+  createBreezeMcpServer: vi.fn((getAuth: () => unknown) => {
+    capturedMcpArgs.push({ getAuth });
+    return { type: 'sdk' };
+  }),
+  BREEZE_MCP_TOOL_NAMES: ['mcp__breeze__query_devices'],
+}));
+vi.mock('./aiAgentSdk', () => ({
+  createSessionPreToolUse: vi.fn(() => vi.fn()),
+  createSessionPostToolUse: vi.fn(() => vi.fn()),
+}));
+vi.mock('./aiToolOutput', () => ({
+  redactAiToolOutputText: (s: string) => s,
+  redactSensitiveToolInput: (s: unknown) => s,
+}));
+vi.mock('./clientIp', () => ({ getTrustedClientIpOrUndefined: () => undefined }));
+
+import { StreamingSessionManager, buildDeviceBoundSessionAuth } from './streamingSessionManager';
+import { buildOrgAccessClosures, dbAccessContextFromAuth } from '../middleware/auth';
+import type { AuthContext } from '../middleware/auth';
+import { devices } from '../db/schema';
+
+const LOGIN_ORG = 'aaaaaaaa-1111-4222-8333-444455556666';
+const DEVICE_ORG = 'bbbbbbbb-1111-4222-8333-444455556666';
+const PARTNER_ID = 'cccccccc-1111-4222-8333-444455556666';
+const DEVICE_ID = 'dddddddd-1111-4222-8333-444455556666';
+const USER_ID = 'eeeeeeee-1111-4222-8333-444455556666';
+
+/**
+ * Partner-scope login: orgId is null (partner tokens never carry one) and
+ * accessibleOrgIds lists every org under the partner — LOGIN_ORG first, which
+ * is exactly what the `getOrgId(auth)` helpers fall back to (the bug).
+ */
+function makePartnerAuth(): AuthContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    partnerId: PARTNER_ID,
+    accessibleOrgIds: [LOGIN_ORG, DEVICE_ORG],
+    ...buildOrgAccessClosures([LOGIN_ORG, DEVICE_ORG]),
+    user: { id: USER_ID, email: 'tech@msp.example' },
+  } as unknown as AuthContext;
+}
+
+const DB_SESSION = {
+  orgId: DEVICE_ORG,
+  sdkSessionId: null,
+  model: 'claude-sonnet-4-5-20250929',
+  maxTurns: 50,
+  turnCount: 0,
+  systemPrompt: null,
+};
+
+describe('buildDeviceBoundSessionAuth', () => {
+  it('narrows a partner-scope login to the device org (sibling org under the same partner)', () => {
+    const auth = makePartnerAuth();
+    const narrowed = buildDeviceBoundSessionAuth(auth, DEVICE_ORG);
+
+    // Org axis pinned to the DEVICE's org — org-scoped tools (manage_patches,
+    // search_logs, …) now resolve the session org, never accessibleOrgIds[0].
+    expect(narrowed.orgId).toBe(DEVICE_ORG);
+    expect(narrowed.accessibleOrgIds).toEqual([DEVICE_ORG]);
+    expect(narrowed.canAccessOrg(DEVICE_ORG)).toBe(true);
+    expect(narrowed.canAccessOrg(LOGIN_ORG)).toBe(false);
+    expect(narrowed.orgCondition(devices.orgId)).toEqual(eq(devices.orgId, DEVICE_ORG));
+
+    // Partner axis preserved (#2822): scope stays 'partner' so the derived RLS
+    // context keeps accessiblePartnerIds — partner-wide config tables (scripts,
+    // alert templates, update rings) must NOT black out in device-bound chat.
+    expect(narrowed.scope).toBe('partner');
+    expect(narrowed.partnerId).toBe(PARTNER_ID);
+    const dbCtx = dbAccessContextFromAuth(narrowed);
+    expect(dbCtx.accessiblePartnerIds).toEqual([PARTNER_ID]);
+    expect(dbCtx.currentPartnerId).toBe(PARTNER_ID);
+    expect(dbCtx.accessibleOrgIds).toEqual([DEVICE_ORG]);
+    expect(dbCtx.orgId).toBe(DEVICE_ORG);
+    expect(dbCtx.userId).toBe(USER_ID);
+  });
+
+  it('preserves site restrictions and identity fields (narrows, never widens)', () => {
+    const canAccessSite = vi.fn(() => false);
+    const auth = {
+      ...makePartnerAuth(),
+      allowedSiteIds: ['site-1'],
+      canAccessSite,
+    } as unknown as AuthContext;
+
+    const narrowed = buildDeviceBoundSessionAuth(auth, DEVICE_ORG);
+
+    expect(narrowed.allowedSiteIds).toEqual(['site-1']);
+    expect(narrowed.canAccessSite).toBe(canAccessSite);
+    expect(narrowed.user).toBe(auth.user);
+  });
+
+  it('returns the same reference when the auth is already pinned to the session org', () => {
+    const auth = {
+      scope: 'organization',
+      orgId: DEVICE_ORG,
+      partnerId: PARTNER_ID,
+      accessibleOrgIds: [DEVICE_ORG],
+      ...buildOrgAccessClosures([DEVICE_ORG]),
+      user: { id: USER_ID },
+    } as unknown as AuthContext;
+
+    expect(buildDeviceBoundSessionAuth(auth, DEVICE_ORG)).toBe(auth);
+  });
+
+  // Note: this pins query TARGETING for tool helpers (`getOrgId(auth)` now
+  // resolves the device org); the RLS layer still serializes system scope as
+  // unrestricted ('*'), which is fine — system scope is not tenant-bounded.
+  it('narrows a system-scope auth (unrestricted) to the session org while keeping system scope', () => {
+    const auth = {
+      scope: 'system',
+      orgId: null,
+      partnerId: null,
+      accessibleOrgIds: null,
+      ...buildOrgAccessClosures(null),
+      user: { id: USER_ID },
+    } as unknown as AuthContext;
+
+    const narrowed = buildDeviceBoundSessionAuth(auth, DEVICE_ORG);
+    expect(narrowed.scope).toBe('system');
+    expect(narrowed.orgId).toBe(DEVICE_ORG);
+    expect(narrowed.accessibleOrgIds).toEqual([DEVICE_ORG]);
+  });
+
+  it('throws (fails loudly) when the caller cannot access the session org', () => {
+    const auth = {
+      scope: 'organization',
+      orgId: LOGIN_ORG,
+      partnerId: PARTNER_ID,
+      accessibleOrgIds: [LOGIN_ORG],
+      ...buildOrgAccessClosures([LOGIN_ORG]),
+      user: { id: USER_ID },
+    } as unknown as AuthContext;
+
+    expect(() => buildDeviceBoundSessionAuth(auth, DEVICE_ORG)).toThrow(
+      /not accessible/,
+    );
+  });
+});
+
+describe('getOrCreate — device-bound sessions narrow the tool-facing auth', () => {
+  let manager: StreamingSessionManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedMcpArgs.length = 0;
+    queryMock.mockImplementation(() => ({
+      // Never-yielding stream: the background processor just parks.
+      async *[Symbol.asyncIterator]() {
+        await new Promise(() => undefined);
+      },
+      interrupt: vi.fn(),
+      close: vi.fn(),
+    }));
+    manager = new StreamingSessionManager();
+  });
+
+  afterEach(() => {
+    manager.shutdown();
+  });
+
+  it('hands MCP tool handlers a device-org-pinned auth for a device-bound session', async () => {
+    const rawAuth = makePartnerAuth();
+    const session = await manager.getOrCreate(
+      'sess-device-bound',
+      { ...DB_SESSION, deviceId: DEVICE_ID },
+      rawAuth,
+      undefined,
+      'PROMPT',
+      undefined,
+    );
+
+    expect(session.deviceId).toBe(DEVICE_ID);
+    const toolAuth = capturedMcpArgs[0]!.getAuth() as AuthContext;
+    expect(toolAuth.orgId).toBe(DEVICE_ORG);
+    expect(toolAuth.accessibleOrgIds).toEqual([DEVICE_ORG]);
+    expect(toolAuth.scope).toBe('partner');
+    expect(toolAuth.partnerId).toBe(PARTNER_ID);
+    // The getOrgId(auth) fallback that mis-scoped tools (accessibleOrgIds[0])
+    // now resolves the device org either way.
+    expect(toolAuth.orgId ?? toolAuth.accessibleOrgIds?.[0]).toBe(DEVICE_ORG);
+    // RBAC / rate limits / audit still see the RAW login auth — narrowing must
+    // not flip a dual-membership tech from their partner role to an org role.
+    expect(session.auth).toBe(rawAuth);
+    expect(session.toolAuth).not.toBe(rawAuth);
+  });
+
+  it('re-narrows the refreshed auth on follow-up messages (never reverts to login scope)', async () => {
+    await manager.getOrCreate(
+      'sess-refresh',
+      { ...DB_SESSION, deviceId: DEVICE_ID },
+      makePartnerAuth(),
+      undefined,
+      'PROMPT',
+      undefined,
+    );
+
+    // Second message on the same in-memory session with a fresh request auth.
+    await manager.getOrCreate(
+      'sess-refresh',
+      { ...DB_SESSION, deviceId: DEVICE_ID },
+      makePartnerAuth(),
+      undefined,
+      'PROMPT',
+      undefined,
+    );
+
+    const toolAuth = capturedMcpArgs[0]!.getAuth() as AuthContext;
+    expect(toolAuth.orgId).toBe(DEVICE_ORG);
+    expect(toolAuth.accessibleOrgIds).toEqual([DEVICE_ORG]);
+  });
+
+  it('leaves non-device sessions untouched (partner techs keep fleet-wide reach in general chat)', async () => {
+    const auth = makePartnerAuth();
+    const session = await manager.getOrCreate(
+      'sess-general',
+      { ...DB_SESSION, deviceId: null },
+      auth,
+      undefined,
+      'PROMPT',
+      undefined,
+    );
+
+    expect(session.deviceId).toBeNull();
+    expect(capturedMcpArgs[0]!.getAuth()).toBe(auth);
+    expect(session.toolAuth).toBe(auth);
+  });
+});

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -18,6 +18,7 @@ import { db, withDbAccessContext, runOutsideDbContext } from '../db';
 import { aiSessions, aiMessages, aiBudgets } from '../db/schema';
 import { eq, and } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
+import { buildOrgAccessClosures } from '../middleware/auth';
 import type { AiStreamEvent, AiApprovalMode } from '@breeze/shared/types/ai';
 import { AsyncEventQueue } from '../utils/asyncQueue';
 import { recordUsageFromSdkResult, calculateCostCents } from './aiCostTracker';
@@ -291,6 +292,13 @@ export interface ActiveSession {
    */
   readonly orgId: string;
   /**
+   * Bound device ID from the aiSessions DB row (null when the session is not
+   * device-bound). When set, `toolAuth` is narrowed to the session org via
+   * `buildDeviceBoundSessionAuth` so org-scoped tools query the DEVICE's org,
+   * not the login org (#3087).
+   */
+  readonly deviceId: string | null;
+  /**
    * Model id this session runs with (from the aiSessions row). Used to price
    * tokens for cost tracking when the SDK fails to report total_cost_usd.
    */
@@ -303,7 +311,20 @@ export interface ActiveSession {
   state: SessionState;
   lastActivityAt: number;
   readonly createdAt: number;
+  /**
+   * RAW login AuthContext from the latest request. Used for actor identity,
+   * RBAC (`checkToolPermission` resolves the login role from it — a partner
+   * tech keeps their partner role, matching the rest of the API), rate limits,
+   * and audit attribution. NOT for tool queries — see `toolAuth`.
+   */
   auth: AuthContext;
+  /**
+   * Effective AuthContext for TOOL EXECUTION (MCP handlers + their RLS DB
+   * context). For device-bound sessions this is `auth` narrowed to the
+   * session (device) org via `buildDeviceBoundSessionAuth` (#3087); otherwise
+   * it is `auth` itself. Refreshed alongside `auth` on every request.
+   */
+  toolAuth: AuthContext;
   /** Immutable audit data extracted from the latest request (avoids holding stale Hono context) */
   auditSnapshot: AuditSnapshot;
   mcpServer: McpSdkServerConfigWithInstance;
@@ -365,6 +386,51 @@ export interface ActiveSession {
   recordExtraUsage?: (usage: { inputTokens: number; outputTokens: number; costCents: number }) => Promise<void>;
 }
 
+/**
+ * Narrow a caller's AuthContext to a device-bound session's org (#3087).
+ *
+ * `ai_sessions.org_id` is anchored to the bound DEVICE's org at creation
+ * (services/aiAgent.ts createSession — gated on `auth.canAccessOrg` +
+ * `auth.canAccessSite`), but tool execution historically ran under the raw
+ * login AuthContext. For a partner-scope tech whose login org differs from the
+ * device's org, org-scoped tools (`getOrgId(auth)` → `accessibleOrgIds[0]`,
+ * `auth.orgCondition(...)` → whole partner) silently queried the WRONG org —
+ * e.g. `manage_patches` returned a sibling org's patches and `search_logs`
+ * returned empty for the device's own logs.
+ *
+ * The returned context pins the org axis to the session org:
+ * - `orgId` / `accessibleOrgIds` = the session (device) org only, with matching
+ *   `orgCondition` / `canAccessOrg` closures from `buildOrgAccessClosures`.
+ * - `scope` and `partnerId` are PRESERVED — collapsing a partner scope to
+ *   'organization' would drop `accessiblePartnerIds` from the derived RLS
+ *   context and black out partner-axis tables (scripts, alert templates,
+ *   update rings — the #2822 failure mode). Partner-wide config rows apply to
+ *   the device's org and must stay readable.
+ * - Site restrictions (`allowedSiteIds` / `canAccessSite`), `helperDeviceId`,
+ *   principal/user/token are preserved via spread — this narrows, never widens.
+ *
+ * Defensive: throws if the caller cannot access the session org. Unreachable
+ * in practice (`getSession` pre-filters by `auth.orgCondition`), but if auth
+ * ever regresses we must fail loudly rather than run tools cross-org.
+ */
+export function buildDeviceBoundSessionAuth(auth: AuthContext, sessionOrgId: string): AuthContext {
+  if (!auth.canAccessOrg(sessionOrgId)) {
+    throw new Error('Device-bound AI session org is not accessible to the caller');
+  }
+  const alreadyPinned =
+    auth.orgId === sessionOrgId &&
+    auth.accessibleOrgIds?.length === 1 &&
+    auth.accessibleOrgIds[0] === sessionOrgId;
+  if (alreadyPinned) return auth;
+
+  return {
+    ...auth,
+    orgId: sessionOrgId,
+    accessibleOrgIds: [sessionOrgId],
+    ...buildOrgAccessClosures([sessionOrgId]),
+  };
+}
+
 // ============================================
 // StreamingSessionManager (singleton)
 // ============================================
@@ -405,6 +471,13 @@ export class StreamingSessionManager {
       maxTurns: number;
       turnCount: number;
       systemPrompt: string | null;
+      /**
+       * Bound device from the aiSessions row. When set, the session's
+       * effective auth is narrowed to the session org (#3087). Callers whose
+       * middleware already pins the auth to one org (helper chat, client AI)
+       * may omit it — narrowing would be a no-op there.
+       */
+      deviceId?: string | null;
     },
     auth: AuthContext,
     requestContext: RequestLike | undefined,
@@ -426,8 +499,13 @@ export class StreamingSessionManager {
 
     const existing = this.sessions.get(breezeSessionId);
     if (existing && existing.state !== 'closed') {
-      // Update per-request context
+      // Update per-request context. Device-bound sessions re-narrow the fresh
+      // request auth to the session org every time (#3087) — `toolAuth` must
+      // never revert to the raw login scope on a follow-up message.
       existing.auth = auth;
+      existing.toolAuth = existing.deviceId
+        ? buildDeviceBoundSessionAuth(auth, existing.orgId)
+        : auth;
       existing.auditSnapshot = snapshot;
       existing.allowedTools = allowedTools;
       existing.lastActivityAt = Date.now();
@@ -459,12 +537,20 @@ export class StreamingSessionManager {
       console.error('[StreamingSessionManager] Failed to load approval mode, defaulting to per_step:', err);
     }
 
+    // Device-bound sessions execute tools under the DEVICE's org, not the
+    // login org (#3087). `toolAuth` (MCP tool handlers + their RLS context)
+    // is narrowed to the session org; `auth` stays raw so RBAC, rate limits,
+    // and audit attribution keep resolving the login identity/role.
+    const deviceId = dbSession.deviceId ?? null;
+    const toolAuth = deviceId ? buildDeviceBoundSessionAuth(auth, dbSession.orgId) : auth;
+
     // Build partial session object so callbacks can reference it.
     // query and processorPromise are filled in after creation.
     const now = Date.now();
     const session: ActiveSession = {
       breezeSessionId,
       orgId: dbSession.orgId,
+      deviceId,
       model: dbSession.model,
       sdkSessionId: dbSession.sdkSessionId,
       query: null as unknown as Query, // set below
@@ -475,6 +561,7 @@ export class StreamingSessionManager {
       lastActivityAt: now,
       createdAt: now,
       auth,
+      toolAuth,
       auditSnapshot: snapshot,
       mcpServer: null as unknown as McpSdkServerConfigWithInstance, // set below
       mcpPrefix: MCP_PREFIX, // updated below if custom factory
@@ -503,11 +590,11 @@ export class StreamingSessionManager {
     let mcpServer: McpSdkServerConfigWithInstance;
     let mcpServerName = 'breeze';
     if (mcpServerFactory) {
-      const custom = mcpServerFactory(() => session.auth, preToolUse, postToolUse, () => session);
+      const custom = mcpServerFactory(() => session.toolAuth, preToolUse, postToolUse, () => session);
       mcpServer = custom.server;
       mcpServerName = custom.name;
     } else {
-      mcpServer = createBreezeMcpServer(() => session.auth, preToolUse, postToolUse, () => session);
+      mcpServer = createBreezeMcpServer(() => session.toolAuth, preToolUse, postToolUse, () => session);
     }
     session.mcpServer = mcpServer;
     session.mcpPrefix = `mcp__${mcpServerName}__`;

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -501,10 +501,14 @@ export class StreamingSessionManager {
     if (existing && existing.state !== 'closed') {
       // Update per-request context. Device-bound sessions re-narrow the fresh
       // request auth to the session org every time (#3087) — `toolAuth` must
-      // never revert to the raw login scope on a follow-up message.
+      // never revert to the raw login scope on a follow-up message. Narrow
+      // against the freshly-loaded `dbSession.orgId`, not the possibly-stale
+      // `existing.orgId` snapshot captured at session creation — this is the
+      // current DB value, so it survives the device being moved to a
+      // different org mid-session.
       existing.auth = auth;
       existing.toolAuth = existing.deviceId
-        ? buildDeviceBoundSessionAuth(auth, existing.orgId)
+        ? buildDeviceBoundSessionAuth(auth, dbSession.orgId)
         : auth;
       existing.auditSnapshot = snapshot;
       existing.allowedTools = allowedTools;


### PR DESCRIPTION
Closes #3087

## Problem

A chat session bound to a device in a **sibling org under the same partner** ran org-scoped tools under the *login* org: `manage_patches` (list) returned the login org's patches, and every `search_logs` call returned `{logs: [], total: 0}` because the RMM-side log search never looked at the org that owns the device. Not a tenant-isolation breach (RLS held; both orgs belong to the partner) — a correctness bug that silently corrupts investigations.

## Root cause

`ai_sessions.org_id` is **already** correctly anchored to the device's org at creation (`services/aiAgent.ts` `createSession`, gated on `auth.canAccessOrg` + `auth.canAccessSite`). But tool execution (`aiAgentSdkTools.ts` `makeHandler`/`makeSessionAwareHandler`) took `getAuth() => session.auth` — the **raw login AuthContext** — for both the RLS `DbAccessContext` and the tool handlers. Partner tokens carry `orgId: null`, so the `getOrgId(auth)` helper (cloned in 15 `aiTools*` modules) fell back to `accessibleOrgIds[0]` — an arbitrary org from an unordered partner-org select — and `search_logs`' `auth.orgCondition(...)` spanned the whole partner. The session's `device_id`/`org_id` were never consulted.

## Fix

One chokepoint in `StreamingSessionManager` covering all ~200 tools:

- **`ActiveSession.toolAuth`** — the request auth narrowed to the session (device) org via new `buildDeviceBoundSessionAuth`, wired into the MCP server's `getAuth` thunk (tool handlers + their RLS context). Recomputed on every per-request auth refresh, so a follow-up message never reverts to login scope.
- **Narrowing contract**: `orgId`/`accessibleOrgIds` pinned to the session org with closures from the canonical `buildOrgAccessClosures`; `scope`/`partnerId` **preserved** so the partner RLS axis stays intact (partner-wide scripts/templates/rings stay readable — the #2822 failure mode); site restrictions and identity preserved; throws if the caller cannot access the session org (defensive — `getSession` already pre-filters).
- **`session.auth` stays RAW**: RBAC (`checkToolPermission` — `permissions.ts` resolves org membership before partner role), rate limits, and audit attribution keep resolving the login identity/role, matching the rest of the API. A dual-membership tech does not flip roles because a session is device-bound.
- Non-device sessions unchanged — partner techs keep fleet-wide reach in general chat. Helper/client-AI paths already pin their auth via their own middleware and are no-ops here.
- Two adjacent same-root-cause fixes: SDK `result` usage recording used `auth.orgId` (null for partner logins — **usage recording was silently skipped**) and `postToolUse` audit org attribution — both now use the canonical `session.orgId`.

## Product contract (explicit)

A device-bound session's org-scoped reads/writes target the **device's org**. Partner-*role* capabilities (partner-wide config reads, `get_fleet_status` by partnerId) are intentionally retained — the narrowing is the org query axis, not a full sandbox.

## Design review

Codex (gpt-5.6, xhigh, read-only) independently reviewed the design: agreed the session-manager chokepoint is correct (patching the 15 `getOrgId` clones would miss `orgCondition`/RLS/future tools; `makeHandler` is too late for `preToolUse`), and flagged the RBAC role-flip risk that motivated the raw-vs-tool auth split above.

## Tests

- New `streamingSessionManager.deviceBoundAuth.test.ts` (8 tests): partner-scope login narrowed to a sibling device org (org axis pinned, `accessibleOrgIds[0]` = device org), partner RLS axis preserved in `dbAccessContextFromAuth` (#2822 guard), site closures preserved, already-pinned identity short-circuit, system-scope behavior, fail-loud throw, and `getOrCreate` wiring: device-bound `getAuth()` is narrowed on creation **and** refresh, `session.auth` stays raw, non-device sessions untouched.
- `vitest run` green: deviceBoundAuth + clientLoop + security (21), aiAgentSdk + planMatch + m365risk + sessionAware (118), ai_sessions_crud + ai_sessions_actions + aiAgent.deviceTask (37). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)