### PR TITLE
fix(ai): record explicit tool_result when the SDK drops a call before dispatch

### DIFF
--- a/apps/api/src/services/aiAgent.authz.test.ts
+++ b/apps/api/src/services/aiAgent.authz.test.ts
@@ -32,6 +32,10 @@ vi.mock('../db/schema', () => ({
     sessionId: 'aiToolExecutions.sessionId',
     intentId: 'aiToolExecutions.intentId',
   },
+  approvalRequests: {
+    executionId: 'approvalRequests.executionId',
+    status: 'approvalRequests.status',
+  },
   delegantM365Connections: {},
   devices: {},
 }));
@@ -174,6 +178,102 @@ describe('handleApproval owner-binding (SR5-10)', () => {
     const ok = await handleApproval('exec-1', true, auth('victim'), 's1');
 
     expect(ok).toBe(false);
+  });
+});
+
+// #3094: the Tier-2 per_step flow creates BOTH an ai_tool_executions row and a
+// mobile-bridge approval_requests row. The inline web-chat decide historically
+// flipped only the execution row, stranding the bridge row 'pending' until its
+// 5-minute TTL — which reads as an unattended-expired approval sitting next to
+// a recorded success. Pin that handleApproval now mirrors the decision onto
+// the still-pending bridge row.
+describe('handleApproval approval_requests mirror (#3094)', () => {
+  function stubExecutionThenSession(execution: unknown, session: unknown) {
+    stubSelectOnce([execution]);
+    stubSelectOnce([session]);
+  }
+
+  function captureUpdates() {
+    const calls: Array<{ set: Record<string, unknown>; where: unknown }> = [];
+    let call = 0;
+    updateMock.mockImplementation(() => ({
+      set: (values: Record<string, unknown>) => ({
+        where: (cond: unknown) => {
+          calls.push({ set: values, where: cond });
+          call += 1;
+          // First update is the CAS on aiToolExecutions (#3089) — chains
+          // .returning() and must yield the updated row for `updated` to be
+          // truthy so the mirror below is reached. Second update is the
+          // approval_requests mirror, which resolves the where() directly.
+          if (call === 1) {
+            return { returning: vi.fn().mockResolvedValue([{ id: 'exec-1' }]) };
+          }
+          return Promise.resolve(undefined);
+        },
+      }),
+    }));
+    return calls;
+  }
+
+  it('marks the pending bridge row approved when the owner approves', async () => {
+    stubExecutionThenSession(
+      { id: 'exec-1', status: 'pending', sessionId: 's1' },
+      { id: 's1', orgId: 'org-1', userId: 'victim' },
+    );
+    const updates = captureUpdates();
+
+    const ok = await handleApproval('exec-1', true, auth('victim'), 's1');
+
+    expect(ok).toBe(true);
+    expect(updates).toHaveLength(2);
+    const mirror = updates[1]!;
+    expect(mirror.set).toMatchObject({ status: 'approved' });
+    expect(mirror.set.decidedAt).toBeInstanceOf(Date);
+    // Predicate must bind to this execution AND only flip a still-pending row.
+    const where = mirror.where as { op: string; conds: Array<{ col: unknown; val: unknown }> };
+    expect(where.op).toBe('and');
+    expect(where.conds).toContainEqual(
+      expect.objectContaining({ col: 'approvalRequests.executionId', val: 'exec-1' }),
+    );
+    expect(where.conds).toContainEqual(
+      expect.objectContaining({ col: 'approvalRequests.status', val: 'pending' }),
+    );
+  });
+
+  it('marks the pending bridge row denied when the owner rejects', async () => {
+    stubExecutionThenSession(
+      { id: 'exec-1', status: 'pending', sessionId: 's1' },
+      { id: 's1', orgId: 'org-1', userId: 'victim' },
+    );
+    const updates = captureUpdates();
+
+    const ok = await handleApproval('exec-1', false, auth('victim'), 's1');
+
+    expect(ok).toBe(true);
+    expect(updates[1]!.set).toMatchObject({ status: 'denied' });
+  });
+
+  it('still reports success when the bridge mirror fails (execution row is the source of truth)', async () => {
+    stubExecutionThenSession(
+      { id: 'exec-1', status: 'pending', sessionId: 's1' },
+      { id: 's1', orgId: 'org-1', userId: 'victim' },
+    );
+    let call = 0;
+    updateMock.mockImplementation(() => ({
+      set: (values: Record<string, unknown>) => ({
+        where: () => {
+          call += 1;
+          // First update (the CAS) must succeed and report the updated row so
+          // `updated` is truthy and the mirror update is attempted at all.
+          if (call === 1) {
+            return { returning: vi.fn().mockResolvedValue([{ id: 'exec-1' }]) };
+          }
+          return Promise.reject(new Error('db down'));
+        },
+      }),
+    }));
+
+    await expect(handleApproval('exec-1', true, auth('victim'), 's1')).resolves.toBe(true);
   });
 });
 

--- a/apps/api/src/services/aiAgent.ts
+++ b/apps/api/src/services/aiAgent.ts
@@ -7,7 +7,7 @@
  */
 
 import { db, withSystemDbAccessContext } from '../db';
-import { aiSessions, aiMessages, aiToolExecutions, delegantM365Connections, devices } from '../db/schema';
+import { aiSessions, aiMessages, aiToolExecutions, approvalRequests, delegantM365Connections, devices } from '../db/schema';
 import { eq, and, desc, sql, type SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiPageContext, AiApprovalMode } from '@breeze/shared/types/ai';
@@ -459,7 +459,35 @@ export async function handleApproval(
     ))
     .returning({ id: aiToolExecutions.id });
 
-  return !!updated;
+  if (!updated) return false;
+
+  // Mirror the decision onto the mobile-bridge approval_requests row (#3094).
+  // The Tier-2 per_step flow creates BOTH ledgers (aiAgentSdk.ts
+  // createSessionPreToolUse): ai_tool_executions (which waitForApproval polls)
+  // and an approval_requests row for the mobile /approvals surface. The
+  // /approvals decide route mirrors its decision back onto ai_tool_executions,
+  // but this inline web-chat path historically flipped only ai_tool_executions
+  // — leaving the bridge row 'pending' until its 5-minute TTL lapsed, which
+  // reads as an unattended-expired approval next to a recorded success in any
+  // audit review. Best-effort: the execution row above is the source of truth
+  // the SDK poll unblocks on, so a mirror failure must not fail the decide.
+  try {
+    await db
+      .update(approvalRequests)
+      .set({
+        status: approved ? 'approved' : 'denied',
+        decidedAt: new Date(),
+        decisionReason: 'Decided inline in chat by the session owner',
+      })
+      .where(and(
+        eq(approvalRequests.executionId, executionId),
+        eq(approvalRequests.status, 'pending'),
+      ));
+  } catch (err) {
+    console.error('[AI] Failed to mirror chat approval onto approval_requests:', executionId, err);
+  }
+
+  return true;
 }
 
 /**

--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -1378,6 +1378,11 @@ export function createSessionPostToolUse(session: ActiveSession): PostToolUseCal
     const toolUseId = session.toolUseIdQueue.shift();
     if (!toolUseId) {
       console.warn(`[AI-SDK] postToolUse: toolUseIdQueue empty for ${toolName} — tool_result will have no toolUseId`);
+    } else {
+      // Drop the paired name entry recorded at content_block_start — it exists
+      // for the dropped-call fallback (#3094), which must not fire for a call
+      // this postToolUse is handling.
+      session.toolUseNames?.delete(toolUseId);
     }
     const safeOutput = compactToolResultForChat(toolName, output);
     const parsedOutput = safeParseJson(safeOutput);

--- a/apps/api/src/services/aiToolSchemas.validateToolInput.test.ts
+++ b/apps/api/src/services/aiToolSchemas.validateToolInput.test.ts
@@ -49,3 +49,55 @@ describe('validateToolInput error formatting', () => {
     }
   });
 });
+
+// Regression for #3094: a set_device_context call whose values contain
+// parentheses ("169.254.7.26 (APIPA)") must validate — the prod call vanished
+// at the SDK layer without a tool_result, and the model's paren-sanitizing
+// retry implied the schema rejected parenthesized text. Pin that both the
+// summary and details values accept parentheses, and that the realistic
+// SDK-layer rejections for this tool are the type/length failures, not parens.
+describe('set_device_context parenthesized input (#3094)', () => {
+  const base = {
+    deviceId: '00000000-0000-0000-0000-000000000001',
+    contextType: 'quirk',
+  };
+
+  it('accepts parentheses in details values', () => {
+    expect(
+      validateToolInput('set_device_context', {
+        ...base,
+        summary: 'NIC fell back to APIPA',
+        details: { ethernetIP: '169.254.7.26 (APIPA)' },
+      })
+    ).toEqual({ success: true });
+  });
+
+  it('accepts parentheses in the summary', () => {
+    expect(
+      validateToolInput('set_device_context', {
+        ...base,
+        summary: 'Ethernet has APIPA address 169.254.7.26 (APIPA) — DHCP unreachable',
+      })
+    ).toEqual({ success: true });
+  });
+
+  it('rejects details passed as a JSON-encoded string (a realistic silent-drop trigger)', () => {
+    const result = validateToolInput('set_device_context', {
+      ...base,
+      summary: 's',
+      details: '{"ethernetIP": "169.254.7.26 (APIPA)"}',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a summary over 255 chars (a realistic silent-drop trigger)', () => {
+    const result = validateToolInput('set_device_context', {
+      ...base,
+      summary: `169.254.7.26 (APIPA) ${'x'.repeat(255)}`,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('summary');
+    }
+  });
+});

--- a/apps/api/src/services/clientAiTools.ts
+++ b/apps/api/src/services/clientAiTools.ts
@@ -668,6 +668,9 @@ export function makeClientToolHandler(
       // the technician path drains them in createSessionPostToolUse
       // (aiAgentSdk.ts:640). Client handlers bypass that callback, so drain here.
       const toolUseId = session.toolUseIdQueue.shift() ?? crypto.randomUUID();
+      // Drop the paired name entry recorded at content_block_start (see the
+      // dropped-call fallback in streamingSessionManager.ts, #3094).
+      session.toolUseNames?.delete(toolUseId);
       const startTime = Date.now();
 
       // Server-side write-mode enforcement (pinned contract): 'readonly'

--- a/apps/api/src/services/streamingSessionManager.droppedToolResult.test.ts
+++ b/apps/api/src/services/streamingSessionManager.droppedToolResult.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Regression tests for issue #3094: a tool call the SDK rejects BEFORE our MCP
+ * handler runs (e.g. a -32602 input-schema validation failure on a
+ * set_device_context call carrying a parenthesized value) used to vanish — the
+ * model saw an error tool_result and retried, but Breeze persisted no
+ * ai_messages tool_result row, emitted no SSE event, and left a stale
+ * toolUseIdQueue entry that misattributed every subsequent result.
+ *
+ * The background processor's 'user' case now detects exactly those orphans
+ * (tool_result blocks whose tool_use id is still queued) and records an
+ * explicit error result instead of silence.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+
+const { queryMock, insertedRows, updateCalls } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  insertedRows: [] as Array<Record<string, unknown>>,
+  updateCalls: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({ query: queryMock }));
+
+vi.mock('../db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([{ approvalMode: 'per_step' }])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        updateCalls.push(values);
+        return { where: vi.fn(() => Promise.resolve()) };
+      }),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((row: Record<string, unknown>) => {
+        insertedRows.push(row);
+        return Promise.resolve();
+      }),
+    })),
+  },
+  withDbAccessContext: vi.fn((_ctx: unknown, fn: () => unknown) => fn()),
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('./aiCostTracker', () => ({ recordUsageFromSdkResult: vi.fn(() => Promise.resolve()) }));
+vi.mock('./aiAgent', () => ({ sanitizeErrorForClient: (e: unknown) => String(e) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
+vi.mock('./aiAgentSdkTools', () => ({
+  createBreezeMcpServer: vi.fn(() => ({ type: 'sdk' })),
+  BREEZE_MCP_TOOL_NAMES: ['mcp__breeze__set_device_context'],
+}));
+vi.mock('./aiAgentSdk', () => ({
+  createSessionPreToolUse: vi.fn(() => vi.fn()),
+  createSessionPostToolUse: vi.fn(() => vi.fn()),
+}));
+vi.mock('./aiToolOutput', () => ({
+  redactAiToolOutputText: (s: string) => s,
+  redactSensitiveToolInput: (input: Record<string, unknown>) => input,
+}));
+vi.mock('./clientIp', () => ({ getTrustedClientIpOrUndefined: () => undefined }));
+
+import { StreamingSessionManager } from './streamingSessionManager';
+import type { AuthContext } from '../middleware/auth';
+
+const ORG = '0c0c0c0c-1111-4222-8333-444455556666';
+
+const DB_SESSION = {
+  orgId: ORG,
+  sdkSessionId: null,
+  model: 'claude-sonnet-4-5-20250929',
+  maxTurns: 50,
+  turnCount: 0,
+  systemPrompt: null,
+};
+
+const AUTH = {
+  orgId: ORG,
+  scope: 'organization',
+  accessibleOrgIds: [ORG],
+  user: { id: 'beefbeef-1111-4222-8333-444455556666', email: 'tech@contoso.com' },
+} as unknown as AuthContext;
+
+const PAREN_INPUT = {
+  deviceId: '3f8b0e6a-1234-4c56-8d9e-000000000001',
+  contextType: 'quirk',
+  summary: 'NIC fell back to APIPA',
+  details: { ethernetIP: '169.254.7.26 (APIPA)' },
+};
+
+const TOOL_USE_ID = 'toolu_paren_01';
+
+function toolUseStreamEvent(id: string, name: string) {
+  return {
+    type: 'stream_event',
+    event: {
+      type: 'content_block_start',
+      content_block: { type: 'tool_use', id, name },
+    },
+  };
+}
+
+function assistantToolUseMessage(id: string, name: string, input: Record<string, unknown>) {
+  return {
+    type: 'assistant',
+    message: {
+      content: [{ type: 'tool_use', id, name, input }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    },
+  };
+}
+
+function userToolResultMessage(id: string, text: string) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: id,
+          is_error: true,
+          content: [{ type: 'text', text }],
+        },
+      ],
+    },
+  };
+}
+
+const RESULT_MSG = {
+  type: 'result',
+  subtype: 'success',
+  total_cost_usd: 0.01,
+  usage: { input_tokens: 10, output_tokens: 5 },
+  num_turns: 1,
+};
+
+function mockSdkQuery(messages: unknown[]) {
+  queryMock.mockImplementation(() => ({
+    async *[Symbol.asyncIterator]() {
+      yield* messages as never[];
+    },
+    interrupt: vi.fn(),
+    close: vi.fn(),
+  }));
+}
+
+let manager: StreamingSessionManager;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertedRows.length = 0;
+  updateCalls.length = 0;
+  manager = new StreamingSessionManager();
+});
+
+afterEach(() => {
+  manager.shutdown();
+});
+
+const VALIDATION_ERROR_TEXT =
+  'MCP error -32602: Input validation error: Invalid arguments for tool set_device_context: '
+  + '[{"code":"invalid_type","path":["details"]}] (input contained "169.254.7.26 (APIPA)")';
+
+describe('dropped tool_result fallback (#3094)', () => {
+  it('persists an explicit error tool_result and emits the SSE event for a call the MCP handler never saw', async () => {
+    mockSdkQuery([
+      toolUseStreamEvent(TOOL_USE_ID, 'mcp__breeze__set_device_context'),
+      assistantToolUseMessage(TOOL_USE_ID, 'mcp__breeze__set_device_context', PAREN_INPUT),
+      // The SDK feeds the model an error tool_result without ever calling our
+      // MCP server — postToolUse never shifts the queue for this id.
+      userToolResultMessage(TOOL_USE_ID, VALIDATION_ERROR_TEXT),
+      RESULT_MSG,
+    ]);
+
+    const session = await manager.getOrCreate(
+      'sess-dropped', DB_SESSION, AUTH, undefined, 'PROMPT', undefined,
+    );
+    await session.processorPromise;
+
+    // Transcript row: role tool_result, correct correlation id + bare tool
+    // name, explicit error payload (not silence).
+    const resultRows = insertedRows.filter((r) => r.role === 'tool_result');
+    expect(resultRows).toHaveLength(1);
+    expect(resultRows[0]).toMatchObject({
+      sessionId: 'sess-dropped',
+      toolName: 'set_device_context',
+      toolUseId: TOOL_USE_ID,
+    });
+    const output = resultRows[0]!.toolOutput as { error: string; droppedBeforeExecution: boolean };
+    expect(output.droppedBeforeExecution).toBe(true);
+    expect(output.error).toContain('Invalid arguments for tool set_device_context');
+    expect(output.error).toContain('(APIPA)');
+
+    // SSE event so the UI tool card resolves instead of spinning forever.
+    const events = session.eventBus.getReplayEvents();
+    const toolResultEvents = events.filter((e) => e.type === 'tool_result');
+    expect(toolResultEvents).toHaveLength(1);
+    expect(toolResultEvents[0]).toMatchObject({ toolUseId: TOOL_USE_ID, isError: true });
+
+    // Queue hygiene: the stale id must not poison attribution of later calls.
+    expect(session.toolUseIdQueue).toHaveLength(0);
+    expect(session.toolUseNames?.has(TOOL_USE_ID)).toBe(false);
+
+    // Session auto-flag so flagged-session review surfaces the drop.
+    const flagUpdates = updateCalls.filter((u) => typeof u.flagReason === 'string');
+    expect(flagUpdates).toHaveLength(1);
+    expect(flagUpdates[0]!.flagReason).toContain('set_device_context');
+  });
+
+  it('does not double-record a tool_result already handled by postToolUse (id no longer queued)', async () => {
+    mockSdkQuery([
+      // No content_block_start for this id — simulates postToolUse having
+      // already drained the queue before the SDK echoed the user message.
+      userToolResultMessage('toolu_already_handled', 'Context recorded successfully (ID: abc).'),
+      RESULT_MSG,
+    ]);
+
+    const session = await manager.getOrCreate(
+      'sess-handled', DB_SESSION, AUTH, undefined, 'PROMPT', undefined,
+    );
+    await session.processorPromise;
+
+    expect(insertedRows.filter((r) => r.role === 'tool_result')).toHaveLength(0);
+    expect(session.eventBus.getReplayEvents().filter((e) => e.type === 'tool_result')).toHaveLength(0);
+    expect(updateCalls.filter((u) => typeof u.flagReason === 'string')).toHaveLength(0);
+  });
+
+  it('ignores plain-text user messages (resume replay) entirely', async () => {
+    mockSdkQuery([
+      { type: 'user', message: { role: 'user', content: 'plain follow-up text' } },
+      RESULT_MSG,
+    ]);
+
+    const session = await manager.getOrCreate(
+      'sess-plain', DB_SESSION, AUTH, undefined, 'PROMPT', undefined,
+    );
+    await session.processorPromise;
+
+    expect(insertedRows.filter((r) => r.role === 'tool_result')).toHaveLength(0);
+  });
+
+  it('keeps attribution intact for a later call after an earlier drop', async () => {
+    mockSdkQuery([
+      toolUseStreamEvent(TOOL_USE_ID, 'mcp__breeze__set_device_context'),
+      assistantToolUseMessage(TOOL_USE_ID, 'mcp__breeze__set_device_context', PAREN_INPUT),
+      userToolResultMessage(TOOL_USE_ID, VALIDATION_ERROR_TEXT),
+      // Retry call: id enters the queue; its (mocked) postToolUse never runs
+      // in this harness, so the queue should contain exactly this second id.
+      toolUseStreamEvent('toolu_retry_02', 'mcp__breeze__set_device_context'),
+      RESULT_MSG,
+    ]);
+
+    const session = await manager.getOrCreate(
+      'sess-retry', DB_SESSION, AUTH, undefined, 'PROMPT', undefined,
+    );
+    await session.processorPromise;
+
+    // The dropped id was spliced out; the retry id is untouched at the head.
+    expect(session.toolUseIdQueue).toEqual(['toolu_retry_02']);
+    expect(session.toolUseNames?.get('toolu_retry_02')).toBe('set_device_context');
+  });
+});

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -16,7 +16,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk';
 import type { Query, SDKResultMessage, SDKUserMessage, McpSdkServerConfigWithInstance } from '@anthropic-ai/claude-agent-sdk';
 import { db, withDbAccessContext, runOutsideDbContext } from '../db';
 import { aiSessions, aiMessages, aiBudgets } from '../db/schema';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, isNull } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import { buildOrgAccessClosures } from '../middleware/auth';
 import type { AiStreamEvent, AiApprovalMode } from '@breeze/shared/types/ai';
@@ -340,6 +340,15 @@ export interface ActiveSession {
    * Reset after every flush.
    */
   pendingTurnUsage: PendingTurnUsage;
+  /**
+   * tool_use id → bare tool name, recorded at content_block_start alongside
+   * toolUseIdQueue. Consumed by postToolUse on the normal path, or by the
+   * dropped-call fallback in the background processor's 'user' case when the
+   * SDK rejected the call before our MCP handler ever ran (issue #3094).
+   * Optional so existing fixtures that build ActiveSession literals compile
+   * unchanged; the fallback degrades to 'unknown_tool' without it.
+   */
+  toolUseNames?: Map<string, string>;
   /** Promise that resolves when background processor finishes */
   readonly processorPromise: Promise<void>;
   /** Timer for per-turn timeout; cleared when 'result' arrives */
@@ -571,6 +580,7 @@ export class StreamingSessionManager {
       mcpPrefix: MCP_PREFIX, // updated below if custom factory
       toolUseIdQueue: [],
       pendingTurnUsage: emptyPendingTurnUsage(),
+      toolUseNames: new Map(),
       processorPromise: Promise.resolve(),
       turnTimeoutId: null,
       approvalWaitDeadline: null,
@@ -839,12 +849,17 @@ export class StreamingSessionManager {
                 // content_block_start fires before the tool executes;
                 // postToolUse shifts the queue after execution.
                 session.toolUseIdQueue.push(block.id);
+                const bareStreamToolName = block.name.startsWith(session.mcpPrefix)
+                  ? block.name.slice(session.mcpPrefix.length)
+                  : block.name;
+                // Name lookup for the dropped-call fallback (#3094): if the
+                // SDK rejects this call before the MCP handler runs, the
+                // orphaned tool_result only carries the id, not the name.
+                session.toolUseNames?.set(block.id, bareStreamToolName);
 
                 session.eventBus.publish({
                   type: 'tool_use_start',
-                  toolName: block.name.startsWith(session.mcpPrefix)
-                    ? block.name.slice(session.mcpPrefix.length)
-                    : block.name,
+                  toolName: bareStreamToolName,
                   toolUseId: block.id,
                   input: {},
                 });
@@ -944,7 +959,36 @@ export class StreamingSessionManager {
           }
 
           case 'user': {
-            // SDK replays user messages during resume — skip, already in DB
+            // Ordinary user content is skipped (the SDK replays user messages
+            // during resume; they are already in DB). BUT this is also the only
+            // place a tool_result the model received WITHOUT our MCP handler
+            // running is visible: when the SDK rejects a tool call before
+            // dispatch (e.g. a -32602 input-schema validation failure), the
+            // model is fed an error tool_result while preToolUse/postToolUse
+            // never fire — historically leaving NO ai_messages row, NO SSE
+            // event, and a stale toolUseIdQueue entry that misattributes every
+            // subsequent result (issue #3094: a set_device_context call with a
+            // parenthesized details value vanished from the transcript while
+            // the model saw a validation error and silently retried). Detect
+            // exactly those orphans — a tool_result whose tool_use id is still
+            // queued; postToolUse shifts the queue before the MCP call
+            // returns, so normally-executed calls never match here, and
+            // replayed history predates this process's queue — and record an
+            // explicit error result instead of silence.
+            const userContent = (message as SDKUserMessage).message?.content;
+            if (Array.isArray(userContent)) {
+              for (const block of userContent) {
+                if (
+                  typeof block === 'object' && block !== null &&
+                  (block as { type?: string }).type === 'tool_result'
+                ) {
+                  await this.recordDroppedToolResult(
+                    session,
+                    block as { tool_use_id?: string; content?: unknown; is_error?: boolean },
+                  );
+                }
+              }
+            }
             break;
           }
 
@@ -1148,6 +1192,102 @@ export class StreamingSessionManager {
       if (this.sessions.has(session.breezeSessionId)) {
         this.remove(session.breezeSessionId);
       }
+    }
+  }
+
+  /**
+   * Persist + emit an explicit error tool_result for a tool call the SDK
+   * rejected BEFORE our MCP handler ran (issue #3094).
+   *
+   * Detection contract: a tool_result block inside an SDK 'user' message whose
+   * tool_use id is STILL in session.toolUseIdQueue was never seen by
+   * createSessionPostToolUse (which shifts the queue synchronously before the
+   * MCP call returns). For those calls nothing else will ever write the
+   * transcript row or resolve the UI tool card, so this fallback:
+   *  - removes the stale queue entry (it would misattribute every subsequent
+   *    tool_result to the wrong toolUseId),
+   *  - emits the SSE tool_result event (UI card resolves with the error),
+   *  - persists the ai_messages tool_result row (transcript/audit review sees
+   *    an explicit failure instead of a vanished call),
+   *  - flags the session (parity with postToolUse's tool-failure auto-flag).
+   */
+  private async recordDroppedToolResult(
+    session: ActiveSession,
+    block: { tool_use_id?: string; content?: unknown; is_error?: boolean },
+  ): Promise<void> {
+    const toolUseId = block.tool_use_id;
+    if (!toolUseId) return;
+    const queueIdx = session.toolUseIdQueue.indexOf(toolUseId);
+    if (queueIdx === -1) return; // handled by postToolUse, or replayed history
+    session.toolUseIdQueue.splice(queueIdx, 1);
+    const toolName = session.toolUseNames?.get(toolUseId) ?? 'unknown_tool';
+    session.toolUseNames?.delete(toolUseId);
+
+    const rawText = Array.isArray(block.content)
+      ? (block.content as Array<{ type?: string; text?: string }>)
+          .map((c) => (typeof c?.text === 'string' ? c.text : ''))
+          .join(' ')
+          .trim()
+      : typeof block.content === 'string'
+        ? block.content
+        : '';
+    // The text is SDK/CLI-authored (typically an input-schema validation error
+    // that only references our own advertised tool schema); redact + cap as
+    // defense-in-depth before it reaches the stream and the transcript.
+    const errorText = redactAiToolOutputText(
+      rawText || 'Tool call was rejected before execution and produced no result.',
+    ).slice(0, 1000);
+    const output = { error: errorText, droppedBeforeExecution: true };
+
+    console.warn(
+      `[StreamingSessionManager] Tool call ${toolName} (${toolUseId}) was rejected before the MCP handler ran — recording explicit error tool_result`,
+    );
+
+    // SSE first (mirrors createSessionPostToolUse): the UI must receive the
+    // result even if persistence fails.
+    session.eventBus.publish({
+      type: 'tool_result',
+      toolUseId,
+      output,
+      isError: block.is_error ?? true,
+    });
+
+    try {
+      await withDbAccessContext(
+        { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+        () =>
+          db.insert(aiMessages).values({
+            sessionId: session.breezeSessionId,
+            role: 'tool_result',
+            toolName,
+            toolOutput: output,
+            toolUseId,
+          })
+      );
+    } catch (err) {
+      captureException(err);
+      console.error('[StreamingSessionManager] Failed to persist dropped tool_result:', toolName, err);
+    }
+
+    // Auto-flag the session (first failure only) so flagged-session review
+    // surfaces these drops — mirrors postToolUse's tool-failure flag.
+    try {
+      await withDbAccessContext(
+        { scope: 'organization', orgId: session.orgId, accessibleOrgIds: [session.orgId] },
+        () =>
+          db.update(aiSessions)
+            .set({
+              flaggedAt: new Date(),
+              flagReason: `Tool rejected before execution: ${toolName} — ${errorText.slice(0, 300)}`,
+            })
+            .where(and(
+              eq(aiSessions.id, session.breezeSessionId),
+              isNull(aiSessions.flaggedAt),
+            ))
+      );
+    } catch (err) {
+      captureException(err);
+      console.error('[StreamingSessionManager] Failed to auto-flag session for dropped tool_result:', session.breezeSessionId, err);
     }
   }
 


### PR DESCRIPTION
## Summary

`set_device_context` calls carrying a parenthesized value (e.g. `169.254.7.26 (APIPA)`) could vanish from the AI session transcript with no `tool_result` — the Claude Agent SDK rejected the tool call (an MCP `-32602` input-validation error) *before* our own `preToolUse`/`postToolUse` handlers ever ran, so nothing recorded the failure: no `ai_messages` row, no SSE event, and a stale `toolUseIdQueue` entry that misattributed the *next* tool's result.

Root cause is at the SDK/MCP transport layer, not in our own validation — our `set_device_context` Zod schema (`aiToolSchemas.ts`) already accepts parentheses in both `summary` and `details`, which the new `aiToolSchemas.validateToolInput.test.ts` cases pin explicitly.

## Fix

`StreamingSessionManager`'s background processor now detects these orphaned `tool_result` blocks in the SDK's `'user'` message case (an id still present in `session.toolUseIdQueue`, meaning `postToolUse` never shifted it) and records an explicit error result instead of silence:
- persists an `ai_messages` `tool_result` row (`droppedBeforeExecution: true`),
- emits the SSE `tool_result` event so the UI tool card resolves instead of spinning,
- clears the stale `toolUseIdQueue`/`toolUseNames` entries so later calls aren't misattributed,
- auto-flags the session (first occurrence) for flagged-session review.

A companion `toolUseNames` map (id → bare tool name, populated at `content_block_start`) lets the fallback path name the dropped tool; it's drained normally by `postToolUse` and the client-tool handler so it never leaks into the fallback for calls that executed normally.

## Safety verdict: expired approval_requests row next to a recorded success — orphaned bookkeeping, NOT an approval bypass

Verified by directly reading the gating code (not inferring from names):

- The actual execution gate, `waitForApproval` (`apps/api/src/services/aiAgent.ts:301-359`), reads **only** `aiToolExecutions.status` in its poll loop (`aiAgent.ts:310-323`). `approvalRequests` is never imported or referenced anywhere in that function.
- `aiToolExecutions` is created first; `approvalRequests` is created afterward and references it via `executionId` (`apps/api/src/services/aiAgentSdk.ts:536-559` then `:944-966`), purely as a bridge for the mobile `/approvals` UI surface — the schema comment on `approval_requests.execution_id` (`apps/api/src/db/schema/approvals.ts:47-54`) confirms this.
- The 30s expiry reaper that flips stale `approvalRequests` rows to `expired` and mirrors the decision onto `aiToolExecutions` (`apps/api/src/jobs/approvalExpiryReaper.ts:127-141`) guards that mirror write with `eq(aiToolExecutions.status, 'pending')` — it is structurally incapable of overwriting an already-resolved (`approved`/`completed`) execution row.
- The mobile `/approvals` decide route (`apps/api/src/routes/approvals.ts:681-727`) CASes `approvalRequests` first, then mirrors onto `aiToolExecutions` only if present, in a try/catch that's explicitly documented as non-fatal — if the mirror fails, `waitForApproval` just times out and self-rejects; it never silently allows.

Conclusion: a `approvalRequests` row sitting `pending` past its TTL while the linked `aiToolExecutions` row already shows `approved`/executed is a **leftover mobile-notification row**, not a second authorization gate that got skipped. This PR additionally makes `handleApproval` (the in-app web-chat decide path, `aiAgent.ts`) mirror its decision onto the still-pending `approvalRequests` row — previously it only flipped `aiToolExecutions`, which is why the bridge row was stranded — closing that cosmetic gap so audit review no longer sees a spuriously-expired row next to a resolved execution.

Caveat: the Tier-3 durable `action_intents` release worker (`apps/api/src/jobs/intentReleaseWorker.ts:277-285`) *does* consult `approvalRequests.status` as a fail-closed pre-execution check — but that's a distinct code path from the Tier-2 `per_step` flow this issue describes, and it fails *closed* (blocks execution on a missing/mismatched row), so it doesn't change the verdict above.

## Testing

- `apps/api/src/services/streamingSessionManager.droppedToolResult.test.ts` (new) — 4 cases: persists explicit error result + SSE event for a genuinely dropped call; does not double-record a call `postToolUse` already handled; ignores plain-text resume-replay user messages; keeps queue attribution correct for a retry after a drop.
- `apps/api/src/services/aiToolSchemas.validateToolInput.test.ts` — pins that `set_device_context` accepts parentheses in `summary`/`details`, and that the realistic SDK-layer rejection triggers are type/length errors, not parens.
- `apps/api/src/services/aiAgent.authz.test.ts` — new `handleApproval approval_requests mirror (#3094)` describe block: approve/deny mirror onto the bridge row, and mirror-failure doesn't fail the primary decide.
- Full targeted run: `streamingSessionManager.droppedToolResult.test.ts`, `aiAgent.authz.test.ts`, `aiToolSchemas.validateToolInput.test.ts` — 27/27 passed.
- Broader regression run: `aiAgentSdk.test.ts`, `aiAgentSdk.m365risk.test.ts`, `aiAgentSdk.planMatch.test.ts`, `clientAiTools.contract.test.ts`, `clientAiTools.handler.test.ts`, `clientAiTools.registry.test.ts`, `streamingSessionManager.clientLoop.test.ts`, `streamingSessionManager.security.test.ts`, `aiAgent.test.ts` — 165/165 passed.
- `tsc --noEmit` (with `NODE_OPTIONS="--max-old-space-size=8192"` per the known OOM issue on this box) — clean, no errors.

Closes #3094