### PR TITLE
fix(mobile): stop rendering raw internal error text in SessionsSheet (#3115)

### DIFF
--- a/apps/mobile/src/screens/chat/HomeScreen.tsx
+++ b/apps/mobile/src/screens/chat/HomeScreen.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFocusEffect } from '@react-navigation/native';
+import * as Sentry from '@sentry/react-native';
 
 import { useAppDispatch, useAppSelector } from '../../store';
 import {
@@ -235,8 +236,10 @@ export function HomeScreen() {
         const messages = historyToMessages(rows);
         dispatch(loadHistory({ sessionId: sid, messages }));
       } catch (err) {
-        const errMsg = err instanceof Error ? err.message : 'Could not load session.';
-        dispatch(setError(errMsg));
+        // The raw message is internal (function name + HTTP status) — report it
+        // to Sentry and show the user a static string instead (issue #3115).
+        Sentry.captureException(err, { tags: { area: 'ai-sessions-history' } });
+        dispatch(setError('Could not load that conversation.'));
       }
     },
     [dispatch],

--- a/apps/mobile/src/screens/chat/components/SessionsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SessionsSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, FlatList, Modal, Pressable, Text, View } from 'react-native';
+import * as Sentry from '@sentry/react-native';
 
 import { useApprovalTheme, radii, spacing, type } from '../../../theme';
 import { listAiSessions, type AiSessionListItem } from '../../../services/aiChat';
@@ -22,7 +23,12 @@ export function SessionsSheet({ visible, onCancel, onSelect }: Props) {
     setError(null);
     listAiSessions(30)
       .then(setSessions)
-      .catch((err: Error) => setError(err.message));
+      .catch((err: Error) => {
+        // The raw message is internal (function name + HTTP status) — report it
+        // to Sentry and show the user a static string instead (issue #3115).
+        Sentry.captureException(err, { tags: { area: 'ai-sessions-history' } });
+        setError("Couldn't load conversation history.");
+      });
   }, [visible]);
 
   return (


### PR DESCRIPTION
## Summary

The History sheet rendered the raw internal error string (`listAiSessions failed: 401`) verbatim in red when loading conversation history failed. This maps the failure to a static user-facing message — "Couldn't load conversation history." — and reports the internal `err.message` to Sentry instead (`captureException` with `tags.area = 'ai-sessions-history'`, matching the existing mobile Sentry pattern in `RootNavigator.tsx` / `auth.ts`), following the `SettingsSheet.tsx` convention of short static user-facing strings.

PR review found the identical leak one tap deeper in the same flow: selecting a session from the sheet rendered `getAiSessionMessages failed: <status>` verbatim via `HomeScreen.tsx` `handleSelectSession`, with no Sentry capture. Second commit applies the same pattern there ("Could not load that conversation.").

`apps/mobile/src/services/aiChat.ts` is intentionally **untouched**: the thrown messages no longer reach the screen (Sentry-only), and #3114 is editing `authedFetch` in the same file in parallel — leaving it alone avoids a conflict.

Known remaining siblings of the same defect class (raw `err.message` in UI, no Sentry), out of this issue's scope and left for a follow-up: `HomeScreen.tsx:194` (create session), `SystemsScreen.tsx:~210`, `useSystemsData.ts:~105`, `DeviceDetailScreen.tsx:~174`.

## Stacking note

**Stacked PR — base is `ToddHebebrand/ios-app-testing`, not `main`** (the issue was diagnosed against 4 unmerged mobile commits on that branch). `ci.yml` only triggers on PRs targeting `main`, so **no CI runs on this PR**; verification was run locally instead (below).

## Verification (local, Node 22.23.2)

- `pnpm typecheck` in `apps/mobile` — clean (re-run after review fix)
- `pnpm test` in `apps/mobile` — 27 files, 261 passed / 3 skipped (re-run after review fix)

No mobile component-test infra exists (service-level Vitest only), so the change is covered by typecheck + the full existing mobile suite; on-device verification to follow by the orchestrator.

Closes #3115

🤖 Generated with [Claude Code](https://claude.com/claude-code)