### PR TITLE
fix(mobile): show screen-lock setup guidance when no authenticator is enrolled (#3117)

### DIFF
--- a/apps/mobile/src/screens/approvals/authOutcome.test.ts
+++ b/apps/mobile/src/screens/approvals/authOutcome.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { classifyAuthFailure } from './authOutcome';
+import {
+  classifyAuthFailure,
+  classifyPreAuth,
+  NO_AUTHENTICATOR_MESSAGE,
+} from './authOutcome';
 
 describe('classifyAuthFailure', () => {
   it('treats an explicit user cancel as a silent no-op', () => {
@@ -29,6 +33,16 @@ describe('classifyAuthFailure', () => {
     }
   });
 
+  it('reports no-authenticator setup guidance, not "try again", for enrollment codes (#3117)', () => {
+    for (const code of ['not_enrolled', 'passcode_not_set']) {
+      const r = classifyAuthFailure(code);
+      expect(r.kind).toBe('no_authenticator');
+      expect(r.message).toBe(NO_AUTHENTICATOR_MESSAGE);
+      expect(r.message).toMatch(/screen lock/i);
+      expect(r.message).not.toMatch(/try again/i);
+    }
+  });
+
   it('falls back to a generic failure for unknown codes', () => {
     const r = classifyAuthFailure('authentication_failed');
     expect(r.kind).toBe('failed');
@@ -42,9 +56,38 @@ describe('classifyAuthFailure', () => {
   });
 
   it('never returns a null message except for the silent user_cancel case', () => {
-    const codes = ['system_cancel', 'app_cancel', 'lockout', 'lockout_permanent', 'weird', undefined];
+    const codes = [
+      'system_cancel',
+      'app_cancel',
+      'lockout',
+      'lockout_permanent',
+      'not_enrolled',
+      'passcode_not_set',
+      'weird',
+      undefined,
+    ];
     for (const code of codes) {
       expect(classifyAuthFailure(code).message).not.toBeNull();
     }
+  });
+});
+
+describe('classifyPreAuth', () => {
+  it('flags SecurityLevel.NONE (no screen lock at all) as no_authenticator (#3117)', () => {
+    const r = classifyPreAuth(0);
+    expect(r).not.toBeNull();
+    expect(r?.kind).toBe('no_authenticator');
+    expect(r?.message).toBe(NO_AUTHENTICATOR_MESSAGE);
+  });
+
+  it('lets any enrolled security level proceed to the prompt', () => {
+    // 1 = SECRET (PIN/pattern/password), 2 = BIOMETRIC_WEAK, 3 = BIOMETRIC_STRONG
+    for (const level of [1, 2, 3]) {
+      expect(classifyPreAuth(level)).toBeNull();
+    }
+  });
+
+  it('does not block the attempt when the probe failed (null level)', () => {
+    expect(classifyPreAuth(null)).toBeNull();
   });
 });

--- a/apps/mobile/src/screens/approvals/authOutcome.ts
+++ b/apps/mobile/src/screens/approvals/authOutcome.ts
@@ -9,7 +9,12 @@
  * not succeed".
  */
 
-export type AuthFailureKind = 'silent' | 'interrupted' | 'lockout' | 'failed';
+export type AuthFailureKind =
+  | 'silent'
+  | 'interrupted'
+  | 'lockout'
+  | 'no_authenticator'
+  | 'failed';
 
 export interface AuthFailureClassification {
   kind: AuthFailureKind;
@@ -29,6 +34,37 @@ const SILENT_CANCEL_CODE = 'user_cancel';
 const INTERRUPTED_CODES = new Set(['system_cancel', 'app_cancel']);
 
 const LOCKOUT_CODES = new Set(['lockout', 'lockout_permanent']);
+
+// The device has NO enrolled authenticator at all — no biometric AND no
+// PIN/pattern/password. By the time these codes reach the classifier the
+// component has already tried the device-credential fallback, so this is a
+// permanent configuration state, not a transient failure: "Try again" can
+// never succeed (issue #3117). Surface setup guidance instead.
+const NO_AUTHENTICATOR_CODES = new Set(['not_enrolled', 'passcode_not_set']);
+
+export const NO_AUTHENTICATOR_MESSAGE =
+  'This device has no screen lock. Set up a screen lock in device settings to approve requests.';
+
+// Mirrors expo-local-authentication's SecurityLevel.NONE. Kept as a local
+// constant so this module stays free of RN/Expo imports (the mobile Vitest
+// harness is node-env, pure-logic only — see the header comment).
+const SECURITY_LEVEL_NONE = 0;
+
+/**
+ * Preflight check run BEFORE showing any auth prompt. `enrolledLevel` is
+ * the result of `getEnrolledLevelAsync()` (or `null` if the probe threw —
+ * in that case we don't block the attempt; the prompt's own error code is
+ * the backstop). Returns the no-authenticator classification when the
+ * device has no screen lock at all, else `null` (proceed to the prompt).
+ */
+export function classifyPreAuth(
+  enrolledLevel: number | null,
+): AuthFailureClassification | null {
+  if (enrolledLevel === SECURITY_LEVEL_NONE) {
+    return { kind: 'no_authenticator', message: NO_AUTHENTICATOR_MESSAGE };
+  }
+  return null;
+}
 
 /**
  * Map an `expo-local-authentication` failure `error` code to what the
@@ -50,6 +86,9 @@ export function classifyAuthFailure(code: string | undefined): AuthFailureClassi
       kind: 'lockout',
       message: 'Biometrics locked. Use device passcode in Settings to unlock.',
     };
+  }
+  if (code && NO_AUTHENTICATOR_CODES.has(code)) {
+    return { kind: 'no_authenticator', message: NO_AUTHENTICATOR_MESSAGE };
   }
   return { kind: 'failed', message: 'Authentication failed. Try again.' };
 }

--- a/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
+++ b/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
@@ -149,12 +149,14 @@ export function ApprovalButtons({
     try {
       await Linking.sendIntent('android.settings.SECURITY_SETTINGS');
     } catch (err) {
+      // Some OEM ROMs / work profiles don't resolve this intent. Don't
+      // fall back to Linking.openSettings() — that opens Breeze's own
+      // app-info page, which has no lock-screen setup and would silently
+      // send the user to the wrong place. Surface manual guidance instead.
       console.warn('[ApprovalButtons] could not open security settings', err);
-      try {
-        await Linking.openSettings();
-      } catch (settingsErr) {
-        console.warn('[ApprovalButtons] could not open app settings either', settingsErr);
-      }
+      setAuthMessage(
+        'Could not open settings. Open your device Settings > Security to set up a screen lock, then try again.',
+      );
     }
   }
 

--- a/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
+++ b/apps/mobile/src/screens/approvals/components/ApprovalButtons.tsx
@@ -1,12 +1,16 @@
 import { useRef, useState } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Linking, Platform, Pressable, Text, View } from 'react-native';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { useApprovalTheme, type, spacing, radii, palette } from '../../../theme';
 import { haptic } from '../../../lib/motion';
 import { HoldToConfirm } from './HoldToConfirm';
 import { DenyReasonSheet } from './DenyReasonSheet';
 import { captureRequestId, type CapturedRequestId } from '../decisionTarget';
-import { classifyAuthFailure } from '../authOutcome';
+import {
+  classifyAuthFailure,
+  classifyPreAuth,
+  type AuthFailureKind,
+} from '../authOutcome';
 
 interface Props {
   // The approval the user is looking at right now (live prop). We snapshot
@@ -40,6 +44,9 @@ export function ApprovalButtons({
   const theme = useApprovalTheme('dark');
   const [denyOpen, setDenyOpen] = useState(false);
   const [authMessage, setAuthMessage] = useState<string | null>(null);
+  // Kind of the last auth failure — drives the extra "open settings" action
+  // for the no-authenticator case (issue #3117).
+  const [authKind, setAuthKind] = useState<AuthFailureKind | null>(null);
   // Snapshot of the request id at the moment Deny was tapped — the deny
   // reason sheet stays open across re-renders, so reading the live prop in
   // its onSubmit would have the same focus-swap hazard as approve.
@@ -58,16 +65,34 @@ export function ApprovalButtons({
     const target = captureRequestId(requestId);
     haptic.tap();
     setAuthMessage(null);
+    setAuthKind(null);
 
     let hasHw = false;
     let enrolled = false;
+    // null = probe failed; don't block the attempt on a probe error — the
+    // prompt's own error code (classifyAuthFailure) is the backstop.
+    let enrolledLevel: number | null = null;
     try {
       hasHw = await LocalAuthentication.hasHardwareAsync();
       enrolled = await LocalAuthentication.isEnrolledAsync();
+      enrolledLevel = await LocalAuthentication.getEnrolledLevelAsync();
     } catch (err) {
       console.warn('[ApprovalButtons] biometric hardware probe failed', err);
       hasHw = false;
       enrolled = false;
+      enrolledLevel = null;
+    }
+
+    // No authenticator enrolled at all (no biometric, no PIN/pattern/
+    // password): the prompt is doomed — Android fails it immediately with
+    // "Authentication failed. Try again.", which misreads a permanent
+    // configuration state as a transient failure (issue #3117). Skip the
+    // prompt and show setup guidance instead.
+    const preAuth = classifyPreAuth(enrolledLevel);
+    if (preAuth) {
+      setAuthMessage(preAuth.message);
+      setAuthKind(preAuth.kind);
+      return;
     }
 
     // authenticateAsync / authenticateWithPasscode can REJECT (another
@@ -102,6 +127,7 @@ export function ApprovalButtons({
     } catch (err) {
       console.warn('[ApprovalButtons] biometric auth threw', err);
       setAuthMessage('Authentication failed. Try again.');
+      setAuthKind('failed');
     }
   }
 
@@ -111,8 +137,25 @@ export function ApprovalButtons({
     // mid-confirmation) now surface an actionable retry instead of being
     // swallowed (#746 Issue 2). Classification is unit-tested in
     // authOutcome.test.ts.
-    const { message } = classifyAuthFailure((result as { error?: string }).error);
+    const { kind, message } = classifyAuthFailure((result as { error?: string }).error);
     setAuthMessage(message);
+    setAuthKind(message === null ? null : kind);
+  }
+
+  async function openSecuritySettings() {
+    // Android exposes the lock-screen setup screen directly. There is no
+    // public iOS equivalent (App-Prefs: URLs are private API), so the link
+    // is Android-only — iOS gets the plain guidance copy.
+    try {
+      await Linking.sendIntent('android.settings.SECURITY_SETTINGS');
+    } catch (err) {
+      console.warn('[ApprovalButtons] could not open security settings', err);
+      try {
+        await Linking.openSettings();
+      } catch (settingsErr) {
+        console.warn('[ApprovalButtons] could not open app settings either', settingsErr);
+      }
+    }
   }
 
   return (
@@ -126,6 +169,17 @@ export function ApprovalButtons({
         >
           {authMessage}
         </Text>
+      ) : null}
+      {authMessage && authKind === 'no_authenticator' && Platform.OS === 'android' ? (
+        <Pressable
+          onPress={openSecuritySettings}
+          hitSlop={8}
+          style={{ paddingHorizontal: spacing[6], marginBottom: spacing[2], alignSelf: 'flex-start' }}
+        >
+          <Text style={[type.meta, { color: theme.textHi, textDecorationLine: 'underline' }]}>
+            Open security settings
+          </Text>
+        </Pressable>
       ) : null}
       <View style={{ flexDirection: 'row', paddingHorizontal: spacing[6], gap: spacing[3] }}>
         <Pressable


### PR DESCRIPTION
## Summary

On a device with **no screen lock configured at all** (no biometric, no PIN/pattern/password), tapping **Approve** showed "Authentication failed. Try again." — misdiagnosing a permanent configuration state as a transient failure. Retrying can never succeed; the approval flow was unusable with no explanation.

The device-credential fallback itself already works (verified in the issue); this PR only fixes the branching + copy for the no-authenticator case.

## Changes

- **`authOutcome.ts`** (pure logic, unit-tested):
  - New `no_authenticator` failure kind for the `not_enrolled` / `passcode_not_set` result codes — by the time these reach the classifier the device-credential fallback has already been tried, so they mean "no authenticator at all". Copy: *"This device has no screen lock. Set up a screen lock in device settings to approve requests."*
  - New `classifyPreAuth(enrolledLevel)` preflight helper: `SecurityLevel.NONE` → the same guidance; `null` (probe threw) → proceed to the prompt so a probe error never blocks a legitimate attempt (the prompt's own error code is the backstop).
- **`ApprovalButtons.tsx`**:
  - Probes `getEnrolledLevelAsync()` alongside the existing hardware/enrollment probes and short-circuits the doomed prompt when no authenticator exists.
  - Android-only **"Open security settings"** link under the message (`Linking.sendIntent('android.settings.SECURITY_SETTINGS')`, falling back to `Linking.openSettings()`); iOS has no public deep link to lock-screen setup, so it gets the plain copy.
- **`authOutcome.test.ts`**: covers the new classification codes and all three preflight branches.

Deliberately does not touch the deny path or `DenyReasonSheet` (#3116 is being fixed in parallel there).

## Stacked PR — no CI

Based on `ToddHebebrand/ios-app-testing` (the issue was diagnosed against its unmerged mobile approvals work), **not** `main`. `ci.yml` only triggers on PRs targeting `main`, so **no CI runs here**; verification was done locally:

- `pnpm exec vitest run` (apps/mobile): 27 files, 265 passed / 3 skipped
- `pnpm exec tsc --noEmit` (apps/mobile): clean

## Verification of the defect path

Issue repro (Android emulator, no screen lock) showed `AuthenticatorStatus: 7` (not enrolled) and an immediate failure with the misleading copy. With this change that state is detected pre-prompt via `getEnrolledLevelAsync() === SecurityLevel.NONE` and surfaces setup guidance + a settings link instead. On-device verification to follow by the orchestrator.

Closes #3117

🤖 Generated with [Claude Code](https://claude.com/claude-code)