### PR TITLE
fix(mobile): lift the deny-reason sheet above the Android keyboard (#3116)

### DIFF
--- a/apps/mobile/src/screens/approvals/components/DenyReasonSheet.tsx
+++ b/apps/mobile/src/screens/approvals/components/DenyReasonSheet.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Modal, Pressable, Text, TextInput, View } from 'react-native';
+import { KeyboardAvoidingView, Modal, Platform, Pressable, Text, TextInput, View } from 'react-native';
 import { useApprovalTheme, type, spacing, radii, palette } from '../../../theme';
 
 interface Props {
@@ -25,71 +25,76 @@ export function DenyReasonSheet({ visible, onCancel, onSubmit }: Props) {
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={handleCancel}>
-      <Pressable
-        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
-        onPress={handleCancel}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={{ flex: 1 }}
       >
         <Pressable
-          onPress={(e) => e.stopPropagation()}
-          style={{
-            backgroundColor: theme.bg1,
-            borderTopLeftRadius: radii.xl,
-            borderTopRightRadius: radii.xl,
-            padding: spacing[6],
-            paddingBottom: spacing[10],
-          }}
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
+          onPress={handleCancel}
         >
-          <Text style={[type.title, { color: theme.textHi }]}>Why deny?</Text>
-          <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
-            Optional. Helps the requesting session understand.
-          </Text>
-          <TextInput
-            value={reason}
-            onChangeText={setReason}
-            placeholder="Reason"
-            placeholderTextColor={theme.textLo}
-            multiline
-            style={[
-              type.body,
-              {
-                color: theme.textHi,
-                backgroundColor: theme.bg2,
-                borderRadius: radii.md,
-                padding: spacing[4],
-                marginTop: spacing[4],
-                minHeight: 88,
-                textAlignVertical: 'top',
-              },
-            ]}
-          />
-          <View style={{ flexDirection: 'row', marginTop: spacing[5], gap: spacing[3] }}>
-            <Pressable
-              onPress={handleCancel}
-              style={{
-                flex: 1,
-                paddingVertical: spacing[4],
-                alignItems: 'center',
-                borderRadius: radii.md,
-                backgroundColor: theme.bg2,
-              }}
-            >
-              <Text style={[type.bodyMd, { color: theme.textHi }]}>Cancel</Text>
-            </Pressable>
-            <Pressable
-              onPress={handleSubmit}
-              style={{
-                flex: 1,
-                paddingVertical: spacing[4],
-                alignItems: 'center',
-                borderRadius: radii.md,
-                backgroundColor: theme.deny,
-              }}
-            >
-              <Text style={[type.bodyMd, { color: palette.deny.onBase }]}>Deny</Text>
-            </Pressable>
-          </View>
+          <Pressable
+            onPress={(e) => e.stopPropagation()}
+            style={{
+              backgroundColor: theme.bg1,
+              borderTopLeftRadius: radii.xl,
+              borderTopRightRadius: radii.xl,
+              padding: spacing[6],
+              paddingBottom: spacing[10],
+            }}
+          >
+            <Text style={[type.title, { color: theme.textHi }]}>Why deny?</Text>
+            <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
+              Optional. Helps the requesting session understand.
+            </Text>
+            <TextInput
+              value={reason}
+              onChangeText={setReason}
+              placeholder="Reason"
+              placeholderTextColor={theme.textLo}
+              multiline
+              style={[
+                type.body,
+                {
+                  color: theme.textHi,
+                  backgroundColor: theme.bg2,
+                  borderRadius: radii.md,
+                  padding: spacing[4],
+                  marginTop: spacing[4],
+                  minHeight: 88,
+                  textAlignVertical: 'top',
+                },
+              ]}
+            />
+            <View style={{ flexDirection: 'row', marginTop: spacing[5], gap: spacing[3] }}>
+              <Pressable
+                onPress={handleCancel}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.md,
+                  backgroundColor: theme.bg2,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: theme.textHi }]}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleSubmit}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.md,
+                  backgroundColor: theme.deny,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: palette.deny.onBase }]}>Deny</Text>
+              </Pressable>
+            </View>
+          </Pressable>
         </Pressable>
-      </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary

On Android, focusing the reason field in the approval deny sheet raised the IME over the entire sheet — title, the field being typed into, and both buttons — so the deny reason had to be typed blind. `android:windowSoftInputMode="adjustResize"` was already set on `MainActivity`, but `DenyReasonSheet` had no `KeyboardAvoidingView`, so the bottom-anchored modal never lifted above the keyboard.

This wraps the sheet's backdrop (inside the `Modal`) in a `KeyboardAvoidingView` with the house `Platform.OS === 'ios' ? 'padding' : 'height'` behavior split, matching the existing input-bearing screens (`HomeScreen`, `LoginScreen`, `MfaChallengeScreen`, `ServerSelectScreen`).

`SuspiciousReportSheet` was checked and has no text input, so it is not affected. The diff is confined to `DenyReasonSheet.tsx` layout only — the approve/auth path is untouched (sibling issue #3117 is being fixed in parallel in the same directory).

Closes #3116

## Stacking note

This PR is **stacked on `ToddHebebrand/ios-app-testing`** (the branch the bug was diagnosed against, with unmerged approvals-queue work), not `main`. `ci.yml` only triggers on PRs targeting `main`, so **no CI will run here** — verification was done locally instead (below).

## Verification

- `pnpm typecheck` (apps/mobile, `tsc --noEmit`): clean
- `pnpm test` (apps/mobile, vitest): 27 files, 261 passed / 3 skipped
- **Not visually verified**: this is a keyboard-occlusion layout fix and cannot be fully verified headlessly. On-device verification on the Android emulator (deny sheet lifts above the IME, typing visible, buttons reachable) is still needed and will be done by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)