### PR TITLE
fix(mobile): refresh expired access token on 401 in aiChat authedFetch (#3114)

### DIFF
--- a/apps/mobile/src/services/aiChat.test.ts
+++ b/apps/mobile/src/services/aiChat.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { listAiSessions } from './aiChat';
+import { createAiSession, listAiSessions } from './aiChat';
 import { refreshToken } from './api';
 import { storeToken } from './auth';
 import { fetchWithTimeout } from './fetchWithTimeout';
 
 vi.mock('./serverConfig', () => ({
   getServerUrl: vi.fn().mockResolvedValue('https://api.test'),
+}));
+
+vi.mock('@sentry/react-native', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
 }));
 
 vi.mock('expo-secure-store', () => ({
@@ -107,6 +112,45 @@ describe('authedFetch 401 refresh-and-retry (via listAiSessions)', () => {
     expect(sessions).toHaveLength(1);
     const retryHeaders = (fetchMock.mock.calls[1][1] as RequestInit).headers as Record<string, string>;
     expect(retryHeaders.Authorization).toBe('Bearer fresh-token');
+  });
+
+  it('replays a POST retry with the same method, body, and CSRF header', async () => {
+    const created = { id: 's9', title: null, orgId: 'o1', createdAt: 'now' };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse(created));
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' });
+
+    const session = await createAiSession({ title: 'hello' });
+
+    expect(session.id).toBe('s9');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [firstUrl, firstInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [retryUrl, retryInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(retryUrl).toBe(firstUrl);
+    expect(retryInit.method).toBe('POST');
+    expect(retryInit.body).toBe(firstInit.body);
+    expect(retryInit.body).toBe(JSON.stringify({ title: 'hello' }));
+    const retryHeaders = retryInit.headers as Record<string, string>;
+    expect(retryHeaders['x-breeze-csrf']).toBe('1');
+    expect(retryHeaders.Authorization).toBe('Bearer fresh-token');
+  });
+
+  it('clears the single-flight guard after a failed refresh so a later 401 refreshes again', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401));
+    refreshMock.mockRejectedValueOnce({ message: 'offline' });
+    await expect(listAiSessions()).rejects.toThrow('listAiSessions failed: 401');
+
+    // A transient failure must not poison the guard: the next 401 refreshes.
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse(sessionsBody));
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' });
+
+    const sessions = await listAiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(refreshMock).toHaveBeenCalledTimes(2);
   });
 
   it('single-flights concurrent 401s into one refresh call', async () => {

--- a/apps/mobile/src/services/aiChat.test.ts
+++ b/apps/mobile/src/services/aiChat.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { listAiSessions } from './aiChat';
+import { refreshToken } from './api';
+import { storeToken } from './auth';
+import { fetchWithTimeout } from './fetchWithTimeout';
+
+vi.mock('./serverConfig', () => ({
+  getServerUrl: vi.fn().mockResolvedValue('https://api.test'),
+}));
+
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn().mockResolvedValue('stale-token'),
+}));
+
+vi.mock('./fetchWithTimeout', () => ({
+  fetchWithTimeout: vi.fn(),
+}));
+
+// api.ts pulls in Sentry/installation-id modules that don't exist in the node
+// test environment — mock the whole module, we only need refreshToken.
+vi.mock('./api', () => ({
+  refreshToken: vi.fn(),
+}));
+
+vi.mock('./auth', () => ({
+  storeToken: vi.fn().mockResolvedValue(undefined),
+}));
+
+const fetchMock = vi.mocked(fetchWithTimeout);
+const refreshMock = vi.mocked(refreshToken);
+const storeTokenMock = vi.mocked(storeToken);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const sessionsBody = { data: [{ id: 's1', title: 'hi', status: 'active', turnCount: 1, lastActivityAt: null, createdAt: 'now' }] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeTokenMock.mockResolvedValue(undefined);
+});
+
+describe('authedFetch 401 refresh-and-retry (via listAiSessions)', () => {
+  it('does not refresh when the request succeeds', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(sessionsBody));
+
+    const sessions = await listAiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes on 401, persists the new token, and retries once with it', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse(sessionsBody));
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' });
+
+    const sessions = await listAiSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(storeTokenMock).toHaveBeenCalledWith('fresh-token');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstHeaders = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    const retryHeaders = (fetchMock.mock.calls[1][1] as RequestInit).headers as Record<string, string>;
+    expect(firstHeaders.Authorization).toBe('Bearer stale-token');
+    expect(retryHeaders.Authorization).toBe('Bearer fresh-token');
+  });
+
+  it('surfaces the original 401 when the refresh itself fails', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401));
+    refreshMock.mockRejectedValueOnce({ message: 'Failed to refresh token' });
+
+    await expect(listAiSessions()).rejects.toThrow('listAiSessions failed: 401');
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no retry without a new token
+  });
+
+  it('retries only once — a second 401 is returned, not re-refreshed', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401));
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' });
+
+    await expect(listAiSessions()).rejects.toThrow('listAiSessions failed: 401');
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('still retries with the refreshed token when persisting it fails', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse(sessionsBody));
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' });
+    storeTokenMock.mockRejectedValueOnce(new Error('Failed to store authentication token'));
+
+    const sessions = await listAiSessions();
+
+    expect(sessions).toHaveLength(1);
+    const retryHeaders = (fetchMock.mock.calls[1][1] as RequestInit).headers as Record<string, string>;
+    expect(retryHeaders.Authorization).toBe('Bearer fresh-token');
+  });
+
+  it('single-flights concurrent 401s into one refresh call', async () => {
+    // Both concurrent requests 401 first, then both retries succeed.
+    fetchMock.mockImplementation(async (_url, init) => {
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      return headers.Authorization === 'Bearer fresh-token'
+        ? jsonResponse(sessionsBody)
+        : jsonResponse({ error: 'Unauthorized' }, 401);
+    });
+    let resolveRefresh: (v: { token: string }) => void;
+    refreshMock.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveRefresh = resolve; }),
+    );
+
+    const p1 = listAiSessions();
+    const p2 = listAiSessions();
+    // Let both initial requests hit the 401 and enter the refresh path.
+    await new Promise((r) => setTimeout(r, 0));
+    resolveRefresh!({ token: 'fresh-token' });
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toHaveLength(1);
+    expect(r2).toHaveLength(1);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/services/aiChat.ts
+++ b/apps/mobile/src/services/aiChat.ts
@@ -1,7 +1,9 @@
 import * as SecureStore from 'expo-secure-store';
+import * as Sentry from '@sentry/react-native';
 
 import { getServerUrl } from './serverConfig';
 import { fetchWithTimeout } from './fetchWithTimeout';
+import type { ApiError } from './api';
 import { refreshToken } from './api';
 import { storeToken } from './auth';
 
@@ -31,7 +33,11 @@ async function getToken(): Promise<string | null> {
 
 // Single-flight guard so N concurrent 401s trigger one /auth/refresh, not N.
 // Cleared once the refresh settles; callers that grabbed the promise still
-// receive its result.
+// receive its result. NOTE: /auth/refresh rotates the refresh cookie and
+// replaying a rotated token revokes the whole token family, so this guard is
+// only safe while aiChat is the sole mobile refresh caller — if another
+// service starts calling refreshToken(), move the single-flight into a shared
+// module.
 let refreshInFlight: Promise<string | null> | null = null;
 
 /**
@@ -47,15 +53,32 @@ async function refreshAccessToken(): Promise<string | null> {
         const { token } = await refreshToken();
         try {
           await storeToken(token);
-        } catch {
+        } catch (e) {
           // Persisting failed (locked keychain, etc.) — the in-memory token is
-          // still valid for the retry, and storeToken already reported the
-          // failure. Don't turn a usable refresh into a hard failure.
+          // still valid for the retry, so don't turn a usable refresh into a
+          // hard failure. But a phone that can't persist tokens will silently
+          // double every aiChat round-trip while all non-refreshing services
+          // hard-401, so make the real cause observable in production
+          // (console.* goes nowhere on release RN builds).
+          Sentry.captureException(e, {
+            tags: { area: 'aichat-token-refresh' },
+            extra: { stage: 'persist' },
+          });
         }
         return token;
-      } catch {
-        // Refresh itself failed — the session is genuinely over. Callers
-        // return the original 401 so the UI's existing auth handling fires.
+      } catch (e) {
+        // Refresh failed — expired refresh cookie, offline, or a
+        // /auth/refresh outage. We return null so the caller surfaces the
+        // original 401 to the UI either way, but record which failure mode it
+        // was: without this, "users see 401s" is undiagnosable in production.
+        Sentry.captureMessage('aiChat token refresh failed', {
+          level: 'warning',
+          tags: { area: 'aichat-token-refresh' },
+          extra: {
+            statusCode: (e as ApiError)?.statusCode,
+            message: (e as ApiError)?.message ?? String(e),
+          },
+        });
         return null;
       } finally {
         refreshInFlight = null;

--- a/apps/mobile/src/services/aiChat.ts
+++ b/apps/mobile/src/services/aiChat.ts
@@ -2,6 +2,8 @@ import * as SecureStore from 'expo-secure-store';
 
 import { getServerUrl } from './serverConfig';
 import { fetchWithTimeout } from './fetchWithTimeout';
+import { refreshToken } from './api';
+import { storeToken } from './auth';
 
 const FALLBACK_API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001';
 const API_CORE_PREFIX = '/api/v1';
@@ -27,12 +29,48 @@ async function getToken(): Promise<string | null> {
   }
 }
 
-async function authedFetch(
+// Single-flight guard so N concurrent 401s trigger one /auth/refresh, not N.
+// Cleared once the refresh settles; callers that grabbed the promise still
+// receive its result.
+let refreshInFlight: Promise<string | null> | null = null;
+
+/**
+ * Refresh the access token via the shared `refreshToken()` helper (api.ts) and
+ * persist it so every service reading `breeze_auth_token` picks it up.
+ * Returns the new token, or null when refresh failed (e.g. the refresh cookie
+ * itself expired) — callers then surface the original 401.
+ */
+async function refreshAccessToken(): Promise<string | null> {
+  if (!refreshInFlight) {
+    refreshInFlight = (async () => {
+      try {
+        const { token } = await refreshToken();
+        try {
+          await storeToken(token);
+        } catch {
+          // Persisting failed (locked keychain, etc.) — the in-memory token is
+          // still valid for the retry, and storeToken already reported the
+          // failure. Don't turn a usable refresh into a hard failure.
+        }
+        return token;
+      } catch {
+        // Refresh itself failed — the session is genuinely over. Callers
+        // return the original 401 so the UI's existing auth handling fires.
+        return null;
+      } finally {
+        refreshInFlight = null;
+      }
+    })();
+  }
+  return refreshInFlight;
+}
+
+async function doAuthedFetch(
   path: string,
-  init: RequestInit & { stream?: boolean } = {},
+  init: RequestInit & { stream?: boolean },
+  token: string | null,
 ): Promise<Response> {
   const baseUrl = (await getServerUrl()) || FALLBACK_API_BASE_URL;
-  const token = await getToken();
   const url = `${baseUrl}${API_CORE_PREFIX}${path}`;
 
   const headers: Record<string, string> = {
@@ -47,6 +85,25 @@ async function authedFetch(
   // HEADERS and clears its timer once they arrive, so an open stream body is
   // never aborted mid-flight.
   return fetchWithTimeout(url, { ...init, headers, credentials: 'include' });
+}
+
+// Access tokens live 15 minutes (ACCESS_TOKEN_EXPIRY, apps/api/src/services/jwt.ts)
+// and this wrapper reads whatever is in SecureStore, so any call made >15m
+// after login starts with an expired bearer. On 401, refresh once via the same
+// token lifecycle the rest of the mobile services use, then retry the request
+// a single time (#3114). Bodies here are always JSON strings, so re-sending
+// `init` unchanged is safe.
+async function authedFetch(
+  path: string,
+  init: RequestInit & { stream?: boolean } = {},
+): Promise<Response> {
+  const res = await doAuthedFetch(path, init, await getToken());
+  if (res.status !== 401) return res;
+
+  const newToken = await refreshAccessToken();
+  if (!newToken) return res;
+
+  return doAuthedFetch(path, init, newToken);
 }
 
 export async function createAiSession(input: CreateSessionPayload = {}): Promise<AiSessionSummary> {


### PR DESCRIPTION
Closes #3114

## Problem

`aiChat.ts` has its own fetch wrapper, `authedFetch`, which attaches whatever token is in SecureStore with no expiry check, refresh, or retry. Access tokens live 15 minutes (`ACCESS_TOKEN_EXPIRY`, `apps/api/src/services/jwt.ts`), so any AI-chat REST call made >15m after login 401s — user-visible as `listAiSessions failed: 401` when opening chat history.

## Fix

- `authedFetch` now retries **once** on 401: it refreshes via the existing `refreshToken()` helper (`apps/mobile/src/services/api.ts`), persists the new token with `storeToken()` (`auth.ts`) so every service reading `breeze_auth_token` benefits, and re-issues the request with the fresh bearer.
- Concurrent 401s single-flight into one `/auth/refresh` call.
- If the refresh itself fails (refresh cookie expired → session genuinely over), the **original 401** is returned so existing auth handling fires.
- A `storeToken` persistence failure (locked keychain) does not discard the usable in-memory token for the retry.

## Scope notes

- **Stacked PR** — based on `ToddHebebrand/ios-app-testing` (the branch this issue was diagnosed against), so `ci.yml` will NOT run (it only triggers on PRs targeting `main`). Verification was run locally; see below.
- Sibling issue #3115 (the `listAiSessions` error copy / SessionsSheet UX) is being fixed in parallel — this diff deliberately does not touch error messages or SessionsSheet.
- Known residual: `streamChat` (XHR SSE path) still attaches the stored token without refresh; a chat message sent >15m after login with no interim refresh can still 401 at stream open. Kept out of scope per the issue, which targets `authedFetch`.

## Verification (local)

- New unit suite `apps/mobile/src/services/aiChat.test.ts` — 6 tests: no refresh on success, refresh+persist+retry with new bearer, original 401 surfaced when refresh fails, retry-once (second 401 not re-refreshed), retry proceeds when persistence fails, concurrent 401s single-flighted.
- Full mobile suite: 28 files, 267 passed / 3 skipped.
- `tsc --noEmit` (apps/mobile): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)