### PR TITLE
fix(mobile): stop Settings asserting push works when registration is unsupported (#3118)

### DIFF
--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -757,10 +757,12 @@ function ToggleRow({
         paddingVertical: spacing[3],
         flexDirection: 'row',
         alignItems: 'center',
-        opacity: disabled ? 0.55 : 1,
       }}
     >
       <View style={{ flex: 1, marginRight: spacing[3] }}>
+        {/* Only the label and Switch signal "disabled" — the description stays
+            at full contrast because for a disabled row it carries the
+            explanation the user must be able to read (#3118). */}
         <Text style={[type.bodyMd, { color: disabled ? theme.textLo : theme.textHi }]}>{label}</Text>
         {description ? (
           <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
@@ -774,6 +776,7 @@ function ToggleRow({
         onValueChange={onChange}
         trackColor={{ false: theme.bg3, true: palette.brand.deep }}
         thumbColor={value ? palette.brand.base : theme.textMd}
+        style={disabled ? { opacity: 0.55 } : undefined}
       />
     </View>
   );

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -43,6 +43,7 @@ import { ease, duration } from '../../../lib/motion';
 import { track } from '../../../lib/analytics';
 import { relativeTime } from '../../../lib/relativeTime';
 import { Toast } from '../../../components/Toast';
+import { pushUnavailableCopy } from './pushUnavailableCopy';
 import { Avatar } from './Avatar';
 import { ChangePasswordSheet } from './ChangePasswordSheet';
 import type { PairedMobileDevice } from '../../../services/mobileDevices';
@@ -81,6 +82,13 @@ export function SettingsSheet({ visible, onCancel }: Props) {
   const activeAppCount = useAppSelector(selectActiveConnectedAppsCount);
   const pendingDeviceId = useAppSelector((s) => s.lifecycle.pendingDeviceId);
   const pendingAppId = useAppSelector((s) => s.lifecycle.pendingAppId);
+  // 'unsupported' is a deliberate "push not built / not possible here" state
+  // (e.g. android_push_not_configured) — the sheet must not show an ON toggle
+  // asserting a capability the build doesn't have. 'failed' keeps the normal
+  // toggle: ApprovalGate already surfaces failures with its own banner. #3118
+  const pushRegistration = useAppSelector((s) => s.auth.pushRegistration);
+  const pushRegistrationReason = useAppSelector((s) => s.auth.pushRegistrationReason);
+  const pushUnavailable = pushRegistration === 'unsupported';
 
   const screenWidth = Dimensions.get('window').width;
   const sheetWidth = Math.min(screenWidth * 0.84, 420);
@@ -286,6 +294,8 @@ export function SettingsSheet({ visible, onCancel }: Props) {
             biometricOn={biometricOn}
             notificationsOn={notificationsOn}
             criticalOnly={criticalOnly}
+            pushUnavailable={pushUnavailable}
+            pushUnavailableReason={pushRegistrationReason}
             buildVersion={buildVersion}
             pairedDevices={pairedDevices}
             connectedApps={connectedApps}
@@ -332,6 +342,8 @@ function SheetBody({
   biometricOn,
   notificationsOn,
   criticalOnly,
+  pushUnavailable,
+  pushUnavailableReason,
   buildVersion,
   pairedDevices,
   connectedApps,
@@ -356,6 +368,8 @@ function SheetBody({
   biometricOn: boolean;
   notificationsOn: boolean;
   criticalOnly: boolean;
+  pushUnavailable: boolean;
+  pushUnavailableReason: string | null;
   buildVersion: string;
   pairedDevices: PairedMobileDevice[];
   connectedApps: ConnectedApp[];
@@ -372,6 +386,7 @@ function SheetBody({
   onRevokeDevice: (device: PairedMobileDevice) => void;
   onRevokeApp: (app: ConnectedApp) => void;
 }) {
+  const pushCopy = pushUnavailable ? pushUnavailableCopy(pushUnavailableReason) : null;
   return (
     <View style={{ flex: 1 }}>
       <ScrollView
@@ -417,15 +432,26 @@ function SheetBody({
           />
         ) : null}
 
-        <ToggleRow
-          label="Notifications"
-          description="Approval pushes and alerts"
-          value={notificationsOn}
-          onChange={onToggleNotifications}
-          theme={theme}
-        />
+        {pushCopy ? (
+          <ToggleRow
+            label="Notifications"
+            description={pushCopy.notificationsRow}
+            value={false}
+            disabled
+            onChange={() => {}}
+            theme={theme}
+          />
+        ) : (
+          <ToggleRow
+            label="Notifications"
+            description="Approval pushes and alerts"
+            value={notificationsOn}
+            onChange={onToggleNotifications}
+            theme={theme}
+          />
+        )}
 
-        {notificationsOn ? (
+        {!pushCopy && notificationsOn ? (
           <ToggleRow
             label="Critical only"
             description="Quiet pushes for medium and warning alerts"
@@ -450,7 +476,11 @@ function SheetBody({
         <SectionHeader label="This phone + others" theme={theme} />
         {pairedDevices.length === 0 ? (
           <EmptyHint
-            text="No paired devices yet. Sign in on another phone to see it here."
+            text={
+              pushCopy
+                ? pushCopy.pairedDevicesHint
+                : 'No paired devices yet. Sign in on another phone to see it here.'
+            }
             theme={theme}
           />
         ) : (
@@ -709,12 +739,14 @@ function ToggleRow({
   label,
   description,
   value,
+  disabled,
   onChange,
   theme,
 }: {
   label: string;
   description?: string;
   value: boolean;
+  disabled?: boolean;
   onChange: (v: boolean) => void;
   theme: ReturnType<typeof useApprovalTheme>;
 }) {
@@ -725,10 +757,11 @@ function ToggleRow({
         paddingVertical: spacing[3],
         flexDirection: 'row',
         alignItems: 'center',
+        opacity: disabled ? 0.55 : 1,
       }}
     >
       <View style={{ flex: 1, marginRight: spacing[3] }}>
-        <Text style={[type.bodyMd, { color: theme.textHi }]}>{label}</Text>
+        <Text style={[type.bodyMd, { color: disabled ? theme.textLo : theme.textHi }]}>{label}</Text>
         {description ? (
           <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
             {description}
@@ -737,6 +770,7 @@ function ToggleRow({
       </View>
       <Switch
         value={value}
+        disabled={disabled}
         onValueChange={onChange}
         trackColor={{ false: theme.bg3, true: palette.brand.deep }}
         thumbColor={value ? palette.brand.base : theme.textMd}

--- a/apps/mobile/src/screens/chat/components/pushUnavailableCopy.test.ts
+++ b/apps/mobile/src/screens/chat/components/pushUnavailableCopy.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+
+import { pushUnavailableCopy } from './pushUnavailableCopy';
+
+describe('pushUnavailableCopy', () => {
+  it('names Android for the not-built-yet reason (#3118)', () => {
+    const copy = pushUnavailableCopy('android_push_not_configured');
+    expect(copy.notificationsRow).toMatch(/Android/);
+    expect(copy.notificationsRow).toMatch(/aren't available/i);
+    expect(copy.pairedDevicesHint).toMatch(/Android/);
+  });
+
+  it('names the simulator for not_physical_device', () => {
+    const copy = pushUnavailableCopy('not_physical_device');
+    expect(copy.notificationsRow).toMatch(/simulator/i);
+    expect(copy.pairedDevicesHint).toMatch(/simulator/i);
+  });
+
+  it('falls back to a generic device message for unknown reasons and null', () => {
+    for (const reason of ['something_new', null]) {
+      const copy = pushUnavailableCopy(reason);
+      expect(copy.notificationsRow).toMatch(/this device/i);
+      expect(copy.pairedDevicesHint.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never phrases the paired-devices hint as an error or a user mistake', () => {
+    for (const reason of ['android_push_not_configured', 'not_physical_device', null]) {
+      const copy = pushUnavailableCopy(reason);
+      expect(copy.pairedDevicesHint).not.toMatch(/error|failed|wrong/i);
+    }
+  });
+});

--- a/apps/mobile/src/screens/chat/components/pushUnavailableCopy.ts
+++ b/apps/mobile/src/screens/chat/components/pushUnavailableCopy.ts
@@ -1,0 +1,39 @@
+/**
+ * Copy for the Settings sheet when push registration reported `unsupported`
+ * (services/notifications.ts). `unsupported` is a deliberate "not built /
+ * not possible here" resting state — not a failure — so the sheet must stop
+ * asserting the capability (an ON Notifications toggle) and explain instead.
+ *
+ * Kept as a pure module (approverBannerCopy.ts precedent) so the
+ * reason → copy mapping is unit-tested rather than re-litigated in JSX.
+ * Issue #3118.
+ */
+export interface PushUnavailableCopy {
+  /** Replaces the Notifications toggle description. */
+  notificationsRow: string;
+  /** Replaces the paired-devices empty hint, which otherwise reads as an error. */
+  pairedDevicesHint: string;
+}
+
+export function pushUnavailableCopy(reason: string | null): PushUnavailableCopy {
+  switch (reason) {
+    case 'android_push_not_configured':
+      return {
+        notificationsRow: "Push notifications aren't available on Android yet.",
+        pairedDevicesHint:
+          "Push isn't available on Android yet, so this phone can't register itself. Phones that register for pushes appear here.",
+      };
+    case 'not_physical_device':
+      return {
+        notificationsRow: "Push notifications aren't available in the simulator.",
+        pairedDevicesHint:
+          "Simulators can't register for pushes, so this device isn't listed. Phones that register for pushes appear here.",
+      };
+    default:
+      return {
+        notificationsRow: "Push notifications aren't available on this device.",
+        pairedDevicesHint:
+          "This device can't register for pushes, so it isn't listed. Phones that register for pushes appear here.",
+      };
+  }
+}

--- a/apps/mobile/src/services/notifications.test.ts
+++ b/apps/mobile/src/services/notifications.test.ts
@@ -40,6 +40,7 @@ import {
   reconcileApprovalNotifications,
   staleApprovalNotificationIds,
 } from './notifications';
+import { pushUnavailableCopy } from '../screens/chat/components/pushUnavailableCopy';
 
 beforeEach(() => {
   platform.OS = 'ios';
@@ -99,6 +100,22 @@ describe('registerForPushNotifications', () => {
       status: 'unsupported',
       reason: 'not_physical_device',
     });
+  });
+
+  it('emits reasons the Settings sheet maps to SPECIFIC copy, not the generic fallback (#3118)', async () => {
+    // Pins the string contract between this service and pushUnavailableCopy:
+    // if a reason is renamed here, the sheet silently falls through to generic
+    // "this device" copy with both sides' own tests still green.
+    platform.OS = 'android';
+    const android = await registerForPushNotifications();
+    if (android.status !== 'unsupported') throw new Error('expected unsupported');
+    expect(pushUnavailableCopy(android.reason).notificationsRow).toMatch(/Android/);
+
+    platform.OS = 'ios';
+    device.isDevice = false;
+    const sim = await registerForPushNotifications();
+    if (sim.status !== 'unsupported') throw new Error('expected unsupported');
+    expect(pushUnavailableCopy(sim.reason).notificationsRow).toMatch(/simulator/i);
   });
 
   it('reports failed when the user denies permission', async () => {


### PR DESCRIPTION
## Summary

Fixes the Android Settings sheet asserting a push capability the build does not have. `registerForPushNotifications()` deliberately returns `{ status: 'unsupported', reason: 'android_push_not_configured' }` on Android (intentional not-built-yet state), but `SettingsSheet` showed the Notifications toggle ON with a "Critical only" sub-toggle, and the paired-devices empty state ("Sign in on another phone to see it here") read as an error — this phone can never register a token, so it never lists itself.

## Changes

- `SettingsSheet` now reads `auth.pushRegistration` / `pushRegistrationReason` from the store (already populated by `PushRegistrationGate` in `App.tsx`).
- When status is `unsupported`, the Notifications row renders in a disabled/explanatory state: dimmed, Switch OFF and disabled, description replaced with reason-specific copy ("Push notifications aren't available on Android yet."). The Critical-only sub-toggle is hidden.
- The paired-devices empty hint gets matching copy explaining the phone can't register itself, so the empty state no longer reads as an error.
- `failed` status keeps the normal toggle — `ApprovalGate` already surfaces registration failures with its own banner; this change only covers the deliberate `unsupported` state.
- Copy mapping lives in a pure module `pushUnavailableCopy.ts` (same precedent as `approverBannerCopy.ts`) with unit tests covering `android_push_not_configured`, `not_physical_device`, and the generic fallback.

This does NOT implement Android push — the issue explicitly scopes that out.

## Stacked PR — CI will not run

This PR is based on `ToddHebebrand/ios-app-testing` (the issue was diagnosed against its 4 unmerged mobile commits), so `ci.yml` will NOT trigger (it only runs on PRs targeting `main`). Verification was run locally instead:

- `npx tsc --noEmit` in `apps/mobile`: clean
- `pnpm exec vitest run` in `apps/mobile`: 28 files, 265 passed / 3 skipped (includes new `pushUnavailableCopy.test.ts`)

Closes #3118

🤖 Generated with [Claude Code](https://claude.com/claude-code)