### PR TITLE
fix(mobile): render AI chat markdown tables as stacked labelled rows (#3119)

### DIFF
--- a/apps/mobile/src/screens/chat/components/MarkdownBody.tsx
+++ b/apps/mobile/src/screens/chat/components/MarkdownBody.tsx
@@ -3,7 +3,7 @@ import { Text, View } from 'react-native';
 import Markdown, { type RenderRules } from 'react-native-markdown-display';
 
 import { useApprovalTheme, fontFamily, radii, spacing } from '../../../theme';
-import { parseMarkdownTable } from './markdownTable';
+import { parseMarkdownTable, toDisplayRows } from './markdownTable';
 
 interface Props {
   content: string;
@@ -208,17 +208,14 @@ export function MarkdownBody({ content }: Props) {
     () => ({
       hr: () => null,
       table: (node) => {
-        const { labels, rows } = parseMarkdownTable(node);
-        // Header-only table: show the header cells as a plain row rather
-        // than dropping the content (no labels to pair them with).
-        const bodyRows = rows.length > 0 ? rows : labels.length > 0 ? [labels] : [];
-        if (bodyRows.length === 0) {
+        const parsed = parseMarkdownTable(node);
+        const { rows, showLabels } = toDisplayRows(parsed);
+        if (rows.length === 0) {
           return null;
         }
-        const showLabels = rows.length > 0;
         return (
           <View key={node.key} style={tableStyles.card}>
-            {bodyRows.map((cells, rowIndex) => (
+            {rows.map((cells, rowIndex) => (
               <View
                 key={rowIndex}
                 style={
@@ -226,11 +223,15 @@ export function MarkdownBody({ content }: Props) {
                 }
               >
                 {cells.map((value, cellIndex) => {
-                  const label = showLabels ? labels[cellIndex] : undefined;
+                  const label = showLabels ? parsed.labels[cellIndex] : undefined;
+                  if (!label && !value) {
+                    return null;
+                  }
                   return (
                     <Text key={cellIndex} style={tableStyles.line}>
                       {label ? <Text style={tableStyles.label}>{label}: </Text> : null}
-                      {value}
+                      {/* Em dash keeps a labelled blank cell legible ("OS: —"). */}
+                      {value || '—'}
                     </Text>
                   );
                 })}

--- a/apps/mobile/src/screens/chat/components/MarkdownBody.tsx
+++ b/apps/mobile/src/screens/chat/components/MarkdownBody.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
+import { Text, View } from 'react-native';
 import Markdown, { type RenderRules } from 'react-native-markdown-display';
 
 import { useApprovalTheme, fontFamily, radii, spacing } from '../../../theme';
+import { parseMarkdownTable } from './markdownTable';
 
 interface Props {
   content: string;
@@ -155,27 +157,45 @@ export function MarkdownBody({ content }: Props) {
         height: 0,
         backgroundColor: 'transparent',
       },
-      table: {
-        borderColor: theme.border,
+      // No table/thead/tr/th/td styles here: tables are rendered entirely by
+      // the custom `table` rule below (issue #3119).
+    }),
+    [theme],
+  );
+
+  // Custom table renderer (issue #3119). With mergeStyle={false} the library
+  // drops its default layout styles (tr: row direction, th/td: flex 1), so
+  // cells collapsed into full-width stacked lines. Rather than restoring the
+  // grid — which squeezes 3+ columns into unreadable slivers at phone widths
+  // or forces a horizontal scroller nested inside the chat scroll — tables
+  // render as stacked rows with the column label repeated per value
+  // ("OS: Windows Server"), matching the app's block cards (DeviceCard etc.).
+  const tableStyles = useMemo(
+    () => ({
+      card: {
         borderWidth: 1,
+        borderColor: theme.border,
         borderRadius: radii.md,
         marginVertical: spacing[2],
+        overflow: 'hidden' as const,
       },
-      thead: {
-        backgroundColor: theme.bg2,
+      row: {
+        paddingHorizontal: spacing[4],
+        paddingVertical: spacing[3],
       },
-      th: {
-        padding: spacing[3],
+      rowDivider: {
+        borderTopWidth: 1,
+        borderTopColor: theme.border,
+      },
+      line: {
+        fontFamily: fontFamily.sans,
+        fontSize: 15,
+        lineHeight: 22,
+        color: theme.textHi,
+      },
+      label: {
         fontFamily: fontFamily.sansSemiBold,
-        color: theme.textHi,
-      },
-      td: {
-        padding: spacing[3],
-        color: theme.textHi,
-      },
-      tr: {
-        borderBottomColor: theme.border,
-        borderBottomWidth: 1,
+        color: theme.textMd,
       },
     }),
     [theme],
@@ -187,8 +207,40 @@ export function MarkdownBody({ content }: Props) {
   const rules: RenderRules = useMemo(
     () => ({
       hr: () => null,
+      table: (node) => {
+        const { labels, rows } = parseMarkdownTable(node);
+        // Header-only table: show the header cells as a plain row rather
+        // than dropping the content (no labels to pair them with).
+        const bodyRows = rows.length > 0 ? rows : labels.length > 0 ? [labels] : [];
+        if (bodyRows.length === 0) {
+          return null;
+        }
+        const showLabels = rows.length > 0;
+        return (
+          <View key={node.key} style={tableStyles.card}>
+            {bodyRows.map((cells, rowIndex) => (
+              <View
+                key={rowIndex}
+                style={
+                  rowIndex > 0 ? [tableStyles.row, tableStyles.rowDivider] : tableStyles.row
+                }
+              >
+                {cells.map((value, cellIndex) => {
+                  const label = showLabels ? labels[cellIndex] : undefined;
+                  return (
+                    <Text key={cellIndex} style={tableStyles.line}>
+                      {label ? <Text style={tableStyles.label}>{label}: </Text> : null}
+                      {value}
+                    </Text>
+                  );
+                })}
+              </View>
+            ))}
+          </View>
+        );
+      },
     }),
-    [],
+    [tableStyles],
   );
 
   return (

--- a/apps/mobile/src/screens/chat/components/markdownTable.test.ts
+++ b/apps/mobile/src/screens/chat/components/markdownTable.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractCellText,
+  parseMarkdownTable,
+  type MarkdownTableNode,
+} from './markdownTable';
+
+// Fixture builders mirroring the react-native-markdown-display AST shape:
+// table → thead → tr → th → textgroup → text (see markdownTable.ts header).
+const text = (content: string): MarkdownTableNode => ({ type: 'text', content });
+const textgroup = (...children: MarkdownTableNode[]): MarkdownTableNode => ({
+  type: 'textgroup',
+  children,
+});
+const node = (type: string, ...children: MarkdownTableNode[]): MarkdownTableNode => ({
+  type,
+  children,
+});
+const cell = (type: 'th' | 'td', content: string): MarkdownTableNode =>
+  node(type, textgroup(text(content)));
+
+const fleetTable: MarkdownTableNode = node(
+  'table',
+  node('thead', node('tr', cell('th', 'Device'), cell('th', 'OS'), cell('th', 'Last Seen'))),
+  node(
+    'tbody',
+    node(
+      'tr',
+      cell('td', 'Domain Controller (RVW-DC-01)'),
+      cell('td', 'Windows Server'),
+      cell('td', 'July 11, 2:03 AM'),
+    ),
+    node(
+      'tr',
+      cell('td', 'Reception PC (RVW-WIN-01)'),
+      cell('td', 'Windows'),
+      cell('td', 'July 11, 2:02 AM'),
+    ),
+  ),
+);
+
+describe('parseMarkdownTable', () => {
+  it('parses header labels and body rows from a GFM table AST', () => {
+    expect(parseMarkdownTable(fleetTable)).toEqual({
+      labels: ['Device', 'OS', 'Last Seen'],
+      rows: [
+        ['Domain Controller (RVW-DC-01)', 'Windows Server', 'July 11, 2:03 AM'],
+        ['Reception PC (RVW-WIN-01)', 'Windows', 'July 11, 2:02 AM'],
+      ],
+    });
+  });
+
+  it('finds rows without relying on thead/tbody wrappers', () => {
+    const bare = node(
+      'table',
+      node('tr', cell('th', 'A'), cell('th', 'B')),
+      node('tr', cell('td', '1'), cell('td', '2')),
+    );
+    expect(parseMarkdownTable(bare)).toEqual({
+      labels: ['A', 'B'],
+      rows: [['1', '2']],
+    });
+  });
+
+  it('keeps ragged rows (fewer or more cells than the header)', () => {
+    const ragged = node(
+      'table',
+      node('thead', node('tr', cell('th', 'A'), cell('th', 'B'))),
+      node('tbody', node('tr', cell('td', 'only')), node('tr', cell('td', '1'), cell('td', '2'), cell('td', '3'))),
+    );
+    expect(parseMarkdownTable(ragged).rows).toEqual([['only'], ['1', '2', '3']]);
+  });
+
+  it('treats extra header rows as body rows so content is not dropped', () => {
+    const twoHeaders = node(
+      'table',
+      node('thead', node('tr', cell('th', 'A')), node('tr', cell('th', 'A2'))),
+      node('tbody', node('tr', cell('td', '1'))),
+    );
+    expect(parseMarkdownTable(twoHeaders)).toEqual({
+      labels: ['A'],
+      rows: [['A2'], ['1']],
+    });
+  });
+
+  it('returns empty labels for a table without a header row', () => {
+    const headerless = node('table', node('tbody', node('tr', cell('td', 'x'), cell('td', 'y'))));
+    expect(parseMarkdownTable(headerless)).toEqual({ labels: [], rows: [['x', 'y']] });
+  });
+
+  it('returns a header-only table as labels with no rows', () => {
+    const headerOnly = node('table', node('thead', node('tr', cell('th', 'A'), cell('th', 'B'))));
+    expect(parseMarkdownTable(headerOnly)).toEqual({ labels: ['A', 'B'], rows: [] });
+  });
+
+  it('handles an empty table node', () => {
+    expect(parseMarkdownTable(node('table'))).toEqual({ labels: [], rows: [] });
+  });
+
+  it('collapses whitespace and trims cell text', () => {
+    const table = node(
+      'table',
+      node('thead', node('tr', node('th', textgroup(text('  Last '), text(' Seen  '))))),
+    );
+    expect(parseMarkdownTable(table).labels).toEqual(['Last Seen']);
+  });
+});
+
+describe('extractCellText', () => {
+  it('flattens inline markup to its text content', () => {
+    const rich = node(
+      'td',
+      textgroup(
+        node('strong', text('RVW-DC-01')),
+        text(' is '),
+        { type: 'code_inline', content: 'offline' },
+      ),
+    );
+    expect(extractCellText(rich)).toBe('RVW-DC-01 is offline');
+  });
+
+  it('renders soft/hard breaks as spaces', () => {
+    const broken = node('td', textgroup(text('a'), { type: 'softbreak' }, text('b')));
+    expect(extractCellText(broken)).toBe('a b');
+  });
+
+  it('uses alt text for images', () => {
+    const img: MarkdownTableNode = {
+      type: 'image',
+      attributes: { alt: 'screenshot' },
+    };
+    expect(extractCellText(node('td', img))).toBe('screenshot');
+  });
+});

--- a/apps/mobile/src/screens/chat/components/markdownTable.test.ts
+++ b/apps/mobile/src/screens/chat/components/markdownTable.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractCellText,
   parseMarkdownTable,
+  toDisplayRows,
   type MarkdownTableNode,
 } from './markdownTable';
 
@@ -104,6 +105,33 @@ describe('parseMarkdownTable', () => {
       node('thead', node('tr', node('th', textgroup(text('  Last '), text(' Seen  '))))),
     );
     expect(parseMarkdownTable(table).labels).toEqual(['Last Seen']);
+  });
+});
+
+describe('toDisplayRows', () => {
+  it('labels body rows when a header exists', () => {
+    expect(toDisplayRows({ labels: ['A', 'B'], rows: [['1', '2']] })).toEqual({
+      rows: [['1', '2']],
+      showLabels: true,
+    });
+  });
+
+  it('renders headerless rows without labels', () => {
+    expect(toDisplayRows({ labels: [], rows: [['1', '2']] })).toEqual({
+      rows: [['1', '2']],
+      showLabels: false,
+    });
+  });
+
+  it('turns a header-only table into one unlabelled row', () => {
+    expect(toDisplayRows({ labels: ['A', 'B'], rows: [] })).toEqual({
+      rows: [['A', 'B']],
+      showLabels: false,
+    });
+  });
+
+  it('renders nothing for an empty table', () => {
+    expect(toDisplayRows({ labels: [], rows: [] })).toEqual({ rows: [], showLabels: false });
   });
 });
 

--- a/apps/mobile/src/screens/chat/components/markdownTable.ts
+++ b/apps/mobile/src/screens/chat/components/markdownTable.ts
@@ -40,7 +40,12 @@ function collectDescendants(
   return out;
 }
 
-/** Flatten a cell subtree to plain text (inline markup is dropped, content kept). */
+/**
+ * Flatten a cell subtree to plain text (inline markup is dropped, content
+ * kept). Note this is lossy by design: links keep their label but lose the
+ * href (they render as inert text inside tables), and images reduce to alt
+ * text.
+ */
 export function extractCellText(node: MarkdownTableNode): string {
   if (node.type === 'softbreak' || node.type === 'hardbreak') {
     return ' ';
@@ -85,4 +90,28 @@ export function parseMarkdownTable(table: MarkdownTableNode): ParsedMarkdownTabl
 
   const [labels = [], ...extraHeaderRows] = headerRows;
   return { labels, rows: [...extraHeaderRows, ...bodyRows] };
+}
+
+export interface MarkdownTableDisplay {
+  /** Rows to render, each as cell texts in column order. Empty → render nothing. */
+  rows: string[][];
+  /** Whether to prefix each value with its column label. */
+  showLabels: boolean;
+}
+
+/**
+ * Decide what the stacked renderer should draw:
+ * - Normal table → body rows, labelled.
+ * - Header-only table → the header cells as one plain row (no labels to pair).
+ * - Headerless table → body rows, unlabelled.
+ * - Empty table → nothing.
+ */
+export function toDisplayRows({ labels, rows }: ParsedMarkdownTable): MarkdownTableDisplay {
+  if (rows.length > 0) {
+    return { rows, showLabels: labels.length > 0 };
+  }
+  if (labels.length > 0) {
+    return { rows: [labels], showLabels: false };
+  }
+  return { rows: [], showLabels: false };
 }

--- a/apps/mobile/src/screens/chat/components/markdownTable.ts
+++ b/apps/mobile/src/screens/chat/components/markdownTable.ts
@@ -1,0 +1,88 @@
+// Pure AST helpers behind the chat markdown table renderer (issue #3119).
+//
+// react-native-markdown-display parses GFM tables into an AST shaped like
+//   table → thead → tr → th → textgroup → text
+//         → tbody → tr → td → textgroup → text
+// but the wrapper layers vary (textgroup only appears around inline runs,
+// and some pipelines emit tr directly under table), so discovery here is
+// recursive rather than positional.
+//
+// Deliberately free of React / React Native imports so the mobile Vitest
+// config (node env, .ts only) can cover it.
+
+export interface MarkdownTableNode {
+  type: string;
+  content?: string;
+  children?: readonly MarkdownTableNode[];
+  attributes?: Record<string, unknown>;
+}
+
+export interface ParsedMarkdownTable {
+  /** Header cell texts, in column order. Empty when the table has no header row. */
+  labels: string[];
+  /** Body rows (plus any extra header rows), each as cell texts in column order. */
+  rows: string[][];
+}
+
+/** Depth-first collect of descendant nodes matching `types`, without descending into a match. */
+function collectDescendants(
+  node: MarkdownTableNode,
+  types: readonly string[],
+  out: MarkdownTableNode[] = [],
+): MarkdownTableNode[] {
+  for (const child of node.children ?? []) {
+    if (types.includes(child.type)) {
+      out.push(child);
+    } else {
+      collectDescendants(child, types, out);
+    }
+  }
+  return out;
+}
+
+/** Flatten a cell subtree to plain text (inline markup is dropped, content kept). */
+export function extractCellText(node: MarkdownTableNode): string {
+  if (node.type === 'softbreak' || node.type === 'hardbreak') {
+    return ' ';
+  }
+  if (node.type === 'image') {
+    return String(node.attributes?.alt ?? '');
+  }
+  const children = node.children ?? [];
+  if (children.length === 0) {
+    return node.content ?? '';
+  }
+  return children.map(extractCellText).join('');
+}
+
+function cellText(node: MarkdownTableNode): string {
+  return extractCellText(node).replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Parse a `table` AST node into header labels and body rows.
+ *
+ * A row counts as a header row when any of its cells is a `th`. Only the
+ * first header row supplies labels; any further header rows are kept as
+ * ordinary rows so no content is silently dropped.
+ */
+export function parseMarkdownTable(table: MarkdownTableNode): ParsedMarkdownTable {
+  const headerRows: string[][] = [];
+  const bodyRows: string[][] = [];
+
+  for (const tr of collectDescendants(table, ['tr'])) {
+    const cells = collectDescendants(tr, ['th', 'td']);
+    if (cells.length === 0) {
+      continue;
+    }
+    const values = cells.map(cellText);
+    if (cells.some((cell) => cell.type === 'th')) {
+      headerRows.push(values);
+    } else {
+      bodyRows.push(values);
+    }
+  }
+
+  const [labels = [], ...extraHeaderRows] = headerRows;
+  return { labels, rows: [...extraHeaderRows, ...bodyRows] };
+}


### PR DESCRIPTION
Closes #3119

## Root cause

`MarkdownBody.tsx` passes `mergeStyle={false}` to `react-native-markdown-display`, which discards the library's **default layout styles** — including `tr: { flexDirection: 'row' }` and `th`/`td: { flex: 1 }`. The app's own `table`/`tr`/`th`/`td` style overrides were purely decorative (borders, padding, fonts), so table cells fell back to React Native's default column stacking: every cell on its own full-width line, exactly as reported. The table rules were wired in all along; the layout styles were dropped.

## Fix — deliberate stacked/labelled renderer (option 2)

The issue offered two directions. This PR implements **option 2** (stacked rows with the column label repeated per value), as a reasoned choice:

- The observed tables are wide fleet tables (`Device | OS | Last Seen`) with long values. Restoring the grid (`flex: 1` columns) squeezes 3+ columns into unreadable wrapped slivers at phone widths, and a horizontally-scrollable table nested inside the vertical chat scroll both fights the scroll gesture and puts the header/columns off-screen — recreating the value↔column association loss the issue complains about, just in another form.
- The chat already renders structured data as stacked block cards (`DeviceCard`, `FleetStatusRow`), so labelled stacked rows match the existing visual language.
- The issue author leaned this way; the accidental collapse becomes a deliberate design.

Each table renders as a bordered card (theme tokens: `border`, `radii.md`), one block per row separated by hairline dividers, each value on a line prefixed with its muted semibold column label: `OS: Windows Server`.

## Implementation

- `apps/mobile/src/screens/chat/components/markdownTable.ts` — new pure helper (no React/RN imports, so the node-env Vitest config can cover it): parses the `table` AST node into `{ labels, rows }`. Discovery of `tr`/`th`/`td` is recursive, so `textgroup` wrappers and missing `thead`/`tbody` don't break it; cell text is flattened from inline markup (bold/code kept as text, breaks as spaces, image alt text). Edge handling: ragged rows kept as-is, extra header rows demoted to body rows rather than dropped, header-only tables render the header cells as a plain row, headerless tables render values without labels.
- `MarkdownBody.tsx` — custom `table` render rule using the helper; the now-dead decorative `table`/`thead`/`th`/`td`/`tr` styles are removed.

## Verification

- `pnpm exec vitest run` (apps/mobile): **28 files, 272 passed, 3 skipped** — includes 11 new tests for the table parser.
- `pnpm run typecheck` (apps/mobile, `tsc --noEmit`): clean.
- **Visual rendering has NOT been verified on a device/emulator** — the mobile app has no RN component test runtime, and I deliberately did not touch the shared dev stack/emulator. On-device verification (Android emulator, AI chat with a table-bearing response) should confirm the stacked card layout before merge.

## Stacked PR note

This PR is **based on `ToddHebebrand/ios-app-testing`** (not `main`) because the issue was diagnosed against its 4 unmerged mobile commits. `ci.yml` only triggers on PRs targeting `main`, so **no CI runs here** — verification above was run locally. Dispatch `gh workflow run CI --ref fix/3119-mobile-markdown-tables` if a CI record is wanted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)