### PR TITLE
fix(deps): bump fast-uri override to 3.1.5 for CVE-2026-18446

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "fast-xml-parser@<5.5.7": ">=5.5.7",
       "fast-xml-parser@<5.7.0": ">=5.7.0",
       "fast-xml-parser@<5.10.1": ">=5.10.1",
-      "fast-uri@>=3.0.0 <3.1.4": "3.1.4",
+      "fast-uri@>=3.0.0 <3.1.5": "3.1.5",
       "brace-expansion@<1.1.18": ">=1.1.18",
       "brace-expansion@>=2.0.0 <2.1.4": ">=5.0.9",
       "brace-expansion@>=4.0.0 <5.0.9": ">=5.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   fast-xml-parser@<5.5.7: '>=5.5.7'
   fast-xml-parser@<5.7.0: '>=5.7.0'
   fast-xml-parser@<5.10.1: '>=5.10.1'
-  fast-uri@>=3.0.0 <3.1.4: 3.1.4
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
   brace-expansion@<1.1.18: '>=1.1.18'
   brace-expansion@>=2.0.0 <2.1.4: '>=5.0.9'
   brace-expansion@>=4.0.0 <5.0.9: '>=5.0.9'
@@ -7654,8 +7654,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -15423,9 +15423,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.0': {}
 
@@ -17275,7 +17273,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -19163,7 +19161,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
The existing override pinned fast-uri to 3.1.4 (the fix for the previous advisory); CVE-2026-18446 (host confusion) now affects 3.1.4 itself, and the blocking Trivy filesystem/image scans went red on every branch when the advisory published today. Bumps the override to the fixed 3.1.5 line and regenerates the lockfile (single resolution, no duplicate keys).

Verification: `pnpm install --lockfile-only` resolves cleanly; the PR's own Trivy jobs are the functional test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)