### PR TITLE
ci: add test-mobile job so the apps/mobile vitest suite runs in CI (#3139)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,38 @@ jobs:
       - name: Run Web tests
         run: pnpm test --filter=@breeze/web
 
+  # Not yet wired into ci-success / branch protection — see #3139. Promote to
+  # required once the job proves stable.
+  test-mobile:
+    name: Test Mobile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .node-version
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Mobile tests
+        run: pnpm test --filter=breeze-mobile
+
+      - name: Run Mobile type check
+        working-directory: apps/mobile
+        run: pnpm exec tsc --noEmit
+
   test-portal:
     name: Test Portal
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`ci.yml` had required `test-api`/`test-web`/`test-agent` jobs but nothing ran the `apps/mobile` vitest suite or its typecheck — all 28 mobile test files were local-only, so a mobile regression merged green (flagged independently by reviewers on #3124, #3125, #3131).

This adds a `test-mobile` job mirroring `test-web`:

- same pinned `actions/checkout` / `pnpm/action-setup` / `actions/setup-node` steps (`.node-version`, pnpm cache, `pnpm install --frozen-lockfile`)
- `pnpm test --filter=breeze-mobile` (root `test` = `turbo run test`; package name per `apps/mobile/package.json`)
- `pnpm exec tsc --noEmit` with `working-directory: apps/mobile` (the existing `typecheck` job only covers `apps/api` + astro)

Deliberately **not** wired into the `ci-success` aggregate and **not** marked required in branch protection — the issue asks to promote it only once it proves stable. A comment above the job records that.

Closes #3139

## Stacked PR — CI will not run here

This PR is based on `ToddHebebrand/ios-app-testing` (stacked), and `ci.yml` triggers only on `pull_request: branches: [main]`, so the workflow — including the new job — will not run on this PR. Validation was done locally instead:

- `actionlint .github/workflows/ci.yml` — no new findings (one pre-existing SC2155 warning in an unrelated script, present on the base at line 1031).
- `pnpm install --frozen-lockfile` then `pnpm test --filter=breeze-mobile` in a fresh worktree of the base branch: **27 test files passed, 261 passed / 3 skipped** — exactly the expected suite.
- `pnpm exec tsc --noEmit` in `apps/mobile`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)