### PR TITLE
fix(mobile): lift ChangePasswordSheet and SearchSheet above the Android keyboard (#3142)

### DIFF
--- a/apps/mobile/src/screens/approvals/components/DenyReasonSheet.tsx
+++ b/apps/mobile/src/screens/approvals/components/DenyReasonSheet.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Modal, Pressable, Text, TextInput, View } from 'react-native';
+import { KeyboardAvoidingView, Modal, Platform, Pressable, Text, TextInput, View } from 'react-native';
 import { useApprovalTheme, type, spacing, radii, palette } from '../../../theme';
 
 interface Props {
@@ -25,71 +25,76 @@ export function DenyReasonSheet({ visible, onCancel, onSubmit }: Props) {
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={handleCancel}>
-      <Pressable
-        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
-        onPress={handleCancel}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={{ flex: 1 }}
       >
         <Pressable
-          onPress={(e) => e.stopPropagation()}
-          style={{
-            backgroundColor: theme.bg1,
-            borderTopLeftRadius: radii.xl,
-            borderTopRightRadius: radii.xl,
-            padding: spacing[6],
-            paddingBottom: spacing[10],
-          }}
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
+          onPress={handleCancel}
         >
-          <Text style={[type.title, { color: theme.textHi }]}>Why deny?</Text>
-          <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
-            Optional. Helps the requesting session understand.
-          </Text>
-          <TextInput
-            value={reason}
-            onChangeText={setReason}
-            placeholder="Reason"
-            placeholderTextColor={theme.textLo}
-            multiline
-            style={[
-              type.body,
-              {
-                color: theme.textHi,
-                backgroundColor: theme.bg2,
-                borderRadius: radii.md,
-                padding: spacing[4],
-                marginTop: spacing[4],
-                minHeight: 88,
-                textAlignVertical: 'top',
-              },
-            ]}
-          />
-          <View style={{ flexDirection: 'row', marginTop: spacing[5], gap: spacing[3] }}>
-            <Pressable
-              onPress={handleCancel}
-              style={{
-                flex: 1,
-                paddingVertical: spacing[4],
-                alignItems: 'center',
-                borderRadius: radii.md,
-                backgroundColor: theme.bg2,
-              }}
-            >
-              <Text style={[type.bodyMd, { color: theme.textHi }]}>Cancel</Text>
-            </Pressable>
-            <Pressable
-              onPress={handleSubmit}
-              style={{
-                flex: 1,
-                paddingVertical: spacing[4],
-                alignItems: 'center',
-                borderRadius: radii.md,
-                backgroundColor: theme.deny,
-              }}
-            >
-              <Text style={[type.bodyMd, { color: palette.deny.onBase }]}>Deny</Text>
-            </Pressable>
-          </View>
+          <Pressable
+            onPress={(e) => e.stopPropagation()}
+            style={{
+              backgroundColor: theme.bg1,
+              borderTopLeftRadius: radii.xl,
+              borderTopRightRadius: radii.xl,
+              padding: spacing[6],
+              paddingBottom: spacing[10],
+            }}
+          >
+            <Text style={[type.title, { color: theme.textHi }]}>Why deny?</Text>
+            <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
+              Optional. Helps the requesting session understand.
+            </Text>
+            <TextInput
+              value={reason}
+              onChangeText={setReason}
+              placeholder="Reason"
+              placeholderTextColor={theme.textLo}
+              multiline
+              style={[
+                type.body,
+                {
+                  color: theme.textHi,
+                  backgroundColor: theme.bg2,
+                  borderRadius: radii.md,
+                  padding: spacing[4],
+                  marginTop: spacing[4],
+                  minHeight: 88,
+                  textAlignVertical: 'top',
+                },
+              ]}
+            />
+            <View style={{ flexDirection: 'row', marginTop: spacing[5], gap: spacing[3] }}>
+              <Pressable
+                onPress={handleCancel}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.md,
+                  backgroundColor: theme.bg2,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: theme.textHi }]}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleSubmit}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.md,
+                  backgroundColor: theme.deny,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: palette.deny.onBase }]}>Deny</Text>
+              </Pressable>
+            </View>
+          </Pressable>
         </Pressable>
-      </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/apps/mobile/src/screens/chat/components/ChangePasswordSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/ChangePasswordSheet.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import {
   Alert,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
   Text,
   TextInput,
@@ -180,94 +182,99 @@ export function ChangePasswordSheet({ visible, onCancel, onSuccess }: Props) {
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={handleCancel}>
-      <Pressable
-        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
-        onPress={handleCancel}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={{ flex: 1 }}
       >
         <Pressable
-          onPress={(e) => e.stopPropagation()}
-          style={{
-            backgroundColor: theme.bg1,
-            borderTopLeftRadius: radii.xl,
-            borderTopRightRadius: radii.xl,
-            padding: spacing[6],
-            paddingBottom: insets.bottom + spacing[6],
-          }}
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
+          onPress={handleCancel}
         >
-          <View
+          <Pressable
+            onPress={(e) => e.stopPropagation()}
             style={{
-              alignSelf: 'center',
-              width: 36,
-              height: 4,
-              borderRadius: 2,
-              backgroundColor: theme.bg3,
-              marginBottom: spacing[4],
+              backgroundColor: theme.bg1,
+              borderTopLeftRadius: radii.xl,
+              borderTopRightRadius: radii.xl,
+              padding: spacing[6],
+              paddingBottom: insets.bottom + spacing[6],
             }}
-          />
-          <Text style={[type.title, { color: theme.textHi }]}>Change password</Text>
-          <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
-            8+ characters, with at least one uppercase, lowercase, and number.
-          </Text>
-
-          <PasswordField
-            label="CURRENT"
-            value={current}
-            onChangeText={setCurrent}
-            textColor={theme.textHi}
-            bg2={theme.bg2}
-            textLo={theme.textLo}
-          />
-          <PasswordField
-            label="NEW"
-            value={next}
-            onChangeText={setNext}
-            textColor={theme.textHi}
-            bg2={theme.bg2}
-            textLo={theme.textLo}
-          />
-          <PasswordField
-            label="CONFIRM NEW"
-            value={confirm}
-            onChangeText={setConfirm}
-            textColor={theme.textHi}
-            bg2={theme.bg2}
-            textLo={theme.textLo}
-          />
-
-          <View style={{ flexDirection: 'row', marginTop: spacing[6], gap: spacing[3] }}>
-            <Pressable
-              onPress={handleCancel}
-              disabled={submitting}
+          >
+            <View
               style={{
-                flex: 1,
-                paddingVertical: spacing[4],
-                alignItems: 'center',
-                borderRadius: radii.lg,
-                backgroundColor: theme.bg2,
-                opacity: submitting ? 0.5 : 1,
+                alignSelf: 'center',
+                width: 36,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: theme.bg3,
+                marginBottom: spacing[4],
               }}
-            >
-              <Text style={[type.bodyMd, { color: theme.textHi }]}>Cancel</Text>
-            </Pressable>
-            <Pressable
-              onPress={handleSubmit}
-              disabled={submitting}
-              style={{
-                flex: 1.4,
-                paddingVertical: spacing[4],
-                alignItems: 'center',
-                borderRadius: radii.lg,
-                backgroundColor: theme.brand,
-                opacity: submitting ? 0.5 : 1,
-              }}
-            >
-              <Text style={[type.bodyMd, { color: palette.approve.onBase }]}>
-                {submitting ? 'Saving' : 'Save'}
-              </Text>
-            </Pressable>
-          </View>
+            />
+            <Text style={[type.title, { color: theme.textHi }]}>Change password</Text>
+            <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
+              8+ characters, with at least one uppercase, lowercase, and number.
+            </Text>
+
+            <PasswordField
+              label="CURRENT"
+              value={current}
+              onChangeText={setCurrent}
+              textColor={theme.textHi}
+              bg2={theme.bg2}
+              textLo={theme.textLo}
+            />
+            <PasswordField
+              label="NEW"
+              value={next}
+              onChangeText={setNext}
+              textColor={theme.textHi}
+              bg2={theme.bg2}
+              textLo={theme.textLo}
+            />
+            <PasswordField
+              label="CONFIRM NEW"
+              value={confirm}
+              onChangeText={setConfirm}
+              textColor={theme.textHi}
+              bg2={theme.bg2}
+              textLo={theme.textLo}
+            />
+
+            <View style={{ flexDirection: 'row', marginTop: spacing[6], gap: spacing[3] }}>
+              <Pressable
+                onPress={handleCancel}
+                disabled={submitting}
+                style={{
+                  flex: 1,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.lg,
+                  backgroundColor: theme.bg2,
+                  opacity: submitting ? 0.5 : 1,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: theme.textHi }]}>Cancel</Text>
+              </Pressable>
+              <Pressable
+                onPress={handleSubmit}
+                disabled={submitting}
+                style={{
+                  flex: 1.4,
+                  paddingVertical: spacing[4],
+                  alignItems: 'center',
+                  borderRadius: radii.lg,
+                  backgroundColor: theme.brand,
+                  opacity: submitting ? 0.5 : 1,
+                }}
+              >
+                <Text style={[type.bodyMd, { color: palette.approve.onBase }]}>
+                  {submitting ? 'Saving' : 'Save'}
+                </Text>
+              </Pressable>
+            </View>
+          </Pressable>
         </Pressable>
-      </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/apps/mobile/src/screens/search/SearchSheet.tsx
+++ b/apps/mobile/src/screens/search/SearchSheet.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
 import {
   FlatList,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
   Text,
   TextInput,
@@ -200,143 +202,148 @@ export function SearchSheet({ visible, onCancel, onSelect }: Props) {
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onCancel}>
-      <Pressable
-        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
-        onPress={onCancel}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={{ flex: 1 }}
       >
         <Pressable
-          onPress={(e) => e.stopPropagation()}
-          style={{
-            backgroundColor: theme.bg1,
-            borderTopLeftRadius: radii.xl,
-            borderTopRightRadius: radii.xl,
-            paddingTop: spacing[5],
-            paddingBottom: spacing[10],
-            maxHeight: '80%',
-          }}
+          style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.55)', justifyContent: 'flex-end' }}
+          onPress={onCancel}
         >
-          <View
+          <Pressable
+            onPress={(e) => e.stopPropagation()}
             style={{
-              alignSelf: 'center',
-              width: 36,
-              height: 4,
-              borderRadius: 2,
-              backgroundColor: theme.bg3,
-              marginBottom: spacing[4],
+              backgroundColor: theme.bg1,
+              borderTopLeftRadius: radii.xl,
+              borderTopRightRadius: radii.xl,
+              paddingTop: spacing[5],
+              paddingBottom: spacing[10],
+              maxHeight: '80%',
             }}
-          />
-
-          <View style={{ paddingHorizontal: spacing[6] }}>
+          >
             <View
               style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                backgroundColor: theme.bg2,
-                borderRadius: radii.md,
-                paddingHorizontal: spacing[3],
-                height: 40,
+                alignSelf: 'center',
+                width: 36,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: theme.bg3,
+                marginBottom: spacing[4],
               }}
-            >
-              <SearchGlyph color={theme.textLo} />
-              <TextInput
-                ref={inputRef}
-                value={query}
-                onChangeText={setQuery}
-                placeholder="Search devices, alerts, conversations"
-                placeholderTextColor={theme.textLo}
-                autoCapitalize="none"
-                autoCorrect={false}
-                returnKeyType="search"
-                accessibilityLabel="Search"
-                style={[
-                  type.body,
-                  {
-                    flex: 1,
-                    marginLeft: spacing[2],
-                    color: theme.textHi,
-                    paddingVertical: 0,
-                  },
-                ]}
-              />
-              {trimmed ? (
-                <Pressable
-                  onPress={() => {
-                    setQuery('');
-                    inputRef.current?.focus();
-                  }}
-                  hitSlop={8}
-                  accessibilityLabel="Clear search"
-                >
-                  <Text style={[type.meta, { color: theme.textMd }]}>Clear</Text>
-                </Pressable>
-              ) : null}
-            </View>
-          </View>
-
-          {error ? (
-            <View
-              style={{
-                paddingHorizontal: spacing[6],
-                paddingTop: spacing[4],
-              }}
-            >
-              <Text style={[type.meta, { color: palette.deny.base }]}>
-                Couldn't search. Try again.
-              </Text>
-            </View>
-          ) : null}
-
-          {showEmptyHint ? (
-            <View
-              style={{
-                paddingHorizontal: spacing[6],
-                paddingTop: spacing[5],
-              }}
-            >
-              <Text style={[type.meta, { color: theme.textLo }]}>
-                Try a hostname, alert title, or chat snippet.
-              </Text>
-            </View>
-          ) : null}
-
-          {showSkeleton ? (
-            <View style={{ marginTop: spacing[4] }}>
-              <SkeletonRow borderColor={theme.border} bg={theme.bg2} />
-              <SkeletonRow borderColor={theme.border} bg={theme.bg2} />
-              <SkeletonRow borderColor={theme.border} bg={theme.bg2} />
-            </View>
-          ) : null}
-
-          {showNoMatches ? (
-            <View
-              style={{
-                paddingHorizontal: spacing[6],
-                paddingTop: spacing[5],
-              }}
-            >
-              <Text style={[type.meta, { color: theme.textLo }]}>
-                No matches yet. Keep typing.
-              </Text>
-            </View>
-          ) : null}
-
-          {results.length > 0 ? (
-            <FlatList
-              data={results}
-              keyExtractor={(r) => `${r.kind}:${r.id}`}
-              keyboardShouldPersistTaps="handled"
-              style={{ marginTop: spacing[3] }}
-              renderItem={({ item }) => (
-                <ResultRow
-                  result={item}
-                  borderColor={theme.border}
-                  onPress={() => handleSelect(item)}
-                />
-              )}
             />
-          ) : null}
+
+            <View style={{ paddingHorizontal: spacing[6] }}>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  backgroundColor: theme.bg2,
+                  borderRadius: radii.md,
+                  paddingHorizontal: spacing[3],
+                  height: 40,
+                }}
+              >
+                <SearchGlyph color={theme.textLo} />
+                <TextInput
+                  ref={inputRef}
+                  value={query}
+                  onChangeText={setQuery}
+                  placeholder="Search devices, alerts, conversations"
+                  placeholderTextColor={theme.textLo}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  returnKeyType="search"
+                  accessibilityLabel="Search"
+                  style={[
+                    type.body,
+                    {
+                      flex: 1,
+                      marginLeft: spacing[2],
+                      color: theme.textHi,
+                      paddingVertical: 0,
+                    },
+                  ]}
+                />
+                {trimmed ? (
+                  <Pressable
+                    onPress={() => {
+                      setQuery('');
+                      inputRef.current?.focus();
+                    }}
+                    hitSlop={8}
+                    accessibilityLabel="Clear search"
+                  >
+                    <Text style={[type.meta, { color: theme.textMd }]}>Clear</Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            </View>
+
+            {error ? (
+              <View
+                style={{
+                  paddingHorizontal: spacing[6],
+                  paddingTop: spacing[4],
+                }}
+              >
+                <Text style={[type.meta, { color: palette.deny.base }]}>
+                  Couldn't search. Try again.
+                </Text>
+              </View>
+            ) : null}
+
+            {showEmptyHint ? (
+              <View
+                style={{
+                  paddingHorizontal: spacing[6],
+                  paddingTop: spacing[5],
+                }}
+              >
+                <Text style={[type.meta, { color: theme.textLo }]}>
+                  Try a hostname, alert title, or chat snippet.
+                </Text>
+              </View>
+            ) : null}
+
+            {showSkeleton ? (
+              <View style={{ marginTop: spacing[4] }}>
+                <SkeletonRow borderColor={theme.border} bg={theme.bg2} />
+                <SkeletonRow borderColor={theme.border} bg={theme.bg2} />
+                <SkeletonRow borderColor={theme.border} bg={theme.bg2} />
+              </View>
+            ) : null}
+
+            {showNoMatches ? (
+              <View
+                style={{
+                  paddingHorizontal: spacing[6],
+                  paddingTop: spacing[5],
+                }}
+              >
+                <Text style={[type.meta, { color: theme.textLo }]}>
+                  No matches yet. Keep typing.
+                </Text>
+              </View>
+            ) : null}
+
+            {results.length > 0 ? (
+              <FlatList
+                data={results}
+                keyExtractor={(r) => `${r.kind}:${r.id}`}
+                keyboardShouldPersistTaps="handled"
+                style={{ marginTop: spacing[3] }}
+                renderItem={({ item }) => (
+                  <ResultRow
+                    result={item}
+                    borderColor={theme.border}
+                    onPress={() => handleSelect(item)}
+                  />
+                )}
+              />
+            ) : null}
+          </Pressable>
         </Pressable>
-      </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary

Same defect class as #3116: `ChangePasswordSheet` and `SearchSheet` are bottom-anchored Modal sheets with text inputs and no `KeyboardAvoidingView`, so focusing a field on Android raises the IME fully over the sheet. This applies the identical wrapper pattern from `DenyReasonSheet` (PR #3123): `KeyboardAvoidingView` with `behavior={Platform.OS === 'ios' ? 'padding' : 'height'}` around the sheet content inside the Modal. The diff is structurally a pure wrap + re-indent — no logic changes.

**Stacked on #3123** (`fix/3116-deny-sheet-keyboard`) so the reference implementation is on the base and there is zero conflict surface. Retarget to `ToddHebebrand/ios-app-testing` when #3123 merges. Because `ci.yml` triggers only on PRs targeting `main`, no CI runs on this PR — verification is local (below).

## Sweep for other affected sheets

Swept `apps/mobile/src` for input-bearing bottom sheets (files combining `Modal` + `TextInput`): only `DenyReasonSheet` (fixed in #3123, on this base), `ChangePasswordSheet`, and `SearchSheet` exist. No other sheets need the wrapper.

## Verification

- `npx tsc --noEmit` in `apps/mobile`: clean.
- Full mobile vitest suite: 27 files, 261 passed / 3 skipped.
- Layout behavior cannot be verified headlessly — on-device Android verification (keyboard no longer occluding the sheets) is pending with the orchestrator. Per #3123's review note, if a residual gap shows on Android, the known fallback is `behavior: undefined` on Android (letting `adjustResize` do the lift alone).

Closes #3142

🤖 Generated with [Claude Code](https://claude.com/claude-code)