### PR TITLE
fix(mobile): refresh expired access token on 401 at streamChat SSE open (#3140)

### DIFF
--- a/apps/mobile/src/services/aiChat.test.ts
+++ b/apps/mobile/src/services/aiChat.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createAiSession, listAiSessions } from './aiChat';
+import { createAiSession, listAiSessions, streamChat } from './aiChat';
+import type { AiStreamEvent } from './aiChat';
 import { refreshToken } from './api';
 import { storeToken } from './auth';
 import { fetchWithTimeout } from './fetchWithTimeout';
@@ -176,5 +177,217 @@ describe('authedFetch 401 refresh-and-retry (via listAiSessions)', () => {
     expect(r1).toHaveLength(1);
     expect(r2).toHaveLength(1);
     expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamChat SSE 401 refresh-and-reopen (#3140)
+// ---------------------------------------------------------------------------
+
+class FakeXhr {
+  static instances: FakeXhr[] = [];
+  method = '';
+  url = '';
+  headers: Record<string, string> = {};
+  withCredentials = false;
+  readyState = 0;
+  status = 0;
+  responseText = '';
+  sentBody: string | null = null;
+  abortCalled = false;
+  onreadystatechange: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor() {
+    FakeXhr.instances.push(this);
+  }
+
+  open(method: string, url: string): void {
+    this.method = method;
+    this.url = url;
+    this.readyState = 1;
+  }
+
+  setRequestHeader(key: string, value: string): void {
+    this.headers[key] = value;
+  }
+
+  send(body: string): void {
+    this.sentBody = body;
+  }
+
+  abort(): void {
+    this.abortCalled = true;
+  }
+
+  // Test helpers — simulate server behavior.
+  emitChunk(status: number, text: string): void {
+    this.status = status;
+    this.responseText += text;
+    this.readyState = 3;
+    this.onreadystatechange?.();
+  }
+
+  finish(status: number, text = ''): void {
+    this.status = status;
+    this.responseText += text;
+    this.readyState = 4;
+    this.onreadystatechange?.();
+  }
+}
+
+const flushAsync = () => new Promise((r) => setTimeout(r, 0));
+
+function startStream() {
+  const events: AiStreamEvent[] = [];
+  const onError = vi.fn();
+  const onDone = vi.fn();
+  const handle = streamChat({
+    sessionId: 'sess-1',
+    content: 'hello there',
+    onEvent: (e) => events.push(e),
+    onError,
+    onDone,
+  });
+  return { events, onError, onDone, handle };
+}
+
+describe('streamChat 401 refresh-and-reopen', () => {
+  beforeEach(() => {
+    FakeXhr.instances = [];
+    vi.stubGlobal('XMLHttpRequest', FakeXhr);
+  });
+
+  it('streams without refreshing when the token is still valid', async () => {
+    const { events, onError, onDone } = startStream();
+    await flushAsync();
+
+    expect(FakeXhr.instances).toHaveLength(1);
+    const xhr = FakeXhr.instances[0];
+    expect(xhr.method).toBe('POST');
+    expect(xhr.url).toBe('https://api.test/api/v1/ai/sessions/sess-1/messages');
+    expect(xhr.headers.Authorization).toBe('Bearer stale-token');
+    expect(xhr.headers.Accept).toBe('text/event-stream');
+    expect(xhr.headers['x-breeze-csrf']).toBe('1');
+    expect(xhr.sentBody).toBe(JSON.stringify({ content: 'hello there' }));
+
+    xhr.emitChunk(200, 'event: content_delta\ndata: {"type":"content_delta","delta":"hi"}\n\n');
+    xhr.finish(200, 'event: done\ndata: {"type":"done"}\n\n');
+
+    expect(events).toEqual([
+      { type: 'content_delta', delta: 'hi' },
+      { type: 'done' },
+    ]);
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it('refreshes on 401 at stream open and reopens once with the fresh token', async () => {
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' } as Awaited<ReturnType<typeof refreshToken>>);
+    const { events, onError, onDone } = startStream();
+    await flushAsync();
+
+    FakeXhr.instances[0].finish(401, '{"error":"Unauthorized"}');
+    await flushAsync();
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(storeTokenMock).toHaveBeenCalledWith('fresh-token');
+    expect(FakeXhr.instances).toHaveLength(2);
+    const retry = FakeXhr.instances[1];
+    expect(retry.url).toBe(FakeXhr.instances[0].url);
+    expect(retry.headers.Authorization).toBe('Bearer fresh-token');
+    expect(retry.sentBody).toBe(FakeXhr.instances[0].sentBody);
+
+    retry.emitChunk(200, 'event: content_delta\ndata: {"type":"content_delta","delta":"hi"}\n\n');
+    retry.finish(200, 'event: done\ndata: {"type":"done"}\n\n');
+
+    // The 401 body never reached callbacks; the retried stream did.
+    expect(events).toEqual([
+      { type: 'content_delta', delta: 'hi' },
+      { type: 'done' },
+    ]);
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the original 401 when the refresh fails, without reopening', async () => {
+    refreshMock.mockRejectedValueOnce({ message: 'Failed to refresh token' });
+    const { events, onError, onDone } = startStream();
+    await flushAsync();
+
+    FakeXhr.instances[0].finish(401, '{"error":"Unauthorized"}');
+    await flushAsync();
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(FakeXhr.instances).toHaveLength(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('Unauthorized');
+    expect(onDone).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it('reopens only once — a second 401 surfaces without another refresh', async () => {
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' } as Awaited<ReturnType<typeof refreshToken>>);
+    const { onError } = startStream();
+    await flushAsync();
+
+    FakeXhr.instances[0].finish(401, '{"error":"Unauthorized"}');
+    await flushAsync();
+    expect(FakeXhr.instances).toHaveLength(2);
+
+    FakeXhr.instances[1].finish(401, '{"error":"Unauthorized"}');
+    await flushAsync();
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(FakeXhr.instances).toHaveLength(2);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('Unauthorized');
+  });
+
+  it('does not reopen when aborted while the refresh is in flight', async () => {
+    let resolveRefresh: (v: { token: string }) => void;
+    refreshMock.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveRefresh = resolve; }) as ReturnType<typeof refreshToken>,
+    );
+    const { onError, onDone, handle } = startStream();
+    await flushAsync();
+
+    FakeXhr.instances[0].finish(401, '{"error":"Unauthorized"}');
+    await flushAsync();
+
+    handle.abort();
+    resolveRefresh!({ token: 'fresh-token' });
+    await flushAsync();
+
+    expect(FakeXhr.instances).toHaveLength(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('abort() aborts the retried stream, not the dead 401 attempt', async () => {
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' } as Awaited<ReturnType<typeof refreshToken>>);
+    const { handle } = startStream();
+    await flushAsync();
+
+    FakeXhr.instances[0].finish(401, '{"error":"Unauthorized"}');
+    await flushAsync();
+    expect(FakeXhr.instances).toHaveLength(2);
+
+    handle.abort();
+    expect(FakeXhr.instances[1].abortCalled).toBe(true);
+  });
+
+  it('non-401 HTTP failures surface immediately without refreshing', async () => {
+    const { onError } = startStream();
+    await flushAsync();
+
+    FakeXhr.instances[0].finish(500, '{"error":"boom"}');
+    await flushAsync();
+
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(FakeXhr.instances).toHaveLength(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('boom');
   });
 });

--- a/apps/mobile/src/services/aiChat.test.ts
+++ b/apps/mobile/src/services/aiChat.test.ts
@@ -212,7 +212,16 @@ class FakeXhr {
     this.headers[key] = value;
   }
 
+  // When set, the next send() throws synchronously (simulates platform-level
+  // XHR failures on RN/Hermes). One-shot: cleared on use.
+  static throwOnNextSend: Error | null = null;
+
   send(body: string): void {
+    if (FakeXhr.throwOnNextSend) {
+      const err = FakeXhr.throwOnNextSend;
+      FakeXhr.throwOnNextSend = null;
+      throw err;
+    }
     this.sentBody = body;
   }
 
@@ -255,6 +264,7 @@ function startStream() {
 describe('streamChat 401 refresh-and-reopen', () => {
   beforeEach(() => {
     FakeXhr.instances = [];
+    FakeXhr.throwOnNextSend = null;
     vi.stubGlobal('XMLHttpRequest', FakeXhr);
   });
 
@@ -288,7 +298,11 @@ describe('streamChat 401 refresh-and-reopen', () => {
     const { events, onError, onDone } = startStream();
     await flushAsync();
 
-    FakeXhr.instances[0].finish(401, '{"error":"Unauthorized"}');
+    // Real RN XHR delivers the 401 body incrementally at readyState 3
+    // (status is already set at HEADERS_RECEIVED) before DONE — mirror that
+    // sequence so the parse-skip guard is exercised where it matters.
+    FakeXhr.instances[0].emitChunk(401, '{"error":"Unauthorized"}');
+    FakeXhr.instances[0].finish(401);
     await flushAsync();
 
     expect(refreshMock).toHaveBeenCalledTimes(1);
@@ -376,6 +390,60 @@ describe('streamChat 401 refresh-and-reopen', () => {
 
     handle.abort();
     expect(FakeXhr.instances[1].abortCalled).toBe(true);
+  });
+
+  it('surfaces a throw from the retried open via onError instead of hanging', async () => {
+    refreshMock.mockResolvedValueOnce({ token: 'fresh-token' } as Awaited<ReturnType<typeof refreshToken>>);
+    const { onError, onDone } = startStream();
+    await flushAsync();
+
+    FakeXhr.throwOnNextSend = new Error('send exploded');
+    FakeXhr.instances[0].finish(401, '{"error":"Unauthorized"}');
+    await flushAsync();
+
+    // The retry attempt threw synchronously — the caller must still get an
+    // error callback rather than a permanently "streaming" chat.
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('send exploded');
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it('shares one single-flight refresh between a streamChat 401 and a concurrent authedFetch 401', async () => {
+    // Replaying a rotated refresh token revokes the whole token family, so a
+    // chat send racing a REST call at token expiry MUST coalesce into ONE
+    // /auth/refresh across both paths.
+    let resolveRefresh: (v: { token: string }) => void;
+    refreshMock.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveRefresh = resolve; }) as ReturnType<typeof refreshToken>,
+    );
+    fetchMock.mockImplementation(async (_url, init) => {
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      return headers.Authorization === 'Bearer fresh-token'
+        ? jsonResponse(sessionsBody)
+        : jsonResponse({ error: 'Unauthorized' }, 401);
+    });
+
+    const { events, onDone } = startStream();
+    const listPromise = listAiSessions();
+    await flushAsync();
+
+    // Both paths hit their 401 and enter the shared refresh.
+    FakeXhr.instances[0].finish(401, '{"error":"Unauthorized"}');
+    await flushAsync();
+    resolveRefresh!({ token: 'fresh-token' });
+    await flushAsync();
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+
+    // Both paths retried with the fresh token.
+    const sessions = await listPromise;
+    expect(sessions).toHaveLength(1);
+    expect(FakeXhr.instances).toHaveLength(2);
+    expect(FakeXhr.instances[1].headers.Authorization).toBe('Bearer fresh-token');
+
+    FakeXhr.instances[1].finish(200, 'event: done\ndata: {"type":"done"}\n\n');
+    expect(events).toEqual([{ type: 'done' }]);
+    expect(onDone).toHaveBeenCalledTimes(1);
   });
 
   it('non-401 HTTP failures surface immediately without refreshing', async () => {

--- a/apps/mobile/src/services/aiChat.ts
+++ b/apps/mobile/src/services/aiChat.ts
@@ -218,23 +218,16 @@ const KNOWN_EVENT_TYPES = new Set([
 // platform-spotty; XHR's incremental `responseText` reads are reliable
 // across iOS/Android/Hermes. We track how many bytes we've already parsed
 // so each `onreadystatechange` (state 3 = LOADING) only handles new data.
+//
+// Auth mirrors authedFetch (#3114/#3140): the stored access token expires
+// after 15 minutes, so a stream opened with a stale token 401s before any
+// SSE data flows. On a 401 at stream open we refresh once through the same
+// single-flighted refreshAccessToken() and reopen the stream with the fresh
+// token; a second 401 (or a failed refresh) surfaces to the caller.
 export function streamChat(opts: SseStreamOptions): SseStreamHandle {
   let aborted = false;
-  let cursor = 0;
-  let buffered = '';
-
-  const xhr = new XMLHttpRequest();
   let didEmitDone = false;
-
-  const flushBuffered = () => {
-    let idx = buffered.indexOf('\n\n');
-    while (idx !== -1) {
-      const block = buffered.slice(0, idx);
-      buffered = buffered.slice(idx + 2);
-      handleSseBlock(block);
-      idx = buffered.indexOf('\n\n');
-    }
-  };
+  let currentXhr: XMLHttpRequest | null = null;
 
   const handleSseBlock = (block: string) => {
     if (!block.trim()) return;
@@ -262,49 +255,96 @@ export function streamChat(opts: SseStreamOptions): SseStreamHandle {
     }
   };
 
+  const emitHttpError = (xhr: XMLHttpRequest) => {
+    let msg = `HTTP ${xhr.status}`;
+    try {
+      const body = JSON.parse(xhr.responseText);
+      if (body && typeof body.error === 'string') msg = body.error;
+    } catch {
+      // keep generic message
+    }
+    opts.onError(new Error(msg));
+  };
+
+  // Opens one stream attempt. Parse state (cursor/buffered) is per-attempt so
+  // a retried stream never inherits the 401 attempt's response bytes.
+  const openStream = (url: string, token: string | null, canRetryAuth: boolean) => {
+    let cursor = 0;
+    let buffered = '';
+    const xhr = new XMLHttpRequest();
+    currentXhr = xhr;
+
+    const flushBuffered = () => {
+      let idx = buffered.indexOf('\n\n');
+      while (idx !== -1) {
+        const block = buffered.slice(0, idx);
+        buffered = buffered.slice(idx + 2);
+        handleSseBlock(block);
+        idx = buffered.indexOf('\n\n');
+      }
+    };
+
+    xhr.open('POST', url, true);
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.setRequestHeader('Accept', 'text/event-stream');
+    xhr.setRequestHeader('x-breeze-csrf', '1');
+    if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+    xhr.withCredentials = true;
+
+    xhr.onreadystatechange = () => {
+      if (aborted) return;
+      // A 401 body is a JSON error, never SSE blocks — skip incremental
+      // parsing on an attempt we may retry so nothing leaks to callbacks.
+      const authRetryPending = xhr.status === 401 && canRetryAuth;
+      if (
+        !authRetryPending &&
+        xhr.readyState >= 3 &&
+        xhr.responseText &&
+        xhr.responseText.length > cursor
+      ) {
+        buffered += xhr.responseText.slice(cursor);
+        cursor = xhr.responseText.length;
+        flushBuffered();
+      }
+      if (xhr.readyState === 4) {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          if (!didEmitDone) opts.onDone();
+          return;
+        }
+        if (authRetryPending) {
+          // Stale access token (>15 min since login with no interim REST
+          // call). Refresh once via the shared single-flight helper and
+          // reopen; on refresh failure surface the original 401.
+          void (async () => {
+            const newToken = await refreshAccessToken();
+            if (aborted) return;
+            if (newToken) {
+              openStream(url, newToken, false);
+              return;
+            }
+            emitHttpError(xhr);
+          })();
+          return;
+        }
+        emitHttpError(xhr);
+      }
+    };
+
+    xhr.onerror = () => {
+      if (aborted) return;
+      opts.onError(new Error('Network error'));
+    };
+
+    xhr.send(JSON.stringify({ content: opts.content }));
+  };
+
   (async () => {
     try {
       const baseUrl = (await getServerUrl()) || FALLBACK_API_BASE_URL;
       const token = await getToken();
       const url = `${baseUrl}${API_CORE_PREFIX}/ai/sessions/${opts.sessionId}/messages`;
       if (aborted) return;
-
-      xhr.open('POST', url, true);
-      xhr.setRequestHeader('Content-Type', 'application/json');
-      xhr.setRequestHeader('Accept', 'text/event-stream');
-      xhr.setRequestHeader('x-breeze-csrf', '1');
-      if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`);
-      xhr.withCredentials = true;
-
-      xhr.onreadystatechange = () => {
-        if (aborted) return;
-        if (xhr.readyState >= 3 && xhr.responseText && xhr.responseText.length > cursor) {
-          buffered += xhr.responseText.slice(cursor);
-          cursor = xhr.responseText.length;
-          flushBuffered();
-        }
-        if (xhr.readyState === 4) {
-          if (xhr.status >= 200 && xhr.status < 300) {
-            if (!didEmitDone) opts.onDone();
-            return;
-          }
-          let msg = `HTTP ${xhr.status}`;
-          try {
-            const body = JSON.parse(xhr.responseText);
-            if (body && typeof body.error === 'string') msg = body.error;
-          } catch {
-            // keep generic message
-          }
-          opts.onError(new Error(msg));
-        }
-      };
-
-      xhr.onerror = () => {
-        if (aborted) return;
-        opts.onError(new Error('Network error'));
-      };
-
-      xhr.send(JSON.stringify({ content: opts.content }));
+      openStream(url, token, true);
     } catch (err) {
       if (aborted) return;
       opts.onError(err instanceof Error ? err : new Error(String(err)));
@@ -314,7 +354,7 @@ export function streamChat(opts: SseStreamOptions): SseStreamHandle {
   return {
     abort: () => {
       aborted = true;
-      try { xhr.abort(); } catch { /* noop */ }
+      try { currentXhr?.abort(); } catch { /* noop */ }
     },
   };
 }

--- a/apps/mobile/src/services/aiChat.ts
+++ b/apps/mobile/src/services/aiChat.ts
@@ -314,15 +314,23 @@ export function streamChat(opts: SseStreamOptions): SseStreamHandle {
         if (authRetryPending) {
           // Stale access token (>15 min since login with no interim REST
           // call). Refresh once via the shared single-flight helper and
-          // reopen; on refresh failure surface the original 401.
+          // reopen; on refresh failure surface the original 401. The whole
+          // body is guarded: a throw from the retried open (or from the
+          // refresh) must reach onError — an unhandled rejection here would
+          // leave the chat UI streaming forever with no error surfaced.
           void (async () => {
-            const newToken = await refreshAccessToken();
-            if (aborted) return;
-            if (newToken) {
-              openStream(url, newToken, false);
-              return;
+            try {
+              const newToken = await refreshAccessToken();
+              if (aborted) return;
+              if (newToken) {
+                openStream(url, newToken, false);
+                return;
+              }
+              emitHttpError(xhr);
+            } catch (err) {
+              if (aborted) return;
+              opts.onError(err instanceof Error ? err : new Error(String(err)));
             }
-            emitHttpError(xhr);
           })();
           return;
         }


### PR DESCRIPTION
## Summary

`streamChat` (the XHR-based SSE send path in `apps/mobile/src/services/aiChat.ts`) attached the stored access token raw, so the first chat message sent more than ~15 minutes after login 401'd at stream open, and the UI retry replayed the same stale token (`HomeScreen.tsx` skips `createAiSession` once a session id exists, so no refreshing REST call intervenes).

This applies the same refresh lifecycle #3124 gave `authedFetch`, reusing its single-flighted `refreshAccessToken()` rather than duplicating it:

- On a **401 at stream open** (readyState 4), refresh once via the shared single-flight helper and reopen the stream with the fresh token.
- **Retry is bounded to one**: a second 401 (or a failed refresh) surfaces the original HTTP error through `onError`.
- **Per-attempt parse state** (`cursor`/`buffered` scoped to each open) plus a 401 guard on the incremental parser keep the 401 JSON body from ever reaching SSE callbacks.
- **`abort()` targets whichever XHR is live** (initial or retried attempt), and an abort during the in-flight refresh suppresses the reopen.

No change needed in `HomeScreen.tsx` — its retry path now gets a fresh token at the service layer.

## Stacking

**Stacked on #3124** (`fix/3114-aichat-token-refresh`) — it builds directly on that branch's refresh helpers. Will retarget to `ToddHebebrand/ios-app-testing` when #3124 merges. `ci.yml` does not run on non-main-based PRs; verification below is local.

## Verification

- `pnpm exec vitest run` in `apps/mobile`: **28 files, 276 passed, 3 skipped** — includes 7 new `streamChat 401 refresh-and-reopen` tests (success without refresh; refresh-and-reopen with fresh token/same body; refresh failure surfaces original 401; single retry bound; abort during refresh; abort targets live XHR; non-401 errors don't refresh).
- `npx tsc --noEmit` in `apps/mobile`: clean.
- Real >15-min token-expiry behavior to be verified on-device by the orchestrator.

Closes #3140

🤖 Generated with [Claude Code](https://claude.com/claude-code)