### PR TITLE
fix(mobile): stop notification settings asserting behavior the app doesn't deliver (#3143)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -51,14 +51,17 @@ import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
 import { Provider as ReduxProvider, useDispatch, useSelector } from 'react-redux';
 import { Provider as PaperProvider, MD3DarkTheme, MD3LightTheme } from 'react-native-paper';
-import { useColorScheme } from 'react-native';
+import { AppState, useColorScheme } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { store, type AppDispatch, type RootState } from './src/store';
 import { RootNavigator } from './src/navigation/RootNavigator';
 import { AppLockGate } from './src/navigation/AppLockGate';
-import { registerForPushNotifications } from './src/services/notifications';
+import {
+  registerForPushNotifications,
+  reconcilePushRegistration,
+} from './src/services/notifications';
 import { setPushRegistration } from './src/store/authSlice';
 
 // Hold the native splash until the first real screen is ready to paint.
@@ -111,17 +114,56 @@ const customDarkTheme = {
 function PushRegistrationGate() {
   const dispatch = useDispatch<AppDispatch>();
   const token = useSelector((s: RootState) => s.auth.token);
+  const pushRegistration = useSelector((s: RootState) => s.auth.pushRegistration);
+  const pushRegistrationReason = useSelector((s: RootState) => s.auth.pushRegistrationReason);
 
   useEffect(() => {
     if (!token) return;
     let cancelled = false;
     (async () => {
-      const outcome = await registerForPushNotifications();
-      if (cancelled) return;
-      dispatch(setPushRegistration({ status: outcome.status, reason: outcome.status === 'ok' ? null : outcome.reason }));
+      try {
+        const outcome = await registerForPushNotifications();
+        if (cancelled) return;
+        dispatch(setPushRegistration({ status: outcome.status, reason: outcome.status === 'ok' ? null : outcome.reason }));
+      } catch (err) {
+        // registerForPushNotifications is total by contract, but if anything
+        // still rejects the store must not stay at 'idle' — Settings would
+        // read "Checking push registration…" forever. #3143
+        if (cancelled) return;
+        console.warn('[push] registration threw', err);
+        dispatch(setPushRegistration({
+          status: 'failed',
+          reason: err instanceof Error ? err.message : 'unknown',
+        }));
+      }
     })();
     return () => { cancelled = true; };
   }, [token, dispatch]);
+
+  // iOS keeps the app alive when the user flips the notification permission in
+  // Settings (which the Settings sheet's Notifications row now deep-links to),
+  // so re-check on every foreground and correct the stored status — otherwise
+  // the row and ApprovalGate's banner keep asserting a stale 'ok'. #3143
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state !== 'active') return;
+      void (async () => {
+        try {
+          const outcome = await reconcilePushRegistration(pushRegistration, pushRegistrationReason);
+          if (cancelled || !outcome) return;
+          dispatch(setPushRegistration({ status: outcome.status, reason: outcome.status === 'ok' ? null : outcome.reason }));
+        } catch (err) {
+          console.warn('[push] foreground permission re-check failed', err);
+        }
+      })();
+    });
+    return () => {
+      cancelled = true;
+      sub.remove();
+    };
+  }, [token, pushRegistration, pushRegistrationReason, dispatch]);
 
   return null;
 }

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -10,7 +10,6 @@ import {
   Text,
   View,
 } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   useAnimatedStyle,
@@ -43,7 +42,7 @@ import { ease, duration } from '../../../lib/motion';
 import { track } from '../../../lib/analytics';
 import { relativeTime } from '../../../lib/relativeTime';
 import { Toast } from '../../../components/Toast';
-import { pushUnavailableCopy } from './pushUnavailableCopy';
+import { notificationsRowCopy, type NotificationsRowCopy } from './pushUnavailableCopy';
 import { Avatar } from './Avatar';
 import { ChangePasswordSheet } from './ChangePasswordSheet';
 import type { PairedMobileDevice } from '../../../services/mobileDevices';
@@ -54,8 +53,6 @@ interface Props {
   onCancel: () => void;
 }
 
-const NOTIF_KEY = 'notificationsEnabled';
-const NOTIF_CRITICAL_ONLY_KEY = 'notificationsCriticalOnly';
 const TERMS_URL = 'https://breezermm.com/legal/terms-of-service/';
 const PRIVACY_URL = 'https://breezermm.com/legal/privacy-policy/';
 
@@ -82,13 +79,14 @@ export function SettingsSheet({ visible, onCancel }: Props) {
   const activeAppCount = useAppSelector(selectActiveConnectedAppsCount);
   const pendingDeviceId = useAppSelector((s) => s.lifecycle.pendingDeviceId);
   const pendingAppId = useAppSelector((s) => s.lifecycle.pendingAppId);
-  // 'unsupported' is a deliberate "push not built / not possible here" state
-  // (e.g. android_push_not_configured) — the sheet must not show an ON toggle
-  // asserting a capability the build doesn't have. 'failed' keeps the normal
-  // toggle: ApprovalGate already surfaces failures with its own banner. #3118
+  // The Notifications row is a status READOUT, not a control (#3118, #3143).
+  // The old Notifications / Critical-only toggles only wrote AsyncStorage keys
+  // nothing consumed, and 'failed' relied on ApprovalGate's banner — which is
+  // dismissible, after which the ON toggle was the only (wrong) signal left.
+  // Every registration state now renders honest copy here, and the row links
+  // to system Settings when that's the real control.
   const pushRegistration = useAppSelector((s) => s.auth.pushRegistration);
   const pushRegistrationReason = useAppSelector((s) => s.auth.pushRegistrationReason);
-  const pushUnavailable = pushRegistration === 'unsupported';
 
   const screenWidth = Dimensions.get('window').width;
   const sheetWidth = Math.min(screenWidth * 0.84, 420);
@@ -98,8 +96,6 @@ export function SettingsSheet({ visible, onCancel }: Props) {
 
   const [biometricAvailable, setBiometricAvailable] = useState(false);
   const [biometricOn, setBiometricOn] = useState(false);
-  const [notificationsOn, setNotificationsOn] = useState(true);
-  const [criticalOnly, setCriticalOnly] = useState(false);
   const [passwordOpen, setPasswordOpen] = useState(false);
   const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
 
@@ -116,10 +112,6 @@ export function SettingsSheet({ visible, onCancel }: Props) {
       const avail = await checkBiometricAvailability();
       setBiometricAvailable(avail);
       if (avail) setBiometricOn(await isBiometricEnabled());
-      const stored = await AsyncStorage.getItem(NOTIF_KEY);
-      if (stored !== null) setNotificationsOn(stored === 'true');
-      const critical = await AsyncStorage.getItem(NOTIF_CRITICAL_ONLY_KEY);
-      if (critical !== null) setCriticalOnly(critical === 'true');
     })();
 
     // Refresh both lifecycle lists every time the sheet opens (tab focus
@@ -205,14 +197,12 @@ export function SettingsSheet({ visible, onCancel }: Props) {
     }
   }
 
-  async function onToggleNotifications(next: boolean) {
-    setNotificationsOn(next);
-    await AsyncStorage.setItem(NOTIF_KEY, String(next));
-  }
-
-  async function onToggleCriticalOnly(next: boolean) {
-    setCriticalOnly(next);
-    await AsyncStorage.setItem(NOTIF_CRITICAL_ONLY_KEY, String(next));
+  async function onPressNotificationSettings() {
+    try {
+      await Linking.openSettings();
+    } catch {
+      Alert.alert('Cannot open Settings', 'Open your phone’s Settings app and find Breeze.');
+    }
   }
 
   function onPressChangePassword() {
@@ -292,18 +282,14 @@ export function SettingsSheet({ visible, onCancel }: Props) {
             insetBottom={insets.bottom}
             biometricAvailable={biometricAvailable}
             biometricOn={biometricOn}
-            notificationsOn={notificationsOn}
-            criticalOnly={criticalOnly}
-            pushUnavailable={pushUnavailable}
-            pushUnavailableReason={pushRegistrationReason}
+            pushCopy={notificationsRowCopy(pushRegistration, pushRegistrationReason)}
             buildVersion={buildVersion}
             pairedDevices={pairedDevices}
             connectedApps={connectedApps}
             pendingDeviceId={pendingDeviceId}
             pendingAppId={pendingAppId}
             onToggleBiometric={onToggleBiometric}
-            onToggleNotifications={onToggleNotifications}
-            onToggleCriticalOnly={onToggleCriticalOnly}
+            onPressNotificationSettings={onPressNotificationSettings}
             onPressChangePassword={onPressChangePassword}
             onPressTerms={() => safeOpen(TERMS_URL)}
             onPressPrivacy={() => safeOpen(PRIVACY_URL)}
@@ -340,18 +326,14 @@ function SheetBody({
   insetBottom,
   biometricAvailable,
   biometricOn,
-  notificationsOn,
-  criticalOnly,
-  pushUnavailable,
-  pushUnavailableReason,
+  pushCopy,
   buildVersion,
   pairedDevices,
   connectedApps,
   pendingDeviceId,
   pendingAppId,
   onToggleBiometric,
-  onToggleNotifications,
-  onToggleCriticalOnly,
+  onPressNotificationSettings,
   onPressChangePassword,
   onPressTerms,
   onPressPrivacy,
@@ -366,18 +348,14 @@ function SheetBody({
   insetBottom: number;
   biometricAvailable: boolean;
   biometricOn: boolean;
-  notificationsOn: boolean;
-  criticalOnly: boolean;
-  pushUnavailable: boolean;
-  pushUnavailableReason: string | null;
+  pushCopy: NotificationsRowCopy;
   buildVersion: string;
   pairedDevices: PairedMobileDevice[];
   connectedApps: ConnectedApp[];
   pendingDeviceId: string | null;
   pendingAppId: string | null;
   onToggleBiometric: (v: boolean) => void;
-  onToggleNotifications: (v: boolean) => void;
-  onToggleCriticalOnly: (v: boolean) => void;
+  onPressNotificationSettings: () => void;
   onPressChangePassword: () => void;
   onPressTerms: () => void;
   onPressPrivacy: () => void;
@@ -386,7 +364,6 @@ function SheetBody({
   onRevokeDevice: (device: PairedMobileDevice) => void;
   onRevokeApp: (app: ConnectedApp) => void;
 }) {
-  const pushCopy = pushUnavailable ? pushUnavailableCopy(pushUnavailableReason) : null;
   return (
     <View style={{ flex: 1 }}>
       <ScrollView
@@ -432,34 +409,11 @@ function SheetBody({
           />
         ) : null}
 
-        {pushCopy ? (
-          <ToggleRow
-            label="Notifications"
-            description={pushCopy.notificationsRow}
-            value={false}
-            disabled
-            onChange={() => {}}
-            theme={theme}
-          />
-        ) : (
-          <ToggleRow
-            label="Notifications"
-            description="Approval pushes and alerts"
-            value={notificationsOn}
-            onChange={onToggleNotifications}
-            theme={theme}
-          />
-        )}
-
-        {!pushCopy && notificationsOn ? (
-          <ToggleRow
-            label="Critical only"
-            description="Quiet pushes for medium and warning alerts"
-            value={criticalOnly}
-            onChange={onToggleCriticalOnly}
-            theme={theme}
-          />
-        ) : null}
+        <NotificationsRow
+          copy={pushCopy}
+          onPress={onPressNotificationSettings}
+          theme={theme}
+        />
 
         <SectionDivider color={theme.border} />
 
@@ -477,9 +431,8 @@ function SheetBody({
         {pairedDevices.length === 0 ? (
           <EmptyHint
             text={
-              pushCopy
-                ? pushCopy.pairedDevicesHint
-                : 'No paired devices yet. Sign in on another phone to see it here.'
+              pushCopy.pairedDevicesHint ??
+              'No paired devices yet. Sign in on another phone to see it here.'
             }
             theme={theme}
           />
@@ -739,14 +692,12 @@ function ToggleRow({
   label,
   description,
   value,
-  disabled,
   onChange,
   theme,
 }: {
   label: string;
   description?: string;
   value: boolean;
-  disabled?: boolean;
   onChange: (v: boolean) => void;
   theme: ReturnType<typeof useApprovalTheme>;
 }) {
@@ -760,10 +711,7 @@ function ToggleRow({
       }}
     >
       <View style={{ flex: 1, marginRight: spacing[3] }}>
-        {/* Only the label and Switch signal "disabled" — the description stays
-            at full contrast because for a disabled row it carries the
-            explanation the user must be able to read (#3118). */}
-        <Text style={[type.bodyMd, { color: disabled ? theme.textLo : theme.textHi }]}>{label}</Text>
+        <Text style={[type.bodyMd, { color: theme.textHi }]}>{label}</Text>
         {description ? (
           <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
             {description}
@@ -772,12 +720,67 @@ function ToggleRow({
       </View>
       <Switch
         value={value}
-        disabled={disabled}
         onValueChange={onChange}
         trackColor={{ false: theme.bg3, true: palette.brand.deep }}
         thumbColor={value ? palette.brand.base : theme.textMd}
-        style={disabled ? { opacity: 0.55 } : undefined}
       />
     </View>
+  );
+}
+
+/**
+ * Status readout for push notifications (#3118, #3143). Not a toggle: the app
+ * has no code path that could honor an in-app on/off or "critical only"
+ * preference (background pushes are presented by the OS), so the row reports
+ * the actual registration state and, when the OS permission is the lever,
+ * opens system Settings on tap.
+ */
+function NotificationsRow({
+  copy,
+  onPress,
+  theme,
+}: {
+  copy: NotificationsRowCopy;
+  onPress: () => void;
+  theme: ReturnType<typeof useApprovalTheme>;
+}) {
+  const body = (
+    <View style={{ flex: 1, marginRight: spacing[3] }}>
+      <Text style={[type.bodyMd, { color: theme.textHi }]}>Notifications</Text>
+      <Text style={[type.meta, { color: theme.textMd, marginTop: spacing[1] }]}>
+        {copy.description}
+      </Text>
+    </View>
+  );
+
+  if (!copy.opensSystemSettings) {
+    return (
+      <View
+        style={{
+          paddingHorizontal: spacing[6],
+          paddingVertical: spacing[3],
+          flexDirection: 'row',
+          alignItems: 'center',
+        }}
+      >
+        {body}
+      </View>
+    );
+  }
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      style={({ pressed }) => ({
+        paddingHorizontal: spacing[6],
+        paddingVertical: spacing[3],
+        flexDirection: 'row',
+        alignItems: 'center',
+        backgroundColor: pressed ? theme.bg2 : 'transparent',
+      })}
+    >
+      {body}
+    </Pressable>
   );
 }

--- a/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SettingsSheet.tsx
@@ -200,7 +200,8 @@ export function SettingsSheet({ visible, onCancel }: Props) {
   async function onPressNotificationSettings() {
     try {
       await Linking.openSettings();
-    } catch {
+    } catch (err) {
+      console.warn('[settings] openSettings failed', err);
       Alert.alert('Cannot open Settings', 'Open your phone’s Settings app and find Breeze.');
     }
   }

--- a/apps/mobile/src/screens/chat/components/pushUnavailableCopy.test.ts
+++ b/apps/mobile/src/screens/chat/components/pushUnavailableCopy.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import { pushUnavailableCopy } from './pushUnavailableCopy';
+import {
+  notificationsRowCopy,
+  pushUnavailableCopy,
+  type PushRowStatus,
+} from './pushUnavailableCopy';
 
 describe('pushUnavailableCopy', () => {
   it('names Android for the not-built-yet reason (#3118)', () => {
@@ -28,6 +32,87 @@ describe('pushUnavailableCopy', () => {
     for (const reason of ['android_push_not_configured', 'not_physical_device', null]) {
       const copy = pushUnavailableCopy(reason);
       expect(copy.pairedDevicesHint).not.toMatch(/error|failed|wrong/i);
+    }
+  });
+});
+
+describe('notificationsRowCopy (#3143)', () => {
+  const REASONS = ['android_push_not_configured', 'not_physical_device', 'permission_denied', 'something_new', null];
+  const STATUSES: PushRowStatus[] = ['idle', 'ok', 'failed', 'unsupported'];
+
+  it("only 'ok' may claim pushes are being delivered", () => {
+    // The false-assurance pin: every non-ok state must not assert delivery.
+    for (const status of STATUSES) {
+      for (const reason of REASONS) {
+        const copy = notificationsRowCopy(status, reason);
+        if (status === 'ok') {
+          expect(copy.description).toMatch(/delivered/i);
+        } else {
+          expect(copy.description).not.toMatch(/delivered|arriving/i);
+        }
+      }
+    }
+  });
+
+  it("'ok' points at system Settings as the real control", () => {
+    const copy = notificationsRowCopy('ok', null);
+    expect(copy.opensSystemSettings).toBe(true);
+    expect(copy.description).toMatch(/Settings/);
+    expect(copy.pairedDevicesHint).toBeNull();
+  });
+
+  it("'unsupported' reuses the reason-specific #3118 copy verbatim", () => {
+    for (const reason of ['android_push_not_configured', 'not_physical_device', null]) {
+      const copy = notificationsRowCopy('unsupported', reason);
+      const base = pushUnavailableCopy(reason);
+      expect(copy.description).toBe(base.notificationsRow);
+      expect(copy.pairedDevicesHint).toBe(base.pairedDevicesHint);
+      expect(copy.opensSystemSettings).toBe(false);
+    }
+  });
+
+  it("'failed' says pushes aren't registered and never contradicts the ApprovalGate banner", () => {
+    // The banner says "Push notifications aren't registered … sign in again".
+    // This row is what remains after the banner is dismissed, so it must carry
+    // the same truth.
+    for (const reason of ['permission_denied', 'some network error', null]) {
+      const copy = notificationsRowCopy('failed', reason);
+      expect(copy.description).toMatch(/aren't registered/);
+      expect(copy.description).toMatch(/sign in again/i);
+    }
+  });
+
+  it("'failed' + permission_denied names Settings as the fix and links there", () => {
+    const copy = notificationsRowCopy('failed', 'permission_denied');
+    expect(copy.description).toMatch(/turned off for Breeze in Settings/);
+    expect(copy.opensSystemSettings).toBe(true);
+  });
+
+  it("'failed' with a non-permission reason does not send the user to Settings", () => {
+    for (const reason of ['some network error', null]) {
+      const copy = notificationsRowCopy('failed', reason);
+      expect(copy.opensSystemSettings).toBe(false);
+      expect(copy.description).toMatch(/won't reach this phone/);
+    }
+  });
+
+  it("'idle' is a neutral in-progress state", () => {
+    const copy = notificationsRowCopy('idle', null);
+    expect(copy.description).toMatch(/checking/i);
+    expect(copy.opensSystemSettings).toBe(false);
+    expect(copy.pairedDevicesHint).toBeNull();
+  });
+
+  it('only unsupported overrides the paired-devices hint', () => {
+    for (const status of STATUSES) {
+      for (const reason of REASONS) {
+        const copy = notificationsRowCopy(status, reason);
+        if (status === 'unsupported') {
+          expect(copy.pairedDevicesHint).not.toBeNull();
+        } else {
+          expect(copy.pairedDevicesHint).toBeNull();
+        }
+      }
     }
   });
 });

--- a/apps/mobile/src/screens/chat/components/pushUnavailableCopy.ts
+++ b/apps/mobile/src/screens/chat/components/pushUnavailableCopy.ts
@@ -37,3 +37,84 @@ export function pushUnavailableCopy(reason: string | null): PushUnavailableCopy 
       };
   }
 }
+
+/**
+ * Copy for the Settings sheet's Notifications row across ALL push-registration
+ * states (#3143, extending the #3118 treatment above).
+ *
+ * The old Notifications / Critical-only toggles were write-only: they persisted
+ * to AsyncStorage but nothing consumed the keys, and the client has no seam
+ * that could honor them — the foreground display handler never sees
+ * background/lock-screen pushes, which is where approval pushes land. So the
+ * row is now a status readout instead of a control: the one real control the
+ * user has (the OS notification permission) lives in system Settings, and the
+ * row deep-links there when that's actionable.
+ *
+ * Only `ok` may claim pushes are being delivered — every other status must
+ * tell the truth that they aren't. In particular `failed` must carry the
+ * explanation here too, because ApprovalGate's failure banner is dismissible
+ * per session and this row is what remains after dismissal.
+ */
+export type PushRowStatus = 'idle' | 'ok' | 'failed' | 'unsupported';
+
+export interface NotificationsRowCopy {
+  /** Description under the "Notifications" label. */
+  description: string;
+  /**
+   * True when tapping the row should open the app's system notification
+   * settings (Linking.openSettings) — the real on/off control.
+   */
+  opensSystemSettings: boolean;
+  /**
+   * Replaces the paired-devices empty hint when this device cannot register
+   * itself (`unsupported`); null means keep the default hint.
+   */
+  pairedDevicesHint: string | null;
+}
+
+export function notificationsRowCopy(
+  status: PushRowStatus,
+  reason: string | null
+): NotificationsRowCopy {
+  switch (status) {
+    case 'idle':
+      return {
+        description: 'Checking push registration…',
+        opensSystemSettings: false,
+        pairedDevicesHint: null,
+      };
+    case 'ok':
+      return {
+        description:
+          'Approval pushes and alerts are delivered to this phone. Tap to manage them in Settings.',
+        opensSystemSettings: true,
+        pairedDevicesHint: null,
+      };
+    case 'unsupported': {
+      const copy = pushUnavailableCopy(reason);
+      return {
+        description: copy.notificationsRow,
+        opensSystemSettings: false,
+        pairedDevicesHint: copy.pairedDevicesHint,
+      };
+    }
+    case 'failed':
+      // Phrasing mirrors ApprovalGate's PushFailedBanner ("Push notifications
+      // aren't registered … allowed for Breeze in Settings … sign in again")
+      // so the two surfaces never contradict each other.
+      if (reason === 'permission_denied') {
+        return {
+          description:
+            "Push notifications aren't registered — notifications are turned off for Breeze in Settings. Tap to allow them, then sign in again.",
+          opensSystemSettings: true,
+          pairedDevicesHint: null,
+        };
+      }
+      return {
+        description:
+          "Push notifications aren't registered, so approval requests won't reach this phone. Sign in again to retry.",
+        opensSystemSettings: false,
+        pairedDevicesHint: null,
+      };
+  }
+}

--- a/apps/mobile/src/services/notifications.test.ts
+++ b/apps/mobile/src/services/notifications.test.ts
@@ -38,6 +38,7 @@ vi.mock('./api', () => ({ registerPushToken: (...a: unknown[]) => api.registerPu
 import {
   registerForPushNotifications,
   reconcileApprovalNotifications,
+  reconcilePushRegistration,
   staleApprovalNotificationIds,
 } from './notifications';
 import {
@@ -131,6 +132,32 @@ describe('registerForPushNotifications', () => {
     });
   });
 
+  it('resolves failed instead of rejecting when the permission check itself throws (#3143)', async () => {
+    // Pre-#3143 the permission calls ran before the try/catch, so a throw here
+    // became an unhandled rejection in PushRegistrationGate and the store
+    // stayed at 'idle' — "Checking push registration…" forever in Settings.
+    notif.getPermissionsAsync.mockRejectedValue(new Error('boom'));
+
+    await expect(registerForPushNotifications()).resolves.toEqual({
+      status: 'failed',
+      reason: 'boom',
+    });
+  });
+
+  it('Android channel-setup failure does not reject or flip a registered token to failed (#3143)', async () => {
+    // The token is already registered with the API by the time channels are
+    // configured; a channel failure is a presentation nit, not a delivery
+    // failure. Pre-#3143 this ran after the catch and rejected the promise.
+    platform.OS = 'android';
+    constants.expoConfig = { extra: { eas: { projectId: 'proj-1' } } };
+    notif.setNotificationChannelAsync.mockRejectedValue(new Error('channel boom'));
+
+    await expect(registerForPushNotifications()).resolves.toEqual({
+      status: 'ok',
+      token: 'ExponentPushToken[x]',
+    });
+  });
+
   it("permission-denied failure maps to the Settings-actionable row copy (#3143)", async () => {
     // Pins the reason-string contract for the FAILED branch, same as the
     // unsupported pin above: rename 'permission_denied' here and the Settings
@@ -212,5 +239,52 @@ describe('reconcileApprovalNotifications', () => {
   it('degrades quietly when the notification APIs throw', async () => {
     notif.getPresentedNotificationsAsync.mockRejectedValue(new Error('no permission'));
     await expect(reconcileApprovalNotifications([])).resolves.toBeUndefined();
+  });
+});
+
+describe('reconcilePushRegistration (#3143)', () => {
+  it("'ok' with permission still granted needs no correction", async () => {
+    await expect(reconcilePushRegistration('ok', null)).resolves.toBeNull();
+  });
+
+  it("'ok' downgrades to failed/permission_denied when the user revoked permission in Settings", async () => {
+    // The exact sequence the Settings sheet's deep-link invites: tap row →
+    // system Settings → turn Breeze notifications off → return to the app.
+    // iOS does not restart the app, so without this the row keeps claiming
+    // "delivered" for the rest of the session.
+    notif.getPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    await expect(reconcilePushRegistration('ok', null)).resolves.toEqual({
+      status: 'failed',
+      reason: 'permission_denied',
+    });
+  });
+
+  it("failed/permission_denied re-registers fully once permission is granted again", async () => {
+    const out = await reconcilePushRegistration('failed', 'permission_denied');
+
+    // Not just a status flip: the token must actually be (re)registered.
+    expect(out).toEqual({ status: 'ok', token: 'APNS-TOKEN' });
+    expect(api.registerPushToken).toHaveBeenCalledWith('APNS-TOKEN', 'ios');
+  });
+
+  it('failed/permission_denied stays put while permission remains denied', async () => {
+    notif.getPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    await expect(reconcilePushRegistration('failed', 'permission_denied')).resolves.toBeNull();
+    expect(api.registerPushToken).not.toHaveBeenCalled();
+  });
+
+  it('non-permission failures and resting states are never touched by a foreground hop', async () => {
+    for (const [status, reason] of [
+      ['failed', 'some network error'],
+      ['failed', null],
+      ['unsupported', 'android_push_not_configured'],
+      ['idle', null],
+    ] as const) {
+      await expect(reconcilePushRegistration(status, reason)).resolves.toBeNull();
+    }
+    expect(notif.getPermissionsAsync).not.toHaveBeenCalled();
+    expect(api.registerPushToken).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/services/notifications.test.ts
+++ b/apps/mobile/src/services/notifications.test.ts
@@ -40,7 +40,10 @@ import {
   reconcileApprovalNotifications,
   staleApprovalNotificationIds,
 } from './notifications';
-import { pushUnavailableCopy } from '../screens/chat/components/pushUnavailableCopy';
+import {
+  notificationsRowCopy,
+  pushUnavailableCopy,
+} from '../screens/chat/components/pushUnavailableCopy';
 
 beforeEach(() => {
   platform.OS = 'ios';
@@ -126,6 +129,21 @@ describe('registerForPushNotifications', () => {
       status: 'failed',
       reason: 'permission_denied',
     });
+  });
+
+  it("permission-denied failure maps to the Settings-actionable row copy (#3143)", async () => {
+    // Pins the reason-string contract for the FAILED branch, same as the
+    // unsupported pin above: rename 'permission_denied' here and the Settings
+    // sheet silently falls back to the generic "sign in again to retry" copy
+    // (no Settings deep-link) with both sides' own tests still green.
+    notif.getPermissionsAsync.mockResolvedValue({ status: 'denied' });
+    notif.requestPermissionsAsync.mockResolvedValue({ status: 'denied' });
+
+    const out = await registerForPushNotifications();
+    if (out.status !== 'failed') throw new Error('expected failed');
+    const copy = notificationsRowCopy(out.status, out.reason);
+    expect(copy.opensSystemSettings).toBe(true);
+    expect(copy.description).toMatch(/turned off for Breeze in Settings/);
   });
 
   it('reports failed when the token call throws', async () => {

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -28,21 +28,26 @@ export async function registerForPushNotifications(): Promise<PushRegistrationOu
     return { status: 'unsupported', reason: 'not_physical_device' };
   }
 
-  const { status: existingStatus } = await Notifications.getPermissionsAsync();
-  let finalStatus = existingStatus;
-
-  if (existingStatus !== 'granted') {
-    const { status } = await Notifications.requestPermissionsAsync();
-    finalStatus = status;
-  }
-
-  if (finalStatus !== 'granted') {
-    console.log('Push notification permission not granted');
-    return { status: 'failed', reason: 'permission_denied' };
-  }
-
+  // Everything from here on is inside one try/catch so the outcome contract is
+  // TOTAL: this function resolves to ok/unsupported/failed, never rejects.
+  // The permission calls used to run before the try — a throw there became an
+  // unhandled rejection in PushRegistrationGate and left the store stuck at
+  // 'idle' ("Checking push registration…" forever in Settings). #3143
   let token: string | null = null;
   try {
+    const { status: existingStatus } = await Notifications.getPermissionsAsync();
+    let finalStatus = existingStatus;
+
+    if (existingStatus !== 'granted') {
+      const { status } = await Notifications.requestPermissionsAsync();
+      finalStatus = status;
+    }
+
+    if (finalStatus !== 'granted') {
+      console.log('Push notification permission not granted');
+      return { status: 'failed', reason: 'permission_denied' };
+    }
+
     if (Platform.OS === 'ios') {
       // Native device push token: raw APNs token. Uses getDevicePushTokenAsync
       // — needs NO Expo projectId/account — so push works with a plain
@@ -80,31 +85,73 @@ export async function registerForPushNotifications(): Promise<PushRegistrationOu
   }
 
   if (Platform.OS === 'android') {
-    await Notifications.setNotificationChannelAsync('alerts', {
-      name: 'Alerts',
-      importance: Notifications.AndroidImportance.MAX,
-      vibrationPattern: [0, 250, 250, 250],
-      lightColor: '#FF231F7C',
-      sound: 'default',
-    });
+    // Best-effort: the token is already registered with the API at this point,
+    // so a channel-setup failure must not reject the promise (pre-#3143 it ran
+    // after the catch and did exactly that) nor flip the outcome to 'failed' —
+    // pushes still arrive, at worst with default channel presentation.
+    try {
+      await Notifications.setNotificationChannelAsync('alerts', {
+        name: 'Alerts',
+        importance: Notifications.AndroidImportance.MAX,
+        vibrationPattern: [0, 250, 250, 250],
+        lightColor: '#FF231F7C',
+        sound: 'default',
+      });
 
-    await Notifications.setNotificationChannelAsync('approvals', {
-      name: 'Approvals',
-      importance: Notifications.AndroidImportance.MAX,
-      vibrationPattern: [0, 200, 100, 200],
-      lightColor: '#1c8a9e',
-      sound: 'default',
-    });
+      await Notifications.setNotificationChannelAsync('approvals', {
+        name: 'Approvals',
+        importance: Notifications.AndroidImportance.MAX,
+        vibrationPattern: [0, 200, 100, 200],
+        lightColor: '#1c8a9e',
+        sound: 'default',
+      });
 
-    await Notifications.setNotificationChannelAsync('default', {
-      name: 'Default',
-      importance: Notifications.AndroidImportance.DEFAULT,
-      vibrationPattern: [0, 250],
-      lightColor: '#2563eb',
-    });
+      await Notifications.setNotificationChannelAsync('default', {
+        name: 'Default',
+        importance: Notifications.AndroidImportance.DEFAULT,
+        vibrationPattern: [0, 250],
+        lightColor: '#2563eb',
+      });
+    } catch (err) {
+      console.warn('[notifications] Android channel setup failed', err);
+    }
   }
 
   return { status: 'ok', token };
+}
+
+/**
+ * Re-evaluate push registration when the app returns to the foreground (#3143).
+ *
+ * iOS does not restart the app when the user flips the notification permission
+ * in Settings, and registration otherwise runs once per login — so without
+ * this, a user could tap the Settings sheet's Notifications row ("Tap to
+ * manage them in Settings"), revoke the permission, come back, and the row
+ * (and ApprovalGate's banner logic) would keep claiming pushes are delivered
+ * for the rest of the session.
+ *
+ * Returns the corrected outcome to dispatch, or null when the stored status is
+ * still accurate. Only the two permission-driven transitions are handled:
+ *   ok --permission revoked--> failed/permission_denied
+ *   failed/permission_denied --permission granted--> full re-registration
+ * `unsupported` and non-permission failures are resting states a foreground
+ * hop cannot change.
+ */
+export async function reconcilePushRegistration(
+  status: 'idle' | 'ok' | 'failed' | 'unsupported',
+  reason: string | null
+): Promise<PushRegistrationOutcome | null> {
+  if (status === 'ok') {
+    const { status: perm } = await Notifications.getPermissionsAsync();
+    if (perm === 'granted') return null;
+    return { status: 'failed', reason: 'permission_denied' };
+  }
+  if (status === 'failed' && reason === 'permission_denied') {
+    const { status: perm } = await Notifications.getPermissionsAsync();
+    if (perm !== 'granted') return null;
+    return registerForPushNotifications();
+  }
+  return null;
 }
 
 /**

--- a/apps/mobile/src/store/authSlice.ts
+++ b/apps/mobile/src/store/authSlice.ts
@@ -232,6 +232,10 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.error = null;
         state.mfaChallenge = null;
+        // Reset push status too — leaving the previous account's 'ok'/'failed'
+        // behind briefly shows stale copy in Settings after the next sign-in.
+        state.pushRegistration = 'idle';
+        state.pushRegistrationReason = null;
         state.approverRegistration = 'idle';
         state.approverRegistrationReason = null;
         state.authenticatorRegisterGrantId = null;
@@ -242,6 +246,8 @@ const authSlice = createSlice({
         state.isLoading = false;
         state.error = null;
         state.mfaChallenge = null;
+        state.pushRegistration = 'idle';
+        state.pushRegistrationReason = null;
         state.approverRegistration = 'idle';
         state.approverRegistrationReason = null;
         state.authenticatorRegisterGrantId = null;


### PR DESCRIPTION
Closes #3143

**STACKED on #3125** (`fix/3118-android-push-settings-state`). Retarget to `ToddHebebrand/ios-app-testing` when #3125 merges. Because the base is a sibling branch, `ci.yml` does not run on this PR — verification is local (below).

## What was wrong

1. The Notifications / Critical-only toggles in `SettingsSheet.tsx` were write-only: they persisted `notificationsEnabled` / `notificationsCriticalOnly` to AsyncStorage, but no code path anywhere consumed those keys. Flipping them changed nothing.
2. When push registration status is `failed`, ApprovalGate's banner is dismissible per session; after dismissal the ON Notifications toggle was the only remaining signal — asserting pushes work when they don't.

## Which branch I took for part 1, and why

Checked for a client-side seam where the toggles could take real effect. The only display seam is `Notifications.setNotificationHandler` in `services/notifications.ts`, and it runs **foreground-only** — background/lock-screen pushes (where approval pushes overwhelmingly land) are presented by the OS with no JS involvement. Wiring the toggles there would leave "Notifications: Off" false for the dominant case, and "Critical only" can never be honored client-side at all (severity filtering needs server-side dispatch changes, explicitly out of scope). Token-unregistration on toggle-off could make the master toggle real, but drags in token persistence, a re-register flow, and paired-device/approver interplay — not a clean seam.

So: **no clean seam → the toggles are removed** and the row becomes an honest, status-aware readout, per the issue's "honesty over dead controls" option:

- `ok` — "Approval pushes and alerts are delivered to this phone. Tap to manage them in Settings." Tapping opens the app's system notification settings (`Linking.openSettings()`) — the one real on/off control the user actually has.
- `unsupported` — keeps #3125's reason-specific copy verbatim (same strings, same paired-devices hint).
- `failed` — **part 2**: the row now says "Push notifications aren't registered … sign in again", phrased to mirror ApprovalGate's `PushFailedBanner` so the two surfaces never contradict; for `permission_denied` it names Settings as the fix and deep-links there. The banner stays dismissible (by design — it's a standing-condition overlay), but the truth now survives dismissal in Settings.
- `idle` — neutral "Checking push registration…".

The dead AsyncStorage keys and handlers are removed; `ToggleRow`'s now-unused `disabled` support (added in #3125 solely for the unsupported row) is removed too since Biometric is its only remaining caller.

## Tests

Extends the #3125 pure-module pattern:

- `pushUnavailableCopy.test.ts`: new `notificationsRowCopy` suite — the core pin is *only `ok` may claim delivery*, asserted across every status × reason combination; plus per-status copy/deep-link/paired-hint assertions and verbatim-reuse of the #3118 unsupported strings.
- `notifications.test.ts`: reason-string contract pin for the `failed` branch — `permission_denied` from `registerForPushNotifications` must map to the Settings-actionable copy (same rationale as #3125's unsupported pin: a renamed reason would silently degrade to generic copy with both sides' tests green).

## Verification (local — stacked PR runs no CI)

- `npx tsc --noEmit` in `apps/mobile`: clean
- Full mobile vitest suite: 28 files, 275 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)