### PR TITLE
fix(mobile): stop rendering raw internal error text in four more screens (#3141)

### DIFF
--- a/apps/mobile/src/lib/errorReporting.test.ts
+++ b/apps/mobile/src/lib/errorReporting.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the service layer so importing errorReporting never pulls
+// expo-secure-store (the node-only vitest runtime can't parse native modules).
+vi.mock('../services/api', () => ({
+  DEVICE_BLOCKED_CODE: 'device_blocked',
+}));
+
+const sentry = { captureException: vi.fn() };
+vi.mock('@sentry/react-native', () => ({
+  captureException: (...a: unknown[]) => sentry.captureException(...a),
+}));
+
+import { reportInternalError } from './errorReporting';
+
+beforeEach(() => {
+  sentry.captureException.mockReset();
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('reportInternalError', () => {
+  it('passes real Error instances through unchanged, tagged with the area', () => {
+    const err = new Error('getAiSessionMessages failed: 404');
+    reportInternalError(err, 'ai-sessions-history');
+
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+    const [captured, hint] = sentry.captureException.mock.calls[0];
+    expect(captured).toBe(err);
+    expect(hint).toEqual({ tags: { area: 'ai-sessions-history' } });
+  });
+
+  it('normalizes plain-object ApiError throws into a real Error keyed on area and status', () => {
+    // services/api.ts throws object literals, not Error instances.
+    const apiError = { message: 'An error occurred', statusCode: 500 };
+    reportInternalError(apiError, 'device-metrics');
+
+    expect(sentry.captureException).toHaveBeenCalledTimes(1);
+    const [captured, hint] = sentry.captureException.mock.calls[0];
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error).message).toBe('device-metrics failed: 500 An error occurred');
+    expect(hint).toEqual({
+      tags: { area: 'device-metrics' },
+      extra: { apiError },
+    });
+  });
+
+  it('tolerates non-object throws', () => {
+    reportInternalError('boom', 'systems-data');
+
+    const [captured] = sentry.captureException.mock.calls[0];
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error).message).toBe('systems-data failed: ? boom');
+  });
+
+  it('skips reporting expected blocked-device responses', () => {
+    reportInternalError(
+      { message: 'Device blocked', code: 'device_blocked', statusCode: 403 },
+      'systems-data',
+    );
+
+    expect(sentry.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/lib/errorReporting.ts
+++ b/apps/mobile/src/lib/errorReporting.ts
@@ -1,0 +1,35 @@
+import * as Sentry from '@sentry/react-native';
+
+import { DEVICE_BLOCKED_CODE, type ApiError } from '../services/api';
+
+/**
+ * Report an internal error to Sentry without rendering its raw message to the
+ * user (issues #3115 / #3141): call sites show static copy on screen and route
+ * the detail (function name, HTTP status) here instead.
+ *
+ * services/api.ts throws plain `ApiError` object literals, not `Error`
+ * instances. Captured as-is, those become stackless synthetic Sentry events
+ * that all group into one issue ("Object captured as exception…"), so
+ * non-Error values are normalized into a real `Error` keyed on the area and
+ * status, with the original object preserved in `extra`.
+ */
+export function reportInternalError(err: unknown, area: string): void {
+  const apiErr = err && typeof err === 'object' ? (err as Partial<ApiError>) : null;
+
+  // Blocked-device responses are an expected administrative state that api.ts
+  // already surfaces globally via notifyDeviceBlocked — reporting them as
+  // exceptions would spam Sentry on every background poll while blocked.
+  if (apiErr?.code === DEVICE_BLOCKED_CODE) return;
+
+  const normalized =
+    err instanceof Error
+      ? err
+      : new Error(
+          `${area} failed: ${apiErr?.statusCode ?? '?'} ${apiErr?.message ?? String(err)}`.trim(),
+        );
+
+  Sentry.captureException(normalized, {
+    tags: { area },
+    ...(err instanceof Error ? {} : { extra: { apiError: err } }),
+  });
+}

--- a/apps/mobile/src/screens/chat/HomeScreen.tsx
+++ b/apps/mobile/src/screens/chat/HomeScreen.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFocusEffect } from '@react-navigation/native';
+import * as Sentry from '@sentry/react-native';
 
 import { useAppDispatch, useAppSelector } from '../../store';
 import {
@@ -235,8 +236,10 @@ export function HomeScreen() {
         const messages = historyToMessages(rows);
         dispatch(loadHistory({ sessionId: sid, messages }));
       } catch (err) {
-        const errMsg = err instanceof Error ? err.message : 'Could not load session.';
-        dispatch(setError(errMsg));
+        // The raw message is internal (function name + HTTP status) — report it
+        // to Sentry and show the user a static string instead (issue #3115).
+        Sentry.captureException(err, { tags: { area: 'ai-sessions-history' } });
+        dispatch(setError('Could not load that conversation.'));
       }
     },
     [dispatch],

--- a/apps/mobile/src/screens/chat/HomeScreen.tsx
+++ b/apps/mobile/src/screens/chat/HomeScreen.tsx
@@ -37,6 +37,7 @@ import {
 import { fetchAlerts } from '../../store/alertsSlice';
 import { fetchOne as fetchApprovalOne, setFocus as setApprovalFocus } from '../../store/approvalsSlice';
 import { track } from '../../lib/analytics';
+import { reportInternalError } from '../../lib/errorReporting';
 import { ChatHeader } from './components/ChatHeader';
 import { ColdOpenChips } from './components/ColdOpenChips';
 import { Composer } from './components/Composer';
@@ -193,7 +194,7 @@ export function HomeScreen() {
           dispatch(setStatus('error'));
           // The raw message is internal (function name + HTTP status) — report it
           // to Sentry and show the user a static string instead (issue #3141).
-          Sentry.captureException(err, { tags: { area: 'ai-session-create' } });
+          reportInternalError(err, 'ai-session-create');
           dispatch(failAssistantMessage({ id: userMessageId, error: 'Could not start a session.' }));
           return;
         }

--- a/apps/mobile/src/screens/chat/HomeScreen.tsx
+++ b/apps/mobile/src/screens/chat/HomeScreen.tsx
@@ -191,8 +191,10 @@ export function HomeScreen() {
           track('chat_session_created');
         } catch (err) {
           dispatch(setStatus('error'));
-          const errMsg = err instanceof Error ? err.message : 'Could not start a session.';
-          dispatch(failAssistantMessage({ id: userMessageId, error: errMsg }));
+          // The raw message is internal (function name + HTTP status) — report it
+          // to Sentry and show the user a static string instead (issue #3141).
+          Sentry.captureException(err, { tags: { area: 'ai-session-create' } });
+          dispatch(failAssistantMessage({ id: userMessageId, error: 'Could not start a session.' }));
           return;
         }
       }

--- a/apps/mobile/src/screens/chat/components/SessionsSheet.tsx
+++ b/apps/mobile/src/screens/chat/components/SessionsSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, FlatList, Modal, Pressable, Text, View } from 'react-native';
+import * as Sentry from '@sentry/react-native';
 
 import { useApprovalTheme, radii, spacing, type } from '../../../theme';
 import { listAiSessions, type AiSessionListItem } from '../../../services/aiChat';
@@ -22,7 +23,12 @@ export function SessionsSheet({ visible, onCancel, onSelect }: Props) {
     setError(null);
     listAiSessions(30)
       .then(setSessions)
-      .catch((err: Error) => setError(err.message));
+      .catch((err: Error) => {
+        // The raw message is internal (function name + HTTP status) — report it
+        // to Sentry and show the user a static string instead (issue #3115).
+        Sentry.captureException(err, { tags: { area: 'ai-sessions-history' } });
+        setError("Couldn't load conversation history.");
+      });
   }, [visible]);
 
   return (

--- a/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
+++ b/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View } from 'react-native';
-import * as Sentry from '@sentry/react-native';
 
 import {
   getDeviceMetrics,
@@ -18,6 +17,7 @@ import {
   type,
 } from '../../theme';
 import { Spinner } from '../../components/Spinner';
+import { reportInternalError } from '../../lib/errorReporting';
 
 interface Props {
   route: { params: { device: Device } };
@@ -171,10 +171,10 @@ export function DeviceDetailScreen({ route }: Props) {
       .then((data) => {
         if (mounted) setMetrics(data);
       })
-      .catch((err: Error) => {
+      .catch((err: unknown) => {
         // The raw message is internal (function name + HTTP status) — report it
         // to Sentry and keep only a static string in UI state (issue #3141).
-        Sentry.captureException(err, { tags: { area: 'device-metrics' } });
+        reportInternalError(err, 'device-metrics');
         if (mounted) setMetricsError('Could not load metrics.');
       })
       .finally(() => {

--- a/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
+++ b/apps/mobile/src/screens/devices/DeviceDetailScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View } from 'react-native';
+import * as Sentry from '@sentry/react-native';
 
 import {
   getDeviceMetrics,
@@ -171,7 +172,10 @@ export function DeviceDetailScreen({ route }: Props) {
         if (mounted) setMetrics(data);
       })
       .catch((err: Error) => {
-        if (mounted) setMetricsError(err.message);
+        // The raw message is internal (function name + HTTP status) — report it
+        // to Sentry and keep only a static string in UI state (issue #3141).
+        Sentry.captureException(err, { tags: { area: 'device-metrics' } });
+        if (mounted) setMetricsError('Could not load metrics.');
       })
       .finally(() => {
         if (mounted) setLoadingMetrics(false);

--- a/apps/mobile/src/screens/systems/SystemsScreen.tsx
+++ b/apps/mobile/src/screens/systems/SystemsScreen.tsx
@@ -4,7 +4,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import Svg, { Circle, Line } from 'react-native-svg';
-import * as Sentry from '@sentry/react-native';
 
 import { useApprovalTheme, palette, spacing, type } from '../../theme';
 import type { Alert, Device } from '../../services/api';
@@ -19,6 +18,7 @@ import { SearchSheet } from '../search/SearchSheet';
 import type { MobileSearchResult } from '../../services/search';
 import { haptic } from '../../lib/motion';
 import { track } from '../../lib/analytics';
+import { reportInternalError } from '../../lib/errorReporting';
 
 import { AlertActionSheet } from './components/AlertActionSheet';
 import { FilterChip } from './components/FilterChip';
@@ -210,7 +210,9 @@ export function SystemsScreen() {
       } catch (err) {
         // The raw message is internal (function name + HTTP status) — report it
         // to Sentry and show the user a static string instead (issue #3141).
-        Sentry.captureException(err, { tags: { area: 'ai-sessions-history' } });
+        // Distinct tag from the HomeTab history paths: this open comes from
+        // Systems search and surfaces as a toast, not the chat error banner.
+        reportInternalError(err, 'ai-session-open-from-search');
         const msg = 'Could not load that conversation.';
         dispatch(setChatError(msg));
         setToast({ kind: 'error', text: msg });

--- a/apps/mobile/src/screens/systems/SystemsScreen.tsx
+++ b/apps/mobile/src/screens/systems/SystemsScreen.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import Svg, { Circle, Line } from 'react-native-svg';
+import * as Sentry from '@sentry/react-native';
 
 import { useApprovalTheme, palette, spacing, type } from '../../theme';
 import type { Alert, Device } from '../../services/api';
@@ -207,7 +208,10 @@ export function SystemsScreen() {
         const parent = navigation.getParent<NativeStackNavigationProp<MainTabParamList>>();
         if (parent) parent.navigate('HomeTab');
       } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Could not load conversation.';
+        // The raw message is internal (function name + HTTP status) — report it
+        // to Sentry and show the user a static string instead (issue #3141).
+        Sentry.captureException(err, { tags: { area: 'ai-sessions-history' } });
+        const msg = 'Could not load that conversation.';
         dispatch(setChatError(msg));
         setToast({ kind: 'error', text: msg });
       }

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import * as Sentry from '@sentry/react-native';
+
+import { reportInternalError } from '../../lib/errorReporting';
 
 import type { Alert, Device } from '../../services/api';
 import { getAlerts, getDevices } from '../../services/api';
@@ -105,7 +106,7 @@ export function useSystemsData() {
     } catch (err) {
       // The raw message is internal (function name + HTTP status) — report it
       // to Sentry and keep only a static string in UI state (issue #3141).
-      Sentry.captureException(err, { tags: { area: 'systems-data' } });
+      reportInternalError(err, 'systems-data');
       setData((d) => ({
         ...d,
         loading: false,

--- a/apps/mobile/src/screens/systems/useSystemsData.ts
+++ b/apps/mobile/src/screens/systems/useSystemsData.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Sentry from '@sentry/react-native';
 
 import type { Alert, Device } from '../../services/api';
 import { getAlerts, getDevices } from '../../services/api';
@@ -102,12 +103,14 @@ export function useSystemsData() {
       });
       lastFetchAt.current = Date.now();
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : 'Failed to load systems data.';
+      // The raw message is internal (function name + HTTP status) — report it
+      // to Sentry and keep only a static string in UI state (issue #3141).
+      Sentry.captureException(err, { tags: { area: 'systems-data' } });
       setData((d) => ({
         ...d,
         loading: false,
         refreshing: false,
-        error: errMsg,
+        error: 'Failed to load systems data.',
       }));
     } finally {
       inFlight.current = false;


### PR DESCRIPTION
Closes #3141

## What

Sweeps the four remaining sites of the #3115 defect class — mobile service errors carry internal detail (function name + HTTP status, e.g. `getAiSessionMessages failed: 404`) that was rendered directly to users. Each site now shows static user-facing copy and reports the internal detail to Sentry through a new shared helper `lib/errorReporting.ts` (`reportInternalError(err, area)`), following the pattern established in #3120:

| Site | Surface | Area tag |
|---|---|---|
| `SystemsScreen.tsx` (session-open-from-search path) | toast + chat error banner | `ai-session-open-from-search` |
| `useSystemsData.ts` | systems fetch error state | `systems-data` |
| `DeviceDetailScreen.tsx` | device metrics error state | `device-metrics` |
| `HomeScreen.tsx` (create-session path) | failed-message error text | `ai-session-create` |

The helper exists because `services/api.ts` throws plain `ApiError` object literals, not `Error` instances — captured directly they become stackless synthetic Sentry events that all group into one issue. `reportInternalError` passes real Errors through unchanged, wraps object throws in a real `Error` keyed on area + status (original object preserved in `extra`), and skips expected `device_blocked` responses so background polls on a blocked device don't spam Sentry. Covered by `lib/errorReporting.test.ts`.

## Sweep results

Grepped `apps/mobile` for further sites rendering raw `err.message`/`error.message` to users. No additional sites of this class found:

- `SearchSheet.tsx` already renders static copy ("Couldn't search. Try again.") — the raw string in `searchCoordinator` state is never shown.
- `ChangePasswordSheet.tsx`, `ServerSelectScreen.tsx`, alert-acknowledge toasts, and `DeviceDetailScreen` action errors surface server-authored `body.error` copy or local static validation strings (via `api.ts` `ApiError`), not the internal function-name class.
- HomeScreen streaming paths (`ev.message` from SSE error events, stream `onError`) were deliberately left in place per the issue scope (create-session path only); noting that `onError` can still surface e.g. `HTTP 500` in a chat bubble — candidate for a follow-up if wanted.
- `SettingsSheet.tsx`, approvals screens, and `aiChat.ts` internals untouched (in flight on sibling branches).

## Stacking

**Stacked on #3120** (`fix/3115-sessions-sheet-error-text`) because HomeScreen.tsx is already modified there. Retarget to `ToddHebebrand/ios-app-testing` when #3120 merges. Note: `ci.yml` does not run on non-main-based PRs — verification is local (below).

## Verification

- `npx tsc --noEmit` in `apps/mobile`: clean
- Full mobile vitest suite: 28 files, 265 passed / 3 skipped (includes 4 new helper tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)