### PR TITLE
feat(patching): third-party auto-approval as a first-class Update Ring control

### DIFF
--- a/apps/api/migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql
+++ b/apps/api/migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql
@@ -37,10 +37,24 @@ BEGIN
   -- 2) Rings with an autoApprove:true third_party_app category rule: turn on
   --    the ring-level toggle (carrying the rule's deferral override) and strip
   --    the rule. Preserves intent: those rings wanted 3P auto-approved.
+  --    Accepted narrowing: an {enabled:true, severities:[]} ring with a 3P
+  --    rule loses its rule-based 3P behavior — statement 1 runs first and
+  --    stamps thirdPartyApps:false (no recognized severities), so this
+  --    statement's "lacks thirdPartyApps" guard then skips it, and statement
+  --    3 strips the now-inert rule. Fail-closed; 0 known rows.
   UPDATE patch_policies p
   SET auto_approve =
         (CASE WHEN jsonb_typeof(p.auto_approve) = 'object' THEN p.auto_approve ELSE '{}'::jsonb END)
         || jsonb_build_object('enabled', true, 'thirdPartyApps', true)
+        -- The pre-image's OS auto-approve state must survive this ring-level
+        -- enable: if the ring wasn't already boolean-true enabled, its
+        -- severities (if any) belonged to a disabled state and must not
+        -- silently start applying now that 'enabled' flips to true. Compare
+        -- against the jsonb boolean (not ->>'enabled' = 'true' text, which a
+        -- malformed {"enabled":"true"} string row would also fail — and we
+        -- want that case cleared too).
+        || CASE WHEN p.auto_approve->'enabled' = 'true'::jsonb THEN '{}'::jsonb
+                ELSE jsonb_build_object('severities', '[]'::jsonb) END
         || COALESCE(
              (SELECT CASE WHEN (r.rule->>'deferralDaysOverride') ~ '^\d{1,3}$'
                            AND (r.rule->>'deferralDaysOverride')::int <= 365

--- a/apps/api/migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql
+++ b/apps/api/migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql
@@ -1,0 +1,88 @@
+-- Spec 2026-08-04: third-party ring auto-approve. Backfills the explicit
+-- autoApprove.thirdPartyApps shape and migrates legacy 'third_party_app'
+-- category rules to the ring-level toggle. Idempotent; counts RAISEd so the
+-- rollout numbers land in Postgres logs (expected prod: 0 / 1 / 0 rows).
+
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  -- 1) Enabled object-shaped rows lacking thirdPartyApps: derive it from
+  --    whether the row has >=1 recognized severity (mirrors
+  --    parseRingAutoApprove's compatibility rule / the old #2218 exemption).
+  UPDATE patch_policies
+  SET auto_approve = auto_approve
+        || jsonb_build_object(
+             'thirdPartyApps',
+             EXISTS (
+               SELECT 1
+               FROM jsonb_array_elements_text(
+                 CASE WHEN jsonb_typeof(auto_approve->'severities') = 'array'
+                      THEN auto_approve->'severities'
+                      ELSE '[]'::jsonb END
+               ) AS sev(v)
+               WHERE sev.v IN ('critical','important','moderate','low')
+             )
+           )
+        || CASE WHEN auto_approve ? 'thirdPartyDeferralDays'
+                 THEN '{}'::jsonb
+                 ELSE jsonb_build_object('thirdPartyDeferralDays', NULL::int) END
+  WHERE kind = 'ring'
+    AND jsonb_typeof(auto_approve) = 'object'
+    AND auto_approve->>'enabled' = 'true'
+    AND NOT auto_approve ? 'thirdPartyApps';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'ring-3p backfill: stamped explicit thirdPartyApps on % enabled auto_approve rows', n; END IF;
+
+  -- 2) Rings with an autoApprove:true third_party_app category rule: turn on
+  --    the ring-level toggle (carrying the rule's deferral override) and strip
+  --    the rule. Preserves intent: those rings wanted 3P auto-approved.
+  UPDATE patch_policies p
+  SET auto_approve =
+        (CASE WHEN jsonb_typeof(p.auto_approve) = 'object' THEN p.auto_approve ELSE '{}'::jsonb END)
+        || jsonb_build_object('enabled', true, 'thirdPartyApps', true)
+        || COALESCE(
+             (SELECT CASE WHEN (r.rule->>'deferralDaysOverride') ~ '^\d{1,3}$'
+                           AND (r.rule->>'deferralDaysOverride')::int <= 365
+                          THEN jsonb_build_object('thirdPartyDeferralDays', (r.rule->>'deferralDaysOverride')::int)
+                          ELSE '{}'::jsonb END
+              FROM jsonb_array_elements(p.category_rules) AS r(rule)
+              WHERE r.rule->>'category' = 'third_party_app'
+                AND r.rule->>'autoApprove' = 'true'
+              LIMIT 1),
+             '{}'::jsonb),
+      category_rules = COALESCE(
+        (SELECT jsonb_agg(r.rule)
+         FROM jsonb_array_elements(p.category_rules) AS r(rule)
+         WHERE r.rule->>'category' IS DISTINCT FROM 'third_party_app'),
+        '[]'::jsonb),
+      updated_at = now()
+  WHERE p.kind = 'ring'
+    AND jsonb_typeof(p.category_rules) = 'array'
+    AND NOT (p.auto_approve ? 'thirdPartyApps')
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p.category_rules) AS r(rule)
+      WHERE r.rule->>'category' = 'third_party_app'
+        AND r.rule->>'autoApprove' = 'true'
+    );
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'ring-3p backfill: converted third_party_app category rules to the ring toggle on % rings', n; END IF;
+
+  -- 3) Strip any remaining (autoApprove:false) third_party_app rules — nothing
+  --    to preserve; the category no longer exists.
+  UPDATE patch_policies p
+  SET category_rules = COALESCE(
+        (SELECT jsonb_agg(r.rule)
+         FROM jsonb_array_elements(p.category_rules) AS r(rule)
+         WHERE r.rule->>'category' IS DISTINCT FROM 'third_party_app'),
+        '[]'::jsonb),
+      updated_at = now()
+  WHERE p.kind = 'ring'
+    AND jsonb_typeof(p.category_rules) = 'array'
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p.category_rules) AS r(rule)
+      WHERE r.rule->>'category' = 'third_party_app'
+    );
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'ring-3p backfill: stripped inert third_party_app rules from % rings', n; END IF;
+END $$;

--- a/apps/api/migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql
+++ b/apps/api/migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql
@@ -1,15 +1,71 @@
 -- Spec 2026-08-04: third-party ring auto-approve. Backfills the explicit
 -- autoApprove.thirdPartyApps shape and migrates legacy 'third_party_app'
 -- category rules to the ring-level toggle. Idempotent; counts RAISEd so the
--- rollout numbers land in Postgres logs (expected prod: 0 / 1 / 0 rows).
+-- rollout numbers land in Postgres logs (expected prod: 1 / 0 / 0 rows).
+--
+-- Statement order matters: rule conversion (1) runs BEFORE the generic
+-- thirdPartyApps stamp (2), so a ring whose 3P behavior came from a category
+-- rule keeps that behavior (and its deferral hold) regardless of what the
+-- severity-derivation in (2) would have concluded.
 
 DO $$
 DECLARE
   n integer;
 BEGIN
-  -- 1) Enabled object-shaped rows lacking thirdPartyApps: derive it from
-  --    whether the row has >=1 recognized severity (mirrors
+  -- 1) Rings with an autoApprove:true third_party_app category rule: turn on
+  --    the ring-level toggle and strip the rule. Preserves intent: those rings
+  --    wanted 3P auto-approved. The old category path held 3P patches for
+  --    rule.deferralDaysOverride ?? the ring's deferral_days COLUMN (not the
+  --    auto_approve jsonb's deferralDays), so that exact value is carried into
+  --    thirdPartyDeferralDays — otherwise converted rings would silently lose
+  --    their hold and auto-approve 3P updates on first sight (fail-open).
+  UPDATE patch_policies p
+  SET auto_approve =
+        (CASE WHEN jsonb_typeof(p.auto_approve) = 'object' THEN p.auto_approve ELSE '{}'::jsonb END)
+        || jsonb_build_object('enabled', true, 'thirdPartyApps', true)
+        -- The pre-image's OS auto-approve state must survive this ring-level
+        -- enable: if the ring wasn't already boolean-true enabled, its
+        -- severities (if any) belonged to a disabled state and must not
+        -- silently start applying now that 'enabled' flips to true. Compare
+        -- against the jsonb boolean (not ->>'enabled' = 'true' text, which a
+        -- malformed {"enabled":"true"} string row would also SATISFY,
+        -- preserving severities we want cleared — the jsonb comparison
+        -- correctly excludes that row so its severities are cleared too).
+        || CASE WHEN p.auto_approve->'enabled' = 'true'::jsonb THEN '{}'::jsonb
+                ELSE jsonb_build_object('severities', '[]'::jsonb) END
+        || COALESCE(
+             (SELECT CASE WHEN (r.rule->>'deferralDaysOverride') ~ '^\d{1,3}$'
+                           AND (r.rule->>'deferralDaysOverride')::int <= 365
+                          THEN jsonb_build_object('thirdPartyDeferralDays', (r.rule->>'deferralDaysOverride')::int)
+                          -- No usable override → the old hold was the ring's
+                          -- deferral_days column; carry it explicitly.
+                          ELSE jsonb_build_object('thirdPartyDeferralDays', p.deferral_days) END
+              FROM jsonb_array_elements(p.category_rules) AS r(rule)
+              WHERE r.rule->>'category' = 'third_party_app'
+                AND r.rule->>'autoApprove' = 'true'
+              LIMIT 1),
+             '{}'::jsonb),
+      category_rules = COALESCE(
+        (SELECT jsonb_agg(r.rule)
+         FROM jsonb_array_elements(p.category_rules) AS r(rule)
+         WHERE r.rule->>'category' IS DISTINCT FROM 'third_party_app'),
+        '[]'::jsonb),
+      updated_at = now()
+  WHERE p.kind = 'ring'
+    AND jsonb_typeof(p.category_rules) = 'array'
+    AND NOT (p.auto_approve ? 'thirdPartyApps')
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p.category_rules) AS r(rule)
+      WHERE r.rule->>'category' = 'third_party_app'
+        AND r.rule->>'autoApprove' = 'true'
+    );
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'ring-3p backfill: converted third_party_app category rules to the ring toggle on % rings', n; END IF;
+
+  -- 2) Remaining enabled object-shaped rows lacking thirdPartyApps: derive it
+  --    from whether the row has >=1 recognized severity (mirrors
   --    parseRingAutoApprove's compatibility rule / the old #2218 exemption).
+  --    Rows converted by (1) already carry the key and are skipped.
   UPDATE patch_policies
   SET auto_approve = auto_approve
         || jsonb_build_object(
@@ -33,54 +89,6 @@ BEGIN
     AND NOT auto_approve ? 'thirdPartyApps';
   GET DIAGNOSTICS n = ROW_COUNT;
   IF n > 0 THEN RAISE WARNING 'ring-3p backfill: stamped explicit thirdPartyApps on % enabled auto_approve rows', n; END IF;
-
-  -- 2) Rings with an autoApprove:true third_party_app category rule: turn on
-  --    the ring-level toggle (carrying the rule's deferral override) and strip
-  --    the rule. Preserves intent: those rings wanted 3P auto-approved.
-  --    Accepted narrowing: an {enabled:true, severities:[]} ring with a 3P
-  --    rule loses its rule-based 3P behavior — statement 1 runs first and
-  --    stamps thirdPartyApps:false (no recognized severities), so this
-  --    statement's "lacks thirdPartyApps" guard then skips it, and statement
-  --    3 strips the now-inert rule. Fail-closed; 0 known rows.
-  UPDATE patch_policies p
-  SET auto_approve =
-        (CASE WHEN jsonb_typeof(p.auto_approve) = 'object' THEN p.auto_approve ELSE '{}'::jsonb END)
-        || jsonb_build_object('enabled', true, 'thirdPartyApps', true)
-        -- The pre-image's OS auto-approve state must survive this ring-level
-        -- enable: if the ring wasn't already boolean-true enabled, its
-        -- severities (if any) belonged to a disabled state and must not
-        -- silently start applying now that 'enabled' flips to true. Compare
-        -- against the jsonb boolean (not ->>'enabled' = 'true' text, which a
-        -- malformed {"enabled":"true"} string row would also fail — and we
-        -- want that case cleared too).
-        || CASE WHEN p.auto_approve->'enabled' = 'true'::jsonb THEN '{}'::jsonb
-                ELSE jsonb_build_object('severities', '[]'::jsonb) END
-        || COALESCE(
-             (SELECT CASE WHEN (r.rule->>'deferralDaysOverride') ~ '^\d{1,3}$'
-                           AND (r.rule->>'deferralDaysOverride')::int <= 365
-                          THEN jsonb_build_object('thirdPartyDeferralDays', (r.rule->>'deferralDaysOverride')::int)
-                          ELSE '{}'::jsonb END
-              FROM jsonb_array_elements(p.category_rules) AS r(rule)
-              WHERE r.rule->>'category' = 'third_party_app'
-                AND r.rule->>'autoApprove' = 'true'
-              LIMIT 1),
-             '{}'::jsonb),
-      category_rules = COALESCE(
-        (SELECT jsonb_agg(r.rule)
-         FROM jsonb_array_elements(p.category_rules) AS r(rule)
-         WHERE r.rule->>'category' IS DISTINCT FROM 'third_party_app'),
-        '[]'::jsonb),
-      updated_at = now()
-  WHERE p.kind = 'ring'
-    AND jsonb_typeof(p.category_rules) = 'array'
-    AND NOT (p.auto_approve ? 'thirdPartyApps')
-    AND EXISTS (
-      SELECT 1 FROM jsonb_array_elements(p.category_rules) AS r(rule)
-      WHERE r.rule->>'category' = 'third_party_app'
-        AND r.rule->>'autoApprove' = 'true'
-    );
-  GET DIAGNOSTICS n = ROW_COUNT;
-  IF n > 0 THEN RAISE WARNING 'ring-3p backfill: converted third_party_app category rules to the ring toggle on % rings', n; END IF;
 
   -- 3) Strip any remaining (autoApprove:false) third_party_app rules — nothing
   --    to preserve; the category no longer exists.

--- a/apps/api/src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
+++ b/apps/api/src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
@@ -93,16 +93,38 @@ async function seedPendingPatch(opts: {
   return patch.id;
 }
 
+/**
+ * Shape of the ring's raw `autoApprove` JSONB as accepted by
+ * parseRingAutoApprove — deliberately loose (deferralDays/thirdPartyApps/
+ * thirdPartyDeferralDays all optional) so tests can exercise legacy/compat
+ * shapes (e.g. omitting thirdPartyApps entirely) the same way a real stored
+ * row could.
+ */
+interface RingConfigAutoApprove {
+  enabled: boolean;
+  severities: string[];
+  deferralDays?: number;
+  thirdPartyApps?: boolean;
+  thirdPartyDeferralDays?: number | null;
+}
+
 function ringConfig(
   partnerId: string,
-  sources: string[],
+  sources: string[] | undefined,
   deferralDays = 0,
+  autoApprove: RingConfigAutoApprove = {
+    enabled: true,
+    severities: ['critical'],
+    deferralDays: deferralDays ?? 0,
+    thirdPartyApps: true,
+    thirdPartyDeferralDays: null,
+  },
 ): ApprovalEvaluationConfig {
   return {
     ringId: randomUUID(),
     ringPartnerId: partnerId,
     categoryRules: [],
-    autoApprove: { enabled: true, severities: ['critical', 'important'], deferralDays },
+    autoApprove,
     deferralDays: 0,
     sources,
   };
@@ -222,6 +244,145 @@ describe('third-party ring auto-approve (#2218) — end-to-end against Postgres'
 
     const approved = await evaluate(deviceId, ringConfig(partnerId, ['third_party'], 7));
 
+    expect(approved).toHaveLength(1);
+    expect(approved[0]!.patchId).toBe(patchId);
+    expect(approved[0]!.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('does NOT approve third-party when the ring toggle is off, even with sources third_party', async () => {
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-f');
+    await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+    });
+
+    const approved = await evaluate(
+      deviceId,
+      ringConfig(partnerId, ['os', 'third_party'], 0, {
+        enabled: true,
+        severities: ['critical'],
+        thirdPartyApps: false,
+      }),
+    );
+
+    expect(approved).toEqual([]);
+  });
+
+  it('does NOT approve third-party for a legacy snapshot with absent sources, even with the toggle on', async () => {
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-g');
+    await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+    });
+
+    const approved = await evaluate(
+      deviceId,
+      ringConfig(partnerId, undefined, 0, {
+        enabled: true,
+        severities: ['critical'],
+        thirdPartyApps: true,
+      }),
+    );
+
+    expect(approved).toEqual([]);
+  });
+
+  it('approves third-party on a third-party-only ring (empty severities)', async () => {
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-h');
+    const thirdPartyPatchId = await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+    });
+    const osPatchId = await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'microsoft',
+      severity: 'critical',
+    });
+
+    const approved = await evaluate(
+      deviceId,
+      ringConfig(partnerId, ['third_party'], 0, {
+        enabled: true,
+        severities: [],
+        thirdPartyApps: true,
+      }),
+    );
+
+    expect(approved.map((p) => p.patchId)).toEqual([thirdPartyPatchId]);
+    expect(approved.map((p) => p.patchId)).not.toContain(osPatchId);
+  });
+
+  it('legacy autoApprove without thirdPartyApps still approves 3P when severities were set (compat rule)', async () => {
+    const deviceId = await seedDevice(orgId, siteId, '3p-device-i');
+    const patchId = await seedPendingPatch({
+      orgId,
+      deviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+    });
+
+    const approved = await evaluate(
+      deviceId,
+      // No thirdPartyApps key at all — parseRingAutoApprove must derive it
+      // from severities.length > 0 (the pre-2026-08 compat rule).
+      ringConfig(partnerId, ['os', 'third_party'], 0, {
+        enabled: true,
+        severities: ['critical'],
+      }),
+    );
+
+    expect(approved).toHaveLength(1);
+    expect(approved[0]!.patchId).toBe(patchId);
+    expect(approved[0]!.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('applies thirdPartyDeferralDays over deferralDays using the first-seen anchor', async () => {
+    // autoApprove.deferralDays is deliberately set to a DIFFERENT value (1)
+    // than thirdPartyDeferralDays (7) so a bug that fell back to deferralDays
+    // instead of the third-party override would flip the "3 days ago" case.
+    const config = ringConfig(partnerId, ['third_party'], 0, {
+      enabled: true,
+      severities: ['critical'],
+      deferralDays: 1,
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: 7,
+    });
+
+    const heldDeviceId = await seedDevice(orgId, siteId, '3p-device-j');
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 3600 * 1000);
+    await seedPendingPatch({
+      orgId,
+      deviceId: heldDeviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+      firstSeenAt: threeDaysAgo,
+    });
+    const heldApproved = await evaluate(heldDeviceId, config);
+    expect(heldApproved).toEqual([]);
+
+    const approvedDeviceId = await seedDevice(orgId, siteId, '3p-device-k');
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 3600 * 1000);
+    const patchId = await seedPendingPatch({
+      orgId,
+      deviceId: approvedDeviceId,
+      source: 'third_party',
+      severity: 'unknown',
+      packageId: 'Mozilla.Firefox',
+      firstSeenAt: eightDaysAgo,
+    });
+    const approved = await evaluate(approvedDeviceId, config);
     expect(approved).toHaveLength(1);
     expect(approved[0]!.patchId).toBe(patchId);
     expect(approved[0]!.approvalReason).toBe('ring_auto_approve');

--- a/apps/api/src/__tests__/integration/ringThirdPartyBackfillMigration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/ringThirdPartyBackfillMigration.integration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Replays 2026-08-13-ring-third-party-auto-approve-backfill.sql against seeded
+ * pre-backfill rings — the shapes production rows actually had before the
+ * explicit thirdPartyApps field existed.
+ *
+ * CI databases are migrated schema-fresh in globalSetup, so the backfill's
+ * DO-block would otherwise only ever run against zero rows. This suite seeds
+ * the real pre-migration shapes, re-runs the migration file from disk, and
+ * asserts the behaviours the expand/contract plan depends on:
+ *
+ *  - a converted third_party_app rule carries its deferralDaysOverride into
+ *    thirdPartyDeferralDays;
+ *  - a converted rule WITHOUT a usable override carries the ring's
+ *    deferral_days COLUMN (the old category-path hold) — the fail-open bug
+ *    class this test exists to pin: without the carry, converted rings
+ *    auto-approve third-party updates immediately;
+ *  - the pre-image guard: severities that belonged to a not-boolean-true
+ *    enabled state (including the malformed {"enabled":"true"} string shape)
+ *    are cleared, so flipping `enabled` on never silently enables OS
+ *    auto-approval;
+ *  - severity-derived thirdPartyApps stamping for enabled rows without rules;
+ *  - autoApprove:false rules are stripped without enabling anything;
+ *  - replay is a true no-op (idempotent).
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ *
+ * Run:
+ *   pnpm --filter @breeze/api exec vitest run -c vitest.integration.config.ts \
+ *     src/__tests__/integration/ringThirdPartyBackfillMigration.integration.test.ts
+ */
+import './setup';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { inArray, sql } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { patchPolicies } from '../../db/schema';
+import { createPartner } from './db-utils';
+import { getTestDb } from './setup';
+
+const MIGRATION_FILE = join(
+  __dirname,
+  '../../../migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql',
+);
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+async function runMigration() {
+  await getTestDb().execute(sql.raw(readFileSync(MIGRATION_FILE, 'utf8')));
+}
+
+type SeededRing = { id: string; name: string };
+
+async function seedRing(
+  partnerId: string,
+  name: string,
+  row: {
+    deferralDays: number;
+    autoApprove: unknown;
+    categoryRules?: unknown[];
+  }
+): Promise<SeededRing> {
+  const db = getTestDb();
+  const [ring] = await db
+    .insert(patchPolicies)
+    .values({
+      partnerId,
+      kind: 'ring',
+      name,
+      deferralDays: row.deferralDays,
+      autoApprove: row.autoApprove,
+      categoryRules: row.categoryRules ?? [],
+    })
+    .returning({ id: patchPolicies.id, name: patchPolicies.name });
+  return ring!;
+}
+
+async function fetchRings(ids: string[]) {
+  const db = getTestDb();
+  const rows = await db
+    .select({
+      id: patchPolicies.id,
+      autoApprove: patchPolicies.autoApprove,
+      categoryRules: patchPolicies.categoryRules,
+      deferralDays: patchPolicies.deferralDays,
+    })
+    .from(patchPolicies)
+    .where(inArray(patchPolicies.id, ids));
+  return new Map(rows.map((r) => [r.id, r]));
+}
+
+describe('2026-08-13 ring third-party backfill migration', () => {
+  runDb('backfills every pre-image shape correctly and is idempotent', async () => {
+    const partner = await createPartner();
+    const pid = partner!.id;
+
+    // 1) Enabled ring, 3P allow rule WITH explicit deferralDaysOverride: the
+    //    override wins; severities survive (pre-image was boolean-true
+    //    enabled); the unrelated rule survives the strip.
+    const withOverride = await seedRing(pid, 'bf-with-override', {
+      deferralDays: 14,
+      autoApprove: { enabled: true, severities: ['critical'], deferralDays: 3 },
+      categoryRules: [
+        { category: 'third_party_app', autoApprove: true, deferralDaysOverride: 30 },
+        { category: 'security', autoApprove: true },
+      ],
+    });
+
+    // 2) Legacy boolean-true auto_approve, 3P allow rule WITHOUT an override:
+    //    the old category path held 3P patches for the ring's deferral_days
+    //    COLUMN (14) — that value must be carried, not dropped to 0.
+    const columnCarry = await seedRing(pid, 'bf-column-carry', {
+      deferralDays: 14,
+      autoApprove: true,
+      categoryRules: [{ category: 'third_party_app', autoApprove: true }],
+    });
+
+    // 3) DISABLED ring with parked severities + 3P allow rule: the ring-level
+    //    enable must not resurrect severities that belonged to a disabled
+    //    state (pre-image guard), and the column hold (7) is carried.
+    const disabledGuard = await seedRing(pid, 'bf-disabled-guard', {
+      deferralDays: 7,
+      autoApprove: { enabled: false, severities: ['critical', 'important'] },
+      categoryRules: [{ category: 'third_party_app', autoApprove: true }],
+    });
+
+    // 4) Malformed {"enabled":"true"} STRING row + 3P allow rule: the jsonb
+    //    boolean comparison must treat it as not-enabled and clear severities
+    //    (the ->>'enabled' text form would wrongly preserve them).
+    const stringEnabled = await seedRing(pid, 'bf-string-enabled', {
+      deferralDays: 0,
+      autoApprove: { enabled: 'true', severities: ['critical'] },
+      categoryRules: [{ category: 'third_party_app', autoApprove: true }],
+    });
+
+    // 5) 3P allow rule whose override is out of range (999 > 365): falls back
+    //    to the column carry (5), not to the invalid value and not to 0.
+    const invalidOverride = await seedRing(pid, 'bf-invalid-override', {
+      deferralDays: 5,
+      autoApprove: true,
+      categoryRules: [{ category: 'third_party_app', autoApprove: true, deferralDaysOverride: 999 }],
+    });
+
+    // 6) Enabled ring, recognized severities, NO rules: severity-derived
+    //    thirdPartyApps stamp with inherit hold (statement 2).
+    const derivedOn = await seedRing(pid, 'bf-derived-on', {
+      deferralDays: 0,
+      autoApprove: { enabled: true, severities: ['important'] },
+    });
+
+    // 7) Enabled ring, only unrecognized severities: derives to false.
+    const derivedOff = await seedRing(pid, 'bf-derived-off', {
+      deferralDays: 0,
+      autoApprove: { enabled: true, severities: ['bogus'] },
+    });
+
+    // 8) autoApprove:false 3P rule only: stripped by statement 3, toggle stays
+    //    derived (true here — severities exist), nothing else changes.
+    const denyRuleOnly = await seedRing(pid, 'bf-deny-rule-only', {
+      deferralDays: 9,
+      autoApprove: { enabled: true, severities: ['critical'], deferralDays: 2 },
+      categoryRules: [{ category: 'third_party_app', autoApprove: false }],
+    });
+
+    const ids = [
+      withOverride.id,
+      columnCarry.id,
+      disabledGuard.id,
+      stringEnabled.id,
+      invalidOverride.id,
+      derivedOn.id,
+      derivedOff.id,
+      denyRuleOnly.id,
+    ];
+
+    await runMigration();
+    const after = await fetchRings(ids);
+
+    expect(after.get(withOverride.id)!.autoApprove).toEqual({
+      enabled: true,
+      severities: ['critical'],
+      deferralDays: 3,
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: 30,
+    });
+    expect(after.get(withOverride.id)!.categoryRules).toEqual([
+      { category: 'security', autoApprove: true },
+    ]);
+
+    expect(after.get(columnCarry.id)!.autoApprove).toEqual({
+      enabled: true,
+      severities: [],
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: 14,
+    });
+    expect(after.get(columnCarry.id)!.categoryRules).toEqual([]);
+
+    expect(after.get(disabledGuard.id)!.autoApprove).toEqual({
+      enabled: true,
+      severities: [],
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: 7,
+    });
+
+    expect(after.get(stringEnabled.id)!.autoApprove).toEqual({
+      enabled: true,
+      severities: [],
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: 0,
+    });
+
+    expect(after.get(invalidOverride.id)!.autoApprove).toEqual({
+      enabled: true,
+      severities: [],
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: 5,
+    });
+
+    expect(after.get(derivedOn.id)!.autoApprove).toEqual({
+      enabled: true,
+      severities: ['important'],
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: null,
+    });
+
+    expect(after.get(derivedOff.id)!.autoApprove).toEqual({
+      enabled: true,
+      severities: ['bogus'],
+      thirdPartyApps: false,
+      thirdPartyDeferralDays: null,
+    });
+
+    expect(after.get(denyRuleOnly.id)!.autoApprove).toEqual({
+      enabled: true,
+      severities: ['critical'],
+      deferralDays: 2,
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: null,
+    });
+    expect(after.get(denyRuleOnly.id)!.categoryRules).toEqual([]);
+
+    // Idempotency: a replay must be a byte-for-byte no-op on every row.
+    await runMigration();
+    const replayed = await fetchRings(ids);
+    for (const id of ids) {
+      expect(replayed.get(id)).toEqual(after.get(id));
+    }
+  });
+});

--- a/apps/api/src/db/schema/patches.ts
+++ b/apps/api/src/db/schema/patches.ts
@@ -148,6 +148,9 @@ export const patchPolicies = pgTable('patch_policies', {
   description: text('description'),
   enabled: boolean('enabled').notNull().default(true),
   targets: jsonb('targets').notNull().default({}),
+  // DEPRECATED (spec 2026-08-04): never consumed by the approval path — the
+  // evaluated sources are config_policy_patch_settings.sources. Writers removed
+  // in the same release; DROP COLUMN ships one release later (expand/contract).
   sources: patchSourceEnum('sources').array(),
   autoApprove: jsonb('auto_approve').notNull().default({}),
   schedule: jsonb('schedule').notNull().default({}),

--- a/apps/api/src/jobs/patchJobExecutor.ts
+++ b/apps/api/src/jobs/patchJobExecutor.ts
@@ -23,6 +23,7 @@ import { getBullMQConnection } from '../services/redis';
 import { isReusableState } from '../services/bullmqUtils';
 import {
   resolveApprovedPatchesForDevice,
+  type CategoryRule,
   type PolicyAppRule,
   type PolicyAutoApproveConfig,
   type RingConfig,
@@ -39,6 +40,17 @@ const jobPolicyAutoApproveSchema = z.object({
   enabled: z.boolean(),
   severities: z.array(z.string()),
   deferralDays: z.number().int().min(0).optional(),
+});
+
+// Strict shape for one patches.categoryRules entry as stored in the job JSONB.
+// Matches the evaluator's CategoryRule: severityFilter is the legacy stored
+// alias for autoApproveSeverities (pre-2026-08 snapshots), both read-only here.
+const jobCategoryRuleSchema = z.object({
+  category: z.string().min(1),
+  autoApprove: z.boolean(),
+  autoApproveSeverities: z.array(z.string()).optional(),
+  severityFilter: z.array(z.string()).optional(),
+  deferralDaysOverride: z.number().int().min(0).nullable().optional(),
 });
 
 /**
@@ -672,11 +684,45 @@ async function prepareDeviceExecution(
     return { skipped: true, reason: 'Invalid patch category filter' };
   }
 
+  // Category rules were the one snapshot field cast blind while every sibling
+  // (sources, apps, policyAutoApprove, categories) is validated loudly — and a
+  // matching rule is now TERMINAL in the evaluator, so a malformed entry
+  // silently became a deny. Mirror the apps posture: a rule with a usable
+  // category but bad shape coerces to an explicit deny (fail-closed, matching
+  // what the evaluator's `!rule.autoApprove` would have done — but logged);
+  // a rule with no usable category is dropped, loudly.
+  const jobCategoryRules: CategoryRule[] = [];
+  if (patchesConfig?.categoryRules !== undefined) {
+    if (!Array.isArray(patchesConfig.categoryRules)) {
+      const message = `[PatchJobExecutor] Job ${patchJobId} has malformed patches.categoryRules; ignoring category rules`;
+      console.warn(`${message}:`, JSON.stringify(patchesConfig.categoryRules));
+      captureException(new Error(message));
+    } else {
+      for (const entry of patchesConfig.categoryRules) {
+        const parsed = jobCategoryRuleSchema.safeParse(entry);
+        if (parsed.success) {
+          jobCategoryRules.push(parsed.data);
+          continue;
+        }
+        const e = entry as { category?: unknown } | null;
+        if (e !== null && typeof e === 'object' && typeof e.category === 'string' && e.category.length > 0) {
+          console.warn(
+            `[PatchJobExecutor] Job ${patchJobId} coercing malformed category rule to deny (fail-closed):`,
+            JSON.stringify(entry)
+          );
+          jobCategoryRules.push({ category: e.category, autoApprove: false });
+        } else {
+          const message = `[PatchJobExecutor] Job ${patchJobId} dropping malformed category rule with unusable category`;
+          console.warn(`${message}:`, JSON.stringify(entry));
+          captureException(new Error(message));
+        }
+      }
+    }
+  }
+
   const ringConfig: RingConfig = {
     ringId: patchesConfig?.ringId ?? null,
-    categoryRules: (Array.isArray(patchesConfig?.categoryRules)
-      ? patchesConfig.categoryRules
-      : []) as RingConfig['categoryRules'],
+    categoryRules: jobCategoryRules,
     autoApprove: patchesConfig?.autoApprove ?? {},
     deferralDays: 0,
     categories: jobCategories,

--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -303,8 +303,16 @@ updateRingRoutes.get(
       .orderBy(desc(patchJobs.createdAt))
       .limit(5);
 
+    // `sources` is deprecated (never consumed by the approval path — see the
+    // schema comment on patchPolicies.sources) and must not leak into ring
+    // responses, matching the list endpoint. The detail query above is a
+    // bare full-row select (it also needs every other column for the
+    // response and the partnerId check above), so strip it here rather than
+    // hand-projecting all ~20 remaining columns.
+    const { sources: _sources, ...ringWithoutSources } = ring;
+
     return c.json({
-      ...ring,
+      ...ringWithoutSources,
       approvalSummary,
       recentJobs,
     });

--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -19,7 +19,9 @@ import { ringAutoApproveSchema } from '@breeze/shared/validators';
 
 // Typed default for a ring's autoApprove JSONB (#1317). A freshly created or
 // auto-provisioned ring auto-approves nothing until an operator opts in.
-const DEFAULT_RING_AUTO_APPROVE = { enabled: false, severities: [], deferralDays: 0 } as const;
+const DEFAULT_RING_AUTO_APPROVE = {
+  enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
+} as const;
 
 export const updateRingRoutes = new Hono();
 const requireUpdateRingRead = requirePermission(PERMISSIONS.DEVICES_READ.resource, PERMISSIONS.DEVICES_READ.action);
@@ -80,7 +82,9 @@ const listRingsSchema = z.object({
 });
 
 const categoryRuleSchema = z.object({
-  category: z.string().max(100),
+  category: z.string().max(100).refine((c) => c.trim().toLowerCase() !== 'third_party_app', {
+    message: "The 'third_party_app' category rule was replaced by autoApprove.thirdPartyApps on the ring.",
+  }),
   autoApprove: z.boolean(),
   autoApproveSeverities: z.array(z.enum(['critical', 'important', 'moderate', 'low'])).optional(),
   deferralDaysOverride: z.number().int().min(0).max(365).nullable().optional(),
@@ -98,7 +102,6 @@ const createRingSchema = z.object({
   categories: z.array(z.string().max(100)).optional(),
   excludeCategories: z.array(z.string().max(100)).optional(),
   categoryRules: z.array(categoryRuleSchema).optional(),
-  sources: z.array(z.enum(['microsoft', 'apple', 'linux', 'third_party', 'custom'])).optional(),
   // Ring-level auto-approval gate (#1317). Typed shape replaces the old
   // free-form record so the ring owns approval rules with validated severities.
   autoApprove: ringAutoApproveSchema.optional(),
@@ -116,7 +119,6 @@ const updateRingSchema = z.object({
   categories: z.array(z.string().max(100)).optional(),
   excludeCategories: z.array(z.string().max(100)).optional(),
   categoryRules: z.array(categoryRuleSchema).optional(),
-  sources: z.array(z.enum(['microsoft', 'apple', 'linux', 'third_party', 'custom'])).optional(),
   // Ring-level auto-approval gate (#1317). See createRingSchema.
   autoApprove: ringAutoApproveSchema.optional(),
   targets: z.record(z.string(), z.unknown()).optional(),
@@ -179,7 +181,6 @@ updateRingRoutes.get(
         gracePeriodHours: patchPolicies.gracePeriodHours,
         categories: patchPolicies.categories,
         excludeCategories: patchPolicies.excludeCategories,
-        sources: patchPolicies.sources,
         autoApprove: patchPolicies.autoApprove,
         categoryRules: patchPolicies.categoryRules,
         targets: patchPolicies.targets,
@@ -230,7 +231,6 @@ updateRingRoutes.post(
         gracePeriodHours: data.gracePeriodHours ?? 4,
         categories: data.categories ?? [],
         excludeCategories: data.excludeCategories ?? [],
-        sources: data.sources ?? null,
         autoApprove: data.autoApprove ?? DEFAULT_RING_AUTO_APPROVE,
         categoryRules: data.categoryRules ?? [],
         targets: data.targets ?? {},
@@ -345,7 +345,6 @@ updateRingRoutes.patch(
     if (data.gracePeriodHours !== undefined) updateFields.gracePeriodHours = data.gracePeriodHours;
     if (data.categories !== undefined) updateFields.categories = data.categories;
     if (data.excludeCategories !== undefined) updateFields.excludeCategories = data.excludeCategories;
-    if (data.sources !== undefined) updateFields.sources = data.sources;
     if (data.autoApprove !== undefined) updateFields.autoApprove = data.autoApprove;
     if (data.categoryRules !== undefined) updateFields.categoryRules = data.categoryRules;
     if (data.targets !== undefined) updateFields.targets = data.targets;

--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -15,7 +15,7 @@ import { getPagination, inferPatchOs } from './patches/helpers';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS } from '../services/permissions';
-import { ringAutoApproveSchema } from '@breeze/shared/validators';
+import { ringAutoApproveSchema, mergeRingAutoApproveWrite } from '@breeze/shared/validators';
 
 // Typed default for a ring's autoApprove JSONB (#1317). A freshly created or
 // auto-provisioned ring auto-approves nothing until an operator opts in.
@@ -231,7 +231,9 @@ updateRingRoutes.post(
         gracePeriodHours: data.gracePeriodHours ?? 4,
         categories: data.categories ?? [],
         excludeCategories: data.excludeCategories ?? [],
-        autoApprove: data.autoApprove ?? DEFAULT_RING_AUTO_APPROVE,
+        autoApprove: data.autoApprove
+          ? mergeRingAutoApproveWrite(data.autoApprove, undefined)
+          : DEFAULT_RING_AUTO_APPROVE,
         categoryRules: data.categoryRules ?? [],
         targets: data.targets ?? {},
         createdBy: auth.user.id,
@@ -333,7 +335,11 @@ updateRingRoutes.patch(
     const data = c.req.valid('json');
 
     const [existing] = await db
-      .select({ id: patchPolicies.id, partnerId: patchPolicies.partnerId })
+      .select({
+        id: patchPolicies.id,
+        partnerId: patchPolicies.partnerId,
+        autoApprove: patchPolicies.autoApprove,
+      })
       .from(patchPolicies)
       .where(and(eq(patchPolicies.id, id), eq(patchPolicies.kind, 'ring')))
       .limit(1);
@@ -353,7 +359,11 @@ updateRingRoutes.patch(
     if (data.gracePeriodHours !== undefined) updateFields.gracePeriodHours = data.gracePeriodHours;
     if (data.categories !== undefined) updateFields.categories = data.categories;
     if (data.excludeCategories !== undefined) updateFields.excludeCategories = data.excludeCategories;
-    if (data.autoApprove !== undefined) updateFields.autoApprove = data.autoApprove;
+    // Merge, don't replace: absent third-party fields (old-shape writers)
+    // preserve the ring's current opt-in instead of resetting it to defaults.
+    if (data.autoApprove !== undefined) {
+      updateFields.autoApprove = mergeRingAutoApproveWrite(data.autoApprove, existing.autoApprove);
+    }
     if (data.categoryRules !== undefined) updateFields.categoryRules = data.categoryRules;
     if (data.targets !== undefined) updateFields.targets = data.targets;
 

--- a/apps/api/src/routes/updateRings_detail_update_delete.test.ts
+++ b/apps/api/src/routes/updateRings_detail_update_delete.test.ts
@@ -248,6 +248,46 @@ describe('updateRings routes', () => {
 
       expect(res.status).toBe(400);
     });
+
+    it('no longer returns sources in ring detail responses', async () => {
+      vi.mocked(db.select)
+        // ring lookup — sources is deprecated but the row still carries it
+        // until the column is dropped; the route must strip it regardless.
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([makeRing({ sources: ['microsoft'] })])
+            })
+          })
+        } as any)
+        // approval counts
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              groupBy: vi.fn().mockResolvedValue([])
+            })
+          })
+        } as any)
+        // recent jobs
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([])
+              })
+            })
+          })
+        } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}`, {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).not.toHaveProperty('sources');
+    });
   });
 
   // ----------------------------------------------------------------

--- a/apps/api/src/routes/updateRings_detail_update_delete.test.ts
+++ b/apps/api/src/routes/updateRings_detail_update_delete.test.ts
@@ -355,6 +355,73 @@ describe('updateRings routes', () => {
 
       expect(res.status).toBe(400);
     });
+
+    it('PATCH persists thirdPartyApps and thirdPartyDeferralDays', async () => {
+      const autoApprove = {
+        enabled: true,
+        severities: [] as string[],
+        deferralDays: 0,
+        thirdPartyApps: true,
+        thirdPartyDeferralDays: 21
+      };
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: RING_ID, partnerId: PARTNER_ID }])
+          })
+        })
+      } as any);
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([makeRing({ autoApprove })])
+        })
+      });
+      vi.mocked(db.update).mockReturnValueOnce({ set: setMock } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ autoApprove })
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.autoApprove).toEqual(autoApprove);
+
+      const updateFields = setMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(updateFields.autoApprove).toMatchObject({
+        thirdPartyApps: true,
+        thirdPartyDeferralDays: 21
+      });
+    });
+
+    it('PATCH rejects a sources payload as an unknown field no-op', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{ id: RING_ID, partnerId: PARTNER_ID }])
+          })
+        })
+      } as any);
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([makeRing()])
+        })
+      });
+      vi.mocked(db.update).mockReturnValueOnce({ set: setMock } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        // Zod strips unknown keys by default, so `sources` is silently dropped
+        // rather than rejected — assert the DB update call never sees it.
+        body: JSON.stringify({ sources: ['third_party'] })
+      });
+
+      expect(res.status).toBe(200);
+      const updateFields = setMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(updateFields).not.toHaveProperty('sources');
+    });
   });
 
   // ----------------------------------------------------------------

--- a/apps/api/src/routes/updateRings_detail_update_delete.test.ts
+++ b/apps/api/src/routes/updateRings_detail_update_delete.test.ts
@@ -435,7 +435,108 @@ describe('updateRings routes', () => {
       });
     });
 
-    it('PATCH rejects a sources payload as an unknown field no-op', async () => {
+    it('PATCH with an old-shape autoApprove preserves the stored third-party opt-in (merge, not replace)', async () => {
+      // A pre-2026-08 client replays {enabled, severities, deferralDays} — the
+      // absent third-party fields must carry the stored row's values instead
+      // of resetting a toggle the client doesn't know about.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: RING_ID,
+              partnerId: PARTNER_ID,
+              autoApprove: { enabled: true, severities: ['critical'], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: 9 }
+            }])
+          })
+        })
+      } as any);
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([makeRing()])
+        })
+      });
+      vi.mocked(db.update).mockReturnValueOnce({ set: setMock } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ autoApprove: { enabled: true, severities: ['important'], deferralDays: 5 } })
+      });
+
+      expect(res.status).toBe(200);
+      const updateFields = setMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(updateFields.autoApprove).toEqual({
+        enabled: true,
+        severities: ['important'],
+        deferralDays: 5,
+        thirdPartyApps: true,
+        thirdPartyDeferralDays: 9
+      });
+    });
+
+    it('PATCH derives the preserved third-party opt-in from a legacy stored row without the field', async () => {
+      // Stored pre-backfill severity ring: absent thirdPartyApps derives true
+      // (the old #2218 exemption), so an old-shape write keeps 3P on.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: RING_ID,
+              partnerId: PARTNER_ID,
+              autoApprove: { enabled: true, severities: ['critical'] }
+            }])
+          })
+        })
+      } as any);
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([makeRing()])
+        })
+      });
+      vi.mocked(db.update).mockReturnValueOnce({ set: setMock } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ autoApprove: { enabled: true, severities: ['critical'], deferralDays: 3 } })
+      });
+
+      expect(res.status).toBe(200);
+      const updateFields = setMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(updateFields.autoApprove).toMatchObject({ thirdPartyApps: true, thirdPartyDeferralDays: null });
+    });
+
+    it('PATCH with an explicit thirdPartyApps:false overrides the stored opt-in', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: RING_ID,
+              partnerId: PARTNER_ID,
+              autoApprove: { enabled: true, severities: ['critical'], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: 9 }
+            }])
+          })
+        })
+      } as any);
+      const setMock = vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([makeRing()])
+        })
+      });
+      vi.mocked(db.update).mockReturnValueOnce({ set: setMock } as any);
+
+      const res = await app.request(`/update-rings/${RING_ID}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ autoApprove: { enabled: true, severities: ['critical'], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null } })
+      });
+
+      expect(res.status).toBe(200);
+      const updateFields = setMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(updateFields.autoApprove).toMatchObject({ thirdPartyApps: false, thirdPartyDeferralDays: null });
+    });
+
+    it('PATCH silently strips a sources payload (unknown key) — the DB update never sees it', async () => {
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({

--- a/apps/api/src/routes/updateRings_list_create.test.ts
+++ b/apps/api/src/routes/updateRings_list_create.test.ts
@@ -299,6 +299,34 @@ describe('updateRings routes', () => {
       expect(body.name).toBe('Test Ring');
     });
 
+    it('stamps explicit third-party defaults when an old-shape autoApprove omits them on create', async () => {
+      // No stored row to preserve on create: omitted third-party fields become
+      // explicit false/null (fail-closed), never schema-defaulted surprises.
+      const valuesMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([makeRing()])
+      });
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/update-rings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Old Shape Ring',
+          autoApprove: { enabled: true, severities: ['critical'], deferralDays: 2 }
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const inserted = valuesMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(inserted.autoApprove).toEqual({
+        enabled: true,
+        severities: ['critical'],
+        deferralDays: 2,
+        thirdPartyApps: false,
+        thirdPartyDeferralDays: null
+      });
+    });
+
     it('should resolve partnerId from the query string for system users', async () => {
       vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
         c.set('auth', {

--- a/apps/api/src/routes/updateRings_list_create.test.ts
+++ b/apps/api/src/routes/updateRings_list_create.test.ts
@@ -240,6 +240,36 @@ describe('updateRings routes', () => {
 
       expect(res.status).toBe(403);
     });
+
+    it('no longer returns sources in ring list responses', async () => {
+      // The list select no longer requests `sources`, so a real DB response
+      // (and thus this mock) has no `sources` key at all.
+      const { sources: _sources, ...ringWithoutSources } = makeRing({ name: 'Default', ringOrder: 0 });
+      const rings = [ringWithoutSources];
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(rings)
+          })
+        })
+      } as any);
+
+      const res = await app.request('/update-rings', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' }
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.length).toBeGreaterThan(0);
+      for (const ring of body.data) {
+        expect(ring).not.toHaveProperty('sources');
+      }
+
+      // The select projection itself must not request the sources column.
+      const projection = vi.mocked(db.select).mock.calls[0]![0] as Record<string, unknown>;
+      expect(projection).not.toHaveProperty('sources');
+    });
   });
 
   // ----------------------------------------------------------------
@@ -401,6 +431,52 @@ describe('updateRings routes', () => {
       });
 
       expect(res.status).toBe(400);
+    });
+
+    it('creates a third-party-only ring (empty severities + thirdPartyApps)', async () => {
+      const autoApprove = {
+        enabled: true,
+        severities: [] as string[],
+        deferralDays: 0,
+        thirdPartyApps: true,
+        thirdPartyDeferralDays: 14
+      };
+      const created = makeRing({ autoApprove });
+      const valuesMock = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([created])
+      });
+      vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+      const res = await app.request('/update-rings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({ name: 'Third Party Ring', autoApprove })
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.autoApprove).toEqual(autoApprove);
+
+      const insertValues = valuesMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(insertValues.autoApprove).toMatchObject({
+        thirdPartyApps: true,
+        thirdPartyDeferralDays: 14
+      });
+    });
+
+    it('rejects a third_party_app category rule with a helpful message', async () => {
+      const res = await app.request('/update-rings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Ring',
+          categoryRules: [{ category: 'third_party_app', autoApprove: true }]
+        })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(JSON.stringify(body)).toContain('thirdPartyApps');
     });
   });
 

--- a/apps/api/src/scripts/migrateToConfigPolicies.ts
+++ b/apps/api/src/scripts/migrateToConfigPolicies.ts
@@ -492,6 +492,10 @@ async function migratePatchPoliciesLive(
   // never consumed by the approval path) — default to ['os'] rather than
   // reading it, so this one-shot script isn't the last remaining reader of
   // that column once its writers are gone.
+  // Acceptable only because this script is retained as a one-shot, not a
+  // repeatable sync: re-running it for a legacy partner whose ring already
+  // opted in to third-party auto-approve would silently drop that opt-in
+  // by re-writing sources to ['os'] here.
   const sources: string[] = ['os'];
 
   await tx.insert(configPolicyPatchSettings).values({

--- a/apps/api/src/scripts/migrateToConfigPolicies.ts
+++ b/apps/api/src/scripts/migrateToConfigPolicies.ts
@@ -488,15 +488,19 @@ async function migratePatchPoliciesLive(
   if (!featureLink) throw new Error('Failed to create patch feature link');
   summary.featureLinksCreated++;
 
-  // The legacy patch_policies.sources column is deprecated (spec 2026-08-04,
-  // never consumed by the approval path) — default to ['os'] rather than
-  // reading it, so this one-shot script isn't the last remaining reader of
-  // that column once its writers are gone.
-  // Acceptable only because this script is retained as a one-shot, not a
-  // repeatable sync: re-running it for a legacy partner whose ring already
-  // opted in to third-party auto-approve would silently drop that opt-in
-  // by re-writing sources to ['os'] here.
-  const sources: string[] = ['os'];
+  // Carry the legacy policy's source selection: hardcoding ['os'] here would
+  // silently drop a not-yet-migrated partner's third-party opt-in on the
+  // script's FIRST run — killing their 3P patch jobs AND (under dual consent)
+  // the ring-level thirdPartyApps toggle. The patch_policies.sources column is
+  // deprecated but this read is fine until the drop lands; #3151's DROP COLUMN
+  // removes the Drizzle field, which breaks this line at compile time and
+  // forces this script to be updated (or deleted) in the same PR.
+  const sources: string[] = primary.sources ?? ['os'];
+  if (sources.some((s) => s !== 'os')) {
+    console.warn(
+      `[migrateToConfigPolicies] carrying non-OS patch sources ${JSON.stringify(sources)} from legacy policy ${primary.id}`
+    );
+  }
 
   await tx.insert(configPolicyPatchSettings).values({
     featureLinkId: featureLink.id,

--- a/apps/api/src/scripts/migrateToConfigPolicies.ts
+++ b/apps/api/src/scripts/migrateToConfigPolicies.ts
@@ -488,8 +488,11 @@ async function migratePatchPoliciesLive(
   if (!featureLink) throw new Error('Failed to create patch feature link');
   summary.featureLinksCreated++;
 
-  // sources is a patchSourceEnum[] on the legacy table, text[] on the target.
-  const sources: string[] = (primary.sources as string[] | null) ?? ['os'];
+  // The legacy patch_policies.sources column is deprecated (spec 2026-08-04,
+  // never consumed by the approval path) — default to ['os'] rather than
+  // reading it, so this one-shot script isn't the last remaining reader of
+  // that column once its writers are gone.
+  const sources: string[] = ['os'];
 
   await tx.insert(configPolicyPatchSettings).values({
     featureLinkId: featureLink.id,

--- a/apps/api/src/services/aiToolSchemas.ts
+++ b/apps/api/src/services/aiToolSchemas.ts
@@ -1393,7 +1393,6 @@ export const toolInputSchemas: Record<string, z.ZodType> = {
     gracePeriodHours: z.number().int().min(0).optional(),
     categories: z.array(z.string()).max(50).optional(),
     excludeCategories: z.array(z.string()).max(50).optional(),
-    sources: z.array(z.enum(['microsoft', 'apple', 'linux', 'third_party', 'custom'])).optional(),
     autoApprove: ringAutoApproveSchema.optional(),
     enabled: z.boolean().optional(),
     limit: z.number().int().min(1).max(100).optional(),

--- a/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
@@ -252,6 +252,38 @@ describe('manage_update_rings autoApprove fail-closed write boundary (#1317)', (
     expect(setArg.autoApprove).toMatchObject({ enabled: true, severities: ['low'] });
   });
 
+  it('update with an old-shape autoApprove preserves the stored third-party opt-in (merge, not replace)', async () => {
+    // The model routinely writes partial objects for fields it wasn't asked
+    // about — an omitted thirdPartyApps must not reset the ring's opt-in.
+    mockSelectReturns({
+      id: RING_ID,
+      partnerId: PARTNER_ID,
+      name: 'Ring A',
+      kind: 'ring',
+      autoApprove: { enabled: true, severities: ['critical'], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: 12 },
+    });
+    mockUpdate();
+    const tool = getTool();
+    const output = await tool.handler(
+      {
+        action: 'update',
+        ringId: RING_ID,
+        autoApprove: { enabled: true, severities: ['low'] },
+      },
+      makeAuth()
+    );
+
+    expect(JSON.parse(output).success).toBe(true);
+    const setArg = updateMock.mock.results[0]!.value.set.mock.calls[0][0];
+    expect(setArg.autoApprove).toEqual({
+      enabled: true,
+      severities: ['low'],
+      deferralDays: 0,
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: 12,
+    });
+  });
+
   it('rejects create and other actions for org-scope callers', async () => {
     const tool = getTool();
     const orgAuth = {

--- a/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
@@ -32,7 +32,6 @@ vi.mock('../db/schema/patches', () => ({
     gracePeriodHours: 'patchPolicies.gracePeriodHours',
     categories: 'patchPolicies.categories',
     excludeCategories: 'patchPolicies.excludeCategories',
-    sources: 'patchPolicies.sources',
   },
 }));
 vi.mock('../db/schema/softwarePolicies', () => ({ softwarePolicies: {} }));
@@ -348,6 +347,23 @@ describe('manage_update_rings autoApprove fail-closed write boundary (#1317)', (
     const parsed = JSON.parse(output);
     expect(parsed.error).toMatch(/severity|third-party/i);
     expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('manage_update_rings get strips the deprecated sources column from the response', async () => {
+    mockSelectReturns({
+      id: RING_ID,
+      partnerId: PARTNER_ID,
+      name: 'Ring A',
+      kind: 'ring',
+      sources: ['microsoft'],
+    });
+    const tool = getTool();
+    const output = await tool.handler({ action: 'get', ringId: RING_ID }, makeAuth());
+
+    const parsed = JSON.parse(output);
+    expect(parsed.ring).toBeDefined();
+    expect(parsed.ring).not.toHaveProperty('sources');
+    expect(parsed.ring.id).toBe(RING_ID);
   });
 });
 

--- a/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
@@ -286,6 +286,69 @@ describe('manage_update_rings autoApprove fail-closed write boundary (#1317)', (
     expect(written.partnerId).toBe(PARTNER_ID);
     expect(written.orgId).toBeUndefined();
   });
+
+  it('manage_update_rings create accepts a third-party-only autoApprove', async () => {
+    mockInsertReturns({ id: RING_ID, name: 'Ring A' });
+    const tool = getTool();
+    const output = await tool.handler(
+      {
+        action: 'create',
+        name: 'Ring A',
+        autoApprove: { enabled: true, severities: [], thirdPartyApps: true },
+      },
+      makeAuth()
+    );
+
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.success).toBe(true);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    const written = insertMock.mock.results[0]!.value.values.mock.calls[0][0];
+    expect(written.autoApprove).toMatchObject({
+      enabled: true,
+      severities: [],
+      thirdPartyApps: true,
+    });
+  });
+
+  it('manage_update_rings create/update ignore a sources input and never write the column', async () => {
+    mockInsertReturns({ id: RING_ID, name: 'Ring A' });
+    const tool = getTool();
+    const createOutput = await tool.handler(
+      { action: 'create', name: 'Ring A', sources: ['os'] },
+      makeAuth()
+    );
+    expect(JSON.parse(createOutput).success).toBe(true);
+    const createdValues = insertMock.mock.results[0]!.value.values.mock.calls[0][0];
+    expect(createdValues).not.toHaveProperty('sources');
+
+    vi.clearAllMocks();
+    mockSelectReturns({ id: RING_ID, partnerId: PARTNER_ID, name: 'Ring A', kind: 'ring' });
+    mockUpdate();
+    const updateOutput = await tool.handler(
+      { action: 'update', ringId: RING_ID, sources: ['os'] },
+      makeAuth()
+    );
+    expect(JSON.parse(updateOutput).success).toBe(true);
+    const updatedValues = updateMock.mock.results[0]!.value.set.mock.calls[0][0];
+    expect(updatedValues).not.toHaveProperty('sources');
+  });
+
+  it('manage_update_rings still rejects enabled with no severities and no thirdPartyApps', async () => {
+    const tool = getTool();
+    const output = await tool.handler(
+      {
+        action: 'create',
+        name: 'Ring A',
+        autoApprove: { enabled: true, severities: [] },
+      },
+      makeAuth()
+    );
+
+    const parsed = JSON.parse(output);
+    expect(parsed.error).toMatch(/severity|third-party/i);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
 });
 
 // manage_backup_configs used to write `providerConfig` straight to the DB,

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -235,7 +235,10 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
 
         const [ring] = await db.select().from(patchPolicies).where(and(...conditions)).limit(1);
         if (!ring) return JSON.stringify({ error: 'Update ring not found or access denied' });
-        return JSON.stringify({ ring });
+        // `sources` is deprecated (never consumed by the approval path) and must
+        // not leak into ring responses, matching the REST detail endpoint.
+        const { sources: _sources, ...ringWithoutSources } = ring;
+        return JSON.stringify({ ring: ringWithoutSources });
       }
 
       if (action === 'create') {

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -180,8 +180,7 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
           gracePeriodHours: { type: 'number', description: 'Hours after deadline before reboot is forced (default: 4)' },
           categories: { type: 'array', items: { type: 'string' }, description: 'Patch categories to include (e.g. ["critical","important","security"])' },
           excludeCategories: { type: 'array', items: { type: 'string' }, description: 'Patch categories to exclude' },
-          sources: { type: 'array', items: { type: 'string' }, description: 'Patch sources: ["microsoft","apple","linux","third_party","custom"]' },
-          autoApprove: { type: 'object', description: 'Auto-approval rules (e.g. { enabled: true, severities: ["critical","important"], deferralDays: 0 }). severities must be a subset of ["critical","important","moderate","low"]. If enabled is true you MUST list at least one severity — an enabled rule with an empty severity set is rejected (it would auto-approve nothing).' },
+          autoApprove: { type: 'object', description: 'Auto-approval rules, e.g. { enabled: true, severities: ["critical","important"], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null }. severities gate OS patches only and must be a subset of ["critical","important","moderate","low"]. thirdPartyApps auto-approves third-party app updates (winget/Chocolatey/Homebrew/custom) — it also requires the linked configuration policy to include third-party patch sources. If enabled is true you MUST set at least one severity OR thirdPartyApps: true.' },
           enabled: { type: 'boolean', description: 'Whether ring is active (for update)' },
           limit: { type: 'number', description: 'Max results for list (default 25)' },
         },
@@ -213,7 +212,6 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
           deadlineDays: patchPolicies.deadlineDays,
           gracePeriodHours: patchPolicies.gracePeriodHours,
           categories: patchPolicies.categories,
-          sources: patchPolicies.sources,
           autoApprove: patchPolicies.autoApprove,
           ringOrder: patchPolicies.ringOrder,
           createdAt: patchPolicies.createdAt,
@@ -264,7 +262,6 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
           gracePeriodHours: Number(input.gracePeriodHours) || 4,
           categories: (input.categories as string[]) ?? [],
           excludeCategories: (input.excludeCategories as string[]) ?? [],
-          sources: (input.sources as any[]) ?? undefined,
           autoApprove,
           createdBy: auth.user.id,
         }).returning();
@@ -296,7 +293,6 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
         if (input.gracePeriodHours != null) updates.gracePeriodHours = Number(input.gracePeriodHours);
         if (input.categories) updates.categories = input.categories;
         if (input.excludeCategories) updates.excludeCategories = input.excludeCategories;
-        if (input.sources) updates.sources = input.sources;
         if (input.autoApprove != null) {
           // Fail-closed autoApprove (#1317): reject enabled-without-severity at
           // the write boundary, mirroring the route's ringAutoApproveSchema.

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -16,7 +16,11 @@ import { configPolicyBackupSettings } from '../db/schema/configurationPolicies';
 import { eq, and, desc, sql, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
-import { ringAutoApproveSchema, backupProfileSelectionsSchema } from '@breeze/shared/validators';
+import {
+  ringAutoApproveSchema,
+  mergeRingAutoApproveWrite,
+  backupProfileSelectionsSchema,
+} from '@breeze/shared/validators';
 import { canManagePartnerWidePolicies } from './partnerWideAccess';
 import { sanitizeThrownToolError } from './aiToolErrors';
 import { validateS3Details } from '../routes/backup/schemas';
@@ -33,14 +37,18 @@ import { validateS3Details } from '../routes/backup/schemas';
  * string mirroring the route schema's refinement when the input is invalid.
  */
 function validateRingAutoApprove(
-  raw: unknown
+  raw: unknown,
+  storedRaw?: unknown
 ): { value: Record<string, unknown> } | { error: string } {
   const parsed = ringAutoApproveSchema.safeParse(raw);
   if (!parsed.success) {
     const message = parsed.error.issues[0]?.message ?? 'Invalid autoApprove configuration.';
     return { error: message };
   }
-  return { value: parsed.data as Record<string, unknown> };
+  // Merge, don't replace: the model routinely writes partial objects for
+  // fields it wasn't asked about, so absent third-party fields preserve the
+  // ring's current opt-in instead of resetting it to defaults.
+  return { value: mergeRingAutoApproveWrite(parsed.data, storedRaw) as unknown as Record<string, unknown> };
 }
 
 /**
@@ -180,7 +188,7 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
           gracePeriodHours: { type: 'number', description: 'Hours after deadline before reboot is forced (default: 4)' },
           categories: { type: 'array', items: { type: 'string' }, description: 'Patch categories to include (e.g. ["critical","important","security"])' },
           excludeCategories: { type: 'array', items: { type: 'string' }, description: 'Patch categories to exclude' },
-          autoApprove: { type: 'object', description: 'Auto-approval rules, e.g. { enabled: true, severities: ["critical","important"], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null }. severities gate OS patches only and must be a subset of ["critical","important","moderate","low"]. thirdPartyApps auto-approves third-party app updates (winget/Chocolatey/Homebrew/custom) — it also requires the linked configuration policy to include third-party patch sources. If enabled is true you MUST set at least one severity OR thirdPartyApps: true.' },
+          autoApprove: { type: 'object', description: 'Auto-approval rules, e.g. { enabled: true, severities: ["critical","important"], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null }. severities gate OS patches only and must be a subset of ["critical","important","moderate","low"]. thirdPartyApps auto-approves third-party app updates (winget/Chocolatey/Homebrew/custom) — it also requires the linked configuration policy to include third-party patch sources. If enabled is true you MUST set at least one severity OR thirdPartyApps: true. On update, omitting thirdPartyApps/thirdPartyDeferralDays preserves the ring\'s current third-party settings; send explicit values to change them.' },
           enabled: { type: 'boolean', description: 'Whether ring is active (for update)' },
           limit: { type: 'number', description: 'Max results for list (default 25)' },
         },
@@ -299,7 +307,7 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
         if (input.autoApprove != null) {
           // Fail-closed autoApprove (#1317): reject enabled-without-severity at
           // the write boundary, mirroring the route's ringAutoApproveSchema.
-          const validated = validateRingAutoApprove(input.autoApprove);
+          const validated = validateRingAutoApprove(input.autoApprove, existing.autoApprove);
           if ('error' in validated) return JSON.stringify({ error: validated.error });
           updates.autoApprove = validated.value;
         }

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -387,8 +387,8 @@ describe('app rules in resolveApprovedPatchesForDevice', () => {
   it('applies an app block rule under a linked ring too', async () => {
     mockPendingAndApprovals(
       [
-        pendingRow({ patchId: P1, devicePatchId: 'dp-1', source: 'third_party', category: 'homebrew', packageId: 'Mozilla.Firefox', version: '121.0' }),
-        pendingRow({ patchId: P2, devicePatchId: 'dp-2', source: 'third_party', category: 'homebrew', packageId: 'VideoLAN.VLC', version: '3.0.20' }),
+        pendingRow({ patchId: P1, devicePatchId: 'dp-1', source: 'third_party', category: 'third_party_app', packageId: 'Mozilla.Firefox', version: '121.0' }),
+        pendingRow({ patchId: P2, devicePatchId: 'dp-2', source: 'third_party', category: 'third_party_app', packageId: 'VideoLAN.VLC', version: '3.0.20' }),
       ],
       []
     );
@@ -520,7 +520,7 @@ describe('ring-less path: only manual approvals apply', () => {
   });
 });
 
-describe('third_party_app category rule', () => {
+describe('"third_party_app" as a literal category (virtual source-matching removed, #spec 2026-08-04)', () => {
   beforeEach(() => {
     vi.mocked(db.select).mockReset();
   });
@@ -532,7 +532,7 @@ describe('third_party_app category rule', () => {
     deferralDays: 0,
   };
 
-  it('auto-approves a third_party-source patch regardless of its category string', async () => {
+  it('no longer matches a third_party-source patch whose category is not literally "third_party_app"', async () => {
     mockPendingAndApprovals(
       [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000010', source: 'third_party', category: 'homebrew-cask' })],
       []
@@ -540,11 +540,10 @@ describe('third_party_app category rule', () => {
 
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, ringWithThirdPartyRule);
 
-    expect(approved).toHaveLength(1);
-    expect(approved[0]?.approvalReason).toBe('category_rule');
+    expect(approved).toHaveLength(0);
   });
 
-  it('does not apply the third_party_app rule to OS-source patches', async () => {
+  it('does not match an OS-source patch whose category is not literally "third_party_app"', async () => {
     mockPendingAndApprovals(
       [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000011', source: 'microsoft', category: 'application' })],
       []
@@ -555,7 +554,7 @@ describe('third_party_app category rule', () => {
     expect(approved).toHaveLength(0);
   });
 
-  it('prefers an exact category rule over the third_party_app fallback', async () => {
+  it('an exact category rule governs; an unrelated third_party_app rule never applies to it (no virtual fallback)', async () => {
     mockPendingAndApprovals(
       [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000012', source: 'third_party', category: 'homebrew', severity: 'low' })],
       []
@@ -572,9 +571,9 @@ describe('third_party_app category rule', () => {
     expect(approved).toHaveLength(0);
   });
 
-  it('applies the severity filter on the third_party_app rule', async () => {
+  it('applies the severity filter on a literal "third_party_app" category rule', async () => {
     mockPendingAndApprovals(
-      [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000013', source: 'third_party', category: 'homebrew', severity: 'low' })],
+      [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000013', source: 'third_party', category: 'third_party_app', severity: 'low' })],
       []
     );
 
@@ -586,11 +585,11 @@ describe('third_party_app category rule', () => {
     expect(approved).toHaveLength(0);
   });
 
-  it('does NOT auto-approve a null-severity patch under a category severity filter', async () => {
+  it('does NOT auto-approve a null-severity patch under a literal "third_party_app" category severity filter', async () => {
     // Mirrors the ring/policy fail-closed posture: a null-severity patch must
     // not slip past a non-empty category severityFilter.
     mockPendingAndApprovals(
-      [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-00000000001a', source: 'third_party', category: 'homebrew', severity: null })],
+      [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-00000000001a', source: 'third_party', category: 'third_party_app', severity: null })],
       []
     );
 
@@ -602,10 +601,10 @@ describe('third_party_app category rule', () => {
     expect(approved).toHaveLength(0);
   });
 
-  it('applies the deferral window on the third_party_app rule', async () => {
+  it('applies the deferral window on a literal "third_party_app" category rule', async () => {
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
     mockPendingAndApprovals(
-      [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000014', source: 'third_party', category: 'homebrew', releaseDate: yesterday })],
+      [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000014', source: 'third_party', category: 'third_party_app', releaseDate: yesterday })],
       []
     );
 
@@ -621,7 +620,7 @@ describe('third_party_app category rule', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       mockPendingAndApprovals(
-        [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000019', source: 'third_party', category: 'homebrew', releaseDate: null })],
+        [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000019', source: 'third_party', category: 'third_party_app', releaseDate: null })],
         []
       );
 
@@ -639,7 +638,7 @@ describe('third_party_app category rule', () => {
     }
   });
 
-  it('matches the third_party_app rule when the patch category is null', async () => {
+  it('does not match the third_party_app rule when the patch category is null (no virtual source-fallback)', async () => {
     mockPendingAndApprovals(
       [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000015', source: 'third_party', category: null })],
       []
@@ -647,11 +646,10 @@ describe('third_party_app category rule', () => {
 
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, ringWithThirdPartyRule);
 
-    expect(approved).toHaveLength(1);
-    expect(approved[0]?.approvalReason).toBe('category_rule');
+    expect(approved).toHaveLength(0);
   });
 
-  it('an exact category rule with autoApprove false suppresses the third_party_app fallback', async () => {
+  it('a matching autoApprove:false category rule blocks approval regardless of an unrelated third_party_app rule', async () => {
     mockPendingAndApprovals(
       [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000016', source: 'third_party', category: 'homebrew' })],
       []
@@ -668,7 +666,7 @@ describe('third_party_app category rule', () => {
     expect(approved).toHaveLength(0);
   });
 
-  it('combines source filtering with the third_party_app rule (headline flow)', async () => {
+  it('source filtering still applies; a same-source patch with a different category no longer matches a third_party_app rule', async () => {
     mockPendingAndApprovals(
       [
         pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000017', source: 'microsoft', category: 'security' }),
@@ -682,7 +680,93 @@ describe('third_party_app category rule', () => {
       sources: ['third_party'],
     });
 
-    expect(approved.map((p) => p.patchId)).toEqual(['aaaaaaaa-0000-0000-0000-000000000018']);
+    expect(approved).toEqual([]);
+  });
+});
+
+describe('category rules — repaired semantics (#spec 2026-08-04)', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('enforces autoApproveSeverities written by the route/UI (was silently ignored)', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, category: 'security', severity: 'moderate' })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'security', autoApprove: true, autoApproveSeverities: ['critical'] }],
+      autoApprove: {},
+      deferralDays: 0,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('still honors legacy stored severityFilter as a read alias', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, category: 'security', severity: 'critical' })],
+      []
+    );
+
+    const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'security', autoApprove: true, severityFilter: ['critical'] }],
+      autoApprove: {},
+      deferralDays: 0,
+    });
+
+    expect(approved.map((r) => r.patchId)).toEqual([P1]);
+    expect(approved[0]?.approvalReason).toBe('category_rule');
+
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, category: 'security', severity: 'low' })],
+      []
+    );
+
+    const notApproved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'security', autoApprove: true, severityFilter: ['critical'] }],
+      autoApprove: {},
+      deferralDays: 0,
+    });
+
+    expect(notApproved).toEqual([]);
+  });
+
+  it('treats a matching autoApprove:false rule as terminal — no fall-through to ring auto-approve', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, category: 'security', severity: 'critical' })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'security', autoApprove: false }],
+      autoApprove: { enabled: true, severities: ['critical'] },
+      deferralDays: 0,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('no longer matches third-party patches to a third_party_app rule', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', category: 'application', severity: 'critical' })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'third_party_app', autoApprove: true }],
+      autoApprove: { enabled: false, severities: [] },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+
+    expect(result).toEqual([]);
   });
 });
 
@@ -1411,10 +1495,10 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
     }
   });
 
-  it('applies the first-seen fallback on a third_party_app category deferral too', async () => {
+  it('applies the first-seen fallback on a literal "third_party_app" category deferral too', async () => {
     const yesterday = new Date(Date.now() - 24 * 3600 * 1000);
     mockPendingAndApprovals(
-      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: yesterday, category: 'homebrew' })],
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: yesterday, category: 'third_party_app' })],
       []
     );
 
@@ -1429,7 +1513,7 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
 
     const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000);
     mockPendingAndApprovals(
-      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: tenDaysAgo, category: 'homebrew' })],
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: tenDaysAgo, category: 'third_party_app' })],
       []
     );
 

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -402,8 +402,11 @@ describe('app rules in resolveApprovedPatchesForDevice', () => {
     const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
       ringId: RING_ID,
       categoryRules: [{ category: 'third_party_app', autoApprove: true }],
-      autoApprove: {},
+      // Dual consent: a category allow rule for a third-party patch requires
+      // the same policy-sources + ring-toggle legs as Priority 3.
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true },
       deferralDays: 0,
+      sources: ['third_party'],
       apps: [{ source: 'third_party', packageId: 'Mozilla.Firefox', action: 'block' }],
     });
 
@@ -538,6 +541,17 @@ describe('"third_party_app" as a literal category (virtual source-matching remov
     deferralDays: 0,
   };
 
+  // Dual consent granted (policy sources + ring toggle) so the category rule
+  // itself is what each test exercises — without consent a third-party patch
+  // is refused before the rule's severity/deferral gates are ever reached.
+  const consentedRingWithThirdPartyRule: RingConfig = {
+    ringId: RING_ID,
+    categoryRules: [{ category: 'third_party_app', autoApprove: true }],
+    autoApprove: { enabled: true, severities: [], thirdPartyApps: true },
+    deferralDays: 0,
+    sources: ['third_party'],
+  };
+
   it('no longer matches a third_party-source patch whose category is not literally "third_party_app"', async () => {
     mockPendingAndApprovals(
       [pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000010', source: 'third_party', category: 'homebrew-cask' })],
@@ -567,7 +581,7 @@ describe('"third_party_app" as a literal category (virtual source-matching remov
     );
 
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
-      ...ringWithThirdPartyRule,
+      ...consentedRingWithThirdPartyRule,
       categoryRules: [
         { category: 'homebrew', autoApprove: true, severityFilter: ['critical'] },
         { category: 'third_party_app', autoApprove: true },
@@ -584,7 +598,7 @@ describe('"third_party_app" as a literal category (virtual source-matching remov
     );
 
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
-      ...ringWithThirdPartyRule,
+      ...consentedRingWithThirdPartyRule,
       categoryRules: [{ category: 'third_party_app', autoApprove: true, severityFilter: ['critical'] }],
     });
 
@@ -600,7 +614,7 @@ describe('"third_party_app" as a literal category (virtual source-matching remov
     );
 
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
-      ...ringWithThirdPartyRule,
+      ...consentedRingWithThirdPartyRule,
       categoryRules: [{ category: 'third_party_app', autoApprove: true, severityFilter: ['critical'] }],
     });
 
@@ -615,7 +629,7 @@ describe('"third_party_app" as a literal category (virtual source-matching remov
     );
 
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
-      ...ringWithThirdPartyRule,
+      ...consentedRingWithThirdPartyRule,
       categoryRules: [{ category: 'third_party_app', autoApprove: true, deferralDaysOverride: 7 }],
     });
 
@@ -631,7 +645,7 @@ describe('"third_party_app" as a literal category (virtual source-matching remov
       );
 
       const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
-        ...ringWithThirdPartyRule,
+        ...consentedRingWithThirdPartyRule,
         categoryRules: [{ category: 'third_party_app', autoApprove: true, deferralDaysOverride: 7 }],
       });
 
@@ -662,7 +676,7 @@ describe('"third_party_app" as a literal category (virtual source-matching remov
     );
 
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
-      ...ringWithThirdPartyRule,
+      ...consentedRingWithThirdPartyRule,
       categoryRules: [
         { category: 'homebrew', autoApprove: false },
         { category: 'third_party_app', autoApprove: true },
@@ -709,6 +723,34 @@ describe('category rules — repaired semantics (#spec 2026-08-04)', () => {
     });
 
     expect(result).toEqual([]);
+  });
+
+  it('prefers autoApproveSeverities over severityFilter when both are present', async () => {
+    // Canonical field wins; the legacy alias must not resurrect a wider list.
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'microsoft', category: 'security', severity: 'low' })],
+      []
+    );
+    const refused = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'security', autoApprove: true, autoApproveSeverities: ['critical'], severityFilter: ['low'] }],
+      autoApprove: {},
+      deferralDays: 0,
+    });
+    expect(refused).toEqual([]);
+
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'microsoft', category: 'security', severity: 'critical' })],
+      []
+    );
+    const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'security', autoApprove: true, autoApproveSeverities: ['critical'], severityFilter: ['low'] }],
+      autoApprove: {},
+      deferralDays: 0,
+    });
+    expect(approved).toHaveLength(1);
+    expect(approved[0]?.approvalReason).toBe('category_rule');
   });
 
   it('still honors legacy stored severityFilter as a read alias', async () => {
@@ -1511,7 +1553,7 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
     const held = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
       ringId: RING_ID,
       categoryRules: [{ category: 'third_party_app', autoApprove: true, deferralDaysOverride: 7 }],
-      autoApprove: {},
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true },
       deferralDays: 0,
       sources: ['third_party'],
     });
@@ -1526,7 +1568,7 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
       ringId: RING_ID,
       categoryRules: [{ category: 'third_party_app', autoApprove: true, deferralDaysOverride: 7 }],
-      autoApprove: {},
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true },
       deferralDays: 0,
       sources: ['third_party'],
     });
@@ -1681,6 +1723,107 @@ describe('ring auto-approve — third-party dual consent (#spec 2026-08-04)', ()
     });
     expect(heldViaInherit).toEqual([]);
   });
+
+  it('honors an explicit thirdPartyDeferralDays of 0 over a non-zero inherited hold', async () => {
+    // Pins the ?? (not ||) semantics: 0 is an explicit "no hold" override and
+    // must not fall back to deferralDays.
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: new Date() })],
+      []
+    );
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true, deferralDays: 7, thirdPartyDeferralDays: 0 },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('evaluates a mixed OS + third-party ring per-source: OS approves, 3P refused with the toggle off', async () => {
+    mockPendingAndApprovals(
+      [
+        pendingRow({ patchId: P1, source: 'microsoft', category: 'security', severity: 'critical' }),
+        pendingRow({ patchId: P2, devicePatchId: 'dp-2', source: 'third_party', severity: 'unknown', releaseDate: null }),
+      ],
+      []
+    );
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: ['critical'], thirdPartyApps: false, deferralDays: 0 },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+    expect(result.map((r) => r.patchId)).toEqual([P1]);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('a literal category allow rule cannot bypass dual consent for a third-party patch (ring toggle off)', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', category: 'homebrew', severity: 'unknown', releaseDate: null })],
+      []
+    );
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'homebrew', autoApprove: true }],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: false },
+      deferralDays: 0,
+      sources: ['third_party'],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('a literal category allow rule cannot bypass the policy-sources consent leg (legacy absent sources)', async () => {
+    // Legacy job snapshots have no sources (= no upstream filtering) — exactly
+    // the case the literal 'third_party' check defends. The rule must not
+    // reintroduce the bypass.
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', category: 'homebrew', severity: 'unknown', releaseDate: null })],
+      []
+    );
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'homebrew', autoApprove: true }],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true },
+      deferralDays: 0,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('a literal category allow rule approves a third-party patch once BOTH consent legs hold', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', category: 'homebrew', severity: 'unknown', releaseDate: null })],
+      []
+    );
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'homebrew', autoApprove: true }],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true },
+      deferralDays: 0,
+      sources: ['third_party'],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('category_rule');
+  });
+
+  it('an autoApprove:false category rule is terminal for a third-party patch even with full dual consent', async () => {
+    // A per-category "needs manual approval" beats the ring-level 3P gate.
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', category: 'homebrew', severity: 'unknown', releaseDate: null })],
+      []
+    );
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [{ category: 'homebrew', autoApprove: false }],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true },
+      deferralDays: 0,
+      sources: ['third_party'],
+    });
+    expect(result).toEqual([]);
+  });
 });
 
 describe('parseRingAutoApprove — thirdPartyApps compatibility (#spec 2026-08-04)', () => {
@@ -1713,10 +1856,37 @@ describe('parseRingAutoApprove — thirdPartyApps compatibility (#spec 2026-08-0
     expect(parseRingAutoApprove({ enabled: true, severities: ['critical'] })).toMatchObject({ enabled: true, deferralDays: 0 });
   });
 
-  it('parses thirdPartyDeferralDays: valid int kept, malformed/absent/null → null', () => {
+  it('parses thirdPartyDeferralDays: valid int kept, absent/null → inherit (null)', () => {
     expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: 14 }).thirdPartyDeferralDays).toBe(14);
     expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: null }).thirdPartyDeferralDays).toBeNull();
-    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: 999 }).thirdPartyDeferralDays).toBeNull();
     expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true }).thirdPartyDeferralDays).toBeNull();
+  });
+
+  it('disables the row on a present-but-invalid thirdPartyDeferralDays instead of coercing to inherit', () => {
+    // Coercing to null would inherit deferralDays (often 0 = approve
+    // immediately) — the fail-open direction the sibling deferralDays field
+    // was already hardened against.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: '30' }).enabled).toBe(false);
+      expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: 999 }).enabled).toBe(false);
+      expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: -1 }).enabled).toBe(false);
+      expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: 1.5 }).enabled).toBe(false);
+      expect(String(warnSpy.mock.calls[0]?.[0] ?? '')).toContain('malformed autoApprove.thirdPartyDeferralDays');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('warns (loudly, with context) when a malformed deferralDays disables the row', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: '7' }, 'ring test-ring').enabled).toBe(false);
+      const warning = String(warnSpy.mock.calls[0]?.[0] ?? '');
+      expect(warning).toContain('ring test-ring');
+      expect(warning).toContain('malformed autoApprove.deferralDays');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -264,7 +264,13 @@ describe('resolveApprovedPatchesForDevice source filtering', () => {
     expect(approved.map((p) => p.patchId)).toEqual(['aaaaaaaa-0000-0000-0000-000000000003']);
   });
 
-  it('applies no source filtering when sources is absent (legacy jobs)', async () => {
+  it('applies no source filtering to OS patches when sources is absent (legacy jobs), but still refuses third-party (dual consent, #spec 2026-08-04)', async () => {
+    // buildAllowedPatchSources itself does not gate on absent sources (legacy
+    // "no filtering" jobs), but the ring-level dual-consent check in
+    // evaluatePatchApproval requires the literal 'third_party' selection
+    // regardless — an absent policy sources array can never satisfy that, so
+    // the third-party patch stays unapproved even though its severity matches
+    // the ring's OS severity list.
     mockPendingAndApprovals(
       [
         pendingRow({ patchId: 'aaaaaaaa-0000-0000-0000-000000000001', source: 'microsoft' }),
@@ -275,7 +281,7 @@ describe('resolveApprovedPatchesForDevice source filtering', () => {
 
     const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, baseRing);
 
-    expect(approved).toHaveLength(2);
+    expect(approved.map((p) => p.patchId)).toEqual(['aaaaaaaa-0000-0000-0000-000000000001']);
   });
 
   it('source filter also gates manually approved patches', async () => {
@@ -1526,6 +1532,154 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
     });
     expect(approved).toHaveLength(1);
     expect(approved[0]?.approvalReason).toBe('category_rule');
+  });
+});
+
+// ---- Ring auto-approve: third-party dual consent (#spec 2026-08-04) ----
+describe('ring auto-approve — third-party dual consent (#spec 2026-08-04)', () => {
+  beforeEach(() => {
+    vi.mocked(db.select).mockReset();
+  });
+
+  it('approves a third-party patch only with BOTH policy sources third_party AND ring thirdPartyApps', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true, deferralDays: 0 },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('does not approve third-party when the ring toggle is off, even with policy consent', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: ['critical'], thirdPartyApps: false, deferralDays: 0 },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not approve third-party when policy sources are absent (legacy snapshot) even with the toggle on', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true, deferralDays: 0 },
+      deferralDays: 0,
+      sources: undefined,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('supports a third-party-only ring: empty severities approves 3P and no OS patches', async () => {
+    mockPendingAndApprovals(
+      [
+        pendingRow({ patchId: P1, devicePatchId: 'dp-1', source: 'third_party', severity: 'unknown', releaseDate: null }),
+        pendingRow({ patchId: P2, devicePatchId: 'dp-2', source: 'microsoft', severity: 'critical' }),
+      ],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true, deferralDays: 0 },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+
+    expect(result.map((r) => r.patchId)).toEqual([P1]);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('treats custom-source patches as third-party for the toggle', async () => {
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'custom', severity: 'unknown', releaseDate: null })],
+      []
+    );
+
+    const result = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true, deferralDays: 0 },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.approvalReason).toBe('ring_auto_approve');
+  });
+
+  it('applies thirdPartyDeferralDays over deferralDays for 3P, anchored on firstSeenAt', async () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: threeDaysAgo })],
+      []
+    );
+
+    const held = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true, deferralDays: 0, thirdPartyDeferralDays: 7 },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+    expect(held).toEqual([]);
+
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: eightDaysAgo })],
+      []
+    );
+
+    const approved = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true, deferralDays: 0, thirdPartyDeferralDays: 7 },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+    expect(approved).toHaveLength(1);
+    expect(approved[0]?.approvalReason).toBe('ring_auto_approve');
+
+    // null thirdPartyDeferralDays inherits deferralDays: with deferralDays:7 the
+    // same 3-day-old first-seen timestamp is still held.
+    const threeDaysAgo2 = new Date(Date.now() - 3 * 24 * 3600 * 1000);
+    mockPendingAndApprovals(
+      [pendingRow({ patchId: P1, source: 'third_party', severity: 'unknown', releaseDate: null, firstSeenAt: threeDaysAgo2 })],
+      []
+    );
+
+    const heldViaInherit = await resolveApprovedPatchesForDevice(DEVICE_ID, ORG_ID, {
+      ringId: RING_ID,
+      categoryRules: [],
+      autoApprove: { enabled: true, severities: [], thirdPartyApps: true, deferralDays: 7, thirdPartyDeferralDays: null },
+      deferralDays: 0,
+      sources: ['os', 'third_party'],
+    });
+    expect(heldViaInherit).toEqual([]);
   });
 });
 

--- a/apps/api/src/services/patchApprovalEvaluator.test.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.test.ts
@@ -24,6 +24,7 @@ import {
   comparePatchVersions,
   evaluateAppRule,
   isCategoryAllowed,
+  parseRingAutoApprove,
   resolveApprovedPatchesForDevice,
   THIRD_PARTY_PATCH_SOURCES,
   type ApprovalEvaluationConfig,
@@ -1441,5 +1442,43 @@ describe('deferral first-seen fallback for third-party patches (#2218)', () => {
     });
     expect(approved).toHaveLength(1);
     expect(approved[0]?.approvalReason).toBe('category_rule');
+  });
+});
+
+describe('parseRingAutoApprove — thirdPartyApps compatibility (#spec 2026-08-04)', () => {
+  it('derives thirdPartyApps=true for a legacy enabled row with recognized severities', () => {
+    const cfg = parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: 3 });
+    expect(cfg).toEqual({ enabled: true, severities: ['critical'], deferralDays: 3, thirdPartyApps: true, thirdPartyDeferralDays: null });
+  });
+
+  it('derives thirdPartyApps=false for legacy enabled rows with no recognized severities', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: [] }).thirdPartyApps).toBe(false);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['bogus'] }).thirdPartyApps).toBe(false);
+    expect(parseRingAutoApprove(true).thirdPartyApps).toBe(false);
+  });
+
+  it('honors an explicit thirdPartyApps boolean and treats malformed as false', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true }).thirdPartyApps).toBe(true);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], thirdPartyApps: false }).thirdPartyApps).toBe(false);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], thirdPartyApps: 'yes' }).thirdPartyApps).toBe(false);
+  });
+
+  it('drops unrecognized severity strings', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical', 'bogus', 7] }).severities).toEqual(['critical']);
+  });
+
+  it('disables the row on a present-but-invalid deferralDays instead of coercing to 0', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: 'soon' }).enabled).toBe(false);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: -1 }).enabled).toBe(false);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: 1.5 }).enabled).toBe(false);
+    // absent stays fine
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'] })).toMatchObject({ enabled: true, deferralDays: 0 });
+  });
+
+  it('parses thirdPartyDeferralDays: valid int kept, malformed/absent/null → null', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: 14 }).thirdPartyDeferralDays).toBe(14);
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: null }).thirdPartyDeferralDays).toBeNull();
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: 999 }).thirdPartyDeferralDays).toBeNull();
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true }).thirdPartyDeferralDays).toBeNull();
   });
 });

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -659,54 +659,76 @@ function isHeldByDeferral(
 interface RingAutoApproveConfig {
   enabled: boolean;
   severities: string[];
-  /**
-   * Deferral window in days for the ring auto-approve gate (#1317). 0 = no
-   * deferral. A patch whose release date is within this window is held, not
-   * approved, mirroring the policy-level / category deferral semantics.
-   */
+  /** Deferral window (days) for OS ring auto-approve. 0 = no deferral. */
   deferralDays: number;
+  /** Third-party source-level auto-approve toggle (dual consent with policy sources). */
+  thirdPartyApps: boolean;
+  /** Third-party hold override; null = inherit deferralDays. First-seen anchored (#2218). */
+  thirdPartyDeferralDays: number | null;
 }
+
+const RECOGNIZED_RING_SEVERITIES = new Set(['critical', 'important', 'moderate', 'low']);
+
+const DISABLED_RING_AUTO_APPROVE: RingAutoApproveConfig = {
+  enabled: false,
+  severities: [],
+  deferralDays: 0,
+  thirdPartyApps: false,
+  thirdPartyDeferralDays: null,
+};
 
 /**
  * Parse a ring's `autoApprove` JSONB into a typed config. Tolerant of every
- * historical shape so already-stored rings keep working after #1317:
- *  - boolean `true`  → enabled, EMPTY severity set, no deferral
- *  - `{ enabled: true, severities: [...] }` (no deferralDays) → deferral 0
- *  - `{ enabled: true, severities: [...], deferralDays: N }` → typed shape
- * Anything else (missing, `{}`, malformed) fails closed to disabled.
- *
- * NOTE: this parser is deliberately permissive about SHAPE but the approval
- * decision is fail-closed about MEANING. `enabled` with an empty severity set
- * (the legacy boolean `true`, an AI-tool-written `{ enabled: true }`, etc.)
- * auto-approves NOTHING — evaluatePatchApproval requires a non-empty severity
- * set before it will return 'ring_auto_approve'. This matches the write-side
- * Zod refinement (ringAutoApproveSchema) so the read path cannot become more
- * permissive than the writer, regardless of who wrote the row.
+ * historical shape, but FAIL-CLOSED about meaning:
+ *  - boolean `true` → enabled, no severities, no third-party → approves nothing
+ *  - missing/`{}`/malformed → disabled
+ *  - unrecognized severity strings are dropped (never matched anyway; dropping
+ *    them keeps the thirdPartyApps compatibility rule honest)
+ *  - a PRESENT but invalid `deferralDays` disables the row entirely — the old
+ *    coerce-to-0 turned a malformed hold into "no hold", which is fail-open
+ *  - `thirdPartyApps` absent (pre-2026-08 rows and job snapshots frozen before
+ *    the backfill): derived as `severities.length > 0`, which reproduces the
+ *    old #2218 severity-exemption behavior for rows the write schema accepted,
+ *    while keeping malformed `{enabled:true}` rows inert. Present non-boolean
+ *    (AI-tool or hand-written rows) → false.
  */
-function parseRingAutoApprove(autoApprove: unknown): RingAutoApproveConfig {
-  // Boolean `true` shorthand: enabled but no explicit severities. Because the
-  // read boundary fails closed on an empty severity set, this approves nothing.
+export function parseRingAutoApprove(autoApprove: unknown): RingAutoApproveConfig {
   if (autoApprove === true) {
-    return { enabled: true, severities: [], deferralDays: 0 };
+    return { ...DISABLED_RING_AUTO_APPROVE, enabled: true };
   }
 
   if (!autoApprove || typeof autoApprove !== 'object') {
-    return { enabled: false, severities: [], deferralDays: 0 };
+    return DISABLED_RING_AUTO_APPROVE;
   }
 
   const config = autoApprove as Record<string, unknown>;
-
-  if (config.enabled === true) {
-    const severities = Array.isArray(config.severities)
-      ? config.severities.filter((s): s is string => typeof s === 'string')
-      : [];
-    const rawDeferral = config.deferralDays;
-    const deferralDays =
-      typeof rawDeferral === 'number' && Number.isInteger(rawDeferral) && rawDeferral > 0
-        ? rawDeferral
-        : 0;
-    return { enabled: true, severities, deferralDays };
+  if (config.enabled !== true) {
+    return DISABLED_RING_AUTO_APPROVE;
   }
 
-  return { enabled: false, severities: [], deferralDays: 0 };
+  const severities = Array.isArray(config.severities)
+    ? config.severities.filter(
+        (s): s is string => typeof s === 'string' && RECOGNIZED_RING_SEVERITIES.has(s)
+      )
+    : [];
+
+  let deferralDays = 0;
+  if (config.deferralDays !== undefined) {
+    const raw = config.deferralDays;
+    if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 0) {
+      return DISABLED_RING_AUTO_APPROVE;
+    }
+    deferralDays = raw;
+  }
+
+  const thirdPartyApps =
+    'thirdPartyApps' in config ? config.thirdPartyApps === true : severities.length > 0;
+
+  const rawTp = config.thirdPartyDeferralDays;
+  const thirdPartyDeferralDays =
+    typeof rawTp === 'number' && Number.isInteger(rawTp) && rawTp >= 0 && rawTp <= 365
+      ? rawTp
+      : null;
+
+  return { enabled: true, severities, deferralDays, thirdPartyApps, thirdPartyDeferralDays };
 }

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -4,7 +4,7 @@
  * Single approval/filtering gate for patch job execution. For each device it
  * resolves the set of pending patches a job is allowed to install, covering:
  *  - manual approvals (partner-wide or ring-scoped)
- *  - ring category rules (including the virtual 'third_party_app' category)
+ *  - ring category rules (exact OS category match; terminal on match)
  *  - ring-level auto-approve (enabled + severities + deferral window) — #1317
  *  - ring-less policy-level auto-approve (severity list + deferral window)
  *  - policy source filtering ('os' vs 'third_party', ...)
@@ -24,8 +24,11 @@ import { and, eq, inArray } from 'drizzle-orm';
 export interface CategoryRule {
   category: string;
   autoApprove: boolean;
+  /** Severity allowlist — the canonical field name the route/UI write (updateRings.ts categoryRuleSchema). */
+  autoApproveSeverities?: string[];
+  /** @deprecated Legacy stored alias for autoApproveSeverities (rows/snapshots written before 2026-08). Read-only. */
   severityFilter?: string[];
-  deferralDaysOverride?: number;
+  deferralDaysOverride?: number | null;
 }
 
 /**
@@ -527,31 +530,33 @@ function evaluatePatchApproval(
     return null;
   }
 
-  // Priority 2: Category rule.
-  // 'third_party_app' is a virtual category — agents report inconsistent
-  // category strings for app updates (application/homebrew/homebrew-cask/...),
-  // so it matches by patch source instead. An exact category rule wins.
-  let rule = patch.category ? categoryRuleMap.get(canonicalizePatchCategory(patch.category)) : undefined;
-  if (!rule && isThirdPartyPatchSource(patch.source)) {
-    rule = categoryRuleMap.get('third_party_app');
-  }
-  if (rule && rule.autoApprove) {
-    // Check severity filter. When a non-empty filter is set, a patch whose
-    // severity is null cannot satisfy it and must NOT auto-approve — same
-    // fail-closed posture as the policy and ring paths. (Previously a
-    // null-severity patch short-circuited the filter and fell through.)
-    if (rule.severityFilter && rule.severityFilter.length > 0) {
-      if (!patch.severity || !rule.severityFilter.includes(patch.severity)) {
-        return null; // Severity null, or not in allowed list
+  // Priority 2: Category rule (OS categories only). The virtual
+  // 'third_party_app' category was removed — third-party auto-approval is the
+  // ring-level thirdPartyApps toggle (Priority 3); stored third_party_app rules
+  // were migrated to it by the 2026-08-13 backfill. A matching rule is
+  // TERMINAL either way: autoApprove:false means "needs manual approval" (the
+  // UI's words) and must not fall through to ring-level auto-approve.
+  const rule = patch.category
+    ? categoryRuleMap.get(canonicalizePatchCategory(patch.category))
+    : undefined;
+  if (rule) {
+    if (!rule.autoApprove) {
+      return null;
+    }
+    // Severity allowlist. Canonical name is autoApproveSeverities (what the
+    // route/UI write); severityFilter is honored as a legacy stored alias —
+    // before 2026-08 the evaluator ONLY read severityFilter, which the writers
+    // never produced, so chips were silently unenforced (fail-open).
+    const severityAllowlist = rule.autoApproveSeverities ?? rule.severityFilter;
+    if (severityAllowlist && severityAllowlist.length > 0) {
+      if (!patch.severity || !severityAllowlist.includes(patch.severity)) {
+        return null;
       }
     }
-
-    // Check deferral period
     const deferralDays = rule.deferralDaysOverride ?? ringConfig.deferralDays;
     if (isHeldByDeferral(patch, deferralDays, now, 'category')) {
       return null;
     }
-
     return 'category_rule';
   }
 

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -560,48 +560,42 @@ function evaluatePatchApproval(
     return 'category_rule';
   }
 
-  // Priority 3: Ring-level auto-approve (#1317). The ring now owns approval, so
-  // this honors the configured severities AND a deferral window (held, not
-  // approved, until the patch ages past it) — consistent with the policy-level
-  // and category deferral semantics.
-  //
-  // FAIL-CLOSED at the read boundary (mirrors the write-side Zod refinement in
-  // ringAutoApproveSchema): auto-approval requires an explicit, non-empty
-  // severity set AND a patch severity that is in it. We must NOT trust that the
-  // stored row went through the route schema — the manage_update_rings AI tool
-  // and legacy boolean `true` rows can both produce `enabled` with empty
-  // severities, which previously fell through and auto-approved EVERY pending
-  // patch (auto-approve-all). A null-severity patch likewise never auto-approves
-  // under a restricted list, matching the policy path above.
+  // Priority 3: Ring-level auto-approve (#1317). Severity gates OS candidates;
+  // third-party candidates are gated by the explicit thirdPartyApps toggle
+  // (#2218 exemption replaced by spec 2026-08-04) under DUAL CONSENT:
+  //  - the POLICY must have opted into third-party sources ('third_party' in
+  //    the snapshotted sources; the default is ['os']). This stays even though
+  //    buildAllowedPatchSources filters upstream, because ABSENT sources mean
+  //    "no filtering" for legacy job snapshots — without this literal check, a
+  //    legacy snapshot plus a permissive ring would silently widen to 3P.
+  //  - the RING's autoApprove.thirdPartyApps must be true.
+  // NOTE: the literal 'third_party' selection vs the expanded patch-source
+  // bucket ('third_party'|'custom') stay in lockstep because
+  // buildAllowedPatchSources only admits 'custom' rows via the 'third_party'
+  // selection (or an explicit 'custom' entry) — if that expansion table ever
+  // changes, revisit this check too.
   if (ringAutoApprove.enabled) {
+    if (isThirdPartyPatchSource(patch.source)) {
+      if (!(ringConfig.sources ?? []).includes('third_party')) {
+        return null;
+      }
+      if (!ringAutoApprove.thirdPartyApps) {
+        return null;
+      }
+      const hold = ringAutoApprove.thirdPartyDeferralDays ?? ringAutoApprove.deferralDays;
+      if (isHeldByDeferral(patch, hold, now, 'ring')) {
+        return null;
+      }
+      return 'ring_auto_approve';
+    }
+
+    // OS path: unchanged fail-closed severity gating. Enabled with an empty
+    // severity set approves no OS patches (legacy boolean `true` and malformed
+    // `{enabled:true}` rows stay inert here).
     if (ringAutoApprove.severities.length === 0) {
-      // Enabled but no severities selected = approve nothing (fail-closed).
       return null;
     }
-    // Third-party severity exemption (#2218): winget/chocolatey/homebrew
-    // updates have no vendor severity concept — the agent/API ingest them with
-    // severity='unknown' — so requiring membership in the ring's severity set
-    // made third-party auto-approval dead configuration. When the policy has
-    // EXPLICITLY opted into third-party sources ('third_party' in sources; the
-    // default is ['os']) and this candidate is a third-party patch, skip the
-    // severity MEMBERSHIP check only. Everything else stays fail-closed: the
-    // empty-severities kill-switch above still approves nothing (a malformed
-    // `{ enabled: true }` row stays inert), OS patches keep full severity
-    // gating, and the source, category, app-rule, and deferral gates all still
-    // apply to third-party candidates.
-    // NOTE: this reads the RAW policy sources array for the literal
-    // 'third_party' selection, while isThirdPartyPatchSource matches the
-    // expanded patch-source bucket ('third_party' | 'custom'). The two stay in
-    // lockstep because buildAllowedPatchSources only admits 'custom' rows via
-    // the 'third_party' selection (or an explicit 'custom' entry) — if that
-    // expansion table ever changes, revisit this line too.
-    const severityExempt =
-      isThirdPartyPatchSource(patch.source) &&
-      (ringConfig.sources ?? []).includes('third_party');
-    if (
-      !severityExempt &&
-      (!patch.severity || !ringAutoApprove.severities.includes(patch.severity))
-    ) {
+    if (!patch.severity || !ringAutoApprove.severities.includes(patch.severity)) {
       return null;
     }
     if (isHeldByDeferral(patch, ringAutoApprove.deferralDays, now, 'ring')) {

--- a/apps/api/src/services/patchApprovalEvaluator.ts
+++ b/apps/api/src/services/patchApprovalEvaluator.ts
@@ -16,6 +16,7 @@
 import { db } from '../db';
 import { devicePatches, patches, patchApprovals, organizations, OUTSTANDING_DEVICE_PATCH_STATUSES } from '../db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
+import { captureException } from './sentry';
 
 // ============================================
 // Types
@@ -460,7 +461,10 @@ export async function resolveApprovedPatchesForDevice(
 
   // 4. Parse ring-level auto-approve config (#1317): enabled + severities +
   //    deferral. Backward-compatible with the legacy boolean / no-deferral shapes.
-  const ringAutoApprove = parseRingAutoApprove(ringConfig.autoApprove);
+  const ringAutoApprove = parseRingAutoApprove(
+    ringConfig.autoApprove,
+    ringConfig.ringId ? `ring ${ringConfig.ringId}` : undefined
+  );
 
   const now = new Date();
   const approved: ApprovedPatch[] = [];
@@ -530,18 +534,33 @@ function evaluatePatchApproval(
     return null;
   }
 
-  // Priority 2: Category rule (OS categories only). The virtual
-  // 'third_party_app' category was removed — third-party auto-approval is the
-  // ring-level thirdPartyApps toggle (Priority 3); stored third_party_app rules
-  // were migrated to it by the 2026-08-13 backfill. A matching rule is
-  // TERMINAL either way: autoApprove:false means "needs manual approval" (the
-  // UI's words) and must not fall through to ring-level auto-approve.
+  // Priority 2: Category rule. The virtual 'third_party_app' category was
+  // removed — third-party auto-approval is the ring-level thirdPartyApps
+  // toggle (Priority 3); stored third_party_app rules were migrated to it by
+  // the 2026-08-13 backfill. A literal category rule can still match a
+  // third-party patch (winget emits e.g. 'application'), so an allow rule for
+  // a third-party candidate additionally requires the same dual consent as
+  // Priority 3 — otherwise a category rule would bypass both consent legs. A
+  // matching rule is TERMINAL either way: autoApprove:false means "needs
+  // manual approval" (the UI's words) and must not fall through to ring-level
+  // auto-approve, including for third-party patches (a per-category manual
+  // gate beats the ring-level 3P toggle).
   const rule = patch.category
     ? categoryRuleMap.get(canonicalizePatchCategory(patch.category))
     : undefined;
   if (rule) {
     if (!rule.autoApprove) {
       return null;
+    }
+    if (isThirdPartyPatchSource(patch.source)) {
+      // Dual consent (same legs as Priority 3): the policy must opt into
+      // third-party sources AND the ring's thirdPartyApps toggle must be on.
+      if (
+        !(ringConfig.sources ?? []).includes('third_party') ||
+        !ringAutoApprove.thirdPartyApps
+      ) {
+        return null;
+      }
     }
     // Severity allowlist. Canonical name is autoApproveSeverities (what the
     // route/UI write); severityFilter is honored as a legacy stored alias —
@@ -569,11 +588,12 @@ function evaluatePatchApproval(
   //    "no filtering" for legacy job snapshots — without this literal check, a
   //    legacy snapshot plus a permissive ring would silently widen to 3P.
   //  - the RING's autoApprove.thirdPartyApps must be true.
-  // NOTE: the literal 'third_party' selection vs the expanded patch-source
-  // bucket ('third_party'|'custom') stay in lockstep because
-  // buildAllowedPatchSources only admits 'custom' rows via the 'third_party'
-  // selection (or an explicit 'custom' entry) — if that expansion table ever
-  // changes, revisit this check too.
+  // NOTE: the literal 'third_party' check is deliberately NARROWER than the
+  // expanded patch-source bucket ('third_party'|'custom'): a policy whose
+  // sources are ONLY ['custom'] passes buildAllowedPatchSources for
+  // custom-source patches but does NOT grant ring-level 3P auto-approval —
+  // those patches stay manual-only. Fail-closed asymmetry, kept intentionally;
+  // if buildAllowedPatchSources' expansion table ever changes, revisit.
   if (ringAutoApprove.enabled) {
     if (isThirdPartyPatchSource(patch.source)) {
       if (!(ringConfig.sources ?? []).includes('third_party')) {
@@ -662,7 +682,10 @@ interface RingAutoApproveConfig {
   deferralDays: number;
   /** Third-party source-level auto-approve toggle (dual consent with policy sources). */
   thirdPartyApps: boolean;
-  /** Third-party hold override; null = inherit deferralDays. First-seen anchored (#2218). */
+  /**
+   * Third-party hold override; null = inherit deferralDays. Anchored on
+   * releaseDate when present, first-seen otherwise (#2218).
+   */
   thirdPartyDeferralDays: number | null;
 }
 
@@ -681,17 +704,21 @@ const DISABLED_RING_AUTO_APPROVE: RingAutoApproveConfig = {
  * historical shape, but FAIL-CLOSED about meaning:
  *  - boolean `true` → enabled, no severities, no third-party → approves nothing
  *  - missing/`{}`/malformed → disabled
- *  - unrecognized severity strings are dropped (never matched anyway; dropping
- *    them keeps the thirdPartyApps compatibility rule honest)
- *  - a PRESENT but invalid `deferralDays` disables the row entirely — the old
- *    coerce-to-0 turned a malformed hold into "no hold", which is fail-open
+ *  - unrecognized severity strings are dropped (never writable through the
+ *    schema, and matching them would defeat the thirdPartyApps derivation)
+ *  - a PRESENT but invalid `deferralDays` or `thirdPartyDeferralDays` disables
+ *    the row entirely — the old coerce turned a malformed hold into "no hold"
+ *    (fail-open); disabling is loud (warn + Sentry) so the malformed row is
+ *    findable instead of silently approving nothing
  *  - `thirdPartyApps` absent (pre-2026-08 rows and job snapshots frozen before
  *    the backfill): derived as `severities.length > 0`, which reproduces the
  *    old #2218 severity-exemption behavior for rows the write schema accepted,
  *    while keeping malformed `{enabled:true}` rows inert. Present non-boolean
  *    (AI-tool or hand-written rows) → false.
+ *
+ * `context` names the owning ring/job in the malformed-config logs.
  */
-export function parseRingAutoApprove(autoApprove: unknown): RingAutoApproveConfig {
+export function parseRingAutoApprove(autoApprove: unknown, context?: string): RingAutoApproveConfig {
   if (autoApprove === true) {
     return { ...DISABLED_RING_AUTO_APPROVE, enabled: true };
   }
@@ -715,7 +742,7 @@ export function parseRingAutoApprove(autoApprove: unknown): RingAutoApproveConfi
   if (config.deferralDays !== undefined) {
     const raw = config.deferralDays;
     if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 0) {
-      return DISABLED_RING_AUTO_APPROVE;
+      return disabledForMalformedField('deferralDays', raw, context);
     }
     deferralDays = raw;
   }
@@ -723,11 +750,35 @@ export function parseRingAutoApprove(autoApprove: unknown): RingAutoApproveConfi
   const thirdPartyApps =
     'thirdPartyApps' in config ? config.thirdPartyApps === true : severities.length > 0;
 
+  // Same fail-closed posture as deferralDays: null/absent = inherit, but a
+  // present non-conforming value disables the row rather than silently
+  // inheriting (often 0 = approve immediately, the fail-open direction).
+  let thirdPartyDeferralDays: number | null = null;
   const rawTp = config.thirdPartyDeferralDays;
-  const thirdPartyDeferralDays =
-    typeof rawTp === 'number' && Number.isInteger(rawTp) && rawTp >= 0 && rawTp <= 365
-      ? rawTp
-      : null;
+  if (rawTp !== undefined && rawTp !== null) {
+    if (typeof rawTp !== 'number' || !Number.isInteger(rawTp) || rawTp < 0 || rawTp > 365) {
+      return disabledForMalformedField('thirdPartyDeferralDays', rawTp, context);
+    }
+    thirdPartyDeferralDays = rawTp;
+  }
 
   return { enabled: true, severities, deferralDays, thirdPartyApps, thirdPartyDeferralDays };
+}
+
+/**
+ * Malformed auto-approve config degrades to disabled (silently ENABLING
+ * auto-approval is the dangerous direction) — but loudly, mirroring the
+ * patchJobExecutor posture for malformed snapshot fields: a disabled-by-parse
+ * ring otherwise strands its devices in no_approved_patches with nothing
+ * pointing at the bad row.
+ */
+function disabledForMalformedField(
+  field: string,
+  value: unknown,
+  context?: string
+): RingAutoApproveConfig {
+  const message = `[PatchApproval] ${context ?? 'ring auto-approve config'} has malformed autoApprove.${field}; treating ring auto-approve as disabled`;
+  console.warn(`${message}:`, JSON.stringify(value));
+  captureException(new Error(message));
+  return DISABLED_RING_AUTO_APPROVE;
 }

--- a/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx
@@ -560,6 +560,9 @@ export default function PatchTab({
             />
           </button>
         </div>
+        <p className="mt-2 text-xs text-muted-foreground" data-testid="patch-third-party-ring-hint">
+          {i18n.t("policies:configurationPolicies.featureTabs.patchTab.thirdPartyRingHint")}
+        </p>
       </div>
 
       <PatchAppRulesSection apps={settings.apps} onChange={(apps) => update('apps', apps)} />

--- a/apps/web/src/components/patches/UpdateRingForm.test.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.test.tsx
@@ -46,6 +46,8 @@ describe('UpdateRingForm — ring auto-approve (#1317)', () => {
       enabled: true,
       severities: ['critical', 'important'],
       deferralDays: 7,
+      thirdPartyApps: false,
+      thirdPartyDeferralDays: 0,
     });
   });
 
@@ -59,7 +61,9 @@ describe('UpdateRingForm — ring auto-approve (#1317)', () => {
     fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
     fireEvent.click(screen.getByRole('button', { name: /save ring/i }));
 
-    await screen.findByText('Select at least one severity for auto-approval.');
+    await screen.findByText(
+      'Select at least one severity or enable third-party app auto-approval.'
+    );
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -167,5 +171,135 @@ describe('UpdateRingForm — ring auto-approve (#1317)', () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect((onSubmit.mock.calls[0][0] as UpdateRingFormValues).deadlineDays).toBeNull();
+  });
+});
+
+// Third-party app updates are no longer a patch *category* rule — they are a
+// ring-level gate with its own hold, because vendors publish no severity for
+// them (winget/Chocolatey/Homebrew).
+describe('UpdateRingForm — third-party app auto-approve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the third-party toggle inside the enabled auto-approve section', () => {
+    render(
+      <UpdateRingForm
+        onSubmit={vi.fn()}
+        defaultValues={{
+          name: 'Pilot',
+          autoApprove: {
+            enabled: true,
+            severities: ['critical'],
+            deferralDays: 0,
+            thirdPartyApps: false,
+            thirdPartyDeferralDays: 0,
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('ring-third-party-section')).toBeInTheDocument();
+    expect(screen.getByTestId('ring-third-party-enabled')).not.toBeChecked();
+    // The hold + policy note only appear once the gate is on.
+    expect(screen.queryByTestId('ring-third-party-deferral')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('ring-third-party-policy-note')).not.toBeInTheDocument();
+  });
+
+  it('hides the third-party subsection while the default rule is manual', () => {
+    render(<UpdateRingForm onSubmit={vi.fn()} />);
+
+    expect(screen.queryByTestId('ring-third-party-section')).not.toBeInTheDocument();
+  });
+
+  it('shows the policy-consent note when third-party is on', () => {
+    render(<UpdateRingForm onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+    fireEvent.click(screen.getByTestId('ring-third-party-enabled'));
+
+    expect(screen.getByTestId('ring-third-party-policy-note')).toBeInTheDocument();
+    expect(screen.getByTestId('ring-third-party-deferral')).toBeInTheDocument();
+  });
+
+  it('submits a third-party-only ring without a severity validation error', async () => {
+    const onSubmit = vi.fn();
+    render(<UpdateRingForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Pilot, Broad'), { target: { value: 'Apps' } });
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+    fireEvent.click(screen.getByTestId('ring-third-party-enabled'));
+    fireEvent.change(screen.getByTestId('ring-third-party-deferral'), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: /save ring/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    const values = onSubmit.mock.calls[0][0] as UpdateRingFormValues;
+    expect(values.autoApprove.thirdPartyApps).toBe(true);
+    expect(values.autoApprove.severities).toEqual([]);
+    expect(values.autoApprove.thirdPartyDeferralDays).toBe(3);
+  });
+
+  it('still blocks enabled + no severities + third-party off', async () => {
+    const onSubmit = vi.fn();
+    render(<UpdateRingForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. Pilot, Broad'), { target: { value: 'Pilot' } });
+    fireEvent.click(screen.getByTestId('ring-auto-approve-enabled'));
+    expect(screen.getByTestId('ring-third-party-enabled')).not.toBeChecked();
+    fireEvent.click(screen.getByRole('button', { name: /save ring/i }));
+
+    await screen.findByText(
+      'Select at least one severity or enable third-party app auto-approval.'
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('no longer offers third_party_app as a category override option', () => {
+    render(<UpdateRingForm onSubmit={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /add override/i }));
+
+    const select = screen.getByRole('combobox', { name: 'Category' }) as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).not.toContain('third_party_app');
+    expect(values).toContain('security');
+  });
+
+  // The API sends `thirdPartyDeferralDays: null` for "inherit the ring hold";
+  // the form always shows (and submits) a concrete number.
+  it('resolves a null third-party hold to the inherited ring hold', () => {
+    render(
+      <UpdateRingForm
+        onSubmit={vi.fn()}
+        defaultValues={{
+          name: 'Broad',
+          autoApprove: {
+            enabled: true,
+            severities: ['critical'],
+            deferralDays: 6,
+            thirdPartyApps: true,
+            thirdPartyDeferralDays: null,
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('ring-third-party-enabled')).toBeChecked();
+    expect(screen.getByTestId('ring-third-party-deferral')).toHaveValue(6);
+  });
+
+  // Rings saved before the gate existed have no third-party fields at all.
+  it('defaults a legacy ring without third-party fields to off', () => {
+    render(
+      <UpdateRingForm
+        onSubmit={vi.fn()}
+        defaultValues={{
+          name: 'Legacy',
+          autoApprove: { enabled: true, severities: ['critical'], deferralDays: 2 },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('ring-third-party-enabled')).not.toBeChecked();
   });
 });

--- a/apps/web/src/components/patches/UpdateRingForm.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.tsx
@@ -19,12 +19,16 @@ function makeRingSchema(t: TFunction<'patches'>) {
     enabled: z.boolean(),
     severities: z.array(z.enum(['critical', 'important', 'moderate', 'low'])),
     deferralDays: z.coerce.number().int().min(0).max(365),
+    thirdPartyApps: z.boolean(),
+    // Always a concrete number in the form (pre-filled from the ring hold);
+    // null "inherit" is an API-writer concept, mirroring deferralDaysOverride.
+    thirdPartyDeferralDays: z.coerce.number().int().min(0).max(365),
   }).superRefine((data, ctx) => {
-    if (data.enabled && data.severities.length === 0) {
+    if (data.enabled && data.severities.length === 0 && !data.thirdPartyApps) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['severities'],
-        message: t('updateRingForm.validation.selectSeverity'),
+        message: t('updateRingForm.validation.selectSeverityOrThirdParty'),
       });
     }
   });
@@ -48,10 +52,19 @@ function makeRingSchema(t: TFunction<'patches'>) {
 type RingSchema = ReturnType<typeof makeRingSchema>;
 export type UpdateRingFormValues = z.infer<RingSchema>;
 
+/** Defaults arrive from the API, which may omit the third-party fields (older
+ *  rings) or send `thirdPartyDeferralDays: null` meaning "inherit the ring
+ *  hold". Both are normalized to concrete form values in `initialValues`. */
+export type UpdateRingFormDefaults = Partial<Omit<UpdateRingFormValues, 'autoApprove'>> & {
+  autoApprove?: Partial<Omit<UpdateRingFormValues['autoApprove'], 'thirdPartyDeferralDays'>> & {
+    thirdPartyDeferralDays?: number | null;
+  };
+};
+
 type UpdateRingFormProps = {
   onSubmit?: (values: UpdateRingFormValues) => void | Promise<void>;
   onCancel?: () => void;
-  defaultValues?: Partial<UpdateRingFormValues>;
+  defaultValues?: UpdateRingFormDefaults;
   submitLabel?: string;
   loading?: boolean;
   /** When editing, surfaces the blast radius of a change. */
@@ -64,12 +77,13 @@ type Severity = 'critical' | 'important' | 'moderate' | 'low';
 // classifyWindowsUpdateCategory) so the approval evaluator's category rules
 // actually match. Note 'definitions' is plural to match the agent; the
 // evaluator also canonicalizes legacy singular 'definition' rules.
+// 'third_party_app' is deliberately absent: third-party app updates are governed
+// by the ring-level toggle below (the API rejects a category rule for them).
 const categoryOptions = [
   { value: 'security', labelKey: 'updateRingForm.categories.security' },
   { value: 'feature', labelKey: 'updateRingForm.categories.feature' },
   { value: 'firmware', labelKey: 'updateRingForm.categories.firmware' },
   { value: 'driver', labelKey: 'updateRingForm.categories.driver' },
-  { value: 'third_party_app', labelKey: 'updateRingForm.categories.thirdPartyApp' },
   { value: 'definitions', labelKey: 'updateRingForm.categories.definitions' },
 ];
 
@@ -209,13 +223,26 @@ export default function UpdateRingForm({
       deferralDays: 0,
       deadlineDays: null,
       gracePeriodHours: 4,
-      autoApprove: { enabled: false, severities: [], deferralDays: 0 },
+      autoApprove: { enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: 0 },
       categoryRules: [],
       ...defaultValues,
-    } satisfies Partial<UpdateRingFormValues>;
+    } satisfies UpdateRingFormDefaults;
     const inheritedHold = merged.autoApprove?.deferralDays ?? merged.deferralDays ?? 0;
+    // A ring saved before the third-party gate existed has no `thirdPartyApps`,
+    // and a null third-party hold means "inherit" — resolve both to concrete
+    // values so the controls are never blank/uncontrolled.
+    const aa = merged.autoApprove ?? {};
+    const mergedAutoApprove = {
+      enabled: false,
+      severities: [],
+      deferralDays: inheritedHold,
+      thirdPartyApps: false,
+      ...aa,
+      thirdPartyDeferralDays: aa.thirdPartyDeferralDays ?? inheritedHold,
+    };
     return {
       ...merged,
+      autoApprove: mergedAutoApprove,
       categoryRules: (merged.categoryRules ?? []).map((r) => ({
         ...r,
         autoApproveSeverities: r.autoApproveSeverities ?? [],
@@ -402,6 +429,35 @@ export default function UpdateRingForm({
                   </p>
                 </div>
                 <HoldField field={register('autoApprove.deferralDays')} testId="ring-auto-approve-deferral" t={t} />
+
+                <div className="mt-4 w-full border-t pt-4" data-testid="ring-third-party-section">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <span className="text-sm font-medium">{t('updateRingForm.thirdParty.title')}</span>
+                      <p className="mt-0.5 max-w-md text-xs text-muted-foreground">
+                        {t('updateRingForm.thirdParty.description')}
+                      </p>
+                    </div>
+                    <ApproveToggle
+                      checked={!!autoApprove?.thirdPartyApps}
+                      field={register('autoApprove.thirdPartyApps')}
+                      testId="ring-third-party-enabled"
+                      t={t}
+                    />
+                  </div>
+                  {autoApprove?.thirdPartyApps && (
+                    <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
+                      <p className="max-w-md text-xs text-muted-foreground" data-testid="ring-third-party-policy-note">
+                        {t('updateRingForm.thirdParty.policyNote')}
+                      </p>
+                      <HoldField
+                        field={register('autoApprove.thirdPartyDeferralDays')}
+                        testId="ring-third-party-deferral"
+                        t={t}
+                      />
+                    </div>
+                  )}
+                </div>
               </div>
             ) : (
               <p className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/patches/UpdateRingForm.tsx
+++ b/apps/web/src/components/patches/UpdateRingForm.tsx
@@ -446,15 +446,20 @@ export default function UpdateRingForm({
                     />
                   </div>
                   {autoApprove?.thirdPartyApps && (
-                    <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
-                      <p className="max-w-md text-xs text-muted-foreground" data-testid="ring-third-party-policy-note">
-                        {t('updateRingForm.thirdParty.policyNote')}
+                    <div className="mt-3">
+                      <div className="flex flex-wrap items-end justify-between gap-4">
+                        <p className="max-w-md text-xs text-muted-foreground" data-testid="ring-third-party-policy-note">
+                          {t('updateRingForm.thirdParty.policyNote')}
+                        </p>
+                        <HoldField
+                          field={register('autoApprove.thirdPartyDeferralDays')}
+                          testId="ring-third-party-deferral"
+                          t={t}
+                        />
+                      </div>
+                      <p className="mt-1 text-right text-xs text-muted-foreground" data-testid="ring-third-party-hold-note">
+                        {t('updateRingForm.thirdParty.holdNote')}
                       </p>
-                      <HoldField
-                        field={register('autoApprove.thirdPartyDeferralDays')}
-                        testId="ring-third-party-deferral"
-                        t={t}
-                      />
                     </div>
                   )}
                 </div>

--- a/apps/web/src/components/patches/UpdateRingList.test.tsx
+++ b/apps/web/src/components/patches/UpdateRingList.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '@/lib/i18n';
+
+import UpdateRingList, { type UpdateRingItem } from './UpdateRingList';
+
+function makeRing(overrides: Partial<UpdateRingItem> = {}): UpdateRingItem {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'Ring A',
+    enabled: true,
+    ringOrder: 1,
+    deferralDays: 0,
+    deadlineDays: null,
+    gracePeriodHours: 4,
+    ...overrides,
+  };
+}
+
+describe('UpdateRingList auto-approve column', () => {
+  it('summarizes auto-approve as badges: OS severities, third-party, or Manual', () => {
+    const ringA = makeRing({
+      id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      name: 'Ring A',
+      autoApprove: {
+        enabled: true,
+        severities: ['critical', 'important'],
+        deferralDays: 0,
+        thirdPartyApps: true,
+        thirdPartyDeferralDays: null,
+      },
+    });
+    const ringB = makeRing({
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      name: 'Ring B',
+      ringOrder: 2,
+      autoApprove: {
+        enabled: false,
+        severities: ['critical'],
+        deferralDays: 0,
+        thirdPartyApps: true,
+        thirdPartyDeferralDays: null,
+      },
+    });
+    const ringC = makeRing({
+      id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      name: 'Ring C',
+      ringOrder: 3,
+      autoApprove: {
+        enabled: true,
+        severities: [],
+        deferralDays: 0,
+        thirdPartyApps: true,
+        thirdPartyDeferralDays: 3,
+      },
+    });
+
+    render(<UpdateRingList rings={[ringA, ringB, ringC]} />);
+
+    // Ring A: OS severities badge + third-party badge.
+    const osBadge = screen.getByTestId(`ring-badge-os-${ringA.id}`);
+    expect(osBadge.textContent).toContain('Critical');
+    expect(osBadge.textContent).toContain('Important');
+    expect(screen.getByTestId(`ring-badge-third-party-${ringA.id}`)).toBeTruthy();
+
+    // Ring B: auto-approve disabled → no badges, Manual label instead.
+    expect(screen.queryByTestId(`ring-badge-os-${ringB.id}`)).toBeNull();
+    expect(screen.queryByTestId(`ring-badge-third-party-${ringB.id}`)).toBeNull();
+    const rowB = screen.getByText('Ring B').closest('tr');
+    expect(rowB).not.toBeNull();
+    expect(within(rowB as HTMLElement).getByText('Manual')).toBeTruthy();
+
+    // Ring C: third-party only — an empty severity list means no OS badge.
+    expect(screen.queryByTestId(`ring-badge-os-${ringC.id}`)).toBeNull();
+    expect(screen.getByTestId(`ring-badge-third-party-${ringC.id}`)).toBeTruthy();
+  });
+
+  it('renders the auto-approve header column', () => {
+    render(<UpdateRingList rings={[]} />);
+
+    expect(screen.getByRole('columnheader', { name: 'Auto-approve' })).toBeTruthy();
+    // Empty state must span every column, including the new one.
+    expect(screen.getByText('No update rings found.').getAttribute('colspan')).toBe('9');
+  });
+});

--- a/apps/web/src/components/patches/UpdateRingList.tsx
+++ b/apps/web/src/components/patches/UpdateRingList.tsx
@@ -86,6 +86,39 @@ function ComplianceBadge({ percent, t }: { percent?: number; t: TFunction<'patch
   );
 }
 
+// Summarizes the ring's auto-approval gate: OS severities and third-party apps
+// are independent switches, so a ring can auto-approve one, both, or neither.
+function AutoApproveBadges({ ring, t }: { ring: UpdateRingItem; t: TFunction<'patches'> }) {
+  const aa = ring.autoApprove;
+  const osOn = !!aa?.enabled && aa.severities.length > 0;
+  const tpOn = !!aa?.enabled && !!aa.thirdPartyApps;
+  if (!osOn && !tpOn) {
+    return <span className="text-muted-foreground">{t('updateRingList.badges.manual')}</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {osOn && (
+        <span
+          className="inline-flex items-center rounded-full border bg-muted/40 px-2 py-0.5 text-xs"
+          data-testid={`ring-badge-os-${ring.id}`}
+        >
+          {t('updateRingList.badges.os', {
+            severities: aa!.severities.map((s) => t(/* i18n-dynamic */ `updateRingForm.severities.${s}`)).join(', '),
+          })}
+        </span>
+      )}
+      {tpOn && (
+        <span
+          className="inline-flex items-center rounded-full border bg-muted/40 px-2 py-0.5 text-xs"
+          data-testid={`ring-badge-third-party-${ring.id}`}
+        >
+          {t('updateRingList.badges.thirdParty')}
+        </span>
+      )}
+    </div>
+  );
+}
+
 export default function UpdateRingList({
   rings,
   onEdit,
@@ -147,6 +180,7 @@ export default function UpdateRingList({
               <th className="px-4 py-3">{t('updateRingList.table.ring')}</th>
               <th className="px-4 py-3">{t('updateRingList.table.deferral')}</th>
               <th className="px-4 py-3">{t('updateRingList.table.deadline')}</th>
+              <th className="px-4 py-3">{t('updateRingList.table.autoApprove')}</th>
               <th className="px-4 py-3">{t('updateRingList.table.devices')}</th>
               <th className="px-4 py-3">{t('updateRingList.table.compliance')}</th>
               <th className="px-4 py-3">{t('updateRingList.table.updated')}</th>
@@ -157,7 +191,7 @@ export default function UpdateRingList({
             {paginatedRings.length === 0 ? (
               <tr>
                 <td
-                  colSpan={8}
+                  colSpan={9}
                   className="px-4 py-6 text-center text-sm text-muted-foreground"
                 >
                   {t('updateRingList.empty')}
@@ -196,6 +230,9 @@ export default function UpdateRingList({
                     {ring.deadlineDays == null
                       ? t('updateRingList.none')
                       : t('updateRingList.days', { count: ring.deadlineDays })}
+                  </td>
+                  <td className="px-4 py-3">
+                    <AutoApproveBadges ring={ring} t={t} />
                   </td>
                   <td className="px-4 py-3 text-muted-foreground">
                     {ring.deviceCount ?? t('updateRingList.emptyValue')}

--- a/apps/web/src/components/patches/UpdateRingList.tsx
+++ b/apps/web/src/components/patches/UpdateRingList.tsx
@@ -26,6 +26,11 @@ export type RingAutoApprove = {
   enabled: boolean;
   severities: Array<'critical' | 'important' | 'moderate' | 'low'>;
   deferralDays: number;
+  /** Third-party app updates auto-approve independently of severity. Absent on
+   *  rings saved before the gate existed. */
+  thirdPartyApps?: boolean;
+  /** null = inherit the ring's hold. */
+  thirdPartyDeferralDays?: number | null;
 };
 
 export type UpdateRingItem = {

--- a/apps/web/src/components/patches/patchHelpers.test.ts
+++ b/apps/web/src/components/patches/patchHelpers.test.ts
@@ -90,15 +90,29 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
     });
   });
 
-  it('clamps a non-positive or non-integer deferralDays to 0', () => {
+  it('treats a present-but-invalid deferralDays as disabled (mirrors the API fail-closed parse)', () => {
+    // The evaluator disables such a row entirely; showing it as an enabled
+    // 0-day hold would let a save silently resurrect config the API refused.
     expect(
       normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], deferralDays: -3, thirdPartyApps: false } })
         .autoApprove
-    ).toMatchObject({ enabled: true, severities: ['low'], deferralDays: 0 });
+    ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null });
     expect(
       normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], deferralDays: 1.5, thirdPartyApps: false } })
         .autoApprove
+    ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null });
+    // Absent stays fine (0 = no hold).
+    expect(
+      normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], thirdPartyApps: false } })
+        .autoApprove
     ).toMatchObject({ enabled: true, severities: ['low'], deferralDays: 0 });
+  });
+
+  it('preserves parked severities on a well-formed DISABLED row (editor divergence from the evaluator)', () => {
+    expect(
+      normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: false, severities: ['critical'], deferralDays: 3 } })
+        .autoApprove
+    ).toMatchObject({ enabled: false, severities: ['critical'], deferralDays: 3 });
   });
 
   // The editor round-trips this object straight back into the ring PATCH body,
@@ -175,7 +189,7 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
     ).toMatchObject({ thirdPartyApps: false });
   });
 
-  it('coerces malformed third-party values', () => {
+  it('coerces a non-boolean thirdPartyApps to false, but a present-but-invalid hold disables the row', () => {
     // A non-boolean thirdPartyApps is present-but-invalid → false (never derived).
     expect(
       normalizeRing({
@@ -185,8 +199,10 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
       }).autoApprove
     ).toMatchObject({ thirdPartyApps: false });
 
-    // Out-of-range / non-integer / non-numeric holds fall back to inherit (null).
-    for (const bad of [-1, 366, 1.5, '3', null]) {
+    // Present-but-invalid holds disable the row (mirrors the API fail-closed
+    // parse — coercing to "inherit" would show a valid-looking editor state
+    // for config the evaluator refuses). Explicit null stays inherit.
+    for (const bad of [-1, 366, 1.5, '3']) {
       expect(
         normalizeRing({
           id: 'r1',
@@ -199,7 +215,14 @@ describe('normalizeRing — autoApprove normalization (#1317)', () => {
             thirdPartyDeferralDays: bad,
           },
         }).autoApprove
-      ).toMatchObject({ thirdPartyApps: true, thirdPartyDeferralDays: null });
+      ).toEqual({ enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null });
     }
+    expect(
+      normalizeRing({
+        id: 'r1',
+        name: 'x',
+        autoApprove: { enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: null },
+      }).autoApprove
+    ).toEqual({ enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: null });
   });
 });

--- a/apps/web/src/components/patches/patchHelpers.test.ts
+++ b/apps/web/src/components/patches/patchHelpers.test.ts
@@ -38,36 +38,168 @@ describe('normalizePatch — os resolution (#2215)', () => {
 describe('normalizeRing — autoApprove normalization (#1317)', () => {
   it('defaults a missing autoApprove to disabled', () => {
     const ring = normalizeRing({ id: 'r1', name: 'Default' });
-    expect(ring.autoApprove).toEqual({ enabled: false, severities: [], deferralDays: 0 });
+    expect(ring.autoApprove).toEqual({
+      enabled: false,
+      severities: [],
+      deferralDays: 0,
+      thirdPartyApps: false,
+      thirdPartyDeferralDays: null,
+    });
   });
 
   it('coerces a legacy {} autoApprove to disabled', () => {
     const ring = normalizeRing({ id: 'r1', name: 'Default', autoApprove: {} });
-    expect(ring.autoApprove).toEqual({ enabled: false, severities: [], deferralDays: 0 });
+    expect(ring.autoApprove).toEqual({
+      enabled: false,
+      severities: [],
+      deferralDays: 0,
+      thirdPartyApps: false,
+      thirdPartyDeferralDays: null,
+    });
   });
 
   it('coerces a legacy boolean true to enabled with no severity filter', () => {
     const ring = normalizeRing({ id: 'r1', name: 'Default', autoApprove: true });
-    expect(ring.autoApprove).toEqual({ enabled: true, severities: [], deferralDays: 0 });
+    expect(ring.autoApprove).toEqual({
+      enabled: true,
+      severities: [],
+      deferralDays: 0,
+      thirdPartyApps: false,
+      thirdPartyDeferralDays: null,
+    });
   });
 
   it('passes through a typed autoApprove gate and drops unknown severities', () => {
     const ring = normalizeRing({
       id: 'r1',
       name: 'Broad',
-      autoApprove: { enabled: true, severities: ['critical', 'bogus', 'low'], deferralDays: 5 },
+      autoApprove: {
+        enabled: true,
+        severities: ['critical', 'bogus', 'low'],
+        deferralDays: 5,
+        thirdPartyApps: false,
+        thirdPartyDeferralDays: null,
+      },
     });
-    expect(ring.autoApprove).toEqual({ enabled: true, severities: ['critical', 'low'], deferralDays: 5 });
+    expect(ring.autoApprove).toEqual({
+      enabled: true,
+      severities: ['critical', 'low'],
+      deferralDays: 5,
+      thirdPartyApps: false,
+      thirdPartyDeferralDays: null,
+    });
   });
 
   it('clamps a non-positive or non-integer deferralDays to 0', () => {
     expect(
-      normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], deferralDays: -3 } })
+      normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], deferralDays: -3, thirdPartyApps: false } })
         .autoApprove
-    ).toEqual({ enabled: true, severities: ['low'], deferralDays: 0 });
+    ).toMatchObject({ enabled: true, severities: ['low'], deferralDays: 0 });
     expect(
-      normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], deferralDays: 1.5 } })
+      normalizeRing({ id: 'r1', name: 'x', autoApprove: { enabled: true, severities: ['low'], deferralDays: 1.5, thirdPartyApps: false } })
         .autoApprove
-    ).toEqual({ enabled: true, severities: ['low'], deferralDays: 0 });
+    ).toMatchObject({ enabled: true, severities: ['low'], deferralDays: 0 });
+  });
+
+  // The editor round-trips this object straight back into the ring PATCH body,
+  // so a dropped field is a silently reverted policy (#spec 2026-08-04).
+  it('round-trips an explicit third-party gate in both states', () => {
+    expect(
+      normalizeRing({
+        id: 'r1',
+        name: 'Apps',
+        autoApprove: {
+          enabled: true,
+          severities: [],
+          deferralDays: 0,
+          thirdPartyApps: true,
+          thirdPartyDeferralDays: 3,
+        },
+      }).autoApprove
+    ).toEqual({
+      enabled: true,
+      severities: [],
+      deferralDays: 0,
+      thirdPartyApps: true,
+      thirdPartyDeferralDays: 3,
+    });
+
+    expect(
+      normalizeRing({
+        id: 'r1',
+        name: 'OS only',
+        autoApprove: {
+          enabled: true,
+          severities: ['critical'],
+          deferralDays: 2,
+          thirdPartyApps: false,
+          thirdPartyDeferralDays: 0,
+        },
+      }).autoApprove
+    ).toEqual({
+      enabled: true,
+      severities: ['critical'],
+      deferralDays: 2,
+      thirdPartyApps: false,
+      thirdPartyDeferralDays: 0,
+    });
+  });
+
+  // Mirrors parseRingAutoApprove: a pre-gate ring auto-approved third-party
+  // updates whenever it auto-approved anything, so an absent key derives from
+  // the (filtered) severity list rather than defaulting to off.
+  it('derives thirdPartyApps from severities when the key is absent (legacy rows)', () => {
+    expect(
+      normalizeRing({
+        id: 'r1',
+        name: 'Legacy on',
+        autoApprove: { enabled: true, severities: ['critical'], deferralDays: 0 },
+      }).autoApprove
+    ).toMatchObject({ thirdPartyApps: true, thirdPartyDeferralDays: null });
+
+    expect(
+      normalizeRing({
+        id: 'r1',
+        name: 'Legacy off',
+        autoApprove: { enabled: true, severities: [], deferralDays: 0 },
+      }).autoApprove
+    ).toMatchObject({ thirdPartyApps: false });
+
+    // Only recognized severities count — an all-bogus list derives off.
+    expect(
+      normalizeRing({
+        id: 'r1',
+        name: 'Legacy bogus',
+        autoApprove: { enabled: true, severities: ['bogus'], deferralDays: 0 },
+      }).autoApprove
+    ).toMatchObject({ thirdPartyApps: false });
+  });
+
+  it('coerces malformed third-party values', () => {
+    // A non-boolean thirdPartyApps is present-but-invalid → false (never derived).
+    expect(
+      normalizeRing({
+        id: 'r1',
+        name: 'x',
+        autoApprove: { enabled: true, severities: ['critical'], deferralDays: 0, thirdPartyApps: 'yes' },
+      }).autoApprove
+    ).toMatchObject({ thirdPartyApps: false });
+
+    // Out-of-range / non-integer / non-numeric holds fall back to inherit (null).
+    for (const bad of [-1, 366, 1.5, '3', null]) {
+      expect(
+        normalizeRing({
+          id: 'r1',
+          name: 'x',
+          autoApprove: {
+            enabled: true,
+            severities: [],
+            deferralDays: 0,
+            thirdPartyApps: true,
+            thirdPartyDeferralDays: bad,
+          },
+        }).autoApprove
+      ).toMatchObject({ thirdPartyApps: true, thirdPartyDeferralDays: null });
+    }
   });
 });

--- a/apps/web/src/components/patches/patchHelpers.ts
+++ b/apps/web/src/components/patches/patchHelpers.ts
@@ -94,17 +94,31 @@ export function normalizePatch(raw: Record<string, unknown>, index: number): Pat
 const RING_SEVERITIES = ['critical', 'important', 'moderate', 'low'] as const;
 type RingSeverity = (typeof RING_SEVERITIES)[number];
 
+const DISABLED_RING_AUTO_APPROVE: NonNullable<UpdateRingItem['autoApprove']> = {
+  enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
+};
+
 /**
  * Normalize a ring's stored `autoApprove` JSONB (#1317) into the typed form
  * the editor expects. Tolerant of every historical shape the API may have
  * stored: `{}` / missing → disabled; boolean `true` → enabled with no severity
  * filter; the typed `{ enabled, severities, deferralDays, thirdPartyApps,
  * thirdPartyDeferralDays }` object passes through. Mirrors the API-side
- * `parseRingAutoApprove`, including its legacy-compat rule for the third-party
- * gate: an absent `thirdPartyApps` key derives from whether any severity is
- * selected (pre-gate rings auto-approved third-party updates whenever the ring
- * auto-approved anything), and a `thirdPartyDeferralDays` outside 0-365 —
- * or absent — means "inherit the ring hold" (null).
+ * `parseRingAutoApprove`, including:
+ *  - the legacy-compat rule for the third-party gate: an absent
+ *    `thirdPartyApps` key derives from whether any severity is selected
+ *    (pre-gate rings auto-approved third-party updates whenever the ring
+ *    auto-approved anything);
+ *  - fail-closed holds: a PRESENT but invalid `deferralDays` or
+ *    `thirdPartyDeferralDays` means the evaluator treats the row as disabled,
+ *    so the editor must show it disabled too — coercing to a valid-looking
+ *    value here would let a save silently resurrect config the evaluator
+ *    fail-closed on. Absent/null `thirdPartyDeferralDays` = inherit (null).
+ *
+ * One deliberate editor-vs-evaluator divergence: a well-formed but DISABLED
+ * row keeps its stored severities/fields here (the evaluator collapses any
+ * disabled row, but the editor must not lose a selection the operator parked
+ * behind the off switch).
  *
  * Dropping a field here is a silent policy loss: the editor round-trips this
  * object straight back into the PATCH body, so anything not carried is written
@@ -115,26 +129,35 @@ function normalizeRingAutoApprove(raw: unknown): UpdateRingItem['autoApprove'] {
     return { enabled: true, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null };
   }
   if (!raw || typeof raw !== 'object') {
-    return { enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null };
+    return { ...DISABLED_RING_AUTO_APPROVE };
   }
   const obj = raw as Record<string, unknown>;
   const severities = Array.isArray(obj.severities)
     ? obj.severities.filter((s): s is RingSeverity => RING_SEVERITIES.includes(s as RingSeverity))
     : [];
-  const deferralDays =
-    typeof obj.deferralDays === 'number' && Number.isInteger(obj.deferralDays) && obj.deferralDays > 0
-      ? obj.deferralDays
-      : 0;
+  let deferralDays = 0;
+  if (obj.deferralDays !== undefined) {
+    const rawHold = obj.deferralDays;
+    if (typeof rawHold !== 'number' || !Number.isInteger(rawHold) || rawHold < 0) {
+      return { ...DISABLED_RING_AUTO_APPROVE };
+    }
+    deferralDays = rawHold;
+  }
   const thirdPartyApps =
     'thirdPartyApps' in obj ? obj.thirdPartyApps === true : severities.length > 0;
+  let thirdPartyDeferralDays: number | null = null;
   const rawThirdPartyHold = obj.thirdPartyDeferralDays;
-  const thirdPartyDeferralDays =
-    typeof rawThirdPartyHold === 'number'
-    && Number.isInteger(rawThirdPartyHold)
-    && rawThirdPartyHold >= 0
-    && rawThirdPartyHold <= 365
-      ? rawThirdPartyHold
-      : null;
+  if (rawThirdPartyHold !== undefined && rawThirdPartyHold !== null) {
+    if (
+      typeof rawThirdPartyHold !== 'number'
+      || !Number.isInteger(rawThirdPartyHold)
+      || rawThirdPartyHold < 0
+      || rawThirdPartyHold > 365
+    ) {
+      return { ...DISABLED_RING_AUTO_APPROVE };
+    }
+    thirdPartyDeferralDays = rawThirdPartyHold;
+  }
   return { enabled: obj.enabled === true, severities, deferralDays, thirdPartyApps, thirdPartyDeferralDays };
 }
 

--- a/apps/web/src/components/patches/patchHelpers.ts
+++ b/apps/web/src/components/patches/patchHelpers.ts
@@ -98,12 +98,25 @@ type RingSeverity = (typeof RING_SEVERITIES)[number];
  * Normalize a ring's stored `autoApprove` JSONB (#1317) into the typed form
  * the editor expects. Tolerant of every historical shape the API may have
  * stored: `{}` / missing → disabled; boolean `true` → enabled with no severity
- * filter; the typed `{ enabled, severities, deferralDays }` object passes
- * through. Mirrors the API-side `parseRingAutoApprove`.
+ * filter; the typed `{ enabled, severities, deferralDays, thirdPartyApps,
+ * thirdPartyDeferralDays }` object passes through. Mirrors the API-side
+ * `parseRingAutoApprove`, including its legacy-compat rule for the third-party
+ * gate: an absent `thirdPartyApps` key derives from whether any severity is
+ * selected (pre-gate rings auto-approved third-party updates whenever the ring
+ * auto-approved anything), and a `thirdPartyDeferralDays` outside 0-365 —
+ * or absent — means "inherit the ring hold" (null).
+ *
+ * Dropping a field here is a silent policy loss: the editor round-trips this
+ * object straight back into the PATCH body, so anything not carried is written
+ * back as its default.
  */
 function normalizeRingAutoApprove(raw: unknown): UpdateRingItem['autoApprove'] {
-  if (raw === true) return { enabled: true, severities: [], deferralDays: 0 };
-  if (!raw || typeof raw !== 'object') return { enabled: false, severities: [], deferralDays: 0 };
+  if (raw === true) {
+    return { enabled: true, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null };
+  }
+  if (!raw || typeof raw !== 'object') {
+    return { enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null };
+  }
   const obj = raw as Record<string, unknown>;
   const severities = Array.isArray(obj.severities)
     ? obj.severities.filter((s): s is RingSeverity => RING_SEVERITIES.includes(s as RingSeverity))
@@ -112,7 +125,17 @@ function normalizeRingAutoApprove(raw: unknown): UpdateRingItem['autoApprove'] {
     typeof obj.deferralDays === 'number' && Number.isInteger(obj.deferralDays) && obj.deferralDays > 0
       ? obj.deferralDays
       : 0;
-  return { enabled: obj.enabled === true, severities, deferralDays };
+  const thirdPartyApps =
+    'thirdPartyApps' in obj ? obj.thirdPartyApps === true : severities.length > 0;
+  const rawThirdPartyHold = obj.thirdPartyDeferralDays;
+  const thirdPartyDeferralDays =
+    typeof rawThirdPartyHold === 'number'
+    && Number.isInteger(rawThirdPartyHold)
+    && rawThirdPartyHold >= 0
+    && rawThirdPartyHold <= 365
+      ? rawThirdPartyHold
+      : null;
+  return { enabled: obj.enabled === true, severities, deferralDays, thirdPartyApps, thirdPartyDeferralDays };
 }
 
 export function normalizeRing(raw: Record<string, unknown>): UpdateRingItem {

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -34,7 +34,9 @@ const namespaceDuplicateBaselines = {
     'devices.json': 159,
     'discovery.json': 17,
     'integrations.json': 23,
-    'patches.json': 22,
+    // +1: updateRingList.badges.manual — "Manual" is spelled identically in
+    // pt-BR.
+    'patches.json': 23,
     'peripherals.json': 4,
     'policies.json': 357,
     'portal.json': 3,
@@ -67,7 +69,9 @@ const namespaceDuplicateBaselines = {
     'devices.json': 115,
     'discovery.json': 17,
     'integrations.json': 31,
-    'patches.json': 15,
+    // +1: updateRingList.badges.manual — "Manual" is spelled identically in
+    // es-419.
+    'patches.json': 16,
     'peripherals.json': 4,
     'policies.json': 241,
     'portal.json': 4,
@@ -168,7 +172,9 @@ const namespaceDuplicateBaselines = {
     'devices.json': 146,
     'discovery.json': 26,
     'integrations.json': 43,
-    'patches.json': 22,
+    // +1: updateRingList.badges.os — "OS: {{severities}}" is an acronym plus an
+    // interpolation; German uses the same "OS" acronym.
+    'patches.json': 23,
     'peripherals.json': 4,
     'policies.json': 205,
     'portal.json': 4,

--- a/apps/web/src/locales/de-DE/patches.json
+++ b/apps/web/src/locales/de-DE/patches.json
@@ -372,6 +372,7 @@
     "validation": {
       "selectCategory": "Kategorie auswählen",
       "selectSeverity": "Mindestens einen Schweregrad für die automatische Freigabe auswählen.",
+      "selectSeverityOrThirdParty": "Mindestens einen Schweregrad auswählen oder die automatische Genehmigung für Drittanbieter-Apps aktivieren.",
       "nameRequired": "Ringname ist erforderlich"
     },
     "categories": {
@@ -379,7 +380,6 @@
       "feature": "Funktionsupdates",
       "firmware": "Firmware",
       "driver": "Treiber",
-      "thirdPartyApp": "Drittanbieter-Apps",
       "definitions": "Definitionsupdates"
     },
     "severities": {
@@ -421,10 +421,15 @@
       "description": "Legt fest, welche Patches in diesem Ring automatisch freigegeben und wie lange sie nach der Veröffentlichung durch den Anbieter zurückgehalten werden. Der Standard gilt für jede Kategorie; mit einer Überschreibung kann eine Kategorie abweichend behandelt werden.",
       "allCategories": "Alle Kategorien",
       "default": "Standard",
-      "severityNote": "Schweregrade gelten für Betriebssystemupdates. Updates von Drittanbieter-Apps (winget, Homebrew) haben keinen vom Anbieter festgelegten Schweregrad – wenn eine Richtlinie andere Softwarequellen aktiviert, werden sie unabhängig von den hier ausgewählten Schweregraden nach dem Zeitplan dieses Rings automatisch freigegeben.",
+      "severityNote": "Schweregrade gelten nur für Betriebssystem-Updates. Drittanbieter-App-Updates werden über den Schalter unten gesteuert — sie sind nicht schweregradbasiert.",
       "manualDefault": "Jeder Patch in diesem Ring muss manuell freigegeben werden.",
       "manualCategory": "Patches in dieser Kategorie müssen manuell freigegeben werden.",
       "noOverrides": "Alle Kategorien verwenden den Standard. Mit einer Überschreibung kann eine Kategorie abweichend behandelt werden."
+    },
+    "thirdParty": {
+      "title": "Drittanbieter-Anwendungen",
+      "description": "App-Updates aus winget, Chocolatey und Homebrew automatisch genehmigen. App-Sperr-/Pin-Regeln gelten weiterhin; die Wartezeit zählt ab der ersten Meldung des Updates durch das Gerät.",
+      "policyNote": "Gilt nur für Geräte, deren Konfigurationsrichtlinie Software-Updates von Drittanbietern einschließt (Patch-Einstellungen der Richtlinie)."
     },
     "usage": {
       "messageOne": "Dieser Ring gilt für {{count}} Gerät. Änderungen werden bei dessen nächster Rückmeldung wirksam.",

--- a/apps/web/src/locales/de-DE/patches.json
+++ b/apps/web/src/locales/de-DE/patches.json
@@ -462,7 +462,13 @@
       "devices": "Geräte",
       "compliance": "Compliance",
       "updated": "Aktualisiert",
-      "actions": "Aktionen"
+      "actions": "Aktionen",
+      "autoApprove": "Automatisch genehmigen"
+    },
+    "badges": {
+      "manual": "Manuell",
+      "os": "OS: {{severities}}",
+      "thirdParty": "Drittanbieter-Apps"
     }
   }
 }

--- a/apps/web/src/locales/de-DE/patches.json
+++ b/apps/web/src/locales/de-DE/patches.json
@@ -429,7 +429,8 @@
     "thirdParty": {
       "title": "Drittanbieter-Anwendungen",
       "description": "App-Updates aus winget, Chocolatey und Homebrew automatisch genehmigen. App-Sperr-/Pin-Regeln gelten weiterhin; die Wartezeit zählt ab der ersten Meldung des Updates durch das Gerät.",
-      "policyNote": "Gilt nur für Geräte, deren Konfigurationsrichtlinie Software-Updates von Drittanbietern einschließt (Patch-Einstellungen der Richtlinie)."
+      "policyNote": "Gilt nur für Geräte, deren Konfigurationsrichtlinie Software-Updates von Drittanbietern einschließt (Patch-Einstellungen der Richtlinie).",
+      "holdNote": "Vorausgefüllt mit der Wartezeit der automatischen Genehmigung des Rings. Nach dem Speichern ist diese Wartezeit unabhängig und folgt ihr nicht mehr."
     },
     "usage": {
       "messageOne": "Dieser Ring gilt für {{count}} Gerät. Änderungen werden bei dessen nächster Rückmeldung wirksam.",

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -910,7 +910,8 @@
         "createUpdateRing": "Update-Ring erstellen",
         "text2xl": "2xl",
         "saveChanges": "Änderungen speichern",
-        "createRing": "Ring erstellen"
+        "createRing": "Ring erstellen",
+        "thirdPartyRingHint": "Regeln zur automatischen Genehmigung von Drittanbieter-Updates werden im verknüpften Update-Ring konfiguriert."
       },
       "peripheralControlTab": {
         "linkPeripheralPolicy": "Link-Peripherierichtlinie",

--- a/apps/web/src/locales/en/patches.json
+++ b/apps/web/src/locales/en/patches.json
@@ -429,7 +429,8 @@
     "thirdParty": {
       "title": "Third-party applications",
       "description": "Auto-approve app updates from winget, Chocolatey, and Homebrew. App block/pin rules still apply; the hold is measured from when each device first reports the update.",
-      "policyNote": "Applies only to devices whose configuration policy includes third-party software updates (policy Patch settings)."
+      "policyNote": "Applies only to devices whose configuration policy includes third-party software updates (policy Patch settings).",
+      "holdNote": "Pre-filled from the ring's auto-approve hold. After saving, this hold is independent and no longer follows it."
     },
     "usage": {
       "messageOne": "This ring applies to {{count}} device. Changes take effect on its next check-in.",

--- a/apps/web/src/locales/en/patches.json
+++ b/apps/web/src/locales/en/patches.json
@@ -372,6 +372,7 @@
     "validation": {
       "selectCategory": "Select a category",
       "selectSeverity": "Select at least one severity for auto-approval.",
+      "selectSeverityOrThirdParty": "Select at least one severity or enable third-party app auto-approval.",
       "nameRequired": "Ring name is required"
     },
     "categories": {
@@ -379,7 +380,6 @@
       "feature": "Feature Updates",
       "firmware": "Firmware",
       "driver": "Drivers",
-      "thirdPartyApp": "Third-Party Apps",
       "definitions": "Definition Updates"
     },
     "severities": {
@@ -421,10 +421,15 @@
       "description": "What auto-approves in this ring, and how long to hold a patch after its vendor release. The default applies to every category; add an override to treat one differently.",
       "allCategories": "All categories",
       "default": "Default",
-      "severityNote": "Severities apply to OS updates. Third-party app updates (winget, Homebrew) have no vendor severity — when a policy enables other-software sources, they auto-approve on this ring's cadence regardless of the severities selected here.",
+      "severityNote": "Severities apply to OS updates only. Third-party app updates are controlled by the toggle below — they are not severity-controlled.",
       "manualDefault": "Every patch in this ring needs manual approval.",
       "manualCategory": "Patches in this category need manual approval.",
       "noOverrides": "All categories follow the default. Add an override to treat one differently."
+    },
+    "thirdParty": {
+      "title": "Third-party applications",
+      "description": "Auto-approve app updates from winget, Chocolatey, and Homebrew. App block/pin rules still apply; the hold is measured from when each device first reports the update.",
+      "policyNote": "Applies only to devices whose configuration policy includes third-party software updates (policy Patch settings)."
     },
     "usage": {
       "messageOne": "This ring applies to {{count}} device. Changes take effect on its next check-in.",

--- a/apps/web/src/locales/en/patches.json
+++ b/apps/web/src/locales/en/patches.json
@@ -462,7 +462,13 @@
       "devices": "Devices",
       "compliance": "Compliance",
       "updated": "Updated",
-      "actions": "Actions"
+      "actions": "Actions",
+      "autoApprove": "Auto-approve"
+    },
+    "badges": {
+      "manual": "Manual",
+      "os": "OS: {{severities}}",
+      "thirdParty": "3rd-party apps"
     }
   }
 }

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -910,7 +910,8 @@
         "createUpdateRing": "Create update ring",
         "text2xl": "2xl",
         "saveChanges": "Save Changes",
-        "createRing": "Create Ring"
+        "createRing": "Create Ring",
+        "thirdPartyRingHint": "Auto-approval rules for third-party updates are configured on the linked Update Ring."
       },
       "peripheralControlTab": {
         "linkPeripheralPolicy": "Link Peripheral Policy",

--- a/apps/web/src/locales/es-419/patches.json
+++ b/apps/web/src/locales/es-419/patches.json
@@ -429,7 +429,8 @@
     "thirdParty": {
       "title": "Aplicaciones de terceros",
       "description": "Aprueba automáticamente actualizaciones de apps de winget, Chocolatey y Homebrew. Las reglas de bloqueo/fijado de apps siguen aplicando; la espera se mide desde que cada dispositivo reporta la actualización por primera vez.",
-      "policyNote": "Aplica solo a dispositivos cuya política de configuración incluye actualizaciones de software de terceros (ajustes de parches de la política)."
+      "policyNote": "Aplica solo a dispositivos cuya política de configuración incluye actualizaciones de software de terceros (ajustes de parches de la política).",
+      "holdNote": "Prellenado con la espera de aprobación automática del anillo. Después de guardar, esta espera es independiente y ya no la sigue."
     },
     "usage": {
       "messageOne": "Este anillo se aplica al dispositivo {{count}}. Los cambios entran en vigor en su próximo check-in.",

--- a/apps/web/src/locales/es-419/patches.json
+++ b/apps/web/src/locales/es-419/patches.json
@@ -462,7 +462,13 @@
       "devices": "Dispositivos",
       "compliance": "Cumplimiento",
       "updated": "Actualizado",
-      "actions": "Acciones"
+      "actions": "Acciones",
+      "autoApprove": "Aprobación automática"
+    },
+    "badges": {
+      "manual": "Manual",
+      "os": "SO: {{severities}}",
+      "thirdParty": "Apps de terceros"
     }
   }
 }

--- a/apps/web/src/locales/es-419/patches.json
+++ b/apps/web/src/locales/es-419/patches.json
@@ -372,6 +372,7 @@
     "validation": {
       "selectCategory": "Seleccione una categoría",
       "selectSeverity": "Seleccione al menos una gravedad para la aprobación automática.",
+      "selectSeverityOrThirdParty": "Selecciona al menos una severidad o habilita la aprobación automática de apps de terceros.",
       "nameRequired": "El nombre del anillo es obligatorio."
     },
     "categories": {
@@ -379,7 +380,6 @@
       "feature": "Actualizaciones de funciones",
       "firmware": "firmware",
       "driver": "Controladores",
-      "thirdPartyApp": "Aplicaciones de terceros",
       "definitions": "Actualizaciones de definiciones"
     },
     "severities": {
@@ -421,10 +421,15 @@
       "description": "Qué se aprueba automáticamente en este anillo y durante cuánto tiempo se debe retener un parche después del lanzamiento del proveedor. El valor predeterminado se aplica a todas las categorías; agregue una anulación para tratar uno de manera diferente.",
       "allCategories": "Todas las categorias",
       "default": "Por defecto",
-      "severityNote": "Se aplican gravedades a las actualizaciones de OS. Las actualizaciones de aplicaciones de terceros (winget, Homebrew) no tienen gravedad de proveedor: cuando una política habilita otras fuentes de software, se aprueban automáticamente según la cadencia de este anillo, independientemente de las gravedades seleccionadas aquí.",
+      "severityNote": "Las severidades aplican solo a las actualizaciones del sistema operativo. Las actualizaciones de apps de terceros se controlan con el interruptor de abajo — no se controlan por severidad.",
       "manualDefault": "Cada parche de este anillo necesita aprobación manual.",
       "manualCategory": "Los parches de esta categoría necesitan aprobación manual.",
       "noOverrides": "Todas las categorías siguen el valor predeterminado. Agregue una anulación para tratar uno de manera diferente."
+    },
+    "thirdParty": {
+      "title": "Aplicaciones de terceros",
+      "description": "Aprueba automáticamente actualizaciones de apps de winget, Chocolatey y Homebrew. Las reglas de bloqueo/fijado de apps siguen aplicando; la espera se mide desde que cada dispositivo reporta la actualización por primera vez.",
+      "policyNote": "Aplica solo a dispositivos cuya política de configuración incluye actualizaciones de software de terceros (ajustes de parches de la política)."
     },
     "usage": {
       "messageOne": "Este anillo se aplica al dispositivo {{count}}. Los cambios entran en vigor en su próximo check-in.",

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -910,7 +910,8 @@
         "createUpdateRing": "Crear anillo de actualización",
         "text2xl": "2xl",
         "saveChanges": "Guardar cambios",
-        "createRing": "Crear anillo"
+        "createRing": "Crear anillo",
+        "thirdPartyRingHint": "Las reglas de aprobación automática para actualizaciones de terceros se configuran en el anillo de actualización vinculado."
       },
       "peripheralControlTab": {
         "linkPeripheralPolicy": "Política de enlace periférico",

--- a/apps/web/src/locales/fr-CA/patches.json
+++ b/apps/web/src/locales/fr-CA/patches.json
@@ -429,7 +429,8 @@
     "thirdParty": {
       "title": "Applications tierces",
       "description": "Approuver automatiquement les mises à jour d'applications winget, Chocolatey et Homebrew. Les règles de blocage/épinglage s'appliquent toujours ; le délai est mesuré à partir du premier signalement de la mise à jour par chaque appareil.",
-      "policyNote": "S'applique uniquement aux appareils dont la politique de configuration inclut les mises à jour logicielles tierces (paramètres de correctifs de la politique)."
+      "policyNote": "S'applique uniquement aux appareils dont la politique de configuration inclut les mises à jour logicielles tierces (paramètres de correctifs de la politique).",
+      "holdNote": "Prérempli avec le délai d'approbation automatique de l'anneau. Après l'enregistrement, ce délai est indépendant et ne le suit plus."
     },
     "usage": {
       "messageOne": "Cet anneau s’applique à {{count}} appareil. Les modifications prendront effet lors de son prochain check-in.",

--- a/apps/web/src/locales/fr-CA/patches.json
+++ b/apps/web/src/locales/fr-CA/patches.json
@@ -462,7 +462,13 @@
       "devices": "Dispositifs",
       "compliance": "Conformité",
       "updated": "Mise à jour",
-      "actions": "Actions"
+      "actions": "Actions",
+      "autoApprove": "Approbation auto"
+    },
+    "badges": {
+      "manual": "Manuelle",
+      "os": "SE : {{severities}}",
+      "thirdParty": "Applications tierces"
     }
   }
 }

--- a/apps/web/src/locales/fr-CA/patches.json
+++ b/apps/web/src/locales/fr-CA/patches.json
@@ -372,6 +372,7 @@
     "validation": {
       "selectCategory": "Sélectionnez une catégorie",
       "selectSeverity": "Sélectionnez au moins une sévérité pour l’approbation automatique.",
+      "selectSeverityOrThirdParty": "Sélectionnez au moins une sévérité ou activez l'approbation automatique des applications tierces.",
       "nameRequired": "Un nom d’anneau est requis"
     },
     "categories": {
@@ -379,7 +380,6 @@
       "feature": "Mises à jour des fonctionnalités",
       "firmware": "Micrologiciel",
       "driver": "Pilotes",
-      "thirdPartyApp": "Applications tierces",
       "definitions": "Mises à jour des définitions"
     },
     "severities": {
@@ -421,10 +421,15 @@
       "description": "Ce qui est approuvé automatiquement dans cet anneau, et combien de temps il faut conserver un patch après sa sortie chez le fabricant. Le principe par défaut s’applique à toutes les catégories ; Ajoutez une dérogation pour traiter un autre type différemment.",
       "allCategories": "Toutes les catégories",
       "default": "Par défaut",
-      "severityNote": "Les sévérités s’appliquent aux mises à jour du système d’exploitation. Les mises à jour d’applications tierces (winget, Homebrew) n’ont aucune sévérité du fournisseur — lorsqu’une politique permet à d’autres sources logicielles, elles sont approuvées automatiquement selon le rythme de cet anneau, quel que soit le niveau de sévérité sélectionné ici.",
+      "severityNote": "Les sévérités ne s'appliquent qu'aux mises à jour du système d'exploitation. Les mises à jour d'applications tierces sont contrôlées par l'interrupteur ci-dessous — elles ne sont pas contrôlées par sévérité.",
       "manualDefault": "Chaque correctif de cet anneau nécessite une approbation manuelle.",
       "manualCategory": "Les correctifs de cette catégorie nécessitent une approbation manuelle.",
       "noOverrides": "Toutes les catégories suivent la norme par défaut. Ajoutez une dérogation pour traiter un autre type différemment."
+    },
+    "thirdParty": {
+      "title": "Applications tierces",
+      "description": "Approuver automatiquement les mises à jour d'applications winget, Chocolatey et Homebrew. Les règles de blocage/épinglage s'appliquent toujours ; le délai est mesuré à partir du premier signalement de la mise à jour par chaque appareil.",
+      "policyNote": "S'applique uniquement aux appareils dont la politique de configuration inclut les mises à jour logicielles tierces (paramètres de correctifs de la politique)."
     },
     "usage": {
       "messageOne": "Cet anneau s’applique à {{count}} appareil. Les modifications prendront effet lors de son prochain check-in.",

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -910,7 +910,8 @@
         "createUpdateRing": "Créer un anneau de mise à jour",
         "text2xl": "2XL",
         "saveChanges": "Enregistrer les modifications",
-        "createRing": "Créer un anneau"
+        "createRing": "Créer un anneau",
+        "thirdPartyRingHint": "Les règles d'approbation automatique des mises à jour tierces se configurent dans l'anneau de mise à jour lié."
       },
       "peripheralControlTab": {
         "linkPeripheralPolicy": "Politique de périphériques de lien",

--- a/apps/web/src/locales/fr-FR/patches.json
+++ b/apps/web/src/locales/fr-FR/patches.json
@@ -429,7 +429,8 @@
     "thirdParty": {
       "title": "Applications tierces",
       "description": "Approuver automatiquement les mises à jour d'applications winget, Chocolatey et Homebrew. Les règles de blocage/épinglage s'appliquent toujours ; le délai est mesuré à partir du premier signalement de la mise à jour par chaque appareil.",
-      "policyNote": "S'applique uniquement aux appareils dont la politique de configuration inclut les mises à jour logicielles tierces (paramètres de correctifs de la politique)."
+      "policyNote": "S'applique uniquement aux appareils dont la politique de configuration inclut les mises à jour logicielles tierces (paramètres de correctifs de la politique).",
+      "holdNote": "Prérempli avec le délai d'approbation automatique de l'anneau. Après l'enregistrement, ce délai est indépendant et ne le suit plus."
     },
     "usage": {
       "messageOne": "Cet anneau s’applique à {{count}} appareil. Les modifications prendront effet lors de son prochain check-in.",

--- a/apps/web/src/locales/fr-FR/patches.json
+++ b/apps/web/src/locales/fr-FR/patches.json
@@ -462,7 +462,13 @@
       "devices": "Dispositifs",
       "compliance": "Conformité",
       "updated": "Mise à jour",
-      "actions": "Actions"
+      "actions": "Actions",
+      "autoApprove": "Approbation auto"
+    },
+    "badges": {
+      "manual": "Manuelle",
+      "os": "SE : {{severities}}",
+      "thirdParty": "Applications tierces"
     }
   }
 }

--- a/apps/web/src/locales/fr-FR/patches.json
+++ b/apps/web/src/locales/fr-FR/patches.json
@@ -372,6 +372,7 @@
     "validation": {
       "selectCategory": "Sélectionnez une catégorie",
       "selectSeverity": "Sélectionnez au moins une sévérité pour l’approbation automatique.",
+      "selectSeverityOrThirdParty": "Sélectionnez au moins une sévérité ou activez l'approbation automatique des applications tierces.",
       "nameRequired": "Un nom d’anneau est requis"
     },
     "categories": {
@@ -379,7 +380,6 @@
       "feature": "Mises à jour des fonctionnalités",
       "firmware": "Micrologiciel",
       "driver": "Pilotes",
-      "thirdPartyApp": "Applications tierces",
       "definitions": "Mises à jour des définitions"
     },
     "severities": {
@@ -421,10 +421,15 @@
       "description": "Ce qui est approuvé automatiquement dans cet anneau, et combien de temps il faut conserver un patch après sa sortie chez le fabricant. Le principe par défaut s’applique à toutes les catégories ; Ajoutez une dérogation pour traiter un autre type différemment.",
       "allCategories": "Toutes les catégories",
       "default": "Par défaut",
-      "severityNote": "Les sévérités s’appliquent aux mises à jour du système d’exploitation. Les mises à jour d’applications tierces (winget, Homebrew) n’ont aucune sévérité du fournisseur — lorsqu’une politique permet à d’autres sources logicielles, elles sont approuvées automatiquement selon le rythme de cet anneau, quel que soit le niveau de sévérité sélectionné ici.",
+      "severityNote": "Les sévérités ne s'appliquent qu'aux mises à jour du système d'exploitation. Les mises à jour d'applications tierces sont contrôlées par l'interrupteur ci-dessous — elles ne sont pas contrôlées par sévérité.",
       "manualDefault": "Chaque correctif de cet anneau nécessite une approbation manuelle.",
       "manualCategory": "Les correctifs de cette catégorie nécessitent une approbation manuelle.",
       "noOverrides": "Toutes les catégories suivent la norme par défaut. Ajoutez une dérogation pour traiter un autre type différemment."
+    },
+    "thirdParty": {
+      "title": "Applications tierces",
+      "description": "Approuver automatiquement les mises à jour d'applications winget, Chocolatey et Homebrew. Les règles de blocage/épinglage s'appliquent toujours ; le délai est mesuré à partir du premier signalement de la mise à jour par chaque appareil.",
+      "policyNote": "S'applique uniquement aux appareils dont la politique de configuration inclut les mises à jour logicielles tierces (paramètres de correctifs de la politique)."
     },
     "usage": {
       "messageOne": "Cet anneau s’applique à {{count}} appareil. Les modifications prendront effet lors de son prochain check-in.",

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -910,7 +910,8 @@
         "createUpdateRing": "Créer un anneau de mise à jour",
         "text2xl": "2XL",
         "saveChanges": "Enregistrer les modifications",
-        "createRing": "Créer un anneau"
+        "createRing": "Créer un anneau",
+        "thirdPartyRingHint": "Les règles d'approbation automatique des mises à jour tierces se configurent dans l'anneau de mise à jour lié."
       },
       "peripheralControlTab": {
         "linkPeripheralPolicy": "Politique de périphériques de lien",

--- a/apps/web/src/locales/it-IT/patches.json
+++ b/apps/web/src/locales/it-IT/patches.json
@@ -429,7 +429,8 @@
     "thirdParty": {
       "title": "Applicazioni di terze parti",
       "description": "Approva automaticamente gli aggiornamenti delle app da winget, Chocolatey e Homebrew. Le regole di blocco/fissaggio delle app restano valide; l'attesa è misurata da quando ogni dispositivo segnala per la prima volta l'aggiornamento.",
-      "policyNote": "Si applica solo ai dispositivi la cui politica di configurazione include gli aggiornamenti software di terze parti (impostazioni patch della politica)."
+      "policyNote": "Si applica solo ai dispositivi la cui politica di configurazione include gli aggiornamenti software di terze parti (impostazioni patch della politica).",
+      "holdNote": "Precompilato con l'attesa di approvazione automatica dell'anello. Dopo il salvataggio, questa attesa è indipendente e non la segue più."
     },
     "usage": {
       "messageOne": "Questo anello si applica a {{count}} dispositivo. Le modifiche avranno effetto al prossimo check-in.",

--- a/apps/web/src/locales/it-IT/patches.json
+++ b/apps/web/src/locales/it-IT/patches.json
@@ -462,7 +462,13 @@
       "devices": "Dispositivi",
       "compliance": "Conformità",
       "updated": "Aggiornato",
-      "actions": "Azioni"
+      "actions": "Azioni",
+      "autoApprove": "Approvazione automatica"
+    },
+    "badges": {
+      "manual": "Manuale",
+      "os": "SO: {{severities}}",
+      "thirdParty": "App di terze parti"
     }
   }
 }

--- a/apps/web/src/locales/it-IT/patches.json
+++ b/apps/web/src/locales/it-IT/patches.json
@@ -372,6 +372,7 @@
     "validation": {
       "selectCategory": "Seleziona una categoria",
       "selectSeverity": "Seleziona almeno una gravità per l'approvazione automatica.",
+      "selectSeverityOrThirdParty": "Seleziona almeno una gravità o abilita l'approvazione automatica delle app di terze parti.",
       "nameRequired": "Il nome dell'anello è obbligatorio"
     },
     "categories": {
@@ -379,7 +380,6 @@
       "feature": "Aggiornamenti funzionalità",
       "firmware": "Firmware",
       "driver": "Driver",
-      "thirdPartyApp": "App di terze parti",
       "definitions": "Aggiornamenti definizioni"
     },
     "severities": {
@@ -421,10 +421,15 @@
       "description": "Cosa viene approvato automaticamente in questo anello e per quanto tempo trattenere una patch dopo il rilascio del vendor. L'impostazione predefinita si applica a ogni categoria; aggiungi un override per gestirne una diversamente.",
       "allCategories": "Tutte le categorie",
       "default": "Predefinito",
-      "severityNote": "Le gravità si applicano agli aggiornamenti OS. Gli aggiornamenti delle app di terze parti (winget, Homebrew) non hanno una gravità del vendor — quando un criterio abilita fonti di altro software, vengono approvati automaticamente secondo la cadenza di questo anello, indipendentemente dalle gravità selezionate qui.",
+      "severityNote": "Le gravità si applicano solo agli aggiornamenti del sistema operativo. Gli aggiornamenti delle app di terze parti sono controllati dall'interruttore qui sotto — non sono controllati per gravità.",
       "manualDefault": "Ogni patch in questo anello richiede l'approvazione manuale.",
       "manualCategory": "Le patch in questa categoria richiedono l'approvazione manuale.",
       "noOverrides": "Tutte le categorie seguono l'impostazione predefinita. Aggiungi un override per gestirne una diversamente."
+    },
+    "thirdParty": {
+      "title": "Applicazioni di terze parti",
+      "description": "Approva automaticamente gli aggiornamenti delle app da winget, Chocolatey e Homebrew. Le regole di blocco/fissaggio delle app restano valide; l'attesa è misurata da quando ogni dispositivo segnala per la prima volta l'aggiornamento.",
+      "policyNote": "Si applica solo ai dispositivi la cui politica di configurazione include gli aggiornamenti software di terze parti (impostazioni patch della politica)."
     },
     "usage": {
       "messageOne": "Questo anello si applica a {{count}} dispositivo. Le modifiche avranno effetto al prossimo check-in.",

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -910,7 +910,8 @@
         "createUpdateRing": "Crea anello di aggiornamento",
         "text2xl": "2xl",
         "saveChanges": "Salva modifiche",
-        "createRing": "Crea anello"
+        "createRing": "Crea anello",
+        "thirdPartyRingHint": "Le regole di approvazione automatica per gli aggiornamenti di terze parti si configurano nell'anello di aggiornamento collegato."
       },
       "peripheralControlTab": {
         "linkPeripheralPolicy": "Collega criterio periferiche",

--- a/apps/web/src/locales/pt-BR/patches.json
+++ b/apps/web/src/locales/pt-BR/patches.json
@@ -372,6 +372,7 @@
     "validation": {
       "selectCategory": "Selecione uma categoria",
       "selectSeverity": "Selecione pelo menos uma severidade para aprovação automática.",
+      "selectSeverityOrThirdParty": "Selecione pelo menos uma severidade ou habilite a aprovação automática de apps de terceiros.",
       "nameRequired": "O nome do anel é obrigatório"
     },
     "categories": {
@@ -379,7 +380,6 @@
       "feature": "Atualizações de recursos",
       "firmware": "Firmware",
       "driver": "Drivers",
-      "thirdPartyApp": "Apps de terceiros",
       "definitions": "Atualizações de definições"
     },
     "severities": {
@@ -421,10 +421,15 @@
       "description": "O que é aprovado automaticamente neste anel e por quanto tempo reter um patch após o lançamento pelo fornecedor. O padrão se aplica a todas as categorias; adicione uma substituição para tratar uma delas de forma diferente.",
       "allCategories": "Todas as categorias",
       "default": "Padrão",
-      "severityNote": "As severidades se aplicam a atualizações do SO. Atualizações de apps de terceiros (winget, Homebrew) não têm severidade do fornecedor — quando uma política habilita fontes de outros softwares, elas são aprovadas automaticamente no ritmo deste anel, independentemente das severidades selecionadas aqui.",
+      "severityNote": "As severidades se aplicam apenas às atualizações do sistema operacional. Atualizações de apps de terceiros são controladas pelo botão abaixo — não são controladas por severidade.",
       "manualDefault": "Todos os patches neste anel precisam de aprovação manual.",
       "manualCategory": "Patches nesta categoria precisam de aprovação manual.",
       "noOverrides": "Todas as categorias seguem o padrão. Adicione uma substituição para tratar uma delas de forma diferente."
+    },
+    "thirdParty": {
+      "title": "Aplicativos de terceiros",
+      "description": "Aprovar automaticamente atualizações de apps do winget, Chocolatey e Homebrew. As regras de bloqueio/fixação de apps continuam valendo; a espera é medida a partir do primeiro relato da atualização por cada dispositivo.",
+      "policyNote": "Aplica-se apenas a dispositivos cuja política de configuração inclui atualizações de software de terceiros (configurações de patch da política)."
     },
     "usage": {
       "messageOne": "Este anel se aplica a {{count}} dispositivo. As alterações entram em vigor no próximo check-in dele.",

--- a/apps/web/src/locales/pt-BR/patches.json
+++ b/apps/web/src/locales/pt-BR/patches.json
@@ -462,7 +462,13 @@
       "devices": "Dispositivos",
       "compliance": "Conformidade",
       "updated": "Atualizado",
-      "actions": "Ações"
+      "actions": "Ações",
+      "autoApprove": "Aprovação automática"
+    },
+    "badges": {
+      "manual": "Manual",
+      "os": "SO: {{severities}}",
+      "thirdParty": "Apps de terceiros"
     }
   }
 }

--- a/apps/web/src/locales/pt-BR/patches.json
+++ b/apps/web/src/locales/pt-BR/patches.json
@@ -429,7 +429,8 @@
     "thirdParty": {
       "title": "Aplicativos de terceiros",
       "description": "Aprovar automaticamente atualizações de apps do winget, Chocolatey e Homebrew. As regras de bloqueio/fixação de apps continuam valendo; a espera é medida a partir do primeiro relato da atualização por cada dispositivo.",
-      "policyNote": "Aplica-se apenas a dispositivos cuja política de configuração inclui atualizações de software de terceiros (configurações de patch da política)."
+      "policyNote": "Aplica-se apenas a dispositivos cuja política de configuração inclui atualizações de software de terceiros (configurações de patch da política).",
+      "holdNote": "Pré-preenchido com a espera de aprovação automática do anel. Após salvar, essa espera é independente e não a acompanha mais."
     },
     "usage": {
       "messageOne": "Este anel se aplica a {{count}} dispositivo. As alterações entram em vigor no próximo check-in dele.",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -910,7 +910,8 @@
         "createUpdateRing": "Criar anel de atualização",
         "text2xl": "2xl",
         "saveChanges": "Salvar alterações",
-        "createRing": "Criar anel"
+        "createRing": "Criar anel",
+        "thirdPartyRingHint": "As regras de aprovação automática para atualizações de terceiros são configuradas no anel de atualização vinculado."
       },
       "peripheralControlTab": {
         "linkPeripheralPolicy": "Vincular política de periféricos",

--- a/docs/superpowers/plans/vuln-patch/2026-08-04-third-party-update-ring-auto-approve.md
+++ b/docs/superpowers/plans/vuln-patch/2026-08-04-third-party-update-ring-auto-approve.md
@@ -1,0 +1,1149 @@
+# Third-Party Update Ring Auto-Approval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make third-party (winget/Chocolatey/Homebrew) patching a first-class, visible citizen of Update Ring auto-approval via an explicit `thirdPartyApps` toggle, replacing the invisible severity exemption — and fix the category-rule bugs found during design.
+
+**Architecture:** The ring's `auto_approve` JSONB gains `thirdPartyApps: boolean` and `thirdPartyDeferralDays: number|null`. The evaluator requires **dual consent** for third-party auto-approval: the config policy's `sources` must include `'third_party'` (existing gate, kept) AND the ring toggle must be on. The `third_party_app` virtual category is removed (one inert stored rule fleet-wide, migrated by SQL). The dead `patch_policies.sources` column is deprecated this release (writers removed), dropped next release.
+
+**Tech Stack:** TypeScript, Hono, Drizzle, Zod 4, Vitest, React + react-hook-form + i18next, hand-written SQL migrations.
+
+**Spec:** `docs/superpowers/specs/vuln-patch/2026-08-04-third-party-update-ring-auto-approve-design.md` — read it before starting.
+
+## Global Constraints
+
+- Node is pinned to 22.23.2; use `pnpm`.
+- Never edit a shipped migration; new migration filename must sort lexicographically AFTER the current last file in `apps/api/migrations/` (currently `2026-08-12-device-identity-collision-alert-template.sql` — verify with `ls apps/api/migrations | tail -1` and use a later date prefix, e.g. `2026-08-13-`).
+- Migrations must be idempotent and must NOT contain inner `BEGIN;`/`COMMIT;`. Data-cleanup statements report row counts via `GET DIAGNOSTICS` + `RAISE WARNING`.
+- i18n key parity: any key added/removed in `apps/web/src/locales/en/` MUST be added/removed in ALL locales: `de-DE`, `en`, `es-419`, `fr-CA`, `fr-FR`, `it-IT`, `pt-BR`. Missing parity reds main.
+- `pnpm test` does NOT run the integration suites. Task 10 needs a real Postgres (`DATABASE_URL=postgresql://breeze:breeze@localhost:5432/breeze`); locally the integration suite wants the fsync=off tmpfs DB or it looks hung.
+- Evaluator changes are fail-closed: when in doubt, approve nothing. Never widen approval for malformed stored data.
+- No changes to `patchJobExecutor.ts` or `patchJobSnapshot.ts` are needed: `autoApprove` JSONB passes through the snapshot opaquely and is parsed at read time by `parseRingAutoApprove`; the policy `sources` array is already snapshotted and threaded as `ApprovalEvaluationConfig.sources`.
+- This branch (`ToddHebebrand/3rd-party-patch-update-rings`) is the working branch; commit after every task.
+
+---
+
+### Task 1: Shared validator — `ringAutoApproveSchema` gains third-party fields
+
+**Files:**
+- Modify: `packages/shared/src/validators/index.ts:612-645`
+- Test: `packages/shared/src/validators/index_inline_settings.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (root task).
+- Produces: `ringAutoApproveSchema` / type `RingAutoApprove` now `{ enabled: boolean; severities: ('critical'|'important'|'moderate'|'low')[]; deferralDays: number; thirdPartyApps: boolean; thirdPartyDeferralDays: number | null }`. Refinement: `enabled` requires (`severities.length > 0` OR `thirdPartyApps`). Tasks 2, 5, 7, 8 rely on these exact names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `ringAutoApproveSchema` describe block in `packages/shared/src/validators/index_inline_settings.test.ts` (the block containing the test at line ~44):
+
+```ts
+  it('accepts a third-party-only ring: enabled with empty severities but thirdPartyApps', () => {
+    const result = ringAutoApproveSchema.safeParse({
+      enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects enabled with empty severities and thirdPartyApps false', () => {
+    const result = ringAutoApproveSchema.safeParse({
+      enabled: true, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults thirdPartyApps=false and thirdPartyDeferralDays=null when omitted', () => {
+    const result = ringAutoApproveSchema.parse({ enabled: true, severities: ['critical'], deferralDays: 0 });
+    expect(result.thirdPartyApps).toBe(false);
+    expect(result.thirdPartyDeferralDays).toBeNull();
+  });
+
+  it('rejects out-of-range thirdPartyDeferralDays', () => {
+    expect(ringAutoApproveSchema.safeParse({ enabled: true, severities: ['low'], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: 366 }).success).toBe(false);
+    expect(ringAutoApproveSchema.safeParse({ enabled: true, severities: ['low'], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: -1 }).success).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `pnpm --filter @breeze/shared test -- index_inline_settings`
+Expected: the 4 new tests FAIL (`thirdPartyApps` unknown / third-party-only shape rejected by current refinement).
+
+- [ ] **Step 3: Implement the schema change**
+
+In `packages/shared/src/validators/index.ts`, replace the `ringAutoApproveSchema` definition (lines 631-643) with:
+
+```ts
+export const ringAutoApproveSchema = z.object({
+  enabled: z.boolean().default(false),
+  severities: z.array(z.enum(['critical', 'important', 'moderate', 'low'])).default([]),
+  deferralDays: z.number().int().min(0).max(365).default(0),
+  // Third-party (winget/Chocolatey/Homebrew + 'custom') auto-approval. Severity
+  // is not the control axis for these (they mostly ingest severity='unknown'),
+  // so this is a source-level toggle. Dual consent applies at evaluation: the
+  // config policy's `sources` must ALSO include 'third_party'.
+  thirdPartyApps: z.boolean().default(false),
+  // Hold for third-party candidates, anchored on first-seen (#2218). null =
+  // inherit deferralDays.
+  thirdPartyDeferralDays: z.number().int().min(0).max(365).nullable().default(null),
+}).superRefine((data, ctx) => {
+  if (data.enabled && data.severities.length === 0 && !data.thirdPartyApps) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['severities'],
+      message: 'Select at least one severity or enable third-party app auto-approval.',
+    });
+  }
+});
+```
+
+Also update the doc comment above it (lines 612-630): change "Empty `severities` while `enabled` means nothing auto-approves" to "Empty `severities` while `enabled` approves no OS patches; `thirdPartyApps` independently opts third-party candidates in (dual consent with the policy's `sources`)."
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @breeze/shared test -- index_inline_settings`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/index.ts packages/shared/src/validators/index_inline_settings.test.ts
+git commit -m "feat(shared): ringAutoApproveSchema gains thirdPartyApps + thirdPartyDeferralDays"
+```
+
+---
+
+### Task 2: Evaluator parse layer — `parseRingAutoApprove` compatibility + fail-closed tightening
+
+**Files:**
+- Modify: `apps/api/src/services/patchApprovalEvaluator.ts:659-712` (interface `RingAutoApproveConfig` + `parseRingAutoApprove`)
+- Test: `apps/api/src/services/patchApprovalEvaluator.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (the evaluator parses raw JSONB itself; it must not import the Zod schema — stored rows predate it).
+- Produces: `RingAutoApproveConfig` = `{ enabled: boolean; severities: string[]; deferralDays: number; thirdPartyApps: boolean; thirdPartyDeferralDays: number | null }`. `parseRingAutoApprove(autoApprove: unknown): RingAutoApproveConfig` with the compatibility rules below. Tasks 3-4 rely on these exact field names.
+
+Compatibility rules (from the spec, §Evaluator changes item 4):
+- `thirdPartyApps` **absent** → `severities.length > 0` after sanitization (preserves the old #2218 exemption for valid pre-migration rows; keeps `{enabled:true, severities:[]}` and boolean `true` inert).
+- `thirdPartyApps` **present non-boolean** → `false`.
+- Unrecognized severity strings are dropped (previously any string was kept).
+- A **present but invalid** `deferralDays` (non-number, non-integer, negative) now disables the whole row (previously coerced to 0 = no hold, which is fail-open). Absent `deferralDays` still → 0.
+- `thirdPartyDeferralDays`: integer in [0, 365] → value; anything else (absent, null, malformed) → `null`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new describe block to `apps/api/src/services/patchApprovalEvaluator.test.ts`. The file already exports/tests via `resolveApprovedPatchesForDevice`; for parse-level behavior, export `parseRingAutoApprove` from the evaluator (add `export` keyword) and test it directly:
+
+```ts
+import { parseRingAutoApprove } from './patchApprovalEvaluator';
+
+describe('parseRingAutoApprove — thirdPartyApps compatibility (#spec 2026-08-04)', () => {
+  it('derives thirdPartyApps=true for a legacy enabled row with recognized severities', () => {
+    const cfg = parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: 3 });
+    expect(cfg).toEqual({ enabled: true, severities: ['critical'], deferralDays: 3, thirdPartyApps: true, thirdPartyDeferralDays: null });
+  });
+
+  it('derives thirdPartyApps=false for legacy enabled rows with no recognized severities', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: [] }).thirdPartyApps).toBe(false);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['bogus'] }).thirdPartyApps).toBe(false);
+    expect(parseRingAutoApprove(true).thirdPartyApps).toBe(false);
+  });
+
+  it('honors an explicit thirdPartyApps boolean and treats malformed as false', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true }).thirdPartyApps).toBe(true);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], thirdPartyApps: false }).thirdPartyApps).toBe(false);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], thirdPartyApps: 'yes' }).thirdPartyApps).toBe(false);
+  });
+
+  it('drops unrecognized severity strings', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical', 'bogus', 7] }).severities).toEqual(['critical']);
+  });
+
+  it('disables the row on a present-but-invalid deferralDays instead of coercing to 0', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: 'soon' }).enabled).toBe(false);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: -1 }).enabled).toBe(false);
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'], deferralDays: 1.5 }).enabled).toBe(false);
+    // absent stays fine
+    expect(parseRingAutoApprove({ enabled: true, severities: ['critical'] })).toMatchObject({ enabled: true, deferralDays: 0 });
+  });
+
+  it('parses thirdPartyDeferralDays: valid int kept, malformed/absent/null → null', () => {
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: 14 }).thirdPartyDeferralDays).toBe(14);
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: null }).thirdPartyDeferralDays).toBeNull();
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true, thirdPartyDeferralDays: 999 }).thirdPartyDeferralDays).toBeNull();
+    expect(parseRingAutoApprove({ enabled: true, severities: [], thirdPartyApps: true }).thirdPartyDeferralDays).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api test -- patchApprovalEvaluator`
+Expected: FAIL — `parseRingAutoApprove` is not exported and lacks the new fields.
+
+- [ ] **Step 3: Implement**
+
+Replace `RingAutoApproveConfig` (lines 659-668) and `parseRingAutoApprove` (lines 670-712) with:
+
+```ts
+interface RingAutoApproveConfig {
+  enabled: boolean;
+  severities: string[];
+  /** Deferral window (days) for OS ring auto-approve. 0 = no deferral. */
+  deferralDays: number;
+  /** Third-party source-level auto-approve toggle (dual consent with policy sources). */
+  thirdPartyApps: boolean;
+  /** Third-party hold override; null = inherit deferralDays. First-seen anchored (#2218). */
+  thirdPartyDeferralDays: number | null;
+}
+
+const RECOGNIZED_RING_SEVERITIES = new Set(['critical', 'important', 'moderate', 'low']);
+
+const DISABLED_RING_AUTO_APPROVE: RingAutoApproveConfig = {
+  enabled: false,
+  severities: [],
+  deferralDays: 0,
+  thirdPartyApps: false,
+  thirdPartyDeferralDays: null,
+};
+
+/**
+ * Parse a ring's `autoApprove` JSONB into a typed config. Tolerant of every
+ * historical shape, but FAIL-CLOSED about meaning:
+ *  - boolean `true` → enabled, no severities, no third-party → approves nothing
+ *  - missing/`{}`/malformed → disabled
+ *  - unrecognized severity strings are dropped (never matched anyway; dropping
+ *    them keeps the thirdPartyApps compatibility rule honest)
+ *  - a PRESENT but invalid `deferralDays` disables the row entirely — the old
+ *    coerce-to-0 turned a malformed hold into "no hold", which is fail-open
+ *  - `thirdPartyApps` absent (pre-2026-08 rows and job snapshots frozen before
+ *    the backfill): derived as `severities.length > 0`, which reproduces the
+ *    old #2218 severity-exemption behavior for rows the write schema accepted,
+ *    while keeping malformed `{enabled:true}` rows inert. Present non-boolean
+ *    (AI-tool or hand-written rows) → false.
+ */
+export function parseRingAutoApprove(autoApprove: unknown): RingAutoApproveConfig {
+  if (autoApprove === true) {
+    return { ...DISABLED_RING_AUTO_APPROVE, enabled: true };
+  }
+
+  if (!autoApprove || typeof autoApprove !== 'object') {
+    return DISABLED_RING_AUTO_APPROVE;
+  }
+
+  const config = autoApprove as Record<string, unknown>;
+  if (config.enabled !== true) {
+    return DISABLED_RING_AUTO_APPROVE;
+  }
+
+  const severities = Array.isArray(config.severities)
+    ? config.severities.filter(
+        (s): s is string => typeof s === 'string' && RECOGNIZED_RING_SEVERITIES.has(s)
+      )
+    : [];
+
+  let deferralDays = 0;
+  if (config.deferralDays !== undefined) {
+    const raw = config.deferralDays;
+    if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 0) {
+      return DISABLED_RING_AUTO_APPROVE;
+    }
+    deferralDays = raw;
+  }
+
+  const thirdPartyApps =
+    'thirdPartyApps' in config ? config.thirdPartyApps === true : severities.length > 0;
+
+  const rawTp = config.thirdPartyDeferralDays;
+  const thirdPartyDeferralDays =
+    typeof rawTp === 'number' && Number.isInteger(rawTp) && rawTp >= 0 && rawTp <= 365
+      ? rawTp
+      : null;
+
+  return { enabled: true, severities, deferralDays, thirdPartyApps, thirdPartyDeferralDays };
+}
+```
+
+- [ ] **Step 4: Run the full evaluator test file**
+
+Run: `pnpm --filter @breeze/api test -- patchApprovalEvaluator`
+Expected: new tests PASS. Pre-existing tests may fail ONLY if they asserted the old coerce-to-0 deferral behavior — update any such test to expect the disabled row instead (the new behavior is the spec'd one).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/patchApprovalEvaluator.ts apps/api/src/services/patchApprovalEvaluator.test.ts
+git commit -m "feat(api): parseRingAutoApprove thirdPartyApps compatibility + fail-closed deferral/severity parsing"
+```
+
+---
+
+### Task 3: Evaluator — category-rule repairs (inert severity chips, non-terminal manual rules, remove virtual category)
+
+**Files:**
+- Modify: `apps/api/src/services/patchApprovalEvaluator.ts:24-29` (CategoryRule), `:530-556` (Priority 2 block)
+- Test: `apps/api/src/services/patchApprovalEvaluator.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `CategoryRule` = `{ category: string; autoApprove: boolean; autoApproveSeverities?: string[]; severityFilter?: string[]; deferralDaysOverride?: number | null }` (`severityFilter` kept as deprecated read alias). Priority-2 semantics: exact-category match only; a matching `autoApprove:false` rule is TERMINAL (returns null).
+
+Three defects being fixed (all confirmed against current code):
+1. Routes/UI write `autoApproveSeverities` (`updateRings.ts:85`) but the evaluator reads `severityFilter` (`:27`, `:543`) → severity chips on category rules never enforce (fail-open).
+2. A matching rule with `autoApprove:false` falls through to ring auto-approve, contradicting the UI's "needs manual approval" copy.
+3. The virtual `third_party_app` source-match (`:535-537`) is superseded by the ring-level toggle (Task 4); stored rules are migrated by Task 6.
+
+- [ ] **Step 1: Write the failing tests**
+
+The existing test file drives `resolveApprovedPatchesForDevice` with mocked DB rows. Follow its established mock pattern (look at how existing category-rule tests in the file seed `device_patches`/`patches` and build the config). Add:
+
+```ts
+describe('category rules — repaired semantics (#spec 2026-08-04)', () => {
+  it('enforces autoApproveSeverities written by the route/UI (was silently ignored)', async () => {
+    // patch: category 'security', severity 'moderate'
+    // rule: { category: 'security', autoApprove: true, autoApproveSeverities: ['critical'] }
+    // Expect: NOT approved (previously approved because the evaluator read `severityFilter`).
+  });
+
+  it('still honors legacy stored severityFilter as a read alias', async () => {
+    // rule: { category: 'security', autoApprove: true, severityFilter: ['critical'] }
+    // patch severity 'critical' → approved via 'category_rule'; patch severity 'low' → not approved.
+  });
+
+  it('treats a matching autoApprove:false rule as terminal — no fall-through to ring auto-approve', async () => {
+    // ring autoApprove: { enabled: true, severities: ['critical'] }
+    // rule: { category: 'security', autoApprove: false }
+    // patch: category 'security', severity 'critical'
+    // Expect: NOT approved (previously fell through and ring-auto-approved).
+  });
+
+  it('no longer matches third-party patches to a third_party_app rule', async () => {
+    // ring autoApprove disabled; rule: { category: 'third_party_app', autoApprove: true }
+    // patch: source 'third_party', category 'application', policy sources ['os','third_party']
+    // Expect: NOT approved (virtual category removed; Task 4's toggle is the path).
+  });
+});
+```
+
+Flesh these out with the file's existing helpers/mocks — each test body must build real inputs, run `resolveApprovedPatchesForDevice`, and assert on the returned array. Also UPDATE the existing tests that assert the old behavior (there are existing specs covering `severityFilter` naming, third_party_app virtual matching, and fall-through — flip their expectations to the new semantics rather than deleting them; keep their descriptions accurate).
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `pnpm --filter @breeze/api test -- patchApprovalEvaluator`
+Expected: the 4 new tests FAIL against current logic.
+
+- [ ] **Step 3: Implement**
+
+Update `CategoryRule` (lines 24-29):
+
+```ts
+export interface CategoryRule {
+  category: string;
+  autoApprove: boolean;
+  /** Severity allowlist — the canonical field name the route/UI write (updateRings.ts categoryRuleSchema). */
+  autoApproveSeverities?: string[];
+  /** @deprecated Legacy stored alias for autoApproveSeverities (rows/snapshots written before 2026-08). Read-only. */
+  severityFilter?: string[];
+  deferralDaysOverride?: number | null;
+}
+```
+
+Replace the Priority 2 block (lines 530-556) with:
+
+```ts
+  // Priority 2: Category rule (OS categories only). The virtual
+  // 'third_party_app' category was removed — third-party auto-approval is the
+  // ring-level thirdPartyApps toggle (Priority 3); stored third_party_app rules
+  // were migrated to it by the 2026-08-13 backfill. A matching rule is
+  // TERMINAL either way: autoApprove:false means "needs manual approval" (the
+  // UI's words) and must not fall through to ring-level auto-approve.
+  const rule = patch.category
+    ? categoryRuleMap.get(canonicalizePatchCategory(patch.category))
+    : undefined;
+  if (rule) {
+    if (!rule.autoApprove) {
+      return null;
+    }
+    // Severity allowlist. Canonical name is autoApproveSeverities (what the
+    // route/UI write); severityFilter is honored as a legacy stored alias —
+    // before 2026-08 the evaluator ONLY read severityFilter, which the writers
+    // never produced, so chips were silently unenforced (fail-open).
+    const severityAllowlist = rule.autoApproveSeverities ?? rule.severityFilter;
+    if (severityAllowlist && severityAllowlist.length > 0) {
+      if (!patch.severity || !severityAllowlist.includes(patch.severity)) {
+        return null;
+      }
+    }
+    const deferralDays = rule.deferralDaysOverride ?? ringConfig.deferralDays;
+    if (isHeldByDeferral(patch, deferralDays, now, 'category')) {
+      return null;
+    }
+    return 'category_rule';
+  }
+```
+
+Note: `deferralDaysOverride` may be stored as `null` ("inherit") by the route schema — `?? ringConfig.deferralDays` already handles that; keep it.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @breeze/api test -- patchApprovalEvaluator`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/patchApprovalEvaluator.ts apps/api/src/services/patchApprovalEvaluator.test.ts
+git commit -m "fix(api): category rules enforce written severities, are terminal, and drop the third_party_app virtual category"
+```
+
+---
+
+### Task 4: Evaluator — dual-consent third-party ring auto-approve
+
+**Files:**
+- Modify: `apps/api/src/services/patchApprovalEvaluator.ts:558-609` (Priority 3 block)
+- Test: `apps/api/src/services/patchApprovalEvaluator.test.ts`
+
+**Interfaces:**
+- Consumes: `RingAutoApproveConfig.thirdPartyApps` / `.thirdPartyDeferralDays` from Task 2.
+- Produces: final ring-approval semantics — OS: enabled + non-empty severities + membership + deferral; third-party (`third_party`|`custom` source): enabled + policy `sources` contains `'third_party'` + `thirdPartyApps` + deferral(`thirdPartyDeferralDays ?? deferralDays`, first-seen anchored). Task 10's integration suite asserts these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `patchApprovalEvaluator.test.ts`, following the file's existing mock pattern:
+
+```ts
+describe('ring auto-approve — third-party dual consent (#spec 2026-08-04)', () => {
+  it('approves a third-party patch only with BOTH policy sources third_party AND ring thirdPartyApps', async () => {
+    // enabled ring { severities: [], thirdPartyApps: true }, policy sources ['os','third_party']
+    // 3P patch (severity 'unknown', no releaseDate) → approved, reason 'ring_auto_approve'
+  });
+
+  it('does not approve third-party when the ring toggle is off, even with policy consent', async () => {
+    // enabled ring { severities: ['critical'], thirdPartyApps: false }, sources ['os','third_party'] → 3P not approved
+  });
+
+  it('does not approve third-party when policy sources are absent (legacy snapshot) even with the toggle on', async () => {
+    // enabled ring { severities: [], thirdPartyApps: true }, config.sources UNDEFINED → 3P not approved
+    // (absent sources = "no filtering" upstream; the dual-consent check must still refuse)
+  });
+
+  it('supports a third-party-only ring: empty severities approves 3P and no OS patches', async () => {
+    // enabled ring { severities: [], thirdPartyApps: true }, sources ['os','third_party']
+    // 3P patch approved; OS patch severity 'critical' NOT approved (empty OS severity set stays fail-closed)
+  });
+
+  it('treats custom-source patches as third-party for the toggle', async () => {
+    // patch source 'custom' behaves exactly like 'third_party' under the toggle
+  });
+
+  it('applies thirdPartyDeferralDays over deferralDays for 3P, anchored on firstSeenAt', async () => {
+    // thirdPartyDeferralDays: 7, firstSeenAt 3 days ago → held; firstSeenAt 8 days ago → approved
+    // null thirdPartyDeferralDays inherits deferralDays
+  });
+});
+```
+
+Flesh out with real mock rows per the file's pattern. Also update the existing #2218 exemption tests in this file — the exemption predicate is replaced, so tests asserting "3P approves because sources contains third_party while thirdPartyApps is untouched/absent" must be revisited: with the Task 2 compatibility rule, a legacy row `{enabled:true, severities:['critical']}` derives `thirdPartyApps=true`, so most existing exemption tests keep passing unchanged — verify rather than assume.
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `pnpm --filter @breeze/api test -- patchApprovalEvaluator`
+Expected: new tests FAIL (third-party-only ring hits the empty-severities kill-switch; toggle ignored).
+
+- [ ] **Step 3: Implement**
+
+Replace the Priority 3 block (current lines 558-606) with:
+
+```ts
+  // Priority 3: Ring-level auto-approve (#1317). Severity gates OS candidates;
+  // third-party candidates are gated by the explicit thirdPartyApps toggle
+  // (#2218 exemption replaced by spec 2026-08-04) under DUAL CONSENT:
+  //  - the POLICY must have opted into third-party sources ('third_party' in
+  //    the snapshotted sources; the default is ['os']). This stays even though
+  //    buildAllowedPatchSources filters upstream, because ABSENT sources mean
+  //    "no filtering" for legacy job snapshots — without this literal check, a
+  //    legacy snapshot plus a permissive ring would silently widen to 3P.
+  //  - the RING's autoApprove.thirdPartyApps must be true.
+  // NOTE: the literal 'third_party' selection vs the expanded patch-source
+  // bucket ('third_party'|'custom') stay in lockstep because
+  // buildAllowedPatchSources only admits 'custom' rows via the 'third_party'
+  // selection (or an explicit 'custom' entry) — if that expansion table ever
+  // changes, revisit this check too.
+  if (ringAutoApprove.enabled) {
+    if (isThirdPartyPatchSource(patch.source)) {
+      if (!(ringConfig.sources ?? []).includes('third_party')) {
+        return null;
+      }
+      if (!ringAutoApprove.thirdPartyApps) {
+        return null;
+      }
+      const hold = ringAutoApprove.thirdPartyDeferralDays ?? ringAutoApprove.deferralDays;
+      if (isHeldByDeferral(patch, hold, now, 'ring')) {
+        return null;
+      }
+      return 'ring_auto_approve';
+    }
+
+    // OS path: unchanged fail-closed severity gating. Enabled with an empty
+    // severity set approves no OS patches (legacy boolean `true` and malformed
+    // `{enabled:true}` rows stay inert here).
+    if (ringAutoApprove.severities.length === 0) {
+      return null;
+    }
+    if (!patch.severity || !ringAutoApprove.severities.includes(patch.severity)) {
+      return null;
+    }
+    if (isHeldByDeferral(patch, ringAutoApprove.deferralDays, now, 'ring')) {
+      return null;
+    }
+    return 'ring_auto_approve';
+  }
+
+  return null;
+```
+
+`isHeldByDeferral` (lines 611-657) needs no change — the first-seen fallback for third-party is already in place.
+
+- [ ] **Step 4: Run the whole API unit suite for the touched area**
+
+Run: `pnpm --filter @breeze/api test -- patchApprovalEvaluator`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/patchApprovalEvaluator.ts apps/api/src/services/patchApprovalEvaluator.test.ts
+git commit -m "feat(api): explicit dual-consent third-party ring auto-approve replaces the severity exemption"
+```
+
+---
+
+### Task 5: Ring routes — new autoApprove fields flow; deprecate `sources`; reject `third_party_app` rules
+
+**Files:**
+- Modify: `apps/api/src/routes/updateRings.ts` (`:22` default, `:82-87` categoryRuleSchema, `:101`/`:119` sources lines, `:182` list select, `:233` insert, `:348` update, and the `GET /:id` select — grep `sources: patchPolicies.sources` for every occurrence)
+- Modify: `apps/api/src/db/schema/patches.ts:151` (deprecation comment only)
+- Test: `apps/api/src/routes/updateRings_list_create.test.ts`, `apps/api/src/routes/updateRings_detail_update_delete.test.ts`
+
+**Interfaces:**
+- Consumes: `ringAutoApproveSchema` from Task 1 (already imported at `updateRings.ts:18` — new fields validate automatically).
+- Produces: create/update API accepts `autoApprove.thirdPartyApps`/`thirdPartyDeferralDays`, rejects `sources` (unknown key) and `third_party_app` category rules. Ring responses no longer include `sources`. Task 8's UI posts against this contract.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `updateRings_list_create.test.ts` (follow its existing route-test mock pattern):
+
+```ts
+  it('creates a third-party-only ring (empty severities + thirdPartyApps)', async () => {
+    // POST { name, autoApprove: { enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: 14 } }
+    // Expect 200/201 and the inserted values to include the two new fields.
+  });
+
+  it('rejects a third_party_app category rule with a helpful message', async () => {
+    // POST { name, categoryRules: [{ category: 'third_party_app', autoApprove: true }] } → 400
+  });
+
+  it('no longer returns sources in ring list responses', async () => {
+    // GET / → each ring object lacks a `sources` key
+  });
+```
+
+In `updateRings_detail_update_delete.test.ts`:
+
+```ts
+  it('PATCH persists thirdPartyApps and thirdPartyDeferralDays', async () => { /* PATCH autoApprove with new fields → updateFields.autoApprove carries them */ });
+  it('PATCH rejects a sources payload as an unknown field no-op', async () => { /* PATCH { sources: ['os'] } → sources not in updateFields (Zod strips unknown keys; assert the update call received no sources) */ });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @breeze/api test -- updateRings_list_create updateRings_detail_update_delete`
+Expected: new tests FAIL (sources still selected/written; third_party_app accepted; note `createRingSchema` currently accepts `sources` so the strip-assertion fails).
+
+- [ ] **Step 3: Implement**
+
+1. `DEFAULT_RING_AUTO_APPROVE` (line 22):
+```ts
+const DEFAULT_RING_AUTO_APPROVE = {
+  enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
+} as const;
+```
+2. `categoryRuleSchema` (lines 82-87) — reject the retired virtual category:
+```ts
+const categoryRuleSchema = z.object({
+  category: z.string().max(100).refine((c) => c.trim().toLowerCase() !== 'third_party_app', {
+    message: "The 'third_party_app' category rule was replaced by autoApprove.thirdPartyApps on the ring.",
+  }),
+  autoApprove: z.boolean(),
+  autoApproveSeverities: z.array(z.enum(['critical', 'important', 'moderate', 'low'])).optional(),
+  deferralDaysOverride: z.number().int().min(0).max(365).nullable().optional(),
+});
+```
+3. Delete the `sources:` line from `createRingSchema` (:101) and `updateRingSchema` (:119).
+4. Delete `sources: patchPolicies.sources,` from the list select (:182) and from the `GET /:id` select (grep for the second occurrence).
+5. Delete `sources: data.sources ?? null,` from the insert (:233) and `if (data.sources !== undefined) updateFields.sources = data.sources;` from the update (:348).
+6. In `apps/api/src/db/schema/patches.ts`, above the `sources` column on `patchPolicies` (~line 151), add:
+```ts
+  // DEPRECATED (spec 2026-08-04): never consumed by the approval path — the
+  // evaluated sources are config_policy_patch_settings.sources. Writers removed
+  // in the same release; DROP COLUMN ships one release later (expand/contract).
+```
+7. `pnpm --filter @breeze/api exec tsc --noEmit` will surface any other reader of `patchPolicies.sources` — the known one is `aiToolsPolicyPrereqs.ts` (Task 7); if others appear, remove their `sources` usage the same way and note it in the commit message.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @breeze/api test -- updateRings`
+Expected: PASS (update any pre-existing test fixtures that posted `sources` or asserted it in responses).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/routes/updateRings.ts apps/api/src/db/schema/patches.ts apps/api/src/routes/updateRings_list_create.test.ts apps/api/src/routes/updateRings_detail_update_delete.test.ts
+git commit -m "feat(api): ring routes accept thirdPartyApps, drop dead sources plumbing, reject third_party_app rules"
+```
+
+---
+
+### Task 6: Backfill migration
+
+**Files:**
+- Create: `apps/api/migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql` (confirm the prefix sorts after `ls apps/api/migrations | tail -1` first)
+
+**Interfaces:**
+- Consumes: the parse compatibility rule from Task 2 (the SQL must implement the SAME rule: thirdPartyApps=true iff enabled with ≥1 recognized severity).
+- Produces: all `patch_policies.auto_approve` rows carry explicit `thirdPartyApps`; no `third_party_app` category rules remain. Prod expectation (surveyed 2026-08-04): statement 1 touches 0 rows, statements 2-3 touch 1 row (EU).
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Spec 2026-08-04: third-party ring auto-approve. Backfills the explicit
+-- autoApprove.thirdPartyApps shape and migrates legacy 'third_party_app'
+-- category rules to the ring-level toggle. Idempotent; counts RAISEd so the
+-- rollout numbers land in Postgres logs (expected prod: 0 / 1 / 0 rows).
+
+DO $$
+DECLARE
+  n integer;
+BEGIN
+  -- 1) Enabled object-shaped rows lacking thirdPartyApps: derive it from
+  --    whether the row has >=1 recognized severity (mirrors
+  --    parseRingAutoApprove's compatibility rule / the old #2218 exemption).
+  UPDATE patch_policies
+  SET auto_approve = auto_approve
+        || jsonb_build_object(
+             'thirdPartyApps',
+             EXISTS (
+               SELECT 1
+               FROM jsonb_array_elements_text(
+                 CASE WHEN jsonb_typeof(auto_approve->'severities') = 'array'
+                      THEN auto_approve->'severities'
+                      ELSE '[]'::jsonb END
+               ) AS sev(v)
+               WHERE sev.v IN ('critical','important','moderate','low')
+             )
+           )
+        || jsonb_build_object('thirdPartyDeferralDays', NULL::int)
+  WHERE kind = 'ring'
+    AND jsonb_typeof(auto_approve) = 'object'
+    AND auto_approve->>'enabled' = 'true'
+    AND NOT auto_approve ? 'thirdPartyApps';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'ring-3p backfill: stamped explicit thirdPartyApps on % enabled auto_approve rows', n; END IF;
+
+  -- 2) Rings with an autoApprove:true third_party_app category rule: turn on
+  --    the ring-level toggle (carrying the rule's deferral override) and strip
+  --    the rule. Preserves intent: those rings wanted 3P auto-approved.
+  UPDATE patch_policies p
+  SET auto_approve =
+        (CASE WHEN jsonb_typeof(p.auto_approve) = 'object' THEN p.auto_approve ELSE '{}'::jsonb END)
+        || jsonb_build_object('enabled', true, 'thirdPartyApps', true)
+        || COALESCE(
+             (SELECT CASE WHEN (r.rule->>'deferralDaysOverride') ~ '^\d+$'
+                          THEN jsonb_build_object('thirdPartyDeferralDays', (r.rule->>'deferralDaysOverride')::int)
+                          ELSE '{}'::jsonb END
+              FROM jsonb_array_elements(p.category_rules) AS r(rule)
+              WHERE r.rule->>'category' = 'third_party_app'
+                AND r.rule->>'autoApprove' = 'true'
+              LIMIT 1),
+             '{}'::jsonb),
+      category_rules = COALESCE(
+        (SELECT jsonb_agg(r.rule)
+         FROM jsonb_array_elements(p.category_rules) AS r(rule)
+         WHERE r.rule->>'category' IS DISTINCT FROM 'third_party_app'),
+        '[]'::jsonb),
+      updated_at = now()
+  WHERE p.kind = 'ring'
+    AND jsonb_typeof(p.category_rules) = 'array'
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p.category_rules) AS r(rule)
+      WHERE r.rule->>'category' = 'third_party_app'
+        AND r.rule->>'autoApprove' = 'true'
+    );
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'ring-3p backfill: converted third_party_app category rules to the ring toggle on % rings', n; END IF;
+
+  -- 3) Strip any remaining (autoApprove:false) third_party_app rules — nothing
+  --    to preserve; the category no longer exists.
+  UPDATE patch_policies p
+  SET category_rules = COALESCE(
+        (SELECT jsonb_agg(r.rule)
+         FROM jsonb_array_elements(p.category_rules) AS r(rule)
+         WHERE r.rule->>'category' IS DISTINCT FROM 'third_party_app'),
+        '[]'::jsonb),
+      updated_at = now()
+  WHERE p.kind = 'ring'
+    AND jsonb_typeof(p.category_rules) = 'array'
+    AND EXISTS (
+      SELECT 1 FROM jsonb_array_elements(p.category_rules) AS r(rule)
+      WHERE r.rule->>'category' = 'third_party_app'
+    );
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n > 0 THEN RAISE WARNING 'ring-3p backfill: stripped inert third_party_app rules from % rings', n; END IF;
+END $$;
+```
+
+- [ ] **Step 2: Apply and verify idempotency locally**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+pnpm db:migrate
+```
+Expected: applies cleanly. Then seed a probe row and re-run to prove idempotency + correctness:
+
+```bash
+psql "$DATABASE_URL" -c "UPDATE patch_policies SET auto_approve='{\"enabled\":true,\"severities\":[\"critical\"]}'::jsonb, category_rules='[{\"category\":\"third_party_app\",\"autoApprove\":true,\"deferralDaysOverride\":5}]'::jsonb WHERE kind='ring' AND id=(SELECT id FROM patch_policies WHERE kind='ring' LIMIT 1) RETURNING id;"
+psql "$DATABASE_URL" -c "DELETE FROM breeze_migrations WHERE filename LIKE '2026-08-13-ring-third-party%';"
+pnpm db:migrate
+psql "$DATABASE_URL" -c "SELECT auto_approve, category_rules FROM patch_policies WHERE kind='ring' AND auto_approve ? 'thirdPartyApps' LIMIT 3;"
+```
+Expected: the probe row shows `thirdPartyApps: true`, `thirdPartyDeferralDays: 5`, and an empty/3p-free `category_rules`. Re-running `pnpm db:migrate` again (after another `DELETE FROM breeze_migrations ...`) is a no-op (all three WARNING counts absent). Reset the probe row afterwards if it was a seeded dev ring.
+
+- [ ] **Step 3: Run `pnpm db:check-drift`**
+
+Expected: no drift (data-only migration).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/migrations/2026-08-13-ring-third-party-auto-approve-backfill.sql
+git commit -m "feat(api): backfill explicit thirdPartyApps and migrate third_party_app category rules"
+```
+
+---
+
+### Task 7: AI tool surface sweep
+
+**Files:**
+- Modify: `apps/api/src/services/aiToolsPolicyPrereqs.ts` (`:35` validateRingAutoApprove doc, `:183-184` input_schema, `:216` list select, `:267` create values, `:299` update)
+- Modify: `apps/api/src/services/aiToolSchemas.ts:1396` (manage_update_rings Zod: delete the `sources` line; `:1397` autoApprove uses the shared schema — updates automatically)
+- Check (grep, update only if they mention ring `sources`/severity-only auto-approve): `apps/api/src/services/mcpGuidance.ts`, `aiAgentSystemPrompt.ts`, `aiGuardrails.ts`, `aiAgentSdkTools.ts`
+- Test: `apps/api/src/services/aiToolsPolicyPrereqs.test.ts`
+
+**Interfaces:**
+- Consumes: `ringAutoApproveSchema` (Task 1) via `validateRingAutoApprove`.
+- Produces: `manage_update_rings` accepts the new autoApprove fields, no longer accepts/returns `sources`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `aiToolsPolicyPrereqs.test.ts`, following its existing handler-invocation pattern:
+
+```ts
+  it('manage_update_rings create accepts a third-party-only autoApprove', async () => {
+    // action create, autoApprove { enabled: true, severities: [], thirdPartyApps: true } → success (no "must list at least one severity" error)
+  });
+
+  it('manage_update_rings create/update ignore a sources input and never write the column', async () => {
+    // action create with sources: ['os'] → inserted values contain no `sources` key
+  });
+
+  it('manage_update_rings still rejects enabled with no severities and no thirdPartyApps', async () => {
+    // autoApprove { enabled: true, severities: [] } → error mentioning severity or third-party
+  });
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `pnpm --filter @breeze/api test -- aiToolsPolicyPrereqs`
+Expected: FAIL (third-party-only rejected by the old refinement path through `validateRingAutoApprove`; sources still written). Note: if `validateRingAutoApprove` (line 35) wraps the shared `ringAutoApproveSchema`, the first/third tests may already pass after Task 1 — verify, and keep the tests either way as regression cover.
+
+- [ ] **Step 3: Implement**
+
+1. Delete the `sources:` property from the `manage_update_rings` `input_schema` (line 183), from the list select (line 216), the create values (line 267), and the update branch (line 299).
+2. Update the `autoApprove` description (line 184) to:
+```ts
+autoApprove: { type: 'object', description: 'Auto-approval rules, e.g. { enabled: true, severities: ["critical","important"], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null }. severities gate OS patches only and must be a subset of ["critical","important","moderate","low"]. thirdPartyApps auto-approves third-party app updates (winget/Chocolatey/Homebrew/custom) — it also requires the linked configuration policy to include third-party patch sources. If enabled is true you MUST set at least one severity OR thirdPartyApps: true.' },
+```
+3. Delete the `sources:` line from the `manage_update_rings` Zod schema in `aiToolSchemas.ts` (line 1396).
+4. `grep -n "sources" apps/api/src/services/mcpGuidance.ts apps/api/src/services/aiAgentSystemPrompt.ts apps/api/src/services/aiGuardrails.ts apps/api/src/services/aiAgentSdkTools.ts` — update any prose describing ring `sources` or "severities required" auto-approve rules to match the new contract; leave unrelated hits alone.
+5. `pnpm --filter @breeze/api exec tsc --noEmit` — must be clean (this is also the check that no other `patchPolicies.sources` reader survived Tasks 5/7; `apps/api/src/scripts/migrateToConfigPolicies.ts:491` may still reference it — that script is a retained one-shot, remove its `sources` mapping too).
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @breeze/api test -- aiToolsPolicyPrereqs aiToolSchemas`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/services/aiToolsPolicyPrereqs.ts apps/api/src/services/aiToolSchemas.ts apps/api/src/services/aiToolsPolicyPrereqs.test.ts apps/api/src/scripts/migrateToConfigPolicies.ts
+git commit -m "feat(api): manage_update_rings supports thirdPartyApps, drops ring sources"
+```
+
+---
+
+### Task 8: Web — UpdateRingForm third-party subsection
+
+**Files:**
+- Modify: `apps/web/src/components/patches/UpdateRingForm.tsx`
+- Modify: `apps/web/src/locales/{de-DE,en,es-419,fr-CA,fr-FR,it-IT,pt-BR}/patches.json`
+- Test: `apps/web/src/components/patches/UpdateRingForm.test.tsx`
+
+**Interfaces:**
+- Consumes: API contract from Task 5 (`autoApprove.thirdPartyApps: boolean`, `autoApprove.thirdPartyDeferralDays: number` — the form always submits a concrete number, mirroring the existing category-override "explicit, never blank" pattern at `UpdateRingForm.tsx:266-276`; `null` inherit is for API writers only).
+- Produces: form values type `UpdateRingFormValues['autoApprove']` gains the two fields; `PatchesPage.tsx` posts form values as-is, so no wiring change there (verify in Step 4).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `UpdateRingForm.test.tsx`, following its existing render/interaction pattern:
+
+```tsx
+  it('renders the third-party toggle inside the enabled auto-approve section', async () => {
+    // render with defaultValues { autoApprove: { enabled: true, severities: ['critical'], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: 0 } }
+    // expect screen.getByTestId('ring-third-party-enabled') to be in the document and unchecked
+  });
+
+  it('submits a third-party-only ring without a severity validation error', async () => {
+    // enable auto-approve, leave severities empty, check ring-third-party-enabled, submit
+    // expect onSubmit called with autoApprove.thirdPartyApps === true and severities []
+  });
+
+  it('still blocks enabled + no severities + third-party off', async () => {
+    // enable auto-approve, submit → validation message, onSubmit not called
+  });
+
+  it('no longer offers third_party_app as a category override option', () => {
+    // add an override; assert the category <select> has no option with value 'third_party_app'
+  });
+
+  it('shows the policy-consent note when third-party is on', async () => {
+    // check the toggle → getByTestId('ring-third-party-policy-note') visible
+  });
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `pnpm --filter @breeze/web test -- UpdateRingForm`
+Expected: new tests FAIL.
+
+- [ ] **Step 3: Implement the form changes**
+
+1. `makeRingSchema` — extend `ringAutoApproveFormSchema` (lines 18-30):
+```ts
+  const ringAutoApproveFormSchema = z.object({
+    enabled: z.boolean(),
+    severities: z.array(z.enum(['critical', 'important', 'moderate', 'low'])),
+    deferralDays: z.coerce.number().int().min(0).max(365),
+    thirdPartyApps: z.boolean(),
+    // Always a concrete number in the form (pre-filled from the ring hold);
+    // null "inherit" is an API-writer concept, mirroring deferralDaysOverride.
+    thirdPartyDeferralDays: z.coerce.number().int().min(0).max(365),
+  }).superRefine((data, ctx) => {
+    if (data.enabled && data.severities.length === 0 && !data.thirdPartyApps) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['severities'],
+        message: t('updateRingForm.validation.selectSeverityOrThirdParty'),
+      });
+    }
+  });
+```
+2. `categoryOptions` (lines 67-74): delete the `third_party_app` entry and update the comment to note third-party moved to the ring-level toggle.
+3. `initialValues` (lines 204-227): change the `autoApprove` default to
+```ts
+      autoApprove: { enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: 0 },
+```
+and after `merged` is built, normalize an incoming null/undefined third-party hold to the inherited value:
+```ts
+    const aa = merged.autoApprove ?? { enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null };
+    const mergedAutoApprove = {
+      thirdPartyApps: false,
+      ...aa,
+      thirdPartyDeferralDays: aa.thirdPartyDeferralDays ?? aa.deferralDays ?? 0,
+    };
+```
+and use `autoApprove: mergedAutoApprove` in the returned object.
+4. In the enabled branch of the default-rule card (after the severities/HoldField row ending at line 405), insert the subsection:
+```tsx
+                <div className="mt-4 w-full border-t pt-4" data-testid="ring-third-party-section">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <span className="text-sm font-medium">{t('updateRingForm.thirdParty.title')}</span>
+                      <p className="mt-0.5 max-w-md text-xs text-muted-foreground">
+                        {t('updateRingForm.thirdParty.description')}
+                      </p>
+                    </div>
+                    <ApproveToggle
+                      checked={!!autoApprove?.thirdPartyApps}
+                      field={register('autoApprove.thirdPartyApps')}
+                      testId="ring-third-party-enabled"
+                      t={t}
+                    />
+                  </div>
+                  {autoApprove?.thirdPartyApps && (
+                    <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
+                      <p className="max-w-md text-xs text-muted-foreground" data-testid="ring-third-party-policy-note">
+                        {t('updateRingForm.thirdParty.policyNote')}
+                      </p>
+                      <HoldField
+                        field={register('autoApprove.thirdPartyDeferralDays')}
+                        testId="ring-third-party-deferral"
+                        t={t}
+                      />
+                    </div>
+                  )}
+                </div>
+```
+   Layout note: the enabled branch's container (line 382) is `flex flex-wrap items-end justify-between` — the new `w-full` block wraps below the severities/hold row. Keep the existing `ring-third-party-severity-note` testid on the severity note (copy changes below).
+5. The `onSubmit` transform (lines 280-290) spreads `values.autoApprove`, so the new fields flow through untouched — no change needed there.
+
+- [ ] **Step 4: Verify PatchesPage wiring**
+
+`grep -n "autoApprove" apps/web/src/components/patches/PatchesPage.tsx` — confirm create/update handlers post `values.autoApprove` (or the whole form values) without field-picking. If a handler picks fields explicitly, add the two new ones. Also confirm `defaultValues` passed when editing a ring come from the API object (which now includes the new fields).
+
+- [ ] **Step 5: Locale keys**
+
+In `apps/web/src/locales/en/patches.json` under `updateRingForm`:
+- Add `validation.selectSeverityOrThirdParty`: `"Select at least one severity or enable third-party app auto-approval."`
+- Replace `approvalPolicy.severityNote` with: `"Severities apply to OS updates only. Third-party app updates are controlled by the toggle below — they are not severity-controlled."`
+- Add object `thirdParty`:
+```json
+"thirdParty": {
+  "title": "Third-party applications",
+  "description": "Auto-approve app updates from winget, Chocolatey, and Homebrew. App block/pin rules still apply; the hold is measured from when each device first reports the update.",
+  "policyNote": "Applies only to devices whose configuration policy includes third-party software updates (policy Patch settings)."
+}
+```
+- Delete `categories.thirdPartyApp`.
+
+Mirror in every other locale (same keys, translated; delete `categories.thirdPartyApp` everywhere):
+- **de-DE:** selectSeverityOrThirdParty `"Mindestens einen Schweregrad auswählen oder die automatische Genehmigung für Drittanbieter-Apps aktivieren."` · severityNote `"Schweregrade gelten nur für Betriebssystem-Updates. Drittanbieter-App-Updates werden über den Schalter unten gesteuert — sie sind nicht schweregradbasiert."` · title `"Drittanbieter-Anwendungen"` · description `"App-Updates aus winget, Chocolatey und Homebrew automatisch genehmigen. App-Sperr-/Pin-Regeln gelten weiterhin; die Wartezeit zählt ab der ersten Meldung des Updates durch das Gerät."` · policyNote `"Gilt nur für Geräte, deren Konfigurationsrichtlinie Software-Updates von Drittanbietern einschließt (Patch-Einstellungen der Richtlinie)."`
+- **es-419:** `"Selecciona al menos una severidad o habilita la aprobación automática de apps de terceros."` · `"Las severidades aplican solo a las actualizaciones del sistema operativo. Las actualizaciones de apps de terceros se controlan con el interruptor de abajo — no se controlan por severidad."` · `"Aplicaciones de terceros"` · `"Aprueba automáticamente actualizaciones de apps de winget, Chocolatey y Homebrew. Las reglas de bloqueo/fijado de apps siguen aplicando; la espera se mide desde que cada dispositivo reporta la actualización por primera vez."` · `"Aplica solo a dispositivos cuya política de configuración incluye actualizaciones de software de terceros (ajustes de parches de la política)."`
+- **fr-FR / fr-CA:** `"Sélectionnez au moins une sévérité ou activez l'approbation automatique des applications tierces."` · `"Les sévérités ne s'appliquent qu'aux mises à jour du système d'exploitation. Les mises à jour d'applications tierces sont contrôlées par l'interrupteur ci-dessous — elles ne sont pas contrôlées par sévérité."` · `"Applications tierces"` · `"Approuver automatiquement les mises à jour d'applications winget, Chocolatey et Homebrew. Les règles de blocage/épinglage s'appliquent toujours ; le délai est mesuré à partir du premier signalement de la mise à jour par chaque appareil."` · `"S'applique uniquement aux appareils dont la politique de configuration inclut les mises à jour logicielles tierces (paramètres de correctifs de la politique)."`
+- **it-IT:** `"Seleziona almeno una gravità o abilita l'approvazione automatica delle app di terze parti."` · `"Le gravità si applicano solo agli aggiornamenti del sistema operativo. Gli aggiornamenti delle app di terze parti sono controllati dall'interruttore qui sotto — non sono controllati per gravità."` · `"Applicazioni di terze parti"` · `"Approva automaticamente gli aggiornamenti delle app da winget, Chocolatey e Homebrew. Le regole di blocco/fissaggio delle app restano valide; l'attesa è misurata da quando ogni dispositivo segnala per la prima volta l'aggiornamento."` · `"Si applica solo ai dispositivi la cui politica di configurazione include gli aggiornamenti software di terze parti (impostazioni patch della politica)."`
+- **pt-BR:** `"Selecione pelo menos uma severidade ou habilite a aprovação automática de apps de terceiros."` · `"As severidades se aplicam apenas às atualizações do sistema operacional. Atualizações de apps de terceiros são controladas pelo botão abaixo — não são controladas por severidade."` · `"Aplicativos de terceiros"` · `"Aprovar automaticamente atualizações de apps do winget, Chocolatey e Homebrew. As regras de bloqueio/fixação de apps continuam valendo; a espera é medida a partir do primeiro relato da atualização por cada dispositivo."` · `"Aplica-se apenas a dispositivos cuja política de configuração inclui atualizações de software de terceiros (configurações de patch da política)."`
+
+- [ ] **Step 6: Run tests**
+
+Run: `pnpm --filter @breeze/web test -- UpdateRingForm`
+Expected: PASS, including the pre-existing severity-note test (update its copy assertion if it matched the old string). Also run `pnpm --filter @breeze/web test -- i18n` if a key-parity/literal-key suite exists (grep `apps/web/src` for the i18n gate test) — parity must be green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/patches/UpdateRingForm.tsx apps/web/src/components/patches/UpdateRingForm.test.tsx apps/web/src/locales/*/patches.json
+git commit -m "feat(web): third-party auto-approve subsection on the update ring form"
+```
+
+---
+
+### Task 9: Web — ring list badges + PatchTab cross-link hint
+
+**Files:**
+- Modify: `apps/web/src/components/patches/UpdateRingList.tsx`
+- Modify: `apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx:529-563` (hint below the toggle box)
+- Modify: `apps/web/src/locales/{de-DE,en,es-419,fr-CA,fr-FR,it-IT,pt-BR}/patches.json` and `.../policies.json`
+- Test: `apps/web/src/components/patches/UpdateRingList.test.tsx` (create if absent — check first; PatchesPage.test.tsx may cover the list instead)
+
+**Interfaces:**
+- Consumes: `UpdateRingItem.autoApprove` now includes `thirdPartyApps?: boolean; thirdPartyDeferralDays?: number | null` (extend the local `RingAutoApprove` type at `UpdateRingList.tsx:25-29`).
+- Produces: an "Auto-approve" column summarizing each ring.
+
+- [ ] **Step 1: Write the failing test**
+
+If `UpdateRingList.test.tsx` exists, add there; otherwise create it following `PatchList.test.tsx`'s render pattern:
+
+```tsx
+  it('summarizes auto-approve as badges: OS severities, third-party, or Manual', () => {
+    // ring A: autoApprove { enabled: true, severities: ['critical','important'], thirdPartyApps: true }
+    //   → getByTestId(`ring-badge-os-${a.id}`) contains 'Critical' and 'Important'; getByTestId(`ring-badge-third-party-${a.id}`) present
+    // ring B: autoApprove { enabled: false, ... } → row shows the Manual label
+    // ring C: autoApprove { enabled: true, severities: [], thirdPartyApps: true } → third-party badge only, no OS badge
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @breeze/web test -- UpdateRingList`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+1. Extend the type (lines 25-29):
+```ts
+export type RingAutoApprove = {
+  enabled: boolean;
+  severities: Array<'critical' | 'important' | 'moderate' | 'low'>;
+  deferralDays: number;
+  thirdPartyApps?: boolean;
+  thirdPartyDeferralDays?: number | null;
+};
+```
+2. Add the badge component next to `ComplianceBadge`:
+```tsx
+function AutoApproveBadges({ ring, t }: { ring: UpdateRingItem; t: TFunction<'patches'> }) {
+  const aa = ring.autoApprove;
+  const osOn = !!aa?.enabled && aa.severities.length > 0;
+  const tpOn = !!aa?.enabled && !!aa.thirdPartyApps;
+  if (!osOn && !tpOn) {
+    return <span className="text-muted-foreground">{t('updateRingList.badges.manual')}</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {osOn && (
+        <span
+          className="inline-flex items-center rounded-full border bg-muted/40 px-2 py-0.5 text-xs"
+          data-testid={`ring-badge-os-${ring.id}`}
+        >
+          {t('updateRingList.badges.os', {
+            severities: aa!.severities.map((s) => t(/* i18n-dynamic */ `updateRingForm.severities.${s}`)).join(', '),
+          })}
+        </span>
+      )}
+      {tpOn && (
+        <span
+          className="inline-flex items-center rounded-full border bg-muted/40 px-2 py-0.5 text-xs"
+          data-testid={`ring-badge-third-party-${ring.id}`}
+        >
+          {t('updateRingList.badges.thirdParty')}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+3. Add a header cell after Deadline (line 144): `<th className="px-4 py-3">{t('updateRingList.table.autoApprove')}</th>`, a body cell after the deadline cell (line 194): `<td className="px-4 py-3"><AutoApproveBadges ring={ring} t={t} /></td>`, and bump the empty-state `colSpan` from 8 to 9 (line 155).
+4. PatchTab hint — after the toggle's closing `</div>` (line 562), inside the same `mt-6` section:
+```tsx
+        <p className="mt-2 text-xs text-muted-foreground" data-testid="patch-third-party-ring-hint">
+          {i18n.t("policies:configurationPolicies.featureTabs.patchTab.thirdPartyRingHint")}
+        </p>
+```
+5. Locale keys — `patches.json` `updateRingList` gains:
+```json
+"table": { "...existing...": "keep", "autoApprove": "Auto-approve" },
+"badges": { "manual": "Manual", "os": "OS: {{severities}}", "thirdParty": "3rd-party apps" }
+```
+en values above; translations: de-DE `"Automatisch genehmigen"` / `"Manuell"` / `"OS: {{severities}}"` / `"Drittanbieter-Apps"`; es-419 `"Aprobación automática"` / `"Manual"` / `"SO: {{severities}}"` / `"Apps de terceros"`; fr-FR & fr-CA `"Approbation auto"` / `"Manuelle"` / `"SE : {{severities}}"` / `"Applications tierces"`; it-IT `"Approvazione automatica"` / `"Manuale"` / `"SO: {{severities}}"` / `"App di terze parti"`; pt-BR `"Aprovação automática"` / `"Manual"` / `"SO: {{severities}}"` / `"Apps de terceiros"`.
+`policies.json` `configurationPolicies.featureTabs.patchTab` gains `thirdPartyRingHint`: en `"Auto-approval rules for third-party updates are configured on the linked Update Ring."`; de-DE `"Regeln zur automatischen Genehmigung von Drittanbieter-Updates werden im verknüpften Update-Ring konfiguriert."`; es-419 `"Las reglas de aprobación automática para actualizaciones de terceros se configuran en el anillo de actualización vinculado."`; fr-FR/fr-CA `"Les règles d'approbation automatique des mises à jour tierces se configurent dans l'anneau de mise à jour lié."`; it-IT `"Le regole di approvazione automatica per gli aggiornamenti di terze parti si configurano nell'anello di aggiornamento collegato."`; pt-BR `"As regras de aprovação automática para atualizações de terceiros são configuradas no anel de atualização vinculado."`
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @breeze/web test -- UpdateRingList PatchTab PatchesPage`
+Expected: PASS (fix any snapshot/colSpan assertions in PatchesPage.test.tsx that counted columns).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/patches/UpdateRingList.tsx apps/web/src/components/patches/UpdateRingList.test.tsx apps/web/src/components/configurationPolicies/featureTabs/PatchTab.tsx apps/web/src/locales/*/patches.json apps/web/src/locales/*/policies.json
+git commit -m "feat(web): ring auto-approve badges + PatchTab third-party ring hint"
+```
+
+---
+
+### Task 10: Integration suite — real-Postgres proof of the new gates
+
+**Files:**
+- Modify: `apps/api/src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 2-4 (this suite runs `resolveApprovedPatchesForDevice` against real rows).
+
+- [ ] **Step 1: Update the suite**
+
+The file's `ringConfig(partnerId, sources, deferralDays?)` helper builds an `ApprovalEvaluationConfig` whose `autoApprove` today relies on the exemption. Rework:
+
+1. Give the helper an explicit autoApprove parameter: `ringConfig(partnerId, sources, deferralDays?, autoApprove = { enabled: true, severities: ['critical'], deferralDays: deferralDays ?? 0, thirdPartyApps: true, thirdPartyDeferralDays: null })`.
+2. Keep/adjust the existing cases (winget-shaped approval, OS severity gating unchanged, deferral hold/first-seen anchor) — they should pass with `thirdPartyApps: true` where they previously leaned on `sources` alone.
+3. Add these cases:
+
+```ts
+  it('does NOT approve third-party when the ring toggle is off, even with sources third_party', async () => {
+    // autoApprove { enabled: true, severities: ['critical'], thirdPartyApps: false }, sources ['os','third_party'] → []
+  });
+
+  it('does NOT approve third-party for a legacy snapshot with absent sources, even with the toggle on', async () => {
+    // ringConfig with sources: undefined, autoApprove.thirdPartyApps: true → [] for the 3P patch
+  });
+
+  it('approves third-party on a third-party-only ring (empty severities)', async () => {
+    // autoApprove { enabled: true, severities: [], thirdPartyApps: true }, sources ['third_party'] → 3P approved, OS patch not
+  });
+
+  it('legacy autoApprove without thirdPartyApps still approves 3P when severities were set (compat rule)', async () => {
+    // autoApprove { enabled: true, severities: ['critical'] } (no thirdPartyApps key), sources ['os','third_party'] → 3P approved
+  });
+
+  it('applies thirdPartyDeferralDays over deferralDays using the first-seen anchor', async () => {
+    // thirdPartyDeferralDays: 7, device_patches.created_at 3 days ago → held; 8 days ago → approved
+  });
+```
+
+- [ ] **Step 2: Run the integration suite**
+
+```bash
+export DATABASE_URL="postgresql://breeze:breeze@localhost:5432/breeze"
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
+```
+Expected: PASS. (Needs the local Postgres up; if it appears hung, that's the missing fsync=off tmpfs DB — see `docs`/memory note, use the project's standard integration DB setup.)
+
+- [ ] **Step 3: Run the adjacent contract suites** (tenancy untouched, but cheap insurance since `patch_policies` data shapes changed)
+
+```bash
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/patchApprovalEvaluatorTombstone.integration.test.ts src/__tests__/integration/patch-approval-org-scope.integration.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/__tests__/integration/patchThirdPartyRingAutoApprove.integration.test.ts
+git commit -m "test(api): integration cover for dual-consent third-party ring auto-approve"
+```
+
+---
+
+### Task 11: Full verification pass
+
+- [ ] **Step 1: Typecheck + full unit suites**
+
+```bash
+pnpm --filter @breeze/api exec tsc --noEmit
+pnpm --filter @breeze/shared test
+pnpm --filter @breeze/api test
+pnpm --filter @breeze/web test
+```
+Expected: all green. Remember `pnpm test` ≠ CI green: the integration suites (Task 10) and RLS contract suite run separately — RLS is untouched here (no new tables/columns), but if anything in `apps/api/src/db/schema/` changed beyond comments, run `pnpm db:check-drift` again.
+
+- [ ] **Step 2: Grep sweep — no stragglers**
+
+```bash
+grep -rn "third_party_app" apps/api/src apps/web/src --include="*.ts" --include="*.tsx" | grep -v test | grep -v migrations
+grep -rn "severityFilter" apps/api/src --include="*.ts" | grep -v test
+grep -rn "patchPolicies.sources\|sources: patchPolicies" apps/api/src --include="*.ts"
+```
+Expected: `third_party_app` remains only in the evaluator's legacy-alias comment/migration; `severityFilter` only as the deprecated alias in `CategoryRule` + its read; `patchPolicies.sources` only in the Drizzle schema definition (deprecated comment) — nowhere read or written.
+
+- [ ] **Step 3: Commit any stragglers, then push**
+
+```bash
+git push -u origin ToddHebebrand/3rd-party-patch-update-rings
+```
+
+---
+
+## Follow-ups (NOT in this branch)
+
+1. **Release N+1 contract migration:** `ALTER TABLE patch_policies DROP COLUMN IF EXISTS sources;` + remove the column from `apps/api/src/db/schema/patches.ts`. File a GitHub issue when this branch's PR opens, labeled for the release after next, referencing the spec.
+2. **Phase 2 `requireBreezeTested` gate** (spec §Phase 2): auto-approve only with an exact-version `third_party_release_tests` pass. Separate spec/plan.
+3. **Docs:** after merge, run `/update-breeze-docs` for the patching docs (ring form gained a section; PatchTab copy changed).

--- a/docs/superpowers/specs/vuln-patch/2026-08-04-third-party-update-ring-auto-approve-design.md
+++ b/docs/superpowers/specs/vuln-patch/2026-08-04-third-party-update-ring-auto-approve-design.md
@@ -1,0 +1,223 @@
+# Third-Party Patching as a First-Class Update Ring Auto-Approval — Design
+
+**Date:** 2026-08-04
+**Status:** Proposed
+**Branch/worktree:** `ToddHebebrand/3rd-party-patch-update-rings`
+**Advisor quorum:** Fable position + independent Codex (gpt-5.6, xhigh, read-only) review — agreed on
+direction; Codex refinements incorporated (dual consent, source-specific kill-switch, category-rule
+repairs, two-release column drop).
+
+## Problem
+
+MSPs cannot see or control third-party (winget/Chocolatey/Homebrew) auto-approval from the Update
+Ring UI. Third-party patching is *mostly built* — same `patches`/`device_patches` pipeline, same
+approval model, dedicated evaluator accommodations — but it is invisible and effectively
+unconfigurable from the ring, for four compounding reasons:
+
+1. **The source scope gate is on the config policy, not the ring.**
+   `config_policy_patch_settings.sources` defaults to `['os']`
+   (`apps/api/src/db/schema/configurationPolicies.ts:194`); `buildAllowedPatchSources`
+   (`apps/api/src/services/patchApprovalEvaluator.ts:187`) filters third-party out **before any ring
+   logic runs**. The only UI control is the "Include third-party software updates" switch buried on
+   the config-policy Patch tab (`PatchTab.tsx:509-563`, restored by #2300 after #1428 deleted it).
+2. **The ring's own `sources` column is dead.** `patch_policies.sources` is written by
+   `routes/updateRings.ts:233,348` and read back for display, but has **no consumer in the approval
+   path** — a leftover from #1428's unfinished "sources live on rings" intent.
+3. **Severity is a dead axis for third-party.** Ring auto-approve is severity-driven
+   (`ringAutoApproveSchema` allows only `critical|important|moderate|low`,
+   `packages/shared/src/validators/index.ts:631-645`), while third-party patches ingest with
+   `severity='unknown'`. The workaround — the severity-membership exemption at
+   `patchApprovalEvaluator.ts:593-595` — keys off the *policy's* raw `sources` array, which the ring
+   UI can neither see nor set.
+4. **The ring form has no third-party control at all.** `UpdateRingForm.tsx` shows severity chips and
+   category rules; nothing says "third-party apps" except a buried `third_party_app` entry in the
+   category-rule picker whose severity filter is broken (see Repairs below).
+
+Net effect: the answer to "why isn't 3rd-party in update ring auto-approvals" is *it is, but only via
+an invisible exemption behind a config-policy toggle that defaults off, with zero ring-level UI*.
+
+## Decision: authority split (settled, keep it)
+
+- **Config policy = eligibility/scope.** "May this policy install third-party patches at all?"
+  (`sources`, the existing PatchTab toggle). Stays the outer gate, default `['os']` (opt-in).
+- **Update ring = positive auto-approval rules.** "Which eligible patches auto-approve, and when?"
+  Third-party becomes an **explicit ring-level toggle**, not a severity exemption.
+- **Dual consent is required** for third-party auto-approval — both the policy source opt-in *and*
+  the ring toggle. This is deliberate defense-in-depth and also protects legacy job snapshots whose
+  absent `sources` mean "no filtering" (`patchJobExecutor.ts:544-560`): without the policy-side
+  check, such a job plus a permissive ring would silently widen to third-party.
+- **`patch_policies.sources` is deprecated and dropped** (two-release expand/contract), not wired.
+  Wiring it would create two overlapping source authorities with unexplainable intersection
+  semantics.
+
+Rejected alternatives:
+- *Wire `patch_policies.sources` as the authority* — duplicates the policy control; a partner-level
+  ring is linked from many policies with potentially different scopes.
+- *Keep policy-only control (status quo)* — conflates "may install" with "should auto-approve";
+  invisible from the ring UI, which is the reported problem.
+- *Per-category-rule only (`third_party_app`)* — third-party is a first-class *source* decision;
+  `third_party_app` is a virtual implementation category with (currently broken) severity semantics.
+
+## Data model & schema changes
+
+### `ringAutoApproveSchema` (`packages/shared/src/validators/index.ts`)
+
+```ts
+{
+  enabled: boolean,
+  severities: ('critical'|'important'|'moderate'|'low')[],  // OS-only, unchanged
+  deferralDays: number,                                     // unchanged
+  thirdPartyApps: boolean,                                  // NEW — default false on write
+  thirdPartyDeferralDays: number | null,                    // NEW — null = inherit deferralDays
+}
+```
+
+- Write-side refinement changes from "enabled ⇒ severities non-empty" to
+  **"enabled ⇒ (severities non-empty OR thirdPartyApps)"** — this enables third-party-only rings.
+- `severities` remains OS-only; **`unknown` is deliberately not added** to the enum. Third-party
+  auto-approval is not severity-controlled (note: catalog enrichment can stamp a
+  `defaultSeverity` on third-party rows — `thirdPartyEnrichment.ts:87` — so UI copy must say
+  "not severity-controlled", not "third-party has no severity").
+- `thirdPartyApps` covers sources `third_party` **and** `custom` (the `isThirdPartyPatchSource`
+  bucket, `patchApprovalEvaluator.ts:176-179`) — document and test this explicitly.
+
+No new columns: this all lives in the existing `patch_policies.auto_approve` jsonb.
+
+### Backfill migration
+
+One idempotent migration rewrites existing `auto_approve` jsonb rows to the explicit shape:
+`thirdPartyApps = (enabled === true AND severities contains ≥1 recognized severity)`, plus the
+`third_party_app` category-rule conversion described under Category-rule repairs. This preserves
+today's exemption behavior exactly (the exemption only ever fired for enabled rings, and the write
+schema required non-empty severities), while leaving legacy/malformed rows
+(`true`, `{enabled:true, severities:[]}`) inert. Wrap the UPDATE in the `GET DIAGNOSTICS` row-count
+warning pattern. Prod survey 2026-08-04: zero rings in either region have auto-approve enabled, so
+the severity-derived branch is expected to touch 0 rows; the category-rule conversion touches 1.
+
+### `patch_policies.sources` removal (expand/contract)
+
+- **Release N:** stop writing the column; drop `sources` from ring create/update route schemas and
+  responses (`updateRings.ts:101,118,182,233,348`), the AI tool contract
+  (`aiToolsPolicyPrereqs.ts:183,267`), and the retained one-shot script
+  (`migrateToConfigPolicies.ts:491`). Drizzle schema keeps the column marked deprecated.
+- **Release N+1:** migration `ALTER TABLE patch_policies DROP COLUMN IF EXISTS sources;` + remove
+  from Drizzle schema. (Same-release drop would 500 older API instances during a rolling deploy.)
+
+## Evaluator changes (`patchApprovalEvaluator.ts`)
+
+1. **Replace the exemption predicate with dual consent.** Third-party ring auto-approval requires:
+   ```ts
+   isThirdPartyPatchSource(patch.source)
+     && (ringConfig.sources ?? []).includes('third_party')   // policy consent — KEEP
+     && ringAutoApprove.enabled
+     && ringAutoApprove.thirdPartyApps                        // ring consent — NEW
+   ```
+   `ringConfig.sources` here is the snapshotted *policy* sources (as today); the literal-`'third_party'`
+   / expanded-bucket lockstep note at :587-592 still applies.
+2. **Make the empty-severities kill-switch source-specific.** Today `enabled + severities:[]`
+   approves nothing (:571-575). New semantics: OS candidates still require non-empty `severities`
+   and membership; third-party candidates ignore `severities` entirely and require `thirdPartyApps`.
+   A third-party-only ring (`severities:[]`, `thirdPartyApps:true`) must work.
+3. **Third-party deferral:** hold window = `thirdPartyDeferralDays ?? deferralDays`, anchored on
+   first-seen (`device_patches.createdAt`) as today (:626-635, #2218). Fail-closed anchor handling
+   unchanged.
+4. **`parseRingAutoApprove` legacy rule (fail-closed):**
+   - Field **absent** (pre-backfill rows, old job snapshots — snapshots freeze `autoApprove` jsonb,
+     so compatibility parsing must remain even after the backfill):
+     `thirdPartyApps = severities.length > 0` (mirrors the backfill rule).
+   - Field **present but malformed** (non-boolean): `false`. Same for `thirdPartyDeferralDays`
+     (non-integer/negative → `null`).
+   - While in there, tighten the existing fail-open wart: unrecognized severity strings are dropped
+     (not silently kept), and an invalid *non-zero* `deferralDays` disables auto-approve for that
+     row rather than coercing to 0 (:699-707 today coerces invalid → no deferral, which is
+     fail-open).
+
+## Category-rule repairs (pre-existing bugs, fix in the same change)
+
+These must land with (or before) the new toggle — adding a second third-party control on top of
+broken category semantics compounds the confusion:
+
+1. **Severity field mismatch — category severity chips are inert.** The route/UI write
+   `autoApproveSeverities` (`updateRings.ts:85`); the evaluator reads `rule.severityFilter`
+   (`patchApprovalEvaluator.ts:27,543`), which is always `undefined` for UI-written rules → a rule
+   configured "auto-approve critical only" approves **every** severity in that category (fail-open).
+   Fix: evaluator reads `autoApproveSeverities` (accept `severityFilter` as a legacy alias when
+   parsing stored jsonb/snapshots).
+2. **Manual category rules are not terminal.** `autoApprove:false` rules fall through to ring-level
+   auto-approve (:538), contradicting the UI's "manual approval required" copy
+   (`UpdateRingForm.tsx:464`). Fix: a matching rule with `autoApprove:false` returns `null`
+   (terminal), matching the UI contract.
+3. **`third_party_app` virtual category is removed entirely** (evaluator match at :535-537, UI
+   picker option, API acceptance). Prod survey (2026-08-04, both regions): **zero** rings have
+   ring-level auto-approve enabled anywhere; exactly **one** ring fleet-wide (EU, "Default") has a
+   `third_party_app` category rule — currently inert because its partner has no policy with
+   third-party sources. The backfill migration converts stored `third_party_app` rules to the new
+   shape (`thirdPartyApps=true` + `enabled=true`, `deferralDaysOverride` → `thirdPartyDeferralDays`)
+   and strips them from `category_rules`, preserving intent with no behavior change. Category rules
+   become OS-only. (Job snapshots frozen pre-deploy still parse; the evaluator ignores an
+   unrecognized `third_party_app` rule after removal, which for the one affected ring changes
+   nothing — it was inert.)
+
+## UI rework
+
+### `UpdateRingForm.tsx` — auto-approve section splits into two subsections
+
+- **"Operating system updates"** — existing severity chips + deferral, unchanged behavior. Copy fix:
+  deferral is anchored on vendor release date.
+- **"Third-party applications"** — new toggle ("Auto-approve third-party app updates
+  (winget, Chocolatey, Homebrew)"), optional deferral-days override (placeholder = ring deferral),
+  and two explainer lines:
+  - "Third-party auto-approval is not severity-controlled; app block/pin rules and deferral still
+    apply." (replaces the current #2218 exemption note at :397-402)
+  - "Applies only to devices whose configuration policy includes third-party software updates
+    (Policy → Patch settings)." — with a link/hint to the PatchTab toggle. This is the critical
+    cross-navigation affordance: dual consent must be *visible*, not discovered.
+- Enable-state validation mirrors the new refinement: enabling auto-approve requires ≥1 severity OR
+  the third-party toggle.
+- Category-rule picker drops `third_party_app` from options (stored rules are migrated away by the
+  backfill, so nothing legacy needs rendering).
+
+### `UpdateRingList.tsx` / rings tab
+
+- Per-ring auto-approve badges: e.g. `OS: critical+important · 3rd-party: on` / `off`. Today the
+  list shows deferral/deadline/grace but nothing about what actually auto-approves.
+
+### Config-policy PatchTab
+
+- Unchanged functionally. Copy addition under the third-party switch: "Auto-approval rules for
+  third-party updates are configured on the linked Update Ring." (mirror of the ring-side hint).
+
+### Out-of-scope UI (noted, not in this change)
+
+- An "effective status" indicator on the ring ("N linked policies include third-party") — needs a
+  new aggregate endpoint; nice-to-have.
+- `DevicePatchStatusTab` / compliance views already render third-party correctly.
+
+## AI tool / MCP surface sweep
+
+`manage_update_rings` (`aiToolsPolicyPrereqs.ts`) must gain `thirdPartyApps`/`thirdPartyDeferralDays`
+in its input schema and lose `sources`; sweep `aiToolSchemas.ts`, `aiAgentSdkTools.ts`,
+`mcpGuidance.ts`, `aiAgentSystemPrompt.ts`, `aiGuardrails.ts` for ring-shape references. The
+evaluator's fail-closed read boundary already assumes AI-written rows can be malformed — keep it.
+
+## Testing
+
+- **Unit (`patchApprovalEvaluator.test.ts`):** dual-consent matrix (policy±, toggle±, enabled±);
+  third-party-only ring (empty severities) approves 3P and no OS; legacy-parse rule (absent field
+  with/without severities; malformed field); `custom` source included; category-rule severity alias
+  + terminal-manual fixes; tightened deferral parsing.
+- **Integration (`patchThirdPartyRingAutoApprove.integration.test.ts`):** update to the new flag;
+  add a case proving a legacy job snapshot with absent `sources` does NOT auto-approve third-party.
+- **Validators (`index_inline_settings.test.ts`):** new refinement shapes.
+- **Web:** UpdateRingForm subsection render/validation; badges.
+
+## Phase 2 (explicitly out of scope)
+
+- **`requireBreezeTested` gate:** only auto-approve a third-party patch when
+  `third_party_release_tests` has a `result='pass'` row for the **exact** source/package/version
+  (`breeze_tested` alone merely opts a catalog item into testing — `wingetReleaseTestWorker.ts:21`).
+- Severity/CVE-informed third-party approval (catalog `defaultSeverity`, `patches.cve_ids`).
+- Ring-aware manual per-device install (`routes/devices/patches.ts:172-185` known limitation).
+- Deadline/grace enforcement (stored on rings, never consumed by the executor).
+- Unidentified third-party patches (missing `packageId`) bypass app rules by design (:400-408) —
+  revisit if broad third-party auto-approval increases exposure.

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -616,8 +616,8 @@ export type PolicyAppRule = z.infer<typeof policyAppRuleSchema>;
  * Rings). The ring owns the WHAT-installs auto-approval gate: an enabled flag,
  * the severities that auto-approve, and a deferral window (days after a patch's
  * release before it is eligible to auto-approve). Empty `severities` while
- * `enabled` means "nothing auto-approves" (fail-closed) — auto-approval must
- * always be an explicit opt-in to a specific severity set.
+ * `enabled` approves no OS patches; `thirdPartyApps` independently opts
+ * third-party candidates in (dual consent with the policy's `sources`).
  *
  * The legacy/dormant `autoApprove` JSONB values (`{}`, `true`,
  * `{ enabled: true, severities: [...] }` without `deferralDays`) all still
@@ -632,12 +632,20 @@ export const ringAutoApproveSchema = z.object({
   enabled: z.boolean().default(false),
   severities: z.array(z.enum(['critical', 'important', 'moderate', 'low'])).default([]),
   deferralDays: z.number().int().min(0).max(365).default(0),
+  // Third-party (winget/Chocolatey/Homebrew + 'custom') auto-approval. Severity
+  // is not the control axis for these (they mostly ingest severity='unknown'),
+  // so this is a source-level toggle. Dual consent applies at evaluation: the
+  // config policy's `sources` must ALSO include 'third_party'.
+  thirdPartyApps: z.boolean().default(false),
+  // Hold for third-party candidates, anchored on first-seen (#2218). null =
+  // inherit deferralDays.
+  thirdPartyDeferralDays: z.number().int().min(0).max(365).nullable().default(null),
 }).superRefine((data, ctx) => {
-  if (data.enabled && data.severities.length === 0) {
+  if (data.enabled && data.severities.length === 0 && !data.thirdPartyApps) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ['severities'],
-      message: 'Select at least one severity for auto-approval.',
+      message: 'Select at least one severity or enable third-party app auto-approval.',
     });
   }
 });

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -636,10 +636,16 @@ export const ringAutoApproveSchema = z.object({
   // is not the control axis for these (they mostly ingest severity='unknown'),
   // so this is a source-level toggle. Dual consent applies at evaluation: the
   // config policy's `sources` must ALSO include 'third_party'.
-  thirdPartyApps: z.boolean().default(false),
-  // Hold for third-party candidates, anchored on first-seen (#2218). null =
-  // inherit deferralDays.
-  thirdPartyDeferralDays: z.number().int().min(0).max(365).nullable().default(null),
+  //
+  // OPTIONAL (no default) on purpose: an omitted value means "writer predates
+  // this field" and the API write path preserves the ring's current setting
+  // (mergeRingAutoApproveWrite) instead of resetting it — a `.default(false)`
+  // would make an old-shape replay indistinguishable from an explicit opt-out.
+  thirdPartyApps: z.boolean().optional(),
+  // Hold for third-party candidates, anchored on releaseDate when present,
+  // first-seen otherwise (#2218). null = inherit deferralDays. Optional for
+  // the same old-shape-preservation reason as thirdPartyApps.
+  thirdPartyDeferralDays: z.number().int().min(0).max(365).nullable().optional(),
 }).superRefine((data, ctx) => {
   if (data.enabled && data.severities.length === 0 && !data.thirdPartyApps) {
     ctx.addIssue({
@@ -651,6 +657,58 @@ export const ringAutoApproveSchema = z.object({
 });
 
 export type RingAutoApprove = z.infer<typeof ringAutoApproveSchema>;
+
+const RING_AUTO_APPROVE_SEVERITIES = new Set(['critical', 'important', 'moderate', 'low']);
+
+/**
+ * Resolve an incoming `autoApprove` write against the stored row. The two
+ * third-party fields are OPTIONAL in `ringAutoApproveSchema` so a pre-2026-08
+ * client replaying the old `{enabled, severities, deferralDays}` shape (a
+ * script, a stale tab, an AI-tool partial write) cannot silently reset a
+ * ring's third-party opt-in it doesn't know about: absent fields carry over
+ * the stored row's effective values (same compat derivation as the API's
+ * parseRingAutoApprove — an absent stored `thirdPartyApps` derives from the
+ * stored severities); explicit values — including explicit `false` — always
+ * win. Pass `storedRaw: undefined` on create to stamp the explicit defaults.
+ */
+export function mergeRingAutoApproveWrite(
+  incoming: RingAutoApprove,
+  storedRaw: unknown
+): {
+  enabled: boolean;
+  severities: RingAutoApprove['severities'];
+  deferralDays: number;
+  thirdPartyApps: boolean;
+  thirdPartyDeferralDays: number | null;
+} {
+  let storedThirdPartyApps = false;
+  let storedThirdPartyDeferralDays: number | null = null;
+  if (storedRaw && typeof storedRaw === 'object') {
+    const stored = storedRaw as Record<string, unknown>;
+    const storedSeverities = Array.isArray(stored.severities)
+      ? stored.severities.filter(
+          (s): s is string => typeof s === 'string' && RING_AUTO_APPROVE_SEVERITIES.has(s)
+        )
+      : [];
+    storedThirdPartyApps =
+      'thirdPartyApps' in stored ? stored.thirdPartyApps === true : storedSeverities.length > 0;
+    const rawTp = stored.thirdPartyDeferralDays;
+    storedThirdPartyDeferralDays =
+      typeof rawTp === 'number' && Number.isInteger(rawTp) && rawTp >= 0 && rawTp <= 365
+        ? rawTp
+        : null;
+  }
+  return {
+    enabled: incoming.enabled,
+    severities: incoming.severities,
+    deferralDays: incoming.deferralDays,
+    thirdPartyApps: incoming.thirdPartyApps ?? storedThirdPartyApps,
+    thirdPartyDeferralDays:
+      incoming.thirdPartyDeferralDays !== undefined
+        ? incoming.thirdPartyDeferralDays
+        : storedThirdPartyDeferralDays,
+  };
+}
 
 export const patchInlineSettingsSchema = z.object({
   sources: z.array(patchSourceValueSchema).min(1).default(['os']),

--- a/packages/shared/src/validators/index_inline_settings.test.ts
+++ b/packages/shared/src/validators/index_inline_settings.test.ts
@@ -17,7 +17,9 @@ describe('ringAutoApproveSchema', () => {
     const result = ringAutoApproveSchema.safeParse({});
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data).toEqual({ enabled: false, severities: [], deferralDays: 0 });
+      expect(result.data).toEqual({
+        enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
+      });
     }
   });
 
@@ -48,6 +50,31 @@ describe('ringAutoApproveSchema', () => {
   it('allows disabled with no severities (the default off state)', () => {
     const result = ringAutoApproveSchema.safeParse({ enabled: false, severities: [], deferralDays: 0 });
     expect(result.success).toBe(true);
+  });
+
+  it('accepts a third-party-only ring: enabled with empty severities but thirdPartyApps', () => {
+    const result = ringAutoApproveSchema.safeParse({
+      enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects enabled with empty severities and thirdPartyApps false', () => {
+    const result = ringAutoApproveSchema.safeParse({
+      enabled: true, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('defaults thirdPartyApps=false and thirdPartyDeferralDays=null when omitted', () => {
+    const result = ringAutoApproveSchema.parse({ enabled: true, severities: ['critical'], deferralDays: 0 });
+    expect(result.thirdPartyApps).toBe(false);
+    expect(result.thirdPartyDeferralDays).toBeNull();
+  });
+
+  it('rejects out-of-range thirdPartyDeferralDays', () => {
+    expect(ringAutoApproveSchema.safeParse({ enabled: true, severities: ['low'], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: 366 }).success).toBe(false);
+    expect(ringAutoApproveSchema.safeParse({ enabled: true, severities: ['low'], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: -1 }).success).toBe(false);
   });
 });
 

--- a/packages/shared/src/validators/index_inline_settings.test.ts
+++ b/packages/shared/src/validators/index_inline_settings.test.ts
@@ -3,6 +3,7 @@ import {
   patchInlineSettingsSchema,
   policyAppRuleSchema,
   ringAutoApproveSchema,
+  mergeRingAutoApproveWrite,
   eventLogInlineSettingsSchema,
   sensitiveDataInlineSettingsSchema,
   monitoringInlineSettingsSchema,
@@ -13,13 +14,16 @@ import {
 // ============================================
 
 describe('ringAutoApproveSchema', () => {
-  it('applies fail-closed defaults', () => {
+  it('applies fail-closed defaults (third-party fields stay ABSENT, not defaulted)', () => {
+    // thirdPartyApps/thirdPartyDeferralDays deliberately have no schema
+    // default: an omitted value means "writer predates the field" and the API
+    // write path preserves the stored row via mergeRingAutoApproveWrite. A
+    // .default(false) would make an old-shape replay indistinguishable from an
+    // explicit opt-out.
     const result = ringAutoApproveSchema.safeParse({});
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data).toEqual({
-        enabled: false, severities: [], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
-      });
+      expect(result.data).toEqual({ enabled: false, severities: [], deferralDays: 0 });
     }
   });
 
@@ -66,10 +70,32 @@ describe('ringAutoApproveSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('defaults thirdPartyApps=false and thirdPartyDeferralDays=null when omitted', () => {
+  it('leaves omitted third-party fields undefined for the write path to merge', () => {
     const result = ringAutoApproveSchema.parse({ enabled: true, severities: ['critical'], deferralDays: 0 });
-    expect(result.thirdPartyApps).toBe(false);
-    expect(result.thirdPartyDeferralDays).toBeNull();
+    expect(result.thirdPartyApps).toBeUndefined();
+    expect(result.thirdPartyDeferralDays).toBeUndefined();
+  });
+
+  it('mergeRingAutoApproveWrite: absent fields carry the stored opt-in; explicit values win; create stamps defaults', () => {
+    const incoming = ringAutoApproveSchema.parse({ enabled: true, severities: ['low'], deferralDays: 2 });
+    // Stored explicit opt-in carried
+    expect(mergeRingAutoApproveWrite(incoming, {
+      enabled: true, severities: ['critical'], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: 9,
+    })).toEqual({ enabled: true, severities: ['low'], deferralDays: 2, thirdPartyApps: true, thirdPartyDeferralDays: 9 });
+    // Legacy stored row without the field: derives from stored severities
+    expect(mergeRingAutoApproveWrite(incoming, { enabled: true, severities: ['critical'] }).thirdPartyApps).toBe(true);
+    expect(mergeRingAutoApproveWrite(incoming, { enabled: true, severities: [] }).thirdPartyApps).toBe(false);
+    // Explicit false always wins over a stored true
+    const explicitOff = ringAutoApproveSchema.parse({
+      enabled: true, severities: ['low'], deferralDays: 0, thirdPartyApps: false, thirdPartyDeferralDays: null,
+    });
+    expect(mergeRingAutoApproveWrite(explicitOff, {
+      enabled: true, severities: [], deferralDays: 0, thirdPartyApps: true, thirdPartyDeferralDays: 9,
+    })).toMatchObject({ thirdPartyApps: false, thirdPartyDeferralDays: null });
+    // Create (no stored row): explicit fail-closed defaults
+    expect(mergeRingAutoApproveWrite(incoming, undefined)).toEqual({
+      enabled: true, severities: ['low'], deferralDays: 2, thirdPartyApps: false, thirdPartyDeferralDays: null,
+    });
   });
 
   it('rejects out-of-range thirdPartyDeferralDays', () => {


### PR DESCRIPTION
## Summary

Third-party (winget/Chocolatey/Homebrew) patching becomes a visible, explicit Update Ring auto-approval control. Previously it only worked via an invisible severity exemption keyed off the config policy's `sources` — nothing on the ring UI mentioned third-party at all.

- **New ring control:** `autoApprove.thirdPartyApps` (+ optional `thirdPartyDeferralDays`, first-seen anchored) in the ring's `auto_approve` JSONB. Ring form gets a "Third-party applications" subsection; rings list gets auto-approve badges; the config-policy Patch tab cross-links to the ring.
- **Dual consent, fail-closed:** third-party auto-approves only when the config policy's patch `sources` include `third_party` AND the ring toggle is on. Absent `sources` on legacy job snapshots always refuses (no scope-widening). Third-party-only rings (no OS severities) are now expressible.
- **Dead column deprecated:** `patch_policies.sources` (written since #1428, never read by the evaluator) loses all writers/readers this release; `DROP COLUMN` ships next release (follow-up issue).
- **Backfill migration** stamps explicit `thirdPartyApps` on existing rings (preserving the old exemption behavior) and converts/strips stored `third_party_app` category rules (1 row fleet-wide, currently inert). Live-verified with 4 probe cases incl. idempotency.

## Pre-existing bugs fixed en route

- **Category-rule severity chips were inert (fail-open):** the UI/API write `autoApproveSeverities` but the evaluator read `severityFilter` — "auto-approve critical only" approved every severity in the category. Now enforced (legacy alias still honored on read).
- **"Manual approval" category rules were not terminal** — they fell through to ring-level auto-approve, contradicting the UI copy.
- A third-party patch carrying an OS-style severity could slip through the OS severity-membership path when policy sources were absent — the 3P branch now fully owns third-party candidates.
- `parseRingAutoApprove` coerced invalid non-zero deferrals to 0 (fail-open) — now disables the row.

## Spec / plan

- `docs/superpowers/specs/vuln-patch/2026-08-04-third-party-update-ring-auto-approve-design.md`
- `docs/superpowers/plans/vuln-patch/2026-08-04-third-party-update-ring-auto-approve.md`

## Testing

- Unit: shared 1617, API 19528, web 4824 — all green; `tsc --noEmit` clean.
- Integration (real Postgres, clean per-worktree stack): `patchThirdPartyRingAutoApprove` 10/10 (dual-consent matrix, legacy-snapshot refusal, 3P-only ring, custom source, first-seen deferral override) + adjacent approval suites 6/6.
- i18n: all 7 locales carry the new keys; localeParity/translationCoverage/keyUsage suites green.
- Migration: probe-verified live (conversion, explicit-key preservation, disabled-ring severities cleared on enable, idempotent re-run).

## Deploy notes

- No new env vars, no schema DDL (data-only migration, runs via autoMigrate at boot).
- Release N of expand/contract for `patch_policies.sources` — the column stays but is unused; drop lands next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)