### PR TITLE
chore(agents): issue-fixer runs on Opus, delegates to Sonnet subagents

### DIFF
--- a/.claude/agents/issue-fixer.md
+++ b/.claude/agents/issue-fixer.md
@@ -1,6 +1,7 @@
 ---
 name: issue-fixer
 description: Use to drive a GitHub issue end-to-end to an open, reviewed PR on the Breeze repo. Give it a specific issue number, OR ask it to find an eligible issue itself and work that one. It claims the issue, fixes it in an isolated worktree, verifies, opens a PR, runs PR review, and posts a review-summary comment — then stops without merging or closing. An orchestrator can fan out several in parallel, each in its own worktree.
+model: opus
 ---
 
 You are an issue-fixer for the Breeze RMM repo (`LanternOps/breeze`). You take
@@ -16,6 +17,19 @@ runbook; this prompt only sets expectations.
   selection first: scan the backlog, rank candidates, and run the guard on your
   top pick (moving to the next if it aborts) until one passes — then work it.
   Report which issues you considered and why you skipped each.
+
+## Model policy
+
+You run on Opus: spend it on the judgment-heavy work — root-cause diagnosis,
+design decisions, and interpreting review findings. Delegate the rest to
+**Sonnet subagents** (pass `model: sonnet` explicitly when you spawn them):
+PR reviewers, mechanical/well-specified edits, test-output triage, doc sweeps.
+Never spawn a Fable subagent.
+
+Run your verification (tests, typecheck) **synchronously in the foreground** —
+if you end your turn to "wait" for a background run, nothing will ever wake
+you. On a loaded host, run test files in small batches with generous timeouts
+rather than one big run.
 
 ## Non-negotiable boundaries
 


### PR DESCRIPTION
Cherry-pick of 3929fc311 off the `ToddHebebrand/ai-session-review` branch so the agent-policy change lands on main independently.

- Pin `model: opus` in the issue-fixer frontmatter so fleet dispatches no longer inherit the session model (a Fable-inherited fleet hit the usage limit mid-run on 2026-08-04).
- Spawned reviewers and mechanical subagents get `model: sonnet` explicitly.
- Require synchronous foreground verification — agents that end their turn waiting on background test runs are never woken.

Config-only change (`.claude/agents/issue-fixer.md`); no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)