### PR TITLE
chore(api): drop deprecated patch_policies.sources column (#3151)

### DIFF
--- a/apps/api/migrations/2026-08-14-drop-patch-policies-sources.sql
+++ b/apps/api/migrations/2026-08-14-drop-patch-policies-sources.sql
@@ -1,0 +1,9 @@
+-- Contract phase of the third-party update ring auto-approve spec
+-- (docs/superpowers/specs/vuln-patch/2026-08-04-third-party-update-ring-auto-approve-design.md).
+-- The expand phase (#3150) removed every reader and writer of
+-- patch_policies.sources; the column was never consumed by the approval path
+-- (the evaluated sources live on config_policy_patch_settings.sources).
+-- This migration must only ship one release AFTER #3150 so rolling deploys
+-- never run an older API against the dropped column. See issue #3151.
+
+ALTER TABLE patch_policies DROP COLUMN IF EXISTS sources;

--- a/apps/api/src/db/schema/patches.ts
+++ b/apps/api/src/db/schema/patches.ts
@@ -148,10 +148,6 @@ export const patchPolicies = pgTable('patch_policies', {
   description: text('description'),
   enabled: boolean('enabled').notNull().default(true),
   targets: jsonb('targets').notNull().default({}),
-  // DEPRECATED (spec 2026-08-04): never consumed by the approval path — the
-  // evaluated sources are config_policy_patch_settings.sources. Writers removed
-  // in the same release; DROP COLUMN ships one release later (expand/contract).
-  sources: patchSourceEnum('sources').array(),
   autoApprove: jsonb('auto_approve').notNull().default({}),
   schedule: jsonb('schedule').notNull().default({}),
   rebootPolicy: jsonb('reboot_policy').notNull().default({}),

--- a/apps/api/src/routes/updateRings.ts
+++ b/apps/api/src/routes/updateRings.ts
@@ -305,16 +305,8 @@ updateRingRoutes.get(
       .orderBy(desc(patchJobs.createdAt))
       .limit(5);
 
-    // `sources` is deprecated (never consumed by the approval path — see the
-    // schema comment on patchPolicies.sources) and must not leak into ring
-    // responses, matching the list endpoint. The detail query above is a
-    // bare full-row select (it also needs every other column for the
-    // response and the partnerId check above), so strip it here rather than
-    // hand-projecting all ~20 remaining columns.
-    const { sources: _sources, ...ringWithoutSources } = ring;
-
     return c.json({
-      ...ringWithoutSources,
+      ...ring,
       approvalSummary,
       recentJobs,
     });

--- a/apps/api/src/routes/updateRings_detail_update_delete.test.ts
+++ b/apps/api/src/routes/updateRings_detail_update_delete.test.ts
@@ -43,7 +43,6 @@ vi.mock('../db/schema', () => ({
     gracePeriodHours: 'gracePeriodHours',
     categories: 'categories',
     excludeCategories: 'excludeCategories',
-    sources: 'sources',
     autoApprove: 'autoApprove',
     categoryRules: 'categoryRules',
     targets: 'targets',
@@ -126,7 +125,6 @@ function makeRing(overrides: Record<string, unknown> = {}) {
     gracePeriodHours: 4,
     categories: [],
     excludeCategories: [],
-    sources: null,
     autoApprove: {},
     categoryRules: [],
     targets: {},
@@ -251,12 +249,12 @@ describe('updateRings routes', () => {
 
     it('no longer returns sources in ring detail responses', async () => {
       vi.mocked(db.select)
-        // ring lookup — sources is deprecated but the row still carries it
-        // until the column is dropped; the route must strip it regardless.
+        // ring lookup — the sources column was dropped (#3151), so a real
+        // full-row select never returns it and neither must the response.
         .mockReturnValueOnce({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              limit: vi.fn().mockResolvedValue([makeRing({ sources: ['microsoft'] })])
+              limit: vi.fn().mockResolvedValue([makeRing()])
             })
           })
         } as any)

--- a/apps/api/src/routes/updateRings_list_create.test.ts
+++ b/apps/api/src/routes/updateRings_list_create.test.ts
@@ -44,7 +44,6 @@ vi.mock('../db/schema', () => ({
     gracePeriodHours: 'gracePeriodHours',
     categories: 'categories',
     excludeCategories: 'excludeCategories',
-    sources: 'sources',
     autoApprove: 'autoApprove',
     categoryRules: 'categoryRules',
     targets: 'targets',
@@ -127,7 +126,6 @@ function makeRing(overrides: Record<string, unknown> = {}) {
     gracePeriodHours: 4,
     categories: [],
     excludeCategories: [],
-    sources: null,
     autoApprove: {},
     categoryRules: [],
     targets: {},
@@ -242,10 +240,9 @@ describe('updateRings routes', () => {
     });
 
     it('no longer returns sources in ring list responses', async () => {
-      // The list select no longer requests `sources`, so a real DB response
+      // The sources column was dropped (#3151), so a real DB response
       // (and thus this mock) has no `sources` key at all.
-      const { sources: _sources, ...ringWithoutSources } = makeRing({ name: 'Default', ringOrder: 0 });
-      const rings = [ringWithoutSources];
+      const rings = [makeRing({ name: 'Default', ringOrder: 0 })];
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({

--- a/apps/api/src/scripts/migrateToConfigPolicies.ts
+++ b/apps/api/src/scripts/migrateToConfigPolicies.ts
@@ -488,19 +488,13 @@ async function migratePatchPoliciesLive(
   if (!featureLink) throw new Error('Failed to create patch feature link');
   summary.featureLinksCreated++;
 
-  // Carry the legacy policy's source selection: hardcoding ['os'] here would
-  // silently drop a not-yet-migrated partner's third-party opt-in on the
-  // script's FIRST run — killing their 3P patch jobs AND (under dual consent)
-  // the ring-level thirdPartyApps toggle. The patch_policies.sources column is
-  // deprecated but this read is fine until the drop lands; #3151's DROP COLUMN
-  // removes the Drizzle field, which breaks this line at compile time and
-  // forces this script to be updated (or deleted) in the same PR.
-  const sources: string[] = primary.sources ?? ['os'];
-  if (sources.some((s) => s !== 'os')) {
-    console.warn(
-      `[migrateToConfigPolicies] carrying non-OS patch sources ${JSON.stringify(sources)} from legacy policy ${primary.id}`
-    );
-  }
+  // The legacy patch_policies.sources column was dropped (spec 2026-08-04,
+  // never consumed by the approval path) — default to ['os'].
+  // Acceptable only because this script is retained as a one-shot, not a
+  // repeatable sync: re-running it for a legacy partner whose ring already
+  // opted in to third-party auto-approve would silently drop that opt-in
+  // by re-writing sources to ['os'] here.
+  const sources: string[] = ['os'];
 
   await tx.insert(configPolicyPatchSettings).values({
     featureLinkId: featureLink.id,

--- a/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.test.ts
@@ -381,13 +381,12 @@ describe('manage_update_rings autoApprove fail-closed write boundary (#1317)', (
     expect(insertMock).not.toHaveBeenCalled();
   });
 
-  it('manage_update_rings get strips the deprecated sources column from the response', async () => {
+  it('manage_update_rings get returns ring rows without a sources key (column dropped, #3151)', async () => {
     mockSelectReturns({
       id: RING_ID,
       partnerId: PARTNER_ID,
       name: 'Ring A',
       kind: 'ring',
-      sources: ['microsoft'],
     });
     const tool = getTool();
     const output = await tool.handler({ action: 'get', ringId: RING_ID }, makeAuth());

--- a/apps/api/src/services/aiToolsPolicyPrereqs.ts
+++ b/apps/api/src/services/aiToolsPolicyPrereqs.ts
@@ -243,10 +243,7 @@ export function registerPolicyPrereqTools(aiTools: Map<string, AiTool>): void {
 
         const [ring] = await db.select().from(patchPolicies).where(and(...conditions)).limit(1);
         if (!ring) return JSON.stringify({ error: 'Update ring not found or access denied' });
-        // `sources` is deprecated (never consumed by the approval path) and must
-        // not leak into ring responses, matching the REST detail endpoint.
-        const { sources: _sources, ...ringWithoutSources } = ring;
-        return JSON.stringify({ ring: ringWithoutSources });
+        return JSON.stringify({ ring });
       }
 
       if (action === 'create') {


### PR DESCRIPTION
## Summary

Contract phase of the third-party update ring auto-approve expand/contract plan (`docs/superpowers/specs/vuln-patch/2026-08-04-third-party-update-ring-auto-approve-design.md`). The expand phase (#3150) removed every reader and writer of `patch_policies.sources`; this PR drops the column itself.

- **Migration** `2026-08-14-drop-patch-policies-sources.sql`: `ALTER TABLE patch_policies DROP COLUMN IF EXISTS sources;` — idempotent, no inner transaction.
- **Schema**: removed the deprecated `sources` column definition + deprecation comment from `apps/api/src/db/schema/patches.ts` (`patchSourceEnum` itself stays — still used by `patches.source`).
- **Dead strips removed**: with the column gone from the schema, a full-row select can no longer return a `sources` key, so the defensive `const { sources: _sources, ...rest }` strips in `routes/updateRings.ts` (detail endpoint) and `services/aiToolsPolicyPrereqs.ts` (`manage_update_rings` get) are removed. Tests updated accordingly; the `not.toHaveProperty('sources')` response assertions are kept as regression guards.
- **`migrateToConfigPolicies.ts`**: `primary.sources ?? ['os']` becomes a hardcoded `['os']`. This is the compile-time handoff #3150 deliberately set up — its comment said the DROP COLUMN "removes the Drizzle field, which breaks this line at compile time and forces this script to be updated (or deleted) in the same PR." The retained caveat: the script is a one-shot, not a repeatable sync, so re-running it for a legacy partner whose ring already opted into third-party auto-approve would silently reset that opt-in.
- No cascade/export-registry changes needed: `patch_policies` is partner-owned (no `org_id`, no `device_id`), so it appears in none of the cascade or export-policy lists.

## ⚠️ MERGE GATE — still NOT satisfied as of 2026-08-07

- [x] **#3150 merged** — 2026-08-05, `f146d4027`.
- [ ] **A release containing #3150 has shipped to BOTH prod regions (EU + US).** **Not met.** Verified 2026-08-07:
  - `git tag --contains f146d4027` returns **zero tags** — no release contains #3150.
  - Latest release is **v0.103.0**, tagged 2026-07-31 — five days *before* #3150 merged.
  - `https://eu.2breeze.app/health` and `https://us.2breeze.app/health` both report **`"version":"0.103.0"`**.

  So the code currently running in both regions still reads `patch_policies.sources`. Merging and deploying this now would not merely break a rolling deploy — it would break both live regions the moment the migration applied.

**Unblocks when:** a release cutting from a main that includes `f146d4027` has been deployed to EU *and* US, and `/health` reports that version in both. Re-verify with the three checks above rather than assuming the tag implies the deploy — per the deploy runbook, the hand-maintained service list has silently skipped services before.

## Rebase note (2026-08-07)

This PR was stacked on `ToddHebebrand/3rd-party-patch-update-rings` (#3150). That PR was **squash-merged**, which discards the shared history, so all 14 of its commits on this branch started colliding with main's squashed copy — the PR went `CONFLICTING` with 23 conflicted files, none of which were actually this PR's work.

Resolved by replaying only this PR's own commit onto main (`git rebase --onto origin/main 66f77811b`) rather than hand-resolving. That left **1 commit / 8 files**, down from 15 commits / 39 files. The single genuine conflict was `migrateToConfigPolicies.ts` — exactly the handoff described above — resolved in favour of this PR's version. Pre-rebase head `b72c9e4eb` is preserved locally on `backup/3154-pre-rebase-b72c9e4eb`.

## Verification (re-run on the rebased tree, 2026-08-07)

- `tsc --noEmit -p apps/api/tsconfig.json` → **exit 0**, no output.
- `apps/api` full unit suite → **1283 files passed / 5 skipped, 20484 tests passed / 48 skipped**.
- Repo-wide grep for `patchPolicies.sources` / `patch_policies.sources`: only three **comment** references remain (`migrateToConfigPolicies.ts:491`, `aiAgentSdkTools.ts:1887`, `aiAgentSdkTools.mcpCoverage.test.ts:211`) — no live readers or writers.
- `patchPolicies` schema object confirmed to have no `sources` field.
- Migration sorts after the `2026-08-13` ring backfill from #3150; it has no ordering dependency on the sibling `2026-08-14-a-`/`-b-` files (independent `DROP COLUMN`).

Closes #3151

🤖 Generated with [Claude Code](https://claude.com/claude-code)
