### PR TITLE
fix(quotes): PDF layout rebalance, overlap fixes, and slimmer editor chrome

### DIFF
--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import zlib from 'node:zlib';
+import PDFKitDocument from 'pdfkit';
 import { PDFDocument } from 'pdf-lib';
-import { renderQuotePdf, contractUploadedMarker } from './quotePdf';
+import { renderQuotePdf, contractUploadedMarker, columnsFor } from './quotePdf';
 
 // A minimal valid 1x1 transparent PNG (the smallest real PNG pdfkit will accept).
 const ONE_BY_ONE_PNG = Buffer.from(
@@ -15,14 +16,22 @@ const ONE_BY_ONE_PNG = Buffer.from(
 // with its WinAnsi-encoded Helvetica the hex bytes ARE the character codes, so a
 // straight hex→latin1 decode reconstructs the visible text. Literal `(...)`
 // strings are handled too for robustness.
-function extractPdfTextByStream(pdf: Buffer): string[] {
-  const s = pdf.toString('latin1');
-  const streamRe = /stream\r?\n([\s\S]*?)\r?\nendstream/g;
+function inflatePdfStreams(pdf: Buffer): string[] {
+  const raw = pdf.toString('latin1');
+  const headerRe = /\/Length\s+(\d+)[\s\S]{0,120}?\/Filter\s+\/FlateDecode[\s\S]{0,40}?stream\r?\n/g;
   const streams: string[] = [];
-  let sm: RegExpExecArray | null;
-  while ((sm = streamRe.exec(s))) {
-    let body: string;
-    try { body = zlib.inflateSync(Buffer.from(sm[1]!, 'latin1')).toString('latin1'); } catch { continue; }
+  let match: RegExpExecArray | null;
+  while ((match = headerRe.exec(raw))) {
+    const length = Number(match[1]);
+    const compressed = Buffer.from(raw.slice(headerRe.lastIndex, headerRe.lastIndex + length), 'latin1');
+    try { streams.push(zlib.inflateSync(compressed).toString('latin1')); } catch { /* Skip non-text/corrupt streams. */ }
+  }
+  return streams;
+}
+
+function extractPdfTextByStream(pdf: Buffer): string[] {
+  const streams: string[] = [];
+  for (const body of inflatePdfStreams(pdf)) {
     const tokenRe = /<([0-9a-fA-F]+)>|\(((?:[^()\\]|\\.)*)\)/g;
     let out = '';
     let tm: RegExpExecArray | null;
@@ -43,7 +52,118 @@ function extractPdfText(pdf: Buffer): string {
   return extractPdfTextByStream(pdf).join(' ');
 }
 
+function extractPositionedPdfText(pdf: Buffer): { text: string; x: number; y: number }[] {
+  const fragments: { text: string; x: number; y: number }[] = [];
+  for (const body of inflatePdfStreams(pdf)) {
+    const textObjectRe = /BT\s+([\s\S]*?)\s+ET/g;
+    let textObject: RegExpExecArray | null;
+    while ((textObject = textObjectRe.exec(body))) {
+      const tm = /1 0 0 1 ([\d.]+) ([\d.]+) Tm/.exec(textObject[1]!);
+      if (!tm) continue;
+      let text = '';
+      const tokenRe = /<([0-9a-fA-F]+)>|\(((?:[^()\\]|\\.)*)\)/g;
+      let token: RegExpExecArray | null;
+      while ((token = tokenRe.exec(textObject[1]!))) {
+        text += token[1] !== undefined
+          ? Buffer.from(token[1].length % 2 ? `${token[1]}0` : token[1], 'hex').toString('latin1')
+          : token[2]!.replace(/\\([()\\])/g, '$1');
+      }
+      if (text) fragments.push({ text, x: Number(tm[1]), y: 841.89 - Number(tm[2]) });
+    }
+  }
+  return fragments;
+}
+
 describe('renderQuotePdf', () => {
+  it('allocates at least half the table to descriptions while keeping realistic amounts on one line', () => {
+    const doc = new PDFKitDocument({ size: 'A4', margin: 50 });
+    const taxed = columnsFor(doc, true);
+    const untaxed = columnsFor(doc, false);
+    const fraction = (points: number) => points / taxed.contentWidth;
+
+    expect(fraction(taxed.colDescX - taxed.left)).toBeCloseTo(0.08, 5);
+    expect(fraction(taxed.colDescW)).toBeGreaterThanOrEqual(0.52);
+    expect(fraction(untaxed.colDescW)).toBeGreaterThanOrEqual(0.60);
+    expect(taxed.colQtyW).toBeCloseTo(taxed.contentWidth * 0.07, 5);
+    expect(taxed.colAmtX + taxed.colNumW).toBeCloseTo(taxed.right, 5);
+    expect(untaxed.colAmtX + untaxed.colNumW).toBeCloseTo(untaxed.right, 5);
+
+    doc.font('Helvetica-Bold').fontSize(10);
+    const rowAmountWidth = doc.widthOfString('$888,888.88');
+    expect(taxed.colNumW).toBeGreaterThanOrEqual(rowAmountWidth + 2);
+    expect(untaxed.colNumW).toBeGreaterThanOrEqual(rowAmountWidth + 2);
+
+    doc.font('Helvetica-Bold').fontSize(14);
+    const emphasisAmountWidth = doc.widthOfString('$888,888.88');
+    expect(taxed.colSummaryNumW).toBeGreaterThanOrEqual(emphasisAmountWidth + 2);
+    expect(taxed.colSummaryAmtX + taxed.colSummaryNumW).toBeCloseTo(taxed.right, 5);
+    doc.end();
+  });
+
+  it('starts the first rich-text block below both wrapped identity columns', async () => {
+    const buf = await renderQuotePdf(
+      {
+        id: 'q-wrap', quoteNumber: 'Q-WRAP', currencyCode: 'USD',
+        sellerSnapshot: {
+          name: 'Seller With A Very Long Legal Name That Wraps Across Multiple Lines In The Left Identity Column',
+          address: {
+            line1: '12345 An Extremely Long Seller Street Address That Must Wrap In The Narrow Left Column',
+            line2: 'Suite 900, Building Seven, Attention Accounts Receivable And Contract Administration',
+            city: 'A Very Long Municipality Name', region: 'Texas', postalCode: '78701-1234', country: 'United States of America',
+          },
+          phone: '+1 (888) 555-0199 extension 12345',
+          email: 'long.billing.department@example.test',
+          website: 'https://www.example.test/a/very/long/path',
+        },
+        billToName: 'Customer With A Very Long Legal Name That Also Wraps In The Prepared For Column',
+        billToAddress: {
+          line1: '98765 Another Extremely Long Street Address That Must Wrap In The Right Column',
+          line2: 'Floor 42, Attention Procurement, Legal, Finance, And Information Technology',
+          city: 'Another Long Municipality Name', region: 'California', postalCode: '90210-1234', country: 'United States of America',
+        },
+        issueDate: '2026-08-04', expiryDate: '2026-09-03',
+        oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00',
+        dueOnAcceptanceTotal: '100.00', total: '100.00',
+      },
+      [{ id: 'rich', blockType: 'rich_text', sortOrder: 0, content: { html: '<p>FIRST_RICH_PARAGRAPH must be below both columns.</p>' } }],
+      [], async () => null, { partnerName: 'Acme' },
+    );
+    const positioned = extractPositionedPdfText(buf);
+    const firstRich = positioned.find((fragment) => fragment.text.includes('FIRST_RICH_PARAGRAPH'));
+    const identity = positioned.filter((fragment) =>
+      fragment.text.includes('Seller With') || fragment.text.includes('Customer With') ||
+      fragment.text.includes('12345 An') || fragment.text.includes('98765 Another') ||
+      fragment.text.includes('long.billing') || fragment.text.includes('Valid until:'),
+    );
+    expect(firstRich).toBeDefined();
+    expect(identity.length).toBeGreaterThan(0);
+    expect(firstRich!.y - Math.max(...identity.map((fragment) => fragment.y))).toBeGreaterThanOrEqual(28);
+  });
+
+  it('omits empty recurring summary rows unless a matching recurring line exists', async () => {
+    const quote = {
+      id: 'q1', quoteNumber: 'Q-SUMMARY', currencyCode: 'USD',
+      oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00',
+      dueOnAcceptanceTotal: '100.00', total: '100.00',
+    };
+    const blocks = [{ id: 'b1', blockType: 'line_items' as const, sortOrder: 0, content: {} }];
+    const oneTime = [{ id: 'l1', blockId: 'b1', description: 'Setup', quantity: '1', unitPrice: '100', lineTotal: '100.00', recurrence: 'one_time' }];
+    const oneTimePdf = await renderQuotePdf(quote, blocks, oneTime, async () => null, {});
+    const oneTimeText = extractPdfText(oneTimePdf);
+    expect(oneTimeText).not.toContain('Monthly');
+    expect(oneTimeText).not.toContain('Annual');
+
+    const freeRecurring = [
+      ...oneTime,
+      { id: 'l2', blockId: 'b1', description: 'Included monitoring', quantity: '1', unitPrice: '0', lineTotal: '0.00', recurrence: 'monthly' },
+      { id: 'l3', blockId: 'b1', description: 'Included annual review', quantity: '1', unitPrice: '0', lineTotal: '0.00', recurrence: 'annual' },
+    ];
+    const recurringPdf = await renderQuotePdf(quote, blocks, freeRecurring, async () => null, {});
+    const recurringText = extractPdfText(recurringPdf);
+    expect(recurringText).toContain('Monthly');
+    expect(recurringText).toContain('Annual');
+  });
+
   it('produces a PDF buffer (heading + line_items block)', async () => {
     const buf = await renderQuotePdf(
       { id: 'q1', quoteNumber: 'Q-1', oneTimeTotal: '100.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '100.00', currencyCode: 'USD' },
@@ -353,6 +473,65 @@ describe('renderQuotePdf', () => {
     // Split by recurrence: one-time $200 and $50/mo.
     expect(text).toContain('200.00');
     expect(text).toContain('50.00/mo');
+  });
+
+  it('moves a long mixed-recurrence subtotal below its label instead of overlapping it', async () => {
+    const buf = await renderQuotePdf(
+      {
+        id: 'q1', quoteNumber: 'Q-LONG-SUB', currencyCode: 'USD',
+        oneTimeTotal: '12000.00', monthlyRecurringTotal: '4800.00', annualRecurringTotal: '9600.00',
+        dueOnAcceptanceTotal: '12000.00', total: '26400.00',
+      },
+      [{ id: 'b1', blockType: 'line_items', sortOrder: 0, content: { showSubtotal: true } }],
+      [
+        { id: 'l1', blockId: 'b1', description: 'Setup', quantity: '1', unitPrice: '12000', lineTotal: '12000.00', recurrence: 'one_time' },
+        { id: 'l2', blockId: 'b1', description: 'Service', quantity: '1', unitPrice: '4800', lineTotal: '4800.00', recurrence: 'monthly' },
+        { id: 'l3', blockId: 'b1', description: 'Review', quantity: '1', unitPrice: '9600', lineTotal: '9600.00', recurrence: 'annual' },
+      ],
+      async () => null,
+      {},
+    );
+    const positioned = extractPositionedPdfText(buf);
+    const label = positioned.find((fragment) => fragment.text === 'Subtotal');
+    const amount = positioned.find((fragment) => fragment.text.includes('$12,000.00') && fragment.text.includes('$4,800.00/mo'));
+    expect(label).toBeDefined();
+    expect(amount).toBeDefined();
+    expect(amount!.y).toBeGreaterThan(label!.y);
+  });
+
+  it('moves a long category breakdown amount below its label instead of crowding the next row', async () => {
+    const buf = await renderQuotePdf(
+      {
+        id: 'q1', quoteNumber: 'Q-LONG-CATEGORY', currencyCode: 'USD',
+        oneTimeTotal: '3000.00', monthlyRecurringTotal: '4800.00', annualRecurringTotal: '9600.00',
+        dueOnAcceptanceTotal: '3000.00', total: '17400.00',
+        categoryBreakdown: [
+          { category: 'hardware', oneTimeTotal: '100.00', monthlyTotal: '0.00', annualTotal: '0.00' },
+          { category: 'service', oneTimeTotal: '3000.00', monthlyTotal: '4800.00', annualTotal: '9600.00' },
+        ],
+      },
+      [],
+      [
+        { id: 'l1', description: 'Setup', quantity: '1', unitPrice: '3000', lineTotal: '3000.00', recurrence: 'one_time' },
+        { id: 'l2', description: 'Service', quantity: '1', unitPrice: '4800', lineTotal: '4800.00', recurrence: 'monthly' },
+        { id: 'l3', description: 'Review', quantity: '1', unitPrice: '9600', lineTotal: '9600.00', recurrence: 'annual' },
+      ],
+      async () => null,
+      {},
+    );
+    const positioned = extractPositionedPdfText(buf);
+    const label = positioned.find((fragment) => fragment.text === 'Service');
+    const amount = positioned.find((fragment) => fragment.text.includes('$3,000.00') && fragment.text.includes('$4,800.00/mo'));
+    const oneTime = positioned.find((fragment) => fragment.text === 'One-time');
+    const categoryLastLine = positioned
+      .filter((fragment) => fragment.text.includes('$9,600.00/yr') && oneTime && fragment.y < oneTime.y)
+      .sort((a, b) => b.y - a.y)[0];
+    expect(label).toBeDefined();
+    expect(amount).toBeDefined();
+    expect(amount!.y).toBeGreaterThan(label!.y);
+    expect(oneTime).toBeDefined();
+    expect(categoryLastLine).toBeDefined();
+    expect(oneTime!.y - categoryLastLine!.y).toBeGreaterThanOrEqual(10);
   });
 
   it('renderQuotePdf includes the From block and T&C', async () => {

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -82,21 +82,37 @@ describe('renderQuotePdf', () => {
     const fraction = (points: number) => points / taxed.contentWidth;
 
     expect(fraction(taxed.colDescX - taxed.left)).toBeCloseTo(0.08, 5);
-    expect(fraction(taxed.colDescW)).toBeGreaterThanOrEqual(0.52);
-    expect(fraction(untaxed.colDescW)).toBeGreaterThanOrEqual(0.60);
+    expect(fraction(taxed.colDescW)).toBeGreaterThanOrEqual(0.48);
+    expect(fraction(untaxed.colDescW)).toBeGreaterThanOrEqual(0.55);
     expect(taxed.colQtyW).toBeCloseTo(taxed.contentWidth * 0.07, 5);
-    expect(taxed.colAmtX + taxed.colNumW).toBeCloseTo(taxed.right, 5);
-    expect(untaxed.colAmtX + untaxed.colNumW).toBeCloseTo(untaxed.right, 5);
+    expect(taxed.colAmtX + taxed.colAmtW).toBeCloseTo(taxed.right, 5);
+    expect(untaxed.colAmtX + untaxed.colAmtW).toBeCloseTo(untaxed.right, 5);
 
-    doc.font('Helvetica-Bold').fontSize(10);
-    const rowAmountWidth = doc.widthOfString('$888,888.88');
-    expect(taxed.colNumW).toBeGreaterThanOrEqual(rowAmountWidth + 2);
-    expect(untaxed.colNumW).toBeGreaterThanOrEqual(rowAmountWidth + 2);
+    // Measure at the row's REAL font (Helvetica regular 10 — see the money
+    // draws in renderLineTable). UNIT/TAX render bare money; TOTAL renders
+    // money + the recurrence suffix, which is why it has its own wider box —
+    // asserting the suffix-less string against colNumW is what let a wrapping
+    // "$12,000.00/mo" TOTAL ship.
+    doc.font('Helvetica').fontSize(10);
+    const bareAmountWidth = doc.widthOfString('$888,888.88');
+    const suffixedAmountWidth = doc.widthOfString('$888,888.88/mo');
+    expect(taxed.colNumW).toBeGreaterThanOrEqual(bareAmountWidth + 2);
+    expect(untaxed.colNumW).toBeGreaterThanOrEqual(bareAmountWidth + 2);
+    expect(taxed.colAmtW).toBeGreaterThanOrEqual(suffixedAmountWidth + 2);
+    expect(untaxed.colAmtW).toBeGreaterThanOrEqual(suffixedAmountWidth + 2);
 
     doc.font('Helvetica-Bold').fontSize(14);
-    const emphasisAmountWidth = doc.widthOfString('$888,888.88');
+    const emphasisAmountWidth = doc.widthOfString('$1,000,000.00');
     expect(taxed.colSummaryNumW).toBeGreaterThanOrEqual(emphasisAmountWidth + 2);
     expect(taxed.colSummaryAmtX + taxed.colSummaryNumW).toBeCloseTo(taxed.right, 5);
+
+    // The summary label box must fit its widest static label (bold 12pt) —
+    // rows advance by fixed constants, so a wrapped label overprints the next
+    // row. Mirrors the sumX/labelW arithmetic in renderRecurringSummary.
+    const sumX = taxed.left + taxed.contentWidth * 0.36;
+    const labelW = taxed.colSummaryAmtX - sumX - 8;
+    doc.font('Helvetica-Bold').fontSize(12);
+    expect(labelW).toBeGreaterThanOrEqual(doc.widthOfString('Remaining balance (due per terms)') + 2);
     doc.end();
   });
 
@@ -455,6 +471,36 @@ describe('renderQuotePdf', () => {
     expect(summaryStream).toContain('Remaining balance');
     // The summary page must be its own page — none of the 25 line rows on it.
     expect(summaryStream).not.toContain('Item ');
+  });
+
+  it('never draws the summary into the bottom margin for the no-deposit, suppressed-row shape', async () => {
+    // The deposit+breakdown page-break test above proves the reservation for
+    // the TALLEST summary; this sweep guards the SHORTEST one (rollupRows = 1,
+    // no rule-separated deposit trio, no trailer row). The reservation and the
+    // drawn advances share named constants, so they can only drift apart if
+    // someone edits drawRow without them — in which case some line count in
+    // this sweep lands the final emphasis row below the bottom margin.
+    const blocks = [{ id: 'b1', blockType: 'line_items' as const, sortOrder: 0, content: {} }];
+    const BOTTOM_MARGIN = 50; // pdf y-coords are bottom-up: content must stay >= margin
+    for (let count = 20; count <= 32; count++) {
+      const lines = Array.from({ length: count }, (_, i) => ({
+        id: `l${i}`, blockId: 'b1', description: `Item ${i + 1}`,
+        quantity: '1', unitPrice: '10', lineTotal: '10.00', recurrence: 'one_time' as const,
+      }));
+      const buf = await renderQuotePdf(
+        {
+          id: 'q1', quoteNumber: `Q-SWEEP-${count}`,
+          oneTimeTotal: '1000.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00',
+          dueOnAcceptanceTotal: '1000.00', total: '1000.00', currencyCode: 'USD',
+        } as never,
+        blocks, lines, async () => null, {},
+      );
+      const due = extractPositionedPdfText(buf).filter((f) => f.text.includes('Due on acceptance'));
+      expect(due.length).toBeGreaterThan(0);
+      for (const f of due) {
+        expect(f.y, `count=${count}: emphasis row overflowed into the bottom margin`).toBeGreaterThanOrEqual(BOTTOM_MARGIN - 5);
+      }
+    }
   });
 
   it('renders a per-table Subtotal row only when the block opts in', async () => {

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -187,15 +187,19 @@ export function contractUploadedMarker(templateName: string): string {
 export interface QuotePdfColumns {
   left: number; right: number; contentWidth: number;
   colQtyX: number; colQtyW: number; colDescX: number; colDescW: number;
-  colUnitX: number; colTaxX: number; colNumW: number; colAmtX: number;
+  colUnitX: number; colTaxX: number; colNumW: number; colAmtX: number; colAmtW: number;
   colSummaryAmtX: number; colSummaryNumW: number;
   showTax: boolean;
 }
 
 // When showTax is set the table carries a fifth column (qty | description | unit
-// | tax | total) and uses 12.5%-wide money cells; the four-column layout can give
-// each money cell 14%. The summary gets a wider 17% amount box for its 14pt
-// emphasis figure while sharing TOTAL's right edge.
+// | tax | total) with 12.5%-wide money cells; the four-column layout gives each
+// money cell 14%. TOTAL gets its own wider box (16.5% / 17.5%) because it is the
+// one cell that renders money PLUS a recurrence suffix ("$12,000.00/mo") — sized
+// to colNumW it character-wraps, and the wrapped second line overprints the next
+// row (row height is measured from the description column only). The summary
+// gets a 19% amount box for its 14pt emphasis figure; both it and TOTAL share
+// the table's right edge so the amounts stay visually aligned.
 export function columnsFor(doc: PDFKit.PDFDocument, showTax = false): QuotePdfColumns {
   const left = doc.page.margins.left;
   const right = doc.page.width - doc.page.margins.right;
@@ -207,15 +211,14 @@ export function columnsFor(doc: PDFKit.PDFDocument, showTax = false): QuotePdfCo
       colQtyX: left,
       colQtyW: contentWidth * 0.07,
       colDescX,
-      colDescW: contentWidth * 0.52,
-      colUnitX: left + contentWidth * 0.605,
-      colTaxX: left + contentWidth * 0.735,
-      colAmtX: left + contentWidth * 0.875,
+      colDescW: contentWidth * 0.485,
+      colUnitX: left + contentWidth * 0.57,
+      colTaxX: left + contentWidth * 0.70,
+      colAmtX: left + contentWidth * 0.835,
       colNumW: contentWidth * 0.125,
-      // The 14pt emphasis figure needs more room than the 10pt table cells.
-      // It shares TOTAL's right edge, so the visual alignment remains intact.
-      colSummaryAmtX: left + contentWidth * 0.83,
-      colSummaryNumW: contentWidth * 0.17,
+      colAmtW: contentWidth * 0.165,
+      colSummaryAmtX: left + contentWidth * 0.81,
+      colSummaryNumW: contentWidth * 0.19,
     };
   }
   return {
@@ -223,13 +226,14 @@ export function columnsFor(doc: PDFKit.PDFDocument, showTax = false): QuotePdfCo
     colQtyX: left,
     colQtyW: contentWidth * 0.07,
     colDescX,
-    colDescW: contentWidth * 0.60,
-    colUnitX: left + contentWidth * 0.69,
-    colTaxX: left + contentWidth * 0.72, // unused when !showTax
-    colAmtX: left + contentWidth * 0.86,
+    colDescW: contentWidth * 0.57,
+    colUnitX: left + contentWidth * 0.66,
+    colTaxX: left + contentWidth * 0.70, // unused when !showTax
+    colAmtX: left + contentWidth * 0.825,
     colNumW: contentWidth * 0.14,
-    colSummaryAmtX: left + contentWidth * 0.83,
-    colSummaryNumW: contentWidth * 0.17,
+    colAmtW: contentWidth * 0.175,
+    colSummaryAmtX: left + contentWidth * 0.81,
+    colSummaryNumW: contentWidth * 0.19,
   };
 }
 
@@ -304,7 +308,7 @@ async function renderLineTable(
     doc.text('DESCRIPTION', c.colDescX, headerY, { width: c.colDescW, align: 'left' });
     doc.text('UNIT', c.colUnitX, headerY, { width: c.colNumW, align: 'right' });
     if (showTax) doc.text('TAX', c.colTaxX, headerY, { width: c.colNumW, align: 'right' });
-    doc.text('TOTAL', c.colAmtX, headerY, { width: c.colNumW, align: 'right' });
+    doc.text('TOTAL', c.colAmtX, headerY, { width: c.colAmtW, align: 'right' });
     return headerY + 24;
   };
   // Page-break helper that re-draws the column header on the fresh page (unlike
@@ -377,14 +381,17 @@ async function renderLineTable(
       doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica').text(blurb, descX + gutter, y + titleHeight + 2, { width: descW, lineGap: 1 });
       doc.fillColor('#1f2937').fontSize(10);
     }
-    doc.font('Helvetica').fontSize(10).text(formatMoney(l.unitPrice, currency), c.colUnitX, y, { width: c.colNumW, align: 'right' });
+    // lineBreak: false on every money cell — row height is measured from the
+    // description column only, so a wrapped amount would overprint the next
+    // row. An amount too wide for its box clips into the column gap instead.
+    doc.font('Helvetica').fontSize(10).text(formatMoney(l.unitPrice, currency), c.colUnitX, y, { width: c.colNumW, align: 'right', lineBreak: false });
     if (showTax) {
       const t = lineTax(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), !!l.taxable, taxRate);
-      doc.fillColor('#6b7280').text(t === null ? '—' : formatMoney(t, currency), c.colTaxX, y, { width: c.colNumW, align: 'right' });
+      doc.fillColor('#6b7280').text(t === null ? '—' : formatMoney(t, currency), c.colTaxX, y, { width: c.colNumW, align: 'right', lineBreak: false });
       doc.fillColor('#1f2937');
     }
     const suffix = recurrenceSuffix(l.recurrence);
-    doc.font('Helvetica').fontSize(10).text(`${formatMoney(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
+    doc.font('Helvetica').fontSize(10).text(`${formatMoney(l.lineTotal ?? Number(l.quantity) * Number(l.unitPrice), currency)}${suffix}`, c.colAmtX, y, { width: c.colAmtW, align: 'right', lineBreak: false });
     y += rowHeight + 6;
   }
 
@@ -461,7 +468,11 @@ function renderRecurringSummary(
   const showTaxRow = quote.taxTotal != null && Number(quote.taxTotal) > 0;
   const hasRecurring =
     Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
-  const sumX = c.left + c.contentWidth * 0.40;
+  // 0.36, not 0.40: the label box ends at colSummaryAmtX (0.81), and the widest
+  // label — "Remaining balance (due per terms)" at bold 12pt, ~200pt — needs the
+  // extra room. Rows advance by the fixed constants below, so a wrapped label
+  // overprints the next row exactly like a wrapped amount would.
+  const sumX = c.left + c.contentWidth * 0.36;
   const labelX = sumX;
   const labelW = c.colSummaryAmtX - sumX - 8;
   const categoryAmountX = c.colSummaryAmtX - 60;
@@ -530,7 +541,9 @@ function renderRecurringSummary(
     const strong = bold || emphasis;
     doc.font(strong ? 'Helvetica-Bold' : 'Helvetica').fontSize(emphasis ? 14 : strong ? 12 : 10).fillColor(strong ? '#111827' : '#6b7280');
     doc.text(label, labelX, y, { width: labelW, align: 'left' });
-    doc.fillColor(emphasis ? primary : strong ? '#111827' : '#1f2937').text(`${formatMoney(amount, currency)}${suffix}`, c.colSummaryAmtX, y, { width: c.colSummaryNumW, align: 'right' });
+    // lineBreak: false — the y advances below are fixed constants shared with
+    // the page-break reservation; a wrapped amount would silently break both.
+    doc.fillColor(emphasis ? primary : strong ? '#111827' : '#1f2937').text(`${formatMoney(amount, currency)}${suffix}`, c.colSummaryAmtX, y, { width: c.colSummaryNumW, align: 'right', lineBreak: false });
     y += emphasis ? EMPHASIS_ROW_ADVANCE : strong ? BOLD_ROW_ADVANCE : REGULAR_ROW_ADVANCE;
   };
 

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -184,43 +184,52 @@ export function contractUploadedMarker(templateName: string): string {
 // Computed once we have the document margins.
 // ---------------------------------------------------------------------------
 
-interface Cols {
+export interface QuotePdfColumns {
   left: number; right: number; contentWidth: number;
-  colQtyX: number; colDescX: number; colDescW: number; colUnitX: number; colTaxX: number; colNumW: number; colAmtX: number;
+  colQtyX: number; colQtyW: number; colDescX: number; colDescW: number;
+  colUnitX: number; colTaxX: number; colNumW: number; colAmtX: number;
+  colSummaryAmtX: number; colSummaryNumW: number;
   showTax: boolean;
 }
 
 // When showTax is set the table carries a fifth column (qty | description | unit
-// | tax | total) and the money columns narrow to fit; otherwise the original
-// four-column layout (qty | description | unit | total) is preserved so existing
-// tax-free quotes render byte-identically. The summary uses the same colAmtX so
-// its amounts stay aligned under TOTAL.
-function columnsFor(doc: PDFKit.PDFDocument, showTax = false): Cols {
+// | tax | total) and uses 12.5%-wide money cells; the four-column layout can give
+// each money cell 14%. The summary gets a wider 17% amount box for its 14pt
+// emphasis figure while sharing TOTAL's right edge.
+export function columnsFor(doc: PDFKit.PDFDocument, showTax = false): QuotePdfColumns {
   const left = doc.page.margins.left;
   const right = doc.page.width - doc.page.margins.right;
   const contentWidth = right - left;
-  const colDescX = left + contentWidth * 0.12;
+  const colDescX = left + contentWidth * 0.08;
   if (showTax) {
     return {
       left, right, contentWidth, showTax,
       colQtyX: left,
+      colQtyW: contentWidth * 0.07,
       colDescX,
-      colDescW: contentWidth * 0.36,
-      colUnitX: left + contentWidth * 0.50,
-      colTaxX: left + contentWidth * 0.67,
-      colAmtX: left + contentWidth * 0.84,
-      colNumW: contentWidth * 0.15,
+      colDescW: contentWidth * 0.52,
+      colUnitX: left + contentWidth * 0.605,
+      colTaxX: left + contentWidth * 0.735,
+      colAmtX: left + contentWidth * 0.875,
+      colNumW: contentWidth * 0.125,
+      // The 14pt emphasis figure needs more room than the 10pt table cells.
+      // It shares TOTAL's right edge, so the visual alignment remains intact.
+      colSummaryAmtX: left + contentWidth * 0.83,
+      colSummaryNumW: contentWidth * 0.17,
     };
   }
   return {
     left, right, contentWidth, showTax,
     colQtyX: left,
+    colQtyW: contentWidth * 0.07,
     colDescX,
-    colDescW: contentWidth * 0.46,
-    colUnitX: left + contentWidth * 0.60,
-    colTaxX: left + contentWidth * 0.70, // unused when !showTax
-    colAmtX: left + contentWidth * 0.80,
-    colNumW: contentWidth * 0.18,
+    colDescW: contentWidth * 0.60,
+    colUnitX: left + contentWidth * 0.69,
+    colTaxX: left + contentWidth * 0.72, // unused when !showTax
+    colAmtX: left + contentWidth * 0.86,
+    colNumW: contentWidth * 0.14,
+    colSummaryAmtX: left + contentWidth * 0.83,
+    colSummaryNumW: contentWidth * 0.17,
   };
 }
 
@@ -291,7 +300,7 @@ async function renderLineTable(
     doc.rect(c.left - 6, headerY - 5, c.contentWidth + 12, 22).fill('#f8fafc');
     doc.restore();
     doc.fillColor('#6b7280').fontSize(8.5).font('Helvetica-Bold');
-    doc.text('QTY', c.colQtyX, headerY, { width: c.contentWidth * 0.10, align: 'left' });
+    doc.text('QTY', c.colQtyX, headerY, { width: c.colQtyW, align: 'left' });
     doc.text('DESCRIPTION', c.colDescX, headerY, { width: c.colDescW, align: 'left' });
     doc.text('UNIT', c.colUnitX, headerY, { width: c.colNumW, align: 'right' });
     if (showTax) doc.text('TAX', c.colTaxX, headerY, { width: c.colNumW, align: 'right' });
@@ -351,7 +360,7 @@ async function renderLineTable(
     // so tall rows spilled past the bottom margin.)
     y = ensureRowSpace(y, rowHeight + 6);
     doc.fillColor('#1f2937').font('Helvetica').fontSize(10);
-    doc.text(String(Number(l.quantity)), c.colQtyX, y, { width: c.contentWidth * 0.10, align: 'left' });
+    doc.text(String(Number(l.quantity)), c.colQtyX, y, { width: c.colQtyW, align: 'left' });
     if (img) {
       // A buffer that loaded but pdfkit can't decode: skip the thumbnail (never
       // abort the document) but REPORT it — the pre-load loop above logs byte-level
@@ -395,12 +404,27 @@ async function renderLineTable(
     if (sums.monthly > 0) parts.push(`${formatMoney(sums.monthly, currency)}/mo`);
     if (sums.annual > 0) parts.push(`${formatMoney(sums.annual, currency)}/yr`);
     if (parts.length) {
-      y = ensureRowSpace(y, 24);
+      const subtotalText = parts.join('  +  ');
+      doc.font('Helvetica-Bold').fontSize(9.5);
+      const subtotalWidth = c.right - c.colUnitX;
+      const labelWidth = doc.widthOfString('Subtotal');
+      const inlineAmountWidth = subtotalWidth - labelWidth - 10;
+      const stackAmount = doc.widthOfString(subtotalText) > inlineAmountWidth;
+      const amountHeight = doc.heightOfString(subtotalText, { width: subtotalWidth, align: 'right' });
+      const subtotalHeight = 6 + (stackAmount ? 14 + amountHeight + 6 : Math.max(12, amountHeight) + 6);
+      y = ensureRowSpace(y, subtotalHeight);
       doc.moveTo(c.colUnitX, y).lineTo(c.right, y).lineWidth(0.5).strokeColor('#e5e7eb').stroke();
       y += 6;
       doc.font('Helvetica-Bold').fontSize(9.5).fillColor('#374151').text('Subtotal', c.colUnitX, y, { width: c.contentWidth * 0.2, align: 'left' });
-      doc.fillColor('#111827').text(parts.join('  +  '), c.colUnitX, y, { width: c.right - c.colUnitX, align: 'right' });
-      y += 18;
+      if (stackAmount) {
+        y += 14;
+        doc.fillColor('#111827').text(subtotalText, c.colUnitX, y, { width: subtotalWidth, align: 'right' });
+        y += amountHeight + 6;
+      } else {
+        const amountX = c.colUnitX + labelWidth + 10;
+        doc.fillColor('#111827').text(subtotalText, amountX, y, { width: c.right - amountX, align: 'right' });
+        y += Math.max(12, amountHeight) + 6;
+      }
     }
   }
   return y + 6;
@@ -417,46 +441,84 @@ async function renderLineTable(
 // amount.
 // ---------------------------------------------------------------------------
 
-function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, currency: string, primary: string, startY: number, showTax = false): number {
+function renderRecurringSummary(
+  doc: PDFKit.PDFDocument,
+  quote: QuoteHeader,
+  currency: string,
+  primary: string,
+  startY: number,
+  showTax = false,
+  recurringLines: { monthly: boolean; annual: boolean } = { monthly: false, annual: false },
+): number {
   const c = columnsFor(doc, showTax);
   // Hoisted above ensureSpace so the page-break reservation can size itself to
   // the actual content drawn below.
   const breakdown = quote.categoryBreakdown ?? [];
   const depositDue = quote.depositDueTotal ?? quote.depositAmount;
   const hasDeposit = quote.depositType && quote.depositType !== 'none' && depositDue != null;
-  // 90px covered the legacy footer. Category rows add 12px each (+4px gap) and a
-  // deposit adds the due-on-acceptance anchor row (18px) plus the bold remainder
-  // row (18px) — reserve for them, or ensureSpace won't break the page and the
-  // new rows draw past the bottom margin (pdfkit doesn't auto-paginate
-  // explicit-coordinate text). Stays 90 for a no-deposit, ≤1-category quote so
-  // those render exactly as before.
-  const needed = 90 + (breakdown.length > 1 ? breakdown.length * 12 + 4 : 0) + (hasDeposit ? 36 : 0);
+  const showMonthly = Number(quote.monthlyRecurringTotal ?? 0) !== 0 || recurringLines.monthly;
+  const showAnnual = Number(quote.annualRecurringTotal ?? 0) !== 0 || recurringLines.annual;
+  const showTaxRow = quote.taxTotal != null && Number(quote.taxTotal) > 0;
+  const hasRecurring =
+    Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+  const sumX = c.left + c.contentWidth * 0.40;
+  const labelX = sumX;
+  const labelW = c.colSummaryAmtX - sumX - 8;
+  const categoryAmountX = c.colSummaryAmtX - 60;
+  const categoryAmountW = c.right - categoryAmountX;
+  doc.font('Helvetica').fontSize(9);
+  const breakdownRows = breakdown.length > 1 ? breakdown.map((b) => {
+    const label = b.category === 'other' ? 'Other' : b.category[0]!.toUpperCase() + b.category.slice(1);
+    const parts: string[] = [];
+    if (Number(b.oneTimeTotal) > 0) parts.push(formatMoney(b.oneTimeTotal, currency));
+    if (Number(b.monthlyTotal) > 0) parts.push(`${formatMoney(b.monthlyTotal, currency)}/mo`);
+    if (Number(b.annualTotal) > 0) parts.push(`${formatMoney(b.annualTotal, currency)}/yr`);
+    const amount = parts.join(' + ');
+    const stacked = doc.widthOfString(amount) > categoryAmountW;
+    const amountHeight = stacked ? doc.heightOfString(amount, { width: c.right - sumX, align: 'right' }) : 0;
+    return { label, amount, stacked, amountHeight, height: stacked ? 12 + amountHeight + 5 : 14 };
+  }) : [];
+
+  // These advances are shared by the reservation and drawing code below. Keep
+  // the arithmetic literal and exact: explicit-coordinate pdfkit text does not
+  // auto-paginate, so under-reserving even one row can push the footer into the
+  // bottom margin.
+  const TOP_RULE_ADVANCE = 10;
+  const BREAKDOWN_GAP = 5;
+  const REGULAR_ROW_ADVANCE = 16;
+  const BOLD_ROW_ADVANCE = 20;
+  const EMPHASIS_ROW_ADVANCE = 22;
+  const EMPHASIS_RULE_ADVANCE = 13;
+  const rollupRows = 1 + Number(showMonthly) + Number(showAnnual) + Number(showTaxRow);
+  const breakdownHeight = breakdownRows.length ? breakdownRows.reduce((total, row) => total + row.height, 0) + BREAKDOWN_GAP : 0;
+  const emphasisHeight = hasDeposit
+    ? BOLD_ROW_ADVANCE + EMPHASIS_ROW_ADVANCE + BOLD_ROW_ADVANCE
+    : EMPHASIS_ROW_ADVANCE;
+  const needed = TOP_RULE_ADVANCE + breakdownHeight + rollupRows * REGULAR_ROW_ADVANCE +
+    EMPHASIS_RULE_ADVANCE + emphasisHeight + (hasRecurring ? REGULAR_ROW_ADVANCE : 0);
   let y = ensureSpace(doc, startY + 6, needed);
 
   // Wider label column than the line table's so the emphasised "Due on
   // acceptance" figure (14pt) and the recurring labels never wrap/overlap.
-  const sumX = c.left + c.contentWidth * 0.40;
   doc.moveTo(sumX, y).lineTo(c.right, y).lineWidth(1).strokeColor('#e5e7eb').stroke();
-  y += 8;
-
-  const labelX = sumX;
-  const labelW = c.colAmtX - sumX - 8;
+  y += TOP_RULE_ADVANCE;
 
   // Per-category subtotals (muted) — only worth showing when the quote spans more
   // than one category. Drawn above the One-time/Monthly/Annual roll-up.
-  if (breakdown.length > 1) {
-    for (const b of breakdown) {
-      const label = b.category === 'other' ? 'Other' : b.category[0]!.toUpperCase() + b.category.slice(1);
-      const parts: string[] = [];
-      if (Number(b.oneTimeTotal) > 0) parts.push(formatMoney(b.oneTimeTotal, currency));
-      if (Number(b.monthlyTotal) > 0) parts.push(`${formatMoney(b.monthlyTotal, currency)}/mo`);
-      if (Number(b.annualTotal) > 0) parts.push(`${formatMoney(b.annualTotal, currency)}/yr`);
+  if (breakdownRows.length) {
+    for (const row of breakdownRows) {
       doc.font('Helvetica').fontSize(9).fillColor('#9ca3af');
-      doc.text(label, labelX, y, { width: labelW, align: 'left' });
-      doc.text(parts.join(' + '), c.colAmtX - 60, y, { width: c.colNumW + 60, align: 'right' });
-      y += 12;
+      doc.text(row.label, labelX, y, { width: labelW, align: 'left' });
+      if (row.stacked) {
+        y += 12;
+        doc.text(row.amount, sumX, y, { width: c.right - sumX, align: 'right' });
+        y += row.amountHeight + 5;
+      } else {
+        doc.text(row.amount, categoryAmountX, y, { width: categoryAmountW, align: 'right' });
+        y += row.height;
+      }
     }
-    y += 4;
+    y += BREAKDOWN_GAP;
   }
   const drawRow = (
     label: string,
@@ -468,18 +530,21 @@ function renderRecurringSummary(doc: PDFKit.PDFDocument, quote: QuoteHeader, cur
     const strong = bold || emphasis;
     doc.font(strong ? 'Helvetica-Bold' : 'Helvetica').fontSize(emphasis ? 14 : strong ? 12 : 10).fillColor(strong ? '#111827' : '#6b7280');
     doc.text(label, labelX, y, { width: labelW, align: 'left' });
-    doc.fillColor(emphasis ? primary : strong ? '#111827' : '#1f2937').text(`${formatMoney(amount, currency)}${suffix}`, c.colAmtX, y, { width: c.colNumW, align: 'right' });
-    y += emphasis ? 20 : strong ? 18 : 14;
+    doc.fillColor(emphasis ? primary : strong ? '#111827' : '#1f2937').text(`${formatMoney(amount, currency)}${suffix}`, c.colSummaryAmtX, y, { width: c.colSummaryNumW, align: 'right' });
+    y += emphasis ? EMPHASIS_ROW_ADVANCE : strong ? BOLD_ROW_ADVANCE : REGULAR_ROW_ADVANCE;
   };
 
   drawRow('One-time', quote.oneTimeTotal, '');
-  drawRow('Monthly', quote.monthlyRecurringTotal, '/mo');
-  drawRow('Annual', quote.annualRecurringTotal, '/yr');
-  if (quote.taxTotal != null && Number(quote.taxTotal) > 0) {
+  if (showMonthly) drawRow('Monthly', quote.monthlyRecurringTotal, '/mo');
+  if (showAnnual) drawRow('Annual', quote.annualRecurringTotal, '/yr');
+  if (showTaxRow) {
     drawRow(`Tax${quote.taxRate ? ` (${(Number(quote.taxRate) * 100).toFixed(2)}%)` : ''}`, quote.taxTotal, '');
   }
-  const hasRecurring =
-    Number(quote.monthlyRecurringTotal ?? 0) > 0 || Number(quote.annualRecurringTotal ?? 0) > 0;
+  // Separate the roll-up from the amount the customer pays now. The 4pt top
+  // padding and 9pt bottom padding are included in EMPHASIS_RULE_ADVANCE.
+  y += 4;
+  doc.moveTo(sumX, y).lineTo(c.right, y).lineWidth(0.5).strokeColor('#e5e7eb').stroke();
+  y += 9;
   // Accent primary figure = what the customer pays NOW. With a deposit, the
   // emphasised figure is the deposit due — anchored by an explicit "Due on
   // acceptance" row above it so the three figures visibly sum (due = deposit +
@@ -514,7 +579,7 @@ async function renderCoverPage(
   quote: QuoteHeader,
   branding: QuotePdfBranding,
   loadImage: (imageId: string) => Promise<{ data: Buffer } | null>,
-  c: Cols,
+  c: QuotePdfColumns,
 ): Promise<void> {
   const cp = (quote.coverPage ?? null) as CoverPage | null;
   if (!cp?.enabled) return;
@@ -653,28 +718,35 @@ export async function renderQuotePdf(
 
   doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('FROM', c.left, y);
   doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? partnerName, c.left, y + 12, { width: c.contentWidth * 0.5 });
-  let fromY = y + 28;
+  let fromY = doc.y + 2;
   doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
-  for (const aline of sellerAddressLines(seller)) { doc.text(aline, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 13; }
+  for (const aline of sellerAddressLines(seller)) {
+    doc.text(aline, c.left, fromY, { width: c.contentWidth * 0.5 });
+    fromY = doc.y + 1.5;
+  }
   doc.fillColor('#6b7280').fontSize(9);
-  if (seller?.phone) { doc.text(seller.phone, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
-  if (seller?.email) { doc.text(seller.email, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
-  if (seller?.website) { doc.text(seller.website, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY += 12; }
+  if (seller?.phone) { doc.text(seller.phone, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY = doc.y + 1.5; }
+  if (seller?.email) { doc.text(seller.email, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY = doc.y + 1.5; }
+  if (seller?.website) { doc.text(seller.website, c.left, fromY, { width: c.contentWidth * 0.5 }); fromY = doc.y + 1.5; }
 
   let billY = y;
   if (quote.billToName) {
     doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED FOR', rightX, billY, { width: rightW });
     doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(quote.billToName, rightX, billY + 12, { width: rightW });
-    billY += 28;
+    billY = doc.y + 2;
   }
   doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
-  for (const aline of addressLines(quote.billToAddress as BillToAddress | null)) { doc.text(aline, rightX, billY, { width: rightW }); billY += 13; }
-  if (quote.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${quote.billToTaxId}`, rightX, billY, { width: rightW }); billY += 13; }
+  for (const aline of addressLines(quote.billToAddress as BillToAddress | null)) {
+    doc.text(aline, rightX, billY, { width: rightW });
+    billY = doc.y + 1.5;
+  }
+  if (quote.billToTaxId) { doc.fillColor('#6b7280').fontSize(9).text(`Tax ID: ${quote.billToTaxId}`, rightX, billY, { width: rightW }); billY = doc.y + 1.5; }
   doc.fillColor('#4b5563').fontSize(10).font('Helvetica');
-  if (quote.issueDate) { doc.text(`Issued: ${formatDate(quote.issueDate)}`, rightX, billY, { width: rightW }); billY += 14; }
-  if (quote.expiryDate) { doc.text(`Valid until: ${formatDate(quote.expiryDate)}`, rightX, billY, { width: rightW }); billY += 14; }
+  if (quote.issueDate) { doc.text(`Issued: ${formatDate(quote.issueDate)}`, rightX, billY, { width: rightW }); billY = doc.y + 2; }
+  if (quote.expiryDate) { doc.text(`Valid until: ${formatDate(quote.expiryDate)}`, rightX, billY, { width: rightW }); billY = doc.y + 2; }
 
-  y = Math.max(fromY, billY) + 20;
+  y = Math.max(fromY, billY) + 28;
+  doc.y = y;
 
   // Intro notes, if any (above the blocks).
   if (quote.introNotes) {
@@ -788,7 +860,10 @@ export async function renderQuotePdf(
   if (orphanLines.length) y = await renderLineTable(doc, orphanLines, currency, y, loadCatalogImage, loadImage, taxRate, showTax);
 
   // ---- Recurring summary footer -------------------------------------------
-  y = renderRecurringSummary(doc, quote, currency, primary, y, showTax);
+  y = renderRecurringSummary(doc, quote, currency, primary, y, showTax, {
+    monthly: lines.some((line) => line.recurrence === 'monthly'),
+    annual: lines.some((line) => line.recurrence === 'annual'),
+  });
 
   // ---- Terms & Conditions --------------------------------------------------
   if (quote.termsAndConditions) {

--- a/apps/api/src/services/richTextPdf.test.ts
+++ b/apps/api/src/services/richTextPdf.test.ts
@@ -64,6 +64,23 @@ describe('renderRichTextIntoPdf', () => {
     };
   }
 
+  it('honors startY when pdfkit\'s cursor was left higher by a side-by-side column', () => {
+    // Regression: quotePdf tracks the bottom of two identity columns separately.
+    // If the right column was drawn last but the left column was taller, doc.y
+    // could be above the explicit startY. The renderer must not jump back to
+    // that stale cursor and draw the first paragraph over the identity block.
+    const doc = new PDFDocument({ size: 'A4', margin: 50 });
+    doc.y = 140;
+    const after = renderRichTextIntoPdf(doc, '<p>First proposal paragraph.</p>', {
+      x: 50,
+      width: 495,
+      startY: 320,
+      ensureRoom: makeEnsureRoom(doc),
+    });
+
+    expect(after).toBeGreaterThan(320);
+  });
+
   it('spaces consecutive blocks apart instead of drawing them flush against each other', () => {
     // Regression: an earlier version of this renderer computed each block's
     // trailing gap into a local variable that was never actually reserved via
@@ -84,6 +101,7 @@ describe('renderRichTextIntoPdf', () => {
     // Two blocks drawn: the gap between them must show up in the total advance —
     // i.e. the cursor moves by strictly more than 2x the bare per-line text height.
     expect(after - before).toBeGreaterThan(bareTextHeight * 2);
+    expect(after - before - bareTextHeight * 2).toBeGreaterThanOrEqual(5.5);
   });
 
   // Render into an UNCOMPRESSED pdfkit doc and return the raw bytes, so tests can

--- a/apps/api/src/services/richTextPdf.ts
+++ b/apps/api/src/services/richTextPdf.ts
@@ -302,6 +302,10 @@ export interface RenderRichTextOpts {
  *  trailing spacing), for the caller to continue drawing from. */
 export function renderRichTextIntoPdf(doc: PDFKit.PDFDocument, html: string, opts: RenderRichTextOpts): number {
   const blocks = parseRichText(html);
+  // Side-by-side callers can legitimately leave pdfkit's implicit cursor at the
+  // bottom of the column drawn last rather than the lower of both columns.
+  // startY is the public contract; synchronize doc.y before ensureRoom reads it.
+  doc.y = opts.startY;
   let y = opts.startY;
   // The gap BEFORE the upcoming block (0 for the first block; each subsequent
   // block's leading gap is the PREVIOUS block's spacingAfter). Tracked explicitly

--- a/apps/portal/src/components/portal/quoteBlocks.tsx
+++ b/apps/portal/src/components/portal/quoteBlocks.tsx
@@ -84,7 +84,7 @@ function PricingTable({
         <table className="w-full min-w-[30rem] text-sm">
           <thead>
             <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
-              <th className="px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
+              <th className="w-full px-4 py-2.5 text-left font-medium sm:px-5">Description</th>
               <th className="px-2 py-2.5 text-right font-medium">Qty</th>
               <th className="px-2 py-2.5 text-right font-medium">Unit price</th>
               {showTax && <th className="px-2 py-2.5 text-right font-medium">Tax</th>}
@@ -105,7 +105,7 @@ function PricingTable({
                   const tax = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
                   return (
                   <tr key={l.id} data-testid={`quote-line-${l.id}`} className="border-b align-top last:border-0">
-                    <td className="px-4 py-3 text-foreground sm:px-5">
+                    <td className="w-full px-4 py-3 text-foreground sm:px-5">
                       <div className="flex items-start gap-2.5">
                         {l.imageUrl && (
                           // A line whose catalog item happens to have no image

--- a/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteBlockCard.tsx
@@ -464,26 +464,21 @@ export function BlockCard({
                 the per-line Total — the most-checked figure on a quote — is always
                 visible without sideways scrolling at desktop widths. Billing cadence
                 rides in the Price cell; Taxable moved to each line's controls row;
-                per-line tax renders as a sub-line under the Total. The wrapper still
-                scrolls on genuinely narrow screens (phone), without a sticky column.
-                max-h + overflow-y-auto (in addition to the existing overflow-x-auto)
-                makes THIS div the sticky containing block for the header cells below —
-                position:sticky on a descendant binds to its nearest scroll-container
-                ancestor, and an unbounded overflow-x-auto div never actually scrolls
-                vertically, so a plain `sticky top-0` inside it is inert (verified: the
-                header just scrolls off with the rows). Bounding the height is what
-                makes the header cells' sticky top-0 do anything at all. The cap is
-                generous (70vh) so short blocks never show an inner scrollbar — it only
-                engages once a section has enough rows to need a pinned header. */}
-            <div className="max-h-[70vh] overflow-x-auto overflow-y-auto rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring" role="region" aria-label={t('quotes.editor.table.scrollAria')} tabIndex={0}>
+                per-line tax renders as a sub-line under the Total. The wrapper only
+                scrolls HORIZONTALLY on genuinely narrow screens (phone) — the page is
+                the editor's single vertical scroller. An earlier design capped this
+                div at max-h-[70vh] to make sticky header cells work, but a vertical
+                scrollport per pricing block made the editor read as nested boxes of
+                scrollbars, so the block now grows to its content instead. */}
+            <div className="overflow-x-auto rounded-md focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring" role="region" aria-label={t('quotes.editor.table.scrollAria')} tabIndex={0}>
             <table className="w-full min-w-[36rem] text-sm" data-testid={`quote-block-lines-${block.id}`}>
               <thead>
                 <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
-                  <th className="sticky top-0 z-10 min-w-[12rem] bg-card px-1.5 py-2 font-medium">{t('quotes.editor.table.item')}</th>
-                  <th className="sticky top-0 z-10 bg-card px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.qty')}</th>
-                  <th className="sticky top-0 z-10 bg-card px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.unitPrice')}</th>
-                  <th className="sticky top-0 z-10 bg-card px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.total')}</th>
-                  {canWrite && <th className="sticky top-0 z-10 bg-card px-1.5 py-2" />}
+                  <th className="min-w-[12rem] px-1.5 py-2 font-medium">{t('quotes.editor.table.item')}</th>
+                  <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.qty')}</th>
+                  <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.unitPrice')}</th>
+                  <th className="px-1.5 py-2 text-right font-medium">{t('quotes.editor.table.total')}</th>
+                  {canWrite && <th className="px-1.5 py-2" />}
                 </tr>
               </thead>
               <tbody>

--- a/apps/web/src/components/billing/quotes/QuoteDocument.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteDocument.tsx
@@ -153,7 +153,7 @@ function PricingTable({ lines, quoteId, currency, label, taxRate, showTax, showS
         <table className="w-full min-w-[30rem] text-sm">
           <thead>
             <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
-              <th className="px-4 py-2.5 text-left font-medium sm:px-5">{t('quotes.document.table.description')}</th>
+              <th className="w-full px-4 py-2.5 text-left font-medium sm:px-5">{t('quotes.document.table.description')}</th>
               <th className="px-2 py-2.5 text-right font-medium">{t('quotes.document.table.qty')}</th>
               <th className="px-2 py-2.5 text-right font-medium">{t('quotes.document.table.unitPrice')}</th>
               {showTax && <th className="px-2 py-2.5 text-right font-medium">{t('quotes.document.table.tax')}</th>}
@@ -167,7 +167,7 @@ function PricingTable({ lines, quoteId, currency, label, taxRate, showTax, showS
               const tax = showTax ? lineTaxAmount(l.lineTotal, l.taxable, taxRate) : null;
               return (
                 <tr key={l.id} className="border-b align-top last:border-0">
-                  <td className="px-4 py-3 text-foreground sm:px-5">
+                  <td className="w-full px-4 py-3 text-foreground sm:px-5">
                     <div className="flex items-start gap-2.5">
                       {(l.imageId || l.catalogItemId) && (
                         <DocLineThumb path={l.imageId ? quoteImageUrl(quoteId, l.imageId) : catalogItemImagePath(l.catalogItemId!)} />

--- a/apps/web/src/components/billing/quotes/QuoteEditor.polish.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.polish.test.tsx
@@ -124,6 +124,11 @@ describe('QuoteEditor — per-block table has no vertical scrollport', () => {
     expect(wrapper.className).toMatch(/\boverflow-x-auto\b/);
     expect(wrapper.className).not.toMatch(/\bmax-h-/);
     expect(wrapper.className).not.toMatch(/\boverflow-y-auto\b/);
+    // The wrapper is still a HORIZONTAL scroll region on narrow screens, so it
+    // must keep its keyboard/AT affordances.
+    expect(wrapper).toHaveAttribute('role', 'region');
+    expect(wrapper).toHaveAttribute('aria-label');
+    expect(wrapper).toHaveAttribute('tabindex', '0');
 
     const headerCells = table.querySelectorAll('thead th');
     expect(headerCells.length).toBeGreaterThan(0);

--- a/apps/web/src/components/billing/quotes/QuoteEditor.polish.test.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteEditor.polish.test.tsx
@@ -107,20 +107,28 @@ describe('QuoteEditor — ADD SECTION heading-text gating', () => {
   });
 });
 
-describe('QuoteEditor — sticky per-block column headers', () => {
+describe('QuoteEditor — per-block table has no vertical scrollport', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('pins the header row (sticky + solid background) above the scrolling rows', async () => {
+  // The page is the editor's single vertical scroller: an earlier design
+  // capped each block's table wrapper at max-h-[70vh] (to make sticky header
+  // cells engage), but a scrollport per pricing block made the editor read as
+  // nested boxes of scrollbars. The wrapper may still scroll horizontally on
+  // narrow screens.
+  it('lets the block grow to its content (no max-h / overflow-y cap, no sticky header cells)', async () => {
     render(<QuoteEditor detail={onePricingBlock} onChanged={vi.fn()} />);
     await waitFor(() => expect(screen.getByTestId('quote-block-lines-blk-1')).toBeInTheDocument());
 
     const table = screen.getByTestId('quote-block-lines-blk-1');
+    const wrapper = table.parentElement as HTMLElement;
+    expect(wrapper.className).toMatch(/\boverflow-x-auto\b/);
+    expect(wrapper.className).not.toMatch(/\bmax-h-/);
+    expect(wrapper.className).not.toMatch(/\boverflow-y-auto\b/);
+
     const headerCells = table.querySelectorAll('thead th');
     expect(headerCells.length).toBeGreaterThan(0);
     headerCells.forEach((th) => {
-      expect(th.className).toMatch(/\bsticky\b/);
-      expect(th.className).toMatch(/\btop-0\b/);
-      expect(th.className).toMatch(/\bbg-card\b/);
+      expect(th.className).not.toMatch(/\bsticky\b/);
     });
   });
 });

--- a/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
+++ b/apps/web/src/components/billing/quotes/QuoteHeaderMeta.tsx
@@ -5,11 +5,12 @@
 //                           amber/green save language as every other field).
 //                           Rendered into DocumentWorkspace's titleSlot.
 //   QuoteCustomerSwitcher — the customer (organization) selector, rendered
-//                           into DocumentWorkspace's metaSlot on its OWN line
-//                           under the title. It used to sit inline between the
-//                           title and the status pill, which squeezed the
-//                           title and left the select floating mis-aligned in
-//                           the header row.
+//                           into DocumentWorkspace's metaSlot: inline AFTER the
+//                           title + status pill, wrapping to its own line when
+//                           the header row runs out of width. (An early design
+//                           put it BETWEEN the title and the pill, which
+//                           squeezed the title — after-the-pill + wrap avoids
+//                           that while keeping the pinned header one row.)
 //
 // Non-draft quotes keep the plain read-only h1 and no switcher. Each piece
 // reports its own pending state; QuoteWorkspace ORs them into the Send gate.
@@ -107,7 +108,7 @@ export function QuoteHeaderMeta({ detail, onChanged, onPendingChange, onUnsavedC
           onBlur={() => void saveTitle()}
           disabled={titleBusy}
           data-testid="quote-title"
-          className={`w-full rounded-md border bg-transparent px-2 py-0.5 text-xl font-semibold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(titleDirty, titleSaved))}`}
+          className={`w-full rounded-md border bg-transparent px-2 py-0.5 text-lg font-semibold transition-colors focus:outline-hidden disabled:opacity-60 ${seamless(fieldRing(titleDirty, titleSaved))}`}
         />
       </div>
       <SrSaved show={titleSaved} testId="quote-title-saved" />

--- a/apps/web/src/components/billing/shared/DocumentWorkspace.test.tsx
+++ b/apps/web/src/components/billing/shared/DocumentWorkspace.test.tsx
@@ -98,16 +98,18 @@ describe('DocumentWorkspace', () => {
     expect(h1).toHaveClass('sr-only');
   });
 
-  it('renders metaSlot below the title row', () => {
+  it('renders metaSlot inline in the header row, after the title cluster', () => {
     renderWs({
       titleSlot: <input data-testid="title-input" defaultValue="THING-1" />,
       metaSlot: <span data-testid="meta-slot">Customer: Acme</span>,
     });
     const meta = screen.getByTestId('meta-slot');
-    expect(meta).toBeInTheDocument();
-    // Below the title row, not inside it — the switcher used to sit inline and
-    // squeeze the title.
-    expect(screen.getByTestId('title-input').compareDocumentPosition(meta))
+    const titleInput = screen.getByTestId('title-input');
+    // Inline after the title + pill cluster, in the same wrapping flex row —
+    // NOT inside the title cluster (where it would squeeze the title) and NOT
+    // on a separate dedicated line (the header must stay one row when wide).
+    expect(meta.parentElement).toBe(titleInput.parentElement!.parentElement);
+    expect(titleInput.parentElement!.compareDocumentPosition(meta))
       .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 

--- a/apps/web/src/components/billing/shared/DocumentWorkspace.tsx
+++ b/apps/web/src/components/billing/shared/DocumentWorkspace.tsx
@@ -20,9 +20,9 @@ export interface DocumentWorkspaceProps {
    *  workspace's editable title input for drafts). The `title` string is still
    *  required as the fallback/document identity. */
   titleSlot?: ReactNode;
-  /** Rendered on its own line directly under the title row (e.g. the quote
-   *  workspace's customer switcher) — metadata that belongs with the document
-   *  identity but must not squeeze the title or the status pill. */
+  /** Rendered inline after the title + status pill (e.g. the quote workspace's
+   *  customer switcher), wrapping onto its own line when the row runs out of
+   *  width — keeps the pinned header to a single row on wide screens. */
   metaSlot?: ReactNode;
   statusPill?: ReactNode;
   actions?: ReactNode;
@@ -109,19 +109,20 @@ export function DocumentWorkspace({
           of scrolled content show through above it. -top-4/-top-6 pin the bar
           flush with main's true top edge; its own pt re-covers the zone. */}
       <div className="sticky -top-4 z-20 -mx-4 -mt-4 bg-background px-4 pt-4 md:-top-6 md:-mx-6 md:-mt-6 md:px-6 md:pt-6">
-        {/* Back link on its own line, THEN title + actions as one row: the
-            actions cluster aligns with the title it acts on, not with the tiny
-            back link above it. */}
-        <a
-          href={backHref}
-          aria-label={t('shared.documentWorkspace.backAria', { label: backLabel.toLowerCase() })}
-          className="text-xs text-muted-foreground hover:underline"
-        >
-          <span aria-hidden="true">←</span> {backLabel}
-        </a>
-        <div className="mt-1 flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 min-w-0">
+        {/* One compact row: back link, title (+ status pill), inline meta and
+            the actions cluster all share it, wrapping on narrow screens. The
+            header is pinned, so every vertical pixel here is stolen from the
+            working canvas below — keep it short. */}
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+            <a
+              href={backHref}
+              aria-label={t('shared.documentWorkspace.backAria', { label: backLabel.toLowerCase() })}
+              className="shrink-0 text-xs text-muted-foreground hover:underline"
+            >
+              <span aria-hidden="true">←</span> {backLabel}
+            </a>
+            <div className="flex min-w-0 flex-1 items-center gap-2">
               {titleSlot ? (
                 <>
                   {/* The slot replaces the VISUAL heading (e.g. with an editable
@@ -132,7 +133,7 @@ export function DocumentWorkspace({
                   {titleSlot}
                 </>
               ) : (
-                <h1 className="truncate text-xl font-semibold" data-testid={`${idPrefix}-workspace-title`}>
+                <h1 className="truncate text-lg font-semibold" data-testid={`${idPrefix}-workspace-title`}>
                   {title}
                 </h1>
               )}
@@ -149,7 +150,7 @@ export function DocumentWorkspace({
 
         {/* Tabs */}
         <div
-          className="mt-4 flex gap-1 border-b"
+          className="mt-2 flex gap-1 border-b"
           role="tablist"
           data-testid={`${idPrefix}-workspace-tabs`}
           onKeyDown={onTabKeyDown}
@@ -165,7 +166,7 @@ export function DocumentWorkspace({
               tabIndex={activeTab === t.id ? 0 : -1}
               onClick={() => onTabChange(t.id)}
               data-testid={`${idPrefix}-tab-${t.id}`}
-              className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition ${
+              className={`-mb-px border-b-2 px-3 py-1.5 text-sm font-medium transition ${
                 activeTab === t.id
                   ? 'border-primary text-foreground'
                   : 'border-transparent text-muted-foreground hover:text-foreground'

--- a/apps/web/src/locales/de-DE/billing.json
+++ b/apps/web/src/locales/de-DE/billing.json
@@ -721,7 +721,7 @@
         "notTaxable": "Nicht steuerpflichtig",
         "qty": "Menge",
         "recurrence": "Abrechnung",
-        "scrollAria": "Preistabelle – scrollen Sie auf schmalen Bildschirmen seitwärts für Gesamtsummen und Zeilenaktionen; bei langen Abschnitten scrollt sie vertikal mit fixierter Kopfzeile",
+        "scrollAria": "Preistabelle – scrollen Sie auf schmalen Bildschirmen seitwärts für Gesamtsummen und Zeilenaktionen",
         "showSubtotal": "Zwischensummenzeile anzeigen",
         "tax": "Steuer",
         "taxSuffix": "+ {{amount}} Steuer",

--- a/apps/web/src/locales/en/billing.json
+++ b/apps/web/src/locales/en/billing.json
@@ -721,7 +721,7 @@
         "notTaxable": "Not taxable",
         "qty": "Qty",
         "recurrence": "Billing",
-        "scrollAria": "Pricing table — scrolls sideways on narrow screens for totals and row actions, and vertically (with the header pinned) once a section grows long",
+        "scrollAria": "Pricing table — scrolls sideways on narrow screens for totals and row actions",
         "showSubtotal": "Show subtotal row",
         "tax": "Tax",
         "taxSuffix": "+ {{amount}} tax",

--- a/apps/web/src/locales/es-419/billing.json
+++ b/apps/web/src/locales/es-419/billing.json
@@ -721,7 +721,7 @@
         "notTaxable": "No sujeto a impuestos",
         "qty": "Cantidad",
         "recurrence": "Facturación",
-        "scrollAria": "Tabla de precios: desplácese hacia los lados en pantallas angostas para ver totales y acciones de fila; en secciones largas, se desplaza verticalmente con el encabezado fijo",
+        "scrollAria": "Tabla de precios: desplácese hacia los lados en pantallas angostas para ver totales y acciones de fila",
         "showSubtotal": "Mostrar fila de subtotal",
         "tax": "Impuesto",
         "taxSuffix": "+ {{amount}} de impuesto",

--- a/apps/web/src/locales/fr-FR/billing.json
+++ b/apps/web/src/locales/fr-FR/billing.json
@@ -721,7 +721,7 @@
         "notTaxable": "Non taxable",
         "qty": "Qté",
         "recurrence": "Facturation",
-        "scrollAria": "Tableau de prix — faites défiler horizontalement sur écrans étroits pour les totaux et les actions de ligne ; pour les sections longues, défilement vertical avec l'en-tête fixe",
+        "scrollAria": "Tableau de prix — faites défiler horizontalement sur écrans étroits pour les totaux et les actions de ligne",
         "showSubtotal": "Afficher la ligne de sous-total",
         "tax": "Taxe",
         "taxSuffix": "+ {{amount}} de taxe",

--- a/apps/web/src/locales/pt-BR/billing.json
+++ b/apps/web/src/locales/pt-BR/billing.json
@@ -721,7 +721,7 @@
         "notTaxable": "Não tributável",
         "qty": "Qtd.",
         "recurrence": "Cobrança",
-        "scrollAria": "Tabela de preços — role lateralmente em telas estreitas para ver totais e ações da linha; em seções longas, role verticalmente com o cabeçalho fixo",
+        "scrollAria": "Tabela de preços — role lateralmente em telas estreitas para ver totais e ações da linha",
         "showSubtotal": "Mostrar linha de subtotal",
         "tax": "Imposto",
         "taxSuffix": "+ {{amount}} de imposto",


### PR DESCRIPTION
## Summary

Cleanup pass on quote PDF rendering, the web/portal previews, and the quote editor chrome.

### PDF (`quotePdf.ts` / `richTextPdf.ts`)
- Widen the line-table DESCRIPTION column (0.36 → 0.52 of content width with tax, 0.46 → 0.60 without); money columns are sized to fit `$888,888.88` with slack, and the TOTAL cell gets its own wider box since it renders money **plus** a recurrence suffix — `"$12,000.00/mo"` used to character-wrap and overprint the next row (row height is measured from the description column only). All money cells now draw with `lineBreak:false` so pathological amounts clip instead of stacking.
- Fix intro/rich-text overlapping FROM / PREPARED FOR: the identity columns advanced by fixed increments that under-counted wrapped address lines. Both columns now track pdfkit's real cursor, and `renderRichTextIntoPdf` honors `startY` instead of a stale `doc.y` left by side-by-side columns.
- Totals block: suppress zero Monthly/Annual rows on quotes with no recurring lines, widen the amount box so a 14pt `$1,000,000.00` fits, move the block's left edge (0.40 → 0.36) so the widest label ("Remaining balance (due per terms)") no longer wraps into the row below, and derive the page-break reservation from the exact rows drawn.

### Preview + portal parity (`QuoteDocument.tsx` / `quoteBlocks.tsx`)
- DESCRIPTION cells take `w-full` so table auto-layout hands slack width to the description instead of spreading it across the numeric columns.

### Editor chrome (`DocumentWorkspace.tsx` / `QuoteHeaderMeta.tsx` / `QuoteBlockCard.tsx`)
- Collapse the pinned header to one wrapping row (back link, title, status pill, customer switcher, actions) with a tighter tablist.
- Remove the per-block `max-h-[70vh]` scrollport and its sticky header cells: blocks grow to content and the page is the single vertical scroller; horizontal overflow on narrow screens is preserved.
- Trim the now-stale vertical-scroll clause from `quotes.editor.table.scrollAria` in en/de-DE/es-419/fr-FR/pt-BR (fr-CA/it-IT were already correct).

## Tests
- Geometry tests pin the money-column widths (measuring the suffixed TOTAL string at the row's real font), the summary box width/left edge, and a line-count sweep proving the no-deposit, suppressed-row summary shape never draws into the bottom margin.
- `renderRichTextIntoPdf` startY behavior covered in `richTextPdf.test.ts`.
- `DocumentWorkspace` metaSlot test rewritten to assert the new inline-after-pill contract (it was green-lighting the old layout) and that the pricing-table wrapper keeps its role/aria-label/tabindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)