### PR TITLE
fix(api): stop redactLogFields dropping (and reprototyping on) __proto__ (#3129)

### DIFF
--- a/apps/api/src/services/logRedaction.test.ts
+++ b/apps/api/src/services/logRedaction.test.ts
@@ -36,6 +36,51 @@ describe('log redaction', () => {
     );
   });
 
+  // #3129. Plain assignment to the literal key `__proto__` hits the setter
+  // inherited from Object.prototype, so the field silently disappears from the
+  // output — and when the value is an object, the returned object's prototype is
+  // replaced with it. These assert the field survives AND the prototype does not
+  // move, because a fix that only restored the key could still reprototype.
+  describe('__proto__ handling (#3129)', () => {
+    it('preserves a __proto__ subtree instead of dropping it', () => {
+      const out = redactLogFields(JSON.parse('{"__proto__":{"inner":"kept"},"other":1}')) as Record<string, unknown>;
+
+      expect(Object.prototype.hasOwnProperty.call(out, '__proto__')).toBe(true);
+      expect(Object.keys(out)).toContain('__proto__');
+      expect((out as any).__proto__).toEqual({ inner: 'kept' });
+      expect(out.other).toBe(1);
+    });
+
+    it('does not let a __proto__ value reprototype the redacted object', () => {
+      const out = redactLogFields(JSON.parse('{"__proto__":{"polluted":"yes"}}')) as Record<string, unknown>;
+
+      expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+      // The value must be readable as data, never inherited behaviour.
+      expect(({} as any).polluted).toBeUndefined();
+    });
+
+    it('preserves a primitive __proto__ value, which the setter discards outright', () => {
+      const out = redactLogFields(JSON.parse('{"__proto__":"just-a-string"}')) as Record<string, unknown>;
+
+      expect((out as any).__proto__).toBe('just-a-string');
+      expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    });
+
+    it('still redacts a secret-named key nested under __proto__', () => {
+      const out = redactLogFields(JSON.parse('{"__proto__":{"password":"hunter2"}}')) as Record<string, unknown>;
+
+      expect((out as any).__proto__).toEqual({ password: '[REDACTED]' });
+    });
+
+    it('survives JSON round-trip with the key intact', () => {
+      const out = redactLogFields(JSON.parse('{"__proto__":{"inner":"kept"}}'));
+      const round = JSON.parse(JSON.stringify(out));
+
+      expect(Object.prototype.hasOwnProperty.call(round, '__proto__')).toBe(true);
+      expect(round.__proto__).toEqual({ inner: 'kept' });
+    });
+  });
+
   it('redacts row messages and fields defensively before returning logs', () => {
     expect(redactAgentLogRow({
       id: 'log-1',

--- a/apps/api/src/services/logRedaction.ts
+++ b/apps/api/src/services/logRedaction.ts
@@ -39,7 +39,29 @@ export function redactLogFields(value: unknown, depth = 0): unknown {
 
   const redacted: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    redacted[key] = isSecretKey(key) ? REDACTED : redactLogFields(entry, depth + 1);
+    const redactedEntry = isSecretKey(key) ? REDACTED : redactLogFields(entry, depth + 1);
+
+    // `redacted[key] = …` for the literal key `__proto__` does NOT create an own
+    // property — it invokes the setter inherited from Object.prototype (#3129):
+    //   * object value    -> the key vanishes from the output AND the returned
+    //                        object's prototype is silently replaced, so it
+    //                        inherits whatever the agent sent.
+    //   * primitive value -> the key vanishes, silently.
+    // Either way the field is lost from redacted logs; the object case also
+    // reprototypes an object built from untrusted input. defineProperty writes a
+    // real own property and leaves the prototype alone, so the field survives
+    // under its true name and JSON.stringify round-trips it unchanged.
+    if (key === '__proto__') {
+      Object.defineProperty(redacted, key, {
+        value: redactedEntry,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+      continue;
+    }
+
+    redacted[key] = redactedEntry;
   }
   return redacted;
 }


### PR DESCRIPTION
Closes #3129.

## One correction to the issue's framing

The issue says "not a security hole (dropping is fail-safe against prototype pollution)". That holds for a **primitive** value. For an **object** value it does not — verified under node 22.23.2:

```js
const o = {};
o['__proto__'] = { leaked: 'value' };
Object.keys(o)                                  // []            <- key gone
Object.getPrototypeOf(o) !== Object.prototype   // true          <- prototype REPLACED
o.leaked                                        // 'value'       <- now inherited
```

`redacted[key] = …` never creates an own property for that key; it hits the setter inherited from `Object.prototype`. So the object case doesn't just lose the field — it reprototypes an object assembled from untrusted agent input, and the result inherits the agent's keys. Still not remotely exploitable, and `JSON.stringify` ignores inherited properties so stored output is unaffected, but any code reading the returned object can see them. Worth naming rather than filing purely under data loss.

## The fix

`Object.defineProperty`, which writes a real own property and leaves the prototype alone.

**I did not take the rename the issue proposed** (`__proto__` → `"__proto__(renamed)"` via a null-prototype carrier). Two reasons: renaming preserves the value but distorts the field name in exactly the log someone is reading to debug it, and a null-prototype carrier changes the shape of *every* returned object to fix one key — `hasOwnProperty` and friends stop working on the result. `defineProperty` keeps the field under its true name, keeps an ordinary prototype, and touches nothing else. `JSON.stringify` round-trips it unchanged, so persisted output is identical to any other field.

Happy to switch to the rename if you'd rather the redacted output never contain a literal `__proto__` key at all — that's a defensible position for anything downstream that might spread the object into a plain literal, it just wasn't the trade I'd pick by default.

## Tests

Five cases, and **I confirmed they fail against the previous implementation** before the fix went in — 4 of the 5 fail; the secret-key-nested case passes either way because it never reaches the assignment:

```
FAIL  __proto__ handling (#3129) > preserves a __proto__ subtree instead of dropping it
FAIL  __proto__ handling (#3129) > does not let a __proto__ value reprototype the redacted object
FAIL  __proto__ handling (#3129) > preserves a primitive __proto__ value, which the setter discards outright
FAIL  __proto__ handling (#3129) > survives JSON round-trip with the key intact
```

Two assert the **prototype** specifically, not just the key, because a fix that only restored the key could still reprototype and would otherwise look green.

## Local gate

Node 22.23.2, all green:

- `tsc --noEmit` — clean, exit 0
- `vitest run` in `apps/api` — **1253 files / 19705 tests passed, 0 failed**
- `eslint` on both changed files — clean

Single-file change plus its test; no dependency, lockfile, Go or container surface touched.
