### PR TITLE
fix(api): make the Architecture dynamic-group filter match stored GOARCH (#3166)

### DIFF
--- a/apps/api/src/services/filterEngine.test.ts
+++ b/apps/api/src/services/filterEngine.test.ts
@@ -130,6 +130,53 @@ describe('filterEngine virtual EXISTS fields (#968)', () => {
   });
 });
 
+// #3166: the Architecture filter advertised x64/x86/arm64 while the agent stores
+// Go's runtime.GOARCH verbatim (amd64/386/arm64), so x64 and x86 matched nothing.
+// arm64 worked only by coincidence of spelling. These pin the projection, not the
+// enum list — asserting the enum values alone would have passed while the filter
+// stayed broken, which is how this shipped.
+describe('filterEngine architecture normalization (#3166)', () => {
+  const renderWithParams = (cond: FilterCondition) => {
+    const q = dialect.sqlToQuery(buildConditionSQL(cond));
+    return { sql: q.sql, params: q.params };
+  };
+
+  it('projects the stored GOARCH column into the advertised vocabulary', () => {
+    const { sql } = renderWithParams({ field: 'architecture', operator: 'equals', value: 'x64' });
+
+    // The comparison must not hit the raw column directly.
+    expect(sql).toMatch(/case lower\("devices"\."architecture"\)/i);
+    expect(sql).toMatch(/when 'amd64' then 'x64'/i);
+    expect(sql).toMatch(/when '386' then 'x86'/i);
+    expect(sql).toMatch(/when 'aarch64' then 'arm64'/i);
+  });
+
+  it('compares the caller value unchanged, so x64 is what reaches the predicate', () => {
+    const { params } = renderWithParams({ field: 'architecture', operator: 'equals', value: 'x64' });
+    expect(params).toContain('x64');
+  });
+
+  it('applies to every operator, not just equals', () => {
+    for (const operator of ['equals', 'notEquals', 'in', 'notIn'] as const) {
+      const value = operator === 'in' || operator === 'notIn' ? ['x64', 'arm64'] : 'x64';
+      const { sql } = renderWithParams({ field: 'architecture', operator, value });
+      expect.soft(sql, `operator ${operator}`).toMatch(/case lower\("devices"\."architecture"\)/i);
+    }
+  });
+
+  it('leaves an unrecognised architecture filterable by its raw name', () => {
+    // Anything not in the map falls through lower-cased rather than being
+    // swallowed, so a future arch is still reachable instead of matching nothing.
+    const { sql } = renderWithParams({ field: 'architecture', operator: 'equals', value: 'riscv64' });
+    expect(sql).toMatch(/else lower\("devices"\."architecture"\)/i);
+  });
+
+  it('still advertises the enum the projection targets', () => {
+    const def = getFieldDefinition('architecture');
+    expect(def?.enumValues).toEqual(['x64', 'x86', 'arm64']);
+  });
+});
+
 describe('filterEngine field registration (#968)', () => {
   it('registers the three boolean fields', () => {
     for (const key of ['patches.pending', 'alerts.critical', 'system.rebootRequired']) {

--- a/apps/api/src/services/filterEngine.ts
+++ b/apps/api/src/services/filterEngine.ts
@@ -183,6 +183,42 @@ function getColumnForField(field: string): { table: 'devices' | 'hardware' | 'ne
     };
   }
 
+  // #3166: the agent reports Go's `runtime.GOARCH` verbatim (`amd64`, `arm64`,
+  // `386`) and enrollment stores it untranslated, but this field advertises the
+  // friendlier `x64` / `x86` / `arm64`. A condition of `architecture equals x64`
+  // was therefore compared against a column literally containing `amd64` and
+  // matched nothing — on one live instance every device stores `amd64`, so the
+  // x64 option could never match anything at all. `arm64` worked only because
+  // Go's spelling happens to equal the enum's.
+  //
+  // Projecting the column into the advertised vocabulary (rather than mapping
+  // the value) fixes every operator at once — equals, notEquals, in, notIn,
+  // contains — instead of special-casing equality and leaving the rest broken.
+  // It also needs no migration and no change to what agents send: stored data
+  // stays raw GOARCH, which is what the agent actually knows.
+  //
+  // Historical spellings are folded in too, so a device enrolled by any agent
+  // version lands in the right bucket. Anything unrecognised passes through
+  // lower-cased rather than being swallowed, so a new architecture is still
+  // filterable by its raw name instead of silently matching nothing.
+  if (field === 'architecture') {
+    return {
+      table: 'devices',
+      column: 'architecture',
+      computed: sql`CASE lower(${devices.architecture})
+        WHEN 'amd64' THEN 'x64'
+        WHEN 'x86_64' THEN 'x64'
+        WHEN 'x64' THEN 'x64'
+        WHEN '386' THEN 'x86'
+        WHEN 'i386' THEN 'x86'
+        WHEN 'x86' THEN 'x86'
+        WHEN 'arm64' THEN 'arm64'
+        WHEN 'aarch64' THEN 'arm64'
+        ELSE lower(${devices.architecture})
+      END`
+    };
+  }
+
   // Computed fields
   if (field === 'daysSinceLastSeen') {
     return {


### PR DESCRIPTION
Closes #3166. Your triage was right on every point; this takes the filter-engine option from the fix sketch.

## Confirmed empirically

The Architecture filter advertises `x64` / `x86` / `arm64`, the agent reports Go's `runtime.GOARCH` verbatim (`amd64`, `386`, `arm64`), and enrollment stores it untranslated. So `architecture equals x64` compares against a column containing `amd64`.

On a live instance I checked, **all 216 devices store `amd64`** — the `x64` option could never have matched a single device there. `arm64` "works" only because Go's spelling happens to equal the enum's, which is why it looked like a partial bug rather than a total one.

## Projecting the column, not mapping the value

`getColumnForField` now returns a `computed` expression for `architecture`, using the extension point the engine already has for `daysSinceLastSeen`.

That choice matters: mapping the *value* would have fixed `equals` and left `notEquals`, `in`, `notIn` and `contains` quietly broken in the same way. Projecting the *column* fixes every operator at once, needs no migration, and needs no agent change — stored data stays raw GOARCH, which is what the agent actually knows, and the UI keeps its friendlier labels.

Historical spellings (`x86_64`, `i386`, `aarch64`, plus the enum values themselves) fold into the same buckets so a device enrolled by any agent version lands correctly. Anything unrecognised falls through lower-cased rather than being swallowed, so a future architecture stays filterable by its raw name instead of silently matching nothing — the same failure mode this issue is about.

## Deliberately not changed

**The stored value and the agent.** Normalising at write time would need a backfill of every existing row and would change what the device detail view displays, for nothing the projection doesn't already give you. Happy to go that way instead if you'd rather have one canonical vocabulary in the column — it's a bigger change with a migration, so I didn't assume.

**Windows 32-bit** is covered by the `386` → `x86` mapping, but I have no 32-bit device to confirm against, so that arm of it is reasoned from `runtime.GOARCH` rather than observed.

## Tests

Pinned to the projection, not the enum list. Asserting the advertised enum values alone would pass while the filter stayed broken — which is how this shipped — so there's a case per operator, one proving the caller's value reaches the predicate unchanged, and one covering the unrecognised-arch fallthrough.

**Confirmed failing with the projection removed** before the fix went in.

## Local gate

Node 22.23.2, all green: `tsc --noEmit` clean; `vitest run` in `apps/api` **1253 files / 19705 tests passed, 0 failed**; eslint clean on both changed files.
