### PR TITLE
ci(security): retry osv-scanner download on transient network errors

### DIFF
--- a/scripts/security/install-osv-scanner.sh
+++ b/scripts/security/install-osv-scanner.sh
@@ -16,8 +16,15 @@ base_url="https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
-curl -sSfL -o "$workdir/$asset" "$base_url/$asset"
-curl -sSfL -o "$workdir/$checksums" "$base_url/$checksums"
+# --retry alone only covers timeouts and HTTP 408/429/5xx; --retry-all-errors is
+# needed for transient TCP resets (curl exit 35 "Recv failure: Connection reset
+# by peer"), which have flaked the Security Audit job.
+curl_fetch() {
+  curl -sSfL --retry 5 --retry-delay 2 --retry-all-errors --connect-timeout 15 -o "$1" "$2"
+}
+
+curl_fetch "$workdir/$asset" "$base_url/$asset"
+curl_fetch "$workdir/$checksums" "$base_url/$checksums"
 (cd "$workdir" && grep "  ${asset}$" "$checksums" | sha256sum -c -)
 
 sudo install -m 0755 "$workdir/$asset" /usr/local/bin/osv-scanner


### PR DESCRIPTION
The Security Audit job failed on PR #3098 with `curl: (35) Recv failure: Connection reset by peer` while `scripts/security/install-osv-scanner.sh` downloaded the osv-scanner binary from GitHub releases — a transient network flake unrelated to the PR's changes.

Plain `--retry` only covers timeouts and HTTP 408/429/5xx; it does not retry TCP resets. This adds `--retry-all-errors` (5 attempts, 2s delay, 15s connect timeout) to both the binary and SHA256SUMS fetches via a small `curl_fetch` helper.

Checksum verification is unchanged, so a corrupted retry still fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)