### PR TITLE
fix(api): accept the terminal command_result shapes the agent actually sends (#3167)

### DIFF
--- a/apps/api/src/routes/agentWs.terminalResultSchema.test.ts
+++ b/apps/api/src/routes/agentWs.terminalResultSchema.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { terminalCommandResultSchema } from './agentWs';
+
+// #3167: the schema's `result` is `.strict()` and used to list only
+// event/sessionId/exitCode — none of which is what the agent sends. Every
+// successful terminal command_result therefore failed validation and was dropped
+// as malformed, and the ack was never sent.
+//
+// These parse the schema directly. An earlier draft drove the WS message handler
+// instead and was VACUOUS: with a valid `status` the handler never reaches the
+// drop path in that harness, so "expect not dropped" passed against the broken
+// schema too. Verified by reverting the schema and watching those tests stay
+// green. Asserting the schema object is the thing that can actually fail.
+describe('terminalCommandResultSchema accepts what the agent sends (#3167)', () => {
+  const SESSION = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const envelope = (result: Record<string, unknown>) => ({
+    type: 'command_result' as const,
+    commandId: `term-start-${SESSION}`,
+    status: 'completed' as const,
+    result,
+  });
+
+  // Exactly the payloads agent/internal/remote/tools/terminal.go returns.
+  const agentShapes: Array<[string, Record<string, unknown>]> = [
+    ['StartTerminal', { sessionId: SESSION, cols: 80, rows: 24, started: true }],
+    ['WriteTerminal', { sessionId: SESSION, written: 12 }],
+    ['ResizeTerminal', { sessionId: SESSION, cols: 120, rows: 40, resized: true }],
+    ['StopTerminal', { sessionId: SESSION, stopped: true }],
+  ];
+
+  for (const [name, result] of agentShapes) {
+    it(`accepts the ${name} result`, () => {
+      const parsed = terminalCommandResultSchema.safeParse(envelope(result));
+      expect(parsed.success, parsed.success ? '' : JSON.stringify(parsed.error.issues)).toBe(true);
+    });
+  }
+
+  it('still rejects an undeclared key, so .strict() is intact', () => {
+    const parsed = terminalCommandResultSchema.safeParse(
+      envelope({ sessionId: SESSION, somethingNobodyDeclared: 1 })
+    );
+    expect(parsed.success).toBe(false);
+  });
+
+  it('still rejects a malformed session id', () => {
+    const parsed = terminalCommandResultSchema.safeParse(envelope({ sessionId: 'x' }));
+    expect(parsed.success).toBe(false);
+  });
+
+  it('keeps the unconsumed event enum working for agents that do send it', () => {
+    // No server code reads result.event on the terminal path — the only readers
+    // of fastResult.event are the desktop schema's peer_disconnected /
+    // consent_denied. Kept so an agent build that starts sending it is not
+    // rejected, which would be this same bug again.
+    const parsed = terminalCommandResultSchema.safeParse(
+      envelope({ event: 'session_ended', sessionId: SESSION, exitCode: 0 })
+    );
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -3029,16 +3029,45 @@ const terminalOutputFastPathSchema = z.object({
   encoding: z.enum(['base64']).optional(),
 });
 
-const terminalCommandResultSchema = z.object({
+export const terminalCommandResultSchema = z.object({
   type: z.literal('command_result'),
   commandId: z.string().regex(/^term-[a-zA-Z0-9_-]+$/).max(128),
   status: z.enum(['completed', 'failed', 'cancelled']),
   error: z.string().max(8192).optional(),
   exitCode: z.number().int().optional(),
+  // #3167: this object is `.strict()`, and it used to list only
+  // event/sessionId/exitCode — none of which is the shape the agent actually
+  // sends. `agent/internal/remote/tools/terminal.go` returns
+  // {sessionId, cols, rows, started} for start, {sessionId, written} for write,
+  // {sessionId, cols, rows, resized} for resize and {sessionId, stopped} for
+  // stop, so EVERY successful terminal command_result failed validation and was
+  // dropped as malformed, and the ack below was never sent.
+  //
+  // The `event` enum here has never had a consumer: the only reads of
+  // `fastResult.event` are the desktop path's `peer_disconnected` /
+  // `consent_denied`, which come from desktopCommandResultSchema. It is kept
+  // (optional, harmless) rather than removed, since removing it would reject any
+  // agent build that does start sending it — the same failure this fixes.
+  //
+  // Kept `.strict()` deliberately. Switching to passthrough would also stop the
+  // drops, but this is an unauthenticated-shape fast path on the agent socket and
+  // bounding what can be pushed through it is worth keeping; the fix is to
+  // describe reality, not to stop checking.
+  //
+  // cols/rows are bounded generously rather than mirroring the agent's current
+  // clamps (20-500 / 5-200). Pinning the server to the agent's exact constants
+  // would mean a future agent widening them silently reintroduces this same
+  // dropped-result bug.
   result: z.object({
     event: z.enum(['session_started', 'session_ended', 'session_error']).optional(),
     sessionId: z.string().min(SESSION_ID_MIN).max(SESSION_ID_MAX).optional(),
     exitCode: z.number().int().optional(),
+    cols: z.number().int().nonnegative().max(10_000).optional(),
+    rows: z.number().int().nonnegative().max(10_000).optional(),
+    written: z.number().int().nonnegative().optional(),
+    started: z.boolean().optional(),
+    resized: z.boolean().optional(),
+    stopped: z.boolean().optional(),
   }).strict().optional(),
 }).passthrough();
 


### PR DESCRIPTION
Closes #3167. Your triage was exact — I verified each field set against `terminal.go` rather than taking it on the description.

## The mismatch

`terminalCommandResultSchema.result` is `.strict()` and listed `event` / `sessionId` / `exitCode`. The agent sends none of those shapes:

| handler | actual result |
|---|---|
| `StartTerminal` | `{sessionId, cols, rows, started}` |
| `WriteTerminal` | `{sessionId, written}` |
| `ResizeTerminal` | `{sessionId, cols, rows, resized}` |
| `StopTerminal` | `{sessionId, stopped}` |

So every successful terminal `command_result` failed validation, got logged as malformed, and the ack never fired.

## Two things I kept on purpose

**`.strict()`.** Switching to passthrough would also stop the drops, but this is a fast path on the agent socket and bounding what can be pushed through it is worth keeping. The fix is to describe reality, not to stop checking. There's a test asserting an undeclared key is still rejected.

**The `event` enum**, even though it has no consumer. I checked: the only reads of `fastResult.event` are the desktop path's `peer_disconnected` / `consent_denied`, from `desktopCommandResultSchema`. The terminal enum is dead — which is probably how the mismatch survived, since the schema describes an imagined shape nothing ever produced. Removing it would reject any agent build that *does* start sending it, i.e. this same bug in the other direction, so it stays optional and harmless.

`cols`/`rows` are bounded generously rather than mirroring the agent's current clamps (20–500 / 5–200), so a future agent widening its own limits doesn't silently reintroduce dropped results.

## On the tests — worth reading

My first attempt drove the WS message handler with the real payloads and asserted "not dropped". All four passed. **They were vacuous.** With a valid `status` the handler never reaches the drop path in that harness, so the assertion could never fail — it passed against the *broken* schema too.

I caught it by reverting the schema and watching them stay green, then threw them away.

The replacements parse the schema directly and were verified the same way: reverting the schema fails all four shape cases. That required exporting `terminalCommandResultSchema`, which felt worth it to have an assertion that can actually fail.

## Local gate

Node 22.23.2, all green: `tsc --noEmit` clean; `vitest run` in `apps/api` **1260 files / 19860 tests passed, 0 failed**; eslint clean on all three files.

Scope note: this fixes the schema/implementation mismatch and restores the ack. As your triage says, it is not the cause of the paste-reordering corruption — terminal output streams via `terminal_output`, not this ack — so that remains separate.
