### PR TITLE
fix(api): stop the reaper claiming "no response from agent" when the agent replied (#3097)

### DIFF
--- a/apps/api/src/jobs/staleCommandReaper.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { selectMock, updateMock, deviceCommandsTable, restoreJobsTable, backupJobsTable, devicesTable, softwareDeploymentsTable, deploymentResultsTable, queueBackupStopCommandMock } = vi.hoisted(() => ({
+const { selectMock, updateMock, deviceCommandsTable, restoreJobsTable, backupJobsTable, devicesTable, softwareDeploymentsTable, deploymentResultsTable, scriptExecutionsTable, scriptExecutionBatchesTable, queueBackupStopCommandMock } = vi.hoisted(() => ({
   selectMock: vi.fn(),
   updateMock: vi.fn(),
   deviceCommandsTable: {
@@ -49,6 +49,23 @@ const { selectMock, updateMock, deviceCommandsTable, restoreJobsTable, backupJob
     errorMessage: 'deployment_results.error_message',
     deviceCommandId: 'deployment_results.device_command_id',
   },
+  scriptExecutionsTable: {
+    id: 'script_executions.id',
+    status: 'script_executions.status',
+    scriptId: 'script_executions.script_id',
+    createdAt: 'script_executions.created_at',
+    startedAt: 'script_executions.started_at',
+    completedAt: 'script_executions.completed_at',
+    errorMessage: 'script_executions.error_message',
+  },
+  scriptExecutionBatchesTable: {
+    id: 'script_execution_batches.id',
+    devicesTargeted: 'script_execution_batches.devices_targeted',
+    devicesCompleted: 'script_execution_batches.devices_completed',
+    devicesFailed: 'script_execution_batches.devices_failed',
+    status: 'script_execution_batches.status',
+    completedAt: 'script_execution_batches.completed_at',
+  },
   queueBackupStopCommandMock: vi.fn(),
 }));
 
@@ -80,6 +97,8 @@ vi.mock('../db/schema', async (importOriginal) => {
     devices: devicesTable,
     softwareDeployments: softwareDeploymentsTable,
     deploymentResults: deploymentResultsTable,
+    scriptExecutions: scriptExecutionsTable,
+    scriptExecutionBatches: scriptExecutionBatchesTable,
   };
 });
 
@@ -108,6 +127,7 @@ import {
   resolveMaxReapPerRun,
   SOFTWARE_INSTALL_TIMEOUT_MS,
   SOFTWARE_QUEUED_EXPIRY_MS,
+  reapStaleScriptExecutions
 } from './staleCommandReaper';
 
 function selectChain(resolvedValue: unknown) {
@@ -912,5 +932,93 @@ describe('reapStaleSoftwareDeploymentResults', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+
+// #3097: script results submitted over the HTTP path never reach
+// `script_executions`, so the row stays pending, lands in this reaper, and was
+// stamped `timeout` / "no response from agent". That is false whenever a terminal
+// device_commands row exists — the agent DID answer. On one live instance 89
+// executions read `timeout` while their command had completed with output.
+describe('reapStaleScriptExecutions terminal-command guard (#3097)', () => {
+  const longAgo = new Date(Date.now() - 60 * 60 * 1000);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  function arrange(cmdRow: Record<string, unknown> | undefined) {
+    // 1st select: the stale executions. 2nd: the related device command.
+    selectMock
+      .mockReturnValueOnce(selectChain([
+        { id: 'exec-1', status: 'pending', scriptId: 'script-1', createdAt: longAgo, startedAt: null },
+      ]))
+      .mockReturnValueOnce(selectChain(cmdRow ? [cmdRow] : []));
+
+    // Typed parameter so `execSet.mock.calls[0][0]` is the written row rather
+    // than `never` — the assertions below read it directly.
+    const execSet = vi.fn((_values: Record<string, unknown>) => ({
+      where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'exec-1' }]) })),
+    }));
+    updateMock.mockImplementation((table: unknown) => {
+      if (table === scriptExecutionsTable) return { set: execSet };
+      throw new Error(`Unexpected table update: ${String(table)}`);
+    });
+    return { execSet };
+  }
+
+  it('does not claim "no response from agent" when the command completed', async () => {
+    const { execSet } = arrange({
+      payload: { executionId: 'exec-1' },
+      status: 'completed',
+      result: { status: 'completed', stdout: 'it ran' },
+    });
+
+    await reapStaleScriptExecutions();
+
+    const written = execSet.mock.calls[0]![0];
+    expect(written.status).toBe('completed');
+    expect(String(written.errorMessage)).not.toContain('no response from agent');
+  });
+
+  it('records failed — not timeout — when the command failed', async () => {
+    const { execSet } = arrange({
+      payload: { executionId: 'exec-1' },
+      status: 'failed',
+      result: { status: 'failed', stderr: 'boom' },
+    });
+
+    await reapStaleScriptExecutions();
+
+    const written = execSet.mock.calls[0]![0];
+    expect(written.status).toBe('failed');
+    expect(String(written.errorMessage)).not.toContain('no response from agent');
+  });
+
+  it('still reports a genuine agent silence as timeout', async () => {
+    // Command never reached a terminal state — the original claim is true here
+    // and must survive, or the guard would mask real agent silence.
+    const { execSet } = arrange({
+      payload: { executionId: 'exec-1' },
+      status: 'sent',
+      result: null,
+    });
+
+    await reapStaleScriptExecutions();
+
+    const written = execSet.mock.calls[0]![0];
+    expect(written.status).toBe('timeout');
+    expect(String(written.errorMessage)).toContain('no response from agent');
+  });
+
+  it('still reports timeout when no command row exists at all', async () => {
+    const { execSet } = arrange(undefined);
+
+    await reapStaleScriptExecutions();
+
+    const written = execSet.mock.calls[0]![0];
+    expect(written.status).toBe('timeout');
+    expect(String(written.errorMessage)).toContain('no response from agent');
   });
 });

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -286,7 +286,7 @@ export async function reapStaleDeviceCommands(): Promise<number> {
   return reaped;
 }
 
-async function reapStaleScriptExecutions(): Promise<number> {
+export async function reapStaleScriptExecutions(): Promise<number> {
   // Default script timeout + grace buffer (300s script + 300s grace = 10 min)
   const defaultTimeoutMs = 300 * 1000 + 5 * 60 * 1000;
   const conservativeCutoff = new Date(Date.now() - defaultTimeoutMs);
@@ -319,12 +319,56 @@ async function reapStaleScriptExecutions(): Promise<number> {
 
     if (now - referenceTime < defaultTimeoutMs) continue;
 
+    // #3097: this lookup used to happen AFTER the update, purely to find the
+    // batch. It runs first now because it also answers whether the agent
+    // actually replied.
+    //
+    // Script results submitted over the HTTP path never reach `script_executions`
+    // (only agentWs registers `script: handleScriptResult`), so the row stays
+    // pending and lands here — where the reaper stamped it `timeout` with
+    // "no response from agent". That claim is false whenever a terminal
+    // `device_commands` row exists: the agent DID respond, the result simply was
+    // not mirrored. On one live instance 89 executions read `timeout` while their
+    // command had completed successfully with captured output.
+    //
+    // This does not persist the result — that belongs with the shared-handler
+    // work. It stops the reaper asserting something it cannot know, and records
+    // the outcome the command actually reached.
+    const relatedCmd = await db
+      .select({
+        payload: deviceCommands.payload,
+        status: deviceCommands.status,
+        result: deviceCommands.result,
+      })
+      .from(deviceCommands)
+      .where(
+        and(
+          eq(deviceCommands.type, 'script'),
+          sql`${deviceCommands.payload}->>'executionId' = ${exec.id}`,
+        ),
+      )
+      .limit(1);
+
+    const cmd = relatedCmd[0];
+    const cmdIsTerminal = cmd?.status === 'completed' || cmd?.status === 'failed';
+    const cmdResultStatus = (cmd?.result as Record<string, unknown> | null | undefined)?.status;
+    // Mirror handleScriptResult's mapping so a reaped row agrees with what the
+    // WS path would have written for the same command.
+    const reapedStatus: 'timeout' | 'completed' | 'failed' = !cmdIsTerminal
+      ? 'timeout'
+      : cmd?.status === 'completed' && cmdResultStatus !== 'failed' && cmdResultStatus !== 'timeout'
+        ? 'completed'
+        : 'failed';
+    const reapedError = cmdIsTerminal
+      ? 'Agent result was delivered but never recorded on this execution; recovered from the device command (#3097)'
+      : 'Server-side timeout: no response from agent';
+
     const updated = await db
       .update(scriptExecutions)
       .set({
-        status: 'timeout',
+        status: reapedStatus,
         completedAt: new Date(),
-        errorMessage: 'Server-side timeout: no response from agent',
+        errorMessage: reapedError,
       })
       .where(
         and(
@@ -337,27 +381,20 @@ async function reapStaleScriptExecutions(): Promise<number> {
     if (updated.length === 0) continue;
     reaped++;
 
-    // Find the parent batch via the deviceCommand that references this execution
-    const relatedCmd = await db
-      .select({ payload: deviceCommands.payload })
-      .from(deviceCommands)
-      .where(
-        and(
-          eq(deviceCommands.type, 'script'),
-          sql`${deviceCommands.payload}->>'executionId' = ${exec.id}`,
-        ),
-      )
-      .limit(1);
-
-    const batchId = (relatedCmd[0]?.payload as Record<string, unknown>)?.batchId as string | undefined;
+    // Batch attribution reuses the row fetched above (same query, one round-trip).
+    const batchId = (cmd?.payload as Record<string, unknown>)?.batchId as string | undefined;
     if (batchId) {
       // Atomic: increment counter + check completion in a transaction
       await db.transaction(async (tx) => {
+        // A recovered success must not be counted as a batch failure — that was
+        // the same false claim one level up.
         await tx
           .update(scriptExecutionBatches)
-          .set({
-            devicesFailed: sql`${scriptExecutionBatches.devicesFailed} + 1`,
-          })
+          .set(
+            reapedStatus === 'completed'
+              ? { devicesCompleted: sql`${scriptExecutionBatches.devicesCompleted} + 1` }
+              : { devicesFailed: sql`${scriptExecutionBatches.devicesFailed} + 1` },
+          )
           .where(eq(scriptExecutionBatches.id, batchId));
 
         const [batch] = await tx


### PR DESCRIPTION
Step 1 of the sequencing you set on #3097 — the reaper guard, on its own, ahead of the extraction. Leaves #3097 open for the extraction PR.

## What it fixes

Results submitted over the HTTP path never reach `script_executions`, so the row stays pending, ages past the cutoff, and lands in `reapStaleScriptExecutions` — which stamped it `timeout` with *"Server-side timeout: no response from agent"*.

That's false whenever a terminal `device_commands` row exists. The agent did respond; the result was simply never mirrored. **89 executions on one live instance read `timeout` while their command had completed successfully with output.**

The reaper now reads the related command *before* deciding, and when that row is terminal it records the outcome the command actually reached — mapped the same way `handleScriptResult` maps it, so a reaped row agrees with what the WS path would have written. Non-terminal command, or no command row at all: original wording stands, because there it's true.

**It does not persist stdout/stderr.** That's the extraction's job. This only stops the reaper asserting something it cannot know.

The command lookup already existed a few lines below, used only for `batchId`. It moved above the update and serves both purposes now, so no extra round-trip.

## Two things to look at in review

**The batch counter carried the same false assumption** — it incremented `devicesFailed` unconditionally, so a recovered success was still counted as a batch failure. It now increments `devicesCompleted` when the command completed. That's slightly beyond a literal "add a guard", and I'd rather you saw it flagged than buried: leaving it would have kept the same wrong claim one level up.

**`reapStaleScriptExecutions` is now exported** so it can be tested directly.

## Tests

Four cases, and the two I care most about are the negative ones — a guard that swallowed *real* agent silence would be worse than the bug it fixes:

- command completed → recovers as `completed`, message no longer claims silence
- command failed → records `failed`, not `timeout`
- command non-terminal (`sent`) → still `timeout`, still "no response from agent"
- no command row at all → same

Confirmed the two recovery cases **fail** against the previous behaviour before the guard went in.

## Local gate

Node 22.23.2, all green: `tsc --noEmit` clean; `vitest run` in `apps/api` **1271 files / 20146 tests passed, 0 failed**; eslint clean on both changed files.

Extraction next, once this lands — `services/` home for the handler block and registry, canonical byte-length `commandResultSchema` exported from `schemas.ts` and imported by both transports, the two dynamic imports left as-is, and a body that can honestly say the handlers are byte-identical with the schema unification as the one intentional behaviour change.
