### PR TITLE
fix(ai): expose billing, quote, catalog and contract tools to the in-product chat

### DIFF
--- a/apps/api/src/services/aiAgentSdkTools.ts
+++ b/apps/api/src/services/aiAgentSdkTools.ts
@@ -25,6 +25,7 @@ import {
   peripheralPolicyActionEnum,
 } from '../db/schema';
 import { CONFIG_FEATURE_TYPES } from './configFeatureTypes';
+import { INVOICE_STATUSES } from '@breeze/shared';
 import { getToolTimeout, withToolTimeout } from './toolTimeouts';
 import {
   m365LookupUserHandler, m365RecentSigninsHandler, m365ListGroupMembershipsHandler,
@@ -201,6 +202,26 @@ export const TOOL_TIERS = {
   // Org lifecycle tools (issue #2366) — new-customer intake (org → site → quote)
   list_organizations: 1,
   manage_organizations: 2,      // create_org/update_org/create_site escalate to 3 in guardrails
+  // Billing / quoting / catalog / contracts (#3156). Same #2605 failure mode as
+  // the vulnerability tools: registered in the aiTools execution registry (all
+  // Tier 2 there) and reachable by external MCP clients, but never listed here
+  // — so BREEZE_MCP_TOOL_NAMES omitted them and the chat answered "I have no
+  // invoicing tool". Tier 2 mirrors the registry tier exactly; the nine reads
+  // additionally sit in TIER2_READONLY_TOOLS (#3130) so they auto-execute with
+  // an audit row instead of prompting per list call, while the two `manage_*`
+  // mutators stay prompt-on-every-action (no TIER2_ACTIONS entry) and escalate
+  // to Tier 3 for the financially-final actions via TIER3_ACTIONS.
+  list_invoices: 2,
+  get_invoice: 2,
+  manage_invoices: 2,           // issue/void/record_payment/void_payment escalate to 3 in guardrails
+  list_quotes: 2,
+  get_quote: 2,
+  list_contracts: 2,
+  get_contract: 2,
+  manage_contracts: 2,          // activate/pause/resume/cancel escalate to 3 in guardrails
+  search_catalog: 2,
+  get_catalog_item: 2,
+  lookup_distributor_product: 2,
   // M365 helpdesk tools (Delegant-backed)
   m365_lookup_user: 1,
   m365_recent_signins: 1,
@@ -2037,6 +2058,170 @@ export function createBreezeMcpServer(
         email: z.string().email().max(255).optional(),
       },
       makeHandler('manage_organizations', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    // Billing, quoting, catalog and contract tools (#3156). Identical failure
+    // mode to the vulnerability tools above (#2605): all eleven were registered
+    // in the aiTools execution registry (aiToolsBilling / aiToolsQuotes /
+    // aiToolsCatalog / aiToolsContracts) and served to EXTERNAL MCP clients via
+    // getToolDefinitions(), but had no tool() declaration here — so the
+    // in-product chat never saw them and answered "I don't have an invoicing
+    // tool". Worse, #3130 had already added the nine reads to
+    // TIER2_READONLY_TOOLS, an allowlist that is only consulted on the chat
+    // path (aiAgentSdk.ts), making it entirely inert.
+    //
+    // Descriptions are duplicated here, as for every other tool in this file;
+    // the aiTools* modules keep the canonical copy served to external MCP.
+    // Input shapes mirror toolInputSchemas (aiToolSchemas.ts) exactly — that is
+    // the gate executeTool validates against, and a key the model is told to
+    // send but Zod does not know is stripped silently.
+
+    tool(
+      'list_invoices',
+      'List invoices for the orgs the caller can access, newest first. Optionally filter by org or status. Each invoice includes depositDue and, when a deposit is configured, a derived depositPaid boolean. Use this for "invoices", "billing", "what do they owe", "unpaid" or "overdue" questions. Read-only.',
+      {
+        orgId: uuid.optional(),
+        status: z.enum(INVOICE_STATUSES).optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      makeHandler('list_invoices', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'get_invoice',
+      'Get the full accounting view of one invoice (header plus all lines) by id. Includes depositDue and, when a deposit is configured, a derived depositPaid boolean. Read-only.',
+      {
+        invoiceId: uuid,
+      },
+      makeHandler('get_invoice', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'manage_invoices',
+      'Create and manage invoices for orgs the caller can access: build drafts, add/edit/remove lines, delete a draft, assemble from an org or ticket, issue (finalize), void, record or void payments, and create a Stripe pay link. Issue/void/payment actions finalize financial state and require approval.',
+      {
+        action: z.enum([
+          'create_draft', 'add_manual_line', 'add_catalog_line', 'add_bundle_line', 'add_contract_line',
+          'update_line', 'remove_line', 'update_header', 'delete_draft',
+          'assemble_from_org', 'assemble_from_ticket',
+          'issue', 'void', 'record_payment', 'void_payment', 'create_pay_link',
+        ]),
+        orgId: uuid.optional(),
+        siteId: uuid.optional(),
+        invoiceId: uuid.optional(),
+        lineId: uuid.optional(),
+        paymentId: uuid.optional(),
+        catalogItemId: uuid.optional(),
+        bundleId: uuid.optional(),
+        contractId: uuid.optional(),
+        contractLineId: uuid.optional(),
+        ticketId: uuid.optional(),
+        quantity: z.number().optional(),
+        notes: z.string().optional(),
+        termsAndConditions: z.string().optional(),
+        reason: z.string().optional(),
+        reissue: z.boolean().optional(),
+        from: z.string().optional(),
+        to: z.string().optional(),
+        line: z.record(z.string(), z.unknown()).optional(),
+        patch: z.record(z.string(), z.unknown()).optional(),
+        payment: z.record(z.string(), z.unknown()).optional(),
+      },
+      makeHandler('manage_invoices', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'list_quotes',
+      'List quotes/proposals for the orgs the caller can access, newest first. Optionally filter by org or status. Read-only.',
+      {
+        orgId: uuid.optional(),
+        status: z.enum(['draft', 'sent', 'viewed', 'accepted', 'declined', 'expired', 'converted']).optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      makeHandler('list_quotes', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'get_quote',
+      'Get the full view of one quote/proposal by id: header (with derived totals, deposit and category breakdown), content blocks, and line items — the same view the web UI shows. Read-only.',
+      {
+        quoteId: uuid,
+      },
+      makeHandler('get_quote', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'list_contracts',
+      'List recurring contracts for the orgs the caller can access, newest first. Optionally filter by org or status. Read-only.',
+      {
+        orgId: uuid.optional(),
+        status: z.enum(['draft', 'active', 'paused', 'cancelled', 'expired']).optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      makeHandler('list_contracts', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'get_contract',
+      'Get the full view of one recurring contract (header, lines, and billing-period history) by id. Read-only.',
+      {
+        contractId: uuid,
+      },
+      makeHandler('get_contract', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'manage_contracts',
+      'Create and manage recurring contracts for orgs the caller can access: draft edits, lines, and lifecycle actions. Activate, pause, resume, and cancel actions change contract lifecycle state and require approval.',
+      {
+        action: z.enum([
+          'create_draft',
+          'update',
+          'delete_draft',
+          'add_line',
+          'remove_line',
+          'activate',
+          'pause',
+          'resume',
+          'cancel',
+        ]),
+        contractId: uuid.optional(),
+        lineId: uuid.optional(),
+        input: z.record(z.string(), z.unknown()).optional(),
+        line: z.record(z.string(), z.unknown()).optional(),
+        patch: z.record(z.string(), z.unknown()).optional(),
+      },
+      makeHandler('manage_contracts', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'search_catalog',
+      'Search the partner product catalog (hardware, software, services, and bundles). The search term matches item name, SKU, and distributor part numbers (manufacturer part number / SYNNEX SKU). Optional filters: item type, bundle flag. Read-only.',
+      {
+        search: z.string().optional(),
+        itemType: z.enum(['hardware', 'software', 'service']).optional(),
+        isBundle: z.boolean().optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+      },
+      makeHandler('search_catalog', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'get_catalog_item',
+      'Get full detail for one catalog item by id, including bundle components if it is a bundle. Read-only.',
+      {
+        catalogItemId: uuid,
+      },
+      makeHandler('get_catalog_item', getAuth, onPreToolUse, onPostToolUse)
+    ),
+
+    tool(
+      'lookup_distributor_product',
+      'Live TD SYNNEX (EC Express) price & availability lookup for a SINGLE distributor SKU or manufacturer part number. Returns reseller cost, MSRP, currency, total stock, and per-warehouse availability. Read-only, but makes an outbound call to the distributor (partner-scoped). Use this to price a distributor product that is NOT yet in the catalog before adding it to a quote; for items already in the catalog use search_catalog instead.',
+      {
+        query: z.string().min(1).max(40),
+      },
+      makeHandler('lookup_distributor_product', getAuth, onPreToolUse, onPostToolUse)
     ),
 
     // Microsoft 365 typed Graph read-query tools (Task 9) — registered as

--- a/apps/api/src/services/aiGuardrails.readonly.contract.test.ts
+++ b/apps/api/src/services/aiGuardrails.readonly.contract.test.ts
@@ -18,8 +18,11 @@
  * NOTE: no vi.mock — this suite needs the REAL aiTools registry, because base
  * tiers are half the answer (same rationale as aiGuardrailsTierConfig.parity.test.ts).
  */
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
+import { TOOL_TIERS } from './aiAgentSdkTools';
 import {
   checkGuardrails,
   TIER1_ACTIONS,
@@ -74,6 +77,104 @@ describe('TIER2_READONLY_TOOLS — wholly read-only base-Tier-2 tools (#3130)', 
       expect(check.tier, tool).toBe(2);
       expect(check.readOnly, tool).toBe(true);
     }
+  });
+});
+
+/**
+ * #3156 — the allowlist above only pays off on a surface that can actually CALL
+ * the tool, and the ONLY consumer of `GuardrailCheck.readOnly` is the in-product
+ * chat's preToolUse (aiAgentSdk.ts). The external MCP route runs the same
+ * checkGuardrails but ignores `readOnly` entirely, so an entry here that the
+ * chat cannot see is 100% dead code, not merely degraded.
+ *
+ * What the chat can see is derived from `TOOL_TIERS` twice over:
+ *   - `BREEZE_MCP_TOOL_NAMES = Object.keys(TOOL_TIERS)` is the `allowedTools`
+ *     list handed to the SDK, and
+ *   - `createSessionPreToolUse` rejects `!TOOL_TIERS[toolName]` as "Unknown tool".
+ *
+ * All nine tools #3156 shipped into TIER2_READONLY_TOOLS were absent from
+ * TOOL_TIERS, so the chat replied "I don't have an invoicing tool" while the
+ * allowlist claimed to be optimising its prompts. Nothing failed. These tests
+ * are the missing link between the two maps.
+ */
+describe('TIER2_READONLY_TOOLS is reachable by the chat (#3156)', () => {
+  /** Tool names declared via `tool('<name>', ...)` in the breeze SDK MCP server. */
+  const declaredToolNames = new Set(
+    Array.from(
+      readFileSync(new URL('./aiAgentSdkTools.ts', import.meta.url), 'utf8')
+        .matchAll(/\btool\(\s*'([a-z0-9_]+)'/g),
+      // Group 1 is non-optional in this pattern, so a match always has it.
+      (m) => m[1]!,
+    ),
+  );
+
+  it('every member has a TOOL_TIERS entry', () => {
+    const missing = Array.from(TIER2_READONLY_TOOLS).filter(
+      (tool) => !(tool in (TOOL_TIERS as Record<string, number>)),
+    );
+    expect(
+      missing,
+      'these tools are on the read-only auto-execute allowlist but missing from TOOL_TIERS, so '
+        + 'BREEZE_MCP_TOOL_NAMES omits them and createSessionPreToolUse rejects them as '
+        + '"Unknown tool" — the chat can never call them and the allowlist entry is dead (#3156)',
+    ).toEqual([]);
+  });
+
+  it('every member has a tool() declaration in createBreezeMcpServer', () => {
+    const undeclared = Array.from(TIER2_READONLY_TOOLS).filter(
+      (tool) => !declaredToolNames.has(tool),
+    );
+    expect(
+      undeclared,
+      'a TOOL_TIERS entry alone only allowlists the mcp__breeze__ name; without a tool() '
+        + 'declaration no such tool exists and the model silently picks a neighbour (#2605)',
+    ).toEqual([]);
+  });
+
+  it('the TOOL_TIERS entry agrees with the aiTools registry tier', () => {
+    // checkGuardrails resolves the base tier from the REGISTRY, not TOOL_TIERS.
+    // A divergence would make the readOnly annotation above and the tier the
+    // chat is gated on describe two different tools.
+    for (const tool of TIER2_READONLY_TOOLS) {
+      expect((TOOL_TIERS as Record<string, number>)[tool], tool).toBe(getToolTier(tool));
+    }
+  });
+});
+
+/**
+ * #3156 companion: the two mutating billing/contract tools were exposed to chat
+ * in the same change. They are deliberately NOT on any read-only allowlist, so
+ * every action must still reach an approval prompt — Tier 2 (per-step prompt
+ * under the default mode) for draft edits, Tier 3 (durable action intent) for
+ * the financially-final ones.
+ */
+describe('billing/contract mutators still prompt (#3156)', () => {
+  it.each([
+    ['manage_invoices', 'create_draft'],
+    ['manage_invoices', 'delete_draft'],
+    ['manage_contracts', 'create_draft'],
+    ['manage_contracts', 'delete_draft'],
+  ])('%s (%s) resolves to tier 2 without readOnly', (tool, action) => {
+    const check = checkGuardrails(tool, { action });
+    expect(check.tier).toBe(2);
+    expect(check.readOnly).toBeUndefined();
+    expect(TIER2_READONLY_TOOLS.has(tool)).toBe(false);
+  });
+
+  it.each([
+    ['manage_invoices', 'issue'],
+    ['manage_invoices', 'void'],
+    ['manage_invoices', 'record_payment'],
+    ['manage_invoices', 'void_payment'],
+    ['manage_contracts', 'activate'],
+    ['manage_contracts', 'pause'],
+    ['manage_contracts', 'resume'],
+    ['manage_contracts', 'cancel'],
+  ])('%s (%s) escalates to tier 3 and requires approval', (tool, action) => {
+    const check = checkGuardrails(tool, { action });
+    expect(check.tier).toBe(3);
+    expect(check.requiresApproval).toBe(true);
+    expect(check.readOnly).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What was broken

Eleven AI tools — `list_invoices`, `get_invoice`, `manage_invoices`, `list_quotes`, `get_quote`, `list_contracts`, `get_contract`, `manage_contracts`, `search_catalog`, `get_catalog_item`, `lookup_distributor_product` — were registered in the `aiTools` execution registry (`aiToolsBilling.ts`, `aiToolsQuotes.ts`, `aiToolsContracts.ts`, `aiToolsCatalog.ts`) with schemas, permissions and tiers, but had **no `tool()` declaration in `createBreezeMcpServer`** and **no `TOOL_TIERS` entry**.

`BREEZE_MCP_TOOL_NAMES = Object.keys(TOOL_TIERS)` is the `allowedTools` list handed to the SDK, and `createSessionPreToolUse` rejects `!TOOL_TIERS[toolName]` as "Unknown tool" — so the in-product technician chat could never see or call any of them.

**User-visible symptom:** ask the chat "list our invoices" and the model replies that it has no invoicing tool, then routes the question to a neighbouring tool. Verified manually in the running app.

External MCP clients could reach all eleven the whole time via `getToolDefinitions()`, which is why the gap never surfaced as a broken integration.

This is the identical failure mode to the BE-16 vulnerability tools (#2605) — the code comment documenting that incident sits ~40 lines above the new block.

### Secondary finding — `TIER2_READONLY_TOOLS` was entirely dead

`GuardrailCheck.readOnly` (#3130 / #3156) is consumed in exactly one place: `createSessionPreToolUse` in `aiAgentSdk.ts:653`. The external-MCP route (`routes/mcpServer.ts:1190`) calls the same `checkGuardrails` but reads only `.allowed` and `.tier` — it never looks at `readOnly`.

So the nine read tools #3156 added to `TIER2_READONLY_TOOLS` were **100% dead code**, not merely degraded: the only surface that honours the allowlist is the same surface that could not call the tools. Nothing failed; the allowlist simply claimed to be optimising prompts for tools the chat did not have.

## The fix

**`apps/api/src/services/aiAgentSdkTools.ts`**

- `tool()` declarations for all eleven, placed after the org-lifecycle block. Input shapes mirror `toolInputSchemas` exactly (that is the gate `executeTool` validates against, and `z.object()` *strips* unknown keys rather than rejecting). Descriptions are duplicated inline as for every other tool in the file; the `aiTools*` modules keep the canonical copy served to external MCP.
- `TOOL_TIERS` entries at **tier 2** for all eleven, matching their `aiTools` registry tier exactly. This matters because `checkGuardrails` resolves the base tier from the *registry*, not from `TOOL_TIERS` — a divergence would mean the two maps describe different tools.

Traced end-to-end rather than assumed:

- **Nine reads** — no `action` discriminator in their input, so `checkGuardrails` skips every per-action table and returns `{ tier: 2, requiresApproval: false, readOnly: true }` (base tier 2 + `TIER2_READONLY_TOOLS` membership). In `preToolUse` that hits `tier === 2 && readOnlyAutoExec` → auto-execute with an `ai_tool_executions` row stamped `read_only_auto`. Paused sessions and unmatched calls during an active plan still prompt, unchanged.
- **`manage_invoices` / `manage_contracts`** — included deliberately so the #3028/#3098 `delete_draft` fix is reachable from chat. Neither is on any read-only allowlist and neither has a `TIER2_ACTIONS` entry, so draft actions fall to base tier 2 with `readOnly` unset → the per-step prompt still fires. `issue`/`void`/`record_payment`/`void_payment` and `activate`/`pause`/`resume`/`cancel` already sit in `TIER3_ACTIONS` → tier 3, `requiresApproval: true`, durable action intent. Both paths are now asserted, not assumed.

## The contract test

`apps/api/src/services/aiGuardrails.readonly.contract.test.ts` gains a `TIER2_READONLY_TOOLS is reachable by the chat (#3156)` block asserting:

1. every member has a `TOOL_TIERS` entry (the direct guard against this bug class);
2. every member has a real `tool('<name>', ...)` declaration in `aiAgentSdkTools.ts`, read from source — a `TOOL_TIERS` entry alone only allowlists the `mcp__breeze__` name, which is the #2605 half of the failure;
3. the `TOOL_TIERS` tier agrees with the `aiTools` registry tier.

Plus a `billing/contract mutators still prompt (#3156)` block pinning the tier-2-no-`readOnly` and tier-3-requires-approval resolutions above.

**Verified genuinely red pre-fix**: with `aiAgentSdkTools.ts` reverted, all three reachability tests fail (`3 failed | 20 passed`). The existing `aiAgentSdkTools.mcpCoverage.test.ts` already covers the general `TOOL_TIERS` → `tool()` direction; the new tests close the `TIER2_READONLY_TOOLS` → `TOOL_TIERS` edge it could not see.

## Verification

- `tsc --noEmit --project apps/api/tsconfig.json` — clean (needs `NODE_OPTIONS=--max-old-space-size=8192`).
- `eslint` on both changed files — clean.
- `vitest run src/services/aiGuardrails src/services/aiAgentSdk src/services/aiTools src/services/clientAiTools src/services/scriptBuilderTools` — **106 files, 1588 tests passed**.
- `vitest run src/routes/mcpServer src/services/aiAgentSystemPrompt src/services/streamingSessionManager src/routes/clientAi` — **40 files, 368 tests passed**.

## Out of scope

`manage_quotes` and `manage_catalog` are also registered in the `aiTools` registry and still absent from chat, so the chat can now read quotes and catalog items but not create or edit them. Left alone deliberately — outside this change's brief and unverified against the quote/catalog write paths. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
