### PR TITLE
fix(api): materialize dynamic group membership instead of stranding it on a dead transaction

### DIFF
--- a/apps/api/src/__tests__/integration/dynamicGroupMembershipMaterialization.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dynamicGroupMembershipMaterialization.integration.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Real-Postgres coverage for dynamic device-group membership materialization.
+ *
+ * THE DEFECT (observed live): creating a dynamic group with `Architecture
+ * equals x64` previewed 3 matching devices, but
+ * `SELECT count(*) FROM device_group_memberships WHERE group_id = <new group>`
+ * stayed at 0 forever, with nothing in the API logs.
+ *
+ * MECHANISM: `routes/groups.ts` fired the evaluation without awaiting it
+ * (`evaluateGroupMembership(id).catch(...)`). Only the evaluation's FIRST query
+ * was dispatched while the request's `withDbAccessContext` transaction was
+ * still open; the handler then returned, drizzle/postgres.js committed that
+ * transaction and released its pooled connection, and the detached
+ * continuation's next query was queued on a transaction handle that no longer
+ * owned a connection. That query never executed, so the promise never settled,
+ * so the route's `.catch()` never ran — zero rows, zero errors, zero logs.
+ *
+ * Why a real database is required: the mocked route suites resolve
+ * `evaluateGroupMembership` from a `vi.fn()`, so a detached call looks
+ * identical to an awaited one. Only a real pooled connection with a real
+ * transaction lifecycle can reproduce the stall, and only real `breeze_app`
+ * forced RLS can prove the tenant boundary on the write.
+ *
+ * Coverage:
+ *   1. POST /groups (dynamic) — memberships are readable the instant the
+ *      response lands, and the response's own deviceCount agrees. FAILS before
+ *      the fix (0 rows, and the request itself leaks a never-settling promise).
+ *   2. Cross-tenant — a matching device in ANOTHER partner's org is never
+ *      absorbed, and every materialized row carries the group's own org_id.
+ *   3. RLS backstop — an org-B-scoped context cannot forge a membership row
+ *      into org A's group even when it names org A's ids (42501).
+ *   4. PATCH /groups/:id — a filter change re-materializes before responding
+ *      (that branch was fire-and-forget too).
+ */
+import './setup';
+
+import { describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { deviceGroupMemberships, deviceGroups, devices } from '../../db/schema';
+import { groupRoutes } from '../../routes/groups';
+import { createAccessToken, type TokenPayload } from '../../services/jwt';
+import {
+  createOrganization,
+  createPartner,
+  createSite,
+  setupTestEnvironment,
+  type TestEnvironment,
+} from './db-utils';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+const X64_FILTER = {
+  operator: 'AND' as const,
+  conditions: [{ field: 'architecture', operator: 'equals', value: 'x64' }],
+};
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route('/groups', groupRoutes);
+  return app;
+}
+
+/**
+ * The group routes are `requireMfa()`-gated and `setupTestEnvironment` mints
+ * its token with `mfa: false`, so re-mint the same identity with `mfa: true`.
+ */
+async function mfaSatisfiedToken(env: TestEnvironment): Promise<string> {
+  const payload: Omit<TokenPayload, 'type'> = {
+    sub: env.user.id,
+    email: env.user.email,
+    roleId: env.role.id,
+    orgId: env.organization.id,
+    partnerId: env.partner.id,
+    scope: 'organization',
+    mfa: true,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  };
+  return createAccessToken(payload);
+}
+
+/**
+ * `amd64` is what the Go agent actually stores for an x64 box (#3166) — using
+ * the raw GOARCH spelling keeps this test honest about the projection the
+ * Architecture filter relies on.
+ */
+async function seedDevice(orgId: string, siteId: string, architecture = 'amd64'): Promise<string> {
+  return withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname: `host-${randomUUID().slice(0, 8)}`,
+        osType: 'windows',
+        osVersion: '10',
+        architecture,
+        agentVersion: '1.0.0',
+        status: 'online',
+      })
+      .returning({ id: devices.id });
+    return row!.id;
+  });
+}
+
+async function membershipRows(groupId: string): Promise<Array<{ deviceId: string; orgId: string }>> {
+  return withSystemDbAccessContext(async () =>
+    db
+      .select({ deviceId: deviceGroupMemberships.deviceId, orgId: deviceGroupMemberships.orgId })
+      .from(deviceGroupMemberships)
+      .where(eq(deviceGroupMemberships.groupId, groupId)),
+  );
+}
+
+/** An unrelated partner + org + site, i.e. a genuinely different tenant. */
+async function seedForeignTenant(): Promise<{ orgId: string; siteId: string }> {
+  const partner = await createPartner();
+  const organization = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: organization.id });
+  return { orgId: organization.id, siteId: site.id };
+}
+
+async function createDynamicGroup(
+  app: Hono,
+  token: string,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return app.request('/groups', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('dynamic device group membership materialization', () => {
+  runDb('materializes membership before the create response returns', async () => {
+    const env = await setupTestEnvironment();
+    const token = await mfaSatisfiedToken(env);
+    const app = makeApp();
+
+    const deviceA = await seedDevice(env.organization.id, env.site.id);
+    const deviceB = await seedDevice(env.organization.id, env.site.id);
+    // arm64 box in the same org: proves the filter still discriminates.
+    await seedDevice(env.organization.id, env.site.id, 'arm64');
+
+    const res = await createDynamicGroup(app, token, {
+      name: `x64 boxes ${randomUUID().slice(0, 8)}`,
+      type: 'dynamic',
+      filterConditions: X64_FILTER,
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    const groupId: string = body.data.id;
+
+    // The membership rows exist the moment the caller can see the response —
+    // no polling, no eventual consistency. This is the assertion that fails
+    // (0 rows) against the fire-and-forget version.
+    const rows = await membershipRows(groupId);
+    expect(rows.map((r) => r.deviceId).sort()).toEqual([deviceA, deviceB].sort());
+    expect(body.data.deviceCount).toBe(2);
+  });
+
+  runDb('never absorbs a matching device from another tenant', async () => {
+    const env = await setupTestEnvironment();
+    const token = await mfaSatisfiedToken(env);
+    const app = makeApp();
+
+    const ownDevice = await seedDevice(env.organization.id, env.site.id);
+    const foreign = await seedForeignTenant();
+    const foreignDevice = await seedDevice(foreign.orgId, foreign.siteId);
+
+    const res = await createDynamicGroup(app, token, {
+      name: `x64 boxes ${randomUUID().slice(0, 8)}`,
+      type: 'dynamic',
+      filterConditions: X64_FILTER,
+    });
+    expect(res.status).toBe(201);
+    const groupId: string = (await res.json()).data.id;
+
+    const rows = await membershipRows(groupId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.deviceId).toBe(ownDevice);
+    // Every materialized row is stamped with the GROUP's org, never a
+    // device-derived or caller-derived one.
+    expect(rows[0]!.orgId).toBe(env.organization.id);
+    expect(rows.map((r) => r.deviceId)).not.toContain(foreignDevice);
+  });
+
+  runDb('RLS rejects a forged cross-tenant membership into the group', async () => {
+    const env = await setupTestEnvironment();
+    const token = await mfaSatisfiedToken(env);
+    const app = makeApp();
+
+    await seedDevice(env.organization.id, env.site.id);
+    const foreign = await seedForeignTenant();
+    const foreignDevice = await seedDevice(foreign.orgId, foreign.siteId);
+
+    const res = await createDynamicGroup(app, token, {
+      name: `x64 boxes ${randomUUID().slice(0, 8)}`,
+      type: 'dynamic',
+      filterConditions: X64_FILTER,
+    });
+    const groupId: string = (await res.json()).data.id;
+
+    const foreignContext: DbAccessContext = {
+      scope: 'organization',
+      orgId: foreign.orgId,
+      accessibleOrgIds: [foreign.orgId],
+      accessiblePartnerIds: null,
+      userId: null,
+      currentPartnerId: null,
+    };
+
+    // The foreign tenant cannot even SEE the group…
+    const visible = await withDbAccessContext(foreignContext, async () =>
+      db.select({ id: deviceGroups.id }).from(deviceGroups).where(eq(deviceGroups.id, groupId)),
+    );
+    expect(visible).toHaveLength(0);
+
+    // …and Postgres refuses a membership row stamped with org A's org_id.
+    // The failed statement aborts the surrounding access-context transaction,
+    // and postgres.js's `begin` rethrows even when the callback handled it, so
+    // the catch has to live OUTSIDE withDbAccessContext.
+    const forged = await withDbAccessContext(foreignContext, async () =>
+      db.insert(deviceGroupMemberships).values({
+        groupId,
+        deviceId: foreignDevice,
+        orgId: env.organization.id,
+        addedBy: 'manual',
+      }),
+    ).then(() => null, (err: Error) => err);
+    expect(forged).toBeInstanceOf(Error);
+    // Drizzle wraps the driver error, so the policy violation is on `.cause`.
+    expect(String((forged as { cause?: { message?: string } }).cause?.message))
+      .toMatch(/row-level security/i);
+
+    // KNOWN GAP, asserted deliberately so it cannot change unnoticed: the
+    // `device_group_memberships` policies key on `org_id` ALONE
+    // (`breeze_has_org_access(org_id)`), and there is no composite FK tying
+    // (group_id, org_id) back to device_groups. So a foreign tenant that
+    // somehow learned the group's UUID can insert a row naming that group as
+    // long as it stamps its OWN org_id. What matters for tenant isolation is
+    // that such a row is quarantined: org A can never read it, so it can never
+    // surface as a member of org A's group. Closing the gap properly needs a
+    // composite FK + backfill and is tracked separately from this fix.
+    await withDbAccessContext(foreignContext, async () =>
+      db.insert(deviceGroupMemberships).values({
+        groupId,
+        deviceId: foreignDevice,
+        orgId: foreign.orgId,
+        addedBy: 'manual',
+      }),
+    );
+
+    const visibleToOwner = await withDbAccessContext(
+      {
+        scope: 'organization',
+        orgId: env.organization.id,
+        accessibleOrgIds: [env.organization.id],
+        accessiblePartnerIds: null,
+        userId: null,
+        currentPartnerId: null,
+      },
+      async () =>
+        db
+          .select({ deviceId: deviceGroupMemberships.deviceId })
+          .from(deviceGroupMemberships)
+          .where(eq(deviceGroupMemberships.groupId, groupId)),
+    );
+    expect(visibleToOwner.map((r) => r.deviceId)).not.toContain(foreignDevice);
+
+    // And the group's own materialization never produced the foreign device.
+    const rows = await membershipRows(groupId);
+    expect(rows.filter((r) => r.orgId === env.organization.id).map((r) => r.deviceId))
+      .not.toContain(foreignDevice);
+  });
+
+  runDb('re-materializes membership when the filter changes on update', async () => {
+    const env = await setupTestEnvironment();
+    const token = await mfaSatisfiedToken(env);
+    const app = makeApp();
+
+    const x64Device = await seedDevice(env.organization.id, env.site.id, 'amd64');
+    const armDevice = await seedDevice(env.organization.id, env.site.id, 'arm64');
+
+    const created = await createDynamicGroup(app, token, {
+      name: `arch group ${randomUUID().slice(0, 8)}`,
+      type: 'dynamic',
+      filterConditions: X64_FILTER,
+    });
+    const groupId: string = (await created.json()).data.id;
+    expect((await membershipRows(groupId)).map((r) => r.deviceId)).toEqual([x64Device]);
+
+    const patched = await app.request(`/groups/${groupId}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        filterConditions: {
+          operator: 'AND',
+          conditions: [{ field: 'architecture', operator: 'equals', value: 'arm64' }],
+        },
+      }),
+    });
+
+    expect(patched.status).toBe(200);
+    const rows = await membershipRows(groupId);
+    expect(rows.map((r) => r.deviceId)).toEqual([armDevice]);
+    // The response's deviceCount is read after the re-evaluation, so it is
+    // already correct rather than one request behind.
+    expect((await patched.json()).data.deviceCount).toBe(1);
+  });
+
+  runDb('logs loudly when the group is not visible to the caller context', async () => {
+    const env = await setupTestEnvironment();
+    await seedDevice(env.organization.id, env.site.id);
+
+    const [group] = await withSystemDbAccessContext(async () =>
+      db
+        .insert(deviceGroups)
+        .values({
+          orgId: env.organization.id,
+          name: `hidden ${randomUUID().slice(0, 8)}`,
+          type: 'dynamic',
+          filterConditions: X64_FILTER,
+          filterFieldsUsed: ['architecture'],
+        })
+        .returning({ id: deviceGroups.id }),
+    );
+
+    const foreign = await seedForeignTenant();
+    const errors: string[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => { errors.push(String(args[0])); };
+    try {
+      const { evaluateGroupMembership } = await import('../../services/groupMembership');
+      const summary = await withDbAccessContext(
+        {
+          scope: 'organization',
+          orgId: foreign.orgId,
+          accessibleOrgIds: [foreign.orgId],
+          accessiblePartnerIds: null,
+          userId: null,
+          currentPartnerId: null,
+        },
+        () => evaluateGroupMembership(group!.id),
+      );
+      expect(summary).toMatchObject({ evaluatedGroups: 0, added: 0, materialized: 0 });
+    } finally {
+      console.error = original;
+    }
+
+    expect(errors.some((line) => line.includes(group!.id) && line.includes('NOT materialized'))).toBe(true);
+
+    // And nothing was written for the group by that call.
+    const rows = await withSystemDbAccessContext(async () =>
+      db
+        .select({ deviceId: deviceGroupMemberships.deviceId })
+        .from(deviceGroupMemberships)
+        .where(and(eq(deviceGroupMemberships.groupId, group!.id))),
+    );
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -505,15 +505,31 @@ groupRoutes.post(
       }
     });
 
-    // If dynamic group with filter, evaluate membership
+    // If dynamic group with filter, materialize membership before responding.
+    //
+    // This used to be fire-and-forget (`evaluateGroupMembership(id).catch(...)`),
+    // which never worked: the detached promise resumed AFTER the request's
+    // `withDbAccessContext` transaction had committed and released its pooled
+    // connection, so its next query was queued on a dead transaction handle and
+    // never executed. The promise never settled, the `.catch` never ran, and the
+    // group stayed permanently empty with nothing in the logs. Awaiting inside
+    // the request keeps the evaluation in the caller's own org-scoped RLS
+    // context — the correct tenant, enforced by Postgres — and lets the response
+    // carry the real device count. The evaluation is a handful of statements
+    // (bounded filter query + bulk insert), not a per-device loop.
+    let deviceCount = 0;
     if (group.type === 'dynamic' && group.filterConditions) {
-      // Run membership evaluation asynchronously (don't block the response)
-      evaluateGroupMembership(group.id).catch((err) => {
+      try {
+        await evaluateGroupMembership(group.id);
+        deviceCount = await getDeviceCountForGroup(group.id);
+      } catch (err) {
+        // The group itself was created; failing the request would invite a
+        // duplicate on retry. Surface the failure instead of swallowing it.
         console.error(`Failed to evaluate membership for new group ${group.id}:`, err);
-      });
+      }
     }
 
-    return c.json({ data: mapGroupRow(group, 0) }, 201);
+    return c.json({ data: mapGroupRow(group, deviceCount) }, 201);
   }
 );
 
@@ -628,16 +644,17 @@ groupRoutes.patch(
       }
     });
 
-    // Site changes are security-boundary changes, so finish evaluation before
-    // returning. Filter-only changes retain the existing asynchronous behavior.
+    // Always finish the re-evaluation before returning. Site changes are
+    // security-boundary changes and always had to be awaited; the filter-only
+    // branch used to be fire-and-forget, which silently did nothing at all —
+    // the detached promise resumed after this request's `withDbAccessContext`
+    // transaction had committed, so its queries were stranded on a closed
+    // transaction handle and never ran (no rows, no error, no log). Awaiting
+    // also means the `deviceCount` returned below reflects the new filter.
+    // A failure propagates (PATCH is idempotent, so a 500 is retryable) rather
+    // than leaving membership silently stale against the new filter or site.
     if (effectiveType === 'dynamic' && (filterChanged || siteChanged) && updated.filterConditions) {
-      if (siteChanged) {
-        await evaluateGroupMembership(updated.id);
-      } else {
-        evaluateGroupMembership(updated.id).catch((err) => {
-          console.error(`Failed to re-evaluate membership for group ${updated.id}:`, err);
-        });
-      }
+      await evaluateGroupMembership(updated.id);
     }
 
     const deviceCount = await getDeviceCountForGroup(id);

--- a/apps/api/src/routes/groups_get_create.test.ts
+++ b/apps/api/src/routes/groups_get_create.test.ts
@@ -116,6 +116,7 @@ vi.mock('../middleware/auth', () => ({
 import { db } from '../db';
 import { authMiddleware } from '../middleware/auth';
 import { validateFilter } from '../services/filterEngine';
+import { evaluateGroupMembership } from '../services/groupMembership';
 
 function makeGroup(overrides: Record<string, unknown> = {}) {
   return {
@@ -399,6 +400,88 @@ describe('groups routes', () => {
       expect(res.status).toBe(400);
       const body = await res.json();
       expect(body.error).toContain('Invalid filter');
+    });
+
+    // Regression guard for the silent zero-row materialization: the route used
+    // to call `evaluateGroupMembership(id).catch(...)` without awaiting it. The
+    // detached promise resumed only AFTER the request's withDbAccessContext
+    // transaction had committed and released its pooled connection, so its next
+    // query was stranded on a dead transaction handle and never ran — no rows,
+    // no rejection, no log. Holding the evaluation open here proves the handler
+    // genuinely waits for it, which is what keeps the write inside the caller's
+    // live org-scoped RLS context.
+    it('waits for dynamic membership materialization before responding', async () => {
+      const created = makeGroup({
+        type: 'dynamic',
+        filterConditions: { operator: 'AND', conditions: [{ field: 'osType', operator: 'equals', value: 'windows' }] }
+      });
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([created]) })
+      } as any);
+      // Earlier cases in this file leave unconsumed `mockReturnValueOnce`
+      // entries on db.select, and clearAllMocks does not drain that queue.
+      vi.mocked(db.select).mockReset();
+      // getDeviceCountForGroup, read AFTER materialization finishes.
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ count: 3 }]) })
+      } as any);
+
+      let releaseEvaluation!: () => void;
+      const evaluationHeld = new Promise<void>((resolve) => { releaseEvaluation = resolve; });
+      vi.mocked(evaluateGroupMembership).mockReturnValueOnce(evaluationHeld as any);
+
+      let settled = false;
+      const pending = Promise.resolve(app.request('/groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Dynamic Group',
+          type: 'dynamic',
+          filterConditions: { operator: 'AND', conditions: [{ field: 'osType', operator: 'equals', value: 'windows' }] }
+        })
+      })).then((res: Response) => { settled = true; return res; });
+
+      // Let the event loop drain: if the route were still fire-and-forget it
+      // would already have responded here.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+
+      releaseEvaluation();
+      const res = await pending;
+
+      expect(res.status).toBe(201);
+      expect(evaluateGroupMembership).toHaveBeenCalledWith(GROUP_ID);
+      const body = await res.json();
+      // The response carries the real materialized count, not a hardcoded 0.
+      expect(body.data.deviceCount).toBe(3);
+    });
+
+    it('still returns 201 (and logs) when materialization fails', async () => {
+      const created = makeGroup({
+        type: 'dynamic',
+        filterConditions: { operator: 'AND', conditions: [{ field: 'osType', operator: 'equals', value: 'windows' }] }
+      });
+      vi.mocked(db.insert).mockReturnValueOnce({
+        values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([created]) })
+      } as any);
+      vi.mocked(db.select).mockReset();
+      vi.mocked(evaluateGroupMembership).mockRejectedValueOnce(new Error('boom'));
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const res = await app.request('/groups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+        body: JSON.stringify({
+          name: 'Dynamic Group',
+          type: 'dynamic',
+          filterConditions: { operator: 'AND', conditions: [{ field: 'osType', operator: 'equals', value: 'windows' }] }
+        })
+      });
+
+      expect(res.status).toBe(201);
+      expect(errorSpy).toHaveBeenCalled();
+      expect(String(errorSpy.mock.calls[0]?.[0])).toContain(GROUP_ID);
+      errorSpy.mockRestore();
     });
 
     it('should validate parent group exists and belongs to same org', async () => {

--- a/apps/api/src/services/groupMembership.materialization.test.ts
+++ b/apps/api/src/services/groupMembership.materialization.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit coverage for the diagnostics + write shape of `evaluateGroupMembership`
+ * (the whole-group dynamic materialization).
+ *
+ * The defect these guard: a dynamic group was created, the server-side preview
+ * reported 3 matching devices, and `device_group_memberships` stayed at 0 rows
+ * with NOTHING in the API logs. The route fired the evaluation and did not
+ * await it, so the detached promise resumed after the request's
+ * `withDbAccessContext` transaction had committed; its next query was stranded
+ * on a closed transaction handle and never executed. The promise never settled,
+ * so the route's `.catch()` never ran either.
+ *
+ * The route fix (awaiting) lives in `routes/groups.ts` and is proved end-to-end
+ * by `__tests__/integration/dynamicGroupMembershipMaterialization.integration.test.ts`.
+ * What is tested HERE is the second half of the fix — that the service can no
+ * longer fail quietly:
+ *   - a group row the caller cannot SEE (the signature of a missing/torn-down
+ *     RLS access context) is logged as an error instead of returning a bland
+ *     zero summary,
+ *   - a materialization that comes up short of what the filter matched is
+ *     logged with the group id and BOTH counts,
+ *   - a healthy materialization logs nothing and stamps the group's own org on
+ *     every membership row it writes.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockSelect,
+  mockInsert,
+  mockDelete,
+  mockUpdate,
+  mockEvaluateFilter,
+  mockHasDbAccessContext,
+  mockGetCurrentDbAccessContext,
+} = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockInsert: vi.fn(),
+  mockDelete: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockEvaluateFilter: vi.fn(),
+  mockHasDbAccessContext: vi.fn(),
+  mockGetCurrentDbAccessContext: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: mockSelect,
+    insert: mockInsert,
+    update: mockUpdate,
+    delete: mockDelete,
+  },
+  hasDbAccessContext: mockHasDbAccessContext,
+  getCurrentDbAccessContext: mockGetCurrentDbAccessContext,
+}));
+
+vi.mock('../db/schema', () => ({
+  deviceGroups: {
+    id: 'group.id',
+    type: 'group.type',
+    filterConditions: 'group.filterConditions',
+    filterFieldsUsed: 'group.filterFieldsUsed',
+    orgId: 'group.orgId',
+    siteId: 'group.siteId',
+  },
+  devices: { id: 'device.id', orgId: 'device.orgId', siteId: 'device.siteId' },
+  deviceGroupMemberships: {
+    groupId: 'membership.groupId',
+    deviceId: 'membership.deviceId',
+    isPinned: 'membership.isPinned',
+  },
+  groupMembershipLog: {},
+}));
+
+vi.mock('./filterEngine', () => ({
+  deviceMatchesFilter: vi.fn(),
+  evaluateFilter: mockEvaluateFilter,
+  extractFieldsFromFilter: vi.fn().mockReturnValue([]),
+}));
+
+import { evaluateGroupMembership } from './groupMembership';
+
+const FILTER = { operator: 'AND' as const, conditions: [] };
+
+function groupRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'group-1',
+    orgId: 'org-a',
+    siteId: null,
+    type: 'dynamic',
+    filterConditions: FILTER,
+    filterFieldsUsed: [],
+    ...overrides,
+  };
+}
+
+/** `db.select().from().where().limit()` (single-row lookups). */
+function limitChain(rows: unknown[]) {
+  return { from: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }) }) };
+}
+
+/** `db.select().from().where()` (list + count queries). */
+function whereChain(rows: unknown[]) {
+  return { from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }) };
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+/** Rows handed to each `db.insert(...).values(...)` call, in order. */
+let insertedRows: unknown[][];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  insertedRows = [];
+  mockInsert.mockImplementation(() => ({
+    values: (rows: unknown[]) => {
+      insertedRows.push(rows);
+      return { onConflictDoNothing: vi.fn().mockResolvedValue(undefined) };
+    },
+  }));
+  mockDelete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+  mockUpdate.mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }) });
+  mockHasDbAccessContext.mockReturnValue(true);
+  mockGetCurrentDbAccessContext.mockReturnValue({ scope: 'organization', orgId: 'org-a' });
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe('evaluateGroupMembership — silent-failure diagnostics', () => {
+  it('logs an error naming the group and the DB access context when the group row is invisible', async () => {
+    // Exactly what a contextless / torn-down-context read looks like under
+    // forced RLS: the SELECT succeeds and returns nothing.
+    mockSelect.mockReturnValueOnce(limitChain([]));
+    mockHasDbAccessContext.mockReturnValue(false);
+
+    const result = await evaluateGroupMembership('group-1');
+
+    expect(result).toEqual({ evaluatedGroups: 0, added: 0, removed: 0, matched: 0, materialized: 0 });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const message = String(errorSpy.mock.calls[0]?.[0]);
+    expect(message).toContain('group-1');
+    expect(message).toContain('dbAccessContext=none');
+    expect(message).toContain('NOT materialized');
+    expect(mockEvaluateFilter).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet for a group that exists but is not a dynamic group', async () => {
+    mockSelect.mockReturnValueOnce(limitChain([groupRow({ type: 'static' })]));
+
+    const result = await evaluateGroupMembership('group-1');
+
+    expect(result).toEqual({ evaluatedGroups: 0, added: 0, removed: 0 });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs a shortfall with the matched count and the count that actually landed', async () => {
+    mockSelect
+      .mockReturnValueOnce(limitChain([groupRow()]))       // group lookup
+      .mockReturnValueOnce(whereChain([]))                  // current memberships
+      .mockReturnValueOnce(whereChain([{ count: 0 }]));     // post-write verification
+    mockEvaluateFilter.mockResolvedValue({
+      deviceIds: ['dev-1', 'dev-2', 'dev-3'],
+      totalCount: 3,
+      evaluatedAt: new Date(),
+    });
+
+    const result = await evaluateGroupMembership('group-1');
+
+    expect(result).toMatchObject({ added: 3, matched: 3, materialized: 0 });
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const message = String(errorSpy.mock.calls[0]?.[0]);
+    expect(message).toContain('materialization shortfall');
+    expect(message).toContain('group-1');
+    expect(message).toContain('org-a');
+    expect(message).toContain('matched 3 device(s)');
+    expect(message).toContain('found 0');
+  });
+
+  it('logs nothing and stamps the group org on every row when materialization succeeds', async () => {
+    mockSelect
+      .mockReturnValueOnce(limitChain([groupRow()]))
+      .mockReturnValueOnce(whereChain([]))
+      .mockReturnValueOnce(whereChain([{ count: 2 }]));
+    mockEvaluateFilter.mockResolvedValue({
+      deviceIds: ['dev-1', 'dev-2'],
+      totalCount: 2,
+      evaluatedAt: new Date(),
+    });
+
+    const result = await evaluateGroupMembership('group-1');
+
+    expect(result).toMatchObject({ evaluatedGroups: 1, added: 2, removed: 0, matched: 2, materialized: 2 });
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    // Memberships carry the GROUP's org, never a device-derived one.
+    expect(insertedRows[0]).toEqual([
+      { deviceId: 'dev-1', groupId: 'group-1', orgId: 'org-a', addedBy: 'dynamic_rule' },
+      { deviceId: 'dev-2', groupId: 'group-1', orgId: 'org-a', addedBy: 'dynamic_rule' },
+    ]);
+  });
+
+  it('counts a pinned non-matching member towards the expected total', async () => {
+    mockSelect
+      .mockReturnValueOnce(limitChain([groupRow()]))
+      .mockReturnValueOnce(whereChain([{ deviceId: 'pinned-1', isPinned: true }]))
+      .mockReturnValueOnce(whereChain([{ count: 2 }])); // pinned-1 + dev-1
+    mockEvaluateFilter.mockResolvedValue({
+      deviceIds: ['dev-1'],
+      totalCount: 1,
+      evaluatedAt: new Date(),
+    });
+
+    const result = await evaluateGroupMembership('group-1');
+
+    expect(result).toMatchObject({ added: 1, removed: 0, matched: 1, materialized: 2 });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes the membership log as one batched insert instead of one per device', async () => {
+    mockSelect
+      .mockReturnValueOnce(limitChain([groupRow()]))
+      .mockReturnValueOnce(whereChain([]))
+      .mockReturnValueOnce(whereChain([{ count: 3 }]));
+    mockEvaluateFilter.mockResolvedValue({
+      deviceIds: ['dev-1', 'dev-2', 'dev-3'],
+      totalCount: 3,
+      evaluatedAt: new Date(),
+    });
+
+    await evaluateGroupMembership('group-1');
+
+    // 1 membership insert + 1 batched log insert — NOT 1 + 3.
+    expect(mockInsert).toHaveBeenCalledTimes(2);
+    expect(insertedRows[1]).toHaveLength(3);
+    expect((insertedRows[1] as unknown[])[0]).toEqual({
+      groupId: 'group-1',
+      deviceId: 'dev-1',
+      orgId: 'org-a',
+      action: 'added',
+      reason: 'filter_match',
+    });
+  });
+});

--- a/apps/api/src/services/groupMembership.ts
+++ b/apps/api/src/services/groupMembership.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import type { FilterConditionGroup } from './filterEngine';
-import { db } from '../db';
+import { db, getCurrentDbAccessContext, hasDbAccessContext } from '../db';
 import { deviceGroups, deviceGroupMemberships, devices, groupMembershipLog } from '../db/schema';
 import { deviceMatchesFilter, evaluateFilter, extractFieldsFromFilter } from './filterEngine';
 
@@ -12,6 +12,32 @@ export interface MembershipUpdateSummary {
   evaluatedGroups: number;
   added: number;
   removed: number;
+  /**
+   * Devices the group's filter matched, i.e. the same number the server-side
+   * preview endpoint reports for that filter. Only set by the whole-group
+   * evaluation (`evaluateGroupMembership`).
+   */
+  matched?: number;
+  /**
+   * Membership rows actually READABLE for the group once the writes finished.
+   * Compared against `matched` to turn a silent zero-row materialization into
+   * a logged error — see `evaluateGroupMembership`.
+   */
+  materialized?: number;
+}
+
+/**
+ * Short description of the RLS access context the current call is running in,
+ * for diagnostics only. `none` is the dangerous one: under the forced-RLS
+ * `breeze_app` role a contextless SELECT silently returns zero rows, which is
+ * exactly how a dynamic group ends up with an empty membership and no error
+ * anywhere in the logs.
+ */
+function describeDbContext(): string {
+  if (!hasDbAccessContext()) return 'none';
+  const context = getCurrentDbAccessContext();
+  if (!context) return 'unknown';
+  return context.orgId ? `${context.scope}:${context.orgId}` : context.scope;
 }
 
 function isFilterConditionGroup(value: unknown): value is FilterConditionGroup {
@@ -69,6 +95,35 @@ export async function logMembershipChange(
     action,
     reason
   });
+}
+
+/**
+ * Bulk variant of `logMembershipChange`. A whole-group evaluation can add or
+ * remove every device in an org at once; one INSERT per device turned the
+ * evaluation into an O(devices) round-trip storm, which is what made running
+ * it inside the request unattractive in the first place. One multi-row INSERT
+ * keeps the whole evaluation to a handful of statements regardless of size.
+ */
+async function logMembershipChanges(
+  groupId: string,
+  deviceIds: string[],
+  action: MembershipAction,
+  reason: MembershipReason,
+  orgId: string,
+  database: GroupMembershipDatabase = db,
+): Promise<void> {
+  if (deviceIds.length === 0) return;
+  await database.insert(groupMembershipLog).values(
+    deviceIds.map((deviceId) => ({ groupId, deviceId, orgId, action, reason })),
+  );
+}
+
+async function countGroupMemberships(groupId: string): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(deviceGroupMemberships)
+    .where(eq(deviceGroupMemberships.groupId, groupId));
+  return Number(row?.count ?? 0);
 }
 
 export async function evaluateDeviceMembershipForGroup(
@@ -175,7 +230,20 @@ export async function evaluateGroupMembership(groupId: string): Promise<Membersh
     .where(eq(deviceGroups.id, groupId))
     .limit(1);
 
-  if (!group || group.type !== 'dynamic' || !isFilterConditionGroup(group.filterConditions)) {
+  if (!group) {
+    // Every caller evaluates a group it has just created, updated or read, so
+    // an invisible group row is never "the group is gone" — it means the SELECT
+    // was filtered by RLS because this call is running with the wrong access
+    // context (or none at all). Returning a zero summary here is what made the
+    // whole materialization vanish without a single log line, so say it loudly.
+    console.error(
+      `[groupMembership] group ${groupId} is not visible to this DB access context ` +
+      `(dbAccessContext=${describeDbContext()}) — membership was NOT materialized`,
+    );
+    return { evaluatedGroups: 0, added: 0, removed: 0, matched: 0, materialized: 0 };
+  }
+
+  if (group.type !== 'dynamic' || !isFilterConditionGroup(group.filterConditions)) {
     return { evaluatedGroups: 0, added: 0, removed: 0 };
   }
 
@@ -224,9 +292,7 @@ export async function evaluateGroupMembership(groupId: string): Promise<Membersh
         }))
       )
       .onConflictDoNothing();
-    await Promise.all(
-      toAdd.map(deviceId => logMembershipChange(groupId, deviceId, 'added', 'filter_match', group.orgId))
-    );
+    await logMembershipChanges(groupId, toAdd, 'added', 'filter_match', group.orgId);
   }
 
   if (toRemove.length > 0) {
@@ -238,12 +304,39 @@ export async function evaluateGroupMembership(groupId: string): Promise<Membersh
           inArray(deviceGroupMemberships.deviceId, toRemove)
         )
       );
-    await Promise.all(
-      toRemove.map(deviceId => logMembershipChange(groupId, deviceId, 'removed', 'filter_unmatch', group.orgId))
-    );
+    await logMembershipChanges(groupId, toRemove, 'removed', 'filter_unmatch', group.orgId);
   }
 
-  return { evaluatedGroups: 1, added: toAdd.length, removed: toRemove.length };
+  // Verify what actually landed whenever we wrote something. `matched` is the
+  // same number the server-side preview endpoint reports for this filter, so a
+  // shortfall is precisely the "preview says 3, membership says 0" symptom —
+  // the one that previously left no trace anywhere. Pinned members survive a
+  // filter miss, so they count towards the expected total too.
+  const matched = matchingIds.size;
+  let materialized: number | undefined;
+  if (toAdd.length > 0 || toRemove.length > 0) {
+    const expected = new Set(matchingIds);
+    for (const membership of currentMemberships) {
+      if (membership.isPinned) expected.add(membership.deviceId);
+    }
+    materialized = await countGroupMemberships(groupId);
+    if (materialized < expected.size) {
+      console.error(
+        `[groupMembership] materialization shortfall for group ${groupId} (org ${group.orgId}): ` +
+        `filter matched ${matched} device(s), expected ${expected.size} membership row(s), ` +
+        `found ${materialized} after add=${toAdd.length} remove=${toRemove.length} ` +
+        `(dbAccessContext=${describeDbContext()})`,
+      );
+    }
+  }
+
+  return {
+    evaluatedGroups: 1,
+    added: toAdd.length,
+    removed: toRemove.length,
+    matched,
+    materialized,
+  };
 }
 
 /**


### PR DESCRIPTION
## The defect

Creating a dynamic device group with `Architecture equals x64` showed a server-side preview of **3 matching devices**, but

```sql
SELECT count(*) FROM device_group_memberships WHERE group_id = '<new group>';
```

stayed at **0** indefinitely. Nothing appeared in the API logs — not even the `console.error` the create route already had.

## Mechanism (verified against a real Postgres, not inferred)

`apps/api/src/routes/groups.ts:511` fired the evaluation and deliberately did not await it:

```ts
evaluateGroupMembership(group.id).catch((err) => { console.error(...); });
```

`authMiddleware` runs the whole handler inside `withDbAccessContext`, which is `baseDb.transaction(...)` (`apps/api/src/db/index.ts:275`) because the RLS GUCs are set with `SET LOCAL`. The sequence is:

1. `evaluateGroupMembership` runs synchronously up to its first `await`, so the `SELECT ... FROM device_groups` (`services/groupMembership.ts:172`) **is** dispatched on the still-open request transaction and succeeds.
2. The handler returns; drizzle/postgres.js commits that transaction and releases its reserved pooled connection.
3. The detached continuation resumes. AsyncLocalStorage still resolves `db` to the *committed* transaction handle, so the next query — on the create path that is `evaluateFilter` → `withFilterStatementTimeout` → `db.transaction(...)`, i.e. a `SAVEPOINT` (`services/filterEngine.ts:556`) — is queued on a connection that transaction no longer owns.
4. That query is **never executed and never errors**. The promise never settles, so the route's `.catch()` never runs. Zero rows, zero errors, zero logs.

Reproduced deterministically: with the evaluation started inside a live `withDbAccessContext` and awaited afterwards, step 1 returned the group row, then the whole promise timed out unsettled and `device_group_memberships` stayed at 0. It is **not** an RLS policy rejection (that raises `new row violates row-level security policy`, loudly) and **not** an `org_id` mismatch — the org stamping was already correct.

The preview endpoint worked precisely because it `await`s `evaluateFilterWithPreview` inside the request (`routes/groups.ts:966`), so it never leaves the live transaction.

The filter-only branch of `PATCH /groups/:id` (`routes/groups.ts:637`) had the identical shape and was equally inert. The `siteChanged` branch already awaited, which is why site moves worked.

## The fix

**`apps/api/src/routes/groups.ts`**
- `POST /groups`: `await evaluateGroupMembership(...)`, then read `getDeviceCountForGroup(...)` so the 201 carries the real count instead of a hardcoded `0`. A failure is caught and logged but still returns 201 — the group *was* created, and failing the request would invite a duplicate on retry.
- `PATCH /groups/:id`: the fire-and-forget branch is gone; both filter and site changes await. A failure propagates (PATCH is idempotent, so a 500 is retryable) rather than leaving membership silently stale against the new filter.

**`apps/api/src/services/groupMembership.ts`**
- The per-device `groupMembershipLog` INSERTs (`Promise.all(toAdd.map(logMembershipChange))`) are batched into one multi-row INSERT. This is what makes awaiting cheap: the whole evaluation is now a fixed handful of statements regardless of how many devices matched, instead of O(devices) round trips.
- **Loud on invisible group**: a `!group` result now logs an error naming the group id and the active DB access context (`dbAccessContext=none|organization:<id>|...`) instead of returning a bland zero summary. A caller only ever evaluates a group it just created or read, so an invisible row is always an access-context bug, never "the group is gone".
- **Loud on shortfall**: after writing, the service re-counts the group's membership rows and logs an error if the count is below what the filter matched (plus surviving pinned members). `matched` is the same number the preview endpoint reports for that filter, so this diagnostic states the exact reported symptom: *"filter matched 3 device(s), expected 3 membership row(s), found 0"*.
- `MembershipUpdateSummary` gains optional `matched` / `materialized`.

No new tables, no new columns, no migration — nothing touches the cascade-registration or export-policy lists.

## Tenant safety

The write is now **more** tenant-constrained than before, not less:

- The evaluation runs inside the caller's own **org-scoped** request context, so Postgres RLS enforces the boundary on every read and write. The alternative (escalating to `withSystemDbAccessContext` for detached work) would have removed that DB-level backstop in favour of app-layer scoping only; awaiting keeps the strict version.
- App-layer scoping is unchanged and correct: `evaluateFilter` filters on `eq(devices.orgId, group.orgId)`, and every membership row is stamped with the **group's** `orgId`, never a device- or caller-derived one.
- Proven against real Postgres: a matching device in a *different partner's* org is never absorbed, every materialized row carries the group's `org_id`, the foreign tenant cannot see the group at all, and a membership INSERT claiming the owner's `org_id` is rejected with `new row violates row-level security policy`.

### Pre-existing gap, now pinned by a test (not introduced here)

`device_group_memberships` policies key on `org_id` alone (`breeze_has_org_access(org_id)`), and there is no composite FK tying `(group_id, org_id)` back to `device_groups`. A foreign tenant that somehow learned a group's UUID can insert a row naming that group **as long as it stamps its own `org_id`**. Such a row is quarantined — the owning org's context cannot read it, so it can never surface as a member of their group — and the group's own materialization never produces it. The integration test asserts both the rejection and the quarantine so the behaviour can't drift unnoticed. Closing it properly needs a `UNIQUE (id, org_id)` on `device_groups` plus a composite FK and a backfill; that is deliberately out of scope for this fix.

## Test evidence

New `apps/api/src/__tests__/integration/dynamicGroupMembershipMaterialization.integration.test.ts` (real Postgres, real JWT, real `authMiddleware`, real `breeze_app` forced RLS — the mocked route suites resolve `evaluateGroupMembership` from a `vi.fn()`, so a detached call looks identical to an awaited one there):

1. membership rows are readable the instant the 201 lands, and `data.deviceCount` agrees;
2. a matching device in another partner's org is never absorbed; every row carries the group's `org_id`;
3. the foreign tenant cannot see the group, and an INSERT claiming the owner's `org_id` is rejected by RLS (with the quarantine gap above asserted explicitly);
4. `PATCH` with a new filter re-materializes before responding;
5. an evaluation run under a context that cannot see the group logs the loud error and writes nothing.

New `apps/api/src/services/groupMembership.materialization.test.ts` (6 unit tests) covers the invisible-group log, the shortfall log, the quiet happy path, pinned members counting toward the expected total, and the batched log INSERT.

`apps/api/src/routes/groups_get_create.test.ts` gains two cases: the create handler must not respond while the evaluation is still pending, and a failed materialization still returns 201 while logging.

**Verified in both directions:**

| Suite | Pre-fix (source reverted to `origin/main`) | Post-fix |
|---|---|---|
| `dynamicGroupMembershipMaterialization.integration.test.ts` | **4 failed / 1 passed** — `expected [] to deeply equal [ …(2) ]`, i.e. exactly the 0-rows symptom | **5 passed** |
| `groupMembership.materialization.test.ts` + `groups_get_create.test.ts` | **6 failed / 16 passed** | **22 passed** |

Full runs on the final tree:

- `tsc --noEmit -p apps/api/tsconfig.json` → exit 0
- `groupMembership.siteScope`, `groupMembership.materialization`, `groups`, `groups_get_create`, `groups_update_delete`, `groups_devices`, `groups_list`, `groups_preview_pin`, `groups_log_multitenant`, `src/events` → **9 files / 88 tests passed**
- integration suite above → **5 passed**

Integration tests genuinely ran, against a throwaway Postgres 16 on `:5434` provisioned via the repo's own `autoMigrate` + the integration `globalSetup`/`setup` files (tmpfs + `fsync=off`, per the known local-perf trap), with the standard `breeze_app` unprivileged role and forced RLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
