### PR TITLE
fix(api): honour the script's own timeoutSeconds in the stale reaper (#3190)

### DIFF
--- a/apps/api/src/jobs/staleCommandReaper.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.test.ts
@@ -936,11 +936,6 @@ describe('reapStaleSoftwareDeploymentResults', () => {
 });
 
 
-// #3097: script results submitted over the HTTP path never reach
-// `script_executions`, so the row stays pending, lands in this reaper, and was
-// stamped `timeout` / "no response from agent". That is false whenever a terminal
-// device_commands row exists — the agent DID answer. On one live instance 89
-// executions read `timeout` while their command had completed with output.
 // #3190: the reaper used a flat 300s+grace deadline for every execution and
 // ignored the script's own `timeoutSeconds`, which is wrong in both directions.
 // These two cases are the issue's two symptoms, and each one flips if the
@@ -988,6 +983,42 @@ describe('reapStaleScriptExecutions per-script timeout (#3190)', () => {
     expect(execSet).toHaveBeenCalledTimes(1);
   });
 
+  // Pins the `running` reference-time branch, which had no coverage anywhere in
+  // this file. It only mattered once the deadline became per-script: "which
+  // timestamp do we measure from" and "how long is the budget" now interact, so
+  // a regression in either could otherwise ship green. Old createdAt, recent
+  // startedAt, short script — measuring from createdAt would reap it, measuring
+  // from startedAt correctly does not.
+  it('measures a running execution from startedAt, not createdAt', async () => {
+    const createdAt = new Date(Date.now() - 60 * 60 * 1000);
+    const startedAt = new Date(Date.now() - 60 * 1000);
+    selectMock
+      .mockReturnValueOnce(selectChain([
+        {
+          id: 'exec-1',
+          status: 'running',
+          scriptId: 'script-1',
+          createdAt,
+          startedAt,
+          timeoutSeconds: 30,
+        },
+      ]))
+      .mockReturnValueOnce(selectChain([]));
+
+    const execSet = vi.fn((_values: Record<string, unknown>) => ({
+      where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'exec-1' }]) })),
+    }));
+    updateMock.mockImplementation((table: unknown) => {
+      if (table === scriptExecutionsTable) return { set: execSet };
+      throw new Error(`Unexpected table update: ${String(table)}`);
+    });
+
+    const reaped = await reapStaleScriptExecutions();
+
+    expect(reaped).toBe(0);
+    expect(execSet).not.toHaveBeenCalled();
+  });
+
   it('leaves a long-timeout script alone while it is still within its deadline', async () => {
     // 1h script => 1h + 5min grace. At 30 minutes it is still running legally.
     // Under the old flat 10-minute deadline this was reaped and reported as
@@ -1001,6 +1032,11 @@ describe('reapStaleScriptExecutions per-script timeout (#3190)', () => {
   });
 });
 
+// #3097: script results submitted over the HTTP path never reach
+// `script_executions`, so the row stays pending, lands in this reaper, and was
+// stamped `timeout` / "no response from agent". That is false whenever a terminal
+// device_commands row exists — the agent DID answer. On one live instance 89
+// executions read `timeout` while their command had completed with output.
 describe('reapStaleScriptExecutions terminal-command guard (#3097)', () => {
   const longAgo = new Date(Date.now() - 60 * 60 * 1000);
 

--- a/apps/api/src/jobs/staleCommandReaper.test.ts
+++ b/apps/api/src/jobs/staleCommandReaper.test.ts
@@ -941,6 +941,66 @@ describe('reapStaleSoftwareDeploymentResults', () => {
 // stamped `timeout` / "no response from agent". That is false whenever a terminal
 // device_commands row exists — the agent DID answer. On one live instance 89
 // executions read `timeout` while their command had completed with output.
+// #3190: the reaper used a flat 300s+grace deadline for every execution and
+// ignored the script's own `timeoutSeconds`, which is wrong in both directions.
+// These two cases are the issue's two symptoms, and each one flips if the
+// per-script deadline is reverted to a constant.
+describe('reapStaleScriptExecutions per-script timeout (#3190)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  function arrangeExec(opts: { timeoutSeconds: number; ageMs: number }) {
+    const createdAt = new Date(Date.now() - opts.ageMs);
+    selectMock
+      .mockReturnValueOnce(selectChain([
+        {
+          id: 'exec-1',
+          status: 'pending',
+          scriptId: 'script-1',
+          createdAt,
+          startedAt: null,
+          timeoutSeconds: opts.timeoutSeconds,
+        },
+      ]))
+      // the #3097 device-command lookup — no terminal row, so the guard is inert
+      .mockReturnValueOnce(selectChain([]));
+
+    const execSet = vi.fn((_values: Record<string, unknown>) => ({
+      where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'exec-1' }]) })),
+    }));
+    updateMock.mockImplementation((table: unknown) => {
+      if (table === scriptExecutionsTable) return { set: execSet };
+      throw new Error(`Unexpected table update: ${String(table)}`);
+    });
+    return { execSet };
+  }
+
+  it('reaps a short-timeout script once its own deadline has passed', async () => {
+    // 30s script => 30s + 5min grace = 5.5min. At 7 minutes it is overdue.
+    // Under the old flat 10-minute deadline this row was skipped, so the
+    // execution sat pending far past its own contract.
+    const { execSet } = arrangeExec({ timeoutSeconds: 30, ageMs: 7 * 60 * 1000 });
+
+    const reaped = await reapStaleScriptExecutions();
+
+    expect(reaped).toBe(1);
+    expect(execSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a long-timeout script alone while it is still within its deadline', async () => {
+    // 1h script => 1h + 5min grace. At 30 minutes it is still running legally.
+    // Under the old flat 10-minute deadline this was reaped and reported as
+    // "no response from agent" while the script was working correctly.
+    const { execSet } = arrangeExec({ timeoutSeconds: 3600, ageMs: 30 * 60 * 1000 });
+
+    const reaped = await reapStaleScriptExecutions();
+
+    expect(reaped).toBe(0);
+    expect(execSet).not.toHaveBeenCalled();
+  });
+});
+
 describe('reapStaleScriptExecutions terminal-command guard (#3097)', () => {
   const longAgo = new Date(Date.now() - 60 * 60 * 1000);
 

--- a/apps/api/src/jobs/staleCommandReaper.ts
+++ b/apps/api/src/jobs/staleCommandReaper.ts
@@ -6,6 +6,7 @@ import {
   deviceCommands,
   scriptExecutions,
   scriptExecutionBatches,
+  scripts,
   patchJobs,
   patchJobResults,
   deployments,
@@ -21,11 +22,11 @@ import {
   STALE_BACKUP_REAP_MARKER,
 } from '../db/schema';
 import { getBullMQConnection } from '../services/redis';
-import { getCommandTimeoutMs, EXCLUDED_COMMAND_TYPES } from '../services/commandTimeouts';
+import { getCommandTimeoutMs, EXCLUDED_COMMAND_TYPES, SCRIPT_GRACE_BUFFER_MS } from '../services/commandTimeouts';
 import { captureException } from '../services/sentry';
 import { recordBackupCommandTimeout, recordRestoreTimeout } from '../services/backupMetrics';
 import { revokeViewerSession } from '../services/viewerTokenRevocation';
-import { queueBackupStopCommand } from '../services/commandQueue';
+import { queueBackupStopCommand, CommandTypes } from '../services/commandQueue';
 import { envInt } from '../utils/envInt';
 
 const QUEUE_NAME = 'stale-command-reaper';
@@ -287,9 +288,23 @@ export async function reapStaleDeviceCommands(): Promise<number> {
 }
 
 export async function reapStaleScriptExecutions(): Promise<number> {
-  // Default script timeout + grace buffer (300s script + 300s grace = 10 min)
-  const defaultTimeoutMs = 300 * 1000 + 5 * 60 * 1000;
-  const conservativeCutoff = new Date(Date.now() - defaultTimeoutMs);
+  // #3190: this used to be a flat `300s + 5min grace` for every execution,
+  // ignoring the script's own `timeoutSeconds`. That is wrong in both
+  // directions: a legitimately long script was reaped and reported as stale
+  // while it was still running correctly, and a short-timeout script sat
+  // pending far past its own contract.
+  //
+  // The deadline now comes from the script row, through the same
+  // `getCommandTimeoutMs` used by the device-command reaper above — one source
+  // of truth for "how long may a script take", rather than a second copy that
+  // can drift from it.
+  //
+  // The SQL pre-filter uses the grace buffer alone as a conservative floor:
+  // `timeoutSeconds` is a non-negative integer, so every per-script deadline is
+  // at least SCRIPT_GRACE_BUFFER_MS and nothing younger than that can be due.
+  // Rows selected here are re-checked per row below against their own script's
+  // deadline, mirroring reapStaleDeviceCommands.
+  const conservativeCutoff = new Date(Date.now() - SCRIPT_GRACE_BUFFER_MS);
 
   const staleExecs = await db
     .select({
@@ -298,8 +313,10 @@ export async function reapStaleScriptExecutions(): Promise<number> {
       scriptId: scriptExecutions.scriptId,
       createdAt: scriptExecutions.createdAt,
       startedAt: scriptExecutions.startedAt,
+      timeoutSeconds: scripts.timeoutSeconds,
     })
     .from(scriptExecutions)
+    .innerJoin(scripts, eq(scripts.id, scriptExecutions.scriptId))
     .where(
       and(
         inArray(scriptExecutions.status, ['pending', 'queued', 'running']),
@@ -313,11 +330,17 @@ export async function reapStaleScriptExecutions(): Promise<number> {
   let reaped = 0;
 
   for (const exec of staleExecs) {
+    // The per-row deadline must use the script's own value too. Leaving this
+    // check on a fixed constant would keep enforcing the old floor and make
+    // the fix inert for exactly the short-timeout case #3190 describes.
+    const timeoutMs = getCommandTimeoutMs(CommandTypes.SCRIPT, {
+      timeoutSeconds: exec.timeoutSeconds,
+    });
     const referenceTime = exec.status === 'running' && exec.startedAt
       ? exec.startedAt.getTime()
       : exec.createdAt.getTime();
 
-    if (now - referenceTime < defaultTimeoutMs) continue;
+    if (now - referenceTime < timeoutMs) continue;
 
     // #3097: this lookup used to happen AFTER the update, purely to find the
     // batch. It runs first now because it also answers whether the agent

--- a/apps/api/src/services/commandTimeouts.ts
+++ b/apps/api/src/services/commandTimeouts.ts
@@ -13,7 +13,11 @@ const TWO_HOURS = 2 * 60 * 60 * 1000;
 // sit before the generic reaper closes it out.
 const SEVEN_DAYS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = THIRTY_MINUTES;
-const SCRIPT_GRACE_BUFFER_MS = 5 * 60 * 1000; // extra buffer on top of per-script timeout
+// Extra buffer on top of a script's own timeout, so the agent-side timeout
+// always fires first. Exported because the stale reaper needs it as the floor
+// for its SQL pre-filter: every per-script deadline is at least this long, so
+// nothing younger than the buffer can be due (#3190).
+export const SCRIPT_GRACE_BUFFER_MS = 5 * 60 * 1000;
 const DEFAULT_SCRIPT_TIMEOUT_S = 300;
 
 // ── Commands that should never be reaped (interactive sessions) ───


### PR DESCRIPTION
Fixes #3190.

## The defect

`reapStaleScriptExecutions` used a flat deadline for every execution:

```ts
const defaultTimeoutMs = 300 * 1000 + 5 * 60 * 1000; // 300s script + 300s grace
```

It never read the script's own `timeoutSeconds`, so it is wrong in both directions:

- a **long-timeout script** is reaped and stamped "no response from agent" while it is still executing correctly;
- a **short-timeout script** sits pending far past its own contract.

## The fix

The deadline now comes from the script row through `getCommandTimeoutMs`, which is the same helper `reapStaleDeviceCommands` already uses a few lines above. That leaves one source of truth for "how long may a script take" instead of a second hardcoded copy that can drift from it.

**Both the query pre-filter and the per-row re-check use it.** That second one is the part worth calling out: leaving the re-check on a fixed constant would keep enforcing the old floor and make the whole change inert for exactly the short-timeout case this issue names. The tests below fail in precisely that way if it is reverted.

The pre-filter uses `SCRIPT_GRACE_BUFFER_MS` as a conservative floor — `timeoutSeconds` is a non-negative integer, so every per-script deadline is at least the grace buffer and nothing younger than that can be due. Rows are then re-checked individually, mirroring the device-command reaper's `SHORTEST_TIMEOUT_MS` pattern.

## Safety

- `script_executions.script_id` is `NOT NULL` (`db/schema/scripts.ts:114`), so the `innerJoin` to `scripts` cannot silently drop rows.
- Executions whose script uses the default 300s are **completely unaffected** — the old constant was exactly what `getCommandTimeoutMs` returns for the default. Existing behaviour is preserved where it was already correct.
- `SCRIPT_GRACE_BUFFER_MS` is newly exported; its value is unchanged.
- No migration, no schema change, no new table or column, so there is nothing to add to the cascade or export-policy registries.

## Relationship to #3097

These are separate axes of the same function and do not overlap, as discussed on the issue. #3097 (merged as #3172) decides *what the reaper concludes* about a row it already selected; this decides *which rows are selected and when*. #3172's terminal-command guard is untouched here and its tests still pass.

Worth noting the interaction runs one way: a tighter per-script deadline selects those rows **sooner and in greater number**, so the #3172 guard gets more load, not less.

## Test evidence

Two new cases, one per direction of the defect:

| Case | Script timeout | Age | Expected |
|---|---|---|---|
| short-timeout is reaped once its own deadline passes | 30s (→ 5.5 min) | 7 min | reaped |
| long-timeout is left alone while still within its deadline | 1h (→ 65 min) | 30 min | not reaped |

**Verified in both directions.** Replacing *only* the per-script deadline with the old flat constant, leaving everything else in place:

| | Result |
|---|---|
| flat deadline restored | **2 failed / 34 passed** — exactly the two new cases |
| fix in place | **36 passed** |

Full runs on the final tree, Node 22.23.2:

- `tsc --noEmit -p apps/api/tsconfig.json` → **exit 0**, no output
- `apps/api` full unit suite → **1273 files passed / 5 skipped, 20199 tests passed / 61 skipped**
- Targeted: `staleCommandReaper`, `commandTimeouts` → 2 files / 38 tests passed

https://claude.ai/code/session_01RUup17Z6KMH9jSkhBBhRJ1
