### PR TITLE
fix(api): scope snmpWorker DB contexts to DB statements only (#3215)

### DIFF
--- a/apps/api/src/jobs/snmpQueue.test.ts
+++ b/apps/api/src/jobs/snmpQueue.test.ts
@@ -23,6 +23,9 @@ vi.mock('../db', () => ({
     update: vi.fn(),
   },
   withSystemDbAccessContext: undefined,
+  // #1105 tripwire used by createInstrumentedQueue (the factory getSnmpQueue
+  // now builds through). No-op here — these tests hold no DB context.
+  assertOutsideHeldDbContext: vi.fn(),
 }));
 
 vi.mock('../db/schema', () => ({

--- a/apps/api/src/jobs/snmpWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/snmpWorker.dbcontext.test.ts
@@ -316,9 +316,15 @@ describe('snmpWorker DB-context scoping (#3215)', () => {
   });
 
   it('the worker handler does not wrap job bodies in an outer context', async () => {
-    // Guard against reintroducing the outer runWithSystemDbAccess: because
-    // withDbAccessContext re-entry is a no-op, an outer wrap would make the
-    // scheduler's enqueues run at depth 1 and never emit a second ctx:enter.
+    // Guard against reintroducing the outer runWithSystemDbAccess.
+    //
+    // Careful about WHY this fails, because prod and this mock differ: in prod
+    // `withDbAccessContext` short-circuits on re-entry, so an outer wrap would
+    // leave one transaction open across the enqueues. This mock does NOT model
+    // that short-circuit — it increments depth unconditionally — so an outer
+    // wrap here shows up as TWO ctx:enter events with the select at depth 2 and
+    // the enqueues at depth 1. Either way the assertions below fail (verified by
+    // mutation), which is what matters; don't read the mock as prod semantics.
     mockDb.select.mockReturnValueOnce(
       selectWhereChain([{ id: 'd1', orgId: 'o1', pollingInterval: 60, lastPolled: null }], 'dueSelect') as never
     );

--- a/apps/api/src/jobs/snmpWorker.dbcontext.test.ts
+++ b/apps/api/src/jobs/snmpWorker.dbcontext.test.ts
@@ -1,0 +1,336 @@
+/**
+ * snmpWorker DB-context scoping (#1105 class, issue #3215).
+ *
+ * The regression these tests lock down: `createSnmpWorker` used to wrap the
+ * ENTIRE job body in `withSystemDbAccessContext`, so the scheduler's Redis
+ * fan-out and the poll-device agent WebSocket dispatch ran while a pooled
+ * Postgres connection sat idle-in-transaction (observed: 51 seconds).
+ *
+ * An identity `fn => fn()` mock of the context helper can never catch that, so
+ * the mock below tracks real enter/exit depth and the tests assert WHICH depth
+ * each DB read, each enqueue and each WS send happened at.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb, ctxState, queueMock, agentWsMock } = vi.hoisted(() => ({
+  mockDb: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+  // DB-access-context depth + an ordered event log, so a test can prove which
+  // work runs inside a held transaction and which runs after it closes.
+  ctxState: { depth: 0, events: [] as string[] },
+  queueMock: {
+    getJob: vi.fn(async () => null),
+    add: vi.fn(async () => ({ id: 'job-1' })),
+    addBulk: vi.fn(async () => []),
+    getRepeatableJobs: vi.fn(async () => []),
+    removeRepeatableByKey: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+  },
+  agentWsMock: {
+    isAgentConnected: vi.fn(() => true),
+    sendCommandToAgent: vi.fn(() => true),
+  },
+}));
+
+const workerProcessors: Array<(job: { data: unknown }) => Promise<unknown>> = [];
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    getJob = queueMock.getJob;
+    add = queueMock.add;
+    addBulk = queueMock.addBulk;
+    getRepeatableJobs = queueMock.getRepeatableJobs;
+    removeRepeatableByKey = queueMock.removeRepeatableByKey;
+    close = queueMock.close;
+  },
+  Worker: class {
+    constructor(_name: string, processor: (job: { data: unknown }) => Promise<unknown>) {
+      workerProcessors.push(processor);
+    }
+
+    close = vi.fn();
+    on = vi.fn();
+  },
+  Job: class {},
+}));
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  // Real-ish context wrapper: tracks depth around fn so the tests can assert
+  // what runs inside the context vs after it closes.
+  withSystemDbAccessContext: async (fn: () => unknown) => {
+    ctxState.depth++;
+    ctxState.events.push('ctx:enter');
+    try {
+      return await fn();
+    } finally {
+      ctxState.depth--;
+      ctxState.events.push('ctx:exit');
+    }
+  },
+  // #1105 tripwire wired into createInstrumentedQueue's add(). Mirror prod
+  // semantics: record a violation if an enqueue runs while a context is held.
+  assertOutsideHeldDbContext: (op: string) => {
+    if (ctxState.depth > 0) ctxState.events.push(`tripwire-violation:${op}`);
+  },
+}));
+
+vi.mock('../db/schema', () => ({
+  snmpDevices: {
+    id: 'snmpDevices.id',
+    orgId: 'snmpDevices.orgId',
+    isActive: 'snmpDevices.isActive',
+    lastPolled: 'snmpDevices.lastPolled',
+    pollingInterval: 'snmpDevices.pollingInterval',
+  },
+  snmpMetrics: { deviceId: 'snmpMetrics.deviceId' },
+  snmpTemplates: {
+    id: 'snmpTemplates.id',
+    oids: 'snmpTemplates.oids',
+    isBuiltIn: 'snmpTemplates.isBuiltIn',
+    orgId: 'snmpTemplates.orgId',
+  },
+  devices: {
+    agentId: 'devices.agentId',
+    orgId: 'devices.orgId',
+    isEphemeral: 'devices.isEphemeral',
+    status: 'devices.status',
+  },
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('../routes/agentWs', () => ({
+  isAgentConnected: agentWsMock.isAgentConnected,
+  sendCommandToAgent: agentWsMock.sendCommandToAgent,
+}));
+
+vi.mock('../services/snmpSecrets', () => ({
+  decryptSnmpSecret: vi.fn((v: string | null) => v),
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: vi.fn(),
+}));
+
+import { createSnmpWorker } from './snmpWorker';
+
+/** A `.select().from().where().limit()` chain that logs the depth it ran at. */
+function selectLimitChain(rows: unknown[], label: string) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockImplementation(async () => {
+          ctxState.events.push(`${label}@depth${ctxState.depth}`);
+          return rows;
+        }),
+      }),
+    }),
+  };
+}
+
+/** A `.select().from().where()` chain (no limit) that logs its depth. */
+function selectWhereChain(rows: unknown[], label: string) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockImplementation(async () => {
+        ctxState.events.push(`${label}@depth${ctxState.depth}`);
+        return rows;
+      }),
+    }),
+  };
+}
+
+function runJob(data: unknown): Promise<unknown> {
+  const processor = workerProcessors[0];
+  if (!processor) throw new Error('worker processor was not registered');
+  return processor({ data });
+}
+
+describe('snmpWorker DB-context scoping (#3215)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    workerProcessors.length = 0;
+    ctxState.depth = 0;
+    ctxState.events = [];
+
+    queueMock.getJob.mockResolvedValue(null);
+    queueMock.add.mockImplementation(async () => {
+      ctxState.events.push(`enqueue@depth${ctxState.depth}`);
+      return { id: 'job-1' };
+    });
+    agentWsMock.isAgentConnected.mockImplementation(() => {
+      ctxState.events.push(`isAgentConnected@depth${ctxState.depth}`);
+      return true;
+    });
+    agentWsMock.sendCommandToAgent.mockImplementation(() => {
+      ctxState.events.push(`wsDispatch@depth${ctxState.depth}`);
+      return true;
+    });
+
+    createSnmpWorker();
+  });
+
+  it('poll-scheduler reads due devices in-context but enqueues OUTSIDE it', async () => {
+    mockDb.select.mockReturnValueOnce(
+      selectWhereChain(
+        [
+          { id: 'd1', orgId: 'o1', pollingInterval: 60, lastPolled: null },
+          { id: 'd2', orgId: 'o2', pollingInterval: 60, lastPolled: null },
+        ],
+        'dueSelect'
+      ) as never
+    );
+
+    const result = await runJob({ type: 'poll-scheduler' });
+
+    expect(result).toEqual({ enqueued: 2 });
+    // The SELECT runs in-context (depth 1), the context CLOSES, then both
+    // enqueues run with no transaction held (depth 0). This is the #1105 fix.
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'dueSelect@depth1',
+      'ctx:exit',
+      'enqueue@depth0',
+      'enqueue@depth0',
+    ]);
+    expect(ctxState.events.some((e) => e.startsWith('tripwire-violation'))).toBe(false);
+  });
+
+  it('poll-scheduler opens no second context when nothing is due', async () => {
+    mockDb.select.mockReturnValueOnce(selectWhereChain([], 'dueSelect') as never);
+
+    const result = await runJob({ type: 'poll-scheduler' });
+
+    expect(result).toEqual({ enqueued: 0 });
+    expect(queueMock.add).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual(['ctx:enter', 'dueSelect@depth1', 'ctx:exit']);
+  });
+
+  it('poll-device reads config in-context but dispatches to the agent OUTSIDE it', async () => {
+    mockDb.select
+      .mockReturnValueOnce(
+        selectLimitChain(
+          [
+            {
+              id: 'd1',
+              orgId: 'o1',
+              templateId: 't1',
+              ipAddress: '10.0.0.1',
+              port: 161,
+              snmpVersion: 'v2c',
+              community: 'public',
+              username: null,
+              authProtocol: null,
+              authPassword: null,
+              privProtocol: null,
+              privPassword: null,
+            },
+          ],
+          'deviceSelect'
+        ) as never
+      )
+      .mockReturnValueOnce(
+        selectLimitChain([{ oids: [{ oid: '1.3.6.1.2.1.1.1.0' }] }], 'templateSelect') as never
+      )
+      .mockReturnValueOnce(selectLimitChain([{ agentId: 'agent-1' }], 'agentSelect') as never);
+
+    const result = await runJob({ type: 'poll-device', deviceId: 'd1', orgId: 'o1' });
+
+    expect(result).toEqual({ dispatched: true, agentId: 'agent-1' });
+    // All three reads share ONE context; the WS connectivity check and the
+    // socket write happen only after it closes.
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'deviceSelect@depth1',
+      'templateSelect@depth1',
+      'agentSelect@depth1',
+      'ctx:exit',
+      'isAgentConnected@depth0',
+      'wsDispatch@depth0',
+    ]);
+  });
+
+  it('poll-device does not dispatch — and holds no context — when the device is missing', async () => {
+    mockDb.select.mockReturnValueOnce(selectLimitChain([], 'deviceSelect') as never);
+
+    const result = await runJob({ type: 'poll-device', deviceId: 'gone', orgId: 'o1' });
+
+    expect(result).toEqual({ dispatched: false, agentId: null });
+    expect(agentWsMock.sendCommandToAgent).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual(['ctx:enter', 'deviceSelect@depth1', 'ctx:exit']);
+  });
+
+  it('process-poll-results parses metrics between two short contexts, writes inside one', async () => {
+    mockDb.select.mockReturnValueOnce(selectLimitChain([{ orgId: 'o1' }], 'orgSelect') as never);
+
+    const valuesMock = vi.fn().mockImplementation(async () => {
+      ctxState.events.push(`insert@depth${ctxState.depth}`);
+    });
+    mockDb.insert.mockReturnValue({ values: valuesMock } as never);
+    mockDb.update.mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockImplementation(async () => {
+          ctxState.events.push(`update@depth${ctxState.depth}`);
+        }),
+      }),
+    } as never);
+
+    const result = await runJob({
+      type: 'process-poll-results',
+      deviceId: 'd1',
+      metrics: [
+        { oid: '1.3.6.1.2.1.1.1.0', name: 'sysDescr', value: 'router', timestamp: '2026-08-07T00:00:00.000Z' },
+      ],
+    });
+
+    expect(result).toEqual({ metricsWritten: 1 });
+    // Two separate short contexts — the lookup, then the writes. The metric
+    // mapping in between happens with no transaction held, and the insert +
+    // status stamp still share one context so they commit together.
+    expect(ctxState.events).toEqual([
+      'ctx:enter',
+      'orgSelect@depth1',
+      'ctx:exit',
+      'ctx:enter',
+      'insert@depth1',
+      'update@depth1',
+      'ctx:exit',
+    ]);
+  });
+
+  it('process-poll-results skips the write context entirely when the device is unknown', async () => {
+    mockDb.select.mockReturnValueOnce(selectLimitChain([], 'orgSelect') as never);
+
+    const result = await runJob({ type: 'process-poll-results', deviceId: 'gone', metrics: [] });
+
+    expect(result).toEqual({ metricsWritten: 0 });
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(ctxState.events).toEqual(['ctx:enter', 'orgSelect@depth1', 'ctx:exit']);
+  });
+
+  it('the worker handler does not wrap job bodies in an outer context', async () => {
+    // Guard against reintroducing the outer runWithSystemDbAccess: because
+    // withDbAccessContext re-entry is a no-op, an outer wrap would make the
+    // scheduler's enqueues run at depth 1 and never emit a second ctx:enter.
+    mockDb.select.mockReturnValueOnce(
+      selectWhereChain([{ id: 'd1', orgId: 'o1', pollingInterval: 60, lastPolled: null }], 'dueSelect') as never
+    );
+
+    await runJob({ type: 'poll-scheduler' });
+
+    expect(ctxState.events[0]).toBe('ctx:enter');
+    expect(ctxState.events.filter((e) => e === 'ctx:enter')).toHaveLength(1);
+    expect(ctxState.events.at(-1)).toBe('enqueue@depth0');
+  });
+
+  it('rejects an unknown job type', async () => {
+    await expect(runJob({ type: 'nope' })).rejects.toThrow('Unknown job type: nope');
+  });
+});

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -28,10 +28,19 @@ let snmpQueue: Queue | null = null;
 
 export function getSnmpQueue(): Queue {
   if (!snmpQueue) {
-    // Instrumented so an enqueue made inside a held DB context trips the #1105
-    // tripwire instead of silently pinning a pooled connection
-    // idle-in-transaction (the bare `new Queue` here is how the scheduler's
-    // 51-second connection hold went unnoticed in production).
+    // Instrumented so an `add`/`addBulk` made inside a held DB context trips the
+    // #1105 tripwire instead of silently pinning a pooled connection
+    // idle-in-transaction.
+    //
+    // Partial coverage, deliberately stated: createInstrumentedQueue wraps only
+    // Queue.add/addBulk. `enqueueSnmpPoll` does up to three Redis round-trips
+    // BEFORE that (`queue.getJob`, then `job.getState` / `job.remove` on the Job
+    // object, which a Queue-level factory cannot reach), and on the reusable-state
+    // dedupe path it returns without ever calling add. In the steady state of a
+    // busy poll queue that is most iterations — so the tripwire alone would NOT
+    // have caught the 51-second scheduler hold. The depth assertions in
+    // snmpWorker.dbcontext.test.ts are the real regression fence; this is
+    // defense-in-depth on top of them.
     snmpQueue = createInstrumentedQueue(SNMP_QUEUE);
   }
   return snmpQueue;
@@ -99,11 +108,28 @@ export function createSnmpWorker(): Worker<SnmpJobData> {
   );
 }
 
-interface PollDispatchInputs {
-  device: typeof snmpDevices.$inferSelect | null;
-  oids: string[];
-  agentId: string | null;
-}
+/**
+ * Outcome of the poll-device read phase.
+ *
+ * Discriminated on purpose: `{ device: null }`, "no OIDs" and "no online agent"
+ * are three different causes, and a bare `{device, oids, agentId}` struct only
+ * distinguishes them via the ORDER the caller happens to check them in. That
+ * made the log line a function of guard order rather than of the actual cause —
+ * reorder the guards and "No OIDs configured" silently becomes "No online
+ * agent", pointing ops at agent connectivity for a template misconfiguration.
+ * Note `agentId` is also genuinely *unknown* (not "none found") on the no-OIDs
+ * path, because the agent query is skipped there.
+ */
+type PollDispatchInputs =
+  | { status: 'device-missing' }
+  | { status: 'no-oids' }
+  | { status: 'no-agent' }
+  | {
+      status: 'ok';
+      device: typeof snmpDevices.$inferSelect;
+      oids: string[];
+      agentId: string;
+    };
 
 /**
  * Phase 1 of a poll-device job: read every row the dispatch needs inside ONE
@@ -119,7 +145,7 @@ async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDisp
     .limit(1);
 
   if (!device) {
-    return { device: null, oids: [], agentId: null };
+    return { status: 'device-missing' };
   }
 
   // Load template OIDs if device has a template
@@ -140,7 +166,7 @@ async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDisp
   }
 
   if (oids.length === 0) {
-    return { device, oids, agentId: null };
+    return { status: 'no-oids' };
   }
 
   // Find an online agent for this org.
@@ -162,7 +188,12 @@ async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDisp
     )
     .limit(1);
 
-  return { device, oids, agentId: onlineAgent?.agentId ?? null };
+  const agentId = onlineAgent?.agentId ?? null;
+  if (!agentId) {
+    return { status: 'no-agent' };
+  }
+
+  return { status: 'ok', device, oids, agentId };
 }
 
 /**
@@ -173,25 +204,27 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
   agentId: string | null;
 }> {
   // Phase 1 — all DB reads inside a short system DB context, which then CLOSES.
-  const { device, oids, agentId } = await runWithSystemDbAccess(() =>
-    loadPollDispatchInputs(data)
-  );
+  const inputs = await runWithSystemDbAccess(() => loadPollDispatchInputs(data));
 
   // Phase 2 — connectivity check, credential decrypt and the agent WebSocket
   // dispatch, all with NO DB context open (#1105). sendCommandToAgent writes to
   // a socket whose peer may be slow or wedged; holding the transaction across
   // it is what pinned pooled connections for tens of seconds.
-  if (!device) {
-    console.error(`[SnmpWorker] Device ${data.deviceId} not found`);
-    return { dispatched: false, agentId: null };
+  switch (inputs.status) {
+    case 'device-missing':
+      console.error(`[SnmpWorker] Device ${data.deviceId} not found`);
+      return { dispatched: false, agentId: null };
+    case 'no-oids':
+      console.warn(`[SnmpWorker] No OIDs configured for device ${data.deviceId}`);
+      return { dispatched: false, agentId: null };
+    case 'no-agent':
+      console.warn(`[SnmpWorker] No online agent for org ${data.orgId}`);
+      return { dispatched: false, agentId: null };
   }
 
-  if (oids.length === 0) {
-    console.warn(`[SnmpWorker] No OIDs configured for device ${data.deviceId}`);
-    return { dispatched: false, agentId: null };
-  }
+  const { device, oids, agentId } = inputs;
 
-  if (!agentId || !isAgentConnected(agentId)) {
+  if (!isAgentConnected(agentId)) {
     console.warn(`[SnmpWorker] No online agent for org ${data.orgId}`);
     return { dispatched: false, agentId: null };
   }

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -10,6 +10,7 @@ import * as dbModule from '../db';
 import { snmpDevices, snmpMetrics, snmpTemplates, devices } from '../db/schema';
 import { eq, and, or, sql } from 'drizzle-orm';
 import { getBullMQConnection } from '../services/redis';
+import { createInstrumentedQueue } from '../services/bullmqQueue';
 import { isReusableState } from '../services/bullmqUtils';
 import { attachWorkerObservability } from './workerObservability';
 import { sendCommandToAgent, isAgentConnected, type AgentCommand } from '../routes/agentWs';
@@ -27,9 +28,11 @@ let snmpQueue: Queue | null = null;
 
 export function getSnmpQueue(): Queue {
   if (!snmpQueue) {
-    snmpQueue = new Queue(SNMP_QUEUE, {
-      connection: getBullMQConnection()
-    });
+    // Instrumented so an enqueue made inside a held DB context trips the #1105
+    // tripwire instead of silently pinning a pooled connection
+    // idle-in-transaction (the bare `new Queue` here is how the scheduler's
+    // 51-second connection hold went unnoticed in production).
+    snmpQueue = createInstrumentedQueue(SNMP_QUEUE);
   }
   return snmpQueue;
 }
@@ -62,22 +65,29 @@ interface PollSchedulerJobData {
 
 type SnmpJobData = PollDeviceJobData | ProcessPollResultsJobData | PollSchedulerJobData;
 
-function createSnmpWorker(): Worker<SnmpJobData> {
+export function createSnmpWorker(): Worker<SnmpJobData> {
   return new Worker<SnmpJobData>(
     SNMP_QUEUE,
     async (job: Job<SnmpJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        switch (job.data.type) {
-          case 'poll-scheduler':
-            return await processScheduler();
-          case 'poll-device':
-            return await processPollDevice(job.data);
-          case 'process-poll-results':
-            return await processPollResults(job.data);
-          default:
-            throw new Error(`Unknown job type: ${(job.data as { type: string }).type}`);
-        }
-      });
+      // #1105: every job type below manages its OWN short-lived system DB
+      // context, so the Redis fan-out (poll-scheduler) and the agent WebSocket
+      // dispatch (poll-device) run with no pooled connection pinned
+      // idle-in-transaction.
+      //
+      // Do NOT reintroduce an outer runWithSystemDbAccess here:
+      // withDbAccessContext re-entry is a no-op (`if (dbContextStorage.getStore())
+      // return fn()`), so an outer wrap silently defeats every inner scope and
+      // restores the whole-job hold this fix removed.
+      switch (job.data.type) {
+        case 'poll-scheduler':
+          return await processScheduler();
+        case 'poll-device':
+          return await processPollDevice(job.data);
+        case 'process-poll-results':
+          return await processPollResults(job.data);
+        default:
+          throw new Error(`Unknown job type: ${(job.data as { type: string }).type}`);
+      }
     },
     {
       connection: getBullMQConnection(),
@@ -89,13 +99,18 @@ function createSnmpWorker(): Worker<SnmpJobData> {
   );
 }
 
-/**
- * Dispatch an SNMP poll command to an agent
- */
-async function processPollDevice(data: PollDeviceJobData): Promise<{
-  dispatched: boolean;
+interface PollDispatchInputs {
+  device: typeof snmpDevices.$inferSelect | null;
+  oids: string[];
   agentId: string | null;
-}> {
+}
+
+/**
+ * Phase 1 of a poll-device job: read every row the dispatch needs inside ONE
+ * short-lived system DB context. Nothing here talks to Redis or the agent
+ * WebSocket, so the pooled connection is released before dispatch (#1105).
+ */
+async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDispatchInputs> {
   // Load the device config
   const [device] = await db
     .select()
@@ -104,8 +119,7 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
     .limit(1);
 
   if (!device) {
-    console.error(`[SnmpWorker] Device ${data.deviceId} not found`);
-    return { dispatched: false, agentId: null };
+    return { device: null, oids: [], agentId: null };
   }
 
   // Load template OIDs if device has a template
@@ -126,8 +140,7 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
   }
 
   if (oids.length === 0) {
-    console.warn(`[SnmpWorker] No OIDs configured for device ${data.deviceId}`);
-    return { dispatched: false, agentId: null };
+    return { device, oids, agentId: null };
   }
 
   // Find an online agent for this org.
@@ -149,7 +162,34 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
     )
     .limit(1);
 
-  const agentId = onlineAgent?.agentId ?? null;
+  return { device, oids, agentId: onlineAgent?.agentId ?? null };
+}
+
+/**
+ * Dispatch an SNMP poll command to an agent
+ */
+async function processPollDevice(data: PollDeviceJobData): Promise<{
+  dispatched: boolean;
+  agentId: string | null;
+}> {
+  // Phase 1 — all DB reads inside a short system DB context, which then CLOSES.
+  const { device, oids, agentId } = await runWithSystemDbAccess(() =>
+    loadPollDispatchInputs(data)
+  );
+
+  // Phase 2 — connectivity check, credential decrypt and the agent WebSocket
+  // dispatch, all with NO DB context open (#1105). sendCommandToAgent writes to
+  // a socket whose peer may be slow or wedged; holding the transaction across
+  // it is what pinned pooled connections for tens of seconds.
+  if (!device) {
+    console.error(`[SnmpWorker] Device ${data.deviceId} not found`);
+    return { dispatched: false, agentId: null };
+  }
+
+  if (oids.length === 0) {
+    console.warn(`[SnmpWorker] No OIDs configured for device ${data.deviceId}`);
+    return { dispatched: false, agentId: null };
+  }
 
   if (!agentId || !isAgentConnected(agentId)) {
     console.warn(`[SnmpWorker] No online agent for org ${data.orgId}`);
@@ -177,18 +217,24 @@ async function processPollResults(data: ProcessPollResultsJobData): Promise<{
 }> {
   const now = new Date();
 
-  // Look up orgId from the SNMP device so every metric row carries it for RLS.
-  const [snmpDevice] = await db
-    .select({ orgId: snmpDevices.orgId })
-    .from(snmpDevices)
-    .where(eq(snmpDevices.id, data.deviceId))
-    .limit(1);
+  // Phase 1 — look up orgId from the SNMP device so every metric row carries it
+  // for RLS. Its own short context, which then closes.
+  const [snmpDevice] = await runWithSystemDbAccess(() =>
+    db
+      .select({ orgId: snmpDevices.orgId })
+      .from(snmpDevices)
+      .where(eq(snmpDevices.id, data.deviceId))
+      .limit(1)
+  );
 
   if (!snmpDevice) {
     console.error(`[SnmpWorker] SNMP device ${data.deviceId} not found; cannot write metrics`);
     return { metricsWritten: 0 };
   }
 
+  // Phase 2 — parse/shape the agent-supplied metrics with NO DB context open.
+  // An agent can return thousands of OIDs; this is pure CPU work and must not
+  // run while a pooled connection sits idle-in-transaction (#1105).
   const rows = data.metrics.map((metric) => ({
     deviceId: data.deviceId,
     orgId: snmpDevice.orgId,
@@ -199,18 +245,22 @@ async function processPollResults(data: ProcessPollResultsJobData): Promise<{
     timestamp: metric.timestamp ? new Date(metric.timestamp) : now
   }));
 
-  if (rows.length > 0) {
-    await db.insert(snmpMetrics).values(rows);
-  }
+  // Phase 3 — the writes, in one context so the metric insert and the device
+  // status stamp commit together.
+  await runWithSystemDbAccess(async () => {
+    if (rows.length > 0) {
+      await db.insert(snmpMetrics).values(rows);
+    }
 
-  // Update device lastPolled and status
-  await db
-    .update(snmpDevices)
-    .set({
-      lastPolled: now,
-      lastStatus: 'online'
-    })
-    .where(eq(snmpDevices.id, data.deviceId));
+    // Update device lastPolled and status
+    await db
+      .update(snmpDevices)
+      .set({
+        lastPolled: now,
+        lastStatus: 'online'
+      })
+      .where(eq(snmpDevices.id, data.deviceId));
+  });
 
   console.log(`[SnmpWorker] Wrote ${rows.length} metrics for device ${data.deviceId}`);
   return { metricsWritten: rows.length };
@@ -382,25 +432,34 @@ async function scheduleSnmpPolling(): Promise<void> {
 async function processScheduler(): Promise<{ enqueued: number }> {
   const now = new Date();
 
+  // Phase 1 — read the due devices inside a short system DB context, then let
+  // it CLOSE. Everything after this is pure Redis/BullMQ work; the enqueue loop
+  // below calls queue.getJob / getState / remove / add per device, and holding
+  // those round-trips inside the context is what left this select sitting
+  // `idle in transaction` for 51 seconds in production (#1105).
+  //
   // Find all active devices that are due for polling:
   //   lastPolled IS NULL  OR  lastPolled + pollingInterval <= now
-  const dueDevices = await db
-    .select({
-      id: snmpDevices.id,
-      orgId: snmpDevices.orgId,
-      pollingInterval: snmpDevices.pollingInterval,
-      lastPolled: snmpDevices.lastPolled
-    })
-    .from(snmpDevices)
-    .where(
-      and(
-        eq(snmpDevices.isActive, true),
-        sql`(${snmpDevices.lastPolled} IS NULL OR ${snmpDevices.lastPolled} + make_interval(secs => ${snmpDevices.pollingInterval}) <= ${now.toISOString()})`
+  const dueDevices = await runWithSystemDbAccess(() =>
+    db
+      .select({
+        id: snmpDevices.id,
+        orgId: snmpDevices.orgId,
+        pollingInterval: snmpDevices.pollingInterval,
+        lastPolled: snmpDevices.lastPolled
+      })
+      .from(snmpDevices)
+      .where(
+        and(
+          eq(snmpDevices.isActive, true),
+          sql`(${snmpDevices.lastPolled} IS NULL OR ${snmpDevices.lastPolled} + make_interval(secs => ${snmpDevices.pollingInterval}) <= ${now.toISOString()})`
+        )
       )
-    );
+  );
 
   if (dueDevices.length === 0) return { enqueued: 0 };
 
+  // Phase 2 — enqueue the per-device polls with NO DB context open.
   let enqueued = 0;
   for (const device of dueDevices) {
     try {


### PR DESCRIPTION
## Problem

`createSnmpWorker` wrapped the **entire** job body in `withSystemDbAccessContext`, so every SNMP job held a pooled Postgres connection open in a transaction across work that never touches Postgres — the per-device Redis fan-out, the agent WebSocket dispatch, and metric parsing.

Observed in production: the scheduler's own `snmp_devices` select sitting `idle in transaction` for **51 seconds**, the longest single connection hold on the box. This is the #1105 pattern.

## Fix

The worker handler no longer opens an outer context. Each job type manages its own short-lived one, matching the established remediation in `monitorWorker.ts` / `securityPostureWorker.ts` / `intentOutboxPublisher.ts`:

| Job type | Inside the context | Outside it |
|---|---|---|
| `poll-scheduler` | due-device select | `queue.getJob` / `getState` / `remove` / `add` fan-out |
| `poll-device` | device config + template OIDs + online-agent pick (one context) | `isAgentConnected`, credential decrypt, `sendCommandToAgent` WS write |
| `process-poll-results` | org lookup (ctx 1); metric insert + status stamp (ctx 2, still atomic together) | metric parsing/shaping |

`getSnmpQueue` now builds through `createInstrumentedQueue`, so a future enqueue inside a held context trips the #1105 tripwire instead of silently pinning a connection. Both `enqueueSnmpPollResults` call sites in `agentWs.ts` already wrap in `runOutsideDbContext`, so the tripwire stays quiet on the request path.

## Why the test is shaped the way it is

Reintroducing an outer wrap would be **silent**: `withDbAccessContext` re-entry is a no-op (`if (dbContextStorage.getStore()) return fn()`), so an outer context defeats every inner scope without any error. An identity `fn => fn()` mock can never catch that.

`snmpWorker.dbcontext.test.ts` therefore uses a depth-tracking context mock and asserts the exact enter/exit ordering per job type, e.g.:

```
['ctx:enter','dueSelect@depth1','ctx:exit','enqueue@depth0','enqueue@depth0']
```

plus a dedicated case asserting the handler opens exactly one `ctx:enter` and ends at `enqueue@depth0`.

`createSnmpWorker` is now exported so the test can drive the real processor (mirrors `createSecurityPostureWorker`).

## Verification

- `vitest run src/jobs/snmpWorker.dbcontext.test.ts src/jobs/snmpQueue.test.ts src/routes/agentWs.test.ts` — **109 passed**, single worker.
- `tsc --noEmit` on `apps/api` — clean.
- No schema/migration/tenancy changes; no cascade or RLS list touched.

`snmpQueue.test.ts` needed `assertOutsideHeldDbContext: vi.fn()` added to its `../db` mock — required by `createInstrumentedQueue`, same one-line change `securityPostureWorker.test.ts` carries.

## ⚠️ Expected merge conflict with #3217

**#3217 is being fixed in parallel and edits the same file** (`apps/api/src/jobs/snmpWorker.ts`, the `processScheduler` due-check / backoff logic). This PR deliberately leaves the due-check SQL **textually identical** and only restructures the context around it, so the conflict should be a small, mechanical resolution in `processScheduler`. Whichever merges second should re-run `src/jobs/snmpWorker.dbcontext.test.ts` after resolving — the depth assertions will catch a resolution that accidentally moves the enqueue loop back inside the context.

## Follow-up for the user — production ops, NOT in this PR

The issue's 4th checklist item is a **production droplet action** and is intentionally not done here:

> Remove the temporary Caddy edge-shed for `/api/v1/devices/*/sessions/live` on the production droplets.

The Caddyfile is not part of the api/web image, so a version bump will **not** remove it — it must be hand-edited on each droplet at deploy time, or `/sessions/live` stays disabled and silently masks this fix.

Closes #3215

🤖 Generated with [Claude Code](https://claude.com/claude-code)