### PR TITLE
fix(db): name the opening caller in the #1105 hold warning (#3218)

### DIFF
--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -179,28 +179,68 @@ describe('#1105 DB-context tripwires', () => {
       // The TAG is the load-bearing part: extras are only visible inside a
       // single event, so an unfilterable bucket (BREEZE-A, ~7k events) stays
       // unfilterable if the label only lands in `extra`.
-      expect(capturedMessages[0]!.tags).toEqual({ dbContextLabel: 'agentWs.heartbeat' });
+      expect(capturedMessages[0]!.tags?.dbContextLabel).toBe('agentWs.heartbeat');
       // Also in the message, because Sentry groups by message — that is what
       // splits one bucket into per-handler issues.
       expect(capturedMessages[0]!.message).toContain('[agentWs.heartbeat]');
+      // #3218 added a second, derived tag alongside it. `dbContextLabel` must
+      // stay EXPLICIT-only so existing Sentry queries keep their meaning — the
+      // derived opener goes in its own key, never widening this one.
+      expect(capturedMessages[0]!.tags?.dbContextOpener).toEqual(expect.stringContaining('dbContextTripwire'));
     });
 
-    it('omits the tag entirely for an unlabelled context, leaving the message text unchanged', async () => {
-      // Grouping stability: every existing caller is unlabelled, so their
-      // message must be byte-identical to before this change or their Sentry
-      // history splits into a new issue for no reason.
+    it('derives a grouping label from the opener when the context is unlabelled (#3218)', async () => {
+      // Supersedes the previous contract ("unlabelled callers keep byte-identical
+      // message text"). That stability was deliberately traded away in #3218:
+      // most callers are unlabelled, so preserving their text meant they all
+      // landed in ONE opaque bucket that could not be attributed. Regrouping
+      // them per source is a one-time cost paid once, on purpose.
       process.env.DB_CONTEXT_HELD_WARN_MS = '50';
       process.env.DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS = '0';
       __resetHeldContextCaptureThrottleForTests();
 
-      await withSystemDbAccessContext(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 90));
-      });
+      async function anUnlabelledCallerThatHolds(): Promise<void> {
+        await withSystemDbAccessContext(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 90));
+        });
+      }
+      await anUnlabelledCallerThatHolds();
 
       expect(capturedMessages).toHaveLength(1);
-      expect(capturedMessages[0]!.tags).toBeUndefined();
-      expect(capturedMessages[0]!.message).toContain('withDbAccessContext (scope=system) held');
-      expect(capturedMessages[0]!.message).not.toContain('[');
+      const event = capturedMessages[0]!;
+      expect(event.message).toContain('withDbAccessContext (scope=system)');
+      expect(event.message).toContain(HELD);
+      // No explicit label was passed, so only the derived tag is present.
+      expect(event.tags?.dbContextLabel).toBeUndefined();
+      expect(event.tags?.dbContextOpener).toContain('anUnlabelledCallerThatHolds');
+      // The derived name reaches the grouped message too...
+      expect(event.message).toContain('[');
+      expect(event.message).toContain('anUnlabelledCallerThatHolds');
+      // ...but the precise file:line must NOT, or every edit above the call site
+      // forks the Sentry issue. It belongs to the console line and the extra.
+      expect(event.message).not.toMatch(/\.ts:\d+/);
+      expect(String(event.extra?.openedAtFrame)).toMatch(/dbContextTripwire.*:\d+:\d+/);
+    });
+
+    it('names the opening caller in the CONSOLE line, not just in Sentry (#3218)', async () => {
+      // The whole point of #3218: during the incident the DSN rate limit was
+      // saturated by a concurrent hot error, so the throttled Sentry captures
+      // were dropped exactly when needed. The console line must stand alone.
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+
+      async function theConsoleAttributionCulprit(): Promise<void> {
+        await withSystemDbAccessContext(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 90));
+        });
+      }
+      await theConsoleAttributionCulprit();
+
+      const hits = heldWarns();
+      expect(hits).toHaveLength(1);
+      const line = String(hits[0]![0]);
+      expect(line).toContain('theConsoleAttributionCulprit');
+      // A real file:line an operator can jump to, straight from droplet logs.
+      expect(line).toMatch(/Opened at .*dbContextTripwire.*:\d+:\d+\./);
     });
 
     it('still warns when fn THROWS after holding the context too long (the finally path)', async () => {

--- a/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
+++ b/apps/api/src/__tests__/integration/dbContextTripwire.integration.test.ts
@@ -222,6 +222,33 @@ describe('#1105 DB-context tripwires', () => {
       expect(String(event.extra?.openedAtFrame)).toMatch(/dbContextTripwire.*:\d+:\d+/);
     });
 
+    it('attributes a caller that uses a bare `return` instead of `await` (#3218)', async () => {
+      // 66 call sites in this repo do `return withSystemDbAccessContext(...)`
+      // with no await — most BullMQ job workers among them, which are a prime
+      // suspect for real long holds. V8 links an async frame only at a genuine
+      // await, so while the opener stack was allocated inside the transaction
+      // callback (after six awaits) every one of those callers was dropped from
+      // the trace: unattributed, or misattributed to the next function out.
+      // The stack is now allocated at withDbAccessContext ENTRY, where the
+      // caller's frame is live on the synchronous stack regardless of idiom.
+      process.env.DB_CONTEXT_HELD_WARN_MS = '50';
+      process.env.DB_CONTEXT_HELD_CAPTURE_THROTTLE_MS = '0';
+      __resetHeldContextCaptureThrottleForTests();
+
+      // Deliberately a bare return — no await anywhere in the chain.
+      function aBareReturnWorkerCallsite(): Promise<void> {
+        return withSystemDbAccessContext(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 90));
+        });
+      }
+      await aBareReturnWorkerCallsite();
+
+      const hits = heldWarns();
+      expect(hits).toHaveLength(1);
+      expect(String(hits[0]![0])).toContain('aBareReturnWorkerCallsite');
+      expect(capturedMessages[0]!.tags?.dbContextOpener).toContain('aBareReturnWorkerCallsite');
+    });
+
     it('names the opening caller in the CONSOLE line, not just in Sentry (#3218)', async () => {
       // The whole point of #3218: during the incident the DSN rate limit was
       // saturated by a concurrent hot error, so the throttled Sentry captures

--- a/apps/api/src/db/heldContextCaptureThrottle.test.ts
+++ b/apps/api/src/db/heldContextCaptureThrottle.test.ts
@@ -10,6 +10,8 @@ vi.mock('../services/sentry', () => ({
 import {
   shouldCaptureHeldContext,
   shouldReportHeldContextSite,
+  parseOpenerFrame,
+  formatHeldContextWarning,
   __resetHeldContextCaptureThrottleForTests,
   __resetHeldContextAssertDedupeForTests,
 } from './index';
@@ -91,5 +93,154 @@ describe('shouldReportHeldContextSite (enqueue-tripwire Sentry-capture dedupe)',
     expect(shouldReportHeldContextSite('stack-a')).toBe(true);
     __resetHeldContextAssertDedupeForTests();
     expect(shouldReportHeldContextSite('stack-a')).toBe(true);
+  });
+});
+
+// #3218: the console warning has to name the caller by itself. The `openedAt`
+// stack was already captured but only reached Sentry — which is exactly the
+// channel that drops these warnings during the incident that produces them
+// (the concurrent hot error saturates the DSN rate limit). These guard the
+// frame picker that turns that stack into one log-line attribution.
+describe('parseOpenerFrame (#1105 hold-warning attribution)', () => {
+  const frames = (...lines: string[]) =>
+    ['Error: withDbAccessContext opened here', ...lines].join('\n');
+
+  // The emitter allocates the Error inside withDbAccessContext, so the top
+  // frame is ALWAYS this module. Returning it would reproduce the exact BREEZE-9
+  // failure: 12k events all naming the emitter instead of the caller.
+  it('skips this module and the context wrappers to reach the caller', () => {
+    const result = parseOpenerFrame(frames(
+      '    at withDbAccessContext (/app/apps/api/src/db/index.ts:304:34)',
+      '    at withSystemDbAccessContext (/app/apps/api/src/db/index.ts:353:10)',
+      '    at pollDevices (/app/apps/api/src/workers/devicePoller.ts:88:12)',
+    ));
+    expect(result).toEqual({
+      location: 'apps/api/src/workers/devicePoller.ts:88:12',
+      label: 'devicePoller.pollDevices',
+    });
+  });
+
+  it('skips node_modules and node-internal frames', () => {
+    const result = parseOpenerFrame(frames(
+      '    at withDbAccessContext (/app/apps/api/src/db/index.ts:304:34)',
+      '    at Object.begin (/app/node_modules/postgres/cjs/src/index.js:512:9)',
+      '    at processTicksAndRejections (node:internal/process/task_queues:95:5)',
+      '    at handleHeartbeat (/app/apps/api/src/routes/agent/heartbeat.ts:120:3)',
+    ));
+    expect(result?.location).toBe('apps/api/src/routes/agent/heartbeat.ts:120:3');
+    expect(result?.label).toBe('heartbeat.handleHeartbeat');
+  });
+
+  it('handles async frames, receiver prefixes and [as alias] suffixes', () => {
+    const result = parseOpenerFrame(frames(
+      '    at async Object.getDevice [as handler] (/app/apps/api/src/routes/devices.ts:42:10)',
+    ));
+    expect(result).toEqual({
+      location: 'apps/api/src/routes/devices.ts:42:10',
+      label: 'devices.getDevice',
+    });
+  });
+
+  it('handles a bare location frame with no function name', () => {
+    const result = parseOpenerFrame(frames(
+      '    at /app/apps/api/src/services/alertEngine.ts:17:5',
+    ));
+    expect(result).toEqual({
+      location: 'apps/api/src/services/alertEngine.ts:17:5',
+      label: 'alertEngine',
+    });
+  });
+
+  it('strips the file:// scheme ESM stacks carry', () => {
+    const result = parseOpenerFrame(frames(
+      '    at run (file:///app/apps/api/src/workers/patchWorker.ts:9:1)',
+    ));
+    expect(result?.location).toBe('apps/api/src/workers/patchWorker.ts:9:1');
+  });
+
+  // The label feeds a Sentry tag and the grouped message; line numbers move on
+  // every unrelated edit above the call site, so they must NOT reach it or one
+  // issue forks into a new one per release.
+  it('keeps line/column out of the grouping label', () => {
+    const a = parseOpenerFrame(frames('    at run (/app/apps/api/src/workers/w.ts:9:1)'));
+    const b = parseOpenerFrame(frames('    at run (/app/apps/api/src/workers/w.ts:412:7)'));
+    expect(a?.label).toBe(b?.label);
+    expect(a?.location).not.toBe(b?.location);
+  });
+
+  it('returns null when there is no application frame, rather than naming the runtime', () => {
+    expect(parseOpenerFrame(frames(
+      '    at withDbAccessContext (/app/apps/api/src/db/index.ts:304:34)',
+      '    at processTicksAndRejections (node:internal/process/task_queues:95:5)',
+    ))).toBeNull();
+  });
+
+  it('returns null for an absent or frameless stack', () => {
+    expect(parseOpenerFrame(undefined)).toBeNull();
+    expect(parseOpenerFrame('')).toBeNull();
+    expect(parseOpenerFrame('Error: no frames here')).toBeNull();
+  });
+
+  // Attribution must survive a compiled deploy — that is where it is needed.
+  it('attributes a built .js frame the same way', () => {
+    const result = parseOpenerFrame(frames(
+      '    at withDbAccessContext (/app/apps/api/dist/db/index.js:1204:34)',
+      '    at sweep (/app/apps/api/dist/workers/sweeper.js:77:9)',
+    ));
+    expect(result?.label).toBe('sweeper.sweep');
+  });
+});
+
+// The payoff of #3218: what actually lands in the droplet log. The console line
+// must be self-sufficient for attribution while the Sentry-facing `message`
+// stays stable enough to group.
+describe('formatHeldContextWarning (#3218 console attribution)', () => {
+  const frame = { location: 'apps/api/src/workers/sweeper.ts:77:9', label: 'sweeper.sweep' };
+  const base = { scope: 'system' as const, openerFrame: frame, heldMs: 40_000, warnMs: 2_000 };
+
+  it('names the caller in the console line — the whole point of the issue', () => {
+    const { consoleLine } = formatHeldContextWarning(base);
+    expect(consoleLine).toContain('apps/api/src/workers/sweeper.ts:77:9');
+    expect(consoleLine).toContain('[sweeper.sweep]');
+    expect(consoleLine).toContain('40000ms');
+  });
+
+  it('keeps file:line OUT of the Sentry message so grouping survives edits', () => {
+    const early = formatHeldContextWarning(base);
+    const later = formatHeldContextWarning({
+      ...base,
+      openerFrame: { location: 'apps/api/src/workers/sweeper.ts:412:9', label: 'sweeper.sweep' },
+    });
+    expect(early.message).not.toContain(':77:9');
+    expect(early.message).toBe(later.message);
+    expect(early.consoleLine).not.toBe(later.consoleLine);
+  });
+
+  it('prefers an explicit label over the derived one, and tags them separately', () => {
+    const { message, tags } = formatHeldContextWarning({ ...base, label: 'agentWs.heartbeat' });
+    expect(message).toContain('[agentWs.heartbeat]');
+    expect(message).not.toContain('[sweeper.sweep]');
+    // Existing Sentry queries on dbContextLabel keep meaning explicit-only.
+    expect(tags).toEqual({ dbContextLabel: 'agentWs.heartbeat', dbContextOpener: 'sweeper.sweep' });
+  });
+
+  it('derives the label when no explicit one was passed', () => {
+    const { message, tags } = formatHeldContextWarning(base);
+    expect(message).toContain('[sweeper.sweep]');
+    expect(tags).toEqual({ dbContextOpener: 'sweeper.sweep' });
+  });
+
+  it('degrades to the previous message shape when no frame is resolvable', () => {
+    const { message, consoleLine, tags } = formatHeldContextWarning({ ...base, openerFrame: null });
+    expect(message).toContain('withDbAccessContext (scope=system) held a pooled connection');
+    expect(consoleLine).toBe(message);
+    expect(tags).toEqual({});
+  });
+
+  it('still reports scope, threshold and the #1105 remediation pointer', () => {
+    const { consoleLine } = formatHeldContextWarning({ ...base, scope: 'organization' });
+    expect(consoleLine).toContain('scope=organization');
+    expect(consoleLine).toContain('>= 2000ms');
+    expect(consoleLine).toContain('runOutsideDbContext (#1105)');
   });
 });

--- a/apps/api/src/db/heldContextCaptureThrottle.test.ts
+++ b/apps/api/src/db/heldContextCaptureThrottle.test.ts
@@ -181,6 +181,45 @@ describe('parseOpenerFrame (#1105 hold-warning attribution)', () => {
     expect(parseOpenerFrame('Error: no frames here')).toBeNull();
   });
 
+  // Openers are not all in apps/ — a context can be opened from shared code.
+  it('attributes a frame in packages/ too', () => {
+    const result = parseOpenerFrame(frames(
+      '    at withDbAccessContext (/app/apps/api/src/db/index.ts:304:34)',
+      '    at dispatch (/app/packages/shared/src/queue/dispatch.ts:12:4)',
+    ));
+    expect(result).toEqual({
+      location: 'packages/shared/src/queue/dispatch.ts:12:4',
+      label: 'dispatch.dispatch',
+    });
+  });
+
+  // The path-based self-exclusion hardcodes today's filename. If this module is
+  // ever split or renamed, the emitter frame must STILL be skipped by name, or
+  // the BREEZE-9 bug (every event naming the emitter) silently returns.
+  it('still skips the emitter by function name if db/index.ts is renamed', () => {
+    const result = parseOpenerFrame(frames(
+      '    at withDbAccessContext (/app/apps/api/src/db/accessContext.ts:304:34)',
+      '    at withSystemDbAccessContext (/app/apps/api/src/db/accessContext.ts:353:10)',
+      '    at reconcile (/app/apps/api/src/workers/reconciler.ts:31:2)',
+    ));
+    expect(result?.label).toBe('reconciler.reconcile');
+  });
+
+  it('skips node_modules nested inside an app directory', () => {
+    const result = parseOpenerFrame(frames(
+      '    at q (/app/apps/api/node_modules/drizzle-orm/session.js:88:1)',
+      '    at tick (/app/apps/api/src/workers/tick.ts:4:4)',
+    ));
+    expect(result?.location).toBe('apps/api/src/workers/tick.ts:4:4');
+  });
+
+  it('normalizes a constructor frame instead of leaking "new " into the label', () => {
+    const result = parseOpenerFrame(frames(
+      '    at new PatchClient (/app/apps/api/src/workers/patchWorker.ts:5:1)',
+    ));
+    expect(result?.label).toBe('patchWorker.PatchClient');
+  });
+
   // Attribution must survive a compiled deploy — that is where it is needed.
   it('attributes a built .js frame the same way', () => {
     const result = parseOpenerFrame(frames(
@@ -188,6 +227,54 @@ describe('parseOpenerFrame (#1105 hold-warning attribution)', () => {
       '    at sweep (/app/apps/api/dist/workers/sweeper.js:77:9)',
     ));
     expect(result?.label).toBe('sweeper.sweep');
+  });
+});
+
+// The synthetic stacks above pin the parsing rules, but the feature rests on an
+// assumption they cannot test: the emitter allocates its Error INSIDE the
+// transaction callback, after ~6 `await tx.execute(...)` calls, so the opener's
+// synchronous frames are long gone by then. It only works because V8 keeps
+// async frames across awaits (rendered `at async fn (...)`). If that ever stops
+// holding, every warning silently degrades to naming nothing — so assert it
+// against a real, runtime-generated stack rather than a hand-written string.
+describe('parseOpenerFrame against a REAL V8 async stack', () => {
+  async function theCulpritThatHoldsTheConnection(): Promise<string | undefined> {
+    // `return await`, not a bare `return` — V8 only links an async frame into
+    // the trace at a real await point, so a tail `return f()` drops the caller
+    // from the stack entirely. Real openers all `await withDbAccessContext(...)`,
+    // which is the shape reproduced here.
+    return await emulateTransactionCallback();
+  }
+
+  async function emulateTransactionCallback(): Promise<string | undefined> {
+    // Mirror the awaits that precede the Error allocation in withDbAccessContext.
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+    return new Error('withDbAccessContext opened here').stack;
+  }
+
+  it('still carries the caller frames after 6 awaits — the assumption the feature rests on', async () => {
+    const stack = await theCulpritThatHoldsTheConnection();
+    // The outer caller is several awaits and one frame above the allocation. If
+    // V8 ever drops async frames this goes empty and every warning degrades to
+    // naming nothing — which is the exact BREEZE-9 failure being fixed.
+    expect(stack).toContain('theCulpritThatHoldsTheConnection');
+  });
+
+  it('resolves a real runtime stack to the nearest application frame', async () => {
+    const stack = await theCulpritThatHoldsTheConnection();
+    const frame = parseOpenerFrame(stack);
+
+    expect(frame).not.toBeNull();
+    // The NEAREST app frame is the right answer: in production the equivalent
+    // intermediate (the transaction callback) lives in db/index.ts and is
+    // skipped, so the nearest remaining frame IS the true opener. Here that
+    // helper sits in this test file, so it is legitimately the nearest one.
+    expect(frame!.label).toContain('emulateTransactionCallback');
+    // A jumpable location, parsed out of genuine V8 output.
+    expect(frame!.location).toMatch(/heldContextCaptureThrottle\.test\.ts:\d+:\d+$/);
+    // Never the runtime or the emitter's own module.
+    expect(frame!.location).not.toContain('node_modules');
+    expect(frame!.location).not.toMatch(/^node:/);
   });
 });
 
@@ -224,6 +311,25 @@ describe('formatHeldContextWarning (#3218 console attribution)', () => {
     expect(tags).toEqual({ dbContextLabel: 'agentWs.heartbeat', dbContextOpener: 'sweeper.sweep' });
   });
 
+  // A blank label must not win the `??` race and then render as nothing: that
+  // would both defeat the REQUIRED-label safeguard on shared closures (agentWs,
+  // BREEZE-A) and suppress the derived fallback — strictly worse than passing
+  // no label at all.
+  it.each([['', 'empty'], ['   ', 'whitespace-only']])(
+    'treats a %s label as absent and falls back to the derived one',
+    (blank) => {
+      const { message, tags } = formatHeldContextWarning({ ...base, label: blank });
+      expect(message).toContain('[sweeper.sweep]');
+      expect(tags).toEqual({ dbContextOpener: 'sweeper.sweep' });
+    },
+  );
+
+  it('trims a padded explicit label rather than emitting the padding', () => {
+    const { message, tags } = formatHeldContextWarning({ ...base, label: '  agentWs.heartbeat  ' });
+    expect(message).toContain('[agentWs.heartbeat]');
+    expect(tags.dbContextLabel).toBe('agentWs.heartbeat');
+  });
+
   it('derives the label when no explicit one was passed', () => {
     const { message, tags } = formatHeldContextWarning(base);
     expect(message).toContain('[sweeper.sweep]');
@@ -235,6 +341,17 @@ describe('formatHeldContextWarning (#3218 console attribution)', () => {
     expect(message).toContain('withDbAccessContext (scope=system) held a pooled connection');
     expect(consoleLine).toBe(message);
     expect(tags).toEqual({});
+  });
+
+  it('omits the "Opened at" suffix when a label is given but no frame resolved', () => {
+    const { consoleLine, tags } = formatHeldContextWarning({
+      ...base,
+      openerFrame: null,
+      label: 'agentWs.heartbeat',
+    });
+    expect(consoleLine).toContain('[agentWs.heartbeat]');
+    expect(consoleLine).not.toContain('Opened at');
+    expect(tags).toEqual({ dbContextLabel: 'agentWs.heartbeat' });
   });
 
   it('still reports scope, threshold and the #1105 remediation pointer', () => {

--- a/apps/api/src/db/heldContextCaptureThrottle.test.ts
+++ b/apps/api/src/db/heldContextCaptureThrottle.test.ts
@@ -213,6 +213,23 @@ describe('parseOpenerFrame (#1105 hold-warning attribution)', () => {
     expect(result?.location).toBe('apps/api/src/workers/tick.ts:4:4');
   });
 
+  // Path-shortening cuts from the first apps|packages|agent|scripts segment
+  // found anywhere. `scripts/` is a real directory inside many published
+  // packages, so shortening BEFORE the node_modules test would hide the
+  // prefix and promote a dependency's frame to "the caller".
+  it.each([
+    '/app/node_modules/undici/scripts/build.js:10:5',
+    '/app/node_modules/react-native/scripts/launch.js:3:1',
+    '/app/node_modules/@scope/pkg/packages/core/dist/run.js:7:2',
+  ])('does not mistake %s for application code', (depFrame) => {
+    const result = parseOpenerFrame(frames(
+      `    at build (${depFrame})`,
+      '    at realOpener (/app/apps/api/src/jobs/backupWorker.ts:64:8)',
+    ));
+    expect(result?.location).toBe('apps/api/src/jobs/backupWorker.ts:64:8');
+    expect(result?.label).toBe('backupWorker.realOpener');
+  });
+
   it('normalizes a constructor frame instead of leaking "new " into the label', () => {
     const result = parseOpenerFrame(frames(
       '    at new PatchClient (/app/apps/api/src/workers/patchWorker.ts:5:1)',
@@ -230,13 +247,13 @@ describe('parseOpenerFrame (#1105 hold-warning attribution)', () => {
   });
 });
 
-// The synthetic stacks above pin the parsing rules, but the feature rests on an
-// assumption they cannot test: the emitter allocates its Error INSIDE the
-// transaction callback, after ~6 `await tx.execute(...)` calls, so the opener's
-// synchronous frames are long gone by then. It only works because V8 keeps
-// async frames across awaits (rendered `at async fn (...)`). If that ever stops
-// holding, every warning silently degrades to naming nothing — so assert it
-// against a real, runtime-generated stack rather than a hand-written string.
+// Characterization tests for the V8 behavior that dictated where the emitter
+// allocates its Error. Allocating it AFTER awaits (as the emitter originally
+// did, inside the transaction callback) relies on V8's async-stack
+// reconstruction — which links a frame only at a genuine `await`. These pin
+// that limitation with real, runtime-generated stacks and document why
+// withDbAccessContext now allocates at ENTRY instead, where the caller's frame
+// is live synchronously and no reconstruction is needed.
 describe('parseOpenerFrame against a REAL V8 async stack', () => {
   async function theCulpritThatHoldsTheConnection(): Promise<string | undefined> {
     // `return await`, not a bare `return` — V8 only links an async frame into

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -329,11 +329,18 @@ function isNonApplicationFrame(location: string, fnName: string | null): boolean
   return fnName !== null && DB_CONTEXT_WRAPPER_FUNCTIONS.has(stripFramePrefixes(fnName));
 }
 
-/** Strip the machine-specific prefix so log lines stay short and comparable. */
+/**
+ * Strip the machine-specific prefix so log lines stay short and comparable.
+ * MUST run only AFTER a frame has been accepted as application code: it cuts
+ * from the first `apps|packages|agent|scripts` segment found ANYWHERE, and
+ * `scripts/` is a common directory inside third-party packages (undici,
+ * react-native, chrome-launcher, …). Shortening first would hide the
+ * `node_modules` prefix from the rejection test and promote a dependency's
+ * frame to "the caller".
+ */
 function toRepoRelative(location: string): string {
-  const withoutScheme = location.replace(/^file:\/\//, '');
-  const match = /(?:^|\/)((?:apps|packages|agent|scripts)\/.+)$/.exec(withoutScheme);
-  return match?.[1] ?? withoutScheme;
+  const match = /(?:^|\/)((?:apps|packages|agent|scripts)\/.+)$/.exec(location);
+  return match?.[1] ?? location;
 }
 
 /**
@@ -353,8 +360,10 @@ export function parseOpenerFrame(stack: string | undefined): HeldContextOpenerFr
     const rawLocation = match[2] ?? match[3];
     if (!rawLocation) continue;
 
-    const location = toRepoRelative(rawLocation.trim());
-    if (isNonApplicationFrame(location, fnName)) continue;
+    // Reject against the FULL path (see toRepoRelative), then shorten.
+    const fullLocation = rawLocation.trim().replace(/^file:\/\//, '');
+    if (isNonApplicationFrame(fullLocation, fnName)) continue;
+    const location = toRepoRelative(fullLocation);
 
     // `apps/api/src/routes/devices.ts:42:10` → `devices`.
     const file = /([^/\\]+?)\.[cm]?[jt]sx?(?::\d+)*$/.exec(location)?.[1] ?? null;
@@ -432,6 +441,27 @@ export async function withDbAccessContext<T>(
     return fn();
   }
 
+  const warnMs = getHeldContextWarnMs();
+  // Capture the OPENER's stack HERE — at function entry, before any await and
+  // before the transaction callback — so the caller's frame is genuinely live
+  // on the synchronous stack.
+  //
+  // This used to be allocated inside the transaction callback, after six
+  // `await tx.execute(...)` hops. That only ever worked via V8's async-stack
+  // reconstruction, which links a frame ONLY at a real `await`: a caller doing
+  // `return withSystemDbAccessContext(...)` (a bare return, no await — 66 call
+  // sites in this repo, including most BullMQ job workers) was dropped from the
+  // trace entirely. Those degraded to an unattributed warning, or worse, named
+  // the next function out and misidentified the culprit. Allocating at entry is
+  // idiom-independent: the caller's frame is on the stack at call time no matter
+  // how it invoked us.
+  //
+  // Cost is unchanged: `new Error()` captures the structured trace but V8 only
+  // formats it on first `.stack` access, which happens ONLY when a hold actually
+  // breaches the threshold. The hot path pays one small allocation, not stack
+  // serialization, and only when the tripwire is armed at all.
+  const opener = warnMs > 0 ? new Error('withDbAccessContext opened here') : undefined;
+
   return baseDb.transaction(async (tx) => {
     const serializedOrgIds = serializeAccessibleIds(context.scope, context.accessibleOrgIds);
     const serializedPartnerIds = serializeAccessibleIds(context.scope, context.accessiblePartnerIds);
@@ -444,24 +474,10 @@ export async function withDbAccessContext<T>(
     await tx.execute(sql`select set_config('breeze.user_id', ${serializedUserId}, true)`);
     await tx.execute(sql`select set_config('breeze.current_partner_id', ${context.currentPartnerId ?? ''}, true)`);
 
-    const warnMs = getHeldContextWarnMs();
+    // Timed from HERE, not from function entry: the hold being measured is the
+    // one on a pooled connection, which only starts once the transaction owns
+    // one. Time spent waiting for the pool is a different problem.
     const startedAt = warnMs > 0 ? Date.now() : 0;
-    // Capture the OPENER's stack here, synchronously, while the call chain that
-    // opened this context is still on the stack.
-    //
-    // The warning below used to build its stack inside the `finally`, which runs
-    // after `await` — by then the synchronous frames are gone and all that
-    // remains is the microtask trampoline plus whatever host loop is at the
-    // bottom (`processTicksAndRejections` / `sql.begin` / bullmq's worker.js).
-    // That is why BREEZE-9 accumulated ~12k events that name nothing
-    // actionable: every one pointed at this emitter instead of at the code
-    // holding the connection. Allocating the Error here records the real opener.
-    //
-    // Cost: `new Error()` captures the structured trace but V8 only formats it
-    // on first `.stack` access, which we do ONLY when a hold actually breaches
-    // the threshold. So the hot path pays one small allocation, not stack
-    // serialization, and only when the tripwire is armed at all.
-    const opener = warnMs > 0 ? new Error('withDbAccessContext opened here') : undefined;
     try {
       return await dbContextStorage.run(tx as unknown as typeof baseDb, () =>
         dbContextMetaStorage.run(context, fn),

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -300,14 +300,33 @@ export interface HeldContextOpenerFrame {
 // `at Object.foo [as bar] (loc)` — the bracketed alias stays inside `fn`.
 const STACK_FRAME_RE = /^\s*at\s+(?:async\s+)?(?:(.+?)\s+\((.+)\)|(.+))$/;
 
+/**
+ * Reduce a V8 function name to its bare identifier: drop the receiver prefix
+ * (`Object.foo`), the `[as alias]` suffix, and the `new ` of a constructor
+ * frame, any of which would otherwise leak into a grouping label.
+ */
+function stripFramePrefixes(fnName: string): string {
+  return fnName
+    .replace(/\s*\[as .+?\]$/, '')
+    .replace(/^new\s+/, '')
+    .split('.')
+    .pop() ?? fnName;
+}
+
 function isNonApplicationFrame(location: string, fnName: string | null): boolean {
   if (location.includes('node_modules')) return true;
   // Node internals: `node:internal/...`, `internal/process/...`, `node:events`.
   if (location.startsWith('node:') || location.startsWith('internal/')) return true;
   // This module itself — the frame where `new Error()` was allocated. Matched on
   // the path so it also holds when the wrapper name is minified away in a build.
-  if (/(^|\/)db\/index\.[cm]?[jt]s(:|$)/.test(location)) return true;
-  return fnName !== null && DB_CONTEXT_WRAPPER_FUNCTIONS.has(fnName);
+  // Backslashes are normalized first so a Windows dev path is excluded too.
+  if (/(^|[/\\])db[/\\]index\.[cm]?[jt]s(:|$)/.test(location)) return true;
+  // Name-based fallback. Deliberately redundant with the path test above: if
+  // this file is ever split or renamed (the CLAUDE.md size guideline invites
+  // exactly that), the path test stops matching and the emitter's own frame
+  // would leak through as "the caller" — reproducing the BREEZE-9 bug this is
+  // meant to prevent. The wrappers keep their names across such a move.
+  return fnName !== null && DB_CONTEXT_WRAPPER_FUNCTIONS.has(stripFramePrefixes(fnName));
 }
 
 /** Strip the machine-specific prefix so log lines stay short and comparable. */
@@ -337,10 +356,9 @@ export function parseOpenerFrame(stack: string | undefined): HeldContextOpenerFr
     const location = toRepoRelative(rawLocation.trim());
     if (isNonApplicationFrame(location, fnName)) continue;
 
-    // `apps/api/src/routes/devices.ts:42:10` → `devices`; drop V8's receiver
-    // prefix and `[as alias]` suffix from `Object.getDevice [as handler]`.
+    // `apps/api/src/routes/devices.ts:42:10` → `devices`.
     const file = /([^/\\]+?)\.[cm]?[jt]sx?(?::\d+)*$/.exec(location)?.[1] ?? null;
-    const fn = fnName?.replace(/\s*\[as .+?\]$/, '').split('.').pop() || null;
+    const fn = fnName ? stripFramePrefixes(fnName) || null : null;
     const label = file && fn ? `${file}.${fn}` : (file ?? fn);
 
     return { location, label };
@@ -376,7 +394,15 @@ export function formatHeldContextWarning(input: {
   // fall back to the opening frame so unlabelled callers, which are most of
   // them, still group per source instead of arriving as one opaque bucket. This
   // is a one-time regrouping for previously-unlabelled callers, by design.
-  const label = explicitLabel ?? openerFrame?.label ?? null;
+  // Normalize ONCE, and gate both the message and the tag on the same value. A
+  // blank label must fall through to the derived one rather than winning and
+  // then rendering as nothing: `label: string` accepts '' at the call sites that
+  // treat the label as REQUIRED precisely to stop a shared closure collapsing
+  // into one anonymous bucket (agentWs, the ~7k-event BREEZE-A incident). With a
+  // bare `??` an empty string would silently defeat that safeguard AND suppress
+  // the fallback — strictly worse than passing no label at all.
+  const normalizedExplicit = explicitLabel?.trim() ? explicitLabel.trim() : null;
+  const label = normalizedExplicit ?? openerFrame?.label ?? null;
   const labelPart = label ? ` [${label}]` : '';
   const message =
     `withDbAccessContext (scope=${scope})${labelPart} held a pooled connection in an open `
@@ -388,7 +414,7 @@ export function formatHeldContextWarning(input: {
   // dashboards keep their meaning; the derived name gets its own tag rather
   // than silently widening that one.
   const tags: Record<string, string> = {};
-  if (explicitLabel) tags.dbContextLabel = explicitLabel;
+  if (normalizedExplicit) tags.dbContextLabel = normalizedExplicit;
   if (openerFrame?.label) tags.dbContextOpener = openerFrame.label;
 
   return {
@@ -477,8 +503,18 @@ export async function withDbAccessContext<T>(
             }
           }
         }
-      } catch {
-        // Detection instrumentation must never alter fn's real result/error.
+      } catch (instrumentationError) {
+        // Detection instrumentation must never alter fn's real result/error, so
+        // this stays broad. But it must not swallow itself into total silence
+        // either: #3218 exists because this warning was unattributable, and a
+        // future slip in the frame parsing above would otherwise make the whole
+        // warning vanish with no trace at all. Leave a breadcrumb, and guard
+        // even that — a throw from the reporter would defeat the purpose.
+        try {
+          console.warn('[db-context-hold-warning] instrumentation failed:', instrumentationError);
+        } catch {
+          // Truly last resort: console itself is unusable. Preserve fn's outcome.
+        }
       }
     }
   });

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -167,6 +167,11 @@ export interface DbAccessContext {
    * to an anonymous arrow inside `onMessage`. The stack alone cannot tell
    * `heartbeat` from `command_result`. Set this wherever several distinct paths
    * share a context helper.
+   *
+   * When omitted, the warning falls back to a name derived from the opening
+   * stack frame (#3218), which is adequate for the common case of one call site
+   * per path — so an explicit label is only REQUIRED for the shared-closure
+   * case above, where the derived name would collapse several paths into one.
    */
   label?: string;
 }
@@ -264,6 +269,135 @@ export function shouldCaptureHeldContext(scope: string, now: number, throttleMs:
   return false;
 }
 
+// #3218 — the console warning must name the caller on its own. The `openedAt`
+// stack was captured but only ever shipped to Sentry, so an operator reading
+// droplet logs during an incident could not attribute a single hold. That is
+// exactly when Sentry is least likely to have it: the hot error that causes the
+// holds also saturates the DSN rate limit and drops the throttled hold captures.
+// So we format ONE frame from the already-captured stack into the log line.
+//
+// Frames that name this module or its wrappers describe the emitter, not the
+// caller, and node_modules / node-internal frames describe the runtime — both
+// are skipped so the frame we print is the first APPLICATION frame.
+const DB_CONTEXT_WRAPPER_FUNCTIONS = new Set([
+  'withDbAccessContext',
+  'withSystemDbAccessContext',
+  'withResolvedDbAccessContext',
+]);
+
+export interface HeldContextOpenerFrame {
+  /** Human-readable `path:line:col`, trimmed to a repo-relative path. */
+  readonly location: string;
+  /**
+   * Low-cardinality `basename.fn` name derived from the frame, suitable for
+   * Sentry grouping. Deliberately excludes line/column: those shift on every
+   * unrelated edit, which would fork one issue into a new one per release.
+   */
+  readonly label: string | null;
+}
+
+// `at fn (loc)` | `at async fn (loc)` | `at loc`. Also handles V8's
+// `at Object.foo [as bar] (loc)` — the bracketed alias stays inside `fn`.
+const STACK_FRAME_RE = /^\s*at\s+(?:async\s+)?(?:(.+?)\s+\((.+)\)|(.+))$/;
+
+function isNonApplicationFrame(location: string, fnName: string | null): boolean {
+  if (location.includes('node_modules')) return true;
+  // Node internals: `node:internal/...`, `internal/process/...`, `node:events`.
+  if (location.startsWith('node:') || location.startsWith('internal/')) return true;
+  // This module itself — the frame where `new Error()` was allocated. Matched on
+  // the path so it also holds when the wrapper name is minified away in a build.
+  if (/(^|\/)db\/index\.[cm]?[jt]s(:|$)/.test(location)) return true;
+  return fnName !== null && DB_CONTEXT_WRAPPER_FUNCTIONS.has(fnName);
+}
+
+/** Strip the machine-specific prefix so log lines stay short and comparable. */
+function toRepoRelative(location: string): string {
+  const withoutScheme = location.replace(/^file:\/\//, '');
+  const match = /(?:^|\/)((?:apps|packages|agent|scripts)\/.+)$/.exec(withoutScheme);
+  return match?.[1] ?? withoutScheme;
+}
+
+/**
+ * Pick the first application frame out of a captured stack and describe it.
+ * Returns null when the stack is absent or contains no application frame (e.g.
+ * a context opened directly from a node-internal callback). Pure — exported for
+ * unit testing.
+ */
+export function parseOpenerFrame(stack: string | undefined): HeldContextOpenerFrame | null {
+  if (!stack) return null;
+
+  for (const line of stack.split('\n')) {
+    const match = STACK_FRAME_RE.exec(line);
+    if (!match) continue;
+
+    const fnName = match[1] ?? null;
+    const rawLocation = match[2] ?? match[3];
+    if (!rawLocation) continue;
+
+    const location = toRepoRelative(rawLocation.trim());
+    if (isNonApplicationFrame(location, fnName)) continue;
+
+    // `apps/api/src/routes/devices.ts:42:10` → `devices`; drop V8's receiver
+    // prefix and `[as alias]` suffix from `Object.getDevice [as handler]`.
+    const file = /([^/\\]+?)\.[cm]?[jt]sx?(?::\d+)*$/.exec(location)?.[1] ?? null;
+    const fn = fnName?.replace(/\s*\[as .+?\]$/, '').split('.').pop() || null;
+    const label = file && fn ? `${file}.${fn}` : (file ?? fn);
+
+    return { location, label };
+  }
+
+  return null;
+}
+
+/**
+ * Compose the #1105 hold warning. Split out from the emitter so the exact text
+ * that reaches the console — the thing #3218 is about — is unit-testable
+ * without a live pool.
+ *
+ * Deliberately returns TWO strings. `message` is the Sentry-facing text and
+ * carries only the low-cardinality label; `consoleLine` adds the precise
+ * `file:line`. Sentry groups by message text, so a line number in `message`
+ * would fork one issue into a new one on every unrelated edit above the call
+ * site. The console has no such constraint and is where precision is needed.
+ */
+export function formatHeldContextWarning(input: {
+  scope: DbAccessScope;
+  label?: string | null;
+  openerFrame: HeldContextOpenerFrame | null;
+  heldMs: number;
+  warnMs: number;
+}): { message: string; consoleLine: string; tags: Record<string, string> } {
+  const { scope, label: explicitLabel, openerFrame, heldMs, warnMs } = input;
+
+  // The label goes in the MESSAGE, not just the tag: Sentry groups by message,
+  // so including it splits one bucket into per-source issues that can be
+  // resolved independently. An explicit label wins — it is curated and can
+  // separate paths that share one helper closure (the agent-WS case). Otherwise
+  // fall back to the opening frame so unlabelled callers, which are most of
+  // them, still group per source instead of arriving as one opaque bucket. This
+  // is a one-time regrouping for previously-unlabelled callers, by design.
+  const label = explicitLabel ?? openerFrame?.label ?? null;
+  const labelPart = label ? ` [${label}]` : '';
+  const message =
+    `withDbAccessContext (scope=${scope})${labelPart} held a pooled connection in an open `
+    + `transaction for ${heldMs}ms (>= ${warnMs}ms) — long enough that it likely did slow `
+    + `non-DB work (Redis/HTTP/loops) or a slow query inside the context. If the former, `
+    + `move it after the context closes or wrap it in runOutsideDbContext (#1105).`;
+
+  // `dbContextLabel` stays EXPLICIT-only so existing Sentry queries and
+  // dashboards keep their meaning; the derived name gets its own tag rather
+  // than silently widening that one.
+  const tags: Record<string, string> = {};
+  if (explicitLabel) tags.dbContextLabel = explicitLabel;
+  if (openerFrame?.label) tags.dbContextOpener = openerFrame.label;
+
+  return {
+    message,
+    consoleLine: openerFrame ? `${message} Opened at ${openerFrame.location}.` : message,
+    tags,
+  };
+}
+
 export async function withDbAccessContext<T>(
   context: DbAccessContext,
   fn: () => Promise<T>
@@ -315,18 +449,17 @@ export async function withDbAccessContext<T>(
         if (warnMs > 0) {
           const heldMs = Date.now() - startedAt;
           if (heldMs >= warnMs) {
-            // The label goes in the MESSAGE, not just the tag: Sentry groups by
-            // message, so including it splits one bucket into per-source issues
-            // that can be resolved independently. Unlabelled callers keep the
-            // exact previous message text, so their existing grouping is not
-            // disturbed by this change.
-            const labelPart = context.label ? ` [${context.label}]` : '';
-            const message =
-              `withDbAccessContext (scope=${context.scope})${labelPart} held a pooled connection in an open `
-              + `transaction for ${heldMs}ms (>= ${warnMs}ms) — long enough that it likely did slow `
-              + `non-DB work (Redis/HTTP/loops) or a slow query inside the context. If the former, `
-              + `move it after the context closes or wrap it in runOutsideDbContext (#1105).`;
-            console.warn(message);
+            // Formatting the stack costs a `.stack` access, so it happens here —
+            // only once a hold has actually breached the threshold (#3218).
+            const openerFrame = parseOpenerFrame(opener?.stack);
+            const { message, consoleLine, tags } = formatHeldContextWarning({
+              scope: context.scope,
+              label: context.label,
+              openerFrame,
+              heldMs,
+              warnMs,
+            });
+            console.warn(consoleLine);
             // Throttle the Sentry capture per scope (see getHeldContextCaptureThrottleMs)
             // so a recurring conn-hold can't flood the org's event quota.
             if (shouldCaptureHeldContext(context.scope, Date.now(), getHeldContextCaptureThrottleMs())) {
@@ -337,9 +470,10 @@ export async function withDbAccessContext<T>(
                 // opened the context. `stack` is kept (emitter-side, i.e. the
                 // await trampoline) only because the previous shape had it and
                 // dropping a field silently is worse than an extra one.
+                openedAtFrame: openerFrame?.location,
                 openedAt: opener?.stack,
                 stack: new Error().stack,
-              }, context.label ? { dbContextLabel: context.label } : undefined);
+              }, Object.keys(tags).length > 0 ? tags : undefined);
             }
           }
         }


### PR DESCRIPTION
## Problem

The `withDbAccessContext` hold tripwire (`apps/api/src/db/index.ts`, #1105) already captured the opener's stack — but only ever sent it to **Sentry**. The console warning carried scope, duration, and an optional `label` that most call sites don't pass. During the recent production incident that was a diagnostic dead end twice over:

1. **Console-only debugging was blind** — droplet logs showed 99 holds/10min with no way to attribute them from the box.
2. **Sentry wasn't there either** — the concurrent hot error saturated the DSN's rate limit, so the throttled hold captures (1/scope/5min) were dropped exactly when they mattered. The incident that *causes* the holds also suppresses their attribution.

## Change

Format one frame from the already-captured stack into the log line.

- **`parseOpenerFrame(stack)`** — picks the first **application** frame, skipping `node_modules`, node internals, and this module's own wrapper frames. That last skip matters: the `Error` is allocated inside `withDbAccessContext`, so the emitter frame is *always* on top — returning it would reproduce the BREEZE-9 failure of ~12k events naming the emitter instead of the caller. Handles `async`, `Object.fn [as alias]`, `new ClassName`, bare-location frames, `file://` ESM paths, `packages/` frames, and built `.js` paths.
- **`formatHeldContextWarning(...)`** — composes the warning. Returns `message` (Sentry-facing) and `consoleLine` separately. Both functions are pure and exported, so the text that actually reaches the console is testable without a live pool.
- **Auto-derived label** — when no explicit `label` was passed, one is derived from the opening frame (`basename.fn`) so unlabelled callers group per source instead of arriving as one opaque bucket. An explicit label still wins; it's curated and can separate paths that share one helper closure (the agent-WS case, where 12 contexts funnel through one closure).

### The load-bearing fix: *where* the stack is captured

The opener `Error` was allocated **inside the transaction callback, after six `await tx.execute(...)` hops**. That only ever worked via V8's async-stack reconstruction — which links a frame **only at a genuine `await`**. A caller doing a bare `return withSystemDbAccessContext(...)` was dropped from the trace entirely.

That idiom is used at **66 call sites** in this repo, including most BullMQ job workers — a prime suspect for the real long holds this tripwire exists to catch. Those would have been unattributed, or *misattributed to the next function out*, which is worse than nothing because it names an innocent frame as the culprit.

Fixed at the root: the `Error` is now allocated at **`withDbAccessContext` entry**, where the caller's frame is live on the synchronous stack regardless of how it invoked us — no async reconstruction involved. Cost is unchanged: same single allocation per context open, still gated on `warnMs > 0`, still only `.stack`-formatted on an actual breach. `startedAt` deliberately stays inside the transaction callback, since the hold being measured begins when the transaction owns a pooled connection.

### Two deliberate calls worth reviewing

- **`file:line` goes to the console only, never into the Sentry `message`.** Sentry groups by message text, and a line number shifts on every unrelated edit above the call site — putting it in `message` would fork one issue into a new one per release. Sentry gets the precise frame as the `openedAtFrame` extra instead.
- **The derived name gets its own `dbContextOpener` tag** rather than widening `dbContextLabel`, which stays explicit-only so existing Sentry queries/dashboards keep their meaning.

**Expected side effect:** previously-unlabelled callers now carry a derived label in the message, so they regroup **once** in Sentry into per-source issues. That's the intent of the issue, not a regression. The two existing integration tests that encoded the old "unlabelled callers keep byte-identical text" contract were updated deliberately.

### Before / after

```
- withDbAccessContext (scope=system) held a pooled connection in an open transaction for 40000ms (>= 2000ms) — …
+ withDbAccessContext (scope=system) [sweeper.sweep] held a pooled connection in an open transaction for 40000ms (>= 2000ms) — … Opened at apps/api/src/workers/sweeper.ts:77:9.
```

## Non-goal

Client-side capping of the genuine hot errors that saturate the DSN is a separate, known exposure and is explicitly out of scope per the issue. Untouched here.

## ⚠️ Overlapping work in flight

**#3214 is being fixed in parallel and also edits `apps/api/src/db/index.ts`** (pool configuration / connection-health). This PR's diff is confined to the hold-warning path — the two new pure helpers, and moving the opener allocation to function entry. A conflict is possible but should be mechanical — expect it and merge accordingly.

## Verification

- **Unit:** `vitest run src/db/` single-worker — **32 files, 1412 passed / 13 skipped**. 36 of those are in the touched file.
- **Integration (blocking `integration-test` job):** ran locally against a real Postgres via a worktree-private stack — `dbContextTripwire.integration.test.ts` **15 passed**, including a new end-to-end test proving a bare-`return` caller now attributes correctly.
- `tsc --noEmit` on `apps/api` — clean.
- No schema, migration, tenancy, or cascade surface touched.

Closes #3218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
