### PR TITLE
fix(api): scope alertWorker evaluate-all DB context to reads only (#3216)

### DIFF
--- a/apps/api/src/jobs/alertQueue.test.ts
+++ b/apps/api/src/jobs/alertQueue.test.ts
@@ -27,7 +27,9 @@ vi.mock('../services/redis', () => ({
 
 vi.mock('../db', () => ({
   db: {},
-
+  // getAlertQueue now builds an instrumented Queue, whose add/addBulk call the
+  // #1105 tripwire guard (services/bullmqQueue.ts).
+  assertOutsideHeldDbContext: vi.fn(),
   runOutsideDbContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),

--- a/apps/api/src/jobs/alertWorker.test.ts
+++ b/apps/api/src/jobs/alertWorker.test.ts
@@ -20,6 +20,11 @@ const {
     orgReadDepths: [] as number[],
     deviceReadDepths: [] as number[],
     addBulkDepths: [] as number[],
+    // Every operation the #1105 guard was consulted for. Asserting this is
+    // non-empty is what pins the queue to createInstrumentedQueue — checking
+    // only `tripwireViolations` would pass just as happily against a bare
+    // `new Queue`, which never calls the guard at all.
+    tripwireCalls: [] as string[],
     tripwireViolations: [] as string[]
   };
   return {
@@ -110,6 +115,7 @@ vi.mock('../db', () => ({
   // Mirrors the production guard wired into createInstrumentedQueue: record the
   // enqueue call sites that ran while a transaction was still held.
   assertOutsideHeldDbContext: (operation: string) => {
+    ctx.tripwireCalls.push(operation);
     if (ctx.depth > 0) ctx.tripwireViolations.push(operation);
   }
 }));
@@ -151,6 +157,7 @@ const resetCtx = () => {
   ctx.orgReadDepths.length = 0;
   ctx.deviceReadDepths.length = 0;
   ctx.addBulkDepths.length = 0;
+  ctx.tripwireCalls.length = 0;
   ctx.tripwireViolations.length = 0;
 };
 
@@ -272,7 +279,15 @@ describe('alertWorker evaluate-all #1105 DB-context scoping', () => {
     expect(ctx.addBulkDepths).toHaveLength(3);
     expect(ctx.addBulkDepths).toEqual([0, 0, 0]);
 
-    // ...and the instrumented queue's #1105 tripwire agrees.
+    // ...and the instrumented queue's #1105 tripwire agrees. Both halves are
+    // load-bearing: the first pins getAlertQueue() to createInstrumentedQueue
+    // (a bare `new Queue` never consults the guard, so the second assertion
+    // alone would pass vacuously); the second pins the context boundary.
+    expect(ctx.tripwireCalls).toEqual([
+      'bullmq.addBulk(alert-evaluation)',
+      'bullmq.addBulk(alert-evaluation)',
+      'bullmq.addBulk(alert-evaluation)'
+    ]);
     expect(ctx.tripwireViolations).toEqual([]);
 
     // The context must be scoped, not removed: reads still run inside one, or
@@ -302,6 +317,7 @@ describe('alertWorker evaluate-all #1105 DB-context scoping', () => {
 
     expect(result.queued).toBe(600);
     expect(ctx.addBulkDepths).toEqual([0, 0]);
+    expect(ctx.tripwireCalls).toHaveLength(2);
     expect(ctx.tripwireViolations).toEqual([]);
   });
 

--- a/apps/api/src/jobs/alertWorker.test.ts
+++ b/apps/api/src/jobs/alertWorker.test.ts
@@ -1,20 +1,48 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
 
-const { addBulkMock, addMock, getJobMock, warnSpy, devicesSchema, organizationsSchema, fleetState } = vi.hoisted(() => ({
-  addBulkMock: vi.fn(async () => undefined),
-  addMock: vi.fn(async () => ({ id: 'queued-job-1' })),
-  getJobMock: vi.fn(async () => null),
-  warnSpy: vi.fn(),
-  devicesSchema: {
-    id: 'devices.id',
-    orgId: 'devices.orgId',
-    status: 'devices.status',
-    lastSeenAt: 'devices.lastSeenAt',
-    isEphemeral: 'devices.isEphemeral'
-  } as const,
-  organizationsSchema: { id: 'organizations.id', status: 'organizations.status', type: 'organizations.type' } as const,
-  fleetState: { fleet: [] as { id: string; orgId: string }[], chunkCalls: 0 }
-}));
+const {
+  addBulkMock,
+  addMock,
+  getJobMock,
+  warnSpy,
+  devicesSchema,
+  organizationsSchema,
+  fleetState,
+  ctx,
+  workerState
+} = vi.hoisted(() => {
+  // Models the #1105 surface under test: `depth > 0` means a
+  // withDbAccessContext transaction is open and a pooled Postgres connection is
+  // pinned. Every mocked DB read and every enqueue records the depth it saw, so
+  // the tests can assert WHERE the context boundary actually falls.
+  const ctx = {
+    depth: 0,
+    orgReadDepths: [] as number[],
+    deviceReadDepths: [] as number[],
+    addBulkDepths: [] as number[],
+    tripwireViolations: [] as string[]
+  };
+  return {
+    addBulkMock: vi.fn(async () => {
+      ctx.addBulkDepths.push(ctx.depth);
+      return undefined;
+    }),
+    addMock: vi.fn(async () => ({ id: 'queued-job-1' })),
+    getJobMock: vi.fn(async () => null),
+    warnSpy: vi.fn(),
+    devicesSchema: {
+      id: 'devices.id',
+      orgId: 'devices.orgId',
+      status: 'devices.status',
+      lastSeenAt: 'devices.lastSeenAt',
+      isEphemeral: 'devices.isEphemeral'
+    } as const,
+    organizationsSchema: { id: 'organizations.id', status: 'organizations.status', type: 'organizations.type' } as const,
+    fleetState: { fleet: [] as { id: string; orgId: string }[], chunkCalls: 0 },
+    ctx,
+    workerState: { processor: null as null | ((job: { data: unknown }) => Promise<unknown>) }
+  };
+});
 
 vi.mock('drizzle-orm', () => ({
   eq: (col: unknown, val: unknown) => ({ op: 'eq', col, val }),
@@ -47,13 +75,17 @@ vi.mock('../db', () => ({
       from: (table: unknown) => {
         if (table === organizationsSchema) {
           return {
-            where: () => Promise.resolve([{ id: 'org-1' }])
+            where: () => {
+              ctx.orgReadDepths.push(ctx.depth);
+              return Promise.resolve([{ id: 'org-1' }]);
+            }
           };
         }
         return {
           where: () => ({
             orderBy: () => ({
               limit: (limit: number) => {
+                ctx.deviceReadDepths.push(ctx.depth);
                 const startIdx = fleetState.chunkCalls * limit;
                 const slice = fleetState.fleet.slice(startIdx, startIdx + limit);
                 fleetState.chunkCalls++;
@@ -63,10 +95,23 @@ vi.mock('../db', () => ({
           })
         };
       }
-    })),
-    withSystemDbAccessContext: undefined
+    }))
   },
-  withSystemDbAccessContext: undefined
+  // Real nesting semantics are irrelevant here; what matters is that a context
+  // is OPEN for the duration of `fn` and closed after it settles.
+  withSystemDbAccessContext: async <T>(fn: () => Promise<T>): Promise<T> => {
+    ctx.depth++;
+    try {
+      return await fn();
+    } finally {
+      ctx.depth--;
+    }
+  },
+  // Mirrors the production guard wired into createInstrumentedQueue: record the
+  // enqueue call sites that ran while a transaction was still held.
+  assertOutsideHeldDbContext: (operation: string) => {
+    if (ctx.depth > 0) ctx.tripwireViolations.push(operation);
+  }
 }));
 
 vi.mock('bullmq', () => ({
@@ -76,6 +121,9 @@ vi.mock('bullmq', () => ({
     getJob = getJobMock;
   },
   Worker: class {
+    constructor(_name: string, processor: (job: { data: unknown }) => Promise<unknown>) {
+      workerState.processor = processor;
+    }
     on = vi.fn();
     close = vi.fn();
   }
@@ -96,12 +144,21 @@ vi.mock('../services/bullmqUtils', () => ({
   isReusableState: vi.fn(() => false)
 }));
 
-import { processEvaluateAll, triggerFullEvaluation } from './alertWorker';
+import { createAlertWorker, processEvaluateAll, triggerFullEvaluation } from './alertWorker';
+
+const resetCtx = () => {
+  ctx.depth = 0;
+  ctx.orgReadDepths.length = 0;
+  ctx.deviceReadDepths.length = 0;
+  ctx.addBulkDepths.length = 0;
+  ctx.tripwireViolations.length = 0;
+};
 
 describe('alertWorker.processEvaluateAll cursor fan-out', () => {
   beforeEach(() => {
     fleetState.fleet = [];
     fleetState.chunkCalls = 0;
+    resetCtx();
     addBulkMock.mockClear();
     warnSpy.mockClear();
     vi.spyOn(console, 'warn').mockImplementation(warnSpy);
@@ -177,6 +234,93 @@ describe('alertWorker.processEvaluateAll cursor fan-out', () => {
 
     expect(result.queued).toBe(0);
     expect(addBulkMock).not.toHaveBeenCalled();
+  });
+});
+
+// Regression for #3216 (Sentry BREEZE-9, #1105 class): the evaluate-all sweep
+// used to run its entire per-device iteration and Redis fan-out inside the DB
+// context opened by the worker wrapper, pinning a pooled Postgres connection
+// idle-in-transaction for ~5s on every 60s cycle. The context must now be scoped
+// to the reads only, with every enqueue landing after it closes.
+describe('alertWorker evaluate-all #1105 DB-context scoping', () => {
+  beforeEach(() => {
+    fleetState.fleet = [];
+    fleetState.chunkCalls = 0;
+    resetCtx();
+    workerState.processor = null;
+    addBulkMock.mockClear();
+    vi.spyOn(console, 'warn').mockImplementation(warnSpy);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    delete process.env.ALERT_WORKER_MAX_DEVICES_PER_RUN;
+    delete process.env.ALERT_WORKER_CHUNK_SIZE;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not hold a DB context across the enqueue loop', async () => {
+    process.env.ALERT_WORKER_CHUNK_SIZE = '500';
+    fleetState.fleet = buildFleet(1500);
+
+    const result = await processEvaluateAll({ type: 'evaluate-all' });
+
+    expect(result.queued).toBe(1500);
+
+    // The whole point: every addBulk in the multi-page loop ran with NO context
+    // open. A single non-zero entry here is the bug returning.
+    expect(ctx.addBulkDepths).toHaveLength(3);
+    expect(ctx.addBulkDepths).toEqual([0, 0, 0]);
+
+    // ...and the instrumented queue's #1105 tripwire agrees.
+    expect(ctx.tripwireViolations).toEqual([]);
+
+    // The context must be scoped, not removed: reads still run inside one, or
+    // the fan-out would be reading past RLS on a bare pool.
+    expect(ctx.orgReadDepths.every((d) => d > 0)).toBe(true);
+    // 4 reads, not 3: 1500 devices at chunkSize 500 fills every page exactly, so
+    // the `chunk.length < limit` early-out never fires and the loop terminates on
+    // a final empty page. That page opens its own context too.
+    expect(ctx.deviceReadDepths).toHaveLength(4);
+    expect(ctx.deviceReadDepths.every((d) => d > 0)).toBe(true);
+
+    // Nothing leaked: the sweep leaves no context open behind it.
+    expect(ctx.depth).toBe(0);
+  });
+
+  it('runs the evaluate-all job through the worker handler with no wrapping context', async () => {
+    process.env.ALERT_WORKER_CHUNK_SIZE = '500';
+    fleetState.fleet = buildFleet(600);
+
+    createAlertWorker();
+    expect(workerState.processor).toBeTypeOf('function');
+
+    // Exercised through the real worker processor, because the wrapper is what
+    // opened the offending context — asserting on processEvaluateAll alone would
+    // not catch a blanket runWithSystemDbAccess being reinstated here.
+    const result = (await workerState.processor!({ data: { type: 'evaluate-all' } })) as { queued: number };
+
+    expect(result.queued).toBe(600);
+    expect(ctx.addBulkDepths).toEqual([0, 0]);
+    expect(ctx.tripwireViolations).toEqual([]);
+  });
+
+  it('still wraps per-device evaluation in a system DB context', async () => {
+    createAlertWorker();
+    expect(workerState.processor).toBeTypeOf('function');
+
+    const seenDepths: number[] = [];
+    const { evaluateDeviceAlerts, evaluateDeviceAlertsFromPolicy } = await import('../services/alertService');
+    vi.mocked(evaluateDeviceAlerts).mockImplementation(async () => {
+      seenDepths.push(ctx.depth);
+      return [];
+    });
+    vi.mocked(evaluateDeviceAlertsFromPolicy).mockImplementation(async () => []);
+
+    await workerState.processor!({ data: { type: 'evaluate-device', deviceId: 'device-1', orgId: 'org-1' } });
+
+    // evaluate-device does its own reads AND writes; it keeps the wrapper.
+    expect(seenDepths).toEqual([1]);
   });
 });
 

--- a/apps/api/src/jobs/alertWorker.ts
+++ b/apps/api/src/jobs/alertWorker.ts
@@ -17,6 +17,7 @@ import {
   checkAutoResolveFromConfigPolicy,
 } from '../services/alertService';
 import { isReusableState } from '../services/bullmqUtils';
+import { createInstrumentedQueue } from '../services/bullmqQueue';
 import { attachWorkerObservability } from './workerObservability';
 import { envInt } from '../utils/envInt';
 
@@ -47,9 +48,11 @@ let alertQueue: Queue | null = null;
  */
 export function getAlertQueue(): Queue {
   if (!alertQueue) {
-    alertQueue = new Queue(ALERT_QUEUE, {
-      connection: getBullMQConnection()
-    });
+    // Instrumented so an enqueue made from inside a held DB context trips the
+    // #1105 tripwire instead of silently pinning a pooled connection. The bare
+    // `new Queue` that used to be here is exactly why the evaluate-all addBulk
+    // hold (BREEZE-9, ~5s every 60s) went unnoticed for months (#3216).
+    alertQueue = createInstrumentedQueue(ALERT_QUEUE);
   }
   return alertQueue;
 }
@@ -80,23 +83,28 @@ export function createAlertWorker(): Worker<AlertJobData> {
   return new Worker<AlertJobData>(
     ALERT_QUEUE,
     async (job: Job<AlertJobData>) => {
-      return runWithSystemDbAccess(async () => {
-        const startTime = Date.now();
+      const data = job.data;
 
-        switch (job.data.type) {
-          case 'evaluate-all':
-            return await processEvaluateAll(job.data);
+      switch (data.type) {
+        case 'evaluate-all':
+          // Deliberately NOT wrapped. `processEvaluateAll` self-manages its DB
+          // context: it reads each fleet page inside a SHORT system context that
+          // closes before that page's Redis fan-out. A blanket wrap here pinned a
+          // pooled connection idle-in-transaction for the entire ~5s enqueue loop
+          // on every 60s cycle (#1105 / BREEZE-9, #3216). Mirrors
+          // monitorWorker's `monitor-scheduler` and securityPostureWorker's
+          // `scan-orgs`, which are structurally the same fan-out job.
+          return await processEvaluateAll(data);
 
-          case 'evaluate-device':
-            return await processEvaluateDevice(job.data);
+        case 'evaluate-device':
+          return await runWithSystemDbAccess(() => processEvaluateDevice(data));
 
-          case 'auto-resolve':
-            return await processAutoResolve(job.data);
+        case 'auto-resolve':
+          return await runWithSystemDbAccess(() => processAutoResolve(data));
 
-          default:
-            throw new Error(`Unknown job type: ${(job.data as { type: string }).type}`);
-        }
-      });
+        default:
+          throw new Error(`Unknown job type: ${(data as { type: string }).type}`);
+      }
     },
     {
       connection: getBullMQConnection(),
@@ -110,7 +118,22 @@ export function createAlertWorker(): Worker<AlertJobData> {
 
 /**
  * Process evaluate-all job
- * Fetches devices with recent metrics and queues individual device evaluations
+ * Fetches devices with recent metrics and queues individual device evaluations.
+ *
+ * #1105 CONTRACT (BREEZE-9 / #3216): this function must be called with NO DB
+ * context open — the worker handler intentionally does not wrap it. It opens one
+ * short-lived system context per DB read and lets each close before the Redis
+ * fan-out for that page runs, so no pooled connection is ever held
+ * idle-in-transaction across `queue.addBulk`. Wrapping the whole call in
+ * `withSystemDbAccessContext` re-creates the original bug: nested
+ * `withDbAccessContext` calls short-circuit to the ambient transaction, so every
+ * read below would silently rejoin the outer context and the enqueue loop would
+ * again pin a connection for the full ~5s sweep.
+ *
+ * Pagination therefore spans transactions. That is intentional and safe: the
+ * keyset cursor (`devices.id` ascending) stays stable, `recentThreshold` is
+ * computed once so the eligibility window does not drift between pages, and a
+ * device whose status flips mid-sweep is simply picked up on the next 60s cycle.
  */
 export async function processEvaluateAll(data: EvaluateAllJobData): Promise<{
   queued: number;
@@ -132,13 +155,15 @@ export async function processEvaluateAll(data: EvaluateAllJobData): Promise<{
   // for RLS reasons, so it is NOT filtered out for us — every fleet sweep has to
   // exclude it explicitly. Alert evaluation is the path that pages on-call staff,
   // so ephemeral devices are excluded at both the org and the device level.
-  const orgs = await db
-    .select({ id: organizations.id })
-    .from(organizations)
-    .where(and(
-      eq(organizations.status, 'active'),
-      ne(organizations.type, 'quick_support')
-    ));
+  const orgs = await runWithSystemDbAccess(async () =>
+    db
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(and(
+        eq(organizations.status, 'active'),
+        ne(organizations.type, 'quick_support')
+      ))
+  );
 
   if (orgs.length === 0) {
     return { queued: 0, skipped: 0, durationMs: Date.now() - startTime };
@@ -173,12 +198,16 @@ export async function processEvaluateAll(data: EvaluateAllJobData): Promise<{
     ];
     if (cursor) conditions.push(gt(devices.id, cursor));
 
-    const chunk = await db
-      .select({ id: devices.id, orgId: devices.orgId })
-      .from(devices)
-      .where(and(...conditions))
-      .orderBy(asc(devices.id))
-      .limit(limit);
+    // Page read inside its own system context, which CLOSES before the addBulk
+    // below (#1105).
+    const chunk = await runWithSystemDbAccess(async () =>
+      db
+        .select({ id: devices.id, orgId: devices.orgId })
+        .from(devices)
+        .where(and(...conditions))
+        .orderBy(asc(devices.id))
+        .limit(limit)
+    );
 
     if (chunk.length === 0) break;
 

--- a/apps/api/src/jobs/alertWorker.ts
+++ b/apps/api/src/jobs/alertWorker.ts
@@ -50,8 +50,9 @@ export function getAlertQueue(): Queue {
   if (!alertQueue) {
     // Instrumented so an enqueue made from inside a held DB context trips the
     // #1105 tripwire instead of silently pinning a pooled connection. The bare
-    // `new Queue` that used to be here is exactly why the evaluate-all addBulk
-    // hold (BREEZE-9, ~5s every 60s) went unnoticed for months (#3216).
+    // `new Queue` that used to be here left this queue outside the tripwire's
+    // (still incrementally adopted) coverage, so the evaluate-all addBulk hold
+    // — BREEZE-9, ~5s every 60s — had to be found by hand from Sentry (#3216).
     alertQueue = createInstrumentedQueue(ALERT_QUEUE);
   }
   return alertQueue;


### PR DESCRIPTION
## Problem

The `evaluate-all` sweep ran its entire per-org/per-device iteration **and** its Redis fan-out inside the system DB context opened by the worker wrapper. That pinned a pooled Postgres connection idle-in-transaction for ~4.9s on every 60s cycle — **15,469** held-context warnings since June 16 (Sentry **BREEZE-9**), the largest remaining steady #1105 offender. Under normal pool conditions it wasted a connection ~8% of the time; under a degraded pool the same holds stretched to 20–40s and amplified the outage.

## Fix

Standard #1105 remediation, matching `monitorWorker`'s `monitor-scheduler` and `securityPostureWorker`'s `scan-orgs` — structurally the same fan-out job:

- **Worker handler no longer blanket-wraps the job body.** `evaluate-all` self-manages its context; `evaluate-device` and `auto-resolve` keep theirs (they read *and* write per device).
- **`processEvaluateAll` opens one short-lived system context per DB read** — the org list, then each keyset-paginated device page — and lets it close before that page's `queue.addBulk`. No connection is held across an enqueue.
- **`getAlertQueue()` now builds via `createInstrumentedQueue`**, so any future enqueue from inside a held context trips the #1105 tripwire instead of going unnoticed. The bare `new Queue` is precisely why this hid for months (same note already on `securityPostureWorker`).

### Behaviour note — pagination now spans transactions

Intentional and safe: the keyset cursor (`devices.id` ascending) stays stable, `recentThreshold` is computed once so the eligibility window does not drift between pages, and a device whose status flips mid-sweep is simply picked up on the next 60s cycle. This is a best-effort fan-out enqueue, not a consistent snapshot.

No tenancy change: reads still run inside a system context, so RLS behaviour is identical. The context is **scoped**, not removed — one of the new tests asserts exactly that, so a "fix" that just deleted the context would fail.

## Verification

- `apps/api/src/jobs/**` + `ticketEvents` + `readiness` suites, single-fork: **926 passed, 1 skipped, 0 failed**.
- `pnpm exec tsc --noEmit --project apps/api/tsconfig.json`: clean.
- **Guard proven non-vacuous:** temporarily reinstating the blanket `runWithSystemDbAccess` wrapper turns the new test red — `expected [1, 1] to deeply equal [0, 0]`.

### Tests added

Three cases in `alertWorker.test.ts` asserting where the context boundary actually falls:

1. `does not hold a DB context across the enqueue loop` — every `addBulk` across a 3-page sweep observes zero open contexts, the tripwire records no violations, the reads all observe an open context, and no context leaks after the sweep.
2. `runs the evaluate-all job through the worker handler with no wrapping context` — driven through the **real worker processor** (the wrapper is what opened the offending context, so asserting on `processEvaluateAll` alone would not catch a regression there).
3. `still wraps per-device evaluation in a system DB context` — confirms the other job types were not collaterally unwrapped.

Closes #3216

🤖 Generated with [Claude Code](https://claude.com/claude-code)