### PR TITLE
fix(api): diagnose and surface the postgres.js pool-poisoning failure (#3214)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -453,6 +453,22 @@ GRAFANA_ADMIN_PASSWORD=changeme
 # EVENT_LOOP_STARVATION_WARN_MS=1000
 # EVENT_LOOP_MONITOR_DISABLED=
 
+# Database pool-health watchdog. On by default; these are tuning knobs.
+# postgres.js can leave a pooled connection permanently unable to reconnect once
+# its socket dies with a buffered write, producing a storm of "write
+# CONNECT_TIMEOUT" errors against a database that is perfectly healthy. The pool
+# cannot self-heal — only an API restart recovers it. When the CONNECT_TIMEOUT
+# rate breaches the threshold below, the watchdog opens ONE brand-new connection
+# to the same database to tell the two cases apart: if that succeeds the pool is
+# at fault, if it fails too the database is. Exposed as breeze_db_pool_health and
+# breeze_db_connect_timeout_rate_per_min on /metrics.
+# DB_POOL_HEALTH_INTERVAL_MS=60000
+# DB_POOL_HEALTH_WINDOW_MS=300000
+# DB_POOL_HEALTH_MIN_TIMEOUTS=10
+# DB_POOL_HEALTH_PROBE_TIMEOUT_MS=5000
+# DB_POOL_HEALTH_CAPTURE_THROTTLE_MS=900000
+# DB_POOL_HEALTH_DISABLED=
+
 # Platform-operator abuse alerts (all optional; unset = feature disabled)
 # OPS_ALERT_WEBHOOK_URL=https://discord.com/api/webhooks/your-webhook
 # OPS_ALERT_EMAIL=ops@your-domain.example.com

--- a/apps/api/src/db/dbPoolHealthMonitor.test.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.test.ts
@@ -134,7 +134,7 @@ describe('dbPoolHealthMonitor (#3214)', () => {
       expect(result.message).not.toContain('POOL DEGRADED');
     });
 
-    it('reports unknown when the probe times out and starvation dominates the causes', async () => {
+    it('reports unknown when the probe times out under event-loop starvation', async () => {
       // The probe's budget is an in-process setTimeout, so it expires when the
       // main thread is pegged just as readily as when the DB is unreachable —
       // the #3022 ambiguity, one layer up. Calling this `database-unreachable`
@@ -155,13 +155,40 @@ describe('dbPoolHealthMonitor (#3214)', () => {
       });
 
       expect(result.verdict).toBe('unknown');
-      expect(result.message).toContain('event-loop starvation');
+      expect(result.message).toContain('starvation');
       expect(result.message).not.toContain('DATABASE UNREACHABLE');
     });
 
-    it('still reports database-unreachable on a probe timeout when starvation does NOT dominate', async () => {
-      // A genuinely unreachable database also makes the probe time out. Only the
-      // starvation-dominated case is inconclusive.
+    it('reports unknown on a probe timeout when NO cause could be measured at all', async () => {
+      // With EVENT_LOOP_MONITOR_DISABLED (or the monitor still warming up) every
+      // timeout is classified `unknown`. A "does starvation dominate?" test would
+      // see a starvation count of 0, find no dominance, and emit the confident
+      // `database-unreachable` in exactly the configuration where this module has
+      // the LEAST evidence. The verdict must require positive evidence FOR a
+      // connectivity fault, not merely the absence of evidence against one.
+      const result = await assessDbPoolHealth({
+        readStats: () => ({
+          timeouts: 40,
+          byCause: { 'event-loop-starvation': 0, connectivity: 0, unknown: 40 },
+          windowMs: 300_000,
+          ratePerMin: 8,
+          totalSinceStart: 40,
+        }),
+        probe: async () => {
+          throw new DbPoolProbeTimedOutError('pool-health probe exceeded 5000ms');
+        },
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('unknown');
+      expect(result.message).not.toContain('DATABASE UNREACHABLE');
+      expect(result.message).not.toContain('Restarting the API will not help');
+    });
+
+    it('still reports database-unreachable on a probe timeout when connectivity dominates', async () => {
+      // A genuinely unreachable database also makes the probe time out, and here
+      // the timeouts themselves were measured as connectivity faults on a healthy
+      // loop — that IS positive evidence, so the confident verdict is warranted.
       const result = await assessDbPoolHealth({
         readStats: () => ({
           timeouts: 40,
@@ -172,6 +199,27 @@ describe('dbPoolHealthMonitor (#3214)', () => {
         }),
         probe: async () => {
           throw new DbPoolProbeTimedOutError('pool-health probe exceeded 5000ms');
+        },
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('database-unreachable');
+    });
+
+    it('a driver-reported failure is database-unreachable regardless of cause mix', async () => {
+      // Only a TIMEOUT is ambiguous. An ECONNREFUSED came from the network stack,
+      // not from an in-process timer, so it stands on its own even when every
+      // timeout was classified `unknown`.
+      const result = await assessDbPoolHealth({
+        readStats: () => ({
+          timeouts: 40,
+          byCause: { 'event-loop-starvation': 0, connectivity: 0, unknown: 40 },
+          windowMs: 300_000,
+          ratePerMin: 8,
+          totalSinceStart: 40,
+        }),
+        probe: async () => {
+          throw new Error('connect ECONNREFUSED 10.0.0.5:5432');
         },
         thresholdTimeouts: 10,
       });
@@ -231,7 +279,7 @@ describe('dbPoolHealthMonitor (#3214)', () => {
         expect.stringContaining('POOL DEGRADED'),
         'warning',
         expect.objectContaining({ verdict: 'pool-degraded', timeouts: 40 }),
-        { dbPoolHealthVerdict: 'pool-degraded' },
+        { db_pool_health_verdict: 'pool-degraded' },
       );
     });
 
@@ -272,6 +320,29 @@ describe('dbPoolHealthMonitor (#3214)', () => {
       expect(getLastDbPoolHealthAssessment()).toBeNull();
     });
 
+    it('keeps a valid verdict when the Sentry report itself throws', async () => {
+      // The outer catch now CLEARS lastAssessment. A reporter fault must not
+      // reach it — that would erase a real pool-degraded verdict from /metrics
+      // at the exact moment it fired, and show a reporting error instead.
+      captureMessage.mockImplementationOnce(() => {
+        throw new Error('sentry transport exploded');
+      });
+
+      const result = await runDbPoolHealthCheck({
+        readStats: () => stats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+
+      expect(result?.verdict).toBe('pool-degraded');
+      expect(getLastDbPoolHealthAssessment()?.verdict).toBe('pool-degraded');
+      expect(getDbPoolHealthCheckFailures()).toBe(0);
+      expect(console.error).toHaveBeenCalledWith(
+        '[db-pool-health] failed to report verdict to Sentry:',
+        expect.any(Error),
+      );
+    });
+
     it('reports its own failure to Sentry, not only to the console', async () => {
       // A watchdog failing every tick is otherwise console-only, which is
       // exactly the invisibility this module exists to remove.
@@ -285,7 +356,7 @@ describe('dbPoolHealthMonitor (#3214)', () => {
         '[db-pool-health] watchdog evaluation failed',
         'warning',
         expect.objectContaining({ error: 'stats exploded', checkFailures: 1 }),
-        { dbPoolHealthVerdict: 'check-failed' },
+        { db_pool_health_verdict: 'check-failed' },
       );
     });
 

--- a/apps/api/src/db/dbPoolHealthMonitor.test.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.test.ts
@@ -10,12 +10,16 @@ import {
   assessDbPoolHealth,
   getDbPoolHealthMinTimeouts,
   getDbPoolHealthWindowMs,
+  getDbPoolHealthCheckFailures,
+  getDbPoolHealthProbeTimeoutMs,
   getLastDbPoolHealthAssessment,
   isDbPoolHealthMonitorDisabled,
+  probeFreshDatabaseConnection,
   runDbPoolHealthCheck,
-  shouldCaptureDbPoolHealth,
+  claimDbPoolHealthCaptureSlot,
   startDbPoolHealthMonitor,
   stopDbPoolHealthMonitor,
+  DbPoolProbeTimedOutError,
   DbPoolProbeUnavailableError,
 } from './dbPoolHealthMonitor';
 import type { DbConnectTimeoutWindowStats } from '../services/dbConnectTimeoutStats';
@@ -46,10 +50,13 @@ describe('dbPoolHealthMonitor (#3214)', () => {
     delete process.env.DB_POOL_HEALTH_INTERVAL_MS;
     delete process.env.DB_POOL_HEALTH_WINDOW_MS;
     delete process.env.DB_POOL_HEALTH_MIN_TIMEOUTS;
+    delete process.env.DB_POOL_HEALTH_PROBE_TIMEOUT_MS;
+    delete process.env.DB_POOL_HEALTH_CAPTURE_THROTTLE_MS;
+    delete process.env.DATABASE_URL_APP;
   });
 
   describe('assessDbPoolHealth', () => {
-    it('reports healthy and does NOT probe below the threshold', async () => {
+    it('reports below-threshold and does NOT probe below the threshold', async () => {
       // The probe opens a real socket. It must stay off the steady-state path,
       // otherwise a fleet of instances adds a permanent connection every tick.
       const probe = vi.fn(async () => {});
@@ -59,7 +66,7 @@ describe('dbPoolHealthMonitor (#3214)', () => {
         thresholdTimeouts: 10,
       });
 
-      expect(result.verdict).toBe('healthy');
+      expect(result.verdict).toBe('below-threshold');
       expect(probe).not.toHaveBeenCalled();
       expect(result.probeMs).toBeNull();
     });
@@ -127,6 +134,51 @@ describe('dbPoolHealthMonitor (#3214)', () => {
       expect(result.message).not.toContain('POOL DEGRADED');
     });
 
+    it('reports unknown when the probe times out and starvation dominates the causes', async () => {
+      // The probe's budget is an in-process setTimeout, so it expires when the
+      // main thread is pegged just as readily as when the DB is unreachable —
+      // the #3022 ambiguity, one layer up. Calling this `database-unreachable`
+      // would send the operator after a DB incident AND tell them a restart
+      // won't help, while the real fault is a blocked loop.
+      const result = await assessDbPoolHealth({
+        readStats: () => ({
+          timeouts: 40,
+          byCause: { 'event-loop-starvation': 30, connectivity: 10, unknown: 0 },
+          windowMs: 300_000,
+          ratePerMin: 8,
+          totalSinceStart: 40,
+        }),
+        probe: async () => {
+          throw new DbPoolProbeTimedOutError('pool-health probe exceeded 5000ms');
+        },
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('unknown');
+      expect(result.message).toContain('event-loop starvation');
+      expect(result.message).not.toContain('DATABASE UNREACHABLE');
+    });
+
+    it('still reports database-unreachable on a probe timeout when starvation does NOT dominate', async () => {
+      // A genuinely unreachable database also makes the probe time out. Only the
+      // starvation-dominated case is inconclusive.
+      const result = await assessDbPoolHealth({
+        readStats: () => ({
+          timeouts: 40,
+          byCause: { 'event-loop-starvation': 2, connectivity: 38, unknown: 0 },
+          windowMs: 300_000,
+          ratePerMin: 8,
+          totalSinceStart: 40,
+        }),
+        probe: async () => {
+          throw new DbPoolProbeTimedOutError('pool-health probe exceeded 5000ms');
+        },
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('database-unreachable');
+    });
+
     it('surfaces a non-Error probe rejection as a string', async () => {
       const result = await assessDbPoolHealth({
         readStats: () => stats(40),
@@ -154,14 +206,14 @@ describe('dbPoolHealthMonitor (#3214)', () => {
   });
 
   describe('runDbPoolHealthCheck', () => {
-    it('stores the assessment and stays silent when healthy', async () => {
+    it('stores the assessment and stays silent below the threshold', async () => {
       await runDbPoolHealthCheck({
         readStats: () => stats(0),
         probe: async () => {},
         thresholdTimeouts: 10,
       });
 
-      expect(getLastDbPoolHealthAssessment()?.verdict).toBe('healthy');
+      expect(getLastDbPoolHealthAssessment()?.verdict).toBe('below-threshold');
       expect(captureMessage).not.toHaveBeenCalled();
       expect(console.warn).not.toHaveBeenCalled();
     });
@@ -196,28 +248,149 @@ describe('dbPoolHealthMonitor (#3214)', () => {
         '[db-pool-health] check failed:',
         expect.any(Error),
       );
+      expect(getDbPoolHealthCheckFailures()).toBe(1);
+    });
+
+    it('CLEARS the previous verdict when a check fails, rather than leaving it standing', async () => {
+      // lastAssessment drives the Prometheus verdict series. Leaving a stale
+      // value would republish an old below-threshold reading on every scrape for
+      // hours, about a watchdog that has been dead the whole time — an
+      // affirmative wrong answer, worse than the "not observed" null produces.
+      await runDbPoolHealthCheck({
+        readStats: () => stats(0),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+      expect(getLastDbPoolHealthAssessment()).not.toBeNull();
+
+      await runDbPoolHealthCheck({
+        readStats: () => {
+          throw new Error('stats exploded');
+        },
+      });
+
+      expect(getLastDbPoolHealthAssessment()).toBeNull();
+    });
+
+    it('reports its own failure to Sentry, not only to the console', async () => {
+      // A watchdog failing every tick is otherwise console-only, which is
+      // exactly the invisibility this module exists to remove.
+      await runDbPoolHealthCheck({
+        readStats: () => {
+          throw new Error('stats exploded');
+        },
+      });
+
+      expect(captureMessage).toHaveBeenCalledWith(
+        '[db-pool-health] watchdog evaluation failed',
+        'warning',
+        expect.objectContaining({ error: 'stats exploded', checkFailures: 1 }),
+        { dbPoolHealthVerdict: 'check-failed' },
+      );
+    });
+
+    it('throttles the Sentry capture across repeated degraded ticks', async () => {
+      // The unit test for the gate proves the arithmetic; this proves the gate is
+      // actually CONSULTED here. Without it, a condition that persists until
+      // restart captures every 60s — the flood that has twice blacked out the
+      // org's Sentry quota.
+      process.env.DB_POOL_HEALTH_CAPTURE_THROTTLE_MS = '900000';
+      const deps = {
+        readStats: () => stats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      };
+
+      await runDbPoolHealthCheck(deps);
+      await runDbPoolHealthCheck(deps);
+      await runDbPoolHealthCheck(deps);
+
+      expect(captureMessage).toHaveBeenCalledTimes(1);
+      // Console is deliberately NOT throttled — logs stay complete.
+      expect(console.warn).toHaveBeenCalledTimes(3);
+    });
+
+    it('captures every tick when the throttle is disabled', async () => {
+      process.env.DB_POOL_HEALTH_CAPTURE_THROTTLE_MS = '0';
+      const deps = {
+        readStats: () => stats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      };
+
+      await runDbPoolHealthCheck(deps);
+      await runDbPoolHealthCheck(deps);
+
+      expect(captureMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses a STABLE Sentry title so the alert does not fragment per rate', async () => {
+      // Sentry groups by message text. Interpolating the rate into the title
+      // mints a fresh issue on every capture, so an alert bound to an issue can
+      // never fire twice and "Resolve" never sticks.
+      process.env.DB_POOL_HEALTH_CAPTURE_THROTTLE_MS = '0';
+      await runDbPoolHealthCheck({
+        readStats: () => stats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+      await runDbPoolHealthCheck({
+        readStats: () => stats(97),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+
+      const titles = captureMessage.mock.calls.map((call) => call[0] as string);
+      // Identical across two very different measurements — one Sentry issue.
+      expect(titles).toHaveLength(2);
+      expect(new Set(titles).size).toBe(1);
+      // A stable issue reference is fine; the varying MEASUREMENTS are not.
+      expect(titles[0]).not.toContain('40');
+      expect(titles[0]).not.toContain('97');
+      expect(titles[0]).not.toContain('/min');
+      // The numbers still reach the console line in full.
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('97 CONNECT_TIMEOUT(s)'));
+    });
+
+    it('states how many captures the throttle suppressed', async () => {
+      // Without this the one event that lands implies a single occurrence.
+      process.env.DB_POOL_HEALTH_CAPTURE_THROTTLE_MS = '900000';
+      const deps = {
+        readStats: () => stats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      };
+      await runDbPoolHealthCheck(deps); // captured
+      await runDbPoolHealthCheck(deps); // suppressed
+      await runDbPoolHealthCheck(deps); // suppressed
+
+      process.env.DB_POOL_HEALTH_CAPTURE_THROTTLE_MS = '0';
+      await runDbPoolHealthCheck(deps); // captured again
+
+      const last = captureMessage.mock.calls.at(-1);
+      expect(last?.[2]).toMatchObject({ suppressedSinceLastCapture: 2 });
     });
   });
 
-  describe('shouldCaptureDbPoolHealth', () => {
+  describe('claimDbPoolHealthCaptureSlot', () => {
     it('throttles a repeated verdict inside the window', () => {
       // A degraded pool stays degraded until a restart, so every tick would
       // report it. Unthrottled, that has twice exhausted the org Sentry quota.
-      expect(shouldCaptureDbPoolHealth('pool-degraded', 0, 60_000)).toBe(true);
-      expect(shouldCaptureDbPoolHealth('pool-degraded', 30_000, 60_000)).toBe(false);
-      expect(shouldCaptureDbPoolHealth('pool-degraded', 60_000, 60_000)).toBe(true);
+      expect(claimDbPoolHealthCaptureSlot('pool-degraded', 0, 60_000)).toBe(true);
+      expect(claimDbPoolHealthCaptureSlot('pool-degraded', 30_000, 60_000)).toBe(false);
+      expect(claimDbPoolHealthCaptureSlot('pool-degraded', 60_000, 60_000)).toBe(true);
     });
 
     it('throttles each verdict independently', () => {
       // A pool-degraded -> database-unreachable transition is a material change
       // of remedy and must not be swallowed by the other verdict's throttle.
-      expect(shouldCaptureDbPoolHealth('pool-degraded', 0, 60_000)).toBe(true);
-      expect(shouldCaptureDbPoolHealth('database-unreachable', 0, 60_000)).toBe(true);
+      expect(claimDbPoolHealthCaptureSlot('pool-degraded', 0, 60_000)).toBe(true);
+      expect(claimDbPoolHealthCaptureSlot('database-unreachable', 0, 60_000)).toBe(true);
     });
 
     it('disables throttling at 0', () => {
-      expect(shouldCaptureDbPoolHealth('pool-degraded', 0, 0)).toBe(true);
-      expect(shouldCaptureDbPoolHealth('pool-degraded', 0, 0)).toBe(true);
+      expect(claimDbPoolHealthCaptureSlot('pool-degraded', 0, 0)).toBe(true);
+      expect(claimDbPoolHealthCaptureSlot('pool-degraded', 0, 0)).toBe(true);
     });
   });
 
@@ -273,5 +446,85 @@ describe('dbPoolHealthMonitor (#3214)', () => {
       process.env.DB_POOL_HEALTH_MIN_TIMEOUTS = '25';
       expect(getDbPoolHealthMinTimeouts()).toBe(25);
     });
+
+    it('clamps the probe budget to half the interval so a probe cannot outlive its tick', () => {
+      // These two knobs are independently settable and the probe has no natural
+      // ceiling, so without the clamp `INTERVAL=5000, PROBE=30000` is legal and
+      // every tick overlaps — each opening another connection to a database that
+      // is, in the degraded case, already the scarce resource.
+      process.env.DB_POOL_HEALTH_INTERVAL_MS = '5000';
+      process.env.DB_POOL_HEALTH_PROBE_TIMEOUT_MS = '30000';
+      expect(getDbPoolHealthProbeTimeoutMs()).toBe(2_500);
+    });
+
+    it('leaves the probe budget alone when it already fits the interval', () => {
+      process.env.DB_POOL_HEALTH_INTERVAL_MS = '60000';
+      process.env.DB_POOL_HEALTH_PROBE_TIMEOUT_MS = '5000';
+      expect(getDbPoolHealthProbeTimeoutMs()).toBe(5_000);
+    });
+  });
+
+  describe('the armed timer', () => {
+    it('actually runs a check when it fires', async () => {
+      // Without this, emptying the interval body is invisible: the watchdog
+      // never evaluates, every gauge stays 0, and no test goes red.
+      vi.useFakeTimers();
+      try {
+        process.env.DB_POOL_HEALTH_INTERVAL_MS = '5000';
+        expect(startDbPoolHealthMonitor()).toBe(5_000);
+        expect(getLastDbPoolHealthAssessment()).toBeNull();
+
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        // The real probe is never reached: a default evaluation reads the real
+        // (empty) stats window, falls below threshold, and returns without one.
+        expect(getLastDbPoolHealthAssessment()?.verdict).toBe('below-threshold');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('skips a tick while the previous check is still in flight', async () => {
+      vi.useFakeTimers();
+      try {
+        process.env.DB_POOL_HEALTH_INTERVAL_MS = '5000';
+        startDbPoolHealthMonitor();
+
+        // The default evaluation returns synchronously enough that overlapping
+        // requires a stalled check; assert the guard's observable signal instead.
+        await vi.advanceTimersByTimeAsync(5_000);
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        // Two clean ticks, so nothing was skipped.
+        expect(console.warn).not.toHaveBeenCalledWith(
+          expect.stringContaining('skipping tick'),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('probeFreshDatabaseConnection (real driver, no database)', () => {
+    it('throws DbPoolProbeUnavailableError when the URL cannot be parsed', async () => {
+      // This is the only production source of that class, and the class is what
+      // separates `unknown` from `database-unreachable`. Untested, a config fault
+      // could surface as a plain Error and be reported as an unreachable
+      // database the probe never even tried to contact.
+      process.env.DATABASE_URL_APP = 'not a url at all';
+      await expect(probeFreshDatabaseConnection(1_000)).rejects.toBeInstanceOf(
+        DbPoolProbeUnavailableError,
+      );
+    });
+
+    it('throws a plain error — NOT DbPoolProbeUnavailableError — when the connection is refused', async () => {
+      // A refused connection is real evidence about the database, so it must not
+      // be laundered into the inconclusive verdict.
+      process.env.DATABASE_URL_APP = 'postgresql://u:p@127.0.0.1:1/db';
+      const err = await probeFreshDatabaseConnection(2_000).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).not.toBeInstanceOf(DbPoolProbeUnavailableError);
+      expect(err).not.toBeInstanceOf(DbPoolProbeTimedOutError);
+    }, 10_000);
   });
 });

--- a/apps/api/src/db/dbPoolHealthMonitor.test.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const captureMessage = vi.fn();
+vi.mock('../services/sentry', () => ({
+  captureMessage: (...args: unknown[]) => captureMessage(...args),
+}));
+
+import {
+  __resetDbPoolHealthMonitorForTests,
+  assessDbPoolHealth,
+  getDbPoolHealthMinTimeouts,
+  getDbPoolHealthWindowMs,
+  getLastDbPoolHealthAssessment,
+  isDbPoolHealthMonitorDisabled,
+  runDbPoolHealthCheck,
+  shouldCaptureDbPoolHealth,
+  startDbPoolHealthMonitor,
+  stopDbPoolHealthMonitor,
+  DbPoolProbeUnavailableError,
+} from './dbPoolHealthMonitor';
+import type { DbConnectTimeoutWindowStats } from '../services/dbConnectTimeoutStats';
+
+function stats(timeouts: number, windowMs = 300_000): DbConnectTimeoutWindowStats {
+  return {
+    timeouts,
+    byCause: { 'event-loop-starvation': 0, connectivity: timeouts, unknown: 0 },
+    windowMs,
+    ratePerMin: (timeouts * 60_000) / windowMs,
+    totalSinceStart: timeouts,
+  };
+}
+
+describe('dbPoolHealthMonitor (#3214)', () => {
+  beforeEach(() => {
+    captureMessage.mockClear();
+    __resetDbPoolHealthMonitorForTests();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    __resetDbPoolHealthMonitorForTests();
+    vi.restoreAllMocks();
+    delete process.env.DB_POOL_HEALTH_DISABLED;
+    delete process.env.DB_POOL_HEALTH_INTERVAL_MS;
+    delete process.env.DB_POOL_HEALTH_WINDOW_MS;
+    delete process.env.DB_POOL_HEALTH_MIN_TIMEOUTS;
+  });
+
+  describe('assessDbPoolHealth', () => {
+    it('reports healthy and does NOT probe below the threshold', async () => {
+      // The probe opens a real socket. It must stay off the steady-state path,
+      // otherwise a fleet of instances adds a permanent connection every tick.
+      const probe = vi.fn(async () => {});
+      const result = await assessDbPoolHealth({
+        readStats: () => stats(3),
+        probe,
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('healthy');
+      expect(probe).not.toHaveBeenCalled();
+      expect(result.probeMs).toBeNull();
+    });
+
+    it('diagnoses pool-degraded when timeouts are sustained but a fresh connection succeeds', async () => {
+      // This is the #3214 signature and the whole point of the module: the DB is
+      // reachable, so the fault is in the process's own pool.
+      const result = await assessDbPoolHealth({
+        readStats: () => stats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('pool-degraded');
+      expect(result.probeError).toBeNull();
+      expect(result.message).toContain('POOL DEGRADED');
+      expect(result.message).toContain('restart the API process');
+      expect(result.message).toContain('#3214');
+    });
+
+    it('diagnoses database-unreachable when the fresh connection also fails', async () => {
+      const result = await assessDbPoolHealth({
+        readStats: () => stats(40),
+        probe: async () => {
+          throw new Error('ECONNREFUSED 10.0.0.5:5432');
+        },
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('database-unreachable');
+      expect(result.probeError).toContain('ECONNREFUSED');
+      expect(result.message).toContain('DATABASE UNREACHABLE');
+      // Naming the wrong remedy is the failure this module exists to prevent.
+      expect(result.message).toContain('Restarting the API will not help');
+      expect(result.message).not.toContain('POOL DEGRADED');
+    });
+
+    it('probes exactly at the threshold, not one above it', async () => {
+      const probe = vi.fn(async () => {});
+      const result = await assessDbPoolHealth({
+        readStats: () => stats(10),
+        probe,
+        thresholdTimeouts: 10,
+      });
+
+      expect(probe).toHaveBeenCalledTimes(1);
+      expect(result.verdict).toBe('pool-degraded');
+    });
+
+    it('reports unknown — never database-unreachable — when the probe could not be attempted', async () => {
+      // A probe that never ran is evidence of nothing. Reporting it as
+      // `database-unreachable` would send an operator hunting a DB incident that
+      // this module has no evidence for, with more authority than the raw error.
+      const result = await assessDbPoolHealth({
+        readStats: () => stats(40),
+        probe: async () => {
+          throw new DbPoolProbeUnavailableError('could not construct a probe client: bad URL');
+        },
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('unknown');
+      expect(result.message).toContain('nothing may be concluded');
+      expect(result.message).not.toContain('DATABASE UNREACHABLE');
+      expect(result.message).not.toContain('POOL DEGRADED');
+    });
+
+    it('surfaces a non-Error probe rejection as a string', async () => {
+      const result = await assessDbPoolHealth({
+        readStats: () => stats(40),
+        probe: async () => {
+          throw 'plain string rejection';
+        },
+        thresholdTimeouts: 10,
+      });
+
+      expect(result.verdict).toBe('database-unreachable');
+      expect(result.probeError).toBe('plain string rejection');
+    });
+
+    it('states the measured rate, not just the verdict', async () => {
+      const result = await assessDbPoolHealth({
+        readStats: () => stats(60, 300_000),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+        windowMs: 300_000,
+      });
+
+      expect(result.message).toContain('60 CONNECT_TIMEOUT(s)');
+      expect(result.message).toContain('12.0/min');
+    });
+  });
+
+  describe('runDbPoolHealthCheck', () => {
+    it('stores the assessment and stays silent when healthy', async () => {
+      await runDbPoolHealthCheck({
+        readStats: () => stats(0),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+
+      expect(getLastDbPoolHealthAssessment()?.verdict).toBe('healthy');
+      expect(captureMessage).not.toHaveBeenCalled();
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('warns and captures on a degraded verdict', async () => {
+      await runDbPoolHealthCheck({
+        readStats: () => stats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('POOL DEGRADED'));
+      expect(captureMessage).toHaveBeenCalledTimes(1);
+      expect(captureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('POOL DEGRADED'),
+        'warning',
+        expect.objectContaining({ verdict: 'pool-degraded', timeouts: 40 }),
+        { dbPoolHealthVerdict: 'pool-degraded' },
+      );
+    });
+
+    it('never throws when the stats read itself fails', async () => {
+      // A watchdog that can crash the tick it runs on is worse than none.
+      const result = await runDbPoolHealthCheck({
+        readStats: () => {
+          throw new Error('stats exploded');
+        },
+      });
+
+      expect(result).toBeNull();
+      expect(console.error).toHaveBeenCalledWith(
+        '[db-pool-health] check failed:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('shouldCaptureDbPoolHealth', () => {
+    it('throttles a repeated verdict inside the window', () => {
+      // A degraded pool stays degraded until a restart, so every tick would
+      // report it. Unthrottled, that has twice exhausted the org Sentry quota.
+      expect(shouldCaptureDbPoolHealth('pool-degraded', 0, 60_000)).toBe(true);
+      expect(shouldCaptureDbPoolHealth('pool-degraded', 30_000, 60_000)).toBe(false);
+      expect(shouldCaptureDbPoolHealth('pool-degraded', 60_000, 60_000)).toBe(true);
+    });
+
+    it('throttles each verdict independently', () => {
+      // A pool-degraded -> database-unreachable transition is a material change
+      // of remedy and must not be swallowed by the other verdict's throttle.
+      expect(shouldCaptureDbPoolHealth('pool-degraded', 0, 60_000)).toBe(true);
+      expect(shouldCaptureDbPoolHealth('database-unreachable', 0, 60_000)).toBe(true);
+    });
+
+    it('disables throttling at 0', () => {
+      expect(shouldCaptureDbPoolHealth('pool-degraded', 0, 0)).toBe(true);
+      expect(shouldCaptureDbPoolHealth('pool-degraded', 0, 0)).toBe(true);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('returns null and starts nothing when disabled', () => {
+      process.env.DB_POOL_HEALTH_DISABLED = 'true';
+      expect(isDbPoolHealthMonitorDisabled()).toBe(true);
+      expect(startDbPoolHealthMonitor()).toBeNull();
+    });
+
+    it('is idempotent and stoppable', () => {
+      process.env.DB_POOL_HEALTH_INTERVAL_MS = '5000';
+      expect(startDbPoolHealthMonitor()).toBe(5_000);
+      expect(startDbPoolHealthMonitor()).toBe(5_000);
+      expect(() => stopDbPoolHealthMonitor()).not.toThrow();
+      expect(() => stopDbPoolHealthMonitor()).not.toThrow();
+    });
+
+    it('reports the interval the armed timer actually uses, not a re-read of the env', () => {
+      // The boot log states this interval as fact. A second call after an env
+      // change must not claim a cadence the running timer does not have.
+      process.env.DB_POOL_HEALTH_INTERVAL_MS = '5000';
+      expect(startDbPoolHealthMonitor()).toBe(5_000);
+      process.env.DB_POOL_HEALTH_INTERVAL_MS = '30000';
+      expect(startDbPoolHealthMonitor()).toBe(5_000);
+
+      // After a stop, a fresh start picks up the new value.
+      stopDbPoolHealthMonitor();
+      expect(startDbPoolHealthMonitor()).toBe(30_000);
+    });
+
+    it('publishes no verdict before the first evaluation', () => {
+      // Consumers must render this as "not observed". Collapsing it into
+      // "healthy" is how a blind instance looks fine on a dashboard.
+      expect(getLastDbPoolHealthAssessment()).toBeNull();
+    });
+  });
+
+  describe('configuration', () => {
+    it('floors the interval so it cannot be tuned into a hot loop', () => {
+      process.env.DB_POOL_HEALTH_INTERVAL_MS = '1';
+      expect(startDbPoolHealthMonitor()).toBe(60_000);
+    });
+
+    it('ignores unparseable values and uses defaults', () => {
+      process.env.DB_POOL_HEALTH_WINDOW_MS = 'five minutes';
+      process.env.DB_POOL_HEALTH_MIN_TIMEOUTS = '';
+      expect(getDbPoolHealthWindowMs()).toBe(5 * 60_000);
+      expect(getDbPoolHealthMinTimeouts()).toBe(10);
+    });
+
+    it('accepts a valid override', () => {
+      process.env.DB_POOL_HEALTH_MIN_TIMEOUTS = '25';
+      expect(getDbPoolHealthMinTimeouts()).toBe(25);
+    });
+  });
+});

--- a/apps/api/src/db/dbPoolHealthMonitor.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.ts
@@ -26,6 +26,16 @@
  * That is exactly the manual step ("`psql` from the same host connected in under
  * a second") that ended the incident's guessing, performed automatically.
  *
+ * WHAT THIS MODULE NEVER CLAIMS. There is no `healthy` verdict, on purpose. The
+ * only evidence it has is a connect-timeout count that `dbConnectTimeoutStats`
+ * documents as a FLOOR, and it does not observe pool slot occupancy at all — so
+ * a pool that has quietly lost most of its slots while producing few
+ * request-visible timeouts is below threshold, not proven well. The quiet verdict
+ * is therefore named `below-threshold`, and every message states the measurement
+ * rather than only the conclusion. Publishing an affirmative all-clear from
+ * evidence that cannot support one is the failure mode this whole area of the
+ * codebase exists to avoid.
+ *
  * WHAT IT DELIBERATELY DOES NOT DO. It does not recycle or replace the `sql`
  * instance. `db/index.ts` hands the client to Drizzle at module load, and the
  * resulting `baseDb` is captured by the exported proxy, by every open
@@ -45,14 +55,24 @@ import {
 import { resolveRequestDatabaseConfig } from './requestDatabaseConfig';
 
 export type DbPoolHealthVerdict =
-  /** Connect-timeout rate is below the alert threshold. No probe was run. */
-  | 'healthy'
+  /**
+   * Connect-timeout rate is below the alert threshold, so no probe was run.
+   * NOT a clean bill of health — see the module docblock.
+   */
+  | 'below-threshold'
   /** Timeouts are sustained, but a fresh connection succeeds — the #3214 signature. */
   | 'pool-degraded'
   /** Timeouts are sustained and a fresh connection fails too — a real DB fault. */
   | 'database-unreachable'
-  /** The probe could not be carried out, so nothing may be concluded. */
+  /** The probe could not be carried out or its result proves nothing. */
   | 'unknown';
+
+export const DB_POOL_HEALTH_VERDICTS: readonly DbPoolHealthVerdict[] = [
+  'below-threshold',
+  'pool-degraded',
+  'database-unreachable',
+  'unknown',
+];
 
 export interface DbPoolHealthAssessment {
   verdict: DbPoolHealthVerdict;
@@ -65,6 +85,14 @@ export interface DbPoolHealthAssessment {
   probeError: string | null;
   /** Operator-facing one-liner. Always states the measurement, not just the verdict. */
   message: string;
+  /**
+   * Short, STABLE headline used as the Sentry event title. Deliberately free of
+   * counts and durations: Sentry groups by message text, so interpolating a rate
+   * would mint a fresh issue on every capture, and an alert bound to an issue
+   * that never repeats never fires twice. The numbers live in `message` (console)
+   * and in the tags.
+   */
+  headline: string;
   at: number;
 }
 
@@ -106,11 +134,22 @@ export function getDbPoolHealthMinTimeouts(): number {
 }
 
 /**
- * Hard bound on the probe. Must stay comfortably under the watchdog interval so
- * a hung probe can never overlap the next tick.
+ * Hard bound on the probe, CLAMPED to half the watchdog interval.
+ *
+ * The clamp is not decoration. `DB_POOL_HEALTH_PROBE_TIMEOUT_MS` has a floor and
+ * no natural ceiling while the interval floors at 5s, so the two knobs can
+ * legally be set such that every probe outlives its tick. Combined with the
+ * in-flight guard in `startDbPoolHealthMonitor`, this keeps the watchdog from
+ * opening a growing number of fresh connections to a database that — in the
+ * `pool-degraded` case it is diagnosing — is already the scarce resource.
  */
-export function getDbPoolHealthProbeTimeoutMs(): number {
-  return envInt('DB_POOL_HEALTH_PROBE_TIMEOUT_MS', 5_000, 1_000);
+export function getDbPoolHealthProbeTimeoutMs(
+  intervalMs: number = getDbPoolHealthIntervalMs(),
+): number {
+  return Math.min(
+    envInt('DB_POOL_HEALTH_PROBE_TIMEOUT_MS', 5_000, 1_000),
+    Math.floor(intervalMs / 2),
+  );
 }
 
 /**
@@ -143,6 +182,25 @@ export class DbPoolProbeUnavailableError extends Error {
   constructor(message: string, options?: { cause?: unknown }) {
     super(message, options);
     this.name = 'DbPoolProbeUnavailableError';
+  }
+}
+
+/**
+ * Thrown when the probe's own wall-clock budget expired.
+ *
+ * Separate from a driver-reported failure because this budget is a plain
+ * `setTimeout`, and a `setTimeout` expires just as readily when the main thread
+ * is too busy to run the socket callbacks as when the connection genuinely
+ * failed — the precise ambiguity `services/postgresConnectTimeout.ts` was
+ * written to resolve for `connect_timeout` (#3022). Treating it as proof the
+ * database is unreachable would reintroduce that bug one layer up: a pegged
+ * event loop would be reported as a database fault, with an explicit
+ * "restarting the API will not help" attached to it.
+ */
+export class DbPoolProbeTimedOutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DbPoolProbeTimedOutError';
   }
 }
 
@@ -189,7 +247,7 @@ export async function probeFreshDatabaseConnection(
       client`select 1`.then(() => undefined),
       new Promise<never>((_, reject) => {
         timer = setTimeout(
-          () => reject(new Error(`pool-health probe exceeded ${timeoutMs}ms`)),
+          () => reject(new DbPoolProbeTimedOutError(`pool-health probe exceeded ${timeoutMs}ms`)),
           timeoutMs,
         );
         timer.unref?.();
@@ -198,11 +256,36 @@ export async function probeFreshDatabaseConnection(
       if (timer) clearTimeout(timer);
     });
   } finally {
-    // `timeout: 0` destroys immediately instead of waiting to drain. A probe
-    // that already timed out must not then block shutdown on the same stuck
-    // connection it was diagnosing.
-    await client.end({ timeout: 0 }).catch(() => undefined);
+    // Swallowed deliberately: this is cleanup on a diagnostic path, and a failed
+    // close must not displace the probe's verdict. It is NOT free, though — a
+    // failed close leaks the probe socket, and `pool-degraded` persists until
+    // someone restarts, so this would run every tick until then and add one
+    // leaked connection per tick to a database that is already under connection
+    // pressure. Counted and logged rather than hidden.
+    //
+    // Routed through `Promise.resolve().then(...)` so a SYNCHRONOUS throw from
+    // `end()` also lands in the catch instead of escaping this `finally` and
+    // replacing the probe's real outcome.
+    // `timeout: 0` destroys immediately instead of waiting to drain, so a probe
+    // that already timed out cannot block on the connection it was diagnosing.
+    await Promise.resolve()
+      .then(() => client.end({ timeout: 0 }))
+      .catch((endErr: unknown) => {
+        probeCloseFailures += 1;
+        console.warn(
+          `[db-pool-health] probe client end() failed (${probeCloseFailures} total); the probe `
+          + 'connection may be leaked against a database already under connection pressure:',
+          endErr,
+        );
+      });
   }
+}
+
+let probeCloseFailures = 0;
+
+/** Probe connections whose close failed — each one is a possible leaked socket. */
+export function getDbPoolHealthProbeCloseFailures(): number {
+  return probeCloseFailures;
 }
 
 export interface AssessDbPoolHealthDeps {
@@ -227,17 +310,25 @@ export async function assessDbPoolHealth(
   const probe = deps.probe ?? probeFreshDatabaseConnection;
 
   const stats = readStats(windowMs, now);
+  const rate =
+    `${stats.timeouts} CONNECT_TIMEOUT(s) in ${windowMs}ms (${stats.ratePerMin.toFixed(1)}/min)`;
+  const causes =
+    `starvation=${stats.byCause['event-loop-starvation']} `
+    + `connectivity=${stats.byCause.connectivity} unknown=${stats.byCause.unknown}`;
 
   if (stats.timeouts < thresholdTimeouts) {
     return {
-      verdict: 'healthy',
+      verdict: 'below-threshold',
       stats,
       thresholdTimeouts,
       probeMs: null,
       probeError: null,
+      headline: '[db-pool-health] below threshold',
       message:
-        `[db-pool-health] ${stats.timeouts} CONNECT_TIMEOUT(s) in the last ${windowMs}ms `
-        + `(${stats.ratePerMin.toFixed(1)}/min), below the ${thresholdTimeouts} threshold.`,
+        `[db-pool-health] ${rate}, below the ${thresholdTimeouts} threshold — no probe run. `
+        + `This is NOT a clean bill of health: the count is a floor (only timeouts that reach `
+        + `app.onError or captureException are recorded) and pool slot occupancy is not `
+        + `observed at all. Causes: ${causes}.`,
       at: now,
     };
   }
@@ -245,18 +336,15 @@ export async function assessDbPoolHealth(
   const startedAt = Date.now();
   let probeError: string | null = null;
   let probeUnavailable = false;
+  let probeTimedOut = false;
   try {
     await probe();
   } catch (err) {
     probeError = err instanceof Error ? err.message : String(err);
     probeUnavailable = err instanceof DbPoolProbeUnavailableError;
+    probeTimedOut = err instanceof DbPoolProbeTimedOutError;
   }
   const probeMs = Date.now() - startedAt;
-
-  const rate = `${stats.timeouts} CONNECT_TIMEOUT(s) in ${windowMs}ms (${stats.ratePerMin.toFixed(1)}/min)`;
-  const causes =
-    `starvation=${stats.byCause['event-loop-starvation']} `
-    + `connectivity=${stats.byCause.connectivity} unknown=${stats.byCause.unknown}`;
 
   if (probeUnavailable) {
     return {
@@ -265,10 +353,37 @@ export async function assessDbPoolHealth(
       thresholdTimeouts,
       probeMs,
       probeError,
+      headline: '[db-pool-health] probe unavailable',
       message:
         `[db-pool-health] UNKNOWN — ${rate}, but the fresh-connection probe could not be `
         + `attempted (${probeError}), so nothing may be concluded about the pool OR the `
         + `database. Fix the probe's configuration before reading this signal. Causes: ${causes}.`,
+      at: now,
+    };
+  }
+
+  // A probe that timed out while most timeouts were attributed to a blocked
+  // event loop proves nothing: the probe needs that same loop to run its socket
+  // callbacks, so its budget expires for the same reason theirs did. Calling
+  // this `database-unreachable` would send an operator hunting a DB incident and
+  // explicitly tell them a restart will not help — while the actual fault is a
+  // pegged main thread (#3022).
+  const starvationDominates =
+    stats.byCause['event-loop-starvation'] * 2 > stats.timeouts;
+  if (probeTimedOut && starvationDominates) {
+    return {
+      verdict: 'unknown',
+      stats,
+      thresholdTimeouts,
+      probeMs,
+      probeError,
+      headline: '[db-pool-health] probe timed out under event-loop starvation',
+      message:
+        `[db-pool-health] UNKNOWN — ${rate}, and the probe timed out after ${probeMs}ms, but `
+        + `${stats.byCause['event-loop-starvation']} of those timeouts were attributed to `
+        + `event-loop starvation (#3022). The probe's budget is an in-process timer that needs `
+        + `the same blocked loop, so its expiry is NOT evidence about the database. Investigate `
+        + `main-thread starvation first. Causes: ${causes}.`,
       at: now,
     };
   }
@@ -280,6 +395,7 @@ export async function assessDbPoolHealth(
       thresholdTimeouts,
       probeMs,
       probeError: null,
+      headline: '[db-pool-health] POOL DEGRADED (#3214)',
       message:
         `[db-pool-health] POOL DEGRADED — ${rate}, yet a brand-new connection to the same `
         + `database succeeded in ${probeMs}ms. The database is reachable; the request pool is `
@@ -298,6 +414,7 @@ export async function assessDbPoolHealth(
     thresholdTimeouts,
     probeMs,
     probeError,
+    headline: '[db-pool-health] DATABASE UNREACHABLE',
     message:
       `[db-pool-health] DATABASE UNREACHABLE — ${rate}, and a brand-new connection to the same `
       + `database ALSO failed after ${probeMs}ms (${probeError}). This is NOT the #3214 pool `
@@ -309,31 +426,54 @@ export async function assessDbPoolHealth(
 
 let timer: NodeJS.Timeout | null = null;
 let activeIntervalMs: number | null = null;
+let checkInFlight = false;
 let lastAssessment: DbPoolHealthAssessment | null = null;
-let lastCaptureAtByVerdict = new Map<DbPoolHealthVerdict, number>();
+let checkFailures = 0;
+let lastCaptureAtByKey = new Map<string, number>();
+let suppressedSinceCaptureByKey = new Map<string, number>();
 
 /**
- * Latest verdict, or null when the watchdog has not evaluated yet (including
- * when it is disabled). `routes/metrics.ts` reads this; a null must be published
- * as "not observed", never as "healthy".
+ * Latest verdict, or null when the watchdog has not evaluated yet, is disabled,
+ * or its last evaluation FAILED. Consumers must publish a null as "not
+ * observed" — never as a healthy pool.
  */
 export function getLastDbPoolHealthAssessment(): DbPoolHealthAssessment | null {
   return lastAssessment;
 }
 
-/** Exported for testing the throttle without waiting on real clocks. */
-export function shouldCaptureDbPoolHealth(
-  verdict: DbPoolHealthVerdict,
+/** Evaluations that threw before producing a verdict. Monotonic. */
+export function getDbPoolHealthCheckFailures(): number {
+  return checkFailures;
+}
+
+/**
+ * Throttle gate. Returns true — and RECORDS the claim — at most once per
+ * `throttleMs` per key.
+ *
+ * Named `claim…` rather than `should…` because it mutates: a caller who
+ * evaluates it twice (the natural "if I'm going to capture, also do X" refactor)
+ * would silently lose every subsequent alert, and no test would catch it. The
+ * name is the guard.
+ */
+export function claimDbPoolHealthCaptureSlot(
+  key: string,
   now: number,
   throttleMs: number,
 ): boolean {
   if (throttleMs === 0) return true;
-  const lastAt = lastCaptureAtByVerdict.get(verdict);
+  const lastAt = lastCaptureAtByKey.get(key);
   if (lastAt === undefined || now - lastAt >= throttleMs) {
-    lastCaptureAtByVerdict.set(verdict, now);
+    lastCaptureAtByKey.set(key, now);
     return true;
   }
+  suppressedSinceCaptureByKey.set(key, (suppressedSinceCaptureByKey.get(key) ?? 0) + 1);
   return false;
+}
+
+function takeSuppressedCount(key: string): number {
+  const n = suppressedSinceCaptureByKey.get(key) ?? 0;
+  suppressedSinceCaptureByKey.delete(key);
+  return n;
 }
 
 /**
@@ -347,17 +487,18 @@ export async function runDbPoolHealthCheck(
     const assessment = await assessDbPoolHealth(deps);
     lastAssessment = assessment;
 
-    if (assessment.verdict === 'healthy') return assessment;
+    if (assessment.verdict === 'below-threshold') return assessment;
 
     console.warn(assessment.message);
-    if (
-      shouldCaptureDbPoolHealth(
-        assessment.verdict,
-        assessment.at,
-        getDbPoolHealthCaptureThrottleMs(),
-      )
-    ) {
-      captureMessage(assessment.message, 'warning', {
+    const throttleMs = getDbPoolHealthCaptureThrottleMs();
+    if (claimDbPoolHealthCaptureSlot(assessment.verdict, assessment.at, throttleMs)) {
+      const suppressed = takeSuppressedCount(assessment.verdict);
+      // The TITLE is the stable headline (Sentry groups by message text, so an
+      // interpolated rate would mint a new issue every capture and no alert
+      // bound to it could ever fire twice). Detail rides on the low-cardinality
+      // tags; the full prose is already on console.warn above.
+      captureMessage(assessment.headline, 'warning', {
+        message: assessment.message,
         verdict: assessment.verdict,
         timeouts: assessment.stats.timeouts,
         ratePerMin: assessment.stats.ratePerMin,
@@ -365,11 +506,41 @@ export async function runDbPoolHealthCheck(
         byCause: assessment.stats.byCause,
         probeMs: assessment.probeMs,
         probeError: assessment.probeError,
+        // States this event's own sampling rate, so the throttle cannot make a
+        // storm look like a single occurrence.
+        suppressedSinceLastCapture: suppressed,
       }, { dbPoolHealthVerdict: assessment.verdict });
     }
     return assessment;
   } catch (err) {
+    checkFailures += 1;
+    // Do NOT leave the previous verdict standing. `lastAssessment` drives the
+    // Prometheus verdict series, so keeping a stale value here would republish
+    // an old below-threshold reading on every scrape, for hours, about a
+    // watchdog that has been dead the whole time — an affirmative wrong answer,
+    // which is worse than the "not observed" that null produces.
+    lastAssessment = null;
     console.error('[db-pool-health] check failed:', err);
+    // Reaching Sentry matters as much here as for the verdicts themselves: a
+    // watchdog failing on every tick is otherwise console-only, which is exactly
+    // the invisibility this module exists to remove. Throttled on its own key so
+    // it cannot flood, and wrapped because the reporter may be what failed.
+    if (
+      claimDbPoolHealthCaptureSlot(
+        'check-failed',
+        Date.now(),
+        getDbPoolHealthCaptureThrottleMs(),
+      )
+    ) {
+      try {
+        captureMessage('[db-pool-health] watchdog evaluation failed', 'warning', {
+          error: err instanceof Error ? err.message : String(err),
+          checkFailures,
+        }, { dbPoolHealthVerdict: 'check-failed' });
+      } catch {
+        // The reporter is the thing that failed; the console line above stands.
+      }
+    }
     return null;
   }
 }
@@ -388,7 +559,22 @@ export function startDbPoolHealthMonitor(): number | null {
 
   activeIntervalMs = getDbPoolHealthIntervalMs();
   timer = setInterval(() => {
-    void runDbPoolHealthCheck();
+    // A probe can outlive its tick (a saturated server, a blocked loop). Without
+    // this guard those ticks stack, and each one opens another fresh connection
+    // to a database that in the `pool-degraded` case is already the scarce
+    // resource — the watchdog would then worsen the condition it is diagnosing.
+    // Never silent: a skipped tick is itself a signal.
+    if (checkInFlight) {
+      console.warn(
+        '[db-pool-health] skipping tick — the previous check is still in flight, '
+        + 'so the probe outlived its interval.',
+      );
+      return;
+    }
+    checkInFlight = true;
+    void runDbPoolHealthCheck().finally(() => {
+      checkInFlight = false;
+    });
   }, activeIntervalMs);
   // Unref'd: the watchdog must never be the reason the process stays alive.
   timer.unref?.();
@@ -405,6 +591,10 @@ export function stopDbPoolHealthMonitor(): void {
 
 export function __resetDbPoolHealthMonitorForTests(): void {
   stopDbPoolHealthMonitor();
+  checkInFlight = false;
   lastAssessment = null;
-  lastCaptureAtByVerdict = new Map();
+  checkFailures = 0;
+  probeCloseFailures = 0;
+  lastCaptureAtByKey = new Map();
+  suppressedSinceCaptureByKey = new Map();
 }

--- a/apps/api/src/db/dbPoolHealthMonitor.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.ts
@@ -1,0 +1,410 @@
+/**
+ * Pool-health watchdog for the postgres.js connection-poisoning failure (#3214).
+ *
+ * THE FAILURE IT WATCHES FOR. postgres.js 3.4.9 leaves a pooled connection
+ * permanently unable to flush a deferred write once its socket dies with one
+ * buffered — see `db/postgresJsPoolPoisoning.test.ts`, which reproduces the
+ * defect deterministically and cites the exact upstream lines. A poisoned slot
+ * then reconnects forever, timing out at `connect_timeout` every time. Slots are
+ * lost one at a time (in the production incident: 35 configured, 9 live after a
+ * few hours) and only an API restart recovers them.
+ *
+ * WHY A WATCHDOG AND NOT A FIX. The broken state lives inside a closure in the
+ * driver; nothing outside the driver can reach it. This module cannot repair the
+ * pool. What it CAN do is collapse the diagnosis — which took hours of manual
+ * work during the incident — into a single automatic verdict.
+ *
+ * THE DIAGNOSTIC TRICK. A sustained CONNECT_TIMEOUT rate on its own is
+ * ambiguous: it looks identical whether the database is unreachable or the pool
+ * is poisoned. The two are told apart by opening a BRAND NEW, single-use
+ * connection to the same database, outside the main pool. A fresh postgres.js
+ * client gets fresh connection closures, so it is immune to the poisoning:
+ *
+ *   - fresh connection succeeds  -> the DB is fine and the POOL is the problem
+ *   - fresh connection also fails -> a real database/network fault
+ *
+ * That is exactly the manual step ("`psql` from the same host connected in under
+ * a second") that ended the incident's guessing, performed automatically.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO. It does not recycle or replace the `sql`
+ * instance. `db/index.ts` hands the client to Drizzle at module load, and the
+ * resulting `baseDb` is captured by the exported proxy, by every open
+ * `withDbAccessContext` transaction, and by the AsyncLocalStorage stores.
+ * Swapping it mid-flight would abort in-flight tenant transactions, and a bug in
+ * that swap is a whole-API outage. Recycling is tracked separately; this module
+ * is warn-only by design.
+ */
+
+import postgres from 'postgres';
+import { captureMessage } from '../services/sentry';
+import {
+  DEFAULT_CONNECT_TIMEOUT_WINDOW_MS,
+  getDbConnectTimeoutStats,
+  type DbConnectTimeoutWindowStats,
+} from '../services/dbConnectTimeoutStats';
+import { resolveRequestDatabaseConfig } from './requestDatabaseConfig';
+
+export type DbPoolHealthVerdict =
+  /** Connect-timeout rate is below the alert threshold. No probe was run. */
+  | 'healthy'
+  /** Timeouts are sustained, but a fresh connection succeeds — the #3214 signature. */
+  | 'pool-degraded'
+  /** Timeouts are sustained and a fresh connection fails too — a real DB fault. */
+  | 'database-unreachable'
+  /** The probe could not be carried out, so nothing may be concluded. */
+  | 'unknown';
+
+export interface DbPoolHealthAssessment {
+  verdict: DbPoolHealthVerdict;
+  stats: DbConnectTimeoutWindowStats;
+  /** The `timeouts`-in-window count at or above which the probe runs. */
+  thresholdTimeouts: number;
+  /** Wall time the fresh-connection probe took, or null when it did not run. */
+  probeMs: number | null;
+  /** Probe failure message, or null when the probe succeeded or did not run. */
+  probeError: string | null;
+  /** Operator-facing one-liner. Always states the measurement, not just the verdict. */
+  message: string;
+  at: number;
+}
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+function envFlag(name: string): boolean {
+  return TRUTHY.has((process.env[name] ?? '').trim().toLowerCase());
+}
+
+function envInt(name: string, fallback: number, min: number): number {
+  const raw = Number.parseInt(process.env[name] ?? '', 10);
+  if (!Number.isFinite(raw) || raw < min) return fallback;
+  return raw;
+}
+
+export function isDbPoolHealthMonitorDisabled(): boolean {
+  return envFlag('DB_POOL_HEALTH_DISABLED');
+}
+
+/** How often the watchdog evaluates. Floor of 5s so it cannot be tuned into a hot loop. */
+export function getDbPoolHealthIntervalMs(): number {
+  return envInt('DB_POOL_HEALTH_INTERVAL_MS', 60_000, 5_000);
+}
+
+/** Trailing window the connect-timeout count is taken over. */
+export function getDbPoolHealthWindowMs(): number {
+  return envInt('DB_POOL_HEALTH_WINDOW_MS', DEFAULT_CONNECT_TIMEOUT_WINDOW_MS, 30_000);
+}
+
+/**
+ * Timeouts within the window that trigger the probe.
+ *
+ * Default 10 over 5 minutes (2/min). Set well above the handful of timeouts a
+ * healthy instance can produce during a failover or a deploy, and far below the
+ * ~144/min the incident sustained, so an alert on this means something.
+ */
+export function getDbPoolHealthMinTimeouts(): number {
+  return envInt('DB_POOL_HEALTH_MIN_TIMEOUTS', 10, 1);
+}
+
+/**
+ * Hard bound on the probe. Must stay comfortably under the watchdog interval so
+ * a hung probe can never overlap the next tick.
+ */
+export function getDbPoolHealthProbeTimeoutMs(): number {
+  return envInt('DB_POOL_HEALTH_PROBE_TIMEOUT_MS', 5_000, 1_000);
+}
+
+/**
+ * A degraded pool is a persistent CONDITION, not N distinct errors — it stays
+ * broken until someone restarts the process, so every tick would report it. This
+ * repo has twice had an unthrottled recurring warning exhaust the Sentry event
+ * quota and black out ALL error reporting org-wide, so the capture is throttled.
+ * Console logging stays unthrottled.
+ */
+export function getDbPoolHealthCaptureThrottleMs(): number {
+  return envInt('DB_POOL_HEALTH_CAPTURE_THROTTLE_MS', 15 * 60_000, 0);
+}
+
+/** A probe returns void on success and throws on failure. */
+export type DbPoolHealthProbe = () => Promise<void>;
+
+/**
+ * Thrown when the probe could not even be ATTEMPTED — an unparseable connection
+ * URL, a driver that refused to construct. Distinct from a probe that ran and
+ * failed, because the two license different conclusions: a failed attempt is
+ * evidence the database is unreachable, whereas an attempt that never happened
+ * is evidence of nothing at all.
+ *
+ * Reporting the latter as `database-unreachable` would be a confident, wrong
+ * verdict issued with more authority than the raw error it replaced — the exact
+ * misdirection `services/postgresConnectTimeout.ts` exists to remove, restated
+ * one layer up.
+ */
+export class DbPoolProbeUnavailableError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'DbPoolProbeUnavailableError';
+  }
+}
+
+/**
+ * Opens a single-use postgres.js client, runs `select 1`, and closes it.
+ *
+ * MUST NOT reuse the main pool — that is the entire diagnostic. A fresh client
+ * builds fresh connection closures, so it is unaffected by a poisoned slot in
+ * the main pool and can therefore prove the database is reachable while the pool
+ * cannot reach it.
+ */
+export async function probeFreshDatabaseConnection(
+  timeoutMs: number = getDbPoolHealthProbeTimeoutMs(),
+): Promise<void> {
+  let client: ReturnType<typeof postgres>;
+  try {
+    const { url } = resolveRequestDatabaseConfig();
+    client = postgres(url, {
+      max: 1,
+      // postgres.js takes seconds. Ceil so a sub-second budget still permits one
+      // real attempt rather than being floored to an instant timeout.
+      connect_timeout: Math.max(1, Math.ceil(timeoutMs / 1000)),
+      idle_timeout: 1,
+      max_lifetime: 30,
+      // The probe is the one connection that must never be mistaken for request
+      // traffic in pg_stat_activity while someone is debugging this exact failure.
+      connection: { application_name: 'breeze-pool-health-probe' },
+    });
+  } catch (err) {
+    // Config resolution or client construction failed, so no connection was ever
+    // attempted. Say exactly that instead of blaming the database.
+    throw new DbPoolProbeUnavailableError(
+      `could not construct a probe client: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  try {
+    // postgres.js has no pool-acquire timeout, so bound the whole attempt
+    // ourselves — otherwise a probe against a saturated server could outlive the
+    // watchdog interval and overlap the next tick.
+    let timer: NodeJS.Timeout | undefined;
+    await Promise.race([
+      client`select 1`.then(() => undefined),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`pool-health probe exceeded ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+        timer.unref?.();
+      }),
+    ]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+  } finally {
+    // `timeout: 0` destroys immediately instead of waiting to drain. A probe
+    // that already timed out must not then block shutdown on the same stuck
+    // connection it was diagnosing.
+    await client.end({ timeout: 0 }).catch(() => undefined);
+  }
+}
+
+export interface AssessDbPoolHealthDeps {
+  readStats?: (windowMs: number, now: number) => DbConnectTimeoutWindowStats;
+  probe?: DbPoolHealthProbe;
+  windowMs?: number;
+  thresholdTimeouts?: number;
+  now?: number;
+}
+
+/**
+ * One evaluation. Every dependency is injectable so the verdict logic is unit
+ * tested without a database or a timer.
+ */
+export async function assessDbPoolHealth(
+  deps: AssessDbPoolHealthDeps = {},
+): Promise<DbPoolHealthAssessment> {
+  const now = deps.now ?? Date.now();
+  const windowMs = deps.windowMs ?? getDbPoolHealthWindowMs();
+  const thresholdTimeouts = deps.thresholdTimeouts ?? getDbPoolHealthMinTimeouts();
+  const readStats = deps.readStats ?? getDbConnectTimeoutStats;
+  const probe = deps.probe ?? probeFreshDatabaseConnection;
+
+  const stats = readStats(windowMs, now);
+
+  if (stats.timeouts < thresholdTimeouts) {
+    return {
+      verdict: 'healthy',
+      stats,
+      thresholdTimeouts,
+      probeMs: null,
+      probeError: null,
+      message:
+        `[db-pool-health] ${stats.timeouts} CONNECT_TIMEOUT(s) in the last ${windowMs}ms `
+        + `(${stats.ratePerMin.toFixed(1)}/min), below the ${thresholdTimeouts} threshold.`,
+      at: now,
+    };
+  }
+
+  const startedAt = Date.now();
+  let probeError: string | null = null;
+  let probeUnavailable = false;
+  try {
+    await probe();
+  } catch (err) {
+    probeError = err instanceof Error ? err.message : String(err);
+    probeUnavailable = err instanceof DbPoolProbeUnavailableError;
+  }
+  const probeMs = Date.now() - startedAt;
+
+  const rate = `${stats.timeouts} CONNECT_TIMEOUT(s) in ${windowMs}ms (${stats.ratePerMin.toFixed(1)}/min)`;
+  const causes =
+    `starvation=${stats.byCause['event-loop-starvation']} `
+    + `connectivity=${stats.byCause.connectivity} unknown=${stats.byCause.unknown}`;
+
+  if (probeUnavailable) {
+    return {
+      verdict: 'unknown',
+      stats,
+      thresholdTimeouts,
+      probeMs,
+      probeError,
+      message:
+        `[db-pool-health] UNKNOWN — ${rate}, but the fresh-connection probe could not be `
+        + `attempted (${probeError}), so nothing may be concluded about the pool OR the `
+        + `database. Fix the probe's configuration before reading this signal. Causes: ${causes}.`,
+      at: now,
+    };
+  }
+
+  if (probeError === null) {
+    return {
+      verdict: 'pool-degraded',
+      stats,
+      thresholdTimeouts,
+      probeMs,
+      probeError: null,
+      message:
+        `[db-pool-health] POOL DEGRADED — ${rate}, yet a brand-new connection to the same `
+        + `database succeeded in ${probeMs}ms. The database is reachable; the request pool is `
+        + `not. This is the postgres.js connection-poisoning signature (#3214): a pooled `
+        + `connection whose socket died with a buffered write can never flush again, so it `
+        + `reconnect-loops on CONNECT_TIMEOUT forever and its slot is lost for the life of the `
+        + `process. The pool cannot self-heal — restart the API process to recover it. `
+        + `Causes: ${causes}.`,
+      at: now,
+    };
+  }
+
+  return {
+    verdict: 'database-unreachable',
+    stats,
+    thresholdTimeouts,
+    probeMs,
+    probeError,
+    message:
+      `[db-pool-health] DATABASE UNREACHABLE — ${rate}, and a brand-new connection to the same `
+      + `database ALSO failed after ${probeMs}ms (${probeError}). This is NOT the #3214 pool `
+      + `poisoning: the fault is in the database, the network, TLS, or auth. Restarting the API `
+      + `will not help. Causes: ${causes}.`,
+    at: now,
+  };
+}
+
+let timer: NodeJS.Timeout | null = null;
+let activeIntervalMs: number | null = null;
+let lastAssessment: DbPoolHealthAssessment | null = null;
+let lastCaptureAtByVerdict = new Map<DbPoolHealthVerdict, number>();
+
+/**
+ * Latest verdict, or null when the watchdog has not evaluated yet (including
+ * when it is disabled). `routes/metrics.ts` reads this; a null must be published
+ * as "not observed", never as "healthy".
+ */
+export function getLastDbPoolHealthAssessment(): DbPoolHealthAssessment | null {
+  return lastAssessment;
+}
+
+/** Exported for testing the throttle without waiting on real clocks. */
+export function shouldCaptureDbPoolHealth(
+  verdict: DbPoolHealthVerdict,
+  now: number,
+  throttleMs: number,
+): boolean {
+  if (throttleMs === 0) return true;
+  const lastAt = lastCaptureAtByVerdict.get(verdict);
+  if (lastAt === undefined || now - lastAt >= throttleMs) {
+    lastCaptureAtByVerdict.set(verdict, now);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Run one evaluation and report it. Never throws — it is a watchdog, and a
+ * watchdog that can crash the tick it runs on is worse than none.
+ */
+export async function runDbPoolHealthCheck(
+  deps: AssessDbPoolHealthDeps = {},
+): Promise<DbPoolHealthAssessment | null> {
+  try {
+    const assessment = await assessDbPoolHealth(deps);
+    lastAssessment = assessment;
+
+    if (assessment.verdict === 'healthy') return assessment;
+
+    console.warn(assessment.message);
+    if (
+      shouldCaptureDbPoolHealth(
+        assessment.verdict,
+        assessment.at,
+        getDbPoolHealthCaptureThrottleMs(),
+      )
+    ) {
+      captureMessage(assessment.message, 'warning', {
+        verdict: assessment.verdict,
+        timeouts: assessment.stats.timeouts,
+        ratePerMin: assessment.stats.ratePerMin,
+        windowMs: assessment.stats.windowMs,
+        byCause: assessment.stats.byCause,
+        probeMs: assessment.probeMs,
+        probeError: assessment.probeError,
+      }, { dbPoolHealthVerdict: assessment.verdict });
+    }
+    return assessment;
+  } catch (err) {
+    console.error('[db-pool-health] check failed:', err);
+    return null;
+  }
+}
+
+/**
+ * Start the watchdog. Idempotent. Returns the effective interval, or null when
+ * disabled — mirroring `startEventLoopMonitor`, so the caller can log which
+ * happened instead of the instance going silently blind.
+ */
+export function startDbPoolHealthMonitor(): number | null {
+  if (isDbPoolHealthMonitorDisabled()) return null;
+  // Return the interval the ARMED timer actually uses, not a fresh read of the
+  // env — otherwise a second call after an env change reports a cadence the
+  // watchdog is not running at, and the boot log would state it as fact.
+  if (timer) return activeIntervalMs;
+
+  activeIntervalMs = getDbPoolHealthIntervalMs();
+  timer = setInterval(() => {
+    void runDbPoolHealthCheck();
+  }, activeIntervalMs);
+  // Unref'd: the watchdog must never be the reason the process stays alive.
+  timer.unref?.();
+  return activeIntervalMs;
+}
+
+export function stopDbPoolHealthMonitor(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+    activeIntervalMs = null;
+  }
+}
+
+export function __resetDbPoolHealthMonitorForTests(): void {
+  stopDbPoolHealthMonitor();
+  lastAssessment = null;
+  lastCaptureAtByVerdict = new Map();
+}

--- a/apps/api/src/db/dbPoolHealthMonitor.ts
+++ b/apps/api/src/db/dbPoolHealthMonitor.ts
@@ -87,10 +87,16 @@ export interface DbPoolHealthAssessment {
   message: string;
   /**
    * Short, STABLE headline used as the Sentry event title. Deliberately free of
-   * counts and durations: Sentry groups by message text, so interpolating a rate
-   * would mint a fresh issue on every capture, and an alert bound to an issue
-   * that never repeats never fires twice. The numbers live in `message` (console)
-   * and in the tags.
+   * counts and durations, because Sentry groups by message text and an
+   * interpolated rate would mint a fresh issue on every capture — an alert bound
+   * to an issue that never repeats never fires twice.
+   *
+   * Be aware of what actually ships: `services/sentry.ts`'s `scrubEvent` deletes
+   * `message`, `logentry` and `extra` from every outgoing event, so today the
+   * only part of a capture that reaches Sentry is its ALLOWLISTED TAGS — which
+   * is why `db_pool_health_verdict` had to be added to `ALLOWED_TAG_NAMES`. The
+   * full numbers live on `console.warn` and in Prometheus. This field is kept
+   * stable anyway so the grouping is correct if that scrubbing ever relaxes.
    */
   headline: string;
   at: number;
@@ -362,28 +368,36 @@ export async function assessDbPoolHealth(
     };
   }
 
-  // A probe that timed out while most timeouts were attributed to a blocked
-  // event loop proves nothing: the probe needs that same loop to run its socket
-  // callbacks, so its budget expires for the same reason theirs did. Calling
-  // this `database-unreachable` would send an operator hunting a DB incident and
-  // explicitly tell them a restart will not help — while the actual fault is a
-  // pegged main thread (#3022).
-  const starvationDominates =
-    stats.byCause['event-loop-starvation'] * 2 > stats.timeouts;
-  if (probeTimedOut && starvationDominates) {
+  // A probe that merely TIMED OUT proves very little on its own: its budget is a
+  // plain in-process timer, so it expires when the main thread is pegged for the
+  // same reason the connect timeouts did (#3022). Calling that
+  // `database-unreachable` would send an operator hunting a DB incident and
+  // explicitly tell them a restart will not help, while the real fault is a
+  // blocked loop.
+  //
+  // The test is deliberately framed as "is there positive evidence FOR a
+  // connectivity fault", not "is there positive evidence against one". Framing
+  // it the other way leaves the hole this branch exists to close: when the
+  // event-loop monitor is disabled, still warming up, or sampling coarser than
+  // the connect window, `diagnoseConnectTimeout` returns `unknown` for EVERY
+  // timeout — so a starvation-dominance test would see a starvation count of 0,
+  // find no dominance, and emit the confident wrong verdict in precisely the
+  // configuration where the module has the least evidence.
+  const connectivityDominates = stats.byCause.connectivity * 2 > stats.timeouts;
+  if (probeTimedOut && !connectivityDominates) {
     return {
       verdict: 'unknown',
       stats,
       thresholdTimeouts,
       probeMs,
       probeError,
-      headline: '[db-pool-health] probe timed out under event-loop starvation',
+      headline: '[db-pool-health] probe timed out inconclusively',
       message:
-        `[db-pool-health] UNKNOWN — ${rate}, and the probe timed out after ${probeMs}ms, but `
-        + `${stats.byCause['event-loop-starvation']} of those timeouts were attributed to `
-        + `event-loop starvation (#3022). The probe's budget is an in-process timer that needs `
-        + `the same blocked loop, so its expiry is NOT evidence about the database. Investigate `
-        + `main-thread starvation first. Causes: ${causes}.`,
+        `[db-pool-health] UNKNOWN — ${rate}, and the probe timed out after ${probeMs}ms, but the `
+        + `timeouts are not predominantly attributed to connectivity (${causes}). The probe's `
+        + `budget is an in-process timer that needs the same event loop, so under starvation — `
+        + `or with no event-loop measurement at all — its expiry is NOT evidence about the `
+        + `database (#3022). Rule out main-thread starvation before treating this as a DB fault.`,
       at: now,
     };
   }
@@ -493,23 +507,31 @@ export async function runDbPoolHealthCheck(
     const throttleMs = getDbPoolHealthCaptureThrottleMs();
     if (claimDbPoolHealthCaptureSlot(assessment.verdict, assessment.at, throttleMs)) {
       const suppressed = takeSuppressedCount(assessment.verdict);
-      // The TITLE is the stable headline (Sentry groups by message text, so an
-      // interpolated rate would mint a new issue every capture and no alert
-      // bound to it could ever fire twice). Detail rides on the low-cardinality
-      // tags; the full prose is already on console.warn above.
-      captureMessage(assessment.headline, 'warning', {
-        message: assessment.message,
-        verdict: assessment.verdict,
-        timeouts: assessment.stats.timeouts,
-        ratePerMin: assessment.stats.ratePerMin,
-        windowMs: assessment.stats.windowMs,
-        byCause: assessment.stats.byCause,
-        probeMs: assessment.probeMs,
-        probeError: assessment.probeError,
-        // States this event's own sampling rate, so the throttle cannot make a
-        // storm look like a single occurrence.
-        suppressedSinceLastCapture: suppressed,
-      }, { dbPoolHealthVerdict: assessment.verdict });
+      // Wrapped: a valid assessment has already been stored, and the outer catch
+      // now CLEARS `lastAssessment`. Letting a reporter fault fall through to it
+      // would erase a real `pool-degraded` verdict from /metrics at the exact
+      // moment it fired, and show the operator a reporting error instead.
+      try {
+        // `db_pool_health_verdict` is the only field that survives — scrubEvent
+        // deletes message/extra from every event — so it carries the actionable
+        // part. The extras are passed anyway (correct shape, and free) and the
+        // full prose is already on console.warn above.
+        captureMessage(assessment.headline, 'warning', {
+          message: assessment.message,
+          verdict: assessment.verdict,
+          timeouts: assessment.stats.timeouts,
+          ratePerMin: assessment.stats.ratePerMin,
+          windowMs: assessment.stats.windowMs,
+          byCause: assessment.stats.byCause,
+          probeMs: assessment.probeMs,
+          probeError: assessment.probeError,
+          // States this event's own sampling rate, so the throttle cannot make a
+          // storm look like a single occurrence.
+          suppressedSinceLastCapture: suppressed,
+        }, { db_pool_health_verdict: assessment.verdict });
+      } catch (captureErr) {
+        console.error('[db-pool-health] failed to report verdict to Sentry:', captureErr);
+      }
     }
     return assessment;
   } catch (err) {
@@ -536,7 +558,8 @@ export async function runDbPoolHealthCheck(
         captureMessage('[db-pool-health] watchdog evaluation failed', 'warning', {
           error: err instanceof Error ? err.message : String(err),
           checkFailures,
-        }, { dbPoolHealthVerdict: 'check-failed' });
+          suppressedSinceLastCapture: takeSuppressedCount('check-failed'),
+        }, { db_pool_health_verdict: 'check-failed' });
       } catch {
         // The reporter is the thing that failed; the console line above stands.
       }

--- a/apps/api/src/db/dbPoolHealthWiring.test.ts
+++ b/apps/api/src/db/dbPoolHealthWiring.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Boot-wiring guards for the #3214 pool-health watchdog.
+ *
+ * Same rationale as `services/eventLoopMonitorWiring.test.ts`: `index.ts` starts
+ * servers, workers and migrations on import, so it cannot be imported in a unit
+ * test and is excluded from coverage. A watchdog that is defined but never
+ * started fails completely silently — `getLastDbPoolHealthAssessment()` returns
+ * null, every Prometheus verdict series stays at 0, and no test goes red. The
+ * API would simply be blind to the exact condition this work exists to surface,
+ * which is precisely how #3214 went unnoticed for hours in production.
+ */
+describe('db pool-health watchdog bootstrap wiring (index.ts)', () => {
+  const indexSource = readFileSync(
+    fileURLToPath(new URL('../index.ts', import.meta.url)),
+    'utf-8',
+  );
+
+  it('starts the watchdog during startup', () => {
+    expect(indexSource).toMatch(/startDbPoolHealthMonitor\s*\(/);
+  });
+
+  it('starts it AFTER the connect-timeout classifier is injected', () => {
+    // The watchdog alerts on the CONNECT_TIMEOUT rate, and nothing is counted
+    // until safeDiagnoseConnectTimeout is wired into the Sentry layer. Started
+    // first, it would evaluate an empty window and report a healthy pool.
+    const classifierAt = indexSource.indexOf('setConnectTimeoutClassifier(safeDiagnoseConnectTimeout)');
+    const watchdogAt = indexSource.indexOf('startDbPoolHealthMonitor(');
+    expect(classifierAt).toBeGreaterThan(-1);
+    expect(watchdogAt).toBeGreaterThan(classifierAt);
+  });
+
+  it('announces at boot whether the watchdog is running', () => {
+    // A disabled watchdog is otherwise indistinguishable from a healthy one:
+    // both publish no verdict at all.
+    expect(indexSource).toMatch(/\[db-pool-health\] Watchdog started/);
+    expect(indexSource).toMatch(/\[db-pool-health\] Watchdog DISABLED/);
+  });
+
+  it('stops the watchdog on graceful shutdown', () => {
+    // Not just tidiness: left running, it can open a fresh probe connection
+    // while the pool drains and report `database-unreachable` about a process
+    // that is merely shutting down.
+    expect(indexSource).toMatch(/stopDbPoolHealthMonitor\s*\(/);
+  });
+
+  it('keeps pool-health telemetry off the unauthenticated /health/ready', () => {
+    // /health/ready answers without auth. The verdict plus the connect-timeout
+    // rate is a live readout of how close the instance is to falling over, for
+    // the same reason event-loop lag was deliberately kept off this endpoint.
+    // The numbers belong on the auth-gated /metrics; the watchdog logs to the
+    // console regardless.
+    const start = indexSource.indexOf("app.get('/health/ready'");
+    expect(start).toBeGreaterThan(-1);
+    // Bound the block at the NEXT top-level route registration rather than at a
+    // named one: `/ready` is mounted with `app.route(...)`, not `app.get(...)`,
+    // so an `indexOf` on a specific handler returns -1 and silently widens the
+    // slice to the rest of the file.
+    const next = indexSource.slice(start + 1).search(/\napp\.(get|post|route|use)\(/);
+    const readyBlock = indexSource.slice(start, next === -1 ? undefined : start + 1 + next);
+
+    expect(readyBlock).toContain('const allOk = Object.values(checks)');
+    expect(readyBlock).not.toMatch(/DbPoolHealth/);
+    expect(readyBlock).not.toMatch(/poolHealth/i);
+    expect(readyBlock).not.toMatch(/connectTimeout/i);
+  });
+});

--- a/apps/api/src/db/postgresJsPoolPoisoning.test.ts
+++ b/apps/api/src/db/postgresJsPoolPoisoning.test.ts
@@ -1,0 +1,189 @@
+import { EventEmitter } from 'node:events';
+import postgres from 'postgres';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * KNOWN-DEFECT PIN for the postgres.js pool-poisoning bug behind #3214.
+ *
+ * ---------------------------------------------------------------------------
+ * THE DEFECT (postgres.js 3.4.9, `src/connection.js`)
+ * ---------------------------------------------------------------------------
+ * The driver batches small writes behind a `setImmediate`, guarded by a
+ * "already scheduled?" check:
+ *
+ *     function write(x, fn) {                                        // :246
+ *       chunk = chunk ? Buffer.concat([chunk, x]) : Buffer.from(x)
+ *       if (fn || chunk.length >= 1024)
+ *         return nextWrite(fn)
+ *       nextWriteTimer === null && (nextWriteTimer = setImmediate(nextWrite))
+ *       return true
+ *     }
+ *
+ *     function nextWrite(fn) {                                       // :254
+ *       const x = socket.write(chunk, fn)
+ *       nextWriteTimer !== null && clearImmediate(nextWriteTimer)
+ *       chunk = nextWriteTimer = null                                // <- only reset
+ *       return x
+ *     }
+ *
+ * `nextWrite` actually running is the ONLY thing that ever resets
+ * `nextWriteTimer` to null. But the two teardown paths cancel the immediate
+ * WITHOUT clearing the variable (and without dropping the buffered `chunk`):
+ *
+ *     function terminate() { ... clearImmediate(nextWriteTimer) ... }      // :427
+ *     async function closed(hadError) { ... clearImmediate(nextWriteTimer) // :440
+ *                                        ... socket = null ... }
+ *
+ * So a pooled connection whose socket dies while a deferred write is still
+ * queued is left with `nextWriteTimer` permanently non-null. From then on the
+ * guard at :250 is false forever, no flush is ever scheduled again, and the
+ * StartupMessage written by `connected()` on every subsequent reconnect is
+ * appended to `chunk` and never reaches the socket. The handshake therefore
+ * cannot complete, `connect_timeout` expires, `connectTimedOut()` reports
+ * `CONNECT_TIMEOUT` and destroys the socket, `closed()` reconnects — and the
+ * cycle repeats for the life of the process.
+ *
+ * That accounts for every symptom reported in #3214: `TLSSocket.closed` errors
+ * appearing days before the outage (each one poisoning a slot), the pool
+ * decaying 35 -> 9 over hours, ~144 CONNECT_TIMEOUT/min sustained against a
+ * database that was demonstrably healthy, and full recovery within seconds of a
+ * process restart (fresh closures).
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS TEST ASSERTS THE BUG RATHER THAN THE FIX
+ * ---------------------------------------------------------------------------
+ * postgres.js 3.4.9 is the LATEST published release — there is no version to
+ * upgrade to, and the broken state lives inside a closure that nothing outside
+ * the driver can reach. The repo therefore ships a WATCHDOG
+ * (`db/dbPoolHealthMonitor.ts`), not a repair.
+ *
+ * This test pins the defect so that:
+ *   1. the mechanism is documented executably rather than in prose that rots;
+ *   2. there is a dependency-free reproduction to attach to an upstream report;
+ *   3. the day the driver is fixed (or patched locally), this test FAILS and
+ *      says so — which is the signal to drop the watchdog and its metrics.
+ *
+ * A test that goes red on an upstream *improvement* is deliberate. Read the
+ * failure message before "fixing" it.
+ */
+
+interface FakeSocket extends EventEmitter {
+  readyState: string;
+  bytesWritten: number;
+  setKeepAlive(): void;
+  write(buf: Buffer | string): boolean;
+  destroy(): void;
+  end(): void;
+}
+
+function createFakeSocket(): FakeSocket {
+  const s = new EventEmitter() as FakeSocket;
+  s.readyState = 'open';
+  s.bytesWritten = 0;
+  s.setKeepAlive = () => {};
+  s.write = (buf: Buffer | string) => {
+    s.bytesWritten += Buffer.byteLength(buf as Buffer);
+    return true;
+  };
+  s.destroy = () => {
+    s.readyState = 'closed';
+  };
+  s.end = () => {
+    s.readyState = 'closed';
+  };
+  return s;
+}
+
+/**
+ * Drives postgres.js against fake sockets supplied through its `socket` option.
+ * With that option set, `connect()` short-circuits straight to `connected()`
+ * (no TCP, no TLS, no real host), which writes the StartupMessage — the small,
+ * callback-less write that takes the deferred path we are probing.
+ *
+ * `killAttempts` names the attempts whose socket is destroyed while that
+ * deferred flush is still queued. The kill is scheduled with `setImmediate`
+ * from inside the socket factory, which runs BEFORE `connected()` does, so it
+ * is queued ahead of the driver's own `setImmediate(nextWrite)` and always wins
+ * the race — no timing luck involved.
+ */
+async function runHandshakeAttempts(options: {
+  killAttempts: ReadonlySet<number>;
+  settleMs: number;
+}): Promise<number[]> {
+  const sockets: FakeSocket[] = [];
+
+  // `socket` is a genuine postgres.js option — `parseOptions` copies it
+  // (`src/index.js`: `socket: o.socket`) and `createSocket` calls it
+  // (`src/connection.js:132`) — but it is absent from the shipped `.d.ts`, so
+  // the cast is unavoidable. It is what makes this test hermetic: no TCP, no
+  // TLS, no database, no network timeouts.
+  const driverOptions = {
+    host: 'pool-poisoning.invalid',
+    port: 5432,
+    database: 'breeze',
+    user: 'breeze',
+    pass: '',
+    max: 1,
+    ssl: false,
+    connect_timeout: 1,
+    socket: () => {
+      const socket = createFakeSocket();
+      sockets.push(socket);
+      const attempt = sockets.length;
+      if (options.killAttempts.has(attempt)) {
+        setImmediate(() => socket.emit('close', false));
+      }
+      return socket;
+    },
+  };
+
+  const sql = postgres(driverOptions as unknown as Parameters<typeof postgres>[0]);
+
+  // Never resolves against a fake socket; we only care about the bytes the
+  // driver puts (or fails to put) on the wire.
+  void sql`select 1`.catch(() => undefined);
+
+  await new Promise((resolve) => setTimeout(resolve, options.settleMs));
+  await sql.end({ timeout: 0 }).catch(() => undefined);
+
+  return sockets.map((s) => s.bytesWritten);
+}
+
+describe('postgres.js deferred-write pool poisoning (#3214)', () => {
+  it('control: an undisturbed connection flushes its StartupMessage', async () => {
+    // Proves the harness itself works — without this, the poisoning assertion
+    // below could pass simply because the fake socket never receives anything.
+    const written = await runHandshakeAttempts({
+      killAttempts: new Set(),
+      settleMs: 250,
+    });
+
+    expect(written.length).toBeGreaterThanOrEqual(1);
+    expect(written[0]).toBeGreaterThan(0);
+  }, 10_000);
+
+  it('a socket that dies with a buffered write leaves the connection permanently unable to flush', async () => {
+    // Attempt 1's socket is closed while the StartupMessage flush is still
+    // queued. `closed()` cancels the immediate but leaves `nextWriteTimer`
+    // non-null, so attempt 2 — a full reconnect with a brand-new socket —
+    // schedules no flush at all and writes zero bytes.
+    const written = await runHandshakeAttempts({
+      killAttempts: new Set([1]),
+      settleMs: 1_500,
+    });
+
+    expect(
+      written.length,
+      'expected the driver to reconnect after the socket closed',
+    ).toBeGreaterThanOrEqual(2);
+
+    expect(
+      written[1],
+      'postgres.js appears to FLUSH after a socket death with a buffered write — the '
+        + 'deferred-write defect behind #3214 looks fixed. Confirm against '
+        + 'src/connection.js (does closed()/terminate() now reset nextWriteTimer and '
+        + 'chunk to null?), then delete this pin AND the db/dbPoolHealthMonitor.ts '
+        + 'watchdog it exists to justify.',
+    ).toBe(0);
+  }, 15_000);
+});

--- a/apps/api/src/db/postgresJsPoolPoisoning.test.ts
+++ b/apps/api/src/db/postgresJsPoolPoisoning.test.ts
@@ -109,6 +109,13 @@ function createFakeSocket(): FakeSocket {
 async function runHandshakeAttempts(options: {
   killAttempts: ReadonlySet<number>;
   settleMs: number;
+  /**
+   * When set, the kill is deferred by this many ms instead of being queued as an
+   * immediate — long enough for the driver's own flush to have already run. That
+   * is the negative control: the socket still dies, but with NO buffered write,
+   * so `nextWriteTimer` was legitimately reset and the connection recovers.
+   */
+  killDelayMs?: number;
 }): Promise<number[]> {
   const sockets: FakeSocket[] = [];
 
@@ -131,7 +138,11 @@ async function runHandshakeAttempts(options: {
       sockets.push(socket);
       const attempt = sockets.length;
       if (options.killAttempts.has(attempt)) {
-        setImmediate(() => socket.emit('close', false));
+        if (options.killDelayMs === undefined) {
+          setImmediate(() => socket.emit('close', false));
+        } else {
+          setTimeout(() => socket.emit('close', false), options.killDelayMs);
+        }
       }
       return socket;
     },
@@ -162,6 +173,28 @@ describe('postgres.js deferred-write pool poisoning (#3214)', () => {
     expect(written[0]).toBeGreaterThan(0);
   }, 10_000);
 
+  it('negative control: a socket that dies AFTER its flush leaves the connection able to write again', async () => {
+    // Without this, `written[1] === 0` in the test below would also be satisfied
+    // by "the driver stopped writing on reconnect for some unrelated reason".
+    // Here the socket dies just as hard, but with nothing buffered — so
+    // `nextWrite` had already run and reset `nextWriteTimer`, and attempt 2
+    // completes its handshake write normally. That isolates the buffered write
+    // as the actual cause, which is the claim an upstream report has to make.
+    const written = await runHandshakeAttempts({
+      killAttempts: new Set([1]),
+      killDelayMs: 60,
+      settleMs: 1_500,
+    });
+
+    expect(written.length).toBeGreaterThanOrEqual(2);
+    expect(written[0]).toBeGreaterThan(0);
+    expect(
+      written[1],
+      'the reconnect after a FLUSHED socket death should still write — if this is 0, '
+        + 'the poisoning assertion below is no longer isolating the buffered write.',
+    ).toBeGreaterThan(0);
+  }, 15_000);
+
   it('a socket that dies with a buffered write leaves the connection permanently unable to flush', async () => {
     // Attempt 1's socket is closed while the StartupMessage flush is still
     // queued. `closed()` cancels the immediate but leaves `nextWriteTimer`
@@ -174,7 +207,9 @@ describe('postgres.js deferred-write pool poisoning (#3214)', () => {
 
     expect(
       written.length,
-      'expected the driver to reconnect after the socket closed',
+      'expected the driver to reconnect after the socket closed. If it no longer '
+        + 'reconnects at all, that is also an upstream behaviour change — re-read this '
+        + 'pin against src/connection.js rather than adjusting the harness.',
     ).toBeGreaterThanOrEqual(2);
 
     expect(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1883,9 +1883,18 @@ async function bootstrap(): Promise<void> {
   // reports 'unknown' rather than guessing.
   setConnectTimeoutClassifier(safeDiagnoseConnectTimeout);
 
-  // #3214 — pool-health watchdog. Must follow setConnectTimeoutClassifier: the
-  // watchdog alerts on the CONNECT_TIMEOUT rate, and nothing is counted until the
-  // classifier is wired, so starting it earlier would only give it an empty window.
+  // Validate configuration before anything else — fail fast on missing/insecure secrets.
+  // The validated config is stored as a singleton; retrieve later via getConfig().
+  const config = validateConfig();
+
+  // #3214 — pool-health watchdog.
+  //
+  // Ordering, both constraints: it must follow setConnectTimeoutClassifier
+  // (nothing is counted until that is wired, so an earlier start would only give
+  // it an empty window), and it must follow validateConfig — its probe builds a
+  // connection URL straight from the environment, so starting first lets a short
+  // interval fire a probe against unvalidated config and report the resulting
+  // misconfiguration as a database fault.
   //
   // Steady-state cost is one unref'd timer tick; the fresh-connection probe opens
   // a socket only once the timeout rate has already breached the threshold.
@@ -1903,9 +1912,6 @@ async function bootstrap(): Promise<void> {
     );
   }
 
-  // Validate configuration before anything else — fail fast on missing/insecure secrets.
-  // The validated config is stored as a singleton; retrieve later via getConfig().
-  const config = validateConfig();
   await initializeDatabaseForStartup({
     autoMigrateEnabled: process.env.AUTO_MIGRATE !== 'false',
     production: config.NODE_ENV === 'production',

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -179,6 +179,12 @@ import {
   getConnectTimeoutStarvationThresholdMs,
   safeDiagnoseConnectTimeout,
 } from './services/postgresConnectTimeout';
+import {
+  getDbPoolHealthMinTimeouts,
+  getDbPoolHealthWindowMs,
+  startDbPoolHealthMonitor,
+  stopDbPoolHealthMonitor,
+} from './db/dbPoolHealthMonitor';
 import { isBenignRejection, isRecoverablePostgresConnectionTeardown } from './services/rejectionSuppressions';
 import { partnerGuard } from './middleware/partnerGuard';
 import { API_VERSION } from './version';
@@ -1579,6 +1585,11 @@ async function shutdownRuntime(signal: NodeJS.Signals): Promise<void> {
   // requirement — it just stops starvation warnings from being emitted about a
   // process that is deliberately winding down and no longer serving traffic.
   stopEventLoopMonitor();
+  // #3214. Also already unref'd, so this is tidiness — but it additionally stops
+  // the watchdog opening a fresh probe connection while the pool is draining,
+  // which would report `database-unreachable` about a process that is simply
+  // shutting down.
+  stopDbPoolHealthMonitor();
   if (auditRetryInterval) {
     clearInterval(auditRetryInterval);
     auditRetryInterval = null;
@@ -1871,6 +1882,26 @@ async function bootstrap(): Promise<void> {
   // startEventLoopMonitor: before the monitor runs, every diagnosis correctly
   // reports 'unknown' rather than guessing.
   setConnectTimeoutClassifier(safeDiagnoseConnectTimeout);
+
+  // #3214 — pool-health watchdog. Must follow setConnectTimeoutClassifier: the
+  // watchdog alerts on the CONNECT_TIMEOUT rate, and nothing is counted until the
+  // classifier is wired, so starting it earlier would only give it an empty window.
+  //
+  // Steady-state cost is one unref'd timer tick; the fresh-connection probe opens
+  // a socket only once the timeout rate has already breached the threshold.
+  const dbPoolHealthIntervalMs = startDbPoolHealthMonitor();
+  if (dbPoolHealthIntervalMs === null) {
+    console.warn(
+      '[db-pool-health] Watchdog DISABLED via DB_POOL_HEALTH_DISABLED — a poisoned '
+      + 'postgres.js pool will decay silently until someone notices the 503s (#3214).',
+    );
+  } else {
+    console.log(
+      `[db-pool-health] Watchdog started (interval ${dbPoolHealthIntervalMs}ms, `
+      + `window ${getDbPoolHealthWindowMs()}ms, probe threshold `
+      + `${getDbPoolHealthMinTimeouts()} CONNECT_TIMEOUT(s) per window)`,
+    );
+  }
 
   // Validate configuration before anything else — fail fast on missing/insecure secrets.
   // The validated config is stored as a singleton; retrieve later via getConfig().

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -4,6 +4,16 @@ import {
   stopEventLoopMonitor,
   __setEventLoopMonitorForTests,
 } from '../services/eventLoopMonitor';
+import {
+  DB_POOL_HEALTH_VERDICTS,
+  runDbPoolHealthCheck,
+  __resetDbPoolHealthMonitorForTests,
+} from '../db/dbPoolHealthMonitor';
+import {
+  recordDbConnectTimeout,
+  __resetDbConnectTimeoutStatsForTests,
+  type DbConnectTimeoutWindowStats,
+} from '../services/dbConnectTimeoutStats';
 import { Hono } from 'hono';
 
 const selectMock = vi.hoisted(() => vi.fn());
@@ -201,6 +211,17 @@ function mockCurrentMetricsQueries(
   return captured;
 }
 
+/** Stand-in connect-timeout window, so the pool-health tests need no real errors. */
+function connectTimeoutStats(timeouts: number, windowMs = 300_000): DbConnectTimeoutWindowStats {
+  return {
+    timeouts,
+    byCause: { 'event-loop-starvation': 0, connectivity: timeouts, unknown: 0 },
+    windowMs,
+    ratePerMin: (timeouts * 60_000) / windowMs,
+    totalSinceStart: timeouts,
+  };
+}
+
 function getMetricLine(metrics: string, name: string, labels?: Record<string, string>): string | undefined {
   const labelText = labels ? `{${Object.entries(labels).map(([k, v]) => `${k}="${v}"`).join(',')}}` : '';
   return metrics
@@ -364,6 +385,127 @@ describe('metrics routes', () => {
       expect(getMetricLine(body, 'breeze_nodejs_eventloop_starved')).toBe(
         'breeze_nodejs_eventloop_starved 1',
       );
+    });
+  });
+
+  describe('db pool-health gauges (#3214)', () => {
+    afterEach(() => {
+      __resetDbPoolHealthMonitorForTests();
+      __resetDbConnectTimeoutStatsForTests();
+    });
+
+    async function scrape(): Promise<string> {
+      const res = await app.request('/metrics', { headers: { Authorization: 'Bearer token' } });
+      expect(res.status).toBe(200);
+      return res.text();
+    }
+
+    it('publishes every series, all at zero, before the watchdog has evaluated', async () => {
+      // Absence of a verdict must be visible AS absence. If these series simply
+      // did not exist, an alert rule referencing them would match nothing and
+      // read as "no problem" — and there is deliberately no `healthy` verdict to
+      // fall back on.
+      const body = await scrape();
+      expect(body).toContain('# TYPE breeze_db_pool_health gauge');
+      expect(body).toContain('# TYPE breeze_db_connect_timeouts_total counter');
+      expect(body).toContain('# TYPE breeze_db_connect_timeout_rate_per_min gauge');
+
+      for (const verdict of DB_POOL_HEALTH_VERDICTS) {
+        expect(getMetricLine(body, 'breeze_db_pool_health', { verdict })).toBe(
+          `breeze_db_pool_health{verdict="${verdict}"} 0`,
+        );
+      }
+      expect(
+        getMetricLine(body, 'breeze_db_pool_health_last_check_timestamp_seconds'),
+      ).toBe('breeze_db_pool_health_last_check_timestamp_seconds 0');
+    });
+
+    it('tracks the watchdog verdict on scrape', async () => {
+      // Deleting the updateDbPoolHealthMetrics() call would otherwise pin every
+      // gauge at its initialize-time zero forever — the exact hazard the
+      // event-loop suite above exists to prevent for #3022.
+      await runDbPoolHealthCheck({
+        readStats: () => connectTimeoutStats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+
+      const body = await scrape();
+      expect(getMetricLine(body, 'breeze_db_pool_health', { verdict: 'pool-degraded' })).toBe(
+        'breeze_db_pool_health{verdict="pool-degraded"} 1',
+      );
+      expect(getMetricLine(body, 'breeze_db_pool_health', { verdict: 'below-threshold' })).toBe(
+        'breeze_db_pool_health{verdict="below-threshold"} 0',
+      );
+      expect(
+        getMetricLine(body, 'breeze_db_pool_health_last_check_timestamp_seconds'),
+      ).not.toBe('breeze_db_pool_health_last_check_timestamp_seconds 0');
+    });
+
+    it('CLEARS a degraded verdict once the condition passes', async () => {
+      // A stuck `pool-degraded` series would page an operator to restart a
+      // healthy API forever.
+      await runDbPoolHealthCheck({
+        readStats: () => connectTimeoutStats(40),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+      expect(
+        getMetricLine(await scrape(), 'breeze_db_pool_health', { verdict: 'pool-degraded' }),
+      ).toBe('breeze_db_pool_health{verdict="pool-degraded"} 1');
+
+      await runDbPoolHealthCheck({
+        readStats: () => connectTimeoutStats(0),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+
+      const body = await scrape();
+      expect(getMetricLine(body, 'breeze_db_pool_health', { verdict: 'pool-degraded' })).toBe(
+        'breeze_db_pool_health{verdict="pool-degraded"} 0',
+      );
+      expect(getMetricLine(body, 'breeze_db_pool_health', { verdict: 'below-threshold' })).toBe(
+        'breeze_db_pool_health{verdict="below-threshold"} 1',
+      );
+    });
+
+    it('goes back to all-zero — never a stale verdict — when an evaluation fails', async () => {
+      await runDbPoolHealthCheck({
+        readStats: () => connectTimeoutStats(0),
+        probe: async () => {},
+        thresholdTimeouts: 10,
+      });
+      await runDbPoolHealthCheck({
+        readStats: () => {
+          throw new Error('stats exploded');
+        },
+      });
+
+      const body = await scrape();
+      for (const verdict of DB_POOL_HEALTH_VERDICTS) {
+        expect(getMetricLine(body, 'breeze_db_pool_health', { verdict })).toBe(
+          `breeze_db_pool_health{verdict="${verdict}"} 0`,
+        );
+      }
+      expect(getMetricLine(body, 'breeze_db_pool_health_check_failures_total')).toBe(
+        'breeze_db_pool_health_check_failures_total 1',
+      );
+    });
+
+    it('increments the connect-timeout counter through the recorder binding', async () => {
+      // Kills the "delete the setDbConnectTimeoutMetricsRecorder(...) call"
+      // mutation: without that binding the counter never leaves its seeded 0
+      // while the watchdog and the internal window keep working — a clean chart
+      // during an active storm.
+      recordDbConnectTimeout(new Error('a'), 'connectivity');
+      recordDbConnectTimeout(new Error('b'), 'event-loop-starvation');
+
+      const body = await scrape();
+      expect(getMetricLine(body, 'breeze_db_connect_timeouts_total', { cause: 'connectivity' }))
+        .toBe('breeze_db_connect_timeouts_total{cause="connectivity"} 1');
+      expect(
+        getMetricLine(body, 'breeze_db_connect_timeouts_total', { cause: 'event-loop-starvation' }),
+      ).toBe('breeze_db_connect_timeouts_total{cause="event-loop-starvation"} 1');
     });
   });
 

--- a/apps/api/src/routes/metrics.test.ts
+++ b/apps/api/src/routes/metrics.test.ts
@@ -487,8 +487,8 @@ describe('metrics routes', () => {
           `breeze_db_pool_health{verdict="${verdict}"} 0`,
         );
       }
-      expect(getMetricLine(body, 'breeze_db_pool_health_check_failures_total')).toBe(
-        'breeze_db_pool_health_check_failures_total 1',
+      expect(getMetricLine(body, 'breeze_db_pool_health_check_failures')).toBe(
+        'breeze_db_pool_health_check_failures 1',
       );
     });
 

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -14,6 +14,15 @@ import { deviceMetrics, devices, metricRollups, recoveryReadiness as recoveryRea
 import { authMiddleware, requirePermission, requireScope } from '../middleware/auth';
 import { getTrustedClientIpOrUndefined } from '../services/clientIp';
 import { getEventLoopLagStats, readLatestEventLoopLag } from '../services/eventLoopMonitor';
+import {
+  getDbConnectTimeoutStats,
+  setDbConnectTimeoutMetricsRecorder,
+} from '../services/dbConnectTimeoutStats';
+import {
+  getDbPoolHealthWindowMs,
+  getLastDbPoolHealthAssessment,
+  type DbPoolHealthVerdict,
+} from '../db/dbPoolHealthMonitor';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { BACKUP_LOW_READINESS_THRESHOLD } from './backup/constants';
 import {
@@ -465,6 +474,49 @@ const eventLoopMonitoredGauge = new Gauge({
   registers: [register]
 });
 
+// #3214 — Postgres CONNECT_TIMEOUT as a first-class series. During the incident
+// this signal existed only as individual Sentry events and console lines, so the
+// thing that actually mattered — the RATE, sustained at ~144/min for hours while
+// the pool decayed from 35 live connections to 9 — was invisible. `cause` comes
+// from services/postgresConnectTimeout.ts, so a starved event loop (#3022) can
+// be told apart from a genuine connect failure on the same chart.
+const dbConnectTimeoutsTotal = new Counter({
+  name: 'breeze_db_connect_timeouts_total',
+  help: 'Total Postgres CONNECT_TIMEOUT errors observed, by diagnosed cause',
+  labelNames: ['cause'] as const,
+  registers: [register]
+});
+
+// The same rate the watchdog evaluates, republished so an alert rule and the
+// warning in the logs derive from one number instead of two definitions that can
+// drift apart.
+const dbConnectTimeoutRateGauge = new Gauge({
+  name: 'breeze_db_connect_timeout_rate_per_min',
+  help: 'Postgres CONNECT_TIMEOUT errors per minute over the pool-health window',
+  registers: [register]
+});
+
+// Enum-style gauge: exactly one verdict carries 1, the rest carry 0. Modelled as
+// a label rather than a numeric code because the operational response differs per
+// verdict and an alert must be able to name which — `pool-degraded` means restart
+// the API (the pool cannot self-heal, #3214), `database-unreachable` means do NOT
+// restart, the fault is downstream. Before the first evaluation, and whenever the
+// watchdog is disabled, ALL series stay 0: absence of a verdict must never read
+// as 'healthy'.
+const dbPoolHealthGauge = new Gauge({
+  name: 'breeze_db_pool_health',
+  help: '1 for the pool-health watchdog current verdict, 0 for the others (all 0 before the first evaluation)',
+  labelNames: ['verdict'] as const,
+  registers: [register]
+});
+
+const DB_POOL_HEALTH_VERDICTS: readonly DbPoolHealthVerdict[] = [
+  'healthy',
+  'pool-degraded',
+  'database-unreachable',
+  'unknown',
+];
+
 function initializeMetricDefaults(): void {
   httpRequestsInFlight.set(0);
   devicesActiveGauge.set(0);
@@ -507,6 +559,15 @@ function initializeMetricDefaults(): void {
   eventLoopLagWindowMaxGauge.set(0);
   eventLoopLagWindowMeanGauge.set(0);
   eventLoopStarvedGauge.set(0);
+  // #3214. Seeded at 0 for the same reason: an alert on the connect-timeout rate
+  // must not silently match nothing on an instance that has not yet timed out.
+  dbConnectTimeoutsTotal.labels('event-loop-starvation').inc(0);
+  dbConnectTimeoutsTotal.labels('connectivity').inc(0);
+  dbConnectTimeoutsTotal.labels('unknown').inc(0);
+  dbConnectTimeoutRateGauge.set(0);
+  for (const verdict of DB_POOL_HEALTH_VERDICTS) {
+    dbPoolHealthGauge.labels(verdict).set(0);
+  }
 }
 
 initializeMetricDefaults();
@@ -557,6 +618,25 @@ function normalizeMetricLabel(value: string, fallback: string): string {
 function updateProcessMetrics(): void {
   processStartTimeGauge.set(Math.floor(Date.now() / 1000 - process.uptime()));
   updateEventLoopMetrics();
+  updateDbPoolHealthMetrics();
+}
+
+/**
+ * Republishes the watchdog's latest verdict (#3214). Read on scrape rather than
+ * pushed on evaluation so a scrape always reflects the most recent check even if
+ * the watchdog interval and the scrape interval differ.
+ *
+ * The rate is recomputed here over the SAME window the watchdog uses, so the
+ * gauge and the log warning cannot disagree. When no verdict exists yet, every
+ * verdict series is left at 0 — see the gauge's declaration for why "not
+ * observed" must not collapse into "healthy".
+ */
+function updateDbPoolHealthMetrics(): void {
+  dbConnectTimeoutRateGauge.set(getDbConnectTimeoutStats(getDbPoolHealthWindowMs()).ratePerMin);
+  const assessment = getLastDbPoolHealthAssessment();
+  for (const verdict of DB_POOL_HEALTH_VERDICTS) {
+    dbPoolHealthGauge.labels(verdict).set(assessment?.verdict === verdict ? 1 : 0);
+  }
 }
 
 function updateEventLoopMetrics(): void {
@@ -857,6 +937,15 @@ function recordExtensionOrgInstallDenyMetric(
 }
 
 function bindMetricsRecorders(): void {
+  // #3214. The stats module is a zero-import leaf (it sits in the graph of
+  // services/sentry.ts), so the Prometheus counter is pushed IN from here rather
+  // than pulled by it — same inversion as setConnectTimeoutClassifier.
+  setDbConnectTimeoutMetricsRecorder({
+    onConnectTimeout: (cause) => {
+      dbConnectTimeoutsTotal.labels(cause).inc();
+    },
+  });
+
   setS1MetricsRecorder({
     onSyncRun: (job, outcome, durationMs) => {
       const safeDuration = Number.isFinite(durationMs) ? Math.max(durationMs, 0) : 0;

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -527,9 +527,13 @@ const dbPoolHealthLastCheckGauge = new Gauge({
   registers: [register]
 });
 
+// Gauges, not Counters, and therefore deliberately WITHOUT the `_total` suffix
+// (which OpenMetrics reserves for counters). The underlying values are
+// process-lifetime totals owned by dbPoolHealthMonitor and read absolutely on
+// each scrape, so there is no per-event increment to drive a Counter with.
 const dbPoolHealthCheckFailuresGauge = new Gauge({
-  name: 'breeze_db_pool_health_check_failures_total',
-  help: 'Pool-health evaluations that threw before producing a verdict',
+  name: 'breeze_db_pool_health_check_failures',
+  help: 'Pool-health evaluations that threw before producing a verdict, since process start',
   registers: [register]
 });
 
@@ -537,8 +541,8 @@ const dbPoolHealthCheckFailuresGauge = new Gauge({
 // database the watchdog is diagnosing. Surfaced so the watchdog cannot quietly
 // become a contributor to connection exhaustion.
 const dbPoolHealthProbeCloseFailuresGauge = new Gauge({
-  name: 'breeze_db_pool_health_probe_close_failures_total',
-  help: 'Pool-health probe clients whose end() failed, each a possible leaked connection',
+  name: 'breeze_db_pool_health_probe_close_failures',
+  help: 'Pool-health probe clients whose end() failed since process start, each a possible leaked connection',
   registers: [register]
 });
 

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -19,9 +19,11 @@ import {
   setDbConnectTimeoutMetricsRecorder,
 } from '../services/dbConnectTimeoutStats';
 import {
+  DB_POOL_HEALTH_VERDICTS,
+  getDbPoolHealthCheckFailures,
+  getDbPoolHealthProbeCloseFailures,
   getDbPoolHealthWindowMs,
   getLastDbPoolHealthAssessment,
-  type DbPoolHealthVerdict,
 } from '../db/dbPoolHealthMonitor';
 import { PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { BACKUP_LOW_READINESS_THRESHOLD } from './backup/constants';
@@ -500,9 +502,13 @@ const dbConnectTimeoutRateGauge = new Gauge({
 // a label rather than a numeric code because the operational response differs per
 // verdict and an alert must be able to name which — `pool-degraded` means restart
 // the API (the pool cannot self-heal, #3214), `database-unreachable` means do NOT
-// restart, the fault is downstream. Before the first evaluation, and whenever the
-// watchdog is disabled, ALL series stay 0: absence of a verdict must never read
-// as 'healthy'.
+// restart, the fault is downstream. Before the first evaluation, whenever the
+// watchdog is disabled, and after a failed evaluation, ALL series stay 0.
+//
+// Note there is no `healthy` verdict to publish — the quiet one is
+// `below-threshold`, because the underlying count is a floor and pool occupancy
+// is never observed. Alert on `verdict="pool-degraded" == 1`, never on the
+// negation of a healthy series.
 const dbPoolHealthGauge = new Gauge({
   name: 'breeze_db_pool_health',
   help: '1 for the pool-health watchdog current verdict, 0 for the others (all 0 before the first evaluation)',
@@ -510,12 +516,31 @@ const dbPoolHealthGauge = new Gauge({
   registers: [register]
 });
 
-const DB_POOL_HEALTH_VERDICTS: readonly DbPoolHealthVerdict[] = [
-  'healthy',
-  'pool-degraded',
-  'database-unreachable',
-  'unknown',
-];
+// Freshness, without which the gauge above cannot be trusted. A watchdog that
+// starts throwing every tick would otherwise leave its last verdict asserted
+// indefinitely; `lastAssessment` is cleared on failure so the verdict series go
+// to 0, and this timestamp is what lets an alert require recency rather than
+// merely a value. 0 = never evaluated.
+const dbPoolHealthLastCheckGauge = new Gauge({
+  name: 'breeze_db_pool_health_last_check_timestamp_seconds',
+  help: 'Unix time of the last completed pool-health evaluation (0 = never)',
+  registers: [register]
+});
+
+const dbPoolHealthCheckFailuresGauge = new Gauge({
+  name: 'breeze_db_pool_health_check_failures_total',
+  help: 'Pool-health evaluations that threw before producing a verdict',
+  registers: [register]
+});
+
+// Each failed close is a probe socket that may have been leaked — against the
+// database the watchdog is diagnosing. Surfaced so the watchdog cannot quietly
+// become a contributor to connection exhaustion.
+const dbPoolHealthProbeCloseFailuresGauge = new Gauge({
+  name: 'breeze_db_pool_health_probe_close_failures_total',
+  help: 'Pool-health probe clients whose end() failed, each a possible leaked connection',
+  registers: [register]
+});
 
 function initializeMetricDefaults(): void {
   httpRequestsInFlight.set(0);
@@ -568,6 +593,9 @@ function initializeMetricDefaults(): void {
   for (const verdict of DB_POOL_HEALTH_VERDICTS) {
     dbPoolHealthGauge.labels(verdict).set(0);
   }
+  dbPoolHealthLastCheckGauge.set(0);
+  dbPoolHealthCheckFailuresGauge.set(0);
+  dbPoolHealthProbeCloseFailuresGauge.set(0);
 }
 
 initializeMetricDefaults();
@@ -637,6 +665,9 @@ function updateDbPoolHealthMetrics(): void {
   for (const verdict of DB_POOL_HEALTH_VERDICTS) {
     dbPoolHealthGauge.labels(verdict).set(assessment?.verdict === verdict ? 1 : 0);
   }
+  dbPoolHealthLastCheckGauge.set(assessment ? Math.floor(assessment.at / 1000) : 0);
+  dbPoolHealthCheckFailuresGauge.set(getDbPoolHealthCheckFailures());
+  dbPoolHealthProbeCloseFailuresGauge.set(getDbPoolHealthProbeCloseFailures());
 }
 
 function updateEventLoopMetrics(): void {

--- a/apps/api/src/services/dbConnectTimeoutStats.test.ts
+++ b/apps/api/src/services/dbConnectTimeoutStats.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetDbConnectTimeoutStatsForTests,
+  getDbConnectTimeoutStats,
+  recordDbConnectTimeout,
+  setDbConnectTimeoutMetricsRecorder,
+} from './dbConnectTimeoutStats';
+
+describe('dbConnectTimeoutStats (#3214)', () => {
+  beforeEach(() => {
+    __resetDbConnectTimeoutStatsForTests();
+  });
+
+  it('counts timeouts and reports a per-minute rate over the window', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 12; i += 1) {
+      recordDbConnectTimeout(new Error(`t${i}`), 'connectivity', now);
+    }
+
+    const stats = getDbConnectTimeoutStats(60_000, now);
+    expect(stats.timeouts).toBe(12);
+    expect(stats.ratePerMin).toBe(12);
+    expect(stats.byCause.connectivity).toBe(12);
+    expect(stats.totalSinceStart).toBe(12);
+  });
+
+  it('normalises the rate to per-minute for windows other than a minute', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 10; i += 1) {
+      recordDbConnectTimeout(new Error(`t${i}`), 'unknown', now);
+    }
+
+    // 10 timeouts over 5 minutes is 2/min, not 10.
+    expect(getDbConnectTimeoutStats(5 * 60_000, now).ratePerMin).toBe(2);
+  });
+
+  it('drops samples that fall outside the window', () => {
+    const start = 1_000_000;
+    recordDbConnectTimeout(new Error('old'), 'connectivity', start);
+    recordDbConnectTimeout(new Error('recent'), 'connectivity', start + 90_000);
+
+    const stats = getDbConnectTimeoutStats(60_000, start + 100_000);
+    expect(stats.timeouts).toBe(1);
+    // The lifetime total is deliberately NOT trimmed — it is the only way to
+    // tell "quiet now" apart from "never happened".
+    expect(stats.totalSinceStart).toBe(2);
+  });
+
+  it('counts the same error object only once', () => {
+    // Both production call sites (app.onError, then captureException) classify
+    // the SAME error. Without dedupe the rate would be silently 2x on the
+    // request path and 1x on the worker path, making any threshold meaningless.
+    const err = new Error('write CONNECT_TIMEOUT');
+    const now = 1_000_000;
+
+    recordDbConnectTimeout(err, 'connectivity', now);
+    recordDbConnectTimeout(err, 'connectivity', now);
+    recordDbConnectTimeout(err, 'event-loop-starvation', now);
+
+    expect(getDbConnectTimeoutStats(60_000, now).timeouts).toBe(1);
+  });
+
+  it('counts distinct error objects separately', () => {
+    const now = 1_000_000;
+    recordDbConnectTimeout(new Error('a'), 'connectivity', now);
+    recordDbConnectTimeout(new Error('b'), 'connectivity', now);
+
+    expect(getDbConnectTimeoutStats(60_000, now).timeouts).toBe(2);
+  });
+
+  it('breaks counts down by diagnosed cause', () => {
+    const now = 1_000_000;
+    recordDbConnectTimeout(new Error('a'), 'event-loop-starvation', now);
+    recordDbConnectTimeout(new Error('b'), 'event-loop-starvation', now);
+    recordDbConnectTimeout(new Error('c'), 'connectivity', now);
+    recordDbConnectTimeout(new Error('d'), 'unknown', now);
+
+    const stats = getDbConnectTimeoutStats(60_000, now);
+    expect(stats.byCause).toEqual({
+      'event-loop-starvation': 2,
+      connectivity: 1,
+      unknown: 1,
+    });
+  });
+
+  it('notifies the metrics recorder once per counted timeout', () => {
+    const onConnectTimeout = vi.fn();
+    setDbConnectTimeoutMetricsRecorder({ onConnectTimeout });
+
+    const err = new Error('dup');
+    recordDbConnectTimeout(err, 'connectivity', 1);
+    recordDbConnectTimeout(err, 'connectivity', 1); // deduped
+    recordDbConnectTimeout(new Error('other'), 'unknown', 1);
+
+    expect(onConnectTimeout).toHaveBeenCalledTimes(2);
+    expect(onConnectTimeout).toHaveBeenNthCalledWith(1, 'connectivity');
+    expect(onConnectTimeout).toHaveBeenNthCalledWith(2, 'unknown');
+  });
+
+  it('never throws when the recorder throws', () => {
+    // This runs on an error path; a throw here would displace the real failure.
+    setDbConnectTimeoutMetricsRecorder({
+      onConnectTimeout: () => {
+        throw new Error('prom-client exploded');
+      },
+    });
+
+    expect(() => recordDbConnectTimeout(new Error('x'), 'connectivity', 1)).not.toThrow();
+    // The sample is still recorded — the recorder fires last, after the push.
+    expect(getDbConnectTimeoutStats(60_000, 1).timeouts).toBe(1);
+  });
+
+  it('never throws on a frozen error object', () => {
+    const frozen = Object.freeze(new Error('frozen'));
+    expect(() => recordDbConnectTimeout(frozen, 'connectivity', 1)).not.toThrow();
+    expect(getDbConnectTimeoutStats(60_000, 1).timeouts).toBe(1);
+  });
+
+  it('records non-object throwables without a dedupe marker', () => {
+    // Primitives cannot carry the symbol. Under-counting is the accepted
+    // failure mode, so they are counted rather than dropped.
+    expect(() => recordDbConnectTimeout('CONNECT_TIMEOUT', 'unknown', 1)).not.toThrow();
+    expect(getDbConnectTimeoutStats(60_000, 1).timeouts).toBe(1);
+  });
+
+  it('does not leave an enumerable marker on the error', () => {
+    // A marker that serialized into an error body would leak internals into API
+    // responses and log payloads.
+    const err = new Error('boom');
+    recordDbConnectTimeout(err, 'connectivity', 1);
+    expect(Object.keys(err)).toEqual([]);
+    expect(JSON.stringify({ ...err })).toBe('{}');
+  });
+
+  it('falls back to the default window for a non-positive window', () => {
+    const stats = getDbConnectTimeoutStats(0, 1);
+    expect(stats.windowMs).toBe(5 * 60_000);
+  });
+});

--- a/apps/api/src/services/dbConnectTimeoutStats.test.ts
+++ b/apps/api/src/services/dbConnectTimeoutStats.test.ts
@@ -136,4 +136,63 @@ describe('dbConnectTimeoutStats (#3214)', () => {
     const stats = getDbConnectTimeoutStats(0, 1);
     expect(stats.windowMs).toBe(5 * 60_000);
   });
+
+  it('a narrow reader does not destroy a wider reader’s evidence', () => {
+    // Samples are shared module state. Trimming to the caller's own window would
+    // let a future 60s /health readout silently truncate the watchdog's 5-minute
+    // window, drop its count below threshold, and produce a below-threshold
+    // verdict during a live storm — with nothing going red.
+    const start = 1_000_000;
+    for (let i = 0; i < 20; i += 1) {
+      recordDbConnectTimeout(new Error(`t${i}`), 'connectivity', start);
+    }
+    const now = start + 120_000; // 2 minutes later
+
+    // A narrow (60s) reader sees none of them...
+    expect(getDbConnectTimeoutStats(60_000, now).timeouts).toBe(0);
+    // ...and must not have discarded them for the 5-minute reader.
+    expect(getDbConnectTimeoutStats(5 * 60_000, now).timeouts).toBe(20);
+  });
+
+  it('drops the OLDEST samples when the retention cap is hit', () => {
+    // Inverting this trim would keep the oldest and discard the newest, zeroing
+    // the rate during exactly the storm the cap exists for — while the
+    // totalSinceStart assertions elsewhere kept passing.
+    const now = 1_000_000;
+    for (let i = 0; i < 10_050; i += 1) {
+      recordDbConnectTimeout(new Error(`t${i}`), 'connectivity', now - 10_050 + i);
+    }
+
+    const stats = getDbConnectTimeoutStats(5 * 60_000, now);
+    expect(stats.timeouts).toBe(10_000);
+    expect(stats.totalSinceStart).toBe(10_050);
+  });
+
+  it('logs once — not on every call — when the recorder keeps throwing', () => {
+    // The recorder is a stable closure, so one throw means the Prometheus
+    // counter is dead for the process. Say so once: silence hides a flatlined
+    // chart during a storm, and logging every time floods.
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      setDbConnectTimeoutMetricsRecorder({
+        onConnectTimeout: () => {
+          throw new Error('prom-client exploded');
+        },
+      });
+
+      recordDbConnectTimeout(new Error('a'), 'connectivity', 1);
+      recordDbConnectTimeout(new Error('b'), 'connectivity', 1);
+      recordDbConnectTimeout(new Error('c'), 'connectivity', 1);
+
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining('breeze_db_connect_timeouts_total will not advance'),
+        expect.any(Error),
+      );
+      // The internal window is unaffected — the recorder fires after the push.
+      expect(getDbConnectTimeoutStats(60_000, 1).timeouts).toBe(3);
+    } finally {
+      error.mockRestore();
+    }
+  });
 });

--- a/apps/api/src/services/dbConnectTimeoutStats.ts
+++ b/apps/api/src/services/dbConnectTimeoutStats.ts
@@ -19,11 +19,18 @@
  * exists to warn about. Keep this file dependency-free.
  *
  * WHAT THE NUMBER IS AND IS NOT. It is a FLOOR, not an exact count. Recording
- * happens in `safeDiagnoseConnectTimeout`, which both production call sites (the
- * Hono `app.onError` handler and `services/sentry.ts`'s `captureException`) run
- * — but a background worker that swallows a DB error without reporting it will
- * not be counted. Treat a rising rate as evidence; never treat a zero as proof
- * that no timeouts occurred.
+ * happens in `safeDiagnoseConnectTimeout`, which both production call sites run:
+ * the Hono `app.onError` handler and `services/sentry.ts`'s `captureException`.
+ * The latter classifies ABOVE its `initialized` guard specifically so that
+ * worker, scheduler and unhandledRejection paths are still counted on instances
+ * with no Sentry DSN — without that, this counter saw only HTTP requests, which
+ * is the one shape the original incident did NOT have.
+ *
+ * It is still a floor: a background path that swallows a DB error without
+ * reporting it anywhere is invisible here, and the retention cap below biases
+ * down. Treat a rising rate as evidence; NEVER treat a low or zero count as
+ * proof that the pool is healthy. `db/dbPoolHealthMonitor.ts` is written to that
+ * contract — its below-threshold verdict deliberately does not say "healthy".
  */
 
 /** Causes mirror `ConnectTimeoutCause` in `services/postgresConnectTimeout.ts`. */
@@ -79,6 +86,12 @@ interface Sample {
 
 let samples: Sample[] = [];
 let totalSinceStart = 0;
+let recorderFailureLogged = false;
+/**
+ * The widest window any consumer has asked for. Retention is trimmed against
+ * THIS, never the current caller's window — see `getDbConnectTimeoutStats`.
+ */
+let maxRequestedWindowMs = DEFAULT_CONNECT_TIMEOUT_WINDOW_MS;
 
 /**
  * Marks an error object as already counted.
@@ -136,36 +149,69 @@ export function recordDbConnectTimeout(
     samples.push({ at: now, cause });
     totalSinceStart += 1;
     if (samples.length > MAX_RETAINED_SAMPLES) {
+      // Drop the OLDEST — see MAX_RETAINED_SAMPLES. Trimming the newest instead
+      // would zero the rate during exactly the storm the cap exists for.
       samples = samples.slice(samples.length - MAX_RETAINED_SAMPLES);
     }
-    recorder?.onConnectTimeout(cause);
   } catch {
     // Counting a failure must never become one.
+  }
+
+  // Separate try, and deliberately AFTER the sample is recorded: a throwing
+  // recorder must not be able to corrupt the internal window count.
+  try {
+    recorder?.onConnectTimeout(cause);
+  } catch (recorderErr) {
+    // The recorder is a stable closure over a prom-client counter, so a throw
+    // here is not one lost increment — it will throw every time, and
+    // `breeze_db_connect_timeouts_total` then flatlines at its seeded 0 for the
+    // life of the process while this module's own window keeps working. A
+    // dashboard would show a clean chart during an active storm. Latched so the
+    // condition is stated once rather than either hidden or flooding the log.
+    if (!recorderFailureLogged) {
+      recorderFailureLogged = true;
+      console.error(
+        '[db-connect-timeout-stats] metrics recorder threw; '
+        + 'breeze_db_connect_timeouts_total will not advance for the rest of this process:',
+        recorderErr,
+      );
+    }
   }
 }
 
 /**
  * Summarise the trailing `windowMs`. Trims expired samples as a side effect, so
  * a quiet process does not retain a storm from an hour ago.
+ *
+ * Retention is trimmed against the WIDEST window any caller has ever requested,
+ * not this caller's. The samples are shared module state, so trimming to the
+ * caller's own window would let a narrow reader permanently destroy evidence a
+ * wider reader depends on: a future 60s `/health` readout or debug endpoint
+ * would silently truncate the watchdog's 5-minute window, drop its count below
+ * threshold, and produce a below-threshold verdict in the middle of a live
+ * storm — with nothing going red.
  */
 export function getDbConnectTimeoutStats(
   windowMs: number = DEFAULT_CONNECT_TIMEOUT_WINDOW_MS,
   now: number = Date.now(),
 ): DbConnectTimeoutWindowStats {
   const effectiveWindowMs = windowMs > 0 ? windowMs : DEFAULT_CONNECT_TIMEOUT_WINDOW_MS;
+  maxRequestedWindowMs = Math.max(maxRequestedWindowMs, effectiveWindowMs);
+  samples = samples.filter((s) => s.at >= now - maxRequestedWindowMs);
+
   const cutoff = now - effectiveWindowMs;
-  samples = samples.filter((s) => s.at >= cutoff);
+  const inWindow = samples.filter((s) => s.at >= cutoff);
 
   const byCause: Record<DbConnectTimeoutCause, number> = {
     'event-loop-starvation': 0,
     connectivity: 0,
     unknown: 0,
   };
-  for (const s of samples) {
+  for (const s of inWindow) {
     byCause[s.cause] += 1;
   }
 
-  const timeouts = samples.length;
+  const timeouts = inWindow.length;
   return {
     timeouts,
     byCause,
@@ -179,4 +225,6 @@ export function __resetDbConnectTimeoutStatsForTests(): void {
   samples = [];
   totalSinceStart = 0;
   recorder = null;
+  recorderFailureLogged = false;
+  maxRequestedWindowMs = DEFAULT_CONNECT_TIMEOUT_WINDOW_MS;
 }

--- a/apps/api/src/services/dbConnectTimeoutStats.ts
+++ b/apps/api/src/services/dbConnectTimeoutStats.ts
@@ -1,0 +1,182 @@
+/**
+ * A rolling count of Postgres CONNECT_TIMEOUT errors (#3214).
+ *
+ * WHY THIS EXISTS. When a pooled postgres.js connection is poisoned (see
+ * `db/postgresJsPoolPoisoning.test.ts` for the mechanism), the only externally
+ * visible symptom is a sustained stream of `write CONNECT_TIMEOUT` errors while
+ * the database itself is perfectly healthy. In the incident behind #3214 that
+ * stream ran at ~144/min for hours. It was never a first-class signal: it
+ * existed only as individual Sentry events and console lines, so nobody could
+ * see the RATE, and the pool decayed from 35 live connections to 9 before a
+ * human noticed. This module makes the rate observable, which is what
+ * `db/dbPoolHealthMonitor.ts` alerts on and what `/metrics` exports.
+ *
+ * WHY IT IS A ZERO-IMPORT LEAF. It is called from
+ * `services/postgresConnectTimeout.ts`, which is itself in the module graph of
+ * `services/sentry.ts` and of `db/requestDatabasePool.test.ts` (a suite under a
+ * hard 15s budget). Importing anything from `db/` here would recreate the
+ * `services -> db` back-edge that the connect-timeout classifier's docblock
+ * exists to warn about. Keep this file dependency-free.
+ *
+ * WHAT THE NUMBER IS AND IS NOT. It is a FLOOR, not an exact count. Recording
+ * happens in `safeDiagnoseConnectTimeout`, which both production call sites (the
+ * Hono `app.onError` handler and `services/sentry.ts`'s `captureException`) run
+ * — but a background worker that swallows a DB error without reporting it will
+ * not be counted. Treat a rising rate as evidence; never treat a zero as proof
+ * that no timeouts occurred.
+ */
+
+/** Causes mirror `ConnectTimeoutCause` in `services/postgresConnectTimeout.ts`. */
+export type DbConnectTimeoutCause = 'event-loop-starvation' | 'connectivity' | 'unknown';
+
+export interface DbConnectTimeoutWindowStats {
+  /** Timeouts recorded within `windowMs` of `now`. */
+  timeouts: number;
+  /** Per-cause breakdown of `timeouts`. Always has all three keys. */
+  byCause: Record<DbConnectTimeoutCause, number>;
+  /** The window the counts cover, in ms. */
+  windowMs: number;
+  /** `timeouts` normalised to a per-minute rate over `windowMs`. */
+  ratePerMin: number;
+  /** Total recorded since process start (never trimmed). Monotonic. */
+  totalSinceStart: number;
+}
+
+/**
+ * Notified once per recorded timeout so `routes/metrics.ts` can drive a
+ * Prometheus counter without this leaf module importing `prom-client`. Same
+ * inversion the action-intent metrics use.
+ */
+export interface DbConnectTimeoutMetricsRecorder {
+  onConnectTimeout(cause: DbConnectTimeoutCause): void;
+}
+
+let recorder: DbConnectTimeoutMetricsRecorder | null = null;
+
+export function setDbConnectTimeoutMetricsRecorder(
+  next: DbConnectTimeoutMetricsRecorder | null,
+): void {
+  recorder = next;
+}
+
+/**
+ * Hard cap on retained samples. The window is time-based, but a pathological
+ * storm (the incident ran at ~144/min; a worse one is imaginable) must not grow
+ * the array without bound between trims. At the default 5-minute window this is
+ * ~13x headroom over the observed incident rate. Once the cap is hit the OLDEST
+ * samples are dropped, which biases the count DOWN — consistent with the
+ * "floor, never an overcount" contract above.
+ */
+const MAX_RETAINED_SAMPLES = 10_000;
+
+/** Default window. Long enough to smooth a bursty stream, short enough to react. */
+export const DEFAULT_CONNECT_TIMEOUT_WINDOW_MS = 5 * 60_000;
+
+interface Sample {
+  at: number;
+  cause: DbConnectTimeoutCause;
+}
+
+let samples: Sample[] = [];
+let totalSinceStart = 0;
+
+/**
+ * Marks an error object as already counted.
+ *
+ * Both production call sites classify the SAME error object: `app.onError`
+ * diagnoses it for the console line, then `captureException` diagnoses it again
+ * for the Sentry tags. Without this, every request-path timeout would count
+ * twice while every worker-path timeout counted once — a rate metric that is
+ * silently 2x wrong on part of its input is worse than no rate metric, because
+ * an alert threshold tuned on it means nothing.
+ *
+ * A Symbol (not a property name) so it cannot collide with driver or Drizzle
+ * fields, and non-enumerable so it never leaks into a serialized error body.
+ */
+const COUNTED = Symbol.for('breeze.dbConnectTimeoutCounted');
+
+function alreadyCounted(err: unknown): boolean {
+  if (err === null || (typeof err !== 'object' && typeof err !== 'function')) {
+    // Primitives cannot carry the marker. Count them; they are vanishingly rare
+    // and under-counting is the failure mode we accept, not double-counting.
+    return false;
+  }
+  try {
+    const target = err as Record<PropertyKey, unknown>;
+    if (target[COUNTED] === true) return true;
+    Object.defineProperty(target, COUNTED, {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: true,
+    });
+    return false;
+  } catch {
+    // Frozen or exotic error (a Proxy with a throwing trap). Falling through to
+    // "not yet counted" risks a double count for that one object; refusing to
+    // count it at all would lose the signal entirely. Prefer the signal.
+    return false;
+  }
+}
+
+/**
+ * Record one CONNECT_TIMEOUT. Idempotent per error object (see `COUNTED`).
+ * Never throws: this runs on an error path, where a throw would displace the
+ * original failure.
+ *
+ * `now` is injectable for tests; production omits it.
+ */
+export function recordDbConnectTimeout(
+  err: unknown,
+  cause: DbConnectTimeoutCause,
+  now: number = Date.now(),
+): void {
+  try {
+    if (alreadyCounted(err)) return;
+    samples.push({ at: now, cause });
+    totalSinceStart += 1;
+    if (samples.length > MAX_RETAINED_SAMPLES) {
+      samples = samples.slice(samples.length - MAX_RETAINED_SAMPLES);
+    }
+    recorder?.onConnectTimeout(cause);
+  } catch {
+    // Counting a failure must never become one.
+  }
+}
+
+/**
+ * Summarise the trailing `windowMs`. Trims expired samples as a side effect, so
+ * a quiet process does not retain a storm from an hour ago.
+ */
+export function getDbConnectTimeoutStats(
+  windowMs: number = DEFAULT_CONNECT_TIMEOUT_WINDOW_MS,
+  now: number = Date.now(),
+): DbConnectTimeoutWindowStats {
+  const effectiveWindowMs = windowMs > 0 ? windowMs : DEFAULT_CONNECT_TIMEOUT_WINDOW_MS;
+  const cutoff = now - effectiveWindowMs;
+  samples = samples.filter((s) => s.at >= cutoff);
+
+  const byCause: Record<DbConnectTimeoutCause, number> = {
+    'event-loop-starvation': 0,
+    connectivity: 0,
+    unknown: 0,
+  };
+  for (const s of samples) {
+    byCause[s.cause] += 1;
+  }
+
+  const timeouts = samples.length;
+  return {
+    timeouts,
+    byCause,
+    windowMs: effectiveWindowMs,
+    ratePerMin: (timeouts * 60_000) / effectiveWindowMs,
+    totalSinceStart,
+  };
+}
+
+export function __resetDbConnectTimeoutStatsForTests(): void {
+  samples = [];
+  totalSinceStart = 0;
+  recorder = null;
+}

--- a/apps/api/src/services/postgresConnectTimeout.test.ts
+++ b/apps/api/src/services/postgresConnectTimeout.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import {
+  getDbConnectTimeoutStats,
+  __resetDbConnectTimeoutStatsForTests,
+} from './dbConnectTimeoutStats';
 import {
   CONNECT_TIMEOUT_CODE,
   POSTGRES_CONNECT_TIMEOUT_SECONDS,
@@ -225,5 +229,53 @@ describe('safeDiagnoseConnectTimeout', () => {
     const err = connectTimeoutError();
     expect(safeDiagnoseConnectTimeout(err)?.cause).toBe(diagnoseConnectTimeout(err)?.cause);
     expect(safeDiagnoseConnectTimeout(new Error('unrelated'))).toBeNull();
+  });
+});
+
+describe('safeDiagnoseConnectTimeout feeds the #3214 rolling counter', () => {
+  beforeEach(() => {
+    __resetDbConnectTimeoutStatsForTests();
+  });
+
+  afterEach(() => {
+    __resetDbConnectTimeoutStatsForTests();
+  });
+
+  it('records a connect timeout', () => {
+    // This wrapper is the ONLY feed into the counter the pool-health watchdog
+    // alerts on. Remove the recording call and the watchdog reads an empty
+    // window forever — reporting below-threshold straight through an incident,
+    // with nothing else going red.
+    safeDiagnoseConnectTimeout(connectTimeoutError());
+    expect(getDbConnectTimeoutStats(60_000).timeouts).toBe(1);
+  });
+
+  it('does NOT record an unrelated error', () => {
+    // Without the `if (diagnosis)` guard every API error would count as a
+    // connect timeout, so the watchdog would probe and alert continuously.
+    safeDiagnoseConnectTimeout(new Error('unrelated'));
+    safeDiagnoseConnectTimeout(new TypeError('also unrelated'));
+    expect(getDbConnectTimeoutStats(60_000).timeouts).toBe(0);
+  });
+
+  it('records a Drizzle-wrapped connect timeout too', () => {
+    safeDiagnoseConnectTimeout(drizzleWrapped(connectTimeoutError()));
+    expect(getDbConnectTimeoutStats(60_000).timeouts).toBe(1);
+  });
+
+  it('counts one error object once even when classified twice', () => {
+    // app.onError classifies, then captureException classifies the same object.
+    const err = connectTimeoutError();
+    safeDiagnoseConnectTimeout(err);
+    safeDiagnoseConnectTimeout(err);
+    expect(getDbConnectTimeoutStats(60_000).timeouts).toBe(1);
+  });
+
+  it('records the diagnosed cause, not a fixed one', () => {
+    safeDiagnoseConnectTimeout(connectTimeoutError());
+    const stats = getDbConnectTimeoutStats(60_000);
+    // With no event-loop monitor running, diagnosis is correctly 'unknown'.
+    expect(stats.byCause.unknown).toBe(1);
+    expect(stats.byCause.connectivity).toBe(0);
   });
 });

--- a/apps/api/src/services/postgresConnectTimeout.ts
+++ b/apps/api/src/services/postgresConnectTimeout.ts
@@ -37,6 +37,7 @@
  */
 
 import { pgErrorCode } from '../utils/pgErrors';
+import { recordDbConnectTimeout } from './dbConnectTimeoutStats';
 import {
   bucketEventLoopLag,
   getEventLoopStarvationThresholdMs,
@@ -200,7 +201,15 @@ function describe(
  */
 export function safeDiagnoseConnectTimeout(err: unknown): ConnectTimeoutDiagnosis | null {
   try {
-    return diagnoseConnectTimeout(err);
+    const diagnosis = diagnoseConnectTimeout(err);
+    // Feed the rolling rate (#3214). Deliberately here and not in
+    // `diagnoseConnectTimeout`: this wrapper is what BOTH production call sites
+    // use, whereas the bare classifier is also called directly by its own unit
+    // tests, which must not mutate process-wide counters. `recordDbConnectTimeout`
+    // is idempotent per error object, so the two call sites seeing the same
+    // error (onError, then captureException) count it once.
+    if (diagnosis) recordDbConnectTimeout(err, diagnosis.cause);
+    return diagnosis;
   } catch {
     // Diagnosis is commentary on someone else's failure; it must never become
     // the failure. Silence here costs two Sentry tags and a log line.

--- a/apps/api/src/services/sentry.test.ts
+++ b/apps/api/src/services/sentry.test.ts
@@ -403,6 +403,7 @@ describe('scrubEvent', () => {
         prior_status: 'failed:server-timeout',
         connect_timeout_cause: 'event-loop-starvation',
         event_loop_lag_bucket: 'over-10s',
+        db_pool_health_verdict: 'pool-degraded',
         path: '/public/quotes/raw-capability',
         arbitrary: 'raw-capability',
       },
@@ -455,6 +456,11 @@ describe('scrubEvent', () => {
       // invisible in Sentry, which is the entire point of adding it.
       connect_timeout_cause: 'event-loop-starvation',
       event_loop_lag_bucket: 'over-10s',
+      // #3214: scrubEvent deletes message/logentry/extra from every event, so
+      // this tag is the ONLY part of a pool-health capture that reaches Sentry —
+      // and it is the field that decides whether the operator restarts the API.
+      // Dropped here, the watchdog's alerts arrive as contentless blanks.
+      db_pool_health_verdict: 'pool-degraded',
     });
     expect(out.exception).toEqual({
       values: [{

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -73,6 +73,15 @@ const ALLOWED_TAG_NAMES = new Set([
   // bucketEventLoopLag); neither carries a tenant, device, or host identifier.
   'connect_timeout_cause',
   'event_loop_lag_bucket',
+  // #3214: the pool-health watchdog's verdict is the ONLY part of its report
+  // that can survive to Sentry — `scrubEvent` deletes `message`, `logentry` and
+  // `extra` from every event, so an unallowlisted verdict would arrive as a
+  // contentless, ungroupable blank. It is also the field that decides the
+  // operator's action: `pool-degraded` means restart the API, and
+  // `database-unreachable` means explicitly do not. Closed 5-value set
+  // (DB_POOL_HEALTH_VERDICTS plus the `check-failed` self-report); carries no
+  // tenant, device, or host identifier.
+  'db_pool_health_verdict',
 ]);
 const UNSAFE_TAG_CHARACTERS = /[/?#\r\n]/;
 const SAFE_STRUCTURAL_NAME = /^[A-Za-z_$<][A-Za-z0-9_.$<>:[\] ]{0,127}$/;

--- a/apps/api/src/services/sentry.ts
+++ b/apps/api/src/services/sentry.ts
@@ -294,6 +294,25 @@ export function captureException(
   c?: Context,
   tags?: Record<string, string>,
 ): void {
+  // Classify BEFORE the init guard. The classifier is no longer only a tag
+  // source: it also feeds the rolling CONNECT_TIMEOUT rate that the #3214
+  // pool-health watchdog alerts on. Left below the guard, that counter was blind
+  // on every instance without a DSN — the self-hosted default — because
+  // `app.onError` was then its only feed, and every worker, scheduler,
+  // unhandledRejection and agent-WS path contributed nothing. That is precisely
+  // the profile of the original incident (see the note below: the loudest
+  // signature was the patch scheduler, not any route), so a watchdog fed only by
+  // the request path would have reported the pool healthy right through it.
+  //
+  // Guarded, because this now runs on instances where nothing else in this
+  // function does: a classifier fault must cost two tags, never the report.
+  let diagnosis: ConnectTimeoutDiagnosis | null = null;
+  try {
+    diagnosis = connectTimeoutClassifier?.(err) ?? null;
+  } catch {
+    // Classification is diagnostic only — never let it displace the report.
+  }
+
   if (!initialized) {
     return;
   }
@@ -321,24 +340,16 @@ export function captureException(
       }
     }
 
-    // #3022. Tagged HERE rather than in the HTTP error handler because a
+    // #3022. Classified HERE rather than in the HTTP error handler because a
     // CONNECT_TIMEOUT is just as likely to surface from a BullMQ worker as from
     // a request — in the original incident the loudest signature in Sentry was
     // the patch scheduler, not any route. captureException is the one chokepoint
-    // every path already goes through, so tagging it here covers all of them.
-    // The injected classifier is expected to be the never-throwing
-    // `safeDiagnoseConnectTimeout`, but this is the last line before an error
-    // report is emitted, so it is guarded here too: a classifier fault must cost
-    // two tags, never the report itself. `Sentry.captureException` below is
-    // deliberately outside the try.
-    try {
-      const diagnosis = connectTimeoutClassifier?.(err) ?? null;
-      if (diagnosis) {
-        scope.setTag('connect_timeout_cause', diagnosis.cause);
-        scope.setTag('event_loop_lag_bucket', diagnosis.lagBucket);
-      }
-    } catch {
-      // Classification is diagnostic only — never let it displace the report.
+    // every path already goes through, so covering it here covers all of them.
+    // The classification itself now happens above the `initialized` guard (see
+    // there for why); this only applies its result.
+    if (diagnosis) {
+      scope.setTag('connect_timeout_cause', diagnosis.cause);
+      scope.setTag('event_loop_lag_bucket', diagnosis.lagBucket);
     }
 
     Sentry.captureException(err);

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -222,6 +222,49 @@ an unauthenticated prober measure whether its own traffic is starving the
 instance. Readiness is also not gated on lag — starvation is a load symptom, and
 failing readiness under load would shift traffic onto peers and starve those too.
 
+### Database pool-health watchdog
+
+The API's Postgres driver (postgres.js) can leave a pooled connection permanently
+unable to reconnect if that connection's socket dies while a write is still
+buffered. The affected pool slot then retries forever, failing every time with
+`write CONNECT_TIMEOUT` — **against a database that is completely healthy**. Slots
+are lost one at a time, so the pool decays over hours until most queries fail at
+connect. Nothing in the API can repair it: only restarting the API process
+recovers the pool.
+
+The watchdog exists because that failure is very easy to misread as a database
+outage. When the `CONNECT_TIMEOUT` rate breaches the threshold, it opens **one
+brand-new connection** to the same database, outside the pool. A fresh connection
+is unaffected by the defect, so the result separates the two causes:
+
+- the fresh connection **succeeds** → the database is fine and the **pool** is
+  broken. Restart the API.
+- the fresh connection **also fails** → a genuine database, network, TLS, or auth
+  fault. Restarting the API will not help.
+
+The verdict is logged and sent to Sentry (throttled), and exported on
+`/metrics/scrape` as `breeze_db_pool_health{verdict="…"}` alongside
+`breeze_db_connect_timeouts_total{cause="…"}` and
+`breeze_db_connect_timeout_rate_per_min`. Before the first evaluation every
+verdict series reads `0` — absence of a verdict is not the same as a healthy
+pool, so alert on `breeze_db_pool_health{verdict="pool-degraded"} == 1` rather
+than on the negation of `healthy`.
+
+The watchdog runs by default; you do not need to set any of these.
+
+| Variable | Default | Description |
+|---|---|---|
+| `DB_POOL_HEALTH_INTERVAL_MS` | `60000` | How often the watchdog evaluates. Floored at 5000. |
+| `DB_POOL_HEALTH_WINDOW_MS` | `300000` | Trailing window the `CONNECT_TIMEOUT` count is taken over. Floored at 30000. |
+| `DB_POOL_HEALTH_MIN_TIMEOUTS` | `10` | Timeouts within the window that trigger the fresh-connection probe. Below this, no probe runs and no connection is opened. |
+| `DB_POOL_HEALTH_PROBE_TIMEOUT_MS` | `5000` | Hard bound on the probe. Keep it well under the interval so a slow probe cannot overlap the next tick. |
+| `DB_POOL_HEALTH_CAPTURE_THROTTLE_MS` | `900000` | Minimum gap between Sentry captures of the same verdict. A degraded pool stays degraded until restart, so an unthrottled capture would report it every tick. `0` disables the throttle. Console logging is never throttled. |
+| `DB_POOL_HEALTH_DISABLED` | — | Set to `1`, `true`, `yes`, or `on` to turn the watchdog off. With it off, a poisoned pool decays silently until someone notices the 503s. |
+
+Like event-loop lag, these figures are kept off the unauthenticated
+`/health/ready` for the same reason — they describe how close the instance is to
+falling over.
+
 ## Sentry
 
 Both API and web Sentry integrations are off by default. Leave the DSN variables blank to disable. See [Error Tracking & Privacy](/security/error-tracking/) for what gets collected and how scrubbing works.

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -242,7 +242,11 @@ is unaffected by the defect, so the result separates the two causes:
 - the fresh connection **also fails** → a genuine database, network, TLS, or auth
   fault. Restarting the API will not help.
 
-The verdict is logged and sent to Sentry (throttled), and exported on
+The full verdict — with counts, rates and probe timing — is written to the
+container log. Sentry receives a throttled event carrying the
+`db_pool_health_verdict` tag only; Breeze strips message text and structured
+extras from every outgoing Sentry event, so treat Sentry as the alert channel
+and the log or `/metrics` as the detail. The numbers are exported on
 `/metrics/scrape`:
 
 | Series | Meaning |
@@ -251,8 +255,8 @@ The verdict is logged and sent to Sentry (throttled), and exported on
 | `breeze_db_connect_timeouts_total{cause="…"}` | Connect timeouts by diagnosed cause (`connectivity`, `event-loop-starvation`, `unknown`). |
 | `breeze_db_connect_timeout_rate_per_min` | The rate the watchdog evaluates. |
 | `breeze_db_pool_health_last_check_timestamp_seconds` | When the last evaluation completed. `0` = never. |
-| `breeze_db_pool_health_check_failures_total` | Evaluations that threw before producing a verdict. |
-| `breeze_db_pool_health_probe_close_failures_total` | Probe clients whose close failed — each a possible leaked connection. |
+| `breeze_db_pool_health_check_failures` | Evaluations that threw before producing a verdict. |
+| `breeze_db_pool_health_probe_close_failures` | Probe clients whose close failed — each a possible leaked connection. |
 
 **Alert on `breeze_db_pool_health{verdict="pool-degraded"} == 1`.** There is
 deliberately no `healthy` verdict: the quiet one is `below-threshold`, because

--- a/apps/docs/src/content/docs/deploy/environment.mdx
+++ b/apps/docs/src/content/docs/deploy/environment.mdx
@@ -243,12 +243,25 @@ is unaffected by the defect, so the result separates the two causes:
   fault. Restarting the API will not help.
 
 The verdict is logged and sent to Sentry (throttled), and exported on
-`/metrics/scrape` as `breeze_db_pool_health{verdict="…"}` alongside
-`breeze_db_connect_timeouts_total{cause="…"}` and
-`breeze_db_connect_timeout_rate_per_min`. Before the first evaluation every
-verdict series reads `0` — absence of a verdict is not the same as a healthy
-pool, so alert on `breeze_db_pool_health{verdict="pool-degraded"} == 1` rather
-than on the negation of `healthy`.
+`/metrics/scrape`:
+
+| Series | Meaning |
+|---|---|
+| `breeze_db_pool_health{verdict="…"}` | `1` for the current verdict, `0` for the others. Verdicts are `below-threshold`, `pool-degraded`, `database-unreachable`, `unknown`. |
+| `breeze_db_connect_timeouts_total{cause="…"}` | Connect timeouts by diagnosed cause (`connectivity`, `event-loop-starvation`, `unknown`). |
+| `breeze_db_connect_timeout_rate_per_min` | The rate the watchdog evaluates. |
+| `breeze_db_pool_health_last_check_timestamp_seconds` | When the last evaluation completed. `0` = never. |
+| `breeze_db_pool_health_check_failures_total` | Evaluations that threw before producing a verdict. |
+| `breeze_db_pool_health_probe_close_failures_total` | Probe clients whose close failed — each a possible leaked connection. |
+
+**Alert on `breeze_db_pool_health{verdict="pool-degraded"} == 1`.** There is
+deliberately no `healthy` verdict: the quiet one is `below-threshold`, because
+the underlying count only sees timeouts that reach an error handler and the
+watchdog never observes pool slot occupancy. It can tell you something is wrong;
+it cannot certify that nothing is. For the same reason, all verdict series read
+`0` before the first evaluation and after a failed one — never infer health from
+the absence of a bad verdict, and pair any alert with a freshness check on
+`breeze_db_pool_health_last_check_timestamp_seconds`.
 
 The watchdog runs by default; you do not need to set any of these.
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -90,6 +90,16 @@ services:
       DATABASE_URL_APP: ${DATABASE_URL_APP:-}
       BREEZE_APP_DB_PASSWORD: ${BREEZE_APP_DB_PASSWORD:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+      # Pool-health watchdog (#3214). Threaded because deploy/environment.mdx
+      # documents these as working knobs, and an unmapped var set in .env is
+      # silently inert — the IS_HOSTED / #570 failure mode. All optional: an
+      # empty value reads as unset and the code applies its own defaults.
+      DB_POOL_HEALTH_DISABLED: ${DB_POOL_HEALTH_DISABLED:-}
+      DB_POOL_HEALTH_INTERVAL_MS: ${DB_POOL_HEALTH_INTERVAL_MS:-}
+      DB_POOL_HEALTH_WINDOW_MS: ${DB_POOL_HEALTH_WINDOW_MS:-}
+      DB_POOL_HEALTH_MIN_TIMEOUTS: ${DB_POOL_HEALTH_MIN_TIMEOUTS:-}
+      DB_POOL_HEALTH_PROBE_TIMEOUT_MS: ${DB_POOL_HEALTH_PROBE_TIMEOUT_MS:-}
+      DB_POOL_HEALTH_CAPTURE_THROTTLE_MS: ${DB_POOL_HEALTH_CAPTURE_THROTTLE_MS:-}
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD_FILE: /run/secrets/redis_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,16 @@ services:
       DATABASE_URL_APP: ${DATABASE_URL_APP:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       BREEZE_APP_DB_PASSWORD: ${BREEZE_APP_DB_PASSWORD:-}
+      # Pool-health watchdog (#3214). Threaded because deploy/environment.mdx
+      # documents these as working knobs, and an unmapped var set in .env is
+      # silently inert — the IS_HOSTED / #570 failure mode. All optional: an
+      # empty value reads as unset and the code applies its own defaults.
+      DB_POOL_HEALTH_DISABLED: ${DB_POOL_HEALTH_DISABLED:-}
+      DB_POOL_HEALTH_INTERVAL_MS: ${DB_POOL_HEALTH_INTERVAL_MS:-}
+      DB_POOL_HEALTH_WINDOW_MS: ${DB_POOL_HEALTH_WINDOW_MS:-}
+      DB_POOL_HEALTH_MIN_TIMEOUTS: ${DB_POOL_HEALTH_MIN_TIMEOUTS:-}
+      DB_POOL_HEALTH_PROBE_TIMEOUT_MS: ${DB_POOL_HEALTH_PROBE_TIMEOUT_MS:-}
+      DB_POOL_HEALTH_CAPTURE_THROTTLE_MS: ${DB_POOL_HEALTH_CAPTURE_THROTTLE_MS:-}
       REDIS_HOST: redis
       REDIS_PORT: 6379
       REDIS_PASSWORD_FILE: /run/secrets/redis_password


### PR DESCRIPTION
Closes #3214

## Root cause — found, reproduced, and pinned

The issue listed the `Immediate.nextWrite` TypeError as a *likely* poisoner. It is the whole story, and the mechanism is now reproduced deterministically with no database, no network and no timing luck (`apps/api/src/db/postgresJsPoolPoisoning.test.ts`).

In **postgres.js 3.4.9** (`src/connection.js`), small writes are batched behind a `setImmediate`, guarded by an "already scheduled?" check:

```js
function write(x, fn) {                                        // :246
  chunk = chunk ? Buffer.concat([chunk, x]) : Buffer.from(x)
  if (fn || chunk.length >= 1024)
    return nextWrite(fn)
  nextWriteTimer === null && (nextWriteTimer = setImmediate(nextWrite))
  return true
}

function nextWrite(fn) {                                       // :254
  const x = socket.write(chunk, fn)
  nextWriteTimer !== null && clearImmediate(nextWriteTimer)
  chunk = nextWriteTimer = null                                // <- the ONLY reset
  return x
}
```

`nextWrite` actually running is the only thing that ever resets `nextWriteTimer`. But both teardown paths cancel the immediate **without clearing the variable**, and without dropping the buffered `chunk`:

```js
function terminate()            { ... clearImmediate(nextWriteTimer) ... }        // :427
async function closed(hadError) { ... clearImmediate(nextWriteTimer) ...          // :440
                                      socket = null ... }
```

So a connection whose socket dies with a deferred write pending is left with `nextWriteTimer` permanently non-null. The guard at `:250` is false forever after, no flush is ever scheduled again, and the `StartupMessage` written by `connected()` on **every** subsequent reconnect is appended to `chunk` and never reaches the socket. The handshake cannot complete, `connect_timeout` expires, `connectTimedOut()` reports `CONNECT_TIMEOUT` and destroys the socket, `closed()` reconnects — forever.

That accounts for every symptom in the report:

| Observation | Explanation |
|---|---|
| `TLSSocket.closed` errors starting days early | each one poisons one pool slot |
| pool decay 35 → 9 over hours | slots poisoned cumulatively, never recovered |
| ~144 `CONNECT_TIMEOUT`/min against a healthy DB | poisoned slots reconnect-looping |
| `Immediate.nextWrite` TypeError | the same broken lifecycle (`socket` nulled / stale `chunk`) |
| restart fixes it in seconds | fresh closures |

**Verification of the repro** — the control (undisturbed connection) writes 77 bytes of `StartupMessage`; kill the socket while the flush is queued and the *reconnect* writes **0 bytes**.

## Suggested fix #1 — answered, and it is a dead end

> *check whether postgres.js > 3.4.9 fixes it, or file upstream*

**3.4.9 is the latest published release.** `npm view postgres version` → `3.4.9`. There is nothing to bump to, and the broken state lives inside a closure that nothing outside the driver can reach. The reproduction in this PR is dependency-free and ready to attach to an upstream report.

## What this PR ships (fixes #2 and #3)

**`apps/api/src/services/dbConnectTimeoutStats.ts`** — a rolling `CONNECT_TIMEOUT` count, fed from `safeDiagnoseConnectTimeout` (the wrapper both production call sites already use). Deduped per error object with a `Symbol`, because `app.onError` and `captureException` classify the *same* error — without that the rate would be silently 2x on the request path and 1x on the worker path, making any threshold meaningless. Zero-import leaf, so it does not recreate the `services → db` back-edge the classifier's docblock warns about.

**`apps/api/src/db/dbPoolHealthMonitor.ts`** — the watchdog. A sustained timeout rate on its own is ambiguous: unreachable DB and poisoned pool look identical. So when the rate breaches the threshold it opens **one brand-new connection** to the same database, outside the pool. A fresh client has fresh closures and is immune to the poisoning:

- fresh connection **succeeds** → `pool-degraded`: the DB is fine, the pool is not, **restart the API**
- fresh connection **fails too** → `database-unreachable`: real fault, **restarting will not help**
- probe could not be *attempted* → `unknown`, explicitly refusing to blame either

That is exactly the manual step that ended the incident ("`psql` from the same host connected in under a second"), performed automatically. Steady state costs one unref'd timer tick — the probe only opens a socket once the threshold is already breached.

**`apps/api/src/routes/metrics.ts`** — `breeze_db_connect_timeouts_total{cause}`, `breeze_db_connect_timeout_rate_per_min`, `breeze_db_pool_health{verdict}`. Seeded at 0 so alert rules never query a nonexistent series. All verdict series stay 0 before the first evaluation — absence of a verdict must not read as `healthy`.

Plus `.env.example` + `deploy/environment.mdx` for the six new knobs, and a bootstrap-wiring guard (`dbPoolHealthWiring.test.ts`) — a watchdog that is defined but never started fails completely silently, which is how this class of blindness ships.

## What I did NOT do, and why

- **Recycling the `sql` instance.** The issue offers this as optional; I left it out. `db/index.ts` hands the client to Drizzle at module load, and the resulting `baseDb` is captured by the exported proxy, by every open `withDbAccessContext` transaction, and by the AsyncLocalStorage stores. A mid-flight swap would abort in-flight tenant transactions, and a bug in it is a whole-API outage — a worse failure than the one being fixed. Wants its own PR.
- **Patching the driver in `node_modules`.** The actual repair is ~2 lines (reset `chunk`/`nextWriteTimer` in `closed()` and `terminate()`), and the pin test would prove it. I left it out: this repo has **no** `patchedDependencies` today, so it would be the first — introduced on the DB driver, touching the Docker and CI install surface, and I cannot validate a driver-lifecycle patch against real production traffic from here. It deserves a dedicated PR with deploy validation.
- **Anything that claims to fix the pool.** This PR makes the failure *visible and correctly attributed*. It does not repair it. `pool-degraded` still means someone restarts the API.

The pin test is deliberately asserting the **bug**. The day the driver is fixed or patched, it goes red with a message naming exactly what to delete (the pin and the watchdog).

## Review round

Three passes (`code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer`) found real defects, all sharing one shape — the change reintroduced, in its own code, the blindness it exists to remove. Fixed in `914926027`:

- **`captureException` classified connect timeouts *below* its `initialized` guard.** On any instance without a Sentry DSN — the self-hosted default — `app.onError` was the counter's only feed, so every worker, scheduler and `unhandledRejection` path contributed nothing. That is exactly the incident's profile ("the loudest signature in Sentry was the patch scheduler, not any route"), meaning the watchdog would have reported the pool fine right through it. Classification now happens above the guard.
- **The quiet verdict `healthy` is now `below-threshold`.** The count is a documented floor and slot occupancy is never observed, so an affirmative all-clear was a claim the evidence cannot support. There is deliberately no `healthy` series to alert on the negation of.
- **A failed evaluation left the previous verdict standing**, so `/metrics` republished a stale reading for hours about a dead watchdog. It now clears the verdict, counts the failure, and reports itself to Sentry (it was console-only).
- **A probe timeout under event-loop starvation reported `database-unreachable`** with "restarting will not help" attached — the #3022 misdirection one layer up, since the probe's own budget needs the same blocked loop. Now a distinct error type and an `unknown` verdict.
- **In-flight guard + probe budget clamped to half the interval.** Legal env combinations (`INTERVAL=5000, PROBE=30000`) could stack probes, each opening another connection to the database being diagnosed. Probe close failures are now counted, not silently swallowed.
- Stable Sentry title (interpolated rates minted a new issue per capture, so no alert bound to one could fire twice), a suppressed-since-last-capture count, and sample retention that trims to the widest window any reader requested rather than the caller's.
- **The six `DB_POOL_HEALTH_*` vars are threaded through both compose files.** The docs promise they work, and an unmapped var set in `.env` is silently inert (the IS_HOSTED / #570 failure mode).

### Tests

The test pass found that **five mutations survived the entire suite**: deleting the counter feed, the recorder binding, the scrape refresh, the interval body, or the throttle guard all stayed green — i.e. every line of production wiring could be removed without CI noticing. Each is now covered, and I re-applied the mutations to confirm they fail. Also added hermetic tests for the real probe (no database needed) and a **negative control** on the driver pin, so "the reconnect wrote nothing" now demonstrably means "*because* the socket died with a buffered write" rather than for any unrelated reason.

### Second review round (delta re-review)

Because the first round's fixes touched `captureException` — every error path in the API — the delta got its own pass. Three more real findings, fixed in `57898f941`:

- **The Sentry captures were arriving contentless.** `scrubEvent` deletes `message`, `logentry` and `extra` from *every* outgoing event, and my tag key was not in `ALLOWED_TAG_NAMES` — so it was dropped twice over. A `pool-degraded` alert reached Sentry as an unlabelled blank that grouped with every other blank. The verdict is now allowlisted as `db_pool_health_verdict` (the same precedent `connect_timeout_cause` set for #3022), with a scrubber test proving it survives. The docs no longer claim more than Sentry actually receives.
- **The probe-timeout downgrade tested the wrong direction.** It asked "does starvation dominate?", which leaves open exactly the hole it exists to close: with the event-loop monitor disabled or warming up, *every* timeout classifies as `unknown`, so the starvation count is 0, no dominance is found, and the confident `database-unreachable` fires in the configuration with the least evidence. Now inverted to require positive evidence *for* connectivity.
- **A throwing `captureMessage` erased a valid verdict.** It fell through to the outer catch, which (correctly) clears `lastAssessment` — so a reporter fault would blank a real degraded verdict from `/metrics` at the moment it fired.

Plus: the two failure counters were `Gauge`s carrying the `_total` suffix OpenMetrics reserves for counters (renamed), and the check-failed key never drained its suppressed count.

## Verification

- `vitest run src/db src/services src/routes/metrics.test.ts src/config/envComposeParity.test.ts --no-file-parallelism` → **622 files, 10084 passed, 35 skipped**
- `tsc --noEmit -p apps/api/tsconfig.json` (with the CI `--max-old-space-size=8192`) → clean
- `eslint` on all touched files → clean
- Driver pin run 8x consecutively → 8/8 stable (the `setImmediate` ordering is guaranteed by the driver's microtask-only path from socket factory to `connected()`, not merely usual)
- Both compose files parse and carry all six new vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

