### PR TITLE
docs(reference): correct the X-API-Key auth claim — it is not general-purpose (#3247)

### DIFF
--- a/apps/docs/src/content/docs/reference/api-keys.mdx
+++ b/apps/docs/src/content/docs/reference/api-keys.mdx
@@ -87,11 +87,13 @@ Scopes can be updated after creation via the `PATCH` endpoint without rotating t
 
 ### Authentication Flow
 
-To authenticate with an API key, include it in the `X-API-Key` header:
+To authenticate with an API key, include it in the `X-API-Key` header — on one of
+the routes that accept it (see [Where API keys work](#where-api-keys-work) below;
+the general REST API is not one of them):
 
 ```bash
 curl -H "X-API-Key: brz_aBcDeFgHiJkLmNoPqRsTuVwXyZ012" \
-  https://breeze.yourdomain.com/api/v1/devices
+  https://breeze.yourdomain.com/api/v1/devices/$DEVICE_ID/custom-fields
 ```
 
 The middleware performs these steps in order:
@@ -116,9 +118,28 @@ The middleware performs these steps in order:
 | `X-RateLimit-Reset` | Unix timestamp when the window resets. |
 | `Retry-After` | Seconds until the rate limit resets (only on 429 responses). |
 
+### Where API keys work
+
+An API key authenticates **three surfaces**, not the API as a whole:
+
+| Endpoint | Required scope |
+|---|---|
+| `/api/v1/mcp/*` — the [MCP server](/features/mcp-server/) | `ai:*` |
+| `POST /api/v1/dev/push` | `devices:execute` |
+| `GET /api/v1/devices/:id/custom-fields` | `devices:read` |
+| `PATCH /api/v1/devices/:id/custom-fields` | `devices:write` |
+
+Every other route authenticates from the `Authorization` header alone and never
+looks at `X-API-Key`, so a key sent anywhere else returns
+`401 Missing or invalid authorization header`. A key with `devices:read` will not
+authenticate `GET /api/v1/devices` — that route needs a user JWT. Scopes gate what
+a key may do on the routes above; they do not widen where it is accepted.
+
 ### Dual Authentication
 
-Some endpoints accept either a JWT bearer token or an API key. When both headers are present, the API key takes precedence: the route handler checks for `X-API-Key` first and authenticates via `apiKeyAuthMiddleware`, falling back to `authMiddleware` only when that header is absent.
+The routes listed above accept either a JWT bearer token or an API key. When both headers are present, the API key takes precedence: the route handler checks for `X-API-Key` first and authenticates via `apiKeyAuthMiddleware`, falling back to `authMiddleware` only when that header is absent.
+
+On the JWT path some of them are stricter than the key path: `PATCH /devices/:id/custom-fields` and `POST /dev/push` additionally require MFA, matching the permissions they mirror.
 
 ### Key Rotation
 

--- a/apps/docs/src/content/docs/reference/api.mdx
+++ b/apps/docs/src/content/docs/reference/api.mdx
@@ -23,12 +23,41 @@ curl -H "Authorization: Bearer $TOKEN" \
   https://breeze.yourdomain.com/api/v1/devices
 ```
 
-API keys can also be used via the `X-API-Key` header:
+### API keys are not general-purpose auth
+
+<Aside type="caution" title="An API key will not authenticate the general REST API">
+`X-API-Key` is accepted on **three** surfaces only. Every other route reads the
+`Authorization` header and nothing else, so sending a key to (for example)
+`GET /api/v1/devices` returns `401 Missing or invalid authorization header` —
+the key is never consulted.
+</Aside>
+
+The surfaces that accept `X-API-Key`:
+
+| Endpoint | Required key scope |
+|---|---|
+| `/api/v1/mcp/*` — the [MCP server](/features/mcp-server/) | `ai:*` |
+| `POST /api/v1/dev/push` | `devices:execute` |
+| `GET /api/v1/devices/:id/custom-fields` | `devices:read` |
+| `PATCH /api/v1/devices/:id/custom-fields` | `devices:write` |
+
+Those four routes are dual-auth: they use the key when `X-API-Key` is present
+and fall back to a user JWT when it is absent. Everything else is JWT-only.
 
 ```bash
+# Works — a dual-auth route.
+curl -H "X-API-Key: brz_..." \
+  https://breeze.yourdomain.com/api/v1/devices/$DEVICE_ID/custom-fields
+
+# Returns 401 — the devices list is JWT-only.
 curl -H "X-API-Key: brz_..." \
   https://breeze.yourdomain.com/api/v1/devices
 ```
+
+If you are scripting against Breeze, log in and use the resulting JWT. Note that
+some write routes additionally require MFA on the JWT path — including
+`POST /orgs/partners`, `POST /orgs/organizations` and `POST /orgs/sites` — so an
+account without MFA enrolled cannot create tenancy unattended.
 
 ### Login
 


### PR DESCRIPTION
Fixes #3247 — the top item in your #3249 ordering, and the one that costs hours rather than days.

## What was wrong

`reference/api.mdx` said an API key authenticates the REST API and used `GET /api/v1/devices` as the example. That call returns `401 Missing or invalid authorization header`.

Confirmed against `origin/main` rather than taken from the issue: `authMiddleware` (`middleware/auth.ts:448`) reads the `Authorization` header and nothing else, throwing at `:451` when it is absent or not `Bearer`-prefixed. `devices/core.ts:276` puts the entire devices surface behind it, so the documented example is specifically one of the calls that cannot work.

## Where keys actually work

Three surfaces, all dual-auth — key when `X-API-Key` is present, user JWT when it is absent:

| Endpoint | Scope | Mount |
|---|---|---|
| `/api/v1/mcp/*` | `ai:*` | `index.ts:1114`, `mcpServer.ts:221` |
| `POST /api/v1/dev/push` | `devices:execute` | `index.ts:1115`, `devPush.ts:79` |
| `GET /api/v1/devices/:id/custom-fields` | `devices:read` | `devices/customFieldValues.ts:87` |
| `PATCH /api/v1/devices/:id/custom-fields` | `devices:write` | same |

Both reference pages now carry that table, and the broken `/devices` example is replaced by one that works. I added the distinction that made this trap easy to fall into: **scopes gate what a key may do on those routes, not where it is accepted.** A `devices:read` key still cannot call `GET /api/v1/devices`, which is exactly the wrong inference a scope list invites.

Also covered your third point — the `requireMfa()` gate on `POST /orgs/partners` (`orgs.ts:394`), `POST /orgs/organizations` (`:1279`) and `POST /orgs/sites` (`:1855`), so nobody discovers mid-migration that an MFA-less service account cannot create tenancy.

## Two line-number corrections

Not substantive, but so the issue isn't a false trail later: `apiKeyAuthMiddleware` is mounted at `mcpServer.ts:221` (not 219) and the devices `authMiddleware` is at `devices/core.ts:276` (not 268). Everything else in the issue checked out exactly, including that the three mount sites are the only non-test ones — `servicePrincipals.ts:20` even carries a comment asserting it never imports it.

## On the cross-link I did not add

Your issue points at `migration/toolkit.mdx` as the source of truth for the accurate behaviour, and it is — but that page only exists in #3250, which is still open. Linking to it from here would ship a dead link until that merges, so I kept the MFA guidance self-contained. Worth adding the cross-link when #3250 lands; happy to do it in that PR or a follow-up, whichever you prefer.

## Verification

- `astro build` — exit 0, 150 pages, both pages render
- the new `#where-api-keys-work` heading generates its anchor and the in-page link resolves to it (checked in the built HTML, not assumed)
- `/features/mcp-server/` link target exists in `dist`
- `pnpm test:docs-automation` — 5/5 pass

Diff is two `.mdx` files; no lockfile or manifest churn.
