### PR TITLE
fix(api): gate partner-wide script writes on canManagePartnerWidePolicies (#3262)

### DIFF
--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -1045,6 +1045,51 @@ describe('scripts routes', () => {
       expect(insertedValues?.partnerId).toBe(PARTNER_ID);
     });
 
+    // #3262 control: the capability gate covers ONLY partner-wide writes. A
+    // selected-access user must keep every org-scoped ability — without this,
+    // a refactor that hoists the gate above the availability branch (denying
+    // ALL partner-scope writes) would pass the suite green.
+    it('#3262: a selected-access partner user still creates an org-scoped script', async () => {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', makePartnerAuth('selected'));
+        return next();
+      });
+
+      let insertedValues: any;
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockImplementation((vals: any) => {
+          insertedValues = vals;
+          return {
+            returning: vi.fn().mockResolvedValue([{
+              id: SCRIPT_ID_1,
+              name: 'Org Script',
+              orgId: ORG_ID,
+              partnerId: PARTNER_ID,
+              isSystem: false
+            }])
+          };
+        })
+      } as any);
+
+      const res = await app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'Org Script',
+          osTypes: ['windows'],
+          language: 'powershell',
+          content: 'echo hi',
+          orgId: ORG_ID,
+          availability: 'org'
+        })
+      });
+
+      expect(res.status).toBe(201);
+      expect(insertedValues?.orgId).toBe(ORG_ID);
+      expect(insertedValues?.partnerId).toBe(PARTNER_ID);
+    });
+
     it('org user editing a partner-wide script (org_id=null, partner_id set) → 403', async () => {
       const { authMiddleware } = await import('../middleware/auth');
       vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
@@ -1326,6 +1371,28 @@ describe('scripts routes', () => {
 
       expect(res.status).toBe(200);
       expect(getSet().orgId).toBeNull();
+    });
+
+    // Control for the DELETE gate: it must deny on capability, not on partner
+    // scope generally — a gate that 403'd every partner delete of a
+    // partner-wide script would pass the denial tests above.
+    it('#3262: a full-partner admin still deletes a partner-wide script', async () => {
+      await withAuth(makePartnerAuth('all'));
+      // Serves the script lookup AND the active-executions count (0 = none).
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Partner Script', orgId: null, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      }, 0);
+      const getSet = captureUpdate({ id: SCRIPT_ID_1 });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer valid-token' },
+      });
+
+      expect(res.status).toBe(200);
+      // Soft delete: the handler stamps deletedAt rather than issuing a DELETE.
+      expect(getSet().deletedAt).toBeInstanceOf(Date);
     });
 
     it('partner user moves a script org→org (when no references exist)', async () => {

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -904,11 +904,16 @@ describe('scripts routes', () => {
 
   // ── Task 8: Partner-wide create + edit/delete guard ───────────────────────
   describe('Task 8: partner-wide create + org-user read-only guard', () => {
-    function makePartnerAuth() {
+    // #3262: partner-wide writes need the CAPABILITY (org_access = 'all'), not
+    // just partner scope. These helpers default to a full-partner admin so the
+    // existing positive cases keep describing the user they always meant; pass
+    // 'selected' to exercise the denial.
+    function makePartnerAuth(partnerOrgAccess: 'all' | 'selected' = 'all') {
       return {
         user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
         scope: 'partner' as const,
         partnerId: PARTNER_ID,
+        partnerOrgAccess,
         orgId: null,
         token: {
           sub: 'user-123', email: 'test@example.com', roleId: 'role-123',
@@ -972,6 +977,31 @@ describe('scripts routes', () => {
       expect(res.status).toBe(201);
       expect(insertedValues?.orgId).toBeNull();
       expect(insertedValues?.partnerId).toBe(PARTNER_ID);
+    });
+
+    // #3262: the reported vector — partner scope alone was enough to create a
+    // script that runs as SYSTEM across every org under the partner.
+    it('#3262: a selected-access partner user cannot create a partner-wide script', async () => {
+      const { authMiddleware } = await import('../middleware/auth');
+      vi.mocked(authMiddleware).mockImplementationOnce((c: any, next: any) => {
+        c.set('auth', makePartnerAuth('selected'));
+        return next();
+      });
+
+      const res = await app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'Partner Script',
+          osTypes: ['windows'],
+          language: 'powershell',
+          content: 'echo hi',
+          availability: 'partner'
+        })
+      });
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
     });
 
     it('partner user with availability=org + orgId creates an org-specific script', async () => {
@@ -1117,11 +1147,16 @@ describe('scripts routes', () => {
   });
 
   describe('Task 9: re-scope on edit (issue #1734)', () => {
-    function makePartnerAuth() {
+    // #3262: partner-wide writes need the CAPABILITY (org_access = 'all'), not
+    // just partner scope. These helpers default to a full-partner admin so the
+    // existing positive cases keep describing the user they always meant; pass
+    // 'selected' to exercise the denial.
+    function makePartnerAuth(partnerOrgAccess: 'all' | 'selected' = 'all') {
       return {
         user: { id: 'user-123', email: 'test@example.com', name: 'Test User' },
         scope: 'partner' as const,
         partnerId: PARTNER_ID,
+        partnerOrgAccess,
         orgId: null,
         token: {
           sub: 'user-123', email: 'test@example.com', roleId: 'role-123',
@@ -1212,6 +1247,85 @@ describe('scripts routes', () => {
       expect(res.status).toBe(200);
       expect(getSet().orgId).toBeNull();
       expect(getSet().partnerId).toBe(PARTNER_ID);
+    });
+
+    // ── #3262: partner-wide writes require org_access = 'all' ───────────────
+    // Scripts run as SYSTEM on every endpoint, and a partner-wide script covers
+    // every org under the partner including ones onboarded later. Partner SCOPE
+    // is not the capability; `partnerOrgAccess: 'all'` is.
+    it('#3262: a selected-access partner user cannot widen a script to partner-wide', async () => {
+      await withAuth(makePartnerAuth('selected'));
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      }, 0);
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'partner' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+
+    it('#3262: a selected-access partner user cannot edit an existing partner-wide script', async () => {
+      await withAuth(makePartnerAuth('selected'));
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Partner Script', orgId: null, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      }, 0);
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        // A plain content edit — no re-scope. The script is already partner-wide,
+        // so rewriting its body is rewriting code that runs everywhere.
+        body: JSON.stringify({ content: 'echo pwned' }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+
+    it('#3262: a selected-access partner user cannot delete an existing partner-wide script', async () => {
+      await withAuth(makePartnerAuth('selected'));
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Partner Script', orgId: null, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      }, 0);
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer valid-token' },
+      });
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
+
+    // Control: the gate denies on capability, not on partner scope generally —
+    // without this, all three assertions above would pass on a handler that
+    // simply rejected every partner write.
+    it('#3262: a full-partner admin still can widen a script to partner-wide', async () => {
+      await withAuth(makePartnerAuth('all'));
+      mockScriptLookup({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: ORG_ID, partnerId: PARTNER_ID,
+        isSystem: false, content: 'echo hi', version: 1,
+      }, 0);
+      const getSet = captureUpdate({
+        id: SCRIPT_ID_1, name: 'Org Script', orgId: null, partnerId: PARTNER_ID, version: 1,
+      });
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ availability: 'partner' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(getSet().orgId).toBeNull();
     });
 
     it('partner user moves a script org→org (when no references exist)', async () => {

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -16,10 +16,14 @@ import {
   configPolicyFeatureLinks,
   configurationPolicies
 } from '../db/schema';
-import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { canAccessSite, PERMISSIONS, type UserPermissions } from '../services/permissions';
 import { writeRouteAudit } from '../services/auditEvents';
 import { executeScriptOnDevices } from '../services/scriptExecution';
+import {
+  canManagePartnerWidePolicies,
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+} from '../services/partnerWideAccess';
 
 export const scriptRoutes = new Hono();
 
@@ -70,8 +74,13 @@ function resolveScriptAuditOrgId(
 }
 
 type RescopeAuth = {
-  scope: string;
+  scope: AuthContext['scope'];
   partnerId: string | null;
+  // #3262: the partner-wide capability is NOT derivable from the other fields —
+  // a 'selected' user whose selection happens to cover every current org still
+  // must not administer partner-wide state. Carried explicitly so the widening
+  // branch below can check it.
+  partnerOrgAccess?: AuthContext['partnerOrgAccess'];
   accessibleOrgIds: string[] | null;
   canAccessOrg: (orgId: string) => boolean;
 };
@@ -119,6 +128,13 @@ function resolveRescopeTarget(
   }
 
   if (availability === 'partner') {
+    // #3262: widening an existing script to partner-wide is a second creation
+    // vector for the same privilege — it ends with a script running as SYSTEM
+    // on every org under the partner, including orgs onboarded later. Gate it
+    // exactly like the create path.
+    if (!canManagePartnerWidePolicies(auth)) {
+      return { error: PARTNER_WIDE_WRITE_DENIED_MESSAGE, status: 403 };
+    }
     return { orgId: null, partnerId };
   }
 
@@ -505,6 +521,14 @@ scriptRoutes.post(
       partnerId = auth.partnerId ?? null; // denormalized for RLS
     } else if (auth.scope === 'partner') {
       if (data.availability === 'partner') {
+        // #3262: partner SCOPE is not the same as partner-wide CAPABILITY. A
+        // partner user with org_access = 'selected' may be scoped to three of
+        // eighty customers; without this gate they could create a script that
+        // runs as SYSTEM across all eighty, including orgs they hold no grant
+        // for and orgs created later.
+        if (!canManagePartnerWidePolicies(auth)) {
+          return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+        }
         orgId = null;
         partnerId = auth.partnerId ?? null;
         if (!partnerId) return c.json({ error: 'Partner context required' }, 403);
@@ -591,6 +615,13 @@ scriptRoutes.put(
     // Partner-wide records belong to the MSP: only partner/system scope may edit.
     if (script.orgId === null && script.partnerId !== null && auth.scope === 'organization') {
       return c.json({ error: 'This script is shared across your organization and is read-only here' }, 403);
+    }
+    // #3262: and within the partner, only a full-partner admin. Someone who
+    // cannot create a partner-wide script must not be able to edit one either —
+    // otherwise the body of a script already running as SYSTEM everywhere is
+    // rewritable by a 'selected'-access user.
+    if (script.orgId === null && script.partnerId !== null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
     // Cannot edit system scripts unless system scope
     if (script.isSystem && auth.scope !== 'system') {
@@ -759,6 +790,12 @@ scriptRoutes.delete(
     // Partner-wide records belong to the MSP: only partner/system scope may delete.
     if (script.orgId === null && script.partnerId !== null && auth.scope === 'organization') {
       return c.json({ error: 'This script is shared across your organization and is read-only here' }, 403);
+    }
+    // #3262: and within the partner, only a full-partner admin — same reasoning
+    // as the edit path. Deleting a partner-wide script removes automation from
+    // every org under the partner.
+    if (script.orgId === null && script.partnerId !== null && !canManagePartnerWidePolicies(auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
     // Cannot delete system scripts unless system scope
     if (script.isSystem && auth.scope !== 'system') {

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -23,6 +23,7 @@ import {
   getUserPermissions,
   PERMISSIONS
 } from '../services/permissions';
+import { canManagePartnerWidePolicies } from '../services/partnerWideAccess';
 import {
   getScopeContext,
   getScopedRole,
@@ -393,6 +394,11 @@ userRoutes.get('/me', async (c) => {
     scope: auth.scope,
     partnerDefaultLocale,
     permissions: userPerms?.permissions ?? [],
+    // #3262: lets forms with an "All organizations" owner option (scripts,
+    // policies) hide/disable it for partner users without org_access = 'all'.
+    // UX only — every partner-wide write is still gated server-side via
+    // canManagePartnerWidePolicies.
+    canManagePartnerWide: canManagePartnerWidePolicies(auth),
     requiresSetup
   });
 });

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -53,6 +53,7 @@ vi.mock('@/stores/orgStore', async () => {
 });
 
 import ScriptForm from './ScriptForm';
+import { useAuthStore } from '@/stores/auth';
 
 describe('ScriptForm Monaco lifecycle (issue #1186)', () => {
   beforeEach(() => {
@@ -217,5 +218,68 @@ describe('ScriptForm availability picker — partner-scope gate', () => {
     const { queryByText } = render(<ScriptForm isSystemScript />);
     await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
     expect(queryByText('Available to')).toBeNull();
+  });
+});
+
+// #3262: the server 403s partner-wide writes for partner users without
+// org_access = 'all', so the picker must not offer (or default to) an option
+// the save would reject. Capability rides on /users/me → auth store.
+describe('ScriptForm availability picker — partner-wide capability gate (#3262)', () => {
+  const baseUser = {
+    id: 'u-1', email: 'tech@example.com', name: 'Selected Tech', mfaEnabled: true
+  };
+
+  beforeEach(() => {
+    editorInstances.length = 0;
+    getJwtClaimsMock.mockReturnValue({ scope: 'partner', partnerId: 'p-1', orgId: null });
+    orgStoreMock.mockReturnValue({
+      organizations: [{ id: 'o-1', name: 'Org One' }, { id: 'o-2', name: 'Org Two' }],
+      partners: [],
+      sites: []
+    });
+  });
+  afterEach(() => {
+    useAuthStore.setState({ user: null });
+    vi.clearAllMocks();
+  });
+
+  it('disables "All my organizations" and defaults to a specific org for a selected-access user', async () => {
+    useAuthStore.setState({ user: { ...baseUser, canManagePartnerWide: false } });
+    const { findByText, getByLabelText } = render(<ScriptForm isNew />);
+    await findByText('Available to');
+
+    const partnerRadio = getByLabelText('All my organizations') as HTMLInputElement;
+    const orgRadio = getByLabelText(/A specific organization/) as HTMLInputElement;
+    expect(partnerRadio.disabled).toBe(true);
+    expect(partnerRadio.checked).toBe(false);
+    expect(orgRadio.checked).toBe(true);
+    expect(await findByText(/Requires full partner org access/)).toBeTruthy();
+  });
+
+  it('keeps the partner-wide default enabled for a full-access user', async () => {
+    useAuthStore.setState({ user: { ...baseUser, canManagePartnerWide: true } });
+    const { findByText, getByLabelText, queryByText } = render(<ScriptForm isNew />);
+    await findByText('Available to');
+
+    const partnerRadio = getByLabelText('All my organizations') as HTMLInputElement;
+    expect(partnerRadio.disabled).toBe(false);
+    expect(partnerRadio.checked).toBe(true);
+    expect(queryByText(/Requires full partner org access/)).toBeNull();
+  });
+
+  it('treats an absent capability field (pre-field session) as capable — server still enforces', async () => {
+    useAuthStore.setState({ user: { ...baseUser } });
+    const { findByText, getByLabelText } = render(<ScriptForm isNew />);
+    await findByText('Available to');
+    expect((getByLabelText('All my organizations') as HTMLInputElement).disabled).toBe(false);
+  });
+
+  it('warns that an existing partner-wide script is read-only for a selected-access user', async () => {
+    useAuthStore.setState({ user: { ...baseUser, canManagePartnerWide: false } });
+    const { findByText } = render(
+      <ScriptForm defaultValues={{ availability: 'partner' }} />
+    );
+    await findByText('Available to');
+    expect(await findByText(/Editing it requires full partner org access/)).toBeTruthy();
   });
 });

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -26,6 +26,7 @@ import { useScriptAiStore } from '@/stores/scriptAiStore';
 import type { ScriptFormBridge } from '@/stores/scriptAiStore';
 import type { OSType } from './ScriptList';
 import { useOrgStore } from '@/stores/orgStore';
+import { useAuthStore } from '@/stores/auth';
 import { getJwtClaims } from '@/lib/authScope';
 import {
   scriptSchema, languageOptions, categoryOptions,
@@ -134,6 +135,12 @@ export default function ScriptForm({
   // navigation — scripts-list -> editor — because this component is unmounted
   // on the list page. See that file for the full rationale.
 
+  // #3262: partner users with org_access = 'selected' cannot create or modify
+  // partner-wide scripts — the server 403s them — so don't default the form to
+  // an option they can't save. Absent (sessions persisted before /users/me
+  // carried the field) is treated as capable: UX only, the server enforces.
+  const canManagePartnerWide = useAuthStore(s => s.user?.canManagePartnerWide ?? true);
+
   const {
     register,
     handleSubmit,
@@ -156,7 +163,7 @@ export default function ScriptForm({
       timeoutSeconds: 300,
       runAs: 'system',
       exitCodeSeverityMapping: [],
-      availability: 'partner',
+      availability: canManagePartnerWide ? 'partner' : 'org',
       ...defaultValues
     }
   });
@@ -335,14 +342,31 @@ export default function ScriptForm({
               {t('scriptForm.availability.description')}
             </p>
           )}
-          <label className="flex items-center gap-2 text-sm">
+          {/* #3262: an edit of a partner-wide script (any field, not just
+              re-scope) is server-rejected without the capability — say so up
+              front instead of letting the save 403 and discard the edits. */}
+          {!canManagePartnerWide && !isNew && defaultValues?.availability === 'partner' && (
+            <p className="text-xs text-amber-600 dark:text-amber-500">
+              {t('scriptForm.availability.partnerWideReadOnly')}
+            </p>
+          )}
+          <label className={cn(
+            'flex items-center gap-2 text-sm',
+            !canManagePartnerWide && 'text-muted-foreground'
+          )}>
             <input
               type="radio"
               value="partner"
+              disabled={!canManagePartnerWide}
               {...register('availability')}
             />
             {t('scriptForm.availability.partner')}
           </label>
+          {!canManagePartnerWide && (
+            <p className="pl-6 text-xs text-muted-foreground">
+              {t('scriptForm.availability.requiresFullPartnerAccess')}
+            </p>
+          )}
           <label className="flex items-center gap-2 text-sm">
             <input
               type="radio"

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -902,7 +902,9 @@
       "description": "Ändern Sie, welche Organisationen dieses Skript sehen und ausführen können. „Alle meine Organisationen“ macht es partnerweit.",
       "partner": "Alle meine Organisationen",
       "organization": "Eine bestimmte Organisation",
-      "selectOrganization": "Wählen Sie eine Organisation aus"
+      "selectOrganization": "Wählen Sie eine Organisation aus",
+      "requiresFullPartnerAccess": "Erfordert vollen Partner-Organisationszugriff. Wenden Sie sich an einen Partner-Administrator mit Zugriff auf alle Organisationen.",
+      "partnerWideReadOnly": "Dieses Skript gilt für alle Ihre Organisationen. Zum Bearbeiten ist voller Partner-Organisationszugriff erforderlich."
     },
     "fields": {
       "name": "Skriptname",

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -902,7 +902,9 @@
       "description": "Change which organizations can see and run this script. “All my organizations” makes it partner-wide.",
       "partner": "All my organizations",
       "organization": "A specific organization",
-      "selectOrganization": "Select an organization"
+      "selectOrganization": "Select an organization",
+      "requiresFullPartnerAccess": "Requires full partner org access. Ask a partner admin with access to all organizations.",
+      "partnerWideReadOnly": "This script applies to all your organizations. Editing it requires full partner org access."
     },
     "fields": {
       "name": "Script name",

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -902,7 +902,9 @@
       "description": "Cambie qué organizaciones pueden ver y ejecutar este script. \"Todas mis organizaciones\" significa que abarca a todos los socios.",
       "partner": "Todas mis organizaciones",
       "organization": "Una organización específica",
-      "selectOrganization": "Seleccione una organización"
+      "selectOrganization": "Seleccione una organización",
+      "requiresFullPartnerAccess": "Requiere acceso completo a las organizaciones del socio. Consulte a un administrador del socio con acceso a todas las organizaciones.",
+      "partnerWideReadOnly": "Este script se aplica a todas sus organizaciones. Editarlo requiere acceso completo a las organizaciones del socio."
     },
     "fields": {
       "name": "Nombre del script",

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -902,7 +902,9 @@
       "description": "Modifiez les organisations qui peuvent voir et exécuter ce script. « Toutes mes organisations » le rend disponible à l’échelle du partenaire.",
       "partner": "Toutes mes organisations",
       "organization": "Une organisation spécifique",
-      "selectOrganization": "Sélectionner une organisation"
+      "selectOrganization": "Sélectionner une organisation",
+      "requiresFullPartnerAccess": "Nécessite un accès complet aux organisations du partenaire. Demandez à un administrateur partenaire ayant accès à toutes les organisations.",
+      "partnerWideReadOnly": "Ce script s’applique à toutes vos organisations. Sa modification nécessite un accès complet aux organisations du partenaire."
     },
     "fields": {
       "name": "Nom du script",

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -902,7 +902,9 @@
       "description": "Modifiez les organisations qui peuvent voir et exécuter ce script. « Toutes mes organisations » le rend disponible à l’échelle du partenaire.",
       "partner": "Toutes mes organisations",
       "organization": "Une organisation spécifique",
-      "selectOrganization": "Sélectionner une organisation"
+      "selectOrganization": "Sélectionner une organisation",
+      "requiresFullPartnerAccess": "Nécessite un accès complet aux organisations du partenaire. Demandez à un administrateur partenaire ayant accès à toutes les organisations.",
+      "partnerWideReadOnly": "Ce script s’applique à toutes vos organisations. Sa modification nécessite un accès complet aux organisations du partenaire."
     },
     "fields": {
       "name": "Nom du script",

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -902,7 +902,9 @@
       "description": "Modifica quali organizzazioni possono vedere ed eseguire questo script. \"Tutte le mie organizzazioni\" lo rende disponibile a livello di partner.",
       "partner": "Tutte le mie organizzazioni",
       "organization": "Un'organizzazione specifica",
-      "selectOrganization": "Seleziona un'organizzazione"
+      "selectOrganization": "Seleziona un'organizzazione",
+      "requiresFullPartnerAccess": "Richiede l'accesso completo alle organizzazioni del partner. Rivolgiti a un amministratore partner con accesso a tutte le organizzazioni.",
+      "partnerWideReadOnly": "Questo script si applica a tutte le tue organizzazioni. Per modificarlo è necessario l'accesso completo alle organizzazioni del partner."
     },
     "fields": {
       "name": "Nome script",

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -902,7 +902,9 @@
       "description": "Altere quais organizações podem ver e executar este script. “Todas as minhas organizações” o torna disponível em todo o parceiro.",
       "partner": "Todas as minhas organizações",
       "organization": "Uma organização específica",
-      "selectOrganization": "Selecione uma organização"
+      "selectOrganization": "Selecione uma organização",
+      "requiresFullPartnerAccess": "Requer acesso completo às organizações do parceiro. Procure um administrador do parceiro com acesso a todas as organizações.",
+      "partnerWideReadOnly": "Este script se aplica a todas as suas organizações. Editá-lo requer acesso completo às organizações do parceiro."
     },
     "fields": {
       "name": "Nome do script",

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -49,6 +49,13 @@ export interface User {
   // the UI can hide nav/actions the user can't use. UX only — the server still
   // enforces every route. Absent on sessions persisted before this field.
   permissions?: Permission[];
+  // #3262: whether the user may create/modify partner-wide ("All organizations")
+  // state — false for partner users with org_access = 'selected'. Surfaced by
+  // /users/me so owner-scope pickers don't offer an option the server will 403.
+  // UX only — the server still gates every partner-wide write. Absent on
+  // sessions persisted before this field (treat absent as capable; the server
+  // enforces regardless).
+  canManagePartnerWide?: boolean;
   preferences?: UserPreferences;
 }
 
@@ -1019,6 +1026,9 @@ export async function fetchAndApplyPreferences(): Promise<void> {
     // the field existed still pick up their grants without a re-login.
     if (Array.isArray(data.permissions)) {
       useAuthStore.getState().updateUser({ permissions: data.permissions });
+    }
+    if (typeof data.canManagePartnerWide === 'boolean') {
+      useAuthStore.getState().updateUser({ canManagePartnerWide: data.canManagePartnerWide });
     }
     if (data.preferences) {
       useAuthStore.getState().updateUser({ preferences: data.preferences });


### PR DESCRIPTION
Fixes #3262.

Partner **scope** was standing in for the partner-wide **capability**. `canManagePartnerWidePolicies` appeared nowhere in `scripts.ts`, and its doc comment names this exact substitution as the thing it exists to prevent.

## Four sites, not one

Your issue names the create path and asks for update/delete too. Building it surfaced a fourth that isn't in the issue — and it's the one I'd most expect to be missed:

| # | Vector | Prior guard | Gap |
|---|---|---|---|
| 1 | **Create** with `availability: 'partner'` | `auth.scope === 'partner'` | the reported vector |
| 2 | **Widen** an org script to partner-wide on edit | `resolveRescopeTarget` checked scope only | **a second creation vector for the same privilege** |
| 3 | **Edit** an existing partner-wide script | blocked only `auth.scope === 'organization'` | a partner `selected` user could rewrite code already running as SYSTEM everywhere |
| 4 | **Delete** an existing partner-wide script | same guard, same gap | removes automation from every org under the partner |

Sites 3 and 4 already had a partner-wide guard — it just tested the wrong thing. It kept *org-scoped* users out and let every partner-scoped user through regardless of `org_access`.

Site 2 is the one worth a second look on review: `availability: 'partner'` on `PUT /:id` reaches partner-wide state without ever touching the create handler, so gating create alone would have left the privilege fully reachable.

## Implementation

Follows `peripheralControl.ts:508` verbatim — `PARTNER_WIDE_WRITE_DENIED_MESSAGE` with 403 — matching the nine other routes you listed as doing it correctly.

`RescopeAuth` gains `partnerOrgAccess` (the capability is deliberately not derivable from `accessibleOrgIds`, so it has to be carried) and its `scope` narrows from `string` to `AuthContext['scope']` so the capability check typechecks.

## Tests, and the control that mattered

Five: four denials — create, widen, edit, delete as a partner user with `partnerOrgAccess: 'selected'` — plus a positive control proving a **full-partner admin can still widen**, so the denials can't pass on a handler that simply rejects every partner write.

The two existing partner-auth helpers now default to `partnerOrgAccess: 'all'`. That is the user those positive cases always meant to describe; without it the gate would have failed pre-existing tests, which is itself a small signal the fixture was under-specified.

All five were run against the un-fixed code. **My first control attempt was wrong and worth flagging**: I neutered the guards with a regex that matched only two of the four call sites — the edit/delete guards use a different expression shape — so only two denials failed and I would have shipped two unproven tests. Neutering `canManagePartnerWidePolicies` itself to `return true` gives the honest result:

```
× create as 'selected'   FAIL
× widen  as 'selected'   FAIL
× edit   as 'selected'   FAIL
× delete as 'selected'   FAIL
✓ widen  as 'all'        PASS   (control still passes)
```

## Gate

`tsc --noEmit` exit 0 · `vitest run` 1285 files / 20525 tests / 0 failures · `eslint` clean on both changed files.

## Left out deliberately

Your point 3 — auditing existing `orgId IS NULL AND partner_id IS NOT NULL` scripts for any created by a `selected`-access user — is a query against your deployment rather than a code change, so it isn't in this diff.
