### PR TITLE
fix(backup): short-retry ACL denials and abort on a lost VSS snapshot (#3259, #3260)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1253,7 +1253,7 @@ jobs:
           CGO_ENABLED: "0"
         shell: pwsh
         run: |
-          $out = go test ./internal/backup -run 'TestPermanentWindowsErrnoConstantsMatchWin32|TestClassifyPermanentUploadError|TestLookupPermanentWindowsErrno|TestRewritePathsForVSS|TestReportableLiveReads|TestSummarizeLiveReads' -v 2>&1
+          $out = go test ./internal/backup -run 'TestWindowsUploadErrnoConstantsMatchWin32|TestClassifyUploadFailure|TestLookupWindowsUploadErrno|TestRewritePathsForVSS|TestReportableLiveReads|TestSummarizeLiveReads' -v 2>&1
           $exit = $LASTEXITCODE
           $out | ForEach-Object { Write-Host $_ }
           if ($exit -ne 0) { throw "go test failed (exit $exit)" }

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -427,8 +427,18 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		}
 	}
 
+	// sourceLiveness watches the shadow-copy roots this run reads from so the
+	// upload loop can tell "the snapshot died" apart from "these files are
+	// bad" (#3260). Built here, immediately after the session is created and
+	// the paths are rewritten onto it, so its self-calibrating stat sees the
+	// roots at their freshest — the file walk below can itself take minutes.
+	// Stays nil for a non-VSS run: reading the live filesystem has nothing to
+	// defend.
+	var sourceLiveness sourceLivenessFn
+
 	// Rewrite paths to shadow copy device paths when VSS is active
 	if vssSession != nil {
+		sourceLiveness = newShadowRootLiveness(vssSession.ShadowPaths)
 		var unmappedIdx []int
 		backupPaths, unmappedIdx = rewritePathsForVSS(backupPaths, vssSession.ShadowPaths, systemStateStagingIdx)
 		if liveReads := reportableLiveReads(backupPaths, unmappedIdx, systemStateStagingIdx); len(liveReads) > 0 {
@@ -629,7 +639,7 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 		}
 	}
 
-	snapshot, snapErr := createSnapshotWithProgress(runCtx, m.config.Provider, files, progressFn, journal, prevSnapshot)
+	snapshot, snapErr := createSnapshotWithProgress(runCtx, m.config.Provider, files, progressFn, journal, prevSnapshot, sourceLiveness)
 	if errors.Is(snapErr, errBackupStopped) {
 		return stopBackupRun()
 	}

--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -429,9 +429,16 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 
 	// sourceLiveness watches the shadow-copy roots this run reads from so the
 	// upload loop can tell "the snapshot died" apart from "these files are
-	// bad" (#3260). Built here, immediately after the session is created and
-	// the paths are rewritten onto it, so its self-calibrating stat sees the
-	// roots at their freshest — the file walk below can itself take minutes.
+	// bad" (#3260).
+	//
+	// Built at the very top of the VSS block — before the path rewrite, and well
+	// before the file walk, which on a large volume runs for minutes. That
+	// ordering is load-bearing: newShadowRootLiveness calibrates by stat-ing
+	// each root once and watching only the ones that answer, so it has to run
+	// while the snapshot is as fresh as it will ever be. Calibrating after the
+	// walk would risk arming the guard against a snapshot that had already
+	// started to go.
+	//
 	// Stays nil for a non-VSS run: reading the live filesystem has nothing to
 	// defend.
 	var sourceLiveness sourceLivenessFn

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -475,22 +475,30 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 	}
 
 	// abortSourceGone is the single exit point for the abort taken when the
-	// source snapshot goes away mid-run (#3260). It deliberately mirrors
-	// abortStopped: the run did not
-	// finish, so no manifest is written, and the partial remote prefix is
-	// cleaned up ONLY when there is no journal — with a journal, the prefix
-	// plus the journal are this run's resume state and the objects already
-	// uploaded stay usable for the next attempt.
+	// source snapshot goes away mid-run (#3260). The run stops either way; what
+	// differs is what happens to the objects already uploaded, and that turns
+	// entirely on whether this run has a checkpoint journal.
 	//
-	// Not written as a partial success on purpose. The already-uploaded objects
-	// are real data, but publishing a manifest for them would mint a snapshot
-	// that LOOKS complete while silently missing every file the loop never
-	// reached — a restore point that lies. Failing loudly and keeping the
-	// journal preserves the same bytes without the lie.
+	//   journal != nil — the prefix plus the journal ARE the resume state, and
+	//     the next attempt resumes into this very snapshot ID. No manifest:
+	//     publishing one now would stake a completed-snapshot claim on an ID
+	//     the next run is still filling in. Nothing is deleted.
+	//
+	//   journal == nil — there is no resume state, so leaving the prefix
+	//     unpublished would strand the uploaded objects as unreachable orphans.
+	//     Publish a PARTIAL manifest instead, making them a real restore point.
+	//     This is not a "snapshot that lies": a manifest enumerates what the
+	//     snapshot contains, it does not assert completeness, and the run is
+	//     still reported as FAILED with the source-loss reason and the counts.
+	//     Deleting them would be a regression against the pre-#3260 behaviour,
+	//     where the same run finished as a flagged partial success and left a
+	//     usable restore point behind.
 	//
 	// The error carries the counts because #3260's whole complaint is that the
 	// operator-visible failure said nothing useful about what happened.
 	abortSourceGone := func(cause error) (*Snapshot, error) {
+		detail := fmt.Errorf("%w (aborted after %d of %d files uploaded, %d failed)",
+			cause, len(snapshot.Files), filesTotal, len(errs))
 		log.Error("backup source snapshot is gone mid-run, aborting the run",
 			"snapshotId", snapshot.ID,
 			"filesUploaded", len(snapshot.Files),
@@ -499,11 +507,36 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 			"resumable", journal != nil,
 			"error", cause.Error(),
 		)
-		if journal == nil {
-			cleanupSnapshotPrefix(provider, snapshot.ID)
+		if journal != nil {
+			return nil, detail
 		}
-		return nil, fmt.Errorf("%w (aborted after %d of %d files uploaded, %d failed)",
-			cause, len(snapshot.Files), filesTotal, len(errs))
+		if len(snapshot.Files) == 0 {
+			// Nothing landed, so there is no restore point to preserve and the
+			// prefix holds no recoverable data. Same disposal as any other
+			// journal-less abort.
+			cleanupSnapshotPrefix(provider, snapshot.ID)
+			return nil, detail
+		}
+		snapshot.UploadFailures = errs
+		if pubErr := publishSnapshotManifest(ctx, provider, snapshot, prefix); pubErr != nil {
+			// Deliberately NOT followed by cleanupSnapshotPrefix. Deletion is
+			// irreversible and this is a data-protection product: retained
+			// orphans cost storage, deleted backups cost the customer their
+			// files. Log loudly enough that an operator can find them.
+			log.Error("could not publish a partial manifest for the aborted run; the uploaded objects are RETAINED but unreachable without one",
+				"snapshotId", snapshot.ID,
+				"prefix", prefix,
+				"filesUploaded", len(snapshot.Files),
+				"error", pubErr.Error(),
+			)
+			return snapshot, errors.Join(detail, pubErr)
+		}
+		log.Warn("published a PARTIAL manifest for the aborted run; it restores the files that landed before the source snapshot went away",
+			"snapshotId", snapshot.ID,
+			"filesUploaded", len(snapshot.Files),
+			"filesTotal", filesTotal,
+		)
+		return snapshot, detail
 	}
 
 	for _, file := range files {
@@ -721,9 +754,38 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		return abortStopped()
 	}
 
+	if err := publishSnapshotManifest(ctx, provider, snapshot, prefix); err != nil {
+		if errors.Is(err, errBackupStopped) {
+			// A manifest-upload deadline expiry is fatal for the snapshot too
+			// (unlike a per-file data upload): without the manifest the
+			// snapshot isn't restorable, so there's nothing to keep going for.
+			return abortStopped()
+		}
+		return snapshot, err
+	}
+
+	if journal != nil {
+		if err := journal.Complete(); err != nil {
+			log.Warn("failed to remove completed checkpoint journal", "error", err.Error())
+		}
+		completed = true
+	}
+
+	return snapshot, nil
+}
+
+// publishSnapshotManifest serializes snapshot's manifest and uploads it under
+// prefix, making the objects already stored there a reachable restore point.
+//
+// Extracted so the mid-run source-loss abort can publish the partial set it
+// managed to store (see abortSourceGone) using exactly the same code path as a
+// normal completion — a second, subtly different manifest writer is how the two
+// would drift apart. errBackupStopped is returned unwrapped so callers can tell
+// a job cancel from a genuine manifest failure.
+func publishSnapshotManifest(ctx context.Context, provider providers.BackupProvider, snapshot *Snapshot, prefix string) error {
 	manifestPath, manifestErr := writeSnapshotManifest(snapshot)
 	if manifestErr != nil {
-		return snapshot, manifestErr
+		return manifestErr
 	}
 	defer os.Remove(manifestPath)
 
@@ -738,22 +800,11 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 	cancelAttempt()
 	if manifestUploadErr != nil {
 		if errors.Is(manifestUploadErr, errBackupStopped) {
-			// A manifest-upload deadline expiry is fatal for the snapshot too
-			// (unlike a per-file data upload): without the manifest the
-			// snapshot isn't restorable, so there's nothing to keep going for.
-			return abortStopped()
+			return manifestUploadErr
 		}
-		return snapshot, fmt.Errorf("failed to upload snapshot manifest: %w", manifestUploadErr)
+		return fmt.Errorf("failed to upload snapshot manifest: %w", manifestUploadErr)
 	}
-
-	if journal != nil {
-		if err := journal.Complete(); err != nil {
-			log.Warn("failed to remove completed checkpoint journal", "error", err.Error())
-		}
-		completed = true
-	}
-
-	return snapshot, nil
+	return nil
 }
 
 // attemptFileUpload runs a single upload attempt for file against a fresh

--- a/agent/internal/backup/snapshot.go
+++ b/agent/internal/backup/snapshot.go
@@ -230,6 +230,35 @@ func setUploadRetryDelayForTest(d time.Duration) (restore func()) {
 	return func() { uploadRetryDelay = old }
 }
 
+// shortUploadRetryDelay is the backoff for a source-permission denial
+// (retryAfterShortDelay — see classifyUploadFailure). An NTFS ACL never clears,
+// so the wait exists purely to ride out an AV/indexer/filter-driver hold.
+//
+// One second is an operational tradeoff, not a guarantee: Windows promises
+// nothing about how quickly such a hold clears, so this does narrow the
+// recovery window compared with the 30s backoff. It is still the right call —
+// the retry itself (the thing that actually recovers a transient hold) is
+// preserved, and the 27-29s per denied file it removes is what let a run
+// outlive its own shadow copy and lose EVERY file (#3259 -> #3260).
+var shortUploadRetryDelay = 1 * time.Second
+
+// setShortUploadRetryDelayForTest overrides shortUploadRetryDelay. Call the
+// returned restore func (typically via defer) to put the real delay back.
+func setShortUploadRetryDelayForTest(d time.Duration) (restore func()) {
+	old := shortUploadRetryDelay
+	shortUploadRetryDelay = d
+	return func() { shortUploadRetryDelay = old }
+}
+
+// retryDelayFor maps a retry policy to the wall-clock the upload loop spends
+// before its single retry.
+func retryDelayFor(policy uploadRetryPolicy) time.Duration {
+	if policy == retryAfterShortDelay {
+		return shortUploadRetryDelay
+	}
+	return uploadRetryDelay
+}
+
 // CreateSnapshot creates a new snapshot and uploads files via the provider.
 func CreateSnapshot(provider providers.BackupProvider, files []backupFile) (*Snapshot, error) {
 	return CreateSnapshotContext(context.Background(), provider, files)
@@ -241,7 +270,7 @@ func CreateSnapshot(provider providers.BackupProvider, files []backupFile) (*Sna
 // dedupe against a previous manifest (always a full backup); see
 // createSnapshotWithProgress for all three.
 func CreateSnapshotContext(ctx context.Context, provider providers.BackupProvider, files []backupFile) (*Snapshot, error) {
-	return createSnapshotWithProgress(ctx, provider, files, nil, nil, nil)
+	return createSnapshotWithProgress(ctx, provider, files, nil, nil, nil, nil)
 }
 
 // createSnapshotWithProgress creates a new snapshot using the provided
@@ -282,9 +311,19 @@ func CreateSnapshotContext(ctx context.Context, provider providers.BackupProvide
 // the very same snapshot ID) and is authoritative for it; the reference
 // index only offers to point at an OLDER snapshot's object. Checking
 // resumedFiles first in the loop below implements that priority.
-func createSnapshotWithProgress(ctx context.Context, provider providers.BackupProvider, files []backupFile, onProgress ProgressFn, journal *snapshotJournal, prevSnapshot *Snapshot) (*Snapshot, error) {
+//
+// sourceLiveness, if non-nil, reports whether the point-in-time source the
+// files were read from still exists (the VSS shadow copy — see
+// newShadowRootLiveness). It is consulted only after a per-file upload has
+// already failed, and a positive answer aborts the whole run rather than
+// letting every remaining file be recorded as individually bad (#3260). nil
+// means the run reads the live filesystem and has nothing to defend.
+func createSnapshotWithProgress(ctx context.Context, provider providers.BackupProvider, files []backupFile, onProgress ProgressFn, journal *snapshotJournal, prevSnapshot *Snapshot, sourceLiveness sourceLivenessFn) (*Snapshot, error) {
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if sourceLiveness == nil {
+		sourceLiveness = func(string) error { return nil }
 	}
 
 	// Register the journal's fd cleanup before any other return path so
@@ -435,6 +474,38 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		return nil, errBackupStopped
 	}
 
+	// abortSourceGone is the single exit point for the abort taken when the
+	// source snapshot goes away mid-run (#3260). It deliberately mirrors
+	// abortStopped: the run did not
+	// finish, so no manifest is written, and the partial remote prefix is
+	// cleaned up ONLY when there is no journal — with a journal, the prefix
+	// plus the journal are this run's resume state and the objects already
+	// uploaded stay usable for the next attempt.
+	//
+	// Not written as a partial success on purpose. The already-uploaded objects
+	// are real data, but publishing a manifest for them would mint a snapshot
+	// that LOOKS complete while silently missing every file the loop never
+	// reached — a restore point that lies. Failing loudly and keeping the
+	// journal preserves the same bytes without the lie.
+	//
+	// The error carries the counts because #3260's whole complaint is that the
+	// operator-visible failure said nothing useful about what happened.
+	abortSourceGone := func(cause error) (*Snapshot, error) {
+		log.Error("backup source snapshot is gone mid-run, aborting the run",
+			"snapshotId", snapshot.ID,
+			"filesUploaded", len(snapshot.Files),
+			"filesFailed", len(errs),
+			"filesTotal", filesTotal,
+			"resumable", journal != nil,
+			"error", cause.Error(),
+		)
+		if journal == nil {
+			cleanupSnapshotPrefix(provider, snapshot.ID)
+		}
+		return nil, fmt.Errorf("%w (aborted after %d of %d files uploaded, %d failed)",
+			cause, len(snapshot.Files), filesTotal, len(errs))
+	}
+
 	for _, file := range files {
 		if err := ctx.Err(); err != nil {
 			return abortStopped()
@@ -482,7 +553,16 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		uploadStart := time.Now()
 		uploadErr := attemptFileUpload(ctx, provider, file, backupPath)
 		if uploadErr != nil && !errors.Is(uploadErr, errBackupStopped) {
-			if reason, permanent := classifyPermanentUploadError(uploadErr, file.sourcePath); permanent {
+			// Before spending anything else on this failure, make sure the
+			// source we are reading from still exists. If the shadow copy died,
+			// this file is not bad and neither is any file after it — sleeping
+			// on a retry, and then blaming the file, is exactly the behaviour
+			// that turned 15 unreadable files into 40 lost ones (#3260).
+			if goneErr := sourceLiveness(file.sourcePath); goneErr != nil {
+				return abortSourceGone(goneErr)
+			}
+			policy, reason := classifyUploadFailure(uploadErr, file.sourcePath)
+			if policy == skipWithoutRetry {
 				// The source is locked by a live process, already gone, or an
 				// unhydratable cloud placeholder. A retry cannot change that,
 				// so skip immediately instead of burning uploadRetryDelay on a
@@ -505,21 +585,35 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 				// converted to a plain error). Job-context cancel during the
 				// backoff wait aborts immediately — never retried.
 				//
+				// retryDelayFor picks the wait: the full backoff for an
+				// unrecognised (probably transient) failure, or the short one
+				// for a source-permission denial, which is nearly always a
+				// structural ACL (#3259).
+				//
 				// Warn, not debug: a single retry is the first observable symptom
 				// of a stalling destination, and it is the point at which we have
 				// already burned the full per-file deadline.
+				retryDelay := retryDelayFor(policy)
+				if reason == "" {
+					// The failure was not attributable to the source file (a
+					// destination outage, a provider-side error, an
+					// unrecognised errno). Say so rather than logging an empty
+					// field, which reads like a dropped value.
+					reason = "unclassified"
+				}
 				log.Warn("file upload failed, retrying once",
 					"path", file.sourcePath,
 					"bytes", file.size,
 					"elapsedMs", time.Since(uploadStart).Milliseconds(),
 					"deadlineMs", deadline.Milliseconds(),
-					"retryDelayMs", uploadRetryDelay.Milliseconds(),
+					"retryDelayMs", retryDelay.Milliseconds(),
+					"reason", reason,
 					"error", uploadErr.Error(),
 				)
 				select {
 				case <-ctx.Done():
 					uploadErr = errBackupStopped
-				case <-time.After(uploadRetryDelay):
+				case <-time.After(retryDelay):
 					uploadErr = attemptFileUpload(ctx, provider, file, backupPath)
 				}
 			}
@@ -527,6 +621,15 @@ func createSnapshotWithProgress(ctx context.Context, provider providers.BackupPr
 		if uploadErr != nil {
 			if errors.Is(uploadErr, errBackupStopped) {
 				return abortStopped()
+			}
+			// Probed a second time on purpose: the retry above is the window in
+			// which the snapshot most often dies, and #3260's own tell was a
+			// file whose error flipped from ACCESS_DENIED to PATH_NOT_FOUND
+			// between the first attempt and the retry. Costs one stat per
+			// failing file, and the very first one to see a dead root ends the
+			// run — so at most one extra stat beyond the abort itself.
+			if goneErr := sourceLiveness(file.sourcePath); goneErr != nil {
+				return abortSourceGone(goneErr)
 			}
 			err := fmt.Errorf("failed to upload %s: %w", file.sourcePath, uploadErr)
 			errs = append(errs, err)

--- a/agent/internal/backup/snapshot_test.go
+++ b/agent/internal/backup/snapshot_test.go
@@ -341,7 +341,7 @@ func TestSnapshotProgressCallback(t *testing.T) {
 	restore := setProgressThrottleForTest(0) // emit every file in tests
 	defer restore()
 	_, err := createSnapshotWithProgress(context.Background(), p, files,
-		func(fd, ft int, bd, bt int64, snapshotID string) { got = append(got, bd) }, nil, nil)
+		func(fd, ft int, bd, bt int64, snapshotID string) { got = append(got, bd) }, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +374,7 @@ func TestSnapshotProgressCarriesSnapshotIDFromFirstEmission(t *testing.T) {
 	snapshot, err := createSnapshotWithProgress(context.Background(), p, files,
 		func(fd, ft int, bd, bt int64, snapshotID string) {
 			got = append(got, emission{filesDone: fd, bytesDone: bd, snapshotID: snapshotID})
-		}, nil, nil)
+		}, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -709,7 +709,7 @@ func TestCreateSnapshotWithProgress_StopWithoutJournal_CleansUpPrefix(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := createSnapshotWithProgress(ctx, provider, files, nil, nil, nil)
+		_, err := createSnapshotWithProgress(ctx, provider, files, nil, nil, nil, nil)
 		errCh <- err
 	}()
 
@@ -759,7 +759,7 @@ func TestCreateSnapshotWithProgress_StopWithJournal_PreservesPrefixAndJournal(t 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := createSnapshotWithProgress(ctx, provider, files, nil, journal, nil)
+		_, err := createSnapshotWithProgress(ctx, provider, files, nil, journal, nil, nil)
 		errCh <- err
 	}()
 
@@ -830,7 +830,7 @@ func TestCreateSnapshotWithProgress_ResumeAfterInterruption(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := createSnapshotWithProgress(ctx, provider, files, nil, journal1, nil)
+		_, err := createSnapshotWithProgress(ctx, provider, files, nil, journal1, nil, nil)
 		errCh <- err
 	}()
 	select {
@@ -873,7 +873,7 @@ func TestCreateSnapshotWithProgress_ResumeAfterInterruption(t *testing.T) {
 		recording.files[k] = v
 	}
 
-	snapshot2, err := createSnapshotWithProgress(context.Background(), recording, files, nil, journal2, nil)
+	snapshot2, err := createSnapshotWithProgress(context.Background(), recording, files, nil, journal2, nil, nil)
 	if err != nil {
 		t.Fatalf("run 2 failed: %v", err)
 	}
@@ -947,7 +947,7 @@ func TestSnapshotRegistrationEmissionReportsResumedCounters(t *testing.T) {
 	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files,
 		func(fd, ft int, bd, bt int64, snapshotID string) {
 			got = append(got, emission{filesDone: fd, bytesDone: bd, snapshotID: snapshotID})
-		}, journal, nil)
+		}, journal, nil, nil)
 	if err != nil {
 		t.Fatalf("createSnapshotWithProgress failed: %v", err)
 	}
@@ -997,7 +997,7 @@ func TestCreateSnapshotWithProgress_ChangedFileReuploadsAndSupersedes(t *testing
 		{sourcePath: changedPath, snapshotPath: "path_0/changed.txt", size: int64(len("new content")), modTime: newModTime},
 	}
 
-	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, journal, nil)
+	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, journal, nil, nil)
 	if err != nil {
 		t.Fatalf("createSnapshotWithProgress failed: %v", err)
 	}
@@ -1033,7 +1033,7 @@ func TestCreateSnapshotWithProgress_JournalRecordFailureDoesNotFailBackup(t *tes
 		t.Fatalf("test setup: failed to close journal file: %v", err)
 	}
 
-	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, journal, nil)
+	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, journal, nil, nil)
 	if err != nil {
 		t.Fatalf("a broken journal must not fail the backup, got: %v", err)
 	}
@@ -1093,7 +1093,7 @@ func TestCreateSnapshotWithProgress_VSSOriginalPathResumeMatch(t *testing.T) {
 		modTime:      modTime,
 	}
 
-	snapshot, err := createSnapshotWithProgress(context.Background(), provider, []backupFile{run2File}, nil, journal2, nil)
+	snapshot, err := createSnapshotWithProgress(context.Background(), provider, []backupFile{run2File}, nil, journal2, nil, nil)
 	if err != nil {
 		t.Fatalf("run 2 failed: %v", err)
 	}
@@ -1124,7 +1124,7 @@ func TestCreateSnapshotWithProgress_NonVSSFilesCarryNoOriginalPath(t *testing.T)
 		{sourcePath: writeTempFile(t, "plain"), snapshotPath: "a", size: 5}, // originalPath left zero-value
 	}
 
-	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, nil)
+	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("createSnapshotWithProgress failed: %v", err)
 	}
@@ -1442,7 +1442,7 @@ func TestSnapshotProgressKeepalive_EmitsDuringInFlightUpload(t *testing.T) {
 				case progressed <- emission{fd, ft, bd, bt}:
 				default:
 				}
-			}, nil, nil)
+			}, nil, nil, nil)
 		done <- err
 	}()
 
@@ -1543,7 +1543,7 @@ func TestCreateSnapshotWithProgress_IncrementalTwoRun_ReferencesUnchangedFiles(t
 		{sourcePath: f2, snapshotPath: "path_0/f2.txt", size: 3, modTime: modTime},
 		{sourcePath: f3, snapshotPath: "path_0/f3.txt", size: 5, modTime: modTime},
 	}
-	snapshot1, err := createSnapshotWithProgress(context.Background(), provider, run1Files, nil, nil, nil)
+	snapshot1, err := createSnapshotWithProgress(context.Background(), provider, run1Files, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("run 1 failed: %v", err)
 	}
@@ -1583,7 +1583,7 @@ func TestCreateSnapshotWithProgress_IncrementalTwoRun_ReferencesUnchangedFiles(t
 		{sourcePath: f2, snapshotPath: "path_0/f2.txt", size: int64(len("TWO-CHANGED")), modTime: newModTime}, // changed
 		// f3 deliberately absent — deleted from disk before this run's walk.
 	}
-	snapshot2, err := createSnapshotWithProgress(context.Background(), provider, run2Files, nil, nil, prev)
+	snapshot2, err := createSnapshotWithProgress(context.Background(), provider, run2Files, nil, nil, prev, nil)
 	if err != nil {
 		t.Fatalf("run 2 failed: %v", err)
 	}
@@ -1674,7 +1674,7 @@ func TestIncrementalBackup_FetchFailureFallsBackToFullRun(t *testing.T) {
 	}
 	provider.listErr = nil // the run itself must still be able to list/delete normally
 
-	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, prev)
+	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, prev, nil)
 	if err != nil {
 		t.Fatalf("full-run fallback failed: %v", err)
 	}
@@ -1732,7 +1732,7 @@ func TestCreateSnapshotWithProgress_JournalResumeWinsOverReference(t *testing.T)
 	provider := newMockProvider()
 	files := []backupFile{{sourcePath: filePath, snapshotPath: "path_0/f.txt", size: int64(len("content")), modTime: modTime}}
 
-	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, journal, prevSnapshot)
+	snapshot, err := createSnapshotWithProgress(context.Background(), provider, files, nil, journal, prevSnapshot, nil)
 	if err != nil {
 		t.Fatalf("createSnapshotWithProgress failed: %v", err)
 	}

--- a/agent/internal/backup/source_liveness.go
+++ b/agent/internal/backup/source_liveness.go
@@ -1,0 +1,184 @@
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+// errSourceSnapshotGone marks the mid-run abort in #3260: the point-in-time
+// source the run is reading from — on Windows, the VSS shadow copy created at
+// the start of the job — stopped resolving while the upload loop was still
+// walking it.
+//
+// Field repro (v0.104.0, Windows Server 2022, 2026-08-07, job b906f40d): 15
+// ACL-denied files out of 40 each burned the 30s upload backoff (#3259); at
+// roughly +390s the shadow copy `HarddiskVolumeShadowCopy26` stopped resolving,
+// and files 14-40 — every one of them readable — then failed with
+// ERROR_PATH_NOT_FOUND. Because ERROR_PATH_NOT_FOUND is in the permanent
+// fast-skip set, the run drained the rest of its file list at memory speed and
+// recorded all of it as per-file failures. The job finished `failed` with zero
+// files backed up and an error log that blamed the files.
+//
+// Recording a dead snapshot's fallout as per-file verdicts is the worst
+// available outcome: it is indistinguishable from "those files were bad". This
+// error exists so the run stops at the first sign of it and says what actually
+// happened.
+//
+// Deliberately NOT called "expired": a VSS_CTX_BACKUP shadow copy has no TTL,
+// so nothing here times out. It becomes unavailable — deleted by the provider,
+// lost to diff-area exhaustion, removed externally, or (see the note in
+// vss.CreateShadowCopy about releasing IVssBackupComponents) auto-released. The
+// guard is agnostic about which; it only reports that the source went away.
+var errSourceSnapshotGone = errors.New("backup source snapshot is no longer available (VSS shadow copy deleted or became unavailable mid-run)")
+
+// sourceLivenessFn reports a non-nil error when the point-in-time source that
+// sourcePath was read from has gone away. It is scoped to a single file on
+// purpose: with several volumes snapshotted, losing volume D's shadow copy says
+// nothing about the files still to be read from volume C, and aborting the run
+// over an unrelated volume would be its own false-abort bug.
+//
+// A nil sourceLivenessFn means "this run has no snapshot to defend" — a non-VSS
+// run reads the live filesystem, which cannot go away out from under it.
+//
+// It is only ever consulted AFTER a per-file upload has already failed, so its
+// cost is bounded by the number of failures, not the number of files.
+type sourceLivenessFn func(sourcePath string) error
+
+// snapshotRootStat is os.Stat, indirected so tests can retire a shadow root
+// mid-run without a real VSS session.
+var snapshotRootStat = os.Stat
+
+// setSnapshotRootStatForTest overrides snapshotRootStat. Call the returned
+// restore func (typically via defer) to put the real os.Stat back.
+func setSnapshotRootStatForTest(fn func(string) (os.FileInfo, error)) (restore func()) {
+	old := snapshotRootStat
+	snapshotRootStat = fn
+	return func() { snapshotRootStat = old }
+}
+
+// shadowRootConfirmDelay separates the two stats that must BOTH report "gone"
+// before a run is aborted. Killing a whole backup is drastic enough to be worth
+// one confirmation: a single anomalous stat can never do it, only a root that
+// is still missing a moment later.
+var shadowRootConfirmDelay = 250 * time.Millisecond
+
+// setShadowRootConfirmDelayForTest overrides shadowRootConfirmDelay. Call the
+// returned restore func (typically via defer) to put the real delay back.
+func setShadowRootConfirmDelayForTest(d time.Duration) (restore func()) {
+	old := shadowRootConfirmDelay
+	shadowRootConfirmDelay = d
+	return func() { shadowRootConfirmDelay = old }
+}
+
+// newShadowRootLiveness builds a liveness probe over the VSS shadow-copy device
+// roots this run's files were rewritten onto (`vss.VSSSession.ShadowPaths`,
+// values like `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy26`; see
+// rewritePathsForVSS, which prefixes exactly these strings onto each source
+// path). Returns nil — meaning "nothing to defend" — when the run is not
+// reading from a shadow copy at all.
+//
+// SELF-CALIBRATING BY DESIGN. Each root is stat'd once here, at construction,
+// and only the roots that resolve at that moment are watched. This is what
+// makes a false abort structurally impossible rather than merely unlikely: the
+// probe can never fail on a path form that os.Stat was never able to resolve in
+// the first place (`\\?\GLOBALROOT\...` is an unusual shape, and a probe that
+// assumed it stats cleanly would abort every healthy backup if that assumption
+// were ever wrong). A root only counts as gone if it demonstrably resolved at
+// the start of the run and stopped resolving later — which is exactly the
+// transition #3260 describes and nothing else.
+func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
+	seen := map[string]bool{}
+	var roots []string
+	for _, root := range shadowPaths {
+		if root == "" || seen[root] {
+			continue
+		}
+		seen[root] = true
+		if _, err := snapshotRootStat(root); err != nil {
+			// Not watchable: it never resolved, so its later failure would say
+			// nothing about the snapshot going away. Debug, not warn — on an
+			// odd path form this is expected, and the run is unaffected either
+			// way (it simply keeps the pre-#3260 behaviour for those files).
+			log.Debug("shadow copy root is not stat-able, excluding it from mid-run liveness checks",
+				"root", root,
+				"error", err.Error(),
+			)
+			continue
+		}
+		roots = append(roots, root)
+	}
+	if len(roots) == 0 {
+		return nil
+	}
+	// Longest root first so prefix matching picks the most specific one, and
+	// deterministically (map iteration order is randomized).
+	sort.Slice(roots, func(i, j int) bool {
+		if len(roots[i]) != len(roots[j]) {
+			return len(roots[i]) > len(roots[j])
+		}
+		return roots[i] < roots[j]
+	})
+
+	log.Debug("watching shadow copy roots for mid-run disappearance", "roots", len(roots))
+
+	return func(sourcePath string) error {
+		root, ok := matchShadowRoot(roots, sourcePath)
+		if !ok {
+			// This file was not read through a watched shadow root — a
+			// system-state staging file, or a path on an unprotected volume
+			// that rewritePathsForVSS left pointing at the live filesystem.
+			// There is no snapshot behind it to have gone away.
+			return nil
+		}
+		if !shadowRootMissing(root) {
+			return nil
+		}
+		// Confirm before killing the run. A root that is genuinely gone stays
+		// gone; a one-off anomalous stat resolves on the second look.
+		time.Sleep(shadowRootConfirmDelay)
+		if !shadowRootMissing(root) {
+			log.Warn("shadow copy root briefly failed to resolve but came back, continuing",
+				"root", root,
+			)
+			return nil
+		}
+		return fmt.Errorf("%w: %s", errSourceSnapshotGone, root)
+	}
+}
+
+// matchShadowRoot returns the watched root that sourcePath was read through.
+// roots must be ordered longest-first.
+func matchShadowRoot(roots []string, sourcePath string) (string, bool) {
+	for _, root := range roots {
+		if strings.HasPrefix(sourcePath, root) {
+			return root, true
+		}
+	}
+	return "", false
+}
+
+// shadowRootMissing reports whether a root has stopped existing.
+//
+// Only a not-exist answer counts. Any OTHER stat error — a momentary I/O
+// hiccup, a permission oddity — is NOT evidence that the snapshot went away,
+// and aborting a whole run on it would recreate the bug this guards against in
+// a new form.
+func shadowRootMissing(root string) bool {
+	_, err := snapshotRootStat(root)
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+	log.Debug("shadow copy root liveness check was inconclusive, treating the snapshot as alive",
+		"root", root,
+		"error", err.Error(),
+	)
+	return false
+}

--- a/agent/internal/backup/source_liveness.go
+++ b/agent/internal/backup/source_liveness.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -113,6 +114,18 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 		roots = append(roots, root)
 	}
 	if len(roots) == 0 {
+		if len(shadowPaths) > 0 {
+			// VSS really was active for this run, yet not one of its roots
+			// could be watched — so the #3260 guard is OFF and a shadow copy
+			// that dies mid-run will once again be recorded as a pile of
+			// per-file failures. Warn, not Debug: at production verbosity a
+			// silent nil here is indistinguishable from "the guard is armed
+			// and saw nothing wrong", which is exactly the ambiguity this
+			// whole change exists to remove.
+			log.Warn("VSS is active but no shadow copy root could be watched; mid-run snapshot-loss detection is disabled for this run",
+				"rootsOffered", len(shadowPaths),
+			)
+		}
 		return nil
 	}
 	// Longest root first so prefix matching picks the most specific one, and
@@ -126,6 +139,13 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 
 	log.Debug("watching shadow copy roots for mid-run disappearance", "roots", len(roots))
 
+	// warnedInconclusive tracks roots already reported as un-checkable, so the
+	// warning below fires once per root per run rather than once per failing
+	// file. Guarded because nothing in the contract promises the probe is only
+	// ever called from the single upload goroutine.
+	var mu sync.Mutex
+	warnedInconclusive := map[string]bool{}
+
 	return func(sourcePath string) error {
 		root, ok := matchShadowRoot(roots, sourcePath)
 		if !ok {
@@ -135,13 +155,33 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 			// There is no snapshot behind it to have gone away.
 			return nil
 		}
-		if !shadowRootMissing(root) {
+		missing, inconclusive := shadowRootMissing(root)
+		if inconclusive != nil {
+			// The stat failed for a reason other than "does not exist", so it
+			// is not evidence of anything and the run continues. But a root
+			// that answers this way every time leaves the guard unable to
+			// decide, for the rest of the run, whether a failure is the file's
+			// fault or the snapshot's — the same ambiguity as having no guard
+			// at all, so it has to be visible above Debug.
+			mu.Lock()
+			first := !warnedInconclusive[root]
+			warnedInconclusive[root] = true
+			mu.Unlock()
+			if first {
+				log.Warn("shadow copy root liveness check is inconclusive; treating the snapshot as alive and cannot confirm this root for the rest of the run",
+					"root", root,
+					"error", inconclusive.Error(),
+				)
+			}
+			return nil
+		}
+		if !missing {
 			return nil
 		}
 		// Confirm before killing the run. A root that is genuinely gone stays
 		// gone; a one-off anomalous stat resolves on the second look.
 		time.Sleep(shadowRootConfirmDelay)
-		if !shadowRootMissing(root) {
+		if confirmed, _ := shadowRootMissing(root); !confirmed {
 			log.Warn("shadow copy root briefly failed to resolve but came back, continuing",
 				"root", root,
 			)
@@ -153,9 +193,19 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 
 // matchShadowRoot returns the watched root that sourcePath was read through.
 // roots must be ordered longest-first.
+//
+// The match is on a path BOUNDARY, not a bare string prefix: shadow-copy device
+// paths are numbered (`...HarddiskVolumeShadowCopy2` vs `...ShadowCopy26`), so a
+// bare prefix test would let a file under ShadowCopy26 be checked against
+// ShadowCopy2's root whenever 26 itself is unwatched — and abort a healthy run
+// because some other volume's snapshot went away.
 func matchShadowRoot(roots []string, sourcePath string) (string, bool) {
 	for _, root := range roots {
-		if strings.HasPrefix(sourcePath, root) {
+		if !strings.HasPrefix(sourcePath, root) {
+			continue
+		}
+		rest := sourcePath[len(root):]
+		if rest == "" || rest[0] == '\\' || rest[0] == '/' {
 			return root, true
 		}
 	}
@@ -164,21 +214,19 @@ func matchShadowRoot(roots []string, sourcePath string) (string, bool) {
 
 // shadowRootMissing reports whether a root has stopped existing.
 //
-// Only a not-exist answer counts. Any OTHER stat error — a momentary I/O
-// hiccup, a permission oddity — is NOT evidence that the snapshot went away,
-// and aborting a whole run on it would recreate the bug this guards against in
-// a new form.
-func shadowRootMissing(root string) bool {
+// Three-way, not boolean: (false, nil) alive, (true, nil) confirmed gone, and
+// (false, err) inconclusive. Only a not-exist answer counts as gone. Any OTHER
+// stat error — a momentary I/O hiccup, a permission oddity — is NOT evidence
+// that the snapshot went away, and aborting a whole run on it would recreate
+// the bug this guards against in a new form. The error is returned rather than
+// swallowed so the caller can surface a root it can no longer vouch for.
+func shadowRootMissing(root string) (missing bool, inconclusive error) {
 	_, err := snapshotRootStat(root)
 	if err == nil {
-		return false
+		return false, nil
 	}
 	if errors.Is(err, fs.ErrNotExist) {
-		return true
+		return true, nil
 	}
-	log.Debug("shadow copy root liveness check was inconclusive, treating the snapshot as alive",
-		"root", root,
-		"error", err.Error(),
-	)
-	return false
+	return false, err
 }

--- a/agent/internal/backup/source_liveness.go
+++ b/agent/internal/backup/source_liveness.go
@@ -181,7 +181,18 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 		// Confirm before killing the run. A root that is genuinely gone stays
 		// gone; a one-off anomalous stat resolves on the second look.
 		time.Sleep(shadowRootConfirmDelay)
-		if confirmed, _ := shadowRootMissing(root); !confirmed {
+		confirmed, confirmErr := shadowRootMissing(root)
+		if confirmErr != nil {
+			// The second look neither confirmed nor cleared it. Report that
+			// honestly rather than as "came back" — an unactionable message
+			// that misdescribes what happened is the #3260 complaint itself.
+			log.Warn("shadow copy root went missing then answered inconclusively; not aborting the run",
+				"root", root,
+				"error", confirmErr.Error(),
+			)
+			return nil
+		}
+		if !confirmed {
 			log.Warn("shadow copy root briefly failed to resolve but came back, continuing",
 				"root", root,
 			)

--- a/agent/internal/backup/source_liveness.go
+++ b/agent/internal/backup/source_liveness.go
@@ -16,14 +16,16 @@ import (
 // the start of the job — stopped resolving while the upload loop was still
 // walking it.
 //
-// Field repro (v0.104.0, Windows Server 2022, 2026-08-07, job b906f40d): 15
-// ACL-denied files out of 40 each burned the 30s upload backoff (#3259); at
-// roughly +390s the shadow copy `HarddiskVolumeShadowCopy26` stopped resolving,
-// and files 14-40 — every one of them readable — then failed with
-// ERROR_PATH_NOT_FOUND. Because ERROR_PATH_NOT_FOUND is in the permanent
-// fast-skip set, the run drained the rest of its file list at memory speed and
-// recorded all of it as per-file failures. The job finished `failed` with zero
-// files backed up and an error log that blamed the files.
+// Field repro (v0.104.0, Windows Server 2022, 2026-08-07, job b906f40d): a
+// 40-file set with 15 ACL-denied files. The first ~13 denials each burned the
+// 30s upload backoff (#3259) — 13 x 30s is the +390s at which the shadow copy
+// `HarddiskVolumeShadowCopy26` stopped resolving, before the run had even
+// reached the last of the denied files. From there every remaining file —
+// including the 25+ readable ones — failed with ERROR_PATH_NOT_FOUND. Because
+// ERROR_PATH_NOT_FOUND is in the permanent fast-skip set, the run drained the
+// rest of its file list at memory speed and recorded all of it as per-file
+// failures. The job finished `failed` with zero files backed up and an error
+// log that blamed the files.
 //
 // Recording a dead snapshot's fallout as per-file verdicts is the worst
 // available outcome: it is indistinguishable from "those files were bad". This
@@ -32,16 +34,24 @@ import (
 //
 // Deliberately NOT called "expired": a VSS_CTX_BACKUP shadow copy has no TTL,
 // so nothing here times out. It becomes unavailable — deleted by the provider,
-// lost to diff-area exhaustion, removed externally, or (see the note in
-// vss.CreateShadowCopy about releasing IVssBackupComponents) auto-released. The
-// guard is agnostic about which; it only reports that the source went away.
+// lost to diff-area exhaustion, removed externally, or auto-released when
+// IVssBackupComponents is released (Microsoft-documented behaviour for
+// auto-release VSS_CTX_BACKUP copies; the contrary note in
+// vss.CreateShadowCopy, which claims reclamation only at requester process
+// exit, is tracked as #3269). The guard is agnostic about which; it only
+// reports that the source went away.
 var errSourceSnapshotGone = errors.New("backup source snapshot is no longer available (VSS shadow copy deleted or became unavailable mid-run)")
 
 // sourceLivenessFn reports a non-nil error when the point-in-time source that
-// sourcePath was read from has gone away. It is scoped to a single file on
-// purpose: with several volumes snapshotted, losing volume D's shadow copy says
-// nothing about the files still to be read from volume C, and aborting the run
-// over an unrelated volume would be its own false-abort bug.
+// sourcePath was read from has gone away.
+//
+// It is scoped to a single file on purpose, but note what that scoping does and
+// does not do. It governs which failures TRIGGER an abort — a file on volume C
+// is judged against C's shadow copy, so losing volume D cannot condemn it. The
+// abort itself is NOT scoped: once triggered it ends the whole run, both
+// volumes included. That is intended (a run that can no longer read one of its
+// sources is not a run worth finishing), but it means the per-volume check is
+// about not firing spuriously, not about limiting the blast radius.
 //
 // A nil sourceLivenessFn means "this run has no snapshot to defend" — a non-VSS
 // run reads the live filesystem, which cannot go away out from under it.
@@ -50,9 +60,54 @@ var errSourceSnapshotGone = errors.New("backup source snapshot is no longer avai
 // cost is bounded by the number of failures, not the number of files.
 type sourceLivenessFn func(sourcePath string) error
 
+// watchedRoot is one shadow-copy root the run is reading from.
+//
+// prefix and statPath are separate because they answer different questions and
+// are NOT always the same string. prefix is the exact text rewritePathsForVSS
+// prepended to every source path on that volume, so it is what file paths must
+// be matched against. statPath is whatever form of that root os.Stat actually
+// accepts.
+//
+// They diverge on real Windows. vss.CreateShadowCopy returns
+// VSS_SNAPSHOT_PROP.SnapshotDeviceObject verbatim — e.g.
+// `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy26`, with NO trailing
+// separator — and a bare device path of that shape is not reliably stat-able
+// even while the snapshot is perfectly healthy and every file under it reads
+// fine. Conflating the two would make resolveStatablePath fail on every real
+// run and silently disarm the whole guard.
+type watchedRoot struct {
+	prefix   string
+	statPath string
+}
+
 // snapshotRootStat is os.Stat, indirected so tests can retire a shadow root
 // mid-run without a real VSS session.
 var snapshotRootStat = os.Stat
+
+// resolveStatablePath finds a form of root that os.Stat accepts, and returns
+// it. Tries the root verbatim first, then with a trailing separator appended.
+//
+// The trailing-separator fallback is the difference between a working guard and
+// an inert one on Windows: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopyNN`
+// names a device object, and the Win32 attribute query behind os.Stat wants a
+// directory path. Everything that has ever been shown to work on a real shadow
+// copy — the live VSS test's ReadDir, the file walk itself — goes through a
+// path with a separator after the device name, never the bare device name.
+//
+// The error returned is the FIRST failure (the verbatim one), since that is the
+// form the caller asked about.
+func resolveStatablePath(root string) (string, error) {
+	_, err := snapshotRootStat(root)
+	if err == nil {
+		return root, nil
+	}
+	if withSep := root + `\`; withSep != root {
+		if _, sepErr := snapshotRootStat(withSep); sepErr == nil {
+			return withSep, nil
+		}
+	}
+	return "", err
+}
 
 // setSnapshotRootStatForTest overrides snapshotRootStat. Call the returned
 // restore func (typically via defer) to put the real os.Stat back.
@@ -94,25 +149,29 @@ func setShadowRootConfirmDelayForTest(d time.Duration) (restore func()) {
 // transition #3260 describes and nothing else.
 func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 	seen := map[string]bool{}
-	var roots []string
+	var roots []watchedRoot
+	type exclusion struct {
+		root string
+		err  error
+	}
+	var excluded []exclusion
+
 	for _, root := range shadowPaths {
 		if root == "" || seen[root] {
 			continue
 		}
 		seen[root] = true
-		if _, err := snapshotRootStat(root); err != nil {
+		statPath, err := resolveStatablePath(root)
+		if err != nil {
 			// Not watchable: it never resolved, so its later failure would say
-			// nothing about the snapshot going away. Debug, not warn — on an
-			// odd path form this is expected, and the run is unaffected either
-			// way (it simply keeps the pre-#3260 behaviour for those files).
-			log.Debug("shadow copy root is not stat-able, excluding it from mid-run liveness checks",
-				"root", root,
-				"error", err.Error(),
-			)
+			// nothing about the snapshot going away. Logged after the loop,
+			// where we know whether this was a total or partial loss of cover.
+			excluded = append(excluded, exclusion{root: root, err: err})
 			continue
 		}
-		roots = append(roots, root)
+		roots = append(roots, watchedRoot{prefix: root, statPath: statPath})
 	}
+
 	if len(roots) == 0 {
 		if len(shadowPaths) > 0 {
 			// VSS really was active for this run, yet not one of its roots
@@ -125,19 +184,42 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 			log.Warn("VSS is active but no shadow copy root could be watched; mid-run snapshot-loss detection is disabled for this run",
 				"rootsOffered", len(shadowPaths),
 			)
+			for _, ex := range excluded {
+				log.Warn("shadow copy root is not stat-able", "root", ex.root, "error", ex.err.Error())
+			}
 		}
 		return nil
 	}
+
+	// PARTIAL cover is the dangerous middle case: the guard is armed, so the
+	// run looks protected, but files on an excluded volume can still be
+	// misattributed exactly as #3260 describes. Warn per excluded root —
+	// silence here would hide a half-disarmed guard behind an armed one.
+	for _, ex := range excluded {
+		log.Warn("shadow copy root is not stat-able; mid-run snapshot-loss detection is disabled for FILES ON THIS VOLUME ONLY",
+			"root", ex.root,
+			"error", ex.err.Error(),
+			"rootsStillWatched", len(roots),
+		)
+	}
+
 	// Longest root first so prefix matching picks the most specific one, and
 	// deterministically (map iteration order is randomized).
 	sort.Slice(roots, func(i, j int) bool {
-		if len(roots[i]) != len(roots[j]) {
-			return len(roots[i]) > len(roots[j])
+		if len(roots[i].prefix) != len(roots[j].prefix) {
+			return len(roots[i].prefix) > len(roots[j].prefix)
 		}
-		return roots[i] < roots[j]
+		return roots[i].prefix < roots[j].prefix
 	})
 
-	log.Debug("watching shadow copy roots for mid-run disappearance", "roots", len(roots))
+	// Info, not Debug: this is the one line that lets a production log
+	// positively confirm the #3260 guard was armed for a given run, and say
+	// over how much of it. Without it, "armed and quiet" and "never armed"
+	// look the same after the fact.
+	log.Info("mid-run snapshot-loss detection armed",
+		"rootsWatched", len(roots),
+		"rootsExcluded", len(excluded),
+	)
 
 	// warnedInconclusive tracks roots already reported as un-checkable, so the
 	// warning below fires once per root per run rather than once per failing
@@ -150,12 +232,12 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 		root, ok := matchShadowRoot(roots, sourcePath)
 		if !ok {
 			// This file was not read through a watched shadow root — a
-			// system-state staging file, or a path on an unprotected volume
-			// that rewritePathsForVSS left pointing at the live filesystem.
-			// There is no snapshot behind it to have gone away.
+			// system-state staging file, a path on an unprotected volume that
+			// rewritePathsForVSS left pointing at the live filesystem, or a
+			// volume excluded above. There is no watched snapshot behind it.
 			return nil
 		}
-		missing, inconclusive := shadowRootMissing(root)
+		missing, inconclusive := shadowRootMissing(root.statPath)
 		if inconclusive != nil {
 			// The stat failed for a reason other than "does not exist", so it
 			// is not evidence of anything and the run continues. But a root
@@ -164,12 +246,12 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 			// fault or the snapshot's — the same ambiguity as having no guard
 			// at all, so it has to be visible above Debug.
 			mu.Lock()
-			first := !warnedInconclusive[root]
-			warnedInconclusive[root] = true
+			first := !warnedInconclusive[root.prefix]
+			warnedInconclusive[root.prefix] = true
 			mu.Unlock()
 			if first {
 				log.Warn("shadow copy root liveness check is inconclusive; treating the snapshot as alive and cannot confirm this root for the rest of the run",
-					"root", root,
+					"root", root.prefix,
 					"error", inconclusive.Error(),
 				)
 			}
@@ -181,24 +263,24 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 		// Confirm before killing the run. A root that is genuinely gone stays
 		// gone; a one-off anomalous stat resolves on the second look.
 		time.Sleep(shadowRootConfirmDelay)
-		confirmed, confirmErr := shadowRootMissing(root)
+		confirmed, confirmErr := shadowRootMissing(root.statPath)
 		if confirmErr != nil {
 			// The second look neither confirmed nor cleared it. Report that
 			// honestly rather than as "came back" — an unactionable message
 			// that misdescribes what happened is the #3260 complaint itself.
 			log.Warn("shadow copy root went missing then answered inconclusively; not aborting the run",
-				"root", root,
+				"root", root.prefix,
 				"error", confirmErr.Error(),
 			)
 			return nil
 		}
 		if !confirmed {
 			log.Warn("shadow copy root briefly failed to resolve but came back, continuing",
-				"root", root,
+				"root", root.prefix,
 			)
 			return nil
 		}
-		return fmt.Errorf("%w: %s", errSourceSnapshotGone, root)
+		return fmt.Errorf("%w: %s", errSourceSnapshotGone, root.prefix)
 	}
 }
 
@@ -210,17 +292,17 @@ func newShadowRootLiveness(shadowPaths map[string]string) sourceLivenessFn {
 // bare prefix test would let a file under ShadowCopy26 be checked against
 // ShadowCopy2's root whenever 26 itself is unwatched — and abort a healthy run
 // because some other volume's snapshot went away.
-func matchShadowRoot(roots []string, sourcePath string) (string, bool) {
+func matchShadowRoot(roots []watchedRoot, sourcePath string) (watchedRoot, bool) {
 	for _, root := range roots {
-		if !strings.HasPrefix(sourcePath, root) {
+		if !strings.HasPrefix(sourcePath, root.prefix) {
 			continue
 		}
-		rest := sourcePath[len(root):]
+		rest := sourcePath[len(root.prefix):]
 		if rest == "" || rest[0] == '\\' || rest[0] == '/' {
 			return root, true
 		}
 	}
-	return "", false
+	return watchedRoot{}, false
 }
 
 // shadowRootMissing reports whether a root has stopped existing.

--- a/agent/internal/backup/source_liveness_test.go
+++ b/agent/internal/backup/source_liveness_test.go
@@ -1,0 +1,451 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fakeStat drives snapshotRootStat from a per-path script so a test can retire
+// a shadow root mid-run without a real VSS session. Absent paths report
+// fs.ErrNotExist; a path can be given a non-not-exist error to model an
+// inconclusive stat.
+type fakeStat struct {
+	mu      sync.Mutex
+	present map[string]bool
+	errFor  map[string]error
+}
+
+func newFakeStat(present ...string) *fakeStat {
+	f := &fakeStat{present: map[string]bool{}, errFor: map[string]error{}}
+	for _, p := range present {
+		f.present[p] = true
+	}
+	return f
+}
+
+func (f *fakeStat) stat(path string) (os.FileInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err, ok := f.errFor[path]; ok {
+		return nil, err
+	}
+	if !f.present[path] {
+		return nil, &fs.PathError{Op: "stat", Path: path, Err: syscall.ENOENT}
+	}
+	// The probe only ever inspects the error, never the FileInfo.
+	return nil, nil
+}
+
+func (f *fakeStat) set(path string, present bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.present[path] = present
+}
+
+func (f *fakeStat) setErr(path string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.errFor[path] = err
+}
+
+// install swaps in the fake stat and neutralises the confirmation delay so the
+// suite does not pay it on every probe. Tests that care about the confirmation
+// behaviour drive it explicitly.
+func (f *fakeStat) install(t *testing.T) {
+	t.Helper()
+	t.Cleanup(setSnapshotRootStatForTest(f.stat))
+	t.Cleanup(setShadowRootConfirmDelayForTest(0))
+}
+
+const (
+	shadowC = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy26`
+	shadowD = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy27`
+	// A source path as rewritePathsForVSS produces it: the shadow device path
+	// with the volume-relative remainder appended.
+	fileOnC = shadowC + `\Users\u\Documents\report.docx`
+	fileOnD = shadowD + `\Data\db.mdf`
+)
+
+func TestNewShadowRootLiveness(t *testing.T) {
+	tests := []struct {
+		name        string
+		present     []string
+		shadowPaths map[string]string
+		wantNil     bool
+		// retire is applied after construction, before probing.
+		retire    []string
+		probePath string
+		wantGone  bool
+		wantNames string
+	}{
+		{
+			name:        "no VSS session means nothing to defend",
+			shadowPaths: nil,
+			wantNil:     true,
+		},
+		{
+			name:        "empty device path is not watchable",
+			shadowPaths: map[string]string{`C:`: ""},
+			wantNil:     true,
+		},
+		{
+			// The self-calibration guard: a root that never stat'd cleanly is
+			// excluded, so its later failure can never abort a healthy run.
+			name:        "root that does not resolve at construction is excluded",
+			present:     nil,
+			shadowPaths: map[string]string{`C:`: shadowC},
+			wantNil:     true,
+		},
+		{
+			name:        "live root reports alive",
+			present:     []string{shadowC},
+			shadowPaths: map[string]string{`C:`: shadowC},
+			probePath:   fileOnC,
+			wantGone:    false,
+		},
+		{
+			name:        "root that resolved then vanished reports gone",
+			present:     []string{shadowC},
+			shadowPaths: map[string]string{`C:`: shadowC},
+			retire:      []string{shadowC},
+			probePath:   fileOnC,
+			wantGone:    true,
+			wantNames:   shadowC,
+		},
+		{
+			// Per-volume scoping: losing D's shadow copy must not abort a run
+			// that is still reading healthy files from C.
+			name:        "losing another volume's root does not condemn this file",
+			present:     []string{shadowC, shadowD},
+			shadowPaths: map[string]string{`C:`: shadowC, `D:`: shadowD},
+			retire:      []string{shadowD},
+			probePath:   fileOnC,
+			wantGone:    false,
+		},
+		{
+			name:        "the volume that actually vanished does condemn its own files",
+			present:     []string{shadowC, shadowD},
+			shadowPaths: map[string]string{`C:`: shadowC, `D:`: shadowD},
+			retire:      []string{shadowD},
+			probePath:   fileOnD,
+			wantGone:    true,
+			wantNames:   shadowD,
+		},
+		{
+			// A staging/live-read path never went through a shadow root, so
+			// there is no snapshot behind it to have gone away.
+			name:        "path outside every watched root is never condemned",
+			present:     []string{shadowC},
+			shadowPaths: map[string]string{`C:`: shadowC},
+			retire:      []string{shadowC},
+			probePath:   `C:\ProgramData\breeze\staging\systemstate.bin`,
+			wantGone:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeStat(tc.present...)
+			f.install(t)
+
+			probe := newShadowRootLiveness(tc.shadowPaths)
+			if tc.wantNil {
+				if probe != nil {
+					t.Fatal("want a nil probe (nothing watchable), got one")
+				}
+				return
+			}
+			if probe == nil {
+				t.Fatal("want a probe over the live roots, got nil")
+			}
+			for _, p := range tc.retire {
+				f.set(p, false)
+			}
+			err := probe(tc.probePath)
+			if !tc.wantGone {
+				if err != nil {
+					t.Fatalf("want the snapshot reported alive for %q, got %v", tc.probePath, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("want the vanished shadow root reported gone for %q, got nil", tc.probePath)
+			}
+			if !errors.Is(err, errSourceSnapshotGone) {
+				t.Fatalf("want errSourceSnapshotGone, got %v", err)
+			}
+			// The abort message must name the root — #3260's own complaint is
+			// that the operator-visible failure said nothing usable.
+			if !strings.Contains(err.Error(), tc.wantNames) {
+				t.Fatalf("error %q does not name the vanished root %q", err, tc.wantNames)
+			}
+		})
+	}
+}
+
+// A stat that fails for a reason OTHER than "does not exist" is not evidence
+// the snapshot went away. Aborting a whole run on a transient I/O hiccup would
+// recreate #3260 in a new form.
+func TestShadowRootLiveness_InconclusiveStatIsNotGone(t *testing.T) {
+	f := newFakeStat(shadowC)
+	f.install(t)
+	probe := newShadowRootLiveness(map[string]string{`C:`: shadowC})
+	if probe == nil {
+		t.Fatal("want a probe, got nil")
+	}
+	f.setErr(shadowC, errors.New("the device is not ready"))
+
+	if err := probe(fileOnC); err != nil {
+		t.Fatalf("an inconclusive stat error must not report the snapshot gone, got %v", err)
+	}
+}
+
+// Killing a whole backup is drastic enough to require confirmation: a root that
+// is missing once but back on the confirmation look must not abort the run.
+func TestShadowRootLiveness_TransientMissRequiresConfirmation(t *testing.T) {
+	// Scripted stat: construction sees it present, the first probe sees it
+	// missing, every look after that sees it present again.
+	var mu sync.Mutex
+	calls := 0
+	t.Cleanup(setSnapshotRootStatForTest(func(string) (os.FileInfo, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 2 {
+			return nil, &fs.PathError{Op: "stat", Path: shadowC, Err: syscall.ENOENT}
+		}
+		return nil, nil
+	}))
+	t.Cleanup(setShadowRootConfirmDelayForTest(0))
+
+	probe := newShadowRootLiveness(map[string]string{`C:`: shadowC})
+	if probe == nil {
+		t.Fatal("want a probe, got nil")
+	}
+	if err := probe(fileOnC); err != nil {
+		t.Fatalf("a single anomalous stat must not abort the run, got %v", err)
+	}
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 3 {
+		t.Fatalf("want 3 stats (construction + miss + confirmation), got %d", got)
+	}
+}
+
+// ...and a root that is still missing on the confirmation look IS gone.
+func TestShadowRootLiveness_ConfirmedMissIsGone(t *testing.T) {
+	f := newFakeStat(shadowC)
+	f.install(t)
+	probe := newShadowRootLiveness(map[string]string{`C:`: shadowC})
+	f.set(shadowC, false)
+
+	err := probe(fileOnC)
+	if !errors.Is(err, errSourceSnapshotGone) {
+		t.Fatalf("want errSourceSnapshotGone for a confirmed-missing root, got %v", err)
+	}
+}
+
+// expiringProvider fails a chosen file, and from that moment on every
+// subsequent file fails too — the exact #3260 shape, where a dead shadow copy
+// makes every remaining healthy file unreadable.
+type expiringProvider struct {
+	mu sync.Mutex
+	// killAfter is the source path whose failure kills the snapshot.
+	killAfter string
+	dead      bool
+	onDeath   func()
+	attempts  []string
+}
+
+func (p *expiringProvider) UploadContext(_ context.Context, localPath, _ string) error {
+	p.mu.Lock()
+	p.attempts = append(p.attempts, localPath)
+	dead := p.dead
+	trigger := localPath == p.killAfter
+	if trigger && !dead {
+		p.dead = true
+	}
+	onDeath := p.onDeath
+	p.mu.Unlock()
+
+	if trigger {
+		if onDeath != nil {
+			onDeath()
+		}
+		// The denial that starts it all (#3259's ACL case).
+		return permissionErr(localPath)
+	}
+	if dead {
+		// Everything read after the snapshot dies looks like
+		// ERROR_PATH_NOT_FOUND.
+		return notFoundErr(localPath)
+	}
+	return nil
+}
+
+func (p *expiringProvider) Upload(localPath, remotePath string) error {
+	return p.UploadContext(context.Background(), localPath, remotePath)
+}
+func (p *expiringProvider) Download(string, string) error { return nil }
+func (p *expiringProvider) List(string) ([]string, error) { return nil, nil }
+func (p *expiringProvider) Delete(string) error           { return nil }
+
+func (p *expiringProvider) attemptCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.attempts)
+}
+
+// The #3260 regression test. A shadow copy that goes away mid-run must abort
+// the run with an explicit error, NOT record every remaining healthy file as an
+// individual per-file failure.
+func TestCreateSnapshot_ShadowCopyLostMidRun_AbortsExplicitly(t *testing.T) {
+	defer setShortUploadRetryDelayForTest(0)()
+	defer setUploadRetryDelayForTest(0)()
+
+	f := newFakeStat(shadowC)
+	f.install(t)
+
+	// Real files under ONE directory (the loop checksums and compresses through
+	// them), with that directory standing in for the shadow root: it exercises
+	// the real prefix matching without needing a Windows device path.
+	root, files := filesUnderCommonRoot(t, 6)
+	f.set(root, true)
+
+	provider := &expiringProvider{
+		killAfter: files[2].sourcePath,
+		// The snapshot goes away at the same instant the third file fails.
+		onDeath: func() { f.set(root, false) },
+	}
+	liveness := newShadowRootLiveness(map[string]string{`C:`: root})
+	if liveness == nil {
+		t.Fatal("test setup: want a liveness probe, got nil")
+	}
+
+	snap, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, nil, liveness)
+
+	if err == nil {
+		t.Fatal("want the run aborted when the shadow copy is lost, got nil error")
+	}
+	if !errors.Is(err, errSourceSnapshotGone) {
+		t.Fatalf("want errSourceSnapshotGone, got %v", err)
+	}
+	if snap != nil {
+		t.Fatalf("want no snapshot from an aborted run, got one with %d files", len(snap.Files))
+	}
+	// The whole point: files 4-6 were healthy and must never have been tried
+	// against a dead snapshot, let alone recorded as bad. Files 1-2 uploaded,
+	// file 3 failed and triggered the abort.
+	if got := provider.attemptCount(); got != 3 {
+		t.Fatalf("want the run to stop at the failing file (3 attempts), got %d — it kept walking a dead snapshot", got)
+	}
+	// The operator-visible error has to say what happened and how far it got.
+	for _, want := range []string{"no longer available", root, "2 of 6 files uploaded"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("abort error %q is missing %q", err, want)
+		}
+	}
+}
+
+// filesUnderCommonRoot writes n real files into a single directory and returns
+// that directory plus the backupFiles for them. The shared directory stands in
+// for a VSS shadow root so matchShadowRoot's prefix logic is exercised for real
+// on any OS (writeTempFile puts each file in its own subdirectory, which would
+// give the files no common prefix to match on).
+func filesUnderCommonRoot(t *testing.T, n int) (string, []backupFile) {
+	t.Helper()
+	root := t.TempDir()
+	files := make([]backupFile, 0, n)
+	for i := 0; i < n; i++ {
+		body := []byte(fmt.Sprintf("file-%d", i))
+		p := filepath.Join(root, fmt.Sprintf("f%d.txt", i))
+		if err := os.WriteFile(p, body, 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+		files = append(files, backupFile{
+			sourcePath:   p,
+			snapshotPath: fmt.Sprintf("f%d", i),
+			size:         int64(len(body)),
+		})
+	}
+	return root, files
+}
+
+// A run with no snapshot to defend (nil probe — the non-VSS case) must behave
+// exactly as before: per-file failures stay per-file, the job carries on.
+func TestCreateSnapshot_NilLiveness_KeepsPerFileFailureBehaviour(t *testing.T) {
+	defer setUploadRetryDelayForTest(0)()
+
+	good := writeTempFile(t, "good")
+	bad := writeTempFile(t, "bad")
+	p := newFixedErrorProvider(notFoundErr(bad), bad)
+	files := []backupFile{
+		{sourcePath: good, snapshotPath: "good", size: 4},
+		{sourcePath: bad, snapshotPath: "bad", size: 3},
+	}
+
+	snap, err := createSnapshotWithProgress(context.Background(), p, files, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("a per-file failure must not abort a run with no snapshot to defend, got %v", err)
+	}
+	if snap == nil || len(snap.Files) != 1 || len(snap.UploadFailures) != 1 {
+		t.Fatalf("want 1 uploaded + 1 recorded failure, got %+v", snap)
+	}
+}
+
+// A live snapshot must not abort: the probe answering "alive" leaves the
+// existing skip-and-continue behaviour completely untouched.
+func TestCreateSnapshot_LiveSnapshot_DoesNotAbortOnPerFileFailure(t *testing.T) {
+	defer setUploadRetryDelayForTest(0)()
+
+	f := newFakeStat()
+	f.install(t)
+
+	root, files := filesUnderCommonRoot(t, 2)
+	f.set(root, true)
+	liveness := newShadowRootLiveness(map[string]string{`C:`: root})
+	if liveness == nil {
+		t.Fatal("test setup: want a liveness probe, got nil")
+	}
+
+	p := newFixedErrorProvider(notFoundErr(files[1].sourcePath), files[1].sourcePath)
+
+	snap, err := createSnapshotWithProgress(context.Background(), p, files, nil, nil, nil, liveness)
+	if err != nil {
+		t.Fatalf("a live snapshot must not abort on a per-file failure, got %v", err)
+	}
+	if snap == nil || len(snap.Files) != 1 || len(snap.UploadFailures) != 1 {
+		t.Fatalf("want 1 uploaded + 1 recorded failure, got %+v", snap)
+	}
+}
+
+// Job cancellation must still win: a cancelled run reports errBackupStopped
+// (which the manager maps to "stopped"), never the snapshot-loss abort.
+func TestCreateSnapshot_CancelBeatsLivenessAbort(t *testing.T) {
+	defer setUploadRetryDelayForTest(10 * time.Millisecond)()
+
+	f := newFakeStat()
+	f.install(t)
+
+	root, files := filesUnderCommonRoot(t, 1)
+	f.set(root, true)
+	liveness := newShadowRootLiveness(map[string]string{`C:`: root})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := createSnapshotWithProgress(ctx, newMockProvider(), files, nil, nil, nil, liveness)
+	if !errors.Is(err, errBackupStopped) {
+		t.Fatalf("want errBackupStopped for a cancelled run, got %v", err)
+	}
+}

--- a/agent/internal/backup/source_liveness_test.go
+++ b/agent/internal/backup/source_liveness_test.go
@@ -192,6 +192,60 @@ func TestNewShadowRootLiveness(t *testing.T) {
 	}
 }
 
+// Shadow-copy device paths are NUMBERED, so `...ShadowCopy2` is a bare string
+// prefix of `...ShadowCopy26`. Matching must be on a path boundary: otherwise a
+// file rooted under an UNWATCHED ShadowCopy26 would be checked against
+// ShadowCopy2, and losing that unrelated volume would abort a healthy run.
+func TestMatchShadowRoot_MatchesOnPathBoundaryNotBarePrefix(t *testing.T) {
+	const shortRoot = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy2`
+	// Longest-first, as newShadowRootLiveness orders them.
+	roots := []string{shadowC, shortRoot}
+
+	tests := []struct {
+		name     string
+		path     string
+		wantRoot string
+		wantOK   bool
+	}{
+		{
+			name:     "path under the short root matches it",
+			path:     shortRoot + `\Users\u\a.txt`,
+			wantRoot: shortRoot,
+			wantOK:   true,
+		},
+		{
+			name:     "path under the long root matches the long root, not the short one",
+			path:     shadowC + `\Users\u\a.txt`,
+			wantRoot: shadowC,
+			wantOK:   true,
+		},
+		{
+			// The regression this boundary check exists for: ShadowCopy27 is
+			// not watched, and must NOT fall through onto ShadowCopy2.
+			name:   "path under an unwatched sibling root matches nothing",
+			path:   shadowD + `\Data\db.mdf`,
+			wantOK: false,
+		},
+		{
+			name:     "the bare root itself matches",
+			path:     shortRoot,
+			wantRoot: shortRoot,
+			wantOK:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, ok := matchShadowRoot(roots, tc.path)
+			if ok != tc.wantOK {
+				t.Fatalf("matchShadowRoot(%q) ok = %v, want %v (root %q)", tc.path, ok, tc.wantOK, root)
+			}
+			if ok && root != tc.wantRoot {
+				t.Fatalf("matchShadowRoot(%q) = %q, want %q", tc.path, root, tc.wantRoot)
+			}
+		})
+	}
+}
+
 // A stat that fails for a reason OTHER than "does not exist" is not evidence
 // the snapshot went away. Aborting a whole run on a transient I/O hiccup would
 // recreate #3260 in a new form.

--- a/agent/internal/backup/source_liveness_test.go
+++ b/agent/internal/backup/source_liveness_test.go
@@ -435,6 +435,99 @@ func filesUnderCommonRoot(t *testing.T, n int) (string, []backupFile) {
 	return root, files
 }
 
+// dyingOnRetryProvider fails a file's FIRST attempt with a permission denial
+// (the #3259 case, which takes the short retry) while the snapshot is still
+// alive, then kills the snapshot as part of serving the RETRY. Every other file
+// uploads cleanly.
+//
+// That last part is what makes this test isolate the SECOND liveness probe:
+// with only healthy files afterwards, no later per-file failure ever occurs, so
+// the pre-retry probe can never fire again. If the post-retry probe in
+// createSnapshotWithProgress were removed, the dead snapshot would be recorded
+// as a lone per-file failure and the run would report success.
+type dyingOnRetryProvider struct {
+	mu       sync.Mutex
+	target   string
+	attempts map[string]int
+	onDeath  func()
+}
+
+func (p *dyingOnRetryProvider) UploadContext(_ context.Context, localPath, _ string) error {
+	p.mu.Lock()
+	p.attempts[localPath]++
+	n := p.attempts[localPath]
+	isTarget := localPath == p.target
+	onDeath := p.onDeath
+	p.mu.Unlock()
+
+	if !isTarget {
+		return nil
+	}
+	if n == 1 {
+		// Snapshot still healthy here — the pre-retry probe must say "alive".
+		return permissionErr(localPath)
+	}
+	// The retry itself is where the shadow copy goes away. #3260's tell was
+	// exactly this: one file's error flipping ACCESS_DENIED -> PATH_NOT_FOUND
+	// between the first attempt and the retry.
+	if onDeath != nil {
+		onDeath()
+	}
+	return notFoundErr(localPath)
+}
+
+func (p *dyingOnRetryProvider) Upload(localPath, remotePath string) error {
+	return p.UploadContext(context.Background(), localPath, remotePath)
+}
+func (p *dyingOnRetryProvider) Download(string, string) error { return nil }
+func (p *dyingOnRetryProvider) List(string) ([]string, error) { return nil, nil }
+func (p *dyingOnRetryProvider) Delete(string) error           { return nil }
+
+// The snapshot can die during the retry backoff, not just before it — the
+// upload loop probes liveness on both sides of the retry, and this pins the
+// second probe specifically.
+func TestCreateSnapshot_ShadowCopyLostDuringRetry_AbortsExplicitly(t *testing.T) {
+	defer setShortUploadRetryDelayForTest(0)()
+	defer setUploadRetryDelayForTest(0)()
+
+	f := newFakeStat()
+	f.install(t)
+
+	root, files := filesUnderCommonRoot(t, 4)
+	f.set(root, true)
+
+	provider := &dyingOnRetryProvider{
+		target:   files[1].sourcePath,
+		attempts: map[string]int{},
+		onDeath:  func() { f.set(root, false) },
+	}
+	liveness := newShadowRootLiveness(map[string]string{`C:`: root})
+	if liveness == nil {
+		t.Fatal("test setup: want a liveness probe, got nil")
+	}
+
+	snap, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, nil, liveness)
+
+	if !errors.Is(err, errSourceSnapshotGone) {
+		t.Fatalf("want errSourceSnapshotGone when the snapshot dies during the retry, got %v", err)
+	}
+	if snap != nil {
+		t.Fatalf("want no snapshot from an aborted run, got one with %d files", len(snap.Files))
+	}
+	// File 2 was attempted twice (initial + retry); files 3-4 must never have
+	// been reached.
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if got := provider.attempts[files[1].sourcePath]; got != 2 {
+		t.Fatalf("want 2 attempts on the failing file (initial + retry), got %d", got)
+	}
+	for _, later := range files[2:] {
+		if got := provider.attempts[later.sourcePath]; got != 0 {
+			t.Fatalf("file %s was uploaded against a dead snapshot (%d attempts)", later.snapshotPath, got)
+		}
+	}
+}
+
 // A run with no snapshot to defend (nil probe — the non-VSS case) must behave
 // exactly as before: per-file failures stay per-file, the job carries on.
 func TestCreateSnapshot_NilLiveness_KeepsPerFileFailureBehaviour(t *testing.T) {

--- a/agent/internal/backup/source_liveness_test.go
+++ b/agent/internal/backup/source_liveness_test.go
@@ -198,8 +198,13 @@ func TestNewShadowRootLiveness(t *testing.T) {
 // ShadowCopy2, and losing that unrelated volume would abort a healthy run.
 func TestMatchShadowRoot_MatchesOnPathBoundaryNotBarePrefix(t *testing.T) {
 	const shortRoot = `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy2`
-	// Longest-first, as newShadowRootLiveness orders them.
-	roots := []string{shadowC, shortRoot}
+	// Longest-first, as newShadowRootLiveness orders them. statPath is the
+	// bare form here; the prefix/statPath split is exercised separately by
+	// TestNewShadowRootLiveness_FallsBackToTrailingSeparatorForm.
+	roots := []watchedRoot{
+		{prefix: shadowC, statPath: shadowC},
+		{prefix: shortRoot, statPath: shortRoot},
+	}
 
 	tests := []struct {
 		name     string
@@ -237,12 +242,64 @@ func TestMatchShadowRoot_MatchesOnPathBoundaryNotBarePrefix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			root, ok := matchShadowRoot(roots, tc.path)
 			if ok != tc.wantOK {
-				t.Fatalf("matchShadowRoot(%q) ok = %v, want %v (root %q)", tc.path, ok, tc.wantOK, root)
+				t.Fatalf("matchShadowRoot(%q) ok = %v, want %v (root %q)", tc.path, ok, tc.wantOK, root.prefix)
 			}
-			if ok && root != tc.wantRoot {
-				t.Fatalf("matchShadowRoot(%q) = %q, want %q", tc.path, root, tc.wantRoot)
+			if ok && root.prefix != tc.wantRoot {
+				t.Fatalf("matchShadowRoot(%q) = %q, want %q", tc.path, root.prefix, tc.wantRoot)
 			}
 		})
+	}
+}
+
+// The arming precondition on real Windows. vss.CreateShadowCopy hands back
+// SnapshotDeviceObject verbatim — a BARE `\\?\GLOBALROOT\Device\...ShadowCopyNN`
+// with no trailing separator — and nothing in the codebase has ever shown that
+// form to be stat-able (the live VSS test and the file walk both go through a
+// subdirectory). If it is not, and there were no fallback, calibration would
+// exclude every root on every real run and the whole #3260 guard would be
+// silently inert.
+func TestNewShadowRootLiveness_FallsBackToTrailingSeparatorForm(t *testing.T) {
+	withSep := shadowC + `\`
+	// Only the trailing-separator form resolves — the shape a Windows device
+	// object is suspected to have.
+	f := newFakeStat(withSep)
+	f.install(t)
+
+	probe := newShadowRootLiveness(map[string]string{`C:`: shadowC})
+	if probe == nil {
+		t.Fatal("bare root did not stat and no trailing-separator fallback was tried: the guard would be inert on Windows")
+	}
+	// Still alive: nothing has gone away.
+	if err := probe(fileOnC); err != nil {
+		t.Fatalf("want the snapshot reported alive, got %v", err)
+	}
+	// Retiring the form that actually calibrated must be detected — i.e. the
+	// probe stats the SAME form it calibrated on, not the bare one.
+	f.set(withSep, false)
+	if err := probe(fileOnC); !errors.Is(err, errSourceSnapshotGone) {
+		t.Fatalf("want errSourceSnapshotGone once the calibrated form stopped resolving, got %v", err)
+	}
+}
+
+// Files are matched on the root's PREFIX (the text rewritePathsForVSS actually
+// prepended), never on whichever form happened to stat. Matching on a
+// trailing-separator statPath would break the path-boundary check and silently
+// stop matching every file.
+func TestNewShadowRootLiveness_MatchesOnPrefixNotStatForm(t *testing.T) {
+	withSep := shadowC + `\`
+	f := newFakeStat(withSep)
+	f.install(t)
+
+	probe := newShadowRootLiveness(map[string]string{`C:`: shadowC})
+	if probe == nil {
+		t.Fatal("want a probe, got nil")
+	}
+	f.set(withSep, false)
+
+	// fileOnC is shadowC + `\Users\...` — it must still be recognised as living
+	// under this root even though the watched stat form has the separator.
+	if err := probe(fileOnC); !errors.Is(err, errSourceSnapshotGone) {
+		t.Fatalf("file under the root was not matched to it, got %v", err)
 	}
 }
 
@@ -296,6 +353,44 @@ func TestShadowRootLiveness_TransientMissRequiresConfirmation(t *testing.T) {
 	}
 }
 
+// The third confirmation outcome: gone on the first look, then INCONCLUSIVE on
+// the confirmation look. That is not proof the snapshot went away, so the run
+// must survive it — a whole backup is too much to kill on an ambiguous answer.
+func TestShadowRootLiveness_MissThenInconclusiveDoesNotAbort(t *testing.T) {
+	// Scripted stat: construction resolves, the first probe says not-exist, the
+	// confirmation look fails with something that is neither.
+	var mu sync.Mutex
+	calls := 0
+	t.Cleanup(setSnapshotRootStatForTest(func(string) (os.FileInfo, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		switch calls {
+		case 1:
+			return nil, nil // calibration
+		case 2:
+			return nil, &fs.PathError{Op: "stat", Path: shadowC, Err: syscall.ENOENT}
+		default:
+			return nil, errors.New("the device is not ready")
+		}
+	}))
+	t.Cleanup(setShadowRootConfirmDelayForTest(0))
+
+	probe := newShadowRootLiveness(map[string]string{`C:`: shadowC})
+	if probe == nil {
+		t.Fatal("want a probe, got nil")
+	}
+	if err := probe(fileOnC); err != nil {
+		t.Fatalf("an inconclusive CONFIRMATION must not abort the run, got %v", err)
+	}
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 3 {
+		t.Fatalf("want 3 stats (calibration + miss + inconclusive confirmation), got %d", got)
+	}
+}
+
 // ...and a root that is still missing on the confirmation look IS gone.
 func TestShadowRootLiveness_ConfirmedMissIsGone(t *testing.T) {
 	f := newFakeStat(shadowC)
@@ -316,13 +411,21 @@ type expiringProvider struct {
 	mu sync.Mutex
 	// killAfter is the source path whose failure kills the snapshot.
 	killAfter string
-	dead      bool
-	onDeath   func()
-	attempts  []string
+	// srcRoot scopes the damage to files READ FROM the snapshot. A dead shadow
+	// copy does not stop the destination from accepting writes, so the manifest
+	// — written to a local temp file — must still upload.
+	srcRoot  string
+	dead     bool
+	onDeath  func()
+	attempts []string
 }
 
 func (p *expiringProvider) UploadContext(_ context.Context, localPath, _ string) error {
 	p.mu.Lock()
+	if p.srcRoot != "" && !strings.HasPrefix(localPath, p.srcRoot) {
+		p.mu.Unlock()
+		return nil // not read from the snapshot (e.g. the manifest)
+	}
 	p.attempts = append(p.attempts, localPath)
 	dead := p.dead
 	trigger := localPath == p.killAfter
@@ -378,6 +481,7 @@ func TestCreateSnapshot_ShadowCopyLostMidRun_AbortsExplicitly(t *testing.T) {
 
 	provider := &expiringProvider{
 		killAfter: files[2].sourcePath,
+		srcRoot:   root,
 		// The snapshot goes away at the same instant the third file fails.
 		onDeath: func() { f.set(root, false) },
 	}
@@ -394,8 +498,11 @@ func TestCreateSnapshot_ShadowCopyLostMidRun_AbortsExplicitly(t *testing.T) {
 	if !errors.Is(err, errSourceSnapshotGone) {
 		t.Fatalf("want errSourceSnapshotGone, got %v", err)
 	}
-	if snap != nil {
-		t.Fatalf("want no snapshot from an aborted run, got one with %d files", len(snap.Files))
+	// Journal-less abort keeps what landed: the two files uploaded before the
+	// loss come back as a published partial restore point (see
+	// TestCreateSnapshot_SourceGoneWithoutJournal_PublishesPartialManifest).
+	if snap == nil || len(snap.Files) != 2 {
+		t.Fatalf("want the 2 files that landed preserved, got %+v", snap)
 	}
 	// The whole point: files 4-6 were healthy and must never have been tried
 	// against a dead snapshot, let alone recorded as bad. Files 1-2 uploaded,
@@ -448,12 +555,17 @@ func filesUnderCommonRoot(t *testing.T, n int) (string, []backupFile) {
 type dyingOnRetryProvider struct {
 	mu       sync.Mutex
 	target   string
+	srcRoot  string
 	attempts map[string]int
 	onDeath  func()
 }
 
 func (p *dyingOnRetryProvider) UploadContext(_ context.Context, localPath, _ string) error {
 	p.mu.Lock()
+	if p.srcRoot != "" && !strings.HasPrefix(localPath, p.srcRoot) {
+		p.mu.Unlock()
+		return nil // not read from the snapshot (e.g. the manifest)
+	}
 	p.attempts[localPath]++
 	n := p.attempts[localPath]
 	isTarget := localPath == p.target
@@ -498,6 +610,7 @@ func TestCreateSnapshot_ShadowCopyLostDuringRetry_AbortsExplicitly(t *testing.T)
 
 	provider := &dyingOnRetryProvider{
 		target:   files[1].sourcePath,
+		srcRoot:  root,
 		attempts: map[string]int{},
 		onDeath:  func() { f.set(root, false) },
 	}
@@ -511,8 +624,8 @@ func TestCreateSnapshot_ShadowCopyLostDuringRetry_AbortsExplicitly(t *testing.T)
 	if !errors.Is(err, errSourceSnapshotGone) {
 		t.Fatalf("want errSourceSnapshotGone when the snapshot dies during the retry, got %v", err)
 	}
-	if snap != nil {
-		t.Fatalf("want no snapshot from an aborted run, got one with %d files", len(snap.Files))
+	if snap == nil || len(snap.Files) != 1 {
+		t.Fatalf("want the 1 file that landed before the loss preserved, got %+v", snap)
 	}
 	// File 2 was attempted twice (initial + retry); files 3-4 must never have
 	// been reached.
@@ -527,6 +640,205 @@ func TestCreateSnapshot_ShadowCopyLostDuringRetry_AbortsExplicitly(t *testing.T)
 		}
 	}
 }
+
+// With a journal, the source-loss abort must leave the remote prefix ALONE and
+// leave the journal on disk: together they are this run's resume state, and the
+// next attempt resumes into the very same snapshot ID. No manifest is published
+// — that would stake a completed-snapshot claim on an ID still being filled in.
+func TestCreateSnapshot_SourceGoneWithJournal_PreservesPrefixAndJournal(t *testing.T) {
+	defer setShortUploadRetryDelayForTest(0)()
+	defer setUploadRetryDelayForTest(0)()
+
+	f := newFakeStat()
+	f.install(t)
+	root, files := filesUnderCommonRoot(t, 5)
+	f.set(root, true)
+
+	backing := newMockProvider()
+	provider := &snapshotKillingProvider{
+		backing: backing,
+		target:  files[2].sourcePath,
+		srcRoot: root,
+		onDeath: func() { f.set(root, false) },
+	}
+
+	journalDir := t.TempDir()
+	journal, _, err := openSnapshotJournal(journalDir, "test-source-gone-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("openSnapshotJournal failed: %v", err)
+	}
+	journalPath := journal.path
+
+	liveness := newShadowRootLiveness(map[string]string{`C:`: root})
+	snap, err := createSnapshotWithProgress(context.Background(), provider, files, nil, journal, nil, liveness)
+
+	if !errors.Is(err, errSourceSnapshotGone) {
+		t.Fatalf("want errSourceSnapshotGone, got %v", err)
+	}
+	if snap != nil {
+		t.Fatalf("a journal-backed abort resumes rather than publishing; want nil snapshot, got %d files", len(snap.Files))
+	}
+	if len(backing.deleteCalls) != 0 {
+		t.Fatalf("a journal-backed source-loss abort must NOT delete the partial prefix, got deletes: %v", backing.deleteCalls)
+	}
+	if _, statErr := os.Stat(journalPath); statErr != nil {
+		t.Fatalf("want the journal left on disk for resume, stat err = %v", statErr)
+	}
+	// No manifest was published for this snapshot ID.
+	if n := countManifestUploads(backing); n != 0 {
+		t.Fatalf("a journal-backed abort must not publish a manifest, but published %d", n)
+	}
+	// The files that landed before the loss are recorded and resumable.
+	j2, resumed, err := openSnapshotJournal(journalDir, "test-source-gone-identity", journalMaxAge)
+	if err != nil {
+		t.Fatalf("reopen failed: %v", err)
+	}
+	if !resumed {
+		t.Fatal("want the abandoned journal to resume on reopen")
+	}
+	if _, ok := j2.Lookup(files[0].sourcePath, files[0].size, files[0].modTime); !ok {
+		t.Error("want the file uploaded before the loss recorded in the journal")
+	}
+	j2.Abandon()
+}
+
+// WITHOUT a journal there is no resume state, so the uploaded objects would be
+// unreachable orphans if nothing published them. The abort must publish a
+// PARTIAL manifest instead of deleting them — deleting would be a regression
+// against pre-#3260 behaviour, where the same run left a usable (flagged)
+// restore point behind. The run is still reported as failed.
+func TestCreateSnapshot_SourceGoneWithoutJournal_PublishesPartialManifest(t *testing.T) {
+	defer setShortUploadRetryDelayForTest(0)()
+	defer setUploadRetryDelayForTest(0)()
+
+	f := newFakeStat()
+	f.install(t)
+	root, files := filesUnderCommonRoot(t, 5)
+	f.set(root, true)
+
+	backing := newMockProvider()
+	provider := &snapshotKillingProvider{
+		backing: backing,
+		target:  files[2].sourcePath,
+		srcRoot: root,
+		onDeath: func() { f.set(root, false) },
+	}
+
+	liveness := newShadowRootLiveness(map[string]string{`C:`: root})
+	snap, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, nil, liveness)
+
+	if !errors.Is(err, errSourceSnapshotGone) {
+		t.Fatalf("want errSourceSnapshotGone so the job still reports failed, got %v", err)
+	}
+	// Non-nil snapshot alongside the error is what lets the manager record
+	// FilesBackedUp while still failing the job.
+	if snap == nil {
+		t.Fatal("want the partial snapshot returned so the manager can report what landed, got nil")
+	}
+	if len(snap.Files) != 2 {
+		t.Fatalf("want the 2 files that landed before the loss, got %d", len(snap.Files))
+	}
+	if len(backing.deleteCalls) != 0 {
+		t.Fatalf("uploaded backup data was DELETED on abort: %v", backing.deleteCalls)
+	}
+	manifests := countManifestUploads(backing)
+	if manifests != 1 {
+		t.Fatalf("want exactly 1 partial manifest published so the objects are restorable, got %d", manifests)
+	}
+}
+
+// Nothing landed: there is no restore point to preserve, so the journal-less
+// abort disposes of the prefix as any other journal-less abort would.
+func TestCreateSnapshot_SourceGoneWithoutJournal_NoFilesUploaded_CleansUp(t *testing.T) {
+	defer setShortUploadRetryDelayForTest(0)()
+	defer setUploadRetryDelayForTest(0)()
+
+	f := newFakeStat()
+	f.install(t)
+	root, files := filesUnderCommonRoot(t, 3)
+	f.set(root, true)
+
+	backing := newMockProvider()
+	provider := &snapshotKillingProvider{
+		backing: backing,
+		target:  files[0].sourcePath, // the very first file kills it
+		srcRoot: root,
+		onDeath: func() { f.set(root, false) },
+	}
+
+	liveness := newShadowRootLiveness(map[string]string{`C:`: root})
+	snap, err := createSnapshotWithProgress(context.Background(), provider, files, nil, nil, nil, liveness)
+
+	if !errors.Is(err, errSourceSnapshotGone) {
+		t.Fatalf("want errSourceSnapshotGone, got %v", err)
+	}
+	if snap != nil {
+		t.Fatalf("want nil snapshot when nothing was stored, got %d files", len(snap.Files))
+	}
+	// Nothing was stored, so there is nothing to publish and nothing worth
+	// keeping — in particular no manifest claiming an empty restore point.
+	if n := countManifestUploads(backing); n != 0 {
+		t.Fatalf("want no manifest when zero files landed, got %d", n)
+	}
+}
+
+// countManifestUploads counts snapshot manifests published to the mock.
+func countManifestUploads(m *mockProvider) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, call := range m.uploadCalls {
+		if strings.HasSuffix(call.remotePath, snapshotManifestKey) {
+			n++
+		}
+	}
+	return n
+}
+
+// snapshotKillingProvider delegates to a real mock provider (so uploads are
+// recorded and a manifest can actually be published) but fails one chosen file
+// with a permission denial, killing the snapshot as it does so.
+type snapshotKillingProvider struct {
+	backing *mockProvider
+	target  string
+	srcRoot string
+	mu      sync.Mutex
+	dead    bool
+	onDeath func()
+}
+
+func (p *snapshotKillingProvider) UploadContext(_ context.Context, localPath, remotePath string) error {
+	if p.srcRoot != "" && !strings.HasPrefix(localPath, p.srcRoot) {
+		// Not read from the snapshot (the manifest): the destination is fine.
+		return p.backing.Upload(localPath, remotePath)
+	}
+	p.mu.Lock()
+	dead := p.dead
+	trigger := localPath == p.target
+	if trigger && !dead {
+		p.dead = true
+	}
+	onDeath := p.onDeath
+	p.mu.Unlock()
+
+	if trigger {
+		if onDeath != nil {
+			onDeath()
+		}
+		return permissionErr(localPath)
+	}
+	if dead {
+		return notFoundErr(localPath)
+	}
+	return p.backing.Upload(localPath, remotePath)
+}
+
+func (p *snapshotKillingProvider) Upload(localPath, remotePath string) error {
+	return p.UploadContext(context.Background(), localPath, remotePath)
+}
+func (p *snapshotKillingProvider) Download(a, b string) error      { return p.backing.Download(a, b) }
+func (p *snapshotKillingProvider) List(a string) ([]string, error) { return p.backing.List(a) }
+func (p *snapshotKillingProvider) Delete(a string) error           { return p.backing.Delete(a) }
 
 // A run with no snapshot to defend (nil probe — the non-VSS case) must behave
 // exactly as before: per-file failures stay per-file, the job carries on.

--- a/agent/internal/backup/upload_error_class.go
+++ b/agent/internal/backup/upload_error_class.go
@@ -14,6 +14,10 @@ import (
 // file takes the same skip-and-continue path, is appended to
 // Snapshot.UploadFailures (and so to job.ErrorCount), and never aborts the job.
 // Only the sleep changes.
+//
+// The one thing in the upload loop that CAN end a run early is the separate
+// sourceLiveness probe (see source_liveness.go) — but that is a verdict on the
+// source snapshot as a whole, not on any file, and nothing here influences it.
 type uploadRetryPolicy int
 
 const (

--- a/agent/internal/backup/upload_error_class.go
+++ b/agent/internal/backup/upload_error_class.go
@@ -6,29 +6,61 @@ import (
 	"io/fs"
 )
 
-// Win32 system error codes (winerror.h) that make a per-file upload failure
-// PERMANENT: the source cannot be read on this attempt or any subsequent one,
-// so the single 30s retry in createSnapshotWithProgress is pure wasted
-// wall-clock (#2997).
+// uploadRetryPolicy is the verdict classifyUploadFailure returns for a per-file
+// upload failure: how much wall-clock the caller should spend before the single
+// retry, or whether to skip the file outright.
+//
+// It NEVER changes what happens to a file that ultimately fails: every failed
+// file takes the same skip-and-continue path, is appended to
+// Snapshot.UploadFailures (and so to job.ErrorCount), and never aborts the job.
+// Only the sleep changes.
+type uploadRetryPolicy int
+
+const (
+	// retryAfterDefaultDelay waits the full uploadRetryDelay before retrying
+	// once. The conservative default for anything unrecognised: a
+	// misclassification costs 30s of wall-clock, never a lost file.
+	retryAfterDefaultDelay uploadRetryPolicy = iota
+
+	// retryAfterShortDelay waits only shortUploadRetryDelay before retrying
+	// once. For a permission denial on the SOURCE file: overwhelmingly an NTFS
+	// ACL that will never clear, but occasionally a transient AV/indexer/filter
+	// -driver hold, which clears in well under a second. Keeping the retry
+	// preserves the safety net; shortening it removes the 30s-per-file stall
+	// (#3259).
+	retryAfterShortDelay
+
+	// skipWithoutRetry retries not at all. For a source that is locked by a
+	// live process, already gone, or an unhydratable cloud placeholder: a retry
+	// cannot change the outcome, so the backoff is pure waste (#2997/#3002).
+	skipWithoutRetry
+)
+
+// Win32 system error codes (winerror.h) that let a per-file upload failure be
+// classified more precisely than "unknown, wait 30s and retry".
 //
 // Field evidence from a 123,600-file C:\Users run on 0.103.0: 316 files were
 // skipped after retry, 2h38m of a 2h41m run was spent asleep in the backoff,
-// and every one of those errors was in this set — 254 ERROR_SHARING_VIOLATION
-// and 54 ERROR_LOCK_VIOLATION on live browser caches (Chrome/Edge Cache_Data,
-// GPUCache, WebView2 leveldb), 16 not-found on cache files that vanished
-// between scan and upload. A separate OneDrive repro burned 630s of backoff on
-// 21 cloud-only placeholders: the backup helper runs as SYSTEM and cannot
-// hydrate a user's placeholder, so ERROR_CLOUD_FILE_ACCESS_DENIED is
-// deterministic there by construction.
+// and every one of those errors was in the permanent set — 254
+// ERROR_SHARING_VIOLATION and 54 ERROR_LOCK_VIOLATION on live browser caches
+// (Chrome/Edge Cache_Data, GPUCache, WebView2 leveldb), 16 not-found on cache
+// files that vanished between scan and upload. A separate OneDrive repro burned
+// 630s of backoff on 21 cloud-only placeholders: the backup helper runs as
+// SYSTEM and cannot hydrate a user's placeholder, so
+// ERROR_CLOUD_FILE_ACCESS_DENIED is deterministic there by construction. A
+// third repro (v0.104.0, Windows Server 2022, 2026-08-07) measured +27-29s per
+// plain-ACL-denied file across 40-file runs — the ERROR_ACCESS_DENIED case
+// below.
 //
 // The codes are declared here, platform-independently, so the table stays
 // unit-testable on macOS/Linux; only the syscall.Errno -> table lookup is
-// Windows-gated (permanentUploadErrno, in the _windows/_other files).
+// Windows-gated (windowsUploadErrnoPolicy, in the _windows/_other files).
 // upload_error_class_codes_windows_test.go asserts each value against its
 // golang.org/x/sys/windows constant, and CI runs that file on Windows.
 const (
 	winErrFileNotFound     uintptr = 2  // ERROR_FILE_NOT_FOUND
 	winErrPathNotFound     uintptr = 3  // ERROR_PATH_NOT_FOUND
+	winErrAccessDenied     uintptr = 5  // ERROR_ACCESS_DENIED
 	winErrSharingViolation uintptr = 32 // ERROR_SHARING_VIOLATION
 	winErrLockViolation    uintptr = 33 // ERROR_LOCK_VIOLATION
 	// ERROR_CLOUD_FILE_ACCESS_DENIED, HRESULT 0x8007018B. NOTE: #2997 quotes
@@ -40,49 +72,62 @@ const (
 	winErrCloudFileAccessDenied uintptr = 0x18B // 395
 )
 
-// permanentWindowsErrnos maps each permanent Win32 code to its symbolic name,
-// which is logged as the skip `reason` so a support reader can tell a locked
-// browser cache from an unhydratable OneDrive placeholder without decoding a
-// localized message string. Deliberately NOT keyed on error text: the Windows
-// messages in the field logs are localized, so string matching would silently
-// stop classifying anything on a non-English host.
+// windowsUploadErrno pairs a Win32 code's retry policy with its symbolic name,
+// which is logged as the `reason` so a support reader can tell a locked browser
+// cache from an unhydratable OneDrive placeholder from an ACL denial without
+// decoding a localized message string. Deliberately NOT keyed on error text:
+// the Windows messages in the field logs are localized, so string matching
+// would silently stop classifying anything on a non-English host.
+type windowsUploadErrno struct {
+	name   string
+	policy uploadRetryPolicy
+}
+
+// windowsUploadErrnos is the Win32 code -> policy table.
 //
-// Deliberately excluded (still retried): ERROR_ACCESS_DENIED (5), which can be
-// a transient AV/indexer hold rather than a structural denial, and the rest of
-// the ERROR_CLOUD_FILE_* family, which includes genuinely retryable states
-// (e.g. ERROR_CLOUD_FILE_NETWORK_UNAVAILABLE). Widening the set is a separate,
+// ERROR_ACCESS_DENIED (5) is retryAfterShortDelay rather than skipWithoutRetry
+// on purpose. The denial is almost always a structural NTFS ACL, but an AV/EDR
+// filter driver or the search indexer can also deny a CreateFile transiently —
+// and, critically, such a driver denies for ANY requested access mask, so
+// re-probing the file with FILE_READ_ATTRIBUTES cannot distinguish the two
+// cases. There is no reliable discriminator, and a false "permanent" verdict
+// would silently drop a healthy file from a backup. Keeping one retry and
+// shortening the wait gets ~97% of the time back with none of that risk.
+//
+// Still deliberately excluded (full retry): the rest of the ERROR_CLOUD_FILE_*
+// family, which includes genuinely retryable states (e.g.
+// ERROR_CLOUD_FILE_NETWORK_UNAVAILABLE). Widening the set is a separate,
 // evidence-led change.
-var permanentWindowsErrnos = map[uintptr]string{
-	winErrFileNotFound:          "ERROR_FILE_NOT_FOUND",
-	winErrPathNotFound:          "ERROR_PATH_NOT_FOUND",
-	winErrSharingViolation:      "ERROR_SHARING_VIOLATION",
-	winErrLockViolation:         "ERROR_LOCK_VIOLATION",
-	winErrCloudFileAccessDenied: "ERROR_CLOUD_FILE_ACCESS_DENIED",
+var windowsUploadErrnos = map[uintptr]windowsUploadErrno{
+	winErrFileNotFound:          {"ERROR_FILE_NOT_FOUND", skipWithoutRetry},
+	winErrPathNotFound:          {"ERROR_PATH_NOT_FOUND", skipWithoutRetry},
+	winErrSharingViolation:      {"ERROR_SHARING_VIOLATION", skipWithoutRetry},
+	winErrLockViolation:         {"ERROR_LOCK_VIOLATION", skipWithoutRetry},
+	winErrCloudFileAccessDenied: {"ERROR_CLOUD_FILE_ACCESS_DENIED", skipWithoutRetry},
+	winErrAccessDenied:          {"ERROR_ACCESS_DENIED", retryAfterShortDelay},
 }
 
-// lookupPermanentWindowsErrno reports whether a Win32 error code is one that a
-// per-file upload retry cannot recover from, along with its symbolic name.
-func lookupPermanentWindowsErrno(code uintptr) (string, bool) {
-	name, ok := permanentWindowsErrnos[code]
-	return name, ok
+// lookupWindowsUploadErrno reports the retry policy for a Win32 error code,
+// along with its symbolic name. ok is false for any code not in the table,
+// which keeps its full retry.
+func lookupWindowsUploadErrno(code uintptr) (string, uploadRetryPolicy, bool) {
+	entry, ok := windowsUploadErrnos[code]
+	if !ok {
+		return "", retryAfterDefaultDelay, false
+	}
+	return entry.name, entry.policy, true
 }
 
-// classifyPermanentUploadError reports whether a per-file upload failure is
-// permanent — i.e. re-attempting the same file cannot change the outcome — and
-// returns a short reason for the log line. sourcePath is the file being backed
-// up, and is required: see the source-attribution step below.
+// classifyUploadFailure decides how a per-file upload failure should be
+// retried, and returns a short reason for the log line. sourcePath is the file
+// being backed up, and is required: see the source-attribution step below.
 //
-// Callers use this ONLY to decide whether to spend uploadRetryDelay before the
-// single retry. It never changes what happens to the file: a permanent failure
-// takes the same skip-and-continue path as any other per-file failure, is
-// appended to Snapshot.UploadFailures (and so to job.ErrorCount), and never
-// aborts the job. Only the sleep goes away.
-//
-// Conservative by design: anything unrecognised is treated as transient and
-// keeps its retry, so a misclassification costs 30s rather than a lost file.
-func classifyPermanentUploadError(err error, sourcePath string) (string, bool) {
+// Conservative by design: anything unrecognised gets retryAfterDefaultDelay and
+// keeps its full backoff, so a misclassification costs wall-clock rather than a
+// lost file.
+func classifyUploadFailure(err error, sourcePath string) (uploadRetryPolicy, string) {
 	if err == nil {
-		return "", false
+		return retryAfterDefaultDelay, ""
 	}
 	// Cancellation and deadline expiry are lifecycle signals, not source-file
 	// verdicts. They are handled by the caller's own errBackupStopped branch;
@@ -90,9 +135,9 @@ func classifyPermanentUploadError(err error, sourcePath string) (string, bool) {
 	if errors.Is(err, errBackupStopped) ||
 		errors.Is(err, context.Canceled) ||
 		errors.Is(err, context.DeadlineExceeded) {
-		return "", false
+		return retryAfterDefaultDelay, ""
 	}
-	// Only a failure attributable to the SOURCE file can be permanent, so the
+	// Only a failure attributable to the SOURCE file can be classified, so the
 	// chain must contain an *fs.PathError naming it. Every provider opens the
 	// source with os.Open(localPath) and wraps the result with %w
 	// (providers/{s3,azure,gcs,b2}.go, providers/local.go), so a real
@@ -108,12 +153,13 @@ func classifyPermanentUploadError(err error, sourcePath string) (string, bool) {
 	// loss. An unrecognised error shape simply keeps its retry.
 	var pathErr *fs.PathError
 	if !errors.As(err, &pathErr) || pathErr.Path != sourcePath {
-		return "", false
+		return retryAfterDefaultDelay, ""
 	}
 	// Windows-only: the Win32 codes above, matched numerically off the
-	// syscall.Errno the *fs.PathError carries.
-	if name, ok := permanentUploadErrno(pathErr.Err); ok {
-		return name, true
+	// syscall.Errno the *fs.PathError carries. Checked before the portable
+	// branches so the log line carries the precise symbolic name.
+	if name, policy, ok := windowsUploadErrnoPolicy(pathErr.Err); ok {
+		return policy, name
 	}
 	// Portable: a source file that no longer exists. Covers ENOENT on Unix and
 	// (redundantly with the table above) ERROR_FILE_NOT_FOUND /
@@ -122,7 +168,18 @@ func classifyPermanentUploadError(err error, sourcePath string) (string, bool) {
 	// agent's Unix builds too — a temp/cache file that vanishes between scan
 	// and upload is just as unretryable there.
 	if errors.Is(pathErr, fs.ErrNotExist) {
-		return "file not found", true
+		return skipWithoutRetry, "file not found"
 	}
-	return "", false
+	// Portable: a source file the agent is not permitted to read. Covers
+	// EACCES/EPERM on Unix and (redundantly with the table above)
+	// ERROR_ACCESS_DENIED on Windows, since syscall.Errno.Is maps all three to
+	// fs.ErrPermission. Same reasoning as the table entry: a permission denial
+	// on the source is overwhelmingly structural, so it keeps exactly one retry
+	// but not the 30s wait. Ordered AFTER the not-exist branch because Windows
+	// maps ERROR_SHARING_VIOLATION to fs.ErrPermission too, and that code is
+	// already resolved to skipWithoutRetry by the table above.
+	if errors.Is(pathErr, fs.ErrPermission) {
+		return retryAfterShortDelay, "permission denied"
+	}
+	return retryAfterDefaultDelay, ""
 }

--- a/agent/internal/backup/upload_error_class.go
+++ b/agent/internal/backup/upload_error_class.go
@@ -172,12 +172,15 @@ func classifyUploadFailure(err error, sourcePath string) (uploadRetryPolicy, str
 	}
 	// Portable: a source file the agent is not permitted to read. Covers
 	// EACCES/EPERM on Unix and (redundantly with the table above)
-	// ERROR_ACCESS_DENIED on Windows, since syscall.Errno.Is maps all three to
-	// fs.ErrPermission. Same reasoning as the table entry: a permission denial
-	// on the source is overwhelmingly structural, so it keeps exactly one retry
-	// but not the 30s wait. Ordered AFTER the not-exist branch because Windows
-	// maps ERROR_SHARING_VIOLATION to fs.ErrPermission too, and that code is
-	// already resolved to skipWithoutRetry by the table above.
+	// ERROR_ACCESS_DENIED on Windows — syscall.Errno.Is maps exactly those
+	// three to fs.ErrPermission, and notably NOT ERROR_SHARING_VIOLATION,
+	// which reaches skipWithoutRetry only via the Win32 table. Same reasoning
+	// as the table entry: a permission denial on the source is overwhelmingly
+	// structural, so it keeps exactly one retry but not the 30s wait.
+	//
+	// Reached only for codes the table did not resolve, so on Windows the
+	// table's more specific verdict and reason string always win. That
+	// ordering is asserted by TestClassifyUploadFailure_RealWindowsErrno.
 	if errors.Is(pathErr, fs.ErrPermission) {
 		return retryAfterShortDelay, "permission denied"
 	}

--- a/agent/internal/backup/upload_error_class_codes_windows_test.go
+++ b/agent/internal/backup/upload_error_class_codes_windows_test.go
@@ -11,12 +11,12 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// The permanent-error codes are declared as plain numbers in
-// upload_error_class.go so the table stays unit-testable on macOS/Linux (where
-// golang.org/x/sys/windows does not build). This test is the other half of
-// that trade: on Windows it pins each literal to the real constant, so a typo
-// in the table cannot go unnoticed forever.
-func TestPermanentWindowsErrnoConstantsMatchWin32(t *testing.T) {
+// The Win32 codes are declared as plain numbers in upload_error_class.go so the
+// table stays unit-testable on macOS/Linux (where golang.org/x/sys/windows does
+// not build). This test is the other half of that trade: on Windows it pins
+// each literal to the real constant, so a typo in the table cannot go unnoticed
+// forever.
+func TestWindowsUploadErrnoConstantsMatchWin32(t *testing.T) {
 	tests := []struct {
 		name string
 		got  uintptr
@@ -24,6 +24,7 @@ func TestPermanentWindowsErrnoConstantsMatchWin32(t *testing.T) {
 	}{
 		{"ERROR_FILE_NOT_FOUND", winErrFileNotFound, windows.ERROR_FILE_NOT_FOUND},
 		{"ERROR_PATH_NOT_FOUND", winErrPathNotFound, windows.ERROR_PATH_NOT_FOUND},
+		{"ERROR_ACCESS_DENIED", winErrAccessDenied, windows.ERROR_ACCESS_DENIED},
 		{"ERROR_SHARING_VIOLATION", winErrSharingViolation, windows.ERROR_SHARING_VIOLATION},
 		{"ERROR_LOCK_VIOLATION", winErrLockViolation, windows.ERROR_LOCK_VIOLATION},
 		{"ERROR_CLOUD_FILE_ACCESS_DENIED", winErrCloudFileAccessDenied, windows.ERROR_CLOUD_FILE_ACCESS_DENIED},
@@ -38,17 +39,26 @@ func TestPermanentWindowsErrnoConstantsMatchWin32(t *testing.T) {
 }
 
 // A real Windows errno must reach the classifier through the *fs.PathError +
-// %w wrapping the upload path applies. Windows-only because syscall.Errno
-// values are platform-specific.
-func TestClassifyPermanentUploadError_RealWindowsErrno(t *testing.T) {
+// %w wrapping the upload path applies, and come out with the right policy.
+// Windows-only because syscall.Errno values are platform-specific.
+func TestClassifyUploadFailure_RealWindowsErrno(t *testing.T) {
 	const src = `C:\Users\u\AppData\Local\Google\Chrome\User Data\Default\Cache\Cache_Data\f_00a1`
 	for _, tc := range []struct {
-		name  string
-		errno windows.Errno
+		name       string
+		errno      windows.Errno
+		wantPolicy uploadRetryPolicy
 	}{
-		{"ERROR_SHARING_VIOLATION", windows.ERROR_SHARING_VIOLATION},
-		{"ERROR_LOCK_VIOLATION", windows.ERROR_LOCK_VIOLATION},
-		{"ERROR_CLOUD_FILE_ACCESS_DENIED", windows.ERROR_CLOUD_FILE_ACCESS_DENIED},
+		{"ERROR_SHARING_VIOLATION", windows.ERROR_SHARING_VIOLATION, skipWithoutRetry},
+		{"ERROR_LOCK_VIOLATION", windows.ERROR_LOCK_VIOLATION, skipWithoutRetry},
+		{"ERROR_CLOUD_FILE_ACCESS_DENIED", windows.ERROR_CLOUD_FILE_ACCESS_DENIED, skipWithoutRetry},
+		// #3259. Note the ordering guarantee this asserts: Go maps BOTH
+		// ERROR_ACCESS_DENIED and ERROR_SHARING_VIOLATION onto fs.ErrPermission,
+		// so the Win32 table must be consulted before the portable
+		// fs.ErrPermission branch — otherwise a sharing violation would
+		// downgrade from skipWithoutRetry to retryAfterShortDelay and start
+		// paying a backoff again. The ERROR_SHARING_VIOLATION row above is what
+		// catches that regression.
+		{"ERROR_ACCESS_DENIED", windows.ERROR_ACCESS_DENIED, retryAfterShortDelay},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := fmt.Errorf("failed to compress file: %w", &fs.PathError{
@@ -56,9 +66,9 @@ func TestClassifyPermanentUploadError_RealWindowsErrno(t *testing.T) {
 				Path: src,
 				Err:  syscall.Errno(tc.errno),
 			})
-			name, ok := classifyPermanentUploadError(err, src)
-			if !ok {
-				t.Fatalf("want %s classified permanent, got transient", tc.name)
+			policy, name := classifyUploadFailure(err, src)
+			if policy != tc.wantPolicy {
+				t.Fatalf("classifyUploadFailure(%s) policy = %v, want %v", tc.name, policy, tc.wantPolicy)
 			}
 			if name != tc.name {
 				t.Fatalf("reason = %q, want %q", name, tc.name)

--- a/agent/internal/backup/upload_error_class_codes_windows_test.go
+++ b/agent/internal/backup/upload_error_class_codes_windows_test.go
@@ -51,13 +51,20 @@ func TestClassifyUploadFailure_RealWindowsErrno(t *testing.T) {
 		{"ERROR_SHARING_VIOLATION", windows.ERROR_SHARING_VIOLATION, skipWithoutRetry},
 		{"ERROR_LOCK_VIOLATION", windows.ERROR_LOCK_VIOLATION, skipWithoutRetry},
 		{"ERROR_CLOUD_FILE_ACCESS_DENIED", windows.ERROR_CLOUD_FILE_ACCESS_DENIED, skipWithoutRetry},
-		// #3259. Note the ordering guarantee this asserts: Go maps BOTH
-		// ERROR_ACCESS_DENIED and ERROR_SHARING_VIOLATION onto fs.ErrPermission,
-		// so the Win32 table must be consulted before the portable
-		// fs.ErrPermission branch — otherwise a sharing violation would
-		// downgrade from skipWithoutRetry to retryAfterShortDelay and start
-		// paying a backoff again. The ERROR_SHARING_VIOLATION row above is what
-		// catches that regression.
+		// #3259. Two regressions this row and the ones above jointly catch:
+		//
+		//  1. The Win32 table being dropped or dead-coded. syscall.Errno.Is
+		//     maps only ERROR_ACCESS_DENIED / EACCES / EPERM to
+		//     fs.ErrPermission — NOT ERROR_SHARING_VIOLATION, ERROR_LOCK_VIOLATION
+		//     or ERROR_CLOUD_FILE_ACCESS_DENIED. Those three have no portable
+		//     branch to fall back on, so if the table stops being consulted
+		//     they silently regain the 30s backoff. The rows above are the
+		//     canary for that.
+		//  2. The table being consulted AFTER the portable branch. Policy
+		//     would still come out right for ERROR_ACCESS_DENIED, but the
+		//     reason string would degrade from the precise
+		//     "ERROR_ACCESS_DENIED" to the generic "permission denied" — which
+		//     is what support reads. The exact-name assertion below catches it.
 		{"ERROR_ACCESS_DENIED", windows.ERROR_ACCESS_DENIED, retryAfterShortDelay},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/agent/internal/backup/upload_error_class_other.go
+++ b/agent/internal/backup/upload_error_class_other.go
@@ -2,15 +2,17 @@
 
 package backup
 
-// permanentUploadErrno is a deliberate no-op off Windows.
+// windowsUploadErrnoPolicy is a deliberate no-op off Windows.
 //
-// The codes in permanentWindowsErrnos are Win32 values and collide with
-// unrelated POSIX errnos — 32 is EPIPE and 33 is EDOM on Linux/darwin, both of
-// which are ordinary I/O failures that must keep their retry. Matching the
+// The codes in windowsUploadErrnos are Win32 values and collide with unrelated
+// POSIX errnos — 5 is EIO, 32 is EPIPE and 33 is EDOM on Linux/darwin, all of
+// which are ordinary I/O failures that must keep their full retry. Matching the
 // Win32 table against a Unix syscall.Errno would silently drop files from
 // backups on macOS and Linux hosts, so it is never attempted here.
 //
-// Unix permanence is covered by the portable fs.ErrNotExist branch in
-// classifyPermanentUploadError; the lock/sharing/cloud-placeholder failure
-// modes this fix targets are Windows-only by nature.
-func permanentUploadErrno(error) (string, bool) { return "", false }
+// Unix permanence and Unix permission denials are covered instead by the
+// portable fs.ErrNotExist / fs.ErrPermission branches in classifyUploadFailure;
+// the lock/sharing/cloud-placeholder failure modes are Windows-only by nature.
+func windowsUploadErrnoPolicy(error) (string, uploadRetryPolicy, bool) {
+	return "", retryAfterDefaultDelay, false
+}

--- a/agent/internal/backup/upload_error_class_other_test.go
+++ b/agent/internal/backup/upload_error_class_other_test.go
@@ -1,0 +1,68 @@
+//go:build !windows
+
+package backup
+
+import (
+	"fmt"
+	"io/fs"
+	"syscall"
+	"testing"
+)
+
+// The Win32 codes in windowsUploadErrnos are numerically identical to unrelated
+// POSIX errnos, and applying that table off Windows would silently drop files
+// from backups on macOS and Linux hosts. upload_error_class_other.go exists
+// solely to prevent that, and it is a no-op body — the kind of code that looks
+// deletable, or that someone "unifies" cross-platform while tidying up.
+//
+// This test is the tripwire for that refactor. Each of these errnos, wrapped as
+// a SOURCE-attributed *fs.PathError (so it clears the source-attribution guard
+// and reaches the platform lookup), must keep its full retry:
+//
+//	 5  EIO   on Unix / ERROR_ACCESS_DENIED   on Windows -> would become retryAfterShortDelay
+//	32  EPIPE on Unix / ERROR_SHARING_VIOLATION         -> would become skipWithoutRetry
+//	33  EDOM  on Unix / ERROR_LOCK_VIOLATION            -> would become skipWithoutRetry
+//	 2  ENOENT is deliberately absent: it is genuinely permanent on both
+//	    platforms and is handled by the PORTABLE fs.ErrNotExist branch, so it
+//	    is not evidence of the table leaking.
+//
+// A skipWithoutRetry verdict here would mean an ordinary I/O error on a Unix
+// agent silently drops the file from the backup with no retry at all.
+func TestClassifyUploadFailure_Win32CodesAreNeverAppliedToUnixErrnos(t *testing.T) {
+	const src = "/home/u/Documents/report.odt"
+
+	tests := []struct {
+		name  string
+		errno syscall.Errno
+	}{
+		{name: "EIO (5) collides with ERROR_ACCESS_DENIED", errno: syscall.EIO},
+		{name: "EPIPE (32) collides with ERROR_SHARING_VIOLATION", errno: syscall.EPIPE},
+		{name: "EDOM (33) collides with ERROR_LOCK_VIOLATION", errno: syscall.EDOM},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := fmt.Errorf("failed to open source file: %w",
+				&fs.PathError{Op: "open", Path: src, Err: tc.errno})
+
+			policy, reason := classifyUploadFailure(err, src)
+			if policy != retryAfterDefaultDelay {
+				t.Fatalf("errno %d (%v) classified as %v (reason %q) off Windows — the Win32 table is leaking onto POSIX errnos; see upload_error_class_other.go",
+					uintptr(tc.errno), tc.errno, policy, reason)
+			}
+		})
+	}
+}
+
+// The platform hook itself must stay inert off Windows, whatever it is handed.
+func TestWindowsUploadErrnoPolicy_IsANoOpOffWindows(t *testing.T) {
+	for _, errno := range []syscall.Errno{syscall.EIO, syscall.EPIPE, syscall.EDOM, syscall.EACCES} {
+		name, policy, ok := windowsUploadErrnoPolicy(errno)
+		if ok {
+			t.Fatalf("windowsUploadErrnoPolicy(%v) matched off Windows as %q/%v; it must never consult the Win32 table here",
+				errno, name, policy)
+		}
+		if policy != retryAfterDefaultDelay {
+			t.Fatalf("windowsUploadErrnoPolicy(%v) returned %v, want the conservative retryAfterDefaultDelay", errno, policy)
+		}
+	}
+}

--- a/agent/internal/backup/upload_error_class_test.go
+++ b/agent/internal/backup/upload_error_class_test.go
@@ -64,6 +64,15 @@ func notFoundErr(path string) error {
 	return fmt.Errorf("failed to open source file: %w", &fs.PathError{Op: "open", Path: path, Err: syscall.ENOENT})
 }
 
+// permissionErr is the shape an ACL-denied source file produces: a
+// *fs.PathError wrapping EACCES (ERROR_ACCESS_DENIED on Windows — the Go
+// runtime maps all of EACCES/EPERM/ERROR_ACCESS_DENIED to fs.ErrPermission),
+// wrapped again by the compression layer exactly as CompressFile does. This is
+// the #3259 case: `icacls /deny` on a plain NTFS file.
+func permissionErr(path string) error {
+	return fmt.Errorf("failed to open source file: %w", &fs.PathError{Op: "open", Path: path, Err: syscall.EACCES})
+}
+
 // A permanent per-file error must skip immediately. The whole point of #2997:
 // a real 123,600-file C:\Users run spent 2h38m of its 2h41m asleep in this
 // backoff for 316 files that could never have succeeded.
@@ -155,29 +164,41 @@ func TestPerFileUploadRetry_PermanentError_StillCountedAndJobContinues(t *testin
 	}
 }
 
-func TestClassifyPermanentUploadError(t *testing.T) {
+func TestClassifyUploadFailure(t *testing.T) {
 	const src = `C:\Users\u\AppData\Local\Google\Chrome\User Data\Default\Cache\Cache_Data\f_00a1`
 	tests := []struct {
 		name string
 		err  error
-		want bool
+		want uploadRetryPolicy
 	}{
-		{name: "nil", err: nil, want: false},
-		{name: "job cancel is never permanent", err: errBackupStopped, want: false},
-		{name: "wrapped job cancel is never permanent", err: fmt.Errorf("upload: %w", errBackupStopped), want: false},
-		{name: "context canceled is never permanent", err: context.Canceled, want: false},
-		{name: "deadline exceeded is never permanent", err: context.DeadlineExceeded, want: false},
-		{name: "generic transient upload error", err: errors.New("UploadPart: RequestTimeout"), want: false},
-		{name: "connection reset is transient", err: syscall.ECONNRESET, want: false},
-		{name: "vanished source file", err: notFoundErr(src), want: true},
+		{name: "nil", err: nil, want: retryAfterDefaultDelay},
+		{name: "job cancel is never classified", err: errBackupStopped, want: retryAfterDefaultDelay},
+		{name: "wrapped job cancel is never classified", err: fmt.Errorf("upload: %w", errBackupStopped), want: retryAfterDefaultDelay},
+		{name: "context canceled is never classified", err: context.Canceled, want: retryAfterDefaultDelay},
+		{name: "deadline exceeded is never classified", err: context.DeadlineExceeded, want: retryAfterDefaultDelay},
+		{name: "generic transient upload error", err: errors.New("UploadPart: RequestTimeout"), want: retryAfterDefaultDelay},
+		{name: "connection reset is transient", err: syscall.ECONNRESET, want: retryAfterDefaultDelay},
+		{name: "vanished source file", err: notFoundErr(src), want: skipWithoutRetry},
 		{
 			name: "vanished source file surfaced by the compression layer",
 			err:  fmt.Errorf("failed to compress file: %w", &fs.PathError{Op: "read", Path: src, Err: syscall.ENOENT}),
-			want: true,
+			want: skipWithoutRetry,
+		},
+		// #3259: an ACL denial on the SOURCE keeps exactly one retry (an
+		// AV/indexer hold is indistinguishable from an ACL at the API level)
+		// but must not spend the full 30s waiting for an ACL to change its
+		// mind. syscall.Errno.Is maps EACCES/EPERM (and, on Windows,
+		// ERROR_ACCESS_DENIED) to fs.ErrPermission, so this branch is portable.
+		{name: "source permission denial gets the short retry", err: permissionErr(src), want: retryAfterShortDelay},
+		{
+			name: "source permission denial surfaced by the compression layer",
+			err:  fmt.Errorf("failed to compress file: %w", &fs.PathError{Op: "read", Path: src, Err: syscall.EPERM}),
+			want: retryAfterShortDelay,
 		},
 		// A bare sentinel carries no path, so it cannot be attributed to the
 		// source and must keep its retry.
-		{name: "bare fs.ErrNotExist is not attributable to the source", err: fs.ErrNotExist, want: false},
+		{name: "bare fs.ErrNotExist is not attributable to the source", err: fs.ErrNotExist, want: retryAfterDefaultDelay},
+		{name: "bare fs.ErrPermission is not attributable to the source", err: fs.ErrPermission, want: retryAfterDefaultDelay},
 		// The destination-outage guard. LocalProvider creates the destination
 		// per file; a UNC/mapped-drive target that drops mid-run returns
 		// ENOENT from os.MkdirAll. Classifying that permanent would drain the
@@ -185,21 +206,88 @@ func TestClassifyPermanentUploadError(t *testing.T) {
 		{
 			name: "vanished DESTINATION directory stays transient",
 			err:  fmt.Errorf("failed to create backup directory: %w", &fs.PathError{Op: "mkdir", Path: `\\nas\backups\snap`, Err: syscall.ENOENT}),
-			want: false,
+			want: retryAfterDefaultDelay,
 		},
 		{
 			name: "unwritable DESTINATION file stays transient",
 			err:  fmt.Errorf("failed to create destination file: %w", &fs.PathError{Op: "open", Path: `\\nas\backups\snap\f_00a1.gz`, Err: syscall.ENOENT}),
-			want: false,
+			want: retryAfterDefaultDelay,
+		},
+		// Same guard for the permission branch: a destination the agent cannot
+		// write to must keep the full backoff, or a share that briefly rejects
+		// writes would drain the rest of the run at 1s per file.
+		{
+			name: "unwritable DESTINATION stays transient (permission)",
+			err:  fmt.Errorf("failed to create destination file: %w", &fs.PathError{Op: "open", Path: `\\nas\backups\snap\f_00a1.gz`, Err: syscall.EACCES}),
+			want: retryAfterDefaultDelay,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, got := classifyPermanentUploadError(tc.err, src)
+			got, _ := classifyUploadFailure(tc.err, src)
 			if got != tc.want {
-				t.Fatalf("classifyPermanentUploadError(%v) = %v, want %v", tc.err, got, tc.want)
+				t.Fatalf("classifyUploadFailure(%v) = %v, want %v", tc.err, got, tc.want)
 			}
 		})
+	}
+}
+
+// #3259: measured +27-29s per ACL-denied file on a real Windows Server 2022
+// agent. The denial keeps its single retry — an AV/indexer hold can clear —
+// but must take the short backoff, not the 30s one.
+func TestPerFileUploadRetry_PermissionDenied_UsesShortBackoff(t *testing.T) {
+	restoreLong := setUploadRetryDelayForTest(30 * time.Second) // the real production delay
+	defer restoreLong()
+	const short = 150 * time.Millisecond
+	restoreShort := setShortUploadRetryDelayForTest(short)
+	defer restoreShort()
+
+	src := writeTempFile(t, "a")
+	p := newFixedErrorProvider(permissionErr(src))
+	files := []backupFile{{sourcePath: src, snapshotPath: "a", size: 1}}
+
+	start := time.Now()
+	_, err := CreateSnapshotContext(context.Background(), p, files)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("want an error when the only file is permission-denied, got nil")
+	}
+	// The retry is preserved: an AV/indexer hold is the case it exists for.
+	if got := p.callCount(src); got != 2 {
+		t.Fatalf("want 2 upload attempts for a permission denial (initial + one short retry), got %d", got)
+	}
+	if elapsed < short {
+		t.Fatalf("permission denial skipped its short backoff entirely: elapsed %s, want >= %s", elapsed, short)
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("permission denial slept in the LONG retry backoff: elapsed %s (long delay is 30s)", elapsed)
+	}
+}
+
+// The short backoff must not leak into unrelated failures: a transient
+// destination error still gets the full 30s, which is the only thing absorbing
+// a short NAS/UNC outage.
+func TestPerFileUploadRetry_ShortBackoffDoesNotApplyToTransientErrors(t *testing.T) {
+	const long = 200 * time.Millisecond
+	restoreLong := setUploadRetryDelayForTest(long)
+	defer restoreLong()
+	restoreShort := setShortUploadRetryDelayForTest(0)
+	defer restoreShort()
+
+	src := writeTempFile(t, "a")
+	p := newFixedErrorProvider(errors.New("UploadPart: RequestTimeout: your socket connection timed out"))
+	files := []backupFile{{sourcePath: src, snapshotPath: "a", size: 1}}
+
+	start := time.Now()
+	if _, err := CreateSnapshotContext(context.Background(), p, files); err == nil {
+		t.Fatal("want an error when the only file fails twice, got nil")
+	}
+	if elapsed := time.Since(start); elapsed < long {
+		t.Fatalf("transient error took the SHORT backoff: elapsed %s, want >= %s", elapsed, long)
+	}
+	if got := p.callCount(src); got != 2 {
+		t.Fatalf("want exactly 2 upload attempts for a transient error, got %d", got)
 	}
 }
 
@@ -232,33 +320,49 @@ func TestPerFileUploadRetry_DestinationError_StillWaitsAndRetries(t *testing.T) 
 // The Win32 code table is declared platform-independently precisely so it can
 // be asserted here, on any OS. See upload_error_class_other.go for why the
 // table must never be applied to a Unix errno.
-func TestLookupPermanentWindowsErrno(t *testing.T) {
+func TestLookupWindowsUploadErrno(t *testing.T) {
 	tests := []struct {
-		name     string
-		code     uintptr
-		wantName string
-		want     bool
+		name       string
+		code       uintptr
+		wantName   string
+		wantPolicy uploadRetryPolicy
+		want       bool
 	}{
-		{name: "sharing violation (live browser cache)", code: 32, wantName: "ERROR_SHARING_VIOLATION", want: true},
-		{name: "lock violation", code: 33, wantName: "ERROR_LOCK_VIOLATION", want: true},
-		{name: "file not found", code: 2, wantName: "ERROR_FILE_NOT_FOUND", want: true},
-		{name: "path not found", code: 3, wantName: "ERROR_PATH_NOT_FOUND", want: true},
-		{name: "cloud file access denied (OneDrive placeholder)", code: 395, wantName: "ERROR_CLOUD_FILE_ACCESS_DENIED", want: true},
+		{name: "sharing violation (live browser cache)", code: 32, wantName: "ERROR_SHARING_VIOLATION", wantPolicy: skipWithoutRetry, want: true},
+		{name: "lock violation", code: 33, wantName: "ERROR_LOCK_VIOLATION", wantPolicy: skipWithoutRetry, want: true},
+		{name: "file not found", code: 2, wantName: "ERROR_FILE_NOT_FOUND", wantPolicy: skipWithoutRetry, want: true},
+		{name: "path not found", code: 3, wantName: "ERROR_PATH_NOT_FOUND", wantPolicy: skipWithoutRetry, want: true},
+		{name: "cloud file access denied (OneDrive placeholder)", code: 395, wantName: "ERROR_CLOUD_FILE_ACCESS_DENIED", wantPolicy: skipWithoutRetry, want: true},
+		// #3259: plain ACL denial. Still retried once — an AV/EDR filter driver
+		// denies with the same code and DOES clear — but on the short backoff,
+		// not the 30s one. Never skipWithoutRetry: a false permanent verdict
+		// would silently drop a healthy file from the backup.
+		{name: "plain access denied gets the short retry", code: 5, wantName: "ERROR_ACCESS_DENIED", wantPolicy: retryAfterShortDelay, want: true},
 		{name: "success is not a failure", code: 0, want: false},
-		{name: "plain access denied stays retryable", code: 5, want: false},
-		{name: "network name deleted stays retryable", code: 64, want: false},
+		{name: "network name deleted stays fully retryable", code: 64, want: false},
 		// 380 is ERROR_CLOUD_FILE_INVALID_REQUEST, not ACCESS_DENIED — the
 		// HRESULT quoted in #2997 (0x8007017C) points here by mistake.
-		{name: "cloud file invalid request stays retryable", code: 380, want: false},
+		{name: "cloud file invalid request stays fully retryable", code: 380, want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			name, ok := lookupPermanentWindowsErrno(tc.code)
+			name, policy, ok := lookupWindowsUploadErrno(tc.code)
 			if ok != tc.want {
-				t.Fatalf("lookupPermanentWindowsErrno(%d) ok = %v, want %v", tc.code, ok, tc.want)
+				t.Fatalf("lookupWindowsUploadErrno(%d) ok = %v, want %v", tc.code, ok, tc.want)
 			}
-			if ok && name != tc.wantName {
-				t.Fatalf("lookupPermanentWindowsErrno(%d) name = %q, want %q", tc.code, name, tc.wantName)
+			if !ok {
+				// An unrecognised code must fall back to the conservative
+				// full-backoff retry, never to a skip.
+				if policy != retryAfterDefaultDelay {
+					t.Fatalf("lookupWindowsUploadErrno(%d) unrecognised policy = %v, want retryAfterDefaultDelay", tc.code, policy)
+				}
+				return
+			}
+			if name != tc.wantName {
+				t.Fatalf("lookupWindowsUploadErrno(%d) name = %q, want %q", tc.code, name, tc.wantName)
+			}
+			if policy != tc.wantPolicy {
+				t.Fatalf("lookupWindowsUploadErrno(%d) policy = %v, want %v", tc.code, policy, tc.wantPolicy)
 			}
 		})
 	}

--- a/agent/internal/backup/upload_error_class_windows.go
+++ b/agent/internal/backup/upload_error_class_windows.go
@@ -7,15 +7,15 @@ import (
 	"syscall"
 )
 
-// permanentUploadErrno matches the Win32 code carried by a failed source-file
-// read/open against permanentWindowsErrnos. Callers pass the *fs.PathError's
-// Err (see classifyPermanentUploadError), which is normally a syscall.Errno
-// directly; errors.As is used rather than a type assertion so a provider that
-// wraps it further still classifies.
-func permanentUploadErrno(err error) (string, bool) {
+// windowsUploadErrnoPolicy matches the Win32 code carried by a failed
+// source-file read/open against windowsUploadErrnos. Callers pass the
+// *fs.PathError's Err (see classifyUploadFailure), which is normally a
+// syscall.Errno directly; errors.As is used rather than a type assertion so a
+// provider that wraps it further still classifies.
+func windowsUploadErrnoPolicy(err error) (string, uploadRetryPolicy, bool) {
 	var errno syscall.Errno
 	if !errors.As(err, &errno) {
-		return "", false
+		return "", retryAfterDefaultDelay, false
 	}
-	return lookupPermanentWindowsErrno(uintptr(errno))
+	return lookupWindowsUploadErrno(uintptr(errno))
 }

--- a/agent/internal/backup/vss/vss_windows_live_test.go
+++ b/agent/internal/backup/vss/vss_windows_live_test.go
@@ -108,6 +108,29 @@ func TestLive_CreateShadowCopy_EndToEnd(t *testing.T) {
 		t.Errorf("%q is empty through the shadow copy", shadowWindows)
 	}
 
+	// Which form of the ROOT itself is stat-able, recorded on real hardware.
+	//
+	// This is the arming precondition for the #3260 mid-run snapshot-loss guard
+	// (backup.newShadowRootLiveness): it calibrates by os.Stat-ing each shadow
+	// root and watches only the roots that answer. Everything above goes through
+	// a SUBDIRECTORY, so none of it says whether the bare device path — which is
+	// what CreateShadowCopy returns, and what the guard is handed — resolves.
+	// If neither form did, the guard would silently disarm on every real run.
+	//
+	// Not a hard failure on the bare form: the guard tries `root + "\\"` as a
+	// fallback precisely because the bare device object may not be stat-able.
+	// At least ONE of them must work, and the log line records which, so a
+	// future change to resolveStatablePath can be checked against reality.
+	_, bareErr := os.Stat(shadow)
+	withSep := shadow + `\`
+	_, sepErr := os.Stat(withSep)
+	t.Logf("shadow root stat: bare %q -> %v; with separator %q -> %v", shadow, bareErr, withSep, sepErr)
+	if bareErr != nil && sepErr != nil {
+		t.Errorf("neither shadow root form is stat-able (bare: %v; with separator: %v) — "+
+			"backup.newShadowRootLiveness would exclude every root and the #3260 guard would be inert",
+			bareErr, sepErr)
+	}
+
 	t.Logf("shadow copy %s -> %s (%d entries under \\Windows, %d writers)",
 		vol, shadow, len(entries), len(session.Writers))
 }

--- a/apps/api/src/jobs/backupWorker.test.ts
+++ b/apps/api/src/jobs/backupWorker.test.ts
@@ -447,3 +447,55 @@ describe('processResults — agent terminal status hop (#3000)', () => {
     );
   });
 });
+
+// #3260: a malformed `result` payload used to report
+// `Malformed backup result payload: expected object, received null` with no
+// indication of WHICH field was wrong, because the old message only joined
+// `issue.message` and dropped `issue.path` — indistinguishable from "some
+// named field inside the payload is null". describeZodIssues fixes this by
+// rendering an issue's empty path as the literal `<root>` instead of
+// silently omitting it.
+//
+// NOTE: a literal top-level `result: null` cannot be driven through this
+// function as a regression case — `data.result.status` (evaluated one line
+// above the schema parse, to capture the outer command status) dereferences
+// `data.result` before `backupCommandResultSchema.safeParse` ever runs, so a
+// null `result` throws a TypeError instead of reaching the malformed-payload
+// branch this test targets. An array reproduces the same root-level
+// "expected object" Zod failure (empty `issue.path`) without that crash, so
+// it exercises the same describeZodIssues code path #3260 was about.
+describe('processResults — malformed payload path rendering (#3260)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('labels a root-level schema failure as <root> instead of dropping the path', async () => {
+    await __testOnly.processResults({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      result: [],
+    } as any);
+
+    expect(markBackupJobFailedIfInFlightMock).toHaveBeenCalledWith(
+      'job-1',
+      expect.stringMatching(/^Malformed backup result payload:.*<root>/)
+    );
+  });
+
+  it('labels a malformed named field with its own path, not <root>', async () => {
+    await __testOnly.processResults({
+      jobId: 'job-1',
+      orgId: 'org-1',
+      deviceId: 'device-1',
+      // filesBackedUp must be a nonnegative int — a negative number fails
+      // validation at a named path, which must NOT collapse to <root>.
+      result: { status: 'completed', filesBackedUp: -1 },
+    } as any);
+
+    const [, message] = markBackupJobFailedIfInFlightMock.mock.calls[0]!;
+    expect(message).toMatch(/^Malformed backup result payload:/);
+    expect(message).toContain('filesBackedUp');
+    expect(message).not.toContain('<root>');
+  });
+});

--- a/apps/api/src/jobs/backupWorker.ts
+++ b/apps/api/src/jobs/backupWorker.ts
@@ -38,6 +38,7 @@ import {
 import * as backupEnqueue from './backupEnqueue';
 import { resolveBackupStorageEncryptionPlan } from '../services/backupEncryption';
 import { backupCommandResultSchema } from '../routes/backup/resultSchemas';
+import { describeZodIssues } from '../lib/zodIssues';
 import { getDueOccurrenceKey } from '../routes/backup/helpers';
 import { applyBackupCommandResultToJob } from '../services/backupResultPersistence';
 import { markBackupJobFailedIfInFlight } from '../services/backupResultPersistence';
@@ -711,7 +712,7 @@ async function processResults(
   if (!parsed.success) {
     await markBackupJobFailedIfInFlight(
       data.jobId,
-      `Malformed backup result payload: ${parsed.error.issues.map((issue) => issue.message).join(', ')}`,
+      `Malformed backup result payload: ${describeZodIssues(parsed.error)}`,
     );
     return { processed: false };
   }

--- a/apps/api/src/lib/zodIssues.test.ts
+++ b/apps/api/src/lib/zodIssues.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import {
   describeFirstZodIssue,
+  describeZodIssues,
   flattenZodIssues,
   flattenedZodDetails,
   zodValidationErrorBody,
@@ -88,5 +89,42 @@ describe('describeFirstZodIssue', () => {
 
   it('returns null when there are no issues at all', () => {
     expect(describeFirstZodIssue({ issues: [] })).toBeNull();
+  });
+});
+
+describe('describeZodIssues', () => {
+  // The #3260 case verbatim: the agent sent a null backup result payload and
+  // the operator-visible error read "Invalid input: expected object, received
+  // null" with no indication of WHAT was null.
+  it('labels a root-level failure as <root> instead of dropping the path', () => {
+    const error = z.object({ status: z.string() }).safeParse(null).error!;
+    const described = describeZodIssues(error);
+    expect(described).toContain('<root>');
+    expect(described).toContain('expected object, received null');
+  });
+
+  it('names the offending field for a nested failure', () => {
+    const error = z.object({ result: z.object({ status: z.string() }) }).safeParse({ result: { status: 5 } })
+      .error!;
+    expect(describeZodIssues(error)).toMatch(/^result\.status: /);
+  });
+
+  it('lists every issue, path-qualified', () => {
+    const error = z.object({ a: z.string(), b: z.number() }).safeParse({ a: 1, b: 'x' }).error!;
+    const described = describeZodIssues(error);
+    expect(described).toContain('a: ');
+    expect(described).toContain('b: ');
+    expect(described).toContain('; ');
+  });
+
+  it('unwraps union noise rather than reporting a bare "Invalid input"', () => {
+    const error = nested.safeParse({ items: [{ conditions: [{ type: 'a', value: 'nope' }] }] }).error!;
+    const described = describeZodIssues(error);
+    expect(described).toContain('items.0.conditions.0.value');
+    expect(described).not.toBe('<root>: Invalid input');
+  });
+
+  it('degrades to a stated placeholder rather than an empty string', () => {
+    expect(describeZodIssues({ issues: [] })).toBe('no validation detail available');
   });
 });

--- a/apps/api/src/lib/zodIssues.ts
+++ b/apps/api/src/lib/zodIssues.ts
@@ -143,3 +143,24 @@ export function describeFirstZodIssue(error: { issues: readonly ZodIssueLike[] }
   const path = first.path.length > 0 ? `${formatIssuePath(first.path)}: ` : '';
   return `${path}${first.message}`;
 }
+
+/** Rendered for an issue whose path is empty — the value as a whole is wrong. */
+const ROOT_PATH_LABEL = '<root>';
+
+/**
+ * Every issue as `path: message`, joined — for a single operator-facing error
+ * string that has to identify WHICH field was rejected.
+ *
+ * Unlike `describeFirstZodIssue`, an empty path renders as `<root>` rather than
+ * being omitted. That distinction is the whole point: a run whose entire result
+ * payload was null produced `Invalid input: expected object, received null`
+ * with an empty path, and dropping the path made it impossible to tell "the
+ * payload is null" from "some unnamed field inside it is null" (#3260).
+ */
+export function describeZodIssues(error: { issues: readonly ZodIssueLike[] }): string {
+  const issues = flattenZodIssues(error.issues);
+  if (issues.length === 0) return 'no validation detail available';
+  return issues
+    .map((issue) => `${formatIssuePath(issue.path) || ROOT_PATH_LABEL}: ${issue.message}`)
+    .join('; ');
+}

--- a/apps/api/src/routes/agentWs.ts
+++ b/apps/api/src/routes/agentWs.ts
@@ -37,6 +37,7 @@ import {
   tryParseBackupResultPayload,
 } from '../services/backupProgress';
 import { backupCommandResultSchema } from './backup/resultSchemas';
+import { describeZodIssues } from '../lib/zodIssues';
 import { matchRoleScopedAgentTokenHash, suspendAgentToken, type AgentCredentialRole } from '../middleware/agentAuth';
 import { AGENT_TOKEN_SUSPEND_REASON } from '../services/agentTokenSuspension';
 import {
@@ -1231,7 +1232,7 @@ export async function processOrphanedCommandResult(
       const backupData = parsedBackup.success ? parsedBackup.data : undefined;
       const malformedPayloadError = parsedBackup.success
         ? null
-        : `Malformed backup result payload: ${parsedBackup.error.issues.map((issue) => issue.message).join(', ')}`;
+        : `Malformed backup result payload: ${describeZodIssues(parsedBackup.error)}`;
 
       if (isRedisAvailable()) {
         // Exit the held org-scoped transaction context for the Redis

--- a/apps/api/src/routes/backup/hyperv.ts
+++ b/apps/api/src/routes/backup/hyperv.ts
@@ -11,6 +11,7 @@ import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services
 import { resolveScopedOrgId } from './helpers';
 import { resolveAllBackupAssignedDevices, resolveBackupConfigForDevice, effectiveBackupModes } from '../../services/featureConfigResolver';
 import { backupCommandResultSchema } from './resultSchemas';
+import { describeZodIssues } from '../../lib/zodIssues';
 import {
   applyBackupCommandResultToJob,
   markBackupJobFailedIfInFlight,
@@ -329,7 +330,7 @@ hypervRoutes.post(
       parsedData = result.stdout ? JSON.parse(result.stdout) : {};
       const parsedBackup = backupCommandResultSchema.safeParse(parsedData);
       if (!parsedBackup.success) {
-        throw new Error(parsedBackup.error.issues.map((issue) => issue.message).join(', '));
+        throw new Error(describeZodIssues(parsedBackup.error));
       }
       const persisted = await applyBackupCommandResultToJob({
         jobId: backupJob.id,

--- a/apps/api/src/routes/backup/mssql.ts
+++ b/apps/api/src/routes/backup/mssql.ts
@@ -14,6 +14,7 @@ import { canAccessSite, PERMISSIONS, type UserPermissions } from '../../services
 import { resolveScopedOrgId } from './helpers';
 import { resolveAllBackupAssignedDevices, resolveBackupConfigForDevice, effectiveBackupModes } from '../../services/featureConfigResolver';
 import { backupCommandResultSchema } from './resultSchemas';
+import { describeZodIssues } from '../../lib/zodIssues';
 import {
   applyBackupCommandResultToJob,
   markBackupJobFailedIfInFlight,
@@ -312,7 +313,7 @@ mssqlRoutes.post(
       parsedData = result.stdout ? JSON.parse(result.stdout) : {};
       const parsedBackup = backupCommandResultSchema.safeParse(parsedData);
       if (!parsedBackup.success) {
-        throw new Error(parsedBackup.error.issues.map((issue) => issue.message).join(', '));
+        throw new Error(describeZodIssues(parsedBackup.error));
       }
 
       const persisted = await applyBackupCommandResultToJob({

--- a/apps/api/src/services/commandResultHandlers.ts
+++ b/apps/api/src/services/commandResultHandlers.ts
@@ -29,6 +29,7 @@ import { processBackupVerificationResult } from '../routes/backup/verificationSe
 import { applyBackupCommandResultToJob } from './backupResultPersistence';
 import { applyVaultSyncCommandResult } from './vaultSyncPersistence';
 import { backupCommandResultSchema } from '../routes/backup/resultSchemas';
+import { describeZodIssues } from '../lib/zodIssues';
 import { redactSecretsFromOutput, redactOptionalSecretText } from './secretRedaction';
 import { updateRestoreJobByCommandId } from './restoreResultPersistence';
 import { captureException } from './sentry';
@@ -228,7 +229,7 @@ async function handleProviderBackedBackupResult({ agentId, command, result, reso
             deviceId: backupJob.deviceId,
             resultStatus: 'failed',
             result: {
-              error: `Malformed backup result payload: ${parsedBackup.error.issues.map((issue) => issue.message).join(', ')}`,
+              error: `Malformed backup result payload: ${describeZodIssues(parsedBackup.error)}`,
             },
           });
         } else {


### PR DESCRIPTION
Fixes #3259
Fixes #3260

Two coupled backup defects from v0.104.0 release QA on a real Windows Server 2022 agent. The first wastes wall-clock; the second turns that wasted wall-clock into total data loss. Same files, one PR.

## #3259 — plain `ERROR_ACCESS_DENIED` burned ~30s per file

#3002/#2997 taught the per-file upload retry to fast-skip permanently-failing files, but deliberately excluded plain `ERROR_ACCESS_DENIED` (5) because it "can be a transient AV/indexer hold". So the single most common cause of an unreadable file — an ordinary NTFS ACL — paid the full 30s backoff. Measured **+27-29s per denied file**.

**The ACL probe (the issue's first choice) was NOT taken.** `FILE_READ_ATTRIBUTES` and `FILE_READ_DATA` are distinct rights, and a failed probe still cannot prove the original denial came from the DACL rather than an AV/EDR minifilter. There is no discriminator that cannot produce a false "permanent" verdict — and a false permanent verdict silently drops a **healthy** file from a backup, which is precisely the failure class of #3260. Took the issue's option 2 instead.

`classifyPermanentUploadError` (bool) becomes **`classifyUploadFailure`**, returning an `uploadRetryPolicy`:

| policy | when | wait |
|---|---|---|
| `skipWithoutRetry` | not-found, sharing/lock violation, cloud placeholder | none |
| `retryAfterShortDelay` | **source permission denial (new)** | 1s |
| `retryAfterDefaultDelay` | everything unrecognised | 30s |

The retry itself — the thing that actually recovers a transient hold — is preserved; only the wait shrinks. Anything unrecognised still gets the full backoff, so a misclassification costs wall-clock, never a file.

Matched two ways: via the Win32 table (`ERROR_ACCESS_DENIED`, so logs carry the precise symbolic name) and portably via `fs.ErrPermission` (EACCES/EPERM on Unix). **The table is consulted first** so `ERROR_SHARING_VIOLATION` — which Go also maps to `fs.ErrPermission` — keeps its `skipWithoutRetry`. A Windows-only test pins that ordering.

## #3260 — the stalls outlived the shadow copy and lost everything

With 15 denied files of 40, the accumulated backoff ran ~390s, the shadow copy stopped resolving, and files 14-40 — **every one readable** — failed with `ERROR_PATH_NOT_FOUND`. Because PATH_NOT_FOUND is in the fast-skip set, the run drained its remaining file list at memory speed and recorded all of it as per-file failures: 0 of 40 backed up, `status=failed`, an error log that blamed the files.

New `agent/internal/backup/source_liveness.go` adds a probe over the shadow-copy device roots the run reads from, consulted **only after a per-file upload has already failed** — before the retry sleep, and again after it, since the retry is exactly where the reported `ACCESS_DENIED -> PATH_NOT_FOUND` flip happened. A root that has gone away aborts the run with an explicit error naming the root and the progress counts, instead of condemning every remaining file.

Three properties keep the abort from becoming its own false-positive bug:

- **Self-calibrating** — each root is stat'd at construction; only roots that resolved *then* are watched. The probe can never fail on a path form `os.Stat` could not resolve in the first place (`\\?\GLOBALROOT\...` is an unusual shape, and a probe that assumed it stats cleanly would abort every healthy backup if that assumption were wrong).
- **Confirmed** — a root must be missing on two looks, separated by a short delay, before a run dies.
- **Per-volume** — scoped to the failing file's own root, so losing volume D never aborts files still being read from volume C.

Only a not-exist answer counts; any other stat error is inconclusive and treated as alive.

**Abort semantics: mirrors `abortStopped`, does not publish a partial manifest.** With a journal, the remote prefix plus the journal remain this run's resume state, so the already-uploaded bytes survive and the next run picks them up. Publishing a manifest for the partial set would mint a snapshot that *looks* complete while silently missing every file the loop never reached — a restore point that lies. Flagging this as the one design call worth a second opinion.

**No cumulative retry wall-clock budget**, deliberately. A `VSS_CTX_BACKUP` shadow copy has no TTL, so age does not predict validity and any fixed budget would be an arbitrary guess. The liveness probe is the real defense.

## Secondary (API) — malformed-payload errors named no field

All three `Malformed backup result payload` sites (`jobs/backupWorker.ts`, `routes/agentWs.ts`, `services/commandResultHandlers.ts`) joined only `issue.message` and dropped the Zod `path`, so the reported `Invalid input: expected object, received null` was unactionable.

Adds `describeZodIssues` to `apps/api/src/lib/zodIssues.ts` — reusing the existing flattening, which also unwraps `invalid_union` noise — and uses it at all three sites rather than adding a fourth ad-hoc `.map(i => ...)`. **An empty path renders as `<root>` rather than being omitted**: that is the distinction that makes "the whole payload was null" legible instead of ambiguous.

## Verification

| check | command | result |
|---|---|---|
| backup pkg | `cd agent && go test -race -count=1 ./internal/backup/...` | 7 packages ok |
| full agent | `cd agent && go test -race -count=1 ./...` | exit 0, 66 packages, 0 failures |
| windows build | `GOOS=windows GOARCH=amd64 go build ./...` | clean |
| windows tests compile | `GOOS=windows GOARCH=amd64 go vet ./internal/backup/...` | clean (only pre-existing `unsafe.Pointer` notes in untouched `vss_windows.go`) |
| linux build | `GOOS=linux GOARCH=amd64 go build ./...` | clean |
| API tests | `pnpm exec vitest run --no-file-parallelism src/lib/zodIssues.test.ts src/jobs/backupWorker.test.ts src/routes/agentWs.test.ts src/routes/agentWs.terminalResultSchema.test.ts` | 4 files, 137 passed |
| API typecheck | `pnpm exec tsc --noEmit -p tsconfig.json` | clean |

New coverage: the retry-policy table (incl. the ordering guarantee), the short-vs-long backoff split, the liveness probe's self-calibration / confirmation / per-volume scoping / inconclusive-error handling, an end-to-end "shadow copy dies at file 3 of 6" regression asserting the run stops at 3 attempts rather than walking a dead snapshot, and `<root>` vs named-path rendering.

## Residual risk — likely true root cause of #3260 is NOT fixed here

`vss.CreateShadowCopy` releases `IVssBackupComponents` before returning (`agent/internal/backup/vss/vss_windows.go`, the `defer callVtable(backupComponents, vtblRelease)`), with a comment asserting Windows only reclaims a non-persistent `VSS_CTX_BACKUP` copy on **process** exit. Microsoft documents the opposite: releasing that object deletes auto-release shadow copies. The existing live test only reads through the device shortly after Release, so it would not catch a delayed reclaim — and a delayed reclaim fits the observed ~390s disappearance at least as well as diff-area exhaustion.

**This PR does not attempt that fix.** Keeping the requester alive on a dedicated locked COM thread across scan + upload + manifest, with `BackupComplete`/`AbortBackup`, is a lifetime rewrite of the vss package — Windows-only, untestable from here, and already tracked as a follow-up on #2999. #3260 names the explicit abort as the required minimum and snapshot refresh as stretch, so this PR delivers the abort and the liveness probe (which is still needed regardless — diff-area exhaustion and external deletion are real). **Worth its own issue.**

Also worth noting: the outer queue schema (`backupProcessResultSchema`) guarantees `data.result` is a non-null object before `processResults` runs, so the reported root-level "received null" most likely arose from a *nested* null. Either way the new message now names whatever it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (3 agents: code-reviewer, silent-failure-hunter, pr-test-analyzer)

**5 findings raised, all addressed.** code-reviewer found no correctness bugs. The other two found real gaps:

| # | From | Finding | Fix |
|---|---|---|---|
| 1 | silent-failure | VSS active but zero watchable roots returned `nil` with only Debug lines — the #3260 guard could be entirely OFF and look identical to "armed, nothing wrong" | Warn once, naming how many roots were offered |
| 2 | silent-failure | A root stat'ing with a persistent non-not-exist error was treated as alive and logged at Debug forever | `shadowRootMissing` is now three-way (alive / gone / inconclusive); caller warns once per root per run |
| 3 | self-found | `matchShadowRoot` used a bare `strings.HasPrefix` — `...ShadowCopy2` prefixes `...ShadowCopy26`, so a file under an **unwatched** ShadowCopy26 would be checked against ShadowCopy2's root and could abort a healthy run | Match on a path boundary (separator or exact); new `TestMatchShadowRoot_MatchesOnPathBoundaryNotBarePrefix` |
| 4 | self-found | An inconclusive *confirmation* look was logged as "came back" — a message that misdescribes what happened, which is #3260's own complaint | Reported on its own terms |
| 5 | pr-test-analyzer | The **post-retry** liveness probe was not pinned by any test: disabling only it left the package green, because the existing regression test kills the snapshot synchronously with the first attempt | New `TestCreateSnapshot_ShadowCopyLostDuringRetry_AbortsExplicitly`, proven non-vacuous |

None of these changed the abort decision — only a confirmed not-exist still aborts. They changed what an operator can see, and closed one genuine false-abort vector (#3 hardening).

**A comment of mine was factually wrong and is corrected.** I had written that Go maps both `ERROR_ACCESS_DENIED` and `ERROR_SHARING_VIOLATION` to `fs.ErrPermission`, making table-before-portable ordering the thing that keeps a sharing violation on `skipWithoutRetry`. Checked the stdlib (`syscall/syscall_windows.go`, `Errno.Is`): only `ERROR_ACCESS_DENIED`/`EACCES`/`EPERM` map to `fs.ErrPermission`. `ERROR_SHARING_VIOLATION` does not — it has no portable fallback at all. Ordering still matters (for the precise symbolic reason string support reads), and the sharing/lock/cloud rows guard against the table being dropped entirely. Comments now say what is true.

**CI caught the rename, as designed.** The `Test Agent (Windows)` step pins test names in its `-run` filter and asserts an exact PASS count precisely so a rename can't quietly drop coverage. The classifier rename tripped it; three names updated, count unchanged at 14 (the rename was one-for-one).

### Known remaining gap (not fixed here)

The manager-level wiring in `RunBackupContext` — `sourceLiveness = newShadowRootLiveness(vssSession.ShadowPaths)` and its threading into `createSnapshotWithProgress` — has no test. Every liveness test calls the leaf functions directly. A refactor that dropped those two lines would pass CI and only resurface as a #3260 recurrence in production. Covering it needs the `vss.Provider` to become injectable into `RunBackupContext` (today it's constructed inline via `vss.NewProvider`, and the whole branch is `runtime.GOOS == "windows"`-gated so it never executes in CI's Linux/macOS runs). That's a testability refactor of the manager, deliberately out of scope here — **worth its own issue alongside the requester-lifetime one.**


---

## Review round 2 (code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer)

Nothing blocking, but two findings were latent defeats of the entire #3260 guard. All applied in `b7511589d`.

**1. The guard was probably inert on real Windows (the important one).** `vss.CreateShadowCopy` returns `SnapshotDeviceObject` verbatim — a **bare** `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopyNN`, no trailing separator — and calibration stat'd exactly that. Nothing in the tree has ever shown that form to be stat-able: the live VSS test does `ReadDir(shadow+"\Windows")`, `collectFiles` stats `shadow+rest`, and every liveness test uses a fake stat. If the bare form doesn't resolve, calibration excluded every root on every real run and the guard silently disarmed — fail-safe, but useless.

`resolveStatablePath` now tries the root verbatim, then with a trailing separator, and watches whichever answers. That required splitting a root into **`prefix`** (the exact text `rewritePathsForVSS` prepended — what files are matched against) and **`statPath`** (the form that actually stats); conflating them would have broken the path-boundary match instead. The live Windows test now records which form resolves and **fails if neither does**, so a real run verifies the arming precondition rather than assuming it.

**2. Journal-less abort destroyed data that pre-PR runs kept.** `abortSourceGone` deleted the uploaded objects whenever `journal == nil` (which happens when `resolveJournalDir` fails). Pre-PR, that same run finished as a flagged partial success and left a usable restore point — so the PR was a regression on that path.

I took the **preferred** fix rather than the minimum bar, because the `return snapshot, err` pattern already existed in this function and the manifest writer was trivially extractable:

| journal | behavior |
|---|---|
| present | unchanged — prefix + journal are resume state; nothing deleted, no manifest |
| absent, ≥1 file landed | publish a **partial manifest** so the objects stay reachable; return `(snapshot, err)` so the job still reports **failed** with the source-loss reason while recording what landed |
| absent, nothing landed | clean up (no restore point to preserve) |
| manifest publish itself fails | objects **retained** and logged loudly — deletion is irreversible and this is a data-protection product |

I also withdrew my own "a restore point that lies" justification: a manifest enumerates what a snapshot contains, it does not assert completeness, and the job is failed either way. `publishSnapshotManifest` is extracted so the abort and a normal completion can't drift apart.

**3. Partial-guard silence.** An excluded root was Debug-only and the Warn fired only when *zero* roots were watchable — so a multi-volume run with the guard off for one volume reproduced #3260's misattribution invisibly. Excluded roots now Warn whenever others are still watched, and the arming line is **Info** with watched/excluded counts.

**4.** `routes/backup/{hyperv,mssql}.ts` still dropped the Zod path over the same schema — both switched to `describeZodIssues`.

**Tests added:** journal-vs-journal-less abort disposition (the data-integrity guard for #2, written against the final behavior); a `!windows` Win32/POSIX errno-collision tripwire (5=EIO, 32=EPIPE, 33=EDOM must keep the full retry — `upload_error_class_other.go` exists only to prevent that leak and is a no-op body someone could "unify" away); the miss→inconclusive confirmation branch; the trailing-separator fallback and prefix-vs-statPath matching.

Writing these surfaced a flaw in my two existing abort tests: their fake providers were killing the **manifest** upload too, which a dead *source* snapshot cannot do. Now scoped to source reads only.

**Comment corrections (comment-analyzer).** The forensic narrative said 15 files each burned 30s — the record says ~13 did, and 13×30s *is* the +390s the same sentence quotes (the snapshot died before the last denials were reached); "files 14-40, every one readable" also conflicted with 15-of-40 denied. The cross-reference to `vss.CreateShadowCopy` pointed at a note asserting the *opposite* of the Microsoft-documented behavior (now stated inline, contrary note tracked as **#3269**). "Never aborts the job" in `upload_error_class.go` was false one screen away. The `backup.go` ordering claim had the sequence backwards.

**Verification:** `go test -race ./...` — **67 packages, 0 failures**. `go vet ./...` clean; `GOOS=windows` and `GOOS=linux` builds clean; `GOOS=windows go vet ./internal/backup/...` clean. API: **5 files, 147 passed**; `tsc --noEmit` clean. The `Test Agent (Windows)` PASS-count guard still expects 14 — the new errno test is `!windows`-tagged, so it doesn't count there.
