### PR TITLE
feat(partner-api): unattended tenancy provisioning via partner service principals (#3243)

### DIFF
--- a/apps/api/src/middleware/partnerApiAuth.test.ts
+++ b/apps/api/src/middleware/partnerApiAuth.test.ts
@@ -142,13 +142,13 @@ const ORG_2 = '55555555-5555-4555-8555-555555555555';
 
 type TestContext = Context & { _headers: Record<string, string> };
 
-function createContext(apiKey: string | null = RAW_KEY): TestContext {
+function createContext(apiKey: string | null = RAW_KEY, method = 'GET'): TestContext {
   const responseHeaders: Record<string, string> = {};
   const store = new Map<string, unknown>();
   return {
     req: {
       path: '/api/v1/partner-api/organizations',
-      method: 'GET',
+      method,
       header: (name: string) => {
         if (name.toLowerCase() === 'x-api-key') return apiKey;
         if (name.toLowerCase() === 'user-agent') return 'partner-client/1.0';
@@ -747,6 +747,100 @@ describe('partnerApiAuthMiddleware', () => {
 
     expect(withResolvedDbAccessContext).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
+  });
+
+  describe('non-GET write branch (#3243)', () => {
+    it('resolves the principal WITHOUT a held request context and lets handlers open their own', async () => {
+      mockBootstrap();
+      const context = createContext(RAW_KEY, 'POST');
+      const next = vi.fn(async () => {
+        // The provisioning handlers must NOT run inside a held transaction:
+        // an org INSERT from a nested system tx would wait on this request's
+        // own shared partner advisory lock forever (see partnerApiAuth.ts).
+        expect(mocks.insideSystemContext).toBe(false);
+        expect(mocks.insidePartnerContext).toBe(false);
+      });
+
+      await partnerApiAuthMiddleware(context, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(withResolvedDbAccessContext).not.toHaveBeenCalled();
+      // Org discovery still ran (in a short bounded system context) so scope
+      // and org-access checks see the same accessible set reads do.
+      expect(mocks.systemContextCalls).toBeGreaterThanOrEqual(1);
+      expect(context.get('partnerApiPrincipal')).toMatchObject({
+        partnerServicePrincipalId: PRINCIPAL_ID,
+        partnerId: PARTNER_ID,
+        accessibleOrgIds: [ORG_1, ORG_2],
+      });
+    });
+
+    it('applies a tighter per-principal write rate limit in its own bucket', async () => {
+      mockBootstrap();
+      const context = createContext(RAW_KEY, 'POST');
+      const next = vi.fn();
+
+      await partnerApiAuthMiddleware(context, next);
+
+      // Call 1: pre-lookup probe throttle; call 2: the key's own limit;
+      // call 3: the write ceiling — min(key limit 600, 120) = 120.
+      expect(rateLimiter).toHaveBeenNthCalledWith(
+        3,
+        { redis: true },
+        `partner_api_write_rate:${PRINCIPAL_ID}:${KEY_ID}`,
+        120,
+        3600,
+      );
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects with 429 and Retry-After when the write bucket is exhausted', async () => {
+      mockBootstrap();
+      const resetAt = new Date(Date.now() + 30_000);
+      mocks.rateLimiter
+        .mockResolvedValueOnce({ allowed: true, remaining: 299, resetAt })
+        .mockResolvedValueOnce({ allowed: true, remaining: 299, resetAt })
+        .mockResolvedValueOnce({ allowed: false, remaining: 0, resetAt });
+      const context = createContext(RAW_KEY, 'POST');
+      const next = vi.fn();
+
+      await expect(partnerApiAuthMiddleware(context, next)).rejects.toMatchObject({
+        status: 429,
+        message: 'Partner API rate limit exceeded',
+      });
+      expect(next).not.toHaveBeenCalled();
+      expect(context._headers['Retry-After']).toBeDefined();
+    });
+
+    it('records machine use for a failed write and rethrows the downstream error', async () => {
+      mockBootstrap();
+      const context = createContext(RAW_KEY, 'POST');
+      const boom = new HTTPException(500, { message: 'write exploded' });
+      const next = vi.fn(async () => { throw boom; });
+
+      await expect(partnerApiAuthMiddleware(context, next)).rejects.toBe(boom);
+
+      expect(mocks.writeAuditEvent).toHaveBeenCalledWith(context, expect.objectContaining({
+        action: 'partner_api.request',
+        actorType: 'api_key',
+        actorId: KEY_ID,
+        result: 'failure',
+        details: expect.objectContaining({ method: 'POST', status: 500 }),
+      }));
+    });
+
+    it('records machine use for a successful write', async () => {
+      mockBootstrap();
+      const context = createContext(RAW_KEY, 'POST');
+
+      await partnerApiAuthMiddleware(context, vi.fn());
+
+      expect(mocks.writeAuditEvent).toHaveBeenCalledWith(context, expect.objectContaining({
+        action: 'partner_api.request',
+        result: 'success',
+        details: expect.objectContaining({ method: 'POST' }),
+      }));
+    });
   });
 });
 

--- a/apps/api/src/middleware/partnerApiAuth.ts
+++ b/apps/api/src/middleware/partnerApiAuth.ts
@@ -46,6 +46,16 @@ const PARTNER_API_KEY_PATTERN = /^brz_sp_[A-Za-z0-9_-]{43}$/;
 const AUTH_REQUIRED_MESSAGE = 'Partner API authentication required';
 const INVALID_CREDENTIALS_MESSAGE = 'Invalid partner API credentials';
 
+/**
+ * Ceiling for non-GET requests, counted per principal+key per hour in a
+ * bucket separate from (and always at most equal to) the key's own limit.
+ * Provisioning writes are low-volume by nature — an onboarding run creating
+ * an org, a handful of sites, and per-site enrollment keys for 80 customers
+ * fits comfortably — while an unattended credential minting organizations at
+ * read-export speed is a billing/abuse signal, not a workload (#3243).
+ */
+export const PARTNER_API_WRITE_RATE_LIMIT_PER_HOUR = 120;
+
 function invalidCredentials(): HTTPException {
   return new HTTPException(401, { message: INVALID_CREDENTIALS_MESSAGE });
 }
@@ -137,6 +147,25 @@ async function bootstrapCredential(
       rateLimit: credential.rateLimit,
     };
   });
+}
+
+// The hidden per-partner 'quick_support' org is an internal Quick Support
+// artifact, never a customer tenant — it must not enter the Partner API's
+// accessible set (which every export route derives its org filter from,
+// including the caller-supplied ?orgId, validated against this list).
+// Verified: the Partner API mounts no support-session routes, so removing
+// it here costs no functionality.
+async function discoverAccessibleOrgIds(partnerId: string): Promise<string[]> {
+  const activeOrganizations = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(and(
+      eq(organizations.partnerId, partnerId),
+      eq(organizations.status, 'active'),
+      isNull(organizations.deletedAt),
+      ne(organizations.type, 'quick_support'),
+    ));
+  return activeOrganizations.map((organization) => organization.id);
 }
 
 function setRateLimitHeaders(
@@ -265,6 +294,60 @@ export async function partnerApiAuthMiddleware(c: Context, next: Next): Promise<
   // or RLS context switch itself fails before downstream routing begins.
   let principal: PartnerApiPrincipalContext = { ...bootstrap, accessibleOrgIds: [] };
   let downstreamError: unknown;
+
+  if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
+    // Non-GET (#3243): provisioning writes run OUTSIDE the read path's held
+    // partner-RLS snapshot transaction, for two reasons:
+    //
+    // 1. The held read transaction takes the partner discovery advisory lock
+    //    SHARED for the whole request, while an `organizations` INSERT fires
+    //    a statement trigger that must take the same lock EXCLUSIVE
+    //    (2026-07-21-partner-export-canonical-org-mutations.sql). Running
+    //    that insert from a nested system transaction on a second pooled
+    //    connection would wait on our own request's shared lock — an
+    //    application-level self-deadlock that only a statement timeout ends.
+    //
+    // 2. Writes take no export snapshot, so the consistency machinery the
+    //    lock exists for does not apply. This mirrors the human /orgs/*
+    //    write routes, which also run their inserts in bounded contexts.
+    //
+    // Handlers therefore receive NO ambient DB context and must open their
+    // own bounded withDbAccessContext / withSystemDbAccessContext per
+    // operation (the contextless-write guard enforces this).
+    const writeLimit = Math.min(bootstrap.rateLimit, PARTNER_API_WRITE_RATE_LIMIT_PER_HOUR);
+    const writeCheck = await rateLimiter(
+      getRedis(),
+      `partner_api_write_rate:${bootstrap.partnerServicePrincipalId}:${bootstrap.keyId}`,
+      writeLimit,
+      3600,
+    );
+    setRateLimitHeaders(c, writeLimit, writeCheck);
+    if (!writeCheck.allowed) {
+      c.header('Retry-After', String(Math.max(
+        1,
+        Math.ceil((writeCheck.resetAt.getTime() - Date.now()) / 1000),
+      )));
+      throw new HTTPException(429, { message: 'Partner API rate limit exceeded' });
+    }
+
+    try {
+      const accessibleOrgIds = await withSystemDbAccessContext(() =>
+        discoverAccessibleOrgIds(bootstrap.partnerId),
+      );
+      principal = { ...bootstrap, accessibleOrgIds };
+      c.set('partnerApiPrincipal', principal);
+      await next();
+    } catch (error) {
+      downstreamError = error;
+    }
+
+    const writeStatus = downstreamStatus(c, downstreamError);
+    const writeResult = downstreamError || c.error || writeStatus >= 400 ? 'failure' : 'success';
+    await recordMachineUse(c, principal, writeResult, writeStatus);
+    if (downstreamError) throw downstreamError;
+    return;
+  }
+
   try {
     await withResolvedDbAccessContext(async () => {
       // Hold partner discovery shared from allowlist discovery through the
@@ -274,24 +357,9 @@ export async function partnerApiAuthMiddleware(c: Context, next: Next): Promise<
       await db.execute(sql`SELECT public.breeze_partner_export_lock_partners_shared(
         ARRAY[${bootstrap.partnerId}::uuid]
       )`);
-      // The hidden per-partner 'quick_support' org is an internal Quick Support
-      // artifact, never a customer tenant — it must not enter the Partner API's
-      // accessible set (which every export route derives its org filter from,
-      // including the caller-supplied ?orgId, validated against this list).
-      // Verified: the Partner API mounts no support-session routes, so removing
-      // it here costs no functionality.
-      const activeOrganizations = await db
-        .select({ id: organizations.id })
-        .from(organizations)
-        .where(and(
-          eq(organizations.partnerId, bootstrap.partnerId),
-          eq(organizations.status, 'active'),
-          isNull(organizations.deletedAt),
-          ne(organizations.type, 'quick_support'),
-        ));
       const resolvedPrincipal: PartnerApiPrincipalContext = {
         ...bootstrap,
-        accessibleOrgIds: activeOrganizations.map((organization) => organization.id),
+        accessibleOrgIds: await discoverAccessibleOrgIds(bootstrap.partnerId),
       };
       return {
         context: {

--- a/apps/api/src/routes/partnerApi/index.ts
+++ b/apps/api/src/routes/partnerApi/index.ts
@@ -5,6 +5,7 @@ import { partnerOrganizationRoutes } from './organizations';
 import { partnerInventoryRoutes } from './inventory';
 import { partnerRelationshipRoutes } from './relationships';
 import { partnerConfigurationRoutes } from './configuration';
+import { partnerProvisioningRoutes } from './provisioning';
 import { partnerExportAuditMiddleware } from './audit';
 
 export const partnerApiRoutes = new Hono();
@@ -20,3 +21,6 @@ partnerApiRoutes.route('/', partnerDeviceRoutes);
 partnerApiRoutes.route('/', partnerInventoryRoutes);
 partnerApiRoutes.route('/', partnerRelationshipRoutes);
 partnerApiRoutes.route('/', partnerConfigurationRoutes);
+// Provisioning writes (#3243). Non-GET routes must ALSO be listed in the
+// writeSurface.test.ts allowlist — adding a route here alone fails CI.
+partnerApiRoutes.route('/', partnerProvisioningRoutes);

--- a/apps/api/src/routes/partnerApi/organizations.ts
+++ b/apps/api/src/routes/partnerApi/organizations.ts
@@ -239,7 +239,7 @@ export function buildEnvelope<T extends ExportSourceRow>(input: {
   };
 }
 
-function jsonField(record: unknown, names: string[]): string | null {
+export function jsonField(record: unknown, names: string[]): string | null {
   if (!record || typeof record !== 'object' || Array.isArray(record)) return null;
   for (const name of names) {
     const value = (record as Record<string, unknown>)[name];

--- a/apps/api/src/routes/partnerApi/provisioning.test.ts
+++ b/apps/api/src/routes/partnerApi/provisioning.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ORG_ID = '22222222-2222-4222-8222-222222222222';
+const PARTNER_ID = '33333333-3333-4333-8333-333333333333';
+const SITE_ID = '44444444-4444-4444-8444-444444444444';
+const KEY_ID = '55555555-5555-4555-8555-555555555555';
+const PRINCIPAL_ID = '66666666-6666-4666-8666-666666666666';
+const KEY_ROW_ID = '77777777-7777-4777-8777-777777777777';
+const CREATED_AT = new Date('2026-08-01T12:00:00.000Z');
+const UPDATED_AT = new Date('2026-08-02T12:00:00.000Z');
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  insert: vi.fn(),
+  execute: vi.fn(),
+  audit: vi.fn(async () => undefined),
+  assertTtlWithinCap: vi.fn(async () => null as string | null),
+  partnerContexts: [] as unknown[],
+  systemContextOpens: 0,
+  // Populated in beforeEach — vi.hoisted runs before module-level constants.
+  accessibleOrgIds: [] as string[],
+}));
+
+vi.mock('../../db', () => ({
+  db: { select: mocks.select, insert: mocks.insert, execute: mocks.execute },
+  hasDbAccessContext: () => true,
+  withDbAccessContext: async (ctx: unknown, fn: () => unknown) => {
+    mocks.partnerContexts.push(ctx);
+    return fn();
+  },
+  withSystemDbAccessContext: async (fn: () => unknown) => {
+    mocks.systemContextOpens += 1;
+    return fn();
+  },
+}));
+vi.mock('../../config/env', () => ({
+  PARTNER_API_CURSOR_SIGNING_KEY: Buffer.from('0123456789abcdef0123456789abcdef', 'utf8'),
+}));
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEventAsync: mocks.audit,
+  requestLikeFromSnapshot: (value: unknown) => value,
+}));
+vi.mock('../../services/enrollmentDefaults', () => ({
+  assertTtlWithinCap: mocks.assertTtlWithinCap,
+}));
+vi.mock('../../middleware/partnerApiAuth', () => ({
+  partnerApiAuthMiddleware: async (c: any, next: any) => {
+    if (c.req.header('X-API-Key') !== 'test-key') return c.json({ error: 'authentication required' }, 401);
+    c.set('partnerApiPrincipal', {
+      partnerServicePrincipalId: PRINCIPAL_ID,
+      keyId: KEY_ID,
+      partnerId: PARTNER_ID,
+      name: 'migration-bot',
+      rateLimit: 1000,
+      accessibleOrgIds: mocks.accessibleOrgIds,
+      scopes: (c.req.header('X-Test-Scopes') ?? '').split(',').filter(Boolean),
+    });
+    return next();
+  },
+  requirePartnerApiScope: (...required: string[]) => async (c: any, next: any) => {
+    const principal = c.get('partnerApiPrincipal');
+    return required.every((scope) => principal.scopes.includes(scope))
+      ? next()
+      : c.json({ error: 'scope required' }, 403);
+  },
+}));
+
+import { partnerApiRoutes } from './index';
+
+type QueryResult = unknown[] | Error;
+
+function selectBuilder(result: QueryResult) {
+  const promise = result instanceof Error ? Promise.reject(result) : Promise.resolve(result);
+  const builder: any = {
+    from: vi.fn(() => builder),
+    where: vi.fn(() => builder),
+    limit: vi.fn(() => promise),
+    then: promise.then.bind(promise),
+  };
+  return builder;
+}
+
+let selectResults: QueryResult[] = [];
+let insertResults: QueryResult[] = [];
+let insertedValues: unknown[] = [];
+
+function primeDb() {
+  mocks.select.mockImplementation(() => selectBuilder(selectResults.shift() ?? []));
+  mocks.insert.mockImplementation(() => ({
+    values: vi.fn((values: unknown) => {
+      insertedValues.push(values);
+      const result = insertResults.shift() ?? [];
+      return {
+        returning: vi.fn(() =>
+          result instanceof Error ? Promise.reject(result) : Promise.resolve(result),
+        ),
+      };
+    }),
+  }));
+  mocks.execute.mockResolvedValue([]);
+}
+
+const app = new Hono();
+app.route('/', partnerApiRoutes);
+
+function post(path: string, scope: string, body: unknown, apiKey = 'test-key') {
+  return app.request(path, {
+    method: 'POST',
+    headers: { 'X-API-Key': apiKey, 'X-Test-Scopes': scope, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const orgRow = {
+  id: ORG_ID,
+  partnerId: PARTNER_ID,
+  name: 'Acme',
+  slug: 'acme',
+  type: 'customer',
+  status: 'active',
+  createdAt: CREATED_AT,
+  updatedAt: UPDATED_AT,
+  partnerExportUpdatedAt: UPDATED_AT,
+};
+
+const siteRow = {
+  id: SITE_ID,
+  orgId: ORG_ID,
+  name: 'HQ',
+  timezone: 'UTC',
+  address: { line1: '1 Main St', city: 'Denver' },
+  contact: { name: 'NOC', email: 'noc@example.com' },
+  createdAt: CREATED_AT,
+  updatedAt: UPDATED_AT,
+  partnerExportUpdatedAt: UPDATED_AT,
+};
+
+const keyRow = {
+  id: KEY_ROW_ID,
+  orgId: ORG_ID,
+  siteId: null,
+  name: 'migration key',
+  usageCount: 0,
+  maxUsage: 1,
+  expiresAt: new Date('2026-09-01T12:00:00.000Z'),
+  createdAt: CREATED_AT,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectResults = [];
+  insertResults = [];
+  insertedValues = [];
+  mocks.partnerContexts = [];
+  mocks.systemContextOpens = 0;
+  mocks.accessibleOrgIds = [ORG_ID];
+  mocks.assertTtlWithinCap.mockResolvedValue(null);
+  primeDb();
+});
+
+describe('POST /organizations', () => {
+  function primeSuccess({ maxOrganizations = null as number | null, orgCount = 0 } = {}) {
+    selectResults = maxOrganizations === null
+      ? [[{ maxOrganizations }], [{ partnerExportUpdatedAt: UPDATED_AT }]]
+      : [[{ maxOrganizations }], [{ value: orgCount }], [{ partnerExportUpdatedAt: UPDATED_AT }]];
+    insertResults = [[orgRow]];
+  }
+
+  it('requires authentication', async () => {
+    const res = await post('/organizations', 'organizations:write', { name: 'Acme', slug: 'acme' }, 'wrong');
+    expect(res.status).toBe(401);
+  });
+
+  it('requires the organizations:write scope', async () => {
+    const res = await post('/organizations', 'organizations:read', { name: 'Acme', slug: 'acme' });
+    expect(res.status).toBe(403);
+  });
+
+  it('creates an organization under the principal partner in a system context', async () => {
+    primeSuccess();
+    const res = await post('/organizations', 'organizations:write', { name: 'Acme', slug: 'acme' });
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.schemaVersion).toBe('1');
+    expect(body.data).toMatchObject({ id: ORG_ID, orgId: ORG_ID, name: 'Acme', slug: 'acme', type: 'customer' });
+    expect(body.data.revision).toMatch(/^[a-f0-9]{64}$/);
+    expect(mocks.systemContextOpens).toBe(1);
+    expect(insertedValues[0]).toMatchObject({ partnerId: PARTNER_ID, name: 'Acme', slug: 'acme' });
+  });
+
+  it('ignores a body-supplied partnerId — the principal partner wins', async () => {
+    primeSuccess();
+    const res = await post('/organizations', 'organizations:write', {
+      name: 'Acme', slug: 'acme', partnerId: OTHER_ORG_ID,
+    });
+    expect(res.status).toBe(201);
+    expect((insertedValues[0] as { partnerId: string }).partnerId).toBe(PARTNER_ID);
+  });
+
+  it('refuses at the partner maxOrganizations cap with a specific error', async () => {
+    primeSuccess({ maxOrganizations: 3, orgCount: 3 });
+    const res = await post('/organizations', 'organizations:write', { name: 'Acme', slug: 'acme' });
+    expect(res.status).toBe(409);
+    const body = await res.json() as any;
+    expect(body.code).toBe('partner_provisioning_org_limit_reached');
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('creates below the maxOrganizations cap', async () => {
+    primeSuccess({ maxOrganizations: 3, orgCount: 2 });
+    const res = await post('/organizations', 'organizations:write', { name: 'Acme', slug: 'acme' });
+    expect(res.status).toBe(201);
+  });
+
+  it('maps a slug unique violation to 409', async () => {
+    selectResults = [[{ maxOrganizations: null }]];
+    insertResults = [Object.assign(new Error('duplicate key'), { code: '23505' })];
+    const res = await post('/organizations', 'organizations:write', { name: 'Acme', slug: 'acme' });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as any).code).toBe('partner_provisioning_slug_conflict');
+  });
+
+  it('rejects lifecycle statuses the human API reserves', async () => {
+    const res = await post('/organizations', 'organizations:write', {
+      name: 'Acme', slug: 'acme', status: 'churned',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('attributes the audit event to the service principal', async () => {
+    primeSuccess();
+    await post('/organizations', 'organizations:write', { name: 'Acme', slug: 'acme' });
+    expect(mocks.audit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: 'organization.create',
+      actorType: 'api_key',
+      actorId: KEY_ID,
+      orgId: ORG_ID,
+      details: expect.objectContaining({
+        principalType: 'partner_service_principal',
+        partnerServicePrincipalId: PRINCIPAL_ID,
+        partnerId: PARTNER_ID,
+      }),
+    }));
+  });
+});
+
+describe('POST /sites', () => {
+  function primeSuccess() {
+    insertResults = [[siteRow]];
+    selectResults = [[{ partnerExportUpdatedAt: UPDATED_AT }]];
+  }
+
+  it('requires the sites:write scope', async () => {
+    const res = await post('/sites', 'sites:read', { orgId: ORG_ID, name: 'HQ' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects an orgId outside the principal accessible set with 403', async () => {
+    const res = await post('/sites', 'sites:write', { orgId: OTHER_ORG_ID, name: 'HQ' });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as any).code).toBe('partner_provisioning_org_access_denied');
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it('creates a site inside a partner-scoped bounded context with a null userId', async () => {
+    primeSuccess();
+    const res = await post('/sites', 'sites:write', {
+      orgId: ORG_ID, name: 'HQ', address: { line1: '1 Main St', city: 'Denver' }, contact: { name: 'NOC' },
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.data).toMatchObject({
+      id: SITE_ID, orgId: ORG_ID, siteId: SITE_ID, name: 'HQ', timezone: 'UTC',
+    });
+    expect(body.data.address).toMatchObject({ line1: '1 Main St', city: 'Denver' });
+    expect(body.data.contact).toMatchObject({ name: 'NOC', email: 'noc@example.com' });
+    expect(mocks.partnerContexts[0]).toMatchObject({
+      scope: 'partner',
+      accessibleOrgIds: [ORG_ID],
+      accessiblePartnerIds: [PARTNER_ID],
+      currentPartnerId: PARTNER_ID,
+      userId: null,
+    });
+    expect(insertedValues[0]).toMatchObject({ orgId: ORG_ID, name: 'HQ', timezone: 'UTC' });
+  });
+
+  it('attributes the audit event to the service principal', async () => {
+    primeSuccess();
+    await post('/sites', 'sites:write', { orgId: ORG_ID, name: 'HQ' });
+    expect(mocks.audit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: 'site.create',
+      actorType: 'api_key',
+      actorId: KEY_ID,
+    }));
+  });
+});
+
+describe('POST /enrollment-keys', () => {
+  function primeSuccess({ withSite = false } = {}) {
+    selectResults = withSite ? [[{ id: SITE_ID }]] : [];
+    insertResults = [[keyRow]];
+  }
+
+  it('requires the enrollment-keys:write scope', async () => {
+    const res = await post('/enrollment-keys', 'organizations:write', { orgId: ORG_ID, name: 'k' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects an orgId outside the principal accessible set with 403', async () => {
+    const res = await post('/enrollment-keys', 'enrollment-keys:write', { orgId: OTHER_ORG_ID, name: 'k' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects ttlMinutes and expiresAt together', async () => {
+    const res = await post('/enrollment-keys', 'enrollment-keys:write', {
+      orgId: ORG_ID, name: 'k', ttlMinutes: 60, expiresAt: '2026-09-01T00:00:00Z',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unknown keys via .strict()', async () => {
+    const res = await post('/enrollment-keys', 'enrollment-keys:write', {
+      orgId: ORG_ID, name: 'k', maxUses: 5,
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toContain('maxUses');
+  });
+
+  it('rejects a TTL above the partner cap', async () => {
+    mocks.assertTtlWithinCap.mockResolvedValue('ttlMinutes exceeds the partner maximum of 60 minutes');
+    const res = await post('/enrollment-keys', 'enrollment-keys:write', {
+      orgId: ORG_ID, name: 'k', ttlMinutes: 120,
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).code).toBe('partner_provisioning_ttl_exceeds_cap');
+    expect(mocks.assertTtlWithinCap).toHaveBeenCalledWith(ORG_ID, 120);
+  });
+
+  it('rejects a siteId that does not belong to the org', async () => {
+    selectResults = [[]];
+    const res = await post('/enrollment-keys', 'enrollment-keys:write', {
+      orgId: ORG_ID, siteId: SITE_ID, name: 'k',
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).code).toBe('partner_provisioning_site_mismatch');
+  });
+
+  it('returns the raw key exactly once with a hashed row and no createdBy user', async () => {
+    primeSuccess();
+    const res = await post('/enrollment-keys', 'enrollment-keys:write', {
+      orgId: ORG_ID, name: 'migration key', ttlMinutes: 60,
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json() as any;
+    expect(body.key).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.data).toMatchObject({ id: KEY_ROW_ID, orgId: ORG_ID, name: 'migration key', maxUsage: 1 });
+    // The stored value must be the HASH, never the raw key.
+    const stored = insertedValues[0] as { key: string; createdBy: unknown };
+    expect(stored.key).not.toBe(body.key);
+    expect(stored.key).toMatch(/^[0-9a-f]{64}$/);
+    expect(stored.createdBy).toBeNull();
+    // The raw key never appears inside the DTO record.
+    expect(JSON.stringify(body.data)).not.toContain(body.key);
+  });
+
+  it('attributes the audit event to the service principal', async () => {
+    primeSuccess();
+    await post('/enrollment-keys', 'enrollment-keys:write', { orgId: ORG_ID, name: 'k' });
+    expect(mocks.audit).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: 'enrollment_key.create',
+      actorType: 'api_key',
+      actorId: KEY_ID,
+      details: expect.objectContaining({ partnerServicePrincipalId: PRINCIPAL_ID }),
+    }));
+  });
+});

--- a/apps/api/src/routes/partnerApi/provisioning.test.ts
+++ b/apps/api/src/routes/partnerApi/provisioning.test.ts
@@ -161,10 +161,22 @@ beforeEach(() => {
 });
 
 describe('POST /organizations', () => {
-  function primeSuccess({ maxOrganizations = null as number | null, orgCount = 0 } = {}) {
+  function primeSuccess({
+    maxOrganizations = null as number | null,
+    orgCount = 0,
+    postInsertCount = null as number | null,
+  } = {}) {
+    // Select order with a cap configured: partner row → pre-insert count →
+    // post-insert recount → export-stamp re-read. Without a cap the counts
+    // are skipped entirely.
     selectResults = maxOrganizations === null
       ? [[{ maxOrganizations }], [{ partnerExportUpdatedAt: UPDATED_AT }]]
-      : [[{ maxOrganizations }], [{ value: orgCount }], [{ partnerExportUpdatedAt: UPDATED_AT }]];
+      : [
+        [{ maxOrganizations }],
+        [{ value: orgCount }],
+        [{ value: postInsertCount ?? orgCount + 1 }],
+        [{ partnerExportUpdatedAt: UPDATED_AT }],
+      ];
     insertResults = [[orgRow]];
   }
 
@@ -212,6 +224,16 @@ describe('POST /organizations', () => {
     primeSuccess({ maxOrganizations: 3, orgCount: 2 });
     const res = await post('/organizations', 'organizations:write', { name: 'Acme', slug: 'acme' });
     expect(res.status).toBe(201);
+  });
+
+  it('rolls back an insert a concurrent create raced past the cap', async () => {
+    // Pre-insert count passes (2 < 3) but the post-insert recount sees 4 —
+    // a concurrent transaction committed first. The insert must be rolled
+    // back and reported as the same specific quota error.
+    primeSuccess({ maxOrganizations: 3, orgCount: 2, postInsertCount: 4 });
+    const res = await post('/organizations', 'organizations:write', { name: 'Acme', slug: 'acme' });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as any).code).toBe('partner_provisioning_org_limit_reached');
   });
 
   it('maps a slug unique violation to 409', async () => {

--- a/apps/api/src/routes/partnerApi/provisioning.ts
+++ b/apps/api/src/routes/partnerApi/provisioning.ts
@@ -161,7 +161,6 @@ function auditProvisioningCreate(
 }
 
 function createdResponse(
-  c: Parameters<typeof writeAuditEventAsync>[0] & { json: Function },
   resource: PartnerExportResource,
   identity: { id: string; orgId: string },
   record: Record<string, unknown>,
@@ -281,7 +280,7 @@ partnerProvisioningRoutes.post(
       details: { status: organization.status, type: organization.type },
     });
 
-    const body = createdResponse(c, 'organizations', { id: organization.id, orgId: organization.id }, {
+    const body = createdResponse('organizations', { id: organization.id, orgId: organization.id }, {
       id: organization.id,
       orgId: organization.id,
       siteId: null,
@@ -345,7 +344,7 @@ partnerProvisioningRoutes.post(
       resourceName: site.name,
     });
 
-    const body = createdResponse(c, 'sites', { id: site.id, orgId: site.orgId }, {
+    const body = createdResponse('sites', { id: site.id, orgId: site.orgId }, {
       id: site.id,
       orgId: site.orgId,
       siteId: site.id,

--- a/apps/api/src/routes/partnerApi/provisioning.ts
+++ b/apps/api/src/routes/partnerApi/provisioning.ts
@@ -114,6 +114,15 @@ function partnerScopedDbContext(principal: PartnerApiPrincipalContext): DbAccess
   };
 }
 
+/** Thrown inside the create-organization transaction to roll back an insert
+ *  that a concurrent create pushed past `partner.maxOrganizations`. */
+class OrgQuotaExceededError extends Error {
+  constructor(readonly cap: number) {
+    super('partner organization quota exceeded');
+    this.name = 'OrgQuotaExceededError';
+  }
+}
+
 function isUniqueViolation(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   const code = (error as { code?: unknown }).code;
@@ -187,6 +196,18 @@ partnerProvisioningRoutes.post(
       | { kind: 'quota'; cap: number }
       | { kind: 'failed' };
 
+    async function countPartnerOrganizations(partnerId: string): Promise<number> {
+      const [tally] = await db
+        .select({ value: sql<number>`count(*)::int` })
+        .from(organizations)
+        .where(and(
+          eq(organizations.partnerId, partnerId),
+          isNull(organizations.deletedAt),
+          ne(organizations.type, 'quick_support'),
+        ));
+      return tally?.value ?? 0;
+    }
+
     let outcome: CreateOutcome;
     try {
       // System context (bounded to this operation): a freshly created org's id
@@ -195,31 +216,17 @@ partnerProvisioningRoutes.post(
       // under partner scope — same escape the human route uses. Partner
       // authority was established by the auth middleware.
       outcome = await withSystemDbAccessContext(async (): Promise<CreateOutcome> => {
-        // Take the partner-export discovery lock EXCLUSIVE up front. This (a)
-        // serializes concurrent creates for the same partner so the
-        // maxOrganizations check below cannot be raced past the cap, and (b)
-        // pre-empts the `organizations` insert trigger, which takes the same
-        // lock and treats an already-held exclusive as re-entrant.
-        await db.execute(sql`SELECT public.breeze_partner_export_lock_partners_exclusive(
-          ARRAY[${principal.partnerId}::uuid]
-        )`);
-
         const [partnerRow] = await db
           .select({ maxOrganizations: partners.maxOrganizations })
           .from(partners)
           .where(eq(partners.id, principal.partnerId))
           .limit(1);
         const cap = partnerRow?.maxOrganizations ?? null;
-        if (cap !== null) {
-          const [tally] = await db
-            .select({ value: sql<number>`count(*)::int` })
-            .from(organizations)
-            .where(and(
-              eq(organizations.partnerId, principal.partnerId),
-              isNull(organizations.deletedAt),
-              ne(organizations.type, 'quick_support'),
-            ));
-          if ((tally?.value ?? 0) >= cap) return { kind: 'quota', cap };
+        // Fast path: refuse before inserting. This check alone is racy — two
+        // concurrent creates could both pass it — so it is backed by the
+        // post-insert recount below.
+        if (cap !== null && await countPartnerOrganizations(principal.partnerId) >= cap) {
+          return { kind: 'quota', cap };
         }
 
         const [organization] = await db
@@ -233,6 +240,20 @@ partnerProvisioningRoutes.post(
           })
           .returning();
         if (!organization) return { kind: 'failed' };
+
+        // Race-free quota enforcement WITHOUT calling the partner-export lock
+        // functions (EXECUTE is deliberately revoked from breeze_app — they
+        // are private to the SECURITY DEFINER insert triggers, see
+        // 2026-07-22-partner-export-lock-upgrade-hardening.sql). The insert
+        // statement's own AFTER trigger takes the partner discovery lock
+        // EXCLUSIVE, so concurrent same-partner org inserts serialize on it
+        // until COMMIT: by the time a second transaction's insert returns,
+        // the first one's row is committed and visible to this READ COMMITTED
+        // recount. Over the cap → throw, which rolls the whole transaction
+        // (and our insert) back.
+        if (cap !== null && await countPartnerOrganizations(principal.partnerId) > cap) {
+          throw new OrgQuotaExceededError(cap);
+        }
 
         // The AFTER-statement export trigger has already stamped
         // partner_export_updated_at by now; re-read it so the create response
@@ -249,13 +270,17 @@ partnerProvisioningRoutes.post(
         };
       });
     } catch (error) {
-      if (isUniqueViolation(error)) {
+      if (error instanceof OrgQuotaExceededError) {
+        // The transaction (including the over-cap insert) has rolled back.
+        outcome = { kind: 'quota', cap: error.cap };
+      } else if (isUniqueViolation(error)) {
         return c.json({
           error: 'An organization with this slug already exists.',
           code: 'partner_provisioning_slug_conflict',
         }, 409);
+      } else {
+        throw error;
       }
-      throw error;
     }
 
     if (outcome.kind === 'quota') {

--- a/apps/api/src/routes/partnerApi/provisioning.ts
+++ b/apps/api/src/routes/partnerApi/provisioning.ts
@@ -1,0 +1,483 @@
+/**
+ * Partner API provisioning writes (#3243).
+ *
+ * The three create routes that let a partner service principal provision
+ * tenancy unattended: organizations, sites, enrollment keys. Decisions from
+ * the #3243 thread this file implements:
+ *
+ * - Writes live on the Partner API because the machine principal already
+ *   authenticates here; the human `/orgs/*` MFA gate is never involved and
+ *   `hasSatisfiedMfa` is untouched.
+ * - Create only. Deletion of tenancy stays human + MFA on the main API.
+ * - `partnerId` always comes from the principal — a body-supplied value is
+ *   stripped by the schemas, never honored.
+ * - Every route is listed in the `writeSurface.test.ts` allowlist; responses
+ *   reuse the read-side export DTO contracts so `exportSafety` applies to
+ *   created objects exactly as it does to reads.
+ *
+ * Execution model: the auth middleware gives non-GET requests NO ambient DB
+ * context (see partnerApiAuth.ts) — each handler opens its own bounded
+ * context per operation, mirroring the human write routes.
+ */
+import { Hono } from 'hono';
+import { and, eq, isNull, ne, sql } from 'drizzle-orm';
+import { z } from 'zod';
+import { isValidIanaTimezone } from '@breeze/shared';
+import { zValidator } from '../../lib/validation';
+import { db, withDbAccessContext, withSystemDbAccessContext, type DbAccessContext } from '../../db';
+import { enrollmentKeys, organizations, partners, sites } from '../../db/schema';
+import {
+  requirePartnerApiScope,
+  type PartnerApiPrincipalContext,
+} from '../../middleware/partnerApiAuth';
+import { writeAuditEventAsync } from '../../services/auditEvents';
+import { assertTtlWithinCap } from '../../services/enrollmentDefaults';
+import {
+  generateEnrollmentKey,
+  getDefaultEnrollmentKeyTtlMinutes,
+  hashEnrollmentKey,
+} from '../../services/enrollmentKeySecurity';
+import { computePartnerExportRevision, safelyExportDefinition } from './exportSafety';
+import { jsonField } from './organizations';
+import {
+  enrollmentKeyCreateResponseSchema,
+  organizationCreateResponseSchema,
+  siteCreateResponseSchema,
+  type PartnerExportResource,
+} from './schemas';
+
+// Same 365-day ceiling as the human enrollment-key routes (enrollmentKeys.ts
+// MAX_TTL_MINUTES / devices/core.ts ENROLL_TOKEN_MAX_TTL_MINUTES).
+const ENROLLMENT_KEY_MAX_TTL_MINUTES = 525_600;
+
+// `partnerId` is intentionally absent from every body schema: the principal's
+// partner always wins, and zod strips unrecognized keys on non-strict objects,
+// so a caller-supplied `partnerId` is silently ignored rather than trusted.
+const createOrganizationBodySchema = z.object({
+  name: z.string().min(1).max(255),
+  slug: z.string().min(1).max(100),
+  type: z.enum(['customer', 'internal']).optional(),
+  // Narrower than the human create schema on purpose: an unattended
+  // provisioning credential creating `suspended`/`churned` tenants is not a
+  // workload. Lifecycle transitions stay on the human API.
+  status: z.enum(['active', 'trial']).optional(),
+});
+
+const boundedAddressString = z.string().max(1000).nullable().optional();
+// Mirrors the read DTO's normalized shape (partnerSiteAddressSchema /
+// partnerSiteContactSchema) so what a principal writes is exactly what it
+// reads back. Free-form `settings` is deliberately NOT writable here — it is
+// an open container the read DTO never exposes.
+const createSiteBodySchema = z.object({
+  orgId: z.string().uuid(),
+  name: z.string().min(1).max(255),
+  timezone: z.string().max(64).refine(isValidIanaTimezone, 'Invalid IANA timezone').default('UTC'),
+  address: z.object({
+    line1: boundedAddressString,
+    line2: boundedAddressString,
+    city: boundedAddressString,
+    region: boundedAddressString,
+    postalCode: boundedAddressString,
+    country: boundedAddressString,
+  }).strict().nullable().optional(),
+  contact: z.object({
+    name: boundedAddressString,
+    email: boundedAddressString,
+    phone: boundedAddressString,
+  }).strict().nullable().optional(),
+});
+
+// Mirrors createEnrollmentKeySchema on the human route: `.strict()`,
+// `ttlMinutes` XOR `expiresAt`, `maxUsage` 1–100000. `orgId` is required —
+// a machine caller always knows its target org (unlike the human route's
+// single-org partner convenience default).
+const createEnrollmentKeyBodySchema = z.object({
+  orgId: z.string().uuid(),
+  siteId: z.string().uuid().optional(),
+  name: z.string().min(1).max(255),
+  maxUsage: z.number().int().min(1).max(100000).optional(),
+  expiresAt: z.string().datetime().optional(),
+  ttlMinutes: z.number().int().min(1).max(ENROLLMENT_KEY_MAX_TTL_MINUTES).optional(),
+}).strict().refine(
+  (data) => !(data.expiresAt !== undefined && data.ttlMinutes !== undefined),
+  { message: 'Pass either ttlMinutes or expiresAt, not both', path: ['ttlMinutes'] },
+);
+
+function partnerScopedDbContext(principal: PartnerApiPrincipalContext): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: principal.accessibleOrgIds,
+    accessiblePartnerIds: [principal.partnerId],
+    currentPartnerId: principal.partnerId,
+    userId: null,
+  };
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const code = (error as { code?: unknown }).code;
+  if (code === '23505') return true;
+  const cause = (error as { cause?: unknown }).cause;
+  return !!cause && typeof cause === 'object' && (cause as { code?: unknown }).code === '23505';
+}
+
+function iso(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toISOString();
+}
+
+function auditProvisioningCreate(
+  c: Parameters<typeof writeAuditEventAsync>[0],
+  principal: PartnerApiPrincipalContext,
+  event: {
+    orgId: string;
+    action: string;
+    resourceType: string;
+    resourceId: string;
+    resourceName: string;
+    details?: Record<string, unknown>;
+  },
+): void {
+  // Attribution is the SERVICE PRINCIPAL (actorType api_key / key id), never a
+  // human — there is no user anywhere in this auth path (userId is null).
+  void writeAuditEventAsync(c, {
+    orgId: event.orgId,
+    actorType: 'api_key',
+    actorId: principal.keyId,
+    action: event.action,
+    resourceType: event.resourceType,
+    resourceId: event.resourceId,
+    resourceName: event.resourceName,
+    result: 'success',
+    details: {
+      principalType: 'partner_service_principal',
+      partnerServicePrincipalId: principal.partnerServicePrincipalId,
+      keyId: principal.keyId,
+      partnerId: principal.partnerId,
+      ...event.details,
+    },
+  });
+}
+
+function createdResponse(
+  c: Parameters<typeof writeAuditEventAsync>[0] & { json: Function },
+  resource: PartnerExportResource,
+  identity: { id: string; orgId: string },
+  record: Record<string, unknown>,
+) {
+  const definition = { ...record, revision: computePartnerExportRevision(record) };
+  const inspected = safelyExportDefinition({ resource, ...identity }, definition);
+  return inspected.safe
+    ? { data: inspected.definition, blocked: undefined }
+    : { data: null, blocked: [inspected.blocked] };
+}
+
+export const partnerProvisioningRoutes = new Hono();
+
+partnerProvisioningRoutes.post(
+  '/organizations',
+  requirePartnerApiScope('organizations:write'),
+  zValidator('json', createOrganizationBodySchema),
+  async (c) => {
+    const principal = c.get('partnerApiPrincipal');
+    const data = c.req.valid('json');
+
+    type CreateOutcome =
+      | { kind: 'created'; organization: typeof organizations.$inferSelect; sourceUpdatedAt: Date }
+      | { kind: 'quota'; cap: number }
+      | { kind: 'failed' };
+
+    let outcome: CreateOutcome;
+    try {
+      // System context (bounded to this operation): a freshly created org's id
+      // cannot be in any accessible_org_ids pre-insert, so the id-keyed RLS
+      // policies on `organizations` reject both the INSERT and its RETURNING
+      // under partner scope — same escape the human route uses. Partner
+      // authority was established by the auth middleware.
+      outcome = await withSystemDbAccessContext(async (): Promise<CreateOutcome> => {
+        // Take the partner-export discovery lock EXCLUSIVE up front. This (a)
+        // serializes concurrent creates for the same partner so the
+        // maxOrganizations check below cannot be raced past the cap, and (b)
+        // pre-empts the `organizations` insert trigger, which takes the same
+        // lock and treats an already-held exclusive as re-entrant.
+        await db.execute(sql`SELECT public.breeze_partner_export_lock_partners_exclusive(
+          ARRAY[${principal.partnerId}::uuid]
+        )`);
+
+        const [partnerRow] = await db
+          .select({ maxOrganizations: partners.maxOrganizations })
+          .from(partners)
+          .where(eq(partners.id, principal.partnerId))
+          .limit(1);
+        const cap = partnerRow?.maxOrganizations ?? null;
+        if (cap !== null) {
+          const [tally] = await db
+            .select({ value: sql<number>`count(*)::int` })
+            .from(organizations)
+            .where(and(
+              eq(organizations.partnerId, principal.partnerId),
+              isNull(organizations.deletedAt),
+              ne(organizations.type, 'quick_support'),
+            ));
+          if ((tally?.value ?? 0) >= cap) return { kind: 'quota', cap };
+        }
+
+        const [organization] = await db
+          .insert(organizations)
+          .values({
+            partnerId: principal.partnerId,
+            name: data.name,
+            slug: data.slug,
+            type: data.type,
+            status: data.status,
+          })
+          .returning();
+        if (!organization) return { kind: 'failed' };
+
+        // The AFTER-statement export trigger has already stamped
+        // partner_export_updated_at by now; re-read it so the create response
+        // carries the same sourceUpdatedAt/revision a subsequent GET returns.
+        const [stamped] = await db
+          .select({ partnerExportUpdatedAt: organizations.partnerExportUpdatedAt })
+          .from(organizations)
+          .where(eq(organizations.id, organization.id))
+          .limit(1);
+        return {
+          kind: 'created',
+          organization,
+          sourceUpdatedAt: stamped?.partnerExportUpdatedAt ?? organization.updatedAt,
+        };
+      });
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        return c.json({
+          error: 'An organization with this slug already exists.',
+          code: 'partner_provisioning_slug_conflict',
+        }, 409);
+      }
+      throw error;
+    }
+
+    if (outcome.kind === 'quota') {
+      // Deliberately specific (not a generic 500): an unattended credential
+      // hitting the org cap is a billing conversation, not a server fault.
+      return c.json({
+        error: `Organization limit reached (${outcome.cap}). Contact your Breeze administrator to raise the partner cap.`,
+        code: 'partner_provisioning_org_limit_reached',
+      }, 409);
+    }
+    if (outcome.kind === 'failed') {
+      return c.json({ error: 'Organization create failed.', code: 'partner_provisioning_failed' }, 500);
+    }
+
+    const { organization, sourceUpdatedAt } = outcome;
+    auditProvisioningCreate(c, principal, {
+      orgId: organization.id,
+      action: 'organization.create',
+      resourceType: 'organization',
+      resourceId: organization.id,
+      resourceName: organization.name,
+      details: { status: organization.status, type: organization.type },
+    });
+
+    const body = createdResponse(c, 'organizations', { id: organization.id, orgId: organization.id }, {
+      id: organization.id,
+      orgId: organization.id,
+      siteId: null,
+      sourceUpdatedAt: iso(sourceUpdatedAt),
+      name: organization.name,
+      slug: organization.slug,
+      type: organization.type,
+    });
+    return c.json(organizationCreateResponseSchema.parse({
+      schemaVersion: '1' as const,
+      data: body.data,
+      ...(body.blocked ? { blocked: body.blocked } : {}),
+    }), 201);
+  },
+);
+
+partnerProvisioningRoutes.post(
+  '/sites',
+  requirePartnerApiScope('sites:write'),
+  zValidator('json', createSiteBodySchema),
+  async (c) => {
+    const principal = c.get('partnerApiPrincipal');
+    const data = c.req.valid('json');
+
+    if (!principal.accessibleOrgIds.includes(data.orgId)) {
+      return c.json({
+        error: 'Access to this organization denied.',
+        code: 'partner_provisioning_org_access_denied',
+      }, 403);
+    }
+
+    const created = await withDbAccessContext(partnerScopedDbContext(principal), async () => {
+      const [site] = await db
+        .insert(sites)
+        .values({
+          orgId: data.orgId,
+          name: data.name,
+          timezone: data.timezone,
+          address: data.address ?? null,
+          contact: data.contact ?? null,
+        })
+        .returning();
+      if (!site) return null;
+      const [stamped] = await db
+        .select({ partnerExportUpdatedAt: sites.partnerExportUpdatedAt })
+        .from(sites)
+        .where(eq(sites.id, site.id))
+        .limit(1);
+      return { site, sourceUpdatedAt: stamped?.partnerExportUpdatedAt ?? site.updatedAt };
+    });
+    if (!created) {
+      return c.json({ error: 'Site create failed.', code: 'partner_provisioning_failed' }, 500);
+    }
+
+    const { site, sourceUpdatedAt } = created;
+    auditProvisioningCreate(c, principal, {
+      orgId: site.orgId,
+      action: 'site.create',
+      resourceType: 'site',
+      resourceId: site.id,
+      resourceName: site.name,
+    });
+
+    const body = createdResponse(c, 'sites', { id: site.id, orgId: site.orgId }, {
+      id: site.id,
+      orgId: site.orgId,
+      siteId: site.id,
+      sourceUpdatedAt: iso(sourceUpdatedAt),
+      name: site.name,
+      timezone: site.timezone,
+      address: site.address ? {
+        line1: jsonField(site.address, ['line1', 'addressLine1', 'street1']),
+        line2: jsonField(site.address, ['line2', 'addressLine2', 'street2']),
+        city: jsonField(site.address, ['city']),
+        region: jsonField(site.address, ['region', 'state']),
+        postalCode: jsonField(site.address, ['postalCode', 'zip']),
+        country: jsonField(site.address, ['country']),
+      } : null,
+      contact: site.contact ? {
+        name: jsonField(site.contact, ['name']),
+        email: jsonField(site.contact, ['email']),
+        phone: jsonField(site.contact, ['phone']),
+      } : null,
+    });
+    return c.json(siteCreateResponseSchema.parse({
+      schemaVersion: '1' as const,
+      data: body.data,
+      ...(body.blocked ? { blocked: body.blocked } : {}),
+    }), 201);
+  },
+);
+
+partnerProvisioningRoutes.post(
+  '/enrollment-keys',
+  requirePartnerApiScope('enrollment-keys:write'),
+  zValidator('json', createEnrollmentKeyBodySchema),
+  async (c) => {
+    const principal = c.get('partnerApiPrincipal');
+    const data = c.req.valid('json');
+
+    if (!principal.accessibleOrgIds.includes(data.orgId)) {
+      return c.json({
+        error: 'Access to this organization denied.',
+        code: 'partner_provisioning_org_access_denied',
+      }, 403);
+    }
+
+    // Reject (never clamp) a TTL above the partner cap — both expiry paths,
+    // same as the human route (#2776): capping only ttlMinutes would leave
+    // expiresAt as a wide-open bypass. assertTtlWithinCap manages its own
+    // system-context read, so it runs before any bounded context opens.
+    const impliedTtlMinutes = data.ttlMinutes !== undefined
+      ? data.ttlMinutes
+      : data.expiresAt !== undefined
+        ? Math.ceil((new Date(data.expiresAt).getTime() - Date.now()) / 60_000)
+        : undefined;
+    const capError = await assertTtlWithinCap(data.orgId, impliedTtlMinutes);
+    if (capError) {
+      return c.json({ error: capError, code: 'partner_provisioning_ttl_exceeds_cap' }, 400);
+    }
+
+    const rawKey = generateEnrollmentKey();
+    const keyHash = hashEnrollmentKey(rawKey);
+    const expiresAt = data.ttlMinutes !== undefined
+      ? new Date(Date.now() + data.ttlMinutes * 60 * 1000)
+      : data.expiresAt
+        ? new Date(data.expiresAt)
+        : new Date(Date.now() + getDefaultEnrollmentKeyTtlMinutes() * 60 * 1000);
+
+    const outcome = await withDbAccessContext(partnerScopedDbContext(principal), async () => {
+      if (data.siteId) {
+        const [site] = await db
+          .select({ id: sites.id })
+          .from(sites)
+          .where(and(eq(sites.id, data.siteId), eq(sites.orgId, data.orgId)))
+          .limit(1);
+        if (!site) return { kind: 'bad_site' as const };
+      }
+      const [enrollmentKey] = await db
+        .insert(enrollmentKeys)
+        .values({
+          orgId: data.orgId,
+          siteId: data.siteId ?? null,
+          name: data.name,
+          key: keyHash,
+          maxUsage: data.maxUsage ?? 1,
+          expiresAt,
+          // No human in this auth path; attribution lives in the audit event.
+          createdBy: null,
+        })
+        .returning();
+      return enrollmentKey
+        ? { kind: 'created' as const, enrollmentKey }
+        : { kind: 'failed' as const };
+    });
+
+    if (outcome.kind === 'bad_site') {
+      return c.json({
+        error: 'siteId does not belong to the specified org.',
+        code: 'partner_provisioning_site_mismatch',
+      }, 400);
+    }
+    if (outcome.kind === 'failed') {
+      return c.json({ error: 'Enrollment key create failed.', code: 'partner_provisioning_failed' }, 500);
+    }
+
+    const { enrollmentKey } = outcome;
+    auditProvisioningCreate(c, principal, {
+      orgId: enrollmentKey.orgId,
+      action: 'enrollment_key.create',
+      resourceType: 'enrollment_key',
+      resourceId: enrollmentKey.id,
+      resourceName: enrollmentKey.name,
+      details: {
+        siteId: enrollmentKey.siteId,
+        maxUsage: enrollmentKey.maxUsage,
+        expiresAt: enrollmentKey.expiresAt,
+      },
+    });
+
+    // The raw key is returned exactly once, deliberately OUTSIDE `data`: the
+    // DTO record is a strict no-secret allowlist and the response schema pins
+    // the one-time credential to a single explicit top-level field.
+    return c.json(enrollmentKeyCreateResponseSchema.parse({
+      schemaVersion: '1' as const,
+      data: {
+        id: enrollmentKey.id,
+        orgId: enrollmentKey.orgId,
+        siteId: enrollmentKey.siteId,
+        name: enrollmentKey.name,
+        usageCount: enrollmentKey.usageCount,
+        maxUsage: enrollmentKey.maxUsage,
+        expiresAt: enrollmentKey.expiresAt ? iso(enrollmentKey.expiresAt) : null,
+        createdAt: iso(enrollmentKey.createdAt),
+      },
+      key: rawKey,
+    }), 201);
+  },
+);

--- a/apps/api/src/routes/partnerApi/schemas.ts
+++ b/apps/api/src/routes/partnerApi/schemas.ts
@@ -477,6 +477,58 @@ export const customFieldValueExportEnvelopeSchema = createPartnerExportEnvelopeS
   partnerCustomFieldValueExportRecordSchema,
 );
 
+// --- Provisioning create responses (#3243) -------------------------------
+//
+// Created-object responses reuse the exact read-side export record schemas
+// (same strict allowlists, same revision contract), so `dtoSafety` /
+// `exportSafety` apply to writes exactly as they do to reads. `data` is null
+// only when the post-insert safety inspection blocked the record — the row
+// exists either way, and `blocked` then carries the identity.
+export function createPartnerProvisioningResponseSchema<T extends z.ZodType>(recordSchema: T) {
+  return z.object({
+    schemaVersion: z.literal('1'),
+    data: recordSchema.nullable(),
+    blocked: z.array(partnerExportBlockedRecordSchema).max(1).optional(),
+  }).strict().superRefine((value, ctx) => {
+    if ((value.data === null) !== (value.blocked !== undefined && value.blocked.length > 0)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['data'],
+        message: 'blocked must be present exactly when data is null',
+      });
+    }
+  });
+}
+
+export const organizationCreateResponseSchema = createPartnerProvisioningResponseSchema(
+  partnerOrganizationExportRecordSchema,
+);
+export const siteCreateResponseSchema = createPartnerProvisioningResponseSchema(
+  partnerSiteExportRecordSchema,
+);
+
+// Enrollment keys are not an export resource, so this record is a bespoke
+// strict allowlist rather than a reuse of a read DTO. The hashed `key`
+// column and `keySecretHash` are deliberately absent; the one-time raw key
+// travels in the response's top-level `key` field, never inside `data`.
+export const partnerEnrollmentKeyCreateRecordSchema = z.object({
+  id: z.string().uuid(),
+  orgId: z.string().uuid(),
+  siteId: z.string().uuid().nullable(),
+  name: z.string().min(1).max(255),
+  usageCount: z.number().int().nonnegative(),
+  maxUsage: z.number().int().positive().nullable(),
+  expiresAt: partnerExportTimestampSchema.nullable(),
+  createdAt: partnerExportTimestampSchema,
+}).strict();
+
+export const enrollmentKeyCreateResponseSchema = z.object({
+  schemaVersion: z.literal('1'),
+  data: partnerEnrollmentKeyCreateRecordSchema,
+  /** Returned exactly once, at creation. 64-char hex, as on the human route. */
+  key: z.string().regex(/^[0-9a-f]{64}$/u),
+}).strict();
+
 export type PartnerExportEnvelope<T extends PartnerExportRecordBase> = {
   schemaVersion: '1';
   snapshotAt: string;

--- a/apps/api/src/routes/partnerApi/schemas.ts
+++ b/apps/api/src/routes/partnerApi/schemas.ts
@@ -490,7 +490,10 @@ export function createPartnerProvisioningResponseSchema<T extends z.ZodType>(rec
     data: recordSchema.nullable(),
     blocked: z.array(partnerExportBlockedRecordSchema).max(1).optional(),
   }).strict().superRefine((value, ctx) => {
-    if ((value.data === null) !== (value.blocked !== undefined && value.blocked.length > 0)) {
+    // The generic record type defeats inference on the refined object shape,
+    // so narrow explicitly — only the null/blocked pairing is inspected here.
+    const view = value as unknown as { data: unknown; blocked?: unknown[] };
+    if ((view.data === null) !== (view.blocked !== undefined && view.blocked.length > 0)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['data'],

--- a/apps/api/src/routes/partnerApi/writeSurface.test.ts
+++ b/apps/api/src/routes/partnerApi/writeSurface.test.ts
@@ -42,7 +42,12 @@ import { partnerApiRoutes } from './index';
  * API), a dedicated `:write` scope, per-principal write rate limiting, and
  * audit attribution to the service principal.
  */
-const PARTNER_API_NON_GET_ROUTE_ALLOWLIST: readonly string[] = [];
+const PARTNER_API_NON_GET_ROUTE_ALLOWLIST: readonly string[] = [
+  // #3243 — unattended tenancy provisioning (partner service principal).
+  'POST /enrollment-keys', // enrollment-keys:write; TTL cap enforced; raw key returned once
+  'POST /organizations', // organizations:write; partner.maxOrganizations quota enforced
+  'POST /sites', // sites:write; orgId must be in the principal's accessible set
+];
 
 describe('partner API write surface', () => {
   function nonGetRoutes(): string[] {

--- a/apps/api/src/routes/partnerApi/writeSurface.test.ts
+++ b/apps/api/src/routes/partnerApi/writeSurface.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The route modules under this directory register their handlers at import
+// time; the registration itself needs no database, Redis, or env secrets, so
+// those transitive imports are mocked exactly like the sibling route tests.
+vi.mock('../../db', () => ({
+  db: {},
+  hasDbAccessContext: () => true,
+  withDbAccessContext: async (_ctx: unknown, fn: () => unknown) => fn(),
+  withSystemDbAccessContext: async (fn: () => unknown) => fn(),
+  runOutsideDbContext: (fn: () => unknown) => fn(),
+}));
+vi.mock('../../config/env', () => ({
+  PARTNER_API_CURSOR_SIGNING_KEY: Buffer.from('0123456789abcdef0123456789abcdef', 'utf8'),
+}));
+vi.mock('../../middleware/partnerApiAuth', () => ({
+  partnerApiAuthMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
+  requirePartnerApiScope: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+vi.mock('../../services/auditEvents', () => ({
+  writeAuditEventAsync: vi.fn(),
+  requestLikeFromSnapshot: (value: unknown) => value,
+}));
+
+import { partnerApiRoutes } from './index';
+
+/**
+ * The Partner API was read-only by construction until #3243 — every route was
+ * a `.get()`, and "this surface cannot mutate tenancy" was verifiable with a
+ * grep. Issue #3243 deliberately gave it a write side (unattended tenancy
+ * provisioning for migrations and integrations), which destroyed that cheap
+ * invariant. This allowlist is its stronger replacement: every non-GET route
+ * registered under `partnerApiRoutes` must appear here as a deliberate,
+ * reviewable line, so a future write route cannot slip in as a side effect of
+ * an unrelated change — it fails CI instead of relying on a reviewer noticing.
+ *
+ * Same idiom as `CORE_ORG_CASCADE_DELETE_ORDER`, `runActionAllowlist.ts`, and
+ * the RLS coverage allowlists.
+ *
+ * Adding an entry requires the same scrutiny the #3243 thread applied:
+ * create/update only (org/site/key DELETION stays human + MFA on the main
+ * API), a dedicated `:write` scope, per-principal write rate limiting, and
+ * audit attribution to the service principal.
+ */
+const PARTNER_API_NON_GET_ROUTE_ALLOWLIST: readonly string[] = [];
+
+describe('partner API write surface', () => {
+  function nonGetRoutes(): string[] {
+    const seen = new Set<string>();
+    for (const route of partnerApiRoutes.routes) {
+      // 'ALL' entries are `.use()` middleware registrations, not endpoints.
+      if (route.method === 'GET' || route.method === 'ALL') continue;
+      seen.add(`${route.method} ${route.path}`);
+    }
+    return [...seen].sort();
+  }
+
+  it('every non-GET route is explicitly allowlisted', () => {
+    expect(nonGetRoutes()).toEqual([...PARTNER_API_NON_GET_ROUTE_ALLOWLIST].sort());
+  });
+
+  it('catches an unlisted write route being added to the surface', () => {
+    // Prove the enumeration actually sees new registrations: temporarily
+    // register a write route the allowlist does not contain and assert the
+    // comparison would fail. Registered on a throwaway clone-like path check
+    // via the live router, then verified present in the enumeration.
+    const before = nonGetRoutes();
+    partnerApiRoutes.post('/__write-surface-canary__', (c) => c.text('never'));
+    try {
+      const after = nonGetRoutes();
+      expect(after).toContain('POST /__write-surface-canary__');
+      expect(after).not.toEqual([...PARTNER_API_NON_GET_ROUTE_ALLOWLIST].sort());
+      expect(after.length).toBe(before.length + 1);
+    } finally {
+      // Hono has no route deregistration; scrub the canary from the internal
+      // route table so this test cannot leak state into sibling suites that
+      // import the same module instance.
+      const routes = partnerApiRoutes.routes as Array<{ path: string }>;
+      for (let i = routes.length - 1; i >= 0; i -= 1) {
+        if (routes[i]?.path === '/__write-surface-canary__') routes.splice(i, 1);
+      }
+    }
+  });
+});

--- a/apps/api/src/services/enrollmentKeySecurity.ts
+++ b/apps/api/src/services/enrollmentKeySecurity.ts
@@ -1,4 +1,26 @@
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
+
+/**
+ * Mints a raw enrollment key value (64-char hex) for the Partner API
+ * provisioning route (#3243). Identical format/entropy to the human route's
+ * local generator in routes/enrollmentKeys.ts (which stays local because a
+ * dozen test suites mock this module with only the hash functions).
+ */
+export function generateEnrollmentKey(): string {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * Default lifetime applied when a create request supplies neither
+ * `ttlMinutes` nor `expiresAt`. Same env knob the human route has always
+ * read; resolved per call so tests can vary the env.
+ */
+export function getDefaultEnrollmentKeyTtlMinutes(): number {
+  const raw = process.env.ENROLLMENT_KEY_DEFAULT_TTL_MINUTES;
+  if (!raw) return 60;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : 60;
+}
 
 // Primary pepper used for ALL new enrollment-key hashes. Required in production.
 function getPrimaryPepper(): string {

--- a/apps/api/src/services/partnerServicePrincipalScopes.test.ts
+++ b/apps/api/src/services/partnerServicePrincipalScopes.test.ts
@@ -49,10 +49,29 @@ describe('partner partner-service-principal scopes', () => {
     expect(hasPartnerServicePrincipalScope(['devices'], 'devices:read')).toBe(false);
   });
 
-  it('publishes a frozen default Weavestream delegation containing all eight scopes', () => {
-    expect(DEFAULT_WEAVESTREAM_PARTNER_SERVICE_PRINCIPAL_SCOPES).toEqual(
-      PARTNER_SERVICE_PRINCIPAL_SCOPES,
-    );
+  it('publishes a frozen default Weavestream delegation of exactly the eight read scopes', () => {
+    // Named explicitly on purpose — NOT derived from PARTNER_SERVICE_PRINCIPAL_SCOPES.
+    // Since #3243 the full scope list also contains tenancy WRITE scopes, and the
+    // default delegation must never absorb a new scope implicitly: adding one
+    // here has to be a deliberate human decision, because every default-scoped
+    // principal inherits it.
+    expect(DEFAULT_WEAVESTREAM_PARTNER_SERVICE_PRINCIPAL_SCOPES).toEqual([
+      'organizations:read',
+      'sites:read',
+      'devices:read',
+      'inventory:read',
+      'configuration:read',
+      'scripts:read',
+      'backup-configuration:read',
+      'custom-fields:read',
+    ]);
     expect(Object.isFrozen(DEFAULT_WEAVESTREAM_PARTNER_SERVICE_PRINCIPAL_SCOPES)).toBe(true);
+  });
+
+  it('never includes a write scope in the default delegation', () => {
+    // Provisioning writes (#3243) are opt-in at principal creation only.
+    for (const scope of DEFAULT_WEAVESTREAM_PARTNER_SERVICE_PRINCIPAL_SCOPES) {
+      expect(scope.endsWith(':read')).toBe(true);
+    }
   });
 });

--- a/apps/api/src/services/partnerServicePrincipalScopes.ts
+++ b/apps/api/src/services/partnerServicePrincipalScopes.ts
@@ -1,4 +1,4 @@
-export const PARTNER_SERVICE_PRINCIPAL_SCOPES = Object.freeze([
+export const PARTNER_SERVICE_PRINCIPAL_READ_SCOPES = Object.freeze([
   'organizations:read',
   'sites:read',
   'devices:read',
@@ -9,11 +9,30 @@ export const PARTNER_SERVICE_PRINCIPAL_SCOPES = Object.freeze([
   'custom-fields:read',
 ] as const);
 
+// Provisioning write scopes (#3243). Create/update only by design — deletion
+// of tenancy stays a human + MFA action on the main API and must never grow a
+// scope here. These are opt-in at principal creation and are deliberately NOT
+// part of any default scope set.
+export const PARTNER_SERVICE_PRINCIPAL_WRITE_SCOPES = Object.freeze([
+  'organizations:write',
+  'sites:write',
+  'enrollment-keys:write',
+] as const);
+
+export const PARTNER_SERVICE_PRINCIPAL_SCOPES = Object.freeze([
+  ...PARTNER_SERVICE_PRINCIPAL_READ_SCOPES,
+  ...PARTNER_SERVICE_PRINCIPAL_WRITE_SCOPES,
+] as const);
+
 export type PartnerServicePrincipalScope =
   (typeof PARTNER_SERVICE_PRINCIPAL_SCOPES)[number];
 
+// Read-only on purpose: the Weavestream default existed before the write
+// scopes did, and silently widening a DEFAULT to include tenancy writes would
+// grant every default-scoped principal provisioning power. Write scopes are
+// opt-in per principal, never implicit (#3243).
 export const DEFAULT_WEAVESTREAM_PARTNER_SERVICE_PRINCIPAL_SCOPES = Object.freeze(
-  [...PARTNER_SERVICE_PRINCIPAL_SCOPES] as PartnerServicePrincipalScope[],
+  [...PARTNER_SERVICE_PRINCIPAL_READ_SCOPES] as PartnerServicePrincipalScope[],
 );
 
 const PARTNER_SERVICE_PRINCIPAL_SCOPE_SET = new Set<string>(

--- a/apps/docs/src/content/docs/reference/api-keys.mdx
+++ b/apps/docs/src/content/docs/reference/api-keys.mdx
@@ -197,6 +197,26 @@ All routes are prefixed with `/api/v1/service-principals`, require JWT (user-ses
 
 Every mutation is recorded in the audit log (`service_principal.create`, `service_principal.rotate_key`, `service_principal.disable`, `service_principal.migrate_key`) with the acting user, the principal, and -- for key operations -- the new key's prefix only. The raw key material is never logged.
 
+### Partner Service Principal Scopes
+
+**Partner** service principals (keys prefixed `brz_sp_`, managed from Settings → Partner Service Principals) authenticate the [Partner API](/reference/api/#partner-api-service-principals) and carry their own scope vocabulary:
+
+| Scope | Grants |
+|--------|--------|
+| `organizations:read` | Export organizations |
+| `sites:read` | Export sites |
+| `devices:read` | Export devices |
+| `inventory:read` | Export device inventory, software, and relationships |
+| `configuration:read` | Export configuration policies, assignments, and automations |
+| `scripts:read` | Export scripts |
+| `backup-configuration:read` | Export backup configuration |
+| `custom-fields:read` | Export custom field definitions and values |
+| `organizations:write` | Create organizations (bounded by the partner's organization cap) |
+| `sites:write` | Create sites in the principal's accessible organizations |
+| `enrollment-keys:write` | Create enrollment keys (raw key returned once) |
+
+The three `:write` scopes exist for unattended tenancy provisioning -- migration scripts, scheduled syncs, and partner-built integrations. They are **opt-in at principal creation and never part of the default scope set**: a default-scoped principal stays read-only. Grant them only to credentials that genuinely provision tenancy, and prefer a dedicated principal for provisioning so rotation and revocation stay surgical. Provisioning is create-only -- deleting organizations, sites, or enrollment keys remains a human, MFA-gated action.
+
 ---
 
 ## Enrollment Keys

--- a/apps/docs/src/content/docs/reference/api.mdx
+++ b/apps/docs/src/content/docs/reference/api.mdx
@@ -167,6 +167,41 @@ curl -X POST https://breeze.yourdomain.com/api/v1/auth/refresh \
 | `DELETE` | `/api-keys/:id` | Revoke API key |
 | `POST` | `/api-keys/:id/rotate` | Rotate API key |
 
+## Partner API (Service Principals)
+
+Machine-to-machine surface authenticated with a **partner service principal**
+key (`X-API-Key: brz_sp_…`), not a user JWT. Reads are cursor-paginated
+exports; the provisioning writes let migration scripts and integrations
+create tenancy unattended — no MFA challenge is involved because no human is.
+Each route requires the listed scope on the principal.
+
+| Method | Path | Scope | Description |
+|---|---|---|---|
+| `GET` | `/partner-api/organizations` | `organizations:read` | Export organizations |
+| `GET` | `/partner-api/sites` | `sites:read` | Export sites |
+| `GET` | `/partner-api/devices` | `devices:read` | Export devices |
+| `GET` | `/partner-api/device-inventory` | `inventory:read` | Export device inventory |
+| `GET` | `/partner-api/device-software` | `inventory:read` | Export installed software |
+| `GET` | `/partner-api/device-relationships` | `inventory:read` | Export topology/relationship edges |
+| `GET` | `/partner-api/configuration-policies` | `configuration:read` | Export configuration policies |
+| `GET` | `/partner-api/configuration-assignments` | `configuration:read` | Export policy assignments |
+| `GET` | `/partner-api/scripts` | `scripts:read` | Export scripts |
+| `GET` | `/partner-api/automations` | `configuration:read` | Export automations |
+| `GET` | `/partner-api/backup-configurations` | `backup-configuration:read` | Export backup configuration |
+| `GET` | `/partner-api/custom-fields` | `custom-fields:read` | Export custom field definitions |
+| `GET` | `/partner-api/custom-field-values` | `custom-fields:read` | Export custom field values |
+| `POST` | `/partner-api/organizations` | `organizations:write` | Create an organization under the principal's partner. Enforces the partner's `maxOrganizations` cap (409 when reached). Body: `name`, `slug`, `type?`, `status?` (`active`/`trial`). |
+| `POST` | `/partner-api/sites` | `sites:write` | Create a site. `orgId` must be in the principal's accessible organizations (403 otherwise). Body: `orgId`, `name`, `timezone?`, `address?`, `contact?`. |
+| `POST` | `/partner-api/enrollment-keys` | `enrollment-keys:write` | Create an enrollment key. Body: `orgId`, `name`, `siteId?`, `maxUsage?`, and `ttlMinutes` **or** `expiresAt` (never both). The raw key is returned once in the 201 body. |
+
+Provisioning is deliberately **create-only**: there are no `DELETE` routes on
+this surface, and organization deletion remains a human, MFA-gated action on
+the main API. `partnerId` never appears in any write body — it always comes
+from the authenticated principal. Writes share the principal's hourly rate
+limit but are additionally capped by a tighter per-principal write budget
+(120/hour), and every write is attributed to the service principal in the
+audit log.
+
 ## Alerts
 
 | Method | Path | Description |

--- a/apps/web/src/components/settings/PartnerServicePrincipalsPage.tsx
+++ b/apps/web/src/components/settings/PartnerServicePrincipalsPage.tsx
@@ -5,10 +5,14 @@ import { navigateTo } from '@/lib/navigation';
 import { fetchWithAuth } from '../../stores/auth';
 import { handleActionError, runAction } from '../../lib/runAction';
 
-const AVAILABLE_SCOPES = [
+const READ_SCOPES = [
   'organizations:read', 'sites:read', 'devices:read', 'inventory:read',
   'configuration:read', 'scripts:read', 'backup-configuration:read', 'custom-fields:read',
 ] as const;
+// Provisioning write scopes (#3243): opt-in per principal, NEVER part of the
+// default selection — a default-scoped principal must stay read-only.
+const WRITE_SCOPES = ['organizations:write', 'sites:write', 'enrollment-keys:write'] as const;
+const AVAILABLE_SCOPES = [...READ_SCOPES, ...WRITE_SCOPES] as const;
 
 type PrincipalKey = {
   id: string;
@@ -40,7 +44,7 @@ type PrincipalDraft = {
 };
 
 const EMPTY_DRAFT: PrincipalDraft = {
-  name: '', description: '', scopes: [...AVAILABLE_SCOPES], expiresAt: '', sourceCidrs: '',
+  name: '', description: '', scopes: [...READ_SCOPES], expiresAt: '', sourceCidrs: '',
 };
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
@@ -78,7 +82,7 @@ export default function PartnerServicePrincipalsPage() {
   useEffect(() => { void load(); }, [load]);
 
   const closeReveal = () => setNewKey(null);
-  const openCreate = () => { setEditing('new'); setDraft({ ...EMPTY_DRAFT, scopes: [...AVAILABLE_SCOPES] }); };
+  const openCreate = () => { setEditing('new'); setDraft({ ...EMPTY_DRAFT, scopes: [...READ_SCOPES] }); };
   const openEdit = (principal: Principal) => {
     setEditing(principal);
     setDraft({


### PR DESCRIPTION
Closes #3243. Part of epic #3249.

Implements the plan in `docs/superpowers/plans/open/2026-08-08-partner-api-provisioning-writes.md` (on the `docs/rmm-migration-guides` branch): lets a partner service principal create organizations, sites, and enrollment keys unattended, so RMM-migration scripts and integrations can provision tenancy without an MFA'd human JWT.

## What changed

**Scopes** (`services/partnerServicePrincipalScopes.ts`)
- New `organizations:write`, `sites:write`, `enrollment-keys:write`, validated by the existing `validatePartnerServicePrincipalScopes` and mintable only through the MFA-gated partner principal management routes.
- The Weavestream default scope set is now pinned to the read scopes explicitly — write scopes are **opt-in at principal creation, never implicit**.
- `hasSatisfiedMfa` is untouched, per the issue thread's explicit rejection of principal-type branching.

**Write-surface allowlist test** (`routes/partnerApi/writeSurface.test.ts`) — written FIRST, per the condition attached to the #3243 decision
- Enumerates every route under `partnerApiRoutes`; the set of non-GET routes must equal an explicit allowlist constant. Seeded empty, verified green on the pre-change tree; its first run against the new routes failed with exactly `POST /organizations`, `POST /sites`, `POST /enrollment-keys` before they were allowlisted (evidence the guard works). A canary test proves a fourth unlisted write route fails the suite.

**Auth middleware** (`middleware/partnerApiAuth.ts`)
- Non-GET requests take a new branch: principal + org discovery resolve in a short bounded system context, and the handler runs with **no ambient DB context** — handlers open their own bounded contexts per operation (mirroring the human `/orgs/*` write routes).
- Why: the read path holds the partner-export advisory lock **shared** for the whole request, while an `organizations` INSERT trigger takes the same lock **exclusive** (`2026-07-21-partner-export-canonical-org-mutations.sql`). An insert from a nested system transaction on a second pooled connection would wait on our own request's shared lock — an application-level self-deadlock. Writes also take no export snapshot, so the held-transaction consistency machinery doesn't apply to them.
- Writes get a tighter per-principal rate bucket: `min(key limit, 120)/hour`, separate Redis key, 429 + `Retry-After` on exhaustion. `recordMachineUse` continues to audit every write request (success and failure) as the service principal.

**Routes** (`routes/partnerApi/provisioning.ts`)
- `POST /partner-api/organizations` — `organizations:write`. `partnerId` comes only from the principal (body value stripped). Runs in a bounded system context (a new org's id can't pass the id-keyed RLS insert policy under partner scope — same escape as the human route). The `maxOrganizations` cap is enforced race-free without touching the private export-lock functions (EXECUTE is revoked from `breeze_app`): pre-check, insert (the SECURITY DEFINER insert trigger serializes same-partner creates until commit), then a post-insert recount in the same transaction that rolls back an over-cap insert. Slug 23505 maps to 409; the cap returns a specific 409 (`partner_provisioning_org_limit_reached`). Status restricted to `active`/`trial` (creating suspended/churned tenants unattended is not a workload).
- `POST /partner-api/sites` — `sites:write`. `orgId` outside the principal's accessible set → 403. Insert runs in a partner-scoped bounded context (`userId: null`), so RLS enforces org access a second time.
- `POST /partner-api/enrollment-keys` — `enrollment-keys:write`. Mirrors the human schema (`.strict()`, `ttlMinutes` XOR `expiresAt`, `maxUsage` 1–100000), rejects TTLs above the partner cap on both expiry paths via the shared `assertTtlWithinCap`, verifies `siteId` belongs to the org, stores only the hash, `createdBy: null`. Raw key returned exactly once at the top level of the 201 body.
- Created-object responses reuse the read-side export DTO contracts: same strict record schemas, `revision`, and `safelyExportDefinition` inspection, so `dtoSafety`/`exportSafety` apply to writes exactly as to reads.
- **No DELETE routes** — deletion stays human + MFA on the main API (plan Task 4).
- Audit: `organization.create` / `site.create` / `enrollment_key.create` events attributed to the service principal (`actorType: 'api_key'`, key id), never a human.

**UI** (`apps/web/.../PartnerServicePrincipalsPage.tsx`) — write scopes selectable but excluded from the default selection.

**Docs** — `reference/api.mdx` gains a Partner API section (all routes + scopes); `reference/api-keys.mdx` gains the partner-principal scope table with the opt-in warning.

## Tests

- `writeSurface.test.ts` — allowlist + canary (first run failed pre-allowlist, see above).
- `provisioning.test.ts` — 22 cases: scope/auth (401/403), body-`partnerId` ignored, org-access 403s, `maxOrganizations` boundary (at cap 409 / below cap 201 / concurrent-overshoot rollback 409), TTL-cap 400, XOR 400, `.strict()` unknown-key 400, site-mismatch 400, raw-key-once + hash-stored + `createdBy` null, DTO revision shape, partner-context `userId: null`, audit attribution for all three routes.
- `partnerApiAuth.test.ts` — 5 new cases for the write branch: no held context during `next()`, write bucket key/limit, write 429 + Retry-After, machine-use audit on write success and failure. All 34 pre-existing cases unchanged and green.
- Affected suites green locally (single worker): 19 files, 490 tests (`partnerApiAuth`, all `routes/partnerApi/*`, `partnerServicePrincipals`, `enrollmentKeys*`, `enrollmentKeySecurity`). `tsc --noEmit` clean for `apps/api`.

## Not in this PR

- `apps/docs/.../migration/toolkit.mdx` rewrite (plan Task 7): that file lives on the unmerged `docs/rmm-migration-guides` branch (PR #3250), not on `main` — its auth section and Recipe 1/2 should be updated there (or in a follow-up) once both PRs land.
- End-to-end verification against a live stack (plan Verification §2): needs a running deployment; unit + contract coverage above stands in.
- Bulk import on the Partner API (explicitly out of scope, #3242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
