### PR TITLE
docs(specs,plans): RMM migration epic design specs and implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-08-08-fleet-migration-posture-report.md
+++ b/docs/superpowers/plans/2026-08-08-fleet-migration-posture-report.md
@@ -1,0 +1,131 @@
+# Fleet Migration / Decommission Report Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the competing-management-tool detection Breeze already collects as a fleet-level report, so an MSP can answer "which endpoints still run the RMM we're migrating off, and is it safe to uninstall there?" in one request instead of one per device.
+
+**Architecture:** Two aggregate SQL queries over the existing `devices.management_posture` jsonb — detections, and coverage denominators — behind two read endpoints and a fleet page. **No new table**; the jsonb stays the single source of truth.
+
+**Tech Stack:** PostgreSQL (jsonb aggregation), Drizzle/raw SQL, Hono routes, React (web), Vitest.
+
+**Spec:** `docs/superpowers/specs/onboarding-signup/2026-08-08-fleet-migration-posture-report-design.md`
+**Issue:** #3244 · **Epic:** #3249
+
+> **✅ SHIPPED** — merged to main as `bf505f83a` (PR #3264): the two-query service, both routes, the mixed-fixture unit + integration suites, the fleet page (`/devices/posture` + sidebar entry) with per-org migration progress, posture-age counters, the orphaned remote-access callout, and CSV export; docs updated (Recipe 5 + `features/management-posture.mdx`). **Deferred:** Task 5's performance measurement against a 10k-device seeded fleet (numbers still to be recorded on #3244 from an environment with a DB) and Task 4's site filter (the spec's endpoint contract has no site param; site-restricted users are already auto-narrowed via `allowedSiteIds` — can follow as a small increment).
+
+---
+
+## Critical implementation note — read before starting
+
+**Do not compute detections and coverage in one `GROUP BY`.** A single grouped query with a `LEFT JOIN LATERAL` collapses three populations that mean different things — never-scanned, scanned-with-category-absent, scanned-with-empty-array — into one identical `(product NULL, status NULL)` row. A never-scanned device then reads as verified-clean, which is precisely the failure this feature exists to prevent. This was a real defect in an earlier draft of the spec.
+
+Two queries. Detections use `CROSS JOIN LATERAL`; coverage is computed separately without any lateral join.
+
+No agent changes. Detection already ships in `agent/internal/mgmtdetect/`.
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|---|---|
+| `apps/api/src/services/managementPostureReport.ts` | The two queries + assembly |
+| `apps/api/src/services/managementPostureReport.test.ts` | Unit tests |
+| `apps/web/src/components/devices/FleetPostureReport.tsx` | Fleet view |
+| `apps/web/src/pages/devices/posture.astro` | Page mount |
+
+### Modified files
+| File | Change |
+|---|---|
+| `apps/api/src/routes/devices/core.ts` | Two summary/drill-down routes |
+| `apps/docs/src/content/docs/migration/toolkit.mdx` | Replace Recipe 5's N+1 loop |
+| `apps/docs/src/content/docs/features/management-posture.mdx` | Document the fleet view |
+
+---
+
+## Task 1: Aggregation service — the two queries
+
+- [x] `getPostureDetections({ orgId?, category = 'rmm', stalenessDays = 7 })`:
+  ```sql
+  SELECT d.org_id,
+         e.value->>'name'   AS product,
+         e.value->>'status' AS status,
+         count(DISTINCT d.id) AS device_count,
+         count(DISTINCT d.id) FILTER (
+           WHERE (d.management_posture->>'collectedAt')::timestamptz > now() - $3::interval
+         ) AS fresh_device_count
+  FROM devices d
+  CROSS JOIN LATERAL jsonb_array_elements(
+    COALESCE(d.management_posture->'categories'->$1, '[]'::jsonb)
+  ) e
+  WHERE d.deleted_at IS NULL AND ($2::uuid IS NULL OR d.org_id = $2)
+  GROUP BY 1, 2, 3;
+  ```
+  `count(DISTINCT d.id)`, never `count(*)` — a posture array listing the same product twice would otherwise double-count the device.
+- [x] `getPostureCoverage({ orgId?, category, stalenessDays })` — per org, **no lateral join**:
+  ```sql
+  SELECT d.org_id,
+         count(*) AS total_devices,
+         count(*) FILTER (WHERE d.management_posture IS NULL) AS never_scanned,
+         count(*) FILTER (WHERE d.management_posture IS NOT NULL
+           AND (d.management_posture->>'collectedAt')::timestamptz <= now() - $3::interval) AS stale,
+         count(*) FILTER (WHERE d.management_posture IS NOT NULL
+           AND COALESCE(jsonb_array_length(
+                 COALESCE(d.management_posture->'categories'->$1, '[]'::jsonb)), 0) = 0) AS scanned_none_detected
+  FROM devices d
+  WHERE d.deleted_at IS NULL AND ($2::uuid IS NULL OR d.org_id = $2)
+  GROUP BY 1;
+  ```
+- [x] Assemble both into one response; never emit a detection count without its coverage denominators.
+- [x] Validate `category` against the ingest enum (`mdm`, `rmm`, `remoteAccess`, `endpointSecurity`, `policyEngine`, `backup`, `identityMfa`, `siem`, `dnsFiltering`, `zeroTrustVpn`, `patchManagement`) — never interpolate it into SQL unvalidated.
+
+## Task 2: Routes
+
+- [x] `GET /devices/management-posture/summary` — query `orgId?`, `category?` (default `rmm`), `stalenessDays?` (default 7). Returns per-org, per-product, per-status counts plus `total`, `neverScanned`, `stale`, `scannedNoneDetected`.
+- [x] `GET /devices/management-posture/devices` — query `product`, `category?`, `orgId?`, `status?`, standard pagination. The drill-down behind a count.
+- [x] Both read-only, `authMiddleware`, org-scoped by the caller's access context — a partner-scoped caller gets their estate, an org-scoped caller one org.
+- [x] Mount **before** any `/devices/:id` route so `management-posture` is not captured as an id parameter.
+
+## Task 3: Tests — the mixed fixture is the test
+
+- [x] Build one fixture org containing all four populations simultaneously: never scanned (`management_posture` NULL), scanned-stale, scanned-clean, scanned-with-a-detection. A single-population fixture passes against the collapsed one-query form this design had to correct, so the mixed fixture is what actually guards it.
+- [x] Assert the buckets partition the fleet: `never_scanned + stale + fresh-clean + fresh-detected == total_devices`, nothing double-counted or dropped.
+- [x] A device with an empty category array, and one with the category key absent, both land in `scanned_none_detected` — **not** `never_scanned`.
+- [x] A posture array listing the same product twice counts the device once.
+- [x] `active` vs `installed` reported separately; `unknown` neither dropped nor merged.
+- [x] Staleness boundary: `freshDeviceCount <= deviceCount` always.
+- [x] Org scoping: an org-scoped token sees only its own devices; a partner roll-up never includes an org that partner does not own.
+- [x] No new table — assert the contract suites are **unchanged** (no RLS/cascade/export registration needed; `devices` is already registered and `management_posture` is already `excludedOpen`).
+
+## Task 4: Web fleet view
+
+- [ ] `FleetPostureReport.tsx`: devices grouped by detected product, filterable by organization and site, with the device list behind each count.
+- [x] Per-org migration progress: enrolled, still carrying a competing RMM, carrying **both** (the healthy mid-migration state), and Breeze-only.
+- [x] **Show posture age next to every count.** Never render a bare zero — zero-with-12-stale is a different fact from zero-with-everything-fresh, and only one means "safe to uninstall". This is a requirement, not polish.
+- [x] **Call out orphaned remote-access agents as a security finding.** ScreenConnect survives a ConnectWise Automate uninstall; Splashtop survives Atera and Syncro uninstalls; `mgmtdetect` fingerprints these independently under `CategoryRemoteAccess`. Present them as an exposure, not as migration housekeeping.
+- [x] CSV export, so the report can go to the customer as evidence of a completed migration.
+
+## Task 5: Performance check
+
+- [ ] Measure both queries against a seeded fleet of 10,000+ devices with realistic posture payloads. Record the numbers on #3244.
+- [ ] Per-org filtering should ride the `org_id` index; the partner-wide roll-up is a full scan with jsonb detoast — acceptable for an on-demand report.
+- [ ] If it is too slow, prefer a **materialised view refreshed from the jsonb** over a hand-maintained denormalized table. A hand-maintained copy can drift out of sync and report a competing agent as removed while it is still installed — the failure that strands endpoints. Do not introduce one.
+
+## Task 6: Docs
+
+- [x] Replace Recipe 5 in `apps/docs/src/content/docs/migration/toolkit.mdx` — the per-device loop becomes a single call to the summary endpoint.
+- [x] Update the "Known Rough Edges" table: remove the Management Posture row.
+- [x] Add the fleet view to `apps/docs/src/content/docs/features/management-posture.mdx`.
+
+---
+
+## Verification
+
+- [x] `pnpm --filter @breeze/api test -- managementPosture` green.
+- [ ] End-to-end against a seeded fleet: counts reconcile with the raw jsonb, and a device with NULL posture appears as unknown in the UI rather than clean.
+
+## Out of scope
+
+- **Automated uninstall of a competing RMM.** Detection informs; the operator drives removal through their own tooling. No competitor-uninstall logic exists in the repo today and adding it is a separate product and security decision.
+- Filter-DSL integration, posture history/trend (the jsonb is overwritten each scan), and non-RMM category reports — all deferred in the spec.

--- a/docs/superpowers/plans/2026-08-08-org-external-links-and-bulk-import.md
+++ b/docs/superpowers/plans/2026-08-08-org-external-links-and-bulk-import.md
@@ -1,0 +1,172 @@
+# Organization External Links + Bulk Org/Site Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an MSP migrating off another RMM rebuild their whole tenancy tree in one pass, and make re-import idempotent for every import source — CSV today, PSA and accounting next.
+
+**Architecture:** New `organization_external_links` table (one-to-many, replacing the single-valued `organizations.accounting_*` pair), plus a shared `orgImport` preview→commit service with a source seam. CSV is parsed client-side; the API takes JSON only.
+
+**Tech Stack:** PostgreSQL + hand-written SQL migration, Drizzle ORM, Hono routes, Zod, React (web), Vitest.
+
+**Spec:** `docs/superpowers/specs/onboarding-signup/2026-08-08-bulk-org-site-import-design.md`
+**Issue:** #3242 · **Epic:** #3249 · **Unblocks:** #3246
+
+> **✅ SHIPPED** — merged to main as `1d1880817` (PR #3273): migration + RLS + cascade/export registrations, `orgImport` preview→commit service with the source seam, `POST /orgs/import{,/preview}`, QuickBooks dual-write + union read (Task 4), and the `BulkOrgImport` web UI. **Phase 2 (by design, not this PR):** the PSA-backed source (#3246) plugs into the `OrgImportSource` seam, and moving QuickBooks fully onto the seam / dropping the legacy `accounting_*` columns is a later contract-phase PR. A live end-to-end CSV round-trip wasn't separately run; the service/route/integration suites cover idempotent re-import.
+
+---
+
+## Critical implementation note — read before starting
+
+The QuickBooks importer currently writes `accountingProvider` / `accountingExternalId`
+(`services/accounting/quickbooksCustomerImport.ts:213-214`) and nothing else.
+
+**If the reader moves to the link table while that writer does not, every org QuickBooks creates after this PR gets no link row, the next QuickBooks import fails to match it, and it creates a duplicate organization** — the exact failure this table exists to prevent. Task 4 is therefore not optional and cannot be deferred.
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|---|---|
+| `apps/api/migrations/2026-08-08-organization-external-links.sql` | Table, indexes, RLS policies, backfill |
+| `apps/api/src/db/schema/orgExternalLinks.ts` | Drizzle schema |
+| `apps/api/src/services/orgImport/index.ts` | `previewOrgImport` / `commitOrgImport` |
+| `apps/api/src/services/orgImport/types.ts` | `ImportRow`, `AnnotatedRow`, `OrgImportSource` |
+| `apps/api/src/services/orgImport/slug.ts` | `slugify` / `generateUniqueSlug` moved here |
+| `apps/web/src/components/organizations/BulkOrgImport.tsx` | Upload → map → preview → commit |
+| `apps/api/src/__tests__/integration/orgExternalLinksRls.integration.test.ts` | Forge tests |
+
+### Modified files
+| File | Change |
+|---|---|
+| `apps/api/src/routes/orgs.ts` | `POST /orgs/import/preview`, `POST /orgs/import` |
+| `apps/api/src/services/tenantCascade.ts` | Register in `CORE_ORG_CASCADE_DELETE_ORDER` |
+| `apps/api/src/services/tenantExportPolicyRegistry.ts` | Register in `CORE_TENANT_EXPORT_POLICY` |
+| `apps/api/src/services/accounting/quickbooksCustomerImport.ts` | **Dual-write + union read** |
+| `apps/api/src/db/schema/index.ts` | Export the new schema |
+
+---
+
+## Task 1: Migration + schema
+
+- [x] Write `apps/api/migrations/2026-08-08-organization-external-links.sql`, idempotent, no inner `BEGIN`/`COMMIT`:
+  ```sql
+  CREATE TABLE IF NOT EXISTS organization_external_links (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id       uuid NOT NULL,
+    partner_id   uuid NOT NULL,
+    system       text NOT NULL,
+    external_id  text NOT NULL,
+    label        text,
+    created_by   uuid,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    updated_at   timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT organization_external_links_org_partner_fk
+      FOREIGN KEY (org_id, partner_id)
+      REFERENCES organizations (id, partner_id) ON DELETE CASCADE
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS organization_external_links_uniq
+    ON organization_external_links (partner_id, system, external_id);
+  CREATE INDEX IF NOT EXISTS organization_external_links_org_idx
+    ON organization_external_links (org_id);
+  ```
+  Prior art for the composite FK: `deployment_invites_org_partner_fk` in `apps/api/migrations/2026-05-03-tenant-rls-force-and-invites.sql:10-21`.
+- [x] Enable **and force** RLS; add the org-axis policy (`breeze_has_org_access(org_id)` plus the system branch), guarded by a `pg_policies` existence check.
+- [x] Add **no** `json`/`jsonb`/`bytea` column — any open container is classified `excludedOpen` and would be dropped from tenant export.
+- [x] Backfill from the shipped columns, reporting the row count:
+  ```sql
+  DO $$
+  DECLARE n integer;
+  BEGIN
+    INSERT INTO organization_external_links (org_id, partner_id, system, external_id)
+    SELECT id, partner_id, accounting_provider, accounting_external_id
+    FROM organizations
+    WHERE accounting_external_id IS NOT NULL AND accounting_provider IS NOT NULL
+    ON CONFLICT DO NOTHING;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RAISE WARNING 'backfilled % accounting external links', n;
+  END $$;
+  ```
+- [x] Add the Drizzle schema and export it.
+- [x] `pnpm db:migrate && pnpm db:check-drift` — no drift.
+
+## Task 2: Register the contracts (do not defer to a follow-up PR)
+
+- [x] `CORE_ORG_CASCADE_DELETE_ORDER` in `services/tenantCascade.ts` — insert `'organization_external_links'` alphabetically (before `'organizations'`, which stays last). Note the list is a lint, not the delete order: `tenantCascade.ts:14-17` computes children-first topologically from `pg_constraint` at delete time.
+- [x] `CORE_TENANT_EXPORT_POLICY` in `services/tenantExportPolicyRegistry.ts`:
+  ```ts
+  "organization_external_links": tablePolicy("org_id", {
+    included: ["id","org_id","partner_id","system","external_id","label","created_by","created_at","updated_at"],
+    reviewedIncluded: [], excludedSensitive: [], excludedOpen: []
+  }),
+  ```
+- [x] No device-cascade entry (no `device_id`), no `AUDIT_ADMIN_REQUIRED_TABLES` entry (rows are mutable), no `PARTNER_TENANT_TABLES` / `DUAL_AXIS_TENANT_TABLES` entry (RLS auto-discovery keys on the `org_id` column; the extra `partner_id` column does not reclassify it).
+- [x] Partner erasure needs no registration — `cascadeDeletePartner` (`tenantCascade.ts:744, 847-862`) sweeps `information_schema` for `partner_id` columns dynamically.
+
+## Task 3: RLS + contract verification
+
+- [x] Run the contract suites against a live DB: `rls-coverage`, `tenantCascade`, `tenant-export-policy`, `tenantExportErasureRoundtrip`. None of these fail in the `Test API` unit job.
+- [x] As `breeze_app` (`docker exec -it breeze-postgres psql -U breeze_app -d breeze`), forge a cross-tenant insert — must fail with `new row violates row-level security policy`.
+- [x] Add `orgExternalLinksRls.integration.test.ts`: cross-partner forge → 42501; composite-FK violation (link row whose `partner_id` disagrees with the org's) → rejected; org isolation on read.
+- [x] Dispatch CI on the branch: `gh workflow run CI --ref <branch>`.
+
+## Task 4: QuickBooks dual-write + union read — REQUIRED IN THIS PR
+
+- [x] In `quickbooksCustomerImport.ts`, on org create, insert the link row **in addition to** the existing `accountingProvider` / `accountingExternalId` columns, inside the same `runOutsideDbContext(() => withSystemDbAccessContext(...))` block.
+- [x] Change `loadExistingOrgs` to build `byExternalId` from the **union** of the link table and the legacy columns, so an org linked by either mechanism matches.
+- [x] Sweep for other writers before calling this done:
+  `grep -rn "accountingExternalId\|accounting_external_id" apps/api/src`
+- [x] Test: an org created by the QuickBooks importer after this change has both a link row and the legacy columns, and a second import of the same customer is a **skip**, not a duplicate.
+
+## Task 5: Import service (`services/orgImport/`)
+
+- [x] Move `slugify` / `generateUniqueSlug` out of `quickbooksCustomerImport.ts` into `orgImport/slug.ts`; re-export from the old location for back-compat.
+- [x] Define the source seam:
+  ```ts
+  interface OrgImportSource { system: string; list(ctx): Promise<ImportRow[]>; }
+  ```
+- [x] `previewOrgImport(rows, partnerId)` annotating each row `create` | `link-match` | `name-match` | `matched-soft-deleted` | `conflict`, with resolved slug and existing `organizationId`.
+- [x] `commitOrgImport(rows, partnerId, actor, mode)`:
+  - resolve by `(partner_id, system, external_id)`, else normalised name within partner;
+  - `mode: 'skip'` leaves matches untouched; `'update'` patches only fields present in the row;
+  - create org + sites + link row inside `runOutsideDbContext(() => withSystemDbAccessContext(...))`, following `orgs.ts:1037`;
+  - `writeRouteAudit` for every org, site, and link created;
+  - per-row failure recorded, remaining rows proceed.
+- [x] **Soft-delete handling:** a match against an org with `deletedAt IS NOT NULL` annotates `matched-soft-deleted` and commit **refuses** it unless the caller explicitly opts to reactivate. Never silently attach sites to a dead tenant, never silently mint a duplicate beside it.
+- [x] Multiple rows sharing an `organization` value create one org with many sites.
+
+## Task 6: Routes
+
+- [x] `POST /orgs/import/preview` and `POST /orgs/import` in `routes/orgs.ts`, gated `requireScope('partner','system')` + `requireOrgWrite` + `requireMfa()` — matching the write routes they compose.
+- [x] Zod: max 1000 rows; `timezone` validated with the existing `isValidIanaTimezone`; `mode: 'skip' | 'update'`.
+- [x] Commit **re-derives** each row's annotation and rejects any row whose annotation changed since preview (preview is advisory; the unique index is authority).
+- [x] Return `{ imported, updated, skipped, errors }` with per-row detail.
+
+## Task 7: Web UI
+
+- [x] `BulkOrgImport.tsx` on the Organizations settings area, modelled on `components/integrations/QuickbooksCustomerImport.tsx`.
+- [x] Client-side CSV parse (new dependency in `apps/web` only — the API never sees CSV), column mapping, preview table with per-row status badges.
+- [x] `name-match` rows unchecked by default; `matched-soft-deleted` rows call out the reactivate choice explicitly.
+- [x] Commit through `runAction` so partial success surfaces ("54 imported, 4 skipped, 2 failed").
+
+## Task 8: Tests
+
+- [x] Service: externalId dedupe; name-match flagged not auto-applied; slug collision suffixing; multi-site grouping; `skip` vs `update`; partial success; soft-deleted match refused.
+- [x] Routes: scope + MFA gating; row cap; annotation-changed-since-preview rejection.
+- [x] Backfill: existing QuickBooks-linked orgs appear exactly once; re-running the migration is a no-op.
+- [x] Web: preview rendering, name-match default-unchecked, `runAction` partial-success.
+
+---
+
+## Verification
+
+- [x] `pnpm --filter @breeze/api test` and `pnpm --filter @breeze/web test` green.
+- [x] All four contract suites green against a live DB (Task 3).
+- [ ] End-to-end: export a `organization,site` CSV per the migration docs, import it, confirm the tree matches and a second import of the same file is a full skip.
+
+## Out of scope
+
+- Device import, contacts, custom-field backfill (#3257, #3258).
+- PSA source (#3246) — this plan only lands the seam it plugs into.
+- Dropping the `accounting_*` columns — separate contract-phase PR once every writer is migrated.

--- a/docs/superpowers/plans/2026-08-08-partner-api-provisioning-writes.md
+++ b/docs/superpowers/plans/2026-08-08-partner-api-provisioning-writes.md
@@ -1,0 +1,97 @@
+# Partner API Provisioning Writes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a partner service principal create organizations, sites, and enrollment keys unattended — so migration scripts, scheduled syncs, and partner-built integrations can provision tenancy without a human completing an MFA challenge.
+
+**Architecture:** Add write scopes and three `POST` routes to the existing Partner API, which already authenticates a machine principal. Routes delegate to the same service functions the human `/orgs/*` routes call. A new allowlist test keeps the surface's read-only-by-default character auditable.
+
+**Tech Stack:** Hono routes, Zod, Drizzle ORM, Vitest.
+
+**Spec decision:** #3243 comment thread (design settled there; no separate spec file)
+**Issue:** #3243 · **Epic:** #3249
+
+> **✅ SHIPPED** — merged to main as `870c69f61` (PR #3274): write scopes (opt-in, default delegation stays read-only), the `writeSurface.test.ts` allowlist (written first, canary-verified), the three provisioning routes with race-free `maxOrganizations` quota (409), tighter per-principal write rate bucket (`min(key limit, 120)`/hour), service-principal audit attribution, plus `reference/api.mdx` + `reference/api-keys.mdx` and the principals settings UI. **Deferred:** the migration-toolkit rewrite (Task 7's toolkit boxes) landed separately with the docs branch (PR #3250), and live end-to-end verification of Recipes 1–2 against a running deployment was not run — the unit/contract suites stand in.
+
+---
+
+## Context — what already exists
+
+`apps/api/src/middleware/partnerApiAuth.ts` is a complete machine-principal implementation. It is **not** a user JWT and never goes near MFA:
+
+- High-entropy service-principal token authentication.
+- Resolves a full partner DB access context — `scope: 'partner'`, `accessibleOrgIds` (all active orgs under the partner), `accessiblePartnerIds`, `currentPartnerId`, `userId: null` (`partnerApiAuth.ts:284-297`).
+- Scope enforcement via `requirePartnerApiScope` (`partnerApiAuth.ts:322`).
+- Machine-use audit/telemetry via `recordMachineUse`.
+
+What is missing is only a **write vocabulary** and a **write surface**. Existing scopes are `organizations:read`, `devices:read`, `alerts:read`.
+
+**Do not** solve this by branching `hasSatisfiedMfa` on principal type. That is the vacuous-MFA-grant shape warned about at `middleware/cfAccessLogin.ts:204`, and it would weaken a check used across the entire human surface to fix one path. Rejected in the #3243 thread.
+
+---
+
+## Task 1: Write scopes
+
+- [x] Extend `PartnerServicePrincipalScope` with `organizations:write`, `sites:write`, `enrollment-keys:write`.
+- [x] Update `validatePartnerServicePrincipalScopes` so the new scopes validate and are clamped by the existing delegation ceiling.
+- [x] Confirm an existing read-only principal is unaffected — new scopes are opt-in at principal creation, never granted implicitly.
+- [x] Surface the new scopes in the partner service-principal management UI and in `apps/docs/src/content/docs/reference/api-keys.mdx`.
+
+## Task 2: Non-GET route allowlist test — write this FIRST
+
+This is the condition attached to the decision to give a read-only surface a write side. Writing it before the routes means the first run proves it catches them.
+
+- [x] Add `apps/api/src/routes/partnerApi/writeSurface.test.ts` that enumerates every route registered under `partnerApiRoutes` and asserts the set of non-GET routes equals an explicit allowlist constant.
+- [x] Seed the allowlist **empty**, run the test, confirm it passes on today's tree.
+- [x] Add the three routes from Task 3 to the allowlist as they land — each one a deliberate, reviewable line.
+- [x] Comment the constant with why it exists: the surface was read-only by construction until #3243, and the invariant now lives here instead of in a `grep` for `.get(`.
+
+## Task 3: Provisioning routes
+
+All three delegate to the **same service functions** the `/orgs/*` and `/enrollment-keys` routes call. Do not duplicate validation, slug generation, or tenancy checks.
+
+- [x] `POST /partner-api/organizations` — `requirePartnerApiScope('organizations:write')`. Body mirrors `createOrganizationSchema` (`name`, `slug`, `type?`, `status?`), with `partnerId` taken from the principal and **never** from the body.
+- [x] `POST /partner-api/sites` — `requirePartnerApiScope('sites:write')`. Body mirrors `createSiteSchema`. Reject an `orgId` outside the principal's `accessibleOrgIds` with 403.
+- [x] `POST /partner-api/enrollment-keys` — `requirePartnerApiScope('enrollment-keys:write')`. Body mirrors `createEnrollmentKeySchema` (`.strict()`, `ttlMinutes` XOR `expiresAt`, `maxUsage` 1–100000). The raw key is returned once in the 201 body, as on the existing route.
+- [x] Keep responses in the Partner API's DTO conventions so `dtoSafety` / `exportSafety` apply to created-object responses exactly as they do to reads.
+
+## Task 4: Create/update only — no delete
+
+- [x] Do **not** add `DELETE` routes for organizations, sites, or enrollment keys in this plan. Creation and deletion have very different blast radius; org deletion stays human + MFA.
+- [x] If an update route is added later, it belongs in the Task 2 allowlist too.
+
+## Task 5: Limits, quota, and audit
+
+- [x] Enforce `partner.maxOrganizations` on `POST /partner-api/organizations` — an unattended credential that can create unlimited organizations is a billing and abuse surface. Return a clear 409/422 when the cap is reached, not a generic 500.
+- [x] Apply per-principal rate limiting to the write routes, distinct from (and tighter than) the read limits.
+- [x] Confirm `recordMachineUse` records the write attempts including failures, and that `writeRouteAudit` attributes the change to the **service principal**, not to the human who minted it.
+
+## Task 6: Tests
+
+- [x] Each route: correct scope → success; missing scope → 403; no principal → 401.
+- [x] `partnerId` supplied in the body is ignored; the principal's partner wins.
+- [x] `orgId` outside `accessibleOrgIds` → 403 on the sites and enrollment-key routes.
+- [x] `maxOrganizations` boundary: at the cap → refused with the specific error; below → succeeds.
+- [x] Enrollment key: `ttlMinutes` and `expiresAt` together → 400; unknown key (`maxUses`) → 400 via `.strict()`.
+- [x] Audit rows attribute to the service principal with `userId: null`.
+- [x] The Task 2 allowlist test fails if a fourth non-GET route is added without updating the constant — assert this by temporarily adding one in the test.
+
+## Task 7: Docs
+
+- [x] Update `apps/docs/src/content/docs/migration/toolkit.mdx` — the "Authentication for Migration Scripts" section currently states that tenancy writes require an MFA-satisfied user JWT and that scripts must refresh mid-run. Once this ships, the partner service principal is the correct answer for scripted migration; rewrite that section and the Recipe 1/2 examples to use it.
+- [x] Update the "Known Rough Edges" table in the same file: remove the M2M row.
+- [x] Update `apps/docs/src/content/docs/reference/api.mdx` Partner API section with the new write endpoints.
+
+---
+
+## Verification
+
+- [x] `pnpm --filter @breeze/api test -- partnerApi` green.
+- [ ] End-to-end: mint a partner service principal with the three write scopes, run the migration toolkit's Recipe 1 and Recipe 2 against it with **no** user JWT anywhere, and confirm a tenancy tree plus per-site enrollment keys are created.
+- [x] Confirm a principal **without** the write scopes still gets 403 on all three.
+
+## Out of scope
+
+- Deletes (Task 4).
+- Bulk import on the Partner API — `POST /orgs/import` (#3242) stays on the main API for now; exposing it here is a follow-up once both have shipped and the row-cap/rate-limit interaction is understood.
+- Any change to `hasSatisfiedMfa` or the human MFA path.

--- a/docs/superpowers/plans/2026-08-08-script-bundle-import-export.md
+++ b/docs/superpowers/plans/2026-08-08-script-bundle-import-export.md
@@ -1,0 +1,133 @@
+# Script Library Import / Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move a script library into Breeze from another RMM — or between instances — carrying the metadata that makes it a library rather than a pile of files.
+
+**Architecture:** A versioned JSON bundle format with export, preview, and import endpoints under `/scripts/bundle/*`. Loose `.ps1`/`.sh` files are converted to a bundle client-side, so the API keeps a single JSON intake path. No new tables.
+
+**Tech Stack:** Hono routes, Zod, Drizzle ORM, React (web), Vitest.
+
+**Spec:** `docs/superpowers/specs/onboarding-signup/2026-08-08-script-bundle-import-export-design.md`
+**Issue:** #3245 · **Epic:** #3249
+
+> **✅ SHIPPED** — merged to main as `739e8d84b` (PR #3276), unblocked by #3262. All eight tasks landed: bundle schema v1 with per-entry validation, export/preview/import routes (20MB body carve-out), the `scriptWrite.ts` chokepoint shared with `POST /scripts`, unconditional `isSystem`/tenancy stripping, the partner-availability gate, the `ScriptBundleImport` web UI (loose-file folder → bundle conversion client-side), and docs (`features/scripts.mdx`; the toolkit Recipe 6 rewrite landed with the docs branch, PR #3250). **Deferred:** the review's below-the-line cleanups (shared Dialog, downloadBlob/runAction unification for the export GET, shared enums from `@breeze/shared`, audit batching, a preview→import expected-state contract — recorded as follow-ups in the fix commit) and a live-DB end-to-end export→import round-trip; the unit/route suites' round-trip coverage stands in.
+
+---
+
+## BLOCKED ON #3262 — do not start Task 5 until it merges
+
+`POST /scripts` gates partner-wide creation on `auth.scope === 'partner'` alone, with no `canManagePartnerWidePolicies` check (#3262). Importing a bundle with `availability: 'partner'` over that path turns one upload into a SYSTEM-level script fanned out to every organization under the partner.
+
+Tasks 1–4 and 6–7 can proceed. Task 5 (the `'partner'` option) lands only after #3262.
+
+**A bundle is untrusted input regardless of who uploads it, and its contents run as SYSTEM on customer endpoints.** Task 4 is the heart of this plan.
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|---|---|
+| `apps/api/src/services/scriptBundle/index.ts` | `previewBundle` / `importBundle` / `exportBundle` |
+| `apps/api/src/services/scriptBundle/schema.ts` | Zod bundle schema, v1 |
+| `apps/api/src/services/scriptBundle/index.test.ts` | Unit tests |
+| `apps/web/src/components/scripts/ScriptBundleImport.tsx` | Upload → preview → commit |
+
+### Modified files
+| File | Change |
+|---|---|
+| `apps/api/src/routes/scripts.ts` | Three `/scripts/bundle/*` routes |
+| `apps/docs/src/content/docs/features/scripts.mdx` | Document bundles |
+| `apps/docs/src/content/docs/migration/toolkit.mdx` | Replace Recipe 6 |
+
+---
+
+## Task 1: Bundle schema (v1)
+
+- [x] Define the Zod schema in `scriptBundle/schema.ts`:
+  ```jsonc
+  { "bundleVersion": 1, "exportedAt": "...", "scripts": [ {
+      "name", "description?", "category?", "tags?": [],
+      "osTypes": ["windows"], "language": "powershell", "content",
+      "parameters?", "timeoutSeconds?", "runAs?", "exitCodeSeverityMapping?"
+  } ] }
+  ```
+- [x] Categories and tags travel **by name**, never by id — ids are meaningless across instances and would leak the source tenant's identifiers.
+- [x] Reject an unknown `bundleVersion` with a clear error. Do not best-effort parse.
+- [x] The schema must **not** contain `id`, `orgId`, `partnerId`, `createdBy`, or `isSystem`. Use `.strip()`/`.strict()` semantics so their presence in an uploaded file cannot carry through.
+
+## Task 2: Export
+
+- [x] `GET /scripts/bundle/export?ids=…`, scoped to what the caller can already read.
+- [x] System-library scripts are exportable (they are not secret) but export with `isSystem` **absent**, so a round-trip cannot launder them back in as system scripts.
+- [x] Emit no tenancy identifiers.
+
+## Task 3: Preview + import service
+
+- [x] `previewBundle` annotates each entry `new` / `name-conflict` with the resolved target and any validation error. No writes.
+- [x] `importBundle(bundle, { mode, availability }, actor)` where `mode: 'skip' | 'rename' | 'new-version'`:
+  1. validate `bundleVersion`, then each entry against the **existing** `createScriptSchema` rules (`osTypes` non-empty, `language` enum, `timeoutSeconds` 1–3600, `runAs` enum) — reuse, don't restate;
+  2. resolve categories and tags by name in the target scope, creating what's missing;
+  3. apply `mode` against an existing same-name script in scope;
+  4. write through the **same service path** `POST /scripts` uses — not raw inserts — so the `isSystem` clamp, audit, and validation cannot diverge;
+  5. per-entry failure recorded, remaining entries proceed.
+- [x] Response: `{ imported, skipped, renamed, versioned, errors }`.
+
+## Task 4: Security — the part to review hardest
+
+- [x] **Strip `isSystem` unconditionally**, at every caller scope — stricter than `POST /scripts`, which permits it for `auth.scope === 'system'` (`scripts.ts:525`). Never read the field rather than clamping it. This is the #633 hole in a new costume.
+- [x] **Ignore all tenancy identifiers** in the bundle. Ownership comes from the caller's auth context only.
+- [x] **Bound `parameters` at intake.** `createScriptSchema` types it `z.any()` (`scripts.ts:169`) with no shape, depth, or size limit — the 64KB cap at `scripts.ts:203-206` is *execute-time only*. Import must impose its own size and depth cap; do not inherit `z.any()`.
+- [x] **Reject an all-null `exitCodeSeverityMapping`.** A schema-valid mapping sending every exit code to `null` ships a SYSTEM-level script pre-configured never to raise an alert, neutering the abuse detection this design leans on as its backstop. Reject, or strip the mapping and let the importer re-add it deliberately.
+- [x] **No automations, schedules, or triggers in a v1 bundle.** A bundle that could carry an automation binding would make import arbitrary *scheduled* remote code execution across a fleet in one click.
+- [x] **Import never executes anything.** No "run on import" convenience, ever.
+- [x] **Audit every imported script individually**, tagged with the bundle's identity, so a later abuse finding traces back to the import that introduced it.
+- [x] Enforce max scripts per bundle and max bytes per `content`, server-side.
+- [x] Confirm imported rows are ordinary `scripts` rows so the existing `abuseSignals/sweep` picks them up automatically — that is detection after the fact, which is why the audit trail above matters.
+
+## Task 5: `availability` — BLOCKED ON #3262
+
+- [x] **Default `availability` to `'org'`.** Do not default to `'partner'`.
+- [x] Gate `availability: 'partner'` on `canManagePartnerWidePolicies(auth)` at the import route, returning `PARTNER_WIDE_WRITE_DENIED_MESSAGE`.
+- [x] Land this task only after #3262 merges; verify the underlying `POST /scripts` path is gated before exposing the option here.
+
+## Task 6: Web UI
+
+- [x] `ScriptBundleImport.tsx` on the script library page: export multi-select → download `.json`.
+- [x] Import accepts either a `.json` bundle **or a folder of loose `.ps1` / `.sh` / `.py` / `.bat` files**, which the browser converts into a bundle — inferring `language` and `osTypes` from the extension and `name` from the filename — before anything is sent. Same split as the CSV handling in #3242: the client does format work, the server takes one JSON contract.
+- [x] Preview table with per-entry status and a mode selector; commit through `runAction` so partial results surface ("34 imported, 2 renamed, 1 failed").
+- [x] State plainly on the import screen that scripts run as SYSTEM and a bundle should only be imported from a trusted source.
+
+## Task 7: Tests
+
+- [x] **`isSystem` is ignored from a bundle — including when the caller is system scope.** Assert the stored row is `isSystem: false`. This is the priority regression test.
+- [x] Tenancy fields in a bundle pointing at another tenant are ignored; the script lands in the caller's scope.
+- [x] Unknown `bundleVersion` rejected, not best-effort parsed.
+- [x] Each `mode`: `skip` leaves the original untouched; `rename` suffixes; `new-version` appends to `scriptVersions` rather than replacing history.
+- [x] Oversized / deeply-nested `parameters` rejected **at intake**, not at execute time.
+- [x] All-null `exitCodeSeverityMapping` rejected or stripped.
+- [x] `availability: 'partner'` denied for a caller failing `canManagePartnerWidePolicies`; default is `'org'`.
+- [x] Category/tag resolution by name: existing reused, missing created, hierarchy intact.
+- [x] Round-trip: export → import into an empty tenant → exported bundle is equivalent.
+- [x] Validation parity: an entry that would fail `POST /scripts` fails import too.
+- [x] No new tables — assert the contract suites are unchanged.
+
+## Task 8: Docs
+
+- [x] Replace Recipe 6 in `apps/docs/src/content/docs/migration/toolkit.mdx` with the bundle flow; note the loose-file folder path in the UI.
+- [x] Revisit Recipe 6's `availability: "partner"` recommendation in light of #3262 (also tracked in that plan's Task 6).
+- [x] Remove the script-import row from the "Known Rough Edges" table.
+- [x] Document the bundle format in `apps/docs/src/content/docs/features/scripts.mdx`, including that it is unsigned and trust comes from the importer.
+
+---
+
+## Verification
+
+- [x] `pnpm --filter @breeze/api test -- scriptBundle` and `pnpm --filter @breeze/web test` green.
+- [ ] End-to-end: export a library, import into a fresh tenant, confirm parameters/categories/tags/severity mappings survive and no script arrives as `isSystem`.
+
+## Out of scope
+
+- Signed bundles / trusted publishers, a marketplace, bundling automations or monitors, full `scriptVersions` history export, server-side zip intake. All deferred in the spec.

--- a/docs/superpowers/plans/2026-08-08-scripts-partner-wide-gate.md
+++ b/docs/superpowers/plans/2026-08-08-scripts-partner-wide-gate.md
@@ -1,0 +1,105 @@
+# Scripts: Partner-Wide Creation Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the authz gap where any partner-scoped user — including one with `partner_users.org_access = 'selected'` — can create, edit, or delete a **partner-wide script** that executes as SYSTEM on every endpoint of every organization under the partner.
+
+**Architecture:** Add the existing `canManagePartnerWidePolicies(auth)` capability check to the partner-wide branches of `POST/PUT/DELETE /scripts`, matching the pattern already used by nine other routes. No schema change, no migration.
+
+**Tech Stack:** Hono routes, Drizzle ORM, Vitest.
+
+**Issue:** #3262 · **Epic:** #3249 · **Blocks:** #3245 (script bundle import)
+
+> **✅ SHIPPED** — merged via PR #3263 (commit `42a1b9b84`) plus follow-up PR #3272 (commit `b01681907`, same-partner ownership enforcement on partner-wide writes). Beyond plan scope, the PR also hid the partner-wide toggle in the web UI (`ScriptForm.tsx`) for users lacking the capability. **Deferred:** Task 3's audit of pre-existing partner-wide scripts (a query against the deployment's data, left to the operator per the #3262 thread) and Task 5's sibling-table sweep. Task 6's docs note landed with the migration-docs update on PR #3250.
+
+---
+
+## Context
+
+`apps/api/src/routes/scripts.ts:502-506` gates partner-wide creation on scope alone:
+
+```ts
+} else if (auth.scope === 'partner') {
+  if (data.availability === 'partner') {
+    orgId = null;
+    partnerId = auth.partnerId ?? null;
+    if (!partnerId) return c.json({ error: 'Partner context required' }, 403);
+  }
+```
+
+Verified absent from the file: `canManagePartnerWidePolicies` (0 hits), `partnerOrgAccess` (0 hits).
+
+`services/partnerWideAccess.ts` is explicit that scope is not a sufficient proxy:
+
+> *Deliberately NOT derivable from accessibleOrgIds: a 'selected' user whose selection happens to cover every current org still must not administer partner-wide state.*
+
+Reference implementation to copy: `apps/api/src/routes/peripheralControl.ts:508`.
+
+**Severity:** partner-confined (RLS still prevents cross-partner reach), so this is privilege escalation *within* a partner — to SYSTEM-level code execution across orgs the user was never granted.
+
+---
+
+## Task 1: Gate partner-wide script creation
+
+- [x] Import `canManagePartnerWidePolicies` and `PARTNER_WIDE_WRITE_DENIED_MESSAGE` from `../services/partnerWideAccess` in `apps/api/src/routes/scripts.ts`.
+- [x] In the `auth.scope === 'partner'` / `data.availability === 'partner'` branch (~line 503), return `403` with `PARTNER_WIDE_WRITE_DENIED_MESSAGE` when `!canManagePartnerWidePolicies(auth)`.
+- [x] Place the check **before** `orgId = null` is assigned, so a denied request cannot fall through with partner ownership half-applied.
+- [x] Confirm system scope still passes (the helper returns true for `auth.scope === 'system'`).
+
+## Task 2: Gate update and delete of partner-owned scripts
+
+A user who cannot create partner-wide state must not be able to edit or remove it.
+
+- [x] In `PUT /scripts/:id`, after loading the existing row, deny with 403 when `existing.orgId === null && existing.partnerId !== null && !canManagePartnerWidePolicies(auth)`.
+- [x] Same in `DELETE /scripts/:id` (soft delete — sets `deletedAt`).
+- [x] Leave the existing `isSystem && auth.scope !== 'system'` checks (`scripts.ts:592`, `:760`) intact; these are additive, not replacements.
+- [x] Verify the ownership test is `orgId === null`, not `partnerId !== null` alone — an org-owned script also carries `partnerId` as an RLS denormalization (`scripts.ts:500-501`), so keying on `partnerId` would wrongly block ordinary org script edits.
+
+## Task 3: Audit existing partner-wide scripts
+
+- [ ] Query partner-owned scripts and their creators:
+  ```sql
+  SELECT s.id, s.name, s.partner_id, s.created_by, s.created_at, pu.org_access
+  FROM scripts s
+  LEFT JOIN partner_users pu
+    ON pu.user_id = s.created_by AND pu.partner_id = s.partner_id
+  WHERE s.org_id IS NULL AND s.partner_id IS NOT NULL AND s.deleted_at IS NULL
+  ORDER BY s.created_at DESC;
+  ```
+- [ ] Flag any row whose creator has `org_access <> 'all'` — those were created through the gap.
+- [ ] Report findings on #3262. Do **not** auto-delete: a legitimate script may have been created by a since-downgraded user. Removal is an operator decision.
+
+## Task 4: Tests
+
+- [x] `scripts.test.ts`: partner scope + `partnerOrgAccess: 'selected'` + `availability: 'partner'` → **403**, and no row is written.
+- [x] Partner scope + `partnerOrgAccess: 'all'` + `availability: 'partner'` → 201, `orgId` null, `partnerId` set.
+- [x] System scope + `availability: 'partner'` → 201 (unchanged).
+- [x] Partner scope + `partnerOrgAccess: 'selected'` + `availability: 'org'` → 201 (org scripts are unaffected — regression guard).
+- [x] Update and delete of a partner-owned script by a `'selected'` user → 403.
+- [x] Update and delete of an **org-owned** script by a `'selected'` user with access to that org → succeeds (guards the `orgId === null` keying from Task 2).
+
+## Task 5: Sweep for the same gap on sibling dual-ownership tables
+
+The nine routes already using the helper are `accessReviews`, `partnerLoginBranding`, `huntress`, `peripheralControl`, `sensitiveData`, `networkKnownGuests`, `pax8`, `roles`, `sso`. Scripts was missed; others may have been too.
+
+- [ ] Enumerate tables with both a nullable `org_id` and a `partner_id` in `apps/api/src/db/schema/` (the dual-ownership shape from CLAUDE.md's Partner-Wide First section).
+- [ ] For each, grep its route file for `canManagePartnerWidePolicies`. Record any table whose partner-wide write path lacks it.
+- [ ] File a follow-up issue per gap found rather than expanding this PR — each needs its own audit query and tests.
+- [ ] If the sweep finds nothing else, say so explicitly on #3262 so the negative result is recorded.
+
+## Task 6: Revisit the migration-docs guidance
+
+- [x] `apps/docs/src/content/docs/migration/toolkit.mdx` Recipe 6 recommends `availability: "partner"` for bulk script import. Once this gate lands the recommendation is safe, but add a one-line note that partner-wide creation requires full partner org access, so a `'selected'` technician following the recipe gets a comprehensible 403 rather than a mystery.
+
+---
+
+## Verification
+
+- [x] `pnpm --filter @breeze/api test -- scripts` green.
+- [ ] Manually: create a partner user with `org_access = 'selected'`, confirm the partner-wide toggle is refused with a clear message.
+- [x] No migration in this plan — confirm `pnpm db:check-drift` is unchanged.
+
+## Out of scope
+
+- UI changes to hide the partner-wide option from users who lack the capability. Server-side denial is the security boundary; hiding the control is a follow-up polish item.
+- Retroactive removal of scripts created through the gap (see Task 3).

--- a/docs/superpowers/plans/notes/2026-08-08-rmm-migration-next-phase-prompt.md
+++ b/docs/superpowers/plans/notes/2026-08-08-rmm-migration-next-phase-prompt.md
@@ -1,0 +1,44 @@
+# Session prompt — RMM migration epic, Phase 2/3
+
+Paste the block below into a fresh Claude Code session in `/home/todd/breeze`.
+
+---
+
+## Prompt
+
+> Continue the RMM migration epic (#3249). Phase 1 shipped: `organization_external_links` + bulk org/site import, partner-API provisioning writes (#3243), the fleet posture report (#3244), script bundles (#3245), and the partner-wide scripts gate (#3262) are all on `main`. Docs are in PR #3250, specs and plans in PR #3279.
+>
+> **Verify before trusting any of the above** — check `main` directly rather than the issue states, which have lagged reality on this epic. `#3242` is still open despite `apps/api/src/services/orgImport/` and `apps/web/src/components/organizations/BulkOrgImport.tsx` both existing on `main`; work out what remains and either close it or scope the remainder.
+>
+> Then take Phase 2 in this order:
+>
+> 1. **#3246 — PSA `getCompanies()` → org import.** Every PSA adapter implements it (`apps/api/src/services/psa/types.ts:62`) and nothing calls it. The `OrgImportSource` seam it plugs into now exists at `apps/api/src/services/orgImport/types.ts`. Also decide what to do about `POST /psa/connections/:id/sync` (`routes/psa.ts`), which writes `lastSyncStatus: 'queued'` with no worker consuming it, and about `halo`/`syncro`/`kaseya` being in the `psa_provider` enum and the connection wizard with no adapter file.
+> 2. **Migrate the QuickBooks importer onto the shared seam.** `quickbooksCustomerImport.ts` should keep its provider client but delegate preview/commit to `services/orgImport/`. Confirm it currently dual-writes both `organization_external_links` and the legacy `accounting_provider`/`accounting_external_id` columns — if it does not, that is a live duplicate-organization bug and takes priority over everything else in this list.
+> 3. **Drop `accounting_provider` / `accounting_external_id`** (still present on `main`: 2 refs in `db/schema/orgs.ts`) once every reader and writer is on the link table. Contract phase. **This also requires updating the `organizations` entry in `CORE_TENANT_EXPORT_POLICY`** — removing a column from a registered table breaks `tenant-export-policy.integration.test.ts` exactly as adding one does. Sweep first: `grep -rn "accountingExternalId\|accounting_external_id" apps/api/src`.
+> 4. **#3247** — one-paragraph docs fix, still open. `reference/api.mdx` documents `X-API-Key` as general-purpose auth with a `/devices` example that returns 401; it is accepted only on the MCP server, dev-push, and device custom-field-value surfaces.
+> 5. **#3248** — GPO / Intune / JAMF deployment guide. Note `agent/scripts/install/install-windows.ps1` takes no enrollment parameters, so document the MSI-properties path rather than a PS1 one-liner (or fix the script and say so).
+>
+> Phase 3 (#3257 custom-field/UDF backfill, #3258 first-class contacts) needs design work before code — #3258 in particular may resolve as "the PSA owns contacts, link read-through" rather than a local table. Do not start either without settling that.
+>
+> Working rules for this epic, learned the hard way:
+> - **Trace the end-to-end data flow, not just the contract checklists.** An adversarial review of the three Phase-1 specs found all three were correct on RLS shapes, cascade lists, and export policy — and all three had a defect in the primary flow that the contract tests would have passed straight through.
+> - **Second-order writers are where the bugs are.** The dual-write gap above is the canonical example: moving a reader to a new table without its writer silently mints duplicate tenants.
+> - **Run an adversarial reviewer on any consequential design before implementing** — spawn a Fable subagent prompted to refute, since `codex` is not authenticated here. It earned its keep last time: it caught a live authz gap (#3262) plus three spec defects.
+
+---
+
+## State at handoff (2026-08-08)
+
+**Shipped to `main`:** `2026-08-08-organization-external-links.sql`, `db/schema/orgExternalLinks.ts`, `services/orgImport/*`, `web/components/organizations/BulkOrgImport.tsx`, `routes/scriptBundle.ts` + `services/scriptBundle/*`, `services/managementPostureReport.ts`, `routes/partnerApi/writeSurface.test.ts`, and the `canManagePartnerWidePolicies` gate in `routes/scripts.ts` (4 refs).
+
+**Open PRs:** #3250 (migration guides, docs-only, 11 files) · #3279 (specs + plans, 8 files). Both rebased onto current `main` as single commits.
+
+**Open issues:** #3242 (bulk import — likely partly shipped, needs triage), #3246, #3247, #3248, #3257, #3258.
+
+**Closed:** #3243, #3244, #3245, #3262.
+
+### Gotchas that cost time this session
+
+- The working branch was cut from `docs/proxy-linking-specs`, not `main`, and drifted **114 commits** behind while the implementations landed. Always `git fetch origin main` and check `git rev-list --count HEAD..origin/main` before reasoning about what exists.
+- `git add docs/superpowers/plans/open/` swept in an unrelated sibling-branch plan. Stage explicit paths on this repo — several parallel doc branches touch the same directories.
+- Issue state lagged the code by a lot on this epic. `git ls-tree -r --name-only origin/main | grep <thing>` is the reliable check.

--- a/docs/superpowers/specs/onboarding-signup/2026-08-08-bulk-org-site-import-design.md
+++ b/docs/superpowers/specs/onboarding-signup/2026-08-08-bulk-org-site-import-design.md
@@ -1,0 +1,363 @@
+# Bulk Organization + Site Import — Design
+
+**Date:** 2026-08-08
+**Status:** Ready for review — all decisions settled (see §0)
+**Issue:** #3242 (epic #3249)
+**Related:** #3246 (PSA `getCompanies()` import) consumes the seam defined here
+
+## Summary
+
+Add bulk import of organizations and sites from a client-parsed CSV/JSON payload,
+so an MSP migrating off Datto RMM / NinjaOne / ConnectWise Automate / Kaseya VSA /
+N-central / Atera / Syncro can rebuild their tenancy tree in one pass instead of
+one form at a time.
+
+Introduces `organization_external_links` — a one-to-many external-system linkage
+that makes re-import idempotent for **any** source, replacing the single-valued
+`organizations.accounting_provider` / `accounting_external_id` pair that shipped
+with the QuickBooks importer.
+
+The import service is built as a shared **org import pipeline** (preview → commit)
+with a source seam, so #3246 becomes a second source rather than a second importer.
+
+## Context
+
+- **The only working org importer** is QuickBooks:
+  `apps/api/src/services/accounting/quickbooksCustomerImport.ts`, design at
+  `docs/superpowers/specs/billing/2026-06-29-quickbooks-customer-import-design.md`.
+  It already solves preview/annotate, slug collision, partial success, and the
+  tenant-create RLS escape. This design generalises it rather than competing with it.
+- **What it shipped** (`db/schema/orgs.ts:124-137`): `accounting_provider` +
+  `accounting_external_id` on `organizations`, partial-unique on
+  `(partner_id, accounting_provider, accounting_external_id)`. **Single-valued.**
+- **Tenant-create RLS escape:** org/site inserts run inside
+  `runOutsideDbContext(() => withSystemDbAccessContext(...))` (`orgs.ts:1037`,
+  and `quickbooksCustomerImport.ts:192`).
+- **`organizations.slug` is not DB-unique.** Only `(id, partner_id)` is unique —
+  which is what makes the composite FK in §1 possible.
+- **No CSV parser exists anywhere in the repo.** Every `parseCsv*` hit is an env-var
+  splitter. CSV is currently export-only.
+- **Write routes** `POST /orgs/organizations` (`orgs.ts:1267`) and `POST /orgs/sites`
+  (`orgs.ts:1832`) are `requireScope('partner'|'system')` + `requireMfa()`-gated.
+  Import inherits both. Unattended use is blocked until #3243 lands; that is
+  deliberate and out of scope here.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| v1 scope | **Orgs + sites only** | Matches what every vendor export produces. Contacts are JSONB blobs, not a table; device custom fields need devices to exist first. |
+| UI placement | **Settings utility under Organizations** | Reusable for every future onboarding batch, not just first run. Mirrors where `QuickbooksCustomerImport.tsx` lives. |
+| CSV parsing | **Client-side; server takes JSON** | Keeps the API a clean JSON contract the migration toolkit scripts can call, keeps column-mapping UX in the UI, and avoids adding a parser + multipart to the API surface. |
+| External linkage | **New `organization_external_links` table** | See §0 — the one open call. |
+| Dedupe key | **`externalId` preferred; normalised-name fallback, flagged in preview** | Vendor exports all carry a stable UID; name matching is only safe with a human in the loop. |
+| Re-import behaviour | **Skip by default; explicit per-row `update` opt-in** | Silent overwrite of edited customer records is worse than a no-op. |
+| Preview statefulness | **Stateless** | The unique index is the real idempotency guard, so preview can be advisory. No import-batch table in v1. |
+
+## 0. Decision — linkage model
+
+**Settled: a one-to-many link table (option B).** Decided without an independent
+advisor leg (Codex auth unavailable and the review was skipped by choice). There was
+no live disagreement to resolve, so what is missing is a second check rather than a
+tiebreak — but this is the highest-consequence call in the document, so it is the one
+to re-examine first if the design ever feels wrong.
+
+- **A — generalise the shipped columns** (`accounting_*` → `source_*`). Keeps a
+  one-external-link-per-org ceiling.
+- **B — `organization_external_links`.** One-to-many. Costs a new table plus its
+  RLS/cascade/export contracts.
+
+**Why B.**
+
+*A is not actually the cheap option.* Renaming shipped columns still requires a
+migration, a repo-wide sweep of readers, and an update to the `organizations` entry
+in `CORE_TENANT_EXPORT_POLICY` — because removing or renaming a column on a
+registered table breaks the export-policy test exactly as adding one does. A pays
+most of B's cost and still buys a ceiling.
+
+*The ceiling breaks realistically, not theoretically.* A migrating MSP legitimately
+has one organization sourced from a *Datto CSV*, linked to *ConnectWise* for
+ticketing, and linked to *QuickBooks* for billing, simultaneously. Under A the second
+importer overwrites the first's link and the failure is **silent**: the first
+importer's idempotency stops working and re-import begins creating duplicate
+organizations. Silent duplicate-tenant creation is close to the worst available
+failure mode in a multi-tenant system, and it would surface as a support ticket long
+after the cause.
+
+*This is the documented trap.* "Works now, retrofit later" on org-shaped data is what
+CLAUDE.md calls out via #1724 and #2126–#2129. Choosing A here would be choosing it
+with the counter-evidence already in hand.
+
+**Reversal cost:** B is harder to undo once rows exist (a new table with four contract
+registrations). That asymmetry is accepted deliberately — the failure mode A risks is
+silent and data-corrupting, while B's cost is visible, upfront, and bounded.
+
+## 1. Data Model
+
+New table. Migration `apps/api/migrations/2026-08-08-organization-external-links.sql`
+— hand-written, idempotent, no inner `BEGIN`/`COMMIT`, policies in the same file.
+
+```sql
+CREATE TABLE IF NOT EXISTS organization_external_links (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id       uuid NOT NULL,
+  partner_id   uuid NOT NULL,
+  system       text NOT NULL,   -- 'quickbooks' | 'connectwise' | 'datto_rmm' | 'csv' | ...
+  external_id  text NOT NULL,
+  label        text,
+  created_by   uuid,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT organization_external_links_org_partner_fk
+    FOREIGN KEY (org_id, partner_id)
+    REFERENCES organizations (id, partner_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS organization_external_links_uniq
+  ON organization_external_links (partner_id, system, external_id);
+CREATE INDEX IF NOT EXISTS organization_external_links_org_idx
+  ON organization_external_links (org_id);
+```
+
+Two deliberate choices:
+
+- **`partner_id` is denormalised and held honest by a composite FK.** Uniqueness must
+  be scoped per partner (two MSPs can both import a Datto site UID `12345`), which
+  needs `partner_id` on the row. The composite FK to `organizations (id, partner_id)`
+  makes a mismatched pair unrepresentable.
+
+  This is not novel: the identical FK already ships as
+  `deployment_invites_org_partner_fk` in
+  `apps/api/migrations/2026-05-03-tenant-rls-force-and-invites.sql:10-21`, against the
+  non-partial unique index `organizations_id_partner_id_unique` created in the same
+  migration (lines 7-8, mirrored at `db/schema/orgs.ts:134`). `organizations.partner_id`
+  is `NOT NULL` (`orgs.ts:104`) and both link columns are NOT NULL, so MATCH SIMPLE
+  never softens the check and drift is genuinely unrepresentable.
+- **No `json`/`jsonb`/`bytea` column.** Any open container must be classified
+  `excludedOpen` and would therefore be dropped from tenant export. `label` is plain
+  text so the whole row survives an export. Do not add a `metadata` jsonb later
+  without accepting that cost.
+
+### Contract registration — all four, same PR
+
+| Contract | Action | Enforced by |
+|---|---|---|
+| RLS | Shape **1** (direct `org_id`) → policy `breeze_has_org_access(org_id)`, enabled + forced, in the same migration. Auto-discovery keys purely on the presence of an `org_id` column, so the `partner_id` column does not reclassify it and **no allowlist entry is needed**. | `rls-coverage.integration.test.ts` |
+| Org cascade | Add `'organization_external_links'` to `CORE_ORG_CASCADE_DELETE_ORDER` in `services/tenantCascade.ts`, alphabetically (before `'organizations'`, which stays last). | `tenantCascade.integration.test.ts` |
+| Export policy | Add to `CORE_TENANT_EXPORT_POLICY` in `services/tenantExportPolicyRegistry.ts` as `tablePolicy("org_id", { included: ["id","org_id","partner_id","system","external_id","label","created_by","created_at","updated_at"], reviewedIncluded: [], excludedSensitive: [], excludedOpen: [] })`. No column name matches `SUSPICIOUS_NAME_PARTS`. | `tenant-export-policy.integration.test.ts`, `tenantExportErasureRoundtrip.integration.test.ts` |
+| Device cascade | **N/A** — no `device_id` column. | — |
+| Append-only | **N/A** — rows are mutable and deletable. | — |
+
+Two clarifications, because it is easy to reason about these wrongly:
+
+- **Alphabetical order is a lint, not the delete order.** `tenantCascade.ts:14-17` is
+  explicit that the hand-maintained list is *not* trusted as a topological order —
+  at delete time it queries `pg_constraint` and topologically sorts children-first.
+  So list position does not "satisfy" the FK direction; the computed order does, and
+  the FK here additionally carries `ON DELETE CASCADE`. Register alphabetically
+  because the test asserts it, not because ordering is load-bearing.
+- **Partner erasure needs no registration.** `cascadeDeletePartner`
+  (`tenantCascade.ts:744, 847-862`) sweeps `information_schema` dynamically for every
+  table with a `partner_id` column, so the new table is picked up automatically.
+
+Both the cascade and export-policy suites need a live database and therefore
+**cannot fail in the `Test API` unit job**. Run them locally before opening the PR,
+and dispatch CI on the branch (`gh workflow run CI --ref <branch>`).
+
+**Policy-shape note.** The two existing tables with this composite FK — `users` and
+`deployment_invites` — both carry *dual-axis* policies, and `deployment_invites` is
+registered in `DUAL_AXIS_TENANT_TABLES`. This table deliberately does not: all import
+writes run in system context, and partner-scoped readers already satisfy
+`breeze_has_org_access` for their accessible orgs, so an org-axis policy is sufficient
+and strictly tighter. Called out because it diverges from every prior instance of the
+pattern — if a future reader needs partner-wide visibility of links for orgs the caller
+cannot otherwise reach, revisit this rather than widening the policy ad hoc.
+
+### Backfill and deprecation
+
+Same migration, backfilling the shipped QuickBooks links with a reported row count:
+
+```sql
+DO $$
+DECLARE n integer;
+BEGIN
+  INSERT INTO organization_external_links (org_id, partner_id, system, external_id)
+  SELECT id, partner_id, accounting_provider, accounting_external_id
+  FROM organizations
+  WHERE accounting_external_id IS NOT NULL AND accounting_provider IS NOT NULL
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RAISE WARNING 'backfilled % accounting external links', n;
+END $$;
+```
+
+`accounting_provider` / `accounting_external_id` stay in place and keep working.
+
+### The QuickBooks importer must DUAL-WRITE in this PR
+
+**This is the single most important implementation note in the document.** An earlier
+draft said only that `quickbooksCustomerImport.ts` switches its `loadExistingOrgs`
+*read* to the link table, deferring the writer to a later phase. That is a bug, and
+precisely the one §0 exists to prevent.
+
+`quickbooksCustomerImport.ts:213-214` writes `accountingProvider` /
+`accountingExternalId` on org insert and nothing else. If the reader moves to the link
+table while the writer does not, then:
+
+1. The migration backfills links for orgs that exist **today**.
+2. Every org QuickBooks creates **after** this PR gets `accounting_*` set and **no
+   link row**.
+3. The next QuickBooks import reads the link table, does not find that org, and
+   **creates a duplicate organization**.
+
+Silent duplicate-tenant creation — exactly the failure mode §0 rejects option A for.
+
+Therefore, in this PR:
+
+- The QuickBooks importer **writes both** the link row and the `accounting_*` columns
+  on every create, for as long as the columns exist.
+- Its `loadExistingOrgs` reads the **union** of the link table and the legacy columns,
+  so an org linked by either mechanism matches.
+- Only once the importer is migrated onto the shared seam (Phase 2) and every writer
+  is confirmed does the drop become safe.
+
+Sweep for other writers before calling this done — `grep -rn "accountingExternalId\|accounting_external_id" apps/api/src`. This is CLAUDE.md's Partner-Wide playbook step 7 ("sweep ALL call sites repo-wide") applied to a different contract; the mechanical registry checks do not catch a missing second writer.
+
+The columns and their partial unique index are dropped in a **later contract-phase
+migration** (pattern: #3151 `patch_policies.sources`). That drop must also update the
+`organizations` entry in `CORE_TENANT_EXPORT_POLICY`, since removing a column from a
+registered table breaks the export-policy test just as adding one does.
+
+### Soft-deleted organizations hold the unique slot
+
+`organizations` has a soft delete (`deletedAt`, `orgs.ts:132`) and product-level org
+deletion is usually soft, not a hard cascade. A soft-deleted org's link rows survive
+and keep `(partner_id, system, external_id)` occupied, so re-importing an offboarded
+customer either silently matches the dead org or fails the unique insert.
+
+Resolution: preview annotates such rows as a distinct **`matched-soft-deleted`** state
+rather than `link-match`, and commit refuses them unless the caller explicitly chooses
+to reactivate the existing org. Never silently attach new sites to a soft-deleted
+tenant, and never silently mint a duplicate alongside it.
+
+## 2. Routes
+
+Both under `orgRoutes`, matching the gating on the write routes they compose —
+`requireScope('partner','system')` + `requireOrgWrite` + `requireMfa()`.
+
+- `POST /orgs/import/preview` — body `{ rows: ImportRow[] }` (max 1000).
+  Returns each row annotated `create | link-match | name-match | conflict`, plus the
+  resolved slug and the existing `organizationId` where matched. No writes.
+- `POST /orgs/import` — body `{ rows: ImportRow[], mode?: 'skip' | 'update' }`.
+  Returns `{ imported, updated, skipped, errors }` with per-row detail.
+
+```ts
+interface ImportRow {
+  organization: string;
+  site?: string;              // repeat `organization` across rows for multiple sites
+  externalId?: string;        // the source vendor's stable UID
+  externalSystem?: string;    // 'datto_rmm' | 'ninjaone' | ... ; defaults to 'csv'
+  timezone?: string;          // IANA, validated by isValidIanaTimezone
+  address?: unknown;
+  contact?: { name?: string; email?: string; phone?: string };
+}
+```
+
+`name-match` rows are **never committed as matches without an explicit client
+acknowledgement** — commit re-derives the annotation and rejects a row whose
+annotation changed since preview. Preview is advisory; the unique index is authority.
+
+Failures are per-row: one bad timezone on row 43 must not roll back rows 1–42.
+Responses are consumed from web through `runAction`.
+
+## 3. Import Service — the shared seam
+
+New `apps/api/src/services/orgImport/`, with the source seam that #3246 plugs into:
+
+```ts
+interface OrgImportSource {
+  system: string;                              // value written to external_links.system
+  list(ctx: OrgImportContext): Promise<ImportRow[]>;
+}
+
+previewOrgImport(rows, partnerId): Promise<AnnotatedRow[]>
+commitOrgImport(rows, partnerId, actor, mode): Promise<OrgImportSummary>
+```
+
+- **CSV source** is a pass-through of client-parsed rows.
+- **PSA source (#3246)** wraps the existing, currently-uncalled
+  `getCompanies()` (`services/psa/types.ts:62`).
+- **QuickBooks** migrates onto this seam once the link table lands.
+
+Commit, per row group (one organization + its sites):
+
+1. Resolve against `organization_external_links` by `(partner_id, system, external_id)`,
+   else by normalised name within the partner.
+2. Matched + `mode: 'skip'` → record skipped. Matched + `mode: 'update'` → patch only
+   the fields present in the row.
+3. Unmatched → create org (`slugify` + `generateUniqueSlug`, both already exported
+   from `quickbooksCustomerImport.ts` and moved into a shared module), create sites,
+   insert the link row — inside
+   `runOutsideDbContext(() => withSystemDbAccessContext(...))`.
+4. `writeRouteAudit` for every org-create, site-create and link-create.
+5. On per-row failure, record and continue.
+
+Creation must go through the same permission-checked path as the single-record routes,
+not raw DB writes.
+
+## 4. Web UI
+
+A "Bulk import" utility on the Organizations settings area, reusing the layout of
+`apps/web/src/components/integrations/QuickbooksCustomerImport.tsx`:
+
+drag-and-drop CSV → client-side parse → column mapping → preview table with
+per-row status badges (`New`, `Already linked`, `Name match — confirm`, `Conflict`)
+→ Import. Name-match rows are unchecked by default and must be ticked deliberately.
+Result surfaces through `runAction` including partial success ("54 imported, 4 skipped,
+2 failed").
+
+The client-side parser is the one new dependency, and it lands in `apps/web` only.
+
+## 5. Testing
+
+- **Service**: externalId dedupe; name-match flagged not auto-applied; slug collision
+  suffixing; multi-site grouping; `skip` vs `update`; partial success.
+- **Routes**: scope + MFA gating; row cap; annotation-changed-since-preview rejection.
+- **Migration/contracts**: cascade ordering (child before `organizations`), export-policy
+  classification, RLS coverage. Forge a cross-partner insert as `breeze_app` and confirm
+  `new row violates row-level security policy`.
+- **Composite FK**: attempt a link row whose `partner_id` disagrees with the org's —
+  must fail, proving the denormalised column cannot drift.
+- **Backfill**: existing QuickBooks-linked orgs appear exactly once in the link table
+  and re-running the migration is a no-op.
+- **Web**: preview rendering, name-match default-unchecked, `runAction` partial-success.
+
+## Deferred — Later Phases
+
+Nothing here is "won't do". Each item is sequenced behind something this phase
+establishes, and each is listed so it does not get lost between PRs.
+
+### Phase 2 — directly unblocked by this work
+
+| Item | Depends on | Tracked by |
+|---|---|---|
+| **PSA-sourced org import** — wire `getCompanies()` as an `OrgImportSource`. Should be small once the seam exists. | The §3 seam | #3246 |
+| **Migrate QuickBooks onto the shared seam** — `quickbooksCustomerImport.ts` keeps its provider client but delegates preview/commit to `orgImport/`. Removes the second, divergent importer. | Link table + seam | Follow-up to #3242 |
+| **Unattended import** — the routes are `requireMfa()`-gated by inheritance, so scripted/scheduled import is impossible until a non-human principal can satisfy them. | Auth decision | #3243 |
+| **Drop `accounting_provider` / `accounting_external_id`** and their partial unique index. Contract phase, after all readers move to the link table. Must also update the `organizations` entry in `CORE_TENANT_EXPORT_POLICY` — removing a column from a registered table breaks the export-policy test exactly as adding one does. | All readers migrated | Follow-up to #3242 |
+
+### Phase 3 — the rest of the migration data model
+
+| Item | Why it is not now | Tracked by |
+|---|---|---|
+| **Device custom-field backfill** — Datto `udf1`–`udf30`, Automate EDFs, Ninja/N-central custom properties, joined to devices on hostname. This is the largest remaining chunk of real customer data that a migration currently loses. | Devices must be enrolled first, so it is inherently a second pass — it cannot share this import's transaction or UI flow. | #3257 |
+| **Organization contacts as a first-class concept** — there is no `contacts` table; contacts are `billingContact` / `contact` JSONB blobs, and `aiToolsOrgs.ts:473` `add_contact` is unimplemented (returns guidance). Import cannot create what the model does not have. | Needs a data-model decision before any importer can target it. | #3258 |
+| **Scheduled/background re-sync** from PSA or accounting — keep org lists in step after the initial import, rather than a one-shot. Note `POST /psa/connections/:id/sync` is currently a stub with no worker. | Needs #3246 plus a worker, and an update-conflict policy stronger than v1's per-row opt-in. | #3246 |
+| **Import-batch persistence** — a stored batch with TTL, giving resumable large imports and per-batch rollback. | Only worth it above roughly a thousand rows; v1's stateless preview plus the DB unique index covers the real cases. | Not filed — revisit if row caps bite |
+
+### Explicitly not planned
+
+- **Device import by upload.** Devices arrive by enrollment. A CSV of hostnames
+  creates rows nothing will ever attach to.
+- **Two-way push** (Breeze org → PSA/accounting company). Separate seam, separate
+  consent model.

--- a/docs/superpowers/specs/onboarding-signup/2026-08-08-fleet-migration-posture-report-design.md
+++ b/docs/superpowers/specs/onboarding-signup/2026-08-08-fleet-migration-posture-report-design.md
@@ -1,0 +1,241 @@
+# Fleet Migration / Decommission Report — Design
+
+**Date:** 2026-08-08
+**Status:** Ready for review
+**Issue:** #3244 (epic #3249)
+
+Filed under `onboarding-signup` alongside the other migration-epic specs.
+
+## Summary
+
+Surface the competing-management-tool detection Breeze already collects as a
+**fleet-level report**, so an MSP can answer "which endpoints still run the RMM we
+are migrating off, and is it safe to uninstall it there?" without an N+1 loop over
+every device.
+
+This is a surfacing feature. The detection already ships and is correct; nothing in
+the agent changes.
+
+## Context
+
+- **Detection exists.** `agent/internal/mgmtdetect/signatures.go` fingerprints 11
+  competing RMMs by name under `CategoryRMM` — ConnectWise Automate, ScreenConnect,
+  Datto RMM, NinjaOne, Atera, SyncroMSP, N-able, Kaseya VSA, Pulseway, Level,
+  Tactical RMM — plus `CategoryRemoteAccess` (TeamViewer, AnyDesk, Splashtop,
+  LogMeIn, BeyondTrust, GoTo Resolve, RustDesk) and ~50 more across MDM, endpoint
+  security, backup, SIEM and VPN.
+- **Storage is a jsonb column**, not a table: `devices.management_posture`
+  (`db/schema/devices.ts:100`). Ingest schema at
+  `routes/agents/schemas.ts:393` (`managementPostureIngestSchema`):
+
+  ```
+  { collectedAt, scanDurationMs,
+    categories: { rmm: [{ name, version?, status, serviceName?, details? }], … },
+    identity: { joinType, azureAdJoined, domainJoined, … } }
+  ```
+
+  `status` is `'active' | 'installed' | 'unknown'`.
+- **Only a per-device read exists** — `GET /devices/:id/management-posture`
+  (`routes/devices/core.ts`), rendered by
+  `apps/web/src/components/devices/DeviceManagementTab.tsx`, one device at a time.
+- **The documented workaround** is `apps/docs/.../migration/toolkit.mdx` Recipe 5:
+  loop the per-device endpoint across the whole fleet and grep the JSON. That is the
+  answer we currently give for the highest-stakes step of a migration.
+
+## Why it matters
+
+Phases 4 and 6 of a migration (verify enrollment, decommission) are where migrations
+fail, and the failure is always the same: the incumbent agent is uninstalled on a
+machine where Breeze enrollment was never verified, leaving an unmanaged endpoint
+that needs a site visit.
+
+The incumbent's own console **cannot** answer this — it cannot see a machine whose
+agent is already broken, and those are exactly the machines that strand. Breeze can,
+because it reports from an agent that works. That asymmetry is the whole value of
+this feature.
+
+## Design Decisions
+
+| Decision | Choice |
+|---|---|
+| Aggregation | **On-the-fly over the jsonb. No denormalized detections table.** |
+| Freshness | **Posture age is a first-class output**, not a footnote. |
+| Never-scanned devices | **Counted explicitly**, never dropped by the join. |
+| Status handling | `active` and `installed` both count as present; reported separately. |
+| Scope | RMM + remote-access categories in v1; the schema is generic so others follow free. |
+| Automated uninstall | **Out of scope**, deliberately. |
+
+## 1. Aggregation — on the fly, no new table
+
+The obvious alternative is denormalising detections into
+`device_management_detections(device_id, org_id, category, product, status, …)` so
+they can be indexed and grouped. **Rejected.**
+
+The jsonb is the source of truth, rewritten by the agent on every posture scan. A
+denormalized copy must be kept in step on every ingest, and a missed sync reports a
+competing agent as *removed when it is still installed*. For a decommission report
+that is precisely the failure that strands endpoints — the report would say "safe to
+uninstall" about a machine where it is not. A drifting cache is worse than a slower
+query here.
+
+Note this is the opposite call from the link table in
+`2026-08-08-bulk-org-site-import-design.md` §0, for a principled reason: there, the
+single-valued model caused silent data *corruption*; here, denormalising would cause
+silent *staleness*. Both decisions avoid the silent-wrong outcome.
+
+Cost is acceptable at the stated target (10,000+ agents): the per-org report filters
+on the indexed `org_id`, and the partner-wide roll-up is an on-demand report, not a
+hot path. Revisit only on measurement — and if it comes to it, prefer a materialised
+view refreshed from the jsonb over a hand-maintained table, so drift stays impossible.
+
+**Two queries, not one.** The detection roll-up and the coverage denominators cannot
+come from the same `GROUP BY`, and conflating them was a real defect in an earlier
+draft of this spec — see the warning below.
+
+*(a) Detections — one row per product/status:*
+
+```sql
+SELECT d.org_id,
+       e.value->>'name'   AS product,
+       e.value->>'status' AS status,
+       count(DISTINCT d.id) AS device_count,
+       count(DISTINCT d.id) FILTER (
+         WHERE (d.management_posture->>'collectedAt')::timestamptz > now() - $3::interval
+       ) AS fresh_device_count
+FROM devices d
+CROSS JOIN LATERAL jsonb_array_elements(
+  COALESCE(d.management_posture->'categories'->$1, '[]'::jsonb)
+) e
+WHERE d.deleted_at IS NULL
+  AND ($2::uuid IS NULL OR d.org_id = $2)
+GROUP BY 1, 2, 3;
+```
+
+`count(DISTINCT d.id)`, not `count(*)`: a posture array that lists the same product
+twice (two services, two install paths) would otherwise double-count the device.
+
+*(b) Coverage — one row per org, computed without the lateral join:*
+
+```sql
+SELECT d.org_id,
+       count(*) AS total_devices,
+       count(*) FILTER (WHERE d.management_posture IS NULL)        AS never_scanned,
+       count(*) FILTER (WHERE d.management_posture IS NOT NULL
+         AND (d.management_posture->>'collectedAt')::timestamptz <= now() - $3::interval
+       )                                                           AS stale,
+       count(*) FILTER (WHERE d.management_posture IS NOT NULL
+         AND COALESCE(jsonb_array_length(
+               COALESCE(d.management_posture->'categories'->$1, '[]'::jsonb)), 0) = 0
+       )                                                           AS scanned_none_detected
+FROM devices d
+WHERE d.deleted_at IS NULL
+  AND ($2::uuid IS NULL OR d.org_id = $2)
+GROUP BY 1;
+```
+
+<!-- The two-query split is the correction; do not merge these back together. -->
+
+**Why not one query with a `LEFT JOIN LATERAL`.** It is tempting, and it is wrong.
+A `LEFT JOIN` does preserve devices with no detections — but it preserves all of them
+as the *same* `(product NULL, status NULL)` group, collapsing three distinct
+populations that mean completely different things:
+
+| Population | Meaning |
+|---|---|
+| `management_posture IS NULL` | **Never scanned** — status unknown |
+| Scanned, category key absent | Scanned, nothing of that category found |
+| Scanned, empty array | Scanned, nothing of that category found |
+
+Only the last two mean "clean". Merging them means a never-scanned device is
+output-indistinguishable from a verified-clean one — which is the precise failure this
+feature exists to prevent, arrived at from the other direction. The `CROSS JOIN` in (a)
+is correct *because* (b) supplies the denominators separately; the danger was never the
+join type, it was trying to get both answers from one grouping.
+
+Devices with `management_posture IS NULL` must never be summarised as anything other
+than **unknown**. On a migration they are the machines most likely to be a problem.
+
+## 2. Freshness is part of the answer
+
+`collectedAt` must be surfaced everywhere a count is. "0 devices still have Datto RMM"
+is only true if the scan is recent; on a device that last checked in 40 days ago it
+means nothing.
+
+- Every summary row carries `deviceCount` **and** `freshDeviceCount` within a caller-
+  supplied staleness window (default 7 days).
+- The response carries an explicit `staleDeviceCount` and `neverScannedCount` per org.
+- The UI must not render a bare zero. Zero-with-12-stale is a different fact from
+  zero-with-everything-fresh, and only one of them means "safe to uninstall".
+
+## 3. Endpoints
+
+Both on the existing devices surface, `authMiddleware` + org scoping as usual.
+
+- `GET /devices/management-posture/summary`
+  Query: `orgId?`, `category?` (default `rmm`), `stalenessDays?` (default 7).
+  Returns per-org, per-product, per-status counts plus the stale/never-scanned
+  totals. **This is the load-bearing endpoint** — Recipe 5 in the migration toolkit
+  collapses from one request per device to one request.
+- `GET /devices/management-posture/devices`
+  Query: `product`, `category?`, `orgId?`, `status?`, plus standard pagination.
+  The drill-down behind a count.
+
+Both are read-only and org-scoped by the caller's access context; a partner-scoped
+caller gets their whole estate, an org-scoped caller gets one org.
+
+## 4. Web UI
+
+A fleet page grouping devices by detected product, filterable by organization and
+site, with per-org migration progress: enrolled, still carrying a competing RMM,
+carrying **both** (the healthy mid-migration state), and Breeze-only.
+
+Two things the UI must do rather than may:
+
+- **Show posture age** next to every count, per §2.
+- **Call out orphaned remote-access agents as a security finding, not migration
+  housekeeping.** ScreenConnect survives a ConnectWise Automate uninstall; Splashtop
+  survives Atera and Syncro uninstalls. `mgmtdetect` fingerprints these independently
+  under `CategoryRemoteAccess`. An unattended remote-access agent on a customer
+  endpoint that nobody monitors is a standing exposure, and this report is the only
+  place it becomes visible.
+
+Export to CSV, so the report can go to the customer as evidence of a completed
+migration.
+
+## 5. Testing
+
+- **The never-scanned case is the priority test.** Build a fixture org containing all
+  four populations at once — never scanned, scanned-stale, scanned-clean, and
+  scanned-with-a-detection — and assert each lands in exactly one bucket with the
+  right count. A single-population fixture passes against the collapsed one-query
+  form that this spec had to correct, so the mixed fixture *is* the test.
+- Assert `never_scanned + stale + fresh-clean + fresh-detected == total_devices` for
+  the fixture: the buckets must partition the fleet with nothing double-counted or
+  dropped.
+- Devices with an empty category array, and with a category absent entirely, both land
+  in `scanned_none_detected` — **not** in `never_scanned`.
+- A posture array listing the same product twice counts the device once
+  (`count(DISTINCT d.id)`).
+- `active` vs `installed` counted separately; `unknown` neither dropped nor merged.
+- Staleness window boundaries; `freshDeviceCount <= deviceCount` always.
+- Org scoping: an org-scoped token sees only its own devices; cross-org counts never
+  leak into a partner-scoped roll-up for a partner that does not own the org.
+- No new table, so **no RLS/cascade/export registration** — `devices` is already
+  registered and `management_posture` is already classified `excludedOpen` (jsonb).
+  Adding no column keeps the export-policy suite untouched.
+
+## Deferred
+
+| Item | Why not now |
+|---|---|
+| Integration with the saved-filter / device-filter DSL, so "has Datto RMM installed" composes with other device filters | More elegant than dedicated endpoints but a bigger surface; the dedicated endpoints unblock the migration story first |
+| Materialised view if measurement shows the on-the-fly query is too slow | Premature without numbers; the shape is designed so this is a drop-in change |
+| Trend over time ("competing agents removed per week") | Needs posture history, which is not retained — the jsonb is overwritten each scan |
+| Other categories (backup, EDR, SIEM) as consolidation reports | The query is generic; this is UI surface, not new mechanism |
+
+## Explicitly not planned
+
+**Automated uninstall of a competing RMM.** Detection informs; the operator decides
+and drives removal through their own tooling. There is no competitor-uninstall logic
+anywhere in the repo today, and adding remote "uninstall the competitor" capability
+is a deliberate product and security decision, not a migration convenience.

--- a/docs/superpowers/specs/onboarding-signup/2026-08-08-script-bundle-import-export-design.md
+++ b/docs/superpowers/specs/onboarding-signup/2026-08-08-script-bundle-import-export-design.md
@@ -1,0 +1,236 @@
+# Script Library Import / Export — Design
+
+**Date:** 2026-08-08
+**Status:** Ready for review
+**Issue:** #3245 (epic #3249)
+
+Filed under `onboarding-signup` alongside the other migration-epic specs.
+
+## Summary
+
+Add a versioned JSON **script bundle** format with export and import, so a script
+library can move into Breeze from another RMM, between a staging and production
+instance, or between partners — carrying the metadata that makes a library a library
+rather than a pile of files.
+
+The bundle is a durable public contract and it carries executable content that runs
+as SYSTEM on customer endpoints, so §4 is the part of this design that matters most.
+
+## Context
+
+- **No import or export exists.** `routes/scripts.ts` and `routes/scriptLibrary.ts`
+  have no bundle, upload, or export endpoint. The one route named "import",
+  `POST /scripts/import/:id` (`scripts.ts:363`), clones a script that is *already*
+  in the system library — it ingests nothing. **New routes must not collide with it**;
+  this design uses `/scripts/bundle/*`.
+- **The data model is richer than the workaround preserves.** `db/schema/scripts.ts`:
+  `scripts` (with `orgId` **and** `partnerId` — already dual-ownership capable),
+  plus `scriptCategories` (hierarchical via `parentId`), `scriptTags`,
+  `scriptToTags`, `scriptVersions`, `scriptTemplates`.
+- **The documented workaround** — `apps/docs/.../migration/toolkit.mdx` Recipe 6 —
+  loops `POST /scripts` over a directory. It moves content and drops everything else:
+  parameters, category, tags, `exitCodeSeverityMapping`, version history.
+- **`isSystem` is correctly clamped today.** `scripts.ts:525`:
+  `const isSystem = auth.scope === 'system' ? (data.isSystem ?? false) : false;`
+  and the update schema rejects it outright (`scripts.ts:194`, closing the #633 hole).
+  Import must inherit this, not re-open it.
+- **Abuse signals are a background sweep, not a create-time gate.**
+  `services/abuseSignals/sweep` calls `loadScriptFindings` / `computeScriptSignals`
+  over stored scripts (`abuseSignals/index.ts:53-63`). Imported scripts are therefore
+  covered automatically **provided import writes ordinary `scripts` rows** — but note
+  this is detection after the fact, not prevention.
+
+## Design Decisions
+
+| Decision | Choice |
+|---|---|
+| Format | Versioned JSON bundle (`bundleVersion: 1`) |
+| Tenancy in the bundle | **None.** No `id`, `orgId`, `partnerId`, `createdBy` |
+| `isSystem` | **Never honoured from a bundle**, at any caller scope |
+| Loose `.ps1`/`.sh` files | Converted to a bundle **client-side**; the server only ever sees JSON |
+| Conflicts | Preview → commit, per-script `skip` / `rename` / `new-version` |
+| `availability` on import | Defaults to **`'org'`**; `'partner'` requires #3262 fixed |
+| Automations/schedules in a bundle | **Excluded** — see §4 |
+| Version history | Current version only; `scriptVersions` stays internal |
+
+## 1. Bundle Format
+
+```jsonc
+{
+  "bundleVersion": 1,
+  "exportedAt": "2026-08-08T00:00:00Z",
+  "scripts": [
+    {
+      "name": "Clear print spooler",
+      "description": "Stops spooler, clears queue, restarts.",
+      "category": "Maintenance",          // by name, resolved/created on import
+      "tags": ["printing", "windows"],    // by name
+      "osTypes": ["windows"],
+      "language": "powershell",
+      "content": "…",
+      "parameters": { /* as stored */ },
+      "timeoutSeconds": 300,
+      "runAs": "system",
+      "exitCodeSeverityMapping": { /* nullable */ }
+    }
+  ]
+}
+```
+
+Categories and tags travel **by name**, not id, and are resolved or created in the
+importing tenant. Ids would be meaningless across instances and would leak the source
+tenant's identifiers.
+
+`bundleVersion` is checked on import; an unknown version is rejected with a clear
+error rather than best-effort parsed. This is the field that lets the format change
+later without breaking bundles already in circulation.
+
+## 2. Routes
+
+- `GET /scripts/bundle/export?ids=…` — bundle for the selected scripts.
+  Org/partner-scoped to what the caller can already read. System-library scripts are
+  exportable (they are not secret) but export with `isSystem` **absent**, so a
+  round-trip cannot launder them back in as system scripts.
+- `POST /scripts/bundle/preview` — annotate each entry `new` / `name-conflict`, with
+  the resolved target and any validation errors. No writes.
+- `POST /scripts/bundle/import` — body `{ bundle, mode, availability }` where
+  `mode: 'skip' | 'rename' | 'new-version'` and
+  `availability: 'org' | 'partner'`.
+
+All three carry the same gating as the script write routes they compose —
+authenticated, permission-checked, MFA where the existing create route requires it.
+Bounded: max scripts per bundle and max bytes per `content`, both enforced server-side.
+
+`availability: 'partner'` is what an MSP migrating a shared toolkit ultimately wants —
+one copy for the whole partner rather than one per organization. It is **not** the
+default here, and must not become one until **#3262** is fixed: the partner-wide create
+path is currently gated on scope alone, with no `canManagePartnerWidePolicies` check.
+Until then, import defaults to `'org'` and `'partner'` is gated on that capability at
+the import route. The migration toolkit docs recommend `availability: "partner"` for
+hand-rolled `POST /scripts` calls; that guidance should be revisited alongside #3262.
+
+## 3. Import Service
+
+`apps/api/src/services/scriptBundle/`, mirroring the preview→commit shape settled for
+org import in `2026-08-08-bulk-org-site-import-design.md` §3 so the two feel the same:
+
+1. Validate `bundleVersion`; validate every entry against the **existing**
+   `createScriptSchema` rules (osTypes non-empty, language enum, `timeoutSeconds`
+   1–3600, `runAs` enum). Reuse the schema; do not restate it.
+2. Resolve categories and tags by name within the target scope, creating what is
+   missing.
+3. Per script, apply `mode` against an existing same-name script in scope.
+4. Write through the **same service path** `POST /scripts` uses — not raw inserts —
+   so the `isSystem` clamp, audit, and validation cannot diverge.
+5. Per-entry failure is recorded and the rest proceed; the response reports
+   `imported` / `skipped` / `renamed` / `versioned` / `errors`.
+
+## 4. Security
+
+This is the section to review hardest. A bundle is executable content that will run
+as SYSTEM on every managed endpoint the importer can target.
+
+- **`isSystem` is stripped unconditionally on import**, at every caller scope —
+  stricter than `POST /scripts`, which permits it for `auth.scope === 'system'`. A
+  bundle is untrusted input regardless of who uploads it; honouring `isSystem` would
+  let a crafted bundle inject scripts that present as trusted system-library entries
+  to every organization. This is the #633 hole in a new costume, and the mitigation is
+  to never read the field rather than to clamp it.
+- **No tenancy identifiers are read from the bundle.** `orgId`, `partnerId`,
+  `createdBy` and `id` are ignored if present. Ownership comes from the caller's auth
+  context only, so a bundle cannot place scripts into a tenant the importer cannot
+  reach.
+- **No automations, schedules, or triggers in a v1 bundle.** If a bundle could carry
+  an automation binding, importing one would be arbitrary scheduled remote code
+  execution across a fleet in a single click. Scripts import inert; binding them to
+  anything stays a separate, deliberate action.
+- **Import never executes anything.** No "run on import" convenience, ever.
+- **Every imported script is audited individually** with the bundle's identity, so a
+  later finding can be traced to the import that introduced it.
+- **Abuse-signal coverage is by construction** — imported scripts are ordinary
+  `scripts` rows, so the existing sweep picks them up. Because that is detection
+  rather than prevention, the audit trail above is what makes it actionable.
+- **Bundles are not trusted by origin in v1.** No signing, no marketplace. A bundle
+  is exactly as trustworthy as the person importing it, and the UI should say so.
+
+### Three fields that need their own handling
+
+"Validation parity with `createScriptSchema`" is not sufficient, because for these
+three the existing rule is weak, absent, or gated elsewhere.
+
+- **`parameters` is `z.any()`** (`scripts.ts:169`) — no shape, no depth, no size
+  limit. The 64KB cap at `scripts.ts:203-206` is *execute-time only*. A bundle would
+  otherwise deliver an arbitrary attacker-authored jsonb blob straight into a column
+  the export-policy registry itself classifies as a capability-bearing open container.
+  **Import must impose its own bound**: a size cap and a depth cap on `parameters`,
+  enforced at intake. Do not inherit `z.any()`.
+- **`exitCodeSeverityMapping` can suppress alerting.** A schema-valid mapping may send
+  every exit code to `null`, so a SYSTEM-level script ships pre-configured never to
+  raise an alert on failure — neutering the after-the-fact abuse detection this design
+  leans on as its backstop. Import should **reject an all-null mapping**, or drop the
+  mapping entirely and let the importer re-add it deliberately.
+- **`availability: 'partner'` currently rides an ungated path.** `POST /scripts` gates
+  partner-wide creation on `auth.scope === 'partner'` alone
+  (`scripts.ts:502-506`); `canManagePartnerWidePolicies` and `partnerOrgAccess` both
+  appear **zero times** in that file, contrary to the CLAUDE.md Partner-Wide contract.
+  A partner user with `org_access = 'selected'` can therefore push SYSTEM-level code to
+  every org under the partner. Tracked as **#3262**.
+
+  **This spec depends on #3262 being fixed first**, and until it is, `availability`
+  must default to `'org'` on import — not `'partner'`. Making partner-wide the
+  recommended default over an ungated path turns one bundle import into a fleet-wide
+  fan-out, which is the amplification this section exists to prevent.
+
+## 5. Web UI
+
+Import/export controls on the script library page.
+
+Export: multi-select → download `.json`.
+
+Import: file picker accepting either a `.json` bundle **or a folder of loose
+`.ps1` / `.sh` / `.py` / `.bat` files**, which the browser converts into a bundle —
+inferring `language` and `osTypes` from the extension, `name` from the filename —
+before anything is sent. This is the same split used for CSV in #3242: the client
+does the format work, the server takes one clean JSON contract. It means the loose-
+file migration case is covered without the API growing a second intake path.
+
+Preview table with per-entry status and a mode selector, then commit through
+`runAction` so partial results surface ("34 imported, 2 renamed, 1 failed").
+
+The import screen must state plainly that scripts run as SYSTEM and that a bundle
+should only be imported from a source the operator trusts.
+
+## 6. Testing
+
+- **`isSystem` is ignored from a bundle** — including when the caller *is* system
+  scope. This is the regression test that matters most; assert the stored row is
+  `isSystem: false`.
+- Tenancy fields in a bundle (`orgId`/`partnerId` pointing at another tenant) are
+  ignored, and the script lands in the caller's scope.
+- Unknown `bundleVersion` rejected, not best-effort parsed.
+- Each `mode` behaves: `skip` leaves the original untouched, `rename` suffixes,
+  `new-version` appends to `scriptVersions` rather than replacing history.
+- Category/tag resolution by name: existing reused, missing created, hierarchy intact.
+- Round-trip: export → import into an empty tenant → exported bundle is equivalent.
+- Caps: oversized bundle and oversized `content` rejected with a clear error.
+- Validation parity: a bundle entry that would fail `POST /scripts` fails import too
+  (`timeoutSeconds: 99999`, empty `osTypes`, bad language).
+- **Oversized / deeply-nested `parameters` rejected at intake**, not at execute time —
+  the existing schema is `z.any()`, so this bound exists only if import adds it.
+- **All-null `exitCodeSeverityMapping` rejected** (or stripped), so a bundle cannot
+  ship a script pre-configured never to alert.
+- **`availability: 'partner'` denied** for a caller failing
+  `canManagePartnerWidePolicies`, and the import default is `'org'`.
+- No new tables, so **no RLS/cascade/export registration**. `scripts` and its
+  satellites are already registered; adding no column leaves the export-policy suite
+  untouched.
+
+## Deferred
+
+| Item | Why not now |
+|---|---|
+| Signed bundles / trusted publishers | Needs a key-distribution story; v1 is explicit that trust comes from the importer |
+| A script marketplace or shared community library | Distribution problem, not an import problem |
+| Bundling automations, monitors, or alert templates alongside scripts | Each is a separate contract, and automations specifically are the RCE hazard in §4 |
+| Exporting full `scriptVersions` history | Internal history; portability does not need it and it multiplies bundle size |
+| Server-side zip intake | The client-side conversion in §5 covers the real case without new server intake |


### PR DESCRIPTION
## What

The design record for the RMM migration epic (#3249) — three specs and five implementation plans. The **code for #3243, #3244, #3245 and #3262 has already shipped to main**; this adds the specs those implementations were built from and the plans that sequenced them, so the reasoning survives next to the code.

Split out of #3250, which now carries only the customer-facing migration guides.

| Spec | Records |
|---|---|
| `bulk-org-site-import-design` | Why `organization_external_links` is one-to-many rather than the single-valued `accounting_*` pair |
| `fleet-migration-posture-report-design` | Why posture is aggregated live rather than denormalised, and why it takes two queries |
| `script-bundle-import-export-design` | The bundle threat model — tenancy stripping, `isSystem`, `parameters` bounds, automation exclusion |

Plans: `scripts-partner-wide-gate`, `org-external-links-and-bulk-import`, `partner-api-provisioning-writes`, `fleet-migration-posture-report`, `script-bundle-import-export`.

## Why these are worth keeping

Each spec records a decision whose *rejected* alternative was the obvious one, and an adversarial review pass caught three cases where the flagship guarantee was contradicted by the artifact in the same document:

- **Single-valued external linkage** looked cheaper but fails silently: an org sourced from a Datto CSV and also linked to ConnectWise and QuickBooks can hold only one link, so the second importer overwrites the first and re-import mints duplicate organizations. The spec also flags that moving the QuickBooks *reader* to the link table without the *writer* reproduces that bug.
- **Denormalising posture detections** would drift and report a competing agent as removed while still installed — the failure that strands endpoints. And a single `GROUP BY` collapses never-scanned devices into verified-clean, so it takes two queries.
- **Script bundles** carry executable content that runs as SYSTEM: `parameters` is `z.any()` with only an execute-time cap, an all-null `exitCodeSeverityMapping` ships a script pre-configured never to alert, and `availability: 'partner'` rode an ungated path until #3262.

## Notes for review

- Docs-only. No code paths touched.
- Specs are marked `Ready for review`; the linkage decision in §0 was settled without an independent advisor leg (noted in the doc).
- Plans sit in `docs/superpowers/plans/` (archived), matching their shipped state rather than the `open/` queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)