### PR TITLE
test(backup): make vss.Provider injectable to pin RunBackupContext liveness wiring (#3270)

### DIFF
--- a/agent/internal/backup/backup.go
+++ b/agent/internal/backup/backup.go
@@ -61,6 +61,24 @@ type BackupConfig struct {
 	VSSEnabled         bool   // Windows only: create VSS shadow copy before backup
 	SystemStateEnabled bool   // Collect system state alongside file backup
 	StagingDir         string // Base directory for temporary staging (empty = OS temp dir)
+
+	// VSSProvider overrides where a VSS-enabled run gets its provider from.
+	// Nil — the production case, and what every real caller sets — means
+	// "use the platform provider", i.e. vss.NewProvider on Windows and no VSS
+	// anywhere else. See resolveVSSProvider for the exact resolution.
+	//
+	// It exists because the snapshot-liveness wiring in RunBackupContext
+	// (#3260/#3266: build the shadow-root probe from the live session and hand
+	// it to the upload loop) was otherwise unreachable from a test — the only
+	// real provider is Windows-only and process-global, so a refactor could
+	// drop or misroute that wiring while every liveness unit test still passed
+	// and the protection was silently disconnected (#3270).
+	//
+	// Scoped to the provider ONLY, deliberately. It says nothing about how a
+	// session is created, held or released, so the COM-lifetime rewrite of that
+	// plumbing (#3269) is free to change the session's shape underneath without
+	// touching this field.
+	VSSProvider vss.Provider
 }
 
 // BackupJob tracks the state of a backup run.
@@ -179,6 +197,33 @@ func (m *BackupManager) GetSystemStateEnabled() bool {
 // before a file-mode backup (Windows only; see BackupConfig.VSSEnabled).
 func (m *BackupManager) GetVSSEnabled() bool {
 	return m.config.VSSEnabled
+}
+
+// resolveVSSProvider decides whether a run takes the VSS path, and with which
+// provider. The second return is the whole gate: false means "no shadow copy
+// this run" and the caller skips the block entirely.
+//
+// An injected BackupConfig.VSSProvider bypasses the runtime.GOOS check on
+// purpose. That check is not a statement about the platform, it is a statement
+// about the only provider that used to be reachable here: vss.NewProvider
+// compiles to a stub off Windows, and calling it there would fail every run
+// with ErrVSSNotSupported and stamp a spurious "VSS failed" warning onto the
+// job. Supplying a provider is the caller asserting it works on this host, so
+// re-deriving that answer from GOOS would just make the seam unusable off
+// Windows — which is exactly the platform the wiring needs to be testable on.
+// Nothing in production sets the field, so the production decision is
+// unchanged.
+func (m *BackupManager) resolveVSSProvider() (vss.Provider, bool) {
+	if !m.config.VSSEnabled {
+		return nil, false
+	}
+	if m.config.VSSProvider != nil {
+		return m.config.VSSProvider, true
+	}
+	if runtime.GOOS != "windows" {
+		return nil, false
+	}
+	return vss.NewProvider(vss.DefaultConfig()), true
 }
 
 // Stop cancels an in-flight backup job and waits for it to unwind. It reports
@@ -315,15 +360,23 @@ func (m *BackupManager) RunBackupContext(ctx context.Context, excludes []string)
 
 	// VSS: create shadow copy on Windows for application-consistent backup
 	var vssSession *vss.VSSSession
-	if m.config.VSSEnabled && runtime.GOOS == "windows" {
+	if provider, useVSS := m.resolveVSSProvider(); useVSS {
 		if err := runCtx.Err(); err != nil {
 			return stopBackupRun()
 		}
 		vssStart := time.Now()
-		provider := vss.NewProvider(vss.DefaultConfig())
 		vssCtx, cancel := context.WithTimeout(runCtx, 10*time.Minute)
 		session, vssErr := provider.CreateShadowCopy(vssCtx, extractVolumes(m.config.Paths))
 		cancel()
+		if vssErr == nil && session == nil {
+			// (nil, nil) is a contract violation, not a success: the success
+			// branch below dereferences the session immediately. Now that the
+			// provider is injectable (BackupConfig.VSSProvider) that branch is
+			// reachable from an implementation this package does not own, so
+			// convert it into the same visible no-VSS outcome as a creation
+			// failure rather than panicking the whole agent run.
+			vssErr = errors.New("vss provider returned no session and no error")
+		}
 		if vssErr != nil {
 			log.Warn("VSS shadow copy failed, proceeding without VSS",
 				"elapsedMs", time.Since(vssStart).Milliseconds(),

--- a/agent/internal/backup/vss_provider_seam_test.go
+++ b/agent/internal/backup/vss_provider_seam_test.go
@@ -1,0 +1,386 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/backup/vss"
+)
+
+// fakeVSSProvider is a cross-platform stand-in for the real, Windows-only VSS
+// provider. It exists so RunBackupContext's snapshot-liveness wiring — build
+// the shadow-root probe from the live session, hand it to the upload loop
+// (#3260/#3266) — can be exercised on the linux/race CI job, which is the only
+// place the backup package is actually tested.
+//
+// It implements vss.Provider and nothing else: no build tags, no syscall
+// imports, no knowledge of how a session is created or torn down beyond the
+// interface. That is deliberate — the COM-lifetime rewrite in #3269 changes
+// session plumbing, not this surface.
+type fakeVSSProvider struct {
+	mu sync.Mutex
+
+	// session is returned verbatim from CreateShadowCopy when createErr is nil.
+	// A nil session with a nil createErr models a provider that violates the
+	// interface contract.
+	session   *vss.VSSSession
+	createErr error
+
+	createCalls      int
+	releaseCalls     int
+	requestedVolumes []string
+}
+
+func (f *fakeVSSProvider) CreateShadowCopy(_ context.Context, volumes []string) (*vss.VSSSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.createCalls++
+	f.requestedVolumes = append([]string(nil), volumes...)
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return f.session, nil
+}
+
+func (f *fakeVSSProvider) ReleaseShadowCopy(_ *vss.VSSSession) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.releaseCalls++
+	return nil
+}
+
+func (f *fakeVSSProvider) ListWriters(_ context.Context) ([]vss.WriterStatus, error) {
+	return nil, nil
+}
+
+func (f *fakeVSSProvider) GetShadowPath(_ *vss.VSSSession, volume string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.session == nil {
+		return "", vss.ErrVSSNotSupported
+	}
+	return f.session.ShadowPaths[volume], nil
+}
+
+func (f *fakeVSSProvider) counts() (create, release int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.createCalls, f.releaseCalls
+}
+
+// hookProvider wraps mockProvider to fail every upload of one source file,
+// running a hook once immediately before the first of those failures. The hook
+// is what retires the shadow root at the exact moment the upload loop is about
+// to consult the liveness probe.
+//
+// Keyed on the file rather than on a call ordinal because the upload loop
+// retries a failed file once: failing "the first call" would let the retry
+// succeed and produce a clean run, which is not the scenario either case is
+// about. Keying on the file also makes both cases independent of the order the
+// scan happens to walk the directory in.
+type hookProvider struct {
+	*mockProvider
+
+	failBase   string // base name of the source file whose uploads always fail
+	failErr    error
+	onFail     func()
+	onFailOnce sync.Once
+}
+
+func (h *hookProvider) Upload(localPath, remotePath string) error {
+	if filepath.Base(localPath) == h.failBase {
+		if h.onFail != nil {
+			h.onFailOnce.Do(h.onFail)
+		}
+		return h.failErr
+	}
+	return h.mockProvider.Upload(localPath, remotePath)
+}
+
+// shadowedSourceDir returns the path rewritePathsForVSS will produce for
+// srcDir under shadowRoot, and creates it. Computed the same way the
+// production rewrite computes it (shadow root + the volume-relative
+// remainder), so the test tracks the real mapping on both Windows — where
+// filepath.VolumeName yields a drive letter — and Unix, where it yields "".
+func shadowedSourceDir(t *testing.T, shadowRoot, srcDir string) string {
+	t.Helper()
+	vol := filepath.VolumeName(srcDir)
+	shadowed := shadowRoot + srcDir[len(vol):]
+	if err := os.MkdirAll(shadowed, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", shadowed, err)
+	}
+	return shadowed
+}
+
+// TestRunBackupContext_InjectedVSSProviderDrivesSnapshotLiveness is the point
+// of the seam (#3270). It runs the WHOLE manager path — provider acquisition,
+// session creation, path rewrite, liveness-probe construction, upload loop —
+// against an injected provider, and pins the two outcomes that the wiring is
+// responsible for telling apart:
+//
+//   - the shadow root goes away mid-run: the run aborts with
+//     errSourceSnapshotGone rather than recording every remaining file as
+//     individually bad, which is #3260 verbatim.
+//   - the shadow root survives: the same upload failure is recorded as one
+//     ordinary per-file failure and the run finishes.
+//
+// Both cases run the real os.Stat against a real directory. Nothing here stubs
+// snapshotRootStat, because the thing under test is precisely whether the
+// session's ShadowPaths reach newShadowRootLiveness and its result reaches
+// createSnapshotWithProgress — a probe driven by a stubbed stat would pass
+// even with that wiring cut.
+func TestRunBackupContext_InjectedVSSProviderDrivesSnapshotLiveness(t *testing.T) {
+	tests := []struct {
+		name string
+		// retireShadowRoot removes the shadow root at the moment the first
+		// upload fails, modelling the snapshot disappearing mid-run.
+		retireShadowRoot bool
+		wantAbort        bool
+	}{
+		{
+			name:             "shadow root disappears mid-run aborts the whole run",
+			retireShadowRoot: true,
+			wantAbort:        true,
+		},
+		{
+			name:             "shadow root survives so the same failure stays per-file",
+			retireShadowRoot: false,
+			wantAbort:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The confirmation delay and the retry backoff are both real
+			// wall-clock waits on the path under test; neither is what this
+			// test is about.
+			t.Cleanup(setShadowRootConfirmDelayForTest(0))
+			t.Cleanup(setUploadRetryDelayForTest(0))
+
+			shadowRoot := t.TempDir()
+			srcDir := t.TempDir()
+			shadowed := shadowedSourceDir(t, shadowRoot, srcDir)
+			createTempFile(t, shadowed, "a.txt", "alpha")
+			createTempFile(t, shadowed, "b.txt", "bravo")
+
+			vssProvider := &fakeVSSProvider{
+				session: &vss.VSSSession{
+					ID:          "shadow-set-1",
+					Volumes:     []string{filepath.VolumeName(srcDir)},
+					ShadowPaths: map[string]string{filepath.VolumeName(srcDir): shadowRoot},
+					CreatedAt:   time.Now().UTC(),
+				},
+			}
+
+			backing := newMockProvider()
+			storage := &hookProvider{
+				mockProvider: backing,
+				failBase:     "a.txt",
+				failErr:      errors.New("destination refused the object"),
+			}
+			if tt.retireShadowRoot {
+				storage.onFail = func() {
+					if err := os.RemoveAll(shadowRoot); err != nil {
+						t.Errorf("failed to retire the shadow root: %v", err)
+					}
+				}
+			}
+
+			mgr := NewBackupManager(BackupConfig{
+				Provider:    storage,
+				Paths:       []string{srcDir},
+				VSSEnabled:  true,
+				VSSProvider: vssProvider,
+				StagingDir:  t.TempDir(),
+			})
+
+			job, err := mgr.RunBackupContext(context.Background(), nil)
+
+			if create, release := vssProvider.counts(); create != 1 || release != 1 {
+				t.Errorf("injected VSS provider: createCalls=%d releaseCalls=%d, want 1 and 1 — "+
+					"the run must acquire the session from the injected provider and release it", create, release)
+			}
+			if job == nil {
+				t.Fatalf("RunBackupContext returned a nil job (err=%v)", err)
+			}
+
+			if !tt.wantAbort {
+				if err != nil {
+					t.Fatalf("a live shadow root must not abort the run, got %v", err)
+				}
+				if errors.Is(err, errSourceSnapshotGone) {
+					t.Fatalf("a live shadow root must never report the snapshot as gone")
+				}
+				if job.ErrorCount != 1 {
+					t.Errorf("ErrorCount = %d, want 1 (the single per-file upload failure)", job.ErrorCount)
+				}
+				if job.Snapshot == nil || len(job.Snapshot.Files) != 1 {
+					t.Errorf("want a snapshot holding the one file that did upload, got %+v", job.Snapshot)
+				}
+				return
+			}
+
+			if !errors.Is(err, errSourceSnapshotGone) {
+				t.Fatalf("want the run to abort with errSourceSnapshotGone, got %v", err)
+			}
+			if job.Status != jobStatusFailed {
+				t.Errorf("job.Status = %q, want %q", job.Status, jobStatusFailed)
+			}
+			// The abort must not be laundered into per-file verdicts: that
+			// misattribution — 15 bad files recorded as 40 — is the whole of
+			// #3260.
+			if job.ErrorCount != 0 {
+				t.Errorf("ErrorCount = %d, want 0: a snapshot-gone abort is a RUN failure, not a pile of per-file failures", job.ErrorCount)
+			}
+			// A journal is open (StagingDir is set), so the abort must leave
+			// the partial prefix intact for the resume rather than deleting it.
+			if len(backing.deleteCalls) != 0 {
+				t.Errorf("a resumable snapshot-gone abort must not delete the partial remote prefix, deletes=%v", backing.deleteCalls)
+			}
+		})
+	}
+}
+
+// TestRunBackupContext_InjectedVSSProviderReceivesRequestedVolumes pins the
+// other half of the acquisition wiring: the volumes the run asks the provider
+// to snapshot are derived from the CONFIGURED paths, not from the rewritten
+// ones. Getting this backwards would ask VSS to snapshot a shadow device.
+func TestRunBackupContext_InjectedVSSProviderReceivesRequestedVolumes(t *testing.T) {
+	srcDir := t.TempDir()
+	createTempFile(t, srcDir, "a.txt", "alpha")
+
+	// No session: the run proceeds without VSS, which is all this test needs.
+	vssProvider := &fakeVSSProvider{createErr: errors.New("no shadow copy for you")}
+
+	mgr := NewBackupManager(BackupConfig{
+		Provider:    newMockProvider(),
+		Paths:       []string{srcDir},
+		VSSEnabled:  true,
+		VSSProvider: vssProvider,
+		StagingDir:  t.TempDir(),
+	})
+
+	if _, err := mgr.RunBackupContext(context.Background(), nil); err != nil {
+		t.Fatalf("a failed shadow copy must degrade to a live-read run, got %v", err)
+	}
+
+	want := extractVolumes([]string{srcDir})
+	vssProvider.mu.Lock()
+	got := vssProvider.requestedVolumes
+	vssProvider.mu.Unlock()
+	if len(got) != len(want) {
+		t.Fatalf("requested volumes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("requested volumes = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestRunBackupContext_VSSProviderReturningNoSessionDoesNotPanic covers the
+// contract violation the seam newly makes reachable: before the provider was
+// injectable, only vss.NewProvider could reach the success branch, and it
+// never returns (nil, nil). An injected provider can, and the success branch
+// dereferences the session immediately — so this must degrade to the ordinary
+// "VSS failed, read live" outcome instead of taking the agent down.
+func TestRunBackupContext_VSSProviderReturningNoSessionDoesNotPanic(t *testing.T) {
+	srcDir := t.TempDir()
+	createTempFile(t, srcDir, "a.txt", "alpha")
+
+	vssProvider := &fakeVSSProvider{} // nil session, nil error
+
+	mgr := NewBackupManager(BackupConfig{
+		Provider:    newMockProvider(),
+		Paths:       []string{srcDir},
+		VSSEnabled:  true,
+		VSSProvider: vssProvider,
+		StagingDir:  t.TempDir(),
+	})
+
+	job, err := mgr.RunBackupContext(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("want the run to complete without VSS, got %v", err)
+	}
+	if job.VSSMetadata != nil {
+		t.Errorf("no session means no VSS metadata, got %+v", job.VSSMetadata)
+	}
+	if job.Warning == "" {
+		t.Error("a run that silently lost its shadow copy must carry a warning; an unwarned live-read run is #3027")
+	}
+	// Nothing was released, because nothing was ever created.
+	if _, release := vssProvider.counts(); release != 0 {
+		t.Errorf("releaseCalls = %d, want 0", release)
+	}
+}
+
+// TestResolveVSSProvider pins the resolution matrix itself, including the one
+// judgement call in it: an injected provider overrides the runtime.GOOS gate,
+// because that gate is about the built-in provider being a stub off Windows,
+// not about the platform being incapable.
+func TestResolveVSSProvider(t *testing.T) {
+	injected := &fakeVSSProvider{}
+
+	tests := []struct {
+		name        string
+		config      BackupConfig
+		wantUse     bool
+		wantSame    vss.Provider // non-nil when the exact injected value must come back
+		windowsOnly bool         // wantUse is only true on Windows
+	}{
+		{
+			name:    "VSS disabled and no provider",
+			config:  BackupConfig{},
+			wantUse: false,
+		},
+		{
+			name:   "VSS disabled beats an injected provider",
+			config: BackupConfig{VSSProvider: injected},
+			// VSSEnabled stays the master switch: injecting a provider must
+			// not switch VSS on for a run that did not ask for it.
+			wantUse: false,
+		},
+		{
+			name:        "VSS enabled with no provider falls back to the platform default",
+			config:      BackupConfig{VSSEnabled: true},
+			windowsOnly: true,
+		},
+		{
+			name:     "VSS enabled with an injected provider uses it on every platform",
+			config:   BackupConfig{VSSEnabled: true, VSSProvider: injected},
+			wantUse:  true,
+			wantSame: injected,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantUse := tt.wantUse
+			if tt.windowsOnly {
+				wantUse = runtime.GOOS == "windows"
+			}
+			provider, use := NewBackupManager(tt.config).resolveVSSProvider()
+			if use != wantUse {
+				t.Fatalf("useVSS = %v, want %v", use, wantUse)
+			}
+			if !use {
+				if provider != nil {
+					t.Errorf("provider = %v, want nil when VSS is off for the run", provider)
+				}
+				return
+			}
+			if provider == nil {
+				t.Fatal("useVSS is true but the provider is nil")
+			}
+			if tt.wantSame != nil && provider != tt.wantSame {
+				t.Errorf("provider = %v, want the injected instance", provider)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3270

## The gap

PR #3266 added the mid-run snapshot-loss guard (#3260): a probe over the VSS shadow-copy roots that aborts a run when the snapshot disappears, rather than draining the file list and recording the fallout as a pile of per-file verdicts. The probe has thorough unit coverage. The two lines in `RunBackupContext` that **build it from the live VSS session and hand it to the upload loop** had none — reaching them needed a real `vss.Provider`, which is Windows-only and process-global.

That is the dangerous shape: a refactor could drop or misroute the wiring while every liveness test still passed and the protection was silently disconnected.

## The seam

A nullable `BackupConfig.VSSProvider vss.Provider` field, mirroring the existing `Provider providers.BackupProvider` field, plus a small `BackupManager.resolveVSSProvider() (vss.Provider, bool)` that replaces the inline gate:

```go
// before
if m.config.VSSEnabled && runtime.GOOS == "windows" {
    provider := vss.NewProvider(vss.DefaultConfig())

// after
if provider, useVSS := m.resolveVSSProvider(); useVSS {
```

Resolution order: `!VSSEnabled` → off; injected provider → use it; else Windows → `vss.NewProvider(vss.DefaultConfig())`; else off. **Nil — every production caller — resolves exactly as before.**

Two judgement calls, both deliberate:

- **An injected provider bypasses the `runtime.GOOS` gate.** That gate was never a statement about platform capability; it exists because `vss.NewProvider` compiles to a stub off Windows, and calling it there would fail every run with `ErrVSSNotSupported` and stamp a spurious "VSS failed" warning on the job. Supplying a provider is the caller asserting it works on this host. Honouring GOOS against it would make the seam unusable on the one platform the package is actually tested on.
- **`VSSEnabled` stays the master switch.** Injecting a provider must not switch VSS on for a run that did not ask for it.

The seam is scoped to the **provider only**. It says nothing about how a session is created, held or released, so the COM-lifetime rewrite in #3269 can change that plumbing underneath without touching this field.

## One incidental fix

A `(nil, nil)` return from `CreateShadowCopy` is now converted into the ordinary "VSS failed, read live" outcome. The success branch dereferences the session immediately (`session.Warnings`), and that branch is now reachable from a provider this package does not own — a contract violation should degrade visibly, not panic the agent run.

## Tests

`agent/internal/backup/vss_provider_seam_test.go` — cross-platform, no build tags, no Windows-only imports, so it runs on the linux + race **Test Agent** jobs.

- **`TestRunBackupContext_InjectedVSSProviderDrivesSnapshotLiveness`** — table-driven over the two outcomes the wiring exists to tell apart. A shadow root that disappears mid-run aborts the whole run with `errSourceSnapshotGone`, `ErrorCount 0`, and the resumable prefix left intact; a root that survives leaves the identical upload failure as one ordinary per-file failure and the run finishes. Both cases drive the **real `os.Stat` against a real directory** — a probe fed by a stubbed `snapshotRootStat` would pass even with the wiring cut, which defeats the purpose.
- **`TestRunBackupContext_InjectedVSSProviderReceivesRequestedVolumes`** — the volumes handed to the provider come from the *configured* paths, not the rewritten ones.
- **`TestRunBackupContext_VSSProviderReturningNoSessionDoesNotPanic`**
- **`TestResolveVSSProvider`** — the resolution matrix, GOOS-aware.

**Verified non-vacuous:** replacing `sourceLiveness = newShadowRootLiveness(...)` with `_ = newShadowRootLiveness(...)` reddens the abort case with `want the run to abort with errSourceSnapshotGone, got failed to upload ...`. Restored before commit.

## CI filter

No existing backup test is renamed, so the hardcoded Windows `-run` filter and its PASS-count assertion (`.github/workflows/ci.yml`) are untouched. The new tests are deliberately **not** added to it: their semantics are platform-neutral, the drive-letter rewrite they would exercise on Windows is already covered by `TestRewritePathsForVSS` (which is in that filter), and the mirrored temp-dir paths the test builds would sit close to `MAX_PATH` on a Windows runner.

## Verification

- `go build ./...`
- `go vet ./internal/backup/...` — host and `GOOS=windows` (only pre-existing `unsafe.Pointer` notes in untouched `vss_windows.go`)
- `go test -race ./internal/backup/...` — all 7 packages green
- `go test -race ./cmd/breeze-backup/...` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)