### PR TITLE
test(web): give the InvoiceWorkspace queued-Issue tests real waitFor headroom (#3219)

### DIFF
--- a/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
+++ b/apps/web/src/components/billing/InvoiceWorkspace.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { configure, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import InvoiceWorkspace from './InvoiceWorkspace';
 import { _resetShowMarginMemoryForTests } from './billingUi';
@@ -49,6 +49,32 @@ function invoice(over: Record<string, unknown>) {
 }
 
 describe('InvoiceWorkspace', () => {
+  // #3219 — the queued-Issue tests assert the END of a multi-hop propagation
+  // chain: the PATCH promise settles → the editor reports saved/failed → the
+  // workspace clears `savePending` → the header un-gates → the queued Issue
+  // fires a fetch. Every hop is promise/render scheduling, so under CI load the
+  // whole chain can outrun Testing Library's 1000ms default `waitFor` timeout.
+  //
+  // That is exactly what the three recorded sightings look like: #2925, this
+  // issue, and #3277 all failed at ~1038ms, i.e. a fraction over the default,
+  // and all passed on a same-commit rerun and locally.
+  //
+  // Fake timers are the wrong instrument here despite being the usual reflex —
+  // nothing in this chain is timer-driven. The delay is promise microtasks plus
+  // React render scheduling, which fake timers do not advance, so they would add
+  // machinery without touching the cause.
+  //
+  // Raised file-wide rather than per-assertion so a future test in this file
+  // inherits the headroom instead of re-discovering the flake. Restored
+  // afterwards because Testing Library's `configure` is process-global.
+  const DEFAULT_ASYNC_UTIL_TIMEOUT_MS = 1000;
+  beforeAll(() => {
+    configure({ asyncUtilTimeout: 5000 });
+  });
+  afterAll(() => {
+    configure({ asyncUtilTimeout: DEFAULT_ASYNC_UTIL_TIMEOUT_MS });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     // The margin preference persists to localStorage plus an in-memory mirror


### PR DESCRIPTION
Fixes #3219. Also covers #3277, which is the same two tests — worth closing as a duplicate once this lands.

## Why these two tests and no others

Three sightings in ten days, always the same pair, always green locally and on a same-commit rerun:

| | when | test |
|---|---|---|
| #2925 | 2026-07-29 | `does NOT fire a queued Issue when the pending save fails` |
| #3219 | 2026-08-07 | `holds a header Issue click…` |
| #3277 | 2026-08-08 | both, on #3264's CI |

They are the only two in the file that assert the **end of a multi-hop propagation chain**: the PATCH promise settles → the editor reports saved/failed → the workspace clears `savePending` → the header un-gates → the queued Issue fires a fetch. Every hop is promise/render scheduling.

All three recorded failures sat at **~1038ms** against Testing Library's **1000ms** default `waitFor` timeout. A fraction over the default is the signature of a timeout, not a logic race — and it explains why a rerun on the identical commit passes.

## Why not fake timers

That was your other suggested option and it's the wrong instrument here: **nothing in this chain is timer-driven.** The delay is promise microtasks plus React render scheduling, neither of which fake timers advance. They'd add machinery without touching the cause, and would need the manual `resolvePatch`/`rejectPatch` promises reworked around them.

Raised file-wide as you specified, rather than per-assertion, so a future test in this file inherits the headroom instead of rediscovering the flake. Restored in `afterAll` since `configure` is process-global.

## What I verified — and what I couldn't

**Could not reproduce the flake locally.** The chain completes in ~30ms on my machine against a 1000ms budget, which is precisely why this only ever fails on loaded CI. I'm not going to claim a green local run as proof of a fix for a CI-only timing failure.

**What I could prove** is that the knob governs the right assertions rather than being inert — setting `asyncUtilTimeout` to 1ms fails **exactly** the two queued-Issue tests and leaves the other five passing:

```
✓ renders a draft as the editor…            ✓ keeps the draft editor MOUNTED…
✓ surfaces an error card…                   ✓ offers the cost/margin toggle…
✓ updates the header from "Draft invoice"…
× holds a header Issue click while the editor is dirty…
× does NOT fire a queued Issue when the pending save fails…
```

The real proof is CI staying green on these two over the next few weeks; if it recurs, the diagnosis is wrong and the next step is instrumenting the chain rather than raising the number again.

## Scope note

No other web test file configures `asyncUtilTimeout` — the whole suite runs on the 1000ms default. I deliberately did **not** raise it globally: that would also slow every genuine failure to the new ceiling, and the blast radius is the entire web suite. Worth considering separately if this shape shows up in other files.

## Gate

`apps/web` vitest — **538 files / 5102 tests / 0 failures** · `tsc --noEmit` exit 0 · `eslint` clean.
