### PR TITLE
fix(backup): hold the VSS session COM references for the whole run and signal BackupComplete (#3269)

### DIFF
--- a/agent/internal/backup/source_liveness.go
+++ b/agent/internal/backup/source_liveness.go
@@ -35,11 +35,17 @@ import (
 // Deliberately NOT called "expired": a VSS_CTX_BACKUP shadow copy has no TTL,
 // so nothing here times out. It becomes unavailable — deleted by the provider,
 // lost to diff-area exhaustion, removed externally, or auto-released when
-// IVssBackupComponents is released (Microsoft-documented behaviour for
-// auto-release VSS_CTX_BACKUP copies; the contrary note in
-// vss.CreateShadowCopy, which claims reclamation only at requester process
-// exit, is tracked as #3269). The guard is agnostic about which; it only
-// reports that the source went away.
+// IVssBackupComponents is released. That last cause was the likely trigger of
+// the field repro above and has since been FIXED (#3269): vss.CreateShadowCopy
+// no longer releases the components object on its way out, and the session now
+// holds it open on a dedicated COM thread until the run ends.
+//
+// This guard stays as defence in depth. The other three causes are real and
+// entirely outside our control, and the whole point of the guard is that it is
+// agnostic about which one fired — it only reports that the source went away.
+// Removing it because one known cause was fixed would put us back to recording
+// a dead snapshot as a pile of per-file faults the next time one of the others
+// happens.
 var errSourceSnapshotGone = errors.New("backup source snapshot is no longer available (VSS shadow copy deleted or became unavailable mid-run)")
 
 // sourceLivenessFn reports a non-nil error when the point-in-time source that

--- a/agent/internal/backup/vss/session_lifetime.go
+++ b/agent/internal/backup/vss/session_lifetime.go
@@ -1,0 +1,209 @@
+package vss
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+)
+
+// This file holds the two pieces of #3269's lifetime fix that are pure Go: the
+// pinned worker thread the COM calls are routed onto, and the process-wide gate
+// that serialises snapshot *creation*.
+//
+// Neither has a build tag, and that is deliberate. The COM calls they carry are
+// unfakeable and Windows-only, but the machinery around them — start a thread,
+// keep every call on it, release exactly once, don't let two runs create a
+// snapshot set at the same moment — is ordinary concurrent Go, and it is where a
+// mistake costs a customer their backup. Keeping it platform-neutral puts it
+// under `go test -race` on every developer machine and in the linux CI job,
+// instead of only in the Windows job, which runs this package without the race
+// detector.
+
+// ---------------------------------------------------------------------------
+// serialThread
+// ---------------------------------------------------------------------------
+
+// errSerialThreadClosed is returned by serialThread.do once the thread has
+// stopped accepting work.
+var errSerialThreadClosed = errors.New("vss: session thread is closed")
+
+// serialThread owns one OS thread and runs submitted closures on it, one at a
+// time.
+//
+// It exists to give the COM work a stable home. A VSS_CTX_BACKUP shadow copy is
+// an *auto-release* copy: Windows deletes it once the requester drops its
+// references to the IVssBackupComponents that created it. Holding that object
+// for the whole backup run means holding a thread that has COM initialised for
+// the whole run, and the Go scheduler may move a goroutine to a different OS
+// thread between any two statements — so the thread has to be pinned and every
+// call routed back onto it.
+//
+// The thread is locked for its entire life and is deliberately NEVER unlocked.
+// A goroutine that exits while still locked makes the Go runtime destroy the
+// underlying OS thread, so no unrelated goroutine can inherit a thread carrying
+// our COM state. Note what that does and does not do: an MTA is process-wide,
+// not a private apartment this thread owns, so destroying the thread does not
+// tear down the MTA, and it is emphatically NOT the mechanism that reclaims the
+// shadow copy. Releasing the IVssBackupComponents is.
+//
+// Two limits worth knowing. Concurrent callers are serialised but not ordered:
+// nothing here promises FIFO among goroutines racing to submit. And a COM call
+// that wedges inside a vtable dispatch cannot be preempted by anything —
+// context, close, or otherwise — because it is a synchronous foreign call on
+// this thread; only the polling *between* COM calls is context-bounded.
+type serialThread struct {
+	calls    chan func()
+	stop     chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+// newSerialThread starts the thread and runs init on it before accepting any
+// work. If init returns an error the thread exits without running teardown —
+// there is nothing initialised to tear down — and the error is returned here.
+// That distinction is load-bearing for COM: CoInitializeEx returning S_FALSE is
+// a success that still owes a CoUninitialize, while a genuine failure such as
+// RPC_E_CHANGED_MODE must never be uninitialized.
+//
+// teardown runs on the same thread after the last submitted closure has
+// finished, immediately before the thread exits.
+func newSerialThread(init func() error, teardown func()) (*serialThread, error) {
+	t := &serialThread{
+		calls: make(chan func()),
+		stop:  make(chan struct{}),
+		done:  make(chan struct{}),
+	}
+	ready := make(chan error, 1)
+
+	go func() {
+		// Never unlocked; see the type comment. This is the single most
+		// load-bearing line in the file.
+		runtime.LockOSThread()
+		defer close(t.done)
+
+		if init != nil {
+			if err := init(); err != nil {
+				ready <- err
+				return
+			}
+		}
+		if teardown != nil {
+			defer teardown()
+		}
+		ready <- nil
+
+		for {
+			// Shutdown wins over pending work. Without this the select below
+			// would pick nondeterministically between a ready call and a closed
+			// stop channel, so close() could still admit one more closure.
+			select {
+			case <-t.stop:
+				return
+			default:
+			}
+			select {
+			case fn := <-t.calls:
+				fn()
+			case <-t.stop:
+				return
+			}
+		}
+	}()
+
+	if err := <-ready; err != nil {
+		// Wait for the goroutine to actually finish, so a failed start never
+		// leaves a thread behind that a later close() would have to reap.
+		<-t.done
+		return nil, err
+	}
+	return t, nil
+}
+
+// do runs fn on the thread and blocks until fn returns. Anything fn writes to
+// variables captured from the caller is visible to the caller once do returns:
+// the channel send and the completion signal are the happens-before edges.
+//
+// It reports errSerialThreadClosed if the thread is already stopping, rather
+// than blocking forever — a call after teardown is a caller bug, and the one
+// thing it must not do is deadlock the backup run.
+func (t *serialThread) do(fn func()) error {
+	// Checked first so a call submitted after close() has begun is refused
+	// rather than racing the worker's own select.
+	select {
+	case <-t.stop:
+		return errSerialThreadClosed
+	default:
+	}
+
+	finished := make(chan struct{})
+	select {
+	case t.calls <- func() { defer close(finished); fn() }:
+	case <-t.done:
+		return errSerialThreadClosed
+	}
+	select {
+	case <-finished:
+		return nil
+	case <-t.done:
+		return errSerialThreadClosed
+	}
+}
+
+// close runs teardown on the thread, waits for it to exit, and is idempotent.
+func (t *serialThread) close() {
+	t.stopOnce.Do(func() { close(t.stop) })
+	<-t.done
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot-creation gate
+// ---------------------------------------------------------------------------
+
+// snapshotCreationGate serialises snapshot *creation* across the process.
+//
+// The scope is deliberate, and it is narrower than "one backup at a time". What
+// VSS actually serialises is the creation interval — from StartSnapshotSet until
+// DoSnapshotSet completes — which is why a second requester inside that window
+// gets VSS_E_SNAPSHOT_SET_IN_PROGRESS. It does not require that only one
+// finished snapshot set be alive at a time, and writers are built to tell
+// concurrent backup sessions apart. So two overlapping backup runs may both end
+// up holding their own live shadow copies; only their creation is queued.
+//
+// Gating the whole session instead would have been a behaviour regression
+// dressed as safety: breeze-backup dispatches every IPC command in its own
+// goroutine and builds an ephemeral BackupManager per server-dispatched
+// backup_run, so overlapping runs are routine, and a session-wide gate would
+// silently downgrade one of them to a live read for the entire duration of the
+// other. It would also mean a single forgotten ReleaseShadowCopy disabled VSS on
+// that machine until the helper restarted. Neither cost buys anything: the
+// exclusion VSS needs is already over by the time DoSnapshotSet returns.
+//
+// Waiting rather than failing fast is right at this scope. Creation is normally
+// seconds, it is already bounded by the caller's creation context, and
+// Microsoft's documented response to VSS_E_SNAPSHOT_SET_IN_PROGRESS is to wait
+// and retry. A wait that outlives the context degrades to
+// ErrVSSSessionInProgress and the caller's existing no-VSS path.
+//
+// Note it cannot serialise against a *different* process acting as requester, so
+// VSS_E_SNAPSHOT_SET_IN_PROGRESS still has to be survivable on its own.
+var snapshotCreationGate = make(chan struct{}, 1)
+
+// acquireSnapshotCreation claims the creation gate, giving up if ctx ends first.
+// The returned release func is nil when the error is non-nil.
+func acquireSnapshotCreation(ctx context.Context) (release func(), err error) {
+	select {
+	case snapshotCreationGate <- struct{}{}:
+		var once sync.Once
+		return func() { once.Do(func() { <-snapshotCreationGate }) }, nil
+	case <-ctx.Done():
+		return nil, ErrVSSSessionInProgress
+	}
+}
+
+// snapshotCreationBusy reports whether the gate is currently held. For tests and
+// diagnostics only — never branch production behaviour on it, since the answer
+// is stale the moment it is returned.
+func snapshotCreationBusy() bool {
+	return len(snapshotCreationGate) > 0
+}

--- a/agent/internal/backup/vss/session_lifetime_test.go
+++ b/agent/internal/backup/vss/session_lifetime_test.go
@@ -1,0 +1,396 @@
+package vss
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// goroutineID reads the calling goroutine's ID out of its own stack header, and
+// returns 0 if that fails. It must never call t.Fatal: it is invoked from the
+// serialThread's goroutine, where the testing package's failure machinery is not
+// allowed to run.
+//
+// It stands in for the property that actually matters — "is this still the same
+// OS thread?" — which Go exposes no portable API for. The substitution is sound
+// for this type specifically: serialThread's goroutine calls
+// runtime.LockOSThread and never unlocks, and a locked goroutine is guaranteed
+// by the runtime to run on that one OS thread and to have no other goroutine
+// scheduled onto it. So for a permanently locked goroutine, same goroutine means
+// same OS thread — and therefore same COM apartment.
+func goroutineID() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	fields := strings.Fields(string(buf[:n]))
+	if len(fields) < 2 || fields[0] != "goroutine" {
+		return 0
+	}
+	id, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+// These tests cover the lifetime machinery behind #3269 with the COM calls out
+// of the picture. They are deliberately NOT build-tagged: the machinery is only
+// used on Windows, but the properties under test — every call lands on the same
+// pinned thread, init/teardown run exactly once and on that thread, a closed
+// thread reports rather than deadlocks, and snapshot creation is serialised
+// process-wide without ever being serialised for longer than creation — are
+// ordinary concurrency, and this is the only way they get run under
+// `go test -race` (the Windows CI job runs this package without the race
+// detector).
+
+// ---------------------------------------------------------------------------
+// serialThread
+// ---------------------------------------------------------------------------
+
+// TestSerialThread_RunsEveryCallOnOneLockedThread is the property the whole fix
+// rests on: an IVssBackupComponents belongs to the COM apartment of the thread
+// that created it, so if two closures ran on different OS threads the interface
+// would be called from outside its apartment. See goroutineID for why comparing
+// goroutine identity is a sound proxy for thread identity here.
+func TestSerialThread_RunsEveryCallOnOneLockedThread(t *testing.T) {
+	var initGID uint64
+	th, err := newSerialThread(func() error {
+		initGID = goroutineID()
+		return nil
+	}, nil)
+	if err != nil {
+		t.Fatalf("newSerialThread: %v", err)
+	}
+	defer th.close()
+
+	// Enough iterations, with scheduling pressure in between, that a goroutine
+	// free to migrate would be very unlikely to stay put by accident.
+	for i := 0; i < 50; i++ {
+		var got uint64
+		if err := th.do(func() { got = goroutineID() }); err != nil {
+			t.Fatalf("do #%d: %v", i, err)
+		}
+		if got == 0 || got != initGID {
+			t.Fatalf("call #%d ran on goroutine %d, want %d (a migrated call would be outside the COM apartment)", i, got, initGID)
+		}
+		runtime.Gosched()
+	}
+}
+
+// TestSerialThread_TeardownRunsOnceOnTheSameThread pins that CoUninitialize's
+// stand-in runs on the thread that ran CoInitializeEx's stand-in, and exactly
+// once no matter how often close is called. Uninitialising a different thread's
+// apartment, or twice, corrupts COM state process-wide.
+func TestSerialThread_TeardownRunsOnceOnTheSameThread(t *testing.T) {
+	var (
+		mu           sync.Mutex
+		initGID      uint64
+		teardownGID  uint64
+		teardownRuns int
+	)
+	th, err := newSerialThread(
+		func() error {
+			mu.Lock()
+			defer mu.Unlock()
+			initGID = goroutineID()
+			return nil
+		},
+		func() {
+			mu.Lock()
+			defer mu.Unlock()
+			teardownGID = goroutineID()
+			teardownRuns++
+		},
+	)
+	if err != nil {
+		t.Fatalf("newSerialThread: %v", err)
+	}
+
+	if err := th.do(func() {}); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+
+	mu.Lock()
+	if teardownRuns != 0 {
+		t.Fatalf("teardown ran %d times before close", teardownRuns)
+	}
+	mu.Unlock()
+
+	th.close()
+	th.close() // idempotent
+	th.close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if teardownRuns != 1 {
+		t.Fatalf("teardown ran %d times, want exactly 1", teardownRuns)
+	}
+	if teardownGID == 0 || teardownGID != initGID {
+		t.Fatalf("teardown ran on goroutine %d, init on %d — CoUninitialize must run on the thread that ran CoInitializeEx", teardownGID, initGID)
+	}
+}
+
+// TestSerialThread_InitFailureStartsNothing covers the CoInitializeEx failure
+// path: no thread is left behind, teardown never runs (there is nothing
+// initialised to tear down), and the error reaches the caller.
+func TestSerialThread_InitFailureStartsNothing(t *testing.T) {
+	sentinel := errors.New("init failed")
+	teardownRan := false
+
+	th, err := newSerialThread(
+		func() error { return sentinel },
+		func() { teardownRan = true },
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want %v", err, sentinel)
+	}
+	if th != nil {
+		t.Fatal("newSerialThread returned a thread alongside an error")
+	}
+	if teardownRan {
+		t.Fatal("teardown ran even though init failed — that would CoUninitialize an apartment that was never entered")
+	}
+}
+
+// TestSerialThread_DoAfterCloseReports is the anti-deadlock property. A release
+// path that runs twice, or a stray call after teardown, must get an error back —
+// blocking forever on a dead thread would hang the whole backup run.
+func TestSerialThread_DoAfterCloseReports(t *testing.T) {
+	th, err := newSerialThread(nil, nil)
+	if err != nil {
+		t.Fatalf("newSerialThread: %v", err)
+	}
+	th.close()
+
+	done := make(chan error, 1)
+	go func() {
+		ran := false
+		err := th.do(func() { ran = true })
+		if ran {
+			done <- errors.New("closure ran on a closed thread")
+			return
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, errSerialThreadClosed) {
+			t.Fatalf("do after close = %v, want errSerialThreadClosed", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("do blocked forever on a closed thread instead of reporting")
+	}
+}
+
+// TestSerialThread_SerialisesConcurrentCallers checks that closures never
+// overlap. COM calls against one IVssBackupComponents are not reentrant, and
+// nothing above this layer takes a second lock.
+func TestSerialThread_SerialisesConcurrentCallers(t *testing.T) {
+	th, err := newSerialThread(nil, nil)
+	if err != nil {
+		t.Fatalf("newSerialThread: %v", err)
+	}
+	defer th.close()
+
+	var (
+		mu      sync.Mutex
+		inside  int
+		maxSeen int
+		ran     int
+	)
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = th.do(func() {
+				mu.Lock()
+				inside++
+				if inside > maxSeen {
+					maxSeen = inside
+				}
+				mu.Unlock()
+
+				runtime.Gosched()
+
+				mu.Lock()
+				inside--
+				ran++
+				mu.Unlock()
+			})
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if maxSeen != 1 {
+		t.Fatalf("observed %d closures running concurrently, want 1", maxSeen)
+	}
+	if ran != 20 {
+		t.Fatalf("%d closures ran, want 20", ran)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot-creation gate
+// ---------------------------------------------------------------------------
+
+// TestSnapshotCreation_SerialisesButDoesNotBlockForever pins the gate's whole
+// point: the second creation waits for the first and then PROCEEDS. It must not
+// be rejected, because both runs are entitled to their own shadow copy — VSS
+// only serialises the creation interval, not the lifetime of finished snapshot
+// sets.
+func TestSnapshotCreation_SerialisesButDoesNotBlockForever(t *testing.T) {
+	first, err := acquireSnapshotCreation(context.Background())
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	if !snapshotCreationBusy() {
+		t.Error("gate reports idle while held")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		release, err := acquireSnapshotCreation(context.Background())
+		if release != nil {
+			release()
+		}
+		secondDone <- err
+	}()
+
+	// The second acquire must still be waiting while the first is held.
+	select {
+	case err := <-secondDone:
+		t.Fatalf("a second creation was admitted while the first held the gate (err=%v)", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	first()
+
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("the second creation must proceed once the gate frees, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the second creation never acquired the gate after it was released")
+	}
+
+	if snapshotCreationBusy() {
+		t.Error("gate is still held after both releases")
+	}
+}
+
+// TestSnapshotCreation_ContextExpiryDegrades covers the bounded-wait contract.
+// A run that cannot get in before its creation deadline must come back with
+// ErrVSSSessionInProgress so backup.go takes its existing "proceed without VSS"
+// path, rather than hanging for the whole of the other run's creation.
+func TestSnapshotCreation_ContextExpiryDegrades(t *testing.T) {
+	release, err := acquireSnapshotCreation(context.Background())
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer release()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	got, err := acquireSnapshotCreation(ctx)
+	if !errors.Is(err, ErrVSSSessionInProgress) {
+		t.Fatalf("err = %v, want ErrVSSSessionInProgress", err)
+	}
+	if got != nil {
+		t.Error("a failed acquire must not return a release func")
+	}
+}
+
+// TestSnapshotCreation_ReleaseIsIdempotent: a double release would free a slot
+// the caller no longer owns, letting two runs create snapshot sets at once — the
+// exact overlap the gate exists to prevent.
+func TestSnapshotCreation_ReleaseIsIdempotent(t *testing.T) {
+	release, err := acquireSnapshotCreation(context.Background())
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	release()
+	release()
+	release()
+
+	if snapshotCreationBusy() {
+		t.Fatal("gate is held after release")
+	}
+	// And it is still usable, exactly once.
+	second, err := acquireSnapshotCreation(context.Background())
+	if err != nil {
+		t.Fatalf("re-acquire after idempotent release: %v", err)
+	}
+	defer second()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := acquireSnapshotCreation(ctx); !errors.Is(err, ErrVSSSessionInProgress) {
+		t.Fatalf("the gate stopped excluding after an idempotent release: %v", err)
+	}
+}
+
+// TestSnapshotCreation_ConcurrentCallersNeverOverlap is the race-detector case.
+// Real callers arrive from independent IPC command goroutines, and the property
+// that matters is that no two are ever inside the creation interval together.
+func TestSnapshotCreation_ConcurrentCallersNeverOverlap(t *testing.T) {
+	const racers = 24
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		inside  int
+		maxSeen int
+		granted int
+	)
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			release, err := acquireSnapshotCreation(context.Background())
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			inside++
+			if inside > maxSeen {
+				maxSeen = inside
+			}
+			granted++
+			mu.Unlock()
+
+			runtime.Gosched()
+
+			mu.Lock()
+			inside--
+			mu.Unlock()
+			release()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if maxSeen != 1 {
+		t.Fatalf("%d creations were inside the gate at once, want 1", maxSeen)
+	}
+	// Every one of them must eventually get in: waiting is the design, rejection
+	// is not.
+	if granted != racers {
+		t.Fatalf("%d of %d creations were admitted, want all of them", granted, racers)
+	}
+	if snapshotCreationBusy() {
+		t.Error("gate is still held after every caller released")
+	}
+}

--- a/agent/internal/backup/vss/types.go
+++ b/agent/internal/backup/vss/types.go
@@ -16,11 +16,18 @@ var (
 	ErrVSSWriterFailed = errors.New("vss: one or more writers failed")
 	ErrVSSNoVolumes    = errors.New("vss: no volumes specified")
 
-	// ErrVSSSessionInProgress means another VSS session is already live in this
-	// process. Only one may be, because a session now holds a real
-	// IVssBackupComponents open for the whole run (#3269) and a second requester
-	// signalling BackupComplete would move writers out from under the first
-	// run's snapshot.
+	// ErrVSSSessionInProgress means this run could not start creating a snapshot
+	// set because another one was being created. It does NOT mean only one
+	// session may be live at a time: concurrent runs on separate providers each
+	// get their own shadow copy, and only the creation interval is serialised
+	// (#3269 — see snapshotCreationGate for why the scope stops there).
+	//
+	// It is returned in two situations:
+	//   - the caller's context ended while waiting for the process-wide
+	//     creation gate, i.e. another run's snapshot creation outlasted this
+	//     run's creation deadline; and
+	//   - CreateShadowCopy was called on a provider that is already holding a
+	//     live session, which is a caller bug and fails immediately.
 	//
 	// Callers should treat it as "no VSS for this run" and degrade to a live
 	// read with a visible warning, exactly as they do for any other creation
@@ -98,8 +105,14 @@ type Provider interface {
 	//
 	// On Windows the returned session is backed by real COM resources held open
 	// on a dedicated thread, so a successful call MUST be paired with exactly
-	// one ReleaseShadowCopy. Only one session may be live per process; a second
-	// concurrent call fails with ErrVSSSessionInProgress rather than queuing.
+	// one ReleaseShadowCopy.
+	//
+	// Concurrency, precisely: snapshot *creation* is serialised process-wide, so
+	// a call made while another run is creating a snapshot set QUEUES rather
+	// than failing, and then proceeds — two concurrent runs on two providers may
+	// each end up holding their own live session. ErrVSSSessionInProgress means
+	// only that this call gave up: either ctx ended while it was queued, or it
+	// was made on a provider that already holds a live session.
 	CreateShadowCopy(ctx context.Context, volumes []string) (*VSSSession, error)
 
 	// ReleaseShadowCopy ends the session. On Windows it signals BackupComplete

--- a/agent/internal/backup/vss/types.go
+++ b/agent/internal/backup/vss/types.go
@@ -15,6 +15,17 @@ var (
 	ErrVSSTimeout      = errors.New("vss: operation timed out")
 	ErrVSSWriterFailed = errors.New("vss: one or more writers failed")
 	ErrVSSNoVolumes    = errors.New("vss: no volumes specified")
+
+	// ErrVSSSessionInProgress means another VSS session is already live in this
+	// process. Only one may be, because a session now holds a real
+	// IVssBackupComponents open for the whole run (#3269) and a second requester
+	// signalling BackupComplete would move writers out from under the first
+	// run's snapshot.
+	//
+	// Callers should treat it as "no VSS for this run" and degrade to a live
+	// read with a visible warning, exactly as they do for any other creation
+	// failure — not as a reason to retry in a loop.
+	ErrVSSSessionInProgress = errors.New("vss: another shadow copy session is already active in this process")
 )
 
 // WriterStatus describes the state of a single VSS writer.
@@ -82,14 +93,24 @@ func DefaultConfig() Config {
 
 // Provider abstracts VSS operations so callers are platform-agnostic.
 type Provider interface {
-	// CreateShadowCopy creates a VSS snapshot set for the given volumes.
+	// CreateShadowCopy creates a VSS snapshot set for the given volumes and
+	// keeps it alive until ReleaseShadowCopy is called for the same session.
+	//
+	// On Windows the returned session is backed by real COM resources held open
+	// on a dedicated thread, so a successful call MUST be paired with exactly
+	// one ReleaseShadowCopy. Only one session may be live per process; a second
+	// concurrent call fails with ErrVSSSessionInProgress rather than queuing.
 	CreateShadowCopy(ctx context.Context, volumes []string) (*VSSSession, error)
 
-	// ReleaseShadowCopy marks the end of the session. On Windows this does not
-	// delete anything and cannot fail: the shadow copies are non-persistent and
-	// Windows reclaims them when the process exits. Do not read a nil return as
-	// "cleanup was verified" — see the Windows implementation for what it
-	// deliberately does not do.
+	// ReleaseShadowCopy ends the session. On Windows it signals BackupComplete
+	// to the VSS writers and then drops the last reference to the
+	// IVssBackupComponents, which is what allows Windows to reclaim the
+	// auto-release shadow copies. It is idempotent, and it does not fail a
+	// backup: a non-nil return reports that the writer handshake or the session
+	// identity was wrong, never that the caller's data is at risk.
+	//
+	// Not calling it leaks the snapshot and blocks every later session in the
+	// process until a lifetime backstop reclaims it.
 	ReleaseShadowCopy(session *VSSSession) error
 
 	// ListWriters enumerates registered VSS writers and their current state.

--- a/agent/internal/backup/vss/vss_windows.go
+++ b/agent/internal/backup/vss/vss_windows.go
@@ -665,9 +665,19 @@ func (p *WindowsProvider) teardownLocked(live *liveSession) error {
 
 	if completeErr != nil {
 		// Warned, not returned as a failure: the backup is already complete and
-		// its data is already uploaded. What this costs is writer hygiene, and
-		// the caller (backup.go) only logs the error anyway. Surfacing it here
-		// keeps the antecedent for a later VSS_E_SNAPSHOT_SET_IN_PROGRESS.
+		// its data is already uploaded. The snapshot is reclaimed either way —
+		// finishBackupOnThread releases the components object on both branches —
+		// so what this costs is writer hygiene, and it self-heals at process
+		// exit.
+		//
+		// KNOWN GAP, deliberately not closed here: this lands in the agent log
+		// only. Every other VSS anomaly in this package is promoted into
+		// job.Warning so an MSP tech sees it (#3027), but the release runs from
+		// a defer in RunBackupContext after the job is already built, so
+		// plumbing it through means mutating a completed job — not a change
+		// worth making inside a data-loss fix. The consequence of leaving it is
+		// that a writer wedging on EVERY run for one customer is only visible by
+		// pulling raw agent logs, never from the job history.
 		slog.Warn("vss: writer completion handshake failed; writers may remain in "+
 			"VSS_WS_WAITING_FOR_BACKUP_COMPLETE until this process exits",
 			"sessionId", live.id, "error", completeErr.Error())

--- a/agent/internal/backup/vss/vss_windows.go
+++ b/agent/internal/backup/vss/vss_windows.go
@@ -77,6 +77,7 @@ const (
 	vtblGetWriterStatusCount  = 17
 	vtblFreeWriterStatus      = 18
 	vtblGetWriterStatus       = 19
+	vtblSetBackupSucceeded    = 20
 	vtblBackupComplete        = 27
 	vtblStartSnapshotSet      = 36
 	vtblAddToSnapshotSet      = 37
@@ -183,8 +184,66 @@ type vssSnapshotProp struct {
 // WindowsProvider implements the Provider interface using the native VSS COM API.
 type WindowsProvider struct {
 	config Config
-	mu     sync.Mutex
+
+	mu sync.Mutex
+	// live is the session this provider is currently holding COM resources for,
+	// nil between runs. Its presence is what makes the shadow copies survive:
+	// see liveSession.
+	live *liveSession
 }
+
+// liveSession is the COM state that has to outlive CreateShadowCopy.
+//
+// Before #3269 nothing here existed, because CreateShadowCopy released its
+// IVssBackupComponents on the way out. A VSS_CTX_BACKUP shadow copy is
+// auto-release, so that Release is what let the snapshot vanish mid-run
+// (#3260): every field below is here so that it cannot.
+type liveSession struct {
+	// id is the snapshot set ID, matched against the session the caller hands
+	// back to ReleaseShadowCopy.
+	id string
+
+	// thread is the pinned, COM-initialised OS thread that owns bc. Every call
+	// against bc — including its final Release — must be dispatched onto it.
+	thread *serialThread
+
+	// bc is the IVssBackupComponents. It is a raw COM pointer owned by thread;
+	// touching it from any other goroutine is a bug.
+	bc uintptr
+
+	createdAt time.Time
+
+	// staleAlarm logs — and only logs — when a session has been held for
+	// implausibly long. See sessionStaleAfter.
+	staleAlarm *time.Timer
+}
+
+// sessionStaleAfter is how long a session may be held before it is reported as
+// probably leaked. The alarm is NON-DESTRUCTIVE: it writes an ERROR and nothing
+// else.
+//
+// It is tempting to make it force-release, and that would be a bug. There is no
+// elapsed-time signal that distinguishes an abandoned session from a slow but
+// perfectly healthy one: RunBackupContext has no maximum duration, a large
+// dataset over a slow link can legitimately run for many hours, and wall-clock
+// time keeps passing while a laptop is suspended mid-run. A timer that deleted
+// the snapshot on a threshold would therefore delete live snapshots out from
+// under healthy runs — which is #3260, recreated deliberately by the very change
+// meant to fix it.
+//
+// So the backstop for a genuinely leaked session stays what it always was:
+// process exit, at which point the auto-release copies are reclaimed normally.
+// The gate this file serialises is snapshot *creation* only, so a leaked session
+// costs one held snapshot, not the machine's ability to take further ones.
+//
+// A package var so tests can shrink it.
+var sessionStaleAfter = 12 * time.Hour
+
+// backupCompleteTimeout bounds the BackupComplete handshake on the release
+// path. It is much shorter than the provider's snapshot budget on purpose:
+// telling the writers the backup is over is best-effort cleanup, and a single
+// wedged writer must not hold up the end of a run that has already succeeded.
+const backupCompleteTimeout = 60 * time.Second
 
 // NewProvider creates a WindowsProvider.
 func NewProvider(config Config) Provider {
@@ -195,6 +254,26 @@ func NewProvider(config Config) Provider {
 // CreateShadowCopy
 // ---------------------------------------------------------------------------
 
+// CreateShadowCopy creates a VSS snapshot set and KEEPS IT ALIVE until
+// ReleaseShadowCopy is called.
+//
+// The whole requester sequence runs as a single closure on a dedicated,
+// COM-initialised, permanently pinned OS thread (serialThread), and the
+// IVssBackupComponents it produces stays open on that thread for the rest of the
+// run. That is the #3269 fix, and the reason for all the machinery: a
+// VSS_CTX_BACKUP shadow copy is an *auto-release* copy, so Windows is entitled
+// to delete it as soon as the requester drops its last reference. The previous
+// implementation released the interface before returning — on the strength of an
+// in-code claim that reclamation only happened at process exit — and a field run
+// duly lost its shadow copy ~390 seconds in, after which every remaining file
+// failed with ERROR_PATH_NOT_FOUND and was recorded as a per-file fault (#3260).
+//
+// Dispatching the body as ONE closure rather than marshalling each COM call
+// individually is also load-bearing. callVtable is //go:uintptrescapes, and its
+// soundness rests on every uintptr(unsafe.Pointer(&x)) conversion appearing
+// directly in a callVtable(...) argument list; per-call marshalling would have
+// meant building argument values on one goroutine and consuming them on another,
+// which is exactly the pattern the directive cannot protect.
 func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string) (*VSSSession, error) {
 	if len(volumes) == 0 {
 		return nil, ErrVSSNoVolumes
@@ -203,40 +282,124 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	// One provider, one live session. Creating a second would strand the first
+	// one's COM objects with no handle left to release them by.
+	if p.live != nil {
+		return nil, fmt.Errorf("%w: this provider already holds session %s",
+			ErrVSSSessionInProgress, p.live.id)
+	}
+
 	start := time.Now()
 
-	// Lock this goroutine to an OS thread for COM.
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	if err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED); err != nil {
-		// S_FALSE (1) means COM was already initialized on this thread — that's OK.
-		if hr, ok := err.(*ole.OleError); !ok || hr.Code() != sFalse {
-			return nil, fmt.Errorf("vss: CoInitializeEx failed: %w", err)
-		}
+	// Snapshot creation — and only creation — is serialised process-wide, since
+	// the provider mutex cannot see the other ephemeral providers a concurrent
+	// backup_run builds. See snapshotCreationGate for why the scope stops here
+	// rather than covering the whole session.
+	if snapshotCreationBusy() {
+		slog.Info("vss: another run is creating a snapshot set; waiting for it before starting ours")
 	}
-	defer ole.CoUninitialize()
+	releaseCreationGate, err := acquireSnapshotCreation(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: waited %s for another run's snapshot creation",
+			err, time.Since(start).Round(time.Second))
+	}
+	defer releaseCreationGate()
 
-	// --- Create IVssBackupComponents ---
-	backupComponents, err := createBackupComponents()
+	// The COM work lives on this thread, and so does everything created inside
+	// it. It is torn down in exactly two places: the failure path just below,
+	// and ReleaseShadowCopy.
+	thread, err := newSerialThread(coInitializeForVSS, ole.CoUninitialize)
 	if err != nil {
 		return nil, err
 	}
 
-	// The shadow copies created below are non-persistent VSS_CTX_BACKUP copies,
-	// which Windows reclaims when the requester *process* exits — not when this
-	// interface is released. breeze-backup runs one job per process and the
-	// caller only needs the device paths, so releasing here is safe. Verified on
-	// Server 2022: the device stays readable after Release and CoUninitialize
-	// for the life of the process (TestLive_CreateShadowCopy_EndToEnd reads
-	// through it after this function has returned).
-	defer callVtable(backupComponents, vtblRelease) //nolint:errcheck
+	var (
+		session          *VSSSession
+		backupComponents uintptr
+		createErr        error
+	)
+	if dispatchErr := thread.do(func() {
+		session, backupComponents, createErr = p.createShadowCopyOnThread(ctx, volumes)
+	}); dispatchErr != nil {
+		thread.close()
+		return nil, dispatchErr
+	}
+	if createErr != nil {
+		// createShadowCopyOnThread has already released everything it made.
+		thread.close()
+		return nil, createErr
+	}
+
+	p.live = &liveSession{
+		id:        session.ID,
+		thread:    thread,
+		bc:        backupComponents,
+		createdAt: time.Now(),
+	}
+	sessionID := session.ID
+	p.live.staleAlarm = time.AfterFunc(sessionStaleAfter, func() {
+		p.reportStaleSession(sessionID)
+	})
+
+	slog.Info("vss: shadow copy created",
+		"sessionId", session.ID,
+		"volumesRequested", len(volumes),
+		"volumesProtected", len(session.ShadowPaths),
+		"volumesUnprotected", len(session.UnprotectedVolumes),
+		"writers", len(session.Writers),
+		"durationMs", time.Since(start).Milliseconds(),
+	)
+	return session, nil
+}
+
+// coInitializeForVSS initialises the calling thread's COM apartment. Must run on
+// the serialThread.
+func coInitializeForVSS() error {
+	if err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED); err != nil {
+		// S_FALSE (1) means COM was already initialized on this thread — that's OK.
+		if hr, ok := err.(*ole.OleError); !ok || hr.Code() != sFalse {
+			return fmt.Errorf("vss: CoInitializeEx failed: %w", err)
+		}
+	}
+	return nil
+}
+
+// createShadowCopyOnThread runs the VSS requester sequence. It MUST be called on
+// the session's serialThread, which owns the COM apartment.
+//
+// On success it returns the session and a LIVE IVssBackupComponents whose
+// ownership passes to the caller. On failure it releases everything it created
+// and returns a zero components pointer, so the caller never has to decide.
+func (p *WindowsProvider) createShadowCopyOnThread(ctx context.Context, volumes []string) (*VSSSession, uintptr, error) {
+	backupComponents, err := createBackupComponents()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Ownership transfers to the caller only when handoff is set, on the very
+	// last line. Until then every return below tears the components object down
+	// here. This replaced a plain `defer Release`, and the difference is the
+	// entire bug: releasing on the success path is what deleted the auto-release
+	// shadow copy mid-run. Releasing on the *failure* paths is still required —
+	// a stranded IVssBackupComponents would hold the process-wide session slot
+	// with nothing left able to free it.
+	handoff := false
+	metadataGathered := false
+	defer func() {
+		if handoff {
+			return
+		}
+		if metadataGathered {
+			callVtable(backupComponents, vtblFreeWriterMetadata) //nolint:errcheck
+		}
+		callVtable(backupComponents, vtblRelease) //nolint:errcheck
+	}()
 
 	slog.Info("vss: backup components created")
 
 	// InitializeForBackup(bstrXML = NULL)
 	if _, err := callVtable(backupComponents, vtblInitializeForBackup, 0); err != nil {
-		return nil, fmt.Errorf("vss: InitializeForBackup failed: %w", err)
+		return nil, 0, fmt.Errorf("vss: InitializeForBackup failed: %w", err)
 	}
 
 	// SetBackupState(bSelectComponents=false, bBackupBootableSystemState=false,
@@ -244,21 +407,23 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 	if _, err := callVtable(backupComponents, vtblSetBackupState,
 		vssBoolFalse, vssBoolFalse,
 		uintptr(vssBackupTypeCopy), vssBoolFalse); err != nil {
-		return nil, fmt.Errorf("vss: SetBackupState failed: %w", err)
+		return nil, 0, fmt.Errorf("vss: SetBackupState failed: %w", err)
 	}
 
 	// GatherWriterMetadata → IVssAsync
 	var gatherAsync uintptr
 	if _, err := callVtable(backupComponents, vtblGatherWriterMetadata,
 		uintptr(unsafe.Pointer(&gatherAsync))); err != nil {
-		return nil, fmt.Errorf("vss: GatherWriterMetadata failed: %w", err)
+		return nil, 0, fmt.Errorf("vss: GatherWriterMetadata failed: %w", err)
 	}
 	if err := p.waitForAsync(ctx, gatherAsync, "GatherWriterMetadata"); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	// Deferred rather than called at the end: every early return below would
-	// otherwise leak the writer metadata for the rest of the process.
-	defer callVtable(backupComponents, vtblFreeWriterMetadata) //nolint:errcheck
+	// Freed by the handoff defer above on every failure path, and by
+	// ReleaseShadowCopy on the success path. It cannot simply be freed at the
+	// end of this function any more: the writer metadata belongs to the
+	// components object, which now outlives the call.
+	metadataGathered = true
 	slog.Info("vss: writer metadata gathered")
 
 	// StartSnapshotSet must precede AddToSnapshotSet; without it every
@@ -266,7 +431,7 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 	var snapshotSetID windows.GUID
 	if _, err := callVtable(backupComponents, vtblStartSnapshotSet,
 		uintptr(unsafe.Pointer(&snapshotSetID))); err != nil {
-		return nil, fmt.Errorf("vss: StartSnapshotSet failed: %w", err)
+		return nil, 0, fmt.Errorf("vss: StartSnapshotSet failed: %w", err)
 	}
 
 	// Any failure from here on leaves a half-built snapshot set that the
@@ -310,7 +475,7 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 		mountPoint := volumeMountPoint(vol)
 		volUTF16, err := syscall.UTF16PtrFromString(mountPoint)
 		if err != nil {
-			return nil, fmt.Errorf("vss: invalid volume %q: %w", vol, err)
+			return nil, 0, fmt.Errorf("vss: invalid volume %q: %w", vol, err)
 		}
 		var snapID windows.GUID
 		_, callErr := callVtable(backupComponents, vtblAddToSnapshotSet,
@@ -320,7 +485,7 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 		)
 		runtime.KeepAlive(volUTF16)
 		if callErr != nil {
-			return nil, fmt.Errorf("vss: AddToSnapshotSet(%s) failed: %w", mountPoint, callErr)
+			return nil, 0, fmt.Errorf("vss: AddToSnapshotSet(%s) failed: %w", mountPoint, callErr)
 		}
 		entries = append(entries, snapEntry{volume: vol, snapID: snapID})
 		slog.Info("vss: volume added to snapshot set", "volume", vol, "mountPoint", mountPoint)
@@ -330,10 +495,10 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 	var prepareAsync uintptr
 	if _, err := callVtable(backupComponents, vtblPrepareForBackup,
 		uintptr(unsafe.Pointer(&prepareAsync))); err != nil {
-		return nil, fmt.Errorf("vss: PrepareForBackup failed: %w", err)
+		return nil, 0, fmt.Errorf("vss: PrepareForBackup failed: %w", err)
 	}
 	if err := p.waitForAsync(ctx, prepareAsync, "PrepareForBackup"); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	slog.Info("vss: prepare for backup completed")
 
@@ -341,10 +506,10 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 	var doSnapAsync uintptr
 	if _, err := callVtable(backupComponents, vtblDoSnapshotSet,
 		uintptr(unsafe.Pointer(&doSnapAsync))); err != nil {
-		return nil, fmt.Errorf("vss: DoSnapshotSet failed: %w", err)
+		return nil, 0, fmt.Errorf("vss: DoSnapshotSet failed: %w", err)
 	}
 	if err := p.waitForAsync(ctx, doSnapAsync, "DoSnapshotSet"); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	slog.Info("vss: snapshot set created")
 
@@ -401,7 +566,7 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 	// HRESULTs into the error: the caller logs only this string, so dropping
 	// them leaves "VSS silently isn't working" with no diagnostic content.
 	if len(shadowPaths) == 0 {
-		return nil, fmt.Errorf("vss: no shadow copy device paths resolved for %d volume(s): %s",
+		return nil, 0, fmt.Errorf("vss: no shadow copy device paths resolved for %d volume(s): %s",
 			len(entries), strings.Join(warnings, "; "))
 	}
 
@@ -417,39 +582,33 @@ func (p *WindowsProvider) CreateShadowCopy(ctx context.Context, volumes []string
 		CreatedAt:          time.Now().UTC(),
 	}
 
-	slog.Info("vss: shadow copy created",
-		"sessionId", session.ID,
-		"volumesRequested", len(volumes),
-		"volumesProtected", len(shadowPaths),
-		"volumesUnprotected", len(unprotected),
-		"writers", len(writers),
-		"durationMs", time.Since(start).Milliseconds(),
-	)
-
-	return session, nil
+	// The components object — and with it the auto-release shadow copies —
+	// now belongs to the caller, which parks it on the session until
+	// ReleaseShadowCopy. Nothing below this line may fail.
+	handoff = true
+	return session, backupComponents, nil
 }
 
 // ---------------------------------------------------------------------------
 // ReleaseShadowCopy
 // ---------------------------------------------------------------------------
 
-// ReleaseShadowCopy is deliberately a no-op that always returns nil.
+// ReleaseShadowCopy ends the session: it tells the writers the backup is over
+// and then drops the last reference to the IVssBackupComponents, which is what
+// lets Windows reclaim the auto-release shadow copies.
 //
-// The shadow copies CreateShadowCopy makes are non-persistent VSS_CTX_BACKUP
-// copies; Windows reclaims them when the breeze-backup process exits, and that
-// process runs exactly one job. There is nothing left to delete here. What this
-// replaced was worse than nothing: it created a *second* IVssBackupComponents
-// and called BackupComplete on it, which cannot work — that instance has no
-// backup in progress.
+// This used to be a no-op, and the two things it did not do were the two halves
+// of #3269. It did not signal BackupComplete, so every writer stayed parked in
+// VSS_WS_WAITING_FOR_BACKUP_COMPLETE until the process exited; and there was
+// nothing left to release, because CreateShadowCopy had already released the
+// components object on its way out — which is what allowed the snapshot to
+// disappear mid-run (#3260).
 //
-// What it does NOT do: signal BackupComplete to the writers, which are
-// therefore left in VSS_WS_WAITING_FOR_BACKUP_COMPLETE until the process exits.
-// Doing that properly means keeping the IVssBackupComponents alive for the
-// session on a dedicated COM thread, which is a lifetime rewrite of this
-// package rather than part of the #2999 fix. Tracked as a follow-up on #2999.
-//
-// The error return exists only to satisfy the Provider interface; a caller
-// checking it is checking a constant.
+// Everything here is best-effort in the sense that it never fails the backup:
+// the run has already finished by the time this is called, and a writer that
+// will not acknowledge completion is not a reason to fail a good backup. It is
+// NOT best-effort about releasing: the COM objects and the process-wide session
+// slot are freed on every path, including when the handshake fails.
 func (p *WindowsProvider) ReleaseShadowCopy(session *VSSSession) error {
 	if session == nil {
 		// A caller bug rather than a normal state — don't let it vanish.
@@ -460,9 +619,128 @@ func (p *WindowsProvider) ReleaseShadowCopy(session *VSSSession) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	slog.Info("vss: shadow copy released (no-op; writers were not sent BackupComplete)",
-		"sessionId", session.ID)
+	live := p.live
+	if live == nil {
+		// Releasing twice, or releasing a session this provider never created.
+		// Idempotent rather than an error: RunBackupContext's deferred release
+		// is the normal path, and a second call must not manufacture a failure.
+		slog.Warn("vss: ReleaseShadowCopy called with no live session on this provider",
+			"sessionId", session.ID)
+		return nil
+	}
+	if live.id != session.ID {
+		// A foreign session. Tearing our own down to satisfy it would be
+		// strictly worse than refusing: it would delete a snapshot some other
+		// run is still reading through.
+		slog.Error("vss: ReleaseShadowCopy called with a session this provider does not hold; refusing to release",
+			"requestedSessionId", session.ID, "liveSessionId", live.id)
+		return fmt.Errorf("vss: session %s is not the live session (%s)", session.ID, live.id)
+	}
+
+	p.live = nil
+	return p.teardownLocked(live)
+}
+
+// teardownLocked runs the writer handshake and releases every resource the
+// session holds. The caller must hold p.mu and must already have cleared
+// p.live, so that a failure here can never leave a half-released session
+// reachable.
+func (p *WindowsProvider) teardownLocked(live *liveSession) error {
+	if live.staleAlarm != nil {
+		live.staleAlarm.Stop()
+	}
+
+	var completeErr error
+	if dispatchErr := live.thread.do(func() {
+		completeErr = p.finishBackupOnThread(live.bc)
+	}); dispatchErr != nil {
+		completeErr = dispatchErr
+	}
+
+	// Closing the thread runs CoUninitialize on it and then lets it exit while
+	// still locked, so the OS thread is destroyed rather than handed back to the
+	// scheduler carrying our COM state. The snapshot is already gone by this
+	// point: the Release inside finishBackupOnThread is what reclaims it.
+	live.thread.close()
+
+	if completeErr != nil {
+		// Warned, not returned as a failure: the backup is already complete and
+		// its data is already uploaded. What this costs is writer hygiene, and
+		// the caller (backup.go) only logs the error anyway. Surfacing it here
+		// keeps the antecedent for a later VSS_E_SNAPSHOT_SET_IN_PROGRESS.
+		slog.Warn("vss: writer completion handshake failed; writers may remain in "+
+			"VSS_WS_WAITING_FOR_BACKUP_COMPLETE until this process exits",
+			"sessionId", live.id, "error", completeErr.Error())
+	}
+
+	slog.Info("vss: shadow copy released",
+		"sessionId", live.id,
+		"heldMs", time.Since(live.createdAt).Milliseconds(),
+		"writersSignalled", completeErr == nil,
+	)
 	return nil
+}
+
+// finishBackupOnThread performs the writer-completion handshake and releases the
+// components object. It MUST run on the session's serialThread.
+//
+// Note what is NOT called here: SetBackupSucceeded (vtblSetBackupSucceeded).
+// That method marks an individual *component* as backed up, and it is only
+// meaningful for a component-based backup. CreateShadowCopy calls
+// SetBackupState with bSelectComponents=FALSE and never calls AddComponent, so
+// this requester has no components to mark — BackupComplete alone is the
+// complete handshake for a non-component backup. The constant is declared and
+// ABI-pinned anyway (see vss_windows_layout_test.go) so that the day someone
+// adds component selection, the slot number is already checked rather than
+// guessed; guessing a slot is exactly how #2999 shipped.
+func (p *WindowsProvider) finishBackupOnThread(bc uintptr) error {
+	// BackupComplete → IVssAsync. This is the call that moves writers out of
+	// VSS_WS_WAITING_FOR_BACKUP_COMPLETE.
+	var completeAsync uintptr
+	if _, err := callVtable(bc, vtblBackupComplete,
+		uintptr(unsafe.Pointer(&completeAsync))); err != nil {
+		// Still release below — a failed BackupComplete is not a reason to leak
+		// the interface and strand the snapshot.
+		callVtable(bc, vtblFreeWriterMetadata) //nolint:errcheck
+		callVtable(bc, vtblRelease)            //nolint:errcheck
+		return fmt.Errorf("vss: BackupComplete failed: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), backupCompleteTimeout)
+	waitErr := p.waitForAsync(ctx, completeAsync, "BackupComplete")
+	cancel()
+
+	callVtable(bc, vtblFreeWriterMetadata) //nolint:errcheck
+	callVtable(bc, vtblRelease)            //nolint:errcheck
+
+	if waitErr != nil {
+		return waitErr
+	}
+	return nil
+}
+
+// reportStaleSession is the sessionStaleAfter alarm. It REPORTS and does not
+// release: see sessionStaleAfter for why forcing a release on a timer would
+// reintroduce #3260. A run this old is either genuinely leaked or genuinely
+// slow, and nothing here can tell which — so it makes the condition visible and
+// leaves the decision to a human.
+func (p *WindowsProvider) reportStaleSession(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	live := p.live
+	// Re-checked under the lock: a normal release racing the timer clears
+	// p.live first, and this must then say nothing at all.
+	if live == nil || live.id != id {
+		return
+	}
+	slog.Error("vss: shadow copy session has been held for an implausibly long time and may have been leaked; "+
+		"it is NOT being released automatically (doing so would delete a snapshot a slow run may still be reading). "+
+		"The copies will be reclaimed when this process exits",
+		"sessionId", id,
+		"heldMs", time.Since(live.createdAt).Milliseconds(),
+		"staleAfter", sessionStaleAfter.String(),
+	)
 }
 
 // ---------------------------------------------------------------------------

--- a/agent/internal/backup/vss/vss_windows_layout_test.go
+++ b/agent/internal/backup/vss/vss_windows_layout_test.go
@@ -116,6 +116,7 @@ func TestVtableIndices_MatchHeaderOrder(t *testing.T) {
 		"GetWriterStatusCount":  vtblGetWriterStatusCount,
 		"FreeWriterStatus":      vtblFreeWriterStatus,
 		"GetWriterStatus":       vtblGetWriterStatus,
+		"SetBackupSucceeded":    vtblSetBackupSucceeded,
 		"BackupComplete":        vtblBackupComplete,
 		"StartSnapshotSet":      vtblStartSnapshotSet,
 		"AddToSnapshotSet":      vtblAddToSnapshotSet,
@@ -135,6 +136,50 @@ func TestVtableIndices_MatchHeaderOrder(t *testing.T) {
 	// The specific mis-mapping that caused #2999.
 	if vtblInitializeForBackup == index["GetWriterComponentsCount"] {
 		t.Error("InitializeForBackup is mapped to GetWriterComponentsCount — this is bug #2999")
+	}
+}
+
+// TestBackupCompleteSlotIsDistinctFromNeighbours guards the release-path
+// handshake added for #3269. BackupComplete is the call that moves writers out
+// of VSS_WS_WAITING_FOR_BACKUP_COMPLETE, and it now runs against a components
+// object that has a real snapshot open — so calling the wrong slot would not
+// merely be inert (the #2999 failure mode), it would operate on a live backup.
+//
+// SaveAsXML (26) takes a BSTR* and BackupComplete (27) takes an IVssAsync**;
+// both are one pointer-sized argument, so an off-by-one here type-checks, links,
+// and silently does the wrong thing.
+func TestBackupCompleteSlotIsDistinctFromNeighbours(t *testing.T) {
+	if vtblBackupComplete != 27 {
+		t.Errorf("IVssBackupComponents::BackupComplete = %d, want 27", vtblBackupComplete)
+	}
+	const saveAsXML, addAlternativeLocationMapping = 26, 28
+	if vtblBackupComplete == saveAsXML {
+		t.Error("BackupComplete is mapped to SaveAsXML — the writers would never be told the backup finished")
+	}
+	if vtblBackupComplete == addAlternativeLocationMapping {
+		t.Error("BackupComplete is mapped to AddAlternativeLocationMapping")
+	}
+}
+
+// TestSetBackupSucceededSlotIsPinned records the slot for a method the provider
+// deliberately does NOT call.
+//
+// CreateShadowCopy sets bSelectComponents=FALSE and never calls AddComponent, so
+// there are no components to mark and BackupComplete alone is the whole
+// handshake (see finishBackupOnThread). The constant exists so that whoever adds
+// component selection later inherits a checked slot number instead of counting
+// header lines by hand — which is the exact mistake that shipped #2999. It also
+// pins the adjacency that makes a miscount dangerous: 19 and 21 both take
+// arguments a wrong call would accept.
+func TestSetBackupSucceededSlotIsPinned(t *testing.T) {
+	if vtblSetBackupSucceeded != 20 {
+		t.Errorf("IVssBackupComponents::SetBackupSucceeded = %d, want 20", vtblSetBackupSucceeded)
+	}
+	if vtblSetBackupSucceeded == vtblGetWriterStatus {
+		t.Error("SetBackupSucceeded collides with GetWriterStatus (19)")
+	}
+	if vtblSetBackupSucceeded == vtblBackupComplete {
+		t.Error("SetBackupSucceeded collides with BackupComplete (27)")
 	}
 }
 

--- a/agent/internal/backup/vss/vss_windows_live_test.go
+++ b/agent/internal/backup/vss/vss_windows_live_test.go
@@ -4,9 +4,11 @@ package vss
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +49,17 @@ func systemVolume(t *testing.T) string {
 
 // TestLive_CreateShadowCopy_EndToEnd is the regression test for #2999. Before
 // the fix, this failed at InitializeForBackup with HRESULT 0x80070057.
+//
+// Its central assertion was INVERTED by #3269. It used to prove that the shadow
+// device survived CreateShadowCopy's own Release + CoUninitialize, on the theory
+// that a VSS_CTX_BACKUP copy is only reclaimed at requester process exit. That
+// theory was wrong — the copies are auto-release — and the test could not have
+// caught it: it read through the device seconds after the Release, and deletion
+// of an auto-release copy is not synchronous with it. Now the session HOLDS its
+// IVssBackupComponents, so what this checks is that the device is readable while
+// the session is held, and that the session releases cleanly afterwards. The
+// multi-minute hold that the old assertion could never have covered lives in
+// TestLive_ShadowCopySurvivesALongHold.
 func TestLive_CreateShadowCopy_EndToEnd(t *testing.T) {
 	requireLiveVSS(t)
 
@@ -60,7 +73,12 @@ func TestLive_CreateShadowCopy_EndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateShadowCopy(%q) failed: %v", vol, err)
 	}
-	defer p.ReleaseShadowCopy(session) //nolint:errcheck
+	released := false
+	defer func() {
+		if !released {
+			p.ReleaseShadowCopy(session) //nolint:errcheck
+		}
+	}()
 
 	if session.ID == "" {
 		t.Error("session ID is empty")
@@ -88,12 +106,11 @@ func TestLive_CreateShadowCopy_EndToEnd(t *testing.T) {
 		t.Errorf("expected no unprotected volumes, got %v", session.UnprotectedVolumes)
 	}
 
-	// The shadow copy must outlive CreateShadowCopy's own Release +
-	// CoUninitialize + UnlockOSThread. A reviewer read the VSS docs as meaning
-	// the device dies with the IVssBackupComponents object, which would make the
-	// whole snapshot useless to the caller; these copies are auto-release, which
-	// on Windows means reclaimed at requester *process* exit. Sleep and force a
-	// GC first so this is not passing on a timing accident.
+	// The shadow copy must be readable while the session is held. The GC and the
+	// sleep are kept because they still rule out a timing accident, but the claim
+	// they support is now the correct one: the device survives because this
+	// process is still holding a reference to the IVssBackupComponents, NOT
+	// because Windows defers reclamation to process exit.
 	runtime.GC()
 	time.Sleep(5 * time.Second)
 
@@ -133,6 +150,199 @@ func TestLive_CreateShadowCopy_EndToEnd(t *testing.T) {
 
 	t.Logf("shadow copy %s -> %s (%d entries under \\Windows, %d writers)",
 		vol, shadow, len(entries), len(session.Writers))
+
+	// Release must succeed and must be idempotent — RunBackupContext's deferred
+	// release is the only caller, but a double release must never manufacture a
+	// failure on a run that has already finished.
+	if err := p.ReleaseShadowCopy(session); err != nil {
+		t.Errorf("ReleaseShadowCopy: %v", err)
+	}
+	released = true
+	if err := p.ReleaseShadowCopy(session); err != nil {
+		t.Errorf("second ReleaseShadowCopy should be a no-op, got %v", err)
+	}
+
+	// The provider must be reusable after a release. If p.live were left set,
+	// every later run on this manager would fail to get a shadow copy and
+	// silently degrade to a live read.
+	second, err := p.CreateShadowCopy(ctx, []string{vol})
+	if err != nil {
+		t.Fatalf("a new session could not be created after release (the provider leaked its live session): %v", err)
+	}
+	if err := p.ReleaseShadowCopy(second); err != nil {
+		t.Errorf("releasing the second session: %v", err)
+	}
+
+	// Writers should have been signalled. This is reported rather than asserted:
+	// BackupComplete is best-effort by design, and a machine with a
+	// non-conforming third-party writer must not turn a green backup red here.
+	// The log line is what a human checks when verifying #3269 by hand.
+	writers, err := p.ListWriters(ctx)
+	if err != nil {
+		t.Logf("post-release ListWriters failed (not fatal): %v", err)
+		return
+	}
+	waiting := 0
+	for _, w := range writers {
+		if w.State == "waiting" {
+			waiting++
+			t.Logf("writer %q (%s) is still %q after BackupComplete", w.Name, w.ID, w.State)
+		}
+	}
+	t.Logf("post-release writer states: %d writers, %d still waiting", len(writers), waiting)
+}
+
+// TestLive_ShadowCopySurvivesALongHold is THE regression test for #3269, and the
+// one the old suite structurally could not contain.
+//
+// The field failure (#3260) was a shadow copy that stopped resolving roughly 390
+// seconds into a run while the process was still alive. Every previous live test
+// read through the device within seconds of creating it, which proves nothing
+// about an auto-release copy: Windows deletes those when the requester drops its
+// references, and that deletion is not synchronous with the Release. So the only
+// honest test is a long one — hold the session, and keep reading through the
+// device for longer than the window in which the field failure appeared.
+//
+// Default hold is 8 minutes (comfortably past the observed ~390s). Override with
+// BREEZE_VSS_HOLD_SECONDS. Run it against a build WITHOUT the fix and it should
+// fail; that is the point.
+func TestLive_ShadowCopySurvivesALongHold(t *testing.T) {
+	requireLiveVSS(t)
+
+	hold := 8 * time.Minute
+	if raw := os.Getenv("BREEZE_VSS_HOLD_SECONDS"); raw != "" {
+		secs, err := strconv.Atoi(raw)
+		if err != nil || secs <= 0 {
+			t.Fatalf("BREEZE_VSS_HOLD_SECONDS=%q must be a positive integer", raw)
+		}
+		hold = time.Duration(secs) * time.Second
+	}
+
+	vol := systemVolume(t)
+	p := NewProvider(DefaultConfig())
+
+	ctx, cancel := context.WithTimeout(context.Background(), hold+10*time.Minute)
+	defer cancel()
+
+	session, err := p.CreateShadowCopy(ctx, []string{vol})
+	if err != nil {
+		t.Fatalf("CreateShadowCopy(%q) failed: %v", vol, err)
+	}
+	defer p.ReleaseShadowCopy(session) //nolint:errcheck
+
+	shadow, ok := session.ShadowPaths[vol]
+	if !ok {
+		t.Fatalf("no shadow path for %q", vol)
+	}
+	shadowWindows := shadow + `\Windows`
+
+	// Drop every Go-side reference we can and force a collection, so a copy that
+	// only survives because something is incidentally pinned is not mistaken for
+	// one the session is deliberately holding.
+	runtime.GC()
+
+	const probeInterval = 30 * time.Second
+	deadline := time.Now().Add(hold)
+	probes := 0
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		sleep := probeInterval
+		if remaining < sleep {
+			sleep = remaining
+		}
+		time.Sleep(sleep)
+		probes++
+
+		elapsed := time.Since(session.CreatedAt)
+		if _, err := os.Stat(shadow + `\`); err != nil {
+			t.Fatalf("shadow root %q stopped resolving after %s (probe %d): %v — "+
+				"this is #3269: the auto-release copy was reclaimed while the run was still in progress",
+				shadow, elapsed.Round(time.Second), probes, err)
+		}
+		entries, err := os.ReadDir(shadowWindows)
+		if err != nil {
+			t.Fatalf("reading %q through the shadow copy failed after %s (probe %d): %v — this is #3269",
+				shadowWindows, elapsed.Round(time.Second), probes, err)
+		}
+		if len(entries) == 0 {
+			t.Fatalf("%q read empty through the shadow copy after %s (probe %d)",
+				shadowWindows, elapsed.Round(time.Second), probes)
+		}
+		t.Logf("t+%s: shadow copy still readable (%d entries)", elapsed.Round(time.Second), len(entries))
+	}
+	t.Logf("shadow copy survived a %s hold across %d probes", hold, probes)
+}
+
+// TestLive_ConcurrentSessionsCoexist pins the scope of the creation gate on real
+// COM, which is the part of #3269 most likely to be got wrong in a later change.
+//
+// Two concurrent backup_run commands each build their own ephemeral
+// BackupManager and their own provider. Both are entitled to a shadow copy: VSS
+// serialises the creation interval (StartSnapshotSet → DoSnapshotSet), not the
+// lifetime of finished snapshot sets. So the second creation may queue behind the
+// first, but it must SUCCEED — and, critically, releasing either session must
+// not disturb the other's device. A gate that covered the whole session would
+// instead silently downgrade one of the two runs to a live read.
+func TestLive_ConcurrentSessionsCoexist(t *testing.T) {
+	requireLiveVSS(t)
+
+	vol := systemVolume(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	first := NewProvider(DefaultConfig())
+	firstSession, err := first.CreateShadowCopy(ctx, []string{vol})
+	if err != nil {
+		t.Fatalf("first CreateShadowCopy failed: %v", err)
+	}
+	defer first.ReleaseShadowCopy(firstSession) //nolint:errcheck
+
+	// The same provider must refuse a second session: it has exactly one slot to
+	// park the components object in, so a second would strand the first's COM
+	// objects with no handle left to release them by.
+	if _, err := first.CreateShadowCopy(ctx, []string{vol}); !errors.Is(err, ErrVSSSessionInProgress) {
+		t.Errorf("same-provider second CreateShadowCopy = %v, want ErrVSSSessionInProgress", err)
+	}
+
+	// A DIFFERENT provider, as a concurrent ephemeral BackupManager would build,
+	// must get its own snapshot.
+	second := NewProvider(DefaultConfig())
+	secondSession, err := second.CreateShadowCopy(ctx, []string{vol})
+	if err != nil {
+		t.Fatalf("a second concurrent provider must still get its own shadow copy, got %v", err)
+	}
+	defer second.ReleaseShadowCopy(secondSession) //nolint:errcheck
+
+	if firstSession.ID == secondSession.ID {
+		t.Errorf("both providers reported the same snapshot set ID %q", firstSession.ID)
+	}
+	firstShadow := firstSession.ShadowPaths[vol]
+	secondShadow := secondSession.ShadowPaths[vol]
+	if firstShadow == "" || secondShadow == "" {
+		t.Fatalf("missing shadow path (first=%q second=%q)", firstShadow, secondShadow)
+	}
+	if firstShadow == secondShadow {
+		t.Errorf("both sessions resolved the same shadow device %q", firstShadow)
+	}
+
+	// ListWriters must stay usable while sessions are held: it is call-scoped,
+	// creates no snapshot, and the vss_writer_list IPC command polls it
+	// independently of any running backup.
+	if _, err := second.ListWriters(ctx); err != nil {
+		t.Errorf("ListWriters during a held session: %v", err)
+	}
+
+	// Releasing one must NOT take the other's device with it.
+	if err := second.ReleaseShadowCopy(secondSession); err != nil {
+		t.Errorf("releasing the second session: %v", err)
+	}
+	if _, err := os.ReadDir(firstShadow + `\Windows`); err != nil {
+		t.Fatalf("the first session's shadow copy became unreadable after the SECOND was released: %v", err)
+	}
+	t.Logf("two concurrent sessions coexisted: %s and %s", firstShadow, secondShadow)
 }
 
 // TestLive_ShadowCopyReadsExclusivelyLockedFile is the reason #2999 matters:

--- a/agent/internal/backup/vss_provider_seam_test.go
+++ b/agent/internal/backup/vss_provider_seam_test.go
@@ -320,6 +320,57 @@ func TestRunBackupContext_VSSProviderReturningNoSessionDoesNotPanic(t *testing.T
 	}
 }
 
+// TestRunBackupContext_ConcurrentSessionRejectionDegradesToLiveRead pins what a
+// run does when it gives up waiting for the process-wide snapshot-creation gate
+// (#3269): it backs the data up from the live volume and says so, loudly.
+//
+// It matters because that gate is new. breeze-backup dispatches every IPC command
+// in its own goroutine and builds an ephemeral BackupManager per
+// server-dispatched backup_run, so overlapping runs are ordinary, not exotic.
+// They normally all get a shadow copy — creation is merely queued — but a run
+// whose creation deadline expires while it waits comes back with
+// ErrVSSSessionInProgress, and it must NOT fail: a live-read backup is worth
+// vastly more than no backup. It must also not be silent, or it becomes #3027 (a
+// run indistinguishable from a clean VSS-backed backup while every locked file
+// was skipped).
+func TestRunBackupContext_ConcurrentSessionRejectionDegradesToLiveRead(t *testing.T) {
+	srcDir := t.TempDir()
+	createTempFile(t, srcDir, "a.txt", "alpha")
+
+	vssProvider := &fakeVSSProvider{createErr: vss.ErrVSSSessionInProgress}
+
+	mgr := NewBackupManager(BackupConfig{
+		Provider:    newMockProvider(),
+		Paths:       []string{srcDir},
+		VSSEnabled:  true,
+		VSSProvider: vssProvider,
+		StagingDir:  t.TempDir(),
+	})
+
+	job, err := mgr.RunBackupContext(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("losing the VSS session race must not fail the run, got %v", err)
+	}
+	if job.Status != jobStatusCompleted {
+		t.Errorf("job.Status = %q, want %q", job.Status, jobStatusCompleted)
+	}
+	if job.Snapshot == nil || len(job.Snapshot.Files) != 1 {
+		t.Errorf("the file must still be backed up from the live volume, got %+v", job.Snapshot)
+	}
+	if job.Warning == "" {
+		t.Error("a live-read run must carry a warning saying so; an unwarned one is #3027")
+	}
+	if job.VSSMetadata != nil {
+		t.Errorf("no session means no VSS metadata, got %+v", job.VSSMetadata)
+	}
+	// Nothing was created, so nothing may be released — releasing a session the
+	// provider never handed out is how the real provider would tear down another
+	// run's live snapshot.
+	if create, release := vssProvider.counts(); create != 1 || release != 0 {
+		t.Errorf("createCalls=%d releaseCalls=%d, want 1 and 0", create, release)
+	}
+}
+
 // TestResolveVSSProvider pins the resolution matrix itself, including the one
 // judgement call in it: an injected provider overrides the runtime.GOOS gate,
 // because that gate is about the built-in provider being a stub off Windows,


### PR DESCRIPTION
Fixes #3269
Context: #3260, #2999

## The bug

`CreateShadowCopy` released its `IVssBackupComponents` before returning, justified by an in-code comment claiming that a `VSS_CTX_BACKUP` shadow copy is reclaimed only when the requester **process** exits. Microsoft documents the opposite: `VSS_CTX_BACKUP` is an **auto-release** context, and auto-release copies are deleted when the requester drops its references.

That is the likely true cause of #3260 — a shadow device that stopped resolving ~390s into a live run, after which every remaining healthy file failed with `ERROR_PATH_NOT_FOUND` and was recorded as an individual per-file fault. PR #3266 added the mid-run abort that stops the misattribution; this PR removes the cause.

The old live test could never have caught it. It read through the device seconds after the Release, and deletion of an auto-release copy is not synchronous with it.

Second symptom, same root cause: `ReleaseShadowCopy` was a no-op that never called `BackupComplete`, leaving VSS writers parked in `VSS_WS_WAITING_FOR_BACKUP_COMPLETE` until the process exited (already noted in-code as a #2999 follow-up).

## The fix

The whole requester sequence now runs as a **single closure on a dedicated, COM-initialised, permanently pinned OS thread**, and the components object stays open on that thread until `ReleaseShadowCopy`, which signals `BackupComplete` to the writers before dropping the last reference.

**One closure, not per-call marshalling.** `callVtable` is `//go:uintptrescapes`, and its soundness requires every `uintptr(unsafe.Pointer(&x))` conversion to appear directly in a `callVtable(...)` argument list. Marshalling per COM call would have meant building argument values on one goroutine and consuming them on another — exactly the pattern the directive cannot protect. The single closure is also a near-zero-diff transformation of proven code.

**Thread discipline.** `runtime.LockOSThread` for the thread's whole life, never unlocked, so the goroutine's exit destroys the OS thread rather than returning it to the scheduler carrying our COM state. `CoInitializeEx(0, COINIT_MULTITHREADED)` once; `CoUninitialize` once at teardown — and only when init actually succeeded (`S_FALSE` still owes an uninitialize; `RPC_E_CHANGED_MODE` must not get one).

## Two design calls worth reading

Both were settled by an advisor quorum (independent read-only Codex review), and **both moved off my first position**:

**1. Snapshot creation is gated process-wide; sessions are not.** My first design gated the whole session. That would have been a user-visible regression: `breeze-backup` dispatches every IPC command in its own goroutine and builds an ephemeral `BackupManager` per server-dispatched `backup_run`, so overlapping runs are routine — and a session-wide gate would silently downgrade one of two concurrent runs to a live read for the entire duration of the other. What VSS actually serialises is the creation interval (`StartSnapshotSet` → `DoSnapshotSet`); it does not require that only one finished snapshot set be alive. So creation queues (bounded by the caller's creation context, since Microsoft's documented response to `VSS_E_SNAPSHOT_SET_IN_PROGRESS` is wait-and-retry), and both runs still get their own shadow copy. A run that gives up waiting returns `ErrVSSSessionInProgress` and takes the existing "proceed without VSS" path with a server-visible warning.

**2. No destructive lifetime watchdog.** My first design force-released a session after 24h to stop a forgotten release from wedging things. That is dangerous: `RunBackupContext` has no maximum duration, a large dataset over a slow link can legitimately run for many hours, and wall-clock time keeps passing while a laptop is suspended mid-run. A timer that deleted the snapshot on a threshold would delete live snapshots out from under healthy runs — **#3260, recreated deliberately by the change meant to fix it.** A stale session is now reported at ERROR and left alone; process exit remains the backstop. Narrowing the gate (call 1) is what makes that affordable: a leaked session costs one held snapshot, not the machine's ability to take further ones.

**`SetBackupSucceeded`** (slot 20) is declared and ABI-pinned but deliberately **not called**: the requester sets `bSelectComponents=FALSE` and never calls `AddComponent`, so there are no components to mark and `BackupComplete` alone is the complete handshake for a non-component backup. The constant exists so a later change inherits a checked slot number instead of counting header lines — guessing a slot is exactly how #2999 shipped.

**`ListWriters`** stays call-scoped with its own COM cycle. It creates no snapshot, and `exec_backup.go`'s `vss_status`/`vss_writer_list` commands poll it independently of any running backup — coupling it to the session thread would have made it fail whenever a backup was in flight.

## Comments corrected in the same PR

The false process-exit claim in `CreateShadowCopy`, the `ReleaseShadowCopy` design note, the `Provider` interface doc in `types.go`, and the `#3269` reference in `source_liveness.go` (the mid-run liveness probe **stays** — three of its four possible causes are unfixed and outside our control, so it remains as defence in depth).

## Tests

The lifetime machinery (`serialThread`, the creation gate) is deliberately **untagged**, so it runs under `go test -race` on every platform and in the linux CI job. The Windows CI job runs this package *without* the race detector, so tagging it would have left the concurrency untested by any detector anywhere.

Added:
- `TestSerialThread_RunsEveryCallOnOneLockedThread`, `TestSerialThread_TeardownRunsOnceOnTheSameThread`, `TestSerialThread_InitFailureStartsNothing`, `TestSerialThread_DoAfterCloseReports`, `TestSerialThread_SerialisesConcurrentCallers`
- `TestSnapshotCreation_SerialisesButDoesNotBlockForever`, `TestSnapshotCreation_ContextExpiryDegrades`, `TestSnapshotCreation_ReleaseIsIdempotent`, `TestSnapshotCreation_ConcurrentCallersNeverOverlap`
- `TestBackupCompleteSlotIsDistinctFromNeighbours`, `TestSetBackupSucceededSlotIsPinned` (windows-tagged ABI pins; these DO run in Windows CI via the unfiltered `go test ./internal/backup/vss`)
- `TestRunBackupContext_ConcurrentSessionRejectionDegradesToLiveRead` (the degrade path stays a completed, warned, live-read backup — never a failure, never silent)
- `TestLive_ShadowCopySurvivesALongHold`, `TestLive_ConcurrentSessionsCoexist` (live suite)

**Mutation-checked**, the way #3280 did:
- `do()` bypassing the pinned thread → 3 tests red
- creation gate not serialising → 4 tests red
- (both restored green)

`TestLive_CreateShadowCopy_EndToEnd`'s central assertion is **inverted**: it used to prove the device survived `CreateShadowCopy`'s own Release, which was the wrong claim and unfalsifiable at that timescale. It now proves the device is readable while the session is held, that release is idempotent, and that the provider is reusable afterwards.

**No CI filter changes needed.** The `-run` regex + exactly-14-PASS assertion in `ci.yml` covers `./internal/backup`; no existing test was renamed, and the one test added there (`TestRunBackupContext_...`) does not match any filtered prefix, so the count is unchanged.

## Verification

- `cd agent && go test -race ./...` — green (full suite)
- `GOOS=windows go build ./...` and `GOOS=windows go vet ./...` — clean (the 3 `possible misuse of unsafe.Pointer` notes are pre-existing, inside `callVtable` and `utf16PtrToString`)
- `gofmt` clean

**Real-Windows verification is REQUIRED and still PENDING.** The COM call sequence cannot be faked, so nothing above proves the fix on real hardware. On an elevated shell on a Windows host:

```
set BREEZE_VSS_LIVE=1
go test ./internal/backup/vss/ -run Live -v -timeout 40m
```

`TestLive_ShadowCopySurvivesALongHold` is the #3269 regression guard: it holds the session for 8 minutes (past the ~390s at which the field failure appeared), probing the shadow path every 30s. Override with `BREEZE_VSS_HOLD_SECONDS`. **It should FAIL on a build without this change** — that is how to confirm the diagnosis, not just the fix. `TestLive_ConcurrentSessionsCoexist` checks that releasing one session does not take another's device with it.

Please hold merge until that live run is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)