### PR TITLE
docs(api): X-API-Key authenticates only MCP, dev-push, and device custom-field surfaces (#3247)

### DIFF
--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -14,10 +14,14 @@ Breeze is a fast, modern Remote Monitoring and Management (RMM) platform for MSP
 
 ## Authentication
 
-The API supports two authentication methods:
-
-- **Bearer Token (JWT)**: Include the token in the \`Authorization\` header as \`Bearer <token>\`
-- **API Key**: Include the API key in the \`X-API-Key\` header
+- **Bearer Token (JWT)**: Include the token in the \`Authorization\` header as \`Bearer <token>\`.
+  This is the credential for the endpoints documented here; tenancy-mutating writes additionally
+  require the session to have completed MFA.
+- **API Key (\`X-API-Key\`)**: organization API keys (\`brz_…\`) are **not** general-purpose API
+  auth. They authenticate exactly three surfaces: \`POST /mcp/*\`, \`POST /dev/push\`, and
+  \`GET\`/\`PATCH /devices/{id}/custom-fields\`. Every other endpoint rejects them with 401.
+- **Partner service-principal key (\`brz_sp_…\`, also via \`X-API-Key\`)**: the machine-to-machine
+  credential for the \`/partner-api/*\` export and provisioning surface (not documented in this spec).
 
 ## Multi-Tenant Architecture
 
@@ -81,7 +85,11 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
         type: 'apiKey',
         in: 'header',
         name: 'X-API-Key',
-        description: 'API key for service-to-service authentication'
+        description:
+          'Organization API key (brz_…). Only valid on POST /mcp/*, POST /dev/push, and ' +
+          'GET/PATCH /devices/{id}/custom-fields — all other endpoints reject it with 401. ' +
+          'For machine-to-machine access use a partner service-principal key (brz_sp_…) ' +
+          'against the /partner-api/* surface.'
       }
     },
     schemas: {
@@ -834,9 +842,12 @@ API requests are rate-limited to ensure fair usage. Rate limit headers are inclu
       }
     }
   },
+  // Global security is JWT-only: organization API keys (apiKeyAuth) authenticate only the
+  // three surfaces named in the scheme description, so advertising apiKeyAuth globally
+  // would be wrong for every documented path. Paths that accept a brz_ key declare it
+  // in their own per-operation `security` array.
   security: [
-    { bearerAuth: [] },
-    { apiKeyAuth: [] }
+    { bearerAuth: [] }
   ],
   paths: {
     // ============================================

--- a/apps/docs/src/content/docs/reference/api-keys.mdx
+++ b/apps/docs/src/content/docs/reference/api-keys.mdx
@@ -10,7 +10,7 @@ import { Steps, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 Breeze RMM provides two distinct key types for different purposes:
 
-- **API Keys** grant programmatic access to the REST API for automation, integrations, and scripting.
+- **API Keys** grant programmatic access to a small set of integration surfaces (the MCP server, the dev-push endpoint, and device custom-field values -- see [Where API Keys Work](#where-api-keys-work)).
 - **Enrollment Keys** are short-lived tokens used to onboard new agents into a specific organization and (optionally) site.
 
 Both key types are organization-scoped and require appropriate permissions to manage.
@@ -19,7 +19,7 @@ Both key types are organization-scoped and require appropriate permissions to ma
 
 ## API Keys
 
-API keys allow external systems to authenticate against the Breeze API without a user session. Each key is tied to a single organization and can be scoped to restrict which operations it may perform.
+API keys allow external systems to authenticate against specific Breeze API surfaces without a user session. Each key is tied to a single organization and can be scoped to restrict which operations it may perform. They are **not** accepted by the general REST API -- see [Where API Keys Work](#where-api-keys-work) for the exact surfaces, and the [Partner API](/reference/api/#partner-api-service-principals) for broad machine-to-machine access.
 
 ### Key Format
 
@@ -87,11 +87,14 @@ Scopes can be updated after creation via the `PATCH` endpoint without rotating t
 
 ### Authentication Flow
 
-To authenticate with an API key, include it in the `X-API-Key` header:
+To authenticate with an API key, include it in the `X-API-Key` header. Note
+that `brz_` keys only authenticate the surfaces listed under
+[Where API keys work](#where-api-keys-work) — for example, reading a device's
+custom-field values:
 
 ```bash
 curl -H "X-API-Key: brz_aBcDeFgHiJkLmNoPqRsTuVwXyZ012" \
-  https://breeze.yourdomain.com/api/v1/devices
+  https://breeze.yourdomain.com/api/v1/devices/DEVICE_UUID/custom-fields
 ```
 
 The middleware performs these steps in order:
@@ -116,9 +119,26 @@ The middleware performs these steps in order:
 | `X-RateLimit-Reset` | Unix timestamp when the window resets. |
 | `Retry-After` | Seconds until the rate limit resets (only on 429 responses). |
 
+### Where API Keys Work
+
+A `brz_` API key is **not** a general-purpose credential for the REST API —
+most endpoints reject it with `401` and require a user JWT. It authenticates
+exactly three surfaces:
+
+| Surface | Method(s) | Required key scope |
+|---------|-----------|--------------------|
+| `/mcp/*` ([MCP server](/features/mcp-server/)) | `POST` | per-tool |
+| `/dev/push` (development push endpoint) | `POST` | -- |
+| `/devices/:id/custom-fields` | `GET` / `PATCH` | `devices:read` / `devices:write` |
+
+For scripted machine-to-machine access to tenancy data (device exports,
+provisioning, migrations), use the [Partner API](/reference/api/#partner-api-service-principals)
+with a partner service-principal key (`brz_sp_…`) instead — see
+[Partner Service Principal Scopes](#partner-service-principal-scopes) below.
+
 ### Dual Authentication
 
-Some endpoints accept either a JWT bearer token or an API key. When both headers are present, the API key takes precedence: the route handler checks for `X-API-Key` first and authenticates via `apiKeyAuthMiddleware`, falling back to `authMiddleware` only when that header is absent.
+The device custom-field-value endpoints accept either a JWT bearer token or an API key. When both headers are present, the API key takes precedence: the route handler checks for `X-API-Key` first and authenticates via `apiKeyAuthMiddleware`, falling back to `authMiddleware` only when that header is absent.
 
 ### Key Rotation
 

--- a/apps/docs/src/content/docs/reference/api.mdx
+++ b/apps/docs/src/content/docs/reference/api.mdx
@@ -23,11 +23,31 @@ curl -H "Authorization: Bearer $TOKEN" \
   https://breeze.yourdomain.com/api/v1/devices
 ```
 
-API keys can also be used via the `X-API-Key` header:
+Tenancy-mutating writes made with a JWT are additionally gated by MFA — the
+session must have completed an MFA challenge, which makes user JWTs a poor fit
+for unattended scripts.
+
+<Aside type="caution" title="X-API-Key is not general-purpose auth">
+  Organization API keys (`brz_…`, sent via the `X-API-Key` header) do **not**
+  authenticate the general REST API. `curl -H "X-API-Key: brz_..." …/devices`
+  returns `401`. A `brz_` key authenticates exactly three surfaces:
+
+  - `POST /mcp/*` — the [MCP server](/features/mcp-server/) for AI integrations
+  - `POST /dev/push` — the development push endpoint
+  - `GET`/`PATCH /devices/:id/custom-fields` — device custom-field values
+    (these accept either a JWT or a `brz_` key)
+
+  Everything else rejects `X-API-Key` with a `brz_` key and requires a JWT.
+</Aside>
+
+For **machine-to-machine integrations** (exports, migration scripts, unattended
+provisioning), use the [Partner API](#partner-api-service-principals) with a
+**partner service-principal key** (`brz_sp_…`) — a distinct credential class,
+also sent via `X-API-Key`, that is not MFA-gated because no human is involved:
 
 ```bash
-curl -H "X-API-Key: brz_..." \
-  https://breeze.yourdomain.com/api/v1/devices
+curl -H "X-API-Key: brz_sp_..." \
+  https://breeze.yourdomain.com/api/v1/partner-api/devices
 ```
 
 ### Login


### PR DESCRIPTION
Fixes #3247

## Problem

The API docs presented `X-API-Key` (`brz_` organization API keys) as general-purpose REST auth, with a curl example against `GET /devices` — which returns 401. Users following the docs to build scripted integrations hit a wall, because the general API requires a user JWT and tenancy writes are additionally MFA-gated.

## Ground truth (verified against code)

`brz_` API keys authenticate exactly three surfaces:

- `POST /api/v1/mcp/*` — `apps/api/src/routes/mcpServer.ts`
- `POST /api/v1/dev/push` — `apps/api/src/routes/devPush.ts`
- `GET`/`PATCH /api/v1/devices/:id/custom-fields` — `apps/api/src/routes/devices/customFieldValues.ts` (dual JWT-or-key auth)

Everything else requires `Authorization: Bearer` with a user JWT. Machine-to-machine tenancy access lives at `/api/v1/partner-api/*` with a distinct credential class — partner service-principal keys (`brz_sp_…`, `middleware/partnerApiAuth.ts`), also sent via `X-API-Key`.

## Changes

- **`apps/docs/src/content/docs/reference/api.mdx`** — Authentication section: replaced the general-purpose `X-API-Key` claim and the broken `/devices` example with the three real surfaces, noted the JWT+MFA reality, and added a working `brz_sp_` example against `GET /partner-api/devices` cross-referencing the existing Partner API section.
- **`apps/docs/src/content/docs/reference/api-keys.mdx`** — fixed the same broken `/devices` example in "Authentication Flow" (now uses the custom-fields endpoint that actually accepts a `brz_` key), added a "Where API Keys Work" section naming the exact surfaces and pointing scripted integrators at the Partner API, and scoped the "Dual Authentication" paragraph to the custom-field routes it describes. Tightened the intro claims to match.
- **`apps/api/src/openapi.ts`** — removed `apiKeyAuth` from the global `security` array (no path documented in the spec accepts a `brz_` key, so advertising it globally was wrong for every path); rewrote the info-block auth prose and the `apiKeyAuth` scheme description to state exactly where the key works and to point at `brz_sp_` / `partner-api` for machine-to-machine use.

## Verification

- `src/routes/docs.test.ts` (the only test importing openapi): 3/3 passed
- `apps/docs` `astro build`: succeeded
- `apps/api` `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
