### PR TITLE
fix(orgs): org-import hardening — sites:write gate, skip-mode link persistence, atomic group create, constraint-aware recovery

### DIFF
--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -195,9 +195,11 @@ vi.mock('drizzle-orm', async (importActual) => {
 
 // Mutable switch for the requirePermission mock so individual tests can
 // simulate a caller whose role LACKS the gated permission (the real middleware
-// 403s). Hoisted because the vi.mock factory below references it. Reset to
-// granted in beforeEach.
-const permissionMockState = vi.hoisted(() => ({ granted: true }));
+// 403s). `granted = false` denies everything; `denied` denies specific
+// `resource:action` pairs so a test can withhold ONE permission (e.g.
+// sites:write) while the rest stay granted. Hoisted because the vi.mock
+// factory below references it. Reset to granted/empty in beforeEach.
+const permissionMockState = vi.hoisted(() => ({ granted: true, denied: new Set<string>() }));
 
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
@@ -221,8 +223,8 @@ vi.mock('../middleware/auth', () => ({
     return next();
   }),
   requirePartner: vi.fn((c: any, next: any) => next()),
-  requirePermission: vi.fn(() => async (c: any, next: any) => {
-    if (!permissionMockState.granted) {
+  requirePermission: vi.fn((resource: string, action: string) => async (c: any, next: any) => {
+    if (!permissionMockState.granted || permissionMockState.denied.has(`${resource}:${action}`)) {
       return c.json({ error: 'Permission denied' }, 403);
     }
     return next();
@@ -304,6 +306,7 @@ describe('org routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     permissionMockState.granted = true;
+    permissionMockState.denied.clear();
     setAuthContext();
     app = new Hono();
     app.route('/orgs', orgRoutes);
@@ -4541,6 +4544,28 @@ describe('org routes', () => {
       });
       expect(res.status).toBe(403);
       expect(orgImportMocks.commitOrgImport).not.toHaveBeenCalled();
+    });
+
+    it('403s commit when the caller lacks sites:write (the import creates sites too)', async () => {
+      permissionMockState.denied.add('sites:write');
+      const res = await app.request('/orgs/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(previewBody),
+      });
+      expect(res.status).toBe(403);
+      expect(orgImportMocks.commitOrgImport).not.toHaveBeenCalled();
+    });
+
+    it('403s preview when the caller lacks sites:write (early honest failure)', async () => {
+      permissionMockState.denied.add('sites:write');
+      const res = await app.request('/orgs/import/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(previewBody),
+      });
+      expect(res.status).toBe(403);
+      expect(orgImportMocks.previewOrgImport).not.toHaveBeenCalled();
     });
 
     it('rejects a partner-scope body naming a different partner', async () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -1407,7 +1407,10 @@ function resolveImportPartnerId(
   return { partnerId };
 }
 
-orgRoutes.post('/import/preview', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', previewOrgImportSchema), async (c) => {
+// The import creates SITES as well as orgs, so it is gated on sites:write in
+// addition to orgs:write (#3242). Preview carries the same gate for an early,
+// honest failure — a preview a caller could never commit is a trap.
+orgRoutes.post('/import/preview', requireScope('partner', 'system'), requireOrgWrite, requireSiteWrite, requireMfa(), zValidator('json', previewOrgImportSchema), async (c) => {
   const auth = c.get('auth') as AuthContext;
   const { rows, partnerId: bodyPartnerId } = c.req.valid('json');
 
@@ -1420,7 +1423,7 @@ orgRoutes.post('/import/preview', requireScope('partner', 'system'), requireOrgW
   return c.json({ rows: annotated });
 });
 
-orgRoutes.post('/import', requireScope('partner', 'system'), requireOrgWrite, requireMfa(), zValidator('json', commitOrgImportSchema), async (c) => {
+orgRoutes.post('/import', requireScope('partner', 'system'), requireOrgWrite, requireSiteWrite, requireMfa(), zValidator('json', commitOrgImportSchema), async (c) => {
   const auth = c.get('auth') as AuthContext;
   const { rows, mode, partnerId: bodyPartnerId } = c.req.valid('json');
 

--- a/apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
+++ b/apps/api/src/services/accounting/quickbooksCustomerImport.test.ts
@@ -218,6 +218,24 @@ describe('importQuickbooksCustomers', () => {
     expect(insertMock).not.toHaveBeenCalled();
   });
 
+  it('skips a customer whose link row was created by the CSV/bulk org import (cross-importer, #3242)', async () => {
+    listRemoteCustomersMock.mockResolvedValue([{ id: 'qb-77', displayName: 'Acme' }]);
+    // Org created by the bulk org-import path (routes/orgs.ts /import): it has
+    // NO legacy accounting_* columns — only an organization_external_links row
+    // with system='quickbooks'. The union read must still match it so the QB
+    // importer does not mint a duplicate org.
+    stubSelects(
+      [{ id: 'org-csv', slug: 'acme', accountingProvider: null, accountingExternalId: null }],
+      [{ orgId: 'org-csv', externalId: 'qb-77' }],
+    );
+    const summary = await importQuickbooksCustomers({ partnerId: 'p1', customerIds: ['qb-77'] });
+    expect(summary.imported).toEqual([]);
+    expect(summary.skipped).toEqual([
+      { customerId: 'qb-77', displayName: 'Acme', organizationId: 'org-csv', reason: 'already_imported' },
+    ]);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
   it('suffixes the slug when the base collides with an existing org slug', async () => {
     listRemoteCustomersMock.mockResolvedValue([{ id: '1', displayName: 'Acme' }]);
     // Slug reservation now spans ALL partner orgs, not just QB-linked ones.

--- a/apps/api/src/services/orgImport/index.ts
+++ b/apps/api/src/services/orgImport/index.ts
@@ -430,12 +430,22 @@ async function commitGroup(
     }
 
     if (mode === 'skip' && !reactivated) {
+      // An acknowledged name-match carrying an externalId persists its link row
+      // even in skip mode: the acknowledgement is the durable fact ("this
+      // external id IS this org"), and without the link row every subsequent
+      // import would re-derive a name-match and re-prompt for the same
+      // confirmation. checkExpectation already guaranteed the acknowledgement
+      // for every surviving row in this group.
+      const createdLink = group.annotation === 'name-match' && group.externalId
+        ? await attachExternalLink(group, partnerId, actor, orgId)
+        : false;
       for (const r of rows) {
         summary.skipped.push({
           index: r.index,
           organization: r.organization,
           organizationId: orgId,
           reason: group.annotation === 'link-match' ? 'already_linked' : 'name_match_confirmed',
+          ...(createdLink && r === rows[0] ? { createdLink: true } : {}),
         });
       }
       return;
@@ -458,6 +468,48 @@ async function commitGroup(
   }
 }
 
+/**
+ * Insert the organization_external_links row for a matched group, treating a
+ * unique violation as "already linked" (idempotent re-acknowledgement or a
+ * concurrent import winning the race). Returns true when a new row was written.
+ */
+async function attachExternalLink(
+  group: RowGroup,
+  partnerId: string,
+  actor: OrgImportActor,
+  orgId: string,
+): Promise<boolean> {
+  try {
+    await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      db.insert(organizationExternalLinks).values({
+        orgId,
+        partnerId,
+        system: group.system,
+        externalId: group.externalId!,
+        createdBy: actor.userId,
+      })
+    ));
+    return true;
+  } catch (err) {
+    if (!isPgUniqueViolation(err)) throw err;
+    return false;
+  }
+}
+
+// The two idempotency guards for external-id linkage: the link table's unique
+// index and the legacy accounting-columns partial unique index. Only a
+// violation of one of THESE means "another import won the race for this
+// external id" — any other unique violation (e.g. a sites index) is an
+// ordinary failure and must not be reported as created_concurrently.
+const LINK_UNIQUE_CONSTRAINTS = [
+  'organization_external_links_uniq',
+  'organizations_accounting_external_uniq',
+] as const;
+
+function isConcurrentLinkViolation(err: unknown): boolean {
+  return LINK_UNIQUE_CONSTRAINTS.some((constraint) => isPgUniqueViolation(err, constraint));
+}
+
 async function createGroup(
   group: RowGroup,
   rows: NormalizedRow[],
@@ -467,38 +519,70 @@ async function createGroup(
 ): Promise<void> {
   const firstContact = rows.find((r) => r.row.contact)?.row.contact;
 
+  // Sites: one per row that names a site; a group with none gets a default
+  // site named after the org (matching the QuickBooks importer).
+  const siteRows = rows.filter((r) => r.site);
+  const effective = siteRows.length > 0 ? siteRows : [rows[0]!];
+
   let orgId: string;
   let createdLink = false;
+  let siteIdByIndex: Map<number, { id: string; name: string }>;
   try {
-    const created = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
-      const [org] = await db.insert(organizations).values({
-        partnerId,
-        name: clamp(group.organization, 255)!,
-        // annotateGroups always resolves a slug for 'create' groups.
-        slug: group.slug!,
-        type: 'customer' as const,
-        ...(firstContact ? { billingContact: firstContact } : {}),
-      }).returning();
-      let linked = false;
-      if (group.externalId) {
-        await db.insert(organizationExternalLinks).values({
-          orgId: org!.id,
+    // One all-or-nothing transaction for the whole group: a failing site
+    // insert must not strand a freshly created org with no default site — the
+    // org, its link row, and every site commit or roll back together, and a
+    // failure reports as one per-group error.
+    const created = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+      db.transaction(async (tx) => {
+        const [org] = await tx.insert(organizations).values({
           partnerId,
-          system: group.system,
-          externalId: group.externalId,
-          createdBy: actor.userId,
-        });
-        linked = true;
-      }
-      return { orgId: org!.id as string, linked };
-    }));
+          name: clamp(group.organization, 255)!,
+          // annotateGroups always resolves a slug for 'create' groups.
+          slug: group.slug!,
+          type: 'customer' as const,
+          ...(firstContact ? { billingContact: firstContact } : {}),
+        }).returning();
+        let linked = false;
+        if (group.externalId) {
+          await tx.insert(organizationExternalLinks).values({
+            orgId: org!.id,
+            partnerId,
+            system: group.system,
+            externalId: group.externalId,
+            createdBy: actor.userId,
+          });
+          linked = true;
+        }
+        const createdSiteNames = new Set<string>();
+        const siteMap = new Map<number, { id: string; name: string }>();
+        for (const r of effective) {
+          const siteName = r.site ?? group.organization;
+          if (createdSiteNames.has(siteName.toLowerCase())) continue;
+          const [site] = await tx.insert(sites).values({
+            orgId: org!.id,
+            name: clamp(siteName, 255)!,
+            timezone: r.row.timezone ?? 'UTC',
+            ...(r.row.address !== undefined ? { address: r.row.address } : {}),
+            ...(r.row.contact ? { contact: r.row.contact } : {}),
+          }).returning();
+          createdSiteNames.add(siteName.toLowerCase());
+          siteMap.set(r.index, { id: site!.id as string, name: siteName });
+        }
+        return { orgId: org!.id as string, linked, siteMap };
+      })
+    ));
     orgId = created.orgId;
     createdLink = created.linked;
+    siteIdByIndex = created.siteMap;
   } catch (err) {
-    // Unique violation on the link row: a concurrent import linked this
-    // external id after our snapshot — honor the skip contract instead of
-    // reporting a raw constraint error. Re-read the winning org id.
-    if (isPgUniqueViolation(err) && group.externalId) {
+    // Unique violation on the LINK unique index (or its legacy accounting
+    // twin): a concurrent import linked this external id after our snapshot —
+    // honor the skip contract instead of reporting a raw constraint error.
+    // Re-read the winning org id. Constraint-checked so a site (or slug)
+    // unique violation inside the transaction is NOT misreported as
+    // created_concurrently — it propagates as an ordinary per-group error
+    // whose message carries the violated constraint.
+    if (group.externalId && isConcurrentLinkViolation(err)) {
       const existing = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
         db.select({ orgId: organizationExternalLinks.orgId })
           .from(organizationExternalLinks)
@@ -522,40 +606,8 @@ async function createGroup(
     throw err;
   }
 
-  // Sites: one per row that names a site; a group with none gets a default
-  // site named after the org (matching the QuickBooks importer).
-  const siteRows = rows.filter((r) => r.site);
-  const effective = siteRows.length > 0 ? siteRows : [rows[0]!];
-  const createdSiteNames = new Set<string>();
-  const siteIdByIndex = new Map<number, { id: string; name: string }>();
-
-  for (const r of effective) {
-    const siteName = r.site ?? group.organization;
-    if (createdSiteNames.has(siteName.toLowerCase())) continue;
-    try {
-      const [site] = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
-        db.insert(sites).values({
-          orgId,
-          name: clamp(siteName, 255)!,
-          timezone: r.row.timezone ?? 'UTC',
-          ...(r.row.address !== undefined ? { address: r.row.address } : {}),
-          ...(r.row.contact ? { contact: r.row.contact } : {}),
-        }).returning()
-      ));
-      createdSiteNames.add(siteName.toLowerCase());
-      siteIdByIndex.set(r.index, { id: site!.id as string, name: siteName });
-    } catch (err) {
-      summary.errors.push({
-        index: r.index,
-        organization: r.organization,
-        error: `Organization created but site "${siteName}" failed: ${err instanceof Error ? err.message : String(err)}`,
-      });
-    }
-  }
-
   let first = true;
   for (const r of rows) {
-    if (summary.errors.some((e) => e.index === r.index)) continue;
     const site = siteIdByIndex.get(r.index) ?? null;
     summary.imported.push({
       index: r.index,
@@ -594,24 +646,11 @@ async function updateGroup(
     }
   }
 
-  // Attach the link row for an acknowledged name-match carrying an externalId
-  // (in update mode only — 'skip' leaves matches untouched), so the NEXT
-  // import matches by id instead of name.
+  // Attach the link row for an acknowledged name-match (or reactivated
+  // soft-deleted match) carrying an externalId, so the NEXT import matches by
+  // id instead of name. Skip-mode name-matches get theirs in commitGroup.
   if (mode === 'update' && group.externalId && group.annotation !== 'link-match') {
-    try {
-      await runOutsideDbContext(() => withSystemDbAccessContext(() =>
-        db.insert(organizationExternalLinks).values({
-          orgId,
-          partnerId,
-          system: group.system,
-          externalId: group.externalId!,
-          createdBy: actor.userId,
-        })
-      ));
-      createdLink = true;
-    } catch (err) {
-      if (!isPgUniqueViolation(err)) throw err;
-    }
+    createdLink = await attachExternalLink(group, partnerId, actor, orgId);
   }
 
   const existingSites = mode === 'update'

--- a/apps/api/src/services/orgImport/index.ts
+++ b/apps/api/src/services/orgImport/index.ts
@@ -429,29 +429,57 @@ async function commitGroup(
       reactivated = true;
     }
 
+    // Persist the link row for ANY acknowledged non-link match carrying an
+    // externalId, in BOTH modes: every surviving name-match or soft-deleted
+    // match passed checkExpectation's explicit acknowledgement, and the
+    // acknowledgement is the durable fact ("this external id IS this org") —
+    // without the link row every subsequent import re-derives the match and
+    // re-prompts for the same confirmation.
+    let createdLink = false;
+    let linkWarning: string | undefined;
+    if (group.externalId && group.annotation !== 'link-match') {
+      const attach = await attachExternalLink(group, partnerId, actor, orgId);
+      if (attach.status === 'conflict') {
+        // A concurrent import linked this external id to a DIFFERENT org after
+        // our snapshot. Reporting confirmation while the durable link points
+        // elsewhere would silently drop the acknowledgement — refuse instead.
+        for (const r of rows) {
+          summary.errors.push({
+            index: r.index,
+            organization: r.organization,
+            error: `External id "${group.externalId}" (${group.system}) is already linked to a different organization`
+              + `${attach.linkedOrgId ? ` (${attach.linkedOrgId})` : ''} — expected ${orgId}; re-run preview`,
+          });
+        }
+        return;
+      }
+      if (attach.status === 'failed') {
+        // Update mode is doing writes for this group anyway — fail it loudly
+        // (pre-existing behavior). Skip mode's link write is an optional extra
+        // on an otherwise write-free path: keep the rows reported as skipped
+        // and surface a warning instead of reclassifying the group as errors.
+        if (mode === 'update') throw attach.error;
+        linkWarning = 'Match confirmed, but persisting the external link failed: '
+          + `${attach.error instanceof Error ? attach.error.message : String(attach.error)} — the next import will ask again`;
+      }
+      createdLink = attach.status === 'created';
+    }
+
     if (mode === 'skip' && !reactivated) {
-      // An acknowledged name-match carrying an externalId persists its link row
-      // even in skip mode: the acknowledgement is the durable fact ("this
-      // external id IS this org"), and without the link row every subsequent
-      // import would re-derive a name-match and re-prompt for the same
-      // confirmation. checkExpectation already guaranteed the acknowledgement
-      // for every surviving row in this group.
-      const createdLink = group.annotation === 'name-match' && group.externalId
-        ? await attachExternalLink(group, partnerId, actor, orgId)
-        : false;
       for (const r of rows) {
         summary.skipped.push({
           index: r.index,
           organization: r.organization,
           organizationId: orgId,
           reason: group.annotation === 'link-match' ? 'already_linked' : 'name_match_confirmed',
-          ...(createdLink && r === rows[0] ? { createdLink: true } : {}),
+          createdLink: createdLink && r === rows[0],
+          ...(linkWarning && r === rows[0] ? { warning: linkWarning } : {}),
         });
       }
       return;
     }
 
-    await updateGroup(group, rows, partnerId, actor, mode, orgId, reactivated, summary);
+    await updateGroup(group, rows, mode, orgId, reactivated, { createdLink, warning: linkWarning }, summary);
   } catch (err) {
     console.error('[org-import] group failed', {
       partnerId,
@@ -468,17 +496,29 @@ async function commitGroup(
   }
 }
 
+type AttachLinkOutcome =
+  | { status: 'created' }
+  /** The identical link (same org) already exists — idempotent re-acknowledgement. */
+  | { status: 'already-linked' }
+  /** The external id is linked to a DIFFERENT org (concurrent import won the race). */
+  | { status: 'conflict'; linkedOrgId: string | null }
+  /** The insert (or the post-conflict re-read) failed for a non-unique reason. */
+  | { status: 'failed'; error: unknown };
+
 /**
- * Insert the organization_external_links row for a matched group, treating a
- * unique violation as "already linked" (idempotent re-acknowledgement or a
- * concurrent import winning the race). Returns true when a new row was written.
+ * Insert the organization_external_links row for a matched group. Never
+ * throws — every outcome is reported so the caller decides the policy
+ * (skip-mode keeps its rows skipped with a warning; update-mode fails loud).
+ * A unique violation is not blindly "already linked": the row is re-read and
+ * compared, because the winner of the race may be a different org and
+ * reporting confirmation then would silently drop the acknowledgement.
  */
 async function attachExternalLink(
   group: RowGroup,
   partnerId: string,
   actor: OrgImportActor,
   orgId: string,
-): Promise<boolean> {
+): Promise<AttachLinkOutcome> {
   try {
     await runOutsideDbContext(() => withSystemDbAccessContext(() =>
       db.insert(organizationExternalLinks).values({
@@ -489,10 +529,26 @@ async function attachExternalLink(
         createdBy: actor.userId,
       })
     ));
-    return true;
+    return { status: 'created' };
   } catch (err) {
-    if (!isPgUniqueViolation(err)) throw err;
-    return false;
+    if (!isConcurrentLinkViolation(err)) return { status: 'failed', error: err };
+    try {
+      const existing = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
+        db.select({ orgId: organizationExternalLinks.orgId })
+          .from(organizationExternalLinks)
+          .where(and(
+            eq(organizationExternalLinks.partnerId, partnerId),
+            eq(organizationExternalLinks.system, group.system),
+            eq(organizationExternalLinks.externalId, group.externalId!),
+          ))
+          .limit(1)
+      )) as Array<{ orgId: string }>;
+      const winner = existing[0]?.orgId ?? null;
+      if (winner === orgId) return { status: 'already-linked' };
+      return { status: 'conflict', linkedOrgId: winner };
+    } catch (reReadErr) {
+      return { status: 'failed', error: reReadErr };
+    }
   }
 }
 
@@ -528,49 +584,57 @@ async function createGroup(
   let createdLink = false;
   let siteIdByIndex: Map<number, { id: string; name: string }>;
   try {
-    // One all-or-nothing transaction for the whole group: a failing site
-    // insert must not strand a freshly created org with no default site — the
-    // org, its link row, and every site commit or roll back together, and a
-    // failure reports as one per-group error.
-    const created = await runOutsideDbContext(() => withSystemDbAccessContext(() =>
-      db.transaction(async (tx) => {
-        const [org] = await tx.insert(organizations).values({
+    // All-or-nothing for the whole group: withSystemDbAccessContext runs its
+    // callback inside ONE transaction (its RLS GUCs are SET LOCAL, so the
+    // helper holds an open transaction for the duration — db/index.ts). The
+    // org, its link row, and every site therefore commit or roll back
+    // together; a failing site insert cannot strand a freshly created org
+    // with no default site, it fails the group as one per-group error.
+    const created = await runOutsideDbContext(() => withSystemDbAccessContext(async () => {
+      const [org] = await db.insert(organizations).values({
+        partnerId,
+        name: clamp(group.organization, 255)!,
+        // annotateGroups always resolves a slug for 'create' groups.
+        slug: group.slug!,
+        type: 'customer' as const,
+        ...(firstContact ? { billingContact: firstContact } : {}),
+      }).returning();
+      let linked = false;
+      if (group.externalId) {
+        await db.insert(organizationExternalLinks).values({
+          orgId: org!.id,
           partnerId,
-          name: clamp(group.organization, 255)!,
-          // annotateGroups always resolves a slug for 'create' groups.
-          slug: group.slug!,
-          type: 'customer' as const,
-          ...(firstContact ? { billingContact: firstContact } : {}),
+          system: group.system,
+          externalId: group.externalId,
+          createdBy: actor.userId,
+        });
+        linked = true;
+      }
+      // One site per distinct (case-insensitive) name; rows whose site name
+      // duplicates an earlier row's map to the already-created site.
+      const siteByName = new Map<string, { id: string; name: string }>();
+      const siteMap = new Map<number, { id: string; name: string }>();
+      for (const r of effective) {
+        const siteName = r.site ?? group.organization;
+        const nameKey = siteName.toLowerCase();
+        const existing = siteByName.get(nameKey);
+        if (existing) {
+          siteMap.set(r.index, existing);
+          continue;
+        }
+        const [site] = await db.insert(sites).values({
+          orgId: org!.id,
+          name: clamp(siteName, 255)!,
+          timezone: r.row.timezone ?? 'UTC',
+          ...(r.row.address !== undefined ? { address: r.row.address } : {}),
+          ...(r.row.contact ? { contact: r.row.contact } : {}),
         }).returning();
-        let linked = false;
-        if (group.externalId) {
-          await tx.insert(organizationExternalLinks).values({
-            orgId: org!.id,
-            partnerId,
-            system: group.system,
-            externalId: group.externalId,
-            createdBy: actor.userId,
-          });
-          linked = true;
-        }
-        const createdSiteNames = new Set<string>();
-        const siteMap = new Map<number, { id: string; name: string }>();
-        for (const r of effective) {
-          const siteName = r.site ?? group.organization;
-          if (createdSiteNames.has(siteName.toLowerCase())) continue;
-          const [site] = await tx.insert(sites).values({
-            orgId: org!.id,
-            name: clamp(siteName, 255)!,
-            timezone: r.row.timezone ?? 'UTC',
-            ...(r.row.address !== undefined ? { address: r.row.address } : {}),
-            ...(r.row.contact ? { contact: r.row.contact } : {}),
-          }).returning();
-          createdSiteNames.add(siteName.toLowerCase());
-          siteMap.set(r.index, { id: site!.id as string, name: siteName });
-        }
-        return { orgId: org!.id as string, linked, siteMap };
-      })
-    ));
+        const entry = { id: site!.id as string, name: siteName };
+        siteByName.set(nameKey, entry);
+        siteMap.set(r.index, entry);
+      }
+      return { orgId: org!.id as string, linked, siteMap };
+    }));
     orgId = created.orgId;
     createdLink = created.linked;
     siteIdByIndex = created.siteMap;
@@ -599,6 +663,7 @@ async function createGroup(
           organization: r.organization,
           organizationId: existing[0]?.orgId ?? null,
           reason: 'created_concurrently',
+          createdLink: false,
         });
       }
       return;
@@ -606,7 +671,6 @@ async function createGroup(
     throw err;
   }
 
-  let first = true;
   for (const r of rows) {
     const site = siteIdByIndex.get(r.index) ?? null;
     summary.imported.push({
@@ -615,26 +679,24 @@ async function createGroup(
       organizationId: orgId,
       siteId: site?.id ?? null,
       siteName: site?.name ?? null,
-      createdOrganization: first,
-      createdLink: first && createdLink,
-      slug: first ? group.slug : null,
+      createdOrganization: r === rows[0],
+      createdLink: createdLink && r === rows[0],
+      slug: r === rows[0] ? group.slug : null,
     });
-    first = false;
   }
 }
 
 async function updateGroup(
   group: RowGroup,
   rows: NormalizedRow[],
-  partnerId: string,
-  actor: OrgImportActor,
   mode: OrgImportMode,
   orgId: string,
   reactivated: boolean,
+  // Link persistence already happened in commitGroup (both modes) — this is
+  // its outcome, reported on the group's first summary row.
+  link: { createdLink: boolean; warning?: string },
   summary: OrgImportSummary,
 ): Promise<void> {
-  let createdLink = false;
-
   if (mode === 'update') {
     // Patch the org name only when it actually changed (case/spacing edits).
     if (group.matchedOrganizationName !== group.organization) {
@@ -644,13 +706,6 @@ async function updateGroup(
           .where(eq(organizations.id, orgId))
       ));
     }
-  }
-
-  // Attach the link row for an acknowledged name-match (or reactivated
-  // soft-deleted match) carrying an externalId, so the NEXT import matches by
-  // id instead of name. Skip-mode name-matches get theirs in commitGroup.
-  if (mode === 'update' && group.externalId && group.annotation !== 'link-match') {
-    createdLink = await attachExternalLink(group, partnerId, actor, orgId);
   }
 
   const existingSites = mode === 'update'
@@ -713,8 +768,9 @@ async function updateGroup(
       siteId,
       siteName,
       createdSite,
-      createdLink: createdLink && r === rows[0],
+      createdLink: link.createdLink && r === rows[0],
       reactivated,
+      ...(link.warning && r === rows[0] ? { warning: link.warning } : {}),
     });
   }
 }

--- a/apps/api/src/services/orgImport/orgImport.test.ts
+++ b/apps/api/src/services/orgImport/orgImport.test.ts
@@ -9,16 +9,11 @@ const { selectMock, insertMock, updateMock, restoreOrgAccessMock } = vi.hoisted(
 }));
 
 vi.mock('../../db', () => ({
-  db: {
-    select: selectMock,
-    insert: insertMock,
-    update: updateMock,
-    // createGroup wraps the whole group in db.transaction; hand the callback a
-    // tx backed by the same mocks so rejections propagate like a rollback.
-    transaction: (fn: (tx: unknown) => unknown) =>
-      fn({ select: selectMock, insert: insertMock, update: updateMock }),
-  },
+  db: { select: selectMock, insert: insertMock, update: updateMock },
   runOutsideDbContext: (fn: () => unknown) => fn(),
+  // The real helper runs its callback inside ONE transaction (SET LOCAL RLS
+  // GUCs), which is what makes createGroup all-or-nothing; the pass-through
+  // here means rejections propagate like a rollback would.
   withSystemDbAccessContext: (fn: () => unknown) => fn(),
 }));
 
@@ -248,6 +243,22 @@ describe('commitOrgImport — create', () => {
     expect(insertedValues[3]!.values).toMatchObject({ name: 'Warehouse', timezone: 'UTC' });
   });
 
+  it('maps a case-duplicate site row to the already-created site instead of null', async () => {
+    stubState([], []);
+    const summary = await commitOrgImport([
+      { organization: 'Acme', site: 'HQ' },
+      { organization: 'Acme', site: 'hq' },
+    ], 'p1', { userId: null }, 'skip');
+    expect(summary.errors).toEqual([]);
+    expect(summary.imported).toHaveLength(2);
+    // org insert + ONE site insert — the duplicate name is not re-created…
+    expect(insertedValues).toHaveLength(2);
+    // …but the deduped row still reports the created site, not null.
+    expect(summary.imported[0]!.siteId).not.toBeNull();
+    expect(summary.imported[1]!.siteId).toBe(summary.imported[0]!.siteId);
+    expect(summary.imported[1]!.siteName).toBe('HQ');
+  });
+
   it('creates a default site named after the org when no row names a site', async () => {
     stubState([], []);
     const summary = await commitOrgImport([{ organization: 'Acme' }], 'p1', { userId: null }, 'skip');
@@ -267,7 +278,7 @@ describe('commitOrgImport — create', () => {
       'p1', { userId: null }, 'skip',
     );
     expect(summary.skipped).toEqual([
-      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'already_linked' },
+      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'already_linked', createdLink: false },
     ]);
     expect(insertMock).not.toHaveBeenCalled();
   });
@@ -299,7 +310,7 @@ describe('commitOrgImport — create', () => {
     );
     expect(summary.errors).toEqual([]);
     expect(summary.skipped).toEqual([
-      { index: 0, organization: 'Acme', organizationId: 'org-winner', reason: 'created_concurrently' },
+      { index: 0, organization: 'Acme', organizationId: 'org-winner', reason: 'created_concurrently', createdLink: false },
     ]);
   });
 
@@ -313,7 +324,7 @@ describe('commitOrgImport — create', () => {
     );
     expect(summary.errors).toEqual([]);
     expect(summary.skipped).toEqual([
-      { index: 0, organization: 'Acme', organizationId: 'org-winner', reason: 'created_concurrently' },
+      { index: 0, organization: 'Acme', organizationId: 'org-winner', reason: 'created_concurrently', createdLink: false },
     ]);
   });
 
@@ -369,7 +380,7 @@ describe('commitOrgImport — expectation guard', () => {
     const rows: CommitRowInput[] = [{ organization: 'Acme', expectedAnnotation: 'name-match' }];
     const summary = await commitOrgImport(rows, 'p1', { userId: null }, 'skip');
     expect(summary.skipped).toEqual([
-      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed' },
+      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed', createdLink: false },
     ]);
   });
 
@@ -396,7 +407,7 @@ describe('commitOrgImport — expectation guard', () => {
     const summary = await commitOrgImport(rows, 'p1', { userId: null }, 'skip');
     expect(summary.errors).toEqual([]);
     expect(summary.skipped).toEqual([
-      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed' },
+      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed', createdLink: false },
     ]);
   });
 
@@ -463,8 +474,10 @@ describe('commitOrgImport — skip-mode link persistence (#3242)', () => {
     });
   });
 
-  it('treats a lost race on the skip-mode link insert as already linked (no createdLink flag)', async () => {
-    stubState([{ id: 'org-1', name: 'Acme', slug: 'acme' }], []);
+  it('treats a lost race that linked the SAME org as already linked (no createdLink flag)', async () => {
+    // Link insert loses the race; the re-read shows the winner is our org-1 —
+    // an idempotent re-acknowledgement, still a plain skip.
+    stubState([{ id: 'org-1', name: 'Acme', slug: 'acme' }], [], [[{ orgId: 'org-1' }]]);
     const dup = Object.assign(new Error('dup'), { code: '23505', constraint: 'organization_external_links_uniq' });
     stubInserts({ failOn: () => dup });
     const summary = await commitOrgImport(
@@ -473,8 +486,61 @@ describe('commitOrgImport — skip-mode link persistence (#3242)', () => {
     );
     expect(summary.errors).toEqual([]);
     expect(summary.skipped).toEqual([
-      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed' },
+      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed', createdLink: false },
     ]);
+  });
+
+  it('refuses the acknowledgement when a concurrent import linked the external id to a DIFFERENT org', async () => {
+    // Link insert loses the race and the re-read shows the winner is org-2:
+    // reporting name_match_confirmed for org-1 would silently drop the
+    // acknowledgement while the durable link points elsewhere.
+    stubState([{ id: 'org-1', name: 'Acme', slug: 'acme' }], [], [[{ orgId: 'org-2' }]]);
+    const dup = Object.assign(new Error('dup'), { code: '23505', constraint: 'organization_external_links_uniq' });
+    stubInserts({ failOn: () => dup });
+    const summary = await commitOrgImport(
+      [{ organization: 'Acme', externalId: '42', expectedAnnotation: 'name-match' } as CommitRowInput],
+      'p1', { userId: null }, 'skip',
+    );
+    expect(summary.skipped).toEqual([]);
+    expect(summary.updated).toEqual([]);
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0]!.error).toMatch(/different organization/);
+    expect(summary.errors[0]!.error).toMatch(/org-2/);
+  });
+
+  it('keeps the group skipped (with a warning) when the optional link persistence fails non-fatally', async () => {
+    stubState([{ id: 'org-1', name: 'Acme', slug: 'acme' }], []);
+    stubInserts({ failOn: () => new Error('connection reset') });
+    const summary = await commitOrgImport(
+      [{ organization: 'Acme', externalId: '42', expectedAnnotation: 'name-match' } as CommitRowInput],
+      'p1', { userId: null }, 'skip',
+    );
+    // The skip path was write-free before the link attach existed — a failed
+    // optional write must not reclassify the group as errors.
+    expect(summary.errors).toEqual([]);
+    expect(summary.skipped).toHaveLength(1);
+    expect(summary.skipped[0]).toMatchObject({
+      index: 0, organizationId: 'org-1', reason: 'name_match_confirmed', createdLink: false,
+    });
+    expect(summary.skipped[0]!.warning).toMatch(/connection reset/);
+  });
+
+  it('persists the link row for a reactivated soft-deleted match in skip mode too', async () => {
+    // Soft-deleted org matched by NAME with an externalId on the row: the
+    // reactivate opt-in is an explicit acknowledgement, so the link must be
+    // written even though mode is skip.
+    stubState([{ id: 'org-1', name: 'Acme', slug: 'acme', deletedAt: new Date('2026-01-01') }], []);
+    const rows: CommitRowInput[] = [
+      { organization: 'Acme', externalId: '42', externalSystem: 'datto_rmm', expectedAnnotation: 'matched-soft-deleted', reactivate: true },
+    ];
+    const summary = await commitOrgImport(rows, 'p1', { userId: 'u1' }, 'skip');
+    expect(summary.errors).toEqual([]);
+    expect(summary.updated).toEqual([
+      expect.objectContaining({ organizationId: 'org-1', reactivated: true, createdLink: true }),
+    ]);
+    expect(insertedValues[0]!.values).toMatchObject({
+      orgId: 'org-1', partnerId: 'p1', system: 'datto_rmm', externalId: '42', createdBy: 'u1',
+    });
   });
 
   it('writes no link row for an acknowledged name-match WITHOUT an externalId', async () => {
@@ -484,7 +550,7 @@ describe('commitOrgImport — skip-mode link persistence (#3242)', () => {
       'p1', { userId: null }, 'skip',
     );
     expect(summary.skipped).toEqual([
-      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed' },
+      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed', createdLink: false },
     ]);
     expect(insertMock).not.toHaveBeenCalled();
   });

--- a/apps/api/src/services/orgImport/orgImport.test.ts
+++ b/apps/api/src/services/orgImport/orgImport.test.ts
@@ -9,7 +9,15 @@ const { selectMock, insertMock, updateMock, restoreOrgAccessMock } = vi.hoisted(
 }));
 
 vi.mock('../../db', () => ({
-  db: { select: selectMock, insert: insertMock, update: updateMock },
+  db: {
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+    // createGroup wraps the whole group in db.transaction; hand the callback a
+    // tx backed by the same mocks so rejections propagate like a rollback.
+    transaction: (fn: (tx: unknown) => unknown) =>
+      fn({ select: selectMock, insert: insertMock, update: updateMock }),
+  },
   runOutsideDbContext: (fn: () => unknown) => fn(),
   withSystemDbAccessContext: (fn: () => unknown) => fn(),
 }));
@@ -282,7 +290,7 @@ describe('commitOrgImport — create', () => {
 
   it('reclassifies a concurrent link unique-violation as skipped', async () => {
     stubState([], [], [[{ orgId: 'org-winner' }]]);
-    const dup = Object.assign(new Error('dup'), { code: '23505' });
+    const dup = Object.assign(new Error('dup'), { code: '23505', constraint: 'organization_external_links_uniq' });
     // Org insert succeeds; the link insert hits the unique index.
     stubInserts({ failOn: (v) => ('externalId' in v ? dup : null) });
     const summary = await commitOrgImport(
@@ -292,6 +300,57 @@ describe('commitOrgImport — create', () => {
     expect(summary.errors).toEqual([]);
     expect(summary.skipped).toEqual([
       { index: 0, organization: 'Acme', organizationId: 'org-winner', reason: 'created_concurrently' },
+    ]);
+  });
+
+  it('also takes the concurrent-link path for the legacy accounting constraint (postgres.js constraint_name field)', async () => {
+    stubState([], [], [[{ orgId: 'org-winner' }]]);
+    const dup = Object.assign(new Error('dup'), { code: '23505', constraint_name: 'organizations_accounting_external_uniq' });
+    stubInserts({ failOn: (v) => ('externalId' in v ? dup : null) });
+    const summary = await commitOrgImport(
+      [{ organization: 'Acme', externalId: '1' }],
+      'p1', { userId: null }, 'skip',
+    );
+    expect(summary.errors).toEqual([]);
+    expect(summary.skipped).toEqual([
+      { index: 0, organization: 'Acme', organizationId: 'org-winner', reason: 'created_concurrently' },
+    ]);
+  });
+
+  it('reports a NON-link unique violation as a per-group error, never created_concurrently (#3242)', async () => {
+    stubState([], []);
+    // A site unique index trips inside the group transaction. Before the
+    // constraint check this misreported as created_concurrently with a null
+    // organizationId; it must surface as an ordinary error naming the index.
+    const dup = Object.assign(
+      new Error('duplicate key value violates unique constraint "sites_org_id_name_uniq"'),
+      { code: '23505', constraint: 'sites_org_id_name_uniq' },
+    );
+    stubInserts({ failOn: (v) => ('timezone' in v ? dup : null) });
+    const summary = await commitOrgImport(
+      [{ organization: 'Acme', site: 'HQ', externalId: '1' }],
+      'p1', { userId: null }, 'skip',
+    );
+    expect(summary.skipped).toEqual([]);
+    expect(summary.imported).toEqual([]);
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0]!.error).toMatch(/sites_org_id_name_uniq/);
+  });
+
+  it('fails the WHOLE group when a site insert fails — no stranded org with partial sites', async () => {
+    stubState([], []);
+    // Second site insert fails; org + link + first site must roll back with it
+    // (single transaction), reporting one per-group error for every row.
+    stubInserts({ failOn: (v) => (v.name === 'Depot' ? new Error('site boom') : null) });
+    const summary = await commitOrgImport([
+      { organization: 'Acme', site: 'HQ', externalId: '1' },
+      { organization: 'Acme', site: 'Depot', externalId: '1' },
+    ], 'p1', { userId: null }, 'skip');
+    expect(summary.imported).toEqual([]);
+    expect(summary.skipped).toEqual([]);
+    expect(summary.errors).toEqual([
+      { index: 0, organization: 'Acme', error: 'site boom' },
+      { index: 1, organization: 'Acme', error: 'site boom' },
     ]);
   });
 });
@@ -383,6 +442,51 @@ describe('commitOrgImport — expectation guard', () => {
     ]);
     expect(updatedValues[0]!.set).toMatchObject({ deletedAt: null, status: 'active' });
     expect(restoreOrgAccessMock).toHaveBeenCalledWith('org-1');
+  });
+});
+
+describe('commitOrgImport — skip-mode link persistence (#3242)', () => {
+  it('writes the link row for an acknowledged name-match with an externalId even in skip mode', async () => {
+    stubState([{ id: 'org-1', name: 'Acme', slug: 'acme' }], []);
+    const rows: CommitRowInput[] = [
+      { organization: 'Acme', externalId: '42', externalSystem: 'datto_rmm', expectedAnnotation: 'name-match' },
+    ];
+    const summary = await commitOrgImport(rows, 'p1', { userId: 'u1' }, 'skip');
+    expect(summary.errors).toEqual([]);
+    expect(summary.skipped).toEqual([
+      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed', createdLink: true },
+    ]);
+    // Exactly ONE insert — the link row. The org itself stays untouched (skip).
+    expect(insertedValues).toHaveLength(1);
+    expect(insertedValues[0]!.values).toMatchObject({
+      orgId: 'org-1', partnerId: 'p1', system: 'datto_rmm', externalId: '42', createdBy: 'u1',
+    });
+  });
+
+  it('treats a lost race on the skip-mode link insert as already linked (no createdLink flag)', async () => {
+    stubState([{ id: 'org-1', name: 'Acme', slug: 'acme' }], []);
+    const dup = Object.assign(new Error('dup'), { code: '23505', constraint: 'organization_external_links_uniq' });
+    stubInserts({ failOn: () => dup });
+    const summary = await commitOrgImport(
+      [{ organization: 'Acme', externalId: '42', expectedAnnotation: 'name-match' } as CommitRowInput],
+      'p1', { userId: null }, 'skip',
+    );
+    expect(summary.errors).toEqual([]);
+    expect(summary.skipped).toEqual([
+      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed' },
+    ]);
+  });
+
+  it('writes no link row for an acknowledged name-match WITHOUT an externalId', async () => {
+    stubState([{ id: 'org-1', name: 'Acme', slug: 'acme' }], []);
+    const summary = await commitOrgImport(
+      [{ organization: 'Acme', expectedAnnotation: 'name-match' } as CommitRowInput],
+      'p1', { userId: null }, 'skip',
+    );
+    expect(summary.skipped).toEqual([
+      { index: 0, organization: 'Acme', organizationId: 'org-1', reason: 'name_match_confirmed' },
+    ]);
+    expect(insertMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/services/orgImport/types.ts
+++ b/apps/api/src/services/orgImport/types.ts
@@ -105,6 +105,8 @@ export interface OrgImportSummary {
     createdSite: boolean;
     createdLink: boolean;
     reactivated: boolean;
+    /** Non-fatal note (e.g. the optional link persistence failed) — first row only. */
+    warning?: string;
   }>;
   skipped: Array<{
     index: number;
@@ -112,10 +114,12 @@ export interface OrgImportSummary {
     organizationId: string | null;
     reason: string;
     /**
-     * True on the group's first row when a skip-mode commit persisted the link
-     * row for an acknowledged name-match (so future imports resolve by id).
+     * True on the group's first row when the commit persisted the link row for
+     * an acknowledged match (so future imports resolve by id, not name).
      */
-    createdLink?: boolean;
+    createdLink: boolean;
+    /** Non-fatal note (e.g. the optional link persistence failed) — first row only. */
+    warning?: string;
   }>;
   errors: Array<{
     index: number;

--- a/apps/api/src/services/orgImport/types.ts
+++ b/apps/api/src/services/orgImport/types.ts
@@ -111,6 +111,11 @@ export interface OrgImportSummary {
     organization: string;
     organizationId: string | null;
     reason: string;
+    /**
+     * True on the group's first row when a skip-mode commit persisted the link
+     * row for an acknowledged name-match (so future imports resolve by id).
+     */
+    createdLink?: boolean;
   }>;
   errors: Array<{
     index: number;


### PR DESCRIPTION
Closes out the remainder of #3242 (the issue will be closed manually with a note). Includes a follow-up commit addressing all 6 findings from the high-effort review.

## Changes (all in `apps/api`; no migrations, no web changes)

### 1. `requireSiteWrite` on both org-import routes
`POST /orgs/import` and `POST /orgs/import/preview` now require `sites:write` in addition to `orgs:write` — the import creates sites, not just orgs. Preview carries the same gate so a caller who could never commit fails early and honestly.

### 2. Acknowledged matches persist their link row in BOTH commit modes
Previously the `organization_external_links` insert lived only in the update-mode flow; the default `mode='skip'` returned before reaching it, so the acknowledgement was never persisted and **every subsequent import re-prompted for the same confirmation**. The link attach is now hoisted into `commitGroup` and runs in both modes for ANY acknowledged non-link match carrying an `externalId` — including a skip-mode reactivated soft-deleted match (review finding 1). The relevant summary entry reports `createdLink` on the group's first row; `createdLink` is an always-present boolean on `skipped` entries, matching the `imported`/`updated` shape (finding 6).

`attachExternalLink` is outcome-based (findings 2 & 3):
- **Unique violation** → constraint-checked (`organization_external_links_uniq` / legacy `organizations_accounting_external_uniq`) and the link row re-read: same org → idempotent "already linked"; **different org → per-group error naming both orgs** instead of silently reporting confirmation while the durable link points elsewhere.
- **Non-23505 failure** → skip mode keeps the rows reported as skipped and attaches a first-row `warning` (new optional field on skipped/updated entries) instead of reclassifying the write-free skip path as errors; update mode keeps failing the group loudly (pre-existing behavior).

### 3. `createGroup` is all-or-nothing
Org + link + all of the group's sites run inside a single `withSystemDbAccessContext` call — the context helper already runs its callback in ONE transaction (its RLS GUCs are `SET LOCAL`), so the group commits or rolls back together with no extra savepoint (finding 5). Previously sites were inserted in separate contexts after the org committed, so a failing site stranded a fresh org with no default site.

**Intended behavior change:** a site failure now rolls back the whole group and reports one per-group error for every row, instead of the old "Organization created but site X failed" per-row site errors.

A row whose site name case-insensitively duplicates an earlier row's now maps to the already-created site's id/name instead of reporting `siteId: null` (finding 4).

### 4. Constraint-aware unique-violation recovery
The `created_concurrently` skip path in `createGroup`'s catch previously treated ANY pg unique violation as a concurrent link import when the group had an `externalId`. It now only fires when the violated constraint is `organization_external_links_uniq` or the legacy `organizations_accounting_external_uniq` (via `isPgUniqueViolation(err, constraint)`, which reads the driver's `constraint_name`/`constraint` field across the Drizzle `.cause` chain, falling back to a message scan). Any other unique violation surfaces as an ordinary per-group error whose message names the violated constraint. An unnamed 23505 with no constraint info now reports as an error rather than being assumed concurrent — failing loud over guessing.

### 5. Cross-importer regression test
`quickbooksCustomerImport.test.ts` now proves that a link row created by the CSV/bulk import path (`system='quickbooks'`, no legacy `accounting_*` columns) makes `importQuickbooksCustomers` skip that customer via the union read instead of minting a duplicate org.

## Tests
- `src/services/orgImport/orgImport.test.ts` — 37 passed (incl. skip-mode link persistence, reactivated-match link persistence, cross-org link-race conflict, non-fatal attach failure warning, case-duplicate site mapping, group atomicity, constraint-aware recovery via both `constraint` and `constraint_name` driver fields)
- `src/services/accounting/quickbooksCustomerImport.test.ts` — 24 passed (1 new)
- `src/routes/orgs.test.ts` — 201 passed (2 new `sites:write` 403 tests; the `requirePermission` mock now supports denying a single `resource:action`)
- `apps/api` typecheck (`tsc --noEmit`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
