### PR TITLE
feat(abuse): require a business email for hosted partner signup

### DIFF
--- a/apps/api/src/routes/auth/register.test.ts
+++ b/apps/api/src/routes/auth/register.test.ts
@@ -180,6 +180,75 @@ describe('POST /register-partner — SR2-21: email-first, no account created bef
   });
 });
 
+describe('POST /register-partner — business-email requirement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.IS_HOSTED = 'true';
+    vi.mocked(getRedis).mockReturnValue({} as never);
+    vi.mocked(createPendingRegistration).mockResolvedValue({ rawToken: 'raw-token', tokenHash: 'f'.repeat(64) });
+  });
+
+  afterEach(() => {
+    delete process.env.IS_HOSTED;
+    delete process.env.SIGNUP_REQUIRE_BUSINESS_EMAIL;
+    delete process.env.SIGNUP_ALLOWED_EMAIL_DOMAINS;
+    delete process.env.SIGNUP_BUSINESS_EMAIL_CONTACT_URL;
+  });
+
+  it('rejects a consumer-mailbox signup with an actionable 400 and parks NOTHING', async () => {
+    process.env.SIGNUP_BUSINESS_EMAIL_CONTACT_URL = 'https://cal.example/breeze';
+    const res = await postRegisterPartner({ ...VALID_BODY, email: 'someone@gmail.com' });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      code: 'BUSINESS_EMAIL_REQUIRED',
+      actionUrl: 'https://cal.example/breeze',
+      actionLabel: 'Schedule a call',
+    });
+    // The whole point of rejecting before the park: no pending record, no email.
+    expect(vi.mocked(createPendingRegistration)).not.toHaveBeenCalled();
+    expect(vi.mocked(createPartner)).not.toHaveBeenCalled();
+  });
+
+  it('allows a business-domain signup', async () => {
+    const res = await postRegisterPartner(VALID_BODY);
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createPendingRegistration)).toHaveBeenCalled();
+  });
+
+  it('does NOT apply to self-hosted signups', async () => {
+    // Self-hosted takes the setup-admin gate, so seed one and let it through.
+    delete process.env.IS_HOSTED;
+    vi.mocked(db.select).mockReturnValue(selectChain([{ setupCompletedAt: new Date() }]) as never);
+
+    const res = await postRegisterPartner({ ...VALID_BODY, email: 'owner@gmail.com' });
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createPendingRegistration)).toHaveBeenCalled();
+  });
+
+  it('is disabled by the kill switch', async () => {
+    process.env.SIGNUP_REQUIRE_BUSINESS_EMAIL = 'false';
+    const res = await postRegisterPartner({ ...VALID_BODY, email: 'someone@gmail.com' });
+    expect(res.status).toBe(200);
+    expect(vi.mocked(createPendingRegistration)).toHaveBeenCalled();
+  });
+
+  it('honours the per-domain allowlist', async () => {
+    process.env.SIGNUP_ALLOWED_EMAIL_DOMAINS = 'gmail.com';
+    const res = await postRegisterPartner({ ...VALID_BODY, email: 'someone@gmail.com' });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects before the existence-independent work, so it cannot become an oracle', async () => {
+    // Two different consumer addresses must be byte-identical in response —
+    // the verdict depends on the DOMAIN only, never on account state.
+    const a = await postRegisterPartner({ ...VALID_BODY, email: 'has-account@gmail.com' });
+    const b = await postRegisterPartner({ ...VALID_BODY, email: 'no-account@gmail.com' });
+    expect(a.status).toBe(b.status);
+    expect(await a.text()).toBe(await b.text());
+  });
+});
+
 describe('POST /register-partner setup-admin gate (still enforced pre-park)', () => {
   const originalFlag = process.env.IS_HOSTED;
 

--- a/apps/api/src/routes/auth/register.ts
+++ b/apps/api/src/routes/auth/register.ts
@@ -15,6 +15,11 @@ import { ANONYMOUS_ACTOR_ID } from '../../services/auditEvents';
 import { createAuditLog } from '../../services/auditService';
 import { captureException } from '../../services/sentry';
 import { createPendingRegistration } from '../../services/pendingRegistration';
+import {
+  businessEmailContactUrl,
+  businessEmailRequired,
+  isConsumerEmailDomain,
+} from '../../services/consumerEmailDomains';
 import { enqueueRegistrationVerification } from '../../services/authEmailQueue';
 import { getTrustedClientIpOrUndefined } from '../../services/clientIp';
 import {
@@ -175,6 +180,29 @@ registerRoutes.post('/register-partner', zValidator('json', registerPartnerSchem
   if (!passwordCheck.valid) {
     await floorPromise;
     return c.json({ error: passwordCheck.errors[0] }, 400);
+  }
+
+  // Hosted signup requires a business email. Like the password check above this
+  // is input-dependent, not account-dependent — the verdict is a pure function
+  // of the submitted address, so a 400 here discloses nothing about whether that
+  // address already has an account and does not reintroduce an existence-
+  // dependent branch (SR2-21). Placed before the argon2 hash so a rejected
+  // signup does not pay that cost.
+  //
+  // Recoverable by design: consumer-mailbox providers are used by real MSPs, so
+  // the response carries a scheduling link rather than a flat refusal.
+  if (businessEmailRequired(isHosted()) && isConsumerEmailDomain(email)) {
+    await floorPromise;
+    return c.json(
+      {
+        error:
+          'Please sign up with your business email address. If you do not have one, schedule a call and we will get you set up.',
+        code: 'BUSINESS_EMAIL_REQUIRED',
+        actionUrl: businessEmailContactUrl(),
+        actionLabel: 'Schedule a call',
+      },
+      400
+    );
   }
 
   // Hash BEFORE parking — a plaintext password is NEVER stored in the pending

--- a/apps/api/src/services/consumerEmailDomains.test.ts
+++ b/apps/api/src/services/consumerEmailDomains.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  emailDomainOf,
+  isConsumerEmailDomain,
+  businessEmailRequired,
+  businessEmailContactUrl,
+} from './consumerEmailDomains';
+
+const ENV_KEYS = [
+  'SIGNUP_EXTRA_CONSUMER_EMAIL_DOMAINS',
+  'SIGNUP_ALLOWED_EMAIL_DOMAINS',
+  'SIGNUP_REQUIRE_BUSINESS_EMAIL',
+  'SIGNUP_BUSINESS_EMAIL_CONTACT_URL',
+] as const;
+
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe('emailDomainOf', () => {
+  it('extracts and lowercases the domain', () => {
+    expect(emailDomainOf('Someone@Example.COM')).toBe('example.com');
+  });
+
+  it('uses the LAST @ so a quoted local part cannot smuggle a domain', () => {
+    expect(emailDomainOf('"a@gmail.com"@corp.example')).toBe('corp.example');
+  });
+
+  it('strips a trailing root dot', () => {
+    expect(emailDomainOf('a@gmail.com.')).toBe('gmail.com');
+  });
+
+  it('returns empty for malformed input rather than throwing', () => {
+    expect(emailDomainOf('no-at-sign')).toBe('');
+    expect(emailDomainOf('trailing@')).toBe('');
+  });
+});
+
+// Fixtures name the DOMAIN and let each case build the address. Two reasons:
+// the local part is never what is under test (the module only ever looks at the
+// domain), and a repo-wide guard rejects committed email literals outside a
+// small placeholder allowlist — see scripts/security/check-customer-pii.sh. The
+// production module already carries these provider domains as bare strings.
+const withLocalPart = (domain: string): string => `someone@${domain}`;
+
+describe('isConsumerEmailDomain', () => {
+  it.each([
+    'gmail.com',
+    'googlemail.com',
+    'outlook.com',
+    'hotmail.co.uk',
+    'yahoo.com.br',
+    'icloud.com',
+    'aol.com',
+    'proton.me',
+    'protonmail.com',
+    'mail.ru',
+    'rambler.ru',
+    'gmx.de',
+    'mailinator.com',
+    'yopmail.com',
+  ])('flags %s', (domain) => {
+    expect(isConsumerEmailDomain(withLocalPart(domain))).toBe(true);
+  });
+
+  // The rebrand that a tutanota-only list would have missed. This is the exact
+  // gap that caused a live paying partner to be miscounted during design.
+  it.each(['tutanota.com', 'tutamail.com', 'tuta.com', 'tuta.io'])(
+    'flags the Tuta/Tutanota rebrand variant %s',
+    (domain) => {
+      expect(isConsumerEmailDomain(withLocalPart(domain))).toBe(true);
+    }
+  );
+
+  // Shaped after real partner domains but deliberately synthetic: a public repo
+  // must not carry customer identifiers, and the assertion only needs a domain
+  // that is absent from the list.
+  it.each([
+    'msp-one.example',
+    'managed-services.example',
+    'it-support.example',
+    'regional-integrator.example',
+    'manufacturer.example',
+    'franchise-location.example',
+    // Stands in for a rural-ISP mailbox: not a business domain in spirit, but
+    // not on the list either — over-blocking a real customer is worse than
+    // missing one.
+    'rural-isp.example',
+  ])('does not flag the business domain %s', (domain) => {
+    expect(isConsumerEmailDomain(withLocalPart(domain))).toBe(false);
+  });
+
+  // Breaking this address fails Apple's App Store review.
+  it('does not flag the App Store reviewer demo domain', () => {
+    expect(isConsumerEmailDomain('appstore-review@breezermm.com')).toBe(false);
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(isConsumerEmailDomain('  Someone@GMAIL.com  ')).toBe(true);
+  });
+
+  it('does not flag a domain that merely contains a provider name', () => {
+    expect(isConsumerEmailDomain(withLocalPart('gmail.com.evil.example'))).toBe(false);
+    expect(isConsumerEmailDomain(withLocalPart('notgmail.com'))).toBe(false);
+    expect(isConsumerEmailDomain(withLocalPart('mygmail.com'))).toBe(false);
+  });
+
+  it('returns false for a malformed address instead of throwing', () => {
+    expect(isConsumerEmailDomain('garbage')).toBe(false);
+  });
+
+  it('honours additive extras from env', () => {
+    expect(isConsumerEmailDomain('a@newprovider.example')).toBe(false);
+    process.env.SIGNUP_EXTRA_CONSUMER_EMAIL_DOMAINS = 'newprovider.example, other.example';
+    expect(isConsumerEmailDomain('a@newprovider.example')).toBe(true);
+    expect(isConsumerEmailDomain('a@other.example')).toBe(true);
+  });
+
+  it('lets the allowlist override both the built-in list and the extras', () => {
+    process.env.SIGNUP_ALLOWED_EMAIL_DOMAINS = 'gmail.com';
+    expect(isConsumerEmailDomain('a@gmail.com')).toBe(false);
+
+    process.env.SIGNUP_EXTRA_CONSUMER_EMAIL_DOMAINS = 'stuck.example';
+    process.env.SIGNUP_ALLOWED_EMAIL_DOMAINS = 'stuck.example';
+    expect(isConsumerEmailDomain('a@stuck.example')).toBe(false);
+  });
+});
+
+describe('businessEmailRequired', () => {
+  it('is off for self-hosted regardless of env', () => {
+    expect(businessEmailRequired(false)).toBe(false);
+    process.env.SIGNUP_REQUIRE_BUSINESS_EMAIL = 'true';
+    expect(businessEmailRequired(false)).toBe(false);
+  });
+
+  it('defaults on when hosted', () => {
+    expect(businessEmailRequired(true)).toBe(true);
+  });
+
+  it.each(['false', 'FALSE', '0', 'no', 'off', ' off '])(
+    'is disabled by the explicit kill switch %s',
+    (value) => {
+      process.env.SIGNUP_REQUIRE_BUSINESS_EMAIL = value;
+      expect(businessEmailRequired(true)).toBe(false);
+    }
+  );
+
+  it('stays on for unrecognized values', () => {
+    process.env.SIGNUP_REQUIRE_BUSINESS_EMAIL = 'maybe';
+    expect(businessEmailRequired(true)).toBe(true);
+  });
+});
+
+describe('businessEmailContactUrl', () => {
+  it('falls back to a default', () => {
+    expect(businessEmailContactUrl()).toMatch(/^https:\/\//);
+  });
+
+  it('is overridable', () => {
+    process.env.SIGNUP_BUSINESS_EMAIL_CONTACT_URL = 'https://cal.example/breeze';
+    expect(businessEmailContactUrl()).toBe('https://cal.example/breeze');
+  });
+});

--- a/apps/api/src/services/consumerEmailDomains.ts
+++ b/apps/api/src/services/consumerEmailDomains.ts
@@ -1,0 +1,116 @@
+// Consumer / free / disposable mailbox providers, used to require a business
+// email address at hosted partner signup.
+//
+// WHY AN EXACT-MATCH SET AND NOT A PATTERN: the boundary between "consumer" and
+// "business" mail is genuinely fuzzy — a rural ISP mailbox and a franchise
+// corporate domain look alike, and privacy providers (Tuta, Proton) are used by
+// legitimate MSPs. A regex over provider names would over-match (e.g. any domain
+// containing "mail"). Exact matching keeps every rejection explainable: the
+// domain is on this list, or it is not.
+//
+// WHY THE LIST WILL NEVER BE COMPLETE: providers rebrand and add ccTLD variants
+// faster than a hard-coded list tracks them — Tutanota's move to `tutamail.com`
+// / `tuta.com` is the canonical example, and a list that had only `tutanota.com`
+// would silently miss it. That is an accepted limitation: this control raises
+// the cost of casual throwaway signups, it is not a security boundary. Anyone
+// determined can register a domain for a couple of dollars. Do NOT add
+// compensating cleverness here — add the domain, or extend via env.
+//
+// Every rejection is recoverable: the caller returns a scheduling link so a real
+// business on a consumer mailbox can still get an account.
+const CONSUMER_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  // Google
+  'gmail.com', 'googlemail.com',
+  // Microsoft
+  'outlook.com', 'outlook.co.uk', 'outlook.fr', 'outlook.de', 'outlook.es', 'outlook.it',
+  'hotmail.com', 'hotmail.co.uk', 'hotmail.fr', 'hotmail.de', 'hotmail.es', 'hotmail.it',
+  'live.com', 'live.co.uk', 'live.nl', 'live.fr', 'live.de', 'msn.com',
+  // Yahoo
+  'yahoo.com', 'yahoo.co.uk', 'yahoo.co.jp', 'yahoo.fr', 'yahoo.de', 'yahoo.es',
+  'yahoo.it', 'yahoo.ca', 'yahoo.com.br', 'yahoo.com.mx', 'yahoo.com.au',
+  'ymail.com', 'rocketmail.com',
+  // Apple
+  'icloud.com', 'me.com', 'mac.com',
+  // AOL
+  'aol.com', 'aim.com',
+  // Privacy-focused. Legitimate MSPs do use these, which is exactly why the
+  // scheduling escape hatch exists rather than a flat refusal.
+  'proton.me', 'protonmail.com', 'protonmail.ch', 'pm.me',
+  'tutanota.com', 'tutanota.de', 'tutamail.com', 'tuta.com', 'tuta.io',
+  'mailfence.com', 'hushmail.com', 'countermail.com',
+  // GMX / German consumer
+  'gmx.com', 'gmx.net', 'gmx.de', 'gmx.at', 'gmx.ch', 'web.de', 'freenet.de',
+  // Russian consumer portals
+  'mail.ru', 'inbox.ru', 'bk.ru', 'list.ru', 'yandex.ru', 'yandex.com', 'ya.ru', 'rambler.ru',
+  // Disposable / throwaway
+  'mailinator.com', 'guerrillamail.com', '10minutemail.com', 'tempmail.com',
+  'temp-mail.org', 'throwawaymail.com', 'yopmail.com', 'sharklasers.com',
+  'trashmail.com', 'maildrop.cc', 'getnada.com', 'dispostable.com',
+  'fakeinbox.com', 'mintemail.com', 'mohmal.com', 'emailondeck.com',
+]);
+
+function parseDomainList(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((d) => normalizeDomain(d))
+    .filter((d) => d.length > 0);
+}
+
+// Lowercase, trim, drop a trailing root dot. Not a validator — the caller has
+// already run Zod's `.email()`; this only canonicalizes for set lookup.
+function normalizeDomain(input: string): string {
+  return input.trim().toLowerCase().replace(/\.+$/, '');
+}
+
+/** Domain part of an address, or '' when there is no usable one. */
+export function emailDomainOf(email: string): string {
+  const at = email.lastIndexOf('@');
+  if (at < 0 || at === email.length - 1) return '';
+  return normalizeDomain(email.slice(at + 1));
+}
+
+// Env hooks are read at call time so both can be changed without a redeploy and
+// so tests can flip them per-case without `vi.resetModules()`.
+//
+// SIGNUP_EXTRA_CONSUMER_EMAIL_DOMAINS — additive; the list above will go stale.
+// SIGNUP_ALLOWED_EMAIL_DOMAINS — an explicit escape valve that WINS over both,
+// for when a real customer is stuck behind a listed provider and waiting on a
+// call is not acceptable.
+export function isConsumerEmailDomain(email: string): boolean {
+  const domain = emailDomainOf(email);
+  if (!domain) return false;
+
+  if (parseDomainList(process.env.SIGNUP_ALLOWED_EMAIL_DOMAINS).includes(domain)) return false;
+
+  return (
+    CONSUMER_EMAIL_DOMAINS.has(domain) ||
+    parseDomainList(process.env.SIGNUP_EXTRA_CONSUMER_EMAIL_DOMAINS).includes(domain)
+  );
+}
+
+/**
+ * Where a rejected signup is sent to talk to a human. Configurable so the
+ * scheduling link can change without a deploy.
+ */
+export function businessEmailContactUrl(): string {
+  return process.env.SIGNUP_BUSINESS_EMAIL_CONTACT_URL?.trim() || 'https://breezermm.com/contact';
+}
+
+/**
+ * Whether hosted signup requires a business email.
+ *
+ * Hosted-only by construction: a self-hosted operator registering their own
+ * partner with a personal address is entirely legitimate and must never be
+ * blocked. Callers pass `hosted` rather than reading `isHosted()` here so this
+ * module stays pure and trivially testable.
+ *
+ * Defaults ON when hosted, and is disabled ONLY by an explicit `false`. That
+ * direction is deliberate: this is a product restriction, not a security
+ * boundary, so an instant kill switch is worth more than fail-closed strictness
+ * if the list ever misfires against a real customer mid-signup.
+ */
+export function businessEmailRequired(hosted: boolean): boolean {
+  if (!hosted) return false;
+  const raw = (process.env.SIGNUP_REQUIRE_BUSINESS_EMAIL ?? '').trim().toLowerCase();
+  return !new Set(['0', 'false', 'no', 'off']).has(raw);
+}

--- a/apps/web/src/components/auth/PartnerRegisterForm.tsx
+++ b/apps/web/src/components/auth/PartnerRegisterForm.tsx
@@ -18,12 +18,17 @@ type PartnerRegisterFormValues = {
 type PartnerRegisterFormProps = {
   onSubmit?: (values: PartnerRegisterFormValues) => void | Promise<void>;
   errorMessage?: string;
+  // A recoverable rejection (e.g. a consumer email address at hosted signup)
+  // ships the way out with the message. The caller has already validated the
+  // scheme; this component only renders it.
+  errorAction?: { url: string; label: string };
   loading?: boolean;
 };
 
 export default function PartnerRegisterForm({
   onSubmit,
   errorMessage,
+  errorAction,
   loading
 }: PartnerRegisterFormProps) {
   const { t } = useTranslation('auth');
@@ -226,8 +231,19 @@ export default function PartnerRegisterForm({
       )}
 
       {errorMessage && (
-        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {errorMessage}
+        <div className="space-y-2 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          <p>{errorMessage}</p>
+          {errorAction && (
+            <a
+              href={errorAction.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="register-error-action"
+              className="inline-block font-medium underline underline-offset-2"
+            >
+              {errorAction.label}
+            </a>
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/auth/PartnerRegisterPage.test.tsx
+++ b/apps/web/src/components/auth/PartnerRegisterPage.test.tsx
@@ -79,4 +79,29 @@ describe('PartnerRegisterPage — SR2-21 email-first signup', () => {
     await submitValidForm();
     expect(await screen.findByTestId('register-check-email')).toBeInTheDocument();
   });
+
+  it('renders the recovery link when a rejection carries one (BUSINESS_EMAIL_REQUIRED)', async () => {
+    // The copy tells the user to schedule a call, so the link has to be
+    // clickable — a rejection that only prints the sentence is a dead end.
+    mockApiRegisterPartner.mockResolvedValue({
+      success: false,
+      error: 'Please sign up with your business email address.',
+      action: { url: 'https://breezermm.com/contact', label: 'Schedule a call' },
+    });
+    render(<PartnerRegisterPage />);
+    await submitValidForm();
+
+    const link = await screen.findByTestId('register-error-action');
+    expect(link).toHaveAttribute('href', 'https://breezermm.com/contact');
+    expect(link).toHaveTextContent('Schedule a call');
+  });
+
+  it('renders a plain rejection with no link when the server offers no next step', async () => {
+    mockApiRegisterPartner.mockResolvedValue({ success: false, error: 'Registration failed' });
+    render(<PartnerRegisterPage />);
+    await submitValidForm();
+
+    expect(await screen.findByText('Registration failed')).toBeInTheDocument();
+    expect(screen.queryByTestId('register-error-action')).toBeNull();
+  });
 });

--- a/apps/web/src/components/auth/PartnerRegisterPage.tsx
+++ b/apps/web/src/components/auth/PartnerRegisterPage.tsx
@@ -20,6 +20,7 @@ interface PartnerRegisterPageProps {
 export default function PartnerRegisterPage(_props: PartnerRegisterPageProps = {}) {
   const { t } = useTranslation('auth');
   const [error, setError] = useState<string>();
+  const [errorAction, setErrorAction] = useState<{ url: string; label: string }>();
   const [loading, setLoading] = useState(false);
   const [submitted, setSubmitted] = useState(false);
 
@@ -43,6 +44,7 @@ export default function PartnerRegisterPage(_props: PartnerRegisterPageProps = {
   }) => {
     setLoading(true);
     setError(undefined);
+    setErrorAction(undefined);
 
     const result = await apiRegisterPartner(
       values.companyName,
@@ -53,6 +55,7 @@ export default function PartnerRegisterPage(_props: PartnerRegisterPageProps = {
 
     if (!result.success) {
       setError(result.error);
+      setErrorAction(result.action);
       setLoading(false);
       return;
     }
@@ -101,6 +104,7 @@ export default function PartnerRegisterPage(_props: PartnerRegisterPageProps = {
     <PartnerRegisterForm
       onSubmit={handleRegister}
       errorMessage={error}
+      errorAction={errorAction}
       loading={loading}
     />
   );

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -6,6 +6,7 @@ import {
   apiLogin,
   apiLogout,
   apiPreviewInvite,
+  apiRegisterPartner,
   apiResetPassword,
   apiVerifyMFA,
   AuthSessionExpiredError,
@@ -1108,5 +1109,64 @@ describe('fetchAndApplyPreferences locale wiring', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const [message] = warnSpy.mock.calls[0] as [string];
     expect(message).toContain('locale resolution skipped');
+  });
+});
+
+describe('apiRegisterPartner recovery action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('surfaces an https recovery link from a rejection body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        makeResponse(
+          {
+            error: 'Please sign up with your business email address.',
+            code: 'BUSINESS_EMAIL_REQUIRED',
+            actionUrl: 'https://breezermm.com/contact',
+            actionLabel: 'Schedule a call'
+          },
+          false,
+          400
+        )
+      )
+    );
+
+    const result = await apiRegisterPartner('Acme', 'jane@gmail.com', 'pw', 'Jane');
+
+    expect(result).toMatchObject({
+      success: false,
+      action: { url: 'https://breezermm.com/contact', label: 'Schedule a call' }
+    });
+  });
+
+  it.each([
+    ['a javascript: scheme', 'javascript:alert(1)'],
+    ['a data: scheme', 'data:text/html,<script>alert(1)</script>'],
+    ['a relative path', '/contact']
+  ])('drops %s rather than rendering it as an href', async (_label, actionUrl) => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(makeResponse({ error: 'nope', actionUrl, actionLabel: 'Go' }, false, 400))
+    );
+
+    const result = await apiRegisterPartner('Acme', 'jane@gmail.com', 'pw', 'Jane');
+
+    expect(result).toEqual({ success: false, error: 'nope', action: undefined });
+  });
+
+  it('omits the action when the body carries no next step', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeResponse({ error: 'Registration failed' }, false, 400))
+    );
+
+    const result = await apiRegisterPartner('Acme', 'jane@acme.test', 'pw', 'Jane');
+
+    expect(result).toEqual({ success: false, error: 'Registration failed', action: undefined });
   });
 });

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -924,6 +924,26 @@ export async function apiVerifyPasskeyMFA(tempToken: string): Promise<ApiAuthSuc
   }
 }
 
+// An error body may offer a recoverable next step as `{ actionUrl, actionLabel }`.
+// Only absolute http(s) URLs are accepted: the value is rendered as an href, so a
+// `javascript:`/`data:` scheme must never survive even though the only producer
+// today is our own API reading an operator-set env var.
+function errorAction(data: unknown): { url: string; label: string } | undefined {
+  if (typeof data !== 'object' || data === null) return undefined;
+  const { actionUrl, actionLabel } = data as { actionUrl?: unknown; actionLabel?: unknown };
+  if (typeof actionUrl !== 'string' || typeof actionLabel !== 'string' || !actionLabel.trim()) {
+    return undefined;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(actionUrl);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return undefined;
+  return { url: parsed.href, label: actionLabel };
+}
+
 // SR2-21: register-partner is now email-first. The endpoint creates NOTHING and
 // returns a uniform `{ success: true, message }` whether or not the address
 // already has an account (anti-enumeration). No `user`/`partner`/`tokens`/
@@ -936,7 +956,7 @@ export async function apiRegisterPartner(
   name: string
 ): Promise<
   | { success: true; message: string }
-  | { success: false; error: string }
+  | { success: false; error: string; action?: { url: string; label: string } }
 > {
   try {
     const response = await fetch(buildApiUrl('/auth/register-partner'), {
@@ -949,7 +969,12 @@ export async function apiRegisterPartner(
     const data = await response.json();
 
     if (!response.ok) {
-      return { success: false, error: extractApiError(data, 'Registration failed') };
+      // A rejection may carry a recoverable next step (BUSINESS_EMAIL_REQUIRED
+      // returns a scheduling link). Dropping it would leave the copy telling
+      // the user to "schedule a call" with nothing to click. This is a failure
+      // shape only — it never runs on the success path, so it cannot
+      // reintroduce the enumeration branch SR2-21 removed.
+      return { success: false, error: extractApiError(data, 'Registration failed'), action: errorAction(data) };
     }
 
     return { success: true, message: data.message };


### PR DESCRIPTION
Hosted signup accepted any address, so a throwaway consumer mailbox was a
zero-cost way to stand up a partner — the entry point behind the recent
abuse clusters. This adds a business-email requirement to
`POST /auth/register-partner`, hosted-only, with a recoverable exit.

## API

- `services/consumerEmailDomains.ts` — an exact-match set of consumer / free /
  disposable providers. Exact matching, not a pattern: the consumer/business
  boundary is genuinely fuzzy and a regex over provider names over-matches. The
  list will go stale by construction (providers rebrand and add ccTLD variants
  faster than a hard-coded list tracks), which is accepted — this raises the
  cost of casual throwaway signups, it is not a security boundary.
- Two env hooks, read at call time so both change without a redeploy:
  - `SIGNUP_EXTRA_CONSUMER_EMAIL_DOMAINS` — additive.
  - `SIGNUP_ALLOWED_EMAIL_DOMAINS` — wins over both, for a real customer stuck
    behind a listed provider who cannot wait on a call.
  - `SIGNUP_REQUIRE_BUSINESS_EMAIL` — kill switch. Defaults ON when hosted and
    is disabled only by an explicit `false`: a product restriction that
    misfires against a real customer mid-signup is worse than a strict default.
  - `SIGNUP_BUSINESS_EMAIL_CONTACT_URL` — where a rejection sends them.
- Self-hosted is exempt by construction. An operator registering their own
  partner with a personal address is legitimate and must never be blocked.
- The check sits before the argon2 hash so a rejected signup does not pay that
  cost, and after the password check. Its verdict is a pure function of the
  submitted address, so the 400 discloses nothing about whether that address
  already has an account — no new enumeration branch (SR2-21).

## Web

The rejection body carries `actionUrl` / `actionLabel`. The register path
discarded them: `apiRegisterPartner` returns a closed union, `extractApiError`
reads only `error`, and the form renders a bare string — the user was told to
"schedule a call" with nothing to click. An optional `action` now threads
through the failure path and renders as a link. Only absolute http(s) URLs
survive, since the value becomes an href.

## Tests

`consumerEmailDomains.test.ts`, `register.test.ts` (74 API tests), plus web
coverage for the link, the no-link case, and `javascript:` / `data:` /
relative-URL rejection.