### PR TITLE
chore(rls): codify partner-axis RLS for the breeze-billing tables

### DIFF
--- a/apps/api/migrations/2026-08-10-billing-tables-partner-rls.sql
+++ b/apps/api/migrations/2026-08-10-billing-tables-partner-rls.sql
@@ -1,0 +1,49 @@
+-- Partner-axis RLS (shape 3) for the breeze-billing service's tables.
+--
+-- These tables are created by the separate breeze-billing service, which
+-- manages its own schema outside this repo's migrations. The billing service
+-- connects as an RLS-exempt role, so forcing RLS here does not affect it;
+-- the policies ensure any breeze_app access to these tables is partner-scoped,
+-- consistent with every other partner-axis table in this repo.
+--
+-- Guarded per-table: self-hosted deployments do not run breeze-billing,
+-- so the tables may be absent.
+
+DO $$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'billing_credit_balances',
+    'billing_credit_transactions',
+    'billing_events',
+    'billing_grace_periods',
+    'billing_subscriptions'
+  ] LOOP
+    IF to_regclass('public.' || t) IS NULL THEN
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', t);
+    EXECUTE format('ALTER TABLE public.%I FORCE ROW LEVEL SECURITY', t);
+
+    EXECUTE format('DROP POLICY IF EXISTS breeze_partner_isolation_select ON public.%I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_partner_isolation_insert ON public.%I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_partner_isolation_update ON public.%I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_partner_isolation_delete ON public.%I', t);
+
+    EXECUTE format(
+      'CREATE POLICY breeze_partner_isolation_select ON public.%I
+         FOR SELECT USING (public.breeze_has_partner_access(partner_id))', t);
+    EXECUTE format(
+      'CREATE POLICY breeze_partner_isolation_insert ON public.%I
+         FOR INSERT WITH CHECK (public.breeze_has_partner_access(partner_id))', t);
+    EXECUTE format(
+      'CREATE POLICY breeze_partner_isolation_update ON public.%I
+         FOR UPDATE USING (public.breeze_has_partner_access(partner_id))
+         WITH CHECK (public.breeze_has_partner_access(partner_id))', t);
+    EXECUTE format(
+      'CREATE POLICY breeze_partner_isolation_delete ON public.%I
+         FOR DELETE USING (public.breeze_has_partner_access(partner_id))', t);
+  END LOOP;
+END $$;


### PR DESCRIPTION
The five `billing_*` tables are created by the separate breeze-billing service,
which manages its own schema outside this repo (drizzle-kit push, no SQL
migrations). On both US and EU prod they had **no RLS, no policies, and
`breeze_app` held full DML** — invisible to `rls-coverage.integration.test.ts`
because they are not in this repo's Drizzle schema, so nothing would ever have
flagged it.

The cross-tenant audit that found this saw no evidence of actual cross-tenant
access; the gap was structural.

This migration is the repo-side record of a fix already applied by hand to both
prod databases. It is idempotent, so `autoMigrate` will no-op and ledger it at
the next release.

## Shape

Shape 3 (partner axis), flat `breeze_has_partner_access(partner_id)` — no tree
traversal — matching every other partner-axis table in the repo. Enable +
force, with select/insert/update/delete policies.

Guarded per table with `to_regclass`: self-hosted deployments do not run
breeze-billing, so the tables may be absent. On a fresh database the tables do
not exist at migration time either, so the file no-ops there by design — these
policies only ever land where breeze-billing has already created its schema.

Forcing RLS does not affect the billing service itself: it connects as an
RLS-exempt role. The policies constrain `breeze_app`, which is what the API
request path uses (`DATABASE_URL_APP`, NOBYPASSRLS, enforced by the config
validator).

## Verified on prod

`breeze_app` sees 0 rows without tenant context while the admin role sees the
full set; billing containers unaffected.

## Follow-up

Any future table created by a sidecar service in the shared database needs its
RLS shipped through this repo's migrations — nothing else will ever add or test
it. The contract test cannot cover these tables while they live outside the
Drizzle schema.