### PR TITLE
fix(ai): count tool executions in the usage rollup and refresh spend live

### DIFF
--- a/apps/api/src/services/aiAgentSdk.ts
+++ b/apps/api/src/services/aiAgentSdk.ts
@@ -1544,6 +1544,11 @@ function isScriptApplyTool(toolName: string): boolean {
  */
 export function createSessionPostToolUse(session: ActiveSession): PostToolUseCallback {
   return async (toolName, input, output, isError, durationMs, sealed) => {
+    // Count this tool call toward the turn's tool_execution_count rollup
+    // (consumed by streamingSessionManager's `result` handler) regardless of
+    // whether the DB writes below succeed — postToolUse only fires for a tool
+    // that actually ran, which is the event the counter tracks.
+    session.pendingTurnToolExecutionCount += 1;
     const toolUseId = session.toolUseIdQueue.shift();
     if (!toolUseId) {
       console.warn(`[AI-SDK] postToolUse: toolUseIdQueue empty for ${toolName} — tool_result will have no toolUseId`);

--- a/apps/api/src/services/aiCostTracker.test.ts
+++ b/apps/api/src/services/aiCostTracker.test.ts
@@ -75,7 +75,11 @@ function setupDbMocks(sessionModel: string | null) {
   const capture: {
     sessionSet?: Record<string, unknown>;
     aggregateValues: Array<Record<string, unknown>>;
-  } = { aggregateValues: [] };
+    // The `set` object passed to onConflictDoUpdate on each aggregate upsert —
+    // what actually gets applied when the (orgId, period, periodKey) row
+    // already exists, i.e. every call after the first for a given period.
+    aggregateConflictSets: Array<Record<string, unknown>>;
+  } = { aggregateValues: [], aggregateConflictSets: [] };
 
   mockDb.update.mockReturnValue({
     set: vi.fn((values: Record<string, unknown>) => {
@@ -87,7 +91,12 @@ function setupDbMocks(sessionModel: string | null) {
   mockDb.insert.mockReturnValue({
     values: vi.fn((values: Record<string, unknown>) => {
       capture.aggregateValues.push(values);
-      return { onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) };
+      return {
+        onConflictDoUpdate: vi.fn((arg: { set: Record<string, unknown> }) => {
+          capture.aggregateConflictSets.push(arg.set);
+          return Promise.resolve(undefined);
+        }),
+      };
     }),
   });
 
@@ -114,6 +123,12 @@ function setupDbMocks(sessionModel: string | null) {
 function recordedCostCents(captured: Record<string, unknown> | undefined): number {
   const expr = captured?.totalCostCents as { values?: unknown[] } | undefined;
   // sql`${col} + ${costCents}` → values = [colRef, costCents]
+  return Number(expr?.values?.[1]);
+}
+
+/** Extract the numeric increment from a `sql\`${col} + ${n}\`` expression under `key`. */
+function recordedIncrement(captured: Record<string, unknown> | undefined, key: string): number {
+  const expr = captured?.[key] as { values?: unknown[] } | undefined;
   return Number(expr?.values?.[1]);
 }
 
@@ -300,6 +315,74 @@ describe('recordUsageFromSdkResult', () => {
     });
 
     expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================
+// recordUsageFromSdkResult — tool_execution_count rollup
+// ============================================
+//
+// Regression: a completed tool execution (a real ai_tool_executions row) never
+// bumped ai_cost_usage.tool_execution_count on the live/SDK chat path. The
+// aggregate insert hardcoded toolExecutionCount: 0, and the onConflictDoUpdate
+// `set` didn't reference the column at all — so once the (orgId, period,
+// periodKey) row existed (the common case, since daily/monthly rows are
+// shared across many turns) the column could never move off 0 no matter how
+// many tool calls ran.
+
+describe('recordUsageFromSdkResult — tool_execution_count rollup', () => {
+  it('increments tool_execution_count on the INSERT path when a tool ran this turn', async () => {
+    const captured = setupDbMocks(null);
+
+    await recordUsageFromSdkResult('sess-tool-1', 'org-1', {
+      total_cost_usd: 0.11,
+      usage: { input_tokens: 50_000, output_tokens: 300 },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+      toolExecutionCount: 1,
+    });
+
+    expect(captured.aggregateValues).toHaveLength(2); // daily + monthly
+    for (const values of captured.aggregateValues) {
+      expect(values.toolExecutionCount).toBe(1);
+    }
+  });
+
+  it('increments tool_execution_count via the onConflictDoUpdate SET (the row-already-exists path)', async () => {
+    const captured = setupDbMocks(null);
+
+    await recordUsageFromSdkResult('sess-tool-2', 'org-1', {
+      total_cost_usd: 0.11,
+      usage: { input_tokens: 50_000, output_tokens: 300 },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+      toolExecutionCount: 1,
+    });
+
+    expect(captured.aggregateConflictSets).toHaveLength(2); // daily + monthly
+    for (const set of captured.aggregateConflictSets) {
+      // sql`${aiCostUsage.toolExecutionCount} + ${1}` — must add 1, not be absent/0.
+      expect(recordedIncrement(set, 'toolExecutionCount')).toBe(1);
+    }
+  });
+
+  it('leaves tool_execution_count untouched (adds 0) when no tool ran this turn', async () => {
+    const captured = setupDbMocks(null);
+
+    await recordUsageFromSdkResult('sess-no-tool', 'org-1', {
+      total_cost_usd: 0.05,
+      usage: { input_tokens: 1_000, output_tokens: 100 },
+      num_turns: 1,
+      model: 'claude-sonnet-4-6',
+      // toolExecutionCount omitted — must default to 0, not throw or skip the column.
+    });
+
+    for (const values of captured.aggregateValues) {
+      expect(values.toolExecutionCount).toBe(0);
+    }
+    for (const set of captured.aggregateConflictSets) {
+      expect(recordedIncrement(set, 'toolExecutionCount')).toBe(0);
+    }
   });
 });
 

--- a/apps/api/src/services/aiCostTracker.ts
+++ b/apps/api/src/services/aiCostTracker.ts
@@ -438,6 +438,12 @@ export async function recordUsageFromSdkResult(
     num_turns: number;
     /** Model id the SDK ran with. Used to price tokens when total_cost_usd is 0. */
     model?: string;
+    /**
+     * Number of tool calls completed during this turn, for the
+     * `ai_cost_usage.tool_execution_count` rollup. Defaults to 0 — callers that
+     * don't track tool calls (or turns with none) leave the counter untouched.
+     */
+    toolExecutionCount?: number;
   }
 ): Promise<void> {
   if (!orgId) {
@@ -450,6 +456,7 @@ export async function recordUsageFromSdkResult(
     cache_read_input_tokens: cacheReadTokens = 0,
     cache_creation_input_tokens: cacheCreationTokens = 0,
   } = result.usage;
+  const toolExecutionCount = result.toolExecutionCount ?? 0;
 
   // What the `*_input_tokens` COLUMNS store. Kept distinct from the three
   // variables above, which stay split because each is billed at its own rate.
@@ -525,7 +532,7 @@ export async function recordUsageFromSdkResult(
           totalCostCents: costCents,
           sessionCount: 0,
           messageCount: 1,
-          toolExecutionCount: 0
+          toolExecutionCount
         })
         .onConflictDoUpdate({
           target: [aiCostUsage.orgId, aiCostUsage.period, aiCostUsage.periodKey],
@@ -534,6 +541,11 @@ export async function recordUsageFromSdkResult(
             outputTokens: sql`${aiCostUsage.outputTokens} + ${outputTokens}`,
             totalCostCents: sql`${aiCostUsage.totalCostCents} + ${costCents}`,
             messageCount: sql`${aiCostUsage.messageCount} + 1`,
+            // Was missing entirely — every SDK-path turn (the normal chat flow,
+            // as opposed to the sessionless recordUsage() path) upserted this row
+            // without ever touching tool_execution_count, so it stayed 0 forever
+            // even though ai_tool_executions rows were being written correctly.
+            toolExecutionCount: sql`${aiCostUsage.toolExecutionCount} + ${toolExecutionCount}`,
             updatedAt: now
           }
         });

--- a/apps/api/src/services/streamingSessionManager.ts
+++ b/apps/api/src/services/streamingSessionManager.ts
@@ -341,6 +341,14 @@ export interface ActiveSession {
    */
   pendingTurnUsage: PendingTurnUsage;
   /**
+   * Count of tool calls completed (postToolUse fired) during the current turn.
+   * Fed into recordUsageFromSdkResult's toolExecutionCount so the
+   * `ai_cost_usage.tool_execution_count` rollup actually increments — mirrors
+   * pendingTurnUsage's accumulate-then-flush-on-`result` lifecycle. Reset to 0
+   * after every flush (normal `result` or the abandoned-turn fallback below).
+   */
+  pendingTurnToolExecutionCount: number;
+  /**
    * tool_use id → bare tool name, recorded at content_block_start alongside
    * toolUseIdQueue. Consumed by postToolUse on the normal path, or by the
    * dropped-call fallback in the background processor's 'user' case when the
@@ -580,6 +588,7 @@ export class StreamingSessionManager {
       mcpPrefix: MCP_PREFIX, // updated below if custom factory
       toolUseIdQueue: [],
       pendingTurnUsage: emptyPendingTurnUsage(),
+      pendingTurnToolExecutionCount: 0,
       toolUseNames: new Map(),
       processorPromise: Promise.resolve(),
       turnTimeoutId: null,
@@ -1032,6 +1041,8 @@ export class StreamingSessionManager {
             const effectiveUsage = hasTokens(sdkReported) ? sdkReported : session.pendingTurnUsage;
             // Consumed (or superseded by the SDK's own numbers) — reset for the next turn.
             session.pendingTurnUsage = emptyPendingTurnUsage();
+            const turnToolExecutionCount = session.pendingTurnToolExecutionCount;
+            session.pendingTurnToolExecutionCount = 0;
 
             const usageData = {
               total_cost_usd: resultMsg.total_cost_usd ?? 0,
@@ -1044,6 +1055,8 @@ export class StreamingSessionManager {
               num_turns: resultMsg.num_turns ?? 0,
               // Model id for token-based cost fallback when the SDK reports $0.
               model: session.model,
+              // Tool calls completed this turn — feeds ai_cost_usage.tool_execution_count.
+              toolExecutionCount: turnToolExecutionCount,
             };
 
             if (!hasTokens(sdkReported)) {
@@ -1141,9 +1154,11 @@ export class StreamingSessionManager {
       // already spent on model API calls still land in the session counters
       // and org cost aggregates (#3095). Zero after a normal turn — the
       // accumulator is reset when each `result` is recorded.
-      if (hasTokens(session.pendingTurnUsage)) {
+      if (hasTokens(session.pendingTurnUsage) || session.pendingTurnToolExecutionCount > 0) {
         const abandoned = session.pendingTurnUsage;
         session.pendingTurnUsage = emptyPendingTurnUsage();
+        const abandonedToolExecutionCount = session.pendingTurnToolExecutionCount;
+        session.pendingTurnToolExecutionCount = 0;
         // Awaited (not fire-and-forget): the most common abandoned-turn trigger
         // is process shutdown (deploy/SIGTERM), where an untracked promise can
         // be killed before it settles — silently, since even the .catch would
@@ -1163,6 +1178,7 @@ export class StreamingSessionManager {
               },
               num_turns: 1,
               model: session.model,
+              toolExecutionCount: abandonedToolExecutionCount,
             })
           );
         } catch (err) {

--- a/apps/web/src/components/ai/AiChatSidebar.tsx
+++ b/apps/web/src/components/ai/AiChatSidebar.tsx
@@ -285,7 +285,7 @@ export default function AiChatSidebar() {
           /* Chat panel */
           <>
             {/* Cost indicator */}
-            <AiCostIndicator enabled={isOpen} />
+            <AiCostIndicator enabled={isOpen} isStreaming={isStreaming} />
 
             {/* M365 customer selector — only when starting a new session */}
             {!sessionId && m365Connections.length > 0 && (

--- a/apps/web/src/components/ai/AiCostIndicator.test.tsx
+++ b/apps/web/src/components/ai/AiCostIndicator.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AiCostIndicator from './AiCostIndicator';
 import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { formatCurrency } from '@/lib/i18n/format';
 
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
@@ -50,6 +51,89 @@ describe('AiCostIndicator polling behavior', () => {
     });
 
     // After a 401, polling should have stopped — still only 1 call
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AiCostIndicator post-turn refresh (defect: stale header through a completed exchange)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    useAuthStoreMock.mockImplementation((selector: any) => selector({ isAuthenticated: true }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const zeroUsage = {
+    daily: { totalCostCents: 0, messageCount: 0 },
+    monthly: { totalCostCents: 0, messageCount: 0 },
+    budget: null,
+  };
+  const oneMessageUsage = {
+    daily: { totalCostCents: 11, messageCount: 1 },
+    monthly: { totalCostCents: 11, messageCount: 1 },
+    budget: null,
+  };
+
+  it('refetches immediately when isStreaming flips true -> false, without waiting for the 60s poll', async () => {
+    fetchWithAuthMock
+      .mockResolvedValueOnce(makeJsonResponse(zeroUsage))
+      .mockResolvedValueOnce(makeJsonResponse(oneMessageUsage));
+
+    const { rerender, container } = render(<AiCostIndicator isStreaming />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain(formatCurrency(0));
+
+    // The exchange completes — the store flips isStreaming to false.
+    rerender(<AiCostIndicator isStreaming={false} />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Refetched right away — no 60s timer advance needed — and the header
+    // reflects the new spend/message count instead of staying at $0.00 / 0 msgs.
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain(formatCurrency(0.11));
+  });
+
+  it('does not refetch on mount or re-render when isStreaming is omitted (back-compat, poll-only)', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse(zeroUsage));
+
+    const { rerender } = render(<AiCostIndicator />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+
+    rerender(<AiCostIndicator />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // No isStreaming prop → the post-turn refresh effect never fires.
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refetch on the false -> true edge (turn starting, not completing)', async () => {
+    fetchWithAuthMock.mockResolvedValue(makeJsonResponse(zeroUsage));
+
+    const { rerender } = render(<AiCostIndicator isStreaming={false} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
+
+    rerender(<AiCostIndicator isStreaming />);
+    await act(async () => {
+      await Promise.resolve();
+    });
     expect(fetchWithAuthMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/ai/AiCostIndicator.tsx
+++ b/apps/web/src/components/ai/AiCostIndicator.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Coins } from "lucide-react";
 import { fetchWithAuth, useAuthStore } from "../../stores/auth";
 import { cn, widthPercentClass } from "@/lib/utils";
@@ -19,14 +19,50 @@ interface UsageData {
 
 interface AiCostIndicatorProps {
   enabled?: boolean;
+  /**
+   * True while an AI turn is actively streaming, false once it completes.
+   * Used to trigger an immediate usage refetch on the true→false edge — the
+   * indicator otherwise only refreshes on its 60s poll, which left the header
+   * ("$0.00 this month" / "0 msgs") stale through an entire completed
+   * exchange, including one with a tool call, until the next tick or a full
+   * page reload. Omit this prop to keep the old poll-only behavior.
+   */
+  isStreaming?: boolean;
 }
 
 export default function AiCostIndicator({
   enabled = true,
+  isStreaming,
 }: AiCostIndicatorProps) {
   const { t } = useTranslation("ai");
   const [usage, setUsage] = useState<UsageData | null>(null);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const wasStreamingRef = useRef(false);
+
+  // Refresh immediately when a turn just finished (true -> false), instead of
+  // waiting up to 60s for the next poll tick. Kept as a separate effect from
+  // the polling one below so it doesn't disturb the poll interval's lifecycle
+  // (401/error backoff, mount/unmount) on every streaming-state change.
+  useEffect(() => {
+    const wasStreaming = wasStreamingRef.current;
+    wasStreamingRef.current = !!isStreaming;
+    if (!enabled || !isAuthenticated || !wasStreaming || isStreaming) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetchWithAuth("/ai/usage");
+        if (res.ok && !cancelled) {
+          setUsage(await res.json());
+        }
+      } catch (err) {
+        console.warn("[AiCostIndicator] post-turn usage refresh failed:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isStreaming, enabled, isAuthenticated]);
 
   useEffect(() => {
     if (!enabled || !isAuthenticated) {

--- a/apps/web/src/components/workspace/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/workspace/WorkspaceChatPanel.tsx
@@ -91,7 +91,7 @@ export default function WorkspaceChatPanel({ tab }: WorkspaceChatPanelProps) {
       </div>
 
       {/* Cost indicator */}
-      <AiCostIndicator enabled />
+      <AiCostIndicator enabled isStreaming={tab.isStreaming} />
 
       {/* Context badge */}
       {tab.pageContext && (


### PR DESCRIPTION
## AI usage reporting — tool executions counted, spend refreshes live

Split out of #3278, where it was incidental to the fleet work and touched no fleet file. Cherry-picked clean onto `main`; nothing else in that PR depends on it.

Two defects in AI usage reporting, both found by QA against a live stack.

### `ai_cost_usage.tool_execution_count` never left 0

`recordUsageFromSdkResult` — the path the streaming chat actually uses — hardcoded `toolExecutionCount: 0` on insert and never referenced the column in its `onConflictDoUpdate` set. The sibling `recordUsage()`, used only by sessionless catalog enrichment, handled `isToolExecution` correctly, which is why tokens, cost and `message_count` incremented while the tool counter stayed pinned at 0 no matter how many `ai_tool_executions` rows were written.

A per-turn counter is now threaded from the SDK post-tool hook through `streamingSessionManager` into both `recordUsageFromSdkResult` call sites, including the abandoned-turn flush.

### The spend indicator read `$0.00` through an entire exchange

`AiCostIndicator` only refreshed on mount and on a 60s interval, so it showed "$0.00 this month / 0 msgs" for the whole conversation and corrected only on a full page reload. It now takes `isStreaming` and refetches on the `true → false` edge. The existing poll and its backoff are untouched.

### Testing

- `apps/api` suite green (20,729 passed / 28 skipped).
- `apps/web` suite green (5,105 passed across 538 files).
- New coverage in `aiCostTracker.test.ts` (counter threading, conflict-update path, abandoned-turn flush) and `AiCostIndicator.test.tsx` (refetch on the streaming edge, no refetch while streaming).

### Self-hosters / ops

No migration, no new env vars. `tool_execution_count` starts accumulating from deploy; historical rows stay 0 and are not backfilled — the underlying `ai_tool_executions` rows were always written, so the true history is recoverable from there if anyone needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
