### PR TITLE
fix(api): give blocking Redis consumers their own connections

### DIFF
--- a/apps/api/src/__tests__/setup.ts
+++ b/apps/api/src/__tests__/setup.ts
@@ -42,6 +42,7 @@ vi.mock('../services/redis', () => {
   return {
     getRedis: vi.fn(() => redisClient),
     getRedisConnection: vi.fn(() => redisClient),
+    createBlockingRedisConnection: vi.fn(() => redisClient),
     getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
     isBullMQAvailable: vi.fn(() => true),
     isRedisAvailable: vi.fn(() => true)

--- a/apps/api/src/services/eventBus.test.ts
+++ b/apps/api/src/services/eventBus.test.ts
@@ -3,7 +3,8 @@ import type { Redis } from 'ioredis';
 
 vi.mock('./redis', () => ({
   getRedis: vi.fn(),
-  getRedisConnection: vi.fn()
+  getRedisConnection: vi.fn(),
+  createBlockingRedisConnection: vi.fn()
 }));
 
 // Mock the db module so we can assert `runOutsideDbContext` is invoked

--- a/apps/api/src/services/eventBus.ts
+++ b/apps/api/src/services/eventBus.ts
@@ -1,5 +1,5 @@
 import Redis from 'ioredis';
-import { getRedisConnection } from './redis';
+import { createBlockingRedisConnection, getRedisConnection } from './redis';
 import { randomUUID } from 'crypto';
 import { runOutsideDbContext } from '../db';
 
@@ -172,6 +172,14 @@ class EventBus {
   private consumerName: string;
   private isConsuming = false;
   private redisClient: Redis | null = null;
+  /**
+   * Dedicated connection for the `XREADGROUP ... BLOCK 5000` in
+   * `consumeLoop` — see `createBlockingRedisConnection`. Lazily created
+   * (never at import time, and never before `startConsuming()` actually
+   * runs) and cached for the bus's lifetime; a new connection per loop
+   * iteration would churn a TCP connect + AUTH every 5 seconds forever.
+   */
+  private blockingRedisClient: Redis | null = null;
 
   constructor() {
     this.consumerName = `consumer-${process.pid}-${randomUUID().slice(0, 8)}`;
@@ -187,6 +195,26 @@ class EventBus {
     }
     this.redisClient = getRedisConnection();
     return this.redisClient;
+  }
+
+  /**
+   * Get or create the dedicated blocking connection used ONLY for
+   * `XREADGROUP ... BLOCK` in `consumeLoop`. Redis serves one command at a
+   * time per connection, and ioredis queues everything else behind an
+   * in-flight command — so a blocking read on the shared connection from
+   * `getOrCreateRedis()` (the same connection `getBullMQConnection()` hands
+   * to every BullMQ `Queue`) would stall every other command on it,
+   * including request-path job enqueues, by up to the full block timeout.
+   * This is the identical defect fixed in `webhookDelivery.ts`'s `BRPOP`
+   * loop; every non-blocking command in this class (publish's `xadd` /
+   * `publish`, consumer-group creation, `xack`, etc.) deliberately stays on
+   * `getOrCreateRedis()`.
+   */
+  private getBlockingRedis(): Redis {
+    if (!this.blockingRedisClient || this.blockingRedisClient.status === 'end') {
+      this.blockingRedisClient = createBlockingRedisConnection('breeze:event-bus:xreadgroup');
+    }
+    return this.blockingRedisClient;
   }
 
   /**
@@ -367,14 +395,19 @@ class EventBus {
   }
 
   private async consumeLoop(orgIds: string[]): Promise<void> {
+    // `redis` handles all NON-blocking commands (xack/lpush inside
+    // processMessage) and stays on the shared connection. Only the blocking
+    // XREADGROUP read below moves to its own connection — see
+    // `getBlockingRedis`.
     const redis = this.getOrCreateRedis();
     const streams = orgIds.map(orgId => `${STREAM_PREFIX}:${orgId}`);
     const streamArgs = streams.flatMap(s => [s, '>']);
 
     while (this.isConsuming) {
       try {
-        // Read from all streams with blocking
-        const results = await redis.xreadgroup(
+        // Read from all streams with blocking. MUST run on the dedicated
+        // connection (see getBlockingRedis) — not the shared one.
+        const results = await this.getBlockingRedis().xreadgroup(
           'GROUP',
           CONSUMER_GROUP,
           this.consumerName,

--- a/apps/api/src/services/redis.ts
+++ b/apps/api/src/services/redis.ts
@@ -176,6 +176,14 @@ export async function closeRedis(): Promise<void> {
     }
     bullmqConnection = null;
   }
+  const blocking = blockingConnections.splice(0, blockingConnections.length);
+  for (const conn of blocking) {
+    try {
+      await conn.quit();
+    } catch (err) {
+      console.warn('[redis] closeRedis: blocking connection quit() failed (connection already closed?):', err);
+    }
+  }
 }
 
 let bullmqConnection: Redis | null = null;
@@ -219,6 +227,38 @@ export function getRedisConnection(): Redis {
   }
 
   return bullmqConnection;
+}
+
+const blockingConnections: Redis[] = [];
+
+/**
+ * Create a DEDICATED connection for a long-blocking read loop
+ * (`BRPOP`/`BLPOP`/`XREAD BLOCK`/`BZPOPMIN`).
+ *
+ * Redis serves one command per connection at a time, and ioredis queues
+ * everything else behind the in-flight command. So a single consumer sitting
+ * in `brpop(queue, 5)` on the connection returned by `getRedisConnection()`
+ * does not just slow itself down — it adds up to a FULL BLOCK TIMEOUT of
+ * latency to every other command on that connection, including every BullMQ
+ * `Queue` write issued from an HTTP request path. That is not theoretical:
+ * `POST /fleet/findings/:id/remediate` measured 8-27s end-to-end (a bare
+ * `PING` on the shared connection took 4.6-5.2s) purely because the webhook
+ * delivery worker's 5-second `BRPOP` owned the socket, while Redis's own
+ * SLOWLOG stayed empty and event-loop lag stayed under 50ms.
+ *
+ * Each caller gets its OWN connection — deliberately not a shared "blocking
+ * singleton", which would just recreate the same head-of-line blocking
+ * between two blocking consumers. Callers should create one at startup and
+ * cache it, never per iteration. Duplicated off the BullMQ connection so it
+ * inherits `maxRetriesPerRequest: null`, which blocking commands require.
+ */
+export function createBlockingRedisConnection(connectionName: string): Redis {
+  const conn = getRedisConnection().duplicate({ connectionName });
+  conn.on('error', (err: Error) => {
+    console.error(`[Redis] Blocking connection '${connectionName}' error:`, err.message);
+  });
+  blockingConnections.push(conn);
+  return conn;
 }
 
 /**

--- a/apps/api/src/workers/webhookDelivery.test.ts
+++ b/apps/api/src/workers/webhookDelivery.test.ts
@@ -7,6 +7,7 @@ const { safeFetchMock, validateWebhookUrlSafetyWithDnsMock } = vi.hoisted(() => 
 
 vi.mock('../services/redis', () => ({
   getRedisConnection: vi.fn(),
+  createBlockingRedisConnection: vi.fn(),
 }));
 
 vi.mock('../services/eventBus', () => ({

--- a/apps/api/src/workers/webhookDelivery.ts
+++ b/apps/api/src/workers/webhookDelivery.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomUUID } from 'crypto';
-import { getRedisConnection } from '../services/redis';
+import { createBlockingRedisConnection, getRedisConnection } from '../services/redis';
+import type Redis from 'ioredis';
 import { getEventBus, type BreezeEvent } from '../services/eventBus';
 import { validateWebhookUrlSafetyWithDns } from '../services/notificationSenders/webhookSender';
 import { safeFetch, SsrfBlockedError } from '../services/urlSafety';
@@ -212,6 +213,20 @@ function calculateRetryDelay(
 class WebhookDeliveryWorker {
   private isRunning = false;
   private onDeliveryComplete?: (result: WebhookDeliveryResult) => Promise<void>;
+  /**
+   * Dedicated connection for the `BRPOP` in `processNextJob` — see
+   * `createBlockingRedisConnection`. Lazily created (never at import time) and
+   * cached for the worker's lifetime; a new connection per loop iteration
+   * would churn a TCP connect + AUTH every 5 seconds forever.
+   */
+  private blockingRedis: Redis | null = null;
+
+  private getBlockingRedis(): Redis {
+    if (!this.blockingRedis || this.blockingRedis.status === 'end') {
+      this.blockingRedis = createBlockingRedisConnection('breeze:webhook-delivery:brpop');
+    }
+    return this.blockingRedis;
+  }
 
   /**
    * Set callback for delivery completion (for updating database)
@@ -273,8 +288,13 @@ class WebhookDeliveryWorker {
     const redis = getRedisConnection();
 
     try {
-      // Blocking pop with 5 second timeout
-      const result = await redis.brpop(WEBHOOK_QUEUE, 5);
+      // Blocking pop with 5 second timeout. This MUST run on its own
+      // connection: Redis serves one command at a time per connection, so a
+      // BRPOP here on the shared connection stalls every other command on it
+      // — including the BullMQ `Queue` writes that HTTP handlers await — by
+      // up to the full 5s block. Non-blocking commands below stay on the
+      // shared connection.
+      const result = await this.getBlockingRedis().brpop(WEBHOOK_QUEUE, 5);
 
       if (!result) return; // Timeout, no jobs
 


### PR DESCRIPTION
## Blocking Redis consumers were stalling every job enqueue in the app

Split out of #3278, where it was incidental to the fleet work and touched no fleet file. Cherry-picked clean onto `main`; nothing else in that PR depends on it.

**This is not a fleet bug — it degraded every request that enqueues a job.** It was found while profiling fleet remediation, which is the only reason it surfaced there.

### The defect

`webhookDelivery`'s queue loop issued a 5-second blocking `BRPOP` on the singleton ioredis connection returned by `getRedisConnection()` — the same connection `getBullMQConnection()` hands to every BullMQ `Queue`. Redis serves one command per connection and ioredis queues everything behind the in-flight command, so every request-path enqueue sat behind that block.

Measured on a local stack:

| Signal | Value |
|---|---|
| Bare `PING` on the shared connection | **4.6s** |
| Event-loop lag | 21ms |
| All DB work | 11–66ms |
| Redis `SLOWLOG` @ 20ms threshold | **empty** |
| `CLIENT LIST` | client parked in `cmd=brpop` |
| `POST /fleet/findings/:id/remediate` | 8.1–26.9s → **41–88ms** |

The empty `SLOWLOG` is the trap: Redis itself is never slow, so every server-side metric looks healthy while the client-side connection is head-of-line blocked. `PING` is what reveals it.

### The fix

Adds `createBlockingRedisConnection()` in `services/redis.ts`, which duplicates a **dedicated connection per blocking consumer** and quits them in `closeRedis()`. Deliberately not a shared "blocking singleton" — that would just recreate the same head-of-line blocking among the blocking consumers.

BullMQ's own workers were never the cause; `bullmq` already duplicates for its blocking connections.

The second commit applies the same fix to `services/eventBus.ts`'s `consumeLoop()` (`XREADGROUP ... BLOCK 5000`, identical defect). That one is **dormant** — nothing calls `startConsuming()` outside tests — so it costs nothing today, but it would reintroduce the app-wide stall the moment event-bus consumption is enabled. Only the blocking read moves; every non-blocking command in the class (`xadd`, pub/sub, consumer-group create, `xack`/`lpush`, `xrange`, `xpending`, dead-letter `lrange`/`lindex`/`lrem`) stays on the shared connection. The connection is created lazily so a bus that never consumes never opens one, and cached so the loop doesn't churn a TCP connect + AUTH every five seconds.

### Testing

`apps/api` suite green — 20,726 passed / 28 skipped across 1,299 files.

**One caveat worth stating rather than burying:** the first of three local runs had a single unidentified test failure that did not reproduce on the two subsequent runs, and I did not capture which test it was before it went green. Given this PR changes Redis connection lifecycle and touches `__tests__/setup.ts`, I'd rather flag that than call the run clean. CI is the check — if it reproduces there it'll be named, and I'll chase it.

### Self-hosters / ops

No migration, no new env vars. Net effect is a small number of additional Redis connections — one per blocking consumer (currently: webhook delivery, plus the event bus only if consumption is ever enabled). Anyone running a connection-capped managed Redis should be aware of the +1/+2, though it is negligible next to BullMQ's existing per-worker duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
