### PR TITLE
fix(web): walk every page of /scripts so the full library is reachable (#3301)

### DIFF
--- a/apps/web/src/components/configurationPolicies/featureTabs/RemediationScriptPicker.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/RemediationScriptPicker.tsx
@@ -1,10 +1,9 @@
 import { useState, useMemo, useEffect } from "react";
 import { X, Search, FileCode, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { fetchWithAuth } from "../../../stores/auth";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
-import { asList } from '@/lib/asList';
+import { fetchAllScripts } from '@/lib/scriptsFetch';
 export type ScriptLanguage = "powershell" | "bash" | "python" | "cmd";
 export type OSType = "windows" | "macos" | "linux";
 export type SelectedScript = {
@@ -70,16 +69,9 @@ export default function RemediationScriptPicker({
     try {
       setLoading(true);
       setError(undefined);
-      const response = await fetchWithAuth("/scripts");
-      if (!response.ok) {
-        throw new Error(
-          i18n.t(
-            "policies:configurationPolicies.featureTabs.remediationScriptPicker.failedToFetchScripts",
-          ),
-        );
-      }
-      const data = await response.json();
-      const scriptList = asList(data, 'scripts');
+      // #3301 — walk every page; a remediation script past the first 50 could
+      // not be selected at all.
+      const { data: scriptList } = await fetchAllScripts();
       const transformedScripts: ScriptRow[] = scriptList.map(
         (s: Record<string, unknown>) => ({
           id: s.id as string,
@@ -92,6 +84,15 @@ export default function RemediationScriptPicker({
       );
       setScripts(transformedScripts);
     } catch (err) {
+      // fetchAllScripts throws the failed Response, not an Error.
+      if (err instanceof Response) {
+        setError(
+          i18n.t(
+            "policies:configurationPolicies.featureTabs.remediationScriptPicker.failedToFetchScripts",
+          ),
+        );
+        return;
+      }
       setError(err instanceof Error ? err.message : "Failed to load scripts");
     } finally {
       setLoading(false);

--- a/apps/web/src/components/devices/ScriptPickerModal.tsx
+++ b/apps/web/src/components/devices/ScriptPickerModal.tsx
@@ -3,11 +3,10 @@ import { X, Search, Play, Loader2, ChevronLeft } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { Dialog } from '../shared/Dialog';
-import { fetchWithAuth } from '../../stores/auth';
 import { fetchLiveSessions, type LiveSession } from '../../services/deviceActions';
 import type { ScriptParameter } from '../scripts/ScriptFormSchema';
 import ScriptParametersForm, { validateParameters } from '../scripts/ScriptParametersForm';
-import { asList } from '@/lib/asList';
+import { fetchAllScripts } from '@/lib/scriptsFetch';
 
 export type ScriptLanguage = 'powershell' | 'bash' | 'python' | 'cmd';
 export type OSType = 'windows' | 'macos' | 'linux';
@@ -101,13 +100,9 @@ export default function ScriptPickerModal({
       setLoading(true);
       setError(undefined);
 
-      const response = await fetchWithAuth('/scripts?includeSystem=true');
-      if (!response.ok) {
-        throw new Error(t('scriptPickerModal.errors.fetch'));
-      }
-
-      const data = await response.json();
-      const scriptList = asList(data, 'scripts');
+      // #3301 — walk every page; a bare request returned only the first 50, so
+      // a script past that could not be picked to run on a device.
+      const { data: scriptList } = await fetchAllScripts({ includeSystem: true });
 
       // Transform scripts
       const transformedScripts: Script[] = scriptList
@@ -124,6 +119,11 @@ export default function ScriptPickerModal({
 
       setScripts(transformedScripts);
     } catch (err) {
+      // fetchAllScripts throws the failed Response, not an Error.
+      if (err instanceof Response) {
+        setError(t('scriptPickerModal.errors.fetch'));
+        return;
+      }
       setError(err instanceof Error ? err.message : t('scriptPickerModal.errors.load'));
     } finally {
       setLoading(false);

--- a/apps/web/src/components/scripts/ScriptCategoryTree.tsx
+++ b/apps/web/src/components/scripts/ScriptCategoryTree.tsx
@@ -12,7 +12,7 @@ import {
 import { cn, leftPxClass, paddingLeftPxClass, topPxClass } from '@/lib/utils';
 import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
-import { asList } from '@/lib/asList';
+import { fetchAllScripts } from '@/lib/scriptsFetch';
 
 type ScriptCategory = {
   id: string;
@@ -178,17 +178,14 @@ export default function ScriptCategoryTree({
       setLoading(true);
       setError(undefined);
 
-      const response = await fetchWithAuth('/scripts?includeSystem=true');
-      if (!response.ok) {
-        if (response.status === 401) {
-          void navigateTo('/login', { replace: true });
-          return;
-        }
-        throw new Error(t('scriptCategoryTree.errors.fetch'));
-      }
-
-      const data = await response.json();
-      const scriptList = asList(data, 'scripts');
+      // #3301 — walk every page so the category tree reflects the whole
+      // library rather than whatever fell in the first 50 rows.
+      const { data: scriptList } = await fetchAllScripts<{
+        id: string;
+        name: string;
+        category?: string | null;
+        status?: string;
+      }>({ includeSystem: true });
 
       // Build categories from script data
       const categoryTree = buildCategoryTree(scriptList);
@@ -196,12 +193,7 @@ export default function ScriptCategoryTree({
       setExpandedIds(new Set(categoryTree.map(cat => cat.id)));
 
       // Build script items
-      const scriptItems: ScriptItem[] = scriptList.map((script: {
-        id: string;
-        name: string;
-        category?: string | null;
-        status?: string;
-      }) => ({
+      const scriptItems: ScriptItem[] = scriptList.map((script) => ({
         id: script.id,
         name: script.name,
         categoryId: script.category
@@ -212,6 +204,16 @@ export default function ScriptCategoryTree({
 
       setScripts(scriptItems);
     } catch (err) {
+      // fetchAllScripts throws the failed Response, so the 401 redirect is
+      // checked on that shape rather than on Error.
+      if (err instanceof Response) {
+        if (err.status === 401) {
+          void navigateTo('/login', { replace: true });
+          return;
+        }
+        setError(t('scriptCategoryTree.errors.fetch'));
+        return;
+      }
       setError(err instanceof Error ? err.message : t('scriptCategoryTree.errors.generic'));
     } finally {
       setLoading(false);

--- a/apps/web/src/components/scripts/ScriptsPage.test.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.test.tsx
@@ -82,7 +82,7 @@ describe('ScriptsPage execution freshness', () => {
   it('updates lastRun from execution response timestamp when available', async () => {
     fetchWithAuthMock.mockImplementation(async (input) => {
       const url = String(input);
-      if (url === '/scripts') {
+      if (url.startsWith('/scripts?')) {
         return makeJsonResponse({ data: [baseScript] });
       }
       if (url === '/devices') {
@@ -112,7 +112,7 @@ describe('ScriptsPage execution freshness', () => {
       expect(screen.getByTestId('last-run-script-1').textContent).toBe('2026-02-09T15:30:00.000Z');
     });
 
-    const scriptsCalls = fetchWithAuthMock.mock.calls.filter(([url]) => String(url) === '/scripts');
+    const scriptsCalls = fetchWithAuthMock.mock.calls.filter(([url]) => String(url).startsWith('/scripts?'));
     expect(scriptsCalls).toHaveLength(1);
   });
 
@@ -121,7 +121,7 @@ describe('ScriptsPage execution freshness', () => {
 
     fetchWithAuthMock.mockImplementation(async (input) => {
       const url = String(input);
-      if (url === '/scripts') {
+      if (url.startsWith('/scripts?')) {
         scriptsFetchCount += 1;
         if (scriptsFetchCount === 1) {
           return makeJsonResponse({ data: [baseScript] });
@@ -155,7 +155,7 @@ describe('ScriptsPage execution freshness', () => {
       expect(screen.getByTestId('last-run-script-1').textContent).toBe('2026-02-09T16:45:00.000Z');
     });
 
-    const scriptsCalls = fetchWithAuthMock.mock.calls.filter(([url]) => String(url) === '/scripts');
+    const scriptsCalls = fetchWithAuthMock.mock.calls.filter(([url]) => String(url).startsWith('/scripts?'));
     expect(scriptsCalls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/apps/web/src/components/scripts/ScriptsPage.tsx
+++ b/apps/web/src/components/scripts/ScriptsPage.tsx
@@ -9,6 +9,7 @@ import ExecutionDetails from './ExecutionDetails';
 import type { ScriptExecution } from './ExecutionHistory';
 import type { ScriptParameter } from './ScriptForm';
 import { fetchWithAuth } from '../../stores/auth';
+import { fetchAllScripts } from '@/lib/scriptsFetch';
 import { useOrgStore } from '../../stores/orgStore';
 import { showToast } from '../shared/Toast';
 import { cn } from '@/lib/utils';
@@ -66,17 +67,23 @@ export default function ScriptsPage() {
     try {
       setLoading(true);
       setError(undefined);
-      const response = await fetchWithAuth('/scripts');
-      if (!response.ok) {
-        if (response.status === 401) {
+      // #3301 — walk every page. A bare `/scripts` returns only the first 50,
+      // and this page has no pagination controls, so script 51+ was simply
+      // unreachable here.
+      const { data } = await fetchAllScripts<ScriptWithDetails>();
+      setScripts(data);
+    } catch (err) {
+      // fetchAllScripts throws the failed Response (not an Error), so the 401
+      // redirect has to be checked on that shape — an `instanceof Error` test
+      // alone would drop the logout and show a generic message instead.
+      if (err instanceof Response) {
+        if (err.status === 401) {
           void navigateTo('/login', { replace: true });
           return;
         }
-        throw new Error(t('scriptsPage.errors.fetch'));
+        setError(t('scriptsPage.errors.fetch'));
+        return;
       }
-      const data = await response.json();
-      setScripts(asList(data, 'scripts'));
-    } catch (err) {
       setError(err instanceof Error ? err.message : t('scriptsPage.errors.generic'));
     } finally {
       setLoading(false);

--- a/apps/web/src/lib/scriptsFetch.test.ts
+++ b/apps/web/src/lib/scriptsFetch.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchAllScripts } from './scriptsFetch';
+
+function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** N placeholder script rows, ids unique across the whole walk. */
+function rows(count: number, offset = 0): { id: string }[] {
+  return Array.from({ length: count }, (_, i) => ({ id: `s${offset + i}` }));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchAllScripts', () => {
+  it('single short page — one request, returns every row', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ data: rows(3), pagination: { page: 1, limit: 100, total: 3 } }),
+    );
+
+    const result = await fetchAllScripts({ fetcher });
+
+    expect(result.data.map((s) => s.id)).toEqual(['s0', 's1', 's2']);
+    expect(result.total).toBe(3);
+    expect(result.pagesWalked).toBe(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('this is the #3301 regression — a library past one page is returned in full, not truncated', async () => {
+    // The bug: one unpaginated request returned 50 rows and every caller
+    // rendered them as if that were the whole library.
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ data: rows(100, 0), pagination: { page: 1, limit: 100, total: 250 } }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ data: rows(100, 100), pagination: { page: 2, limit: 100, total: 250 } }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ data: rows(50, 200), pagination: { page: 3, limit: 100, total: 250 } }),
+      );
+
+    const result = await fetchAllScripts({ fetcher });
+
+    expect(result.data).toHaveLength(250);
+    expect(result.data[0].id).toBe('s0');
+    expect(result.data[249].id).toBe('s249');
+    expect(result.pagesWalked).toBe(3);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it('requests limit=100 and increments page, and omits includeSystem by default', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: rows(2, 0) }))
+      .mockResolvedValueOnce(jsonResponse({ data: rows(1, 2) }));
+
+    await fetchAllScripts({ fetcher, pageLimit: 2 });
+
+    const urls = fetcher.mock.calls.map((c) => c[0] as string);
+    expect(urls[0]).toBe('/scripts?limit=2&page=1');
+    expect(urls[1]).toBe('/scripts?limit=2&page=2');
+    expect(urls[0]).not.toContain('includeSystem');
+  });
+
+  it('passes includeSystem=true through on every page when asked', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: rows(2, 0) }))
+      .mockResolvedValueOnce(jsonResponse({ data: rows(1, 2) }));
+
+    await fetchAllScripts({ fetcher, pageLimit: 2, includeSystem: true });
+
+    for (const call of fetcher.mock.calls) {
+      expect(call[0] as string).toContain('includeSystem=true');
+    }
+  });
+
+  it('an exactly-full final page is followed by one more request that comes back empty', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: rows(2, 0) }))
+      .mockResolvedValueOnce(jsonResponse({ data: [] }));
+
+    const result = await fetchAllScripts({ fetcher, pageLimit: 2 });
+
+    expect(result.data).toHaveLength(2);
+    expect(result.pagesWalked).toBe(2);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts the legacy `scripts` envelope key', async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ scripts: rows(2), pagination: { total: 2 } }));
+
+    const result = await fetchAllScripts({ fetcher });
+
+    expect(result.data.map((s) => s.id)).toEqual(['s0', 's1']);
+  });
+
+  it('a malformed body yields an empty list rather than an envelope object in state', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce(jsonResponse({ unexpected: 'shape' }));
+
+    const result = await fetchAllScripts({ fetcher });
+
+    expect(result.data).toEqual([]);
+    expect(result.pagesWalked).toBe(1);
+  });
+
+  it('throws the failed Response so callers can branch on status (401 → login)', async () => {
+    const failed = jsonResponse({}, { ok: false, status: 401 });
+    const fetcher = vi.fn().mockResolvedValueOnce(failed);
+
+    await expect(fetchAllScripts({ fetcher })).rejects.toBe(failed);
+  });
+
+  it('fails the whole walk when a later page errors — never returns a silent partial', async () => {
+    const failed = jsonResponse({}, { ok: false, status: 500 });
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: rows(2, 0) }))
+      .mockResolvedValueOnce(failed);
+
+    await expect(fetchAllScripts({ fetcher, pageLimit: 2 })).rejects.toBe(failed);
+  });
+
+  it('an already-aborted signal throws before any request is issued', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fetcher = vi.fn();
+
+    await expect(fetchAllScripts({ fetcher, signal: controller.signal })).rejects.toThrow();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('aborting mid-walk stops before the next request', async () => {
+    const controller = new AbortController();
+    const fetcher = vi.fn().mockImplementation(async () => {
+      controller.abort();
+      return jsonResponse({ data: rows(2) });
+    });
+
+    await expect(
+      fetchAllScripts({ fetcher, pageLimit: 2, signal: controller.signal }),
+    ).rejects.toThrow();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('hitting the MAX_PAGES ceiling reports truncation and drops total', async () => {
+    // Server that never returns a short page: the walk must stop at the
+    // safety ceiling AND say so, because a silent stop here is the same class
+    // of bug this module exists to remove.
+    const fetcher = vi.fn().mockImplementation(async () => jsonResponse({
+      data: rows(2),
+      pagination: { total: 9999 },
+    }));
+    const onTruncated = vi.fn();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchAllScripts({ fetcher, pageLimit: 2, onTruncated });
+
+    expect(fetcher).toHaveBeenCalledTimes(50);
+    expect(result.pagesWalked).toBe(50);
+    expect(result.total).toBeUndefined();
+    expect(onTruncated).toHaveBeenCalledWith({
+      pagesWalked: 50,
+      pageLimit: 2,
+      actualCount: 100,
+    });
+  });
+
+  it('an onTruncated callback that throws does not corrupt the return', async () => {
+    const fetcher = vi.fn().mockImplementation(async () => jsonResponse({ data: rows(2) }));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await fetchAllScripts({
+      fetcher,
+      pageLimit: 2,
+      onTruncated: () => {
+        throw new Error('caller bug');
+      },
+    });
+
+    expect(result.data).toHaveLength(100);
+    expect(result.pagesWalked).toBe(50);
+  });
+});

--- a/apps/web/src/lib/scriptsFetch.ts
+++ b/apps/web/src/lib/scriptsFetch.ts
@@ -1,0 +1,135 @@
+/**
+ * Scripts list fetcher — walks the offset-paginated `/scripts` endpoint and
+ * accumulates every accessible row (#3301).
+ *
+ * `GET /scripts` defaults to 50 rows and hard-caps `limit` at 100
+ * (`apps/api/src/routes/scripts.ts`). Four web call sites requested it with no
+ * `limit` and no pagination, so any partner with more than 50 scripts silently
+ * saw only the first 50 — no error, no "showing 50 of N", no way to reach the
+ * rest. Raising the cap alone would not have fixed that; it would have moved
+ * the same silent truncation to 100.
+ *
+ * Modelled on {@link fetchAllNetworkDevices} in `devicesFetch.ts`, which walks
+ * the same offset shape. Kept as its own module rather than folded in there
+ * because that file is about the two device arms; sharing only the pagination
+ * idiom is not a reason to couple scripts to it.
+ */
+import { fetchWithAuth } from '../stores/auth';
+import { asList } from './asList';
+
+/** Per-page size. 100 is the server's hard ceiling for this endpoint —
+ *  requesting more is silently clamped, so asking for exactly the cap is the
+ *  fewest round trips available. */
+const PAGE_LIMIT = 100;
+
+/** Defensive ceiling on the page walk. PAGE_LIMIT * MAX_PAGES = 5,000 scripts,
+ *  which is far beyond any realistic library (the bundle-export flow caps a
+ *  single bundle well below this) while still bounding the loop if the server
+ *  ever returns a full page forever. */
+const MAX_PAGES = 50;
+
+export interface ScriptsListResponse<T = Record<string, unknown>> {
+  /** All accessible script rows, in whatever order the server returned. */
+  data: T[];
+  /** Total accessible row count when the server reported one. */
+  total?: number;
+  /** How many pages were walked. 1 means the library fit in a single page. */
+  pagesWalked: number;
+}
+
+export interface FetchAllScriptsOptions {
+  /** Include `is_system` seed scripts. Matches the old query param exactly —
+   *  two of the four call sites passed it, two did not. */
+  includeSystem?: boolean;
+  /** Override the per-page size for tests. Production should leave this at the
+   *  module default. */
+  pageLimit?: number;
+  /** Override fetcher for tests. Defaults to the auth-wrapped fetch. */
+  fetcher?: typeof fetchWithAuth;
+  /** Optional cancellation signal. A caller that navigates away mid-walk stops
+   *  the walker between pages rather than issuing the remaining requests. */
+  signal?: AbortSignal;
+  /** Invoked when the walk hits MAX_PAGES without exhausting the list. Lets the
+   *  caller surface a visible warning, because a silent truncation here is the
+   *  exact bug this module exists to remove — it would just reappear at 5,000
+   *  instead of 50. */
+  onTruncated?: (info: { pagesWalked: number; pageLimit: number; actualCount: number }) => void;
+}
+
+/**
+ * Walk `/scripts` and return the full accessible set as one array.
+ *
+ * Throws the failed `Response` on the first non-OK page, matching
+ * `fetchAllDevices`, so callers keep their existing status handling —
+ * `catch (err) { if (err instanceof Response && err.status === 401) ... }`.
+ * Failing the whole walk rather than returning a partial list is deliberate:
+ * a partial script library rendered without comment is indistinguishable from
+ * a complete one, which is the bug being fixed.
+ *
+ * `T` is an unchecked assertion about untyped JSON, same as `asList<T>` — pass
+ * it where the caller already has a row type, leave it off otherwise.
+ */
+export async function fetchAllScripts<T = Record<string, unknown>>(
+  options: FetchAllScriptsOptions = {},
+): Promise<ScriptsListResponse<T>> {
+  const pageLimit = options.pageLimit ?? PAGE_LIMIT;
+  const fetcher = options.fetcher ?? fetchWithAuth;
+  const signal = options.signal;
+
+  if (signal?.aborted) throw signalAbortError(signal);
+
+  const accumulated: T[] = [];
+  let total: number | undefined;
+
+  for (let pageNum = 0; pageNum < MAX_PAGES; pageNum++) {
+    // Between-page check so a navigate-away stops the next request before it
+    // is issued, even when the underlying fetch ignores the signal.
+    if (signal?.aborted) throw signalAbortError(signal);
+
+    const params = new URLSearchParams();
+    if (options.includeSystem) params.set('includeSystem', 'true');
+    params.set('limit', String(pageLimit));
+    params.set('page', String(pageNum + 1));
+
+    const resp = await fetcher(`/scripts?${params.toString()}`);
+    if (!resp.ok) throw resp;
+
+    const body = (await resp.json()) as {
+      pagination?: { total?: number; page?: number; limit?: number };
+    };
+    // `asList` with the legacy `scripts` alias, matching every other consumer
+    // of this endpoint — and failing closed to [] rather than storing an
+    // envelope object in React state.
+    const page = asList<T>(body, 'scripts');
+    accumulated.push(...page);
+
+    if (pageNum === 0 && typeof body.pagination?.total === 'number') {
+      total = body.pagination.total;
+    }
+
+    // Offset pagination: a short (or empty) page is the end of the list.
+    if (page.length < pageLimit) {
+      return { data: accumulated, total, pagesWalked: pageNum + 1 };
+    }
+  }
+
+  console.warn(
+    `[fetchAllScripts] hit MAX_PAGES=${MAX_PAGES} safety ceiling at limit=${pageLimit}; truncating walk.`,
+  );
+  try {
+    options.onTruncated?.({ pagesWalked: MAX_PAGES, pageLimit, actualCount: accumulated.length });
+  } catch (err) {
+    // A misbehaving callback must not corrupt the return.
+    console.warn('[fetchAllScripts] onTruncated callback threw:', err);
+  }
+  // `total` is dropped so the caller cannot claim "this is the whole library".
+  return { data: accumulated, total: undefined, pagesWalked: MAX_PAGES };
+}
+
+/** Standard DOMException-shaped AbortError, so callers can branch on
+ *  `err.name === 'AbortError'` regardless of abort source. */
+function signalAbortError(signal: AbortSignal): Error {
+  const reason = (signal as { reason?: unknown }).reason;
+  if (reason instanceof Error) return reason;
+  return new DOMException('Aborted', 'AbortError');
+}


### PR DESCRIPTION
Fixes #3301.

## The bug

`GET /scripts` is offset-paginated and defaults to 50 rows (`apps/api/src/routes/scripts.ts:39`). Four web call sites requested it with no `limit` and no page walk:

| Call site | Effect |
|---|---|
| `ScriptsPage.tsx:69` | the script library page shows the first 50 and has no pagination controls |
| `ScriptPickerModal.tsx:104` | script 51+ can't be picked to run on a device |
| `ScriptCategoryTree.tsx:181` | whole categories disappear from the tree |
| `RemediationScriptPicker.tsx:73` | a remediation script past 50 can't be attached to a policy |

There is no error, no "showing 50 of N", and no way to reach the rest. A partner with a large library just sees a smaller library.

## Why not raise the cap

The endpoint hard-caps `limit` at 100. Raising it moves the same silent truncation from 50 to 100 rather than removing it. The pages have to be walked.

## The fix

Adds `apps/web/src/lib/scriptsFetch.ts`, which walks `/scripts` to exhaustion and returns the full set as one array. Modelled on `fetchAllNetworkDevices` in `devicesFetch.ts`, which walks the same offset shape, and consistent with the already-proven paginated loop at `ScriptBundleImport.tsx:70`.

Three behaviours are deliberate:

- **Throws the failed `Response`** on the first non-OK page, matching `fetchAllDevices`, so callers keep status-based handling. Each call site's catch is updated for that shape. `ScriptsPage` and `ScriptCategoryTree` both redirect on 401, and an `instanceof Error` test alone would have silently dropped that logout.
- **A page error fails the whole walk** rather than returning what it has. A partial library rendered without comment is indistinguishable from a complete one, which is the bug being fixed.
- **The `MAX_PAGES` ceiling reports itself** via `onTruncated` and drops `total`, so the walker can't reintroduce a silent cap of its own at 5,000.

`fetchAllScripts<T>` is generic with a `Record<string, unknown>` default, so the two call sites that already have a row type pass it explicitly and the two that map from raw records are unchanged. Same unchecked-assertion tradeoff `asList<T>` documents.

## Verification

`scriptsFetch.test.ts` — 13 cases: the multi-page walk, short-page and empty-page terminators, request param shape, `includeSystem` propagation, the legacy `scripts` envelope key, malformed bodies failing closed, throw-on-non-OK at first and later pages, abort before and mid-walk, the truncation path, and a throwing `onTruncated` callback.

**Control run:** neutering the page-walk condition (`if (page.length < pageLimit)` → `if (true)`, i.e. the pre-fix single-request behaviour) fails 7 of the 13, including the regression case:

```
AssertionError: expected [ { id: 's0' }, { id: 's1' }, …(98) ] to have a length of 250 but got 100
```

That is the exact shape of the reported bug, so the tests are load-bearing rather than vacuous.

`ScriptsPage.test.tsx` matched the request URL exactly (`url === '/scripts'`); updated to the paginated form.

Local gate green on this branch rebased onto `f400fc315`:

- `vitest run` (apps/web) — **540 files, 5121 tests passed**
- `astro check` — **0 errors**, 0 warnings
- `eslint src` — clean

No dependency, API, agent, or migration changes, so those jobs are unaffected.
