### PR TITLE
feat(psa): dual ownership (org XOR partner) for psa_connections (#2135)

### DIFF
--- a/apps/api/migrations/2026-08-17-psa-connections-partner-ownership.sql
+++ b/apps/api/migrations/2026-08-17-psa-connections-partner-ownership.sql
@@ -100,19 +100,41 @@ CREATE POLICY psa_connections_isolation
 -- pc.org_id IS NULL — i.e. for every partner-owned connection. Collapsed from
 -- four per-command policies to one, matching the parent above.
 --
--- THREE arms, not two. The third (device_id -> devices.org_id) is not
--- cosmetic: deleteDeviceCascade (services/deviceDeletion.ts) runs in the
--- REQUEST context, which for an org-scope token is org-scoped RLS. Without the
--- device arm, a mapping hanging off a PARTNER-owned connection is invisible to
--- that token, its DELETE silently matches zero rows, and the subsequent
--- `DELETE FROM devices` fails with 23503 — a 500 on an ordinary device delete.
--- The arm is also correct on the merits: a ticket about MY device is MY org's
--- record, which is the same principle playbook step 5 states for every
--- worker-created child row (they take the DEVICE's org, not the policy's).
+-- USING and WITH CHECK are deliberately DIFFERENT, because reading and writing
+-- make different tenancy claims:
 --
--- connection_id is NOT NULL and remains the primary tenancy anchor; device_id
--- and alert_id are nullable, so they widen access but can never be the sole
--- basis for it.
+--   USING      = system OR connection-accessible OR device-org OR alert-org
+--   WITH CHECK = system OR connection-accessible ONLY
+--
+-- Reading or deleting a row that references YOUR OWN device or alert is a
+-- legitimate claim — that ticket is your org's record, the same principle
+-- playbook step 5 states for every worker-created child row (they take the
+-- DEVICE's org, not the policy's). But ATTACHING a mapping to a connection is a
+-- claim on the CONNECTION, so the write path must not accept device/alert
+-- ownership as a substitute. A symmetric policy would have let a tenant who
+-- merely owns a device forge a mapping onto a FOREIGN partner's connection,
+-- contradicting this file's own "connection_id is the tenancy anchor" rule.
+--
+-- Both read arms are load-bearing for deleteDeviceCascade
+-- (services/deviceDeletion.ts), which runs in the REQUEST context — org-scoped
+-- RLS for an org token. Its pre-clear matches on `alert_id IN (...) OR
+-- device_id = ...`, so under a PARTNER-owned connection:
+--   * device_id set   -> needs the device arm
+--   * device_id NULL, alert_id set -> needs the ALERT arm
+-- Without the relevant arm the DELETE silently matches zero rows and the
+-- cascade's follow-on `DELETE FROM alerts` / `DELETE FROM devices` fails with
+-- 23503 — a 500 on an ordinary device delete.
+--
+-- connection_id is NOT NULL and remains the primary tenancy anchor for WRITES;
+-- device_id and alert_id are nullable and widen READS only.
+--
+-- NOTE ON ROW VISIBILITY vs AUTHORIZATION: the connection arm passes for ANY
+-- partner-scope caller of the owning partner, necessarily so — a mapping with
+-- neither anchor has no org for Postgres to check. Postgres therefore cannot
+-- express partner_users.org_access='selected' here. Narrowing ticket reads to a
+-- restricted partner user's accessible orgs is done in the app layer by
+-- psaTicketMappingOrgCondition (routes/psa.ts); that condition is the
+-- enforcement point for the refinement and is not redundant with this policy.
 
 ALTER TABLE psa_ticket_mappings ENABLE ROW LEVEL SECURITY;
 ALTER TABLE psa_ticket_mappings FORCE ROW LEVEL SECURITY;
@@ -124,6 +146,7 @@ DROP POLICY IF EXISTS breeze_org_isolation_delete ON psa_ticket_mappings;
 DROP POLICY IF EXISTS psa_ticket_mappings_isolation ON psa_ticket_mappings;
 CREATE POLICY psa_ticket_mappings_isolation
   ON psa_ticket_mappings
+  -- READ/DELETE: connection access, OR ownership of the referenced device or alert.
   USING (
     public.breeze_current_scope() = 'system'
     OR EXISTS (
@@ -139,7 +162,14 @@ CREATE POLICY psa_ticket_mappings_isolation
        WHERE d.id = psa_ticket_mappings.device_id
          AND public.breeze_has_org_access(d.org_id)
     )
+    OR EXISTS (
+      SELECT 1 FROM alerts a
+       WHERE a.id = psa_ticket_mappings.alert_id
+         AND public.breeze_has_org_access(a.org_id)
+    )
   )
+  -- WRITE: connection access ONLY. Owning the device or alert does NOT license
+  -- attaching a mapping to someone else's connection.
   WITH CHECK (
     public.breeze_current_scope() = 'system'
     OR EXISTS (
@@ -149,10 +179,5 @@ CREATE POLICY psa_ticket_mappings_isolation
            (pc.org_id IS NOT NULL AND public.breeze_has_org_access(pc.org_id))
            OR (pc.partner_id IS NOT NULL AND public.breeze_has_partner_access(pc.partner_id))
          )
-    )
-    OR EXISTS (
-      SELECT 1 FROM devices d
-       WHERE d.id = psa_ticket_mappings.device_id
-         AND public.breeze_has_org_access(d.org_id)
     )
   );

--- a/apps/api/migrations/2026-08-17-psa-connections-partner-ownership.sql
+++ b/apps/api/migrations/2026-08-17-psa-connections-partner-ownership.sql
@@ -1,0 +1,158 @@
+-- Partner-owned PSA connections (epic #2135).
+--
+-- An MSP's PSA (ConnectWise, Autotask, Halo, Jira, Zendesk, ServiceNow,
+-- Freshservice) is a PARTNER-level system: one tenant of the PSA covers every
+-- customer the MSP manages. Until now a psa_connections row was always owned by
+-- exactly one org (org_id NOT NULL), so an MSP had to re-enter the same PSA
+-- credentials once per customer org. This migration makes a connection ownable
+-- by EITHER an org (org_id set, partner_id NULL — the existing shape, retained
+-- for the co-managed-IT case where a customer brings their OWN Jira/Zendesk) OR
+-- a partner (partner_id set, org_id NULL — the "partner-wide / all orgs"
+-- shape), enforced by an exactly-one-axis CHECK.
+--
+-- Mirrors alert_rules (2026-07-01), configuration_policies (2026-06-27),
+-- software_policies (#2126) and ticket_forms (2026-07-11). The sibling
+-- accounting_connections table is already partner-axis, so this brings the two
+-- external-system integrations onto the same ownership axis.
+--
+-- The `backup_configs` org-only precedent deliberately does NOT apply here:
+-- that table holds customer-owned STORAGE credentials, whereas a PSA
+-- credential is the MSP's own.
+--
+-- psa_ticket_mappings has no org_id/partner_id of its own — its tenancy is
+-- entirely `connection_id -> psa_connections`. Its four org-only join policies
+-- (2026-04-11-bucket-c-dead-cleanup-rls.sql) are rewritten to dual-axis IN THIS
+-- SAME FILE: left org-only they would make every mapping under a partner-owned
+-- connection both invisible AND unwritable, because the parent's org_id is NULL
+-- for exactly those rows. Same hazard the ticket_form_org_links policy
+-- (2026-07-11) documents.
+--
+-- No data cleanup is needed: org_id is NOT NULL today, so every existing row
+-- already satisfies the XOR (org_id set, partner_id NULL) the moment the
+-- constraint lands. Nothing is UPDATEd or DELETEd here, hence no ROW_COUNT
+-- diagnostics block.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, guarded CHECK, DROP POLICY IF EXISTS
+-- then CREATE. Re-applying is a no-op. No inner BEGIN/COMMIT (autoMigrate wraps
+-- each file in a transaction).
+
+-- ============================================
+-- Step 1: schema — add partner_id, relax org_id, XOR CHECK
+-- ============================================
+
+ALTER TABLE psa_connections
+  ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners(id);
+
+ALTER TABLE psa_connections
+  ALTER COLUMN org_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'psa_connections_one_owner_chk'
+      AND conrelid = 'psa_connections'::regclass
+  ) THEN
+    ALTER TABLE psa_connections
+      ADD CONSTRAINT psa_connections_one_owner_chk
+      CHECK ((org_id IS NULL) <> (partner_id IS NULL));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS psa_connections_partner_id_idx
+  ON psa_connections(partner_id);
+
+-- ============================================
+-- Step 2: RLS — dual-axis (org OR partner) + system short-circuit
+-- ============================================
+--
+-- Replaces the four per-command breeze_org_isolation_* policies installed by
+-- the generic org_id sweep (0008-tenant-rls.sql) with ONE policy covering all
+-- commands, per the epic #2135 playbook.
+
+ALTER TABLE psa_connections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE psa_connections FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON psa_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON psa_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON psa_connections;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON psa_connections;
+DROP POLICY IF EXISTS psa_connections_isolation ON psa_connections;
+CREATE POLICY psa_connections_isolation
+  ON psa_connections
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
+    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
+  );
+
+-- ============================================
+-- Step 3: psa_ticket_mappings — rewrite the join policies to dual-axis
+-- ============================================
+--
+-- Tenancy join: psa_ticket_mappings.connection_id -> psa_connections. The old
+-- policies asserted breeze_has_org_access(pc.org_id), which is FALSE whenever
+-- pc.org_id IS NULL — i.e. for every partner-owned connection. Collapsed from
+-- four per-command policies to one, matching the parent above.
+--
+-- THREE arms, not two. The third (device_id -> devices.org_id) is not
+-- cosmetic: deleteDeviceCascade (services/deviceDeletion.ts) runs in the
+-- REQUEST context, which for an org-scope token is org-scoped RLS. Without the
+-- device arm, a mapping hanging off a PARTNER-owned connection is invisible to
+-- that token, its DELETE silently matches zero rows, and the subsequent
+-- `DELETE FROM devices` fails with 23503 — a 500 on an ordinary device delete.
+-- The arm is also correct on the merits: a ticket about MY device is MY org's
+-- record, which is the same principle playbook step 5 states for every
+-- worker-created child row (they take the DEVICE's org, not the policy's).
+--
+-- connection_id is NOT NULL and remains the primary tenancy anchor; device_id
+-- and alert_id are nullable, so they widen access but can never be the sole
+-- basis for it.
+
+ALTER TABLE psa_ticket_mappings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE psa_ticket_mappings FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS breeze_org_isolation_select ON psa_ticket_mappings;
+DROP POLICY IF EXISTS breeze_org_isolation_insert ON psa_ticket_mappings;
+DROP POLICY IF EXISTS breeze_org_isolation_update ON psa_ticket_mappings;
+DROP POLICY IF EXISTS breeze_org_isolation_delete ON psa_ticket_mappings;
+DROP POLICY IF EXISTS psa_ticket_mappings_isolation ON psa_ticket_mappings;
+CREATE POLICY psa_ticket_mappings_isolation
+  ON psa_ticket_mappings
+  USING (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM psa_connections pc
+       WHERE pc.id = psa_ticket_mappings.connection_id
+         AND (
+           (pc.org_id IS NOT NULL AND public.breeze_has_org_access(pc.org_id))
+           OR (pc.partner_id IS NOT NULL AND public.breeze_has_partner_access(pc.partner_id))
+         )
+    )
+    OR EXISTS (
+      SELECT 1 FROM devices d
+       WHERE d.id = psa_ticket_mappings.device_id
+         AND public.breeze_has_org_access(d.org_id)
+    )
+  )
+  WITH CHECK (
+    public.breeze_current_scope() = 'system'
+    OR EXISTS (
+      SELECT 1 FROM psa_connections pc
+       WHERE pc.id = psa_ticket_mappings.connection_id
+         AND (
+           (pc.org_id IS NOT NULL AND public.breeze_has_org_access(pc.org_id))
+           OR (pc.partner_id IS NOT NULL AND public.breeze_has_partner_access(pc.partner_id))
+         )
+    )
+    OR EXISTS (
+      SELECT 1 FROM devices d
+       WHERE d.id = psa_ticket_mappings.device_id
+         AND public.breeze_has_org_access(d.org_id)
+    )
+  );

--- a/apps/api/src/__tests__/integration/psaConnectionsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/psaConnectionsPartnerRls.integration.test.ts
@@ -31,7 +31,7 @@ import './setup';
 import { describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { db, withDbAccessContext, type DbAccessContext } from '../../db';
-import { devices, psaConnections, psaTicketMappings } from '../../db/schema';
+import { alerts, devices, psaConnections, psaTicketMappings } from '../../db/schema';
 import { createOrganization, createPartner, createSite } from './db-utils';
 
 const SYSTEM_CTX: DbAccessContext = {
@@ -326,6 +326,85 @@ describe('psa_ticket_mappings RLS — dual-axis join through psa_connections', (
       db.delete(psaTicketMappings).where(eq(psaTicketMappings.deviceId, deviceId)).returning(),
     );
     expect(deleted).toHaveLength(1);
+  });
+
+  it('ALERT ARM (review finding 3): an org token can clear a mapping anchored ONLY by alert_id', async () => {
+    // The confirmed device-delete 500. deleteDeviceCascade pre-clears on
+    // `alert_id IN (device's alerts) OR device_id = ...` inside the REQUEST
+    // (org-scoped) context. For a mapping with device_id NULL and alert_id set,
+    // under a PARTNER-owned connection, the connection arm fails (org token)
+    // and the device arm fails (device_id NULL) — so without the alert arm the
+    // DELETE matched zero rows and the cascade's `DELETE FROM alerts` then
+    // raised 23503.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const connectionId = await seedPartnerConnection(partner.id);
+    const deviceId = await seedDevice(org.id);
+
+    const [alertRow] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(alerts)
+        .values({
+          deviceId,
+          orgId: org.id,
+          configItemName: 'PSA alert-arm probe',
+          severity: 'high',
+          title: 'PSA alert-arm probe',
+        })
+        .returning({ id: alerts.id }),
+    );
+
+    const [mapping] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(psaTicketMappings)
+        .values({ connectionId, alertId: alertRow!.id, externalTicketId: 'OPS-5' })
+        .returning(),
+    );
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: psaTicketMappings.id })
+        .from(psaTicketMappings)
+        .where(eq(psaTicketMappings.id, mapping!.id)),
+    );
+    expect(visibleToOrg).toHaveLength(1);
+
+    // The exact statement deleteDeviceCascade issues, in the same context.
+    const deleted = await withDbAccessContext(orgContext(org.id), () =>
+      db.delete(psaTicketMappings).where(eq(psaTicketMappings.alertId, alertRow!.id)).returning(),
+    );
+    expect(deleted).toHaveLength(1);
+
+    // With the mapping gone the alert delete no longer raises 23503.
+    await expect(
+      withDbAccessContext(orgContext(org.id), () =>
+        db.delete(alerts).where(eq(alerts.id, alertRow!.id)).returning(),
+      ),
+    ).resolves.toHaveLength(1);
+  });
+
+  it('WITH CHECK is connection-only: owning the device does NOT license writing onto a foreign connection', async () => {
+    // Review finding 2. USING and WITH CHECK are asymmetric on purpose —
+    // reading a row about your own device is fine, forging one onto another
+    // tenant's connection is not.
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgB = await createOrganization({ partnerId: partnerB.id });
+    const foreignConnectionId = await seedPartnerConnection(partnerA.id);
+    const ownDeviceId = await seedDevice(orgB.id);
+
+    await expect(
+      withDbAccessContext(orgContext(orgB.id), () =>
+        db
+          .insert(psaTicketMappings)
+          .values({
+            connectionId: foreignConnectionId,
+            deviceId: ownDeviceId,
+            externalTicketId: 'FORGED-VIA-DEVICE',
+          })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
   });
 
   it('the device arm does NOT leak a mapping to an unrelated org', async () => {

--- a/apps/api/src/__tests__/integration/psaConnectionsPartnerRls.integration.test.ts
+++ b/apps/api/src/__tests__/integration/psaConnectionsPartnerRls.integration.test.ts
@@ -1,0 +1,353 @@
+/**
+ * psa_connections + psa_ticket_mappings RLS — dual-axis (org OR partner)
+ * enforcement (epic #2135).
+ *
+ * Migration under test: 2026-08-17-psa-connections-partner-ownership.sql.
+ *
+ * A PSA connection is owned by EITHER a partner (partner_id set, org_id NULL —
+ * the MSP's own ConnectWise/Autotask/Jira, shared by every org) OR an org
+ * (org_id set, partner_id NULL — a customer's own Jira/Zendesk in a co-managed
+ * engagement). psa_ticket_mappings has NO owner column of its own; its policy
+ * joins through psa_connections and must carry the parent's partner branch.
+ *
+ * The rls-coverage contract test proves a *policy string* mentions
+ * breeze_has_partner_access; it does NOT prove the branch behaves. This
+ * functional suite runs through the REAL postgres.js driver as `breeze_app`:
+ *   - cross-partner forge -> 42501
+ *   - XOR violations (both axes / neither axis) -> 23514
+ *   - org isolation (org tokens never see partner-wide rows)
+ *   - the partner-scope READ proof: a partner-owned row IS visible to its own
+ *     partner. That is the bug class the reader sweep existed to kill — an
+ *     org-only `org_id IN (...)` filter hid partner-wide connections from the
+ *     very partner that created them.
+ *   - the psa_ticket_mappings device arm, which keeps deleteDeviceCascade from
+ *     silently matching zero rows under an org-scope context.
+ *
+ * No fan-out test: nothing evaluates psa_connections against devices on a
+ * schedule (there is no PSA sync worker — POST /connections/:id/sync is an
+ * honest 501), so playbook step 5 has nothing to assert here.
+ */
+import './setup';
+import { describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { devices, psaConnections, psaTicketMappings } from '../../db/schema';
+import { createOrganization, createPartner, createSite } from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+function partnerContext(partnerId: string, orgIds: string[]): DbAccessContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: orgIds,
+    accessiblePartnerIds: [partnerId],
+    userId: null,
+  };
+}
+
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const CREDENTIALS = { baseUrl: 'https://acme.atlassian.net', apiToken: 'tok' };
+
+async function seedPartnerConnection(partnerId: string, name = 'MSP Jira') {
+  const rows = await withDbAccessContext(partnerContext(partnerId, []), () =>
+    db
+      .insert(psaConnections)
+      .values({ name, provider: 'jira', orgId: null, partnerId, credentials: CREDENTIALS })
+      .returning(),
+  );
+  return rows[0]!.id;
+}
+
+async function seedOrgConnection(orgId: string, name = 'Customer Jira') {
+  const rows = await withDbAccessContext(orgContext(orgId), () =>
+    db
+      .insert(psaConnections)
+      .values({ name, provider: 'jira', orgId, partnerId: null, credentials: CREDENTIALS })
+      .returning(),
+  );
+  return rows[0]!.id;
+}
+
+describe('psa_connections RLS — dual-axis (2026-08-17 migration)', () => {
+  it('PARTNER READ PROOF: a partner sees its own partner-wide connection', async () => {
+    const partner = await createPartner();
+    const id = await seedPartnerConnection(partner.id);
+
+    const visible = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db.select({ id: psaConnections.id }).from(psaConnections).where(eq(psaConnections.id, id)),
+    );
+
+    expect(visible.map((r) => r.id)).toContain(id);
+  });
+
+  it('a different partner can neither see nor forge a connection attributed to the first partner', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerConnection(partnerA.id);
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.select({ id: psaConnections.id }).from(psaConnections).where(eq(psaConnections.id, id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    // Cross-partner forge: WITH CHECK rejects the write outright.
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(psaConnections)
+          .values({
+            name: 'Forged',
+            provider: 'jira',
+            orgId: null,
+            partnerId: partnerA.id,
+            credentials: CREDENTIALS,
+          })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('a different partner cannot UPDATE or DELETE the first partner\'s connection', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const id = await seedPartnerConnection(partnerA.id);
+
+    // Invisible rows simply do not match — no error, but zero effect.
+    const updated = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.update(psaConnections).set({ name: 'Hijacked' }).where(eq(psaConnections.id, id)).returning(),
+    );
+    expect(updated).toEqual([]);
+
+    const deleted = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db.delete(psaConnections).where(eq(psaConnections.id, id)).returning(),
+    );
+    expect(deleted).toEqual([]);
+
+    const stillThere = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.select({ name: psaConnections.name }).from(psaConnections).where(eq(psaConnections.id, id)),
+    );
+    expect(stillThere[0]?.name).toBe('MSP Jira');
+  });
+
+  it('ORG ISOLATION: an org token cannot see a partner-wide connection, even under its own partner', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const partnerConnId = await seedPartnerConnection(partner.id);
+
+    // RLS is STRICTER than the app layer: an org token carries a partnerId but
+    // never passes breeze_has_partner_access. Never claim parity.
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: psaConnections.id })
+        .from(psaConnections)
+        .where(eq(psaConnections.id, partnerConnId)),
+    );
+    expect(visibleToOrg).toEqual([]);
+
+    // ...but its own org-owned connection round-trips fine.
+    const orgConnId = await seedOrgConnection(org.id);
+    const ownVisible = await withDbAccessContext(orgContext(org.id), () =>
+      db.select({ id: psaConnections.id }).from(psaConnections).where(eq(psaConnections.id, orgConnId)),
+    );
+    expect(ownVisible.map((r) => r.id)).toEqual([orgConnId]);
+  });
+
+  it('one org cannot see another org\'s connection under the same partner', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const orgAConnId = await seedOrgConnection(orgA.id);
+
+    const visibleToB = await withDbAccessContext(orgContext(orgB.id), () =>
+      db.select({ id: psaConnections.id }).from(psaConnections).where(eq(psaConnections.id, orgAConnId)),
+    );
+    expect(visibleToB).toEqual([]);
+  });
+
+  it('a partner sees BOTH its partner-wide row and its orgs\' rows in one query', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const partnerConnId = await seedPartnerConnection(partner.id);
+    const orgConnId = await seedOrgConnection(org.id);
+
+    const visible = await withDbAccessContext(partnerContext(partner.id, [org.id]), () =>
+      db.select({ id: psaConnections.id }).from(psaConnections),
+    );
+    const ids = visible.map((r) => r.id);
+    expect(ids).toContain(partnerConnId);
+    expect(ids).toContain(orgConnId);
+  });
+
+  it('the one-owner CHECK rejects BOTH axes and NEITHER axis', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(psaConnections)
+          .values({
+            name: 'Both',
+            provider: 'jira',
+            orgId: org.id,
+            partnerId: partner.id,
+            credentials: CREDENTIALS,
+          })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+
+    await expect(
+      withDbAccessContext(SYSTEM_CTX, () =>
+        db
+          .insert(psaConnections)
+          .values({
+            name: 'Neither',
+            provider: 'jira',
+            orgId: null,
+            partnerId: null,
+            credentials: CREDENTIALS,
+          })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '23514' } });
+  });
+});
+
+describe('psa_ticket_mappings RLS — dual-axis join through psa_connections', () => {
+  async function seedDevice(orgId: string) {
+    const site = await createSite({ orgId });
+    const rows = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(devices)
+        .values({
+          orgId,
+          siteId: site.id,
+          agentId: `psa-rls-${site.id.slice(0, 18)}`,
+          hostname: 'psa-rls-host',
+          osType: 'windows',
+          osVersion: '10.0',
+          architecture: 'x64',
+          agentVersion: '1.0.0',
+        })
+        .returning(),
+    );
+    return rows[0]!.id;
+  }
+
+  it('a mapping under a partner-wide connection is visible to its partner', async () => {
+    const partner = await createPartner();
+    const connectionId = await seedPartnerConnection(partner.id);
+
+    const inserted = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .insert(psaTicketMappings)
+        .values({ connectionId, externalTicketId: 'OPS-1' })
+        .returning(),
+    );
+    expect(inserted).toHaveLength(1);
+
+    const visible = await withDbAccessContext(partnerContext(partner.id, []), () =>
+      db
+        .select({ id: psaTicketMappings.id })
+        .from(psaTicketMappings)
+        .where(eq(psaTicketMappings.id, inserted[0]!.id)),
+    );
+    expect(visible).toHaveLength(1);
+  });
+
+  it('a different partner can neither see nor forge a mapping under the first partner\'s connection', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const connectionId = await seedPartnerConnection(partnerA.id);
+    const [mapping] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db.insert(psaTicketMappings).values({ connectionId, externalTicketId: 'OPS-2' }).returning(),
+    );
+
+    const visibleToB = await withDbAccessContext(partnerContext(partnerB.id, []), () =>
+      db
+        .select({ id: psaTicketMappings.id })
+        .from(psaTicketMappings)
+        .where(eq(psaTicketMappings.id, mapping!.id)),
+    );
+    expect(visibleToB).toEqual([]);
+
+    await expect(
+      withDbAccessContext(partnerContext(partnerB.id, []), () =>
+        db
+          .insert(psaTicketMappings)
+          .values({ connectionId, externalTicketId: 'FORGED' })
+          .returning(),
+      ),
+    ).rejects.toMatchObject({ cause: { code: '42501' } });
+  });
+
+  it('DEVICE ARM: an org token can see and DELETE a mapping on its own device under a PARTNER-wide connection', async () => {
+    // Regression guard for the deleteDeviceCascade hazard: that cascade runs in
+    // the REQUEST context. Without the device arm on the policy this DELETE
+    // matches zero rows and the subsequent `DELETE FROM devices` fails 23503.
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const connectionId = await seedPartnerConnection(partner.id);
+    const deviceId = await seedDevice(org.id);
+
+    const [mapping] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(psaTicketMappings)
+        .values({ connectionId, deviceId, externalTicketId: 'OPS-3' })
+        .returning(),
+    );
+
+    const visibleToOrg = await withDbAccessContext(orgContext(org.id), () =>
+      db
+        .select({ id: psaTicketMappings.id })
+        .from(psaTicketMappings)
+        .where(eq(psaTicketMappings.id, mapping!.id)),
+    );
+    expect(visibleToOrg).toHaveLength(1);
+
+    const deleted = await withDbAccessContext(orgContext(org.id), () =>
+      db.delete(psaTicketMappings).where(eq(psaTicketMappings.deviceId, deviceId)).returning(),
+    );
+    expect(deleted).toHaveLength(1);
+  });
+
+  it('the device arm does NOT leak a mapping to an unrelated org', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    const connectionId = await seedPartnerConnection(partner.id);
+    const deviceId = await seedDevice(orgA.id);
+
+    const [mapping] = await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .insert(psaTicketMappings)
+        .values({ connectionId, deviceId, externalTicketId: 'OPS-4' })
+        .returning(),
+    );
+
+    const visibleToB = await withDbAccessContext(orgContext(orgB.id), () =>
+      db
+        .select({ id: psaTicketMappings.id })
+        .from(psaTicketMappings)
+        .where(eq(psaTicketMappings.id, mapping!.id)),
+    );
+    expect(visibleToB).toEqual([]);
+  });
+});

--- a/apps/api/src/__tests__/integration/psaTicketMappingOrgScoping.integration.test.ts
+++ b/apps/api/src/__tests__/integration/psaTicketMappingOrgScoping.integration.test.ts
@@ -1,0 +1,270 @@
+/**
+ * PSA ticket-mapping org scoping — the cross-org data leak (PR #3308 review,
+ * findings 0/1/8).
+ *
+ * THE CONCEPTUAL ERROR THIS GUARDS: "partner scope" is not authorization for
+ * everything reachable from a partner-owned row. Two different things were
+ * conflated:
+ *
+ *   psa_connections  = partner-owned CONFIG. Correctly visible to any
+ *                      partner-scope caller of that partner.
+ *   psa_ticket_mappings = PER-ORG DATA. Each row names a specific org's device,
+ *                      alert, and external ticket id/URL. It must ALWAYS be
+ *                      filtered by the caller's accessible orgs, whatever the
+ *                      scope.
+ *
+ * Because the route scoped tickets through the CONNECTION, a partner_user with
+ * org_access='selected' limited to org A read org B's external ticket ids and
+ * URLs through the shared partner-wide connection. RLS cannot catch this: the
+ * psa_ticket_mappings connection arm passes for every partner-scope caller of
+ * the owning partner (it must — an unanchored mapping has no org to check), so
+ * `psaTicketMappingOrgCondition` in routes/psa.ts is the enforcement point.
+ * That makes these route-level tests, against a real DB, the only thing that
+ * can prove the fix. A Drizzle mock would return whatever rows we fabricate.
+ *
+ * Also covers the mirror image (finding 8): an ORG-scope caller must SEE their
+ * own device's ticket under a partner-wide connection. That previously returned
+ * an empty list, because the query innerJoin'd psa_connections and RLS hides
+ * partner-wide connections from org tokens.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.test.yml up -d
+ */
+import './setup';
+
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+// psaRoutes applies authMiddleware itself (`psaRoutes.use('*', ...)`), so the
+// harness must NOT wrap it again.
+import { psaRoutes } from '../../routes/psa';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  alerts,
+  devices,
+  partnerUsers,
+  psaConnections,
+  psaTicketMappings,
+} from '../../db/schema';
+import { createIntegrationTestClient, createOrganization, createSite } from './db-utils';
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.route('/psa', psaRoutes);
+  return app;
+}
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+async function seedDevice(orgId: string, hostname: string) {
+  const site = await createSite({ orgId });
+  const rows = await withDbAccessContext(SYSTEM_CTX, () =>
+    db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId: site.id,
+        agentId: `psa-scope-${site.id.slice(0, 16)}`,
+        hostname,
+        osType: 'windows',
+        osVersion: '10.0',
+        architecture: 'x64',
+        agentVersion: '1.0.0',
+      })
+      .returning(),
+  );
+  return rows[0]!.id;
+}
+
+async function seedAlert(orgId: string, deviceId: string, title: string) {
+  const rows = await withDbAccessContext(SYSTEM_CTX, () =>
+    db
+      .insert(alerts)
+      .values({ orgId, deviceId, configItemName: title, severity: 'high', title })
+      .returning({ id: alerts.id }),
+  );
+  return rows[0]!.id;
+}
+
+async function seedPartnerConnection(partnerId: string) {
+  const rows = await withDbAccessContext(SYSTEM_CTX, () =>
+    db
+      .insert(psaConnections)
+      .values({
+        name: 'MSP Jira',
+        provider: 'jira',
+        orgId: null,
+        partnerId,
+        credentials: { baseUrl: 'https://acme.atlassian.net', apiToken: 'tok' },
+      })
+      .returning(),
+  );
+  return rows[0]!.id;
+}
+
+async function seedMapping(
+  connectionId: string,
+  externalTicketId: string,
+  anchors: { deviceId?: string; alertId?: string },
+) {
+  const rows = await withDbAccessContext(SYSTEM_CTX, () =>
+    db
+      .insert(psaTicketMappings)
+      .values({ connectionId, externalTicketId, ...anchors })
+      .returning(),
+  );
+  return rows[0]!.id;
+}
+
+function ticketIds(body: { data?: Array<{ raw?: { externalTicketId?: string | null } }> }) {
+  return (body.data ?? []).map((row) => row.raw?.externalTicketId).filter(Boolean);
+}
+
+describe('GET /psa/tickets — org scoping of partner-wide connection data', () => {
+  it('LEAK GUARD: a selected-access partner user sees only their own orgs\' mappings', async () => {
+    const app = buildApp();
+    // setupTestEnvironment builds partner + org A and a partner-scope token.
+    const client = await createIntegrationTestClient(app, { scope: 'partner' });
+    const partnerId = client.env.partner.id;
+    const orgA = client.env.organization;
+
+    // A second org under the SAME partner, which this user must not reach.
+    const orgB = await createOrganization({ partnerId });
+
+    // Restrict the membership to org A only.
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .update(partnerUsers)
+        .set({ orgAccess: 'selected', orgIds: [orgA.id] })
+        .where(eq(partnerUsers.userId, client.env.user.id)),
+    );
+
+    const connectionId = await seedPartnerConnection(partnerId);
+    const deviceA = await seedDevice(orgA.id, 'org-a-host');
+    const deviceB = await seedDevice(orgB.id, 'org-b-host');
+    await seedMapping(connectionId, 'ORG-A-1', { deviceId: deviceA });
+    await seedMapping(connectionId, 'ORG-B-SECRET', { deviceId: deviceB });
+
+    const res = await client.get('/psa/tickets?limit=50');
+    expect(res.status).toBe(200);
+    const seen = ticketIds(await res.json());
+
+    expect(seen).toContain('ORG-A-1');
+    // The leak: org B's external ticket id must never appear.
+    expect(seen).not.toContain('ORG-B-SECRET');
+  });
+
+  it('LEAK GUARD: the same holds for GET /connections/:id/tickets', async () => {
+    // This route applied NO org filter at all once connection access passed.
+    const app = buildApp();
+    const client = await createIntegrationTestClient(app, { scope: 'partner' });
+    const partnerId = client.env.partner.id;
+    const orgA = client.env.organization;
+    const orgB = await createOrganization({ partnerId });
+
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .update(partnerUsers)
+        .set({ orgAccess: 'selected', orgIds: [orgA.id] })
+        .where(eq(partnerUsers.userId, client.env.user.id)),
+    );
+
+    const connectionId = await seedPartnerConnection(partnerId);
+    const deviceA = await seedDevice(orgA.id, 'org-a-host-2');
+    const deviceB = await seedDevice(orgB.id, 'org-b-host-2');
+    await seedMapping(connectionId, 'CONN-ORG-A', { deviceId: deviceA });
+    await seedMapping(connectionId, 'CONN-ORG-B-SECRET', { deviceId: deviceB });
+
+    const res = await client.get(`/psa/connections/${connectionId}/tickets?limit=50`);
+    expect(res.status).toBe(200);
+    const seen = ticketIds(await res.json());
+
+    expect(seen).toContain('CONN-ORG-A');
+    expect(seen).not.toContain('CONN-ORG-B-SECRET');
+  });
+
+  it('the ALERT anchor is scoped too, not just the device anchor', async () => {
+    const app = buildApp();
+    const client = await createIntegrationTestClient(app, { scope: 'partner' });
+    const partnerId = client.env.partner.id;
+    const orgA = client.env.organization;
+    const orgB = await createOrganization({ partnerId });
+
+    await withDbAccessContext(SYSTEM_CTX, () =>
+      db
+        .update(partnerUsers)
+        .set({ orgAccess: 'selected', orgIds: [orgA.id] })
+        .where(eq(partnerUsers.userId, client.env.user.id)),
+    );
+
+    const connectionId = await seedPartnerConnection(partnerId);
+    const deviceB = await seedDevice(orgB.id, 'org-b-alert-host');
+    const alertB = await seedAlert(orgB.id, deviceB, 'Org B alert');
+    // device_id NULL — only the alert anchors this row to org B.
+    await seedMapping(connectionId, 'ALERT-ORG-B-SECRET', { alertId: alertB });
+
+    const res = await client.get('/psa/tickets?limit=50');
+    expect(res.status).toBe(200);
+    expect(ticketIds(await res.json())).not.toContain('ALERT-ORG-B-SECRET');
+  });
+
+  it('a FULL partner admin still sees every org\'s mappings', async () => {
+    // The fix must not over-restrict: org_access='all' keeps full reach.
+    const app = buildApp();
+    const client = await createIntegrationTestClient(app, { scope: 'partner' });
+    const partnerId = client.env.partner.id;
+    const orgA = client.env.organization;
+    const orgB = await createOrganization({ partnerId });
+
+    const connectionId = await seedPartnerConnection(partnerId);
+    const deviceA = await seedDevice(orgA.id, 'full-a-host');
+    const deviceB = await seedDevice(orgB.id, 'full-b-host');
+    await seedMapping(connectionId, 'FULL-ORG-A', { deviceId: deviceA });
+    await seedMapping(connectionId, 'FULL-ORG-B', { deviceId: deviceB });
+
+    const res = await client.get('/psa/tickets?limit=50');
+    expect(res.status).toBe(200);
+    const seen = ticketIds(await res.json());
+    expect(seen).toContain('FULL-ORG-A');
+    expect(seen).toContain('FULL-ORG-B');
+  });
+
+  it('FINDING 8: an ORG-scope caller sees their own device\'s ticket under a PARTNER-wide connection', async () => {
+    // Previously an empty list: the query innerJoin'd psa_connections, and
+    // psa_connections RLS hides partner-wide rows from org tokens, so the
+    // ticket vanished with the connection it hung off.
+    const app = buildApp();
+    const client = await createIntegrationTestClient(app, { scope: 'organization' });
+    const partnerId = client.env.partner.id;
+    const org = client.env.organization;
+
+    const connectionId = await seedPartnerConnection(partnerId);
+    const deviceId = await seedDevice(org.id, 'org-scope-host');
+    await seedMapping(connectionId, 'MY-OWN-TICKET', { deviceId });
+
+    const res = await client.get('/psa/tickets?limit=50');
+    expect(res.status).toBe(200);
+    expect(ticketIds(await res.json())).toContain('MY-OWN-TICKET');
+  });
+
+  it('an org-scope caller still cannot see ANOTHER org\'s ticket on that connection', async () => {
+    const app = buildApp();
+    const client = await createIntegrationTestClient(app, { scope: 'organization' });
+    const partnerId = client.env.partner.id;
+    const otherOrg = await createOrganization({ partnerId });
+
+    const connectionId = await seedPartnerConnection(partnerId);
+    const otherDevice = await seedDevice(otherOrg.id, 'other-org-host');
+    await seedMapping(connectionId, 'OTHER-ORG-SECRET', { deviceId: otherDevice });
+
+    const res = await client.get('/psa/tickets?limit=50');
+    expect(res.status).toBe(200);
+    expect(ticketIds(await res.json())).not.toContain('OTHER-ORG-SECRET');
+  });
+});

--- a/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
+++ b/apps/api/src/__tests__/integration/rls-coverage.integration.test.ts
@@ -427,6 +427,19 @@ const DUAL_AXIS_TENANT_TABLES: ReadonlySet<string> = new Set<string>([
   // Functional cross-partner forge proof:
   // contractTemplatesPartnerRls.integration.test.ts.
   'contract_template_versions',
+  // psa_connections (epic #2135, 2026-08-17): an MSP's PSA is a PARTNER-level
+  // system (its sibling accounting_connections is already partner-axis), so a
+  // connection is partner-wide (partner_id set, org_id NULL) OR org-scoped
+  // (org_id set, partner_id NULL — a customer's own Jira/Zendesk in a
+  // co-managed engagement). Retrofitted from org-only in
+  // 2026-08-17-psa-connections-partner-ownership. The org_id column means
+  // org-tenant auto-discovery already asserts the breeze_has_org_access branch;
+  // this entry asserts the breeze_has_partner_access (partner-wide) branch.
+  // CHECK psa_connections_one_owner_chk enforces exactly one axis. The child
+  // psa_ticket_mappings stays a parent-FK join (registered below) and its
+  // policy gained the partner branch in the same migration. Functional
+  // cross-partner forge proof: psaConnectionsPartnerRls.integration.test.ts.
+  'psa_connections',
 ]);
 
 // Tables that carry a `device_id` FK but no denormalized `org_id`. Their
@@ -501,6 +514,12 @@ const PARENT_FK_JOIN_POLICY_TABLES: ReadonlyMap<string, readonly string[]> = new
   // (2026-04-11-bucket-c-dead-cleanup-rls.sql) but had no org_id column and was
   // never allowlisted, so the contract test couldn't see it. Register it so a
   // future regression that drops/weakens the policy is caught.
+  // 2026-08-17 (epic #2135): the four per-command policies were collapsed into
+  // one `psa_ticket_mappings_isolation` and the join predicate gained the
+  // parent's partner branch. A plain breeze_has_org_access(pc.org_id) join is
+  // now WRONG — the parent's org_id is NULL for every partner-owned
+  // connection, which would make those mappings invisible AND unwritable.
+  // Same hazard ticket_form_org_links documents below.
   ['psa_ticket_mappings', ['psa_connections']],
   // ticket_form_org_links (2026-07-11): org allowlist for partner-wide
   // ticket_forms. Its policy joins through ticket_forms and OR's in the

--- a/apps/api/src/db/schema/integrations.ts
+++ b/apps/api/src/db/schema/integrations.ts
@@ -1,5 +1,5 @@
 import { pgTable, uuid, varchar, text, timestamp, boolean, jsonb, pgEnum, integer } from 'drizzle-orm/pg-core';
-import { organizations } from './orgs';
+import { organizations, partners } from './orgs';
 import { users } from './users';
 import { alerts } from './alerts';
 import { devices } from './devices';
@@ -107,9 +107,15 @@ export const eventBusEvents = pgTable('event_bus_events', {
   createdAt: timestamp('created_at').defaultNow().notNull()
 });
 
+// Dual ownership (epic #2135): a connection is owned by EITHER an org
+// (org_id set, partner_id NULL — a customer's own Jira/Zendesk in a co-managed
+// engagement) OR a partner (partner_id set, org_id NULL — the MSP's own PSA,
+// shared across all orgs). Exactly one axis is set, enforced in Postgres by
+// psa_connections_one_owner_chk (2026-08-17-psa-connections-partner-ownership).
 export const psaConnections = pgTable('psa_connections', {
   id: uuid('id').primaryKey().defaultRandom(),
-  orgId: uuid('org_id').notNull().references(() => organizations.id),
+  orgId: uuid('org_id').references(() => organizations.id),
+  partnerId: uuid('partner_id').references(() => partners.id),
   provider: psaProviderEnum('provider').notNull(),
   name: varchar('name', { length: 255 }).notNull(),
   credentials: jsonb('credentials').notNull(),

--- a/apps/api/src/routes/psa.test.ts
+++ b/apps/api/src/routes/psa.test.ts
@@ -970,6 +970,80 @@ describe('psa routes', () => {
       expect(updateMock).not.toHaveBeenCalled();
     });
 
+    it('withholds the credential prefill from a partner user who cannot manage partner-wide rows', async () => {
+      // orgs:write alone is NOT enough (review finding 5). This caller is
+      // refused every mutation on the row, so handing them the edit-form
+      // prefill would leak the exact material #3291 gated to someone who
+      // cannot use it.
+      asPartner({ orgAccess: 'selected' });
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.credentials).toBeUndefined();
+      expect(body.data.credentialFields).toBeUndefined();
+      // The non-gated public boolean stays.
+      expect(body.data.hasCredentials).toBe(true);
+    });
+
+    it('still gives the credential prefill to a full partner admin', async () => {
+      asPartner({ orgAccess: 'all' });
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.credentials).toBeDefined();
+      expect(body.data.credentialFields).toBeDefined();
+    });
+
+    it('scopes GET /tickets by the mapping org anchors, NOT by joining psa_connections', async () => {
+      // The innerJoin had to go: psa_connections RLS hides partner-wide rows
+      // from org tokens, so joining dropped every ticket about an org's own
+      // device whenever the MSP's PSA was partner-wide (review finding 8).
+      const rowsChain = makeChain([]);
+      const countChain = makeChain([{ count: 0 }]);
+      selectMock
+        .mockReturnValueOnce(rowsChain as never)
+        .mockReturnValueOnce(countChain as never);
+
+      const res = await app.request('/psa/tickets?page=1&limit=10', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      expect(rowsChain.innerJoin).not.toHaveBeenCalled();
+      expect(countChain.innerJoin).not.toHaveBeenCalled();
+      // A scoping predicate is still applied on both queries.
+      expect(rowsChain.where).toHaveBeenCalled();
+      expect(countChain.where).toHaveBeenCalled();
+      expect(rowsChain.where.mock.calls[0]![0]).toBeDefined();
+    });
+
+    it('applies an org filter to GET /connections/:id/tickets, not just connection access', async () => {
+      // Review finding 1: this route previously applied NO org filter once
+      // ensureConnectionAccess passed, so a restricted partner user read every
+      // org's external ticket ids through a partner-wide connection.
+      asPartner({ orgAccess: 'selected', orgs: ['org-123'] });
+      const rowsChain = makeChain([]);
+      const countChain = makeChain([{ count: 0 }]);
+      selectMock
+        .mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never)
+        .mockReturnValueOnce(rowsChain as never)
+        .mockReturnValueOnce(countChain as never);
+
+      const res = await app.request('/psa/connections/conn-1/tickets?page=1&limit=10', {
+        method: 'GET'
+      });
+
+      expect(res.status).toBe(200);
+      // connectionId eq + the org-anchor condition => more than one predicate.
+      const whereArg = rowsChain.where.mock.calls[0]![0] as { queryChunks?: unknown[] };
+      expect(whereArg).toBeDefined();
+      expect(countChain.where).toHaveBeenCalled();
+    });
+
     it('serializes ownerScope organization for an org-owned row', async () => {
       selectMock.mockReturnValueOnce(makeChain([connectionRow({ partnerId: null })]) as never);
 

--- a/apps/api/src/routes/psa.test.ts
+++ b/apps/api/src/routes/psa.test.ts
@@ -53,6 +53,7 @@ vi.mock('../db/schema', () => ({
   psaConnections: {
     id: 'psa_connections.id',
     orgId: 'psa_connections.org_id',
+    partnerId: 'psa_connections.partner_id',
     provider: 'psa_connections.provider',
     name: 'psa_connections.name',
     credentials: 'psa_connections.credentials',
@@ -113,10 +114,14 @@ vi.mock('../middleware/auth', () => ({
     c.set('auth', {
       scope: 'organization',
       partnerId: null,
+      partnerOrgAccess: null,
       orgId: 'org-123',
       user: { id: 'user-123', email: 'test@example.com' },
       canAccessOrg: (orgId: string) => orgId === 'org-123',
-      accessibleOrgIds: ['org-123']
+      accessibleOrgIds: ['org-123'],
+      // Real AuthContext closure: an org-scope caller is restricted to
+      // its own org. A marker object suffices — `.where()` is mocked.
+      orgCondition: (col: unknown) => ({ orgEq: col, value: 'org-123' })
     });
     return next();
   }),
@@ -316,10 +321,14 @@ describe('psa routes', () => {
       c.set('auth', {
         scope: 'organization',
         partnerId: null,
+        partnerOrgAccess: null,
         orgId: 'org-123',
         user: { id: 'user-123', email: 'test@example.com' },
         canAccessOrg: (orgId: string) => orgId === 'org-123',
-        accessibleOrgIds: ['org-123']
+        accessibleOrgIds: ['org-123'],
+        // Real AuthContext closure: an org-scope caller is restricted to
+        // its own org. A marker object suffices — `.where()` is mocked.
+        orgCondition: (col: unknown) => ({ orgEq: col, value: 'org-123' })
       });
       return next();
     });
@@ -728,6 +737,249 @@ describe('psa routes', () => {
     expect(res.status).toBe(200);
     expect(rowsChain.leftJoin).toHaveBeenCalled();
     expect(countChain.leftJoin).toHaveBeenCalled();
+  });
+
+  // ---- Dual ownership: org XOR partner (epic #2135) ----
+
+  describe('dual ownership (org XOR partner)', () => {
+    /** Install a partner-scope auth context. `orgAccess` drives the partner-wide gate. */
+    function asPartner(opts: {
+      partnerId?: string;
+      orgAccess?: 'all' | 'selected' | 'none' | null;
+      orgs?: string[];
+    } = {}) {
+      const partnerId = opts.partnerId ?? 'partner-1';
+      const orgs = opts.orgs ?? ['org-123'];
+      vi.mocked(authMiddleware).mockImplementation((c: any, next: any) => {
+        c.set('auth', {
+          scope: 'partner',
+          partnerId,
+          partnerOrgAccess: opts.orgAccess ?? 'all',
+          orgId: null,
+          user: { id: 'user-123', email: 'test@example.com' },
+          canAccessOrg: (orgId: string) => orgs.includes(orgId),
+          accessibleOrgIds: orgs,
+          orgCondition: (col: unknown) => ({ orgIn: col, value: orgs })
+        });
+        return next();
+      });
+    }
+
+    const partnerOwnedRow = (overrides: Record<string, unknown> = {}) =>
+      connectionRow({ orgId: null, partnerId: 'partner-1', ...overrides });
+
+    it('creates a partner-wide connection with org_id NULL and the token partner', async () => {
+      asPartner({ orgAccess: 'all' });
+      const values = vi.fn((_row: Record<string, unknown>) => ({ returning: vi.fn(async () => [partnerOwnedRow()]) }));
+      insertMock.mockReturnValueOnce({ values } as any);
+
+      const res = await app.request('/psa/connections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          provider: 'jira',
+          name: 'MSP Jira',
+          credentials: { baseUrl: 'https://acme.atlassian.net', username: 'a@acme.com', apiToken: 't' }
+        })
+      });
+
+      expect(res.status).toBe(201);
+      // The XOR: org_id NULL, partner_id from the CALLER'S TOKEN (never the body).
+      const inserted = values.mock.calls[0]![0] as Record<string, unknown>;
+      expect(inserted.orgId).toBeNull();
+      expect(inserted.partnerId).toBe('partner-1');
+
+      const body = await res.json();
+      expect(body.ownerScope).toBe('partner');
+      expect(body.orgId).toBeNull();
+    });
+
+    it('ignores a body-supplied orgId when ownerScope is partner', async () => {
+      asPartner({ orgAccess: 'all' });
+      const values = vi.fn((_row: Record<string, unknown>) => ({ returning: vi.fn(async () => [partnerOwnedRow()]) }));
+      insertMock.mockReturnValueOnce({ values } as any);
+
+      const res = await app.request('/psa/connections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          orgId: '11111111-1111-4111-8111-111111111111',
+          provider: 'jira',
+          name: 'MSP Jira',
+          credentials: { baseUrl: 'https://acme.atlassian.net', username: 'a@acme.com', apiToken: 't' }
+        })
+      });
+
+      expect(res.status).toBe(201);
+      expect((values.mock.calls[0]![0] as Record<string, unknown>).orgId).toBeNull();
+    });
+
+    it('denies partner-wide create without full partner org access', async () => {
+      asPartner({ orgAccess: 'selected' });
+
+      const res = await app.request('/psa/connections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          provider: 'jira',
+          name: 'MSP Jira',
+          credentials: { baseUrl: 'https://acme.atlassian.net', username: 'a@acme.com', apiToken: 't' }
+        })
+      });
+
+      expect(res.status).toBe(403);
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+
+    it('denies partner-wide create from an org-scope caller', async () => {
+      // Default beforeEach auth is org scope with partnerId null.
+      const res = await app.request('/psa/connections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ownerScope: 'partner',
+          provider: 'jira',
+          name: 'MSP Jira',
+          credentials: { baseUrl: 'https://acme.atlassian.net', username: 'a@acme.com', apiToken: 't' }
+        })
+      });
+
+      expect(res.status).toBe(403);
+      expect(insertMock).not.toHaveBeenCalled();
+    });
+
+    it('defaults to an org-owned connection when ownerScope is omitted', async () => {
+      const values = vi.fn((_row: Record<string, unknown>) => ({ returning: vi.fn(async () => [connectionRow({ partnerId: null })]) }));
+      insertMock.mockReturnValueOnce({ values } as any);
+
+      const res = await app.request('/psa/connections', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: 'jira',
+          name: 'Customer Jira',
+          credentials: { baseUrl: 'https://acme.atlassian.net', username: 'a@acme.com', apiToken: 't' }
+        })
+      });
+
+      expect(res.status).toBe(201);
+      const inserted = values.mock.calls[0]![0] as Record<string, unknown>;
+      expect(inserted.orgId).toBe('org-123');
+      expect(inserted.partnerId).toBeNull();
+      expect((await res.json()).ownerScope).toBe('organization');
+    });
+
+    it('lets the owning partner read a partner-wide connection', async () => {
+      asPartner({ orgAccess: 'all' });
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.ownerScope).toBe('partner');
+      expect(body.data.orgId).toBeNull();
+    });
+
+    it('denies a DIFFERENT partner access to a partner-wide connection', async () => {
+      asPartner({ partnerId: 'partner-2', orgAccess: 'all' });
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', { method: 'GET' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('denies an org-scope caller access to a partner-wide connection', async () => {
+      // Org tokens carry a partnerId but never pass breeze_has_partner_access,
+      // so the app layer must refuse rather than 200-with-no-rows.
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', { method: 'GET' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('denies PATCH of a partner-wide connection without full partner org access', async () => {
+      asPartner({ orgAccess: 'selected' });
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' })
+      });
+
+      expect(res.status).toBe(403);
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('denies DELETE of a partner-wide connection without full partner org access', async () => {
+      asPartner({ orgAccess: 'selected' });
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', { method: 'DELETE' });
+
+      expect(res.status).toBe(403);
+      expect(deleteMock).not.toHaveBeenCalled();
+    });
+
+    it('denies status changes on a partner-wide connection without full partner org access', async () => {
+      asPartner({ orgAccess: 'selected' });
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+
+      const res = await app.request('/psa/connections/conn-1/status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'paused' })
+      });
+
+      expect(res.status).toBe(403);
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('allows a full partner admin to PATCH a partner-wide connection', async () => {
+      asPartner({ orgAccess: 'all' });
+      selectMock.mockReturnValueOnce(makeChain([partnerOwnedRow()]) as never);
+      updateMock.mockReturnValueOnce(makeChain([partnerOwnedRow({ name: 'Renamed' })]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' })
+      });
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).ownerScope).toBe('partner');
+    });
+
+    it('rejects ownerScope on PATCH (ownership is immutable)', async () => {
+      asPartner({ orgAccess: 'all' });
+
+      const res = await app.request('/psa/connections/conn-1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ownerScope: 'organization' })
+      });
+
+      // Unknown key only => no recognised updates.
+      expect(res.status).toBe(400);
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('serializes ownerScope organization for an org-owned row', async () => {
+      selectMock.mockReturnValueOnce(makeChain([connectionRow({ partnerId: null })]) as never);
+
+      const res = await app.request('/psa/connections/conn-1', { method: 'GET' });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.ownerScope).toBe('organization');
+      expect(body.data.orgId).toBe('org-123');
+    });
   });
 
   it('denies partner access when the organization is not linked', async () => {

--- a/apps/api/src/routes/psa.ts
+++ b/apps/api/src/routes/psa.ts
@@ -93,7 +93,14 @@ function getPagination(query: { page?: string; limit?: string }) {
   return { page, limit, offset: (page - 1) * limit };
 }
 
-type ConnectionOwner = { orgId: string | null; partnerId: string | null };
+// `partnerId`/`orgId` are nullable in Postgres; accept `undefined` too so a
+// partially-selected row can never be misread as partner-owned.
+type ConnectionOwner = { orgId?: string | null; partnerId?: string | null };
+
+/** The partner that owns this row, or null when it is org-owned. */
+function ownerPartnerId(connection: ConnectionOwner): string | null {
+  return connection.partnerId ?? null;
+}
 
 type OrgAccessAuth = Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>;
 
@@ -127,11 +134,12 @@ async function ensureConnectionAccess(
 ) {
   if (auth.scope === 'system') return true;
 
-  if (connection.partnerId !== null) {
-    return auth.scope === 'partner' && auth.partnerId === connection.partnerId;
+  const partnerId = ownerPartnerId(connection);
+  if (partnerId !== null) {
+    return auth.scope === 'partner' && auth.partnerId === partnerId;
   }
 
-  if (connection.orgId === null) return false;
+  if (!connection.orgId) return false;
   return ensureOrgAccess(connection.orgId, auth);
 }
 
@@ -155,7 +163,7 @@ function psaConnectionAccessCondition(
 
 /** 'partner' when the row is partner-wide ("All orgs"), else 'organization'. */
 function ownerScopeOf(connection: ConnectionOwner): 'organization' | 'partner' {
-  return connection.partnerId !== null ? 'partner' : 'organization';
+  return ownerPartnerId(connection) !== null ? 'partner' : 'organization';
 }
 
 /**
@@ -171,7 +179,7 @@ function partnerWideWriteBlocked(
   connection: ConnectionOwner,
   auth: Pick<AuthContext, 'scope' | 'partnerOrgAccess'>
 ): boolean {
-  return connection.partnerId !== null && !canManagePartnerWidePolicies(auth);
+  return ownerPartnerId(connection) !== null && !canManagePartnerWidePolicies(auth);
 }
 
 /**
@@ -181,9 +189,9 @@ function partnerWideWriteBlocked(
  */
 function auditOwnerFields(connection: ConnectionOwner) {
   return {
-    orgId: connection.orgId,
+    orgId: connection.orgId ?? null,
     ownerScope: ownerScopeOf(connection),
-    partnerId: connection.partnerId
+    partnerId: ownerPartnerId(connection)
   };
 }
 

--- a/apps/api/src/routes/psa.ts
+++ b/apps/api/src/routes/psa.ts
@@ -161,6 +161,55 @@ function psaConnectionAccessCondition(
   return orgCond;
 }
 
+/**
+ * WHERE fragment restricting psa_ticket_mappings rows to the caller's ACCESSIBLE
+ * ORGS, via the mapping's own org anchors.
+ *
+ * This is the tenancy boundary for ticket DATA, and it is deliberately separate
+ * from `psaConnectionAccessCondition`, which governs CONFIG visibility. The two
+ * were conflated before, which leaked data:
+ *
+ *   A psa_connections row is partner-owned CONFIG — correctly visible to any
+ *   partner-scope caller of that partner. The psa_ticket_mappings rows hanging
+ *   off it are PER-ORG DATA: they name a specific org's device, alert, and
+ *   external ticket. A `partner_user` with org_access='selected' scoped to org A
+ *   could read org B's external ticket ids/URLs through the partner-wide
+ *   connection, because "partner scope" was treated as sufficient authorization
+ *   for everything reachable from a partner-owned row. It is not.
+ *
+ * Every anchor that is SET must be accessible (AND, not OR): a row is withheld
+ * if EITHER its device or its alert belongs to an org the caller cannot reach.
+ * A row with neither anchor references no org at all, so connection access
+ * governs it and it passes this filter.
+ *
+ * Note this is NOT redundant with RLS. `breeze_has_org_access` does respect the
+ * caller's accessible-org list, but the psa_ticket_mappings policy's
+ * connection arm passes for ANY partner-scope caller of the owning partner —
+ * necessarily so, since unanchored rows have no org to check. Postgres cannot
+ * express "org_access='selected'" here; this condition is the enforcement point
+ * for that refinement and must not be removed as "the policy already covers it".
+ */
+function psaTicketMappingOrgCondition(
+  auth: Pick<AuthContext, 'accessibleOrgIds'>
+): SQL | undefined {
+  const orgIds = auth.accessibleOrgIds;
+  if (orgIds === null) return undefined; // system scope — unrestricted
+  if (orgIds.length === 0) return sql`false`;
+
+  return sql`(
+    (${psaTicketMappings.deviceId} IS NULL OR EXISTS (
+      SELECT 1 FROM devices d
+       WHERE d.id = ${psaTicketMappings.deviceId}
+         AND d.org_id = ANY(${orgIds}::uuid[])
+    ))
+    AND (${psaTicketMappings.alertId} IS NULL OR EXISTS (
+      SELECT 1 FROM alerts a
+       WHERE a.id = ${psaTicketMappings.alertId}
+         AND a.org_id = ANY(${orgIds}::uuid[])
+    ))
+  )`;
+}
+
 /** 'partner' when the row is partner-wide ("All orgs"), else 'organization'. */
 function ownerScopeOf(connection: ConnectionOwner): 'organization' | 'partner' {
   return ownerPartnerId(connection) !== null ? 'partner' : 'organization';
@@ -370,26 +419,12 @@ function mapTicketRow(row: {
   };
 }
 
-async function resolveOrgIds(
-  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>,
-  queryOrgId?: string
-): Promise<string[] | null> {
-  if (auth.scope === 'organization') {
-    if (!auth.orgId) return [];
-    return [auth.orgId];
-  }
-
-  if (auth.scope === 'partner') {
-    if (queryOrgId) {
-      const hasAccess = await ensureOrgAccess(queryOrgId, auth);
-      return hasAccess ? [queryOrgId] : [];
-    }
-
-    return auth.accessibleOrgIds ?? [];
-  }
-
-  return queryOrgId ? [queryOrgId] : null;
-}
+// `resolveOrgIds` used to live here. It returned a flat org-id list and every
+// caller turned that into `inArray(psa_connections.org_id, ids)` — the exact
+// org-only shape that made partner-wide connections invisible. Both call sites
+// now use psaConnectionAccessCondition (config visibility) or
+// psaTicketMappingOrgCondition (ticket data), so the helper is deleted rather
+// than left around for the next endpoint to copy.
 
 async function getConnectionById(id: string) {
   const [connection] = await db
@@ -639,10 +674,17 @@ psaRoutes.get(
     // material or which auth mode a connection is configured with (#3291
     // review) — `requirePermission(ORGS_READ)` above has already resolved and
     // cached the permission set on the context.
+    //
+    // orgs:write is necessary but NOT sufficient (epic #2135): a partner user
+    // without full partner org access is refused every mutation on a
+    // partner-wide connection, so handing them the edit-form prefill would
+    // leak exactly the material #3291 gated to someone who cannot use it. The
+    // prefill gate must therefore mirror the write gate, not just the
+    // permission.
     const perms = c.get('permissions') as UserPermissions | undefined;
-    const canManage = perms
+    const canManage = (perms
       ? hasPermission(perms, PERMISSIONS.ORGS_WRITE.resource, PERMISSIONS.ORGS_WRITE.action)
-      : false;
+      : false) && !partnerWideWriteBlocked(connection, auth);
 
     return c.json({ data: serializeConnection(connection, canManage) });
   }
@@ -985,11 +1027,18 @@ psaRoutes.get(
     const { page, limit, offset } = getPagination(query);
 
     const conditions: SQL[] = [];
-    // Scoped through the innerJoin on psa_connections below. Dual-axis (epic
-    // #2135): an org-only `orgId IN (...)` here dropped every ticket belonging
-    // to a partner-wide connection, since those rows have org_id NULL.
-    const accessCondition = psaConnectionAccessCondition(auth);
-    if (accessCondition) conditions.push(accessCondition);
+    // Tenancy comes from the MAPPING's own org anchors, not from the connection.
+    //
+    // There is deliberately NO innerJoin on psa_connections any more. That join
+    // could not coexist with correct org-scope behaviour: psa_connections RLS
+    // (rightly) hides partner-wide rows from org tokens, so the join silently
+    // dropped every ticket about an org's OWN device whenever the MSP's PSA was
+    // partner-wide — the connection was invisible, so the ticket vanished with
+    // it. Scoping the mapping rows directly fixes that and is also what closes
+    // the cross-org leak, since the connection arm alone cannot express
+    // org_access='selected'. psa_ticket_mappings RLS still bounds the partner.
+    const ticketOrgCondition = psaTicketMappingOrgCondition(auth);
+    if (ticketOrgCondition) conditions.push(ticketOrgCondition);
     if (perms?.allowedSiteIds) {
       conditions.push(or(
         isNull(psaTicketMappings.deviceId),
@@ -1012,8 +1061,7 @@ psaRoutes.get(
         updatedAt: psaTicketMappings.updatedAt,
         createdAt: psaTicketMappings.createdAt
       })
-      .from(psaTicketMappings)
-      .innerJoin(psaConnectionsTable, eq(psaTicketMappings.connectionId, psaConnectionsTable.id));
+      .from(psaTicketMappings);
     const rows = await (perms?.allowedSiteIds
       ? rowsQuery.leftJoin(devices, eq(psaTicketMappings.deviceId, devices.id)).where(whereClause)
       : rowsQuery.where(whereClause))
@@ -1023,8 +1071,7 @@ psaRoutes.get(
 
     const countQuery = db
       .select({ count: sql<number>`count(*)` })
-      .from(psaTicketMappings)
-      .innerJoin(psaConnectionsTable, eq(psaTicketMappings.connectionId, psaConnectionsTable.id));
+      .from(psaTicketMappings);
     const countRows = await (perms?.allowedSiteIds
       ? countQuery.leftJoin(devices, eq(psaTicketMappings.deviceId, devices.id)).where(whereClause)
       : countQuery.where(whereClause));
@@ -1059,6 +1106,13 @@ psaRoutes.get(
     }
 
     const conditions: SQL[] = [eq(psaTicketMappings.connectionId, connectionId)];
+    // `ensureConnectionAccess` above proves the caller may see the CONNECTION.
+    // It says nothing about which orgs' ticket DATA they may read: for a
+    // partner-wide connection it passes for every partner-scope caller,
+    // including an org_access='selected' user. Without this the route returned
+    // every org's external ticket ids and URLs under that connection.
+    const ticketOrgCondition = psaTicketMappingOrgCondition(auth);
+    if (ticketOrgCondition) conditions.push(ticketOrgCondition);
     if (perms?.allowedSiteIds) {
       conditions.push(or(
         isNull(psaTicketMappings.deviceId),

--- a/apps/api/src/routes/psa.ts
+++ b/apps/api/src/routes/psa.ts
@@ -20,6 +20,7 @@ import {
   canManagePartnerWidePolicies
 } from '../services/partnerWideAccess';
 import { createPSAProvider } from '../services/psa';
+import { psaTicketMappingOrgCondition } from '../services/psa/ticketScope';
 import {
   PsaConfigError,
   decryptCredentials,
@@ -159,55 +160,6 @@ function psaConnectionAccessCondition(
     return sql`(${orgCond} OR (${psaConnectionsTable.orgId} IS NULL AND ${psaConnectionsTable.partnerId} = ${auth.partnerId}))`;
   }
   return orgCond;
-}
-
-/**
- * WHERE fragment restricting psa_ticket_mappings rows to the caller's ACCESSIBLE
- * ORGS, via the mapping's own org anchors.
- *
- * This is the tenancy boundary for ticket DATA, and it is deliberately separate
- * from `psaConnectionAccessCondition`, which governs CONFIG visibility. The two
- * were conflated before, which leaked data:
- *
- *   A psa_connections row is partner-owned CONFIG — correctly visible to any
- *   partner-scope caller of that partner. The psa_ticket_mappings rows hanging
- *   off it are PER-ORG DATA: they name a specific org's device, alert, and
- *   external ticket. A `partner_user` with org_access='selected' scoped to org A
- *   could read org B's external ticket ids/URLs through the partner-wide
- *   connection, because "partner scope" was treated as sufficient authorization
- *   for everything reachable from a partner-owned row. It is not.
- *
- * Every anchor that is SET must be accessible (AND, not OR): a row is withheld
- * if EITHER its device or its alert belongs to an org the caller cannot reach.
- * A row with neither anchor references no org at all, so connection access
- * governs it and it passes this filter.
- *
- * Note this is NOT redundant with RLS. `breeze_has_org_access` does respect the
- * caller's accessible-org list, but the psa_ticket_mappings policy's
- * connection arm passes for ANY partner-scope caller of the owning partner —
- * necessarily so, since unanchored rows have no org to check. Postgres cannot
- * express "org_access='selected'" here; this condition is the enforcement point
- * for that refinement and must not be removed as "the policy already covers it".
- */
-function psaTicketMappingOrgCondition(
-  auth: Pick<AuthContext, 'accessibleOrgIds'>
-): SQL | undefined {
-  const orgIds = auth.accessibleOrgIds;
-  if (orgIds === null) return undefined; // system scope — unrestricted
-  if (orgIds.length === 0) return sql`false`;
-
-  return sql`(
-    (${psaTicketMappings.deviceId} IS NULL OR EXISTS (
-      SELECT 1 FROM devices d
-       WHERE d.id = ${psaTicketMappings.deviceId}
-         AND d.org_id = ANY(${orgIds}::uuid[])
-    ))
-    AND (${psaTicketMappings.alertId} IS NULL OR EXISTS (
-      SELECT 1 FROM alerts a
-       WHERE a.id = ${psaTicketMappings.alertId}
-         AND a.org_id = ANY(${orgIds}::uuid[])
-    ))
-  )`;
 }
 
 /** 'partner' when the row is partner-wide ("All orgs"), else 'organization'. */
@@ -1037,7 +989,7 @@ psaRoutes.get(
     // it. Scoping the mapping rows directly fixes that and is also what closes
     // the cross-org leak, since the connection arm alone cannot express
     // org_access='selected'. psa_ticket_mappings RLS still bounds the partner.
-    const ticketOrgCondition = psaTicketMappingOrgCondition(auth);
+    const ticketOrgCondition = psaTicketMappingOrgCondition(auth.accessibleOrgIds);
     if (ticketOrgCondition) conditions.push(ticketOrgCondition);
     if (perms?.allowedSiteIds) {
       conditions.push(or(
@@ -1111,7 +1063,7 @@ psaRoutes.get(
     // partner-wide connection it passes for every partner-scope caller,
     // including an org_access='selected' user. Without this the route returned
     // every org's external ticket ids and URLs under that connection.
-    const ticketOrgCondition = psaTicketMappingOrgCondition(auth);
+    const ticketOrgCondition = psaTicketMappingOrgCondition(auth.accessibleOrgIds);
     if (ticketOrgCondition) conditions.push(ticketOrgCondition);
     if (perms?.allowedSiteIds) {
       conditions.push(or(

--- a/apps/api/src/routes/psa.ts
+++ b/apps/api/src/routes/psa.ts
@@ -15,6 +15,10 @@ import { db } from '../db';
 import { devices, psaConnections as psaConnectionsTable, psaTicketMappings } from '../db/schema';
 import { writeRouteAudit } from '../services/auditEvents';
 import { PERMISSIONS, hasPermission, type UserPermissions } from '../services/permissions';
+import {
+  PARTNER_WIDE_WRITE_DENIED_MESSAGE,
+  canManagePartnerWidePolicies
+} from '../services/partnerWideAccess';
 import { createPSAProvider } from '../services/psa';
 import {
   PsaConfigError,
@@ -42,6 +46,12 @@ const listConnectionsSchema = z.object({
 });
 
 const createConnectionSchema = z.object({
+  // Ownership axis (epic #2135). Absent => 'organization', preserving the
+  // pre-#2135 behaviour for every existing API client. The WEB form defaults
+  // its selector to 'partner' (an MSP's PSA is normally partner-wide), but the
+  // wire default stays org-scoped so an unaware caller can never accidentally
+  // publish a credential to every org under the partner.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   orgId: z.string().guid().optional(),
   provider: providerSchema,
   name: z.string().min(1).max(255),
@@ -55,6 +65,11 @@ const createConnectionSchema = z.object({
   ).optional().default({})
 });
 
+// Ownership is immutable after create — there is deliberately no `ownerScope`
+// (nor `orgId`/`partnerId`) here. Re-homing a connection would silently move
+// every psa_ticket_mappings child across a tenant boundary, and this schema is
+// hand-written rather than derived via `.partial()`, so there is nothing to
+// `.omit({ ownerScope: true })` from.
 const updateConnectionSchema = z.object({
   name: z.string().min(1).max(255).optional(),
   credentials: z.record(z.string(), z.any()).refine(
@@ -78,10 +93,11 @@ function getPagination(query: { page?: string; limit?: string }) {
   return { page, limit, offset: (page - 1) * limit };
 }
 
-async function ensureOrgAccess(
-  orgId: string,
-  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>
-) {
+type ConnectionOwner = { orgId: string | null; partnerId: string | null };
+
+type OrgAccessAuth = Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg'>;
+
+async function ensureOrgAccess(orgId: string, auth: OrgAccessAuth) {
   if (auth.scope === 'organization') {
     return auth.orgId === orgId;
   }
@@ -91,6 +107,84 @@ async function ensureOrgAccess(
   }
 
   return true;
+}
+
+/**
+ * Dual-axis access check for one connection row (epic #2135). Replaces the
+ * org-only `ensureOrgAccess(connection.orgId, ...)` — a partner-owned row has
+ * `orgId === null`, which the org check can only ever reject.
+ *
+ * The partner arm is gated on `auth.scope === 'partner'`. An ORG-scope token
+ * carries a partnerId but never passes `breeze_has_partner_access`, so allowing
+ * it here would let the app layer approve a read that RLS then returns empty
+ * for — a confusing 200-with-no-rows instead of an honest 403. RLS is strictly
+ * stricter than this check; the two are NOT at parity and this function must
+ * never be described as enforcing isolation on its own.
+ */
+async function ensureConnectionAccess(
+  connection: ConnectionOwner,
+  auth: Pick<AuthContext, 'scope' | 'orgId' | 'accessibleOrgIds' | 'canAccessOrg' | 'partnerId'>
+) {
+  if (auth.scope === 'system') return true;
+
+  if (connection.partnerId !== null) {
+    return auth.scope === 'partner' && auth.partnerId === connection.partnerId;
+  }
+
+  if (connection.orgId === null) return false;
+  return ensureOrgAccess(connection.orgId, auth);
+}
+
+/**
+ * WHERE fragment restricting a psa_connections query to what `auth` may see:
+ * the caller's own orgs, OR (partner scope only) the partner's partner-wide
+ * rows. `undefined` means system scope — no filter.
+ *
+ * Mirrors `softwarePolicyAccessCondition` in routes/softwarePolicies.ts.
+ */
+function psaConnectionAccessCondition(
+  auth: Pick<AuthContext, 'scope' | 'partnerId' | 'orgCondition'>
+): SQL | undefined {
+  const orgCond = auth.orgCondition(psaConnectionsTable.orgId);
+  if (!orgCond) return undefined;
+  if (auth.scope === 'partner' && auth.partnerId) {
+    return sql`(${orgCond} OR (${psaConnectionsTable.orgId} IS NULL AND ${psaConnectionsTable.partnerId} = ${auth.partnerId}))`;
+  }
+  return orgCond;
+}
+
+/** 'partner' when the row is partner-wide ("All orgs"), else 'organization'. */
+function ownerScopeOf(connection: ConnectionOwner): 'organization' | 'partner' {
+  return connection.partnerId !== null ? 'partner' : 'organization';
+}
+
+/**
+ * True when the caller may SEE this connection but must not MUTATE it because
+ * it is partner-wide and they lack full partner org access (epic #2135).
+ *
+ * Applied to update, delete, status AND test. Status is an update by another
+ * name — pausing a partner-wide connection pauses it for every org — and test
+ * both writes `syncSettings.lastTestedAt/status` and exercises the MSP's own
+ * PSA credentials, so a 'selected'-access partner user is held to the same bar.
+ */
+function partnerWideWriteBlocked(
+  connection: ConnectionOwner,
+  auth: Pick<AuthContext, 'scope' | 'partnerOrgAccess'>
+): boolean {
+  return connection.partnerId !== null && !canManagePartnerWidePolicies(auth);
+}
+
+/**
+ * Audit anchor for a connection. A partner-wide row has no org, so the audit
+ * row carries org_id NULL (RouteAuditInput allows it) and the partner id lands
+ * in `details` — otherwise the erasure/forensic trail loses the owner entirely.
+ */
+function auditOwnerFields(connection: ConnectionOwner) {
+  return {
+    orgId: connection.orgId,
+    ownerScope: ownerScopeOf(connection),
+    partnerId: connection.partnerId
+  };
 }
 
 function extractLastTestedAt(syncSettings: unknown): Date | null {
@@ -168,7 +262,8 @@ function deriveConnectionStatus(settings: unknown): 'active' | 'paused' | 'error
 function serializeConnection(
   connection: {
     id: string;
-    orgId: string;
+    orgId: string | null;
+    partnerId: string | null;
     provider: string;
     name: string;
     credentials: unknown;
@@ -186,7 +281,11 @@ function serializeConnection(
 
   const response = {
     id: connection.id,
+    // NULL for a partner-wide connection (epic #2135). Kept in the response —
+    // removing a field is a breaking public-API change — but consumers should
+    // branch on `ownerScope`, not on `orgId == null`.
     orgId: connection.orgId,
+    ownerScope: ownerScopeOf(connection),
     provider: connection.provider,
     name: connection.name,
     status: deriveConnectionStatus(settings),
@@ -289,6 +388,7 @@ async function getConnectionById(id: string) {
     .select({
       id: psaConnectionsTable.id,
       orgId: psaConnectionsTable.orgId,
+      partnerId: psaConnectionsTable.partnerId,
       provider: psaConnectionsTable.provider,
       name: psaConnectionsTable.name,
       credentials: psaConnectionsTable.credentials,
@@ -317,18 +417,31 @@ psaRoutes.get(
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
 
-    const orgIds = await resolveOrgIds(auth, query.orgId);
-
     if (auth.scope === 'organization' && !auth.orgId) {
       return c.json({ error: 'Organization context required' }, 403);
     }
 
-    const conditions = [];
-    if (orgIds) {
-      if (orgIds.length === 0) {
+    const conditions: SQL[] = [];
+
+    if (query.orgId) {
+      // Explicit org filter. A partner-wide connection genuinely serves this
+      // org, so it stays in the result — dropping it here would recreate the
+      // exact "partner-wide row is invisible to the partner that made it" bug
+      // this change exists to fix. Partner arm gated on partner scope.
+      const hasAccess = await ensureOrgAccess(query.orgId, auth);
+      if (!hasAccess) {
         return c.json({ data: [], pagination: { page, limit, total: 0 } });
       }
-      conditions.push(inArray(psaConnectionsTable.orgId, orgIds));
+      const orgFilter = eq(psaConnectionsTable.orgId, query.orgId);
+      conditions.push(
+        auth.scope === 'partner' && auth.partnerId
+          ? sql`(${orgFilter} OR (${psaConnectionsTable.orgId} IS NULL AND ${psaConnectionsTable.partnerId} = ${auth.partnerId}))`
+          : orgFilter
+      );
+    } else {
+      // No explicit filter: everything the caller may see on EITHER axis.
+      const accessCondition = psaConnectionAccessCondition(auth);
+      if (accessCondition) conditions.push(accessCondition);
     }
 
     if (query.provider) {
@@ -341,6 +454,7 @@ psaRoutes.get(
       .select({
         id: psaConnectionsTable.id,
         orgId: psaConnectionsTable.orgId,
+        partnerId: psaConnectionsTable.partnerId,
         provider: psaConnectionsTable.provider,
         name: psaConnectionsTable.name,
         credentials: psaConnectionsTable.credentials,
@@ -378,28 +492,50 @@ psaRoutes.post(
     const auth = c.get('auth');
     const data = c.req.valid('json');
 
-    let orgId = data.orgId;
+    // Ownership axis (epic #2135). A partner-wide connection publishes ONE set
+    // of PSA credentials to every org under the partner — including orgs
+    // created later — so creating one is gated on the partner-wide capability.
+    // The partner is ALWAYS derived from the caller's own token, never from the
+    // request body.
+    let owner: ConnectionOwner;
 
-    if (auth.scope === 'organization') {
-      if (!auth.orgId) {
-        return c.json({ error: 'Organization context required' }, 403);
+    if (data.ownerScope === 'partner') {
+      if (!auth.partnerId) {
+        return c.json({ error: 'Partner-wide PSA connections require partner scope' }, 403);
       }
-      orgId = auth.orgId;
-    } else if (auth.scope === 'partner') {
-      if (!orgId) {
-        const singleOrg = auth.accessibleOrgIds?.[0];
-        if (auth.accessibleOrgIds?.length === 1 && singleOrg) {
-          orgId = singleOrg;
-        } else {
-          return c.json({ error: 'orgId is required when partner has multiple organizations' }, 400);
+      if (!canManagePartnerWidePolicies(auth)) {
+        return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
+      }
+      owner = { orgId: null, partnerId: auth.partnerId };
+    } else {
+      let orgId = data.orgId;
+
+      if (auth.scope === 'organization') {
+        if (!auth.orgId) {
+          return c.json({ error: 'Organization context required' }, 403);
         }
+        orgId = auth.orgId;
+      } else if (auth.scope === 'partner') {
+        if (!orgId) {
+          const singleOrg = auth.accessibleOrgIds?.[0];
+          if (auth.accessibleOrgIds?.length === 1 && singleOrg) {
+            orgId = singleOrg;
+          } else {
+            return c.json({ error: 'orgId is required when partner has multiple organizations' }, 400);
+          }
+        }
+        const hasAccess = await ensureOrgAccess(orgId, auth);
+        if (!hasAccess) {
+          return c.json({ error: 'Access to this organization denied' }, 403);
+        }
+      } else if (auth.scope === 'system' && !orgId) {
+        return c.json({ error: 'orgId is required for system scope' }, 400);
       }
-      const hasAccess = await ensureOrgAccess(orgId, auth);
-      if (!hasAccess) {
-        return c.json({ error: 'Access to this organization denied' }, 403);
+
+      if (!orgId) {
+        return c.json({ error: 'orgId is required for an organization-owned connection' }, 400);
       }
-    } else if (auth.scope === 'system' && !orgId) {
-      return c.json({ error: 'orgId is required for system scope' }, 400);
+      owner = { orgId, partnerId: null };
     }
 
     const baseUrlError = validatePsaCredentialBaseUrl(data.credentials);
@@ -430,7 +566,8 @@ psaRoutes.post(
     const [connection] = await db
       .insert(psaConnectionsTable)
       .values({
-        orgId: orgId as string,
+        orgId: owner.orgId,
+        partnerId: owner.partnerId,
         provider: data.provider as PsaProvider,
         name: data.name,
         credentials: credentialsEncrypted,
@@ -442,6 +579,7 @@ psaRoutes.post(
       .returning({
         id: psaConnectionsTable.id,
         orgId: psaConnectionsTable.orgId,
+        partnerId: psaConnectionsTable.partnerId,
         provider: psaConnectionsTable.provider,
         name: psaConnectionsTable.name,
         credentials: psaConnectionsTable.credentials,
@@ -462,7 +600,7 @@ psaRoutes.post(
       resourceType: 'psa_connection',
       resourceId: connection.id,
       resourceName: connection.name,
-      details: { provider: connection.provider }
+      details: { provider: connection.provider, ...auditOwnerFields(connection) }
     });
 
     return c.json(serializeConnection(connection, false), 201);
@@ -482,7 +620,7 @@ psaRoutes.get(
       return c.json({ error: 'PSA connection not found' }, 404);
     }
 
-    const hasAccess = await ensureOrgAccess(connection.orgId, auth);
+    const hasAccess = await ensureConnectionAccess(connection, auth);
     if (!hasAccess) {
       return c.json({ error: 'Access denied' }, 403);
     }
@@ -522,9 +660,13 @@ psaRoutes.patch(
       return c.json({ error: 'PSA connection not found' }, 404);
     }
 
-    const hasAccess = await ensureOrgAccess(existing.orgId, auth);
+    const hasAccess = await ensureConnectionAccess(existing, auth);
     if (!hasAccess) {
       return c.json({ error: 'Access denied' }, 403);
+    }
+
+    if (partnerWideWriteBlocked(existing, auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     const updates: Record<string, unknown> = {
@@ -588,6 +730,7 @@ psaRoutes.patch(
       .returning({
         id: psaConnectionsTable.id,
         orgId: psaConnectionsTable.orgId,
+        partnerId: psaConnectionsTable.partnerId,
         provider: psaConnectionsTable.provider,
         name: psaConnectionsTable.name,
         credentials: psaConnectionsTable.credentials,
@@ -608,7 +751,7 @@ psaRoutes.patch(
       resourceType: 'psa_connection',
       resourceId: updated.id,
       resourceName: updated.name,
-      details: { changedFields: Object.keys(data) }
+      details: { changedFields: Object.keys(data), ...auditOwnerFields(updated) }
     });
 
     return c.json(serializeConnection(updated, false));
@@ -629,9 +772,13 @@ psaRoutes.delete(
       return c.json({ error: 'PSA connection not found' }, 404);
     }
 
-    const hasAccess = await ensureOrgAccess(existing.orgId, auth);
+    const hasAccess = await ensureConnectionAccess(existing, auth);
     if (!hasAccess) {
       return c.json({ error: 'Access denied' }, 403);
+    }
+
+    if (partnerWideWriteBlocked(existing, auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     await db.delete(psaTicketMappings).where(eq(psaTicketMappings.connectionId, connectionId));
@@ -642,7 +789,8 @@ psaRoutes.delete(
       action: 'psa.connection.delete',
       resourceType: 'psa_connection',
       resourceId: existing.id,
-      resourceName: existing.name
+      resourceName: existing.name,
+      details: { ...auditOwnerFields(existing) }
     });
 
     return c.json({ success: true });
@@ -672,9 +820,13 @@ psaRoutes.post(
       return c.json({ error: 'PSA connection not found' }, 404);
     }
 
-    const hasAccess = await ensureOrgAccess(existing.orgId, auth);
+    const hasAccess = await ensureConnectionAccess(existing, auth);
     if (!hasAccess) {
       return c.json({ error: 'Access denied' }, 403);
+    }
+
+    if (partnerWideWriteBlocked(existing, auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     const credentials = decryptCredentials(existing.credentials);
@@ -733,7 +885,7 @@ psaRoutes.post(
       resourceType: 'psa_connection',
       resourceId: existing.id,
       resourceName: existing.name,
-      details: { success: result.success },
+      details: { success: result.success, ...auditOwnerFields(existing) },
       result: result.success ? 'success' : 'failure'
     });
 
@@ -780,9 +932,13 @@ psaRoutes.post(
       return c.json({ error: 'PSA connection not found' }, 404);
     }
 
-    const hasAccess = await ensureOrgAccess(existing.orgId, auth);
+    const hasAccess = await ensureConnectionAccess(existing, auth);
     if (!hasAccess) {
       return c.json({ error: 'Access denied' }, 403);
+    }
+
+    if (partnerWideWriteBlocked(existing, auth)) {
+      return c.json({ error: PARTNER_WIDE_WRITE_DENIED_MESSAGE }, 403);
     }
 
     const body = await c.req.json<{ status: string }>();
@@ -802,7 +958,7 @@ psaRoutes.post(
       resourceType: 'psa_connection',
       resourceId: existing.id,
       resourceName: existing.name,
-      details: { status: body.status }
+      details: { status: body.status, ...auditOwnerFields(existing) }
     });
 
     return c.json({ success: true, status: body.status });
@@ -820,15 +976,12 @@ psaRoutes.get(
     const query = c.req.valid('query');
     const { page, limit, offset } = getPagination(query);
 
-    const orgIds = await resolveOrgIds(auth);
-    if (orgIds && orgIds.length === 0) {
-      return c.json({ data: [], pagination: { page, limit, total: 0 } });
-    }
-
     const conditions: SQL[] = [];
-    if (orgIds) {
-      conditions.push(inArray(psaConnectionsTable.orgId, orgIds));
-    }
+    // Scoped through the innerJoin on psa_connections below. Dual-axis (epic
+    // #2135): an org-only `orgId IN (...)` here dropped every ticket belonging
+    // to a partner-wide connection, since those rows have org_id NULL.
+    const accessCondition = psaConnectionAccessCondition(auth);
+    if (accessCondition) conditions.push(accessCondition);
     if (perms?.allowedSiteIds) {
       conditions.push(or(
         isNull(psaTicketMappings.deviceId),
@@ -892,7 +1045,7 @@ psaRoutes.get(
       return c.json({ error: 'PSA connection not found' }, 404);
     }
 
-    const hasAccess = await ensureOrgAccess(connection.orgId, auth);
+    const hasAccess = await ensureConnectionAccess(connection, auth);
     if (!hasAccess) {
       return c.json({ error: 'Access denied' }, 403);
     }

--- a/apps/api/src/services/aiToolsIntegrations.ts
+++ b/apps/api/src/services/aiToolsIntegrations.ts
@@ -185,8 +185,20 @@ export function registerIntegrationTools(aiTools: Map<string, AiTool>): void {
       const connectionId = input.connectionId as string | undefined;
 
       const conditions: SQL[] = [];
+      // Dual-axis (epic #2135): psa_connections is org-owned OR partner-wide.
+      // A bare orgCondition() is an eq/IN on org_id, which NULL never matches,
+      // so partner-wide connections were invisible to this tool — including to
+      // the very partner admin whose PSA it is. Partner arm gated on partner
+      // scope: an org token carries a partnerId but never passes
+      // breeze_has_partner_access, so RLS would return nothing anyway.
       const orgCond = auth.orgCondition(psaConnections.orgId);
-      if (orgCond) conditions.push(orgCond);
+      if (orgCond) {
+        conditions.push(
+          auth.scope === 'partner' && auth.partnerId
+            ? sql`(${orgCond} OR (${psaConnections.orgId} IS NULL AND ${psaConnections.partnerId} = ${auth.partnerId}))`
+            : orgCond
+        );
+      }
       if (connectionId) conditions.push(eq(psaConnections.id, connectionId));
 
       const rows = await db
@@ -194,6 +206,8 @@ export function registerIntegrationTools(aiTools: Map<string, AiTool>): void {
           id: psaConnections.id,
           provider: psaConnections.provider,
           name: psaConnections.name,
+          // 'partner' => the MSP's own PSA, shared across every org.
+          ownerScope: sql<'organization' | 'partner'>`CASE WHEN ${psaConnections.partnerId} IS NOT NULL THEN 'partner' ELSE 'organization' END`,
           enabled: psaConnections.enabled,
           lastSyncAt: psaConnections.lastSyncAt,
           lastSyncStatus: psaConnections.lastSyncStatus,

--- a/apps/api/src/services/deviceDeletion.ts
+++ b/apps/api/src/services/deviceDeletion.ts
@@ -48,6 +48,14 @@ export async function deleteDeviceCascade(
   await tx.execute(sql`DELETE FROM ai_action_plans WHERE session_id IN ${deviceAiSessionIds}`);
   await tx.execute(sql`DELETE FROM alert_correlations WHERE parent_alert_id IN ${deviceAlertIds} OR child_alert_id IN ${deviceAlertIds}`);
   await tx.execute(sql`DELETE FROM alert_notifications WHERE alert_id IN ${deviceAlertIds}`);
+  // psa_ticket_mappings.alert_id -> alerts(id) has NO explicit ON DELETE (so
+  // NO ACTION), and 'alerts' sits in the "Monitoring & logs" block of
+  // CORE_DEVICE_CASCADE_DELETE_TABLES, ~30 entries AHEAD of
+  // 'psa_ticket_mappings' in "Portal & integrations". The list-driven loop
+  // below therefore deletes the alerts first and raises 23503 on any mapping
+  // that referenced one. Clear both FK arms here, with the other transitive
+  // alert children. The list entry stays — this just makes it a no-op.
+  await tx.execute(sql`DELETE FROM psa_ticket_mappings WHERE alert_id IN ${deviceAlertIds} OR device_id = ${deviceId}`);
   await tx.execute(sql`UPDATE log_correlations SET alert_id = NULL WHERE alert_id IN ${deviceAlertIds}`);
   await tx.execute(sql`UPDATE network_change_events SET alert_id = NULL WHERE alert_id IN ${deviceAlertIds}`);
 

--- a/apps/api/src/services/psa/ticketScope.test.ts
+++ b/apps/api/src/services/psa/ticketScope.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Renders psaTicketMappingOrgCondition through the REAL Postgres dialect.
+ *
+ * routes/psa.test.ts mocks the entire db layer, so a malformed sql template
+ * there produces a passing test and a runtime 500. That is how
+ * `d.org_id = ANY(${orgIds}::uuid[])` shipped to CI: drizzle expands a JS array
+ * in a sql template into a comma-separated parameter list, so Postgres saw a
+ * record (`cannot cast type record to uuid[]`) — or, with a single element,
+ * `malformed array literal`. These tests assert the emitted SQL and parameter
+ * binding directly, catching that class in the fast unit job.
+ */
+import { describe, it, expect } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { psaTicketMappingOrgCondition } from './ticketScope';
+
+const dialect = new PgDialect();
+
+function render(orgIds: string[] | null) {
+  const condition = psaTicketMappingOrgCondition(orgIds);
+  if (!condition) return null;
+  const query = dialect.sqlToQuery(condition);
+  return { sql: query.sql.replace(/\s+/g, ' ').trim(), params: query.params };
+}
+
+const ORG_A = 'aaaaaaaa-0000-4000-8000-000000000001';
+const ORG_B = 'bbbbbbbb-0000-4000-8000-000000000002';
+
+describe('psaTicketMappingOrgCondition', () => {
+  it('returns undefined for system scope (no filter)', () => {
+    expect(psaTicketMappingOrgCondition(null)).toBeUndefined();
+  });
+
+  it('returns an impossible condition when the caller reaches no orgs', () => {
+    const rendered = render([]);
+    expect(rendered?.sql).toBe('false');
+    expect(rendered?.params).toEqual([]);
+  });
+
+  it('binds a SINGLE org as one parameter, not an array literal', () => {
+    // The one-element case is what produced `malformed array literal`.
+    const rendered = render([ORG_A])!;
+    expect(rendered.sql).toContain('IN ($1::uuid)');
+    expect(rendered.sql).not.toContain('ANY(');
+    expect(rendered.params).toEqual([ORG_A, ORG_A]);
+  });
+
+  it('binds MULTIPLE orgs as separate parameters', () => {
+    const rendered = render([ORG_A, ORG_B])!;
+    expect(rendered.sql).toContain('IN ($1::uuid, $2::uuid)');
+    expect(rendered.sql).toContain('IN ($3::uuid, $4::uuid)');
+    // Once per anchor (device, then alert).
+    expect(rendered.params).toEqual([ORG_A, ORG_B, ORG_A, ORG_B]);
+  });
+
+  it('checks BOTH anchors, each null-tolerant, combined with AND', () => {
+    const rendered = render([ORG_A])!;
+    // A row is withheld if EITHER anchor points outside the caller's orgs...
+    expect(rendered.sql).toContain('AND (');
+    // ...but an absent anchor never withholds it.
+    expect(rendered.sql).toContain('"psa_ticket_mappings"."device_id" IS NULL OR EXISTS');
+    expect(rendered.sql).toContain('"psa_ticket_mappings"."alert_id" IS NULL OR EXISTS');
+    // Correlated to the outer mapping row, joining devices/alerts for the org.
+    expect(rendered.sql).toContain('FROM devices d');
+    expect(rendered.sql).toContain('FROM alerts a');
+    expect(rendered.sql).toContain('d.id = "psa_ticket_mappings"."device_id"');
+    expect(rendered.sql).toContain('a.id = "psa_ticket_mappings"."alert_id"');
+  });
+});

--- a/apps/api/src/services/psa/ticketScope.ts
+++ b/apps/api/src/services/psa/ticketScope.ts
@@ -1,0 +1,63 @@
+/**
+ * Org scoping for psa_ticket_mappings reads (epic #2135; PR #3308 review).
+ *
+ * Deliberately a dependency-free leaf module — schema types only, no `../db`
+ * import — so it can be unit-tested by rendering it through the real Postgres
+ * dialect. routes/psa.ts mocks the whole db layer in its own tests, which makes
+ * malformed SQL invisible there; that is exactly how an `= ANY(${array})` bug
+ * reached CI (`cannot cast type record to uuid[]`).
+ */
+import { sql, type SQL } from 'drizzle-orm';
+import { psaTicketMappings } from '../../db/schema';
+
+/**
+ * WHERE fragment restricting psa_ticket_mappings rows to `accessibleOrgIds`,
+ * via the mapping's OWN org anchors. Returns `undefined` for system scope.
+ *
+ * This is the tenancy boundary for ticket DATA, and it is deliberately separate
+ * from the connection-visibility condition, which governs CONFIG. Conflating
+ * them leaked data: a psa_connections row is partner-owned CONFIG, correctly
+ * visible to any partner-scope caller of that partner, but the mappings hanging
+ * off it name a specific org's device, alert and external ticket. A
+ * `partner_user` with org_access='selected' scoped to org A could read org B's
+ * external ticket ids and URLs through the shared partner-wide connection.
+ *
+ * Every anchor that is SET must be accessible (AND, not OR): a row is withheld
+ * if EITHER its device or its alert belongs to an unreachable org. A row with
+ * neither anchor references no org at all, so connection access governs it and
+ * it passes this filter.
+ *
+ * NOT redundant with RLS. `breeze_has_org_access` does respect the caller's
+ * accessible-org list, but the psa_ticket_mappings policy's connection arm
+ * passes for ANY partner-scope caller of the owning partner — necessarily so,
+ * since an unanchored row has no org for Postgres to check. Postgres cannot
+ * express `partner_users.org_access='selected'`; this condition is the
+ * enforcement point for that refinement and must not be removed as "the policy
+ * already covers it".
+ */
+export function psaTicketMappingOrgCondition(
+  accessibleOrgIds: string[] | null
+): SQL | undefined {
+  if (accessibleOrgIds === null) return undefined; // system scope — unrestricted
+  if (accessibleOrgIds.length === 0) return sql`false`;
+
+  // Bind each id as its OWN parameter. Interpolating the array directly
+  // (`= ANY(${orgIds}::uuid[])`) does not work: drizzle expands a JS array in a
+  // sql template into a comma-separated parameter list, so Postgres sees a
+  // record and rejects it with `cannot cast type record to uuid[]` (or
+  // `malformed array literal` when the list has exactly one element).
+  const orgList = sql.join(accessibleOrgIds.map((id) => sql`${id}::uuid`), sql`, `);
+
+  return sql`(
+    (${psaTicketMappings.deviceId} IS NULL OR EXISTS (
+      SELECT 1 FROM devices d
+       WHERE d.id = ${psaTicketMappings.deviceId}
+         AND d.org_id IN (${orgList})
+    ))
+    AND (${psaTicketMappings.alertId} IS NULL OR EXISTS (
+      SELECT 1 FROM alerts a
+       WHERE a.id = ${psaTicketMappings.alertId}
+         AND a.org_id IN (${orgList})
+    ))
+  )`;
+}

--- a/apps/api/src/services/tenantCascade.partner.test.ts
+++ b/apps/api/src/services/tenantCascade.partner.test.ts
@@ -24,7 +24,11 @@ describe('cascadeDeletePartner', () => {
 
     execMock
       .mockResolvedValueOnce([{ id: 'org-1' }])
-      // SSO FK-child pre-clears (#2195): user_sso_identities, then sso_sessions
+      // FK-child pre-clears, in list order: user_sso_identities and
+      // sso_sessions (#2195), then psa_ticket_mappings (epic #2135 — it has no
+      // partner_id column, so the sweep below cannot reach it, yet its
+      // connection_id FK into psa_connections is NO ACTION).
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ table_name: 'scripts' }, { table_name: 'users' }])
@@ -52,6 +56,13 @@ describe('cascadeDeletePartner', () => {
     expect(firstSweepIdx).toBeGreaterThan(-1);
     expect(identityClearIdx).toBeLessThan(firstSweepIdx);
     expect(sessionsClearIdx).toBeLessThan(firstSweepIdx);
+
+    // psa_ticket_mappings (epic #2135): same shape — no partner_id column, so
+    // it MUST be pre-cleared before `DELETE FROM psa_connections WHERE
+    // partner_id = ...` or the sweep aborts with 23503.
+    const psaClearIdx = calls.findIndex((c) => c.includes('psa_ticket_mappings'));
+    expect(psaClearIdx).toBeGreaterThan(-1);
+    expect(psaClearIdx).toBeLessThan(firstSweepIdx);
 
     // exactly one partners delete, and it is the LAST execute() call
     expect(calls.filter((c) => c.includes('partners')).length).toBe(1);

--- a/apps/api/src/services/tenantCascade.ts
+++ b/apps/api/src/services/tenantCascade.ts
@@ -415,6 +415,26 @@ const ASSOCIATED_SYSTEM_SCOPED_TABLES: ReadonlyArray<{
       WHERE provider_id IN (SELECT id FROM sso_providers WHERE org_id = ${orgId})
     `,
   },
+  // psa_ticket_mappings has NO org_id/partner_id column, so neither the org
+  // cascade list nor the partner-axis sweep reaches it — yet it holds THREE
+  // FKs into the cascade set, every one of them declared without an explicit
+  // ON DELETE (so NO ACTION): connection_id -> psa_connections (NOT NULL),
+  // alert_id -> alerts, device_id -> devices. Without this pre-clear the org
+  // erasure aborts with 23503 on whichever of those parents is deleted first
+  // for any org that ever opened a PSA ticket. All three arms are required:
+  // `alerts` and `devices` are deleted by the main cascade loop regardless of
+  // which org owns the CONNECTION, so a mapping whose connection is
+  // partner-owned (org_id NULL, epic #2135) still pins this org's alert and
+  // device rows.
+  {
+    table: 'psa_ticket_mappings',
+    clearSql: (orgId) => sql`
+      DELETE FROM psa_ticket_mappings
+      WHERE connection_id IN (SELECT id FROM psa_connections WHERE org_id = ${orgId})
+         OR alert_id IN (SELECT id FROM alerts WHERE org_id = ${orgId})
+         OR device_id IN (SELECT id FROM devices WHERE org_id = ${orgId})
+    `,
+  },
 ];
 
 /**
@@ -817,7 +837,7 @@ export async function cascadeDeletePartner(
   // partner that ever exercised SSO would fail the sweep on the
   // sso_providers/users DELETEs (FK violation) without this pre-clear.
   // Mirrors the ASSOCIATED_SYSTEM_SCOPED_TABLES step in cascadeDeleteOrg.
-  const partnerSsoPreClears: ReadonlyArray<{ table: string; clearSql: ReturnType<typeof sql> }> = [
+  const partnerAssociatedPreClears: ReadonlyArray<{ table: string; clearSql: ReturnType<typeof sql> }> = [
     {
       table: 'user_sso_identities',
       clearSql: sql`
@@ -833,8 +853,22 @@ export async function cascadeDeletePartner(
         WHERE provider_id IN (SELECT id FROM sso_providers WHERE partner_id = ${partnerId})
       `,
     },
+    // psa_ticket_mappings (epic #2135): same no-tenancy-column shape as the SSO
+    // children above. psa_connections gained partner_id, so the partner-axis
+    // sweep below now runs `DELETE FROM psa_connections WHERE partner_id = ...`
+    // — which raises 23503 against the NO ACTION connection_id FK for any
+    // mapping created under a partner-owned connection. Mappings under the
+    // partner's CHILD orgs are already gone: cascadeDeleteOrg ran for each of
+    // them above and its own psa_ticket_mappings pre-clear covers those.
+    {
+      table: 'psa_ticket_mappings',
+      clearSql: sql`
+        DELETE FROM psa_ticket_mappings
+        WHERE connection_id IN (SELECT id FROM psa_connections WHERE partner_id = ${partnerId})
+      `,
+    },
   ];
-  for (const assoc of partnerSsoPreClears) {
+  for (const assoc of partnerAssociatedPreClears) {
     try {
       const count = await dbModule.withSystemDbAccessContext(async () => {
         const result = await dbModule.db.execute(assoc.clearSql);

--- a/apps/api/src/services/tenantExportPolicyRegistry.ts
+++ b/apps/api/src/services/tenantExportPolicyRegistry.ts
@@ -230,7 +230,12 @@ export const CORE_TENANT_EXPORT_POLICY: TenantExportPolicyRegistry = {
   "portal_branding": tablePolicy("org_id", {"included":["id","org_id","logo_url","favicon_url","primary_color","secondary_color","accent_color","custom_domain","domain_verified","welcome_message","support_email","support_phone","footer_text","custom_css","enable_tickets","enable_asset_checkout","enable_self_service","created_at","updated_at"],"reviewedIncluded":["enable_password_reset"],"excludedSensitive":[],"excludedOpen":[]}),
   "portal_users": tablePolicy("org_id", {"included":["id","org_id","email","name","entra_oid","entra_tenant_id","auth_method","linked_user_id","receive_notifications","last_login_at","status","created_at","updated_at"],"reviewedIncluded":["invited_by","invited_at"],"excludedSensitive":["password_hash"],"excludedOpen":[]}),
   "provision_credential_handles": tablePolicy("org_id", {"included":["id","org_id","device_id","created_by","created_at","expires_at","consumed_at","consumed_from_ip"],"reviewedIncluded":[],"excludedSensitive":["token"],"excludedOpen":["credentials"]}),
-  "psa_connections": tablePolicy("org_id", {"included":["id","org_id","provider","name","enabled","last_sync_at","last_sync_status","last_sync_error","created_by","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["credentials","settings","sync_settings"]}),
+  // partner_id (epic #2135, 2026-08-17): dual ownership — org_id XOR partner_id.
+  // A tenant identifier like org_id, so `included`. Note the org export only
+  // ever emits ORG-owned rows (the exporter filters on org_id), so a
+  // partner-owned connection never appears in a customer's export — correct:
+  // it is the MSP's credential, not the customer's data.
+  "psa_connections": tablePolicy("org_id", {"included":["id","org_id","partner_id","provider","name","enabled","last_sync_at","last_sync_status","last_sync_error","created_by","created_at","updated_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["credentials","settings","sync_settings"]}),
   "quote_acceptances": tablePolicy("org_id", {"included":["id","quote_id","org_id","signer_name","signer_email","signed_at","ip_address","user_agent","quote_sha256","created_at"],"reviewedIncluded":[],"excludedSensitive":["acceptance_token_jti"],"excludedOpen":[]}),
   "quote_blocks": tablePolicy("org_id", {"included":["id","quote_id","org_id","block_type","sort_order","created_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["content"]}),
   "quote_images": tablePolicy("org_id", {"included":["id","quote_id","org_id","mime","byte_size","sha256","created_at"],"reviewedIncluded":[],"excludedSensitive":[],"excludedOpen":["image_data"]}),

--- a/apps/web/src/components/psa/PsaConnectionForm.tsx
+++ b/apps/web/src/components/psa/PsaConnectionForm.tsx
@@ -11,6 +11,11 @@ const createPsaConnectionSchema = (t: (key: string) => string) => z.object({
   // own PSA. CREATE ONLY — ownership is immutable afterwards, and the server
   // derives the partner from the caller's token, never from this value.
   ownerScope: z.enum(['organization', 'partner']).optional(),
+  // Which org owns the connection when ownerScope is 'organization'. Required
+  // in that branch for a partner with 2+ orgs — the API cannot guess, and
+  // omitting it used to 400 ("orgId is required when partner has multiple
+  // organizations"). Org-scope callers never send it; the server derives it.
+  orgId: z.string().optional(),
   name: z.string().min(1, t('longTail.psa.PsaConnectionForm.validation.nameRequired')),
   // Single-source provider list — @breeze/shared PSA_PROVIDERS.
   provider: psaProviderIdSchema,
@@ -124,6 +129,8 @@ type PsaConnectionFormProps = {
    * who may administer partner-wide state (epic #2135).
    */
   showOwnerScope?: boolean;
+  /** Orgs the caller may create an org-owned connection for (partner scope). */
+  ownerOrgOptions?: ReadonlyArray<{ id: string; name: string }>;
   /** Per-field presence of the STORED secrets (server: `credentialFields`). */
   credentialFields?: Partial<Record<PsaCredentialField, boolean>>;
 };
@@ -187,6 +194,7 @@ export default function PsaConnectionForm({
   testingConnection,
   isEditing,
   showOwnerScope = false,
+  ownerOrgOptions = [],
   credentialFields
 }: PsaConnectionFormProps) {
   const { t } = useTranslation('common');
@@ -202,10 +210,13 @@ export default function PsaConnectionForm({
   } = useForm<PsaConnectionFormValues>({
     resolver: zodResolver(psaConnectionSchema),
     defaultValues: {
-      // An MSP's PSA is normally partner-level, so the form defaults to
-      // "All organizations". Only ever sent when showOwnerScope is true; the
-      // API's own default stays 'organization' for non-browser clients.
+      // Default comes from the caller via defaultValues (useDefaultOwnerScope
+      // in the page) — the repo-wide rule, not a literal, so this form tracks
+      // the convention if it changes. Partner-wide remains the default in the
+      // All-organizations view. The API's own default stays 'organization' for
+      // non-browser clients.
       ownerScope: 'partner',
+      orgId: '',
       name: '',
       provider: 'jira',
       baseUrl: '',
@@ -233,6 +244,7 @@ export default function PsaConnectionForm({
   });
 
   const selectedProvider = useWatch({ control, name: 'provider' });
+  const selectedOwnerScope = useWatch({ control, name: 'ownerScope' });
   const syncEnabled = useWatch({ control, name: 'syncEnabled' });
   const isLoading = useMemo(() => loading ?? isSubmitting, [loading, isSubmitting]);
 
@@ -283,6 +295,27 @@ export default function PsaConnectionForm({
             />
             {t('longTail.psa.PsaConnectionForm.ownerScope.thisOrganizationOnly')}
           </label>
+
+          {/* Which org owns it. Without this a partner with 2+ orgs sends no
+              orgId and the create 400s. */}
+          {selectedOwnerScope === 'organization' && ownerOrgOptions.length > 0 && (
+            <div className="space-y-1 pl-6">
+              <label htmlFor="connection-owner-org" className="text-sm font-medium">
+                {t('longTail.psa.PsaConnectionForm.ownerScope.organization')}
+              </label>
+              <select
+                id="connection-owner-org"
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
+                {...register('orgId')}
+                data-testid="psa-connection-owner-org-select"
+              >
+                {ownerOrgOptions.map((org) => (
+                  <option key={org.id} value={org.id}>{org.name}</option>
+                ))}
+              </select>
+              {errors.orgId && <p className="text-sm text-destructive">{errors.orgId.message}</p>}
+            </div>
+          )}
         </fieldset>
       )}
 

--- a/apps/web/src/components/psa/PsaConnectionForm.tsx
+++ b/apps/web/src/components/psa/PsaConnectionForm.tsx
@@ -7,6 +7,10 @@ import { providerMeta, type PsaProvider } from './PsaConnectionList';
 import { useTranslation } from 'react-i18next';
 
 const createPsaConnectionSchema = (t: (key: string) => string) => z.object({
+  // Ownership axis (epic #2135). 'partner' = partner-wide / all-orgs: the MSP's
+  // own PSA. CREATE ONLY — ownership is immutable afterwards, and the server
+  // derives the partner from the caller's token, never from this value.
+  ownerScope: z.enum(['organization', 'partner']).optional(),
   name: z.string().min(1, t('longTail.psa.PsaConnectionForm.validation.nameRequired')),
   // Single-source provider list — @breeze/shared PSA_PROVIDERS.
   provider: psaProviderIdSchema,
@@ -115,6 +119,11 @@ type PsaConnectionFormProps = {
   loading?: boolean;
   testingConnection?: boolean;
   isEditing?: boolean;
+  /**
+   * Show the ownership-scope selector. Create-only, and only for partner users
+   * who may administer partner-wide state (epic #2135).
+   */
+  showOwnerScope?: boolean;
   /** Per-field presence of the STORED secrets (server: `credentialFields`). */
   credentialFields?: Partial<Record<PsaCredentialField, boolean>>;
 };
@@ -177,6 +186,7 @@ export default function PsaConnectionForm({
   loading,
   testingConnection,
   isEditing,
+  showOwnerScope = false,
   credentialFields
 }: PsaConnectionFormProps) {
   const { t } = useTranslation('common');
@@ -192,6 +202,10 @@ export default function PsaConnectionForm({
   } = useForm<PsaConnectionFormValues>({
     resolver: zodResolver(psaConnectionSchema),
     defaultValues: {
+      // An MSP's PSA is normally partner-level, so the form defaults to
+      // "All organizations". Only ever sent when showOwnerScope is true; the
+      // API's own default stays 'organization' for non-browser clients.
+      ownerScope: 'partner',
       name: '',
       provider: 'jira',
       baseUrl: '',
@@ -239,6 +253,39 @@ export default function PsaConnectionForm({
       })}
       className="space-y-6 rounded-lg border bg-card p-6 shadow-xs"
     >
+      {/* Ownership scope — create-only, partner admins only (epic #2135) */}
+      {showOwnerScope && !isEditing && (
+        <fieldset
+          className="space-y-2 rounded-md border p-4"
+          data-testid="psa-connection-owner"
+        >
+          <legend className="px-1 text-xs font-medium uppercase text-muted-foreground">
+            {t('longTail.psa.PsaConnectionForm.ownerScope.legend')}
+          </legend>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              value="partner"
+              {...register('ownerScope')}
+              data-testid="psa-connection-owner-partner"
+            />
+            {t('longTail.psa.PsaConnectionForm.ownerScope.allOrganizations')}
+            <span className="text-muted-foreground">
+              {t('longTail.psa.PsaConnectionForm.ownerScope.partnerWideHint')}
+            </span>
+          </label>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              value="organization"
+              {...register('ownerScope')}
+              data-testid="psa-connection-owner-org"
+            />
+            {t('longTail.psa.PsaConnectionForm.ownerScope.thisOrganizationOnly')}
+          </label>
+        </fieldset>
+      )}
+
       <div className="space-y-4">
         <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
           {t('longTail.psa.PsaConnectionForm.sections.basicInformation')}

--- a/apps/web/src/components/psa/PsaConnectionList.tsx
+++ b/apps/web/src/components/psa/PsaConnectionList.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Layers } from 'lucide-react';
 import type { PsaProviderId } from '@breeze/shared';
 
 // Derived from the single-source provider list in @breeze/shared.
@@ -12,6 +13,12 @@ export type PsaConnection = {
   provider: PsaProvider;
   name: string;
   status: PsaConnectionStatus;
+  /**
+   * 'partner' = partner-wide ("All orgs"): the MSP's own PSA, shared by every
+   * organization under the partner (epic #2135). Optional so older cached
+   * payloads keep rendering as org-owned.
+   */
+  ownerScope?: 'organization' | 'partner';
 };
 
 type PsaConnectionListProps = {
@@ -230,7 +237,21 @@ export default function PsaConnectionList({
                         <span className="text-sm font-medium">{providerMeta[connection.provider].label}</span>
                       </div>
                     </td>
-                    <td className="px-4 py-3 text-sm font-medium">{connection.name}</td>
+                    <td className="px-4 py-3 text-sm font-medium">
+                      <div className="flex items-center gap-2">
+                        <span>{connection.name}</span>
+                        {connection.ownerScope === 'partner' && (
+                          <span
+                            className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary"
+                            title={t('longTail.psa.PsaConnectionList.partnerWideTitle')}
+                            data-testid="partner-wide-badge"
+                          >
+                            <Layers className="h-3 w-3" />
+                            {t('longTail.psa.PsaConnectionList.allOrgs')}
+                          </span>
+                        )}
+                      </div>
+                    </td>
                     <td className="px-4 py-3 text-sm">
                       <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${statusStyle.className}`}>
                         {t(/* i18n-dynamic */ statusStyle.labelKey)}

--- a/apps/web/src/components/psa/PsaConnectionList.tsx
+++ b/apps/web/src/components/psa/PsaConnectionList.tsx
@@ -23,6 +23,12 @@ export type PsaConnection = {
 
 type PsaConnectionListProps = {
   connections: PsaConnection[];
+  /**
+   * True for a partner-wide connection the caller may see but not mutate
+   * (epic #2135). Row actions are disabled with a tooltip instead of letting
+   * the click land on the server's 403.
+   */
+  isLockedPartnerWide?: (connection: PsaConnection) => boolean;
   onEdit?: (connection: PsaConnection) => void;
   onToggleStatus?: (connection: PsaConnection, newStatus: 'active' | 'paused') => void;
   onDelete?: (connection: PsaConnection) => void;
@@ -129,7 +135,8 @@ export default function PsaConnectionList({
   connections,
   onEdit,
   onToggleStatus,
-  onDelete
+  onDelete,
+  isLockedPartnerWide
 }: PsaConnectionListProps) {
   const { t } = useTranslation('common');
   const [query, setQuery] = useState('');
@@ -229,6 +236,8 @@ export default function PsaConnectionList({
                 // Defensive fallback: an unexpected status string must not
                 // crash the whole list render.
                 const statusStyle = statusConfig[connection.status] ?? statusConfig.active;
+                const locked = isLockedPartnerWide?.(connection) ?? false;
+                const lockedReason = t('longTail.psa.PsaConnectionList.partnerWideLocked');
                 return (
                   <tr key={connection.id} className="transition hover:bg-muted/40">
                     <td className="px-4 py-3">
@@ -258,11 +267,17 @@ export default function PsaConnectionList({
                       </span>
                     </td>
                     <td className="px-4 py-3 text-right">
+                      {/* Partner-wide rows a restricted user cannot mutate:
+                          disable rather than let them click into a 403 toast.
+                          The server gate is authoritative either way. */}
                       <div className="flex justify-end gap-2">
                         <button
                           type="button"
                           onClick={() => onEdit?.(connection)}
-                          className="rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted"
+                          disabled={locked}
+                          title={locked ? lockedReason : undefined}
+                          className="rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                          data-testid="psa-connection-edit"
                         >
                           {t('common:actions.edit')}
                         </button>
@@ -272,14 +287,20 @@ export default function PsaConnectionList({
                             connection,
                             connection.status === 'active' ? 'paused' : 'active'
                           )}
-                          className="rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted"
+                          disabled={locked}
+                          title={locked ? lockedReason : undefined}
+                          className="rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                          data-testid="psa-connection-toggle"
                         >
                           {connection.status === 'active' ? t('longTail.psa.PsaConnectionList.actions.pause') : t('longTail.psa.PsaConnectionList.actions.resume')}
                         </button>
                         <button
                           type="button"
                           onClick={() => onDelete?.(connection)}
-                          className="rounded-md border border-destructive/40 px-3 py-1 text-xs font-medium text-destructive hover:bg-destructive/10"
+                          disabled={locked}
+                          title={locked ? lockedReason : undefined}
+                          className="rounded-md border border-destructive/40 px-3 py-1 text-xs font-medium text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50"
+                          data-testid="psa-connection-delete"
                         >
                           {t('common:actions.delete')}
                         </button>

--- a/apps/web/src/components/psa/PsaConnectionsPage.test.tsx
+++ b/apps/web/src/components/psa/PsaConnectionsPage.test.tsx
@@ -21,6 +21,25 @@ vi.mock('@/lib/authScope', () => ({
   getJwtClaims: () => jwtClaims,
 }));
 
+// The page reads its create-time ownerScope default from the shared hook
+// (review finding 4) rather than hard-coding 'partner'.
+const ownerScopeState: { isPartnerScope: boolean; defaultOwnerScope: 'organization' | 'partner' } = {
+  isPartnerScope: false,
+  defaultOwnerScope: 'organization',
+};
+vi.mock('@/hooks/useDefaultOwnerScope', () => ({
+  useDefaultOwnerScope: () => ownerScopeState,
+}));
+
+// Org picker source for the "This organization only" branch (finding 6).
+const orgStoreState: { organizations: Array<{ id: string; name: string }>; currentOrgId: string | null } = {
+  organizations: [],
+  currentOrgId: null,
+};
+vi.mock('../../stores/orgStore', () => ({
+  useOrgStore: (selector: (s: unknown) => unknown) => selector(orgStoreState),
+}));
+
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
 
 function makeResponse(payload: unknown, ok = true, status = ok ? 200 : 500): Response {
@@ -282,12 +301,18 @@ describe('PsaConnectionsPage round-trip contract', () => {
       jwtClaims.scope = 'organization';
       jwtClaims.partnerId = null;
       delete authUser.canManagePartnerWide;
+      ownerScopeState.isPartnerScope = false;
+      ownerScopeState.defaultOwnerScope = 'organization';
+      orgStoreState.organizations = [];
+      orgStoreState.currentOrgId = null;
     });
 
     function asPartnerAdmin() {
       jwtClaims.scope = 'partner';
       jwtClaims.partnerId = 'p-1';
       authUser.canManagePartnerWide = true;
+      ownerScopeState.isPartnerScope = true;
+      ownerScopeState.defaultOwnerScope = 'partner';
     }
 
     it('renders the "All orgs" badge only for a partner-owned connection', async () => {
@@ -375,10 +400,145 @@ describe('PsaConnectionsPage round-trip contract', () => {
       expect((recorded[0]!.body as Record<string, unknown>).ownerScope).toBe('organization');
     });
 
+    it('takes its create default from useDefaultOwnerScope, not a literal', async () => {
+      // Review finding 4: with a concrete org selected the shared hook returns
+      // 'organization', and this form must follow it rather than always
+      // pre-selecting partner-wide.
+      asPartnerAdmin();
+      ownerScopeState.defaultOwnerScope = 'organization';
+      orgStoreState.organizations = [{ id: 'org-1', name: 'Acme' }];
+      orgStoreState.currentOrgId = 'org-1';
+      installFetchRouter({ 'GET /psa/connections': { data: [] } }, []);
+
+      const user = userEvent.setup();
+      render(<PsaConnectionsPage />);
+      await user.click(await screen.findByRole('button', { name: /add connection/i }));
+
+      expect(screen.getByTestId('psa-connection-owner-org')).toBeChecked();
+      expect(screen.getByTestId('psa-connection-owner-partner')).not.toBeChecked();
+    });
+
+    it('MULTI-ORG CREATE: sends orgId with the org-owned branch so the API does not 400', async () => {
+      // Review finding 6: the "This organization only" radio previously sent no
+      // orgId, so create failed for any partner with 2+ orgs.
+      asPartnerAdmin();
+      orgStoreState.organizations = [
+        { id: 'org-1', name: 'Acme' },
+        { id: 'org-2', name: 'Globex' },
+      ];
+      orgStoreState.currentOrgId = 'org-1';
+      const recorded: RecordedRequest[] = [];
+      installFetchRouter(
+        {
+          'GET /psa/connections': { data: [] },
+          'POST /psa/connections': { id: 'c-new', provider: 'jira', name: 'Globex Jira', status: 'active', ownerScope: 'organization' },
+        },
+        recorded
+      );
+
+      const user = userEvent.setup();
+      render(<PsaConnectionsPage />);
+      await user.click(await screen.findByRole('button', { name: /add connection/i }));
+
+      await user.click(screen.getByTestId('psa-connection-owner-org'));
+      // The picker only appears on the org-owned branch.
+      const picker = await screen.findByTestId('psa-connection-owner-org-select');
+      await user.selectOptions(picker, 'org-2');
+
+      await user.type(screen.getByLabelText(/connection name/i), 'Globex Jira');
+      await user.type(screen.getByLabelText(/instance url/i), 'https://acme.atlassian.net');
+      await user.type(screen.getByLabelText(/username or email/i), 'admin@acme.com');
+      await user.type(screen.getByLabelText(/api token/i), 'tok-123');
+      await user.click(screen.getByRole('button', { name: /create connection/i }));
+
+      await waitFor(() => expect(recorded).toHaveLength(1));
+      const body = recorded[0]!.body as Record<string, unknown>;
+      expect(body.ownerScope).toBe('organization');
+      expect(body.orgId).toBe('org-2');
+    });
+
+    it('hides the org picker on the partner-wide branch', async () => {
+      asPartnerAdmin();
+      orgStoreState.organizations = [{ id: 'org-1', name: 'Acme' }];
+      installFetchRouter({ 'GET /psa/connections': { data: [] } }, []);
+
+      const user = userEvent.setup();
+      render(<PsaConnectionsPage />);
+      await user.click(await screen.findByRole('button', { name: /add connection/i }));
+
+      expect(screen.getByTestId('psa-connection-owner-partner')).toBeChecked();
+      expect(screen.queryByTestId('psa-connection-owner-org-select')).toBeNull();
+    });
+
+    it('ROW ACTIONS: disables edit/pause/delete on a partner-wide row the user cannot manage', async () => {
+      // Review finding 7: these used to render enabled and the click landed on
+      // the server's new 403 as an error toast.
+      jwtClaims.scope = 'partner';
+      jwtClaims.partnerId = 'p-1';
+      authUser.canManagePartnerWide = false;
+      ownerScopeState.isPartnerScope = true;
+      installFetchRouter(
+        {
+          'GET /psa/connections': {
+            data: [{ id: 'c1', provider: 'jira', name: 'MSP Jira', status: 'active', ownerScope: 'partner' }],
+          },
+        },
+        []
+      );
+
+      render(<PsaConnectionsPage />);
+
+      await screen.findByText('MSP Jira');
+      expect(screen.getByTestId('psa-connection-edit')).toBeDisabled();
+      expect(screen.getByTestId('psa-connection-toggle')).toBeDisabled();
+      expect(screen.getByTestId('psa-connection-delete')).toBeDisabled();
+    });
+
+    it('leaves row actions enabled on an ORG-owned row for the same restricted user', async () => {
+      jwtClaims.scope = 'partner';
+      jwtClaims.partnerId = 'p-1';
+      authUser.canManagePartnerWide = false;
+      ownerScopeState.isPartnerScope = true;
+      installFetchRouter(
+        {
+          'GET /psa/connections': {
+            data: [{ id: 'c2', provider: 'zendesk', name: 'Customer Zendesk', status: 'active', ownerScope: 'organization' }],
+          },
+        },
+        []
+      );
+
+      render(<PsaConnectionsPage />);
+
+      await screen.findByText('Customer Zendesk');
+      expect(screen.getByTestId('psa-connection-edit')).toBeEnabled();
+      expect(screen.getByTestId('psa-connection-delete')).toBeEnabled();
+    });
+
+    it('leaves row actions enabled on a partner-wide row for a FULL partner admin', async () => {
+      asPartnerAdmin();
+      installFetchRouter(
+        {
+          'GET /psa/connections': {
+            data: [{ id: 'c1', provider: 'jira', name: 'MSP Jira', status: 'active', ownerScope: 'partner' }],
+          },
+        },
+        []
+      );
+
+      render(<PsaConnectionsPage />);
+
+      await screen.findByText('MSP Jira');
+      expect(screen.getByTestId('psa-connection-edit')).toBeEnabled();
+      expect(screen.getByTestId('psa-connection-delete')).toBeEnabled();
+    });
+
     it('hides the selector for a partner user without the partner-wide capability', async () => {
       jwtClaims.scope = 'partner';
       jwtClaims.partnerId = 'p-1';
       authUser.canManagePartnerWide = false;
+      ownerScopeState.isPartnerScope = true;
+      ownerScopeState.defaultOwnerScope = 'partner';
       installFetchRouter({ 'GET /psa/connections': { data: [] } }, []);
 
       const user = userEvent.setup();

--- a/apps/web/src/components/psa/PsaConnectionsPage.test.tsx
+++ b/apps/web/src/components/psa/PsaConnectionsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import PsaConnectionsPage from './PsaConnectionsPage';
 import { fetchWithAuth } from '../../stores/auth';
 

--- a/apps/web/src/components/psa/PsaConnectionsPage.test.tsx
+++ b/apps/web/src/components/psa/PsaConnectionsPage.test.tsx
@@ -4,10 +4,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PsaConnectionsPage from './PsaConnectionsPage';
 import { fetchWithAuth } from '../../stores/auth';
 
+// `useAuthStore` is a zustand selector hook; the page reads only
+// `user.canManagePartnerWide` from it (epic #2135 ownerScope gate).
+const authUser: { canManagePartnerWide?: boolean } = {};
 vi.mock('../../stores/auth', () => ({
   fetchWithAuth: vi.fn(),
   registerOrgIdProvider: vi.fn(),
   resolveApiOrigin: vi.fn(() => 'https://us.2breeze.app'),
+  useAuthStore: (selector: (s: unknown) => unknown) => selector({ user: authUser }),
+}));
+
+// Default: org scope, so the ownerScope selector stays hidden and every
+// pre-existing assertion in this file describes an org-owned connection.
+const jwtClaims: { scope?: string; partnerId?: string | null } = { scope: 'organization', partnerId: null };
+vi.mock('@/lib/authScope', () => ({
+  getJwtClaims: () => jwtClaims,
 }));
 
 const fetchWithAuthMock = vi.mocked(fetchWithAuth);
@@ -261,6 +272,121 @@ describe('PsaConnectionsPage round-trip contract', () => {
 
     await waitFor(() => expect(testButton).toBeDisabled());
     expect(screen.getByTestId('psa-test-dirty-hint')).toBeInTheDocument();
+  });
+
+  // ---- Dual ownership: org XOR partner (epic #2135) ----
+
+  describe('ownerScope selector and All orgs badge', () => {
+    afterEach(() => {
+      // Restore the org-scope default the rest of the file assumes.
+      jwtClaims.scope = 'organization';
+      jwtClaims.partnerId = null;
+      delete authUser.canManagePartnerWide;
+    });
+
+    function asPartnerAdmin() {
+      jwtClaims.scope = 'partner';
+      jwtClaims.partnerId = 'p-1';
+      authUser.canManagePartnerWide = true;
+    }
+
+    it('renders the "All orgs" badge only for a partner-owned connection', async () => {
+      installFetchRouter(
+        {
+          'GET /psa/connections': {
+            data: [
+              { id: 'c1', provider: 'jira', name: 'MSP Jira', status: 'active', ownerScope: 'partner' },
+              { id: 'c2', provider: 'zendesk', name: 'Customer Zendesk', status: 'active', ownerScope: 'organization' },
+            ],
+          },
+        },
+        []
+      );
+
+      render(<PsaConnectionsPage />);
+
+      await screen.findByText('MSP Jira');
+      expect(screen.getAllByTestId('partner-wide-badge')).toHaveLength(1);
+    });
+
+    it('hides the ownerScope selector for an org-scope user', async () => {
+      installFetchRouter({ 'GET /psa/connections': { data: [] } }, []);
+
+      const user = userEvent.setup();
+      render(<PsaConnectionsPage />);
+      await user.click(await screen.findByRole('button', { name: /add connection/i }));
+
+      expect(screen.queryByTestId('psa-connection-owner')).toBeNull();
+    });
+
+    it('shows the selector defaulted to partner-wide and POSTs ownerScope:partner', async () => {
+      asPartnerAdmin();
+      const recorded: RecordedRequest[] = [];
+      installFetchRouter(
+        {
+          'GET /psa/connections': { data: [] },
+          'POST /psa/connections': { id: 'c-new', provider: 'jira', name: 'MSP Jira', status: 'active', ownerScope: 'partner' },
+        },
+        recorded
+      );
+
+      const user = userEvent.setup();
+      render(<PsaConnectionsPage />);
+      await user.click(await screen.findByRole('button', { name: /add connection/i }));
+
+      expect(screen.getByTestId('psa-connection-owner')).toBeInTheDocument();
+      // Partner-wide is the default for a new connection.
+      expect(screen.getByTestId('psa-connection-owner-partner')).toBeChecked();
+      expect(screen.getByTestId('psa-connection-owner-org')).not.toBeChecked();
+
+      await user.type(screen.getByLabelText(/connection name/i), 'MSP Jira');
+      await user.type(screen.getByLabelText(/instance url/i), 'https://acme.atlassian.net');
+      await user.type(screen.getByLabelText(/username or email/i), 'admin@acme.com');
+      await user.type(screen.getByLabelText(/api token/i), 'tok-123');
+      await user.click(screen.getByRole('button', { name: /create connection/i }));
+
+      await waitFor(() => expect(recorded).toHaveLength(1));
+      expect((recorded[0]!.body as Record<string, unknown>).ownerScope).toBe('partner');
+    });
+
+    it('POSTs ownerScope:organization when the org radio is chosen', async () => {
+      asPartnerAdmin();
+      const recorded: RecordedRequest[] = [];
+      installFetchRouter(
+        {
+          'GET /psa/connections': { data: [] },
+          'POST /psa/connections': { id: 'c-new', provider: 'jira', name: 'Cust Jira', status: 'active', ownerScope: 'organization' },
+        },
+        recorded
+      );
+
+      const user = userEvent.setup();
+      render(<PsaConnectionsPage />);
+      await user.click(await screen.findByRole('button', { name: /add connection/i }));
+
+      await user.click(screen.getByTestId('psa-connection-owner-org'));
+      await user.type(screen.getByLabelText(/connection name/i), 'Cust Jira');
+      await user.type(screen.getByLabelText(/instance url/i), 'https://acme.atlassian.net');
+      await user.type(screen.getByLabelText(/username or email/i), 'admin@acme.com');
+      await user.type(screen.getByLabelText(/api token/i), 'tok-123');
+      await user.click(screen.getByRole('button', { name: /create connection/i }));
+
+      await waitFor(() => expect(recorded).toHaveLength(1));
+      expect((recorded[0]!.body as Record<string, unknown>).ownerScope).toBe('organization');
+    });
+
+    it('hides the selector for a partner user without the partner-wide capability', async () => {
+      jwtClaims.scope = 'partner';
+      jwtClaims.partnerId = 'p-1';
+      authUser.canManagePartnerWide = false;
+      installFetchRouter({ 'GET /psa/connections': { data: [] } }, []);
+
+      const user = userEvent.setup();
+      render(<PsaConnectionsPage />);
+      await user.click(await screen.findByRole('button', { name: /add connection/i }));
+
+      expect(screen.queryByTestId('psa-connection-owner')).toBeNull();
+    });
   });
 
   it('no longer offers a "Sync now" action (sync endpoint is an honest 501)', async () => {

--- a/apps/web/src/components/psa/PsaConnectionsPage.tsx
+++ b/apps/web/src/components/psa/PsaConnectionsPage.tsx
@@ -6,7 +6,8 @@ import PsaConnectionForm, {
 } from './PsaConnectionForm';
 import PsaTicketList, { type PsaTicket } from './PsaTicketList';
 import { fetchWithAuth, useAuthStore } from '../../stores/auth';
-import { getJwtClaims } from '@/lib/authScope';
+import { useDefaultOwnerScope } from '@/hooks/useDefaultOwnerScope';
+import { useOrgStore } from '../../stores/orgStore';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { useTranslation } from 'react-i18next';
@@ -114,8 +115,26 @@ export default function PsaConnectionsPage() {
   // users holding the partner-wide capability. Absent = capable; the server
   // (canManagePartnerWidePolicies) enforces regardless — this is UX only.
   const canManagePartnerWide = useAuthStore(s => s.user?.canManagePartnerWide ?? true);
-  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
-  const showOwnerScope = jwtScope === 'partner' && !!jwtPartnerId && canManagePartnerWide;
+  // Repo-wide rule for "what does a new config object default to" — do not
+  // inline a literal here (epic #2135; 8 surfaces share this hook).
+  const { isPartnerScope, defaultOwnerScope } = useDefaultOwnerScope();
+  const showOwnerScope = isPartnerScope && canManagePartnerWide;
+  const organizations = useOrgStore(s => s.organizations);
+  const currentOrgId = useOrgStore(s => s.currentOrgId);
+  const ownerOrgOptions = showOwnerScope
+    ? organizations.map(o => ({ id: o.id, name: o.name }))
+    : [];
+
+  /**
+   * A partner-wide connection the caller may SEE but not MUTATE. Mirrors the
+   * server's canManagePartnerWidePolicies gate so restricted users don't meet a
+   * 403 toast after clicking (finding 7) — the server still enforces.
+   */
+  const isLockedPartnerWide = useCallback(
+    (connection: PsaConnection) =>
+      connection.ownerScope === 'partner' && !canManagePartnerWide,
+    [canManagePartnerWide]
+  );
 
   const fetchConnections = useCallback(async () => {
     try {
@@ -261,7 +280,13 @@ export default function PsaConnectionsPage() {
         : {
             ...base,
             provider: values.provider,
-            ...(showOwnerScope && values.ownerScope ? { ownerScope: values.ownerScope } : {})
+            ...(showOwnerScope && values.ownerScope ? { ownerScope: values.ownerScope } : {}),
+            // Only meaningful on the org-owned branch. A partner with 2+ orgs
+            // MUST send it or the API 400s; org-scope callers omit it and the
+            // server derives the org from their token.
+            ...(showOwnerScope && values.ownerScope === 'organization' && values.orgId
+              ? { orgId: values.orgId }
+              : {})
           };
 
       await runAction({
@@ -365,6 +390,7 @@ export default function PsaConnectionsPage() {
         onEdit={handleEdit}
         onToggleStatus={handleToggleStatus}
         onDelete={handleDelete}
+        isLockedPartnerWide={isLockedPartnerWide}
       />
 
       <PsaTicketList tickets={tickets} />
@@ -386,6 +412,7 @@ export default function PsaConnectionsPage() {
               onSubmit={handleSubmit}
               onCancel={handleCloseModal}
               showOwnerScope={showOwnerScope}
+              ownerOrgOptions={ownerOrgOptions}
               onTestConnection={modalMode === 'edit' ? handleTestConnection : undefined}
               defaultValues={
                 selectedConnectionDetails
@@ -417,7 +444,12 @@ export default function PsaConnectionsPage() {
                       syncOnClose: selectedConnectionDetails.settings?.syncOnClose ?? true,
                       includeNotes: selectedConnectionDetails.settings?.includeNotes ?? true
                     }
-                  : undefined
+                  : {
+                      // Create defaults. ownerScope comes from the shared hook,
+                      // not a literal, so this form follows the repo-wide rule.
+                      ownerScope: defaultOwnerScope,
+                      orgId: currentOrgId ?? ownerOrgOptions[0]?.id ?? ''
+                    }
               }
               submitLabel={modalMode === 'add' ? t('longTail.psa.PsaConnectionsPage.actions.createConnection') : t('longTail.psa.PsaConnectionsPage.actions.saveChanges')}
               loading={submitting}

--- a/apps/web/src/components/psa/PsaConnectionsPage.tsx
+++ b/apps/web/src/components/psa/PsaConnectionsPage.tsx
@@ -5,7 +5,8 @@ import PsaConnectionForm, {
   type PsaCredentialField
 } from './PsaConnectionForm';
 import PsaTicketList, { type PsaTicket } from './PsaTicketList';
-import { fetchWithAuth } from '../../stores/auth';
+import { fetchWithAuth, useAuthStore } from '../../stores/auth';
+import { getJwtClaims } from '@/lib/authScope';
 import { runAction, ActionError } from '../../lib/runAction';
 import { showToast } from '../shared/Toast';
 import { useTranslation } from 'react-i18next';
@@ -31,6 +32,8 @@ type TestResult = {
 type PsaConnectionDetails = {
   id: string;
   name: string;
+  /** 'partner' = partner-wide ("All orgs"), epic #2135. Immutable after create. */
+  ownerScope?: 'organization' | 'partner';
   provider: PsaConnectionFormValues['provider'];
   /** True when ANY credential material is stored (not permission-gated). */
   hasCredentials?: boolean;
@@ -105,6 +108,14 @@ export default function PsaConnectionsPage() {
   const [submitting, setSubmitting] = useState(false);
   const [testingConnection, setTestingConnection] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
+
+  // Same UX gate as ScriptForm/ScriptBundleImport (#3262): partner-wide is only
+  // meaningful for partner-scope callers, and within partner scope only for
+  // users holding the partner-wide capability. Absent = capable; the server
+  // (canManagePartnerWidePolicies) enforces regardless — this is UX only.
+  const canManagePartnerWide = useAuthStore(s => s.user?.canManagePartnerWide ?? true);
+  const { scope: jwtScope, partnerId: jwtPartnerId } = getJwtClaims();
+  const showOwnerScope = jwtScope === 'partner' && !!jwtPartnerId && canManagePartnerWide;
 
   const fetchConnections = useCallback(async () => {
     try {
@@ -241,7 +252,17 @@ export default function PsaConnectionsPage() {
       const method = modalMode === 'edit' ? 'PATCH' : 'POST';
 
       const base = toConnectionPayload(values);
-      const payload = modalMode === 'edit' ? base : { ...base, provider: values.provider };
+      // ownerScope is create-only (epic #2135) — the PATCH schema rejects it,
+      // and re-homing a connection is deliberately not a supported operation.
+      // Only sent when the selector was actually shown, so an org-scope user's
+      // create keeps the server's 'organization' default.
+      const payload = modalMode === 'edit'
+        ? base
+        : {
+            ...base,
+            provider: values.provider,
+            ...(showOwnerScope && values.ownerScope ? { ownerScope: values.ownerScope } : {})
+          };
 
       await runAction({
         request: () => fetchWithAuth(url, { method, body: JSON.stringify(payload) }),
@@ -364,6 +385,7 @@ export default function PsaConnectionsPage() {
             <PsaConnectionForm
               onSubmit={handleSubmit}
               onCancel={handleCloseModal}
+              showOwnerScope={showOwnerScope}
               onTestConnection={modalMode === 'edit' ? handleTestConnection : undefined}
               defaultValues={
                 selectedConnectionDetails

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -1021,6 +1021,12 @@
         "validation": {
           "nameRequired": "Der Verbindungsname ist erforderlich",
           "validUrl": "Es muss eine gültige URL angegeben werden"
+        },
+        "ownerScope": {
+          "legend": "Eigentum",
+          "allOrganizations": "Alle Organisationen",
+          "partnerWideHint": "(partnerweit — das eigene PSA Ihres MSP)",
+          "thisOrganizationOnly": "Nur diese Organisation"
         }
       },
       "PsaConnectionList": {
@@ -1049,7 +1055,9 @@
           "paused": "Pausiert",
           "syncing": "Wird synchronisiert"
         },
-        "title": "PSA-Verbindungen"
+        "title": "PSA-Verbindungen",
+        "allOrgs": "Alle Orgs",
+        "partnerWideTitle": "Partnerweite Verbindung — von jeder Organisation genutzt"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -1026,7 +1026,8 @@
           "legend": "Eigentum",
           "allOrganizations": "Alle Organisationen",
           "partnerWideHint": "(partnerweit — das eigene PSA Ihres MSP)",
-          "thisOrganizationOnly": "Nur diese Organisation"
+          "thisOrganizationOnly": "Nur diese Organisation",
+          "organization": "Organisation"
         }
       },
       "PsaConnectionList": {
@@ -1057,7 +1058,8 @@
         },
         "title": "PSA-Verbindungen",
         "allOrgs": "Alle Orgs",
-        "partnerWideTitle": "Partnerweite Verbindung — von jeder Organisation genutzt"
+        "partnerWideTitle": "Partnerweite Verbindung — von jeder Organisation genutzt",
+        "partnerWideLocked": "Partnerweite Verbindung — Änderung erfordert vollen Partner-Organisationszugriff"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -1026,7 +1026,8 @@
           "legend": "Ownership",
           "allOrganizations": "All organizations",
           "partnerWideHint": "(partner-wide — your MSP's own PSA)",
-          "thisOrganizationOnly": "This organization only"
+          "thisOrganizationOnly": "This organization only",
+          "organization": "Organization"
         }
       },
       "PsaConnectionList": {
@@ -1057,7 +1058,8 @@
         },
         "title": "PSA Connections",
         "allOrgs": "All orgs",
-        "partnerWideTitle": "Partner-wide connection — shared by every organization"
+        "partnerWideTitle": "Partner-wide connection — shared by every organization",
+        "partnerWideLocked": "Partner-wide connection — requires full partner organization access to modify"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -1021,6 +1021,12 @@
         "validation": {
           "nameRequired": "Connection name is required",
           "validUrl": "Must be a valid URL"
+        },
+        "ownerScope": {
+          "legend": "Ownership",
+          "allOrganizations": "All organizations",
+          "partnerWideHint": "(partner-wide — your MSP's own PSA)",
+          "thisOrganizationOnly": "This organization only"
         }
       },
       "PsaConnectionList": {
@@ -1049,7 +1055,9 @@
           "paused": "Paused",
           "syncing": "Syncing"
         },
-        "title": "PSA Connections"
+        "title": "PSA Connections",
+        "allOrgs": "All orgs",
+        "partnerWideTitle": "Partner-wide connection — shared by every organization"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -1021,6 +1021,12 @@
         "validation": {
           "nameRequired": "El nombre de la conexión es obligatorio.",
           "validUrl": "Debe ser un URL válido."
+        },
+        "ownerScope": {
+          "legend": "Propiedad",
+          "allOrganizations": "Todas las organizaciones",
+          "partnerWideHint": "(a nivel de socio — el PSA propio de su MSP)",
+          "thisOrganizationOnly": "Solo esta organización"
         }
       },
       "PsaConnectionList": {
@@ -1049,7 +1055,9 @@
           "paused": "En pausa",
           "syncing": "Sincronizando"
         },
-        "title": "Conexiones PSA"
+        "title": "Conexiones PSA",
+        "allOrgs": "Todas las orgs",
+        "partnerWideTitle": "Conexión a nivel de socio — compartida por todas las organizaciones"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -1026,7 +1026,8 @@
           "legend": "Propiedad",
           "allOrganizations": "Todas las organizaciones",
           "partnerWideHint": "(a nivel de socio — el PSA propio de su MSP)",
-          "thisOrganizationOnly": "Solo esta organización"
+          "thisOrganizationOnly": "Solo esta organización",
+          "organization": "Organización"
         }
       },
       "PsaConnectionList": {
@@ -1057,7 +1058,8 @@
         },
         "title": "Conexiones PSA",
         "allOrgs": "Todas las orgs",
-        "partnerWideTitle": "Conexión a nivel de socio — compartida por todas las organizaciones"
+        "partnerWideTitle": "Conexión a nivel de socio — compartida por todas las organizaciones",
+        "partnerWideLocked": "Conexión a nivel de socio — modificarla requiere acceso completo a las organizaciones del socio"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -1021,6 +1021,12 @@
         "validation": {
           "nameRequired": "Le nom de connexion est requis",
           "validUrl": "Doit être un URL valide"
+        },
+        "ownerScope": {
+          "legend": "Propriété",
+          "allOrganizations": "Toutes les organisations",
+          "partnerWideHint": "(à l'échelle du partenaire — le PSA de votre MSP)",
+          "thisOrganizationOnly": "Cette organisation seulement"
         }
       },
       "PsaConnectionList": {
@@ -1049,7 +1055,9 @@
           "paused": "En pause",
           "syncing": "Synchronisation"
         },
-        "title": "Connexions PSA"
+        "title": "Connexions PSA",
+        "allOrgs": "Toutes les orgs",
+        "partnerWideTitle": "Connexion à l'échelle du partenaire — partagée par toutes les organisations"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -1026,7 +1026,8 @@
           "legend": "Propriété",
           "allOrganizations": "Toutes les organisations",
           "partnerWideHint": "(à l'échelle du partenaire — le PSA de votre MSP)",
-          "thisOrganizationOnly": "Cette organisation seulement"
+          "thisOrganizationOnly": "Cette organisation seulement",
+          "organization": "Organisation"
         }
       },
       "PsaConnectionList": {
@@ -1057,7 +1058,8 @@
         },
         "title": "Connexions PSA",
         "allOrgs": "Toutes les orgs",
-        "partnerWideTitle": "Connexion à l'échelle du partenaire — partagée par toutes les organisations"
+        "partnerWideTitle": "Connexion à l'échelle du partenaire — partagée par toutes les organisations",
+        "partnerWideLocked": "Connexion à l'échelle du partenaire — la modification requiert un accès complet aux organisations du partenaire"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -1021,6 +1021,12 @@
         "validation": {
           "nameRequired": "Le nom de connexion est requis",
           "validUrl": "Doit être un URL valide"
+        },
+        "ownerScope": {
+          "legend": "Propriété",
+          "allOrganizations": "Toutes les organisations",
+          "partnerWideHint": "(à l'échelle du partenaire — le PSA de votre MSP)",
+          "thisOrganizationOnly": "Cette organisation uniquement"
         }
       },
       "PsaConnectionList": {
@@ -1049,7 +1055,9 @@
           "paused": "En pause",
           "syncing": "Synchronisation"
         },
-        "title": "Connexions PSA"
+        "title": "Connexions PSA",
+        "allOrgs": "Toutes les orgs",
+        "partnerWideTitle": "Connexion à l'échelle du partenaire — partagée par toutes les organisations"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -1026,7 +1026,8 @@
           "legend": "Propriété",
           "allOrganizations": "Toutes les organisations",
           "partnerWideHint": "(à l'échelle du partenaire — le PSA de votre MSP)",
-          "thisOrganizationOnly": "Cette organisation uniquement"
+          "thisOrganizationOnly": "Cette organisation uniquement",
+          "organization": "Organisation"
         }
       },
       "PsaConnectionList": {
@@ -1057,7 +1058,8 @@
         },
         "title": "Connexions PSA",
         "allOrgs": "Toutes les orgs",
-        "partnerWideTitle": "Connexion à l'échelle du partenaire — partagée par toutes les organisations"
+        "partnerWideTitle": "Connexion à l'échelle du partenaire — partagée par toutes les organisations",
+        "partnerWideLocked": "Connexion à l'échelle du partenaire — la modification requiert un accès complet aux organisations du partenaire"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -1021,6 +1021,12 @@
         "validation": {
           "nameRequired": "Il nome della connessione è obbligatorio",
           "validUrl": "Deve essere un URL valido"
+        },
+        "ownerScope": {
+          "legend": "Proprietà",
+          "allOrganizations": "Tutte le organizzazioni",
+          "partnerWideHint": "(a livello di partner — il PSA del tuo MSP)",
+          "thisOrganizationOnly": "Solo questa organizzazione"
         }
       },
       "PsaConnectionList": {
@@ -1049,7 +1055,9 @@
           "paused": "In pausa",
           "syncing": "Sincronizzazione"
         },
-        "title": "Connessioni PSA"
+        "title": "Connessioni PSA",
+        "allOrgs": "Tutte le org",
+        "partnerWideTitle": "Connessione a livello di partner — condivisa da tutte le organizzazioni"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -1026,7 +1026,8 @@
           "legend": "Proprietà",
           "allOrganizations": "Tutte le organizzazioni",
           "partnerWideHint": "(a livello di partner — il PSA del tuo MSP)",
-          "thisOrganizationOnly": "Solo questa organizzazione"
+          "thisOrganizationOnly": "Solo questa organizzazione",
+          "organization": "Organizzazione"
         }
       },
       "PsaConnectionList": {
@@ -1057,7 +1058,8 @@
         },
         "title": "Connessioni PSA",
         "allOrgs": "Tutte le org",
-        "partnerWideTitle": "Connessione a livello di partner — condivisa da tutte le organizzazioni"
+        "partnerWideTitle": "Connessione a livello di partner — condivisa da tutte le organizzazioni",
+        "partnerWideLocked": "Connessione a livello di partner — la modifica richiede accesso completo alle organizzazioni del partner"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -1021,6 +1021,12 @@
         "validation": {
           "nameRequired": "Nome da conexão é obrigatório",
           "validUrl": "Deve ser uma URL válida"
+        },
+        "ownerScope": {
+          "legend": "Propriedade",
+          "allOrganizations": "Todas as organizações",
+          "partnerWideHint": "(nível de parceiro — o PSA do seu MSP)",
+          "thisOrganizationOnly": "Somente esta organização"
         }
       },
       "PsaConnectionList": {
@@ -1049,7 +1055,9 @@
           "paused": "Pausada",
           "syncing": "Sincronizando"
         },
-        "title": "Conexões PSA"
+        "title": "Conexões PSA",
+        "allOrgs": "Todas as orgs",
+        "partnerWideTitle": "Conexão de nível de parceiro — compartilhada por todas as organizações"
       },
       "PsaConnectionsPage": {
         "actions": {

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -1026,7 +1026,8 @@
           "legend": "Propriedade",
           "allOrganizations": "Todas as organizações",
           "partnerWideHint": "(nível de parceiro — o PSA do seu MSP)",
-          "thisOrganizationOnly": "Somente esta organização"
+          "thisOrganizationOnly": "Somente esta organização",
+          "organization": "Organização"
         }
       },
       "PsaConnectionList": {
@@ -1057,7 +1058,8 @@
         },
         "title": "Conexões PSA",
         "allOrgs": "Todas as orgs",
-        "partnerWideTitle": "Conexão de nível de parceiro — compartilhada por todas as organizações"
+        "partnerWideTitle": "Conexão de nível de parceiro — compartilhada por todas as organizações",
+        "partnerWideLocked": "Conexão de nível de parceiro — alterá-la requer acesso completo às organizações do parceiro"
       },
       "PsaConnectionsPage": {
         "actions": {


### PR DESCRIPTION
Retrofits dual ownership (`org_id` XOR `partner_id`) onto `psa_connections`, following the **Partner-Wide First** playbook (epic #2135).

---

## Review round 2 — 10 findings applied

A high-effort review found a **real cross-org data leak** plus 9 more. All fixed.

### The conceptual error (findings 0, 1, 8)

The PR treated **partner scope as sufficient authorization for partner-wide rows**. It is not — two different things were conflated:

- `psa_connections` is partner-owned **CONFIG** → correctly visible to any partner-scope caller of that partner.
- The `psa_ticket_mappings` hanging off it are per-org **DATA** — each row names a specific org's device, alert and external ticket → must **always** be filtered by the caller's accessible orgs, whatever the scope.

**The leak:** `psaConnectionAccessCondition` OR'd in the partner arm for any partner-scope token without consulting `partnerOrgAccess`, so a `partner_user` with `org_access='selected'` limited to org A read **org B's external ticket ids, URLs, alert ids and device ids** via `GET /psa/tickets`. `GET /connections/:id/tickets` was worse — after `ensureConnectionAccess` passed it applied **no org filter at all**.

**Fix:** a new `psaTicketMappingOrgCondition` constrains the **mapping rows themselves** through their own org anchors (`device_id → devices.org_id`, `alert_id → alerts.org_id`), AND-combined so a row is withheld if *either* anchor is out of reach. A row with neither anchor references no org, so connection access governs it.

**This required dropping the `psa_connections` innerJoin on `/tickets`** — it could not coexist with correct org-scope behaviour. `psa_connections` RLS rightly hides partner-wide rows from org tokens, so the join silently discarded every ticket about an org's *own* device whenever the MSP's PSA was partner-wide. That is finding 8, the same bug's mirror image: with the join gone and the anchor filter in place, an org-scope caller now correctly sees their own device's ticket. The `auth.scope === 'partner'` gate is dropped on the ticket path and **kept** on the connection-visibility path, where it is correct.

**RLS cannot enforce this.** The `psa_ticket_mappings` connection arm passes for any partner-scope caller of the owning partner — necessarily, since an unanchored row has no org for Postgres to check. Postgres cannot express `org_access='selected'`, so this app-layer condition is the enforcement point, and it is documented as such so it is not later deleted as "redundant with the policy".

### Finding 2 — asymmetric USING / WITH CHECK

The device arm was a bare `OR` in **both** clauses, so owning a device authorized *writing* a mapping onto a foreign tenant's connection — contradicting the migration's own "connection_id is the tenancy anchor" rule. Now split:

- `USING` = system OR connection-accessible OR device-org OR **alert-org**
- `WITH CHECK` = system OR connection-accessible **only**

This closes the foreign-connection write hole and the missing-alert-arm hole together. Applied by **amending the existing unmerged migration** rather than adding a follow-up: the file has never been applied to a persistent database (only ephemeral CI containers, torn down each run), `breeze_migrations` keys on filename so it still applies exactly once everywhere, and shipping a knowingly-wrong policy into history to immediately supersede it would gain nothing. The rule it must not break — never edit a **shipped** migration — is not engaged.

### Finding 3 — VERDICT: CONFIRMED REAL

Traced end to end. `deleteDeviceCascade` pre-clears on `alert_id IN (device's alerts) OR device_id = ...` inside the **request** (org-scoped) context. For a mapping with `device_id` NULL and `alert_id` set under a **partner-owned** connection: the connection arm fails (org token cannot see partner-wide connections), the device arm fails (`device_id` NULL) → the DELETE matches **zero rows** → the cascade's follow-on `DELETE FROM alerts` raises **23503** → `DELETE /devices/:id` 500s. Fixed by the `USING` alert arm; the regression test deletes exactly such a mapping under org-scoped RLS.

### Findings 4–7, 9

| # | Fix |
|---|---|
| 4 | Create form takes its default from the canonical `useDefaultOwnerScope` hook instead of a hard-coded `'partner'`. Partner-wide remains the default in the All-organizations view. |
| 5 | `GET /connections/:id` computes `canManage` as orgs:write **AND NOT** `partnerWideWriteBlocked`, so a user barred from mutating a partner-wide connection no longer receives the credential prefill or `credentialFields` — the material #3291 gated. |
| 6 | "This organization only" sent no `orgId`, so create **400'd for any partner with 2+ orgs**. Added an org picker on that branch, populated from the caller's accessible orgs. |
| 7 | Edit/Pause/Delete are disabled with an explanatory tooltip on partner-wide rows the user cannot manage, instead of letting the click land on the new 403 as an error toast. |
| 9 | Deleted the dead org-only `resolveOrgIds`, so the next endpoint author cannot copy the partner-wide-invisible shape. |

### A bug CI caught that the local tests structurally could not

The first cut used `d.org_id = ANY(${orgIds}::uuid[])`. Drizzle expands a JS array in a `sql` template into a comma-separated **parameter list**, so Postgres received a record: `cannot cast type record to uuid[]` (and `malformed array literal` for a single-element list). `routes/psa.test.ts` mocks the entire db layer, so malformed SQL passes there and fails only against a real database.

Fixed by binding each id via `sql.join`, and — to close the gap rather than just the bug — the condition moved into a dependency-free `services/psa/ticketScope.ts` with `ticketScope.test.ts`, which renders it through the real `PgDialect` and asserts the emitted SQL and parameter binding. That moves this class of failure into the fast unit job.

### Round-2 verification (all green, real Postgres)

| Suite | Where | Result |
|---|---|---|
| `psaTicketMappingOrgScoping.integration.test.ts` (**new**) | shard 2 | ✓ 6 — the leak guards + finding 8 |
| `psaConnectionsPartnerRls.integration.test.ts` | shard 2 | ✓ 13 (was 11; +alert arm, +WITH CHECK forge) |
| `rls-coverage` / `tenant-export-policy` / `tenantExportErasureRoundtrip` / `tenantCascadePartner` | shard 1 | ✓ 75 / 2 / 2 / 3 |
| `tenantCascade` / `tenantCascadeExecution` / `tenantCascadeSso` | shard 4 | ✓ 5 / 3 / 4 |
| `psa.test.ts` + `ticketScope.test.ts` | local | ✓ 50 |
| web `PsaConnectionsPage.test.tsx` | local | ✓ 16 |
| i18n parity / coverage / keyUsage + `no-silent-mutations` | local | ✓ 164 |

**56/56 CI checks pass.** The `WITH CHECK` forge check runs as `breeze_app` through the real postgres.js driver and asserts `42501` — that is the manual forge check, executed as a test because this environment has no local database (no `docker`/`psql`/`podman`).

---

## Why partner-wide

An MSP's PSA is a **partner-level** system: one ConnectWise/Autotask/Jira tenant covers every customer the MSP manages. Before this, `psa_connections.org_id` was `NOT NULL`, so an MSP had to re-enter the same PSA credentials once per customer org.

Corroborating signals: the sibling `accounting_connections` table is already partner-axis, the real UI has no org picker, and the org-import feature that will consume this is partner-scoped. The `backup_configs` org-only precedent does **not** apply — that table holds the *customer's* storage credentials, whereas a PSA credential is the *MSP's own*.

Dual ownership rather than partner-only preserves existing org-owned rows and the legitimate co-managed-IT case (a customer bringing their own Jira/Zendesk).

## Migration — `2026-08-17-psa-connections-partner-ownership.sql`

Date-ordering checked with `ls apps/api/migrations/ | tail -5`: the latest shipped file is `2026-08-15-snmp-poll-attempt-backoff.sql`, so `2026-08-17-` sorts last. **Not** added to the closed `2026-08-06` block. `scripts/check-migration-naming.sh` passes (pre-commit hook).

- `partner_id uuid REFERENCES partners(id)`, `org_id` `DROP NOT NULL`
- `psa_connections_one_owner_chk CHECK ((org_id IS NULL) <> (partner_id IS NULL))`
- `psa_connections_partner_id_idx`
- ONE dual-axis policy replacing the four `breeze_org_isolation_*` policies from the generic `0008-tenant-rls.sql` sweep:

```sql
CREATE POLICY psa_connections_isolation
  ON psa_connections
  USING (
    public.breeze_current_scope() = 'system'
    OR (org_id IS NOT NULL AND public.breeze_has_org_access(org_id))
    OR (partner_id IS NOT NULL AND public.breeze_has_partner_access(partner_id))
  )
  WITH CHECK ( ...same... );
```

No data cleanup block: `org_id` is `NOT NULL` today, so every existing row satisfies the XOR the moment the constraint lands. Nothing is UPDATEd or DELETEd, hence no `ROW_COUNT` diagnostics.

### `psa_ticket_mappings` join policies — rewritten in the SAME migration

Its four org-only join policies (from `2026-04-11-bucket-c-dead-cleanup-rls.sql`) asserted `breeze_has_org_access(pc.org_id)`, which is FALSE whenever `pc.org_id IS NULL` — i.e. for *every* partner-owned connection. Left alone, mappings under a partner-owned connection would be both invisible AND unwritable. Collapsed to one policy with **three** arms (same hazard `ticket_form_org_links` documents):

1. system short-circuit
2. join to `psa_connections` with the parent's **dual-axis** predicate
3. **`device_id → devices.org_id`**

Arm 3 is not cosmetic. `deleteDeviceCascade` runs in the **request** context, which for an org-scope token is org-scoped RLS. Without it, a mapping hanging off a partner-owned connection is invisible to that token, its `DELETE` silently matches zero rows, and the following `DELETE FROM devices` fails `23503` — a 500 on an ordinary device delete, newly introduced by this PR. The arm is also right on the merits: a ticket about *my* device is *my* org's record, which is exactly what playbook step 5 says for worker-created child rows.

## Erasure / cascade fix (confirmed gap)

`psa_ticket_mappings` has **no** `org_id` and **no** `partner_id`, yet holds **three** FKs into the cascade set, every one declared without an explicit `ON DELETE` (so `NO ACTION`): `connection_id → psa_connections` (NOT NULL), `alert_id → alerts`, `device_id → devices`.

**Chosen fix: pre-clears in both cascades**, following the existing `ASSOCIATED_SYSTEM_SCOPED_TABLES` / partner pre-clear pattern (#2195). Rejected `ON DELETE CASCADE` because:

- the per-table row counts are **load-bearing**, not cosmetic — `cascadeDeletePartner` reports them so a purge that silently matched zero rows under forced RLS surfaces as `totalRowsDeleted === 0` instead of masquerading as success. DB-level cascades are invisible to `extractRowCount`.
- repo convention is explicit enumeration **even when the FK already cascades** (`organization_external_links`, `ticket_form_org_links`).
- a uniform `ON DELETE CASCADE` on the nullable `alert_id`/`device_id` would change **non-erasure** behaviour (an alert-retention purge would start destroying ticket mappings); `SET NULL` there would contradict `deleteDeviceCascade`, which deletes them by `device_id`. The pre-clear changes nothing outside erasure.

The **org** pre-clear needs all three arms. With `org_id` nullable, a mapping under a *partner-owned* connection matches no `connection_id IN (… WHERE org_id = $org)` subquery, yet still pins that org's `alerts` and `devices` rows — both of which the main loop deletes. Connection-only would be a guaranteed `23503`.

**This was already latently broken before this PR** (`alerts`/`devices` are deleted by the org cascade regardless of connection ownership) — and **no contract test in the repo can catch it**: `tenantCascade.integration.test.ts` enumerates membership from `information_schema.columns WHERE column_name='org_id'` and skips FK edges whose endpoints are outside the cascade set, so a table with neither column is structurally invisible to it. That is exactly how #2195 shipped. It is **dormant**, though — there is no INSERT path for `psa_ticket_mappings` anywhere in the repo (no PSA sync worker exists), so the table is empty in every deployment.

Also fixed: **`deleteDeviceCascade` deletes `alerts` ~30 entries *before* `psa_ticket_mappings`** in `CORE_DEVICE_CASCADE_DELETE_TABLES`, so a mapping referencing that device's alert raises `23503` on `DELETE /devices/:id`. Pre-existing, unrelated to GDPR erasure, fixed here since this PR touches the same table.

## Reader sweep (playbook step 7)

Every `psa_connections.orgId` call site, swept repo-wide:

| Site | Fix |
|---|---|
| `routes/psa.ts` `GET /connections` (`inArray(orgId, orgIds)`) + its count query | dual-axis `psaConnectionAccessCondition` |
| `routes/psa.ts` `GET /tickets` + its count query (through the join) | dual-axis condition on the joined parent |
| `routes/psa.ts` `resolveOrgIds` | no longer used for scoping the two list routes |
| `routes/psa.ts` × 6 `ensureOrgAccess(connection.orgId, …)` (detail, PATCH, DELETE, test, status, `:id/tickets`) | `ensureConnectionAccess` (dual-axis) |
| `routes/psa.ts` `serializeConnection` | `ownerScope` added, `orgId` now nullable |
| `services/aiToolsIntegrations.ts` `query_psa_status` (`auth.orgCondition`) | dual-axis condition + `ownerScope` in the tool result |
| `apps/web` `PsaConnectionList` / `PsaConnectionForm` / `PsaConnectionsPage` | `ownerScope` type, badge, selector |

Confirmed **not** affected: `encryptedColumnRegistry` and `services/psa/credentials.ts` (keyed on table+column, no tenant axis); `routes/devices/core.ts` (`psa_ticket_mappings` deletes by `device_id`, and its exclusion from the org-denormalized set stays correct); `routes/integrations.ts` `/integrations/psa` (an unrelated in-memory Map). No hits in portal, mobile, helper, agent, viewer, or any worker.

## Writes

- create takes `ownerScope: 'organization' | 'partner'`; **absent ⇒ `organization`**, preserving behaviour for existing API clients. The **web form** defaults its selector to partner-wide (per the product decision) — the wire default stays org-scoped so an unaware caller can never accidentally publish a credential to every org.
- partner-wide create/update/delete/**status**/**test** gated on `canManagePartnerWidePolicies(auth)`. Status is an update by another name (pausing a partner-wide connection pauses it everywhere), and test both writes `syncSettings` and exercises the MSP's credentials — so both are held to the same bar.
- the partner is **always** derived from the caller's token, never the body (covered by a test).
- ownership is **immutable** after create: `updateConnectionSchema` is hand-written and has no `ownerScope`, so there is nothing to `.omit({ ownerScope: true })` from — noted in a comment at the schema.
- app-layer partner conditions are gated on `auth.scope === 'partner'`. An org token carries a `partnerId` but never passes `breeze_has_partner_access`; **RLS is stricter than the app layer and the two are not at parity.**

## Registration (separate contracts)

- `DUAL_AXIS_TENANT_TABLES` ← `psa_connections`
- `PARENT_FK_JOIN_POLICY_TABLES` entry for `psa_ticket_mappings` re-commented for the dual-axis parent
- `CORE_TENANT_EXPORT_POLICY` ← `partner_id` in `psa_connections.included` (a tenant identifier). **This is the row that fires on a new column, not just a new table.** The org export only ever emits org-owned rows, so a partner-owned connection never appears in a customer's export — correct, it is the MSP's credential.
- org cascade entry verified: `DELETE FROM psa_connections WHERE org_id = X` correctly leaves partner-owned rows alone; they are reached by the partner-axis sweep, which `psa_connections` now joins automatically via its new `partner_id` column.

## Playbook steps 4 and 5 — N/A, considered not forgotten

- **Step 4 (config-policy linkage):** N/A. `psa_connections` is not a config-policy feature — it is not in `FEATURE_TABLE_MAP`, nothing links it via `config_policy_feature_links`, and `PARTNER_LINKABLE_FEATURE_TYPES` has no PSA member.
- **Step 5 (evaluation/enforcement fan-out):** N/A. No worker or scheduler evaluates `psa_connections` against devices — nothing consumes `services/psa/index.ts` on a schedule, and `POST /connections/:id/sync` is an honest 501. Consequently the new RLS suite has no fan-out test.

## Tests

- **new** `psaConnectionsPartnerRls.integration.test.ts` — cross-partner forge → `42501`, XOR (both axes / neither) → `23514`, org isolation, cross-org isolation, the **partner-scope read proof**, and the `psa_ticket_mappings` device arm.
- `psa.test.ts` — 14 new cases (ownerScope create incl. body-`orgId` ignored, partner-wide gating on update/delete/status, dual-axis detail access, org-scope denial).
- `tenantCascade.partner.test.ts` — asserts the `psa_ticket_mappings` pre-clear runs before the partner-axis sweep.
- `PsaConnectionsPage.test.tsx` — 5 new cases (badge, selector visibility by scope + capability, both ownerScope POST paths).
- i18n strings added to all seven locales; `localeParity` / `translationCoverage` / `keyUsage` pass.

## Contract suites — verified in CI against real Postgres

They could **not** be run locally: this authoring environment has no `docker`, `psql`, or `podman` binary, no `/var/run/docker.sock`, and nothing listening on 5432/5433/54320, so the manual `breeze_app` forge check was done as an automated test instead of by hand. All four blocking **Integration Tests** shards are green and every relevant suite is confirmed executed, not skipped:

| Suite | Shard | Result |
|---|---|---|
| `psaConnectionsPartnerRls.integration.test.ts` (**new**) | 2 | ✓ 11 tests |
| `rls-coverage.integration.test.ts` | 1 | ✓ 75 tests |
| `tenant-export-policy.integration.test.ts` | 1 | ✓ 2 tests |
| `tenantExportErasureRoundtrip.integration.test.ts` | 1 | ✓ 2 tests |
| `tenantCascade.integration.test.ts` | 4 | ✓ 5 tests |
| `tenantCascadePartner.integration.test.ts` | 1 | ✓ 3 tests |
| `tenantCascadeExecution` / `tenantCascadeSso` | 4 | ✓ 3 / ✓ 4 tests |

The cross-tenant forge assertions (`42501`) and the XOR CHECK assertions (`23514`) in the new suite ARE the `breeze_app` manual check, run as `breeze_app` through the real postgres.js driver.

Also run locally: full API unit suite **20,774 passed / 1,296 files** (the single failing file, `requestDatabaseCompose.test.ts`, is `spawnSync docker ENOENT` — environmental, it shells out to `docker compose`); both `tsc --noEmit` clean.

## Deviations

- **Advisor quorum ran on Opus, not Codex.** `codex` is not installed in this environment; the CLAUDE.md fallback is an adversarial subagent. The first attempt (Fable) hit a credit limit, so the review ran on Opus. It confirmed the pre-clear choice, corrected my weaker justification for it (the "only 1 of 3 FKs" argument — replaced above with row-count accounting + repo convention), and independently found both the `deleteDeviceCascade` ordering bug and the org-token RLS hazard, which are fixed here.
- The reviewer's stronger alternative — denormalize `org_id` onto `psa_ticket_mappings` so it joins the auto-discovered shape-1 set — was **considered and rejected**: `device_id` and `alert_id` are both nullable, so a mapping under a partner-wide connection that is neither device- nor alert-linked has no org to derive, making `org_id NOT NULL` underivable in general. Worth revisiting when the PSA sync backend lands and the real child-row shape is known.
- `POST /connections/:id/test` is gated on the partner-wide capability even though the playbook names only create/update/delete — rationale above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

