### PR TITLE
docs: integration-test blocks PRs — it is smoke-test that is continue-on-error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ For test-writing conventions (Drizzle mock patterns, table-driven Go tests, vali
 - `test-api`, `test-web`, `test-agent` are **required** jobs on PRs
 - New test files are auto-discovered — no CI config changes needed
 - Go coverage is uploaded as artifact; no threshold enforced yet
-- Integration tests run in the `smoke-test`/`integration-test` jobs — non-blocking on PRs (`continue-on-error` on pull_request only) but REQUIRED on main, so a green PR can still turn main red
+- Integration tests run in the **`integration-test`** job (4 shards), which **blocks PRs**: it carries no `continue-on-error`, and `ci-success` hard-fails on `needs.integration-test.result`. Do not hand-dispatch CI to get an integration run on a PR that targets `main` — it already ran. The `continue-on-error: ${{ github.event_name == 'pull_request' }}` in `ci.yml` belongs to the separate **`smoke-test`** job (Docker image build + stack boot + endpoint smoke), which is non-blocking on PRs and required on main. A green PR can still redden main, but through a stale base or a stacked branch (see the tenancy section above), not through a skipped integration run
 
 ### Running Tests Locally
 ```bash


### PR DESCRIPTION
One-line fix to `CLAUDE.md`. The doc claims integration tests are non-blocking on PRs; they aren't, and the wrong belief has now cost two consecutive PRs a bogus warning plus a request to hand-dispatch CI (#3308, #3309).

## What the line said

> Integration tests run in the `smoke-test`/`integration-test` jobs — non-blocking on PRs (`continue-on-error` on pull_request only) but REQUIRED on main, so a green PR can still turn main red

It conflates two jobs, and the `integration-test` half is wrong.

## Verified against `.github/workflows/ci.yml`

| Claim | Evidence |
|---|---|
| `integration-test` blocks PRs | line 1652, 4 shards, **no** `continue-on-error` anywhere in the job |
| `ci-success` enforces it | `INTEGRATION_TEST_RESULT: ${{ needs.integration-test.result }}` (2063) → `[[ "${INTEGRATION_TEST_RESULT}" != "success" ]] || … exit 1` (2093) |
| the `continue-on-error` is `smoke-test`'s | line 1786, inside `smoke-test:` (1782–1787) |
| …and `smoke-test` says so itself | *"The API integration suite used to run here too — it now has its own **BLOCKING** integration-test job above; this job is purely the Docker image build + stack boot + endpoint smoke."* |

The only other `continue-on-error` in the file is a step-level `true` on the schema-drift check (line 88), unrelated.

Confirmed empirically on #3308: all four `Integration Tests` shards ran and gated the PR without anyone dispatching anything, shard 1 additionally carrying `test:rls-coverage` and `test:request-db-role`.

## What the replacement preserves

The real hazard stays, re-pointed at its actual cause: a green PR **can** still redden main — via a stale base or a stacked branch, which the tenancy section already explains in detail. The stacked-PR guidance there (`pull_request: branches: [main]`, so a sibling-based PR triggers *no* CI and `gh pr checks` reads green) is correct and left untouched; `gh workflow run CI --ref <branch>` is still the right move **there**, just not on a PR targeting `main`.

## Verification

Documentation only — one line in `CLAUDE.md`. No code, config, or workflow changes, so no test, type, or dependency surface is touched. Nothing in the repo reads or asserts `CLAUDE.md` content (the only references to it are prose comments in `db/index.ts` and a few integration tests).
