### PR TITLE
docs(plans): Phase 3 design handoff prompt for the RMM migration epic

### DIFF
--- a/docs/superpowers/plans/2026-08-09-custom-field-backfill-import.md
+++ b/docs/superpowers/plans/2026-08-09-custom-field-backfill-import.md
@@ -13,14 +13,13 @@
 
 ---
 
-## Blocking decision — resolve before Task 1
+## Decision — settled 2026-08-09
 
-**Spec §0 is not settled.** Values currently live in `devices.custom_fields`, a flat jsonb keyed by a bare string, while the definition namespace is dual-axis. The shipped partner-export query joins them by string match (`routes/partnerApi/configuration.ts:427-440`), so an org-owned and a partner-wide definition sharing a `field_key` emit **two export records for one datum** — and the importer is what manufactures that collision at scale.
+**Spec §0 is resolved: Option B.** Promote values to `device_custom_field_values` with a `definition_id` FK, behind a trigger-maintained `devices.custom_fields` projection so 34 of 37 consumers do not change.
 
-- **Option A** — stay on jsonb; the importer refuses cross-axis collisions at preview. Smaller. Residual risk stays open on the plain API, and every `custom.<key>` filter stays unindexed.
-- **Option B (recommended)** — `device_custom_field_values` with a `definition_id` FK, plus a trigger-maintained `devices.custom_fields` projection so 34 of 37 consumers do not change. Prerequisite phase 3a.
+Why it mattered: values live in a flat jsonb keyed by a bare string while the definition namespace is dual-axis, so the shipped partner-export query (`routes/partnerApi/configuration.ts:427-440`) emits **two contradictory export records for one datum** when an org-owned and a partner-wide definition share a `field_key` — and a per-org definitions import is exactly what manufactures that collision at scale.
 
-Tasks 1–3 below are the shared hardening and apply either way. **Task 4 exists only under Option B.**
+**Sequencing: Task 4 is a prerequisite PR (phase 3a), landing before the importer (phase 3b).** Tasks 1–3 are shared hardening and come first.
 
 ---
 
@@ -39,7 +38,7 @@ Tasks 1–3 below are the shared hardening and apply either way. **Task 4 exists
 | File | Responsibility |
 |---|---|
 | `apps/api/migrations/2026-08-19-custom-field-definition-constraints.sql` | Unique indexes, XOR check, duplicate report |
-| `apps/api/migrations/2026-08-20-device-custom-field-values.sql` | **Option B only** — values table, projection trigger, backfill |
+| `apps/api/migrations/2026-08-20-device-custom-field-values.sql` | Values table, projection trigger, backfill — the phase-3a prerequisite |
 | `apps/api/src/services/customFields/validateValue.ts` | `validateCustomFieldValue(definition, value)` — shared |
 | `apps/api/src/services/customFields/hardwareIdentity.ts` | Junk-serial denylist ported from the Go agent |
 | `apps/api/src/services/deviceCustomFieldImport/index.ts` | Preview / commit for values |
@@ -55,8 +54,8 @@ Tasks 1–3 below are the shared hardening and apply either way. **Task 4 exists
 | `apps/api/src/routes/devices/customFieldValues.ts` | Apply shared value validation |
 | `apps/api/src/routes/devices/core.ts` | Same, on the `PATCH /devices/:id` path |
 | `apps/web/src/components/settings/CustomFieldsPage.tsx` | `ownerScope` selector + "All orgs" badge |
-| `apps/api/src/services/filterEngine.ts` | **Option B** — rewrite the `custom.<key>` query |
-| `apps/api/src/routes/partnerApi/configuration.ts` | **Option B** — rewrite two jsonb queries |
+| `apps/api/src/services/filterEngine.ts` | Rewrite the `custom.<key>` query onto the values table (Task 4) |
+| `apps/api/src/routes/partnerApi/configuration.ts` | Rewrite two jsonb queries onto the values table (Task 4) |
 
 ---
 
@@ -87,7 +86,7 @@ Tasks 1–3 below are the shared hardening and apply either way. **Task 4 exists
 - [ ] Commit to snake_case keys explicitly; warn on any mapping to the reserved `asset_tag` / `inventory_id` / `external_id`, which feed `stableIdentifiers` in `routes/partnerApi/devices.ts:123-125`.
 - [ ] Tests: a `number` field rejects `"abc"`; a `dropdown` rejects a value outside `options.choices`; an unknown key is rejected; both existing write paths enforce it.
 
-## Task 4: Values table + projection — **Option B only**
+## Task 4: Values table + projection — PREREQUISITE PR (phase 3a)
 
 - [ ] `apps/api/migrations/2026-08-20-device-custom-field-values.sql`: `device_custom_field_values(id, device_id, org_id, definition_id, value_text, value_number, value_bool, value_date, source, created_at, updated_at)`, `UNIQUE (device_id, definition_id)`, FK to definitions with `ON DELETE CASCADE` (fixes the current orphaned-value bug).
 - [ ] Backfill from every existing `devices.custom_fields` blob, resolving each key to a definition; report counts, and report keys that resolve to no definition rather than dropping them silently.
@@ -154,5 +153,5 @@ Tasks 1–3 below are the shared hardening and apply either way. **Task 4 exists
 
 ## Out of scope
 
-- Org/site-level custom fields (#3257 spec §8), per-key expression indexes (Option A only), additional first-class mapping targets.
+- Org/site-level custom fields (#3257 spec §8), per-key expression indexes (moot under Option B), additional first-class mapping targets.
 - Contacts (#3258).

--- a/docs/superpowers/plans/2026-08-09-custom-field-backfill-import.md
+++ b/docs/superpowers/plans/2026-08-09-custom-field-backfill-import.md
@@ -1,0 +1,158 @@
+# Custom-Field / UDF Backfill Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a migrating MSP bring years of hand-entered UDF data (Datto `udf1`–`udf30`, Automate EDFs, Kaseya/Ninja/N-central/Atera custom fields) into Breeze, joined to enrolled devices, with preview→commit and per-row match status.
+
+**Architecture:** Harden the destination first (uniqueness, XOR, partner-wide gate, type validation), then a two-pass importer — field definitions, then values — mirroring the `orgImport` preview→commit pipeline.
+
+**Tech Stack:** PostgreSQL + hand-written SQL migrations, Drizzle ORM, Hono routes, Zod, React (web), Vitest.
+
+**Spec:** `docs/superpowers/specs/onboarding-signup/2026-08-09-custom-field-backfill-import-design.md`
+**Issue:** #3257 · **Epic:** #3249
+
+---
+
+## Blocking decision — resolve before Task 1
+
+**Spec §0 is not settled.** Values currently live in `devices.custom_fields`, a flat jsonb keyed by a bare string, while the definition namespace is dual-axis. The shipped partner-export query joins them by string match (`routes/partnerApi/configuration.ts:427-440`), so an org-owned and a partner-wide definition sharing a `field_key` emit **two export records for one datum** — and the importer is what manufactures that collision at scale.
+
+- **Option A** — stay on jsonb; the importer refuses cross-axis collisions at preview. Smaller. Residual risk stays open on the plain API, and every `custom.<key>` filter stays unindexed.
+- **Option B (recommended)** — `device_custom_field_values` with a `definition_id` FK, plus a trigger-maintained `devices.custom_fields` projection so 34 of 37 consumers do not change. Prerequisite phase 3a.
+
+Tasks 1–3 below are the shared hardening and apply either way. **Task 4 exists only under Option B.**
+
+---
+
+## Critical implementation notes — read before starting
+
+1. **Migrations must be dated `2026-08-19` or later.** The tree ships migrations through `2026-08-18`; today's date does **not** sort last, contrary to the handoff note. `check-migration-naming.sh` will not catch this case.
+2. **A bulk value write takes a per-org EXCLUSIVE advisory lock held until COMMIT** (`2026-07-18-partner-export-org-locks.sql:339` → `pg_advisory_xact_lock(1000201, hashtext(org_id))`), because the devices statement trigger's change tuple includes `custom_fields`. One transaction per org-chunk, never one for the whole import.
+3. **RLS is not the backstop here.** Resolving devices across orgs requires system DB context, and `breeze_has_org_access` short-circuits to `TRUE` for system scope (`0001-baseline.sql:1663-1671`). Every isolation guarantee is app-layer and must be proven by a forge test.
+4. **Value validation is a security control, not hardening.** Values are substituted into installer command lines (`installerVariables.ts` → `softwareDeployment.ts` → `sendCommandToAgent`) and select deployment/automation targets via `filterEngine` → `deploymentTargetResolver.ts`.
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|---|---|
+| `apps/api/migrations/2026-08-19-custom-field-definition-constraints.sql` | Unique indexes, XOR check, duplicate report |
+| `apps/api/migrations/2026-08-20-device-custom-field-values.sql` | **Option B only** — values table, projection trigger, backfill |
+| `apps/api/src/services/customFields/validateValue.ts` | `validateCustomFieldValue(definition, value)` — shared |
+| `apps/api/src/services/customFields/hardwareIdentity.ts` | Junk-serial denylist ported from the Go agent |
+| `apps/api/src/services/deviceCustomFieldImport/index.ts` | Preview / commit for values |
+| `apps/api/src/services/deviceCustomFieldImport/resolve.ts` | deviceId → serial → hostname resolution |
+| `apps/api/src/services/customFieldDefinitionImport.ts` | Preview / commit for definitions |
+| `apps/web/src/components/devices/BulkCustomFieldImport.tsx` | Definitions + values, mapping, preview, chunked commit |
+| `apps/api/src/__tests__/integration/customFieldDefinitionsPartnerRls.integration.test.ts` | Partner-wide RLS suite |
+
+### Modified files
+| File | Change |
+|---|---|
+| `apps/api/src/routes/customFields.ts` | `canManagePartnerWidePolicies` gate; definitions import routes |
+| `apps/api/src/routes/devices/customFieldValues.ts` | Apply shared value validation |
+| `apps/api/src/routes/devices/core.ts` | Same, on the `PATCH /devices/:id` path |
+| `apps/web/src/components/settings/CustomFieldsPage.tsx` | `ownerScope` selector + "All orgs" badge |
+| `apps/api/src/services/filterEngine.ts` | **Option B** — rewrite the `custom.<key>` query |
+| `apps/api/src/routes/partnerApi/configuration.ts` | **Option B** — rewrite two jsonb queries |
+
+---
+
+## Task 1: Definition constraints migration
+
+- [ ] Write `apps/api/migrations/2026-08-19-custom-field-definition-constraints.sql`, idempotent, no inner `BEGIN`/`COMMIT`.
+- [ ] Add the XOR constraint, copying `2026-07-01-alert-rules-partner-ownership.sql:38-48` — guarded `DO $$ … pg_constraint` check then `CHECK ((org_id IS NULL) <> (partner_id IS NULL))`. Report any offending row count first; existing data should conform, since the POST route already rejects both malformed shapes.
+- [ ] **Detect duplicate `field_key`s and fail loudly rather than resolving them.** Report the count and the affected `(owner, field_key)` pairs via `RAISE WARNING` per CLAUDE.md's row-count rule; create the unique indexes only when the count is zero.
+  - Deleting a duplicate silently retypes every stored value (the survivor dictates `type`, and values carry none).
+  - Renaming one orphans every stored value instantly and breaks `remoteAccessLauncher.ts:73` (`provider.customFieldKey` in partner settings) and `installerVariables.ts:30,51-53` (`{{device.customField.<key>}}` on software packages).
+  - Cleanup is an operator decision made with knowledge of which duplicate carries values.
+- [ ] Add the two partial unique indexes (`(org_id, field_key) WHERE org_id IS NOT NULL`, `(partner_id, field_key) WHERE partner_id IS NOT NULL`).
+- [ ] Note in the migration that these do **not** cover cross-axis collision — that is spec §0.
+- [ ] `pnpm db:migrate && pnpm db:check-drift` — no drift. Existing registrations are unchanged (no new table, no new column), so no cascade/export-policy edit is needed for this task.
+
+## Task 2: Partner-wide gate + UI — must ship together
+
+- [ ] Add `canManagePartnerWidePolicies(auth)` to the partner-wide branches of POST/PATCH/DELETE in `routes/customFields.ts`. Reference implementation: `routes/peripheralControl.ts:508`.
+- [ ] **This is a behavioural regression if shipped alone.** The web create modal never sends ownership, so partner-scoped users fall through to `partnerId = auth.partnerId` — in practice essentially every existing custom field is partner-wide, and the gate requires `partnerOrgAccess === 'all'` (`services/partnerWideAccess.ts:25-29`). Ordinary techs with `orgAccess='selected'` would start getting 403s through the plain UI.
+- [ ] Therefore, same PR: create-only `ownerScope` selector + "All orgs" badge in `CustomFieldsPage.tsx`, pattern `components/software/PolicyForm.tsx`; hide the partner-wide option for users lacking the capability.
+- [ ] Add `customFieldDefinitionsPartnerRls.integration.test.ts`: cross-partner forge → 42501, XOR → 23514, org isolation.
+- [ ] Test: a tech with `orgAccess='selected'` cannot create a partner-wide definition and does not see the option.
+
+## Task 3: Value validation — apply to existing paths, not just the importer
+
+- [ ] `services/customFields/validateValue.ts` — `validateCustomFieldValue(definition, value)` enforcing the declared `type`, `options.choices` for `dropdown`, `required`, and that the `fieldKey` resolves to a visible definition.
+- [ ] Apply it in `routes/devices/customFieldValues.ts` **and** on the `PATCH /devices/:id` path (`routes/devices/core.ts:1238-1246`). Validating only the importer leaves the trivially scriptable API-key path beside it unvalidated.
+- [ ] Commit to snake_case keys explicitly; warn on any mapping to the reserved `asset_tag` / `inventory_id` / `external_id`, which feed `stableIdentifiers` in `routes/partnerApi/devices.ts:123-125`.
+- [ ] Tests: a `number` field rejects `"abc"`; a `dropdown` rejects a value outside `options.choices`; an unknown key is rejected; both existing write paths enforce it.
+
+## Task 4: Values table + projection — **Option B only**
+
+- [ ] `apps/api/migrations/2026-08-20-device-custom-field-values.sql`: `device_custom_field_values(id, device_id, org_id, definition_id, value_text, value_number, value_bool, value_date, source, created_at, updated_at)`, `UNIQUE (device_id, definition_id)`, FK to definitions with `ON DELETE CASCADE` (fixes the current orphaned-value bug).
+- [ ] Backfill from every existing `devices.custom_fields` blob, resolving each key to a definition; report counts, and report keys that resolve to no definition rather than dropping them silently.
+- [ ] Projection trigger keeping `devices.custom_fields` in sync so the 17 JS readers, both partner-export triggers, and the MCP projection keep working unchanged.
+- [ ] Rewrite the only three SQL consumers: `filterEngine.ts:181-182`, `partnerApi/configuration.ts:433`, `:440`.
+- [ ] **Contract registration, same PR:** RLS (shape 5 — `device_id` with denormalized `org_id`), `CORE_ORG_CASCADE_DELETE_ORDER`, `CORE_DEVICE_CASCADE_DELETE_TABLES` **and** `CORE_DEVICE_ORG_DENORMALIZED_TABLES` (`routes/devices/core.ts`), `CORE_TENANT_EXPORT_POLICY` with typed columns `included` — which closes the tenant-export gap.
+- [ ] Test: a value write updates both the table and the projection, and still bumps `partner_export_updated_at`.
+
+## Task 5: Device resolution
+
+- [ ] `services/deviceCustomFieldImport/resolve.ts` — resolution order `deviceId` → `serialNumber` (via `device_hardware`) → `hostname` (case-insensitive), **always within one organization**. 0 matches = `not-found`; >1 = `ambiguous`; never guess.
+- [ ] Port the junk-serial denylist from `agent/internal/collectors/hardware.go:156-190` (`cleanHardwareIdentityValue`) into a shared TS constant — do **not** author a second, divergent list.
+- [ ] **Apply it to the DB side of the join as well as the CSV side.** The agent's filter runs only on Windows (`hardware_windows.go:136`); Linux (`hardware_linux.go:35`) and macOS (`hardware_darwin.go:46`) write raw values, so junk serials are already stored.
+- [ ] For hostname collisions, surface ranked candidates using enrollment's existing priority chain (token-authenticated > online > non-decommissioned > oldest, `routes/agents/enrollment.ts:514-518`) and require an explicit pick. The rule stays "never auto-pick"; the UI stops being a dead end.
+- [ ] Tests: explicit id wins; serial beats hostname; junk serials excluded on **both** sides; cross-org hostname collision never resolves outside the caller's orgs.
+
+## Task 6: Import services
+
+- [ ] `customFieldDefinitionImport.ts` — preview annotations `create | already-exists | type-conflict` (`type` is immutable on update, so a differing type is a conflict, never a silent cast); partner-wide creation gated per Task 2.
+- [ ] `deviceCustomFieldImport/index.ts` — preview/commit with annotations `matched | ambiguous | not-found | no-definition | type-error | reserved-key | already-set`. Only `matched` commits; `ambiguous` commits only with an acknowledged `deviceId`.
+- [ ] Commit **re-derives** every annotation against fresh state and rejects rows whose annotation changed since preview, with identity pinning — mirror `checkExpectation` (`orgImport/index.ts:407-448`).
+- [ ] **Mapping targets** per spec §3: `{kind:'customField', fieldKey}` and `{kind:'warranty', field}`. Warranty writes `device_warranty` with `data_source:'import'` and does not clobber a `data_source:'provider'` row without an explicit opt-in.
+- [ ] Stateless — client-held acknowledgement, audits only, exactly like `orgImport` (`services/orgImport/audit.ts`). If a persisted job record is added later it carries `org_id` and must land in the cascade **and** export-policy lists in the same PR.
+
+## Task 7: Routes
+
+- [ ] `POST /custom-fields/import{,/preview}` (definitions) and `POST /devices/custom-fields/import{,/preview}` (values).
+- [ ] Both value routes: `requireScope('partner','system')` + `requireOrgWrite` + `requireMfa()`. **Reject `X-API-Key`** — the existing `dualAuth` applies MFA only on the JWT branch and deliberately skips the site allowlist for API keys.
+- [ ] Per-row re-authorization against the caller's accessible orgs, plus `canAccessSite(perms, device.siteId)` (a plain boolean — fail closed on false) — `allowedSiteIds` is populated only on the org axis (`services/permissions.ts:171`).
+- [ ] Do **not** reuse `getDeviceWithOrgCheck` (`routes/devices/helpers.ts:83-113`) — it selects with no org predicate and checks in JS, which is the only check under a system context.
+- [ ] Row cap **1000** (`MAX_IMPORT_ROWS`), and commit **one transaction per org-chunk** — never one transaction for the whole import (see critical note 2).
+- [ ] `writeRouteAudit` per definition created and per device backfilled.
+
+## Task 8: Web UI
+
+- [ ] `BulkCustomFieldImport.tsx` modelled on `BulkOrgImport.tsx`: definitions step (upload the incumbent's field list, choose ownership, preview) then values step (CSV → `lib/csvParse.ts` → per-column mapping target + join-key column → preview → chunked commit with progress).
+- [ ] `ambiguous` rows expand to ranked candidates and require an explicit pick; select-all spans only `matched`.
+- [ ] Results through `runAction` including partial success across chunks.
+
+## Task 9: Tests
+
+- [ ] Isolation: a cross-partner forge under **system DB context** is rejected by the app layer — the test must not rely on RLS.
+- [ ] Site gating: a site-restricted org user cannot backfill a device outside their sites.
+- [ ] Auth: `X-API-Key` rejected on both import routes; MFA required.
+- [ ] Idempotency: re-running an identical import changes nothing and reports every row `already-set`.
+- [ ] Batching: an import spanning three orgs commits three transactions, none spanning more than one org's advisory lock.
+- [ ] Warranty target: an imported `warranty_end_date` makes `warrantyAlertEvaluator` fire and appears in `routes/partnerApi/inventory.ts`.
+- [ ] Prerequisites: the duplicate migration fails loudly with a count when duplicates exist and is a no-op otherwise; XOR rejects both malformed shapes.
+
+## Task 10: Docs + follow-up issues
+
+- [ ] Update `migration/overview.mdx` Phase 5 and each per-vendor guide with the backfill flow and the source field surfaces.
+- [ ] File the deferred items rather than losing them: dynamic-group recompute after import (the device-change pipeline is unwired — `initializeDeviceEventHandlers` has no caller, and `'custom'` never overlaps `'custom.<key>'`); incumbent identity at enrollment for late-enrolling devices; org/site-level custom fields.
+- [ ] One line each in the spec's §9 surfaces confirmed at review time: MCP exposure (`mcpServer.ts:1875`) and partner-export secret-scanning at volume (`exportSafety.classification.ts:46`).
+
+---
+
+## Verification
+
+- [ ] `apps/api` and `apps/web` unit suites green (package-local `vitest`; `pnpm` is unusable on this machine).
+- [ ] Contract suites green against a live DB — required under Option B, and for the partner-RLS suite either way.
+- [ ] Dispatch CI on the branch: `gh workflow run CI --ref <branch>`.
+- [ ] End-to-end: import a 30-field definition list plus a multi-org value CSV, confirm matched rows land, ambiguous rows are refused until acknowledged, and a re-run is a full no-op.
+
+## Out of scope
+
+- Org/site-level custom fields (#3257 spec §8), per-key expression indexes (Option A only), additional first-class mapping targets.
+- Contacts (#3258).

--- a/docs/superpowers/plans/2026-08-09-organization-contacts.md
+++ b/docs/superpowers/plans/2026-08-09-organization-contacts.md
@@ -13,11 +13,11 @@
 
 ---
 
-## Blocking decision — resolve before Task 1
+## Decision — settled 2026-08-09
 
-**Spec §0.2 is not settled.** The choice is between a new `contacts` table (recommended) and extending `portal_users`, which is already the de-facto contact store (`services/inboundEmail/resolveOrg.ts:44-73` is literally named `findOrCreateEmailContact`) and already carries every contract a new table must re-earn.
+**Spec §0.2 is resolved: build the new `contacts` table**, with `portal_users` becoming a login attached to a contact. The alternative (extending `portal_users`, already the de-facto contact store via `findOrCreateEmailContact`) was considered and declined.
 
-Do not start until the user has chosen. If `portal_users` is chosen, Tasks 1–3 collapse into a column-addition migration and Task 9 becomes the whole of the person-record work.
+**Consequence for this plan: Task 9 is mandatory, not conditional.** Without repointing inbound email and backfilling/linking existing portal users, the product ends up with two person tables that drift — which is the whole argument the rejected option was making.
 
 ---
 
@@ -81,7 +81,7 @@ Do not start until the user has chosen. If `portal_users` is chosen, Tasks 1–3
 
 ## Task 3: Backfill
 
-- [ ] Same migration: backfill from `sites.contact` (`roles='{site}'`, `site_id` set, `is_primary`), from `organizations.billing_contact` (`roles='{billing}'`), and — if §0.2 is accepted — one contact per `portal_users` row linked via the new `portal_users.contact_id`.
+- [ ] Same migration: backfill from `sites.contact` (`roles='{site}'`, `site_id` set, `is_primary`), from `organizations.billing_contact` (`roles='{billing}'`), and one contact per `portal_users` row linked via the new `portal_users.contact_id`.
 - [ ] Skip blobs that are NULL, `'{}'`, or carry no `name`/`email`/`phone`.
 - [ ] Every step reports its count: `DO $$ … GET DIAGNOSTICS n = ROW_COUNT; IF n > 0 THEN RAISE WARNING 'backfilled % <what>', n; END IF; END $$;`
 - [ ] Re-running the migration is a no-op.
@@ -135,7 +135,7 @@ Do not start until the user has chosen. If `portal_users` is chosen, Tasks 1–3
 - [ ] `BulkContactImport.tsx` modelled on `BulkOrgImport.tsx`: CSV → `lib/csvParse.ts` → column mapping → preview with status badges → commit.
 - [ ] `email-match` / `name-match` unchecked by default; select-all spans only `create` and `link-match`.
 
-## Task 9: Repoint inbound email — REQUIRED if §0.2 is accepted
+## Task 9: Repoint inbound email — REQUIRED (§0.2 is settled)
 
 - [ ] `services/inboundEmail/resolveOrg.ts` `findOrCreateEmailContact` creates a `contacts` row (creating a `portal_users` row only when portal access is actually granted).
 - [ ] Add nullable `portal_users.contact_id` FK; backfill and link one contact per existing portal user.

--- a/docs/superpowers/plans/2026-08-09-organization-contacts.md
+++ b/docs/superpowers/plans/2026-08-09-organization-contacts.md
@@ -1,0 +1,172 @@
+# Organization Contacts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Breeze a first-class contact record so migrating MSPs can bring their customers' people across, and so contact PII stops being silently dropped from tenant export.
+
+**Architecture:** New `contacts` (org-scoped, RLS shape 1) + `contact_external_links` (re-import identity). The existing `organizations.billing_contact` / `sites.contact` jsonb columns are **kept permanently** as a dual-written compatibility projection. Preview→commit importer mirroring `orgImport`.
+
+**Tech Stack:** PostgreSQL + hand-written SQL migration, Drizzle ORM, Hono routes, Zod, React (web), Vitest.
+
+**Spec:** `docs/superpowers/specs/onboarding-signup/2026-08-09-organization-contacts-design.md`
+**Issue:** #3258 · **Epic:** #3249
+
+---
+
+## Blocking decision — resolve before Task 1
+
+**Spec §0.2 is not settled.** The choice is between a new `contacts` table (recommended) and extending `portal_users`, which is already the de-facto contact store (`services/inboundEmail/resolveOrg.ts:44-73` is literally named `findOrCreateEmailContact`) and already carries every contract a new table must re-earn.
+
+Do not start until the user has chosen. If `portal_users` is chosen, Tasks 1–3 collapse into a column-addition migration and Task 9 becomes the whole of the person-record work.
+
+---
+
+## Critical implementation notes — read before starting
+
+1. **Do NOT plan to drop `organizations.billing_contact` or `sites.contact`.** Three shipped contracts depend on `sites.contact` existing: a partner-export watermark trigger reads it by name (`2026-07-18-partner-export-org-locks.sql:279-284`), it is a `.strict()` public partner-API DTO (`routes/partnerApi/schemas.ts:120-131`) whose records are content-hashed, and the two columns have deliberately different partner-API exposure. See spec §2.
+2. **The site PATCH writer has no literal `contact:` token.** `routes/orgs.ts:~2028-2038` writes it through `{...data}` spread. A grep-driven sweep misses it. This is the exact class of miss this epic has been bitten by.
+3. **Migrations must be dated `2026-08-19` or later.** The tree ships migrations through `2026-08-18`; today's date does **not** sort last, contrary to the handoff note.
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|---|---|
+| `apps/api/migrations/2026-08-19-contacts.sql` | Both tables, indexes, RLS policies, backfill |
+| `apps/api/src/db/schema/contacts.ts` | Drizzle schema |
+| `apps/api/src/services/contacts/compat.ts` | `upsertSiteContact` / `upsertBillingContact` — the only writers |
+| `apps/api/src/services/contacts/import.ts` | `previewContactImport` / `commitContactImport` |
+| `apps/api/src/services/contacts/types.ts` | `ContactImportRow`, annotations |
+| `apps/web/src/components/organizations/ContactsCard.tsx` | List / add / edit / delete |
+| `apps/web/src/components/organizations/BulkContactImport.tsx` | Upload → map → preview → commit |
+| `apps/api/src/__tests__/integration/contactsRls.integration.test.ts` | Forge tests |
+
+### Modified files
+| File | Change |
+|---|---|
+| `apps/api/src/routes/orgs.ts` | Contact CRUD + import routes; route all four jsonb writers through compat |
+| `apps/api/src/services/invoiceService.ts` | Billing-contact write goes through compat |
+| `apps/api/src/routes/invoices/settings.ts` | Same |
+| `apps/api/src/services/orgImport/index.ts` | Site/billing contact writes go through compat |
+| `apps/api/src/routes/partnerApi/provisioning.ts` | Site contact write goes through compat |
+| `apps/api/src/services/inboundEmail/resolveOrg.ts` | `findOrCreateEmailContact` creates a contact |
+| `apps/api/src/services/tenantCascade.ts` | Register both tables |
+| `apps/api/src/services/tenantExportPolicyRegistry.ts` | Register both tables, all columns `included` |
+| `apps/api/src/services/aiToolsOrgs.ts` | Real `add_contact` |
+| `apps/api/src/services/aiGuardrails.ts` | Tier + approval scope + summary |
+| `apps/api/src/services/aiAgentSdkTools.ts`, `aiToolSchemas.ts` | Duplicated action enums |
+| `apps/api/src/db/schema/index.ts` | Export the new schema |
+
+---
+
+## Task 1: Migration + schema
+
+- [ ] Write `apps/api/migrations/2026-08-19-contacts.sql`, idempotent, no inner `BEGIN`/`COMMIT`, per spec §1.1 and §1.2.
+- [ ] `contacts`: composite FK `(site_id, org_id) → sites(id, org_id)` (the required `sites_id_org_id_uniq` already exists, `2026-07-23-partner-export-material-state-hardening.sql:39`); `contacts_id_org_id_uniq`; the non-unique `(org_id, lower(email))` index; the two partial `is_primary` unique indexes.
+- [ ] `contact_external_links`: composite FK `(contact_id, org_id) → contacts(id, org_id)`; `UNIQUE (org_id, system, external_id)` — **org-scoped, not partner-scoped**, deliberately diverging from `organization_external_links` so one person can exist at two customers (spec §1.2).
+- [ ] Add **no** `json`/`jsonb`/`bytea` column to either table.
+- [ ] Enable **and force** RLS on both; four `breeze_has_org_access(org_id)` policies each, guarded by `pg_policies` existence checks. Copy `device_mtls_certificates`.
+- [ ] Add the Drizzle schema and export it.
+- [ ] `pnpm db:migrate && pnpm db:check-drift` — no drift.
+
+## Task 2: Register the contracts (do not defer)
+
+- [ ] `CORE_ORG_CASCADE_DELETE_ORDER` — add `'contact_external_links'` and `'contacts'` alphabetically. Both sort ahead of `sites` and `organizations`.
+- [ ] `CORE_TENANT_EXPORT_POLICY` — both tables, **every column `included`**. No name matches `SUSPICIOUS_NAME_PARTS`; no open containers exist by construction. This is the point of the feature.
+- [ ] Add **no** `DUAL_AXIS_TENANT_TABLES` entry — that asserts a partner branch these tables do not have.
+- [ ] No device-cascade entry (no `device_id`); no `AUDIT_ADMIN_REQUIRED_TABLES` entry (rows are mutable).
+- [ ] Add **no** partner-export resource in this PR (spec §2 — it needs `RESOURCE_CLASSIFICATION`, locks, material state, canonical parity).
+
+## Task 3: Backfill
+
+- [ ] Same migration: backfill from `sites.contact` (`roles='{site}'`, `site_id` set, `is_primary`), from `organizations.billing_contact` (`roles='{billing}'`), and — if §0.2 is accepted — one contact per `portal_users` row linked via the new `portal_users.contact_id`.
+- [ ] Skip blobs that are NULL, `'{}'`, or carry no `name`/`email`/`phone`.
+- [ ] Every step reports its count: `DO $$ … GET DIAGNOSTICS n = ROW_COUNT; IF n > 0 THEN RAISE WARNING 'backfilled % <what>', n; END IF; END $$;`
+- [ ] Re-running the migration is a no-op.
+
+## Task 4: The compat service — REQUIRED IN THIS PR
+
+- [ ] `services/contacts/compat.ts` with `upsertSiteContact(siteId, orgId, contact, actor)` and `upsertBillingContact(orgId, patch, actor)`, each writing the contact row **and** the legacy jsonb in one transaction.
+- [ ] Route every writer through it — the full list, verified, is in spec §2:
+  - `routes/orgs.ts` org create, org PATCH (**whole-blob replace**), site create, **site PATCH (`{...data}` spread — no literal `contact:` token)**
+  - `services/invoiceService.ts:497-506` (atomic `||` jsonb merge of email/name)
+  - `routes/invoices/settings.ts:30`
+  - `services/orgImport/index.ts` (~`:702,729,760,860,876`) — `:702` is the first-wins contact collapse, `:729` writes `billingContact`, `:760`/`:876` write `sites.contact`
+  - `services/accounting/quickbooksCustomerImport.ts:143` (indirect, via orgImport)
+  - `routes/partnerApi/provisioning.ts` site create/update
+- [ ] Fix the pre-existing race as a deliberate side effect: org PATCH replaces `billing_contact` wholesale while `invoiceService` merges into it, so a partial PATCH silently drops merged keys. Both now go through `upsertBillingContact`. Add a test.
+- [ ] Leave **all readers on the jsonb** in this PR. Writers move, readers do not — strictly safer than the Phase-1 sequencing.
+- [ ] Sweep before calling it done: `rg -na 'billingContact|billing_contact' apps/api/src apps/web/src packages/shared/src` **and** re-read every `.update(sites)` / `.update(organizations)` call site, because the spread writer will not appear in the grep.
+
+## Task 5: Contract + RLS verification
+
+- [ ] Run all four contract suites against a live DB: `rls-coverage`, `tenantCascade`, `tenant-export-policy`, `tenantExportErasureRoundtrip`. None of these fail in the `Test API` unit job.
+- [ ] As `breeze_app`, forge a cross-tenant contact insert — must fail with `new row violates row-level security policy`.
+- [ ] `contactsRls.integration.test.ts`: cross-org forge → 42501; a contact whose `site_id` belongs to another org → rejected by the composite FK; a link row whose `org_id` disagrees with its contact's → rejected; org isolation on read.
+- [ ] **Partner-export regression test**: editing a site contact through the compat service still bumps `sites.partner_export_updated_at` (the trigger at `2026-07-18-partner-export-org-locks.sql:279-284` reads `sites.contact` by name).
+- [ ] **Partner-API parity test**: `GET /partner-api/sites` contact payload byte-identical before/after; `organizations` still has no `billingContact` (`routes/partnerApi/organizations.test.ts:150,158`).
+- [ ] Dispatch CI on the branch: `gh workflow run CI --ref <branch>`.
+
+## Task 6: Contact CRUD + import routes
+
+- [ ] `GET/POST /orgs/organizations/:id/contacts`, `PATCH/DELETE /orgs/contacts/:id` — reads `orgs:read`; writes `orgs:write` + `requireMfa()`.
+- [ ] `POST /orgs/contacts/import/preview` and `POST /orgs/contacts/import`, max 1000 rows (`MAX_IMPORT_ROWS`).
+- [ ] Annotations `create | link-match | email-match | name-match | conflict | org-not-found`. `link-match` auto-applies; `email-match` and `name-match` require an echoed `expectedAnnotation`.
+- [ ] Commit **re-derives** every annotation and rejects rows whose annotation changed since preview, with identity pinning — mirror `checkExpectation` (`orgImport/index.ts:407-448`).
+- [ ] Per-row failure recorded, remaining rows proceed; always HTTP 200 with `{ imported, updated, skipped, errors }`.
+- [ ] `writeRouteAudit` for every contact created, updated, and deleted.
+
+## Task 7: `add_contact` becomes real — all five edits together
+
+- [ ] `services/aiToolsOrgs.ts` — real handler; fix the tool description (`:477`) and the input schema (`:486-492`, which currently documents params the handler ignores).
+- [ ] `services/aiAgentSdkTools.ts:2051,2053` and `services/aiToolSchemas.ts:307` — the duplicated action enums.
+- [ ] **`services/aiGuardrails.ts` — add `'add_contact'` to `TIER3_ACTIONS.manage_organizations` AND to `TIER3_SUPERVISED_ACTIONS.manage_organizations`.** Both. Omitting the first leaves it auto-executing with no approval while writing PII; adding only the first makes `resolveApprovalScope` fall through to the closing `return 'four_eyes'`, demanding a second approver to create a contact. Supervised is correct — `TIER3_FOUR_EYES_ACTIONS.manage_organizations` is `['create_org']` only (`:267`).
+- [ ] Remove the now-false comment at `aiGuardrails.ts:203-204` ("returns guidance only").
+- [ ] `buildApprovalDescription` (`aiGuardrails.ts:1366`; its `manage_organizations` branch at `:1526-1531`) — add a contact branch so the approver sees name/email instead of `Organizations: add_contact`.
+- [ ] Extend `aiGuardrails.approvalScope.contract.test.ts:139-180`, which currently pins only four tools and catches none of the above.
+- [ ] Test: `add_contact` resolves to `supervised` — not tier 2, not `four_eyes`.
+
+## Task 8: Web UI
+
+- [ ] `ContactsCard.tsx` on the organization detail page — list, add, edit, delete, role badges, "Primary" marker, site attribution. All mutations through `runAction`.
+- [ ] Site detail keeps its single-contact editor (now writing through compat) and links to the full list.
+- [ ] `BulkContactImport.tsx` modelled on `BulkOrgImport.tsx`: CSV → `lib/csvParse.ts` → column mapping → preview with status badges → commit.
+- [ ] `email-match` / `name-match` unchecked by default; select-all spans only `create` and `link-match`.
+
+## Task 9: Repoint inbound email — REQUIRED if §0.2 is accepted
+
+- [ ] `services/inboundEmail/resolveOrg.ts` `findOrCreateEmailContact` creates a `contacts` row (creating a `portal_users` row only when portal access is actually granted).
+- [ ] Add nullable `portal_users.contact_id` FK; backfill and link one contact per existing portal user.
+- [ ] **Without this, inbound email keeps minting people in the other table and "who do I email" is permanently split across two.** This is the objection that makes §0.2 close; leaving it undone concedes the argument.
+- [ ] Test: an inbound email from an unknown sender at a mapped domain creates exactly one contact and no orphan portal user.
+
+## Task 10: Tests
+
+- [ ] Service: link-match dedupe; email-match and name-match flagged not auto-applied; a shared mailbox (three contacts, one address) imports cleanly; an emailless contact round-trips; re-import is a no-op; partial success.
+- [ ] Compat: every writer in Task 4 produces both a contact row and the jsonb; the org-PATCH/invoiceService clobber race is fixed.
+- [ ] Backfill: idempotent; blobs with no usable field produce no row.
+- [ ] Update, do not delete, the behaviour-pinning suites listed in spec §2: `orgBillingSettings.integration.test.ts:26-60` (incl. "clear by setting email to JSON null"), `billing-contact-info.integration.test.ts`, `invoiceService.test.ts:317-343` (asserts a Drizzle `SQL` merge expression), `quoteLifecycle.test.ts` fixtures, `orgs.test.ts:1480-1488` (projection leak guard).
+- [ ] Web: preview rendering, fuzzy-match default-unchecked, `runAction` partial success.
+
+## Task 11: Docs
+
+- [ ] Update the three migration guides that tell readers contacts must be entered by hand: `migration/atera.mdx:29,77`, `migration/connectwise-automate.mdx:28`, `migration/syncro.mdx:30,74`.
+- [ ] Add contact rows to the six guides that are currently **silent** on contacts (`datto-rmm`, `kaseya-vsa`, `n-central`, `ninjaone`, `other-rmms`, `overview`) — silence is worse than a stated limitation for a reader migrating from Datto.
+- [ ] `migration/toolkit.mdx:116,120` — document the contact import endpoints.
+
+---
+
+## Verification
+
+- [ ] `apps/api` and `apps/web` unit suites green (run package-local `vitest`; `pnpm` is unusable on this machine).
+- [ ] All four contract suites green against a live DB (Task 5).
+- [ ] Partner-export watermark and partner-API parity tests green (Task 5) — these are the two silent-bug guards.
+- [ ] End-to-end: import a contacts CSV for an org with sites, confirm rows land, the jsonb projection matches, and a second import of the same file is a full skip.
+
+## Out of scope
+
+- Dropping the legacy jsonb columns — **not a deferral, a decision** (spec §2).
+- Per-role primacy (`contact_roles`), notification routing to contacts, partner-export `contacts` resource, partner-level contact unification, per-person cross-org erasure — all in spec "Deferred".
+- Custom-field backfill (#3257).

--- a/docs/superpowers/plans/notes/2026-08-09-rmm-migration-phase3-design-prompt.md
+++ b/docs/superpowers/plans/notes/2026-08-09-rmm-migration-phase3-design-prompt.md
@@ -1,0 +1,178 @@
+# RMM migration epic (#3249) — Phase 3 design session prompt
+
+> **Paste everything below the line into a fresh session.** It is written to be
+> self-contained: it carries the verified state of the code, the decisions
+> already made, and the working rules this epic has earned the hard way.
+
+---
+
+## Mission
+
+Design — **do not implement** — Phase 3 of the RMM migration epic (#3249):
+
+- **#3258 — first-class contacts.** A data-model decision. It may resolve as
+  *"the PSA owns contacts, link read-through"* rather than a local table.
+  **Settle this first**: it gates the shape of everything else, and building the
+  wrong thing here is expensive to unwind.
+- **#3257 — custom-field / UDF backfill import.** The largest chunk of genuine
+  customer data an MSP abandons when migrating: warranty expiry, asset tag,
+  purchase date, primary user, contract reference — hand-entered over years.
+
+The deliverable is **specs and plans, reviewed and committed** — not code. Two
+design docs under `docs/superpowers/specs/<area>/2026-08-XX-<slug>-design.md`
+with matching implementation plans under `docs/superpowers/plans/`, following the
+Phase-1 pattern (e.g. `specs/onboarding-signup/2026-08-08-bulk-org-site-import-design.md`
+and `plans/2026-08-08-org-external-links-and-bulk-import.md`).
+
+Stop and check in with the user before writing implementation code.
+
+## Working rules for this epic (learned the hard way — binding)
+
+- **Trace the end-to-end data flow, not just the contract checklists.** An
+  adversarial review of the three Phase-1 specs found all three were correct on
+  RLS shapes, cascade lists, and export policy — and all three had a defect in
+  the *primary flow* that the contract tests would have passed straight through.
+- **Second-order writers are where the bugs are.** Moving a reader to a new
+  table without its writer silently mints duplicate tenants. When you introduce a
+  new home for data, sweep for everyone who writes the old one.
+- **Run an adversarial reviewer on any consequential design before implementing.**
+  Spawn a subagent prompted to *refute*, since `codex` is not authenticated on
+  this machine. It has earned its keep every single time: last session it caught
+  a live authz gap (#3262), three spec defects, and pre-empted an SSRF hole in
+  PSA pagination cursors.
+- **Never take a subagent's "done" at face value.** Verify the claim yourself —
+  the commit exists, on the right branch, and the mechanism is what was described.
+- **Ask the right question, not the familiar one.** Phase 2's worst bug was an
+  authz gate copied from a sibling route: it asked "is this connection
+  partner-owned?" when the correct question was "how wide does this write reach?"
+  A refactor in the same PR also silently dropped a guard added earlier in the
+  same epic. Both passed review once before being caught.
+
+## State at handoff (2026-08-09) — Phase 2 is COMPLETE
+
+Everything below is merged to `main` with CI green.
+
+| Issue | PR | Shipped |
+|---|---|---|
+| #3242 | #3283 | org-import hardening; closed with a won't-fix note on CSV-body parsing |
+| #3246 | #3311 | PSA `getCompanies()` wired into org import via the `OrgImportSource` seam |
+| #3247 | #3284 | X-API-Key docs across all **four** surfaces + `openapi.ts` |
+| #3248 | #3285 | `migration/mass-deployment.mdx` (GPO/Intune/JAMF) |
+
+Also landed: `psa_connections` dual ownership (org XOR partner) per the #2135
+playbook, a real `/test` route, an honest 501 on the dead `/sync`, origin-pinned
+PSA pagination, the QuickBooks importer migrated onto the shared seam, and the
+legacy `accounting_provider` / `accounting_external_id` columns dropped.
+
+**Open in the epic:** #3257 and #3258 only. Epic #3249 has a Phase 2 completion
+comment with the full detail.
+
+**The import pipeline you will design against exists and is proven:**
+`services/orgImport/` — `OrgImportSource { system, list(ctx) }`, plus
+`previewOrgImport` / `commitOrgImport`, annotations
+`create | link-match | name-match | matched-soft-deleted | conflict`, a
+`checkExpectation` TOCTOU guard, and `organization_external_links` for external
+identity. `services/psa/companyImport.ts` is the reference implementation of the
+seam; `apps/web/src/components/organizations/OrgImportPreviewTable.tsx` is the
+shared preview table both importers render.
+
+## Ground truth verified 2026-08-09 (don't re-derive this)
+
+**Custom fields (#3257) — the destination exists, the import path does not.**
+
+- `apps/api/src/db/schema/customFields.ts` — `custom_field_definitions` is the
+  only table in the file. It already carries **both** `org_id` and `partner_id`
+  as nullable FKs. Columns: `name`, `fieldKey`, `type`
+  (`text|number|boolean|dropdown|date` enum), `options` jsonb, `required`,
+  `defaultValue` jsonb, `deviceTypes` text[].
+  *Check whether it has a `one_owner_chk` XOR constraint and a dual-axis RLS
+  policy — if not, it predates the #2135 playbook and this is the moment to fix it.*
+- **Values are NOT a table.** They live in `devices.customFields` — a
+  `jsonb('custom_fields').default({})` column (`db/schema/devices.ts:105`).
+  The write path (`routes/devices/customFieldValues.ts:230`) does
+  `{ ...existing, ...updates }` and writes the merged blob, so **overwrite-on-
+  rerun idempotency (#3257 requirement 4) already falls out of the storage model**.
+  A jsonb column is `excludedOpen` under the export policy — relevant if you
+  propose promoting values to a real table.
+- Routes: `routes/customFields.ts` (definitions) and
+  `routes/devices/customFieldValues.ts` (values, incl. an X-API-Key surface).
+
+**Contacts (#3258) — nothing exists.**
+
+- No `contacts` table. `organizations.billingContact` (`db/schema/orgs.ts:119`)
+  and `sites.contact` (`:151`) are bare `jsonb` columns — no shape enforced at
+  the DB layer.
+- `services/aiToolsOrgs.ts:431` — `add_contact` returns a structured
+  `CONTACT_ENTITY_UNDEFINED` "needs a product decision" note and writes nothing.
+  The tool description at `:478` advertises it as "not yet supported".
+- Every migration guide under `apps/docs/src/content/docs/migration/` currently
+  tells the reader to enter contacts by hand or keep them in the PSA. Those pages
+  need updating by whatever this design concludes.
+
+## Design questions to settle
+
+**#3258 — decide this one first.**
+
+1. Real `contacts` table (org-scoped, shape 1) with a role/type and optional site
+   association — or keep JSONB and merely allow an array?
+2. **Or read-through from the PSA**, which is usually the system of record. The
+   issue itself flags this as possibly the real answer. Phase 2 shipped the PSA
+   connection plumbing that would make it feasible; weigh it honestly rather than
+   defaulting to a table because a table is the familiar move.
+3. If a table: the full tenancy contract in the creating migration — RLS
+   policies, `CORE_ORG_CASCADE_DELETE_ORDER`, and `CORE_TENANT_EXPORT_POLICY`.
+   Contact details are personal data, so the export/erasure classification
+   matters more here than usual. This is squarely GDPR-relevant.
+4. Migration path for existing `billingContact` / `contact` JSONB values.
+5. Does `add_contact` become real as part of this, or stay stubbed?
+
+**#3257.**
+
+1. **The join key is the hard part.** The only key available across every source
+   is **hostname** — not unique across a partner, and it changes when a machine
+   is renamed. Ambiguous match: reject the row, or require an explicit `deviceId`?
+2. Import the incumbent's field *types*, or land everything as text and let the
+   operator retype? (Breeze types are `text|number|boolean|dropdown|date`.)
+3. Scope: device-level only, or also org/site-level fields? ConnectWise Automate
+   and N-central both have them; Breeze's definitions table has no site axis.
+4. This runs **after** enrollment (devices must exist), so it is inherently a
+   second pass — see `apps/docs/src/content/docs/migration/overview.mdx` Phase 4.
+   It cannot share a transaction, payload, or UI flow with the org importer.
+5. Source field surfaces are enumerated in the issue body (Datto `udf1`–`udf30`,
+   Automate EDFs, Kaseya VSA, NinjaOne, N-central, Atera).
+
+## Repo gotchas that cost time last session
+
+- **`rg -na`, never bare `grep -r`.** `services/orgImport/index.ts` contains a
+  literal NUL byte, so `grep` classifies it as binary and prints nothing — no
+  match, no warning. It held the *only* production reader of a column I was
+  about to drop, and the sweep reported zero hits.
+- **`gh pr checks` lies about Integration Tests.** Those shards are
+  `continue-on-error` on pull requests, so a genuine failure renders as a pass.
+  Read the real values:
+  `gh api repos/LanternOps/breeze/actions/runs/<id>/jobs --jq '.jobs[] | select(.conclusion!="success")'`.
+- **Stacked PRs run no CI at all.** `ci.yml` triggers on
+  `pull_request: branches: [main]`, so a PR based on a sibling branch runs only
+  the two smoke workflows — and `gh pr checks` reads green. Branch from `main`,
+  or dispatch per branch: `gh workflow run CI --ref <branch>`.
+- **`2026-08-06` is a CLOSED migration date block.** Never add `-g-`. Use a plain
+  `YYYY-MM-DD-<slug>.sql` on a later date — today's date already sorts last,
+  which is the property you actually want.
+- Issue state lags the code on this epic. `git ls-tree -r --name-only origin/main | rg <thing>`
+  is the reliable check.
+- `pnpm` is unusable on this machine (Node 20 vs the required 22) — run
+  package-local `vitest` / `tsc` directly; the api `tsc` needs a larger heap.
+- Cap concurrent subagents at 2–3. Twelve parallel `tsc`/`vitest` runs crashed
+  the session twice.
+
+## Suggested shape for the session
+
+1. Read both issue bodies in full (`gh issue view 3257` / `3258`) — they contain
+   source-by-source field tables not reproduced here.
+2. Settle #3258's question 2 (local table vs PSA read-through) **before**
+   designing either doc. Form a position, then have an adversarial subagent try
+   to refute it. If the two disagree, weigh it on the merits and surface the
+   disagreement to the user with a recommendation rather than silently picking.
+3. Write both design docs, then run one adversarial review pass over them.
+4. Present the plan and the open product decisions to the user. Do not start
+   implementation without a green light.

--- a/docs/superpowers/specs/onboarding-signup/2026-08-09-custom-field-backfill-import-design.md
+++ b/docs/superpowers/specs/onboarding-signup/2026-08-09-custom-field-backfill-import-design.md
@@ -1,7 +1,7 @@
 # Custom-Field / UDF Backfill Import — Design
 
 **Date:** 2026-08-09
-**Status:** Ready for review — one decision deliberately surfaced to the user (§0)
+**Status:** Approved — all decisions settled; §0 resolved to **Option B** by the user 2026-08-09
 **Issue:** #3257 (epic #3249, Phase 3)
 **Related:** #3242 (the preview→commit pipeline this mirrors), #3258 (the other Phase-3 doc)
 
@@ -53,7 +53,7 @@ are about fixing the destination first.
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Value storage | **Promote to `device_custom_field_values`, keep `devices.custom_fields` as a trigger-maintained projection** | §0 — the flat value namespace corrupts a shipped export contract. Surfaced to the user. |
+| Value storage | **Promote to `device_custom_field_values`, keep `devices.custom_fields` as a trigger-maintained projection** | §0 — settled (Option B, 2026-08-09). The flat value namespace corrupts a shipped export contract. |
 | Destination hardening | **Four prerequisites, before any importer** | §2. Uniqueness, XOR, partner-wide gate, type validation. |
 | Mapping targets | **Custom fields *and* first-class columns (`device_warranty`)** | §3. Warranty expiry is the issue's headline field and already has a better home. |
 | Join key | **`deviceId` → serial → hostname, org-scoped, never guess** | §4 |
@@ -67,9 +67,9 @@ are about fixing the destination first.
 
 ## 0. Decision — where values live
 
-**This is the call I am surfacing rather than settling.** The issue reads as an import
-feature; it is actually a storage-model question, and answering it wrongly is the
-expensive outcome.
+**Settled 2026-08-09: Option B.** The issue reads as an import feature; it is actually a
+storage-model question, and answering it wrongly is the expensive outcome. Option A is
+recorded below as the rejected alternative.
 
 ### The problem with the current model
 
@@ -103,7 +103,7 @@ and refuses the row. Residual risk: the hazard remains open on the plain API (wh
 such check), the export gap stays (fixable — see below), and every `custom.<key>` filter
 stays unindexed as volume grows 100×.
 
-### Option B — `device_custom_field_values` + a trigger-maintained jsonb projection — **recommended**
+### Option B — `device_custom_field_values` + a trigger-maintained jsonb projection — CHOSEN
 
 A real values table keyed by `definition_id`, with `devices.custom_fields` kept as a
 derived projection so existing readers do not change.
@@ -147,14 +147,18 @@ has a `specific` escape hatch already used twice (registry `:119`, `:255`). So t
 is fixable under Option A too. It is a supporting argument for B, not a decisive one — the
 decisive argument is the export-contract corruption above.
 
-### Recommendation
+### Decision
 
-**Option B, sequenced as a prerequisite phase (3a) ahead of the importer (3b).** The reason
-is CLAUDE.md's own rule: retrofitting the storage model *after* backfilling 300k values is
-strictly worse than doing it before, and this is a correctness argument about shipped
-behaviour rather than a taste argument about schema style. If the user prefers to keep
-scope tight, Option A plus the preview-time collision refusal is a legitimate answer — it
-should be chosen deliberately, with the residual risk named.
+**Option B, sequenced as a prerequisite phase (3a) ahead of the importer (3b)** — chosen by
+the user on 2026-08-09. The reason is CLAUDE.md's own rule: retrofitting the storage model
+*after* backfilling 300k values is strictly worse than doing it before, and this is a
+correctness argument about shipped behaviour rather than a taste argument about schema style.
+
+Option A was declined. It remains the fallback if phase 3a proves larger than estimated, but
+taking it would mean accepting that the cross-axis collision stays reachable through the
+plain API, that `custom.<key>` filters stay unindexed at 100× volume, and that the
+tenant-export gap is closed by the `openContainerReviewed` escape hatch rather than by
+having queryable data.
 
 ---
 
@@ -502,10 +506,10 @@ different type is a conflict, never a silent change.
 - **Warranty target**: an imported `warranty_end_date` makes `warrantyAlertEvaluator` fire and
   appears in `routes/partnerApi/inventory.ts`; a `data_source='provider'` row is not clobbered
   without opt-in.
-- **Contracts** (Option B): RLS coverage, org cascade, device cascade
+- **Contracts**: RLS coverage, org cascade, device cascade
   (`CORE_DEVICE_CASCADE_DELETE_TABLES` **and** `CORE_DEVICE_ORG_DENORMALIZED_TABLES`, since the
   table carries `device_id` and a denormalized `org_id`), export policy, erasure roundtrip.
-- **Projection** (Option B): a value write updates both the table and `devices.custom_fields`,
+- **Projection**: a value write updates both the table and `devices.custom_fields`,
   and still bumps `partner_export_updated_at`.
 
 ---
@@ -517,7 +521,7 @@ different type is a conflict, never a silent change.
 | **Org/site-level custom fields** | No site axis on definitions, no value home. §8. | Not filed |
 | **Incumbent identity at enrollment** so late-enrolling devices get backfilled on arrival | Needs an enrollment-path change; pattern exists (`matchInviteOnEnrollment.ts`). §4. | Not filed |
 | **Dynamic-group recompute after import** | The whole device-change pipeline is unwired. §9. | Not filed |
-| **Per-key expression indexes** (Option A only) | Unnecessary under Option B. | Not filed |
+| **Per-key expression indexes** | Moot — Option B replaces the scan with a B-tree. | Not filed |
 | **More first-class mapping targets** (asset tag → a real column, primary user → `devices.last_user`) | Additive once §3's target model exists. | Not filed |
 
 ### Explicitly not planned

--- a/docs/superpowers/specs/onboarding-signup/2026-08-09-custom-field-backfill-import-design.md
+++ b/docs/superpowers/specs/onboarding-signup/2026-08-09-custom-field-backfill-import-design.md
@@ -1,0 +1,527 @@
+# Custom-Field / UDF Backfill Import — Design
+
+**Date:** 2026-08-09
+**Status:** Ready for review — one decision deliberately surfaced to the user (§0)
+**Issue:** #3257 (epic #3249, Phase 3)
+**Related:** #3242 (the preview→commit pipeline this mirrors), #3258 (the other Phase-3 doc)
+
+## Summary
+
+Let an MSP bring their user-defined fields across when migrating — Datto `udf1`–`udf30`,
+ConnectWise Automate EDFs, Kaseya VSA custom fields, NinjaOne/N-central custom
+properties, Atera custom values. Two passes: **field-definition import** so `udf7`
+becomes a named, typed field once instead of being retyped thirty times, then
+**value backfill** joined to enrolled devices, with preview → commit and per-row match
+status.
+
+This runs after Phase 4 of a migration (devices must exist), so it cannot share a
+transaction, payload, or UI flow with the org importer.
+
+**The largest finding is that the destination is not ready.** `custom_field_definitions`
+has no uniqueness on `field_key`, no XOR constraint, no partner-wide authorization gate,
+and there is no value-vs-type validation anywhere in the product. Pouring 300k
+hand-entered values into that is how a migration turns into a support incident. §0 and §2
+are about fixing the destination first.
+
+## Context — verified 2026-08-09
+
+- **Definitions** (`db/schema/customFields.ts`) — `custom_field_definitions`, dual-axis
+  nullable `org_id`/`partner_id`, columns `name`, `field_key`, `type`
+  (`text|number|boolean|dropdown|date`), `options` jsonb, `required`, `default_value` jsonb,
+  `device_types` text[]. Dual-axis RLS shipped in `2026-06-11-i-custom-fields-dual-axis-rls.sql`;
+  registered in `DUAL_AXIS_TENANT_TABLES`, `CORE_ORG_CASCADE_DELETE_ORDER`, and
+  `CORE_TENANT_EXPORT_POLICY`.
+- **Values are not a table.** `devices.customFields` is `jsonb('custom_fields').default({})`
+  (`db/schema/devices.ts:105`). Written by `routes/devices/customFieldValues.ts` (`{...existing,
+  ...updates}`) and also by `PATCH /devices/:id` (`routes/devices/core.ts:1238-1246`).
+- **`devices.custom_fields` is `excludedOpen`** (`tenantExportPolicyRegistry.ts:140`) — values
+  are dropped from the GDPR tenant export. They *are* published through the partner API's
+  `custom-field-values` resource, so the gap is the tenant export specifically.
+- **No index of any kind on `custom_fields`.** Every `custom.<key>` filter compiles to an
+  unindexed `jsonb_extract_path_text` scan (`filterEngine.ts:181-182`). The sibling jsonb
+  column `devices.management_posture` has three expression indexes
+  (`0001-baseline.sql:9400-9414`) — someone already hit this wall next door.
+- **Join keys.** `devices.hostname` exists and is deliberately **not** unique per org
+  (`routes/agents/enrollment.ts` inserts a fresh row on hostname collision, per the #2764
+  identity design). `serial_number` lives on `device_hardware`, nullable, not unique. There is
+  **no `external_id` on devices** and no incumbent-RMM identity recorded anywhere.
+- **Migration dates:** the last shipped migration is `2026-08-18-drop-organizations-accounting-columns.sql`.
+  Today's date does **not** sort last, contrary to the Phase-3 handoff note. New migrations
+  must be dated `2026-08-19` or later or they replay out of order on a fresh database.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Value storage | **Promote to `device_custom_field_values`, keep `devices.custom_fields` as a trigger-maintained projection** | §0 — the flat value namespace corrupts a shipped export contract. Surfaced to the user. |
+| Destination hardening | **Four prerequisites, before any importer** | §2. Uniqueness, XOR, partner-wide gate, type validation. |
+| Mapping targets | **Custom fields *and* first-class columns (`device_warranty`)** | §3. Warranty expiry is the issue's headline field and already has a better home. |
+| Join key | **`deviceId` → serial → hostname, org-scoped, never guess** | §4 |
+| Request shape | **Partner-scoped, many orgs per request** | Matches `orgImport`; a Datto export is partner-wide. Safety comes from per-row authorization, not request shape. |
+| Auth | **`requireMfa()`, no `X-API-Key`, site-gated** | §5 — the existing value route bypasses both. |
+| Row cap | **1000 per request (`MAX_IMPORT_ROWS`), one transaction per org-chunk** | §6 — a per-org exclusive advisory lock is held until COMMIT. |
+| Field-key case | **snake_case only** | §7 — `assetTag` is readable but not creatable today. |
+| Scope | **Device-level only in v1** | §8 |
+
+---
+
+## 0. Decision — where values live
+
+**This is the call I am surfacing rather than settling.** The issue reads as an import
+feature; it is actually a storage-model question, and answering it wrongly is the
+expensive outcome.
+
+### The problem with the current model
+
+`devices.custom_fields` is one flat jsonb object per device, keyed by a bare string.
+Nothing in `devices.custom_fields.udf7` records *which definition* it belongs to — but the
+definition namespace is **dual-axis**. The shipped partner-export query joins them by
+string match (`routes/partnerApi/configuration.ts:427-440`, verified):
+
+```sql
+JOIN public.custom_field_definitions f
+  ON (f.org_id = eo.id OR (f.org_id IS NULL AND f.partner_id = $partnerId))
+ AND d.custom_fields ? f.field_key
+...
+md5(d.id::text || ':' || f.id::text) AS identity_hash
+```
+
+If an org-owned `udf7` and a partner-wide `udf7` both exist, this emits **two export
+records for one datum**, with two different synthetic ids (the hash includes `f.id`).
+`customFieldSource()` at `:410-425` duplicates the definitions the same way.
+
+That collision cannot be prevented by any constraint on this shape: uniqueness would have
+to span two nullable ownership columns across disjoint row sets. And the importer is
+precisely what manufactures the scenario — today essentially every custom field is
+partner-wide (§2.3), and a per-org definitions import creates org-owned rows beside them
+in bulk.
+
+### Option A — stay on jsonb, refuse collisions at preview
+
+Cheapest. The importer detects an org-owned key colliding with a visible partner-wide key
+and refuses the row. Residual risk: the hazard remains open on the plain API (which has no
+such check), the export gap stays (fixable — see below), and every `custom.<key>` filter
+stays unindexed as volume grows 100×.
+
+### Option B — `device_custom_field_values` + a trigger-maintained jsonb projection — **recommended**
+
+A real values table keyed by `definition_id`, with `devices.custom_fields` kept as a
+derived projection so existing readers do not change.
+
+```sql
+device_custom_field_values (
+  id, device_id, org_id, definition_id,
+  value_text, value_number, value_bool, value_date,
+  source, created_at, updated_at
+)
+UNIQUE (device_id, definition_id)
+```
+
+- **Correctness by construction.** A value points at exactly one definition; the export
+  join becomes a lookup and the duplicate-record defect disappears.
+- **34 of 37 consumers do not change.** A full enumeration finds 37 consumer sites, but only
+  **three** touch the jsonb in SQL — `filterEngine.ts:181-182` and
+  `partnerApi/configuration.ts:433,440`. The rest are JS reads that consume whatever the
+  row already carries: `stripSensitiveDeviceFields` echoes
+  (`routes/devices/core.ts:1009,1294,1441,1484`, `moveOrg.ts:280`, `provision.ts:367`),
+  Drizzle select projections (`core.ts:622,814`), the `resolveRemoteAccessLaunch` hand-offs
+  (`core.ts:995,1084`), plus `remoteAccessLauncher.ts:73`, `installerVariables.ts:53`,
+  `softwareDeployment.ts:300,395`, `aiToolsDevice.ts:560`, `DeviceInfoTab.tsx:1175`. The
+  projection keeps all of them, both partner-export triggers, and the MCP projection working.
+- **Indexing.** A plain B-tree on `(device_id, definition_id)` and on `value_date` replaces
+  a full scan per filter.
+- **Export.** Typed columns are `included`, closing the tenant-export gap properly.
+- **Fixes two live bugs for free:** deleting a definition currently leaves orphaned keys in
+  every device's blob (a `definition_id` FK cascades), and type validation finally has an
+  anchor.
+
+**Cost, stated honestly:** a migration with a backfill of every existing blob, a projection
+trigger (write amplification on every value change), three query rewrites, and the writer
+move. It is a prerequisite PR, not a footnote — but it is one PR, not the multi-PR project
+I first assumed.
+
+**One premise I had wrong.** I believed `excludedOpen` was absolute and therefore that the
+export gap could only be fixed by promotion. It is not: `tenantExportPolicy.ts:223-227`
+requires only `openContainerReviewed: true` to include an open container, and `tablePolicy`
+has a `specific` escape hatch already used twice (registry `:119`, `:255`). So the export gap
+is fixable under Option A too. It is a supporting argument for B, not a decisive one — the
+decisive argument is the export-contract corruption above.
+
+### Recommendation
+
+**Option B, sequenced as a prerequisite phase (3a) ahead of the importer (3b).** The reason
+is CLAUDE.md's own rule: retrofitting the storage model *after* backfilling 300k values is
+strictly worse than doing it before, and this is a correctness argument about shipped
+behaviour rather than a taste argument about schema style. If the user prefers to keep
+scope tight, Option A plus the preview-time collision refusal is a legitimate answer — it
+should be chosen deliberately, with the residual risk named.
+
+---
+
+## 1. Two passes, two route pairs
+
+Definitions and values have different tenancy, different authorization, and different
+lifecycles. They do not share an endpoint.
+
+- `POST /custom-fields/import/preview` · `POST /custom-fields/import` — **definitions**.
+  Config data; org **or** partner owned; partner-wide writes gated (§2.3).
+- `POST /devices/custom-fields/import/preview` · `POST /devices/custom-fields/import` —
+  **values**. Device data; org-scoped; device resolution and site gating (§4, §5).
+
+Name them unambiguously in code (`deviceCustomFieldImport`, not `customFieldImport`):
+`tickets.custom_fields` (`db/schema/portal.ts:74`) and the PSA/Jira `customFields`
+(`services/psa/jira.ts:26`) are unrelated namesakes.
+
+---
+
+## 2. Harden the destination first
+
+All four are missing today, and all four are load-bearing for a bulk import.
+
+### 2.1 Uniqueness on `field_key` — the definitions import has no idempotency key
+
+`routes/customFields.ts` POST does no pre-insert `SELECT` and no uniqueness check; the web
+create modal (`CustomFieldsPage.tsx`) contains zero references to `orgId`/`partnerId`/`scope`,
+so it cannot warn either. Creating "Asset Tag" twice succeeds. Re-running a definitions
+import would mint duplicate `udf7` rows without this.
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS custom_field_definitions_org_key_uniq
+  ON custom_field_definitions (org_id, field_key) WHERE org_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS custom_field_definitions_partner_key_uniq
+  ON custom_field_definitions (partner_id, field_key) WHERE partner_id IS NOT NULL;
+```
+
+**Cross-axis collision is NOT covered by these** — that is §0's whole point. Under Option B
+it stops mattering for correctness; under Option A the importer must refuse it at preview.
+
+**Existing duplicates block the index, and neither obvious cleanup is safe:**
+
+- *Delete the duplicate* — the survivor dictates the `type`. If the two disagree
+  (`text` vs `number`), every value already stored under that key is silently retyped, with
+  no value-side migration because values carry no type.
+- *Rename the duplicate* (`udf7` → `udf7_2`) — values are keyed by the string, so a rename
+  orphans every stored value instantly, and breaks consumers holding the key as
+  configuration: `remoteAccessLauncher.ts:73` (`provider.customFieldKey`, stored in partner
+  settings) and `installerVariables.ts:30,51-53` (`{{device.customField.<key>}}` on software
+  packages).
+
+**Resolution:** the migration reports duplicates rather than resolving them. It emits a
+`RAISE WARNING` with the count and the affected `(owner, field_key)` pairs per CLAUDE.md's
+row-count rule, and creates the index only when the count is zero; otherwise it fails loudly
+with the list. Cleanup is an operator decision made with knowledge of which duplicate carries
+values — not something a migration should guess. (`CREATE INDEX CONCURRENTLY` is available
+if needed — `autoMigrate.ts:572-606` has a documented non-transactional path — but the data,
+not the locking, is the obstacle here.)
+
+### 2.2 XOR constraint
+
+`(NULL, NULL)` and `(set, set)` are both structurally legal today. A `(NULL, NULL)` row is
+invisible to every non-system caller (`breeze_has_org_access(NULL)` is FALSE) **and survives
+org cascade forever**, since the cascade deletes by `org_id` — a latent GDPR orphan.
+
+Existing data almost certainly conforms: `routes/customFields.ts` POST rejects `(set, set)`
+with a 400 and makes `(NULL, NULL)` unreachable on every scope. Add the constraint with a
+row-count report anyway, copying `2026-07-01-alert-rules-partner-ownership.sql:38-48` — the
+guarded `DO $$ … pg_constraint` existence check plus
+`CHECK ((org_id IS NULL) <> (partner_id IS NULL))`, the form seventeen tables already use.
+
+### 2.3 The partner-wide gate — a behavioural change, not just hardening
+
+`routes/customFields.ts` create/update/delete carry `requireMfa()` and permission checks but
+**no `canManagePartnerWidePolicies`** — the same gap as #3262 for scripts. A bulk import
+creating partner-wide definitions is the widest write in the product, so this must land
+before the importer, not after.
+
+But it cannot land alone. Because the web create modal never sends ownership, partner-scoped
+users fall through to `partnerId = auth.partnerId` with `org_id` null — so **in practice
+essentially every custom field an MSP has today is partner-wide**. `canManagePartnerWidePolicies`
+requires `partnerOrgAccess === 'all'` (`services/partnerWideAccess.ts:25-29`), so adding it
+outright stops ordinary techs with `orgAccess='selected'` from doing what they do today,
+through the ordinary UI. A bare 403 is a support ticket, not hardening.
+
+Ship it with the full #2135 playbook step 6: a create-only `ownerScope` selector and an
+"All orgs" badge (pattern: `components/software/PolicyForm.tsx`), plus a
+`customFieldDefinitionsPartnerRls.integration.test.ts` suite.
+
+### 2.4 Value-vs-declared-type validation — a security control, not a nicety
+
+Nothing anywhere validates a value against its definition. `customFieldValueSchema`
+(`customFieldValues.ts:68-75`) and `updateDeviceSchema.customFields`
+(`routes/devices/schemas.ts:104`) both accept an unconstrained
+`Record<string, string|number|boolean|null>`. No code branches on `type`; `options.choices`,
+`min`/`max`, `required`, and "does this `fieldKey` exist at all" are unenforced.
+
+This matters more than it looks, because custom-field values are **both an execution sink
+and a targeting control**:
+
+- `installerVariables.ts:30,51-53` substitutes `{{device.customField.<key>}}` into installer
+  command lines, which flow through `softwareDeployment.ts` → `queueCommand` →
+  `sendCommandToAgent` and execute on the endpoint.
+- `filterEngine`'s `custom.<key>` path feeds `services/groupMembership.ts` **and**
+  `services/deploymentTargetResolver.ts`, consumed by `deploymentEngine.ts`, `routes/software.ts`
+  and `services/automationRuntime.ts` — so values **select which devices receive software
+  installs and automation runs.**
+
+Bulk-loading 300k unvalidated strings from a competitor's export into that surface is a mass
+injection *and* mass mis-targeting vector.
+
+A shared `validateCustomFieldValue(definition, value)` must therefore be applied to **the two
+existing write paths as well as the importer** — otherwise the importer is validated and the
+trivially scriptable API-key path beside it is not.
+
+---
+
+## 3. Mapping targets — not every UDF belongs in a custom field
+
+The issue names warranty expiry first. Breeze already has `device_warranty`
+(`db/schema/warranty.ts:28-51`): one row per device (`deviceIdIdx` unique), typed
+`warranty_start_date` / `warranty_end_date`, a `status` enum, an index on the end date, and a
+`data_source` column defaulting to `'provider'` — an `'import'` source is an already-designed
+extension point. It is consumed by `warrantyAlertEvaluator.ts`, `warrantySync.ts`,
+`routes/devices/warranty.ts`, `routes/partnerApi/inventory.ts` and the Dell/Lenovo/HP
+integrations. `filterEngine` has no warranty field at all.
+
+So importing warranty expiry into a custom field ships the flagship use case **inert**: no
+alert fires, the warranty dashboard and partner inventory export stay empty, and it is not
+even filterable as a first-class field.
+
+The importer therefore takes a **mapping target** per column, not a field key:
+
+```ts
+type MappingTarget =
+  | { kind: 'customField'; fieldKey: string }
+  | { kind: 'warranty'; field: 'warrantyEndDate' | 'warrantyStartDate' | 'manufacturer' };
+```
+
+v1 supports `customField` and `warranty` (writing `data_source: 'import'`, never clobbering a
+row whose `data_source = 'provider'` without an explicit opt-in — a provider lookup is more
+trustworthy than a hand-typed CSV). Other first-class targets are additive later.
+
+---
+
+## 4. Resolving a row to a device
+
+Resolution order, **always within one organization**, first hit wins:
+
+1. **explicit `deviceId`** — authoritative.
+2. **`serialNumber`** → `device_hardware.serial_number`.
+3. **`hostname`** → `devices.hostname`, case-insensitive.
+
+0 matches → `not-found`. More than 1 → `ambiguous`. **Never guess.**
+
+**Junk serials are already in the database.** The denylist does not need inventing — the agent
+has one: `cleanHardwareIdentityValue()` (`agent/internal/collectors/hardware.go:156-190`)
+covering `"default string"`, `"none"`, `"system serial number"`, `"to be filled by"`, `"o.e.m"`,
+all-zeros. But it is applied **only on Windows** (`hardware_windows.go:136`); Linux
+(`hardware_linux.go:35`) and macOS (`hardware_darwin.go:46`) write raw DMI/IOKit values
+through. So: port that exact list to a shared TS constant rather than authoring a second,
+divergent one, and **apply it to the DB side of the join as well as the CSV side** — otherwise
+every Linux box reporting `Default string` collapses into one giant ambiguous match group.
+
+**Hostname ambiguity will be common, not rare.** `devices.hostname` is not unique per org by
+design, and `possible_replacement_of_device_id` (`db/schema/devices.ts:159`) plus the
+enrollment path exist because re-imaged and replaced machines legitimately produce several
+rows — exactly the machines an MSP most wants backfilled. Rather than dead-ending those rows,
+preview surfaces the candidates ranked by the collision priority chain enrollment already uses
+(token-authenticated > online > non-decommissioned > oldest, `enrollment.ts:514-518`) and the
+operator acknowledges one. The rule stays "never auto-pick"; the UI stops being a dead end.
+
+**Devices that enroll after the backfill are stranded.** There is no `external_id` on `devices`
+and no incumbent-RMM identity recorded at enrollment, so a late device has no re-match key.
+Mitigation in v1 is that the import is cheap to re-run (idempotent). Recording an incumbent
+identity at enrollment so backfill can be applied on arrival — the pattern
+`modules/mcpInvites/matchInviteOnEnrollment.ts:28-54` uses for `deployment_invites` — is
+deferred and worth filing.
+
+---
+
+## 5. Authorization and tenant isolation
+
+Both value routes: `requireScope('partner','system')` + `requireOrgWrite` + `requireMfa()`,
+matching the org importer (`routes/orgs.ts:1386,1399`). Partner-scoped and multi-org per
+request: a Datto or Automate export is inherently partner-wide with a company column, and
+forcing one CSV per org would mean 200 uploads for a mid-size MSP with no safety return.
+
+**Safety comes from per-row authorization, not from the request shape — and RLS is not the
+backstop here.** Resolving devices across orgs requires system DB context, and
+`breeze_has_org_access` short-circuits to `TRUE` for system scope
+(`0001-baseline.sql:1663-1671`). Every isolation guarantee on this path is app-layer. Therefore:
+
+- every resolved device is re-checked against the caller's accessible orgs, per row;
+- **site restrictions apply.** `allowedSiteIds` is populated only on the org axis
+  (`services/permissions.ts:171`; the partner axis at `:182-185` never sets it), so a
+  site-restricted org user must be gated with `canAccessSite(perms, device.siteId)`
+  (`services/permissions.ts`, re-exported via `middleware/auth.ts:4`) — it returns a plain
+  boolean, so the caller must fail closed on `false`;
+- **the importer does not accept `X-API-Key`.** The existing value route's `dualAuth` applies
+  `requireMfa` only on the JWT branch and deliberately skips the site allowlist for API keys.
+  A bulk backfill is exactly the operation that should require MFA and honour site limits;
+- do **not** reuse `getDeviceWithOrgCheck` (`routes/devices/helpers.ts:83-113`) naively — it
+  selects with no org predicate and checks in JS afterward, which is fine under RLS and is the
+  *only* check under a system context;
+- a cross-partner forge integration test proves it, rather than an appeal to RLS.
+
+---
+
+## 6. Batching — the constraint that sets the row cap
+
+`breeze_partner_export_devices_update()` is an `AFTER UPDATE … FOR EACH STATEMENT` trigger on
+`devices` whose change tuple **includes `custom_fields`** (`2026-07-18-partner-export-org-locks.sql:320-336`).
+On any custom-field change it calls `breeze_partner_export_lock_orgs_exclusive(org_ids)` →
+`pg_advisory_xact_lock(1000201, hashtext(org_id))` (`:339`, `:147`) — an **exclusive,
+transaction-scoped advisory lock per org, released only at COMMIT** — then issues a second
+`UPDATE devices`. A second statement trigger,
+`breeze_partner_export_z_custom_values_update` (`2026-07-31-device-custom-value-move-owners.sql:44-49`),
+takes partner-exclusive and org locks on the same condition.
+
+A single large transaction therefore holds exclusive locks on every touched org for its whole
+duration, blocking heartbeats, enrollment, and every other device write for those orgs.
+
+So: **1000 rows per request** (matching `MAX_IMPORT_ROWS`, `orgImport/index.ts:47` — not the
+5000 an earlier draft proposed), and commit **one transaction per org-chunk** within the
+request, never one transaction for the whole import. Chunks are independent and idempotent, so
+the web UI chunks a large file and reports cumulative progress. Under Option B the projection
+trigger keeps the same locks in play, so this holds either way.
+
+---
+
+## 7. Field keys, reserved names, and preview semantics
+
+**snake_case only.** `createCustomFieldSchema.fieldKey` enforces `/^[a-z][a-z0-9_]*$/` and
+`CUSTOM_FIELD_KEY_PATTERN` (`filterEngine.ts:43`) is the same, so a camelCase key can be *read*
+but never created or filtered. Commit to snake_case explicitly.
+
+**`asset_tag` is a reserved key with a live consumer.** `routes/partnerApi/devices.ts:123-125`
+derives `stableIdentifiers.assetTag` from `['assetTag','asset_tag']`, and likewise
+`inventoryId`/`externalId`. Asset tag is one of the five fields the issue names. Decision:
+importing to `asset_tag` **does** populate the partner-API `stableIdentifiers` contract, and
+that is intended — but the preview must say so on the row, because it silently changes a
+partner-integration identity field fleet-wide. The importer warns on any mapping to
+`asset_tag`, `inventory_id`, or `external_id`.
+
+**Preview → commit** mirrors `orgImport` exactly, including TOCTOU re-derivation
+(`checkExpectation`, `orgImport/index.ts:407-448`): commit re-derives every annotation against
+fresh state and rejects any row whose annotation changed since preview, with identity pinning
+so an acknowledgement cannot transfer to a different device. Annotations:
+
+`matched | ambiguous | not-found | no-definition | type-error | reserved-key | already-set`
+
+Only `matched` commits. `ambiguous` commits only with an acknowledged `deviceId`.
+
+**Idempotency** is overwrite-on-rerun: under Option A the jsonb merge already gives it; under
+Option B the `UNIQUE (device_id, definition_id)` upsert does.
+
+**Statefulness:** the flow is stateless with a client-held acknowledgement, exactly like
+`orgImport` (which writes audits only, `services/orgImport/audit.ts`). If a persisted import-job
+record is added later it will carry `org_id`, and it must then land in
+`CORE_ORG_CASCADE_DELETE_ORDER`, `CORE_TENANT_EXPORT_POLICY`, and RLS policies in the same PR —
+the contract CLAUDE.md records as having shipped broken five times.
+
+---
+
+## 8. Scope — device-level only in v1
+
+Automate and N-central both carry org/site-level custom fields, and the issue names them. They
+are deferred because there is genuinely nowhere to put them: `custom_field_definitions` has no
+site axis, and organizations/sites carry only a generic `settings` jsonb with no value home.
+Adding both is a second data-model change and belongs in its own issue.
+
+This is a narrower gap than it looks now that §3 exists: the most valuable org/site-level fields
+in practice (contract reference, account manager) are closer to contact and contract data —
+which #3258 and the existing contracts module already model — than to device UDFs.
+
+---
+
+## 9. Known-inert surfaces to flag, not fix
+
+After a 300k-value import, **no dynamic group re-evaluates**, for two independent reasons:
+
+1. `events/deviceEvents.ts:114` maps `customFields → 'custom'`, while `filterEngine.ts:685-687`
+   records the verbatim `custom.<key>`. The group lookup is an array overlap
+   (`deviceEvents.ts:78`), and `'custom'` never overlaps `'custom.warranty_expiry'`.
+2. `initializeDeviceEventHandlers` (`deviceEvents.ts:170`) has **no caller anywhere** in
+   `apps/api/src`; `emitDeviceChange` / `onDeviceChange` are never called outside their own file.
+   The whole device-change → `updateDeviceMemberships` pipeline is unwired.
+
+This is pre-existing and out of scope, but it must be stated: without a post-commit group
+recompute, imported values do not affect targeting until something else touches the device.
+File it.
+
+Two more worth one line each so they are decisions rather than discoveries:
+
+- **MCP/AI exposure.** `customFields` is in `SAFE_DEVICE_RESOURCE_FIELDS` (`mcpServer.ts:1875`),
+  so every imported value is exposed to the `breeze://devices/{id}` MCP resource on landing.
+- **Secret-scanning at volume.** `custom-field-values` is classified `'customer-authored'`
+  (`partnerApi/exportSafety.classification.ts:46`). A competitor's UDF dump is a plausible way
+  for credentials to arrive in bulk into a store whose own route header warns it is
+  "NOT A SECRETS STORE". Confirm the heuristic does not false-positive at volume and block a
+  partner export.
+
+---
+
+## 10. Web UI
+
+A "Backfill custom fields" utility beside the device list, modelled on
+`components/organizations/BulkOrgImport.tsx`: drag-drop CSV → client-side parse
+(`lib/csvParse.ts`) → column mapping (each column choosing a **mapping target** per §3, plus the
+join-key column) → preview table with per-row status badges → commit in chunks with progress.
+
+`ambiguous` rows expand to show the candidate devices ranked per §4 and require an explicit
+pick; select-all spans only `matched`, matching the existing guard that a bulk toggle must never
+opt hundreds of rows into a fuzzy match. Results surface through `runAction` including partial
+success.
+
+A **definitions** import step precedes it in the same utility: upload the incumbent's field
+list, choose org-wide or partner-wide ownership (gated per §2.3), preview `create` /
+`already-exists` / `type-conflict` — `type` is immutable on update today, so a re-import with a
+different type is a conflict, never a silent change.
+
+---
+
+## 11. Testing
+
+- **Resolution**: explicit id wins; serial beats hostname; junk serials excluded on **both**
+  sides of the join; hostname collision yields ranked candidates and refuses to auto-pick;
+  cross-org hostname collision never resolves outside the caller's orgs.
+- **Isolation**: a cross-partner forge under system DB context is rejected by the app layer —
+  the test must not rely on RLS, which returns TRUE in system scope.
+- **Site gating**: a site-restricted org user cannot backfill a device outside their sites.
+- **Auth**: `X-API-Key` is rejected on both import routes; MFA required.
+- **Validation**: a `number` field rejects `"abc"`; a `dropdown` rejects a value outside
+  `options.choices`; an unknown `fieldKey` annotates `no-definition`; and the same validation
+  applies to `PATCH /devices/:id/custom-fields` and `PATCH /devices/:id`.
+- **Idempotency**: re-running an identical import changes nothing and reports every row as
+  `already-set`.
+- **Batching**: an import spanning three orgs commits three transactions, and no transaction
+  spans more than one org's advisory lock.
+- **Prerequisites**: the duplicate-`field_key` migration fails loudly with a count when
+  duplicates exist and is a no-op when they do not; the XOR constraint rejects `(NULL,NULL)` and
+  `(set,set)`; a tech with `orgAccess='selected'` cannot create a partner-wide definition and
+  the UI hides the option.
+- **Warranty target**: an imported `warranty_end_date` makes `warrantyAlertEvaluator` fire and
+  appears in `routes/partnerApi/inventory.ts`; a `data_source='provider'` row is not clobbered
+  without opt-in.
+- **Contracts** (Option B): RLS coverage, org cascade, device cascade
+  (`CORE_DEVICE_CASCADE_DELETE_TABLES` **and** `CORE_DEVICE_ORG_DENORMALIZED_TABLES`, since the
+  table carries `device_id` and a denormalized `org_id`), export policy, erasure roundtrip.
+- **Projection** (Option B): a value write updates both the table and `devices.custom_fields`,
+  and still bumps `partner_export_updated_at`.
+
+---
+
+## Deferred
+
+| Item | Why not now | Tracked by |
+|---|---|---|
+| **Org/site-level custom fields** | No site axis on definitions, no value home. §8. | Not filed |
+| **Incumbent identity at enrollment** so late-enrolling devices get backfilled on arrival | Needs an enrollment-path change; pattern exists (`matchInviteOnEnrollment.ts`). §4. | Not filed |
+| **Dynamic-group recompute after import** | The whole device-change pipeline is unwired. §9. | Not filed |
+| **Per-key expression indexes** (Option A only) | Unnecessary under Option B. | Not filed |
+| **More first-class mapping targets** (asset tag → a real column, primary user → `devices.last_user`) | Additive once §3's target model exists. | Not filed |
+
+### Explicitly not planned
+
+- **Importing values for devices that do not exist.** Devices arrive by enrollment; a value with
+  no device is not data, it is a pending join with no expiry.
+- **Changing a definition's `type` on re-import.** Immutable today; a conflict, not a silent cast.

--- a/docs/superpowers/specs/onboarding-signup/2026-08-09-organization-contacts-design.md
+++ b/docs/superpowers/specs/onboarding-signup/2026-08-09-organization-contacts-design.md
@@ -1,7 +1,7 @@
 # First-Class Organization Contacts — Design
 
 **Date:** 2026-08-09
-**Status:** Ready for review — one decision deliberately surfaced to the user (§0.2)
+**Status:** Approved — all decisions settled; §0.2 resolved by the user 2026-08-09
 **Issue:** #3258 (epic #3249, Phase 3)
 **Related:** #3242 (org import pipeline this reuses), #3257 (the other Phase-3 doc)
 
@@ -52,7 +52,7 @@ by dual-write. §2 is the reason, and it is the single most important section he
 | Decision | Choice | Rationale |
 |---|---|---|
 | Ownership model | **Local table; PSA/RMM/accounting are import sources** | §0.1 — no PSA adapter has any contact capability at all. |
-| Person record | **New `contacts`; `portal_users` becomes a login attached to one** | §0.2 — the contested call, surfaced to the user. |
+| Person record | **New `contacts`; `portal_users` becomes a login attached to one** | §0.2 — settled by the user 2026-08-09 over the cheaper `portal_users` extension. |
 | Tenancy shape | **Shape 1, `org_id NOT NULL`** | A contact is customer data, not config/policy. #2135's partner-wide default targets policy tables; the partner-side "person" is `users`. |
 | Site association | **Nullable `site_id`, composite FK `(site_id, org_id) → sites(id, org_id)`** | `sites_id_org_id_uniq` already exists (`2026-07-23-partner-export-material-state-hardening.sql:39`), so cross-org site pinning is unrepresentable. |
 | Re-import identity | **`contact_external_links`, unique `(org_id, system, external_id)`** | §1.2 — email is not a safe unique key, and emailless contacts are exactly the no-natural-key case the link pattern exists for. |
@@ -105,11 +105,12 @@ shape the epic already chose for organizations — and that drift is not current
 possible anyway: there is no PSA sync worker (`POST /psa/connections/:id/sync` is a
 501 stub with nothing consuming it). Sourcing is one-shot import, exactly like orgs.
 
-### 0.2 Contested — new `contacts` table vs. extending `portal_users`
+### 0.2 Settled — new `contacts` table, with `portal_users` linked to it
 
-**This is the one call I am surfacing rather than settling silently**, because an
-adversarial review made a strong case against my position and it is expensive to
-reverse either way.
+**Settled by the user on 2026-08-09**, in favour of the new table. This was the closest
+call in the document: an adversarial review made a strong case for extending
+`portal_users` instead, and that case is recorded below in full because it is the thing
+to re-read first if this design ever feels wrong.
 
 **The case for extending `portal_users`** (`db/schema/portal.ts:34-56`) is real:
 
@@ -154,9 +155,13 @@ To make that true rather than aspirational, this phase must also:
 
 Step 3 is not optional. Without it inbound email keeps minting people in the other
 table and "who do I email" is permanently split across two — precisely the objection
-that makes this decision close. If the user prefers the cheaper path, extending
-`portal_users` is a legitimate answer and §1 collapses to a column-addition migration;
-it should be chosen deliberately, not by default.
+that makes this decision close, so leaving it undone would concede the argument.
+
+**The rejected alternative, recorded:** extending `portal_users` would have collapsed §1
+to a column-addition migration and reused contracts that are already paid for. It was
+declined because a contact and a portal login are different things at different
+cardinalities, and merging them would put every imported contact on the portal
+user-management screen. Revisit only with that trade-off back in hand.
 
 ---
 
@@ -387,7 +392,7 @@ Same migration, every cleanup statement reporting its row count per CLAUDE.md:
    `site_id` set, `roles = '{site}'`, `is_primary = true`.
 2. **From `organizations.billing_contact`** → one contact per org with a non-empty blob,
    `site_id NULL`, `roles = '{billing}'`, `is_primary = true`.
-3. **From `portal_users`** (only if §0.2 is accepted) → one contact per portal user,
+3. **From `portal_users`** → one contact per portal user,
    linked via the new `portal_users.contact_id`.
 
 Blobs that are `NULL`, `'{}'`, or carry no `name`/`email`/`phone` are skipped — they are

--- a/docs/superpowers/specs/onboarding-signup/2026-08-09-organization-contacts-design.md
+++ b/docs/superpowers/specs/onboarding-signup/2026-08-09-organization-contacts-design.md
@@ -1,0 +1,537 @@
+# First-Class Organization Contacts — Design
+
+**Date:** 2026-08-09
+**Status:** Ready for review — one decision deliberately surfaced to the user (§0.2)
+**Issue:** #3258 (epic #3249, Phase 3)
+**Related:** #3242 (org import pipeline this reuses), #3257 (the other Phase-3 doc)
+
+## Summary
+
+Give Breeze a real contact record, so an MSP migrating off Datto RMM / Automate /
+NinjaOne / Atera / Syncro can bring their customers' people with them, and so
+"who do I tell" stops being a free-text string in a jsonb bag.
+
+Adds `contacts` (org-scoped, RLS shape 1) and `contact_external_links` (re-import
+identity, mirroring `organization_external_links`), plus a preview→commit importer
+modelled on the shipped `orgImport` pipeline.
+
+**The existing `organizations.billing_contact` and `sites.contact` jsonb columns
+are NOT dropped, now or later.** They become a compatibility projection maintained
+by dual-write. §2 is the reason, and it is the single most important section here.
+
+## Context — verified 2026-08-09
+
+- **No `contacts` table exists.** `organizations.billingContact` (`db/schema/orgs.ts:118`)
+  and `sites.contact` (`:145`) are bare nullable `jsonb` — no `$type<>()`, no default,
+  no DB-layer shape.
+- **Validation is inconsistent and weakest where it matters.** `sites.contact` has a
+  real route-layer shape (`siteContactSchema`, `routes/orgs.ts:215-225`, `.passthrough()`),
+  but org create/PATCH validate `billingContact` with **`z.any()`** (`routes/orgs.ts:187`).
+  `packages/shared/src/validators/index.ts:110,117` types both as
+  `z.record(z.string(), z.unknown())`. There is no shared `Contact` type.
+- **`add_contact` is a stub.** `services/aiToolsOrgs.ts:423-437` returns
+  `CONTACT_ENTITY_UNDEFINED` guidance and writes nothing; the tool description
+  (`:477`) advertises it as "not yet supported" while the input schema (`:488-492`)
+  documents `orgId`/`email` params the handler ignores.
+- **Contact PII is silently dropped from tenant export.** Both jsonb columns are
+  bucketed `excludedOpen` (`tenantExportPolicyRegistry.ts:281,325`) — while the
+  *structured* `billing_address_line1…country` columns on the same `organizations`
+  row are `included` (`:320`). The exclusion carries no sensitivity rationale; it is
+  purely the blanket "open container" rule.
+- **QuickBooks is already a contact source.** `quickbooksCustomerImport.ts:143`
+  emits `contact: {name,email,phone}` into `orgImport`, landing at
+  `orgImport/index.ts:729`. Contacts are not a greenfield import problem.
+- **Migration date ordering:** the last shipped migration is
+  `2026-08-18-drop-organizations-accounting-columns.sql`. Today's date does **not**
+  sort last in this repo (contrary to the Phase-3 handoff note), so a new migration
+  must be dated after 2026-08-18 or it replays in a different position on a fresh
+  database than on an existing one.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Ownership model | **Local table; PSA/RMM/accounting are import sources** | §0.1 — no PSA adapter has any contact capability at all. |
+| Person record | **New `contacts`; `portal_users` becomes a login attached to one** | §0.2 — the contested call, surfaced to the user. |
+| Tenancy shape | **Shape 1, `org_id NOT NULL`** | A contact is customer data, not config/policy. #2135's partner-wide default targets policy tables; the partner-side "person" is `users`. |
+| Site association | **Nullable `site_id`, composite FK `(site_id, org_id) → sites(id, org_id)`** | `sites_id_org_id_uniq` already exists (`2026-07-23-partner-export-material-state-hardening.sql:39`), so cross-org site pinning is unrepresentable. |
+| Re-import identity | **`contact_external_links`, unique `(org_id, system, external_id)`** | §1.2 — email is not a safe unique key, and emailless contacts are exactly the no-natural-key case the link pattern exists for. |
+| Email | **Indexed, NOT unique** | Shared mailboxes (`info@`, `accounts@`) are one address for several real people. |
+| Legacy jsonb | **Kept forever as a dual-written projection** | §2 — three separate shipped contracts depend on `sites.contact` existing. |
+| Role primacy | **Single `is_primary` "headline contact"; per-role primacy deferred** | §1.3 — honest about what this is and is not. |
+| Open containers | **No `json`/`jsonb`/`bytea` column on either table** | Would be `excludedOpen` and drop straight back out of tenant export. |
+
+---
+
+## 0. Decisions
+
+### 0.1 Settled — a local table, not PSA read-through
+
+Issue #3258 asks whether the PSA, as the usual system of record, should own contacts
+via read-through. **It should not**, and the reason is not a preference:
+
+**There is no PSA contact capability to read through.** `PSAProvider`
+(`services/psa/types.ts`) declares exactly six methods — `testConnection`,
+`getCompanies`, `createTicket`, `updateTicket`, `getTicket`, `syncTickets`. A sweep
+for `contact` across the entire `services/psa/` directory returns **one** hit: a
+comment in `companyImport.ts:29` recording that `PSACompany` carries no contact.
+Read-through means designing and building a new capability across six adapters
+(ConnectWise, Autotask, ServiceNow, Freshservice, Zendesk, and Jira — which has no
+company concept at all), with pagination and SSRF-safe walking, before a single
+contact appears in the UI. It is the more expensive option, not the cheaper one.
+
+Three further reasons, in decreasing order of force:
+
+1. **The migration sources are RMMs, not PSAs.** This epic exists to get data out of
+   Datto RMM, Automate, NinjaOne, Atera and Syncro. Read-through from a *PSA* cannot
+   import a *Datto* contact export. It would leave #3258's originating problem unsolved.
+2. **Not every Breeze customer has a PSA.** `psa_connections` rows are optional, and
+   CLAUDE.md names internal IT teams as a target alongside MSPs. Read-through delivers
+   them nothing.
+3. **Read-through has no local id.** `tickets.submitted_by` and
+   `ticket_comments.portal_user_id` are FKs to a local person row today. Anything that
+   later wants to reference a contact — an escalation step, a portal login, a ticket
+   requester — needs a stable local id that a remote lookup cannot provide.
+
+**A claim I withdrew.** An earlier draft argued that read-through would couple alert
+delivery to PSA availability. That is not true today: no notification code reads any
+contact field. Alert recipients resolve from `users` and from free-text strings in
+`notification_channels.config`. The coupling argument is about a future that does not
+exist yet, and the case does not need it.
+
+**Honest counter-argument.** The PSA genuinely is the system of record, and a local
+copy drifts. The answer is that this is replication with local identity — the same
+shape the epic already chose for organizations — and that drift is not currently
+possible anyway: there is no PSA sync worker (`POST /psa/connections/:id/sync` is a
+501 stub with nothing consuming it). Sourcing is one-shot import, exactly like orgs.
+
+### 0.2 Contested — new `contacts` table vs. extending `portal_users`
+
+**This is the one call I am surfacing rather than settling silently**, because an
+adversarial review made a strong case against my position and it is expensive to
+reverse either way.
+
+**The case for extending `portal_users`** (`db/schema/portal.ts:34-56`) is real:
+
+- It is *already* the de-facto contact store. `services/inboundEmail/resolveOrg.ts:44-73`
+  is named `findOrCreateEmailContact`, its docstring says it creates "a password-less
+  **contact** for attribution", and the column that governs it is literally
+  `customer_email_domains.auto_create_contact` (`db/schema/emailInbound.ts:55`).
+- It already has `org_id NOT NULL` (RLS shape 1), nullable `password_hash`,
+  non-unique `email`, `name`, and `receive_notifications`.
+- **Every contract a new table would have to re-earn is already paid**: it is in
+  `CORE_ORG_CASCADE_DELETE_ORDER` (`tenantCascade.ts:262`) and in
+  `CORE_TENANT_EXPORT_POLICY` with `email` and `name` already in `included`
+  (`tenantExportPolicyRegistry.ts:231`) — so contact PII is *not* uniformly dropped
+  from export today, only the jsonb halves are.
+- It is already a working FK target (`tickets.submitted_by`, `ticket_comments.portal_user_id`).
+- The stub's stated reason for refusing to write it — "portal users carry user-invite
+  semantics we must not trigger" (`aiToolsOrgs.ts:424-430`) — is **factually wrong**.
+  Invite semantics live in the route (`routes/orgPortalUsers.ts:116-148`), not the
+  schema, and `resolveOrg.ts` already creates non-invite rows.
+
+**Recommendation: still build `contacts`, but link it.** The deciding argument is
+that a contact and a portal login are different cardinalities of different things,
+and the repo will keep paying for conflating them:
+
+- A contact needs `site_id`, `title`, `phone`, and `roles`; `portal_users` needs
+  `password_hash`, `entra_oid`, `auth_method`, `invited_by`, `status`. Merging gives
+  one table where half the columns are meaningless for half the rows.
+- **Backfilling a customer's 40 imported contacts into `portal_users` puts them on
+  the portal user-management screen** (`routes/orgPortalUsers.ts`), which lists that
+  table. Every existing reader would have to learn a distinction it does not have
+  today — which is the same second-order-reader trap, merely pointed the other way.
+- The industry model that every import source uses (ConnectWise, Autotask, Pax8)
+  treats the contact as the parent and portal/login access as a capability of it.
+
+So: **`contacts` is the person; `portal_users` becomes a login attached to a contact.**
+To make that true rather than aspirational, this phase must also:
+
+1. add nullable `portal_users.contact_id` FK,
+2. backfill one `contacts` row per existing `portal_users` row and link them, and
+3. **repoint `findOrCreateEmailContact` to create a `contacts` row** (creating a
+   `portal_user` only when portal access is actually granted).
+
+Step 3 is not optional. Without it inbound email keeps minting people in the other
+table and "who do I email" is permanently split across two — precisely the objection
+that makes this decision close. If the user prefers the cheaper path, extending
+`portal_users` is a legitimate answer and §1 collapses to a column-addition migration;
+it should be chosen deliberately, not by default.
+
+---
+
+## 1. Data Model
+
+Migration `apps/api/migrations/2026-08-19-contacts.sql` — hand-written, idempotent,
+no inner `BEGIN`/`COMMIT`, policies in the same file. Dated after
+`2026-08-18-drop-organizations-accounting-columns.sql` so replay order is identical
+on a fresh and an existing database.
+
+### 1.1 `contacts`
+
+```sql
+CREATE TABLE IF NOT EXISTS contacts (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id      uuid NOT NULL,
+  site_id     uuid,
+  name        varchar(255) NOT NULL,
+  email       varchar(320),
+  phone       varchar(64),
+  mobile      varchar(64),
+  title       varchar(255),
+  roles       text[] NOT NULL DEFAULT '{}',
+  is_primary  boolean NOT NULL DEFAULT false,
+  notes       text,
+  created_by  uuid,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT contacts_org_fk FOREIGN KEY (org_id)
+    REFERENCES organizations (id) ON DELETE CASCADE,
+  CONSTRAINT contacts_site_org_fk FOREIGN KEY (site_id, org_id)
+    REFERENCES sites (id, org_id) ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS contacts_id_org_id_uniq ON contacts (id, org_id);
+CREATE INDEX IF NOT EXISTS contacts_org_idx ON contacts (org_id);
+CREATE INDEX IF NOT EXISTS contacts_site_idx ON contacts (site_id) WHERE site_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS contacts_org_email_idx ON contacts (org_id, lower(email)) WHERE email IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS contacts_org_primary_uniq  ON contacts (org_id)  WHERE is_primary AND site_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS contacts_site_primary_uniq ON contacts (site_id) WHERE is_primary AND site_id IS NOT NULL;
+```
+
+Deliberate choices:
+
+- **`contacts_site_org_fk` is composite.** A site pinned from another organization is
+  unrepresentable rather than merely validated. The required unique index on
+  `sites (id, org_id)` already ships.
+- **`contacts_org_email_idx` is NOT unique.** A shared mailbox (`info@`, `accounts@`,
+  `helpdesk@`) is one address belonging to several real people at one customer, and a
+  unique constraint would make that legitimate shape unimportable. Email is a *match
+  hint* in preview (§4), never an authority.
+- **No `json`/`jsonb`/`bytea` column.** Any open container is classified `excludedOpen`
+  and would drop the row's most interesting fields straight back out of tenant export
+  — the exact defect this table exists to fix. Do not add a `metadata` jsonb later
+  without accepting that cost.
+- **`roles text[]`** rather than an enum: the vocabulary
+  (`billing | technical | escalation | admin | site | after_hours`) is validated in the
+  app layer and will grow per import source. `text[]` is export-safe; `device_types`
+  on `custom_field_definitions` is the in-repo precedent.
+
+### 1.2 `contact_external_links`
+
+```sql
+CREATE TABLE IF NOT EXISTS contact_external_links (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  contact_id  uuid NOT NULL,
+  org_id      uuid NOT NULL,
+  system      text NOT NULL,
+  external_id text NOT NULL,
+  created_by  uuid,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT contact_external_links_contact_org_fk FOREIGN KEY (contact_id, org_id)
+    REFERENCES contacts (id, org_id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS contact_external_links_uniq
+  ON contact_external_links (org_id, system, external_id);
+CREATE INDEX IF NOT EXISTS contact_external_links_contact_idx
+  ON contact_external_links (contact_id);
+```
+
+**Why a link table when I argued against one for contacts initially.** The tempting
+shortcut is to dedupe on `(org_id, lower(email))` and skip this. That fails on three
+real shapes: shared mailboxes (above), contacts with no email at all (phone-only site
+contacts are common in RMM exports), and email changes — which are identity changes
+that the repo already paid for once on `users` (`email_epoch`, `pending_email`,
+`2026-07-18-pending-email-and-verification-purpose.sql`). Records with no safe natural
+key are exactly what `organization_external_links` exists for, and re-import
+idempotency is the same requirement. Consistency with the shipped pattern is a bonus,
+not the reason.
+
+**Why the unique is `(org_id, …)` and not `(partner_id, …)` as it is for orgs.** A
+person can legitimately work for two of an MSP's customers. Partner-scoping the key
+would force those two relationships to collapse onto one row spanning two tenants —
+unrepresentable under shape 1 and wrong besides. Org-scoping yields one contact row
+per org, each linked to the same source id, which is the correct model. This is a
+deliberate divergence from `organization_external_links` and is called out so a future
+reader does not "fix" it.
+
+### 1.3 What `is_primary` is, and is not
+
+`is_primary` means **"the headline contact for this org (or this site)"** — the one the
+compat projection in §2 writes into the jsonb columns, and the one a UI shows first.
+The partial unique indexes enforce exactly one per org and one per site.
+
+It is **not** per-role primacy, and per-role primacy is a real requirement in this repo:
+`services/pax8CompanyReadiness.ts:26-42` gates ordering on a company having a primary
+**admin** *and* a primary **billing** *and* a primary **technical** contact, reading a
+`contacts[].types[] = {type, primary}` wire shape. ConnectWise and Autotask model it
+the same way.
+
+That is deferred rather than guessed at, because no consumer in this phase needs it and
+the retrofit is mechanical: a `contact_roles(contact_id, org_id, role, is_primary)` child
+table with `UNIQUE (org_id, role) WHERE is_primary`, populated by `unnest(roles)`. Do
+not widen `is_primary` to mean per-role primacy — add the child table.
+
+### 1.4 Contract registration — all in the same PR
+
+| Contract | Action | Enforced by |
+|---|---|---|
+| RLS | Both tables: shape **1**, `ENABLE` + `FORCE`, four policies `breeze_has_org_access(org_id)`, in the creating migration. Auto-discovered from the `org_id` column, so **no allowlist entry**. Copy `device_mtls_certificates` (`rls-coverage.integration.test.ts:3675-3690`). Must **not** be added to `DUAL_AXIS_TENANT_TABLES` — that asserts a partner branch these tables do not have. | `rls-coverage.integration.test.ts` |
+| Org cascade | Add `'contact_external_links'` and `'contacts'` to `CORE_ORG_CASCADE_DELETE_ORDER`, alphabetically. Both sort ahead of `sites` and `organizations`, and the real order is recomputed children-first from `pg_constraint` at delete time (`tenantCascade.ts:473`) — alphabetical placement is a lint, not the delete order. | `tenantCascade.integration.test.ts` |
+| Export policy | Both tables: **every column `included`.** No name matches `SUSPICIOUS_NAME_PARTS`; no open containers exist by construction. This is the point of the exercise — it moves contact PII from "silently dropped" into the export. | `tenant-export-policy.integration.test.ts`, `tenantExportErasureRoundtrip.integration.test.ts` |
+| Device cascade | **N/A** — no `device_id` column. | — |
+| Append-only | **N/A** — rows are mutable and deletable. | — |
+| Partner export | **Deliberately none in this phase.** See §2. | — |
+
+Both the cascade and export-policy suites need a live database and **cannot fail in the
+`Test API` unit job**. Run them locally and dispatch CI on the branch
+(`gh workflow run CI --ref <branch>`).
+
+---
+
+## 2. The legacy jsonb columns stay — this is not a deferral
+
+The obvious plan, and the one the Phase-1 spec used for `accounting_*`, is dual-write
+now and drop the columns in a later contract phase. **For these two columns that plan
+is wrong**, and each of the three reasons was found by adversarial review rather than by
+reading the schema:
+
+1. **A partner-export watermark trigger reads `sites.contact` by name.**
+   `breeze_partner_export_sites_update()` detects change with a hardcoded tuple —
+   `ROW(old_row.org_id, old_row.name, old_row.address, old_row.timezone, old_row.contact)
+   IS DISTINCT FROM ROW(new_row…)` (`2026-07-18-partner-export-org-locks.sql:279-284`,
+   trigger wired at `:459-462`; no later migration redefines it). The moment site contact
+   stops living in that column, a contact-only edit stops bumping
+   `sites.partner_export_updated_at` and partner-API consumers polling the sites cursor
+   never see it — a silent divergence bug inside the machinery built to prevent exactly that.
+2. **`sites.contact` is a published API contract, not an internal blob.**
+   `partnerSiteContactSchema` is `.strict()` and embedded in `partnerSiteExportRecordSchema`
+   (`routes/partnerApi/schemas.ts:120-131`); it is a write DTO on `POST /partner-api/sites`
+   (`provisioning.ts:83-87`), it is in the published OpenAPI (`openapi.ts:247,2009`), and it
+   is documented (`apps/docs/.../reference/api.mdx:214`, `migration/toolkit.mdx:116`).
+   Export records are additionally content-hashed (`computePartnerExportRevision`,
+   `exportSafety.ts:72-74`), so changing the emitted shape re-hashes **every** site record
+   and triggers a full re-sync across all partner consumers.
+3. **The two columns have deliberately different exposure.** `organizations.billing_contact`
+   is explicitly kept out of the partner API with a negative regression test
+   (`routes/partnerApi/organizations.test.ts:150,158`) and out of AI model context
+   (`aiToolsOrgs.ts:144-149,181-183`), while `sites.contact` *is* exported. Collapsing both
+   into one table erases the boundary that makes those two exclusions expressible.
+
+So the columns remain, maintained by dual-write, and `contacts` becomes the richer
+superset. Adding a partner-export `contacts` resource later is a separate, deliberate
+project — it needs a `RESOURCE_CLASSIFICATION` entry (`exportSafety.classification.ts:25`
+is a total `Record<PartnerExportResource, …>`, so omitting it is a compile error), locks,
+`breeze_partner_export_next_timestamp`, material state, and canonical parity.
+
+### The compat service is the only writer
+
+New `apps/api/src/services/contacts/compat.ts`, the single place both representations
+are written:
+
+```ts
+upsertSiteContact(siteId, orgId, contact, actor)      // contacts row + sites.contact jsonb
+upsertBillingContact(orgId, patch, actor)             // contacts row (roles ⊇ billing) + organizations.billing_contact
+```
+
+Both write inside one transaction. Every existing writer routes through them.
+
+### Writer sweep — the list a grep will not produce
+
+The Phase-1 lesson was "a reader moved without its writer mints duplicates". Here the
+readers are deliberately left alone and only writers move, which is strictly safer — but
+the sweep still has to be complete:
+
+| Writer | Note |
+|---|---|
+| `routes/orgs.ts` — org create | `billingContact: data.billingContact`, validated by `z.any()` (`:187`) |
+| `routes/orgs.ts` — org PATCH | **Whole-blob replace.** Clobbers the atomic merge below; see the pre-existing race note |
+| `routes/orgs.ts` — site create | validated by `siteContactSchema` |
+| `routes/orgs.ts` — site PATCH (~`:2028-2038`) | **Writes `contact` via `{...data}` spread. There is no literal `contact:` token at the write site — a grep-driven sweep misses this entirely.** |
+| `services/invoiceService.ts:497-506` | Atomic `COALESCE(…) \|\| …::jsonb` merge of `email`/`name` only |
+| `routes/invoices/settings.ts:30` | The HTTP route for the above |
+| `services/orgImport/index.ts` (~`:702,729,760,860,876`) | Bulk import; `:702` collapses many rows to one contact, first-wins; `:729` writes `billingContact`; `:760`/`:876` write `sites.contact` |
+| `services/accounting/quickbooksCustomerImport.ts:143` | Indirect — emits `contact` into `orgImport` |
+| `routes/partnerApi/provisioning.ts` | Site create/update via the public partner API |
+| Web | `billing/OrgBillingSettings.tsx`, `settings/SiteDetailPage.tsx`, `settings/OrganizationsPage.tsx`, `settings/PartnerSettingsPage.tsx` |
+
+**Pre-existing race, worth fixing here:** org PATCH replaces `billing_contact` wholesale
+while `invoiceService` merges into it. A PATCH carrying a partial blob silently drops
+keys the merge had written. Routing both through `upsertBillingContact` fixes it as a
+side effect; do it deliberately and test it.
+
+**Readers that must keep working unchanged** (all currently read the jsonb):
+`invoicePdf.ts:582-586` `resolveBillingEmail` (the single extraction point, called at
+`:518` and `quoteLifecycle.ts:165`), the `no_billing_contact` reason code
+(`db/schema/quotes.ts:27`, `invoicePdf.ts:453,561`, `quoteLifecycle.ts:324`,
+`web/lib/api/quotes.ts:284,292`) and its i18n keys across **all 7 locales**
+(`billing.json:851,854,1255,1343,1434`), plus the bare `.select()` org/site readers at
+`routes/orgs.ts:1434,1853,1975,2012,2063`.
+
+**Behaviour-pinning tests that will need updating, not deleting:**
+`__tests__/integration/orgBillingSettings.integration.test.ts:26-60` (including "clear by
+setting email to JSON null"), `__tests__/integration/billing-contact-info.integration.test.ts`,
+`invoiceService.test.ts:317-343` (asserts the `set` value is a Drizzle `SQL` merge
+expression), `quoteLifecycle.test.ts` fixtures, and the projection-leak guard
+`orgs.test.ts:1480-1488`.
+
+---
+
+## 3. Backfill
+
+Same migration, every cleanup statement reporting its row count per CLAUDE.md:
+
+1. **From `sites.contact`** → one contact per site with a non-empty blob,
+   `site_id` set, `roles = '{site}'`, `is_primary = true`.
+2. **From `organizations.billing_contact`** → one contact per org with a non-empty blob,
+   `site_id NULL`, `roles = '{billing}'`, `is_primary = true`.
+3. **From `portal_users`** (only if §0.2 is accepted) → one contact per portal user,
+   linked via the new `portal_users.contact_id`.
+
+Blobs that are `NULL`, `'{}'`, or carry no `name`/`email`/`phone` are skipped — they are
+not contacts. Each step wraps in `DO $$ … GET DIAGNOSTICS n = ROW_COUNT; IF n > 0 THEN
+RAISE WARNING 'backfilled % <what>', n; END IF; END $$;` so the counts land in Postgres
+logs. Re-running the migration must be a no-op.
+
+---
+
+## 4. Routes
+
+Under `orgRoutes`, matching the gating of the org write routes they sit beside —
+reads `requireScope('organization','partner','system')` + `orgs:read`; writes additionally
+`orgs:write` + `requireMfa()`.
+
+- `GET    /orgs/organizations/:id/contacts` — list, optional `siteId` / `role` filters.
+- `POST   /orgs/organizations/:id/contacts`
+- `PATCH  /orgs/contacts/:id`
+- `DELETE /orgs/contacts/:id`
+- `POST   /orgs/contacts/import/preview` — body `{ rows: ContactImportRow[] }`, max 1000
+  (`MAX_IMPORT_ROWS`). No writes.
+- `POST   /orgs/contacts/import` — returns `{ imported, updated, skipped, errors }`,
+  always HTTP 200, per-row detail. Consumed through `runAction`.
+
+```ts
+interface ContactImportRow {
+  organizationId?: string;      // preferred
+  organization?: string;        // else resolved by name within the partner
+  site?: string;                // optional site name within that org
+  name: string;
+  email?: string;
+  phone?: string;
+  mobile?: string;
+  title?: string;
+  roles?: string[];
+  externalId?: string;          // the source's stable contact id
+  externalSystem?: string;      // 'datto_rmm' | 'connectwise' | ... ; defaults to 'csv'
+}
+```
+
+Annotations, mirroring the shipped pipeline:
+`create | link-match | email-match | name-match | conflict | org-not-found`.
+
+- `link-match` resolves through `contact_external_links` and is safe to auto-apply.
+- **`email-match` and `name-match` are never committed without explicit
+  acknowledgement** — the client must echo `expectedAnnotation`, exactly as
+  `checkExpectation` requires today (`orgImport/index.ts:407-448`).
+- Commit **re-derives** every annotation against fresh state and rejects any row whose
+  annotation changed since preview. Preview is advisory; the unique index is authority.
+- Per-row failure is recorded and the remaining rows proceed.
+
+Contacts arriving through the *org* importer's existing `contact` field keep working and
+now also create a contact row via §2's compat service. The dedicated importer exists for
+the many-contacts-per-org case the org importer cannot express.
+
+---
+
+## 5. `add_contact` becomes real — and must be re-classified
+
+Making the stub write is four coordinated edits plus a guardrail change that is easy to
+get silently wrong:
+
+- `services/aiToolsOrgs.ts` — real handler, tool description (`:477`), and an input schema
+  that matches what the handler actually consumes (`:486-492` currently documents
+  `orgId`/`email` params it ignores).
+- `services/aiAgentSdkTools.ts:2051,2053` and `services/aiToolSchemas.ts:307` — the same
+  action enum, duplicated. All must change together.
+- **`services/aiGuardrails.ts` — add `'add_contact'` to `TIER3_ACTIONS.manage_organizations`
+  AND to `TIER3_SUPERVISED_ACTIONS.manage_organizations`.** Both, or it fails in one of two
+  silent ways:
+  - omitted from `TIER3_ACTIONS` → stays tier 2 and **auto-executes with no approval at
+    all** while writing customer PII (the current exemption at `:203-204` exists *because*
+    the action is a no-op, and that premise is about to become false);
+  - added to `TIER3_ACTIONS` only → `resolveApprovalScope` matches neither `*_ACTIONS`
+    table, falls through both whole-tool sets, and hits the closing `return 'four_eyes'`
+    — so **creating a contact would demand a second human approver.**
+
+  Supervised is the right scope: `TIER3_FOUR_EYES_ACTIONS.manage_organizations` is
+  `['create_org']` only (`:267`) — reserved for tenant creation — and `create_site` /
+  `update_org` are supervised.
+- `buildApprovalDescription` (`aiGuardrails.ts:1366`; its `manage_organizations` branch at `:1526-1531`) falls through to `Organizations: ${action}`,
+  so an approver would see no name or email. Add a contact branch, or approval is blind.
+- Extend the enumeration guard `aiGuardrails.approvalScope.contract.test.ts:139-180`,
+  which currently pins only four tools and would not catch any of the above.
+
+---
+
+## 6. Web UI
+
+- **Contacts card on the organization detail page** — list, add, edit, delete, role badges,
+  a "Primary" marker, and site attribution. Mutations go through `runAction`.
+- **Site detail** keeps its existing single-contact editor, which now writes through the
+  compat service; the card links to the full contact list.
+- **Bulk contact import** modelled on `components/organizations/BulkOrgImport.tsx`:
+  drag-drop CSV → client-side parse (`lib/csvParse.ts`) → column mapping → preview table
+  with per-row status badges → commit. `email-match` and `name-match` rows are unchecked
+  by default; select-all spans only `create` and `link-match`, matching the existing
+  guard that a bulk toggle must never opt hundreds of rows into a fuzzy match.
+
+---
+
+## 7. Testing
+
+- **Service**: link-match dedupe; email-match and name-match flagged, not auto-applied;
+  shared mailbox (three contacts, one address) imports cleanly; emailless contact
+  round-trips; re-import is a no-op; per-row partial success.
+- **Compat**: every writer in §2's table produces both a contact row and the jsonb; the
+  org-PATCH/invoiceService clobber race is fixed and pinned.
+- **Partner export**: editing a site contact through the new path still bumps
+  `sites.partner_export_updated_at` — a direct regression test for the trigger in §2.1.
+- **Partner API**: `GET /partner-api/sites` contact payload is byte-identical before and
+  after, and `organizations` still has no `billingContact` (`organizations.test.ts:150,158`).
+- **Contracts**: RLS coverage, cascade ordering, export policy, erasure roundtrip. Forge a
+  cross-tenant insert as `breeze_app` — must fail with
+  `new row violates row-level security policy`.
+- **Composite FKs**: a contact whose `site_id` belongs to another org must be rejected; a
+  link row whose `org_id` disagrees with its contact's must be rejected.
+- **Guardrails**: `add_contact` resolves to `supervised` — not tier 2, not `four_eyes`.
+- **Backfill**: idempotent; blobs with no usable field produce no row.
+- **Web**: preview rendering, fuzzy-match rows default-unchecked, `runAction` partial success.
+
+---
+
+## Deferred — with reasons, so they are not lost
+
+| Item | Why not now | Tracked by |
+|---|---|---|
+| **Per-role primacy** (`contact_roles` child table) | No consumer in this phase; Pax8 readiness (`pax8CompanyReadiness.ts:26-42`) is the named future one. Migration is `unnest(roles)`. | Not filed — file with §1.3's shape |
+| **Notification routing to contacts** | The issue's strongest "beyond migration" motivation, but alert recipients are free-text strings in `notification_channels.config` today; rewiring them is its own design. | Not filed |
+| **Partner-export `contacts` resource** | Needs `RESOURCE_CLASSIFICATION`, locks, material state, canonical parity. §2. | Not filed |
+| **Partner-level contact unification** | `partners.settings.contact` (`routes/orgs.ts:477-482`, with a `website` field) is the MSP's own profile, not a customer contact — and it already diverges from the `partners.billingEmail/Phone/Website` columns `sellerSnapshot.ts:46-48` reads. An `org_id NOT NULL` table cannot hold it. | Not filed |
+| **Per-person erasure across orgs** | One human at N customers is N rows by design (§1.2). Org-level cascade is the erasure contract; a partner-wide "erase this person" utility is a separate DSR feature. | Not filed |
+| **PSA contact sync** | Requires a `getContacts` capability across six adapters *and* a sync worker (none exists). Once built it is another import source behind the same preview→commit. | #3246 follow-up |
+
+### Explicitly not planned
+
+- **Dropping `organizations.billing_contact` / `sites.contact`.** §2. Not a deferral — a decision.
+- **Making `contacts.email` unique.** It breaks shared mailboxes, which are normal.
+- **Reusing `users` for contacts.** `users.email` is globally unique
+  (`0001-baseline.sql:8427`), so the same person could not be a contact at two MSPs, and
+  every row drags an auth-epoch chain.
+
+### Naming note
+
+`'contacts'` and `'gcontacts'` already exist as cloud-to-cloud **backup scope** strings
+(`routes/c2c/schemas.ts:53,60`). Different namespace, no code conflict, but the docs
+should not use "contacts" unqualified where a reader might be thinking about M365 backup.


### PR DESCRIPTION
Phase 2 of the RMM migration epic (#3249) is complete — #3242, #3246, #3247 and #3248 are all closed and merged. What remains is #3257 (custom-field/UDF backfill) and #3258 (first-class contacts), both of which need design before any code is written.

This adds a self-contained handoff prompt for that design session.

## Why it's worth committing rather than pasting

It records ground truth verified against `main`, so the next session doesn't re-derive it — and two of those facts change the design:

- **Custom field _values_ are not a table.** They live in `devices.custom_fields`, a jsonb column whose write path merges (`{...existing, ...updates}`). So #3257's idempotent-rerun requirement already falls out of the storage model.
- **`custom_field_definitions` already carries both `org_id` and `partner_id`**, but likely predates the #2135 partner-wide playbook — so whether it has the XOR constraint and a dual-axis RLS policy is a design input, not an assumption.
- **Contacts genuinely don't exist**: two bare jsonb columns with no DB-level shape, and `add_contact` returns a `CONTACT_ENTITY_UNDEFINED` stub at `aiToolsOrgs.ts:431`.

It also frames #3258 as the question to settle first, since the issue itself suspects the answer is PSA read-through rather than a local contacts table — and Phase 2 shipped the PSA plumbing that would make that viable.

## Also carried forward

The operational traps this epic hit: `rg -na` over bare `grep -r` (a NUL byte in `orgImport/index.ts` makes grep silently skip the file), `gh pr checks` misreporting `continue-on-error` Integration shards as passes, stacked PRs running no CI at all, and the closed `2026-08-06` migration date block.

Docs only — no code, no CI-relevant surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)