### PR TITLE
feat(web): what's-new splash on login with reopen link

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -63,6 +63,7 @@ import { hasPermission } from '../../lib/permissions';
 import { WEB_VERSION } from '../../lib/version';
 import { semverCompare } from '@breeze/shared';
 import { getJwtClaims } from '../../lib/authScope';
+import { REOPEN_EVENT } from '../whatsNew/WhatsNewSplash';
 import BrandHeader from './BrandHeader';
 import { ENABLE_EDR_INTEGRATIONS } from '../../lib/featureFlags';
 import { useExtensionNavigation } from '../extensions/useExtensionNavigation';
@@ -797,6 +798,13 @@ export default function Sidebar({ currentPath: initialPath = '/' }: SidebarProps
             )}
             {apiVersion === 'unavailable' && ' · API unavailable'}
           </p>
+          <button
+            type="button"
+            onClick={() => window.dispatchEvent(new Event(REOPEN_EVENT))}
+            className="hover:text-muted-foreground hover:underline"
+          >
+            {t('whatsNew.link')}
+          </button>
         </div>
       )}
     </aside>

--- a/apps/web/src/components/whatsNew/WhatsNewSplash.test.tsx
+++ b/apps/web/src/components/whatsNew/WhatsNewSplash.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import WhatsNewSplash from './WhatsNewSplash';
+import { LAST_SEEN_KEY } from '../../lib/whatsNewState';
+
+// t returns key + interpolated version so assertions are stable without real i18n.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (k: string, opts?: Record<string, unknown>) =>
+      opts?.version ? `${k}:${opts.version}` : k,
+  }),
+}));
+
+// Force a known decision by stubbing the running version and entries indirectly:
+// seed localStorage floor below the bundled entry so the newest entry shows.
+vi.mock('../../lib/version', () => ({ WEB_VERSION: '99.0.0' }));
+
+beforeEach(() => {
+  window.localStorage.clear();
+  // floor below any real entry so decideWhatsNew returns the newest bundled entry
+  window.localStorage.setItem(LAST_SEEN_KEY, '0.0.1');
+});
+
+describe('WhatsNewSplash', () => {
+  it('renders the newest entry title + highlights', async () => {
+    render(<WhatsNewSplash />);
+    // The decision runs in a useEffect, so wait for the post-mount render.
+    expect(await screen.findByText(/whatsNew\.title:/)).toBeInTheDocument();
+    // at least one highlight bullet is present
+    expect(screen.getAllByRole('listitem').length).toBeGreaterThan(0);
+  });
+
+  it('"Got it" writes lastSeen and closes', async () => {
+    render(<WhatsNewSplash />);
+    const gotIt = await screen.findByText('whatsNew.gotIt');
+    fireEvent.click(gotIt);
+    expect(window.localStorage.getItem(LAST_SEEN_KEY)).not.toBe('0.0.1');
+    await waitFor(() => {
+      expect(screen.queryByText('whatsNew.gotIt')).not.toBeInTheDocument();
+    });
+  });
+
+  it('"Show me later" closes without writing', async () => {
+    render(<WhatsNewSplash />);
+    const later = await screen.findByText('whatsNew.later');
+    fireEvent.click(later);
+    expect(window.localStorage.getItem(LAST_SEEN_KEY)).toBe('0.0.1');
+    await waitFor(() => {
+      expect(screen.queryByText('whatsNew.later')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders nothing when there is no applicable entry', async () => {
+    window.localStorage.clear(); // first-ever load => baseline only, no show
+    const { container } = render(<WhatsNewSplash />);
+    // Give the mount effect a tick to run (it will write the baseline and stay closed).
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/whatsNew/WhatsNewSplash.tsx
+++ b/apps/web/src/components/whatsNew/WhatsNewSplash.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+// Initializes the shared i18next singleton. Islands hydrate independently, so
+// an island that hydrates before whichever other island happens to pull i18n in
+// would otherwise render raw keys (and mismatch the SSR markup).
+import '../../lib/i18n';
 import { Dialog } from '../shared/Dialog';
 import {
   decideWhatsNew,

--- a/apps/web/src/components/whatsNew/WhatsNewSplash.tsx
+++ b/apps/web/src/components/whatsNew/WhatsNewSplash.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog } from '../shared/Dialog';
+import {
+  decideWhatsNew,
+  markSeen,
+  latestApplicableEntry,
+  LAST_SEEN_KEY,
+} from '../../lib/whatsNewState';
+import type { WhatsNewEntry } from '../../lib/whatsNew';
+
+export const REOPEN_EVENT = 'breeze:whats-new:open';
+
+export default function WhatsNewSplash() {
+  const { t } = useTranslation('common');
+  const [entry, setEntry] = useState<WhatsNewEntry | null>(null);
+  const [open, setOpen] = useState(false);
+
+  // Decide once on mount (post-hydration; initial render is null → no SSR mismatch).
+  useEffect(() => {
+    const decision = decideWhatsNew(window.localStorage);
+    if (decision.baselineToSet) {
+      window.localStorage.setItem(LAST_SEEN_KEY, decision.baselineToSet);
+      return;
+    }
+    if (decision.entry) {
+      setEntry(decision.entry);
+      setOpen(true);
+    }
+  }, []);
+
+  // Reopen from the sidebar link (separate island → window-event bridge).
+  useEffect(() => {
+    const onReopen = () => {
+      const e = latestApplicableEntry();
+      if (e) {
+        setEntry(e);
+        setOpen(true);
+      }
+    };
+    window.addEventListener(REOPEN_EVENT, onReopen);
+    return () => window.removeEventListener(REOPEN_EVENT, onReopen);
+  }, []);
+
+  if (!entry) return null;
+
+  const gotIt = () => {
+    markSeen(window.localStorage, entry.version);
+    setOpen(false);
+  };
+  // Dialog onClose fires on Esc / backdrop → treated as "show me later".
+  const later = () => setOpen(false);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={later}
+      title={t('whatsNew.title', { version: entry.version })}
+      labelledBy="whats-new-heading"
+      maxWidth="lg"
+      className="p-6"
+    >
+      <h2 id="whats-new-heading" className="text-lg font-semibold">
+        {t('whatsNew.title', { version: entry.version })}
+      </h2>
+      <p className="mt-1 text-sm text-muted-foreground">{entry.title}</p>
+      <ul className="mt-4 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+        {entry.highlights.map((h, i) => (
+          <li key={i}>{h}</li>
+        ))}
+      </ul>
+      {entry.learnMoreUrl && (
+        <a
+          href={entry.learnMoreUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-3 inline-block text-sm text-primary hover:underline"
+        >
+          {t('whatsNew.learnMore')}
+        </a>
+      )}
+      <div className="mt-6 flex items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={later}
+          className="h-10 rounded-md border px-4 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+        >
+          {t('whatsNew.later')}
+        </button>
+        <button
+          type="button"
+          onClick={gotIt}
+          className="h-10 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+        >
+          {t('whatsNew.gotIt')}
+        </button>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/web/src/layouts/DashboardLayout.astro
+++ b/apps/web/src/layouts/DashboardLayout.astro
@@ -10,6 +10,7 @@ import AiChatSidebar from '../components/ai/AiChatSidebar';
 import HelpPanel from '../components/help/HelpPanel';
 import OnboardingTour from '../components/onboarding/OnboardingTour';
 import ToastContainer from '../components/shared/Toast';
+import WhatsNewSplash from '../components/whatsNew/WhatsNewSplash';
 
 interface Props {
   title: string;
@@ -55,5 +56,6 @@ const accentClass = getAccentClass(currentPath);
   <AiChatSidebar client:load transition:persist />
   <HelpPanel client:load transition:persist />
   <ToastContainer client:load transition:persist />
+  <WhatsNewSplash client:load transition:persist />
   <OnboardingTour client:idle />
 </Layout>

--- a/apps/web/src/lib/whatsNew.ts
+++ b/apps/web/src/lib/whatsNew.ts
@@ -1,0 +1,30 @@
+/** One release's "what's new" content, bundled with the web build. */
+export interface WhatsNewEntry {
+  /** Exact release version, e.g. "0.105.0". Compared with semverCompare. */
+  version: string;
+  /** ISO date, e.g. "2026-08-12". */
+  date: string;
+  /** One-line headline. */
+  title: string;
+  /** 2–5 short bullets. */
+  highlights: string[];
+  /** Optional deep link (docs / release notes). */
+  learnMoreUrl?: string;
+}
+
+/**
+ * Newest-first. Authored per release alongside the release-notes flow.
+ * Entry content is English-only in v1 (see spec non-goals).
+ */
+export const WHATS_NEW_ENTRIES: WhatsNewEntry[] = [
+  {
+    version: '0.105.0',
+    date: '2026-08-12',
+    title: 'Faster fleet views and clearer device health',
+    highlights: [
+      'Fleet lists load noticeably faster on large tenants.',
+      'Device health cards surface reliability at a glance.',
+    ],
+    learnMoreUrl: 'https://breezermm.com/release-notes',
+  },
+];

--- a/apps/web/src/lib/whatsNewState.test.ts
+++ b/apps/web/src/lib/whatsNewState.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { decideWhatsNew, markSeen, latestApplicableEntry, LAST_SEEN_KEY } from './whatsNewState';
+import type { WhatsNewEntry } from './whatsNew';
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    _map: map,
+  };
+}
+
+const ENTRIES: WhatsNewEntry[] = [
+  { version: '0.105.0', date: '2026-08-12', title: 'B', highlights: ['b'] },
+  { version: '0.104.0', date: '2026-08-08', title: 'A', highlights: ['a'] },
+];
+
+describe('decideWhatsNew', () => {
+  it('never shows on dev builds', () => {
+    const s = fakeStorage();
+    expect(decideWhatsNew(s, 'dev', ENTRIES)).toEqual({ entry: null, baselineToSet: null });
+    expect(s._map.has(LAST_SEEN_KEY)).toBe(false);
+  });
+
+  it('first-ever load sets baseline without showing', () => {
+    const s = fakeStorage();
+    expect(decideWhatsNew(s, '0.105.0', ENTRIES)).toEqual({ entry: null, baselineToSet: '0.105.0' });
+  });
+
+  it('shows the newest entry above the floor and at/below web version', () => {
+    const s = fakeStorage({ [LAST_SEEN_KEY]: '0.104.0' });
+    const d = decideWhatsNew(s, '0.105.0', ENTRIES);
+    expect(d.entry?.version).toBe('0.105.0');
+    expect(d.baselineToSet).toBeNull();
+  });
+
+  it('shows nothing when floor equals newest', () => {
+    const s = fakeStorage({ [LAST_SEEN_KEY]: '0.105.0' });
+    expect(decideWhatsNew(s, '0.105.0', ENTRIES).entry).toBeNull();
+  });
+
+  it('suppresses entries newer than the running web version', () => {
+    const s = fakeStorage({ [LAST_SEEN_KEY]: '0.103.0' });
+    // web is 0.104.0, so 0.105.0 must not show; 0.104.0 should.
+    expect(decideWhatsNew(s, '0.104.0', ENTRIES).entry?.version).toBe('0.104.0');
+  });
+
+  it('shows nothing after markSeen', () => {
+    const s = fakeStorage({ [LAST_SEEN_KEY]: '0.104.0' });
+    markSeen(s, '0.105.0');
+    expect(decideWhatsNew(s, '0.105.0', ENTRIES).entry).toBeNull();
+  });
+});
+
+describe('latestApplicableEntry', () => {
+  it('returns newest entry <= web version regardless of floor', () => {
+    expect(latestApplicableEntry('0.104.0', ENTRIES)?.version).toBe('0.104.0');
+  });
+  it('returns newest entry on dev (for demoability)', () => {
+    expect(latestApplicableEntry('dev', ENTRIES)?.version).toBe('0.105.0');
+  });
+});

--- a/apps/web/src/lib/whatsNewState.ts
+++ b/apps/web/src/lib/whatsNewState.ts
@@ -1,0 +1,56 @@
+import { semverCompare } from '@breeze/shared';
+import { WEB_VERSION } from './version';
+import { WHATS_NEW_ENTRIES, type WhatsNewEntry } from './whatsNew';
+
+export const LAST_SEEN_KEY = 'breeze.whatsNew.lastSeenVersion';
+
+export interface WhatsNewDecision {
+  /** The entry to show, or null. */
+  entry: WhatsNewEntry | null;
+  /** First-ever load only: caller writes this baseline and shows nothing. */
+  baselineToSet: string | null;
+}
+
+function highest(entries: WhatsNewEntry[]): WhatsNewEntry | null {
+  return entries.reduce<WhatsNewEntry | null>((best, e) => {
+    if (!best) return e;
+    const c = semverCompare(e.version, best.version);
+    return c !== null && c > 0 ? e : best;
+  }, null);
+}
+
+/** Pure: storage is injected so it is trivially testable. */
+export function decideWhatsNew(
+  storage: Pick<Storage, 'getItem' | 'setItem'>,
+  webVersion: string = WEB_VERSION,
+  entries: WhatsNewEntry[] = WHATS_NEW_ENTRIES,
+): WhatsNewDecision {
+  if (webVersion === 'dev') return { entry: null, baselineToSet: null };
+
+  const floor = storage.getItem(LAST_SEEN_KEY);
+  if (!floor) return { entry: null, baselineToSet: webVersion };
+
+  const applicable = entries.filter((e) => {
+    const aboveFloor = semverCompare(e.version, floor);
+    const atMostWeb = semverCompare(e.version, webVersion);
+    return aboveFloor !== null && aboveFloor > 0 && atMostWeb !== null && atMostWeb <= 0;
+  });
+  return { entry: highest(applicable), baselineToSet: null };
+}
+
+export function markSeen(storage: Pick<Storage, 'setItem'>, version: string): void {
+  storage.setItem(LAST_SEEN_KEY, version);
+}
+
+/** Newest entry the running build has shipped, ignoring dismissal (for reopen). */
+export function latestApplicableEntry(
+  webVersion: string = WEB_VERSION,
+  entries: WhatsNewEntry[] = WHATS_NEW_ENTRIES,
+): WhatsNewEntry | null {
+  if (webVersion === 'dev') return highest(entries);
+  const applicable = entries.filter((e) => {
+    const c = semverCompare(e.version, webVersion);
+    return c !== null && c <= 0;
+  });
+  return highest(applicable);
+}

--- a/apps/web/src/locales/de-DE/common.json
+++ b/apps/web/src/locales/de-DE/common.json
@@ -2194,5 +2194,12 @@
         "send": "Senden"
       }
     }
+  },
+  "whatsNew": {
+    "title": "Neu in {{version}}",
+    "gotIt": "Verstanden",
+    "later": "Später anzeigen",
+    "learnMore": "Mehr erfahren",
+    "link": "Neuigkeiten"
   }
 }

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -2194,5 +2194,12 @@
         "send": "Send"
       }
     }
+  },
+  "whatsNew": {
+    "title": "What's new in {{version}}",
+    "gotIt": "Got it",
+    "later": "Show me later",
+    "learnMore": "Learn more",
+    "link": "What's new"
   }
 }

--- a/apps/web/src/locales/es-419/common.json
+++ b/apps/web/src/locales/es-419/common.json
@@ -2194,5 +2194,12 @@
         "send": "Enviar"
       }
     }
+  },
+  "whatsNew": {
+    "title": "Novedades en {{version}}",
+    "gotIt": "Entendido",
+    "later": "Mostrar más tarde",
+    "learnMore": "Más información",
+    "link": "Novedades"
   }
 }

--- a/apps/web/src/locales/fr-CA/common.json
+++ b/apps/web/src/locales/fr-CA/common.json
@@ -2194,5 +2194,12 @@
         "send": "Envoyer"
       }
     }
+  },
+  "whatsNew": {
+    "title": "Nouveautés de la version {{version}}",
+    "gotIt": "Compris",
+    "later": "Afficher plus tard",
+    "learnMore": "En savoir plus",
+    "link": "Nouveautés"
   }
 }

--- a/apps/web/src/locales/fr-FR/common.json
+++ b/apps/web/src/locales/fr-FR/common.json
@@ -2194,5 +2194,12 @@
         "send": "Envoyer"
       }
     }
+  },
+  "whatsNew": {
+    "title": "Nouveautés de la version {{version}}",
+    "gotIt": "Compris",
+    "later": "Afficher plus tard",
+    "learnMore": "En savoir plus",
+    "link": "Nouveautés"
   }
 }

--- a/apps/web/src/locales/it-IT/common.json
+++ b/apps/web/src/locales/it-IT/common.json
@@ -2194,5 +2194,12 @@
         "send": "Invia"
       }
     }
+  },
+  "whatsNew": {
+    "title": "Novità nella versione {{version}}",
+    "gotIt": "Ho capito",
+    "later": "Mostra più tardi",
+    "learnMore": "Scopri di più",
+    "link": "Novità"
   }
 }

--- a/apps/web/src/locales/pt-BR/common.json
+++ b/apps/web/src/locales/pt-BR/common.json
@@ -2194,5 +2194,12 @@
         "send": "Enviar"
       }
     }
+  },
+  "whatsNew": {
+    "title": "Novidades na versão {{version}}",
+    "gotIt": "Entendi",
+    "later": "Mostrar mais tarde",
+    "learnMore": "Saiba mais",
+    "link": "Novidades"
   }
 }


### PR DESCRIPTION
## What

Adds a **"What's new" splash** for authenticated users: after a release, on login, a dismissible modal ("Welcome to version X — what's new") shows the release highlights, with **Got it** (mark this version seen) and **Show me later** (snooze to next login). A persistent **"What's new"** link in the sidebar footer reopens it anytime.

Content is a changelog bundled with the web build; dismissal state is per-browser `localStorage`. No API, no DB, no agent changes.

## How

- `lib/whatsNew.ts` — bundled `WhatsNewEntry[]` changelog data (newest-first), authored per release.
- `lib/whatsNewState.ts` — pure decision logic (storage injected, fully unit-tested): show the newest entry in the `lastSeen < version <= WEB_VERSION` window; first-ever load silently baselines without showing; `WEB_VERSION === 'dev'` never auto-shows; handles `semverCompare` returning `null`.
- `components/whatsNew/WhatsNewSplash.tsx` — modal reusing the shared `Dialog` primitive (focus-trap, Esc, backdrop, aria); reopen bridged from the sidebar via a `window` event.
- `locales/*/common.json` (×7) — `whatsNew.*` chrome strings with real translations; passes the locale key-parity gate.
- Mounted in `DashboardLayout.astro`; reopen link added to `Sidebar.tsx`.

Changelog **entry copy** is English-only in v1 (chrome is localized); server-side cross-device dismissal and a multi-version catch-up view are intentional non-goals.

## Tests

62 passing — decision logic (8), component (4, via the shared `Dialog`), locale parity (50). `tsc` clean.

Spec: `docs/superpowers/specs/2026-08-09-whats-new-splash-design.md` · Plan: `docs/superpowers/plans/2026-08-09-whats-new-splash.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
