### PR TITLE
feat(webhooks): honour the self-hosted private-network gate, drop the local IP policy

### DIFF
--- a/apps/api/src/services/notificationSenders/webhookSender.test.ts
+++ b/apps/api/src/services/notificationSenders/webhookSender.test.ts
@@ -1,8 +1,19 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// `validateWebhookUrlSafetyWithDns` resolves the hostname via a dynamic
+// `import('dns/promises')`, which `__setLookupForTests` (a urlSafety/safeFetch
+// hook) does NOT intercept. Without this mock the lookup simply fails and the
+// "rejects" assertions pass for the wrong reason.
+const { dnsLookupMock } = vi.hoisted(() => ({ dnsLookupMock: vi.fn() }));
+vi.mock('dns/promises', () => ({
+  lookup: dnsLookupMock,
+  default: { lookup: dnsLookupMock },
+}));
 import {
   sendWebhookNotification,
   validateWebhookConfig,
   validateWebhookUrlSafety,
+  validateWebhookUrlSafetyWithDns,
   redactUrlForLogs
 } from './webhookSender';
 import { __setLookupForTests } from '../urlSafety';
@@ -102,5 +113,101 @@ describe('redactUrlForLogs', () => {
   it('strips hash fragments', () => {
     expect(redactUrlForLogs('https://example.com/hook#section'))
       .toBe('https://example.com/hook');
+  });
+});
+
+/**
+ * Self-hosted private-network opt-in (#2293 gate, reused).
+ *
+ * A self-hosted operator's webhook receiver — SIEM, log collector, ticketing —
+ * normally lives on their own LAN and often speaks plain http. Hosted SaaS must
+ * never dial those, so the gate is `selfHostAllowsPrivateNetwork()` from
+ * config/env: it opens ONLY on an affirmative IS_HOSTED self-host declaration.
+ *
+ * The security-relevant half of this block is the "still rejected" cases: the
+ * opt-in must widen the target space to RFC1918/ULA only, and must NOT become a
+ * general SSRF escape hatch. Loopback, link-local, cloud metadata and CGNAT stay
+ * blocked in both modes.
+ */
+describe('webhook URL safety — self-hosted private-network opt-in', () => {
+  afterEach(() => {
+    delete process.env.IS_HOSTED;
+    dnsLookupMock.mockReset();
+    __setLookupForTests(null);
+  });
+
+  describe('hosted / undeclared (default) stays strict', () => {
+    it('rejects plain http even to an RFC1918 address', () => {
+      delete process.env.IS_HOSTED;
+      expect(validateWebhookUrlSafety('http://10.1.2.3/collector').join(' ')).toContain('HTTPS');
+    });
+
+    it('rejects an RFC1918 target over https', () => {
+      delete process.env.IS_HOSTED;
+      expect(validateWebhookUrlSafety('https://10.1.2.3/hook').length).toBeGreaterThan(0);
+    });
+
+    it.each(['true', '1', 'yes', 'on', '', 'garbage'])(
+      'stays strict when IS_HOSTED=%j (fail-closed)',
+      (value) => {
+        process.env.IS_HOSTED = value;
+        expect(validateWebhookUrlSafety('https://10.1.2.3/hook').length).toBeGreaterThan(0);
+      }
+    );
+  });
+
+  describe('affirmatively self-hosted opens RFC1918/ULA + http', () => {
+    it.each(['false', '0', 'no', 'off', 'FALSE', ' off '])(
+      'accepts an on-LAN http receiver when IS_HOSTED=%j',
+      (value) => {
+        process.env.IS_HOSTED = value;
+        expect(validateWebhookUrlSafety('http://10.1.2.3/collector')).toEqual([]);
+      }
+    );
+
+    it('accepts the other RFC1918 ranges and ULA over https', () => {
+      process.env.IS_HOSTED = 'false';
+      expect(validateWebhookUrlSafety('https://192.168.1.10/hook')).toEqual([]);
+      expect(validateWebhookUrlSafety('https://172.16.4.4/hook')).toEqual([]);
+      expect(validateWebhookUrlSafety('https://[fd00::1]/hook')).toEqual([]);
+    });
+  });
+
+  describe('the opt-in is NOT an SSRF escape hatch', () => {
+    it.each([
+      ['loopback v4', 'https://127.0.0.1/hook'],
+      ['loopback v6', 'https://[::1]/hook'],
+      ['link-local', 'https://169.254.1.1/hook'],
+      ['cloud metadata', 'https://169.254.169.254/latest/meta-data/'],
+      ['alibaba metadata', 'https://100.100.100.200/hook'],
+      ['CGNAT / tailnet', 'https://100.64.5.5/hook'],
+      ['localhost name', 'https://localhost/hook'],
+    ])('still rejects %s when self-hosted', (_label, url) => {
+      process.env.IS_HOSTED = 'false';
+      expect(validateWebhookUrlSafety(url).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('DNS-resolved targets honour the same policy', () => {
+    it('accepts a hostname resolving to RFC1918 when self-hosted', async () => {
+      process.env.IS_HOSTED = 'false';
+      dnsLookupMock.mockResolvedValue([{ address: '10.1.2.3', family: 4 }]);
+      await expect(validateWebhookUrlSafetyWithDns('https://logs.internal.example/hook')).resolves.toEqual([]);
+    });
+
+    it('still refuses a hostname resolving to cloud metadata when self-hosted', async () => {
+      process.env.IS_HOSTED = 'false';
+      dnsLookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+      const errors = await validateWebhookUrlSafetyWithDns('https://sneaky.example/hook');
+      // Not vacuous: the same stub returning 10.1.2.3 above yields [].
+      expect(errors.join(' ')).toContain('blocked address space');
+    });
+
+    it('refuses a hostname resolving to RFC1918 when NOT self-hosted', async () => {
+      delete process.env.IS_HOSTED;
+      dnsLookupMock.mockResolvedValue([{ address: '10.1.2.3', family: 4 }]);
+      const errors = await validateWebhookUrlSafetyWithDns('https://logs.internal.example/hook');
+      expect(errors.join(' ')).toContain('blocked address space');
+    });
   });
 });

--- a/apps/api/src/services/notificationSenders/webhookSender.ts
+++ b/apps/api/src/services/notificationSenders/webhookSender.ts
@@ -6,7 +6,8 @@
  */
 
 import { isIP } from 'net';
-import { safeFetch, SsrfBlockedError } from '../urlSafety';
+import { isAlwaysBlockedIp, isPrivateIp, safeFetch, SsrfBlockedError } from '../urlSafety';
+import { selfHostAllowsPrivateNetwork } from '../../config/env';
 import { getOutboundHeaderValidationErrors, sanitizeOutboundHeaders, validateOutboundHeader } from '../outboundHeaders';
 
 export function redactUrlForLogs(rawUrl: string): string {
@@ -59,60 +60,6 @@ export interface SendResult {
   responseBody?: string;
 }
 
-function parseIpv4Octets(hostname: string): number[] | null {
-  const parts = hostname.split('.');
-  if (parts.length !== 4) return null;
-
-  const octets = parts.map((part) => Number(part));
-  if (octets.some((value) => !Number.isInteger(value) || value < 0 || value > 255)) {
-    return null;
-  }
-
-  return octets;
-}
-
-function isPrivateIpv4(hostname: string): boolean {
-  const octets = parseIpv4Octets(hostname);
-  if (!octets) return false;
-
-  const a = octets[0]!;
-  const b = octets[1]!;
-  if (a === 10) return true;
-  if (a === 127) return true;
-  if (a === 169 && b === 254) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  if (a === 192 && b === 168) return true;
-  if (a === 100 && b >= 64 && b <= 127) return true;
-  if (a === 192 && b === 0 && octets[2] === 0) return true;
-  if (a === 192 && b === 0 && octets[2] === 2) return true;
-  if (a === 198 && b >= 18 && b <= 19) return true;
-  if (a === 198 && b === 51 && octets[2] === 100) return true;
-  if (a === 203 && b === 0 && octets[2] === 113) return true;
-  if (a >= 224) return true;
-  if (a === 0) return true;
-  return false;
-}
-
-function isPrivateIpv6(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-
-  if (normalized === '::1' || normalized === '::') return true;
-  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true; // Unique local
-  if (
-    normalized.startsWith('fe8')
-    || normalized.startsWith('fe9')
-    || normalized.startsWith('fea')
-    || normalized.startsWith('feb')
-  ) return true; // Link local fe80::/10
-
-  if (normalized.startsWith('::ffff:')) {
-    const ipv4Part = normalized.slice('::ffff:'.length);
-    if (isPrivateIpv4(ipv4Part)) return true;
-  }
-
-  return false;
-}
-
 export function validateWebhookUrlSafety(rawUrl: string): string[] {
   const errors: string[] = [];
   let parsed: URL;
@@ -123,7 +70,13 @@ export function validateWebhookUrlSafety(rawUrl: string): string[] {
     return ['Invalid URL format'];
   }
 
-  if (parsed.protocol !== 'https:') {
+  // Self-hosted operators own both ends of the connection, so an on-LAN
+  // receiver (SIEM, log collector, ticketing) may legitimately be plain http
+  // on an RFC1918 address. Hosted SaaS stays HTTPS-only: a private target is
+  // unreachable from us anyway and is a genuine SSRF vector.
+  const allowPrivate = selfHostAllowsPrivateNetwork();
+
+  if (parsed.protocol !== 'https:' && !(allowPrivate && parsed.protocol === 'http:')) {
     errors.push('Webhook URL must use HTTPS');
   }
 
@@ -137,12 +90,18 @@ export function validateWebhookUrlSafety(rawUrl: string): string[] {
     errors.push('Webhook URL cannot target localhost or local network hostnames');
   }
 
+  // `isAlwaysBlockedIp` is the shared policy: with private networking opted in
+  // it permits RFC1918/ULA only, and still refuses loopback, link-local, cloud
+  // metadata and CGNAT (100.64/10) — the ranges that are never a legitimate
+  // receiver. Without the opt-in, `isPrivateIp` refuses every private range.
+  const blocked = allowPrivate ? isAlwaysBlockedIp : isPrivateIp;
   const ipVersion = isIP(hostname);
-  if (ipVersion === 4 && isPrivateIpv4(hostname)) {
-    errors.push('Webhook URL cannot target private, loopback, or link-local IPv4 addresses');
-  }
-  if (ipVersion === 6 && isPrivateIpv6(hostname)) {
-    errors.push('Webhook URL cannot target private, loopback, or link-local IPv6 addresses');
+  if (ipVersion !== 0 && blocked(hostname)) {
+    errors.push(
+      allowPrivate
+        ? 'Webhook URL cannot target loopback, link-local, metadata, or CGNAT addresses'
+        : 'Webhook URL cannot target private, loopback, or link-local addresses'
+    );
   }
 
   return errors;
@@ -179,7 +138,7 @@ export async function validateWebhookUrlSafetyWithDns(rawUrl: string): Promise<s
 
     const blockedTargets = resolved
       .map((entry) => entry.address)
-      .filter((address) => isPrivateIpv4(address) || isPrivateIpv6(address));
+      .filter(selfHostAllowsPrivateNetwork() ? isAlwaysBlockedIp : isPrivateIp);
 
     if (blockedTargets.length > 0) {
       errors.push(`Webhook URL resolves to blocked address space: ${blockedTargets.join(', ')}`);
@@ -280,7 +239,11 @@ export async function sendWebhookNotification(
         headers,
         body,
         signal: controller.signal,
-        redirect: 'error'
+        redirect: 'error',
+        // Must mirror the save-time decision, or a URL we accepted would be
+        // refused at delivery — the TOCTOU re-check is meant to catch DNS
+        // rebinding, not to second-guess the deployment's own policy.
+        allowPrivateNetwork: selfHostAllowsPrivateNetwork()
       });
 
       clearTimeout(timeoutId);


### PR DESCRIPTION
## The gap

**A self-hosted Breeze cannot send a webhook to anything on its own LAN.**

`webhookSender` requires HTTPS and refuses every RFC1918 address, so an operator whose receiver is an on-prem SIEM, log collector, or ticketing system has no delivery path to it. That is precisely the deployment shape where the receiver is *guaranteed* to be private — the self-hoster owns both ends of the wire.

The failure is also quiet in the worst way: it surfaces as a validation error on save, so it reads like the operator mistyped a URL rather than like a policy decision.

## This is the consolidation the codebase already asked for

I did not invent a policy here. `config/env.ts` already exports `selfHostAllowsPrivateNetwork()`, already tested in `config/env.test.ts`, and its own comment states the intent:

> The DNS-provider (`services/dnsProviders/index.ts`) and PSA (`services/psa/http.ts`) integrations currently carry their own equivalent IS_HOSTED-affirmative gates — **consolidating all three onto this helper is a worthwhile follow-up**

Three integrations already make this exact call. SSO uses the canonical helper; PSA and dnsProviders carry their own copies. **`webhookSender` was the one outbound integration with no gate at all** — and rather than reuse `urlSafety.ts`, it hand-rolled ~54 lines of address-range policy (`parseIpv4Octets` / `isPrivateIpv4` / `isPrivateIpv6`).

That duplicate was not merely redundant, it was **less precise**. It collapsed loopback, link-local, cloud metadata, CGNAT and RFC1918 into one verdict with one error string. With only that predicate there is no way to open an operator's LAN without also opening `169.254.169.254`. `urlSafety.ts` already draws that line correctly via `isAlwaysBlockedIp`; the webhook path just wasn't using it.

So this PR is subtractive: **net −37 lines of source**, one file, and one fewer private implementation of a security policy that must never drift.

## What changes

- Gate on `selfHostAllowsPrivateNetwork()` — fail-closed. Opens only on an affirmative `IS_HOSTED` (`false`/`0`/`no`/`off`); unset, empty, garbage and truthy all stay strict (the #570 lesson).
- When open: permit `http:`, and swap the block predicate to `isAlwaysBlockedIp` — RFC1918/ULA only.
- Apply the same predicate to the DNS-resolved half.
- Pass `allowPrivateNetwork` through to `safeFetch`, so delivery agrees with what was accepted at save time. The TOCTOU re-check exists to catch DNS rebinding, not to overrule the deployment's own policy — without this a URL you accepted would be refused at send.
- Delete the duplicated local policy.

**Hosted SaaS behaviour is byte-identical.**

## It is not an SSRF escape hatch, and that is asserted

Loopback, link-local, cloud metadata and CGNAT (`100.64/10`) remain blocked in **both** modes. The opt-in widens the target space to the operator's own LAN; it does not disable the guard. Seven cases assert this directly rather than leaving it implied:

| still rejected when self-hosted |
|---|
| loopback v4 `127.0.0.1` |
| loopback v6 `::1` |
| link-local `169.254.1.1` |
| AWS metadata `169.254.169.254` |
| Alibaba metadata `100.100.100.200` |
| CGNAT `100.64/10` |
| `localhost` by name |

CGNAT staying blocked is deliberate and matches the documented decision in `urlSafety.ts` — I am not proposing to relax it.

## Control

Reverting the source and keeping the tests fails **8** — precisely the "self-hosted opens RFC1918/ULA + http" cases and the DNS-accepts case. The other **27 pass in both versions**, including every "still rejected" assertion.

That split is the point: the capability tests prove the change does something, and the security assertions prove they are invariants rather than artifacts of it.

## One trap worth flagging for future tests here

The DNS tests stub `dns/promises` directly. `__setLookupForTests` is a `urlSafety`/`safeFetch` hook and does **not** intercept the dynamic `import('dns/promises')` inside `validateWebhookUrlSafetyWithDns`. Without a real stub the lookup simply fails, and every "rejects" assertion passes for the wrong reason. Two of mine did exactly that until I checked why an expected-to-fail case was green.

## Verification

| Check | Result |
|---|---|
| `webhookSender.test.ts` | **35 passed** (+109 lines of tests) |
| full `apps/api` unit suite | **1304 files / 20958 passed**, 5/37 skipped |
| `tsc --noEmit` (apps/api) | 0 errors |
| `eslint` | clean |

No schema change, no migration, no new dependency. One source file touched.

## Provenance

Found while wiring a self-hosted deployment's alert/script/patch events to an on-LAN log collector. Every event type needed is already emitted by the webhook system — the only thing standing between the two was this guard.
