### PR TITLE
feat(agent): compile-time control-plane build-mode host policy (inert by default)

### DIFF
--- a/agent/internal/agentapp/bootstrap.go
+++ b/agent/internal/agentapp/bootstrap.go
@@ -209,6 +209,7 @@ func runBootstrap() {
 		bsLog.Error("bootstrap token redemption failed", "error", err.Error())
 		fmt.Fprintf(os.Stderr, "Bootstrap failed: %v\n", err)
 		osExit(1) // hard — roll back the install (osExit: test seam, enroll_error.go)
+		return    // under a noop osExit test seam, don't fall through to a nil res
 	}
 
 	if err := gateRedeemResponse(*res); err != nil {

--- a/agent/internal/agentapp/bootstrap.go
+++ b/agent/internal/agentapp/bootstrap.go
@@ -13,11 +13,35 @@ import (
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
 	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/pkg/api"
 )
 
 var errNoBootstrapInput = errors.New("no bootstrap token from filename or properties")
+
+// gateBootstrapServer refuses, in a hosted build, to contact a control-plane host
+// outside the compiled allowlist — called BEFORE the token is redeemed so a
+// bootstrap token is never disclosed to a non-allowlisted server. No-op in
+// self-host builds.
+func gateBootstrapServer(server string) error {
+	return hostpolicy.AllowedURL(server)
+}
+
+// gateRedeemResponse refuses a redeem response that tries to re-point the agent
+// at a non-allowlisted primary or backup control plane (design constraint 2:
+// the redeem-response redirect must be gated, not just the filename host).
+func gateRedeemResponse(res bootstrapResult) error {
+	if err := hostpolicy.AllowedURL(res.ServerURL); err != nil {
+		return err
+	}
+	if res.BackupServerURL != "" {
+		if err := hostpolicy.AllowedURL(res.BackupServerURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // bootstrapInstallData arrives via --install-data on the BootstrapEnroll
 // deferred CA's command line, formatted directly from
@@ -172,12 +196,26 @@ func runBootstrap() {
 		return // exit 0 — soft
 	}
 
+	if err := gateBootstrapServer(server); err != nil {
+		bsLog.Error("bootstrap refused: control-plane host not allowed", "error", err.Error())
+		fmt.Fprintf(os.Stderr, "Bootstrap failed: %v\n", err)
+		osExit(1) // hard — roll back the install; token NOT sent to this host
+		return
+	}
+
 	bsLog.Info("redeeming bootstrap token", "server", server)
 	res, err := redeemBootstrapToken(server, token)
 	if err != nil {
 		bsLog.Error("bootstrap token redemption failed", "error", err.Error())
 		fmt.Fprintf(os.Stderr, "Bootstrap failed: %v\n", err)
 		osExit(1) // hard — roll back the install (osExit: test seam, enroll_error.go)
+	}
+
+	if err := gateRedeemResponse(*res); err != nil {
+		bsLog.Error("bootstrap refused: redeem response host not allowed", "error", err.Error())
+		fmt.Fprintf(os.Stderr, "Bootstrap failed: %v\n", err)
+		osExit(1) // hard — roll back; do not adopt a non-allowlisted redirect
+		return
 	}
 
 	// Hand off to the existing enroll path via the package globals it reads.

--- a/agent/internal/agentapp/bootstrap_hostpolicy_test.go
+++ b/agent/internal/agentapp/bootstrap_hostpolicy_test.go
@@ -1,0 +1,46 @@
+package agentapp
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// gateBootstrapServer is the extracted, testable gate (implemented in Step 3).
+func TestGateBootstrapServer_HostedRefusesNonAllowlisted(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	if err := gateBootstrapServer("https://attacker.es"); err == nil {
+		t.Fatal("hosted build must refuse non-allowlisted bootstrap server before redeem")
+	}
+	if err := gateBootstrapServer("https://hosted-a.example"); err != nil {
+		t.Fatalf("hosted build must allow allowlisted bootstrap server, got %v", err)
+	}
+}
+
+func TestGateBootstrapServer_SelfHostAllowsAll(t *testing.T) {
+	if err := gateBootstrapServer("https://anything.example"); err != nil {
+		t.Fatalf("self-host must allow any bootstrap server, got %v", err)
+	}
+}
+
+func TestGateRedeemResponse_RefusesRedirectToC2(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	// Attacker points filename at an allowlisted-looking host that redeems and
+	// hands back a C2 serverUrl — must be refused before adoption.
+	res := bootstrapResult{ServerURL: "https://c2.attacker.es", BackupServerURL: ""}
+	if err := gateRedeemResponse(res); err == nil {
+		t.Fatal("must refuse redeem-response serverUrl on non-allowlisted host")
+	}
+	res2 := bootstrapResult{ServerURL: "https://hosted-a.example", BackupServerURL: "https://c2.attacker.es"}
+	if err := gateRedeemResponse(res2); err == nil {
+		t.Fatal("must refuse redeem-response backupServerUrl on non-allowlisted host")
+	}
+	res3 := bootstrapResult{ServerURL: "https://hosted-a.example", BackupServerURL: "https://hosted-a.example"}
+	if err := gateRedeemResponse(res3); err != nil {
+		t.Fatalf("must allow all-allowlisted redeem response, got %v", err)
+	}
+}

--- a/agent/internal/agentapp/bootstrap_refuse_before_disclose_test.go
+++ b/agent/internal/agentapp/bootstrap_refuse_before_disclose_test.go
@@ -1,0 +1,111 @@
+package agentapp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// TestRunBootstrapNeverDisclosesTokenToNonAllowlistedHost is the end-to-end
+// guard for the "refuse before disclosing" constraint: a hosted build must
+// reject a non-allowlisted control-plane host BEFORE the single-use bootstrap
+// token is transmitted to it.
+//
+// The unit tests around gateBootstrapServer prove the gate function returns an
+// error. They do NOT prove the gate runs first. Reordering the gate to sit
+// after redeemBootstrapToken, or dropping the osExit(1)/return, would leave
+// every one of those tests green while the token is handed to an attacker's
+// server — which is precisely the primitive this whole build mode exists to
+// remove. So assert on the wire: zero requests reach the host.
+//
+// Mirrors the hit-counter pattern in TestRunBootstrapSkipsRedeemWhenAlreadyEnrolled.
+func TestRunBootstrapNeverDisclosesTokenToNonAllowlistedHost(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	// Deliberately NOT enrolled (no agent_id): an already-enrolled config
+	// short-circuits before the gate, which would pass this test vacuously.
+	if err := os.WriteFile(cfgPath, []byte(
+		"log_file: "+filepath.ToSlash(filepath.Join(dir, "agent.log"))+"\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1) // any request here means the token left the process
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	// Hosted build. The httptest server listens on 127.0.0.1, which is not on
+	// this allowlist, so it stands in for the attacker-run control plane.
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	origCfg, origData, origQuiet := cfgFile, bootstrapInstallData, quietEnroll
+	t.Cleanup(func() { cfgFile, bootstrapInstallData, quietEnroll = origCfg, origData, origQuiet })
+	cfgFile, quietEnroll = cfgPath, true
+	bootstrapInstallData = `C:\dl\breeze-agent.msi|TESTTOKEN1|` + srv.URL
+
+	var exitCode atomic.Int32
+	exitCode.Store(-1)
+	origExit := osExit
+	osExit = func(code int) { exitCode.Store(int32(code)) }
+	t.Cleanup(func() { osExit = origExit })
+
+	runBootstrap()
+
+	if n := hits.Load(); n != 0 {
+		t.Errorf("bootstrap token was sent to a non-allowlisted host: %d request(s) reached it", n)
+	}
+	if c := exitCode.Load(); c != 1 {
+		t.Errorf("hosted bootstrap against a non-allowlisted host: osExit = %d, want 1 (hard refuse)", c)
+	}
+}
+
+// TestRunBootstrapSelfHostStillReachesTheServer is the companion regression
+// guard: the repo-default self-host build must be completely unrestricted, so
+// the SAME setup that is refused above must still reach the server. Without
+// this, the test above would keep passing if the gate started refusing every
+// host in every build — breaking every self-hosted install on the planet.
+func TestRunBootstrapSelfHostStillReachesTheServer(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(cfgPath, []byte(
+		"log_file: "+filepath.ToSlash(filepath.Join(dir, "agent.log"))+"\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusForbidden) // fail the redeem; we only care that it was attempted
+	}))
+	defer srv.Close()
+
+	// No SetAllowedHostsForTest call: this is the repo default (self-host).
+	if hostpolicy.Enforced() {
+		t.Fatal("repo default must be self-host (empty allowlist); hostpolicy.Enforced() is true")
+	}
+
+	origCfg, origData, origQuiet := cfgFile, bootstrapInstallData, quietEnroll
+	t.Cleanup(func() { cfgFile, bootstrapInstallData, quietEnroll = origCfg, origData, origQuiet })
+	cfgFile, quietEnroll = cfgPath, true
+	bootstrapInstallData = `C:\dl\breeze-agent.msi|TESTTOKEN1|` + srv.URL
+
+	origExit := osExit
+	osExit = func(code int) {} // redeem will fail against the 403; swallow the exit
+	t.Cleanup(func() { osExit = origExit })
+
+	runBootstrap()
+
+	if n := hits.Load(); n == 0 {
+		t.Error("self-host build did not contact the configured server: the host gate is not inert by default")
+	}
+}

--- a/agent/internal/agentapp/enroll_hostpolicy_test.go
+++ b/agent/internal/agentapp/enroll_hostpolicy_test.go
@@ -23,3 +23,56 @@ func TestGateEnrollPrimary_SelfHostAllowsAll(t *testing.T) {
 		t.Fatalf("self-host must allow any --server, got %v", err)
 	}
 }
+
+// gateEnrollResponseBackup refuses, in a hosted build, an enroll response
+// backup control-plane URL outside the compiled allowlist — enforced at
+// Enforced() tier (gap AND strict), unlike ValidateBackupServerURL's
+// Strict()-only gate on the existing-fleet paths it guards. It runs on the
+// raw response field, before resolveBackupServerURL's own validation, so a
+// strict build cannot swallow this refusal as a soft "dropped" seed instead.
+func TestGateEnrollResponseBackup_EnforcedRefusesNonAllowlisted_Gap(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+	// strictMode intentionally left off — a gap build must still refuse a
+	// non-allowlisted backup at fresh-enroll time, unlike the existing-fleet
+	// ValidateBackupServerURL path.
+
+	if err := gateEnrollResponseBackup("https://attacker.es"); err == nil {
+		t.Fatal("gap build must refuse a non-allowlisted enroll-response backup")
+	}
+}
+
+func TestGateEnrollResponseBackup_EnforcedRefusesNonAllowlisted_Strict(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	if err := gateEnrollResponseBackup("https://attacker.es"); err == nil {
+		t.Fatal("strict build must refuse a non-allowlisted enroll-response backup")
+	}
+}
+
+func TestGateEnrollResponseBackup_HostedAllowsAllowlisted(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example,hosted-b.example")
+	defer restore()
+
+	if err := gateEnrollResponseBackup("https://hosted-b.example"); err != nil {
+		t.Fatalf("hosted build must allow an allowlisted backup, got %v", err)
+	}
+}
+
+func TestGateEnrollResponseBackup_SelfHostAllowsAny(t *testing.T) {
+	if err := gateEnrollResponseBackup("https://attacker.es"); err != nil {
+		t.Fatalf("self-host must never refuse a backup, got %v", err)
+	}
+}
+
+func TestGateEnrollResponseBackup_EmptyIsNoOp(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	if err := gateEnrollResponseBackup(""); err != nil {
+		t.Fatalf("no backup in the response must not be refused, got %v", err)
+	}
+}

--- a/agent/internal/agentapp/enroll_hostpolicy_test.go
+++ b/agent/internal/agentapp/enroll_hostpolicy_test.go
@@ -1,0 +1,25 @@
+package agentapp
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+func TestGateEnrollPrimary_HostedAllowlist(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	if err := gateEnrollPrimary("https://evil.example"); err == nil {
+		t.Fatal("hosted build must refuse --server on non-allowlisted host")
+	}
+	if err := gateEnrollPrimary("https://hosted-a.example"); err != nil {
+		t.Fatalf("hosted build must allow allowlisted --server, got %v", err)
+	}
+}
+
+func TestGateEnrollPrimary_SelfHostAllowsAll(t *testing.T) {
+	if err := gateEnrollPrimary("https://anything.example"); err != nil {
+		t.Fatalf("self-host must allow any --server, got %v", err)
+	}
+}

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -606,7 +606,11 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	// Support session in support.go. runAgent alone would miss the two
 	// primary service deployment modes, which return into runAsService
 	// before ever reaching runAgent's own body.
-	log.Info("control-plane build mode", "mode", hostpolicy.Mode(), "allowedHosts", hostpolicy.Hosts())
+	buildModeLogArgs := []any{"mode", hostpolicy.Mode()}
+	if hostpolicy.Enforced() {
+		buildModeLogArgs = append(buildModeLogArgs, "allowedHosts", hostpolicy.Hosts())
+	}
+	log.Info("control-plane build mode", buildModeLogArgs...)
 	if err := checkPersistedServerAllowed(cfg); err != nil {
 		if hostpolicy.Strict() {
 			// Belt-and-braces: config.Load -> ValidateTiered already fatals
@@ -1148,12 +1152,6 @@ func runAgent() {
 			return
 		}
 	}
-
-	// Build-mode self-check (log + gap/strict enforcement) now lives in
-	// startAgentFn/startAgent — the shared choke point reached by every
-	// entry point, including the Windows SCM and Unix service-manager
-	// paths that return early into runAsService above and never reach
-	// this point in runAgent.
 
 	comps, err := startAgentFn(cfg)
 	if err != nil {

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -1227,6 +1227,26 @@ func resolveBackupServerURL(enrollSeed, bootstrapSeed, primaryServerURL string) 
 	return seed, nil
 }
 
+// gateEnrollResponseBackup refuses, in a hosted build, an enroll response
+// backup control-plane URL outside the compiled allowlist. It runs on the
+// RAW response field, BEFORE resolveBackupServerURL's precedence/validation
+// logic — exactly where gateRedeemResponse checks res.BackupServerURL in
+// bootstrap.go — and is gated at Enforced() tier (gap AND strict), not
+// ValidateBackupServerURL's Strict()-only gate on the EXISTING-fleet paths it
+// guards (heartbeat configUpdate push, self-heal). Running before
+// resolveBackupServerURL matters: that function's own ValidateBackupServerURL
+// call already soft-drops (warn + skip) a non-allowlisted backup under
+// Strict(), which would otherwise swallow this gate's hard refusal in a
+// strict build. Fresh enrollment is a fresh-install path, matching
+// gateBootstrapServer/gateRedeemResponse/gateEnrollPrimary. No-op in
+// self-host and when the response carries no backup.
+func gateEnrollResponseBackup(backup string) error {
+	if backup == "" {
+		return nil
+	}
+	return hostpolicy.AllowedURL(backup)
+}
+
 // applyEnrollResponseIdentity copies the identity/credential fields an
 // EnrollResponse carries into cfg: AgentID, AuthToken, WatchdogAuthToken,
 // HelperAuthToken, OrgID, SiteID, and DeviceID.
@@ -1556,6 +1576,16 @@ func enrollWithConfig(cfg *config.Config, cfgFile, enrollmentKey, secret string)
 	}
 
 	applyEnrollResponseIdentity(cfg, enrollResp)
+
+	// Refused, in a hosted build, BEFORE resolveBackupServerURL's own
+	// Strict()-only validation gets a chance to soft-drop it — see
+	// gateEnrollResponseBackup's doc comment. bootstrapServerURL (the
+	// fallback seed below) needs no separate gate here: it only ever arrives
+	// via the bootstrap flow, which already hard-refused it through
+	// gateRedeemResponse before enrollDevice ever ran.
+	if err := gateEnrollResponseBackup(enrollResp.BackupServerURL); err != nil {
+		return &enrollFailure{cat: catConfig, friendly: "enrollment refused: backup control-plane host not allowed", detail: err}
+	}
 
 	// Backup control-plane URL (#2288): enroll response wins; bootstrap value
 	// is the fallback. Validated before persisting — a bad value must not

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -599,6 +599,36 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 		return nil, fmt.Errorf("startAgent called with unenrolled config — caller must waitForEnrollment first")
 	}
 
+	// Build-mode self-check. Lives here — not in runAgent — because this is
+	// the single choke point every entry point reaches: console/Unix via
+	// runAgent's startAgentFn call, the Windows SCM service and the Unix
+	// runAsService loop (both call startAgentFn directly), and the Quick
+	// Support session in support.go. runAgent alone would miss the two
+	// primary service deployment modes, which return into runAsService
+	// before ever reaching runAgent's own body.
+	log.Info("control-plane build mode", "mode", hostpolicy.Mode(), "allowedHosts", hostpolicy.Hosts())
+	if err := checkPersistedServerAllowed(cfg); err != nil {
+		if hostpolicy.Strict() {
+			// Belt-and-braces: config.Load -> ValidateTiered already fatals
+			// on a persisted out-of-allowlist ServerURL before any caller
+			// reaches startAgent, but keeping an explicit refusal here makes
+			// the invariant local to the function that actually starts
+			// components, instead of depending on every caller having gone
+			// through config.Load first.
+			log.Error("hosted build refuses to run against this server", "error", err.Error())
+			fmt.Fprintf(os.Stderr,
+				"This is a Breeze hosted-edition build and cannot manage a self-hosted server.\n"+
+					"Use the self-host build instead. Details: %v\n", err)
+			osExit(1)
+			return nil, err
+		}
+		// Gap build: warn and keep running. The migration-needed signal
+		// (Task 8) surfaces this on the self-hosted dashboard so the admin
+		// can migrate before the strict build ships. Do NOT exit.
+		log.Warn("hosted-edition agent is managing a self-hosted server; migrate to the self-host build before the enforced release",
+			"error", err.Error())
+	}
+
 	// Quick Support clients are throwaway, unelevated, and live entirely in a
 	// temp workspace. They must never touch the machine-wide install: no
 	// self-update (a support session outlives nothing), and every ProgramData
@@ -1119,22 +1149,11 @@ func runAgent() {
 		}
 	}
 
-	log.Info("control-plane build mode", "mode", hostpolicy.Mode(), "allowedHosts", hostpolicy.Hosts())
-	if err := checkPersistedServerAllowed(cfg); err != nil {
-		if hostpolicy.Strict() {
-			log.Error("hosted build refuses to run against this server", "error", err.Error())
-			fmt.Fprintf(os.Stderr,
-				"This is a Breeze hosted-edition build and cannot manage a self-hosted server.\n"+
-					"Use the self-host build instead. Details: %v\n", err)
-			osExit(1)
-			return
-		}
-		// Gap build: warn and keep running. The migration-needed signal
-		// (Task 8) surfaces this on the self-hosted dashboard so the admin
-		// can migrate before the strict build ships. Do NOT exit.
-		log.Warn("hosted-edition agent is managing a self-hosted server; migrate to the self-host build before the enforced release",
-			"error", err.Error())
-	}
+	// Build-mode self-check (log + gap/strict enforcement) now lives in
+	// startAgentFn/startAgent — the shared choke point reached by every
+	// entry point, including the Windows SCM and Unix service-manager
+	// paths that return early into runAsService above and never reach
+	// this point in runAgent.
 
 	comps, err := startAgentFn(cfg)
 	if err != nil {

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -1269,7 +1269,7 @@ func assertHostnameNonEmpty(info *collectors.SystemInfo) error {
 // checkPersistedServerAllowed is a pure predicate: it reports the violation
 // when a hosted build (Enforced) has a persisted primary cfg.ServerURL
 // outside the compiled allowlist. It does NOT decide warn-vs-hard-fail —
-// that split is made by the caller in runAgent, gated on hostpolicy.Strict().
+// that split is made by the caller in startAgent, gated on hostpolicy.Strict().
 // Empty server (unenrolled) and self-host builds always return nil.
 func checkPersistedServerAllowed(cfg *config.Config) error {
 	if cfg == nil || cfg.ServerURL == "" {

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/breeze-rmm/agent/internal/elevaccount"
 	"github.com/breeze-rmm/agent/internal/eventlog"
 	"github.com/breeze-rmm/agent/internal/heartbeat"
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/internal/mtls"
@@ -1229,6 +1230,19 @@ func assertHostnameNonEmpty(info *collectors.SystemInfo) error {
 	return nil
 }
 
+// gateEnrollPrimary refuses, in a hosted build, a primary control-plane
+// server URL outside the compiled allowlist. serverURL is the one package
+// global fed by all three primary-server entry points — filename,
+// MSI property, and --server — so this single gate at the point it is
+// applied to cfg covers all of them. (The enroll *response* carries no
+// primary ServerURL — api.EnrollResponse has only BackupServerURL — so
+// there is no second gate needed on the response side, unlike bootstrap's
+// gateRedeemResponse.) No-op in self-host builds. Mirrors
+// gateBootstrapServer/gateRedeemResponse in bootstrap.go.
+func gateEnrollPrimary(server string) error {
+	return hostpolicy.AllowedURL(server)
+}
+
 func enrollDevice(enrollmentKey string) {
 	enrollmentKey, serverURL, enrollmentSecret = trimEnrollInputs(
 		enrollmentKey, serverURL, enrollmentSecret,
@@ -1240,6 +1254,19 @@ func enrollDevice(enrollmentKey string) {
 	}
 
 	if serverURL != "" {
+		// Gated here, before cfg.ServerURL is ever set: at this point in
+		// enrollDevice, logging has not been initialised yet (initEnrollLogging
+		// / the scoped enrollLog are set up a few lines below), so this uses
+		// enrollError — the function's existing four-sink failure reporter,
+		// which logs through the package-level `log` var rather than the
+		// not-yet-initialised enrollLog — exactly as the "server URL required"
+		// pre-flight check below does. catConfig is correct here: like that
+		// check, this fires before any HTTP call is made, so isRefundable4xx
+		// correctly treats it as non-refundable.
+		if err := gateEnrollPrimary(serverURL); err != nil {
+			enrollError(catConfig, "control-plane host not allowed", err)
+			return // enrollError does not return in production; belt-and-braces.
+		}
 		cfg.ServerURL = serverURL
 	}
 

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -1119,6 +1119,23 @@ func runAgent() {
 		}
 	}
 
+	log.Info("control-plane build mode", "mode", hostpolicy.Mode(), "allowedHosts", hostpolicy.Hosts())
+	if err := checkPersistedServerAllowed(cfg); err != nil {
+		if hostpolicy.Strict() {
+			log.Error("hosted build refuses to run against this server", "error", err.Error())
+			fmt.Fprintf(os.Stderr,
+				"This is a Breeze hosted-edition build and cannot manage a self-hosted server.\n"+
+					"Use the self-host build instead. Details: %v\n", err)
+			osExit(1)
+			return
+		}
+		// Gap build: warn and keep running. The migration-needed signal
+		// (Task 8) surfaces this on the self-hosted dashboard so the admin
+		// can migrate before the strict build ships. Do NOT exit.
+		log.Warn("hosted-edition agent is managing a self-hosted server; migrate to the self-host build before the enforced release",
+			"error", err.Error())
+	}
+
 	comps, err := startAgentFn(cfg)
 	if err != nil {
 		if isPermissionError(err) {
@@ -1228,6 +1245,18 @@ func assertHostnameNonEmpty(info *collectors.SystemInfo) error {
 		return errors.New("empty hostname after fallback chain")
 	}
 	return nil
+}
+
+// checkPersistedServerAllowed is a pure predicate: it reports the violation
+// when a hosted build (Enforced) has a persisted primary cfg.ServerURL
+// outside the compiled allowlist. It does NOT decide warn-vs-hard-fail —
+// that split is made by the caller in runAgent, gated on hostpolicy.Strict().
+// Empty server (unenrolled) and self-host builds always return nil.
+func checkPersistedServerAllowed(cfg *config.Config) error {
+	if cfg == nil || cfg.ServerURL == "" {
+		return nil
+	}
+	return hostpolicy.AllowedURL(cfg.ServerURL)
 }
 
 // gateEnrollPrimary refuses, in a hosted build, a primary control-plane

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -587,6 +587,47 @@ func runWithTimeout(name string, d time.Duration, fn func()) {
 	}
 }
 
+// enforceBuildModeGate is startAgent's build-mode self-check, extracted as a
+// named helper (mirroring checkPersistedServerAllowed/gateEnrollPrimary
+// above) so the gap/strict decision is directly testable without invoking
+// startAgent's full initialization (mTLS load, heartbeat bring-up, hardware
+// collection). Logs the resolved build mode, then on a persisted-server
+// violation either hard-refuses to start (strict — logs, prints an operator
+// message, calls osExit(1), and returns the violation error as a
+// belt-and-braces measure for a stubbed-osExit test) or warns and returns nil
+// (gap — the migration-needed heartbeat signal covers this case; see
+// migrationSignal). Self-host and an unenrolled/empty ServerURL always
+// return nil (checkPersistedServerAllowed's contract).
+func enforceBuildModeGate(cfg *config.Config) error {
+	buildModeLogArgs := []any{"mode", hostpolicy.Mode()}
+	if hostpolicy.Enforced() {
+		buildModeLogArgs = append(buildModeLogArgs, "allowedHosts", hostpolicy.Hosts())
+	}
+	log.Info("control-plane build mode", buildModeLogArgs...)
+	if err := checkPersistedServerAllowed(cfg); err != nil {
+		if hostpolicy.Strict() {
+			// Belt-and-braces: config.Load -> ValidateTiered already fatals
+			// on a persisted out-of-allowlist ServerURL before any caller
+			// reaches startAgent, but keeping an explicit refusal here makes
+			// the invariant local to the function that actually starts
+			// components, instead of depending on every caller having gone
+			// through config.Load first.
+			log.Error("hosted build refuses to run against this server", "error", err.Error())
+			fmt.Fprintf(os.Stderr,
+				"This is a Breeze hosted-edition build and cannot manage a self-hosted server.\n"+
+					"Use the self-host build instead. Details: %v\n", err)
+			osExit(1)
+			return err
+		}
+		// Gap build: warn and keep running. The migration-needed signal
+		// (Task 8) surfaces this on the self-hosted dashboard so the admin
+		// can migrate before the strict build ships. Do NOT exit.
+		log.Warn("hosted-edition agent is managing a self-hosted server; migrate to the self-host build before the enforced release",
+			"error", err.Error())
+	}
+	return nil
+}
+
 // startAgent performs all agent initialisation assuming cfg is already
 // enrolled. Returns the running components or an error if any
 // initialization step fails (mTLS load, log shipper init, heartbeat
@@ -606,31 +647,8 @@ func startAgent(cfg *config.Config) (*agentComponents, error) {
 	// Support session in support.go. runAgent alone would miss the two
 	// primary service deployment modes, which return into runAsService
 	// before ever reaching runAgent's own body.
-	buildModeLogArgs := []any{"mode", hostpolicy.Mode()}
-	if hostpolicy.Enforced() {
-		buildModeLogArgs = append(buildModeLogArgs, "allowedHosts", hostpolicy.Hosts())
-	}
-	log.Info("control-plane build mode", buildModeLogArgs...)
-	if err := checkPersistedServerAllowed(cfg); err != nil {
-		if hostpolicy.Strict() {
-			// Belt-and-braces: config.Load -> ValidateTiered already fatals
-			// on a persisted out-of-allowlist ServerURL before any caller
-			// reaches startAgent, but keeping an explicit refusal here makes
-			// the invariant local to the function that actually starts
-			// components, instead of depending on every caller having gone
-			// through config.Load first.
-			log.Error("hosted build refuses to run against this server", "error", err.Error())
-			fmt.Fprintf(os.Stderr,
-				"This is a Breeze hosted-edition build and cannot manage a self-hosted server.\n"+
-					"Use the self-host build instead. Details: %v\n", err)
-			osExit(1)
-			return nil, err
-		}
-		// Gap build: warn and keep running. The migration-needed signal
-		// (Task 8) surfaces this on the self-hosted dashboard so the admin
-		// can migrate before the strict build ships. Do NOT exit.
-		log.Warn("hosted-edition agent is managing a self-hosted server; migrate to the self-host build before the enforced release",
-			"error", err.Error())
+	if err := enforceBuildModeGate(cfg); err != nil {
+		return nil, err
 	}
 
 	// Quick Support clients are throwaway, unelevated, and live entirely in a

--- a/agent/internal/agentapp/startagent_gate_test.go
+++ b/agent/internal/agentapp/startagent_gate_test.go
@@ -1,0 +1,103 @@
+package agentapp
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+	"github.com/breeze-rmm/agent/internal/logging"
+)
+
+// TestEnforceBuildModeGate_Gap proves the untested half of startAgent's
+// gap/strict wiring: a gap build (allowlist set, strict off) with a
+// non-allowlisted persisted server must NOT exit and must let startup
+// proceed past the check (enforceBuildModeGate returns nil).
+func TestEnforceBuildModeGate_Gap(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+	// strictMode intentionally left off (gap build default).
+
+	exited := false
+	origExit := osExit
+	osExit = func(code int) { exited = true }
+	t.Cleanup(func() { osExit = origExit })
+
+	cfg := &config.Config{ServerURL: "https://selfhosted.example"}
+	if err := enforceBuildModeGate(cfg); err != nil {
+		t.Fatalf("gap build must not fail startup, got %v", err)
+	}
+	if exited {
+		t.Fatal("gap build must not call osExit")
+	}
+}
+
+// TestEnforceBuildModeGate_Strict proves the strict half: a strict build
+// with a non-allowlisted persisted server must call osExit(1) and return a
+// non-nil error (the refusal path startAgent's caller relies on).
+func TestEnforceBuildModeGate_Strict(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	var exitCode int
+	exited := false
+	origExit := osExit
+	osExit = func(code int) { exited = true; exitCode = code }
+	t.Cleanup(func() { osExit = origExit })
+
+	cfg := &config.Config{ServerURL: "https://selfhosted.example"}
+	err := enforceBuildModeGate(cfg)
+	if err == nil {
+		t.Fatal("strict build must return a non-nil error (refusal path)")
+	}
+	if !exited || exitCode != 1 {
+		t.Fatalf("strict build must call osExit(1); exited=%v code=%d", exited, exitCode)
+	}
+}
+
+// TestEnforceBuildModeGate_SelfHost is the untouched-by-default control: the
+// repo-default self-host build must never exit or fail startup, regardless
+// of the persisted server URL.
+func TestEnforceBuildModeGate_SelfHost(t *testing.T) {
+	origExit := osExit
+	osExit = func(code int) { t.Fatalf("self-host must never call osExit, got code %d", code) }
+	t.Cleanup(func() { osExit = origExit })
+
+	cfg := &config.Config{ServerURL: "https://anything.example"}
+	if err := enforceBuildModeGate(cfg); err != nil {
+		t.Fatalf("self-host build must not fail startup, got %v", err)
+	}
+}
+
+// TestEnforceBuildModeGate_LogAllowedHosts pins item 5's log-line fix at the
+// wiring level: self-host logs no allowedHosts attribute, while an enforced
+// (gap or strict) build does.
+func TestEnforceBuildModeGate_LogAllowedHosts(t *testing.T) {
+	origExit := osExit
+	osExit = func(code int) {}
+	t.Cleanup(func() { osExit = origExit })
+
+	var buf bytes.Buffer
+	logging.Init("text", "debug", &buf)
+	t.Cleanup(func() { logging.Init("text", "info", nil) })
+
+	if err := enforceBuildModeGate(&config.Config{}); err != nil {
+		t.Fatalf("self-host must not fail startup, got %v", err)
+	}
+	if strings.Contains(buf.String(), "allowedHosts") {
+		t.Errorf("self-host build-mode log must not include allowedHosts, got: %s", buf.String())
+	}
+
+	buf.Reset()
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+	if err := enforceBuildModeGate(&config.Config{ServerURL: "https://hosted-a.example"}); err != nil {
+		t.Fatalf("gap build with an allowlisted server must not fail startup, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "allowedHosts") {
+		t.Errorf("enforced build-mode log must include allowedHosts, got: %s", buf.String())
+	}
+}

--- a/agent/internal/agentapp/startup_hostpolicy_test.go
+++ b/agent/internal/agentapp/startup_hostpolicy_test.go
@@ -1,0 +1,33 @@
+package agentapp
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// checkPersistedServerAllowed is a pure predicate: it reports the violation
+// (hosted build + persisted primary ServerURL outside the allowlist) but does
+// not itself decide warn-vs-hard-fail — that split lives in runAgent, gated
+// on hostpolicy.Strict().
+func TestCheckPersistedServerAllowed(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	if err := checkPersistedServerAllowed(&config.Config{ServerURL: "https://selfhosted.example"}); err == nil {
+		t.Fatal("hosted build must report a violation for a non-allowlisted persisted server")
+	}
+	if err := checkPersistedServerAllowed(&config.Config{ServerURL: "https://hosted-a.example"}); err != nil {
+		t.Fatalf("hosted build must not report a violation for an allowlisted persisted server, got %v", err)
+	}
+	if err := checkPersistedServerAllowed(&config.Config{ServerURL: ""}); err != nil {
+		t.Fatalf("empty (unenrolled) server must not report a violation, got %v", err)
+	}
+}
+
+func TestCheckPersistedServerAllowed_SelfHost(t *testing.T) {
+	if err := checkPersistedServerAllowed(&config.Config{ServerURL: "https://anything.example"}); err != nil {
+		t.Fatalf("self-host must never report a violation, got %v", err)
+	}
+}

--- a/agent/internal/agentapp/support.go
+++ b/agent/internal/agentapp/support.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/breeze-rmm/agent/internal/collectors"
 	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
 	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/pkg/api"
 	"github.com/spf13/cobra"
@@ -263,6 +264,18 @@ func promptSupportInput(prefillServer string) (code, server string, err error) {
 	return "", server, errors.New("no valid support code entered")
 }
 
+// gateSupportServer refuses, in a hosted build, to redeem a support code
+// against (or adopt a redirect to) a control-plane host outside the compiled
+// allowlist. The support flow is a fresh connection with no prior enrollment
+// to fall back on, so it gates on hostpolicy.Enforced() the same way
+// AllowedURL already does — a signed binary must not be turned into an
+// arbitrary-server client via the Quick Support code path any more than via
+// bootstrap or normal enrollment. No-op in self-host builds. Mirrors
+// gateBootstrapServer/gateRedeemResponse in bootstrap.go.
+func gateSupportServer(server string) error {
+	return hostpolicy.AllowedURL(server)
+}
+
 // supportFail prints a user-facing failure and exits nonzero. The end user is
 // typically a non-technical person on the phone with a technician, so the
 // message names the next action rather than the internals.
@@ -357,6 +370,12 @@ func runSupportSession() {
 		osType = runtime.GOOS
 	}
 
+	if err := gateSupportServer(server); err != nil {
+		_ = os.RemoveAll(workDir)
+		supportFail("This build can only contact its configured Breeze server. Ask your technician for a new code.", err)
+		return
+	}
+
 	resp, err := api.RedeemSupportCode(server, code, hostname, osType)
 	if err != nil {
 		_ = os.RemoveAll(workDir)
@@ -372,8 +391,15 @@ func runSupportSession() {
 
 	// The redeem response is authoritative for the control-plane URL: a
 	// self-hosted deployment can hand back a different (e.g. externally
-	// reachable) address than the one the download link used.
+	// reachable) address than the one the download link used. Gated the same
+	// as the initial server: a hosted build must not adopt a redirect to a
+	// non-allowlisted host any more than it may redeem against one.
 	if strings.TrimSpace(resp.ServerURL) != "" {
+		if err := gateSupportServer(resp.ServerURL); err != nil {
+			_ = os.RemoveAll(workDir)
+			supportFail("This build can only contact its configured Breeze server. Ask your technician for a new code.", err)
+			return
+		}
 		cfg.ServerURL = strings.TrimSpace(resp.ServerURL)
 	}
 	cfg.SupportSessionID = resp.SessionID

--- a/agent/internal/agentapp/support_hostpolicy_test.go
+++ b/agent/internal/agentapp/support_hostpolicy_test.go
@@ -1,0 +1,32 @@
+package agentapp
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// gateSupportServer is the Quick Support redeem-path gate — the same
+// signed-binary-obeys-arbitrary-server primitive bootstrap and enrollment
+// already gate, applied to the support-code redeem flow. See
+// bootstrap_hostpolicy_test.go for the sibling gates on that path.
+func TestGateSupportServer_SelfHostAllowsAny(t *testing.T) {
+	if err := gateSupportServer("https://anything.example"); err != nil {
+		t.Fatalf("self-host must allow any support server, got %v", err)
+	}
+	if err := gateSupportServer("https://attacker.es"); err != nil {
+		t.Fatalf("self-host must allow any support server, got %v", err)
+	}
+}
+
+func TestGateSupportServer_HostedRefusesNonAllowlisted(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	if err := gateSupportServer("https://attacker.es"); err == nil {
+		t.Fatal("hosted build must refuse a non-allowlisted support server")
+	}
+	if err := gateSupportServer("https://hosted-a.example"); err != nil {
+		t.Fatalf("hosted build must allow the allowlisted support server, got %v", err)
+	}
+}

--- a/agent/internal/config/validate.go
+++ b/agent/internal/config/validate.go
@@ -102,7 +102,31 @@ func (c *Config) ValidateTiered() ValidationResult {
 	}
 
 	if err := ValidateBackupServerURL(c.BackupServerURL); err != nil {
-		result.Fatals = append(result.Fatals, err)
+		// LOAD-path degrade: a strict build with a non-allowlisted PERSISTED
+		// backup must not fatal startup over an existing-fleet backup that
+		// predates a hosted flip — degrade to warn + clear, mirroring the
+		// backup==primary self-heal immediately below, rather than letting
+		// this reach config load's fatal-Aborts-startup path. Only this
+		// LOAD-path evaluation degrades: ingestion paths (heartbeat
+		// configUpdate push, enroll-response adoption, bootstrap redeem
+		// response) call ValidateBackupServerURL directly and must keep
+		// erroring on a NEW non-allowlisted backup — see that function's own
+		// doc comment, which is intentionally unchanged here.
+		//
+		// ValidateBackupServerURL doesn't expose which check failed, so
+		// distinguishing "the backup is well-formed but not allowlisted"
+		// from any other validation failure (malformed URL, disallowed
+		// scheme — which stay fatal) means re-checking hostpolicy directly.
+		// Gap builds never reach this branch: ValidateBackupServerURL only
+		// hostpolicy-checks under Strict(), so under gap err is nil here
+		// whenever the only problem would have been the allowlist.
+		if hostpolicy.Strict() && hostpolicy.AllowedURL(c.BackupServerURL) != nil {
+			result.Warnings = append(result.Warnings, fmt.Errorf(
+				"persisted backup_server_url is not an allowed control-plane host for this build; clearing it: %w", err))
+			c.BackupServerURL = ""
+		} else {
+			result.Fatals = append(result.Fatals, err)
+		}
 	}
 	// Self-heal a backup equal to the primary (a torn promote persist could
 	// leave this on disk, #2288): it is useless as a failover target and the

--- a/agent/internal/config/validate.go
+++ b/agent/internal/config/validate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
 	"github.com/breeze-rmm/agent/internal/logging"
 )
 
@@ -88,6 +89,15 @@ func (c *Config) ValidateTiered() ValidationResult {
 			result.Fatals = append(result.Fatals, fmt.Errorf("server_url %q is not a valid URL: %w", c.ServerURL, err))
 		} else if u.Scheme != "http" && u.Scheme != "https" {
 			result.Fatals = append(result.Fatals, fmt.Errorf("server_url scheme must be http or https, got %q", u.Scheme))
+		} else if hostpolicy.Strict() {
+			// GAP-MODEL: only the strict build hard-fails a non-allowlisted
+			// primary server_url on this existing-fleet runtime path. A gap
+			// build (allowlist set, strict off) must not degrade a
+			// self-hosted fleet's persisted config — the migration is
+			// signaled elsewhere, not enforced here.
+			if err := hostpolicy.AllowedURL(c.ServerURL); err != nil {
+				result.Fatals = append(result.Fatals, err)
+			}
 		}
 	}
 
@@ -256,6 +266,15 @@ func ValidateBackupServerURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil || u.Host == "" {
 		return fmt.Errorf("backup_server_url %q is not a valid URL", raw)
+	}
+	if hostpolicy.Strict() {
+		// GAP-MODEL: only the strict build refuses a non-allowlisted backup
+		// host on this existing-fleet runtime path (enroll-response backup,
+		// heartbeat configUpdate push, self-heal). A gap build accepts it —
+		// the migration is signaled elsewhere, not enforced here.
+		if err := hostpolicy.AllowedURL(raw); err != nil {
+			return err
+		}
 	}
 	switch u.Scheme {
 	case "https":

--- a/agent/internal/config/validate_hostpolicy_test.go
+++ b/agent/internal/config/validate_hostpolicy_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// GAP-MODEL: this is an existing-fleet runtime path. Enforcement must gate on
+// hostpolicy.Strict() (allowlist set AND strictMode on), not Enforced()
+// (allowlist set alone). A gap build (allowlist set, strict off) must keep
+// accepting non-allowlisted backup/primary URLs — the migration is signaled
+// elsewhere, not enforced on this path. Only the later strict build rejects
+// them. See hostpolicy package docs and Task 4 brief GAP-MODEL banner.
+
+func TestValidateBackupServerURL_HostedAllowlist_StrictRejects(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example,hosted-b.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	if err := ValidateBackupServerURL("https://attacker.es"); err == nil {
+		t.Fatal("strict hosted build must reject non-allowlisted backup_server_url")
+	}
+	if err := ValidateBackupServerURL("https://hosted-b.example"); err != nil {
+		t.Fatalf("strict hosted build must accept allowlisted backup, got %v", err)
+	}
+	if err := ValidateBackupServerURL(""); err != nil {
+		t.Fatalf("empty backup must remain valid (clears backup), got %v", err)
+	}
+}
+
+func TestValidateBackupServerURL_GapModeAcceptsNonAllowlisted(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example,hosted-b.example")
+	defer restoreHosts()
+	// strictMode intentionally left off (gap build default).
+
+	if err := ValidateBackupServerURL("https://attacker.es"); err != nil {
+		t.Fatalf("gap build must accept non-allowlisted backup_server_url (no hard enforcement yet), got %v", err)
+	}
+}
+
+func TestValidateBackupServerURL_SelfHostUnrestricted(t *testing.T) {
+	if err := ValidateBackupServerURL("https://anything.example"); err != nil {
+		t.Fatalf("self-host must accept any https backup, got %v", err)
+	}
+}
+
+func TestValidateTiered_HostedRejectsNonAllowlistedPrimary_Strict(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	c := &Config{ServerURL: "https://attacker.es"}
+	res := c.ValidateTiered()
+	if !res.HasFatals() {
+		t.Fatal("strict hosted build must fatal on non-allowlisted server_url")
+	}
+
+	c2 := &Config{ServerURL: "https://hosted-a.example"}
+	if c2.ValidateTiered().HasFatals() {
+		t.Fatal("strict hosted build must accept allowlisted server_url")
+	}
+}
+
+func TestValidateTiered_GapModeAcceptsNonAllowlistedPrimary(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	// strictMode intentionally left off (gap build default).
+
+	c := &Config{ServerURL: "https://attacker.es"}
+	if c.ValidateTiered().HasFatals() {
+		t.Fatal("gap build must accept non-allowlisted server_url (no hard enforcement yet)")
+	}
+}

--- a/agent/internal/config/validate_hostpolicy_test.go
+++ b/agent/internal/config/validate_hostpolicy_test.go
@@ -74,3 +74,95 @@ func TestValidateTiered_GapModeAcceptsNonAllowlistedPrimary(t *testing.T) {
 		t.Fatal("gap build must accept non-allowlisted server_url (no hard enforcement yet)")
 	}
 }
+
+// TestValidateTiered_StrictDegradesNonAllowlistedPersistedBackup is the
+// LOAD-path degrade: a strict build with an allowlisted primary but a
+// non-allowlisted PERSISTED backup must not fatal startup (config load ->
+// os.Exit(1) in runAgent/runWatchdog) over an existing-fleet backup that
+// predates a hosted flip. It must instead warn and clear the field —
+// mirroring the backup==primary self-heal a few lines below in
+// ValidateTiered. This is deliberately narrower than
+// ValidateBackupServerURL's own Strict()-tier error, which ingestion paths
+// (heartbeat configUpdate push, enroll-response adoption, bootstrap redeem
+// response) still rely on to reject a NEW non-allowlisted backup outright —
+// see TestValidateBackupServerURL_HostedAllowlist_StrictRejects above, which
+// calls ValidateBackupServerURL directly and must keep failing.
+func TestValidateTiered_StrictDegradesNonAllowlistedPersistedBackup(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	c := &Config{ServerURL: "https://hosted-a.example", BackupServerURL: "https://attacker.es"}
+	res := c.ValidateTiered()
+
+	if res.HasFatals() {
+		t.Fatalf("strict build must not fatal on a non-allowlisted persisted backup, got fatals: %v", res.Fatals)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatal("strict build must warn about a non-allowlisted persisted backup being cleared")
+	}
+	if c.BackupServerURL != "" {
+		t.Errorf("non-allowlisted persisted backup must be cleared, got %q", c.BackupServerURL)
+	}
+}
+
+// TestValidateTiered_StrictNonAllowlistedPrimaryStillFatal is the negative
+// control: the primary ServerURL fatal must be completely unaffected by the
+// backup degrade above.
+func TestValidateTiered_StrictNonAllowlistedPrimaryStillFatal(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	c := &Config{ServerURL: "https://attacker.es"}
+	if !c.ValidateTiered().HasFatals() {
+		t.Fatal("strict build must still fatal on a non-allowlisted PRIMARY server_url")
+	}
+}
+
+// TestValidateTiered_GapModeDoesNotClearNonAllowlistedBackup proves gap mode
+// must not degrade either: the persisted backup is left untouched, exactly
+// like the pre-existing gap-mode primary behavior above. ValidateBackupServerURL
+// itself doesn't hostpolicy-check under gap, so this also confirms the load
+// path adds no gap-mode enforcement.
+func TestValidateTiered_GapModeDoesNotClearNonAllowlistedBackup(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	// strictMode intentionally left off (gap build default).
+
+	c := &Config{ServerURL: "https://hosted-a.example", BackupServerURL: "https://attacker.es"}
+	res := c.ValidateTiered()
+	if res.HasFatals() {
+		t.Fatalf("gap build must not fatal on a non-allowlisted persisted backup, got: %v", res.Fatals)
+	}
+	if c.BackupServerURL != "https://attacker.es" {
+		t.Errorf("gap build must not clear a non-allowlisted persisted backup, got %q", c.BackupServerURL)
+	}
+}
+
+// TestValidateTiered_GapModeMalformedNonAllowlistedBackupStaysFatal is the
+// edge case that makes the degrade's own Strict() guard load-bearing rather
+// than redundant: hostpolicy.AllowedURL gates on Enforced() (gap OR strict),
+// not Strict(), so a gap build with the allowlist compiled in still sees
+// AllowedURL return non-nil for a non-allowlisted host. Without an explicit
+// Strict() check in the degrade condition, a persisted backup that is BOTH
+// a genuine scheme violation (non-https, non-localhost — unconditionally
+// fatal in every build) AND non-allowlisted would be misclassified as the
+// hostpolicy case and incorrectly warn+cleared in gap mode instead of
+// fataling like every other malformed backup.
+func TestValidateTiered_GapModeMalformedNonAllowlistedBackupStaysFatal(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	// strictMode intentionally left off (gap build default).
+
+	c := &Config{ServerURL: "https://hosted-a.example", BackupServerURL: "http://attacker.es"}
+	res := c.ValidateTiered()
+	if !res.HasFatals() {
+		t.Fatal("gap build must still fatal on a malformed (non-https) backup, even when it is also non-allowlisted")
+	}
+	if c.BackupServerURL != "http://attacker.es" {
+		t.Errorf("a fatal validation failure must not clear the field, got %q", c.BackupServerURL)
+	}
+}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -31,6 +31,7 @@ import (
 	"github.com/breeze-rmm/agent/internal/executor"
 	"github.com/breeze-rmm/agent/internal/health"
 	"github.com/breeze-rmm/agent/internal/helper"
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
 	"github.com/breeze-rmm/agent/internal/httputil"
 	"github.com/breeze-rmm/agent/internal/ipc"
 	"github.com/breeze-rmm/agent/internal/logging"
@@ -3495,6 +3496,18 @@ func (h *Heartbeat) recordHeartbeatFailure(payload *HeartbeatPayload) {
 // Only the URL that actually passed the probe may be promoted; re-reading
 // config here bricked stragglers with server_url="" during migrations.
 func (h *Heartbeat) promoteBackupServerURL(probedURL string) {
+	// Defense-in-depth: Task 4 already gated ingestion of backup_server_url,
+	// so probedURL should only ever be a previously-allowlisted value. This
+	// guards against a torn-persist or a backup that predates the hosted
+	// flip. Gated on Strict() (not Enforced()) so an existing-fleet gap
+	// build keeps promoting normally — only a strict build refuses.
+	if hostpolicy.Strict() {
+		if err := hostpolicy.AllowedURL(probedURL); err != nil {
+			log.Warn("refusing failover promotion to non-allowlisted host",
+				"host", probedURL, "error", err.Error())
+			return
+		}
+	}
 	if probedURL == "" {
 		log.Error("refusing to promote empty backup server URL")
 		return

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -137,8 +137,8 @@ type HeartbeatPayload struct {
 	// self-healing pattern, NOT the sticky isVirtual pattern) so a resolved
 	// condition clears a dashboard migration banner on the next beat.
 	// omitempty on both: a self-host build (the only build in this repo
-	// today) reports "" / false, so the wire payload is byte-identical to
-	// pre-Task-8 agents.
+	// today) reports "" / false — both omitempty fields drop out — so the
+	// wire payload is byte-identical to pre-Task-8 agents.
 	AgentEdition      string `json:"agentEdition,omitempty"`
 	MigrationRequired bool   `json:"migrationRequired,omitempty"`
 }
@@ -147,10 +147,12 @@ type HeartbeatPayload struct {
 // hosted build currently talking to a non-allowlisted server (migration
 // needed). Pure; independent of hostpolicy.Strict() — reporting is
 // telemetry, not enforcement, so it fires the same in gap and strict hosted
-// builds.
+// builds. Self-host returns ("", false) — NOT "self-host" — because the
+// AgentEdition field is omitempty: only the empty string drops out of the
+// wire payload, preserving byte-identity with pre-Task-8 agents.
 func migrationSignal(server string) (edition string, migrationRequired bool) {
 	if !hostpolicy.Enforced() {
-		return "self-host", false
+		return "", false
 	}
 	return "hosted", hostpolicy.AllowedURL(server) != nil
 }

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -131,6 +131,28 @@ type HeartbeatPayload struct {
 	// — which this build never does, but the server must not assume "object
 	// present" implies "version 1" either. See SecurityCapabilities below.
 	SecurityCapabilities SecurityCapabilities `json:"securityCapabilities"`
+	// AgentEdition + MigrationRequired are the hosted/self-host build-edition
+	// telemetry signal (Phase 1 gap model, Task 8). Sent every heartbeat and
+	// written unconditionally server-side (the outboundNetworkPolicyVersion
+	// self-healing pattern, NOT the sticky isVirtual pattern) so a resolved
+	// condition clears a dashboard migration banner on the next beat.
+	// omitempty on both: a self-host build (the only build in this repo
+	// today) reports "" / false, so the wire payload is byte-identical to
+	// pre-Task-8 agents.
+	AgentEdition      string `json:"agentEdition,omitempty"`
+	MigrationRequired bool   `json:"migrationRequired,omitempty"`
+}
+
+// migrationSignal reports the agent's build edition and whether it is a
+// hosted build currently talking to a non-allowlisted server (migration
+// needed). Pure; independent of hostpolicy.Strict() — reporting is
+// telemetry, not enforcement, so it fires the same in gap and strict hosted
+// builds.
+func migrationSignal(server string) (edition string, migrationRequired bool) {
+	if !hostpolicy.Enforced() {
+		return "self-host", false
+	}
+	return "hosted", hostpolicy.AllowedURL(server) != nil
 }
 
 // SecurityCapabilities is the agent's outbound-network-policy capability
@@ -3668,6 +3690,9 @@ func (h *Heartbeat) sendHeartbeat() {
 		// toggle.
 		SecurityCapabilities: SecurityCapabilities{OutboundNetworkPolicyVersion: 1},
 	}
+	// Hosted/self-host build-edition + migration-needed telemetry (Task 8).
+	// Independent of hostpolicy.Strict() — see migrationSignal doc comment.
+	payload.AgentEdition, payload.MigrationRequired = migrationSignal(h.ServerURL())
 
 	h.mu.Lock()
 	if h.helperLifecycle != nil {

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -3528,6 +3528,10 @@ func (h *Heartbeat) recordHeartbeatFailure(payload *HeartbeatPayload) {
 // Only the URL that actually passed the probe may be promoted; re-reading
 // config here bricked stragglers with server_url="" during migrations.
 func (h *Heartbeat) promoteBackupServerURL(probedURL string) {
+	if probedURL == "" {
+		log.Error("refusing to promote empty backup server URL")
+		return
+	}
 	// Defense-in-depth: Task 4 already gated ingestion of backup_server_url,
 	// so probedURL should only ever be a previously-allowlisted value. This
 	// guards against a torn-persist or a backup that predates the hosted
@@ -3539,10 +3543,6 @@ func (h *Heartbeat) promoteBackupServerURL(probedURL string) {
 				"host", probedURL, "error", err.Error())
 			return
 		}
-	}
-	if probedURL == "" {
-		log.Error("refusing to promote empty backup server URL")
-		return
 	}
 	h.mu.Lock()
 	oldPrimary := h.config.ServerURL

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -144,17 +144,25 @@ type HeartbeatPayload struct {
 }
 
 // migrationSignal reports the agent's build edition and whether it is a
-// hosted build currently talking to a non-allowlisted server (migration
-// needed). Pure; independent of hostpolicy.Strict() — reporting is
-// telemetry, not enforcement, so it fires the same in gap and strict hosted
-// builds. Self-host returns ("", false) — NOT "self-host" — because the
+// hosted build currently talking to a non-allowlisted primary OR persisted
+// backup server (migration needed). backup is checked only when non-empty —
+// nothing is persisted to violate the allowlist when there is no backup.
+// Pure; independent of hostpolicy.Strict() — reporting is telemetry, not
+// enforcement, so it fires the same in gap and strict hosted builds.
+// Self-host returns ("", false) — NOT "self-host" — because the
 // AgentEdition field is omitempty: only the empty string drops out of the
 // wire payload, preserving byte-identity with pre-Task-8 agents.
-func migrationSignal(server string) (edition string, migrationRequired bool) {
+func migrationSignal(server, backup string) (edition string, migrationRequired bool) {
 	if !hostpolicy.Enforced() {
 		return "", false
 	}
-	return "hosted", hostpolicy.AllowedURL(server) != nil
+	if hostpolicy.AllowedURL(server) != nil {
+		return "hosted", true
+	}
+	if backup != "" && hostpolicy.AllowedURL(backup) != nil {
+		return "hosted", true
+	}
+	return "hosted", false
 }
 
 // SecurityCapabilities is the agent's outbound-network-policy capability
@@ -3694,7 +3702,10 @@ func (h *Heartbeat) sendHeartbeat() {
 	}
 	// Hosted/self-host build-edition + migration-needed telemetry (Task 8).
 	// Independent of hostpolicy.Strict() — see migrationSignal doc comment.
-	payload.AgentEdition, payload.MigrationRequired = migrationSignal(h.ServerURL())
+	// Checks the persisted backup as well as the primary so a hosted-gap
+	// build with an allowlisted primary but a non-allowlisted backup still
+	// surfaces the dashboard migration banner.
+	payload.AgentEdition, payload.MigrationRequired = migrationSignal(h.ServerURL(), h.BackupServerURL())
 
 	h.mu.Lock()
 	if h.helperLifecycle != nil {

--- a/agent/internal/heartbeat/migration_signal_test.go
+++ b/agent/internal/heartbeat/migration_signal_test.go
@@ -10,19 +10,48 @@ func TestMigrationSignal(t *testing.T) {
 	// Self-host build: empty edition (omitempty drops it from the wire
 	// payload, keeping byte-identity with pre-Task-8 agents), never
 	// migration-needed.
-	if e, m := migrationSignal("https://anything.example"); e != "" || m {
+	if e, m := migrationSignal("https://anything.example", ""); e != "" || m {
 		t.Fatalf("self-host: want (\"\",false), got (%s,%v)", e, m)
 	}
 
 	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
 	defer restore()
 
-	// Hosted build on an allowlisted server: edition hosted, no migration.
-	if e, m := migrationSignal("https://hosted-a.example"); e != "hosted" || m {
-		t.Fatalf("hosted allowlisted: want (hosted,false), got (%s,%v)", e, m)
+	// Hosted build on an allowlisted server, no backup: edition hosted, no migration.
+	if e, m := migrationSignal("https://hosted-a.example", ""); e != "hosted" || m {
+		t.Fatalf("hosted allowlisted, no backup: want (hosted,false), got (%s,%v)", e, m)
+	}
+	// Hosted build on an allowlisted primary AND an allowlisted backup: no migration.
+	if e, m := migrationSignal("https://hosted-a.example", "https://hosted-a.example"); e != "hosted" || m {
+		t.Fatalf("hosted allowlisted primary+backup: want (hosted,false), got (%s,%v)", e, m)
 	}
 	// Hosted build on a non-allowlisted (self-hosted) server: migration needed.
-	if e, m := migrationSignal("https://selfhosted.example"); e != "hosted" || !m {
+	if e, m := migrationSignal("https://selfhosted.example", ""); e != "hosted" || !m {
 		t.Fatalf("hosted non-allowlisted: want (hosted,true), got (%s,%v)", e, m)
+	}
+}
+
+// TestMigrationSignal_DivergentBackup is the regression guard for the gap
+// migrationSignal used to have: a hosted build with an allowlisted primary
+// but a non-allowlisted persisted backup emitted no migration signal at all,
+// because the function only ever inspected the primary. A hosted-gap build
+// running against such a fleet would never surface the dashboard migration
+// banner.
+func TestMigrationSignal_DivergentBackup(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	// Primary allowlisted, backup NOT allowlisted: migration needed.
+	if e, m := migrationSignal("https://hosted-a.example", "https://selfhosted.example"); e != "hosted" || !m {
+		t.Fatalf("allowlisted primary + non-allowlisted backup: want (hosted,true), got (%s,%v)", e, m)
+	}
+	// Both non-allowlisted: still migration needed (primary alone already
+	// triggers it — this just confirms the backup check doesn't mask that).
+	if e, m := migrationSignal("https://selfhosted.example", "https://also-selfhosted.example"); e != "hosted" || !m {
+		t.Fatalf("non-allowlisted primary + backup: want (hosted,true), got (%s,%v)", e, m)
+	}
+	// Empty backup must never itself trigger a signal (nothing persisted to violate).
+	if e, m := migrationSignal("https://hosted-a.example", ""); e != "hosted" || m {
+		t.Fatalf("allowlisted primary + empty backup: want (hosted,false), got (%s,%v)", e, m)
 	}
 }

--- a/agent/internal/heartbeat/migration_signal_test.go
+++ b/agent/internal/heartbeat/migration_signal_test.go
@@ -1,0 +1,26 @@
+package heartbeat
+
+import (
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+func TestMigrationSignal(t *testing.T) {
+	// Self-host build: edition self-host, never migration-needed.
+	if e, m := migrationSignal("https://anything.example"); e != "self-host" || m {
+		t.Fatalf("self-host: want (self-host,false), got (%s,%v)", e, m)
+	}
+
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	// Hosted build on an allowlisted server: edition hosted, no migration.
+	if e, m := migrationSignal("https://hosted-a.example"); e != "hosted" || m {
+		t.Fatalf("hosted allowlisted: want (hosted,false), got (%s,%v)", e, m)
+	}
+	// Hosted build on a non-allowlisted (self-hosted) server: migration needed.
+	if e, m := migrationSignal("https://selfhosted.example"); e != "hosted" || !m {
+		t.Fatalf("hosted non-allowlisted: want (hosted,true), got (%s,%v)", e, m)
+	}
+}

--- a/agent/internal/heartbeat/migration_signal_test.go
+++ b/agent/internal/heartbeat/migration_signal_test.go
@@ -7,9 +7,11 @@ import (
 )
 
 func TestMigrationSignal(t *testing.T) {
-	// Self-host build: edition self-host, never migration-needed.
-	if e, m := migrationSignal("https://anything.example"); e != "self-host" || m {
-		t.Fatalf("self-host: want (self-host,false), got (%s,%v)", e, m)
+	// Self-host build: empty edition (omitempty drops it from the wire
+	// payload, keeping byte-identity with pre-Task-8 agents), never
+	// migration-needed.
+	if e, m := migrationSignal("https://anything.example"); e != "" || m {
+		t.Fatalf("self-host: want (\"\",false), got (%s,%v)", e, m)
 	}
 
 	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")

--- a/agent/internal/heartbeat/migration_signal_wire_test.go
+++ b/agent/internal/heartbeat/migration_signal_wire_test.go
@@ -20,7 +20,7 @@ import (
 // agents, so assert on the marshalled bytes.
 func TestHeartbeatPayloadWireByteIdentity(t *testing.T) {
 	var payload HeartbeatPayload
-	payload.AgentEdition, payload.MigrationRequired = migrationSignal("https://selfhosted.example")
+	payload.AgentEdition, payload.MigrationRequired = migrationSignal("https://selfhosted.example", "")
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -43,7 +43,7 @@ func TestHeartbeatPayloadWireHostedSignal(t *testing.T) {
 	defer restore()
 
 	var payload HeartbeatPayload
-	payload.AgentEdition, payload.MigrationRequired = migrationSignal("https://selfhosted.example")
+	payload.AgentEdition, payload.MigrationRequired = migrationSignal("https://selfhosted.example", "")
 
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/agent/internal/heartbeat/migration_signal_wire_test.go
+++ b/agent/internal/heartbeat/migration_signal_wire_test.go
@@ -1,0 +1,63 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// TestHeartbeatPayloadWireByteIdentity pins the omitempty contract on the
+// build-edition telemetry fields at the JSON layer, which is the only layer
+// where it actually matters.
+//
+// TestMigrationSignal asserts migrationSignal() returns ("", false) for a
+// self-host build, but that is a Go-level claim: dropping `omitempty` from
+// either struct tag would leave it green while every self-hosted agent in
+// the field silently starts sending two new keys. The whole point of the
+// zero values is that the wire payload stays byte-identical to pre-edition
+// agents, so assert on the marshalled bytes.
+func TestHeartbeatPayloadWireByteIdentity(t *testing.T) {
+	var payload HeartbeatPayload
+	payload.AgentEdition, payload.MigrationRequired = migrationSignal("https://selfhosted.example")
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal self-host payload: %v", err)
+	}
+	for _, key := range []string{`"agentEdition"`, `"migrationRequired"`} {
+		if strings.Contains(string(body), key) {
+			t.Errorf("self-host heartbeat payload must not carry %s on the wire "+
+				"(omitempty dropped from the struct tag?)", key)
+		}
+	}
+}
+
+// TestHeartbeatPayloadWireHostedSignal is the other half of the contract: a
+// hosted build talking to a non-allowlisted server MUST put both keys on the
+// wire, or the server never learns the device needs migrating and the
+// dashboard banner never fires.
+func TestHeartbeatPayloadWireHostedSignal(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	var payload HeartbeatPayload
+	payload.AgentEdition, payload.MigrationRequired = migrationSignal("https://selfhosted.example")
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal hosted payload: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal hosted payload: %v", err)
+	}
+	if decoded["agentEdition"] != "hosted" {
+		t.Errorf("hosted build: agentEdition = %v, want %q", decoded["agentEdition"], "hosted")
+	}
+	if decoded["migrationRequired"] != true {
+		t.Errorf("hosted build on a non-allowlisted server: migrationRequired = %v, want true",
+			decoded["migrationRequired"])
+	}
+}

--- a/agent/internal/heartbeat/promote_hostpolicy_test.go
+++ b/agent/internal/heartbeat/promote_hostpolicy_test.go
@@ -3,9 +3,11 @@ package heartbeat
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/breeze-rmm/agent/internal/hostpolicy"
+	"github.com/breeze-rmm/agent/internal/logging"
 )
 
 // TestPromoteBackup_StrictRefusesNonAllowlisted is the defense-in-depth check
@@ -52,5 +54,43 @@ func TestPromoteBackup_GapPromotesNormally(t *testing.T) {
 
 	if got := h.serverURL(); got != backupURL {
 		t.Fatalf("gap build must promote normally (no degradation); primary = %q, want %q", got, backupURL)
+	}
+}
+
+// TestPromoteBackup_EmptyProbedURLDiagnosticRunsFirst pins the log-ordering
+// contract: the pre-existing empty-probedURL diagnostic must run BEFORE the
+// hostpolicy refusal check, not after. hostpolicy.AllowedURL("") also
+// returns a "not a parseable URL" error, so with the checks in the wrong
+// order an empty probedURL under a strict build silently logs the
+// hostpolicy-refusal message instead of the empty-URL diagnostic — the two
+// return paths are behaviourally identical (neither promotes), so this can
+// only be observed on the log output, not on heartbeat state.
+func TestPromoteBackup_EmptyProbedURLDiagnosticRunsFirst(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	buf := &syncBuffer{}
+	logging.Init("text", "debug", buf)
+	t.Cleanup(func() { logging.Init("text", "info", nil) })
+
+	const primaryURL = "https://hosted-a.example"
+	cfg := swapTestConfig(t, primaryURL, "")
+	h := newFailoverTestHeartbeat(cfg, failoverRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("unexpected HTTP call: promotion must not make network requests")
+	}))
+
+	h.promoteBackupServerURL("")
+
+	out := buf.String()
+	if !strings.Contains(out, "refusing to promote empty backup server URL") {
+		t.Errorf("expected the empty-probedURL diagnostic in the log, got: %s", out)
+	}
+	if strings.Contains(out, "refusing failover promotion to non-allowlisted host") {
+		t.Errorf("empty probedURL must not fall through to the hostpolicy refusal message, got: %s", out)
+	}
+	if got := h.serverURL(); got != primaryURL {
+		t.Fatalf("empty probedURL must never promote; primary = %q, want unchanged %q", got, primaryURL)
 	}
 }

--- a/agent/internal/heartbeat/promote_hostpolicy_test.go
+++ b/agent/internal/heartbeat/promote_hostpolicy_test.go
@@ -1,0 +1,56 @@
+package heartbeat
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// TestPromoteBackup_StrictRefusesNonAllowlisted is the defense-in-depth check
+// for the strict build: promoteBackupServerURL must refuse to swap in a
+// non-allowlisted host and leave the current primary untouched, even though
+// Task 4 already gated ingestion of the backup_server_url that reaches here.
+func TestPromoteBackup_StrictRefusesNonAllowlisted(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	const primaryURL = "https://hosted-a.example"
+	cfg := swapTestConfig(t, primaryURL, "")
+	h := newFailoverTestHeartbeat(cfg, failoverRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("unexpected HTTP call: promotion must not make network requests")
+	}))
+
+	h.promoteBackupServerURL("https://attacker.es")
+
+	if got := h.serverURL(); got != primaryURL {
+		t.Fatalf("strict build must not promote non-allowlisted host; primary now %q, want unchanged %q", got, primaryURL)
+	}
+}
+
+// TestPromoteBackup_GapPromotesNormally proves the gap build (allowlist set,
+// strict mode off) does not degrade existing-fleet failover: a probed backup
+// that isn't on the allowlist is still promoted, matching pre-hostpolicy
+// behavior.
+func TestPromoteBackup_GapPromotesNormally(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+
+	const (
+		primaryURL = "https://hosted-a.example"
+		backupURL  = "https://attacker.es" // not allowlisted; gap build must still promote it
+	)
+	cfg := swapTestConfig(t, primaryURL, backupURL)
+	h := newFailoverTestHeartbeat(cfg, failoverRoundTripper(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("unexpected HTTP call: promotion must not make network requests")
+	}))
+
+	h.promoteBackupServerURL(backupURL)
+
+	if got := h.serverURL(); got != backupURL {
+		t.Fatalf("gap build must promote normally (no degradation); primary = %q, want %q", got, backupURL)
+	}
+}

--- a/agent/internal/hostpolicy/hostpolicy.go
+++ b/agent/internal/hostpolicy/hostpolicy.go
@@ -99,7 +99,7 @@ func AllowedURL(rawURL string) error {
 	}
 	u, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil || u.Host == "" {
-		return fmt.Errorf("hosted build: control-plane URL %q is not a parseable https URL", rawURL)
+		return fmt.Errorf("hosted build: control-plane URL %q is not a parseable URL", rawURL)
 	}
 	if !AllowedHost(u.Hostname()) {
 		return fmt.Errorf("hosted build refuses control-plane host %q (allowed: %s)",

--- a/agent/internal/hostpolicy/hostpolicy.go
+++ b/agent/internal/hostpolicy/hostpolicy.go
@@ -79,8 +79,8 @@ func Hosts() []string {
 
 // AllowedHost reports whether host (bare hostname, no port) is permitted.
 // Self-host permits everything. Matching is exact and case-insensitive — there is
-// deliberately NO wildcard/suffix logic, so "2breeze.app.evil.com" never matches
-// an allowlisted "us.2breeze.app".
+// deliberately NO wildcard/suffix logic, so "hosted-a.example.evil.com" never matches
+// an allowlisted "hosted-a.example".
 func AllowedHost(host string) bool {
 	if !Enforced() {
 		return true

--- a/agent/internal/hostpolicy/hostpolicy.go
+++ b/agent/internal/hostpolicy/hostpolicy.go
@@ -13,6 +13,7 @@
 package hostpolicy
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -125,7 +126,10 @@ func AllowedURL(rawURL string) error {
 	}
 	u, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil || u.Host == "" {
-		return fmt.Errorf("hosted build: control-plane URL %q is not a parseable URL", rawURL)
+		// Deliberately does NOT echo rawURL: a malformed URL may embed a
+		// token or query string, and this error is documented as safe to
+		// surface/log verbatim.
+		return errors.New("hosted build: control-plane URL is not a parseable URL")
 	}
 	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
 	if _, ok := s.hosts[host]; !ok {

--- a/agent/internal/hostpolicy/hostpolicy.go
+++ b/agent/internal/hostpolicy/hostpolicy.go
@@ -1,0 +1,127 @@
+// Package hostpolicy enforces the compile-time control-plane host allowlist that
+// distinguishes a "hosted" Breeze build (may only contact Breeze-operated
+// control planes) from a "self-host" build (unrestricted).
+//
+// The allowlist is injected at build time via:
+//
+//	-ldflags "-X github.com/breeze-rmm/agent/internal/hostpolicy.allowedHosts=host1,host2"
+//
+// An EMPTY allowedHosts (the repo default) means self-host mode: no restriction,
+// identical to historical behavior — so this control is inert until a build opts
+// into hosted mode. Never commit a non-empty value; infra hostnames stay out of
+// source (see CLAUDE.md "No Internal Infrastructure Details").
+package hostpolicy
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// allowedHosts is the ldflag-injected, comma-separated list of exact,
+// case-insensitive control-plane hostnames a hosted build may contact.
+// Empty => self-host (unrestricted).
+var allowedHosts = ""
+
+// strictMode is ldflag-injected ("1"/"true"/anything non-empty => strict).
+// Empty (repo default, and the gap build) => warn mode: existing-fleet
+// violations are detected and reported rather than hard-failed. Meaningless
+// without allowedHosts.
+//
+//	-ldflags "-X github.com/breeze-rmm/agent/internal/hostpolicy.strictMode=1"
+var strictMode = ""
+
+// parsed is the normalized allowlist set, (re)computed from allowedHosts.
+var parsed = parseHosts(allowedHosts)
+
+// strict is the normalized strict flag, (re)computed from strictMode.
+var strict = strings.TrimSpace(strictMode) != ""
+
+func parseHosts(raw string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, h := range strings.Split(raw, ",") {
+		if h = strings.ToLower(strings.TrimSpace(h)); h != "" {
+			set[h] = struct{}{}
+		}
+	}
+	return set
+}
+
+// Enforced reports whether this build restricts control-plane hosts (hosted mode,
+// gap OR strict).
+func Enforced() bool { return len(parsed) > 0 }
+
+// Strict reports whether existing-fleet violations hard-fail (the strict build).
+// False in a gap build (allowlist set, strictMode empty) and in self-host.
+func Strict() bool { return Enforced() && strict }
+
+// Mode returns "hosted-strict", "hosted-gap", or "self-host", for logging.
+func Mode() string {
+	if !Enforced() {
+		return "self-host"
+	}
+	if strict {
+		return "hosted-strict"
+	}
+	return "hosted-gap"
+}
+
+// Hosts returns the sorted allowlist (empty in self-host), for error/log text.
+func Hosts() []string {
+	out := make([]string, 0, len(parsed))
+	for h := range parsed {
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// AllowedHost reports whether host (bare hostname, no port) is permitted.
+// Self-host permits everything. Matching is exact and case-insensitive — there is
+// deliberately NO wildcard/suffix logic, so "2breeze.app.evil.com" never matches
+// an allowlisted "us.2breeze.app".
+func AllowedHost(host string) bool {
+	if !Enforced() {
+		return true
+	}
+	_, ok := parsed[strings.ToLower(strings.TrimSpace(host))]
+	return ok
+}
+
+// AllowedURL parses rawURL and checks its hostname (port stripped). Returns nil
+// when allowed or in self-host mode. In hosted mode a malformed URL is refused.
+// The returned error is safe to surface/log: it names only the offending host and
+// the allowlist, never a token or secret.
+func AllowedURL(rawURL string) error {
+	if !Enforced() {
+		return nil
+	}
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("hosted build: control-plane URL %q is not a parseable https URL", rawURL)
+	}
+	if !AllowedHost(u.Hostname()) {
+		return fmt.Errorf("hosted build refuses control-plane host %q (allowed: %s)",
+			u.Hostname(), strings.Join(Hosts(), ", "))
+	}
+	return nil
+}
+
+// SetAllowedHostsForTest overrides the compiled allowlist at runtime for TESTS
+// ONLY and returns a restore func. Not safe for production use (mutates package
+// state without synchronization).
+func SetAllowedHostsForTest(csv string) (restore func()) {
+	prev := parsed
+	parsed = parseHosts(csv)
+	return func() { parsed = prev }
+}
+
+// SetStrictModeForTest overrides strict mode at runtime for TESTS ONLY and
+// returns a restore func. Not safe for production use (mutates package state
+// without synchronization).
+func SetStrictModeForTest(on bool) (restore func()) {
+	prev := strict
+	strict = on
+	return func() { strict = prev }
+}

--- a/agent/internal/hostpolicy/hostpolicy.go
+++ b/agent/internal/hostpolicy/hostpolicy.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync/atomic"
 )
 
 // allowedHosts is the ldflag-injected, comma-separated list of exact,
@@ -32,11 +33,26 @@ var allowedHosts = ""
 //	-ldflags "-X github.com/breeze-rmm/agent/internal/hostpolicy.strictMode=1"
 var strictMode = ""
 
-// parsed is the normalized allowlist set, (re)computed from allowedHosts.
-var parsed = parseHosts(allowedHosts)
+// snapshot is the immutable, derived form of the two ldflag inputs (or of a
+// test-seam override — see testseams.go). It is never mutated after
+// construction; a new snapshot is built and swapped in wholesale, which is
+// what makes concurrent reads (heartbeat loop, updater) safe without a mutex.
+type snapshot struct {
+	hosts  map[string]struct{}
+	strict bool
+}
 
-// strict is the normalized strict flag, (re)computed from strictMode.
-var strict = strings.TrimSpace(strictMode) != ""
+// current holds the active snapshot. Loaded by every predicate below and
+// swapped atomically by the test seams. Production code never calls Store —
+// the snapshot is fixed at process start from the ldflag-injected vars.
+var current atomic.Pointer[snapshot]
+
+func init() {
+	current.Store(&snapshot{
+		hosts:  parseHosts(allowedHosts),
+		strict: strings.TrimSpace(strictMode) != "",
+	})
+}
 
 func parseHosts(raw string) map[string]struct{} {
 	set := make(map[string]struct{})
@@ -48,20 +64,33 @@ func parseHosts(raw string) map[string]struct{} {
 	return set
 }
 
+func sortedHosts(hosts map[string]struct{}) []string {
+	out := make([]string, 0, len(hosts))
+	for h := range hosts {
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // Enforced reports whether this build restricts control-plane hosts (hosted mode,
 // gap OR strict).
-func Enforced() bool { return len(parsed) > 0 }
+func Enforced() bool { return len(current.Load().hosts) > 0 }
 
 // Strict reports whether existing-fleet violations hard-fail (the strict build).
 // False in a gap build (allowlist set, strictMode empty) and in self-host.
-func Strict() bool { return Enforced() && strict }
+func Strict() bool {
+	s := current.Load()
+	return len(s.hosts) > 0 && s.strict
+}
 
 // Mode returns "hosted-strict", "hosted-gap", or "self-host", for logging.
 func Mode() string {
-	if !Enforced() {
+	s := current.Load()
+	if len(s.hosts) == 0 {
 		return "self-host"
 	}
-	if strict {
+	if s.strict {
 		return "hosted-strict"
 	}
 	return "hosted-gap"
@@ -69,12 +98,7 @@ func Mode() string {
 
 // Hosts returns the sorted allowlist (empty in self-host), for error/log text.
 func Hosts() []string {
-	out := make([]string, 0, len(parsed))
-	for h := range parsed {
-		out = append(out, h)
-	}
-	sort.Strings(out)
-	return out
+	return sortedHosts(current.Load().hosts)
 }
 
 // AllowedHost reports whether host (bare hostname, no port) is permitted.
@@ -82,10 +106,11 @@ func Hosts() []string {
 // deliberately NO wildcard/suffix logic, so "hosted-a.example.evil.com" never matches
 // an allowlisted "hosted-a.example".
 func AllowedHost(host string) bool {
-	if !Enforced() {
+	s := current.Load()
+	if len(s.hosts) == 0 {
 		return true
 	}
-	_, ok := parsed[strings.ToLower(strings.TrimSpace(host))]
+	_, ok := s.hosts[strings.ToLower(strings.TrimSpace(host))]
 	return ok
 }
 
@@ -94,34 +119,18 @@ func AllowedHost(host string) bool {
 // The returned error is safe to surface/log: it names only the offending host and
 // the allowlist, never a token or secret.
 func AllowedURL(rawURL string) error {
-	if !Enforced() {
+	s := current.Load()
+	if len(s.hosts) == 0 {
 		return nil
 	}
 	u, err := url.Parse(strings.TrimSpace(rawURL))
 	if err != nil || u.Host == "" {
 		return fmt.Errorf("hosted build: control-plane URL %q is not a parseable URL", rawURL)
 	}
-	if !AllowedHost(u.Hostname()) {
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	if _, ok := s.hosts[host]; !ok {
 		return fmt.Errorf("hosted build refuses control-plane host %q (allowed: %s)",
-			u.Hostname(), strings.Join(Hosts(), ", "))
+			u.Hostname(), strings.Join(sortedHosts(s.hosts), ", "))
 	}
 	return nil
-}
-
-// SetAllowedHostsForTest overrides the compiled allowlist at runtime for TESTS
-// ONLY and returns a restore func. Not safe for production use (mutates package
-// state without synchronization).
-func SetAllowedHostsForTest(csv string) (restore func()) {
-	prev := parsed
-	parsed = parseHosts(csv)
-	return func() { parsed = prev }
-}
-
-// SetStrictModeForTest overrides strict mode at runtime for TESTS ONLY and
-// returns a restore func. Not safe for production use (mutates package state
-// without synchronization).
-func SetStrictModeForTest(on bool) (restore func()) {
-	prev := strict
-	strict = on
-	return func() { strict = prev }
 }

--- a/agent/internal/hostpolicy/hostpolicy_test.go
+++ b/agent/internal/hostpolicy/hostpolicy_test.go
@@ -1,0 +1,81 @@
+// agent/internal/hostpolicy/hostpolicy_test.go
+package hostpolicy
+
+import "testing"
+
+func TestSelfHostDefaultAllowsEverything(t *testing.T) {
+	// Repo default: allowedHosts is empty => self-host => unrestricted.
+	if Enforced() {
+		t.Fatalf("repo default must be self-host (Enforced()=false), got hosted")
+	}
+	if Mode() != "self-host" {
+		t.Fatalf("Mode()=%q, want self-host", Mode())
+	}
+	for _, h := range []string{"anything.example", "attacker.es", ""} {
+		if !AllowedHost(h) {
+			t.Errorf("self-host must allow %q", h)
+		}
+	}
+	if err := AllowedURL("https://attacker.es/x"); err != nil {
+		t.Errorf("self-host AllowedURL must be nil, got %v", err)
+	}
+}
+
+func TestHostedExactMatchAndSuffixAttack(t *testing.T) {
+	restore := SetAllowedHostsForTest("us.2breeze.app, eu.2breeze.app")
+	defer restore()
+
+	if !Enforced() || Mode() != "hosted-gap" {
+		t.Fatalf("expected hosted-gap mode after allowlist override, got %q", Mode())
+	}
+	if Strict() {
+		t.Fatal("strict must be false when only the allowlist is set (gap build)")
+	}
+	// Allowed: exact, case-insensitive, with port.
+	for _, ok := range []string{
+		"https://us.2breeze.app/api",
+		"https://US.2Breeze.App/api",
+		"https://eu.2breeze.app:443/api",
+	} {
+		if err := AllowedURL(ok); err != nil {
+			t.Errorf("AllowedURL(%q) should pass, got %v", ok, err)
+		}
+	}
+	// Refused: suffix attack, subdomain injection, lookalike, unparseable.
+	for _, bad := range []string{
+		"https://2breeze.app.evil.com/api", // suffix attack
+		"https://us.2breeze.app.evil.com",  // suffix attack
+		"https://evil-us.2breeze.app",      // not exact
+		"https://app.2breeze.app",          // sibling not allowlisted
+		"https://attacker.es",
+		"://nonsense",
+	} {
+		if err := AllowedURL(bad); err == nil {
+			t.Errorf("AllowedURL(%q) must be refused in hosted mode", bad)
+		}
+	}
+}
+
+func TestHostedRejectsUnparseableAndEmpty(t *testing.T) {
+	restore := SetAllowedHostsForTest("us.2breeze.app")
+	defer restore()
+	for _, bad := range []string{"", "   ", "not a url", "https://"} {
+		if err := AllowedURL(bad); err == nil {
+			t.Errorf("hosted AllowedURL(%q) must error", bad)
+		}
+	}
+}
+
+func TestStrictModeGate(t *testing.T) {
+	// Strict is meaningless without an allowlist.
+	rs := SetStrictModeForTest(true)
+	defer rs()
+	if Strict() {
+		t.Fatal("Strict() must be false in self-host even with strictMode set")
+	}
+	ra := SetAllowedHostsForTest("us.2breeze.app")
+	defer ra()
+	if !Strict() || Mode() != "hosted-strict" {
+		t.Fatalf("expected hosted-strict when both set, got Strict()=%v Mode()=%q", Strict(), Mode())
+	}
+}

--- a/agent/internal/hostpolicy/hostpolicy_test.go
+++ b/agent/internal/hostpolicy/hostpolicy_test.go
@@ -2,6 +2,7 @@
 package hostpolicy
 
 import (
+	"strings"
 	"sync"
 	"testing"
 )
@@ -76,6 +77,25 @@ func TestHostedExactMatchAndSuffixAttack(t *testing.T) {
 		if err := AllowedURL(bad); err == nil {
 			t.Errorf("AllowedURL(%q) must be refused in hosted mode", bad)
 		}
+	}
+}
+
+// TestHostedUnparseableURLErrorDoesNotEchoRawInput pins the doc claim on
+// AllowedURL ("the returned error ... never a token or secret"): a malformed
+// URL may embed a token or query string, so the unparseable-URL branch must
+// not format the raw input verbatim into the error.
+func TestHostedUnparseableURLErrorDoesNotEchoRawInput(t *testing.T) {
+	restore := SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	const secret = "s3cr3t-token-value"
+	bad := "not a url?token=" + secret
+	err := AllowedURL(bad)
+	if err == nil {
+		t.Fatalf("AllowedURL(%q) must error", bad)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Errorf("AllowedURL error must not echo the raw (possibly secret-bearing) input, got: %v", err)
 	}
 }
 

--- a/agent/internal/hostpolicy/hostpolicy_test.go
+++ b/agent/internal/hostpolicy/hostpolicy_test.go
@@ -21,6 +21,26 @@ func TestSelfHostDefaultAllowsEverything(t *testing.T) {
 	}
 }
 
+// TestCommittedLdflagVarsAreEmpty pins the repo-default contract for BOTH
+// injected vars, not just allowedHosts. A committed non-empty allowedHosts
+// would violate the CLAUDE.md "no internal infrastructure details in public
+// code" rule; a committed non-empty strictMode would arm the hard-fail tier
+// for every self-hosted build the moment an allowlist appeared. Both must be
+// injected at build time only, so both are asserted here.
+func TestCommittedLdflagVarsAreEmpty(t *testing.T) {
+	if allowedHosts != "" {
+		t.Errorf("committed allowedHosts must be empty, got %q "+
+			"(hosted values are injected by the release pipeline, never committed)", allowedHosts)
+	}
+	if strictMode != "" {
+		t.Errorf("committed strictMode must be empty, got %q "+
+			"(strict is a build-time opt-in, never the repo default)", strictMode)
+	}
+	if Strict() {
+		t.Error("repo default must not be strict")
+	}
+}
+
 func TestHostedExactMatchAndSuffixAttack(t *testing.T) {
 	restore := SetAllowedHostsForTest("hosted-a.example, hosted-b.example")
 	defer restore()

--- a/agent/internal/hostpolicy/hostpolicy_test.go
+++ b/agent/internal/hostpolicy/hostpolicy_test.go
@@ -44,8 +44,8 @@ func TestHostedExactMatchAndSuffixAttack(t *testing.T) {
 	// Refused: suffix attack, subdomain injection, lookalike, unparseable.
 	for _, bad := range []string{
 		"https://hosted-a.example.evil.com/api", // suffix attack
-		"https://hosted-a.example.evil.com",  // suffix attack
-		"https://evil-hosted-a.example",      // not exact
+		"https://hosted-a.example.evil.com",     // suffix attack
+		"https://evil-hosted-a.example",         // not exact
 		"https://app.hosted-a.example",          // sibling not allowlisted
 		"https://attacker.es",
 		"://nonsense",

--- a/agent/internal/hostpolicy/hostpolicy_test.go
+++ b/agent/internal/hostpolicy/hostpolicy_test.go
@@ -22,7 +22,7 @@ func TestSelfHostDefaultAllowsEverything(t *testing.T) {
 }
 
 func TestHostedExactMatchAndSuffixAttack(t *testing.T) {
-	restore := SetAllowedHostsForTest("us.2breeze.app, eu.2breeze.app")
+	restore := SetAllowedHostsForTest("hosted-a.example, hosted-b.example")
 	defer restore()
 
 	if !Enforced() || Mode() != "hosted-gap" {
@@ -33,9 +33,9 @@ func TestHostedExactMatchAndSuffixAttack(t *testing.T) {
 	}
 	// Allowed: exact, case-insensitive, with port.
 	for _, ok := range []string{
-		"https://us.2breeze.app/api",
-		"https://US.2Breeze.App/api",
-		"https://eu.2breeze.app:443/api",
+		"https://hosted-a.example/api",
+		"https://HOSTED-A.Example/api",
+		"https://hosted-b.example:443/api",
 	} {
 		if err := AllowedURL(ok); err != nil {
 			t.Errorf("AllowedURL(%q) should pass, got %v", ok, err)
@@ -43,10 +43,10 @@ func TestHostedExactMatchAndSuffixAttack(t *testing.T) {
 	}
 	// Refused: suffix attack, subdomain injection, lookalike, unparseable.
 	for _, bad := range []string{
-		"https://2breeze.app.evil.com/api", // suffix attack
-		"https://us.2breeze.app.evil.com",  // suffix attack
-		"https://evil-us.2breeze.app",      // not exact
-		"https://app.2breeze.app",          // sibling not allowlisted
+		"https://hosted-a.example.evil.com/api", // suffix attack
+		"https://hosted-a.example.evil.com",  // suffix attack
+		"https://evil-hosted-a.example",      // not exact
+		"https://app.hosted-a.example",          // sibling not allowlisted
 		"https://attacker.es",
 		"://nonsense",
 	} {
@@ -57,7 +57,7 @@ func TestHostedExactMatchAndSuffixAttack(t *testing.T) {
 }
 
 func TestHostedRejectsUnparseableAndEmpty(t *testing.T) {
-	restore := SetAllowedHostsForTest("us.2breeze.app")
+	restore := SetAllowedHostsForTest("hosted-a.example")
 	defer restore()
 	for _, bad := range []string{"", "   ", "not a url", "https://"} {
 		if err := AllowedURL(bad); err == nil {
@@ -73,7 +73,7 @@ func TestStrictModeGate(t *testing.T) {
 	if Strict() {
 		t.Fatal("Strict() must be false in self-host even with strictMode set")
 	}
-	ra := SetAllowedHostsForTest("us.2breeze.app")
+	ra := SetAllowedHostsForTest("hosted-a.example")
 	defer ra()
 	if !Strict() || Mode() != "hosted-strict" {
 		t.Fatalf("expected hosted-strict when both set, got Strict()=%v Mode()=%q", Strict(), Mode())

--- a/agent/internal/hostpolicy/hostpolicy_test.go
+++ b/agent/internal/hostpolicy/hostpolicy_test.go
@@ -1,7 +1,10 @@
 // agent/internal/hostpolicy/hostpolicy_test.go
 package hostpolicy
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestSelfHostDefaultAllowsEverything(t *testing.T) {
 	// Repo default: allowedHosts is empty => self-host => unrestricted.
@@ -98,4 +101,40 @@ func TestStrictModeGate(t *testing.T) {
 	if !Strict() || Mode() != "hosted-strict" {
 		t.Fatalf("expected hosted-strict when both set, got Strict()=%v Mode()=%q", Strict(), Mode())
 	}
+}
+
+// TestConcurrentSeamSwapAndReadIsRaceFree pins the concurrency contract the
+// test seams must uphold: the heartbeat loop and updater read the predicates
+// (AllowedHost, Mode, Hosts) from arbitrary goroutines while a test can be
+// swapping the seam state on another. Before the atomic-snapshot fix, both
+// sides touched unsynchronized package globals directly and this test failed
+// under `go test -race`.
+func TestConcurrentSeamSwapAndReadIsRaceFree(t *testing.T) {
+	restore := SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				AllowedHost("hosted-a.example")
+				_ = Mode()
+				_ = Hosts()
+				_ = AllowedURL("https://hosted-a.example/x")
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		r := SetAllowedHostsForTest("hosted-b.example")
+		r()
+	}
+	close(stop)
+	wg.Wait()
 }

--- a/agent/internal/hostpolicy/testseams.go
+++ b/agent/internal/hostpolicy/testseams.go
@@ -1,0 +1,36 @@
+package hostpolicy
+
+// TEST ONLY. SetAllowedHostsForTest and SetStrictModeForTest let tests in
+// this and other packages (config, agentapp, heartbeat, updater) exercise
+// hosted/strict-mode behavior without rebuilding the binary with ldflags.
+//
+// Importing "testing" from a non-test file is deliberate here, and scoped to
+// exactly this guard: testing.Testing() reports whether the current binary
+// was built by `go test`, so both seams panic when called from a production
+// binary. That keeps the override capability out of shipped builds while
+// leaving it usable from any package's test files, since all of them run
+// inside a `go test` binary in the same process.
+
+import "testing"
+
+// SetAllowedHostsForTest overrides the compiled allowlist at runtime for TESTS
+// ONLY and returns a restore func. Panics if called outside `go test`.
+func SetAllowedHostsForTest(csv string) (restore func()) {
+	if !testing.Testing() {
+		panic("hostpolicy test seams are test-only")
+	}
+	prev := current.Load()
+	current.Store(&snapshot{hosts: parseHosts(csv), strict: prev.strict})
+	return func() { current.Store(prev) }
+}
+
+// SetStrictModeForTest overrides strict mode at runtime for TESTS ONLY and
+// returns a restore func. Panics if called outside `go test`.
+func SetStrictModeForTest(on bool) (restore func()) {
+	if !testing.Testing() {
+		panic("hostpolicy test seams are test-only")
+	}
+	prev := current.Load()
+	current.Store(&snapshot{hosts: prev.hosts, strict: on})
+	return func() { current.Store(prev) }
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
 	"github.com/breeze-rmm/agent/internal/logging"
 	"github.com/breeze-rmm/agent/internal/netpolicy"
 	"github.com/breeze-rmm/agent/internal/secmem"
@@ -105,6 +106,30 @@ func New(cfg *Config) *Updater {
 	}
 }
 
+// filterControlPlaneOrigins drops any control-plane origin outside the
+// compiled allowlist. Identity (no filtering) in self-host AND in a gap
+// build (allowlist compiled in, strict mode off) — existing-fleet agents on
+// a gap build must keep functioning unchanged; only a strict build hard-
+// filters. It filters ONLY the control-plane origin set passed to
+// netpolicy, never the signed download target, which may legitimately be a
+// cross-origin CDN URL (checksum + Ed25519 manifest-signature bound) —
+// see updaterPolicy's doc comment below.
+func filterControlPlaneOrigins(origins []string) []string {
+	if !hostpolicy.Strict() {
+		return origins
+	}
+	out := make([]string, 0, len(origins))
+	for _, o := range origins {
+		if o == "" {
+			continue
+		}
+		if hostpolicy.AllowedURL(o) == nil {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
 // updaterPolicy builds the netpolicy.Policy that governs every network
 // destination this Updater talks to. ControlPlaneOrigins carries BOTH the
 // primary (cfg.ServerURL()) and the configured backup server URL, snapshotted
@@ -114,7 +139,8 @@ func New(cfg *Config) *Updater {
 // what grants cleartext HTTP and private-address reachability for the
 // ControlPlaneDownload purpose; omitting either origin silently makes that
 // control plane's downloads fail with cleartext_not_allowed or
-// private_address_not_allowed.
+// private_address_not_allowed. Origins are then passed through
+// filterControlPlaneOrigins, which is a no-op outside a strict hosted build.
 func updaterPolicy(cfg *Config) netpolicy.Policy {
 	var origins []string
 	if cfg != nil {
@@ -123,6 +149,7 @@ func updaterPolicy(cfg *Config) netpolicy.Policy {
 		}
 		origins = append(origins, cfg.BackupServerURL)
 	}
+	origins = filterControlPlaneOrigins(origins)
 	return netpolicy.Policy{
 		Purpose:             netpolicy.ControlPlaneDownload,
 		ControlPlaneOrigins: origins,

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -107,13 +107,25 @@ func New(cfg *Config) *Updater {
 }
 
 // filterControlPlaneOrigins drops any control-plane origin outside the
-// compiled allowlist. Identity (no filtering) in self-host AND in a gap
-// build (allowlist compiled in, strict mode off) — existing-fleet agents on
-// a gap build must keep functioning unchanged; only a strict build hard-
-// filters. It filters ONLY the control-plane origin set passed to
-// netpolicy, never the signed download target, which may legitimately be a
-// cross-origin CDN URL (checksum + Ed25519 manifest-signature bound) —
-// see updaterPolicy's doc comment below.
+// compiled allowlist from the ControlPlaneOrigins list passed to netpolicy.
+// Identity (no filtering) in self-host AND in a gap build (allowlist
+// compiled in, strict mode off) — existing-fleet agents on a gap build must
+// keep functioning unchanged; only a strict build filters.
+//
+// What dropping an origin actually gates: ControlPlaneOrigins membership
+// grants exactly two things at that origin — reachability to a private
+// address, and (for ControlPlaneDownload) permission to use plain HTTP (see
+// netpolicy.Policy.ControlPlaneOrigins). It does NOT, by itself, block an
+// HTTPS request to a public host at that origin — netpolicy permits that
+// regardless of ControlPlaneOrigins membership. So filtering a
+// non-allowlisted control-plane origin here is not a guarantee that a
+// strict build refuses to talk to it; it only withdraws the private-address
+// and cleartext-HTTP grants for that origin.
+//
+// It filters ONLY the control-plane origin set passed to netpolicy, never
+// the signed download target, which may legitimately be a cross-origin CDN
+// URL (checksum + Ed25519 manifest-signature bound) — see updaterPolicy's
+// doc comment below.
 func filterControlPlaneOrigins(origins []string) []string {
 	if !hostpolicy.Strict() {
 		return origins

--- a/agent/internal/updater/updater_hostpolicy_test.go
+++ b/agent/internal/updater/updater_hostpolicy_test.go
@@ -1,0 +1,51 @@
+package updater
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// TestFilterControlPlaneOrigins_Strict verifies that a strict hosted build
+// drops any origin outside the compiled allowlist.
+func TestFilterControlPlaneOrigins_Strict(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	in := []string{"https://hosted-a.example", "https://stale.attacker.es", ""}
+	got := filterControlPlaneOrigins(in)
+	want := []string{"https://hosted-a.example"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filterControlPlaneOrigins=%v, want %v", got, want)
+	}
+}
+
+// TestFilterControlPlaneOrigins_Gap verifies that an existing-fleet gap
+// build (allowlist compiled in, but strict mode off) leaves origins
+// untouched — matching the runtime GAP-MODEL: identity in self-host AND
+// gap, filtering only in strict.
+func TestFilterControlPlaneOrigins_Gap(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(false)
+	defer restoreStrict()
+
+	in := []string{"https://hosted-a.example", "https://stale.attacker.es", ""}
+	got := filterControlPlaneOrigins(in)
+	if !reflect.DeepEqual(got, in) {
+		t.Fatalf("gap build must not filter origins; got %v, want %v", got, in)
+	}
+}
+
+// TestFilterControlPlaneOrigins_SelfHostIdentity verifies that a self-host
+// build (no compiled allowlist) never filters origins.
+func TestFilterControlPlaneOrigins_SelfHostIdentity(t *testing.T) {
+	in := []string{"https://a.example", "https://b.example"}
+	got := filterControlPlaneOrigins(in)
+	if !reflect.DeepEqual(got, in) {
+		t.Fatalf("self-host must not filter origins; got %v", got)
+	}
+}

--- a/agent/internal/updater/updater_hostpolicy_test.go
+++ b/agent/internal/updater/updater_hostpolicy_test.go
@@ -49,3 +49,46 @@ func TestFilterControlPlaneOrigins_SelfHostIdentity(t *testing.T) {
 		t.Fatalf("self-host must not filter origins; got %v", got)
 	}
 }
+
+// TestUpdaterPolicy_StrictExcludesNonAllowlistedBackup proves updaterPolicy
+// (the real assembly function every production Updater is built from — see
+// New) actually applies filterControlPlaneOrigins to the origins that reach
+// netpolicy.Policy.ControlPlaneOrigins, not just that the filter function
+// works in isolation.
+func TestUpdaterPolicy_StrictExcludesNonAllowlistedBackup(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	restoreStrict := hostpolicy.SetStrictModeForTest(true)
+	defer restoreStrict()
+
+	cfg := &Config{
+		ServerURL:       func() string { return "https://hosted-a.example" },
+		BackupServerURL: "https://stale.attacker.es",
+	}
+	policy := updaterPolicy(cfg)
+	want := []string{"https://hosted-a.example"}
+	if !reflect.DeepEqual(policy.ControlPlaneOrigins, want) {
+		t.Fatalf("strict build: updaterPolicy().ControlPlaneOrigins = %v, want %v (non-allowlisted backup excluded)",
+			policy.ControlPlaneOrigins, want)
+	}
+}
+
+// TestUpdaterPolicy_GapIdentity is the companion: a gap build must pass both
+// origins through updaterPolicy unfiltered — matching the runtime GAP-MODEL
+// (existing-fleet agents on a gap build keep functioning unchanged).
+func TestUpdaterPolicy_GapIdentity(t *testing.T) {
+	restoreHosts := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restoreHosts()
+	// strictMode intentionally left off (gap build default).
+
+	cfg := &Config{
+		ServerURL:       func() string { return "https://hosted-a.example" },
+		BackupServerURL: "https://stale.attacker.es",
+	}
+	policy := updaterPolicy(cfg)
+	want := []string{"https://hosted-a.example", "https://stale.attacker.es"}
+	if !reflect.DeepEqual(policy.ControlPlaneOrigins, want) {
+		t.Fatalf("gap build: updaterPolicy().ControlPlaneOrigins = %v, want %v (unfiltered)",
+			policy.ControlPlaneOrigins, want)
+	}
+}


### PR DESCRIPTION
## What

Adds a compile-time **control-plane build-mode host policy** to the Go agent. A new leaf package `agent/internal/hostpolicy` exposes two ldflag-injected vars — `allowedHosts` and `strictMode` — and pure predicates `Enforced()` / `Strict()`. When `allowedHosts` is set, the build only accepts control-plane servers whose host is in the (exact, case-insensitive, anchored — no wildcard/suffix) allowlist.

**Inert by default.** Both vars are empty in the repo, so an ordinary build is `self-host` mode = unrestricted = current behavior. Nothing changes for any build the repo produces today; the constraints activate only when a release injects the vars via `-ldflags -X`.

## Behavior model

Two tiers, split by when the control-plane URL arrives:

- **Fresh install (bootstrap / enroll)** — refused when `Enforced()` (any hosted build) if the server isn't allowlisted. The bootstrap token is checked *before* it is transmitted, so it is never sent to a non-allowlisted host. Covers the filename host, MSI property, redeem-response redirect, and `--server`.
- **Existing fleet (runtime paths)** — gated only when `Strict()`: server/backup URL validation, failover promotion, and updater control-plane origins. A non-strict ("gap") build never degrades an already-enrolled fleet; it only reports the condition.
- **Startup self-check** lives in the shared `startAgent` choke point (covers console, Windows service, macOS daemon, and quick-support): gap logs a warning and continues; strict hard-fails with an operator message.
- **Quick Support** redeem is gated the same way (host checked before the code is sent).
- The **heartbeat** reports `agentEdition` / `migrationRequired` (both `omitempty`; a self-host build emits neither, so the wire payload is byte-identical to today). The API/dashboard consumer is a separate change.

## Tests

New `_test.go` suites per touched package (`hostpolicy`, `agentapp` bootstrap/enroll/startup/quick-support, `config` validation, `updater` origins, `heartbeat` signal). Whole agent module passes `go test -race ./...`; `go vet` clean. No real hostnames in source — the allowlist is ldflag-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
