### PR TITLE
fix(contacts): bound backfill projections so an overlong jsonb value cannot abort the migration

### DIFF
--- a/apps/api/migrations/2026-08-19-contacts.sql
+++ b/apps/api/migrations/2026-08-19-contacts.sql
@@ -249,9 +249,23 @@ CREATE INDEX IF NOT EXISTS portal_users_contact_idx
 -- than ON CONFLICT, because none of the target indexes covers the natural
 -- key being backfilled — re-running must still be a no-op.
 --
--- jsonb_typeof(...) = 'object' guards are load-bearing: organizations
--- .billing_contact is validated with z.any() on the org routes, so the column
--- can legally hold a string, a number, or an array.
+-- jsonb_typeof(...) = 'object' guards are load-bearing: sites.contact and
+-- organizations.billing_contact are validated as
+-- z.record(z.string(), z.unknown()) on the create routes, and legacy rows /
+-- direct DB writes predate even that, so the columns can hold a string, a
+-- number, or an array.
+--
+-- left(...) is equally load-bearing. Those validators bound the CONTAINER to
+-- an object but leave every VALUE a z.unknown() of unbounded length, while
+-- the destination columns are varchar(255)/(320)/(64). An overlong value --
+-- a free-text phone carrying an extension and an after-hours number clears
+-- 64 characters without looking unusual -- raises 22001 inside the INSERT.
+-- Because each step is ONE set-based INSERT ... SELECT, that does not skip
+-- the offending row: it rolls back the whole step for every tenant. And
+-- because autoMigrate applies the plan in a bare loop with no per-file
+-- try/catch, the throw aborts the run and every later migration, so a
+-- fix-forward migration could never repair it. Truncating at the column
+-- width is the only remedy that keeps the upgrade alive.
 
 -- 1. sites.contact → one site-pinned contact per site with a usable blob.
 DO $$
@@ -259,9 +273,9 @@ DECLARE n integer;
 BEGIN
   INSERT INTO contacts (org_id, site_id, name, email, phone, roles, is_primary)
   SELECT s.org_id, s.id,
-         NULLIF(btrim(s.contact->>'name'), ''),
-         NULLIF(btrim(s.contact->>'email'), ''),
-         NULLIF(btrim(s.contact->>'phone'), ''),
+         left(NULLIF(btrim(s.contact->>'name'), ''), 255),
+         left(NULLIF(btrim(s.contact->>'email'), ''), 320),
+         left(NULLIF(btrim(s.contact->>'phone'), ''), 64),
          ARRAY['site'], true
   FROM sites s
   WHERE s.contact IS NOT NULL
@@ -280,9 +294,9 @@ DECLARE n integer;
 BEGIN
   INSERT INTO contacts (org_id, name, email, phone, roles, is_primary)
   SELECT o.id,
-         NULLIF(btrim(o.billing_contact->>'name'), ''),
-         NULLIF(btrim(o.billing_contact->>'email'), ''),
-         NULLIF(btrim(o.billing_contact->>'phone'), ''),
+         left(NULLIF(btrim(o.billing_contact->>'name'), ''), 255),
+         left(NULLIF(btrim(o.billing_contact->>'email'), ''), 320),
+         left(NULLIF(btrim(o.billing_contact->>'phone'), ''), 64),
          ARRAY['billing'], true
   FROM organizations o
   WHERE o.billing_contact IS NOT NULL

--- a/apps/api/src/__tests__/integration/contactsBackfillMigration.integration.test.ts
+++ b/apps/api/src/__tests__/integration/contactsBackfillMigration.integration.test.ts
@@ -287,4 +287,53 @@ describe('2026-08-19-contacts.sql backfills — replayed against seeded legacy r
       .where(and(eq(portalUsers.orgId, org.id), isNull(portalUsers.contactId)));
     expect(unlinked).toHaveLength(0);
   });
+
+  // The validators bound these blobs to an object but leave every value an
+  // unbounded z.unknown(), so nothing stops a value longer than the column it
+  // lands in. Before the left(...) bounds this raised 22001 and, because each
+  // step is one set-based INSERT ... SELECT, took the whole step down with it.
+  runDb('an overlong value is truncated instead of aborting the backfill', async () => {
+    const partner = await createPartner();
+    const benign = await createOrganization({ partnerId: partner.id });
+    const hostile = await createOrganization({ partnerId: partner.id });
+    const suffix = unique();
+
+    await setBillingContact(benign.id, {
+      name: 'Jane Doe',
+      email: `ap-${suffix}@example.test`,
+      phone: '555-1234',
+    });
+
+    // 71 characters, into contacts.phone varchar(64). Nothing about it looks
+    // unusual — an extension, an after-hours number and a note is ordinary.
+    const longPhone = '555-1234 ext 567, after hours 555-9999, cell 555-0000 (no texts please)';
+    expect(longPhone.length).toBeGreaterThan(64);
+    await setBillingContact(hostile.id, {
+      name: 'Bob Overflow',
+      email: `bob-${suffix}@example.test`,
+      phone: longPhone,
+    });
+
+    // A site blob on the same org overflows contacts.name varchar(255).
+    const site = await createSite({ orgId: hostile.id, name: `long-${suffix}` });
+    const longName = 'A'.repeat(300);
+    await setSiteContact(site.id, { name: longName, email: `site-${suffix}@example.test` });
+
+    await replayMigration();
+
+    // The control is the assertion that matters: it shares no row with the
+    // hostile org, so if it is missing the failure was global, not per-row.
+    const benignContacts = await contactsFor(benign.id);
+    expect(benignContacts, 'an unrelated org must not lose its backfill').toHaveLength(1);
+    expect(benignContacts[0]!.phone).toBe('555-1234');
+
+    const hostileContacts = await contactsFor(hostile.id);
+    const billing = hostileContacts.find((c) => c.roles?.includes('billing'));
+    const siteContact = hostileContacts.find((c) => c.roles?.includes('site'));
+
+    expect(billing?.phone).toBe(longPhone.slice(0, 64));
+    expect(billing!.phone!.length).toBe(64);
+    expect(siteContact?.name).toBe(longName.slice(0, 255));
+    expect(siteContact!.name!.length).toBe(255);
+  });
 });

--- a/apps/api/src/db/autoMigrate.ts
+++ b/apps/api/src/db/autoMigrate.ts
@@ -181,6 +181,12 @@ export const CHECKSUM_RECONCILIATIONS: Record<
     to: '6be4c7fa5b808e4ca51f63824f6d5b286f0b8dfc081ed8a43cc33f731fdb6148',
     reason: '#2622 (v0.97.1): advisory-lock gate function had breeze.scope attributes dropped outright; superuser DBs applied the original v0.97.0 file, heal their recorded checksum instead of crashing the upgrade.',
   },
+  '2026-08-19-contacts.sql': {
+    from: '4b6559271dbc35c85e342756a3892909a7f2cee58e4b5bdc8e04207ffe842a64',
+    to: 'e586cb0f8474e3a84d06638def12268896bba260d3c4568679e90935cc6e1a52',
+    reason:
+      "#3316: bound the two backfill projections with left(...) at the destination column widths. The original raises 22001 on a sites.contact / organizations.billing_contact value longer than varchar(255)/(320)/(64), which aborts the whole migration run. Equivalent for any DB that already applied the original: applying it successfully proves no value exceeded a limit, so left(...) would have returned those same strings unchanged — heal the recorded checksum rather than crashing the upgrade.",
+  },
 };
 
 /**


### PR DESCRIPTION
Follow-up to #3316. The two backfills in `2026-08-19-contacts.sql` project unbounded jsonb values into `varchar`-bounded columns, so an ordinary-looking value aborts the upgrade.

## The defect

| Target | Width | Source |
|---|---|---|
| `contacts.name` | `varchar(255)` | `->>'name'` |
| `contacts.email` | `varchar(320)` | `->>'email'` |
| `contacts.phone` | `varchar(64)` | `->>'phone'` |

`createSiteSchema.contact` and `createOrgSchema.billingContact` are `z.record(z.string(), z.unknown())` (`packages/shared/src/validators/index.ts:111,119`). The record shape constrains the container to an object; every *value* is `unknown`, with no `max()` and no string check. Legacy rows and direct DB writes predate even that.

`phone varchar(64)` is the one that bites. A realistic free-text entry clears it without looking unusual:

```
555-1234 ext 567, after hours 555-9999, cell 555-0000 (no texts please)   -- 71 chars
```

**The failure is not a skipped row.** Each step is a single set-based `INSERT ... SELECT`, so one overlong value rolls the step back for *every* tenant. The new test seeds a benign control org alongside the hostile one; before this change the control loses its backfill too.

## Why it can't be fixed forward

`autoMigrate` applies the plan in a bare `for` loop with no per-migration `try/catch` (`apps/api/src/db/autoMigrate.ts:563`). A throw propagates out of the loop and out of `autoMigrate`, so the failing file's transaction rolls back **and every migration after it never runs**. A new migration added later would sort after `2026-08-19-contacts.sql` and would never execute.

That is why this edits the file in place and adds a `CHECKSUM_RECONCILIATIONS` entry rather than shipping a follow-up migration.

The reconciliation is safe by construction: applying the original successfully *proves* no value exceeded a limit, so `left(...)` returns those same strings unchanged. Databases that never applied the original are unaffected and simply apply the current file. Same class as the #994 and #2622 entries above it.

## Change

- `left(NULLIF(btrim(...), ''), 255 | 320 | 64)` on both backfill steps.
- `CHECKSUM_RECONCILIATIONS['2026-08-19-contacts.sql']`, `4b655927… -> e586cb0f…`.
- A regression case in `contactsBackfillMigration.integration.test.ts`, asserting the control org keeps its backfill and both overlong values land truncated at the column width.
- Corrected the header comment: it said `billing_contact` is validated with `z.any()`. It is `z.record(z.string(), z.unknown())`, so the `jsonb_typeof` guard is right for legacy and direct-DB rows, not for the reason stated.

Step 3b needs no bound: `portal_users.name` is `varchar(255)` into an identical column, and `email` widens 255 -> 320.

## Verification

Real Postgres 16, `docker-compose.test.yml`, Node 22.23.2.

**The control was run first.** With the fix reverted, the new test fails with `22001 value too long for type character varying(255)` from step 1, and the four pre-existing cases still pass. With the fix, 5/5 pass. The run also logs `[auto-migrate] Reconciled checksum for 2026-08-19-contacts.sql`, which exercises the reconciliation path end to end because the database had recorded the original checksum.

| Check | Result |
|---|---|
| `tsc --noEmit` (api) | exit 0, 0 errors |
| API unit | 20969 passed / 1309 files |
| `contactsBackfillMigration` | 5 passed (control verified failing) |
| `contactsRls` | 5 passed |
| `tenantCascade` | 5 passed |
| `tenant-export-policy` | 2 passed |
| `tenantExportErasureRoundtrip` | 2 passed |
| `test:rls` | 22 passed |
| Trivy (secret, misconfig — changed dirs) | exit 0 |

Three checks are not green locally and are **identical on `origin/main`**, which I ran as a baseline on the same database rather than assuming:

- `test:rls-coverage` — 74/75. The failure is `manifest_signing_keys … returns zero rows`, caused by a residual row from a local migrate; CI tears the database down with `down -v`. `origin/main` fails the same single test.
- `go test` — 67 packages pass; `TestBrewGetInstalledListsPackages` shells out to `brew list --versions` and fails on this macOS host. cgo-linked packages fail to build with `runtime/cgo: open terminal failed: not a terminal`, a non-TTY C-toolchain artifact.
- `govulncheck` (1 pre-existing, `GO-2026-5051` in `go-smb2@v1.1.0`, *Fixed in: N/A*) and `pnpm audit` (6 pre-existing, 2 high, all under `apps__mobile>expo>@expo/metro>metro>image-size`).

This diff is three files and touches no Go source, no `go.mod`, and no dependency, so it cannot affect those last two.
