### PR TITLE
docs: BYO signing design spec + phase implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-08-09-byo-signing-1-release-unsigned-artifacts.md
+++ b/docs/superpowers/plans/2026-08-09-byo-signing-1-release-unsigned-artifacts.md
@@ -1,0 +1,760 @@
+# BYO Signing Phase 1: Release Unsigned Artifacts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish the exact pre-signing Windows and macOS build outputs as `-unsigned` release assets, and extend the signed release-artifact manifest with `sourceCommit` plus `intendedUse: "signing-input"` / `platformTrust: "none"` entries for them — without weakening any existing integrity guarantee on the signed set.
+
+**Architecture:** The Windows exe build moves out of the signing-gated `build-windows-msi` job into a new unconditional-on-tags `build-windows-unsigned` job that uploads `-unsigned` artifacts; `build-windows-msi` then downloads those artifacts as its signing inputs, which makes the published unsigned files byte-identical pre-sign inputs *by construction* and makes unsigned publication independent of `vars.ENABLE_WINDOWS_SIGNING`. macOS unsigned capture is a copy step inserted between the (already unconditional) artifact downloads and the step-gated signing in `build-macos-agent`. The manifest generator in `create-release` classifies `-unsigned` names before its extension-based branches and records the release's source commit; a new assertion step proves the classification and the signed-set non-regression before the manifest is signed.
+
+**Tech Stack:** GitHub Actions YAML, PowerShell, bash, Python (inline manifest generator), TypeScript (manifest parser tolerance)
+
+## Global Constraints
+
+- Exact new artifact filenames (from the approved spec, table in Deliverable 1): `breeze-agent-windows-amd64-unsigned.exe`, `breeze-backup-windows-amd64-unsigned.exe`, `breeze-watchdog-windows-amd64-unsigned.exe`, `breeze-user-helper-windows-amd64-unsigned.exe`, and `breeze-{agent,backup,desktop-helper,watchdog}-darwin-{amd64,arm64}-unsigned` (8 darwin files, no extension). No unsigned `Breeze Installer.app.zip`, no unsigned MSI or PKG.
+- The `-unsigned` suffix goes **before** the `.exe` extension on Windows and at the end of the extensionless darwin names; the suffix rule in the manifest classifier MUST be evaluated before the `.exe`/`.msi` extension branch.
+- Unsigned manifest entries get `intendedUse: "signing-input"` AND `platformTrust: "none"`; signed-set entries keep their existing `platformTrust` values byte-for-byte and never gain `intendedUse`.
+- `sourceCommit` = the checked-out release commit, resolved as `git rev-parse 'HEAD^{commit}'` in the `create-release` job (see Task 3 note: this is `$GITHUB_SHA` for lightweight tags but stays correct for annotated tags, where `GITHUB_SHA` can name the tag object).
+- Unsigned uploads must not be gated on `vars.ENABLE_WINDOWS_SIGNING` / `vars.ENABLE_MACOS_SIGNING` — the capture path runs on every `v*` tag. (The `release-integrity-gate` still fails a tag release when signing is disabled; flipping that end-state is rollout step 4 of the spec, explicitly out of scope here.)
+- `release-integrity-gate` must not regress: all existing `require_success` assertions stay; this plan only *adds* a requirement (the new `build-windows-unsigned` job) and a manifest-content assertion step.
+- `scripts/security/check-supply-chain-hardening.sh` greps `release.yml` for sentinel strings (`^permissions:`, `^  release-integrity-gate:`, `needs: .*release-integrity-gate`, `ENABLE_MACOS_SIGNING must be true for tag releases`, `Required signed/notarized release asset missing or empty`, `release-artifact-manifest\.json` + `.minisig` + `.ed25519`) — none of these strings may be removed or reworded.
+- The `-unsigned` files must NOT flow into the `binaries-init` Docker image (`build-binaries-image` downloads `breeze-agent-*` patterns which now match them) — Task 4 strips them from image staging.
+- API-side: `apps/api/src/services/releaseArtifactManifest.ts` is a hand-rolled tolerant parser (NOT zod); new fields must be proven tolerated by unit test, not assumed.
+- No migrations are touched in this deliverable (repo rule "never edit a shipped migration" is n/a but binding).
+- Workflow YAML has no unit runner: every workflow edit is validated with `actionlint` (installed at `/opt/homebrew/bin/actionlint`), `python3 -c 'import yaml; yaml.safe_load(...)'`, the supply-chain hardening script, and (for the Python generator) a local fixture run.
+- `actionlint` has pre-existing shellcheck findings in `release.yml` (e.g. SC2046 at lines 751/1015) — capture a baseline before editing and require **no new findings**, not zero findings.
+- Conventional-commit messages; every commit ends with the trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Work on a dedicated branch off `main` (e.g. `byo-signing-1-unsigned-artifacts`); do not commit to `main` directly.
+
+---
+
+### Task 1: Unconditional Windows exe build job publishing `-unsigned` artifacts; rewire `build-windows-msi` to consume them
+
+**Files:**
+- Modify: `/Users/toddhebebrand/orca/workspaces/breeze/constrained-signed-installer/.github/workflows/release.yml`
+  - `build-windows-msi` job: header at line 254, signing-var gate at lines 256–259, `Setup Go` at 273–277, `Download Go dependencies` at 279–282, `Get version from tag` at 299–306, `Build Windows resources and binary` step at 308–425, `Scan Windows binaries for plaintext threat signatures (#2797)` step at 427–448, sign steps at 485–579, `Build MSI` at 581–591, MSI sign at 593–616, `Verify signatures` at 618–638, uploads at 640–683.
+  - `release-integrity-gate` job: `needs` at line 1907, env block at 1916–1923, `require_success` calls at 1940–1947.
+  - `create-release` job: `needs` at line 1957, `if` conditions at 1958–1976, download pattern at line 1989 (already matches `breeze-agent-*`, `breeze-backup-*`, `breeze-watchdog-*`, `breeze-user-helper-*` — the new artifact names need no pattern change).
+- Test: `actionlint`, YAML parse, `bash scripts/security/check-supply-chain-hardening.sh`, targeted `grep` assertions (no unit runner for workflows).
+
+**Interfaces:**
+- Consumes: `build-agent` matrix job (ordering only — the Windows exes are rebuilt resource-stamped, not taken from the matrix).
+- Produces: four CI artifacts `breeze-{agent,backup,watchdog,user-helper}-windows-amd64-unsigned`, each containing the single file of the same name + `.exe`; `build-windows-msi` consumes exactly these as signing inputs; `create-release` picks them up via the existing `breeze-agent-*`/`breeze-backup-*`/`breeze-watchdog-*`/`breeze-user-helper-*` download patterns (line 1989) and its copy loops (lines 1997–2030).
+
+**Steps:**
+
+- [ ] Create the working branch: `git checkout main && git pull && git checkout -b byo-signing-1-unsigned-artifacts`
+- [ ] Capture the actionlint baseline: `actionlint .github/workflows/release.yml > /tmp/actionlint-baseline.txt 2>&1 || true` (pre-existing shellcheck findings are expected).
+- [ ] In `.github/workflows/release.yml`, insert a new job **immediately before** the `build-windows-msi:` job (line 254), with this exact content (job-level default `permissions: contents: read` from line 24–25 applies; deliberately NO `environment:`, NO secrets, NO `vars.ENABLE_WINDOWS_SIGNING` gate):
+
+  ```yaml
+    build-windows-unsigned:
+      name: Build Windows Agent Binaries (unsigned)
+      if: >-
+        github.ref_type == 'tag'
+        && startsWith(github.ref, 'refs/tags/v')
+      runs-on: windows-latest
+      needs: [build-agent]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+          with:
+            persist-credentials: false
+
+        - name: Setup Go
+          uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+          with:
+            go-version: ${{ env.GO_VERSION }}
+            cache-dependency-path: agent/go.sum
+
+        - name: Download Go dependencies
+          working-directory: agent
+          shell: pwsh
+          run: go mod download
+
+        - name: Get version from tag
+          id: version
+          shell: pwsh
+          env:
+            REF_NAME: ${{ github.ref_name }}
+          run: |
+            $version = $env:REF_NAME.Substring(1)
+            "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+  ```
+
+- [ ] **Move** (cut from `build-windows-msi`, paste into `build-windows-unsigned` after the `Get version from tag` step, verbatim, unchanged) the step `Build Windows resources and binary` — currently lines 308–425 including its leading comments — and the step `Scan Windows binaries for plaintext threat signatures (#2797)` — currently lines 427–448 including its leading comment block. These carry the go-winres resource stamping, the four `go build`s into `dist\`, the #949 manifest guard, and the #2797 threat-signature scan; they run identically in the new job.
+- [ ] Append to `build-windows-unsigned`, after the moved scan step, these exact staging + upload steps:
+
+  ```yaml
+        - name: Stage unsigned Windows exes (BYO signing inputs)
+          shell: pwsh
+          run: |
+            $ErrorActionPreference = "Stop"
+            New-Item -Path dist-unsigned -ItemType Directory -Force | Out-Null
+            foreach ($component in @("agent", "backup", "watchdog", "user-helper")) {
+              $src = "dist\breeze-$component-windows-amd64.exe"
+              if (-not (Test-Path $src)) { throw "missing expected build output: $src" }
+              Copy-Item $src "dist-unsigned\breeze-$component-windows-amd64-unsigned.exe"
+            }
+
+        - name: Upload unsigned agent EXE artifact
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          with:
+            name: breeze-agent-windows-amd64-unsigned
+            path: dist-unsigned/breeze-agent-windows-amd64-unsigned.exe
+            retention-days: 30
+
+        - name: Upload unsigned backup EXE artifact
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          with:
+            name: breeze-backup-windows-amd64-unsigned
+            path: dist-unsigned/breeze-backup-windows-amd64-unsigned.exe
+            retention-days: 30
+
+        - name: Upload unsigned watchdog EXE artifact
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          with:
+            name: breeze-watchdog-windows-amd64-unsigned
+            path: dist-unsigned/breeze-watchdog-windows-amd64-unsigned.exe
+            retention-days: 30
+
+        - name: Upload unsigned user-helper EXE artifact
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          with:
+            name: breeze-user-helper-windows-amd64-unsigned
+            path: dist-unsigned/breeze-user-helper-windows-amd64-unsigned.exe
+            retention-days: 30
+  ```
+
+- [ ] Rewire `build-windows-msi` to consume the unsigned artifacts:
+  - Change its `needs:` (currently `needs: [build-agent]`, line 261) to `needs: [build-agent, build-windows-unsigned]`.
+  - Delete its `Setup Go` (273–277) and `Download Go dependencies` (279–282) steps (Go is no longer used in this job; `agent/installer/build-msi.ps1` is pure WiX — verified it contains no `go build`/`go-winres` calls).
+  - In place of the two moved steps (after `Get version from tag`, before `Validate signing configuration` at current line 450), insert exactly:
+
+  ```yaml
+        - name: Download unsigned Windows exes (signing inputs)
+          uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+          with:
+            pattern: 'breeze-*-windows-amd64-unsigned'
+            path: dist-unsigned/
+            merge-multiple: true
+
+        # The published -unsigned assets are byte-identical to the files signed
+        # below by construction: the signing job's inputs ARE the unsigned
+        # artifacts (BYO signing, Deliverable 1).
+        - name: Stage exes for signing
+          shell: pwsh
+          run: |
+            $ErrorActionPreference = "Stop"
+            New-Item -Path dist -ItemType Directory -Force | Out-Null
+            foreach ($component in @("agent", "backup", "watchdog", "user-helper")) {
+              $src = "dist-unsigned\breeze-$component-windows-amd64-unsigned.exe"
+              if (-not (Test-Path $src)) { throw "missing unsigned input artifact: $src" }
+              Copy-Item $src "dist\breeze-$component-windows-amd64.exe"
+            }
+  ```
+
+  - Leave everything else in `build-windows-msi` untouched: the `vars.ENABLE_WINDOWS_SIGNING` job gate, the `signing-prerelease`/`signing-production` environment, `.NET`/WiX setup, `Validate signing configuration`, `Azure Login`, all eight per-exe sign steps (stable + prerelease variants — the unsigned capture is upstream of both, so one capture covers both variants), `Build MSI`, MSI signing, `Verify signatures`, and the signed-artifact uploads. All signing-step file paths (`dist\breeze-*-windows-amd64.exe`) are unchanged.
+- [ ] Wire the new job into `release-integrity-gate`:
+  - `needs` (line 1907): append `build-windows-unsigned` to the list.
+  - Env block (after line 1916's `BUILD_WINDOWS_MSI_RESULT`): add `BUILD_WINDOWS_UNSIGNED_RESULT: ${{ needs.build-windows-unsigned.result }}`.
+  - After `require_success "build-windows-msi" "$BUILD_WINDOWS_MSI_RESULT"` (line 1940): add `require_success "build-windows-unsigned" "$BUILD_WINDOWS_UNSIGNED_RESULT"`.
+- [ ] Wire the new job into `create-release`:
+  - `needs` (line 1957): append `build-windows-unsigned`.
+  - `if` block: after the `needs.release-integrity-gate.result == 'success'` line (line 1965), add `&& needs.build-windows-unsigned.result == 'success'` (strict success — the job runs on every tag; `create-release` only runs on tags).
+- [ ] Validate: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` — expect no output, exit 0.
+- [ ] Validate: `actionlint .github/workflows/release.yml > /tmp/actionlint-after.txt 2>&1 || true; diff /tmp/actionlint-baseline.txt /tmp/actionlint-after.txt` — expect only line-number shifts on pre-existing findings, no new rule IDs. (Line numbers WILL shift; compare finding content, not positions: `grep -o 'SC[0-9]*\|expression .*' /tmp/actionlint-baseline.txt | sort | uniq -c` vs the same for the after-file.)
+- [ ] Validate: `bash scripts/security/check-supply-chain-hardening.sh` — expect exit 0.
+- [ ] Assert the moved steps landed exactly once each: `grep -c 'Build Windows resources and binary' .github/workflows/release.yml` → `1`; `grep -c 'Scan Windows binaries for plaintext threat signatures' .github/workflows/release.yml` → `1`; `grep -c 'build-windows-unsigned' .github/workflows/release.yml` → expect `5` (job key, build-windows-msi needs, gate needs, gate env, create-release needs) plus `1` for the `require_success` line and `1` for the create-release `if` line = `7` total.
+- [ ] Commit:
+
+  ```bash
+  git add .github/workflows/release.yml
+  git commit -m "feat(release): build windows exes unconditionally and publish unsigned signing inputs
+
+  Moves the resource-stamped Windows exe build (go-winres stamping, #949
+  manifest guard, #2797 threat-signature scan) out of the
+  ENABLE_WINDOWS_SIGNING-gated build-windows-msi job into a new
+  build-windows-unsigned job that runs on every v* tag and uploads
+  breeze-{agent,backup,watchdog,user-helper}-windows-amd64-unsigned.exe.
+  build-windows-msi now downloads those artifacts as its signing inputs,
+  so the published unsigned assets are byte-identical pre-sign inputs by
+  construction, and unsigned publication no longer depends on the signing
+  toggle. release-integrity-gate additionally requires the new job.
+
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 2: Publish unsigned darwin binaries from `build-macos-agent` pre-sign
+
+**Files:**
+- Modify: `/Users/toddhebebrand/orca/workspaces/breeze/constrained-signed-installer/.github/workflows/release.yml` — `build-macos-agent` job (line 685 pre-Task-1; job runs on all tags, signing is step-gated on `vars.ENABLE_MACOS_SIGNING`): insert new steps between the last artifact download (`Download watchdog darwin/arm64 artifact`, lines 740–744) and `Import certificate into keychain` (line 746). Signing mutates `staging/` in place at `Sign binaries` (line 770), so capture MUST precede line 746.
+- Test: same workflow validators as Task 1.
+
+**Interfaces:**
+- Consumes: the eight `breeze-{agent,backup,desktop-helper,watchdog}-darwin-{amd64,arm64}` artifacts already downloaded into `staging/` (lines 698–744). Note: on macOS these ARE the untouched `build-agent` matrix outputs — this job signs in place and never rebuilds, so the unsigned copies equal the matrix outputs (unlike Windows).
+- Produces: four CI artifacts `breeze-{agent,backup,desktop-helper,watchdog}-darwin-unsigned`, each containing that component's two arch files named `breeze-<component>-darwin-{amd64,arm64}-unsigned`. Artifact names match the existing `create-release` download patterns (`breeze-agent-*`, `breeze-backup-*`, `breeze-desktop-helper-*`, `breeze-watchdog-*`, line 1989) and copy loops.
+
+**Steps:**
+
+- [ ] In `build-macos-agent`, insert after the `Download watchdog darwin/arm64 artifact` step and before `Import certificate into keychain`, with NO `if:` condition (must run whether or not `ENABLE_MACOS_SIGNING` is set — job-level gating already restricts to tags only):
+
+  ```yaml
+        # BYO signing (Deliverable 1): capture the exact pre-sign inputs. The
+        # sign step below mutates staging/ in place, so this MUST run before
+        # any codesign invocation. Deliberately not gated on
+        # vars.ENABLE_MACOS_SIGNING — unsigned publication is independent of
+        # the signing toggle.
+        - name: Stage unsigned darwin binaries (BYO signing inputs)
+          run: |
+            set -euo pipefail
+            mkdir -p staging-unsigned
+            count=0
+            for bin in staging/breeze-agent-darwin-amd64 staging/breeze-agent-darwin-arm64 \
+                       staging/breeze-backup-darwin-amd64 staging/breeze-backup-darwin-arm64 \
+                       staging/breeze-desktop-helper-darwin-amd64 staging/breeze-desktop-helper-darwin-arm64 \
+                       staging/breeze-watchdog-darwin-amd64 staging/breeze-watchdog-darwin-arm64; do
+              if [ ! -f "$bin" ]; then
+                echo "::error::missing expected darwin binary for unsigned capture: $bin"
+                exit 1
+              fi
+              cp "$bin" "staging-unsigned/$(basename "$bin")-unsigned"
+              count=$((count + 1))
+            done
+            if [ "$count" -ne 8 ]; then
+              echo "::error::expected 8 unsigned darwin binaries, staged $count"
+              exit 1
+            fi
+
+        - name: Upload unsigned agent darwin binaries
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          with:
+            name: breeze-agent-darwin-unsigned
+            path: staging-unsigned/breeze-agent-darwin-*-unsigned
+            retention-days: 30
+
+        - name: Upload unsigned backup darwin binaries
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          with:
+            name: breeze-backup-darwin-unsigned
+            path: staging-unsigned/breeze-backup-darwin-*-unsigned
+            retention-days: 30
+
+        - name: Upload unsigned desktop-helper darwin binaries
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          with:
+            name: breeze-desktop-helper-darwin-unsigned
+            path: staging-unsigned/breeze-desktop-helper-darwin-*-unsigned
+            retention-days: 30
+
+        - name: Upload unsigned watchdog darwin binaries
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+          with:
+            name: breeze-watchdog-darwin-unsigned
+            path: staging-unsigned/breeze-watchdog-darwin-*-unsigned
+            retention-days: 30
+  ```
+
+- [ ] Confirm no glob interference: the later `Sign binaries` / `Notarize binaries` / verify loops iterate `staging/breeze-*-darwin-*` — the unsigned copies live in `staging-unsigned/`, outside those globs, so the signed path is untouched. Assert: `grep -n 'staging-unsigned' .github/workflows/release.yml` shows hits only inside the five new steps.
+- [ ] Validate: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` — exit 0.
+- [ ] Validate: `actionlint .github/workflows/release.yml` — no new finding kinds vs `/tmp/actionlint-baseline.txt`.
+- [ ] Validate: `bash scripts/security/check-supply-chain-hardening.sh` — exit 0 (the `ENABLE_MACOS_SIGNING must be true for tag releases` sentinel at current line 930 is untouched).
+- [ ] Commit:
+
+  ```bash
+  git add .github/workflows/release.yml
+  git commit -m "feat(release): publish unsigned darwin signing-input binaries pre-sign
+
+  Captures the eight darwin agent/backup/desktop-helper/watchdog binaries
+  into staging-unsigned/ with an explicit -unsigned suffix before any
+  codesign mutation in build-macos-agent, and uploads them as four
+  per-component artifacts. Not gated on ENABLE_MACOS_SIGNING. The signed
+  path (sign/notarize/pkg/verify) is untouched.
+
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 3: Manifest generator — `sourceCommit` + `signing-input` classification (unsigned rule before the extension branch)
+
+**Files:**
+- Modify: `/Users/toddhebebrand/orca/workspaces/breeze/constrained-signed-installer/.github/workflows/release.yml` — the inline Python generator inside the `Prepare release assets` step of `create-release` (pre-Task-1 lines: heredoc opens at 2065, `DARWIN_BINARY_RE` at 2084–2086, `platform_trust` at 2088–2099, asset loop at 2101–2110, manifest dict at 2112–2117).
+- Test: local fixture run of the edited Python block + `jq` assertions (no unit runner for inline workflow Python).
+
+**Interfaces:**
+- Consumes: files in `release-assets/` (now including the 12 unsigned files copied in by the existing `breeze-agent-*`/`breeze-backup-*`/`breeze-desktop-helper-*`/`breeze-user-helper-*`/`breeze-watchdog-*` loops at lines 1997–2030), `GITHUB_REPOSITORY`, `GITHUB_REF_NAME`, and a new `SOURCE_COMMIT` env resolved from the checked-out workspace.
+- Produces: `release-artifact-manifest.json` with top-level `sourceCommit` and, for `-unsigned` assets only, `platformTrust: "none"` + `intendedUse: "signing-input"`. The API parser (`apps/api/src/services/releaseArtifactManifest.ts:139-159`) validates only `schemaVersion`/`repository`/`release`/`assets` and passes unknown keys through — Task 5 proves this with tests.
+
+**Steps:**
+
+- [ ] In the `Prepare release assets` step, immediately before the `python3 <<'PY'` line (2065), insert these two shell lines (the job checked out the tag at line 1980–1983, so `HEAD` is the release commit; `^{commit}` peels annotated tags):
+
+  ```bash
+          SOURCE_COMMIT="$(git rev-parse 'HEAD^{commit}')"
+          export SOURCE_COMMIT
+  ```
+
+- [ ] Inside the Python heredoc, insert after the `DARWIN_BINARY_RE` definition (currently ending line 2086) and replace the `platform_trust` function (2088–2099) so the block reads exactly (remember: heredoc content sits at the same YAML indent as the `python3` line — top-level Python code has no extra indent):
+
+  ```python
+          # BYO signing (Deliverable 1): unsigned build outputs published as
+          # inputs for self-hosters to sign with their own certificates. The
+          # -unsigned rule MUST be evaluated before the extension branches —
+          # breeze-agent-windows-amd64-unsigned.exe would otherwise classify
+          # as windows-authenticode-required.
+          UNSIGNED_INPUT_RE = re.compile(
+              r"^breeze-(agent|backup|watchdog|user-helper)-windows-amd64-unsigned\.exe$"
+              r"|^breeze-(agent|backup|desktop-helper|watchdog)-darwin-(amd64|arm64)-unsigned$"
+          )
+
+          def is_signing_input(name):
+              return UNSIGNED_INPUT_RE.match(name) is not None
+
+          def platform_trust(name):
+              if is_signing_input(name):
+                  return "none"
+              if name.endswith(".msi") or name.endswith(".exe"):
+                  return "windows-authenticode-required"
+              if (
+                  name.endswith(".pkg")
+                  or name.endswith(".app.zip")
+                  or name.endswith(".dmg")
+              ):
+                  return "macos-developer-id-notarization-required"
+              if DARWIN_BINARY_RE.match(name):
+                  return "macos-developer-id-notarization-required"
+              return "release-workflow-produced"
+  ```
+
+- [ ] Replace the asset loop body (currently 2101–2110) with:
+
+  ```python
+          assets = []
+          for path in sorted(release_dir.iterdir(), key=lambda item: item.name):
+              if not path.is_file() or path.name in excluded:
+                  continue
+              entry = {
+                  "name": path.name,
+                  "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                  "size": path.stat().st_size,
+                  "platformTrust": platform_trust(path.name),
+              }
+              if is_signing_input(path.name):
+                  entry["intendedUse"] = "signing-input"
+              assets.append(entry)
+  ```
+
+- [ ] Replace the manifest dict (currently 2112–2117) with:
+
+  ```python
+          manifest = {
+              "schemaVersion": 1,
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "release": os.environ["GITHUB_REF_NAME"],
+              "sourceCommit": os.environ["SOURCE_COMMIT"],
+              "assets": assets,
+          }
+  ```
+
+  (`schemaVersion` stays `1`: the additions are backward-compatible optional fields; the API parser hard-requires `schemaVersion === 1` at `releaseArtifactManifest.ts:150`, so bumping it would break every deployed API.)
+- [ ] Validate the edited block by running it against a local fixture. Extract the heredoc body into a temp file and run it exactly as CI would:
+
+  ```bash
+  work="$(mktemp -d)"
+  mkdir -p "$work/release-assets"
+  cd "$work"
+  # signed-set representatives + unsigned representatives + a linux binary
+  printf 'a' > "release-assets/breeze-agent-windows-amd64.exe"
+  printf 'b' > "release-assets/breeze-agent-windows-amd64-unsigned.exe"
+  printf 'c' > "release-assets/breeze-user-helper-windows-amd64-unsigned.exe"
+  printf 'd' > "release-assets/breeze-agent.msi"
+  printf 'e' > "release-assets/breeze-agent-darwin-amd64"
+  printf 'f' > "release-assets/breeze-agent-darwin-amd64-unsigned"
+  printf 'g' > "release-assets/breeze-desktop-helper-darwin-arm64-unsigned"
+  printf 'h' > "release-assets/breeze-agent-linux-amd64"
+  printf 'i' > "release-assets/Breeze Installer.app.zip"
+  # extract the python between the heredoc markers of the Prepare step
+  awk '/python3 <<.PY./{flag=1;next}/^          PY$/{flag=0}flag' \
+    /Users/toddhebebrand/orca/workspaces/breeze/constrained-signed-installer/.github/workflows/release.yml \
+    | sed 's/^          //' > gen.py
+  GITHUB_REPOSITORY=LanternOps/breeze GITHUB_REF_NAME=v9.9.9 \
+    SOURCE_COMMIT=0123456789abcdef0123456789abcdef01234567 \
+    python3 gen.py
+  ```
+
+  Note: if the awk extraction matches more than one heredoc (`Verify signing-input manifest entries` from Task 4 also uses `<<'PY'` once that task lands — in THIS task there is exactly one), pin it by line range instead. Expect `gen.py` to run cleanly and write `release-assets/release-artifact-manifest.json`.
+- [ ] Assert fixture output (all must exit 0):
+
+  ```bash
+  jq -e '.sourceCommit == "0123456789abcdef0123456789abcdef01234567"' release-assets/release-artifact-manifest.json
+  jq -e '.schemaVersion == 1' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "breeze-agent-windows-amd64-unsigned.exe") | (.platformTrust == "none" and .intendedUse == "signing-input")' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "breeze-user-helper-windows-amd64-unsigned.exe") | (.platformTrust == "none" and .intendedUse == "signing-input")' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "breeze-agent-darwin-amd64-unsigned") | (.platformTrust == "none" and .intendedUse == "signing-input")' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "breeze-desktop-helper-darwin-arm64-unsigned") | (.platformTrust == "none" and .intendedUse == "signing-input")' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "breeze-agent-windows-amd64.exe") | (.platformTrust == "windows-authenticode-required" and (has("intendedUse") | not))' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "breeze-agent.msi") | .platformTrust == "windows-authenticode-required"' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "breeze-agent-darwin-amd64") | .platformTrust == "macos-developer-id-notarization-required"' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "Breeze Installer.app.zip") | .platformTrust == "macos-developer-id-notarization-required"' release-assets/release-artifact-manifest.json
+  jq -e '.assets[] | select(.name == "breeze-agent-linux-amd64") | .platformTrust == "release-workflow-produced"' release-assets/release-artifact-manifest.json
+  jq -e '[.assets[] | select(.intendedUse == "signing-input")] | length == 4' release-assets/release-artifact-manifest.json
+  ```
+
+- [ ] Validate the workflow file: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` and `actionlint .github/workflows/release.yml` (no new finding kinds); `bash scripts/security/check-supply-chain-hardening.sh` — exit 0.
+- [ ] Commit:
+
+  ```bash
+  git add .github/workflows/release.yml
+  git commit -m "feat(release): manifest sourceCommit + signing-input classification for unsigned assets
+
+  The release-artifact-manifest generator now records the peeled release
+  commit (git rev-parse HEAD^{commit} — GITHUB_SHA can name the tag
+  object for annotated tags) as top-level sourceCommit, and classifies
+  the published -unsigned assets as platformTrust \"none\" with
+  intendedUse \"signing-input\". The -unsigned rule runs before the
+  .exe/.msi extension branch so unsigned Windows exes cannot classify as
+  windows-authenticode-required. Signed-set classification is unchanged;
+  schemaVersion stays 1 (additive optional fields).
+
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 4: Workflow-level manifest assertions + keep the binaries-init image signed-only
+
+**Files:**
+- Modify: `/Users/toddhebebrand/orca/workspaces/breeze/constrained-signed-installer/.github/workflows/release.yml`
+  - `create-release`: insert a new step between `Prepare release assets` (heredoc `PY` terminator, pre-Task line 2121) and `Sign release artifact manifest` (pre-Task line 2123) — assertions must fail BEFORE the manifest signature is produced.
+  - `build-binaries-image`: insert a step between `Download helper artifacts` (pre-Task lines 2343–2348) and `Write VERSION file` (pre-Task lines 2350–2353). Its download patterns (`breeze-agent-*` etc., lines 2329–2348) now match the unsigned artifacts, which would otherwise bloat the GHCR `binaries` image; the API's local scan would ignore them (`binarySync.ts:96-99` anchors `^breeze-agent-(os)-(arch)(\.exe)?$`, so `-unsigned` names never register), but shipping unusable bytes in the image and the `/target` volume is pure waste.
+- Test: workflow validators; the checksum/integrity machinery needs NO change — `Generate release checksums` (`sha256sum *`, pre-Task lines 2222–2225) and `Verify release asset integrity requirements` (dynamic `find` over `release-assets/`, pre-Task lines 2227–2277) automatically include the unsigned files.
+
+**Interfaces:**
+- Consumes: `release-assets/release-artifact-manifest.json` from Task 3; the checked-out workspace for `git rev-parse`.
+- Produces: a hard release-blocking assertion that (a) `sourceCommit` is present, 40-hex, and equals the checked-out commit; (b) exactly the 12 expected `-unsigned` assets exist, each `platformTrust: "none"` + `intendedUse: "signing-input"`; (c) no other asset carries `-unsigned` or `intendedUse` or `platformTrust: "none"`; (d) signed-set spot checks for every trust class are unchanged. This is the "assert manifest gains sourceCommit + intendedUse entries with correct classification order; assert the integrity gate still passes" requirement from the spec's Testing section.
+
+**Steps:**
+
+- [ ] Insert into `create-release`, immediately after the `Prepare release assets` step and before `Sign release artifact manifest`:
+
+  ```yaml
+        # BYO signing (Deliverable 1) non-regression: the manifest must gain
+        # sourceCommit and exactly the expected signing-input entries, and the
+        # signed set's platform-trust classification must be unchanged. Runs
+        # before the manifest is signed so a violation blocks the release.
+        - name: Verify signing-input manifest entries
+          if: startsWith(github.ref, 'refs/tags/')
+          run: |
+            set -euo pipefail
+            SOURCE_COMMIT="$(git rev-parse 'HEAD^{commit}')"
+            export SOURCE_COMMIT
+            python3 <<'PY'
+            import json
+            import os
+            import re
+
+            with open("release-assets/release-artifact-manifest.json") as fh:
+                manifest = json.load(fh)
+
+            source_commit = manifest.get("sourceCommit")
+            assert isinstance(source_commit, str) and re.fullmatch(r"[0-9a-f]{40}", source_commit), \
+                f"sourceCommit missing or malformed: {source_commit!r}"
+            assert source_commit == os.environ["SOURCE_COMMIT"], \
+                f"sourceCommit {source_commit} != checked-out commit {os.environ['SOURCE_COMMIT']}"
+
+            EXPECTED_UNSIGNED = {
+                "breeze-agent-windows-amd64-unsigned.exe",
+                "breeze-backup-windows-amd64-unsigned.exe",
+                "breeze-watchdog-windows-amd64-unsigned.exe",
+                "breeze-user-helper-windows-amd64-unsigned.exe",
+                "breeze-agent-darwin-amd64-unsigned",
+                "breeze-agent-darwin-arm64-unsigned",
+                "breeze-backup-darwin-amd64-unsigned",
+                "breeze-backup-darwin-arm64-unsigned",
+                "breeze-desktop-helper-darwin-amd64-unsigned",
+                "breeze-desktop-helper-darwin-arm64-unsigned",
+                "breeze-watchdog-darwin-amd64-unsigned",
+                "breeze-watchdog-darwin-arm64-unsigned",
+            }
+            by_name = {a["name"]: a for a in manifest["assets"]}
+            missing = EXPECTED_UNSIGNED - set(by_name)
+            assert not missing, f"missing unsigned signing-input assets: {sorted(missing)}"
+            for name in sorted(EXPECTED_UNSIGNED):
+                entry = by_name[name]
+                assert entry.get("platformTrust") == "none", \
+                    f"{name}: platformTrust {entry.get('platformTrust')!r} != 'none'"
+                assert entry.get("intendedUse") == "signing-input", \
+                    f"{name}: intendedUse {entry.get('intendedUse')!r} != 'signing-input'"
+            for name, entry in by_name.items():
+                if name in EXPECTED_UNSIGNED:
+                    continue
+                assert "-unsigned" not in name, \
+                    f"unexpected -unsigned asset outside the expected set: {name}"
+                assert "intendedUse" not in entry, \
+                    f"{name}: signed-set asset must not carry intendedUse"
+                assert entry.get("platformTrust") != "none", \
+                    f"{name}: signed-set asset must not have platformTrust 'none'"
+            # Signed-set spot checks, one per trust class (classification-order
+            # non-regression for the extension branches).
+            assert by_name["breeze-agent.msi"]["platformTrust"] == "windows-authenticode-required"
+            assert by_name["breeze-agent-windows-amd64.exe"]["platformTrust"] == "windows-authenticode-required"
+            assert by_name["breeze-agent-darwin-arm64"]["platformTrust"] == "macos-developer-id-notarization-required"
+            assert by_name["breeze-agent-linux-amd64"]["platformTrust"] == "release-workflow-produced"
+            print(f"OK: {len(EXPECTED_UNSIGNED)} signing-input assets verified; sourceCommit={source_commit}")
+            PY
+  ```
+
+  (Indentation note: the heredoc body must sit at the same YAML indent as the `python3` line, exactly like the existing generator block — the Python then sees flush-left top-level code.)
+- [ ] Insert into `build-binaries-image`, after `Download helper artifacts` and before `Write VERSION file`:
+
+  ```yaml
+        # BYO signing (Deliverable 1): -unsigned signing inputs are published
+        # release assets only. Keep them out of the binaries-init image — the
+        # API's local scanner would ignore them (parseBinaryFilename anchors on
+        # breeze-<component>-<os>-<arch>[.exe]) but they'd bloat the image and
+        # the /target volume for nothing.
+        - name: Drop unsigned signing-input files from image staging
+          run: |
+            set -euo pipefail
+            find staging -type f -name '*-unsigned*' -print -delete
+  ```
+
+- [ ] Validate: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'`; `actionlint .github/workflows/release.yml` (no new finding kinds); `bash scripts/security/check-supply-chain-hardening.sh` — all clean.
+- [ ] Sanity-run the assertion block itself against the Task 3 fixture manifest to prove the Python is syntactically sound: from the Task 3 `$work` dir, extract JUST this new heredoc into `verify.py` (by line range via `sed -n 'START,ENDp'` on the workflow file, then `sed 's/^            //'` to strip the YAML indent), edit nothing, and run `SOURCE_COMMIT=0123456789abcdef0123456789abcdef01234567 python3 verify.py` — expected outcome: **AssertionError naming the 8 missing unsigned assets** (the fixture deliberately contains only 4 of the 12 expected names). That failure IS the pass criterion here: it proves the file parses and the assertions execute in order (sourceCommit check passed, missing-set check fired).
+- [ ] Commit:
+
+  ```bash
+  git add .github/workflows/release.yml
+  git commit -m "feat(release): assert signing-input manifest entries; keep binaries image signed-only
+
+  Adds a release-blocking verification step (before the manifest is
+  signed) that sourceCommit matches the checked-out commit and that
+  exactly the 12 expected -unsigned assets carry platformTrust none +
+  intendedUse signing-input while the signed set's classification is
+  unchanged. Also strips -unsigned files from build-binaries-image
+  staging so the GHCR binaries-init image ships only servable binaries.
+
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 5: API manifest-parser tolerance — typed optional fields + unit tests
+
+**Files:**
+- Modify: `/Users/toddhebebrand/orca/workspaces/breeze/constrained-signed-installer/apps/api/src/services/releaseArtifactManifest.ts` — `ReleaseArtifactManifestAsset` type (lines 16–21), `ReleaseArtifactManifest` type (lines 23–28). The parser is hand-rolled and tolerant: `parseManifest` (139–159) checks only `schemaVersion === 1`, `repository`/`release` strings, `assets` array; extra JSON keys pass through untouched, and `expectedPlatformTrust` enforcement (281–288) is opt-in per call. NO behavioral change is needed — this task pins the tolerance with types and regression tests so Deliverable 3 can't silently break it.
+- Test: `/Users/toddhebebrand/orca/workspaces/breeze/constrained-signed-installer/apps/api/src/services/releaseArtifactManifest.test.ts` (co-located; currently 267 lines, closes with `});` at line 267).
+
+**Interfaces:**
+- Consumes: manifests produced by Task 3 (top-level `sourceCommit`, per-asset `intendedUse`, `platformTrust: "none"`).
+- Produces: unit-test proof that (a) such manifests verify successfully with `platformTrust: "none"` surfaced in the result, and (b) a caller passing `expectedPlatformTrust: "windows-authenticode-required"` is REJECTED for a `"none"` entry (the existing mismatch check at `releaseArtifactManifest.ts:281-288` — the fail-closed seam Deliverable 3c builds on). `VerifiedReleaseArtifact` deliberately does NOT gain `intendedUse` here; surfacing it is Deliverable 3c scope.
+
+**Steps:**
+
+- [ ] Add the two new tests to `releaseArtifactManifest.test.ts`, inserted immediately before the final `});` (line 267). These are characterization tests: they are **expected to pass on the first run** because the parser is already tolerant — if either fails, the parser is NOT tolerant and the failure output defines exactly what to fix in `parseManifest`/`selectManifestAsset` before proceeding.
+
+  ```ts
+    it("tolerates sourceCommit and intendedUse manifest fields (BYO signing inputs)", async () => {
+      // Deliverable 1 of the self-host BYO-signing design adds a top-level
+      // sourceCommit and per-asset intendedUse/platformTrust:"none" for
+      // -unsigned signing-input assets. The parser is deliberately tolerant
+      // of unknown fields; this pins that contract so older APIs keep
+      // verifying newer manifests.
+      const asset = Buffer.from("unsigned-signing-input");
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({
+        format: "der",
+        type: "spki",
+      }) as Buffer;
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = publicDer
+        .subarray(publicDer.length - 32)
+        .toString("base64");
+      const manifest = Buffer.from(
+        JSON.stringify({
+          schemaVersion: 1,
+          repository: "lanternops/breeze",
+          release: "v1.2.3",
+          sourceCommit: "0123456789abcdef0123456789abcdef01234567",
+          assets: [
+            {
+              name: "breeze-agent-windows-amd64-unsigned.exe",
+              sha256: createSha256(asset),
+              size: asset.length,
+              platformTrust: "none",
+              intendedUse: "signing-input",
+            },
+          ],
+        }),
+      );
+      const signature = Buffer.from(
+        sign(null, manifest, privateKey).toString("base64"),
+      );
+
+      await expect(
+        verifyReleaseArtifactBuffer({
+          assetName: "breeze-agent-windows-amd64-unsigned.exe",
+          assetBuffer: asset,
+          manifestBytes: manifest,
+          signatureBytes: signature,
+          expectedRepository: "lanternops/breeze",
+          expectedRelease: "v1.2.3",
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          assetName: "breeze-agent-windows-amd64-unsigned.exe",
+          platformTrust: "none",
+        }),
+      );
+    });
+
+    it("rejects a signing-input entry when the caller expects authenticode trust", async () => {
+      // The expectedPlatformTrust mismatch check is the fail-closed seam that
+      // Deliverable 3c's positive allowlist builds on: an -unsigned entry
+      // (platformTrust "none") must never satisfy a caller that demands
+      // windows-authenticode-required.
+      const asset = Buffer.from("unsigned-signing-input");
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({
+        format: "der",
+        type: "spki",
+      }) as Buffer;
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = publicDer
+        .subarray(publicDer.length - 32)
+        .toString("base64");
+      const manifest = Buffer.from(
+        JSON.stringify({
+          schemaVersion: 1,
+          repository: "lanternops/breeze",
+          release: "v1.2.3",
+          sourceCommit: "0123456789abcdef0123456789abcdef01234567",
+          assets: [
+            {
+              name: "breeze-agent-windows-amd64-unsigned.exe",
+              sha256: createSha256(asset),
+              size: asset.length,
+              platformTrust: "none",
+              intendedUse: "signing-input",
+            },
+          ],
+        }),
+      );
+      const signature = Buffer.from(
+        sign(null, manifest, privateKey).toString("base64"),
+      );
+
+      await expect(
+        verifyReleaseArtifactBuffer({
+          assetName: "breeze-agent-windows-amd64-unsigned.exe",
+          assetBuffer: asset,
+          manifestBytes: manifest,
+          signatureBytes: signature,
+          expectedRepository: "lanternops/breeze",
+          expectedPlatformTrust: "windows-authenticode-required",
+        }),
+      ).rejects.toThrow("platform trust mismatch");
+    });
+  ```
+
+  (`generateKeyPairSync`, `sign`, and `createSha256` are already imported/defined in this file — lines 1 and 43–45.)
+- [ ] Run the suite: `pnpm --filter @breeze/api test -- src/services/releaseArtifactManifest.test.ts` — expect all tests green, including the two new ones. If the tolerance test fails, fix `parseManifest` to ignore unknown keys (it should not need it) and re-run until green.
+- [ ] In `releaseArtifactManifest.ts`, document the fields in the structural types (no runtime effect — the fields are already passed through — this makes the contract visible to Deliverable 3 work). Change lines 16–21 to:
+
+  ```ts
+  type ReleaseArtifactManifestAsset = {
+    name?: unknown;
+    sha256?: unknown;
+    size?: unknown;
+    platformTrust?: unknown;
+    // BYO signing (Deliverable 1): "signing-input" marks published unsigned
+    // build outputs. Tolerated here; positive rejection at registration/serve
+    // time is Deliverable 3c.
+    intendedUse?: unknown;
+  };
+  ```
+
+  and lines 23–28 to:
+
+  ```ts
+  type ReleaseArtifactManifest = {
+    schemaVersion?: unknown;
+    repository?: unknown;
+    release?: unknown;
+    // BYO signing (Deliverable 1): the release's peeled source commit SHA,
+    // recorded so downstream signing workflows can pin their checkout.
+    sourceCommit?: unknown;
+    assets?: unknown;
+  };
+  ```
+
+- [ ] Re-run: `pnpm --filter @breeze/api test -- src/services/releaseArtifactManifest.test.ts` — green. Then typecheck the package build path used by CI: `pnpm --filter @breeze/api build` (or the repo's turbo typecheck if faster) — no errors.
+- [ ] Note (no action): editing `releaseArtifactManifest.ts` puts this PR in the path filters of `.github/workflows/ci-smoke-binary-source-github.yml` (lines 22–30), so the github-mode smoke will run on the PR against the pinned published release `0.65.8` — its manifest lacks the new optional fields, which is exactly the backward-compat case; it must stay green with zero changes to the smoke workflow.
+- [ ] Commit:
+
+  ```bash
+  git add apps/api/src/services/releaseArtifactManifest.ts apps/api/src/services/releaseArtifactManifest.test.ts
+  git commit -m "test(api): pin release-manifest tolerance for sourceCommit/intendedUse fields
+
+  The hand-rolled manifest parser already passes unknown fields through;
+  these characterization tests pin that contract for the BYO-signing
+  manifest additions (top-level sourceCommit, per-asset intendedUse +
+  platformTrust none) and prove expectedPlatformTrust still fails closed
+  against signing-input entries. Types document the new optional fields.
+
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+  ```
+
+---
+
+### Task 6: Final verification sweep
+
+**Files:**
+- Test only — no new edits expected. Touches nothing unless a check fails.
+
+**Interfaces:**
+- Consumes: the four commits from Tasks 1–5.
+- Produces: verified branch ready for PR.
+
+**Steps:**
+
+- [ ] Full-file YAML parse: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` — exit 0.
+- [ ] `actionlint .github/workflows/release.yml` — compare finding kinds against `/tmp/actionlint-baseline.txt`; no new rule violations.
+- [ ] `bash scripts/security/check-supply-chain-hardening.sh` — exit 0.
+- [ ] Structural greps against the final workflow (each must match):
+  - `grep -n 'build-windows-unsigned:' .github/workflows/release.yml` — job exists.
+  - `grep -n "needs: \[build-agent, build-windows-unsigned\]" .github/workflows/release.yml` — signing job rewired.
+  - `grep -c 'unsigned' .github/workflows/release.yml` — sanity: dozens of hits, all inside the Task 1/2/3/4 additions (`git diff main -- .github/workflows/release.yml | grep '^+.*unsigned' | wc -l` matches the grep count delta).
+  - `grep -n 'sourceCommit' .github/workflows/release.yml` — generator + assertion step (2 regions).
+  - `grep -n "intendedUse" .github/workflows/release.yml` — generator + assertion step.
+- [ ] API tests: `pnpm --filter @breeze/api test -- src/services/releaseArtifactManifest.test.ts` — green.
+- [ ] Re-run the Task 3 fixture end-to-end once more from a clean `mktemp -d` (guards against edits from Task 4 having disturbed the generator heredoc; pin the awk extraction to the FIRST `<<'PY'` heredoc or use a line range, since the assertion step added a second one).
+- [ ] Review the diff as a whole: `git diff main --stat` — expected files: `.github/workflows/release.yml`, `apps/api/src/services/releaseArtifactManifest.ts`, `apps/api/src/services/releaseArtifactManifest.test.ts`, plus this plan doc if committed. Nothing else.
+- [ ] Confirm out-of-scope items were NOT touched (they belong to later deliverables): no changes to `binarySync.ts`, `binarySource.ts`, `msiSigning.ts`, config schema, compose files, smoke workflows, or any migration.
+- [ ] If any step above required a fix, commit it:
+
+  ```bash
+  git add -A
+  git commit -m "chore(release): fixups from BYO-signing phase-1 verification sweep
+
+  Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+  ```
+
+---
+
+## Out of scope (later deliverables / rollout steps — do NOT do these here)
+
+- Creating releases with signing disabled: `release-integrity-gate` still hard-requires `build-windows-msi`, `build-macos-agent`, etc. on tags, and the macOS `Verify macOS signatures and notarization` step (lines 926–932) still fails closed when `ENABLE_MACOS_SIGNING != 'true'`. This plan only makes the unsigned *capture* independent of the signing vars; flipping the gate is rollout step 4 of the spec, after the hosted-distribution decision.
+- Rejecting `intendedUse: "signing-input"` assets at registration/serve time (Deliverable 3c), deployment re-signing (3b), unified release source (3a), template repo (D2), guide (D4), `msiSigning.ts` cleanup (D5).
+- Surfacing `intendedUse` in `VerifiedReleaseArtifact` — deferred to 3c where it gets an enforcing consumer.
+
+## Verified current-state facts this plan relies on
+
+- `build-windows-msi` is job-gated on `vars.ENABLE_WINDOWS_SIGNING` (lines 256–259) and rebuilds resource-stamped exes itself (step at 308–425); the generic `build-agent` matrix Windows exe is NOT the signing input.
+- `build-macos-agent` runs on all tags (job `if` at 687–689 has no signing var); `ENABLE_MACOS_SIGNING` gates individual steps; signing mutates `staging/` in place (line 770 onward) — so pre-sign capture must precede line 746. Its pre-sign inputs are the untouched `build-agent` matrix outputs.
+- Manifest generator: `platform_trust` at lines 2088–2099 classifies every `.exe`/`.msi` as `windows-authenticode-required` — hence the mandatory rule ordering.
+- `create-release` artifact download pattern (line 1989) and copy loops (1997–2030) already match the new artifact names; `sha256sum *` checksums (2222–2225) and the dynamic integrity verification (2227–2277) automatically include unsigned files.
+- `releaseArtifactManifest.ts` is NOT zod and NOT strict — unknown fields flow through (`parseManifest`, 139–159).
+- Neither smoke workflow (`ci-smoke-binary-source-{github,local}.yml`) asserts manifest shape; the github one exercises a pinned published release (`0.65.8`) and is unaffected.
+- `binarySync.ts` github-mode sync targets exact asset names (`AGENT_TARGETS` etc., lines 25–61) and local mode's `parseBinaryFilename` (91–107) is anchored — `-unsigned` names are never registered by the API in either mode.
+- `agent/installer/build-msi.ps1` contains no Go usage — `build-windows-msi` can drop its Go toolchain steps.

--- a/docs/superpowers/plans/2026-08-09-byo-signing-2-api-release-source.md
+++ b/docs/superpowers/plans/2026-08-09-byo-signing-2-api-release-source.md
@@ -1,0 +1,2132 @@
+# BYO Signing Phase 2: API Release Source + Trust Chain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement spec Deliverable 3 (3a unified release source, 3b deployment re-signing for overridden repos, 3c positive trust allowlist at ingestion + serving, 3d recovery-media manifest-driven hashes) and Deliverable 5 (retire `msiSigning.ts`) from `docs/superpowers/specs/2026-08-09-selfhost-byo-signing-design.md`, so a self-hoster can point `BINARY_GITHUB_REPOSITORY` at their own signed-release repo and their agents update via the TOFU-pinned deployment key with zero agent-side changes.
+
+**Architecture:** A single validated release-source helper (`releaseSource.ts`) replaces the three fragmented repo identities (`binarySource.ts` hardcoded constant, `binarySync.ts` `GITHUB_REPO` env, `BINARY_GITHUB_REPOSITORY` manifest-only override). When the source is overridden, github-mode sync re-signs a normalized per-asset update manifest with the existing per-deployment Ed25519 key (`manifestSigning.ts`) and stamps the `deploy-*` key ID; the official path stays byte-identical. A positive platform-trust allowlist is enforced centrally in `releaseArtifactManifest.selectManifestAsset` (every manifest verification funnels through it) plus a name-based `signing-input` guard in the URL-builder chokepoint that `download.ts`/`supportPublic.ts` redirect/proxy through. Recovery media verifies the backup binary against the deployment-verified release manifest instead of the static hash table. `msiSigning.ts` and every env/validation/compose/test-mock trace of `MSI_SIGNING_*` are deleted.
+
+**Tech Stack:** TypeScript (Hono API), Vitest, Drizzle, Go (agent updater E2E), Docker Compose
+
+## Global Constraints
+
+- Default repository is `lanternops/breeze` (case-insensitive compare everywhere; manifest repository matching is already case-insensitive per `releaseArtifactManifest.ts:238-252`).
+- Repository values must match `/^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/` — anything else throws at the helper AND boot-refuses via the config schema.
+- Production override rule: `BINARY_GITHUB_REPOSITORY` set to a non-official repo requires `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` explicitly set (note: production already requires it unconditionally at `validate.ts:1109-1116`; the new rule adds the override-specific message and survives any future relaxation of the blanket rule).
+- Re-sign ONLY for overridden repos: when `isOfficialReleaseSource()` is true the github sync path must remain **byte-identical** to today (still stamps `signingKeyId: "release-artifact-manifest-ed25519"`, still stores the raw release manifest, never calls `ensureActiveSigningKey`).
+- `intendedUse: "signing-input"` assets (and any `-unsigned`-named asset) are never registrable and never serveable; unknown `platformTrust` values fail closed; canonical Windows `.exe`/`.msi` require `windows-authenticode-required`; canonical macOS assets require `macos-developer-id-notarization-required`.
+- New env var `BINARY_GITHUB_REPOSITORY` must be added to the config schema (`validate.ts`), BOTH compose `environment:` blocks (`docker-compose.yml` api service, `deploy/docker-compose.prod.yml` api service), and BOTH `.env.example` files (as a commented entry — `envComposeParity.test.ts` only enforces uncommented assignments, but the compose mapping is required regardless per the deploy contract).
+- Compose files are touched → run `pnpm --filter @breeze/api test -- src/config/composeBindMounts.test.ts src/config/envComposeParity.test.ts src/config/proxyTrustCompose.test.ts` in the tasks that edit them.
+- TDD: every behavioral change lands as failing test → implement → pass. Unit config (`apps/api/vitest.config.ts`) with Drizzle mocks per `binarySync.test.ts` patterns; no new integration-suite dependencies.
+- Go: `cd agent && go test -race ./internal/updater/...`.
+- Conventional commits; every commit ends with the trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Out of scope (explicit handoffs): `apps/docs` content changes (Phase 3/Deliverable 4); a `ci-smoke-binary-source-github.yml` override variant needs a real fixture repo with releases and is deferred to the Phase 3 template-repo work; the template repo itself (Deliverable 2); release.yml changes (Deliverable 1).
+
+---
+
+### Task 1: Create the validated release-source helper
+
+**Files:**
+- Create: `apps/api/src/services/releaseSource.ts`
+- Test: `apps/api/src/services/releaseSource.test.ts` (new)
+
+**Interfaces:**
+- Produces:
+  - `getReleaseSourceRepository(): string` — `BINARY_GITHUB_REPOSITORY` → legacy `GITHUB_REPO` (deprecation-warned once) → `'lanternops/breeze'`; throws on invalid shape.
+  - `isOfficialReleaseSource(): boolean` — lowercase compare against `OFFICIAL_RELEASE_REPOSITORY`.
+  - `getReleaseSourceReleaseBase(): string` — `https://github.com/<repo>/releases`.
+  - `getReleaseSourceApiBase(): string` — `https://api.github.com/repos/<repo>`.
+  - `getReleaseDownloadUrl(tag: string | null, assetName: string): string` — `latest/download/<asset>` when tag is null, else `download/<tag>/<asset>`.
+  - `OFFICIAL_RELEASE_REPOSITORY = 'lanternops/breeze'` (exported const).
+- Consumes: `process.env.BINARY_GITHUB_REPOSITORY`, `process.env.GITHUB_REPO`.
+
+**Steps:**
+
+- [ ] Write `apps/api/src/services/releaseSource.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  OFFICIAL_RELEASE_REPOSITORY,
+  getReleaseDownloadUrl,
+  getReleaseSourceApiBase,
+  getReleaseSourceReleaseBase,
+  getReleaseSourceRepository,
+  isOfficialReleaseSource,
+} from './releaseSource';
+
+describe('releaseSource', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.BINARY_GITHUB_REPOSITORY;
+    delete process.env.GITHUB_REPO;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('defaults to the official repository', () => {
+    expect(getReleaseSourceRepository()).toBe(OFFICIAL_RELEASE_REPOSITORY);
+    expect(isOfficialReleaseSource()).toBe(true);
+  });
+
+  it('resolves BINARY_GITHUB_REPOSITORY as the override', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = 'acme/breeze-selfhost-signing';
+    expect(getReleaseSourceRepository()).toBe('acme/breeze-selfhost-signing');
+    expect(isOfficialReleaseSource()).toBe(false);
+  });
+
+  it('treats a case-variant of the official repo as official', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = 'LanternOps/breeze';
+    expect(isOfficialReleaseSource()).toBe(true);
+  });
+
+  it('falls back to the legacy GITHUB_REPO alias when BINARY_GITHUB_REPOSITORY is unset', () => {
+    process.env.GITHUB_REPO = 'LanternOps/breeze';
+    expect(getReleaseSourceRepository()).toBe('LanternOps/breeze');
+  });
+
+  it('prefers BINARY_GITHUB_REPOSITORY over the legacy alias', () => {
+    process.env.GITHUB_REPO = 'legacy/repo';
+    process.env.BINARY_GITHUB_REPOSITORY = 'acme/breeze-selfhost-signing';
+    expect(getReleaseSourceRepository()).toBe('acme/breeze-selfhost-signing');
+  });
+
+  it.each([
+    'no-slash',
+    'a/b/c',
+    'owner/repo?x=1',
+    'owner/../repo',
+    '../etc/passwd',
+    'owner/repo#frag',
+    'owner /repo',
+    'https://github.com/owner/repo',
+  ])('rejects malformed repository %j', (bad) => {
+    process.env.BINARY_GITHUB_REPOSITORY = bad;
+    expect(() => getReleaseSourceRepository()).toThrow(/Invalid release source repository/);
+  });
+
+  it('accepts dots, underscores, and hyphens in the repository name', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = 'my-org/breeze_signing.v2';
+    expect(getReleaseSourceRepository()).toBe('my-org/breeze_signing.v2');
+  });
+
+  it('builds release, API, and download URLs from the resolved repository', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = 'acme/breeze-selfhost-signing';
+    expect(getReleaseSourceReleaseBase()).toBe(
+      'https://github.com/acme/breeze-selfhost-signing/releases',
+    );
+    expect(getReleaseSourceApiBase()).toBe(
+      'https://api.github.com/repos/acme/breeze-selfhost-signing',
+    );
+    expect(getReleaseDownloadUrl(null, 'breeze-agent.msi')).toBe(
+      'https://github.com/acme/breeze-selfhost-signing/releases/latest/download/breeze-agent.msi',
+    );
+    expect(getReleaseDownloadUrl('v1.2.3', 'breeze-agent.msi')).toBe(
+      'https://github.com/acme/breeze-selfhost-signing/releases/download/v1.2.3/breeze-agent.msi',
+    );
+  });
+});
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/releaseSource.test.ts` — expect failure: `Cannot find module './releaseSource'`.
+- [ ] Create `apps/api/src/services/releaseSource.ts`:
+
+```ts
+/**
+ * Single source of truth for WHICH GitHub repository this deployment pulls
+ * release artifacts from (spec: 2026-08-09-selfhost-byo-signing-design.md,
+ * Deliverable 3a).
+ *
+ * Before this module the release-source identity was fragmented three ways:
+ * binarySource.ts hardcoded lanternops/breeze for download URLs, binarySync.ts
+ * read a separate GITHUB_REPO env for the Releases API, and
+ * BINARY_GITHUB_REPOSITORY only affected manifest-repository validation. Every
+ * consumer now resolves the repository here.
+ *
+ * BYO signing: a self-hoster sets BINARY_GITHUB_REPOSITORY=theirorg/their-repo
+ * (plus RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=<their release key>) and the
+ * whole instance — sync, download redirects, installer pre-flight, support
+ * client, recovery media — follows their signed releases.
+ */
+
+export const OFFICIAL_RELEASE_REPOSITORY = 'lanternops/breeze';
+
+// Strict owner/repository shape. GitHub owner names are alphanumeric+hyphen;
+// repository names additionally allow dot and underscore. Nothing else may
+// reach URL construction (path traversal, query strings, schemes).
+const REPOSITORY_PATTERN = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/;
+
+let legacyGithubRepoWarned = false;
+
+export function getReleaseSourceRepository(): string {
+  const override = process.env.BINARY_GITHUB_REPOSITORY?.trim();
+  const legacy = process.env.GITHUB_REPO?.trim();
+
+  let repository = OFFICIAL_RELEASE_REPOSITORY;
+  if (override) {
+    repository = override;
+  } else if (legacy) {
+    // Pre-unification binarySync.ts read GITHUB_REPO. Kept as a deprecated
+    // alias so an existing deployment that set it does not silently flip back
+    // to the official repo on upgrade.
+    if (!legacyGithubRepoWarned) {
+      console.warn(
+        '[releaseSource] GITHUB_REPO is deprecated; set BINARY_GITHUB_REPOSITORY instead',
+      );
+      legacyGithubRepoWarned = true;
+    }
+    repository = legacy;
+  }
+
+  if (!REPOSITORY_PATTERN.test(repository)) {
+    throw new Error(
+      `Invalid release source repository "${repository}": expected "owner/repository" matching [A-Za-z0-9-]+/[A-Za-z0-9._-]+`,
+    );
+  }
+  return repository;
+}
+
+export function isOfficialReleaseSource(): boolean {
+  return getReleaseSourceRepository().toLowerCase() === OFFICIAL_RELEASE_REPOSITORY;
+}
+
+export function getReleaseSourceReleaseBase(): string {
+  return `https://github.com/${getReleaseSourceRepository()}/releases`;
+}
+
+export function getReleaseSourceApiBase(): string {
+  return `https://api.github.com/repos/${getReleaseSourceRepository()}`;
+}
+
+/** tag === null means "latest". Tags are passed verbatim (e.g. "v1.2.3"). */
+export function getReleaseDownloadUrl(tag: string | null, assetName: string): string {
+  const base = getReleaseSourceReleaseBase();
+  return tag === null
+    ? `${base}/latest/download/${assetName}`
+    : `${base}/download/${tag}/${assetName}`;
+}
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/releaseSource.test.ts` — expect all green.
+- [ ] Commit: `feat(api): validated release-source helper for BYO signing (spec 3a)`
+
+---
+
+### Task 2: Wire binarySource.ts URL builders through the helper
+
+**Files:**
+- Modify: `apps/api/src/services/binarySource.ts` (delete hardcoded `GITHUB_RELEASE_BASE`/`GITHUB_REPOSITORY` at lines 3-4; rewrite `getGithubReleasePageUrl` at 37-43, `githubDownloadBase` at 45-51, `getGithubReleaseRepository` at 53-55)
+- Test: `apps/api/src/services/binarySource.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `getReleaseSourceRepository`, `getReleaseSourceReleaseBase` from `./releaseSource`.
+- Produces: unchanged public signatures — `getGithubReleaseRepository(): string` (now delegates), `getGithubAgentUrl(os, arch)`, `getGithubBackupUrl`, `getGithubAgentPkgUrl`, `getGithubWatchdogUrl`, `getGithubUserHelperUrl`, `getGithubRegularMsiUrl`, `getGithubViewerUrl`, `getGithubHelperUrl`, `getGithubInstallerAppUrl`, `getGithubReleasePageUrl`, manifest URL builders. Callers (`routes/agents/download.ts:6`, `routes/supportPublic.ts`, `services/installerBuilder.ts:8-13`, `services/recoveryMediaService.ts:25`) need no edits.
+
+**Steps:**
+
+- [ ] Write `apps/api/src/services/binarySource.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  getGithubAgentUrl,
+  getGithubHelperUrl,
+  getGithubInstallerAppUrl,
+  getGithubRegularMsiUrl,
+  getGithubReleasePageUrl,
+  getGithubReleaseRepository,
+  getGithubViewerUrl,
+} from './binarySource';
+
+describe('binarySource release-source unification', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.BINARY_GITHUB_REPOSITORY;
+    delete process.env.GITHUB_REPO;
+    delete process.env.BINARY_VERSION;
+    delete process.env.BREEZE_VERSION;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('default URLs are unchanged (official repo, latest)', () => {
+    expect(getGithubAgentUrl('windows', 'amd64')).toBe(
+      'https://github.com/lanternops/breeze/releases/latest/download/breeze-agent-windows-amd64.exe',
+    );
+    expect(getGithubRegularMsiUrl()).toBe(
+      'https://github.com/lanternops/breeze/releases/latest/download/breeze-agent.msi',
+    );
+    expect(getGithubReleasePageUrl()).toBe(
+      'https://github.com/lanternops/breeze/releases/latest',
+    );
+  });
+
+  it('every URL builder follows BINARY_GITHUB_REPOSITORY', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = 'acme/breeze-selfhost-signing';
+    process.env.BINARY_VERSION = '1.2.3';
+    const base = 'https://github.com/acme/breeze-selfhost-signing/releases/download/v1.2.3';
+    expect(getGithubAgentUrl('linux', 'arm64')).toBe(`${base}/breeze-agent-linux-arm64`);
+    expect(getGithubViewerUrl('windows')).toBe(`${base}/breeze-viewer-windows.msi`);
+    expect(getGithubHelperUrl('darwin')).toBe(`${base}/breeze-helper-macos.dmg`);
+    expect(getGithubInstallerAppUrl()).toBe(`${base}/Breeze.Installer.app.zip`);
+    expect(getGithubReleaseRepository()).toBe('acme/breeze-selfhost-signing');
+    expect(getGithubReleasePageUrl()).toBe(
+      'https://github.com/acme/breeze-selfhost-signing/releases/tag/v1.2.3',
+    );
+  });
+
+  it('rejects a malformed repository before building any URL', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = 'owner/repo/../evil';
+    expect(() => getGithubAgentUrl('windows', 'amd64')).toThrow(
+      /Invalid release source repository/,
+    );
+  });
+});
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/binarySource.test.ts` — expect failures on the override test (URLs still hardcode `lanternops/breeze`).
+- [ ] Edit `apps/api/src/services/binarySource.ts`. Replace lines 3-4:
+
+```ts
+const GITHUB_RELEASE_BASE = 'https://github.com/lanternops/breeze/releases';
+const GITHUB_REPOSITORY = 'lanternops/breeze';
+```
+
+with:
+
+```ts
+import { getReleaseSourceReleaseBase, getReleaseSourceRepository } from './releaseSource';
+```
+
+  Then replace every `GITHUB_RELEASE_BASE` usage (lines 40, 42, 48, 50) with `getReleaseSourceReleaseBase()`:
+
+```ts
+export function getGithubReleasePageUrl(): string {
+  const version = getGithubReleaseVersion();
+  if (version === 'latest') {
+    return `${getReleaseSourceReleaseBase()}/latest`;
+  }
+  return `${getReleaseSourceReleaseBase()}/tag/v${version}`;
+}
+
+function githubDownloadBase(): string {
+  const version = getGithubReleaseVersion();
+  if (version === 'latest') {
+    return `${getReleaseSourceReleaseBase()}/latest/download`;
+  }
+  return `${getReleaseSourceReleaseBase()}/download/v${version}`;
+}
+```
+
+  And replace `getGithubReleaseRepository` (lines 53-55) with a delegation:
+
+```ts
+export function getGithubReleaseRepository(): string {
+  return getReleaseSourceRepository();
+}
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/binarySource.test.ts src/services/releaseSource.test.ts src/services/installerBuilder.test.ts` — expect green (installerBuilder pre-flight consumes `getGithubReleaseRepository`, which behaves identically for unset/official env).
+- [ ] Commit: `feat(api): route binarySource URL builders through the unified release source (spec 3a)`
+
+---
+
+### Task 3: Wire binarySync.ts through the helper (retire GITHUB_REPO)
+
+**Files:**
+- Modify: `apps/api/src/services/binarySync.ts` (delete `const GITHUB_REPO` at line 17; `expectedRepository` at line 225; GitHub API URL construction at lines 551-553)
+- Test: `apps/api/src/services/binarySync.test.ts` (extend; helper `makeSignedReleaseManifest` at lines 75-104, `makeSignedReleaseManifestMulti` at 108-141)
+
+**Interfaces:**
+- Consumes: `getReleaseSourceRepository`, `getReleaseSourceApiBase` from `./releaseSource`.
+- Produces: `syncFromGitHub(requestedVersion?: string): Promise<{ version: string; synced: string[] }>` — signature unchanged.
+
+**Steps:**
+
+- [ ] In `apps/api/src/services/binarySync.test.ts`, first update the two manifest fixture helpers to take a repository (needed by this task and Task 5). Change the signature of `makeSignedReleaseManifest` (line 75) to:
+
+```ts
+function makeSignedReleaseManifest(
+  assetName: string,
+  assetBuffer: Buffer,
+  repository = "LanternOps/breeze",
+) {
+```
+
+  and its manifest body to use `repository:` instead of the literal. Same for `makeSignedReleaseManifestMulti` (line 108):
+
+```ts
+function makeSignedReleaseManifestMulti(
+  assets: { name: string; buffer: Buffer }[],
+  release = "v1.2.3",
+  repository = "LanternOps/breeze",
+) {
+```
+
+- [ ] Add the failing tests to `binarySync.test.ts` (inside the top-level `describe("binarySync", ...)`):
+
+```ts
+  describe("release-source unification (spec 3a)", () => {
+    function stubOverriddenRepoFetch(
+      repo: string,
+      assetName: string,
+      asset: Buffer,
+      signed: ReturnType<typeof makeSignedReleaseManifest>,
+    ) {
+      const fetchSpy = vi.fn(async (url: string) => {
+        if (url === `https://api.github.com/repos/${repo}/releases/latest`) {
+          return new Response(
+            JSON.stringify({
+              tag_name: "v1.2.3",
+              body: "release notes",
+              assets: [
+                {
+                  name: assetName,
+                  browser_download_url: `https://github.com/${repo}/releases/download/v1.2.3/${assetName}`,
+                  size: asset.length,
+                },
+                {
+                  name: "release-artifact-manifest.json",
+                  browser_download_url: `https://github.com/${repo}/releases/download/v1.2.3/release-artifact-manifest.json`,
+                  size: signed.manifest.length,
+                },
+                {
+                  name: "release-artifact-manifest.json.ed25519",
+                  browser_download_url: `https://github.com/${repo}/releases/download/v1.2.3/release-artifact-manifest.json.ed25519`,
+                  size: signed.signature.length,
+                },
+              ],
+            }),
+          );
+        }
+        if (url.endsWith("/release-artifact-manifest.json"))
+          return new Response(signed.manifest);
+        if (url.endsWith("/release-artifact-manifest.json.ed25519"))
+          return new Response(signed.signature);
+        return new Response("not found", { status: 404 });
+      });
+      vi.stubGlobal("fetch", fetchSpy);
+      return fetchSpy;
+    }
+
+    it("queries the GitHub API for the overridden repository and accepts its manifest", async () => {
+      const repo = "acme/breeze-selfhost-signing";
+      process.env.BINARY_GITHUB_REPOSITORY = repo;
+      const assetName = "breeze-agent-linux-amd64";
+      const asset = Buffer.from("self-hosted agent bytes");
+      const signed = makeSignedReleaseManifest(assetName, asset, repo);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      const fetchSpy = stubOverriddenRepoFetch(repo, assetName, asset, signed);
+
+      const result = await syncFromGitHub();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `https://api.github.com/repos/${repo}/releases/latest`,
+        expect.anything(),
+      );
+      expect(result.synced).toContain("agent:linux/amd64");
+    });
+
+    it("rejects a manifest whose repository does not match the overridden source", async () => {
+      const repo = "acme/breeze-selfhost-signing";
+      process.env.BINARY_GITHUB_REPOSITORY = repo;
+      const assetName = "breeze-agent-linux-amd64";
+      const asset = Buffer.from("self-hosted agent bytes");
+      // Manifest still claims the OFFICIAL repository — must not register.
+      const signed = makeSignedReleaseManifest(assetName, asset, "LanternOps/breeze");
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      stubOverriddenRepoFetch(repo, assetName, asset, signed);
+
+      await expect(syncFromGitHub()).rejects.toThrow(/repository mismatch/);
+      expect(dbMocks.insertValues).not.toHaveBeenCalled();
+    });
+
+    it("honors the legacy GITHUB_REPO alias", async () => {
+      const repo = "legacyorg/breeze-mirror";
+      process.env.GITHUB_REPO = repo;
+      const assetName = "breeze-agent-linux-amd64";
+      const asset = Buffer.from("legacy alias bytes");
+      const signed = makeSignedReleaseManifest(assetName, asset, repo);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      const fetchSpy = stubOverriddenRepoFetch(repo, assetName, asset, signed);
+      await syncFromGitHub();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `https://api.github.com/repos/${repo}/releases/latest`,
+        expect.anything(),
+      );
+    });
+  });
+```
+
+  Note: existing tests stub fetch with `url.includes("/releases/latest")`, which continues to match the new `getReleaseSourceApiBase()`-built URL, so they stay green. Also add `delete process.env.BINARY_GITHUB_REPOSITORY; delete process.env.GITHUB_REPO;` to the file's `beforeEach` (line 146-149) so ambient env can never leak in.
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/binarySync.test.ts` — the new tests fail (API URL still built from module-load-time `GITHUB_REPO`; repository-mismatch test fails because `expectedRepository` is the module constant).
+- [ ] Edit `apps/api/src/services/binarySync.ts`:
+  - Delete line 17 (`const GITHUB_REPO = process.env.GITHUB_REPO || "LanternOps/breeze";`).
+  - Add to the imports: `import { getReleaseSourceApiBase, getReleaseSourceRepository } from "./releaseSource";`
+  - Line 225: `expectedRepository: GITHUB_REPO,` → `expectedRepository: getReleaseSourceRepository(),`
+  - Lines 551-553:
+
+```ts
+  const ghUrl = requestedVersion
+    ? `${getReleaseSourceApiBase()}/releases/tags/${requestedVersion}`
+    : `${getReleaseSourceApiBase()}/releases/latest`;
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/binarySync.test.ts src/services/binarySync.selftest.test.ts` — expect green.
+- [ ] Commit: `feat(api): binarySync resolves its GitHub repo via the unified release source, retiring GITHUB_REPO (spec 3a)`
+
+---
+
+### Task 4: Config schema, production override rule, compose mappings, env examples
+
+**Files:**
+- Modify: `apps/api/src/config/validate.ts` (schema near `BINARY_SOURCE` at line 501; production superRefine block after line 1116)
+- Modify: `docker-compose.yml` (api `environment:`, after line 273)
+- Modify: `deploy/docker-compose.prod.yml` (api `environment:`, after line 219)
+- Modify: `.env.example` (binary-source section, after the `# BINARY_SOURCE=github` line at ~861)
+- Modify: `deploy/.env.example` (after the `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` block ending ~line 103)
+- Test: `apps/api/src/config/validate.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: existing `hasReleaseArtifactManifestPublicKey(data)` helper (`validate.ts:194-202`).
+- Produces: boot-refusal on malformed `BINARY_GITHUB_REPOSITORY` (all envs) and on production override without a manifest trust root.
+
+**Steps:**
+
+- [ ] Add failing tests to `apps/api/src/config/validate.test.ts` (place next to the existing binary-source/production tests; reuse the file's `withEnv` + `validEnv`/`prodBase` fixtures):
+
+```ts
+  describe('BINARY_GITHUB_REPOSITORY (BYO signing, spec 3a)', () => {
+    it('refuses to boot on a malformed repository in any environment', () => {
+      withEnv({ ...validEnv, BINARY_GITHUB_REPOSITORY: 'not-a-repo' }, () => {
+        expect(() => validateConfig()).toThrow(/BINARY_GITHUB_REPOSITORY/);
+      });
+    });
+
+    it('treats an empty string (compose ${VAR:-} interpolation) as unset', () => {
+      withEnv({ ...validEnv, BINARY_GITHUB_REPOSITORY: '' }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+
+    it('production: overriding the release source requires the manifest trust root', () => {
+      withEnv(
+        {
+          ...prodBase,
+          BINARY_GITHUB_REPOSITORY: 'acme/breeze-selfhost-signing',
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: '',
+          BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: '',
+        },
+        () => {
+          expect(() => validateConfig()).toThrow(/BINARY_GITHUB_REPOSITORY/);
+        },
+      );
+    });
+
+    it('production: override boots when the trust root is set', () => {
+      withEnv(
+        {
+          ...prodBase,
+          BINARY_GITHUB_REPOSITORY: 'acme/breeze-selfhost-signing',
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: 'yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=',
+        },
+        () => {
+          expect(() => validateConfig()).not.toThrow();
+        },
+      );
+    });
+  });
+```
+
+  (If `prodBase` is scoped inside the H-3 describe at line 1633, define a local equivalent: `{ ...validEnv, NODE_ENV: 'production' as const, CORS_ALLOWED_ORIGINS: 'https://app.breeze.io', TRUST_PROXY_HEADERS: 'true' }`.)
+- [ ] Run `pnpm --filter @breeze/api test -- src/config/validate.test.ts` — new tests fail (unknown key is accepted silently today).
+- [ ] Edit `apps/api/src/config/validate.ts`. After line 501 (`BINARY_SOURCE: z.string().optional(),`) insert:
+
+```ts
+    // BYO signing (spec 3a): the release-source repository override consumed by
+    // services/releaseSource.ts. Empty string means "unset" — both compose
+    // files map it as `${BINARY_GITHUB_REPOSITORY:-}`, which always injects the
+    // key. Shape is validated in EVERY environment so a typo'd override
+    // boot-refuses instead of silently building garbage GitHub URLs.
+    BINARY_GITHUB_REPOSITORY: z.preprocess(
+      (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+      z
+        .string()
+        .regex(
+          /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/,
+          'BINARY_GITHUB_REPOSITORY must be "owner/repository" ([A-Za-z0-9-]+/[A-Za-z0-9._-]+)',
+        )
+        .optional(),
+    ),
+```
+
+  Then, in the production superRefine block immediately after the existing `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` rule (after line 1116), insert:
+
+```ts
+      // BYO signing (spec 3a): pointing the deployment at a NON-official
+      // release repository only makes sense with a manifest trust root that is
+      // the OVERRIDING repository's release key — without one, github-mode
+      // sync would either fail closed on every release or (if the blanket
+      // production key rule above were ever relaxed) accept unverified
+      // third-party binaries. Kept as its own rule with its own message even
+      // though the blanket rule currently subsumes the "unset" case.
+      const releaseRepositoryOverride = data.BINARY_GITHUB_REPOSITORY?.trim().toLowerCase();
+      if (
+        releaseRepositoryOverride &&
+        releaseRepositoryOverride !== 'lanternops/breeze' &&
+        !hasReleaseArtifactManifestPublicKey(data)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['BINARY_GITHUB_REPOSITORY'],
+          message:
+            'BINARY_GITHUB_REPOSITORY overrides the release source; production requires RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to be set to the overriding repository\'s release manifest public key (NOT the official Breeze key).',
+        });
+      }
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/config/validate.test.ts` — expect green.
+- [ ] Edit `docker-compose.yml`: after line 273 (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: ${RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS:-}`) add:
+
+```yaml
+      # BYO signing: override the GitHub repository that releases are pulled
+      # from (default lanternops/breeze). Pair with
+      # RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS set to YOUR release manifest key.
+      BINARY_GITHUB_REPOSITORY: ${BINARY_GITHUB_REPOSITORY:-}
+```
+
+- [ ] Edit `deploy/docker-compose.prod.yml`: after line 219 (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: ...`) add:
+
+```yaml
+      BINARY_GITHUB_REPOSITORY: ${BINARY_GITHUB_REPOSITORY:-}
+```
+
+- [ ] Edit `.env.example`: after the `# BINARY_SOURCE=github` line (~861) add:
+
+```
+#
+# BYO signing: pull releases from YOUR signed-release repository instead of the
+# official one (see the "Sign Your Own Agent Packages" guide). When you set
+# this, you MUST also set RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to YOUR release
+# manifest public key — production refuses to boot otherwise.
+# BINARY_GITHUB_REPOSITORY=lanternops/breeze
+```
+
+- [ ] Edit `deploy/.env.example`: after the `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=...` line (~103) add:
+
+```
+# BYO signing: override the release repository (default lanternops/breeze).
+# Requires RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to be YOUR release key.
+# BINARY_GITHUB_REPOSITORY=lanternops/breeze
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/config/validate.test.ts src/config/envComposeParity.test.ts src/config/composeBindMounts.test.ts src/config/proxyTrustCompose.test.ts` — expect green (commented env-example entries impose no parity requirement; the compose mapping is additive).
+- [ ] Commit: `feat(api): BINARY_GITHUB_REPOSITORY config schema, production override rule, compose + env-example wiring (spec 3a)`
+
+---
+
+### Task 5: Deployment re-signing on overridden-repo github sync
+
+**Files:**
+- Modify: `apps/api/src/services/binarySync.ts` (new `applyDeploymentSigning` helper; call it at the top of `upsertVersion`, currently line 822)
+- Test: `apps/api/src/services/binarySync.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `isOfficialReleaseSource()` from `./releaseSource`; `ensureActiveSigningKey(): Promise<{ keyId: string; publicKeyB64: string }>` and `signManifest(manifestJson: string): Promise<string>` from `./manifestSigning` (both already imported at line 15).
+- Produces (module-private):
+
+```ts
+async function applyDeploymentSigning(args: {
+  metadata: { checksum: string; size: number; releaseManifest?: string; manifestSignature?: string; signingKeyId?: string };
+  version: string;
+  component: string;
+  platform: string;
+  arch: string;
+  downloadUrl: string;
+}): Promise<typeof args.metadata>
+```
+
+**Steps:**
+
+- [ ] Add failing tests to `binarySync.test.ts`. First extend the top-of-file crypto import (line 1) to `import { createHash, generateKeyPairSync, sign, verify } from "node:crypto";`. Then add:
+
+```ts
+  describe("deployment re-signing on overridden repos (spec 3b)", () => {
+    const repo = "acme/breeze-selfhost-signing";
+    const assetName = "breeze-agent-linux-amd64";
+
+    function stubRepoFetch(
+      asset: Buffer,
+      signed: ReturnType<typeof makeSignedReleaseManifest>,
+    ) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (url.includes("/releases/latest")) {
+            return new Response(
+              JSON.stringify({
+                tag_name: "v1.2.3",
+                body: "release notes",
+                assets: [
+                  {
+                    name: assetName,
+                    browser_download_url: `https://github.com/${repo}/releases/download/v1.2.3/${assetName}`,
+                    size: asset.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json",
+                    browser_download_url: `https://github.com/${repo}/releases/download/v1.2.3/release-artifact-manifest.json`,
+                    size: signed.manifest.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json.ed25519",
+                    browser_download_url: `https://github.com/${repo}/releases/download/v1.2.3/release-artifact-manifest.json.ed25519`,
+                    size: signed.signature.length,
+                  },
+                ],
+              }),
+            );
+          }
+          if (url.endsWith("/release-artifact-manifest.json"))
+            return new Response(signed.manifest);
+          if (url.endsWith("/release-artifact-manifest.json.ed25519"))
+            return new Response(signed.signature);
+          return new Response("not found", { status: 404 });
+        }),
+      );
+    }
+
+    it("stamps the deploy-* key ID and a normalized manifest that verifies against the deployment key", async () => {
+      process.env.BINARY_GITHUB_REPOSITORY = repo;
+      const asset = Buffer.from("self-hoster signed agent bytes");
+      const signed = makeSignedReleaseManifest(assetName, asset, repo);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      // Real deployment key: signManifest signs with it so the test can
+      // assert the stored signature verifies against the deployment pubkey.
+      const { publicKey: deployPub, privateKey: deployPriv } =
+        generateKeyPairSync("ed25519");
+      manifestSigningMocks.signManifest.mockImplementation(
+        async (json: string) =>
+          sign(null, Buffer.from(json, "utf8"), deployPriv).toString("base64"),
+      );
+
+      try {
+        stubRepoFetch(asset, signed);
+        const result = await syncFromGitHub();
+        expect(result.synced).toContain("agent:linux/amd64");
+
+        expect(manifestSigningMocks.ensureActiveSigningKey).toHaveBeenCalled();
+        const insert = dbMocks.insertValues.mock.calls[0]![0] as Record<string, unknown>;
+        expect(insert.signingKeyId).toBe("deploy-test-aaaaaaaa");
+        // NOT the raw release manifest: a normalized per-asset update manifest.
+        expect(JSON.parse(insert.releaseManifest as string)).toEqual({
+          version: "1.2.3",
+          component: "agent",
+          platform: "linux",
+          arch: "amd64",
+          url: `https://github.com/${repo}/releases/download/v1.2.3/${assetName}`,
+          checksum: signed.checksum,
+          size: asset.length,
+        });
+        expect(
+          verify(
+            null,
+            Buffer.from(insert.releaseManifest as string, "utf8"),
+            deployPub,
+            Buffer.from(insert.manifestSignature as string, "base64"),
+          ),
+        ).toBe(true);
+
+        // Conflict-update path carries the same re-signed fields.
+        const set = (dbMocks.onConflictDoUpdate.mock.calls[0]![0] as any).set;
+        expect(set.signingKeyId).toBe("deploy-test-aaaaaaaa");
+        expect(set.releaseManifest).toBe(insert.releaseManifest);
+      } finally {
+        // vi.clearAllMocks() clears CALLS, not implementations — restore the
+        // hoisted default so later tests keep the canned signature.
+        manifestSigningMocks.signManifest.mockImplementation(
+          async () => "test-signature-base64",
+        );
+      }
+    });
+
+    it("official-repo path is untouched: raw manifest, official key ID, no deployment key provisioning", async () => {
+      // No override env set.
+      const asset = Buffer.from("official agent bytes");
+      const signed = makeSignedReleaseManifest(assetName, asset);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (url.includes("/releases/latest")) {
+            return new Response(
+              JSON.stringify({
+                tag_name: "v1.2.3",
+                body: null,
+                assets: [
+                  {
+                    name: assetName,
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/v1.2.3/${assetName}`,
+                    size: asset.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json",
+                    browser_download_url: "https://github.com/LanternOps/breeze/releases/download/v1.2.3/release-artifact-manifest.json",
+                    size: signed.manifest.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json.ed25519",
+                    browser_download_url: "https://github.com/LanternOps/breeze/releases/download/v1.2.3/release-artifact-manifest.json.ed25519",
+                    size: signed.signature.length,
+                  },
+                ],
+              }),
+            );
+          }
+          if (url.endsWith("/release-artifact-manifest.json"))
+            return new Response(signed.manifest);
+          if (url.endsWith("/release-artifact-manifest.json.ed25519"))
+            return new Response(signed.signature);
+          return new Response("not found", { status: 404 });
+        }),
+      );
+
+      await syncFromGitHub();
+
+      expect(manifestSigningMocks.ensureActiveSigningKey).not.toHaveBeenCalled();
+      expect(manifestSigningMocks.signManifest).not.toHaveBeenCalled();
+      const insert = dbMocks.insertValues.mock.calls[0]![0] as Record<string, unknown>;
+      expect(insert.signingKeyId).toBe("release-artifact-manifest-ed25519");
+      expect(insert.releaseManifest).toBe(signed.manifest.toString("utf8"));
+    });
+  });
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/binarySync.test.ts` — the first new test fails (`signingKeyId` is still `release-artifact-manifest-ed25519`).
+- [ ] Edit `apps/api/src/services/binarySync.ts`. Extend the Task 3 import to `import { getReleaseSourceApiBase, getReleaseSourceRepository, isOfficialReleaseSource } from "./releaseSource";`. Add above `upsertVersion` (currently line 819):
+
+```ts
+type UpsertMetadata = {
+  checksum: string;
+  size: number;
+  releaseManifest?: string;
+  manifestSignature?: string;
+  signingKeyId?: string;
+};
+
+// Spec 3b: when syncing from an OVERRIDDEN repository, the release manifest is
+// signed by the self-hoster's release key, which agents do not (and must not
+// need to) trust. Re-sign a NORMALIZED per-asset update manifest — the exact
+// shape registerLocalBinaries produces — with the per-deployment key and stamp
+// the deploy-* key ID, so agents verify against their TOFU-pinned deployment
+// key with zero agent-side changes.
+//
+// For the official repository this is a pass-through: that path must stay
+// byte-identical (raw release manifest + "release-artifact-manifest-ed25519",
+// which agents bind to the embedded official key). The checksums.txt fallback
+// path (no releaseManifest, non-production only) is also passed through — there
+// is no verified manifest to normalize.
+async function applyDeploymentSigning(args: {
+  metadata: UpsertMetadata;
+  version: string;
+  component: string;
+  platform: string;
+  arch: string;
+  downloadUrl: string;
+}): Promise<UpsertMetadata> {
+  const { metadata } = args;
+  if (isOfficialReleaseSource() || !metadata.releaseManifest) {
+    return metadata;
+  }
+
+  const { keyId } = await ensureActiveSigningKey();
+  const releaseManifest = JSON.stringify({
+    version: args.version,
+    component: args.component,
+    platform: args.platform,
+    arch: args.arch,
+    url: args.downloadUrl,
+    checksum: metadata.checksum,
+    size: metadata.size,
+  });
+  const manifestSignature = await signManifest(releaseManifest);
+  return {
+    checksum: metadata.checksum,
+    size: metadata.size,
+    releaseManifest,
+    manifestSignature,
+    signingKeyId: keyId,
+  };
+}
+```
+
+  Then in `upsertVersion` (line 822), insert as the first statement of the function body and use `signedMetadata` in place of `metadata` in both the `.values({...})` and the `.onConflictDoUpdate({ set: {...} })` blocks:
+
+```ts
+  const signedMetadata = await applyDeploymentSigning({
+    metadata,
+    version,
+    component,
+    platform,
+    arch,
+    downloadUrl,
+  });
+```
+
+  (A signing failure — e.g. missing `APP_ENCRYPTION_KEY` — throws inside the existing per-target `try/catch` in the four `syncFromGitHub` loops, so one component failure logs and continues, matching current upsert-failure semantics; the asset is simply not registered — fail closed.)
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/binarySync.test.ts src/services/binarySync.selftest.test.ts` — expect green (the second new test locks the official-path bytes).
+- [ ] Commit: `feat(api): re-sign github-synced update manifests with the deployment key for overridden release sources (spec 3b)`
+
+---
+
+### Task 6: Positive trust allowlist, enforced centrally
+
+**Files:**
+- Create: `apps/api/src/services/releaseAssetTrust.ts`
+- Modify: `apps/api/src/services/releaseArtifactManifest.ts` (asset type at lines 16-21, `VerifiedReleaseArtifact` at 35-42, `selectManifestAsset` at 230-295, both verify returns at 219-227 and 314-322)
+- Modify: `apps/api/src/services/binarySource.ts` (asset-URL chokepoint for the serving surfaces `routes/agents/download.ts:42` and `routes/supportPublic.ts:193`, which redirect/proxy via these builders)
+- Test: `apps/api/src/services/releaseAssetTrust.test.ts` (new), `apps/api/src/services/releaseArtifactManifest.test.ts` (extend), `apps/api/src/services/binarySource.test.ts` (extend)
+- Sweep: test fixtures that stamp `platformTrust` on canonical Windows/macOS asset names — `apps/api/src/services/binarySync.test.ts` (helpers currently hardcode `"release-workflow-produced"` for every asset incl. `.exe`), `apps/api/src/services/installerBuilder.test.ts`, `apps/api/src/routes/agentVersions.test.ts`, `apps/api/src/services/releaseArtifactManifest.test.ts`
+
+**Interfaces:**
+- Produces (`releaseAssetTrust.ts`):
+
+```ts
+export const PLATFORM_TRUST_WINDOWS = 'windows-authenticode-required';
+export const PLATFORM_TRUST_MACOS = 'macos-developer-id-notarization-required';
+export const PLATFORM_TRUST_WORKFLOW = 'release-workflow-produced';
+export const PLATFORM_TRUST_NONE = 'none';
+export const INTENDED_USE_SIGNING_INPUT = 'signing-input';
+export function isSigningInputAssetName(assetName: string): boolean;
+export function requiredPlatformTrustFor(assetName: string): string | null;
+export function assertDistributableReleaseAsset(args: { assetName: string; platformTrust: string | null; intendedUse: string | null }): void;
+```
+
+- Modifies: `VerifiedReleaseArtifact` gains `intendedUse: string | null`.
+
+**Steps:**
+
+- [ ] Write `apps/api/src/services/releaseAssetTrust.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  PLATFORM_TRUST_MACOS,
+  PLATFORM_TRUST_WINDOWS,
+  PLATFORM_TRUST_WORKFLOW,
+  assertDistributableReleaseAsset,
+  isSigningInputAssetName,
+  requiredPlatformTrustFor,
+} from './releaseAssetTrust';
+
+describe('releaseAssetTrust', () => {
+  it.each([
+    ['breeze-agent-windows-amd64-unsigned.exe', true],
+    ['breeze-agent-darwin-arm64-unsigned', true],
+    ['breeze-user-helper-windows-amd64-unsigned.exe', true],
+    ['breeze-agent-windows-amd64.exe', false],
+    ['breeze-agent.msi', false],
+    ['breeze-agent-darwin-arm64', false],
+  ])('isSigningInputAssetName(%s) === %s', (name, expected) => {
+    expect(isSigningInputAssetName(name)).toBe(expected);
+  });
+
+  it.each([
+    ['breeze-agent-windows-amd64.exe', PLATFORM_TRUST_WINDOWS],
+    ['breeze-agent.msi', PLATFORM_TRUST_WINDOWS],
+    ['breeze-viewer-windows.msi', PLATFORM_TRUST_WINDOWS],
+    ['breeze-agent-darwin-arm64.pkg', PLATFORM_TRUST_MACOS],
+    ['breeze-helper-macos.dmg', PLATFORM_TRUST_MACOS],
+    ['Breeze Installer.app.zip', PLATFORM_TRUST_MACOS],
+    ['Breeze.Installer.app.zip', PLATFORM_TRUST_MACOS],
+    ['breeze-agent-darwin-amd64', PLATFORM_TRUST_MACOS],
+    ['breeze-watchdog-darwin-arm64', PLATFORM_TRUST_MACOS],
+    ['breeze-agent-linux-amd64', null],
+    ['install.sh', null],
+  ])('requiredPlatformTrustFor(%s) === %s', (name, expected) => {
+    expect(requiredPlatformTrustFor(name)).toBe(expected);
+  });
+
+  it('rejects signing-input intendedUse regardless of trust value', () => {
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-windows-amd64-unsigned.exe',
+        platformTrust: 'none',
+        intendedUse: 'signing-input',
+      }),
+    ).toThrow(/not distributable/);
+  });
+
+  it('rejects ANY non-null intendedUse (unknown values fail closed)', () => {
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-linux-amd64',
+        platformTrust: PLATFORM_TRUST_WORKFLOW,
+        intendedUse: 'debugging-symbols',
+      }),
+    ).toThrow(/not distributable/);
+  });
+
+  it('rejects -unsigned names even when the manifest entry claims full trust', () => {
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-windows-amd64-unsigned.exe',
+        platformTrust: PLATFORM_TRUST_WINDOWS,
+        intendedUse: null,
+      }),
+    ).toThrow(/signing input/);
+  });
+
+  it('rejects unknown platformTrust values', () => {
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-linux-amd64',
+        platformTrust: 'totally-new-trust-level',
+        intendedUse: null,
+      }),
+    ).toThrow(/unknown platformTrust/);
+  });
+
+  it('requires windows-authenticode-required on canonical Windows executables', () => {
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-windows-amd64.exe',
+        platformTrust: PLATFORM_TRUST_WORKFLOW,
+        intendedUse: null,
+      }),
+    ).toThrow(/windows-authenticode-required/);
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-windows-amd64.exe',
+        platformTrust: null,
+        intendedUse: null,
+      }),
+    ).toThrow(/windows-authenticode-required/);
+  });
+
+  it('requires macos-developer-id-notarization-required on canonical macOS assets', () => {
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-darwin-arm64.pkg',
+        platformTrust: PLATFORM_TRUST_WORKFLOW,
+        intendedUse: null,
+      }),
+    ).toThrow(/macos-developer-id-notarization-required/);
+  });
+
+  it('accepts a correctly-labeled canonical asset and a plain linux asset', () => {
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-windows-amd64.exe',
+        platformTrust: PLATFORM_TRUST_WINDOWS,
+        intendedUse: null,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-linux-amd64',
+        platformTrust: PLATFORM_TRUST_WORKFLOW,
+        intendedUse: null,
+      }),
+    ).not.toThrow();
+    // Pre-platformTrust manifests: null on a non-canonical asset is tolerated.
+    expect(() =>
+      assertDistributableReleaseAsset({
+        assetName: 'breeze-agent-linux-amd64',
+        platformTrust: null,
+        intendedUse: null,
+      }),
+    ).not.toThrow();
+  });
+});
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/releaseAssetTrust.test.ts` — fails (module missing).
+- [ ] Create `apps/api/src/services/releaseAssetTrust.ts`:
+
+```ts
+/**
+ * Positive platform-trust allowlist for release assets (spec 3c).
+ *
+ * Replaces expected-value-only checking: instead of only failing when a caller
+ * happened to pass expectedPlatformTrust, every manifest-verified asset is
+ * checked against what its NAME requires, unknown trust vocabulary fails
+ * closed, and signing-input assets (Deliverable 1's `-unsigned` uploads with
+ * intendedUse: "signing-input") are never distributable.
+ *
+ * The name classifier deliberately mirrors the manifest generator in
+ * .github/workflows/release.yml (platform_trust(), ~line 2088) — keep the two
+ * in sync when the asset taxonomy changes.
+ */
+
+export const PLATFORM_TRUST_WINDOWS = 'windows-authenticode-required';
+export const PLATFORM_TRUST_MACOS = 'macos-developer-id-notarization-required';
+export const PLATFORM_TRUST_WORKFLOW = 'release-workflow-produced';
+export const PLATFORM_TRUST_NONE = 'none';
+
+export const KNOWN_PLATFORM_TRUST_VALUES: ReadonlySet<string> = new Set([
+  PLATFORM_TRUST_WINDOWS,
+  PLATFORM_TRUST_MACOS,
+  PLATFORM_TRUST_WORKFLOW,
+  PLATFORM_TRUST_NONE,
+]);
+
+export const INTENDED_USE_SIGNING_INPUT = 'signing-input';
+
+// Raw darwin Mach-O binaries carry Developer ID + notarization even though
+// they ship inside the .pkg (see release.yml DARWIN_BINARY_RE).
+const DARWIN_BINARY_RE = /^breeze-(agent|backup|desktop-helper|watchdog)-darwin-(amd64|arm64)$/;
+
+// "-unsigned" immediately before the extension chain (or at the end for
+// extensionless darwin/linux binaries): breeze-agent-windows-amd64-unsigned.exe,
+// breeze-agent-darwin-arm64-unsigned.
+const SIGNING_INPUT_NAME_RE = /-unsigned(\.[A-Za-z0-9]+)*$/;
+
+export function isSigningInputAssetName(assetName: string): boolean {
+  return SIGNING_INPUT_NAME_RE.test(assetName);
+}
+
+/**
+ * The platformTrust value an asset's NAME requires, or null when the name
+ * implies no platform-signing requirement (Linux binaries, scripts, manifests).
+ */
+export function requiredPlatformTrustFor(assetName: string): string | null {
+  if (/\.(exe|msi)$/i.test(assetName)) return PLATFORM_TRUST_WINDOWS;
+  if (/\.pkg$/i.test(assetName) || /\.dmg$/i.test(assetName) || /\.app\.zip$/i.test(assetName)) {
+    return PLATFORM_TRUST_MACOS;
+  }
+  if (DARWIN_BINARY_RE.test(assetName)) return PLATFORM_TRUST_MACOS;
+  return null;
+}
+
+/**
+ * Throws unless the asset may be registered or served to end users/agents.
+ * Fail-closed on: any intendedUse (the only known value, "signing-input", is
+ * never distributable, and unknown future values must not slip through), a
+ * signing-input-shaped name, unknown platformTrust vocabulary, and a canonical
+ * Windows/macOS asset whose trust label is missing or weaker than required.
+ *
+ * platformTrust === null on a NON-canonical asset is tolerated for manifests
+ * predating the platformTrust field.
+ */
+export function assertDistributableReleaseAsset(args: {
+  assetName: string;
+  platformTrust: string | null;
+  intendedUse: string | null;
+}): void {
+  if (args.intendedUse !== null) {
+    throw new Error(
+      `Release asset ${args.assetName} is not distributable (intendedUse=${args.intendedUse})`,
+    );
+  }
+  if (isSigningInputAssetName(args.assetName)) {
+    throw new Error(
+      `Release asset ${args.assetName} is a signing input and must never be registered or served`,
+    );
+  }
+  if (args.platformTrust !== null && !KNOWN_PLATFORM_TRUST_VALUES.has(args.platformTrust)) {
+    throw new Error(
+      `Release asset ${args.assetName} has unknown platformTrust "${args.platformTrust}"`,
+    );
+  }
+  const required = requiredPlatformTrustFor(args.assetName);
+  if (required !== null && args.platformTrust !== required) {
+    throw new Error(
+      `Release asset ${args.assetName} requires platformTrust "${required}", got ${
+        args.platformTrust === null ? 'none recorded' : `"${args.platformTrust}"`
+      }`,
+    );
+  }
+}
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/releaseAssetTrust.test.ts` — green.
+- [ ] Add failing tests to `apps/api/src/services/releaseArtifactManifest.test.ts`. The file's existing `makeSignedManifest` helper (lines 9-41) hardcodes `platformTrust: "release-workflow-produced"` for a **`breeze-agent.msi`** fixture, which the new enforcement would reject — so first extend the helper to classify by name and accept overrides:
+
+```ts
+import { requiredPlatformTrustFor } from "./releaseAssetTrust";
+
+function makeSignedManifest(args: {
+  assetName: string;
+  assetBuffer: Buffer;
+  release?: string;
+  repository?: string;
+  assetOverrides?: Record<string, unknown>;
+}) {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  const rawPublicKey = publicDer
+    .subarray(publicDer.length - 32)
+    .toString("base64");
+  const manifest = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      repository: args.repository ?? "lanternops/breeze",
+      release: args.release ?? "v1.2.3",
+      assets: [
+        {
+          name: args.assetName,
+          sha256: "placeholder",
+          size: args.assetBuffer.length,
+          platformTrust:
+            requiredPlatformTrustFor(args.assetName) ??
+            "release-workflow-produced",
+          ...(args.assetOverrides ?? {}),
+        },
+      ],
+    }).replace("placeholder", createSha256(args.assetBuffer)),
+  );
+
+  return {
+    manifest,
+    signature: Buffer.from(sign(null, manifest, privateKey).toString("base64")),
+    publicKey: rawPublicKey,
+  };
+}
+```
+
+  (The classify-by-name default keeps every existing `breeze-agent.msi` test in this file green under the new enforcement.) Then add the new tests:
+
+```ts
+  describe("positive trust enforcement (spec 3c)", () => {
+    it("rejects verification of a signing-input asset", async () => {
+      const asset = Buffer.from("unsigned input bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-windows-amd64-unsigned.exe",
+        assetBuffer: asset,
+        assetOverrides: { platformTrust: "none", intendedUse: "signing-input" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+      await expect(
+        verifyReleaseArtifactManifestAsset({
+          assetName: "breeze-agent-windows-amd64-unsigned.exe",
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).rejects.toThrow(/not distributable/);
+    });
+
+    it("rejects an unknown platformTrust value", async () => {
+      const asset = Buffer.from("linux agent bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-linux-amd64",
+        assetBuffer: asset,
+        assetOverrides: { platformTrust: "mystery-trust" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+      await expect(
+        verifyReleaseArtifactManifestAsset({
+          assetName: "breeze-agent-linux-amd64",
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).rejects.toThrow(/unknown platformTrust/);
+    });
+
+    it("rejects a canonical Windows exe without windows-authenticode-required", async () => {
+      const asset = Buffer.from("windows agent bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-windows-amd64.exe",
+        assetBuffer: asset,
+        assetOverrides: { platformTrust: "release-workflow-produced" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+      await expect(
+        verifyReleaseArtifactManifestAsset({
+          assetName: "breeze-agent-windows-amd64.exe",
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).rejects.toThrow(/windows-authenticode-required/);
+    });
+
+    it("returns intendedUse: null and the required trust for ordinary assets", async () => {
+      const asset = Buffer.from("windows agent bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-windows-amd64.exe",
+        assetBuffer: asset,
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+      await expect(
+        verifyReleaseArtifactManifestAsset({
+          assetName: "breeze-agent-windows-amd64.exe",
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).resolves.toMatchObject({
+        platformTrust: "windows-authenticode-required",
+        intendedUse: null,
+      });
+    });
+  });
+```
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/releaseArtifactManifest.test.ts` — new tests fail.
+- [ ] Edit `apps/api/src/services/releaseArtifactManifest.ts`:
+  - Add import: `import { assertDistributableReleaseAsset } from './releaseAssetTrust';`
+  - Add `intendedUse?: unknown;` to `ReleaseArtifactManifestAsset` (lines 16-21).
+  - Add `intendedUse: string | null;` to `VerifiedReleaseArtifact` (lines 35-42).
+  - In `selectManifestAsset` (after the size check ending at line 280, BEFORE the `expectedPlatformTrust` check at 281):
+
+```ts
+  // Spec 3c: positive allowlist, enforced for EVERY manifest verification —
+  // github sync registration, installer/support asset pre-flight, and recovery
+  // media all funnel through here. expectedPlatformTrust (below) remains as a
+  // caller-supplied stricter expectation on top of this baseline.
+  assertDistributableReleaseAsset({
+    assetName: args.assetName,
+    platformTrust: typeof entry.platformTrust === 'string' ? entry.platformTrust : null,
+    intendedUse: typeof entry.intendedUse === 'string' ? entry.intendedUse : null,
+  });
+```
+
+  - In both return blocks (`verifyReleaseArtifactBuffer` lines 219-227 and `verifyReleaseArtifactManifestAsset` lines 314-322), add after the `platformTrust` field:
+
+```ts
+    intendedUse: typeof entry.intendedUse === 'string' ? entry.intendedUse : null,
+```
+
+  (For `verifyReleaseArtifactBuffer`, `entry` is already in scope; keep the field derivation identical in both.)
+- [ ] Sweep test fixtures that now violate the positive allowlist: in `apps/api/src/services/binarySync.test.ts`, change both manifest helpers to classify trust by name instead of hardcoding `"release-workflow-produced"`:
+
+```ts
+import { requiredPlatformTrustFor } from "./releaseAssetTrust";
+
+function fixturePlatformTrust(name: string): string {
+  return requiredPlatformTrustFor(name) ?? "release-workflow-produced";
+}
+```
+
+  and use `platformTrust: fixturePlatformTrust(a.name)` / `platformTrust: fixturePlatformTrust(assetName)` in `makeSignedReleaseManifest` and `makeSignedReleaseManifestMulti`. Then run `grep -rn "platformTrust" apps/api/src --include="*.test.ts"` and apply the same fix to any fixture in `installerBuilder.test.ts` and `agentVersions.test.ts` that stamps a canonical `.exe`/`.msi`/`.pkg`/`.dmg`/darwin-binary name with the wrong value (`installerBuilder.test.ts` already passes the correct expected values for its MSI/pkg fixtures — verify, don't assume).
+- [ ] Add a serving-surface guard in `apps/api/src/services/binarySource.ts`: add import `import { isSigningInputAssetName } from './releaseAssetTrust';`, add the chokepoint below `githubDownloadBase()`:
+
+```ts
+// Spec 3c serving-surface guard: routes/agents/download.ts redirects and
+// routes/supportPublic.ts proxies whatever URL these builders produce, without
+// ever seeing a manifest. All canonical asset filenames are static strings
+// today, so this is a tripwire against a future builder (or refactor) leaking
+// a signing-input asset onto a public surface.
+function githubAssetDownloadUrl(filename: string): string {
+  if (isSigningInputAssetName(filename)) {
+    throw new Error(
+      `Refusing to build a download URL for signing-input asset "${filename}"`,
+    );
+  }
+  return `${githubDownloadBase()}/${filename}`;
+}
+```
+
+  and replace every `` `${githubDownloadBase()}/${filename}` `` template in the asset builders (`getGithubAgentUrl`, `getGithubBackupUrl`, `getGithubAgentPkgUrl`, `getGithubWatchdogUrl`, `getGithubUserHelperUrl`, `getGithubRegularMsiUrl`, `getGithubViewerUrl`, `getGithubHelperUrl`, `getGithubInstallerAppUrl`) with `githubAssetDownloadUrl(filename)` (for `getGithubRegularMsiUrl`/`getGithubInstallerAppUrl`, pass the literal: `githubAssetDownloadUrl('breeze-agent.msi')`, `githubAssetDownloadUrl('Breeze.Installer.app.zip')`). Leave the two manifest-URL builders on `githubDownloadBase()`.
+- [ ] Add to `apps/api/src/services/binarySource.test.ts`:
+
+```ts
+  it('serving-surface guard: refuses to build URLs for signing-input asset names', async () => {
+    const { HELPER_FILENAMES } = await import('./binarySource');
+    // Simulate a future registry mistake by direct call through a builder that
+    // takes caller-controlled filename mapping.
+    HELPER_FILENAMES.windows = 'breeze-helper-windows-unsigned.msi';
+    const { getGithubHelperUrl } = await import('./binarySource');
+    expect(() => getGithubHelperUrl('windows')).toThrow(/signing-input/);
+    HELPER_FILENAMES.windows = 'breeze-helper-windows.msi';
+  });
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/releaseAssetTrust.test.ts src/services/releaseArtifactManifest.test.ts src/services/binarySource.test.ts src/services/binarySync.test.ts src/services/installerBuilder.test.ts src/routes/agentVersions.test.ts src/routes/agents/download.test.ts src/routes/supportPublic.test.ts` — expect green.
+- [ ] Commit: `feat(api): positive platform-trust allowlist at manifest verification + serving chokepoints (spec 3c)`
+
+---
+
+### Task 7: Recovery media — expected hashes from the verified release manifest
+
+**Files:**
+- Modify: `apps/api/src/services/recoveryMediaService.ts` (`resolveBackupBinary` at lines 81-120; imports at 24-26)
+- Test: `apps/api/src/services/recoveryMediaService.test.ts` (new)
+- Unchanged: `apps/api/src/services/binaryManifest.ts` (`verifyBinaryChecksum` at 53-95 stays as the LOCAL-mode path; the static `recovery-binary-manifest.json` table no longer gates github mode)
+
+**Interfaces:**
+- Consumes: `verifyGithubReleaseArtifactBuffer` from `./releaseArtifactManifest` (returns `VerifiedReleaseArtifact | null`; throws when verification is required but unconfigured, and on any hash/size/trust mismatch); `getGithubReleaseArtifactManifestUrl`, `getGithubReleaseArtifactManifestSignatureUrl` from `./binarySource`; `getReleaseSourceRepository` from `./releaseSource`; `VerifiedRecoveryBinary` type from `./binaryManifest`.
+- Produces: `export async function resolveBackupBinary(platform: string, architecture: string, workingDir: string): Promise<{ fileName: string; filePath: string; verified: VerifiedRecoveryBinary }>` (previously module-private; exported for unit testing, same call site in `buildRecoveryMediaArtifact` at line 395).
+
+**Steps:**
+
+- [ ] Write `apps/api/src/services/recoveryMediaService.test.ts`:
+
+```ts
+import { createHash, generateKeyPairSync, sign } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// recoveryMediaService pulls in the db and the recovery-bootstrap/signing
+// stack at module load; none of it is exercised by resolveBackupBinary.
+vi.mock('../db', () => ({ db: {} }));
+vi.mock('./recoveryBootstrap', () => ({
+  asRecord: (v: unknown) => (v && typeof v === 'object' ? v : {}),
+  getStringValue: () => null,
+  resolveServerUrl: () => 'https://breeze.example.com',
+  resolveSnapshotProviderConfig: vi.fn(),
+}));
+vi.mock('./recoverySigning', () => ({
+  getRecoverySigningKey: () => null,
+  isRecoverySigningConfigured: () => false,
+  signRecoveryArtifact: vi.fn(),
+}));
+
+import { resolveBackupBinary } from './recoveryMediaService';
+
+function makeSignedBackupManifest(assetName: string, assetBuffer: Buffer) {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const publicDer = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+  const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString('base64');
+  const manifest = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      repository: 'LanternOps/breeze',
+      release: 'v1.2.3',
+      assets: [
+        {
+          name: assetName,
+          sha256: createHash('sha256').update(assetBuffer).digest('hex'),
+          size: assetBuffer.length,
+          platformTrust: 'release-workflow-produced',
+        },
+      ],
+    }),
+  );
+  return {
+    manifest,
+    signature: Buffer.from(sign(null, manifest, privateKey).toString('base64')),
+    publicKey: rawPublicKey,
+  };
+}
+
+describe('resolveBackupBinary (github mode, spec 3d)', () => {
+  const originalEnv = process.env;
+  let workingDir: string;
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv };
+    delete process.env.BINARY_SOURCE; // github is the default
+    delete process.env.BINARY_GITHUB_REPOSITORY;
+    delete process.env.GITHUB_REPO;
+    process.env.BINARY_VERSION = '1.2.3';
+    workingDir = await mkdtemp(join(tmpdir(), 'recovery-test-'));
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+    await rm(workingDir, { recursive: true, force: true });
+  });
+
+  function stubFetch(assetName: string, bytes: Buffer, signed: ReturnType<typeof makeSignedBackupManifest>) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.endsWith(`/${assetName}`)) return new Response(bytes);
+        if (url.endsWith('/release-artifact-manifest.json')) return new Response(signed.manifest);
+        if (url.endsWith('/release-artifact-manifest.json.ed25519')) return new Response(signed.signature);
+        return new Response('not found', { status: 404 });
+      }),
+    );
+  }
+
+  it('verifies the backup binary against the signed release manifest, not the static table', async () => {
+    const bytes = Buffer.from('backup binary bytes');
+    const signed = makeSignedBackupManifest('breeze-backup-linux-amd64', bytes);
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+    stubFetch('breeze-backup-linux-amd64', bytes, signed);
+
+    const result = await resolveBackupBinary('linux', 'amd64', workingDir);
+    expect(result.verified).toMatchObject({
+      platform: 'linux',
+      architecture: 'amd64',
+      sourceType: 'github',
+      sourceRef: 'github-release:v1.2.3',
+      version: '1.2.3',
+      sha256: createHash('sha256').update(bytes).digest('hex'),
+      manifestVersion: 'v1.2.3',
+    });
+  });
+
+  it('fails closed when the downloaded bytes do not match the manifest hash', async () => {
+    const bytes = Buffer.from('backup binary bytes');
+    const signed = makeSignedBackupManifest('breeze-backup-linux-amd64', bytes);
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+    stubFetch('breeze-backup-linux-amd64', Buffer.from('TAMPERED bytes!!!!!'), signed);
+
+    await expect(resolveBackupBinary('linux', 'amd64', workingDir)).rejects.toThrow(
+      /mismatch/,
+    );
+  });
+
+  it('fails closed when no manifest trust root is configured', async () => {
+    const bytes = Buffer.from('backup binary bytes');
+    const signed = makeSignedBackupManifest('breeze-backup-linux-amd64', bytes);
+    delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    delete process.env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    stubFetch('breeze-backup-linux-amd64', bytes, signed);
+
+    await expect(resolveBackupBinary('linux', 'amd64', workingDir)).rejects.toThrow(
+      /RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS/,
+    );
+  });
+
+  it('still requires a pinned version (never "latest")', async () => {
+    process.env.BINARY_VERSION = 'latest';
+    await expect(resolveBackupBinary('linux', 'amd64', workingDir)).rejects.toThrow(
+      /pinned GitHub release version/,
+    );
+  });
+});
+```
+
+  (Size note: the manifest lists the tampered test's size as the ORIGINAL bytes' length, and the tampered buffer has a different length, so the failure surfaces as a size or digest mismatch — the `/mismatch/` matcher covers both.)
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/recoveryMediaService.test.ts` — fails (`resolveBackupBinary` is not exported; github path uses the static table).
+- [ ] Edit `apps/api/src/services/recoveryMediaService.ts`:
+  - Extend imports:
+
+```ts
+import { verifyBinaryChecksum, type VerifiedRecoveryBinary } from './binaryManifest';
+import {
+  getBinarySource,
+  getGithubBackupUrl,
+  getGithubReleaseArtifactManifestSignatureUrl,
+  getGithubReleaseArtifactManifestUrl,
+  getGithubReleaseVersion,
+} from './binarySource';
+import { verifyGithubReleaseArtifactBuffer } from './releaseArtifactManifest';
+import { getReleaseSourceRepository } from './releaseSource';
+```
+
+  - Replace `resolveBackupBinary` (lines 81-120) with:
+
+```ts
+export async function resolveBackupBinary(
+  platform: string,
+  architecture: string,
+  workingDir: string,
+): Promise<{
+  fileName: string;
+  filePath: string;
+  verified: VerifiedRecoveryBinary;
+}> {
+  const fileName = getBinaryFileName(platform, architecture);
+  const destinationPath = join(workingDir, fileName);
+  const sourceType = getBinarySource();
+
+  if (sourceType === 'github') {
+    // Spec 3d: expected hashes come from the deployment-verified release
+    // manifest, not a static table — a BYO-signed backup binary has a
+    // different hash per self-hoster, which no shipped table can know.
+    const version = getGithubReleaseVersion();
+    if (version === 'latest') {
+      throw new Error(
+        'Recovery helper builds require a pinned GitHub release version, not "latest"',
+      );
+    }
+    const sourceRef = `github-release:v${version}`;
+    await downloadFile(getGithubBackupUrl(platform, architecture), destinationPath);
+
+    const verifiedAsset = await verifyGithubReleaseArtifactBuffer({
+      assetName: fileName,
+      assetBuffer: await readFile(destinationPath),
+      manifestUrl: getGithubReleaseArtifactManifestUrl(),
+      signatureUrl: getGithubReleaseArtifactManifestSignatureUrl(),
+      expectedRepository: getReleaseSourceRepository(),
+      expectedRelease: `v${version}`,
+    });
+    if (!verifiedAsset) {
+      // Only reachable outside production with no trust root configured.
+      // Recovery media is a restore path — never ship an unverified helper.
+      throw new Error(
+        'Recovery helper builds require RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS so the backup binary can be verified against the signed release manifest',
+      );
+    }
+    return {
+      fileName,
+      filePath: destinationPath,
+      verified: {
+        platform,
+        architecture,
+        sourceType: 'github',
+        sourceRef,
+        version,
+        sha256: verifiedAsset.sha256,
+        manifestVersion: verifiedAsset.release,
+      },
+    };
+  }
+
+  // Local mode: unchanged — verify against the pinned checksum table
+  // (BINARY_CHECKSUM_MANIFEST overrides the shipped recovery-binary-manifest.json).
+  const candidatePath = resolve(
+    process.env.BACKUP_BINARY_DIR ||
+      process.env.AGENT_BINARY_DIR ||
+      './agent/bin',
+    fileName
+  );
+  const sourceRef = candidatePath;
+  const version = process.env.BINARY_VERSION || process.env.BREEZE_VERSION || 'workspace-local';
+  await copyFile(candidatePath, destinationPath);
+
+  const verified = await verifyBinaryChecksum({
+    filePath: destinationPath,
+    platform,
+    architecture,
+    sourceType,
+    sourceRef,
+    version,
+  });
+  return { fileName, filePath: destinationPath, verified };
+}
+```
+
+  (`buildRecoveryMediaArtifact` at line 395 consumes `binary.verified.version/.sourceType/.sourceRef/.manifestVersion` — all preserved. The `helperBinaryDigestVerified: true` metadata claim at line 511 is now backed by the release-manifest digest check in github mode.)
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/recoveryMediaService.test.ts src/services/binaryManifest.test.ts src/services/recoveryDownloadService.test.ts src/services/recoveryBootstrap.test.ts` — expect green.
+- [ ] Commit: `feat(api): recovery media verifies the backup binary against the signed release manifest (spec 3d)`
+
+---
+
+### Task 8: Retire msiSigning.ts (Deliverable 5)
+
+**Files:**
+- Delete: `apps/api/src/services/msiSigning.ts`, `apps/api/src/services/msiSigning.test.ts`
+- Modify: `apps/api/src/config/validate.ts` (schema lines 594-598; superRefine lines 1358-1370; indicator-comment line 1256)
+- Modify: `apps/api/src/config/validate.test.ts` (MSI-signing cases: header comment ~1626, tests ~1827-1845, fixture usage ~1890)
+- Modify: `apps/api/src/routes/system.ts` (line 75)
+- Modify: `apps/api/src/routes/enrollmentKeys_installer.test.ts` (mock lines 98-103, import line 134, reset line 220), `apps/api/src/routes/enrollmentKeys.test.ts` (mock 76-77, import 156, `mockReturnValue(null)` at 250, 609, 754, 794, 1297, 1611, 2075), `apps/api/src/routes/enrollmentKeys_capClamp.test.ts` (line 76)
+- Modify: `apps/api/src/services/installerBuilder.ts` (comment line 32)
+- Modify: `docker-compose.yml` (lines 296-300), `deploy/docker-compose.prod.yml` (lines 270-272)
+- Modify: `.env.example` (MSI Signing block, lines ~793-804), `deploy/.env.example` (MSI Signing block, lines ~304-307)
+
+**Interfaces:** none produced — pure removal. Confirmed before deletion: NO runtime module imports `MsiSigningService` (only test mocks + the two env reads above), so this cannot change route behavior.
+
+**Steps:**
+
+- [ ] TDD the observable change first — add to `apps/api/src/routes/system.test.ts` (the file already provides `setAuth()` and `makeApp()`, and mocks `requirePermission` as a pass-through, so `GET /system/config-status` is reachable):
+
+```ts
+  it('config-status no longer reports an msiSigning integration flag (per-download signing retired)', async () => {
+    setAuth();
+    const app = makeApp();
+    const res = await app.request('/system/config-status');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { integrations: Record<string, unknown> };
+    expect(body.integrations).not.toHaveProperty('msiSigning');
+  });
+```
+
+  and to `apps/api/src/config/validate.test.ts`, inside the `Feature-flagged production secrets (H-3)` describe (~line 1633) where `prodBase` is in scope — this REPLACES the block of MSI tests deleted below:
+
+```ts
+    it('MSI_SIGNING_URL is inert: production boots without MSI_SIGNING_CF_ACCESS_SECRET', () => {
+      withEnv({
+        ...prodBase,
+        MSI_SIGNING_URL: 'https://sign.example.com/sign-breeze-agent',
+        MSI_SIGNING_CF_ACCESS_SECRET: '',
+      }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/routes/system.test.ts src/config/validate.test.ts` — both new tests fail.
+- [ ] `git rm apps/api/src/services/msiSigning.ts apps/api/src/services/msiSigning.test.ts`
+- [ ] Edit `apps/api/src/config/validate.ts`: delete lines 594-598 (the `// MSI signing —` comment plus `MSI_SIGNING_URL` and `MSI_SIGNING_CF_ACCESS_SECRET` schema entries); delete lines 1358-1370 (the `// MSI signing (MSI_SIGNING_URL as indicator).` comment block, `const msiSigningEnabled ...`, and its `requireIf(...)` call); on line 1256 change `S3_BUCKET, CLOUDFLARE_API_TOKEN, MSI_SIGNING_URL` → `S3_BUCKET, CLOUDFLARE_API_TOKEN`.
+- [ ] Edit `apps/api/src/config/validate.test.ts`: delete the `- MSI signing: MSI_SIGNING_URL set` line from the H-3 header comment (~1626), the `--- MSI signing (MSI_SIGNING_URL set) ---` tests (~1827-1845), and remove `MSI_SIGNING_URL`/`MSI_SIGNING_CF_ACCESS_SECRET` keys from any remaining fixture objects (~1890). Keep the new inert-var test from the first step.
+- [ ] Edit `apps/api/src/routes/system.ts`: delete line 75 (`msiSigning: !!env.MSI_SIGNING_URL,`).
+- [ ] Edit the three enrollment-key test files: remove the `vi.mock('../services/msiSigning', ...)` blocks, the `import { MsiSigningService } from '../services/msiSigning';` lines, and every `vi.mocked(MsiSigningService.fromEnv).mockReturnValue(null);` statement (they are stale — the routes stopped importing the service when the per-download signing path was removed).
+- [ ] Edit `apps/api/src/services/installerBuilder.ts` line 32: `// --- Windows zip bundle builder (fallback when remote signing service is not configured) ---` → `// --- Windows zip bundle builder ---`
+- [ ] Edit `docker-compose.yml`: delete lines 296-300 (the `# MSI Signing (optional — ...)` comment and the four `MSI_SIGNING_*` mappings). Edit `deploy/docker-compose.prod.yml`: delete lines 270-272 (the three `MSI_SIGNING_*` mappings).
+- [ ] Edit `.env.example`: delete the whole `# MSI Signing (Windows installer code-signing tunnel)` block (header lines ~793-795 through `# MSI_SIGNING_API_KEY=` at ~804, plus the trailing blank line). Edit `deploy/.env.example`: delete the `# ── MSI Signing (optional) ─────…` block (~304-307).
+- [ ] Sweep for stragglers: `grep -rn "MSI_SIGNING\|msiSigning\|MsiSigningService" apps/api docker-compose.yml deploy .env.example --include="*.ts" --include="*.yml" -l` must return nothing. (`apps/docs` and `docs/` mentions are Phase 3's docs deliverable — leave them; note the handoff in the PR description.)
+- [ ] Run `pnpm --filter @breeze/api test -- src/routes/system.test.ts src/config/validate.test.ts src/routes/enrollmentKeys.test.ts src/routes/enrollmentKeys_installer.test.ts src/routes/enrollmentKeys_capClamp.test.ts src/config/envComposeParity.test.ts src/config/composeBindMounts.test.ts` — expect green.
+- [ ] Commit: `chore(api): retire the dead per-download MSI signing client and every MSI_SIGNING_* surface (spec deliverable 5)`
+
+---
+
+### Task 9: Trust-chain E2E — three distinct keys ending in real Go-updater verification
+
+**Files:**
+- Create: `scripts/generate-deployment-manifest-fixture.mjs` (deterministic fixture generator)
+- Create: `agent/internal/updater/testdata/deployment_signed_manifest.json` (generated, committed)
+- Create: `agent/internal/updater/deployment_trustchain_test.go`
+- Create: `apps/api/src/services/releaseTrustChain.e2e.test.ts` (unit config — no DB)
+
+**Interfaces:**
+- Fixture JSON contract (shared between vitest and Go):
+
+```json
+{
+  "keyId": "deploy-fixture-trustchain",
+  "publicKeyB64": "<raw Ed25519 pubkey, base64>",
+  "entries": [
+    { "platform": "linux",   "arch": "amd64", "url": "…", "checksum": "…", "manifest": "<exact JSON string the API stores>", "signatureB64": "…" },
+    { "platform": "linux",   "arch": "arm64", … },
+    { "platform": "macos",   "arch": "amd64", … },
+    { "platform": "macos",   "arch": "arm64", … },
+    { "platform": "windows", "arch": "amd64", … }
+  ]
+}
+```
+
+- Consumes (Go): `Updater.verifyUpdateManifest(info downloadInfo, version string) (updateManifest, error)` (`updater.go:928`) with `Config.PinnedManifestPubKeys` in `"<keyId>:<base64>"` form (pattern: `updater_test.go:926-970`). `manifestPlatform()` maps GOOS darwin → `"macos"` (`updater.go:378-383`) — fixture `platform` values match.
+- Ed25519 signatures are deterministic (RFC 8032), so a fixed seed makes the fixture reproducible and lets the vitest assert the API produces the exact committed bytes.
+
+**Steps:**
+
+- [ ] Create `scripts/generate-deployment-manifest-fixture.mjs`:
+
+```js
+#!/usr/bin/env node
+// Regenerates agent/internal/updater/testdata/deployment_signed_manifest.json —
+// the cross-language trust-chain golden fixture. Deterministic: fixed Ed25519
+// seed + deterministic RFC 8032 signatures, so re-running is a no-op unless the
+// normalized-manifest shape changes (in which case BOTH sides of the contract
+// must move together; see releaseTrustChain.e2e.test.ts and
+// deployment_trustchain_test.go).
+import { createHash, createPrivateKey, createPublicKey, sign } from 'node:crypto';
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SEED_HEX = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+const PKCS8_ED25519_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+const KEY_ID = 'deploy-fixture-trustchain';
+const REPO = 'acme/breeze-selfhost-signing';
+const VERSION = '9.9.9';
+
+const privateKey = createPrivateKey({
+  key: Buffer.concat([PKCS8_ED25519_PREFIX, Buffer.from(SEED_HEX, 'hex')]),
+  format: 'der',
+  type: 'pkcs8',
+});
+const spki = createPublicKey(privateKey).export({ format: 'der', type: 'spki' });
+const publicKeyB64 = spki.subarray(spki.length - 32).toString('base64');
+
+const checksum = createHash('sha256').update('trust-chain-fixture-binary').digest('hex');
+
+const targets = [
+  { goos: 'linux', platform: 'linux', arch: 'amd64', ext: '' },
+  { goos: 'linux', platform: 'linux', arch: 'arm64', ext: '' },
+  { goos: 'darwin', platform: 'macos', arch: 'amd64', ext: '' },
+  { goos: 'darwin', platform: 'macos', arch: 'arm64', ext: '' },
+  { goos: 'windows', platform: 'windows', arch: 'amd64', ext: '.exe' },
+];
+
+const entries = targets.map((t) => {
+  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/breeze-agent-${t.goos}-${t.arch}${t.ext}`;
+  // EXACT key order of binarySync.applyDeploymentSigning's normalized manifest.
+  const manifest = JSON.stringify({
+    version: VERSION,
+    component: 'agent',
+    platform: t.platform,
+    arch: t.arch,
+    url,
+    checksum,
+    size: 4096,
+  });
+  return {
+    platform: t.platform,
+    arch: t.arch,
+    url,
+    checksum,
+    manifest,
+    signatureB64: sign(null, Buffer.from(manifest, 'utf8'), privateKey).toString('base64'),
+  };
+});
+
+const out = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'agent/internal/updater/testdata/deployment_signed_manifest.json',
+);
+writeFileSync(out, JSON.stringify({ keyId: KEY_ID, publicKeyB64, entries }, null, 2) + '\n');
+console.log(`wrote ${out}`);
+```
+
+- [ ] Run `mkdir -p agent/internal/updater/testdata && node scripts/generate-deployment-manifest-fixture.mjs` and commit the generated JSON alongside the script.
+- [ ] Write `agent/internal/updater/deployment_trustchain_test.go`:
+
+```go
+package updater
+
+import (
+	"encoding/json"
+	"os"
+	"runtime"
+	"testing"
+)
+
+// deploymentManifestFixture mirrors the JSON written by
+// scripts/generate-deployment-manifest-fixture.mjs. It is the Go end of the
+// BYO-signing trust chain (spec 3b): the API re-signs a normalized update
+// manifest with the per-deployment key; this test proves the shipped agent
+// accepts EXACTLY those bytes under the deploy-* key ID — and only under it.
+type deploymentManifestFixture struct {
+	KeyID        string `json:"keyId"`
+	PublicKeyB64 string `json:"publicKeyB64"`
+	Entries      []struct {
+		Platform     string `json:"platform"`
+		Arch         string `json:"arch"`
+		URL          string `json:"url"`
+		Checksum     string `json:"checksum"`
+		Manifest     string `json:"manifest"`
+		SignatureB64 string `json:"signatureB64"`
+	} `json:"entries"`
+}
+
+func loadDeploymentManifestFixture(t *testing.T) deploymentManifestFixture {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/deployment_signed_manifest.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var fx deploymentManifestFixture
+	if err := json.Unmarshal(raw, &fx); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return fx
+}
+
+func TestDeploymentSignedManifestFixture_VerifiesUnderPinnedDeploymentKey(t *testing.T) {
+	fx := loadDeploymentManifestFixture(t)
+
+	var entry *struct {
+		Platform     string `json:"platform"`
+		Arch         string `json:"arch"`
+		URL          string `json:"url"`
+		Checksum     string `json:"checksum"`
+		Manifest     string `json:"manifest"`
+		SignatureB64 string `json:"signatureB64"`
+	}
+	for i := range fx.Entries {
+		if fx.Entries[i].Platform == manifestPlatform() && fx.Entries[i].Arch == runtime.GOARCH {
+			entry = &fx.Entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		t.Skipf("fixture has no entry for %s/%s", manifestPlatform(), runtime.GOARCH)
+	}
+
+	u := &Updater{
+		config: &Config{
+			Component:             "agent",
+			PinnedManifestPubKeys: []string{fx.KeyID + ":" + fx.PublicKeyB64},
+		},
+	}
+	info := downloadInfo{
+		URL:               entry.URL,
+		Checksum:          entry.Checksum,
+		Manifest:          entry.Manifest,
+		ManifestSignature: entry.SignatureB64,
+		SigningKeyID:      fx.KeyID,
+	}
+	got, err := u.verifyUpdateManifest(info, "9.9.9")
+	if err != nil {
+		t.Fatalf("verifyUpdateManifest: %v", err)
+	}
+	if got.Version != "9.9.9" || got.Component != "agent" {
+		t.Fatalf("unexpected manifest accepted: %+v", got)
+	}
+}
+
+func TestDeploymentSignedManifestFixture_RejectedUnderOfficialKeyID(t *testing.T) {
+	// Keyed trust means the deployment signature must NOT verify when the
+	// response claims the embedded official key's ID (P1-UPD-001 semantics).
+	fx := loadDeploymentManifestFixture(t)
+	entry := fx.Entries[0]
+
+	u := &Updater{
+		config: &Config{
+			Component:             "agent",
+			PinnedManifestPubKeys: []string{fx.KeyID + ":" + fx.PublicKeyB64},
+		},
+	}
+	info := downloadInfo{
+		URL:               entry.URL,
+		Checksum:          entry.Checksum,
+		Manifest:          entry.Manifest,
+		ManifestSignature: entry.SignatureB64,
+		SigningKeyID:      "release-artifact-manifest-ed25519",
+	}
+	if _, err := u.verifyUpdateManifest(info, "9.9.9"); err == nil {
+		t.Fatal("expected verification to fail under the official key ID")
+	}
+}
+```
+
+- [ ] Run `cd agent && go test -race ./internal/updater/ -run TestDeploymentSignedManifestFixture` — first test fails only if the fixture/normalized shape disagree with `updateManifest` (`updater.go:349-357`); fix the generator, never the agent, until green. (Note: the platform-match test verifies `platform`/`arch` against the runtime, which is why the fixture carries all five agent targets.)
+- [ ] Write `apps/api/src/services/releaseTrustChain.e2e.test.ts` — the vitest half walks all three keys and pins the API's output to the committed fixture bytes:
+
+```ts
+import { createHash, generateKeyPairSync, sign } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const insertValues = vi.fn(() => ({ onConflictDoUpdate }));
+  const updateWhere = vi.fn().mockResolvedValue(undefined);
+  const tx = {
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: updateWhere })) })),
+    insert: vi.fn(() => ({ values: insertValues })),
+  };
+  return {
+    insertValues,
+    transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => fn(tx)),
+  };
+});
+vi.mock('../db', () => ({ db: { transaction: dbMocks.transaction } }));
+vi.mock('./s3Storage', () => ({ isS3Configured: () => false, syncDirectory: vi.fn() }));
+
+// Deployment key = the FIXTURE key: signManifest signs with the fixture seed so
+// the sync output must be byte-identical to what the Go updater test verifies.
+// Everything the mock factory touches lives inside vi.hoisted(): static imports
+// are hoisted above module-body consts, and the factory runs while
+// './binarySync' is being imported — a plain top-level const would still be in
+// its temporal dead zone at that point.
+const trustChainSigner = vi.hoisted(() => {
+  const { createPrivateKey, sign } =
+    require('node:crypto') as typeof import('node:crypto');
+  const privateKey = createPrivateKey({
+    key: Buffer.concat([
+      Buffer.from('302e020100300506032b657004220420', 'hex'), // PKCS8 Ed25519 prefix
+      Buffer.from(
+        '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f', // fixture seed
+        'hex',
+      ),
+    ]),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  return {
+    keyId: 'deploy-fixture-trustchain',
+    ensureActiveSigningKey: vi.fn(async () => ({
+      keyId: 'deploy-fixture-trustchain',
+      publicKeyB64: '',
+    })),
+    signManifest: vi.fn(async (json: string) =>
+      sign(null, Buffer.from(json, 'utf8'), privateKey).toString('base64'),
+    ),
+  };
+});
+vi.mock('./manifestSigning', () => ({
+  ensureActiveSigningKey: trustChainSigner.ensureActiveSigningKey,
+  signManifest: trustChainSigner.signManifest,
+}));
+
+import { syncFromGitHub } from './binarySync';
+import { verifyReleaseArtifactManifestAsset } from './releaseArtifactManifest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const fixture = JSON.parse(
+  readFileSync(
+    path.join(REPO_ROOT, 'agent/internal/updater/testdata/deployment_signed_manifest.json'),
+    'utf8',
+  ),
+) as {
+  keyId: string;
+  publicKeyB64: string;
+  entries: Array<{
+    platform: string;
+    arch: string;
+    url: string;
+    checksum: string;
+    manifest: string;
+    signatureB64: string;
+  }>;
+};
+
+function rawPub(publicKey: import('node:crypto').KeyObject): string {
+  const der = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
+  return der.subarray(der.length - 32).toString('base64');
+}
+
+function signManifestBytes(
+  manifest: Buffer,
+  privateKey: import('node:crypto').KeyObject,
+): Buffer {
+  return Buffer.from(sign(null, manifest, privateKey).toString('base64'));
+}
+
+describe('trust-chain E2E: official key → self-hoster release key → deployment key (spec 3b/3c)', () => {
+  const originalEnv = process.env;
+  const REPO = 'acme/breeze-selfhost-signing';
+  const CHECKSUM = createHash('sha256').update('trust-chain-fixture-binary').digest('hex');
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.GITHUB_REPO;
+    delete process.env.BINARY_GITHUB_REPOSITORY;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it('layer 1 — the official source key verifies canonical assets and rejects signing inputs', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ed25519'); // official key
+    const officialManifest = Buffer.from(
+      JSON.stringify({
+        schemaVersion: 1,
+        repository: 'LanternOps/breeze',
+        release: 'v9.9.9',
+        assets: [
+          {
+            name: 'breeze-agent-windows-amd64.exe',
+            sha256: CHECKSUM,
+            size: 4096,
+            platformTrust: 'windows-authenticode-required',
+          },
+          {
+            name: 'breeze-agent-windows-amd64-unsigned.exe',
+            sha256: CHECKSUM,
+            size: 4096,
+            platformTrust: 'none',
+            intendedUse: 'signing-input',
+          },
+        ],
+      }),
+    );
+    const signature = signManifestBytes(officialManifest, privateKey);
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = rawPub(publicKey);
+
+    // The template workflow's verification of official inputs is out of repo;
+    // in-repo, layer 1 means: the official key gates canonical assets, and the
+    // API can NEVER register/serve a signing input even from a valid manifest.
+    await expect(
+      verifyReleaseArtifactManifestAsset({
+        assetName: 'breeze-agent-windows-amd64.exe',
+        manifestBytes: officialManifest,
+        signatureBytes: signature,
+      }),
+    ).resolves.toMatchObject({ platformTrust: 'windows-authenticode-required' });
+    await expect(
+      verifyReleaseArtifactManifestAsset({
+        assetName: 'breeze-agent-windows-amd64-unsigned.exe',
+        manifestBytes: officialManifest,
+        signatureBytes: signature,
+      }),
+    ).rejects.toThrow(/not distributable/);
+  });
+
+  it('layers 2+3 — self-hoster release key gates the sync; deployment key output matches the Go-verified fixture bytes', async () => {
+    process.env.BINARY_GITHUB_REPOSITORY = REPO;
+    process.env.BINARY_VERSION = '9.9.9';
+
+    const officialKey = generateKeyPairSync('ed25519'); // distinct key #1
+    const selfHosterKey = generateKeyPairSync('ed25519'); // distinct key #2
+    // distinct key #3 is the fixture deployment seed inside the signManifest mock.
+
+    const releaseManifest = Buffer.from(
+      JSON.stringify({
+        schemaVersion: 1,
+        repository: REPO,
+        release: 'v9.9.9',
+        assets: [
+          {
+            name: 'breeze-agent-linux-amd64',
+            sha256: CHECKSUM,
+            size: 4096,
+            platformTrust: 'release-workflow-produced',
+          },
+        ],
+      }),
+    );
+    const selfHosterSig = signManifestBytes(releaseManifest, selfHosterKey.privateKey);
+    const officialSig = signManifestBytes(releaseManifest, officialKey.privateKey);
+
+    const stub = (signatureBody: Buffer) =>
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (url: string) => {
+          if (url.includes('/releases/tags/v9.9.9') || url.includes('/releases/latest')) {
+            return new Response(
+              JSON.stringify({
+                tag_name: 'v9.9.9',
+                body: null,
+                assets: [
+                  {
+                    name: 'breeze-agent-linux-amd64',
+                    browser_download_url: `https://github.com/${REPO}/releases/download/v9.9.9/breeze-agent-linux-amd64`,
+                    size: 4096,
+                  },
+                  {
+                    name: 'release-artifact-manifest.json',
+                    browser_download_url: `https://github.com/${REPO}/releases/download/v9.9.9/release-artifact-manifest.json`,
+                    size: releaseManifest.length,
+                  },
+                  {
+                    name: 'release-artifact-manifest.json.ed25519',
+                    browser_download_url: `https://github.com/${REPO}/releases/download/v9.9.9/release-artifact-manifest.json.ed25519`,
+                    size: signatureBody.length,
+                  },
+                ],
+              }),
+            );
+          }
+          if (url.endsWith('/release-artifact-manifest.json')) return new Response(releaseManifest);
+          if (url.endsWith('/release-artifact-manifest.json.ed25519')) return new Response(signatureBody);
+          return new Response('not found', { status: 404 });
+        }),
+      );
+
+    // Source isolation: with only the SELF-HOSTER key configured, a manifest
+    // signed by the (still distinct) official key must be rejected.
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = rawPub(selfHosterKey.publicKey);
+    stub(officialSig);
+    await expect(syncFromGitHub('v9.9.9')).rejects.toThrow(/signature verification failed/);
+    expect(dbMocks.insertValues).not.toHaveBeenCalled();
+
+    // Happy path: self-hoster-signed manifest registers, and the stored row is
+    // byte-identical to the committed Go fixture — same manifest string, same
+    // deterministic Ed25519 signature, same deploy-* key ID.
+    stub(selfHosterSig);
+    const result = await syncFromGitHub('v9.9.9');
+    expect(result.synced).toContain('agent:linux/amd64');
+
+    const fixtureEntry = fixture.entries.find(
+      (e) => e.platform === 'linux' && e.arch === 'amd64',
+    )!;
+    const insert = dbMocks.insertValues.mock.calls[0]![0] as Record<string, unknown>;
+    expect(insert.signingKeyId).toBe(fixture.keyId);
+    expect(insert.releaseManifest).toBe(fixtureEntry.manifest);
+    expect(insert.manifestSignature).toBe(fixtureEntry.signatureB64);
+  });
+});
+```
+
+- [ ] Run `pnpm --filter @breeze/api test -- src/services/releaseTrustChain.e2e.test.ts` — if the byte-equality assertion fails, the generator and `applyDeploymentSigning` disagree on the normalized shape; fix the generator (or Task 5 code) so all three of {API output, fixture, Go verification} agree, then re-run `node scripts/generate-deployment-manifest-fixture.mjs` and the Go test.
+- [ ] Run the full local gate: `pnpm --filter @breeze/api test` and `cd agent && go test -race ./internal/updater/...` — all green.
+- [ ] Commit: `test(api,agent): three-key trust-chain E2E with a shared deployment-signed manifest fixture (spec testing)`
+
+---
+
+## Final verification (whole plan)
+
+- [ ] `pnpm --filter @breeze/api test` — full API unit suite green (remember: this does NOT run the RLS/integration configs; none of this plan touches tenancy/cascade surfaces, and no new tables/columns were added, so no cascade/export-policy registration applies).
+- [ ] `cd agent && go test -race ./internal/updater/...` — green.
+- [ ] `grep -rn "MSI_SIGNING\|MsiSigningService" apps/api docker-compose.yml deploy .env.example` — empty.
+- [ ] `grep -rn "GITHUB_REPO " apps/api/src --include="*.ts" | grep -v releaseSource` — only the deprecated-alias read in `releaseSource.ts` remains.
+- [ ] Confirm official-path byte-identity one more time: the Task 5 regression test (`official-repo path is untouched`) and the pre-existing `binarySync.test.ts:156` test both assert `signingKeyId: "release-artifact-manifest-ed25519"` with the raw manifest.
+- [ ] PR description records the explicit handoffs: apps/docs + `docs/signing/*` MSI mentions (Phase 3, Deliverable 4), smoke-workflow override variant (needs the Phase 3 fixture repo), template repo (Deliverable 2), release.yml `sourceCommit`/`intendedUse` emission (Deliverable 1 — until it ships, no official manifest contains `intendedUse`, which this plan tolerates: `intendedUse` absent ⇒ `null` ⇒ distributable).

--- a/docs/superpowers/plans/2026-08-09-byo-signing-3-template-and-guide.md
+++ b/docs/superpowers/plans/2026-08-09-byo-signing-3-template-and-guide.md
@@ -1,0 +1,2266 @@
+# BYO Signing Phase 3: Template Repo + Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Deliverable 2 (the public `breeze-selfhost-signing` template repository) and Deliverable 4 (the "Sign Your Own Agent Packages" docs guide plus related doc fixes) of the approved spec `docs/superpowers/specs/2026-08-09-selfhost-byo-signing-design.md`. Self-hosters click "Use this template", add their Azure/Apple/manifest secrets, dispatch one workflow, and get a complete signed release (Windows MSI + exes, macOS pkgs + Installer.app, mirrored Linux/viewer/helper assets, their own Ed25519-signed manifest) that a repointed Breeze instance consumes via `BINARY_SOURCE=github` + `BINARY_GITHUB_REPOSITORY`.
+
+**Architecture:** The template's full contents are authored under a new top-level monorepo directory `selfhost-signing-template/` so they are reviewable and lintable in-repo (GitHub never executes workflows outside the root `.github/`, so the nested workflow files are inert here). The workflow is a **distilled copy** of the `release.yml` signing jobs (maintenance stance per spec §Deliverable 2): a shared verify preamble (local composite action + Node Ed25519 verifier) authenticates the official release manifest against a **committed** official public key and binds the tag to the manifest's `sourceCommit` **before any secret-consuming step**, then three jobs (`windows`, `macos`, `publish`) sign the official unsigned inputs with the self-hoster's credentials, mirror the never-signed canonical assets, and publish a release + self-signed manifest on the self-hoster's repo. A final, user-confirmed task pushes the directory contents as the root of the standalone public repo `lanternops/breeze-selfhost-signing` and marks it a template.
+
+**Tech Stack:** GitHub Actions YAML, PowerShell, bash, Astro/Starlight mdx docs
+
+## Global Constraints
+
+- Workflow inputs: `version` (required, strictly validated `X.Y.Z[-suffix]`, regex `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$`, no leading `v`); `signing-mode`: `azure-artifact-signing` (default) | `pfx`; `platforms`: `all` (default) | `windows` | `macos`; `dry-run` (boolean, default false).
+- The official manifest key ships **committed** as `official-release-key.pub` (PEM, SPKI body `MCowBQYDK2VwAyEAyzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=`, raw form `yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=`) — never a workflow input; rotations arrive as template updates.
+- Every platform job verifies the official manifest signature AND resolves the tag to the manifest's `sourceCommit` SHA **before** any step that carries a secret in its `env`/`with`; secrets appear only on individual post-verify steps, never at job/workflow `env` level.
+- All third-party actions pinned to full commit SHAs copied verbatim from `release.yml` (checkout `3d3c42e5aac5ba805825da76410c181273ba90b1`, setup-dotnet `a98b56852c35b8e3190ac28c8c2271da59106c68`, setup-go `b7ad1dad31e06c5925ef5d2fc7ad053ef454303e`, azure/login `532459ea530d8321f2fb9bb10d1e0bcf23869a43`, azure/artifact-signing-action `c7ab2a863ab5f9a846ddb8265964877ef296ee82`, upload-artifact `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`, download-artifact `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c`, softprops/action-gh-release `3d0d9888cb7fd7b750713d6e236d1fcb99157228`).
+- WiX is version-pinned (`dotnet tool install --global wix --version 7.0.1` + `wix eula accept wix7`); implementation must confirm the exact 7.x version against the most recent green official release run log and adjust the pin before merging.
+- PFX mode is labeled **legacy/internal-PKI only** everywhere it appears (CA/B Forum requires HSM-resident keys for publicly trusted certs since June 2023).
+- Azure mode uses OIDC federated credentials only (`azure/login` with `client-id`+`tenant-id`, `allow-no-subscriptions: true`); single cert profile secret `AZURE_CERT_PROFILE` (no prod/prerelease split).
+- Only `RELEASE_MANIFEST_ED25519_PRIVATE_KEY` is stored as a secret; the public key is derived from it at publish time and the full compose `environment:` block is printed in the workflow run summary.
+- The publish job refuses to overwrite an existing `v${version}` release on the self-hoster's repo (checked in `validate` and again immediately before `gh release create`).
+- Mirror list covers every asset the API URL helpers reference that the platform jobs don't produce: `breeze-{agent,backup,watchdog}-linux-{amd64,arm64}`, `breeze-viewer-{windows.msi,macos.dmg,linux.AppImage}`, `latest.json`, `breeze-helper-{windows.msi,macos.dmg,linux.AppImage}` (per `binarySync.ts` `AGENT_TARGETS`/`HELPER_TARGETS`/`WATCHDOG_TARGETS` and `binarySource.ts` `VIEWER_FILENAMES`/`HELPER_FILENAMES`; no install scripts exist as release assets — `install.sh` is served by the API itself).
+- Notarization auth is Apple ID + app-specific password + team ID only (matches `scripts/release/notarize-submit.sh`; **no** ASC API key in v1).
+- Manifest format matches the official generator (`schemaVersion: 1`, `repository`, `release`, sorted `assets[]` with `name`/`sha256`/`size`/`platformTrust`, `json.dumps(indent=2, sort_keys=True)`) plus Phase 1's `sourceCommit`; `platformTrust` vocabulary is exactly `windows-authenticode-required` | `macos-developer-id-notarization-required` | `release-workflow-produced`; any `-unsigned` filename in `release-assets/` aborts publish.
+- Unsigned inputs are only accepted when their manifest entry carries `intendedUse: "signing-input"`; mirrored assets are rejected if they carry it.
+- The docs guide's only sanctioned uncertainty marker is `{/* verify-against-portal */}` (the MDX comment form — literal HTML `<!-- -->` comments are a build error in MDX v3, so the sanctioned marker is expressed as an MDX comment) and it appears only in the Azure portal walkthrough (Part 1) and Apple enrollment (Part 2).
+- Docs validation: `pnpm --filter @breeze/docs build` (package name confirmed in `apps/docs/package.json`); template validation: `actionlint` + `bash -n` + `node --check` + the verifier self-test.
+- This plan modifies nothing outside `selfhost-signing-template/`, `apps/docs/`, `docs/signing/`, and the final gated publish task; Deliverables 1 (unsigned assets + `sourceCommit`/`intendedUse`) and 3 (API re-signing + `BINARY_GITHUB_REPOSITORY` unification) are separate phases that ship first — the template's live dry-run can only pass against a release that contains the Phase 1 unsigned set.
+- Commit at each working state; every commit message ends with the trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Do **not** run the final publish task (Task 9) without explicit user confirmation in-session — it is an outward-facing action creating a public repo.
+
+---
+
+### Task 1: Template repo skeleton — README, official key, keygen script
+
+**Files:**
+- `selfhost-signing-template/README.md` (new)
+- `selfhost-signing-template/official-release-key.pub` (new)
+- `selfhost-signing-template/scripts/generate-manifest-key.sh` (new)
+- `selfhost-signing-template/.gitignore` (new)
+
+**Interfaces:**
+- `official-release-key.pub`: PEM SPKI Ed25519 public key; consumed by `scripts/verify-manifest.mjs` (Task 2) via `--key`.
+- `generate-manifest-key.sh`: no args; prints the private-key PEM (for the `RELEASE_MANIFEST_ED25519_PRIVATE_KEY` secret), the raw-base64 public key, and the compose mapping block; writes nothing outside a self-deleting temp dir.
+
+**Steps:**
+
+- [ ] Create `selfhost-signing-template/official-release-key.pub` with exactly the content of `internal/release-keys/release-manifest.ed25519.pub` (readable in this workspace; if a fresh clone lacks the gitignored `internal/` dir, use the known value — it is the public trust anchor also published at `.env.example:354`):
+
+```
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAyzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
+-----END PUBLIC KEY-----
+```
+
+- [ ] Sanity-check the committed key derives the documented raw form: `openssl pkey -pubin -in selfhost-signing-template/official-release-key.pub -outform DER | tail -c 32 | base64` must print `yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=` (procedure mirrors `internal/release-keys/README.md`).
+
+- [ ] Create `selfhost-signing-template/.gitignore`:
+
+```
+*.key
+*.pfx
+*.p12
+release-assets/
+dist/
+staging/
+out/
+node_modules/
+```
+
+- [ ] Create `selfhost-signing-template/scripts/generate-manifest-key.sh` (mode 755):
+
+```bash
+#!/usr/bin/env bash
+# generate-manifest-key.sh — one-shot Ed25519 release-manifest keypair for
+# breeze-selfhost-signing. Mirrors the official keygen procedure
+# (openssl genpkey ed25519 -> SPKI DER -> raw 32-byte suffix, base64).
+#
+# Only the PRIVATE key is ever stored (as the GitHub Actions secret
+# RELEASE_MANIFEST_ED25519_PRIVATE_KEY). The workflow derives the public key
+# from it on every run and prints your instance env block in the run summary,
+# so nothing here needs committing. Run locally; nothing is uploaded.
+set -euo pipefail
+
+command -v openssl >/dev/null 2>&1 || { echo "openssl is required" >&2; exit 1; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+openssl genpkey -algorithm ed25519 -out "$tmp/release-manifest.key" 2>/dev/null
+raw_b64="$(openssl pkey -in "$tmp/release-manifest.key" -pubout -outform DER | tail -c 32 | base64)"
+
+cat <<EOF
+
+==========================================================================
+1) GitHub secret — in YOUR copy of this repo:
+   Settings -> Secrets and variables -> Actions -> New repository secret
+   Name : RELEASE_MANIFEST_ED25519_PRIVATE_KEY
+   Value: exactly the PEM below, including the BEGIN/END lines
+==========================================================================
+$(cat "$tmp/release-manifest.key")
+
+==========================================================================
+2) Your Breeze instance .env — add or replace:
+==========================================================================
+RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=${raw_b64}
+
+==========================================================================
+3) Your docker-compose.yml — the api service must MAP the variable
+   (a value in .env alone never reaches the container):
+==========================================================================
+  api:
+    environment:
+      RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: \${RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS}
+
+The private key above exists only in a temp dir that is deleted when this
+script exits — copy it into the GitHub secret NOW. Never commit it. If you
+lose it, rerun this script and update both the secret and your .env
+(during rotation you can trust both keys at once:
+RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=oldkey,newkey).
+EOF
+```
+
+- [ ] Create `selfhost-signing-template/README.md`:
+
+````markdown
+# breeze-selfhost-signing
+
+Sign official [Breeze RMM](https://github.com/lanternops/breeze) agent
+releases with **your own** code-signing certificates — no fork, no Windows or
+Mac hardware, no per-download signing. One workflow run per Breeze release
+produces a complete signed release on this repository that your self-hosted
+Breeze instance consumes directly.
+
+Full walkthrough (Azure Artifact Signing from zero, Apple Developer ID
+enrollment, pointing your instance at your builds): **Sign Your Own Agent
+Packages** in the Breeze docs (`/deploy/sign-your-own-packages/`).
+
+## How it works
+
+1. The workflow downloads the official release's signed
+   `release-artifact-manifest.json` and verifies it against the official
+   Ed25519 key **committed in this repo** (`official-release-key.pub`) —
+   before it touches any of your secrets.
+2. It resolves the release tag and requires it to match the manifest's
+   `sourceCommit` (a moved tag aborts the run), then checks out the Breeze
+   build scripts at that exact commit.
+3. It downloads the official **unsigned** build outputs
+   (`*-unsigned.exe`, `breeze-*-darwin-*-unsigned`), verifies each SHA-256
+   against the manifest, signs them with your certificates, builds the MSI /
+   pkgs / `Breeze Installer.app`, and verifies every signature.
+4. It mirrors the never-signed official assets (Linux binaries,
+   viewer/helper installers) after verifying them, generates **your** release
+   manifest, signs it with **your** Ed25519 manifest key, and publishes
+   release `v<version>` on this repository.
+
+Your agents never trust this repo's key directly — your Breeze API re-signs
+update manifests with its per-deployment key (standard since the BYO-signing
+release), so fleet trust is unchanged.
+
+## Quickstart
+
+1. Click **Use this template** (a private copy is fine — the workflow only
+   reads public official releases).
+2. Run `./scripts/generate-manifest-key.sh` locally and follow its output:
+   store the private key as the `RELEASE_MANIFEST_ED25519_PRIVATE_KEY`
+   secret; keep the printed env block for step 6.
+3. Add the platform secrets for your signing mode (tables below).
+4. **Recommended:** create a GitHub Environment named `signing`
+   (Settings → Environments), move the secrets there, and add yourself as a
+   required reviewer — every signing run then needs an explicit approval.
+   The workflow's signing jobs reference the `signing` environment.
+5. Actions → **Sign Breeze Release** → Run workflow. Do a `dry-run: true`
+   pass first (no secrets needed) to validate the plumbing, then a real run.
+6. Point your instance at your builds (the run summary prints this block
+   with your real key):
+
+   ```bash
+   BINARY_SOURCE=github
+   BINARY_GITHUB_REPOSITORY=<your-org>/<this-repo>
+   BINARY_VERSION=<version>
+   RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=<your raw base64 public key>
+   AGENT_AUTO_PROMOTE=false   # recommended for first adoption; promote explicitly
+   ```
+
+## Workflow inputs
+
+| Input | Values | Notes |
+|---|---|---|
+| `version` | `X.Y.Z` or `X.Y.Z-suffix` (no leading `v`) | Must be an official Breeze release that publishes unsigned signing inputs. The run refuses to overwrite an existing `v<version>` release here. |
+| `signing-mode` | `azure-artifact-signing` (default), `pfx` | PFX is **legacy / internal-PKI only** — publicly trusted code-signing keys must live in HSMs (CA/B Forum, June 2023), so exportable PFX files are generally unavailable for new OV certs. |
+| `platforms` | `all` (default), `windows`, `macos` | Skip a platform **only if your fleet has no such devices** — a skipped platform's assets are absent from your release and those downloads will 404. |
+| `dry-run` | `false` (default), `true` | Download + verify + build with signing stubbed; no secrets or certs needed. Publishes nothing — assets land as a workflow artifact. |
+
+## Secrets
+
+### Manifest signing (always required for real runs)
+
+| Secret | Value |
+|---|---|
+| `RELEASE_MANIFEST_ED25519_PRIVATE_KEY` | PEM output of `scripts/generate-manifest-key.sh`. The public key is derived from it at run time — nothing else to store. |
+
+### Windows — `azure-artifact-signing` mode (default)
+
+Uses OIDC federated credentials (no client secret stored). The guide's Part 1
+walks through creating each of these.
+
+| Secret | Value |
+|---|---|
+| `AZURE_CLIENT_ID` | App registration (client) ID with a GitHub OIDC federated credential for this repo |
+| `AZURE_TENANT_ID` | Entra tenant ID |
+| `AZURE_SIGNING_ENDPOINT` | Artifact Signing account endpoint, e.g. `https://eus.codesigning.azure.net` |
+| `AZURE_SIGNING_ACCOUNT_NAME` | Artifact Signing account name |
+| `AZURE_CERT_PROFILE` | Certificate profile name (one profile — this repo does not split prod/prerelease) |
+
+### Windows — `pfx` mode (legacy / internal PKI only)
+
+| Secret | Value |
+|---|---|
+| `WINDOWS_PFX_BASE64` | `base64 -w0 your-cert.pfx` (macOS: `base64 -i your-cert.pfx`) |
+| `WINDOWS_PFX_PASSWORD` | PFX password |
+
+Optional repository **variable** `PFX_TIMESTAMP_URL` overrides the RFC 3161
+timestamp server (default `http://timestamp.digicert.com`).
+
+### macOS
+
+| Secret | Value |
+|---|---|
+| `APPLE_CERTIFICATE` | base64 of a `.p12` export containing BOTH your **Developer ID Application** and **Developer ID Installer** certificates + keys |
+| `APPLE_CERTIFICATE_PASSWORD` | `.p12` export password |
+| `APPLE_SIGNING_IDENTITY` | e.g. `Developer ID Application: Your Org (TEAMID)` |
+| `APPLE_INSTALLER_IDENTITY` | e.g. `Developer ID Installer: Your Org (TEAMID)` |
+| `APPLE_ID` | Apple ID email used for notarization |
+| `APPLE_PASSWORD` | App-specific password for that Apple ID (not your account password; ASC API keys are not supported) |
+| `APPLE_TEAM_ID` | 10-character team ID |
+
+## What a run publishes
+
+Signed by you: `breeze-agent.msi`, `breeze-agent-windows-amd64.exe`,
+`breeze-backup-windows-amd64.exe`, `breeze-watchdog-windows-amd64.exe`,
+`breeze-user-helper-windows-amd64.exe`,
+`breeze-{agent,backup,desktop-helper,watchdog}-darwin-{amd64,arm64}`,
+`breeze-agent-darwin-{amd64,arm64}.pkg`, `Breeze Installer.app.zip`.
+
+Mirrored from the official release (verified, never signed by anyone):
+`breeze-{agent,backup,watchdog}-linux-{amd64,arm64}`,
+`breeze-viewer-{windows.msi,macos.dmg,linux.AppImage}`, `latest.json`,
+`breeze-helper-{windows.msi,macos.dmg,linux.AppImage}`.
+
+Generated: `release-artifact-manifest.json` + `.ed25519` (signed with your
+manifest key), `checksums.txt`.
+
+## Expectations
+
+- **SmartScreen reputation ramps over time.** A correct signature does not
+  mean an instant clean install experience — reputation accrues per
+  certificate and per file hash. Signing once per release (what this repo
+  does) is what lets it accrue at all.
+- **Publisher name**: your organization appears as the publisher on
+  Breeze-branded binaries. That is expected; a full rebrand is the fork path
+  (`docs/signing/ARTIFACT_SIGNING_OPERATIONS.md`, Model B).
+- **Key rotation**: when LanternOps rotates the official manifest key,
+  `official-release-key.pub` changes here — pull template updates before
+  signing a release made with the new key.
+````
+
+- [ ] `bash -n selfhost-signing-template/scripts/generate-manifest-key.sh` passes; `chmod +x` applied.
+- [ ] Commit: `feat(selfhost-signing): template skeleton — README, official key, manifest keygen`.
+
+---
+
+### Task 2: Shared verify preamble — composite action + Node verifier + asset downloader
+
+**Files:**
+- `selfhost-signing-template/.github/actions/verify-official-release/action.yml` (new)
+- `selfhost-signing-template/scripts/verify-manifest.mjs` (new)
+- `selfhost-signing-template/scripts/download-verified-asset.sh` (new)
+- `selfhost-signing-template/scripts/verify-manifest.test.mjs` (new)
+
+**Interfaces:**
+- Composite action `verify-official-release`: input `version`; outputs `source-commit` (verified 40-hex SHA) and `manifest-path` (verified manifest JSON on disk). MUST be the first functional step of every job; carries no secrets (only `github.token` for the tag-resolution API read).
+- `verify-manifest.mjs verify --manifest M --signature S --key K --repository R --release T` → prints `sourceCommit` on stdout, exits non-zero on any failure.
+- `verify-manifest.mjs check-asset --manifest M --name N --file F [--expect-signing-input|--forbid-signing-input]` → verifies sha256 + size (+ `intendedUse` policy), exits non-zero on mismatch.
+- `download-verified-asset.sh <version> <asset-name> <dest-path> [--expect-signing-input|--forbid-signing-input]` → curl + check-asset; requires env `OFFICIAL_MANIFEST_PATH`.
+
+**Steps:**
+
+- [ ] Create `selfhost-signing-template/scripts/verify-manifest.mjs`:
+
+```js
+#!/usr/bin/env node
+// verify-manifest.mjs — verify the official Breeze release-artifact-manifest
+// (raw Ed25519, base64 signature) and check downloaded assets against it.
+// Pure node:crypto so it runs identically on ubuntu/windows/macos runners and
+// matches the verifier the Breeze API itself uses.
+import { createHash, createPublicKey, verify as edVerify } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+const SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+
+function loadPublicKey(path) {
+  const text = readFileSync(path, 'utf8').trim();
+  if (text.includes('BEGIN PUBLIC KEY')) return createPublicKey(text);
+  const decoded = Buffer.from(text, 'base64');
+  if (decoded.length === 32) {
+    return createPublicKey({
+      key: Buffer.concat([SPKI_PREFIX, decoded]),
+      format: 'der',
+      type: 'spki',
+    });
+  }
+  return createPublicKey({ key: decoded, format: 'der', type: 'spki' });
+}
+
+function arg(name) {
+  const i = process.argv.indexOf(name);
+  return i === -1 ? null : process.argv[i + 1];
+}
+function has(name) {
+  return process.argv.includes(name);
+}
+function die(msg) {
+  console.error(`::error::${msg}`);
+  process.exit(1);
+}
+
+const cmd = process.argv[2];
+
+if (cmd === 'verify') {
+  const manifestPath = arg('--manifest');
+  const sigPath = arg('--signature');
+  const keyPath = arg('--key');
+  const repository = arg('--repository');
+  const release = arg('--release');
+  if (!manifestPath || !sigPath || !keyPath || !repository || !release) {
+    die('verify: --manifest, --signature, --key, --repository, --release are all required');
+  }
+  const manifestBytes = readFileSync(manifestPath);
+  const signature = Buffer.from(readFileSync(sigPath, 'utf8').trim(), 'base64');
+  const key = loadPublicKey(keyPath);
+  if (!edVerify(null, manifestBytes, key, signature)) {
+    die('release manifest Ed25519 signature verification FAILED — refusing to continue');
+  }
+  const manifest = JSON.parse(manifestBytes.toString('utf8'));
+  if (manifest.repository !== repository) {
+    die(`manifest repository mismatch: expected ${repository}, got ${manifest.repository}`);
+  }
+  if (manifest.release !== release) {
+    die(`manifest release mismatch: expected ${release}, got ${manifest.release}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(manifest.sourceCommit ?? '')) {
+    die('manifest has no valid sourceCommit — this Breeze release predates BYO-signing support (need a release with the unsigned asset set)');
+  }
+  process.stdout.write(`${manifest.sourceCommit}\n`);
+} else if (cmd === 'check-asset') {
+  const manifestPath = arg('--manifest');
+  const name = arg('--name');
+  const file = arg('--file');
+  if (!manifestPath || !name || !file) {
+    die('check-asset: --manifest, --name, --file are all required');
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const entry = (manifest.assets ?? []).find((a) => a.name === name);
+  if (!entry) die(`asset ${name} is not present in the signed manifest`);
+  const bytes = readFileSync(file);
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  if (sha256 !== entry.sha256) {
+    die(`sha256 mismatch for ${name}: manifest=${entry.sha256} actual=${sha256}`);
+  }
+  if (bytes.length !== entry.size) {
+    die(`size mismatch for ${name}: manifest=${entry.size} actual=${bytes.length}`);
+  }
+  if (has('--expect-signing-input') && entry.intendedUse !== 'signing-input') {
+    die(`${name} is not marked intendedUse=signing-input — refusing to treat a distributable asset as a signing input`);
+  }
+  if (has('--forbid-signing-input') && entry.intendedUse === 'signing-input') {
+    die(`${name} is a signing input, not a distributable asset — refusing to mirror it`);
+  }
+  console.log(`ok ${name} sha256=${sha256} size=${bytes.length}`);
+} else {
+  die(`unknown command: ${cmd} (expected 'verify' or 'check-asset')`);
+}
+```
+
+- [ ] Create `selfhost-signing-template/scripts/download-verified-asset.sh` (mode 755):
+
+```bash
+#!/usr/bin/env bash
+# download-verified-asset.sh <version> <asset-name> <dest-path> [policy-flag]
+# Downloads one official release asset and verifies sha256+size (and the
+# intendedUse policy) against the already-verified official manifest.
+# Requires: OFFICIAL_MANIFEST_PATH env (set from the verify-official-release
+# action's manifest-path output). policy-flag defaults to
+# --forbid-signing-input; pass --expect-signing-input for unsigned inputs.
+set -euo pipefail
+
+VERSION="$1"
+ASSET="$2"
+DEST="$3"
+POLICY="${4:---forbid-signing-input}"
+MANIFEST="${OFFICIAL_MANIFEST_PATH:?OFFICIAL_MANIFEST_PATH not set — run verify-official-release first}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+url="https://github.com/lanternops/breeze/releases/download/v${VERSION}/${ASSET}"
+mkdir -p "$(dirname "$DEST")"
+curl -fsSL --retry 3 --retry-delay 5 -o "$DEST" "$url"
+node "$SCRIPT_DIR/verify-manifest.mjs" check-asset \
+  --manifest "$MANIFEST" --name "$ASSET" --file "$DEST" "$POLICY"
+```
+
+- [ ] Create `selfhost-signing-template/.github/actions/verify-official-release/action.yml`:
+
+```yaml
+name: Verify official Breeze release
+description: >-
+  Download the official release-artifact-manifest for the requested version,
+  verify its Ed25519 signature against the COMMITTED official key, and bind
+  the release tag to the manifest's sourceCommit. This action must run before
+  any step that exposes a signing credential; it carries no secrets itself.
+inputs:
+  version:
+    description: Official Breeze release version, without the leading v
+    required: true
+outputs:
+  source-commit:
+    description: Verified 40-char commit SHA the official release was built from
+    value: ${{ steps.verify.outputs.source-commit }}
+  manifest-path:
+    description: Path to the verified official manifest JSON
+    value: ${{ steps.verify.outputs.manifest-path }}
+runs:
+  using: composite
+  steps:
+    - id: verify
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        base="https://github.com/lanternops/breeze/releases/download/v${VERSION}"
+        dir="${RUNNER_TEMP}/official-manifest"
+        mkdir -p "$dir"
+        curl -fsSL --retry 3 --retry-delay 5 \
+          -o "$dir/release-artifact-manifest.json" \
+          "$base/release-artifact-manifest.json"
+        curl -fsSL --retry 3 --retry-delay 5 \
+          -o "$dir/release-artifact-manifest.json.ed25519" \
+          "$base/release-artifact-manifest.json.ed25519"
+
+        source_commit="$(node "${GITHUB_WORKSPACE}/scripts/verify-manifest.mjs" verify \
+          --manifest "$dir/release-artifact-manifest.json" \
+          --signature "$dir/release-artifact-manifest.json.ed25519" \
+          --key "${GITHUB_WORKSPACE}/official-release-key.pub" \
+          --repository "lanternops/breeze" \
+          --release "v${VERSION}")"
+
+        # Tags are movable; the signed manifest is not. Bind them.
+        tag_commit="$(gh api "repos/lanternops/breeze/commits/v${VERSION}" --jq .sha)"
+        if [ "$tag_commit" != "$source_commit" ]; then
+          echo "::error::tag v${VERSION} resolves to ${tag_commit} but the signed manifest records sourceCommit ${source_commit} — the tag has moved; refusing to continue"
+          exit 1
+        fi
+
+        echo "source-commit=${source_commit}" >> "$GITHUB_OUTPUT"
+        echo "manifest-path=${dir}/release-artifact-manifest.json" >> "$GITHUB_OUTPUT"
+        echo "Verified official manifest for v${VERSION}; sourceCommit=${source_commit}"
+```
+
+- [ ] Create `selfhost-signing-template/scripts/verify-manifest.test.mjs` — self-contained test that generates an ephemeral Ed25519 keypair, writes a fixture manifest + signature + asset file to a temp dir, and asserts: (1) `verify` succeeds and prints the sourceCommit; (2) `verify` fails on a tampered manifest byte; (3) `verify` fails when `sourceCommit` is missing; (4) `check-asset` passes on the correct file, fails on wrong hash; (5) `--expect-signing-input` / `--forbid-signing-input` enforce `intendedUse`:
+
+```js
+#!/usr/bin/env node
+// verify-manifest.test.mjs — self-test for verify-manifest.mjs. Run: node scripts/verify-manifest.test.mjs
+import { generateKeyPairSync, sign, createHash } from 'node:crypto';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const script = join(dirname(fileURLToPath(import.meta.url)), 'verify-manifest.mjs');
+const dir = mkdtempSync(join(tmpdir(), 'verify-manifest-test-'));
+let failures = 0;
+
+function run(args) {
+  return spawnSync(process.execPath, [script, ...args], { encoding: 'utf8' });
+}
+function expect(label, cond) {
+  if (cond) console.log(`PASS ${label}`);
+  else { console.error(`FAIL ${label}`); failures += 1; }
+}
+
+const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+const rawPub = publicKey.export({ format: 'der', type: 'spki' }).subarray(-32).toString('base64');
+const keyPath = join(dir, 'key.pub');
+writeFileSync(keyPath, `${rawPub}\n`);
+
+const asset = Buffer.from('unsigned-binary-bytes');
+const assetPath = join(dir, 'breeze-agent-windows-amd64-unsigned.exe');
+writeFileSync(assetPath, asset);
+
+const manifest = {
+  schemaVersion: 1,
+  repository: 'lanternops/breeze',
+  release: 'v9.9.9',
+  sourceCommit: 'a'.repeat(40),
+  assets: [
+    {
+      name: 'breeze-agent-windows-amd64-unsigned.exe',
+      sha256: createHash('sha256').update(asset).digest('hex'),
+      size: asset.length,
+      platformTrust: 'none',
+      intendedUse: 'signing-input',
+    },
+    {
+      name: 'breeze-agent-linux-amd64',
+      sha256: createHash('sha256').update(asset).digest('hex'),
+      size: asset.length,
+      platformTrust: 'release-workflow-produced',
+    },
+  ],
+};
+const manifestPath = join(dir, 'manifest.json');
+const manifestBytes = Buffer.from(JSON.stringify(manifest, null, 2));
+writeFileSync(manifestPath, manifestBytes);
+const sigPath = join(dir, 'manifest.json.ed25519');
+writeFileSync(sigPath, sign(null, manifestBytes, privateKey).toString('base64') + '\n');
+
+const okVerify = run(['verify', '--manifest', manifestPath, '--signature', sigPath,
+  '--key', keyPath, '--repository', 'lanternops/breeze', '--release', 'v9.9.9']);
+expect('verify: valid manifest', okVerify.status === 0 && okVerify.stdout.trim() === 'a'.repeat(40));
+
+const tamperedPath = join(dir, 'tampered.json');
+writeFileSync(tamperedPath, Buffer.concat([manifestBytes, Buffer.from(' ')]));
+const badVerify = run(['verify', '--manifest', tamperedPath, '--signature', sigPath,
+  '--key', keyPath, '--repository', 'lanternops/breeze', '--release', 'v9.9.9']);
+expect('verify: tampered manifest rejected', badVerify.status !== 0);
+
+const noCommit = { ...manifest };
+delete noCommit.sourceCommit;
+const noCommitBytes = Buffer.from(JSON.stringify(noCommit, null, 2));
+const noCommitPath = join(dir, 'nocommit.json');
+writeFileSync(noCommitPath, noCommitBytes);
+writeFileSync(`${noCommitPath}.ed25519`, sign(null, noCommitBytes, privateKey).toString('base64'));
+const noCommitVerify = run(['verify', '--manifest', noCommitPath, '--signature', `${noCommitPath}.ed25519`,
+  '--key', keyPath, '--repository', 'lanternops/breeze', '--release', 'v9.9.9']);
+expect('verify: missing sourceCommit rejected', noCommitVerify.status !== 0);
+
+const okAsset = run(['check-asset', '--manifest', manifestPath,
+  '--name', 'breeze-agent-windows-amd64-unsigned.exe', '--file', assetPath, '--expect-signing-input']);
+expect('check-asset: valid signing input', okAsset.status === 0);
+
+const wrongFile = join(dir, 'wrong.bin');
+writeFileSync(wrongFile, 'different-bytes');
+const badAsset = run(['check-asset', '--manifest', manifestPath,
+  '--name', 'breeze-agent-windows-amd64-unsigned.exe', '--file', wrongFile, '--expect-signing-input']);
+expect('check-asset: hash mismatch rejected', badAsset.status !== 0);
+
+const mirrorRejected = run(['check-asset', '--manifest', manifestPath,
+  '--name', 'breeze-agent-windows-amd64-unsigned.exe', '--file', assetPath, '--forbid-signing-input']);
+expect('check-asset: signing input rejected as mirror', mirrorRejected.status !== 0);
+
+const mirrorOk = run(['check-asset', '--manifest', manifestPath,
+  '--name', 'breeze-agent-linux-amd64', '--file', assetPath, '--forbid-signing-input']);
+expect('check-asset: distributable mirror accepted', mirrorOk.status === 0);
+
+rmSync(dir, { recursive: true, force: true });
+if (failures > 0) process.exit(1);
+console.log('all verify-manifest tests passed');
+```
+
+- [ ] Validate: `node --check selfhost-signing-template/scripts/verify-manifest.mjs`, `bash -n selfhost-signing-template/scripts/download-verified-asset.sh`, and `node selfhost-signing-template/scripts/verify-manifest.test.mjs` (all PASS lines, exit 0).
+- [ ] Commit: `feat(selfhost-signing): manifest verify preamble (composite action + node verifier + tests)`.
+
+---
+
+### Task 3: `sign-release.yml` — workflow header, validate job, windows job
+
+**Files:**
+- `selfhost-signing-template/.github/workflows/sign-release.yml` (new — this task writes the header, `validate`, and `windows` jobs; Tasks 4–5 append `macos` and `publish` to the same file)
+
+**Interfaces:**
+- `validate` job: outputs `version` (echoed input) — fails fast on bad version format or an existing `v<version>` release on the self-hoster's repo (skipped in dry-run).
+- `windows` job: consumes the 4 official unsigned exes, produces artifact `signed-windows` containing `breeze-agent-windows-amd64.exe`, `breeze-backup-windows-amd64.exe`, `breeze-watchdog-windows-amd64.exe`, `breeze-user-helper-windows-amd64.exe`, `breeze-agent.msi` (all signed unless dry-run).
+- `workflow_call` trigger mirrors `workflow_dispatch` inputs so the template's own CI (Task 6) can exercise dry-run.
+
+**Steps:**
+
+- [ ] Create `selfhost-signing-template/.github/workflows/sign-release.yml` with the following content (header + `validate` + `windows`):
+
+```yaml
+name: Sign Breeze Release
+
+# Distilled from the signing jobs of lanternops/breeze .github/workflows/release.yml.
+# Maintenance stance: this is a COPY, not a reusable workflow — your secrets never
+# flow through LanternOps workflow definitions, and refactors of the product repo's
+# release.yml cannot break your runs. Version-sensitive build logic lives in the
+# product repo and is checked out at the manifest-verified sourceCommit.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Breeze release version to sign (X.Y.Z or X.Y.Z-suffix, no leading v)'
+        required: true
+        type: string
+      signing-mode:
+        description: 'Windows signing backend (pfx is legacy/internal-PKI only)'
+        required: true
+        default: azure-artifact-signing
+        type: choice
+        options:
+          - azure-artifact-signing
+          - pfx
+      platforms:
+        description: 'Platforms to sign'
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - windows
+          - macos
+      dry-run:
+        description: 'Download + verify + build with signing stubbed (no secrets needed)'
+        required: true
+        default: false
+        type: boolean
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      signing-mode:
+        required: false
+        default: azure-artifact-signing
+        type: string
+      platforms:
+        required: false
+        default: all
+        type: string
+      dry-run:
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write   # publish the signed release on this repository
+  id-token: write   # Azure OIDC federated login (azure-artifact-signing mode)
+
+concurrency:
+  group: sign-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate inputs
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Validate version format
+        id: check
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::version '$VERSION' is not X.Y.Z or X.Y.Z-suffix (no leading v)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse to overwrite an existing release
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::release v${VERSION} already exists on ${GITHUB_REPOSITORY}. Signing must happen once per release so SmartScreen/Gatekeeper reputation accrues on a stable hash — delete the release manually first if you truly need to re-sign."
+            exit 1
+          fi
+          echo "no existing release v${VERSION} — ok to proceed"
+
+  windows:
+    name: Sign Windows artifacts
+    needs: [validate]
+    if: inputs.platforms == 'all' || inputs.platforms == 'windows'
+    runs-on: windows-latest
+    environment: signing
+    steps:
+      - name: Checkout signing repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # ---- Trust boundary: everything below `verify` may assume the official
+      # ---- release is authentic. No secrets appear above or inside it.
+      - name: Verify official release manifest
+        id: verify
+        uses: ./.github/actions/verify-official-release
+        with:
+          version: ${{ needs.validate.outputs.version }}
+
+      - name: Checkout Breeze source at manifest sourceCommit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: lanternops/breeze
+          ref: ${{ steps.verify.outputs.source-commit }}
+          path: breeze
+          persist-credentials: false
+
+      - name: Download and verify unsigned signing inputs
+        shell: bash
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          OFFICIAL_MANIFEST_PATH: ${{ steps.verify.outputs.manifest-path }}
+        run: |
+          set -euo pipefail
+          for pair in \
+            "breeze-agent-windows-amd64-unsigned.exe:breeze-agent-windows-amd64.exe" \
+            "breeze-backup-windows-amd64-unsigned.exe:breeze-backup-windows-amd64.exe" \
+            "breeze-watchdog-windows-amd64-unsigned.exe:breeze-watchdog-windows-amd64.exe" \
+            "breeze-user-helper-windows-amd64-unsigned.exe:breeze-user-helper-windows-amd64.exe"
+          do
+            src="${pair%%:*}"; dst="${pair##*:}"
+            # explicit `bash` prefix: the exec bit is not reliable after a
+            # Windows checkout, and git-bash is the shell here
+            bash scripts/download-verified-asset.sh "$VERSION" "$src" "dist/$dst" --expect-signing-input
+          done
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install WiX CLI (pinned)
+        shell: pwsh
+        run: |
+          # Version-pinned, unlike the product CI which floats — a WiX minor
+          # bump must not change your MSI bytes out from under you.
+          dotnet tool install --global wix --version 7.0.1
+          if ($LASTEXITCODE -ne 0) { throw "wix install failed with exit code $LASTEXITCODE" }
+          "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          wix eula accept wix7
+
+      - name: Validate Azure signing secrets
+        if: inputs.signing-mode == 'azure-artifact-signing' && inputs.dry-run == false
+        shell: pwsh
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          AZURE_CERT_PROFILE: ${{ secrets.AZURE_CERT_PROFILE }}
+        run: |
+          $required = @("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SIGNING_ENDPOINT", "AZURE_SIGNING_ACCOUNT_NAME", "AZURE_CERT_PROFILE")
+          foreach ($name in $required) {
+            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name" -ErrorAction SilentlyContinue).Value)) {
+              throw "Missing required signing secret: $name (see README secrets table)"
+            }
+          }
+
+      - name: Validate PFX signing secrets
+        if: inputs.signing-mode == 'pfx' && inputs.dry-run == false
+        shell: pwsh
+        env:
+          WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}
+          WINDOWS_PFX_PASSWORD: ${{ secrets.WINDOWS_PFX_PASSWORD }}
+        run: |
+          foreach ($name in @("WINDOWS_PFX_BASE64", "WINDOWS_PFX_PASSWORD")) {
+            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name" -ErrorAction SilentlyContinue).Value)) {
+              throw "Missing required signing secret: $name (see README secrets table)"
+            }
+          }
+
+      - name: Azure Login (OIDC)
+        if: inputs.signing-mode == 'azure-artifact-signing' && inputs.dry-run == false
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Sign agent EXE (Azure Artifact Signing)
+        if: inputs.signing-mode == 'azure-artifact-signing' && inputs.dry-run == false
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files: ${{ github.workspace }}\dist\breeze-agent-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign backup EXE (Azure Artifact Signing)
+        if: inputs.signing-mode == 'azure-artifact-signing' && inputs.dry-run == false
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files: ${{ github.workspace }}\dist\breeze-backup-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign watchdog EXE (Azure Artifact Signing)
+        if: inputs.signing-mode == 'azure-artifact-signing' && inputs.dry-run == false
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files: ${{ github.workspace }}\dist\breeze-watchdog-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign user-helper EXE (Azure Artifact Signing)
+        if: inputs.signing-mode == 'azure-artifact-signing' && inputs.dry-run == false
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files: ${{ github.workspace }}\dist\breeze-user-helper-windows-amd64.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign EXEs (PFX — legacy/internal PKI)
+        if: inputs.signing-mode == 'pfx' && inputs.dry-run == false
+        shell: pwsh
+        env:
+          WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}
+          WINDOWS_PFX_PASSWORD: ${{ secrets.WINDOWS_PFX_PASSWORD }}
+          PFX_TIMESTAMP_URL: ${{ vars.PFX_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $pfxPath = Join-Path $env:RUNNER_TEMP "signing.pfx"
+          [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:WINDOWS_PFX_BASE64))
+          $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" |
+            Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $signtool) { throw "signtool.exe not found in Windows SDK" }
+          $targets = @(
+            "dist\breeze-agent-windows-amd64.exe",
+            "dist\breeze-backup-windows-amd64.exe",
+            "dist\breeze-watchdog-windows-amd64.exe",
+            "dist\breeze-user-helper-windows-amd64.exe"
+          )
+          foreach ($f in $targets) {
+            & $signtool sign /fd SHA256 /f $pfxPath /p $env:WINDOWS_PFX_PASSWORD /tr $env:PFX_TIMESTAMP_URL /td SHA256 $f
+            if ($LASTEXITCODE -ne 0) { throw "signtool failed for $f with exit code $LASTEXITCODE" }
+          }
+
+      - name: Build MSI
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $root = $env:GITHUB_WORKSPACE
+          $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
+          $backupExe = Join-Path $root "dist\breeze-backup-windows-amd64.exe"
+          $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
+          $userHelperExe = Join-Path $root "dist\breeze-user-helper-windows-amd64.exe"
+          $msiPath = Join-Path $root "dist\breeze-agent.msi"
+          & (Join-Path $root "breeze\agent\installer\build-msi.ps1") `
+            -Version $env:VERSION `
+            -AgentExePath $agentExe `
+            -BackupExePath $backupExe `
+            -WatchdogExePath $watchdogExe `
+            -UserHelperExePath $userHelperExe `
+            -OutputPath $msiPath
+
+      - name: Sign MSI (Azure Artifact Signing)
+        if: inputs.signing-mode == 'azure-artifact-signing' && inputs.dry-run == false
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE }}
+          files: ${{ github.workspace }}\dist\breeze-agent.msi
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Sign MSI (PFX — legacy/internal PKI)
+        if: inputs.signing-mode == 'pfx' && inputs.dry-run == false
+        shell: pwsh
+        env:
+          WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}
+          WINDOWS_PFX_PASSWORD: ${{ secrets.WINDOWS_PFX_PASSWORD }}
+          PFX_TIMESTAMP_URL: ${{ vars.PFX_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $pfxPath = Join-Path $env:RUNNER_TEMP "signing.pfx"
+          if (-not (Test-Path $pfxPath)) {
+            [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:WINDOWS_PFX_BASE64))
+          }
+          $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" |
+            Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
+          & $signtool sign /fd SHA256 /f $pfxPath /p $env:WINDOWS_PFX_PASSWORD /tr $env:PFX_TIMESTAMP_URL /td SHA256 "dist\breeze-agent.msi"
+          if ($LASTEXITCODE -ne 0) { throw "signtool failed for MSI with exit code $LASTEXITCODE" }
+
+      - name: Remove PFX from disk
+        if: always() && inputs.signing-mode == 'pfx'
+        shell: pwsh
+        run: Remove-Item -Force -ErrorAction SilentlyContinue (Join-Path $env:RUNNER_TEMP "signing.pfx")
+
+      - name: Verify signatures
+        if: inputs.dry-run == false
+        shell: pwsh
+        run: |
+          $targets = @(
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-agent-windows-amd64.exe"),
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-backup-windows-amd64.exe"),
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-watchdog-windows-amd64.exe"),
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-user-helper-windows-amd64.exe"),
+            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-agent.msi")
+          )
+          foreach ($target in $targets) {
+            $sig = Get-AuthenticodeSignature -FilePath $target
+            # Valid = fully trusted chain; UnknownError = signed but the Azure
+            # Artifact Signing root is not yet in the runner's local trust store
+            # (normal for new accounts).
+            if ($sig.Status -ne "Valid" -and $sig.Status -ne "UnknownError") {
+              throw "Signature validation failed for $target. Status: $($sig.Status)"
+            }
+            if ($sig.Status -eq "UnknownError") {
+              Write-Host "::warning::$target signed but root cert not yet trusted locally (Status: UnknownError). This is normal for new Azure Artifact Signing accounts."
+            }
+            Write-Host "Verified: $target - Status: $($sig.Status) - Signer: $($sig.SignerCertificate.Subject)"
+          }
+
+      - name: Assert dry-run outputs exist
+        if: inputs.dry-run == true
+        shell: pwsh
+        run: |
+          foreach ($f in @("dist\breeze-agent-windows-amd64.exe", "dist\breeze-backup-windows-amd64.exe", "dist\breeze-watchdog-windows-amd64.exe", "dist\breeze-user-helper-windows-amd64.exe", "dist\breeze-agent.msi")) {
+            if (-not (Test-Path $f) -or (Get-Item $f).Length -eq 0) { throw "dry-run output missing or empty: $f" }
+            Write-Host "dry-run output ok: $f"
+          }
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: signed-windows
+          path: |
+            dist/breeze-agent-windows-amd64.exe
+            dist/breeze-backup-windows-amd64.exe
+            dist/breeze-watchdog-windows-amd64.exe
+            dist/breeze-user-helper-windows-amd64.exe
+            dist/breeze-agent.msi
+          retention-days: 7
+```
+
+- [ ] Before merging, confirm the WiX pin: open the most recent green official release run (`gh run list --repo lanternops/breeze --workflow release.yml`), read the "Install WiX CLI" step log for the resolved `wix` tool version, and set `--version` in the "Install WiX CLI (pinned)" step to exactly that version (the `7.0.1` written above is the expected current 7.x line; the log is authoritative).
+- [ ] Validate: `actionlint selfhost-signing-template/.github/workflows/sign-release.yml` (install locally via `brew install actionlint` if missing). Note: the file is incomplete until Task 5 appends `publish`; run actionlint after each task — the partial file is still valid YAML/workflow syntax because each task appends whole jobs.
+- [ ] Commit: `feat(selfhost-signing): sign-release workflow — validate + windows signing job`.
+---
+
+### Task 4: `sign-release.yml` — macOS job (binaries, pkgs, Installer.app)
+
+**Files:**
+- `selfhost-signing-template/.github/workflows/sign-release.yml` (append the `macos` job after `windows`)
+
+**Interfaces:**
+- `macos` job: consumes the 8 official unsigned darwin binaries; produces artifact `signed-macos` containing the 8 signed binaries (canonical names), `breeze-agent-darwin-{amd64,arm64}.pkg`, and `Breeze Installer.app.zip` — all flattened into `out/`. Merges the product repo's `build-macos-agent` and `build-macos-installer-app` jobs into one job (one keychain lifecycle, one runner).
+
+**Steps:**
+
+- [ ] Append the `macos` job to `sign-release.yml`:
+
+```yaml
+  macos:
+    name: Sign macOS artifacts
+    needs: [validate]
+    if: inputs.platforms == 'all' || inputs.platforms == 'macos'
+    runs-on: macos-latest
+    environment: signing
+    steps:
+      - name: Checkout signing repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      # ---- Trust boundary: everything below `verify` may assume the official
+      # ---- release is authentic. No secrets appear above or inside it.
+      - name: Verify official release manifest
+        id: verify
+        uses: ./.github/actions/verify-official-release
+        with:
+          version: ${{ needs.validate.outputs.version }}
+
+      - name: Checkout Breeze source at manifest sourceCommit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: lanternops/breeze
+          ref: ${{ steps.verify.outputs.source-commit }}
+          path: breeze
+          persist-credentials: false
+
+      - name: Download and verify unsigned signing inputs
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          OFFICIAL_MANIFEST_PATH: ${{ steps.verify.outputs.manifest-path }}
+        run: |
+          set -euo pipefail
+          for component in agent backup desktop-helper watchdog; do
+            for arch in amd64 arm64; do
+              scripts/download-verified-asset.sh "$VERSION" \
+                "breeze-${component}-darwin-${arch}-unsigned" \
+                "staging/breeze-${component}-darwin-${arch}" \
+                --expect-signing-input
+            done
+          done
+          chmod 755 staging/breeze-*
+
+      - name: Validate macOS signing secrets
+        if: inputs.dry-run == false
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY APPLE_INSTALLER_IDENTITY APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Missing required signing secret: $name (see README secrets table)"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+      - name: Import certificates into ephemeral keychain
+        if: inputs.dry-run == false
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | tr -d '"')
+
+          rm -f "$CERT_PATH"
+
+      - name: Sign binaries (hardened runtime + entitlements)
+        if: inputs.dry-run == false
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          set -euo pipefail
+          for bin in staging/breeze-agent-darwin-* staging/breeze-backup-darwin-* staging/breeze-desktop-helper-darwin-* staging/breeze-watchdog-darwin-*; do
+            [ -f "$bin" ] || continue
+            case "$bin" in *.pkg|*.zip) continue ;; esac
+            codesign --force --options runtime \
+              --entitlements breeze/agent/entitlements/agent-macos.entitlements.plist \
+              --sign "$APPLE_SIGNING_IDENTITY" --timestamp "$bin"
+            codesign --verify --verbose "$bin"
+            echo "Signed: $bin"
+          done
+
+      - name: Notarize binaries
+        if: inputs.dry-run == false
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          chmod +x breeze/scripts/release/notarize-submit.sh
+          for bin in staging/breeze-agent-darwin-* staging/breeze-backup-darwin-* staging/breeze-desktop-helper-darwin-* staging/breeze-watchdog-darwin-*; do
+            [ -f "$bin" ] || continue
+            case "$bin" in *.pkg|*.zip) continue ;; esac
+            ZIP_PATH="${bin}.zip"
+            ditto -c -k --keepParent "$bin" "$ZIP_PATH"
+            breeze/scripts/release/notarize-submit.sh "$ZIP_PATH"
+            rm -f "$ZIP_PATH"
+          done
+
+      - name: Build macOS .pkg installers
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          chmod +x breeze/agent/installer/macos/build-pkg.sh
+          for arch in amd64 arm64; do
+            breeze/agent/installer/macos/build-pkg.sh \
+              "staging/breeze-agent-darwin-${arch}" \
+              "staging/breeze-desktop-helper-darwin-${arch}" \
+              "staging/breeze-backup-darwin-${arch}" \
+              "staging/breeze-watchdog-darwin-${arch}" \
+              "$VERSION" \
+              "$arch" \
+              "staging/breeze-agent-darwin-${arch}.pkg"
+          done
+
+      - name: Sign .pkg installers
+        if: inputs.dry-run == false
+        env:
+          APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
+        run: |
+          set -euo pipefail
+          for pkg in staging/*.pkg; do
+            SIGNED="${pkg%.pkg}-signed.pkg"
+            productsign --sign "$APPLE_INSTALLER_IDENTITY" "$pkg" "$SIGNED"
+            mv "$SIGNED" "$pkg"
+            echo "Signed: $(basename "$pkg")"
+          done
+
+      - name: Notarize and staple .pkg installers
+        if: inputs.dry-run == false
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          for pkg in staging/*.pkg; do
+            breeze/scripts/release/notarize-submit.sh "$pkg"
+            xcrun stapler staple "$pkg"
+            xcrun stapler validate "$pkg"
+            echo "Notarized and stapled: $(basename "$pkg")"
+          done
+
+      - name: Build Breeze Installer.app from source
+        run: |
+          set -euo pipefail
+          chmod +x breeze/agent/installer/macos-app/build-app-bundle.sh
+          breeze/agent/installer/macos-app/build-app-bundle.sh \
+            --pkg-amd64 staging/breeze-agent-darwin-amd64.pkg \
+            --pkg-arm64 staging/breeze-agent-darwin-arm64.pkg \
+            --output "build/Breeze Installer.app"
+
+      - name: Sign Installer.app
+        if: inputs.dry-run == false
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          set -euo pipefail
+          codesign --force --options runtime \
+            --entitlements breeze/agent/installer/macos-app/entitlements.plist \
+            --sign "$APPLE_SIGNING_IDENTITY" --timestamp \
+            --deep "build/Breeze Installer.app"
+          codesign --verify --verbose=2 "build/Breeze Installer.app"
+
+      - name: Notarize + staple Installer.app
+        if: inputs.dry-run == false
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          ditto -c -k --keepParent "build/Breeze Installer.app" build/installer-notarize.zip
+          breeze/scripts/release/notarize-submit.sh build/installer-notarize.zip
+          xcrun stapler staple "build/Breeze Installer.app"
+          xcrun stapler validate "build/Breeze Installer.app"
+          spctl -a -t exec -vv "build/Breeze Installer.app"
+
+      - name: Verify macOS signatures and notarization
+        if: inputs.dry-run == false
+        run: |
+          set -euo pipefail
+          # Raw Mach-O binaries: verify signature + hardened runtime + Developer ID.
+          # Do NOT run `spctl -a -t exec` against raw command-line binaries —
+          # Gatekeeper's exec assessment is bundle-aware and rejects raw Mach-O
+          # even when signing/notarization are correct. The user-facing
+          # assessment happens at the .pkg layer below.
+          for bin in staging/breeze-agent-darwin-* staging/breeze-backup-darwin-* staging/breeze-desktop-helper-darwin-* staging/breeze-watchdog-darwin-*; do
+            [ -f "$bin" ] || continue
+            case "$bin" in *.pkg|*.zip) continue ;; esac
+            codesign --verify --strict --verbose=2 "$bin"
+            DETAILS=$(codesign -dvvv "$bin" 2>&1)
+            if ! grep -q 'flags=.*runtime' <<<"$DETAILS"; then
+              echo "::error::$bin missing hardened runtime flag"
+              echo "$DETAILS"
+              exit 1
+            fi
+            if ! grep -q 'Authority=Developer ID Application' <<<"$DETAILS"; then
+              echo "::error::$bin not signed by Developer ID Application"
+              echo "$DETAILS"
+              exit 1
+            fi
+          done
+
+          for pkg in staging/*.pkg; do
+            [ -f "$pkg" ] || continue
+            pkgutil --check-signature "$pkg"
+            xcrun stapler validate "$pkg"
+            spctl -a -vv -t install "$pkg"
+          done
+
+      - name: Package Installer.app for release
+        run: |
+          set -euo pipefail
+          ditto -c -k --sequesterRsrc --keepParent \
+            "build/Breeze Installer.app" \
+            "build/Breeze Installer.app.zip"
+
+      - name: Collect outputs
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          for component in agent backup desktop-helper watchdog; do
+            for arch in amd64 arm64; do
+              cp "staging/breeze-${component}-darwin-${arch}" out/
+            done
+          done
+          cp staging/breeze-agent-darwin-amd64.pkg staging/breeze-agent-darwin-arm64.pkg out/
+          cp "build/Breeze Installer.app.zip" out/
+          ls -lh out/
+
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: signed-macos
+          path: out/*
+          retention-days: 7
+
+      - name: Cleanup keychain
+        if: always() && inputs.dry-run == false
+        run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
+```
+
+- [ ] Validate: `actionlint selfhost-signing-template/.github/workflows/sign-release.yml`.
+- [ ] Commit: `feat(selfhost-signing): macos signing job (binaries, pkgs, Installer.app)`.
+
+---
+
+### Task 5: `sign-release.yml` — publish job (mirror + manifest + release)
+
+**Files:**
+- `selfhost-signing-template/.github/workflows/sign-release.yml` (append the `publish` job after `macos`)
+
+**Interfaces:**
+- `publish` job: needs `validate`, `windows`, `macos`; runs when at least one platform job succeeded and none failed. Assembles `release-assets/` from the platform artifacts + verified mirrors, generates + signs the self-hoster's manifest, writes `checksums.txt`, publishes `v<version>` on the self-hoster's repo (or uploads a `dry-run-release-assets` artifact), and prints the instance env block in `$GITHUB_STEP_SUMMARY`.
+- Mirror list (bash array `MIRROR_ASSETS`) is the contract with the API URL helpers; asset names verified against `apps/api/src/services/binarySync.ts` (`AGENT_TARGETS` at ~line 25, `HELPER_TARGETS`, `USER_HELPER_TARGETS`, `WATCHDOG_TARGETS`) and `apps/api/src/services/binarySource.ts` (`VIEWER_FILENAMES`/`HELPER_FILENAMES` at ~line 109, `getGithubBackupUrl`).
+
+**Steps:**
+
+- [ ] Append the `publish` job to `sign-release.yml`:
+
+```yaml
+  publish:
+    name: Publish signed release
+    needs: [validate, windows, macos]
+    if: >-
+      always() && !cancelled()
+      && needs.validate.result == 'success'
+      && (needs.windows.result == 'success' || needs.windows.result == 'skipped')
+      && (needs.macos.result == 'success' || needs.macos.result == 'skipped')
+      && !(needs.windows.result == 'skipped' && needs.macos.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: signing
+    steps:
+      - name: Checkout signing repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Verify official release manifest
+        id: verify
+        uses: ./.github/actions/verify-official-release
+        with:
+          version: ${{ needs.validate.outputs.version }}
+
+      - name: Download signed Windows artifacts
+        if: needs.windows.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-windows
+          path: release-assets/
+
+      - name: Download signed macOS artifacts
+        if: needs.macos.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: signed-macos
+          path: release-assets/
+
+      - name: Mirror never-signed official assets (verified)
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          OFFICIAL_MANIFEST_PATH: ${{ steps.verify.outputs.manifest-path }}
+        run: |
+          set -euo pipefail
+          # Contract: every canonical asset the Breeze API's URL helpers can
+          # request from a repointed repository, minus what the platform jobs
+          # produce. Sources of truth in the product repo:
+          #   apps/api/src/services/binarySync.ts   (AGENT/WATCHDOG/HELPER/USER_HELPER targets)
+          #   apps/api/src/services/binarySource.ts (VIEWER_FILENAMES, HELPER_FILENAMES,
+          #                                          getGithubBackupUrl, getGithubInstallerAppUrl)
+          MIRROR_ASSETS=(
+            breeze-agent-linux-amd64
+            breeze-agent-linux-arm64
+            breeze-backup-linux-amd64
+            breeze-backup-linux-arm64
+            breeze-watchdog-linux-amd64
+            breeze-watchdog-linux-arm64
+            breeze-viewer-windows.msi
+            breeze-viewer-macos.dmg
+            breeze-viewer-linux.AppImage
+            latest.json
+            breeze-helper-windows.msi
+            breeze-helper-macos.dmg
+            breeze-helper-linux.AppImage
+          )
+          for asset in "${MIRROR_ASSETS[@]}"; do
+            scripts/download-verified-asset.sh "$VERSION" "$asset" "release-assets/$asset" --forbid-signing-input
+          done
+
+      - name: Generate release artifact manifest
+        env:
+          SIGN_VERSION: ${{ needs.validate.outputs.version }}
+          SOURCE_COMMIT: ${{ steps.verify.outputs.source-commit }}
+        run: |
+          python3 <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          release_dir = Path("release-assets")
+          excluded = {
+              "checksums.txt",
+              "release-artifact-manifest.json",
+              "release-artifact-manifest.json.ed25519",
+              "release-artifact-manifest.json.minisig",
+          }
+
+          # Same classifier and platformTrust vocabulary as the official
+          # generator in lanternops/breeze release.yml — the Breeze API
+          # already understands exactly these values.
+          DARWIN_BINARY_RE = re.compile(
+              r"^breeze-(agent|backup|desktop-helper|watchdog)-darwin-(amd64|arm64)$"
+          )
+
+          def platform_trust(name):
+              if name.endswith(".msi") or name.endswith(".exe"):
+                  return "windows-authenticode-required"
+              if (
+                  name.endswith(".pkg")
+                  or name.endswith(".app.zip")
+                  or name.endswith(".dmg")
+              ):
+                  return "macos-developer-id-notarization-required"
+              if DARWIN_BINARY_RE.match(name):
+                  return "macos-developer-id-notarization-required"
+              return "release-workflow-produced"
+
+          assets = []
+          for path in sorted(release_dir.iterdir(), key=lambda item: item.name):
+              if not path.is_file() or path.name in excluded:
+                  continue
+              if "-unsigned" in path.name:
+                  raise SystemExit(
+                      f"refusing to publish signing input {path.name} — "
+                      "unsigned inputs must never reach a distributable release"
+                  )
+              assets.append({
+                  "name": path.name,
+                  "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                  "size": path.stat().st_size,
+                  "platformTrust": platform_trust(path.name),
+              })
+
+          if not assets:
+              raise SystemExit("release-assets/ is empty — nothing to publish")
+
+          manifest = {
+              "schemaVersion": 1,
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "release": f"v{os.environ['SIGN_VERSION']}",
+              "sourceCommit": os.environ["SOURCE_COMMIT"],
+              "assets": assets,
+          }
+          (release_dir / "release-artifact-manifest.json").write_text(
+              json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+          )
+          print(f"manifest written with {len(assets)} assets")
+          PY
+
+      - name: Sign release artifact manifest (your Ed25519 key)
+        env:
+          RELEASE_MANIFEST_ED25519_PRIVATE_KEY: ${{ secrets.RELEASE_MANIFEST_ED25519_PRIVATE_KEY }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          node <<'NODE'
+          const {
+            createPrivateKey,
+            createPublicKey,
+            generateKeyPairSync,
+            sign,
+            verify,
+          } = require('node:crypto');
+          const { readFileSync, writeFileSync } = require('node:fs');
+
+          const dryRun = process.env.DRY_RUN === 'true';
+          const raw = (process.env.RELEASE_MANIFEST_ED25519_PRIVATE_KEY ?? '').trim();
+
+          let privateKey;
+          if (!raw) {
+            if (!dryRun) {
+              throw new Error(
+                'RELEASE_MANIFEST_ED25519_PRIVATE_KEY secret is not set — run scripts/generate-manifest-key.sh and add it (see README)'
+              );
+            }
+            ({ privateKey } = generateKeyPairSync('ed25519'));
+            console.log('dry-run: signing with an ephemeral throwaway key');
+          } else {
+            privateKey = raw.includes('BEGIN PRIVATE KEY')
+              ? createPrivateKey(raw)
+              : createPrivateKey({ key: Buffer.from(raw, 'base64'), format: 'der', type: 'pkcs8' });
+          }
+
+          const publicKey = createPublicKey(privateKey);
+          const rawPub = publicKey
+            .export({ format: 'der', type: 'spki' })
+            .subarray(-32)
+            .toString('base64');
+
+          const manifest = readFileSync('release-assets/release-artifact-manifest.json');
+          const signature = sign(null, manifest, privateKey);
+          if (!verify(null, manifest, publicKey, signature)) {
+            throw new Error('Ed25519 manifest signature self-verification failed');
+          }
+          writeFileSync(
+            'release-assets/release-artifact-manifest.json.ed25519',
+            `${signature.toString('base64')}\n`,
+            { mode: 0o644 }
+          );
+          writeFileSync('derived-public-key.txt', `${rawPub}\n`);
+          console.log(`manifest signed; derived public key: ${rawPub}`);
+          NODE
+
+      - name: Generate release checksums
+        run: |
+          cd release-assets
+          sha256sum * > checksums.txt
+
+      - name: Verify release asset integrity
+        run: |
+          set -euo pipefail
+          if [ ! -s "release-assets/checksums.txt" ]; then
+            echo "::error::checksums.txt missing or empty"
+            exit 1
+          fi
+          count=0
+          for path in release-assets/*; do
+            asset="$(basename "$path")"
+            [ "$asset" = "checksums.txt" ] && continue
+            count=$((count + 1))
+            if [ ! -s "$path" ]; then
+              echo "::error::release asset missing or empty: $asset"
+              exit 1
+            fi
+            if ! grep -Fq "  $asset" release-assets/checksums.txt; then
+              echo "::error::checksums.txt missing SHA-256 entry for $asset"
+              exit 1
+            fi
+          done
+          if [ "$count" -eq 0 ]; then
+            echo "::error::no release assets assembled"
+            exit 1
+          fi
+          echo "Verified $count release assets against checksums.txt"
+
+      - name: Upload dry-run assets as workflow artifact
+        if: inputs.dry-run == true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dry-run-release-assets
+          path: release-assets/*
+          retention-days: 7
+
+      - name: Create release
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Re-check immediately before create: a concurrent run may have
+          # published between validate and now.
+          if gh release view "v${VERSION}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::release v${VERSION} appeared on ${GITHUB_REPOSITORY} while this run was in flight — refusing to overwrite"
+            exit 1
+          fi
+          gh release create "v${VERSION}" release-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Breeze ${VERSION} (self-signed)" \
+            --notes "Breeze ${VERSION} agent packages signed with this organization's certificates. Built from official unsigned artifacts of https://github.com/lanternops/breeze/releases/tag/v${VERSION}, verified against the official Ed25519 release manifest before signing."
+
+      - name: Write instance configuration summary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          set -euo pipefail
+          pubkey="$(cat derived-public-key.txt)"
+          {
+            echo "## Point your Breeze instance at this release"
+            echo ""
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "> **Dry run** — nothing was published and the key below is a throwaway. Real runs print your real key here."
+              echo ""
+            fi
+            echo '```bash'
+            echo "BINARY_SOURCE=github"
+            echo "BINARY_GITHUB_REPOSITORY=${GITHUB_REPOSITORY}"
+            echo "BINARY_VERSION=${VERSION}"
+            echo "RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=${pubkey}"
+            echo "AGENT_AUTO_PROMOTE=false   # recommended: promote explicitly after verifying sync"
+            echo '```'
+            echo ""
+            echo "Map each variable in your compose file's \`api\` service \`environment:\` block — a value in \`.env\` alone never reaches the container. Full walkthrough: the \"Sign Your Own Agent Packages\" guide in the Breeze docs."
+          } >> "$GITHUB_STEP_SUMMARY"
+```
+
+- [ ] Verification sweep before commit: `grep -n 'githubDownloadBase\|FILENAMES\|getGithub' apps/api/src/services/binarySource.ts` and confirm every URL helper's asset name is either produced by a platform job or present in `MIRROR_ASSETS` (`Breeze.Installer.app.zip` is produced by the macos job; `install.sh` is API-generated, not a release asset). Also `grep -rn 'breeze-desktop-helper-windows' apps/api agent/internal/updater` — if any consumer fetches a Windows desktop-helper release asset, add `breeze-desktop-helper-windows-amd64.exe` to `MIRROR_ASSETS` and record the finding in the PR description (as of this plan's research, no URL helper references it).
+- [ ] Validate: `actionlint selfhost-signing-template/.github/workflows/sign-release.yml`; also `python3 -c "compile(open('/tmp/x.py').read(),'x','exec')"`-style spot check is unnecessary — instead extract the python heredoc to a temp file and run `python3 -m py_compile` on it once during implementation.
+- [ ] Commit: `feat(selfhost-signing): publish job — verified mirrors, self-signed manifest, release creation`.
+
+---
+
+### Task 6: Template CI — lint, verifier self-test, gated live dry-run
+
+**Files:**
+- `selfhost-signing-template/.github/workflows/ci.yml` (new)
+
+**Interfaces:**
+- `lint` job: actionlint (pinned via Go module version) + `bash -n` + `node --check` + `node scripts/verify-manifest.test.mjs`.
+- `dry-run` job: calls `sign-release.yml` via `workflow_call` with `dry-run: true`; gated on repository variable `DRY_RUN_VERSION` being set, because it can only pass against an official release that ships the Phase 1 unsigned asset set. LanternOps sets the variable on the template repo once such a release exists; template consumers inherit a no-op until they set it.
+
+**Steps:**
+
+- [ ] Create `selfhost-signing-template/.github/workflows/ci.yml`:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint workflows and scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Go (for actionlint)
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        with:
+          go-version: '1.24'
+
+      - name: actionlint
+        run: |
+          set -euo pipefail
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          "$(go env GOPATH)/bin/actionlint" -color
+
+      - name: Shell and Node syntax checks
+        run: |
+          set -euo pipefail
+          bash -n scripts/generate-manifest-key.sh
+          bash -n scripts/download-verified-asset.sh
+          node --check scripts/verify-manifest.mjs
+
+      - name: Verifier self-test
+        run: node scripts/verify-manifest.test.mjs
+
+      - name: Committed official key sanity check
+        run: |
+          set -euo pipefail
+          raw="$(openssl pkey -pubin -in official-release-key.pub -outform DER | tail -c 32 | base64 -w0)"
+          if [ ${#raw} -ne 44 ]; then
+            echo "::error::official-release-key.pub does not decode to a 32-byte Ed25519 key"
+            exit 1
+          fi
+          echo "official key ok: $raw"
+
+  # Full end-to-end dry run against a real official release (no secrets).
+  # Gated on the DRY_RUN_VERSION repository variable: it can only pass against
+  # an official Breeze release that publishes the unsigned signing-input asset
+  # set. Set the variable (Settings -> Secrets and variables -> Actions ->
+  # Variables) to e.g. 0.106.0 to enable.
+  dry-run:
+    name: Dry-run sign workflow
+    needs: [lint]
+    if: vars.DRY_RUN_VERSION != ''
+    uses: ./.github/workflows/sign-release.yml
+    with:
+      version: ${{ vars.DRY_RUN_VERSION }}
+      signing-mode: azure-artifact-signing
+      platforms: all
+      dry-run: true
+```
+
+- [ ] Validate: `actionlint selfhost-signing-template/.github/workflows/ci.yml` and re-run `actionlint` on `sign-release.yml` (the `workflow_call` trigger added in Task 3 is what makes the `uses:` reference legal — actionlint will confirm input compatibility).
+- [ ] Post-publish (Task 9) note: after Deliverable 1 ships in an official release, set `DRY_RUN_VERSION` on `lanternops/breeze-selfhost-signing` to that version so template CI exercises the real dry-run path; until then CI is lint + self-test only.
+- [ ] Commit: `feat(selfhost-signing): template CI — lint, verifier self-test, gated dry-run`.
+---
+
+### Task 7: The guide — `apps/docs` deploy page "Sign Your Own Agent Packages"
+
+**Files:**
+- `apps/docs/src/content/docs/deploy/sign-your-own-packages.mdx` (new)
+
+**Interfaces:**
+- Starlight page, sidebar order 8 (between Code Signing at 7 and Cloudflare Access Trust at 9), conventions copied from `binaries.mdx`/`code-signing.mdx` (frontmatter shape, `@astrojs/starlight/components` imports, `---` section separators).
+- The ONLY sanctioned uncertainty markers are `{/* verify-against-portal */}` MDX comments, confined to Part 1 (Azure portal) and Part 2 (Apple enrollment) — everything else states verified behavior.
+- Cross-links: `/deploy/binaries/`, `/deploy/environment/`, `/deploy/upgrades/#controlled-agent-fleet-rollout`, `/deploy/antivirus-exceptions/`, `/deploy/code-signing/`.
+
+**Steps:**
+
+- [ ] Create `apps/docs/src/content/docs/deploy/sign-your-own-packages.mdx` with the following content:
+
+````mdx
+---
+title: Sign Your Own Agent Packages
+description: Sign official Breeze agent releases with your own Windows and macOS certificates using the breeze-selfhost-signing template.
+sidebar:
+  order: 8
+  label: Sign Your Own Packages
+---
+
+import { Steps, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+Self-hosted Breeze deployments sign the official agent packages with **their
+own** code-signing certificates. LanternOps publishes every release's build
+outputs *unsigned* alongside a cryptographically signed manifest; the
+[`breeze-selfhost-signing`](https://github.com/lanternops/breeze-selfhost-signing)
+template repository turns those into fully signed Windows and macOS packages
+under your identity — no fork, no build environment, no Windows or Mac
+hardware of your own.
+
+---
+
+## Part 0 — Overview
+
+### Why signing matters
+
+An RMM agent installs silently, runs as SYSTEM/root, and captures screens —
+exactly the profile operating systems and AV engines are paranoid about.
+Unsigned agent packages mean SmartScreen interception on every Windows
+install, Gatekeeper refusal on macOS, and elevated AV false-positive rates.
+Signing *once per release* also matters: reputation systems score the
+certificate **and the file hash**, so a stable signed artifact accrues trust
+where per-download re-signing never could.
+
+### What you'll have at the end
+
+- A private GitHub repo (from the template) that signs each Breeze release
+  with one button press and publishes it as `v<version>` on that repo.
+- Signed + timestamped Windows `breeze-agent.msi` and component exes; signed,
+  notarized, stapled macOS pkgs and `Breeze Installer.app`.
+- Your own Ed25519-signed release manifest that your Breeze API verifies
+  end-to-end.
+- Your instance pulling from your repo via `BINARY_GITHUB_REPOSITORY`,
+  with agents updating through the existing per-deployment trust chain.
+
+### Cost and time expectations
+
+| Item | Cost | Lead time |
+|---|---|---|
+| Azure Artifact Signing (formerly Trusted Signing), Basic tier | ~US$9.99/mo | Identity validation typically takes **1–7 business days**; available to organizations and, in the US and Canada, individuals |
+| Apple Developer Program | US$99/yr | Enrollment usually 1–2 days (D-U-N-S lookup can add time for organizations) |
+| GitHub Actions | Free minutes generally suffice (one run per Breeze release) | — |
+
+### Choosing a Windows signing path
+
+Adapted from the maintainer decision matrix in
+`docs/signing/WINDOWS_INSTALLER_SIGNING.md`:
+
+| Option | Fit | Notes |
+|---|---|---|
+| **Azure Artifact Signing** (recommended) | Most self-hosters | No hardware token, HSM-backed keys, OIDC from GitHub Actions, cheap. The template's default mode. |
+| **CA cloud-signing service** (DigiCert KeyLocker, SSL.com eSigner, …) | Orgs already invested in a CA | Works in principle (they expose `signtool`-compatible flows) but is **not wired into the template in v1** — you would adapt the PFX steps yourself. |
+| **PFX file** | Legacy / internal PKI **only** | Since June 2023 the CA/B Forum requires publicly trusted code-signing keys to live in hardware modules, so newly issued OV certs are generally **not exportable** as PFX. Use only with an internal enterprise CA whose root your fleet already trusts. |
+
+<Aside type="caution" title="SmartScreen is not instant">
+  A valid signature is necessary but not sufficient. SmartScreen reputation
+  ramps per certificate and per file hash over days-to-weeks of installs.
+  Expect "Windows protected your PC" on early installs of a brand-new
+  certificate — see [Troubleshooting](#troubleshooting).
+</Aside>
+
+---
+
+## Part 1 — Azure Artifact Signing from zero
+
+You will create four things: an Artifact Signing account, a validated
+identity, a certificate profile, and an Entra app registration with a GitHub
+OIDC federated credential.
+
+{/* verify-against-portal */}
+### 1. Create the Artifact Signing account
+
+<Steps>
+
+1. In the [Azure portal](https://portal.azure.com), search for **Artifact
+   Signing** (formerly *Trusted Signing*) and select **Create**.
+
+2. Pick your subscription and a resource group, an **account name** (this
+   becomes the `AZURE_SIGNING_ACCOUNT_NAME` secret), and a region. Note the
+   region's endpoint URL, e.g. `https://eus.codesigning.azure.net` for East
+   US — this becomes `AZURE_SIGNING_ENDPOINT`.
+
+3. Select the **Basic** SKU and create the account.
+
+</Steps>
+
+{/* verify-against-portal */}
+### 2. Complete identity validation
+
+<Steps>
+
+1. In your Artifact Signing account, open **Identity validations** →
+   **New identity** → **Public**.
+
+2. Enter your legal organization name, registration number, and address
+   exactly as legally registered. For US/Canada individuals, choose the
+   individual flow and complete the identity-verification session.
+
+3. Submit and wait. Validation is performed by Microsoft's verification
+   partner and typically completes in 1–7 business days; you'll get email
+   updates. You cannot create a certificate profile until the identity shows
+   **Completed**.
+
+</Steps>
+
+{/* verify-against-portal */}
+### 3. Create a certificate profile
+
+<Steps>
+
+1. In the account, open **Certificate profiles** → **Create** →
+   **Public Trust**.
+
+2. Name the profile (this becomes `AZURE_CERT_PROFILE`) and bind it to your
+   completed identity validation. The generated certificates are short-lived
+   and rotated by Azure automatically — nothing to renew.
+
+</Steps>
+
+{/* verify-against-portal */}
+### 4. App registration + GitHub OIDC federated credential
+
+<Steps>
+
+1. In **Microsoft Entra ID** → **App registrations** → **New registration**,
+   create an app (e.g. `breeze-selfhost-signing`). Record the **Application
+   (client) ID** (`AZURE_CLIENT_ID`) and **Directory (tenant) ID**
+   (`AZURE_TENANT_ID`).
+
+2. In the app: **Certificates & secrets** → **Federated credentials** →
+   **Add credential** → scenario **GitHub Actions deploying Azure
+   resources**. Enter your GitHub org, the signing repo name, and entity type
+   **Environment** with value `signing` (the workflow's signing jobs run in
+   the `signing` environment). No client secret is created — the workflow
+   authenticates with short-lived OIDC tokens.
+
+3. Back in the Artifact Signing account: **Access control (IAM)** → **Add
+   role assignment** → role **Trusted Signing Certificate Profile Signer** →
+   assign to the app registration's service principal.
+
+</Steps>
+
+---
+
+## Part 2 — Apple Developer ID
+
+{/* verify-against-portal */}
+### 1. Enroll and create certificates
+
+<Steps>
+
+1. Enroll in the [Apple Developer Program](https://developer.apple.com/programs/enroll/)
+   (US$99/yr). Organizations need a D-U-N-S number; the legal entity name
+   becomes the publisher string users see.
+
+2. In [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/certificates/list),
+   create **two** certificates: **Developer ID Application** (signs the
+   binaries and the Installer.app) and **Developer ID Installer** (signs the
+   `.pkg` files). Generate the CSRs in Keychain Access on any Mac
+   (Certificate Assistant → Request a Certificate From a Certificate
+   Authority), or via `openssl` if you have no Mac.
+
+3. Install both certificates into the same Keychain Access keychain, select
+   the two certificates **with their private keys**, and export as a single
+   `.p12` with a strong password.
+
+</Steps>
+
+{/* verify-against-portal */}
+### 2. App-specific password for notarization
+
+<Steps>
+
+1. Sign in at [account.apple.com](https://account.apple.com) with the Apple
+   ID that belongs to (or is invited to) your developer team.
+
+2. Under **Sign-In and Security** → **App-Specific Passwords**, generate one
+   (label it e.g. `breeze-notarytool`). This is the `APPLE_PASSWORD` secret —
+   notarization does not accept your account password, and the template does
+   not support App Store Connect API keys in v1.
+
+3. Find your 10-character **Team ID** under
+   [Membership details](https://developer.apple.com/account#MembershipDetailsCard)
+   (`APPLE_TEAM_ID`).
+
+</Steps>
+
+Compute the secret values:
+
+```bash
+base64 -i developer-id-export.p12 | pbcopy   # -> APPLE_CERTIFICATE
+security find-identity -v -p codesigning     # copy the exact strings for
+                                             # APPLE_SIGNING_IDENTITY, e.g.
+                                             # "Developer ID Application: Example Org (ABCDE12345)"
+```
+
+`APPLE_INSTALLER_IDENTITY` is the matching
+`Developer ID Installer: Example Org (ABCDE12345)` string (installer
+identities don't appear under `-p codesigning`; use
+`security find-identity -v` and pick the Installer entry).
+
+---
+
+## Part 3 — Create your signing repo
+
+<Steps>
+
+1. Open [`lanternops/breeze-selfhost-signing`](https://github.com/lanternops/breeze-selfhost-signing)
+   and click **Use this template** → **Create a new repository**. Private is
+   fine — the workflow only reads public official releases.
+
+2. Clone it and run `./scripts/generate-manifest-key.sh`. Store the printed
+   PEM as the `RELEASE_MANIFEST_ED25519_PRIVATE_KEY` Actions secret and keep
+   the printed `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` line for Part 5. Only
+   the private key is ever stored; the workflow re-derives the public key on
+   every run.
+
+3. Create a GitHub **Environment** named `signing`
+   (Settings → Environments) and add yourself as a **required reviewer**.
+   The workflow's signing jobs run in this environment, so every run that
+   can touch your certificates waits for your approval. Add the secrets to
+   this environment (or as repository secrets if you skip the reviewer
+   gate).
+
+4. Add the platform secrets from Parts 1–2. The full tables live in the
+   template's README: Azure mode needs `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
+   `AZURE_SIGNING_ENDPOINT`, `AZURE_SIGNING_ACCOUNT_NAME`,
+   `AZURE_CERT_PROFILE`; macOS needs `APPLE_CERTIFICATE`,
+   `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`,
+   `APPLE_INSTALLER_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`,
+   `APPLE_TEAM_ID`.
+
+5. Validate the plumbing with a **dry run**: Actions → *Sign Breeze
+   Release* → Run workflow → set `dry-run: true` and a current Breeze
+   version. A dry run downloads and verifies the official inputs and builds
+   the MSI/pkgs/app with signing stubbed — it needs **no secrets and no
+   certificates**, so you can do this before paying anyone.
+
+</Steps>
+
+---
+
+## Part 4 — Run the workflow
+
+Dispatch **Sign Breeze Release** with the version from the official release
+you want (e.g. `0.106.0` — no leading `v`). What each job does:
+
+| Job | What it does |
+|---|---|
+| `validate` | Checks the version format and refuses to overwrite an existing `v<version>` release on your repo (signing must happen once per release so reputation accrues on a stable hash). |
+| `windows` | Verifies the official manifest against the committed official key, pins the tag to the manifest's `sourceCommit`, checks out the Breeze build scripts at that commit, downloads + hash-verifies the four unsigned exes, signs them (Azure Artifact Signing or PFX), builds the MSI with WiX v4, signs the MSI, and sweeps everything with `Get-AuthenticodeSignature`. |
+| `macos` | Same verify preamble; imports your `.p12` into an ephemeral keychain (deleted even on failure), codesigns all eight darwin binaries with hardened runtime + the repo's entitlements, notarizes them, builds both pkgs, `productsign`s, notarizes + staples, builds `Breeze Installer.app` from source around **your** pkgs, signs/notarizes/staples it, then verifies with `codesign --verify --strict`, `pkgutil --check-signature`, and `spctl -a -t install`. |
+| `publish` | Mirrors the never-signed official assets (Linux agent/backup/watchdog, viewer, helper — each hash-verified against the official manifest), generates **your** `release-artifact-manifest.json` (+ `.ed25519` signed with your manifest key), writes `checksums.txt`, and creates release `v<version>` on your repo. The run summary prints the exact env block for Part 5. |
+
+<Aside type="note" title="Verifying outputs locally">
+  Windows: `Get-AuthenticodeSignature .\breeze-agent.msi` should report your
+  organization as signer (Status `Valid`, or `UnknownError` on a machine that
+  hasn't yet cached the Azure Artifact Signing root — that status still means
+  "signed"). macOS: `pkgutil --check-signature breeze-agent-darwin-arm64.pkg`
+  and `spctl -a -vv -t install breeze-agent-darwin-arm64.pkg` should show
+  your Developer ID and `source=Notarized Developer ID`. Then install the MSI
+  and pkg on clean test VMs before promoting to your fleet.
+</Aside>
+
+---
+
+## Part 5 — Point your instance at your builds
+
+### T1 (recommended): repointed GitHub mode
+
+Add to your instance `.env`:
+
+```bash
+BINARY_SOURCE=github
+BINARY_GITHUB_REPOSITORY=your-org/your-signing-repo
+BINARY_VERSION=0.106.0        # the version you signed (or rely on BREEZE_VERSION)
+RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=<your raw base64 key from Part 3>
+AGENT_AUTO_PROMOTE=false      # recommended during first adoption
+```
+
+**And map every one of them** in your compose file's `api` service — a value
+in `.env` alone never reaches the container:
+
+```yaml
+  api:
+    environment:
+      BINARY_SOURCE: ${BINARY_SOURCE:-github}
+      BINARY_GITHUB_REPOSITORY: ${BINARY_GITHUB_REPOSITORY:-}
+      BINARY_VERSION: ${BINARY_VERSION:-}
+      RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: ${RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS}
+      AGENT_AUTO_PROMOTE: ${AGENT_AUTO_PROMOTE:-true}
+```
+
+<Aside type="caution" title="The key must be YOURS">
+  In production, overriding `BINARY_GITHUB_REPOSITORY` requires
+  `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` to be set explicitly — and it must
+  be **your** manifest key, not the official Breeze key. The official key
+  cannot verify your releases; leaving it in place fails closed at sync time.
+</Aside>
+
+On restart, the API fetches your release, verifies your manifest, registers
+the binaries, and re-signs update manifests with its **per-deployment key** —
+agents keep trusting the same deployment key they pinned at enrollment, so no
+agent-side changes are needed.
+
+### T2 (zero-config fallback): local mode
+
+Download your signed release assets and drop them into the API's binary
+directories (`AGENT_BINARY_DIR`, `VIEWER_BINARY_DIR`, `HELPER_BINARY_DIR`)
+with `BINARY_SOURCE=local`. See [Binary Distribution](/deploy/binaries/) for
+directory layout and S3 offload. This works today on any version and needs no
+repository override — at the cost of manual downloads per release.
+
+### Migration flow for an existing fleet
+
+<Steps>
+
+1. Set `AGENT_AUTO_PROMOTE=false` **before** the switch, so registering your
+   release does not instantly become the fleet upgrade target.
+
+2. Apply the T1 env changes and restart the API. Watch the logs for the
+   sync: every platform/arch your fleet uses must register successfully
+   (a missing asset here means a skipped platform in your signing run).
+
+3. Verify a manual download of each platform installer from your instance,
+   install on a test device, confirm it enrolls and heartbeats.
+
+4. Promote explicitly (platform admin, Settings → Agent Versions, or
+   `POST /agent-versions/promote`) — see
+   [Controlled agent fleet rollout](/deploy/upgrades/#controlled-agent-fleet-rollout).
+   Existing agents upgrade to your signed build like any normal version
+   promotion.
+
+</Steps>
+
+### Optional hardening
+
+Once the whole fleet has pinned your deployment key, you can set
+`AGENT_REQUIRE_MANIFEST_SIGNING_KEY_ID=true` so agents refuse update
+manifests that don't name an explicit trusted key — removing the embedded
+official key as a possible update signer. Leave this off until every agent
+has upgraded at least once through your instance.
+
+---
+
+## Troubleshooting
+
+**SmartScreen still warns after signing.**
+Expected at first. Reputation accrues per certificate and per file hash;
+a brand-new Azure Artifact Signing identity starts near zero. It clears
+after enough real installs — typically days to a few weeks. Verify the
+signature is actually present (`Get-AuthenticodeSignature`) and keep the
+release stable (never re-sign an already-published version; the workflow
+enforces this).
+
+**`UnknownError` from `Get-AuthenticodeSignature`.**
+The file *is* signed; the machine just hasn't chained to the Azure Artifact
+Signing root yet. The workflow treats this status as success with a warning,
+matching the official pipeline.
+
+**Notarization rejected (`status: Invalid`).**
+The workflow prints the full `notarytool log` on failure. The most common
+causes: the `.p12` is missing the private key (re-export from Keychain
+Access with the key selected), the Apple ID isn't a member of the team in
+`APPLE_TEAM_ID`, or `APPLE_PASSWORD` is an account password instead of an
+app-specific password.
+
+**Manifest verification failed / `sourceCommit` mismatch.**
+The template refuses to run when the official manifest signature doesn't
+verify or the release tag no longer points at the manifest's recorded
+commit. Both indicate the official release changed after publication —
+do not work around this; check the official repository's security
+announcements and open an issue.
+
+**`asset ... not present in signed manifest` on an older version.**
+Unsigned signing inputs ship with Breeze releases from the BYO-signing
+release onward. You cannot self-sign releases older than that.
+
+**Your API refuses to sync your release.**
+Check that `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` is your key (raw base64,
+44 chars), that it's mapped in the compose `environment:` block, and that
+`BINARY_VERSION`/`BREEZE_VERSION` matches a release that exists on your
+signing repo.
+
+**AV flags your signed agent.**
+Some engines flag new publishers regardless of signature. Add the
+recommended exclusions per platform — see
+[Antivirus Exceptions](/deploy/antivirus-exceptions/) — and submit
+false-positive reports with your signed binaries; a stable hash makes those
+reports effective.
+
+---
+
+## Appendix
+
+### Viewer and Helper apps
+
+The technician-side Viewer and Helper (Tauri) apps are mirrored from the
+official release as-is. If you want to sign those under your identity too,
+the relevant official jobs are `build-viewer`, `sign-windows-tauri`,
+`build-viewer-macos`, and `build-helper-macos` in
+`.github/workflows/release.yml` — that path is closer to a fork than to this
+template, and Gatekeeper's right-click-open flow is generally tolerable for
+technician tooling.
+
+### PFX mode details
+
+`signing-mode: pfx` signs with `signtool sign /fd SHA256 /tr <timestamp> /td
+SHA256` using `WINDOWS_PFX_BASE64` + `WINDOWS_PFX_PASSWORD`, with the
+timestamp server overridable via the `PFX_TIMESTAMP_URL` repository
+variable. It exists for internal-PKI deployments (your enterprise CA root is
+already in your fleet's trust store via GPO/MDM). It is **not** a path to
+public trust: publicly trusted code-signing keys must live in HSMs, so a
+file-based key either predates that rule or is internal-only. SmartScreen
+reputation never accrues for internal CAs — pair PFX mode with the
+[AV exclusions](/deploy/antivirus-exceptions/) and GPO trust configuration.
+
+### Relationship to the fork path
+
+This template signs **official, unmodified** Breeze builds — your
+organization appears as publisher on Breeze-branded software, which is
+expected and documented. If you need your own branding (product name,
+identifiers, icons), that is the fork path: see Model B in
+`docs/signing/ARTIFACT_SIGNING_OPERATIONS.md` in the repository.
+````
+
+- [ ] Validate: `pnpm --filter @breeze/docs build` passes (catches MDX syntax, broken component imports; Starlight link checking flags any bad internal hrefs).
+- [ ] Grep the built page source for `verify-against-portal` — the marker must appear only within Part 1 and Part 2 sections (6 occurrences as written).
+- [ ] Commit: `docs(deploy): Sign Your Own Agent Packages guide`.
+
+---
+
+### Task 8: Related doc fixes — code-signing.mdx, environment.mdx, binaries.mdx, signing docs
+
+**Files:**
+- `apps/docs/src/content/docs/deploy/code-signing.mdx` (edit)
+- `apps/docs/src/content/docs/deploy/environment.mdx` (edit)
+- `apps/docs/src/content/docs/deploy/binaries.mdx` (edit)
+- `docs/signing/WINDOWS_INSTALLER_SIGNING.md` (edit)
+- `docs/signing/ARTIFACT_SIGNING_OPERATIONS.md` (edit)
+
+**Interfaces:** none new — corrections and cross-links. Note: the `BINARY_GITHUB_REPOSITORY` semantics documented here are the **unified** semantics shipped by the Phase 2 (Deliverable 3) plan; this task must land after (or in the same release as) that phase.
+
+**Steps:**
+
+- [ ] `code-signing.mdx` — fix the stale AzureSignTool/EV claims (lines ~30-67):
+  - In the "Signed Artifacts" table, replace every `Azure Code Signing (EV certificate)` cell with `Azure Artifact Signing (formerly Trusted Signing)`.
+  - Replace the Windows "How it works" intro sentence and steps 2–3. Old step 2: `The `AzureSignTool` utility authenticates to Azure Key Vault using a service principal.` Old step 3: `Each binary is signed with the EV certificate stored in Azure Key Vault.` New text:
+
+```mdx
+Windows binaries are signed using **Azure Artifact Signing** (formerly Azure Trusted Signing). The signing happens in the GitHub Actions release workflow.
+
+### How it works
+
+<Steps>
+
+1. The release workflow rebuilds the resource-stamped Windows binaries (agent, backup, watchdog, user-helper) and signs each with the `azure/artifact-signing-action`, authenticating via an OIDC federated credential (no stored client secret).
+
+2. Each binary is signed and RFC 3161-timestamped against the Azure Artifact Signing endpoint; the certificates are short-lived and HSM-backed — the private key never exists outside Azure.
+
+3. The MSI installer is built from the signed binaries with WiX v4, then signed as a separate step.
+
+4. The workflow verifies every signature with `Get-AuthenticodeSignature` before upload (tolerating `UnknownError`, which means "signed, root not yet cached locally").
+
+5. Signed artifacts are uploaded to the GitHub release together with a signed release manifest.
+
+</Steps>
+```
+
+  - Replace the `<Aside>` at ~65-67 with: `Azure Artifact Signing keys are HSM-backed and never exportable, meeting the CA/Browser Forum hardware requirements for publicly trusted code signing. Certificates are short-lived and rotated automatically — there is nothing to renew.`
+- [ ] `code-signing.mdx` — **delete** the entire "Installer Download Signing" section (heading at ~108 through the `See [Environment Variables]...` line at ~128, including the `MSI_SIGNING_URL` table). Replace it with:
+
+```mdx
+## Signing Your Own Packages (Self-Hosted)
+
+Self-hosted deployments sign the official agent packages with their own
+certificates — per release, never per download, so SmartScreen and
+Gatekeeper reputation accrues on a stable hash. See
+[Sign Your Own Agent Packages](/deploy/sign-your-own-packages/).
+```
+
+- [ ] `code-signing.mdx` — in Troubleshooting, update the SmartScreen paragraph's stale EV sentence (`EV certificates build reputation faster than standard OV certificates.`) to: `Azure Artifact Signing certificates build reputation faster than traditional OV certificates because Microsoft attests the identity validation.` and append a sentence linking the new guide for self-hosters.
+- [ ] `environment.mdx` — Binary Distribution table (~line 132-146): fix the `BINARY_SOURCE` default cell from `local` to `github` (code: `binarySource.ts:9` defaults to github; `binaries.mdx` already says github). Add a new row directly under `BINARY_SOURCE`:
+
+```
+| `BINARY_GITHUB_REPOSITORY` | `lanternops/breeze` | | GitHub `owner/repository` used for **all** release consumption in `github` mode — download redirects, release sync, and manifest validation. Point it at your signing repo to serve self-signed packages (see [Sign Your Own Agent Packages](/deploy/sign-your-own-packages/)). In production, overriding it requires `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` to be explicitly set to **your** manifest key. |
+```
+
+- [ ] `environment.mdx` — update the `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` row's description: after "only change it if you sign your own binaries." add "When `BINARY_GITHUB_REPOSITORY` points at your own signing repository, this **must** be your own manifest key (the workflow run summary prints it)."
+- [ ] `environment.mdx` — **delete** the entire "MSI Installer Signing" section (~499-507: the `## MSI Installer Signing` heading, its 3-row table, and the `<Aside>` beneath it). No replacement — the per-download signing path is retired (Deliverable 5 removes the code).
+- [ ] `binaries.mdx` — in the "GitHub Mode (Default)" section, after the `BINARY_VERSION` paragraph (~line 31), insert:
+
+```mdx
+The repository itself is configurable: `BINARY_GITHUB_REPOSITORY` (default
+`lanternops/breeze`) controls where downloads redirect and where release
+sync reads from. Self-hosters who [sign their own agent
+packages](/deploy/sign-your-own-packages/) point this at their signing
+repository and set `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` to their own
+manifest key.
+```
+
+- [ ] `binaries.mdx` — at the end of the "Manifest trust root" subsection, add a short "Unsigned signing inputs" note: official releases also publish `*-unsigned` build outputs with manifest entries marked `intendedUse: "signing-input"` and `platformTrust: "none"`; these exist solely as inputs for self-signing and are never registrable or downloadable through the API.
+- [ ] `docs/signing/WINDOWS_INSTALLER_SIGNING.md` — replace the stale `## Current State` body (~5-7: "Raw `.exe` binaries... No signing, no installer, no Windows resource metadata.") with:
+
+```markdown
+## Current State
+
+Fully implemented in `.github/workflows/release.yml`: resource-stamped exes
+(go-winres) signed via `azure/artifact-signing-action` (Azure Artifact
+Signing, formerly Trusted Signing) with OIDC auth, a WiX v4 MSI built from
+the signed exes and then itself signed, and a `Get-AuthenticodeSignature`
+verification sweep. Official releases additionally publish the pre-signing
+unsigned outputs (`*-unsigned.exe`) as manifest-tracked signing inputs so
+self-hosters can sign with their own certificates — see the
+`breeze-selfhost-signing` template and the "Sign Your Own Agent Packages"
+docs page. The rest of this document is the original design/evaluation
+record.
+```
+
+- [ ] `docs/signing/ARTIFACT_SIGNING_OPERATIONS.md` — in the "Model B: Independent Self-Host or Fork Distribution" section (~120-154), insert directly after the `### Goal` paragraph:
+
+```markdown
+### Preferred path: the signing template
+
+For self-hosters who want their own signing identity on **unmodified**
+official builds, the supported path is the `breeze-selfhost-signing`
+template repository (docs: "Sign Your Own Agent Packages" deploy page). It
+verifies the official release manifest + `sourceCommit` before signing and
+publishes a manifest-signed release the API consumes via
+`BINARY_GITHUB_REPOSITORY`. The template's source of truth lives in this
+monorepo at `selfhost-signing-template/` — **whenever the signing steps in
+`.github/workflows/release.yml` change, diff the template against them and
+push an update** (release-checklist item). The fork checklist below remains
+the path for full rebrands.
+```
+
+- [ ] Validate: `pnpm --filter @breeze/docs build`; `grep -rn "MSI_SIGNING" apps/docs/src` returns nothing; `grep -rn "AzureSignTool" apps/docs/src` returns nothing.
+- [ ] Commit: `docs: fix stale signing docs; retire MSI_SIGNING docs; document BINARY_GITHUB_REPOSITORY`.
+
+---
+
+### Task 9: Publish the standalone template repo (GATED — requires explicit user confirmation)
+
+**Files:** none in-repo (operates on `selfhost-signing-template/` contents and github.com)
+
+**Interfaces:** creates public repo `lanternops/breeze-selfhost-signing` with the template directory's contents at its root, marked as a template repository.
+
+> **STOP: do not execute this task without the user explicitly confirming in-session.** It creates a public, outward-facing repository under the lanternops org. Everything before this task is fully reviewable in-repo.
+
+**Steps:**
+
+- [ ] Preflight: all prior tasks merged to `main`; `actionlint`, `node scripts/verify-manifest.test.mjs`, and the docs build are green on `main`.
+- [ ] **Ask the user for confirmation** (name the exact repo and visibility). Only proceed on an explicit yes.
+- [ ] Create and push (contents become the repo **root**, not a subdirectory):
+
+```bash
+gh repo create lanternops/breeze-selfhost-signing --public \
+  --description "Sign official Breeze RMM agent releases with your own certificates" \
+  --homepage "https://github.com/lanternops/breeze"
+
+SCRATCH="$(mktemp -d)"
+cp -R selfhost-signing-template/. "$SCRATCH/"
+cd "$SCRATCH"
+git init -b main
+git add -A
+git commit -m "feat: initial breeze-selfhost-signing template
+
+Distilled from lanternops/breeze .github/workflows/release.yml signing jobs.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+git remote add origin "https://github.com/lanternops/breeze-selfhost-signing.git"
+git push -u origin main
+```
+
+- [ ] Mark it a template repository (works regardless of gh version):
+
+```bash
+gh api -X PATCH repos/lanternops/breeze-selfhost-signing -f is_template=true
+```
+
+- [ ] Verify: `gh repo view lanternops/breeze-selfhost-signing --json isTemplate,visibility` shows `"isTemplate": true, "visibility": "PUBLIC"`; the CI workflow's `lint` job runs green on the pushed commit (the `dry-run` job stays skipped until `DRY_RUN_VERSION` is set).
+- [ ] Once an official release containing the Phase 1 unsigned asset set exists: `gh variable set DRY_RUN_VERSION --repo lanternops/breeze-selfhost-signing --body "<that version>"` and confirm the CI dry-run passes end-to-end (this is the template's live validation gate from the spec's Testing section; the *signed*-path validation against a scratch Azure account + test-VM installs is a manual release-checklist item before announcing the template).
+- [ ] Update the "Use this template" URL in `sign-your-own-packages.mdx` if the final repo slug differs (it should not).
+
+---
+
+## Self-review notes (performed while drafting — already folded in)
+
+- **Spec Deliverable 2 coverage**: README + secrets tables + environment recommendation (Task 1); committed official key, never an input (Task 1); all four workflow inputs with exact validation (Task 3); verify-before-secrets preamble with tag↔`sourceCommit` binding (Tasks 2–5); Azure/PFX/macOS jobs mirroring `release.yml` step-for-step with the exact pinned action SHAs and parameter shapes (Tasks 3–4); publish job with verified mirror list, official-format manifest + `sourceCommit`, refuse-overwrite, checksums (Task 5); dry-run wired through every job + template CI (Tasks 3–6); WiX pinned where the product CI floats (Task 3).
+- **Spec Deliverable 4 coverage**: guide Parts 0–5, troubleshooting, appendix, antivirus cross-link (Task 7); all five doc fixes incl. the `MSI_SIGNING_URL` section deletion and the Model B pointer with the release-checklist diff item (Task 8).
+- **Asset-name consistency**: unsigned input names match spec Deliverable 1's table exactly (4 Windows `-unsigned.exe`, 8 darwin `-unsigned`); produced/mirrored names match `binarySource.ts`/`binarySync.ts` helpers (`breeze-agent.msi`, `Breeze Installer.app.zip` → served as `Breeze.Installer.app.zip`, viewer/helper filename maps).
+- **Zero placeholders** outside the six `{/* verify-against-portal */}` markers in guide Parts 1–2; the WiX `7.0.1` pin and CI `DRY_RUN_VERSION` gate each carry an explicit in-plan verification step rather than a placeholder value.
+
+## Spec assumptions found WRONG in the code (carried into this plan)
+
+1. **"Install scripts" are not release assets.** Spec Deliverable 2's mirror list says to mirror "install scripts"; `release.yml`'s `Prepare release assets` step uploads none, and `GET /api/v1/agents/install.sh` is generated by the API. The mirror list therefore omits them.
+2. **`binarySync.ts:25` is `AGENT_TARGETS`, not `GH_PLATFORM_MAP`** (that map is at line 19) — the mirror-list contract in this plan cites the actual target arrays (`AGENT_TARGETS`, `HELPER_TARGETS`, `USER_HELPER_TARGETS`, `WATCHDOG_TARGETS`).
+3. **HTML comments are illegal in MDX** — the sanctioned `<!-- verify-against-portal -->` marker is expressed as `{/* verify-against-portal */}` in the guide, since a literal HTML comment fails `pnpm --filter @breeze/docs build`.
+4. **`environment.mdx` documents `BINARY_SOURCE` default as `local`; the code default is `github`** (`binarySource.ts:9`) — fixed in Task 8 beyond the spec's listed corrections.
+5. **The official Windows verify sweep omits the user-helper exe** (`release.yml:618` checks agent/backup/watchdog/MSI only); the template's sweep adds `breeze-user-helper-windows-amd64.exe` — a deliberate, noted improvement, not a copy bug.
+6. **`internal/release-keys/` is readable in this workspace** (the gitignore does not hide it from the working tree), so `official-release-key.pub` is copied directly; the `.env.example:354` value `yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=` matches its SPKI suffix, confirming both sources agree.
+
+

--- a/docs/superpowers/specs/2026-08-09-selfhost-byo-signing-design.md
+++ b/docs/superpowers/specs/2026-08-09-selfhost-byo-signing-design.md
@@ -20,7 +20,7 @@
 ## Background (current state)
 
 - All signing lives in `.github/workflows/release.yml`: Windows via `azure/artifact-signing-action` (Azure Artifact Signing, formerly Trusted Signing), gated on `vars.ENABLE_WINDOWS_SIGNING` + 6 Azure secrets; macOS via Developer ID + `notarytool`, gated on `vars.ENABLE_MACOS_SIGNING` + 7 Apple secrets.
-- Build order matters on Windows: the signing job **rebuilds** the resource-stamped exes itself (`release.yml:372-395` — agent, backup, watchdog, user-helper), signs them, then `agent/installer/build-msi.ps1` (WiX v4) builds the MSI from them, then the MSI is signed. The generic build-matrix outputs are *not* the exact pre-signing inputs. Same shape on macOS: sign binaries → `build-pkg.sh` → `productsign` → notarize + staple. `Breeze Installer.app` embeds the already-built arch-specific PKGs (`release.yml:1034`).
+- Build order matters on Windows: the signing job **rebuilds** the resource-stamped exes itself (`release.yml:308-425` — agent, backup, watchdog, user-helper), signs them, then `agent/installer/build-msi.ps1` (WiX v4) builds the MSI from them, then the MSI is signed. The generic build-matrix outputs are *not* the exact pre-signing inputs — **on Windows only**; the macOS job never rebuilds, it signs the untouched `build-agent` matrix outputs in place, then `build-pkg.sh` → `productsign` → notarize + staple. `Breeze Installer.app` embeds the already-built arch-specific PKGs (`release.yml:1034`).
 - Release integrity: `release-artifact-manifest.json` (name, sha256, size, `platformTrust` per asset) signed with minisign + raw Ed25519. The API verifies it against `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` and fails closed in production. The manifest generator classifies trust **by file extension** (`release.yml:2088` — every `.exe`/`.msi` → `windows-authenticode-required`), and trust is only enforced where a caller passes an expected value (`releaseArtifactManifest.ts:281`).
 - Release-source identity is fragmented: `binarySource.ts:3` hardcodes `lanternops/breeze` for download URLs; `binarySync.ts:17` separately uses `GITHUB_REPO` (env, default `LanternOps/breeze`) for release sync; `BINARY_GITHUB_REPOSITORY` affects **manifest-repository validation only** and is absent from the config schema and compose env mappings.
 - Agent update trust: github-mode sync stamps assets with `signingKeyId: "release-artifact-manifest-ed25519"` (`binarySync.ts:240`), which agents bind to the **embedded official key** (`agent/internal/updater/updater.go:266`); an ID-bearing response is verified against exactly that one key (`updater.go:637`). The per-deployment Ed25519 key (`manifestSigning.ts`, delivered via enrollment/heartbeat TOFU) is today only used when registering **local** binaries (`binarySync.ts:317`). The embedded official key is always merged into the agent trust set (`updater.go:510`) — it is *not* a source-scoped fallback. `AGENT_REQUIRE_MANIFEST_SIGNING_KEY_ID` defaults off.
@@ -53,8 +53,8 @@ Notes:
 
 - **No unsigned `Breeze Installer.app.zip`.** The app embeds the arch-specific PKGs, which the self-hoster produces themselves — their workflow builds the app from the tag-pinned source *after* signing its PKGs.
 - **Manifest modeling:** unsigned inputs get manifest entries with a new field `intendedUse: "signing-input"` and `platformTrust: "none"` — `platformTrust` is not overloaded. The generator's extension-based classification (`release.yml:2088`) must handle the `-unsigned` rule **before** the `.exe`/`.msi` branch.
-- **`sourceCommit`:** the manifest gains the release's `$GITHUB_SHA`, so downstream workflows can bind the tag checkout to the exact signed source revision (tags are movable; the manifest is not).
-- When signing is disabled (`ENABLE_WINDOWS_SIGNING`/`ENABLE_MACOS_SIGNING` false), unsigned uploads still happen — that combination is the eventual end-state for public releases.
+- **`sourceCommit`:** the manifest gains the release's **peeled** commit SHA (`git rev-parse 'HEAD^{commit}'`, not raw `$GITHUB_SHA`, which can name the tag *object* for annotated tags), so downstream workflows can bind the tag checkout to the exact signed source revision (tags are movable; the manifest is not).
+- When signing is disabled (`ENABLE_WINDOWS_SIGNING`/`ENABLE_MACOS_SIGNING` false), the unsigned *capture and upload* still runs — but `release-integrity-gate` still hard-requires the signing jobs on tags, so a signing-disabled tag produces no release at all until rollout step 4 flips that end-state. Phase 1 only makes the capture signing-var-independent.
 - `release-integrity-gate` must not regress: unsigned uploads are additive and must not weaken the platform-trust assertions on the signed set.
 
 ## Deliverable 2 — Template repo `breeze-selfhost-signing`
@@ -90,7 +90,7 @@ All third-party actions pinned to full commit SHAs (same pattern as `release.yml
 
 **`publish`** (needs both, tolerates a skipped platform):
 1. Assemble signed artifacts + `checksums.txt`.
-2. **Mirror every retained canonical asset** from the official release that the API's URL helpers expect — Linux agent/watchdog binaries, viewer/helper assets, install scripts — so a repointed instance doesn't 404 on non-Windows/macOS paths (`binarySync.ts:25`, `binarySource.ts:109`).
+2. **Mirror every retained canonical asset** from the official release that the API's URL helpers expect — Linux agent/backup/watchdog binaries, viewer/helper installers, `latest.json` — so a repointed instance doesn't 404 on non-Windows/macOS paths (source of truth: `binarySync.ts` target arrays + `binarySource.ts` filename maps). Install scripts are *not* release assets — `install.sh` is generated by the API.
 3. Build and sign **their** `release-artifact-manifest.json` (+ `.ed25519`) with their manifest key, same format and `platformTrust` vocabulary the API already understands.
 4. Create release `v${version}` on their repo with everything attached.
 
@@ -128,7 +128,7 @@ Replace expected-value-only checking with a positive allowlist wherever assets a
 
 ### 3d. Recovery media expected hashes
 
-`recoveryMediaService.ts:92` verifies the backup binary against static hashes; a self-signed backup binary has a different hash, so recovery-media verification would fail on BYO deployments. Implementation item: source expected hashes from the active (deployment-verified) release manifest instead of the static table.
+`recoveryMediaService.ts` verifies the backup binary against static hashes (github branch starts ~line 92, static check ~111-118); a self-signed backup binary has a different hash, so recovery-media verification would fail on BYO deployments. Implementation item: in github mode, source expected hashes from the active (deployment-verified) release manifest instead of the static table. **Scope decision (plan phase):** local mode (T2) has no verified manifest, so the static table + existing `BINARY_CHECKSUM_MANIFEST` override remain its path — unchanged behavior.
 
 ### Supported topologies (documented)
 

--- a/docs/superpowers/specs/2026-08-09-selfhost-byo-signing-design.md
+++ b/docs/superpowers/specs/2026-08-09-selfhost-byo-signing-design.md
@@ -1,0 +1,185 @@
+# Self-Hoster BYO Signing — Design
+
+**Date:** 2026-08-09
+**Status:** Approved design, pre-implementation. Advisor quorum: Codex (gpt-5.6-sol, xhigh, read-only) reviewed the draft and returned AGREE-with-amendments; the three blocking findings (deployment re-signing, source-commit binding, release-source unification) were verified against the code and are folded in below.
+**Context:** Breeze is removing self-hoster access to officially signed agent packages. Self-hosters will instead sign the official artifacts themselves. This spec covers the tooling and documentation that makes that as user-friendly as possible.
+
+## Goals
+
+- Self-hosters can produce fully signed Windows + macOS agent artifacts from official **unsigned** release outputs, without forking the product repo or owning Windows/Mac hardware.
+- Signing happens **once per release** (never per download) so SmartScreen/Gatekeeper reputation accrues on a stable hash. This is a hard constraint inherited from the retirement of the per-download MSI signing VM (`docs/superpowers/specs/installer-enrollment/2026-06-24-msi-filename-bootstrap-design.md`): the signed artifact is never mutated; per-org customization rides on the filename-bootstrap-token design.
+- A self-hosted instance consumes the self-signed artifacts through existing, supported plumbing (`BINARY_SOURCE`), with fail-closed integrity verification end to end.
+
+## Non-Goals / Out of Scope
+
+- **Hosted distribution mechanics.** Droplets run `BINARY_SOURCE=github` against public release assets today. How hosted keeps receiving signed artifacts once they leave the public release (private assets + token, or the GHCR `binaries-init` image) is a companion operational decision that must be made **before the removal ships**, but is not designed here.
+- **In-app signing.** Rejected: rebuilding MSIs in a Linux container is fragile, notarization requires long-running Apple-credentialed calls server-side, and it recreates the complexity the `MSI_SIGNING_URL` VM was retired for.
+- **Linux packaging/signing.** Nothing is signed on Linux today; unchanged. (But the self-hoster's release must still *mirror* the unsigned Linux assets — see Deliverable 2.)
+- **Viewer/Helper (Tauri) apps.** Technician-side tools; Gatekeeper right-click is tolerable. The guide gets a short appendix pointing at the relevant `release.yml` jobs for self-hosters who want to go further. Their unsigned official assets are mirrored, not re-signed.
+
+## Background (current state)
+
+- All signing lives in `.github/workflows/release.yml`: Windows via `azure/artifact-signing-action` (Azure Artifact Signing, formerly Trusted Signing), gated on `vars.ENABLE_WINDOWS_SIGNING` + 6 Azure secrets; macOS via Developer ID + `notarytool`, gated on `vars.ENABLE_MACOS_SIGNING` + 7 Apple secrets.
+- Build order matters on Windows: the signing job **rebuilds** the resource-stamped exes itself (`release.yml:372-395` — agent, backup, watchdog, user-helper), signs them, then `agent/installer/build-msi.ps1` (WiX v4) builds the MSI from them, then the MSI is signed. The generic build-matrix outputs are *not* the exact pre-signing inputs. Same shape on macOS: sign binaries → `build-pkg.sh` → `productsign` → notarize + staple. `Breeze Installer.app` embeds the already-built arch-specific PKGs (`release.yml:1034`).
+- Release integrity: `release-artifact-manifest.json` (name, sha256, size, `platformTrust` per asset) signed with minisign + raw Ed25519. The API verifies it against `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` and fails closed in production. The manifest generator classifies trust **by file extension** (`release.yml:2088` — every `.exe`/`.msi` → `windows-authenticode-required`), and trust is only enforced where a caller passes an expected value (`releaseArtifactManifest.ts:281`).
+- Release-source identity is fragmented: `binarySource.ts:3` hardcodes `lanternops/breeze` for download URLs; `binarySync.ts:17` separately uses `GITHUB_REPO` (env, default `LanternOps/breeze`) for release sync; `BINARY_GITHUB_REPOSITORY` affects **manifest-repository validation only** and is absent from the config schema and compose env mappings.
+- Agent update trust: github-mode sync stamps assets with `signingKeyId: "release-artifact-manifest-ed25519"` (`binarySync.ts:240`), which agents bind to the **embedded official key** (`agent/internal/updater/updater.go:266`); an ID-bearing response is verified against exactly that one key (`updater.go:637`). The per-deployment Ed25519 key (`manifestSigning.ts`, delivered via enrollment/heartbeat TOFU) is today only used when registering **local** binaries (`binarySync.ts:317`). The embedded official key is always merged into the agent trust set (`updater.go:510`) — it is *not* a source-scoped fallback. `AGENT_REQUIRE_MANIFEST_SIGNING_KEY_ID` defaults off.
+- `apps/api/src/services/msiSigning.ts` (the old per-download signing client) is dead code with live docs and live production config validation.
+- Recovery media verifies the backup binary against **static expected hashes** (`recoveryMediaService.ts:92`, `binaryManifest.ts:61`), not the release manifest.
+
+## Trust model (the spine of the design)
+
+Three layers, deliberately separated:
+
+1. **Official source trust** — the self-hoster's signing workflow verifies unsigned inputs against the official Ed25519-signed release manifest *and* checks out build scripts at the manifest-recorded `sourceCommit` SHA. LanternOps is trusted as the **source of code**, verified cryptographically before any signing credential is exposed.
+2. **Self-hoster release trust** — the self-hoster's workflow signs artifacts with their platform credentials and publishes their own release manifest signed with **their** Ed25519 key. Their API verifies syncs against that key (`RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS`).
+3. **Deployment→agent trust** — the API **re-signs** a normalized update manifest with its existing per-deployment key and serves the `deploy-*` key ID to agents. Agents never need to know or trust the self-hoster's release key; they trust their deployment's TOFU-pinned key, exactly as local mode works today.
+
+Explicit policy decision: the embedded official key remains in every agent's trust set (the binaries are official builds). Self-hosters who want to fully cut LanternOps out as a potential update signer set `AGENT_REQUIRE_MANIFEST_SIGNING_KEY_ID=true` after their fleet has pinned the deployment key; the guide documents this as an optional hardening step, not a default.
+
+## Deliverable 1 — Publish unsigned artifacts from the official release
+
+`release.yml` uploads unsigned build outputs with an explicit `-unsigned` suffix, **captured from the signing jobs immediately before signing** (not from the generic build matrix — the signing job's resource-stamped rebuilds are the true inputs):
+
+| Artifact | Source |
+|---|---|
+| `breeze-agent-windows-amd64-unsigned.exe` | signing job, pre-sign |
+| `breeze-backup-windows-amd64-unsigned.exe` | " |
+| `breeze-watchdog-windows-amd64-unsigned.exe` | " |
+| `breeze-user-helper-windows-amd64-unsigned.exe` | " |
+| `breeze-{agent,backup,desktop-helper,watchdog}-darwin-{amd64,arm64}-unsigned` | macOS job, pre-sign |
+
+Notes:
+
+- **No unsigned `Breeze Installer.app.zip`.** The app embeds the arch-specific PKGs, which the self-hoster produces themselves — their workflow builds the app from the tag-pinned source *after* signing its PKGs.
+- **Manifest modeling:** unsigned inputs get manifest entries with a new field `intendedUse: "signing-input"` and `platformTrust: "none"` — `platformTrust` is not overloaded. The generator's extension-based classification (`release.yml:2088`) must handle the `-unsigned` rule **before** the `.exe`/`.msi` branch.
+- **`sourceCommit`:** the manifest gains the release's `$GITHUB_SHA`, so downstream workflows can bind the tag checkout to the exact signed source revision (tags are movable; the manifest is not).
+- When signing is disabled (`ENABLE_WINDOWS_SIGNING`/`ENABLE_MACOS_SIGNING` false), unsigned uploads still happen — that combination is the eventual end-state for public releases.
+- `release-integrity-gate` must not regress: unsigned uploads are additive and must not weaken the platform-trust assertions on the signed set.
+
+## Deliverable 2 — Template repo `breeze-selfhost-signing`
+
+A public template repository owned by lanternops. Self-hoster clicks "Use this template", adds secrets, runs the workflow. Contents:
+
+- `README.md` — quickstart + secrets table (mirrors the guide).
+- `official-release-key.pub` — the official manifest Ed25519 public key, **committed and review-controlled** (not a workflow input; rotations arrive as template updates).
+- `.github/workflows/sign-release.yml` — `workflow_dispatch` with inputs:
+  - `version` (required, strictly validated `X.Y.Z[-suffix]`; the workflow refuses to overwrite an existing release of the same version)
+  - `signing-mode`: `azure-artifact-signing` (default) | `pfx` — PFX mode is labeled **legacy/internal-PKI only**: since June 2023 the CA/B Forum requires publicly trusted code-signing keys to live in hardware modules, so exportable PFX files are generally unavailable for newly issued OV certs. The realistic alternatives are Azure Artifact Signing or a CA cloud-signing service (out of scope for v1, noted in the guide).
+  - `platforms`: `all` (default) | `windows` | `macos` — Windows-only shops don't need Apple secrets.
+  - `dry-run`: runs download + verify + build with signing stubbed; no secrets or certs needed. Lets the template be CI-tested and lets self-hosters validate setup before paying for anything.
+- `scripts/generate-manifest-key.sh` — one-shot Ed25519 keygen; only the **private** key goes into repo secrets, the public key and the exact compose `environment:` block are printed in the workflow run summary.
+
+All third-party actions pinned to full commit SHAs (same pattern as `release.yml`). WiX is version-pinned (the product CI currently floats it — pin both).
+
+### Jobs
+
+**Common preamble (each platform job):** download the official manifest + `.ed25519` signature for `v${version}`; verify against the committed official key **before any secret is exposed**; resolve the tag and require it to match the manifest's `sourceCommit`; checkout `lanternops/breeze` at that immutable SHA (build scripts, WiX sources, entitlements, winres config); download unsigned inputs and verify sha256 + size against the manifest. **Fail closed at every step.**
+
+**`windows`** (`windows-latest`):
+1. Sign the 4 exes — `azure/artifact-signing-action` (their secrets) or `signtool` + PFX per `signing-mode`.
+2. Build the MSI via `agent/installer/build-msi.ps1`; sign the MSI.
+3. Verify: `Get-AuthenticodeSignature` sweep (tolerating `UnknownError` for fresh ACS roots, same as `release.yml:618`).
+
+**`macos`** (`macos-latest`):
+1. Ephemeral keychain import of their Developer ID Application cert (deleted in `always()` cleanup).
+2. `codesign --options runtime` with the repo's entitlements files over all darwin binaries; notarize via `notarytool` with Apple ID + app-specific password + team ID (matching `scripts/release/notarize-submit.sh` — ASC API-key auth is **not** promised in v1).
+3. `build-pkg.sh` → `productsign` with their Developer ID Installer cert → notarize + `stapler staple`.
+4. Build `Breeze Installer.app` from the checked-out source embedding **their** signed PKGs; sign, notarize, staple, zip.
+5. Verify: `codesign --verify --strict`, `pkgutil --check-signature`, `spctl --assess`.
+
+**`publish`** (needs both, tolerates a skipped platform):
+1. Assemble signed artifacts + `checksums.txt`.
+2. **Mirror every retained canonical asset** from the official release that the API's URL helpers expect — Linux agent/watchdog binaries, viewer/helper assets, install scripts — so a repointed instance doesn't 404 on non-Windows/macOS paths (`binarySync.ts:25`, `binarySource.ts:109`).
+3. Build and sign **their** `release-artifact-manifest.json` (+ `.ed25519`) with their manifest key, same format and `platformTrust` vocabulary the API already understands.
+4. Create release `v${version}` on their repo with everything attached.
+
+### Secrets
+
+- Azure mode: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SIGNING_ENDPOINT`, `AZURE_SIGNING_ACCOUNT_NAME`, `AZURE_CERT_PROFILE` (single profile; no prod/prerelease split), with OIDC federated credential preferred over `AZURE_CLIENT_SECRET`.
+- PFX mode: `WINDOWS_PFX_BASE64`, `WINDOWS_PFX_PASSWORD`.
+- macOS: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_INSTALLER_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`.
+- Manifest: `RELEASE_MANIFEST_ED25519_PRIVATE_KEY` only (public derived).
+- README recommends a GitHub Environment with required reviewers around the signing secrets.
+
+### Maintenance stance
+
+The template workflow is a **distilled copy** of the `release.yml` signing jobs, not a reusable workflow referenced from our repo — self-hosters' runs must not break when we refactor `release.yml`, and their secrets must never flow through our workflow definitions. Drift risk is accepted and mitigated by (a) the `sourceCommit`-pinned checkout putting all version-sensitive parts in the product repo, and (b) a release-checklist item to diff the template whenever `release.yml` signing steps change.
+
+## Deliverable 3 — API: unified release source + deployment re-signing
+
+### 3a. One validated release-source helper
+
+A single helper (strict `owner/repository` validation) resolves the release source from `BINARY_GITHUB_REPOSITORY` (default `lanternops/breeze`) and is used by **every** consumer: release-page/download URLs (`binarySource.ts:3`), GitHub API sync (`binarySync.ts:17` — retiring the separate `GITHUB_REPO` env or aliasing it through the helper), expected-manifest-repository validation, and the installer/support/recovery/viewer/helper URL builders. Added to the config schema (`validate.ts`) and the compose `environment:` mappings (a value in `.env` is not sufficient — it must be mapped, per the deploy contract).
+
+Production validation: overriding the repository requires `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` to be explicitly set; the docs make unambiguous that it must then be **their** key.
+
+### 3b. Deployment re-signing on github-mode sync (the fix that makes T1 work)
+
+When syncing from an overridden repository, the API:
+1. Verifies the self-hoster's release manifest against `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS` (repository, release, filename, hash, size, platform trust).
+2. Registers assets with a **normalized update manifest re-signed by the per-deployment key** (`manifestSigning.ts`), stamping the `deploy-*` key ID — instead of today's hardcoded `signingKeyId: "release-artifact-manifest-ed25519"` (`binarySync.ts:240`), which agents can only verify against the embedded official key.
+
+Agents then verify updates against their TOFU-pinned deployment key with zero agent-side changes. For the unmodified official-repo path, behavior is unchanged. (Design choice: re-sign *only* for overridden repos, keeping the official path byte-identical; unifying both paths onto deployment signing is a possible later simplification, not required here.)
+
+### 3c. Positive trust enforcement at ingestion
+
+Replace expected-value-only checking with a positive allowlist wherever assets are registered or served: canonical Windows executables/MSIs require `windows-authenticode-required`; canonical macOS assets require `macos-developer-id-notarization-required`; `intendedUse: "signing-input"` assets are **never registrable or serveable**; unknown `platformTrust` values fail closed. Enforcement must sit centrally (sync + serve layers) because several public surfaces proxy or redirect without inspecting a manifest (`routes/agents/download.ts:41`, `supportPublic.ts:192`).
+
+### 3d. Recovery media expected hashes
+
+`recoveryMediaService.ts:92` verifies the backup binary against static hashes; a self-signed backup binary has a different hash, so recovery-media verification would fail on BYO deployments. Implementation item: source expected hashes from the active (deployment-verified) release manifest instead of the static table.
+
+### Supported topologies (documented)
+
+- **T1 (recommended):** `BINARY_SOURCE=github`, `BINARY_GITHUB_REPOSITORY=theirorg/breeze-selfhost-signing`, `RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=<their pubkey>`. Instance auto-pulls their signed releases; agents update via the deployment key (3b).
+- **T2 (zero-code fallback, works today):** `BINARY_SOURCE=local`, signed artifacts dropped into `AGENT_BINARY_DIR`.
+- Migration guidance for both: set `AGENT_AUTO_PROMOTE=false` (defaults true) during first adoption; verify every required platform synced, then promote explicitly.
+
+## Deliverable 4 — The guide (`apps/docs`, new deploy page: "Sign Your Own Agent Packages")
+
+The centerpiece. Structure:
+
+- **Part 0 — Overview**: why signing matters (SmartScreen, Gatekeeper, AV); what you'll have at the end; cost + time expectations (Azure Artifact Signing — formerly Trusted Signing — Basic ~US$9.99/mo, identity validation takes days; available to organizations and, in the US/Canada, individuals; Apple Developer Program US$99/yr). Decision table: Azure Artifact Signing vs. CA cloud signing vs. legacy PFX (adapted from `docs/signing/WINDOWS_INSTALLER_SIGNING.md`).
+- **Part 1 — Azure Artifact Signing from zero**: create the resource, identity validation walkthrough, cert profile, Entra app registration, GitHub OIDC federated credential, role assignment. Portal-level step-by-step.
+- **Part 2 — Apple Developer ID**: enroll, create Developer ID Application + Installer certs, export `.p12`, app-specific password.
+- **Part 3 — Create your signing repo**: use the template, fill the secrets table, generate your manifest key, dry-run.
+- **Part 4 — Run the workflow**: dispatch, what each job does, how to verify outputs locally.
+- **Part 5 — Point your instance at your builds**: T1 and T2, env tables (including compose mapping), `AGENT_AUTO_PROMOTE=false` migration flow, how the fleet picks up the new version, optional hardening via `AGENT_REQUIRE_MANIFEST_SIGNING_KEY_ID=true`.
+- **Troubleshooting**: SmartScreen reputation ramp-up (signed ≠ instantly clean; reputation accrues per cert + hash), notarization rejections, AV exclusions (`antivirus-exceptions.mdx` cross-link), manifest verification failures.
+- **Appendix**: viewer/helper signing pointers; PFX-mode details and its legacy status.
+
+### Related doc fixes (same effort)
+
+- `apps/docs/src/content/docs/deploy/code-signing.mdx`: fix the stale AzureSignTool/Key Vault claim (actual: `azure/artifact-signing-action`); **delete** the `MSI_SIGNING_URL` per-download section; link the new guide.
+- `deploy/binaries.mdx` + `deploy/environment.mdx`: document the unified `BINARY_GITHUB_REPOSITORY` semantics and the unsigned-artifact set.
+- `docs/signing/WINDOWS_INSTALLER_SIGNING.md` `## Current State` is badly stale ("No signing, no installer") — refresh or replace with a pointer.
+- `docs/signing/ARTIFACT_SIGNING_OPERATIONS.md` Model B: point at the new template/guide as the preferred path (fork-and-rebrand remains documented for full forks).
+
+## Deliverable 5 — Cleanup: retire `msiSigning.ts`
+
+Delete `apps/api/src/services/msiSigning.ts` + `msiSigning.test.ts`, the `MSI_SIGNING_*` env vars, their validation in `apps/api/src/config/validate.ts:594-598,1358-1369`, the `system.ts:75` health flag, every docs/`.env.example` mention, **plus** the stale mocks/imports in installer route tests (e.g. `enrollmentKeys_installer.test.ts:98`) and the outdated comment at `installerBuilder.ts:32`.
+
+## Testing
+
+- **API**: unit tests for the release-source helper (URL derivation, strict validation, every consumer wired); deployment re-signing on overridden-repo sync (asserts `deploy-*` key ID, not the official ID); positive-allowlist trust enforcement incl. `signing-input` rejection and unknown-value fail-closed; config-validation tests for the override rules. Extend `ci-smoke-binary-source-github.yml` (or add a variant) to exercise the override against a fixture repo/manifest.
+- **Trust-chain E2E**: one test that walks all three layers with **distinct keys** — official source key → self-hoster release key → deployment key — ending in real Go-updater verification of the served manifest (`agent/internal/updater` test or harness).
+- **Template workflow**: `dry-run` exercised in the template repo's own CI; signed-path validation via a manual run against a real prerelease with a scratch Azure account before the template is published; install the resulting MSI/pkg on test VMs.
+- **Release changes**: assert manifest gains `sourceCommit` + `intendedUse` entries with correct classification order; assert the integrity gate still passes.
+
+## Risks & Edge Cases
+
+- **SmartScreen expectations**: even correctly signed, non-EV reputations ramp over time. The guide must set expectations to avoid "I signed it and it still warns" support load.
+- **Signing-credential exposure to our repo**: the self-hoster's workflow runs our build scripts while holding their credentials. Mitigated by manifest-verified `sourceCommit` checkout (a moved tag cannot inject scripts) and SHA-pinned actions.
+- **Eligibility gaps**: Azure identity validation can still exclude some self-hosters (region/entity); PFX-legacy and CA cloud signing are the documented escape hatches.
+- **Publisher-name semantics**: self-hosters sign Breeze-branded binaries under their own cert — their org name appears as publisher on "Breeze Agent". Acceptable and documented; full rebrand belongs to the fork path (Model B).
+- **Asset-mirroring completeness**: a repointed instance serves *all* binary types from the one repository; the publish job's mirror list must be contract-tested against the API's expected-asset list or missing assets surface as user-facing 404s.
+- **Existing fleets**: already-installed agents keep updating fine — update trust becomes the per-deployment key (3b), and the swap to self-signed binaries is a normal version promotion. Called out in Part 5.
+- **Drift between template and product**: mitigated per the maintenance stance; residual risk accepted.
+
+## Rollout Order
+
+1. Deliverable 1 + the manifest changes (`sourceCommit`, `intendedUse`) ship first: purely additive and harmless while signed packages are still public, and the template can't be validated without them.
+2. Deliverable 3 (API) ships next — re-signing and trust enforcement are self-contained and inert for unmodified deployments.
+3. Deliverables 2, 4, 5 follow (template validated end-to-end against a prerelease containing the unsigned set, guide, cleanup). Self-hosters get a migration window while both signed and unsigned artifacts are public.
+4. The actual removal of public signed artifacts happens last, after the hosted-distribution decision (out of scope here) is implemented, with a deprecation notice in release notes at least one release ahead.


### PR DESCRIPTION
Adds the self-hoster BYO package-signing design spec and the three phase implementation plans (phases 1–3 already merged as #3327, #3330, #3331). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)