### PR TITLE
feat(agent): enforce edition match on release manifest assets

### DIFF
--- a/agent/internal/updater/edition.go
+++ b/agent/internal/updater/edition.go
@@ -1,0 +1,31 @@
+package updater
+
+import (
+	"strings"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// editionAllowed reports whether a release artifact manifest asset entry may
+// be applied to this running build, based on its optional "edition" field.
+//
+// An ABSENT edition (assetEdition == "") is always accepted: it covers both
+// manifests predating the edition field (back-compat) and the fact that an
+// agent built before this check existed never calls editionAllowed at all,
+// so old agents can still upgrade cleanly into edition-stamped manifests.
+//
+// A non-empty edition must match this build's own edition family: "hosted"
+// when hostpolicy.Enforced() (an allowlist-injected hosted build), or
+// "self-host" when it is not (the unrestricted repo-default build). Any
+// other value — including a typo or a future edition this build predates —
+// fails closed rather than being silently accepted.
+func editionAllowed(assetEdition string) bool {
+	assetEdition = strings.TrimSpace(assetEdition)
+	if assetEdition == "" {
+		return true
+	}
+	if hostpolicy.Enforced() {
+		return assetEdition == "hosted"
+	}
+	return assetEdition == "self-host"
+}

--- a/agent/internal/updater/edition_test.go
+++ b/agent/internal/updater/edition_test.go
@@ -1,0 +1,272 @@
+package updater
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/hostpolicy"
+)
+
+// Edition-aware update manifest enforcement (backward-compatible).
+//
+// Release-artifact manifests carry an optional per-asset "edition" field
+// ("self-host" | "hosted"). The updater must refuse to apply an asset whose
+// declared edition does not match the running build's own edition family,
+// while treating an ABSENT field as acceptable — both because manifests
+// predating the field must keep working, and because an old agent (built
+// before this check existed) never consults the field at all, so it can
+// still upgrade cleanly into an edition-stamped manifest.
+
+// signedReleaseArtifactDownloadInfoWithEdition mirrors
+// signedReleaseArtifactDownloadInfo (updater_test.go) but stamps the single
+// asset entry with an explicit edition, using the real production
+// releaseArtifactManifest/releaseArtifactAsset types so the JSON tag names
+// are pinned by the compiler rather than hand-duplicated.
+func signedReleaseArtifactDownloadInfoWithEdition(t *testing.T, version, assetName, edition, rawURL string, content []byte) downloadInfo {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installEmbeddedManifestKey(t, testEmbeddedKeyID, publicKey)
+
+	sum := sha256.Sum256(content)
+	checksum := hex.EncodeToString(sum[:])
+	manifest := releaseArtifactManifest{
+		SchemaVersion: 1,
+		Release:       "v" + version,
+		Assets: []releaseArtifactAsset{
+			{Name: assetName, SHA256: checksum, Size: int64(len(content)), Edition: edition},
+		},
+	}
+	payload, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := ed25519.Sign(privateKey, payload)
+	return downloadInfo{
+		URL:               rawURL,
+		Checksum:          checksum,
+		Manifest:          string(payload),
+		ManifestSignature: base64.StdEncoding.EncodeToString(signature),
+		SigningKeyID:      testEmbeddedKeyID,
+	}
+}
+
+func agentAssetName() string {
+	suffix := ""
+	if runtime.GOOS == "windows" {
+		suffix = ".exe"
+	}
+	return "breeze-agent-" + runtime.GOOS + "-" + runtime.GOARCH + suffix
+}
+
+// --- editionAllowed: pure helper -------------------------------------------------
+
+func TestEditionAllowed_AbsentAcceptedInSelfHost(t *testing.T) {
+	// repo-default build: hostpolicy.Enforced() == false
+	if !editionAllowed("") {
+		t.Fatal("absent edition must be accepted in self-host build")
+	}
+}
+
+func TestEditionAllowed_AbsentAcceptedInHosted(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+	if !editionAllowed("") {
+		t.Fatal("absent edition must be accepted in hosted build")
+	}
+}
+
+func TestEditionAllowed_SelfHostAcceptedInSelfHostBuild(t *testing.T) {
+	if !editionAllowed("self-host") {
+		t.Fatal("edition=self-host must be accepted in a self-host build")
+	}
+}
+
+func TestEditionAllowed_SelfHostRejectedInHostedBuild(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+	if editionAllowed("self-host") {
+		t.Fatal("edition=self-host must be rejected in a hosted build")
+	}
+}
+
+func TestEditionAllowed_HostedRejectedInSelfHostBuild(t *testing.T) {
+	if editionAllowed("hosted") {
+		t.Fatal("edition=hosted must be rejected in a self-host build")
+	}
+}
+
+func TestEditionAllowed_HostedAcceptedInHostedBuild(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+	if !editionAllowed("hosted") {
+		t.Fatal("edition=hosted must be accepted in a hosted build")
+	}
+}
+
+func TestEditionAllowed_UnknownValueRejectedRegardlessOfBuildMode(t *testing.T) {
+	if editionAllowed("enterprise") {
+		t.Fatal("unrecognized edition must be rejected in self-host build")
+	}
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+	if editionAllowed("enterprise") {
+		t.Fatal("unrecognized edition must be rejected in hosted build")
+	}
+}
+
+// --- primary manifest-verified path: verifyReleaseArtifactManifest ---------------
+
+func TestVerifyUpdateManifest_ReleaseArtifact_EditionAbsent_AcceptedSelfHost(t *testing.T) {
+	assetName := agentAssetName()
+	content := []byte("fake binary edition-absent self-host")
+	info := signedReleaseArtifactDownloadInfoWithEdition(t, "1.0.0", assetName, "", "http://example/"+assetName, content)
+
+	u := &Updater{config: &Config{Component: "agent"}}
+	if _, err := u.verifyUpdateManifest(info, "1.0.0"); err != nil {
+		t.Fatalf("absent edition must be accepted in self-host build: %v", err)
+	}
+}
+
+func TestVerifyUpdateManifest_ReleaseArtifact_EditionAbsent_AcceptedHosted(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	assetName := agentAssetName()
+	content := []byte("fake binary edition-absent hosted")
+	info := signedReleaseArtifactDownloadInfoWithEdition(t, "1.0.0", assetName, "", "http://example/"+assetName, content)
+
+	u := &Updater{config: &Config{Component: "agent"}}
+	if _, err := u.verifyUpdateManifest(info, "1.0.0"); err != nil {
+		t.Fatalf("absent edition must be accepted in hosted build: %v", err)
+	}
+}
+
+func TestVerifyUpdateManifest_ReleaseArtifact_SelfHostEdition_AcceptedInSelfHostBuild(t *testing.T) {
+	assetName := agentAssetName()
+	content := []byte("fake binary edition self-host")
+	info := signedReleaseArtifactDownloadInfoWithEdition(t, "1.0.0", assetName, "self-host", "http://example/"+assetName, content)
+
+	u := &Updater{config: &Config{Component: "agent"}}
+	if _, err := u.verifyUpdateManifest(info, "1.0.0"); err != nil {
+		t.Fatalf("edition=self-host must be accepted in a self-host build: %v", err)
+	}
+}
+
+func TestVerifyUpdateManifest_ReleaseArtifact_SelfHostEdition_RejectedInHostedBuild(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	assetName := agentAssetName()
+	content := []byte("fake binary edition self-host")
+	info := signedReleaseArtifactDownloadInfoWithEdition(t, "1.0.0", assetName, "self-host", "http://example/"+assetName, content)
+
+	u := &Updater{config: &Config{Component: "agent"}}
+	if _, err := u.verifyUpdateManifest(info, "1.0.0"); err == nil {
+		t.Fatal("edition=self-host must be rejected in a hosted build")
+	}
+}
+
+func TestVerifyUpdateManifest_ReleaseArtifact_HostedEdition_RejectedInSelfHostBuild(t *testing.T) {
+	assetName := agentAssetName()
+	content := []byte("fake binary edition hosted")
+	info := signedReleaseArtifactDownloadInfoWithEdition(t, "1.0.0", assetName, "hosted", "http://example/"+assetName, content)
+
+	u := &Updater{config: &Config{Component: "agent"}}
+	if _, err := u.verifyUpdateManifest(info, "1.0.0"); err == nil {
+		t.Fatal("edition=hosted must be rejected in a self-host build")
+	}
+}
+
+func TestVerifyUpdateManifest_ReleaseArtifact_HostedEdition_AcceptedInHostedBuild(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	assetName := agentAssetName()
+	content := []byte("fake binary edition hosted")
+	info := signedReleaseArtifactDownloadInfoWithEdition(t, "1.0.0", assetName, "hosted", "http://example/"+assetName, content)
+
+	u := &Updater{config: &Config{Component: "agent"}}
+	if _, err := u.verifyUpdateManifest(info, "1.0.0"); err != nil {
+		t.Fatalf("edition=hosted must be accepted in a hosted build: %v", err)
+	}
+}
+
+// --- fallback path that still consults manifest asset entries: pkgAssetChecksum --
+
+func TestPkgAssetChecksum_EditionAbsent_AcceptedSelfHost(t *testing.T) {
+	pkgName := "breeze-agent-darwin-" + runtime.GOARCH + ".pkg"
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: pkgName, SHA256: strings.Repeat("a", 64), Size: 20},
+	})
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err != nil {
+		t.Fatalf("absent edition must be accepted in self-host build: %v", err)
+	}
+}
+
+func TestPkgAssetChecksum_EditionAbsent_AcceptedHosted(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	pkgName := "breeze-agent-darwin-" + runtime.GOARCH + ".pkg"
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: pkgName, SHA256: strings.Repeat("a", 64), Size: 20},
+	})
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err != nil {
+		t.Fatalf("absent edition must be accepted in hosted build: %v", err)
+	}
+}
+
+func TestPkgAssetChecksum_SelfHostEdition_AcceptedInSelfHostBuild(t *testing.T) {
+	pkgName := "breeze-agent-darwin-" + runtime.GOARCH + ".pkg"
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: pkgName, SHA256: strings.Repeat("a", 64), Size: 20, Edition: "self-host"},
+	})
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err != nil {
+		t.Fatalf("edition=self-host must be accepted in a self-host build: %v", err)
+	}
+}
+
+func TestPkgAssetChecksum_SelfHostEdition_RejectedInHostedBuild(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	pkgName := "breeze-agent-darwin-" + runtime.GOARCH + ".pkg"
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: pkgName, SHA256: strings.Repeat("a", 64), Size: 20, Edition: "self-host"},
+	})
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err == nil {
+		t.Fatal("edition=self-host must be rejected in a hosted build")
+	}
+}
+
+func TestPkgAssetChecksum_HostedEdition_RejectedInSelfHostBuild(t *testing.T) {
+	pkgName := "breeze-agent-darwin-" + runtime.GOARCH + ".pkg"
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: pkgName, SHA256: strings.Repeat("a", 64), Size: 20, Edition: "hosted"},
+	})
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err == nil {
+		t.Fatal("edition=hosted must be rejected in a self-host build")
+	}
+}
+
+func TestPkgAssetChecksum_HostedEdition_AcceptedInHostedBuild(t *testing.T) {
+	restore := hostpolicy.SetAllowedHostsForTest("hosted-a.example")
+	defer restore()
+
+	pkgName := "breeze-agent-darwin-" + runtime.GOARCH + ".pkg"
+	payload := buildReleaseManifest(t, "v1.2.3", []releaseArtifactAsset{
+		{Name: pkgName, SHA256: strings.Repeat("a", 64), Size: 20, Edition: "hosted"},
+	})
+	if _, err := pkgAssetChecksum(payload, "1.2.3"); err != nil {
+		t.Fatalf("edition=hosted must be accepted in a hosted build: %v", err)
+	}
+}

--- a/agent/internal/updater/updater.go
+++ b/agent/internal/updater/updater.go
@@ -405,6 +405,11 @@ type releaseArtifactAsset struct {
 	Name   string `json:"name"`
 	SHA256 string `json:"sha256"`
 	Size   int64  `json:"size"`
+	// Edition is optional and additive: "self-host" | "hosted" | "" (absent).
+	// Absent means the manifest predates edition-stamping (or the running
+	// agent is old enough not to look at this field at all) — either way it
+	// is accepted unconditionally. See editionAllowed.
+	Edition string `json:"edition,omitempty"`
 }
 
 func (u *Updater) component() string {
@@ -533,6 +538,9 @@ func pkgAssetChecksum(verifiedManifest []byte, version string) (string, error) {
 	for i := range manifest.Assets {
 		if manifest.Assets[i].Name != name {
 			continue
+		}
+		if !editionAllowed(manifest.Assets[i].Edition) {
+			return "", fmt.Errorf("update rejected: artifact edition %q does not match this build", manifest.Assets[i].Edition)
 		}
 		sha := manifest.Assets[i].SHA256
 		if len(sha) != 64 {
@@ -1059,6 +1067,9 @@ func (u *Updater) verifyReleaseArtifactManifest(payload []byte, info downloadInf
 	}
 	if selected == nil {
 		return updateManifest{}, fmt.Errorf("release artifact manifest does not include %s", assetName)
+	}
+	if !editionAllowed(selected.Edition) {
+		return updateManifest{}, fmt.Errorf("update rejected: artifact edition %q does not match this build", selected.Edition)
 	}
 	if len(selected.SHA256) != 64 {
 		return updateManifest{}, fmt.Errorf("release artifact manifest checksum must be SHA-256 hex")


### PR DESCRIPTION
Adds an optional per-asset `edition` field to the release-artifact manifest the updater parses, and refuses to apply an asset whose declared edition does not match the running build's own edition family (derived from the build-mode host policy). An absent field is accepted for backward compatibility, so existing manifests and fleets are unaffected. Enforced on both manifest-consulting paths (primary verification and the macOS pkg checksum lookup), with mutation-verified tests.

Part of the release-pipeline build-mode hardening series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)