### PR TITLE
feat(installer): parameterize MSI edition identity

### DIFF
--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -2,6 +2,31 @@
 <?ifndef Version?>
 <?define Version=0.1.0?>
 <?endif?>
+<!-- Installer-identity variables (edition parameterization).
+     ProductName/UpgradeCode default to the ORIGINAL "Hosted" edition's
+     values so a bare `wix build breeze.wxs` (no -d overrides) still
+     produces today's package byte-for-byte identical in identity —
+     existing hosted fleets must keep upgrading via the SAME UpgradeCode.
+     build-msi.ps1's -Edition switch supplies overrides for the
+     "Self-Hosted" edition. OtherUpgradeCode is the UpgradeCode of
+     whichever edition this build is NOT — see the cross-edition Upgrade
+     guard below Package for why it exists and why its default is the
+     Self-Hosted GUID (the complement of the Hosted defaults here). -->
+<?ifndef ProductName?>
+<?define ProductName=Breeze Agent?>
+<?endif?>
+<?ifndef UpgradeCode?>
+<?define UpgradeCode={70A57B7A-4F72-4E18-B8D3-7D2783C2C1A9}?>
+<?endif?>
+<!-- {787838E2-1A3E-4B61-8514-75DD922A6B1B} is the PERMANENT UpgradeCode for
+     the "Self-Hosted" edition, generated once for this parameterization
+     work. It must NEVER change — it is how self-hosted fleets recognize
+     their own upgrade lineage, and it is also the value the Hosted
+     edition's cross-edition guard checks for below (as OtherUpgradeCode's
+     default). -->
+<?ifndef OtherUpgradeCode?>
+<?define OtherUpgradeCode={787838E2-1A3E-4B61-8514-75DD922A6B1B}?>
+<?endif?>
 <?ifndef AgentExePath?>
 <?define AgentExePath=..\breeze-agent-windows-amd64.exe?>
 <?endif?>
@@ -26,10 +51,10 @@
 
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
   <Package
-    Name="Breeze Agent"
+    Name="$(var.ProductName)"
     Manufacturer="Breeze RMM"
     Version="$(var.Version)"
-    UpgradeCode="{70A57B7A-4F72-4E18-B8D3-7D2783C2C1A9}"
+    UpgradeCode="$(var.UpgradeCode)"
     Scope="perMachine"
     InstallerVersion="500"
     Language="1033">
@@ -59,11 +84,33 @@
          this flag, reinstalling a rebuilt same-version MSI (common with the
          signing-service pipeline) installs SIDE-BY-SIDE: two ARP entries
          both claiming the services, and the eventual uninstall of either
-         one rips the services out from under the survivor. -->
+         one rips the services out from under the survivor.
+
+         Cross-edition guard (OTHEREDITIONFOUND below): Hosted and
+         Self-Hosted are separate PRODUCTS (distinct UpgradeCodes, see the
+         preprocessor block at the top of this file) that install into the
+         exact same paths and claim the exact same service names
+         (BreezeAgent / BreezeWatchdog) — they are NOT upgrade-related to
+         each other, so MajorUpgrade above (which only knows this package's
+         OWN UpgradeCode) does nothing to stop them coexisting. Side-by-side
+         would be the same class of corruption AllowSameVersionUpgrades
+         guards against above (two ARP entries fighting over one set of
+         services/files, whichever uninstalls first yanking them out from
+         under the survivor) — so it must be refused outright in both
+         directions, not merely discouraged. The Upgrade/Launch pair
+         immediately below does that: OnlyDetect="yes" makes it a pure
+         probe (no RemoveExistingProducts action is scheduled for the other
+         product), and the Launch Condition blocks install before any files
+         are touched if the other edition is found. -->
     <MajorUpgrade
       DowngradeErrorMessage="A newer version of Breeze Agent is already installed."
       AllowSameVersionUpgrades="yes"
       Schedule="afterInstallExecute" />
+
+    <Upgrade Id="$(var.OtherUpgradeCode)">
+      <UpgradeVersion Minimum="0.0.0.0" IncludeMinimum="yes" OnlyDetect="yes" Property="OTHEREDITIONFOUND" />
+    </Upgrade>
+    <Launch Condition="NOT OTHEREDITIONFOUND" Message="A different edition of the Breeze Agent is already installed. Uninstall it before installing this edition." />
 
     <Launch Condition="VersionNT64" Message="Breeze Agent requires 64-bit Windows." />
     <Launch Condition="(NOT SERVER_URL AND NOT ENROLLMENT_KEY) OR (SERVER_URL AND ENROLLMENT_KEY)" Message="SERVER_URL and ENROLLMENT_KEY must be provided together." />

--- a/agent/installer/breeze.wxs
+++ b/agent/installer/breeze.wxs
@@ -111,6 +111,18 @@
       <UpgradeVersion Minimum="0.0.0.0" IncludeMinimum="yes" OnlyDetect="yes" Property="OTHEREDITIONFOUND" />
     </Upgrade>
     <Launch Condition="NOT OTHEREDITIONFOUND" Message="A different edition of the Breeze Agent is already installed. Uninstall it before installing this edition." />
+    <!-- The stock MSI sequences run LaunchConditions (100) BEFORE
+         FindRelatedProducts (200), which would leave OTHEREDITIONFOUND
+         permanently unset when the Launch condition above is evaluated —
+         i.e. the cross-edition guard would never fire. Reorder so the
+         related-product probe populates the property first, in both the
+         interactive and silent install paths. -->
+    <InstallUISequence>
+      <FindRelatedProducts Before="LaunchConditions" />
+    </InstallUISequence>
+    <InstallExecuteSequence>
+      <FindRelatedProducts Before="LaunchConditions" />
+    </InstallExecuteSequence>
 
     <Launch Condition="VersionNT64" Message="Breeze Agent requires 64-bit Windows." />
     <Launch Condition="(NOT SERVER_URL AND NOT ENROLLMENT_KEY) OR (SERVER_URL AND ENROLLMENT_KEY)" Message="SERVER_URL and ENROLLMENT_KEY must be provided together." />

--- a/agent/installer/build-msi.ps1
+++ b/agent/installer/build-msi.ps1
@@ -2,6 +2,18 @@ param(
     [Parameter(Mandatory = $false)]
     [string]$Version = "0.1.0",
 
+    # Installer identity to build. "Hosted" (default) reproduces today's MSI
+    # identity byte-for-byte (ProductName "Breeze Agent", the original
+    # UpgradeCode) so existing callers that pass nothing get an unchanged
+    # package and existing hosted fleets keep upgrading in place.
+    # "SelfHost" builds the self-hosted edition under its own permanent
+    # UpgradeCode. See breeze.wxs's preprocessor block and the cross-edition
+    # Upgrade/Launch guard near MajorUpgrade for why the two must never
+    # share an UpgradeCode.
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("Hosted", "SelfHost")]
+    [string]$Edition = "Hosted",
+
     [Parameter(Mandatory = $false)]
     [string]$AgentExePath = "",
 
@@ -81,11 +93,38 @@ if (-not (Test-Path $outputDir)) {
     New-Item -Path $outputDir -ItemType Directory -Force | Out-Null
 }
 
+# Edition identity map. These UpgradeCodes are the SAME literals hardcoded
+# as the ifndef defaults in breeze.wxs (Hosted) and its cross-edition guard
+# comment (SelfHost) — duplicated here only because build-msi.ps1 must pass
+# the "other" edition's code explicitly (a bare `wix build breeze.wxs` with
+# no -d overrides can only ever default to Hosted-vs-SelfHost, never the
+# reverse). Do not change either GUID; the SelfHost UpgradeCode in
+# particular is permanent — self-hosted fleets identify their upgrade
+# lineage by it.
+$hostedProductName = "Breeze Agent"
+$hostedUpgradeCode = "{70A57B7A-4F72-4E18-B8D3-7D2783C2C1A9}"
+$selfHostProductName = "Breeze Agent (Self-Hosted)"
+$selfHostUpgradeCode = "{787838E2-1A3E-4B61-8514-75DD922A6B1B}"
+
+if ($Edition -eq "SelfHost") {
+    $editionProductName = $selfHostProductName
+    $editionUpgradeCode = $selfHostUpgradeCode
+    $editionOtherUpgradeCode = $hostedUpgradeCode
+}
+else {
+    $editionProductName = $hostedProductName
+    $editionUpgradeCode = $hostedUpgradeCode
+    $editionOtherUpgradeCode = $selfHostUpgradeCode
+}
+
 $wixArgs = @(
     "build",
     "$installerPath",
     "-arch", "x64",
     "-d", "Version=$msiVersion",
+    "-d", "ProductName=$editionProductName",
+    "-d", "UpgradeCode=$editionUpgradeCode",
+    "-d", "OtherUpgradeCode=$editionOtherUpgradeCode",
     "-d", "AgentExePath=$AgentExePath",
     "-d", "BackupExePath=$BackupExePath",
     "-d", "WatchdogExePath=$WatchdogExePath",


### PR DESCRIPTION
Adds an `-Edition Hosted|SelfHost` switch to `build-msi.ps1` with matching WiX preprocessor variables in `breeze.wxs` (ProductName/UpgradeCode), defaulting byte-for-byte to today's identity so existing callers and fleets are unchanged. The self-host edition gets its own permanent UpgradeCode, and a cross-edition detect-and-refuse guard (with explicit `FindRelatedProducts` sequencing so the probe populates before launch conditions) prevents the two editions — which share install paths and service names — from ever installing side-by-side.

Static verification only on this branch (XML well-formedness, PowerShell parse, variable/define audit); real install/upgrade/cross-edition matrix runs on a Windows VM before any release uses the new edition.

Part of the release-pipeline build-mode hardening series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)