### PR TITLE
feat(release): edition-aware build pipeline + self-host artifact publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1002,7 +1002,7 @@ jobs:
         run: go mod download
 
       - name: Build Agent
-        working-directory: agent
+        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -1010,9 +1010,9 @@ jobs:
           BUILD_VERSION: ${{ github.sha }}
           CGO_LDFLAGS_ALLOW: '-weak_framework|ScreenCaptureKit'
         run: |
-          go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
-            -o "breeze-agent-${GOOS}-${GOARCH}${{ matrix.suffix }}" \
-            ./cmd/breeze-agent
+          agent/scripts/build-edition.sh --edition self-host --component agent \
+            --goos "$GOOS" --goarch "$GOARCH" --version "$BUILD_VERSION" \
+            --out "breeze-agent-${GOOS}-${GOARCH}${{ matrix.suffix }}"
 
       # Windows-only: build the GUI-subsystem user-helper so the scheduled task
       # that launches it at logon does not allocate a visible console window.
@@ -1024,16 +1024,16 @@ jobs:
       # embedded here — the manifest regression guard lives in release.yml.
       - name: Build user-helper (Windows only)
         if: matrix.goos == 'windows'
-        working-directory: agent
+        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: ${{ matrix.cgo }}
           BUILD_VERSION: ${{ github.sha }}
         run: |
-          go build -ldflags="-s -w -X main.version=${BUILD_VERSION} -H windowsgui" \
-            -o "breeze-user-helper-${GOOS}-${GOARCH}${{ matrix.suffix }}" \
-            ./cmd/breeze-user-helper
+          agent/scripts/build-edition.sh --edition self-host --component user-helper \
+            --goos "$GOOS" --goarch "$GOARCH" --version "$BUILD_VERSION" --windowsgui \
+            --out "breeze-user-helper-${GOOS}-${GOARCH}${{ matrix.suffix }}"
 
       # Regression guard (#2797): built agent binaries must not contain
       # plaintext threat-signature strings — AV engines flag them as malware
@@ -1125,6 +1125,9 @@ jobs:
       - name: Run Go tests
         working-directory: agent
         run: CGO_ENABLED=0 go test -v -coverprofile=coverage.out ./...
+
+      - name: Test build-edition.sh (edition fail-closed matrix + real build)
+        run: agent/scripts/build-edition_test.sh
 
       - name: Upload coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -1389,13 +1392,18 @@ jobs:
 
       - name: Build Windows agent
         working-directory: agent
+        shell: bash
         env:
           CGO_ENABLED: '0'
           BUILD_VERSION: ${{ github.sha }}
         run: |
-          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" `
-            -o breeze-agent.exe ./cmd/breeze-agent
-          if (-not (Test-Path breeze-agent.exe)) { throw "breeze-agent.exe was not produced" }
+          scripts/build-edition.sh --edition self-host --component agent \
+            --goos windows --goarch amd64 --version "$BUILD_VERSION" \
+            --out breeze-agent.exe
+          if [ ! -f breeze-agent.exe ]; then
+            echo "::error::breeze-agent.exe was not produced" >&2
+            exit 1
+          fi
 
       - name: Boot agent and assert it stays up
         working-directory: agent

--- a/.github/workflows/dev-build-agent.yml
+++ b/.github/workflows/dev-build-agent.yml
@@ -183,10 +183,9 @@ jobs:
           GOOS: darwin
         run: |
           set -euo pipefail
-          go build \
-            -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
-            -o "breeze-agent-darwin-${GOARCH}" \
-            ./cmd/breeze-agent
+          scripts/build-edition.sh --edition self-host --component agent \
+            --goos "$GOOS" --goarch "$GOARCH" --version "$BUILD_VERSION" \
+            --out "breeze-agent-darwin-${GOARCH}"
 
       - name: Package unsigned artifact with strict provenance
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
         run: echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build Agent
-        working-directory: agent
+        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -163,9 +163,9 @@ jobs:
           # where SCK doesn't exist (prevents dyld Symbol not found crash)
           CGO_LDFLAGS_ALLOW: '-weak_framework|ScreenCaptureKit'
         run: |
-          go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
-            -o "breeze-agent-${GOOS}-${GOARCH}${{ matrix.suffix }}" \
-            ./cmd/breeze-agent
+          agent/scripts/build-edition.sh --edition self-host --component agent \
+            --goos "$GOOS" --goarch "$GOARCH" --version "$BUILD_VERSION" \
+            --out "breeze-agent-${GOOS}-${GOARCH}${{ matrix.suffix }}"
 
       - name: Upload Agent artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -175,7 +175,7 @@ jobs:
           retention-days: 30
 
       - name: Build breeze-backup
-        working-directory: agent
+        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -183,9 +183,9 @@ jobs:
           BUILD_VERSION: ${{ steps.version.outputs.version }}
           CGO_LDFLAGS_ALLOW: '-weak_framework|ScreenCaptureKit'
         run: |
-          go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
-            -o "breeze-backup-${GOOS}-${GOARCH}${{ matrix.suffix }}" \
-            ./cmd/breeze-backup
+          agent/scripts/build-edition.sh --edition self-host --component backup \
+            --goos "$GOOS" --goarch "$GOARCH" --version "$BUILD_VERSION" \
+            --out "breeze-backup-${GOOS}-${GOARCH}${{ matrix.suffix }}"
 
       - name: Upload breeze-backup artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -195,16 +195,16 @@ jobs:
           retention-days: 30
 
       - name: Build breeze-watchdog
-        working-directory: agent
+        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
           BUILD_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
-            -o "breeze-watchdog-${GOOS}-${GOARCH}${{ matrix.suffix }}" \
-            ./cmd/breeze-watchdog
+          agent/scripts/build-edition.sh --edition self-host --component watchdog \
+            --goos "$GOOS" --goarch "$GOARCH" --version "$BUILD_VERSION" \
+            --out "breeze-watchdog-${GOOS}-${GOARCH}${{ matrix.suffix }}"
 
       - name: Upload breeze-watchdog artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -215,7 +215,7 @@ jobs:
 
       - name: Build breeze-desktop-helper
         if: matrix.goos == 'darwin'
-        working-directory: agent
+        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -223,9 +223,9 @@ jobs:
           BUILD_VERSION: ${{ steps.version.outputs.version }}
           CGO_LDFLAGS_ALLOW: '-weak_framework|ScreenCaptureKit'
         run: |
-          go build -ldflags="-s -w -X main.version=${BUILD_VERSION}" \
-            -o "breeze-desktop-helper-${GOOS}-${GOARCH}" \
-            ./cmd/breeze-desktop-helper
+          agent/scripts/build-edition.sh --edition self-host --component desktop-helper \
+            --goos "$GOOS" --goarch "$GOARCH" --version "$BUILD_VERSION" \
+            --out "breeze-desktop-helper-${GOOS}-${GOARCH}"
 
       - name: Upload breeze-desktop-helper artifact
         if: matrix.goos == 'darwin'
@@ -348,29 +348,20 @@ jobs:
             --out ..\cmd\breeze-desktop-helper\rsrc_windows_amd64.syso
           if ($LASTEXITCODE -ne 0) { throw "go-winres simply breeze-desktop-helper failed with exit code $LASTEXITCODE" }
           Pop-Location
-          Push-Location agent
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          $env:CGO_ENABLED = "0"
-          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-agent-windows-amd64.exe .\cmd\breeze-agent
-          if ($LASTEXITCODE -ne 0) { throw "go build breeze-agent failed with exit code $LASTEXITCODE" }
-          Pop-Location
+          # All four exes below route through agent/scripts/build-edition.sh
+          # (invoked via git-bash, which windows-latest runners provide) so
+          # the self-host/hosted edition rules are enforced in one place
+          # rather than reimplemented per go-build call site. --edition
+          # self-host here is what makes this the public, unrestricted build
+          # (agent/internal/hostpolicy stays inert; see the script's header).
+          bash agent/scripts/build-edition.sh --edition self-host --component agent --goos windows --goarch amd64 --version $env:BUILD_VERSION --out ../dist/breeze-agent-windows-amd64.exe
+          if ($LASTEXITCODE -ne 0) { throw "build-edition.sh (agent) failed with exit code $LASTEXITCODE" }
           # Build breeze-backup
-          Push-Location agent
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          $env:CGO_ENABLED = "0"
-          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-backup-windows-amd64.exe .\cmd\breeze-backup
-          if ($LASTEXITCODE -ne 0) { throw "go build breeze-backup failed with exit code $LASTEXITCODE" }
-          Pop-Location
+          bash agent/scripts/build-edition.sh --edition self-host --component backup --goos windows --goarch amd64 --version $env:BUILD_VERSION --out ../dist/breeze-backup-windows-amd64.exe
+          if ($LASTEXITCODE -ne 0) { throw "build-edition.sh (backup) failed with exit code $LASTEXITCODE" }
           # Build breeze-watchdog
-          Push-Location agent
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          $env:CGO_ENABLED = "0"
-          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION" -o ..\dist\breeze-watchdog-windows-amd64.exe .\cmd\breeze-watchdog
-          if ($LASTEXITCODE -ne 0) { throw "go build breeze-watchdog failed with exit code $LASTEXITCODE" }
-          Pop-Location
+          bash agent/scripts/build-edition.sh --edition self-host --component watchdog --goos windows --goarch amd64 --version $env:BUILD_VERSION --out ../dist/breeze-watchdog-windows-amd64.exe
+          if ($LASTEXITCODE -ne 0) { throw "build-edition.sh (watchdog) failed with exit code $LASTEXITCODE" }
           # Build breeze-user-helper (GUI-subsystem sibling of breeze-agent).
           # Thin cmd/breeze-user-helper wrapper over the same internal/agentapp
           # code as breeze-agent — only the -H windowsgui linker flag and the
@@ -378,13 +369,8 @@ jobs:
           # lets it ship asInvoker instead of the agent's requireAdministrator.
           # Required by the AgentUserHelper scheduled task and the sessionbroker
           # user-session spawn path (which uses the user's non-elevated token).
-          Push-Location agent
-          $env:GOOS = "windows"
-          $env:GOARCH = "amd64"
-          $env:CGO_ENABLED = "0"
-          go build -ldflags="-s -w -X main.version=$env:BUILD_VERSION -H windowsgui" -o ..\dist\breeze-user-helper-windows-amd64.exe .\cmd\breeze-user-helper
-          if ($LASTEXITCODE -ne 0) { throw "go build breeze-user-helper failed with exit code $LASTEXITCODE" }
-          Pop-Location
+          bash agent/scripts/build-edition.sh --edition self-host --component user-helper --goos windows --goarch amd64 --version $env:BUILD_VERSION --windowsgui --out ../dist/breeze-user-helper-windows-amd64.exe
+          if ($LASTEXITCODE -ne 0) { throw "build-edition.sh (user-helper) failed with exit code $LASTEXITCODE" }
           # Regression guard (#949): assert the SHIPPED manifests are correct.
           # The user-helper MUST be asInvoker and the agent MUST be
           # requireAdministrator — and the inverse for each, since #949 is a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,6 +412,49 @@ jobs:
           fi
           bash scripts/security/check-agent-binary-signatures.sh "${bins[@]}"
 
+      # Publish these go-winres-resourced exes (VERSIONINFO, icon, the #949
+      # asInvoker/requireAdministrator manifests) under their canonical
+      # (non "-unsigned") artifact names. This job's overwrite:true wins over
+      # build-agent's earlier, unresourced windows/amd64 matrix-leg upload of
+      # the same artifact names — the public pipeline no longer signs these,
+      # but the canonical filenames must still carry the resourced build,
+      # since the agent's own Windows auto-updater fetches
+      # breeze-agent-windows-amd64.exe (and its siblings) by that exact name
+      # from the GitHub release (agent/internal/updater/updater.go).
+      - name: Upload agent EXE artifact (canonical name)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: breeze-agent-windows-amd64
+          path: dist/breeze-agent-windows-amd64.exe
+          overwrite: true
+          retention-days: 30
+
+      - name: Upload backup EXE artifact (canonical name)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: breeze-backup-windows-amd64
+          path: dist/breeze-backup-windows-amd64.exe
+          overwrite: true
+          retention-days: 30
+
+      - name: Upload watchdog EXE artifact (canonical name)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: breeze-watchdog-windows-amd64
+          path: dist/breeze-watchdog-windows-amd64.exe
+          overwrite: true
+          retention-days: 30
+
+      # Issue #816: ship the user-helper as a discrete GitHub release asset so
+      # the agent's in-place auto-upgrade can fetch it directly.
+      - name: Upload user-helper EXE artifact (canonical name)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: breeze-user-helper-windows-amd64
+          path: dist/breeze-user-helper-windows-amd64.exe
+          overwrite: true
+          retention-days: 30
+
       - name: Stage unsigned Windows exes (BYO signing inputs)
         shell: pwsh
         run: |
@@ -451,55 +494,9 @@ jobs:
           path: dist-unsigned/breeze-user-helper-windows-amd64-unsigned.exe
           retention-days: 30
 
-  build-windows-msi:
-    name: Build + Sign Windows Artifacts
-    if: >-
-      vars.ENABLE_WINDOWS_SIGNING == 'true'
-      && github.ref_type == 'tag'
-      && startsWith(github.ref, 'refs/tags/v')
-    runs-on: windows-latest
-    needs: [build-agent, build-windows-unsigned]
-    permissions:
-      contents: read
-      id-token: write
-    environment:
-      name: ${{ contains(github.ref_name, '-') && 'signing-prerelease' || 'signing-production' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-
-      - name: Get version from tag
-        id: version
-        shell: pwsh
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          $version = $env:REF_NAME.Substring(1)
-          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-
-      - name: Download unsigned Windows exes (signing inputs)
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: 'breeze-*-windows-amd64-unsigned'
-          path: dist-unsigned/
-          merge-multiple: true
-
-      # The published -unsigned assets are byte-identical to the files signed
-      # below by construction: the signing job's inputs ARE the unsigned
-      # artifacts (BYO signing, Deliverable 1).
-      - name: Stage exes for signing
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          New-Item -Path dist -ItemType Directory -Force | Out-Null
-          foreach ($component in @("agent", "backup", "watchdog", "user-helper")) {
-            $src = "dist-unsigned\breeze-$component-windows-amd64-unsigned.exe"
-            if (-not (Test-Path $src)) { throw "missing unsigned input artifact: $src" }
-            Copy-Item $src "dist\breeze-$component-windows-amd64.exe"
-          }
-
+      # The public release no longer Authenticode-signs the agent MSI (see
+      # the removed build-windows-msi job). This publishes the self-host
+      # edition MSI unsigned, built from the exact exes staged above.
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
@@ -515,140 +512,10 @@ jobs:
           "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           wix eula accept wix7
 
-      - name: Validate signing configuration
-        shell: pwsh
-        env:
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          AZURE_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          AZURE_CERT_PROFILE_PROD: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          AZURE_CERT_PROFILE_PRERELEASE: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-        run: |
-          $required = @("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SIGNING_ENDPOINT", "AZURE_SIGNING_ACCOUNT_NAME")
-          foreach ($name in $required) {
-            if ([string]::IsNullOrWhiteSpace((Get-Item "env:$name").Value)) {
-              throw "Missing required signing secret: $name"
-            }
-          }
-
-          $isPrerelease = "${{ contains(github.ref_name, '-') }}" -eq "true"
-          if ($isPrerelease) {
-            if ([string]::IsNullOrWhiteSpace($env:AZURE_CERT_PROFILE_PRERELEASE)) {
-              throw "Missing required signing secret: AZURE_CERT_PROFILE_PRERELEASE"
-            }
-          } else {
-            if ([string]::IsNullOrWhiteSpace($env:AZURE_CERT_PROFILE_PROD)) {
-              throw "Missing required signing secret: AZURE_CERT_PROFILE_PROD"
-            }
-          }
-
-      - name: Azure Login (OIDC)
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
-      - name: Sign Windows EXE (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-agent-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign Windows EXE (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-agent-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign backup EXE (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-backup-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign backup EXE (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-backup-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign watchdog executable (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-watchdog-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign watchdog executable (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-watchdog-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign user-helper EXE (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-user-helper-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign user-helper EXE (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-user-helper-windows-amd64.exe
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Build MSI
+      - name: Build unsigned self-host MSI
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
           $root = $env:GITHUB_WORKSPACE
           $version = "${{ steps.version.outputs.version }}"
           $agentExe = Join-Path $root "dist\breeze-agent-windows-amd64.exe"
@@ -656,98 +523,14 @@ jobs:
           $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
           $userHelperExe = Join-Path $root "dist\breeze-user-helper-windows-amd64.exe"
           $msiPath = Join-Path $root "dist\breeze-agent.msi"
-          & (Join-Path $root "agent\installer\build-msi.ps1") -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -UserHelperExePath $userHelperExe -OutputPath $msiPath
+          & (Join-Path $root "agent\installer\build-msi.ps1") -Edition SelfHost -Version $version -AgentExePath $agentExe -BackupExePath $backupExe -WatchdogExePath $watchdogExe -UserHelperExePath $userHelperExe -OutputPath $msiPath
+          if ($LASTEXITCODE -ne 0) { throw "build-msi.ps1 (SelfHost) failed with exit code $LASTEXITCODE" }
 
-      # Sign the agent MSI (Azure Trusted Signing).
-      - name: Sign MSI (stable profile)
-        if: ${{ !contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PROD }}
-          files: ${{ github.workspace }}\dist\breeze-agent.msi
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Sign MSI (prerelease profile)
-        if: ${{ contains(github.ref_name, '-') }}
-        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
-        with:
-          endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_PRERELEASE }}
-          files: ${{ github.workspace }}\dist\breeze-agent.msi
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-
-      - name: Verify signatures
-        shell: pwsh
-        run: |
-          $targets = @(
-            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-agent-windows-amd64.exe"),
-            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-backup-windows-amd64.exe"),
-            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-watchdog-windows-amd64.exe"),
-            (Join-Path $env:GITHUB_WORKSPACE "dist\breeze-agent.msi")
-          )
-          foreach ($target in $targets) {
-            $sig = Get-AuthenticodeSignature -FilePath $target
-            # Valid = fully trusted chain; UnknownError = signed but Azure Trusted
-            # Signing root cert not yet in local trust store (normal for new accounts)
-            if ($sig.Status -ne "Valid" -and $sig.Status -ne "UnknownError") {
-              throw "Signature validation failed for $target. Status: $($sig.Status)"
-            }
-            if ($sig.Status -eq "UnknownError") {
-              Write-Host "::warning::$target signed but root cert not yet trusted locally (Status: UnknownError). This is normal for new Azure Trusted Signing accounts."
-            }
-            Write-Host "Verified: $target - Status: $($sig.Status) - Signer: $($sig.SignerCertificate.Subject)"
-          }
-
-      - name: Upload signed Windows EXE artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: breeze-agent-windows-amd64
-          path: dist/breeze-agent-windows-amd64.exe
-          overwrite: true
-          retention-days: 30
-
-      # Issue #816: ship the user-helper as a discrete GitHub release asset
-      # so the agent's in-place auto-upgrade can fetch it directly. Pre-#816
-      # the binary was only ever bundled into the MSI installer, which meant
-      # hosts that reached new versions via auto-update never received it
-      # and the HelperLifecycleManager fell through to a
-      # `breeze-agent.exe user-helper` fallback every ~30s.
-      - name: Upload signed Windows user-helper EXE artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: breeze-user-helper-windows-amd64
-          path: dist/breeze-user-helper-windows-amd64.exe
-          overwrite: true
-          retention-days: 30
-
-      - name: Upload Windows MSI artifact
+      - name: Upload unsigned self-host Windows MSI artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: breeze-agent-windows-msi
           path: dist/breeze-agent.msi
-          retention-days: 30
-
-      - name: Upload signed backup EXE artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: breeze-backup-windows-amd64
-          path: dist/breeze-backup-windows-amd64.exe
-          overwrite: true
-          retention-days: 30
-
-      - name: Upload signed watchdog EXE artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: breeze-watchdog-windows-amd64
-          path: dist/breeze-watchdog-windows-amd64.exe
-          overwrite: true
           retention-days: 30
 
   build-macos-agent:
@@ -2026,7 +1809,7 @@ jobs:
   release-integrity-gate:
     name: Release Integrity Gate
     runs-on: ubuntu-latest
-    needs: [build-windows-msi, build-windows-unsigned, build-macos-agent, build-macos-installer-app, sign-windows-tauri, build-viewer-macos, build-helper-macos, package-windows-updater, merge-viewer-update-manifest]
+    needs: [build-windows-unsigned, build-macos-agent, build-macos-installer-app, sign-windows-tauri, build-viewer-macos, build-helper-macos, package-windows-updater, merge-viewer-update-manifest]
     if: ${{ always() && !cancelled() }}
     steps:
       - name: Fail closed when release signing was skipped
@@ -2035,7 +1818,6 @@ jobs:
           GITHUB_REF_VALUE: ${{ github.ref }}
           EVENT_NAME: ${{ github.event_name }}
           SKIP_RELEASE: ${{ inputs.skip_release || false }}
-          BUILD_WINDOWS_MSI_RESULT: ${{ needs.build-windows-msi.result }}
           BUILD_WINDOWS_UNSIGNED_RESULT: ${{ needs.build-windows-unsigned.result }}
           BUILD_MACOS_AGENT_RESULT: ${{ needs.build-macos-agent.result }}
           BUILD_MACOS_INSTALLER_APP_RESULT: ${{ needs.build-macos-installer-app.result }}
@@ -2060,7 +1842,6 @@ jobs:
             fi
           }
 
-          require_success "build-windows-msi" "$BUILD_WINDOWS_MSI_RESULT"
           require_success "build-windows-unsigned" "$BUILD_WINDOWS_UNSIGNED_RESULT"
           require_success "build-macos-agent" "$BUILD_MACOS_AGENT_RESULT"
           require_success "build-macos-installer-app" "$BUILD_MACOS_INSTALLER_APP_RESULT"
@@ -2078,7 +1859,7 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-api, build-web, build-agent, build-windows-msi, build-windows-unsigned, build-macos-agent, build-macos-installer-app, sign-windows-tauri, build-viewer, build-helper, build-viewer-macos, build-helper-macos, merge-viewer-update-manifest, package-windows-updater, release-integrity-gate]
+    needs: [build-api, build-web, build-agent, build-windows-unsigned, build-macos-agent, build-macos-installer-app, sign-windows-tauri, build-viewer, build-helper, build-viewer-macos, build-helper-macos, merge-viewer-update-manifest, package-windows-updater, release-integrity-gate]
     if: >-
       github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v')
@@ -2088,7 +1869,6 @@ jobs:
       && needs.build-agent.result == 'success'
       && needs.release-integrity-gate.result == 'success'
       && needs.build-windows-unsigned.result == 'success'
-      && (needs.build-windows-msi.result == 'success' || needs.build-windows-msi.result == 'skipped')
       && (needs.build-macos-agent.result == 'success' || needs.build-macos-agent.result == 'skipped')
       && (needs.build-macos-installer-app.result == 'success' || needs.build-macos-installer-app.result == 'skipped')
       && (needs.sign-windows-tauri.result == 'success' || needs.sign-windows-tauri.result == 'skipped')
@@ -2226,8 +2006,29 @@ jobs:
           def is_signing_input(name):
               return UNSIGNED_INPUT_RE.match(name) is not None
 
+          # The public pipeline no longer Authenticode-signs any agent-family
+          # Windows artifact (the exes or the MSI) — this is the self-host
+          # edition, unsigned by construction. Evaluated before the generic
+          # extension branches below, which would otherwise classify these as
+          # windows-authenticode-required. Deliberately does NOT cover the
+          # unrelated viewer/helper Tauri MSIs (breeze-viewer-windows.msi,
+          # breeze-helper-windows.msi) — those are still Authenticode-signed
+          # (sign-windows-tauri job, out of scope here) and keep that trust
+          # level. breeze-agent-template.msi is not currently produced by
+          # this workflow (removed by an earlier initiative); nothing to
+          # classify.
+          AGENT_FAMILY_WINDOWS_RE = re.compile(
+              r"^breeze-agent\.msi$"
+              r"|^breeze-(agent|backup|watchdog|user-helper)-windows-amd64\.exe$"
+          )
+
+          def is_agent_family_windows(name):
+              return AGENT_FAMILY_WINDOWS_RE.match(name) is not None
+
           def platform_trust(name):
               if is_signing_input(name):
+                  return "none"
+              if is_agent_family_windows(name):
                   return "none"
               if name.endswith(".msi") or name.endswith(".exe"):
                   return "windows-authenticode-required"
@@ -2250,6 +2051,12 @@ jobs:
                   "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
                   "size": path.stat().st_size,
                   "platformTrust": platform_trust(path.name),
+                  # BYO signing (Deliverable 2): every asset this workflow
+                  # produces is the self-host edition — hosted builds happen
+                  # in a separate, private repository and never reach this
+                  # manifest. See the guard step below for the corresponding
+                  # non-regression check.
+                  "edition": "self-host",
               }
               if is_signing_input(path.name):
                   entry["intendedUse"] = "signing-input"
@@ -2305,6 +2112,18 @@ jobs:
               "breeze-watchdog-darwin-amd64-unsigned",
               "breeze-watchdog-darwin-arm64-unsigned",
           }
+          # Canonical (non "-unsigned") agent-family Windows assets. Unlike
+          # every other non-signing-input asset, these legitimately carry
+          # platformTrust "none" — the public pipeline no longer
+          # Authenticode-signs the agent family at all (Deliverable 2).
+          AGENT_FAMILY_WINDOWS_UNSIGNED = {
+              "breeze-agent.msi",
+              "breeze-agent-windows-amd64.exe",
+              "breeze-backup-windows-amd64.exe",
+              "breeze-watchdog-windows-amd64.exe",
+              "breeze-user-helper-windows-amd64.exe",
+          }
+
           by_name = {a["name"]: a for a in manifest["assets"]}
           missing = EXPECTED_UNSIGNED - set(by_name)
           assert not missing, f"missing unsigned signing-input assets: {sorted(missing)}"
@@ -2314,8 +2133,19 @@ jobs:
                   f"{name}: platformTrust {entry.get('platformTrust')!r} != 'none'"
               assert entry.get("intendedUse") == "signing-input", \
                   f"{name}: intendedUse {entry.get('intendedUse')!r} != 'signing-input'"
+
+          missing_agent_family = AGENT_FAMILY_WINDOWS_UNSIGNED - set(by_name)
+          assert not missing_agent_family, \
+              f"missing unsigned agent-family Windows assets: {sorted(missing_agent_family)}"
+          for name in sorted(AGENT_FAMILY_WINDOWS_UNSIGNED):
+              entry = by_name[name]
+              assert entry.get("platformTrust") == "none", \
+                  f"{name}: platformTrust {entry.get('platformTrust')!r} != 'none' (agent-family Windows assets must be unsigned in the public pipeline)"
+              assert "intendedUse" not in entry, \
+                  f"{name}: canonical agent-family asset must not carry intendedUse (that's reserved for the -unsigned signing-input copies)"
+
           for name, entry in by_name.items():
-              if name in EXPECTED_UNSIGNED:
+              if name in EXPECTED_UNSIGNED or name in AGENT_FAMILY_WINDOWS_UNSIGNED:
                   continue
               assert "-unsigned" not in name, \
                   f"unexpected -unsigned asset outside the expected set: {name}"
@@ -2323,13 +2153,35 @@ jobs:
                   f"{name}: signed-set asset must not carry intendedUse"
               assert entry.get("platformTrust") != "none", \
                   f"{name}: signed-set asset must not have platformTrust 'none'"
+
+          # Every asset this workflow produces is the self-host edition —
+          # hosted builds happen in a separate, private repository.
+          for name, entry in by_name.items():
+              assert entry.get("edition") == "self-host", \
+                  f"{name}: edition {entry.get('edition')!r} != 'self-host'"
+
+          # Gate against any hosted/signed agent artifact leaking into public
+          # assets: no agent-family Windows asset may carry a signed/notarized
+          # platformTrust. (Darwin agent binaries are intentionally out of
+          # scope here — macOS Developer ID signing/notarization is a
+          # separate, unchanged gate; see build-macos-agent.)
+          FORBIDDEN_AGENT_TRUST = {
+              "windows-authenticode-required",
+              "macos-developer-id-notarization-required",
+          }
+          for name in AGENT_FAMILY_WINDOWS_UNSIGNED:
+              entry = by_name[name]
+              assert entry.get("platformTrust") not in FORBIDDEN_AGENT_TRUST, \
+                  f"{name}: agent-family asset carries platformTrust {entry.get('platformTrust')!r} — a hosted/signed agent artifact may have leaked into the public release"
+
           # Signed-set spot checks, one per trust class (classification-order
           # non-regression for the extension branches).
-          assert by_name["breeze-agent.msi"]["platformTrust"] == "windows-authenticode-required"
-          assert by_name["breeze-agent-windows-amd64.exe"]["platformTrust"] == "windows-authenticode-required"
+          assert by_name["breeze-agent.msi"]["platformTrust"] == "none"
+          assert by_name["breeze-agent-windows-amd64.exe"]["platformTrust"] == "none"
           assert by_name["breeze-agent-darwin-arm64"]["platformTrust"] == "macos-developer-id-notarization-required"
           assert by_name["breeze-agent-linux-amd64"]["platformTrust"] == "release-workflow-produced"
-          print(f"OK: {len(EXPECTED_UNSIGNED)} signing-input assets verified; sourceCommit={source_commit}")
+          assert by_name["breeze-viewer-windows.msi"]["platformTrust"] == "windows-authenticode-required"
+          print(f"OK: {len(EXPECTED_UNSIGNED)} signing-input assets + {len(AGENT_FAMILY_WINDOWS_UNSIGNED)} unsigned agent-family Windows assets verified; sourceCommit={source_commit}")
           PY
 
       - name: Sign release artifact manifest
@@ -2498,27 +2350,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sync agent versions to Breeze API
-        if: ${{ !contains(github.ref_name, '-') && vars.BREEZE_API_URL != '' }}
-        env:
-          BREEZE_API_URL: ${{ vars.BREEZE_API_URL }}
-          BREEZE_API_KEY: ${{ secrets.BREEZE_API_KEY }}
-        run: |
-          curl -sf -X POST "${BREEZE_API_URL}/api/v1/agent-versions/sync-github" \
-            -H "Authorization: Bearer ${BREEZE_API_KEY}" \
-            -H "Content-Type: application/json" \
-            || echo "::warning::Agent version sync failed (non-fatal)"
-
   build-binaries-image:
     name: Build & Push Binaries Init Image
     runs-on: ubuntu-latest
-    needs: [build-agent, build-windows-msi, build-macos-agent, sign-windows-tauri, build-viewer, build-helper, build-viewer-macos, build-helper-macos, create-release]
+    needs: [build-agent, build-macos-agent, sign-windows-tauri, build-viewer, build-helper, build-viewer-macos, build-helper-macos, create-release]
     if: >-
       github.ref_type == 'tag'
       && startsWith(github.ref, 'refs/tags/v')
       && !cancelled()
       && needs.build-agent.result == 'success'
-      && (needs.build-windows-msi.result == 'success' || needs.build-windows-msi.result == 'skipped')
       && (needs.build-macos-agent.result == 'success' || needs.build-macos-agent.result == 'skipped')
       && (needs.sign-windows-tauri.result == 'success' || needs.sign-windows-tauri.result == 'skipped')
       && needs.build-viewer.result == 'success'

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -1,6 +1,10 @@
 .PHONY: build build-agent build-desktop-helper build-backup build-all build-all-agent build-all-desktop-helper build-all-backup build-windows-user-helper build-winres build-windows-msi clean test install install-service uninstall-service dev-push dev-push-helper build-watchdog build-watchdog-linux build-watchdog-darwin build-watchdog-windows dev-push-watchdog dev-push-both
 
 VERSION ?= 0.5.0
+# Local-dev targets intentionally keep plain LDFLAGS (self-host by
+# construction — no hostpolicy ldflags are ever injected here). Release
+# builds go through agent/scripts/build-edition.sh instead, which adds the
+# self-host/hosted-* edition rules on top of this same -X main.version= base.
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 
 # Default build for current platform (agent + backup)

--- a/agent/scripts/build-edition.sh
+++ b/agent/scripts/build-edition.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+#
+# build-edition.sh — edition-aware `go build` driver for the Breeze agent
+# binary family (agent, backup, watchdog, user-helper, desktop-helper).
+#
+# Every release/CI go-build call site should route through this script
+# instead of invoking `go build` directly, so the fail-closed edition rules
+# below are enforced in exactly one place rather than duplicated (and
+# potentially drifted) across release.yml, ci.yml, and dev-build-agent.yml.
+#
+# Editions:
+#   self-host     — repo default. BREEZE_ALLOWED_HOSTS must be EMPTY/unset.
+#                    No hostpolicy -X flags are emitted; the build is
+#                    unrestricted (agent/internal/hostpolicy is inert).
+#   hosted-gap    — BREEZE_ALLOWED_HOSTS must be set (non-empty). Emits
+#                    -X .../hostpolicy.allowedHosts=<value>. Existing-fleet
+#                    violations are reported but not hard-enforced.
+#   hosted-strict — same as hosted-gap, plus -X .../hostpolicy.strictMode=1.
+#
+# The self-host / hosted-* checks are deliberately fail-closed in BOTH
+# directions: a self-host build refuses to run if BREEZE_ALLOWED_HOSTS is
+# set (a hosted allowlist must never leak into a public, unsigned artifact),
+# and a hosted-* build refuses to run if it is NOT set (an accidentally-empty
+# allowlist would silently ship an "unrestricted" build under a hosted label).
+#
+# This script never echoes the CONTENTS of BREEZE_ALLOWED_HOSTS. Use
+# --print-ldflags for a dry run that prints the assembled -ldflags string
+# with the host list redacted.
+#
+# Usage:
+#   build-edition.sh --edition self-host|hosted-gap|hosted-strict \
+#     --component agent|backup|watchdog|user-helper|desktop-helper \
+#     --goos GOOS --goarch GOARCH --version VERSION --out PATH \
+#     [--windowsgui] [--print-ldflags]
+#
+# Runs on ubuntu/macos/windows GitHub runners via `shell: bash`.
+
+set -euo pipefail
+
+HOSTPOLICY_PKG="github.com/breeze-rmm/agent/internal/hostpolicy"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: build-edition.sh --edition <self-host|hosted-gap|hosted-strict> \
+         --component <agent|backup|watchdog|user-helper|desktop-helper> \
+         --goos <GOOS> --goarch <GOARCH> --version <VERSION> --out <PATH> \
+         [--windowsgui] [--print-ldflags]
+
+  --edition        Build edition. Controls hostpolicy ldflag injection.
+  --component      Which agent-family binary to build.
+  --goos            GOOS to cross-compile for (exported to the build).
+  --goarch          GOARCH to cross-compile for (exported to the build).
+  --version         Value baked into -X main.version=.
+  --out             Output path for the built binary. Resolved the same way
+                     `go build -C agent -o <PATH>` resolves it: relative to
+                     the agent/ module directory, not the caller's cwd.
+                     Required unless --print-ldflags is given.
+  --windowsgui       Add -H windowsgui to -ldflags (GUI-subsystem builds).
+  --print-ldflags     Dry run: print the assembled -ldflags string, with any
+                     BREEZE_ALLOWED_HOSTS value redacted, and exit without
+                     invoking `go build`. Still enforces the fail-closed
+                     edition rules below.
+
+Environment:
+  BREEZE_ALLOWED_HOSTS   Comma-separated hosted control-plane allowlist.
+                         Required (non-empty) for hosted-gap/hosted-strict;
+                         forbidden (must be empty/unset) for self-host.
+  CGO_ENABLED             Passed through if already set by the caller;
+                         defaults to 0 otherwise.
+EOF
+}
+
+edition=""
+component=""
+goos=""
+goarch=""
+version=""
+out=""
+windowsgui=0
+print_ldflags=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --edition)
+      edition="${2:-}"
+      shift 2
+      ;;
+    --component)
+      component="${2:-}"
+      shift 2
+      ;;
+    --goos)
+      goos="${2:-}"
+      shift 2
+      ;;
+    --goarch)
+      goarch="${2:-}"
+      shift 2
+      ;;
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --out)
+      out="${2:-}"
+      shift 2
+      ;;
+    --windowsgui)
+      windowsgui=1
+      shift
+      ;;
+    --print-ldflags)
+      print_ldflags=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "build-edition.sh: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$edition" in
+  self-host|hosted-gap|hosted-strict) ;;
+  "")
+    echo "build-edition.sh: --edition is required" >&2
+    exit 2
+    ;;
+  *)
+    echo "build-edition.sh: unknown --edition '${edition}' (want self-host, hosted-gap, or hosted-strict)" >&2
+    exit 2
+    ;;
+esac
+
+# Component -> package path map. A function (not an associative array) so
+# this stays portable to bash 3.2, which is still what `shell: bash` can
+# resolve to on some macOS runner images.
+component_package() {
+  case "$1" in
+    agent) echo "./cmd/breeze-agent" ;;
+    backup) echo "./cmd/breeze-backup" ;;
+    watchdog) echo "./cmd/breeze-watchdog" ;;
+    user-helper) echo "./cmd/breeze-user-helper" ;;
+    desktop-helper) echo "./cmd/breeze-desktop-helper" ;;
+    *) return 1 ;;
+  esac
+}
+
+if [ -z "$component" ]; then
+  echo "build-edition.sh: --component is required" >&2
+  exit 2
+fi
+
+pkg_path="$(component_package "$component")" || {
+  echo "build-edition.sh: unknown --component '${component}' (want agent, backup, watchdog, user-helper, or desktop-helper)" >&2
+  exit 2
+}
+
+pkg_dir="${AGENT_DIR}/${pkg_path#./}"
+if [ ! -d "$pkg_dir" ]; then
+  echo "build-edition.sh: package directory for component '${component}' not found: ${pkg_dir}" >&2
+  exit 2
+fi
+
+if [ -z "$goos" ]; then
+  echo "build-edition.sh: --goos is required" >&2
+  exit 2
+fi
+if [ -z "$goarch" ]; then
+  echo "build-edition.sh: --goarch is required" >&2
+  exit 2
+fi
+if [ -z "$version" ]; then
+  echo "build-edition.sh: --version is required" >&2
+  exit 2
+fi
+if [ -z "$out" ] && [ "$print_ldflags" -ne 1 ]; then
+  echo "build-edition.sh: --out is required (unless --print-ldflags is given)" >&2
+  exit 2
+fi
+
+host_var="${BREEZE_ALLOWED_HOSTS:-}"
+
+ldflags="-s -w -X main.version=${version}"
+display_ldflags="-s -w -X main.version=${version}"
+
+case "$edition" in
+  self-host)
+    if [ -n "$host_var" ]; then
+      echo "build-edition.sh: BREEZE_ALLOWED_HOSTS is set but --edition is self-host — refusing to build a public self-host artifact with a hosted allowlist embedded. Unset BREEZE_ALLOWED_HOSTS, or pass --edition hosted-gap/hosted-strict." >&2
+      exit 1
+    fi
+    ;;
+  hosted-gap|hosted-strict)
+    if [ -z "$host_var" ]; then
+      echo "build-edition.sh: --edition ${edition} requires BREEZE_ALLOWED_HOSTS to be set (non-empty) — refusing to build a hosted artifact with no allowlist (would silently ship unrestricted)." >&2
+      exit 1
+    fi
+    ldflags="${ldflags} -X ${HOSTPOLICY_PKG}.allowedHosts=${host_var}"
+    display_ldflags="${display_ldflags} -X ${HOSTPOLICY_PKG}.allowedHosts=<redacted>"
+    if [ "$edition" = "hosted-strict" ]; then
+      ldflags="${ldflags} -X ${HOSTPOLICY_PKG}.strictMode=1"
+      display_ldflags="${display_ldflags} -X ${HOSTPOLICY_PKG}.strictMode=1"
+    fi
+    ;;
+esac
+
+if [ "$windowsgui" -eq 1 ]; then
+  ldflags="${ldflags} -H windowsgui"
+  display_ldflags="${display_ldflags} -H windowsgui"
+fi
+
+if [ "$print_ldflags" -eq 1 ]; then
+  echo "$display_ldflags"
+  exit 0
+fi
+
+: "${CGO_ENABLED:=0}"
+export CGO_ENABLED
+export GOOS="$goos"
+export GOARCH="$goarch"
+
+echo "build-edition.sh: component=${component} edition=${edition} goos=${goos} goarch=${goarch} cgo_enabled=${CGO_ENABLED} out=${out}" >&2
+
+exec go build -C "$AGENT_DIR" -ldflags="$ldflags" -o "$out" "$pkg_path"

--- a/agent/scripts/build-edition_test.sh
+++ b/agent/scripts/build-edition_test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# build-edition_test.sh — exercises the fail-closed edition matrix in
+# build-edition.sh, plus one real self-host build to prove the happy path
+# actually produces a binary. Wired into ci.yml's `test-agent` job as a
+# quick step (no network access beyond the Go module proxy, no GH runner
+# secrets required).
+#
+# Usage: agent/scripts/build-edition_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_EDITION="${SCRIPT_DIR}/build-edition.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+failures=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  failures=$((failures + 1))
+}
+
+pass() {
+  echo "PASS: $*"
+}
+
+# assert_refuses NAME EXPECTED_EXIT_CODE -- runs build-edition.sh with the
+# given args (via stdin-free array expansion below) and asserts it exits
+# non-zero and prints something on stderr — i.e. it refused to build.
+assert_refuses() {
+  local name="$1"
+  shift
+  local out
+  local status=0
+  out="$("${BUILD_EDITION}" "$@" 2>&1)" || status=$?
+  if [ "$status" -eq 0 ]; then
+    fail "${name}: expected non-zero exit, got 0. Output: ${out}"
+    return
+  fi
+  if [ -z "$out" ]; then
+    fail "${name}: refused with no diagnostic output"
+    return
+  fi
+  pass "${name} (exit ${status})"
+}
+
+# --- Refusal matrix -------------------------------------------------------
+
+# self-host + BREEZE_ALLOWED_HOSTS set MUST refuse (a hosted allowlist must
+# never leak into a public self-host build).
+BREEZE_ALLOWED_HOSTS="hosted-a.example" \
+  assert_refuses "self-host refuses when BREEZE_ALLOWED_HOSTS is set" \
+  --edition self-host --component agent --goos linux --goarch amd64 \
+  --version 0.0.0-test --print-ldflags
+
+# hosted-gap without BREEZE_ALLOWED_HOSTS MUST refuse (would silently ship
+# an "unrestricted" build under a hosted label).
+unset BREEZE_ALLOWED_HOSTS || true
+assert_refuses "hosted-gap refuses when BREEZE_ALLOWED_HOSTS is unset" \
+  --edition hosted-gap --component agent --goos linux --goarch amd64 \
+  --version 0.0.0-test --print-ldflags
+
+# hosted-strict without BREEZE_ALLOWED_HOSTS MUST also refuse.
+assert_refuses "hosted-strict refuses when BREEZE_ALLOWED_HOSTS is unset" \
+  --edition hosted-strict --component agent --goos linux --goarch amd64 \
+  --version 0.0.0-test --print-ldflags
+
+# Unknown edition / component must be rejected (usage error, not a silent
+# fallthrough to self-host semantics).
+assert_refuses "unknown --edition is rejected" \
+  --edition bogus --component agent --goos linux --goarch amd64 \
+  --version 0.0.0-test --print-ldflags
+assert_refuses "unknown --component is rejected" \
+  --edition self-host --component bogus --goos linux --goarch amd64 \
+  --version 0.0.0-test --print-ldflags
+
+# --- Happy path: ldflags assembly -----------------------------------------
+
+self_host_ldflags="$("${BUILD_EDITION}" \
+  --edition self-host --component agent --goos linux --goarch amd64 \
+  --version 1.2.3 --print-ldflags)"
+case "$self_host_ldflags" in
+  *hostpolicy*)
+    fail "self-host ldflags must not reference hostpolicy at all: ${self_host_ldflags}"
+    ;;
+  "-s -w -X main.version=1.2.3")
+    pass "self-host ldflags are exactly -s -w -X main.version=1.2.3"
+    ;;
+  *)
+    fail "unexpected self-host ldflags: ${self_host_ldflags}"
+    ;;
+esac
+
+hosted_gap_ldflags="$(BREEZE_ALLOWED_HOSTS="hosted-a.example,hosted-b.example" "${BUILD_EDITION}" \
+  --edition hosted-gap --component agent --goos linux --goarch amd64 \
+  --version 1.2.3 --print-ldflags)"
+case "$hosted_gap_ldflags" in
+  *"hosted-a.example"*|*"hosted-b.example"*)
+    fail "hosted-gap --print-ldflags must redact BREEZE_ALLOWED_HOSTS, got: ${hosted_gap_ldflags}"
+    ;;
+  *"hostpolicy.allowedHosts=<redacted>"*)
+    pass "hosted-gap ldflags carry a redacted allowedHosts flag"
+    ;;
+  *)
+    fail "hosted-gap ldflags missing redacted allowedHosts flag: ${hosted_gap_ldflags}"
+    ;;
+esac
+case "$hosted_gap_ldflags" in
+  *strictMode*)
+    fail "hosted-gap must NOT emit strictMode: ${hosted_gap_ldflags}"
+    ;;
+  *)
+    pass "hosted-gap omits strictMode"
+    ;;
+esac
+
+hosted_strict_ldflags="$(BREEZE_ALLOWED_HOSTS="hosted-a.example" "${BUILD_EDITION}" \
+  --edition hosted-strict --component agent --goos linux --goarch amd64 \
+  --version 1.2.3 --print-ldflags)"
+case "$hosted_strict_ldflags" in
+  *"hostpolicy.strictMode=1"*)
+    pass "hosted-strict ldflags carry strictMode=1"
+    ;;
+  *)
+    fail "hosted-strict ldflags missing strictMode=1: ${hosted_strict_ldflags}"
+    ;;
+esac
+case "$hosted_strict_ldflags" in
+  *"hosted-a.example"*)
+    fail "hosted-strict --print-ldflags must redact BREEZE_ALLOWED_HOSTS, got: ${hosted_strict_ldflags}"
+    ;;
+esac
+
+windowsgui_ldflags="$("${BUILD_EDITION}" \
+  --edition self-host --component user-helper --goos windows --goarch amd64 \
+  --version 1.2.3 --windowsgui --print-ldflags)"
+case "$windowsgui_ldflags" in
+  *"-H windowsgui")
+    pass "--windowsgui appends -H windowsgui"
+    ;;
+  *)
+    fail "expected -H windowsgui at the end of ldflags: ${windowsgui_ldflags}"
+    ;;
+esac
+
+# --- Happy path: real self-host build for the host platform ---------------
+
+host_goos="$(go env GOOS)"
+host_goarch="$(go env GOARCH)"
+built_bin="${TMP_DIR}/breeze-agent-selftest"
+
+if ! "${BUILD_EDITION}" \
+  --edition self-host --component agent \
+  --goos "${host_goos}" --goarch "${host_goarch}" \
+  --version 0.0.0-selftest --out "${built_bin}"; then
+  fail "real self-host build of the agent for ${host_goos}/${host_goarch} failed"
+elif [ ! -s "${built_bin}" ]; then
+  fail "real self-host build did not produce a non-empty binary at ${built_bin}"
+else
+  pass "real self-host build produced a binary for ${host_goos}/${host_goarch}"
+fi
+
+# --- Summary ----------------------------------------------------------------
+
+if [ "$failures" -ne 0 ]; then
+  echo "build-edition_test.sh: ${failures} failure(s)" >&2
+  exit 1
+fi
+echo "build-edition_test.sh: all checks passed"


### PR DESCRIPTION
Two-commit series completing the public side of the release-pipeline edition fork:

1. **Edition-aware build driver** — new `agent/scripts/build-edition.sh` becomes the single `go build` entry point for all 12 workflow call sites (release, CI, dev-build). Fail-closed in both directions: a self-host build refuses to run with a host allowlist present in the environment, and a hosted-* build refuses to run without one, so neither edition can be produced mis-labeled. Includes a refusal-matrix test wired into CI; dry-run output redacts the allowlist.

2. **Self-host artifact publication** — the public release now builds and publishes an unsigned self-host MSI (via the new `-Edition SelfHost` installer parameterization) and unsigned agent-family exes under their canonical artifact names (go-winres-resourced, preserving the #944/#949 guarantees); the agent-family Authenticode signing job is removed from this workflow; the release manifest stamps `edition: "self-host"` on every asset with agent-family Windows artifacts at `platformTrust: "none"`; and the manifest verification gate now fails the release if any asset carries a non-self-host edition or an agent-family asset carries a signed trust level. Viewer/helper signing lanes are unchanged. The agent-versions sync step is removed.

Merge order: after #3349, #3350, and the API edition PR — this one flips the pipeline and should land immediately before the next release is cut.

⚠️ `release.yml` only executes on tags: the workflow-side steps (WiX build, Windows uploads) were validated via actionlint/shellcheck/YAML-parse plus functional tests of the manifest generator/verifier against synthetic assets (including deliberate-failure cases), but the first real execution is the next tag. Plan for a careful watch of that run.

Part of the release-pipeline build-mode hardening series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)