### PR TITLE
fix(api): abort sync on re-signing failure, enforce non-official trust root (BYO signing phase 2 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -848,10 +848,14 @@ COTURN_IMAGE_REF=coturn/coturn:latest
 # BINARY_SOURCE=github
 #
 # BYO signing: pull releases from YOUR signed-release repository instead of the
-# official one (see the "Sign Your Own Agent Packages" guide). When you set
-# this, you MUST also set RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to YOUR release
-# manifest public key — production refuses to boot otherwise.
-# BINARY_GITHUB_REPOSITORY=lanternops/breeze
+# official one (see the "Sign Your Own Agent Packages" guide). When you set this
+# to a non-official repository you MUST also change
+# RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to YOUR release manifest public key
+# (the signing workflow's run summary prints it). Leaving it as the official key
+# is rejected at boot in production: manifests from your repo are signed by your
+# key and could never verify under the official one, so every sync would fail
+# closed and the fleet would silently stay on its current version.
+# BINARY_GITHUB_REPOSITORY=your-org/breeze-selfhost-signing
 #
 # Binary edition:
 #   self-host (default) — today's behavior, unchanged.

--- a/agent/internal/updater/deployment_trustchain_test.go
+++ b/agent/internal/updater/deployment_trustchain_test.go
@@ -1,9 +1,15 @@
 package updater
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -36,6 +42,34 @@ func loadDeploymentManifestFixture(t *testing.T) deploymentManifestFixture {
 		t.Fatalf("parse fixture: %v", err)
 	}
 	return fx
+}
+
+// deploymentFixtureSHA256 pins the exact bytes of the committed fixture.
+//
+// The fixture is the ONLY thing tying the API's re-signing output to what this
+// agent accepts, and it is regenerable by script. Without this, the cheapest
+// way to get a red trust-chain test green is to re-run the generator — which
+// silently converts a broken trust chain into a two-file edit. The same
+// constant is asserted on the TypeScript side, so a legitimate regeneration
+// requires deliberately updating a hash in two languages.
+//
+// If you intentionally changed the fixture: re-run
+//
+//	node scripts/generate-deployment-manifest-fixture.mjs
+//
+// then update this constant AND the matching one in
+// apps/api/src/services/releaseTrustChain.e2e.test.ts.
+const deploymentFixtureSHA256 = "81cd0453706322c83fb127727745a6feecd130356944a1cd9c9aa141317a74bc"
+
+func TestDeploymentSignedManifestFixture_BytesArePinned(t *testing.T) {
+	raw, err := os.ReadFile("testdata/deployment_signed_manifest.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	sum := sha256.Sum256(raw)
+	if got := hex.EncodeToString(sum[:]); got != deploymentFixtureSHA256 {
+		t.Fatalf("fixture bytes changed:\n  got  %s\n  want %s\nRegenerating the fixture is not a fix for a failing trust-chain test — see the comment above.", got, deploymentFixtureSHA256)
+	}
 }
 
 func TestDeploymentSignedManifestFixture_VerifiesUnderPinnedDeploymentKey(t *testing.T) {
@@ -84,8 +118,23 @@ func TestDeploymentSignedManifestFixture_VerifiesUnderPinnedDeploymentKey(t *tes
 func TestDeploymentSignedManifestFixture_RejectedUnderOfficialKeyID(t *testing.T) {
 	// Keyed trust means the deployment signature must NOT verify when the
 	// response claims the embedded official key's ID (P1-UPD-001 semantics).
+	//
+	// With ONLY the deploy key pinned this fails at the key-ID map lookup and
+	// never reaches ed25519.Verify — so it would still pass if the cross-key
+	// fallback loop were reintroduced, i.e. the test would survive its own
+	// regression. Install a REAL (decoy) embedded key under the official ID so
+	// the lookup succeeds and the failure has to come from the signature check
+	// itself. Pinning one under that ID is refused outright by the
+	// shadow-protection in assembleManifestTrustKeys, which is why this goes
+	// through the embedded map.
 	fx := loadDeploymentManifestFixture(t)
 	entry := fx.Entries[0]
+
+	decoyPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate decoy key: %v", err)
+	}
+	installEmbeddedManifestKey(t, "release-artifact-manifest-ed25519", decoyPub)
 
 	u := &Updater{
 		config: &Config{
@@ -100,7 +149,106 @@ func TestDeploymentSignedManifestFixture_RejectedUnderOfficialKeyID(t *testing.T
 		ManifestSignature: entry.SignatureB64,
 		SigningKeyID:      "release-artifact-manifest-ed25519",
 	}
-	if _, err := u.verifyUpdateManifest(info, "9.9.9"); err == nil {
+	_, err = u.verifyUpdateManifest(info, "9.9.9")
+	if err == nil {
 		t.Fatal("expected verification to fail under the official key ID")
+	}
+	if !strings.Contains(err.Error(), "signature verification failed") {
+		t.Fatalf("expected a SIGNATURE failure (proving no cross-key fallback), got: %v", err)
+	}
+}
+
+// The acceptance test above proves the fixture verifies. These prove the
+// verification is load-bearing: without them nothing distinguishes "the
+// signature was checked" from "the code path happened to return nil".
+func TestDeploymentSignedManifestFixture_TamperedInputsRejected(t *testing.T) {
+	fx := loadDeploymentManifestFixture(t)
+	entry := fx.Entries[0]
+
+	base := downloadInfo{
+		URL:               entry.URL,
+		Checksum:          entry.Checksum,
+		Manifest:          entry.Manifest,
+		ManifestSignature: entry.SignatureB64,
+		SigningKeyID:      fx.KeyID,
+	}
+
+	sigBytes, err := base64.StdEncoding.DecodeString(entry.SignatureB64)
+	if err != nil {
+		t.Fatalf("decode fixture signature: %v", err)
+	}
+	flipped := make([]byte, len(sigBytes))
+	copy(flipped, sigBytes)
+	flipped[0] ^= 0xFF
+
+	cases := []struct {
+		name   string
+		mutate func(d *downloadInfo)
+	}{
+		{"manifest byte changed", func(d *downloadInfo) {
+			d.Manifest = strings.Replace(d.Manifest, `"agent"`, `"watchdog"`, 1)
+		}},
+		{"signature bit flipped", func(d *downloadInfo) {
+			d.ManifestSignature = base64.StdEncoding.EncodeToString(flipped)
+		}},
+		{"signature truncated", func(d *downloadInfo) {
+			d.ManifestSignature = base64.StdEncoding.EncodeToString(sigBytes[:len(sigBytes)-1])
+		}},
+		{"signature not base64", func(d *downloadInfo) {
+			d.ManifestSignature = "!!!not-base64!!!"
+		}},
+		{"signature empty", func(d *downloadInfo) {
+			d.ManifestSignature = ""
+		}},
+		{"checksum does not match the signed manifest", func(d *downloadInfo) {
+			d.Checksum = strings.Repeat("0", len(entry.Checksum))
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := &Updater{
+				config: &Config{
+					Component:             "agent",
+					PinnedManifestPubKeys: []string{fx.KeyID + ":" + fx.PublicKeyB64},
+				},
+			}
+			info := base
+			tc.mutate(&info)
+			if _, err := u.verifyUpdateManifest(info, "9.9.9"); err == nil {
+				t.Fatalf("expected rejection for %q", tc.name)
+			}
+		})
+	}
+}
+
+// The vitest side asserts only linux/amd64 and the acceptance test above skips
+// unless an entry matches the host, so on any single CI runner most of the
+// fixture went unchecked. Verify every entry's signature directly — that part
+// is platform-independent.
+func TestDeploymentSignedManifestFixture_AllEntriesVerify(t *testing.T) {
+	fx := loadDeploymentManifestFixture(t)
+	if len(fx.Entries) == 0 {
+		t.Fatal("fixture has no entries")
+	}
+
+	u := &Updater{
+		config: &Config{
+			Component:             "agent",
+			PinnedManifestPubKeys: []string{fx.KeyID + ":" + fx.PublicKeyB64},
+		},
+	}
+	for _, entry := range fx.Entries {
+		name := entry.Platform + "/" + entry.Arch
+		t.Run(name, func(t *testing.T) {
+			// verifyManifestSignature takes the RAW signature bytes.
+			sig, err := base64.StdEncoding.DecodeString(entry.SignatureB64)
+			if err != nil {
+				t.Fatalf("decode signature for %s: %v", name, err)
+			}
+			if err := u.verifyManifestSignature([]byte(entry.Manifest), sig, fx.KeyID); err != nil {
+				t.Fatalf("signature did not verify for %s: %v", name, err)
+			}
+		})
 	}
 }

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -660,7 +660,27 @@ describe('validateConfig', () => {
       );
     });
 
-    it('production: override boots when the trust root is set', () => {
+    it('production: override boots when the trust root is set to the self-hoster key', () => {
+      withEnv(
+        {
+          ...prodBase,
+          BINARY_GITHUB_REPOSITORY: 'acme/breeze-selfhost-signing',
+          // A key that is NOT the official one — what the signing workflow's
+          // run summary actually prints.
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: 'kR2Ql8tXvN4mJ7cB1aZfP0sYuE6dW3gH9iL5nO8rT2A=',
+        },
+        () => {
+          expect(() => validateConfig()).not.toThrow();
+        },
+      );
+    });
+
+    // deploy/.env.example ships the official key as an ACTIVE line directly
+    // above the BINARY_GITHUB_REPOSITORY hint, so repointing while leaving it
+    // in place is the DEFAULT mistake. It used to satisfy the "trust root is
+    // set" rule (which only tested non-empty), boot clean, and then fail every
+    // sync closed — freezing the fleet behind one console.error.
+    it('production: override with ONLY the official key is rejected at boot', () => {
       withEnv(
         {
           ...prodBase,
@@ -668,9 +688,68 @@ describe('validateConfig', () => {
           RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: 'yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=',
         },
         () => {
+          expect(() => validateConfig()).toThrow(/still \(only\) the official Breeze key/);
+        },
+      );
+    });
+
+    it('production: legacy GITHUB_REPO override with ONLY the official key is rejected too', () => {
+      withEnv(
+        {
+          ...prodBase,
+          GITHUB_REPO: 'acme/breeze-selfhost-signing',
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: 'yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=',
+        },
+        () => {
+          expect(() => validateConfig()).toThrow(/still \(only\) the official Breeze key/);
+        },
+      );
+    });
+
+    // Keeping the official key alongside your own is legitimate: it lets an
+    // instance verify official releases during a migration.
+    it('production: override boots when the official key is present ALONGSIDE the self-hoster key', () => {
+      withEnv(
+        {
+          ...prodBase,
+          BINARY_GITHUB_REPOSITORY: 'acme/breeze-selfhost-signing',
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS:
+            'yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=,kR2Ql8tXvN4mJ7cB1aZfP0sYuE6dW3gH9iL5nO8rT2A=',
+        },
+        () => {
           expect(() => validateConfig()).not.toThrow();
         },
       );
+    });
+
+    // The official repository is not an "override" — the official key is
+    // exactly right there, and this must keep booting.
+    it('production: official repository with the official key is unaffected', () => {
+      withEnv(
+        {
+          ...prodBase,
+          BINARY_GITHUB_REPOSITORY: 'lanternops/breeze',
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: 'yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=',
+        },
+        () => {
+          expect(() => validateConfig()).not.toThrow();
+        },
+      );
+    });
+
+    it.each([
+      ['owner/..', 'dot-dot repository segment'],
+      ['owner/.', 'single-dot repository segment'],
+    ])('rejects %s (%s) — the pattern alone allows it', (value) => {
+      withEnv({ ...prodBase, BINARY_GITHUB_REPOSITORY: value }, () => {
+        expect(() => validateConfig()).toThrow(/BINARY_GITHUB_REPOSITORY/);
+      });
+    });
+
+    it('treats an empty legacy GITHUB_REPO as unset (compose always injects the key)', () => {
+      withEnv({ ...prodBase, GITHUB_REPO: '' }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
     });
   });
 

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 import { validateM365CustomerGraphReadRuntimeConfigAtBoot } from '../services/m365ControlPlane/runtimeConfig';
 import { validateM365CustomerGraphActionsRuntimeConfigAtBoot } from '../services/m365ControlPlane/writeActionRuntimeConfig';
 import { validateM365CommunicationsRuntimeConfigAtBoot } from '../services/m365ControlPlane/commsRuntimeConfig';
-import { OFFICIAL_RELEASE_REPOSITORY } from '../services/releaseSource';
+import {
+  OFFICIAL_RELEASE_REPOSITORY,
+  RELEASE_SOURCE_REPOSITORY_SHAPE,
+  isValidReleaseSourceRepository,
+} from '../services/releaseSource';
 import {
   decodePartnerApiCursorSigningKey,
   isRecognizedSelfHostSignal,
@@ -199,6 +203,34 @@ function hasReleaseArtifactManifestPublicKey(data: {
   return Boolean(
     data.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS?.trim()
     || data.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS?.trim()
+  );
+}
+
+// The public trust anchor for OFFICIAL Breeze releases. Also embedded in the
+// agent (agent/internal/updater/updater.go) and shipped uncommented in
+// deploy/.env.example — which is exactly why it needs its own check below.
+const OFFICIAL_RELEASE_MANIFEST_PUBLIC_KEY =
+  'yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=';
+
+// True when every configured manifest key is the official one. A self-hoster
+// pointing BINARY_GITHUB_REPOSITORY at their own signing repo while leaving the
+// shipped official key in place would boot cleanly and then fail EVERY sync
+// closed (their manifest cannot verify under the official key), freezing the
+// fleet behind a single console.error. Catch it at boot instead.
+function hasOnlyOfficialReleaseManifestPublicKey(data: {
+  RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS?: string;
+  BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS?: string;
+}): boolean {
+  const configured = [
+    data.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS,
+    data.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS,
+  ]
+    .flatMap((value) => (value ?? '').split(','))
+    .map((key) => key.trim())
+    .filter(Boolean);
+  return (
+    configured.length > 0
+    && configured.every((key) => key === OFFICIAL_RELEASE_MANIFEST_PUBLIC_KEY)
   );
 }
 
@@ -514,9 +546,11 @@ const envObjectSchema = z
       (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
       z
         .string()
-        .regex(
-          /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/,
-          'BINARY_GITHUB_REPOSITORY must be "owner/repository" ([A-Za-z0-9-]+/[A-Za-z0-9._-]+)',
+        // Shared with the runtime resolver so boot validation and
+        // getReleaseSourceRepository() can never drift apart.
+        .refine(
+          isValidReleaseSourceRepository,
+          `BINARY_GITHUB_REPOSITORY must be ${RELEASE_SOURCE_REPOSITORY_SHAPE}`,
         )
         .optional(),
     ),
@@ -524,9 +558,11 @@ const envObjectSchema = z
       (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
       z
         .string()
-        .regex(
-          /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/,
-          'GITHUB_REPO must be "owner/repository" ([A-Za-z0-9-]+/[A-Za-z0-9._-]+)',
+        // Shared with the runtime resolver so boot validation and
+        // getReleaseSourceRepository() can never drift apart.
+        .refine(
+          isValidReleaseSourceRepository,
+          `GITHUB_REPO must be ${RELEASE_SOURCE_REPOSITORY_SHAPE}`,
         )
         .optional(),
     ),
@@ -1194,6 +1230,24 @@ const envSchema = envObjectSchema
               'BINARY_EDITION=hosted requires RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to be set in production, so any release manifest found in the local binaries volume can be verified before being trusted.',
           });
         }
+      }
+
+      // "NOT the official Breeze key" above has to be enforced, not just
+      // stated. deploy/.env.example ships the official key as an ACTIVE line
+      // directly above the BINARY_GITHUB_REPOSITORY hint, so leaving it in
+      // place while repointing is the default mistake, not an exotic one — and
+      // it fails closed silently at sync time rather than loudly at boot.
+      if (
+        releaseRepositoryOverride &&
+        releaseRepositoryOverride !== OFFICIAL_RELEASE_REPOSITORY &&
+        hasOnlyOfficialReleaseManifestPublicKey(data)
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS'],
+          message:
+            `${releaseRepositoryOverrideKey} points at a non-official release repository, but RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS is still (only) the official Breeze key. Manifests from that repository are signed by YOUR release key and can never verify under the official one, so every sync would fail closed and the fleet would silently stay on its current version. Set it to your own manifest public key — the signing workflow's run summary prints it.`,
+        });
       }
 
       rejectSecretReuse(

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2020,11 +2020,23 @@ async function bootstrap(): Promise<void> {
     console.error('[startup] Binary sync failed (non-fatal in github mode):', err);
   }
 
-  // Boot-time self-test for self-host BINARY_SOURCE=local: round-trip a
-  // synthetic manifest through sign + validate. If this fails, agent updates
-  // would silently 409 at runtime (#625). Fail fast so operators see the
-  // problem during `docker compose up` rather than after agents are stuck.
-  if ((process.env.BINARY_SOURCE || 'github').trim().toLowerCase() === 'local') {
+  // Boot-time self-test for every deployment that signs its own update
+  // manifests: round-trip a synthetic manifest through sign + validate. If this
+  // fails, agent updates would silently 409 at runtime (#625). Fail fast so
+  // operators see the problem during `docker compose up` rather than after
+  // agents are stuck.
+  //
+  // BINARY_SOURCE=local has always signed locally. BYO signing added a second
+  // such path: github mode against an OVERRIDDEN repository re-signs each
+  // update manifest with the per-deployment key, so it depends on exactly this
+  // machinery too. Without covering it, a BYO deployment with a rotated
+  // APP_ENCRYPTION_KEY boots clean, reports healthy, and only fails later when
+  // every re-sign throws mid-sync.
+  const { isOfficialReleaseSource } = await import('./services/releaseSource');
+  const signsOwnManifests =
+    (process.env.BINARY_SOURCE || 'github').trim().toLowerCase() === 'local'
+    || !isOfficialReleaseSource();
+  if (signsOwnManifests) {
     try {
       const { runManifestSelfTest } = await import('./services/binarySync.selftest');
       await runWithSystemDbAccess(async () => {

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -665,9 +665,12 @@ agentVersionRoutes.post(
         resourceType: "agent_version",
         resourceId: result.version,
         resourceName: `v${result.version}`,
-        details: { targets: result.synced },
+        details: { targets: result.synced, failed: result.failed },
       });
 
+      // Partial failures are isolated per component (#816) but must not be
+      // invisible: surface them in the response body so an operator sees a
+      // short registration instead of assuming a clean sync.
       return c.json(result);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -173,6 +173,21 @@ function makeSignedReleaseManifestMulti(
   };
 }
 
+// Sign an arbitrary manifest object with a fresh key. Lets a test mutate a
+// manifest (e.g. downgrade one asset's platformTrust) and still present a
+// VALID signature, so the assertion under test is the trust check rather than
+// the signature check.
+function makeSignedReleaseManifestMultiFrom(manifestObject: unknown) {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  const manifest = Buffer.from(JSON.stringify(manifestObject));
+  return {
+    manifest,
+    signature: Buffer.from(sign(null, manifest, privateKey).toString("base64")),
+    publicKey: publicDer.subarray(publicDer.length - 32).toString("base64"),
+  };
+}
+
 describe("binarySync", () => {
   const originalEnv = process.env;
 
@@ -432,6 +447,118 @@ describe("binarySync", () => {
       expect(insert.signingKeyId).toBe("release-artifact-manifest-ed25519");
       expect(insert.releaseManifest).toBe(signed.manifest.toString("utf8"));
     });
+
+    // A re-signing failure is a deployment-wide fault (rotated
+    // APP_ENCRYPTION_KEY, undecryptable signing key — the #625 class). It used
+    // to be swallowed by the per-target log-and-continue catch around
+    // upsertVersion, so sync returned { synced: [] } and the route answered 200
+    // while the fleet silently stayed on the old version.
+    it("aborts the whole sync when deployment re-signing fails, writing nothing", async () => {
+      process.env.BINARY_GITHUB_REPOSITORY = repo;
+      const asset = Buffer.from("self-hoster signed agent bytes");
+      const signed = makeSignedReleaseManifest(assetName, asset, repo);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+      stubRepoFetch(asset, signed);
+
+      manifestSigningMocks.signManifest.mockRejectedValueOnce(
+        new Error("decryptSecret returned null for active signing key"),
+      );
+
+      await expect(syncFromGitHub()).rejects.toThrow(
+        /decryptSecret returned null/,
+      );
+      expect(dbMocks.insertValues).not.toHaveBeenCalled();
+    });
+
+    it("aborts before any write when ensureActiveSigningKey fails", async () => {
+      process.env.BINARY_GITHUB_REPOSITORY = repo;
+      const asset = Buffer.from("self-hoster signed agent bytes");
+      const signed = makeSignedReleaseManifest(assetName, asset, repo);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+      stubRepoFetch(asset, signed);
+
+      manifestSigningMocks.ensureActiveSigningKey.mockRejectedValueOnce(
+        new Error("encryptSecret returned null for Ed25519 seed"),
+      );
+
+      await expect(syncFromGitHub()).rejects.toThrow(/encryptSecret returned null/);
+      expect(dbMocks.insertValues).not.toHaveBeenCalled();
+    });
+  });
+
+  // AGENT_TARGETS ends with windows/amd64, so a Windows trust failure used to
+  // land after the four linux/darwin agents had already been committed AND
+  // promoted, and it escaped syncFromGitHub before the helper, user-helper and
+  // watchdog loops ran at all — upgraded agents, frozen watchdogs (#1802's
+  // failure mode). All verification now happens before any write.
+  describe("trust failures leave no partial state", () => {
+    it("writes nothing when a late-ordered asset fails the trust check", async () => {
+      const linuxAgent = Buffer.from("linux agent bytes");
+      const windowsAgent = Buffer.from("windows agent bytes");
+      const watchdog = Buffer.from("linux watchdog bytes");
+      const assets = [
+        { name: "breeze-agent-linux-amd64", buffer: linuxAgent },
+        { name: "breeze-agent-windows-amd64.exe", buffer: windowsAgent },
+        { name: "breeze-watchdog-linux-amd64", buffer: watchdog },
+      ];
+      const signed = makeSignedReleaseManifestMulti(assets);
+
+      // Downgrade ONLY the Windows agent's label: a self-hoster whose fork
+      // generates manifests but skips Authenticode signing produces exactly
+      // this. It is the last agent target and the trust assert rejects it.
+      const parsed = JSON.parse(signed.manifest.toString("utf8"));
+      const win = parsed.assets.find(
+        (a: { name: string }) => a.name === "breeze-agent-windows-amd64.exe",
+      );
+      win.platformTrust = "release-workflow-produced";
+      const tampered = makeSignedReleaseManifestMultiFrom(parsed);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = tampered.publicKey;
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          if (url.includes("/releases/latest")) {
+            return new Response(
+              JSON.stringify({
+                tag_name: "v1.2.3",
+                body: "release notes",
+                assets: [
+                  ...assets.map((a) => ({
+                    name: a.name,
+                    browser_download_url: `https://github.com/LanternOps/breeze/releases/download/v1.2.3/${a.name}`,
+                    size: a.buffer.length,
+                  })),
+                  {
+                    name: "release-artifact-manifest.json",
+                    browser_download_url:
+                      "https://github.com/LanternOps/breeze/releases/download/v1.2.3/release-artifact-manifest.json",
+                    size: tampered.manifest.length,
+                  },
+                  {
+                    name: "release-artifact-manifest.json.ed25519",
+                    browser_download_url:
+                      "https://github.com/LanternOps/breeze/releases/download/v1.2.3/release-artifact-manifest.json.ed25519",
+                    size: tampered.signature.length,
+                  },
+                ],
+              }),
+            );
+          }
+          if (url.endsWith("/release-artifact-manifest.json"))
+            return new Response(tampered.manifest);
+          if (url.endsWith("/release-artifact-manifest.json.ed25519"))
+            return new Response(tampered.signature);
+          const hit = assets.find((a) => url.endsWith(a.name));
+          if (hit) return new Response(hit.buffer);
+          return new Response("not found", { status: 404 });
+        }),
+      );
+
+      await expect(syncFromGitHub()).rejects.toThrow(/platform trust|platformTrust/i);
+      // The point of the fix: the four earlier targets are NOT committed, and
+      // the watchdog loop is not silently skipped.
+      expect(dbMocks.insertValues).not.toHaveBeenCalled();
+    });
   });
 
   it("syncs GitHub agent versions from the signed release artifact manifest", async () => {
@@ -480,7 +607,7 @@ describe("binarySync", () => {
 
     const result = await syncFromGitHub();
 
-    expect(result).toEqual({ version: "1.2.3", synced: ["agent:linux/amd64"] });
+    expect(result).toEqual({ version: "1.2.3", synced: ["agent:linux/amd64"], failed: [] });
     expect(dbMocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         version: "1.2.3",

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -810,7 +810,7 @@ export async function syncBinaries(): Promise<void> {
  */
 export async function syncFromGitHub(
   requestedVersion?: string,
-): Promise<{ version: string; synced: string[] }> {
+): Promise<{ version: string; synced: string[]; failed: string[] }> {
   const ghUrl = requestedVersion
     ? `${getReleaseSourceApiBase()}/releases/tags/${requestedVersion}`
     : `${getReleaseSourceApiBase()}/releases/latest`;
@@ -849,184 +849,133 @@ export async function syncFromGitHub(
     ? null
     : await parseChecksumsFallback(release.assets);
 
+  // ------------------------------------------------------------------
+  // Phase 1 — RESOLVE. Verify, trust-check and deployment-sign every asset
+  // before touching the database.
+  //
+  // Everything in this phase throws on failure, aborting the whole sync. That
+  // is deliberate: a manifest that fails signature verification, an asset whose
+  // platformTrust contradicts its name, or an undecryptable deployment signing
+  // key are all deployment-wide faults, not per-target ones. Resolving up front
+  // means such a fault cannot leave agent_versions half-updated — which
+  // previously it did, and asymmetrically: AGENT_TARGETS ends with
+  // windows/amd64, so a bad Windows asset committed and PROMOTED all four
+  // linux/darwin agents and then aborted before the helper, user-helper and
+  // watchdog loops ran at all, freezing watchdogs against upgraded agents.
+  // ------------------------------------------------------------------
+  const componentTargets: {
+    component: string;
+    targets: readonly { goos: string; goarch: string; assetName?: string }[];
+  }[] = [
+    { component: "agent", targets: AGENT_TARGETS },
+    { component: "helper", targets: HELPER_TARGETS },
+    { component: "user-helper", targets: USER_HELPER_TARGETS },
+    { component: "watchdog", targets: WATCHDOG_TARGETS },
+  ];
+
+  const plan: {
+    component: string;
+    platform: string;
+    arch: string;
+    downloadUrl: string;
+    signedMetadata: UpsertMetadata;
+  }[] = [];
+
+  for (const { component, targets } of componentTargets) {
+    for (const target of targets) {
+      const suffix = target.goos === "windows" ? ".exe" : "";
+      const assetName =
+        target.assetName ??
+        `breeze-${component}-${target.goos}-${target.goarch}${suffix}`;
+      const asset = release.assets.find((a) => a.name === assetName);
+      // Legitimate "this release predates that artifact" case — stay silent.
+      if (!asset) continue;
+
+      const metadata = await getReleaseAssetMetadata({
+        asset,
+        trustedManifest,
+        fallbackChecksums,
+        releaseTag: release.tag_name,
+      });
+      if (!metadata) {
+        // Different from `!asset`: the asset IS in the release but its checksum
+        // could not be resolved from the trusted manifest or the fallback
+        // checksums file. An unexpected inconsistency the on-call should see.
+        console.warn(
+          `[binarySync] Missing metadata for ${component} asset (release=${release.tag_name}, asset=${assetName}, component=${component}); skipping`,
+        );
+        continue;
+      }
+
+      const platform = GH_PLATFORM_MAP[target.goos];
+      if (!platform) continue;
+
+      plan.push({
+        component,
+        platform,
+        arch: target.goarch,
+        downloadUrl: asset.browser_download_url,
+        signedMetadata: await applyDeploymentSigning({
+          metadata,
+          version,
+          component,
+          platform,
+          arch: target.goarch,
+          downloadUrl: asset.browser_download_url,
+        }),
+      });
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Phase 2 — COMMIT. Only database writes remain, so a failure here is a
+  // transient/storage fault rather than a trust one. Keep going so one bad
+  // upsert does not strand every other component, but record failures and
+  // raise at the end: returning HTTP 200 with `synced: []` let a fully failed
+  // sync read as success while the fleet silently stayed on the old version.
+  // ------------------------------------------------------------------
   const synced: string[] = [];
+  const failures: string[] = [];
 
-  // Sync agent binaries
-  for (const target of AGENT_TARGETS) {
-    const suffix = target.goos === "windows" ? ".exe" : "";
-    const assetName = `breeze-agent-${target.goos}-${target.goarch}${suffix}`;
-    const asset = release.assets.find((a) => a.name === assetName);
-    if (!asset) continue;
-    const metadata = await getReleaseAssetMetadata({
-      asset,
-      trustedManifest,
-      fallbackChecksums,
-      releaseTag: release.tag_name,
-    });
-    if (!metadata) {
-      // `!asset` above is silent (legitimate "release predates this artifact"
-      // case). `!metadata` is different: the asset IS in the release but its
-      // checksum could not be resolved from the trusted manifest or the
-      // fallback checksums file. That's an unexpected manifest/checksums
-      // inconsistency the on-call should be told about — don't skip silently.
-      console.warn(
-        `[binarySync] Missing metadata for agent asset (release=${release.tag_name}, asset=${assetName}, component=agent); skipping`,
-      );
-      continue;
-    }
-    const platform = GH_PLATFORM_MAP[target.goos];
-    if (!platform) continue;
-
+  for (const entry of plan) {
+    const label = `${entry.component}:${entry.platform}/${entry.arch}`;
     try {
       await upsertVersion(
         version,
-        platform,
-        target.goarch,
-        "agent",
-        asset.browser_download_url,
-        metadata,
+        entry.platform,
+        entry.arch,
+        entry.component,
+        entry.downloadUrl,
+        entry.signedMetadata,
         release.body,
       );
-      synced.push(`agent:${platform}/${target.goarch}`);
+      synced.push(label);
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       console.error(
-        `[binarySync] Failed to upsert agent version for ${platform}/${target.goarch}:`,
-        err instanceof Error ? err.message : err,
+        `[binarySync] Failed to upsert ${entry.component} version for ${entry.platform}/${entry.arch}:`,
+        message,
       );
+      failures.push(`${label} (${message})`);
     }
   }
 
-  // Sync helper binaries
-  for (const target of HELPER_TARGETS) {
-    const asset = release.assets.find((a) => a.name === target.assetName);
-    if (!asset) continue;
-    const metadata = await getReleaseAssetMetadata({
-      asset,
-      trustedManifest,
-      fallbackChecksums,
-      releaseTag: release.tag_name,
-    });
-    if (!metadata) {
-      // See agent loop above: `!metadata` after `!asset` passed indicates an
-      // unexpected manifest/checksums inconsistency, not a missing artifact.
-      console.warn(
-        `[binarySync] Missing metadata for helper asset (release=${release.tag_name}, asset=${target.assetName}, component=helper); skipping`,
-      );
-      continue;
-    }
-    const platform = GH_PLATFORM_MAP[target.goos];
-    if (!platform) continue;
-
-    try {
-      await upsertVersion(
-        version,
-        platform,
-        target.goarch,
-        "helper",
-        asset.browser_download_url,
-        metadata,
-        release.body,
-      );
-      synced.push(`helper:${platform}/${target.goarch}`);
-    } catch (err) {
-      console.error(
-        `[binarySync] Failed to upsert helper version for ${platform}/${target.goarch}:`,
-        err instanceof Error ? err.message : err,
-      );
-    }
-  }
-
-  // Sync user-helper binaries (Windows-only; issue #816). Missing for any
-  // pre-#816 release — `release.assets.find` returns undefined and the loop
-  // body short-circuits. The agent treats a 404 here as non-fatal and falls
-  // back to an agent-only upgrade.
-  for (const target of USER_HELPER_TARGETS) {
-    const asset = release.assets.find((a) => a.name === target.assetName);
-    if (!asset) continue;
-    const metadata = await getReleaseAssetMetadata({
-      asset,
-      trustedManifest,
-      fallbackChecksums,
-      releaseTag: release.tag_name,
-    });
-    if (!metadata) {
-      // See agent loop above: `!metadata` after `!asset` passed indicates an
-      // unexpected manifest/checksums inconsistency, not a missing artifact.
-      console.warn(
-        `[binarySync] Missing metadata for user-helper asset (release=${release.tag_name}, asset=${target.assetName}, component=user-helper); skipping`,
-      );
-      continue;
-    }
-    const platform = GH_PLATFORM_MAP[target.goos];
-    if (!platform) continue;
-
-    try {
-      await upsertVersion(
-        version,
-        platform,
-        target.goarch,
-        "user-helper",
-        asset.browser_download_url,
-        metadata,
-        release.body,
-      );
-      synced.push(`user-helper:${platform}/${target.goarch}`);
-    } catch (err) {
-      console.error(
-        `[binarySync] Failed to upsert user-helper version for ${platform}/${target.goarch}:`,
-        err instanceof Error ? err.message : err,
-      );
-    }
-  }
-
-  // Sync watchdog binaries. Same per-arch asset shape as the agent. Missing for
-  // any release predating the watchdog component being published — the
-  // `release.assets.find` returns undefined and the loop body short-circuits.
-  for (const target of WATCHDOG_TARGETS) {
-    const suffix = target.goos === "windows" ? ".exe" : "";
-    const assetName = `breeze-watchdog-${target.goos}-${target.goarch}${suffix}`;
-    const asset = release.assets.find((a) => a.name === assetName);
-    if (!asset) continue;
-    const metadata = await getReleaseAssetMetadata({
-      asset,
-      trustedManifest,
-      fallbackChecksums,
-      releaseTag: release.tag_name,
-    });
-    if (!metadata) {
-      // See agent loop above: `!metadata` after `!asset` passed indicates an
-      // unexpected manifest/checksums inconsistency, not a missing artifact.
-      console.warn(
-        `[binarySync] Missing metadata for watchdog asset (release=${release.tag_name}, asset=${assetName}, component=watchdog); skipping`,
-      );
-      continue;
-    }
-    const platform = GH_PLATFORM_MAP[target.goos];
-    if (!platform) continue;
-
-    try {
-      await upsertVersion(
-        version,
-        platform,
-        target.goarch,
-        "watchdog",
-        asset.browser_download_url,
-        metadata,
-        release.body,
-      );
-      synced.push(`watchdog:${platform}/${target.goarch}`);
-    } catch (err) {
-      console.error(
-        `[binarySync] Failed to upsert watchdog version for ${platform}/${target.goarch}:`,
-        err instanceof Error ? err.message : err,
-      );
-    }
+  // Registering NOTHING while reporting success is the failure that matters:
+  // the caller (POST /agent-versions/sync-github) answered 200 with an empty
+  // `synced`, so a deployment-wide fault read as a successful sync while the
+  // fleet silently stayed on its previous version. A PARTIAL failure keeps the
+  // per-component isolation #816 relies on (a user-helper upsert failing must
+  // not block the agent) — but it is now reported rather than only logged.
+  if (synced.length === 0 && plan.length > 0) {
+    throw new Error(
+      `GitHub sync registered 0 of ${plan.length} binaries for ${version}: ${failures.join("; ")}`,
+    );
   }
 
   console.log(
     `[binarySync] GitHub sync: registered ${synced.length} binaries (version: ${version})`,
   );
-  return { version, synced };
+  return { version, synced, failed: failures };
 }
 
 /**
@@ -1151,23 +1100,22 @@ async function applyDeploymentSigning(args: {
   };
 }
 
+// `signedMetadata` is produced by applyDeploymentSigning BEFORE this is called.
+// Do not move that call in here: every caller wraps upsertVersion in a
+// log-and-continue catch (a DB upsert failing for one target should not strand
+// the rest), and re-signing failures — a rotated APP_ENCRYPTION_KEY, an
+// undecryptable signing key — must NOT be swallowed by it. Those are
+// deployment-wide faults that have to abort the whole sync loudly, the same way
+// manifest-verification failures already do.
 async function upsertVersion(
   version: string,
   platform: string,
   arch: string,
   component: string,
   downloadUrl: string,
-  metadata: UpsertMetadata,
+  signedMetadata: UpsertMetadata,
   releaseNotes?: string | null,
 ) {
-  const signedMetadata = await applyDeploymentSigning({
-    metadata,
-    version,
-    component,
-    platform,
-    arch,
-    downloadUrl,
-  });
   // Controlled fleet rollout (AGENT_AUTO_PROMOTE=false): register but do not
   // promote. Skip the demote UPDATE, insert isLatest:false, and OMIT isLatest
   // from the conflict `set` so an existing promoted row keeps its target.

--- a/apps/api/src/services/releaseArtifactManifest.test.ts
+++ b/apps/api/src/services/releaseArtifactManifest.test.ts
@@ -341,6 +341,36 @@ describe("releaseArtifactManifest", () => {
         intendedUse: null,
       });
     });
+
+    // assertDistributableReleaseAsset rejects ANY non-null intendedUse
+    // precisely so unknown future values cannot slip through. Coercing a
+    // present-but-non-string value to null defeated that: the asset read as
+    // "no intendedUse" and became registrable and servable, with only the
+    // name regex left as a backstop.
+    it.each([
+      ["a number", 1],
+      ["an array", ["signing-input"]],
+      ["an object", { kind: "signing-input" }],
+      ["a boolean", true],
+    ])(
+      "rejects a manifest whose intendedUse is %s rather than reading it as absent",
+      async (_label, value) => {
+        const asset = Buffer.from("linux agent bytes");
+        const signed = makeSignedManifest({
+          assetName: "breeze-agent-linux-amd64",
+          assetBuffer: asset,
+          assetOverrides: { intendedUse: value as unknown as string },
+        });
+        process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+        await expect(
+          verifyReleaseArtifactManifestAsset({
+            assetName: "breeze-agent-linux-amd64",
+            manifestBytes: signed.manifest,
+            signatureBytes: signed.signature,
+          }),
+        ).rejects.toThrow(/non-string intendedUse/);
+      },
+    );
   });
 
   it("rejects intendedUse signing inputs even when sourceCommit is present", async () => {

--- a/apps/api/src/services/releaseArtifactManifest.ts
+++ b/apps/api/src/services/releaseArtifactManifest.ts
@@ -238,9 +238,25 @@ export async function verifyReleaseArtifactBuffer(args: {
     repository: manifest.repository as string,
     platformTrust:
       typeof entry.platformTrust === "string" ? entry.platformTrust : null,
-    intendedUse: typeof entry.intendedUse === 'string' ? entry.intendedUse : null,
+    intendedUse: readIntendedUse(entry, args.assetName),
     edition: typeof entry.edition === 'string' ? entry.edition : null,
   };
+}
+
+// `intendedUse` is the field that marks Phase 1's unsigned signing inputs, and
+// assertDistributableReleaseAsset treats ANY non-null value as non-distributable
+// precisely so unknown future values cannot slip through. Coercing a
+// present-but-non-string value to null would defeat that: `intendedUse: 1` or
+// `intendedUse: ["signing-input"]` would read as "no intendedUse" and become
+// registrable and servable. Reject the shape instead of silently discarding it.
+function readIntendedUse(entry: { intendedUse?: unknown }, assetName: string): string | null {
+  if (entry.intendedUse === undefined || entry.intendedUse === null) return null;
+  if (typeof entry.intendedUse !== 'string') {
+    throw new Error(
+      `Release artifact manifest has non-string intendedUse for ${assetName} (got ${typeof entry.intendedUse}) — refusing to treat it as absent`,
+    );
+  }
+  return entry.intendedUse;
 }
 
 function selectManifestAsset(args: {
@@ -301,7 +317,7 @@ function selectManifestAsset(args: {
   assertDistributableReleaseAsset({
     assetName: args.assetName,
     platformTrust: typeof entry.platformTrust === 'string' ? entry.platformTrust : null,
-    intendedUse: typeof entry.intendedUse === 'string' ? entry.intendedUse : null,
+    intendedUse: readIntendedUse(entry, args.assetName),
     edition: typeof entry.edition === 'string' ? entry.edition : null,
   });
   if (
@@ -345,7 +361,7 @@ export async function verifyReleaseArtifactManifestAsset(args: {
     repository: manifest.repository as string,
     platformTrust:
       typeof entry.platformTrust === "string" ? entry.platformTrust : null,
-    intendedUse: typeof entry.intendedUse === 'string' ? entry.intendedUse : null,
+    intendedUse: readIntendedUse(entry, args.assetName),
     edition: typeof entry.edition === 'string' ? entry.edition : null,
   };
 }

--- a/apps/api/src/services/releaseAssetTrust.ts
+++ b/apps/api/src/services/releaseAssetTrust.ts
@@ -1,11 +1,30 @@
 /**
- * Positive platform-trust allowlist for release assets (spec 3c).
+ * Platform-trust LABEL-CONSISTENCY guard for release assets (spec 3c).
  *
  * Replaces expected-value-only checking: instead of only failing when a caller
  * happened to pass expectedPlatformTrust, every manifest-verified asset is
  * checked against what its NAME requires, unknown trust vocabulary fails
  * closed, and signing-input assets (Deliverable 1's `-unsigned` uploads with
  * intendedUse: "signing-input") are never distributable.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THIS DOES NOT DO. It never inspects the bytes. Nothing here (or anywhere
+ * else in the API) verifies an Authenticode signature or a notarization ticket.
+ * It compares the manifest's platformTrust LABEL against what the asset's name
+ * implies, so for any manifest produced by the reference generator in
+ * .github/workflows/release.yml it is a tautology — both sides compute the same
+ * value from the same filename by the same rules. It can only fire on a
+ * manifest whose label contradicts its own name.
+ *
+ * That is still worth having: it catches a hand-rolled or partially-implemented
+ * third-party manifest that omits or downgrades the label. But it is NOT
+ * evidence that a binary was signed. A self-hoster whose fork keeps the
+ * manifest-generation step and drops the signing step produces assets that pass
+ * this gate unsigned. The control that actually establishes signing lives in
+ * the producing workflow (the breeze-selfhost-signing template's publish job
+ * requires a per-asset signing attestation before it will emit a *-required
+ * platformTrust); this is the consuming-side sanity check on top of it.
+ * ---------------------------------------------------------------------------
  *
  * The name classifier deliberately mirrors the manifest generator in
  * .github/workflows/release.yml (platform_trust(), ~line 2088) — keep the two

--- a/apps/api/src/services/releaseSource.test.ts
+++ b/apps/api/src/services/releaseSource.test.ts
@@ -57,9 +57,41 @@ describe('releaseSource', () => {
     'owner/repo#frag',
     'owner /repo',
     'https://github.com/owner/repo',
+    // These satisfy the character class — the repo segment allows dots — so
+    // the regex alone does NOT deliver the module's "no path traversal"
+    // promise. `owner/..` builds https://api.github.com/repos/owner/.. which
+    // normalizes to the API root. Not exploitable (the owner class excludes
+    // `/`, `@`, `%` and dots, so one `..` can never reach a second repository,
+    // and every builder uses a literal host) — but a typo'd override must fail
+    // loudly rather than 404 mysteriously.
+    'owner/..',
+    'owner/.',
+    './repo',
+    '../repo',
+    // Other shapes a hand-edited .env can produce.
+    'owner@evil/repo',
+    'owner\n/repo',   // interior newline (a trailing one is legitimately trimmed)
+    'owner/repо', // Cyrillic 'о' homoglyph
+    '/repo',
+    'owner/',
   ])('rejects malformed repository %j', (bad) => {
     process.env.BINARY_GITHUB_REPOSITORY = bad;
     expect(() => getReleaseSourceRepository()).toThrow(/Invalid release source repository/);
+  });
+
+  it('trims surrounding whitespace rather than rejecting it (.env values often carry a trailing newline)', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = '  acme/breeze-selfhost-signing\n';
+    expect(getReleaseSourceRepository()).toBe('acme/breeze-selfhost-signing');
+  });
+
+  it('treats a whitespace-only override as unset (compose always injects the key)', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = '   ';
+    expect(getReleaseSourceRepository()).toBe('lanternops/breeze');
+  });
+
+  it('still accepts a legitimate repository name containing dots', () => {
+    process.env.BINARY_GITHUB_REPOSITORY = 'my-org/breeze.signing.v2';
+    expect(getReleaseSourceRepository()).toBe('my-org/breeze.signing.v2');
   });
 
   it('accepts dots, underscores, and hyphens in the repository name', () => {

--- a/apps/api/src/services/releaseSource.ts
+++ b/apps/api/src/services/releaseSource.ts
@@ -22,6 +22,30 @@ export const OFFICIAL_RELEASE_REPOSITORY = 'lanternops/breeze';
 // reach URL construction (path traversal, query strings, schemes).
 const REPOSITORY_PATTERN = /^[A-Za-z0-9-]+\/[A-Za-z0-9._-]+$/;
 
+// `.` and `..` satisfy the repository character class, so the pattern alone
+// does NOT deliver the "no path traversal" promise above: `owner/..` builds
+// https://api.github.com/repos/owner/.. which normalizes to the API root. Not
+// exploitable (the owner class excludes `/`, `@`, `%` and dots, so a single
+// `..` can never reach a second repository, and every builder uses a literal
+// host) — but the guard should mean what it says, and a typo'd override should
+// fail loudly rather than 404 mysteriously.
+const DOTS_ONLY_SEGMENT = /^\.+$/;
+
+/**
+ * Single source of truth for release-source repository validation. Imported by
+ * config/validate.ts so boot-time validation and runtime resolution cannot
+ * drift — a tightening applied to only one of them would let a value pass boot
+ * and then throw mid-sync.
+ */
+export function isValidReleaseSourceRepository(value: string): boolean {
+  if (!REPOSITORY_PATTERN.test(value)) return false;
+  // The pattern guarantees exactly one slash with non-empty sides.
+  return value.split('/').every((segment) => !DOTS_ONLY_SEGMENT.test(segment));
+}
+
+export const RELEASE_SOURCE_REPOSITORY_SHAPE =
+  '"owner/repository" matching [A-Za-z0-9-]+/[A-Za-z0-9._-]+ (no "." or ".." segments)';
+
 let legacyGithubRepoWarned = false;
 
 export function getReleaseSourceRepository(): string {
@@ -44,9 +68,9 @@ export function getReleaseSourceRepository(): string {
     repository = legacy;
   }
 
-  if (!REPOSITORY_PATTERN.test(repository)) {
+  if (!isValidReleaseSourceRepository(repository)) {
     throw new Error(
-      `Invalid release source repository "${repository}": expected "owner/repository" matching [A-Za-z0-9-]+/[A-Za-z0-9._-]+`,
+      `Invalid release source repository "${repository}": expected ${RELEASE_SOURCE_REPOSITORY_SHAPE}`,
     );
   }
   return repository;

--- a/apps/api/src/services/releaseTrustChain.e2e.test.ts
+++ b/apps/api/src/services/releaseTrustChain.e2e.test.ts
@@ -90,6 +90,27 @@ function signManifestBytes(
   return Buffer.from(sign(null, manifest, privateKey).toString('base64'));
 }
 
+// Pins the exact bytes of the committed Go fixture. Mirrors
+// deploymentFixtureSHA256 in
+// agent/internal/updater/deployment_trustchain_test.go.
+//
+// The fixture is the only thing tying this API's re-signing output to what the
+// shipped agent accepts, and it is regenerable by script — so without a pin,
+// the cheapest way to green a red trust-chain test is to re-run the generator,
+// silently turning a broken trust chain into a two-file edit. Requiring the
+// hash to be updated in TWO languages makes that a deliberate act.
+const DEPLOYMENT_FIXTURE_SHA256 =
+  '81cd0453706322c83fb127727745a6feecd130356944a1cd9c9aa141317a74bc';
+
+it('the committed Go fixture bytes are pinned (regenerating is not a fix)', () => {
+  const fixturePath = path.join(
+    REPO_ROOT,
+    'agent/internal/updater/testdata/deployment_signed_manifest.json',
+  );
+  const actual = createHash('sha256').update(readFileSync(fixturePath)).digest('hex');
+  expect(actual).toBe(DEPLOYMENT_FIXTURE_SHA256);
+});
+
 describe('trust-chain E2E: official key → self-hoster release key → deployment key (spec 3b/3c)', () => {
   const originalEnv = process.env;
   const REPO = 'acme/breeze-selfhost-signing';

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -101,8 +101,11 @@ MFA_RECOVERY_CODE_PEPPER=
 # embedded in the agent and CI); leave it as-is unless you sign your own binaries.
 RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=
 # BYO signing: override the release repository (default lanternops/breeze).
-# Requires RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to be YOUR release key.
-# BINARY_GITHUB_REPOSITORY=lanternops/breeze
+# If you set this, you MUST replace the RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS
+# value above with YOUR release manifest public key. Leaving the official key in
+# place is rejected at boot in production — your repo's manifests can never
+# verify under it, so every sync would fail closed and the fleet would freeze.
+# BINARY_GITHUB_REPOSITORY=your-org/breeze-selfhost-signing
 # Binary edition served by this deployment: self-host (default) or hosted.
 # hosted requires BINARY_SOURCE=local and RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS
 # in production — see .env.example at the repo root for details.


### PR DESCRIPTION
Follow-up to #3330, which merged before these review findings could be folded in. One Critical and three High issues, all confirmed against the merged code.

## Critical — a re-signing failure was swallowed and the sync reported success

`applyDeploymentSigning` ran inside `upsertVersion`, which every sync loop wraps in a log-and-continue catch. That catch pre-dated #3330 (its job was one Drizzle upsert failing for one target, per #816), but re-signing throws on a different class entirely: a rotated `APP_ENCRYPTION_KEY` or an undecryptable signing key — the #625 failure mode.

Every target then threw identically, `synced` stayed empty, `POST /agent-versions/sync-github` returned **200**, and the audit row recorded `targets: []`. `agent_versions` kept its pre-repoint rows as `isLatest` while downloads already redirected to the self-hoster's repo: a fleet-wide stuck upgrade loop, reported as success at every layer.

Note the asymmetry it introduced — manifest *verification* is deliberately called outside that try so a bad signature aborts loudly. Re-signing got the opposite treatment.

## High — a trust-label failure aborted mid-loop, leaving partial state

`getReleaseAssetMetadata` is called uncaught, and `AGENT_TARGETS` ends with `windows/amd64`. One mislabeled Windows asset committed **and promoted** all four linux/darwin agents, then escaped `syncFromGitHub` before the helper, user-helper and watchdog loops ran at all — upgraded agents against frozen watchdogs, which is #1802's failure mode.

Both are fixed by splitting `syncFromGitHub` into **resolve-then-commit**. Phase 1 verifies, trust-checks and deployment-signs every asset before any database write, so a deployment-wide fault cannot produce a partial state. Phase 2 only writes, and keeps the per-component isolation #816 relies on — but a run that registers **nothing** while candidates existed now throws instead of returning 200, and partial failures are returned and audited rather than only logged. This also collapses four near-identical loops into one.

## High — the boot self-test only ran in `BINARY_SOURCE=local`

BYO github-mode re-signs every update manifest with the per-deployment key, so it depends on exactly the machinery `runManifestSelfTest` guards. Without it, a BYO deployment with a broken `APP_ENCRYPTION_KEY` booted clean, reported healthy, and hit the Critical above at runtime. Now gated on `local || !isOfficialReleaseSource()`.

## High — the production trust-root rule was satisfied by the official key

It only tested non-empty, while its own message said *"(NOT the official Breeze key)"*. `deploy/.env.example` ships that key as an **active** line directly above the `BINARY_GITHUB_REPOSITORY` hint, so repointing while leaving it in place was the *default* mistake: boot succeeded, then every sync failed closed and the fleet silently froze behind one `console.error`.

Now rejected at boot when the override is non-official and the official key is the **only** one configured. Keeping it alongside your own stays valid — that's a legitimate migration state. Both `.env.example` files corrected; the root one claimed "production refuses to boot otherwise", which was not true.

## Also

- Non-string `intendedUse` coerced to `null` and bypassed the "any intendedUse is non-distributable" gate, leaving only the name regex. Now rejected outright.
- `owner/..` and `owner/.` passed the repository pattern, contradicting the module's own "no path traversal" comment. **Not exploitable** — the owner class excludes the characters needed to reach another host or repository — but a typo'd override should fail loudly. The validator is now shared with `config/validate.ts` instead of the regex being copy-pasted there twice, so the two cannot drift.
- `releaseAssetTrust`'s docstring oversold it: it compares the manifest's *label* against what the filename implies, never inspects bytes, and for any reference-generated manifest it is a tautology. Documented as the label-consistency guard it is, pointing at where signing is actually established (the template's publish job now requires a per-asset signing attestation — #3331).

## Tests

- Re-signing failure (both `signManifest` and `ensureActiveSigningKey`) aborts the sync and writes nothing; a late-ordered trust failure writes nothing at all.
- **The Go rejection test asserted key-ID-unknown, not signature rejection** — it died at the map lookup and would have survived reintroduction of the cross-key fallback it exists to prevent. It now installs a decoy embedded key under the official ID so the lookup succeeds and the failure must come from `ed25519.Verify`, asserted on the message.
- Added Go tamper cases (mutated manifest, flipped/truncated/non-base64/empty signature, mismatched checksum). Verification was real, but nothing locked it.
- **All five fixture entries now have their signatures verified.** Previously vitest checked only `linux/amd64` and the Go test skipped unless the entry matched the host, so exactly one entry was exercised per runner.
- The fixture is regenerable by script, so a red trust-chain test was cheapest to green by re-running the generator. Its SHA-256 is now pinned in **both** languages; a legitimate regeneration takes a deliberate two-language edit.
- Adversarial repository rows (dot segments, `@`, homoglyph, interior newline) and the legacy `GITHUB_REPO` empty-as-unset case.
- `validate.test.ts` used the official key as its "trust root is set" fixture, inadvertently encoding the bug. Corrected, with regression tests for both vars and for the official-alongside-own case.

## Verification

`apps/api` 21,010 passed / 0 failed · `tsc --noEmit` clean · `go test -race ./internal/updater/...` green · `gofmt` and `go vet` clean. Re-verified after rebasing onto post-merge `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)