### PR TITLE
feat(api): edition-aware release sources, BINARY_EDITION mode, agent_versions edition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -853,6 +853,16 @@ COTURN_IMAGE_REF=coturn/coturn:latest
 # manifest public key — production refuses to boot otherwise.
 # BINARY_GITHUB_REPOSITORY=lanternops/breeze
 #
+# Binary edition:
+#   self-host (default) — today's behavior, unchanged.
+#   hosted — this deployment serves privately-distributed binaries only. In
+#            production this REQUIRES BINARY_SOURCE=local and
+#            RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to be set; the deployment
+#            refuses to boot otherwise, and local binary-sync fallbacks that
+#            would otherwise reach out to the public GitHub release are
+#            disabled. Not relevant to self-hosted deployments.
+# BINARY_EDITION=self-host
+#
 # Controlled agent-fleet rollout. Default true: registering/syncing a release
 # immediately becomes the fleet upgrade target (agent_versions.isLatest). Set
 # false to decouple registration from promotion — new binaries are downloadable

--- a/apps/api/migrations/2026-08-10-agent-versions-edition.sql
+++ b/apps/api/migrations/2026-08-10-agent-versions-edition.sql
@@ -1,0 +1,19 @@
+-- Agent build editions ("self-host" vs "hosted") coexisting side-by-side in
+-- agent_versions. The public GitHub release now carries the self-host build
+-- (possibly unsigned) while a hosted deployment distributes its own build
+-- privately; each server only serves/promotes rows matching its own
+-- BINARY_EDITION (see services/binaryEdition.ts). Existing rows backfill to
+-- 'self-host' via the column default (single-pass, no table rewrite).
+ALTER TABLE agent_versions ADD COLUMN IF NOT EXISTS edition varchar(20) NOT NULL DEFAULT 'self-host';
+
+-- Widen the uniqueness constraint to include edition so the same
+-- (version, platform, architecture, component) can be registered once per
+-- edition instead of colliding.
+DO $$ BEGIN
+  ALTER TABLE agent_versions DROP CONSTRAINT IF EXISTS agent_versions_version_platform_arch_component_unique;
+  ALTER TABLE agent_versions DROP CONSTRAINT IF EXISTS agent_versions_version_platform_arch_component_edition_unique;
+  ALTER TABLE agent_versions ADD CONSTRAINT agent_versions_version_platform_arch_component_edition_unique
+    UNIQUE (version, platform, architecture, component, edition);
+END $$;
+
+CREATE INDEX IF NOT EXISTS agent_versions_edition_idx ON agent_versions (edition);

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -674,6 +674,86 @@ describe('validateConfig', () => {
     });
   });
 
+  describe('BINARY_EDITION (hosted fail-closed)', () => {
+    const prodBase = {
+      ...validEnv,
+      NODE_ENV: 'production' as const,
+      CORS_ALLOWED_ORIGINS: 'https://app.breeze.io',
+      TRUST_PROXY_HEADERS: 'true',
+    };
+
+    it('default (unset) boots unchanged in development', () => {
+      withEnv(validEnv, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+
+    it('default (unset) boots unchanged in production', () => {
+      withEnv(prodBase, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+
+    it('BINARY_EDITION=self-host boots unchanged in production', () => {
+      withEnv({ ...prodBase, BINARY_EDITION: 'self-host' }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+
+    it('BINARY_EDITION=hosted has no effect in development (production-only rule)', () => {
+      withEnv({ ...validEnv, BINARY_EDITION: 'hosted', BINARY_SOURCE: 'github' }, () => {
+        expect(() => validateConfig()).not.toThrow();
+      });
+    });
+
+    it('production: BINARY_EDITION=hosted with BINARY_SOURCE=github refuses to boot', () => {
+      withEnv(
+        { ...prodBase, BINARY_EDITION: 'hosted', BINARY_SOURCE: 'github' },
+        () => {
+          expect(() => validateConfig()).toThrow(/BINARY_EDITION=hosted requires BINARY_SOURCE=local/);
+        },
+      );
+    });
+
+    it('production: BINARY_EDITION=hosted with BINARY_SOURCE unset (defaults to github) refuses to boot', () => {
+      withEnv(
+        { ...prodBase, BINARY_EDITION: 'hosted' },
+        () => {
+          expect(() => validateConfig()).toThrow(/BINARY_EDITION=hosted requires BINARY_SOURCE=local/);
+        },
+      );
+    });
+
+    it('production: BINARY_EDITION=hosted with BINARY_SOURCE=local but no manifest trust root refuses to boot', () => {
+      withEnv(
+        {
+          ...prodBase,
+          BINARY_EDITION: 'hosted',
+          BINARY_SOURCE: 'local',
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: '',
+          BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: '',
+        },
+        () => {
+          expect(() => validateConfig()).toThrow(/BINARY_EDITION=hosted requires RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS/);
+        },
+      );
+    });
+
+    it('production: BINARY_EDITION=hosted with BINARY_SOURCE=local and a trust root boots cleanly', () => {
+      withEnv(
+        {
+          ...prodBase,
+          BINARY_EDITION: 'hosted',
+          BINARY_SOURCE: 'local',
+          RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: 'yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTso=',
+        },
+        () => {
+          expect(() => validateConfig()).not.toThrow();
+        },
+      );
+    });
+  });
+
   describe('AGENT_BACKUP_SERVER_URL', () => {
     it('accepts a valid https URL', () => {
       withEnv({ ...validEnv, AGENT_BACKUP_SERVER_URL: 'https://new.example.com' }, () => {

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -500,6 +500,11 @@ const envObjectSchema = z
     BREEZE_BOOTSTRAP_ADMIN_PASSWORD: z.string().optional(),
     BREEZE_BOOTSTRAP_ADMIN_NAME: z.string().optional(),
     BINARY_SOURCE: z.string().optional(),
+    // "self-host" (default, today's behavior) | "hosted". A hosted deployment
+    // must fail closed onto local binaries rather than ever falling back to
+    // the public GitHub release — see the production validation block below
+    // and services/binaryEdition.ts / services/binarySync.ts.
+    BINARY_EDITION: z.string().optional(),
     // BYO signing (spec 3a): the release-source repository override consumed by
     // services/releaseSource.ts. Empty string means "unset" — both compose
     // files map it as `${BINARY_GITHUB_REPOSITORY:-}`, which always injects the
@@ -1159,6 +1164,36 @@ const envSchema = envObjectSchema
           message:
             `${releaseRepositoryOverrideKey} overrides the release source; production requires RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to be set to the overriding repository's release manifest public key (NOT the official Breeze key).`,
         });
+      }
+
+      // BYO signing edition follow-up: a "hosted" deployment must never serve
+      // binaries pulled from the public GitHub release (that release now
+      // carries the self-host edition, unsigned by default). In production
+      // that only holds if binaries come exclusively from the local volume
+      // (BINARY_SOURCE=local — binarySync.ts's GitHub fallbacks are disabled
+      // for edition=hosted, but the primary BINARY_SOURCE=github sync path
+      // is not, so this is the boot-time backstop) AND a manifest trust root
+      // is configured, so whatever manifest IS found in the local volume can
+      // be verified rather than trusted blindly.
+      const binaryEdition = (data.BINARY_EDITION || 'self-host').trim().toLowerCase();
+      if (binaryEdition === 'hosted') {
+        const binarySourceForEdition = (data.BINARY_SOURCE || 'github').trim().toLowerCase();
+        if (binarySourceForEdition !== 'local') {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['BINARY_SOURCE'],
+            message:
+              'BINARY_EDITION=hosted requires BINARY_SOURCE=local in production — a hosted deployment must never serve binaries fetched from the public GitHub release.',
+          });
+        }
+        if (!hasReleaseArtifactManifestPublicKey(data)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS'],
+            message:
+              'BINARY_EDITION=hosted requires RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to be set in production, so any release manifest found in the local binaries volume can be verified before being trusted.',
+          });
+        }
       }
 
       rejectSecretReuse(

--- a/apps/api/src/db/schema/agentVersions.ts
+++ b/apps/api/src/db/schema/agentVersions.ts
@@ -14,15 +14,22 @@ export const agentVersions = pgTable('agent_versions', {
   releaseNotes: text('release_notes'),
   isLatest: boolean('is_latest').notNull().default(false),
   component: varchar('component', { length: 20 }).notNull().default('agent'), // agent, helper, viewer
+  // Release edition ("self-host" | "hosted"): lets the same version/platform/
+  // arch/component coexist as two distinct binaries (the public self-host
+  // release build vs a privately-distributed hosted build). Each server only
+  // serves/promotes rows matching its own BINARY_EDITION (binaryEdition.ts).
+  edition: varchar('edition', { length: 20 }).notNull().default('self-host'),
   createdAt: timestamp('created_at').defaultNow().notNull()
 }, (table) => ({
-  // Composite unique constraint on (version, platform, architecture, component)
-  versionPlatformArchComponentUnique: unique('agent_versions_version_platform_arch_component_unique').on(
+  // Composite unique constraint on (version, platform, architecture, component, edition)
+  versionPlatformArchComponentUnique: unique('agent_versions_version_platform_arch_component_edition_unique').on(
     table.version,
     table.platform,
     table.architecture,
-    table.component
+    table.component,
+    table.edition
   ),
   // Index on isLatest for fast lookups of latest versions
-  isLatestIdx: index('agent_versions_is_latest_idx').on(table.isLatest)
+  isLatestIdx: index('agent_versions_is_latest_idx').on(table.isLatest),
+  editionIdx: index('agent_versions_edition_idx').on(table.edition)
 }));

--- a/apps/api/src/routes/agentVersions.test.ts
+++ b/apps/api/src/routes/agentVersions.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 import { generateKeyPairSync, sign } from "node:crypto";
 
+// Real eq/and are opaque drizzle-orm SQL AST builders that aren't easy to
+// assert on directly. Spy-wrap them (mirrors binarySync.test.ts) so
+// edition-scoping tests can inspect exactly which columns/values a route
+// built into its WHERE clause, without changing any chain shape the other
+// (unmodified) tests in this file already rely on.
+const drizzleSpies = vi.hoisted(() => ({
+  eq: vi.fn((column: unknown, value: unknown) => ({ __op: "eq", column, value })),
+  and: vi.fn((...clauses: unknown[]) => ({ __op: "and", clauses })),
+}));
+vi.mock("drizzle-orm", async (importActual) => {
+  const actual = await importActual<typeof import("drizzle-orm")>();
+  return { ...actual, eq: drizzleSpies.eq, and: drizzleSpies.and };
+});
+
 vi.mock("../db", () => ({
   runOutsideDbContext: vi.fn((fn) => fn()),
   withDbAccessContext: vi.fn(
@@ -58,9 +72,24 @@ import {
   verifyEd25519ManifestSignature,
 } from "./agentVersions";
 import { db } from "../db";
+import { agentVersions } from "../db/schema";
 import * as manifestSigning from "../services/manifestSigning";
 import { writeRouteAudit } from "../services/auditEvents";
 import { requiredPlatformTrustFor } from "../services/releaseAssetTrust";
+
+// Recursively searches an and()/eq() spy tree (see drizzleSpies above) for an
+// eq(agentVersions.edition, expected) leaf clause.
+function hasEditionClause(node: unknown, expected: string): boolean {
+  if (!node || typeof node !== "object") return false;
+  const n = node as { __op?: string; column?: unknown; value?: unknown; clauses?: unknown[] };
+  if (n.__op === "eq") {
+    return n.column === agentVersions.edition && n.value === expected;
+  }
+  if (n.__op === "and" && Array.isArray(n.clauses)) {
+    return n.clauses.some((c) => hasEditionClause(c, expected));
+  }
+  return false;
+}
 
 function makeSignedReleaseManifest(overrides: Record<string, unknown> = {}) {
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
@@ -130,6 +159,7 @@ describe("agentVersions routes", () => {
     delete process.env.BREEZE_UPDATE_MANIFEST_PUBLIC_KEYS;
     delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
     delete process.env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+    delete process.env.BINARY_EDITION;
     app = new Hono();
     // Inject mock auth context
     app.use(async (c: any, next: any) => {
@@ -148,9 +178,11 @@ describe("agentVersions routes", () => {
   // multiple sequential selects.
   function selectResolving(rows: unknown[]) {
     // `where()` must be awaitable on its own (the promote target-rows query has
-    // no .limit()) AND expose .limit() (the in-tx "current isLatest" lookup).
+    // no .limit()) AND expose .limit() (the in-tx "current isLatest" lookup)
+    // AND expose .orderBy() (the edition-scoped /pinnable query).
     const whereResult: any = Promise.resolve(rows);
     whereResult.limit = vi.fn().mockResolvedValue(rows);
+    whereResult.orderBy = vi.fn().mockResolvedValue(rows);
     return {
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue(whereResult),
@@ -379,6 +411,45 @@ describe("agentVersions routes", () => {
         }),
       );
     });
+
+    it("scopes the target-rows lookup and the tx demote/promote to this server's edition", async () => {
+      process.env.BINARY_EDITION = "hosted";
+
+      const targetRowsWhere = vi.fn().mockResolvedValue([
+        { component: "agent", platform: "linux", architecture: "amd64" },
+      ]);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: targetRowsWhere }),
+      } as any);
+
+      const { tx, txUpdate, updateSet } = makeTx({ version: "0.70.0" });
+      vi.mocked(db.transaction).mockImplementation(
+        async (fn: any) => fn(tx) as any,
+      );
+
+      const res = await app.request("/agent-versions/promote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ version: "0.71.0", component: "agent" }),
+      });
+      delete process.env.BINARY_EDITION;
+
+      expect(res.status).toBe(200);
+      // Pre-tx target-rows lookup scoped to edition=hosted.
+      const targetRowsWhereArg = targetRowsWhere.mock.calls[0]?.[0];
+      expect(hasEditionClause(targetRowsWhereArg, "hosted")).toBe(true);
+
+      // In-tx demote (.set({isLatest:false}).where(...)) and promote
+      // (.set({isLatest:true}).where(...)) share the same mocked `where` fn
+      // (makeTx's updateSet always returns the same object) — both calls
+      // must carry the edition scope.
+      expect(txUpdate).toHaveBeenCalledTimes(2);
+      const sharedWhereMock = updateSet.mock.results[0]?.value.where;
+      expect(sharedWhereMock.mock.calls.length).toBe(2);
+      for (const call of sharedWhereMock.mock.calls) {
+        expect(hasEditionClause(call[0], "hosted")).toBe(true);
+      }
+    });
   });
 
   describe("GET /agent-versions/latest", () => {
@@ -429,6 +500,37 @@ describe("agentVersions routes", () => {
       );
 
       expect(res.status).toBe(404);
+    });
+
+    it("scopes the lookup to this server's own edition (default self-host)", async () => {
+      const whereMock = vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([]),
+      });
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: whereMock }),
+      } as any);
+
+      delete process.env.BINARY_EDITION;
+      await app.request("/agent-versions/latest?platform=linux&arch=amd64");
+
+      const whereArg = whereMock.mock.calls[0]?.[0];
+      expect(hasEditionClause(whereArg, "self-host")).toBe(true);
+    });
+
+    it("scopes the lookup to BINARY_EDITION=hosted when configured", async () => {
+      const whereMock = vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([]),
+      });
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: whereMock }),
+      } as any);
+
+      process.env.BINARY_EDITION = "hosted";
+      await app.request("/agent-versions/latest?platform=linux&arch=amd64");
+      delete process.env.BINARY_EDITION;
+
+      const whereArg = whereMock.mock.calls[0]?.[0];
+      expect(hasEditionClause(whereArg, "hosted")).toBe(true);
     });
 
     it("should reject invalid platform", async () => {
@@ -1178,6 +1280,113 @@ describe("agentVersions routes", () => {
       const body = await res.json();
       expect(body.version).toBe("1.0.0");
       expect(body.platform).toBe("linux");
+    });
+
+    it("defaults edition to this server's own edition (self-host) when omitted", async () => {
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          { id: "ver-ed-1", version: "1.0.0", edition: "self-host", isLatest: false },
+        ]),
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+      delete process.env.BINARY_EDITION;
+      const res = await app.request("/agent-versions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          version: "1.0.0",
+          platform: "linux",
+          architecture: "amd64",
+          downloadUrl: "https://s3.example.com/agent-1.0.0",
+          checksum: "c".repeat(64),
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.edition).toBe("self-host");
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ edition: "self-host" }),
+      );
+    });
+
+    it("accepts an explicit edition and stamps it on the row", async () => {
+      const insertValues = vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          { id: "ver-ed-2", version: "1.0.0", edition: "hosted", isLatest: false },
+        ]),
+      });
+      vi.mocked(db.insert).mockReturnValue({ values: insertValues } as any);
+
+      const res = await app.request("/agent-versions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          version: "1.0.0",
+          platform: "linux",
+          architecture: "amd64",
+          downloadUrl: "https://s3.example.com/agent-1.0.0",
+          checksum: "c".repeat(64),
+          edition: "hosted",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.edition).toBe("hosted");
+      expect(insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ edition: "hosted" }),
+      );
+    });
+
+    it("rejects an unrecognized edition value", async () => {
+      const res = await app.request("/agent-versions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          version: "1.0.0",
+          platform: "linux",
+          architecture: "amd64",
+          downloadUrl: "https://s3.example.com/agent-1.0.0",
+          checksum: "c".repeat(64),
+          edition: "enterprise",
+        }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("scopes the isLatest unset to the same edition on create", async () => {
+      const updateWhere = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(db.update).mockReturnValue({
+        set: vi.fn().mockReturnValue({ where: updateWhere }),
+      } as any);
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([
+            { id: "ver-ed-3", version: "3.0.0", edition: "hosted", isLatest: true },
+          ]),
+        }),
+      } as any);
+
+      const res = await app.request("/agent-versions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          version: "3.0.0",
+          platform: "linux",
+          architecture: "amd64",
+          downloadUrl: "https://s3.example.com/agent-3.0.0",
+          checksum: "e".repeat(64),
+          isLatest: true,
+          edition: "hosted",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const whereArg = updateWhere.mock.calls[0]?.[0];
+      expect(hasEditionClause(whereArg, "hosted")).toBe(true);
     });
 
     it("should unset previous latest when isLatest=true", async () => {

--- a/apps/api/src/routes/agentVersions.ts
+++ b/apps/api/src/routes/agentVersions.ts
@@ -14,8 +14,10 @@ import {
 import { platformAdminMiddleware } from "../middleware/platformAdmin";
 import { writeRouteAudit } from "../services/auditEvents";
 import { syncFromGitHub } from "../services/binarySync";
+import { getBinaryEdition } from "../services/binaryEdition";
 import { PERMISSIONS } from "../services/permissions";
 import { verifyReleaseArtifactManifestAsset } from "../services/releaseArtifactManifest";
+import { EDITION_HOSTED, EDITION_SELF_HOST } from "../services/releaseAssetTrust";
 import { getActivePublicKeys as getActiveDeploymentSigningPubKeys } from "../services/manifestSigning";
 
 // Map Go GOOS / user-facing platform names to DB platform names
@@ -44,6 +46,12 @@ const componentEnum = z.enum([
   "user-helper",
   "watchdog",
 ]);
+
+// Release edition ("self-host" | "hosted"): lets the same version/platform/
+// arch/component be registered twice — once per edition — so a hosted
+// deployment's own build can coexist with the public self-host build. Admin
+// create defaults to this server's own edition when omitted.
+const editionEnum = z.enum([EDITION_SELF_HOST, EDITION_HOSTED]);
 
 const latestQuerySchema = z.object({
   platform: platformEnum,
@@ -74,6 +82,7 @@ const createVersionSchema = z.object({
   releaseNotes: z.string().optional(),
   isLatest: z.boolean().optional().default(false),
   component: componentEnum.optional().default("agent"),
+  edition: editionEnum.optional(),
 });
 
 // Controlled fleet rollout: explicitly promote a registered version to the
@@ -418,6 +427,10 @@ agentVersionRoutes.get(
           eq(agentVersions.architecture, arch),
           eq(agentVersions.component, component),
           eq(agentVersions.isLatest, true),
+          // Each server only serves its own build edition (default
+          // self-host, unchanged for every deployment that never sets
+          // BINARY_EDITION).
+          eq(agentVersions.edition, getBinaryEdition()),
         ),
       )
       .limit(1);
@@ -485,6 +498,8 @@ agentVersionRoutes.get(
           eq(agentVersions.platform, platform),
           eq(agentVersions.architecture, arch),
           eq(agentVersions.component, component),
+          // Each server only serves its own build edition.
+          eq(agentVersions.edition, getBinaryEdition()),
         ),
       )
       .limit(1);
@@ -552,9 +567,12 @@ agentVersionRoutes.post(
   async (c) => {
     const auth = c.get("auth");
     const data = c.req.valid("json");
+    const edition = data.edition ?? getBinaryEdition();
 
     // If this version is marked as latest, unset isLatest for other versions
-    // with the same platform/architecture/component
+    // with the same platform/architecture/component/edition. Scoped by
+    // edition too — otherwise promoting a "self-host" row could demote a
+    // coexisting "hosted" row's isLatest for the same platform/arch/component.
     if (data.isLatest) {
       await db
         .update(agentVersions)
@@ -564,6 +582,7 @@ agentVersionRoutes.post(
             eq(agentVersions.platform, data.platform),
             eq(agentVersions.architecture, data.architecture),
             eq(agentVersions.component, data.component),
+            eq(agentVersions.edition, edition),
             eq(agentVersions.isLatest, true),
           ),
         );
@@ -584,6 +603,7 @@ agentVersionRoutes.post(
         releaseNotes: data.releaseNotes,
         isLatest: data.isLatest ?? false,
         component: data.component,
+        edition,
       })
       .returning();
     if (!newVersion) {
@@ -616,6 +636,7 @@ agentVersionRoutes.post(
         fileSize: newVersion.fileSize ? Number(newVersion.fileSize) : null,
         releaseNotes: newVersion.releaseNotes,
         isLatest: newVersion.isLatest,
+        edition: newVersion.edition,
         createdAt: newVersion.createdAt,
       },
       201,
@@ -679,6 +700,10 @@ agentVersionRoutes.get(
         isLatest: agentVersions.isLatest,
       })
       .from(agentVersions)
+      // Scoped to this server's own build edition — a picker offering a
+      // version string that only exists for the OTHER edition would 404 when
+      // promoted (promote is edition-scoped too, see below).
+      .where(eq(agentVersions.edition, getBinaryEdition()))
       .orderBy(desc(agentVersions.createdAt)); // newest-first drives the dedupe order
 
     // Only the two operator-facing binaries are pinnable (agent, watchdog).
@@ -731,6 +756,7 @@ agentVersionRoutes.get("/", platformAdminMiddleware, async (c) => {
       platform: agentVersions.platform,
       architecture: agentVersions.architecture,
       component: agentVersions.component,
+      edition: agentVersions.edition,
       isLatest: agentVersions.isLatest,
       fileSize: agentVersions.fileSize,
       releaseNotes: agentVersions.releaseNotes,
@@ -740,6 +766,10 @@ agentVersionRoutes.get("/", platformAdminMiddleware, async (c) => {
     .orderBy(desc(agentVersions.createdAt));
 
   return c.json({
+    // Platform-admin diagnostic view: intentionally NOT filtered by this
+    // server's own edition, so an operator can see both editions' registered
+    // rows side by side. Contrast with /pinnable and /promote, which are
+    // scoped to getBinaryEdition() because they drive actual fleet targeting.
     versions: rows.map((r) => ({
       ...r,
       fileSize: r.fileSize != null ? Number(r.fileSize) : null,
@@ -753,6 +783,7 @@ agentVersionRoutes.get("/", platformAdminMiddleware, async (c) => {
         platform: r.platform,
         architecture: r.architecture,
         version: r.version,
+        edition: r.edition,
       })),
   });
 });
@@ -772,8 +803,12 @@ agentVersionRoutes.post(
   zValidator("json", promoteSchema),
   async (c) => {
     const { version, component } = c.req.valid("json");
+    const edition = getBinaryEdition();
 
     // Target rows for this version (optionally narrowed to one component).
+    // Scoped to this server's own edition — promote only ever affects rows
+    // this server actually serves, so it can never flip a coexisting other-
+    // edition row's isLatest as a side effect.
     const targetRows = await db
       .select({
         component: agentVersions.component,
@@ -786,8 +821,12 @@ agentVersionRoutes.post(
           ? and(
               eq(agentVersions.version, version),
               eq(agentVersions.component, component),
+              eq(agentVersions.edition, edition),
             )
-          : eq(agentVersions.version, version),
+          : and(
+              eq(agentVersions.version, version),
+              eq(agentVersions.edition, edition),
+            ),
       );
 
     if (targetRows.length === 0) {
@@ -832,6 +871,7 @@ agentVersionRoutes.post(
               eq(agentVersions.component, t.component),
               eq(agentVersions.platform, t.platform),
               eq(agentVersions.architecture, t.architecture),
+              eq(agentVersions.edition, edition),
               eq(agentVersions.isLatest, true),
             ),
           )
@@ -855,6 +895,7 @@ agentVersionRoutes.post(
               eq(agentVersions.component, t.component),
               eq(agentVersions.platform, t.platform),
               eq(agentVersions.architecture, t.architecture),
+              eq(agentVersions.edition, edition),
               eq(agentVersions.isLatest, true),
             ),
           );
@@ -869,6 +910,7 @@ agentVersionRoutes.post(
               eq(agentVersions.component, t.component),
               eq(agentVersions.platform, t.platform),
               eq(agentVersions.architecture, t.architecture),
+              eq(agentVersions.edition, edition),
             ),
           );
       }

--- a/apps/api/src/services/binaryEdition.test.ts
+++ b/apps/api/src/services/binaryEdition.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getBinaryEdition } from './binaryEdition';
+
+describe('getBinaryEdition', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to self-host when unset', () => {
+    delete process.env.BINARY_EDITION;
+    expect(getBinaryEdition()).toBe('self-host');
+  });
+
+  it('defaults to self-host when set to an empty string', () => {
+    process.env.BINARY_EDITION = '';
+    expect(getBinaryEdition()).toBe('self-host');
+  });
+
+  it('returns hosted when explicitly set', () => {
+    process.env.BINARY_EDITION = 'hosted';
+    expect(getBinaryEdition()).toBe('hosted');
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    process.env.BINARY_EDITION = '  HOSTED  ';
+    expect(getBinaryEdition()).toBe('hosted');
+  });
+
+  it('returns self-host explicitly', () => {
+    process.env.BINARY_EDITION = 'self-host';
+    expect(getBinaryEdition()).toBe('self-host');
+  });
+
+  it('warns once and defaults to self-host for an unrecognized value', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.BINARY_EDITION = 'enterprise';
+    expect(getBinaryEdition()).toBe('self-host');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unrecognized BINARY_EDITION="enterprise"'),
+    );
+  });
+});

--- a/apps/api/src/services/binaryEdition.ts
+++ b/apps/api/src/services/binaryEdition.ts
@@ -1,0 +1,28 @@
+/**
+ * BINARY_EDITION controls which agent-build "edition" this deployment
+ * considers itself to be serving: "self-host" (the public, potentially
+ * unsigned release — default, preserves today's behavior) or "hosted" (a
+ * privately-distributed build that must never fall back onto public GitHub
+ * release assets). See releaseAssetTrust.ts for the manifest-side edition
+ * vocabulary this mirrors.
+ *
+ * Fail-closed by design: BINARY_EDITION=hosted changes behavior in two
+ * places — config/validate.ts (production boot refusal unless
+ * BINARY_SOURCE=local + a manifest trust root are both configured) and
+ * binarySync.ts (local-mode GitHub fallbacks refuse instead of silently
+ * pulling public self-host assets).
+ */
+
+export type BinaryEdition = 'self-host' | 'hosted';
+
+let binaryEditionWarned = false;
+
+export function getBinaryEdition(): BinaryEdition {
+  const raw = (process.env.BINARY_EDITION || 'self-host').trim().toLowerCase();
+  if (raw === 'hosted') return 'hosted';
+  if (raw !== 'self-host' && !binaryEditionWarned) {
+    console.warn(`[binaryEdition] Unrecognized BINARY_EDITION="${raw}", defaulting to "self-host"`);
+    binaryEditionWarned = true;
+  }
+  return 'self-host';
+}

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -532,6 +532,73 @@ describe("binarySync", () => {
     }
   });
 
+  describe("BINARY_EDITION=hosted fail-closed (local-mode GitHub fallbacks)", () => {
+    it("throws instead of falling back to GitHub on a stale binaries volume", async () => {
+      process.env.BINARY_SOURCE = "local";
+      process.env.BINARY_EDITION = "hosted";
+      process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      process.env.BREEZE_VERSION = "0.65.9";
+
+      fsMocks.readFile.mockResolvedValue("0.65.8" as any); // stale: != BREEZE_VERSION
+
+      await expect(syncBinaries()).rejects.toThrow(
+        /BINARY_EDITION=hosted refuses to fall back to the public GitHub release/,
+      );
+      expect(fsMocks.readdir).not.toHaveBeenCalled();
+    });
+
+    it("throws instead of falling back to GitHub when no local agent binaries are found", async () => {
+      process.env.BINARY_SOURCE = "local";
+      process.env.BINARY_EDITION = "hosted";
+      process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.BREEZE_VERSION;
+
+      fsMocks.readFile.mockResolvedValue("0.65.9" as any);
+      fsMocks.readdir.mockResolvedValue([] as any); // empty dir -> no binaries found
+
+      await expect(syncBinaries()).rejects.toThrow(
+        /BINARY_EDITION=hosted refuses to fall back to the public GitHub release/,
+      );
+    });
+
+    it("still falls back to GitHub normally when BINARY_EDITION is self-host (default)", async () => {
+      process.env.BINARY_SOURCE = "local";
+      process.env.BINARY_EDITION = "self-host";
+      process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.BREEZE_VERSION;
+
+      fsMocks.readFile.mockResolvedValue("0.65.9" as any);
+      fsMocks.readdir.mockResolvedValue([] as any);
+
+      const fetchSpy = vi.fn(async (url: string) => {
+        if (url.includes("/releases/latest")) {
+          return new Response(
+            JSON.stringify({
+              tag_name: "v1.2.3",
+              body: "",
+              assets: [
+                {
+                  name: "checksums.txt",
+                  browser_download_url: "https://example.com/checksums.txt",
+                  size: 0,
+                },
+              ],
+            }),
+          );
+        }
+        if (url.endsWith("/checksums.txt")) return new Response("");
+        return new Response("not found", { status: 404 });
+      });
+      vi.stubGlobal("fetch", fetchSpy);
+
+      await expect(syncBinaries()).resolves.toBeUndefined();
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+  });
+
   // #1802: the local-binary path historically registered ONLY the agent
   // component, so self-hosters on BINARY_SOURCE=local never got watchdog
   // auto-update. It now also scans + registers breeze-watchdog-* siblings.

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -77,6 +77,29 @@ function fixturePlatformTrust(name: string): string {
   return requiredPlatformTrustFor(name) ?? "release-workflow-produced";
 }
 
+// fsMocks.readFile now also backs loadOfficialLocalManifestPair's read of
+// release-artifact-manifest.json[.ed25519] at the binaries volume root — a
+// blanket `.mockResolvedValue(versionFileContent)` would make THAT read
+// resolve with the version-file string too, which then fails manifest
+// verification (bad JSON) and (for BINARY_EDITION=hosted tests) becomes
+// fatal. Path-aware: only the BINARY_VERSION_FILE read resolves; the
+// official-manifest pair ENOENTs by default (self-host local-mode unchanged
+// unless a test explicitly stages it — see "official manifest" describe
+// block below).
+function mockReadFileVersionOnly(versionFileContent: string) {
+  fsMocks.readFile.mockImplementation((path: unknown) => {
+    if (
+      typeof path === "string" &&
+      (path.endsWith("release-artifact-manifest.json") ||
+        path.endsWith("release-artifact-manifest.json.ed25519"))
+    ) {
+      const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return Promise.reject(err);
+    }
+    return Promise.resolve(versionFileContent);
+  });
+}
+
 function makeSignedReleaseManifest(
   assetName: string,
   assetBuffer: Buffer,
@@ -494,7 +517,7 @@ describe("binarySync", () => {
 
     fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
     fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
-    fsMocks.readFile.mockResolvedValue("0.65.9" as any);
+    mockReadFileVersionOnly("0.65.9");
 
     await syncBinaries();
 
@@ -540,7 +563,7 @@ describe("binarySync", () => {
       process.env.BINARY_VERSION_FILE = "/fake/version";
       process.env.BREEZE_VERSION = "0.65.9";
 
-      fsMocks.readFile.mockResolvedValue("0.65.8" as any); // stale: != BREEZE_VERSION
+      mockReadFileVersionOnly("0.65.8"); // stale: != BREEZE_VERSION
 
       await expect(syncBinaries()).rejects.toThrow(
         /BINARY_EDITION=hosted refuses to fall back to the public GitHub release/,
@@ -555,7 +578,7 @@ describe("binarySync", () => {
       process.env.BINARY_VERSION_FILE = "/fake/version";
       delete process.env.BREEZE_VERSION;
 
-      fsMocks.readFile.mockResolvedValue("0.65.9" as any);
+      mockReadFileVersionOnly("0.65.9");
       fsMocks.readdir.mockResolvedValue([] as any); // empty dir -> no binaries found
 
       await expect(syncBinaries()).rejects.toThrow(
@@ -570,7 +593,7 @@ describe("binarySync", () => {
       process.env.BINARY_VERSION_FILE = "/fake/version";
       delete process.env.BREEZE_VERSION;
 
-      fsMocks.readFile.mockResolvedValue("0.65.9" as any);
+      mockReadFileVersionOnly("0.65.9");
       fsMocks.readdir.mockResolvedValue([] as any);
 
       const fetchSpy = vi.fn(async (url: string) => {
@@ -609,7 +632,7 @@ describe("binarySync", () => {
       process.env.BINARY_VERSION_FILE = "/fake/version";
       delete process.env.BREEZE_VERSION;
       fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
-      fsMocks.readFile.mockResolvedValue("0.65.9" as any);
+      mockReadFileVersionOnly("0.65.9");
     }
 
     it("registers a component=watchdog row alongside the agent when the binary is present", async () => {
@@ -719,7 +742,7 @@ describe("binarySync", () => {
     process.env.BINARY_VERSION_FILE = "/fake/version";
     process.env.BREEZE_VERSION = "0.99.0"; // expected != on-disk
 
-    fsMocks.readFile.mockResolvedValue("0.65.7" as any);
+    mockReadFileVersionOnly("0.65.7");
 
     // GitHub fallback path will call fetch; make it reject so syncFromGitHub
     // throws and the compound-failure catch fires.
@@ -754,6 +777,195 @@ describe("binarySync", () => {
 
     errorSpy.mockRestore();
     warnSpy.mockRestore();
+  });
+
+  // BYO signing edition follow-up: if release-artifact-manifest.json +
+  // .ed25519 are staged at the binaries volume root (dirname(AGENT_BINARY_DIR),
+  // e.g. /data/binaries next to /data/binaries/agent), local-mode registration
+  // verifies and registers covered assets FROM that manifest — raw bytes +
+  // "release-artifact-manifest-ed25519" key ID — instead of re-signing with
+  // the per-deployment key.
+  describe("official manifest from local dir (BYO signing edition follow-up)", () => {
+    function localAssetChecksum(): string {
+      return createHash("sha256").update("local agent bytes").digest("hex");
+    }
+
+    function makeOfficialLocalManifest(
+      assets: { name: string; sha256: string; size: number; edition?: string }[],
+    ) {
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+      const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString("base64");
+      const manifest = Buffer.from(
+        JSON.stringify({
+          schemaVersion: 1,
+          repository: "LanternOps/breeze",
+          release: "v1.2.3",
+          assets: assets.map((a) => ({
+            name: a.name,
+            sha256: a.sha256,
+            size: a.size,
+            platformTrust: fixturePlatformTrust(a.name),
+            ...(a.edition ? { edition: a.edition } : {}),
+          })),
+        }),
+      );
+      const signature = Buffer.from(sign(null, manifest, privateKey).toString("base64"));
+      return { manifest, signature, publicKey: rawPublicKey };
+    }
+
+    function mockReadFileWithOfficialManifest(
+      versionFileContent: string,
+      manifest: Buffer,
+      signature: Buffer,
+    ) {
+      fsMocks.readFile.mockImplementation((path: unknown) => {
+        if (typeof path === "string" && path.endsWith("release-artifact-manifest.json.ed25519")) {
+          return Promise.resolve(signature);
+        }
+        if (typeof path === "string" && path.endsWith("release-artifact-manifest.json")) {
+          return Promise.resolve(manifest);
+        }
+        return Promise.resolve(versionFileContent);
+      });
+    }
+
+    function setLocalScanEnv() {
+      process.env.BINARY_SOURCE = "local";
+      process.env.AGENT_BINARY_DIR = "/data/binaries/agent";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.BREEZE_VERSION;
+      fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+      fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
+    }
+
+    it("registers a covered asset from the official manifest, not the per-deployment re-sign", async () => {
+      setLocalScanEnv();
+      const checksum = localAssetChecksum();
+      const official = makeOfficialLocalManifest([
+        {
+          name: "breeze-agent-linux-amd64",
+          sha256: checksum,
+          size: 18, // Buffer.byteLength("local agent bytes")
+          edition: "self-host",
+        },
+      ]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+      mockReadFileWithOfficialManifest("0.65.9", official.manifest, official.signature);
+
+      await syncBinaries();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signingKeyId: "release-artifact-manifest-ed25519",
+          releaseManifest: official.manifest.toString("utf8"),
+          edition: "self-host",
+          checksum,
+        }),
+      );
+      // The per-deployment key was never needed for this (fully-covered) asset.
+      expect(manifestSigningMocks.signManifest).not.toHaveBeenCalled();
+    });
+
+    it("falls back to per-deployment re-signing for an asset the official manifest doesn't cover", async () => {
+      setLocalScanEnv();
+      const official = makeOfficialLocalManifest([
+        {
+          name: "breeze-agent-windows-amd64.exe", // does not match the scanned linux binary
+          sha256: "a".repeat(64),
+          size: 999,
+        },
+      ]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+      mockReadFileWithOfficialManifest("0.65.9", official.manifest, official.signature);
+
+      await syncBinaries();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ signingKeyId: "deploy-test-aaaaaaaa" }),
+      );
+      expect(manifestSigningMocks.signManifest).toHaveBeenCalled();
+    });
+
+    it("falls back to per-deployment re-signing when the local checksum disagrees with the manifest", async () => {
+      setLocalScanEnv();
+      const official = makeOfficialLocalManifest([
+        {
+          name: "breeze-agent-linux-amd64",
+          sha256: "b".repeat(64), // deliberately wrong
+          size: 18,
+        },
+      ]);
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+      mockReadFileWithOfficialManifest("0.65.9", official.manifest, official.signature);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await syncBinaries();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ signingKeyId: "deploy-test-aaaaaaaa" }),
+      );
+      expect(
+        errorSpy.mock.calls.some((args) =>
+          String(args[0] ?? "").includes("Checksum mismatch"),
+        ),
+      ).toBe(true);
+      errorSpy.mockRestore();
+    });
+
+    it("self-host: falls back to re-signing and logs an error when the manifest fails signature verification", async () => {
+      setLocalScanEnv();
+      const official = makeOfficialLocalManifest([
+        { name: "breeze-agent-linux-amd64", sha256: localAssetChecksum(), size: 18 },
+      ]);
+      const tamperedManifest = Buffer.from(
+        official.manifest.toString("utf8").replace("v1.2.3", "v9.9.9"),
+      );
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+      mockReadFileWithOfficialManifest("0.65.9", tamperedManifest, official.signature);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(syncBinaries()).resolves.toBeUndefined();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ signingKeyId: "deploy-test-aaaaaaaa" }),
+      );
+      expect(
+        errorSpy.mock.calls.some((args) =>
+          String(args[0] ?? "").includes("Official release manifest found but failed verification"),
+        ),
+      ).toBe(true);
+      errorSpy.mockRestore();
+    });
+
+    it("hosted: a manifest that fails verification is fatal, not a silent fallback", async () => {
+      setLocalScanEnv();
+      process.env.BINARY_EDITION = "hosted";
+      const official = makeOfficialLocalManifest([
+        { name: "breeze-agent-linux-amd64", sha256: localAssetChecksum(), size: 18 },
+      ]);
+      const tamperedManifest = Buffer.from(
+        official.manifest.toString("utf8").replace("v1.2.3", "v9.9.9"),
+      );
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = official.publicKey;
+      mockReadFileWithOfficialManifest("0.65.9", tamperedManifest, official.signature);
+
+      await expect(syncBinaries()).rejects.toThrow(
+        /BINARY_EDITION=hosted requires a valid manifest/,
+      );
+      expect(dbMocks.insertValues).not.toHaveBeenCalled();
+    });
+
+    it("unchanged self-host local mode when no official manifest is staged", async () => {
+      setLocalScanEnv();
+      mockReadFileVersionOnly("0.65.9"); // ENOENTs the manifest pair by design
+
+      await syncBinaries();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ signingKeyId: "deploy-test-aaaaaaaa" }),
+      );
+    });
   });
 
   // Issue #816 / PR #845: syncFromGitHub gained a USER_HELPER_TARGETS loop
@@ -1085,7 +1297,7 @@ describe("binarySync", () => {
 
       fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
       fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
-      fsMocks.readFile.mockResolvedValue("0.70.0" as any);
+      mockReadFileVersionOnly("0.70.0");
 
       await syncBinaries();
 
@@ -1123,7 +1335,7 @@ describe("binarySync", () => {
 
       fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
       fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 4096 } as any);
-      fsMocks.readFile.mockResolvedValue("0.70.0" as any);
+      mockReadFileVersionOnly("0.70.0");
 
       await syncBinaries();
 
@@ -1227,7 +1439,7 @@ describe("binarySync", () => {
 
     fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
     fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
-    fsMocks.readFile.mockResolvedValue("0.65.7" as any);
+    mockReadFileVersionOnly("0.65.7");
 
     await syncBinaries();
 
@@ -1250,7 +1462,7 @@ describe("binarySync", () => {
 
       fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
       fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
-      fsMocks.readFile.mockResolvedValue("0.65.7" as any);
+      mockReadFileVersionOnly("0.65.7");
 
       await syncBinaries();
 
@@ -1268,7 +1480,7 @@ describe("binarySync", () => {
 
       fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
       fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
-      fsMocks.readFile.mockResolvedValue("0.65.7" as any);
+      mockReadFileVersionOnly("0.65.7");
 
       await syncBinaries();
 

--- a/apps/api/src/services/binarySync.test.ts
+++ b/apps/api/src/services/binarySync.test.ts
@@ -1211,13 +1211,15 @@ describe("binarySync", () => {
     });
   });
 
-  it("upserts local agent binaries with the full 4-column conflict target (regression: #617)", async () => {
+  it("upserts local agent binaries with the full 5-column conflict target (regression: #617; extended with edition)", async () => {
     // The agent_versions table has a UNIQUE constraint on
-    // (version, platform, architecture, component). The local-binary path used
-    // to omit `component`, so Postgres rejected the upsert with
+    // (version, platform, architecture, component, edition). The local-binary
+    // path used to omit `component`, so Postgres rejected the upsert with
     // "no unique or exclusion constraint matching the ON CONFLICT
     // specification" and the wrapping transaction rolled back, leaving
-    // agent_versions empty after every API restart.
+    // agent_versions empty after every API restart. `edition` was added
+    // later (BYO signing follow-up) to let two editions of the same version
+    // coexist — the conflict target must include it too.
     process.env.BINARY_SOURCE = "local";
     process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
     process.env.BINARY_VERSION_FILE = "/fake/version";
@@ -1234,7 +1236,181 @@ describe("binarySync", () => {
     );
     expect(targets.length).toBeGreaterThan(0);
     for (const target of targets) {
-      expect(target).toHaveLength(4);
+      expect(target).toHaveLength(5);
     }
+  });
+
+  describe("edition stamping (BYO signing follow-up)", () => {
+    it("stamps local-scan registrations with this server's own BINARY_EDITION", async () => {
+      process.env.BINARY_SOURCE = "local";
+      process.env.BINARY_EDITION = "hosted";
+      process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.BREEZE_VERSION;
+
+      fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+      fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
+      fsMocks.readFile.mockResolvedValue("0.65.7" as any);
+
+      await syncBinaries();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ edition: "hosted" }),
+      );
+    });
+
+    it("defaults local-scan registrations to self-host when BINARY_EDITION is unset", async () => {
+      process.env.BINARY_SOURCE = "local";
+      delete process.env.BINARY_EDITION;
+      process.env.AGENT_BINARY_DIR = "/fake/agent/bin";
+      process.env.BINARY_VERSION_FILE = "/fake/version";
+      delete process.env.BREEZE_VERSION;
+
+      fsMocks.readdir.mockResolvedValue(["breeze-agent-linux-amd64"] as any);
+      fsMocks.stat.mockResolvedValue({ isFile: () => true, size: 1234 } as any);
+      fsMocks.readFile.mockResolvedValue("0.65.7" as any);
+
+      await syncBinaries();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ edition: "self-host" }),
+      );
+    });
+
+    it("stamps a GitHub-sync registration with the manifest asset's edition claim", async () => {
+      const asset = Buffer.from("linux agent bytes");
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+      const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString("base64");
+      const manifest = Buffer.from(
+        JSON.stringify({
+          schemaVersion: 1,
+          repository: "LanternOps/breeze",
+          release: "v1.2.3",
+          assets: [
+            {
+              name: "breeze-agent-linux-amd64",
+              sha256: createHash("sha256").update(asset).digest("hex"),
+              size: asset.length,
+              platformTrust: "release-workflow-produced",
+              edition: "self-host",
+            },
+          ],
+        }),
+      );
+      const signature = Buffer.from(sign(null, manifest, privateKey).toString("base64"));
+
+      process.env.BINARY_SOURCE = "github";
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = rawPublicKey;
+
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url.includes("/releases/latest")) {
+          return new Response(
+            JSON.stringify({
+              tag_name: "v1.2.3",
+              body: "",
+              assets: [
+                {
+                  name: "breeze-agent-linux-amd64",
+                  browser_download_url: "https://example.com/breeze-agent-linux-amd64",
+                  size: asset.length,
+                },
+                {
+                  name: "release-artifact-manifest.json",
+                  browser_download_url: "https://example.com/release-artifact-manifest.json",
+                  size: manifest.length,
+                },
+                {
+                  name: "release-artifact-manifest.json.ed25519",
+                  browser_download_url: "https://example.com/release-artifact-manifest.json.ed25519",
+                  size: signature.length,
+                },
+              ],
+            }),
+          );
+        }
+        if (url.endsWith("release-artifact-manifest.json")) return new Response(manifest);
+        if (url.endsWith("release-artifact-manifest.json.ed25519")) return new Response(signature);
+        if (url.endsWith("breeze-agent-linux-amd64")) return new Response(asset);
+        return new Response("not found", { status: 404 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await syncFromGitHub();
+
+      expect(dbMocks.insertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ edition: "self-host" }),
+      );
+    });
+
+    it("refuses to register a GitHub-sourced asset labeled edition hosted", async () => {
+      const asset = Buffer.from("linux agent bytes");
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+      const publicDer = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+      const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString("base64");
+      const manifest = Buffer.from(
+        JSON.stringify({
+          schemaVersion: 1,
+          repository: "LanternOps/breeze",
+          release: "v1.2.3",
+          assets: [
+            {
+              name: "breeze-agent-linux-amd64",
+              sha256: createHash("sha256").update(asset).digest("hex"),
+              size: asset.length,
+              platformTrust: "release-workflow-produced",
+              edition: "hosted",
+            },
+          ],
+        }),
+      );
+      const signature = Buffer.from(sign(null, manifest, privateKey).toString("base64"));
+
+      process.env.BINARY_SOURCE = "github";
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = rawPublicKey;
+
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url.includes("/releases/latest")) {
+          return new Response(
+            JSON.stringify({
+              tag_name: "v1.2.3",
+              body: "",
+              assets: [
+                {
+                  name: "breeze-agent-linux-amd64",
+                  browser_download_url: "https://example.com/breeze-agent-linux-amd64",
+                  size: asset.length,
+                },
+                {
+                  name: "release-artifact-manifest.json",
+                  browser_download_url: "https://example.com/release-artifact-manifest.json",
+                  size: manifest.length,
+                },
+                {
+                  name: "release-artifact-manifest.json.ed25519",
+                  browser_download_url: "https://example.com/release-artifact-manifest.json.ed25519",
+                  size: signature.length,
+                },
+              ],
+            }),
+          );
+        }
+        if (url.endsWith("release-artifact-manifest.json")) return new Response(manifest);
+        if (url.endsWith("release-artifact-manifest.json.ed25519")) return new Response(signature);
+        if (url.endsWith("breeze-agent-linux-amd64")) return new Response(asset);
+        return new Response("not found", { status: 404 });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      // getReleaseAssetMetadata's edition check runs OUTSIDE the per-asset
+      // try/catch that wraps upsertVersion, so this fails the whole sync call
+      // rather than silently skipping just this asset — a hosted-labeled
+      // asset showing up in a public release manifest is a defense-in-depth
+      // tripwire, not a routine skip.
+      await expect(syncFromGitHub()).rejects.toThrow(
+        /must never be fetched from a public GitHub release/,
+      );
+      expect(dbMocks.insertValues).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir, stat } from "node:fs/promises";
 import { createReadStream } from "node:fs";
 import { createHash } from "node:crypto";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db";
@@ -12,6 +12,7 @@ import { getBinaryEdition } from "./binaryEdition";
 import {
   isReleaseArtifactManifestVerificationConfigured,
   verifyReleaseArtifactManifestAsset,
+  verifyReleaseArtifactManifestIntegrity,
 } from "./releaseArtifactManifest";
 import { EDITION_SELF_HOST, assertGithubFetchableEdition } from "./releaseAssetTrust";
 import { ensureActiveSigningKey, signManifest } from "./manifestSigning";
@@ -418,6 +419,149 @@ async function registerLocalBinaries(args: {
   });
 }
 
+// Official-manifest local registration (BYO signing edition follow-up).
+//
+// AGENT_BINARY_DIR (e.g. /data/binaries/agent) is a subdirectory of the
+// binaries volume root (e.g. /data/binaries — see VIEWER_BINARY_DIR and
+// HELPER_BINARY_DIR, siblings under the same root in docker-compose.yml). If
+// an operator has staged an official release-artifact-manifest.json +
+// release-artifact-manifest.json.ed25519 pair at that root (e.g. by copying
+// them alongside the binaries during their own image build or volume seed),
+// registering FROM that manifest — instead of re-signing a fresh
+// per-deployment manifest — lets self-host agents verify updates against the
+// well-known release key embedded in the agent binary, with zero
+// per-deployment key distribution required.
+function officialManifestPairPaths(agentBinaryDir: string): {
+  manifestPath: string;
+  signaturePath: string;
+} {
+  const root = dirname(resolve(agentBinaryDir));
+  return {
+    manifestPath: join(root, "release-artifact-manifest.json"),
+    signaturePath: join(root, "release-artifact-manifest.json.ed25519"),
+  };
+}
+
+async function loadOfficialLocalManifestPair(
+  agentBinaryDir: string,
+): Promise<{ manifestBytes: Buffer; signatureBytes: Buffer } | null> {
+  const { manifestPath, signaturePath } = officialManifestPairPaths(agentBinaryDir);
+  try {
+    const [manifestBytes, signatureBytes] = await Promise.all([
+      readFile(manifestPath),
+      readFile(signaturePath),
+    ]);
+    return { manifestBytes, signatureBytes };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+// Registers whichever of `binaries` the official manifest actually covers
+// (matched by on-disk filename == manifest asset name), verifying each
+// asset's checksum against the LOCAL file before trusting the manifest's
+// claim for it. Binaries the manifest doesn't cover (or whose local checksum
+// disagrees with it) are left unregistered here — the caller falls back to
+// registerLocalBinaries (deploy-key re-sign) for those.
+async function registerFromOfficialManifest(args: {
+  binaries: BinaryInfo[];
+  component: string;
+  version: string;
+  manifestBytes: Buffer;
+  signatureBytes: Buffer;
+  downloadUrlFor: (osParam: string, arch: string) => string;
+}): Promise<{ registeredFilenames: Set<string> }> {
+  const { binaries, component, version, manifestBytes, signatureBytes, downloadUrlFor } = args;
+  const autoPromote = getAgentAutoPromote();
+  const manifestString = manifestBytes.toString("utf8");
+  const signatureString = signatureBytes.toString("utf8").trim();
+  const registeredFilenames = new Set<string>();
+
+  await db.transaction(async (tx) => {
+    for (const bin of binaries) {
+      let verified;
+      try {
+        verified = await verifyReleaseArtifactManifestAsset({
+          assetName: bin.filename,
+          manifestBytes,
+          signatureBytes,
+        });
+      } catch (err) {
+        console.warn(
+          `[binarySync] Official release manifest does not cover ${bin.filename}: ${err instanceof Error ? err.message : err}`,
+        );
+        continue;
+      }
+
+      if (verified.sha256 !== bin.checksum) {
+        console.error(
+          `[binarySync] Checksum mismatch between the local file and the official release manifest for ${bin.filename} — not registering from the official manifest for this asset`,
+        );
+        continue;
+      }
+
+      const edition = verified.edition ?? EDITION_SELF_HOST;
+      const osParam = bin.platform === "macos" ? "darwin" : bin.platform;
+      const downloadUrl = downloadUrlFor(osParam, bin.architecture);
+
+      if (autoPromote) {
+        await tx
+          .update(agentVersions)
+          .set({ isLatest: false })
+          .where(
+            and(
+              eq(agentVersions.platform, bin.platform),
+              eq(agentVersions.architecture, bin.architecture),
+              eq(agentVersions.component, component),
+              eq(agentVersions.edition, edition),
+              eq(agentVersions.isLatest, true),
+            ),
+          );
+      }
+
+      await tx
+        .insert(agentVersions)
+        .values({
+          version,
+          component,
+          platform: bin.platform,
+          architecture: bin.architecture,
+          downloadUrl,
+          checksum: verified.sha256,
+          fileSize: BigInt(verified.size),
+          isLatest: autoPromote,
+          releaseManifest: manifestString,
+          manifestSignature: signatureString,
+          signingKeyId: "release-artifact-manifest-ed25519",
+          edition,
+        })
+        .onConflictDoUpdate({
+          target: [
+            agentVersions.version,
+            agentVersions.platform,
+            agentVersions.architecture,
+            agentVersions.component,
+            agentVersions.edition,
+          ],
+          set: {
+            downloadUrl,
+            checksum: verified.sha256,
+            fileSize: BigInt(verified.size),
+            releaseManifest: manifestString,
+            manifestSignature: signatureString,
+            signingKeyId: "release-artifact-manifest-ed25519",
+            ...(autoPromote ? { isLatest: true } : {}),
+          },
+        });
+
+      registeredFilenames.add(bin.filename);
+    }
+  });
+
+  return { registeredFilenames };
+}
+
 export async function syncBinaries(): Promise<void> {
   if (getBinarySource() === "github") {
     console.log(
@@ -486,6 +630,39 @@ export async function syncBinaries(): Promise<void> {
     }
   }
 
+  // Official-manifest local registration (BYO signing edition follow-up): if
+  // a release-artifact-manifest.json + .ed25519 pair is staged at the
+  // binaries volume root, verify it up front so assets it covers register
+  // against IT (raw manifest + official key ID) instead of a fresh
+  // per-deployment re-sign. Absent files: unchanged self-host local-mode
+  // behavior. Present but invalid: log + fall back UNLESS this is a hosted
+  // deployment, where trusting an unverifiable local manifest is not an
+  // option and sync fails outright instead of silently falling back.
+  let officialManifest: { manifestBytes: Buffer; signatureBytes: Buffer } | null = null;
+  const officialManifestPair = await loadOfficialLocalManifestPair(agentBinaryDir);
+  if (officialManifestPair) {
+    try {
+      verifyReleaseArtifactManifestIntegrity(
+        officialManifestPair.manifestBytes,
+        officialManifestPair.signatureBytes,
+      );
+      officialManifest = officialManifestPair;
+      console.log(
+        "[binarySync] Verified official release-artifact-manifest.json in the binaries volume; registering the assets it covers against it instead of re-signing with the per-deployment key",
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (getBinaryEdition() === "hosted") {
+        throw new Error(
+          `[binarySync] Official release manifest verification failed and BINARY_EDITION=hosted requires a valid manifest: ${msg}`,
+        );
+      }
+      console.error(
+        `[binarySync] Official release manifest found but failed verification, falling back to per-deployment re-signing: ${msg}`,
+      );
+    }
+  }
+
   // Scan and register agent binaries in DB. The watchdog ships in the same
   // directory as its per-arch sibling (breeze-watchdog-{os}-{arch}[.exe]) and is
   // served by the same /download/watchdog route.
@@ -504,18 +681,42 @@ export async function syncBinaries(): Promise<void> {
     // across the loop. See docs/deploy/agent-update-trust-bootstrap.md.
     const { keyId } = await ensureActiveSigningKey();
 
-    await registerLocalBinaries({
-      binaries,
-      component: "agent",
-      version,
-      keyId,
-      downloadUrlFor: (osParam, arch) =>
-        `${serverUrl}/api/v1/agents/download/${osParam}/${arch}`,
-    });
+    let coveredAgentFilenames = new Set<string>();
+    if (officialManifest) {
+      const result = await registerFromOfficialManifest({
+        binaries,
+        component: "agent",
+        version,
+        manifestBytes: officialManifest.manifestBytes,
+        signatureBytes: officialManifest.signatureBytes,
+        downloadUrlFor: (osParam, arch) =>
+          `${serverUrl}/api/v1/agents/download/${osParam}/${arch}`,
+      });
+      coveredAgentFilenames = result.registeredFilenames;
+      if (coveredAgentFilenames.size > 0) {
+        console.log(
+          `[binarySync] Registered ${coveredAgentFilenames.size} agent binaries from the official release manifest (version: ${version})`,
+        );
+      }
+    }
 
-    console.log(
-      `[binarySync] Registered ${binaries.length} agent binaries (version: ${version})`,
+    const remainingAgentBinaries = binaries.filter(
+      (b) => !coveredAgentFilenames.has(b.filename),
     );
+    if (remainingAgentBinaries.length > 0) {
+      await registerLocalBinaries({
+        binaries: remainingAgentBinaries,
+        component: "agent",
+        version,
+        keyId,
+        downloadUrlFor: (osParam, arch) =>
+          `${serverUrl}/api/v1/agents/download/${osParam}/${arch}`,
+      });
+
+      console.log(
+        `[binarySync] Registered ${remainingAgentBinaries.length} agent binaries via per-deployment re-signing (version: ${version})`,
+      );
+    }
 
     // #1802: register the watchdog component too, so self-hosters on
     // BINARY_SOURCE=local get watchdog auto-update (heartbeat.ts watchdogUpgradeTo
@@ -526,14 +727,32 @@ export async function syncBinaries(): Promise<void> {
       // doesn't abort the rest of syncBinaries after the agent already
       // registered — mirrors the GitHub path's per-component try/catch.
       try {
-        await registerLocalBinaries({
-          binaries: watchdogBinaries,
-          component: "watchdog",
-          version,
-          keyId,
-          downloadUrlFor: (osParam, arch) =>
-            `${serverUrl}/api/v1/agents/download/watchdog/${osParam}/${arch}`,
-        });
+        let coveredWatchdogFilenames = new Set<string>();
+        if (officialManifest) {
+          const result = await registerFromOfficialManifest({
+            binaries: watchdogBinaries,
+            component: "watchdog",
+            version,
+            manifestBytes: officialManifest.manifestBytes,
+            signatureBytes: officialManifest.signatureBytes,
+            downloadUrlFor: (osParam, arch) =>
+              `${serverUrl}/api/v1/agents/download/watchdog/${osParam}/${arch}`,
+          });
+          coveredWatchdogFilenames = result.registeredFilenames;
+        }
+        const remainingWatchdogBinaries = watchdogBinaries.filter(
+          (b) => !coveredWatchdogFilenames.has(b.filename),
+        );
+        if (remainingWatchdogBinaries.length > 0) {
+          await registerLocalBinaries({
+            binaries: remainingWatchdogBinaries,
+            component: "watchdog",
+            version,
+            keyId,
+            downloadUrlFor: (osParam, arch) =>
+              `${serverUrl}/api/v1/agents/download/watchdog/${osParam}/${arch}`,
+          });
+        }
         console.log(
           `[binarySync] Registered ${watchdogBinaries.length} watchdog binaries (version: ${version})`,
         );

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -13,6 +13,7 @@ import {
   isReleaseArtifactManifestVerificationConfigured,
   verifyReleaseArtifactManifestAsset,
 } from "./releaseArtifactManifest";
+import { EDITION_SELF_HOST, assertGithubFetchableEdition } from "./releaseAssetTrust";
 import { ensureActiveSigningKey, signManifest } from "./manifestSigning";
 import {
   getReleaseSourceApiBase,
@@ -231,11 +232,14 @@ async function getReleaseAssetMetadata(args: {
   releaseManifest?: string;
   manifestSignature?: string;
   signingKeyId?: string;
+  edition: string;
 } | null> {
   if (!args.trustedManifest) {
     const checksum = args.fallbackChecksums?.get(args.asset.name);
     if (!checksum) return null;
-    return { checksum, size: args.asset.size };
+    // Legacy checksums.txt fallback (non-production only) predates the
+    // edition field entirely — same default as an unset manifest field.
+    return { checksum, size: args.asset.size, edition: EDITION_SELF_HOST };
   }
 
   const verified = await verifyReleaseArtifactManifestAsset({
@@ -245,6 +249,12 @@ async function getReleaseAssetMetadata(args: {
     expectedRepository: getReleaseSourceRepository(),
     expectedRelease: args.releaseTag,
   });
+
+  // Defense in depth: this whole function only runs inside the GitHub sync
+  // flow, so an asset labeled edition "hosted" here would mean a hosted
+  // artifact somehow ended up in a public release manifest — refuse it
+  // outright rather than register it.
+  assertGithubFetchableEdition({ assetName: args.asset.name, edition: verified.edition });
 
   if (verified.size !== args.asset.size) {
     throw new Error(
@@ -258,6 +268,7 @@ async function getReleaseAssetMetadata(args: {
     releaseManifest: args.trustedManifest.manifest,
     manifestSignature: args.trustedManifest.signature,
     signingKeyId: "release-artifact-manifest-ed25519",
+    edition: verified.edition ?? EDITION_SELF_HOST,
   };
 }
 
@@ -328,6 +339,10 @@ async function registerLocalBinaries(args: {
   // the GitHub-source path (upsertVersion) so both registration paths behave
   // identically regardless of component.
   const autoPromote = getAgentAutoPromote();
+  // A locally-scanned binary carries no per-asset edition claim of its own
+  // (unlike a manifest-covered asset — see registerFromOfficialManifest
+  // below), so it's stamped with this SERVER's own configured edition.
+  const edition = getBinaryEdition();
 
   await db.transaction(async (tx) => {
     for (const bin of binaries) {
@@ -346,7 +361,7 @@ async function registerLocalBinaries(args: {
       const releaseManifest = JSON.stringify(manifestObj);
       const manifestSignature = await signManifest(releaseManifest);
 
-      // Demote existing "isLatest" entries for this platform/arch/component.
+      // Demote existing "isLatest" entries for this platform/arch/component/edition.
       if (autoPromote) {
         await tx
           .update(agentVersions)
@@ -356,6 +371,7 @@ async function registerLocalBinaries(args: {
               eq(agentVersions.platform, bin.platform),
               eq(agentVersions.architecture, bin.architecture),
               eq(agentVersions.component, component),
+              eq(agentVersions.edition, edition),
               eq(agentVersions.isLatest, true),
             ),
           );
@@ -376,15 +392,17 @@ async function registerLocalBinaries(args: {
           releaseManifest,
           manifestSignature,
           signingKeyId: keyId,
+          edition,
         })
         .onConflictDoUpdate({
           // Match the actual unique constraint
-          // (version, platform, architecture, component).
+          // (version, platform, architecture, component, edition).
           target: [
             agentVersions.version,
             agentVersions.platform,
             agentVersions.architecture,
             agentVersions.component,
+            agentVersions.edition,
           ],
           set: {
             downloadUrl,
@@ -865,6 +883,7 @@ type UpsertMetadata = {
   releaseManifest?: string;
   manifestSignature?: string;
   signingKeyId?: string;
+  edition: string;
 };
 
 // Spec 3b: when syncing from an OVERRIDDEN repository, the release manifest is
@@ -909,6 +928,7 @@ async function applyDeploymentSigning(args: {
     releaseManifest,
     manifestSignature,
     signingKeyId: keyId,
+    edition: metadata.edition,
   };
 }
 
@@ -934,6 +954,7 @@ async function upsertVersion(
   // from the conflict `set` so an existing promoted row keeps its target.
   // When auto-promote is on (default) behavior is byte-for-byte unchanged.
   const autoPromote = getAgentAutoPromote();
+  const edition = signedMetadata.edition;
   await db.transaction(async (tx) => {
     if (autoPromote) {
       await tx
@@ -944,6 +965,7 @@ async function upsertVersion(
             eq(agentVersions.platform, platform),
             eq(agentVersions.architecture, arch),
             eq(agentVersions.component, component),
+            eq(agentVersions.edition, edition),
             eq(agentVersions.isLatest, true),
           ),
         );
@@ -964,6 +986,7 @@ async function upsertVersion(
         releaseNotes: releaseNotes ?? null,
         isLatest: autoPromote,
         component,
+        edition,
       })
       .onConflictDoUpdate({
         target: [
@@ -971,6 +994,7 @@ async function upsertVersion(
           agentVersions.platform,
           agentVersions.architecture,
           agentVersions.component,
+          agentVersions.edition,
         ],
         set: {
           downloadUrl,

--- a/apps/api/src/services/binarySync.ts
+++ b/apps/api/src/services/binarySync.ts
@@ -8,6 +8,7 @@ import { db } from "../db";
 import { agentVersions } from "../db/schema";
 import { isS3Configured, syncDirectory } from "./s3Storage";
 import { getBinarySource, getAgentAutoPromote } from "./binarySource";
+import { getBinaryEdition } from "./binaryEdition";
 import {
   isReleaseArtifactManifestVerificationConfigured,
   verifyReleaseArtifactManifestAsset,
@@ -24,6 +25,22 @@ const GH_PLATFORM_MAP: Record<string, string> = {
   darwin: "macos",
   windows: "windows",
 };
+
+// BINARY_EDITION=hosted fail-closed (BYO signing edition follow-up): a
+// hosted deployment must never silently fall back to the public GitHub
+// release when its local binaries volume is missing or stale — that release
+// now carries the self-host edition, which is not what a hosted deployment
+// is supposed to serve. Throwing here is deliberate: syncBinaries()'s only
+// caller (index.ts startup) treats a thrown error as fatal when
+// BINARY_SOURCE=local, so this turns a would-be silent substitution into a
+// boot failure an operator has to notice and fix.
+function assertLocalGithubFallbackAllowed(context: string): void {
+  if (getBinaryEdition() === "hosted") {
+    throw new Error(
+      `[binarySync] BINARY_EDITION=hosted refuses to fall back to the public GitHub release (${context}). Fix the local binaries volume instead.`,
+    );
+  }
+}
 
 const AGENT_TARGETS = [
   { goos: "linux", goarch: "amd64" },
@@ -431,6 +448,9 @@ export async function syncBinaries(): Promise<void> {
     version !== "unknown" &&
     version !== expectedVersion
   ) {
+    assertLocalGithubFallbackAllowed(
+      `stale binaries volume: v${version} but BREEZE_VERSION=${expectedVersion}`,
+    );
     console.warn(
       `[binarySync] Stale binaries volume detected: volume has v${version} but BREEZE_VERSION=${expectedVersion}. ` +
         `Falling back to GitHub release sync. To fix, run: docker compose up -d --force-recreate binaries-init`,
@@ -510,6 +530,9 @@ export async function syncBinaries(): Promise<void> {
       );
     }
   } else {
+    assertLocalGithubFallbackAllowed(
+      `no local agent binaries found in ${agentBinaryDir}`,
+    );
     console.log(
       "[binarySync] No local agent binaries found, falling back to GitHub sync",
     );
@@ -800,6 +823,20 @@ async function ensureCurrentVersionRegistered(): Promise<void> {
       .limit(1);
 
     if (existing) return; // Already registered
+
+    // This safety net runs after BOTH sync modes. In github mode, syncing the
+    // current version from GitHub is the primary path, not a fallback — leave
+    // it alone. In local mode it IS a fallback (local scan didn't produce the
+    // running version), so it's subject to the same hosted-edition fail-closed
+    // rule as the other local-mode fallbacks above. Unlike those, this
+    // function is a best-effort safety net by design (never crashes boot), so
+    // mirror that here: log and skip rather than throw.
+    if (getBinarySource() === "local" && getBinaryEdition() === "hosted") {
+      console.error(
+        `[binarySync] Version ${currentVersion} not found in agentVersions and BINARY_EDITION=hosted refuses to fall back to the public GitHub release from local mode. Register it via the local binaries volume instead.`,
+      );
+      return;
+    }
 
     console.log(
       `[binarySync] Version ${currentVersion} not found in agentVersions, syncing from GitHub`,

--- a/apps/api/src/services/installerBuilder.test.ts
+++ b/apps/api/src/services/installerBuilder.test.ts
@@ -20,7 +20,11 @@ function realEnrollmentKey(): string {
   return randomBytes(32).toString('hex');
 }
 
-function signedReleaseManifest(assetName: string, assetBuffer: Buffer) {
+function signedReleaseManifest(
+  assetName: string,
+  assetBuffer: Buffer,
+  assetOverrides: Record<string, unknown> = {},
+) {
   const { publicKey, privateKey } = generateKeyPairSync('ed25519');
   const publicDer = publicKey.export({ format: 'der', type: 'spki' }) as Buffer;
   const rawPublicKey = publicDer.subarray(publicDer.length - 32).toString('base64');
@@ -34,6 +38,7 @@ function signedReleaseManifest(assetName: string, assetBuffer: Buffer) {
         sha256: createHash('sha256').update(assetBuffer).digest('hex'),
         size: assetBuffer.length,
         platformTrust: 'windows-authenticode-required',
+        ...assetOverrides,
       },
     ],
   }));
@@ -77,6 +82,91 @@ describe('fetchRegularMsi', () => {
       'https://github.com/lanternops/breeze/releases/download/v1.2.3/release-artifact-manifest.json.ed25519',
       { redirect: 'follow' },
     );
+  });
+
+  it('accepts an unsigned MSI labeled edition self-host', async () => {
+    const asset = Buffer.from('unsigned-self-host-msi');
+    const signed = signedReleaseManifest('breeze-agent.msi', asset, {
+      platformTrust: 'none',
+      edition: 'self-host',
+    });
+    process.env.BINARY_SOURCE = 'github';
+    process.env.BINARY_VERSION = '1.2.3';
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/breeze-agent.msi')) return new Response(asset);
+      if (url.endsWith('/release-artifact-manifest.json')) return new Response(signed.manifest);
+      if (url.endsWith('/release-artifact-manifest.json.ed25519')) return new Response(signed.signature);
+      return new Response('not found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchRegularMsi()).resolves.toEqual(asset);
+  });
+
+  it('rejects an unsigned MSI with no edition claim (today\'s behavior unchanged)', async () => {
+    const asset = Buffer.from('unsigned-no-edition-msi');
+    const signed = signedReleaseManifest('breeze-agent.msi', asset, {
+      platformTrust: 'none',
+    });
+    process.env.BINARY_SOURCE = 'github';
+    process.env.BINARY_VERSION = '1.2.3';
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/breeze-agent.msi')) return new Response(asset);
+      if (url.endsWith('/release-artifact-manifest.json')) return new Response(signed.manifest);
+      if (url.endsWith('/release-artifact-manifest.json.ed25519')) return new Response(signed.signature);
+      return new Response('not found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchRegularMsi()).rejects.toThrow(/windows-authenticode-required/);
+  });
+
+  it('refuses an MSI labeled edition hosted, even if properly signed', async () => {
+    const asset = Buffer.from('hosted-signed-msi');
+    const signed = signedReleaseManifest('breeze-agent.msi', asset, {
+      platformTrust: 'windows-authenticode-required',
+      edition: 'hosted',
+    });
+    process.env.BINARY_SOURCE = 'github';
+    process.env.BINARY_VERSION = '1.2.3';
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/breeze-agent.msi')) return new Response(asset);
+      if (url.endsWith('/release-artifact-manifest.json')) return new Response(signed.manifest);
+      if (url.endsWith('/release-artifact-manifest.json.ed25519')) return new Response(signed.signature);
+      return new Response('not found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchRegularMsi()).rejects.toThrow(/must never be fetched from a public GitHub release/);
+  });
+
+  it('rejects an unsigned MSI labeled edition hosted', async () => {
+    const asset = Buffer.from('unsigned-hosted-msi');
+    const signed = signedReleaseManifest('breeze-agent.msi', asset, {
+      platformTrust: 'none',
+      edition: 'hosted',
+    });
+    process.env.BINARY_SOURCE = 'github';
+    process.env.BINARY_VERSION = '1.2.3';
+    process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/breeze-agent.msi')) return new Response(asset);
+      if (url.endsWith('/release-artifact-manifest.json')) return new Response(signed.manifest);
+      if (url.endsWith('/release-artifact-manifest.json.ed25519')) return new Response(signed.signature);
+      return new Response('not found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Both violations apply (unsigned + hosted); the baseline trust check
+    // fires first.
+    await expect(fetchRegularMsi()).rejects.toThrow(/windows-authenticode-required/);
   });
 });
 

--- a/apps/api/src/services/installerBuilder.ts
+++ b/apps/api/src/services/installerBuilder.ts
@@ -13,6 +13,7 @@ import {
   getGithubReleaseRepository,
 } from './binarySource';
 import { verifyGithubReleaseArtifactBuffer } from './releaseArtifactManifest';
+import { assertGithubFetchableEdition } from './releaseAssetTrust';
 import {
   InstallerFilenameHostError,
   isEncodedWindowsFilenameApiHost,
@@ -278,15 +279,23 @@ export async function fetchRegularMsi(): Promise<Buffer> {
     const resp = await fetch(url, { redirect: 'follow' });
     if (!resp.ok) throw new Error(`Failed to fetch regular MSI: ${resp.status}`);
     const buffer = Buffer.from(await resp.arrayBuffer());
-    await verifyGithubReleaseArtifactBuffer({
+    // No expectedPlatformTrust here: the public self-host release ships this
+    // MSI unsigned (platformTrust "none") by default, while a BYO-re-signed
+    // repo still ships it Authenticode-signed. Both are legitimate for
+    // edition "self-host" — the edition-aware accept/reject decision lives in
+    // assertDistributableReleaseAsset (releaseAssetTrust.ts), which
+    // verifyGithubReleaseArtifactBuffer runs on every manifest-verified asset.
+    const verified = await verifyGithubReleaseArtifactBuffer({
       assetName: 'breeze-agent.msi',
       assetBuffer: buffer,
       manifestUrl: getGithubReleaseArtifactManifestUrl(),
       signatureUrl: getGithubReleaseArtifactManifestSignatureUrl(),
       expectedRepository: getGithubReleaseRepository(),
       expectedRelease: getGithubExpectedReleaseTag(),
-      expectedPlatformTrust: 'windows-authenticode-required',
     });
+    if (verified) {
+      assertGithubFetchableEdition({ assetName: 'breeze-agent.msi', edition: verified.edition });
+    }
     return buffer;
   }
   const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');
@@ -336,7 +345,7 @@ export async function fetchMacosInstallerAppZip(): Promise<Buffer | null> {
     if (resp.status === 404) return null;
     if (!resp.ok) throw new Error(`Failed to fetch installer app zip: ${resp.status}`);
     const buffer = Buffer.from(await resp.arrayBuffer());
-    await verifyGithubReleaseArtifactBuffer({
+    const verified = await verifyGithubReleaseArtifactBuffer({
       assetName: 'Breeze Installer.app.zip',
       assetBuffer: buffer,
       manifestUrl: getGithubReleaseArtifactManifestUrl(),
@@ -345,6 +354,12 @@ export async function fetchMacosInstallerAppZip(): Promise<Buffer | null> {
       expectedRelease: getGithubExpectedReleaseTag(),
       expectedPlatformTrust: 'macos-developer-id-notarization-required',
     });
+    if (verified) {
+      assertGithubFetchableEdition({
+        assetName: 'Breeze Installer.app.zip',
+        edition: verified.edition,
+      });
+    }
     return buffer;
   }
   const binaryDir = resolve(process.env.AGENT_BINARY_DIR || './agent/bin');

--- a/apps/api/src/services/releaseArtifactManifest.test.ts
+++ b/apps/api/src/services/releaseArtifactManifest.test.ts
@@ -4,6 +4,7 @@ import {
   verifyGithubReleaseArtifactBuffer,
   verifyReleaseArtifactManifestAsset,
   verifyReleaseArtifactBuffer,
+  verifyReleaseArtifactManifestIntegrity,
 } from "./releaseArtifactManifest";
 import { requiredPlatformTrustFor } from "./releaseAssetTrust";
 
@@ -434,5 +435,165 @@ describe("releaseArtifactManifest", () => {
         expectedPlatformTrust: "windows-authenticode-required",
       }),
     ).rejects.toThrow(/not distributable/);
+  });
+
+  describe("edition field (BYO signing follow-up)", () => {
+    it("surfaces edition on the verified result when present", async () => {
+      const asset = Buffer.from("unsigned self-host msi");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent.msi",
+        assetBuffer: asset,
+        assetOverrides: { platformTrust: "none", edition: "self-host" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      await expect(
+        verifyReleaseArtifactBuffer({
+          assetName: "breeze-agent.msi",
+          assetBuffer: asset,
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).resolves.toMatchObject({ edition: "self-host", platformTrust: "none" });
+    });
+
+    it("returns edition: null when the manifest predates the field", async () => {
+      const asset = Buffer.from("trusted-msi");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent.msi",
+        assetBuffer: asset,
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      await expect(
+        verifyReleaseArtifactManifestAsset({
+          assetName: "breeze-agent.msi",
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).resolves.toMatchObject({ edition: null });
+    });
+
+    it("rejects an unsigned breeze-agent.msi with no edition claim (backward compatible)", async () => {
+      const asset = Buffer.from("unsigned msi, no edition claim");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent.msi",
+        assetBuffer: asset,
+        assetOverrides: { platformTrust: "none" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      await expect(
+        verifyReleaseArtifactBuffer({
+          assetName: "breeze-agent.msi",
+          assetBuffer: asset,
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).rejects.toThrow(/windows-authenticode-required/);
+    });
+
+    it("accepts an unsigned breeze-agent.msi labeled edition self-host", async () => {
+      const asset = Buffer.from("unsigned self-host msi bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent.msi",
+        assetBuffer: asset,
+        assetOverrides: { platformTrust: "none", edition: "self-host" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      await expect(
+        verifyReleaseArtifactBuffer({
+          assetName: "breeze-agent.msi",
+          assetBuffer: asset,
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).resolves.toMatchObject({ edition: "self-host", platformTrust: "none" });
+    });
+
+    it("rejects an unsigned breeze-agent.msi labeled edition hosted", async () => {
+      const asset = Buffer.from("unsigned hosted msi bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent.msi",
+        assetBuffer: asset,
+        assetOverrides: { platformTrust: "none", edition: "hosted" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      await expect(
+        verifyReleaseArtifactBuffer({
+          assetName: "breeze-agent.msi",
+          assetBuffer: asset,
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).rejects.toThrow(/windows-authenticode-required/);
+    });
+
+    it("rejects an unknown edition value", async () => {
+      const asset = Buffer.from("linux agent bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-linux-amd64",
+        assetBuffer: asset,
+        assetOverrides: { edition: "enterprise" },
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      await expect(
+        verifyReleaseArtifactManifestAsset({
+          assetName: "breeze-agent-linux-amd64",
+          manifestBytes: signed.manifest,
+          signatureBytes: signed.signature,
+        }),
+      ).rejects.toThrow(/unknown edition/);
+    });
+  });
+
+  describe("verifyReleaseArtifactManifestIntegrity", () => {
+    it("returns release/repository for a validly-signed manifest without a per-asset lookup", () => {
+      const asset = Buffer.from("agent bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-linux-amd64",
+        assetBuffer: asset,
+        release: "v9.9.9",
+        repository: "acme/breeze-selfhost",
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+
+      expect(
+        verifyReleaseArtifactManifestIntegrity(signed.manifest, signed.signature),
+      ).toEqual({ release: "v9.9.9", repository: "acme/breeze-selfhost" });
+    });
+
+    it("throws on a tampered signature", () => {
+      const asset = Buffer.from("agent bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-linux-amd64",
+        assetBuffer: asset,
+      });
+      process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS = signed.publicKey;
+      const tampered = Buffer.from(
+        signed.manifest.toString("utf8").replace("v1.2.3", "v9.9.9"),
+      );
+
+      expect(() =>
+        verifyReleaseArtifactManifestIntegrity(tampered, signed.signature),
+      ).toThrow(/signature verification failed/);
+    });
+
+    it("throws when no trust root is configured", () => {
+      const asset = Buffer.from("agent bytes");
+      const signed = makeSignedManifest({
+        assetName: "breeze-agent-linux-amd64",
+        assetBuffer: asset,
+      });
+      delete process.env.RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+      delete process.env.BREEZE_RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS;
+
+      expect(() =>
+        verifyReleaseArtifactManifestIntegrity(signed.manifest, signed.signature),
+      ).toThrow(/public key is not configured/);
+    });
   });
 });

--- a/apps/api/src/services/releaseArtifactManifest.ts
+++ b/apps/api/src/services/releaseArtifactManifest.ts
@@ -23,6 +23,10 @@ type ReleaseArtifactManifestAsset = {
   // build outputs. Tolerated here; positive rejection at registration/serve
   // time is Deliverable 3c.
   intendedUse?: unknown;
+  // Release edition ("self-host" | "hosted"). Optional — absent on manifests
+  // predating this field, which is tolerated everywhere it's read (treated
+  // as "no edition claim", never as "self-host" by default).
+  edition?: unknown;
 };
 
 type ReleaseArtifactManifest = {
@@ -48,6 +52,7 @@ export type VerifiedReleaseArtifact = {
   repository: string;
   platformTrust: string | null;
   intendedUse: string | null;
+  edition: string | null;
 };
 
 function sha256Hex(buffer: Buffer): string {
@@ -234,6 +239,7 @@ export async function verifyReleaseArtifactBuffer(args: {
     platformTrust:
       typeof entry.platformTrust === "string" ? entry.platformTrust : null,
     intendedUse: typeof entry.intendedUse === 'string' ? entry.intendedUse : null,
+    edition: typeof entry.edition === 'string' ? entry.edition : null,
   };
 }
 
@@ -296,6 +302,7 @@ function selectManifestAsset(args: {
     assetName: args.assetName,
     platformTrust: typeof entry.platformTrust === 'string' ? entry.platformTrust : null,
     intendedUse: typeof entry.intendedUse === 'string' ? entry.intendedUse : null,
+    edition: typeof entry.edition === 'string' ? entry.edition : null,
   });
   if (
     args.expectedPlatformTrust &&
@@ -339,6 +346,27 @@ export async function verifyReleaseArtifactManifestAsset(args: {
     platformTrust:
       typeof entry.platformTrust === "string" ? entry.platformTrust : null,
     intendedUse: typeof entry.intendedUse === 'string' ? entry.intendedUse : null,
+    edition: typeof entry.edition === 'string' ? entry.edition : null,
+  };
+}
+
+/**
+ * Verifies just the manifest pair's signature + schema — no per-asset lookup.
+ * Used when a caller needs to know "is this a validly-signed release artifact
+ * manifest" before it knows (or cares) which specific asset it will look up,
+ * e.g. binarySync's local-mode official-manifest registration (spec: BYO
+ * signing edition follow-up), which registers WHICHEVER assets the manifest
+ * happens to cover.
+ */
+export function verifyReleaseArtifactManifestIntegrity(
+  manifestBytes: Buffer,
+  signatureBytes: Buffer,
+): { release: string; repository: string } {
+  verifyManifestSignature(manifestBytes, signatureBytes);
+  const manifest = parseManifest(manifestBytes);
+  return {
+    release: manifest.release as string,
+    repository: manifest.repository as string,
   };
 }
 

--- a/apps/api/src/services/releaseAssetTrust.test.ts
+++ b/apps/api/src/services/releaseAssetTrust.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   PLATFORM_TRUST_MACOS,
+  PLATFORM_TRUST_NONE,
   PLATFORM_TRUST_WINDOWS,
   PLATFORM_TRUST_WORKFLOW,
   assertDistributableReleaseAsset,
+  assertGithubFetchableEdition,
   isSigningInputAssetName,
   requiredPlatformTrustFor,
 } from './releaseAssetTrust';
@@ -126,5 +128,110 @@ describe('releaseAssetTrust', () => {
         intendedUse: null,
       }),
     ).not.toThrow();
+  });
+
+  describe('edition-aware MSI acceptance', () => {
+    it('accepts an unsigned self-host breeze-agent.msi', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-agent.msi',
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+          edition: 'self-host',
+        }),
+      ).not.toThrow();
+    });
+
+    it('still accepts a signed self-host breeze-agent.msi (BYO-resigned repos)', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-agent.msi',
+          platformTrust: PLATFORM_TRUST_WINDOWS,
+          intendedUse: null,
+          edition: 'self-host',
+        }),
+      ).not.toThrow();
+    });
+
+    it('rejects an unsigned breeze-agent.msi with no edition claim (today\'s behavior unchanged)', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-agent.msi',
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+        }),
+      ).toThrow(/windows-authenticode-required/);
+    });
+
+    it('rejects an unsigned breeze-agent.msi labeled edition "hosted"', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-agent.msi',
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+          edition: 'hosted',
+        }),
+      ).toThrow(/windows-authenticode-required/);
+    });
+
+    it('does NOT extend the unsigned exception to other .msi assets (e.g. helper)', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-helper-windows.msi',
+          platformTrust: PLATFORM_TRUST_NONE,
+          intendedUse: null,
+          edition: 'self-host',
+        }),
+      ).toThrow(/windows-authenticode-required/);
+    });
+
+    it('rejects an unknown edition value (fails closed)', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-agent-linux-amd64',
+          platformTrust: PLATFORM_TRUST_WORKFLOW,
+          intendedUse: null,
+          edition: 'enterprise',
+        }),
+      ).toThrow(/unknown edition/);
+    });
+
+    it('tolerates edition undefined/null identically (manifests predating the field)', () => {
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-agent-linux-amd64',
+          platformTrust: PLATFORM_TRUST_WORKFLOW,
+          intendedUse: null,
+          edition: null,
+        }),
+      ).not.toThrow();
+      expect(() =>
+        assertDistributableReleaseAsset({
+          assetName: 'breeze-agent-linux-amd64',
+          platformTrust: PLATFORM_TRUST_WORKFLOW,
+          intendedUse: null,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('assertGithubFetchableEdition', () => {
+    it('refuses an asset labeled edition "hosted"', () => {
+      expect(() =>
+        assertGithubFetchableEdition({ assetName: 'breeze-agent.msi', edition: 'hosted' }),
+      ).toThrow(/must never be fetched from a public GitHub release/);
+    });
+
+    it('allows edition "self-host"', () => {
+      expect(() =>
+        assertGithubFetchableEdition({ assetName: 'breeze-agent.msi', edition: 'self-host' }),
+      ).not.toThrow();
+    });
+
+    it('allows a null/absent edition (manifests predating the field)', () => {
+      expect(() =>
+        assertGithubFetchableEdition({ assetName: 'breeze-agent.msi', edition: null }),
+      ).not.toThrow();
+    });
   });
 });

--- a/apps/api/src/services/releaseAssetTrust.ts
+++ b/apps/api/src/services/releaseAssetTrust.ts
@@ -26,6 +26,25 @@ export const KNOWN_PLATFORM_TRUST_VALUES: ReadonlySet<string> = new Set([
 
 export const INTENDED_USE_SIGNING_INPUT = 'signing-input';
 
+// Release editions (BYO signing follow-up): "self-host" is the public release
+// build (unsigned by default — BYO-signing repos re-sign it before publishing
+// their own release); "hosted" is built and distributed privately and must
+// never be fetched from a public GitHub release.
+export const EDITION_SELF_HOST = 'self-host';
+export const EDITION_HOSTED = 'hosted';
+
+export const KNOWN_EDITION_VALUES: ReadonlySet<string> = new Set([
+  EDITION_SELF_HOST,
+  EDITION_HOSTED,
+]);
+
+// The one asset the public self-host release is expected to ship unsigned
+// (platformTrust "none"): the Windows MSI. Scoped to this exact filename —
+// NOT every .msi (e.g. breeze-helper-windows.msi stays signed regardless of
+// edition) — because that's the only asset the release pipeline currently
+// produces an unsigned self-host variant of.
+const SELF_HOST_UNSIGNED_MSI_ASSET_NAME = 'breeze-agent.msi';
+
 // Raw darwin Mach-O binaries carry Developer ID + notarization even though
 // they ship inside the .pkg (see release.yml DARWIN_BINARY_RE).
 const DARWIN_BINARY_RE = /^breeze-(agent|backup|desktop-helper|watchdog)-darwin-(amd64|arm64)$/;
@@ -56,16 +75,24 @@ export function requiredPlatformTrustFor(assetName: string): string | null {
  * Throws unless the asset may be registered or served to end users/agents.
  * Fail-closed on: any intendedUse (the only known value, "signing-input", is
  * never distributable, and unknown future values must not slip through), a
- * signing-input-shaped name, unknown platformTrust vocabulary, and a canonical
- * Windows/macOS asset whose trust label is missing or weaker than required.
+ * signing-input-shaped name, unknown platformTrust vocabulary, unknown edition
+ * vocabulary, and a canonical Windows/macOS asset whose trust label is missing
+ * or weaker than required.
  *
  * platformTrust === null on a NON-canonical asset is tolerated for manifests
- * predating the platformTrust field.
+ * predating the platformTrust field. edition is optional throughout — a
+ * manifest predating the edition field (edition undefined/null) behaves
+ * exactly as before this field existed.
+ *
+ * The one edition-aware relaxation: breeze-agent.msi with edition "self-host"
+ * may carry platformTrust "none" (the public self-host release ships it
+ * unsigned by default) in addition to the normal "windows-authenticode-required".
  */
 export function assertDistributableReleaseAsset(args: {
   assetName: string;
   platformTrust: string | null;
   intendedUse: string | null;
+  edition?: string | null;
 }): void {
   if (args.intendedUse !== null) {
     throw new Error(
@@ -82,12 +109,48 @@ export function assertDistributableReleaseAsset(args: {
       `Release asset ${args.assetName} has unknown platformTrust "${args.platformTrust}"`,
     );
   }
+  if (
+    args.edition !== undefined &&
+    args.edition !== null &&
+    !KNOWN_EDITION_VALUES.has(args.edition)
+  ) {
+    throw new Error(
+      `Release asset ${args.assetName} has unknown edition "${args.edition}"`,
+    );
+  }
   const required = requiredPlatformTrustFor(args.assetName);
-  if (required !== null && args.platformTrust !== required) {
+  if (required === null) return;
+
+  const isUnsignedSelfHostMsi =
+    args.assetName === SELF_HOST_UNSIGNED_MSI_ASSET_NAME &&
+    required === PLATFORM_TRUST_WINDOWS &&
+    args.edition === EDITION_SELF_HOST &&
+    args.platformTrust === PLATFORM_TRUST_NONE;
+
+  if (args.platformTrust !== required && !isUnsignedSelfHostMsi) {
     throw new Error(
       `Release asset ${args.assetName} requires platformTrust "${required}", got ${
         args.platformTrust === null ? 'none recorded' : `"${args.platformTrust}"`
       }`,
+    );
+  }
+}
+
+/**
+ * Defense-in-depth policy for the GitHub-fetch surfaces (installerBuilder's
+ * fetchRegularMsi/fetchMacosInstallerAppZip, binarySync's GitHub sync): an
+ * asset labeled edition "hosted" must never be accepted from a public GitHub
+ * release, regardless of how well-formed its trust metadata is. Hosted
+ * artifacts are distributed privately; if one ever showed up in a public
+ * release manifest that would itself be the bug this guards against.
+ */
+export function assertGithubFetchableEdition(args: {
+  assetName: string;
+  edition: string | null;
+}): void {
+  if (args.edition === EDITION_HOSTED) {
+    throw new Error(
+      `Release asset ${args.assetName} is edition "hosted" and must never be fetched from a public GitHub release`,
     );
   }
 }

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -103,6 +103,10 @@ RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS=yzx8ftmcls6uBetFC5SYnZhBo+cbur3IX50TbBthTs
 # BYO signing: override the release repository (default lanternops/breeze).
 # Requires RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS to be YOUR release key.
 # BINARY_GITHUB_REPOSITORY=lanternops/breeze
+# Binary edition served by this deployment: self-host (default) or hosted.
+# hosted requires BINARY_SOURCE=local and RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS
+# in production — see .env.example at the repo root for details.
+# BINARY_EDITION=self-host
 
 # Controlled agent-fleet rollout. Default true: registering/syncing a release
 # immediately becomes the fleet upgrade target. Set false to require an explicit

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -218,6 +218,11 @@ services:
       BINARY_SOURCE: github
       RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS: ${RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS:?Set RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS in .env}
       BINARY_GITHUB_REPOSITORY: ${BINARY_GITHUB_REPOSITORY:-}
+      # Binary edition served by this deployment: self-host (default,
+      # unchanged behavior) or hosted (production requires
+      # BINARY_SOURCE=local + a manifest trust root — not compatible with the
+      # BINARY_SOURCE=github hardcoded above without also changing that).
+      BINARY_EDITION: ${BINARY_EDITION:-self-host}
       # Hosted SaaS gate (#570). This template is for hosted deploys, so
       # IS_HOSTED is required-explicit — operators must set it in .env.
       # Misconfiguration here silently drops new partners to status='active'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,6 +275,10 @@ services:
       # from (default lanternops/breeze). Pair with
       # RELEASE_ARTIFACT_MANIFEST_PUBLIC_KEYS set to YOUR release manifest key.
       BINARY_GITHUB_REPOSITORY: ${BINARY_GITHUB_REPOSITORY:-}
+      # Binary edition served by this deployment: self-host (default,
+      # unchanged behavior) or hosted (production requires
+      # BINARY_SOURCE=local + a manifest trust root — see .env.example).
+      BINARY_EDITION: ${BINARY_EDITION:-self-host}
       # Hosted SaaS gate. Compose defaults to false so self-hosters upgrade
       # without touching their .env. Hosted operators must set IS_HOSTED=true
       # in .env so this interpolates to true. The API config validator (#570)


### PR DESCRIPTION
API side of the release-pipeline edition fork, four commits:

1. **Edition-aware release-asset trust** — the release manifest gains an optional per-asset `edition` field; `breeze-agent.msi` with `edition: "self-host"` is acceptable unsigned (`platformTrust: "none"`) or BYO-re-signed, while hosted-edition assets are refused at every GitHub-fetch surface (installer serving, macOS installer, sync metadata) — a hosted asset should never appear in a public manifest, so this is defense in depth. Absent edition preserves today's behavior exactly.
2. **`BINARY_EDITION` fail-closed mode** — new env (`self-host` default). `hosted` requires `BINARY_SOURCE=local` + manifest keys at production boot, and disables every GitHub fallback in local-mode binary sync (stale volume or empty scan is an error, never a silent public pull).
3. **`agent_versions.edition`** — column + widened uniqueness (idempotent migration; old constraint name verified against the baseline) so both editions of a version coexist; `/latest`, `/:version/download`, `/promote`, `/pinnable` are edition-scoped to the server's own edition; registration stamps edition from the manifest (github) or `BINARY_EDITION` (local scan). The diagnostic list endpoint intentionally shows both.
4. **Staged official manifest** — local mode registers assets from a verified `release-artifact-manifest.json(.ed25519)` staged beside the binaries dir when present (official key chain preserved), falling back to per-deployment re-signing; verification failure is fatal only under `BINARY_EDITION=hosted`.

Unit suite green (21k tests; 3 pre-existing flakes pass in isolation, none in touched code); tsc clean. `db:check-drift` deferred (needs live DB — covered by Integration Tests job).

Part of the release-pipeline build-mode hardening series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)