### PR TITLE
feat(selfhost-signing): build BYO MSIs under the self-host edition identity

### DIFF
--- a/apps/docs/src/content/docs/deploy/sign-your-own-packages.mdx
+++ b/apps/docs/src/content/docs/deploy/sign-your-own-packages.mdx
@@ -471,6 +471,19 @@ file-based key either predates that rule or is internal-only. SmartScreen
 reputation never accrues for internal CAs — pair PFX mode with the
 [AV exclusions](/deploy/antivirus-exceptions/) and GPO trust configuration.
 
+### MSI product identity
+
+The Windows MSI this template builds carries the **self-hosted edition**
+identity: `ProductName` "Breeze Agent (Self-Hosted)" and its own permanent
+`UpgradeCode`, distinct from the `ProductName` "Breeze Agent" that
+hosted-distribution builds use. The two identities can never install over
+each other — that's intentional. The self-hosted `UpgradeCode` is what your
+fleet's upgrade lineage tracks, and it matches the public unsigned self-host
+MSI Breeze publishes with each release, so signing your own copy here keeps
+your fleet on the same upgrade lineage rather than forking it. Signing a
+release from before this edition parameter existed builds the original
+("Breeze Agent") identity, matching what that release actually shipped.
+
 ### Relationship to the fork path
 
 This template signs **official, unmodified** Breeze builds — your

--- a/selfhost-signing-template/.github/workflows/sign-release.yml
+++ b/selfhost-signing-template/.github/workflows/sign-release.yml
@@ -324,13 +324,35 @@ jobs:
           $watchdogExe = Join-Path $root "dist\breeze-watchdog-windows-amd64.exe"
           $userHelperExe = Join-Path $root "dist\breeze-user-helper-windows-amd64.exe"
           $msiPath = Join-Path $root "dist\breeze-agent.msi"
-          & (Join-Path $root "breeze\agent\installer\build-msi.ps1") `
+          $buildMsiScript = Join-Path $root "breeze\agent\installer\build-msi.ps1"
+
+          # Build under the self-hosted edition identity (ProductName
+          # "Breeze Agent (Self-Hosted)", its own permanent UpgradeCode) so a
+          # self-signed MSI never collides with a hosted-distribution install
+          # and its upgrade lineage matches the public unsigned self-host MSI
+          # Breeze publishes with the release. -Edition is only present on
+          # build-msi.ps1 from the release that introduced it onward — this
+          # checkout is pinned to the manifest's verified sourceCommit, so an
+          # older release's script simply won't have the parameter. Grep
+          # rather than assume: pass -Edition SelfHost only when it exists;
+          # an older release then builds under the original ("Breeze Agent")
+          # identity, which is what that release actually shipped.
+          $editionArgs = @()
+          if (Select-String -Path $buildMsiScript -Pattern '\$Edition\b' -Quiet) {
+            $editionArgs = @("-Edition", "SelfHost")
+          }
+          else {
+            Write-Host "build-msi.ps1 at this sourceCommit has no -Edition parameter (pre-edition release) — building under the legacy 'Breeze Agent' identity"
+          }
+
+          & $buildMsiScript `
             -Version $env:VERSION `
             -AgentExePath $agentExe `
             -BackupExePath $backupExe `
             -WatchdogExePath $watchdogExe `
             -UserHelperExePath $userHelperExe `
-            -OutputPath $msiPath
+            -OutputPath $msiPath `
+            @editionArgs
           # $ErrorActionPreference does not turn a non-zero *exit* from an
           # external script into a terminating error — only a thrown exception.
           if ($LASTEXITCODE -ne 0) { throw "build-msi.ps1 failed with exit code $LASTEXITCODE" }

--- a/selfhost-signing-template/README.md
+++ b/selfhost-signing-template/README.md
@@ -122,6 +122,17 @@ timestamp server (default `http://timestamp.digicert.com`).
 
 ## What a run publishes
 
+The Windows MSI builds under the **self-hosted edition** identity —
+`ProductName` "Breeze Agent (Self-Hosted)" and its own permanent
+`UpgradeCode`, distinct from the `ProductName` "Breeze Agent" that hosted
+Breeze distribution uses. This is intentional: the two identities can never
+install on top of each other, and the self-hosted `UpgradeCode` is what your
+fleet's upgrade lineage tracks — matching the public unsigned self-host MSI
+Breeze publishes with each release, so signing it here doesn't fork your
+fleet onto a different upgrade path. Signing a release from before this
+edition parameter existed builds the original ("Breeze Agent") identity,
+matching what that release actually shipped.
+
 Signed by you: `breeze-agent.msi`, `breeze-agent-windows-amd64.exe`,
 `breeze-backup-windows-amd64.exe`, `breeze-watchdog-windows-amd64.exe`,
 `breeze-user-helper-windows-amd64.exe`,


### PR DESCRIPTION
## Summary

- `sign-release.yml`'s **Build MSI** step now passes `-Edition SelfHost` to `build-msi.ps1`, so self-signed MSIs built by the `breeze-selfhost-signing` template carry the `ProductName` "Breeze Agent (Self-Hosted)" and its own permanent `UpgradeCode` — not the hosted-distribution identity (`ProductName` "Breeze Agent", `UpgradeCode {70A57B7A-...}`), which is reserved for Breeze-hosted distribution.
- Why: truthful attribution, self-hosters' fleets keep an upgrade lineage consistent with the public unsigned self-host MSI Breeze already publishes per release, and the self-signed MSI can never collide with (or upgrade-chain onto) a hosted-edition install. `breeze.wxs` on `main` already refuses cross-edition installs.
- Documented the identity split in `selfhost-signing-template/README.md` ("What a run publishes") and the "Sign Your Own Agent Packages" guide (new "MSI product identity" section under Appendix).

## Legacy-release guard

The template checks out `agent/installer/build-msi.ps1` from the *release's* `sourceCommit` (verified via `verify-official-release`), not from `main` — so a release cut before `-Edition` existed won't have the parameter at all. Rather than hardcode a version cutoff, the Build MSI step greps the checked-out script itself:

```powershell
if (Select-String -Path $buildMsiScript -Pattern '\$Edition\b' -Quiet) {
  $editionArgs = @("-Edition", "SelfHost")
}
else {
  Write-Host "build-msi.ps1 at this sourceCommit has no -Edition parameter (pre-edition release) — building under the legacy 'Breeze Agent' identity"
}
```

An older release then builds under the original ("Breeze Agent") identity — matching what that release actually shipped — instead of failing the run on a missing parameter.

## Test plan

- [x] `actionlint` clean on `sign-release.yml` (the pre-existing `ci.yml` reusable-workflow-path error is a monorepo-nesting artifact of testing inside `constrained-signed-installer`, reproduces identically on `origin/main` before this change — the template's own CI runs from its own repo root where the relative path resolves)
- [x] YAML parses (`python3 -m yaml`)
- [x] Extracted PowerShell "Build MSI" step parses cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`, zero syntax errors)
- [x] `node scripts/verify-manifest.test.mjs` — all 21 cases pass (untouched by this change, run as a regression check)
- [ ] Live dry-run of `sign-release.yml` against a real release (not run here — needs GitHub Actions; the template's own `dry-run` CI job exercises this on merge when `DRY_RUN_VERSION` is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)