### PR TITLE
feat(release): optional draft-first gate via RELEASE_DRAFT_FIRST variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2345,7 +2345,13 @@ jobs:
         with:
           files: release-assets/*
           generate_release_notes: true
-          draft: false
+          # RELEASE_DRAFT_FIRST (repo variable, normally unset): when 'true',
+          # the release is created as a DRAFT so downstream consumers (self-host
+          # servers syncing published releases) see nothing until it is
+          # explicitly published — used when a release must be verified and
+          # coordinated with out-of-band deployment steps before going live.
+          # Publish with: gh release edit <tag> --draft=false
+          draft: ${{ vars.RELEASE_DRAFT_FIRST == 'true' }}
           prerelease: ${{ contains(github.ref_name, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a repo-variable gate on the GitHub release's draft status: when `RELEASE_DRAFT_FIRST` is set to `true`, the release is created as a draft (invisible to downstream release-sync consumers) until explicitly published with `gh release edit <tag> --draft=false`. Unset/false preserves today's publish-on-tag behavior exactly.

Used for releases that must be verified and coordinated with out-of-band deployment steps before going live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)