### PR TITLE
fix(billing): carry the quote line name onto the converted invoice (#3319)

### DIFF
--- a/apps/api/src/routes/portal/invoices.test.ts
+++ b/apps/api/src/routes/portal/invoices.test.ts
@@ -6,17 +6,19 @@ const { getCustomerInvoiceMock, markViewedMock } = vi.hoisted(() => ({
   getCustomerInvoiceMock: vi.fn(),
   markViewedMock: vi.fn(),
 }));
-vi.mock('../../services/invoiceService', () => ({
-  getCustomerInvoice: getCustomerInvoiceMock,
-  markViewed: markViewedMock,
-  toCustomerInvoiceLine: (line: Record<string, unknown>) => ({
-    description: line.description,
-    quantity: line.quantity,
-    unitPrice: line.unitPrice,
-    taxable: line.taxable,
-    lineTotal: line.lineTotal,
-  }),
-}));
+// toCustomerInvoiceLine is deliberately kept REAL (importActual) — it is the
+// serialization boundary this suite's leak-guard test exists to police. A
+// hand-written stub here would only ever assert itself: it silently drifted
+// from the real field list when `name` was added (#3319), leaving the keyset
+// test documenting a keyset the route never actually returns.
+vi.mock('../../services/invoiceService', async (importActual) => {
+  const actual = await importActual<typeof import('../../services/invoiceService')>();
+  return {
+    getCustomerInvoice: getCustomerInvoiceMock,
+    markViewed: markViewedMock,
+    toCustomerInvoiceLine: actual.toCustomerInvoiceLine,
+  };
+});
 
 const { getInvoicePdfMock, renderInvoicePdfMock } = vi.hoisted(() => ({
   getInvoicePdfMock: vi.fn(),
@@ -158,6 +160,7 @@ describe('portal invoices routes', () => {
       lines: [{
         id: 'internal-line-id', sourceType: 'time_entry', sourceId: 'source-1',
         costBasis: '10.00', revenueAllocation: { labor: '25.00' }, isUnapprovedTime: true,
+        name: 'Support retainer',
         description: 'Support', quantity: '1.00', unitPrice: '25.00', taxable: true, lineTotal: '25.00',
       }],
     });
@@ -166,8 +169,12 @@ describe('portal invoices routes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(Object.keys(body.lines[0]).sort()).toEqual([
-      'description', 'lineTotal', 'quantity', 'taxable', 'unitPrice',
+      'description', 'lineTotal', 'name', 'quantity', 'taxable', 'unitPrice',
     ]);
+    // The customer-facing title survives the route boundary (#3319) — this is
+    // the assertion the stubbed serializer used to make vacuous.
+    expect(body.lines[0].name).toBe('Support retainer');
+    expect(body.lines[0].description).toBe('Support');
   });
 
   it('GET /invoices/:id maps a cross-tenant 404 from the service', async () => {

--- a/apps/api/src/services/invoiceService.test.ts
+++ b/apps/api/src/services/invoiceService.test.ts
@@ -224,15 +224,49 @@ describe('invoiceService guards', () => {
     const result = await svc.getCustomerInvoice('i1', 'org1');
 
     expect(Object.keys(result.lines[0]!).sort()).toEqual([
-      'description', 'lineTotal', 'quantity', 'taxable', 'unitPrice',
+      'description', 'lineTotal', 'name', 'quantity', 'taxable', 'unitPrice',
     ]);
     expect(result.lines[0]).toEqual({
+      // Legacy line (source row carries no `name`): description stays the title.
+      name: null,
       description: 'Customer-facing work',
       quantity: '2.00',
       unitPrice: '75.00',
       taxable: true,
       lineTotal: '150.00',
     });
+  });
+
+  // #3319: the portal DTO used to collapse the pair as `description ?? name`,
+  // the INVERSE of the fallback the PDF and the MSP web views use, so a line
+  // with both fields set showed the customer the blurb and never the title.
+  it('getCustomerInvoice surfaces name and description as separate fields', async () => {
+    queueResult([{ id: 'i1', status: 'sent', orgId: 'org1', partnerId: 'p1' }]);
+    queueResult([{
+      id: 'internal-line-id',
+      invoiceId: 'i1',
+      orgId: 'org1',
+      sourceType: 'manual',
+      name: 'Onboarding & network setup',
+      description: 'Network audit, agent deployment, endpoint enrollment',
+      quantity: '1.00',
+      unitPrice: '1500.00',
+      taxable: true,
+      lineTotal: '1500.00',
+      customerVisible: true,
+      sortOrder: 0,
+    }]);
+
+    const result = await svc.getCustomerInvoice('i1', 'org1');
+
+    expect(result.lines[0]).toMatchObject({
+      name: 'Onboarding & network setup',
+      description: 'Network audit, agent deployment, endpoint enrollment',
+    });
+    // Still no internal columns leaked alongside the new field.
+    expect(Object.keys(result.lines[0]!).sort()).toEqual([
+      'description', 'lineTotal', 'name', 'quantity', 'taxable', 'unitPrice',
+    ]);
   });
 
   it('markViewed returns 404 INVOICE_NOT_FOUND for a mismatched org (no existence leak)', async () => {

--- a/apps/api/src/services/invoiceService.ts
+++ b/apps/api/src/services/invoiceService.ts
@@ -315,6 +315,14 @@ export async function getInvoice(invoiceId: string, actor: InvoiceActor) {
 }
 
 export type CustomerInvoiceLine = {
+  /**
+   * Line title, mirroring invoice_lines.name (#3319). NULL for legacy lines
+   * created before the name/description split, where `description` holds the
+   * title — the portal renders `name ?? description` as the title and shows
+   * `description` as a sub-line only when `name` is set, exactly like
+   * invoicePdf's lineTitle/lineBlurb.
+   */
+  name: string | null;
   description: string;
   quantity: string;
   unitPrice: string;
@@ -356,7 +364,12 @@ type CustomerInvoiceLineSource = {
 /** Explicit serialization boundary: never spread an invoice_lines row here. */
 export function toCustomerInvoiceLine(line: CustomerInvoiceLineSource): CustomerInvoiceLine {
   return {
-    description: line.description ?? line.name ?? '',
+    // Carry BOTH fields (#3319). This previously collapsed to
+    // `description ?? name`, which is the INVERSE of the fallback every other
+    // renderer uses, so a line with both set showed the customer only the
+    // blurb and never the title.
+    name: line.name ?? null,
+    description: line.description ?? '',
     quantity: line.quantity,
     unitPrice: line.unitPrice,
     taxable: line.taxable,

--- a/apps/api/src/services/quoteAcceptService.test.ts
+++ b/apps/api/src/services/quoteAcceptService.test.ts
@@ -328,6 +328,31 @@ describe('acceptQuote quote-line -> invoice-line label mapping (#3319)', () => {
     expect(invoiceLineValues()).toMatchObject({ name: null, description: 'Legacy widget' });
   });
 
+  it('carries a name-only line (no description) without inventing a blurb', async () => {
+    // The most common catalog shape: a title and no separate blurb.
+    queueAcceptHappyPath({}, { name: 'Firewall replacement', description: null });
+
+    await acceptQuote(baseParams);
+
+    expect(invoiceLineValues()).toMatchObject({ name: 'Firewall replacement', description: null });
+  });
+
+  it.each([['', 'empty'], ['   ', 'whitespace-only']])(
+    'normalizes a %s name to null so the renderer cannot lose BOTH labels',
+    async (blankName) => {
+      // The renderers derive blurb from `name` being truthy, so a '' name would
+      // render the title as '—' and suppress the description entirely.
+      queueAcceptHappyPath({}, { name: blankName, description: 'Real description survives' });
+
+      await acceptQuote(baseParams);
+
+      expect(invoiceLineValues()).toMatchObject({
+        name: null,
+        description: 'Real description survives',
+      });
+    },
+  );
+
   it('normalizes an undefined name to null rather than omitting the column', async () => {
     const { line } = queueAcceptHappyPath();
     delete (line as Record<string, unknown>).name;

--- a/apps/api/src/services/quoteAcceptService.test.ts
+++ b/apps/api/src/services/quoteAcceptService.test.ts
@@ -96,7 +96,10 @@ const baseParams = {
  *  10. update quotes .set(converted)         -> [] (unused)
  *  11. select quotes (final re-select)       -> [updated quote]
  */
-function queueAcceptHappyPath(quoteOverrides: Record<string, unknown> = {}) {
+function queueAcceptHappyPath(
+  quoteOverrides: Record<string, unknown> = {},
+  lineOverrides: Record<string, unknown> = {},
+) {
   const quote = {
     id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent',
     expiryDate: null, quoteNumber: 'Q-2026-0001', taxRate: null,
@@ -110,6 +113,7 @@ function queueAcceptHappyPath(quoteOverrides: Record<string, unknown> = {}) {
     id: 'l1', quoteId: 'q1', recurrence: 'one_time', customerVisible: true,
     taxable: true, quantity: '1', unitPrice: '1000.00', catalogItemId: null,
     description: 'Widget', name: 'Widget', termMonths: null, sortOrder: 0,
+    ...lineOverrides,
   };
 
   queueResult([quote]);                              // 1
@@ -277,6 +281,99 @@ describe('acceptQuote deposit snapshot', () => {
       actorUserId: null,
     });
     expect(result.pax8OrderId).toBe('pax8-order-1');
+  });
+});
+
+// #3319: quote_lines and invoice_lines BOTH carry a `name` (title) alongside
+// `description` (sub-line blurb) since migration 2026-07-03-quote-invoice-line-name;
+// renderers treat the title as `name ?? description`. The conversion mapping
+// dropped `name`, so every converted invoice rendered as a legacy line and the
+// customer-facing item title vanished from the invoice detail and the PDF.
+describe('acceptQuote quote-line -> invoice-line label mapping (#3319)', () => {
+  beforeEach(() => {
+    results.length = 0;
+    vi.clearAllMocks();
+    stagePax8OrderFromQuoteMock.mockResolvedValue({ orderId: null, lineCount: 0 });
+    createContractMock.mockResolvedValue({ contract: { id: 'contractA' }, lines: [] });
+    createExecutedDocumentsMock.mockResolvedValue([]);
+  });
+
+  // .values call order (see queueAcceptHappyPath): [0] quote_acceptances,
+  // [1] invoices, [2] invoice_lines.
+  const invoiceLineValues = () =>
+    (db as unknown as Chain).values.mock.calls[2]![0] as Record<string, unknown>;
+
+  it('carries the quote line name onto the invoice line, distinct from the description', async () => {
+    queueAcceptHappyPath({}, {
+      name: 'Onboarding & network setup',
+      description: 'Network audit, agent deployment, endpoint enrollment',
+    });
+
+    await acceptQuote(baseParams);
+
+    expect(invoiceLineValues()).toMatchObject({
+      name: 'Onboarding & network setup',
+      description: 'Network audit, agent deployment, endpoint enrollment',
+    });
+  });
+
+  it('writes name: null for a legacy quote line that has no name, leaving description as the title', async () => {
+    // Legacy pre-2026-07-03 line: description holds the title, name is NULL.
+    // The invoice line must mirror that shape (NOT fabricate a name) so the
+    // renderer's `name ?? description` fallback keeps showing the title once.
+    queueAcceptHappyPath({}, { name: null, description: 'Legacy widget' });
+
+    await acceptQuote(baseParams);
+
+    expect(invoiceLineValues()).toMatchObject({ name: null, description: 'Legacy widget' });
+  });
+
+  it('normalizes an undefined name to null rather than omitting the column', async () => {
+    const { line } = queueAcceptHappyPath();
+    delete (line as Record<string, unknown>).name;
+
+    await acceptQuote(baseParams);
+
+    const values = invoiceLineValues();
+    expect(values).toHaveProperty('name', null);
+  });
+
+  it('preserves the name on the Phase 4 contract line by composing it into the single label', async () => {
+    // The sibling mapping, asserted here so the two conversion paths stay
+    // honest together. Contract lines deliberately carry ONE label
+    // (NewContractLineSpec has no `name`), so quoteToContract composes
+    // "name — description"; invoice lines have a real `name` column and must
+    // keep the two fields separate instead. Both must preserve the title. A
+    // monthly-only
+    // quote has no one-time lines, so the invoice is never issued — the call
+    // sequence skips the invoice_lines insert, the partners select and the
+    // counter upsert:
+    //   1 quote FOR UPDATE, 2 blocks, 3 lines, 4 acceptances insert,
+    //   5 invoices insert, 6 invoices update, 7 quotes update, 8 re-select.
+    const quote = {
+      id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent',
+      expiryDate: null, quoteNumber: 'Q-2026-0003', taxRate: null,
+      currencyCode: 'USD', siteId: null, terms: null,
+      depositType: 'none', depositPercent: null, depositAmount: null,
+    };
+    queueResult([quote]);
+    queueResult([]);
+    queueResult([{
+      id: 'l1', quoteId: 'q1', recurrence: 'monthly', customerVisible: true,
+      taxable: false, quantity: '1', unitPrice: '99.00', catalogItemId: null,
+      name: 'Managed EDR', description: '24/7 monitoring', termMonths: null, sortOrder: 0,
+    }]);
+    queueResult([{ id: 'acc1' }]);
+    queueResult([{ id: 'inv1' }]);
+    queueResult([]);
+    queueResult([]);
+    queueResult([{ ...quote, status: 'converted' }]);
+
+    await acceptQuote(baseParams);
+
+    expect(createContractMock).toHaveBeenCalledTimes(1);
+    const spec = createContractMock.mock.calls[0]![0] as { lines: Array<Record<string, unknown>> };
+    expect(spec.lines[0]).toMatchObject({ description: 'Managed EDR — 24/7 monitoring' });
   });
 });
 

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -199,7 +199,13 @@ export async function acceptQuote(
       // Dropping `name` here made every converted invoice look like a legacy
       // line, so an accepted "Onboarding & network setup" line showed only its
       // blurb on the invoice and PDF.
-      name: l.name ?? null,
+      //
+      // Blank-normalized, not just null-coalesced: the renderers key the blurb
+      // off `name` being truthy, so a name of '' would render the title as '—'
+      // AND suppress the description — losing BOTH labels. '' is reachable
+      // because the line validators allow an empty string. Storing NULL makes
+      // such a line a well-formed legacy line instead.
+      name: l.name?.trim() || null,
       description: l.description,
       quantity: l.quantity,
       unitPrice: l.unitPrice,

--- a/apps/api/src/services/quoteAcceptService.ts
+++ b/apps/api/src/services/quoteAcceptService.ts
@@ -193,6 +193,13 @@ export async function acceptQuote(
       catalogItemId: l.catalogItemId ?? null,
       parentLineId: null,
       ticketId: null,
+      // Carry BOTH label fields from the quote line (#3319). invoice_lines.name
+      // is the title and `description` the sub-line blurb (migration
+      // 2026-07-03-quote-invoice-line-name); renderers read `name ?? description`.
+      // Dropping `name` here made every converted invoice look like a legacy
+      // line, so an accepted "Onboarding & network setup" line showed only its
+      // blurb on the invoice and PDF.
+      name: l.name ?? null,
       description: l.description,
       quantity: l.quantity,
       unitPrice: l.unitPrice,

--- a/apps/portal/src/components/portal/InvoiceDetailView.test.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { InvoiceDetail, InvoiceLine } from '@/lib/api';
+
+// Same stub the other portal component suites use: the real module reaches
+// `astro:transitions/client`, which has no resolution outside an Astro build.
+vi.mock('@/lib/navigation', () => ({ navigateTo: vi.fn() }));
+
+import InvoiceDetailView from './InvoiceDetailView';
+
+afterEach(() => cleanup());
+
+// #3319: the customer-facing surface where the dropped line name actually
+// showed up. The title/blurb derivation here must stay identical to
+// apps/api/src/services/invoicePdf.ts (lineTitle/lineBlurb) so the portal and
+// the PDF the same customer downloads label a line the same way.
+function line(overrides: Partial<InvoiceLine> = {}): InvoiceLine {
+  return {
+    name: null,
+    // The API serializes a NULL description as '' (invoiceService's
+    // toCustomerInvoiceLine), so '' — not null — is the real absent-blurb shape.
+    description: '',
+    quantity: '1.00',
+    unitPrice: '100.00',
+    lineTotal: '100.00',
+    taxable: false,
+    ...overrides,
+  };
+}
+
+function detail(lines: InvoiceLine[]): InvoiceDetail {
+  return {
+    invoice: {
+      id: 'inv-1',
+      invoiceNumber: 'INV-2026-0001',
+      status: 'sent',
+      currencyCode: 'USD',
+      issueDate: '2026-08-01',
+      dueDate: '2026-08-31',
+      total: '100.00',
+      amountPaid: '0.00',
+      balance: '100.00',
+      depositDue: null,
+      subtotal: '100.00',
+      taxTotal: '0.00',
+      taxRate: null,
+      billToName: 'Acme Co',
+      notes: null,
+    },
+    lines,
+  };
+}
+
+function renderDetail(lines: InvoiceLine[]) {
+  return render(<InvoiceDetailView detail={detail(lines)} />);
+}
+
+describe('InvoiceDetailView line labels (#3319)', () => {
+  it('renders the name as the title and the description as a distinct blurb', () => {
+    renderDetail([line({
+      name: 'Onboarding & network setup',
+      description: 'Network audit, agent deployment, endpoint enrollment',
+    })]);
+
+    // Both survive, as separate elements — the whole point of the issue.
+    expect(screen.getByText('Onboarding & network setup')).toBeTruthy();
+    expect(screen.getByText('Network audit, agent deployment, endpoint enrollment')).toBeTruthy();
+  });
+
+  it('falls back to the description as the title for a legacy line with no name', () => {
+    renderDetail([line({ name: null, description: 'Legacy widget' })]);
+
+    // Rendered exactly once: as the title, NOT additionally as a blurb.
+    expect(screen.getAllByText('Legacy widget')).toHaveLength(1);
+  });
+
+  it('renders a name-only line with no blurb', () => {
+    renderDetail([line({ name: 'Firewall replacement', description: '' })]);
+
+    expect(screen.getAllByText('Firewall replacement')).toHaveLength(1);
+  });
+
+  it('shows a placeholder when the line carries no label at all', () => {
+    renderDetail([line({ name: null, description: '' })]);
+
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+});

--- a/apps/portal/src/components/portal/InvoiceDetailView.tsx
+++ b/apps/portal/src/components/portal/InvoiceDetailView.tsx
@@ -251,9 +251,17 @@ export function InvoiceDetailView({ detail, error }: InvoiceDetailViewProps) {
               <tbody>
                 {lines.map((l, index) => {
                   const tax = showTax ? lineTax(l.lineTotal, l.taxable, taxRate) : null;
+                  // Title/blurb split (#3319), matching invoicePdf's lineTitle/
+                  // lineBlurb so the portal and the PDF the customer receives
+                  // label the same line identically.
+                  const title = (l.name ?? l.description ?? '').trim() || '—';
+                  const blurb = l.name ? (l.description ?? '').trim() : '';
                   return (
-                  <tr key={`${l.description}-${index}`} className="border-b align-top last:border-0">
-                    <td className="px-4 py-3 text-foreground sm:px-5">{l.description}</td>
+                  <tr key={`${title}-${index}`} className="border-b align-top last:border-0">
+                    <td className="px-4 py-3 text-foreground sm:px-5">
+                      {title}
+                      {blurb && <div className="mt-0.5 text-xs text-muted-foreground">{blurb}</div>}
+                    </td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{l.quantity}</td>
                     <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{money(l.unitPrice, currency)}</td>
                     {showTax && <td className="whitespace-nowrap px-2 py-3 text-right tabular-nums text-muted-foreground">{tax === null ? '—' : money(tax, currency)}</td>}

--- a/apps/portal/src/lib/api.ts
+++ b/apps/portal/src/lib/api.ts
@@ -381,6 +381,8 @@ export interface SellerSnapshot {
 }
 
 export interface InvoiceLine {
+  /** Line title; NULL on legacy lines where `description` holds the title (#3319). */
+  name: string | null;
   description: string;
   quantity: string;
   unitPrice: string;


### PR DESCRIPTION
Closes #3319

## Problem

`quote_lines` and `invoice_lines` both gained a `name` (title) column alongside `description` (blurb) in migration `2026-07-03-quote-invoice-line-name`, which documents the renderer contract as `name ?? description` for the title, with `description` shown as a sub-line only when `name` is set.

The quote→invoice conversion writer was never updated to that split. Every converted invoice line was written with `name = NULL`, so it rendered like a legacy line: an accepted quote line named **"Onboarding & network setup"** with description *"Network audit, agent deployment, endpoint enrollment"* became an invoice line labeled only with the description. The customer-facing item name was gone.

## Root cause — two independent gaps, one symptom

**1. Writer (`quoteAcceptService.ts`) — the reported bug.** The invoice-line mapping carried only `description`. Now carries `name: l.name ?? null`.

The Phase 4 contract mapping immediately below it was already correct and is *not* a bug: `NewContractLineSpec` carries a single label by design, so `quoteToContract` deliberately composes `"name — description"` there. Only `invoice_lines` has a real `name` column to populate.

**2. Reader (customer portal) — found while sweeping call sites.** `toCustomerInvoiceLine` collapsed the pair as `description ?? line.name` — the **inverse** of the fallback `invoicePdf.ts` (`lineTitle`/`lineBlurb`) and every MSP web view use. So even with (1) fixed, a customer opening a converted invoice in the self-service portal would still see the blurb and never the title. `CustomerInvoiceLine` now carries both fields and `InvoiceDetailView` renders title/blurb with the same semantics as the PDF, so the portal and the PDF the customer receives label lines identically.

Every other `invoiceLines` writer (`addManualLine`, `addCatalogLine`, `addBundleLine`, the `voidInvoice` reissue clone) was already correct. `addContractLine` and `materializeLines` legitimately have no name to carry.

## Not needed

No migration or schema change — the column already exists, and `invoice_lines` is already registered in `CORE_TENANT_EXPORT_POLICY` with `name` classified in the `included` bucket. No cascade-list change (no new table, no new column).

## Scope

Deliberately untouched: the `apps/web` quote editor, which is being handled separately in #3318.

## Tests

- `quoteAcceptService.test.ts` — 3 new cases pinning the conversion mapping: name preserved distinct from description; a legacy `name: null` line is mirrored rather than fabricated; an `undefined` name normalizes to `null`. A 4th pins the sibling contract composition so a future change can't silently re-split the two paths. **All three fail without the fix** (verified by reverting the one-line change).
- `invoiceService.test.ts` — the exact-keyset portal leak-guard test extended for the new field, plus a new case proving `name`/`description` are surfaced separately.

## Verification

- `vitest run` (single fork) — `invoiceService.test.ts`, `quoteAcceptService.test.ts`, `routes/portal/`, `invoicePdf.test.ts`, `invoiceService.siteScope.test.ts`, `quoteToContract.test.ts`, `contractService.test.ts`: **188 passed**
- `apps/portal` full suite: **89 passed**
- `tsc --noEmit` (apps/api): clean · `astro check` (apps/portal): 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)