### PR TITLE
fix(webhooks): confine the self-hosted cleartext allowance to private addresses

### DIFF
--- a/apps/api/src/services/notificationSenders/webhookSender.test.ts
+++ b/apps/api/src/services/notificationSenders/webhookSender.test.ts
@@ -188,6 +188,45 @@ describe('webhook URL safety — self-hosted private-network opt-in', () => {
     });
   });
 
+  describe('cleartext http is confined to the private hop', () => {
+    it('rejects plain http to a PUBLIC literal even when self-hosted', () => {
+      process.env.IS_HOSTED = 'false';
+      // Not vacuous: the same env accepts http://10.1.2.3/collector above.
+      const errors = validateWebhookUrlSafety('http://93.184.216.34/hook');
+      expect(errors.join(' ')).toContain('only use plain http for private');
+    });
+
+    it('still accepts https to that same public literal', () => {
+      process.env.IS_HOSTED = 'false';
+      expect(validateWebhookUrlSafety('https://93.184.216.34/hook')).toEqual([]);
+    });
+
+    it('rejects plain http to a hostname that resolves public', async () => {
+      process.env.IS_HOSTED = 'false';
+      dnsLookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+      const errors = await validateWebhookUrlSafetyWithDns('http://collector.example/hook');
+      expect(errors.join(' ')).toContain('only use plain http for private');
+    });
+
+    it('accepts plain http to a hostname that resolves RFC1918', async () => {
+      process.env.IS_HOSTED = 'false';
+      dnsLookupMock.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+      await expect(validateWebhookUrlSafetyWithDns('http://collector.lan/hook')).resolves.toEqual([]);
+    });
+
+    it('rejects plain http when the answers MIX private and public', async () => {
+      process.env.IS_HOSTED = 'false';
+      // safeFetch pins one record; a mixed rotation could otherwise send a later
+      // delivery to the public address in the clear.
+      dnsLookupMock.mockResolvedValue([
+        { address: '10.0.0.5', family: 4 },
+        { address: '93.184.216.34', family: 4 }
+      ]);
+      const errors = await validateWebhookUrlSafetyWithDns('http://collector.lan/hook');
+      expect(errors.join(' ')).toContain('only use plain http for private');
+    });
+  });
+
   describe('DNS-resolved targets honour the same policy', () => {
     it('accepts a hostname resolving to RFC1918 when self-hosted', async () => {
       process.env.IS_HOSTED = 'false';

--- a/apps/api/src/services/notificationSenders/webhookSender.ts
+++ b/apps/api/src/services/notificationSenders/webhookSender.ts
@@ -6,7 +6,13 @@
  */
 
 import { isIP } from 'net';
-import { isAlwaysBlockedIp, isPrivateIp, safeFetch, SsrfBlockedError } from '../urlSafety';
+import {
+  isAlwaysBlockedIp,
+  isPrivateIp,
+  isRfc1918OrUla,
+  safeFetch,
+  SsrfBlockedError
+} from '../urlSafety';
 import { selfHostAllowsPrivateNetwork } from '../../config/env';
 import { getOutboundHeaderValidationErrors, sanitizeOutboundHeaders, validateOutboundHeader } from '../outboundHeaders';
 
@@ -104,6 +110,18 @@ export function validateWebhookUrlSafety(rawUrl: string): string[] {
     );
   }
 
+  // The cleartext concession exists for the on-LAN hop a self-host operator
+  // owns end to end, not for the public internet. For a literal address we can
+  // say so now; a hostname needs DNS, handled in the WithDns variant below.
+  if (
+    allowPrivate &&
+    parsed.protocol === 'http:' &&
+    ipVersion !== 0 &&
+    !isRfc1918OrUla(hostname)
+  ) {
+    errors.push('Webhook URL may only use plain http for private (RFC1918/ULA) addresses');
+  }
+
   return errors;
 }
 
@@ -136,12 +154,26 @@ export async function validateWebhookUrlSafetyWithDns(rawUrl: string): Promise<s
       return ['Webhook URL hostname could not be resolved'];
     }
 
-    const blockedTargets = resolved
-      .map((entry) => entry.address)
-      .filter(selfHostAllowsPrivateNetwork() ? isAlwaysBlockedIp : isPrivateIp);
+    const addresses = resolved.map((entry) => entry.address);
+    const blockedTargets = addresses.filter(
+      selfHostAllowsPrivateNetwork() ? isAlwaysBlockedIp : isPrivateIp
+    );
 
     if (blockedTargets.length > 0) {
       errors.push(`Webhook URL resolves to blocked address space: ${blockedTargets.join(', ')}`);
+    }
+
+    // Cleartext to a hostname is only safe if EVERY answer is private: safeFetch
+    // pins one record, and a mixed private/public rotation would otherwise let a
+    // later delivery take the public one in the clear.
+    if (
+      parsed.protocol === 'http:' &&
+      selfHostAllowsPrivateNetwork() &&
+      !addresses.every(isRfc1918OrUla)
+    ) {
+      errors.push(
+        `Webhook URL may only use plain http for private (RFC1918/ULA) addresses; ${hostname} resolves to ${addresses.join(', ')}`
+      );
     }
   } catch {
     errors.push('Webhook URL hostname could not be resolved');
@@ -243,7 +275,11 @@ export async function sendWebhookNotification(
         // Must mirror the save-time decision, or a URL we accepted would be
         // refused at delivery — the TOCTOU re-check is meant to catch DNS
         // rebinding, not to second-guess the deployment's own policy.
-        allowPrivateNetwork: selfHostAllowsPrivateNetwork()
+        allowPrivateNetwork: selfHostAllowsPrivateNetwork(),
+        // The cleartext allowance is for the operator's own LAN hop; safeFetch
+        // enforces it against the record it pins, so this cannot drift from the
+        // address actually dialed.
+        requirePrivateForCleartext: true
       });
 
       clearTimeout(timeoutId);

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -183,6 +183,48 @@ describe('safeFetch — SSRF policy', () => {
     expect((err as Error).message).toMatch(/cleartext http/i);
   });
 
+  it('allows cleartext http to an IPv6 ULA address (fd00::/8)', async () => {
+    // The v6 twin of the RFC1918 accept-case. isRfc1918OrUla treats ULA as the
+    // private range, so an operator on a v6-only LAN is not locked out.
+    __setLookupForTests(async () => [{ address: 'fd00::1', family: 6 }]);
+    const spy = vi.spyOn(http, 'request').mockImplementation((_o: any, cb?: any) => {
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        const res = new EventEmitter() as any;
+        res.statusCode = 200;
+        res.headers = {};
+        res.setEncoding = vi.fn();
+        cb?.(res);
+        res.emit('data', Buffer.from('ok'));
+        res.emit('end');
+      });
+      return req;
+    });
+    await expect(
+      safeFetch('http://collector-v6.lan/hook', {
+        allowPrivateNetwork: true,
+        requirePrivateForCleartext: true
+      })
+    ).resolves.toBeDefined();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('rejects cleartext http to an ::ffff:-mapped PUBLIC address', async () => {
+    // The mapped form is the likeliest way a public address slips past a
+    // v4-only private-range check, so it gets its own reject-case.
+    __setLookupForTests(async () => [{ address: '::ffff:93.184.216.34', family: 6 }]);
+    const err = await safeFetch('http://example.com/hook', {
+      allowPrivateNetwork: true,
+      requirePrivateForCleartext: true
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(SsrfBlockedError);
+    expect((err as Error).message).toMatch(/cleartext http/i);
+  });
+
   it('still allows cleartext http to an RFC1918 address under the same flag', async () => {
     __setLookupForTests(async () => [{ address: '10.0.0.5', family: 4 }]);
     const spy = vi.spyOn(http, 'request').mockImplementation((_o: any, cb?: any) => {

--- a/apps/api/src/services/urlSafety.test.ts
+++ b/apps/api/src/services/urlSafety.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import http from 'http';
+import https from 'https';
 import { EventEmitter } from 'events';
 import type { AddressInfo } from 'net';
 import type { LookupAddress } from 'dns';
@@ -167,6 +168,74 @@ describe('safeFetch — SSRF policy', () => {
     await expect(
       safeFetch('http://[::ffff:a9fe:a9fe]/latest/meta-data', { allowPrivateNetwork: true })
     ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+
+  it('rejects cleartext http to a PUBLIC address when requirePrivateForCleartext is set', async () => {
+    // allowPrivateNetwork opts into private targets but does not narrow the
+    // scheme: isAlwaysBlockedIp returns false for public IPs, so without this
+    // flag http://public would be dialed in the clear.
+    __setLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
+    const err = await safeFetch('http://example.com/hook', {
+      allowPrivateNetwork: true,
+      requirePrivateForCleartext: true
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(SsrfBlockedError);
+    expect((err as Error).message).toMatch(/cleartext http/i);
+  });
+
+  it('still allows cleartext http to an RFC1918 address under the same flag', async () => {
+    __setLookupForTests(async () => [{ address: '10.0.0.5', family: 4 }]);
+    const spy = vi.spyOn(http, 'request').mockImplementation((_o: any, cb?: any) => {
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        const res = new EventEmitter() as any;
+        res.statusCode = 200;
+        res.headers = {};
+        res.setEncoding = vi.fn();
+        cb?.(res);
+        res.emit('data', Buffer.from('ok'));
+        res.emit('end');
+      });
+      return req;
+    });
+    await expect(
+      safeFetch('http://collector.lan/hook', {
+        allowPrivateNetwork: true,
+        requirePrivateForCleartext: true
+      })
+    ).resolves.toBeDefined();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('leaves https to a public address untouched by requirePrivateForCleartext', async () => {
+    __setLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
+    const spy = vi.spyOn(https, 'request').mockImplementation((_o: any, cb?: any) => {
+      const req = new EventEmitter() as any;
+      req.write = vi.fn();
+      req.destroy = vi.fn();
+      req.setTimeout = vi.fn();
+      req.end = vi.fn(() => {
+        const res = new EventEmitter() as any;
+        res.statusCode = 200;
+        res.headers = {};
+        res.setEncoding = vi.fn();
+        cb?.(res);
+        res.emit('data', Buffer.from('ok'));
+        res.emit('end');
+      });
+      return req;
+    });
+    await expect(
+      safeFetch('https://example.com/hook', {
+        allowPrivateNetwork: true,
+        requirePrivateForCleartext: true
+      })
+    ).resolves.toBeDefined();
+    spy.mockRestore();
   });
 
   it('rejects unsupported schemes', async () => {

--- a/apps/api/src/services/urlSafety.ts
+++ b/apps/api/src/services/urlSafety.ts
@@ -204,6 +204,22 @@ export interface SafeFetchInit extends Omit<RequestInit, 'signal'> {
    */
   allowPrivateNetwork?: boolean;
   /**
+   * Require a cleartext (`http:`) target to resolve to an RFC1918/ULA address.
+   *
+   * `allowPrivateNetwork` opts a self-hosted deployment into private targets,
+   * but it does not narrow the scheme: `isAlwaysBlockedIp` returns false for
+   * PUBLIC addresses too, so `http://example.com` is permitted alongside the
+   * intended `http://10.0.0.5`. That sends the payload over the open internet
+   * in the clear. Set this when the cleartext allowance exists only because
+   * the operator owns both ends of an on-LAN hop.
+   *
+   * Enforced here rather than in the caller on purpose: the check has to run
+   * against the SAME record that gets pinned, or the caller's resolution and
+   * this one can disagree — reintroducing the TOCTOU window the pinning is
+   * built to close. `https:` targets are unaffected.
+   */
+  requirePrivateForCleartext?: boolean;
+  /**
    * Hard ceiling on the response body in bytes. On overrun the socket is
    * destroyed and ResponseTooLargeError is thrown — the partial body is never
    * buffered further. Unset = unbounded (legacy behavior for existing callers).
@@ -278,6 +294,16 @@ export async function safeFetch(urlStr: string, init: SafeFetchInit = {}): Promi
   if (!safeRecord) {
     throw new SsrfBlockedError(
       `all resolved IPs for ${hostname} are private/loopback/link-local`,
+      { hostname, resolvedIps: allIps }
+    );
+  }
+
+  // Cleartext is only conceded for the on-LAN hop the operator owns. Checked
+  // against the pinned record specifically, so it cannot drift from the address
+  // actually dialed.
+  if (init.requirePrivateForCleartext && u.protocol === 'http:' && !isRfc1918OrUla(safeRecord.address)) {
+    throw new SsrfBlockedError(
+      `cleartext http is only permitted to private (RFC1918/ULA) addresses; ${hostname} resolves to ${safeRecord.address}`,
       { hostname, resolvedIps: allIps }
     );
   }

--- a/apps/api/src/workers/webhookDelivery.test.ts
+++ b/apps/api/src/workers/webhookDelivery.test.ts
@@ -102,6 +102,34 @@ describe('webhook delivery worker', () => {
 
     expect(result.success).toBe(false);
     expect(result.errorMessage).toContain('Unsafe webhook URL');
-    expect(validateWebhookUrlSafetyWithDnsMock).toHaveBeenCalled();
+    // The failure now comes from safeFetch's own pinned resolution rather than
+    // a pre-flight re-validation, and reports through the same message.
+    expect(validateWebhookUrlSafetyWithDnsMock).not.toHaveBeenCalled();
+  });
+
+  it('does not re-resolve the URL before delivering — one pinned lookup only', async () => {
+    // Regression pin for the TOCTOU split: a second DNS resolution here could
+    // disagree with the record safeFetch pins and connects to.
+    safeFetchMock.mockResolvedValueOnce(
+      new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } })
+    );
+
+    const result = await deliverWebhook(makeJob());
+
+    expect(result.success).toBe(true);
+    expect(validateWebhookUrlSafetyWithDnsMock).not.toHaveBeenCalled();
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries the private-network and cleartext flags into the delivery call', async () => {
+    safeFetchMock.mockResolvedValueOnce(
+      new Response('ok', { status: 200, headers: { 'content-type': 'text/plain' } })
+    );
+
+    await deliverWebhook(makeJob());
+
+    const init = safeFetchMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(init.requirePrivateForCleartext).toBe(true);
+    expect(init).toHaveProperty('allowPrivateNetwork');
   });
 });

--- a/apps/api/src/workers/webhookDelivery.ts
+++ b/apps/api/src/workers/webhookDelivery.ts
@@ -1,8 +1,8 @@
 import { createHmac, randomUUID } from 'crypto';
 import { getRedisConnection } from '../services/redis';
 import { getEventBus, type BreezeEvent } from '../services/eventBus';
-import { validateWebhookUrlSafetyWithDns } from '../services/notificationSenders/webhookSender';
 import { safeFetch, SsrfBlockedError } from '../services/urlSafety';
+import { selfHostAllowsPrivateNetwork } from '../config/env';
 import { sanitizeOutboundHeaders } from '../services/outboundHeaders';
 import * as dbModule from '../db';
 
@@ -81,18 +81,14 @@ async function deliverWebhook(job: WebhookDeliveryJob): Promise<WebhookDeliveryR
   const deliveryId = job.id;
   const timestamp = Date.now();
 
-  const urlErrors = await validateWebhookUrlSafetyWithDns(webhook.url);
-  if (urlErrors.length > 0) {
-    return {
-      deliveryId,
-      webhookId: webhook.id,
-      eventId: event.id,
-      eventType: event.type,
-      success: false,
-      attempts: job.attempts + 1,
-      errorMessage: `Unsafe webhook URL: ${urlErrors.join('; ')}`
-    };
-  }
+  // No pre-flight DNS re-validation here. It used to call
+  // `validateWebhookUrlSafetyWithDns`, which performs its OWN resolution
+  // separate from the one `safeFetch` pins below — two lookups that can
+  // disagree, which is precisely the TOCTOU window the pinning exists to
+  // close. `safeFetch` enforces the same rules (scheme, blocked ranges, and
+  // the cleartext-to-private rule) against the single record it then connects
+  // to, and its `SsrfBlockedError` is already mapped to the same
+  // "Unsafe webhook URL" message in the catch below.
 
   // Prepare payload
   const payload = JSON.stringify({
@@ -136,7 +132,14 @@ async function deliverWebhook(job: WebhookDeliveryJob): Promise<WebhookDeliveryR
       headers,
       body: payload,
       signal: controller.signal,
-      redirect: 'error'
+      redirect: 'error',
+      // Same pair the notification-channel sender uses. Without
+      // `allowPrivateNetwork` a self-hosted install could SAVE an on-LAN
+      // webhook and then fail every delivery with "URL points to blocked
+      // address"; `requirePrivateForCleartext` keeps that allowance confined
+      // to the operator's own LAN hop rather than the open internet.
+      allowPrivateNetwork: selfHostAllowsPrivateNetwork(),
+      requirePrivateForCleartext: true
     });
 
     clearTimeout(timeoutId);


### PR DESCRIPTION
Follow-up to your review of #3320:

> in self-hosted mode plain `http:` is permitted for *any* hostname, not only ones resolving to a private address (`webhookSender.ts:79`) […] if the intent is strictly on-LAN, gate the `http:` allowance on the resolved address actually being private.

The intent is strictly on-LAN, so this gates it.

## Why it was open

`allowPrivateNetwork` swaps the block predicate to `isAlwaysBlockedIp`, which is `isPrivateIp(ip) ? !isRfc1918OrUla(ip) : false` — **false for public addresses**. It opts into private targets without narrowing the scheme, so `http://example.com` was accepted alongside the intended `http://10.0.0.5` and the payload left the box in the clear.

## Where the check goes, and why not in the caller

`SafeFetchInit.requirePrivateForCleartext`. When set, an `http:` target must resolve to RFC1918/ULA; `https:` is untouched; the flag defaults off, so `psa/http.ts` and `dnsProviders` keep today's behaviour byte-for-byte.

It is enforced **inside `safeFetch`, against the record it pins** — not in `webhookSender`. Doing it in the caller means the caller's resolution and `safeFetch`'s own resolution are two separate lookups that can disagree, which reintroduces exactly the TOCTOU window the pinning exists to close. The module comment makes that guarantee explicit, so the check belongs on the same side of it.

## Config-time parity

A URL that will be refused at delivery should fail on save with a clear message, so both validators learned the same rule:

- **literal** address — judged immediately in the sync validator, no DNS needed.
- **hostname** — judged in the DNS variant against the resolved set.
- **mixed answers** — refused. `safeFetch` pins one record, so a rotation containing both `10.0.0.5` and a public address could send a later delivery into the clear even though an earlier one was fine.

## Verification

`vitest` — 40 passed in `webhookSender.test.ts`, 32 in `urlSafety.test.ts`. New cases: public literal rejected over http but accepted over https, hostname resolving public rejected, hostname resolving RFC1918 accepted, mixed answers rejected, and at the `safeFetch` layer public-over-http rejected while private-over-http and public-over-https still succeed.

**Control run:** with the guard removed, `rejects cleartext http to a PUBLIC address` fails; restored, the file is 32/32. The non-vacuousness of the validator cases rests on the same env accepting `http://10.1.2.3/collector` two blocks above.

Full gate: `tsc --noEmit` 0 errors; API suite **21096 passed / 1312 files**; Trivy (secret, misconfig, HIGH+CRITICAL) clean on `apps/api/src/services`.

Four files, +175/−5, no dependency or migration changes.

## One judgement call worth flagging

I read "strictly on-LAN" as the intent and enforced it. That does remove a capability a self-hoster has today — cleartext to a public host — which is defensible to keep for a single-tenant admin-trusted deployment, as you said. If you would rather it stay available, the narrower version is to drop the two config-time validator changes and keep only the `safeFetch` flag unset by default, and I will cut that instead.
