### PR TITLE
fix(agent): bound total shutdown time so systemd stops cleanly (#3323)

### DIFF
--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -556,10 +556,21 @@ func shutdownAgent(comps *agentComponents) {
 	}
 
 	// Notify the watchdog of intentional shutdown so it doesn't restart us.
+	//
+	// Budgeted, because this is a blocking socket write: ipc.Conn.Send arms a
+	// 30s write deadline (internal/ipc/protocol.go), so a watchdog that has
+	// stopped reading its end can park this call for longer than the entire
+	// stop window on its own — the same class of unbounded step as the log
+	// shipper, and enough to exhaust the whole budget before a single core
+	// teardown stage starts. Abandoning it is safe: the stopping-state file
+	// written just above is the durable signal the watchdog reconciles
+	// against, and this notify is only the fast path.
 	if broker := comps.hb.SessionBroker(); broker != nil {
 		if sess := broker.PreferredSessionWithScope("watchdog"); sess != nil {
-			_ = sess.SendNotify("", ipc.TypeShutdownIntent, ipc.ShutdownIntent{
-				Reason: state.ReasonUserStop,
+			clock.run("watchdog shutdown notify", watchdogNotifyBudget, func() {
+				_ = sess.SendNotify("", ipc.TypeShutdownIntent, ipc.ShutdownIntent{
+					Reason: state.ReasonUserStop,
+				})
 			})
 		}
 	}
@@ -577,6 +588,15 @@ func shutdownAgent(comps *agentComponents) {
 	clock.run("websocket stop", websocketStopBudget, comps.wsClient.Stop)
 	clock.run("heartbeat stop", heartbeatStopBudget, comps.hb.Stop)
 
+	// Zeroed unconditionally, including while an abandoned teardown goroutine
+	// may still be running. That goroutine can then read an empty bearer token
+	// and log a single warning instead of authenticating. This is accepted, and
+	// predates the shared budget — runWithTimeout has always abandoned an
+	// overrunning stage and fallen through to here. Wiping the secret is a
+	// hard guarantee at a fixed point in shutdown; the call it degrades is a
+	// best-effort one on a stage we already gave up waiting for, moments
+	// before the process exits. Deferring the wipe to chase it would trade a
+	// security property for a network call that is being dropped anyway.
 	if comps.secureToken != nil {
 		comps.secureToken.Zero()
 	}

--- a/agent/internal/agentapp/main.go
+++ b/agent/internal/agentapp/main.go
@@ -468,13 +468,23 @@ type agentComponents struct {
 // shutdownAgent gracefully stops all agent components.
 //
 // Every blocking stage is wrapped with a deadline so that a stuck HTTP flush
-// (common during OS shutdown when the network has already gone down) can't
-// pin the process past systemd's TimeoutStopSec. Total worst case is bounded
-// by the sum of per-stage timeouts; the unit file caps the outer wait at 15s.
+// (common during OS shutdown when the network has already gone down) can't pin
+// the process past the service manager's stop timeout. Stages run
+// sequentially, so their timeouts are additive — they are therefore drawn from
+// one shared shutdownBudget rather than each being independent, and the whole
+// function is bounded by that budget no matter how many stages apply. See the
+// shutdown timing contract in shutdown_budget.go for how the budget relates to
+// the unit's TimeoutStopSec (#3323).
 func shutdownAgent(comps *agentComponents) {
 	if comps == nil {
 		return
 	}
+
+	clock := newShutdownClock(shutdownBudget)
+
+	// The optional, platform/config-dependent component stops share a
+	// sub-budget so they cannot starve the ungated core teardown below.
+	components := clock.sub(componentStopBudget)
 
 	// Cancel the ETW LUA subscriber FIRST so the kernel-side ETW
 	// session is closed before any later teardown can time out and
@@ -482,10 +492,14 @@ func shutdownAgent(comps *agentComponents) {
 	// the kernel and the next agent restart hits the
 	// "two callers on the same machine would conflict" failure from
 	// NewETWSubscriber's doc comment.
+	//
+	// The cancels are issued unconditionally (they are non-blocking); only
+	// the wait-for-exit is budgeted. That way a component always gets told to
+	// stop even when the sub-budget has run out and we can't wait for it.
 	if comps.etwluaCancel != nil {
 		comps.etwluaCancel()
 		if comps.etwluaDone != nil {
-			runWithTimeout("etwlua stop", 2*time.Second, func() {
+			components.run("etwlua stop", componentStopStage, func() {
 				<-comps.etwluaDone
 			})
 		}
@@ -497,7 +511,7 @@ func shutdownAgent(comps *agentComponents) {
 	if comps.unifiCancel != nil {
 		comps.unifiCancel()
 		if comps.unifiDone != nil {
-			runWithTimeout("unifi collector stop", 2*time.Second, func() {
+			components.run("unifi collector stop", componentStopStage, func() {
 				<-comps.unifiDone
 			})
 		}
@@ -505,13 +519,13 @@ func shutdownAgent(comps *agentComponents) {
 
 	// Cancel workspace indexing before core network teardown. A canceled crawl
 	// attempts one terminal CompleteRun, but we do NOT wait out its 30s HTTP
-	// timeout — the whole shutdown must fit systemd's 15s TimeoutStopSec, and
-	// a missed terminal flush self-heals server-side (the stale run is marked
-	// abandoned on the next crawl start). 2s matches the sibling stages.
+	// timeout — the whole shutdown must fit the shared budget, and a missed
+	// terminal flush self-heals server-side (the stale run is marked abandoned
+	// on the next crawl start). The cap matches the sibling stages.
 	if comps.workspaceIndexCancel != nil {
 		comps.workspaceIndexCancel()
 		if comps.workspaceIndexDone != nil {
-			runWithTimeout("workspace index stop", 2*time.Second, func() {
+			components.run("workspace index stop", componentStopStage, func() {
 				<-comps.workspaceIndexDone
 			})
 		}
@@ -523,7 +537,7 @@ func shutdownAgent(comps *agentComponents) {
 	if comps.supervisorCancel != nil {
 		comps.supervisorCancel()
 		if comps.supervisorDone != nil {
-			runWithTimeout("watchdog supervisor stop", 2*time.Second, func() {
+			components.run("watchdog supervisor stop", componentStopStage, func() {
 				<-comps.supervisorDone
 			})
 		}
@@ -552,18 +566,16 @@ func shutdownAgent(comps *agentComponents) {
 
 	comps.hb.StopAcceptingCommands()
 
-	// Inner ctx deadline is slightly longer than the outer runWithTimeout
-	// budget so ordering is deterministic: runWithTimeout fires first on
-	// a hung DrainAndWait, logs the stage, then drainCancel triggers the
-	// still-running goroutine's ctx to abort.
-	drainCtx, drainCancel := context.WithTimeout(context.Background(), 6*time.Second)
-	runWithTimeout("drain in-flight commands", 5*time.Second, func() {
-		comps.hb.DrainAndWait(drainCtx)
-	})
-	drainCancel()
+	// Drain MUST stay ahead of the two transport stops below: draining after
+	// the websocket and heartbeat are torn down would strand whatever is in
+	// flight. The inner ctx deadline is slightly longer than the stage cap so
+	// ordering is deterministic — the stage timer fires first on a hung
+	// DrainAndWait and logs the stage, then the still-running goroutine's ctx
+	// aborts.
+	clock.runCtx("drain in-flight commands", drainStageBudget, drainCtxGrace, comps.hb.DrainAndWait)
 
-	runWithTimeout("websocket stop", 3*time.Second, comps.wsClient.Stop)
-	runWithTimeout("heartbeat stop", 5*time.Second, comps.hb.Stop)
+	clock.run("websocket stop", websocketStopBudget, comps.wsClient.Stop)
+	clock.run("heartbeat stop", heartbeatStopBudget, comps.hb.Stop)
 
 	if comps.secureToken != nil {
 		comps.secureToken.Zero()
@@ -1192,7 +1204,14 @@ func runAgent() {
 		fmt.Fprintf(os.Stderr, "Failed to start agent: %v\n", err)
 		os.Exit(1)
 	}
-	defer logging.StopShipper()
+	// StopShipper waits on the shipper goroutine with no deadline of its own,
+	// and that goroutine can be parked on a 30s HTTP POST — twice the whole
+	// stop window — precisely on the hosts this matters for (network already
+	// down during OS shutdown). Unbounded it defeats shutdownAgent's budget,
+	// since it runs after shutdownAgent returns (#3323).
+	defer func() {
+		runWithTimeout("log shipper flush", shipperFlushBudget, logging.StopShipper)
+	}()
 
 	// Wait for ctx to be cancelled — SIGINT or SIGTERM via
 	// signal.NotifyContext above. Behaviour change: console-mode

--- a/agent/internal/agentapp/shutdown_budget.go
+++ b/agent/internal/agentapp/shutdown_budget.go
@@ -122,31 +122,67 @@ func (c *shutdownClock) stageTimeout(budget time.Duration) time.Duration {
 	return budget
 }
 
-// run executes fn under min(budget, remaining). Reports whether the stage ran;
-// a false return means the shared budget was already exhausted and the stage
-// was skipped entirely (logged, never silent — a skipped teardown stage is a
-// real signal that something upstream wedged).
+// run executes fn under min(budget, remaining). It reports whether the clock
+// WAITED for the stage — not whether the stage ran, because fn is ALWAYS
+// started.
+//
+// Starting fn even when the budget is spent is deliberate and load-bearing:
+// the stop functions passed here are the whole teardown, not just a wait, and
+// several of them are sync.Once-guarded (Heartbeat.Stop, websocket
+// Client.Stop). A Once never fires twice, so declining to call one doesn't
+// defer that teardown to later — it forgoes it permanently, leaving the
+// session broker, helper lifecycle and audit log open. Out of budget therefore
+// means "start it and don't wait" (the goroutine is abandoned when the process
+// exits), never "skip it".
 func (c *shutdownClock) run(name string, budget time.Duration, fn func()) bool {
 	d := c.stageTimeout(budget)
 	if d <= 0 {
-		log.Warn("shutdown budget exhausted, skipping stage", "stage", name)
+		log.Warn("shutdown budget exhausted, starting stage without waiting", "stage", name)
+		go fn()
 		return false
 	}
+	logIfSqueezed(name, budget, d)
 	runWithTimeout(name, d, fn)
 	return true
 }
 
 // runCtx is run for stages that need a context to abort their own inner work.
 // The context deadline is the stage cap plus grace, so the stage timer fires
-// (and logs) before the context aborts — see drainCtxGrace.
+// (and logs) before the context aborts — see drainCtxGrace. Same
+// always-start contract as run.
 func (c *shutdownClock) runCtx(name string, budget, grace time.Duration, fn func(context.Context)) bool {
 	d := c.stageTimeout(budget)
 	if d <= 0 {
-		log.Warn("shutdown budget exhausted, skipping stage", "stage", name)
+		log.Warn("shutdown budget exhausted, starting stage without waiting", "stage", name)
+		// grace alone, so the abandoned goroutine still gets a bounded window
+		// to notice it should stop rather than a context cancelled out from
+		// under it the instant this returns.
+		ctx, cancel := context.WithTimeout(context.Background(), grace)
+		go func() {
+			defer cancel()
+			fn(ctx)
+		}()
 		return false
 	}
+	logIfSqueezed(name, budget, d)
 	ctx, cancel := context.WithTimeout(context.Background(), d+grace)
 	defer cancel()
 	runWithTimeout(name, d, func() { fn(ctx) })
+	return true
+}
+
+// logIfSqueezed records a stage that got less than its nominal budget because
+// an earlier stage consumed the shared clock. Without this, a squeezed stage
+// that still finishes in its reduced window is indistinguishable in the logs
+// from one that had its full allotment — and a squeeze is the first visible
+// symptom of the shared budget running tight, which is exactly the arithmetic
+// that went unnoticed in #3323.
+// Reports whether the stage was squeezed, so the rule is directly assertable.
+func logIfSqueezed(name string, budget, granted time.Duration) bool {
+	if granted >= budget {
+		return false
+	}
+	log.Warn("shutdown stage squeezed by shared budget",
+		"stage", name, "granted", granted.String(), "budget", budget.String())
 	return true
 }

--- a/agent/internal/agentapp/shutdown_budget.go
+++ b/agent/internal/agentapp/shutdown_budget.go
@@ -1,0 +1,152 @@
+package agentapp
+
+import (
+	"context"
+	"time"
+)
+
+// Shutdown timing contract
+// ------------------------
+//
+// shutdownAgent tears components down SEQUENTIALLY (runWithTimeout blocks the
+// caller before the next stage starts), so per-stage timeouts are ADDITIVE,
+// not concurrent. Before #3323 the stage budgets summed to 17s on an ordinary
+// enrolled Linux agent while the systemd unit capped the stop at
+// TimeoutStopSec=15 — so systemd escalated SIGTERM to SIGKILL mid-teardown.
+// The three ungated stages alone (drain 5s + websocket 3s + heartbeat 5s) are
+// a 13s floor, leaving only 2s for every optional component, which is why the
+// failure looked intermittent: a plain agent squeaked under the cap and one
+// with a UniFi collector landed exactly on it.
+//
+// Two layers keep that from recurring:
+//
+//  1. shutdownBudget is a hard wall-clock cap the agent enforces on ITSELF, on
+//     every platform — systemd, launchd and the Windows SCM each impose their
+//     own stop deadline, so bounding agent-side is what makes the guarantee
+//     portable. Every stage runs for min(its own budget, time remaining), so a
+//     stage added later can never push the total past the cap; it just gets
+//     squeezed (and, if the budget is already spent, skipped with a warning).
+//
+//  2. The systemd unit's TimeoutStopSec sits well ABOVE the agent's own budget
+//     rather than at it, leaving shutdownTailSlack for the UNTIMED tail —
+//     the stopping-state file write, the watchdog IPC notify, secure-token
+//     zeroing, process exit — plus systemd's own SIGTERM delivery latency.
+//
+// TestShutdownStageBudgetsFitShutdownBudget and
+// TestShutdownBudgetFitsUnitTimeoutStopSec assert both layers against the
+// embedded unit, so the numbers can never silently drift apart again. That is
+// the regression the old "Total worst case is bounded by the sum of per-stage
+// timeouts; the unit file caps the outer wait at 15s" comment failed to
+// prevent: the claim was literally true and still wrong, because nothing
+// checked that the sum actually fit under the cap.
+const (
+	// shutdownBudget caps every timed stage in shutdownAgent, combined. The
+	// nominal stage budgets below sum to 17s, leaving 3s of slack before the
+	// clamp starts truncating real work.
+	shutdownBudget = 20 * time.Second
+
+	// componentStopBudget is a shared sub-budget for the OPTIONAL component
+	// stop stages (etwlua, unifi, workspace index, watchdog supervisor).
+	// These are the stages that vary by platform and configuration and they
+	// run ahead of the ungated core teardown, so without a sub-budget a
+	// single wedged optional component could consume the budget the core
+	// stages need. Each stage is additionally capped at componentStopStage.
+	componentStopBudget = 4 * time.Second
+	componentStopStage  = 2 * time.Second
+
+	// Core teardown stages. The ORDER these are invoked in is load-bearing:
+	// drain must stay ahead of the two transport stops, because draining
+	// after the websocket and heartbeat are torn down would strand whatever
+	// is in flight. That constraint is why the stages are budgeted rather
+	// than fanned out concurrently.
+	drainStageBudget    = 5 * time.Second
+	websocketStopBudget = 3 * time.Second
+	heartbeatStopBudget = 5 * time.Second
+
+	// drainCtxGrace makes the drain context outlive its stage cap slightly so
+	// ordering stays deterministic: the stage timer fires and logs the stage
+	// first, then the still-running goroutine's ctx aborts. Preserved from
+	// the original fixed 6s-inner/5s-outer pairing now that the outer cap is
+	// dynamic.
+	drainCtxGrace = 1 * time.Second
+
+	// shipperFlushBudget bounds logging.StopShipper, which runs AFTER
+	// shutdownAgent returns and waits on the shipper goroutine with no
+	// deadline of its own. An in-flight log-ship POST sits on the shipper's
+	// 30s HTTP timeout (internal/logging/shipper.go) — twice the entire stop
+	// window — on exactly the hosts this issue is about: ones whose network
+	// went down during OS shutdown. Unbounded, it defeats the whole budget.
+	shipperFlushBudget = 2 * time.Second
+
+	// shutdownTailSlack is the margin the systemd unit must leave ABOVE
+	// shutdownBudget + shipperFlushBudget. It covers the parts of shutdown
+	// that are deliberately not timed (local state-file write, watchdog IPC
+	// notify, secure-token zeroing, process exit) plus systemd's own signal
+	// delivery latency. Asserted against the unit by
+	// TestShutdownBudgetFitsUnitTimeoutStopSec.
+	shutdownTailSlack = 5 * time.Second
+)
+
+// shutdownClock hands out per-stage timeouts clamped to a shared deadline, so
+// a sequence of sequential stages can never overrun the budget they share.
+//
+// It is deliberately not a context: the stages abandon work rather than
+// cancel it (runWithTimeout leaves fn running on a goroutine that dies with
+// the process), and several of them take no context at all.
+type shutdownClock struct {
+	deadline time.Time
+}
+
+// newShutdownClock starts a clock that expires budget from now.
+func newShutdownClock(budget time.Duration) *shutdownClock {
+	return &shutdownClock{deadline: time.Now().Add(budget)}
+}
+
+// sub derives a nested clock for a group of stages that share a smaller
+// sub-budget. It never extends past the parent's deadline, so a sub-budget can
+// only ever tighten the bound.
+func (c *shutdownClock) sub(budget time.Duration) *shutdownClock {
+	deadline := time.Now().Add(budget)
+	if deadline.After(c.deadline) {
+		deadline = c.deadline
+	}
+	return &shutdownClock{deadline: deadline}
+}
+
+// stageTimeout returns the effective cap for a stage: min(budget, remaining).
+// A result <= 0 means the shared budget is spent and the stage must be skipped.
+func (c *shutdownClock) stageTimeout(budget time.Duration) time.Duration {
+	if remaining := time.Until(c.deadline); remaining < budget {
+		return remaining
+	}
+	return budget
+}
+
+// run executes fn under min(budget, remaining). Reports whether the stage ran;
+// a false return means the shared budget was already exhausted and the stage
+// was skipped entirely (logged, never silent — a skipped teardown stage is a
+// real signal that something upstream wedged).
+func (c *shutdownClock) run(name string, budget time.Duration, fn func()) bool {
+	d := c.stageTimeout(budget)
+	if d <= 0 {
+		log.Warn("shutdown budget exhausted, skipping stage", "stage", name)
+		return false
+	}
+	runWithTimeout(name, d, fn)
+	return true
+}
+
+// runCtx is run for stages that need a context to abort their own inner work.
+// The context deadline is the stage cap plus grace, so the stage timer fires
+// (and logs) before the context aborts — see drainCtxGrace.
+func (c *shutdownClock) runCtx(name string, budget, grace time.Duration, fn func(context.Context)) bool {
+	d := c.stageTimeout(budget)
+	if d <= 0 {
+		log.Warn("shutdown budget exhausted, skipping stage", "stage", name)
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), d+grace)
+	defer cancel()
+	runWithTimeout(name, d, func() { fn(ctx) })
+	return true
+}

--- a/agent/internal/agentapp/shutdown_budget.go
+++ b/agent/internal/agentapp/shutdown_budget.go
@@ -41,8 +41,9 @@ import (
 // checked that the sum actually fit under the cap.
 const (
 	// shutdownBudget caps every timed stage in shutdownAgent, combined. The
-	// nominal stage budgets below sum to 17s, leaving 3s of slack before the
-	// clamp starts truncating real work.
+	// nominal stage budgets below sum to 18s, leaving slack before the clamp
+	// starts truncating real work (asserted, not asserted-in-prose, by
+	// TestShutdownStageBudgetsFitShutdownBudget).
 	shutdownBudget = 20 * time.Second
 
 	// componentStopBudget is a shared sub-budget for the OPTIONAL component
@@ -53,6 +54,15 @@ const (
 	// stages need. Each stage is additionally capped at componentStopStage.
 	componentStopBudget = 4 * time.Second
 	componentStopStage  = 2 * time.Second
+
+	// watchdogNotifyBudget bounds the "agent is stopping intentionally" IPC
+	// notify. It is a blocking socket write and ipc.Conn.Send arms a 30s write
+	// deadline, so a watchdog that stopped reading its end could otherwise
+	// park shutdown for longer than the whole stop window before any core
+	// teardown stage began. A local socket write needs milliseconds; anything
+	// beyond this means the peer is gone, and the stopping-state file already
+	// written is the durable signal the watchdog reconciles against.
+	watchdogNotifyBudget = 1 * time.Second
 
 	// Core teardown stages. The ORDER these are invoked in is load-bearing:
 	// drain must stay ahead of the two transport stops, because draining

--- a/agent/internal/agentapp/shutdown_budget_test.go
+++ b/agent/internal/agentapp/shutdown_budget_test.go
@@ -36,9 +36,10 @@ func unitTimeoutStopSec(t *testing.T) time.Duration {
 
 // nominalStageBudgets is the worst case shutdownAgent can ask for: the shared
 // component sub-budget (which caps all four optional component stops however
-// many apply) plus every ungated core stage.
+// many apply), the watchdog notify, and every ungated core stage.
 func nominalStageBudgets() time.Duration {
-	return componentStopBudget + drainStageBudget + websocketStopBudget + heartbeatStopBudget
+	return componentStopBudget + watchdogNotifyBudget +
+		drainStageBudget + websocketStopBudget + heartbeatStopBudget
 }
 
 // TestShutdownStageBudgetsFitShutdownBudget is the arithmetic the old comment
@@ -179,10 +180,14 @@ func TestShutdownClockRunCtxStartsStageEvenWhenBudgetExhausted(t *testing.T) {
 // gets less than its nominal budget but still completes. It must not be
 // silently indistinguishable from one that ran with its full allotment.
 func TestShutdownClockLogsSqueezedStage(t *testing.T) {
-	clock := &shutdownClock{deadline: time.Now().Add(50 * time.Millisecond)}
+	// A 2s window against a 5s nominal stage: wide enough that scheduling
+	// delay on a loaded runner can't drive `granted` negative and flake the
+	// test, tight enough that it is unambiguously a squeeze.
+	const window = 2 * time.Second
+	clock := &shutdownClock{deadline: time.Now().Add(window)}
 	granted := clock.stageTimeout(5 * time.Second)
-	if granted <= 0 || granted > 50*time.Millisecond {
-		t.Fatalf("expected a positive squeezed budget under 50ms, got %v", granted)
+	if granted <= 0 || granted > window {
+		t.Fatalf("expected a positive squeezed budget of at most %v, got %v", window, granted)
 	}
 	// logIfSqueezed is the observability seam; assert it fires on exactly the
 	// squeeze condition and stays quiet otherwise.

--- a/agent/internal/agentapp/shutdown_budget_test.go
+++ b/agent/internal/agentapp/shutdown_budget_test.go
@@ -61,14 +61,14 @@ func TestShutdownStageBudgetsFitShutdownBudget(t *testing.T) {
 // takes the whole cgroup down mid-teardown and helpers, tunnels and the audit
 // log are never closed.
 func TestShutdownBudgetFitsUnitTimeoutStopSec(t *testing.T) {
-	timeoutStopSec := unitTimeoutStopSec(t)
+	unitStopTimeout := unitTimeoutStopSec(t)
 	needed := shutdownBudget + shipperFlushBudget + shutdownTailSlack
-	if needed > timeoutStopSec {
+	if needed > unitStopTimeout {
 		t.Fatalf("agent needs %v (shutdownBudget %v + shipper flush %v + tail slack %v) but "+
 			"the unit's TimeoutStopSec is %v — systemd would SIGKILL mid-shutdown (#3323). "+
 			"Raise TimeoutStopSec in linuxUnit (and bump currentUnitVersion so deployed "+
 			"hosts reconcile), or lower the agent-side budgets.",
-			needed, shutdownBudget, shipperFlushBudget, shutdownTailSlack, timeoutStopSec)
+			needed, shutdownBudget, shipperFlushBudget, shutdownTailSlack, unitStopTimeout)
 	}
 }
 
@@ -115,14 +115,82 @@ func TestShutdownClockRunHonoursSharedDeadline(t *testing.T) {
 	}
 }
 
-func TestShutdownClockSkipsStageWhenBudgetExhausted(t *testing.T) {
+// TestShutdownClockStartsStageEvenWhenBudgetExhausted pins the contract that
+// an exhausted budget means "start it, don't wait" and never "skip it". The
+// stop functions handed to run are sync.Once-guarded (Heartbeat.Stop,
+// websocket Client.Stop): a Once never fires twice, so declining to call one
+// forgoes that teardown permanently rather than deferring it, leaving the
+// session broker, helper lifecycle and audit log open.
+func TestShutdownClockStartsStageEvenWhenBudgetExhausted(t *testing.T) {
 	clock := &shutdownClock{deadline: time.Now().Add(-time.Second)}
-	ran := false
-	if clock.run("spent", time.Second, func() { ran = true }) {
-		t.Fatal("run reported the stage ran despite an exhausted budget")
+
+	started := make(chan struct{})
+	start := time.Now()
+	waited := clock.run("spent", time.Second, func() { close(started) })
+	elapsed := time.Since(start)
+
+	if waited {
+		t.Fatal("run reported it waited for the stage despite an exhausted budget")
 	}
-	if ran {
-		t.Fatal("stage body executed after the shared budget was exhausted")
+	if elapsed > time.Second {
+		t.Fatalf("run blocked for %v on an exhausted budget; it must not wait", elapsed)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stage was never started on an exhausted budget — a sync.Once-guarded " +
+			"stop skipped here is forgone permanently, not merely deferred")
+	}
+}
+
+// TestShutdownClockRunCtxStartsStageEvenWhenBudgetExhausted is the runCtx half
+// of the same contract, and additionally checks the stage gets a live context
+// rather than one cancelled out from under it as runCtx returns.
+func TestShutdownClockRunCtxStartsStageEvenWhenBudgetExhausted(t *testing.T) {
+	clock := &shutdownClock{deadline: time.Now().Add(-time.Second)}
+
+	type ctxState struct{ hasDeadline, live bool }
+	observed := make(chan ctxState, 1)
+
+	waited := clock.runCtx("spent", time.Second, 500*time.Millisecond, func(ctx context.Context) {
+		_, hasDeadline := ctx.Deadline()
+		live := ctx.Err() == nil
+		observed <- ctxState{hasDeadline: hasDeadline, live: live}
+	})
+	if waited {
+		t.Fatal("runCtx reported it waited despite an exhausted budget")
+	}
+
+	select {
+	case got := <-observed:
+		if !got.hasDeadline {
+			t.Error("stage context has no deadline; the abandoned goroutine would run unbounded")
+		}
+		if !got.live {
+			t.Error("stage context was already cancelled when the stage started, so the " +
+				"stage had no window at all to act on it")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stage was never started on an exhausted budget")
+	}
+}
+
+// TestShutdownClockLogsSqueezedStage exercises the squeeze path: a stage that
+// gets less than its nominal budget but still completes. It must not be
+// silently indistinguishable from one that ran with its full allotment.
+func TestShutdownClockLogsSqueezedStage(t *testing.T) {
+	clock := &shutdownClock{deadline: time.Now().Add(50 * time.Millisecond)}
+	granted := clock.stageTimeout(5 * time.Second)
+	if granted <= 0 || granted > 50*time.Millisecond {
+		t.Fatalf("expected a positive squeezed budget under 50ms, got %v", granted)
+	}
+	// logIfSqueezed is the observability seam; assert it fires on exactly the
+	// squeeze condition and stays quiet otherwise.
+	if !logIfSqueezed("squeezed", 5*time.Second, granted) {
+		t.Fatal("a stage granted less than its budget must be reported as squeezed")
+	}
+	if logIfSqueezed("full", time.Second, time.Second) {
+		t.Fatal("a stage granted its full budget must not be reported as squeezed")
 	}
 }
 

--- a/agent/internal/agentapp/shutdown_budget_test.go
+++ b/agent/internal/agentapp/shutdown_budget_test.go
@@ -1,0 +1,209 @@
+package agentapp
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// unitTimeoutStopSec reads the TimeoutStopSec directive out of the embedded
+// systemd unit. Matching only a line that STARTS with the directive keeps the
+// several prose mentions in the surrounding comment block from being picked up.
+func unitTimeoutStopSec(t *testing.T) time.Duration {
+	t.Helper()
+	for _, line := range strings.Split(linuxUnit, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "TimeoutStopSec=") {
+			continue
+		}
+		raw := strings.TrimPrefix(line, "TimeoutStopSec=")
+		// The unit only ever uses a bare-seconds value; anything else means
+		// someone switched notation and this parser needs revisiting rather
+		// than silently returning a wrong number.
+		secs, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("TimeoutStopSec=%q is not a bare seconds value; update this parser "+
+				"(and re-check the shutdown budget arithmetic) before changing notation", raw)
+		}
+		return time.Duration(secs) * time.Second
+	}
+	t.Fatal("linuxUnit has no TimeoutStopSec directive — the agent's shutdown budget " +
+		"would then race systemd's 90s default with nothing asserting the relationship")
+	return 0
+}
+
+// nominalStageBudgets is the worst case shutdownAgent can ask for: the shared
+// component sub-budget (which caps all four optional component stops however
+// many apply) plus every ungated core stage.
+func nominalStageBudgets() time.Duration {
+	return componentStopBudget + drainStageBudget + websocketStopBudget + heartbeatStopBudget
+}
+
+// TestShutdownStageBudgetsFitShutdownBudget is the arithmetic the old comment
+// asserted in prose and got wrong (#3323). shutdownAgent's stages run
+// sequentially, so their budgets add up; if the nominal sum exceeds the shared
+// budget the clamp starts truncating real teardown work — heartbeat stop, the
+// last stage, would be the one starved.
+func TestShutdownStageBudgetsFitShutdownBudget(t *testing.T) {
+	if sum := nominalStageBudgets(); sum > shutdownBudget {
+		t.Fatalf("shutdown stage budgets sum to %v, over shutdownBudget %v: the last stage "+
+			"(heartbeat stop) would be clamped toward zero. Either lower a stage budget or "+
+			"raise shutdownBudget — and if you raise it, TimeoutStopSec must move too.",
+			sum, shutdownBudget)
+	}
+}
+
+// TestShutdownBudgetFitsUnitTimeoutStopSec is the guard that would have caught
+// #3323 at build time. The agent must finish its own shutdown, with slack to
+// spare, before systemd escalates SIGTERM to SIGKILL — otherwise KillMode=mixed
+// takes the whole cgroup down mid-teardown and helpers, tunnels and the audit
+// log are never closed.
+func TestShutdownBudgetFitsUnitTimeoutStopSec(t *testing.T) {
+	timeoutStopSec := unitTimeoutStopSec(t)
+	needed := shutdownBudget + shipperFlushBudget + shutdownTailSlack
+	if needed > timeoutStopSec {
+		t.Fatalf("agent needs %v (shutdownBudget %v + shipper flush %v + tail slack %v) but "+
+			"the unit's TimeoutStopSec is %v — systemd would SIGKILL mid-shutdown (#3323). "+
+			"Raise TimeoutStopSec in linuxUnit (and bump currentUnitVersion so deployed "+
+			"hosts reconcile), or lower the agent-side budgets.",
+			needed, shutdownBudget, shipperFlushBudget, shutdownTailSlack, timeoutStopSec)
+	}
+}
+
+// TestShutdownBudgetLeavesRoomForUntimedTail pins the reason the slack term
+// exists: the tail after the last timed stage (state-file write, watchdog IPC
+// notify, secure-token zeroing, process exit) is deliberately untimed, so a
+// zero-slack budget would be exactly as broken as the original 17s-vs-15s bug
+// even with the arithmetic "balancing".
+func TestShutdownBudgetLeavesRoomForUntimedTail(t *testing.T) {
+	if shutdownTailSlack <= 0 {
+		t.Fatal("shutdownTailSlack must be positive: the post-teardown tail is untimed")
+	}
+	if slack := unitTimeoutStopSec(t) - (shutdownBudget + shipperFlushBudget); slack < shutdownTailSlack {
+		t.Fatalf("only %v of slack under TimeoutStopSec, want at least %v", slack, shutdownTailSlack)
+	}
+}
+
+func TestShutdownClockClampsStageToRemaining(t *testing.T) {
+	clock := &shutdownClock{deadline: time.Now().Add(100 * time.Millisecond)}
+	if d := clock.stageTimeout(5 * time.Second); d > 100*time.Millisecond {
+		t.Fatalf("stage timeout %v exceeded the clock's remaining budget", d)
+	}
+	// A stage that wants less than what's left keeps its own smaller budget.
+	if d := clock.stageTimeout(10 * time.Millisecond); d != 10*time.Millisecond {
+		t.Fatalf("stage timeout = %v, want the stage's own 10ms budget", d)
+	}
+}
+
+func TestShutdownClockRunHonoursSharedDeadline(t *testing.T) {
+	hang := make(chan struct{})
+	defer close(hang)
+
+	clock := &shutdownClock{deadline: time.Now().Add(80 * time.Millisecond)}
+	start := time.Now()
+	// Three stages that would each block for a minute. Under the pre-#3323
+	// scheme they'd take 3x their individual budgets; sharing a deadline they
+	// must collectively finish within it.
+	for _, name := range []string{"a", "b", "c"} {
+		clock.run(name, time.Minute, func() { <-hang })
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("three hung stages took %v; shared deadline was 80ms (stage budgets "+
+			"are still additive)", elapsed)
+	}
+}
+
+func TestShutdownClockSkipsStageWhenBudgetExhausted(t *testing.T) {
+	clock := &shutdownClock{deadline: time.Now().Add(-time.Second)}
+	ran := false
+	if clock.run("spent", time.Second, func() { ran = true }) {
+		t.Fatal("run reported the stage ran despite an exhausted budget")
+	}
+	if ran {
+		t.Fatal("stage body executed after the shared budget was exhausted")
+	}
+}
+
+// TestShutdownClockSubNeverExceedsParent guards the component sub-budget: it
+// may only tighten the bound, never extend it. A sub-budget larger than what
+// the parent has left would let the optional component stops overrun the whole
+// shutdown budget before the ungated core stages even start.
+func TestShutdownClockSubNeverExceedsParent(t *testing.T) {
+	parent := &shutdownClock{deadline: time.Now().Add(50 * time.Millisecond)}
+	if sub := parent.sub(time.Hour); sub.deadline.After(parent.deadline) {
+		t.Fatalf("sub-clock deadline %v is past the parent's %v", sub.deadline, parent.deadline)
+	}
+	if sub := parent.sub(10 * time.Millisecond); !sub.deadline.Before(parent.deadline) {
+		t.Fatal("a smaller sub-budget must tighten the deadline")
+	}
+}
+
+// TestShutdownClockRunCtxOutlivesStageCap pins the deliberate ordering the
+// drain stage depends on: the stage timer must fire (and log the stage) before
+// the inner context aborts, so a hung drain is reported as a stage timeout
+// rather than surfacing as a context error from inside DrainAndWait.
+func TestShutdownClockRunCtxOutlivesStageCap(t *testing.T) {
+	clock := newShutdownClock(time.Minute)
+
+	stageCap := 60 * time.Millisecond
+	grace := 40 * time.Millisecond
+
+	// The stage goroutine is abandoned when the cap fires and keeps running,
+	// so the deadline is handed back over a channel rather than a shared
+	// variable — the test must not read anything that goroutine still writes.
+	deadlines := make(chan time.Time, 1)
+	blocked := make(chan struct{})
+	defer close(blocked)
+
+	start := time.Now()
+	clock.runCtx("drain", stageCap, grace, func(ctx context.Context) {
+		d, _ := ctx.Deadline()
+		deadlines <- d
+		<-blocked
+	})
+	elapsed := time.Since(start)
+
+	if elapsed < stageCap {
+		t.Fatalf("stage returned after %v, before its %v cap", elapsed, stageCap)
+	}
+
+	var ctxDeadline time.Time
+	select {
+	case ctxDeadline = <-deadlines:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stage never reported its context deadline")
+	}
+	if ctxDeadline.IsZero() {
+		t.Fatal("runCtx handed the stage a context with no deadline")
+	}
+	if got := ctxDeadline.Sub(start); got <= stageCap {
+		t.Fatalf("context deadline %v is not past the %v stage cap: the context would abort "+
+			"before the stage timer fires, inverting the intended ordering", got, stageCap)
+	}
+}
+
+// TestShutdownClockRunCtxCancelsContext ensures the context is released rather
+// than leaked once the stage returns — the stage's goroutine is abandoned, so
+// the context is the only thing left that can tell it to stop.
+func TestShutdownClockRunCtxCancelsContext(t *testing.T) {
+	clock := newShutdownClock(time.Minute)
+
+	gotCtx := make(chan context.Context, 1)
+	release := make(chan struct{})
+	defer close(release)
+
+	clock.runCtx("drain", 30*time.Millisecond, 10*time.Millisecond, func(ctx context.Context) {
+		gotCtx <- ctx
+		<-release
+	})
+
+	ctx := <-gotCtx
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("context still live after the stage returned; abandoned drain work would " +
+			"keep running unbounded")
+	}
+}

--- a/agent/internal/agentapp/systemd_unit.go
+++ b/agent/internal/agentapp/systemd_unit.go
@@ -19,7 +19,12 @@ import (
 // hardened breeze-watchdog (which would re-wedge it at 226/NAMESPACE), and
 // corrects a comment that wrongly claimed the agent re-chowns the directory to
 // root:breeze at runtime (it relaxes it to 0755 instead).
-const currentUnitVersion = 4
+// Version 5 raises TimeoutStopSec above the agent's own shutdown budget. At 15s
+// it sat BELOW the sum of the agent's sequential teardown stage timeouts (17s
+// on an ordinary enrolled Linux agent), so systemd escalated SIGTERM to SIGKILL
+// on routine stops and restarts (#3323). Deployed hosts pick this up on the
+// next agent start via reconcileServiceUnitIfNeeded.
+const currentUnitVersion = 5
 
 const unitVersionPrefix = "# breeze-unit-version:"
 
@@ -35,7 +40,7 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Service]
-# breeze-unit-version: 4
+# breeze-unit-version: 5
 Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
@@ -63,11 +68,23 @@ RuntimeDirectoryPreserve=yes
 # of stampeding the API.
 RestartSec=30
 
-# Cap total stop time so a hung HTTP flush during OS shutdown (network
-# going down) doesn't block system power-off for the 90s systemd default.
+# Outer backstop on stop time, so a hung HTTP flush during OS shutdown (network
+# going down) can't block system power-off for the 90s systemd default.
+#
+# This is deliberately ABOVE the agent's own shutdown budget, not equal to it.
+# The agent bounds its entire graceful teardown itself (see the shutdown timing
+# contract in agent/internal/agentapp/shutdown_budget.go); the slack between
+# that budget and this value covers the parts of shutdown that are not timed —
+# stopping-state file write, watchdog IPC notify, secure-token zeroing, process
+# exit — plus systemd's own signal-delivery latency. Set at 15s the two
+# disagreed: the agent's sequential stage timeouts summed to more than the cap,
+# so systemd SIGKILLed mid-teardown on ordinary stops and restarts, leaving
+# helpers, tunnels and the audit log unclosed (#3323).
+# TestShutdownBudgetFitsUnitTimeoutStopSec keeps the two in sync.
+#
 # KillMode=mixed sends SIGTERM to the main process, then SIGKILL to the
 # whole cgroup after TimeoutStopSec.
-TimeoutStopSec=15
+TimeoutStopSec=30
 KillMode=mixed
 
 # INTENTIONALLY UNSANDBOXED. The remote terminal and remote script execution

--- a/agent/internal/watchdog/recovery_windows_logic.go
+++ b/agent/internal/watchdog/recovery_windows_logic.go
@@ -90,9 +90,13 @@ func (realRecoveryClock) Sleep(ctx context.Context, d time.Duration) error {
 }
 
 const (
-	// windowsStopTimeout exceeds the agent's ~21s maximum serial shutdown
-	// budget with margin, so a slow-but-healthy shutdown is not mistaken for a
-	// hung one and escalated to termination.
+	// windowsStopTimeout exceeds the agent's maximum serial shutdown budget
+	// with margin, so a slow-but-healthy shutdown is not mistaken for a hung
+	// one and escalated to termination. That maximum is
+	// shutdownBudget + shipperFlushBudget in internal/agentapp/shutdown_budget.go
+	// (named rather than restated here, since a hardcoded number is exactly
+	// what silently went stale in #3323); raising either of those means
+	// re-checking this value.
 	windowsStopTimeout = 35 * time.Second
 	// windowsStartTimeout, windowsObserveTimeout and windowsProcessExitTimeout
 	// share the same 35s recovery deadline.

--- a/agent/service/systemd/breeze-agent.service
+++ b/agent/service/systemd/breeze-agent.service
@@ -7,7 +7,7 @@ StartLimitIntervalSec=60
 StartLimitBurst=5
 
 [Service]
-# breeze-unit-version: 4
+# breeze-unit-version: 5
 Type=simple
 ExecStart=/usr/local/bin/breeze-agent start
 WorkingDirectory=/etc/breeze
@@ -35,11 +35,23 @@ RuntimeDirectoryPreserve=yes
 # of stampeding the API.
 RestartSec=30
 
-# Cap total stop time so a hung HTTP flush during OS shutdown (network
-# going down) doesn't block system power-off for the 90s systemd default.
+# Outer backstop on stop time, so a hung HTTP flush during OS shutdown (network
+# going down) can't block system power-off for the 90s systemd default.
+#
+# This is deliberately ABOVE the agent's own shutdown budget, not equal to it.
+# The agent bounds its entire graceful teardown itself (see the shutdown timing
+# contract in agent/internal/agentapp/shutdown_budget.go); the slack between
+# that budget and this value covers the parts of shutdown that are not timed —
+# stopping-state file write, watchdog IPC notify, secure-token zeroing, process
+# exit — plus systemd's own signal-delivery latency. Set at 15s the two
+# disagreed: the agent's sequential stage timeouts summed to more than the cap,
+# so systemd SIGKILLed mid-teardown on ordinary stops and restarts, leaving
+# helpers, tunnels and the audit log unclosed (#3323).
+# TestShutdownBudgetFitsUnitTimeoutStopSec keeps the two in sync.
+#
 # KillMode=mixed sends SIGTERM to the main process, then SIGKILL to the
 # whole cgroup after TimeoutStopSec.
-TimeoutStopSec=15
+TimeoutStopSec=30
 KillMode=mixed
 
 # INTENTIONALLY UNSANDBOXED. The remote terminal and remote script execution


### PR DESCRIPTION
Closes #3323

## The bug

`shutdownAgent` tears components down **sequentially** — `runWithTimeout` blocks the caller before the next stage starts — so its per-stage timeouts are **additive**, not concurrent. They summed to **17s** on an ordinary enrolled Linux agent while the systemd unit capped the stop at `TimeoutStopSec=15`, so systemd escalated SIGTERM to SIGKILL on routine stops and restarts. `KillMode=mixed` then took the whole cgroup with it, leaving helpers, tunnels and the audit log unclosed.

Confirming @bdunncompany's tightening of the arithmetic: the three **ungated** stages alone (drain 5s + websocket 3s + heartbeat 5s) are a **13s floor**, so a plain agent had 2s of margin, one with a UniFi collector landed **exactly on the cap**, and one that also indexed a workspace went **over**. That is why the failure reads as intermittent rather than deterministic.

The comment at `main.go` — *"Total worst case is bounded by the sum of per-stage timeouts; the unit file caps the outer wait at 15s"* — was literally true and still wrong: nothing checked that the sum actually fit under the cap.

## Two more unbounded steps in the same function

The stage arithmetic wasn't the whole story. Two steps in the shutdown path had no budget at all, and each can outlast the entire stop window on its own — on exactly the hosts this issue is about, whose network or IPC peer died during OS shutdown:

1. **The watchdog "shutdown intent" IPC notify** (`main.go`) is a blocking socket write, and `ipc.Conn.Send` arms a **30s** write deadline (`internal/ipc/protocol.go:42`). A watchdog that stopped reading its end parks shutdown before a single core teardown stage begins — enough to re-create this SIGKILL even at `TimeoutStopSec=30`.
2. **`runAgent`'s deferred `logging.StopShipper()`**, which runs *after* `shutdownAgent` returns. `Shipper.Stop()` is `close(stopChan); wg.Wait()` with no deadline of its own, and the shipper's `http.Client` has a **30s** timeout (`internal/logging/shipper.go:113`).

Both are now bounded. Abandoning the notify is safe: the stopping-state file written immediately above it is the durable signal the watchdog reconciles against, and the notify is only the fast path.

## The fix

Two layers, and the issue discussion supports both:

**1. Agent-side total budget (the portable half).** Every stage draws from one shared `shutdownBudget`, running for `min(its own budget, time remaining)`. A stage added later can never push the total past the cap. Bounding agent-side is what makes the guarantee portable: launchd and the Windows SCM impose their own stop deadlines too, and neither is fixed by touching a systemd unit.

Stage **order is unchanged**. Per @bdunncompany's point, drain stays ahead of the two transport stops — draining after the websocket and heartbeat are torn down would strand whatever is in flight. That ordering constraint is precisely why this bounds the stages rather than fanning them out concurrently: the concurrent version is the design call the issue flagged as risky, and the budget gets the same guarantee without it. The optional, platform/config-dependent component stops share a sub-budget so one wedged optional component can't starve the ungated core teardown.

An exhausted budget means **"start the stage and don't wait"**, never "skip it" — `Heartbeat.Stop` and websocket `Client.Stop` are `sync.Once`-guarded, so declining to call one forgoes that teardown permanently rather than deferring it. A stage granted less than its nominal budget is logged as squeezed, since that's the first visible symptom of the shared budget running tight.

**2. `TimeoutStopSec` 15 → 30, deliberately ABOVE the agent's budget rather than equal to it.** The slack covers the parts of shutdown that stay intentionally untimed (stopping-state write, secure-token zeroing, process exit) plus systemd's own signal latency. Setting it *equal* to the agent budget would just recreate a thin-margin version of the same bug. `currentUnitVersion` bumps 4 → 5 so deployed hosts pick it up via `reconcileServiceUnitIfNeeded` on the next agent start.

Worst case is now bounded and **clean** rather than unbounded and killed; in practice these stages complete in milliseconds, since they only consume budget when something is genuinely wedged.

## Why it can't silently regress

The arithmetic is asserted, not narrated. `TestShutdownBudgetFitsUnitTimeoutStopSec` parses `TimeoutStopSec` **out of the embedded unit string** and asserts `shutdownBudget + shipperFlushBudget + shutdownTailSlack` fits under it. `TestShutdownStageBudgetsFitShutdownBudget` asserts the stage budgets fit the shared budget. Both would have failed on `main` before this change.

For the same reason, `windowsStopTimeout`'s comment in `internal/watchdog/recovery_windows_logic.go` no longer restates the agent's max shutdown budget as a hardcoded "~21s" — it names the constants. A hardcoded derived number going stale is precisely this issue.

## Files

- `agent/internal/agentapp/shutdown_budget.go` (new) — budget constants + `shutdownClock`, with the full timing contract documented
- `agent/internal/agentapp/main.go` — stages draw from the shared clock; watchdog notify and deferred shipper flush bounded; misleading comment corrected
- `agent/internal/agentapp/systemd_unit.go` + `agent/service/systemd/breeze-agent.service` — `TimeoutStopSec=30`, unit version 5 (regenerated byte-identically; `TestStaticUnitMatchesEmbedded` holds)
- `agent/internal/agentapp/shutdown_budget_test.go` (new) — the two arithmetic contracts plus clamping, shared-deadline enforcement, start-don't-skip on an exhausted budget (both `run` and `runCtx`), sub-budget tightening, squeeze reporting, and the drain context's deliberate stage-cap/ctx ordering
- `agent/internal/watchdog/recovery_windows_logic.go` — comment only

## Verification

`cd agent && go test -race ./...` — **entire agent suite green**. `go vet` clean; `golangci-lint run --new-from-rev=origin/main ./...` reports 0 issues.

## Notes for review

- **Fleet impact:** the unit-version bump means each Linux host rewrites its unit and restarts the agent once, on the next agent start, via the existing `systemd-run` reconcile escape (the same mechanism used for v3 and v4).
- The self-uninstall backstop in `agent/internal/heartbeat/handlers_uninstall.go` (fires at t≈17s, `os.Exit(0)` at t≈22s) was tuned against the old ceiling. It is **not** a regression — before this change a wedged self-uninstall was SIGKILLed at t≈20s instead, so both truncate, and the normal path completes by t≈6s — but tying that backstop to the shutdown budget would be a reasonable follow-up. It lives in package `heartbeat`, which `agentapp` imports, so sharing the constant needs a small refactor rather than a one-line change; left out of scope here.
- The two dated design docs under `docs/superpowers/{plans,specs}/agent/2026-06-09-*` quote the old `TimeoutStopSec=15` unit. Left as-is — historical records of that design, not live config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)