### PR TITLE
fix(api): make search_logs keyset pagination usable (#3329)

### DIFF
--- a/apps/api/src/__tests__/integration/logSearchCursor.integration.test.ts
+++ b/apps/api/src/__tests__/integration/logSearchCursor.integration.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Integration test — `search_logs` keyset pagination against real Postgres
+ * (regression guard for #3329).
+ *
+ * The keyset predicate used to be a hand-written Drizzle `sql` template that
+ * interpolated the cursor's JS `Date` directly. A bare value inside a `sql`
+ * template is bound with the NOOP encoder, so postgres.js received a `Date`
+ * object at its Bind step and threw
+ * `ERR_INVALID_ARG_TYPE ... Received an instance of Date`. No mock reproduces
+ * this — the failure is in the driver's own type coercion, not in Drizzle's
+ * query-building or in application logic. The fix (`buildLogSearchKeysetCondition`
+ * in `services/logSearch.ts`) routes the comparison through Drizzle's typed
+ * `lt`/`gt`/`eq` helpers instead, which serialize through the column's own
+ * encoder.
+ *
+ * This file proves, against a real DB connection as the unprivileged
+ * `breeze_app` role (the same path production request handlers use via
+ * `withDbAccessContext`):
+ *   1. Paging with a cursor `searchFleetLogs` itself issued resolves, not
+ *      throws — this alone fails on the pre-fix code.
+ *   2. A full keyset walk (limit=4) over ~25 seeded rows exactly reproduces
+ *      a single unpaginated query's order — no gaps, no duplicates.
+ *   3. The uuid tiebreaker: a tie group of 3 rows sharing an identical
+ *      `timestamp` is split across a page boundary, and paging still walks
+ *      through it correctly. The fix removed an explicit `cast(... as uuid)`
+ *      from the old code, so this proves the id comparison still resolves as
+ *      uuid against the live driver. The test also asserts the tie group
+ *      really was split across a page boundary (not merely present) — if it
+ *      landed entirely within one page, dropping the tiebreaker would go
+ *      undetected.
+ *   4. Both `sortOrder: 'desc'` (default) and `sortOrder: 'asc'`.
+ *
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/logSearchCursor.integration.test.ts
+ */
+import './setup';
+
+import { describe, it, expect } from 'vitest';
+import { getTestDb } from './setup';
+import { withDbAccessContext, type DbAccessContext } from '../../db';
+import { deviceEventLogs, devices } from '../../db/schema';
+import { createPartner, createOrganization, createSite } from './db-utils';
+import { searchFleetLogs } from '../../services/logSearch';
+import { buildOrgAccessClosures, type AuthContext } from '../../middleware/auth';
+
+// Wide enough to contain every timestamp seeded below without relying on the
+// default 24h window.
+const WIDE_TIME_RANGE = {
+  start: '2020-01-01T00:00:00.000Z',
+  end: '2030-01-01T00:00:00.000Z',
+};
+
+async function seedFixture() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+  const [device] = await getTestDb()
+    .insert(devices)
+    .values({
+      orgId: org.id,
+      siteId: site.id,
+      agentId: `agent-${org.id}`,
+      hostname: `host-${org.id.slice(0, 8)}`,
+      osType: 'linux',
+      osVersion: '1.0',
+      architecture: 'amd64',
+      agentVersion: '1.0.0',
+      status: 'online',
+    })
+    .returning();
+  if (!device) throw new Error('seedFixture: device insert returned no row');
+  return { partner, org, site, device };
+}
+
+// Distinct `source` per row so seeded rows never collide with the
+// device_event_logs_dedup_idx unique index on (device_id, source, event_id) —
+// eventId is left null on every row.
+async function seedLog(opts: {
+  orgId: string;
+  deviceId: string;
+  timestamp: Date;
+  source: string;
+}) {
+  const [row] = await getTestDb()
+    .insert(deviceEventLogs)
+    .values({
+      deviceId: opts.deviceId,
+      orgId: opts.orgId,
+      timestamp: opts.timestamp,
+      level: 'info',
+      category: 'system',
+      source: opts.source,
+      message: `msg-${opts.source}`,
+    })
+    .returning();
+  if (!row) throw new Error('seedLog: insert returned no row');
+  return row;
+}
+
+function makeAuth(orgId: string): AuthContext {
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([orgId]);
+  return {
+    principal: 'user',
+    user: { id: '00000000-0000-0000-0000-0000000000aa', email: 'op@example.com', name: 'Op', isPlatformAdmin: false },
+    token: {} as unknown as AuthContext['token'],
+    partnerId: null,
+    orgId,
+    scope: 'organization',
+    accessibleOrgIds: [orgId],
+    orgCondition,
+    canAccessOrg,
+  } as unknown as AuthContext;
+}
+
+function ctxFor(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: null,
+    userId: null,
+  };
+}
+
+// Postgres compares `uuid` columns byte-by-byte in the order the bytes appear
+// in the canonical lowercase hex text (no re-ordering, unlike e.g. Windows
+// mixed-endian GUIDs), so a plain string `<`/`>` comparison on the ids
+// returned by the driver reproduces the same ordering as the DB's own id
+// tiebreaker.
+function compareIdsAsc(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+describe('search_logs keyset pagination — real Postgres (#3329)', () => {
+  it('resolves (not throws) when paging with a cursor the service itself issued', async () => {
+    const { org, device } = await seedFixture();
+    const base = new Date('2026-01-01T00:00:00.000Z');
+    for (let i = 0; i < 5; i++) {
+      await seedLog({ orgId: org.id, deviceId: device.id, timestamp: new Date(base.getTime() + i * 1000), source: `regress-${i}` });
+    }
+    const auth = makeAuth(org.id);
+
+    const first = await withDbAccessContext(ctxFor(org.id), () =>
+      searchFleetLogs(auth, { limit: 2, timeRange: WIDE_TIME_RANGE, countMode: 'none' }),
+    );
+    expect(first.nextCursor).not.toBeNull();
+
+    // THE regression: on the pre-fix code this rejects with
+    // ERR_INVALID_ARG_TYPE from postgres.js's Bind step. It must resolve.
+    await expect(
+      withDbAccessContext(ctxFor(org.id), () =>
+        searchFleetLogs(auth, {
+          limit: 2,
+          timeRange: WIDE_TIME_RANGE,
+          countMode: 'none',
+          cursor: first.nextCursor!,
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it('full keyset walk (limit=4) exactly matches an unpaginated query — no gaps, no duplicates (desc + asc)', async () => {
+    const { org, device } = await seedFixture();
+    const base = new Date('2026-02-01T00:00:00.000Z');
+    const total = 25;
+    for (let i = 0; i < total; i++) {
+      await seedLog({
+        orgId: org.id,
+        deviceId: device.id,
+        timestamp: new Date(base.getTime() + i * 60_000),
+        source: `walk-${i}`,
+      });
+    }
+    const auth = makeAuth(org.id);
+
+    for (const sortOrder of ['desc', 'asc'] as const) {
+      const unpaginated = await withDbAccessContext(ctxFor(org.id), () =>
+        searchFleetLogs(auth, { limit: 1000, timeRange: WIDE_TIME_RANGE, countMode: 'none', sortOrder }),
+      );
+      expect(unpaginated.results).toHaveLength(total);
+      const expectedIds = unpaginated.results.map((r) => r.log.id);
+
+      const walked: string[] = [];
+      let cursor: string | undefined;
+      let steps = 0;
+      const MAX_STEPS = total + 2; // generous guard against an infinite loop on a real bug
+      while (steps < MAX_STEPS) {
+        steps++;
+        const page = await withDbAccessContext(ctxFor(org.id), () =>
+          searchFleetLogs(auth, { limit: 4, timeRange: WIDE_TIME_RANGE, countMode: 'none', sortOrder, cursor }),
+        );
+        for (const r of page.results) walked.push(r.log.id);
+        if (!page.hasMore) {
+          expect(page.nextCursor).toBeNull();
+          break;
+        }
+        expect(page.nextCursor).not.toBeNull();
+        cursor = page.nextCursor!;
+      }
+
+      expect(steps).toBeLessThan(MAX_STEPS); // walk actually terminated via hasMore=false
+      expect(walked).toEqual(expectedIds); // same order, no gaps, no dupes
+      expect(new Set(walked).size).toBe(total);
+    }
+  });
+
+  it('uuid tiebreaker: paging continues correctly through a tie group split across a page boundary (desc + asc)', async () => {
+    const { org, device } = await seedFixture();
+    const tieTime = new Date('2026-03-01T12:00:00.000Z');
+    const earlierTime = new Date(tieTime.getTime() - 10_000);
+    const laterTime = new Date(tieTime.getTime() + 10_000);
+
+    const earlier = await seedLog({ orgId: org.id, deviceId: device.id, timestamp: earlierTime, source: 'tie-earlier' });
+    const tieRows = [];
+    for (let i = 0; i < 3; i++) {
+      tieRows.push(await seedLog({ orgId: org.id, deviceId: device.id, timestamp: tieTime, source: `tie-${i}` }));
+    }
+    const later = await seedLog({ orgId: org.id, deviceId: device.id, timestamp: laterTime, source: 'tie-later' });
+
+    // Sanity: the tie group must genuinely share an identical timestamp AS
+    // ROUND-TRIPPED THROUGH POSTGRES, or the "split across a page boundary"
+    // premise below is untested.
+    const tieTimestampValues = new Set(tieRows.map((r) => r.timestamp.getTime()));
+    expect(tieTimestampValues.size).toBe(1);
+
+    const auth = makeAuth(org.id);
+
+    for (const sortOrder of ['desc', 'asc'] as const) {
+      const tieSortedIds = tieRows
+        .map((r) => r.id)
+        .sort((a, b) => (sortOrder === 'desc' ? compareIdsAsc(b, a) : compareIdsAsc(a, b)));
+
+      const expectedOrder = sortOrder === 'desc'
+        ? [later.id, ...tieSortedIds, earlier.id]
+        : [earlier.id, ...tieSortedIds, later.id];
+
+      // limit=2 over 5 rows guarantees at least one page boundary falls
+      // strictly inside the 3-row tie group.
+      const walked: string[] = [];
+      let cursor: string | undefined;
+      let sawBoundaryInsideTieGroup = false;
+      let steps = 0;
+      const MAX_STEPS = 8;
+      while (steps < MAX_STEPS) {
+        steps++;
+        const page = await withDbAccessContext(ctxFor(org.id), () =>
+          searchFleetLogs(auth, { limit: 2, timeRange: WIDE_TIME_RANGE, countMode: 'none', sortOrder, cursor }),
+        );
+        const pageIds = page.results.map((r) => r.log.id);
+        if (pageIds.length > 0) {
+          const lastIdOnPage = pageIds[pageIds.length - 1]!;
+          // The page boundary lands INSIDE the tie group when the last row
+          // on this page is a tie-group member that is not the tie group's
+          // own last element in sort order (i.e. at least one more tied row
+          // remains for the next page to serve).
+          if (tieSortedIds.includes(lastIdOnPage) && lastIdOnPage !== tieSortedIds[tieSortedIds.length - 1]) {
+            sawBoundaryInsideTieGroup = true;
+          }
+        }
+        walked.push(...pageIds);
+        if (!page.hasMore) {
+          expect(page.nextCursor).toBeNull();
+          break;
+        }
+        expect(page.nextCursor).not.toBeNull();
+        cursor = page.nextCursor!;
+      }
+
+      expect(steps).toBeLessThan(MAX_STEPS);
+      // If this is ever false, the test fixture stopped exercising the
+      // boundary-inside-a-tie-group scenario and the assertion below would
+      // no longer be able to catch a dropped tiebreaker.
+      expect(sawBoundaryInsideTieGroup).toBe(true);
+      // Without the uuid tiebreaker, the keyset predicate degrades to
+      // `timestamp < cursor.timestamp` alone, which would skip every
+      // remaining tied row once the cursor's own timestamp equals the tie
+      // value — collapsing this to a 3-element list missing the tied rows
+      // that were still due. Exact-order equality catches that.
+      expect(walked).toEqual(expectedOrder);
+    }
+  });
+});

--- a/apps/api/src/services/aiToolErrors.test.ts
+++ b/apps/api/src/services/aiToolErrors.test.ts
@@ -208,6 +208,21 @@ describe('aiToolErrors', () => {
       expect(sanitizeThrownToolError('get_cis_compliance', new Error(msg))).toBe(msg);
     });
 
+    it('preserves the cursor-rejection messages so a paging client can recover (#3329)', () => {
+      expect(sanitizeThrownToolError('search_logs', new Error('Invalid cursor format.')))
+        .toBe('Invalid cursor format.');
+      expect(sanitizeThrownToolError('search_logs', new Error('Invalid cursor payload.')))
+        .toBe('Invalid cursor payload.');
+    });
+
+    it('does not let the cursor allowlist smuggle driver detail through', () => {
+      // Anchored pattern: anything appended to the literal falls back to generic.
+      expect(sanitizeThrownToolError(
+        'search_logs',
+        new Error('Invalid cursor payload. relation "device_event_logs" does not exist'),
+      )).toBe(GENERIC_TOOL_ERROR_MESSAGE);
+    });
+
     it('handles non-Error throws', () => {
       expect(sanitizeThrownToolError('t', 'a bare string')).toBe(GENERIC_TOOL_ERROR_MESSAGE);
       expect(sanitizeThrownToolError('t', undefined)).toBe(GENERIC_TOOL_ERROR_MESSAGE);

--- a/apps/api/src/services/aiToolErrors.ts
+++ b/apps/api/src/services/aiToolErrors.ts
@@ -37,6 +37,12 @@ export const GENERIC_TOOL_ERROR_MESSAGE =
 const SAFE_THROWN_MESSAGE_PATTERNS: RegExp[] = [
   /^Tool execution timed out after \d+ms/i,
   /^Tool .{1,60} timed out/i,
+  // Pagination cursors are opaque to the caller, so "the tool failed" is not an
+  // actionable answer when one is rejected — the client cannot tell a bad cursor
+  // from a server fault and has no way to recover (#3329). These are fixed
+  // string literals in logSearch.ts with nothing interpolated, so they cannot
+  // carry schema or driver detail; the detector below still vets them anyway.
+  /^Invalid cursor (?:format|payload)\.$/i,
 ];
 
 /**

--- a/apps/api/src/services/aiToolOutput.test.ts
+++ b/apps/api/src/services/aiToolOutput.test.ts
@@ -64,6 +64,60 @@ describe('compactToolResultForChat', () => {
     expect((parsed._chat as Record<string, unknown>).outputCompacted).toBe(true);
     expect((parsed._chat as Record<string, unknown>).nonJsonOutput).toBe(true);
     expect(typeof parsed.preview).toBe('string');
+    expect(parsed.summarized).toBe(true);
+  });
+
+  describe('summarized discriminator (#3329)', () => {
+    // A row-less digest is HTTP 200 with no error field. Without an explicit
+    // marker a programmatic consumer cannot tell it from a record and stores it
+    // as data. `_chat` alone is not that marker — it also rides along with
+    // payloads whose rows are intact.
+    it('marks the row-less digest that replaces an unshrinkable payload', () => {
+      // Synthetic worst case for the branch, not a realistic log page: string
+      // leaves are budgeted on RAW length while the ceiling is enforced on the
+      // JSON-SERIALIZED length, so all-escapable fields double in size after
+      // every compaction tier has run and the payload still overflows.
+      const escapeDense = '"\n\t'.repeat(400);
+      const raw = JSON.stringify(
+        Object.fromEntries(
+          Array.from({ length: 40 }).map((_, idx) => [`field${idx}`, escapeDense]),
+        ),
+      );
+
+      const parsed = JSON.parse(compactToolResultForChat('search_logs', raw)) as Record<string, unknown>;
+
+      expect(parsed.summarized).toBe(true);
+      expect(parsed.logs).toBeUndefined();
+      expect((parsed.summary as Record<string, unknown>).toolName).toBe('search_logs');
+    });
+
+    it('does NOT mark a compacted payload whose rows survived', () => {
+      const raw = JSON.stringify({
+        total: 2_000,
+        alerts: Array.from({ length: 500 }).map((_, idx) => ({
+          id: `alert-${idx}`,
+          title: `Disk usage high on host-${idx}`,
+          severity: 'high',
+        })),
+      });
+
+      const parsed = JSON.parse(compactToolResultForChat('manage_alerts', raw)) as Record<string, unknown>;
+
+      // This is the shape the reporter flagged as ambiguous: `_chat` present,
+      // but the rows are real and must still be read.
+      expect(parsed._chat).toBeDefined();
+      expect(Array.isArray(parsed.alerts)).toBe(true);
+      expect((parsed.alerts as unknown[]).length).toBeGreaterThan(0);
+      expect(parsed.summarized).toBeUndefined();
+    });
+
+    it('does NOT mark a payload that fit without compaction', () => {
+      const raw = JSON.stringify({ logs: [{ id: 'log-1', message: 'ok' }] });
+      const parsed = JSON.parse(compactToolResultForChat('search_logs', raw)) as Record<string, unknown>;
+
+      expect(parsed.summarized).toBeUndefined();
+      expect((parsed.logs as unknown[]).length).toBe(1);
+    });
   });
 
   it('truncates disk cleanup candidates and reports counts', () => {

--- a/apps/api/src/services/aiToolOutput.ts
+++ b/apps/api/src/services/aiToolOutput.ts
@@ -581,6 +581,24 @@ function safeStringify(value: unknown): string {
   }
 }
 
+/**
+ * Shrink a tool result to something a chat turn can carry, and mark it honestly.
+ *
+ * Three outcomes, and a programmatic consumer has to be able to tell them apart
+ * (#3329 — a poller silently stored a digest as if it were a record):
+ *
+ * 1. **Result fits** — returned verbatim.
+ * 2. **Result was compacted but the data survived** — the payload keeps its own
+ *    shape (`logs`, `alerts`, …) and gains a `_chat` note describing what was
+ *    trimmed. Rows are still there; keep reading them.
+ * 3. **Result could not be made to fit** — the payload is REPLACED by a digest
+ *    (`summary`/`preview`) that contains no rows at all.
+ *
+ * `summarized: true` is set on outcome 3 only, and is the supported way to
+ * detect it. Do NOT branch on the presence of `_chat`: it is also present in
+ * outcome 2, where the rows are intact and must be consumed — `manage_alerts`
+ * in particular returns `_chat` right next to a real `alerts` array.
+ */
 export function compactToolResultForChat(toolName: string, rawResult: string): string {
   const parsed = tryParseJson(rawResult);
   if (parsed === null) {
@@ -595,6 +613,7 @@ export function compactToolResultForChat(toolName: string, rawResult: string): s
       return redactedRaw;
     }
     return JSON.stringify({
+      summarized: true,
       _chat: {
         outputCompacted: true,
         nonJsonOutput: true,
@@ -635,6 +654,7 @@ export function compactToolResultForChat(toolName: string, rawResult: string): s
   }
 
   return JSON.stringify({
+    summarized: true,
     _chat: {
       outputCompacted: true,
       originalChars: rawResult.length,

--- a/apps/api/src/services/logSearch.test.ts
+++ b/apps/api/src/services/logSearch.test.ts
@@ -1,6 +1,14 @@
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { describe, expect, it } from 'vitest';
 
-import { mergeSavedLogSearchFilters, resolveSingleOrgId, sanitizeCorrelationPattern } from './logSearch';
+import {
+  buildLogSearchKeysetCondition,
+  decodeSearchCursor,
+  encodeSearchCursor,
+  mergeSavedLogSearchFilters,
+  resolveSingleOrgId,
+  sanitizeCorrelationPattern,
+} from './logSearch';
 
 describe('mergeSavedLogSearchFilters', () => {
   it('applies saved filters when request does not override fields', () => {
@@ -85,6 +93,80 @@ describe('sanitizeCorrelationPattern', () => {
     // 27 terms joined by 26 pipes, over the 25 alternation limit
     const pattern = Array.from({ length: 27 }, () => 'a').join('|');
     expect(() => sanitizeCorrelationPattern(pattern, true)).toThrow(/too complex/i);
+  });
+});
+
+describe('search cursor round-trip (#3329)', () => {
+  const CURSOR_ID = '56d661ad-4fa9-45d8-8dab-eba1fd8fb20c';
+
+  it('decodes a cursor it issued back to the same timestamp and id', () => {
+    const timestamp = new Date('2026-08-10T06:14:42.123Z');
+    const decoded = decodeSearchCursor(encodeSearchCursor({ timestamp, id: CURSOR_ID }));
+
+    expect(decoded.id).toBe(CURSOR_ID);
+    // Millisecond fidelity matters: the keyset predicate uses `timestamp = cursor`
+    // as the tiebreaker branch, so any drift there silently skips rows.
+    expect(decoded.timestamp.toISOString()).toBe(timestamp.toISOString());
+  });
+
+  it('accepts a standard base64 cursor, not just base64url', () => {
+    const timestamp = new Date('2026-08-10T06:14:42.000Z');
+    const standardBase64 = Buffer.from(
+      JSON.stringify({ timestamp: timestamp.toISOString(), id: CURSOR_ID }),
+    ).toString('base64');
+
+    expect(decodeSearchCursor(standardBase64).id).toBe(CURSOR_ID);
+  });
+
+  it('rejects a malformed cursor rather than paging from an arbitrary point', () => {
+    expect(() => decodeSearchCursor('not-base64-json')).toThrow(/invalid cursor/i);
+    expect(() => decodeSearchCursor(
+      Buffer.from(JSON.stringify({ timestamp: 'nope', id: CURSOR_ID })).toString('base64url'),
+    )).toThrow(/invalid cursor payload/i);
+    expect(() => decodeSearchCursor(
+      Buffer.from(JSON.stringify({ timestamp: new Date().toISOString(), id: 'not-a-uuid' })).toString('base64url'),
+    )).toThrow(/invalid cursor payload/i);
+  });
+});
+
+describe('buildLogSearchKeysetCondition (#3329)', () => {
+  const dialect = new PgDialect();
+  const cursor = {
+    timestamp: new Date('2026-08-10T06:14:42.000Z'),
+    id: '56d661ad-4fa9-45d8-8dab-eba1fd8fb20c',
+  };
+
+  /**
+   * The bug this guards: the predicate used to be a hand-written `sql` template
+   * that interpolated `cursor.timestamp` directly. A bare value in a `sql`
+   * template is bound with the NOOP encoder, so the raw `Date` reached
+   * postgres.js, whose Bind step threw ERR_INVALID_ARG_TYPE ("Received an
+   * instance of Date"). Inside the request transaction that surfaced as an
+   * HTTP 500 for the whole call, making `nextCursor` unusable.
+   */
+  it.each(['asc', 'desc'] as const)('binds no raw Date to the driver (sortOrder=%s)', (sortOrder) => {
+    const { params } = dialect.sqlToQuery(buildLogSearchKeysetCondition(cursor, sortOrder));
+
+    expect(params.length).toBeGreaterThan(0);
+    for (const param of params) {
+      expect(param).not.toBeInstanceOf(Date);
+      expect(['string', 'number']).toContain(typeof param);
+    }
+    expect(params).toContain(cursor.id);
+  });
+
+  it('walks backwards for a descending sort and forwards for an ascending sort', () => {
+    const desc = dialect.sqlToQuery(buildLogSearchKeysetCondition(cursor, 'desc')).sql;
+    const asc = dialect.sqlToQuery(buildLogSearchKeysetCondition(cursor, 'asc')).sql;
+
+    expect(desc).toContain('<');
+    expect(desc).not.toContain('>');
+    expect(asc).toContain('>');
+    expect(asc).not.toContain('<');
+    // Both directions need the id tiebreaker for rows sharing a timestamp,
+    // otherwise a page boundary inside one millisecond loses or repeats rows.
+    expect(desc).toContain('"device_event_logs"."id"');
+    expect(asc).toContain('"device_event_logs"."id"');
   });
 });
 

--- a/apps/api/src/services/logSearch.ts
+++ b/apps/api/src/services/logSearch.ts
@@ -3,10 +3,13 @@ import {
   asc,
   desc,
   eq,
+  gt,
   gte,
   ilike,
   inArray,
+  lt,
   lte,
+  or,
   sql,
   type SQL
 } from 'drizzle-orm';
@@ -142,14 +145,19 @@ function parseTimeRange(input?: { start?: string; end?: string }): { start: Date
   return { start, end };
 }
 
-function encodeSearchCursor(cursor: { timestamp: Date; id: string }): string {
+export interface LogSearchCursor {
+  timestamp: Date;
+  id: string;
+}
+
+export function encodeSearchCursor(cursor: LogSearchCursor): string {
   return Buffer.from(JSON.stringify({
     timestamp: cursor.timestamp.toISOString(),
     id: cursor.id,
   })).toString('base64url');
 }
 
-function decodeSearchCursor(raw: string): { timestamp: Date; id: string } {
+export function decodeSearchCursor(raw: string): LogSearchCursor {
   let parsed: unknown;
   try {
     parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
@@ -171,6 +179,51 @@ function decodeSearchCursor(raw: string): { timestamp: Date; id: string } {
   }
 
   return { timestamp, id };
+}
+
+/**
+ * Keyset (`WHERE (ts, id) < (cursor.ts, cursor.id)`) predicate for cursor
+ * pagination, in whichever direction the caller sorted.
+ *
+ * Built from Drizzle's typed comparison helpers on purpose (#3329). The
+ * previous hand-written `sql` template interpolated the cursor's `Date`
+ * directly, and a bare value inside a `sql` template is wrapped in a `Param`
+ * with the *noop* encoder — so the `Date` object reached postgres.js
+ * unserialized and its Bind step threw
+ * `ERR_INVALID_ARG_TYPE: The "string" argument must be ... Received an
+ * instance of Date`. Because every request runs inside `withDbAccessContext`
+ * (a postgres.js `begin()` transaction, which re-throws any query error at
+ * commit even after the caller handled it), that surfaced as an HTTP 500 for
+ * the whole MCP/REST call rather than a tool-level error — i.e. the advertised
+ * `nextCursor` could never be used. `lt`/`gt`/`eq` route the value through the
+ * column's own encoder, which is what serializes the `Date` for the driver.
+ *
+ * Cursor timestamps are millisecond-precision, which is lossless here:
+ * `device_event_logs.timestamp` is agent-supplied and normalized through
+ * `new Date(...)` on ingest (`routes/agents/helpers.ts` `sanitizeTimestamp`),
+ * so the column never holds sub-millisecond values.
+ */
+export function buildLogSearchKeysetCondition(
+  cursor: LogSearchCursor,
+  sortOrder: 'asc' | 'desc',
+): SQL {
+  const condition = sortOrder === 'asc'
+    ? or(
+        gt(deviceEventLogs.timestamp, cursor.timestamp),
+        and(eq(deviceEventLogs.timestamp, cursor.timestamp), gt(deviceEventLogs.id, cursor.id)),
+      )
+    : or(
+        lt(deviceEventLogs.timestamp, cursor.timestamp),
+        and(eq(deviceEventLogs.timestamp, cursor.timestamp), lt(deviceEventLogs.id, cursor.id)),
+      );
+
+  // `or()` is only `undefined` when given no defined operands; both are always
+  // defined above. Assert rather than silently dropping the page boundary,
+  // which would re-serve page 1 forever.
+  if (!condition) {
+    throw new Error('Failed to build log search keyset condition.');
+  }
+  return condition;
 }
 
 export function mergeSavedLogSearchFilters(
@@ -332,18 +385,9 @@ async function runFleetSearch(
   const pageConditions = [...baseConditions];
 
   if (filters.cursor) {
-    const cursor = decodeSearchCursor(filters.cursor);
-    if (sortOrder === 'asc') {
-      pageConditions.push(sql`(
-        ${deviceEventLogs.timestamp} > ${cursor.timestamp}
-        OR (${deviceEventLogs.timestamp} = ${cursor.timestamp} AND ${deviceEventLogs.id} > cast(${cursor.id} as uuid))
-      )`);
-    } else {
-      pageConditions.push(sql`(
-        ${deviceEventLogs.timestamp} < ${cursor.timestamp}
-        OR (${deviceEventLogs.timestamp} = ${cursor.timestamp} AND ${deviceEventLogs.id} < cast(${cursor.id} as uuid))
-      )`);
-    }
+    pageConditions.push(
+      buildLogSearchKeysetCondition(decodeSearchCursor(filters.cursor), sortOrder),
+    );
   }
 
   const whereCondition = and(...pageConditions);


### PR DESCRIPTION
Closes #3329

## The bug

`search_logs` advertised `hasMore: true` alongside a well-formed `nextCursor`, but sending that cursor straight back returned **HTTP 500**. The advertised pagination path could not be used at all — and because `hasMore: true` invites the call, every consumer that pages (log export, SIEM forwarding, an agent walking more than one page) hit it on page 2.

This is not MCP-specific: the REST `POST /logs/search` endpoint shares `searchFleetLogs`, so it had the identical failure.

## Root cause

The keyset predicate in `runFleetSearch` was a hand-written `sql` template that interpolated the cursor's `Date` directly:

```ts
sql`(
  ${deviceEventLogs.timestamp} < ${cursor.timestamp}
  OR (${deviceEventLogs.timestamp} = ${cursor.timestamp} AND ${deviceEventLogs.id} < cast(${cursor.id} as uuid))
)`
```

A bare value inside a Drizzle `sql` template is wrapped in a `Param` with the **noop** encoder, so the raw `Date` object was handed to postgres.js, whose Bind step throws:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string
or an instance of Buffer or ArrayBuffer. Received an instance of Date
    at Bind (postgres/src/connection.js:954)
```

The surrounding `gte`/`lte` time-range conditions were fine precisely because they go through Drizzle's typed helpers, which serialize the `Date` via the **column's** encoder.

Why a 500 rather than a tool-level error: every request runs inside `withDbAccessContext`, a postgres.js `begin()` transaction which re-throws any query error at commit *even after the application handled it*. `search_logs`' own `catch` did return `{ error: ... }`, but the transaction wrapper then threw the raw driver error past it into Hono's global handler.

## The fix

The predicate is now built from Drizzle's typed `lt`/`gt`/`eq` helpers in an exported `buildLogSearchKeysetCondition`, so cursor values are encoded by the column that receives them.

Cursor timestamps stay millisecond-precision, which is **lossless** here rather than merely tolerable: `device_event_logs.timestamp` is agent-supplied and normalized through `new Date(...)` in `sanitizeTimestamp` (`routes/agents/helpers.ts`) on ingest, so the column cannot hold sub-millisecond values. Confirmed against the dev database — 0 of 580 rows have sub-millisecond precision. That matters because the `timestamp = cursor` tiebreaker branch would silently skip rows if the cursor were coarser than the column.

## Verification against a real database

Paging the full dev fleet with `limit: 7`, then diffing against a single unpaginated query:

```
sortOrder=desc pages=83 paged=580 oneShot=580 dupes=0 orderIdentical=true
sortOrder=asc  pages=83 paged=580 oneShot=580 dupes=0 orderIdentical=true
```

No gaps, no duplicates, ordering byte-identical to the one-shot result, in both sort directions.

## Also in this change

**Cursor rejections are now legible.** `Invalid cursor format.` / `Invalid cursor payload.` are added to the AI tool error allowlist. Cursors are opaque to the caller, so the generic *"the tool could not complete this request"* left a paging client unable to distinguish a stale cursor from a server fault, with no recovery path. Both are fixed string literals with nothing interpolated, and the driver-detail detector still vets them — a test asserts that appending driver text to the literal falls back to the generic message.

**Row-less digests are now self-describing.** @bdunncompany's follow-up report flagged a second, compounding behaviour: above a response-size budget the tools return `{_chat, preview, summary}` with **no row array**, as HTTP 200 with no error field, so a poller stores the digest as if it were a record. `_chat` alone is not a usable detector, because it also rides along with payloads whose rows are intact — `manage_alerts` returns `_chat` right next to a real `alerts` array. `compactToolResultForChat` now sets `summarized: true` on exactly the two branches that *replace* the payload, and the contract is documented on the function. The three outcomes are now distinguishable with one key.

## Scope notes

- **Not fixed here — the digest opt-out flag.** The report also asked for a way to opt out of summarisation. That is a real MCP surface decision (budget per tool? per call? interaction with the model's own context limits) rather than a bug fix, so it is left for a follow-up.
- **Not fixed here — why `search_logs` digested at 20-minute windows.** I characterised the compaction path empirically: sweeping row counts 5→1000 and message lengths 80→200,000 chars, the tightest tier always caps `logs` at 10 rows / 300-char messages and lands ~7.2 KB, under the 8 KB ceiling. Total row loss required a payload of almost entirely JSON-escapable characters. So the reported 20-minute-window digest is **not** reproducible from row count or message length alone, and the `summarized` flag makes it detectable rather than explained. Worth pinning down with the reporter.
- **Two more instances of this same defect class exist elsewhere** and are deliberately *not* bundled into this PR (unrelated subsystems, one auth-adjacent, each wants its own test): `services/filterEngine.ts` `applyOperator` (datetime `before`/`after`/`between`/`equals` on `POST /devices/filters/preview`, dynamic groups, deployment targeting) and `oauth/revocationRetry.ts`. Filed separately and linked below.

## Tests

- `logSearch.test.ts` — cursor encode/decode round-trip incl. millisecond fidelity, standard-base64 tolerance, malformed-cursor rejection; and a regression guard that renders the keyset condition through `PgDialect.sqlToQuery` and asserts **no param is a `Date`**. That guard fails on the old code without needing a database.
- `aiToolErrors.test.ts` — cursor messages preserved; allowlist cannot smuggle driver detail.
- `aiToolOutput.test.ts` — `summarized` set on the row-less digest, absent when rows survived alongside `_chat`, absent when nothing was compacted.

`apps/api` affected suites green single-fork (`logSearch`, `aiToolOutput`, `aiToolErrors`, `aiToolsEventLogs.siteScope`, `routes/logs` — 110 passed; `routes/mcpServer` — 16 files, 147 passed). `tsc --noEmit` clean.

Reported by @bdunncompany.

🤖 Generated with [Claude Code](https://claude.com/claude-code)