### PR TITLE
fix(agent): normalize reboot/shutdown delay to minutes on Windows (#3252)

### DIFF
--- a/agent/internal/remote/tools/system.go
+++ b/agent/internal/remote/tools/system.go
@@ -8,16 +8,29 @@ import (
 	"time"
 )
 
+// maxShutdownDelayMinutes bounds the `delay` payload for reboot/shutdown.
+// The wire contract is minutes on every platform (see docs/agents/commands.mdx),
+// so this is 24 hours.
+const maxShutdownDelayMinutes = 1440
+
+// clampShutdownDelayMinutes constrains a caller-supplied delay to [0, 1440]
+// minutes. Applied both when reporting the delay back to the server and inside
+// shutdownArgs, so the emitted argv can never carry an out-of-range value.
+func clampShutdownDelayMinutes(delayMinutes int) int {
+	if delayMinutes < 0 {
+		return 0
+	}
+	if delayMinutes > maxShutdownDelayMinutes {
+		return maxShutdownDelayMinutes
+	}
+	return delayMinutes
+}
+
 // Reboot schedules a system reboot after the requested delay.
-// Maximum delay is 1440 minutes (24 hours).
+// The `delay` payload is in MINUTES on every platform; maximum 1440 (24 hours).
 func Reboot(payload map[string]any) CommandResult {
 	startTime := time.Now()
-	delay := GetPayloadInt(payload, "delay", 0)
-	if delay < 0 {
-		delay = 0
-	} else if delay > 1440 {
-		delay = 1440
-	}
+	delay := clampShutdownDelayMinutes(GetPayloadInt(payload, "delay", 0))
 
 	cmd, err := buildShutdownCommand(true, delay)
 	if err != nil {
@@ -37,15 +50,10 @@ func Reboot(payload map[string]any) CommandResult {
 }
 
 // Shutdown schedules a system shutdown after the requested delay.
-// Maximum delay is 1440 minutes (24 hours).
+// The `delay` payload is in MINUTES on every platform; maximum 1440 (24 hours).
 func Shutdown(payload map[string]any) CommandResult {
 	startTime := time.Now()
-	delay := GetPayloadInt(payload, "delay", 0)
-	if delay < 0 {
-		delay = 0
-	} else if delay > 1440 {
-		delay = 1440
-	}
+	delay := clampShutdownDelayMinutes(GetPayloadInt(payload, "delay", 0))
 
 	cmd, err := buildShutdownCommand(false, delay)
 	if err != nil {
@@ -91,23 +99,47 @@ func Lock(payload map[string]any) CommandResult {
 	return NewSuccessResult(result, time.Since(startTime).Milliseconds())
 }
 
-func buildShutdownCommand(isReboot bool, delay int) (*exec.Cmd, error) {
-	switch runtime.GOOS {
+// shutdownArgs returns the argv for the platform's shutdown binary.
+//
+// delayMinutes is the wire contract shared by every platform (MINUTES). The
+// per-OS unit differs and must be converted here:
+//
+//   - Windows `shutdown /t <n>` takes SECONDS, so the value is scaled by 60.
+//   - Linux/macOS `shutdown -r +<n>` already takes minutes, so it is passed through.
+//
+// Before this conversion existed, `delay: 15` meant 15 minutes on Linux/macOS
+// and 15 seconds on Windows — a 60x skew (issue #3252). `RebootToSafeMode` in
+// system_safemode_windows.go performs the same minutes→seconds scaling.
+//
+// goos is a parameter rather than a direct runtime.GOOS read so the mapping is
+// table-testable from any host platform.
+func shutdownArgs(goos string, isReboot bool, delayMinutes int) (string, []string, error) {
+	delayMinutes = clampShutdownDelayMinutes(delayMinutes)
+
+	switch goos {
 	case "windows":
 		action := "/s"
 		if isReboot {
 			action = "/r"
 		}
-		return exec.Command("shutdown", action, "/t", strconv.Itoa(delay)), nil
+		return "shutdown", []string{action, "/t", strconv.Itoa(delayMinutes * 60)}, nil
 	case "linux", "darwin":
 		action := "-h"
 		if isReboot {
 			action = "-r"
 		}
-		return exec.Command("shutdown", action, "+"+strconv.Itoa(delay)), nil
+		return "shutdown", []string{action, "+" + strconv.Itoa(delayMinutes)}, nil
 	default:
-		return nil, fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+		return "", nil, fmt.Errorf("unsupported OS: %s", goos)
 	}
+}
+
+func buildShutdownCommand(isReboot bool, delayMinutes int) (*exec.Cmd, error) {
+	name, args, err := shutdownArgs(runtime.GOOS, isReboot, delayMinutes)
+	if err != nil {
+		return nil, err
+	}
+	return exec.Command(name, args...), nil
 }
 
 func lockLinuxSession() error {

--- a/agent/internal/remote/tools/system_safemode_windows.go
+++ b/agent/internal/remote/tools/system_safemode_windows.go
@@ -20,12 +20,7 @@ import (
 func RebootToSafeMode(payload map[string]any) CommandResult {
 	startTime := time.Now()
 
-	delay := GetPayloadInt(payload, "delay", 0)
-	if delay < 0 {
-		delay = 0
-	} else if delay > 1440 {
-		delay = 1440
-	}
+	delay := clampShutdownDelayMinutes(GetPayloadInt(payload, "delay", 0))
 
 	slog.Info("reboot to safe mode requested", "delayMinutes", delay)
 

--- a/agent/internal/remote/tools/system_safemode_windows.go
+++ b/agent/internal/remote/tools/system_safemode_windows.go
@@ -5,8 +5,6 @@ package tools
 import (
 	"fmt"
 	"log/slog"
-	"os/exec"
-	"strconv"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/safemode"
@@ -15,14 +13,22 @@ import (
 // RebootToSafeMode sets the BCD safeboot flag to "network" and initiates
 // a system reboot. If the shutdown command fails, the BCD flag is rolled
 // back to prevent an accidental safe mode boot on the next organic reboot.
-// An optional delay (minutes, 0-1440) is supported; converted to seconds
-// for the Windows shutdown command.
+// An optional delay (minutes, 0-1440) is supported; buildShutdownCommand
+// applies the minutes→seconds conversion the Windows `shutdown /t` flag needs.
 func RebootToSafeMode(payload map[string]any) CommandResult {
 	startTime := time.Now()
 
 	delay := clampShutdownDelayMinutes(GetPayloadInt(payload, "delay", 0))
 
 	slog.Info("reboot to safe mode requested", "delayMinutes", delay)
+
+	// Build the command BEFORE touching the BCD flag, so a construction error
+	// can never strand the machine with safeboot set and no reboot scheduled.
+	cmd, err := buildShutdownCommand(true, delay)
+	if err != nil {
+		slog.Error("failed to build shutdown command", "error", err.Error())
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
+	}
 
 	// Set BCD safe mode flag before initiating reboot.
 	if err := safemode.SetSafeBootNetwork(); err != nil {
@@ -31,9 +37,6 @@ func RebootToSafeMode(payload map[string]any) CommandResult {
 	}
 	slog.Info("BCD safeboot flag set to network")
 
-	// Initiate reboot. Delay is in minutes, shutdown /t expects seconds.
-	delaySeconds := delay * 60
-	cmd := exec.Command("shutdown", "/r", "/t", strconv.Itoa(delaySeconds))
 	if err := cmd.Run(); err != nil {
 		// Rollback: clear the BCD flag so the machine doesn't accidentally
 		// enter safe mode on the next organic reboot.

--- a/agent/internal/remote/tools/system_test.go
+++ b/agent/internal/remote/tools/system_test.go
@@ -1,0 +1,157 @@
+package tools
+
+import (
+	"runtime"
+	"slices"
+	"strconv"
+	"testing"
+)
+
+// The `delay` payload for reboot/shutdown is MINUTES on every platform
+// (docs/agents/commands.mdx). Windows `shutdown /t` takes seconds, so the
+// Windows branch must scale by 60; linux/darwin `shutdown +N` is already
+// minutes. Regression coverage for issue #3252, where a `delay: 15` rebooted
+// Linux in 15 minutes and Windows in 15 seconds.
+func TestShutdownArgs_PerPlatformArgv(t *testing.T) {
+	tests := []struct {
+		name        string
+		goos        string
+		isReboot    bool
+		delayMinute int
+		wantArgs    []string
+	}{
+		// ── Windows: minutes → seconds ──────────────────────────────────────
+		{"windows reboot immediate", "windows", true, 0, []string{"/r", "/t", "0"}},
+		{"windows reboot 1min", "windows", true, 1, []string{"/r", "/t", "60"}},
+		{"windows reboot 15min", "windows", true, 15, []string{"/r", "/t", "900"}},
+		{"windows shutdown immediate", "windows", false, 0, []string{"/s", "/t", "0"}},
+		{"windows shutdown 15min", "windows", false, 15, []string{"/s", "/t", "900"}},
+		{"windows reboot max 1440min", "windows", true, 1440, []string{"/r", "/t", "86400"}},
+
+		// ── linux/darwin: minutes passed through ────────────────────────────
+		{"linux reboot immediate", "linux", true, 0, []string{"-r", "+0"}},
+		{"linux reboot 15min", "linux", true, 15, []string{"-r", "+15"}},
+		{"linux shutdown 15min", "linux", false, 15, []string{"-h", "+15"}},
+		{"linux reboot max 1440min", "linux", true, 1440, []string{"-r", "+1440"}},
+		{"darwin reboot 15min", "darwin", true, 15, []string{"-r", "+15"}},
+		{"darwin shutdown immediate", "darwin", false, 0, []string{"-h", "+0"}},
+
+		// ── clamping happens before conversion ──────────────────────────────
+		{"windows negative clamps to 0", "windows", true, -5, []string{"/r", "/t", "0"}},
+		{"linux negative clamps to 0", "linux", true, -5, []string{"-r", "+0"}},
+		{"windows over-max clamps to 1440", "windows", true, 99999, []string{"/r", "/t", "86400"}},
+		{"linux over-max clamps to 1440", "linux", true, 99999, []string{"-r", "+1440"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, args, err := shutdownArgs(tt.goos, tt.isReboot, tt.delayMinute)
+			if err != nil {
+				t.Fatalf("shutdownArgs(%q, %v, %d): unexpected error %v",
+					tt.goos, tt.isReboot, tt.delayMinute, err)
+			}
+			if name != "shutdown" {
+				t.Errorf("binary: got %q, want %q", name, "shutdown")
+			}
+			if !slices.Equal(args, tt.wantArgs) {
+				t.Errorf("argv: got %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+// The same delay must resolve to the same wall-clock time on every supported
+// platform. This is the invariant issue #3252 violated.
+func TestShutdownArgs_DelayIsMinutesOnEveryPlatform(t *testing.T) {
+	for _, delayMinutes := range []int{0, 1, 5, 15, 60, 1440} {
+		t.Run(strconv.Itoa(delayMinutes)+"min", func(t *testing.T) {
+			_, winArgs, err := shutdownArgs("windows", true, delayMinutes)
+			if err != nil {
+				t.Fatalf("windows: %v", err)
+			}
+			// Windows argv is [action, "/t", seconds].
+			winSeconds, err := strconv.Atoi(winArgs[2])
+			if err != nil {
+				t.Fatalf("windows /t value %q is not an integer: %v", winArgs[2], err)
+			}
+
+			for _, goos := range []string{"linux", "darwin"} {
+				_, args, err := shutdownArgs(goos, true, delayMinutes)
+				if err != nil {
+					t.Fatalf("%s: %v", goos, err)
+				}
+				// Unix argv is [action, "+minutes"].
+				unixMinutes, err := strconv.Atoi(args[1][1:])
+				if err != nil {
+					t.Fatalf("%s delay %q is not a +integer: %v", goos, args[1], err)
+				}
+				if unixMinutes*60 != winSeconds {
+					t.Errorf("delay %d min: %s schedules %d s but windows schedules %d s",
+						delayMinutes, goos, unixMinutes*60, winSeconds)
+				}
+			}
+		})
+	}
+}
+
+func TestShutdownArgs_UnsupportedOS(t *testing.T) {
+	for _, goos := range []string{"freebsd", "plan9", ""} {
+		t.Run("goos="+goos, func(t *testing.T) {
+			name, args, err := shutdownArgs(goos, true, 15)
+			if err == nil {
+				t.Fatalf("expected error for goos %q, got name=%q args=%v", goos, name, args)
+			}
+			if name != "" || args != nil {
+				t.Errorf("expected zero-value argv on error, got name=%q args=%v", name, args)
+			}
+		})
+	}
+}
+
+func TestClampShutdownDelayMinutes(t *testing.T) {
+	tests := []struct {
+		in   int
+		want int
+	}{
+		{-1000, 0},
+		{-1, 0},
+		{0, 0},
+		{15, 15},
+		{1440, 1440},
+		{1441, 1440},
+		{1 << 30, 1440},
+	}
+
+	for _, tt := range tests {
+		if got := clampShutdownDelayMinutes(tt.in); got != tt.want {
+			t.Errorf("clampShutdownDelayMinutes(%d): got %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+// buildShutdownCommand must delegate to shutdownArgs for the host platform
+// rather than constructing argv independently.
+func TestBuildShutdownCommand_MatchesShutdownArgsForHostOS(t *testing.T) {
+	const delayMinutes = 15
+
+	wantName, wantArgs, wantErr := shutdownArgs(runtime.GOOS, true, delayMinutes)
+
+	cmd, err := buildShutdownCommand(true, delayMinutes)
+	if wantErr != nil {
+		if err == nil {
+			t.Fatalf("expected error on unsupported host %q, got cmd %v", runtime.GOOS, cmd)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("buildShutdownCommand: %v", err)
+	}
+
+	// exec.Cmd.Args[0] is the binary name; the remainder is the argv tail.
+	if len(cmd.Args) == 0 || cmd.Args[0] != wantName {
+		t.Fatalf("argv[0]: got %v, want %q", cmd.Args, wantName)
+	}
+	if !slices.Equal(cmd.Args[1:], wantArgs) {
+		t.Errorf("argv tail: got %v, want %v", cmd.Args[1:], wantArgs)
+	}
+}


### PR DESCRIPTION
Closes #3252

## Problem

`buildShutdownCommand` emitted the caller-supplied `delay` verbatim into both platform command lines, but the two flags use different units:

| Platform | Command | Unit of the delay arg |
|---|---|---|
| Windows | `shutdown /r /t <n>` | **seconds** |
| linux / darwin | `shutdown -r +<n>` | **minutes** |

The wire contract is **minutes on every platform**:

- `apps/docs/src/content/docs/agents/commands.mdx:271` — "`delay` | int | `0` | Delay in minutes before rebooting (0-1440)"
- the `1440` clamp in `Reboot`/`Shutdown` and their doc comments
- `MAINTENANCE_REBOOT_GRACE_MINUTES = 15`, which `maintenanceRebootWorker.ts` sends as `{type:'reboot', payload:{delay:15}}`

So `delay: 15` rebooted a Linux box in 15 minutes and a Windows box in **15 seconds**, and the 1440 clamp meant "24 hours" on Linux but "24 minutes" on Windows. Every intermediate value was off by 60x. `Shutdown` shared the same helper and the same defect.

**Why it hasn't bitten in production:** the only server-side caller that sends a non-zero delay routes Windows to `schedule_reboot` (which takes an explicit `delayMinutes`) and only sends `reboot` to Linux. Manual UI reboots pass `delay: 0`, where both units agree. The exposure is any caller that sends `reboot`/`shutdown` with a delay to a Windows device.

## Fix

Agent-side conversion only — **the server contract is unchanged**, as requested in the issue. `RebootToSafeMode` (`system_safemode_windows.go`) already scaled minutes to seconds correctly, so the Windows branch here now simply matches its sibling.

- Extract `shutdownArgs(goos, isReboot, delayMinutes)` — a pure, GOOS-parameterized argv builder. Taking `goos` as a parameter instead of reading `runtime.GOOS` inline is what makes the per-platform mapping table-testable from any host. `buildShutdownCommand` now delegates to it.
- Scale by 60 in the Windows branch.
- Extract `clampShutdownDelayMinutes` + `maxShutdownDelayMinutes`, replacing three hand-rolled copies of the same clamp (`Reboot`, `Shutdown`, `RebootToSafeMode`). Also applied *inside* `shutdownArgs`, so the emitted argv can never carry an out-of-range value regardless of caller — relevant now that the value gets multiplied.

## Tests

New `agent/internal/remote/tools/system_test.go` (there was no coverage of this code at all):

- **`TestShutdownArgs_PerPlatformArgv`** — table-driven over the emitted argv per GOOS: reboot vs shutdown, 0/1/15/1440 min, and negative/over-max clamping.
- **`TestShutdownArgs_DelayIsMinutesOnEveryPlatform`** — the invariant this issue violated: asserts the same `delay` resolves to the same wall-clock seconds on windows, linux and darwin.
- **`TestShutdownArgs_UnsupportedOS`** — error path returns zero-value argv.
- **`TestClampShutdownDelayMinutes`** — clamp bounds.
- **`TestBuildShutdownCommand_MatchesShutdownArgsForHostOS`** — guards against `buildShutdownCommand` drifting back to constructing argv independently.

The new tests **fail against the pre-fix code** (verified by reverting the `* 60`: `argv: got [/r /t 15], want [/r /t 900]`).

## Verification

- `go test -race ./internal/remote/tools/ ./internal/heartbeat/ ./internal/privilege/` — all green
- Cross-builds `GOOS=windows|linux|darwin go build ./...` — all OK
- `go vet` clean under all three GOOS (covers the `//go:build windows` safe-mode file)
- `gofmt` clean on touched files

## Out of scope

The issue asks to "consider whether the 0-delay case should keep emitting `/t 0`". Left as-is: that concerns the patch-reboot toast window and belongs to #3197's spec, which targets a different code path. Changing it here would alter manual-reboot behaviour beyond this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)