### PR TITLE
fix(ci): retire the update-community-readme schedule (#3173)

### DIFF
--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -1025,6 +1025,10 @@ test('community README refresh never writes to the repository', () => {
   assert.doesNotMatch(workflowText, /push origin/u);
   assert.doesNotMatch(workflowText, /credential\.helper/u);
   assert.doesNotMatch(workflowText, /persist-credentials:\s*true/u);
-  assert.doesNotMatch(workflowText, /^permissions:\n(?:\s+\w[\w-]*: .*\n)*\s+contents: write$/mu);
+  // Anchored to a line that is *only* the key, so it catches `contents: write`
+  // at the workflow level and inside any job-level permissions block, in any
+  // key order — while still ignoring the header comment, which discusses the
+  // string in prose.
+  assert.doesNotMatch(workflowText, /^\s*contents: write\s*$/mu);
   assert.match(workflowText, /^permissions:\n  contents: read$/mu);
 });

--- a/.github/scripts/check-workflow-security.test.mjs
+++ b/.github/scripts/check-workflow-security.test.mjs
@@ -1013,15 +1013,18 @@ test('all repository checkout steps disable credential persistence', () => {
   assert.deepEqual(failures, []);
 });
 
-test('community README push uses an ephemeral credential helper', () => {
+test('community README refresh never writes to the repository', () => {
   const workflowText = readFileSync(
     new URL('../workflows/update-community-readme.yml', import.meta.url),
     'utf8',
   );
 
-  assert.match(
-    workflowText,
-    /git -c credential\.helper= -c 'credential\.helper=!f\(\).*push origin HEAD:main/su,
-  );
+  // Issue #3173 retired the direct-to-main push. The job reports drift via an
+  // artifact and the run summary; nothing in it may push, hold a credential
+  // helper, or ask for more than read access.
+  assert.doesNotMatch(workflowText, /push origin/u);
+  assert.doesNotMatch(workflowText, /credential\.helper/u);
   assert.doesNotMatch(workflowText, /persist-credentials:\s*true/u);
+  assert.doesNotMatch(workflowText, /^permissions:\n(?:\s+\w[\w-]*: .*\n)*\s+contents: write$/mu);
+  assert.match(workflowText, /^permissions:\n  contents: read$/mu);
 });

--- a/.github/scripts/update-community-readme.test.mjs
+++ b/.github/scripts/update-community-readme.test.mjs
@@ -582,10 +582,8 @@ test('repository workflows gate and safely update the community README', async (
     'node --test .github/scripts/update-community-readme.test.mjs',
   );
   assert.match(ciWorkflow, /run: pnpm test:community-readme/);
-  assert.match(workflow, /^\s*schedule:\s*$/m);
-  assert.match(workflow, /^\s*- cron: ['"]17 5 \* \* \*['"]\s*$/m);
   assert.match(workflow, /^\s*workflow_dispatch:\s*$/m);
-  assert.match(workflow, /^permissions:\n  contents: write$/m);
+  assert.match(workflow, /^permissions:\n  contents: read$/m);
   assert.match(workflow, /^concurrency:\n  group: update-community-readme\n  cancel-in-progress: false$/m);
   assert.match(workflow, /^    timeout-minutes: 10$/m);
   const testCommand = 'node --test .github/scripts/update-community-readme.test.mjs';
@@ -594,8 +592,18 @@ test('repository workflows gate and safely update the community README', async (
   assert.ok(workflow.indexOf(testCommand) < workflow.indexOf(updateCommand));
   assert.doesNotMatch(workflow, /^\s*pull_request:\s*$/m);
   assert.doesNotMatch(workflow, /^\s*push:\s*$/m);
+
+  // Issue #3173: the schedule fired daily into a main-branch ruleset that
+  // rejects direct pushes, so every run failed and hung a red check run on
+  // whatever commit was at the head of main. The job is dispatch-only now.
+  assert.doesNotMatch(workflow, /^\s*schedule:\s*$/m);
+  assert.doesNotMatch(workflow, /^\s*- cron:/m);
+
+  // The run reports drift instead of writing to the repository.
   assert.match(workflow, /git diff --quiet -- README\.md/);
-  assert.match(workflow, /git add README\.md/);
-  assert.match(workflow, /git commit --only .* -- README\.md/);
-  assert.doesNotMatch(workflow, /git add (?:--all|-A|\.)/);
+  assert.match(workflow, /GITHUB_STEP_SUMMARY/);
+  assert.match(workflow, /uses: actions\/upload-artifact@[0-9a-f]{40} #/);
+  assert.doesNotMatch(workflow, /git commit/);
+  assert.doesNotMatch(workflow, /git push|push origin/);
+  assert.doesNotMatch(workflow, /git add/);
 });

--- a/.github/workflows/update-community-readme.yml
+++ b/.github/workflows/update-community-readme.yml
@@ -1,12 +1,30 @@
 name: Update community README
 
+# Manual only, and deliberately read-only.
+#
+# This job used to run on a daily schedule and push the refreshed README
+# straight to `main`. The main-branch ruleset rejects direct pushes, so every
+# scheduled run failed (issue #3173) and attached a red check run to whatever
+# commit happened to be at the head of `main`.
+#
+# Neither obvious repair works on this repository:
+#   * Opening a bot PR instead would never merge — ci.yml's `paths-ignore`
+#     skips `**/*.md`, so the ruleset's only required check, `CI Success`,
+#     never reports on a README-only PR.
+#   * Adding `github-actions` to the ruleset bypass list would hand
+#     main-branch push bypass to every workflow holding `contents: write`.
+#
+# So the run now only *reports*: it publishes the refreshed README as an
+# artifact plus a diff in the job summary, and a human lands that change on a
+# normal branch alongside other work. Sponsors and contributors change on a
+# scale of weeks and nothing downstream reads the README programmatically, so
+# the daily cadence was never load-bearing.
+
 on:
-  schedule:
-    - cron: '17 5 * * *'
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: update-community-readme
@@ -22,7 +40,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
-          ref: main
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -37,17 +54,30 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: node .github/scripts/update-community-readme.mjs
 
-      - name: Commit and push README changes
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Report README drift
+        id: drift
         run: |
           if git diff --quiet -- README.md; then
-            echo "README.md is already current"
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo 'README.md is already current - no sponsor or contributor drift.' >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit --only -m "docs: refresh sponsors and contributors [skip ci]" -- README.md
-          git -c credential.helper= -c 'credential.helper=!f() { printf "%s\n" "username=x-access-token" "password=$GITHUB_TOKEN"; }; f' push origin HEAD:main
+          echo 'changed=true' >> "$GITHUB_OUTPUT"
+          {
+            echo '### README.md is out of date'
+            echo
+            echo 'Download the community-readme artifact from this run, apply it on a branch, and open a normal pull request.'
+            echo
+            echo '```diff'
+            git --no-pager diff -- README.md
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload refreshed README
+        if: steps.drift.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: community-readme
+          path: README.md
+          if-no-files-found: error

--- a/.github/workflows/update-community-readme.yml
+++ b/.github/workflows/update-community-readme.yml
@@ -69,9 +69,13 @@ jobs:
             echo
             echo 'Download the community-readme artifact from this run, apply it on a branch, and open a normal pull request.'
             echo
-            echo '```diff'
+            # Four backticks, not three: every diff line carries a one-char
+            # prefix, so a README line of ``` renders as " ```" - which is a
+            # valid closing fence for a three-backtick block and would truncate
+            # the report without failing the run.
+            echo '````diff'
             git --no-pager diff -- README.md
-            echo '```'
+            echo '````'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload refreshed README


### PR DESCRIPTION
## What

`.github/workflows/update-community-readme.yml` becomes **dispatch-only and read-only**. It no longer runs on a schedule and no longer writes to the repository.

Closes #3173. Reported by @bdunncompany.

## Why

The daily scheduled run pushed the refreshed README straight to `main`. The main-branch ruleset rejects direct pushes, so **every run since at least 2026-07-28 failed** with `GH013: Changes must be made through a pull request` — and because a scheduled run attaches its check run to whatever commit is at the head of `main`, `main` intermittently read red for a reason unrelated to the commit. A standing red trains everyone to stop reading checks, which is the part worth fixing even though the job's output is cosmetic.

Per the [maintainer decision on the issue](https://github.com/LanternOps/breeze/issues/3173#issuecomment-5220945106), neither obvious repair works on this repo:

- **A bot-opened PR could never merge.** `ci.yml` sets `paths-ignore` including `'**/*.md'` on both the `push` and `pull_request` triggers, and the main ruleset's only required status check is `CI Success`. A README-only PR therefore never triggers CI, `CI Success` never reports, and the check sits `expected` forever. That would trade a daily failed run for a daily unmergeable PR plus a human merge every morning.
- **A ruleset bypass is the wrong shape.** Adding the `github-actions` Integration to `bypass_actors` would grant main-branch push bypass to *any* workflow holding `contents: write`, against the least-privilege default `ci.yml:29` deliberately sets.

The daily cadence was never load-bearing: sponsors and contributors change on a scale of weeks, and nothing downstream reads the README programmatically.

## How

The generator script and its `node --test` coverage are untouched — they were never the problem. Only the trigger and the write path change.

| Before | After |
|---|---|
| `on: schedule (17 5 * * *) + workflow_dispatch` | `on: workflow_dispatch` |
| `permissions: contents: write` | `permissions: contents: read` |
| `checkout` pinned `ref: main` | honours the dispatched ref |
| `git commit` + `git push origin HEAD:main` via an ephemeral credential helper | uploads the refreshed `README.md` as a `community-readme` artifact + writes the diff to `$GITHUB_STEP_SUMMARY` |

So the run now only *reports*. When the sponsor list has visibly drifted (before a release, say), you dispatch it, download the artifact or copy the summary diff, and land the change on a normal branch alongside other work — no exception to "everything reaches `main` through a PR", and no hole in branch protection.

The `ref: main` pin existed so the scheduled run always operated on `main` before pushing to `main`. With both the schedule and the push gone, honouring the dispatched ref is the more useful behaviour (you can now sanity-check the generator from a branch), and with no write path it carries no risk.

## Tests

Two existing suites asserted the old shape and are updated to lock in the new contract as a regression guard for #3173:

- `update-community-readme.test.mjs` — swaps the `schedule`/`cron`/`contents: write` assertions for `doesNotMatch` on `schedule:`, `- cron:`, `git commit`, `git push`/`push origin`, and `git add`; adds positive assertions for `GITHUB_STEP_SUMMARY` and a SHA-pinned `upload-artifact`.
- `check-workflow-security.test.mjs` — `community README push uses an ephemeral credential helper` becomes `community README refresh never writes to the repository`, asserting the absence of any push, any `credential.helper`, and `contents: write`.

Both run in CI today (`pnpm test:community-readme`, `pnpm test:workflow-security`), so the new contract is enforced, not just documented.

## Verification

Workflow YAML can't be fully exercised locally, so:

```
actionlint .github/workflows/update-community-readme.yml   # 0 issues
node --test .github/scripts/update-community-readme.test.mjs      # 23 pass, 0 fail
node --test .github/scripts/check-workflow-security.test.mjs \
            scripts/security/pin-github-actions.test.mjs          # 57 pass, 0 fail
node .github/scripts/check-workflow-security.mjs                  # exit 0
node --test .github/scripts/docs-automation-retirement.test.mjs   # 5 pass, 0 fail
```

`actionlint` over the whole `.github/workflows` tree reports zero findings for this file (the remaining hits are pre-existing shellcheck info/warnings in `ci.yml` and `release.yml`).

**Manual verification after merge** — the trigger change can only be confirmed on `main`:

1. `gh workflow run "Update community README" --repo LanternOps/breeze` and confirm the run succeeds.
2. If the README is current, the summary should read `README.md is already current` and no artifact is produced. If it has drifted, the summary carries the diff and a `community-readme` artifact is attached.
3. Confirm no further scheduled runs appear: `gh run list --workflow update-community-readme.yml --repo LanternOps/breeze` should show no new `schedule` events after the merge.

No application code, migrations, or tenant tables are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)