### PR TITLE
fix(web): use shared TimezoneSelect in config-policy Automation/Maintenance tabs (#3361)

### DIFF
--- a/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
@@ -151,6 +151,20 @@ describe('AutomationTab — schedule timezone picker', () => {
     expect(payload.inlineSettings.items[0].timezone).toBe('America/Sao_Paulo');
   });
 
+  // The picker is scoped to the schedule trigger. Pinned because it is now a
+  // mounted combobox rather than an inert <select>: leaking it into the event /
+  // manual branches would put a focusable popup in a form where the timezone is
+  // meaningless.
+  it('renders no timezone picker for non-schedule triggers', () => {
+    addAutomation();
+    expect(screen.getByTestId('automation-timezone-0-trigger')).toBeTruthy();
+
+    for (const trigger of ['event', 'manual']) {
+      fireEvent.click(screen.getByRole('button', { name: new RegExp(`^${trigger}$`, 'i') }));
+      expect(screen.queryByTestId('automation-timezone-0-trigger')).toBeNull();
+    }
+  });
+
   it('defaults to UTC and leaves it intact when untouched', async () => {
     addAutomation();
     expect(screen.getByTestId('automation-timezone-0-trigger').textContent).toContain('UTC');

--- a/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.test.tsx
@@ -109,3 +109,55 @@ describe('AutomationTab — deploy_software action', () => {
     expect(action).toEqual({ type: 'deploy_software', catalogId: 'cat-1' });
   });
 });
+
+// Issue #3361: the schedule trigger shipped its own 9-entry hardcoded timezone
+// list (the same defect #2856 fixed for sites/orgs/partners), so an automation
+// could not be scheduled in e.g. Asia/Dubai. Asserted on the OUTCOME — the
+// chosen zone reaching the save payload — not on TimezoneSelect's internals.
+describe('AutomationTab — schedule timezone picker', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue(makeJsonResponse({ data: CATALOG }));
+  });
+
+  // The timezone control only exists under the (default) "schedule" trigger,
+  // and the empty-state button both creates and expands the automation.
+  const addAutomation = () => {
+    renderTab();
+    fireEvent.click(screen.getAllByRole('button', { name: /Add Automation/i })[0]);
+  };
+
+  it('offers zones that were absent from the old hardcoded list', () => {
+    addAutomation();
+    fireEvent.click(screen.getByTestId('automation-timezone-0-trigger'));
+    fireEvent.change(screen.getByTestId('automation-timezone-0-search'), {
+      target: { value: 'dubai' },
+    });
+    expect(screen.getByTestId('automation-timezone-0-option-Asia/Dubai')).toBeTruthy();
+  });
+
+  it('saves a zone picked from the full IANA list', async () => {
+    addAutomation();
+    fireEvent.click(screen.getByTestId('automation-timezone-0-trigger'));
+    fireEvent.change(screen.getByTestId('automation-timezone-0-search'), {
+      target: { value: 'sao paulo' },
+    });
+    fireEvent.click(screen.getByTestId('automation-timezone-0-option-America/Sao_Paulo'));
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const payload = saveMock.mock.calls[0][1];
+    expect(payload.inlineSettings.items[0].timezone).toBe('America/Sao_Paulo');
+  });
+
+  it('defaults to UTC and leaves it intact when untouched', async () => {
+    addAutomation();
+    expect(screen.getByTestId('automation-timezone-0-trigger').textContent).toContain('UTC');
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const payload = saveMock.mock.calls[0][1];
+    expect(payload.inlineSettings.items[0].timezone).toBe('UTC');
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/AutomationTab.tsx
@@ -14,6 +14,7 @@ import { FEATURE_META } from "./types";
 import { useFeatureLink } from "./useFeatureLink";
 import FeatureTabShell from "./FeatureTabShell";
 import InlineEntityPicker from "./InlineEntityPicker";
+import TimezoneSelect from "@/components/shared/TimezoneSelect";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
 type TriggerType = "schedule" | "event" | "manual";
@@ -53,17 +54,6 @@ const defaultItem: AutomationItem = {
   actions: [{ type: "run_script" }],
   onFailure: "stop",
 };
-const timezoneOptions = [
-  { value: "UTC", labelKey: "configurationPolicies.featureTabs.automationTab.uTC" },
-  { value: "America/New_York", labelKey: "configurationPolicies.featureTabs.automationTab.easternAmericaNewYork" },
-  { value: "America/Chicago", labelKey: "configurationPolicies.featureTabs.automationTab.centralAmericaChicago" },
-  { value: "America/Denver", labelKey: "configurationPolicies.featureTabs.automationTab.mountainAmericaDenver" },
-  { value: "America/Los_Angeles", labelKey: "configurationPolicies.featureTabs.automationTab.pacificAmericaLosAngeles" },
-  { value: "Europe/London", labelKey: "configurationPolicies.featureTabs.automationTab.europeLondon" },
-  { value: "Europe/Paris", labelKey: "configurationPolicies.featureTabs.automationTab.europeParis" },
-  { value: "Asia/Tokyo", labelKey: "configurationPolicies.featureTabs.automationTab.asiaTokyo" },
-  { value: "Australia/Sydney", labelKey: "configurationPolicies.featureTabs.automationTab.australiaSydney" },
-];
 const triggerOptions: {
   value: TriggerType;
   labelKey: string;
@@ -570,24 +560,27 @@ export default function AutomationTab({
                         </div>
                       </div>
                       <div>
-                        <label className="text-xs font-medium text-muted-foreground">
+                        <label
+                          htmlFor={`automation-timezone-${index}`}
+                          className="text-xs font-medium text-muted-foreground"
+                        >
                           {i18n.t(
                             "policies:configurationPolicies.featureTabs.automationTab.timezone",
                           )}
                         </label>
-                        <select
-                          value={item.timezone || "UTC"}
-                          onChange={(e) =>
-                            updateItem(index, { timezone: e.target.value })
-                          }
-                          className="mt-1 h-9 w-full rounded-md border bg-background px-3 text-sm"
-                        >
-                          {timezoneOptions.map((tz) => (
-                            <option key={tz.value} value={tz.value}>
-                              {t(/* i18n-dynamic */ tz.labelKey)}
-                            </option>
-                          ))}
-                        </select>
+                        <div className="mt-1">
+                          <TimezoneSelect
+                            id={`automation-timezone-${index}`}
+                            label={i18n.t(
+                              "policies:configurationPolicies.featureTabs.automationTab.timezone",
+                            )}
+                            value={item.timezone || "UTC"}
+                            onChange={(timezone) =>
+                              updateItem(index, { timezone })
+                            }
+                            testId={`automation-timezone-${index}`}
+                          />
+                        </div>
                       </div>
                     </div>
                   )}

--- a/apps/web/src/components/configurationPolicies/featureTabs/MaintenanceTab.test.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/MaintenanceTab.test.tsx
@@ -71,3 +71,61 @@ describe('MaintenanceTab — rebootIfPending', () => {
     expect(payload.inlineSettings.rebootIfPending).toBe(true);
   });
 });
+
+// Issue #3361: this tab shipped its own 16-entry hardcoded timezone list, the
+// same defect #2856 fixed for sites/orgs/partners. Asia/Dubai was not in it, so
+// a maintenance window could not be scheduled in that zone at all. These tests
+// pin the fix to the OUTCOME (an out-of-old-list zone reaches the save payload)
+// rather than to TimezoneSelect's internals, so they keep their meaning if the
+// picker is restyled.
+describe('MaintenanceTab — timezone picker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMock.mockResolvedValue({
+      id: 'link-1',
+      featureType: 'maintenance',
+      featurePolicyId: null,
+      inlineSettings: {},
+    });
+  });
+
+  const renderTab = () =>
+    render(
+      <MaintenanceTab policyId="policy-1" existingLink={undefined} linkedPolicyId={null} onLinkChanged={vi.fn()} />,
+    );
+
+  it('offers zones that were absent from the old hardcoded list', () => {
+    renderTab();
+    fireEvent.click(screen.getByTestId('maintenance-timezone-trigger'));
+    fireEvent.change(screen.getByTestId('maintenance-timezone-search'), {
+      target: { value: 'dubai' },
+    });
+    expect(screen.getByTestId('maintenance-timezone-option-Asia/Dubai')).toBeTruthy();
+  });
+
+  it('saves a zone picked from the full IANA list', async () => {
+    renderTab();
+    fireEvent.click(screen.getByTestId('maintenance-timezone-trigger'));
+    fireEvent.change(screen.getByTestId('maintenance-timezone-search'), {
+      target: { value: 'sao paulo' },
+    });
+    fireEvent.click(screen.getByTestId('maintenance-timezone-option-America/Sao_Paulo'));
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const [, payload] = saveMock.mock.calls[0] as [string | null, { inlineSettings: Record<string, unknown> }];
+    expect(payload.inlineSettings.timezone).toBe('America/Sao_Paulo');
+  });
+
+  it('preserves a stored zone the old list did not contain', () => {
+    render(
+      <MaintenanceTab
+        policyId="policy-1"
+        existingLink={{ id: 'link-1', featureType: 'maintenance', featurePolicyId: null, inlineSettings: { timezone: 'Africa/Nairobi' } } as never}
+        linkedPolicyId={null}
+        onLinkChanged={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('maintenance-timezone-trigger').textContent).toContain('Africa/Nairobi');
+  });
+});

--- a/apps/web/src/components/configurationPolicies/featureTabs/MaintenanceTab.tsx
+++ b/apps/web/src/components/configurationPolicies/featureTabs/MaintenanceTab.tsx
@@ -4,6 +4,7 @@ import type { FeatureTabProps } from "./types";
 import { FEATURE_META } from "./types";
 import { useFeatureLink } from "./useFeatureLink";
 import FeatureTabShell from "./FeatureTabShell";
+import TimezoneSelect from "@/components/shared/TimezoneSelect";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
 type MaintenanceSettings = {
@@ -61,23 +62,6 @@ const createRecurrenceOptions = () => [
     ),
   },
 ];
-const createTimezoneOptions = () => [
-  "America/New_York",
-  "America/Chicago",
-  "America/Denver",
-  "America/Los_Angeles",
-  "America/Phoenix",
-  "America/Anchorage",
-  "Pacific/Honolulu",
-  "Europe/London",
-  "Europe/Berlin",
-  "Europe/Paris",
-  "Asia/Tokyo",
-  "Asia/Shanghai",
-  "Asia/Kolkata",
-  "Australia/Sydney",
-  "UTC",
-];
 function ToggleRow({
   label,
   description,
@@ -119,7 +103,6 @@ export default function MaintenanceTab({
 }: FeatureTabProps) {
   useTranslation("policies");
   const recurrenceOptions = createRecurrenceOptions();
-  const timezoneOptions = createTimezoneOptions();
   const { save, remove, saving, error, clearError } = useFeatureLink(policyId);
   const isInherited = !!parentLink && !existingLink;
   const effectiveLink = existingLink ?? parentLink;
@@ -258,22 +241,22 @@ export default function MaintenanceTab({
 
         {/* Timezone */}
         <div>
-          <label className="text-sm font-medium">
+          <label htmlFor="maintenance-timezone" className="text-sm font-medium">
             {i18n.t(
               "policies:configurationPolicies.featureTabs.maintenanceTab.timezone",
             )}
           </label>
-          <select
-            value={settings.timezone}
-            onChange={(e) => update("timezone", e.target.value)}
-            className="mt-2 h-10 w-full rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring"
-          >
-            {timezoneOptions.map((tz) => (
-              <option key={tz} value={tz}>
-                {tz}
-              </option>
-            ))}
-          </select>
+          <div className="mt-2">
+            <TimezoneSelect
+              id="maintenance-timezone"
+              label={i18n.t(
+                "policies:configurationPolicies.featureTabs.maintenanceTab.timezone",
+              )}
+              value={settings.timezone}
+              onChange={(timezone) => update("timezone", timezone)}
+              testId="maintenance-timezone"
+            />
+          </div>
         </div>
 
         {/* Notify before */}

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -255,15 +255,6 @@
         "metricNotSet": "nicht festgelegt"
       },
       "automationTab": {
-        "uTC": "UTC",
-        "easternAmericaNewYork": "Osten (Amerika/New_York)",
-        "centralAmericaChicago": "Zentral (Amerika/Chicago)",
-        "mountainAmericaDenver": "Berg (Amerika/Denver)",
-        "pacificAmericaLosAngeles": "Pazifik (Amerika/Los_Angeles)",
-        "europeLondon": "Europa/London",
-        "europeParis": "Europe/Paris",
-        "asiaTokyo": "Asien/Tokio",
-        "australiaSydney": "Australien/Sydney",
         "schedule": "Zeitplan",
         "event": "Ereignis",
         "manual": "Manuell",

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -255,15 +255,6 @@
         "metricNotSet": "not set"
       },
       "automationTab": {
-        "uTC": "UTC",
-        "easternAmericaNewYork": "Eastern (America/New_York)",
-        "centralAmericaChicago": "Central (America/Chicago)",
-        "mountainAmericaDenver": "Mountain (America/Denver)",
-        "pacificAmericaLosAngeles": "Pacific (America/Los_Angeles)",
-        "europeLondon": "Europe/London",
-        "europeParis": "Europe/Paris",
-        "asiaTokyo": "Asia/Tokyo",
-        "australiaSydney": "Australia/Sydney",
         "schedule": "Schedule",
         "event": "Event",
         "manual": "Manual",

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -255,15 +255,6 @@
         "metricNotSet": "sin definir"
       },
       "automationTab": {
-        "uTC": "UTC",
-        "easternAmericaNewYork": "Este (America/New_York)",
-        "centralAmericaChicago": "Centro (America/Chicago)",
-        "mountainAmericaDenver": "Montaña (America/Denver)",
-        "pacificAmericaLosAngeles": "Pacífico (America/Los_Angeles)",
-        "europeLondon": "Europe/London",
-        "europeParis": "Europe/Paris",
-        "asiaTokyo": "Asia/Tokyo",
-        "australiaSydney": "Australia/Sydney",
         "schedule": "Cronograma",
         "event": "Evento",
         "manual": "Manual",

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -255,15 +255,6 @@
         "metricNotSet": "non défini"
       },
       "automationTab": {
-        "uTC": "UTC",
-        "easternAmericaNewYork": "Est (Amérique/New_York)",
-        "centralAmericaChicago": "Centre (Amérique / Chicago)",
-        "mountainAmericaDenver": "Mountain (Amérique/Denver)",
-        "pacificAmericaLosAngeles": "Pacifique (Amérique/Los_Angeles)",
-        "europeLondon": "Europe/Londres",
-        "europeParis": "Europe/Paris",
-        "asiaTokyo": "Asie/Tokyo",
-        "australiaSydney": "Australie/Sydney",
         "schedule": "Calendrier",
         "event": "Événement",
         "manual": "Manuel",

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -255,15 +255,6 @@
         "metricNotSet": "non défini"
       },
       "automationTab": {
-        "uTC": "UTC",
-        "easternAmericaNewYork": "Est (Amérique/New_York)",
-        "centralAmericaChicago": "Centre (Amérique / Chicago)",
-        "mountainAmericaDenver": "Mountain (Amérique/Denver)",
-        "pacificAmericaLosAngeles": "Pacifique (Amérique/Los_Angeles)",
-        "europeLondon": "Europe/Londres",
-        "europeParis": "Europe/Paris",
-        "asiaTokyo": "Asie/Tokyo",
-        "australiaSydney": "Australie/Sydney",
         "schedule": "Calendrier",
         "event": "Événement",
         "manual": "Manuel",

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -255,15 +255,6 @@
         "metricNotSet": "non impostata"
       },
       "automationTab": {
-        "uTC": "UTC",
-        "easternAmericaNewYork": "Orientale (America/New_York)",
-        "centralAmericaChicago": "Centrale (America/Chicago)",
-        "mountainAmericaDenver": "Montagna (America/Denver)",
-        "pacificAmericaLosAngeles": "Pacifico (America/Los_Angeles)",
-        "europeLondon": "Europe/London",
-        "europeParis": "Europe/Paris",
-        "asiaTokyo": "Asia/Tokyo",
-        "australiaSydney": "Australia/Sydney",
         "schedule": "Pianificazione",
         "event": "Evento",
         "manual": "Manuale",

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -255,15 +255,6 @@
         "metricNotSet": "não definida"
       },
       "automationTab": {
-        "uTC": "UTC",
-        "easternAmericaNewYork": "Leste (America/New_York)",
-        "centralAmericaChicago": "Central (America/Chicago)",
-        "mountainAmericaDenver": "Montanhas (America/Denver)",
-        "pacificAmericaLosAngeles": "Pacífico (America/Los_Angeles)",
-        "europeLondon": "Europe/London",
-        "europeParis": "Europe/Paris",
-        "asiaTokyo": "Asia/Tokyo",
-        "australiaSydney": "Australia/Sydney",
         "schedule": "Agendamento",
         "event": "Evento",
         "manual": "Manual",


### PR DESCRIPTION
## Problem

PR #2977 replaced the hardcoded site/org/partner timezone dropdowns with the shared searchable `TimezoneSelect` (issue #2856). A verification sweep found two survivors of the same defect class in the configuration-policy feature tabs:

| File | Old list |
|---|---|
| `AutomationTab.tsx:56` | 9-entry `timezoneOptions` (i18n-keyed labels), gating the **schedule trigger** timezone |
| `MaintenanceTab.tsx:64` | 16-entry `createTimezoneOptions()` (raw IANA strings), gating the **maintenance window** timezone |

Both omitted most of the world, so a config-policy author in `Asia/Dubai` or `America/Sao_Paulo` simply could not pick their own zone. Lower severity than the original report only because both lists happened to include `Europe/Paris`.

## Fix

Both tabs now render `TimezoneSelect` (`apps/web/src/components/shared/TimezoneSelect.tsx`), backed by `listIanaTimezones()` in `packages/shared/src/utils/timezone.ts` — `Intl.supportedValuesOf('timeZone')` with a fallback, ~418 zones, searchable. As a bonus the shared component **preserves a stored zone that is not in the Intl list** instead of silently rewriting it to the first option.

Follows the `SiteForm` / `PartnerRegionalTab` integration pattern:

- the existing `<label>` gains an `htmlFor` pointing at `TimezoneSelect`'s `id`;
- the same translated string is passed as `label`, so the trigger's accessible name carries both the field name and the committed zone (`aria-label` overrides name-from-content, so the value has to be in there);
- AutomationTab's control lives inside a per-item map, so its `id`/`testId` are suffixed with the item index (`automation-timezone-0`).

## i18n

The 9 `configurationPolicies.featureTabs.automationTab.*` per-zone label keys are now unreferenced and are **deleted from all 7 locale files**. Reasoning, since this was the risky part:

- There is **no unused-key gate** — `keyUsage.test.ts` only checks source → catalog, so leaving them would also have been green. Deleted anyway rather than leaving dead keys for translators to maintain.
- `localeParity.test.ts` requires **identical key sets across locales**, so this is all-or-nothing: 9 keys x 7 locales, no partial deletion.
- `translationCoverage.test.ts` namespace baselines are **upper bounds** (`namespaceDuplicateRegressions` flags only *exceeding* the baseline), so removing keys cannot regress them.
- Locale JSON edits were done via a script that **round-trip-verifies formatting before mutating**, so the diff is exactly 9 deleted lines per file and nothing else.

MaintenanceTab had no per-zone keys to orphan — its `maintenanceTab.timezone` field label is retained and now also feeds the picker's accessible name.

## Tests

6 new cases across the two tab suites, asserting the **outcome** rather than `TimezoneSelect`'s internals (so they keep their meaning if the picker is restyled):

- a zone absent from the old hardcoded list (`Asia/Dubai`) is offered by search;
- a zone picked from the full list (`America/Sao_Paulo`) reaches the **save payload**;
- MaintenanceTab preserves a stored out-of-list zone (`Africa/Nairobi`) on render;
- AutomationTab still defaults to `UTC` and leaves it intact when untouched.

**Verification**
- `vitest run AutomationTab.test.tsx MaintenanceTab.test.tsx` — 12 passed (2 files)
- i18n gates + `TimezoneSelect.test.tsx` + `structuralValues.test.ts` — 129 passed. `no-translated-comparisons.test.ts` tripped its 5s timeout on the first pass purely from host contention (repo-wide AST walk running alongside 8 other suites); re-run in isolation it passes in 3.4s.
- `tsc --noEmit -p apps/web/tsconfig.json` — exit 0, zero errors. No `.astro` files touched.
- `eslint` on all four touched source/test files — clean.

Closes #3361

🤖 Generated with [Claude Code](https://claude.com/claude-code)