### PR TITLE
fix(desktop): stop viewer answer-poll from exhausting the global IP rate limit (#3041)

### DIFF
--- a/apps/api/src/middleware/globalRateLimit.test.ts
+++ b/apps/api/src/middleware/globalRateLimit.test.ts
@@ -1,13 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
+// Hoisted so individual tests can flip between the in-memory fallback
+// (getRedis -> null) and the Redis-backed path that production actually runs.
+const mocks = vi.hoisted(() => ({
+  getRedis: vi.fn<() => unknown>(() => null),
+  rateLimiter: vi.fn(),
+}));
+
 vi.mock('../services/redis', () => ({
-  getRedis: () => null,
+  getRedis: mocks.getRedis,
+}));
+
+vi.mock('../services/rate-limit', () => ({
+  rateLimiter: mocks.rateLimiter,
 }));
 
 vi.mock('../services/clientIp', () => ({
   getTrustedClientIp: vi.fn(() => 'global-rate-limit-test'),
 }));
+
+const TEST_IP = 'global-rate-limit-test';
 
 import {
   __resetInMemoryCountersForTests,
@@ -20,6 +33,9 @@ import {
 beforeEach(() => {
   __resetSkipPrefixesForTests();
   __resetInMemoryCountersForTests();
+  // Default to the in-memory fallback; the Redis-path tests opt in.
+  mocks.getRedis.mockReturnValue(null);
+  mocks.rateLimiter.mockReset();
 });
 
 describe('globalRateLimit', () => {
@@ -102,6 +118,37 @@ describe('globalRateLimit — isolated desktop-ws bucket', () => {
     expect(throttled.status).toBe(429);
     expect(throttled.headers.get('Retry-After')).toBe('60');
     expect(throttled.headers.get('X-RateLimit-Limit')).toBe('2');
+  });
+
+  // Production always has Redis, so the in-memory assertions above exercise the
+  // fallback rather than the real path. Pin the key/limit actually handed to the
+  // Redis limiter too.
+  it('hands the isolated key and limit to the Redis limiter', async () => {
+    const fakeRedis = { marker: 'redis' };
+    mocks.getRedis.mockReturnValue(fakeRedis);
+    mocks.rateLimiter.mockResolvedValue({
+      allowed: true,
+      remaining: 599,
+      resetAt: new Date(Date.now() + 60_000),
+    });
+    const app = buildApp({ limit: 300, windowSeconds: 60 });
+
+    await app.request(VIEWER_PATH);
+    expect(mocks.rateLimiter).toHaveBeenCalledWith(
+      fakeRedis,
+      `global:desktopws:${TEST_IP}`,
+      600,
+      60,
+    );
+
+    mocks.rateLimiter.mockClear();
+    await app.request('/api/v1/devices');
+    expect(mocks.rateLimiter).toHaveBeenCalledWith(
+      fakeRedis,
+      `global:${TEST_IP}`,
+      300,
+      60,
+    );
   });
 
   it('exhausting the shared bucket does not throttle viewer traffic', async () => {

--- a/apps/api/src/middleware/globalRateLimit.test.ts
+++ b/apps/api/src/middleware/globalRateLimit.test.ts
@@ -10,13 +10,16 @@ vi.mock('../services/clientIp', () => ({
 }));
 
 import {
+  __resetInMemoryCountersForTests,
   __resetSkipPrefixesForTests,
   globalRateLimit,
+  ISOLATED_BUCKETS,
   registerGlobalRateLimitSkipPrefix,
 } from './globalRateLimit';
 
 beforeEach(() => {
   __resetSkipPrefixesForTests();
+  __resetInMemoryCountersForTests();
 });
 
 describe('globalRateLimit', () => {
@@ -47,5 +50,67 @@ describe('globalRateLimit', () => {
 
     expect(limited.status).toBe(429);
     expect(builtIn.status).toBe(200);
+  });
+});
+
+// Issue #3041: the remote-desktop viewer polls /viewer/session while waiting
+// for the agent's WebRTC answer. Those polls used to share the per-IP bucket
+// with everything else, so a session that died mid-poll could 429 the
+// operator's own dashboard and auth calls and bounce them to the login screen.
+describe('globalRateLimit — isolated desktop-ws bucket', () => {
+  const VIEWER_PATH = '/api/v1/desktop-ws/00000000-0000-0000-0000-000000000000/viewer/session';
+
+  function buildApp(options?: Parameters<typeof globalRateLimit>[0]) {
+    const app = new Hono();
+    app.use('*', globalRateLimit(options));
+    app.get(VIEWER_PATH, (c) => c.json({ ok: true }));
+    app.get('/api/v1/devices', (c) => c.json({ ok: true }));
+    app.post('/api/v1/auth/refresh', (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  it('ships with /api/v1/desktop-ws/ isolated by default', () => {
+    expect(ISOLATED_BUCKETS.some((b) => b.prefix === '/api/v1/desktop-ws/')).toBe(true);
+  });
+
+  it('does not let viewer polls drain the shared bucket', async () => {
+    // Shared budget of 2, but 20 viewer polls — far past what the shared
+    // bucket would tolerate if they were metered together.
+    const app = buildApp({ limit: 2, windowSeconds: 60 });
+
+    for (let i = 0; i < 20; i++) {
+      const poll = await app.request(VIEWER_PATH);
+      expect(poll.status).toBe(200);
+    }
+
+    // The dashboard and the token refresh must still have their full budget.
+    expect((await app.request('/api/v1/devices')).status).toBe(200);
+    expect((await app.request('/api/v1/auth/refresh', { method: 'POST' })).status).toBe(200);
+  });
+
+  it('still caps viewer traffic — isolation is not exemption', async () => {
+    const app = buildApp({
+      limit: 100,
+      windowSeconds: 60,
+      isolatedBuckets: [{ prefix: '/api/v1/desktop-ws/', name: 'desktopws-test', limit: 2 }],
+    });
+
+    expect((await app.request(VIEWER_PATH)).status).toBe(200);
+    expect((await app.request(VIEWER_PATH)).status).toBe(200);
+
+    const throttled = await app.request(VIEWER_PATH);
+    expect(throttled.status).toBe(429);
+    expect(throttled.headers.get('Retry-After')).toBe('60');
+    expect(throttled.headers.get('X-RateLimit-Limit')).toBe('2');
+  });
+
+  it('exhausting the shared bucket does not throttle viewer traffic', async () => {
+    const app = buildApp({ limit: 1, windowSeconds: 60 });
+
+    expect((await app.request('/api/v1/devices')).status).toBe(200);
+    expect((await app.request('/api/v1/devices')).status).toBe(429);
+
+    // An in-flight remote session must survive an unrelated dashboard burst.
+    expect((await app.request(VIEWER_PATH)).status).toBe(200);
   });
 });

--- a/apps/api/src/middleware/globalRateLimit.ts
+++ b/apps/api/src/middleware/globalRateLimit.ts
@@ -25,6 +25,45 @@ const BUILT_IN_SKIP_PREFIXES = ['/api/v1/agents/', '/api/v1/helper/'];
 const skipPrefixes: string[] = [...BUILT_IN_SKIP_PREFIXES];
 const MAX_IN_MEMORY_ENTRIES = 100_000;
 
+/**
+ * A path prefix metered in its own per-IP bucket rather than the shared one.
+ *
+ * Isolation — not exemption. Traffic matching the prefix is still capped, so a
+ * runaway or hostile client can't hammer the endpoint unbounded; it simply
+ * spends a budget nothing else draws on.
+ */
+export interface IsolatedBucket {
+  /** Path prefix routed into this bucket. */
+  prefix: string;
+  /** Key namespace. Must be unique across buckets. */
+  name: string;
+  /** Max requests per window for this bucket (independent of the global cap). */
+  limit: number;
+}
+
+/**
+ * Remote-desktop viewer traffic gets its own bucket (issue #3041).
+ *
+ * While waiting for the agent's WebRTC answer the viewer polls
+ * `/api/v1/desktop-ws/:id/viewer/session` repeatedly, so one connection attempt
+ * is inherently dozens of requests — and when the session dies mid-poll every
+ * one of them 401s. Sharing the default bucket let that burst exhaust the
+ * per-IP budget and 429 the operator's *own* dashboard and auth calls, bouncing
+ * them to the login screen while their session was still valid. A dedicated
+ * bucket keeps the viewer path bounded without letting it starve the console.
+ *
+ * Sizing: with the viewer's backed-off poll a single connection attempt costs
+ * ~35 requests (ice-servers + offer + ~34 answer polls across the 15s window),
+ * so 600/min leaves room for roughly 16 attempts a minute from one IP — enough
+ * for several techs behind one office NAT reconnecting, while still capping a
+ * runaway client at ~10 req/s. Note the prefix covers ALL desktop-ws traffic,
+ * so one runaway viewer can still throttle other remote sessions from the same
+ * IP; it just can no longer touch the dashboard or auth budget.
+ */
+export const ISOLATED_BUCKETS: readonly IsolatedBucket[] = [
+  { prefix: '/api/v1/desktop-ws/', name: 'desktopws', limit: 600 },
+];
+
 export function registerGlobalRateLimitSkipPrefix(prefix: string): void {
   if (!skipPrefixes.includes(prefix)) {
     skipPrefixes.push(prefix);
@@ -33,6 +72,14 @@ export function registerGlobalRateLimitSkipPrefix(prefix: string): void {
 
 export function __resetSkipPrefixesForTests(): void {
   skipPrefixes.splice(0, skipPrefixes.length, ...BUILT_IN_SKIP_PREFIXES);
+}
+
+/**
+ * Clear the in-memory fallback counters so each test starts from a clean
+ * budget. Only meaningful when Redis is stubbed out.
+ */
+export function __resetInMemoryCountersForTests(): void {
+  inMemoryCounters.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -55,15 +102,22 @@ function cleanupExpiredEntries(): void {
 }
 
 interface GlobalRateLimitOptions {
-  /** Max requests per window. Default: 300 */
+  /** Max requests per window for the shared bucket. Default: 300 */
   limit?: number;
   /** Window size in seconds. Default: 60 */
   windowSeconds?: number;
+  /**
+   * Paths metered separately from the shared bucket.
+   * Defaults to {@link ISOLATED_BUCKETS}; overridable so tests can exercise the
+   * capping behaviour without issuing hundreds of requests.
+   */
+  isolatedBuckets?: readonly IsolatedBucket[];
 }
 
 export function globalRateLimit(options?: GlobalRateLimitOptions): MiddlewareHandler {
   const limit = options?.limit ?? 300;
   const windowSeconds = options?.windowSeconds ?? 60;
+  const isolatedBuckets = options?.isolatedBuckets ?? ISOLATED_BUCKETS;
   const windowMs = windowSeconds * 1000;
   const e2eMode = process.env.E2E_MODE === '1' || process.env.E2E_MODE === 'true';
 
@@ -86,6 +140,12 @@ export function globalRateLimit(options?: GlobalRateLimitOptions): MiddlewareHan
     const redis = getRedis();
     const clientIp = getTrustedClientIp(c, 'unknown');
 
+    // Route into a dedicated bucket when the path has one, so high-volume
+    // endpoints can't drain the budget shared by the dashboard and auth.
+    const bucket = isolatedBuckets.find(b => c.req.path.startsWith(b.prefix));
+    const bucketLimit = bucket?.limit ?? limit;
+    const bucketKey = bucket ? `global:${bucket.name}:${clientIp}` : `global:${clientIp}`;
+
     if (!redis) {
       // Redis unavailable — use in-memory fallback so requests are still metered.
       if (!inMemoryFallbackLogged) {
@@ -95,11 +155,11 @@ export function globalRateLimit(options?: GlobalRateLimitOptions): MiddlewareHan
       cleanupExpiredEntries();
 
       const now = Date.now();
-      const entry = inMemoryCounters.get(clientIp);
+      const entry = inMemoryCounters.get(bucketKey);
 
       if (entry && entry.resetAt > now) {
-        if (entry.count >= limit) {
-          c.header('X-RateLimit-Limit', String(limit));
+        if (entry.count >= bucketLimit) {
+          c.header('X-RateLimit-Limit', String(bucketLimit));
           c.header('X-RateLimit-Remaining', '0');
           c.header('X-RateLimit-Reset', String(Math.ceil(entry.resetAt / 1000)));
           c.header('Retry-After', String(windowSeconds));
@@ -108,21 +168,22 @@ export function globalRateLimit(options?: GlobalRateLimitOptions): MiddlewareHan
         entry.count++;
       } else {
         if (inMemoryCounters.size >= MAX_IN_MEMORY_ENTRIES) {
-          // Map full — reject to prevent OOM
+          // Map full — reject to prevent OOM. Still advertise Retry-After:
+          // clients that honour it (the remote-desktop viewer poll does) would
+          // otherwise have no signal and keep retrying at full rate.
+          c.header('Retry-After', String(windowSeconds));
           return c.json({ error: 'Too many requests' }, 429);
         }
-        inMemoryCounters.set(clientIp, { count: 1, resetAt: now + windowMs });
+        inMemoryCounters.set(bucketKey, { count: 1, resetAt: now + windowMs });
       }
 
       return next();
     }
 
-    const key = `global:${clientIp}`;
-
-    const result = await rateLimiter(redis, key, limit, windowSeconds);
+    const result = await rateLimiter(redis, bucketKey, bucketLimit, windowSeconds);
 
     // Always set rate limit headers so clients can self-throttle
-    c.header('X-RateLimit-Limit', String(limit));
+    c.header('X-RateLimit-Limit', String(bucketLimit));
     c.header('X-RateLimit-Remaining', String(result.remaining));
     c.header('X-RateLimit-Reset', String(Math.ceil(result.resetAt.getTime() / 1000)));
 

--- a/apps/viewer/src/lib/sessionEnded.test.ts
+++ b/apps/viewer/src/lib/sessionEnded.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  ANSWER_POLL_INITIAL_INTERVAL_MS,
+  ANSWER_POLL_MAX_INTERVAL_MS,
   createWebRTCSession,
   isSessionEndedResponse,
+  isUnretryableViewerStatus,
+  nextAnswerPollInterval,
+  parseRetryAfterMs,
   SessionEndedError,
   AgentSessionError,
   type AuthenticatedConnectionParams,
@@ -10,23 +15,87 @@ import {
 // ── isSessionEndedResponse ────────────────────────────────────────────────
 
 describe('isSessionEndedResponse', () => {
-  it('treats a bare 401 (no body) as session-ended', () => {
-    expect(isSessionEndedResponse(401, null)).toBe(true);
-    expect(isSessionEndedResponse(401, undefined)).toBe(true);
-    expect(isSessionEndedResponse(401, '')).toBe(true);
-  });
-
-  it('treats a 401 with a "Session ended" body as session-ended', () => {
-    expect(isSessionEndedResponse(401, 'Session ended')).toBe(true);
-    expect(isSessionEndedResponse(401, '{"error":"session ended"}')).toBe(true);
-    expect(isSessionEndedResponse(401, 'token revoked')).toBe(true);
-    expect(isSessionEndedResponse(401, 'session no longer active')).toBe(true);
+  it('treats every 401 as session-ended, whatever the body says', () => {
+    expect(isSessionEndedResponse(401)).toBe(true);
   });
 
   it('does not flag non-401 statuses', () => {
-    expect(isSessionEndedResponse(403, 'Session ended')).toBe(false);
-    expect(isSessionEndedResponse(500, null)).toBe(false);
-    expect(isSessionEndedResponse(200, '')).toBe(false);
+    expect(isSessionEndedResponse(403)).toBe(false);
+    expect(isSessionEndedResponse(500)).toBe(false);
+    expect(isSessionEndedResponse(200)).toBe(false);
+    expect(isSessionEndedResponse(429)).toBe(false);
+  });
+});
+
+// ── isUnretryableViewerStatus ─────────────────────────────────────────────
+
+describe('isUnretryableViewerStatus', () => {
+  it('flags the terminal 4xx the viewer endpoints actually return', () => {
+    // apps/api/src/routes/desktopWs.ts validateViewerSessionAccess
+    expect(isUnretryableViewerStatus(400)).toBe(true); // not a desktop session
+    expect(isUnretryableViewerStatus(403)).toBe(true); // policy / owner mismatch
+    expect(isUnretryableViewerStatus(404)).toBe(true); // session not found
+  });
+
+  it('does not flag the retry-inviting statuses', () => {
+    expect(isUnretryableViewerStatus(408)).toBe(false);
+    expect(isUnretryableViewerStatus(429)).toBe(false);
+    expect(isUnretryableViewerStatus(500)).toBe(false);
+    expect(isUnretryableViewerStatus(503)).toBe(false);
+    expect(isUnretryableViewerStatus(200)).toBe(false);
+  });
+});
+
+// ── parseRetryAfterMs ─────────────────────────────────────────────────────
+
+describe('parseRetryAfterMs', () => {
+  it('parses delta-seconds', () => {
+    expect(parseRetryAfterMs('60')).toBe(60_000);
+    expect(parseRetryAfterMs(' 5 ')).toBe(5_000);
+    expect(parseRetryAfterMs('0')).toBe(0);
+  });
+
+  it('returns null when absent or unparseable', () => {
+    expect(parseRetryAfterMs(null)).toBeNull();
+    expect(parseRetryAfterMs('')).toBeNull();
+    expect(parseRetryAfterMs('Wed, 21 Oct 2026 07:28:00 GMT')).toBeNull();
+    expect(parseRetryAfterMs('-1')).toBeNull();
+  });
+});
+
+// ── answer-poll pacing (issue #3041) ──────────────────────────────────────
+
+describe('answer poll backoff', () => {
+  it('backs off geometrically up to the cap', () => {
+    expect(nextAnswerPollInterval(ANSWER_POLL_INITIAL_INTERVAL_MS)).toBe(75);
+    expect(nextAnswerPollInterval(75)).toBe(113);
+    expect(nextAnswerPollInterval(ANSWER_POLL_MAX_INTERVAL_MS)).toBe(
+      ANSWER_POLL_MAX_INTERVAL_MS,
+    );
+  });
+
+  it('keeps a full 15s wait far below the 300-request per-IP budget', () => {
+    // The reported incident was 213 x 401 in ~26s from a flat 50ms poll, which
+    // alone exhausts the default 300/60s bucket. Walk the real schedule.
+    let elapsed = 0;
+    let interval = ANSWER_POLL_INITIAL_INTERVAL_MS;
+    let requests = 0;
+    while (elapsed < 15_000) {
+      requests += 1;
+      elapsed += interval;
+      interval = nextAnswerPollInterval(interval);
+    }
+
+    expect(requests).toBeLessThan(40);
+    // A flat 50ms poll would have issued 300 over the same window.
+    expect(requests).toBeLessThan(15_000 / ANSWER_POLL_INITIAL_INTERVAL_MS / 5);
+  });
+
+  it('still polls quickly at the start so a healthy agent is picked up fast', () => {
+    // Time to the 3rd poll must stay well under half a second.
+    const first = ANSWER_POLL_INITIAL_INTERVAL_MS;
+    const second = nextAnswerPollInterval(first);
+    expect(first + second).toBeLessThan(200);
   });
 });
 
@@ -63,10 +132,11 @@ const baseParams: AuthenticatedConnectionParams = {
   deviceId: 'dev-1',
 };
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(headers),
     json: async () => body,
     text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   } as unknown as Response;
@@ -119,6 +189,73 @@ describe('createWebRTCSession — session-ended (401) handling', () => {
     await expect(createWebRTCSession(baseParams, videoEl)).rejects.toBeInstanceOf(
       SessionEndedError,
     );
+  });
+
+  // Issue #3041: these are the 401 bodies the API actually returns from
+  // validateViewerSessionAccess. The old body-matching regex recognised none of
+  // them, so the poll kept firing every 50ms until the 15s timeout and burned
+  // the caller's per-IP rate-limit budget.
+  it.each([
+    'Session closed',
+    'Missing viewer token',
+    'Invalid or expired viewer token',
+    'Viewer token revoked',
+    '{"error":"Session closed"}',
+  ])('stops the answer poll on the first 401 (%s)', async (body) => {
+    let sessionPolls = 0;
+    stubFetch((url) => {
+      if (url.includes('/ice-servers')) return jsonResponse({ iceServers: [] });
+      if (url.includes('/viewer/offer')) return jsonResponse({ ok: true });
+      if (url.includes('/viewer/session')) {
+        sessionPolls += 1;
+        return jsonResponse(body, 401);
+      }
+      return jsonResponse({}, 404);
+    });
+
+    await expect(createWebRTCSession(baseParams, videoEl)).rejects.toBeInstanceOf(
+      SessionEndedError,
+    );
+    // The whole point: exactly one poll, not hundreds.
+    expect(sessionPolls).toBe(1);
+  });
+
+  it('stops the answer poll on a terminal 403 instead of polling to timeout', async () => {
+    let sessionPolls = 0;
+    stubFetch((url) => {
+      if (url.includes('/ice-servers')) return jsonResponse({ iceServers: [] });
+      if (url.includes('/viewer/offer')) return jsonResponse({ ok: true });
+      if (url.includes('/viewer/session')) {
+        sessionPolls += 1;
+        return jsonResponse('Remote desktop is disabled by policy', 403);
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const err = await createWebRTCSession(baseParams, videoEl).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    // A policy denial is not a dead session, so it must not masquerade as one.
+    expect(err).not.toBeInstanceOf(SessionEndedError);
+    expect((err as Error).message).toContain('403');
+    expect(sessionPolls).toBe(1);
+  });
+
+  it('gives up rather than polling through a 429 it has been told to wait out', async () => {
+    let sessionPolls = 0;
+    stubFetch((url) => {
+      if (url.includes('/ice-servers')) return jsonResponse({ iceServers: [] });
+      if (url.includes('/viewer/offer')) return jsonResponse({ ok: true });
+      if (url.includes('/viewer/session')) {
+        sessionPolls += 1;
+        // Retry-After (60s) outlasts the 15s answer window.
+        return jsonResponse({ error: 'Too many requests' }, 429, { 'Retry-After': '60' });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    const err = await createWebRTCSession(baseParams, videoEl).catch((e) => e);
+    expect((err as Error).message).toContain('rate limited');
+    expect(sessionPolls).toBe(1);
   });
 
   it('still throws a generic (retryable) error for non-401 offer failures', async () => {

--- a/apps/viewer/src/lib/sessionEnded.test.ts
+++ b/apps/viewer/src/lib/sessionEnded.test.ts
@@ -220,25 +220,30 @@ describe('createWebRTCSession — session-ended (401) handling', () => {
     expect(sessionPolls).toBe(1);
   });
 
-  it('stops the answer poll on a terminal 403 instead of polling to timeout', async () => {
-    let sessionPolls = 0;
-    stubFetch((url) => {
-      if (url.includes('/ice-servers')) return jsonResponse({ iceServers: [] });
-      if (url.includes('/viewer/offer')) return jsonResponse({ ok: true });
-      if (url.includes('/viewer/session')) {
-        sessionPolls += 1;
-        return jsonResponse('Remote desktop is disabled by policy', 403);
-      }
-      return jsonResponse({}, 404);
-    });
+  // 400 not-a-desktop-session, 403 policy-denied/owner-mismatch, 404
+  // session-not-found — all terminal, all previously polled to timeout.
+  it.each([400, 403, 404])(
+    'stops the answer poll on a terminal %i instead of polling to timeout',
+    async (status) => {
+      let sessionPolls = 0;
+      stubFetch((url) => {
+        if (url.includes('/ice-servers')) return jsonResponse({ iceServers: [] });
+        if (url.includes('/viewer/offer')) return jsonResponse({ ok: true });
+        if (url.includes('/viewer/session')) {
+          sessionPolls += 1;
+          return jsonResponse('Remote desktop is disabled by policy', status);
+        }
+        return jsonResponse({}, 404);
+      });
 
-    const err = await createWebRTCSession(baseParams, videoEl).catch((e) => e);
-    expect(err).toBeInstanceOf(Error);
-    // A policy denial is not a dead session, so it must not masquerade as one.
-    expect(err).not.toBeInstanceOf(SessionEndedError);
-    expect((err as Error).message).toContain('403');
-    expect(sessionPolls).toBe(1);
-  });
+      const err = await createWebRTCSession(baseParams, videoEl).catch((e) => e);
+      expect(err).toBeInstanceOf(Error);
+      // A policy denial is not a dead session, so it must not masquerade as one.
+      expect(err).not.toBeInstanceOf(SessionEndedError);
+      expect((err as Error).message).toContain(String(status));
+      expect(sessionPolls).toBe(1);
+    },
+  );
 
   it('gives up rather than polling through a 429 it has been told to wait out', async () => {
     let sessionPolls = 0;
@@ -269,5 +274,83 @@ describe('createWebRTCSession — session-ended (401) handling', () => {
     expect(err).toBeInstanceOf(Error);
     expect(err).not.toBeInstanceOf(SessionEndedError);
     expect(err).not.toBeInstanceOf(AgentSessionError);
+  });
+
+  // The tests above all settle on the first poll. These drive the real
+  // multi-iteration loop (fake timers) to prove that *recoverable* statuses
+  // still retry — the fix must not turn "stop hammering" into "give up".
+  describe('multi-iteration polling', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function stubSessionPolls(responses: (n: number) => Response) {
+      let sessionPolls = 0;
+      stubFetch((url) => {
+        if (url.includes('/ice-servers')) return jsonResponse({ iceServers: [] });
+        if (url.includes('/viewer/offer')) return jsonResponse({ ok: true });
+        if (url.includes('/viewer/session')) {
+          sessionPolls += 1;
+          return responses(sessionPolls);
+        }
+        return jsonResponse({}, 404);
+      });
+      return () => sessionPolls;
+    }
+
+    it('keeps polling through a transient 5xx and still succeeds', async () => {
+      const polls = stubSessionPolls((n) =>
+        n <= 2
+          ? jsonResponse({ error: 'bad gateway' }, 503)
+          : jsonResponse({ webrtcAnswer: 'v=0 answer-sdp' }),
+      );
+
+      const pending = createWebRTCSession(baseParams, videoEl);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(pending).resolves.toMatchObject({ pc: expect.anything() });
+      // Two 503s were ridden out, the third poll got the answer.
+      expect(polls()).toBe(3);
+    });
+
+    it('honours a short Retry-After and resumes polling', async () => {
+      const polls = stubSessionPolls((n) =>
+        n === 1
+          ? jsonResponse({ error: 'Too many requests' }, 429, { 'Retry-After': '1' })
+          : jsonResponse({ webrtcAnswer: 'v=0 answer-sdp' }),
+      );
+
+      const pending = createWebRTCSession(baseParams, videoEl);
+      // Nothing should happen before the server's 1s Retry-After elapses.
+      await vi.advanceTimersByTimeAsync(500);
+      expect(polls()).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(pending).resolves.toMatchObject({ pc: expect.anything() });
+      expect(polls()).toBe(2);
+    });
+
+    it('stays bounded on a 429 that carries no Retry-After', async () => {
+      // No header means no give-up signal, so the loop runs to the timeout —
+      // it must do so at the backed-off cadence, not the old 50ms hot spin.
+      const polls = stubSessionPolls(() => jsonResponse({ error: 'Too many requests' }, 429));
+
+      const pending = createWebRTCSession(baseParams, videoEl);
+      const settled = pending.catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(16_000);
+
+      const message = (await settled as Error).message;
+      expect(message).toContain('Timed out');
+      // The timeout must say what it last saw, or a throttled server looks
+      // identical to an agent that simply never answered.
+      expect(message).toContain('429');
+      expect(polls()).toBeGreaterThan(1);
+      // A flat 50ms poll would have issued ~300 here.
+      expect(polls()).toBeLessThan(40);
+    });
   });
 });

--- a/apps/viewer/src/lib/webrtc.ts
+++ b/apps/viewer/src/lib/webrtc.ts
@@ -269,6 +269,10 @@ function waitForIceGathering(pc: RTCPeerConnection, timeoutMs: number): Promise<
 async function pollForAnswer(params: AuthenticatedConnectionParams, timeoutMs: number): Promise<string> {
   const start = Date.now();
   let intervalMs = ANSWER_POLL_INITIAL_INTERVAL_MS;
+  // Remembered so a timeout can say WHY it timed out. Without this a server
+  // returning 503 for 15s is indistinguishable from an agent that never
+  // answered, and both produce the same misleading "agent didn't respond".
+  let lastErrorStatus: number | null = null;
 
   while (Date.now() - start < timeoutMs) {
     const resp = await apiFetch(
@@ -309,13 +313,26 @@ async function pollForAnswer(params: AuthenticatedConnectionParams, timeoutMs: n
         throw new Error('Remote session is rate limited — please retry in a moment.');
       }
       intervalMs = Math.max(retryAfterMs ?? 0, ANSWER_POLL_MAX_INTERVAL_MS);
+    } else {
+      // 5xx/408 — genuinely transient, so keep polling. Log the first of each
+      // kind so a real outage is visible rather than silently absorbed into a
+      // generic timeout 15s later.
+      if (resp.status !== lastErrorStatus) {
+        console.warn(`Answer poll got HTTP ${resp.status}; retrying until timeout`);
+      }
     }
+
+    if (!resp.ok) lastErrorStatus = resp.status;
 
     await new Promise((r) => setTimeout(r, intervalMs));
     intervalMs = nextAnswerPollInterval(intervalMs);
   }
 
-  throw new Error('Timed out waiting for WebRTC answer from agent');
+  throw new Error(
+    lastErrorStatus === null
+      ? 'Timed out waiting for WebRTC answer from agent'
+      : `Timed out waiting for WebRTC answer from agent (last response: HTTP ${lastErrorStatus})`,
+  );
 }
 
 /**

--- a/apps/viewer/src/lib/webrtc.ts
+++ b/apps/viewer/src/lib/webrtc.ts
@@ -33,16 +33,49 @@ export class SessionEndedError extends Error {
 }
 
 /**
- * Best-effort detection of the server's "session ended" rejection. The server
- * returns HTTP 401 with a body/error mentioning the session has ended; we also
- * treat a bare 401 on the viewer offer/poll path as terminal because a
- * single-session viewer token only ever authorizes one (still-live) session —
- * once it's 401ing there is nothing a retry can recover.
+ * Every 401 on the viewer offer/poll path is terminal.
+ *
+ * A viewer token authorizes exactly one still-live session, so once the server
+ * starts 401ing there is nothing a retry can recover — it has already decided
+ * the token, its JTI, or the session itself is no longer valid.
+ *
+ * This deliberately does NOT inspect the response body. It used to match on the
+ * text ("session ended"/"revoked"/"no longer active"), which silently missed
+ * most of the 401s the API actually returns — `Session closed`, `Missing viewer
+ * token`, `Invalid or expired viewer token` — so the answer poll kept hammering
+ * a dead session until it timed out, burning the caller's per-IP rate-limit
+ * budget and 429ing the operator's own dashboard (issue #3041). Status alone is
+ * the reliable signal; matching prose is not.
  */
-export function isSessionEndedResponse(status: number, body?: string | null): boolean {
-  if (status !== 401) return false;
-  if (!body) return true;
-  return /session\s*ended|ended|revoked|no longer active/i.test(body);
+export function isSessionEndedResponse(status: number): boolean {
+  return status === 401;
+}
+
+/**
+ * True when a response status means this connection attempt can never succeed,
+ * so repeating the identical request is pure wasted load.
+ *
+ * Any 4xx qualifies except the two that explicitly invite a retry — 408
+ * (request timeout) and 429 (rate limited). Everything else the viewer
+ * endpoints return (400 not-a-desktop-session, 403 policy-denied or
+ * owner-mismatch, 404 session-not-found) reflects session, token, or policy
+ * state that the next poll cannot change. 401 is terminal too, but callers
+ * check {@link isSessionEndedResponse} first so it surfaces as the dedicated
+ * SessionEndedError.
+ */
+export function isUnretryableViewerStatus(status: number): boolean {
+  return status >= 400 && status < 500 && status !== 408 && status !== 429;
+}
+
+/**
+ * Retry-After as milliseconds, or null when absent/unparseable. Only the
+ * delta-seconds form is honoured — that's what the API emits.
+ */
+export function parseRetryAfterMs(headerValue: string | null): number | null {
+  if (!headerValue) return null;
+  const seconds = Number(headerValue.trim());
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  return seconds * 1000;
 }
 
 export interface AuthenticatedConnectionParams {
@@ -61,7 +94,26 @@ export interface WebRTCSession {
 }
 
 const ICE_GATHER_TIMEOUT_MS = 3000;
-const ANSWER_POLL_INTERVAL_MS = 50;
+
+/**
+ * Answer-poll pacing. The poll starts tight so a healthy agent (which answers
+ * within a few hundred ms) is still picked up almost immediately, then backs
+ * off geometrically so a slow or dead session doesn't turn the 15s window into
+ * ~300 requests. With these values a full 15s wait costs ~35 requests instead,
+ * which matters because those requests are metered against the caller's IP
+ * (issue #3041).
+ */
+export const ANSWER_POLL_INITIAL_INTERVAL_MS = 50;
+export const ANSWER_POLL_MAX_INTERVAL_MS = 500;
+const ANSWER_POLL_BACKOFF_FACTOR = 1.5;
+
+/** Next answer-poll delay, geometric up to the cap. */
+export function nextAnswerPollInterval(currentMs: number): number {
+  return Math.min(
+    Math.round(currentMs * ANSWER_POLL_BACKOFF_FACTOR),
+    ANSWER_POLL_MAX_INTERVAL_MS,
+  );
+}
 
 /**
  * Create a WebRTC session with the remote agent.
@@ -157,12 +209,12 @@ export async function createWebRTCSession(
     );
 
     if (!offerResp.ok) {
-      const msg = await offerResp.text().catch(() => 'unknown error');
       // A 401 here means the session was ended/revoked server-side — retrying
       // the same sessionId is futile (Finding #5). Surface a terminal error.
-      if (isSessionEndedResponse(offerResp.status, msg)) {
+      if (isSessionEndedResponse(offerResp.status)) {
         throw new SessionEndedError();
       }
+      const msg = await offerResp.text().catch(() => 'unknown error');
       throw new Error(`Failed to submit WebRTC offer: ${msg}`);
     }
 
@@ -216,6 +268,7 @@ function waitForIceGathering(pc: RTCPeerConnection, timeoutMs: number): Promise<
  */
 async function pollForAnswer(params: AuthenticatedConnectionParams, timeoutMs: number): Promise<string> {
   const start = Date.now();
+  let intervalMs = ANSWER_POLL_INITIAL_INTERVAL_MS;
 
   while (Date.now() - start < timeoutMs) {
     const resp = await apiFetch(
@@ -233,17 +286,33 @@ async function pollForAnswer(params: AuthenticatedConnectionParams, timeoutMs: n
       if (data.status === 'failed') {
         throw new AgentSessionError(data.errorMessage || 'Remote desktop failed to start on agent');
       }
-    } else if (resp.status === 401) {
+    } else if (isSessionEndedResponse(resp.status)) {
       // Session ended/revoked server-side mid-poll — stop immediately so the
       // caller can surface a terminal state instead of polling to timeout
       // and then retrying the same dead session (Finding #5).
-      const body = await resp.text().catch(() => null);
-      if (isSessionEndedResponse(resp.status, body)) {
-        throw new SessionEndedError();
+      throw new SessionEndedError();
+    } else if (isUnretryableViewerStatus(resp.status)) {
+      // 400/403/404: the session, token, or policy state rules this attempt
+      // out. Fail now rather than spending the rest of the window re-asking a
+      // question the server has already answered.
+      const detail = (await resp.text().catch(() => ''))?.trim();
+      throw new Error(
+        `Remote session rejected (${resp.status})${detail ? `: ${detail}` : ''}`,
+      );
+    } else if (resp.status === 429) {
+      // The server has explicitly told us to back off. Honour Retry-After, and
+      // if it outlasts the window we're willing to wait, stop rather than keep
+      // adding load to a bucket we've already exhausted.
+      const retryAfterMs = parseRetryAfterMs(resp.headers.get('Retry-After'));
+      const remainingMs = timeoutMs - (Date.now() - start);
+      if (retryAfterMs !== null && retryAfterMs >= remainingMs) {
+        throw new Error('Remote session is rate limited — please retry in a moment.');
       }
+      intervalMs = Math.max(retryAfterMs ?? 0, ANSWER_POLL_MAX_INTERVAL_MS);
     }
 
-    await new Promise((r) => setTimeout(r, ANSWER_POLL_INTERVAL_MS));
+    await new Promise((r) => setTimeout(r, intervalMs));
+    intervalMs = nextAnswerPollInterval(intervalMs);
   }
 
   throw new Error('Timed out waiting for WebRTC answer from agent');

--- a/apps/web/src/stores/auth.test.ts
+++ b/apps/web/src/stores/auth.test.ts
@@ -357,6 +357,36 @@ describe('auth store fetchWithAuth', () => {
     expect(refreshCalls).toHaveLength(2);
   });
 
+  // Issue #3041: a 429 on /auth/refresh is the rate limiter rejecting the
+  // request before it was ever evaluated — no verdict was reached on the
+  // refresh cookie, so it is transient exactly like a 502. It used to fall
+  // through to the hard-failure branch, which is how a runaway remote-desktop
+  // viewer poll could exhaust the shared per-IP budget and dump an operator
+  // with a perfectly valid session on the login screen.
+  it('retries a 429 on refresh and keeps the session', async () => {
+    useAuthStore.getState().login(baseUser, baseTokens);
+    const refreshedTokens: Tokens = { accessToken: 'access-after-429', expiresInSeconds: 3600 };
+    const apiSuccess = makeResponse({ data: { ok: true } }, true, 200);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ error: 'unauthorized' }, false, 401))       // original request
+      .mockResolvedValueOnce(makeResponse({ error: 'Too many requests' }, false, 429))  // refresh throttled
+      .mockResolvedValueOnce(makeResponse({ tokens: refreshedTokens }, true, 200))      // refresh recovers
+      .mockResolvedValueOnce(apiSuccess);                                               // original replayed
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await fetchWithAuth('/devices');
+
+    expect(response).toBe(apiSuccess);
+    // The session must survive being rate limited.
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+    expect(useAuthStore.getState().tokens?.accessToken).toBe(refreshedTokens.accessToken);
+    expect(useAuthStore.getState().sessionExpiredReason).toBeNull();
+    const refreshCalls = fetchMock.mock.calls.filter(([url]) => String(url).endsWith('/api/v1/auth/refresh'));
+    expect(refreshCalls).toHaveLength(2);
+  });
+
   // The retry is bounded: a sustained gateway outage still evicts once the
   // backoff attempts are exhausted (no infinite hang).
   it('logs out when refresh 5xx persists past the retry budget', async () => {

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -313,11 +313,12 @@ const REFRESH_LOCK_NAME = 'breeze-token-refresh';
 //                #1107) — the winning sibling already rotated the SHARED refresh
 //                cookie and the server deliberately did NOT clear it or kill the
 //                session family, so an immediate retry picks up the fresh cookie.
-//   - transient: a gateway/network blip (5xx, offline, timeout) — no verdict was
-//                reached on the refresh cookie, so the session is very likely
-//                still valid and this should be retried with backoff rather than
-//                evicting the user (QA 2026-07-08: a single 502 on /auth/refresh
-//                hard-logged-out the SPA mid-session).
+//   - transient: a gateway/network blip or a rate-limit rejection (5xx, 429,
+//                offline, timeout) — no verdict was reached on the refresh
+//                cookie, so the session is very likely still valid and this
+//                should be retried with backoff rather than evicting the user
+//                (QA 2026-07-08: a single 502 on /auth/refresh hard-logged-out
+//                the SPA mid-session; issue #3041: so did a single 429).
 //   - neither:   a hard failure (expired/reused refresh cookie, real 401/403) —
 //                the session is unrecoverable and the caller must evict.
 async function refreshFetchOnce(): Promise<{ tokens: Tokens | null; raced: boolean; transient: boolean }> {
@@ -357,6 +358,16 @@ async function refreshFetchOnce(): Promise<{ tokens: Tokens | null; raced: boole
     if (body?.reason === 'refresh_raced') {
       return { tokens: null, raced: true, transient: false };
     }
+  }
+
+  // 429 means the rate limiter rejected the request before it was ever
+  // evaluated, so — exactly like a 5xx — no verdict was reached on the refresh
+  // cookie and the session is very likely still valid. Classifying it as a hard
+  // failure evicted people whose session was fine, which is how a runaway
+  // remote-desktop viewer poll (issue #3041) could exhaust the shared per-IP
+  // budget and dump the operator on the login screen.
+  if (refreshResponse.status === 429) {
+    return { tokens: null, raced: false, transient: true };
   }
 
   // 5xx (typically a 502/503/504 from the gateway) means the request never


### PR DESCRIPTION
Closes #3041

A remote-desktop session that died mid-connect could lock the operator out of their own console: `213 x 401 in ~26 seconds` from the viewer's answer poll drained the per-IP rate-limit bucket, and the next dashboard refresh came back `429 {"error":"Too many requests"}` and dumped them on the login screen.

Three defects compounded. Each is fixed independently, so no single one has to hold.

### 1. The poll didn't stop on 401 (viewer)

`isSessionEndedResponse()` only treated a 401 as terminal if the body matched `/session\s*ended|ended|revoked|no longer active/i`. The 401s `validateViewerSessionAccess` actually returns are `Session closed`, `Missing viewer token`, `Invalid or expired viewer token`, and `Viewer token revoked` — **none of the first three match**, so the poll kept firing every 50ms for the full 15s against a session that could never come back.

Now it matches on status alone. A viewer token authorizes exactly one still-live session, so every 401 on this path is terminal — the function's own comment already said as much; the regex just didn't implement it. Matching prose was the bug, so the body is no longer consulted at all.

Two adjacent loops closed while here:
- **Terminal 400/403/404** (not-a-desktop-session, policy-denied, session-not-found) also ran to timeout. They now end the attempt, as a plain `Error` — a policy denial is not a dead session and must not masquerade as one.
- **429** is now honoured via `Retry-After`: if the server's backoff outlasts the answer window, the attempt gives up instead of spending it issuing requests the server already refused.

### 2. A flat 50ms interval could exhaust the bucket by itself (viewer)

15s / 50ms = ~300 requests for **one** connection attempt — the entire default 300/60s budget. The poll now backs off geometrically (50ms, x1.5, capped at 500ms): a full 15s wait costs ~35 requests, while a healthy agent answering in a few hundred ms is picked up just as fast as before.

### 3. Viewer polls shared the dashboard's bucket (API)

`/api/v1/desktop-ws/` was metered in the same per-IP bucket as the dashboard and auth, so the burst starved the console.

It now gets its own bucket — **isolation, not exemption**. Adding it to the existing skip-prefix list was considered and rejected: that would remove all abuse protection from a public token-authenticated endpoint. It stays capped at 600/min; it just can no longer touch the budget the console draws on. Not counting 401s was also rejected — failed auth is exactly what a rate limiter should count.

### 4. The symptom: a 429 on `/auth/refresh` evicted a valid session (web)

This is why the reporter hit the *login screen* rather than just a failed request. `refreshFetchOnce()` classified anything that wasn't a raced 401 or a 5xx as a hard auth failure, so a 429 fell through to `auth-failed` and evicted the session. But a 429 is the rate limiter rejecting the request before it was ever evaluated — no verdict was reached on the refresh cookie, so it is transient, exactly like the 502 case fixed in QA 2026-07-08. It is now retried with the existing backoff.

Also: the in-memory rate-limit fallback returned a 429 with no `Retry-After` on its map-full path, leaving well-behaved clients no backoff signal. Fixed.

## Testing

- `apps/api/src/middleware/globalRateLimit.test.ts` — viewer polls don't drain the shared bucket; the viewer bucket is still capped (isolation != exemption, asserted with `Retry-After` + `X-RateLimit-Limit`); shared-bucket exhaustion doesn't throttle viewer traffic; the shipped default really does isolate `/api/v1/desktop-ws/`.
- `apps/viewer/src/lib/sessionEnded.test.ts` — the poll stops after **exactly one** request for each real API 401 body (table-driven over all four, plus the JSON-wrapped form); terminal 403 ends the attempt without masquerading as `SessionEndedError`; a 429 with `Retry-After: 60` gives up instead of polling; backoff keeps a full 15s wait under 40 requests while staying fast at the start.
- `apps/web/src/stores/auth.test.ts` — a 429 on `/auth/refresh` is retried and the session survives.

**Results:** API 6/6, viewer 21/21, web 46/46, `extensions/loader.test.ts` 49/49 (it also exercises this middleware). `tsc --noEmit` clean on all three packages. No schema, migration, or tenant-table changes.

## Follow-ups (deliberately not in scope)

- Issue ask #4 wanted the console to show a **cooldown** instead of a login bounce. This PR stops the incorrect eviction, but `AuthGuard` still collapses `transient` to a boolean and redirects once the bounded retries are exhausted. Showing a real rate-limited state needs new UI states — worth its own issue.
- `pollForAnswer` takes no `AbortSignal`, so an unmount mid-attempt isn't noticed until the attempt returns (now bounded and much quieter, but not zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)