### PR TITLE
fix(snmp): make the live device row the sole org authority for poll dispatch (#3226)

### DIFF
--- a/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
+++ b/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
@@ -1,0 +1,395 @@
+/**
+ * snmpWorker org authority (issue #3226).
+ *
+ * The regression these tests lock down is a cross-tenant credential
+ * disclosure. `processPollDevice` used to resolve the org from TWO sources for a
+ * single dispatch: the template was scoped on the live `snmp_devices` row while
+ * the online-agent pick was scoped on the BullMQ job payload, captured whenever
+ * the job was enqueued. The command built at the end of that function carries
+ * DECRYPTED SNMP credentials (v1/v2c community string, v3 auth/priv passwords),
+ * and the agent receiving them was chosen by the payload — so a device moved
+ * between orgs while a poll sat queued had its secrets handed to an online agent
+ * in the OLD org.
+ *
+ * The stable jobId (`snmp-poll-<deviceId>`) made that durable rather than a
+ * narrow race: `enqueueSnmpPoll` returns early when it finds the job in a
+ * reusable state, so a later enqueue carrying the correct org never supersedes
+ * the stale payload.
+ *
+ * Two fences, tested here:
+ *   1. worker-side  — the live row is the sole org authority, and a payload that
+ *                     disagrees fails the job loudly before any decrypt.
+ *   2. enqueue-side — a queued job whose payload org has drifted is replaced
+ *                     instead of reused.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb, queueMock, agentWsMock, decryptMock, eqCalls } = vi.hoisted(() => ({
+  mockDb: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+  queueMock: {
+    getJob: vi.fn(async () => null),
+    add: vi.fn(async () => ({ id: 'job-1' })),
+    addBulk: vi.fn(async () => []),
+    getRepeatableJobs: vi.fn(async () => []),
+    removeRepeatableByKey: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+  },
+  agentWsMock: {
+    isAgentConnected: vi.fn(() => true),
+    sendCommandToAgent: vi.fn(() => true),
+  },
+  decryptMock: vi.fn((v: string | null) => v),
+  // Records every drizzle `eq(column, value)` so a test can prove WHICH org
+  // value the online-agent predicate was built from.
+  eqCalls: [] as Array<[unknown, unknown]>,
+}));
+
+vi.mock('bullmq', () => ({
+  Queue: class {
+    getJob = queueMock.getJob;
+    add = queueMock.add;
+    addBulk = queueMock.addBulk;
+    getRepeatableJobs = queueMock.getRepeatableJobs;
+    removeRepeatableByKey = queueMock.removeRepeatableByKey;
+    close = queueMock.close;
+  },
+  Worker: class {
+    close = vi.fn();
+    on = vi.fn();
+  },
+  Job: class {},
+}));
+
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    eq: (column: unknown, value: unknown) => {
+      eqCalls.push([column, value]);
+      return actual.eq(column as never, value as never);
+    },
+  };
+});
+
+vi.mock('../db', () => ({
+  db: mockDb,
+  withSystemDbAccessContext: async (fn: () => unknown) => fn(),
+  assertOutsideHeldDbContext: vi.fn(),
+}));
+
+vi.mock('../db/schema', () => ({
+  snmpDevices: {
+    id: 'snmpDevices.id',
+    orgId: 'snmpDevices.orgId',
+    isActive: 'snmpDevices.isActive',
+    lastPolled: 'snmpDevices.lastPolled',
+    lastPollAttemptedAt: 'snmpDevices.lastPollAttemptedAt',
+    consecutiveFailures: 'snmpDevices.consecutiveFailures',
+    lastStatus: 'snmpDevices.lastStatus',
+    pollingInterval: 'snmpDevices.pollingInterval',
+  },
+  snmpMetrics: { deviceId: 'snmpMetrics.deviceId' },
+  snmpTemplates: {
+    id: 'snmpTemplates.id',
+    oids: 'snmpTemplates.oids',
+    isBuiltIn: 'snmpTemplates.isBuiltIn',
+    orgId: 'snmpTemplates.orgId',
+  },
+  devices: {
+    agentId: 'devices.agentId',
+    orgId: 'devices.orgId',
+    isEphemeral: 'devices.isEphemeral',
+    status: 'devices.status',
+  },
+}));
+
+vi.mock('../services/redis', () => ({
+  getBullMQConnection: vi.fn(() => ({ host: 'localhost', port: 6379 })),
+}));
+
+vi.mock('../routes/agentWs', () => ({
+  isAgentConnected: agentWsMock.isAgentConnected,
+  sendCommandToAgent: agentWsMock.sendCommandToAgent,
+}));
+
+vi.mock('../services/snmpSecrets', () => ({
+  decryptSnmpSecret: decryptMock,
+}));
+
+vi.mock('./workerObservability', () => ({
+  attachWorkerObservability: vi.fn(),
+}));
+
+import { __testables, enqueueSnmpPoll, shutdownSnmpWorker } from './snmpWorker';
+
+const { processPollDevice } = __testables;
+
+const LIVE_ORG = '11111111-1111-1111-1111-111111111111';
+const STALE_ORG = '22222222-2222-2222-2222-222222222222';
+const DEVICE_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+/** The `snmp_devices` row as the dispatch path sees it, with v2c + v3 secrets. */
+function deviceRow(orgId: string) {
+  return {
+    id: DEVICE_ID,
+    orgId,
+    templateId: 'template-1',
+    ipAddress: '10.0.0.1',
+    port: 161,
+    snmpVersion: 'v3',
+    community: 'enc:community',
+    username: 'poller',
+    authProtocol: 'sha',
+    authPassword: 'enc:auth',
+    privProtocol: 'aes',
+    privPassword: 'enc:priv',
+  };
+}
+
+/** A `.select().from().where().limit()` chain resolving to `rows`. */
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+/** Records every `snmp_devices` UPDATE by which write it is. */
+const updateLog: string[] = [];
+function updateChain() {
+  return {
+    set: (payload: Record<string, unknown>) => ({
+      where: async () => {
+        updateLog.push(
+          !('consecutiveFailures' in payload) ? 'attemptStamp' : 'dispatchCount'
+        );
+      },
+    }),
+  };
+}
+
+/**
+ * Wire the three selects a dispatch makes, in order:
+ * device row → template OIDs → online agent.
+ *
+ * ALL THREE are wired even on the mismatch tests, deliberately. Wiring only the
+ * device select would make those tests pass for the wrong reason — the run would
+ * die on an unstubbed `db.select()` a step later, so `rejects.toThrow()` and
+ * "no credentials shipped" would hold even with the bug present. With the full
+ * chain stubbed, the pre-fix code reaches `sendCommandToAgent` and hands the
+ * decrypted community/auth/priv secrets to `agentId`; the assertions below only
+ * pass because the org guard stops it.
+ */
+function wireDispatchSelects(deviceOrgId: string, agentId: string) {
+  mockDb.select
+    .mockReturnValueOnce(selectChain([deviceRow(deviceOrgId)]) as never)
+    .mockReturnValueOnce(selectChain([{ oids: [{ oid: '1.3.6.1.2.1.1.3.0' }] }]) as never)
+    .mockReturnValueOnce(selectChain([{ agentId }]) as never);
+}
+
+describe('snmpWorker org authority (#3226)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    eqCalls.length = 0;
+    updateLog.length = 0;
+    // mockReset, not clearAllMocks: several tests deliberately leave part of the
+    // `mockReturnValueOnce` chain unconsumed (the org guard short-circuits before
+    // the template and agent selects). `clearAllMocks` clears recorded calls but
+    // NOT the queued once-implementations, so those leftovers would be served to
+    // the next test and silently mis-wire it.
+    mockDb.select.mockReset();
+    mockDb.update.mockReset();
+    mockDb.update.mockImplementation(updateChain as never);
+    agentWsMock.isAgentConnected.mockReturnValue(true);
+    agentWsMock.sendCommandToAgent.mockReturnValue(true);
+    queueMock.getJob.mockResolvedValue(null);
+    queueMock.add.mockResolvedValue({ id: 'job-1' });
+    await shutdownSnmpWorker();
+  });
+
+  describe('worker-side fence: the live device row is the only org authority', () => {
+    it('refuses the dispatch and fails loudly when the payload org is stale', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-in-stale-org');
+
+      await expect(
+        processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: STALE_ORG })
+      ).rejects.toThrow(/stale job payload org/);
+    });
+
+    it('decrypts no SNMP secrets and sends no command on an org mismatch', async () => {
+      // Everything a successful dispatch needs is available, so the ONLY thing
+      // standing between the stale payload and `agent-in-stale-org` receiving
+      // this device's decrypted community/auth/priv secrets is the org guard.
+      wireDispatchSelects(LIVE_ORG, 'agent-in-stale-org');
+
+      await expect(
+        processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: STALE_ORG })
+      ).rejects.toThrow();
+
+      // The whole point of the issue: credentials must never reach the wire.
+      expect(decryptMock).not.toHaveBeenCalled();
+      expect(agentWsMock.sendCommandToAgent).not.toHaveBeenCalled();
+    });
+
+    it('stops before the agent lookup, so no agent in either org is even selected', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-in-stale-org');
+
+      await expect(
+        processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: STALE_ORG })
+      ).rejects.toThrow();
+
+      // Device row only — the template and online-agent selects never ran.
+      expect(mockDb.select).toHaveBeenCalledTimes(1);
+      expect(eqCalls.some(([column]) => column === 'devices.orgId')).toBe(false);
+    });
+
+    it('still stamps lastPollAttemptedAt on a mismatch, so the scheduler does not hot-loop', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-in-stale-org');
+
+      await expect(
+        processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: STALE_ORG })
+      ).rejects.toThrow();
+
+      // The throw is raised AFTER the phase-1 context commits. Raised inside it,
+      // the rollback would drop this stamp and leave lastPollAttemptedAt NULL —
+      // re-selecting the device on every 60s tick (the #3217 hot loop).
+      expect(updateLog).toContain('attemptStamp');
+      // It never counted as a dispatched poll, because nothing was dispatched.
+      expect(updateLog).not.toContain('dispatchCount');
+    });
+
+    it('treats a payload with no orgId as stale rather than as a wildcard', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-in-stale-org');
+
+      await expect(
+        processPollDevice({ deviceId: DEVICE_ID } as never)
+      ).rejects.toThrow(/stale job payload org/);
+      expect(decryptMock).not.toHaveBeenCalled();
+    });
+
+    it('builds the online-agent predicate from the live row org', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-live');
+
+      const result = await processPollDevice({
+        type: 'poll-device',
+        deviceId: DEVICE_ID,
+        orgId: LIVE_ORG,
+      });
+
+      expect(result).toEqual({ dispatched: true, agentId: 'agent-live' });
+      // Past the mismatch guard the payload and the row are provably equal, so
+      // this asserts the contract rather than a divergence: the predicate is
+      // built from an org that came out of the device row.
+      expect(eqCalls).toContainEqual(['devices.orgId', LIVE_ORG]);
+    });
+
+    it('dispatches normally when the payload org matches', async () => {
+      wireDispatchSelects(LIVE_ORG, 'agent-live');
+
+      await processPollDevice({ type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG });
+
+      expect(agentWsMock.sendCommandToAgent).toHaveBeenCalledTimes(1);
+      const [agentId, command] = agentWsMock.sendCommandToAgent.mock.calls[0] as unknown as [
+        string,
+        { type: string },
+      ];
+      expect(agentId).toBe('agent-live');
+      expect(command.type).toBe('snmp_poll');
+    });
+  });
+
+  describe('enqueue-side fence: a drifted payload is replaced, not reused', () => {
+    it('replaces a waiting job whose payload org no longer matches the device', async () => {
+      const remove = vi.fn(async () => undefined);
+      queueMock.getJob.mockResolvedValue({
+        id: `snmp-poll-${DEVICE_ID}`,
+        data: { type: 'poll-device', deviceId: DEVICE_ID, orgId: STALE_ORG },
+        getState: vi.fn().mockResolvedValue('waiting'),
+        remove,
+      } as never);
+
+      await enqueueSnmpPoll(DEVICE_ID, LIVE_ORG);
+
+      expect(remove).toHaveBeenCalledTimes(1);
+      expect(queueMock.add).toHaveBeenCalledWith(
+        'poll-device',
+        expect.objectContaining({ deviceId: DEVICE_ID, orgId: LIVE_ORG }),
+        expect.objectContaining({ jobId: `snmp-poll-${DEVICE_ID}` })
+      );
+    });
+
+    it('reuses a waiting job whose payload org still matches', async () => {
+      const remove = vi.fn(async () => undefined);
+      queueMock.getJob.mockResolvedValue({
+        id: 'existing-job',
+        data: { type: 'poll-device', deviceId: DEVICE_ID, orgId: LIVE_ORG },
+        getState: vi.fn().mockResolvedValue('waiting'),
+        remove,
+      } as never);
+
+      const jobId = await enqueueSnmpPoll(DEVICE_ID, LIVE_ORG);
+
+      expect(jobId).toBe('existing-job');
+      expect(remove).not.toHaveBeenCalled();
+      expect(queueMock.add).not.toHaveBeenCalled();
+    });
+
+    it('leaves an ACTIVE drifted job to the worker-side guard instead of racing its lock', async () => {
+      const remove = vi.fn(async () => undefined);
+      queueMock.getJob.mockResolvedValue({
+        id: 'existing-job',
+        data: { type: 'poll-device', deviceId: DEVICE_ID, orgId: STALE_ORG },
+        getState: vi.fn().mockResolvedValue('active'),
+        remove,
+      } as never);
+
+      const jobId = await enqueueSnmpPoll(DEVICE_ID, LIVE_ORG);
+
+      // BullMQ rejects removing a locked job; the in-flight run is refused by
+      // `loadPollDispatchInputs` on the same mismatch.
+      expect(jobId).toBe('existing-job');
+      expect(remove).not.toHaveBeenCalled();
+    });
+
+    it('replaces a queued job that carries no org at all', async () => {
+      const remove = vi.fn(async () => undefined);
+      queueMock.getJob.mockResolvedValue({
+        id: 'legacy-job',
+        data: { type: 'poll-device', deviceId: DEVICE_ID },
+        getState: vi.fn().mockResolvedValue('delayed'),
+        remove,
+      } as never);
+
+      await enqueueSnmpPoll(DEVICE_ID, LIVE_ORG);
+
+      expect(remove).toHaveBeenCalledTimes(1);
+      expect(queueMock.add).toHaveBeenCalledWith(
+        'poll-device',
+        expect.objectContaining({ orgId: LIVE_ORG }),
+        expect.anything()
+      );
+    });
+
+    it('still removes a completed job before re-adding, and does not double-remove', async () => {
+      const remove = vi.fn(async () => undefined);
+      queueMock.getJob.mockResolvedValue({
+        id: 'done-job',
+        data: { type: 'poll-device', deviceId: DEVICE_ID, orgId: STALE_ORG },
+        getState: vi.fn().mockResolvedValue('completed'),
+        remove,
+      } as never);
+
+      await enqueueSnmpPoll(DEVICE_ID, LIVE_ORG);
+
+      expect(remove).toHaveBeenCalledTimes(1);
+      expect(queueMock.add).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
+++ b/apps/api/src/jobs/snmpWorker.orgAuthority.test.ts
@@ -290,6 +290,48 @@ describe('snmpWorker org authority (#3226)', () => {
       expect(eqCalls).toContainEqual(['devices.orgId', LIVE_ORG]);
     });
 
+    // The two log lines below were also switched off the payload org by this
+    // fix. Neither is a credential path — nothing dispatches on either — but a
+    // regression to `data.orgId` would silently reintroduce a stale-payload read
+    // into the very function being hardened, and nothing else would catch it.
+    it('reports the live row org, not the payload org, when the org has no online agent', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockDb.select
+        .mockReturnValueOnce(selectChain([deviceRow(LIVE_ORG)]) as never)
+        .mockReturnValueOnce(selectChain([{ oids: [{ oid: '1.3.6.1.2.1.1.3.0' }] }]) as never)
+        .mockReturnValueOnce(selectChain([]) as never);
+
+      const result = await processPollDevice({
+        type: 'poll-device',
+        deviceId: DEVICE_ID,
+        orgId: LIVE_ORG,
+      });
+
+      expect(result).toEqual({ dispatched: false, agentId: null });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(LIVE_ORG));
+      warn.mockRestore();
+    });
+
+    it('does not dispatch when the selected agent is no longer connected', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      wireDispatchSelects(LIVE_ORG, 'agent-live');
+      agentWsMock.isAgentConnected.mockReturnValue(false);
+
+      const result = await processPollDevice({
+        type: 'poll-device',
+        deviceId: DEVICE_ID,
+        orgId: LIVE_ORG,
+      });
+
+      expect(result).toEqual({ dispatched: false, agentId: null });
+      expect(agentWsMock.sendCommandToAgent).not.toHaveBeenCalled();
+      expect(decryptMock).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(LIVE_ORG));
+      // A poll that never left the building must not count against the device.
+      expect(updateLog).not.toContain('dispatchCount');
+      warn.mockRestore();
+    });
+
     it('dispatches normally when the payload org matches', async () => {
       wireDispatchSelects(LIVE_ORG, 'agent-live');
 
@@ -375,6 +417,36 @@ describe('snmpWorker org authority (#3226)', () => {
         expect.objectContaining({ orgId: LIVE_ORG }),
         expect.anything()
       );
+    });
+
+    it('falls back to the worker-side guard when the drifted job locks mid-replacement', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // The classic TOCTOU: 'waiting' at getState(), locked by a worker by the
+      // time remove() runs. BullMQ rejects the removal.
+      const remove = vi.fn(async () => {
+        throw new Error('Job snmp-poll-x could not be removed because it is locked by another worker');
+      });
+      queueMock.getJob.mockResolvedValue({
+        id: 'raced-job',
+        data: { type: 'poll-device', deviceId: DEVICE_ID, orgId: STALE_ORG },
+        getState: vi.fn().mockResolvedValue('waiting'),
+        remove,
+      } as never);
+
+      // Must not reject: the scheduler's per-device catch would only log this
+      // without Sentry, and the in-flight job is already covered by the
+      // worker-side org guard.
+      const jobId = await enqueueSnmpPoll(DEVICE_ID, LIVE_ORG);
+
+      expect(jobId).toBe('raced-job');
+      // No duplicate add — BullMQ would return the existing job anyway.
+      expect(queueMock.add).not.toHaveBeenCalled();
+      // Handled, not silent.
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('became active mid-replacement'),
+        expect.any(Error)
+      );
+      warn.mockRestore();
     });
 
     it('still removes a completed job before re-adding, and does not double-remove', async () => {

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -75,6 +75,17 @@ export function getSnmpQueue(): Queue {
 interface PollDeviceJobData {
   type: 'poll-device';
   deviceId: string;
+  /**
+   * The device's org as it stood WHEN THE JOB WAS ENQUEUED — advisory only
+   * (issue #3226).
+   *
+   * Nothing in the dispatch path may use this to select data or a delivery
+   * target. It exists purely as a staleness tripwire: `loadPollDispatchInputs`
+   * compares it against the live `snmp_devices` row and refuses the dispatch if
+   * they disagree. See the org-authority note on `loadPollDispatchInputs` for
+   * why a stale value here is a credential-disclosure hazard rather than a
+   * cosmetic inconsistency.
+   */
   orgId: string;
 }
 
@@ -205,8 +216,9 @@ async function markPollDispatched(deviceId: string): Promise<void> {
  */
 type PollDispatchInputs =
   | { status: 'device-missing' }
+  | { status: 'org-mismatch'; payloadOrgId: string; deviceOrgId: string }
   | { status: 'no-oids' }
-  | { status: 'no-agent' }
+  | { status: 'no-agent'; orgId: string }
   | {
       status: 'ok';
       device: typeof snmpDevices.$inferSelect;
@@ -218,9 +230,28 @@ type PollDispatchInputs =
  * Phase 1 of a poll-device job: read every row the dispatch needs inside ONE
  * short-lived system DB context. Nothing here talks to Redis or the agent
  * WebSocket, so the pooled connection is released before dispatch (#1105).
+ *
+ * ORG AUTHORITY (issue #3226) — the live `snmp_devices` row is the ONLY source
+ * of the org for this dispatch. Both the template scope and the online-agent
+ * pick read `device.orgId`; neither may read `data.orgId`.
+ *
+ * This used to be split: the template was scoped on the row while the agent was
+ * picked on the job payload. The payload is captured at enqueue time and, because
+ * `enqueueSnmpPoll` reuses a job with the stable id `snmp-poll-<deviceId>` while
+ * it sits in a reusable state, a payload built before an org change SURVIVES
+ * later enqueues rather than being superseded. The command this function feeds
+ * carries decrypted SNMP credentials (v1/v2c community, v3 auth/priv passwords),
+ * so picking the agent off the stale value handed a now-org-B device's secrets
+ * to an online agent in org A — a durable cross-tenant disclosure, not a race.
+ *
+ * Do NOT "harden" the device load above by adding `eq(snmpDevices.orgId,
+ * data.orgId)`. That re-introduces payload trust through the back door: a moved
+ * device would report as `device-missing`, hiding the very divergence the
+ * mismatch guard exists to surface. Load by primary key, then reconcile.
  */
 async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDispatchInputs> {
-  // Load the device config
+  // Load the device config. Keyed on the primary key alone — see the org
+  // authority note above for why no org predicate belongs here.
   const [device] = await db
     .select()
     .from(snmpDevices)
@@ -229,6 +260,13 @@ async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDisp
 
   if (!device) {
     return { status: 'device-missing' };
+  }
+
+  // Reconcile the advisory payload org against the authoritative row BEFORE any
+  // further read, so a stale job does no work and — critically — never reaches
+  // the credential decrypt in `buildSnmpPollCommand`.
+  if (device.orgId !== data.orgId) {
+    return { status: 'org-mismatch', payloadOrgId: data.orgId, deviceOrgId: device.orgId };
   }
 
   // Load template OIDs if device has a template
@@ -252,7 +290,8 @@ async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDisp
     return { status: 'no-oids' };
   }
 
-  // Find an online agent for this org.
+  // Find an online agent for this org — `device.orgId`, the live row, never the
+  // job payload (#3226).
   //
   // Quick Support exclusion: ephemeral devices (`devices.isEphemeral`) live in
   // the hidden per-partner 'quick_support' org and are a stranger's personal
@@ -264,7 +303,7 @@ async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDisp
     .from(devices)
     .where(
       and(
-        eq(devices.orgId, data.orgId),
+        eq(devices.orgId, device.orgId),
         eq(devices.isEphemeral, false),
         eq(devices.status, 'online')
       )
@@ -273,7 +312,7 @@ async function loadPollDispatchInputs(data: PollDeviceJobData): Promise<PollDisp
 
   const agentId = onlineAgent?.agentId ?? null;
   if (!agentId) {
-    return { status: 'no-agent' };
+    return { status: 'no-agent', orgId: device.orgId };
   }
 
   return { status: 'ok', device, oids, agentId };
@@ -309,18 +348,42 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
     case 'device-missing':
       console.error(`[SnmpWorker] Device ${data.deviceId} not found`);
       return { dispatched: false, agentId: null };
+    case 'org-mismatch': {
+      // Fail the job LOUDLY rather than returning a quiet `dispatched: false`
+      // (issue #3226). This is a tenant-isolation anomaly, so it must reach
+      // `attachWorkerObservability` and the worker's 'failed' handler instead of
+      // scrolling past as one more console line among the routine no-agent
+      // warnings.
+      //
+      // Throwing here — after phase 1 has COMMITTED — is deliberate. The same
+      // throw raised inside the phase-1 callback would roll that transaction
+      // back and take `markPollAttempted`'s stamp with it, leaving
+      // `lastPollAttemptedAt` NULL so the scheduler re-selects this device on
+      // every 60s tick: exactly the hot loop #3217 fixed.
+      //
+      // The failure is self-healing. Nothing retries this payload (no `attempts`
+      // option is set), so the job settles in 'failed'; the next scheduler tick
+      // sees that non-reusable state, removes it, and enqueues a fresh job
+      // carrying the device's current org.
+      const message =
+        `[SnmpWorker] Refusing SNMP poll for device ${data.deviceId}: stale job payload org `
+        + `${inputs.payloadOrgId} does not match live device org ${inputs.deviceOrgId}. `
+        + 'No credentials were decrypted or dispatched.';
+      console.error(message);
+      throw new Error(message);
+    }
     case 'no-oids':
       console.warn(`[SnmpWorker] No OIDs configured for device ${data.deviceId}`);
       return { dispatched: false, agentId: null };
     case 'no-agent':
-      console.warn(`[SnmpWorker] No online agent for org ${data.orgId}`);
+      console.warn(`[SnmpWorker] No online agent for org ${inputs.orgId}`);
       return { dispatched: false, agentId: null };
   }
 
   const { device, oids, agentId } = inputs;
 
   if (!isAgentConnected(agentId)) {
-    console.warn(`[SnmpWorker] No online agent for org ${data.orgId}`);
+    console.warn(`[SnmpWorker] No online agent for org ${device.orgId}`);
     return { dispatched: false, agentId: null };
   }
 
@@ -471,9 +534,32 @@ export async function enqueueSnmpPoll(
   if (existing) {
     const state = await existing.getState();
     if (isReusableState(state)) {
-      return existing.id as string;
-    }
-    if (state === 'completed' || state === 'failed') {
+      // Reuse only while the queued payload still describes the device's CURRENT
+      // org (issue #3226). Callers pass the org they just read from the live row,
+      // so a disagreement means the device changed org while this job sat
+      // queued. Left alone, the stable jobId would keep that stale payload alive
+      // across every subsequent enqueue — the reuse branch returns before `add`
+      // is ever reached, so a fresh org can never overwrite it.
+      //
+      // 'active' is reusable but NOT removable: the worker holds a lock on it and
+      // BullMQ rejects the removal. That job is already in flight, and
+      // `loadPollDispatchInputs` will refuse it on the same mismatch, so leave it
+      // to the worker-side guard rather than racing the lock.
+      // A payload with no `orgId` at all counts as drifted, not as a match. It
+      // cannot be reconciled against the live row, so the worker would refuse it
+      // anyway; replacing it here turns a guaranteed job failure into a correct
+      // poll.
+      const existingOrgId = (existing.data as Partial<PollDeviceJobData> | undefined)?.orgId;
+      const orgDrifted = existingOrgId !== orgId;
+      if (!orgDrifted || state === 'active') {
+        return existing.id as string;
+      }
+      console.warn(
+        `[SnmpWorker] Replacing queued poll for device ${deviceId}: payload org ${existingOrgId} `
+        + `is stale (device is now in org ${orgId}).`
+      );
+      await existing.remove();
+    } else if (state === 'completed' || state === 'failed') {
       await existing.remove();
     }
   }

--- a/apps/api/src/jobs/snmpWorker.ts
+++ b/apps/api/src/jobs/snmpWorker.ts
@@ -361,10 +361,19 @@ async function processPollDevice(data: PollDeviceJobData): Promise<{
       // `lastPollAttemptedAt` NULL so the scheduler re-selects this device on
       // every 60s tick: exactly the hot loop #3217 fixed.
       //
-      // The failure is self-healing. Nothing retries this payload (no `attempts`
-      // option is set), so the job settles in 'failed'; the next scheduler tick
-      // sees that non-reusable state, removes it, and enqueues a fresh job
-      // carrying the device's current org.
+      // The failure is self-healing, on the device's own polling cadence rather
+      // than the scheduler's. Nothing retries this payload (no `attempts` option
+      // is set), so the job settles in 'failed'. The attempt stamp above is what
+      // keeps this device off the next few 60s ticks, so recovery lands the next
+      // time it is genuinely DUE — one `pollingInterval` later (300s by default;
+      // `consecutiveFailures` is untouched here, so no backoff multiplier
+      // applies). At that point `enqueueSnmpPoll` sees the non-reusable 'failed'
+      // state, removes it, and enqueues a fresh job carrying the current org.
+      //
+      // In practice this branch is the backstop, not the usual route: the
+      // enqueue-side check in `enqueueSnmpPoll` normally replaces a drifted
+      // payload before a worker ever picks it up. Reaching here means the job
+      // was already 'active' when the org changed, or that replacement failed.
       const message =
         `[SnmpWorker] Refusing SNMP poll for device ${data.deviceId}: stale job payload org `
         + `${inputs.payloadOrgId} does not match live device org ${inputs.deviceOrgId}. `
@@ -545,6 +554,7 @@ export async function enqueueSnmpPoll(
       // BullMQ rejects the removal. That job is already in flight, and
       // `loadPollDispatchInputs` will refuse it on the same mismatch, so leave it
       // to the worker-side guard rather than racing the lock.
+      //
       // A payload with no `orgId` at all counts as drifted, not as a match. It
       // cannot be reconciled against the live row, so the worker would refuse it
       // anyway; replacing it here turns a guaranteed job failure into a correct
@@ -558,7 +568,29 @@ export async function enqueueSnmpPoll(
         `[SnmpWorker] Replacing queued poll for device ${deviceId}: payload org ${existingOrgId} `
         + `is stale (device is now in org ${orgId}).`
       );
-      await existing.remove();
+      try {
+        await existing.remove();
+      } catch (err) {
+        // The `state === 'active'` check above is a snapshot: with concurrency 10
+        // a 'waiting' job can be picked up and locked between `getState()` and
+        // here, and BullMQ then rejects the removal ("locked by another worker").
+        // Terminal-state removals below cannot hit this — only this new
+        // drifted-reuse path exposes `remove()` to a lockable job.
+        //
+        // Handled, not swallowed: the race collapses into the case the branch
+        // above already delegates. The job is now in flight with a payload we
+        // know to be stale, and `loadPollDispatchInputs` refuses exactly that on
+        // the same mismatch, so no credentials go out either way. Falling through
+        // to `add()` would be pointless — BullMQ returns the existing job for a
+        // duplicate jobId rather than replacing it — so report the job that is
+        // actually queued and let the worker-side fence finish the job.
+        console.warn(
+          `[SnmpWorker] Could not replace the stale-org poll for device ${deviceId} `
+          + '(it became active mid-replacement); the worker-side org guard will refuse it:',
+          err
+        );
+        return existing.id as string;
+      }
     } else if (state === 'completed' || state === 'failed') {
       await existing.remove();
     }


### PR DESCRIPTION
Closes #3226

## The bug

`processPollDevice` (`apps/api/src/jobs/snmpWorker.ts`) resolved the org **twice, from two different sources**, for a single dispatch:

| Consumer | Org source |
|---|---|
| template OID lookup | `device.orgId` — the live `snmp_devices` row |
| online-agent pick | `data.orgId` — the BullMQ job payload |

Those agree only while the device's `org_id` hasn't changed since the job was created.

The command built at the end of that function carries **decrypted SNMP credentials** — the v1/v2c community string and the v3 auth/priv passwords — and the agent that receives them was chosen by the payload. So a device moved between orgs while a poll sat queued had its secrets handed to an online agent in the **old** org.

The stable jobId makes this **durable rather than a narrow race**: `enqueueSnmpPoll` returns early when it finds `snmp-poll-<deviceId>` in a reusable state, so a later enqueue carrying the correct org never supersedes the stale payload — it survives and is reused indefinitely.

Verified still present on `origin/main` (669a3551a) before starting; no prior PR referenced the issue in any state.

## The fix

**One authority: the live row.** Both consumers now read `device.orgId`, and the payload is reconciled against it.

**Worker-side fence.** A payload org that disagrees with the row aborts the dispatch *before* the template read and *before* any credential decrypt, then **fails the job loudly** so it lands in `attachWorkerObservability` and the worker's `failed` handler instead of scrolling past as one more console warning among the routine no-agent lines.

Two subtleties worth flagging for review:

- **The throw is raised after the phase-1 DB context commits, not inside it.** The same throw inside that callback would roll the transaction back and take `markPollAttempted`'s stamp with it — leaving `lastPollAttemptedAt` NULL so the scheduler re-selects the device on every 60s tick. That is exactly the hot loop #3217 fixed.
- **The failure is self-healing, on the device's polling cadence.** No `attempts` option is set, so the job settles in `failed`. The attempt stamp is what keeps the device off the next few 60s ticks, so recovery lands the next time it is genuinely *due* — one `pollingInterval` later, 300s by default (`consecutiveFailures` is untouched here, so no backoff multiplier applies). At that point `enqueueSnmpPoll` sees the non-reusable `failed` state, removes it, and enqueues a fresh job carrying the current org. Worst case is one skipped poll interval for a device that just changed org. This branch is the backstop, not the usual route — the enqueue-side fence normally replaces a drifted payload before a worker picks it up.

**Enqueue-side fence.** A queued job whose payload org has drifted from the org the caller just read from the live row is removed and re-added rather than reused, so in the normal path the stale payload never reaches the worker at all. An `active` job is deliberately left alone — BullMQ rejects removing a locked job, and the worker-side guard refuses that in-flight run on the same mismatch.

**`orgId` stays on the payload deliberately.** The issue offered "drop it or assert it"; dropping it would remove the only signal that a divergence ever happened. It is now documented as advisory — used solely as the staleness tripwire, never as an input.

**A payload with no `orgId` counts as stale, not as a wildcard** — fail-closed on a credential path.

## On the two open questions in the issue

- *"Should the unscoped device load carry an explicit org predicate for defence in depth?"* — **No, and there's now a comment saying so.** Adding `eq(snmpDevices.orgId, data.orgId)` re-introduces payload trust through the back door: a moved device would report as `device-missing`, hiding the very divergence the guard exists to surface. Load by primary key, then reconcile.
- *"Should `moveOrg` drain queued `snmp-poll-*` jobs?"* — not needed for correctness now that both fences are in place, and `snmp_devices` has no `device_id` so it isn't on the device-move path anyway. Left out to keep the diff scoped.

## Verification

- `apps/api/src/jobs/snmpWorker.orgAuthority.test.ts` — **new, 12 cases**, covering: mismatch refuses + throws; no `decryptSnmpSecret` call and no `sendCommandToAgent` on mismatch; abort happens before the agent lookup; the attempt stamp still lands (no #3217 hot loop); missing `orgId` treated as stale; agent predicate built from the row org; happy path still dispatches; and the five enqueue-side reuse/replace cases.
- **Falsifiability checked, and it mattered.** A first draft of the mismatch tests wired only the device select, so they passed against the *unfixed* worker — the run died on an unstubbed `db.select()` one step later rather than on the guard. They now wire the full dispatch chain, so the pre-fix code genuinely reaches `sendCommandToAgent` with the decrypted secrets. **7 of 12 fail on the unfixed worker**, including the "no credentials on the wire" assertion.
- All four SNMP suites green single-fork: `snmpWorker.orgAuthority`, `snmpWorker.dbcontext`, `snmpQueue`, `snmpWorkerScheduler` — **39 passed**.
- `npx tsc --noEmit` on `apps/api` — clean.
- **No RLS/integration suites run:** no local database was available. This change adds no table, column, or migration and does not alter RLS context usage — it only changes which in-memory value a `WHERE` predicate is built from — so no cascade or export-policy registration applies.

## Review round

Reviewed by `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer` and a dedicated security pass. Three findings, all addressed in `73c1cd98c`:

1. **Inaccurate comment (and PR body).** The `org-mismatch` branch claimed recovery happens on "the next scheduler tick". It doesn't — `markPollAttempted` stamps `lastPollAttemptedAt`, which is precisely what keeps the device off the next few 60s ticks. Corrected above and in the code.
2. **Unguarded `existing.remove()`** in the new drifted-reuse path. A `waiting` job can be locked between the `getState()` snapshot and the removal (concurrency is 10), and this path is what newly exposes `remove()` to a lockable job — the pre-existing terminal-state removals can't hit it. It threw into `processScheduler`'s per-device catch, which logs without Sentry. Now handled explicitly: the race collapses into the case the `active` branch already delegates to the worker-side guard, so it logs with the error and returns the job that is actually queued.
3. **Two untested branches the fix touched** — the `no-agent` and `isAgentConnected === false` log lines, both switched off the payload org. Neither dispatches, so neither is a credential path, but a regression there would silently reintroduce a stale-payload read. The `isAgentConnected === false` branch had no coverage anywhere in the repo.

Security pass returned **no CRITICAL/HIGH/MEDIUM findings**: no remaining path lets `data.orgId` influence credential selection or the delivery target, the guard can't be bypassed (`snmp_devices.org_id` is `NOT NULL`, strict `!==`, missing payload org fails closed), the throw is confirmed outside the phase-1 transaction, and no other SNMP dispatch path shares the two-source shape (`buildSnmpPollCommand` has exactly one caller; `monitorWorker` already sources org from its live row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

