### PR TITLE
fix(ai): resolve remediate_vulnerability's org from the device, not accessibleOrgIds[0] (#3322)

### DIFF
--- a/apps/api/src/routes/vulnerabilities.ts
+++ b/apps/api/src/routes/vulnerabilities.ts
@@ -773,10 +773,10 @@ vulnerabilityRoutes.post(
   async (c) => {
     const auth = c.get('auth');
     const { deviceVulnerabilityIds } = c.req.valid('json');
-    // Org-scope callers pass their org; partner/system callers pass '' so the
+    // Org-scope callers pass their org; partner/system callers pass null so the
     // core derives the org per-device (auth.orgId is null off org scope).
     const result = await remediateVulnerabilities(
-      auth.orgId ?? '',
+      auth.orgId,
       deviceVulnerabilityIds,
       auth.user.id,
       auth,

--- a/apps/api/src/services/aiToolsVulnerability.test.ts
+++ b/apps/api/src/services/aiToolsVulnerability.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { VULN_SKIP_REASON_LABELS } from '@breeze/shared';
 
@@ -23,6 +23,13 @@ const fakeAuthCtx = {
 } as unknown as AuthContext;
 
 describe('registerVulnerabilityTools', () => {
+  // Each spy below is restored inline, but an assertion that throws skips its
+  // own `mockRestore()` and leaks the spy's call history into the next test —
+  // which turns one real regression into a cascade of misleading failures.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('registers the two read tools as tier 1', () => {
     const map = registered();
     expect(map.get('get_vulnerability_report')!.tier).toBe(1);

--- a/apps/api/src/services/aiToolsVulnerability.test.ts
+++ b/apps/api/src/services/aiToolsVulnerability.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { VULN_SKIP_REASON_LABELS } from '@breeze/shared';
+
 import { registerVulnerabilityTools } from './aiToolsVulnerability';
 import { TOOL_PERMISSIONS } from './aiGuardrails';
 import { toolInputSchemas } from './aiToolSchemas';
@@ -43,6 +45,91 @@ describe('registerVulnerabilityTools', () => {
     const out = await registered().get('remediate_vulnerability')!.handler({ deviceVulnerabilityIds: ['dv1'] }, fakeAuthCtx);
     expect(spy).toHaveBeenCalledWith('org1', ['dv1'], expect.anything(), fakeAuthCtx);
     expect(JSON.parse(out)).toMatchObject({ scheduled: 1 });
+    spy.mockRestore();
+  });
+
+  // #3322 — a partner-scope chat session has no home org. The handler used to
+  // pass `accessibleOrgIds[0]`, which pinned every remediation to an arbitrary
+  // org and made the core skip any device in a sibling org as
+  // `device_not_found` ("Scheduled 0; 1 skipped", no audit row).
+  it('forwards null (never accessibleOrgIds[0]) for a partner-scope caller with no org pin', async () => {
+    const partnerAuth = {
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: ['orgA', 'orgB'],
+      user: { id: 'user1', email: 'u@example.com' },
+      token: { roleId: null },
+    } as unknown as AuthContext;
+    const spy = vi
+      .spyOn(remediationService, 'remediateVulnerabilities')
+      .mockResolvedValue({ scheduled: 1, skipped: [] });
+
+    const out = await registered().get('remediate_vulnerability')!.handler({ deviceVulnerabilityIds: ['dv1'] }, partnerAuth);
+
+    expect(spy).toHaveBeenCalledWith(null, ['dv1'], 'user1', partnerAuth);
+    expect(spy.mock.calls[0]![0]).not.toBe('orgA');
+    expect(JSON.parse(out)).toMatchObject({ scheduled: 1 });
+    spy.mockRestore();
+  });
+
+  it('forwards null for a system-scope caller (accessibleOrgIds === null)', async () => {
+    const systemAuth = {
+      scope: 'system',
+      orgId: null,
+      accessibleOrgIds: null,
+      user: { id: 'user1', email: 'u@example.com' },
+      token: { roleId: null },
+    } as unknown as AuthContext;
+    const spy = vi
+      .spyOn(remediationService, 'remediateVulnerabilities')
+      .mockResolvedValue({ scheduled: 1, skipped: [] });
+
+    await registered().get('remediate_vulnerability')!.handler({ deviceVulnerabilityIds: ['dv1'] }, systemAuth);
+
+    expect(spy).toHaveBeenCalledWith(null, ['dv1'], 'user1', systemAuth);
+    spy.mockRestore();
+  });
+
+  it('refuses when the caller has neither an org pin nor any reachable org', async () => {
+    const strandedAuth = {
+      scope: 'partner',
+      orgId: null,
+      accessibleOrgIds: [],
+      user: { id: 'user1', email: 'u@example.com' },
+      token: { roleId: null },
+    } as unknown as AuthContext;
+    const spy = vi.spyOn(remediationService, 'remediateVulnerabilities');
+
+    const out = await registered().get('remediate_vulnerability')!.handler({ deviceVulnerabilityIds: ['dv1'] }, strandedAuth);
+
+    expect(JSON.parse(out)).toMatchObject({ error: 'No organization context available' });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  // A bare "N skipped" reads as a benign no-op, so the model narrated the
+  // #3322 failure as if it had succeeded. The reasons belong in the sentence.
+  it('names the distinct skip reasons in the message so a total no-op cannot read as success', async () => {
+    const spy = vi.spyOn(remediationService, 'remediateVulnerabilities').mockResolvedValue({
+      scheduled: 0,
+      skipped: [
+        { id: 'dv1', reason: 'device_not_found' },
+        { id: 'dv2', reason: 'device_not_found' },
+        { id: 'dv3', reason: 'patch_not_approved' },
+      ],
+    });
+
+    const body = JSON.parse(
+      await registered().get('remediate_vulnerability')!.handler({ deviceVulnerabilityIds: ['dv1', 'dv2', 'dv3'] }, fakeAuthCtx),
+    );
+
+    expect(body.scheduled).toBe(0);
+    expect(body.skipped).toHaveLength(3);
+    // Distinct reasons only — not one repeat per finding.
+    expect(body.message).toContain('3 skipped');
+    expect(body.message).toContain(VULN_SKIP_REASON_LABELS.device_not_found);
+    expect(body.message).toContain(VULN_SKIP_REASON_LABELS.patch_not_approved);
+    expect(body.message.match(new RegExp(VULN_SKIP_REASON_LABELS.device_not_found, 'g'))).toHaveLength(1);
     spy.mockRestore();
   });
 

--- a/apps/api/src/services/aiToolsVulnerability.ts
+++ b/apps/api/src/services/aiToolsVulnerability.ts
@@ -5,12 +5,21 @@
  * - get_device_vulnerabilities (Tier 1): one device's findings
  * - remediate_vulnerability (Tier 3): schedule the fixing patch (approval-gated)
  *
- * Handlers run on the SDK/stream path OUTSIDE the request's AsyncLocalStorage DB
- * context, so each device-vulnerability read is wrapped in an org-scoped
- * `withDbAccessContext` — otherwise RLS silently returns 0 rows
+ * Each device-vulnerability read is wrapped in a `withDbAccessContext` so it can
+ * never run context-free — RLS would silently return 0 rows
  * (`[[rls_silent_zero_row_read_sdk_poll]]`). The `vulnerabilities` catalog is a
  * GLOBAL system-only table, so its rows are read in a separate system-context
  * step (`[[rls_partner_axis_read_needs_system_context]]` two-step pattern).
+ *
+ * NOTE on `readDeviceFindings`' single-org context: every live entry point wraps
+ * `executeTool` in `withDbAccessContext(dbAccessContextFromAuth(auth))`
+ * (aiAgentSdkTools.ts, scriptBuilderTools.ts) and the MCP path runs inside the
+ * request context, so that inner wrap is a NO-OP in practice —
+ * `withDbAccessContext` returns `fn()` untouched when a context is already open
+ * (db/index.ts). It is a context-free safety net, NOT a narrowing: the reads
+ * really do see every org the caller can reach, which is what a partner-scope
+ * chat needs. Do not "fix" it into a genuine single-org scope — that would
+ * black out sibling orgs exactly the way #3322 did on the write path.
  */
 
 import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';

--- a/apps/api/src/services/aiToolsVulnerability.ts
+++ b/apps/api/src/services/aiToolsVulnerability.ts
@@ -275,8 +275,25 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
     },
     handler: async (input: Record<string, unknown>, auth: AuthContext) => {
       try {
-        const orgId = getOrgId(auth);
-        if (!orgId) return JSON.stringify({ error: 'No organization context available' });
+        // Pass the caller's REAL org pin — never `getOrgId`'s
+        // `accessibleOrgIds[0]` fallback (#3322). A partner-scope chat session
+        // has no home org, so that fallback pinned every remediation to
+        // whichever org happened to sort first and the core then rejected any
+        // device in a sibling org as `device_not_found` — the tool reported
+        // "Scheduled 0; 1 skipped" and wrote no audit row at all. `null` tells
+        // the core to derive each finding's org from its OWN device, which is
+        // also the org its audit row and domain event are attributed to.
+        // Isolation is unchanged: `auth.orgCondition` + RLS still bound the
+        // caller to their accessible orgs, so this narrows nothing and widens
+        // nothing — it just stops discarding orgs the caller can already reach.
+        const pinnedOrgId = auth.orgId ?? null;
+        // Org-scope callers must carry a concrete org; partner/system callers
+        // legitimately have none, but must still reach at least one org.
+        const reachesAnyOrg =
+          auth.accessibleOrgIds === null || (auth.accessibleOrgIds?.length ?? 0) > 0;
+        if (!pinnedOrgId && !reachesAnyOrg) {
+          return JSON.stringify({ error: 'No organization context available' });
+        }
         const actorUserId = getActorUserId(auth);
         if (!actorUserId) return JSON.stringify({ error: 'No acting user in context' });
         const ids = Array.isArray(input.deviceVulnerabilityIds) ? (input.deviceVulnerabilityIds as string[]) : [];
@@ -284,15 +301,23 @@ export function registerVulnerabilityTools(aiTools: Map<string, AiTool>): void {
 
         // Context-free Phase-3 core: it runs its own org+site authz + audit off
         // `auth` (no Hono Context on the SDK path), so forward this handler's auth.
-        const result = await remediationService.remediateVulnerabilities(orgId, ids, actorUserId, auth);
+        const result = await remediationService.remediateVulnerabilities(pinnedOrgId, ids, actorUserId, auth);
+        // Map the machine-readable skip codes to human prose for the LLM/user.
+        const skipped = result.skipped.map((s) => ({
+          id: s.id,
+          reason: VULN_SKIP_REASON_LABELS[s.reason] ?? s.reason,
+        }));
+        // Name the distinct reasons in the message itself: a bare
+        // "N skipped" reads as a benign no-op and the model narrated it as
+        // success. Whatever went wrong must be visible in the sentence.
+        const reasons = [...new Set(skipped.map((s) => s.reason))];
         return JSON.stringify({
           scheduled: result.scheduled,
-          // Map the machine-readable skip codes to human prose for the LLM/user.
-          skipped: result.skipped.map((s) => ({
-            id: s.id,
-            reason: VULN_SKIP_REASON_LABELS[s.reason] ?? s.reason,
-          })),
-          message: `Scheduled ${result.scheduled} remediation(s); ${result.skipped.length} skipped.`,
+          skipped,
+          message:
+            skipped.length > 0
+              ? `Scheduled ${result.scheduled} remediation(s); ${skipped.length} skipped — ${reasons.join('; ')}.`
+              : `Scheduled ${result.scheduled} remediation(s); 0 skipped.`,
         });
       } catch (err) {
         const message = sanitizeThrownToolError('vulnerability', err);

--- a/apps/api/src/services/vulnerabilityRemediation.test.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.test.ts
@@ -182,3 +182,85 @@ describe('remediateVulnerabilities — cross-org pin (#3322)', () => {
     expect(vi.mocked(createAuditLogAsync)).not.toHaveBeenCalled();
   });
 });
+
+describe('remediateVulnerabilities — invisible vs. already-resolved findings', () => {
+  beforeEach(() => {
+    vi.mocked(queueCommandForExecution).mockClear();
+    stub.queued.clear();
+  });
+
+  it('reports a finding the caller cannot see as not_found, not "already resolved"', async () => {
+    // No deviceVulnerabilities rows queued: the id does not exist, or RLS hides
+    // it because it belongs to a tenant outside the caller's reach.
+    const result = await remediateVulnerabilities(null, [DV1], 'user-1', partnerAuth());
+
+    expect(result).toEqual({ scheduled: 0, skipped: [{ id: DV1, reason: 'not_found' }] });
+    expect(vi.mocked(queueCommandForExecution)).not.toHaveBeenCalled();
+  });
+
+  it('still reports a genuinely resolved finding as not_open', async () => {
+    stub.queued.set(deviceVulnerabilities, [
+      [{ id: DV1, deviceId: DEVICE_B, vulnerabilityId: 'vuln-1', softwareInventoryId: null, status: 'patched' }],
+    ]);
+
+    const result = await remediateVulnerabilities(null, [DV1], 'user-1', partnerAuth());
+
+    expect(result).toEqual({ scheduled: 0, skipped: [{ id: DV1, reason: 'not_open' }] });
+  });
+});
+
+describe('remediateVulnerabilities — one batch spanning two orgs', () => {
+  const DEVICE_A = '66666666-6666-6666-6666-666666666666';
+  const DV2 = '77777777-7777-7777-7777-777777777777';
+  const PATCH_2 = '88888888-8888-8888-8888-888888888888';
+
+  beforeEach(() => {
+    vi.mocked(queueCommandForExecution).mockClear();
+    vi.mocked(createAuditLogAsync).mockClear();
+    vi.mocked(publishEvent).mockClear();
+    stub.queued.clear();
+    // Two findings, two orgs, ONE call — the real shape of a partner-scope
+    // "remediate this CVE across the fleet" request. Each table's FIFO is
+    // consumed once per loop iteration, in finding order.
+    stub.queued.set(deviceVulnerabilities, [
+      [{ id: DV1, deviceId: DEVICE_A, vulnerabilityId: 'vuln-1', softwareInventoryId: null, status: 'open' }],
+      [{ id: DV2, deviceId: DEVICE_B, vulnerabilityId: 'vuln-1', softwareInventoryId: null, status: 'open' }],
+    ]);
+    stub.queued.set(vulnerabilities, [[{ cveId: 'CVE-2025-6554' }], [{ cveId: 'CVE-2025-6554' }]]);
+    stub.queued.set(devices, [
+      [{ id: DEVICE_A, siteId: null, orgId: ORG_A, osType: 'windows' }],
+      [{ id: DEVICE_B, siteId: null, orgId: ORG_B, osType: 'windows' }],
+    ]);
+    stub.queued.set(patches, [[{ patchId: PATCH_1 }], [{ patchId: PATCH_2 }]]);
+    stub.queued.set(patchApprovals, [[{ patchId: PATCH_1 }], [{ patchId: PATCH_2 }]]);
+  });
+
+  it('remediates both findings and re-tenants each audit row to its OWN device org', async () => {
+    const result = await remediateVulnerabilities(null, [DV1, DV2], 'user-1', partnerAuth());
+
+    expect(result).toEqual({ scheduled: 2, skipped: [] });
+    // Worker/child rows take the DEVICE's org — never one org for the batch.
+    const auditOrgs = vi.mocked(createAuditLogAsync).mock.calls.map((c) => (c[0] as { orgId: string }).orgId);
+    expect(auditOrgs).toEqual([ORG_A, ORG_B]);
+    const eventOrgs = vi.mocked(publishEvent).mock.calls.map((c) => c[1]);
+    expect(eventOrgs).toEqual([ORG_A, ORG_B]);
+  });
+});
+
+describe('remediateVulnerabilities — site axis survives a null org pin', () => {
+  beforeEach(() => {
+    vi.mocked(queueCommandForExecution).mockClear();
+    queueRemediableFindingInOrgB();
+  });
+
+  it('still denies a device outside the caller site allowlist when pinnedOrgId is null', async () => {
+    // Dropping the org pin must not also drop the intra-org SITE gate.
+    const result = await remediateVulnerabilities(null, [DV1], 'user-1', {
+      ...partnerAuth(),
+      canAccessSite: () => false,
+    } as unknown as AuthContext);
+
+    expect(result).toEqual({ scheduled: 0, skipped: [{ id: DV1, reason: 'site_access_denied' }] });
+    expect(vi.mocked(queueCommandForExecution)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/vulnerabilityRemediation.test.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.test.ts
@@ -1,14 +1,56 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// The service opens a pooled connection at import; stub it so this pure-logic
-// unit test needs no database.
+// The service opens a pooled connection at import; stub it so these unit tests
+// need no database. `queued` maps a Drizzle table object to a FIFO of result
+// rows: each `db.select().from(<table>)…` chain resolves to that table's next
+// queued batch (or `[]`). Deliberately ignores the WHERE clause — RLS and the
+// `orgCondition` filter cannot be exercised without a real database (that is
+// what the RLS/integration suites are for), so these tests target the one thing
+// that IS pure application logic: the `pinnedOrgId` gate.
+const stub = vi.hoisted(() => {
+  const queued = new Map<unknown, unknown[][]>();
+  const makeChain = () => {
+    let table: unknown;
+    const chain: Record<string, unknown> = {};
+    for (const method of ['from', 'innerJoin', 'where', 'orderBy', 'limit']) {
+      chain[method] = (arg: unknown) => {
+        if (method === 'from') table = arg;
+        return chain;
+      };
+    }
+    chain.then = (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(queued.get(table)?.shift() ?? []).then(resolve, reject);
+    return chain;
+  };
+  return { queued, db: { select: () => makeChain() } };
+});
+
 vi.mock('../db', () => ({
-  db: {},
+  db: stub.db,
   runOutsideDbContext: (fn: () => unknown) => fn(),
   withSystemDbAccessContext: (fn: () => unknown) => fn(),
 }));
+vi.mock('../routes/patches/helpers', () => ({
+  resolvePartnerIdForOrg: vi.fn(async () => 'partner-1'),
+}));
+vi.mock('./commandQueue', () => ({
+  queueCommandForExecution: vi.fn(async () => ({ command: { id: 'cmd-1' } })),
+}));
+vi.mock('./auditService', () => ({ createAuditLogAsync: vi.fn() }));
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn(async () => undefined) }));
 
-import { packageIdNamesVendor } from './vulnerabilityRemediation';
+import { packageIdNamesVendor, remediateVulnerabilities } from './vulnerabilityRemediation';
+import {
+  deviceVulnerabilities,
+  patchApprovals,
+  patches,
+  devices,
+  vulnerabilities,
+} from '../db/schema';
+import { createAuditLogAsync } from './auditService';
+import { publishEvent } from './eventBus';
+import { queueCommandForExecution } from './commandQueue';
+import type { AuthContext } from '../middleware/auth';
 
 describe('packageIdNamesVendor — vendor-stripped fallback corroboration', () => {
   it('corroborates a winget packageId whose publisher is the inventory vendor', () => {
@@ -50,5 +92,93 @@ describe('packageIdNamesVendor — vendor-stripped fallback corroboration', () =
   it('handles apt-style and hyphenated packageIds', () => {
     expect(packageIdNamesVendor('apt:openssl', 'openssl')).toBe(true);
     expect(packageIdNamesVendor('apt:openssl', 'adobe')).toBe(false);
+  });
+});
+
+// ============================================================================
+// #3322 — the `pinnedOrgId` gate must not discard orgs the caller can reach
+// ============================================================================
+
+const ORG_A = '11111111-1111-1111-1111-111111111111';
+const ORG_B = '22222222-2222-2222-2222-222222222222';
+const DEVICE_B = '33333333-3333-3333-3333-333333333333';
+const DV1 = '44444444-4444-4444-4444-444444444444';
+const PATCH_1 = '55555555-5555-5555-5555-555555555555';
+
+/** Queue the rows for one fully-remediable finding on a device in ORG_B. */
+function queueRemediableFindingInOrgB(): void {
+  stub.queued.clear();
+  stub.queued.set(deviceVulnerabilities, [
+    [{ id: DV1, deviceId: DEVICE_B, vulnerabilityId: 'vuln-1', softwareInventoryId: null, status: 'open' }],
+  ]);
+  stub.queued.set(vulnerabilities, [[{ cveId: 'CVE-2025-6554' }]]);
+  stub.queued.set(devices, [[{ id: DEVICE_B, siteId: null, orgId: ORG_B, osType: 'windows' }]]);
+  stub.queued.set(patches, [[{ patchId: PATCH_1 }]]);
+  stub.queued.set(patchApprovals, [[{ patchId: PATCH_1 }]]);
+}
+
+/** Partner-scope auth: no home org, both orgs reachable (the #3322 shape). */
+function partnerAuth(): AuthContext {
+  return {
+    scope: 'partner',
+    orgId: null,
+    accessibleOrgIds: [ORG_A, ORG_B],
+    orgCondition: () => undefined,
+    canAccessOrg: (id: string) => [ORG_A, ORG_B].includes(id),
+    canAccessSite: () => true,
+    user: { id: 'user-1', email: 'tech@msp.example' },
+  } as unknown as AuthContext;
+}
+
+describe('remediateVulnerabilities — cross-org pin (#3322)', () => {
+  beforeEach(() => {
+    vi.mocked(queueCommandForExecution).mockClear();
+    vi.mocked(createAuditLogAsync).mockClear();
+    vi.mocked(publishEvent).mockClear();
+    queueRemediableFindingInOrgB();
+  });
+
+  it('remediates a device outside the first accessible org when the caller has no org pin', async () => {
+    const result = await remediateVulnerabilities(null, [DV1], 'user-1', partnerAuth());
+
+    // Before the fix the AI tool passed accessibleOrgIds[0] (ORG_A) here, and
+    // the device's ORG_B failed the pin check — "Scheduled 0; 1 skipped".
+    expect(result).toEqual({ scheduled: 1, skipped: [] });
+    expect(vi.mocked(queueCommandForExecution)).toHaveBeenCalledWith(
+      DEVICE_B,
+      'install_patches',
+      { patchIds: [PATCH_1] },
+      expect.objectContaining({ userId: 'user-1' }),
+    );
+  });
+
+  it("attributes the audit row and the domain event to the DEVICE's org, not the caller's first org", async () => {
+    await remediateVulnerabilities(null, [DV1], 'user-1', partnerAuth());
+
+    expect(vi.mocked(createAuditLogAsync)).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: ORG_B, action: 'vulnerability.remediate', resourceId: DV1 }),
+    );
+    expect(vi.mocked(publishEvent)).toHaveBeenCalledWith(
+      'vulnerability.remediation_scheduled',
+      ORG_B,
+      expect.objectContaining({ deviceId: DEVICE_B }),
+      'vulnerabilityRemediation',
+      expect.anything(),
+    );
+  });
+
+  it('still enforces a REAL org pin: an org-scoped caller cannot reach a device in another org', async () => {
+    const result = await remediateVulnerabilities(ORG_A, [DV1], 'user-1', {
+      ...partnerAuth(),
+      scope: 'organization',
+      orgId: ORG_A,
+      accessibleOrgIds: [ORG_A],
+    } as unknown as AuthContext);
+
+    // The pin is defense-in-depth on top of RLS and must survive the fix: a
+    // caller who really IS pinned to ORG_A gets no reach into ORG_B.
+    expect(result).toEqual({ scheduled: 0, skipped: [{ id: DV1, reason: 'device_not_found' }] });
+    expect(vi.mocked(queueCommandForExecution)).not.toHaveBeenCalled();
+    expect(vi.mocked(createAuditLogAsync)).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/services/vulnerabilityRemediation.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.ts
@@ -294,7 +294,16 @@ export async function remediateVulnerabilities(
       .from(deviceVulnerabilities)
       .where(eq(deviceVulnerabilities.id, dvId))
       .limit(1);
-    if (!row || row.status !== 'open') {
+    // Distinguish "you cannot see this finding" from "it is already resolved".
+    // A missing row means the id does not exist OR belongs to a tenant this
+    // caller cannot reach; reporting that as `not_open` ("not an open
+    // vulnerability") told the operator the work was already done — the same
+    // class of misleading no-op as #3322 itself.
+    if (!row) {
+      result.skipped.push({ id: dvId, reason: 'not_found' });
+      continue;
+    }
+    if (row.status !== 'open') {
       result.skipped.push({ id: dvId, reason: 'not_open' });
       continue;
     }

--- a/apps/api/src/services/vulnerabilityRemediation.ts
+++ b/apps/api/src/services/vulnerabilityRemediation.ts
@@ -260,9 +260,20 @@ async function windowsOsUpdateCandidates(deviceId: string): Promise<Array<{ patc
  * — which has no Hono `Context` — can call it: it takes an `AuthContext` (not a
  * Hono `Context`) and runs the org+site authz + audit directly off `auth`. RLS
  * isolates orgs; the intra-org SITE axis is enforced here via `auth.canAccessSite`.
+ *
+ * `pinnedOrgId` is the caller's OWN org pin, and it is only ever a
+ * defense-in-depth narrowing on top of RLS — never a source of reach:
+ * - organization scope → `auth.orgId`; a finding on a device outside it is
+ *   skipped as `device_not_found`.
+ * - partner / system scope → `null`. These callers have no home org, so each
+ *   finding's org is derived from its OWN device (which is also the org the
+ *   audit row and the domain event are attributed to). Passing a guessed org
+ *   here — e.g. `accessibleOrgIds[0]` — silently no-ops every device in a
+ *   sibling org, which is exactly what #3322 was.
+ * Never pass an org the caller did not actually pin.
  */
 export async function remediateVulnerabilities(
-  orgId: string,
+  pinnedOrgId: string | null,
   deviceVulnerabilityIds: string[],
   actorUserId: string,
   auth: AuthContext,
@@ -321,9 +332,9 @@ export async function remediateVulnerabilities(
       continue;
     }
     // Defense in depth: an org-scoped caller's device must match their org (RLS
-    // already guarantees this; partner/system callers pass an empty orgId and
-    // rely on orgCondition + RLS).
-    if (orgId && device.orgId !== orgId) {
+    // already guarantees this; partner/system callers pass a null pin and rely
+    // on orgCondition + RLS).
+    if (pinnedOrgId && device.orgId !== pinnedOrgId) {
       result.skipped.push({ id: dvId, reason: 'device_not_found' });
       continue;
     }


### PR DESCRIPTION
## Problem

In a **partner-scope** AI chat session the caller has no home org (`auth.orgId` is null). `remediate_vulnerability` fell back to `auth.accessibleOrgIds[0]` and passed that arbitrary org into `remediateVulnerabilities`, whose defense-in-depth pin check

```ts
if (orgId && device.orgId !== orgId) { result.skipped.push({ id: dvId, reason: 'device_not_found' }); continue; }
```

then rejected **every device outside whichever org happened to sort first**. The Tier-3 approval was granted, the tool answered `Scheduled 0; 1 skipped`, no command was queued — and because the skip happens before step 6, **no audit row was written at all**, so an org-filtered audit view showed no trace of the AI action.

## Root cause

The core was already correct for org-less callers. It derives each finding's org from its **own device** and attributes both the `vulnerability.remediate` audit row and the `vulnerability.remediation_scheduled` domain event to `device.orgId`. `POST /vulnerabilities/remediate` already opted into that by passing `auth.orgId ?? ''`. The AI tool was the only caller that *guessed* an org.

## Fix

- **`services/aiToolsVulnerability.ts`** — pass `auth.orgId ?? null` (the caller's **real** pin) instead of `getOrgId`'s `accessibleOrgIds[0]` fallback. Org-scope callers still pin to their org; partner/system callers pass `null` and the core resolves per device. The guard now refuses only a caller with neither an org pin nor any reachable org.
- **`services/vulnerabilityRemediation.ts`** — parameter renamed to `pinnedOrgId: string | null` with the contract documented, replacing the `''` sentinel so "derive per device" is explicit and a future caller cannot pass a guessed org by accident.
- **`routes/vulnerabilities.ts`** — passes `auth.orgId` directly now that `null` is the signal.
- The tool's `message` now names the **distinct skip reasons**. A bare "N skipped" read as a benign no-op and the model narrated this exact failure as success.

### Tenant isolation

This **widens nothing**. Reach is still bounded by `auth.orgCondition(devices.orgId)` (an `IN`-list over `accessibleOrgIds` for partner scope) plus RLS on the `withDbAccessContext` the SDK tool path opens from `dbAccessContextFromAuth(auth)`. The change only stops discarding orgs the caller can *already* reach. The org pin remains enforced for callers who genuinely have one — covered by a test. Worker/child rows (audit, event) continue to take the **device's** org, per the fan-out rule in CLAUDE.md.

No schema, migration, or cascade/export-policy surface is touched.

## Tests

`services/vulnerabilityRemediation.test.ts` gains a table-keyed Drizzle chain stub and three cases:
- a null-pin caller remediates a device in the **second** accessible org (the regression);
- audit row + domain event are attributed to the **device's** org;
- an org-scoped caller pinned to Org A still gets `device_not_found` for an Org B device, and queues/audits nothing.

`services/aiToolsVulnerability.test.ts` adds partner-scope and system-scope null-forwarding, the stranded-caller refusal, and the distinct-skip-reason message.

```
vitest run --no-file-parallelism src/services/aiToolsVulnerability.test.ts src/services/vulnerabilityRemediation.test.ts   → 25 passed
vitest run --no-file-parallelism src/routes/vulnerabilities.test.ts                                                        → 58 passed
tsc --noEmit                                                                                                               → clean
```

## Out of scope

`ai_sessions` / `ai_tool_executions` stay under the **session** org — a partner chat session legitimately spans orgs, and re-anchoring the session ledger per tool call is a separate design question. The domain audit row, which is what an org-filtered audit view reads, is now correct.

Closes #3322

🤖 Generated with [Claude Code](https://claude.com/claude-code)