### PR TITLE
fix(api): stop binding raw JS Dates into hand-written sql templates (#3369)

### DIFF
--- a/apps/api/src/__tests__/integration/sqlTemplateDateBinding.integration.test.ts
+++ b/apps/api/src/__tests__/integration/sqlTemplateDateBinding.integration.test.ts
@@ -31,14 +31,14 @@
  */
 import './setup';
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 import { getTestDb } from './setup';
 import { createOrganization, createPartner, createSite, createUser } from './db-utils';
 import { withSystemDbAccessContext } from '../../db';
 import { devices, oauthRevocationRetries } from '../../db/schema';
-import { evaluateFilter } from '../../services/filterEngine';
+import { buildConditionSQL, evaluateFilter } from '../../services/filterEngine';
 import { buildRetryConflictUpdate } from '../../oauth/revocationRetry';
 
 // Deliberately spread across a day so a session-time-zone shift of a few hours
@@ -143,41 +143,53 @@ describe('filterEngine datetime predicates — real Postgres (#3369)', () => {
 
   it('gives identical results under a non-UTC session time zone', async () => {
     // `devices.last_seen_at` is `timestamp` WITHOUT time zone, holding UTC wall
-    // clock by Drizzle convention. Had the parameter been cast `::timestamptz`,
-    // Postgres would coerce the naive column *in the session zone* — under
-    // Pacific/Kiritimati (UTC+14) the T2 device (22:00Z) would fall outside the
-    // window below and this assertion would drop it. A silent, deployment-
-    // dependent wrong answer is worse than the TypeError being fixed, so it
-    // gets its own guard.
+    // clock by Drizzle convention. Had the bound parameter been cast
+    // `::timestamptz`, Postgres would coerce the naive column *in the session
+    // zone* — under Pacific/Kiritimati (UTC+14) the T2 device (22:00Z) shifts
+    // to the 16th local and falls outside the window below. A silent,
+    // deployment-dependent wrong answer is worse than the TypeError being
+    // fixed, so the no-cast decision gets its own guard.
+    //
+    // The predicate is run directly rather than through `evaluateFilter`, and
+    // the time zone is set with `SET LOCAL` inside the same transaction as the
+    // query. `getTestDb()` and the application `db` pool (`src/db/index.ts`)
+    // are SEPARATE postgres.js pools on separate connections, so a plain `SET`
+    // on one would not reach a query issued on the other and this guard would
+    // pass vacuously. What is under test here is the SQL `buildConditionSQL`
+    // emits, which is exactly what this asserts.
     const { org, seeded } = await seedOrgWithDevices();
 
-    const run = () =>
-      evaluateFilter(
-        {
-          operator: 'AND',
-          conditions: [
-            {
-              field: 'lastSeenAt',
-              operator: 'between',
-              value: {
-                from: new Date('2026-03-15T06:00:00.000Z'),
-                to: new Date('2026-03-16T00:00:00.000Z'),
-              },
-            },
-          ],
-        },
-        { orgId: org.id },
-      );
+    const predicate = buildConditionSQL({
+      field: 'lastSeenAt',
+      operator: 'between',
+      value: {
+        from: new Date('2026-03-15T06:00:00.000Z'),
+        to: new Date('2026-03-16T00:00:00.000Z'),
+      },
+    });
 
-    const db = getTestDb();
-    const previous = (await db.execute(`SHOW TimeZone`)) as unknown as Array<{ TimeZone: string }>;
-    try {
-      await db.execute(`SET TimeZone = 'Pacific/Kiritimati'`);
-      const shifted = await withSystemDbAccessContext(run);
-      expect([...shifted.deviceIds].sort()).toEqual(idsFor(seeded, [T1, T2]));
-    } finally {
-      await db.execute(`SET TimeZone = '${previous[0]?.TimeZone ?? 'UTC'}'`);
-    }
+    const rowsIn = async (timeZone: string) =>
+      getTestDb().transaction(async (tx) => {
+        // SET LOCAL is transaction-scoped, so it cannot leak into another test.
+        await tx.execute(sql`SET LOCAL TimeZone = ${sql.raw(`'${timeZone}'`)}`);
+        const found = await tx
+          .select({ id: devices.id })
+          .from(devices)
+          .where(and(eq(devices.orgId, org.id), predicate));
+        return found.map((r) => r.id).sort();
+      });
+
+    // Sanity: the zone really is being applied inside the transaction. Without
+    // this, a silently ignored SET would make the comparison below meaningless.
+    const applied = await getTestDb().transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL TimeZone = 'Pacific/Kiritimati'`);
+      const shown = (await tx.execute(sql`SHOW TimeZone`)) as unknown as Array<{ TimeZone: string }>;
+      return shown[0]?.TimeZone;
+    });
+    expect(applied).toBe('Pacific/Kiritimati');
+
+    expect(await rowsIn('UTC')).toEqual(idsFor(seeded, [T1, T2]));
+    expect(await rowsIn('Pacific/Kiritimati')).toEqual(idsFor(seeded, [T1, T2]));
   });
 });
 

--- a/apps/api/src/__tests__/integration/sqlTemplateDateBinding.integration.test.ts
+++ b/apps/api/src/__tests__/integration/sqlTemplateDateBinding.integration.test.ts
@@ -31,7 +31,7 @@
  */
 import './setup';
 
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, isNull, sql } from 'drizzle-orm';
 import { describe, expect, it } from 'vitest';
 
 import { getTestDb } from './setup';
@@ -250,6 +250,11 @@ describe('oauth revocation retry conflict branch — real Postgres (#3369)', () 
       })
       .onConflictDoUpdate({
         target: [oauthRevocationRetries.markerType, oauthRevocationRetries.markerId],
+        // The unique index is PARTIAL (`WHERE completed_at IS NULL`), so the
+        // predicate is required for Postgres to infer the arbiter index —
+        // without it the statement fails 42P10 before the SET list is ever
+        // evaluated. Mirrors `writeOAuthRevocationMarkerDurably`.
+        targetWhere: isNull(oauthRevocationRetries.completedAt),
         set: buildRetryConflictUpdate({
           attemptedAt,
           expiresAt: new Date('2026-03-15T14:00:00.000Z'),
@@ -290,6 +295,11 @@ describe('oauth revocation retry conflict branch — real Postgres (#3369)', () 
       })
       .onConflictDoUpdate({
         target: [oauthRevocationRetries.markerType, oauthRevocationRetries.markerId],
+        // The unique index is PARTIAL (`WHERE completed_at IS NULL`), so the
+        // predicate is required for Postgres to infer the arbiter index —
+        // without it the statement fails 42P10 before the SET list is ever
+        // evaluated. Mirrors `writeOAuthRevocationMarkerDurably`.
+        targetWhere: isNull(oauthRevocationRetries.completedAt),
         set: buildRetryConflictUpdate({
           attemptedAt,
           expiresAt: new Date('2026-03-15T15:00:00.000Z'),

--- a/apps/api/src/__tests__/integration/sqlTemplateDateBinding.integration.test.ts
+++ b/apps/api/src/__tests__/integration/sqlTemplateDateBinding.integration.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Integration test — JS `Date` values bound into hand-written Drizzle `sql`
+ * templates, against real Postgres (regression guard for #3369).
+ *
+ * A bare value inside a `sql` template is wrapped in a `Param` carrying the
+ * NOOP encoder, so the untouched JS object is handed to postgres.js and its
+ * Bind step throws `ERR_INVALID_ARG_TYPE ... Received an instance of Date`.
+ * **No mock reproduces this** — the failure lives in the driver's own type
+ * coercion, not in Drizzle's query building or in application logic. The unit
+ * guards alongside each fixed site assert "no param is a `Date`"; only this
+ * file proves the statements Postgres actually receives are well-typed and
+ * return the right rows.
+ *
+ * Two things are proven here that a rendered-SQL assertion cannot:
+ *
+ *   1. `filterEngine` — the uncast ISO parameter compares *correctly* against
+ *      `devices.last_seen_at`, which is `timestamp` WITHOUT time zone. This is
+ *      the half that a blanket `::timestamptz` cast would have broken far more
+ *      quietly than the original bug: Postgres would reinterpret the naive
+ *      column in the session time zone and shift every boundary. The test runs
+ *      the same assertions under a deliberately non-UTC session `TimeZone` to
+ *      catch exactly that.
+ *   2. `oauth/revocationRetry` — the `ON CONFLICT DO UPDATE` branch, which only
+ *      fires when a retry row already exists, really executes: `$1::timestamptz
+ *      + (LEAST(300, POWER(2, attempts)) * interval '1 second')` and
+ *      `GREATEST(expires_at, $2::timestamptz)` both resolve, and the backoff
+ *      and lifetime-extension semantics hold.
+ *
+ * Run:
+ *   pnpm test:integration -- src/__tests__/integration/sqlTemplateDateBinding.integration.test.ts
+ */
+import './setup';
+
+import { and, eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import { getTestDb } from './setup';
+import { createOrganization, createPartner, createSite, createUser } from './db-utils';
+import { withSystemDbAccessContext } from '../../db';
+import { devices, oauthRevocationRetries } from '../../db/schema';
+import { evaluateFilter } from '../../services/filterEngine';
+import { buildRetryConflictUpdate } from '../../oauth/revocationRetry';
+
+// Deliberately spread across a day so a session-time-zone shift of a few hours
+// moves at least one device across the `between` boundary.
+const T0 = new Date('2026-03-15T02:00:00.000Z');
+const T1 = new Date('2026-03-15T12:00:00.000Z');
+const T2 = new Date('2026-03-15T22:00:00.000Z');
+const T3 = new Date('2026-03-16T09:00:00.000Z');
+
+async function seedOrgWithDevices() {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+  const site = await createSite({ orgId: org.id });
+
+  const seeded: Array<{ id: string; lastSeenAt: Date }> = [];
+  for (const [i, lastSeenAt] of [T0, T1, T2, T3].entries()) {
+    const [row] = await getTestDb()
+      .insert(devices)
+      .values({
+        orgId: org.id,
+        siteId: site.id,
+        agentId: `agent-${org.id}-${i}`,
+        hostname: `host-${org.id.slice(0, 8)}-${i}`,
+        osType: 'linux',
+        osVersion: '1.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+        lastSeenAt,
+      })
+      .returning();
+    if (!row) throw new Error('seedOrgWithDevices: device insert returned no row');
+    seeded.push({ id: row.id, lastSeenAt });
+  }
+  return { org, seeded };
+}
+
+const idsFor = (seeded: Array<{ id: string; lastSeenAt: Date }>, times: Date[]) =>
+  seeded.filter((d) => times.some((t) => t.getTime() === d.lastSeenAt.getTime()))
+    .map((d) => d.id)
+    .sort();
+
+describe('filterEngine datetime predicates — real Postgres (#3369)', () => {
+  it('resolves a between filter carrying real Date bounds, and returns exactly the devices inside the range', async () => {
+    const { org, seeded } = await seedOrgWithDevices();
+
+    // THE regression: on the pre-fix code this rejects with
+    // ERR_INVALID_ARG_TYPE from postgres.js's Bind step before Postgres ever
+    // sees the statement.
+    const result = await withSystemDbAccessContext(() =>
+      evaluateFilter(
+        {
+          operator: 'AND',
+          conditions: [
+            {
+              field: 'lastSeenAt',
+              operator: 'between',
+              // Bounds chosen to sit strictly between seeded values so the
+              // inclusive/exclusive edge is not what the assertion depends on.
+              value: {
+                from: new Date('2026-03-15T06:00:00.000Z'),
+                to: new Date('2026-03-16T00:00:00.000Z'),
+              },
+            },
+          ],
+        },
+        { orgId: org.id },
+      ),
+    );
+
+    expect([...result.deviceIds].sort()).toEqual(idsFor(seeded, [T1, T2]));
+  });
+
+  it.each([
+    ['before', new Date('2026-03-15T12:00:00.001Z'), [T0, T1]],
+    ['after', new Date('2026-03-15T12:00:00.000Z'), [T2, T3]],
+  ] as const)('resolves a %s filter and selects the right side of the boundary', async (operator, value, expected) => {
+    const { org, seeded } = await seedOrgWithDevices();
+
+    const result = await withSystemDbAccessContext(() =>
+      evaluateFilter(
+        { operator: 'AND', conditions: [{ field: 'lastSeenAt', operator, value: new Date(value) }] },
+        { orgId: org.id },
+      ),
+    );
+
+    expect([...result.deviceIds].sort()).toEqual(idsFor(seeded, [...expected]));
+  });
+
+  it('matches an exact stored instant, proving millisecond fidelity survives the round trip', async () => {
+    const { org, seeded } = await seedOrgWithDevices();
+
+    const result = await withSystemDbAccessContext(() =>
+      evaluateFilter(
+        { operator: 'AND', conditions: [{ field: 'lastSeenAt', operator: 'equals', value: new Date(T1) }] },
+        { orgId: org.id },
+      ),
+    );
+
+    expect(result.deviceIds).toEqual(idsFor(seeded, [T1]));
+  });
+
+  it('gives identical results under a non-UTC session time zone', async () => {
+    // `devices.last_seen_at` is `timestamp` WITHOUT time zone, holding UTC wall
+    // clock by Drizzle convention. Had the parameter been cast `::timestamptz`,
+    // Postgres would coerce the naive column *in the session zone* — under
+    // Pacific/Kiritimati (UTC+14) the T2 device (22:00Z) would fall outside the
+    // window below and this assertion would drop it. A silent, deployment-
+    // dependent wrong answer is worse than the TypeError being fixed, so it
+    // gets its own guard.
+    const { org, seeded } = await seedOrgWithDevices();
+
+    const run = () =>
+      evaluateFilter(
+        {
+          operator: 'AND',
+          conditions: [
+            {
+              field: 'lastSeenAt',
+              operator: 'between',
+              value: {
+                from: new Date('2026-03-15T06:00:00.000Z'),
+                to: new Date('2026-03-16T00:00:00.000Z'),
+              },
+            },
+          ],
+        },
+        { orgId: org.id },
+      );
+
+    const db = getTestDb();
+    const previous = (await db.execute(`SHOW TimeZone`)) as unknown as Array<{ TimeZone: string }>;
+    try {
+      await db.execute(`SET TimeZone = 'Pacific/Kiritimati'`);
+      const shifted = await withSystemDbAccessContext(run);
+      expect([...shifted.deviceIds].sort()).toEqual(idsFor(seeded, [T1, T2]));
+    } finally {
+      await db.execute(`SET TimeZone = '${previous[0]?.TimeZone ?? 'UTC'}'`);
+    }
+  });
+});
+
+describe('oauth revocation retry conflict branch — real Postgres (#3369)', () => {
+  async function seedRetryRow(opts: { attempts: number; expiresAt: Date; nextAttemptAt: Date }) {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    const user = await createUser({ partnerId: partner.id, orgId: org.id });
+    const markerId = `grant-${user.id}`;
+
+    await getTestDb().insert(oauthRevocationRetries).values({
+      userId: user.id,
+      markerType: 'grant',
+      markerId,
+      expiresAt: opts.expiresAt,
+      attempts: opts.attempts,
+      nextAttemptAt: opts.nextAttemptAt,
+      lastErrorCode: 'redis_unavailable',
+      updatedAt: new Date(),
+    });
+
+    return { user, markerId };
+  }
+
+  const readRow = (userId: string, markerId: string) =>
+    getTestDb()
+      .select()
+      .from(oauthRevocationRetries)
+      .where(and(
+        eq(oauthRevocationRetries.userId, userId),
+        eq(oauthRevocationRetries.markerId, markerId),
+      ));
+
+  it('executes the backoff arithmetic and extends the deadline, rather than throwing at Bind', async () => {
+    const attemptedAt = new Date('2026-03-15T12:00:00.000Z');
+    const existingExpiry = new Date('2026-03-15T13:00:00.000Z');
+    const { user, markerId } = await seedRetryRow({
+      attempts: 3,
+      expiresAt: existingExpiry,
+      nextAttemptAt: new Date('2026-03-15T11:00:00.000Z'),
+    });
+
+    // The whole point of this branch: it only ever runs on a row that already
+    // exists, i.e. only after a Redis write has already failed. On the pre-fix
+    // code the raw Dates threw at Bind, rolling back the worker's entire batch
+    // and leaving the queue permanently undrained during a Redis outage.
+    await getTestDb()
+      .insert(oauthRevocationRetries)
+      .values({
+        userId: user.id,
+        markerType: 'grant',
+        markerId,
+        expiresAt: new Date('2026-03-15T14:00:00.000Z'),
+        attempts: 1,
+        nextAttemptAt: new Date(attemptedAt.getTime() + 1_000),
+        lastErrorCode: 'redis_write_failed',
+        updatedAt: attemptedAt,
+      })
+      .onConflictDoUpdate({
+        target: [oauthRevocationRetries.markerType, oauthRevocationRetries.markerId],
+        set: buildRetryConflictUpdate({
+          attemptedAt,
+          expiresAt: new Date('2026-03-15T14:00:00.000Z'),
+          errorCode: 'redis_write_failed',
+        }),
+      });
+
+    const [row] = await readRow(user.id, markerId);
+    expect(row).toBeDefined();
+    expect(row!.attempts).toBe(4);
+    // Backoff is computed off the PRE-increment attempts (3) => 2^3 = 8s.
+    expect(row!.nextAttemptAt.toISOString()).toBe('2026-03-15T12:00:08.000Z');
+    // GREATEST picked the later of the two deadlines.
+    expect(row!.expiresAt.toISOString()).toBe('2026-03-15T14:00:00.000Z');
+    expect(row!.lastErrorCode).toBe('redis_write_failed');
+  });
+
+  it('caps the backoff at 300 seconds and never shortens an existing deadline', async () => {
+    const attemptedAt = new Date('2026-03-15T12:00:00.000Z');
+    const existingExpiry = new Date('2026-03-15T20:00:00.000Z');
+    const { user, markerId } = await seedRetryRow({
+      attempts: 20, // 2^20s would be ~12 days without the LEAST(300, ...) cap
+      expiresAt: existingExpiry,
+      nextAttemptAt: new Date('2026-03-15T11:00:00.000Z'),
+    });
+
+    await getTestDb()
+      .insert(oauthRevocationRetries)
+      .values({
+        userId: user.id,
+        markerType: 'grant',
+        markerId,
+        expiresAt: new Date('2026-03-15T15:00:00.000Z'), // EARLIER than existing
+        attempts: 1,
+        nextAttemptAt: new Date(attemptedAt.getTime() + 1_000),
+        lastErrorCode: 'redis_unavailable',
+        updatedAt: attemptedAt,
+      })
+      .onConflictDoUpdate({
+        target: [oauthRevocationRetries.markerType, oauthRevocationRetries.markerId],
+        set: buildRetryConflictUpdate({
+          attemptedAt,
+          expiresAt: new Date('2026-03-15T15:00:00.000Z'),
+          errorCode: 'redis_unavailable',
+        }),
+      });
+
+    const [row] = await readRow(user.id, markerId);
+    expect(row!.nextAttemptAt.toISOString()).toBe('2026-03-15T12:05:00.000Z');
+    // A defense-in-depth revocation marker must never expire earlier than an
+    // attempt already promised.
+    expect(row!.expiresAt.toISOString()).toBe(existingExpiry.toISOString());
+  });
+});

--- a/apps/api/src/db/sqlValues.test.ts
+++ b/apps/api/src/db/sqlValues.test.ts
@@ -64,6 +64,16 @@ describe('sqlValues (#3369)', () => {
     }
   });
 
+  it('drops `undefined` rather than binding it — a pre-existing Drizzle footgun, recorded not fixed', () => {
+    // Drizzle skips an `undefined` interpolation entirely, so the fragment
+    // renders with NO parameter and the surrounding predicate becomes malformed
+    // SQL. `sqlValue` does not change that, and `FilterValue` excludes
+    // `undefined`, so nothing here is reachable today — but the behaviour is
+    // surprising enough to pin, so a future caller widening the type finds it.
+    const { params } = dialect.sqlToQuery(sql`x = ${sqlValue(undefined)}`);
+    expect(params).toEqual([]);
+  });
+
   it('sqlValue keeps each value a separate bound parameter rather than inlining it', () => {
     // Inlining would turn a filter value into SQL text — an injection surface.
     const { sql: text, params } = dialect.sqlToQuery(

--- a/apps/api/src/db/sqlValues.test.ts
+++ b/apps/api/src/db/sqlValues.test.ts
@@ -1,0 +1,76 @@
+import { sql } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+
+import { sqlTimestamp, sqlTimestamptz, sqlValue } from './sqlValues';
+
+const dialect = new PgDialect();
+const AT = new Date('2026-08-10T06:14:42.123Z');
+
+describe('sqlValues (#3369)', () => {
+  /**
+   * The defect these helpers exist to prevent: a bare value in a Drizzle `sql`
+   * template is wrapped in a `Param` with the NOOP encoder, so a `Date` object
+   * reaches postgres.js untouched and its Bind step throws
+   * ERR_INVALID_ARG_TYPE. This test fails against a bare interpolation, which
+   * is what makes it a real guard rather than a restatement of the code.
+   */
+  it('a bare Date interpolation really does bind a Date — the behaviour being guarded against', () => {
+    const { params } = dialect.sqlToQuery(sql`x < ${AT}`);
+    expect(params[0]).toBeInstanceOf(Date);
+  });
+
+  it('sqlTimestamp binds an ISO string with no cast', () => {
+    const { sql: text, params } = dialect.sqlToQuery(sql`x < ${sqlTimestamp(AT)}`);
+
+    expect(params).toEqual(['2026-08-10T06:14:42.123Z']);
+    expect(params[0]).not.toBeInstanceOf(Date);
+    // The absence of a cast is the point, not an oversight. `devices.last_seen_at`
+    // is `timestamp` WITHOUT time zone; casting the parameter to `timestamptz`
+    // would make Postgres reinterpret the naive column in the session time zone
+    // and silently shift every comparison off UTC deployments.
+    expect(text).not.toContain('::');
+  });
+
+  it('sqlTimestamp preserves millisecond precision', () => {
+    // Truncating here would silently move a boundary comparison by up to 1ms,
+    // which is exactly the class of drift that makes keyset paging skip rows.
+    const { params } = dialect.sqlToQuery(sqlTimestamp(new Date('2026-08-10T06:14:42.007Z')));
+    expect(params[0]).toBe('2026-08-10T06:14:42.007Z');
+  });
+
+  it('sqlTimestamptz binds an ISO string cast to timestamptz', () => {
+    const { sql: text, params } = dialect.sqlToQuery(sql`GREATEST(c, ${sqlTimestamptz(AT)})`);
+
+    expect(params).toEqual(['2026-08-10T06:14:42.123Z']);
+    expect(text).toContain('::timestamptz');
+  });
+
+  it('sqlValue serialises a Date and leaves every other scalar alone', () => {
+    const cases: Array<[unknown, unknown]> = [
+      [AT, '2026-08-10T06:14:42.123Z'],
+      ['hello', 'hello'],
+      [42, 42],
+      [0, 0],
+      [true, true],
+      [false, false],
+      [null, null],
+    ];
+
+    for (const [input, expected] of cases) {
+      const { params } = dialect.sqlToQuery(sql`x = ${sqlValue(input)}`);
+      expect(params, `input ${String(input)}`).toEqual([expected]);
+      expect(params[0]).not.toBeInstanceOf(Date);
+    }
+  });
+
+  it('sqlValue keeps each value a separate bound parameter rather than inlining it', () => {
+    // Inlining would turn a filter value into SQL text — an injection surface.
+    const { sql: text, params } = dialect.sqlToQuery(
+      sql`x = ${sqlValue("'); DROP TABLE devices; --")}`,
+    );
+
+    expect(params).toEqual(["'); DROP TABLE devices; --"]);
+    expect(text).not.toContain('DROP TABLE');
+  });
+});

--- a/apps/api/src/db/sqlValues.ts
+++ b/apps/api/src/db/sqlValues.ts
@@ -1,0 +1,95 @@
+import { sql, type SQL } from 'drizzle-orm';
+
+/**
+ * Safe binding of JS values into hand-written Drizzle `sql` templates.
+ *
+ * ## Why this exists
+ *
+ * Drizzle's typed helpers (`eq`, `ne`, `lt`, `gt`, `lte`, `gte`, `between`,
+ * `inArray`, and `.set({ col: value })`) encode a value through the **column's**
+ * driver encoder. That is why `.where(gte(devices.lastSeenAt, someDate))` works.
+ *
+ * A value interpolated into a raw ``sql`...${value}...` `` template has no
+ * column to consult, so Drizzle wraps it in a `Param` carrying the **noop**
+ * encoder and the untouched JS object is handed to postgres.js. For a `Date`,
+ * the driver's Bind step throws:
+ *
+ * ```
+ * TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string
+ * or an instance of Buffer or ArrayBuffer. Received an instance of Date
+ *     at Bind (postgres/src/connection.js:954)
+ * ```
+ *
+ * Request handlers run inside `withDbAccessContext`, a postgres.js `begin()`
+ * transaction that re-throws query errors at commit *even when the application
+ * already caught and handled them*. So this does not surface as a handled
+ * error — it escapes as an HTTP 500 for the whole request, past the caller's
+ * own `catch`. That is what made it so hard to read from the outside in #3329.
+ *
+ * ## Using it
+ *
+ * Interpolate the returned fragment, not the raw value:
+ *
+ * ```ts
+ * sql`${columnRef} < ${sqlValue(cutoff)}`          // safe
+ * sql`${columnRef} < ${cutoff}`                    // 500s when cutoff is a Date
+ * ```
+ *
+ * Prefer a typed helper (`lt(devices.lastSeenAt, cutoff)`) whenever the left
+ * side is a real `Column` — that is the better fix and needs nothing from here.
+ * These helpers are for the cases where it is not: an arbitrary `SQL`
+ * expression, a correlated subquery, or an arithmetic context.
+ *
+ * History: #3329 (first sighting), #3368 (fix), #3369 (remaining sites).
+ */
+
+/**
+ * Bind a `Date` as an ISO-8601 string parameter, with **no** cast.
+ *
+ * This is the default and should be preferred. It is exactly what Drizzle's own
+ * `PgTimestamp.mapToDriverValue` does, so it is correct against both
+ * `timestamp` and `timestamptz` columns: Postgres resolves the untyped
+ * parameter from whatever it is being compared or assigned to.
+ *
+ * Deliberately uncast. The repo mixes both column flavours — `devices.
+ * last_seen_at` is `timestamp` (no tz) while `oauth_revocation_retries.
+ * expires_at` is `timestamptz` — and a blanket `::timestamptz` would be a
+ * *worse* bug than the one being fixed: comparing a naive `timestamp` column
+ * against a `timestamptz` makes Postgres reinterpret the column in the session
+ * time zone, silently shifting every result on any deployment not running UTC.
+ */
+export function sqlTimestamp(value: Date): SQL<unknown> {
+  return sql`${value.toISOString()}`;
+}
+
+/**
+ * Bind a `Date` as an explicitly-cast `timestamptz` parameter.
+ *
+ * Only for contexts where Postgres has no column to infer the parameter's type
+ * from — arithmetic (`$1 + interval '1 second'` has no unique operator
+ * resolution) or a polymorphic function (`GREATEST($1, col)` would resolve off
+ * the other argument).
+ *
+ * The target column must genuinely be `timestamptz`; against a naive
+ * `timestamp` column use {@link sqlTimestamp} instead, for the reason in its
+ * docblock.
+ */
+export function sqlTimestamptz(value: Date): SQL<unknown> {
+  return sql`${value.toISOString()}::timestamptz`;
+}
+
+/**
+ * Bind an arbitrary scalar, serialising a `Date` via {@link sqlTimestamp} and
+ * passing everything else through unchanged.
+ *
+ * For values whose runtime type is not statically known — user-supplied filter
+ * values, for instance, where one code path carries strings, numbers, booleans
+ * and `Date`s.
+ *
+ * Not for arrays or plain objects: those have their own binding rules per call
+ * site (an array may need an explicit `IN` list rather than `ANY($1)`), so they
+ * pass through and remain the caller's responsibility.
+ */
+export function sqlValue(value: unknown): SQL<unknown> {
+  return value instanceof Date ? sqlTimestamp(value) : sql`${value}`;
+}

--- a/apps/api/src/oauth/revocationRetry.test.ts
+++ b/apps/api/src/oauth/revocationRetry.test.ts
@@ -1,6 +1,9 @@
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { revokeGrant, revokeJti } from './revocationCache';
 import {
+  buildRetryConflictUpdate,
   writeOAuthRevocationMarkerDurably,
   type DbTransaction,
 } from './revocationRetry';
@@ -138,5 +141,93 @@ describe('writeOAuthRevocationMarkerDurably', () => {
     expect(serializedLogs).not.toContain('never-log-this-marker');
     consoleError.mockRestore();
     consoleWarn.mockRestore();
+  });
+});
+
+describe('buildRetryConflictUpdate (#3369)', () => {
+  const dialect = new PgDialect();
+  const ATTEMPTED_AT = new Date('2026-08-10T06:14:42.123Z');
+  const EXPIRES_AT = new Date('2026-08-10T07:00:00.000Z');
+
+  const update = () => buildRetryConflictUpdate({
+    attemptedAt: ATTEMPTED_AT,
+    expiresAt: EXPIRES_AT,
+    errorCode: 'redis_unavailable',
+  });
+
+  /**
+   * The bug: both timestamps were interpolated bare into `sql` templates, so
+   * Drizzle bound them with the NOOP encoder and postgres.js received live
+   * `Date` objects, throwing ERR_INVALID_ARG_TYPE at Bind.
+   *
+   * The severity is in *which* branch this is. `onConflictDoUpdate` fires only
+   * when an open retry row already exists — i.e. exactly when a prior Redis
+   * revocation write failed. `jobs/oauthRevocationRetryWorker.ts` re-runs those
+   * rows every 30s, so the throw rolled back the whole
+   * `withSystemDbAccessContext` batch and was swallowed by the generic `.catch`
+   * in `runScheduledDrain`. The revocation retry queue could therefore never
+   * drain or heal during a Redis outage, silently.
+   */
+  it.each(['nextAttemptAt', 'expiresAt'] as const)('binds no raw Date in %s', (key) => {
+    const { params } = dialect.sqlToQuery(update()[key]);
+
+    expect(params.length).toBeGreaterThan(0);
+    for (const param of params) expect(param).not.toBeInstanceOf(Date);
+  });
+
+  it('casts both timestamps to timestamptz so the arithmetic and GREATEST resolve', () => {
+    // Unlike the device filter columns, `oauth_revocation_retries.expires_at` /
+    // `next_attempt_at` really are `timestamptz`, and neither context can infer
+    // the parameter's type: `$1 + interval` has no unique operator resolution,
+    // and GREATEST would resolve off its other argument.
+    const next = dialect.sqlToQuery(update().nextAttemptAt);
+    const expires = dialect.sqlToQuery(update().expiresAt);
+
+    expect(next.sql).toContain('::timestamptz');
+    expect(next.params).toContain(ATTEMPTED_AT.toISOString());
+    expect(expires.sql).toContain('::timestamptz');
+    expect(expires.params).toContain(EXPIRES_AT.toISOString());
+  });
+
+  it('backs off exponentially, capped at 300s, and never shortens the marker lifetime', () => {
+    const next = dialect.sqlToQuery(update().nextAttemptAt).sql;
+    const expires = dialect.sqlToQuery(update().expiresAt).sql;
+    const attempts = dialect.sqlToQuery(update().attempts).sql;
+
+    expect(next).toContain('LEAST(300');
+    expect(next).toContain('POWER(2');
+    expect(next).toContain("interval '1 second'");
+    // GREATEST(existing, incoming): a later retry must never pull the marker's
+    // expiry in, or the defense-in-depth marker would lapse early.
+    expect(expires).toContain('GREATEST');
+    expect(expires).toContain('"expires_at"');
+    expect(attempts).toContain('+ 1');
+  });
+
+  it('is what the conflict branch actually installs', async () => {
+    // Guards against the extraction drifting from its only caller.
+    vi.mocked(revokeGrant).mockRejectedValueOnce(new Error('redis is required'));
+    const fake = fakeTransaction();
+
+    await writeOAuthRevocationMarkerDurably(fake.tx, {
+      userId: USER_ID,
+      markerType: 'grant',
+      markerId: 'grant-secret',
+      expiresAt: EXPIRES_AT,
+    });
+
+    // The mock records untyped args; the shape is asserted, not assumed.
+    const [conflictArgs] = fake.onConflictDoUpdate.mock.calls[0] as unknown as [
+      { set: Record<string, SQL<unknown>> },
+    ];
+    const set = conflictArgs.set;
+    expect(Object.keys(set).sort()).toEqual(Object.keys(update()).sort());
+    for (const key of ['nextAttemptAt', 'expiresAt'] as const) {
+      const fragment = set[key];
+      expect(fragment, `missing ${key}`).toBeDefined();
+      for (const param of dialect.sqlToQuery(fragment!).params) {
+        expect(param).not.toBeInstanceOf(Date);
+      }
+    }
   });
 });

--- a/apps/api/src/oauth/revocationRetry.ts
+++ b/apps/api/src/oauth/revocationRetry.ts
@@ -1,5 +1,6 @@
 import { eq, isNull, sql } from 'drizzle-orm';
 import { db } from '../db';
+import { sqlTimestamptz } from '../db/sqlValues';
 import { oauthRevocationRetries } from '../db/schema';
 import { revokeGrant, revokeJti } from './revocationCache';
 
@@ -33,6 +34,44 @@ function markerErrorCode(error: unknown): 'redis_unavailable' | 'redis_write_fai
 
 function remainingLifetimeSeconds(expiresAt: Date, now: Date): number {
   return Math.max(Math.ceil((expiresAt.getTime() - now.getTime()) / 1000), 1);
+}
+
+/**
+ * The `ON CONFLICT ... DO UPDATE` assignment list for an existing, still-open
+ * retry row: bump the attempt count, push `next_attempt_at` out by an
+ * exponential backoff capped at 300s, and never shorten the marker's lifetime.
+ *
+ * Extracted so the SQL can be rendered and asserted on without a database.
+ *
+ * Both timestamps are bound via `sqlTimestamptz` rather than interpolated bare
+ * (#3369). A raw `Date` inside a `sql` template is wrapped in a `Param` with
+ * the noop encoder and reaches postgres.js as a JS object, whose Bind step
+ * throws `ERR_INVALID_ARG_TYPE`. This branch runs only when a retry row already
+ * exists — i.e. exactly when a prior Redis write failed — so the throw rolled
+ * back the entire `withSystemDbAccessContext` batch in
+ * `jobs/oauthRevocationRetryWorker.ts` and was then swallowed by the generic
+ * `.catch` in `runScheduledDrain`, which logs and returns 0. Net effect: the
+ * OAuth revocation retry queue could never drain or heal during a Redis
+ * outage, and failed silently rather than per-row.
+ *
+ * The explicit `::timestamptz` casts are load-bearing, not decoration: an
+ * untyped parameter has no unique operator resolution against `interval`, and
+ * inside `GREATEST` it would resolve off the other argument's type.
+ */
+export function buildRetryConflictUpdate(args: {
+  attemptedAt: Date;
+  expiresAt: Date;
+  errorCode: 'redis_unavailable' | 'redis_write_failed';
+}) {
+  return {
+    attempts: sql`${oauthRevocationRetries.attempts} + 1`,
+    nextAttemptAt: sql`${sqlTimestamptz(args.attemptedAt)} + (
+      LEAST(300, POWER(2, ${oauthRevocationRetries.attempts})) * interval '1 second'
+    )`,
+    lastErrorCode: args.errorCode,
+    expiresAt: sql`GREATEST(${oauthRevocationRetries.expiresAt}, ${sqlTimestamptz(args.expiresAt)})`,
+    updatedAt: args.attemptedAt,
+  };
 }
 
 /**
@@ -75,15 +114,11 @@ export async function writeOAuthRevocationMarkerDurably(
           oauthRevocationRetries.markerId,
         ],
         targetWhere: isNull(oauthRevocationRetries.completedAt),
-        set: {
-          attempts: sql`${oauthRevocationRetries.attempts} + 1`,
-          nextAttemptAt: sql`${attemptedAt} + (
-            LEAST(300, POWER(2, ${oauthRevocationRetries.attempts})) * interval '1 second'
-          )`,
-          lastErrorCode: errorCode,
-          expiresAt: sql`GREATEST(${oauthRevocationRetries.expiresAt}, ${input.expiresAt})`,
-          updatedAt: attemptedAt,
-        },
+        set: buildRetryConflictUpdate({
+          attemptedAt,
+          expiresAt: input.expiresAt,
+          errorCode,
+        }),
         setWhere: eq(oauthRevocationRetries.userId, input.userId),
       })
       .returning({ userId: oauthRevocationRetries.userId });

--- a/apps/api/src/services/alertCorrelationGroups.test.ts
+++ b/apps/api/src/services/alertCorrelationGroups.test.ts
@@ -124,6 +124,44 @@ describe('alert correlation group materializer', () => {
     expect(groupInsert![0]?.values).toContain(66);
   });
 
+  /**
+   * #3369. `first_seen_at`/`last_seen_at` are taken straight off
+   * `alerts.triggeredAt`, which Drizzle hands back as a live JS `Date`. They
+   * were interpolated bare into the upsert template, so Drizzle bound them with
+   * the NOOP encoder and postgres.js received `Date` objects — its Bind step
+   * throws ERR_INVALID_ARG_TYPE, failing the entire correlation-grouping pass
+   * every time a group had to be written.
+   *
+   * `drizzle-orm` is mocked in this file, so `sql` captures its interpolated
+   * values verbatim: a `Date` surviving anywhere in the bound values is exactly
+   * the pre-fix behaviour, and `sqlTimestamp` replaces it with an ISO string.
+   */
+  it('binds no raw Date into any upsert — timestamps are serialized first', async () => {
+    const containsDate = (value: unknown, depth = 0): boolean => {
+      if (value instanceof Date) return true;
+      if (depth > 6 || value === null || typeof value !== 'object') return false;
+      return Object.values(value as Record<string, unknown>).some((v) => containsDate(v, depth + 1));
+    };
+
+    await persistAlertCorrelationGroupsForAlerts({
+      orgId: ORG_1,
+      alertIds: [ALERT_1, ALERT_2, ALERT_3],
+    });
+
+    expect(dbMock.execute).toHaveBeenCalled();
+    for (const call of dbMock.execute.mock.calls) {
+      expect(containsDate(call[0]?.values ?? [])).toBe(false);
+    }
+
+    const groupInsert = dbMock.execute.mock.calls.find((call) =>
+      JSON.stringify(call[0]?.strings ?? []).includes('first_seen_at')
+    );
+    expect(groupInsert).toBeDefined();
+    // The earliest and latest member timestamps, ISO-serialized.
+    expect(JSON.stringify(groupInsert![0]?.values)).toContain('2026-06-18T12:00:00.000Z');
+    expect(JSON.stringify(groupInsert![0]?.values)).toContain('2026-06-18T12:02:00.000Z');
+  });
+
   it('skips materialization when fewer than two alerts are in scope', async () => {
     const result = await persistAlertCorrelationGroupsForAlerts({
       orgId: ORG_1,

--- a/apps/api/src/services/alertCorrelationGroups.ts
+++ b/apps/api/src/services/alertCorrelationGroups.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { db } from '../db';
+import { sqlTimestamp } from '../db/sqlValues';
 import { alertCorrelations, alerts } from '../db/schema';
 
 const GROUP_METADATA_VERSION = 'alert-correlation-groups-v1';
@@ -103,6 +104,13 @@ async function upsertGroup(orgId: string, component: Component): Promise<string>
   const noiseReductionPercent = memberCount > 0
     ? Math.floor(((memberCount - 1) / memberCount) * 100)
     : 0;
+  // `triggeredAt` is a live JS `Date`. It must be bound through `sqlTimestamp`
+  // rather than interpolated bare into the template below (#3369) — a raw
+  // `Date` in a `sql` template is wrapped with the noop encoder and reaches
+  // postgres.js as a JS object, whose Bind step throws ERR_INVALID_ARG_TYPE and
+  // fails the whole correlation-grouping pass. `first_seen_at`/`last_seen_at`
+  // are naive `timestamp` columns, so the uncast ISO form is the correct
+  // binding here — see the docblock on `sqlTimestamp`.
   const firstSeenAt = component.alerts[0]!.triggeredAt;
   const lastSeenAt = component.alerts[memberCount - 1]!.triggeredAt;
   const correlationTypes = [...new Set(component.correlations.map((link) => link.correlationType))];
@@ -129,8 +137,8 @@ async function upsertGroup(orgId: string, component: Component): Promise<string>
       ${score.toFixed(2)},
       ${noiseReductionPercent},
       ${memberCount},
-      ${firstSeenAt},
-      ${lastSeenAt},
+      ${sqlTimestamp(firstSeenAt)},
+      ${sqlTimestamp(lastSeenAt)},
       jsonb_build_object(
         'version', ${GROUP_METADATA_VERSION},
         'correlationTypes', ${JSON.stringify(correlationTypes)}

--- a/apps/api/src/services/filterEngine.test.ts
+++ b/apps/api/src/services/filterEngine.test.ts
@@ -342,3 +342,97 @@ describe('filterEngine bounds filter-query execution time (#1044 ReDoS)', () => 
     expect(setsStatementTimeout()).toBe(true);
   });
 });
+
+describe('filterEngine datetime binding (#3369)', () => {
+  const dialect = new PgDialect();
+  const FROM = new Date('2026-01-01T00:00:00.000Z');
+  const TO = new Date('2026-02-01T12:30:45.678Z');
+
+  const render = (condition: FilterCondition) => dialect.sqlToQuery(buildConditionSQL(condition));
+
+  /**
+   * The bug: `applyOperator` interpolated the filter value bare into a `sql`
+   * template. `columnRef` there is an arbitrary `SQL` expression rather than a
+   * `Column`, so Drizzle had no encoder to consult and wrapped the value in a
+   * `Param` with the NOOP encoder — handing postgres.js a live `Date`, whose
+   * Bind step throws ERR_INVALID_ARG_TYPE. Because the request runs inside
+   * `withDbAccessContext` (a `begin()` transaction that re-throws at commit),
+   * it escaped as an HTTP 500 for the whole request.
+   *
+   * This is not hypothetical for `between`: `filterValueSchema` parses a range
+   * through `z.coerce.date()`, so the advanced filter builder's date-range
+   * picker produces real `Date`s on every `POST /devices/filters/preview`.
+   */
+  it.each([
+    ['equals', new Date(FROM)],
+    ['notEquals', new Date(FROM)],
+    ['before', new Date(FROM)],
+    ['after', new Date(FROM)],
+    ['lessThan', new Date(FROM)],
+    ['lessThanOrEquals', new Date(FROM)],
+    ['greaterThan', new Date(FROM)],
+    ['greaterThanOrEquals', new Date(FROM)],
+  ] as const)('binds no raw Date for a datetime %s condition', (operator, value) => {
+    const { params } = render({ field: 'lastSeenAt', operator, value });
+
+    expect(params.length).toBeGreaterThan(0);
+    for (const param of params) expect(param).not.toBeInstanceOf(Date);
+    expect(params).toContain(FROM.toISOString());
+  });
+
+  it('binds no raw Date for a between range and keeps both bounds distinct', () => {
+    const { sql: text, params } = render({
+      field: 'lastSeenAt',
+      operator: 'between',
+      value: { from: FROM, to: TO },
+    });
+
+    for (const param of params) expect(param).not.toBeInstanceOf(Date);
+    expect(params).toEqual([FROM.toISOString(), TO.toISOString()]);
+    expect(text).toContain('BETWEEN');
+  });
+
+  it('emits no timestamptz cast — the target columns are naive timestamps', () => {
+    // `devices.last_seen_at` / `enrolled_at` / `quarantined_at` are all
+    // `timestamp` WITHOUT time zone. Casting the bound parameter to
+    // `timestamptz` would make Postgres reinterpret the column in the session
+    // time zone, shifting every result on any non-UTC deployment — a worse bug
+    // than the one being fixed here.
+    const { sql: text } = render({
+      field: 'lastSeenAt',
+      operator: 'between',
+      value: { from: FROM, to: TO },
+    });
+
+    expect(text).not.toContain('timestamptz');
+  });
+
+  it('routes a Date through the related-table and computed-field paths too', () => {
+    // These recurse into applyOperator with a correlated subquery / CASE
+    // expression as columnRef, which is precisely where a typed helper is
+    // unavailable and the bare interpolation used to survive.
+    for (const field of ['enrolledAt', 'quarantinedAt']) {
+      const { params } = render({ field, operator: 'before', value: new Date(FROM) });
+      for (const param of params) expect(param).not.toBeInstanceOf(Date);
+    }
+  });
+
+  it('still binds ordinary scalars unchanged', () => {
+    expect(render({ field: 'hostname', operator: 'equals', value: 'web-01' }).params).toEqual(['web-01']);
+    expect(render({ field: 'status', operator: 'in', value: ['online', 'offline'] }).params)
+      .toEqual(['online', 'offline']);
+  });
+
+  it('binds a numeric between as numbers, not epoch-millisecond timestamps', () => {
+    // Companion to the validator fix: `z.coerce.date()` accepted a plain number
+    // as epoch-ms, so `{ from: 10, to: 90 }` became 1970-01-01T00:00:00.010Z.
+    // Here we assert the engine's own half — numbers stay numbers.
+    const { params } = render({
+      field: 'metrics.cpuPercent',
+      operator: 'between',
+      value: { from: 10, to: 90 },
+    });
+
+    expect(params).toEqual([10, 90]);
+  });
+});

--- a/apps/api/src/services/filterEngine.test.ts
+++ b/apps/api/src/services/filterEngine.test.ts
@@ -417,6 +417,30 @@ describe('filterEngine datetime binding (#3369)', () => {
     }
   });
 
+  it('routes matches, in/notIn and the group membership path through sqlValue too', () => {
+    // `OPERATORS_BY_TYPE` never pairs these operators with a datetime field, and
+    // the public route runs `validateFilter` first — but `FilterCondition` types
+    // `operator` as any `FilterOperator`, and the internal callers
+    // (aiToolsFleet, groupMembership, deploymentTargetResolver) build conditions
+    // by hand and call `evaluateFilter` directly without that gate. Defense in
+    // depth: a Date reaching these branches must still serialize.
+    const at = new Date('2026-01-01T00:00:00.000Z');
+    const cases: FilterCondition[] = [
+      { field: 'hostname', operator: 'matches', value: at as unknown as string },
+      { field: 'lastSeenAt', operator: 'in', value: [at] as unknown as string[] },
+      { field: 'lastSeenAt', operator: 'notIn', value: [at] as unknown as string[] },
+      { field: 'groupId', operator: 'equals', value: at },
+    ];
+
+    for (const condition of cases) {
+      const { params } = render(condition);
+      for (const param of params) {
+        expect(param, `${condition.field}/${condition.operator}`).not.toBeInstanceOf(Date);
+      }
+      expect(params).toContain(at.toISOString());
+    }
+  });
+
   it('still binds ordinary scalars unchanged', () => {
     expect(render({ field: 'hostname', operator: 'equals', value: 'web-01' }).params).toEqual(['web-01']);
     expect(render({ field: 'status', operator: 'in', value: ['online', 'offline'] }).params)

--- a/apps/api/src/services/filterEngine.ts
+++ b/apps/api/src/services/filterEngine.ts
@@ -1,5 +1,6 @@
 import { and, eq, or, not, gt, gte, lt, lte, like, ilike, inArray, isNull, isNotNull, sql, SQL } from 'drizzle-orm';
 import { db } from '../db';
+import { sqlValue } from '../db/sqlValues';
 import { devices, deviceHardware, deviceNetwork, deviceMetrics, deviceSoftware, deviceGroups, deviceGroupMemberships, softwareInventory } from '../db/schema';
 import type {
   FilterOperator,
@@ -355,7 +356,7 @@ export function buildConditionSQL(condition: FilterCondition): SQL<unknown> {
   if (fieldInfo.table === 'groups') {
     // Membership test against device_group_memberships.
     if (operator === 'equals') {
-      return sql`EXISTS (SELECT 1 FROM ${deviceGroupMemberships} WHERE ${deviceGroupMemberships.deviceId} = ${devices.id} AND ${deviceGroupMemberships.groupId} = ${value})`;
+      return sql`EXISTS (SELECT 1 FROM ${deviceGroupMemberships} WHERE ${deviceGroupMemberships.deviceId} = ${devices.id} AND ${deviceGroupMemberships.groupId} = ${sqlValue(value)})`;
     }
     if (operator === 'in' && Array.isArray(value)) {
       return sql`EXISTS (SELECT 1 FROM ${deviceGroupMemberships} WHERE ${deviceGroupMemberships.deviceId} = ${devices.id} AND ${deviceGroupMemberships.groupId} = ANY(${value}))`;
@@ -368,20 +369,30 @@ export function buildConditionSQL(condition: FilterCondition): SQL<unknown> {
 // Build a SQL predicate applying an operator to a column expression. The
 // expression may be a plain device column or a correlated subquery (related
 // tables / latest-metric), so this stays purely about operator semantics.
+//
+// Every user-supplied scalar goes through `sqlValue` rather than being
+// interpolated bare (#3369). `columnRef` is an arbitrary `SQL` expression, not
+// a `Column`, so Drizzle has no encoder to consult and would hand postgres.js
+// the raw JS object — for a `Date` that throws ERR_INVALID_ARG_TYPE at the
+// driver's Bind step, and because the request runs inside a `begin()`
+// transaction the throw escapes as an HTTP 500 rather than a handled error.
+// `FilterValue` really does carry live `Date`s here: `filterValueSchema` parses
+// a `between` range through `z.coerce.date()`, so the advanced filter builder's
+// date-range picker produces them on every `POST /devices/filters/preview`.
 function applyOperator(columnRef: SQL<unknown>, operator: FilterOperator, value: FilterValue): SQL<unknown> {
   switch (operator) {
     case 'equals':
-      return sql`${columnRef} = ${value}`;
+      return sql`${columnRef} = ${sqlValue(value)}`;
     case 'notEquals':
-      return sql`${columnRef} != ${value}`;
+      return sql`${columnRef} != ${sqlValue(value)}`;
     case 'greaterThan':
-      return sql`${columnRef} > ${value}`;
+      return sql`${columnRef} > ${sqlValue(value)}`;
     case 'greaterThanOrEquals':
-      return sql`${columnRef} >= ${value}`;
+      return sql`${columnRef} >= ${sqlValue(value)}`;
     case 'lessThan':
-      return sql`${columnRef} < ${value}`;
+      return sql`${columnRef} < ${sqlValue(value)}`;
     case 'lessThanOrEquals':
-      return sql`${columnRef} <= ${value}`;
+      return sql`${columnRef} <= ${sqlValue(value)}`;
     case 'contains':
       return sql`${columnRef} ILIKE ${'%' + escapeLikePattern(String(value)) + '%'}`;
     case 'notContains':
@@ -391,7 +402,7 @@ function applyOperator(columnRef: SQL<unknown>, operator: FilterOperator, value:
     case 'endsWith':
       return sql`${columnRef} ILIKE ${'%' + escapeLikePattern(String(value))}`;
     case 'matches':
-      return sql`${columnRef} ~ ${value}`;
+      return sql`${columnRef} ~ ${sqlValue(value)}`;
     case 'in':
       if (Array.isArray(value)) {
         // Empty IN matches nothing. Build an explicit IN list (each value bound
@@ -400,7 +411,7 @@ function applyOperator(columnRef: SQL<unknown>, operator: FilterOperator, value:
         // ANY/ALL (array) requires array on right side". Mirrors the software
         // `in` path above.
         if (value.length === 0) return sql`FALSE`;
-        const items = (value as unknown[]).map((v) => sql`${v}`);
+        const items = (value as unknown[]).map((v) => sqlValue(v));
         return sql`${columnRef} IN (${sql.join(items, sql`, `)})`;
       }
       throw new Error('Value must be array for "in" operator');
@@ -409,7 +420,7 @@ function applyOperator(columnRef: SQL<unknown>, operator: FilterOperator, value:
         // Empty NOT IN matches everything; otherwise an explicit NOT IN list
         // for the same reason as `in` above.
         if (value.length === 0) return sql`TRUE`;
-        const items = (value as unknown[]).map((v) => sql`${v}`);
+        const items = (value as unknown[]).map((v) => sqlValue(v));
         return sql`${columnRef} NOT IN (${sql.join(items, sql`, `)})`;
       }
       throw new Error('Value must be array for "notIn" operator');
@@ -432,12 +443,12 @@ function applyOperator(columnRef: SQL<unknown>, operator: FilterOperator, value:
     case 'isNotNull':
       return sql`${columnRef} IS NOT NULL`;
     case 'before':
-      return sql`${columnRef} < ${value}`;
+      return sql`${columnRef} < ${sqlValue(value)}`;
     case 'after':
-      return sql`${columnRef} > ${value}`;
+      return sql`${columnRef} > ${sqlValue(value)}`;
     case 'between':
       if (typeof value === 'object' && value !== null && 'from' in value && 'to' in value) {
-        return sql`${columnRef} BETWEEN ${value.from} AND ${value.to}`;
+        return sql`${columnRef} BETWEEN ${sqlValue(value.from)} AND ${sqlValue(value.to)}`;
       }
       throw new Error('Value must have from/to for "between" operator');
     case 'withinLast':

--- a/packages/shared/src/types/filters.ts
+++ b/packages/shared/src/types/filters.ts
@@ -95,7 +95,8 @@ export type FilterValue =
   | Date
   | string[]
   | number[]
-  | { from: Date; to: Date } // for 'between' operator
+  | { from: Date; to: Date } // for 'between' operator on a date/datetime field
+  | { from: number; to: number } // for 'between' operator on a number field
   | { amount: number; unit: 'minutes' | 'hours' | 'days' | 'weeks' | 'months' }; // for 'withinLast'
 
 /**

--- a/packages/shared/src/validators/filters.ts
+++ b/packages/shared/src/validators/filters.ts
@@ -40,6 +40,19 @@ export const filterOperatorSchema = z.enum([
 // Filter Value Schemas
 // ============================================
 
+// `between` on a number field. MUST be tried before `dateRangeValueSchema`:
+// `z.coerce.date()` accepts a plain number as epoch-milliseconds, so
+// `{ from: 10, to: 90 }` — a perfectly ordinary "metrics.cpuPercent between
+// 10 and 90" — used to parse as the date range 1970-01-01T00:00:00.010Z ..
+// .090Z and was then compared against a numeric column. Discovered while
+// fixing #3369. The web UI hides numeric `between`
+// (apps/web/src/components/filters/filterFields.ts), which is why it went
+// unnoticed, but the REST API, dynamic groups and the AI fleet tool accept it.
+const numberRangeValueSchema = z.object({
+  from: z.number(),
+  to: z.number()
+});
+
 const dateRangeValueSchema = z.object({
   from: z.coerce.date(),
   to: z.coerce.date()
@@ -50,6 +63,11 @@ const relativeTimeValueSchema = z.object({
   unit: z.enum(['minutes', 'hours', 'days', 'weeks', 'months'])
 });
 
+// Union order is significant throughout: Zod returns the FIRST branch that
+// parses, so a broader branch placed earlier shadows a narrower one. `z.string()`
+// leading means an ISO date string stays a string (harmless — Postgres coerces
+// it against the column), while `z.coerce.date()` only ever fires for a real
+// `Date` instance or inside the range schemas.
 export const filterValueSchema = z.union([
   z.string(),
   z.number(),
@@ -57,6 +75,7 @@ export const filterValueSchema = z.union([
   z.coerce.date(),
   z.array(z.string()),
   z.array(z.number()),
+  numberRangeValueSchema,
   dateRangeValueSchema,
   relativeTimeValueSchema
 ]);

--- a/packages/shared/src/validators/filters_operators.test.ts
+++ b/packages/shared/src/validators/filters_operators.test.ts
@@ -89,8 +89,8 @@ describe('filterValueSchema', () => {
     const result = filterValueSchema.safeParse({ from: 10, to: 90 });
 
     expect(result.success).toBe(true);
+    // `toEqual` distinguishes 10 from `new Date(10)`, which is the whole regression.
     expect(result.data).toEqual({ from: 10, to: 90 });
-    expect(result.data).not.toHaveProperty('from', expect.any(Date));
   });
 
   it('still coerces a date range to real Date instances', () => {

--- a/packages/shared/src/validators/filters_operators.test.ts
+++ b/packages/shared/src/validators/filters_operators.test.ts
@@ -79,6 +79,38 @@ describe('filterValueSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  // #3369. `z.coerce.date()` treats a plain number as epoch-milliseconds, so
+  // before `numberRangeValueSchema` was placed ahead of the date range a
+  // perfectly ordinary "metrics.cpuPercent between 10 and 90" parsed as the
+  // date range 1970-01-01T00:00:00.010Z .. .090Z and was then compared against
+  // a numeric column. The web UI hides numeric `between`, but the REST API, dynamic
+  // groups and the AI fleet tool all accept it.
+  it('keeps a numeric between range numeric instead of coercing it to epoch dates', () => {
+    const result = filterValueSchema.safeParse({ from: 10, to: 90 });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ from: 10, to: 90 });
+    expect(result.data).not.toHaveProperty('from', expect.any(Date));
+  });
+
+  it('still coerces a date range to real Date instances', () => {
+    // The narrower numeric branch must not shadow the date branch.
+    const result = filterValueSchema.safeParse({ from: '2026-01-01', to: '2026-12-31' });
+
+    expect(result.success).toBe(true);
+    const range = result.data as { from: Date; to: Date };
+    expect(range.from).toBeInstanceOf(Date);
+    expect(range.to).toBeInstanceOf(Date);
+    expect(range.from.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('does not mistake a relative-time value for a range', () => {
+    const result = filterValueSchema.safeParse({ amount: 7, unit: 'days' });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ amount: 7, unit: 'days' });
+  });
+
   it('should accept relative time values', () => {
     const units = ['minutes', 'hours', 'days', 'weeks', 'months'] as const;
     for (const unit of units) {


### PR DESCRIPTION
Closes #3369

## The defect class

A value interpolated into a Drizzle ``sql`...${value}...` `` template is wrapped in a `Param` carrying the **noop** encoder, so the untouched JS object is handed to postgres.js. For a `Date`, the driver's Bind step throws:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string
or an instance of Buffer or ArrayBuffer. Received an instance of Date
    at Bind (postgres/src/connection.js:954)
```

Drizzle's typed helpers (`eq`, `lt`, `gte`, `between`, `.set({...})`) are safe — they route the value through the **column's** encoder. Only hand-written templates are affected. And because requests run inside `withDbAccessContext`, a postgres.js `begin()` transaction that re-throws query errors at commit *even when the application already handled them*, this surfaces as an HTTP 500 for the whole request rather than a catchable error.

## The shared helper

New `apps/api/src/db/sqlValues.ts`:

| Helper | Emits | Use when |
|---|---|---|
| `sqlTimestamp(date)` | `$1` (ISO string, **no cast**) | default — comparisons, `INSERT`/`SET` targets |
| `sqlTimestamptz(date)` | `$1::timestamptz` | no column to infer from: arithmetic, `GREATEST`/`LEAST` |
| `sqlValue(unknown)` | delegates for `Date`, passes everything else through | values whose runtime type isn't statically known |

**The default is deliberately uncast, and that is the load-bearing design decision here.** The repo mixes both column flavours — `devices.last_seen_at` is `timestamp` **without** time zone, while `oauth_revocation_retries.expires_at` is `timestamptz`. A blanket `::timestamptz` would make Postgres reinterpret the naive column *in the session time zone*, silently shifting every comparison on any deployment not running UTC. That would have been a worse bug than the one being fixed: a wrong answer instead of a loud failure. `sqlTimestamp` matches Drizzle's own `PgTimestamp.mapToDriverValue` exactly, so Postgres resolves the parameter from whatever it is compared or assigned to. The integration test pins this by re-running the same assertions under `TimeZone = 'Pacific/Kiritimati'` (UTC+14).

## Site 1 — `services/filterEngine.ts` (live 500)

`applyOperator`'s `equals` / `notEquals` / `before` / `after` / `between` / `greaterThan…` / `lessThan…` / `matches` / `in` / `notIn` all interpolated the user value bare. `columnRef` there is an arbitrary `SQL` expression (a correlated subquery, a `CASE`, an `EXTRACT`), not a `Column`, so the typed-helper fix from #3368 was not available — hence the shim.

This is reachable today, not hypothetically: `filterValueSchema` parses a `between` range through `z.coerce.date()`, so the advanced filter builder's date-range picker produces real `Date`s. Confirmed by rendering the predicate — `"devices"."last_seen_at" BETWEEN $1 AND $2` with **two `Date` objects** as params.

Reached from `POST /devices/filters/preview`, dynamic device groups, deployment target resolution, and the AI fleet tool.

## Site 2 — `oauth/revocationRetry.ts` (silent, and it defeats the retry)

The `onConflictDoUpdate` branch interpolated `attemptedAt` and `input.expiresAt` bare. That branch fires **only when a retry row already exists** — i.e. exactly when a prior Redis revocation write failed. `jobs/oauthRevocationRetryWorker.ts` re-invokes it every 30s; the throw escaped the `withSystemDbAccessContext` transaction (rolling back the whole batch) and was swallowed by the generic `.catch` in `runScheduledDrain`, which logs and returns 0.

**Net effect: the OAuth revocation retry queue could never drain or heal during a Redis outage, and failed quietly rather than per-row.**

These two sit in arithmetic and `GREATEST` contexts, so they use `sqlTimestamptz` — the casts are load-bearing: `$1 + interval '1 second'` has no unique operator resolution, and `GREATEST($1, col)` would resolve off the other argument. The `set` object is extracted as `buildRetryConflictUpdate` so the SQL can be rendered and asserted without a database.

## Site 3 — `services/alertCorrelationGroups.ts` (found by the sweep)

`upsertGroup` interpolated `firstSeenAt`/`lastSeenAt` bare into its `INSERT … ON CONFLICT` template. Both come straight off `alerts.triggeredAt`, which Drizzle returns as a live `Date`, so **every** group write threw and failed the whole correlation-grouping pass. `first_seen_at`/`last_seen_at` are naive `timestamp` columns, so this uses the uncast `sqlTimestamp`.

## Also fixed — numeric `between` was silently coerced to epoch dates

Found while verifying site 1, on the same endpoint. `z.coerce.date()` accepts a plain number as epoch-milliseconds, and `dateRangeValueSchema` sat ahead of any numeric branch in the union — so `{ from: 10, to: 90 }` (an ordinary `metrics.cpuPercent between 10 and 90`) parsed as the date range `1970-01-01T00:00:00.010Z .. .090Z` and was then compared against a numeric column.

Fixing only the Date binding would have converted one 500 into another (a Postgres type error instead of a driver `TypeError`), so a `numberRangeValueSchema` now precedes the date range in the union, and `FilterValue` gains `{ from: number; to: number }`. The web UI hides numeric `between` (see the comment in `apps/web/src/components/filters/filterFields.ts`), which is why this went unnoticed — but the REST API, dynamic groups and the AI fleet tool all accept it.

## Sweep

A repo-wide pass over every `sql\`\`` template in `apps/api/src` (plus `apps/portal/src` and `packages/*/src`) traced each non-trivial interpolated identifier to its declaration. It found **one** new instance (site 3 above) and confirmed the rest safe: every retention/reaper job, `invoiceService`, `agents/patches`, `patches/helpers`, `auditChainAnchor`, `deploymentEngine`, `maintenanceService`, `mobile`, `devices/warranty`, `metricRollups`, `metricAnomalies`, `userRiskSignals` already `.toISOString()` before interpolating — several with comments citing this exact bug class. `partnerApi` cursor/traversal values are typed `string`, not `Date`. `apps/portal/src` imports no drizzle at all.

No lint rule is proposed: the defect depends on a value's *runtime* type, which a static rule cannot see. The per-site rendered-SQL guards below are the enforceable form.

## Tests

Unit (no database; **each guard was verified to fail against the pre-fix behaviour** — 20 failures when the helpers are stubbed back to a bare pass-through):

- `db/sqlValues.test.ts` — new. Includes an explicit test that a *bare* interpolation really does bind a `Date`, so the file documents the behaviour it guards against; cast/no-cast assertions per helper; millisecond fidelity; parameters stay bound rather than inlined.
- `services/filterEngine.test.ts` — every datetime operator renders through `PgDialect.sqlToQuery` with no `Date` param; `between` keeps both bounds distinct; **no `timestamptz` appears** (the naive-column guard); related-table/computed paths covered; ordinary scalars unchanged; numeric `between` stays numeric.
- `oauth/revocationRetry.test.ts` — `buildRetryConflictUpdate` binds no `Date`, casts both timestamps, keeps the `LEAST(300, POWER(2, …))` backoff and the `GREATEST` lifetime rule, and matches what the conflict branch actually installs.
- `services/alertCorrelationGroups.test.ts` — no `Date` survives in any upsert's bound values.
- `packages/shared/.../filters_operators.test.ts` — numeric range stays numeric, date range still coerces, relative-time value not mistaken for a range.

Integration against real Postgres — `__tests__/integration/sqlTemplateDateBinding.integration.test.ts`, new. No mock reproduces the original failure (it lives in the driver's type coercion), and no rendered-SQL assertion can prove the statement is *semantically* right. This covers `between`/`before`/`after`/`equals` returning exactly the right devices, the same assertions under a non-UTC session time zone, and the revocation-retry conflict branch actually executing its backoff arithmetic (8s from attempts=3; capped at 300s from attempts=20) and never shortening an existing deadline.

`tsc --noEmit` clean across `apps/api`, `apps/web` and `packages/shared`.

Reported by @bdunncompany (sweep credit from #3329 / #3368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
