### PR TITLE
fix(agent): resolve macOS Finder aliases in the file browser (#3344)

### DIFF
--- a/agent/internal/remote/tools/fileops.go
+++ b/agent/internal/remote/tools/fileops.go
@@ -212,6 +212,18 @@ func ListFiles(payload map[string]any) CommandResult {
 		return NewErrorResult(err, time.Since(start).Milliseconds())
 	}
 
+	// A macOS Finder alias to a folder is a regular file, so navigating into one
+	// would otherwise fail with "not a directory". Resolve it and list the
+	// target, re-running containment against the target — alias resolution
+	// deliberately leaves the listed directory, so the deny-list has to be
+	// applied again on the far side (issue #3344).
+	if target, ok := resolveMacAliasPath(cleanPath); ok {
+		if err := enforceReadContainment(target); err != nil {
+			return NewErrorResult(err, time.Since(start).Milliseconds())
+		}
+		cleanPath = target
+	}
+
 	limit := GetPayloadInt(payload, "limit", defaultFileListLimit)
 	if limit < 1 {
 		limit = 1
@@ -249,13 +261,38 @@ func ListFiles(payload map[string]any) CommandResult {
 			entryType = "directory"
 		}
 
+		entryPath := filepath.Join(cleanPath, entry.Name())
+
+		// macOS Finder aliases are regular files holding a bookmark blob, so
+		// without this they list as ordinary ~1KB files and the UI offers the
+		// blob itself for download (issue #3344). Only Type is taken from the
+		// target, because Type is what drives the client's navigate-vs-download
+		// affordance. Path, Size, Modified and Permissions keep describing the
+		// alias file itself: those are what the mutating operations act on, and
+		// a delete confirmation that quoted the target's size while removing
+		// only a 1KB alias would be actively misleading.
+		aliasTarget := ""
+		if target, targetInfo, ok := resolveMacAliasTarget(entryPath, info); ok {
+			// Never surface an alias that leads into a credential store: leaving
+			// it unresolved keeps both the target path and its contents hidden.
+			if err := enforceReadContainment(target); err == nil {
+				aliasTarget = target
+				entryType = "file"
+				if targetInfo.IsDir() {
+					entryType = "directory"
+				}
+			}
+		}
+
 		fileEntries = append(fileEntries, FileEntry{
 			Name:        entry.Name(),
-			Path:        filepath.Join(cleanPath, entry.Name()),
+			Path:        entryPath,
 			Type:        entryType,
 			Size:        info.Size(),
 			Modified:    info.ModTime().Format(time.RFC3339),
 			Permissions: info.Mode().String(),
+			IsAlias:     aliasTarget != "",
+			AliasTarget: aliasTarget,
 		})
 	}
 
@@ -286,6 +323,17 @@ func ReadFile(payload map[string]any) CommandResult {
 	// Defense-in-depth: never read a credential store, even symlinked (SR5-01).
 	if err := enforceReadContainment(cleanPath); err != nil {
 		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
+	// Downloading a macOS Finder alias should deliver the file it points at, not
+	// the bookmark blob (issue #3344). Containment is re-checked against the
+	// target because an alias can point anywhere, including at a credential
+	// store that filepath.EvalSymlinks would never have surfaced.
+	if target, ok := resolveMacAliasPath(cleanPath); ok {
+		if err := enforceReadContainment(target); err != nil {
+			return NewErrorResult(err, time.Since(start).Milliseconds())
+		}
+		cleanPath = target
 	}
 
 	// Check file info first

--- a/agent/internal/remote/tools/macalias.go
+++ b/agent/internal/remote/tools/macalias.go
@@ -1,0 +1,263 @@
+package tools
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// macOS Finder aliases are not symlinks: on disk they are ordinary regular
+// files whose data fork holds a CoreFoundation "bookmark" blob (the same bytes
+// CFURLCreateBookmarkData / -[NSURL writeBookmarkData:toURL:] produce) and
+// whose com.apple.FinderInfo xattr carries the kIsAlias flag. Because they are
+// regular files, os.DirEntry.IsDir() is false and filepath.EvalSymlinks is a
+// no-op on them, so without explicit handling the file browser lists an alias
+// as a ~1KB "file" and offers the raw bookmark blob for download instead of
+// following it (issue #3344).
+//
+// The blob is parsed here in pure Go rather than through CoreServices/cgo: the
+// agent's CI and several release targets build with CGO_ENABLED=0, so a cgo
+// resolver would silently do nothing on exactly the builds that ship.
+//
+// Blob layout (all integers little-endian):
+//
+//	0x00  "book\0\0\0\0mark\0\0\0\0"  magic
+//	0x10  uint32  header size (56 in every macOS version observed)
+//	0x14  uint32  header size, repeated
+//	0x18  uint32  body size
+//	0x1C  uint32  version
+//	...          reserved
+//
+//	body := blob[headerSize:]
+//	body[0:4]  uint32  offset (relative to body) of the first table of contents
+//
+// Table of contents record:
+//
+//	uint32 size, uint32 magic (0xFFFFFFFE), uint32 identifier,
+//	uint32 offset of next TOC (0 = last), uint32 entry count,
+//	then entryCount × { uint32 key, uint32 offset, uint32 reserved }
+//
+// Item at body[offset]:
+//
+//	uint32 length, uint32 type, then length payload bytes
+//
+// The two keys needed to rebuild a POSIX path are the path-component array and
+// the volume path; everything else (CNIDs, volume UUID, creation dates) is
+// ignored.
+const macAliasMagic = "book\x00\x00\x00\x00mark\x00\x00\x00\x00"
+
+const (
+	// bookmarkKeyPathComponents holds an array of the target's path components,
+	// relative to the volume root.
+	bookmarkKeyPathComponents = 0x1004
+	// bookmarkKeyVolumePath holds the mount point of the target's volume ("/"
+	// for the boot volume, "/Volumes/Name" for anything else).
+	bookmarkKeyVolumePath = 0x2002
+
+	bookmarkTypeString = 0x0101
+	bookmarkTypeArray  = 0x0601
+
+	bookmarkTOCMagic = 0xFFFFFFFE
+
+	// bookmarkMinHeaderSize is the smallest header that can still hold the
+	// magic and the header-size field itself.
+	bookmarkMinHeaderSize = 32
+	bookmarkTOCHeaderSize = 20
+	bookmarkTOCEntrySize  = 12
+	bookmarkItemHeader    = 8
+
+	// Bounds applied to attacker-influenced counts so a small hostile file can
+	// never drive a large allocation or a long loop. Real aliases carry a
+	// single TOC and a handful of path components.
+	maxBookmarkTOCs           = 8
+	maxBookmarkTOCEntries     = 512
+	maxBookmarkPathComponents = 256
+	maxBookmarkStringLen      = 4096
+	// maxBookmarkPathLen bounds the reconstructed path; PATH_MAX on macOS is
+	// 1024, so anything longer cannot name a real file.
+	maxBookmarkPathLen = 4096
+
+	// maxAliasFileSize caps how large a regular file may be before it is
+	// dismissed as a possible alias without reading it. Observed aliases are
+	// under 2KB; 64KB is generous headroom.
+	maxAliasFileSize = 64 * 1024
+)
+
+var errNotBookmark = errors.New("not a macOS bookmark blob")
+
+// resolveMacAliasPath resolves path when it names a macOS Finder alias file,
+// taking care of the lstat itself. Returns ("", false) for anything that is not
+// a resolvable alias, and on every non-macOS platform.
+func resolveMacAliasPath(path string) (string, bool) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", false
+	}
+	target, _, ok := resolveMacAliasTarget(path, info)
+	return target, ok
+}
+
+// hasMacAliasMagic reports whether b starts with the bookmark magic.
+func hasMacAliasMagic(b []byte) bool {
+	return len(b) >= len(macAliasMagic) && string(b[:len(macAliasMagic)]) == macAliasMagic
+}
+
+// sliceAt returns body[off:off+n], or false if that range is out of bounds.
+// off and n arrive from the file, so the arithmetic is done in uint64 to keep
+// a hostile 32-bit value from wrapping on any GOARCH.
+func sliceAt(body []byte, off uint32, n uint64) ([]byte, bool) {
+	end := uint64(off) + n
+	if end > uint64(len(body)) {
+		return nil, false
+	}
+	return body[uint64(off):end], true
+}
+
+// bookmarkItem returns the type and payload of the item stored at body[off].
+func bookmarkItem(body []byte, off uint32) (uint32, []byte, bool) {
+	head, ok := sliceAt(body, off, bookmarkItemHeader)
+	if !ok {
+		return 0, nil, false
+	}
+	length := binary.LittleEndian.Uint32(head[0:4])
+	itemType := binary.LittleEndian.Uint32(head[4:8])
+	payload, ok := sliceAt(body, off+bookmarkItemHeader, uint64(length))
+	if !ok {
+		return 0, nil, false
+	}
+	return itemType, payload, true
+}
+
+// bookmarkString reads a UTF-8 string item.
+func bookmarkString(body []byte, off uint32) (string, bool) {
+	itemType, payload, ok := bookmarkItem(body, off)
+	if !ok || itemType != bookmarkTypeString || len(payload) > maxBookmarkStringLen {
+		return "", false
+	}
+	return string(payload), true
+}
+
+// bookmarkStringArray reads an array item whose elements are string items.
+func bookmarkStringArray(body []byte, off uint32, limit int) ([]string, bool) {
+	itemType, payload, ok := bookmarkItem(body, off)
+	if !ok || itemType != bookmarkTypeArray {
+		return nil, false
+	}
+	count := len(payload) / 4
+	if count == 0 || count > limit {
+		return nil, false
+	}
+	out := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		s, ok := bookmarkString(body, binary.LittleEndian.Uint32(payload[i*4:i*4+4]))
+		if !ok {
+			return nil, false
+		}
+		out = append(out, s)
+	}
+	return out, true
+}
+
+// parseBookmarkTargetPath extracts the absolute POSIX path a macOS bookmark
+// blob points at. It only reads the blob — the returned path is not checked for
+// existence, and callers must treat it as untrusted input until they stat it.
+func parseBookmarkTargetPath(blob []byte) (string, error) {
+	if !hasMacAliasMagic(blob) {
+		return "", errNotBookmark
+	}
+	if len(blob) < bookmarkMinHeaderSize {
+		return "", errNotBookmark
+	}
+
+	headerSize := binary.LittleEndian.Uint32(blob[16:20])
+	if headerSize < bookmarkMinHeaderSize || uint64(headerSize) > uint64(len(blob)) {
+		return "", fmt.Errorf("bookmark header size %d out of range", headerSize)
+	}
+	body := blob[headerSize:]
+	if len(body) < 4 {
+		return "", errNotBookmark
+	}
+
+	var (
+		components []string
+		volumePath string
+		tocOffset  = binary.LittleEndian.Uint32(body[0:4])
+		visited    = make(map[uint32]bool, maxBookmarkTOCs)
+	)
+
+	for hop := 0; tocOffset != 0 && hop < maxBookmarkTOCs; hop++ {
+		if visited[tocOffset] {
+			break // cyclic TOC chain in a malformed/hostile blob
+		}
+		visited[tocOffset] = true
+
+		head, ok := sliceAt(body, tocOffset, bookmarkTOCHeaderSize)
+		if !ok {
+			return "", errors.New("bookmark table of contents out of range")
+		}
+		if binary.LittleEndian.Uint32(head[4:8]) != bookmarkTOCMagic {
+			return "", errors.New("bookmark table of contents has bad magic")
+		}
+		next := binary.LittleEndian.Uint32(head[12:16])
+		count := binary.LittleEndian.Uint32(head[16:20])
+		if count > maxBookmarkTOCEntries {
+			return "", fmt.Errorf("bookmark table of contents lists %d entries", count)
+		}
+		entries, ok := sliceAt(body, tocOffset+bookmarkTOCHeaderSize, uint64(count)*bookmarkTOCEntrySize)
+		if !ok {
+			return "", errors.New("bookmark table of contents entries out of range")
+		}
+
+		for i := uint32(0); i < count; i++ {
+			e := entries[i*bookmarkTOCEntrySize:]
+			key := binary.LittleEndian.Uint32(e[0:4])
+			off := binary.LittleEndian.Uint32(e[4:8])
+			switch key {
+			case bookmarkKeyPathComponents:
+				if components == nil {
+					if parts, ok := bookmarkStringArray(body, off, maxBookmarkPathComponents); ok {
+						components = parts
+					}
+				}
+			case bookmarkKeyVolumePath:
+				if volumePath == "" {
+					if s, ok := bookmarkString(body, off); ok {
+						volumePath = s
+					}
+				}
+			}
+		}
+
+		tocOffset = next
+	}
+
+	if len(components) == 0 {
+		return "", errors.New("bookmark carries no path components")
+	}
+	for _, c := range components {
+		// A component containing a separator or a traversal segment would let a
+		// crafted blob synthesise a different path than the one it describes.
+		if c == "" || c == "." || c == ".." || strings.ContainsRune(c, filepath.Separator) || strings.ContainsRune(c, '/') {
+			return "", fmt.Errorf("bookmark path component %q is not a plain name", c)
+		}
+	}
+
+	if volumePath == "" {
+		volumePath = "/"
+	}
+	if !filepath.IsAbs(volumePath) {
+		return "", fmt.Errorf("bookmark volume path %q is not absolute", volumePath)
+	}
+
+	target := filepath.Join(append([]string{volumePath}, components...)...)
+	if !filepath.IsAbs(target) {
+		return "", fmt.Errorf("bookmark resolved to non-absolute path %q", target)
+	}
+	if len(target) > maxBookmarkPathLen {
+		return "", fmt.Errorf("bookmark resolved to an oversized path (%d bytes)", len(target))
+	}
+	return target, nil
+}

--- a/agent/internal/remote/tools/macalias.go
+++ b/agent/internal/remote/tools/macalias.go
@@ -79,11 +79,6 @@ const (
 	// maxBookmarkPathLen bounds the reconstructed path; PATH_MAX on macOS is
 	// 1024, so anything longer cannot name a real file.
 	maxBookmarkPathLen = 4096
-
-	// maxAliasFileSize caps how large a regular file may be before it is
-	// dismissed as a possible alias without reading it. Observed aliases are
-	// under 2KB; 64KB is generous headroom.
-	maxAliasFileSize = 64 * 1024
 )
 
 var errNotBookmark = errors.New("not a macOS bookmark blob")

--- a/agent/internal/remote/tools/macalias_darwin.go
+++ b/agent/internal/remote/tools/macalias_darwin.go
@@ -1,0 +1,106 @@
+//go:build darwin
+
+package tools
+
+import (
+	"encoding/binary"
+	"io"
+	"io/fs"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// finderInfoAttr holds the 32-byte Carbon FileInfo/FolderInfo record.
+	finderInfoAttr = "com.apple.FinderInfo"
+	// finderFlagIsAlias is kIsAlias, bit 15 of the big-endian uint16 Finder
+	// flags field at offset 8 of that record. Finder itself uses this bit to
+	// decide whether a file is an alias, so it is the authoritative test.
+	finderFlagIsAlias = 0x8000
+
+	// maxAliasResolveHops bounds an alias→alias chain.
+	maxAliasResolveHops = 8
+)
+
+// hasFinderAliasFlag reports whether path carries the Finder kIsAlias flag.
+// This is a single getxattr with no open(2), which keeps the per-entry cost of
+// checking a large directory listing negligible: virtually no file on a modern
+// macOS system has a com.apple.FinderInfo xattr at all, so the common case is
+// one failing syscall.
+func hasFinderAliasFlag(path string) bool {
+	var buf [32]byte
+	n, err := unix.Getxattr(path, finderInfoAttr, buf[:])
+	if err != nil || n < 10 {
+		return false
+	}
+	return binary.BigEndian.Uint16(buf[8:10])&finderFlagIsAlias != 0
+}
+
+// resolveAliasHop follows path one step if it is a macOS Finder alias file
+// whose target currently exists. info must be the lstat of path.
+func resolveAliasHop(path string, info fs.FileInfo) (string, fs.FileInfo, bool) {
+	if info == nil || !info.Mode().IsRegular() {
+		return "", nil, false
+	}
+	if info.Size() < int64(len(macAliasMagic)) || info.Size() > maxAliasFileSize {
+		return "", nil, false
+	}
+	if !hasFinderAliasFlag(path) {
+		return "", nil, false
+	}
+	// Read through a bounded reader rather than os.ReadFile: the size above came
+	// from a stat that another process can invalidate before the open, and an
+	// alias blob is never larger than maxAliasFileSize anyway.
+	f, err := os.Open(path)
+	if err != nil {
+		return "", nil, false
+	}
+	blob, err := io.ReadAll(io.LimitReader(f, maxAliasFileSize))
+	f.Close()
+	if err != nil {
+		return "", nil, false
+	}
+	target, err := parseBookmarkTargetPath(blob)
+	if err != nil || target == path {
+		return "", nil, false
+	}
+	targetInfo, err := os.Stat(target)
+	if err != nil {
+		return "", nil, false
+	}
+	return target, targetInfo, true
+}
+
+// resolveMacAliasTarget resolves path when it is a macOS Finder alias file,
+// following alias→alias chains up to maxAliasResolveHops. info must be the
+// lstat of path (os.DirEntry.Info() qualifies).
+//
+// It reports ok=false — leaving the caller's existing behaviour untouched — for
+// anything that is not a resolvable alias: ordinary files, symlinks,
+// directories, aliases whose target has been deleted, and blobs that fail to
+// parse.
+//
+// Resolution is deliberately kept free of containment policy so that every
+// caller decides what a denied target means for it (a per-entry listing hides
+// the alias; an explicit read or navigation returns an error). Callers MUST run
+// enforceReadContainment against the returned target — following an alias
+// intentionally steps outside the directory being listed, and filepath.EvalSymlinks
+// does not see through an alias.
+func resolveMacAliasTarget(path string, info fs.FileInfo) (string, fs.FileInfo, bool) {
+	cur, curInfo := path, info
+	resolved := false
+	visited := map[string]bool{path: true}
+	for hop := 0; hop < maxAliasResolveHops; hop++ {
+		next, nextInfo, ok := resolveAliasHop(cur, curInfo)
+		if !ok || visited[next] {
+			break // not an alias, or an alias chain that loops back on itself
+		}
+		visited[next] = true
+		cur, curInfo, resolved = next, nextInfo, true
+	}
+	if !resolved {
+		return "", nil, false
+	}
+	return cur, curInfo, true
+}

--- a/agent/internal/remote/tools/macalias_darwin.go
+++ b/agent/internal/remote/tools/macalias_darwin.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"io"
 	"io/fs"
+	"log"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -21,6 +22,11 @@ const (
 
 	// maxAliasResolveHops bounds an alias→alias chain.
 	maxAliasResolveHops = 8
+
+	// maxAliasFileSize caps how large a regular file may be before it is
+	// dismissed as a possible alias without reading it. Observed aliases are
+	// under 2KB; 64KB is generous headroom.
+	maxAliasFileSize = 64 * 1024
 )
 
 // hasFinderAliasFlag reports whether path carries the Finder kIsAlias flag.
@@ -49,24 +55,47 @@ func resolveAliasHop(path string, info fs.FileInfo) (string, fs.FileInfo, bool) 
 	if !hasFinderAliasFlag(path) {
 		return "", nil, false
 	}
+	// Past this point Finder's own kIsAlias bit says this IS an alias, so a
+	// failure is worth a log line: the caller degrades it to "ordinary file",
+	// which otherwise leaves a technician staring at a 1KB file with no hint
+	// that resolution was attempted and failed. Logging cannot flood a listing
+	// because almost nothing carries the flag in the first place — the one
+	// genuinely routine failure, a dangling alias whose target was deleted, is
+	// excluded below.
+
 	// Read through a bounded reader rather than os.ReadFile: the size above came
 	// from a stat that another process can invalidate before the open, and an
 	// alias blob is never larger than maxAliasFileSize anyway.
 	f, err := os.Open(path)
 	if err != nil {
+		log.Printf("[WARN] resolveAliasHop: cannot open alias %s: %v", path, err)
 		return "", nil, false
 	}
 	blob, err := io.ReadAll(io.LimitReader(f, maxAliasFileSize))
-	f.Close()
+	_ = f.Close() // read-only handle; a close error cannot affect the bytes read
 	if err != nil {
+		log.Printf("[WARN] resolveAliasHop: cannot read alias %s: %v", path, err)
 		return "", nil, false
 	}
 	target, err := parseBookmarkTargetPath(blob)
-	if err != nil || target == path {
+	if err != nil {
+		// The parser's error is the only forensic trail when a blob is corrupt
+		// or is probing the path-traversal guard, so keep its text.
+		log.Printf("[WARN] resolveAliasHop: cannot parse alias %s: %v", path, err)
+		return "", nil, false
+	}
+	if target == path {
+		log.Printf("[WARN] resolveAliasHop: alias %s points at itself", path)
 		return "", nil, false
 	}
 	targetInfo, err := os.Stat(target)
 	if err != nil {
+		// A dangling alias is routine (a Desktop full of shortcuts to things
+		// since deleted) and stays silent; anything else — a permission error on
+		// a parent directory, an I/O error — is actionable.
+		if !os.IsNotExist(err) {
+			log.Printf("[WARN] resolveAliasHop: cannot stat target of alias %s: %v", path, err)
+		}
 		return "", nil, false
 	}
 	return target, targetInfo, true

--- a/agent/internal/remote/tools/macalias_darwin_test.go
+++ b/agent/internal/remote/tools/macalias_darwin_test.go
@@ -1,0 +1,377 @@
+//go:build darwin
+
+package tools
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// writeAliasFile creates a macOS Finder alias file at aliasPath pointing at
+// target: the bookmark blob in the data fork plus the com.apple.FinderInfo
+// xattr with kIsAlias set, exactly as Finder and -[NSURL writeBookmarkData:toURL:]
+// produce them. Written by hand rather than through CoreServices because the
+// agent must build and test with CGO_ENABLED=0.
+func writeAliasFile(t *testing.T, aliasPath, target string) {
+	t.Helper()
+
+	if !filepath.IsAbs(target) {
+		t.Fatalf("alias target %q must be absolute", target)
+	}
+	components := strings.Split(strings.Trim(target, "/"), "/")
+	blob := buildBookmark(t, "/", components)
+
+	if err := os.WriteFile(aliasPath, blob, 0o644); err != nil {
+		t.Fatalf("write alias file: %v", err)
+	}
+	setFinderAliasFlag(t, aliasPath)
+}
+
+func setFinderAliasFlag(t *testing.T, path string) {
+	t.Helper()
+	var finderInfo [32]byte
+	copy(finderInfo[0:4], "alis")
+	copy(finderInfo[4:8], "MACS")
+	binary.BigEndian.PutUint16(finderInfo[8:10], finderFlagIsAlias)
+	if err := unix.Setxattr(path, finderInfoAttr, finderInfo[:], 0); err != nil {
+		t.Fatalf("set FinderInfo xattr: %v", err)
+	}
+}
+
+// entryByName finds a listing entry by name.
+func entryByName(t *testing.T, entries []FileEntry, name string) FileEntry {
+	t.Helper()
+	for _, e := range entries {
+		if e.Name == name {
+			return e
+		}
+	}
+	t.Fatalf("entry %q not found in listing of %d entries", name, len(entries))
+	return FileEntry{}
+}
+
+func listDir(t *testing.T, dir string) FileListResponse {
+	t.Helper()
+	var payload FileListResponse
+	decodeSuccessPayload(t, ListFiles(map[string]any{"path": dir}), &payload)
+	return payload
+}
+
+// The reported bug (#3344): an alias to a folder listed as a plain file, so the
+// UI offered to download the bookmark blob instead of navigating into it.
+func TestListFilesResolvesFolderAlias(t *testing.T) {
+	root := t.TempDir()
+	targetDir := filepath.Join(root, "iCloud Folder")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "inside.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	desktop := filepath.Join(root, "Desktop")
+	if err := os.Mkdir(desktop, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aliasPath := filepath.Join(desktop, "iCloud Folder alias")
+	writeAliasFile(t, aliasPath, targetDir)
+
+	entry := entryByName(t, listDir(t, desktop).Entries, "iCloud Folder alias")
+
+	if entry.Type != "directory" {
+		t.Errorf("Type = %q, want %q so the client navigates instead of downloading", entry.Type, "directory")
+	}
+	if !entry.IsAlias {
+		t.Error("IsAlias = false, want true")
+	}
+	if entry.AliasTarget != targetDir {
+		t.Errorf("AliasTarget = %q, want %q", entry.AliasTarget, targetDir)
+	}
+	// Path must stay on the alias so rename/delete/move act on the alias and
+	// not on the folder it points at.
+	if entry.Path != aliasPath {
+		t.Errorf("Path = %q, want the alias itself %q", entry.Path, aliasPath)
+	}
+	// Likewise the size describes the ~1KB alias file, which is what a delete
+	// confirmation would be quoting.
+	if entry.Size == 0 || entry.Size > maxAliasFileSize {
+		t.Errorf("Size = %d, want the alias file's own size", entry.Size)
+	}
+}
+
+func TestListFilesResolvesFileAlias(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "report.pdf")
+	if err := os.WriteFile(target, []byte("pdf bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasPath := filepath.Join(root, "report alias")
+	writeAliasFile(t, aliasPath, target)
+
+	entry := entryByName(t, listDir(t, root).Entries, "report alias")
+
+	if entry.Type != "file" {
+		t.Errorf("Type = %q, want %q", entry.Type, "file")
+	}
+	if !entry.IsAlias || entry.AliasTarget != target {
+		t.Errorf("IsAlias = %v, AliasTarget = %q, want true / %q", entry.IsAlias, entry.AliasTarget, target)
+	}
+}
+
+// Navigating into a folder alias: the client sends the alias's own path, and
+// the agent must list the target and report the path it actually listed so the
+// client's breadcrumb and upload destination follow it there.
+func TestListFilesNavigatesIntoFolderAlias(t *testing.T) {
+	root := t.TempDir()
+	targetDir := filepath.Join(root, "Target")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "inside.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasPath := filepath.Join(root, "Target alias")
+	writeAliasFile(t, aliasPath, targetDir)
+
+	payload := listDir(t, aliasPath)
+
+	if payload.Path != targetDir {
+		t.Errorf("listed Path = %q, want the resolved target %q", payload.Path, targetDir)
+	}
+	entryByName(t, payload.Entries, "inside.txt")
+}
+
+// Downloading a file alias must deliver the target's bytes, not the bookmark
+// blob, and must report the target's path so the download gets the target's
+// filename.
+func TestReadFileResolvesFileAlias(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "notes.txt")
+	content := "the real contents"
+	if err := os.WriteFile(target, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	aliasPath := filepath.Join(root, "notes alias")
+	writeAliasFile(t, aliasPath, target)
+
+	var payload struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
+	decodeSuccessPayload(t, ReadFile(map[string]any{"path": aliasPath}), &payload)
+
+	if payload.Content != content {
+		t.Errorf("Content = %q, want the target's contents %q", payload.Content, content)
+	}
+	if payload.Path != target {
+		t.Errorf("Path = %q, want the resolved target %q", payload.Path, target)
+	}
+}
+
+// An alias chain (alias -> alias -> folder) resolves all the way through.
+func TestResolvesAliasChain(t *testing.T) {
+	root := t.TempDir()
+	targetDir := filepath.Join(root, "Final")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(root, "hop1")
+	second := filepath.Join(root, "hop2")
+	writeAliasFile(t, second, targetDir)
+	writeAliasFile(t, first, second)
+
+	entry := entryByName(t, listDir(t, root).Entries, "hop1")
+	if entry.Type != "directory" || entry.AliasTarget != targetDir {
+		t.Errorf("Type = %q, AliasTarget = %q, want directory / %q", entry.Type, entry.AliasTarget, targetDir)
+	}
+}
+
+// A chain that points back at itself must terminate rather than spin.
+func TestAliasChainCycleTerminates(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+	writeAliasFile(t, a, b)
+	writeAliasFile(t, b, a)
+
+	entry := entryByName(t, listDir(t, root).Entries, "a")
+	// Whatever it settles on, it must be a terminating, non-panicking listing.
+	if entry.Path != a {
+		t.Errorf("Path = %q, want %q", entry.Path, a)
+	}
+}
+
+// SR5-01: alias resolution deliberately escapes the listed directory, so the
+// credential-store deny-list has to be re-applied against the target. An alias
+// pointing at a secret must not be resolved, must not disclose its target, and
+// must not be readable through the alias.
+func TestAliasToSensitivePathIsNotResolved(t *testing.T) {
+	root := t.TempDir()
+	sshDir := filepath.Join(root, ".ssh")
+	if err := os.Mkdir(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(sshDir, "id_rsa")
+	if err := os.WriteFile(secret, []byte("PRIVATE KEY"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isSensitiveReadPath(secret) {
+		t.Fatalf("test setup: %q is not on the deny-list", secret)
+	}
+
+	aliasPath := filepath.Join(root, "harmless alias")
+	writeAliasFile(t, aliasPath, secret)
+
+	entry := entryByName(t, listDir(t, root).Entries, "harmless alias")
+	if entry.IsAlias {
+		t.Error("IsAlias = true, want false: an alias into a credential store must stay unresolved")
+	}
+	if entry.AliasTarget != "" {
+		t.Errorf("AliasTarget = %q, want empty: the target path must not be disclosed", entry.AliasTarget)
+	}
+	if entry.Type != "file" {
+		t.Errorf("Type = %q, want %q", entry.Type, "file")
+	}
+
+	// Reading through the alias must be denied outright, not silently served.
+	result := ReadFile(map[string]any{"path": aliasPath})
+	if result.Status == "completed" {
+		t.Fatalf("ReadFile through an alias into a credential store succeeded: %s", result.Stdout)
+	}
+	if !strings.Contains(result.Error, "sensitive path") {
+		t.Errorf("Error = %q, want a sensitive-path denial", result.Error)
+	}
+	if strings.Contains(result.Stdout, "PRIVATE KEY") {
+		t.Error("secret contents leaked through the alias")
+	}
+}
+
+// Listing an alias that points at a credential-store directory must be denied
+// rather than falling back to listing the alias file itself.
+func TestListFilesThroughAliasToSensitiveDirIsDenied(t *testing.T) {
+	root := t.TempDir()
+	// /etc/sudoers.d is deny-listed as a directory in its own right, unlike
+	// e.g. Library/Keychains which is only matched with a trailing separator.
+	sensitiveDir := filepath.Join(root, "etc", "sudoers.d")
+	if err := os.MkdirAll(sensitiveDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if !isSensitiveReadPath(sensitiveDir) {
+		t.Fatalf("test setup: %q is not on the deny-list", sensitiveDir)
+	}
+
+	aliasPath := filepath.Join(root, "keys alias")
+	writeAliasFile(t, aliasPath, sensitiveDir)
+
+	result := ListFiles(map[string]any{"path": aliasPath})
+	if result.Status == "completed" {
+		t.Fatalf("listing through an alias into a keychain directory succeeded: %s", result.Stdout)
+	}
+	if !strings.Contains(result.Error, "sensitive path") {
+		t.Errorf("Error = %q, want a sensitive-path denial", result.Error)
+	}
+}
+
+// Things that must NOT be treated as aliases.
+func TestNonAliasesAreLeftAlone(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A bookmark blob with no kIsAlias flag: some apps store bookmark data in
+	// ordinary files, and those are still just files.
+	unflagged := filepath.Join(root, "bookmark.data")
+	if err := os.WriteFile(unflagged, buildBookmark(t, "/", strings.Split(strings.Trim(target, "/"), "/")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Flagged, but the payload is not a bookmark.
+	junk := filepath.Join(root, "junk.bin")
+	if err := os.WriteFile(junk, []byte(strings.Repeat("not a bookmark", 8)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	setFinderAliasFlag(t, junk)
+
+	// A well-formed alias whose target has been deleted.
+	dangling := filepath.Join(root, "dangling alias")
+	writeAliasFile(t, dangling, filepath.Join(root, "gone.txt"))
+
+	// A plain file and a POSIX symlink, which the existing code already handles.
+	plain := filepath.Join(root, "plain.txt")
+	if err := os.WriteFile(plain, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := listDir(t, root).Entries
+	for _, name := range []string{"bookmark.data", "junk.bin", "dangling alias", "plain.txt", "link.txt"} {
+		e := entryByName(t, entries, name)
+		if e.IsAlias {
+			t.Errorf("%s: IsAlias = true, want false", name)
+		}
+		if e.AliasTarget != "" {
+			t.Errorf("%s: AliasTarget = %q, want empty", name, e.AliasTarget)
+		}
+		if e.Type != "file" {
+			t.Errorf("%s: Type = %q, want %q", name, e.Type, "file")
+		}
+	}
+}
+
+// A file large enough to be implausible as an alias is never opened for
+// parsing, even if it carries the flag.
+func TestOversizedFlaggedFileIsNotProbed(t *testing.T) {
+	root := t.TempDir()
+	big := filepath.Join(root, "big.bin")
+	if err := os.WriteFile(big, make([]byte, maxAliasFileSize+1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	setFinderAliasFlag(t, big)
+
+	entry := entryByName(t, listDir(t, root).Entries, "big.bin")
+	if entry.IsAlias {
+		t.Error("IsAlias = true for an oversized file, want false")
+	}
+}
+
+func TestHasFinderAliasFlag(t *testing.T) {
+	root := t.TempDir()
+	plain := filepath.Join(root, "plain.txt")
+	if err := os.WriteFile(plain, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if hasFinderAliasFlag(plain) {
+		t.Error("hasFinderAliasFlag() = true for a file with no FinderInfo xattr")
+	}
+
+	// FinderInfo present but kIsAlias clear (e.g. a custom-icon flag).
+	tagged := filepath.Join(root, "tagged.txt")
+	if err := os.WriteFile(tagged, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var fi [32]byte
+	copy(fi[0:4], "TEXT")
+	copy(fi[4:8], "MACS")
+	binary.BigEndian.PutUint16(fi[8:10], 0x0400) // kHasCustomIcon
+	if err := unix.Setxattr(tagged, finderInfoAttr, fi[:], 0); err != nil {
+		t.Fatal(err)
+	}
+	if hasFinderAliasFlag(tagged) {
+		t.Error("hasFinderAliasFlag() = true for FinderInfo without kIsAlias")
+	}
+
+	setFinderAliasFlag(t, tagged)
+	if !hasFinderAliasFlag(tagged) {
+		t.Error("hasFinderAliasFlag() = false for FinderInfo with kIsAlias")
+	}
+}

--- a/agent/internal/remote/tools/macalias_other.go
+++ b/agent/internal/remote/tools/macalias_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package tools
+
+import "io/fs"
+
+// resolveMacAliasTarget is a no-op off macOS: Finder alias files are a macOS
+// concept, so every other platform reports "not an alias" and the file browser
+// keeps its existing behaviour. See macalias_darwin.go for the real
+// implementation.
+func resolveMacAliasTarget(_ string, _ fs.FileInfo) (string, fs.FileInfo, bool) {
+	return "", nil, false
+}

--- a/agent/internal/remote/tools/macalias_test.go
+++ b/agent/internal/remote/tools/macalias_test.go
@@ -1,0 +1,255 @@
+package tools
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+// buildBookmark assembles a macOS bookmark blob in the layout documented in
+// macalias.go. It mirrors the byte layout of real alias files produced by
+// macOS Sequoia (verified against aliases created with
+// -[NSURL writeBookmarkData:toURL:] on a 15.x host), so the parser is exercised
+// against the same structure it will meet in the field, on every GOOS.
+func buildBookmark(t *testing.T, volumePath string, components []string) []byte {
+	t.Helper()
+
+	// Body items are laid out first; offsets are relative to the body start.
+	var body []byte
+	// The first four bytes of the body hold the offset of the first TOC, filled
+	// in once the item area is sized.
+	body = append(body, 0, 0, 0, 0)
+
+	appendItem := func(itemType uint32, payload []byte) uint32 {
+		off := uint32(len(body))
+		var head [8]byte
+		binary.LittleEndian.PutUint32(head[0:4], uint32(len(payload)))
+		binary.LittleEndian.PutUint32(head[4:8], itemType)
+		body = append(body, head[:]...)
+		body = append(body, payload...)
+		for len(body)%4 != 0 { // items are 4-byte aligned
+			body = append(body, 0)
+		}
+		return off
+	}
+
+	componentOffsets := make([]byte, 0, len(components)*4)
+	for _, c := range components {
+		off := appendItem(bookmarkTypeString, []byte(c))
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], off)
+		componentOffsets = append(componentOffsets, b[:]...)
+	}
+	componentsOff := appendItem(bookmarkTypeArray, componentOffsets)
+	volumeOff := appendItem(bookmarkTypeString, []byte(volumePath))
+
+	// Table of contents.
+	tocOff := uint32(len(body))
+	entries := []struct {
+		key, off uint32
+	}{
+		{bookmarkKeyPathComponents, componentsOff},
+		{bookmarkKeyVolumePath, volumeOff},
+	}
+	toc := make([]byte, bookmarkTOCHeaderSize)
+	binary.LittleEndian.PutUint32(toc[0:4], uint32(bookmarkTOCHeaderSize+len(entries)*bookmarkTOCEntrySize))
+	binary.LittleEndian.PutUint32(toc[4:8], bookmarkTOCMagic)
+	binary.LittleEndian.PutUint32(toc[8:12], 1)  // identifier
+	binary.LittleEndian.PutUint32(toc[12:16], 0) // next TOC: none
+	binary.LittleEndian.PutUint32(toc[16:20], uint32(len(entries)))
+	for _, e := range entries {
+		var rec [bookmarkTOCEntrySize]byte
+		binary.LittleEndian.PutUint32(rec[0:4], e.key)
+		binary.LittleEndian.PutUint32(rec[4:8], e.off)
+		toc = append(toc, rec[:]...)
+	}
+	body = append(body, toc...)
+	binary.LittleEndian.PutUint32(body[0:4], tocOff)
+
+	header := make([]byte, 56)
+	copy(header, macAliasMagic)
+	binary.LittleEndian.PutUint32(header[16:20], 56)
+	binary.LittleEndian.PutUint32(header[20:24], 56)
+	binary.LittleEndian.PutUint32(header[24:28], uint32(len(body)))
+	binary.LittleEndian.PutUint32(header[28:32], 0x10050000)
+
+	return append(header, body...)
+}
+
+func TestParseBookmarkTargetPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		volumePath string
+		components []string
+		want       string
+	}{
+		{
+			name:       "boot volume folder",
+			volumePath: "/",
+			components: []string{"Users", "tech", "Desktop", "Projects"},
+			want:       "/Users/tech/Desktop/Projects",
+		},
+		{
+			// The reporter's case: a Desktop alias into iCloud Drive.
+			name:       "icloud drive folder",
+			volumePath: "/",
+			components: []string{"Users", "tech", "Library", "Mobile Documents", "com~apple~CloudDocs", "Shared"},
+			want:       "/Users/tech/Library/Mobile Documents/com~apple~CloudDocs/Shared",
+		},
+		{
+			name:       "external volume",
+			volumePath: "/Volumes/Backup Drive",
+			components: []string{"Archive", "2026", "report.pdf"},
+			want:       "/Volumes/Backup Drive/Archive/2026/report.pdf",
+		},
+		{
+			name:       "single component",
+			volumePath: "/",
+			components: []string{"Applications"},
+			want:       "/Applications",
+		},
+		{
+			name:       "names with spaces and unicode",
+			volumePath: "/",
+			components: []string{"Users", "tech", "Ünïcode Dîr", "my file.txt"},
+			want:       "/Users/tech/Ünïcode Dîr/my file.txt",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseBookmarkTargetPath(buildBookmark(t, tc.volumePath, tc.components))
+			if err != nil {
+				t.Fatalf("parseBookmarkTargetPath() error = %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("parseBookmarkTargetPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseBookmarkTargetPathRejectsNonBookmarks(t *testing.T) {
+	valid := buildBookmark(t, "/", []string{"Users", "tech"})
+
+	tests := []struct {
+		name string
+		blob []byte
+	}{
+		{"empty", nil},
+		{"short", []byte("book")},
+		{"wrong magic", append([]byte("junk\x00\x00\x00\x00junk\x00\x00\x00\x00"), valid[16:]...)},
+		{"truncated body", valid[:40]},
+		{"truncated mid-body", valid[:len(valid)-8]},
+		{"plain text file", []byte(strings.Repeat("hello world\n", 40))},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := parseBookmarkTargetPath(tc.blob); err == nil {
+				t.Errorf("parseBookmarkTargetPath() = %q, want error", got)
+			}
+		})
+	}
+}
+
+// A hostile blob must not be able to steer the resolved path somewhere else by
+// smuggling separators or traversal segments into a path component.
+func TestParseBookmarkTargetPathRejectsHostileComponents(t *testing.T) {
+	for _, comp := range []string{"..", ".", "", "etc/shadow", "../../etc"} {
+		t.Run(comp, func(t *testing.T) {
+			blob := buildBookmark(t, "/", []string{"Users", comp})
+			if got, err := parseBookmarkTargetPath(blob); err == nil {
+				t.Errorf("parseBookmarkTargetPath() = %q, want error for component %q", got, comp)
+			}
+		})
+	}
+}
+
+func TestParseBookmarkTargetPathRejectsRelativeVolumePath(t *testing.T) {
+	blob := buildBookmark(t, "relative/volume", []string{"Users"})
+	if got, err := parseBookmarkTargetPath(blob); err == nil {
+		t.Errorf("parseBookmarkTargetPath() = %q, want error", got)
+	}
+}
+
+// A malformed blob must fail fast rather than allocate or spin: the parser is
+// fed bytes that came off a customer's disk.
+func TestParseBookmarkTargetPathBoundsHostileHeaders(t *testing.T) {
+	base := buildBookmark(t, "/", []string{"Users", "tech"})
+
+	t.Run("header size beyond blob", func(t *testing.T) {
+		blob := append([]byte(nil), base...)
+		binary.LittleEndian.PutUint32(blob[16:20], 0xFFFFFFF0)
+		if _, err := parseBookmarkTargetPath(blob); err == nil {
+			t.Error("expected error for out-of-range header size")
+		}
+	})
+
+	t.Run("header size below minimum", func(t *testing.T) {
+		blob := append([]byte(nil), base...)
+		binary.LittleEndian.PutUint32(blob[16:20], 8)
+		if _, err := parseBookmarkTargetPath(blob); err == nil {
+			t.Error("expected error for undersized header")
+		}
+	})
+
+	t.Run("toc offset beyond body", func(t *testing.T) {
+		blob := append([]byte(nil), base...)
+		binary.LittleEndian.PutUint32(blob[56:60], 0xFFFFFF00)
+		if _, err := parseBookmarkTargetPath(blob); err == nil {
+			t.Error("expected error for out-of-range TOC offset")
+		}
+	})
+
+	t.Run("toc entry count beyond body", func(t *testing.T) {
+		blob := append([]byte(nil), base...)
+		tocOff := 56 + binary.LittleEndian.Uint32(blob[56:60])
+		binary.LittleEndian.PutUint32(blob[tocOff+16:tocOff+20], 64)
+		if _, err := parseBookmarkTargetPath(blob); err == nil {
+			t.Error("expected error for oversized TOC entry count")
+		}
+	})
+
+	t.Run("toc entry count beyond cap", func(t *testing.T) {
+		blob := append([]byte(nil), base...)
+		tocOff := 56 + binary.LittleEndian.Uint32(blob[56:60])
+		binary.LittleEndian.PutUint32(blob[tocOff+16:tocOff+20], maxBookmarkTOCEntries+1)
+		if _, err := parseBookmarkTargetPath(blob); err == nil {
+			t.Error("expected error for TOC entry count above the cap")
+		}
+	})
+
+	t.Run("toc chain that loops forever", func(t *testing.T) {
+		blob := append([]byte(nil), base...)
+		tocOff := 56 + binary.LittleEndian.Uint32(blob[56:60])
+		// Point the "next TOC" link back at this same TOC.
+		binary.LittleEndian.PutUint32(blob[tocOff+12:tocOff+16], binary.LittleEndian.Uint32(blob[56:60]))
+		// Must terminate; the self-referencing link is ignored, so the path
+		// still parses from the single real TOC.
+		if _, err := parseBookmarkTargetPath(blob); err != nil {
+			t.Fatalf("parseBookmarkTargetPath() error = %v", err)
+		}
+	})
+
+	t.Run("bad toc magic", func(t *testing.T) {
+		blob := append([]byte(nil), base...)
+		tocOff := 56 + binary.LittleEndian.Uint32(blob[56:60])
+		binary.LittleEndian.PutUint32(blob[tocOff+4:tocOff+8], 0xDEADBEEF)
+		if _, err := parseBookmarkTargetPath(blob); err == nil {
+			t.Error("expected error for bad TOC magic")
+		}
+	})
+}
+
+func TestHasMacAliasMagic(t *testing.T) {
+	if !hasMacAliasMagic([]byte(macAliasMagic + "trailing")) {
+		t.Error("hasMacAliasMagic() = false for a blob with the magic")
+	}
+	if hasMacAliasMagic([]byte("book")) {
+		t.Error("hasMacAliasMagic() = true for a too-short blob")
+	}
+	if hasMacAliasMagic([]byte("bookmark\x00\x00\x00\x00\x00\x00\x00\x00")) {
+		t.Error("hasMacAliasMagic() = true for a blob without the exact magic")
+	}
+}

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -431,12 +431,26 @@ type RegistryValuesResponse struct {
 
 // FileEntry represents a file or directory in file listing responses
 type FileEntry struct {
-	Name        string `json:"name"`
-	Path        string `json:"path"`
-	Type        string `json:"type"` // "file" or "directory"
+	Name string `json:"name"`
+	// Path always names the entry itself. For a macOS Finder alias that means
+	// the alias file, not its target, so rename/delete/move act on the alias.
+	Path string `json:"path"`
+	// Type is "file" or "directory". A resolved macOS Finder alias reports the
+	// kind of its *target*, so existing clients navigate into a folder alias
+	// and download through a file alias without needing to know about aliases.
+	Type string `json:"type"`
+	// Size, Modified and Permissions always describe the entry at Path — for an
+	// alias that is the small bookmark file, not its target, so that a delete
+	// confirmation quotes what will actually be removed.
 	Size        int64  `json:"size,omitempty"`
 	Modified    string `json:"modified,omitempty"`
 	Permissions string `json:"permissions,omitempty"`
+	// IsAlias marks a macOS Finder alias that was resolved successfully, and
+	// AliasTarget carries the absolute path it resolved to. Both are omitted for
+	// ordinary entries and for aliases that could not be resolved (which stay
+	// indistinguishable from plain files, as before).
+	IsAlias     bool   `json:"isAlias,omitempty"`
+	AliasTarget string `json:"aliasTarget,omitempty"`
 }
 
 // FileListResponse represents the response for file listing

--- a/apps/api/src/routes/systemTools/fileBrowser.ts
+++ b/apps/api/src/routes/systemTools/fileBrowser.ts
@@ -49,7 +49,13 @@ fileBrowserRoutes.get(
 
     try {
       const data = JSON.parse(result.stdout || '{}');
-      return c.json({ data: data.entries || [] });
+      // Echo the path the agent actually listed. It normally equals the
+      // requested path, but the agent resolves a macOS Finder alias to its
+      // target before listing (issue #3344), and the client needs the resolved
+      // path so breadcrumbs, "go up" and the upload destination refer to a real
+      // directory rather than to the alias file.
+      const listedPath = typeof data.path === 'string' && data.path ? data.path : path;
+      return c.json({ data: data.entries || [], path: listedPath });
     } catch {
       return c.json({ error: 'Failed to parse agent response for file listing' }, 502);
     }

--- a/apps/api/src/routes/systemTools/types.ts
+++ b/apps/api/src/routes/systemTools/types.ts
@@ -91,8 +91,17 @@ export interface TaskHistoryEntry {
 export interface FileEntryInfo {
   name: string;
   path: string;
+  /**
+   * For a resolved macOS Finder alias this is the *target's* kind, so clients
+   * navigate into a folder alias and download through a file alias without
+   * needing alias-specific handling.
+   */
   type: 'file' | 'directory';
   size?: number;
   modified?: string;
   permissions?: string;
+  /** Set when the agent resolved this entry as a macOS Finder alias. */
+  isAlias?: boolean;
+  /** Absolute path the alias resolved to; `path` still names the alias file. */
+  aliasTarget?: string;
 }

--- a/apps/web/src/components/remote/FileManager.tsx
+++ b/apps/web/src/components/remote/FileManager.tsx
@@ -57,6 +57,13 @@ export type FileEntry = {
   size?: number;
   modified?: string;
   permissions?: string;
+  /**
+   * macOS Finder alias that the agent resolved. `type` reflects the target's
+   * kind (so a folder alias navigates and a file alias downloads), while
+   * `path`/`size`/`modified` still describe the alias file itself.
+   */
+  isAlias?: boolean;
+  aliasTarget?: string;
 };
 
 export type TransferItem = {
@@ -343,7 +350,10 @@ export default function FileManager({
       const json = await response.json();
       const entriesData = Array.isArray(json.data) ? json.data : [];
       setEntries(entriesData);
-      setCurrentPath(path);
+      // Prefer the path the agent actually listed: navigating into a macOS
+      // Finder alias lands on the alias's target, and uploads/breadcrumbs must
+      // follow it there rather than stay on the alias file.
+      setCurrentPath(typeof json.path === 'string' && json.path ? json.path : path);
       setError(null);
     } catch (err) {
       const message = err instanceof Error ? err.message : t('fileManager.errors.loadDirectory');

--- a/apps/web/src/components/remote/FolderPickerDialog.tsx
+++ b/apps/web/src/components/remote/FolderPickerDialog.tsx
@@ -57,7 +57,9 @@ export default function FolderPickerDialog({
           .filter((e) => e.type === 'directory')
           .sort((a, b) => a.name.localeCompare(b.name))
       );
-      setCurrentPath(path);
+      // The agent resolves a macOS Finder alias before listing, so the chosen
+      // destination must be the path it actually listed, not the alias file.
+      setCurrentPath(typeof json.path === 'string' && json.path ? json.path : path);
     } catch (err) {
       const message = err instanceof Error ? err.message : t('folderPickerDialog.errors.loadDirectory');
       setError(message);


### PR DESCRIPTION
Addresses **part 2** of #3344 (File Browser doesn't follow macOS Finder aliases).

> **Not `Closes #3344` on purpose.** That issue bundles two reports. Part 1 (Remote Desktop rename/Delete on Sequoia) is untouched here and triage found no code defect for it, so the issue should stay open after this merges.

## The bug

A Finder alias is **not** a symlink. On disk it is an ordinary regular file whose data fork holds a CoreFoundation bookmark blob and whose `com.apple.FinderInfo` xattr carries the `kIsAlias` flag. So `os.DirEntry.IsDir()` is false and `filepath.EvalSymlinks` is a no-op on one.

`ListFiles` derived `Type` purely from `entry.IsDir()`, which meant every alias was classified `"file"`. The reporter's case — a Desktop alias into iCloud Drive, an extremely common macOS pattern — listed as a ~1KB file and the UI offered the **bookmark blob itself** for download instead of navigating to the target. Technicians had to fall back to Apple Screen Sharing.

## The fix

**`agent/internal/remote/tools/macalias.go`** — the bookmark parser, deliberately built on *every* platform so its tests run in CI's linux job. It walks the blob's table of contents and rebuilds the target path from the path-component array (key `0x1004`) and the volume path (key `0x2002`).

**`agent/internal/remote/tools/macalias_darwin.go`** — detection and resolution. Gates on the `kIsAlias` FinderInfo flag via a single `getxattr` *before* opening anything, so listing a large directory costs one cheap failing syscall per entry rather than an open+read. Alias→alias chains are followed with both a hop limit and a visited-path set.

### Why pure Go and not CoreServices

`NSURL`/`CFURLCreateByResolvingBookmarkData` would have been the supported API, but the agent's CI runs `CGO_ENABLED=0 go test ./...` and several release targets build with cgo off — a cgo resolver would have silently done nothing on exactly the builds that ship. Parser correctness was verified against real alias files generated on macOS Sequoia 15.x (both a folder alias and a file alias) before the synthetic test fixtures were written.

## Behaviour

| Field | For a resolved alias |
|---|---|
| `type` | The **target's** kind — so existing clients navigate into a folder alias and download through a file alias with no alias-specific handling |
| `path` | The **alias file**, unchanged — rename/delete/move must act on the alias, never on what it points at |
| `size` / `modified` / `permissions` | The **alias file**. A delete confirmation quoting the target's size while removing a 1KB alias would be actively misleading |
| `isAlias` / `aliasTarget` | New optional fields marking the entry for clients |

`ListFiles` and `ReadFile` also resolve when the *requested path* is itself an alias, and the API now echoes the path the agent actually listed, so breadcrumbs, "go up" and the upload destination follow the alias to its target rather than pointing at the alias file. Without that echo the listing worked but the client would have tried to upload into a path whose parent is a regular file.

No new UI was built — the fix is deliberately shaped so the existing `type === 'directory'` / `type === 'file'` branches do the right thing. `isAlias`/`aliasTarget` are there for a future badge without needing another agent change.

## Security

Resolving an alias **deliberately leaves the directory being listed**, and `EvalSymlinks` cannot see through one, so this would have been a way around the SR5-01 credential-store deny-list if left alone. Every resolved target is re-checked with `enforceReadContainment`:

- In a listing, an alias into a credential store is left **unresolved** — its target path is never disclosed and it stays indistinguishable from a plain file.
- On read or navigate, it is **denied outright**.

The parser treats its input as hostile: every offset, length and count that comes off disk is bounds-checked in `uint64` (no 32-bit wrap), the TOC chain is cycle-guarded, oversized files are never opened, the blob is read through a `LimitReader` so a stat/open race cannot grow it, and path components containing separators or `..` are rejected so a crafted blob cannot steer resolution somewhere else.

### One pre-existing observation, not changed here

`isSensitiveReadPath` matches keychains via `/library/keychains/` **with a trailing separator**, so the `Library/Keychains` *directory itself* is not deny-listed and can be enumerated today on `main`. Contents are still blocked (the `.keychain-db` basename rule catches them). I left that alone rather than widen a security deny-list inside an unrelated bug fix — flagging it in case it's worth its own issue.

## Verification

- `go test -race -count=1 ./internal/remote/tools/...` — **green** (66s, full package)
- Parser verified against **real macOS Sequoia alias files** (folder + file), both resolving to the correct target with the correct `IsDir`
- Cross-platform `go vet` + `go build ./...` with `CGO_ENABLED=0` for `windows/amd64`, `windows/arm64`, `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64` — all clean, darwin-only code correctly build-tagged
- `go test -c` for `linux/amd64` — confirms the parser tests compile and run off-darwin
- `tsc --noEmit` clean for both `apps/api` and `apps/web`
- `apps/api` systemTools suite: 40 passed; `apps/web` FileManager + no-silent-mutations: 104 passed

### Test coverage added

Parser (all platforms): boot-volume and external-volume paths, the reporter's iCloud Drive path, unicode/spaces, and rejection of non-bookmarks, truncated blobs, hostile headers, oversized/cyclic TOCs, and traversal components.

Darwin end-to-end, driving `ListFiles`/`ReadFile` against alias files built byte-for-byte the way Finder writes them: folder alias resolves to `directory`, file alias downloads the target's bytes under the target's name, navigating into a folder alias lists the target and reports the resolved path, alias chains resolve, cycles terminate, and — the ones that matter most — an alias into a credential store is neither resolved nor readable, while plain files, POSIX symlinks, dangling aliases, unflagged bookmark blobs, flagged junk, and oversized files are all left exactly as they were.

## Reviewer notes

- Nothing outside macOS changes behaviour: `macalias_other.go` returns "not an alias" unconditionally.
- An alias that cannot be resolved (old-format, dangling, unparseable) degrades to the previous behaviour — a plain file — rather than erroring.
- @SemoTech offered to retest; this needs an agent build on a Sequoia box to confirm in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)