### PR TITLE
fix(config): make the env↔compose parity guard see commented-out vars (#3239)

### DIFF
--- a/apps/api/src/config/envComposeParity.test.ts
+++ b/apps/api/src/config/envComposeParity.test.ts
@@ -32,8 +32,10 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..
  * Mapping a var in costs nothing when the operator leaves it unset: the
  * `${VAR:-}` form passes an empty string, which every consumer below treats as
  * "unset" and falls back to its own default. Where a consumer did NOT treat ''
- * that way, the consumer was fixed rather than the var left unmapped — see the
- * cookie helpers' firstConfiguredEnv() (#3239).
+ * that way, the consumer was fixed rather than the var left unmapped — see
+ * resolveAuthCookieSameSite() in routes/auth/helpers.ts, which resolves its
+ * override chain with nested envStr() instead of `??` for exactly this reason
+ * (#3239).
  */
 
 // Variables intentionally NOT threaded into the self-host (root) stack's
@@ -130,6 +132,15 @@ const PAIRS: Pair[] = [
  * Only `# NAME=` is collected, not prose. A comment has to look like an
  * assignment to count, so ordinary explanatory text above a var is not mistaken
  * for a documented knob.
+ *
+ * Prose that OPENS with `# SOME_VAR=value` — e.g. the sentence at
+ * `.env.example` "# OAUTH_DCR_ALLOW_ANONYMOUS=true. The API refuses to boot…" —
+ * does match, and that is the deliberate bias. Such a line is indistinguishable
+ * from a real documented default without parsing English, and this guard exists
+ * to fail LOUD: a spurious hit costs one allow-list line, while the miss it
+ * would otherwise permit is a knob that silently ignores the operator forever.
+ * (That particular line is a no-op anyway — the var is genuinely documented a
+ * few lines below and the Set de-duplicates.)
  */
 export function parseDocumentedVars(text: string): string[] {
   const names = new Set<string>();

--- a/apps/api/src/config/envComposeParity.test.ts
+++ b/apps/api/src/config/envComposeParity.test.ts
@@ -20,13 +20,20 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..
  * and — the reason this test exists — a self-hoster whose CORS/2FA/platform-admin
  * settings all no-op'd because they were never threaded through Compose).
  *
- * The guard, per env-example ↔ compose pair: every active variable in the
- * `.env.example` MUST be either
+ * The guard, per env-example ↔ compose pair: every variable DOCUMENTED in the
+ * `.env.example` — live assignments AND commented-out defaults alike, see
+ * documentedEnvExampleVars() — MUST be either
  *   (a) referenced in the compose file (mapped into a container, sourced into a
  *       secret, or used for interpolation), or
  *   (b) listed in that pair's allow-list below with a reason.
  * Adding a documented var without doing one of those two fails CI here, in the
  * required test-api job, instead of silently in someone's production deploy.
+ *
+ * Mapping a var in costs nothing when the operator leaves it unset: the
+ * `${VAR:-}` form passes an empty string, which every consumer below treats as
+ * "unset" and falls back to its own default. Where a consumer did NOT treat ''
+ * that way, the consumer was fixed rather than the var left unmapped — see the
+ * cookie helpers' firstConfiguredEnv() (#3239).
  */
 
 // Variables intentionally NOT threaded into the self-host (root) stack's
@@ -48,6 +55,7 @@ const ROOT_ALLOWLIST: Record<string, string> = {
   BREEZE_PROXY_TARGET_HOST: 'guided-setup external-proxy bookkeeping',
   BREEZE_EXTERNAL_PROXY: 'guided-setup external-proxy bookkeeping',
   BREEZE_EXTERNAL_PROXY_CIDRS: 'guided-setup copies this into TRUSTED_PROXY_CIDRS (which IS mapped)',
+  COMPOSE_PROFILES: 'read by the `docker compose` CLI itself to select profiles — host-level, never a container env',
 
   // REDIS_URL is not consumed by the API container (it derives its connection
   // from REDIS_HOST/REDIS_PORT + the file-backed redis_password secret).
@@ -61,11 +69,23 @@ const ROOT_ALLOWLIST: Record<string, string> = {
   // misleading, not functional.
   PUBLIC_RELEASE_VERSION: 'web build-time (baked into the prebuilt web image)',
   PUBLIC_TICKET_MAILBOX_APP_ID: 'web build-time PUBLIC_ var (baked into the prebuilt web image)',
+  PUBLIC_DOCS_URL: 'web build-time PUBLIC_ var (apps/web/astro.config.mjs — baked into the prebuilt web image)',
   ENABLE_SENTRY_SMOKE: 'web build/SSR smoke flag (baked into the prebuilt web image)',
   SENTRY_DSN_WEB_SERVER: 'web SSR Sentry DSN (baked into the prebuilt web image)',
   SENTRY_AUTH_TOKEN: 'build-time source-map upload (CI only, never a runtime container env)',
   SENTRY_ORG: 'build-time source-map upload (CI only)',
   SENTRY_PROJECT: 'build-time source-map upload (CI only)',
+
+  // Documented but read by NO code in this repo, so there is nothing to thread
+  // them into — mapping them would manufacture a knob that still does nothing.
+  // Listed here (rather than deleted from .env.example) so the dead
+  // documentation stays visible and the decision to keep or drop each line
+  // stays the maintainer's; see #3239.
+  C2C_M365_CERT_THUMBPRINT: 'no consumer — .env.example marks it "Future: certificate-based auth"',
+  C2C_M365_CERT_PRIVATE_KEY_PATH: 'no consumer — .env.example marks it "Future: certificate-based auth"',
+  USE_AGENT_SDK: 'no consumer anywhere in the repo (documented in deploy/environment.mdx only)',
+  BUSINESS_EMAIL_ALLOW_OVERRIDES:
+    'no consumer — the shipped business-email gate reads SIGNUP_REQUIRE_BUSINESS_EMAIL / SIGNUP_BUSINESS_EMAIL_CONTACT_URL instead',
 };
 
 // The digest-pinned droplet stack. Its api block is well-maintained; after
@@ -94,14 +114,35 @@ const PAIRS: Pair[] = [
   },
 ];
 
-function activeEnvExampleVars(relPath: string): string[] {
-  const text = readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+/**
+ * Every variable the `.env.example` DOCUMENTS — both live assignments
+ * (`FOO=bar`) and commented-out ones (`# FOO=bar`).
+ *
+ * Commenting a line out is how this repo documents an OPTIONAL tuning knob
+ * while leaving the code's own default in force, so the commented form carries
+ * exactly the same promise to the operator as the uncommented one: "set this in
+ * .env and it takes effect". Reading only uncommented lines therefore exempted
+ * the entire optional-knob surface from the guard — the class most likely to be
+ * forgotten, since an unmapped optional var still boots fine and just silently
+ * ignores the operator (#3239; #3236 was one instance, #3224 got wired only by
+ * hand).
+ *
+ * Only `# NAME=` is collected, not prose. A comment has to look like an
+ * assignment to count, so ordinary explanatory text above a var is not mistaken
+ * for a documented knob.
+ */
+export function parseDocumentedVars(text: string): string[] {
   const names = new Set<string>();
   for (const line of text.split('\n')) {
-    const m = /^([A-Z][A-Z0-9_]*)=/.exec(line); // uncommented assignments only
+    // `FOO=…` (live) or `# FOO=…` / `#FOO=…` (documented default, commented out)
+    const m = /^(?:#\s*)?([A-Z][A-Z0-9_]*)=/.exec(line);
     if (m?.[1]) names.add(m[1]);
   }
   return [...names].sort();
+}
+
+function documentedEnvExampleVars(relPath: string): string[] {
+  return parseDocumentedVars(readFileSync(path.join(REPO_ROOT, relPath), 'utf8'));
 }
 
 function isReferencedInCompose(varName: string, compose: string): boolean {
@@ -118,7 +159,7 @@ function isReferencedInCompose(varName: string, compose: string): boolean {
 
 describe.each(PAIRS)('.env.example ↔ compose parity: $name', ({ envExample, compose, allowlist }) => {
   const composeText = readFileSync(path.join(REPO_ROOT, compose), 'utf8');
-  const envVars = activeEnvExampleVars(envExample);
+  const envVars = documentedEnvExampleVars(envExample);
 
   it('every documented variable is either mapped in compose or explicitly allow-listed', () => {
     const unwired = envVars.filter(
@@ -149,5 +190,42 @@ describe.each(PAIRS)('.env.example ↔ compose parity: $name', ({ envExample, co
       `These vars are BOTH referenced in ${compose} and allow-listed — drop them from the allow-list:\n  ` +
         redundant.join('\n  '),
     ).toEqual([]);
+  });
+});
+
+describe('parseDocumentedVars — what counts as a documented variable (#3239)', () => {
+  it('collects commented-out assignments, the form used for optional knobs', () => {
+    expect(parseDocumentedVars('# MCP_REQUIRE_EXECUTE_ADMIN=true')).toEqual([
+      'MCP_REQUIRE_EXECUTE_ADMIN',
+    ]);
+    expect(parseDocumentedVars('#NO_SPACE_AFTER_HASH=1')).toEqual(['NO_SPACE_AFTER_HASH']);
+    expect(parseDocumentedVars('#   INDENTED=1')).toEqual(['INDENTED']);
+  });
+
+  it('still collects live assignments, and de-duplicates against the commented form', () => {
+    expect(parseDocumentedVars('LIVE=1\n# LIVE=2\nOTHER=3')).toEqual(['LIVE', 'OTHER']);
+  });
+
+  it('ignores prose comments — a comment must LOOK like an assignment to count', () => {
+    const prose = [
+      '# Set this to harden the deploy. See docs/deploy/environment.mdx.',
+      '# Values: strict, lax, none',
+      '#   Mail.Read, Files.Read.All, Sites.Read.All',
+      '# lowercase_name=1',
+      '# 9NUMERIC_LEAD=1',
+      '',
+    ].join('\n');
+    expect(parseDocumentedVars(prose)).toEqual([]);
+  });
+
+  it('does not treat an indented non-comment line as an assignment', () => {
+    expect(parseDocumentedVars('    INDENTED_NO_HASH=1')).toEqual([]);
+  });
+
+  it('REGRESSION: the guard would be vacuous on a .env.example of only optional knobs', () => {
+    // Before #3239 this returned [] and the whole file sailed past the parity
+    // assertions — which is exactly how ~39 documented knobs stayed unmapped.
+    const optionalKnobsOnly = '# A_KNOB=1\n# B_KNOB=2\n# C_KNOB=3';
+    expect(parseDocumentedVars(optionalKnobsOnly)).toEqual(['A_KNOB', 'B_KNOB', 'C_KNOB']);
   });
 });

--- a/apps/api/src/routes/auth/helpers.test.ts
+++ b/apps/api/src/routes/auth/helpers.test.ts
@@ -544,6 +544,71 @@ describe('auth cookie Secure flag (#1618 regression)', () => {
   });
 });
 
+// Both names are now threaded through Compose as `VAR: ${VAR:-}` (#3239), so an
+// operator who sets only the GENERIC name still has the AUTH_-prefixed one
+// present in the container — as an empty string. These pin that '' means
+// "unconfigured" and falls through, which `??` did not do.
+describe('auth cookie AUTH_COOKIE_* vs generic COOKIE_* precedence (#3239)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  beforeEach(() => {
+    enableProxyTrust();
+    process.env.NODE_ENV = 'production';
+  });
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    disableProxyTrustEnv();
+    delete process.env.AUTH_COOKIE_FORCE_SECURE;
+    delete process.env.AUTH_COOKIE_SAME_SITE;
+    delete process.env.COOKIE_FORCE_SECURE;
+    delete process.env.COOKIE_SAME_SITE;
+  });
+
+  it('an EMPTY AUTH_COOKIE_SAME_SITE does not shadow COOKIE_SAME_SITE (compose sends "" for an unset knob)', () => {
+    process.env.AUTH_COOKIE_SAME_SITE = '';
+    process.env.COOKIE_SAME_SITE = 'None';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    // With `??` this silently fell back to the Lax default and dropped Secure.
+    expect(setCookies[0]).toContain('SameSite=None; Secure');
+    expect(setCookies[1]).toContain('SameSite=None; Secure');
+  });
+
+  it('an EMPTY AUTH_COOKIE_FORCE_SECURE does not shadow COOKIE_FORCE_SECURE', () => {
+    process.env.AUTH_COOKIE_FORCE_SECURE = '';
+    process.env.COOKIE_FORCE_SECURE = 'true';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('a whitespace-only override is also treated as unconfigured', () => {
+    process.env.AUTH_COOKIE_SAME_SITE = '   ';
+    process.env.COOKIE_SAME_SITE = 'Strict';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'https' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    expect(setCookies[0]).toContain('SameSite=Strict');
+  });
+
+  it('a CONFIGURED AUTH_COOKIE_* override still wins over the generic name', () => {
+    process.env.AUTH_COOKIE_SAME_SITE = 'Strict';
+    process.env.COOKIE_SAME_SITE = 'None';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'https' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    expect(setCookies[0]).toContain('SameSite=Strict');
+    expect(setCookies[0]).not.toContain('SameSite=None');
+  });
+
+  it('both empty falls all the way through to the Lax default', () => {
+    process.env.AUTH_COOKIE_SAME_SITE = '';
+    process.env.COOKIE_SAME_SITE = '';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'https' });
+    setRefreshTokenCookie(c, 'refresh.jwt.value');
+    expect(setCookies[0]).toContain('SameSite=Lax');
+  });
+});
+
 describe('auth cookie transport warnings (#1618 diagnostics)', () => {
   const originalNodeEnv = process.env.NODE_ENV;
   let warnSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/api/src/routes/auth/helpers.ts
+++ b/apps/api/src/routes/auth/helpers.ts
@@ -12,6 +12,7 @@ import {
   verifyPassword,
   getUserEpochs
 } from '../../services';
+import { envStr } from '../../utils/envStr';
 import { getImmediatePeerIpOrUndefined, rateLimitIpKey, trustsForwardedHeadersFrom } from '../../services/clientIp';
 import { effectiveRequestScheme } from '../../services/requestTransport';
 import { createAuditLogAsync } from '../../services/auditService';
@@ -538,12 +539,25 @@ function normalizeSameSite(raw: string | undefined): SameSiteValue {
   return 'Lax';
 }
 
+/**
+ * The AUTH_-prefixed override wins over the generic name only when it is
+ * actually CONFIGURED.
+ *
+ * `??` was safe while neither name was threaded through Compose, and stopped
+ * being safe the moment both were (#3239). Compose renders an unset variable as
+ * `VAR: ""`, so the container sees `AUTH_COOKIE_SAME_SITE=''` — and `''` is not
+ * nullish, so `??` returns it and never consults COOKIE_SAME_SITE. An operator
+ * setting only `COOKIE_SAME_SITE=None` would have been silently downgraded back
+ * to `Lax` (and, via shouldSetSecureCookie, lost the implied `Secure`).
+ * `envStr` treats empty/whitespace-only as absent, which is the precedence the
+ * two-name pair was always meant to express.
+ */
 function resolveAuthCookieSameSite(): SameSiteValue {
-  return normalizeSameSite(process.env.AUTH_COOKIE_SAME_SITE ?? process.env.COOKIE_SAME_SITE);
+  return normalizeSameSite(envStr('AUTH_COOKIE_SAME_SITE', envStr('COOKIE_SAME_SITE', '')));
 }
 
 function forceSecureCookie(): boolean {
-  const forceSecure = (process.env.AUTH_COOKIE_FORCE_SECURE ?? process.env.COOKIE_FORCE_SECURE)?.trim().toLowerCase();
+  const forceSecure = envStr('AUTH_COOKIE_FORCE_SECURE', envStr('COOKIE_FORCE_SECURE', '')).toLowerCase();
   return forceSecure === '1' || forceSecure === 'true';
 }
 

--- a/apps/api/src/routes/portal/helpers.test.ts
+++ b/apps/api/src/routes/portal/helpers.test.ts
@@ -172,6 +172,53 @@ describe('portal cookie Secure flag (#2611)', () => {
   });
 });
 
+// Compose now threads both names in as `VAR: ${VAR:-}` (#3239), so setting only
+// the generic COOKIE_* still leaves PORTAL_COOKIE_* present-but-empty. Pin that
+// '' falls through instead of shadowing. Mirrors the auth-side suite.
+describe('portal cookie PORTAL_COOKIE_* vs generic COOKIE_* precedence (#3239)', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  beforeEach(() => {
+    enableProxyTrust();
+    process.env.NODE_ENV = 'production';
+  });
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    disableProxyTrustEnv();
+    delete process.env.PORTAL_COOKIE_FORCE_SECURE;
+    delete process.env.PORTAL_COOKIE_SAME_SITE;
+    delete process.env.COOKIE_FORCE_SECURE;
+    delete process.env.COOKIE_SAME_SITE;
+  });
+
+  it('an EMPTY PORTAL_COOKIE_SAME_SITE does not shadow COOKIE_SAME_SITE', () => {
+    process.env.PORTAL_COOKIE_SAME_SITE = '';
+    process.env.COOKIE_SAME_SITE = 'None';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setPortalSessionCookies(c, 'session.token.value');
+    expect(setCookies[0]).toContain('SameSite=None; Secure');
+    expect(setCookies[1]).toContain('SameSite=None; Secure');
+  });
+
+  it('an EMPTY PORTAL_COOKIE_FORCE_SECURE does not shadow COOKIE_FORCE_SECURE', () => {
+    process.env.PORTAL_COOKIE_FORCE_SECURE = '';
+    process.env.COOKIE_FORCE_SECURE = 'true';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'http' });
+    setPortalSessionCookies(c, 'session.token.value');
+    expect(setCookies[0]).toContain('; Secure');
+    expect(setCookies[1]).toContain('; Secure');
+  });
+
+  it('a CONFIGURED PORTAL_COOKIE_* override still wins over the generic name', () => {
+    process.env.PORTAL_COOKIE_SAME_SITE = 'Strict';
+    process.env.COOKIE_SAME_SITE = 'None';
+    const { c, setCookies } = makeCookieContext({ forwardedProto: 'https' });
+    setPortalSessionCookies(c, 'session.token.value');
+    expect(setCookies[0]).toContain('SameSite=Strict');
+    expect(setCookies[0]).not.toContain('SameSite=None');
+  });
+});
+
 describe('portal cookie transport warnings (#2611 diagnostics)', () => {
   const originalNodeEnv = process.env.NODE_ENV;
   let warnSpy: ReturnType<typeof vi.spyOn>;

--- a/apps/api/src/routes/portal/helpers.ts
+++ b/apps/api/src/routes/portal/helpers.ts
@@ -1,6 +1,7 @@
 import type { Context, MiddlewareHandler } from 'hono';
 import { createHash, randomBytes, timingSafeEqual } from 'crypto';
 import { nanoid } from 'nanoid';
+import { envStr } from '../../utils/envStr';
 import { getTrustedClientIp } from '../../services/clientIp';
 import { isRequestConnectionSecure } from '../auth/helpers';
 import { writeAuditEvent } from '../../services/auditEvents';
@@ -123,12 +124,17 @@ function normalizeSameSite(raw: string | undefined): SameSiteValue {
   return 'Lax';
 }
 
+/**
+ * PORTAL_-prefixed override wins over the generic name only when CONFIGURED —
+ * `''` must fall through, not shadow. Same reasoning (and same #3239 fix) as
+ * resolveAuthCookieSameSite() in ../auth/helpers.ts; see the note there.
+ */
 function resolvePortalCookieSameSite(): SameSiteValue {
-  return normalizeSameSite(process.env.PORTAL_COOKIE_SAME_SITE ?? process.env.COOKIE_SAME_SITE);
+  return normalizeSameSite(envStr('PORTAL_COOKIE_SAME_SITE', envStr('COOKIE_SAME_SITE', '')));
 }
 
 function forcePortalSecureCookie(): boolean {
-  const forceSecure = (process.env.PORTAL_COOKIE_FORCE_SECURE ?? process.env.COOKIE_FORCE_SECURE)?.trim().toLowerCase();
+  const forceSecure = envStr('PORTAL_COOKIE_FORCE_SECURE', envStr('COOKIE_FORCE_SECURE', '')).toLowerCase();
   return forceSecure === '1' || forceSecure === 'true';
 }
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -303,6 +303,18 @@ services:
       # these MUST be mapped here for compose interpolation to reach the API).
       SYNTHETIC_TEST_TOKEN: ${SYNTHETIC_TEST_TOKEN:-}
       SYNTHETIC_TEST_IP_ALLOWLIST: ${SYNTHETIC_TEST_IP_ALLOWLIST:-}
+      # Optional knobs documented as COMMENTED-OUT defaults in
+      # deploy/.env.example. The parity guard read only uncommented assignments
+      # until #3239, so this whole class was exempt from it and never reached
+      # the container. Same `${VAR:-}` reasoning as the block above.
+      MFA_FORCE_FOR_PARTNER_ADMIN: ${MFA_FORCE_FOR_PARTNER_ADMIN:-}
+      LOGIN_ACCOUNT_LOCKOUT_MAX: ${LOGIN_ACCOUNT_LOCKOUT_MAX:-}
+      LOGIN_ACCOUNT_LOCKOUT_WINDOW_SECONDS: ${LOGIN_ACCOUNT_LOCKOUT_WINDOW_SECONDS:-}
+      AGENT_AUTO_PROMOTE: ${AGENT_AUTO_PROMOTE:-}
+      # Break-glass only: lets the API connect to an unauthenticated Redis.
+      # Mapped so it can be set deliberately in an incident rather than being
+      # inert; leave it unset in normal operation.
+      BREEZE_ALLOW_UNAUTH_REDIS: ${BREEZE_ALLOW_UNAUTH_REDIS:-}
     volumes:
       - api_data:/data
       - binaries:/data/binaries:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,6 +375,48 @@ services:
       METRICS_SCRAPE_IP_ALLOWLIST: ${METRICS_SCRAPE_IP_ALLOWLIST:-}
       # Hosted billing redirect
       BILLING_URL: ${BILLING_URL:-}
+      # --- Optional knobs documented as COMMENTED-OUT defaults ---------------
+      # Everything below is documented in .env.example the way this repo
+      # documents an optional tuning knob: commented out, showing its default.
+      # The parity guard used to read only UNCOMMENTED assignments, so this
+      # entire class was exempt from it and quietly never reached a container
+      # (#3239; #3236 was one instance of the same shape). All are `${VAR:-}`
+      # for the reason spelled out above — '' reads as absent to envStr /
+      # envFlag / envInt, so an unset knob still gets its in-code default.
+      # Auth cookie + CORS hardening. AUTH_/PORTAL_-prefixed names override the
+      # generic COOKIE_* pair; that precedence is resolved with envStr (NOT `??`)
+      # precisely because '' must fall through rather than shadow — see
+      # resolveAuthCookieSameSite() in routes/auth/helpers.ts.
+      COOKIE_SAME_SITE: ${COOKIE_SAME_SITE:-}
+      COOKIE_FORCE_SECURE: ${COOKIE_FORCE_SECURE:-}
+      AUTH_COOKIE_SAME_SITE: ${AUTH_COOKIE_SAME_SITE:-}
+      AUTH_COOKIE_FORCE_SECURE: ${AUTH_COOKIE_FORCE_SECURE:-}
+      PORTAL_COOKIE_SAME_SITE: ${PORTAL_COOKIE_SAME_SITE:-}
+      PORTAL_COOKIE_FORCE_SECURE: ${PORTAL_COOKIE_FORCE_SECURE:-}
+      CORS_INCLUDE_DEFAULT_ORIGINS: ${CORS_INCLUDE_DEFAULT_ORIGINS:-}
+      REFRESH_ROTATION_GRACE_SECONDS: ${REFRESH_ROTATION_GRACE_SECONDS:-}
+      # Customer-portal session store
+      PORTAL_STATE_BACKEND: ${PORTAL_STATE_BACKEND:-}
+      # MCP server rate limits + execute-tool gating
+      MCP_REQUIRE_EXECUTE_ADMIN: ${MCP_REQUIRE_EXECUTE_ADMIN:-}
+      MCP_EXECUTE_TOOL_ALLOWLIST: ${MCP_EXECUTE_TOOL_ALLOWLIST:-}
+      MCP_SSE_RATE_LIMIT_PER_MINUTE: ${MCP_SSE_RATE_LIMIT_PER_MINUTE:-}
+      MCP_MESSAGE_RATE_LIMIT_PER_MINUTE: ${MCP_MESSAGE_RATE_LIMIT_PER_MINUTE:-}
+      MCP_MAX_SSE_SESSIONS_PER_KEY: ${MCP_MAX_SSE_SESSIONS_PER_KEY:-}
+      # AI provider overrides (ANTHROPIC_API_KEY is mapped further up)
+      ANTHROPIC_MODEL: ${ANTHROPIC_MODEL:-}
+      ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-}
+      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
+      # External billing service (hosted only; empty on self-host)
+      BREEZE_BILLING_URL: ${BREEZE_BILLING_URL:-}
+      BREEZE_BILLING_API_KEY: ${BREEZE_BILLING_API_KEY:-}
+      BILLING_SERVICE_URL: ${BILLING_SERVICE_URL:-}
+      BILLING_SERVICE_API_KEY: ${BILLING_SERVICE_API_KEY:-}
+      # Startup + agent-fleet behaviour
+      AUTO_MIGRATE: ${AUTO_MIGRATE:-}
+      AGENT_AUTO_PROMOTE: ${AGENT_AUTO_PROMOTE:-}
+      ENABLE_API_DOCS_UI: ${ENABLE_API_DOCS_UI:-}
+      PUBLIC_ACTIVATION_BASE_URL: ${PUBLIC_ACTIVATION_BASE_URL:-}
     volumes:
       - api_data:/data
       - binaries:/data/binaries:ro


### PR DESCRIPTION
Closes #3239. Reported by @bdunncompany, who also found the root cause while fixing #3236 — the question "why didn't the parity guard catch this?" had a general answer.

## The hole

`apps/api/src/config/envComposeParity.test.ts` exists to stop a documented variable being silently inert. Its extractor matched only uncommented assignments:

```js
const m = /^([A-Z][A-Z0-9_]*)=/.exec(line); // uncommented assignments only
```

But commenting a line out showing its default is precisely how this repo documents an **optional tuning knob**:

```
# MCP_REQUIRE_EXECUTE_ADMIN=true
# LOGIN_ACCOUNT_LOCKOUT_MAX=10
```

So the entire optional-knob surface was exempt from the guard meant to cover it — and it is the class most likely to be forgotten, because an unmapped optional var still boots fine and just silently ignores the operator. #3236 was one instance of this shape; #3224 got wired only because someone did it by hand.

## The change

Extractor is now `^(?:#\s*)?([A-Z][A-Z0-9_]*)=` and the union runs through the same three assertions. That surfaced **31 root-pair** and **5 droplet-pair** variables reaching no container.

### Mapped into the `api` service (26 root)

Settling @bdunncompany's question 2 — these were genuine gaps, not deliberate exclusions, so they are mapped rather than allow-listed.

| Group | Vars |
|---|---|
| Auth/CORS hardening | `COOKIE_SAME_SITE`, `COOKIE_FORCE_SECURE`, `AUTH_COOKIE_SAME_SITE`, `AUTH_COOKIE_FORCE_SECURE`, `PORTAL_COOKIE_SAME_SITE`, `PORTAL_COOKIE_FORCE_SECURE`, `CORS_INCLUDE_DEFAULT_ORIGINS`, `REFRESH_ROTATION_GRACE_SECONDS` |
| Portal session store | `PORTAL_STATE_BACKEND` |
| MCP limits + execute gating | `MCP_REQUIRE_EXECUTE_ADMIN`, `MCP_EXECUTE_TOOL_ALLOWLIST`, `MCP_SSE_RATE_LIMIT_PER_MINUTE`, `MCP_MESSAGE_RATE_LIMIT_PER_MINUTE`, `MCP_MAX_SSE_SESSIONS_PER_KEY` |
| AI provider overrides | `ANTHROPIC_MODEL`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN` |
| External billing service | `BREEZE_BILLING_URL`, `BREEZE_BILLING_API_KEY`, `BILLING_SERVICE_URL`, `BILLING_SERVICE_API_KEY` |
| Startup + agent fleet | `AUTO_MIGRATE`, `AGENT_AUTO_PROMOTE`, `ENABLE_API_DOCS_UI`, `PUBLIC_ACTIVATION_BASE_URL` |

### Mapped into the droplet `api` service (5)

`MFA_FORCE_FOR_PARTNER_ADMIN`, `LOGIN_ACCOUNT_LOCKOUT_MAX`, `LOGIN_ACCOUNT_LOCKOUT_WINDOW_SECONDS`, `AGENT_AUTO_PROMOTE`, `BREEZE_ALLOW_UNAUTH_REDIS`.

`PROD_ALLOWLIST` stays empty.

### Allow-listed with a reason (5 root)

| Var | Reason |
|---|---|
| `COMPOSE_PROFILES` | read by the `docker compose` CLI itself — host-level, never a container env |
| `PUBLIC_DOCS_URL` | web build-time `PUBLIC_` var (`apps/web/astro.config.mjs`), baked into the prebuilt image |
| `C2C_M365_CERT_THUMBPRINT` | no consumer — `.env.example` marks it "Future: certificate-based auth" |
| `C2C_M365_CERT_PRIVATE_KEY_PATH` | same |
| `USE_AGENT_SDK` | no consumer anywhere in the repo (documented in `deploy/environment.mdx` only) |
| `BUSINESS_EMAIL_ALLOW_OVERRIDES` | no consumer — the shipped gate reads `SIGNUP_REQUIRE_BUSINESS_EMAIL` / `SIGNUP_BUSINESS_EMAIL_CONTACT_URL` |

The last four are **dead documentation**, not intentional exclusions. I allow-listed rather than deleted them from `.env.example` so the decision stays yours — see "Open question" below.

## The bug the sweep would otherwise have shipped

This is the part that made the sweep non-mechanical, and it is worth a close look.

`${VAR:-}` renders an unset variable as `VAR: ""`, so the container sees the variable **set to an empty string**, not absent. Four cookie readers resolved a prefixed override against a generic fallback with `??`:

```ts
normalizeSameSite(process.env.AUTH_COOKIE_SAME_SITE ?? process.env.COOKIE_SAME_SITE)
```

`''` is not nullish, so once both names are compose-mapped the prefixed name **permanently shadows** the generic one. An operator setting only `COOKIE_SAME_SITE=None` would silently get `Lax` back — and, via `shouldSetSecureCookie`, lose the implied `Secure`. Setting only `COOKIE_FORCE_SECURE=true` (the documented remedy behind a TLS-terminating proxy the app cannot see) would be ignored outright, issuing non-`Secure` refresh and CSRF cookies.

That is the guard's own founding failure mode, reintroduced by fixing it.

Fixed in the readers rather than by leaving the vars unmapped, since "the prefixed name wins **when configured**" is what the two-name pair always meant. `envStr` (`apps/api/src/utils/envStr.ts`) already exists for exactly this and treats empty/whitespace-only as absent:

```ts
normalizeSameSite(envStr('AUTH_COOKIE_SAME_SITE', envStr('COOKIE_SAME_SITE', '')))
```

Applied to all four sites in `routes/auth/helpers.ts` and `routes/portal/helpers.ts`. No other behavior change — the accepted value sets (`'1'`/`'true'`, `strict`/`none`) are untouched.

The other 25 mapped vars were each traced to their read sites and confirmed to treat `''` identically to unset (`envFlag`/`envInt`/`parseCsvSet`/`positiveIntFromEnv` falsiness checks, or explicit `?? ''`/`.trim()` normalization), including every `config/validate.ts` entry — so no validator starts firing on an empty value at boot.

## Tests

- `parseDocumentedVars` split out as a pure function with 5 cases: commented forms (`# X=`, `#X=`, `#   X=`), de-duplication against the live form, prose comments correctly ignored (`# Values: strict, lax, none`, `# lowercase_name=1`), indented non-comments ignored, and a regression case pinning that a file of only optional knobs is no longer parsed as empty.
- 5 new cookie-precedence tests (auth + portal) covering empty, whitespace-only, configured-override-still-wins, and both-empty-falls-to-default.

**These 5 fail against the pre-fix helpers and pass after** — verified by reverting just the two source files and re-running:

```
FAIL  an EMPTY AUTH_COOKIE_SAME_SITE does not shadow COOKIE_SAME_SITE
FAIL  an EMPTY AUTH_COOKIE_FORCE_SECURE does not shadow COOKIE_FORCE_SECURE
FAIL  a whitespace-only override is also treated as unconfigured
FAIL  an EMPTY PORTAL_COOKIE_SAME_SITE does not shadow COOKIE_SAME_SITE
FAIL  an EMPTY PORTAL_COOKIE_FORCE_SECURE does not shadow COOKIE_FORCE_SECURE
```

Full run: `apps/api/src/config` + the two helper suites + compose-adjacent guards — **331 passed**. `tsc --noEmit` clean. The six compose/guided-setup/supply-chain shell guards pass. No duplicate keys introduced in either `api` environment block.

## Answering @bdunncompany's question 1

> Do commented-out knobs deserve the same guarantee as uncommented ones?

Yes — and the tradeoff they flagged is real and worth stating plainly: **every future optional knob must now be wired or allow-listed at the moment it is documented.** That is the point. The guard fails in the required `test-api` job with the var name and the two ways to resolve it, which is a far cheaper place to learn this than a self-hoster's production deploy.

## Open question for the maintainer

The four no-consumer vars (`USE_AGENT_SDK`, `BUSINESS_EMAIL_ALLOW_OVERRIDES`, and the two `C2C_M365_CERT_*`) are documented knobs that no code reads. Allow-listing keeps them visible; **deleting the lines from `.env.example`** (and the `USE_AGENT_SDK` row from `deploy/environment.mdx`) would arguably be more honest, since a reader today is being promised a knob that does not exist. I left them in place because removing documented lines is your call, not a mechanical sweep's. Happy to follow up either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
