### PR TITLE
fix(api): resolve partner-owned config policies for agent config delivery (#2930)

### DIFF
--- a/apps/api/src/__tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
@@ -427,4 +427,53 @@ describe('agent-facing config-policy resolvers honour partner-wide policies (#29
       expect(patchQ.exclusiveWindowsUpdate).toBe(false);
     });
   });
+
+  describe('status gating: a partner-owned policy that is not active must not resolve', () => {
+    // resolveDeviceEventLogSettings filters on
+    // `eq(configurationPolicies.status, 'active')` in the SAME query as the
+    // partner-wide join predicate — a regression that widened
+    // policyOwnershipCondition without preserving this filter would let a
+    // withdrawn/paused partner-wide policy keep reaching agents. The status
+    // enum (config_policy_status) has no 'draft' value — 'inactive' is the
+    // non-active state a partner uses to pull a policy without deleting it.
+    it('buildEventLogConfigUpdate falls back to EVENT_LOG_DEFAULTS for an inactive partner-owned policy', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      // Distinctive value (not the 100 default) — if this resolved despite
+      // being inactive, the assertion below would catch it explicitly rather
+      // than passing coincidentally.
+      const DISTINCTIVE_MAX_EVENTS = 555;
+      const policyId = await withDbAccessContext(SYSTEM_CTX, async () => {
+        const [policy] = await db
+          .insert(configurationPolicies)
+          .values({
+            orgId: null,
+            partnerId: partner.id,
+            name: `event_log inactive policy ${randomUUID()}`,
+            status: 'inactive',
+          })
+          .returning();
+        createdPolicies.push(policy!.id);
+        const [link] = await db
+          .insert(configPolicyFeatureLinks)
+          .values({ configPolicyId: policy!.id, featureType: 'event_log' })
+          .returning();
+        await db.insert(configPolicyEventLogSettings).values({
+          featureLinkId: link!.id,
+          maxEventsPerCycle: DISTINCTIVE_MAX_EVENTS,
+        });
+        return policy!.id;
+      });
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id), () => buildEventLogConfigUpdate(device.id));
+
+      expect(result.max_events_per_cycle).toBe(EVENT_LOG_DEFAULTS.maxEventsPerCycle);
+      expect(result.max_events_per_cycle).not.toBe(DISTINCTIVE_MAX_EVENTS);
+    });
+  });
 });

--- a/apps/api/src/__tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
+++ b/apps/api/src/__tests__/integration/agentPolicyResolversPartnerWide.integration.test.ts
@@ -1,0 +1,430 @@
+/**
+ * Agent-facing config-policy resolvers honour partner-wide policies (#2930).
+ *
+ * Configuration policies can be PARTNER-owned (`org_id NULL`, `partner_id`
+ * set — the "all orgs" shape from #1724) instead of org-owned. Four
+ * agent-facing resolvers in routes/agents/helpers.ts previously joined on a
+ * bare `configurationPolicies.orgId = device.orgId` and ran the policy query
+ * inside an ORG-SCOPED RLS context. Both halves silently dropped
+ * partner-owned policies:
+ *
+ *   1. The bare org-equality join never matches an `org_id NULL` row, so a
+ *      partner-wide policy was never even selected by the SQL.
+ *   2. Even with a correct predicate, `breeze_has_partner_access` gates
+ *      partner-owned rows, and an org-scoped DbAccessContext (the real shape
+ *      of the agent heartbeat/eventlogs request path) carries
+ *      `accessiblePartnerIds: []` — so the read silently returns ZERO ROWS,
+ *      not an error.
+ *
+ * The fix (services/configPolicyOwnership.ts) is a matched pair:
+ * `policyOwnershipCondition` (dual-axis join predicate) plus
+ * `withPartnerWideVisibility` (a scoped system-context escape around ONLY the
+ * policy join). This test proves both halves for all four resolvers by
+ * invoking them exactly as the agent heartbeat path does: inside a real
+ * org-scoped `withDbAccessContext`, against the real breeze_app RLS-forced
+ * connection.
+ *
+ * If this test file were deleted: a regression that reintroduces a bare
+ * `eq(configurationPolicies.orgId, device.orgId)` join, or that drops the
+ * `withPartnerWideVisibility` escape, would compile fine, pass every unit
+ * test (which mock the DB and never exercise RLS), and pass
+ * configurationPolicyPartnerResolution.integration.test.ts (which resolves
+ * under a SYSTEM-scope AuthContext, so the RLS escape is never exercised).
+ * Partner-wide policies would silently stop reaching agents for event_log,
+ * monitoring, PAM, and patch-source config — exactly the bug #2930 fixed.
+ */
+import './setup';
+import { afterEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import {
+  configurationPolicies,
+  configPolicyFeatureLinks,
+  configPolicyAssignments,
+  configPolicyEventLogSettings,
+  configPolicyMonitoringSettings,
+  configPolicyMonitoringWatches,
+  configPolicyPatchSettings,
+  devices,
+} from '../../db/schema';
+import {
+  buildEventLogConfigUpdate,
+  buildMonitoringConfigUpdate,
+  buildPamConfigUpdate,
+  buildPatchSourceConfigUpdate,
+  EVENT_LOG_DEFAULTS,
+} from '../../routes/agents/helpers';
+import { PAM_DEFAULTS } from '../../routes/agents/pamSettings';
+import { getRedis } from '../../services/redis';
+import { createPartner, createOrganization, createSite } from './db-utils';
+
+const SYSTEM_CTX: DbAccessContext = {
+  scope: 'system',
+  orgId: null,
+  accessibleOrgIds: null,
+  accessiblePartnerIds: null,
+  userId: null,
+};
+
+// The realistic agent-facing shape: an org-scoped request context.
+// accessiblePartnerIds: [] is the crux of the bug — an org token never
+// carries partner-axis access, so breeze_has_partner_access is false and a
+// partner-owned policy is invisible unless the resolver escapes to a system
+// context for the policy join (withPartnerWideVisibility).
+function orgContext(orgId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+  };
+}
+
+const createdPolicies: string[] = [];
+const createdDevices: string[] = [];
+
+afterEach(async () => {
+  await withDbAccessContext(SYSTEM_CTX, async () => {
+    for (const id of createdDevices) {
+      await db.delete(devices).where(eq(devices.id, id));
+    }
+    for (const id of createdPolicies) {
+      await db.delete(configurationPolicies).where(eq(configurationPolicies.id, id));
+    }
+  });
+  createdDevices.length = 0;
+  createdPolicies.length = 0;
+});
+
+async function seedDevice(orgId: string, siteId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [d] = await db
+      .insert(devices)
+      .values({
+        orgId,
+        siteId,
+        agentId: `agent-${randomUUID()}`,
+        hostname: `host-${randomUUID().slice(0, 8)}`,
+        osType: 'windows',
+        osVersion: '1.0',
+        architecture: 'amd64',
+        agentVersion: '1.0.0',
+        status: 'online',
+        deviceRole: 'workstation',
+      })
+      .returning();
+    createdDevices.push(d!.id);
+    return d!;
+  });
+}
+
+async function assign(configPolicyId: string, level: 'partner' | 'organization', targetId: string) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    await db.insert(configPolicyAssignments).values({
+      configPolicyId,
+      level,
+      targetId,
+      priority: 0,
+    });
+  });
+}
+
+// maxEventsPerCycle is the field the seed varies: it's one of the four
+// fields buildEventLogConfigUpdate actually surfaces (max_events_per_cycle),
+// so tests can prove "this specific policy resolved" through the builder's
+// own return value rather than by reading the settings table directly. The
+// default is 100 (EVENT_LOG_DEFAULTS.maxEventsPerCycle) — every seed below
+// uses a value that differs from it.
+async function seedEventLogPolicy(
+  owner: { orgId: string | null; partnerId: string | null },
+  maxEventsPerCycle: number,
+) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: owner.orgId, partnerId: owner.partnerId, name: `event_log policy ${randomUUID()}`, status: 'active' })
+      .returning();
+    createdPolicies.push(policy!.id);
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policy!.id, featureType: 'event_log' })
+      .returning();
+    await db.insert(configPolicyEventLogSettings).values({
+      featureLinkId: link!.id,
+      maxEventsPerCycle,
+    });
+    return policy!.id;
+  });
+}
+
+async function seedMonitoringPolicy(
+  owner: { orgId: string | null; partnerId: string | null },
+  checkIntervalSeconds: number,
+) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: owner.orgId, partnerId: owner.partnerId, name: `monitoring policy ${randomUUID()}`, status: 'active' })
+      .returning();
+    createdPolicies.push(policy!.id);
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policy!.id, featureType: 'monitoring' })
+      .returning();
+    const [settings] = await db
+      .insert(configPolicyMonitoringSettings)
+      .values({ featureLinkId: link!.id, checkIntervalSeconds })
+      .returning();
+    await db.insert(configPolicyMonitoringWatches).values({
+      settingsId: settings!.id,
+      watchType: 'service',
+      name: 'TestService',
+      enabled: true,
+    });
+    return policy!.id;
+  });
+}
+
+async function seedPamPolicy(
+  owner: { orgId: string | null; partnerId: string | null },
+  uacInterceptionEnabled: boolean,
+) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: owner.orgId, partnerId: owner.partnerId, name: `pam policy ${randomUUID()}`, status: 'active' })
+      .returning();
+    createdPolicies.push(policy!.id);
+    await db.insert(configPolicyFeatureLinks).values({
+      configPolicyId: policy!.id,
+      featureType: 'pam',
+      inlineSettings: { uacInterceptionEnabled },
+    });
+    return policy!.id;
+  });
+}
+
+async function seedPatchPolicy(
+  owner: { orgId: string | null; partnerId: string | null },
+  exclusiveWindowsUpdate: boolean,
+) {
+  return withDbAccessContext(SYSTEM_CTX, async () => {
+    const [policy] = await db
+      .insert(configurationPolicies)
+      .values({ orgId: owner.orgId, partnerId: owner.partnerId, name: `patch policy ${randomUUID()}`, status: 'active' })
+      .returning();
+    createdPolicies.push(policy!.id);
+    const [link] = await db
+      .insert(configPolicyFeatureLinks)
+      .values({ configPolicyId: policy!.id, featureType: 'patch' })
+      .returning();
+    await db.insert(configPolicyPatchSettings).values({
+      featureLinkId: link!.id,
+      exclusiveWindowsUpdate,
+    });
+    return policy!.id;
+  });
+}
+
+// Cached resolvers (event_log, monitoring, pam) key on device id with a 120s
+// TTL. Every test seeds a FRESH device (fresh uuid -> fresh cache key), which
+// alone rules out a cache hit masking a resolution failure. This helper is a
+// belt-and-suspenders explicit purge on top of that, so the point is not
+// left implicit: a passing assertion below reflects a live DB resolution,
+// never a cached artifact.
+async function purgeCaches(deviceId: string) {
+  const redis = getRedis();
+  if (!redis) return;
+  await redis.del(
+    `eventlog:settings:device:${deviceId}`,
+    `monitoring:settings:device:${deviceId}`,
+    `pam:settings:device:${deviceId}`,
+  );
+}
+
+describe('agent-facing config-policy resolvers honour partner-wide policies (#2930)', () => {
+  describe('partner-owned policy resolves under an ORG-SCOPED context (the RLS escape)', () => {
+    it('buildEventLogConfigUpdate resolves a partner-owned policy', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      const policyId = await seedEventLogPolicy({ orgId: null, partnerId: partner.id }, 555);
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id), () => buildEventLogConfigUpdate(device.id));
+
+      // 555 is not the default (100) — proves the partner-owned policy
+      // resolved rather than a silent fallback to EVENT_LOG_DEFAULTS.
+      expect(result.max_events_per_cycle).toBe(555);
+      expect(result.max_events_per_cycle).not.toBe(EVENT_LOG_DEFAULTS.maxEventsPerCycle);
+    });
+
+    it('buildMonitoringConfigUpdate resolves a partner-owned policy', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      const policyId = await seedMonitoringPolicy({ orgId: null, partnerId: partner.id }, 999);
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id), () => buildMonitoringConfigUpdate(device.id));
+
+      expect(result).not.toBeNull();
+      expect(result!.check_interval_seconds).toBe(999);
+      expect(result!.watches).toHaveLength(1);
+      expect(result!.watches[0]?.name).toBe('TestService');
+    });
+
+    it('buildPamConfigUpdate resolves a partner-owned policy', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      const policyId = await seedPamPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id), () => buildPamConfigUpdate(device.id));
+
+      expect(result.uacInterceptionEnabled).toBe(true);
+    });
+
+    it('buildPatchSourceConfigUpdate resolves a partner-owned policy', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      // Not cached — no purge needed.
+
+      const policyId = await seedPatchPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(policyId, 'partner', partner.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id), () => buildPatchSourceConfigUpdate(device.id));
+
+      expect(result.exclusiveWindowsUpdate).toBe(true);
+    });
+  });
+
+  describe('fan-out: the same partner-owned policy resolves for devices in TWO different orgs of the same partner', () => {
+    it('event_log, monitoring, pam, and patch all fan out across sibling orgs', async () => {
+      const partner = await createPartner();
+      const orgA = await createOrganization({ partnerId: partner.id });
+      const orgB = await createOrganization({ partnerId: partner.id });
+      const siteA = await createSite({ orgId: orgA!.id });
+      const siteB = await createSite({ orgId: orgB!.id });
+      const deviceA = await seedDevice(orgA!.id, siteA!.id);
+      const deviceB = await seedDevice(orgB!.id, siteB!.id);
+      await purgeCaches(deviceA.id);
+      await purgeCaches(deviceB.id);
+
+      const eventLogPolicyId = await seedEventLogPolicy({ orgId: null, partnerId: partner.id }, 555);
+      await assign(eventLogPolicyId, 'partner', partner.id);
+      const monitoringPolicyId = await seedMonitoringPolicy({ orgId: null, partnerId: partner.id }, 777);
+      await assign(monitoringPolicyId, 'partner', partner.id);
+      const pamPolicyId = await seedPamPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(pamPolicyId, 'partner', partner.id);
+      const patchPolicyId = await seedPatchPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(patchPolicyId, 'partner', partner.id);
+
+      const eventLogA = await withDbAccessContext(orgContext(orgA!.id), () => buildEventLogConfigUpdate(deviceA.id));
+      const eventLogB = await withDbAccessContext(orgContext(orgB!.id), () => buildEventLogConfigUpdate(deviceB.id));
+      const monitoringA = await withDbAccessContext(orgContext(orgA!.id), () => buildMonitoringConfigUpdate(deviceA.id));
+      const monitoringB = await withDbAccessContext(orgContext(orgB!.id), () => buildMonitoringConfigUpdate(deviceB.id));
+      const pamA = await withDbAccessContext(orgContext(orgA!.id), () => buildPamConfigUpdate(deviceA.id));
+      const pamB = await withDbAccessContext(orgContext(orgB!.id), () => buildPamConfigUpdate(deviceB.id));
+      const patchA = await withDbAccessContext(orgContext(orgA!.id), () => buildPatchSourceConfigUpdate(deviceA.id));
+      const patchB = await withDbAccessContext(orgContext(orgB!.id), () => buildPatchSourceConfigUpdate(deviceB.id));
+
+      expect(eventLogA.max_events_per_cycle).toBe(555);
+      expect(eventLogB.max_events_per_cycle).toBe(555);
+      expect(monitoringA?.check_interval_seconds).toBe(777);
+      expect(monitoringB?.check_interval_seconds).toBe(777);
+      expect(pamA.uacInterceptionEnabled).toBe(true);
+      expect(pamB.uacInterceptionEnabled).toBe(true);
+      expect(patchA.exclusiveWindowsUpdate).toBe(true);
+      expect(patchB.exclusiveWindowsUpdate).toBe(true);
+    });
+  });
+
+  describe('precedence: an org-level assignment wins over the partner-wide one (partner is the lowest level)', () => {
+    it('event_log: org-owned policy wins', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      const partnerPolicyId = await seedEventLogPolicy({ orgId: null, partnerId: partner.id }, 555);
+      await assign(partnerPolicyId, 'partner', partner.id);
+      const orgPolicyId = await seedEventLogPolicy({ orgId: org!.id, partnerId: null }, 222);
+      await assign(orgPolicyId, 'organization', org!.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id), () => buildEventLogConfigUpdate(device.id));
+
+      expect(result.max_events_per_cycle).toBe(222);
+    });
+
+    it('pam: org-owned policy wins over the partner-wide one', async () => {
+      const partner = await createPartner();
+      const org = await createOrganization({ partnerId: partner.id });
+      const site = await createSite({ orgId: org!.id });
+      const device = await seedDevice(org!.id, site!.id);
+      await purgeCaches(device.id);
+
+      // Partner-wide says ON; org-level says OFF. Org must win.
+      const partnerPolicyId = await seedPamPolicy({ orgId: null, partnerId: partner.id }, true);
+      await assign(partnerPolicyId, 'partner', partner.id);
+      const orgPolicyId = await seedPamPolicy({ orgId: org!.id, partnerId: null }, false);
+      await assign(orgPolicyId, 'organization', org!.id);
+
+      const result = await withDbAccessContext(orgContext(org!.id), () => buildPamConfigUpdate(device.id));
+
+      expect(result.uacInterceptionEnabled).toBe(false);
+    });
+  });
+
+  describe('isolation: a device under a DIFFERENT partner never receives the first partner\'s policy', () => {
+    it('event_log, monitoring, pam, and patch all fall back to defaults for the foreign-partner device', async () => {
+      const partnerP1 = await createPartner();
+      const orgP1 = await createOrganization({ partnerId: partnerP1.id });
+
+      const partnerQ = await createPartner();
+      const orgQ = await createOrganization({ partnerId: partnerQ.id });
+      const siteQ = await createSite({ orgId: orgQ!.id });
+      const deviceQ = await seedDevice(orgQ!.id, siteQ!.id);
+      await purgeCaches(deviceQ.id);
+
+      // Policies owned by partner P1, assigned partner-wide to P1 — orgP1 is
+      // referenced only to establish a plausible partner (never queried).
+      void orgP1;
+      const eventLogPolicyId = await seedEventLogPolicy({ orgId: null, partnerId: partnerP1.id }, 555);
+      await assign(eventLogPolicyId, 'partner', partnerP1.id);
+      const monitoringPolicyId = await seedMonitoringPolicy({ orgId: null, partnerId: partnerP1.id }, 999);
+      await assign(monitoringPolicyId, 'partner', partnerP1.id);
+      const pamPolicyId = await seedPamPolicy({ orgId: null, partnerId: partnerP1.id }, true);
+      await assign(pamPolicyId, 'partner', partnerP1.id);
+      const patchPolicyId = await seedPatchPolicy({ orgId: null, partnerId: partnerP1.id }, true);
+      await assign(patchPolicyId, 'partner', partnerP1.id);
+
+      const eventLogQ = await withDbAccessContext(orgContext(orgQ!.id), () => buildEventLogConfigUpdate(deviceQ.id));
+      const monitoringQ = await withDbAccessContext(orgContext(orgQ!.id), () => buildMonitoringConfigUpdate(deviceQ.id));
+      const pamQ = await withDbAccessContext(orgContext(orgQ!.id), () => buildPamConfigUpdate(deviceQ.id));
+      const patchQ = await withDbAccessContext(orgContext(orgQ!.id), () => buildPatchSourceConfigUpdate(deviceQ.id));
+
+      // No policy of Q's own partner matched -> defaults across the board,
+      // NOT partner P1's values (555 / 999 / true / true).
+      expect(eventLogQ.max_events_per_cycle).toBe(EVENT_LOG_DEFAULTS.maxEventsPerCycle);
+      expect(monitoringQ).toBeNull();
+      expect(pamQ.uacInterceptionEnabled).toBe(PAM_DEFAULTS.uacInterceptionEnabled);
+      expect(patchQ.exclusiveWindowsUpdate).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/routes/agents/heartbeat.test.ts
+++ b/apps/api/src/routes/agents/heartbeat.test.ts
@@ -13,6 +13,22 @@ const runOutsideDbContextMock = vi.fn(async (fn: () => unknown) => fn());
 // (the #1105 pool-poison fix). Reset per test.
 const callOrder: string[] = [];
 
+// Default pass-through behaviour for withSystemDbAccessContext — extracted so
+// it can be reinstalled via mockImplementationOnce for calls a test doesn't
+// care about, while a specific call (targeted by ordering) is made to reject.
+// A `vi.fn()` (rather than a bare async function) is required so a test can
+// override ONE of the several withSystemDbAccessContext call sites in
+// heartbeat.ts (agent-update-policy lookup, policy-probe config, onedrive
+// settings, the #2930 shared policy-config block, helper settings) without
+// touching the others.
+const systemDbAccessContextPassthrough = async (fn: () => Promise<unknown>) => {
+  callOrder.push('systemCtx:enter');
+  const result = await fn();
+  callOrder.push('systemCtx:exit');
+  return result;
+};
+const withSystemDbAccessContextMock = vi.fn(systemDbAccessContextPassthrough);
+
 vi.mock('../../db', () => ({
   db: {
     select: (...args: unknown[]) => selectMock(...(args as [])),
@@ -30,17 +46,15 @@ vi.mock('../../db', () => ({
     callOrder.push('dbContext:released');
     return result;
   },
-  // Pass-through: the effective agent-update-policy lookup (#2123, BEFORE the
-  // org block) and the policy-probe read (AFTER it) both run in a system
-  // context. Invoke the callback so the mocked getOrgAgentUpdatePolicy /
-  // buildPolicyProbeConfigUpdate still run, and record enter/exit so tests can
-  // assert the update-policy context opens AND closes before the org context.
-  withSystemDbAccessContext: async (fn: () => Promise<unknown>) => {
-    callOrder.push('systemCtx:enter');
-    const result = await fn();
-    callOrder.push('systemCtx:exit');
-    return result;
-  },
+  // Pass-through by default: the effective agent-update-policy lookup (#2123,
+  // BEFORE the org block), the policy-probe read, the onedrive settings read,
+  // the shared #2930 policy-config block, and the helper-settings read all run
+  // in a system context, in that order. Invoke the callback so the mocked
+  // resolvers still run, and record enter/exit so tests can assert ordering
+  // relative to the org context. A `vi.fn()` so an individual test can swap in
+  // a rejection for exactly one call site via mockImplementationOnce.
+  withSystemDbAccessContext: (...args: unknown[]) =>
+    withSystemDbAccessContextMock(...(args as [() => Promise<unknown>])),
 }));
 
 vi.mock('../../db/schema', () => ({
@@ -2103,6 +2117,154 @@ describe('POST /agents/:id/heartbeat — uacInterceptionEnabled delivery', () =>
     const configUpdate = body.configUpdate as Record<string, unknown> | null;
     expect(configUpdate?.onedrive_helper_settings).toBeUndefined();
     expect(configUpdate?.patch_source_settings).toEqual({ exclusiveWindowsUpdate: true });
+  });
+
+  // #2930 coverage gap — event_log_settings and monitoring_settings were only
+  // ever exercised via their vi.fn(() => undefined) defaults; the delivery and
+  // resolver-throws paths were untested even though patch_source_settings
+  // (the sibling resolver in the same shared policy-config block) had both.
+  it('includes event_log_settings in configUpdate when the resolver succeeds', async () => {
+    const { buildEventLogConfigUpdate } = await import('./helpers');
+    const settings = {
+      max_events_per_cycle: 250,
+      collect_categories: ['security', 'system'],
+      minimum_level: 'warning',
+      collection_interval_minutes: 15,
+    };
+    vi.mocked(buildEventLogConfigUpdate).mockResolvedValueOnce(settings);
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.event_log_settings).toEqual(settings);
+  });
+
+  it('omits event_log_settings when the resolver throws (no unintended revert)', async () => {
+    const { buildEventLogConfigUpdate } = await import('./helpers');
+    vi.mocked(buildEventLogConfigUpdate).mockRejectedValueOnce(new Error('boom'));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.event_log_settings).toBeUndefined();
+  });
+
+  it('includes monitoring_settings in configUpdate when the resolver succeeds', async () => {
+    const { buildMonitoringConfigUpdate } = await import('./helpers');
+    const settings = {
+      check_interval_seconds: 60,
+      watches: [
+        {
+          watch_type: 'process',
+          name: 'agent-watch',
+          alert_on_stop: true,
+          alert_after_consecutive_failures: 2,
+          auto_restart: true,
+          max_restart_attempts: 3,
+          restart_cooldown_seconds: 30,
+        },
+      ],
+    };
+    vi.mocked(buildMonitoringConfigUpdate).mockResolvedValueOnce(settings as any);
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.monitoring_settings).toEqual(settings);
+  });
+
+  it('omits monitoring_settings when the resolver throws (no unintended revert)', async () => {
+    const { buildMonitoringConfigUpdate } = await import('./helpers');
+    vi.mocked(buildMonitoringConfigUpdate).mockRejectedValueOnce(new Error('boom'));
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.monitoring_settings).toBeUndefined();
+  });
+
+  // Existing coverage only exercised the `false` default and the
+  // resolver-throws fail-closed path; the successful opt-in delivery was
+  // never asserted.
+  it('delivers uacInterceptionEnabled: true when buildPamConfigUpdate resolves true', async () => {
+    const { buildPamConfigUpdate } = await import('./helpers');
+    vi.mocked(buildPamConfigUpdate).mockResolvedValueOnce({ uacInterceptionEnabled: true });
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.uacInterceptionEnabled).toBe(true);
+  });
+
+  // #2930 — the shared policy-config block (event_log / monitoring / pam /
+  // patch_source) runs AFTER the org transaction has already committed and
+  // its claimed commands are marked delivered. If the outer try/catch around
+  // `withSystemDbAccessContext(...)` were removed, a transaction setup/commit
+  // failure here (e.g. pool exhaustion under #1105-style connection pressure)
+  // would escape as an unhandled rejection and 500 the heartbeat — losing
+  // those already-delivered commands for no benefit, since every field this
+  // block produces is re-resolved on the next heartbeat anyway. This test
+  // pins the fail-safe: only the shared policy-config context is made to
+  // reject (targeted by call order — it is the 4th of 5 withSystemDbAccessContext
+  // calls per heartbeat: #2123 update-policy, policy-probe, onedrive, THIS
+  // ONE, then helper-settings), and the response must still be 200 with all
+  // four policy config keys omitted and uacInterceptionEnabled defaulted to
+  // false, with the failure reported to Sentry.
+  it('returns 200 and omits all four policy config keys when the shared policy-config system context itself fails', async () => {
+    const { captureException } = await import('../../services/sentry');
+
+    withSystemDbAccessContextMock
+      .mockImplementationOnce(systemDbAccessContextPassthrough) // #2123 update-policy lookup
+      .mockImplementationOnce(systemDbAccessContextPassthrough) // policy-probe config
+      .mockImplementationOnce(systemDbAccessContextPassthrough) // onedrive settings
+      .mockImplementationOnce(async () => {
+        throw new Error('shared policy-config system context failed');
+      }); // #2930 shared policy-config block — the one under test
+    // 5th call (helper settings) falls back to the default pass-through.
+
+    const resp = await buildApp().request('/agents/device-1/heartbeat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(minimalHeartbeatBody),
+    });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as Record<string, unknown>;
+    const configUpdate = body.configUpdate as Record<string, unknown> | null;
+    expect(configUpdate?.event_log_settings).toBeUndefined();
+    expect(configUpdate?.monitoring_settings).toBeUndefined();
+    expect(configUpdate?.patch_source_settings).toBeUndefined();
+    expect(body.uacInterceptionEnabled).toBe(false);
+    expect(vi.mocked(captureException)).toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -1256,16 +1256,22 @@ if (latestHelper) {
       let pamSettings: { uacInterceptionEnabled: boolean } | null = null;
       let patchSourceSettings: { exclusiveWindowsUpdate: boolean } | null = null;
 
+      // Sentry on all four, not just pam/patch_source. Losing an event_log or
+      // monitoring policy is precisely the invisible failure #2930 is about:
+      // the agent keeps collecting on stale defaults and nothing surfaces it.
+      // A stdout line is not an alerting channel.
       try {
         eventLogSettings = await buildEventLogConfigUpdate(scoped.deviceId);
       } catch (err) {
         console.error(`[agents] failed to build event log config update for ${agentId}:`, err);
+        captureException(err);
       }
 
       try {
         monitoringSettings = await buildMonitoringConfigUpdate(scoped.deviceId) as Record<string, unknown> | null;
       } catch (err) {
         console.error(`[agents] failed to build monitoring config update for ${agentId}:`, err);
+        captureException(err);
       }
 
       try {

--- a/apps/api/src/routes/agents/heartbeat.ts
+++ b/apps/api/src/routes/agents/heartbeat.ts
@@ -987,36 +987,12 @@ if (latestHelper) {
   // resolving it here would silently miss it regardless of the resolver's own
   // query condition.
 
-  let eventLogSettings: Record<string, unknown> | null = null;
-  try {
-    eventLogSettings = await buildEventLogConfigUpdate(device.id);
-  } catch (err) {
-    console.error(`[agents] failed to build event log config update for ${agentId}:`, err);
-  }
-
-  let monitoringSettings: Record<string, unknown> | null = null;
-  try {
-    monitoringSettings = await buildMonitoringConfigUpdate(device.id) as Record<string, unknown> | null;
-  } catch (err) {
-    console.error(`[agents] failed to build monitoring config update for ${agentId}:`, err);
-  }
-
-  let pamSettings: { uacInterceptionEnabled: boolean } | null = null;
-  try {
-    pamSettings = await buildPamConfigUpdate(device.id);
-  } catch (err) {
-    // Opt-in default means a resolver failure leaves pamSettings null and we
-    // send uacInterceptionEnabled:false below. For an org that *enforces* PAM
-    // (grandfather flag or an explicit enabling policy) this momentarily drops
-    // elevation gating until the next successful heartbeat — call it out so the
-    // Sentry event isn't mistaken for a benign config-build hiccup. Not cached,
-    // so it self-heals on the next heartbeat.
-    console.error(
-      `[agents] failed to build pam config update for ${agentId} — sending uacInterceptionEnabled:false this heartbeat:`,
-      err,
-    );
-    captureException(err);
-  }
+  // #2930 — event_log, monitoring, pam and patch_source config are ALSO built
+  // after this org transaction closes, for the same reason as helper settings
+  // above: each reads configuration_policies, each can match a partner-wide
+  // policy (org_id NULL, partner_id set), and such a row is invisible under
+  // this context's RLS (accessiblePartnerIds: [] above) no matter how the
+  // resolver's own WHERE clause is written. See the post-scoped block below.
 
   // #1105 — onedrive_helper config is built AFTER this org transaction closes
   // (see the post-scoped section below), because Phase 4 per-UPN Graph
@@ -1024,35 +1000,16 @@ if (latestHelper) {
   // would hold a pooled connection in the open org transaction across those
   // calls. Mirrors buildPolicyProbeConfigUpdate's placement.
 
-  // #1872: sole-patch-source enforcement. Omit the block on a resolver error so
-  // a transient failure never reverts an endpoint already under enforcement;
-  // a successful resolve with no patch policy returns false → agent reverts.
-  let patchSourceSettings: { exclusiveWindowsUpdate: boolean } | null = null;
-  try {
-    patchSourceSettings = await buildPatchSourceConfigUpdate(device.id);
-  } catch (err) {
-    console.error(`[agents] failed to build patch_source config update for ${agentId}:`, err);
-    captureException(err);
-  }
-
   // #2288 — backup control-plane URL. ALWAYS present: the configured value,
   // or '' so agents clear a previously-pushed backup (absent = old API =
   // no change; '' = authoritative clear). Always non-null, so the final
   // configUpdate assembly below always carries the key.
-  // onedrive_helper_settings is NOT merged here — it is built post-scoped and
-  // merged into the final configUpdate below (#1105 hoist).
+  // event_log_settings / monitoring_settings / patch_source_settings and
+  // onedrive_helper_settings are NOT merged here — they are built post-scoped
+  // and merged into the final configUpdate below (#1105 / #2930 hoist).
   const mergedConfigUpdate: Record<string, unknown> = {
     backup_server_url: (process.env.AGENT_BACKUP_SERVER_URL ?? '').trim(),
   };
-  if (eventLogSettings) {
-    mergedConfigUpdate.event_log_settings = eventLogSettings;
-  }
-  if (monitoringSettings) {
-    mergedConfigUpdate.monitoring_settings = monitoringSettings;
-  }
-  if (patchSourceSettings) {
-    mergedConfigUpdate.patch_source_settings = patchSourceSettings;
-  }
 
   // Security remediation Wave 6, Task 9 — ALWAYS sent, as true or false.
   //
@@ -1172,10 +1129,8 @@ if (latestHelper) {
       confirmTokenRotation:
         (pendingRotationLive && c.get('agentPendingTokenPresented') === true) || undefined,
       // helperEnabled/helperSettings are merged in AFTER this org-scoped block
-      // closes — see the #1105 comment below.
-      // Opt-in default: a null pamSettings (resolver error, logged above) sends
-      // false so we never prompt users on a device that opted into nothing.
-      uacInterceptionEnabled: pamSettings?.uacInterceptionEnabled ?? false,
+      // closes — see the #1105 comment below. uacInterceptionEnabled likewise
+      // (#2930): the pam resolver moved out with the other policy readers.
       manageRemoteManagement: manageRemoteManagement || undefined,
     },
   };
@@ -1259,9 +1214,117 @@ if (latestHelper) {
     ? { onedrive_helper_settings: onedriveSettings }
     : null;
 
+  // #2930 — event_log / monitoring / pam / patch_source policy readers. These
+  // used to run inside the org transaction, where a partner-wide policy
+  // (org_id NULL) is RLS-invisible, so a partner-authored policy for any of the
+  // four never reached an agent. Same treatment as policyProbeConfig /
+  // onedriveSettings / helperSettings above: resolved after the org tx is
+  // released, under a system context anchored to `scoped.deviceId` — an id
+  // derived from the device the agent already authenticated as, so this cannot
+  // pivot tenants.
+  //
+  // All four share ONE context on purpose. They previously shared the org
+  // transaction, so a DB error already poisoned the others; giving each its own
+  // system transaction would cost four connection acquisitions per heartbeat
+  // against the 25-connection production ceiling for no isolation gain. The
+  // per-resolver try/catch below keeps each feature's documented fallback.
+  //
+  // The whole block is ALSO wrapped in an outer catch. The per-resolver catches
+  // below cannot see a transaction setup or COMMIT failure, and a SQL error
+  // caught locally still leaves the shared transaction aborted — so its commit
+  // throws. By this point the org transaction has committed and the commands in
+  // `scoped.mainResponse` are already marked delivered, so letting that escape
+  // would 500 the heartbeat and lose the claimed commands. Degrading to "no
+  // config update this cycle" is the safe failure: every field here is
+  // re-resolved on the next heartbeat.
+  type PolicyConfigUpdates = {
+    eventLogSettings: Record<string, unknown> | null;
+    monitoringSettings: Record<string, unknown> | null;
+    pamSettings: { uacInterceptionEnabled: boolean } | null;
+    patchSourceSettings: { exclusiveWindowsUpdate: boolean } | null;
+  };
+  let policyConfigs: PolicyConfigUpdates = {
+    eventLogSettings: null,
+    monitoringSettings: null,
+    pamSettings: null,
+    patchSourceSettings: null,
+  };
+  try {
+    policyConfigs = await withSystemDbAccessContext(async (): Promise<PolicyConfigUpdates> => {
+      let eventLogSettings: Record<string, unknown> | null = null;
+      let monitoringSettings: Record<string, unknown> | null = null;
+      let pamSettings: { uacInterceptionEnabled: boolean } | null = null;
+      let patchSourceSettings: { exclusiveWindowsUpdate: boolean } | null = null;
+
+      try {
+        eventLogSettings = await buildEventLogConfigUpdate(scoped.deviceId);
+      } catch (err) {
+        console.error(`[agents] failed to build event log config update for ${agentId}:`, err);
+      }
+
+      try {
+        monitoringSettings = await buildMonitoringConfigUpdate(scoped.deviceId) as Record<string, unknown> | null;
+      } catch (err) {
+        console.error(`[agents] failed to build monitoring config update for ${agentId}:`, err);
+      }
+
+      try {
+        pamSettings = await buildPamConfigUpdate(scoped.deviceId);
+      } catch (err) {
+        // Opt-in default means a resolver failure leaves pamSettings null and we
+        // send uacInterceptionEnabled:false below. For an org that *enforces* PAM
+        // (grandfather flag or an explicit enabling policy) this momentarily drops
+        // elevation gating until the next successful heartbeat — call it out so the
+        // Sentry event isn't mistaken for a benign config-build hiccup. Not cached,
+        // so it self-heals on the next heartbeat.
+        console.error(
+          `[agents] failed to build pam config update for ${agentId} — sending uacInterceptionEnabled:false this heartbeat:`,
+          err,
+        );
+        captureException(err);
+      }
+
+      // #1872: sole-patch-source enforcement. Omit the block on a resolver error so
+      // a transient failure never reverts an endpoint already under enforcement;
+      // a successful resolve with no patch policy returns false → agent reverts.
+      try {
+        patchSourceSettings = await buildPatchSourceConfigUpdate(scoped.deviceId);
+      } catch (err) {
+        console.error(`[agents] failed to build patch_source config update for ${agentId}:`, err);
+        captureException(err);
+      }
+
+      return { eventLogSettings, monitoringSettings, pamSettings, patchSourceSettings };
+    });
+  } catch (err) {
+    // Transaction setup/commit failure — see the note above. Every resolver's
+    // documented "no policy this cycle" fallback already applies because
+    // policyConfigs keeps its all-null initial value.
+    console.error(`[agents] policy config context failed for ${agentId} — omitting config updates this heartbeat:`, err);
+    captureException(err);
+  }
+  const { eventLogSettings, monitoringSettings, pamSettings, patchSourceSettings } = policyConfigs;
+
+  const policyConfigUpdate: Record<string, unknown> = {};
+  if (eventLogSettings) {
+    policyConfigUpdate.event_log_settings = eventLogSettings;
+  }
+  if (monitoringSettings) {
+    policyConfigUpdate.monitoring_settings = monitoringSettings;
+  }
+  if (patchSourceSettings) {
+    policyConfigUpdate.patch_source_settings = patchSourceSettings;
+  }
+  const hasPolicyConfigUpdate = Object.keys(policyConfigUpdate).length > 0;
+
   const scopedConfigUpdate = scoped.mainResponse.configUpdate as Record<string, unknown> | null;
-  const configUpdate = policyProbeConfig || scopedConfigUpdate || onedriveConfigUpdate
-    ? { ...(policyProbeConfig ?? {}), ...(scopedConfigUpdate ?? {}), ...(onedriveConfigUpdate ?? {}) }
+  const configUpdate = policyProbeConfig || scopedConfigUpdate || hasPolicyConfigUpdate || onedriveConfigUpdate
+    ? {
+      ...(policyProbeConfig ?? {}),
+      ...(scopedConfigUpdate ?? {}),
+      ...policyConfigUpdate,
+      ...(onedriveConfigUpdate ?? {}),
+    }
     : null;
 
   // #1105 — helper settings resolved OUTSIDE the org context too (same
@@ -1286,6 +1349,9 @@ if (latestHelper) {
     configUpdate,
     manifestTrustKeys,
     manifestKeyDelegations,
+    // Opt-in default: a null pamSettings (resolver error, logged above) sends
+    // false so we never prompt users on a device that opted into nothing.
+    uacInterceptionEnabled: pamSettings?.uacInterceptionEnabled ?? false,
     helperEnabled: helperSettings?.enabled ?? false,
     helperSettings: helperSettings ?? undefined,
   });

--- a/apps/api/src/routes/agents/helpers.pam.test.ts
+++ b/apps/api/src/routes/agents/helpers.pam.test.ts
@@ -78,6 +78,7 @@ const { dbMock, redisMock, getRedisImpl } = vi.hoisted(() => {
 // ---------------------------------------------------------------------------
 
 vi.mock('../../db', () => ({
+  getCurrentDbAccessContext: vi.fn(() => undefined),
   runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),

--- a/apps/api/src/routes/agents/helpers.partnerWidePolicies.test.ts
+++ b/apps/api/src/routes/agents/helpers.partnerWidePolicies.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Partner-wide (partner-owned) config-policy resolution for the agent-facing
+ * resolvers — issue #2930.
+ *
+ * A `configuration_policies` row owned by a partner has `org_id NULL` and
+ * `partner_id` set. Four resolvers in helpers.ts joined on
+ * `eq(configurationPolicies.orgId, device.orgId)`, which can never match such a
+ * row, so a partner-authored policy was authorable in the UI and silently never
+ * delivered to any agent. The RLS half of the same bug is that partner-owned
+ * rows are invisible under an org-scoped DB context, so a corrected predicate
+ * still resolves nothing without a system-context escape.
+ *
+ * The mocked db returns rows unconditionally and cannot evaluate a WHERE
+ * clause, so these tests pin the two decisions the resolver actually makes:
+ *  - it passes the DEVICE ORG'S PARTNER into `policyOwnershipCondition` (so the
+ *    emitted predicate admits `org_id NULL` rows — the SQL itself is pinned in
+ *    services/configPolicyOwnership.test.ts), and
+ *  - it runs the policy join inside `withPartnerWideVisibility` (the RLS
+ *    escape).
+ * End-to-end proof against real Postgres lives in
+ * __tests__/integration/configurationPolicyPartnerResolution.integration.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+const { dbMock, redisMock, getRedisImpl, ownershipMock, partnerWideVisibilityMock } = vi.hoisted(() => {
+  let selectCallQueue: unknown[][] = [];
+  let selectCallIdx = 0;
+
+  const makeSelectChain = () => {
+    const result = selectCallQueue[selectCallIdx] ?? [];
+    selectCallIdx++;
+
+    const chain: any = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(result)),
+    };
+    chain.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject);
+    return chain;
+  };
+
+  const dbMock = {
+    select: vi.fn(() => makeSelectChain()),
+    _resetQueue(queue: unknown[][]) {
+      selectCallQueue = queue;
+      selectCallIdx = 0;
+      dbMock.select.mockImplementation(() => makeSelectChain());
+    },
+  };
+
+  const redisMock = {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue('OK'),
+  };
+
+  return {
+    dbMock,
+    redisMock,
+    getRedisImpl: vi.fn(() => redisMock as any),
+    ownershipMock: vi.fn(() => 'OWNERSHIP_CONDITION' as any),
+    partnerWideVisibilityMock: vi.fn(<T>(fn: () => Promise<T>) => fn()),
+  };
+});
+
+vi.mock('../../db', () => ({
+  runOutsideDbContext: vi.fn((fn: () => unknown) => fn()),
+  withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
+  withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  getCurrentDbAccessContext: vi.fn(() => undefined),
+  db: dbMock,
+}));
+
+vi.mock('../../services/configPolicyOwnership', () => ({
+  policyOwnershipCondition: ownershipMock,
+  withPartnerWideVisibility: partnerWideVisibilityMock,
+}));
+
+vi.mock('../../db/schema', () => ({
+  devices: { id: 'devices.id', orgId: 'devices.orgId', siteId: 'devices.siteId' },
+  organizations: { id: 'orgs.id', partnerId: 'orgs.partnerId' },
+  deviceGroupMemberships: { groupId: 'dgm.groupId', deviceId: 'dgm.deviceId' },
+  configPolicyAssignments: {
+    level: 'cpa.level',
+    targetId: 'cpa.targetId',
+    configPolicyId: 'cpa.configPolicyId',
+    priority: 'cpa.priority',
+  },
+  configurationPolicies: { id: 'cp.id', status: 'cp.status', orgId: 'cp.orgId', partnerId: 'cp.partnerId' },
+  configPolicyFeatureLinks: {
+    id: 'cpfl.id',
+    configPolicyId: 'cpfl.configPolicyId',
+    featureType: 'cpfl.featureType',
+    inlineSettings: 'cpfl.inlineSettings',
+  },
+  configPolicyEventLogSettings: {
+    featureLinkId: 'cpels.featureLinkId',
+    retentionDays: 'cpels.retentionDays',
+    maxEventsPerCycle: 'cpels.maxEventsPerCycle',
+    collectCategories: 'cpels.collectCategories',
+    minimumLevel: 'cpels.minimumLevel',
+    collectionIntervalMinutes: 'cpels.collectionIntervalMinutes',
+    rateLimitPerHour: 'cpels.rateLimitPerHour',
+  },
+  configPolicyMonitoringSettings: {
+    id: 'cpms.id',
+    featureLinkId: 'cpms.featureLinkId',
+    checkIntervalSeconds: 'cpms.checkIntervalSeconds',
+  },
+  configPolicyMonitoringWatches: {
+    settingsId: 'cpmw.settingsId',
+    enabled: 'cpmw.enabled',
+    sortOrder: 'cpmw.sortOrder',
+  },
+  configPolicyOnedriveSettings: {
+    id: 'cpos.id',
+    featureLinkId: 'cpos.featureLinkId',
+    silentAccountConfig: 'cpos.silentAccountConfig',
+    filesOnDemand: 'cpos.filesOnDemand',
+    kfmSilentOptIn: 'cpos.kfmSilentOptIn',
+    kfmFolders: 'cpos.kfmFolders',
+    kfmBlockOptOut: 'cpos.kfmBlockOptOut',
+    tenantAssociationId: 'cpos.tenantAssociationId',
+    restartOnChange: 'cpos.restartOnChange',
+  },
+  configPolicyOnedriveLibraries: {
+    settingsId: 'cpol.settingsId',
+    enabled: 'cpol.enabled',
+    sortOrder: 'cpol.sortOrder',
+  },
+  onedriveDeviceState: { deviceId: 'ods.deviceId' },
+  pamOrgConfig: { orgId: 'poc.orgId', uacInterceptionEnabled: 'poc.uacInterceptionEnabled' },
+  partners: {},
+  softwarePolicies: {},
+  softwareComplianceStatus: {},
+  deviceCommands: { $inferSelect: {} },
+  deviceDisks: {},
+  deviceFilesystemSnapshots: {},
+  automationPolicies: {},
+  cisBaselines: {},
+  cisBaselineResults: {},
+  cisRemediationActions: {},
+  securityStatus: {},
+  securityThreats: {},
+  securityScans: {},
+  sensitiveDataFindings: {},
+  sensitiveDataScans: {},
+  sites: {},
+  users: {},
+  deviceGroups: {},
+  agentVersions: {},
+}));
+
+vi.mock('../../services/redis', () => ({ getRedis: getRedisImpl }));
+vi.mock('../../services/eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('../../services/commandQueue', () => ({ queueCommandForExecution: vi.fn() }));
+vi.mock('../../services/cisHardening', () => ({ parseCisCollectorOutput: vi.fn() }));
+vi.mock('../../services/sentry', () => ({ captureException: vi.fn() }));
+vi.mock('../../services/cloudflareMtls', () => ({ CloudflareMtlsService: vi.fn() }));
+vi.mock('../../services/softwarePolicyService', () => ({ recordSoftwarePolicyAudit: vi.fn() }));
+vi.mock('../../services/featureConfigResolver', () => ({ resolvePatchConfigForDevice: vi.fn() }));
+vi.mock('../../services/onedriveGraph', () => ({ resolveUserGroupMembershipCached: vi.fn() }));
+vi.mock('../../services/filesystemAnalysis', () => ({
+  getFilesystemScanState: vi.fn(),
+  mergeFilesystemAnalysisPayload: vi.fn(),
+  parseFilesystemAnalysisStdout: vi.fn(),
+  readCheckpointPendingDirectories: vi.fn(),
+  readHotDirectories: vi.fn(),
+  saveFilesystemSnapshot: vi.fn(),
+  upsertFilesystemScanState: vi.fn(),
+}));
+vi.mock('../metrics', () => ({
+  recordSoftwareRemediationDecision: vi.fn(),
+  recordSensitiveDataFinding: vi.fn(),
+  recordSensitiveDataRemediationDecision: vi.fn(),
+}));
+vi.mock('../../jobs/softwareComplianceWorker', () => ({ scheduleSoftwareComplianceCheck: vi.fn() }));
+vi.mock('./policyProbeSafety', () => ({ isAllowedPolicyConfigProbe: vi.fn(() => true) }));
+
+// ---------------------------------------------------------------------------
+import {
+  buildEventLogConfigUpdate,
+  buildMonitoringConfigUpdate,
+  buildPamConfigUpdate,
+  buildHelperConfigUpdate,
+  buildOnedriveHelperConfigUpdate,
+} from './helpers';
+import { ORG_SCOPED_ONLY_FEATURE_TYPES } from '@breeze/shared';
+
+const DEVICE_ID = '00000000-0000-4000-8000-000000000001';
+const ORG_ID = '00000000-0000-4000-8000-000000000002';
+const SITE_ID = '00000000-0000-4000-8000-000000000003';
+const PARTNER_ID = '00000000-0000-4000-8000-000000000004';
+
+const deviceRow = [{ orgId: ORG_ID, siteId: SITE_ID }];
+const orgWithPartner = [{ partnerId: PARTNER_ID }];
+const orgWithoutPartner = [{ partnerId: null }];
+
+/** A watch row shaped like config_policy_monitoring_watches. */
+const watchRow = {
+  watchType: 'service' as const,
+  name: 'Spooler',
+  alertOnStop: true,
+  alertAfterConsecutiveFailures: 2,
+  autoRestart: false,
+  maxRestartAttempts: 3,
+  restartCooldownSeconds: 60,
+  cpuThresholdPercent: null,
+  memoryThresholdMb: null,
+  thresholdDurationSeconds: null,
+};
+
+const eventLogPolicyRow = (level: string) => ({
+  level,
+  assignmentPriority: 1,
+  retentionDays: 45,
+  maxEventsPerCycle: 250,
+  collectCategories: ['security'],
+  minimumLevel: 'warning',
+  collectionIntervalMinutes: 30,
+  rateLimitPerHour: 9000,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRedisImpl.mockReturnValue(null); // no cache — always resolve from "DB"
+  ownershipMock.mockReturnValue('OWNERSHIP_CONDITION' as any);
+  partnerWideVisibilityMock.mockImplementation(<T>(fn: () => Promise<T>) => fn());
+});
+
+/**
+ * Every agent-facing resolver must (a) hand the device org's partner to the
+ * ownership predicate and (b) take the partner-wide RLS escape. Table-driven so
+ * a newly added resolver that forgets either half is a one-line addition here.
+ */
+describe.each([
+  {
+    feature: 'event_log',
+    run: () => buildEventLogConfigUpdate(DEVICE_ID),
+    queue: (org: unknown[]) => [deviceRow, org, [], [eventLogPolicyRow('partner')]],
+  },
+  {
+    feature: 'monitoring',
+    run: () => buildMonitoringConfigUpdate(DEVICE_ID),
+    queue: (org: unknown[]) => [
+      deviceRow,
+      org,
+      [],
+      [{ level: 'partner', assignmentPriority: 1, settingsId: 'set-1', checkIntervalSeconds: 90 }],
+      [watchRow],
+    ],
+  },
+  {
+    feature: 'pam',
+    run: () => buildPamConfigUpdate(DEVICE_ID),
+    queue: (org: unknown[]) => [
+      deviceRow,
+      org,
+      [],
+      [{ level: 'partner', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: true } }],
+    ],
+  },
+  {
+    feature: 'helper',
+    run: () => buildHelperConfigUpdate(DEVICE_ID, ORG_ID),
+    queue: (org: unknown[]) => [
+      deviceRow,
+      org,
+      [],
+      [{ level: 'partner', assignmentPriority: 1, inlineSettings: { enabled: true } }],
+    ],
+  },
+])('$feature resolver — partner-wide ownership (#2930)', ({ run, queue }) => {
+  it('passes the device org\'s partnerId into the ownership predicate', async () => {
+    dbMock._resetQueue(queue(orgWithPartner));
+
+    await run();
+
+    expect(ownershipMock).toHaveBeenCalledWith({ orgId: ORG_ID, partnerId: PARTNER_ID });
+  });
+
+  it('runs the policy join inside the partner-wide RLS escape', async () => {
+    dbMock._resetQueue(queue(orgWithPartner));
+
+    await run();
+
+    expect(partnerWideVisibilityMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes partnerId null when the device org has no partner', async () => {
+    dbMock._resetQueue(queue(orgWithoutPartner));
+
+    await run();
+
+    expect(ownershipMock).toHaveBeenCalledWith({ orgId: ORG_ID, partnerId: null });
+  });
+});
+
+describe('onedrive_helper stays org-only — do not "fix" it like the others', () => {
+  // onedrive_helper is the sole member of ORG_SCOPED_ONLY_FEATURE_TYPES: its
+  // settings carry per-tenant M365 library mappings with no owning org on a
+  // partner-wide policy, and featureLinks.ts 400s the link at write time. An
+  // audit sweep for #2930 will land on this resolver and see an org-only
+  // predicate that looks like the same bug — this test says it isn't.
+  it('is still declared org-scoped-only in the shared constant', () => {
+    expect(ORG_SCOPED_ONLY_FEATURE_TYPES.has('onedrive_helper')).toBe(true);
+  });
+
+  it('does not use the dual-axis ownership predicate or the partner-wide escape', async () => {
+    dbMock._resetQueue([
+      deviceRow,
+      orgWithPartner,
+      [],
+      [{
+        level: 'organization',
+        assignmentPriority: 1,
+        settingsId: 'set-1',
+        silentAccountConfig: true,
+        filesOnDemand: true,
+        kfmSilentOptIn: false,
+        kfmFolders: [],
+        kfmBlockOptOut: false,
+        tenantAssociationId: null,
+        restartOnChange: false,
+      }],
+      [], // no libraries
+    ]);
+
+    await buildOnedriveHelperConfigUpdate(DEVICE_ID);
+
+    expect(ownershipMock).not.toHaveBeenCalled();
+    expect(partnerWideVisibilityMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('partner-owned policies actually reach the agent payload', () => {
+  it('event_log: a partner-level assignment supplies the delivered settings', async () => {
+    dbMock._resetQueue([deviceRow, orgWithPartner, [], [eventLogPolicyRow('partner')]]);
+
+    const settings = await buildEventLogConfigUpdate(DEVICE_ID);
+
+    expect(settings.collection_interval_minutes).toBe(30);
+    expect(settings.max_events_per_cycle).toBe(250);
+    expect(settings.minimum_level).toBe('warning');
+  });
+
+  it('event_log: an org-level policy still outranks a partner-level one', async () => {
+    // Partner-wide policies must widen coverage, not override a customer's own
+    // closer assignment — partner is the LOWEST level in the hierarchy.
+    dbMock._resetQueue([
+      deviceRow,
+      orgWithPartner,
+      [],
+      [
+        eventLogPolicyRow('partner'),
+        { ...eventLogPolicyRow('organization'), collectionIntervalMinutes: 5, maxEventsPerCycle: 10 },
+      ],
+    ]);
+
+    const settings = await buildEventLogConfigUpdate(DEVICE_ID);
+
+    expect(settings.collection_interval_minutes).toBe(5);
+    expect(settings.max_events_per_cycle).toBe(10);
+  });
+
+  it('pam: a partner-level policy enables UAC interception without any org row', async () => {
+    dbMock._resetQueue([
+      deviceRow,
+      orgWithPartner,
+      [],
+      [{ level: 'partner', assignmentPriority: 1, inlineSettings: { uacInterceptionEnabled: true } }],
+      [], // pam_org_config — must not be consulted, the policy resolved
+    ]);
+
+    const result = await buildPamConfigUpdate(DEVICE_ID);
+
+    expect(result.uacInterceptionEnabled).toBe(true);
+  });
+
+  it('monitoring: a partner-level policy delivers its watches', async () => {
+    dbMock._resetQueue([
+      deviceRow,
+      orgWithPartner,
+      [],
+      [{ level: 'partner', assignmentPriority: 1, settingsId: 'set-1', checkIntervalSeconds: 90 }],
+      [watchRow],
+    ]);
+
+    const result = await buildMonitoringConfigUpdate(DEVICE_ID);
+
+    expect(result?.check_interval_seconds).toBe(90);
+    expect(result?.watches).toHaveLength(1);
+    expect(result?.watches[0]?.name).toBe('Spooler');
+  });
+
+  it('monitoring: the watches read shares the policy join\'s escape, not a second one', async () => {
+    // The watches table's RLS walks settings_id → feature link →
+    // configuration_policies, so reading it outside the escape would find the
+    // partner-owned policy and then resolve zero watches (returning null).
+    dbMock._resetQueue([
+      deviceRow,
+      orgWithPartner,
+      [],
+      [{ level: 'partner', assignmentPriority: 1, settingsId: 'set-1', checkIntervalSeconds: 90 }],
+      [watchRow],
+    ]);
+
+    await buildMonitoringConfigUpdate(DEVICE_ID);
+
+    expect(partnerWideVisibilityMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/routes/agents/helpers.ts
+++ b/apps/api/src/routes/agents/helpers.ts
@@ -55,6 +55,7 @@ import {
 } from '../../services/filesystemAnalysis';
 import { recordSoftwarePolicyAudit } from '../../services/softwarePolicyService';
 import { resolvePatchConfigForDevice } from '../../services/featureConfigResolver';
+import { policyOwnershipCondition, withPartnerWideVisibility } from '../../services/configPolicyOwnership';
 import { resolveUserGroupMembershipCached } from '../../services/onedriveGraph';
 import { captureException } from '../../services/sentry';
 import { redactSecretsDeep, redactOptionalSecretText } from '../../services/secretRedaction';
@@ -1774,29 +1775,31 @@ async function resolveDeviceEventLogSettings(deviceId: string): Promise<EventLog
   }
 
   // 5. Single query: assignments → active policies → event_log feature link → settings
-  const rows = await db
-    .select({
-      level: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      retentionDays: configPolicyEventLogSettings.retentionDays,
-      maxEventsPerCycle: configPolicyEventLogSettings.maxEventsPerCycle,
-      collectCategories: configPolicyEventLogSettings.collectCategories,
-      minimumLevel: configPolicyEventLogSettings.minimumLevel,
-      collectionIntervalMinutes: configPolicyEventLogSettings.collectionIntervalMinutes,
-      rateLimitPerHour: configPolicyEventLogSettings.rateLimitPerHour,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
-    .innerJoin(configPolicyFeatureLinks, and(
-      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-      eq(configPolicyFeatureLinks.featureType, 'event_log'),
-    ))
-    .innerJoin(configPolicyEventLogSettings, eq(configPolicyEventLogSettings.featureLinkId, configPolicyFeatureLinks.id))
-    .where(and(
-      eq(configurationPolicies.status, 'active'),
-      eq(configurationPolicies.orgId, device.orgId),
-      or(...targetConditions),
-    ));
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        level: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        retentionDays: configPolicyEventLogSettings.retentionDays,
+        maxEventsPerCycle: configPolicyEventLogSettings.maxEventsPerCycle,
+        collectCategories: configPolicyEventLogSettings.collectCategories,
+        minimumLevel: configPolicyEventLogSettings.minimumLevel,
+        collectionIntervalMinutes: configPolicyEventLogSettings.collectionIntervalMinutes,
+        rateLimitPerHour: configPolicyEventLogSettings.rateLimitPerHour,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+      .innerJoin(configPolicyFeatureLinks, and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'event_log'),
+      ))
+      .innerJoin(configPolicyEventLogSettings, eq(configPolicyEventLogSettings.featureLinkId, configPolicyFeatureLinks.id))
+      .where(and(
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+        or(...targetConditions),
+      ))
+  );
 
   if (rows.length === 0) return EVENT_LOG_DEFAULTS;
 
@@ -1966,48 +1969,61 @@ async function resolveDeviceMonitoringSettings(deviceId: string): Promise<Monito
     );
   }
 
-  // 5. Single query: assignments → active policies → monitoring feature link → settings
-  const rows = await db
-    .select({
-      level: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      settingsId: configPolicyMonitoringSettings.id,
-      checkIntervalSeconds: configPolicyMonitoringSettings.checkIntervalSeconds,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
-    .innerJoin(configPolicyFeatureLinks, and(
-      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-      eq(configPolicyFeatureLinks.featureType, 'monitoring'),
-    ))
-    .innerJoin(configPolicyMonitoringSettings, eq(configPolicyMonitoringSettings.featureLinkId, configPolicyFeatureLinks.id))
-    .where(and(
-      eq(configurationPolicies.status, 'active'),
-      eq(configurationPolicies.orgId, device.orgId),
-      or(...targetConditions),
-    ));
+  // 5-7. Policy join + the winning row's watches, both under one partner-wide
+  // escape (#2930). The watches table's RLS walks settings_id → feature link →
+  // configuration_policies and needs breeze_has_partner_access for a
+  // partner-owned policy, so splitting the two reads across contexts would find
+  // the policy and then silently resolve zero watches (returning null here).
+  // Both reads are pinned to this device's own hierarchy.
+  const resolved = await withPartnerWideVisibility(async () => {
+    // 5. Single query: assignments → active policies → monitoring feature link → settings
+    const rows = await db
+      .select({
+        level: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        settingsId: configPolicyMonitoringSettings.id,
+        checkIntervalSeconds: configPolicyMonitoringSettings.checkIntervalSeconds,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+      .innerJoin(configPolicyFeatureLinks, and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'monitoring'),
+      ))
+      .innerJoin(configPolicyMonitoringSettings, eq(configPolicyMonitoringSettings.featureLinkId, configPolicyFeatureLinks.id))
+      .where(and(
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+        or(...targetConditions),
+      ));
 
-  if (rows.length === 0) return null;
+    if (rows.length === 0) return null;
 
-  // 6. Sort by level priority DESC, then assignment priority ASC — first match wins
-  rows.sort((a, b) => {
-    const levelDiff = (LEVEL_PRIORITY[b.level] ?? 0) - (LEVEL_PRIORITY[a.level] ?? 0);
-    if (levelDiff !== 0) return levelDiff;
-    return a.assignmentPriority - b.assignmentPriority;
+    // 6. Sort by level priority DESC, then assignment priority ASC — first match wins
+    rows.sort((a, b) => {
+      const levelDiff = (LEVEL_PRIORITY[b.level] ?? 0) - (LEVEL_PRIORITY[a.level] ?? 0);
+      if (levelDiff !== 0) return levelDiff;
+      return a.assignmentPriority - b.assignmentPriority;
+    });
+
+    const winner = rows[0];
+    if (!winner) return null;
+
+    // 7. Load watches for the winning settings row
+    const watches = await db
+      .select()
+      .from(configPolicyMonitoringWatches)
+      .where(and(
+        eq(configPolicyMonitoringWatches.settingsId, winner.settingsId),
+        eq(configPolicyMonitoringWatches.enabled, true),
+      ))
+      .orderBy(configPolicyMonitoringWatches.sortOrder);
+
+    return { winner, watches };
   });
 
-  const winner = rows[0];
-  if (!winner) return null;
-
-  // 7. Load watches for the winning settings row
-  const watches = await db
-    .select()
-    .from(configPolicyMonitoringWatches)
-    .where(and(
-      eq(configPolicyMonitoringWatches.settingsId, winner.settingsId),
-      eq(configPolicyMonitoringWatches.enabled, true),
-    ))
-    .orderBy(configPolicyMonitoringWatches.sortOrder);
+  if (!resolved) return null;
+  const { winner, watches } = resolved;
 
   if (watches.length === 0) return null;
 
@@ -2468,28 +2484,25 @@ export async function resolveDeviceHelperSettings(deviceId: string): Promise<Hel
   }
 
   // 5. Single query: assignments → active policies → helper feature link (pure JSONB)
-  const rows = await db
-    .select({
-      level: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      inlineSettings: configPolicyFeatureLinks.inlineSettings,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
-    .innerJoin(configPolicyFeatureLinks, and(
-      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-      eq(configPolicyFeatureLinks.featureType, 'helper'),
-    ))
-    .where(and(
-      eq(configurationPolicies.status, 'active'),
-      // Org-owned policies for this device's org, OR partner-owned policies
-      // (org_id NULL) for this device's partner — same dual-axis shape as
-      // resolveEffectiveConfigWithExecutor (services/configurationPolicy.ts).
-      org?.partnerId
-        ? sql`(${configurationPolicies.orgId} = ${device.orgId} OR (${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${org.partnerId}))`
-        : eq(configurationPolicies.orgId, device.orgId),
-      or(...targetConditions),
-    ));
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        level: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        inlineSettings: configPolicyFeatureLinks.inlineSettings,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+      .innerJoin(configPolicyFeatureLinks, and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'helper'),
+      ))
+      .where(and(
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+        or(...targetConditions),
+      ))
+  );
 
   if (rows.length === 0) return null;
 
@@ -2630,23 +2643,25 @@ async function resolveDevicePamSettings(deviceId: string): Promise<PamSettings> 
   }
 
   // 5. Single query: assignments → active policies → pam feature link (pure JSONB)
-  const rows = await db
-    .select({
-      level: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      inlineSettings: configPolicyFeatureLinks.inlineSettings,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
-    .innerJoin(configPolicyFeatureLinks, and(
-      eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-      eq(configPolicyFeatureLinks.featureType, 'pam'),
-    ))
-    .where(and(
-      eq(configurationPolicies.status, 'active'),
-      eq(configurationPolicies.orgId, device.orgId),
-      or(...targetConditions),
-    ));
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        level: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        inlineSettings: configPolicyFeatureLinks.inlineSettings,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(configurationPolicies, eq(configPolicyAssignments.configPolicyId, configurationPolicies.id))
+      .innerJoin(configPolicyFeatureLinks, and(
+        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+        eq(configPolicyFeatureLinks.featureType, 'pam'),
+      ))
+      .where(and(
+        eq(configurationPolicies.status, 'active'),
+        policyOwnershipCondition({ orgId: device.orgId, partnerId: org?.partnerId ?? null }),
+        or(...targetConditions),
+      ))
+  );
 
   if (rows.length === 0) return resolveOrgPamFallback(device.orgId);
 
@@ -2793,6 +2808,16 @@ async function resolveDeviceOnedriveSettings(deviceId: string): Promise<Onedrive
   }
 
   // 5. Single query: assignments → active policies → onedrive_helper feature link → settings
+  //
+  // DELIBERATELY org-only, unlike the sibling resolvers fixed for #2930.
+  // `onedrive_helper` is the sole member of ORG_SCOPED_ONLY_FEATURE_TYPES
+  // (packages/shared/src/constants/configFeatureTypes.ts): its settings carry
+  // per-tenant M365 library mappings that a partner-wide policy has no owning
+  // org to anchor to, and featureLinks.ts rejects the link with a 400 at write
+  // time. A partner-owned row therefore cannot exist here — adding the
+  // dual-axis predicate would be dead code that implies support we don't have.
+  // Supporting partner-wide OneDrive is a schema/product change, not a resolver
+  // fix.
   const rows = await db
     .select({
       level: configPolicyAssignments.level,

--- a/apps/api/src/services/configPolicyOwnership.test.ts
+++ b/apps/api/src/services/configPolicyOwnership.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the config-policy partner-wide ownership primitives (#2930).
+ *
+ * These assert the two things that, when missing, make a partner-authored
+ * policy silently never reach an agent:
+ *   1. the emitted SQL admits `org_id IS NULL AND partner_id = <device partner>`
+ *      rows, not just `org_id = <device org>`;
+ *   2. the read escapes to a system RLS context, because partner-owned rows are
+ *      invisible under every agent-facing (org-scoped) context.
+ *
+ * The SQL is compiled with the real PgDialect rather than inspected as an AST —
+ * a regression that drops the partner branch changes the compiled text and the
+ * bound parameters, which is exactly what we want to pin.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+const { getCurrentDbAccessContextMock, runOutsideDbContextMock, withSystemDbAccessContextMock } =
+  vi.hoisted(() => ({
+    getCurrentDbAccessContextMock: vi.fn<() => { scope: string } | undefined>(() => undefined),
+    runOutsideDbContextMock: vi.fn(<T>(fn: () => T): T => fn()),
+    withSystemDbAccessContextMock: vi.fn(async <T>(fn: () => Promise<T>): Promise<T> => fn()),
+  }));
+
+vi.mock('../db', () => ({
+  getCurrentDbAccessContext: getCurrentDbAccessContextMock,
+  runOutsideDbContext: runOutsideDbContextMock,
+  withSystemDbAccessContext: withSystemDbAccessContextMock,
+}));
+
+import { policyOwnershipCondition, withPartnerWideVisibility } from './configPolicyOwnership';
+
+const ORG_ID = '00000000-0000-4000-8000-0000000000a1';
+const PARTNER_ID = '00000000-0000-4000-8000-0000000000b2';
+
+const compile = (condition: ReturnType<typeof policyOwnershipCondition>) =>
+  new PgDialect().sqlToQuery(condition);
+
+describe('policyOwnershipCondition', () => {
+  it('admits partner-owned rows (org_id NULL) when the device org has a partner', () => {
+    const { sql, params } = compile(
+      policyOwnershipCondition({ orgId: ORG_ID, partnerId: PARTNER_ID })
+    );
+
+    // The whole point of #2930: an `org_id IS NULL` row owned by this device's
+    // partner must be matched alongside the device's own org-owned rows.
+    expect(sql).toMatch(/"org_id" IS NULL/i);
+    expect(sql).toContain('"partner_id" =');
+    expect(sql).toMatch(/ OR /i);
+    expect(params).toEqual([ORG_ID, PARTNER_ID]);
+  });
+
+  it('still matches the device org — a partner-wide policy must not displace org-owned ones', () => {
+    const { sql, params } = compile(
+      policyOwnershipCondition({ orgId: ORG_ID, partnerId: PARTNER_ID })
+    );
+
+    expect(sql).toContain('"org_id" =');
+    expect(params[0]).toBe(ORG_ID);
+  });
+
+  it('binds ids as parameters, never as inlined literals', () => {
+    const { sql } = compile(policyOwnershipCondition({ orgId: ORG_ID, partnerId: PARTNER_ID }));
+
+    expect(sql).not.toContain(ORG_ID);
+    expect(sql).not.toContain(PARTNER_ID);
+  });
+
+  it('falls back to a plain org-equality predicate when the org has no partner', () => {
+    const { sql, params } = compile(policyOwnershipCondition({ orgId: ORG_ID, partnerId: null }));
+
+    expect(sql).toContain('"org_id" =');
+    expect(sql).not.toMatch(/IS NULL/i);
+    expect(sql).not.toMatch(/partner_id/i);
+    expect(params).toEqual([ORG_ID]);
+  });
+});
+
+describe('withPartnerWideVisibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCurrentDbAccessContextMock.mockReturnValue(undefined);
+  });
+
+  it('escapes to a system context when the caller is org-scoped', async () => {
+    getCurrentDbAccessContextMock.mockReturnValue({ scope: 'organization' });
+
+    await expect(withPartnerWideVisibility(async () => 'rows')).resolves.toBe('rows');
+
+    expect(runOutsideDbContextMock).toHaveBeenCalledTimes(1);
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('escapes when there is no ambient context at all', async () => {
+    getCurrentDbAccessContextMock.mockReturnValue(undefined);
+
+    await withPartnerWideVisibility(async () => null);
+
+    expect(withSystemDbAccessContextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when already system-scoped — never double-holds a connection (#1105)', async () => {
+    getCurrentDbAccessContextMock.mockReturnValue({ scope: 'system' });
+
+    await expect(withPartnerWideVisibility(async () => 'rows')).resolves.toBe('rows');
+
+    expect(runOutsideDbContextMock).not.toHaveBeenCalled();
+    expect(withSystemDbAccessContextMock).not.toHaveBeenCalled();
+  });
+
+  it('propagates the callback error rather than swallowing it', async () => {
+    getCurrentDbAccessContextMock.mockReturnValue({ scope: 'organization' });
+
+    await expect(
+      withPartnerWideVisibility(async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+  });
+});

--- a/apps/api/src/services/configPolicyOwnership.ts
+++ b/apps/api/src/services/configPolicyOwnership.ts
@@ -1,0 +1,84 @@
+import { sql, type SQL } from 'drizzle-orm';
+import { configurationPolicies } from '../db/schema';
+import {
+  getCurrentDbAccessContext,
+  runOutsideDbContext,
+  withSystemDbAccessContext,
+} from '../db';
+
+/**
+ * The two halves of "a per-device resolver honours partner-wide policies".
+ *
+ * A `configuration_policies` row is either ORG-owned (`org_id` set,
+ * `partner_id NULL`) or PARTNER-owned / "partner-wide" (`org_id NULL`,
+ * `partner_id` set) — the XOR is enforced by `<table>_one_owner_chk`. Every
+ * per-device resolver therefore needs BOTH of the following, and fixing only
+ * one of them leaves the feature just as broken:
+ *
+ *  1. {@link policyOwnershipCondition} — the app-layer join predicate. A bare
+ *     `eq(configurationPolicies.orgId, device.orgId)` never matches an
+ *     `org_id NULL` row, so a partner-wide policy is authorable in the UI and
+ *     silently never reaches an agent.
+ *  2. {@link withPartnerWideVisibility} — the RLS context. Partner-owned rows
+ *     are gated by `breeze_has_partner_access`, and every agent-facing context
+ *     (agentAuth, org-scoped user tokens, portal, org-scoped OAuth bearers)
+ *     carries `accessiblePartnerIds: []`. Under those the read returns ZERO
+ *     ROWS — it does not raise — so a correct predicate still resolves nothing.
+ *
+ * Extracted here (issue #2930) because the predicate had been re-derived inline
+ * in four places and three of the five agent resolvers had drifted back to the
+ * org-only form. Siblings: `readWithPartnerAxisVisibility` (`db/partnerAxisRead.ts`)
+ * does the same job for partner-AXIS tables; this module is the config-policy
+ * partner-WIDE equivalent.
+ */
+
+/** The owning org + partner of the device a policy is being resolved for. */
+export interface ConfigPolicyOwner {
+  orgId: string;
+  /** The device org's partner, or null when the org has no partner. */
+  partnerId: string | null;
+}
+
+/**
+ * Build the "does this policy apply to this device" ownership predicate.
+ *
+ * A policy resolves when it is owned by the device's own org (the original
+ * org-scoped shape) OR owned by the device's partner (`org_id NULL`,
+ * `partner_id` set — the partner-wide / "All orgs" shape, #1724). RLS
+ * (`breeze_has_org_access` / `breeze_has_partner_access`) still gates
+ * visibility on top of this; the predicate is never the tenancy boundary.
+ *
+ * Use this in place of a bare org-equality join on EVERY per-device resolver.
+ */
+export function policyOwnershipCondition(owner: ConfigPolicyOwner): SQL {
+  if (owner.partnerId) {
+    return sql`(${configurationPolicies.orgId} = ${owner.orgId} OR (${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${owner.partnerId}))`;
+  }
+  return sql`${configurationPolicies.orgId} = ${owner.orgId}`;
+}
+
+/**
+ * Run a config-policy lookup where partner-wide rows must be visible.
+ *
+ * Wrap ONLY the policy join. Device/site/group reads belong in the caller's own
+ * context so RLS keeps gating which devices a caller may see; the policy join
+ * is self-tenanted by the device hierarchy already resolved there.
+ *
+ * AVAILABILITY: the escape is taken only when it is actually needed. A caller
+ * that is already system-scoped gains nothing and would double-hold pooled
+ * connections — `withDbAccessContext` pins one connection for its whole
+ * callback, and the nested `withSystemDbAccessContext` opens a SECOND
+ * transaction on a SECOND connection. Against the 25-connection US ceiling,
+ * with no acquire timeout in postgres-js, that is the #1105 self-deadlock
+ * shape. Hot paths (the agent heartbeat) should additionally hoist the whole
+ * resolve out of the org transaction so this escape has nothing to double-hold;
+ * it then degrades to the single system context it opens itself.
+ *
+ * The three `db` imports are NAMED on purpose: a unit suite whose
+ * `vi.mock('../db')` factory omits one fails loudly with "No <name> export is
+ * defined on the mock" rather than silently skipping the escape.
+ */
+export async function withPartnerWideVisibility<T>(fn: () => Promise<T>): Promise<T> {
+  if (getCurrentDbAccessContext()?.scope === 'system') return fn();
+  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
+}

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -223,43 +223,48 @@ export async function resolveAlertRulesForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  const rows = await db
-    .select({
-      alertRule: configPolicyAlertRules,
-      assignmentLevel: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      assignmentCreatedAt: configPolicyAssignments.createdAt,
-      assignmentId: configPolicyAssignments.id,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition(hierarchy)
+  // #2930 — the ownership predicate below already admits partner-owned rows,
+  // but under an org-scoped RLS context those rows are invisible and the join
+  // silently returns nothing. Self-tenanted by this device's own hierarchy.
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        alertRule: configPolicyAlertRules,
+        assignmentLevel: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        assignmentCreatedAt: configPolicyAssignments.createdAt,
+        assignmentId: configPolicyAssignments.id,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active'),
+          policyOwnershipCondition(hierarchy)
+        )
       )
-    )
-    .innerJoin(
-      configPolicyFeatureLinks,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        // Server-evaluated rules live exclusively under alert_rule links since the
-        // 2026-07-30 ownership consolidation migration.
-        eq(configPolicyFeatureLinks.featureType, 'alert_rule')
+      .innerJoin(
+        configPolicyFeatureLinks,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          // Server-evaluated rules live exclusively under alert_rule links since the
+          // 2026-07-30 ownership consolidation migration.
+          eq(configPolicyFeatureLinks.featureType, 'alert_rule')
+        )
       )
-    )
-    .innerJoin(
-      configPolicyAlertRules,
-      eq(configPolicyAlertRules.featureLinkId, configPolicyFeatureLinks.id)
-    )
-    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-    .orderBy(
-      configPolicyAssignments.level,
-      configPolicyAssignments.priority,
-      configPolicyAssignments.createdAt,
-      asc(configPolicyAlertRules.sortOrder)
-    );
+      .innerJoin(
+        configPolicyAlertRules,
+        eq(configPolicyAlertRules.featureLinkId, configPolicyFeatureLinks.id)
+      )
+      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+      .orderBy(
+        configPolicyAssignments.level,
+        configPolicyAssignments.priority,
+        configPolicyAssignments.createdAt,
+        asc(configPolicyAlertRules.sortOrder)
+      )
+  );
 
   if (rows.length === 0) return [];
 
@@ -286,41 +291,46 @@ export async function resolveAutomationsForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  const rows = await db
-    .select({
-      automation: configPolicyAutomations,
-      assignmentLevel: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      assignmentCreatedAt: configPolicyAssignments.createdAt,
-      assignmentId: configPolicyAssignments.id,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition(hierarchy)
+  // #2930 — the ownership predicate below already admits partner-owned rows,
+  // but under an org-scoped RLS context those rows are invisible and the join
+  // silently returns nothing. Self-tenanted by this device's own hierarchy.
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        automation: configPolicyAutomations,
+        assignmentLevel: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        assignmentCreatedAt: configPolicyAssignments.createdAt,
+        assignmentId: configPolicyAssignments.id,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active'),
+          policyOwnershipCondition(hierarchy)
+        )
       )
-    )
-    .innerJoin(
-      configPolicyFeatureLinks,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'automation')
+      .innerJoin(
+        configPolicyFeatureLinks,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          eq(configPolicyFeatureLinks.featureType, 'automation')
+        )
       )
-    )
-    .innerJoin(
-      configPolicyAutomations,
-      eq(configPolicyAutomations.featureLinkId, configPolicyFeatureLinks.id)
-    )
-    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-    .orderBy(
-      configPolicyAssignments.level,
-      configPolicyAssignments.priority,
-      configPolicyAssignments.createdAt,
-      asc(configPolicyAutomations.sortOrder)
-    );
+      .innerJoin(
+        configPolicyAutomations,
+        eq(configPolicyAutomations.featureLinkId, configPolicyFeatureLinks.id)
+      )
+      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+      .orderBy(
+        configPolicyAssignments.level,
+        configPolicyAssignments.priority,
+        configPolicyAssignments.createdAt,
+        asc(configPolicyAutomations.sortOrder)
+      )
+  );
 
   if (rows.length === 0) return [];
 
@@ -693,40 +703,45 @@ export async function resolveMaintenanceConfigForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  const rows = await db
-    .select({
-      maintenanceSettings: configPolicyMaintenanceSettings,
-      assignmentLevel: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      assignmentCreatedAt: configPolicyAssignments.createdAt,
-      assignmentId: configPolicyAssignments.id,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition(hierarchy)
+  // #2930 — the ownership predicate below already admits partner-owned rows,
+  // but under an org-scoped RLS context those rows are invisible and the join
+  // silently returns nothing. Self-tenanted by this device's own hierarchy.
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        maintenanceSettings: configPolicyMaintenanceSettings,
+        assignmentLevel: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        assignmentCreatedAt: configPolicyAssignments.createdAt,
+        assignmentId: configPolicyAssignments.id,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active'),
+          policyOwnershipCondition(hierarchy)
+        )
       )
-    )
-    .innerJoin(
-      configPolicyFeatureLinks,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'maintenance')
+      .innerJoin(
+        configPolicyFeatureLinks,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          eq(configPolicyFeatureLinks.featureType, 'maintenance')
+        )
       )
-    )
-    .innerJoin(
-      configPolicyMaintenanceSettings,
-      eq(configPolicyMaintenanceSettings.featureLinkId, configPolicyFeatureLinks.id)
-    )
-    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-    .orderBy(
-      configPolicyAssignments.level,
-      configPolicyAssignments.priority,
-      configPolicyAssignments.createdAt
-    );
+      .innerJoin(
+        configPolicyMaintenanceSettings,
+        eq(configPolicyMaintenanceSettings.featureLinkId, configPolicyFeatureLinks.id)
+      )
+      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+      .orderBy(
+        configPolicyAssignments.level,
+        configPolicyAssignments.priority,
+        configPolicyAssignments.createdAt
+      )
+  );
 
   if (rows.length === 0) return null;
 
@@ -747,41 +762,46 @@ export async function resolveComplianceRulesForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  const rows = await db
-    .select({
-      complianceRule: configPolicyComplianceRules,
-      assignmentLevel: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      assignmentCreatedAt: configPolicyAssignments.createdAt,
-      assignmentId: configPolicyAssignments.id,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition(hierarchy)
+  // #2930 — the ownership predicate below already admits partner-owned rows,
+  // but under an org-scoped RLS context those rows are invisible and the join
+  // silently returns nothing. Self-tenanted by this device's own hierarchy.
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        complianceRule: configPolicyComplianceRules,
+        assignmentLevel: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        assignmentCreatedAt: configPolicyAssignments.createdAt,
+        assignmentId: configPolicyAssignments.id,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active'),
+          policyOwnershipCondition(hierarchy)
+        )
       )
-    )
-    .innerJoin(
-      configPolicyFeatureLinks,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'compliance')
+      .innerJoin(
+        configPolicyFeatureLinks,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          eq(configPolicyFeatureLinks.featureType, 'compliance')
+        )
       )
-    )
-    .innerJoin(
-      configPolicyComplianceRules,
-      eq(configPolicyComplianceRules.featureLinkId, configPolicyFeatureLinks.id)
-    )
-    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-    .orderBy(
-      configPolicyAssignments.level,
-      configPolicyAssignments.priority,
-      configPolicyAssignments.createdAt,
-      asc(configPolicyComplianceRules.sortOrder)
-    );
+      .innerJoin(
+        configPolicyComplianceRules,
+        eq(configPolicyComplianceRules.featureLinkId, configPolicyFeatureLinks.id)
+      )
+      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+      .orderBy(
+        configPolicyAssignments.level,
+        configPolicyAssignments.priority,
+        configPolicyAssignments.createdAt,
+        asc(configPolicyComplianceRules.sortOrder)
+      )
+  );
 
   if (rows.length === 0) return [];
 
@@ -806,36 +826,43 @@ export async function resolveSoftwarePolicyForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  const rows = await db
-    .select({
-      featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
-      assignmentLevel: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      assignmentCreatedAt: configPolicyAssignments.createdAt,
-      assignmentId: configPolicyAssignments.id,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition(hierarchy)
+  // #2930 — the ownership predicate below already admits partner-owned rows,
+  // but under an org-scoped RLS context (e.g. the PAM UAC elevation decision
+  // path, resolved inside the agent request's org-scoped context) those rows
+  // are invisible and the join silently returns nothing. Self-tenanted by this
+  // device's own hierarchy.
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
+        assignmentLevel: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        assignmentCreatedAt: configPolicyAssignments.createdAt,
+        assignmentId: configPolicyAssignments.id,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active'),
+          policyOwnershipCondition(hierarchy)
+        )
       )
-    )
-    .innerJoin(
-      configPolicyFeatureLinks,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'software_policy')
+      .innerJoin(
+        configPolicyFeatureLinks,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          eq(configPolicyFeatureLinks.featureType, 'software_policy')
+        )
       )
-    )
-    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-    .orderBy(
-      configPolicyAssignments.level,
-      configPolicyAssignments.priority,
-      configPolicyAssignments.createdAt
-    );
+      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+      .orderBy(
+        configPolicyAssignments.level,
+        configPolicyAssignments.priority,
+        configPolicyAssignments.createdAt
+      )
+  );
 
   if (rows.length === 0) return null;
 
@@ -1005,35 +1032,40 @@ export async function resolveVulnerabilityEnabledForDevice(deviceId: string): Pr
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  const rows = await db
-    .select({
-      inlineSettings: configPolicyFeatureLinks.inlineSettings,
-      assignmentLevel: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      assignmentCreatedAt: configPolicyAssignments.createdAt,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition(hierarchy)
+  // #2930 — the ownership predicate below already admits partner-owned rows,
+  // but under an org-scoped RLS context those rows are invisible and the join
+  // silently returns nothing. Self-tenanted by this device's own hierarchy.
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        inlineSettings: configPolicyFeatureLinks.inlineSettings,
+        assignmentLevel: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        assignmentCreatedAt: configPolicyAssignments.createdAt,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active'),
+          policyOwnershipCondition(hierarchy)
+        )
       )
-    )
-    .innerJoin(
-      configPolicyFeatureLinks,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'vulnerability')
+      .innerJoin(
+        configPolicyFeatureLinks,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          eq(configPolicyFeatureLinks.featureType, 'vulnerability')
+        )
       )
-    )
-    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-    .orderBy(
-      configPolicyAssignments.level,
-      configPolicyAssignments.priority,
-      configPolicyAssignments.createdAt
-    );
+      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+      .orderBy(
+        configPolicyAssignments.level,
+        configPolicyAssignments.priority,
+        configPolicyAssignments.createdAt
+      )
+  );
 
   if (rows.length === 0) return false;
 
@@ -1664,40 +1696,48 @@ export async function resolveBackupProtectionForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  const rows = await db
-    .select({
-      featureLinkId: configPolicyFeatureLinks.id,
-      retention: configPolicyBackupSettings.retention,
-      assignmentLevel: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      assignmentCreatedAt: configPolicyAssignments.createdAt,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition(hierarchy)
+  // #2930 — the ownership predicate below already admits partner-owned rows,
+  // but under an org-scoped RLS context those rows are invisible and the join
+  // silently returns nothing. Self-tenanted by this device's own hierarchy.
+  // The leftJoin to configPolicyBackupSettings is RLS-chained to
+  // configuration_policies (same feature-link id), so it must stay inside
+  // this same escape rather than resolving separately.
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        featureLinkId: configPolicyFeatureLinks.id,
+        retention: configPolicyBackupSettings.retention,
+        assignmentLevel: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        assignmentCreatedAt: configPolicyAssignments.createdAt,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active'),
+          policyOwnershipCondition(hierarchy)
+        )
       )
-    )
-    .innerJoin(
-      configPolicyFeatureLinks,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'backup')
+      .innerJoin(
+        configPolicyFeatureLinks,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          eq(configPolicyFeatureLinks.featureType, 'backup')
+        )
       )
-    )
-    .leftJoin(
-      configPolicyBackupSettings,
-      eq(configPolicyBackupSettings.featureLinkId, configPolicyFeatureLinks.id)
-    )
-    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-    .orderBy(
-      configPolicyAssignments.level,
-      configPolicyAssignments.priority,
-      configPolicyAssignments.createdAt
-    );
+      .leftJoin(
+        configPolicyBackupSettings,
+        eq(configPolicyBackupSettings.featureLinkId, configPolicyFeatureLinks.id)
+      )
+      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+      .orderBy(
+        configPolicyAssignments.level,
+        configPolicyAssignments.priority,
+        configPolicyAssignments.createdAt
+      )
+  );
 
   if (rows.length === 0) return null;
 

--- a/apps/api/src/services/featureConfigResolver.ts
+++ b/apps/api/src/services/featureConfigResolver.ts
@@ -1,10 +1,6 @@
-import {
-  db,
-  getCurrentDbAccessContext,
-  runOutsideDbContext,
-  withSystemDbAccessContext,
-} from '../db';
+import { db } from '../db';
 import { readWithPartnerAxisVisibility } from '../db/partnerAxisRead';
+import { policyOwnershipCondition, withPartnerWideVisibility } from './configPolicyOwnership';
 import {
   configurationPolicies,
   configPolicyFeatureLinks,
@@ -140,26 +136,6 @@ function buildRoleOsFilterConditions(hierarchy: DeviceHierarchy): SQL[] {
     sql`(${configPolicyAssignments.roleFilter} IS NULL OR ${sql.param(hierarchy.deviceRole)} = ANY(${configPolicyAssignments.roleFilter}))`,
     sql`(${configPolicyAssignments.osFilter} IS NULL OR ${sql.param(hierarchy.osType)} = ANY(${configPolicyAssignments.osFilter}))`,
   ];
-}
-
-/**
- * Build the policy-ownership condition for a device's hierarchy.
- *
- * A configuration_policies row resolves for this device when it is owned by
- * the device's own org (the original org-scoped shape) OR owned by the
- * device's partner (org_id NULL, partner_id set — the "partner-wide / all orgs"
- * shape, #1724). breeze_has_org_access / breeze_has_partner_access at the RLS
- * layer still gate visibility; this is the additional "does this policy apply
- * to this device" join predicate.
- *
- * Use this in place of a bare org-equality join on every per-device resolver
- * so partner-owned policies span all of the partner's orgs.
- */
-function policyOwnershipCondition(hierarchy: DeviceHierarchy): SQL {
-  if (hierarchy.partnerId) {
-    return sql`(${configurationPolicies.orgId} = ${hierarchy.orgId} OR (${configurationPolicies.orgId} IS NULL AND ${configurationPolicies.partnerId} = ${hierarchy.partnerId}))`;
-  }
-  return sql`${configurationPolicies.orgId} = ${hierarchy.orgId}`;
 }
 
 function buildTargetConditions(hierarchy: DeviceHierarchy): SQL[] {
@@ -529,45 +505,53 @@ export async function resolvePatchConfigDetailsForDevice(
   const targetConditions = buildTargetConditions(hierarchy);
   const roleOsConditions = buildRoleOsFilterConditions(hierarchy);
 
-  const rows = await db
-    .select({
-      patchSettings: configPolicyPatchSettings,
-      featureLinkId: configPolicyFeatureLinks.id,
-      configPolicyId: configurationPolicies.id,
-      configPolicyName: configurationPolicies.name,
-      featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
-      assignmentTargetId: configPolicyAssignments.targetId,
-      assignmentLevel: configPolicyAssignments.level,
-      assignmentPriority: configPolicyAssignments.priority,
-      assignmentCreatedAt: configPolicyAssignments.createdAt,
-      assignmentId: configPolicyAssignments.id,
-    })
-    .from(configPolicyAssignments)
-    .innerJoin(
-      configurationPolicies,
-      and(
-        eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
-        eq(configurationPolicies.status, 'active'),
-        policyOwnershipCondition(hierarchy)
+  // #2930 — the ownership predicate below already admits partner-owned rows,
+  // but under an org-scoped RLS context (the agent heartbeat, an org user
+  // token) those rows are invisible and the join silently returns nothing.
+  // Self-tenanted by this device's own hierarchy, so the escape cannot pivot
+  // tenants. Callers on hot paths hoist the whole resolve out of their org
+  // transaction so this opens no second connection.
+  const rows = await withPartnerWideVisibility(() =>
+    db
+      .select({
+        patchSettings: configPolicyPatchSettings,
+        featureLinkId: configPolicyFeatureLinks.id,
+        configPolicyId: configurationPolicies.id,
+        configPolicyName: configurationPolicies.name,
+        featurePolicyId: configPolicyFeatureLinks.featurePolicyId,
+        assignmentTargetId: configPolicyAssignments.targetId,
+        assignmentLevel: configPolicyAssignments.level,
+        assignmentPriority: configPolicyAssignments.priority,
+        assignmentCreatedAt: configPolicyAssignments.createdAt,
+        assignmentId: configPolicyAssignments.id,
+      })
+      .from(configPolicyAssignments)
+      .innerJoin(
+        configurationPolicies,
+        and(
+          eq(configPolicyAssignments.configPolicyId, configurationPolicies.id),
+          eq(configurationPolicies.status, 'active'),
+          policyOwnershipCondition(hierarchy)
+        )
       )
-    )
-    .innerJoin(
-      configPolicyFeatureLinks,
-      and(
-        eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
-        eq(configPolicyFeatureLinks.featureType, 'patch')
+      .innerJoin(
+        configPolicyFeatureLinks,
+        and(
+          eq(configPolicyFeatureLinks.configPolicyId, configurationPolicies.id),
+          eq(configPolicyFeatureLinks.featureType, 'patch')
+        )
       )
-    )
-    .innerJoin(
-      configPolicyPatchSettings,
-      eq(configPolicyPatchSettings.featureLinkId, configPolicyFeatureLinks.id)
-    )
-    .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
-    .orderBy(
-      configPolicyAssignments.level,
-      configPolicyAssignments.priority,
-      configPolicyAssignments.createdAt
-    );
+      .innerJoin(
+        configPolicyPatchSettings,
+        eq(configPolicyPatchSettings.featureLinkId, configPolicyFeatureLinks.id)
+      )
+      .where(and(sql`(${sql.join(targetConditions, sql` OR `)})`, ...roleOsConditions))
+      .orderBy(
+        configPolicyAssignments.level,
+        configPolicyAssignments.priority,
+        configPolicyAssignments.createdAt
+      )
+  );
 
   if (rows.length === 0) return null;
 
@@ -585,29 +569,6 @@ export async function resolvePatchConfigDetailsForDevice(
     assignmentPriority: winner.assignmentPriority,
     resolvedTimezone: await resolveDeviceTimezone(deviceId),
   };
-}
-
-/**
- * Runs a backup POLICY lookup where partner-wide rows must be visible.
- *
- * `configuration_policies` and `backup_profiles` rows owned by a partner have
- * `org_id NULL`, and an org-scoped token never passes `breeze_has_partner_access`
- * — so under a request's RLS context those rows simply do not exist. A backup
- * reader that runs there silently reports "no policy" for partner-linked
- * devices: manual runs fall back to a legacy single-mode job, dashboards call
- * protected devices unprotected. Same trap the heartbeat probe-config hit
- * (#1105); the playbook's answer is a system context.
- *
- * Only the policy/profile joins go through here — they are self-tenanted by the
- * caller-supplied orgId or the device's own hierarchy. Device expansion stays in
- * the caller's context so RLS keeps guarding which devices a caller may see.
- *
- * No-ops when already system-scoped (the scheduler), so the worker doesn't open
- * a second transaction per resolve.
- */
-async function withPartnerWideVisibility<T>(fn: () => Promise<T>): Promise<T> {
-  if (getCurrentDbAccessContext()?.scope === 'system') return fn();
-  return runOutsideDbContext(() => withSystemDbAccessContext(fn));
 }
 
 /**


### PR DESCRIPTION
## Problem

A `configuration_policies` row is either **org-owned** (`org_id` set) or **partner-owned / "partner-wide"** (`org_id NULL`, `partner_id` set). Four agent-facing resolvers only ever matched the first kind, so a partner-authored policy was fully authorable in the UI and **silently never reached a single agent**.

I verified all four against `origin/main` before touching anything — the state was not what the issue described:

| Resolver | App-layer predicate | DB context | Verdict |
|---|---|---|---|
| `event_log` | org-only ❌ | org-scoped ❌ | broken, fixed here |
| `monitoring` | org-only ❌ | org-scoped ❌ | broken, fixed here |
| `pam` | org-only ❌ | org-scoped ❌ | broken, fixed here |
| `patch_source` | **already dual-axis** ✅ | org-scoped ❌ | **half-fixed** — still RLS-blind, fixed here |
| `helper` | fixed in #2911 ✅ | system ✅ | already correct |
| `onedrive_helper` | org-only | system ✅ | **correct as-is — see below** |

`patch_source` is the interesting one: its predicate was corrected along with the rest of `featureConfigResolver.ts`, but it still ran inside the org transaction, so it resolved nothing anyway. That is the whole reason this bug class needs both halves fixed.

## The two failure layers

1. **App layer** — `eq(configurationPolicies.orgId, device.orgId)` can never match an `org_id NULL` row.
2. **RLS** — partner-owned rows are gated by `breeze_has_partner_access`, and every agent-facing context carries `accessiblePartnerIds: []`. Under those the read returns **zero rows rather than raising**, so a corrected predicate still resolves nothing.

## Changes

- **New `apps/api/src/services/configPolicyOwnership.ts`** holds the two primitives that were being re-derived inline in four places: `policyOwnershipCondition()` (dual-axis join predicate) and `withPartnerWideVisibility()` (system-context escape). `featureConfigResolver.ts` imports both instead of keeping private copies; `routes/agents/helpers.ts` now uses them too.
- `event_log` / `monitoring` / `pam` switched to the dual-axis predicate; the already-fixed `helper` resolver drops its inline copy of the same SQL.
- `resolvePatchConfigDetailsForDevice` gains the visibility escape it was missing.
- **Monitoring's escape covers the watches read too.** `config_policy_monitoring_watches` RLS walks `settings_id → feature link → configuration_policies`, so splitting the two reads across contexts would find the policy and then resolve **zero watches** — and the resolver returns `null` on empty watches. Easy half-fix to ship by accident.
- **`heartbeat.ts` hoists all four builders out of the org transaction** into one shared system context, matching the existing `policyProbeConfig` / `onedriveSettings` / `helperSettings` treatment (#1105).

### Two design calls worth reviewing

**One shared system context, not four.** The four already shared the org transaction, so per-resolver isolation was never real; four extra connection acquisitions per heartbeat is not affordable against the 25-connection production ceiling. Per-resolver `try/catch` is preserved inside it, so each feature keeps its documented fallback.

**An outer catch around that context.** The inner catches cannot see a transaction setup or COMMIT failure, and a locally-caught SQL error still leaves the shared transaction aborted — so the commit throws. By that point the org transaction has committed and the commands in the response are already marked delivered, so letting it escape would 500 the heartbeat and **lose the claimed commands**. It now degrades to "no config update this cycle"; everything here is re-resolved on the next heartbeat.

### Deliberately NOT changed

`onedrive_helper` stays org-only. It is the sole member of `ORG_SCOPED_ONLY_FEATURE_TYPES` — its settings carry per-tenant M365 library mappings that a partner-wide policy has no owning org to anchor to, and `featureLinks.ts` rejects the link with a 400 at write time. I initially "fixed" it as a sibling of the other four and backed that out. There is now a regression test asserting it does **not** use the dual-axis predicate, plus a comment at the call site, so the next audit sweep for this bug class doesn't make the same mistake.

## Verification

- **New integration suite** `agentPolicyResolversPartnerWide.integration.test.ts` (real Postgres, `breeze_app` role, RLS forced) drives all four resolvers **inside an org-scoped `withDbAccessContext`** — the realistic agent path — and covers fan-out across sibling orgs, org-beats-partner precedence, and cross-partner isolation. Redis cache keys are purged per test so a cache hit can't mask a resolution failure.
- **Non-vacuity checked:** with the production files reverted to `main`, 5 of its 8 cases fail. The 3 that pass (precedence, foreign-partner isolation) held before too, as they should.
- Unit coverage for the emitted SQL (compiled through the real `PgDialect`, so a dropped partner branch changes the text and params) and for the escape's escalate/no-op branches.
- `apps/api` unit suites: 47 files / 784 tests green (agents + featureConfigResolver + new module). The full API unit suite was swept green after the shared module's named `db` imports required completing one `vi.mock` factory (`helpers.pam.test.ts`).
- Integration: 3 files / 25 tests green (new suite + both existing partner config-policy suites).
- `tsc --noEmit` clean.

## Reviewer notes

- **Integration suites should be dispatched for this branch** (`gh workflow run CI --ref fix/2930-partner-owned-config-resolvers`) — the RLS-context behaviour here is exactly the class that only fails under **Integration Tests**, not the unit job.
- The other two callers of these resolvers (`routes/agents/eventlogs.ts`, `routes/devices/software.ts`) run inside a request-long org transaction, so `withPartnerWideVisibility` briefly double-holds a connection there. That is the same shape already shipped for `resolveBackupConfigForDevice`, and those paths are orders of magnitude lower-volume than the heartbeat — but it is a deliberate trade, not an oversight.
- No schema or migration changes.

Closes #2930

🤖 Generated with [Claude Code](https://claude.com/claude-code)