### PR TITLE
feat(remote): let a technician pick their own remote-access provider (#3389)

### DIFF
--- a/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
+++ b/apps/api/src/routes/devices/core.remoteAccessLaunch.test.ts
@@ -38,6 +38,10 @@ vi.mock('../../middleware/auth', () => ({
       orgId: 'org-123',
       partnerId: null,
       accessibleOrgIds: ['org-123'],
+      // This route is reached by a person clicking Connect, so the mocked
+      // context carries the same discriminator the real one would. The
+      // per-technician provider preference is gated on it.
+      principal: { kind: 'user_session' },
       canAccessOrg: (orgId: string) => orgId === 'org-123'
     });
     return next();
@@ -45,6 +49,9 @@ vi.mock('../../middleware/auth', () => ({
   requireScope: vi.fn(() => async (_c: any, next: any) => next()),
   requirePermission: vi.fn(() => async (_c: any, next: any) => next()),
   requireMfa: vi.fn(() => async (_c: any, next: any) => next()),
+  // Mirrors the real allowlist-of-one rather than stubbing a constant, so this
+  // suite still exercises the gate it depends on.
+  isInteractiveUserSession: vi.fn((a: any) => a?.principal?.kind === 'user_session'),
 }));
 
 vi.mock('./helpers', () => ({

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -18,8 +18,16 @@ import {
   enrollmentKeys,
   organizations,
   partners,
+  users,
 } from '../../db/schema';
-import { authMiddleware, requireMfa, requireScope, requirePermission } from '../../middleware/auth';
+import {
+  authMiddleware,
+  isInteractiveUserSession,
+  requireMfa,
+  requireScope,
+  requirePermission,
+  type AuthContext,
+} from '../../middleware/auth';
 import { PERMISSIONS, canAccessSite, type UserPermissions } from '../../services/permissions';
 import {
   getPagination,
@@ -993,6 +1001,7 @@ coreRoutes.get(
       const launcher = await resolveRemoteAccessLauncherForDevice(
         device.orgId,
         device.customFields as Record<string, unknown> | null,
+        auth,
       );
       if (launcher.launchUrl) {
         hasRemoteAccessLauncher = true;
@@ -1031,9 +1040,34 @@ coreRoutes.get(
  * engine doesn't filter the row out. This mirrors how remoteAccessPolicy.ts
  * uses systemAuth for the same reason.
  */
+/**
+ * Read the acting technician's preferred provider id, if any.
+ *
+ * Gated on `isInteractiveUserSession` on purpose. An MCP API key is built with
+ * `user.id = apiKey.createdBy` (see AuthContext.principal), so keying this off
+ * user identity alone would make a machine caller silently inherit whichever
+ * remote tool the human who minted the key happens to prefer. A preference is a
+ * property of a person at a keyboard; anything else gets the tenant default.
+ */
+async function readPreferredProviderId(auth: AuthContext): Promise<string | null> {
+  if (!isInteractiveUserSession(auth)) return null;
+  const prefs = await withSystemDbAccessContext(async () => {
+    const [row] = await db
+      .select({ preferences: users.preferences })
+      .from(users)
+      .where(eq(users.id, auth.user.id))
+      .limit(1);
+    return row?.preferences ?? null;
+  });
+  if (!prefs || typeof prefs !== 'object' || Array.isArray(prefs)) return null;
+  const value = (prefs as { remoteAccessProviderId?: unknown }).remoteAccessProviderId;
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
 async function resolveRemoteAccessLauncherForDevice(
   orgId: string,
   customFields: Record<string, unknown> | null,
+  auth?: AuthContext,
 ): Promise<RemoteAccessLaunchResult> {
   const partnerSettings = await withSystemDbAccessContext(async () => {
     const [partnerRow] = await db
@@ -1046,7 +1080,8 @@ async function resolveRemoteAccessLauncherForDevice(
   });
   const providers: InheritableRemoteAccessSettings | undefined =
     partnerSettings.remoteAccessProviders;
-  return resolveRemoteAccessLaunch({ customFields }, providers);
+  const preferredProviderId = auth ? await readPreferredProviderId(auth) : null;
+  return resolveRemoteAccessLaunch({ customFields }, providers, preferredProviderId);
 }
 
 // POST /devices/:id/remote-access-launch - Issue a one-shot remote-access
@@ -1082,6 +1117,7 @@ coreRoutes.post(
       launcher = await resolveRemoteAccessLauncherForDevice(
         device.orgId,
         device.customFields as Record<string, unknown> | null,
+        auth,
       );
     } catch (err) {
       captureException(err, c);

--- a/apps/api/src/routes/devices/core.ts
+++ b/apps/api/src/routes/devices/core.ts
@@ -1051,14 +1051,19 @@ coreRoutes.get(
  */
 async function readPreferredProviderId(auth: AuthContext): Promise<string | null> {
   if (!isInteractiveUserSession(auth)) return null;
-  const prefs = await withSystemDbAccessContext(async () => {
-    const [row] = await db
-      .select({ preferences: users.preferences })
-      .from(users)
-      .where(eq(users.id, auth.user.id))
-      .limit(1);
-    return row?.preferences ?? null;
-  });
+  // Deliberately the ambient request context, not a system one. `users` carries
+  // `breeze_user_isolation_select ... OR id = breeze_current_user_id()`, so a
+  // technician reading their own row is already permitted under the caller's
+  // own scope. Reading under the request context is the narrower privilege and
+  // means this can never resolve a row outside the caller's tenant, even if
+  // `auth.user.id` were ever influenced by something other than the verified
+  // token.
+  const [row] = await db
+    .select({ preferences: users.preferences })
+    .from(users)
+    .where(eq(users.id, auth.user.id))
+    .limit(1);
+  const prefs = row?.preferences ?? null;
   if (!prefs || typeof prefs !== 'object' || Array.isArray(prefs)) return null;
   const value = (prefs as { remoteAccessProviderId?: unknown }).remoteAccessProviderId;
   return typeof value === 'string' && value.length > 0 ? value : null;

--- a/apps/api/src/services/remoteAccessLauncher.test.ts
+++ b/apps/api/src/services/remoteAccessLauncher.test.ts
@@ -266,3 +266,72 @@ describe('buildRemoteAccessLaunchUrl', () => {
     ).toBeNull();
   });
 });
+
+describe('resolveRemoteAccessLaunch — per-technician provider preference', () => {
+  const mesh = {
+    id: 'mesh',
+    name: 'Mesh',
+    urlTemplate: 'https://mesh.example.test/#device={id}',
+    customFieldKey: 'mesh_node_id',
+    enabled: true,
+  } as const;
+
+  // Two providers enabled at once; the tenant default is rustdesk.
+  const twoProviders: InheritableRemoteAccessSettings = {
+    defaultProviderId: 'rustdesk',
+    providers: [baseProvider, { ...mesh }],
+  };
+  const device = { customFields: { rustdesk_id: '294064193', mesh_node_id: 'abc123' } };
+
+  it('uses the tenant default when the technician has no preference', () => {
+    const r = resolveRemoteAccessLaunch(device, twoProviders);
+    expect(r.providerId).toBe('rustdesk');
+    expect(r.launchUrl).toBe('rustdesk://294064193?password=plain');
+  });
+
+  it('honours a preference for the OTHER enabled provider', () => {
+    const r = resolveRemoteAccessLaunch(device, twoProviders, 'mesh');
+    expect(r.providerId).toBe('mesh');
+    expect(r.launchUrl).toBe('https://mesh.example.test/#device=abc123');
+  });
+
+  it('falls back to the default when the preference names an unknown provider', () => {
+    // The security property: a preference SELECTS from the tenant's list, so an
+    // id the tenant does not have cannot introduce a destination.
+    const r = resolveRemoteAccessLaunch(device, twoProviders, 'not-a-real-provider');
+    expect(r.providerId).toBe('rustdesk');
+    expect(r.skipReason).toBeNull();
+  });
+
+  it('falls back to the default when the preferred provider is disabled', () => {
+    const settings: InheritableRemoteAccessSettings = {
+      defaultProviderId: 'rustdesk',
+      providers: [baseProvider, { ...mesh, enabled: false }],
+    };
+    const r = resolveRemoteAccessLaunch(device, settings, 'mesh');
+    // Degrades quietly rather than returning provider_disabled and stranding the tech.
+    expect(r.providerId).toBe('rustdesk');
+    expect(r.skipReason).toBeNull();
+  });
+
+  it('lets a valid preference stand in when the tenant has set no default', () => {
+    const noDefault: InheritableRemoteAccessSettings = { providers: [baseProvider, { ...mesh }] };
+    expect(resolveRemoteAccessLaunch(device, noDefault).skipReason).toBe('no_provider_configured');
+    const r = resolveRemoteAccessLaunch(device, noDefault, 'mesh');
+    expect(r.providerId).toBe('mesh');
+    expect(r.launchUrl).toBe('https://mesh.example.test/#device=abc123');
+  });
+
+  it('still refuses a scheme that only resolves after substitution, even when preferred', () => {
+    const sneaky: InheritableRemoteAccessSettings = {
+      defaultProviderId: 'rustdesk',
+      providers: [
+        baseProvider,
+        { id: 'sneaky', name: 'Sneaky', urlTemplate: 'j{id}cript:alert(1)', customFieldKey: 'k', enabled: true },
+      ],
+    };
+    const r = resolveRemoteAccessLaunch({ customFields: { k: 'avas' } }, sneaky, 'sneaky');
+    expect(r.launchUrl).toBeNull();
+    expect(r.skipReason).toBe('scheme_not_allowed');
+  });
+});

--- a/apps/api/src/services/remoteAccessLauncher.ts
+++ b/apps/api/src/services/remoteAccessLauncher.ts
@@ -56,12 +56,33 @@ export function buildRemoteAccessLaunchUrl(
 export function resolveRemoteAccessLaunch(
   device: { customFields?: Record<string, unknown> | null },
   remoteAccess: InheritableRemoteAccessSettings | undefined | null,
+  // A technician's own preferred provider (users.preferences.remoteAccessProviderId).
+  // Deliberately an ID and nothing else: it SELECTS from the tenant's configured
+  // providers, it never supplies one. The template, password and customFieldKey
+  // still come from the tenant record, so a user value cannot introduce a scheme
+  // or a destination -- which is what keeps the javascript: guard below meaningful.
+  preferredProviderId?: string | null,
 ): RemoteAccessLaunchResult {
-  if (!remoteAccess?.defaultProviderId || !remoteAccess.providers?.length) {
+  if (!remoteAccess?.providers?.length) {
     return { launchUrl: null, providerId: null, scheme: null, skipReason: 'no_provider_configured' };
   }
+
+  // A preference only counts when it names a provider this tenant actually has
+  // AND that provider is enabled. Anything else -- unknown id, id belonging to
+  // another tenant, provider since disabled or deleted -- falls through to the
+  // tenant default rather than failing the launch, so a stale preference degrades
+  // quietly instead of stranding the technician.
+  const preferred: RemoteAccessProvider | undefined = preferredProviderId
+    ? remoteAccess.providers.find((p) => p.id === preferredProviderId && p.enabled)
+    : undefined;
+
+  const targetId = preferred?.id ?? remoteAccess.defaultProviderId;
+  if (!targetId) {
+    return { launchUrl: null, providerId: null, scheme: null, skipReason: 'no_provider_configured' };
+  }
+
   const provider: RemoteAccessProvider | undefined = remoteAccess.providers.find(
-    (p) => p.id === remoteAccess.defaultProviderId,
+    (p) => p.id === targetId,
   );
   if (!provider) {
     return { launchUrl: null, providerId: null, scheme: null, skipReason: 'no_provider_configured' };


### PR DESCRIPTION
Closes #3389 (backend only — see "What is deliberately not here").

`defaultProviderId` is tenant-wide, so two technicians who prefer different remote tools cannot both be served. Both providers can already be configured and `enabled` simultaneously; only the *selection* was singular.

## The change

`resolveRemoteAccessLaunch` takes an optional `preferredProviderId` and prefers it over the tenant default.

It is **an ID and nothing else**. The preference SELECTS from the tenant's own provider list and never supplies one — `urlTemplate`, `password` and `customFieldKey` still come from the tenant record. So a user-controlled value cannot introduce a scheme or a destination, which is what keeps the existing post-substitution `javascript:` guard meaningful. That property is the whole design; everything else follows from it.

A preference counts only when it names a provider **this tenant has** and that provider is **enabled**. Unknown id, id belonging to another tenant, provider since disabled or deleted — all fall through to `defaultProviderId` rather than failing, so a stale preference degrades quietly instead of stranding the technician mid-call.

## The non-obvious part: it is gated on `isInteractiveUserSession`

`AuthContext.principal`'s own comment is what drove this:

> `user.id` cannot answer "is a human doing this?". An MCP API key is built with `user.id = apiKey.createdBy` … so a key and the human who minted it are indistinguishable by identity alone

Keying the preference off user identity alone would make a machine caller silently inherit whichever remote tool the human who minted the key happens to prefer. A preference is a property of a person at a keyboard, so non-interactive principals get the tenant default.

## Storage

`users.preferences.remoteAccessProviderId` — an existing `jsonb` column already served by `PATCH /users`. **No migration.**

## What is deliberately not here

No UI. The two open questions on #3389 are yours: where the chooser lives (inline on Connect, a user-settings row, or both), and whether the choice is remembered per device. The resolution and validation logic is reviewable independently of that, which is why this is a draft — say the word and I will add the UI to match whichever you pick, or close this if you would rather own it.

## Verification

`tsc --noEmit` 0 errors. API suite **21246 passed / 1315 files**. Trivy (secret, misconfig, HIGH+CRITICAL) clean on `apps/api/src`.

**Control run, stated precisely:** with the resolution change reverted, **3 of the 6** new cases fail — preference selects the other provider, preference stands in with no tenant default, and the `javascript:`-after-substitution refusal under a preference. The other **3 cannot fail**, because they assert fallback behaviour that is intentionally identical to today's (unknown id → default, disabled preferred → default, no preference → default). They are regression pins, not evidence.

One existing suite needed a fixture update: `core.remoteAccessLaunch.test.ts` mocks `../../middleware/auth`, so it needed `isInteractiveUserSession` added. I mirrored the real allowlist-of-one and gave the mocked context a real `principal` rather than stubbing the gate to a constant, so that suite still exercises the gate it now depends on.
