### PR TITLE
fix(agent): reject malformed reboot delays instead of coercing them to 0 (#3373)

### DIFF
--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -285,17 +285,38 @@ func handleRefreshInventory(h *Heartbeat, _ Command) tools.CommandResult {
 }
 
 func handleRebootSafeMode(h *Heartbeat, cmd Command) tools.CommandResult {
+	start := time.Now()
+
+	// Resolve the delay up front, through the same helper RebootToSafeMode
+	// uses, for two reasons (issue #3373):
+	//   1. The notification below must announce the delay the reboot is
+	//      actually scheduled with. Reading the raw payload separately let the
+	//      toast and the scheduled reboot disagree once either side clamped.
+	//   2. A malformed delay must fail the command here, before anything is
+	//      broadcast — otherwise users are warned of, and then subjected to, an
+	//      immediate forced reboot they never asked for.
+	delay, err := tools.ShutdownDelayMinutes(cmd.Payload)
+	if err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	if h.sessionBroker != nil {
-		delay := tools.GetPayloadInt(cmd.Payload, "delay", 0)
-		var msg string
-		if delay > 0 {
-			msg = fmt.Sprintf("System will reboot into Safe Mode with Networking in %d minutes. Please save all work.", delay)
-		} else {
-			msg = "System is rebooting into Safe Mode with Networking. Please save all work."
-		}
-		h.sessionBroker.BroadcastNotification("Safe Mode Reboot", msg, "critical")
+		h.sessionBroker.BroadcastNotification("Safe Mode Reboot", safeModeRebootNotice(delay), "critical")
 	}
 	return tools.RebootToSafeMode(cmd.Payload)
+}
+
+// safeModeRebootNotice renders the user-facing Safe Mode warning for a delay
+// that has already been parsed and clamped by tools.ShutdownDelayMinutes.
+func safeModeRebootNotice(delayMinutes int) string {
+	if delayMinutes <= 0 {
+		return "System is rebooting into Safe Mode with Networking. Please save all work."
+	}
+	unit := "minutes"
+	if delayMinutes == 1 {
+		unit = "minute"
+	}
+	return fmt.Sprintf("System will reboot into Safe Mode with Networking in %d %s. Please save all work.", delayMinutes, unit)
 }
 
 func handleCollectSoftware(_ *Heartbeat, cmd Command) tools.CommandResult {

--- a/agent/internal/heartbeat/handlers_monitor.go
+++ b/agent/internal/heartbeat/handlers_monitor.go
@@ -21,6 +21,20 @@ func init() {
 	handlerRegistry[tools.CmdNetworkDnsCheck] = handleNetworkDnsCheck
 }
 
+// maxPingCount bounds the ping-sweep repeat count. Monitor checks never need
+// more than a handful of probes, and the value sizes a slice allocation.
+const maxPingCount = 60
+
+func clampPingCount(count int) int {
+	if count < 1 {
+		return 1
+	}
+	if count > maxPingCount {
+		return maxPingCount
+	}
+	return count
+}
+
 func handleNetworkPing(_ *Heartbeat, cmd Command) tools.CommandResult {
 	start := time.Now()
 	target, errResult := tools.RequirePayloadString(cmd.Payload, "target")
@@ -31,7 +45,10 @@ func handleNetworkPing(_ *Heartbeat, cmd Command) tools.CommandResult {
 
 	monitorId := tools.GetPayloadString(cmd.Payload, "monitorId", "")
 	timeout := time.Duration(tools.GetPayloadInt(cmd.Payload, "timeout", 5)) * time.Second
-	count := tools.GetPayloadInt(cmd.Payload, "count", 4)
+	// count sizes an allocation below, so it must be bounded before use: a
+	// negative value panics make(), and a large one lets an unvalidated
+	// payload field reserve arbitrary memory on the device.
+	count := clampPingCount(tools.GetPayloadInt(cmd.Payload, "count", 4))
 
 	ip := net.ParseIP(target)
 	if ip == nil {

--- a/agent/internal/heartbeat/handlers_monitor_count_test.go
+++ b/agent/internal/heartbeat/handlers_monitor_count_test.go
@@ -1,0 +1,36 @@
+package heartbeat
+
+import "testing"
+
+// count sizes a make([]net.IP, count) allocation from a command payload the
+// API forwards unvalidated (payload is z.any()). A negative value panics the
+// handler and a large one reserves arbitrary memory on the device, so the
+// value has to be bounded before it reaches make().
+func TestClampPingCount(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"negative would panic make()", -1, 1},
+		{"large negative", -1 << 30, 1},
+		{"zero yields no probes", 0, 1},
+		{"one", 1, 1},
+		{"default", 4, 4},
+		{"at max", maxPingCount, maxPingCount},
+		{"over max", maxPingCount + 1, maxPingCount},
+		{"absurd allocation request", 1 << 30, maxPingCount},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clampPingCount(tt.in)
+			if got != tt.want {
+				t.Errorf("clampPingCount(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+			if got < 1 {
+				t.Errorf("clampPingCount(%d) = %d, which would make a zero/negative allocation", tt.in, got)
+			}
+		})
+	}
+}

--- a/agent/internal/heartbeat/handlers_network.go
+++ b/agent/internal/heartbeat/handlers_network.go
@@ -1,6 +1,7 @@
 package heartbeat
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/breeze-rmm/agent/internal/discovery"
@@ -68,9 +69,16 @@ func handleSnmpPoll(_ *Heartbeat, cmd Command) tools.CommandResult {
 		snmpVersion = 0x01
 	}
 
+	// The port narrows to uint16 below; an out-of-range value would silently
+	// wrap onto some other port, so reject it instead of probing the wrong one.
+	port := tools.GetPayloadInt(cmd.Payload, "port", 161)
+	if port < 1 || port > 65535 {
+		return tools.NewErrorResult(fmt.Errorf("port must be 1-65535, got %d", port), time.Since(start).Milliseconds())
+	}
+
 	device := snmppoll.SNMPDevice{
 		IP:      target,
-		Port:    uint16(tools.GetPayloadInt(cmd.Payload, "port", 161)),
+		Port:    uint16(port),
 		Version: snmpVersion,
 		Auth: snmppoll.SNMPAuth{
 			Community:      tools.GetPayloadString(cmd.Payload, "community", "public"),

--- a/agent/internal/heartbeat/handlers_network_port_test.go
+++ b/agent/internal/heartbeat/handlers_network_port_test.go
@@ -1,0 +1,32 @@
+package heartbeat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+// The SNMP port narrows to uint16; with GetPayloadInt now accepting numeric
+// strings (issue #3373) an out-of-range value must be rejected up front, not
+// wrapped onto a different port. The invalid values return before any network
+// I/O is attempted, which is what makes this safe to run in a unit test.
+func TestHandleSnmpPollRejectsOutOfRangePort(t *testing.T) {
+	for _, port := range []any{0, -1, 65536, 1 << 20, "70000"} {
+		result := handleSnmpPoll(nil, Command{
+			ID:   "cmd-1",
+			Type: tools.CmdSnmpPoll,
+			Payload: map[string]any{
+				"target": "192.0.2.1",
+				"port":   port,
+			},
+		})
+
+		if result.Status != "failed" {
+			t.Fatalf("port %#v: status = %q, want failed", port, result.Status)
+		}
+		if !strings.Contains(result.Error, "port must be 1-65535") {
+			t.Errorf("port %#v: error %q should name the port range", port, result.Error)
+		}
+	}
+}

--- a/agent/internal/heartbeat/handlers_patch.go
+++ b/agent/internal/heartbeat/handlers_patch.go
@@ -201,7 +201,13 @@ func handleScheduleReboot(h *Heartbeat, cmd Command) tools.CommandResult {
 		return tools.NewErrorResult(fmt.Errorf("reboot manager not available"), time.Since(start).Milliseconds())
 	}
 
-	delayMinutes := tools.GetPayloadInt(cmd.Payload, "delayMinutes", 60)
+	// Strict parse: the 1-10080 range check below would happily pass the
+	// silent 60-minute default, so a malformed delayMinutes used to schedule a
+	// reboot an hour out instead of when the operator asked (issue #3373).
+	delayMinutes, err := tools.ParsePayloadInt(cmd.Payload, "delayMinutes", 60)
+	if err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
 	if delayMinutes < 1 || delayMinutes > 10080 { // 1 min to 7 days
 		return tools.NewErrorResult(fmt.Errorf("delayMinutes must be 1-10080, got %d", delayMinutes), time.Since(start).Milliseconds())
 	}

--- a/agent/internal/heartbeat/handlers_safemode_delay_test.go
+++ b/agent/internal/heartbeat/handlers_safemode_delay_test.go
@@ -1,0 +1,134 @@
+package heartbeat
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/breeze-rmm/agent/internal/remote/tools"
+)
+
+// The toast is rendered from the delay that tools.ShutdownDelayMinutes already
+// parsed and clamped, so it can no longer disagree with the reboot that gets
+// scheduled (issue #3373).
+func TestSafeModeRebootNotice(t *testing.T) {
+	tests := []struct {
+		name         string
+		delayMinutes int
+		want         string
+	}{
+		{
+			name:         "immediate",
+			delayMinutes: 0,
+			want:         "System is rebooting into Safe Mode with Networking. Please save all work.",
+		},
+		{
+			name:         "singular minute is not pluralised",
+			delayMinutes: 1,
+			want:         "System will reboot into Safe Mode with Networking in 1 minute. Please save all work.",
+		},
+		{
+			name:         "plural minutes",
+			delayMinutes: 15,
+			want:         "System will reboot into Safe Mode with Networking in 15 minutes. Please save all work.",
+		},
+		{
+			name:         "clamped maximum is announced as the clamped value",
+			delayMinutes: 1440,
+			want:         "System will reboot into Safe Mode with Networking in 1440 minutes. Please save all work.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := safeModeRebootNotice(tt.delayMinutes); got != tt.want {
+				t.Errorf("safeModeRebootNotice(%d)\n got: %q\nwant: %q", tt.delayMinutes, got, tt.want)
+			}
+		})
+	}
+}
+
+// The announced delay must be the CLAMPED delay. Before the fix the handler
+// re-read the raw payload, so an out-of-range value was announced verbatim
+// while the reboot itself used the clamped one.
+func TestSafeModeNoticeMatchesScheduledDelay(t *testing.T) {
+	for _, raw := range []any{15, "15", float64(15), 5000, -5} {
+		delay, err := tools.ShutdownDelayMinutes(map[string]any{"delay": raw})
+		if err != nil {
+			t.Fatalf("delay %#v: unexpected error %v", raw, err)
+		}
+		notice := safeModeRebootNotice(delay)
+
+		if delay > 0 && !strings.Contains(notice, strconv.Itoa(delay)) {
+			t.Errorf("delay %#v resolves to %d but the notice omits it: %q", raw, delay, notice)
+		}
+		if delay == 0 && strings.Contains(notice, "will reboot") {
+			t.Errorf("delay %#v resolves to 0 (immediate) but the notice promises a delay: %q", raw, notice)
+		}
+	}
+}
+
+// A malformed delay must fail the command outright — before anything is
+// broadcast to logged-in users and before the reboot tool is reached. The old
+// code defaulted to 0, so users were warned of, and then subjected to, an
+// immediate forced reboot into Safe Mode that nobody requested.
+func TestHandleRebootSafeModeRejectsMalformedDelay(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+	}{
+		{"non-numeric string", "soon"},
+		{"empty string", ""},
+		{"bool", true},
+		{"non-integral float", 15.5},
+		{"object", map[string]any{"minutes": 15}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A nil sessionBroker means no broadcast is attempted; the strict
+			// parse returns before the safe-mode tool is called on any OS.
+			result := handleRebootSafeMode(&Heartbeat{}, Command{
+				ID:      "cmd-1",
+				Type:    tools.CmdRebootSafeMode,
+				Payload: map[string]any{"delay": tt.raw},
+			})
+
+			if result.Status != "failed" {
+				t.Fatalf("delay %#v: status = %q, want failed", tt.raw, result.Status)
+			}
+			if !strings.Contains(result.Error, "delay") {
+				t.Errorf("delay %#v: error %q does not name the delay field", tt.raw, result.Error)
+			}
+			// A rejected command must not be reported as a safe-mode reboot
+			// that was attempted and failed for some other reason.
+			if strings.Contains(result.Error, "only supported on Windows") {
+				t.Errorf("delay %#v: reached the safe-mode tool instead of failing validation: %q", tt.raw, result.Error)
+			}
+		})
+	}
+}
+
+// A well-formed delay must flow through to the safe-mode tool. On non-Windows
+// that tool is an inert stub, which makes this wiring assertion safe to run —
+// it can never schedule a real reboot.
+func TestHandleRebootSafeModeAcceptsWellFormedDelay(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("RebootToSafeMode actually reboots on Windows; wiring is asserted on other platforms")
+	}
+
+	for _, raw := range []any{15, "15", float64(15), nil} {
+		result := handleRebootSafeMode(&Heartbeat{}, Command{
+			ID:      "cmd-1",
+			Type:    tools.CmdRebootSafeMode,
+			Payload: map[string]any{"delay": raw},
+		})
+
+		// Reaching the platform stub proves validation passed and the handler
+		// delegated, rather than rejecting a legitimate delay.
+		if !strings.Contains(result.Error, "only supported on Windows") {
+			t.Errorf("delay %#v: expected to reach the safe-mode tool, got %q", raw, result.Error)
+		}
+	}
+}

--- a/agent/internal/remote/tools/computer_action.go
+++ b/agent/internal/remote/tools/computer_action.go
@@ -29,8 +29,18 @@ func ComputerActionWithCapture(payload map[string]any, capFn CaptureFunc) Comman
 		return NewErrorResult(fmt.Errorf("missing required field: action"), 0)
 	}
 
-	x := GetPayloadInt(payload, "x", 0)
-	y := GetPayloadInt(payload, "y", 0)
+	// Coordinates are strict-parsed: absent still means 0 (correct for
+	// non-positional actions like screenshot/key/type), but a malformed value
+	// must not silently become 0 — that would land a real click at the screen's
+	// top-left corner instead of where the caller aimed (issue #3373).
+	x, err := ParsePayloadInt(payload, "x", 0)
+	if err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+	y, err := ParsePayloadInt(payload, "y", 0)
+	if err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
 	text := GetPayloadString(payload, "text", "")
 	key := GetPayloadString(payload, "key", "")
 	modifiers := GetPayloadStringSlice(payload, "modifiers")
@@ -38,7 +48,7 @@ func ComputerActionWithCapture(payload map[string]any, capFn CaptureFunc) Comman
 	monitor := GetPayloadInt(payload, "monitor", 0)
 	captureAfter := GetPayloadBool(payload, "captureAfter", true)
 	captureDelayMs := GetPayloadInt(payload, "captureDelayMs", 500)
-	text, key, modifiers, err := validateComputerActionInput(text, key, modifiers)
+	text, key, modifiers, err = validateComputerActionInput(text, key, modifiers)
 	if err != nil {
 		return NewErrorResult(err, time.Since(start).Milliseconds())
 	}
@@ -55,11 +65,12 @@ func ComputerActionWithCapture(payload map[string]any, capFn CaptureFunc) Comman
 		if screenW > 0 && screenH > 0 && (screenW != coordW || screenH != coordH) {
 			scaleX := float64(screenW) / float64(coordW)
 			scaleY := float64(screenH) / float64(coordH)
+			origX, origY := x, y
 			x = int(float64(x) * scaleX)
 			y = int(float64(y) * scaleY)
 			slog.Debug("scaled coordinates from image to screen space",
-				"origX", GetPayloadInt(payload, "x", 0),
-				"origY", GetPayloadInt(payload, "y", 0),
+				"origX", origX,
+				"origY", origY,
 				"scaledX", x, "scaledY", y,
 				"coordSpace", fmt.Sprintf("%dx%d", coordW, coordH),
 				"screenSpace", fmt.Sprintf("%dx%d", screenW, screenH),

--- a/agent/internal/remote/tools/incident_response.go
+++ b/agent/internal/remote/tools/incident_response.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 	"time"
@@ -237,6 +238,12 @@ func executeProcessKill(payload map[string]any, startTime time.Time) CommandResu
 	// Guard against killing the agent itself
 	if pid == os.Getpid() {
 		return NewErrorResult(fmt.Errorf("cannot kill PID %d: this is the agent process", pid), time.Since(startTime).Milliseconds())
+	}
+
+	// The pid narrows to int32 below; an out-of-range value would wrap and
+	// target a different process than the one named in the containment action.
+	if pid > math.MaxInt32 {
+		return NewErrorResult(fmt.Errorf("pid %d is out of range", pid), time.Since(startTime).Milliseconds())
 	}
 
 	p, err := process.NewProcess(int32(pid))

--- a/agent/internal/remote/tools/narrowing_bounds_test.go
+++ b/agent/internal/remote/tools/narrowing_bounds_test.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// GetPayloadInt now accepts numeric strings (issue #3373), so every value that
+// narrows to a smaller integer type after passing through it must be
+// range-checked first: an out-of-range pid wrapped through int32 would target a
+// DIFFERENT process than the one the operator named.
+func TestParsePayloadPID(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    int32
+		wantErr string
+	}{
+		{"valid", map[string]any{"pid": 1234}, 1234, ""},
+		{"valid numeric string", map[string]any{"pid": "1234"}, 1234, ""},
+		{"at int32 max", map[string]any{"pid": math.MaxInt32}, math.MaxInt32, ""},
+		{"absent is required", map[string]any{}, 0, "required"},
+		{"zero is required", map[string]any{"pid": 0}, 0, "required"},
+		{"negative", map[string]any{"pid": -5}, 0, "out of range"},
+		{"beyond int32 would wrap", map[string]any{"pid": int64(math.MaxInt32) + 1}, 0, "out of range"},
+		{"far beyond int32", map[string]any{"pid": int64(1) << 40}, 0, "out of range"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePayloadPID(tt.payload, "pid")
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("parsePayloadPID(%#v) = %d, want error containing %q", tt.payload, got, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error %q does not contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// An incident-response process_kill with a pid beyond int32 must be rejected
+// before the int32 narrowing, not wrapped onto some other process.
+func TestExecuteProcessKillRejectsOutOfRangePID(t *testing.T) {
+	result := ExecuteContainment(map[string]any{
+		"actionType": "process_kill",
+		"parameters": map[string]any{
+			"pid": int64(math.MaxInt32) + 2,
+		},
+	})
+	if result.Status != "failed" {
+		t.Fatalf("status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "out of range") {
+		t.Errorf("error %q should report the out-of-range pid", result.Error)
+	}
+}
+
+// The terminal clamp is unchanged behaviour, restructured so the bound checks
+// guard the value that is actually converted (CodeQL barrier-guard shape).
+func TestNormalizeTerminalSize(t *testing.T) {
+	tests := []struct {
+		name               string
+		cols, rows         int
+		wantCols, wantRows uint16
+	}{
+		{"defaults pass through", 80, 24, 80, 24},
+		{"below minimums clamp up", 1, -3, minTerminalCols, minTerminalRows},
+		{"above maximums clamp down", 100000, 70000, maxTerminalCols, maxTerminalRows},
+		{"at bounds", maxTerminalCols, minTerminalRows, maxTerminalCols, minTerminalRows},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cols, rows := normalizeTerminalSize(tt.cols, tt.rows)
+			if cols != tt.wantCols || rows != tt.wantRows {
+				t.Errorf("normalizeTerminalSize(%d, %d) = (%d, %d), want (%d, %d)",
+					tt.cols, tt.rows, cols, rows, tt.wantCols, tt.wantRows)
+			}
+		})
+	}
+}

--- a/agent/internal/remote/tools/payload_int_test.go
+++ b/agent/internal/remote/tools/payload_int_test.go
@@ -1,0 +1,215 @@
+package tools
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+)
+
+// ParsePayloadInt exists to separate "the caller omitted this field" from "the
+// caller sent garbage" — a distinction GetPayloadInt collapses. Issue #3373:
+// a reboot carrying the JSON string "15" was read as 0 and rebooted the device
+// immediately.
+func TestParsePayloadInt_Accepted(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want int
+	}{
+		// Types encoding/json and hand-built Go payloads actually produce.
+		{"int", int(15), 15},
+		{"int zero", int(0), 0},
+		{"int negative", int(-5), -5},
+		{"int64", int64(15), 15},
+		{"float64 whole", float64(15), 15},
+		{"float64 zero", float64(0), 0},
+		{"float64 negative whole", float64(-5), -5},
+
+		// The #3373 case: a numeric string must parse, not silently default.
+		{"numeric string", "15", 15},
+		{"numeric string zero", "0", 0},
+		{"numeric string negative", "-5", -5},
+		{"numeric string with surrounding space", "  15  ", 15},
+		{"numeric string explicit plus", "+15", 15},
+
+		// json.Number appears when a decoder is configured with UseNumber.
+		{"json.Number", json.Number("15"), 15},
+		{"json.Number negative", json.Number("-5"), -5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePayloadInt(map[string]any{"delay": tt.raw}, "delay", 999)
+			if err != nil {
+				t.Fatalf("ParsePayloadInt(%#v): unexpected error %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParsePayloadInt(%#v) = %d, want %d", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// An absent key is a meaningful statement the default can stand in for; a
+// present-but-malformed value is not.
+func TestParsePayloadInt_AbsentUsesDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+	}{
+		{"empty payload", map[string]any{}},
+		{"nil payload", nil},
+		{"other keys only", map[string]any{"reason": "patching"}},
+		{"explicit JSON null", map[string]any{"delay": nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePayloadInt(tt.payload, "delay", 42)
+			if err != nil {
+				t.Fatalf("unexpected error for absent key: %v", err)
+			}
+			if got != 42 {
+				t.Errorf("got %d, want the default 42", got)
+			}
+		})
+	}
+}
+
+// Every value here previously became the default (0 for a reboot delay, i.e.
+// "reboot now") with no signal to the caller.
+func TestParsePayloadInt_MalformedIsAnError(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+	}{
+		{"non-numeric string", "soon"},
+		{"empty string", ""},
+		{"whitespace-only string", "   "},
+		{"decimal string", "15.5"},
+		{"string with unit suffix", "15m"},
+		{"hex-ish string", "0x0F"},
+		{"bool true", true},
+		{"bool false", false},
+		{"object", map[string]any{"minutes": 15}},
+		{"array", []any{15}},
+		{"non-integral float", float64(15.5)},
+		{"NaN", math.NaN()},
+		{"positive infinity", math.Inf(1)},
+		{"negative infinity", math.Inf(-1)},
+		{"float beyond int range", 1e300},
+		{"float below int range", -1e300},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePayloadInt(map[string]any{"delay": tt.raw}, "delay", 999)
+			if err == nil {
+				t.Fatalf("ParsePayloadInt(%#v) returned %d with no error; a malformed value must not silently default", tt.raw, got)
+			}
+			// The message has to name the offending field — an operator
+			// reading a failed command result needs to know which one.
+			if !strings.Contains(err.Error(), "delay") {
+				t.Errorf("error %q does not name the field", err)
+			}
+		})
+	}
+}
+
+// The exact payload from the issue title, asserted end to end.
+func TestParsePayloadInt_Issue3373JSONStringDelay(t *testing.T) {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(`{"delay": "15"}`), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	got, err := ParsePayloadInt(payload, "delay", 0)
+	if err != nil {
+		t.Fatalf("a numeric string delay must parse, got error %v", err)
+	}
+	if got != 15 {
+		t.Errorf("delay = %d, want 15 (0 would mean an immediate reboot)", got)
+	}
+}
+
+// GetPayloadInt stays lenient for the many callers that clamp or treat 0 as
+// "use a default", but must accept everything ParsePayloadInt accepts.
+func TestGetPayloadInt_LenientButSameAcceptSet(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+		want int
+	}{
+		// Newly accepted: previously these fell through to the default.
+		{"numeric string", "50", 50},
+		{"json.Number", json.Number("50"), 50},
+
+		// Still accepted, unchanged.
+		{"int", int(50), 50},
+		{"int64", int64(50), 50},
+		{"float64", float64(50), 50},
+
+		// Still swallowed: malformed falls back to the default.
+		{"non-numeric string", "lots", 7},
+		{"bool", true, 7},
+		{"non-integral float", 1.5, 7},
+		{"object", map[string]any{}, 7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPayloadInt(map[string]any{"limit": tt.raw}, "limit", 7); got != tt.want {
+				t.Errorf("GetPayloadInt(%#v) = %d, want %d", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPayloadInt_AbsentUsesDefault(t *testing.T) {
+	if got := GetPayloadInt(map[string]any{}, "limit", 7); got != 7 {
+		t.Errorf("got %d, want 7", got)
+	}
+	if got := GetPayloadInt(map[string]any{"limit": nil}, "limit", 7); got != 7 {
+		t.Errorf("null: got %d, want 7", got)
+	}
+}
+
+// Bounds are enforced by round-trip/range checks rather than an unchecked
+// conversion, whose result Go leaves implementation-defined on overflow.
+func TestParsePayloadInt_IntBoundaries(t *testing.T) {
+	maxInt := int(math.MaxInt)
+	minInt := int(math.MinInt)
+
+	for _, tt := range []struct {
+		name string
+		raw  any
+		want int
+	}{
+		{"max int", maxInt, maxInt},
+		{"min int", minInt, minInt},
+		{"min int as int64", int64(math.MinInt), minInt},
+		{"min int as float64", float64(math.MinInt), minInt},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParsePayloadInt(map[string]any{"n": tt.raw}, "n", 0)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+
+	// 2^63 is exactly one past max int on a 64-bit build and must be rejected
+	// rather than wrapping to a negative delay.
+	if _, err := ParsePayloadInt(map[string]any{"n": -float64(math.MinInt)}, "n", 0); err == nil {
+		t.Error("float64 one past max int must be rejected")
+	}
+
+	// strconv.Atoi reports a range error rather than saturating.
+	if _, err := ParsePayloadInt(map[string]any{"n": "99999999999999999999999"}, "n", 0); err == nil {
+		t.Error("out-of-range numeric string must be rejected")
+	}
+}

--- a/agent/internal/remote/tools/processes.go
+++ b/agent/internal/remote/tools/processes.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -142,16 +143,31 @@ func ListProcesses(payload map[string]any) CommandResult {
 	return NewSuccessResult(response, time.Since(startTime).Milliseconds())
 }
 
+// parsePayloadPID reads a required pid field and narrows it to the int32
+// gopsutil expects. The range check must precede the conversion: an
+// out-of-int32 pid would otherwise wrap and silently target a DIFFERENT
+// process — catastrophic for a kill command.
+func parsePayloadPID(payload map[string]any, key string) (int32, error) {
+	pid := GetPayloadInt(payload, key, 0)
+	if pid == 0 {
+		return 0, fmt.Errorf("%s is required", key)
+	}
+	if pid < 0 || pid > math.MaxInt32 {
+		return 0, fmt.Errorf("%s %d is out of range", key, pid)
+	}
+	return int32(pid), nil
+}
+
 // GetProcess returns details for a specific process
 func GetProcess(payload map[string]any) CommandResult {
 	startTime := time.Now()
 
-	pid := GetPayloadInt(payload, "pid", 0)
-	if pid == 0 {
-		return NewErrorResult(fmt.Errorf("pid is required"), time.Since(startTime).Milliseconds())
+	pid, err := parsePayloadPID(payload, "pid")
+	if err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
 	}
 
-	p, err := process.NewProcess(int32(pid))
+	p, err := process.NewProcess(pid)
 	if err != nil {
 		return NewErrorResult(fmt.Errorf("process not found: %w", err), time.Since(startTime).Milliseconds())
 	}
@@ -169,14 +185,14 @@ func GetProcess(payload map[string]any) CommandResult {
 func KillProcess(payload map[string]any) CommandResult {
 	startTime := time.Now()
 
-	pid := GetPayloadInt(payload, "pid", 0)
-	if pid == 0 {
-		return NewErrorResult(fmt.Errorf("pid is required"), time.Since(startTime).Milliseconds())
+	pid, err := parsePayloadPID(payload, "pid")
+	if err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
 	}
 
 	force := GetPayloadBool(payload, "force", false)
 
-	p, err := process.NewProcess(int32(pid))
+	p, err := process.NewProcess(pid)
 	if err != nil {
 		return NewErrorResult(fmt.Errorf("process not found: %w", err), time.Since(startTime).Milliseconds())
 	}

--- a/agent/internal/remote/tools/shutdown_delay_test.go
+++ b/agent/internal/remote/tools/shutdown_delay_test.go
@@ -1,0 +1,95 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// ShutdownDelayMinutes is the single source of truth for the `delay` field
+// shared by reboot, shutdown, and safe-mode reboot.
+//
+// These tests exercise the parse/clamp helper directly and deliberately never
+// call Reboot/Shutdown/RebootToSafeMode: those run the host's `shutdown`
+// binary, and a regression of this very fix would turn a malformed-input test
+// case into an actual reboot of whatever machine ran the suite. The handlers
+// call this helper first and return early on its error, so the destructive
+// path is covered here without a test being able to schedule a reboot.
+// handleRebootSafeMode in the heartbeat package covers the handler wiring on
+// non-Windows hosts, where the safe-mode tool is an inert stub.
+func TestShutdownDelayMinutes_ValidAndClamped(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    int
+	}{
+		// Absent means "immediately" — the documented default, preserved.
+		{"absent", map[string]any{}, 0},
+		{"explicit null", map[string]any{"delay": nil}, 0},
+
+		// Ordinary values across the accepted types.
+		{"int 15", map[string]any{"delay": 15}, 15},
+		{"int64 15", map[string]any{"delay": int64(15)}, 15},
+		{"float64 15 (the encoding/json shape)", map[string]any{"delay": float64(15)}, 15},
+		{"explicit zero", map[string]any{"delay": 0}, 0},
+
+		// The issue #3373 case: a JSON-string delay now schedules 15 minutes
+		// instead of collapsing to an immediate reboot.
+		{"numeric string 15", map[string]any{"delay": "15"}, 15},
+		{"numeric string 1440", map[string]any{"delay": "1440"}, 1440},
+
+		// Range clamping is unchanged behaviour; only the type is now strict.
+		{"at max", map[string]any{"delay": 1440}, 1440},
+		{"over max clamps down", map[string]any{"delay": 5000}, 1440},
+		{"over max as string clamps down", map[string]any{"delay": "5000"}, 1440},
+		{"negative clamps to zero", map[string]any{"delay": -5}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ShutdownDelayMinutes(tt.payload)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ShutdownDelayMinutes(%#v) = %d, want %d", tt.payload, got, tt.want)
+			}
+		})
+	}
+}
+
+// A malformed delay must fail the command. Returning 0 would mean "reboot this
+// machine right now" — the most destructive possible reading of an input the
+// agent could not understand.
+func TestShutdownDelayMinutes_MalformedIsAnError(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  any
+	}{
+		{"non-numeric string", "soon"},
+		{"empty string", ""},
+		{"string with unit word", "15 minutes"},
+		{"string with unit suffix", "15m"},
+		{"decimal string", "15.5"},
+		{"bool", true},
+		{"non-integral float", 15.5},
+		{"object", map[string]any{"minutes": 15}},
+		{"array", []any{15}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ShutdownDelayMinutes(map[string]any{"delay": tt.raw})
+			if err == nil {
+				t.Fatalf("delay %#v returned %d with no error; a malformed delay must never resolve to an immediate reboot", tt.raw, got)
+			}
+			if got != 0 {
+				t.Errorf("error path returned %d, want the zero value", got)
+			}
+			// An operator reading the failed command result needs to know
+			// which field was rejected.
+			if !strings.Contains(err.Error(), "delay") {
+				t.Errorf("error %q does not name the delay field", err)
+			}
+		})
+	}
+}

--- a/agent/internal/remote/tools/system.go
+++ b/agent/internal/remote/tools/system.go
@@ -8,9 +8,9 @@ import (
 	"time"
 )
 
-// maxShutdownDelayMinutes bounds the `delay` payload for reboot/shutdown.
-// The wire contract is minutes on every platform (see docs/agents/commands.mdx),
-// so this is 24 hours.
+// maxShutdownDelayMinutes bounds the `delay` payload shared by the reboot,
+// shutdown, and safe-mode-reboot commands. The wire contract is minutes on
+// every platform (see docs/agents/commands.mdx), so this is 24 hours.
 const maxShutdownDelayMinutes = 1440
 
 // clampShutdownDelayMinutes constrains a caller-supplied delay to [0, 1440]
@@ -26,11 +26,34 @@ func clampShutdownDelayMinutes(delayMinutes int) int {
 	return delayMinutes
 }
 
+// ShutdownDelayMinutes parses and clamps the `delay` field shared by the
+// reboot, shutdown, and safe-mode-reboot commands. It is the single source of
+// truth for that field, so the value a handler announces to logged-in users can
+// never drift from the value the command is actually scheduled with.
+//
+// A malformed delay is an error rather than a 0. `delay: 0` legitimately means
+// "immediately", so silently collapsing an unparseable value onto it would turn
+// a requested grace period into an instant forced reboot — the exact failure in
+// issue #3373, where a JSON-string "15" became an immediate reboot.
+//
+// An out-of-range delay is still clamped rather than rejected, matching the
+// long-standing behaviour of these commands; only the type is now strict.
+func ShutdownDelayMinutes(payload map[string]any) (int, error) {
+	delay, err := ParsePayloadInt(payload, "delay", 0)
+	if err != nil {
+		return 0, err
+	}
+	return clampShutdownDelayMinutes(delay), nil
+}
+
 // Reboot schedules a system reboot after the requested delay.
 // The `delay` payload is in MINUTES on every platform; maximum 1440 (24 hours).
 func Reboot(payload map[string]any) CommandResult {
 	startTime := time.Now()
-	delay := clampShutdownDelayMinutes(GetPayloadInt(payload, "delay", 0))
+	delay, err := ShutdownDelayMinutes(payload)
+	if err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
+	}
 
 	cmd, err := buildShutdownCommand(true, delay)
 	if err != nil {
@@ -53,7 +76,10 @@ func Reboot(payload map[string]any) CommandResult {
 // The `delay` payload is in MINUTES on every platform; maximum 1440 (24 hours).
 func Shutdown(payload map[string]any) CommandResult {
 	startTime := time.Now()
-	delay := clampShutdownDelayMinutes(GetPayloadInt(payload, "delay", 0))
+	delay, err := ShutdownDelayMinutes(payload)
+	if err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
+	}
 
 	cmd, err := buildShutdownCommand(false, delay)
 	if err != nil {

--- a/agent/internal/remote/tools/system_safemode_windows.go
+++ b/agent/internal/remote/tools/system_safemode_windows.go
@@ -18,7 +18,13 @@ import (
 func RebootToSafeMode(payload map[string]any) CommandResult {
 	startTime := time.Now()
 
-	delay := clampShutdownDelayMinutes(GetPayloadInt(payload, "delay", 0))
+	// Strict parse: a malformed delay must fail the command outright rather
+	// than defaulting to 0, which here means an immediate forced reboot into
+	// Safe Mode with the BCD flag already set (issue #3373).
+	delay, err := ShutdownDelayMinutes(payload)
+	if err != nil {
+		return NewErrorResult(err, time.Since(startTime).Milliseconds())
+	}
 
 	slog.Info("reboot to safe mode requested", "delayMinutes", delay)
 

--- a/agent/internal/remote/tools/terminal.go
+++ b/agent/internal/remote/tools/terminal.go
@@ -140,21 +140,34 @@ func StopTerminal(mgr *terminal.Manager, payload map[string]any) CommandResult {
 }
 
 func normalizeTerminalSize(cols, rows int) (uint16, uint16) {
-	return clampTerminalDimension(cols, minTerminalCols, maxTerminalCols),
-		clampTerminalDimension(rows, minTerminalRows, maxTerminalRows)
+	return clampTerminalCols(cols), clampTerminalRows(rows)
 }
 
-// clampTerminalDimension clamps a payload-supplied dimension into [lo, hi]
-// before narrowing to uint16. The guards test the incoming value directly and
-// each branch returns — reassigning and converting after the merge hides the
-// bound checks from CodeQL's go/incorrect-integer-conversion analysis, which
-// flagged the previous clamp-then-convert shape.
-func clampTerminalDimension(v, lo, hi int) uint16 {
-	if v < lo {
-		return uint16(lo)
+// clampTerminalCols / clampTerminalRows clamp a payload-supplied dimension
+// into its [min, max] range before narrowing to uint16.
+//
+// The shape is deliberate, for CodeQL's go/incorrect-integer-conversion
+// barrier analysis: each guard compares the converted value against a NAMED
+// CONSTANT and early-returns. A merged clamp variable (phi) hides the guards
+// from the analysis, and so does a generic clamp(v, lo, hi) helper — bounds
+// passed as parameters carry no provable range, so `uint16(v)` stays flagged.
+// Two constant-bound copies are the price of a checkable conversion.
+func clampTerminalCols(cols int) uint16 {
+	if cols < minTerminalCols {
+		return minTerminalCols
 	}
-	if v > hi {
-		return uint16(hi)
+	if cols > maxTerminalCols {
+		return maxTerminalCols
 	}
-	return uint16(v)
+	return uint16(cols)
+}
+
+func clampTerminalRows(rows int) uint16 {
+	if rows < minTerminalRows {
+		return minTerminalRows
+	}
+	if rows > maxTerminalRows {
+		return maxTerminalRows
+	}
+	return uint16(rows)
 }

--- a/agent/internal/remote/tools/terminal.go
+++ b/agent/internal/remote/tools/terminal.go
@@ -140,17 +140,21 @@ func StopTerminal(mgr *terminal.Manager, payload map[string]any) CommandResult {
 }
 
 func normalizeTerminalSize(cols, rows int) (uint16, uint16) {
-	if cols < minTerminalCols {
-		cols = minTerminalCols
-	} else if cols > maxTerminalCols {
-		cols = maxTerminalCols
-	}
+	return clampTerminalDimension(cols, minTerminalCols, maxTerminalCols),
+		clampTerminalDimension(rows, minTerminalRows, maxTerminalRows)
+}
 
-	if rows < minTerminalRows {
-		rows = minTerminalRows
-	} else if rows > maxTerminalRows {
-		rows = maxTerminalRows
+// clampTerminalDimension clamps a payload-supplied dimension into [lo, hi]
+// before narrowing to uint16. The guards test the incoming value directly and
+// each branch returns — reassigning and converting after the merge hides the
+// bound checks from CodeQL's go/incorrect-integer-conversion analysis, which
+// flagged the previous clamp-then-convert shape.
+func clampTerminalDimension(v, lo, hi int) uint16 {
+	if v < lo {
+		return uint16(lo)
 	}
-
-	return uint16(cols), uint16(rows)
+	if v > hi {
+		return uint16(hi)
+	}
+	return uint16(v)
 }

--- a/agent/internal/remote/tools/types.go
+++ b/agent/internal/remote/tools/types.go
@@ -3,6 +3,9 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -642,18 +645,97 @@ func GetPayloadString(payload map[string]any, key string, defaultVal string) str
 	return defaultVal
 }
 
-func GetPayloadInt(payload map[string]any, key string, defaultVal int) int {
-	if v, ok := payload[key]; ok {
-		switch n := v.(type) {
-		case int:
-			return n
-		case int64:
-			return int(n)
-		case float64:
-			return int(n)
-		}
+// ParsePayloadInt reads an integer field from a command payload, distinguishing
+// an ABSENT key from a MALFORMED value — the distinction GetPayloadInt cannot
+// express, because it reports both as defaultVal.
+//
+// Absent (returns defaultVal, nil):
+//   - the key is missing, or present as JSON null
+//
+// Accepted:
+//   - int, int64, and float64 — the types encoding/json and hand-built payloads
+//     actually produce
+//   - json.Number and numeric strings ("15"), via a strict base-10 parse
+//
+// Rejected with an error:
+//   - non-integral, NaN, infinite, or out-of-int-range floats (15.5, 1e300)
+//   - booleans, objects, arrays, and unparseable or empty strings ("soon", "")
+//
+// "The caller did not specify this field" is a meaningful statement that a
+// default can stand in for. "The caller specified garbage" is not. Handlers for
+// destructive commands MUST use this rather than GetPayloadInt, so a malformed
+// reboot delay fails the command instead of collapsing onto 0 — which for
+// reboot/shutdown means "act immediately" (issue #3373).
+func ParsePayloadInt(payload map[string]any, key string, defaultVal int) (int, error) {
+	raw, ok := payload[key]
+	if !ok || raw == nil {
+		return defaultVal, nil
 	}
-	return defaultVal
+
+	switch n := raw.(type) {
+	case int:
+		return n, nil
+	case int64:
+		return intFromInt64(key, n)
+	case float64:
+		return intFromFloat64(key, n)
+	case json.Number:
+		return intFromNumericString(key, n.String())
+	case string:
+		return intFromNumericString(key, n)
+	default:
+		return 0, fmt.Errorf("%s must be a number, got %T", key, raw)
+	}
+}
+
+// GetPayloadInt reads an integer field, falling back to defaultVal when the key
+// is absent OR malformed.
+//
+// It accepts exactly what ParsePayloadInt accepts (numeric strings included);
+// the only difference is that a malformed value is swallowed instead of
+// reported. Prefer ParsePayloadInt wherever a silently wrong value has
+// consequences.
+func GetPayloadInt(payload map[string]any, key string, defaultVal int) int {
+	n, err := ParsePayloadInt(payload, key, defaultVal)
+	if err != nil {
+		return defaultVal
+	}
+	return n
+}
+
+// intFromInt64 narrows to int via a round-trip check, which is exact on both
+// 32- and 64-bit builds without needing platform-specific bounds constants.
+func intFromInt64(key string, n int64) (int, error) {
+	if int64(int(n)) != n {
+		return 0, fmt.Errorf("%s value %d is out of range", key, n)
+	}
+	return int(n), nil
+}
+
+func intFromFloat64(key string, f float64) (int, error) {
+	if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) {
+		return 0, fmt.Errorf("%s must be a whole number, got %v", key, f)
+	}
+	// float64 spans far beyond int on every platform; reject out-of-range
+	// values rather than letting the conversion produce an
+	// implementation-defined result. -float64(math.MinInt) is exactly 2^63
+	// (2^31 on 32-bit builds), i.e. one past the largest valid int.
+	if f < float64(math.MinInt) || f >= -float64(math.MinInt) {
+		return 0, fmt.Errorf("%s value %v is out of range", key, f)
+	}
+	return int(f), nil
+}
+
+func intFromNumericString(key, s string) (int, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return 0, fmt.Errorf("%s must be a number, got an empty string", key)
+	}
+	n, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a number, got %q", key, s)
+	}
+	return n, nil
 }
 
 func GetPayloadBool(payload map[string]any, key string, defaultVal bool) bool {


### PR DESCRIPTION
## Problem

`GetPayloadInt` returned `defaultVal` for **both** an absent key and a present-but-unparseable value. For the reboot/shutdown/safe-mode `delay` field that default is `0`, and `0` legitimately means **"act immediately"** — the two cases are indistinguishable.

So a command payload of `{"delay": "15"}` (a JSON string rather than a number) was read as `0` and rebooted the device **instantly**, with no grace period and no error.

This is reachable, not theoretical: the API validates command payloads as `payload: z.any().optional()` (`apps/api/src/routes/devices/schemas.ts:153`), so a string delay from a hand-built API call, an integration, or a serializer quirk reaches the agent verbatim.

## Fix

**`ParsePayloadInt(payload, key, defaultVal) (int, error)`** — separates *absent* from *malformed*:

| Input | Result |
|---|---|
| key missing, or explicit JSON `null` | `(defaultVal, nil)` |
| `int`, `int64`, integral `float64` | the value |
| numeric string `"15"`, `json.Number` | strict base-10 parse |
| `"soon"`, `""`, `"15m"`, `"15.5"` | **error** |
| `bool`, object, array | **error** |
| non-integral / NaN / infinite / out-of-int-range float | **error** |

"The caller did not specify this field" is a statement a default can stand in for. "The caller specified garbage" is not.

`GetPayloadInt` now delegates to it and swallows the error, so it keeps its lenient contract *and* gains numeric-string support — same accept-set, different failure mode.

**`ShutdownDelayMinutes(payload) (int, error)`** — one source of truth for the `delay` field shared by `Reboot`, `Shutdown`, and `RebootToSafeMode`, so the value announced to users can no longer drift from the value actually scheduled.

Out-of-range delays are **still clamped** (`<0 → 0`, `>1440 → 1440`); only the *type* is now strict. See the note on #3371 below.

## Call-site sweep — decision per site

All 57 `GetPayloadInt` call sites were reviewed. Four were changed:

| Call site | Field | Why a silent 0 was dangerous | Decision |
|---|---|---|---|
| `tools/system.go` `Reboot` | `delay` | 0 = reboot now | **strict** via `ShutdownDelayMinutes` |
| `tools/system.go` `Shutdown` | `delay` | 0 = shut down now | **strict** via `ShutdownDelayMinutes` |
| `tools/system_safemode_windows.go` | `delay` | 0 = instant Safe Mode reboot, BCD flag already set | **strict** via `ShutdownDelayMinutes` |
| `heartbeat/handlers.go` `handleRebootSafeMode` | `delay` | re-read the raw payload for the toast → announced delay could differ from the scheduled one; malformed → warned users of, then performed, an unrequested immediate reboot | **strict**, parsed once before any broadcast |

Two more were hardened because the sweep showed a silent default still produced a wrong destructive outcome:

| Call site | Field | Issue | Decision |
|---|---|---|---|
| `heartbeat/handlers_patch.go` `handleScheduleReboot` | `delayMinutes` | the `1-10080` range check *passes* the silent 60 default, so a malformed value silently scheduled a reboot an hour out | **strict** |
| `tools/computer_action.go` | `x`, `y` | a malformed coordinate clicked the screen's **top-left corner** instead of the target. Absent still means 0, correct for `screenshot`/`key`/`type` | **strict** |

**Left lenient — deliberately.** Everything else falls into one of three safe shapes, and all of them additionally *improve* under this change because a numeric string now parses instead of silently defaulting:

- **Explicitly clamped after read** — `filesystem_analysis.go` (7 sites, all wrapped in `clampInt`), `processes.go`, `services.go`, `tasks.go`, `eventlogs.go`, `fileops.go`, `terminal.go` (`normalizeTerminalSize`), `handlers_screenshot.go` / `handlers_script.go` (`helperCommandTimeout` treats `<=0` as the default).
- **Guarded by an explicit `== 0` rejection** — `processes.go` `KillProcess` and `incident_response.go` `executeProcessKill` already `return error` on `pid == 0`, so a fallback fails safe. (These were the precedent for the fix pattern.)
- **Read-only probes with a non-zero default** — `handlers_network.go`, `handlers_logship.go`. Worst case is a degenerate no-op scan, nothing destructive.

One site in that last group turned out **not** to be benign, and review caught it: `handlers_monitor.go`'s `count` flows straight into `make([]net.IP, count)` with no guard. A negative value **panics** the handler; a large one reserves arbitrary memory on the device. Both are reachable because the API forwards payloads unvalidated. Pre-existing and not introduced by the strict-parse change — but this PR's sweep claimed the site was safe, so `clampPingCount` (second commit) makes that claim true.

## Also

The safe-mode notification renders from the parsed/clamped delay and pluralises `1 minute` correctly (previously `in 1 minutes`).

## Overlap with #3371 — expect a conflict

**#3371 (issue #3252, reboot delay unit normalization) is still open** and edits the same `Reboot`/`Shutdown`/`RebootToSafeMode` delay lines. This PR is based on `main` (`81ce580`), **not stacked** — stacked PRs get no CI on this repo.

Conflict is textual and small. Whichever merges second:

- #3371 introduces `maxShutdownDelayMinutes` + `clampShutdownDelayMinutes()`; this PR introduces `maxShutdownDelayMinutes` + `ShutdownDelayMinutes()`. **Resolution: keep one `maxShutdownDelayMinutes`, and have `ShutdownDelayMinutes` call `clampShutdownDelayMinutes` instead of its own inline clamp.** The two are complementary — #3371 owns *units and clamping*, this PR owns *parsing and validation*.
- I deliberately **kept the negative-clamps-to-0 behaviour** rather than making it an error, because #3371 explicitly tests it (`{-1000, 0}`, `{-1, 0}`). Reversing a sibling PR's tested decision from here would be wrong. Worth a follow-up: `delay: -5` silently becoming an immediate reboot is the same bug class as this issue.

## Reviewed and deliberately NOT changed — needs your call

`handleRebootSafeMode` broadcasts the "save your work" notification **before** `tools.RebootToSafeMode` is called and confirmed to succeed. If the BCD flag can't be set or `shutdown /r` fails, every logged-in user gets a critical toast for a reboot that never happens.

The review flagged this as the same hazard class this PR reasons about, and that's fair. I left it alone on purpose:

- The ordering is **pre-existing** — this PR changed *what* is broadcast, not *when*.
- Reversing it has a real cost. On `delay: 0` the reboot begins immediately, so a post-success broadcast races the shutdown and users may get no warning at all.
- That's a UX judgment on a destructive Windows path with no repo precedent, which belongs in its own change rather than a drive-by in a parsing PR.

Happy to do it here or in a follow-up issue — your call.

## Verification

- `go test -race ./internal/remote/tools/...` — **ok** (29.4s, full package)
- `go test -race ./internal/heartbeat/...` — **ok** (39.0s, full package)
- `go vet` clean on `GOOS=windows`, `darwin`, `linux` (the windows vet is what typechecks `system_safemode_windows.go`)
- Cross-builds OK: `windows/amd64`, `linux/amd64`, `linux/arm64`, `darwin/arm64`, `darwin/amd64`
  - `windows/386` fails, but on **pre-existing** code unrelated to this change (`internal/patching/hresult.go` HRESULT constants overflow `int32`) — the agent is 64-bit only.
- **Mutation-tested**: reverting `ShutdownDelayMinutes` to the old lenient read fails 18 subtests across both packages, so the tests are not vacuous.

### A note on the tests

They deliberately **never call `Reboot`/`Shutdown`** — those run the host's `shutdown` binary, and a regression of this very fix would turn a malformed-input test case into an actual reboot of whatever machine ran the suite. The parse/clamp helper is covered directly instead, and handler wiring is asserted through `handleRebootSafeMode`, whose underlying tool is an inert stub off Windows.

Closes #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
