### PR TITLE
fix(api,secrets): seal plaintext into registered columns without requiring APP_ENCRYPTION_KEY_ID

### DIFF
--- a/apps/api/src/services/encryptedColumnRegistry.test.ts
+++ b/apps/api/src/services/encryptedColumnRegistry.test.ts
@@ -90,6 +90,92 @@ describe('encryptedColumnRegistry', () => {
     expect(decryptSecret(transformed.nested.authToken)).toBe('old-token');
   });
 
+  describe('first encryption with no APP_ENCRYPTION_KEY_ID (the shipped default)', () => {
+    // Every other case in this file sets APP_ENCRYPTION_KEY_ID, which is why
+    // this path went uncovered: plaintext was routed through reencryptSecret,
+    // whose missing-key-id guard throws and fails the write.
+
+    it('seals a plaintext text column to v1 instead of throwing', () => {
+      setEncryptionEnv({ APP_ENCRYPTION_KEY: 'legacy-key-material' });
+
+      const transformed = transformEncryptedColumnValue({
+        table: 'device_recovery_keys',
+        column: 'encrypted_key',
+        kind: 'text',
+        description: 'test',
+      }, 'plaintext-recovery-key');
+
+      expect(transformed).toMatch(/^enc:v1:/);
+      expect(decryptSecret(transformed as string)).toBe('plaintext-recovery-key');
+    });
+
+    it('seals a plaintext JSON secret field to v1 and leaves non-secrets alone', () => {
+      setEncryptionEnv({ APP_ENCRYPTION_KEY: 'legacy-key-material' });
+
+      const transformed = transformEncryptedColumnValue({
+        table: 'notification_channels',
+        column: 'config',
+        kind: 'json',
+        description: 'test',
+      }, {
+        label: 'do-not-encrypt',
+        nested: { apiKey: 'plaintext-api-key' },
+      }) as { label: string; nested: { apiKey: string } };
+
+      expect(transformed.label).toBe('do-not-encrypt');
+      expect(transformed.nested.apiKey).toMatch(/^enc:v1:/);
+      expect(decryptSecret(transformed.nested.apiKey)).toBe('plaintext-api-key');
+    });
+
+    it('seals plaintext entries of a text-array column to v1', () => {
+      setEncryptionEnv({ APP_ENCRYPTION_KEY: 'legacy-key-material' });
+
+      const transformed = transformEncryptedColumnValue({
+        table: 'discovery_profiles',
+        column: 'snmp_communities',
+        kind: 'text-array',
+        description: 'test',
+      }, ['public', 'private']) as string[];
+
+      expect(transformed).toHaveLength(2);
+      for (const entry of transformed) {
+        expect(entry).toMatch(/^enc:v1:/);
+      }
+      expect(transformed.map((e) => decryptSecret(e))).toEqual(['public', 'private']);
+    });
+
+    it('still rotates to the active key id when one IS configured', () => {
+      setEncryptionEnv({
+        APP_ENCRYPTION_KEY: 'current-key-material',
+        APP_ENCRYPTION_KEY_ID: 'current',
+      });
+
+      const transformed = transformEncryptedColumnValue({
+        table: 'device_recovery_keys',
+        column: 'encrypted_key',
+        kind: 'text',
+        description: 'test',
+      }, 'plaintext-recovery-key');
+
+      expect(transformed).toMatch(/^enc:v2:current:/);
+      expect(decryptSecret(transformed as string)).toBe('plaintext-recovery-key');
+    });
+
+    it('leaves existing ciphertext untouched when no key id is configured', () => {
+      setEncryptionEnv({ APP_ENCRYPTION_KEY: 'legacy-key-material' });
+      const existing = encryptSecret('already-sealed');
+
+      const transformed = transformEncryptedColumnValue({
+        table: 'device_recovery_keys',
+        column: 'encrypted_key',
+        kind: 'text',
+        description: 'test',
+      }, existing);
+
+      expect(transformed).toBe(existing);
+    });
+  });
+
   it('supports dry-run batch stats without writing updates', async () => {
     setEncryptionEnv({
       APP_ENCRYPTION_KEY: 'current-key-material',

--- a/apps/api/src/services/encryptedColumnRegistry.ts
+++ b/apps/api/src/services/encryptedColumnRegistry.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm';
 import { db, withSystemDbAccessContext } from '../db';
 import {
+  encryptSecret,
   getActiveSecretEncryptionKeyId,
   isEncryptedSecret,
   reencryptSecret,
@@ -140,7 +141,13 @@ function maybeReencryptString(value: string, force: boolean, aad?: string): stri
   if (!force) {
     return value;
   }
-  return reencryptSecret(value, opts) ?? value;
+  // Plaintext reaching a registered column is a first encryption, not a
+  // rotation, so it goes through `encryptSecret`. `reencryptSecret` requires an
+  // active key id and throws without one, which would fail the whole write on a
+  // deployment that has not set APP_ENCRYPTION_KEY_ID — the shipped default.
+  // `encryptSecret` seals to v1 under the global key in that configuration,
+  // matching how every other write path degrades.
+  return encryptSecret(value, opts) ?? value;
 }
 
 function transformJsonSecrets(value: unknown, key?: string, aad?: string): unknown {


### PR DESCRIPTION
Found while answering the `APP_ENCRYPTION_KEY_ID` question on #3239. Separate bug, same theme: a knob whose absence is fatal at write time rather than loud at boot.

## The defect

`encryptColumnValueForWrite` is the documented mandatory path for every mutating route that writes a registered column — "Otherwise a UI edit silently re-writes the column as plaintext". Its plaintext branch routes through the wrong primitive:

```ts
if (!force) {
  return value;
}
return reencryptSecret(value, opts) ?? value;   // value is known NOT encrypted here
```

`reencryptSecret` is the **rotation** primitive and requires a target key id:

```ts
const activeKeyId = getActiveKeyId();
if (!activeKeyId) {
  throw new Error('APP_ENCRYPTION_KEY_ID is required to re-encrypt secrets');
}
```

`encryptSecret` — the **first-encryption** primitive — deliberately handles the same configuration:

```ts
// No active key id: fall back to v1 (legacy global key). AAD is not supported
// for v1 since v1 ciphertext predates key rotation; callers wanting AAD must
// set APP_ENCRYPTION_KEY_ID.
return encryptWithKey(value, getEncryptionKey(), ENCRYPTED_V1_PREFIX);
```

So on a deployment with no `APP_ENCRYPTION_KEY_ID`, writing a **plaintext** secret into any registered column throws and 500s the request — while the codebase's own encrypt primitive would have sealed it to v1 without complaint.

`.env.example:339` ships `APP_ENCRYPTION_KEY_ID=` **empty**, and `config/validate.ts:1816` only requires it once `M365_GRAPH_ACTIONS_TOOLS_ENABLED=true`. The default self-hosted configuration is therefore the affected one.

## Why the rotation path is already correct, and this one isn't

The already-encrypted branch degrades cleanly, because `shouldReencryptSecret` returns `false` when there is no active key id — a rotation with no target is genuinely a no-op. That asymmetry is the whole bug: rotation was taught to stand down without a key id, first encryption was not, and it shares a helper with it.

This is not fail-closed behaviour being preserved. v1 *is* encryption at rest under the global key, so sealing to v1 is exactly what every other write path in the system does in this configuration. The throw buys no confidentiality; it only converts a working write into a 500.

## Blast radius

All 40 registry entries, across all three kinds — `text`, `text-array`, and `json` (the latter whenever a sub-field name is in `SECRET_JSON_KEYS`). Concretely that includes `device_recovery_keys.encrypted_key` (BitLocker/FileVault escrow, #2021), `notification_channels.config`, `webhooks.secret`, `snmp_devices.community`, `psa_connections.credentials`, and the `partners`/`organizations`/`sites` `settings` columns.

It only fires on **first** encryption of a given value, so a deployment that has already sealed its secrets keeps working, and one that never sets the knob hits it the first time an operator saves a new credential. That is what makes it easy to miss in testing and expensive in production — the API boots healthy and passes its health check, then a specific class of write fails.

I hit this shape on a self-hosted 0.96.0 fleet: healthy boot, then every encrypted-column write returning 500. The operator-side resolution then was to set `APP_ENCRYPTION_KEY_ID`, which works but is a workaround for a knob the docs presented as optional.

## The fix

One line, plus the import — route first encryption through `encryptSecret`:

```ts
return encryptSecret(value, opts) ?? value;
```

`reencryptSecret` stays exactly where it belongs, on the rotation branch. When a key id *is* configured, behaviour is byte-for-byte unchanged: both primitives seal to `enc:v2:<id>:` (or v3 under `ENABLE_AAD_V3`) via the same `encryptWithKey`.

Deliberately **not** changed: `reencryptSecret`'s guard. It is correct — rotating to an unspecified key id is genuinely an error, and softening it would hide real misconfiguration in the batch rotation walker.

## Verification

**Reproduced first, against unmodified `origin/main`** — the failure is a real stack through the public entry point, not a constructed one:

```
Error: APP_ENCRYPTION_KEY_ID is required to re-encrypt secrets
 ❯ reencryptSecret src/services/secretCrypto.ts:456:11
 ❯ maybeReencryptString src/services/encryptedColumnRegistry.ts:143:10
 ❯ transformEncryptedColumnValue src/services/encryptedColumnRegistry.ts:177:40
 ❯ encryptColumnValueForWrite src/services/encryptedColumnRegistry.ts:206:10
```

**Why it was never caught:** every pre-existing case in `encryptedColumnRegistry.test.ts` sets `APP_ENCRYPTION_KEY_ID`. The unset configuration — the shipped default — had no coverage at all. Five cases now cover it: plaintext into `text`, `json`, and `text-array`; rotation still reaching `enc:v2:current:` when a key id **is** set; and existing ciphertext left byte-identical when one is not.

**Control run:** with just the production line reverted to `reencryptSecret`, exactly the 3 plaintext cases fail with the error above; the other 2 pass in both states, as they should — so the new cases pin the bug rather than describe the code.

**Full local gate, all green:**

- `tsc --noEmit` (apps/api) — exit 0
- `vitest run` (apps/api, full suite) — **1315 files / 21245 passed**, 37 skipped, exit 0
- Trivy `fs --scanners secret,misconfig --severity HIGH,CRITICAL` on `apps/api/src/services` — clean, exit 0
- No Go and no dependency/lockfile changes, so `govulncheck` and `pnpm audit` are untouched by this diff

Two files, +94/−1. No schema, migration, or dependency changes.

## One judgement call worth flagging

With no key id and `ENABLE_AAD_V3=true`, the v1 fallback silently drops AAD — that is `encryptSecret`'s documented, pre-existing behaviour, and this change simply inherits it rather than introducing it. Sealing to v1 unbound beats refusing the write, but if you would rather AAD-desired-but-unavailable be loud, the honest place is a boot-time assertion that `ENABLE_AAD_V3` requires `APP_ENCRYPTION_KEY_ID` — which is the "wired ⇒ documented/validated" direction I raised on #3239, and I would rather it be its own change than smuggled in here.
