### PR TITLE
fix(agent): deny the Keychains directory node, not just its contents (#3385)

### DIFF
--- a/agent/internal/remote/tools/fileops.go
+++ b/agent/internal/remote/tools/fileops.go
@@ -101,6 +101,10 @@ var sensitiveReadPatterns = []string{
 	"/windows/system32/config/security",
 	"/windows/system32/config/system",
 	"/windows/ntds/ntds.dit",
+	// macOS keychain stores. Listed without a trailing separator so the
+	// Keychains directory node is denied alongside its contents (#3385) — every
+	// file under it is credential material, so there is nothing to allow through.
+	"/library/keychains",
 }
 
 // sensitiveReadBasenames are lowercased filenames that are credential stores
@@ -125,7 +129,23 @@ func matchesPathFragment(norm, frag string) bool {
 // a well-known secret store. The comparison is OS-agnostic (backslashes are
 // normalized to forward slashes and case is folded), so a Windows target checked
 // on a Unix host still matches.
+//
+// Every deny-list entry is anchored at a path-component boundary, and a
+// directory entry denies the directory node itself as well as everything under
+// it (#3385) — matchesPathFragment covers both, so entries must NOT carry a
+// trailing separator.
 func isSensitiveReadPath(p string) bool {
+	// Resolve against the working directory first: the deny-list entries are all
+	// rooted, so a relative path ("etc/shadow") would slip past every rule while
+	// still opening the sensitive target, because the OS resolves it against the
+	// same CWD. Agent services routinely run with CWD "/" (Unix) or
+	// C:\Windows\System32 (Windows), which puts the deny-list squarely in reach.
+	// If the CWD cannot be determined, fall back to the caller's path — the
+	// rooted-path rules below still apply.
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+
 	// Normalize backslashes explicitly: filepath.ToSlash is a no-op on Unix, but
 	// the agent may be asked to read a Windows path (or a Windows path may reach
 	// a Unix test host), so fold both separators unconditionally.
@@ -156,10 +176,10 @@ func isSensitiveReadPath(p string) bool {
 		}
 	}
 
-	// macOS keychains
-	if strings.Contains(norm, "/library/keychains/") ||
-		strings.HasSuffix(base, ".keychain") ||
-		strings.HasSuffix(base, ".keychain-db") {
+	// macOS keychain files outside the standard Keychains directory. The
+	// directory itself (and everything under it) is covered by the
+	// "/library/keychains" entry in sensitiveReadPatterns.
+	if strings.HasSuffix(base, ".keychain") || strings.HasSuffix(base, ".keychain-db") {
 		return true
 	}
 

--- a/agent/internal/remote/tools/fileops_containment_test.go
+++ b/agent/internal/remote/tools/fileops_containment_test.go
@@ -60,6 +60,120 @@ func TestIsSensitiveReadPath(t *testing.T) {
 	}
 }
 
+// TestIsSensitiveReadPathDirectoryNode pins the component-boundary contract for
+// deny-list entries that name a *directory*: the directory node itself must be
+// denied, not just its contents (#3385). Sibling directories that merely share a
+// name prefix must stay readable.
+func TestIsSensitiveReadPathDirectoryNode(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		sensitive bool
+	}{
+		// macOS keychains — the directory node itself (#3385).
+		{"user keychains dir node", "/Users/alice/Library/Keychains", true},
+		{"system keychains dir node", "/Library/Keychains", true},
+		{"keychains dir node trailing slash", "/Users/alice/Library/Keychains/", true},
+		{"keychains dir node backslashes", `C:\Users\bob\Library\Keychains`, true},
+		{"keychains dir node lowercase", "/users/alice/library/keychains", true},
+		// macOS keychains — contents (already denied before #3385, kept as regression).
+		{"keychains direct child", "/Users/alice/Library/Keychains/login.keychain-db", true},
+		{"keychains nested child", "/Users/alice/Library/Keychains/ABCD-1234/keychain-2.db", true},
+		// macOS keychains — prefix siblings must NOT be denied.
+		{"keychains sibling dir", "/Users/alice/Library/Keychainsfoo", false},
+		{"keychains sibling dir child", "/Users/alice/Library/Keychainsfoo/notes.txt", false},
+		{"keychains singular sibling", "/Users/alice/Library/Keychain", false},
+		{"keychain access doc", "/Users/alice/Library/KeychainAccess.txt", false},
+		{"keychains without library parent", "/Users/alice/Keychains", false},
+
+		// Other directory-shaped deny-list entries: node + contents + siblings.
+		{"sudoers.d dir node", "/etc/sudoers.d", true},
+		{"sudoers.d child", "/etc/sudoers.d/90-breeze", true},
+		{"sudoers.d sibling", "/etc/sudoers.dx", false},
+		{"ssl private dir node", "/etc/ssl/private", true},
+		{"ssl private child", "/etc/ssl/private/server.key", true},
+		{"ssl private sibling", "/etc/ssl/privatestuff", false},
+		{"ssl private sibling child", "/etc/ssl/privatestuff/readme.txt", false},
+		{"windows config hive sibling dir", `C:\Windows\System32\config\systemprofile`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSensitiveReadPath(tc.path); got != tc.sensitive {
+				t.Fatalf("isSensitiveReadPath(%q) = %v, want %v", tc.path, got, tc.sensitive)
+			}
+		})
+	}
+}
+
+// TestIsSensitiveReadPathRelativeInput proves the deny-list is evaluated against
+// the absolute path the OS would actually open. Every entry is anchored with a
+// leading "/", so a relative path handed to the agent would otherwise slip past
+// the check and still resolve to the sensitive target via the process CWD
+// (found auditing #3385; agent services commonly run with CWD "/").
+func TestIsSensitiveReadPathRelativeInput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-rooted deny-list entries are not reachable from a Windows CWD")
+	}
+
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "etc", "ssl", "private"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Chdir(root)
+
+	cases := []struct {
+		name      string
+		path      string
+		sensitive bool
+	}{
+		{"relative shadow", "etc/shadow", true},
+		{"relative dot-slash shadow", "./etc/shadow", true},
+		{"relative ssl private dir", "etc/ssl/private", true},
+		{"relative benign", "etc/hosts", false},
+		{"relative benign nested", "docs/readme.md", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSensitiveReadPath(filepath.Clean(tc.path)); got != tc.sensitive {
+				t.Fatalf("isSensitiveReadPath(%q) with cwd %q = %v, want %v", tc.path, root, got, tc.sensitive)
+			}
+		})
+	}
+}
+
+// TestListFilesDeniesKeychainsDirNode is the end-to-end proof for #3385: the
+// Keychains directory listing itself (not just reads of files inside it) is
+// refused at the ListFiles entry point.
+func TestListFilesDeniesKeychainsDirNode(t *testing.T) {
+	dir := t.TempDir()
+	keychains := filepath.Join(dir, "Library", "Keychains")
+	if err := os.MkdirAll(keychains, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(keychains, "login.keychain-db"), []byte("kc"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	res := ListFiles(map[string]any{"path": keychains})
+	if res.Status == "completed" {
+		t.Fatal("expected listing of the Keychains directory itself to be denied")
+	}
+	if !strings.Contains(res.Error, "sensitive path") {
+		t.Fatalf("expected sensitive-path error, got: %q", res.Error)
+	}
+
+	// A prefix-sibling directory must still list.
+	sibling := filepath.Join(dir, "Library", "Keychainsfoo")
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatalf("mkdir sibling: %v", err)
+	}
+	if res = ListFiles(map[string]any{"path": sibling}); res.Status != "completed" {
+		t.Fatalf("expected sibling dir listing to succeed, got: %q", res.Error)
+	}
+}
+
 // TestEnforceReadContainmentSymlinkEscape proves that a symlink whose own name
 // is innocuous cannot be used to read a sensitive target: EvalSymlinks resolves
 // the link before the deny-list check.

--- a/agent/internal/remote/tools/fileops_containment_test.go
+++ b/agent/internal/remote/tools/fileops_containment_test.go
@@ -110,36 +110,85 @@ func TestIsSensitiveReadPathDirectoryNode(t *testing.T) {
 // the absolute path the OS would actually open. Every entry is anchored with a
 // leading "/", so a relative path handed to the agent would otherwise slip past
 // the check and still resolve to the sensitive target via the process CWD
-// (found auditing #3385; agent services commonly run with CWD "/").
+// (found auditing #3385; agent services commonly run with CWD "/" on Unix and
+// C:\Windows\System32 on Windows). Runs on every OS: matching is pure string
+// logic over separator-folded paths, and filepath.Abs joins against the CWD the
+// same way on both platforms, so only the CWD prefix differs.
 func TestIsSensitiveReadPathRelativeInput(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX-rooted deny-list entries are not reachable from a Windows CWD")
-	}
-
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "etc", "ssl", "private"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
+	for _, sub := range []string{
+		filepath.Join("etc", "ssl", "private"),
+		filepath.Join("windows", "system32", "config"),
+		"docs",
+	} {
+		if err := os.MkdirAll(filepath.Join(root, sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
 	}
-	t.Chdir(root)
 
 	cases := []struct {
 		name      string
-		path      string
+		cwdRel    string // CWD to evaluate from, relative to root
+		path      string // relative path as the operator would hand it over
 		sensitive bool
 	}{
-		{"relative shadow", "etc/shadow", true},
-		{"relative dot-slash shadow", "./etc/shadow", true},
-		{"relative ssl private dir", "etc/ssl/private", true},
-		{"relative benign", "etc/hosts", false},
-		{"relative benign nested", "docs/readme.md", false},
+		{"relative shadow", ".", "etc/shadow", true},
+		{"relative dot-slash shadow", ".", "./etc/shadow", true},
+		{"relative ssl private dir node", ".", "etc/ssl/private", true},
+		{"relative keychains dir node", ".", "library/keychains", true},
+		// The Windows service case the deny-list comment calls out: a service
+		// running with CWD C:\Windows\System32 reaches the SAM hive with a bare
+		// "config/sam".
+		{"relative windows SAM hive from system32 cwd", filepath.Join("windows", "system32"), "config/sam", true},
+		{"relative benign", ".", "etc/hosts", false},
+		{"relative benign nested", ".", "docs/readme.md", false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			cwd := filepath.Join(root, tc.cwdRel)
+			t.Chdir(cwd)
 			if got := isSensitiveReadPath(filepath.Clean(tc.path)); got != tc.sensitive {
-				t.Fatalf("isSensitiveReadPath(%q) with cwd %q = %v, want %v", tc.path, root, got, tc.sensitive)
+				t.Fatalf("isSensitiveReadPath(%q) with cwd %q = %v, want %v", tc.path, cwd, got, tc.sensitive)
 			}
 		})
+	}
+}
+
+// TestEnforceReadContainmentSymlinkToKeychainsDirNode closes the bypass the
+// deny-list exists to stop, for the entry fixed in #3385: an innocuously-named
+// *directory* symlink whose target is the Keychains directory itself. The
+// pre-#3385 rule only matched paths inside the directory, so the resolved link
+// target would not have matched either.
+func TestEnforceReadContainmentSymlinkToKeychainsDirNode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is unreliable without privilege on Windows CI")
+	}
+
+	dir := t.TempDir()
+	keychains := filepath.Join(dir, "Library", "Keychains")
+	if err := os.MkdirAll(keychains, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(keychains, "login.keychain-db"), []byte("kc"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	link := filepath.Join(dir, "innocent-folder")
+	if err := os.Symlink(keychains, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := enforceReadContainment(filepath.Clean(link)); err == nil {
+		t.Fatal("expected symlink to the Keychains dir node to be denied, got nil")
+	} else if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink-specific denial, got: %v", err)
+	}
+
+	if res := ListFiles(map[string]any{"path": link}); res.Status == "completed" {
+		t.Fatal("expected ListFiles through the symlink to be denied")
+	} else if !strings.Contains(res.Error, "sensitive path") {
+		t.Fatalf("expected sensitive-path error, got: %q", res.Error)
 	}
 }
 
@@ -162,6 +211,17 @@ func TestListFilesDeniesKeychainsDirNode(t *testing.T) {
 	}
 	if !strings.Contains(res.Error, "sensitive path") {
 		t.Fatalf("expected sensitive-path error, got: %q", res.Error)
+	}
+
+	// ReadFile must refuse the directory node too, and must refuse it for being
+	// sensitive rather than for being a directory — containment has to run
+	// before the IsDir check, or a refactor could leak the distinction.
+	res = ReadFile(map[string]any{"path": keychains})
+	if res.Status == "completed" {
+		t.Fatal("expected ReadFile of the Keychains directory itself to be denied")
+	}
+	if !strings.Contains(res.Error, "sensitive path") {
+		t.Fatalf("expected sensitive-path error from ReadFile, got: %q", res.Error)
 	}
 
 	// A prefix-sibling directory must still list.


### PR DESCRIPTION
## Problem

`isSensitiveReadPath` (`agent/internal/remote/tools/fileops.go`) matched macOS keychains with a **trailing separator**:

```go
if strings.Contains(norm, "/library/keychains/") || ...
```

`ListFiles`/`ReadFile` run `filepath.Clean` on the operator-supplied path first, which strips the trailing slash — so `~/Library/Keychains` normalizes to `/Users/<u>/Library/Keychains` and the substring test never fires. **Listing the Keychains directory itself succeeded on `main`**, leaking keychain file names, sizes, permissions and timestamps. Its contents were still blocked, so this is enumeration rather than content disclosure — but it is exactly the metadata an attacker needs to pick a target.

Reproduced as a failing test before the fix:

```
isSensitiveReadPath("/Users/alice/Library/Keychains") = false, want true
isSensitiveReadPath("/Library/Keychains")             = false, want true
TestListFilesDeniesKeychainsDirNode: expected listing of the Keychains directory itself to be denied
```

## Fix

Move the keychain rule into `sensitiveReadPatterns` as `/library/keychains` — **no trailing separator** — so the existing `matchesPathFragment` component-boundary matcher handles it:

| clause | covers |
|---|---|
| `norm == frag` | `/Library/Keychains` (system keychain dir, exact) |
| `strings.HasSuffix(norm, frag)` | `/Users/alice/Library/Keychains` (the directory node) |
| `strings.Contains(norm, frag+"/")` | everything under it, at any depth |

Prefix siblings (`Library/Keychainsfoo`, `Library/Keychain`, `Library/KeychainAccess.txt`) are **not** matched, which is the property the component-boundary matcher exists to guarantee. The `.keychain` / `.keychain-db` basename rules are retained for keychain files stored outside the standard directory.

The doc comment on `isSensitiveReadPath` now states the invariant explicitly: **deny-list entries must not carry a trailing separator**, because a directory entry is required to deny the node as well as its contents.

### Second finding from the audit: relative paths bypassed the entire deny-list

Every entry is rooted at `/`. A relative path (`etc/shadow`) matched **nothing** — `HasSuffix("etc/shadow", "/etc/shadow")` is false — while the OS still resolved it to the sensitive target against the process CWD. Agent services routinely run with CWD `/` (systemd) or `C:\Windows\System32` (Windows SCM), which puts `/etc/shadow` and `config\SAM` directly in reach. The API accepts the path as a bare `z.string().min(1).max(1024)` (`apps/api/src/routes/systemTools/schemas.ts`), so nothing upstream forces an absolute path — and this deny-list is explicitly documented as not trusting the path it is handed.

`isSensitiveReadPath` now resolves with `filepath.Abs` before comparison. This can only ever make the check **stricter** (absolute inputs are unchanged by `Abs`); if `os.Getwd` fails, it falls back to the caller's path and the rooted rules still apply.

## Per-entry audit of the sensitive-path list

Every rule checked for the directory-node/trailing-separator defect:

| # | Rule | Shape | Node itself denied? | Verdict |
|---|---|---|---|---|
| 1 | `/etc/shadow` | file | n/a | OK |
| 2 | `/etc/gshadow` | file | n/a | OK |
| 3 | `/etc/sudoers` | file | n/a | OK |
| 4 | `/etc/sudoers.d` | **directory** | Yes — `norm == frag` / `HasSuffix` | OK (no trailing sep) |
| 5 | `/etc/ssl/private` | **directory** | Yes — same | OK (no trailing sep) |
| 6 | `/private/etc/master.passwd` | file | n/a | OK |
| 7 | `/etc/master.passwd` | file | n/a | OK |
| 8 | `/windows/system32/config/sam` | file | n/a | OK |
| 9 | `/windows/system32/config/security` | file | n/a | OK |
| 10 | `/windows/system32/config/system` | file | n/a | OK |
| 11 | `/windows/ntds/ntds.dit` | file | n/a | OK for the entry as written — see note A |
| 12 | `sensitiveReadBasenames` (`login data`, `key4.db`, `logins.json`, `signons.sqlite`, `cookies.sqlite`) | basename map | n/a — no separator semantics | OK |
| 13 | `.ssh` rule — `strings.Contains(norm, "/.ssh/")` | **directory, trailing separator** | **No** | **Same syntactic shape, intentionally left as-is — see note B** |
| 14 | `/library/keychains/` → `/library/keychains` | **directory, trailing separator** | **No → Yes** | **FIXED — this issue** |
| — | all entries | rooted at `/` | relative input matched nothing | **FIXED — `filepath.Abs` normalization** |

Rules 4 and 5 were the two other directory-shaped entries and were already correct — they go through `matchesPathFragment` rather than a hand-rolled `strings.Contains`. Rule 14 was the only entry that bypassed that matcher, which is precisely why it was the only one carrying a trailing separator. Regression cases pinning the node/contents/sibling behaviour of rules 4 and 5 are included so a future edit cannot silently reintroduce the defect.

**Note A — `/windows/ntds/ntds.dit`:** the entry names the file, so `C:\Windows\NTDS` remains enumerable and `C:\Windows\NTDS\edb.log` (AD transaction logs, which can carry credential material) remains readable. This is a *missing/too-narrow entry*, not the trailing-separator defect, so it is out of scope here — widening the deny-list belongs in its own change. Flagged below.

**Note B — the `.ssh` rule:** `Contains(norm, "/.ssh/")` has the identical trailing-separator shape, so the `.ssh` directory node is enumerable. **This one is deliberate and was left alone.** The rule is intentionally *selective*: it blocks private keys (`id_*` minus `*.pub`, `identity`, `authorized_keys`) while leaving `config`, `known_hosts` and public halves readable. Denying the directory node while permitting reads of files inside it would be incoherent, and listing `.ssh` reveals strictly less than the `config`/`known_hosts` reads that are already allowed. Keychains are the opposite case — every file under `Library/Keychains` is credential material, so denying the whole subtree including the node is the coherent rule.

## Out of scope — flagged, not fixed

The audit swept the read-capable entry points in `agent/internal/remote/tools/`. These bypass `enforceReadContainment` entirely. They are a *missing call site* class rather than the matching-logic defect this issue describes, and per the precedent set when this issue was split out of #3384, they are not being folded into an unrelated fix:

- **`CopyFile` / `copyDir` (`fileops.go`)** — streams the full contents of an arbitrary `sourcePath`, checking only the much narrower `isDeniedSystemPath`. `CopyFile(/etc/shadow → /tmp/x)` followed by `ReadFile(/tmp/x)` defeats the deny-list outright. **Highest-severity item found.**
- **`RenameFile`, `DeleteFile`→trash, `TrashRestore`** — relocate a sensitive file to an attacker-chosen readable location; no containment check.
- **`AnalyzeFilesystem` (`filesystem_analysis.go`)** — walks an operator-supplied root and returns names/sizes; same enumeration class as this bug, no containment check.
- **`ScanSensitiveData` (`sensitive_data_scan.go`)** — reads file content; `scope.includePaths` is caller-controlled and the default excludes can be overridden.
- **`EncryptFile` (`sensitive_data_remediation.go`)** — reads full plaintext of an operator-supplied path.

`apps/api/src/services/aiToolSchemas.ts` has a separate, narrower `BLOCKED_PATH_PREFIXES` list for AI-tool inputs. It contains no keychain entry and none of its prefixes carry a trailing separator, so it is not a mirror of this list and is not affected.

## Tests

Table-driven, per the Go conventions in `breeze-testing`. Added to `agent/internal/remote/tools/fileops_containment_test.go`:

- **`TestIsSensitiveReadPathDirectoryNode`** (21 cases) — the Keychains node itself in five forms (absolute, system-level, trailing slash, backslash/Windows, already-lowercase); contents at depth 1 and 2; five prefix-sibling negatives; plus node/contents/sibling regression cases for `/etc/sudoers.d` and `/etc/ssl/private`, and the existing `config\systemprofile` false-positive guard.
- **`TestIsSensitiveReadPathRelativeInput`** (5 cases) — relative and `./`-prefixed inputs under a controlled CWD via `t.Chdir`, with benign relative paths asserted still readable. Skipped on Windows, where the POSIX-rooted entries are unreachable from a Windows CWD.
- **`TestListFilesDeniesKeychainsDirNode`** — end-to-end at the `ListFiles` entry point (not just the helper), asserting the denial and that a prefix-sibling directory still lists successfully.

All three fail on `main` and pass with this change.

```
go test -race ./internal/remote/tools/   ok      23.288s
go test -race ./...                      all packages ok
go vet ./internal/remote/tools/          clean (native + GOOS=windows)
GOOS={windows,linux,darwin}/amd64 go build ./...   OK
GOOS=darwin/arm64 go build ./...                    OK
```

## Conflict note

Based on latest `origin/main` (`81ce58025`), **not stacked**. PR #3384 (`fix/3344-macos-finder-aliases`, open) also touches `agent/internal/remote/tools/fileops.go`. Its changes are in the `ListFiles`/`FileEntry` alias-resolution area; this PR touches only the deny-list constants and `isSensitiveReadPath`, so no textual overlap is expected — but whichever merges second should re-run `go test -race ./internal/remote/tools/`. #3373's PR, if it lands in the same package, carries the same caveat.

Closes #3385

🤖 Generated with [Claude Code](https://claude.com/claude-code)
