### PR TITLE
fix(api): match process-sample path id against the agent id, not the device id (#3387)

### DIFF
--- a/apps/api/src/routes/agents/processSample.test.ts
+++ b/apps/api/src/routes/agents/processSample.test.ts
@@ -22,8 +22,8 @@ describe('POST /:id/process-sample', () => {
   beforeEach(() => { inserted.length = 0; });
 
   it('derives org_id from the auth context and ignores any body org_id', async () => {
-    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
-    const res = await app.request('/dev-1/process-sample', {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'agent-1', siteId: 's', role: 'agent' });
+    const res = await app.request('/agent-1/process-sample', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -38,8 +38,8 @@ describe('POST /:id/process-sample', () => {
   });
 
   it('server-stamps timestamp and stores agent time separately', async () => {
-    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
-    await app.request('/dev-1/process-sample', {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'agent-1', siteId: 's', role: 'agent' });
+    await app.request('/agent-1/process-sample', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ timestamp: '2020-01-01T00:00:00.000Z', processes: [] })
@@ -49,9 +49,9 @@ describe('POST /:id/process-sample', () => {
   });
 
   it('rejects a payload over the 16-process cap', async () => {
-    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'agent-1', siteId: 's', role: 'agent' });
     const processes = Array.from({ length: 17 }, (_, i) => ({ name: `p${i}`, pid: i, cpu: 0, ramMb: 0 }));
-    const res = await app.request('/dev-1/process-sample', {
+    const res = await app.request('/agent-1/process-sample', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ timestamp: '2026-06-13T12:00:00.000Z', processes })
@@ -59,9 +59,33 @@ describe('POST /:id/process-sample', () => {
     expect(res.status).toBe(400);
   });
 
-  it('rejects when path id does not match the authenticated device', async () => {
-    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'a', siteId: 's', role: 'agent' });
-    const res = await app.request('/dev-OTHER/process-sample', {
+  // #3387: the agent sends config.AgentID in the path (heartbeat.go
+  // sendProcessSample), matching every sibling ingest route. Comparing it to
+  // the device UUID instead 403'd every real sample, and the pre-fix tests hid
+  // that by putting the device id in the path — a value no agent ever sends.
+  it('accepts the agent id in the path, not the device id (#3387)', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'agent-1', siteId: 's', role: 'agent' });
+
+    const ok = await app.request('/agent-1/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timestamp: '2026-06-13T12:00:00.000Z', processes: [] })
+    });
+    expect(ok.status).toBe(201);
+    // the row is still keyed by the device, resolved from the token
+    expect(inserted[0].deviceId).toBe('dev-1');
+
+    const wrong = await app.request('/dev-1/process-sample', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timestamp: '2026-06-13T12:00:00.000Z', processes: [] })
+    });
+    expect(wrong.status).toBe(403);
+  });
+
+  it('rejects when path agent id does not match the authenticated token', async () => {
+    const app = appWithAgent({ deviceId: 'dev-1', orgId: 'org-real', agentId: 'agent-1', siteId: 's', role: 'agent' });
+    const res = await app.request('/agent-OTHER/process-sample', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ timestamp: '2026-06-13T12:00:00.000Z', processes: [] })
@@ -78,7 +102,7 @@ describe('process-sample ingest — requireAgentRole gate (F8)', () => {
       return next();
     });
     app.route('/', processSampleRoutes);
-    const res = await app.request('/dev-1/process-sample', {
+    const res = await app.request('/agent-1/process-sample', {
       method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}),
     });
     expect(res.status).toBe(403);

--- a/apps/api/src/routes/agents/processSample.ts
+++ b/apps/api/src/routes/agents/processSample.ts
@@ -17,13 +17,15 @@ processSampleRoutes.post(
   bodyLimit({ maxSize: 256 * 1024, onError: (c) => c.json({ error: 'Request body too large' }, 413) }),
   zValidator('json', processSampleSchema),
   async (c) => {
-    const deviceId = c.req.param('id');
+    const agentId = c.req.param('id');
     const data = c.req.valid('json');
     const agent = c.get('agent') as AgentAuthContext | undefined;
 
     // Tenancy is derived server-side from the authenticated device — the agent
     // payload is never trusted for org_id, and the path id must match the token.
-    if (!agent || agent.deviceId !== deviceId) {
+    // `:id` is the AGENT id here, matching every sibling agent ingest route
+    // (inventory, connections, heartbeat) and what the agent actually sends.
+    if (!agent || agent.agentId !== agentId) {
       return c.json({ error: 'Forbidden' }, 403);
     }
 


### PR DESCRIPTION
Closes #3387. @SemoTech's diagnosis is exactly right; I verified every claim against `origin/main` before changing anything, and the fix is the one-line direction they proposed.

## Confirmed

`processSample` is the only agent ingest route that reads `:id` as a **device** id:

```ts
const deviceId = c.req.param('id');
if (!agent || agent.deviceId !== deviceId) {
  return c.json({ error: 'Forbidden' }, 403);
}
```

The agent sends its **AgentID** (`agent/internal/heartbeat/heartbeat.go:1849`):

```go
url := fmt.Sprintf("%s/api/v1/agents/%s/process-sample", h.serverURL(), h.config.AgentID)
```

and every sibling route agrees with the agent — `inventory.ts:32` reads `const agentId = c.req.param('id')` and resolves via `eq(devices.agentId, agentId)`. So the two values can never be equal and **every** real process sample 403s. `device_process_samples` stays empty on any deployment, and agents retry forever.

## Fix

Compare the path id to `agent.agentId`. `AgentAuthContext` already carries `agentId` alongside `deviceId`, so nothing new is resolved and there is no extra query.

The security property is unchanged: the path id must still match the authenticated token, and the row is still keyed by `agent.deviceId` / `agent.orgId` resolved server-side from the token — the agent payload is still never trusted for tenancy.

**Direction of the fix.** The API moves, not the agent. The agent's convention is shared by every other ingest route, and changing the agent instead would break already-deployed fleets against a fixed server. There is also no working population to preserve: since the path has always carried the AgentID, this endpoint has never once succeeded, so no deployment depends on the current behaviour.

## Why CI stayed green

The pre-fix tests put the **device** id in the path — a value no agent ever sends — and set `agentId: 'a'` where it could not be observed. They asserted the bug.

Fixed by making the two ids visibly distinct (`deviceId: 'dev-1'`, `agentId: 'agent-1'`) and driving the routes the way the agent actually does. New case `accepts the agent id in the path, not the device id (#3387)` pins both directions at once: `/agent-1/...` → **201** with the row still keyed to `dev-1`, and `/dev-1/...` → **403**. Because the ids now differ, an implementation that compares against either field alone fails one half.

## Verification

- **Control run:** with only the production line reverted to `agent.deviceId !== agentId`, 3 of 6 cases fail, including the new guard. The other 3 (body cap, id mismatch, watchdog-role gate) pass in both states, as they should — they don't depend on which id `:id` means.
- `tsc --noEmit` (apps/api) — exit 0
- `vitest run` (apps/api, full suite) — **1315 files / 21241 passed**, 37 skipped, exit 0
- Trivy `fs --scanners secret,misconfig --severity HIGH,CRITICAL` on `apps/api/src/routes/agents` — clean, exit 0
- No Go, schema, migration, or dependency changes

Two files, +38/−12.

## One thing left deliberately alone

`processSampleSchema` still accepts a body `orgId` that the handler ignores (the first test pins that it's ignored). Tightening the schema to reject unknown keys is a wider change across the agent ingest surface and would be its own PR — flagging it rather than folding it in here.
