### PR TITLE
fix(agent): route every content-touching file op through containment (#3397)

### DIFF
--- a/agent/internal/heartbeat/handlers_security.go
+++ b/agent/internal/heartbeat/handlers_security.go
@@ -95,11 +95,20 @@ func handleSecurityThreatQuarantine(_ *Heartbeat, cmd Command) tools.CommandResu
 	// tools.QuarantineFile, just reached through the threat surface instead of
 	// the file browser. Gated here rather than inside internal/security so that
 	// package keeps no dependency on the tools deny-list.
-	if err := tools.EnforcePathContainment("quarantine", filepath.Clean(path)); err != nil {
+	// Check and use the same string, as every other call site in #3397 does.
+	path = filepath.Clean(path)
+	if err := tools.EnforcePathContainment("quarantine", path); err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
 
 	quarantineDir := tools.GetPayloadString(cmd.Payload, "quarantineDir", security.DefaultQuarantineDir())
+
+	// quarantineDir is caller-supplied: gate the destination too, or quarantine
+	// implants the file's content wherever the caller points it.
+	if err := tools.EnforcePathContainment("write", filepath.Clean(quarantineDir)); err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	dest, err := security.QuarantineThreat(security.Threat{
 		Name:     tools.GetPayloadString(cmd.Payload, "name", ""),
 		Type:     tools.GetPayloadString(cmd.Payload, "threatType", "malware"),
@@ -126,7 +135,9 @@ func handleSecurityThreatRemove(_ *Heartbeat, cmd Command) tools.CommandResult {
 	// Containment (#3397): destructive-but-not-disclosing, gated for the same
 	// reason as tools.SecureDeleteFile — an unrecoverable delete of a credential
 	// store is not a threat-remediation outcome anyone wants.
-	if err := tools.EnforcePathContainment("delete", filepath.Clean(path)); err != nil {
+	// Check and use the same string, as every other call site in #3397 does.
+	path = filepath.Clean(path)
+	if err := tools.EnforcePathContainment("delete", path); err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
 

--- a/agent/internal/heartbeat/handlers_security.go
+++ b/agent/internal/heartbeat/handlers_security.go
@@ -90,6 +90,15 @@ func handleSecurityThreatQuarantine(_ *Heartbeat, cmd Command) tools.CommandResu
 		errResult.DurationMs = time.Since(start).Milliseconds()
 		return *errResult
 	}
+	// Containment (#3397): threat quarantine is an os.Rename into a
+	// caller-chosen directory — the same laundering primitive as
+	// tools.QuarantineFile, just reached through the threat surface instead of
+	// the file browser. Gated here rather than inside internal/security so that
+	// package keeps no dependency on the tools deny-list.
+	if err := tools.EnforcePathContainment("quarantine", filepath.Clean(path)); err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	quarantineDir := tools.GetPayloadString(cmd.Payload, "quarantineDir", security.DefaultQuarantineDir())
 	dest, err := security.QuarantineThreat(security.Threat{
 		Name:     tools.GetPayloadString(cmd.Payload, "name", ""),
@@ -114,6 +123,13 @@ func handleSecurityThreatRemove(_ *Heartbeat, cmd Command) tools.CommandResult {
 		errResult.DurationMs = time.Since(start).Milliseconds()
 		return *errResult
 	}
+	// Containment (#3397): destructive-but-not-disclosing, gated for the same
+	// reason as tools.SecureDeleteFile — an unrecoverable delete of a credential
+	// store is not a threat-remediation outcome anyone wants.
+	if err := tools.EnforcePathContainment("delete", filepath.Clean(path)); err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	err := security.RemoveThreat(security.Threat{
 		Name:     tools.GetPayloadString(cmd.Payload, "name", ""),
 		Type:     tools.GetPayloadString(cmd.Payload, "threatType", "malware"),
@@ -141,10 +157,24 @@ func handleSecurityThreatRestore(_ *Heartbeat, cmd Command) tools.CommandResult 
 		errResult.DurationMs = time.Since(start).Milliseconds()
 		return *errResult
 	}
-	if err := os.MkdirAll(filepath.Dir(originalPath), 0755); err != nil {
+	// Containment (#3397): both endpoints are caller-supplied, making restore an
+	// arbitrary source→destination move. The source is read-gated (it relocates
+	// content to an operator-chosen path) and the destination is write-gated
+	// (otherwise this is a credential-implant primitive) — the same policy
+	// tools.TrashRestore applies.
+	cleanSource := filepath.Clean(source)
+	cleanOriginal := filepath.Clean(originalPath)
+	if err := tools.EnforcePathContainment("restore", cleanSource); err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+	if err := tools.EnforcePathContainment("write", cleanOriginal); err != nil {
+		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cleanOriginal), 0755); err != nil {
 		return tools.NewErrorResult(fmt.Errorf("failed to create restore directory: %w", err), time.Since(start).Milliseconds())
 	}
-	if err := os.Rename(source, originalPath); err != nil {
+	if err := os.Rename(cleanSource, cleanOriginal); err != nil {
 		return tools.NewErrorResult(fmt.Errorf("failed to restore file: %w", err), time.Since(start).Milliseconds())
 	}
 	return tools.NewSuccessResult(map[string]any{

--- a/agent/internal/remote/filedrop/handler.go
+++ b/agent/internal/remote/filedrop/handler.go
@@ -91,6 +91,17 @@ func (h *FileDropHandler) SendFile(path string) error {
 	if h.dc == nil {
 		return errors.New("filedrop: data channel not configured")
 	}
+
+	// CONTAINMENT GAP (#3397) — READ THIS BEFORE WIRING A CALLER.
+	// SendFile is a second, independent file-content egress path: it streams the
+	// whole file over the WebRTC data channel without passing through
+	// tools.ReadFile, so the sensitive-path deny-list
+	// (tools.EnforcePathContainment) does NOT apply. It is unreachable today —
+	// nothing in the repo calls it — which is the only reason #3397 left it
+	// alone. It cannot call tools.EnforcePathContainment directly: that would
+	// close an import cycle (tools → desktop → filedrop → tools).
+	// Any change that gives SendFile a caller must FIRST lift the deny-list into
+	// a leaf package both sides can import, then gate `path` here.
 	file, err := os.Open(path)
 	if err != nil {
 		return err

--- a/agent/internal/remote/tools/fileops.go
+++ b/agent/internal/remote/tools/fileops.go
@@ -206,16 +206,33 @@ func EnforcePathContainment(verb, cleanPath string) error {
 // the literal string carries no "/.ssh/" to match, and EvalSymlinks errored on
 // the missing leaf so the symlink leg never ran — and implanted the key.
 //
-// So walk up to the nearest ancestor that DOES resolve and re-attach the
-// unresolved remainder. That also covers destinations several levels below a
-// symlink, which WriteFile/RenameFile/CopyFile happily MkdirAll into.
+// So walk up to the nearest ancestor that EXISTS and re-attach the unresolved
+// remainder. That also covers destinations several levels below a symlink,
+// which WriteFile/RenameFile/CopyFile happily MkdirAll into.
+//
+// Two properties of this loop are load-bearing, and an earlier version of this
+// fix got both wrong by capping the iteration count at a constant:
+//
+//   - NO DEPTH CAP. The caller controls the destination string, so any fixed
+//     cap is a bypass, not a safety valve: padding the path with more junk
+//     segments than the cap ("<link>/a/a/a/…/authorized_keys") exhausts the
+//     budget before the resolvable ancestor is reached, the function reports
+//     "could not resolve", and EnforcePathContainment reads that as "nothing to
+//     check" — reopening the exact hole. Termination needs no cap: each step
+//     strictly shortens the path and the loop exits at the root.
+//   - CHEAP PROBE, ONE RESOLVE. The ascent probes with os.Lstat (one syscall
+//     per level) and calls EvalSymlinks once, on the ancestor that exists.
+//     Calling EvalSymlinks on every level instead is quadratic in path depth,
+//     which hands the same attacker a CPU-exhaustion knob.
 func resolveForContainment(cleanPath string) (string, bool) {
 	current := cleanPath
 	remainder := ""
-	// Bounded to keep a pathological path from spinning; far deeper than any
-	// real filesystem nesting.
-	for i := 0; i < 128; i++ {
-		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+	for {
+		if _, err := os.Lstat(current); err == nil {
+			resolved, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", false
+			}
 			if remainder != "" {
 				resolved = filepath.Join(resolved, remainder)
 			}
@@ -232,7 +249,6 @@ func resolveForContainment(cleanPath string) (string, bool) {
 		}
 		current = parent
 	}
-	return "", false
 }
 
 // enforceReadContainment blocks reads/lists of obviously-sensitive credential

--- a/agent/internal/remote/tools/fileops.go
+++ b/agent/internal/remote/tools/fileops.go
@@ -173,19 +173,66 @@ func isSensitiveReadPath(p string) bool {
 //
 // verb names the operation in the error ("read", "copy", "rename", …) so the
 // denial is attributable in agent logs and command results.
+//
+// KNOWN LIMITATION: this is path-string matching, so a HARD link to a credential
+// store under an innocuous name is invisible to it — a hard link has no
+// "resolved path" for EvalSymlinks to follow, and os.Lstat reports it as an
+// ordinary regular file. Closing that would mean comparing inode/device
+// identity against the deny-list, which is a different mechanism. It is not
+// reachable through this toolset (nothing here creates links) and requires a
+// hard link already present on the target filesystem; it is called out so the
+// next reader does not mistake the symlink handling for complete link coverage.
 func EnforcePathContainment(verb, cleanPath string) error {
 	if isSensitiveReadPath(cleanPath) {
 		return fmt.Errorf("%s denied on sensitive path: %s", verb, cleanPath)
 	}
-	// EvalSymlinks requires the target to exist; if it can't be resolved the
-	// literal check above already ran, and the subsequent os.Stat/Open will
-	// surface any not-exist error.
-	if resolved, err := filepath.EvalSymlinks(cleanPath); err == nil && resolved != cleanPath {
+	if resolved, ok := resolveForContainment(cleanPath); ok && resolved != cleanPath {
 		if isSensitiveReadPath(resolved) {
 			return fmt.Errorf("%s denied on sensitive path (via symlink): %s", verb, cleanPath)
 		}
 	}
 	return nil
+}
+
+// resolveForContainment resolves cleanPath through any symlinks, returning
+// false only when nothing along the path can be resolved at all.
+//
+// filepath.EvalSymlinks requires EVERY component including the leaf to exist,
+// which is never true for a write destination — so a naive
+// `EvalSymlinks(path); if err == nil` check silently no-ops on exactly the case
+// enforceWriteContainment cares about. That left a real bypass: with a
+// pre-existing symlinked PARENT (/tmp/innocent -> ~/.ssh),
+// WriteFile("/tmp/innocent/authorized_keys") passed both legs of the check —
+// the literal string carries no "/.ssh/" to match, and EvalSymlinks errored on
+// the missing leaf so the symlink leg never ran — and implanted the key.
+//
+// So walk up to the nearest ancestor that DOES resolve and re-attach the
+// unresolved remainder. That also covers destinations several levels below a
+// symlink, which WriteFile/RenameFile/CopyFile happily MkdirAll into.
+func resolveForContainment(cleanPath string) (string, bool) {
+	current := cleanPath
+	remainder := ""
+	// Bounded to keep a pathological path from spinning; far deeper than any
+	// real filesystem nesting.
+	for i := 0; i < 128; i++ {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			if remainder != "" {
+				resolved = filepath.Join(resolved, remainder)
+			}
+			return resolved, true
+		}
+		parent, base := filepath.Split(current)
+		if base == "" {
+			return "", false
+		}
+		remainder = filepath.Join(base, remainder)
+		parent = filepath.Clean(parent)
+		if parent == current {
+			return "", false
+		}
+		current = parent
+	}
+	return "", false
 }
 
 // enforceReadContainment blocks reads/lists of obviously-sensitive credential
@@ -194,15 +241,66 @@ func enforceReadContainment(cleanPath string) error {
 	return EnforcePathContainment("read", cleanPath)
 }
 
+// maxContainmentWalkEntries bounds the pre-relocation subtree scan. Far above
+// any directory an operator moves through a file browser; exceeding it fails
+// CLOSED, because an unbounded tree is precisely where an unnoticed credential
+// store hides.
+const maxContainmentWalkEntries = 500_000
+
+// enforceTreeContainment refuses to RELOCATE a directory whose subtree contains
+// a credential store, even when the directory itself is not on the deny-list.
+//
+// This exists because the deny-list is a path-string match and several of its
+// rules only fire on a path component BELOW the directory: "~/.ssh" does not
+// match (the rule keys on "/.ssh/"), while "~/.ssh/id_rsa" does. A move carries
+// the whole subtree to a new prefix in one syscall, and the relocated copy no
+// longer matches anything — DeleteFile("~/.ssh") to trash left the private key
+// readable at <trash>/<id>/content/id_rsa, and RenameFile("~/.ssh", "/tmp/x")
+// left it at /tmp/x/id_rsa. Found by the security review of #3397.
+//
+// CopyFile does not need this: copyDir walks and evaluates every entry against
+// its ORIGINAL path, which still carries the telltale component.
+//
+// Applied only to relocating operations. Permanent delete does not need it —
+// destroying a directory discloses nothing, and the top-level gate still
+// refuses a directory that is itself deny-listed.
+func enforceTreeContainment(verb, root string) error {
+	entries := 0
+	var offender string
+	err := filepath.Walk(root, func(path string, _ os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			// An unreadable subtree cannot be cleared, and a move would carry
+			// it wholesale. Fail closed.
+			return walkErr
+		}
+		entries++
+		if entries > maxContainmentWalkEntries {
+			return fmt.Errorf("directory too large to clear for %s (over %d entries)", verb, maxContainmentWalkEntries)
+		}
+		if isSensitiveReadPath(path) {
+			offender = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("%s denied: cannot verify directory contents: %w", verb, err)
+	}
+	if offender != "" {
+		return fmt.Errorf("%s denied on sensitive path: %s (inside %s)", verb, offender, root)
+	}
+	return nil
+}
+
 // enforceWriteContainment blocks an operation that would CREATE or OVERWRITE
 // content at a sensitive path. The deny-list is shared with the read side on
 // purpose: writing to /etc/shadow, /etc/sudoers.d, ~/.ssh/authorized_keys or a
 // keychain is a credential-implant / privilege-escalation primitive, and the
 // file browser has no legitimate reason to reach them (#3397).
 //
-// The destination usually does not exist yet, so the symlink leg of
-// EnforcePathContainment is a no-op here — that is intentional: a pre-existing
-// symlink at the destination still resolves and is still caught.
+// The destination usually does not exist yet; resolveForContainment handles
+// that by resolving the nearest existing ancestor, so a symlinked parent
+// directory cannot smuggle a write into a denied location.
 func enforceWriteContainment(cleanPath string) error {
 	return EnforcePathContainment("write", cleanPath)
 }
@@ -479,6 +577,16 @@ func DeleteFile(payload map[string]any) CommandResult {
 			"deleted":   true,
 			"permanent": true,
 		}, time.Since(start).Milliseconds())
+	}
+
+	// Moving to trash relocates the whole subtree under a prefix the deny-list
+	// no longer recognises, so a directory must be cleared entry-by-entry — the
+	// top-level gate above misses "~/.ssh" and friends. Not needed on the
+	// permanent branch above, which discloses nothing.
+	if info.IsDir() {
+		if err := enforceTreeContainment("delete", cleanPath); err != nil {
+			return NewErrorResult(err, time.Since(start).Milliseconds())
+		}
 	}
 
 	// Move to trash
@@ -860,11 +968,21 @@ func RenameFile(payload map[string]any) CommandResult {
 	}
 
 	// Check if source exists
-	if _, err := os.Stat(cleanOldPath); err != nil {
+	oldInfo, err := os.Stat(cleanOldPath)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return NewErrorResult(fmt.Errorf("source path does not exist: %s", cleanOldPath), time.Since(start).Milliseconds())
 		}
 		return NewErrorResult(fmt.Errorf("failed to stat source: %w", err), time.Since(start).Milliseconds())
+	}
+
+	// A directory rename relocates the entire subtree in one syscall, so clear
+	// it entry-by-entry — the top-level gate misses directories that are not
+	// themselves deny-listed but hold credential stores (e.g. "~/.ssh").
+	if oldInfo.IsDir() {
+		if err := enforceTreeContainment("rename", cleanOldPath); err != nil {
+			return NewErrorResult(err, time.Since(start).Milliseconds())
+		}
 	}
 
 	// Ensure destination parent directory exists

--- a/agent/internal/remote/tools/fileops.go
+++ b/agent/internal/remote/tools/fileops.go
@@ -166,23 +166,45 @@ func isSensitiveReadPath(p string) bool {
 	return false
 }
 
-// enforceReadContainment blocks reads/lists of obviously-sensitive credential
-// stores. Symlinks are resolved first (filepath.EvalSymlinks) so a symlink whose
-// own name is innocuous cannot be used to escape the deny-list. Both the literal
-// path and the resolved path are checked.
-func enforceReadContainment(cleanPath string) error {
+// enforcePathContainment blocks an operation against an obviously-sensitive
+// credential store. Symlinks are resolved first (filepath.EvalSymlinks) so a
+// symlink whose own name is innocuous cannot be used to escape the deny-list;
+// both the literal path and the resolved path are checked.
+//
+// verb names the operation in the error ("read", "copy", "rename", …) so the
+// denial is attributable in agent logs and command results.
+func EnforcePathContainment(verb, cleanPath string) error {
 	if isSensitiveReadPath(cleanPath) {
-		return fmt.Errorf("read denied on sensitive path: %s", cleanPath)
+		return fmt.Errorf("%s denied on sensitive path: %s", verb, cleanPath)
 	}
 	// EvalSymlinks requires the target to exist; if it can't be resolved the
 	// literal check above already ran, and the subsequent os.Stat/Open will
 	// surface any not-exist error.
 	if resolved, err := filepath.EvalSymlinks(cleanPath); err == nil && resolved != cleanPath {
 		if isSensitiveReadPath(resolved) {
-			return fmt.Errorf("read denied on sensitive path (via symlink): %s", cleanPath)
+			return fmt.Errorf("%s denied on sensitive path (via symlink): %s", verb, cleanPath)
 		}
 	}
 	return nil
+}
+
+// enforceReadContainment blocks reads/lists of obviously-sensitive credential
+// stores.
+func enforceReadContainment(cleanPath string) error {
+	return EnforcePathContainment("read", cleanPath)
+}
+
+// enforceWriteContainment blocks an operation that would CREATE or OVERWRITE
+// content at a sensitive path. The deny-list is shared with the read side on
+// purpose: writing to /etc/shadow, /etc/sudoers.d, ~/.ssh/authorized_keys or a
+// keychain is a credential-implant / privilege-escalation primitive, and the
+// file browser has no legitimate reason to reach them (#3397).
+//
+// The destination usually does not exist yet, so the symlink leg of
+// EnforcePathContainment is a no-op here — that is intentional: a pre-existing
+// symlink at the destination still resolves and is still caught.
+func enforceWriteContainment(cleanPath string) error {
+	return EnforcePathContainment("write", cleanPath)
 }
 
 // ListDrives enumerates available drives/mount points.
@@ -343,6 +365,14 @@ func WriteFile(payload map[string]any) CommandResult {
 		return NewErrorResult(fmt.Errorf("operation denied on system path: %s", cleanPath), time.Since(start).Milliseconds())
 	}
 
+	// Containment (#3397): the direct write primitive. Gating CopyFile's and
+	// RenameFile's destinations while leaving this one open would be no gate at
+	// all — WriteFile is the shortest path to implanting an SSH authorized_keys
+	// entry or a /etc/sudoers.d drop-in.
+	if err := enforceWriteContainment(cleanPath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	// Ensure parent directory exists
 	parentDir := filepath.Dir(cleanPath)
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
@@ -399,6 +429,21 @@ func DeleteFile(payload map[string]any) CommandResult {
 	// Check against denied system paths
 	if isDeniedSystemPath(cleanPath) {
 		return NewErrorResult(fmt.Errorf("operation denied on system path: %s", cleanPath), time.Since(start).Milliseconds())
+	}
+
+	// Containment (#3397). Applied to BOTH the trash and permanent branches:
+	//   - trash is disclosing: it relocates the content to
+	//     ~/.breeze-trash/<id>/content, a path the deny-list does not recognise
+	//     and that TrashList happily enumerates, so delete-then-read is a
+	//     complete bypass;
+	//   - permanent delete is destructive-but-not-disclosing, and is gated on
+	//     purpose anyway: irrecoverably destroying a credential store (bricking
+	//     sshd via /etc/shadow, wiping a keychain) is not something the file
+	//     browser has any legitimate reason to do, and leaving the MORE
+	//     destructive branch open while blocking the recoverable one would be
+	//     an incoherent policy.
+	if err := EnforcePathContainment("delete", cleanPath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
 	}
 
 	// Block recursive deletes on any top-level directory (e.g. /home, /var, /opt)
@@ -492,7 +537,10 @@ func DeleteFile(payload map[string]any) CommandResult {
 	if err := os.Rename(cleanPath, contentPath); err != nil {
 		// Rename may fail across devices; fall back to copy + remove
 		if info.IsDir() {
-			if cpErr := copyDir(cleanPath, contentPath); cpErr != nil {
+			// skipSensitive=false: this is the fallback half of a MOVE — the
+			// source is removed below, so an omitted entry would be destroyed.
+			// The sensitive-source gate ran at the top of DeleteFile.
+			if cpErr := copyDir(cleanPath, contentPath, false); cpErr != nil {
 				// Clean up the trash item dir on failure
 				os.RemoveAll(trashItemDir)
 				return NewErrorResult(fmt.Errorf("failed to move directory to trash: %w", cpErr), time.Since(start).Milliseconds())
@@ -592,30 +640,44 @@ func TrashRestore(payload map[string]any) CommandResult {
 
 	contentPath := filepath.Join(trashItemDir, "content")
 
+	// Containment (#3397): restore is an arbitrary-destination WRITE, and the
+	// destination comes from metadata.json — a file on disk that a preceding
+	// WriteFile could have forged. Without this gate, restore is a
+	// credential-implant primitive (drop attacker content at
+	// ~/.ssh/authorized_keys or /etc/sudoers.d/x). DeleteFile now refuses to
+	// trash a sensitive path in the first place, so no honestly-created trash
+	// item can trip this.
+	cleanOriginal := filepath.Clean(meta.OriginalPath)
+	if err := enforceWriteContainment(cleanOriginal); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	// Check if something already exists at the original path to prevent silent overwrite
-	if _, existErr := os.Stat(meta.OriginalPath); existErr == nil {
-		return NewErrorResult(fmt.Errorf("cannot restore: path already exists: %s", meta.OriginalPath), time.Since(start).Milliseconds())
+	if _, existErr := os.Stat(cleanOriginal); existErr == nil {
+		return NewErrorResult(fmt.Errorf("cannot restore: path already exists: %s", cleanOriginal), time.Since(start).Milliseconds())
 	}
 
 	// Ensure the parent directory of the original path exists
-	parentDir := filepath.Dir(meta.OriginalPath)
+	parentDir := filepath.Dir(cleanOriginal)
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
 		return NewErrorResult(fmt.Errorf("failed to create parent directory: %w", err), time.Since(start).Milliseconds())
 	}
 
 	// Move content back to original location
-	if err := os.Rename(contentPath, meta.OriginalPath); err != nil {
+	if err := os.Rename(contentPath, cleanOriginal); err != nil {
 		// Rename may fail across devices; fall back to copy + remove
 		info, statErr := os.Stat(contentPath)
 		if statErr != nil {
 			return NewErrorResult(fmt.Errorf("failed to stat trash content: %w", statErr), time.Since(start).Milliseconds())
 		}
 		if info.IsDir() {
-			if cpErr := copyDir(contentPath, meta.OriginalPath); cpErr != nil {
+			// skipSensitive=false: MOVE semantics, see DeleteFile above. The
+			// restore destination is gated at the top of TrashRestore.
+			if cpErr := copyDir(contentPath, cleanOriginal, false); cpErr != nil {
 				return NewErrorResult(fmt.Errorf("failed to restore directory: %w", cpErr), time.Since(start).Milliseconds())
 			}
 		} else {
-			if cpErr := copyFile(contentPath, meta.OriginalPath, info.Mode()); cpErr != nil {
+			if cpErr := copyFile(contentPath, cleanOriginal, info.Mode()); cpErr != nil {
 				return NewErrorResult(fmt.Errorf("failed to restore file: %w", cpErr), time.Since(start).Milliseconds())
 			}
 		}
@@ -628,7 +690,7 @@ func TrashRestore(payload map[string]any) CommandResult {
 
 	return NewSuccessResult(map[string]any{
 		"trashId":      trashID,
-		"restoredPath": meta.OriginalPath,
+		"restoredPath": cleanOriginal,
 		"restored":     true,
 	}, time.Since(start).Milliseconds())
 }
@@ -784,6 +846,19 @@ func RenameFile(payload map[string]any) CommandResult {
 		return NewErrorResult(fmt.Errorf("operation denied on system path: %s", cleanNewPath), time.Since(start).Milliseconds())
 	}
 
+	// Containment (#3397): rename is the cheapest laundering primitive there is
+	// — `mv /etc/shadow /tmp/x` followed by ReadFile(/tmp/x) defeats the
+	// deny-list without ever "reading" anything. Relocating content out from
+	// under the deny-list is therefore treated as disclosure, not as a merely
+	// destructive op. The destination is gated for the same implant reason as
+	// CopyFile's.
+	if err := EnforcePathContainment("rename", cleanOldPath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+	if err := enforceWriteContainment(cleanNewPath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	// Check if source exists
 	if _, err := os.Stat(cleanOldPath); err != nil {
 		if os.IsNotExist(err) {
@@ -836,6 +911,16 @@ func CopyFile(payload map[string]any) CommandResult {
 		return NewErrorResult(fmt.Errorf("operation denied on system path: %s", cleanDst), time.Since(start).Milliseconds())
 	}
 
+	// Containment (#3397): a copy is a content-disclosing read — copy-then-read
+	// would otherwise defeat the deny-list outright. The destination is gated
+	// too, so a copy cannot implant credential material over a secret store.
+	if err := EnforcePathContainment("copy", cleanSrc); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+	if err := enforceWriteContainment(cleanDst); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	// Check if source exists
 	info, err := os.Stat(cleanSrc)
 	if err != nil {
@@ -850,7 +935,7 @@ func CopyFile(payload map[string]any) CommandResult {
 		if strings.HasPrefix(cleanDst, cleanSrc+string(filepath.Separator)) || cleanDst == cleanSrc {
 			return NewErrorResult(fmt.Errorf("cannot copy directory into itself: %s -> %s", cleanSrc, cleanDst), time.Since(start).Milliseconds())
 		}
-		if err := copyDir(cleanSrc, cleanDst); err != nil {
+		if err := copyDir(cleanSrc, cleanDst, true); err != nil {
 			return NewErrorResult(fmt.Errorf("failed to copy directory: %w", err), time.Since(start).Milliseconds())
 		}
 	} else {
@@ -903,7 +988,20 @@ func copyFile(src, dst string, mode os.FileMode) error {
 
 // copyDir recursively copies a directory tree from src to dst.
 // Symlinks are skipped to prevent security boundary escapes.
-func copyDir(src, dst string) error {
+//
+// skipSensitive controls whether entries matching the read-containment
+// deny-list are omitted from the copy. Pass true for the operator-facing
+// CopyFile: gating only the copy ROOT is not enough, because copying a parent
+// directory (`/Users/alice` → `/tmp/x`) would relocate every credential store
+// beneath it to a path the deny-list no longer recognises, and a plain ReadFile
+// of the copy would then hand it over (#3397).
+//
+// Pass false wherever copyDir is the fallback half of a MOVE (DeleteFile →
+// trash, TrashRestore): those call sites delete the source afterwards, so
+// silently omitting an entry would destroy it. Those operations gate their own
+// source path up front instead, which is the containment check that applies to
+// a move.
+func copyDir(src, dst string, skipSensitive bool) error {
 	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -915,6 +1013,13 @@ func copyDir(src, dst string) error {
 			return fmt.Errorf("lstat %s: %w", path, lstatErr)
 		}
 		if realInfo.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		if skipSensitive && isSensitiveReadPath(path) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 

--- a/agent/internal/remote/tools/fileops_containment_ops_test.go
+++ b/agent/internal/remote/tools/fileops_containment_ops_test.go
@@ -1,0 +1,518 @@
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The deny-list matches path FRAGMENTS at a component boundary, so a path built
+// under t.TempDir() (".../etc/shadow") trips exactly the same rules a real
+// "/etc/shadow" would — no privileged fixtures required.
+
+// makeSensitiveFile creates <root>/etc/shadow (a deny-list match) with content.
+func makeSensitiveFile(t *testing.T, root string) string {
+	t.Helper()
+	dir := filepath.Join(root, "etc")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	p := filepath.Join(dir, "shadow")
+	if err := os.WriteFile(p, []byte("root:$6$hash:19000:0:99999:7:::\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+// makeSensitiveDir creates <root>/etc/ssl/private (a deny-list match) holding a key.
+func makeSensitiveDir(t *testing.T, root string) string {
+	t.Helper()
+	dir := filepath.Join(root, "etc", "ssl", "private")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "server.key"), []byte("KEY"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return dir
+}
+
+// makeBenignFile creates <root>/docs/notes.txt.
+func makeBenignFile(t *testing.T, root string) string {
+	t.Helper()
+	dir := filepath.Join(root, "docs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	p := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(p, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+// makeBenignDir creates <root>/docs holding one file.
+func makeBenignDir(t *testing.T, root string) string {
+	t.Helper()
+	makeBenignFile(t, root)
+	return filepath.Join(root, "docs")
+}
+
+// sourceGatedOp is one operation whose SOURCE/target path must be refused when
+// it names a credential store. `invoke` receives the target path plus a scratch
+// directory it may use for a destination.
+type sourceGatedOp struct {
+	name     string
+	needsDir bool // target must be a directory, not a file
+	// denialInResult is true for ops that report the denial inside a successful
+	// result payload (a scan error) rather than failing the whole command.
+	denialInResult bool
+	invoke         func(t *testing.T, target, scratch string) CommandResult
+}
+
+func sourceGatedOps() []sourceGatedOp {
+	return []sourceGatedOp{
+		// Regressions — these two were already gated before #3397.
+		{name: "read", invoke: func(_ *testing.T, target, _ string) CommandResult {
+			return ReadFile(map[string]any{"path": target})
+		}},
+		{name: "list", needsDir: true, invoke: func(_ *testing.T, target, _ string) CommandResult {
+			return ListFiles(map[string]any{"path": target})
+		}},
+
+		// #3397 — content-disclosing / content-relocating.
+		{name: "copy", invoke: func(_ *testing.T, target, scratch string) CommandResult {
+			return CopyFile(map[string]any{"sourcePath": target, "destPath": filepath.Join(scratch, "out")})
+		}},
+		{name: "copy dir", needsDir: true, invoke: func(_ *testing.T, target, scratch string) CommandResult {
+			return CopyFile(map[string]any{"sourcePath": target, "destPath": filepath.Join(scratch, "outdir")})
+		}},
+		{name: "rename", invoke: func(_ *testing.T, target, scratch string) CommandResult {
+			return RenameFile(map[string]any{"oldPath": target, "newPath": filepath.Join(scratch, "out")})
+		}},
+		{name: "delete to trash", invoke: func(_ *testing.T, target, _ string) CommandResult {
+			return DeleteFile(map[string]any{"path": target})
+		}},
+		{name: "delete permanent", invoke: func(_ *testing.T, target, _ string) CommandResult {
+			return DeleteFile(map[string]any{"path": target, "permanent": true})
+		}},
+		{name: "quarantine", invoke: func(_ *testing.T, target, scratch string) CommandResult {
+			return QuarantineFile(map[string]any{"path": target, "quarantineDir": filepath.Join(scratch, "q")})
+		}},
+		{name: "secure delete", invoke: func(_ *testing.T, target, _ string) CommandResult {
+			return SecureDeleteFile(map[string]any{"path": target})
+		}},
+		{name: "encrypt", invoke: func(_ *testing.T, target, _ string) CommandResult {
+			return EncryptFile(map[string]any{"path": target})
+		}},
+
+		// #3397 — traversal entry points. These report the denial as a scan
+		// error inside an otherwise-successful result.
+		{name: "analyze filesystem root", needsDir: true, invoke: func(_ *testing.T, target, _ string) CommandResult {
+			return AnalyzeFilesystem(map[string]any{"path": target, "timeoutSeconds": 5})
+		}},
+		{name: "analyze filesystem targetDirectories", needsDir: true, denialInResult: true,
+			invoke: func(_ *testing.T, target, scratch string) CommandResult {
+				return AnalyzeFilesystem(map[string]any{
+					"path":              scratch,
+					"scanMode":          "incremental",
+					"targetDirectories": []any{target},
+					"timeoutSeconds":    5,
+				})
+			}},
+		{name: "analyze filesystem checkpoint", needsDir: true, denialInResult: true,
+			invoke: func(_ *testing.T, target, scratch string) CommandResult {
+				return AnalyzeFilesystem(map[string]any{
+					"path":           scratch,
+					"timeoutSeconds": 5,
+					"checkpoint": map[string]any{
+						"pendingDirs": []any{map[string]any{"path": target, "depth": 0}},
+					},
+				})
+			}},
+		{name: "scan sensitive data includePaths", needsDir: true, denialInResult: true,
+			invoke: func(_ *testing.T, target, _ string) CommandResult {
+				return ScanSensitiveData(map[string]any{
+					"scope": map[string]any{"includePaths": []any{target}, "timeoutSeconds": 5},
+				})
+			}},
+	}
+}
+
+// TestOperationsDenySensitiveSource is the core #3397 contract: every operation
+// that reads, copies, moves or destroys file content refuses a source path that
+// names a credential store. Before this fix only ReadFile and ListFiles did,
+// which made CopyFile(/etc/shadow → /tmp/x) + ReadFile(/tmp/x) a complete
+// bypass of the deny-list.
+func TestOperationsDenySensitiveSource(t *testing.T) {
+	for _, op := range sourceGatedOps() {
+		t.Run(op.name, func(t *testing.T) {
+			root := t.TempDir()
+			scratch := t.TempDir()
+
+			var target string
+			if op.needsDir {
+				target = makeSensitiveDir(t, root)
+			} else {
+				target = makeSensitiveFile(t, root)
+			}
+
+			res := op.invoke(t, target, scratch)
+
+			if op.denialInResult {
+				if res.Status != "completed" {
+					t.Fatalf("expected a completed result carrying the denial, got status %q err %q", res.Status, res.Error)
+				}
+				if !strings.Contains(res.Stdout, "denied on sensitive path") {
+					t.Fatalf("expected a containment denial in the result payload, got: %s", res.Stdout)
+				}
+			} else {
+				if res.Status == "completed" {
+					t.Fatalf("expected %s on a sensitive source to be denied, got a completed result", op.name)
+				}
+				if !strings.Contains(res.Error, "denied on sensitive path") {
+					t.Fatalf("expected a containment denial, got: %q", res.Error)
+				}
+			}
+
+			// The target must survive every denial — no operation may have
+			// half-executed before the gate.
+			if _, err := os.Stat(target); err != nil {
+				t.Fatalf("sensitive target was mutated despite denial: %v", err)
+			}
+		})
+	}
+}
+
+// TestOperationsAllowBenignSource is the other half of the contract: the gate
+// must not break ordinary file management. A deny-list that also blocks
+// /home/alice/notes.txt would simply be turned off in the field.
+func TestOperationsAllowBenignSource(t *testing.T) {
+	for _, op := range sourceGatedOps() {
+		t.Run(op.name, func(t *testing.T) {
+			root := t.TempDir()
+			scratch := t.TempDir()
+
+			var target string
+			if op.needsDir {
+				target = makeBenignDir(t, root)
+			} else {
+				target = makeBenignFile(t, root)
+			}
+
+			res := op.invoke(t, target, scratch)
+
+			// EncryptFile legitimately fails without a configured key; that is
+			// not a containment refusal, which is all this test asserts.
+			if strings.Contains(res.Error, "denied on sensitive path") ||
+				strings.Contains(res.Stdout, "denied on sensitive path") {
+				t.Fatalf("benign path was refused by containment: err=%q stdout=%s", res.Error, res.Stdout)
+			}
+		})
+	}
+}
+
+// TestOperationsDenySymlinkToSensitiveSource covers the laundering variant the
+// #3395 review flagged: an innocuously-named symlink pointing at a credential
+// store. EnforcePathContainment resolves the link before matching, so the
+// literal name buys nothing.
+func TestOperationsDenySymlinkToSensitiveSource(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is unreliable without privilege on Windows CI")
+	}
+
+	for _, op := range sourceGatedOps() {
+		if op.denialInResult {
+			// Traversal entry points are covered by the source test; the
+			// symlink property is the same code path (EnforcePathContainment).
+			continue
+		}
+		t.Run(op.name, func(t *testing.T) {
+			root := t.TempDir()
+			scratch := t.TempDir()
+
+			var real string
+			if op.needsDir {
+				real = makeSensitiveDir(t, root)
+			} else {
+				real = makeSensitiveFile(t, root)
+			}
+
+			link := filepath.Join(root, "vacation-photos")
+			if err := os.Symlink(real, link); err != nil {
+				t.Fatalf("symlink: %v", err)
+			}
+
+			res := op.invoke(t, link, scratch)
+			if res.Status == "completed" {
+				t.Fatalf("expected %s through a symlink to a sensitive path to be denied", op.name)
+			}
+			if !strings.Contains(res.Error, "symlink") {
+				t.Fatalf("expected a symlink-specific denial, got: %q", res.Error)
+			}
+			if _, err := os.Stat(real); err != nil {
+				t.Fatalf("sensitive target was mutated despite denial: %v", err)
+			}
+		})
+	}
+}
+
+// destGatedOp is one operation whose DESTINATION must be refused when it names a
+// credential store — otherwise the file browser is a credential-implant tool
+// (drop an SSH authorized_keys entry, a /etc/sudoers.d file, …).
+type destGatedOp struct {
+	name   string
+	invoke func(t *testing.T, dest, scratch string) CommandResult
+}
+
+// TestOperationsDenySensitiveDestination pins the write half of the policy.
+func TestOperationsDenySensitiveDestination(t *testing.T) {
+	ops := []destGatedOp{
+		{name: "write", invoke: func(_ *testing.T, dest, _ string) CommandResult {
+			return WriteFile(map[string]any{"path": dest, "content": "pwned"})
+		}},
+		{name: "copy", invoke: func(t *testing.T, dest, scratch string) CommandResult {
+			return CopyFile(map[string]any{"sourcePath": makeBenignFile(t, scratch), "destPath": dest})
+		}},
+		{name: "rename", invoke: func(t *testing.T, dest, scratch string) CommandResult {
+			return RenameFile(map[string]any{"oldPath": makeBenignFile(t, scratch), "newPath": dest})
+		}},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			root := t.TempDir()
+			scratch := t.TempDir()
+			dest := filepath.Join(root, "home", "alice", ".ssh", "authorized_keys")
+
+			res := op.invoke(t, dest, scratch)
+			if res.Status == "completed" {
+				t.Fatalf("expected %s to a sensitive destination to be denied", op.name)
+			}
+			if !strings.Contains(res.Error, "denied on sensitive path") {
+				t.Fatalf("expected a containment denial, got: %q", res.Error)
+			}
+			if _, err := os.Stat(dest); err == nil {
+				t.Fatal("destination was created despite the denial")
+			}
+		})
+	}
+}
+
+// TestTrashRestoreDeniesForgedSensitiveDestination covers the one destination
+// that is not taken from the command payload: TrashRestore reads it out of
+// metadata.json, a file on disk that a preceding WriteFile could have forged.
+// Without the gate, restore is an arbitrary-content-to-arbitrary-path write.
+func TestTrashRestoreDeniesForgedSensitiveDestination(t *testing.T) {
+	trashDir := t.TempDir()
+	victim := t.TempDir()
+	original := filepath.Join(victim, "home", "alice", ".ssh", "authorized_keys")
+
+	getTrashDirFunc = func() (string, error) { return trashDir, nil }
+	t.Cleanup(func() { getTrashDirFunc = getTrashDir })
+
+	trashID := "1700000000000-forged"
+	itemDir := filepath.Join(trashDir, trashID)
+	if err := os.MkdirAll(itemDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	meta := TrashMetadata{
+		OriginalPath: original,
+		TrashID:      trashID,
+		DeletedAt:    "2026-08-10T00:00:00Z",
+		IsDirectory:  false,
+	}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, "metadata.json"), metaBytes, 0o600); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, "content"), []byte("ssh-rsa AAAA attacker\n"), 0o600); err != nil {
+		t.Fatalf("write content: %v", err)
+	}
+
+	res := TrashRestore(map[string]any{"trashId": trashID})
+	if res.Status == "completed" {
+		t.Fatal("expected restore to a forged sensitive destination to be denied")
+	}
+	if !strings.Contains(res.Error, "denied on sensitive path") {
+		t.Fatalf("expected a containment denial, got: %q", res.Error)
+	}
+	if _, err := os.Stat(original); err == nil {
+		t.Fatal("attacker content was implanted at the sensitive destination")
+	}
+}
+
+// TestTrashRestoreAllowsBenignDestination guards against the gate above turning
+// ordinary undelete into a dead feature.
+func TestTrashRestoreAllowsBenignDestination(t *testing.T) {
+	trashDir := t.TempDir()
+	home := t.TempDir()
+
+	getTrashDirFunc = func() (string, error) { return trashDir, nil }
+	t.Cleanup(func() { getTrashDirFunc = getTrashDir })
+
+	original := filepath.Join(home, "docs", "notes.txt")
+	trashID := "1700000000000-notes.txt"
+	itemDir := filepath.Join(trashDir, trashID)
+	if err := os.MkdirAll(itemDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	meta := TrashMetadata{OriginalPath: original, TrashID: trashID, DeletedAt: "2026-08-10T00:00:00Z"}
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, "metadata.json"), metaBytes, 0o600); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, "content"), []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write content: %v", err)
+	}
+
+	res := TrashRestore(map[string]any{"trashId": trashID})
+	if res.Status != "completed" {
+		t.Fatalf("expected benign restore to succeed, got: %q", res.Error)
+	}
+	if _, err := os.Stat(original); err != nil {
+		t.Fatalf("expected the file to be restored: %v", err)
+	}
+}
+
+// TestCopyDirSkipSensitiveContract pins the copyDir boolean, which is the one
+// place in #3397 where getting the polarity backwards causes DATA LOSS rather
+// than a leak:
+//   - true  (operator-facing CopyFile): sensitive entries are omitted, so
+//     copying a parent directory cannot launder credential stores into a
+//     readable location.
+//   - false (the fallback half of a MOVE — DeleteFile→trash, TrashRestore):
+//     every entry is preserved, because the source is deleted afterwards and an
+//     omitted entry would be destroyed rather than protected.
+func TestCopyDirSkipSensitiveContract(t *testing.T) {
+	cases := []struct {
+		name           string
+		skipSensitive  bool
+		wantSensitive  bool
+		wantBenignKept bool
+	}{
+		{name: "CopyFile semantics omit credential stores", skipSensitive: true, wantSensitive: false, wantBenignKept: true},
+		{name: "move semantics preserve everything", skipSensitive: false, wantSensitive: true, wantBenignKept: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := t.TempDir()
+			dst := filepath.Join(t.TempDir(), "copy")
+
+			makeSensitiveFile(t, src) // <src>/etc/shadow
+			makeSensitiveDir(t, src)  // <src>/etc/ssl/private/server.key
+			makeBenignFile(t, src)    // <src>/docs/notes.txt
+
+			if err := copyDir(src, dst, tc.skipSensitive); err != nil {
+				t.Fatalf("copyDir: %v", err)
+			}
+
+			_, shadowErr := os.Stat(filepath.Join(dst, "etc", "shadow"))
+			_, keyErr := os.Stat(filepath.Join(dst, "etc", "ssl", "private", "server.key"))
+			if got := shadowErr == nil; got != tc.wantSensitive {
+				t.Fatalf("copied shadow = %v, want %v", got, tc.wantSensitive)
+			}
+			if got := keyErr == nil; got != tc.wantSensitive {
+				t.Fatalf("copied private key = %v, want %v", got, tc.wantSensitive)
+			}
+
+			if _, err := os.Stat(filepath.Join(dst, "docs", "notes.txt")); (err == nil) != tc.wantBenignKept {
+				t.Fatalf("benign file present = %v, want %v", err == nil, tc.wantBenignKept)
+			}
+		})
+	}
+}
+
+// TestCopyFileDoesNotLaunderNestedCredentialStores is the end-to-end proof for
+// the copyDir filter: gating only the copy ROOT is insufficient, because
+// copying a benign parent relocates every credential store beneath it to a path
+// the deny-list no longer recognises — and a plain ReadFile of the copy would
+// then serve it.
+func TestCopyFileDoesNotLaunderNestedCredentialStores(t *testing.T) {
+	src := t.TempDir()
+	dstRoot := t.TempDir()
+	dst := filepath.Join(dstRoot, "exfil")
+
+	makeSensitiveFile(t, src)
+	makeBenignFile(t, src)
+
+	res := CopyFile(map[string]any{"sourcePath": src, "destPath": dst})
+	if res.Status != "completed" {
+		t.Fatalf("expected the benign parent copy to succeed, got: %q", res.Error)
+	}
+
+	laundered := filepath.Join(dst, "etc", "shadow")
+	if _, err := os.Stat(laundered); err == nil {
+		t.Fatal("credential store was laundered into the copy destination")
+	}
+
+	// And the copy is still useful for its actual purpose.
+	if _, err := os.Stat(filepath.Join(dst, "docs", "notes.txt")); err != nil {
+		t.Fatalf("expected benign content to be copied: %v", err)
+	}
+}
+
+// TestScanSensitiveDataSkipsCredentialStoresUnderBenignRoot proves the per-entry
+// filter in the scan walk. Unlike AnalyzeFilesystem (metadata only), this walk
+// opens and pattern-matches file CONTENT, so a benign include root containing a
+// credential store would turn the scan into an oracle over it.
+func TestScanSensitiveDataSkipsCredentialStoresUnderBenignRoot(t *testing.T) {
+	root := t.TempDir()
+
+	// Byte-identical content in two places: one inside a deny-listed directory,
+	// one in an ordinary documents folder. Both carry an extension the scanner
+	// accepts, so the ONLY thing that can distinguish them is containment — the
+	// benign copy is the positive control that keeps this test from passing
+	// vacuously if the scan silently stops matching (an earlier draft of this
+	// test did exactly that: both files were skipped by the extension filter).
+	body := []byte("AKIAIOSFODNN7EXAMPLE\n-----BEGIN RSA PRIVATE KEY-----\n")
+	denied := filepath.Join(root, "etc", "sudoers.d", "creds.txt")
+	benign := filepath.Join(root, "docs", "creds.txt")
+	for _, p := range []string{denied, benign} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(p, body, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	res := ScanSensitiveData(map[string]any{
+		"scope": map[string]any{"includePaths": []any{root}, "timeoutSeconds": 5},
+	})
+	if res.Status != "completed" {
+		t.Fatalf("expected the scan to complete, got: %q", res.Error)
+	}
+
+	var parsed SensitiveDataScanResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("unmarshal scan response: %v", err)
+	}
+
+	// Positive control: the identical benign file MUST produce findings.
+	var sawBenign bool
+	for _, f := range parsed.Findings {
+		if f.FilePath == denied {
+			t.Fatalf("scan reported a finding inside a credential store: %s", f.FilePath)
+		}
+		if f.FilePath == benign {
+			sawBenign = true
+		}
+	}
+	if !sawBenign {
+		t.Fatalf("positive control produced no findings — the scan is not exercising the patterns: %s", res.Stdout)
+	}
+	if parsed.Summary.FilesScanned != 1 {
+		t.Fatalf("expected exactly the benign file to be scanned, got filesScanned=%d", parsed.Summary.FilesScanned)
+	}
+}

--- a/agent/internal/remote/tools/fileops_containment_ops_test.go
+++ b/agent/internal/remote/tools/fileops_containment_ops_test.go
@@ -472,9 +472,21 @@ func TestWriteDestinationDeniesSymlinkedParent(t *testing.T) {
 			dest := filepath.Join(link, "authorized_keys")
 			implanted := filepath.Join(ssh, "authorized_keys")
 			if tc.nested {
-				// The op would MkdirAll its way down before writing.
-				dest = filepath.Join(link, "sub", "authorized_keys")
-				implanted = filepath.Join(ssh, "sub", "authorized_keys")
+				// The op would MkdirAll its way down before writing. The depth
+				// is deliberately large: the first version of this fix capped
+				// the ancestor walk at 128 levels, which made the cap itself a
+				// bypass — padding the path past it defeated the check. There
+				// is no cap now, so the number here is arbitrary and the test
+				// fails if one is ever reintroduced.
+				parts := make([]string, 0, 301)
+				parts = append(parts, link)
+				for i := 0; i < 300; i++ {
+					parts = append(parts, "a")
+				}
+				dest = filepath.Join(append(parts, "authorized_keys")...)
+
+				parts[0] = ssh
+				implanted = filepath.Join(append(parts, "authorized_keys")...)
 			}
 
 			res := tc.invoke(t, dest, scratch)

--- a/agent/internal/remote/tools/fileops_containment_ops_test.go
+++ b/agent/internal/remote/tools/fileops_containment_ops_test.go
@@ -61,6 +61,24 @@ func makeBenignDir(t *testing.T, root string) string {
 	return filepath.Join(root, "docs")
 }
 
+// scanScope builds a ScanSensitiveData scope rooted at root with the default
+// exclude list explicitly CLEARED.
+//
+// This is load-bearing, not tidiness: defaultSensitiveExcludePaths() contains
+// "/tmp", which is exactly where t.TempDir() lives on Linux — so the fixture
+// would be dropped by the exclude filter before the containment check ever ran,
+// and the test would pass for the wrong reason. (It did: this suite was green on
+// macOS, where t.TempDir() is under /var/folders, and red on Linux CI.) Clearing
+// the excludes leaves containment as the only thing that can filter the fixture.
+// An empty list is honoured because parseSensitiveScope presence-checks the key.
+func scanScope(root string) map[string]any {
+	return map[string]any{
+		"includePaths":   []any{root},
+		"excludePaths":   []any{},
+		"timeoutSeconds": 5,
+	}
+}
+
 // sourceGatedOp is one operation whose SOURCE/target path must be refused when
 // it names a credential store. `invoke` receives the target path plus a scratch
 // directory it may use for a destination.
@@ -136,7 +154,7 @@ func sourceGatedOps() []sourceGatedOp {
 		{name: "scan sensitive data includePaths", needsDir: true, denialInResult: true,
 			invoke: func(_ *testing.T, target, _ string) CommandResult {
 				return ScanSensitiveData(map[string]any{
-					"scope": map[string]any{"includePaths": []any{target}, "timeoutSeconds": 5},
+					"scope": scanScope(target),
 				})
 			}},
 	}
@@ -487,9 +505,7 @@ func TestScanSensitiveDataSkipsCredentialStoresUnderBenignRoot(t *testing.T) {
 		}
 	}
 
-	res := ScanSensitiveData(map[string]any{
-		"scope": map[string]any{"includePaths": []any{root}, "timeoutSeconds": 5},
-	})
+	res := ScanSensitiveData(map[string]any{"scope": scanScope(root)})
 	if res.Status != "completed" {
 		t.Fatalf("expected the scan to complete, got: %q", res.Error)
 	}

--- a/agent/internal/remote/tools/fileops_containment_ops_test.go
+++ b/agent/internal/remote/tools/fileops_containment_ops_test.go
@@ -320,6 +320,216 @@ func TestOperationsDenySensitiveDestination(t *testing.T) {
 	}
 }
 
+// TestRelocatingADirectoryDeniesNestedCredentialStores is the regression for
+// the second bypass the security review of this PR found and proved
+// exploitable.
+//
+// The deny-list is a path-string match, and several rules only fire on a
+// component BELOW the directory: "~/.ssh" does not match (the rule keys on
+// "/.ssh/"), while "~/.ssh/id_rsa" does. A move carries the whole subtree to a
+// new prefix in one syscall, and the relocated copy matches nothing — so
+// DeleteFile("~/.ssh") to trash left the private key readable at
+// <trash>/<id>/content/id_rsa, and RenameFile("~/.ssh", "/tmp/x") left it at
+// /tmp/x/id_rsa. Both defeat the very bypass this PR set out to close.
+func TestRelocatingADirectoryDeniesNestedCredentialStores(t *testing.T) {
+	ops := []struct {
+		name   string
+		invoke func(t *testing.T, dir, scratch string) CommandResult
+	}{
+		{name: "delete to trash", invoke: func(t *testing.T, dir, scratch string) CommandResult {
+			getTrashDirFunc = func() (string, error) { return scratch, nil }
+			t.Cleanup(func() { getTrashDirFunc = getTrashDir })
+			return DeleteFile(map[string]any{"path": dir, "recursive": true})
+		}},
+		{name: "rename", invoke: func(_ *testing.T, dir, scratch string) CommandResult {
+			return RenameFile(map[string]any{"oldPath": dir, "newPath": filepath.Join(scratch, "moved")})
+		}},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			root := t.TempDir()
+			scratch := t.TempDir()
+
+			// The directory itself is NOT deny-listed; its contents are.
+			ssh := filepath.Join(root, "home", "alice", ".ssh")
+			if err := os.MkdirAll(ssh, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			key := filepath.Join(ssh, "id_rsa")
+			if err := os.WriteFile(key, []byte("PRIVATE KEY"), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if isSensitiveReadPath(ssh) {
+				t.Fatal("fixture invalid: the directory itself must not be deny-listed, or this proves nothing")
+			}
+
+			res := op.invoke(t, ssh, scratch)
+			if res.Status == "completed" {
+				t.Fatalf("expected %s of a directory holding a credential store to be denied", op.name)
+			}
+			if !strings.Contains(res.Error, "denied on sensitive path") {
+				t.Fatalf("expected a containment denial, got: %q", res.Error)
+			}
+			if _, err := os.Stat(key); err != nil {
+				t.Fatalf("the private key was relocated despite the denial: %v", err)
+			}
+		})
+	}
+}
+
+// TestRelocatingABenignDirectoryStillWorks keeps the subtree scan from turning
+// ordinary directory moves into denials.
+func TestRelocatingABenignDirectoryStillWorks(t *testing.T) {
+	root := t.TempDir()
+	scratch := t.TempDir()
+	dir := makeBenignDir(t, root)
+
+	res := RenameFile(map[string]any{"oldPath": dir, "newPath": filepath.Join(scratch, "moved")})
+	if res.Status != "completed" {
+		t.Fatalf("expected a benign directory rename to succeed, got: %q", res.Error)
+	}
+	if _, err := os.Stat(filepath.Join(scratch, "moved", "notes.txt")); err != nil {
+		t.Fatalf("expected the directory to be moved: %v", err)
+	}
+}
+
+// TestQuarantineDeniesSensitiveDestination pins the destination half of
+// quarantine. quarantineDir is caller-supplied, so without a write gate,
+// quarantining an ORDINARY file into /etc/sudoers.d implants its content
+// there — the same credential-implant primitive closed for copy and rename.
+func TestQuarantineDeniesSensitiveDestination(t *testing.T) {
+	root := t.TempDir()
+	source := makeBenignFile(t, root)
+	quarantineDir := filepath.Join(root, "etc", "sudoers.d")
+
+	res := QuarantineFile(map[string]any{"path": source, "quarantineDir": quarantineDir})
+	if res.Status == "completed" {
+		t.Fatal("expected quarantine into a sensitive directory to be denied")
+	}
+	if !strings.Contains(res.Error, "denied on sensitive path") {
+		t.Fatalf("expected a containment denial, got: %q", res.Error)
+	}
+	if _, err := os.Stat(source); err != nil {
+		t.Fatalf("source was moved despite the denial: %v", err)
+	}
+
+	// A benign quarantine directory still works.
+	res = QuarantineFile(map[string]any{"path": source, "quarantineDir": filepath.Join(root, "quarantine")})
+	if res.Status != "completed" {
+		t.Fatalf("expected quarantine into a benign directory to succeed, got: %q", res.Error)
+	}
+}
+
+// TestWriteDestinationDeniesSymlinkedParent is the regression for the bypass
+// the security review of this PR found and proved exploitable: a write
+// destination whose LEAF does not exist yet, reached through a pre-existing
+// symlinked PARENT directory.
+//
+// filepath.EvalSymlinks needs every component including the leaf to exist, so
+// the original check silently no-opped on exactly the case write containment
+// exists for: the literal path "<tmp>/innocent/authorized_keys" carries no
+// "/.ssh/" to match, EvalSymlinks errored on the missing leaf, and the key was
+// implanted. resolveForContainment now resolves the nearest existing ancestor.
+func TestWriteDestinationDeniesSymlinkedParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is unreliable without privilege on Windows CI")
+	}
+
+	cases := []struct {
+		name   string
+		nested bool // destination sits below a directory that does not exist yet
+		invoke func(t *testing.T, dest, scratch string) CommandResult
+	}{
+		{name: "write", invoke: func(_ *testing.T, dest, _ string) CommandResult {
+			return WriteFile(map[string]any{"path": dest, "content": "ssh-rsa ATTACKER"})
+		}},
+		{name: "write nested below the link", nested: true, invoke: func(_ *testing.T, dest, _ string) CommandResult {
+			return WriteFile(map[string]any{"path": dest, "content": "ssh-rsa ATTACKER"})
+		}},
+		{name: "copy", invoke: func(t *testing.T, dest, scratch string) CommandResult {
+			return CopyFile(map[string]any{"sourcePath": makeBenignFile(t, scratch), "destPath": dest})
+		}},
+		{name: "rename", invoke: func(t *testing.T, dest, scratch string) CommandResult {
+			return RenameFile(map[string]any{"oldPath": makeBenignFile(t, scratch), "newPath": dest})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			scratch := t.TempDir()
+
+			ssh := filepath.Join(root, "home", "alice", ".ssh")
+			if err := os.MkdirAll(ssh, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			link := filepath.Join(root, "innocent")
+			if err := os.Symlink(ssh, link); err != nil {
+				t.Fatalf("symlink: %v", err)
+			}
+
+			dest := filepath.Join(link, "authorized_keys")
+			implanted := filepath.Join(ssh, "authorized_keys")
+			if tc.nested {
+				// The op would MkdirAll its way down before writing.
+				dest = filepath.Join(link, "sub", "authorized_keys")
+				implanted = filepath.Join(ssh, "sub", "authorized_keys")
+			}
+
+			res := tc.invoke(t, dest, scratch)
+			if res.Status == "completed" {
+				t.Fatal("expected the write through a symlinked parent to be denied")
+			}
+			if !strings.Contains(res.Error, "denied on sensitive path") {
+				t.Fatalf("expected a containment denial, got: %q", res.Error)
+			}
+			if _, err := os.Stat(implanted); err == nil {
+				t.Fatal("content was implanted inside the credential directory")
+			}
+		})
+	}
+}
+
+// TestAnalyzeFilesystemMarksContainmentDenialsPartial pins the signal that
+// distinguishes "we were not allowed to look" from "nothing to report". Without
+// it, an incremental scan whose every requested directory was refused comes
+// back partial:false with zero results, which reads as a clean scan.
+func TestAnalyzeFilesystemMarksContainmentDenialsPartial(t *testing.T) {
+	root := t.TempDir()
+	denied := makeSensitiveDir(t, root)
+
+	res := AnalyzeFilesystem(map[string]any{
+		"path":              makeBenignDir(t, root),
+		"scanMode":          "incremental",
+		"targetDirectories": []any{denied},
+		"timeoutSeconds":    5,
+	})
+	if res.Status != "completed" {
+		t.Fatalf("expected the analysis to complete, got: %q", res.Error)
+	}
+
+	var parsed FilesystemAnalysisResponse
+	if err := json.Unmarshal([]byte(res.Stdout), &parsed); err != nil {
+		t.Fatalf("unmarshal analysis response: %v", err)
+	}
+	if !parsed.Partial {
+		t.Fatalf("expected partial=true when a requested directory was refused: %s", res.Stdout)
+	}
+	if parsed.Reason == "" {
+		t.Fatal("expected a reason explaining the partial result")
+	}
+	var sawDenial bool
+	for _, e := range parsed.Errors {
+		if strings.Contains(e.Error, "denied on sensitive path") {
+			sawDenial = true
+		}
+	}
+	if !sawDenial {
+		t.Fatalf("expected the denial to be reported as a scan error: %s", res.Stdout)
+	}
+}
+
 // TestTrashRestoreDeniesForgedSensitiveDestination covers the one destination
 // that is not taken from the command payload: TrashRestore reads it out of
 // metadata.json, a file on disk that a preceding WriteFile could have forged.

--- a/agent/internal/remote/tools/filesystem_analysis.go
+++ b/agent/internal/remote/tools/filesystem_analysis.go
@@ -105,6 +105,18 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 	workerCount := clampInt(GetPayloadInt(payload, "workers", defaultWorkers), 1, maxFSWorkers)
 
 	cleanRoot := filepath.Clean(rootPath)
+
+	// Containment (#3397): the scan root is a traversal entry point, so refuse
+	// to point the analyzer at a credential store. This is metadata-only
+	// disclosure (paths + sizes; duplicate grouping keys on size|basename, never
+	// on content), so — unlike CopyFile — entries encountered BELOW a benign
+	// root are not filtered: that would put a deny-list match on the hot path of
+	// a multi-million-entry fleet scan to suppress filenames that ListFiles on
+	// the parent directory already discloses.
+	if err := enforceReadContainment(cleanRoot); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	rootInfo, err := os.Stat(cleanRoot)
 	if err != nil {
 		return NewErrorResult(fmt.Errorf("failed to stat path: %w", err), time.Since(start).Milliseconds())
@@ -121,10 +133,27 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 	dirStack := []scanDirFrame{}
 	visitedDirs := map[string]struct{}{}
 
+	// Containment (#3397): `path` is not the only traversal entry point —
+	// `checkpoint.pendingDirs` and `targetDirectories` seed dirStack directly and
+	// would otherwise walk a credential store under cover of a benign root.
+	// Denials are surfaced as scan errors rather than dropped silently, so an
+	// operator sees why a requested directory produced no results.
+	var containmentDenials []FilesystemScanError
+	allowScanEntry := func(p string) bool {
+		if err := enforceReadContainment(p); err != nil {
+			containmentDenials = append(containmentDenials, FilesystemScanError{Path: p, Error: err.Error()})
+			return false
+		}
+		return true
+	}
+
 	checkpointFrames := readCheckpointFrames(payload["checkpoint"])
 	if len(checkpointFrames) > 0 {
-		dirStack = append(dirStack, checkpointFrames...)
 		for _, frame := range checkpointFrames {
+			if !allowScanEntry(frame.path) {
+				continue
+			}
+			dirStack = append(dirStack, frame)
 			visitedDirs[frame.path] = struct{}{}
 			if _, ok := dirStats[frame.path]; !ok {
 				dirStats[frame.path] = &fsDirAggregate{
@@ -138,6 +167,9 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 		targets := readTargetDirectories(payload["targetDirectories"])
 		if scanMode == "incremental" && len(targets) > 0 {
 			for _, target := range targets {
+				if !allowScanEntry(target) {
+					continue
+				}
 				if _, statErr := os.Stat(target); statErr != nil {
 					continue
 				}
@@ -171,6 +203,7 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 	unrotatedLogs := make([]FilesystemUnrotatedLog, 0, 128)
 	trashUsage := make([]FilesystemTrashUsage, 0, 4)
 	scanErrors := make([]FilesystemScanError, 0, 32)
+	scanErrors = append(scanErrors, containmentDenials...)
 
 	var filesScanned int64
 	var dirsScanned int64

--- a/agent/internal/remote/tools/filesystem_analysis.go
+++ b/agent/internal/remote/tools/filesystem_analysis.go
@@ -220,6 +220,17 @@ func AnalyzeFilesystem(payload map[string]any) CommandResult {
 	queueCond := sync.NewCond(&queueMu)
 	var statsMu sync.Mutex
 
+	// A containment denial makes the result incomplete in exactly the sense
+	// `partial` exists to signal. Without this, an incremental scan whose every
+	// targetDirectories entry was refused returns
+	// partial:false / dirsScanned:0 / errors:[...] — indistinguishable, at the
+	// field a consumer actually branches on, from "nothing changed since the
+	// last checkpoint" rather than "we were not allowed to look".
+	if len(containmentDenials) > 0 {
+		partial = true
+		reason = "containment denied on one or more requested directories"
+	}
+
 	notePartial := func(partialReason string) {
 		queueMu.Lock()
 		partial = true

--- a/agent/internal/remote/tools/sensitive_data_remediation.go
+++ b/agent/internal/remote/tools/sensitive_data_remediation.go
@@ -37,6 +37,16 @@ func QuarantineFile(payload map[string]any) CommandResult {
 
 	quarantineDir := GetPayloadString(payload, "quarantineDir", quarantineDefaultDir())
 	sourcePath := filepath.Clean(path)
+
+	// Containment (#3397). Not in the issue's list of seven, found while
+	// sweeping the package: quarantine is a rename into a caller-chosen
+	// directory, i.e. the same laundering primitive as RenameFile —
+	// QuarantineFile(/etc/shadow) parks the hashes at
+	// /tmp/breeze-quarantine/<ts>_shadow, which ReadFile would then serve.
+	if err := EnforcePathContainment("quarantine", sourcePath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	info, err := os.Stat(sourcePath)
 	if err != nil {
 		return NewErrorResult(fmt.Errorf("failed to stat file: %w", err), time.Since(start).Milliseconds())
@@ -115,6 +125,15 @@ func SecureDeleteFile(payload map[string]any) CommandResult {
 	}
 
 	targetPath := filepath.Clean(path)
+
+	// Containment (#3397). Destructive-but-not-disclosing, gated for the same
+	// reason as DeleteFile's permanent branch: an unrecoverable overwrite of a
+	// credential store has no legitimate remediation use, and secureDeletePath
+	// is strictly less recoverable than the trash path that is already refused.
+	if err := EnforcePathContainment("delete", targetPath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	if err := secureDeletePath(targetPath); err != nil {
 		return NewErrorResult(fmt.Errorf("secure delete failed: %w", err), time.Since(start).Milliseconds())
 	}
@@ -272,6 +291,16 @@ func EncryptFile(payload map[string]any) CommandResult {
 	}
 
 	sourcePath := filepath.Clean(path)
+
+	// Containment (#3397): EncryptFile reads the whole file into memory and then
+	// secure-wipes the source. Both halves are disqualifying for a credential
+	// store — the read is disclosure, and the wipe would irrecoverably brick
+	// authentication on the host. Remediation targets ordinary documents
+	// surfaced by ScanSensitiveData, never the credential deny-list.
+	if err := EnforcePathContainment("encrypt", sourcePath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	info, err := os.Stat(sourcePath)
 	if err != nil {
 		return NewErrorResult(fmt.Errorf("failed to stat file: %w", err), time.Since(start).Milliseconds())

--- a/agent/internal/remote/tools/sensitive_data_remediation.go
+++ b/agent/internal/remote/tools/sensitive_data_remediation.go
@@ -62,6 +62,15 @@ func QuarantineFile(payload map[string]any) CommandResult {
 	targetName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), sanitizeFileName(filepath.Base(sourcePath)))
 	targetPath := filepath.Join(quarantineDir, targetName)
 
+	// quarantineDir is caller-supplied, so the destination needs the same gate
+	// CopyFile/RenameFile/TrashRestore got: without it, quarantining an ordinary
+	// file into "/etc/sudoers.d" implants its content there. Checked against the
+	// computed target rather than the directory so the deny-list sees the exact
+	// path os.Rename will create.
+	if err := enforceWriteContainment(targetPath); err != nil {
+		return NewErrorResult(err, time.Since(start).Milliseconds())
+	}
+
 	if err := os.Rename(sourcePath, targetPath); err != nil {
 		return NewErrorResult(fmt.Errorf("failed to move file to quarantine: %w", err), time.Since(start).Milliseconds())
 	}

--- a/agent/internal/remote/tools/sensitive_data_scan.go
+++ b/agent/internal/remote/tools/sensitive_data_scan.go
@@ -896,6 +896,21 @@ func ScanSensitiveData(payload map[string]any) CommandResult {
 			default:
 			}
 
+			// Containment (#3397): unlike AnalyzeFilesystem (metadata only), this
+			// walk opens and pattern-matches file CONTENT, so a benign root that
+			// happens to contain a credential store would turn the scan into an
+			// oracle over it. The per-entry cost rides along with the two path
+			// predicates already evaluated here.
+			if isSensitiveReadPath(path) {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				mu.Lock()
+				filesSkipped++
+				mu.Unlock()
+				return nil
+			}
+
 			if d.IsDir() {
 				if shouldExcludeSensitivePath(path, scope.excludePaths) || shouldSuppressSensitivePath(path, scope) {
 					return filepath.SkipDir
@@ -932,6 +947,14 @@ func ScanSensitiveData(payload map[string]any) CommandResult {
 
 	for _, include := range scope.includePaths {
 		if shouldExcludeSensitivePath(include, scope.excludePaths) {
+			continue
+		}
+		// Containment (#3397): includePaths is caller-supplied, so gate each
+		// scan root. Recorded as a scan error rather than skipped silently.
+		if err := enforceReadContainment(include); err != nil {
+			mu.Lock()
+			recordErrors([]SensitiveDataScanError{{Path: include, Error: err.Error()}})
+			mu.Unlock()
 			continue
 		}
 		info, err := os.Stat(include)


### PR DESCRIPTION
Closes #3397

## The bug

`CopyFile`/`copyDir` streamed an arbitrary `sourcePath` while checking only the much narrower `isDeniedSystemPath`. `CopyFile(/etc/shadow → /tmp/x)` followed by `ReadFile(/tmp/x)` therefore defeated the sensitive-path deny-list outright — the deny-list only ever guarded `ReadFile` and `ListFiles`.

This is a **missing-call-site** class, distinct from #3385 (a matching bug). The check was simply never invoked on these operations' source paths.

## Per-operation policy

The organising principle: **relocating content out from under the deny-list is disclosure, not merely destruction.** A rename or a trash-move is a complete bypass — it never "reads" anything, yet the bytes end up at a path the deny-list no longer recognises, where a plain `ReadFile` serves them.

| Operation | Source | Destination | Rationale |
|---|---|---|---|
| `CopyFile` / `copyDir` | denied | denied | Content-disclosing. The original report. |
| `RenameFile` | denied | denied | Cheapest laundering primitive of the set: `mv /etc/shadow /tmp/x` + read. |
| `DeleteFile` → trash | denied | — | Relocates content to `~/.breeze-trash/<id>/content`, which `TrashList` enumerates and `ReadFile` serves. |
| `DeleteFile` permanent | denied | — | **Destructive-but-not-disclosing, gated on purpose.** Irrecoverably destroying a credential store has no legitimate file-browser use, and leaving the *more* destructive branch open while blocking the recoverable one would be an incoherent policy. |
| `TrashRestore` | — | denied | Arbitrary-destination write. The destination comes from `metadata.json`, a file on disk a preceding `WriteFile` could forge → credential-implant primitive. |
| `AnalyzeFilesystem` | denied (3 entry points) | — | `path`, `targetDirectories` **and** `checkpoint.pendingDirs` all seed the traversal; gating only `path` leaves two open doors. |
| `ScanSensitiveData` | denied + per-entry filter | — | Reads and pattern-matches file **content**, so a benign root containing a credential store turns the scan into an oracle over it. |
| `EncryptFile` | denied | — | Reads the whole file, then secure-wipes the source. Both halves are disqualifying. |

### Four more found by a package sweep (not in the issue)

| Operation | Gate | Why it matters |
|---|---|---|
| `QuarantineFile` | source | An `os.Rename` into a **caller-chosen** directory — same primitive as `RenameFile`, reached through the remediation surface. Had no checks at all, not even `isDeniedSystemPath`. |
| `SecureDeleteFile` | source | Arbitrary path, zero checks. Same reasoning as permanent delete. |
| `WriteFile` | destination | The direct write primitive. Gating `CopyFile`'s and `RenameFile`'s destinations while leaving this open would be no gate at all — it is the shortest path to an `authorized_keys` entry or a `/etc/sudoers.d` drop-in. |
| `handleSecurityThreat{Quarantine,Remove,Restore}` | source + dest | The same three primitives reached through the **threat** surface in `internal/heartbeat`. `handleSecurityThreatRestore` was the worst of the set: a bare `os.Rename(source, originalPath)` with both endpoints caller-supplied and no checks whatsoever. |

## Design notes

**`copyDir` now takes an explicit `skipSensitive bool`, and the polarity matters.** Gating only the copy *root* is insufficient: copying a benign parent (`/Users/alice` → `/tmp/x`) relocates every credential store beneath it. But `copyDir` is *also* the fallback half of a MOVE (`DeleteFile`→trash, `TrashRestore`), and those call sites delete the source afterwards — silently omitting an entry there would **destroy** it rather than protect it. So `CopyFile` passes `true`; the move paths pass `false` and gate their own source up front. `TestCopyDirSkipSensitiveContract` pins both directions, because getting this backwards causes data loss rather than a leak.

**`AnalyzeFilesystem` deliberately does *not* filter per entry.** It is metadata-only (paths and sizes; duplicate grouping keys on `size|basename`, never on content), so a deny-list call on the hot path of a multi-million-entry fleet scan would only suppress filenames that `ListFiles` on the parent directory already discloses. `ScanSensitiveData` *does* filter per entry — it opens and pattern-matches content, and the cost rides along with two path predicates already evaluated there. Denials in both are surfaced as scan errors rather than dropped silently.

**`enforcePathContainment` → exported `EnforcePathContainment(verb, path)`**, so the heartbeat security handlers can reuse it without `internal/security` taking a dependency on the tools deny-list. `verb` names the operation in the error so denials stay attributable in logs. `enforceReadContainment` keeps its exact previous error strings, so existing tests and #3395's assertions are untouched.

**Known gap, documented in code: `filedrop.SendFile`.** It is a second, independent content-egress path — it streams a whole file over the WebRTC data channel without passing through `tools.ReadFile`. It **cannot** call the gate: that closes an import cycle (`tools → desktop → filedrop → tools`). It has no caller anywhere in the repo today, which is the only reason this PR leaves it alone. It now carries a prominent comment requiring anyone who gives it a caller to first lift the deny-list into a leaf package. Extracting that package *now* would have conflicted hard with #3395, which edits `isSensitiveReadPath` in place.

## Found by review of this PR (three more bypasses, all reproduced first)

The security pass on this PR found three bypasses **in the fix itself**. Each was reproduced before being fixed and now has a regression test.

**1. Symlinked parent on a not-yet-existing write destination.** `filepath.EvalSymlinks` requires every component *including the leaf* to exist — which is never true for a write destination — so the symlink leg silently no-opped on exactly the case `enforceWriteContainment` exists for. With `/tmp/innocent → ~/.ssh`, `WriteFile("/tmp/innocent/authorized_keys")` passed both legs (the literal string carries no `/.ssh/`; `EvalSymlinks` errored on the missing leaf) and **implanted the key**. `resolveForContainment` now walks up to the nearest resolvable ancestor and re-attaches the remainder, which also covers destinations several levels below the link.

**2. Relocating a directory that *holds* a credential store but is not itself deny-listed.** The SSH rule keys on `/.ssh/`, so `~/.ssh` does not match while `~/.ssh/id_rsa` does. A move carries the subtree to a new prefix in one syscall where nothing matches: `DeleteFile("~/.ssh")` to trash left the private key readable at `<trash>/<id>/content/id_rsa`, and `RenameFile("~/.ssh", "/tmp/x")` left it at `/tmp/x/id_rsa` — **defeating the exact bypass this PR set out to close.** `enforceTreeContainment` now clears the subtree ahead of the two relocating operations, bounded and failing closed.

`CopyFile` never needed this: `copyDir` evaluates every entry against its *original* path, which still carries the telltale component. Permanent delete does not need it either — destroying a directory discloses nothing, and the top-level gate still refuses a directory that is itself deny-listed.

**3. `QuarantineFile`'s caller-supplied `quarantineDir` was never write-gated** — quarantining an *ordinary* file into `/etc/sudoers.d` implanted its content there. Now gated at both the tools and heartbeat entry points.

Also from the review: `AnalyzeFilesystem` now reports `partial=true` with a reason when a requested directory is refused (an all-denied incremental scan previously returned `partial=false` with zero results, which reads as a clean scan rather than "we were not allowed to look"), and the **hard-link limitation** of a path-string deny-list is documented on `EnforcePathContainment` — a hard link has no resolved path for `EvalSymlinks` to follow and `os.Lstat` reports it as an ordinary file. Not reachable through this toolset (nothing here creates links), but the symlink handling should not be mistaken for complete link coverage.

### And one more: the first fix was itself bypassable

The re-review of the fix commit found that `resolveForContainment` capped its ancestor walk at 128 iterations. The caller controls the destination string, so padding the path past the cap (`<symlink>/a/a/a/…/authorized_keys`) exhausted the budget before the resolvable ancestor was reached; the function reported "could not resolve", `EnforcePathContainment` read that as "nothing to check", and the write landed in the real `~/.ssh`. **Reproduced at depth 135.** Raising the constant would not have fixed it either — the loop called `EvalSymlinks` at every level, which is quadratic in path depth, trading a containment bypass for a CPU-exhaustion knob on the same attacker-supplied string.

The ascent now probes with `os.Lstat` (one syscall per level) and calls `EvalSymlinks` exactly once, on the ancestor that exists — linear, with no cap at all. Termination is structural rather than budgeted: each step strictly shortens the path and the loop exits at the root. The nested regression case pads to depth 300, so reintroducing any fixed cap of a plausible size fails the test (verified by putting the 128 cap back and watching it go red).

**Worth stating plainly:** an attacker-controlled bound in a security check is a bypass, not a safety valve. Both of the first two attempts here reached for a constant.

## Known limitation, deliberately kept

`enforceTreeContainment` fails closed on **any** `filepath.Walk` error, not just a deny-list hit — an unreadable subdirectory makes the whole directory rename or trash-delete fail with `"cannot verify directory contents"`. As root/LocalSystem that is rare, but it can fire on OneDrive placeholder files, EFS-encrypted files, exclusively-locked files, and macOS TCC/SIP paths. I kept it: relocating a subtree that could not be scanned is precisely the hole being closed, and the error text is distinguishable from a real containment denial. Flagging it as a plausible support ticket rather than a silent surprise.

## Open question for the maintainer

**Should deleting a credential file be blocked outright?** This PR gates `DeleteFile` (both branches) and `SecureDeleteFile` on the deny-list, so an incident responder can no longer remove a leaked SSH key, a stale browser `Login Data`, or a rogue `/etc/sudoers.d` drop-in through the file browser — not even to trash. The review flagged this as the classic shape of over-blocking that ends with someone turning the gate off.

I kept the denial because leaving the *unrecoverable* branch open while blocking the recoverable one is incoherent, and because the alternative (an audited `force` override) is a product decision, not a code one. Happy to add the override in a follow-up if you'd rather not ship the hard denial.

## Overlap with #3395 — merge order

**No conflict in either direction; merge order does not matter.** Verified by trial merge, not by inspection:

- #3395 edits `sensitiveReadPatterns`, `isSensitiveReadPath` and `fileops_containment_test.go`.
- This PR edits `enforceReadContainment`'s body and the *call sites*, and adds a **new** test file (`fileops_containment_ops_test.go`), specifically to stay clear of #3395's hunks.
- `git merge` of this branch with `fix/3385-sensitive-path-dir-node` auto-merges clean; the merged tree builds and both `internal/remote/tools` and `internal/heartbeat` suites pass.

The two changes compose rather than overlap: #3395 widens *what* the deny-list matches, this PR fixes *where* it is consulted. Whichever lands second inherits the other's improvement for free — #3395's `filepath.Abs` normalisation and its `/library/keychains` directory-node entry automatically apply to all thirteen newly-gated call sites.

## Tests

New table-driven suite in `agent/internal/remote/tools/fileops_containment_ops_test.go`, one row per operation:

- `TestOperationsDenySensitiveSource` — 14 ops × denied source blocked, **and** the target survives (nothing half-executed before the gate).
- `TestOperationsAllowBenignSource` — the same 14 ops on ordinary files still work. A deny-list that also blocks `notes.txt` gets turned off in the field.
- `TestOperationsDenySymlinkToSensitiveSource` — innocuously-named symlink → credential store, per op. Covers the directory-symlink laundering #3395's review flagged.
- `TestOperationsDenySensitiveDestination` + `TestTrashRestoreDeniesForgedSensitiveDestination` / `...AllowsBenignDestination` — the write half, including the forged-`metadata.json` implant.
- `TestCopyDirSkipSensitiveContract`, `TestCopyFileDoesNotLaunderNestedCredentialStores`, `TestScanSensitiveDataSkipsCredentialStoresUnderBenignRoot`.

Plus regressions for all three review findings: `TestWriteDestinationDeniesSymlinkedParent` (including a destination nested below the link), `TestRelocatingADirectoryDeniesNestedCredentialStores` / `...ABenignDirectoryStillWorks`, `TestQuarantineDeniesSensitiveDestination`, `TestAnalyzeFilesystemMarksContainmentDenialsPartial`.

Fixtures build `<tmpdir>/etc/shadow` etc. — the deny-list matches path *fragments* at a component boundary, so these trip exactly the rules a real `/etc/shadow` would, with no privileged fixtures and no OS gating.

**Mutation-checked, and it caught a real defect in my own tests.** Neutering `EnforcePathContainment` to `return nil` fails all 30 subtests. An earlier draft of the scan test passed vacuously — both fixture files were being dropped by the extension filter, so nothing was ever scanned. It now carries a byte-identical benign twin as a positive control and asserts `filesScanned == 1`, so the test fails if the scanner ever stops matching. (A partial mutation also surfaced that macOS resolves `/var` → `/private/var`, which fires the symlink leg for nearly every temp path — worth knowing when reading these assertions.)

A second host-dependence bit me the same way and is worth calling out for anyone writing tests against this scanner: `defaultSensitiveExcludePaths()` contains `/tmp`, which is exactly where `t.TempDir()` lives on Linux but *not* on macOS. The scan rows were being dropped by the exclude filter before containment ran — green locally, red on Linux CI. They now clear `excludePaths` explicitly so containment is the only thing that can filter the fixture.

**Verification:** `go test -race ./internal/remote/tools/... ./internal/heartbeat/... ./internal/remote/filedrop/...` green · `go build` + `go vet ./...` clean · cross-builds green for windows, linux and darwin on both amd64 and arm64 · test binaries compile for all three GOOS · `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
