### PR TITLE
fix(deps): dedup pnpm-lock.yaml — duplicated mapping keys break every JS job on main

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8087,18 +8087,6 @@ packages:
     resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -19869,11 +19857,8 @@ snapshots:
 
   hono@4.13.1: {}
 
-  hono@4.13.1: {}
 
-  hono@4.13.1: {}
 
-  hono@4.13.1: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -22012,11 +21997,6 @@ snapshots:
       postcss: 8.5.26
       postcss-selector-parser: 6.1.2
 
-  postcss-nested@6.2.0(postcss@8.5.26):
-    dependencies:
-      postcss: 8.5.26
-      postcss-selector-parser: 6.1.2
-
   postcss-selector-parser@6.0.10:
     dependencies:
       cssesc: 3.0.0
@@ -22036,12 +22016,6 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.25:
-    dependencies:
-      nanoid: 3.3.18
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.26:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1


### PR DESCRIPTION
**`main` is currently red on every JS job** — `Lint`, `Type Check`, `Test API`, `Test Web`, `Test Portal`, `Test Mobile`, all six add-in suites, `Check Migrations`, `NPM Audit`, `Build API image`, `Trivy Image Scan`, both smoke jobs. 22 failures at `e31490837`.

They all fail at the same step, before any of them runs a line of project code:

```
##[group]Run pnpm install --frozen-lockfile
 ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ".../pnpm-lock.yaml" is broken:
 duplicated mapping key (8090:3)
```

## Cause

Six dependabot PRs merged inside 114 seconds (`03:06:42` → `03:08:36`). Each was green against the lockfile as it stood when that PR was built; merged back to back, two of them appended entries that already existed, and YAML rejects a duplicated mapping key outright.

Concretely, on `e31490837`:

| Key | Section | Copies | Expected |
|---|---|---|---|
| `hono@4.13.1` | `packages:` | **4** | 1 |
| `hono@4.13.1` | `snapshots:` | **4** | 1 |
| `postcss@8.5.26` | `snapshots:` | **2** | 1 |
| `postcss-nested@6.2.0(postcss@8.5.26)` | `snapshots:` | **2** | 1 |

From #3341 (hono group) and the tailwind/postcss group at `d958c5ce5`.

Calibration, so "duplicated" isn't misread: a healthy package appears **exactly twice in the file** — once under `packages:` and once under `snapshots:`. `hoist-non-react-statics@3.3.2` sits at lines 8083 and 19866, one each. That cross-section pair is normal and is *not* what breaks; only repeats **within one section** do.

## The change

26 lines deleted, nothing added, nothing regenerated.

Every removed block was verified **byte-identical** to the copy that was kept — same `resolution` integrity hash, same `engines`, same dependency bodies — before removal, so no resolution information is lost. No package version moves; `pnpm-lock.yaml` is the only file touched.

I deliberately did **not** regenerate the lockfile. A regeneration on top of six same-minute bumps would quietly move unrelated transitive versions and make the diff unreviewable at exactly the moment `main` needs a change that is obviously safe.

## Verification

The decisive check is the command that is failing in CI, run against this branch:

```
$ pnpm install --frozen-lockfile
Scope: all 22 workspace projects
Done in 11.2s using pnpm v10.34.5
$ echo $?
0
```

It fails on `origin/main` and succeeds here. Worth noting the fix took two passes: removing only the `hono` duplicates moved the error to `duplicated mapping key (22000:3)` in the postcss entries, so the first attempt was **not** sufficient and I only found the rest by re-running the real command rather than trusting the first diagnosis. A full within-section duplicate scan now reports zero across `importers:`, `packages:` and `snapshots:`.

Since every failing job died at install, restoring install is what unblocks them; CI on this PR exercises the whole set for real.

## Follow-up worth considering, not part of this fix

This will recur. Dependabot lockfile PRs are only valid against the tree they were built on, so merging several in the same minute without a rebase is the trigger. Options are to require branches be up to date before merge for lockfile-touching PRs, or to group dependabot updates so one PR carries one lockfile change. Happy to open an issue if you want it tracked.
