### PR TITLE
fix(api): dispatch policy remediation instead of simulating completion (#3413)

### DIFF
--- a/apps/api/src/services/policyEvaluationRemediationDispatch.test.ts
+++ b/apps/api/src/services/policyEvaluationRemediationDispatch.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #3413: both remediation triggers inserted an automation_runs row and then
+// flipped it to 'completed' on a setTimeout without ever dispatching, so policy
+// drift showed "remediated" while the device was never touched. The observable
+// guarantee is that the real automation runtime is asked to run the row.
+
+const enqueueAutomationRunMock = vi.fn().mockResolvedValue({ enqueued: true });
+vi.mock('../jobs/automationWorker', () => ({
+  enqueueAutomationRun: (...args: unknown[]) => enqueueAutomationRunMock(...args),
+}));
+
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const updateMock = vi.fn();
+
+vi.mock('../db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    insert: (...args: unknown[]) => insertMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+  },
+}));
+
+vi.mock('./eventBus', () => ({ publishEvent: vi.fn() }));
+vi.mock('./featureConfigResolver', () => ({
+  resolveComplianceRulesForDevice: vi.fn(),
+  scanDueComplianceChecks: vi.fn(),
+}));
+
+import {
+  __triggerConfigPolicyRemediation,
+  __triggerRemediationAutomation,
+} from './policyEvaluationService';
+
+const DEVICE = {
+  id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+  orgId: 'oooooooo-oooo-oooo-oooo-oooooooooooo',
+  hostname: 'WS-1',
+  osType: 'windows',
+  osVersion: '10.0.19045',
+};
+const RUN_ID = 'rrrrrrrr-rrrr-rrrr-rrrr-rrrrrrrrrrrr';
+const AUTOMATION_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const SCRIPT_ID = 'ssssssss-ssss-ssss-ssss-ssssssssssss';
+
+/** Queue results for the successive `.select()` chains each trigger performs. */
+function queueSelects(...results: unknown[][]) {
+  const queue = [...results];
+  selectMock.mockImplementation(() => {
+    const chain: Record<string, unknown> = {};
+    const step = () => chain;
+    chain.from = step;
+    chain.where = step;
+    chain.innerJoin = step;
+    chain.leftJoin = step;
+    chain.limit = () => Promise.resolve(queue.shift() ?? []);
+    chain.then = (resolve: (v: unknown) => unknown) => resolve(queue.shift() ?? []);
+    return chain;
+  });
+}
+
+beforeEach(() => {
+  enqueueAutomationRunMock.mockClear();
+  selectMock.mockReset();
+  insertMock.mockReset();
+  updateMock.mockReset();
+
+  insertMock.mockReturnValue({
+    values: () => ({ returning: () => Promise.resolve([{ id: RUN_ID, logs: [] }]) }),
+  });
+  updateMock.mockReturnValue({
+    set: () => ({ where: () => Promise.resolve(undefined) }),
+  });
+});
+
+describe('policy remediation actually dispatches (#3413)', () => {
+  it('config-policy remediation enqueues the run it just created', async () => {
+    queueSelects(
+      [{ orgId: DEVICE.orgId }],                                   // device org lookup
+      [{ partnerId: null }],                                       // automationOwnershipConditionForOrg
+      [{ id: AUTOMATION_ID, actions: [{ scriptId: SCRIPT_ID }] }], // candidate automations
+      [{ id: AUTOMATION_ID, enabled: true }],                      // the automation row
+    );
+
+    const result = await __triggerConfigPolicyRemediation(
+      {
+        id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        name: 'BitLocker enabled',
+        remediationScriptId: SCRIPT_ID,
+        featureLinkId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+      } as never,
+      DEVICE as never,
+    );
+
+    expect(result).toBe(true);
+    expect(enqueueAutomationRunMock).toHaveBeenCalledTimes(1);
+    // the run it inserted, targeted at exactly the device being remediated
+    expect(enqueueAutomationRunMock).toHaveBeenCalledWith(RUN_ID, [DEVICE.id]);
+  });
+
+  it('does not dispatch when no matching automation exists', async () => {
+    queueSelects(
+      [{ orgId: DEVICE.orgId }],
+      [{ partnerId: null }],
+      [{ id: AUTOMATION_ID, actions: [{ scriptId: 'some-other-script' }] }],
+    );
+
+    const result = await __triggerConfigPolicyRemediation(
+      {
+        id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        name: 'BitLocker enabled',
+        remediationScriptId: SCRIPT_ID,
+        featureLinkId: 'ffffffff-ffff-ffff-ffff-ffffffffffff',
+      } as never,
+      DEVICE as never,
+    );
+
+    expect(result).toBe(false);
+    expect(enqueueAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch when the rule carries no remediation script', async () => {
+    const result = await __triggerConfigPolicyRemediation(
+      { id: 'c1', name: 'no-script', remediationScriptId: null, featureLinkId: 'f1' } as never,
+      DEVICE as never,
+    );
+
+    expect(result).toBe(false);
+    expect(enqueueAutomationRunMock).not.toHaveBeenCalled();
+  });
+
+  it('exports the standalone-policy trigger too, so both paths are covered', () => {
+    // The standalone variant carried the identical simulate-completion stub;
+    // pinning its presence keeps a future refactor from dropping one of them.
+    expect(typeof __triggerRemediationAutomation).toBe('function');
+  });
+});

--- a/apps/api/src/services/policyEvaluationService.ts
+++ b/apps/api/src/services/policyEvaluationService.ts
@@ -1168,31 +1168,20 @@ async function triggerRemediationAutomation(
     })
     .where(eq(automations.id, automation.id));
 
-  // Keep behavior consistent with manual trigger route while avoiding model coupling.
-  setTimeout(async () => {
-    try {
-      await db
-        .update(automationRuns)
-        .set({
-          status: 'completed',
-          devicesSucceeded: 1,
-          completedAt: new Date(),
-          logs: [
-            ...(Array.isArray(run.logs) ? run.logs : []),
-            {
-              timestamp: new Date().toISOString(),
-              level: 'info',
-              message: 'Policy remediation automation completed',
-              policyId: policy.id,
-              deviceId: device.id,
-            },
-          ],
-        })
-        .where(eq(automationRuns.id, run.id));
-    } catch (err) {
-      console.error(`[PolicyEvaluation] Failed to update remediation run ${run.id}:`, err);
-    }
-  }, 1000);
+  // Dispatch through the real automation runtime, the same shape
+  // `automationWorker` uses after inserting a run (:448, :490).
+  // `executeAutomationRun` READS this row rather than creating one, so the
+  // insert above is exactly what it wants and no row shape changes.
+  //
+  // Queued rather than awaited: policy evaluation runs inside a fleet sweep,
+  // and blocking it on script execution would make the sweep's duration a
+  // function of remediation work. `enqueueAutomationRun` falls back to inline
+  // execution when Redis is absent, and its stable `automation-run-<id>` job
+  // id stops a re-entrant sweep double-dispatching the same run.
+  // Dynamically imported so this service does not pull the BullMQ worker graph
+  // in at module load — same pattern as drExecutionService.ts:300.
+  const { enqueueAutomationRun } = await import('../jobs/automationWorker');
+  await enqueueAutomationRun(run.id, [device.id]);
 
   return run.id;
 }
@@ -1894,31 +1883,13 @@ async function triggerConfigPolicyRemediation(
     })
     .where(eq(automations.id, automation.id));
 
-  // Simulate completion (same pattern as standalone policy remediation)
-  setTimeout(async () => {
-    try {
-      await db
-        .update(automationRuns)
-        .set({
-          status: 'completed',
-          devicesSucceeded: 1,
-          completedAt: new Date(),
-          logs: [
-            ...(Array.isArray(run.logs) ? run.logs : []),
-            {
-              timestamp: new Date().toISOString(),
-              level: 'info',
-              message: 'Config policy compliance remediation completed',
-              complianceRuleId: complianceRule.id,
-              deviceId: device.id,
-            },
-          ],
-        })
-        .where(eq(automationRuns.id, run.id));
-    } catch (err) {
-      console.error(`[PolicyEvaluation] Failed to update config policy remediation run ${run.id}:`, err);
-    }
-  }, 1000);
+  // Dispatch for real — see the note in triggerRemediationAutomation. The
+  // returned boolean means DISPATCHED, not finished; the run row carries the
+  // outcome once the runtime has executed it.
+  // Dynamically imported so this service does not pull the BullMQ worker graph
+  // in at module load — same pattern as drExecutionService.ts:300.
+  const { enqueueAutomationRun } = await import('../jobs/automationWorker');
+  await enqueueAutomationRun(run.id, [device.id]);
 
   return true;
 }
@@ -2061,3 +2032,9 @@ export async function scanAndEvaluateConfigPolicyCompliance(): Promise<{
     results: allResults,
   };
 }
+
+// Test-only aliases for the remediation dispatch paths (#3413). Exported
+// rather than renamed so the internal call sites stay untouched; same
+// convention as __evaluateRulesForDevice above.
+export const __triggerRemediationAutomation = triggerRemediationAutomation;
+export const __triggerConfigPolicyRemediation = triggerConfigPolicyRemediation;


### PR DESCRIPTION
Closes #3413.

## What was wrong

Both remediation triggers inserted an `automation_runs` row, marked it `completed` on a `setTimeout(…, 1000)`, and never dispatched anything. Policy drift showed "remediated" runs in history while the device was never touched — a silent no-op that reads as success.

**Both sites, since the issue's "the standalone variant behaves identically" is exactly right:**

| Function | Run insert | Simulation |
|---|---|---|
| `triggerRemediationAutomation` (standalone policy) | `:1138` | `setTimeout` `:1172` |
| `triggerConfigPolicyRemediation` (config policy) | `:1862` | `setTimeout` `:1898` |

The second carried the comment `// Simulate completion (same pattern as standalone policy remediation)`, so this was a deliberate stub that was duplicated, not drift. Fixing only one would have left half the feature lying.

## The fix

Each simulation block becomes a real dispatch:

```ts
const { enqueueAutomationRun } = await import('../jobs/automationWorker');
await enqueueAutomationRun(run.id, [device.id]);
```

**No row-shape change was needed.** `executeAutomationRun(runId, targetDeviceIds?)` (`automationRuntime.ts:1737`) *reads* an existing run rather than creating one, so the insert both sites already do is exactly what the runtime wants. This is the same shape `automationWorker.ts:448` and `:490` use — insert the run, then enqueue it — so the policy paths now agree with every other automation trigger instead of having their own.

**Queued rather than awaited inline**, deliberately: policy evaluation runs inside a fleet sweep, and blocking it on script execution would make the sweep's duration a function of remediation work across every non-compliant device. Two properties of `enqueueAutomationRun` matter here and are why it beats calling the runtime directly:

- it falls back to `executeRunInline` via `setImmediate` when Redis is unavailable, so a self-hoster without Redis gets real execution rather than today's silent no-op;
- its stable `automation-run-<id>` job id means a re-entrant sweep cannot double-dispatch the same run.

**Dynamic import, and this one is not stylistic.** A static `import { enqueueAutomationRun } from '../jobs/automationWorker'` pulls the BullMQ worker graph into `policyEvaluationService` at module load, which reaches `jobs/discoveryWorker` → `services/networkBaseline` and broke `policyManagement_compliance_device.test.ts` with `No "discoveredAssetTypeEnum" export is defined on the "../db/schema" mock`. I could have patched that test's mock, but that would have made every future importer of this service pay for the worker graph. `drExecutionService.ts:300` already uses `await import('../jobs/drExecutionWorker')` for exactly this reason, so the dynamic form is the established pattern rather than a workaround.

## The boolean

`triggerConfigPolicyRemediation` returns `true` and `triggerRemediationAutomation` returns the run id. Both now mean **dispatched**, not finished — the run row carries the outcome once the runtime executes it. That is the honest meaning: the previous `true` claimed completion that had not happened. I raised this on the issue before writing the tests; say the word if you'd rather callers distinguish dispatched from completed and I'll follow up.

## Verification

New `policyEvaluationRemediationDispatch.test.ts`, 4 cases. The two trigger functions are exposed via `__`-prefixed aliases at the bottom of the service, matching the existing `__evaluateRulesForDevice` convention, so no internal call site was renamed.

**Control run:** with both dispatch calls removed, `config-policy remediation enqueues the run it just created` fails. Stated plainly — the other 3 are negative cases (no matching automation, no remediation script) plus an export-presence pin, and they **cannot** fail; they exist to stop the fix over-reaching into paths that should still no-op, not to demonstrate it.

- `tsc --noEmit` (apps/api) — exit 0
- `vitest run` (apps/api, full suite) — **1322 files / 21522 passed**, 37 skipped, exit 0
- Trivy `secret,misconfig` HIGH/CRITICAL on `apps/api/src` — clean, exit 0
- No schema, migration or dependency changes

One file changed (+27/−50, the deletions being the two simulation blocks) plus the new test file.

## Not in scope

`resolvePolicyRemediationAutomationIdForOrg` (`:963`) is still only used to look up an id, as the issue notes. It is a separate resolution helper rather than a dispatch path, and nothing here changes what it does.
