### PR TITLE
fix(api): dispatch the run created by POST /policies/:id/remediate (#3416)

### DIFF
--- a/apps/api/src/routes/policyManagement/actions.ts
+++ b/apps/api/src/routes/policyManagement/actions.ts
@@ -257,6 +257,26 @@ actionRoutes.post(
       })
       .returning({ id: automationRuns.id, status: automationRuns.status, startedAt: automationRuns.startedAt });
 
+    if (!run) {
+      // The insert returned no row, so there is nothing to dispatch. Fail
+      // loudly rather than returning the "triggered" message for a run that
+      // does not exist — claiming success we did not achieve is the very bug
+      // this change removes.
+      return c.json({ error: 'Failed to create remediation run' }, 500);
+    }
+
+    // Dispatch for real. Without this the row sits 'running' forever and no
+    // script executes, while the response still claims the automation was
+    // triggered — the same silent no-op fixed for the two policy-evaluation
+    // sites in #3414. No target argument: this route remediates the policy's
+    // own target set, so the runtime resolves targets from the automation
+    // rather than a single device.
+    //
+    // Dynamically imported to keep the BullMQ worker graph out of this route's
+    // module load, matching policyEvaluationService and drExecutionService.
+    const { enqueueAutomationRun } = await import('../../jobs/automationWorker');
+    await enqueueAutomationRun(run.id);
+
     await db
       .update(automations)
       .set({

--- a/apps/api/src/routes/policyManagement/actionsRemediateDispatch.test.ts
+++ b/apps/api/src/routes/policyManagement/actionsRemediateDispatch.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// #3416: POST /policies/:id/remediate inserted a 'running' automation run and
+// returned "Remediation automation triggered" without ever dispatching, so the
+// row sat running forever and no script executed. Third site of the #3413
+// class; the two policy-evaluation sites were fixed in #3414.
+//
+// This is a STRUCTURAL pin, and the limitation is worth stating: the fix is a
+// single call site inside a long Hono handler that would need the whole
+// auth + permission + org-check + db stack stood up to drive end to end, and a
+// fully mocked version of that stack would assert my mocks rather than the
+// route. Pinning the source shape instead is narrow but honest — it fails if
+// the dispatch is removed, moved before the insert, or given a target argument
+// it must not have. A behavioural test belongs with the integration suite that
+// already stands up this router.
+
+describe('manual policy remediation dispatches the run it creates (#3416)', () => {
+  it('dispatches the inserted run, after the insert, with no target argument', async () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = await readFile(join(here, 'actions.ts'), 'utf8');
+
+    // dispatched at all
+    expect(src).toContain("await import('../../jobs/automationWorker')");
+    expect(src).toContain('await enqueueAutomationRun(run.id);');
+
+    // ordered after the run insert — dispatching a row that does not exist yet
+    // would throw inside the runtime rather than remediate anything
+    const insertIdx = src.indexOf('.insert(automationRuns)');
+    const dispatchIdx = src.indexOf('await enqueueAutomationRun(run.id);');
+    expect(insertIdx).toBeGreaterThan(-1);
+    expect(dispatchIdx).toBeGreaterThan(insertIdx);
+
+    // and NOT narrowed to a device list: this route remediates the policy's own
+    // target set, so the runtime must resolve targets from the automation
+    expect(src).not.toMatch(/enqueueAutomationRun\(run\.id,\s*\[/);
+  });
+});


### PR DESCRIPTION
Closes #3416. Third site of the #3413 class, following the two fixed in #3414 (`f2d7fda83`).

## The change

`POST /policies/:id/remediate` inserted a `status: 'running'` automation run, bumped the automation counters, and returned `"Remediation automation triggered"` — never dispatching. The row sat `running` forever and no script executed, while the response claimed otherwise.

```ts
const { enqueueAutomationRun } = await import('../../jobs/automationWorker');
await enqueueAutomationRun(run.id);
```

**No target argument, deliberately.** This route remediates the policy's own target set, so the runtime resolves targets from the automation. Passing a device list — as the two `#3414` sites correctly do, since each remediates one device — would silently narrow a policy-wide remediation to a single machine. The test pins that it is *not* called that way.

**Dynamic import** to keep the BullMQ worker graph out of this route's module load. Static `jobs/` imports are common in `routes/` (`tenantErasure`, `agentWs`, `agents/eventlogs`), so this is the more conservative of two valid options; I used it because a static import of this particular module is what broke an unrelated partial-schema-mocked test in #3414, and consistency across all three sites of one bug class is worth more than saving a dynamic import.

## A guard the fix required

`.returning(...)` types `run` as possibly `undefined`, which the previous code tolerated because it only echoed `run` back in the response body. Dispatching needs it, so `tsc` failed with `TS18048` — a genuine catch, not a formality.

It now returns **500** rather than the success message when the insert yields no row. Returning `"Remediation automation triggered"` for a run that does not exist would be the same class of lie this issue is about.

## Verification

**Control run:** with the dispatch removed, the test fails.

**Stated plainly — this is a structural pin, not a behavioural one.** The fix is a single call site inside a long Hono handler that would need the whole auth, permission, org-check and db stack stood up to drive end to end, and a fully mocked version of that stack would assert my mocks rather than the route. So the test reads the route source and pins three things: that the dispatch happens at all, that it is ordered *after* the run insert, and that it is not given a device-list argument. It fails on removal, on reordering, and on wrongly narrowing the target — but it does not prove the run executes. A behavioural assertion belongs with the integration suite that already stands this router up.

I dropped a second test I had written first, which called the mocked enqueue directly and asserted its arity: it passed identically with and without the fix, so it was documentation wearing a test's clothes.

- `tsc --noEmit` (apps/api) — exit 0 (after the guard above; exit 2 before it)
- `vitest run` (apps/api, full suite) — **1323 files / 21529 passed**, 37 skipped, exit 0
- Trivy `secret,misconfig` HIGH/CRITICAL on `apps/api/src` — clean, exit 0
- No schema, migration or dependency changes

One file changed (+20), plus the new test.

## Class status

With this, all three known sites of "insert a run, never dispatch" are closed: the two policy-evaluation triggers in #3414 and this manual route. `resolvePolicyRemediationAutomationIdForOrg` remains a lookup helper with no dispatch path, as noted on #3413.
