### PR TITLE
fix(approvals): tenant the suspicious-report audit row to the approval, not the reporter (#3234)

### DIFF
--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -845,12 +845,17 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
       //      transaction poisoned and the commit threw — a 500 that also rolled
       //      back the 'reported' flip immediately above. Catching an error does
       //      not heal a Postgres transaction.
-      //   2. `ai_tool_executions` is org-scoped through its session, so under a
-      //      partner-scoped caller (or an org-scoped one whose accessible-org
-      //      list excludes the execution's org) the UPDATE silently matched
-      //      ZERO rows — no error, no mirror, and the SDK's waitForApproval
-      //      never unblocks with the denial. Same reasoning as the intent CAS
-      //      above, which is already system-scoped for exactly this.
+      //   2. `ai_tool_executions` is org-scoped through an EXISTS join on
+      //      `ai_sessions.org_id`, so whenever the caller's accessible-org list
+      //      does not cover the execution's org the UPDATE silently matched
+      //      ZERO rows — no error (an UPDATE filtered out by a USING clause is
+      //      not a violation, just an empty match), no mirror, and the SDK's
+      //      waitForApproval never unblocks with the denial. Note the trigger
+      //      is the ORG LIST, not the scope: a partner-scoped caller with
+      //      `orgAccess: 'all'` does reach the row, while one with
+      //      `orgAccess: 'selected'` that excludes the org does not — as does
+      //      any org-scoped caller in a different org. Same reasoning as the
+      //      intent CAS above, which is already system-scoped for exactly this.
       // Still best-effort: the approval flip and the audit row are the
       // authoritative record, and a missed mirror only delays the SDK waiter to
       // its own timeout rather than letting the flagged action through.
@@ -898,7 +903,13 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
       ));
     } catch (err) {
       console.error('[approvals] report-suspicious: revocation failed:', err);
-      // Non-fatal: the approval row + audit log are still authoritative; the
+      // Escalated to Sentry, not just stdout: a swallowed failure here means the
+      // client the user just called compromised still holds a live grant and
+      // refresh tokens, while they get a 204. `revokeUserOauthClient` fails
+      // closed on Redis-marker problems, so this catch fires on real infra
+      // faults — exactly the case nobody would notice from a stdout line.
+      captureException(err);
+      // Still non-fatal: the approval row + audit log are authoritative, and the
       // user can revoke from the connected-apps UI as a fallback.
     }
   }
@@ -911,8 +922,9 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
   // request transaction, which is precisely how this endpoint 500'd for every
   // partner-scoped caller:
   //
-  //   - `writeAuditEventAsync` persists via `auditService.persistAuditLog`,
-  //     which runs `runOutsideDbContext(() => withSystemDbAccessContext(...))`.
+  //   - `writeAuditEventAsync` persists via `createAuditLogAsync` →
+  //     `auditService.persistAuditLog`, which runs
+  //     `runOutsideDbContext(() => withSystemDbAccessContext(...))`.
   //     That is what lets a NULL org_id land at all: the `audit_logs` INSERT
   //     policy is `WITH CHECK breeze_has_org_access(org_id)`, and that helper
   //     returns FALSE for a NULL org under any non-system scope but TRUE under
@@ -933,8 +945,15 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
   //
   // `writeAuditEventAsync`'s returned promise never rejects — a genuine write
   // failure is queued for retry with backoff and escalated to Sentry on
-  // exhaustion, so the security action still takes effect with a loud signal
-  // instead of a 500. The try/catch is still not redundant: the function is not
+  // exhaustion, so the security action still takes effect instead of 500ing.
+  // Be precise about how strong that is: `auditService`'s retry queue is
+  // in-memory and bounded (3 attempts, drained every 30s), so it covers a
+  // transient DB blip but NOT an outage that outlives the attempts, and a
+  // process restart landing mid-retry drops the entry with no signal at all.
+  // That is the repo-wide audit durability story rather than anything specific
+  // to this handler; it is still strictly better than the raw insert this
+  // replaced, which had no retry AND poisoned the request transaction.
+  // The try/catch is still not redundant: the function is not
   // `async`, so its synchronous prologue (details sanitizing, trusted-client-IP
   // resolution, header reads) can throw BEFORE the retry-backed promise exists.
   // "The audit machinery must never turn this security action into a 500" is

--- a/apps/api/src/routes/approvals.ts
+++ b/apps/api/src/routes/approvals.ts
@@ -9,7 +9,8 @@ import { approvalRequests } from '../db/schema/approvals';
 import { elevationRequests, elevationAudit } from '../db/schema/elevations';
 import { aiToolExecutions, aiSessions } from '../db/schema/ai';
 import { delegantM365Connections } from '../db/schema/delegant';
-import { auditLogs } from '../db/schema/audit';
+import { writeAuditEventAsync } from '../services/auditEvents';
+import { captureException } from '../services/sentry';
 import {
   actionIntents,
   intentOutbox,
@@ -537,6 +538,64 @@ approvalRoutes.post('/:id/deny', zValidator('json', denySchema), async (c) => {
   return decideHandler(c, 'denied', reason);
 });
 
+/**
+ * Which org the `security.suspicious_report` audit row belongs to (#3234).
+ *
+ * The row must be tenanted to the APPROVAL BEING REPORTED, not to whoever
+ * reported it. `approval_requests` has no `org_id` column of its own, so the
+ * linked `action_intents` row is the only authoritative source; the reporter's
+ * own org is a fallback, and for a partner-scoped caller it is `null`.
+ *
+ * Resolution order (per #3234): linked intent's org → reporter's org → NULL.
+ * NULL is therefore only reached when there is honestly no org to name — an
+ * unlinked row (dev seed / PAM) reported by a partner-scoped user — rather than
+ * being the accidental outcome of reading tenancy off the caller's token, which
+ * is what made the endpoint 500 for every partner-scoped caller.
+ *
+ * Runs in a system-scope context of its own: `action_intents` is org-scoped
+ * (Shape 1) and a partner user with `orgAccess: 'selected'` can legitimately
+ * own an approval for an org outside its curated list, so the request context
+ * is not guaranteed to see the intent. Same reasoning as the flip transaction
+ * above. `runOutsideDbContext` is required, not stylistic — a nested
+ * `withDbAccessContext` short-circuits and RETAINS the ambient scope rather
+ * than elevating (see `db/index.ts`).
+ *
+ * Only called when the flip transaction did NOT run — an already-decided row,
+ * or a row with no linked intent at all (which short-circuits to the caller's
+ * org). When that transaction did run it already read the intent's org under
+ * `FOR UPDATE`, on both CAS outcomes, so there is nothing to look up.
+ *
+ * Never throws. A transient failure here degrades the audit row's tenancy to
+ * the caller's org, which is exactly the old (wrong) behaviour — but losing
+ * attribution on one row beats propagating out of a security action and 500ing
+ * the report, which is the very failure mode #3234 is about.
+ */
+async function resolveReportAuditOrgId(
+  intentId: string | null,
+  callerOrgId: string | null,
+): Promise<string | null> {
+  if (!intentId) return callerOrgId;
+  try {
+    const [intent] = await runOutsideDbContext(() =>
+      withSystemDbAccessContext(() =>
+        db
+          .select({ orgId: actionIntents.orgId })
+          .from(actionIntents)
+          .where(eq(actionIntents.id, intentId))
+          .limit(1),
+      ),
+    );
+    return intent?.orgId ?? callerOrgId;
+  } catch (err) {
+    console.error(
+      '[approvals] report-suspicious: failed to resolve the reported approval\'s org; falling back to the caller org:',
+      err,
+    );
+    captureException(err);
+    return callerOrgId;
+  }
+}
+
 // "This wasn't me." Reports the in-flight approval as malicious, denies it,
 // revokes the requesting OAuth client's grant + refresh tokens, and writes a
 // security audit row. Revocation and the audit row are unconditional — the
@@ -565,7 +624,10 @@ approvalRoutes.post('/:id/deny', zValidator('json', denySchema), async (c) => {
 // the intent transaction rolled back.
 approvalRoutes.post('/:id/report-suspicious', async (c) => {
   const userId = c.get('auth').user.id;
-  const orgId = c.get('auth').orgId ?? null;
+  // The REPORTER's own org, which is only the last-resort tenant for the audit
+  // row below — a partner-scoped caller carries `orgId: null` (#3234). See
+  // `resolveReportAuditOrgId` for the resolution order and why it matters.
+  const callerOrgId = c.get('auth').orgId ?? null;
   const id = c.req.param('id');
   if (!id) return c.json({ error: 'Bad request' }, 400);
 
@@ -587,6 +649,14 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
   // security audit row below are exactly what a user reporting a compromised
   // client needs most when the action already slipped through.
   let intentRaceLost: { finalStatus: ActionIntentStatus | null } | null = null;
+
+  // Set IFF the flip transaction below actually ran and read the linked intent
+  // under `FOR UPDATE`. The object's presence is the signal "we already have an
+  // authoritative read, don't look it up again"; its `orgId` is null only in the
+  // narrow case where the intent row vanished from under the lock. Stays null
+  // when there is no linked intent, or when the flip block was skipped because
+  // the row was already decided — those are the cases that need a lookup.
+  let lockedIntent: { orgId: string | null } | null = null;
 
   // Flip status to 'reported' if still pending, else leave as-is. Either way
   // we treat the report as authoritative for revocation + audit.
@@ -649,8 +719,19 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
         const outcome = await runOutsideDbContext(() =>
           withSystemDbAccessContext(() =>
             db.transaction(async (tx) => {
+              // `orgId` is selected here — not just taken from the CAS
+              // `.returning()` below — because the audit row needs the
+              // intent's org whether or not the CAS wins. On a lost race
+              // `cas` is empty but the report still writes revocation + an
+              // audit row, and that row must still be tenanted to the
+              // approval's org rather than falling back to the reporter's
+              // (which is NULL for a partner-scoped caller, #3234).
               const [locked] = await tx
-                .select({ id: actionIntents.id, status: actionIntents.status })
+                .select({
+                  id: actionIntents.id,
+                  status: actionIntents.status,
+                  orgId: actionIntents.orgId,
+                })
                 .from(actionIntents)
                 .where(eq(actionIntents.id, intentId))
                 .for('update');
@@ -686,7 +767,11 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
                   source: actionIntents.source,
                 });
               if (cas.length === 0) {
-                return { rejected: null, finalIntentStatus: locked?.status ?? null };
+                return {
+                  rejected: null,
+                  finalIntentStatus: locked?.status ?? null,
+                  intentOrgId: locked?.orgId ?? null,
+                };
               }
 
               await tx
@@ -700,10 +785,19 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
                   ),
                 );
 
-              return { rejected: cas[0] ?? null, finalIntentStatus: null };
+              return {
+                rejected: cas[0] ?? null,
+                finalIntentStatus: null,
+                intentOrgId: locked?.orgId ?? null,
+              };
             }),
           ),
         );
+        // Carry the linked intent's org out to the audit write below. Recorded
+        // on BOTH CAS outcomes, so the only report-suspicious path that still
+        // needs a lookup is the one where this whole block never ran (an
+        // already-decided row).
+        lockedIntent = { orgId: outcome.intentOrgId ?? null };
         const rejected = outcome.rejected;
         if (rejected) {
           recordActionIntentEvent({
@@ -742,14 +836,38 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
         .where(and(eq(approvalRequests.id, id), eq(approvalRequests.userId, userId)));
 
       // Mirror to ai_tool_executions so the SDK waiter unblocks with denial.
+      //
+      // Runs in its OWN system-scope transaction, for the same two reasons the
+      // audit write below does (#3234) — this try/catch used to be unable to
+      // deliver on either of its apparent promises:
+      //   1. It could not actually contain a failure. A SQL error here aborts
+      //      the ambient REQUEST transaction, so catching the JS error left the
+      //      transaction poisoned and the commit threw — a 500 that also rolled
+      //      back the 'reported' flip immediately above. Catching an error does
+      //      not heal a Postgres transaction.
+      //   2. `ai_tool_executions` is org-scoped through its session, so under a
+      //      partner-scoped caller (or an org-scoped one whose accessible-org
+      //      list excludes the execution's org) the UPDATE silently matched
+      //      ZERO rows — no error, no mirror, and the SDK's waitForApproval
+      //      never unblocks with the denial. Same reasoning as the intent CAS
+      //      above, which is already system-scoped for exactly this.
+      // Still best-effort: the approval flip and the audit row are the
+      // authoritative record, and a missed mirror only delays the SDK waiter to
+      // its own timeout rather than letting the flagged action through.
       if (existing.executionId) {
+        const executionId = existing.executionId;
         try {
-          await db
-            .update(aiToolExecutions)
-            .set({ status: 'rejected', approvedBy: userId, approvedAt: new Date() })
-            .where(eq(aiToolExecutions.id, existing.executionId));
+          await runOutsideDbContext(() =>
+            withSystemDbAccessContext(() =>
+              db
+                .update(aiToolExecutions)
+                .set({ status: 'rejected', approvedBy: userId, approvedAt: new Date() })
+                .where(eq(aiToolExecutions.id, executionId)),
+            ),
+          );
         } catch (err) {
           console.error('[approvals] report-suspicious: failed to mirror to ai_tool_executions:', err);
+          captureException(err);
         }
       }
     }
@@ -785,10 +903,48 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
     }
   }
 
-  // Audit row — security.suspicious_report, scoped to the user.
+  // Audit row — security.suspicious_report, tenanted to the reported approval.
+  //
+  // Deliberately NOT a raw `db.insert(auditLogs)` inside the request
+  // transaction, and NOT atomic with the approval flip above (#3234). Both
+  // properties are load-bearing; please don't "tidy" this back into the
+  // request transaction, which is precisely how this endpoint 500'd for every
+  // partner-scoped caller:
+  //
+  //   - `writeAuditEventAsync` persists via `auditService.persistAuditLog`,
+  //     which runs `runOutsideDbContext(() => withSystemDbAccessContext(...))`.
+  //     That is what lets a NULL org_id land at all: the `audit_logs` INSERT
+  //     policy is `WITH CHECK breeze_has_org_access(org_id)`, and that helper
+  //     returns FALSE for a NULL org under any non-system scope but TRUE under
+  //     `system`. An org-less report is genuinely unattributable, so writing
+  //     the row NULL-org under system scope beats inventing a tenant.
+  //   - Because it commits independently, a failing audit write can no longer
+  //     abort the caller's transaction. The old inline insert could not be
+  //     rescued by its own try/catch: Postgres aborts the whole TRANSACTION on
+  //     an RLS violation, so the swallowed error resurfaced when the request
+  //     transaction committed — a 500 that ALSO rolled back the 'reported'
+  //     flip, leaving the flagged approval pending. A security action that
+  //     fails open.
+  //   - The lost atomicity is the intended trade, not a side effect: a
+  //     `security.suspicious_report` records that someone reported something,
+  //     which stays true whether or not the flip that followed committed.
+  //     Losing the audit trail when surrounding work rolls back is the worse
+  //     failure for a security action.
+  //
+  // `writeAuditEventAsync`'s returned promise never rejects — a genuine write
+  // failure is queued for retry with backoff and escalated to Sentry on
+  // exhaustion, so the security action still takes effect with a loud signal
+  // instead of a 500. The try/catch is still not redundant: the function is not
+  // `async`, so its synchronous prologue (details sanitizing, trusted-client-IP
+  // resolution, header reads) can throw BEFORE the retry-backed promise exists.
+  // "The audit machinery must never turn this security action into a 500" is
+  // the requirement, so it is enforced here rather than assumed.
+  const auditOrgId = lockedIntent
+    ? (lockedIntent.orgId ?? callerOrgId)
+    : await resolveReportAuditOrgId(existing.intentId, callerOrgId);
   try {
-    await db.insert(auditLogs).values({
-      orgId,
+    await writeAuditEventAsync(c, {
+      orgId: auditOrgId,
       actorType: 'user',
       actorId: userId,
       actorEmail: c.get('auth').user.email,
@@ -803,12 +959,21 @@ approvalRoutes.post('/:id/report-suspicious', async (c) => {
         actionToolName: existing.actionToolName,
         priorStatus: existing.status,
         grantsRevoked,
-        refreshTokensRevoked,
+        // Named `refreshRevocationCount`, NOT `refreshTokensRevoked`, and please
+        // don't rename it back. `writeAuditEventAsync` runs details through
+        // `sanitizeAuditPayload` → `redactLogFields`, whose `SECRET_KEY_PATTERN`
+        // matches the bare substring `token` anywhere in a key. Any key
+        // containing "token" is replaced wholesale with '[REDACTED]', so
+        // `refreshTokensRevoked` would persist as a string sentinel instead of
+        // the integer count — losing real forensic detail about how much access
+        // the report actually tore down. It is a count, never a credential.
+        refreshRevocationCount: refreshTokensRevoked,
       },
       result: 'success',
     });
   } catch (err) {
-    console.error('[approvals] report-suspicious: audit insert failed:', err);
+    console.error('[approvals] report-suspicious: audit write failed:', err);
+    captureException(err);
   }
 
   // The report did NOT stop the action — a concurrent decide already carried

--- a/apps/api/src/routes/approvalsReportSuspiciousPartnerScope.integration.test.ts
+++ b/apps/api/src/routes/approvalsReportSuspiciousPartnerScope.integration.test.ts
@@ -53,8 +53,10 @@ import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { db, withSystemDbAccessContext } from '../db';
 import { actionIntents } from '../db/schema/actionIntents';
+import { aiSessions, aiToolExecutions } from '../db/schema/ai';
 import { approvalRequests } from '../db/schema/approvals';
 import { auditLogs } from '../db/schema/audit';
+import { partnerUsers } from '../db/schema/users';
 import { createActionIntent } from '../services/actionIntents/intentService';
 import { PERMISSIONS } from '../services/permissions';
 import { buildOrgAccessClosures, type AuthContext } from '../middleware/auth';
@@ -76,26 +78,44 @@ const SUSPICIOUS_ACTION = 'security.suspicious_report';
 
 interface Scenario {
   partnerId: string;
-  orgId: string;
+  /**
+   * The org the REPORTED intent belongs to — the org every audit assertion
+   * expects. Deliberately NOT the org on the reporting user's own row.
+   */
+  intentOrgId: string;
+  /**
+   * The reporting user's own `users.org_id` / org membership. Distinct from
+   * `intentOrgId` on purpose: if the two were the same value (the obvious way
+   * to seed this), an assertion of "the audit row carries the intent's org"
+   * would pass just as happily against a wrong implementation that read the
+   * REPORTER's org instead. Keeping them different is what makes the assertion
+   * actually discriminate between the two sources.
+   */
+  reporterOwnOrgId: string;
   user: { id: string; email: string };
-  /** Org-scoped role, used only to CREATE the intent being reported. */
+  /** Org-scoped role in `intentOrgId`, used only to CREATE the intent. */
   orgRoleId: string;
   /** Partner-scoped role, used for the report-suspicious token under test. */
   partnerRoleId: string;
 }
 
 /**
- * One user holding BOTH an org membership and a partner membership. The intent
- * is created with the org-scoped context (so the intent has a real `org_id`
- * and the approval row is owned by this user), and then reported with a
- * PARTNER-scoped token for the same user — which is what makes `auth.orgId`
- * null at the audit write. That combination is the whole point of the suite.
+ * One user holding BOTH an org membership and a partner membership, under a
+ * partner with TWO orgs. The intent is created with an org-scoped context for
+ * org A (so the intent has a real `org_id` and the approval row is owned by
+ * this user), and then reported with a PARTNER-scoped token for the same user —
+ * which is what makes `auth.orgId` null at the audit write. That combination is
+ * the whole point of the suite.
+ *
+ * The user's OWN org is org B, so "audit org == org A" can only hold if the
+ * handler really resolved the org from the linked intent.
  */
 async function seedPartnerScopedReporter(): Promise<Scenario> {
   const partner = await createPartner();
-  const org = await createOrganization({ partnerId: partner.id });
+  const intentOrg = await createOrganization({ partnerId: partner.id });
+  const reporterOwnOrg = await createOrganization({ partnerId: partner.id });
 
-  const orgRole = await createRole({ scope: 'organization', orgId: org.id });
+  const orgRole = await createRole({ scope: 'organization', orgId: intentOrg.id });
   await grantRolePermissions(orgRole.id, [PERMISSIONS.DEVICES_EXECUTE]);
 
   const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
@@ -103,10 +123,12 @@ async function seedPartnerScopedReporter(): Promise<Scenario> {
 
   const user = await createUser({
     partnerId: partner.id,
-    orgId: org.id,
+    orgId: reporterOwnOrg.id,
     email: `partner-reporter-${randomUUID()}@reportsuspicious.test`,
   });
-  await assignUserToOrganization(user.id, org.id, orgRole.id);
+  // Membership in the INTENT's org, so createActionIntent's org-scoped context
+  // is legitimate; the user's own `users.org_id` stays org B.
+  await assignUserToOrganization(user.id, intentOrg.id, orgRole.id);
   // orgAccess 'all' so authMiddleware's computeAccessibleOrgIds resolves the
   // partner's orgs. Note the fix must NOT depend on this: the audit org comes
   // from the intent, not from the caller's reachable-org list.
@@ -114,16 +136,17 @@ async function seedPartnerScopedReporter(): Promise<Scenario> {
 
   return {
     partnerId: partner.id,
-    orgId: org.id,
+    intentOrgId: intentOrg.id,
+    reporterOwnOrgId: reporterOwnOrg.id,
     user: { id: user.id, email: user.email },
     orgRoleId: orgRole.id,
     partnerRoleId: partnerRole.id,
   };
 }
 
-/** Org-scoped AuthContext, used ONLY to create the intent under test. */
+/** Org-scoped AuthContext for the INTENT's org, used ONLY to create the intent. */
 function orgScopedAuth(s: Scenario): AuthContext {
-  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([s.orgId]);
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([s.intentOrgId]);
   return {
     principal: { kind: 'user_session' },
     user: { id: s.user.id, email: s.user.email, name: 'Reporter', isPlatformAdmin: false },
@@ -131,16 +154,16 @@ function orgScopedAuth(s: Scenario): AuthContext {
       sub: s.user.id,
       email: s.user.email,
       roleId: s.orgRoleId,
-      orgId: s.orgId,
+      orgId: s.intentOrgId,
       partnerId: s.partnerId,
       scope: 'organization',
       type: 'access',
       mfa: true,
     },
     partnerId: s.partnerId,
-    orgId: s.orgId,
+    orgId: s.intentOrgId,
     scope: 'organization',
-    accessibleOrgIds: [s.orgId],
+    accessibleOrgIds: [s.intentOrgId],
     orgCondition,
     canAccessOrg,
   };
@@ -219,6 +242,78 @@ async function seedStandaloneApproval(s: Scenario): Promise<string> {
   return row.id;
 }
 
+/**
+ * Narrows the reporter's partner membership so its accessible-org list EXCLUDES
+ * the execution's org (org A), leaving only org B selected.
+ *
+ * This is the precondition for the silent-zero-row mirror bug, and it is worth
+ * being exact about it: the trigger is the accessible-ORG-LIST, not the scope.
+ * A partner-scoped caller with `orgAccess: 'all'` still reaches the execution's
+ * row through `ai_tool_executions`' EXISTS-join policy on `ai_sessions.org_id`,
+ * so the pre-fix mirror would have succeeded and the test would pass for the
+ * wrong reason. Only a caller that genuinely cannot see the org reproduces it.
+ */
+async function narrowReporterToOwnOrgOnly(s: Scenario): Promise<void> {
+  await withSystemDbAccessContext(() =>
+    db
+      .update(partnerUsers)
+      .set({ orgAccess: 'selected', orgIds: [s.reporterOwnOrgId] })
+      .where(and(eq(partnerUsers.userId, s.user.id), eq(partnerUsers.partnerId, s.partnerId))),
+  );
+}
+
+/**
+ * An EXECUTION-linked approval: the legacy AI mobile-push shape, where the row
+ * carries `executionId` instead of `intentId` and the handler must mirror the
+ * denial onto `ai_tool_executions` so the SDK's `waitForApproval` unblocks.
+ *
+ * The execution's session belongs to org A. Combined with
+ * `narrowReporterToOwnOrgOnly`, the reporting caller cannot see that org — the
+ * exact shape that made the mirror UPDATE silently match zero rows before the
+ * fix, because `ai_tool_executions` is org-scoped through `ai_sessions.org_id`
+ * via an EXISTS join policy.
+ */
+async function seedExecutionLinkedApproval(
+  s: Scenario,
+): Promise<{ approvalRowId: string; executionId: string }> {
+  return withSystemDbAccessContext(async () => {
+    const [session] = await db
+      .insert(aiSessions)
+      .values({ orgId: s.intentOrgId, userId: s.user.id, status: 'active', type: 'general' })
+      .returning({ id: aiSessions.id });
+    if (!session) throw new Error('seed: ai_sessions insert returned nothing');
+
+    const [execution] = await db
+      .insert(aiToolExecutions)
+      .values({
+        sessionId: session.id,
+        toolName: 'execute_command',
+        toolInput: { deviceId: randomUUID(), commandType: 'kill_process' },
+        status: 'pending',
+      })
+      .returning({ id: aiToolExecutions.id });
+    if (!execution) throw new Error('seed: ai_tool_executions insert returned nothing');
+
+    const [row] = await db
+      .insert(approvalRequests)
+      .values({
+        userId: s.user.id,
+        executionId: execution.id,
+        requestingClientLabel: 'Execution-Linked Reporter Test',
+        actionLabel: 'Execution-linked suspicious action',
+        actionToolName: 'execute_command',
+        riskTier: 'high',
+        riskSummary: 'seeded execution-linked row for #3234 coverage',
+        status: 'pending',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      })
+      .returning({ id: approvalRequests.id });
+    if (!row) throw new Error('seed: execution-linked approval insert returned nothing');
+
+    return { approvalRowId: row.id, executionId: execution.id };
+  });
+}
+
 /** The security audit row for a given approval, read in a system context. */
 async function readSuspiciousAudit(approvalRowId: string) {
   return withSystemDbAccessContext(async () => {
@@ -276,8 +371,10 @@ describe('report-suspicious as a partner-scoped caller (real Postgres, breeze_ap
       expect(audits).toHaveLength(1);
       // The whole point of #3234: the audit row is tenanted to the approval's
       // org, taken from the linked intent — NOT to the reporter's null org.
-      expect(audits[0]?.orgId).toBe(s.orgId);
-      expect(audits[0]?.orgId).not.toBeNull();
+      expect(audits[0]?.orgId).toBe(s.intentOrgId);
+      // Not the reporter's own org either — the assertion above would pass for
+      // the wrong reason if the seed let those two orgs coincide.
+      expect(audits[0]?.orgId).not.toBe(s.reporterOwnOrgId);
       expect(audits[0]?.actorId).toBe(s.user.id);
       expect(audits[0]?.actorType).toBe('user');
       expect(audits[0]?.result).toBe('success');
@@ -316,7 +413,8 @@ describe('report-suspicious as a partner-scoped caller (real Postgres, breeze_ap
       // CAS `.returning()` (which is empty when the race is lost).
       const audits = await readSuspiciousAudit(approvalRowId);
       expect(audits).toHaveLength(1);
-      expect(audits[0]?.orgId).toBe(s.orgId);
+      expect(audits[0]?.orgId).toBe(s.intentOrgId);
+      expect(audits[0]?.orgId).not.toBe(s.reporterOwnOrgId);
     },
   );
 
@@ -341,7 +439,8 @@ describe('report-suspicious as a partner-scoped caller (real Postgres, breeze_ap
 
       const audits = await readSuspiciousAudit(approvalRowId);
       expect(audits).toHaveLength(1);
-      expect(audits[0]?.orgId).toBe(s.orgId);
+      expect(audits[0]?.orgId).toBe(s.intentOrgId);
+      expect(audits[0]?.orgId).not.toBe(s.reporterOwnOrgId);
       const details = audits[0]?.details as Record<string, unknown>;
       // The prior status is preserved for forensics rather than overwritten.
       expect(details.priorStatus).toBe('approved');
@@ -382,6 +481,55 @@ describe('report-suspicious as a partner-scoped caller (real Postgres, breeze_ap
       // under every other scope. Writing NULL beats inventing a tenant.
       expect(audits[0]?.orgId).toBeNull();
       expect(audits[0]?.actorId).toBe(s.user.id);
+    },
+  );
+
+  runDb(
+    'execution-linked: the ai_tool_executions mirror lands even when the caller cannot see the execution org, unblocking the SDK waiter',
+    async () => {
+      const s = seeded!;
+      const { approvalRowId, executionId } = await seedExecutionLinkedApproval(s);
+      // Without this the caller CAN see org A and the pre-fix mirror would have
+      // worked, making the assertion below pass for the wrong reason.
+      await narrowReporterToOwnOrgOnly(s);
+
+      const res = await reportSuspiciousAsPartner(s, approvalRowId);
+      expect(res.status).toBe(204);
+
+      await withSystemDbAccessContext(async () => {
+        const [row] = await db
+          .select({ status: approvalRequests.status })
+          .from(approvalRequests)
+          .where(eq(approvalRequests.id, approvalRowId));
+        expect(row?.status).toBe('reported');
+
+        const [execution] = await db
+          .select({
+            status: aiToolExecutions.status,
+            approvedBy: aiToolExecutions.approvedBy,
+          })
+          .from(aiToolExecutions)
+          .where(eq(aiToolExecutions.id, executionId));
+        // The mirror is the load-bearing assertion. `ai_tool_executions` is
+        // org-scoped through `ai_sessions.org_id` (EXISTS join policy), so
+        // before the fix this UPDATE silently matched ZERO rows for a caller
+        // that cannot reach the execution's org: no error, no mirror, and the
+        // SDK's waitForApproval never learned the action was denied. It now
+        // runs in its own system-scope transaction. Verified non-vacuous —
+        // reverting just the mirror to the ambient request transaction leaves
+        // this row 'pending' and reds this expectation.
+        expect(execution?.status).toBe('rejected');
+        expect(execution?.approvedBy).toBe(s.user.id);
+      });
+
+      // No linked intent on this shape, so the audit row has no intent org to
+      // inherit and the partner-scoped reporter supplies none — NULL, written
+      // under system scope rather than 500ing. Attribution through
+      // `ai_sessions.org_id` is possible but deliberately out of scope (#3234
+      // settled on intent → caller → NULL); see the PR's follow-ups.
+      const audits = await readSuspiciousAudit(approvalRowId);
+      expect(audits).toHaveLength(1);
+      expect(audits[0]?.orgId).toBeNull();
     },
   );
 });

--- a/apps/api/src/routes/approvalsReportSuspiciousPartnerScope.integration.test.ts
+++ b/apps/api/src/routes/approvalsReportSuspiciousPartnerScope.integration.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Real-Postgres proof that `POST /approvals/:id/report-suspicious` works for a
+ * PARTNER-SCOPED caller, and that the security audit row it writes is tenanted
+ * to the approval being reported rather than to whoever reported it (#3234).
+ *
+ * Why this suite has to exist at all — the coverage split that let #3234 ship:
+ *   - `approvals.test.ts` has exactly the right auth shape (its file-wide auth
+ *     mock is `scope: 'partner', orgId: null`) but mocks `../db` wholesale, so
+ *     RLS never runs and the audit insert is stubbed to always succeed.
+ *   - `approvalsDecideSupervised.integration.test.ts` runs against real
+ *     Postgres as `breeze_app` with RLS enforced, but its `requesterAuth()`
+ *     hardcodes `scope: 'organization'`, so `auth.orgId` is never null.
+ * Neither half can catch the bug: a unit test cannot catch this class at all,
+ * because the failure is a Postgres RLS abort. Only "partner-scoped caller +
+ * real RLS" reproduces it, and that combination existed nowhere.
+ *
+ * The bug: the handler bound the audit row's org from `auth.orgId`, which is
+ * NULL for a partner-scoped token. `audit_logs`' INSERT policy is
+ * `WITH CHECK breeze_has_org_access(org_id)` and `breeze_has_org_access(NULL)`
+ * is FALSE under any non-system scope, so the insert was rejected — and because
+ * the whole request runs in ONE transaction (`withDbAccessContext`), that
+ * aborted the TRANSACTION, not just the statement. The handler's local
+ * try/catch swallowed the JS error, the handler returned 204, and then the
+ * commit threw: a 500 whose rollback ALSO undid the row's flip to 'reported'.
+ * A security action that fails open.
+ *
+ * `approval_requests` is Shape 6 (user-id scoped — see
+ * `2026-05-16-approval-shape6-system-bypass.sql`), so a partner-scoped caller
+ * can always read and flip its OWN approval row. `audit_logs` was the only
+ * table that rejected the write, which is why the fix is about org resolution
+ * and write context, not about the caller's permissions.
+ *
+ * Each case below pins one arm of the accepted resolution chain
+ * (linked intent's org → caller's org → NULL):
+ *   1. CAS wins            → org read from the intent row under FOR UPDATE
+ *   2. CAS loses the race  → same locked read, still correct on the 409 path
+ *   3. row already decided → the flip block never runs; `resolveReportAuditOrgId`
+ *                            looks the intent's org up in a system context
+ *   4. standalone row      → no intent and no caller org: NULL, written under
+ *                            system scope, 204 rather than 500
+ *
+ * Co-located with the route it exercises (per the repo's test-placement
+ * convention) rather than under `src/__tests__/integration/`, so it must be
+ * named explicitly in BOTH `vitest.integration.config.ts` (`include`) and
+ * `vitest.config.ts` (`exclude`) — the same dual hand-list the two sibling
+ * `approvalsDecide*.integration.test.ts` suites use. Miss either edit and it
+ * silently never runs in CI, or reds the no-DB unit job on ECONNREFUSED.
+ */
+import '../__tests__/integration/setup';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { randomUUID } from 'crypto';
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { db, withSystemDbAccessContext } from '../db';
+import { actionIntents } from '../db/schema/actionIntents';
+import { approvalRequests } from '../db/schema/approvals';
+import { auditLogs } from '../db/schema/audit';
+import { createActionIntent } from '../services/actionIntents/intentService';
+import { PERMISSIONS } from '../services/permissions';
+import { buildOrgAccessClosures, type AuthContext } from '../middleware/auth';
+import { createAccessToken, type TokenPayload } from '../services/jwt';
+import {
+  assignUserToOrganization,
+  assignUserToPartner,
+  createOrganization,
+  createPartner,
+  createRole,
+  createUser,
+  grantRolePermissions,
+} from '../__tests__/integration/db-utils';
+import { approvalRoutes } from './approvals';
+
+const runDb = it.runIf(!!process.env.DATABASE_URL);
+
+const SUSPICIOUS_ACTION = 'security.suspicious_report';
+
+interface Scenario {
+  partnerId: string;
+  orgId: string;
+  user: { id: string; email: string };
+  /** Org-scoped role, used only to CREATE the intent being reported. */
+  orgRoleId: string;
+  /** Partner-scoped role, used for the report-suspicious token under test. */
+  partnerRoleId: string;
+}
+
+/**
+ * One user holding BOTH an org membership and a partner membership. The intent
+ * is created with the org-scoped context (so the intent has a real `org_id`
+ * and the approval row is owned by this user), and then reported with a
+ * PARTNER-scoped token for the same user — which is what makes `auth.orgId`
+ * null at the audit write. That combination is the whole point of the suite.
+ */
+async function seedPartnerScopedReporter(): Promise<Scenario> {
+  const partner = await createPartner();
+  const org = await createOrganization({ partnerId: partner.id });
+
+  const orgRole = await createRole({ scope: 'organization', orgId: org.id });
+  await grantRolePermissions(orgRole.id, [PERMISSIONS.DEVICES_EXECUTE]);
+
+  const partnerRole = await createRole({ scope: 'partner', partnerId: partner.id });
+  await grantRolePermissions(partnerRole.id, [PERMISSIONS.DEVICES_EXECUTE]);
+
+  const user = await createUser({
+    partnerId: partner.id,
+    orgId: org.id,
+    email: `partner-reporter-${randomUUID()}@reportsuspicious.test`,
+  });
+  await assignUserToOrganization(user.id, org.id, orgRole.id);
+  // orgAccess 'all' so authMiddleware's computeAccessibleOrgIds resolves the
+  // partner's orgs. Note the fix must NOT depend on this: the audit org comes
+  // from the intent, not from the caller's reachable-org list.
+  await assignUserToPartner(user.id, partner.id, partnerRole.id, 'all');
+
+  return {
+    partnerId: partner.id,
+    orgId: org.id,
+    user: { id: user.id, email: user.email },
+    orgRoleId: orgRole.id,
+    partnerRoleId: partnerRole.id,
+  };
+}
+
+/** Org-scoped AuthContext, used ONLY to create the intent under test. */
+function orgScopedAuth(s: Scenario): AuthContext {
+  const { orgCondition, canAccessOrg } = buildOrgAccessClosures([s.orgId]);
+  return {
+    principal: { kind: 'user_session' },
+    user: { id: s.user.id, email: s.user.email, name: 'Reporter', isPlatformAdmin: false },
+    token: {
+      sub: s.user.id,
+      email: s.user.email,
+      roleId: s.orgRoleId,
+      orgId: s.orgId,
+      partnerId: s.partnerId,
+      scope: 'organization',
+      type: 'access',
+      mfa: true,
+    },
+    partnerId: s.partnerId,
+    orgId: s.orgId,
+    scope: 'organization',
+    accessibleOrgIds: [s.orgId],
+    orgCondition,
+    canAccessOrg,
+  };
+}
+
+/**
+ * A real PARTNER-scoped access token — `orgId: null` is the defining feature,
+ * and the direct cause of #3234. Driven through the genuine `authMiddleware`
+ * (mounted inside `approvals.ts` itself), so the request really does run in a
+ * partner-scope `withDbAccessContext` transaction as `breeze_app`.
+ */
+async function partnerScopedToken(s: Scenario): Promise<string> {
+  const payload: Omit<TokenPayload, 'type'> = {
+    sub: s.user.id,
+    email: s.user.email,
+    roleId: s.partnerRoleId,
+    orgId: null,
+    partnerId: s.partnerId,
+    scope: 'partner',
+    mfa: false,
+    aep: 1,
+    mep: 1,
+    sid: randomUUID(),
+  };
+  return createAccessToken(payload);
+}
+
+async function reportSuspiciousAsPartner(s: Scenario, approvalRowId: string): Promise<Response> {
+  const token = await partnerScopedToken(s);
+  const app = new Hono();
+  app.route('/approvals', approvalRoutes);
+  return app.request(`/approvals/${approvalRowId}/report-suspicious`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+/** Seeds a supervised intent + its single requester-owned approval row. */
+async function seedIntent(s: Scenario): Promise<{ intentId: string; approvalRowId: string }> {
+  const snapshot = await createActionIntent(orgScopedAuth(s), {
+    toolName: 'execute_command',
+    input: { deviceId: randomUUID(), commandType: 'kill_process' },
+    source: 'chat',
+  });
+  expect(snapshot.status).toBe('pending_approval');
+  expect(snapshot.requesterApprovalRequestId).toBeTruthy();
+  return { intentId: snapshot.id, approvalRowId: snapshot.requesterApprovalRequestId! };
+}
+
+/**
+ * A standalone approval row: no intent, no execution, no elevation — the
+ * dev-seed / PAM-less shape that `approval_requests_one_source_chk` permits
+ * (it caps the linkage columns at one, and zero is allowed). Inserted under a
+ * system context because the suite itself runs outside any request scope.
+ * `requestingClientId` is left NULL so the handler skips OAuth revocation and
+ * the case stays focused on the audit write.
+ */
+async function seedStandaloneApproval(s: Scenario): Promise<string> {
+  const [row] = await withSystemDbAccessContext(() =>
+    db
+      .insert(approvalRequests)
+      .values({
+        userId: s.user.id,
+        requestingClientLabel: 'Standalone Reporter Test',
+        actionLabel: 'Standalone suspicious action',
+        actionToolName: 'execute_command',
+        riskTier: 'high',
+        riskSummary: 'seeded standalone row for #3234 coverage',
+        status: 'pending',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      })
+      .returning({ id: approvalRequests.id }),
+  );
+  if (!row) throw new Error('seed: standalone approval row insert returned nothing');
+  return row.id;
+}
+
+/** The security audit row for a given approval, read in a system context. */
+async function readSuspiciousAudit(approvalRowId: string) {
+  return withSystemDbAccessContext(async () => {
+    const rows = await db
+      .select({
+        orgId: auditLogs.orgId,
+        actorId: auditLogs.actorId,
+        actorType: auditLogs.actorType,
+        details: auditLogs.details,
+        result: auditLogs.result,
+      })
+      .from(auditLogs)
+      .where(
+        and(eq(auditLogs.action, SUSPICIOUS_ACTION), eq(auditLogs.resourceId, approvalRowId)),
+      );
+    return rows;
+  });
+}
+
+let seeded: Scenario | null = null;
+
+beforeEach(async () => {
+  seeded = await seedPartnerScopedReporter();
+});
+
+describe('report-suspicious as a partner-scoped caller (real Postgres, breeze_app)', () => {
+  runDb(
+    'intent-linked, CAS wins: 204 (not 500), row reported, and the audit row carries the INTENT org — not the caller null org',
+    async () => {
+      const s = seeded!;
+      const { intentId, approvalRowId } = await seedIntent(s);
+
+      const res = await reportSuspiciousAsPartner(s, approvalRowId);
+
+      // Before the fix this was 500 with
+      // `new row violates row-level security policy for table "audit_logs"`.
+      expect(res.status).toBe(204);
+
+      await withSystemDbAccessContext(async () => {
+        const [row] = await db
+          .select({ status: approvalRequests.status })
+          .from(approvalRequests)
+          .where(eq(approvalRequests.id, approvalRowId));
+        // The flip survived: the audit write can no longer roll it back.
+        expect(row?.status).toBe('reported');
+
+        const [intent] = await db
+          .select({ status: actionIntents.status })
+          .from(actionIntents)
+          .where(eq(actionIntents.id, intentId));
+        expect(intent?.status).toBe('rejected');
+      });
+
+      const audits = await readSuspiciousAudit(approvalRowId);
+      expect(audits).toHaveLength(1);
+      // The whole point of #3234: the audit row is tenanted to the approval's
+      // org, taken from the linked intent — NOT to the reporter's null org.
+      expect(audits[0]?.orgId).toBe(s.orgId);
+      expect(audits[0]?.orgId).not.toBeNull();
+      expect(audits[0]?.actorId).toBe(s.user.id);
+      expect(audits[0]?.actorType).toBe('user');
+      expect(audits[0]?.result).toBe('success');
+      const details = audits[0]?.details as Record<string, unknown>;
+      expect(details.approvalId).toBe(approvalRowId);
+      // Key is `refreshRevocationCount`, not `refreshTokensRevoked`: the audit
+      // sanitizer redacts any key containing the substring "token", which would
+      // turn this integer into the string '[REDACTED]'.
+      expect(details.refreshRevocationCount).toBe(0);
+      expect(details).not.toHaveProperty('refreshTokensRevoked');
+    },
+  );
+
+  runDb(
+    'intent-linked, CAS loses the decide race: 409 already_decided, and the audit row STILL carries the intent org',
+    async () => {
+      const s = seeded!;
+      const { intentId, approvalRowId } = await seedIntent(s);
+
+      // Simulate a concurrent decide committing first, exactly as the sibling
+      // atomicity suite does: the handler's unlocked pre-fetch still enters the
+      // intent branch, then its CAS loses under the FOR UPDATE lock.
+      await withSystemDbAccessContext(() =>
+        db
+          .update(actionIntents)
+          .set({ status: 'approved', decidedAt: new Date(), decidedByUserId: s.user.id })
+          .where(eq(actionIntents.id, intentId)),
+      );
+
+      const res = await reportSuspiciousAsPartner(s, approvalRowId);
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({ error: 'already_decided', finalStatus: 'approved' });
+
+      // Revocation + audit are deliberately unconditional on this path, so the
+      // org must be resolved from the LOCKED intent row rather than from the
+      // CAS `.returning()` (which is empty when the race is lost).
+      const audits = await readSuspiciousAudit(approvalRowId);
+      expect(audits).toHaveLength(1);
+      expect(audits[0]?.orgId).toBe(s.orgId);
+    },
+  );
+
+  runDb(
+    'intent-linked but already decided: the flip block never runs, so the org comes from the system-context intent lookup',
+    async () => {
+      const s = seeded!;
+      const { intentId, approvalRowId } = await seedIntent(s);
+
+      // Take the approval row itself out of 'pending', so the handler skips the
+      // entire flip/CAS block — the one path with no locked intent read, and
+      // the reason `resolveReportAuditOrgId` exists.
+      await withSystemDbAccessContext(() =>
+        db
+          .update(approvalRequests)
+          .set({ status: 'approved', decidedAt: new Date() })
+          .where(eq(approvalRequests.id, approvalRowId)),
+      );
+
+      const res = await reportSuspiciousAsPartner(s, approvalRowId);
+      expect(res.status).toBe(204);
+
+      const audits = await readSuspiciousAudit(approvalRowId);
+      expect(audits).toHaveLength(1);
+      expect(audits[0]?.orgId).toBe(s.orgId);
+      const details = audits[0]?.details as Record<string, unknown>;
+      // The prior status is preserved for forensics rather than overwritten.
+      expect(details.priorStatus).toBe('approved');
+
+      await withSystemDbAccessContext(async () => {
+        // A re-report must not clobber the recorded decision.
+        const [intent] = await db
+          .select({ status: actionIntents.status })
+          .from(actionIntents)
+          .where(eq(actionIntents.id, intentId));
+        expect(intent?.status).toBe('pending_approval');
+      });
+    },
+  );
+
+  runDb(
+    'standalone approval with no intent and a partner-scoped caller: 204 with a NULL-org audit row, rather than a 500',
+    async () => {
+      const s = seeded!;
+      const approvalRowId = await seedStandaloneApproval(s);
+
+      const res = await reportSuspiciousAsPartner(s, approvalRowId);
+      expect(res.status).toBe(204);
+
+      await withSystemDbAccessContext(async () => {
+        const [row] = await db
+          .select({ status: approvalRequests.status })
+          .from(approvalRequests)
+          .where(eq(approvalRequests.id, approvalRowId));
+        expect(row?.status).toBe('reported');
+      });
+
+      const audits = await readSuspiciousAudit(approvalRowId);
+      expect(audits).toHaveLength(1);
+      // There is genuinely no org to name here: no linked intent, and the
+      // reporter is partner-scoped. NULL is insertable only because the write
+      // runs in a system-scope context — `breeze_has_org_access(NULL)` is FALSE
+      // under every other scope. Writing NULL beats inventing a tenant.
+      expect(audits[0]?.orgId).toBeNull();
+      expect(audits[0]?.actorId).toBe(s.user.id);
+    },
+  );
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -104,6 +104,12 @@ export default defineConfig({
       // fail it on connect. Belongs to vitest.integration.config.ts
       // (registered in its include list).
       'src/routes/approvalsDecideSupervised.integration.test.ts',
+      // Partner-scoped report-suspicious real-DB test (#3234): imports
+      // `__tests__/integration/setup` (real postgres pool + autoMigrate) and
+      // lives in src/routes/ outside the `src/__tests__/integration/**` glob,
+      // so the no-DB unit runner would fail it on connect. Belongs to
+      // vitest.integration.config.ts (registered in its include list).
+      'src/routes/approvalsReportSuspiciousPartnerScope.integration.test.ts',
       // Create-path atomicity + tenant-isolation real-DB test (Task 7): imports
       // `__tests__/integration/setup` (real postgres pool + autoMigrate) and
       // lives in src/services/actionIntents/ outside the

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -132,6 +132,15 @@ export default defineConfig({
       // suite (approvals.test.ts), so this is the only coverage that exercises
       // the real modules against real Postgres.
       'src/routes/approvalsDecideSupervised.integration.test.ts',
+      // Co-located real-DB integration test for report-suspicious under a
+      // PARTNER-scoped caller (#3234): the only place that combination exists.
+      // The unit suite (approvals.test.ts) has the right auth shape but mocks
+      // `../db`, so RLS never runs; approvalsDecideSupervised hardcodes
+      // scope 'organization', so auth.orgId is never null. Proves the audit row
+      // is tenanted to the reported approval's org rather than the caller's,
+      // and that the endpoint no longer 500s (and no longer rolls the
+      // 'reported' flip back) when that org is null.
+      'src/routes/approvalsReportSuspiciousPartnerScope.integration.test.ts',
       // Co-located real-DB integration test for the create-path atomicity +
       // tenant isolation (Task 7): injects a DB-level fault into the
       // intent_created outbox insert to prove {intent insert + fan-out + outbox}


### PR DESCRIPTION
## The bug

`POST /api/v1/approvals/:id/report-suspicious` returned **500 for every partner-scoped caller**, and the approval it was meant to stop stayed `pending`:

```json
{"error":"Internal Server Error","message":"new row violates row-level security policy for table \"audit_logs\""}
```

A security action that fails open. Found during v0.104.0 release QA, still live on `main`.

## Root cause

The handler bound the audit row's org from the **caller's own token**:

```ts
const orgId = c.get('auth').orgId ?? null;   // NULL for a partner-scoped token
```

`audit_logs`' INSERT policy is `WITH CHECK breeze_has_org_access(org_id)`, and `breeze_has_org_access(NULL)` returns FALSE under any non-system scope (TRUE under `system`). So the insert was rejected.

The local `try/catch` around it could not prevent the 500, and the reason is structural rather than local. The whole request runs inside **one** Postgres transaction opened by auth middleware (`withDbAccessContext` → `baseDb.transaction`). An RLS violation aborts the **transaction**, not just the statement — so the `catch` swallowed the JS error, the handler ran on and returned 204, and then the commit threw, resurfacing the original error from a frame unrelated to the audit write. Worse, that rollback also undid the row's flip to `reported`.

`approval_requests` is Shape 6 (user-id scoped), so the caller could always read and flip its own row; `audit_logs` was the only table that rejected the write.

## The fix

**1. Resolve the audit org from the approval being reported, not the reporter.** Chain: linked intent's org → reporter's org → NULL. Same defect class as the `remediate_vulnerability` fix in `3716e414d` (#3322/#3379), where the org was resolved from the device rather than the caller's context.

The existing `SELECT ... FOR UPDATE` on `action_intents` now also selects `org_id`, so the intent's org is known on **both** CAS outcomes — the lost-race path still writes revocation and an audit row unconditionally, and that row has to be tenanted correctly too (the CAS `.returning()` is empty there). The already-decided path, where the flip transaction never runs at all, resolves the org through a system-scope lookup that never throws.

NULL is therefore only reached when there is honestly no org to name, rather than being the accidental result of reading tenancy off the caller's token.

**2. Write the audit row through the canonical helper.** The raw `db.insert(auditLogs)` is replaced with `writeAuditEventAsync`. `auditService.persistAuditLog` already performs exactly the required `runOutsideDbContext(() => withSystemDbAccessContext(...))` — and its comment block already names *both* this partner-scope NULL-org bug class and the transaction-poisoning class as the reasons it exists. This handler was simply bypassing the repo's central fix. Routing through it buys:

- the system-scope write, so a genuinely org-less report writes NULL instead of inventing a tenant;
- independent commit, so a failing audit write can no longer abort the caller's transaction;
- the bounded retry queue + Sentry escalation, payload sanitizing, and client IP/UA capture.

The independent commit is **deliberate and commented at the write site** so the next reader doesn't helpfully fold it back into the request transaction and restore the 500. A `security.suspicious_report` records that *someone reported something*, which stays true whether or not the flip that followed committed; losing the trail when surrounding work rolls back is the worse failure for a security action.

The write is still wrapped in `try/catch`: `writeAuditEventAsync` is not `async`, so its synchronous prologue (sanitizing, trusted-IP resolution, header reads) can throw before the retry-backed promise exists. "Audit machinery must never turn this security action into a 500" is enforced rather than assumed.

**3. Same poisoning class in the non-intent branch.** The `ai_tool_executions` mirror also ran inside the request transaction under a `try/catch` that could not heal it, *and* silently matched zero rows for any caller whose accessible-org list excludes the execution's org — no error, no mirror, and the SDK's `waitForApproval` never unblocks with the denial. It now runs in its own system-scope transaction, matching the intent CAS immediately above it.

**4. `refreshTokensRevoked` → `refreshRevocationCount`.** The audit sanitizer's `SECRET_KEY_PATTERN` matches the bare substring `token` anywhere in a key, so the integer count would have persisted as the string `[REDACTED]`. It is a count, never a credential. No consumer read the old key.

Both mounts are fixed **by construction** — `index.ts:1044` and `:1056` share this single handler, so the iOS app's "report suspicious" button on `/api/v1/mobile/approvals/:id/report-suspicious` is covered by the same change.

## Coverage

New `approvalsReportSuspiciousPartnerScope.integration.test.ts`: a **partner-scoped caller against real Postgres as `breeze_app` with RLS enforced**. That combination existed nowhere, which is why the bug survived — `approvals.test.ts` has exactly the right auth shape (`scope: 'partner', orgId: null`) but mocks `../db` wholesale so RLS never runs, and `approvalsDecideSupervised.integration.test.ts` has real RLS but hardcodes `scope: 'organization'`. A unit test cannot catch this class at all, because the abort happens in Postgres.

Four cases, one per arm of the resolution chain:

| Case | Asserts |
|---|---|
| intent-linked, CAS wins | 204 (was 500), row `reported`, intent `rejected`, audit org = intent org |
| intent-linked, CAS loses the race | 409 `already_decided`, audit org still = intent org |
| intent-linked, already decided | flip block skipped → org via the system-context lookup |
| standalone row, no intent | 204 with a NULL-org audit row rather than a 500 |

**All four fail against the unfixed handler** with the exact reported error and pass with the fix — verified by reverting `approvals.ts` to its `main` version and re-running:

```
× intent-linked, CAS wins …            AssertionError: expected 500 to be 204
× intent-linked, CAS loses the race …  AssertionError: expected 500 to be 409
× intent-linked but already decided …  AssertionError: expected 500 to be 204
× standalone approval with no intent … AssertionError: expected 500 to be 204
  cause: PostgresError: new row violates row-level security policy for table "audit_logs"
```

Registered in both hand-maintained lists (`vitest.integration.config.ts` include + `vitest.config.ts` exclude), per the convention its two sibling suites document.

## Verification

| Check | Result |
|---|---|
| `approvals.test.ts` (unit, single-fork) | 88 passed |
| new partner-scope integration suite | 4 passed (and 4 failed pre-fix) |
| `approvalsDecideSupervised` + `approvalsDecideAtomicity` integration | 13 passed total with the new suite |
| `vitest.config.rls.ts` | 22 passed |
| `vitest.config.rls-coverage.ts` | 75 passed |
| `tenantCascade` + `tenant-export-policy` integration | 7 passed |
| `tsc --noEmit` (apps/api) | clean |

Run against a private per-worktree stack (`pnpm test-stack up`) so the shared `:5433` database couldn't contaminate results.

## Schema / registration

No schema change, so no cascade or export-policy registration is due. `audit_logs` was already in `CORE_ORG_CASCADE_DELETE_ORDER` and `AUDIT_ADMIN_REQUIRED_TABLES`; both left intact.

## Known follow-ups (deliberately out of scope)

- **Execution-linked and elevation-linked** approvals reported by a partner-scoped caller still get `org_id = NULL`. An org *could* be derived through `ai_tool_executions → ai_sessions` or `elevation_requests`, but that is beyond the resolution order agreed on the issue and each needs its own join plus test. They no longer 500 — they just carry weaker attribution than the intent-linked case.
- The non-intent flip lacks a `status = 'pending'` CAS and neither it nor the mirror checks affected-row counts, so a concurrent decide can be overwritten while the caller still gets 204. Pre-existing; the intent branch already got this treatment in an earlier fix round.

Closes #3234

🤖 Generated with [Claude Code](https://claude.com/claude-code)
