### PR TITLE
fix(agent): apply the breeze group to the macOS IPC socket, not just create it (#3137)

### DIFF
--- a/agent/installer/macos/postinstall
+++ b/agent/installer/macos/postinstall
@@ -65,8 +65,50 @@ if [ -f "$WATCHDOG_PLIST" ]; then
         launchctl load "$WATCHDOG_PLIST" 2>/dev/null || true
 fi
 
+# Add every logged-in GUI user to the breeze group so their desktop helper can
+# dial the 0660 root:breeze IPC socket. Mirrors the equivalent loop in
+# scripts/install/install-linux.sh. Without this the socket is group-owned by a
+# group nobody is in, and Standard (non-admin) users' helpers are denied
+# (#3133/#3134/#3137).
+#
+# Runs BEFORE the LaunchAgents are bootstrapped below: a helper process inherits
+# its group list when it starts, so membership has to exist first.
+add_console_users_to_breeze_group() {
+    local uid username
+    # NOTE: this script runs under `set -e`, so every test below is written as an
+    # `if`. A bare `[ ... ] && continue` returns non-zero when the test is false
+    # and would abort the whole postinstall.
+    for uid in $(ps -axo uid= -o comm= | grep -i '[lL]oginwindow' | awk '{print $1}' | sort -u); do
+        # macOS gives human accounts UIDs from 500 up; below that are system and
+        # service accounts, which never run a Breeze desktop helper.
+        if ! [ "$uid" -ge 500 ] 2>/dev/null; then
+            continue
+        fi
+        username=$(id -un "$uid" 2>/dev/null) || continue
+        if [ -z "$username" ]; then
+            continue
+        fi
+        if dscl . -read /Groups/breeze GroupMembership 2>/dev/null | tr ' ' '\n' | grep -qx "$username"; then
+            continue
+        fi
+        if dscl . -append /Groups/breeze GroupMembership "$username" 2>/dev/null; then
+            echo "Added $username to the breeze group for desktop-helper socket access"
+        else
+            echo "Warning: could not add $username to the breeze group; that user's desktop helper will be denied the agent socket" >&2
+        fi
+    done
+}
+
 # Create breeze group for IPC socket access.
 ensure_breeze_group
+add_console_users_to_breeze_group
+
+# Group-own the config directory so anything created inside it inherits the
+# breeze group under BSD semantics. The daemon chowns agent.sock explicitly on
+# every start (sessionbroker.setupSocket); this is defence in depth. Mode is
+# unchanged — agent.yaml is deliberately world-readable for the user helper
+# (#2483) and secrets.yaml stays 0600 root-only.
+chgrp breeze "$CONFIG_DIR" 2>/dev/null || true
 
 # Stop existing service if running
 launchctl bootout system/com.breeze.agent 2>/dev/null || true

--- a/agent/installer/macos/postinstall
+++ b/agent/installer/macos/postinstall
@@ -65,6 +65,11 @@ if [ -f "$WATCHDOG_PLIST" ]; then
         launchctl load "$WATCHDOG_PLIST" 2>/dev/null || true
 fi
 
+# breeze_group_has_member reports whether $1 is in the breeze group.
+breeze_group_has_member() {
+    dscl . -read /Groups/breeze GroupMembership 2>/dev/null | tr ' ' '\n' | grep -qx "$1"
+}
+
 # Add every logged-in GUI user to the breeze group so their desktop helper can
 # dial the 0660 root:breeze IPC socket. Mirrors the equivalent loop in
 # scripts/install/install-linux.sh. Without this the socket is group-owned by a
@@ -75,9 +80,10 @@ fi
 # its group list when it starts, so membership has to exist first.
 add_console_users_to_breeze_group() {
     local uid username
-    # NOTE: this script runs under `set -e`, so every test below is written as an
-    # `if`. A bare `[ ... ] && continue` returns non-zero when the test is false
-    # and would abort the whole postinstall.
+    # This script runs under `set -e`. The `|| continue` on the id lookup is
+    # load-bearing: a bare failing assignment would abort the whole postinstall.
+    # (A failing `[ ... ] && continue` would NOT — set -e exempts a command that
+    # is part of an && list other than the last one.)
     for uid in $(ps -axo uid= -o comm= | grep -i '[lL]oginwindow' | awk '{print $1}' | sort -u); do
         # macOS gives human accounts UIDs from 500 up; below that are system and
         # service accounts, which never run a Breeze desktop helper.
@@ -88,10 +94,13 @@ add_console_users_to_breeze_group() {
         if [ -z "$username" ]; then
             continue
         fi
-        if dscl . -read /Groups/breeze GroupMembership 2>/dev/null | tr ' ' '\n' | grep -qx "$username"; then
+        if breeze_group_has_member "$username"; then
             continue
         fi
-        if dscl . -append /Groups/breeze GroupMembership "$username" 2>/dev/null; then
+        dscl . -append /Groups/breeze GroupMembership "$username" 2>/dev/null || true
+        # Verify by re-reading rather than trusting dscl's exit status, so the
+        # success line below cannot claim a membership that did not take.
+        if breeze_group_has_member "$username"; then
             echo "Added $username to the breeze group for desktop-helper socket access"
         else
             echo "Warning: could not add $username to the breeze group; that user's desktop helper will be denied the agent socket" >&2
@@ -108,7 +117,8 @@ add_console_users_to_breeze_group
 # every start (sessionbroker.setupSocket); this is defence in depth. Mode is
 # unchanged — agent.yaml is deliberately world-readable for the user helper
 # (#2483) and secrets.yaml stays 0600 root-only.
-chgrp breeze "$CONFIG_DIR" 2>/dev/null || true
+chgrp breeze "$CONFIG_DIR" 2>/dev/null || \
+    echo "Warning: could not group-own $CONFIG_DIR as breeze" >&2
 
 # Stop existing service if running
 launchctl bootout system/com.breeze.agent 2>/dev/null || true

--- a/agent/internal/agentapp/ipc_prereq_order.go
+++ b/agent/internal/agentapp/ipc_prereq_order.go
@@ -1,0 +1,39 @@
+package agentapp
+
+// installIPCPrereqsThenHelpers runs the macOS install steps in the one order
+// that works, and exists purely so that order is enforced by a test instead of
+// by a comment.
+//
+// The ordering is the whole bug in #3133/#3134/#3137. A desktop helper inherits
+// its group list when its process starts, so:
+//
+//  1. the breeze group must exist,
+//  2. the console users must be members of it,
+//  3. only then may the helper LaunchAgents be bootstrapped.
+//
+// `service install` previously bootstrapped the helpers first, so every helper
+// it started was outside the group that owns the IPC socket and was denied.
+//
+// ensureGroup is fatal — without the group there is nothing for the socket to
+// belong to, and a silent partial install is worse than a loud failure.
+// ensureMembers is not: one unresolvable console user must not fail an install
+// that works for everyone else, and the daemon re-attempts membership on every
+// helper start anyway.
+//
+// Lives in an untagged file on purpose. Its darwin caller cannot be tested by
+// the blocking CI jobs (`test-agent` is ubuntu, `test-agent-windows` is windows,
+// and the macOS `test-agent-race` job is not in ci-success's needs), so keeping
+// the ordering contract platform-independent is what puts it under a required
+// check.
+func installIPCPrereqsThenHelpers(
+	ensureGroup func() error,
+	ensureMembers func(),
+	bootstrapHelpers func(),
+) error {
+	if err := ensureGroup(); err != nil {
+		return err
+	}
+	ensureMembers()
+	bootstrapHelpers()
+	return nil
+}

--- a/agent/internal/agentapp/ipc_prereq_order_test.go
+++ b/agent/internal/agentapp/ipc_prereq_order_test.go
@@ -1,0 +1,73 @@
+package agentapp
+
+import (
+	"errors"
+	"testing"
+)
+
+// Untagged so this runs on the required `test-agent` (ubuntu) job. The ordering
+// it pins is the exact regression that shipped in #3133/#3134/#3137, and the
+// darwin caller itself is only reachable on the non-blocking macOS job.
+
+func TestInstallIPCPrereqsThenHelpersOrdering(t *testing.T) {
+	var calls []string
+	err := installIPCPrereqsThenHelpers(
+		func() error { calls = append(calls, "group"); return nil },
+		func() { calls = append(calls, "members") },
+		func() { calls = append(calls, "helpers") },
+	)
+	if err != nil {
+		t.Fatalf("installIPCPrereqsThenHelpers: %v", err)
+	}
+	want := []string{"group", "members", "helpers"}
+	if len(calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Fatalf("calls = %v, want %v — a helper bootstrapped before group membership "+
+				"exists inherits no breeze group and is denied the IPC socket (#3137)", calls, want)
+		}
+	}
+}
+
+func TestInstallIPCPrereqsThenHelpersAbortsWhenTheGroupCannotBeCreated(t *testing.T) {
+	sentinel := errors.New("no free gid")
+	membersCalled := false
+	helpersCalled := false
+	err := installIPCPrereqsThenHelpers(
+		func() error { return sentinel },
+		func() { membersCalled = true },
+		func() { helpersCalled = true },
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want it to wrap %v", err, sentinel)
+	}
+	// Without a group there is nothing to add members to and nothing for the
+	// socket to belong to; continuing would produce a silently broken install.
+	if membersCalled {
+		t.Error("membership was attempted after the group could not be created")
+	}
+	if helpersCalled {
+		t.Error("helpers were bootstrapped after the group could not be created")
+	}
+}
+
+func TestInstallIPCPrereqsThenHelpersStillBootstrapsWhenMembershipIsBestEffort(t *testing.T) {
+	// ensureMembers has no error return by design: one unresolvable console user
+	// must not fail an install that works for everyone else, and the daemon
+	// retries membership on every helper start. Assert the helpers still get
+	// bootstrapped so a partial membership result cannot strand remote desktop.
+	helpersCalled := false
+	err := installIPCPrereqsThenHelpers(
+		func() error { return nil },
+		func() {},
+		func() { helpersCalled = true },
+	)
+	if err != nil {
+		t.Fatalf("installIPCPrereqsThenHelpers: %v", err)
+	}
+	if !helpersCalled {
+		t.Error("helpers were not bootstrapped")
+	}
+}

--- a/agent/internal/agentapp/service_cmd_darwin.go
+++ b/agent/internal/agentapp/service_cmd_darwin.go
@@ -231,19 +231,20 @@ var serviceInstallCmd = &cobra.Command{
 			fmt.Printf("LaunchAgent plist installed to %s\n", darwinDesktopLoginWindowPlistDst)
 		}
 
-		// Create the breeze group and put the logged-in console users in it
-		// BEFORE bootstrapping the helper LaunchAgents. A helper inherits its
-		// group list when it starts, so a helper bootstrapped first would not be
-		// in the group that owns the IPC socket and would be denied
-		// (#3133/#3134/#3137). This ordering was previously reversed.
-		if err := ensureDarwinBreezeGroup(); err != nil {
+		// Create the breeze group, put the logged-in console users in it, and only
+		// THEN bootstrap the helper LaunchAgents so the desktop helper connects
+		// right away rather than waiting for the first heartbeat. A helper
+		// inherits its group list when it starts, so a helper bootstrapped first
+		// would not be in the group that owns the IPC socket and would be denied
+		// (#3133/#3134/#3137). This ordering was previously reversed; it is
+		// pinned by TestInstallIPCPrereqsThenHelpersOrdering.
+		if err := installIPCPrereqsThenHelpers(
+			ensureDarwinBreezeGroup,
+			ensureDarwinBreezeGroupConsoleMembers,
+			bootstrapDesktopHelperPlists,
+		); err != nil {
 			return err
 		}
-		ensureDarwinBreezeGroupConsoleMembers()
-
-		// Immediately load the helper LaunchAgents so the desktop helper connects
-		// right away rather than waiting for the first heartbeat.
-		bootstrapDesktopHelperPlists()
 
 		fmt.Println()
 		fmt.Println("Breeze Agent service installed.")

--- a/agent/internal/agentapp/service_cmd_darwin.go
+++ b/agent/internal/agentapp/service_cmd_darwin.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/breeze-rmm/agent/internal/config"
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
 	"github.com/spf13/cobra"
 )
 
@@ -228,14 +231,19 @@ var serviceInstallCmd = &cobra.Command{
 			fmt.Printf("LaunchAgent plist installed to %s\n", darwinDesktopLoginWindowPlistDst)
 		}
 
-		// Immediately load the helper LaunchAgents so the desktop helper connects
-		// right away rather than waiting for the first heartbeat.
-		bootstrapDesktopHelperPlists()
-
-		// Create breeze group for IPC socket access without assuming a fixed GID.
+		// Create the breeze group and put the logged-in console users in it
+		// BEFORE bootstrapping the helper LaunchAgents. A helper inherits its
+		// group list when it starts, so a helper bootstrapped first would not be
+		// in the group that owns the IPC socket and would be denied
+		// (#3133/#3134/#3137). This ordering was previously reversed.
 		if err := ensureDarwinBreezeGroup(); err != nil {
 			return err
 		}
+		ensureDarwinBreezeGroupConsoleMembers()
+
+		// Immediately load the helper LaunchAgents so the desktop helper connects
+		// right away rather than waiting for the first heartbeat.
+		bootstrapDesktopHelperPlists()
 
 		fmt.Println()
 		fmt.Println("Breeze Agent service installed.")
@@ -607,27 +615,67 @@ func bootstrapDesktopHelperPlists() {
 	}
 }
 
+// ensureDarwinBreezeGroup creates the breeze group that owns the agent's IPC
+// socket. It delegates to sessionbroker so the daemon (which re-ensures the
+// group on every start, in setupSocket) and this install path cannot drift.
 func ensureDarwinBreezeGroup() error {
-	const script = `
-set -e
-if dscl . -read /Groups/breeze >/dev/null 2>&1; then
-  dscl . -read /Groups/breeze PrimaryGroupID >/dev/null
-  exit 0
-fi
-gid=350
-while [ "$gid" -le 499 ]; do
-  if ! dscl . -list /Groups PrimaryGroupID 2>/dev/null | awk '{print $2}' | grep -qx "$gid"; then
-    dscl . -create /Groups/breeze
-    dscl . -create /Groups/breeze PrimaryGroupID "$gid"
-    exit 0
-  fi
-  gid=$((gid + 1))
-done
-echo "no free local system GID available for breeze group" >&2
-exit 1
-`
-	if out, err := exec.Command("/bin/sh", "-c", script).CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to ensure breeze group: %w: %s", err, strings.TrimSpace(string(out)))
+	if err := sessionbroker.EnsureIPCGroup(); err != nil {
+		return fmt.Errorf("failed to ensure %s group: %w", sessionbroker.IPCGroupName, err)
 	}
 	return nil
+}
+
+// ensureDarwinBreezeGroupConsoleMembers adds every logged-in GUI user to the
+// breeze group so their desktop helper can dial the 0660 root:breeze IPC socket.
+//
+// Non-fatal by design: failing the whole install because one console user could
+// not be resolved would be worse than an install that works for everyone else,
+// and the daemon retries this on every helper (re)start anyway.
+func ensureDarwinBreezeGroupConsoleMembers() {
+	for _, username := range darwinConsoleUsernames() {
+		added, err := sessionbroker.EnsureIPCGroupMember(username)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not add %s to the %s group (%v); that user's desktop helper will be denied the agent socket\n",
+				username, sessionbroker.IPCGroupName, err)
+			continue
+		}
+		if added {
+			fmt.Printf("Added %s to the %s group for desktop-helper socket access\n", username, sessionbroker.IPCGroupName)
+		}
+	}
+}
+
+// darwinConsoleUsernames lists the usernames with a GUI (loginwindow) session,
+// excluding root and system/service accounts.
+func darwinConsoleUsernames() []string {
+	out, err := exec.Command("ps", "-axo", "uid=,comm=").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not enumerate GUI sessions for %s group membership: %v\n",
+			sessionbroker.IPCGroupName, err)
+		return nil
+	}
+	var names []string
+	seen := map[string]bool{}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(fields[len(fields)-1]), "loginwindow") {
+			continue
+		}
+		uid, err := strconv.Atoi(fields[0])
+		// macOS assigns human accounts UIDs from 500 up; below that are system
+		// and service accounts, which never run a Breeze desktop helper.
+		if err != nil || uid < 500 {
+			continue
+		}
+		u, err := user.LookupId(fields[0])
+		if err != nil || seen[u.Username] {
+			continue
+		}
+		seen[u.Username] = true
+		names = append(names, u.Username)
+	}
+	return names
 }

--- a/agent/internal/heartbeat/handlers_desktop_helper.go
+++ b/agent/internal/heartbeat/handlers_desktop_helper.go
@@ -739,9 +739,16 @@ var darwinHelperPlists = map[string]string{
 `,
 }
 
-// ensureDarwinHelperPlists writes any missing LaunchAgent plists to disk.
-// The agent runs as root so it can write to /Library/LaunchAgents/.
-func ensureDarwinHelperPlists() {
+// ensureDarwinHelperPrereqs prepares everything a macOS desktop helper needs
+// before it is started: its LaunchAgent plists on disk, and breeze-group
+// membership for the logged-in GUI users so the helper can actually dial the
+// agent's IPC socket (#3133/#3134/#3137).
+//
+// Both must happen before any launchctl kickstart/bootstrap — a helper reads its
+// plist and inherits its group list at start — so every caller invokes this
+// first. The agent runs as root, so it can write to /Library/LaunchAgents/ and
+// edit the group.
+func ensureDarwinHelperPrereqs() {
 	if runtime.GOOS != "darwin" {
 		return
 	}
@@ -755,14 +762,16 @@ func ensureDarwinHelperPlists() {
 			log.Info("installed helper LaunchAgent plist", "path", path)
 		}
 	}
+	ensureDarwinHelperIPCGroupMembership()
 }
 
 // spawnHelperForDesktop spawns a user helper in the target session.
 // If targetSession is empty, it auto-detects the first active non-services session.
 func (h *Heartbeat) spawnHelperForDesktop(targetSession string) error {
 	if runtime.GOOS == "darwin" {
-		// Ensure LaunchAgent plists exist on disk before any kickstart/bootstrap.
-		ensureDarwinHelperPlists()
+		// Ensure the LaunchAgent plists exist on disk and the console users are
+		// in the breeze group before any kickstart/bootstrap.
+		ensureDarwinHelperPrereqs()
 
 		if uids := findGUIUserUIDs(); len(uids) > 0 {
 			bootstrapped := false
@@ -901,7 +910,7 @@ func kickstartDarwinDesktopHelpers() {
 	if runtime.GOOS != "darwin" {
 		return
 	}
-	ensureDarwinHelperPlists()
+	ensureDarwinHelperPrereqs()
 
 	uids := findGUIUserUIDs()
 	for _, uid := range uids {

--- a/agent/internal/heartbeat/helper_group.go
+++ b/agent/internal/heartbeat/helper_group.go
@@ -1,0 +1,22 @@
+package heartbeat
+
+import "strconv"
+
+// minGUIUIDForIPCGroup is the first UID macOS assigns to a human account.
+// Everything below 500 is a system/service account (`_windowserver`, `_spotlight`,
+// …) which never runs a Breeze desktop helper, so those must not be appended to
+// the breeze group — widening a privileged group to service accounts for no
+// benefit.
+const minGUIUIDForIPCGroup = 500
+
+// guiUIDEligibleForIPCGroup reports whether a UID string from findGUIUserUIDs
+// belongs to a human console account that should be a member of the breeze
+// group. Root (0) is excluded because the login-window helper already runs as
+// root and needs no group membership.
+func guiUIDEligibleForIPCGroup(uid string) (int, bool) {
+	n, err := strconv.Atoi(uid)
+	if err != nil || n < minGUIUIDForIPCGroup {
+		return 0, false
+	}
+	return n, true
+}

--- a/agent/internal/heartbeat/helper_group_darwin.go
+++ b/agent/internal/heartbeat/helper_group_darwin.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+package heartbeat
+
+import (
+	"os/user"
+
+	"github.com/breeze-rmm/agent/internal/sessionbroker"
+)
+
+// ensureDarwinHelperIPCGroupMembership puts every logged-in GUI user in the
+// breeze group so their desktop helper can dial the 0660 root:breeze IPC socket.
+//
+// The socket half of #3133/#3134/#3137 (group-owning the socket) is useless on
+// its own: an admin installs the agent, then a Standard user logs in, and that
+// user is in no group the socket grants. The installers add users who are logged
+// in at install time, which misses every later login — hence this runs from the
+// daemon whenever it touches the helper LaunchAgents (login, session switch,
+// self-update kickstart), so a user who logs in for the first time months after
+// install still gets membership.
+//
+// Deliberately called BEFORE any launchctl kickstart/bootstrap: a helper process
+// picks up its group list when it starts, so membership must exist first.
+func ensureDarwinHelperIPCGroupMembership() {
+	for _, uid := range findGUIUserUIDs() {
+		if _, ok := guiUIDEligibleForIPCGroup(uid); !ok {
+			continue
+		}
+		u, err := user.LookupId(uid)
+		if err != nil {
+			log.Warn("could not resolve GUI uid to a username for IPC group membership",
+				"uid", uid, "group", sessionbroker.IPCGroupName, "error", err.Error())
+			continue
+		}
+		added, err := sessionbroker.EnsureIPCGroupMember(u.Username)
+		if err != nil {
+			log.Warn("could not add console user to IPC group; that user's desktop helper will be denied the agent socket",
+				"user", u.Username, "group", sessionbroker.IPCGroupName, "error", err.Error())
+			continue
+		}
+		if added {
+			log.Info("added console user to IPC group for desktop-helper socket access",
+				"user", u.Username, "group", sessionbroker.IPCGroupName)
+		}
+	}
+}

--- a/agent/internal/heartbeat/helper_group_other.go
+++ b/agent/internal/heartbeat/helper_group_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package heartbeat
+
+// ensureDarwinHelperIPCGroupMembership is a no-op off macOS. Linux adds logged-in
+// users to the breeze group in scripts/install/install-linux.sh; Windows helpers
+// use a named pipe with its own SDDL rather than a filesystem group.
+func ensureDarwinHelperIPCGroupMembership() {}

--- a/agent/internal/heartbeat/helper_group_test.go
+++ b/agent/internal/heartbeat/helper_group_test.go
@@ -2,9 +2,15 @@ package heartbeat
 
 import "testing"
 
-// Untagged on purpose: CI has no macOS runner, so a //go:build darwin test would
-// run nowhere (#3019/#3046). The eligibility predicate is pure, so it is covered
-// on both the ubuntu and windows CI jobs.
+// Untagged on purpose. A //go:build darwin test would only ever run on the macOS
+// `test-agent-race` job, which is not in ci-success's needs list and therefore
+// cannot block a merge (#3019/#3046 is the same lesson). The eligibility
+// predicate is pure, so keeping it untagged puts it under the REQUIRED ubuntu
+// `test-agent` job.
+//
+// It does not run on `test-agent-windows`: that job names an explicit package
+// list which omits internal/heartbeat (pre-existing carve-out, #2523). Ubuntu
+// plus the macOS race job is the real coverage.
 
 func TestGUIUIDEligibleForIPCGroup(t *testing.T) {
 	tests := []struct {

--- a/agent/internal/heartbeat/helper_group_test.go
+++ b/agent/internal/heartbeat/helper_group_test.go
@@ -1,0 +1,41 @@
+package heartbeat
+
+import "testing"
+
+// Untagged on purpose: CI has no macOS runner, so a //go:build darwin test would
+// run nowhere (#3019/#3046). The eligibility predicate is pure, so it is covered
+// on both the ubuntu and windows CI jobs.
+
+func TestGUIUIDEligibleForIPCGroup(t *testing.T) {
+	tests := []struct {
+		name   string
+		uid    string
+		want   int
+		wantOK bool
+	}{
+		{name: "first human uid", uid: "501", want: 501, wantOK: true},
+		{name: "second human uid", uid: "502", want: 502, wantOK: true},
+		{name: "boundary is eligible", uid: "500", want: 500, wantOK: true},
+		// Root's loginwindow is the system login UI, not a user session; adding
+		// root to the breeze group would be pointless and misleading.
+		{name: "root rejected", uid: "0", wantOK: false},
+		// Service accounts (_windowserver, _spotlight, …) never run a Breeze
+		// desktop helper, so they must not widen the breeze group.
+		{name: "service account rejected", uid: "88", wantOK: false},
+		{name: "just below the boundary rejected", uid: "499", wantOK: false},
+		{name: "non-numeric rejected", uid: "root", wantOK: false},
+		{name: "empty rejected", uid: "", wantOK: false},
+		{name: "negative rejected", uid: "-1", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := guiUIDEligibleForIPCGroup(tc.uid)
+			if ok != tc.wantOK {
+				t.Fatalf("guiUIDEligibleForIPCGroup(%q) ok = %v, want %v", tc.uid, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Errorf("guiUIDEligibleForIPCGroup(%q) = %d, want %d", tc.uid, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent/internal/sessionbroker/broker_unix.go
+++ b/agent/internal/sessionbroker/broker_unix.go
@@ -55,11 +55,21 @@ func (b *Broker) setupSocket() (net.Listener, error) {
 			"remedy", "reinstall the agent, or create the group manually, to restore user-helper IPC",
 			"error", resolveErr.Error())
 	}
-	if err := applySocketOwner(b.socketPath, owner, os.Chown, os.Chmod); err != nil {
-		listener.Close()
-		return nil, err
+	res := applySocketOwner(b.socketPath, owner, os.Chown, os.Chmod)
+	if res.ChownErr != nil {
+		// Non-fatal for the same reason as the lookup failure above: a socket only
+		// root can reach still serves the watchdog and backup IPC, whereas no
+		// socket at all serves nothing.
+		log.Warn("could not group-own the IPC socket; user-session helpers will be denied",
+			"group", IPCGroupName, "socket", b.socketPath, "error", res.ChownErr.Error())
 	}
-	if owner.GID >= 0 {
+	if res.ChmodErr != nil {
+		// Fatal: the socket would keep net.Listen's umask-derived mode, which is
+		// the one case that could be more permissive than intended. Fail closed.
+		listener.Close()
+		return nil, res.ChmodErr
+	}
+	if owner.GID >= 0 && res.ChownErr == nil {
 		log.Info("IPC socket permissions applied",
 			"socket", b.socketPath, "group", IPCGroupName, "gid", owner.GID, "mode", fmt.Sprintf("%#o", owner.Mode))
 	}

--- a/agent/internal/sessionbroker/broker_unix.go
+++ b/agent/internal/sessionbroker/broker_unix.go
@@ -22,6 +22,15 @@ func (b *Broker) setupSocket() (net.Listener, error) {
 		return nil, fmt.Errorf("chmod %s: %w", dir, err)
 	}
 
+	// The breeze group must exist before the socket can be group-owned by it.
+	// Ensuring it here — on every daemon start — is what makes the socket come
+	// back correctly after a reboot or `launchctl kickstart -k
+	// system/com.breeze.agent`, not just at first install (#3133/#3134/#3137).
+	if err := EnsureIPCGroup(); err != nil {
+		log.Warn("could not ensure IPC socket group; non-admin user helpers may be denied",
+			"group", IPCGroupName, "error", err.Error())
+	}
+
 	listener, err := net.Listen("unix", b.socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("listen %s: %w", b.socketPath, err)
@@ -29,9 +38,30 @@ func (b *Broker) setupSocket() (net.Listener, error) {
 
 	// Allow normal user helpers to traverse the directory and connect to the
 	// socket. Peer credential verification and binary checks remain the gate.
-	if err := os.Chmod(b.socketPath, 0660); err != nil {
+	//
+	// The mode alone is not enough: a root-created socket inherits a group the
+	// console user is not in (`admin` on macOS, where BSD semantics take the
+	// parent directory's group), so 0660 silently locked out every Standard
+	// user's helper. Group-own it explicitly.
+	owner, resolveErr := resolveSocketOwner(ipcGroupIDLookup)
+	if resolveErr != nil {
+		// Deliberately not fatal. Aborting here would leave the agent with no
+		// IPC socket at all, killing remote desktop, backup IPC and the
+		// watchdog link — strictly worse than a socket only root can reach,
+		// which is the pre-fix status quo. Warn loudly with the remedy instead.
+		log.Warn("IPC socket group could not be resolved; user-session helpers will be denied until it exists",
+			"group", IPCGroupName,
+			"socket", b.socketPath,
+			"remedy", "reinstall the agent, or create the group manually, to restore user-helper IPC",
+			"error", resolveErr.Error())
+	}
+	if err := applySocketOwner(b.socketPath, owner, os.Chown, os.Chmod); err != nil {
 		listener.Close()
-		return nil, fmt.Errorf("chmod %s: %w", b.socketPath, err)
+		return nil, err
+	}
+	if owner.GID >= 0 {
+		log.Info("IPC socket permissions applied",
+			"socket", b.socketPath, "group", IPCGroupName, "gid", owner.GID, "mode", fmt.Sprintf("%#o", owner.Mode))
 	}
 	return listener, nil
 }

--- a/agent/internal/sessionbroker/ipc_group.go
+++ b/agent/internal/sessionbroker/ipc_group.go
@@ -1,0 +1,183 @@
+package sessionbroker
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+// IPCGroupName is the dedicated OS group that owns the agent's IPC socket.
+//
+// The daemon runs as root, so without an explicit group the socket lands on
+// whatever group the daemon's process inherits. On macOS that is worse than a
+// coin flip: BSD semantics give a newly created file the *parent directory's*
+// group, and the socket's parent is /Library/Application Support/Breeze, which
+// is group `admin`. Mode 0660 + group `admin` means a Standard (non-admin)
+// console user's desktop helper can never dial the socket, which is exactly
+// what #3133/#3134/#3137 reported: `srw-rw---- root:admin` and
+// `dial unix .../agent.sock: permission denied`.
+//
+// The three install paths (installer/macos/postinstall,
+// scripts/install/install-darwin.sh, and `breeze-agent service install`) all
+// create this group already; the missing half was ever applying it to the
+// socket and putting the console user in it.
+const IPCGroupName = "breeze"
+
+// ipcSocketMode is the mode applied to the IPC socket on every daemon start.
+//
+// Deliberately NOT 0666. Peer-credential + binary-path verification
+// (internal/ipc) is the real admission gate, but the filesystem mode is
+// defence in depth: a world-writable socket lets any local process connect and
+// spend the broker's admission budget, and it is a footgun if the peer checks
+// are ever loosened. 0660 with a real group that the console user belongs to
+// gives the same reachability without opening the socket to every UID on the
+// box. TestIPCSocketModeIsNotWorldAccessible pins this.
+const ipcSocketMode os.FileMode = 0o660
+
+// ipcGroupIDLookup resolves a group name to its GID. It is a variable so
+// ipc_group_darwin.go can install a Directory Services aware implementation and
+// so tests can inject failures.
+//
+// The darwin override is load-bearing, not a nicety: release darwin binaries
+// are cross-compiled with CGO_ENABLED=0 (scripts/build-edition.sh defaults it to
+// 0), and cgo-less os/user parses /etc/group, which never contains a
+// dscl-created group like `breeze`. Without the dscl-backed override the lookup
+// would fail on every shipped macOS build — the precise platform this fixes.
+var ipcGroupIDLookup = lookupGroupIDStdlib
+
+// lookupGroupIDStdlib resolves a group name through os/user.
+func lookupGroupIDStdlib(name string) (int, error) {
+	g, err := user.LookupGroup(name)
+	if err != nil {
+		return -1, err
+	}
+	gid, err := strconv.Atoi(g.Gid)
+	if err != nil {
+		return -1, fmt.Errorf("group %q has non-numeric gid %q: %w", name, g.Gid, err)
+	}
+	return gid, nil
+}
+
+// LookupIPCGroupID resolves IPCGroupName to a numeric GID.
+func LookupIPCGroupID() (int, error) {
+	return ipcGroupIDLookup(IPCGroupName)
+}
+
+// socketOwner is the ownership + mode the IPC socket must end up with.
+// A GID of -1 means "leave the group alone" (os.Chown's no-change sentinel),
+// used when the breeze group cannot be resolved.
+type socketOwner struct {
+	GID  int
+	Mode os.FileMode
+}
+
+// resolveSocketOwner determines the ownership to apply to the IPC socket.
+//
+// On lookup failure it returns a usable owner (GID -1, mode 0660) *alongside*
+// the error so the caller can still tighten the mode and log the reason. It
+// never returns a widened mode: a missing group must not translate into a more
+// permissive socket.
+func resolveSocketOwner(lookupGID func(string) (int, error)) (socketOwner, error) {
+	owner := socketOwner{GID: -1, Mode: ipcSocketMode}
+	gid, err := lookupGID(IPCGroupName)
+	if err != nil {
+		return owner, fmt.Errorf("lookup group %q: %w", IPCGroupName, err)
+	}
+	if gid < 0 {
+		return owner, fmt.Errorf("lookup group %q: got negative gid %d", IPCGroupName, gid)
+	}
+	owner.GID = gid
+	return owner, nil
+}
+
+// applySocketOwner applies owner to path. chown runs before chmod so the mode
+// is the last word (some platforms clear mode bits on ownership change).
+func applySocketOwner(
+	path string,
+	owner socketOwner,
+	chown func(name string, uid, gid int) error,
+	chmod func(name string, mode os.FileMode) error,
+) error {
+	if owner.GID >= 0 {
+		// uid -1 keeps the existing owner (root).
+		if err := chown(path, -1, owner.GID); err != nil {
+			return fmt.Errorf("chown %s to group %d: %w", path, owner.GID, err)
+		}
+	}
+	if err := chmod(path, owner.Mode); err != nil {
+		return fmt.Errorf("chmod %s to %#o: %w", path, owner.Mode, err)
+	}
+	return nil
+}
+
+// validIPCGroupMember rejects usernames that must never reach a privileged
+// dscl argv. In practice the name comes from user.LookupId on a live console
+// UID and is always well-formed, but a name carrying whitespace — or one that
+// dscl would parse as a flag because it starts with '-' — would turn a
+// membership append into a different command, so it is rejected here rather
+// than trusted.
+func validIPCGroupMember(username string) error {
+	switch {
+	case username == "":
+		return errors.New("empty username")
+	case strings.HasPrefix(username, "-"):
+		return fmt.Errorf("username %q starts with '-'", username)
+	case strings.ContainsAny(username, " \t\r\n"):
+		return fmt.Errorf("username %q contains whitespace", username)
+	}
+	return nil
+}
+
+// dsclGroupReadArgs builds the argv that reads a group's PrimaryGroupID from
+// the local Directory Services node.
+func dsclGroupReadArgs(group string) []string {
+	return []string{".", "-read", "/Groups/" + group, "PrimaryGroupID"}
+}
+
+// dsclGroupMembershipReadArgs builds the argv that reads a group's membership.
+func dsclGroupMembershipReadArgs(group string) []string {
+	return []string{".", "-read", "/Groups/" + group, "GroupMembership"}
+}
+
+// dsclGroupAppendMemberArgs builds the argv that adds user to group.
+func dsclGroupAppendMemberArgs(group, username string) []string {
+	return []string{".", "-append", "/Groups/" + group, "GroupMembership", username}
+}
+
+// parseDsclPrimaryGroupID extracts the GID from `dscl . -read /Groups/<g>
+// PrimaryGroupID` output, which looks like "PrimaryGroupID: 350". dscl also
+// emits the folded form (key on its own line, value indented on the next) when
+// the value is long, so both shapes are handled.
+func parseDsclPrimaryGroupID(out string) (int, error) {
+	fields := strings.Fields(strings.TrimPrefix(strings.TrimSpace(out), "PrimaryGroupID:"))
+	if len(fields) == 0 {
+		return -1, fmt.Errorf("dscl: no PrimaryGroupID in output %q", strings.TrimSpace(out))
+	}
+	gid, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return -1, fmt.Errorf("dscl: non-numeric PrimaryGroupID %q", fields[0])
+	}
+	if gid < 0 {
+		return -1, fmt.Errorf("dscl: negative PrimaryGroupID %d", gid)
+	}
+	return gid, nil
+}
+
+// userInDsclGroupMembership reports whether username appears in `dscl . -read
+// /Groups/<g> GroupMembership` output. Matching is on whole space-separated
+// tokens so "jing" does not match a membership list containing "jingxie".
+// An empty username never matches.
+func userInDsclGroupMembership(out, username string) bool {
+	if username == "" {
+		return false
+	}
+	for _, field := range strings.Fields(strings.TrimPrefix(strings.TrimSpace(out), "GroupMembership:")) {
+		if field == username {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/internal/sessionbroker/ipc_group.go
+++ b/agent/internal/sessionbroker/ipc_group.go
@@ -93,24 +93,116 @@ func resolveSocketOwner(lookupGID func(string) (int, error)) (socketOwner, error
 	return owner, nil
 }
 
-// applySocketOwner applies owner to path. chown runs before chmod so the mode
-// is the last word (some platforms clear mode bits on ownership change).
+// socketOwnerResult reports the outcome of applying ownership to the socket.
+// The two errors are deliberately separate because they have different
+// severities — see applySocketOwner.
+type socketOwnerResult struct {
+	// ChownErr is non-fatal. Losing the group means user-session helpers stay
+	// denied (the pre-fix status quo), but the socket still works for root
+	// clients, so the broker must keep running: aborting would also take down
+	// remote desktop, backup IPC and the watchdog link.
+	ChownErr error
+	// ChmodErr is fatal. net.Listen creates the socket at 0777&^umask, so a
+	// socket whose chmod failed keeps whatever the listener's umask produced.
+	// Under an unusual umask that could be world-writable, so this path fails
+	// closed rather than serving a socket with an unverified mode.
+	ChmodErr error
+}
+
+// applySocketOwner applies owner to path.
+//
+// chown runs before chmod so the mode is the last word (some platforms clear
+// mode bits on ownership change), and the chmod is attempted even when the chown
+// failed — skipping it would leave the socket at the listener's default mode,
+// which is the one outcome that could be more permissive than intended.
 func applySocketOwner(
 	path string,
 	owner socketOwner,
 	chown func(name string, uid, gid int) error,
 	chmod func(name string, mode os.FileMode) error,
-) error {
+) socketOwnerResult {
+	var res socketOwnerResult
 	if owner.GID >= 0 {
 		// uid -1 keeps the existing owner (root).
 		if err := chown(path, -1, owner.GID); err != nil {
-			return fmt.Errorf("chown %s to group %d: %w", path, owner.GID, err)
+			res.ChownErr = fmt.Errorf("chown %s to group %d: %w", path, owner.GID, err)
 		}
 	}
 	if err := chmod(path, owner.Mode); err != nil {
-		return fmt.Errorf("chmod %s to %#o: %w", path, owner.Mode, err)
+		res.ChmodErr = fmt.Errorf("chmod %s to %#o: %w", path, owner.Mode, err)
 	}
-	return nil
+	return res
+}
+
+// dsclRunner runs dscl with args and returns its combined output. It exists so
+// the orchestration below (lookup composition, membership ensure) can live in
+// this untagged file and be table-tested on every CI runner, leaving only the
+// exec.Command call behind the darwin build tag.
+type dsclRunner func(args []string) (string, error)
+
+// lookupGroupIDViaDscl resolves a group name through dscl, falling back to
+// fallback (os/user) when dscl either fails or returns output it cannot parse.
+//
+// dscl is tried first because it is the store the installers write to, and
+// because cgo-less os/user only parses /etc/group, which never contains a
+// dscl-created group. When both fail the returned error names both causes —
+// diagnosing this without knowing which layer said what is guesswork.
+func lookupGroupIDViaDscl(run dsclRunner, name string, fallback func(string) (int, error)) (int, error) {
+	out, dsclErr := run(dsclGroupReadArgs(name))
+	if dsclErr == nil {
+		gid, parseErr := parseDsclPrimaryGroupID(out)
+		if parseErr == nil {
+			return gid, nil
+		}
+		dsclErr = parseErr
+	}
+	gid, fallbackErr := fallback(name)
+	if fallbackErr == nil {
+		return gid, nil
+	}
+	return -1, fmt.Errorf("dscl: %v; os/user: %w", dsclErr, fallbackErr)
+}
+
+// groupMemberOutcome is the result of ensureGroupMemberViaDscl.
+type groupMemberOutcome struct {
+	// Added is true when this call appended the membership, false when the user
+	// was already a member.
+	Added bool
+	// ReadErr is the non-fatal error from the membership read that precedes the
+	// append, if any. A freshly created group with no members makes dscl exit
+	// non-zero for the missing GroupMembership key, which is benign — but this
+	// layer cannot tell that apart from a real read failure, so it hands the
+	// error up to be logged rather than discarding it.
+	ReadErr error
+}
+
+// ensureGroupMemberViaDscl adds username to group if it is not already a member.
+//
+// The append is verified by re-reading the membership rather than trusting
+// dscl's exit status, so a nil error genuinely means the user is a member.
+func ensureGroupMemberViaDscl(run dsclRunner, group, username string) (groupMemberOutcome, error) {
+	if err := validIPCGroupMember(username); err != nil {
+		return groupMemberOutcome{}, fmt.Errorf("ensure %q group member: %w", group, err)
+	}
+
+	out, readErr := run(dsclGroupMembershipReadArgs(group))
+	if readErr == nil && userInDsclGroupMembership(out, username) {
+		return groupMemberOutcome{Added: false}, nil
+	}
+	outcome := groupMemberOutcome{ReadErr: readErr}
+
+	if _, err := run(dsclGroupAppendMemberArgs(group, username)); err != nil {
+		return outcome, err
+	}
+	out, err := run(dsclGroupMembershipReadArgs(group))
+	if err != nil {
+		return outcome, fmt.Errorf("verify %q group membership for %q: %w", group, username, err)
+	}
+	if !userInDsclGroupMembership(out, username) {
+		return outcome, fmt.Errorf("dscl reported success but %q is not in group %q", username, group)
+	}
+	outcome.Added = true
+	return outcome, nil
 }
 
 // validIPCGroupMember rejects usernames that must never reach a privileged

--- a/agent/internal/sessionbroker/ipc_group_darwin.go
+++ b/agent/internal/sessionbroker/ipc_group_darwin.go
@@ -28,19 +28,7 @@ func init() {
 // /etc/group, which never contains the dscl-created `breeze` group, so relying
 // on os/user first would fail on exactly the shipped configuration.
 func lookupGroupIDDarwin(name string) (int, error) {
-	out, dsclErr := runDscl(dsclGroupReadArgs(name))
-	if dsclErr == nil {
-		gid, parseErr := parseDsclPrimaryGroupID(out)
-		if parseErr == nil {
-			return gid, nil
-		}
-		dsclErr = parseErr
-	}
-	gid, stdlibErr := lookupGroupIDStdlib(name)
-	if stdlibErr == nil {
-		return gid, nil
-	}
-	return -1, fmt.Errorf("dscl: %v; os/user: %w", dsclErr, stdlibErr)
+	return lookupGroupIDViaDscl(runDscl, name, lookupGroupIDStdlib)
 }
 
 // runDscl executes dscl with args and returns its combined output.
@@ -103,27 +91,16 @@ func EnsureIPCGroup() error {
 // dscl's exit status, so a caller that sees a nil error knows the user really
 // is a member.
 func EnsureIPCGroupMember(username string) (bool, error) {
-	if err := validIPCGroupMember(username); err != nil {
-		return false, fmt.Errorf("ensure %q group member: %w", IPCGroupName, err)
+	outcome, err := ensureGroupMemberViaDscl(runDscl, IPCGroupName, username)
+	if outcome.ReadErr != nil {
+		// Logged rather than swallowed because this branch cannot tell the benign
+		// "freshly created group has no GroupMembership key yet" case apart from a
+		// real read failure (wedged opendirectoryd, a directory-bound node, a
+		// permissions problem). In the benign case it fires at most once per host
+		// — the append gives the group a member, so every later read succeeds — so
+		// a line that keeps recurring is itself the signal something is wrong.
+		log.Warn("could not read IPC group membership; assuming the group is empty and appending",
+			"group", IPCGroupName, "user", username, "error", outcome.ReadErr.Error())
 	}
-	if out, err := runDscl(dsclGroupMembershipReadArgs(IPCGroupName)); err == nil {
-		if userInDsclGroupMembership(out, username) {
-			return false, nil
-		}
-	}
-	// A read failure is not fatal here: a group with no members at all makes
-	// dscl exit non-zero for the missing GroupMembership key, which is the
-	// normal state on a freshly created group. Fall through to the append and
-	// let the verification read below be the authority.
-	if _, err := runDscl(dsclGroupAppendMemberArgs(IPCGroupName, username)); err != nil {
-		return false, err
-	}
-	out, err := runDscl(dsclGroupMembershipReadArgs(IPCGroupName))
-	if err != nil {
-		return false, fmt.Errorf("verify %q group membership for %q: %w", IPCGroupName, username, err)
-	}
-	if !userInDsclGroupMembership(out, username) {
-		return false, fmt.Errorf("dscl reported success but %q is not in group %q", username, IPCGroupName)
-	}
-	return true, nil
+	return outcome.Added, err
 }

--- a/agent/internal/sessionbroker/ipc_group_darwin.go
+++ b/agent/internal/sessionbroker/ipc_group_darwin.go
@@ -1,0 +1,129 @@
+//go:build darwin
+
+package sessionbroker
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// dsclTimeout bounds every dscl invocation. These run on the daemon startup
+// path (setupSocket) and a wedged opendirectoryd is a real macOS failure mode,
+// so a hung lookup must not hold the session broker — and therefore remote
+// desktop, backup IPC and the watchdog link — hostage indefinitely.
+const dsclTimeout = 10 * time.Second
+
+func init() {
+	ipcGroupIDLookup = lookupGroupIDDarwin
+}
+
+// lookupGroupIDDarwin resolves a group name via Directory Services first,
+// falling back to os/user.
+//
+// dscl is the primary source because it is the store the installers write to.
+// cgo-less os/user (how release darwin binaries are built) only parses
+// /etc/group, which never contains the dscl-created `breeze` group, so relying
+// on os/user first would fail on exactly the shipped configuration.
+func lookupGroupIDDarwin(name string) (int, error) {
+	out, dsclErr := runDscl(dsclGroupReadArgs(name))
+	if dsclErr == nil {
+		gid, parseErr := parseDsclPrimaryGroupID(out)
+		if parseErr == nil {
+			return gid, nil
+		}
+		dsclErr = parseErr
+	}
+	gid, stdlibErr := lookupGroupIDStdlib(name)
+	if stdlibErr == nil {
+		return gid, nil
+	}
+	return -1, fmt.Errorf("dscl: %v; os/user: %w", dsclErr, stdlibErr)
+}
+
+// runDscl executes dscl with args and returns its combined output.
+func runDscl(args []string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), dsclTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "dscl", args...).CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("dscl %s: %w: %s",
+			strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+// ensureIPCGroupScript creates the breeze group if absent, without assuming a
+// fixed GID: it scans the local system GID range for a free slot. Kept as a
+// shell script so the daemon, `breeze-agent service install`,
+// installer/macos/postinstall and scripts/install/install-darwin.sh all create
+// the group identically.
+const ensureIPCGroupScript = `
+set -e
+if dscl . -read /Groups/` + IPCGroupName + ` >/dev/null 2>&1; then
+  dscl . -read /Groups/` + IPCGroupName + ` PrimaryGroupID >/dev/null
+  exit 0
+fi
+gid=350
+while [ "$gid" -le 499 ]; do
+  if ! dscl . -list /Groups PrimaryGroupID 2>/dev/null | awk '{print $2}' | grep -qx "$gid"; then
+    dscl . -create /Groups/` + IPCGroupName + `
+    dscl . -create /Groups/` + IPCGroupName + ` PrimaryGroupID "$gid"
+    exit 0
+  fi
+  gid=$((gid + 1))
+done
+echo "no free local system GID available for ` + IPCGroupName + ` group" >&2
+exit 1
+`
+
+// EnsureIPCGroup creates the breeze group if it does not exist. Idempotent.
+//
+// This runs on every daemon start (from setupSocket) rather than at install
+// time only. Hosts installed by an agent build that predates the group, or
+// where an admin removed it, would otherwise never get a group for the socket
+// to belong to and would stay broken forever.
+func EnsureIPCGroup() error {
+	ctx, cancel := context.WithTimeout(context.Background(), dsclTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "/bin/sh", "-c", ensureIPCGroupScript).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ensure %q group: %w: %s", IPCGroupName, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// EnsureIPCGroupMember adds username to the breeze group if absent, so that
+// user's desktop helper can dial the 0660 root:breeze socket. Reports whether
+// the membership was added (false when it already existed).
+//
+// The append is verified by re-reading the membership rather than trusting
+// dscl's exit status, so a caller that sees a nil error knows the user really
+// is a member.
+func EnsureIPCGroupMember(username string) (bool, error) {
+	if err := validIPCGroupMember(username); err != nil {
+		return false, fmt.Errorf("ensure %q group member: %w", IPCGroupName, err)
+	}
+	if out, err := runDscl(dsclGroupMembershipReadArgs(IPCGroupName)); err == nil {
+		if userInDsclGroupMembership(out, username) {
+			return false, nil
+		}
+	}
+	// A read failure is not fatal here: a group with no members at all makes
+	// dscl exit non-zero for the missing GroupMembership key, which is the
+	// normal state on a freshly created group. Fall through to the append and
+	// let the verification read below be the authority.
+	if _, err := runDscl(dsclGroupAppendMemberArgs(IPCGroupName, username)); err != nil {
+		return false, err
+	}
+	out, err := runDscl(dsclGroupMembershipReadArgs(IPCGroupName))
+	if err != nil {
+		return false, fmt.Errorf("verify %q group membership for %q: %w", IPCGroupName, username, err)
+	}
+	if !userInDsclGroupMembership(out, username) {
+		return false, fmt.Errorf("dscl reported success but %q is not in group %q", username, IPCGroupName)
+	}
+	return true, nil
+}

--- a/agent/internal/sessionbroker/ipc_group_other.go
+++ b/agent/internal/sessionbroker/ipc_group_other.go
@@ -1,0 +1,28 @@
+//go:build !darwin
+
+package sessionbroker
+
+import "errors"
+
+// errIPCGroupUnsupported is returned by the non-darwin EnsureIPCGroupMember
+// stub. Linux establishes breeze-group membership in
+// scripts/install/install-linux.sh instead.
+var errIPCGroupUnsupported = errors.New("sessionbroker: breeze group membership management is not supported on this platform")
+
+// EnsureIPCGroup is a no-op off macOS.
+//
+// Linux creates the breeze group in scripts/install/install-linux.sh
+// (groupadd --system breeze) and the socket chown in setupSocket picks it up
+// from there via os/user, which reads /etc/group correctly without cgo. Windows
+// uses a named pipe with its own SDDL, not a filesystem group.
+func EnsureIPCGroup() error { return nil }
+
+// EnsureIPCGroupMember is unsupported off macOS.
+//
+// It returns errIPCGroupUnsupported rather than silently reporting success so a
+// caller that reaches it on the wrong platform learns about it. The only caller
+// is macOS-gated; Linux establishes membership in install-linux.sh, which adds
+// every logged-in user to the breeze group.
+func EnsureIPCGroupMember(username string) (bool, error) {
+	return false, errIPCGroupUnsupported
+}

--- a/agent/internal/sessionbroker/ipc_group_test.go
+++ b/agent/internal/sessionbroker/ipc_group_test.go
@@ -3,15 +3,22 @@ package sessionbroker
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 )
 
 // These tests deliberately live in an untagged file. The bug they cover
-// (#3133/#3134/#3137) is macOS-only, but CI has no macOS runner — `test-agent`
-// is ubuntu-latest and `test-agent-windows` is windows-latest — so anything in a
-// //go:build darwin file is compiled and run nowhere (the #3019/#3046 lesson).
-// The socket-ownership decision and the dscl argv/parsing helpers are therefore
-// pure and platform-independent, and are exercised on every CI runner.
+// (#3133/#3134/#3137) is macOS-only, and every CI job that GATES a merge runs on
+// a platform where a //go:build darwin file is not even compiled: `test-agent` is
+// ubuntu-latest and `test-agent-windows` is windows-latest. There IS a macOS job
+// — `test-agent-race` on macos-latest — but it is absent from `ci-success`'s
+// needs list, so it cannot block a merge. Putting the coverage for a
+// darwin-triggered bug there alone would repeat the #3019/#3046 lesson in a
+// subtler form: it would run, and a failure would be advisory.
+//
+// So the socket-ownership decision, the dscl argv builders/parsers and the dscl
+// orchestration are all pure and platform-independent, and are exercised by a
+// required job. Only the exec.Command calls stay behind the darwin tag.
 
 func TestIPCSocketModeIsNotWorldAccessible(t *testing.T) {
 	if ipcSocketMode != 0o660 {
@@ -96,7 +103,7 @@ func TestApplySocketOwnerChownsThenChmods(t *testing.T) {
 	var calls []string
 	var gotUID, gotGID int
 	var gotMode os.FileMode
-	err := applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
+	res := applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
 		func(name string, uid, gid int) error {
 			calls = append(calls, "chown "+name)
 			gotUID, gotGID = uid, gid
@@ -107,8 +114,8 @@ func TestApplySocketOwnerChownsThenChmods(t *testing.T) {
 			gotMode = mode
 			return nil
 		})
-	if err != nil {
-		t.Fatalf("applySocketOwner: %v", err)
+	if res.ChownErr != nil || res.ChmodErr != nil {
+		t.Fatalf("applySocketOwner: chown=%v chmod=%v", res.ChownErr, res.ChmodErr)
 	}
 	// Order matters: chown can clear mode bits on some platforms, so the chmod
 	// has to be the last word.
@@ -130,11 +137,11 @@ func TestApplySocketOwnerChownsThenChmods(t *testing.T) {
 func TestApplySocketOwnerSkipsChownWhenGroupUnknown(t *testing.T) {
 	chownCalled := false
 	chmodCalled := false
-	err := applySocketOwner("/tmp/agent.sock", socketOwner{GID: -1, Mode: ipcSocketMode},
+	res := applySocketOwner("/tmp/agent.sock", socketOwner{GID: -1, Mode: ipcSocketMode},
 		func(string, int, int) error { chownCalled = true; return nil },
 		func(string, os.FileMode) error { chmodCalled = true; return nil })
-	if err != nil {
-		t.Fatalf("applySocketOwner: %v", err)
+	if res.ChownErr != nil || res.ChmodErr != nil {
+		t.Fatalf("applySocketOwner: chown=%v chmod=%v", res.ChownErr, res.ChmodErr)
 	}
 	if chownCalled {
 		t.Error("chown was called with an unknown group; it would clear the existing group")
@@ -144,23 +151,41 @@ func TestApplySocketOwnerSkipsChownWhenGroupUnknown(t *testing.T) {
 	}
 }
 
-func TestApplySocketOwnerSurfacesChownAndChmodErrors(t *testing.T) {
+func TestApplySocketOwnerSurfacesChownAndChmodErrorsSeparately(t *testing.T) {
 	chownErr := errors.New("chown boom")
 	chmodErr := errors.New("chmod boom")
 
-	err := applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
-		func(string, int, int) error { return chownErr },
-		func(string, os.FileMode) error { t.Fatal("chmod must not run after a failed chown"); return nil })
-	if !errors.Is(err, chownErr) {
-		t.Errorf("chown error = %v, want it to wrap %v", err, chownErr)
-	}
+	t.Run("a failed chown still applies the mode", func(t *testing.T) {
+		// The two errors are reported separately because they differ in severity:
+		// a lost group is survivable, an unapplied mode is not. Skipping the chmod
+		// here would leave the socket at net.Listen's umask-derived mode, the one
+		// outcome that could be MORE permissive than intended.
+		chmodCalled := false
+		res := applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
+			func(string, int, int) error { return chownErr },
+			func(string, os.FileMode) error { chmodCalled = true; return nil })
+		if !errors.Is(res.ChownErr, chownErr) {
+			t.Errorf("ChownErr = %v, want it to wrap %v", res.ChownErr, chownErr)
+		}
+		if res.ChmodErr != nil {
+			t.Errorf("ChmodErr = %v, want nil", res.ChmodErr)
+		}
+		if !chmodCalled {
+			t.Error("chmod was skipped after a failed chown, leaving the socket at the listener's default mode")
+		}
+	})
 
-	err = applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
-		func(string, int, int) error { return nil },
-		func(string, os.FileMode) error { return chmodErr })
-	if !errors.Is(err, chmodErr) {
-		t.Errorf("chmod error = %v, want it to wrap %v", err, chmodErr)
-	}
+	t.Run("a failed chmod is reported on its own channel", func(t *testing.T) {
+		res := applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
+			func(string, int, int) error { return nil },
+			func(string, os.FileMode) error { return chmodErr })
+		if res.ChownErr != nil {
+			t.Errorf("ChownErr = %v, want nil", res.ChownErr)
+		}
+		if !errors.Is(res.ChmodErr, chmodErr) {
+			t.Errorf("ChmodErr = %v, want it to wrap %v", res.ChmodErr, chmodErr)
+		}
+	})
 }
 
 func TestDsclArgvBuilders(t *testing.T) {
@@ -301,5 +326,249 @@ func TestLookupIPCGroupIDUsesTheInstalledLookup(t *testing.T) {
 	}
 	if gid != 412 {
 		t.Errorf("LookupIPCGroupID = %d, want 412", gid)
+	}
+}
+
+// --- dscl orchestration (the branches that used to live behind //go:build darwin) ---
+
+// fakeDscl replays canned responses keyed by the dscl verb+key, and records the
+// argv of every call so ordering can be asserted.
+type fakeDscl struct {
+	readMembership []struct {
+		out string
+		err error
+	}
+	appendErr  error
+	readGID    string
+	readGIDErr error
+	calls      [][]string
+}
+
+func (f *fakeDscl) run(args []string) (string, error) {
+	f.calls = append(f.calls, args)
+	switch {
+	case len(args) >= 4 && args[1] == "-read" && args[3] == "PrimaryGroupID":
+		return f.readGID, f.readGIDErr
+	case len(args) >= 4 && args[1] == "-read" && args[3] == "GroupMembership":
+		if len(f.readMembership) == 0 {
+			return "", errors.New("fakeDscl: unexpected extra membership read")
+		}
+		next := f.readMembership[0]
+		f.readMembership = f.readMembership[1:]
+		return next.out, next.err
+	case len(args) >= 2 && args[1] == "-append":
+		return "", f.appendErr
+	}
+	return "", errors.New("fakeDscl: unexpected argv")
+}
+
+func membershipReads(entries ...struct {
+	out string
+	err error
+}) []struct {
+	out string
+	err error
+} {
+	return entries
+}
+
+func read(out string) struct {
+	out string
+	err error
+} {
+	return struct {
+		out string
+		err error
+	}{out: out}
+}
+
+func readErr(err error) struct {
+	out string
+	err error
+} {
+	return struct {
+		out string
+		err error
+	}{err: err}
+}
+
+func TestEnsureGroupMemberViaDsclAlreadyAMemberDoesNotAppend(t *testing.T) {
+	f := &fakeDscl{readMembership: membershipReads(read("GroupMembership: alice jingxie\n"))}
+	outcome, err := ensureGroupMemberViaDscl(f.run, "breeze", "jingxie")
+	if err != nil {
+		t.Fatalf("ensureGroupMemberViaDscl: %v", err)
+	}
+	if outcome.Added {
+		t.Error("Added = true for a user that was already a member")
+	}
+	if outcome.ReadErr != nil {
+		t.Errorf("ReadErr = %v, want nil", outcome.ReadErr)
+	}
+	if len(f.calls) != 1 {
+		t.Fatalf("made %d dscl calls, want 1 (the membership read only): %v", len(f.calls), f.calls)
+	}
+	for _, c := range f.calls {
+		if len(c) > 1 && c[1] == "-append" {
+			t.Error("appended a membership that already existed")
+		}
+	}
+}
+
+func TestEnsureGroupMemberViaDsclAppendsAndVerifies(t *testing.T) {
+	f := &fakeDscl{readMembership: membershipReads(
+		read("GroupMembership: alice\n"),         // pre-append: not a member
+		read("GroupMembership: alice jingxie\n"), // post-append verification
+	)}
+	outcome, err := ensureGroupMemberViaDscl(f.run, "breeze", "jingxie")
+	if err != nil {
+		t.Fatalf("ensureGroupMemberViaDscl: %v", err)
+	}
+	if !outcome.Added {
+		t.Error("Added = false after a successful append")
+	}
+	// read, append, read — the trailing read is the verification that makes a nil
+	// error mean the user really is a member.
+	if len(f.calls) != 3 {
+		t.Fatalf("made %d dscl calls, want 3: %v", len(f.calls), f.calls)
+	}
+	if f.calls[1][1] != "-append" {
+		t.Errorf("second call = %v, want the append", f.calls[1])
+	}
+	if f.calls[2][3] != "GroupMembership" {
+		t.Errorf("third call = %v, want the verification membership read", f.calls[2])
+	}
+}
+
+func TestEnsureGroupMemberViaDsclSurfacesTheToleratedReadFailure(t *testing.T) {
+	// A group created moments ago has no GroupMembership key, so dscl exits
+	// non-zero. That is benign and must not block the append — but it must be
+	// reported so a read that keeps failing for a real reason is diagnosable.
+	sentinel := errors.New("eDSRecordNotFound")
+	f := &fakeDscl{readMembership: membershipReads(
+		readErr(sentinel),
+		read("GroupMembership: jingxie\n"),
+	)}
+	outcome, err := ensureGroupMemberViaDscl(f.run, "breeze", "jingxie")
+	if err != nil {
+		t.Fatalf("a failed pre-append read must not be fatal: %v", err)
+	}
+	if !outcome.Added {
+		t.Error("Added = false; the append should have proceeded")
+	}
+	if !errors.Is(outcome.ReadErr, sentinel) {
+		t.Errorf("ReadErr = %v, want it to carry %v so the caller can log it", outcome.ReadErr, sentinel)
+	}
+}
+
+func TestEnsureGroupMemberViaDsclAppendFailureIsReported(t *testing.T) {
+	appendErr := errors.New("append denied")
+	f := &fakeDscl{
+		readMembership: membershipReads(read("GroupMembership: alice\n")),
+		appendErr:      appendErr,
+	}
+	outcome, err := ensureGroupMemberViaDscl(f.run, "breeze", "jingxie")
+	if !errors.Is(err, appendErr) {
+		t.Fatalf("error = %v, want it to wrap %v", err, appendErr)
+	}
+	if outcome.Added {
+		t.Error("Added = true despite a failed append")
+	}
+}
+
+func TestEnsureGroupMemberViaDsclVerificationFailuresAreNotReportedAsSuccess(t *testing.T) {
+	verifyErr := errors.New("verify read failed")
+	t.Run("verification read errors", func(t *testing.T) {
+		f := &fakeDscl{readMembership: membershipReads(
+			read("GroupMembership: alice\n"),
+			readErr(verifyErr),
+		)}
+		outcome, err := ensureGroupMemberViaDscl(f.run, "breeze", "jingxie")
+		if !errors.Is(err, verifyErr) {
+			t.Fatalf("error = %v, want it to wrap %v", err, verifyErr)
+		}
+		if outcome.Added {
+			t.Error("Added = true although the membership could not be verified")
+		}
+	})
+	t.Run("dscl exits 0 but the user is still absent", func(t *testing.T) {
+		// The reason verification exists at all: a zero exit status is not proof.
+		f := &fakeDscl{readMembership: membershipReads(
+			read("GroupMembership: alice\n"),
+			read("GroupMembership: alice\n"),
+		)}
+		outcome, err := ensureGroupMemberViaDscl(f.run, "breeze", "jingxie")
+		if err == nil {
+			t.Fatal("expected an error when the verification read does not show the user")
+		}
+		if outcome.Added {
+			t.Error("Added = true although the user is not in the group")
+		}
+	})
+}
+
+func TestEnsureGroupMemberViaDsclRejectsAnUnsafeUsernameBeforeRunningAnything(t *testing.T) {
+	f := &fakeDscl{}
+	if _, err := ensureGroupMemberViaDscl(f.run, "breeze", "-delete"); err == nil {
+		t.Fatal("expected an error for a username that dscl would read as a flag")
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("ran %v; an unsafe username must never reach a privileged argv", f.calls)
+	}
+}
+
+func TestLookupGroupIDViaDsclPrefersDscl(t *testing.T) {
+	f := &fakeDscl{readGID: "PrimaryGroupID: 350\n"}
+	gid, err := lookupGroupIDViaDscl(f.run, "breeze", func(string) (int, error) {
+		t.Error("fallback was used even though dscl succeeded")
+		return 0, nil
+	})
+	if err != nil {
+		t.Fatalf("lookupGroupIDViaDscl: %v", err)
+	}
+	if gid != 350 {
+		t.Errorf("gid = %d, want 350", gid)
+	}
+}
+
+func TestLookupGroupIDViaDsclFallsBackToOsUser(t *testing.T) {
+	tests := []struct {
+		name string
+		f    *fakeDscl
+	}{
+		// Release darwin binaries are cgo-less, so os/user reads /etc/group and
+		// cannot see a dscl-created group. The fallback covers the reverse: a host
+		// where dscl is unavailable or unparseable but /etc/group has the answer.
+		{name: "dscl errors", f: &fakeDscl{readGIDErr: errors.New("dscl unavailable")}},
+		{name: "dscl output unparseable", f: &fakeDscl{readGID: "No such key: PrimaryGroupID\n"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gid, err := lookupGroupIDViaDscl(tc.f.run, "breeze", func(string) (int, error) { return 412, nil })
+			if err != nil {
+				t.Fatalf("lookupGroupIDViaDscl: %v", err)
+			}
+			if gid != 412 {
+				t.Errorf("gid = %d, want 412 from the fallback", gid)
+			}
+		})
+	}
+}
+
+func TestLookupGroupIDViaDsclReportsBothFailures(t *testing.T) {
+	f := &fakeDscl{readGIDErr: errors.New("dscl exploded")}
+	fallbackErr := errors.New("no such group in /etc/group")
+	gid, err := lookupGroupIDViaDscl(f.run, "breeze", func(string) (int, error) { return 0, fallbackErr })
+	if err == nil {
+		t.Fatal("expected an error when both lookups fail")
+	}
+	if gid != -1 {
+		t.Errorf("gid = %d, want -1", gid)
+	}
+	// Both causes must appear: knowing only one of them makes this undiagnosable.
+	if !errors.Is(err, fallbackErr) {
+		t.Errorf("error %v does not wrap the fallback failure", err)
+	}
+	if !strings.Contains(err.Error(), "dscl exploded") {
+		t.Errorf("error %v does not mention the dscl failure", err)
 	}
 }

--- a/agent/internal/sessionbroker/ipc_group_test.go
+++ b/agent/internal/sessionbroker/ipc_group_test.go
@@ -1,0 +1,305 @@
+package sessionbroker
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// These tests deliberately live in an untagged file. The bug they cover
+// (#3133/#3134/#3137) is macOS-only, but CI has no macOS runner — `test-agent`
+// is ubuntu-latest and `test-agent-windows` is windows-latest — so anything in a
+// //go:build darwin file is compiled and run nowhere (the #3019/#3046 lesson).
+// The socket-ownership decision and the dscl argv/parsing helpers are therefore
+// pure and platform-independent, and are exercised on every CI runner.
+
+func TestIPCSocketModeIsNotWorldAccessible(t *testing.T) {
+	if ipcSocketMode != 0o660 {
+		t.Fatalf("ipcSocketMode = %#o, want 0660", ipcSocketMode)
+	}
+	// The reporter's workaround was `chmod 666`. Pin the mode so a future
+	// "simpler fix" cannot land that as the shipped behaviour: the socket must
+	// never be reachable by every local UID.
+	if ipcSocketMode&0o007 != 0 {
+		t.Fatalf("ipcSocketMode = %#o grants access to others; the IPC socket must not be world-accessible", ipcSocketMode)
+	}
+	if ipcSocketMode&0o600 != 0o600 {
+		t.Fatalf("ipcSocketMode = %#o does not grant the owner read+write", ipcSocketMode)
+	}
+	if ipcSocketMode&0o060 != 0o060 {
+		t.Fatalf("ipcSocketMode = %#o does not grant the breeze group read+write; user helpers could not connect", ipcSocketMode)
+	}
+}
+
+func TestIPCGroupNameIsBreeze(t *testing.T) {
+	// The installers (installer/macos/postinstall,
+	// scripts/install/install-darwin.sh, scripts/install/install-linux.sh) create
+	// a group by this literal name. A rename here without renaming it there
+	// silently reintroduces the bug.
+	if IPCGroupName != "breeze" {
+		t.Fatalf("IPCGroupName = %q, want \"breeze\"", IPCGroupName)
+	}
+}
+
+func TestResolveSocketOwnerUsesLookedUpGID(t *testing.T) {
+	var asked string
+	owner, err := resolveSocketOwner(func(name string) (int, error) {
+		asked = name
+		return 350, nil
+	})
+	if err != nil {
+		t.Fatalf("resolveSocketOwner: %v", err)
+	}
+	if asked != IPCGroupName {
+		t.Errorf("looked up group %q, want %q", asked, IPCGroupName)
+	}
+	if owner.GID != 350 {
+		t.Errorf("owner.GID = %d, want 350", owner.GID)
+	}
+	if owner.Mode != ipcSocketMode {
+		t.Errorf("owner.Mode = %#o, want %#o", owner.Mode, ipcSocketMode)
+	}
+}
+
+func TestResolveSocketOwnerLookupFailureStillTightensMode(t *testing.T) {
+	sentinel := errors.New("no such group")
+	owner, err := resolveSocketOwner(func(string) (int, error) { return 0, sentinel })
+	if err == nil {
+		t.Fatal("expected an error when the group cannot be resolved")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error %v does not wrap the lookup failure", err)
+	}
+	// A missing group must never widen the socket: GID -1 means "leave the group
+	// alone" and the mode must still be the restrictive 0660.
+	if owner.GID != -1 {
+		t.Errorf("owner.GID = %d, want -1 (no group change)", owner.GID)
+	}
+	if owner.Mode != ipcSocketMode {
+		t.Errorf("owner.Mode = %#o, want %#o even on lookup failure", owner.Mode, ipcSocketMode)
+	}
+}
+
+func TestResolveSocketOwnerRejectsNegativeGID(t *testing.T) {
+	// A -1 from a lookup would otherwise be indistinguishable from "no change",
+	// masking a broken resolver.
+	owner, err := resolveSocketOwner(func(string) (int, error) { return -1, nil })
+	if err == nil {
+		t.Fatal("expected an error for a negative gid")
+	}
+	if owner.GID != -1 || owner.Mode != ipcSocketMode {
+		t.Errorf("owner = %+v, want {GID:-1 Mode:%#o}", owner, ipcSocketMode)
+	}
+}
+
+func TestApplySocketOwnerChownsThenChmods(t *testing.T) {
+	var calls []string
+	var gotUID, gotGID int
+	var gotMode os.FileMode
+	err := applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
+		func(name string, uid, gid int) error {
+			calls = append(calls, "chown "+name)
+			gotUID, gotGID = uid, gid
+			return nil
+		},
+		func(name string, mode os.FileMode) error {
+			calls = append(calls, "chmod "+name)
+			gotMode = mode
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("applySocketOwner: %v", err)
+	}
+	// Order matters: chown can clear mode bits on some platforms, so the chmod
+	// has to be the last word.
+	want := []string{"chown /tmp/agent.sock", "chmod /tmp/agent.sock"}
+	if len(calls) != len(want) || calls[0] != want[0] || calls[1] != want[1] {
+		t.Errorf("calls = %v, want %v", calls, want)
+	}
+	if gotUID != -1 {
+		t.Errorf("chown uid = %d, want -1 (keep the existing owner, root)", gotUID)
+	}
+	if gotGID != 350 {
+		t.Errorf("chown gid = %d, want 350", gotGID)
+	}
+	if gotMode != ipcSocketMode {
+		t.Errorf("chmod mode = %#o, want %#o", gotMode, ipcSocketMode)
+	}
+}
+
+func TestApplySocketOwnerSkipsChownWhenGroupUnknown(t *testing.T) {
+	chownCalled := false
+	chmodCalled := false
+	err := applySocketOwner("/tmp/agent.sock", socketOwner{GID: -1, Mode: ipcSocketMode},
+		func(string, int, int) error { chownCalled = true; return nil },
+		func(string, os.FileMode) error { chmodCalled = true; return nil })
+	if err != nil {
+		t.Fatalf("applySocketOwner: %v", err)
+	}
+	if chownCalled {
+		t.Error("chown was called with an unknown group; it would clear the existing group")
+	}
+	if !chmodCalled {
+		t.Error("chmod was skipped; the socket would keep whatever mode it was created with")
+	}
+}
+
+func TestApplySocketOwnerSurfacesChownAndChmodErrors(t *testing.T) {
+	chownErr := errors.New("chown boom")
+	chmodErr := errors.New("chmod boom")
+
+	err := applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
+		func(string, int, int) error { return chownErr },
+		func(string, os.FileMode) error { t.Fatal("chmod must not run after a failed chown"); return nil })
+	if !errors.Is(err, chownErr) {
+		t.Errorf("chown error = %v, want it to wrap %v", err, chownErr)
+	}
+
+	err = applySocketOwner("/tmp/agent.sock", socketOwner{GID: 350, Mode: ipcSocketMode},
+		func(string, int, int) error { return nil },
+		func(string, os.FileMode) error { return chmodErr })
+	if !errors.Is(err, chmodErr) {
+		t.Errorf("chmod error = %v, want it to wrap %v", err, chmodErr)
+	}
+}
+
+func TestDsclArgvBuilders(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{
+			name: "read primary gid",
+			got:  dsclGroupReadArgs("breeze"),
+			want: []string{".", "-read", "/Groups/breeze", "PrimaryGroupID"},
+		},
+		{
+			name: "read membership",
+			got:  dsclGroupMembershipReadArgs("breeze"),
+			want: []string{".", "-read", "/Groups/breeze", "GroupMembership"},
+		},
+		{
+			name: "append member",
+			got:  dsclGroupAppendMemberArgs("breeze", "jingxie"),
+			want: []string{".", "-append", "/Groups/breeze", "GroupMembership", "jingxie"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.got) != len(tc.want) {
+				t.Fatalf("argv = %q, want %q", tc.got, tc.want)
+			}
+			for i := range tc.want {
+				if tc.got[i] != tc.want[i] {
+					t.Fatalf("argv = %q, want %q", tc.got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseDsclPrimaryGroupID(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		want    int
+		wantErr bool
+	}{
+		{name: "inline", out: "PrimaryGroupID: 350\n", want: 350},
+		{name: "folded onto the next line", out: "PrimaryGroupID:\n 350\n", want: 350},
+		{name: "no trailing newline", out: "PrimaryGroupID: 501", want: 501},
+		{name: "group missing", out: "<dscl_cmd> DS Error: -14136 (eDSRecordNotFound)\n", wantErr: true},
+		{name: "key missing", out: "No such key: PrimaryGroupID\n", wantErr: true},
+		{name: "empty", out: "", wantErr: true},
+		{name: "negative", out: "PrimaryGroupID: -5\n", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseDsclPrimaryGroupID(tc.out)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseDsclPrimaryGroupID(%q) = %d, want an error", tc.out, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDsclPrimaryGroupID(%q): %v", tc.out, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseDsclPrimaryGroupID(%q) = %d, want %d", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUserInDsclGroupMembership(t *testing.T) {
+	const membership = "GroupMembership: alice jingxie bob\n"
+	tests := []struct {
+		name string
+		out  string
+		user string
+		want bool
+	}{
+		{name: "first member", out: membership, user: "alice", want: true},
+		{name: "middle member", out: membership, user: "jingxie", want: true},
+		{name: "last member", out: membership, user: "bob", want: true},
+		{name: "prefix is not a member", out: membership, user: "jing", want: false},
+		{name: "suffix is not a member", out: membership, user: "xie", want: false},
+		{name: "absent", out: membership, user: "carol", want: false},
+		{name: "empty username never matches", out: membership, user: "", want: false},
+		{name: "folded output", out: "GroupMembership:\n alice\n jingxie\n", user: "jingxie", want: true},
+		{name: "no members yet", out: "No such key: GroupMembership\n", user: "alice", want: false},
+		{name: "empty output", out: "", user: "alice", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := userInDsclGroupMembership(tc.out, tc.user); got != tc.want {
+				t.Errorf("userInDsclGroupMembership(%q, %q) = %v, want %v", tc.out, tc.user, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidIPCGroupMember(t *testing.T) {
+	tests := []struct {
+		name    string
+		user    string
+		wantErr bool
+	}{
+		{name: "ordinary username", user: "jingxie"},
+		{name: "with dot and digits", user: "j.xie2"},
+		{name: "empty", user: "", wantErr: true},
+		{name: "leading dash would be read as a dscl flag", user: "-delete", wantErr: true},
+		{name: "space would split the argv", user: "alice bob", wantErr: true},
+		{name: "newline", user: "alice\nbob", wantErr: true},
+		{name: "tab", user: "alice\tbob", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validIPCGroupMember(tc.user)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("validIPCGroupMember(%q) error = %v, wantErr = %v", tc.user, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestLookupIPCGroupIDUsesTheInstalledLookup(t *testing.T) {
+	orig := ipcGroupIDLookup
+	t.Cleanup(func() { ipcGroupIDLookup = orig })
+
+	ipcGroupIDLookup = func(name string) (int, error) {
+		if name != IPCGroupName {
+			t.Errorf("looked up %q, want %q", name, IPCGroupName)
+		}
+		return 412, nil
+	}
+	gid, err := LookupIPCGroupID()
+	if err != nil {
+		t.Fatalf("LookupIPCGroupID: %v", err)
+	}
+	if gid != 412 {
+		t.Errorf("LookupIPCGroupID = %d, want 412", gid)
+	}
+}

--- a/agent/internal/sessionbroker/ipc_group_unix_test.go
+++ b/agent/internal/sessionbroker/ipc_group_unix_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 // These exercise the real chown/chmod syscalls against a real unix socket, so
-// they prove the production path rather than just the decision logic. They run
-// on the ubuntu `test-agent` CI job (the file is !windows, not darwin), which is
-// the only Unix runner CI has.
+// they prove the production path rather than just the decision logic. Tagged
+// !windows rather than darwin so they run on the REQUIRED ubuntu `test-agent`
+// job, not only on the non-blocking macOS `test-agent-race` job (which is not in
+// ci-success's needs list). They run on both.
 
 // newTestSocketPath returns a short-enough path for a unix socket. sun_path caps
 // at 104 bytes on darwin / 108 on linux, and t.TempDir() under macOS's
@@ -43,12 +44,18 @@ func chownTargetGID(t *testing.T) (int, bool) {
 		t.Logf("os.Getgroups: %v", err)
 		return 0, false
 	}
+	// Callers t.Skip when this returns false. A runner that silently started
+	// skipping would leave the chown assertions unexercised with no signal, so the
+	// no-supplementary-group case is logged loudly rather than skipped quietly.
 	primary := os.Getgid()
 	for _, g := range groups {
 		if g != primary && g >= 0 {
 			return g, true
 		}
 	}
+	t.Logf("VACUOUS-GUARD: this runner exposes no supplementary group distinct from "+
+		"primary gid %d (groups=%v), so the socket chown assertions cannot be made "+
+		"non-vacuously and will be skipped", primary, groups)
 	return 0, false
 }
 
@@ -90,7 +97,7 @@ func TestSetupSocketAppliesGroupAndRestrictiveMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setupSocket: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 
 	mode, gotGID := statSocket(t, path)
 	if mode != 0o660 {
@@ -116,7 +123,7 @@ func TestSetupSocketStillTightensModeWhenGroupIsMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setupSocket must not fail when the group is missing: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 
 	mode, _ := statSocket(t, path)
 	if mode != 0o660 {
@@ -141,7 +148,7 @@ func TestSetupSocketCreatesTraversableParentDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setupSocket: %v", err)
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 
 	fi, err := os.Stat(filepath.Dir(path))
 	if err != nil {
@@ -190,7 +197,7 @@ func TestSetupSocketReplacesAStaleSocket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second setupSocket: %v", err)
 	}
-	defer second.Close()
+	defer func() { _ = second.Close() }()
 
 	mode, gotGID := statSocket(t, path)
 	if mode != 0o660 {
@@ -199,4 +206,53 @@ func TestSetupSocketReplacesAStaleSocket(t *testing.T) {
 	if gotGID != gid {
 		t.Errorf("socket gid after restart = %d, want %d", gotGID, gid)
 	}
+}
+
+func TestSetupSocketSurvivesAFailedChown(t *testing.T) {
+	// chown and chmod failures have different severities in setupSocket: a lost
+	// group is survivable, an unapplied mode is not. Only the survivable half is
+	// reachable here — making a real os.Chmod fail needs a read-only filesystem,
+	// so setupSocket's fail-closed chmod branch is covered at the unit level by
+	// TestApplySocketOwnerSurfacesChownAndChmodErrorsSeparately instead.
+	orig := ipcGroupIDLookup
+	t.Cleanup(func() { ipcGroupIDLookup = orig })
+
+	t.Run("an unresolvable group leaves a working socket", func(t *testing.T) {
+		// Already covered by TestSetupSocketStillTightensModeWhenGroupIsMissing;
+		// asserted here too as the sibling of the chmod case below, so the
+		// asymmetry between the two is visible in one place.
+		ipcGroupIDLookup = func(string) (int, error) { return -1, errors.New("no such group") }
+		path := newTestSocketPath(t)
+		l, err := New(path, nil).setupSocket()
+		if err != nil {
+			t.Fatalf("setupSocket must not fail when the group is unresolvable: %v", err)
+		}
+		defer func() { _ = l.Close() }()
+		if mode, _ := statSocket(t, path); mode != 0o660 {
+			t.Errorf("socket mode = %#o, want 0660", mode)
+		}
+	})
+
+	t.Run("a chown to a group we do not belong to does not kill the broker", func(t *testing.T) {
+		// gid 0 (root/wheel) is not a group an unprivileged test process may chown
+		// to, so os.Chown genuinely fails here — while the chmod still succeeds
+		// because we own the file. The broker must survive with a tightened mode.
+		if os.Geteuid() == 0 {
+			t.Skip("running as root: chown to gid 0 would succeed, so this cannot exercise the failure path")
+		}
+		ipcGroupIDLookup = func(string) (int, error) { return 0, nil }
+		path := newTestSocketPath(t)
+		l, err := New(path, nil).setupSocket()
+		if err != nil {
+			t.Fatalf("setupSocket must not fail when only the chown fails: %v", err)
+		}
+		defer func() { _ = l.Close() }()
+		mode, _ := statSocket(t, path)
+		if mode != 0o660 {
+			t.Errorf("socket mode = %#o, want 0660 — the mode must still be applied when the chown fails", mode)
+		}
+		if mode&0o007 != 0 {
+			t.Errorf("socket mode = %#o is world-accessible", mode)
+		}
+	})
 }

--- a/agent/internal/sessionbroker/ipc_group_unix_test.go
+++ b/agent/internal/sessionbroker/ipc_group_unix_test.go
@@ -1,0 +1,202 @@
+//go:build !windows
+
+package sessionbroker
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// These exercise the real chown/chmod syscalls against a real unix socket, so
+// they prove the production path rather than just the decision logic. They run
+// on the ubuntu `test-agent` CI job (the file is !windows, not darwin), which is
+// the only Unix runner CI has.
+
+// newTestSocketPath returns a short-enough path for a unix socket. sun_path caps
+// at 104 bytes on darwin / 108 on linux, and t.TempDir() under macOS's
+// /var/folders TMPDIR plus a long test name can exceed that.
+func newTestSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "bzsock")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "agent.sock")
+}
+
+// chownTargetGID returns a GID this unprivileged test process is allowed to
+// chown a file it owns to, and which is NOT the process's primary GID.
+//
+// The distinctness matters: a socket is created with the process's primary GID
+// already, so asserting the socket ends up with that GID would pass even if the
+// chown never happened — the exact bug under test. A supplementary group makes
+// the assertion real.
+func chownTargetGID(t *testing.T) (int, bool) {
+	t.Helper()
+	groups, err := os.Getgroups()
+	if err != nil {
+		t.Logf("os.Getgroups: %v", err)
+		return 0, false
+	}
+	primary := os.Getgid()
+	for _, g := range groups {
+		if g != primary && g >= 0 {
+			return g, true
+		}
+	}
+	return 0, false
+}
+
+func statSocket(t *testing.T, path string) (os.FileMode, int) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("%s is not a socket (mode %v)", path, fi.Mode())
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("stat %s: unexpected Sys() type %T", path, fi.Sys())
+	}
+	return fi.Mode().Perm(), int(st.Gid)
+}
+
+func TestSetupSocketAppliesGroupAndRestrictiveMode(t *testing.T) {
+	// Chowning to a group the test process already belongs to is permitted
+	// without root, so this works as an unprivileged CI user.
+	gid, ok := chownTargetGID(t)
+	if !ok {
+		t.Skip("no supplementary group available to chown to; the gid assertion would be vacuous")
+	}
+	orig := ipcGroupIDLookup
+	t.Cleanup(func() { ipcGroupIDLookup = orig })
+	ipcGroupIDLookup = func(name string) (int, error) {
+		if name != IPCGroupName {
+			t.Errorf("looked up group %q, want %q", name, IPCGroupName)
+		}
+		return gid, nil
+	}
+
+	path := newTestSocketPath(t)
+	b := New(path, nil)
+	l, err := b.setupSocket()
+	if err != nil {
+		t.Fatalf("setupSocket: %v", err)
+	}
+	defer l.Close()
+
+	mode, gotGID := statSocket(t, path)
+	if mode != 0o660 {
+		t.Errorf("socket mode = %#o, want 0660", mode)
+	}
+	if gotGID != gid {
+		t.Errorf("socket gid = %d, want %d — the breeze group was never applied, which is the #3137 bug", gotGID, gid)
+	}
+}
+
+func TestSetupSocketStillTightensModeWhenGroupIsMissing(t *testing.T) {
+	// A host with no breeze group (pre-group agent build, or an admin removed it)
+	// must still come up with a working socket rather than no IPC at all: losing
+	// the broker would take remote desktop, backup IPC and the watchdog link with
+	// it, which is strictly worse than the pre-fix root-only socket.
+	orig := ipcGroupIDLookup
+	t.Cleanup(func() { ipcGroupIDLookup = orig })
+	ipcGroupIDLookup = func(string) (int, error) { return 0, errors.New("no such group") }
+
+	path := newTestSocketPath(t)
+	b := New(path, nil)
+	l, err := b.setupSocket()
+	if err != nil {
+		t.Fatalf("setupSocket must not fail when the group is missing: %v", err)
+	}
+	defer l.Close()
+
+	mode, _ := statSocket(t, path)
+	if mode != 0o660 {
+		t.Errorf("socket mode = %#o, want 0660 even without a resolvable group", mode)
+	}
+	if mode&0o007 != 0 {
+		t.Errorf("socket mode = %#o is world-accessible; a missing group must never widen the socket", mode)
+	}
+}
+
+func TestSetupSocketCreatesTraversableParentDirectory(t *testing.T) {
+	// The helper runs as a non-root user and has to traverse the socket's parent
+	// directory to reach it, so the directory needs its execute bit for others.
+	orig := ipcGroupIDLookup
+	t.Cleanup(func() { ipcGroupIDLookup = orig })
+	ipcGroupIDLookup = func(string) (int, error) { return os.Getgid(), nil }
+
+	base := newTestSocketPath(t)
+	path := filepath.Join(filepath.Dir(base), "nested", "agent.sock")
+	b := New(path, nil)
+	l, err := b.setupSocket()
+	if err != nil {
+		t.Fatalf("setupSocket: %v", err)
+	}
+	defer l.Close()
+
+	fi, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("stat socket dir: %v", err)
+	}
+	if fi.Mode().Perm()&0o001 == 0 {
+		t.Errorf("socket dir mode = %#o; a non-root helper cannot traverse it", fi.Mode().Perm())
+	}
+}
+
+func TestSetupSocketReplacesAStaleSocket(t *testing.T) {
+	// The daemon restarts (reboot, `launchctl kickstart -k
+	// system/com.breeze.agent`, self-update) leave a stale socket file behind.
+	// The reporter expected it to "recreate tight again" — assert the second bind
+	// re-applies ownership rather than inheriting whatever the stale file had.
+	gid, ok := chownTargetGID(t)
+	if !ok {
+		t.Skip("no supplementary group available to chown to; the gid assertion would be vacuous")
+	}
+	orig := ipcGroupIDLookup
+	t.Cleanup(func() { ipcGroupIDLookup = orig })
+	ipcGroupIDLookup = func(string) (int, error) { return gid, nil }
+
+	path := newTestSocketPath(t)
+	b := New(path, nil)
+
+	first, err := b.setupSocket()
+	if err != nil {
+		t.Fatalf("first setupSocket: %v", err)
+	}
+	// Simulate a daemon that died without unlinking: Go's unix listener removes
+	// the socket file on Close, so disable that to leave the file behind.
+	ul, isUnix := first.(*net.UnixListener)
+	if !isUnix {
+		t.Fatalf("listener is %T, want *net.UnixListener", first)
+	}
+	ul.SetUnlinkOnClose(false)
+	if err := ul.Close(); err != nil {
+		t.Fatalf("close first listener: %v", err)
+	}
+	if err := os.Chmod(path, 0o777); err != nil {
+		t.Fatalf("chmod stale socket: %v", err)
+	}
+
+	second, err := b.setupSocket()
+	if err != nil {
+		t.Fatalf("second setupSocket: %v", err)
+	}
+	defer second.Close()
+
+	mode, gotGID := statSocket(t, path)
+	if mode != 0o660 {
+		t.Errorf("socket mode after restart = %#o, want 0660", mode)
+	}
+	if gotGID != gid {
+		t.Errorf("socket gid after restart = %d, want %d", gotGID, gid)
+	}
+}

--- a/agent/scripts/install/install-darwin.sh
+++ b/agent/scripts/install/install-darwin.sh
@@ -39,15 +39,21 @@ ensure_breeze_group() {
     exit 1
 }
 
+# breeze_group_has_member reports whether $1 is in the breeze group.
+breeze_group_has_member() {
+    dscl . -read /Groups/breeze GroupMembership 2>/dev/null | tr ' ' '\n' | grep -qx "$1"
+}
+
 # Add every logged-in GUI user to the breeze group so their desktop helper can
 # dial the 0660 root:breeze IPC socket. Mirrors the loop in
 # scripts/install/install-linux.sh; without it the socket is group-owned by a
 # group nobody is in and Standard (non-admin) users' helpers are denied
 # (#3133/#3134/#3137).
 #
-# NOTE: this script runs under `set -euo pipefail`, so every test is written as an
-# `if`. A bare `[ ... ] && continue` returns non-zero when false and would abort
-# the install.
+# This script runs under `set -euo pipefail`. The `|| continue` on the id lookup
+# is load-bearing: a bare failing assignment would abort the install. (A failing
+# `[ ... ] && continue` would NOT — set -e exempts a command that is part of an
+# && list other than the last one.)
 add_console_users_to_breeze_group() {
     local uid username
     for uid in $(ps -axo uid= -o comm= | grep -i '[lL]oginwindow' | awk '{print $1}' | sort -u); do
@@ -60,10 +66,13 @@ add_console_users_to_breeze_group() {
         if [ -z "$username" ]; then
             continue
         fi
-        if dscl . -read /Groups/breeze GroupMembership 2>/dev/null | tr ' ' '\n' | grep -qx "$username"; then
+        if breeze_group_has_member "$username"; then
             continue
         fi
-        if dscl . -append /Groups/breeze GroupMembership "$username" 2>/dev/null; then
+        dscl . -append /Groups/breeze GroupMembership "$username" 2>/dev/null || true
+        # Verify by re-reading rather than trusting dscl's exit status, so the
+        # success line below cannot claim a membership that did not take.
+        if breeze_group_has_member "$username"; then
             echo "Added $username to the 'breeze' group for desktop-helper socket access."
         else
             echo "Warning: could not add $username to the 'breeze' group; that user's desktop helper will be denied the agent socket" >&2

--- a/agent/scripts/install/install-darwin.sh
+++ b/agent/scripts/install/install-darwin.sh
@@ -39,6 +39,38 @@ ensure_breeze_group() {
     exit 1
 }
 
+# Add every logged-in GUI user to the breeze group so their desktop helper can
+# dial the 0660 root:breeze IPC socket. Mirrors the loop in
+# scripts/install/install-linux.sh; without it the socket is group-owned by a
+# group nobody is in and Standard (non-admin) users' helpers are denied
+# (#3133/#3134/#3137).
+#
+# NOTE: this script runs under `set -euo pipefail`, so every test is written as an
+# `if`. A bare `[ ... ] && continue` returns non-zero when false and would abort
+# the install.
+add_console_users_to_breeze_group() {
+    local uid username
+    for uid in $(ps -axo uid= -o comm= | grep -i '[lL]oginwindow' | awk '{print $1}' | sort -u); do
+        # macOS gives human accounts UIDs from 500 up; below that are system and
+        # service accounts, which never run a Breeze desktop helper.
+        if ! [ "$uid" -ge 500 ] 2>/dev/null; then
+            continue
+        fi
+        username=$(id -un "$uid" 2>/dev/null) || continue
+        if [ -z "$username" ]; then
+            continue
+        fi
+        if dscl . -read /Groups/breeze GroupMembership 2>/dev/null | tr ' ' '\n' | grep -qx "$username"; then
+            continue
+        fi
+        if dscl . -append /Groups/breeze GroupMembership "$username" 2>/dev/null; then
+            echo "Added $username to the 'breeze' group for desktop-helper socket access."
+        else
+            echo "Warning: could not add $username to the 'breeze' group; that user's desktop helper will be denied the agent socket" >&2
+        fi
+    done
+}
+
 # Stop existing service before replacing binary (safe for upgrades).
 if [ -f "$PLIST_DST" ]; then
     if launchctl unload "$PLIST_DST" 2>&1; then
@@ -146,6 +178,7 @@ fi
 
 # Create breeze group for IPC socket access
 ensure_breeze_group
+add_console_users_to_breeze_group
 
 # Create IPC socket directory
 mkdir -p "$CONFIG_DIR"
@@ -161,12 +194,14 @@ if [ -f "$CONFIG_DIR/agent.yaml" ] && grep -q 'agent_id:' "$CONFIG_DIR/agent.yam
     echo "  1. Start:   sudo launchctl load $PLIST_DST"
     echo "  2. Status:  sudo launchctl list | grep breeze"
     echo "  3. Logs:    tail -f $LOG_DIR/agent.log"
-    echo "  4. Add users to breeze group:  sudo dscl . -append /Groups/breeze GroupMembership <username>"
+    echo "  4. Users logged in now were added to the breeze group automatically."
+    echo "     Users who log in later are added by the agent when their helper starts."
 else
     echo "Next steps:"
     echo "  1. Enroll:  sudo breeze-agent enroll <enrollment-key> --server https://your-server [--enrollment-secret <secret>]"
     echo "  2. Start:   sudo launchctl load $PLIST_DST"
     echo "  3. Status:  sudo launchctl list | grep breeze"
     echo "  4. Logs:    tail -f $LOG_DIR/agent.log"
-    echo "  5. Add users to breeze group:  sudo dscl . -append /Groups/breeze GroupMembership <username>"
+    echo "  5. Users logged in now were added to the breeze group automatically."
+    echo "     Users who log in later are added by the agent when their helper starts."
 fi


### PR DESCRIPTION
## Problem

On macOS the agent **creates** a `breeze` group but never **applies** it to the IPC socket, and never puts any user in it. So `/Library/Application Support/Breeze/agent.sock` comes up `srw-rw---- root:admin` on every daemon start — BSD semantics give a new file the *parent directory's* group, and the config dir is group `admin`.

Mode `0660` + group `admin` means a Standard (non-admin) console user's desktop helper can never dial the socket. `com.breeze.desktop-helper-user` then crash-loops on `dial unix ".../Breeze/agent.sock": permission denied` (reporter observed runs≈133, last exit 1), which cascades into the TCC symptoms in the linked threads:

- Screen Recording reads **Granted** in System Settings while the helper reports `screenRecording=false` / `captureGranted=false` (ScreenCaptureKit timeout) — the probe runs in the helper's context, and the helper is dead.
- The loginwindow helper re-prompts for Screen Recording endlessly.
- Remote Desktop reads **Missing** / Desktop unavailable with FDA + SR + Accessibility all granted, because the agent never gets a live user-session helper link for that account.

Admin users worked only incidentally (they happen to be in `admin`). The only workaround was `chmod 666` on the socket, reapplied after every install, restart and reboot, since `setupSocket` re-chmods to `0660` on every start.

The `breeze` group creation already existed in all three install paths (`installer/macos/postinstall`, `scripts/install/install-darwin.sh`, `breeze-agent service install`). Only the *application* of it was missing — the mirror-image of `scripts/install/install-linux.sh`, which both chowns the IPC dir to `root:breeze` and adds every logged-in user to the group.

## Fix

Both halves of the invariant are now enforced, and both self-heal.

**1. The socket is group-owned.** `sessionbroker.setupSocket` resolves the `breeze` GID and chowns the socket to `root:breeze` before `chmod 0660`. It runs on **every daemon start**, so the socket comes back correct after a reboot, after `launchctl kickstart -k system/com.breeze.agent`, and after a self-update — the reporter's "sock likely recreated tight again after reboot" case.

Deliberately **not** `0666`. Peer-credential + binary-path verification (`internal/ipc`) stays the real admission gate, but a world-writable socket lets any local process connect and spend the broker's admission budget, and it is a footgun if the peer checks are ever loosened. `TestIPCSocketModeIsNotWorldAccessible` pins this so a future "simpler fix" cannot land `0666` as shipped behaviour.

**2. The console user is a member.** Group-owning the socket is useless alone: an admin installs the agent, a Standard user logs in later, and that user is in no group the socket grants. So:

- The daemon adds every logged-in GUI user to `breeze` whenever it touches the helper LaunchAgents — login, session switch, post-update kickstart — via `ensureDarwinHelperPrereqs`. This covers users who first log in months after install, which the installers cannot.
- Both macOS installers add users logged in at install time, mirroring the `install-linux.sh` loop.
- Always **before** any `launchctl kickstart`/`bootstrap`: a helper inherits its group list when it starts.
- Root and service accounts (uid < 500) are excluded, so the group is not widened to `_windowserver` and friends.

**Supporting fixes**

- The group is **re-ensured on every daemon start**, so a host installed by a build predating the group — or where an admin deleted it — recovers instead of staying broken forever.
- `breeze-agent service install` created the group *after* bootstrapping the helper LaunchAgents. Ordering reversed. The group-creation shell script now has one Go home (`sessionbroker.EnsureIPCGroup`) rather than being duplicated in `agentapp`.
- An unresolvable group logs a `WARN` naming the remedy and leaves the socket at `0660` instead of failing the broker. Aborting would leave the agent with **no** IPC socket, taking remote desktop, backup IPC and the watchdog link with it — strictly worse than the pre-fix root-only socket.
- `dscl` calls are bounded by a timeout, so a wedged `opendirectoryd` (a real macOS failure mode) cannot hold daemon startup — and therefore the whole session broker — hostage. Usernames are validated before reaching a privileged argv.
- The `dscl` GID lookup is Directory-Services-first, with `os/user` as fallback. This is load-bearing: release darwin binaries are built `CGO_ENABLED=0` (`scripts/build-edition.sh` defaults it to 0), and cgo-less `os/user` parses `/etc/group`, which never contains a `dscl`-created group. `os/user` alone would have failed on exactly the shipped configuration.

**Linux had the same latent defect** — `install-linux.sh` chowns `/run/breeze` to `root:breeze`, but the socket itself was created `root:root 0660`, so non-root helpers were locked out there too. The same `setupSocket` chown fixes it, and `os/user` resolves the group correctly from `/etc/group` without cgo.

## Tests

CI has **no macOS runner** — `test-agent` is `ubuntu-latest`, `test-agent-windows` is `windows-latest` — so anything in a `//go:build darwin` file compiles and runs **nowhere** (the #3019/#3046 lesson). The coverage is deliberately placed to actually run:

- `internal/sessionbroker/ipc_group_test.go` (**untagged** — runs on both the ubuntu and windows jobs): the ownership decision, the mode invariant, the `dscl` argv builders, `PrimaryGroupID` / `GroupMembership` parsing (inline + dscl's folded output shape, missing group, missing key), whole-token membership matching (`jing` must not match `jingxie`), and username validation.
- `internal/sessionbroker/ipc_group_unix_test.go` (**`!windows`** — runs on the ubuntu job): the real `chown`/`chmod` syscalls against a real unix socket via `setupSocket`, covering the happy path, the missing-group path, parent-directory traversability, and a stale socket left by a killed daemon.
- `internal/heartbeat/helper_group_test.go` (**untagged**): the UID-eligibility predicate.

Two things worth noting about the socket tests:

- They chown to a **supplementary** group, not the process's primary GID. A socket is already created with the primary GID, so asserting that would pass even if the chown never happened — the exact bug under test.
- They were **mutation-checked**: forcing `owner.GID = -1` in `setupSocket` (pre-fix behaviour) fails `TestSetupSocketAppliesGroupAndRestrictiveMode` and `TestSetupSocketReplacesAStaleSocket`. Reverting makes them pass.

**Status**
- `go test ./...` (agent, `CGO_ENABLED=0`, CI mode): green
- `go test -race` on `internal/sessionbroker` + `internal/heartbeat`: green
- `go vet` + `go build` for darwin arm64/amd64, linux amd64, windows amd64: clean (the darwin-tagged files CI never compiles were cross-vetted explicitly)
- `gofmt` clean on every touched file; `shellcheck -S warning` clean on both modified installers

## Not verified here — needs a real Mac

I have no macOS host with the agent installed, so the end-to-end behaviour is **not** field-verified. Specifically:

1. **Socket ownership** is deterministic and covered by the syscall tests, so I am confident `agent.sock` lands `root:breeze 0660` and survives reboot/kickstart.
2. **Membership taking effect for an already-logged-in user** is the open question. macOS resolves group membership through `opendirectoryd`, and it is not certain a helper restarted mid-session picks up a group added after that GUI session began. Worst case it takes effect at the user's next login — still strictly better than today, where it never works at all, and no worse than a `chmod` that must be reapplied after every restart. A Standard-user login test on a real Mac is the thing to confirm before promoting the build.

## For @SemoTech

Once this ships in an agent build, please **remove both workarounds** and retest:

1. Stop the `chmod 666` on `agent.sock` after install/restart — the socket should now be `srw-rw---- root:breeze` on its own, and stay that way across reboot and `launchctl kickstart -k system/com.breeze.agent`. Please confirm with `ls -l "/Library/Application Support/Breeze/agent.sock"`.
2. Restore `com.breeze.desktop-helper-loginwindow.plist` — the prompt loop was downstream of the dead user-session helper. (Note the separate point from the earlier thread: login-window WebRTC desktop control cannot work on macOS regardless, since Apple blocks synthetic input there without a private entitlement; that path falls back to the VNC relay.)

The check that matters for a **Standard (non-admin)** user: `id -Gn <user>` should list `breeze`, and their `com.breeze.desktop-helper-user` LaunchAgent should stop crash-looping. If a user who was already logged in when the agent upgraded still cannot connect, please log them out and back in and report whether that fixes it — that is exactly the uncertainty in point 2 above, and your answer decides whether a forced helper re-login is also needed.

Refs #3133
Refs #3134
Refs #3137

(Not `Closes` — these are Discord-relayed community reports, so they stay open until the reporter verifies on real hardware.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
