### PR TITLE
fix(groups): accept a null filterConditions on create and stop dropping static deviceIds (#3159)

### DIFF
--- a/apps/api/src/routes/groups.test.ts
+++ b/apps/api/src/routes/groups.test.ts
@@ -15,10 +15,20 @@ vi.mock('../services/filterEngine', () => ({
   validateFilter: vi.fn(() => ({ valid: true }))
 }));
 
-vi.mock('../services/groupMembership', () => ({
-  evaluateGroupMembership: vi.fn(),
-  pinDeviceToGroup: vi.fn()
-}));
+vi.mock('../services/groupMembership', async () => {
+  const actual = await vi.importActual<typeof import('../services/groupMembership')>(
+    '../services/groupMembership'
+  );
+  return {
+    evaluateGroupMembership: vi.fn(),
+    pinDeviceToGroup: vi.fn(),
+    // Real: the extracted tenancy guard + membership insert that group-create
+    // (#3159) and POST /:id/devices now share. The site-confinement cases below
+    // are that logic's coverage, run against the already-mocked `../db`.
+    validateManualMembershipDevices: actual.validateManualMembershipDevices,
+    addManualGroupMemberships: actual.addManualGroupMemberships
+  };
+});
 
 vi.mock('../db', () => ({
   db: {

--- a/apps/api/src/routes/groups.ts
+++ b/apps/api/src/routes/groups.ts
@@ -7,9 +7,11 @@ import { deviceGroups, deviceGroupMemberships, devices, groupMembershipLog, site
 import { authMiddleware, requireMfa, requirePermission, requireScope, type AuthContext } from '../middleware/auth';
 import { evaluateFilterWithPreview, extractFieldsFromFilter, validateFilter } from '../services/filterEngine';
 import {
+  addManualGroupMemberships,
   evaluateGroupMembership,
   pinDeviceToGroup,
   pruneGroupMembershipsOutsideSite,
+  validateManualMembershipDevices,
 } from '../services/groupMembership';
 import { writeRouteAudit } from '../services/auditEvents';
 import type { FilterConditionGroup } from '../services/filterEngine';
@@ -90,13 +92,38 @@ const listGroupsQuerySchema = z.object({
   includeMemberships: z.enum(['true', 'false']).optional()
 });
 
+/**
+ * ONE definition of the `filterConditions` field, shared by create and update.
+ *
+ * #3159: create declared this `.optional()` while update declared it
+ * `.nullable().optional()`, so the very same dashboard payload could edit a
+ * group but never create one — every static-group creation 400'd on
+ * `expected object, received null`. Three accepted forms, identical on both
+ * verbs: omitted, a filter object, or an explicit `null` meaning "no filter".
+ *
+ * `null` is not merely tolerated, it is load-bearing on update: the PATCH route
+ * distinguishes `undefined` ("leave the filter alone") from `null` ("clear it"),
+ * which is how a dynamic group is converted to static. Keep this as one
+ * constant — the two schemas drifting apart is the defect itself, not the
+ * symptom.
+ */
+const groupFilterConditionsField = filterConditionGroupSchema.nullable().optional();
+
 const createGroupSchema = z.object({
   orgId: z.string().guid().optional(),
   siteId: z.string().guid().optional(),
   name: z.string().min(1).max(255),
   type: z.enum(['static', 'dynamic']).default('static'),
   rules: z.any().optional(),
-  filterConditions: filterConditionGroupSchema.optional(),
+  filterConditions: groupFilterConditionsField,
+  /**
+   * Initial membership for a STATIC group. The dashboard has always sent this
+   * on create; the schema used to omit the key entirely, so Zod stripped it and
+   * the group was created empty with a 201 — a silent failure that outlived the
+   * 400 above (#3159). Validated against the group's own org and site before
+   * the group row is written.
+   */
+  deviceIds: z.array(z.string().guid()).optional(),
   parentId: z.string().guid().optional()
 });
 
@@ -105,7 +132,7 @@ const updateGroupSchema = z.object({
   siteId: z.string().guid().nullable().optional(),
   type: z.enum(['static', 'dynamic']).optional(),
   rules: z.any().optional(),
-  filterConditions: filterConditionGroupSchema.nullable().optional(),
+  filterConditions: groupFilterConditionsField,
   parentId: z.string().guid().nullable().optional()
 });
 
@@ -473,6 +500,39 @@ groupRoutes.post(
       filterFieldsUsed = extractFieldsFromFilter(payload.filterConditions);
     }
 
+    // Initial static membership, validated BEFORE the group row is inserted.
+    //
+    // Order matters: a `return c.json(..., 400)` is a normal response, not an
+    // exception, so the request transaction still commits. Validating after the
+    // insert would leave a stranded empty group behind on every rejected batch
+    // and invite a duplicate on retry. An empty array is not an error — it is
+    // what the dashboard sends for a group with no devices selected.
+    const requestedDeviceIds = payload.deviceIds ?? [];
+    if (requestedDeviceIds.length > 0) {
+      if (payload.type === 'dynamic') {
+        return c.json(
+          {
+            error:
+              'Cannot assign devices to a dynamic group; its membership is computed from filterConditions'
+          },
+          400
+        );
+      }
+
+      const deviceValidation = await validateManualMembershipDevices({
+        deviceIds: requestedDeviceIds,
+        orgId: orgId!,
+        siteId: payload.siteId ?? null
+      });
+
+      if (!deviceValidation.ok) {
+        const body = deviceValidation.invalidDevices
+          ? { error: deviceValidation.error, invalidDevices: deviceValidation.invalidDevices }
+          : { error: deviceValidation.error };
+        return c.json(body, deviceValidation.status);
+      }
+    }
+
     const [group] = await db
       .insert(deviceGroups)
       .values({
@@ -505,7 +565,38 @@ groupRoutes.post(
       }
     });
 
-    // If dynamic group with filter, materialize membership before responding.
+    // Membership is materialized before responding, so the 201 carries a device
+    // count the caller can trust for either group type.
+    let deviceCount = 0;
+
+    // Static groups: materialize the devices the caller selected, in the same
+    // request (and therefore the same transaction) as the group itself. Shares
+    // the exact validation + insert path as `POST /:id/devices`, so there is one
+    // implementation of the cross-tenant guard, not two.
+    if (group.type === 'static' && requestedDeviceIds.length > 0) {
+      const { added } = await addManualGroupMemberships({
+        groupId: group.id,
+        orgId: group.orgId,
+        deviceIds: requestedDeviceIds
+      });
+      deviceCount = added.length;
+
+      writeRouteAudit(c, {
+        orgId: group.orgId,
+        action: 'device_group.device.add',
+        resourceType: 'device_group',
+        resourceId: group.id,
+        resourceName: group.name,
+        details: {
+          addedCount: added.length,
+          skippedCount: 0,
+          deviceIds: added,
+          viaGroupCreate: true
+        }
+      });
+    }
+
+    // Dynamic groups: evaluate the filter before responding.
     //
     // This used to be fire-and-forget (`evaluateGroupMembership(id).catch(...)`),
     // which never worked: the detached promise resumed AFTER the request's
@@ -517,7 +608,6 @@ groupRoutes.post(
     // context — the correct tenant, enforced by Postgres — and lets the response
     // carry the real device count. The evaluation is a handful of statements
     // (bounded filter query + bulk insert), not a per-device loop.
-    let deviceCount = 0;
     if (group.type === 'dynamic' && group.filterConditions) {
       try {
         await evaluateGroupMembership(group.id);
@@ -814,56 +904,27 @@ groupRoutes.post(
       return c.json({ error: 'Cannot manually add devices to a dynamic group' }, 400);
     }
 
-    // Verify all devices exist and belong to the same org
-    const deviceRows = await db
-      .select({ id: devices.id, orgId: devices.orgId, siteId: devices.siteId })
-      .from(devices)
-      .where(inArray(devices.id, payload.deviceIds));
-
-    const deviceMap = new Map(deviceRows.map((d) => [d.id, d]));
-    const invalidDevices = payload.deviceIds.filter((deviceId) => {
-      const device = deviceMap.get(deviceId);
-      return !device || device.orgId !== group.orgId;
+    // Verify every device exists, belongs to this org, and respects a
+    // site-bound group's boundary. Shared with the create route so the
+    // cross-tenant guard has exactly one implementation (#3159).
+    const deviceValidation = await validateManualMembershipDevices({
+      deviceIds: payload.deviceIds,
+      orgId: group.orgId,
+      siteId: group.siteId
     });
 
-    if (invalidDevices.length > 0) {
-      return c.json({
-        error: 'Some devices are invalid or belong to a different organization',
-        invalidDevices
-      }, 400);
+    if (!deviceValidation.ok) {
+      const body = deviceValidation.invalidDevices
+        ? { error: deviceValidation.error, invalidDevices: deviceValidation.invalidDevices }
+        : { error: deviceValidation.error };
+      return c.json(body, deviceValidation.status);
     }
 
-    // A site-bound group is itself the membership boundary, even when the
-    // caller can access multiple sites. Reject the complete batch before any
-    // write if one device falls outside that persisted site.
-    if (group.siteId !== null && deviceRows.some((device) => device.siteId !== group.siteId)) {
-      return c.json({ error: 'Access to this site denied' }, 403);
-    }
-
-    // Get existing memberships to avoid duplicates
-    const existingMemberships = await db
-      .select({ deviceId: deviceGroupMemberships.deviceId })
-      .from(deviceGroupMemberships)
-      .where(
-        and(
-          eq(deviceGroupMemberships.groupId, id),
-          inArray(deviceGroupMemberships.deviceId, payload.deviceIds)
-        )
-      );
-
-    const existingSet = new Set(existingMemberships.map((m) => m.deviceId));
-    const newDeviceIds = payload.deviceIds.filter((deviceId) => !existingSet.has(deviceId));
-
-    if (newDeviceIds.length > 0) {
-      await db.insert(deviceGroupMemberships).values(
-        newDeviceIds.map((deviceId) => ({
-          deviceId,
-          groupId: id,
-          orgId: group.orgId,
-          addedBy: 'manual' as const
-        }))
-      );
-    }
+    const { added: newDeviceIds, skipped } = await addManualGroupMemberships({
+      groupId: id,
+      orgId: group.orgId,
+      deviceIds: payload.deviceIds
+    });
 
     writeRouteAudit(c, {
       orgId: group.orgId,
@@ -873,7 +934,7 @@ groupRoutes.post(
       resourceName: group.name,
       details: {
         addedCount: newDeviceIds.length,
-        skippedCount: existingMemberships.length,
+        skippedCount: skipped,
         deviceIds: newDeviceIds
       }
     });
@@ -883,7 +944,7 @@ groupRoutes.post(
     return c.json({
       data: {
         added: newDeviceIds.length,
-        skipped: existingMemberships.length,
+        skipped,
         total: deviceCount
       }
     }, 201);

--- a/apps/api/src/routes/groups_devices.test.ts
+++ b/apps/api/src/routes/groups_devices.test.ts
@@ -34,10 +34,21 @@ vi.mock('../services/filterEngine', () => ({
   validateFilter: vi.fn().mockReturnValue({ valid: true, errors: [] })
 }));
 
-vi.mock('../services/groupMembership', () => ({
-  evaluateGroupMembership: vi.fn().mockResolvedValue(undefined),
-  pinDeviceToGroup: vi.fn().mockResolvedValue(undefined)
-}));
+vi.mock('../services/groupMembership', async () => {
+  const actual = await vi.importActual<typeof import('../services/groupMembership')>(
+    '../services/groupMembership'
+  );
+  return {
+    evaluateGroupMembership: vi.fn().mockResolvedValue(undefined),
+    pinDeviceToGroup: vi.fn().mockResolvedValue(undefined),
+    pruneGroupMembershipsOutsideSite: vi.fn().mockResolvedValue(undefined),
+    // Real: the extracted tenancy guard + membership insert that POST
+    // /:id/devices used to carry inline. These tests are that logic's
+    // coverage, exercised against the already-mocked `../db` / `../db/schema`.
+    validateManualMembershipDevices: actual.validateManualMembershipDevices,
+    addManualGroupMemberships: actual.addManualGroupMemberships
+  };
+});
 
 vi.mock('../db', () => ({
   db: {

--- a/apps/api/src/routes/groups_get_create.test.ts
+++ b/apps/api/src/routes/groups_get_create.test.ts
@@ -125,6 +125,7 @@ vi.mock('../middleware/auth', () => ({
 }));
 
 import { db } from '../db';
+import { writeRouteAudit } from '../services/auditEvents';
 import { authMiddleware } from '../middleware/auth';
 import { validateFilter } from '../services/filterEngine';
 import { evaluateGroupMembership } from '../services/groupMembership';
@@ -568,7 +569,9 @@ describe('groups routes', () => {
         // "filterConditions: Invalid input: expected object, received null".
         expect(res.status).toBe(201);
         expect(valuesMock).toHaveBeenCalledTimes(1);
-        expect(valuesMock.mock.calls[0][0]).toMatchObject({ filterConditions: null });
+        const [groupInsert] = valuesMock.mock.calls;
+        if (!groupInsert) throw new Error('the group insert was never called');
+        expect(groupInsert[0]).toMatchObject({ filterConditions: null });
       });
 
       it('accepts an omitted filterConditions', async () => {
@@ -646,13 +649,30 @@ describe('groups routes', () => {
 
         expect(res.status).toBe(201);
         expect(membershipValuesMock).toHaveBeenCalledTimes(1);
-        const rows = membershipValuesMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+        const [membershipInsert] = membershipValuesMock.mock.calls;
+        if (!membershipInsert) throw new Error('the membership insert was never called');
+        const rows = membershipInsert[0] as Array<Record<string, unknown>>;
         expect(rows).toHaveLength(2);
         for (const row of rows) {
           expect(row).toMatchObject({ groupId: GROUP_ID, orgId: ORG_ID, addedBy: 'manual' });
         }
         const body = await res.json();
         expect(body.data.deviceCount).toBe(2);
+
+        // The membership write gets its own audit event, distinguishable from a
+        // later manual add by `viaGroupCreate`.
+        expect(vi.mocked(writeRouteAudit)).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            action: 'device_group.device.add',
+            orgId: ORG_ID,
+            details: expect.objectContaining({
+              addedCount: 2,
+              deviceIds: [DEVICE_ID, DEVICE_ID_2],
+              viaGroupCreate: true
+            })
+          })
+        );
       });
 
       it('rejects deviceIds on a dynamic create', async () => {

--- a/apps/api/src/routes/groups_get_create.test.ts
+++ b/apps/api/src/routes/groups_get_create.test.ts
@@ -35,10 +35,21 @@ vi.mock('../services/filterEngine', () => ({
   validateFilter: vi.fn().mockReturnValue({ valid: true, errors: [] })
 }));
 
-vi.mock('../services/groupMembership', () => ({
-  evaluateGroupMembership: vi.fn().mockResolvedValue(undefined),
-  pinDeviceToGroup: vi.fn().mockResolvedValue(undefined)
-}));
+vi.mock('../services/groupMembership', async () => {
+  const actual = await vi.importActual<typeof import('../services/groupMembership')>(
+    '../services/groupMembership'
+  );
+  return {
+    evaluateGroupMembership: vi.fn().mockResolvedValue(undefined),
+    pinDeviceToGroup: vi.fn().mockResolvedValue(undefined),
+    pruneGroupMembershipsOutsideSite: vi.fn().mockResolvedValue(undefined),
+    // Real: the extracted tenancy guard + membership insert that group-create
+    // (#3159) and POST /:id/devices now share. These tests are that logic's
+    // coverage, exercised against the already-mocked `../db` / `../db/schema`.
+    validateManualMembershipDevices: actual.validateManualMembershipDevices,
+    addManualGroupMemberships: actual.addManualGroupMemberships
+  };
+});
 
 vi.mock('../db', () => ({
   db: {
@@ -530,6 +541,218 @@ describe('groups routes', () => {
       const body = await res.json();
       expect(body.error).toContain('Site not found');
       expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    // ----------------------------------------------------------------
+    // #3159 — static group creation
+    // ----------------------------------------------------------------
+    // Earlier cases in this file leave unconsumed `mockReturnValueOnce` entries
+    // on db.select and `vi.clearAllMocks()` in the outer `beforeEach` does not
+    // drain that queue — every test here starts with an explicit
+    // `db.select.mockReset()`.
+    describe('#3159 static group creation', () => {
+      it('accepts an explicit filterConditions: null', async () => {
+        vi.mocked(db.select).mockReset();
+        const valuesMock = vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([makeGroup({ type: 'static', filterConditions: null })])
+        });
+        vi.mocked(db.insert).mockReturnValueOnce({ values: valuesMock } as any);
+
+        const res = await app.request('/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ name: 'Static', type: 'static', filterConditions: null })
+        });
+
+        // The headline regression: before the fix this 400'd with
+        // "filterConditions: Invalid input: expected object, received null".
+        expect(res.status).toBe(201);
+        expect(valuesMock).toHaveBeenCalledTimes(1);
+        expect(valuesMock.mock.calls[0][0]).toMatchObject({ filterConditions: null });
+      });
+
+      it('accepts an omitted filterConditions', async () => {
+        vi.mocked(db.select).mockReset();
+        vi.mocked(db.insert).mockReturnValueOnce({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([makeGroup({ type: 'static' })])
+          })
+        } as any);
+
+        const res = await app.request('/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ name: 'Static', type: 'static' })
+        });
+
+        expect(res.status).toBe(201);
+      });
+
+      it('accepts a filter object for a dynamic group', async () => {
+        vi.mocked(db.select).mockReset();
+        // getDeviceCountForGroup, read after the (mocked) evaluateGroupMembership.
+        vi.mocked(db.select).mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ count: 2 }]) })
+        } as any);
+        const filterConditions = {
+          operator: 'AND' as const,
+          conditions: [{ field: 'osType', operator: 'equals', value: 'windows' }]
+        };
+        vi.mocked(db.insert).mockReturnValueOnce({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([makeGroup({ type: 'dynamic', filterConditions })])
+          })
+        } as any);
+
+        const res = await app.request('/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ name: 'Dynamic', type: 'dynamic', filterConditions })
+        });
+
+        // Proves widening the field to `.nullable()` did not break the object form.
+        expect(res.status).toBe(201);
+      });
+
+      it('seeds membership from deviceIds on a static create', async () => {
+        vi.mocked(db.select).mockReset();
+        vi.mocked(db.select)
+          // validateManualMembershipDevices: device lookup
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([
+                { id: DEVICE_ID, orgId: ORG_ID, siteId: null },
+                { id: DEVICE_ID_2, orgId: ORG_ID, siteId: null }
+              ])
+            })
+          } as any)
+          // addManualGroupMemberships: existing-membership lookup
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([]) })
+          } as any);
+
+        const created = makeGroup({ type: 'static' });
+        vi.mocked(db.insert).mockReturnValueOnce({
+          values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([created]) })
+        } as any);
+        const membershipValuesMock = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(db.insert).mockReturnValueOnce({ values: membershipValuesMock } as any);
+
+        const res = await app.request('/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ name: 'Static', type: 'static', deviceIds: [DEVICE_ID, DEVICE_ID_2] })
+        });
+
+        expect(res.status).toBe(201);
+        expect(membershipValuesMock).toHaveBeenCalledTimes(1);
+        const rows = membershipValuesMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+        expect(rows).toHaveLength(2);
+        for (const row of rows) {
+          expect(row).toMatchObject({ groupId: GROUP_ID, orgId: ORG_ID, addedBy: 'manual' });
+        }
+        const body = await res.json();
+        expect(body.data.deviceCount).toBe(2);
+      });
+
+      it('rejects deviceIds on a dynamic create', async () => {
+        vi.mocked(db.select).mockReset();
+
+        const res = await app.request('/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({
+            name: 'Dynamic',
+            type: 'dynamic',
+            filterConditions: {
+              operator: 'AND',
+              conditions: [{ field: 'osType', operator: 'equals', value: 'windows' }]
+            },
+            deviceIds: [DEVICE_ID]
+          })
+        });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toContain('dynamic group');
+        expect(db.insert).not.toHaveBeenCalled();
+      });
+
+      it('rejects a cross-org device and creates no group', async () => {
+        vi.mocked(db.select).mockReset();
+        vi.mocked(db.select).mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ id: DEVICE_ID, orgId: ORG_ID_2, siteId: null }])
+          })
+        } as any);
+
+        const res = await app.request('/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ name: 'Static', type: 'static', deviceIds: [DEVICE_ID] })
+        });
+
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.invalidDevices).toContain(DEVICE_ID);
+        // No orphan empty group left behind on a rejected batch.
+        expect(db.insert).not.toHaveBeenCalled();
+      });
+
+      it("rejects a device outside a site-bound group's site with 403 and creates no group", async () => {
+        vi.mocked(db.select).mockReset();
+        vi.mocked(db.select)
+          // siteBelongsToOrg
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([{ id: SITE_ID }])
+              })
+            })
+          } as any)
+          // validateManualMembershipDevices: device lookup
+          .mockReturnValueOnce({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ id: DEVICE_ID, orgId: ORG_ID, siteId: SITE_ID_2 }])
+            })
+          } as any);
+
+        const res = await app.request('/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({
+            name: 'Static',
+            type: 'static',
+            siteId: SITE_ID,
+            deviceIds: [DEVICE_ID]
+          })
+        });
+
+        expect(res.status).toBe(403);
+        const body = await res.json();
+        expect(body.error).toBe('Access to this site denied');
+        expect(db.insert).not.toHaveBeenCalled();
+      });
+
+      it('does not query devices when deviceIds is an empty array', async () => {
+        vi.mocked(db.select).mockReset();
+        vi.mocked(db.insert).mockReturnValueOnce({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([makeGroup({ type: 'static' })])
+          })
+        } as any);
+
+        const res = await app.request('/groups', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer token' },
+          body: JSON.stringify({ name: 'Static', type: 'static', deviceIds: [] })
+        });
+
+        // An empty list is not an error — it's what the dashboard sends for a
+        // group with no devices selected — and it must not trigger a lookup.
+        expect(res.status).toBe(201);
+        expect(db.select).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/api/src/services/groupMembership.manualMembership.test.ts
+++ b/apps/api/src/services/groupMembership.manualMembership.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit coverage for the two helpers extracted for #3159: the shared tenancy
+ * guard (`validateManualMembershipDevices`) and the shared membership writer
+ * (`addManualGroupMemberships`), used by both group-create (`POST /groups`)
+ * and `POST /:id/devices`. See the doc comments on both functions in
+ * `groupMembership.ts` for the invariants being tested here.
+ *
+ * Mocking style copied from `groupMembership.materialization.test.ts` (the
+ * established db-mocking harness for this directory).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSelect, mockInsert } = vi.hoisted(() => ({
+  mockSelect: vi.fn(),
+  mockInsert: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  db: {
+    select: mockSelect,
+    insert: mockInsert,
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  hasDbAccessContext: vi.fn().mockReturnValue(true),
+  getCurrentDbAccessContext: vi.fn().mockReturnValue({ scope: 'organization', orgId: 'org-a' }),
+}));
+
+vi.mock('../db/schema', () => ({
+  deviceGroups: {
+    id: 'group.id',
+    type: 'group.type',
+    filterConditions: 'group.filterConditions',
+    filterFieldsUsed: 'group.filterFieldsUsed',
+    orgId: 'group.orgId',
+    siteId: 'group.siteId',
+  },
+  devices: { id: 'device.id', orgId: 'device.orgId', siteId: 'device.siteId' },
+  deviceGroupMemberships: {
+    groupId: 'membership.groupId',
+    deviceId: 'membership.deviceId',
+    isPinned: 'membership.isPinned',
+  },
+  groupMembershipLog: {},
+}));
+
+vi.mock('./filterEngine', () => ({
+  deviceMatchesFilter: vi.fn(),
+  evaluateFilter: vi.fn(),
+  extractFieldsFromFilter: vi.fn().mockReturnValue([]),
+}));
+
+import { addManualGroupMemberships, validateManualMembershipDevices } from './groupMembership';
+
+const ORG_ID = 'org-a';
+const ORG_ID_2 = 'org-b';
+const SITE_ID = 'site-x';
+const SITE_ID_2 = 'site-y';
+const GROUP_ID = 'group-1';
+const D1 = 'device-1';
+const D2 = 'device-2';
+
+/** `db.select().from().where()` (list queries, no `.limit()`). */
+function whereChain(rows: unknown[]) {
+  return { from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }) };
+}
+
+let insertedRows: unknown[][];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertedRows = [];
+  mockInsert.mockImplementation(() => ({
+    values: (rows: unknown[]) => {
+      insertedRows.push(rows);
+      return Promise.resolve(undefined);
+    },
+  }));
+});
+
+describe('validateManualMembershipDevices', () => {
+  it('returns ok without querying the database when deviceIds is empty', async () => {
+    const result = await validateManualMembershipDevices({ deviceIds: [], orgId: ORG_ID, siteId: null });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('accepts devices that are all in the same org with no site boundary', async () => {
+    mockSelect.mockReturnValueOnce(whereChain([
+      { id: D1, orgId: ORG_ID, siteId: null },
+      { id: D2, orgId: ORG_ID, siteId: null },
+    ]));
+
+    const result = await validateManualMembershipDevices({
+      deviceIds: [D1, D2],
+      orgId: ORG_ID,
+      siteId: null,
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects a device belonging to a different org', async () => {
+    mockSelect.mockReturnValueOnce(whereChain([
+      { id: D1, orgId: ORG_ID_2, siteId: null },
+    ]));
+
+    const result = await validateManualMembershipDevices({
+      deviceIds: [D1],
+      orgId: ORG_ID,
+      siteId: null,
+    });
+
+    expect(result).toMatchObject({ ok: false, status: 400 });
+    expect((result as { invalidDevices?: string[] }).invalidDevices).toContain(D1);
+  });
+
+  it('rejects a requested device the query does not return at all (RLS-invisible or nonexistent)', async () => {
+    mockSelect.mockReturnValueOnce(whereChain([]));
+
+    const result = await validateManualMembershipDevices({
+      deviceIds: [D1],
+      orgId: ORG_ID,
+      siteId: null,
+    });
+
+    expect(result).toMatchObject({ ok: false, status: 400 });
+    expect((result as { invalidDevices?: string[] }).invalidDevices).toContain(D1);
+  });
+
+  it('rejects a device outside the group site with 403', async () => {
+    mockSelect.mockReturnValueOnce(whereChain([
+      { id: D1, orgId: ORG_ID, siteId: SITE_ID_2 },
+    ]));
+
+    const result = await validateManualMembershipDevices({
+      deviceIds: [D1],
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+    });
+
+    expect(result).toEqual({ ok: false, status: 403, error: 'Access to this site denied' });
+  });
+
+  it('accepts every device sitting in the group site', async () => {
+    mockSelect.mockReturnValueOnce(whereChain([
+      { id: D1, orgId: ORG_ID, siteId: SITE_ID },
+      { id: D2, orgId: ORG_ID, siteId: SITE_ID },
+    ]));
+
+    const result = await validateManualMembershipDevices({
+      deviceIds: [D1, D2],
+      orgId: ORG_ID,
+      siteId: SITE_ID,
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('dedupes duplicate ids in the request', async () => {
+    mockSelect.mockReturnValueOnce(whereChain([
+      { id: D1, orgId: ORG_ID, siteId: null },
+    ]));
+
+    const result = await validateManualMembershipDevices({
+      deviceIds: [D1, D1],
+      orgId: ORG_ID,
+      siteId: null,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect((result as { invalidDevices?: string[] }).invalidDevices).toBeUndefined();
+  });
+});
+
+describe('addManualGroupMemberships', () => {
+  it('skips devices that are already members', async () => {
+    mockSelect.mockReturnValueOnce(whereChain([{ deviceId: D1 }]));
+
+    const result = await addManualGroupMemberships({
+      groupId: GROUP_ID,
+      orgId: ORG_ID,
+      deviceIds: [D1, D2],
+    });
+
+    expect(result).toEqual({ added: [D2], skipped: 1 });
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(insertedRows[0]).toEqual([
+      { deviceId: D2, groupId: GROUP_ID, orgId: ORG_ID, addedBy: 'manual' },
+    ]);
+  });
+
+  it('does nothing for an empty deviceIds list', async () => {
+    const result = await addManualGroupMemberships({
+      groupId: GROUP_ID,
+      orgId: ORG_ID,
+      deviceIds: [],
+    });
+
+    expect(result).toEqual({ added: [], skipped: 0 });
+    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/services/groupMembership.manualMembership.test.ts
+++ b/apps/api/src/services/groupMembership.manualMembership.test.ts
@@ -202,4 +202,22 @@ describe('addManualGroupMemberships', () => {
     expect(mockSelect).not.toHaveBeenCalled();
     expect(mockInsert).not.toHaveBeenCalled();
   });
+
+  it('inserts one row per device when the request repeats an id', async () => {
+    mockSelect.mockReturnValueOnce(whereChain([]));
+
+    const result = await addManualGroupMemberships({
+      groupId: GROUP_ID,
+      orgId: ORG_ID,
+      deviceIds: [D1, D1],
+    });
+
+    // `(device_id, group_id)` is the membership primary key, so a duplicate in
+    // the payload has to collapse before the insert rather than becoming a
+    // constraint violation surfacing as a 500.
+    expect(result).toEqual({ added: [D1], skipped: 0 });
+    expect(insertedRows[0]).toEqual([
+      { deviceId: D1, groupId: GROUP_ID, orgId: ORG_ID, addedBy: 'manual' },
+    ]);
+  });
 });

--- a/apps/api/src/services/groupMembership.ts
+++ b/apps/api/src/services/groupMembership.ts
@@ -543,3 +543,122 @@ export async function removeDeviceFromAllGroups(deviceId: string): Promise<void>
     .delete(deviceGroupMemberships)
     .where(eq(deviceGroupMemberships.deviceId, deviceId));
 }
+
+/**
+ * Outcome of validating a batch of client-supplied device ids for MANUAL
+ * (static-group) membership. A result object rather than a thrown error on
+ * purpose: both callers turn it straight into an HTTP status, and the group
+ * CREATE route has to be able to reject a batch *before* it inserts the group
+ * row.
+ */
+export type ManualMembershipValidation =
+  | { ok: true }
+  | { ok: false; status: 400 | 403; error: string; invalidDevices?: string[] };
+
+/**
+ * Tenancy guard for manually assigned static-group membership.
+ *
+ * Every id passed here is client-supplied, so this is the only thing standing
+ * between a forged payload and a cross-tenant membership row. Two properties
+ * are enforced, both against the GROUP's own org/site — never against anything
+ * else in the request body:
+ *
+ * 1. Every requested device must exist AND belong to `orgId`. A device the
+ *    caller cannot see reads back as absent under RLS and lands in the same
+ *    `invalidDevices` bucket, so "not yours" and "not there" are
+ *    indistinguishable to the caller. That is deliberate.
+ * 2. A site-bound group IS the membership boundary: when the group carries a
+ *    `siteId`, every device must sit in that same site even if the caller can
+ *    access several sites. The whole batch is rejected before any write.
+ *
+ * Extracted from `POST /:id/devices` so group-create can apply the identical
+ * rules: #3159 shipped a create route that silently dropped `deviceIds`, and
+ * the fix must not reimplement this check a second time and let the two copies
+ * drift.
+ */
+export async function validateManualMembershipDevices(params: {
+  deviceIds: readonly string[];
+  orgId: string;
+  siteId: string | null;
+}): Promise<ManualMembershipValidation> {
+  const { orgId, siteId } = params;
+  const requested = [...new Set(params.deviceIds)];
+  if (requested.length === 0) return { ok: true };
+
+  const deviceRows = await db
+    .select({ id: devices.id, orgId: devices.orgId, siteId: devices.siteId })
+    .from(devices)
+    .where(inArray(devices.id, requested));
+
+  const deviceMap = new Map(deviceRows.map((row) => [row.id, row]));
+  const invalidDevices = requested.filter((deviceId) => {
+    const device = deviceMap.get(deviceId);
+    return !device || device.orgId !== orgId;
+  });
+
+  if (invalidDevices.length > 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Some devices are invalid or belong to a different organization',
+      invalidDevices
+    };
+  }
+
+  if (siteId !== null && deviceRows.some((device) => device.siteId !== siteId)) {
+    return { ok: false, status: 403, error: 'Access to this site denied' };
+  }
+
+  return { ok: true };
+}
+
+export interface ManualMembershipWrite {
+  /** Device ids that gained a membership row on this call. */
+  added: string[];
+  /** Requested devices that were already members. */
+  skipped: number;
+}
+
+/**
+ * Inserts manual membership rows for a STATIC group, skipping devices that are
+ * already members.
+ *
+ * Callers MUST have run `validateManualMembershipDevices` first: this function
+ * trusts `orgId` and stamps it onto every row, so it is the wrong place to
+ * accept a client-supplied org.
+ */
+export async function addManualGroupMemberships(params: {
+  groupId: string;
+  orgId: string;
+  deviceIds: readonly string[];
+}): Promise<ManualMembershipWrite> {
+  const { groupId, orgId } = params;
+  const requested = [...new Set(params.deviceIds)];
+  if (requested.length === 0) return { added: [], skipped: 0 };
+
+  const existing = await db
+    .select({ deviceId: deviceGroupMemberships.deviceId })
+    .from(deviceGroupMemberships)
+    .where(
+      and(
+        eq(deviceGroupMemberships.groupId, groupId),
+        inArray(deviceGroupMemberships.deviceId, requested)
+      )
+    );
+
+  const existingSet = new Set(existing.map((row) => row.deviceId));
+  const added = requested.filter((deviceId) => !existingSet.has(deviceId));
+
+  if (added.length > 0) {
+    await db.insert(deviceGroupMemberships).values(
+      added.map((deviceId) => ({
+        deviceId,
+        groupId,
+        orgId,
+        addedBy: 'manual' as const
+      }))
+    );
+  }
+
+  return { added, skipped: existingSet.size };
+}

--- a/apps/web/src/components/devices/DeviceGroupsPage.staticGroups.test.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.staticGroups.test.tsx
@@ -1,0 +1,206 @@
+import '@/lib/i18n';
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import DeviceGroupsPage from './DeviceGroupsPage';
+import { fetchWithAuth } from '../../stores/auth';
+
+vi.mock('../../stores/auth', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock('../../hooks/useFilterPreview', () => ({
+  useFilterPreview: () => ({
+    preview: null,
+    loading: false,
+    error: undefined,
+    refresh: vi.fn(),
+  }),
+}));
+
+const mockFetch = vi.mocked(fetchWithAuth);
+
+const jsonResponse = (body: unknown) =>
+  ({ ok: true, status: 200, json: async () => body }) as unknown as Response;
+
+const DEVICES = [
+  { id: 'device-1', hostname: 'web-01', osType: 'windows', siteId: 'site-1' },
+  { id: 'device-2', hostname: 'db-01', osType: 'linux', siteId: 'site-1' },
+];
+
+const SUPPORTING_RESPONSES: Record<string, unknown> = {
+  '/devices': { data: DEVICES, pagination: { page: 1, limit: 50, total: DEVICES.length } },
+  '/orgs/sites': { data: [{ id: 'site-1', name: 'HQ' }], pagination: { page: 1, limit: 50, total: 1 } },
+  '/policies': { data: [], pagination: { page: 1, limit: 50, total: 0 } },
+  '/scripts': { data: [], pagination: { page: 1, limit: 50, total: 0 } },
+};
+
+/**
+ * Serves the group list plus the supporting endpoints. `writeResponse` stands in
+ * for whatever the create/edit write returns, so a test can make the server
+ * reject the submission.
+ */
+const serveGroups = (groups: unknown[], writeResponse?: Response) => {
+  mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+    const path = String(url).split('?')[0];
+    const method = init?.method ?? 'GET';
+    if (path === '/device-groups' && method === 'GET') {
+      return jsonResponse({ data: groups, total: groups.length });
+    }
+    if (path.startsWith('/device-groups')) {
+      return writeResponse ?? jsonResponse({ data: { id: 'new-group' } });
+    }
+    if (path in SUPPORTING_RESPONSES) return jsonResponse(SUPPORTING_RESPONSES[path]);
+    return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+  });
+};
+
+/** The request the page made with `method`, or undefined. */
+const findWrite = (method: string) =>
+  mockFetch.mock.calls.find(
+    ([, init]) => (init as RequestInit | undefined)?.method === method,
+  );
+
+const parseBody = (call: unknown[] | undefined) =>
+  JSON.parse(String((call?.[1] as RequestInit).body)) as Record<string, unknown>;
+
+/** Ticks the assignment checkbox on the row naming `hostname`. */
+const selectDevice = async (
+  user: ReturnType<typeof userEvent.setup>,
+  hostname: string,
+) => {
+  const row = screen.getByText(hostname).closest('label');
+  if (!row) throw new Error(`No assignment row for ${hostname}`);
+  const checkbox = row.querySelector('input[type="checkbox"]');
+  if (!checkbox) throw new Error(`No checkbox for ${hostname}`);
+  await user.click(checkbox);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * Regression coverage for issue #3159: every static device-group creation from
+ * this page failed with a 400, because the form sent an explicit
+ * `filterConditions: null` that the API's create schema rejected while its
+ * update schema accepted.
+ */
+describe('DeviceGroupsPage static groups', () => {
+  it('omits filterConditions and sends the selected devices when creating a static group', async () => {
+    const user = userEvent.setup();
+    serveGroups([{ id: 'group-1', name: 'Existing', type: 'static', deviceIds: [], deviceCount: 0 }]);
+
+    render(<DeviceGroupsPage />);
+    await screen.findByText('Existing');
+
+    await user.click(screen.getByRole('button', { name: 'Create Group' }));
+    await user.type(screen.getByPlaceholderText('e.g. Production Linux'), 'Cluster Hosts');
+    await selectDevice(user, 'web-01');
+    await user.click(screen.getByRole('button', { name: 'Create group' }));
+
+    await waitFor(() => expect(findWrite('POST')).toBeDefined());
+
+    const post = findWrite('POST');
+    // The literal path, not a translated string. This URL used to be read out
+    // of the i18n catalog (`t("deviceGroupsPage.deviceGroups")`), so any locale
+    // whose translator touched that entry would have posted somewhere else.
+    expect(String(post?.[0])).toBe('/device-groups');
+
+    const body = parseBody(post);
+    expect(body.type).toBe('static');
+    // The defect itself: a static create must NOT carry the key at all. Sending
+    // `null` here is what produced "expected object, received null".
+    expect(body).not.toHaveProperty('filterConditions');
+    // And the devices the user picked have to reach the server — the create
+    // schema silently stripped them, so the group came back empty.
+    expect(body.deviceIds).toEqual(['device-1']);
+  });
+
+  it('sends the filter and no deviceIds when creating a dynamic group', async () => {
+    const user = userEvent.setup();
+    serveGroups([{ id: 'group-1', name: 'Existing', type: 'static', deviceIds: [], deviceCount: 0 }]);
+
+    render(<DeviceGroupsPage />);
+    await screen.findByText('Existing');
+
+    await user.click(screen.getByRole('button', { name: 'Create Group' }));
+    await user.type(screen.getByPlaceholderText('e.g. Production Linux'), 'Web Servers');
+    await user.click(screen.getByRole('button', { name: 'Dynamic' }));
+    await user.type(await screen.findByTestId('value-text-input'), 'web');
+    await user.click(screen.getByRole('button', { name: 'Create group' }));
+
+    await waitFor(() => expect(findWrite('POST')).toBeDefined());
+
+    const body = parseBody(findWrite('POST'));
+    expect(body.filterConditions).toEqual({
+      operator: 'AND',
+      conditions: [{ field: 'hostname', operator: 'contains', value: 'web' }],
+    });
+    // The create route rejects a non-empty device list on a dynamic group
+    // rather than ignoring it, so the form must not send one.
+    expect(body).not.toHaveProperty('deviceIds');
+  });
+
+  it("shows the server's validation message when a create is rejected", async () => {
+    const user = userEvent.setup();
+    serveGroups(
+      [{ id: 'group-1', name: 'Existing', type: 'static', deviceIds: [], deviceCount: 0 }],
+      {
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: 'filterConditions: Invalid input: expected object, received null',
+        }),
+      } as unknown as Response,
+    );
+
+    render(<DeviceGroupsPage />);
+    await screen.findByText('Existing');
+
+    await user.click(screen.getByRole('button', { name: 'Create Group' }));
+    await user.type(screen.getByPlaceholderText('e.g. Production Linux'), 'Cluster Hosts');
+    await user.click(screen.getByRole('button', { name: 'Create group' }));
+
+    // The reporter had to open devtools to find this out: the handler threw a
+    // fixed "Failed to save device group" and dropped the response body.
+    expect(
+      await screen.findByText(
+        'filterConditions: Invalid input: expected object, received null',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('sends an explicit null filterConditions when converting a dynamic group to static', async () => {
+    const user = userEvent.setup();
+    serveGroups([
+      {
+        id: 'group-1',
+        name: 'Web Servers',
+        type: 'dynamic',
+        deviceCount: 2,
+        filterConditions: {
+          operator: 'AND',
+          conditions: [{ field: 'hostname', operator: 'contains', value: 'web' }],
+        },
+      },
+    ]);
+
+    render(<DeviceGroupsPage />);
+    await screen.findByText('Web Servers');
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Static' }));
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => expect(findWrite('PUT')).toBeDefined());
+
+    const body = parseBody(findWrite('PUT'));
+    // Unlike create, the update path MUST say `null` out loud: the API reads an
+    // absent key as "leave the filter alone", which would strand the old filter
+    // on a group the user just made static.
+    expect(body.filterConditions).toBeNull();
+  });
+});

--- a/apps/web/src/components/devices/DeviceGroupsPage.tsx
+++ b/apps/web/src/components/devices/DeviceGroupsPage.tsx
@@ -506,21 +506,37 @@ export default function DeviceGroupsPage() {
       // server evaluated the real filter. The server evaluates only
       // `filterConditions` (routes/groups.ts, services/groupMembership.ts);
       // `rules` is inert storage kept for pre-FilterBuilder rows.
-      const payload = {
+      const isEdit = modalMode === "edit" && Boolean(selectedGroup);
+      const isDynamic = groupForm.type === "dynamic";
+
+      const payload: Record<string, unknown> = {
         name: trimmedName,
         description: groupForm.description.trim(),
         type: groupForm.type,
-        filterConditions:
-          groupForm.type === "dynamic" ? groupForm.filterConditions : null,
-        deviceIds: groupForm.type === "static" ? groupForm.deviceIds : [],
         policyId: groupForm.policyId || null,
       };
 
-      const url =
-        modalMode === "edit" && selectedGroup
-          ? `/device-groups/${selectedGroup.id}`
-          : t("deviceGroupsPage.deviceGroups");
-      const method = modalMode === "edit" ? "PUT" : "POST";
+      if (isDynamic) {
+        payload.filterConditions = groupForm.filterConditions;
+      } else {
+        // A static group carries no filter, and the two verbs want that said
+        // differently (#3159). CREATE omits the key — the documented create
+        // payload, and what CreateGroupModal already sends. EDIT must send an
+        // explicit `null`, because the update route reads `undefined` as "leave
+        // the filter alone"; omitting it would strand a stale filter on a group
+        // converted from dynamic to static.
+        if (isEdit) {
+          payload.filterConditions = null;
+        }
+        // Devices are only meaningful for a static group. The create route
+        // rejects a non-empty list on a dynamic one rather than ignoring it.
+        payload.deviceIds = groupForm.deviceIds;
+      }
+
+      const url = isEdit
+        ? `/device-groups/${selectedGroup!.id}`
+        : "/device-groups";
+      const method = isEdit ? "PUT" : "POST";
 
       const response = await fetchWithAuth(url, {
         method,
@@ -528,7 +544,15 @@ export default function DeviceGroupsPage() {
       });
 
       if (!response.ok) {
-        throw new Error("Failed to save device group");
+        // Surface the server's own message. The reporter of #3159 had to open
+        // devtools to discover their create was failing validation, because
+        // this branch threw a fixed string and dropped the response body.
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(
+          body?.error ?? t("deviceGroupsPage.failedToSaveDeviceGroup"),
+        );
       }
 
       await fetchGroups();

--- a/apps/web/src/locales/de-DE/devices.json
+++ b/apps/web/src/locales/de-DE/devices.json
@@ -709,7 +709,6 @@
   "deviceGroupsPage": {
     "failedToFetchDeviceGroups": "Gerätegruppen konnten nicht abgerufen werden",
     "windows": "Fenster",
-    "deviceGroups": "/device-groups",
     "put": "PUT",
     "post": "POST",
     "failedToSaveDeviceGroup": "Die Gerätegruppe konnte nicht gespeichert werden",

--- a/apps/web/src/locales/en/devices.json
+++ b/apps/web/src/locales/en/devices.json
@@ -709,7 +709,6 @@
   "deviceGroupsPage": {
     "failedToFetchDeviceGroups": "Failed to fetch device groups",
     "windows": "windows",
-    "deviceGroups": "/device-groups",
     "put": "PUT",
     "post": "POST",
     "failedToSaveDeviceGroup": "Failed to save device group",

--- a/apps/web/src/locales/es-419/devices.json
+++ b/apps/web/src/locales/es-419/devices.json
@@ -709,7 +709,6 @@
   "deviceGroupsPage": {
     "failedToFetchDeviceGroups": "No se pudieron recuperar los grupos de dispositivos",
     "windows": "Windows",
-    "deviceGroups": "/device-groups",
     "put": "PUT",
     "post": "POST",
     "failedToSaveDeviceGroup": "No se pudo guardar el grupo de dispositivos",

--- a/apps/web/src/locales/fr-CA/devices.json
+++ b/apps/web/src/locales/fr-CA/devices.json
@@ -709,7 +709,6 @@
   "deviceGroupsPage": {
     "failedToFetchDeviceGroups": "Impossible de récupérer les groupes d’appareils",
     "windows": "Fenêtres",
-    "deviceGroups": "/device-groups",
     "put": "PUT",
     "post": "POST",
     "failedToSaveDeviceGroup": "Impossible d’enregistrer le groupe de périphériques",

--- a/apps/web/src/locales/fr-FR/devices.json
+++ b/apps/web/src/locales/fr-FR/devices.json
@@ -709,7 +709,6 @@
   "deviceGroupsPage": {
     "failedToFetchDeviceGroups": "Impossible de récupérer les groupes d’appareils",
     "windows": "Fenêtres",
-    "deviceGroups": "/device-groups",
     "put": "PUT",
     "post": "POST",
     "failedToSaveDeviceGroup": "Impossible d’enregistrer le groupe de périphériques",

--- a/apps/web/src/locales/it-IT/devices.json
+++ b/apps/web/src/locales/it-IT/devices.json
@@ -709,7 +709,6 @@
   "deviceGroupsPage": {
     "failedToFetchDeviceGroups": "Impossibile recuperare i gruppi di dispositivi",
     "windows": "windows",
-    "deviceGroups": "/device-groups",
     "put": "PUT",
     "post": "POST",
     "failedToSaveDeviceGroup": "Impossibile salvare il gruppo di dispositivi",

--- a/apps/web/src/locales/pt-BR/devices.json
+++ b/apps/web/src/locales/pt-BR/devices.json
@@ -709,7 +709,6 @@
   "deviceGroupsPage": {
     "failedToFetchDeviceGroups": "Falha ao buscar grupos de dispositivos",
     "windows": "windows",
-    "deviceGroups": "/device-groups",
     "put": "PUT",
     "post": "POST",
     "failedToSaveDeviceGroup": "Falha ao salvar o grupo de dispositivos",


### PR DESCRIPTION
## What was broken

Creating a **static** device group from the dashboard failed with a 400 on every attempt, reported in #3159 by @cisspUser01 against 0.103.0.

The create form builds one payload for both verbs and sent `filterConditions: null` for a static group, while `createGroupSchema` declared the field `.optional()` **without** `.nullable()`:

```
{"error":"filterConditions: Invalid input: expected object, received null"}
```

The update schema three lines below it had always been `.nullable().optional()`. That asymmetry is why editing a group worked and creating one never could.

## Why this fix, rather than just loosening the schema

**Both sides, for different reasons — and the divergence itself is the defect.**

- **The schema divergence is the bug, not the symptom.** `filterConditions` is now ONE shared constant (`groupFilterConditionsField`) consumed by both `createGroupSchema` and `updateGroupSchema`, so the two cannot drift apart again without editing the constant that documents why they must match. All three forms — omitted, an object, explicit `null` — behave identically on both verbs.
- **`null` had to be accepted, not just avoided.** This is a public HTTP API (mobile, MCP, partner scripts). `null` is a legitimate way to say "no filter", the create route already normalized it (`payload.filterConditions ?? null`), and rejecting it *only* on create was arbitrary. Widening is backward compatible.
- **The client still had to change, but only on create.** The form now omits the key for a static create (matching `CreateGroupModal`, which has always done it correctly, and the documented payload). It deliberately keeps sending explicit `null` on **edit**: the update route reads `undefined` as "leave the filter alone" and `null` as "clear it", so omitting it there would strand a stale filter on a group the user just converted from dynamic to static.

## The silent failure hiding behind the 400

Fixing only the null would have traded a loud 400 for something worse. `createGroupSchema` had **no `deviceIds` field at all**, so Zod silently stripped the devices the user had just hand-picked and returned 201 on an empty group.

Create now accepts `deviceIds` and materializes the membership in the same request, and **rejects** a non-empty list on a dynamic group rather than ignoring it.

Because that is a cross-tenant write, the ownership guard `POST /:id/devices` carried inline is extracted into `validateManualMembershipDevices` + `addManualGroupMemberships` in `services/groupMembership.ts` and shared by both routes — one implementation of the tenancy check instead of two that can drift. It enforces org ownership against the *group's* org, the site boundary for a site-bound group, and dedupe; membership rows take their `orgId` from the group, never from the request.

**Ordering matters:** the batch is validated *before* the group row is inserted. A `return c.json(..., 400)` is a normal response, not an exception, so the request transaction still commits — validating late would leave a stranded empty group behind on every rejected batch. Three tests assert `db.insert` was never called on the rejection paths.

## Two adjacent defects fixed in passing

- **The POST URL was being read out of the i18n catalog**: `t("deviceGroupsPage.deviceGroups")`, whose value was the literal string `/device-groups` in all seven locales. A codemod accident that worked only for as long as no translator touched that entry. Restored to a literal and the key removed from the catalogs.
- **The failure branch discarded the response body** and threw a fixed `"Failed to save device group"`, which is why the reporter had to dig the real 400 out of devtools. It now surfaces the server's message (the pattern `CreateGroupModal` already uses).

## What I verified about the rest of #3159

- **Bug 1 (dynamic membership never persisted) is already fixed on `origin/main`** by #3181 — the evaluation is awaited at both call sites with the transaction-race explained in-place, and covered by `groups_get_create.test.ts`. Not re-done here.
- **The Groups-list page crash is also already fixed**: the legacy matcher now lives in `deviceGroupMatching.ts`, fully null-hardened, and `getGroupDeviceIds` no longer runs it for filter-authored groups at all — an empty-membership dynamic group can no longer reach it. `deviceGroupMatching.test.ts` already regression-covers undefined hostname, missing `osType`, and malformed rules. Nothing left to harden.

## Known adjacent bugs NOT in this PR (deliberately)

Found while tracing this page; both are separate live defects and bundling them would bury a security-sensitive membership change:

1. **Group editing and drag-and-drop assignment are dead.** The page sends `PUT /device-groups/:id`, but the router only defines `.patch('/:id')` — no PUT handler exists anywhere, so Hono falls through to the 404 handler. Needs a focused PR with update-transition tests.
2. **`POST /device-groups/bulk` does not exist**, so the bulk script/policy actions on that page 404 too. That one needs an API design decision, not a patch.

Also noted: `deviceGroupsPage.put`, `.post` and `.windows` are orphaned codemod debris in the catalogs, already unreferenced before this change, so left alone.

## Tests

| Suite | Result |
|---|---|
| API group routes + membership service (11 files) | 157 passed |
| `DeviceGroupsPage.staticGroups.test.tsx` (new, 4 cases) | 4 passed |
| Device-groups web suites (4 files) | 24 passed |
| i18n guards incl. locale parity (6 files) | 97 passed |
| `no-silent-mutations` | 100 passed |
| `tsc --noEmit` (apps/api) | clean |
| `astro check` (apps/web) | 0 errors |
| eslint (all 8 touched files) | clean |

New coverage: 8 route cases for the accepted/rejected create shapes, 9 unit cases for the extracted helpers, 4 web cases pinning the create/edit payloads, the literal URL and the surfaced error. Verified non-vacuous by reverting the implementation — 14 API tests and 3 of 4 web tests fail against the unpatched code.

Three sibling test files mocked the membership service and would have 500'd after the extraction; they now pass the real helpers through, so their pre-existing cross-org and site-confinement assertions keep exercising the shared code rather than a mock.

`Refs #3159` rather than `Closes` — leaving it open for @cisspUser01 to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Review round (4 agents) — outcome

`/pr-review-toolkit:review-pr` ran code-reviewer, pr-test-analyzer, silent-failure-hunter and comment-analyzer. **0 critical.** What was raised and what I did:

**Acted on:**
- **Type Check failure (CI):** two `noUncheckedIndexedAccess` errors on `mock.calls[0][0]` in the new create tests. Narrowed with an explicit guard rather than `!`/`as any` — fixed in `c49fd86`.
- **Coverage gaps (2):** `addManualGroupMemberships` collapsing a repeated device id, and the `device_group.device.add` audit event the create path writes (incl. the `viaGroupCreate` marker). Both added in `c49fd86`.

**Rejected, with reason:**
- code-reviewer asked for a `try/catch` around the static membership insert, mirroring the dynamic branch, arguing a post-insert throw would strand a created group. **It would not** — the whole handler runs inside one `baseDb.transaction` opened by `withDbAccessContext`, so a throw rolls the group insert back and yields a retry-safe 500 with Sentry context. silent-failure-hunter independently reached the same conclusion and pointed the finding the other way: the *dynamic* branch's swallow is the questionable one, and the pre-existing comment's "would invite a duplicate on retry" rationale does not hold under this transaction model. That branch predates this PR and has a test pinning its 201-and-log behavior, so I left it alone rather than change behavior outside #3159. Worth its own look.

**Deferred deliberately (documented, not silently dropped):**
- **No `.onConflictDoNothing()`** on the manual membership insert, unlike `evaluateGroupMembership`'s. The SELECT-then-INSERT race is pre-existing and only reachable on `POST /:id/devices` (a brand-new group id has no competing writer), and fixing it with honest `added` counts means reworking the insert's return handling plus several test mocks.
- **Manual adds do not write `group_membership_log`** — only a route-level audit event. Also pre-existing on `POST /:id/devices`; closing it in the shared helper would change that endpoint's observable behavior, which this PR otherwise preserves exactly.
- **The web form discards `invalidDevices`** from a 400, so the user sees the failure class but not which device caused it. Rendering it needs new user-facing copy across seven locales, which is more than this fix should carry.

**Verified accurate by comment-analyzer:** the transaction-commit claim behind the validate-before-insert ordering, the `undefined` vs `null` semantics on PATCH, and the shared-helper claim were each traced to the implementing lines.

**On test counts, precisely:** 21 new cases, of which 17 fail against unpatched code (14 API + 3 web). The other 4 are baseline non-regression checks (omitted key, object form, empty array, and the edit-path `null`) that passed before too — they document the contract rather than the fix, and are commented as such.

## Related issues

- **#3425** — for a partner with 2+ orgs, create still 400s with `orgId is required when partner has multiple organizations`: the route reads `orgId` from the body only while the web client sends it as a query param. Reproduces only with multiple orgs, which is why #3159's reporter never hit it. **Deliberately not fixed here** — scoped to #3425.
- **#3426** — the remaining instances of the API-path-in-locale-files class. This PR fixes only the one call site it touches and removes that one key from the seven catalogs.