### PR TITLE
fix(deps): dedup pnpm-lock.yaml again — duplicated hono key breaks every JS job on main

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8129,10 +8129,6 @@ packages:
     resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -19933,8 +19929,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.13.1: {}
 
   hono@4.13.1: {}
 


### PR DESCRIPTION
**`main` is red again on the same failure as #3407**, from a second dependabot burst.

```
##[group]Run pnpm install --frozen-lockfile
 ERR_PNPM_BROKEN_LOCKFILE  ... duplicated mapping key (8132:3)
```

23 failing checks at `3bcb0d976` — every JS job, all dying at install before running any project code. Five PRs merged in **18 seconds** (`13:52:38`–`13:52:56`), and `hono@4.13.1` came back duplicated: ×2 in `packages:` and ×2 in `snapshots:`.

## The change

6 lines deleted, nothing added, no regeneration.

The dedup script **asserts each dropped block is byte-identical to the one it keeps** and aborts otherwise, so this cannot silently discard a genuinely different resolution. Same approach as #3407.

## Verification

The command that is failing in CI, run on this branch:

```
$ pnpm install --frozen-lockfile
Done in 11.5s using pnpm v10.34.5
$ echo $?
0
```

It fails on `main` and succeeds here.

## Worth acting on: this is the second occurrence in ~16 hours

#3407 fixed the identical break last night; the same package has already returned. The trigger is unchanged — several dependabot PRs merged without rebasing, each valid against the tree it was built on, collectively producing a lockfile YAML rejects.

Two options, either of which ends it:

- require branches be **up to date before merge** for lockfile-touching PRs, so the second one rebases instead of appending; or
- **group** dependabot updates so one PR carries one lockfile change.

I raised this on #3407 and it recurred the next day, so it seems worth doing rather than absorbing.

**A detection note that may be more useful than the fix.** Scanning `pnpm-lock.yaml` for keys duplicated *within* a section catches this in seconds, versus ~10 minutes of CI. The calibration that makes it reliable: a healthy package appears **exactly twice in the file** — once under `packages:`, once under `snapshots:` — so only repeats inside one section are corruption. A naive whole-file dedup would delete real entries.

Also worth flagging for anyone debugging this locally: a plain `pnpm install` **rewrites** the broken lockfile rather than failing, so it looks fine locally and the rewrite then contaminates your diff. `--frozen-lockfile` is what reproduces CI.
