### PR TITLE
fix(api): scriptDispatch review findings — cleanup gap, AI payload echo, batch cap (#3409 PR 0 follow-up)

### DIFF
--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -1442,6 +1442,35 @@ describe('mobile routes', () => {
       expect(writeRouteAuditMock).not.toHaveBeenCalled();
     });
 
+    it('surfaces a 409 from executeScriptOnDevices (e.g. maintenance-window suppression)', async () => {
+      // Reachable from mobile now that this route delegates entirely to
+      // executeScriptOnDevices (#3409 PR0 Task 3) — the maintenance-window
+      // suppression branch (409 + maintenanceSuppressedDeviceIds) is newly
+      // exercisable from this caller and existing tests only covered 403/404.
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: '11111111-2222-4333-8444-555555555555', orgId: 'org-123', status: 'online', osType: 'linux', siteId: null }
+        ]) as any
+      );
+      executeScriptOnDevicesMock.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        error: 'All target devices are in a maintenance window with script execution suppressed',
+        maintenanceSuppressedDeviceIds: ['11111111-2222-4333-8444-555555555555'],
+      });
+
+      const res = await app.request('/mobile/devices/11111111-2222-4333-8444-555555555555/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'run_script', scriptId: '22222222-2222-2222-2222-222222222222' })
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe('All target devices are in a maintenance window with script execution suppressed');
+      expect(writeRouteAuditMock).not.toHaveBeenCalled();
+    });
+
     it('should run a script action by delegating to executeScriptOnDevices', async () => {
       vi.mocked(db.select).mockReturnValue(
         mockSelectLimitChain([

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
-import { and, desc, eq, gte, ilike, inArray, isNull, like, ne, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, inArray, like, ne, or, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db } from '../db';
 import {

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -753,6 +753,21 @@ describe('scripts routes', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects more than 500 device ids on execute (#3409 PR0 Wave B — audit fan-out cap)', async () => {
+    const deviceIds = Array.from({ length: 501 }, (_, i) => {
+      const hex = i.toString(16).padStart(12, '0');
+      return `11111111-1111-4111-8111-${hex}`;
+    });
+
+    const res = await app.request(`/scripts/${SCRIPT_ID_1}/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({ deviceIds })
+    });
+
+    expect(res.status).toBe(400);
+  });
+
   it('should reject unsupported runAs override on execute', async () => {
     const res = await app.request(`/scripts/${SCRIPT_ID_1}/execute`, {
       method: 'POST',

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -260,7 +260,16 @@ const updateScriptSchema = z.object({
 
 export const executeScriptSchema = z
   .object({
-    deviceIds: z.array(z.string().guid()).min(1),
+    // Capped at 500: queueCommand fires an un-awaited, fire-and-forget audit
+    // transaction PER DEVICE for 'script' commands (AUDITED_COMMANDS in
+    // commandQueue.ts). The dispatch loop in scriptExecution.ts is sequential
+    // and awaited, but those audit transactions are not — an unbounded batch
+    // would launch hundreds of concurrent transactions against a pool sized
+    // for far fewer while this request also holds a connection, the same
+    // pool-starvation shape that has caused prior production incidents.
+    deviceIds: z.array(z.string().guid()).min(1).max(500, {
+      message: 'Cannot target more than 500 devices in a single script execution',
+    }),
     parameters: z.record(z.string(), z.any()).refine(
       (val) => JSON.stringify(val).length <= 65536,
       { message: 'Object too large (max 64KB)' }

--- a/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
@@ -48,7 +48,17 @@ const mocks = vi.hoisted(() => {
   return {
     contextFlags,
     dispatchScriptToDevice,
-    waitForCommandResult: vi.fn().mockResolvedValue({ id: 'cmd-1', status: 'completed' }),
+    // Modeled on a real device_commands row: carries `payload` (full script
+    // content + parameters) alongside `result`. B1 (#3409 PR0 Wave B): the
+    // handler must project only `result` (+ commandId/executionId) and never
+    // let `payload` — which is what leaked script content into the model
+    // context and persisted chat history — reach the tool's returned JSON.
+    waitForCommandResult: vi.fn().mockResolvedValue({
+      id: 'cmd-1',
+      status: 'completed',
+      payload: { scriptId: 'script-x', content: 'SECRET SCRIPT CONTENT', parameters: { foo: 'bar' } },
+      result: { status: 'completed', exitCode: 0, stdout: 'hi' },
+    }),
   };
 });
 const { dispatchScriptToDevice, waitForCommandResult, contextFlags } = mocks;
@@ -178,7 +188,20 @@ describe('run_script enforces script-device org equality', () => {
 
     // Result comes from waitForCommandResult, not the dispatch return value.
     expect(waitForCommandResult).toHaveBeenCalledWith('cmd-1', 60000);
-    expect(out.results[DEVICE_B]).toEqual({ id: 'cmd-1', status: 'completed' });
+    // B1 (#3409 PR0 Wave B): the handler projects the polled command's
+    // `.result` (+ commandId/executionId) rather than returning the row
+    // whole — `payload` (script content + parameters) must never reach the
+    // model context or persisted chat history.
+    expect(out.results[DEVICE_B]).toEqual({
+      status: 'completed',
+      exitCode: 0,
+      stdout: 'hi',
+      commandId: 'cmd-1',
+      executionId: 'exec-1',
+    });
+    expect(out.results[DEVICE_B]).not.toHaveProperty('payload');
+    expect(out.results[DEVICE_B]).not.toHaveProperty('content');
+    expect(JSON.stringify(out)).not.toContain('SECRET SCRIPT CONTENT');
   });
 
   it('executes a system (null-org) script on any accessible device', async () => {
@@ -206,7 +229,13 @@ describe('run_script partner-wide script visibility (#3409 PR0)', () => {
     );
 
     expect(dispatchScriptToDevice).toHaveBeenCalledTimes(1);
-    expect(out.results[DEVICE_B]).toEqual({ id: 'cmd-1', status: 'completed' });
+    expect(out.results[DEVICE_B]).toEqual({
+      status: 'completed',
+      exitCode: 0,
+      stdout: 'hi',
+      commandId: 'cmd-1',
+      executionId: 'exec-1',
+    });
   });
 
   it('rejects a partner-wide script when the device org belongs to a different partner', async () => {
@@ -286,5 +315,37 @@ describe('run_script surfaces dispatch failures without calling waitForCommandRe
 
     expect(out.results[DEVICE_B].error).toBe('Device is offline, cannot execute command');
     expect(waitForCommandResult).not.toHaveBeenCalled();
+  });
+});
+
+describe('run_script keeps per-device failures isolated in the shared results accumulator', () => {
+  it('does not let one device throwing during dispatch corrupt another device\'s successful result', async () => {
+    const DEVICE_C = '33333333-3333-3333-3333-333333333333';
+    mockDb(
+      { id: SCRIPT_ID, orgId: ORG_B, partnerId: null, language: 'powershell', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' },
+      // The mocked devices select ignores the WHERE clause and always
+      // returns this one row, but the tool keys `results` by the actual
+      // deviceId from the input array, which is what this test asserts on.
+      { id: DEVICE_B, orgId: ORG_B, hostname: 'devB', siteId: null, status: 'online' },
+    );
+
+    // First device's dispatch throws (e.g. a genuine DB/infra fault);
+    // second device's dispatch uses the default (successful) mock.
+    dispatchScriptToDevice.mockImplementationOnce(async () => {
+      throw new Error('boom');
+    });
+
+    const out = JSON.parse(
+      await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B, DEVICE_C] }, makeAuth()),
+    );
+
+    expect(out.results[DEVICE_B].error).toBe('boom');
+    expect(out.results[DEVICE_C]).toEqual({
+      status: 'completed',
+      exitCode: 0,
+      stdout: 'hi',
+      commandId: 'cmd-1',
+      executionId: 'exec-1',
+    });
   });
 });

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -31,6 +31,7 @@ import type { AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
 import { dispatchScriptToDevice } from './scriptDispatch';
+import { captureException } from './sentry';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -189,9 +190,18 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
         return JSON.stringify({ error: 'Script not found or has no content' });
       }
 
-      // Under a system context (intent-release worker) RLS no longer scopes
-      // partner-wide rows — verify partner ownership explicitly against each
-      // target device's org below. Request paths already saw RLS filtering.
+      // This guard is NOT here because the intent-release worker runs under a
+      // system context — it doesn't. jobs/intentReleaseWorker.ts executes this
+      // tool inside `withAuthDbAccessContext(auth, ...)`, which is RLS-scoped
+      // to the reconstructed approver identity, same as a live request. The
+      // real reason this app-layer check is load-bearing: a membership-less
+      // user is issued a system-SCOPE token (see
+      // middleware/auth.ts — payload.scope === 'system'), under which
+      // `auth.orgCondition(...)` returns `undefined` and RLS is effectively
+      // off for that session. For that caller, this org-equality check plus
+      // the device-org→partner lookup below are the ONLY defenses stopping a
+      // partner-wide script from running on a device outside the script's
+      // partner. Do not delete this thinking RLS already covers it.
       const scriptPartnerId = script.partnerId ?? null;
 
       for (const deviceId of deviceIds.slice(0, 10)) { // Limit to 10 devices
@@ -288,8 +298,28 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
             results[deviceId] = { error: dispatch.error };
             continue;
           }
-          results[deviceId] = await runOutsideDbContext(() => waitForCommandResult(dispatch.commandId, 60000));
+          // Project the polled row instead of returning it whole: the row
+          // carries `payload` (full script content + parameters), which must
+          // never reach the model context or persisted chat history — this
+          // repo already redacts that via sanitizeCommandPayloadForAudit /
+          // sanitizeCommandForHistory (services/commandAudit.ts) for the
+          // audit/history paths, and the AI path must not bypass that
+          // convention. Mirrors executeCommand's own return shape
+          // (services/commandQueue.ts) so callers reading top-level
+          // .stdout/.exitCode keep working, plus the new executionId.
+          const cmd = await runOutsideDbContext(() => waitForCommandResult(dispatch.commandId, 60000));
+          results[deviceId] = {
+            ...(cmd.result as unknown as Record<string, unknown> ?? { status: 'failed', error: 'Command did not complete' }),
+            commandId: cmd.id,
+            executionId: dispatch.executionId,
+          };
         } catch (err) {
+          // A thrown error here is indistinguishable from "device unsupported"
+          // once caught below unless it's surfaced — a genuine DB/infra fault
+          // during dispatch must not silently masquerade as graceful
+          // per-device degradation.
+          console.error('[aiToolsScripts] run_script dispatch failed', { deviceId, error: err });
+          captureException(err);
           results[deviceId] = { error: err instanceof Error ? err.message : 'Execution failed' };
         }
       }

--- a/apps/api/src/services/automationRuntime.configPolicy.test.ts
+++ b/apps/api/src/services/automationRuntime.configPolicy.test.ts
@@ -451,6 +451,21 @@ describe('executeConfigPolicyAutomationRun', () => {
     // Verify final status was persisted to DB
     const lastSetCall = setMock.mock.calls[setMock.mock.calls.length - 1]![0];
     expect(lastSetCall.status).toBe('completed');
+
+    // execute_command builds a 'raw' dispatch source — assert the mapping
+    // reaching dispatchScriptToDevice: shell -> language, and provenance
+    // stamped with this automation's id (used by scriptDispatch/audit to
+    // attribute ad-hoc command content back to the triggering automation).
+    expect(dispatchScriptToDevice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: {
+          kind: 'raw',
+          content: 'echo ok',
+          language: 'bash',
+          provenance: `automation:${automation.id}`,
+        },
+      }),
+    );
   });
 
   it('returns failed when device action fails and onFailure is stop', async () => {

--- a/apps/api/src/services/automationRuntime.runScript.test.ts
+++ b/apps/api/src/services/automationRuntime.runScript.test.ts
@@ -146,12 +146,14 @@ describe('executeRunScriptAction — dispatch via scriptDispatch core (#3409 PR0
 
     const input = dispatchMock.mock.calls[0]![0] as Record<string, unknown>;
     expect(input.device).toBe(DEVICE);
-    expect(input.source).toEqual({ kind: 'saved', script: SCRIPT });
+    // automationRunId now lives on the 'saved' source variant, not the
+    // top-level dispatch input (#3409 PR0 Wave A — makes a 'raw' source
+    // silently dropping it an unrepresentable state).
+    expect(input.source).toEqual({ kind: 'saved', script: SCRIPT, automationRunId: RUN_ID });
     expect(input.triggerType).toBe('automation');
     expect(input.triggeredBy).toBe('user-1');
     expect(input.createdBy).toBe('user-1');
     expect(input.runAs).toBe('system');
-    expect(input.automationRunId).toBe(RUN_ID);
     expect(input.requireOnline).toBe(true);
   });
 

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -886,7 +886,7 @@ export async function executeRunScriptAction(
   // row to discard on that path either.
   const dispatch = await dispatchScriptToDevice({
     device: context.device,
-    source: { kind: 'saved', script },
+    source: { kind: 'saved', script, automationRunId: context.runId },
     parameters,
     triggerType: 'automation',
     triggeredBy: context.automation.createdBy ?? null,
@@ -896,7 +896,6 @@ export async function executeRunScriptAction(
     // validation) — preserve the pre-existing runtime behavior of forwarding
     // whatever value was configured rather than adding new validation here.
     runAs: (action.runAs ?? script.runAs) as 'system' | 'user' | 'elevated',
-    automationRunId: context.runId,
     requireOnline: true,
   });
 

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -21,6 +21,7 @@ import { resolveDeploymentTargets } from './deploymentEngine';
 import { canAccessSite, type UserPermissions } from './permissions';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { publishEvent } from './eventBus';
+import { captureException } from './sentry';
 import {
   getEmailRecipients,
   sendEmailNotification,
@@ -930,7 +931,11 @@ export async function executeRunScriptAction(
       actionIndex,
       deviceId: context.device.id,
       commandId: dispatch.commandId,
-      details: { scriptId: script.id, executionId: dispatch.executionId },
+      // deliveryOutcome lets an operator reading the run log distinguish
+      // "queued, agent offline" (no_agent) from "we had a socket and failed
+      // to reach it" (claim_lost/decrypt_failed/send_failed) — see
+      // scriptDispatch.ts's DispatchScriptResult for the full enum.
+      details: { scriptId: script.id, executionId: dispatch.executionId, deliveryOutcome: dispatch.deliveryOutcome },
     }),
   };
 }
@@ -991,7 +996,9 @@ async function executeCommandAction(
       actionIndex,
       deviceId: context.device.id,
       commandId: dispatch.commandId,
-      details: { shell },
+      // See executeRunScriptAction above for why deliveryOutcome is worth
+      // surfacing here.
+      details: { shell, deliveryOutcome: dispatch.deliveryOutcome },
     }),
   };
 }
@@ -1827,9 +1834,16 @@ async function executeAutomationRunInner(
       // {success:false}. Treat it as a device-level failure rather than letting
       // it reject runWithConcurrency's Promise.all and abort the whole run —
       // which would strand every other device's result row (#2023).
+      //
+      // This catch logs into the run's own log entries, but that's a DB
+      // column, not Sentry — a genuine infra fault during automated dispatch
+      // (DB blip, dispatch core throw, etc.) would otherwise be invisible
+      // outside someone reading this specific run's logs. Surface it.
       deviceFailed = true;
       const message = err instanceof Error ? err.message : String(err);
       if (deviceError === null) deviceError = message;
+      console.error('[automationRuntime] action threw during device dispatch', { deviceId: device.id, error: err });
+      captureException(err);
       const errLog = logEntry(`Automation action threw: ${message}`, 'error', { deviceId: device.id });
       logs.push(errLog);
       deviceOutput.push(`[error] ${errLog.message}`);

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SQL, Param } from 'drizzle-orm';
 
 vi.mock('../db', () => ({ db: { select: vi.fn(), insert: vi.fn(), update: vi.fn(), delete: vi.fn() } }));
 vi.mock('./commandQueue', () => ({ queueCommand: vi.fn() }));
@@ -60,25 +61,44 @@ const mockLiveDeviceStatus = (status: string | undefined) => {
   } as any);
 };
 
-/** Flatten a drizzle SQL node into its literal tokens (column names + values). */
-function collectSqlTokens(node: unknown): string[] {
-  const found: string[] = [];
+// Extracts the actually-BOUND query parameters (column name + literal value)
+// from a drizzle SQL condition tree, e.g. `and(eq(id, 'exec-1'), eq(status,
+// 'pending'))` -> [{ column: 'id', value: 'exec-1' }, { column: 'status',
+// value: 'pending' }].
+//
+// This walks ONLY `SQL`/`Param` nodes (verified via `instanceof` against the
+// classes drizzle-orm exports), not the wider object graph. That matters:
+// an earlier version of this helper (`collectSqlTokens`) walked every
+// object reachable from the condition, including the real (unmocked)
+// `scriptExecutions` table/column metadata — which itself contains the
+// literal strings 'status' and 'pending' (column name + enum value) via
+// circular table<->column references. A `toContain('status')` /
+// `toContain('pending')` assertion against that flattened token list passed
+// even when the `eq(status, 'pending')` guard was deleted from production
+// code entirely, because those tokens leak in from schema metadata
+// regardless of the actual WHERE predicate. Restricting the walk to `Param`
+// (the runtime-bound value) and `SQL` (the composite condition) nodes makes
+// the count and identity of bound parameters reflect the real predicate.
+function collectBoundParams(node: unknown): { column: string; value: unknown }[] {
+  const found: { column: string; value: unknown }[] = [];
   const seen = new WeakSet<object>();
   const visit = (value: unknown) => {
-    if (value == null) return;
-    if (typeof value === 'string') {
-      found.push(value);
-      return;
-    }
-    if (typeof value !== 'object') return;
-    // The real (unmocked) drizzle schema objects backing these SQL nodes
-    // carry circular table<->column references — guard against them.
+    if (value == null || typeof value !== 'object') return;
     if (seen.has(value as object)) return;
     seen.add(value as object);
-    for (const child of Object.values(value as Record<string, unknown>)) {
-      if (Array.isArray(child)) child.forEach(visit);
-      else visit(child);
+    if (value instanceof Param) {
+      // `encoder` is the column the param is bound against — do NOT descend
+      // into it (it carries the circular table<->column graph); just read
+      // its name.
+      const encoder = (value as { encoder?: { name?: string } }).encoder;
+      found.push({ column: encoder?.name ?? '<unknown>', value: (value as { value: unknown }).value });
+      return;
     }
+    if (value instanceof SQL) {
+      for (const chunk of (value as unknown as { queryChunks: unknown[] }).queryChunks) visit(chunk);
+    }
+    // Anything else (columns, tables, StringChunk separators) is not
+    // descended into — only SQL/Param nodes can carry bound parameters.
   };
   visit(node);
   return found;
@@ -303,13 +323,24 @@ describe('dispatchScriptToDevice — delivery', () => {
     expect(db.update).toHaveBeenCalledTimes(1);
     expect(setSpy).toHaveBeenCalledWith({ status: 'running', startedAt: executedAt });
     expect(whereArgs).toHaveLength(1);
-    const tokens = collectSqlTokens(whereArgs[0]);
-    expect(tokens).toContain('exec-1');
-    expect(tokens).toContain('status');
-    expect(tokens).toContain('pending');
+    // Discriminating on the STRUCTURE of the bound parameters (not just
+    // their presence anywhere in the SQL node graph — see the comment on
+    // `collectBoundParams`): the guard must bind exactly two parameters,
+    // one pinning the execution id and one pinning status='pending'. If the
+    // `status='pending'` conjunct is removed from production code, this
+    // drops to a single bound param and the assertion fails.
+    const boundParams = collectBoundParams(whereArgs[0]);
+    expect(boundParams).toHaveLength(2);
+    expect(boundParams).toEqual(
+      expect.arrayContaining([
+        { column: 'id', value: 'exec-1' },
+        { column: 'status', value: 'pending' },
+      ]),
+    );
   });
 
   it('reports claim_lost when claimPendingCommandForDelivery loses the race (no throw)', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.mocked(claimPendingCommandForDelivery).mockResolvedValue(null);
     const r = await dispatchScriptToDevice({ device: device({ agentId: 'agent-1' }), source: { kind: 'saved', script: savedScript() } });
     expect(sendCommandToAgent).not.toHaveBeenCalled();
@@ -319,6 +350,11 @@ describe('dispatchScriptToDevice — delivery', () => {
       expect(r.delivered).toBe(false);
       expect(r.deliveryOutcome).toBe('claim_lost');
     }
+    // A8 warn policy: claim_lost is a normal race outcome (another dispatch
+    // path claimed the command first), unlike decrypt_failed/send_failed
+    // (had a connected agent and still failed to reach it) — it must NOT warn.
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
   });
 
   it('releases the claim when decrypt returns null (does NOT send raw payload)', async () => {

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -11,12 +11,14 @@ vi.mock('./sensitiveCommandPayload', () => ({
   decryptCommandForDelivery: vi.fn((c: unknown) => c),
 }));
 vi.mock('../routes/agentWs', () => ({ sendCommandToAgent: vi.fn().mockReturnValue(false) }));
+vi.mock('./sentry', () => ({ captureException: vi.fn() }));
 
 import { db } from '../db';
 import { queueCommand } from './commandQueue';
 import { claimPendingCommandForDelivery } from './commandDispatch';
 import { decryptCommandForDelivery, encryptSensitivePayloadFields } from './sensitiveCommandPayload';
 import { sendCommandToAgent } from '../routes/agentWs';
+import { captureException } from './sentry';
 import { dispatchScriptToDevice } from './scriptDispatch';
 
 const savedScript = (o = {}) => ({
@@ -33,6 +35,19 @@ const insertReturning = (rows: unknown[]) => ({
   values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(rows) }),
 });
 
+// Mocks the cleanup delete (`db.delete(...).where(...).returning(...)`).
+// `rows` models what the delete actually removed — pass `[]` to model a
+// 0-row delete (execution wasn't pending anymore), or configure `whereImpl`
+// to reject to model a transient cleanup-DB failure.
+const mockDiscardDelete = (rows: unknown[] | (() => Promise<unknown[]>)) => {
+  const returning = typeof rows === 'function'
+    ? vi.fn(rows)
+    : vi.fn().mockResolvedValue(rows);
+  const del = { where: vi.fn().mockReturnValue({ returning }) };
+  vi.mocked(db.delete).mockReturnValue(del as any);
+  return del;
+};
+
 // Mocks the live `devices.status` re-read the requireOnline gate performs.
 // Pass `undefined` to model a device row that no longer exists.
 const mockLiveDeviceStatus = (status: string | undefined) => {
@@ -44,6 +59,30 @@ const mockLiveDeviceStatus = (status: string | undefined) => {
     }),
   } as any);
 };
+
+/** Flatten a drizzle SQL node into its literal tokens (column names + values). */
+function collectSqlTokens(node: unknown): string[] {
+  const found: string[] = [];
+  const seen = new WeakSet<object>();
+  const visit = (value: unknown) => {
+    if (value == null) return;
+    if (typeof value === 'string') {
+      found.push(value);
+      return;
+    }
+    if (typeof value !== 'object') return;
+    // The real (unmocked) drizzle schema objects backing these SQL nodes
+    // carry circular table<->column references — guard against them.
+    if (seen.has(value as object)) return;
+    seen.add(value as object);
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      if (Array.isArray(child)) child.forEach(visit);
+      else visit(child);
+    }
+  };
+  visit(node);
+  return found;
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -140,14 +179,22 @@ describe('dispatchScriptToDevice — invariants', () => {
 describe('dispatchScriptToDevice — rows and payload', () => {
   it('saved: creates an execution row with the DEVICE org and passes executionId in payload', async () => {
     const r = await dispatchScriptToDevice({
-      device: device(), source: { kind: 'saved', script: savedScript() },
-      parameters: { a: '1' }, triggeredBy: 'user-1', triggerType: 'manual', automationRunId: null,
+      device: device(), source: { kind: 'saved', script: savedScript(), automationRunId: null },
+      parameters: { a: '1' }, triggeredBy: 'user-1', triggerType: 'manual',
     });
     expect(r.ok).toBe(true);
     const execValues = vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
     expect(execValues).toMatchObject({ scriptId: 'script-1', deviceId: 'device-1', orgId: 'org-a', triggeredBy: 'user-1', status: 'pending' });
     const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
     expect(payload).toMatchObject({ scriptId: 'script-1', executionId: 'exec-1', language: 'bash', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' });
+  });
+
+  it('saved: automationRunId lives on the source variant and is forwarded to the insert', async () => {
+    await dispatchScriptToDevice({
+      device: device(), source: { kind: 'saved', script: savedScript(), automationRunId: 'run-1' },
+    });
+    const execValues = vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
+    expect(execValues).toMatchObject({ automationRunId: 'run-1' });
   });
 
   it('raw: creates NO execution row and uses provenance as payload scriptId', async () => {
@@ -177,8 +224,7 @@ describe('dispatchScriptToDevice — rows and payload', () => {
   });
 
   it('deletes the pending execution row if queueCommand throws', async () => {
-    const del = { where: vi.fn().mockResolvedValue(undefined) };
-    vi.mocked(db.delete).mockReturnValue(del as any);
+    mockDiscardDelete([{ id: 'exec-1' }]);
     vi.mocked(queueCommand).mockRejectedValue(new Error('boom'));
     await expect(dispatchScriptToDevice({ device: device(), source: { kind: 'saved', script: savedScript() } })).rejects.toThrow('boom');
     expect(db.delete).toHaveBeenCalled();
@@ -186,49 +232,143 @@ describe('dispatchScriptToDevice — rows and payload', () => {
 
   it('rethrows the ORIGINAL queueCommand error even if the cleanup delete also throws', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    const del = { where: vi.fn().mockRejectedValue(new Error('cleanup-db-down')) };
-    vi.mocked(db.delete).mockReturnValue(del as any);
+    mockDiscardDelete(() => Promise.reject(new Error('cleanup-db-down')));
     vi.mocked(queueCommand).mockRejectedValue(new Error('boom'));
     await expect(dispatchScriptToDevice({ device: device(), source: { kind: 'saved', script: savedScript() } })).rejects.toThrow('boom');
     expect(db.delete).toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(captureException).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
+  });
+
+  // A1 regression (#3162 non-throw path): queueCommand can resolve falsy
+  // WITHOUT throwing (e.g. a swallowed insert failure inside queueCommand).
+  // Before the fix, this branch returned insert_failed but never ran
+  // cleanup, orphaning the pending execution row for the reaper to later
+  // mislabel 'timeout'.
+  it('discards the pending execution row when queueCommand resolves falsy without throwing', async () => {
+    mockDiscardDelete([{ id: 'exec-1' }]);
+    vi.mocked(queueCommand).mockResolvedValue(undefined as any);
+    const r = await dispatchScriptToDevice({ device: device(), source: { kind: 'saved', script: savedScript() } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('insert_failed');
+    expect(db.delete).toHaveBeenCalled();
+  });
+
+  it('warns when the cleanup delete removes 0 rows (execution was no longer pending)', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockDiscardDelete([]);
+    vi.mocked(queueCommand).mockRejectedValue(new Error('boom'));
+    await expect(dispatchScriptToDevice({ device: device(), source: { kind: 'saved', script: savedScript() } })).rejects.toThrow('boom');
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('discards the pending execution row when the payload build throws', async () => {
+    mockDiscardDelete([{ id: 'exec-1' }]);
+    vi.mocked(encryptSensitivePayloadFields).mockImplementationOnce(() => { throw new Error('payload boom'); });
+    await expect(dispatchScriptToDevice({ device: device(), source: { kind: 'saved', script: savedScript() } })).rejects.toThrow('payload boom');
+    expect(db.delete).toHaveBeenCalled();
+    expect(queueCommand).not.toHaveBeenCalled();
   });
 });
 
 describe('dispatchScriptToDevice — delivery', () => {
   it('claims, decrypts via decryptCommandForDelivery, sends, and marks execution running (guarded)', async () => {
-    const updateWhere = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(db.update).mockReturnValue({ set: vi.fn().mockReturnValue({ where: updateWhere }) } as any);
-    vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt: new Date('2026-08-11T00:00:00Z') } as any);
+    const setSpy = vi.fn();
+    const whereArgs: unknown[] = [];
+    vi.mocked(db.update).mockReturnValue({
+      set: (vals: Record<string, unknown>) => {
+        setSpy(vals);
+        return {
+          where: (condition: unknown) => {
+            whereArgs.push(condition);
+            return Promise.resolve(undefined);
+          },
+        };
+      },
+    } as any);
+    const executedAt = new Date('2026-08-11T00:00:00Z');
+    vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt } as any);
     vi.mocked(sendCommandToAgent).mockReturnValue(true);
     const r = await dispatchScriptToDevice({ device: device({ agentId: 'agent-1' }), source: { kind: 'saved', script: savedScript() } });
     expect(decryptCommandForDelivery).toHaveBeenCalled();
     expect(sendCommandToAgent).toHaveBeenCalledWith('agent-1', expect.objectContaining({ id: 'cmd-1', type: 'script' }));
-    if (r.ok) { expect(r.delivered).toBe(true); expect(r.executedAt).toEqual(new Date('2026-08-11T00:00:00Z')); }
+    if (r.ok) {
+      expect(r.delivered).toBe(true);
+      expect(r.deliveryOutcome).toBe('sent');
+      expect(r.executedAt).toEqual(executedAt);
+    }
+
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledWith({ status: 'running', startedAt: executedAt });
+    expect(whereArgs).toHaveLength(1);
+    const tokens = collectSqlTokens(whereArgs[0]);
+    expect(tokens).toContain('exec-1');
+    expect(tokens).toContain('status');
+    expect(tokens).toContain('pending');
+  });
+
+  it('reports claim_lost when claimPendingCommandForDelivery loses the race (no throw)', async () => {
+    vi.mocked(claimPendingCommandForDelivery).mockResolvedValue(null);
+    const r = await dispatchScriptToDevice({ device: device({ agentId: 'agent-1' }), source: { kind: 'saved', script: savedScript() } });
+    expect(sendCommandToAgent).not.toHaveBeenCalled();
+    expect(db.update).not.toHaveBeenCalled();
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.delivered).toBe(false);
+      expect(r.deliveryOutcome).toBe('claim_lost');
+    }
   });
 
   it('releases the claim when decrypt returns null (does NOT send raw payload)', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt: new Date() } as any);
-    vi.mocked(decryptCommandForDelivery).mockReturnValue(null as any);
+    // Once-only override: the default mock implementation just echoes the
+    // command back, and other tests in this suite rely on that default —
+    // `mockReturnValueOnce` avoids leaking `null` into later tests (plain
+    // `mockReturnValue` is not undone by `vi.clearAllMocks()` in beforeEach).
+    vi.mocked(decryptCommandForDelivery).mockReturnValueOnce(null as any);
     const { releaseClaimedCommandDelivery } = await import('./commandDispatch');
     const r = await dispatchScriptToDevice({ device: device({ agentId: 'agent-1' }), source: { kind: 'saved', script: savedScript() } });
     expect(sendCommandToAgent).not.toHaveBeenCalled();
     expect(releaseClaimedCommandDelivery).toHaveBeenCalledWith('cmd-1', expect.any(Date));
-    if (r.ok) expect(r.delivered).toBe(false);
+    expect(db.update).not.toHaveBeenCalled();
+    if (r.ok) {
+      expect(r.delivered).toBe(false);
+      expect(r.deliveryOutcome).toBe('decrypt_failed');
+    }
+    // decrypt_failed means we had a connected agent and still failed to
+    // reach it — operationally distinct from "queued for later", so it warns.
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
   });
 
   it('releases the claim when the WS send fails', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     vi.mocked(claimPendingCommandForDelivery).mockResolvedValue({ executedAt: new Date() } as any);
     vi.mocked(sendCommandToAgent).mockReturnValue(false);
     const { releaseClaimedCommandDelivery } = await import('./commandDispatch');
     const r = await dispatchScriptToDevice({ device: device({ agentId: 'agent-1' }), source: { kind: 'saved', script: savedScript() } });
     expect(releaseClaimedCommandDelivery).toHaveBeenCalled();
-    if (r.ok) expect(r.delivered).toBe(false);
+    expect(db.update).not.toHaveBeenCalled();
+    if (r.ok) {
+      expect(r.delivered).toBe(false);
+      expect(r.deliveryOutcome).toBe('send_failed');
+    }
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
   });
 
-  it('skips delivery entirely when deliver:false or agentId null', async () => {
-    await dispatchScriptToDevice({ device: device({ agentId: 'agent-1' }), deliver: false, source: { kind: 'saved', script: savedScript() } });
-    await dispatchScriptToDevice({ device: device({ agentId: null }), source: { kind: 'saved', script: savedScript() } });
+  it('skips delivery entirely when agentId is null (normal "no agent connected" case, no warn)', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const r = await dispatchScriptToDevice({ device: device({ agentId: null }), source: { kind: 'saved', script: savedScript() } });
     expect(claimPendingCommandForDelivery).not.toHaveBeenCalled();
+    if (r.ok) {
+      expect(r.delivered).toBe(false);
+      expect(r.deliveryOutcome).toBe('no_agent');
+    }
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -26,7 +26,7 @@ import { captureException } from './sentry';
  * RLS; system-context callers must validate ownership before calling.
  */
 export type ScriptDispatchSource =
-  | { kind: 'saved'; script: typeof scripts.$inferSelect }
+  | { kind: 'saved'; script: typeof scripts.$inferSelect; automationRunId?: string | null }
   | { kind: 'raw'; content: string; language: string; provenance: string };
 
 export type DispatchScriptInput = {
@@ -40,13 +40,22 @@ export type DispatchScriptInput = {
   timeoutSeconds?: number;
   targetSessionId?: number;
   batchId?: string | null;
-  automationRunId?: string | null;
   requireOnline?: boolean;
-  deliver?: boolean;
 };
 
 export type DispatchScriptResult =
-  | { ok: true; commandId: string; executionId: string | null; delivered: boolean; executedAt: Date | null }
+  | {
+      ok: true;
+      commandId: string;
+      executionId: string | null;
+      delivered: boolean;
+      // Distinguishes WHY `delivered` is false. 'no_agent' is the normal
+      // "queued for later" case; 'claim_lost', 'decrypt_failed', and
+      // 'send_failed' all mean we had a connected agent and still failed to
+      // reach it — operationally different, and worth a log line (see below).
+      deliveryOutcome: 'sent' | 'claim_lost' | 'decrypt_failed' | 'send_failed' | 'no_agent';
+      executedAt: Date | null;
+    }
   | { ok: false; code: 'device_decommissioned' | 'device_offline' | 'os_mismatch' | 'org_mismatch' | 'insert_failed'; error: string };
 
 export async function dispatchScriptToDevice(input: DispatchScriptInput): Promise<DispatchScriptResult> {
@@ -115,7 +124,7 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
         orgId: device.orgId,
         triggeredBy: input.triggeredBy ?? null,
         triggerType: input.triggerType ?? 'manual',
-        ...(input.automationRunId ? { automationRunId: input.automationRunId } : {}),
+        ...(source.automationRunId ? { automationRunId: source.automationRunId } : {}),
         parameters,
         status: 'pending',
       })
@@ -126,50 +135,74 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
     executionId = execution.id;
   }
 
-  const payload = encryptSensitivePayloadFields('script', {
-    scriptId: payloadScriptId,
-    ...(executionId ? { executionId } : {}),
-    ...(input.batchId ? { batchId: input.batchId } : {}),
-    language,
-    content,
-    parameters,
-    timeoutSeconds,
-    runAs,
-    ...(input.targetSessionId != null ? { targetSessionId: input.targetSessionId } : {}),
-  });
+  // Discards a pending execution row that would otherwise be orphaned —
+  // stuck 'pending' with no command for the reaper to later mislabel
+  // 'timeout' (the #3162 failure mode, mirrors the old
+  // discardQueuelessExecution in automationRuntime). Used on BOTH the
+  // queueCommand-throws path and the queueCommand-resolves-falsy path: only
+  // one of those raises, so a catch block alone used to miss the other.
+  // `.returning` + a 0-row warning restores the diagnostic the old
+  // discardQueuelessExecution had: a 0-row delete here means the row wasn't
+  // 'pending' anymore for some other reason, which is worth knowing about.
+  // The delete itself is wrapped in its own try/catch: a transient DB error
+  // here must never replace or mask the ORIGINAL failure the caller is about
+  // to see/return.
+  const discardPendingExecution = async (reason: string) => {
+    if (!executionId) return;
+    try {
+      const deleted = await db
+        .delete(scriptExecutions)
+        .where(and(eq(scriptExecutions.id, executionId), eq(scriptExecutions.status, 'pending')))
+        .returning({ id: scriptExecutions.id });
+      if (deleted.length === 0) {
+        console.warn(
+          '[scriptDispatch] execution row was not pending at discard time; leaving it alone',
+          { executionId, deviceId: device.id, reason },
+        );
+      }
+    } catch (cleanupErr) {
+      console.error(
+        '[scriptDispatch] failed to discard pending execution row',
+        { executionId, deviceId: device.id, reason, error: cleanupErr },
+      );
+      captureException(cleanupErr);
+    }
+  };
 
+  let payload: Record<string, unknown>;
   let command: Awaited<ReturnType<typeof queueCommand>>;
+  let stage: 'payload build' | 'queueCommand' = 'payload build';
   try {
+    // Payload build lives inside this guarded region (not after it) so a
+    // throw here — no-op today (no 'script' entry in
+    // SENSITIVE_PAYLOAD_FIELDS), but PR4 of #3409 adds one — also discards
+    // the pending execution row instead of orphaning it.
+    payload = encryptSensitivePayloadFields('script', {
+      scriptId: payloadScriptId,
+      ...(executionId ? { executionId } : {}),
+      ...(input.batchId ? { batchId: input.batchId } : {}),
+      language,
+      content,
+      parameters,
+      timeoutSeconds,
+      runAs,
+      ...(input.targetSessionId != null ? { targetSessionId: input.targetSessionId } : {}),
+    });
+    stage = 'queueCommand';
     command = await queueCommand(device.id, 'script', payload, input.createdBy ?? undefined);
   } catch (err) {
-    // Don't leave an orphaned pending execution the reaper would later
-    // mislabel 'timeout' (mirrors discardQueuelessExecution in automationRuntime).
-    // The cleanup delete is wrapped in its own try/catch: a transient DB error
-    // here must never replace the original queueCommand failure the caller is
-    // about to see (mirrors automationRuntime.ts discardQueuelessExecution).
-    if (executionId) {
-      try {
-        await db.delete(scriptExecutions).where(and(
-          eq(scriptExecutions.id, executionId),
-          eq(scriptExecutions.status, 'pending'),
-        ));
-      } catch (cleanupErr) {
-        console.error(
-          `[scriptDispatch] failed to discard unqueued script execution ${executionId} (device ${device.id}):`,
-          cleanupErr,
-        );
-        captureException(cleanupErr);
-      }
-    }
+    await discardPendingExecution(`${stage} threw`);
     throw err;
   }
   if (!command) {
+    await discardPendingExecution('queueCommand returned no row');
     return { ok: false, code: 'insert_failed', error: 'Failed to create command' };
   }
 
   let delivered = false;
   let executedAt: Date | null = null;
-  if (device.agentId && input.deliver !== false) {
+  let deliveryOutcome: 'sent' | 'claim_lost' | 'decrypt_failed' | 'send_failed' | 'no_agent' = 'no_agent';
+  if (device.agentId) {
     const claimed = await claimPendingCommandForDelivery(command.id);
     if (claimed) {
       const deliverable = decryptCommandForDelivery({ id: command.id, type: 'script', payload });
@@ -178,20 +211,32 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
         : false;
       if (sent) {
         delivered = true;
+        deliveryOutcome = 'sent';
         executedAt = claimed.executedAt;
         if (executionId) {
           // Guarded on pending: a fast agent can already have driven the row
-          // terminal via handleScriptResult (see automationRuntime.ts:996).
+          // terminal (see handleScriptResult in services/commandResultHandlers.ts).
           await db
             .update(scriptExecutions)
             .set({ status: 'running', startedAt: claimed.executedAt })
             .where(and(eq(scriptExecutions.id, executionId), eq(scriptExecutions.status, 'pending')));
         }
       } else {
+        // We had a claimed command and a connected agent and still failed to
+        // reach it — operationally different from the normal "no agent
+        // connected, queued for later" case, so this is worth a log line.
+        deliveryOutcome = deliverable ? 'send_failed' : 'decrypt_failed';
+        console.warn('[scriptDispatch] failed to deliver claimed command to connected agent', {
+          commandId: command.id,
+          deviceId: device.id,
+          deliveryOutcome,
+        });
         await releaseClaimedCommandDelivery(command.id, claimed.executedAt);
       }
+    } else {
+      deliveryOutcome = 'claim_lost';
     }
   }
 
-  return { ok: true, commandId: command.id, executionId, delivered, executedAt };
+  return { ok: true, commandId: command.id, executionId, delivered, deliveryOutcome, executedAt };
 }

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -31,6 +31,7 @@ vi.mock('./scriptDispatch', () => ({
 // allowedSiteIds is set, which these tests don't exercise.
 
 import { db } from '../db';
+import { checkDeviceMaintenanceWindow } from './featureConfigResolver';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { executeScriptOnDevices } from './scriptExecution';
 
@@ -203,7 +204,10 @@ describe('executeScriptOnDevices — cross-org isolation', () => {
     if (result.ok) {
       expect(result.batchIds).toHaveLength(2);
       expect(result.batchIds).toEqual(['batch-org-a', 'batch-org-b']);
-      expect(result.batchId).toBe(result.batchIds[0]);
+      // A multi-org run has no single batch that represents the whole run —
+      // `batchId` (the legacy scalar) must stay null rather than silently
+      // pointing at one arbitrary org's slice. `batchIds` is the complete list.
+      expect(result.batchId).toBeNull();
     }
 
     // Two batch inserts: org-a with 2 devices targeted, org-b with 1.
@@ -228,5 +232,71 @@ describe('executeScriptOnDevices — cross-org isolation', () => {
 
     // Final status update covers both created batches.
     expect(db.update).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Full MaintenanceWindowStatus shape (featureConfigResolver.ts) — the mocked
+// resolver must satisfy every field, not just the two this suite cares about.
+const maintenanceStatus = (overrides: { active: boolean; suppressScripts: boolean }) => ({
+  active: overrides.active,
+  suppressScripts: overrides.suppressScripts,
+  suppressAlerts: false,
+  suppressPatching: false,
+  suppressAutomations: false,
+  rebootIfPending: false,
+});
+
+describe('executeScriptOnDevices — maintenance window suppression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.insert).mockReturnValue(insertReturning([{ id: 'inserted-1' }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+    vi.mocked(checkDeviceMaintenanceWindow).mockResolvedValue(maintenanceStatus({ active: false, suppressScripts: false }));
+  });
+
+  it('returns 409 with maintenanceSuppressedDeviceIds when every target device is in a script-suppressing maintenance window', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([baseDevice({ id: 'device-1', orgId: 'org-b' })]) as any);
+    vi.mocked(checkDeviceMaintenanceWindow).mockResolvedValue(maintenanceStatus({ active: true, suppressScripts: true }));
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-1'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+      expect(result.maintenanceSuppressedDeviceIds).toEqual(['device-1']);
+    }
+    expect(dispatchScriptToDevice).not.toHaveBeenCalled();
+  });
+
+  it('excludes only the suppressed device from an otherwise-executable batch', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-1', orgId: 'org-b' }),
+        baseDevice({ id: 'device-2', orgId: 'org-b' }),
+      ]) as any);
+    vi.mocked(checkDeviceMaintenanceWindow).mockImplementation(async (deviceId: string) =>
+      deviceId === 'device-1'
+        ? maintenanceStatus({ active: true, suppressScripts: true })
+        : maintenanceStatus({ active: false, suppressScripts: false }),
+    );
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-1', 'device-2'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.maintenanceSuppressedDeviceIds).toEqual(['device-1']);
+      expect(result.executions.map((e) => e.deviceId)).toEqual(['device-2']);
+    }
   });
 });

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -191,6 +191,17 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
   }
 
   const executions: Array<{ executionId: string; deviceId: string; commandId: string }> = [];
+  // This loop itself is sequential/awaited and therefore bounded, but
+  // queueCommand (inside dispatchScriptToDevice) fires an un-awaited,
+  // fire-and-forget audit transaction PER DEVICE for 'script' commands
+  // (AUDITED_COMMANDS in commandQueue.ts) that this loop cannot see or wait
+  // on. That's the actual unbounded fan-out risk — a large batch launches
+  // that many concurrent transactions against a pool sized for far fewer
+  // while this request also holds a connection (pool-starvation shape).
+  // The real mitigation is the `.max(500)` cap on `deviceIds` in
+  // executeScriptSchema (routes/scripts.ts) — do not raise that cap without
+  // also addressing this fan-out, and do not "fix" it by restructuring
+  // queueCommand's audit dispatch out from under this loop.
   for (const device of executableDevices) {
     const dispatch = await dispatchScriptToDevice({
       device,
@@ -225,7 +236,15 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
 
   return {
     ok: true,
-    batchId: createdBatchIds[0] ?? null,
+    // `batchId` is a legacy scalar convenience for the common single-batch
+    // case. In a multi-org run there is no single batch that represents the
+    // whole run — createdBatchIds[0] would silently pick an arbitrary org's
+    // batch, and a consumer polling just that id would track only a slice of
+    // the run. Prefer absent-and-loud over misleadingly partial: `batchId` is
+    // only populated when exactly one batch was created. `batchIds` (below)
+    // always carries the complete list and is what multi-batch callers must
+    // use.
+    batchId: createdBatchIds.length === 1 ? createdBatchIds[0]! : null,
     batchIds: createdBatchIds,
     scriptId: input.scriptId,
     script,


### PR DESCRIPTION
Follow-up to #3418, which merged before this review pass landed. Fixes the findings from a five-lens review (general code review, test coverage, silent failures, type design, comment accuracy) of that PR. No new features — all corrections to the `scriptDispatch` seam and its callers.

## Critical

**AI `run_script` echoed full script payloads into the model context and broke its result contract** — `services/aiToolsScripts.ts`. Routing through `waitForCommandResult` returned the whole `device_commands` row including `payload`, so every run shipped the complete script `content` and `parameters` into the LLM turn and persisted chat history (a 50 KB script × 10 devices ≈ 500 KB), bypassing the redaction convention `sanitizeCommandPayloadForAudit`/`sanitizeCommandForHistory` apply everywhere else. It also silently moved `stdout`/`exitCode` under `.result`, breaking anything reading them top-level. Now projects `{...cmd.result, commandId, executionId}`, mirroring the previous `executeCommand` shape exactly (including its null-result fallback). Test asserts no `payload`/`content` key survives.

**Orphaned `pending` execution row when `queueCommand` resolved falsy without throwing** — `services/scriptDispatch.ts`. The catch path discarded the row; the `if (!command)` early return did not, leaving a `pending` `script_executions` row with no command behind it until the reaper stamped it `timeout` — "no response from agent", which is a lie: no command was ever created. This is the #3162 failure mode on the path #3162 didn't cover. Both paths now run one shared `discardPendingExecution(reason)` helper.

## Important

- **Restored the discard 0-row diagnostic.** The deleted `discardQueuelessExecution` used `.returning()` and warned when nothing was deleted, because a 0-row result means something unexpected happened; the extraction dropped both. Same forensic-trail principle CLAUDE.md mandates for migration cleanup statements.
- **Payload build moved inside the guarded region.** `encryptSensitivePayloadFields` sat between the execution insert and the guarded `queueCommand` call. It cannot throw today (no `script` entry in `SENSITIVE_PAYLOAD_FIELDS`), but #3409's secrets PR adds one — at which point a throw there would orphan the row again.
- **Capped `deviceIds` at 500** on `POST /scripts/:id/execute` (previously unbounded). Every script command now fires a fire-and-forget audit transaction per device via `queueCommand`; a 500-device run against a pool of ~30 is the pool-starvation shape that has bitten this repo before. The automation fleet path is separately bounded at `runWithConcurrency(..., 5)`. A structural fix in `queueCommand` belongs in its own PR — the comment pair records why the cap exists so it isn't raised casually.
- **`automationRunId` moved into the `saved` variant of `ScriptDispatchSource`.** It was a top-level input read only for saved sources, so pairing it with a `raw` source silently dropped it. Now uncompilable.
- **Sentry blind spots closed.** The AI tool's per-device catch and `automationRuntime`'s per-device catch both degraded gracefully without ever reporting — an infra fault during dispatch was indistinguishable from "device unsupported", visible only by reading one automation run's log. Both now `captureException`.
- **Corrected a comment that would have gotten the partner guard deleted.** It claimed the intent-release worker runs the tool under a system context; it actually uses `withAuthDbAccessContext` (RLS-scoped to the approver). The guard is still load-bearing, for a different reason: membership-less users receive a **system-scope token** where `orgCondition` returns null and RLS is off, leaving app-layer org-equality plus the device-org→partner check as the only defenses. Also fixed a pointer citing `handleScriptResult` at `automationRuntime.ts:996` (it lives in `services/commandResultHandlers.ts`; that line is now unrelated code).
- **`delivered:false` now carries a reason.** New `deliveryOutcome: 'sent' | 'claim_lost' | 'decrypt_failed' | 'send_failed' | 'no_agent'` distinguishes "queued, agent offline" from "we had a socket and failed to reach it"; the latter two warn. Surfaced in automation action logs.
- **Legacy scalar `batchId` is `null` for multi-org runs** instead of pointing at an arbitrary org's batch, so a partial view fails visibly rather than reporting a misleadingly complete batch. `batchIds` remains the full list; no web consumer reads the scalar.
- Removed the dead `deliver?: boolean` param and an unused `isNull` import.

## Tests

The guarded `status='pending'` update — one of #3418's headline deltas — was referenced by three tests but asserted by none, and the first attempt at fixing that was **vacuous**: the token-scanning helper walked the real Drizzle table graph, so `'status'`/`'pending'` appeared regardless of the predicate. Deleting the guard outright still passed. Replaced with a bound-parameter walker; verified by mutation that removing the guard now fails:

```
AssertionError: expected [ { column: 'id', value: 'exec-1' } ] to have a length of 2 but got 1
```

Also added: `queueCommand`-resolves-undefined regression test (asserts the discard fires), 0-row discard warning, claim-lost path, each `deliveryOutcome` value and its warn policy, maintenance-window 409 in `scriptExecution` plus its mobile passthrough, AI multi-device failure isolation, `execute_command` raw-source mapping (`shell`→`language`, provenance), and 501-device-id rejection.

Full API unit suite: 1320 passed, 1 pre-existing unrelated flake (`extensions/bundleVerifier.test.ts`). Typecheck clean apart from 3 pre-existing Stripe API-version errors.

## Deferred to follow-up issues

Partial-batch semantics in `executeScriptOnDevices` (a single device's dispatch failure throws, discarding the outcomes of already-dispatched devices and leaving the batch row `pending`); the pre-existing manual-path commit-before-deliver race, now cheap to fix centrally behind the one seam; and a structural fix for `queueCommand`'s unbounded audit fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)