### PR TITLE
fix(deps): repair broken pnpm-lock.yaml (duplicated hono@4.13.1 key)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8129,10 +8129,6 @@ packages:
     resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
     engines: {node: '>=16.9.0'}
 
-  hono@4.13.1:
-    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
-    engines: {node: '>=16.9.0'}
-
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -19933,8 +19929,6 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
-
-  hono@4.13.1: {}
 
   hono@4.13.1: {}
 


### PR DESCRIPTION
## main is currently red for every PR

`pnpm install --frozen-lockfile` aborts before installing anything:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "pnpm-lock.yaml" is broken: duplicated mapping key (8132:3)
 8132 |   hono@4.13.1:
----------^
```

That fails all 17 install-dependent jobs — Type Check, Test API, Lint, Check Migrations (both), NPM Audit, Security Audit, Trivy Image Scan, Test Portal, and every Office add-in suite. Any PR opened against main right now inherits it.

## Cause

A dependabot merge left the `hono@4.13.1` entry written twice — once in `packages` (lines 8128 and 8132) and once in `snapshots` (19937 and 19939). Both pairs are byte-identical:

```yaml
  hono@4.13.1:
    resolution: {integrity: sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==}
    engines: {node: '>=16.9.0'}
```

YAML forbids duplicate mapping keys, so pnpm refuses the file outright rather than picking one.

## Fix

Delete the duplicate copy of each block — 6 lines, no resolution or integrity change, nothing else touched. Verified locally:

```
$ pnpm install --frozen-lockfile --ignore-scripts
Done in 27.9s using pnpm v10.34.5
```

Found while investigating CI failures on #3438, which is blocked by this and not by its own changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)