### PR TITLE
feat(remote): slim provider-list endpoint + preferred-remote-tool profile control (#3389)

### DIFF
--- a/apps/api/src/routes/remote/index.ts
+++ b/apps/api/src/routes/remote/index.ts
@@ -1,6 +1,11 @@
 import { Hono } from 'hono';
-import { authMiddleware, requireMfa, requirePermission } from '../../middleware/auth';
+import { authMiddleware, requireMfa, requirePermission, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
+import {
+  readPartnerRemoteAccessSettings,
+  readRemoteAccessSettingsForPartner,
+  toProviderSummaries,
+} from '../../services/remoteAccessProviders';
 import { sessionRoutes } from './sessions';
 import { supportSessionRoutes } from './supportSessions';
 
@@ -10,8 +15,37 @@ export const remoteRoutes = new Hono();
 remoteRoutes.use('*', authMiddleware);
 remoteRoutes.use('*', requirePermission(PERMISSIONS.REMOTE_ACCESS.resource, PERMISSIONS.REMOTE_ACCESS.action), requireMfa());
 
+// GET /remote/providers - the tenant's remote-access providers, id/name/enabled
+// only.
+//
+// Lives here rather than under /orgs because the gate above is exactly right:
+// the same `remote:access` permission that guards issuing a launch URL, and no
+// partner-scope requirement. The only existing source is GET /orgs/partners/me,
+// which is partner-scope gated AND returns the whole settings blob including
+// encrypted provider passwords — the wrong exposure path for a control a
+// technician needs (#3404).
+//
+// Consumers: the profile "preferred remote tool" chooser (#3391/#3389), the
+// org-restriction reads in #3404, and the availability check in #3402.
+remoteRoutes.get('/providers', async (c) => {
+  const auth = c.get('auth') as AuthContext;
+
+  // A partner-scoped caller names its own partner; an org-scoped one does not
+  // (and its accessible-partner list is empty), so resolve through the org the
+  // same way the launcher walks device -> org -> partner.
+  const settings = auth.partnerId
+    ? await readRemoteAccessSettingsForPartner(auth.partnerId)
+    : auth.orgId
+      ? await readPartnerRemoteAccessSettings(auth.orgId)
+      : undefined;
+
+  // No resolvable partner (e.g. a system-scoped caller with no org context) is
+  // an empty directory, not an error: the caller simply has no tenant whose
+  // providers to list.
+  return c.json(toProviderSummaries(settings));
+});
+
 // Mount sub-routes
 remoteRoutes.route('/', sessionRoutes);
 // Quick Support inherits the same auth + remote:access + MFA gate above.
 remoteRoutes.route('/', supportSessionRoutes);
-

--- a/apps/api/src/services/remoteAccessProviders.test.ts
+++ b/apps/api/src/services/remoteAccessProviders.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { toProviderSummaries } from './remoteAccessProviders';
+
+// The projection is the security property of this whole feature: the endpoint
+// exists so a technician's provider chooser stops reading the partner settings
+// blob, which carries urlTemplate / customFieldKey / password (#3404).
+
+const FULL_PROVIDER = {
+  id: 'p1',
+  name: 'ScreenConnect',
+  urlTemplate: 'sc://connect/{{customField}}?pw={{password}}',
+  customFieldKey: 'sc_id',
+  password: 'super-secret',
+  enabled: true,
+};
+
+describe('toProviderSummaries', () => {
+  it('emits id/name/enabled and NOTHING else', () => {
+    const { providers } = toProviderSummaries({ providers: [FULL_PROVIDER] });
+
+    expect(providers).toHaveLength(1);
+    // exact key set — a spread that started leaking a new credential field
+    // would add a key here and fail
+    expect(Object.keys(providers[0]!).sort()).toEqual(['enabled', 'id', 'name']);
+  });
+
+  it('never leaks the credential-bearing fields, checked by value', () => {
+    const serialized = JSON.stringify(toProviderSummaries({ providers: [FULL_PROVIDER] }));
+
+    expect(serialized).not.toContain('super-secret');
+    expect(serialized).not.toContain('sc://connect');
+    expect(serialized).not.toContain('sc_id');
+  });
+
+  it('keeps disabled providers but reports them as disabled', () => {
+    // The chooser needs to render them greyed rather than silently omit them,
+    // so a tech can see why their tool is unavailable.
+    const { providers } = toProviderSummaries({
+      providers: [FULL_PROVIDER, { ...FULL_PROVIDER, id: 'p2', name: 'RustDesk', enabled: false }],
+    });
+
+    expect(providers.map((p) => [p.id, p.enabled])).toEqual([
+      ['p1', true],
+      ['p2', false],
+    ]);
+  });
+
+  it('reports the tenant default when it names a visible provider', () => {
+    const { defaultProviderId } = toProviderSummaries({
+      providers: [FULL_PROVIDER],
+      defaultProviderId: 'p1',
+    });
+    expect(defaultProviderId).toBe('p1');
+  });
+
+  it('drops a dangling default rather than naming a provider that is not there', () => {
+    // #3401: dangling defaultProviderId is creatable today. Reporting it would
+    // render a selected option the chooser has no entry for.
+    const { defaultProviderId } = toProviderSummaries({
+      providers: [FULL_PROVIDER],
+      defaultProviderId: 'does-not-exist',
+    });
+    expect(defaultProviderId).toBeNull();
+  });
+
+  it('is empty and non-throwing for a tenant with no remote access configured', () => {
+    expect(toProviderSummaries(undefined)).toEqual({ providers: [], defaultProviderId: null });
+    expect(toProviderSummaries({})).toEqual({ providers: [], defaultProviderId: null });
+  });
+
+  it('tolerates a malformed providers payload without throwing', () => {
+    // partners.settings is jsonb: nothing guarantees the shape at read time.
+    expect(toProviderSummaries({ providers: 'nonsense' as never })).toEqual({
+      providers: [],
+      defaultProviderId: null,
+    });
+    const { providers } = toProviderSummaries({
+      providers: [null as never, { id: '', name: 'x', enabled: true } as never, FULL_PROVIDER],
+    });
+    expect(providers.map((p) => p.id)).toEqual(['p1']);
+  });
+});

--- a/apps/api/src/services/remoteAccessProviders.ts
+++ b/apps/api/src/services/remoteAccessProviders.ts
@@ -1,0 +1,108 @@
+import { eq } from 'drizzle-orm';
+import type { InheritableRemoteAccessSettings, RemoteAccessProvider } from '@breeze/shared';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { organizations, partners } from '../db/schema';
+
+/**
+ * The only shape of a remote-access provider that may leave the API.
+ *
+ * `RemoteAccessProvider` also carries `urlTemplate`, `customFieldKey` and
+ * `password`. Those are the launcher's inputs and are stored inside the
+ * encrypted `partners.settings` blob — they must never reach a client. This
+ * type exists so the projection is enforced by the compiler rather than by
+ * remembering to delete fields at each call site.
+ */
+export interface RemoteAccessProviderSummary {
+  id: string;
+  name: string;
+  enabled: boolean;
+}
+
+export interface RemoteAccessDirectory {
+  providers: RemoteAccessProviderSummary[];
+  defaultProviderId: string | null;
+}
+
+type PartnerSettingsShape = {
+  remoteAccessProviders?: InheritableRemoteAccessSettings;
+};
+
+/**
+ * Read the remote-access settings of the partner that owns `orgId`.
+ *
+ * **This needs a real privilege escalation and gets one.** `partners`' SELECT
+ * policy is `breeze_has_partner_access(id)`, which tests
+ * `breeze.accessible_partner_ids` — and `computeAccessiblePartnerIds` returns
+ * `[]` for `scope === 'organization'`. An org-scoped technician therefore
+ * cannot see the partner row under their own context, and a *bare*
+ * `withSystemDbAccessContext` would not help: it delegates to
+ * `withDbAccessContext`, which early-returns when a context store already
+ * exists, so inside a request it silently retains the caller's scope. Only
+ * exiting the ALS store first opens a genuinely system-scoped transaction.
+ *
+ * Escalating past RLS is only defensible here because every caller projects
+ * the result through `toProviderSummaries` before it leaves the process. Do
+ * not return the raw settings from a route.
+ *
+ * See #3419 for the same gap in the launcher's own partner read.
+ */
+export async function readPartnerRemoteAccessSettings(
+  orgId: string,
+): Promise<InheritableRemoteAccessSettings | undefined> {
+  const settings = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .select({ settings: partners.settings })
+        .from(partners)
+        .innerJoin(organizations, eq(organizations.partnerId, partners.id))
+        .where(eq(organizations.id, orgId))
+        .limit(1);
+      return (row?.settings ?? {}) as PartnerSettingsShape;
+    }),
+  );
+  return settings.remoteAccessProviders;
+}
+
+/** Same read, when the partner is already known (partner-scoped callers). */
+export async function readRemoteAccessSettingsForPartner(
+  partnerId: string,
+): Promise<InheritableRemoteAccessSettings | undefined> {
+  const settings = await runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      const [row] = await db
+        .select({ settings: partners.settings })
+        .from(partners)
+        .where(eq(partners.id, partnerId))
+        .limit(1);
+      return (row?.settings ?? {}) as PartnerSettingsShape;
+    }),
+  );
+  return settings.remoteAccessProviders;
+}
+
+/**
+ * Project to the client-safe shape. Field-by-field on purpose: a spread would
+ * silently start leaking any credential-bearing field added to
+ * `RemoteAccessProvider` later.
+ */
+export function toProviderSummaries(
+  settings: InheritableRemoteAccessSettings | undefined,
+): RemoteAccessDirectory {
+  const raw: RemoteAccessProvider[] = Array.isArray(settings?.providers) ? settings.providers : [];
+
+  const providers = raw
+    .filter((p): p is RemoteAccessProvider => !!p && typeof p.id === 'string' && p.id.length > 0)
+    .map((p) => ({
+      id: p.id,
+      name: typeof p.name === 'string' ? p.name : '',
+      enabled: p.enabled === true,
+    }));
+
+  // Only report a default the caller can actually see. A dangling id (#3401)
+  // would otherwise render as a selected option that does not exist.
+  const defaultId = settings?.defaultProviderId;
+  const defaultProviderId =
+    typeof defaultId === 'string' && providers.some((p) => p.id === defaultId) ? defaultId : null;
+
+  return { providers, defaultProviderId };
+}

--- a/apps/web/src/components/settings/ProfilePage.tsx
+++ b/apps/web/src/components/settings/ProfilePage.tsx
@@ -8,6 +8,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import ChangePasswordForm from './ChangePasswordForm';
 import ConnectSsoCard from './ConnectSsoCard';
 import MFASettings from './MFASettings';
+import RemoteToolSettings from './RemoteToolSettings';
 import ApproverDevicesSection from './ApproverDevicesSection';
 import ThemingSettings from './ThemingSettings';
 import { createPasskeyCredential, fetchWithAuth, useAuthStore } from '../../stores/auth';
@@ -914,6 +915,10 @@ export default function ProfilePage({ initialUser }: ProfilePageProps) {
       {/* Approval security (Breeze Authenticator) */}
       <ApproverDevicesSection passkeyCount={passkeys.length} mfaMethod={user?.mfaMethod ?? null} />
       <ThemingSettings
+        preferences={user?.preferences}
+        onSaved={(preferences) => setUser(prev => (prev ? { ...prev, preferences } : prev))}
+      />
+      <RemoteToolSettings
         preferences={user?.preferences}
         onSaved={(preferences) => setUser(prev => (prev ? { ...prev, preferences } : prev))}
       />

--- a/apps/web/src/components/settings/RemoteToolSettings.test.tsx
+++ b/apps/web/src/components/settings/RemoteToolSettings.test.tsx
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RemoteToolSettings from './RemoteToolSettings';
+
+const mocks = vi.hoisted(() => ({
+  saveUserPreferences: vi.fn(),
+  fetchWithAuth: vi.fn(),
+  can: vi.fn(),
+}));
+
+vi.mock('@/lib/userPreferences', () => ({ saveUserPreferences: mocks.saveUserPreferences }));
+vi.mock('@/lib/permissions', () => ({ usePermissions: () => ({ permissions: [], can: mocks.can }) }));
+vi.mock('../../stores/auth', () => ({ fetchWithAuth: mocks.fetchWithAuth }));
+
+const DIRECTORY = {
+  providers: [
+    { id: 'mesh', name: 'MeshCentral', enabled: true },
+    { id: 'rust', name: 'RustDesk', enabled: true },
+    { id: 'old', name: 'Retired Tool', enabled: false },
+  ],
+  defaultProviderId: 'mesh',
+};
+
+function respondWith(body: unknown, ok = true) {
+  mocks.fetchWithAuth.mockResolvedValue({ ok, status: ok ? 200 : 500, json: async () => body });
+}
+
+beforeEach(() => {
+  mocks.saveUserPreferences.mockReset().mockResolvedValue({ remoteAccessProviderId: 'rust' });
+  mocks.fetchWithAuth.mockReset();
+  mocks.can.mockReset().mockReturnValue(true);
+});
+
+describe('RemoteToolSettings (#3389)', () => {
+  it('renders nothing for a user without remote:access, and never calls the endpoint', async () => {
+    mocks.can.mockReturnValue(false);
+    respondWith(DIRECTORY);
+
+    const { container } = render(<RemoteToolSettings preferences={{}} />);
+
+    expect(container).toBeEmptyDOMElement();
+    // the capability gate must short-circuit the fetch, not just hide the output
+    expect(mocks.fetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('offers only enabled providers plus the tenant default', async () => {
+    respondWith(DIRECTORY);
+    render(<RemoteToolSettings preferences={{}} />);
+
+    const select = await screen.findByLabelText('Preferred remote tool');
+    const options = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+
+    expect(options).toEqual([
+      'Use organization default (MeshCentral)',
+      'MeshCentral',
+      'RustDesk',
+    ]);
+    expect(options.join()).not.toContain('Retired Tool');
+  });
+
+  it('saves the chosen provider id', async () => {
+    respondWith(DIRECTORY);
+    render(<RemoteToolSettings preferences={{}} />);
+
+    const select = await screen.findByLabelText('Preferred remote tool');
+    await userEvent.selectOptions(select, 'rust');
+
+    await waitFor(() => expect(mocks.saveUserPreferences).toHaveBeenCalledTimes(1));
+    expect(mocks.saveUserPreferences.mock.calls[0]?.[0]).toEqual({ remoteAccessProviderId: 'rust' });
+  });
+
+  it('clears the preference to undefined when the default is chosen', async () => {
+    respondWith(DIRECTORY);
+    render(<RemoteToolSettings preferences={{ remoteAccessProviderId: 'rust' }} />);
+
+    const select = await screen.findByLabelText('Preferred remote tool');
+    await userEvent.selectOptions(select, '');
+
+    await waitFor(() => expect(mocks.saveUserPreferences).toHaveBeenCalledTimes(1));
+    // undefined, not '' — the server treats absent as "follow tenant default"
+    expect(mocks.saveUserPreferences.mock.calls[0]?.[0]).toEqual({ remoteAccessProviderId: undefined });
+  });
+
+  it('explains a stale preference rather than silently dropping it', async () => {
+    respondWith(DIRECTORY);
+    render(<RemoteToolSettings preferences={{ remoteAccessProviderId: 'old' }} />);
+
+    expect(await screen.findByText(/no longer available/i)).toBeTruthy();
+  });
+
+  it('distinguishes a failed load from a tenant with no providers', async () => {
+    mocks.fetchWithAuth.mockRejectedValue(new Error('network'));
+    render(<RemoteToolSettings preferences={{}} />);
+
+    expect(await screen.findByText(/Couldn't load the available remote tools/i)).toBeTruthy();
+    expect(screen.queryByText(/No remote tools are configured/i)).toBeNull();
+  });
+
+  it('says so plainly when the tenant has configured none', async () => {
+    respondWith({ providers: [], defaultProviderId: null });
+    render(<RemoteToolSettings preferences={{}} />);
+
+    expect(await screen.findByText(/No remote tools are configured/i)).toBeTruthy();
+  });
+
+  it('reverts the selection when saving fails', async () => {
+    respondWith(DIRECTORY);
+    mocks.saveUserPreferences.mockRejectedValue(new Error('nope'));
+    render(<RemoteToolSettings preferences={{ remoteAccessProviderId: 'mesh' }} />);
+
+    const select = await screen.findByLabelText('Preferred remote tool') as HTMLSelectElement;
+    await userEvent.selectOptions(select, 'rust');
+
+    await waitFor(() => expect(select.value).toBe('mesh'));
+  });
+});

--- a/apps/web/src/components/settings/RemoteToolSettings.tsx
+++ b/apps/web/src/components/settings/RemoteToolSettings.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from 'react';
+import { MonitorSmartphone } from 'lucide-react';
+import { PERMISSION_GRANTS } from '@breeze/shared';
+import type { UserPreferences } from '../../stores/auth';
+import { fetchWithAuth } from '../../stores/auth';
+import { usePermissions } from '@/lib/permissions';
+import { saveUserPreferences } from '@/lib/userPreferences';
+
+/** Mirrors GET /remote/providers — id/name/enabled only, never a template or password. */
+type ProviderSummary = { id: string; name: string; enabled: boolean };
+type ProviderDirectory = { providers: ProviderSummary[]; defaultProviderId: string | null };
+
+type RemoteToolSettingsProps = {
+  preferences?: UserPreferences | null;
+  onSaved?: (preferences: UserPreferences) => void;
+};
+
+/** Sentinel for "no personal preference — follow the tenant default". */
+const USE_DEFAULT = '';
+
+export default function RemoteToolSettings({ preferences, onSaved }: RemoteToolSettingsProps) {
+  const { can } = usePermissions();
+  // The chooser is gated on the SAME permission GET /remote/providers requires,
+  // so a technician who cannot launch a session is never shown a preference
+  // that could not take effect. Deliberately NOT keyed off an empty provider
+  // list: "you may not use remote access" and "your tenant has configured no
+  // providers" are different states and get different UI below.
+  const mayUseRemoteAccess = can(PERMISSION_GRANTS.REMOTE_ACCESS.resource, PERMISSION_GRANTS.REMOTE_ACCESS.action);
+
+  const [directory, setDirectory] = useState<ProviderDirectory | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [selected, setSelected] = useState<string>(preferences?.remoteAccessProviderId ?? USE_DEFAULT);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [success, setSuccess] = useState<string | undefined>();
+
+  useEffect(() => {
+    setSelected(preferences?.remoteAccessProviderId ?? USE_DEFAULT);
+  }, [preferences?.remoteAccessProviderId]);
+
+  useEffect(() => {
+    if (!mayUseRemoteAccess) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetchWithAuth('/remote/providers');
+        if (!res.ok) throw new Error(String(res.status));
+        const body = (await res.json()) as ProviderDirectory;
+        if (!cancelled) setDirectory(body);
+      } catch {
+        // A failed load must not silently render as "no tools configured" —
+        // that reads as a tenant misconfiguration rather than a fetch problem.
+        if (!cancelled) setLoadFailed(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [mayUseRemoteAccess]);
+
+  const handleChange = useCallback(async (value: string) => {
+    const previous = selected;
+    setSelected(value);
+    setError(undefined);
+    setSuccess(undefined);
+    try {
+      setIsSaving(true);
+      // Empty string clears the preference back to the tenant default.
+      const saved = await saveUserPreferences(
+        { remoteAccessProviderId: value === USE_DEFAULT ? undefined : value },
+        'Failed to save your preferred remote tool',
+      );
+      onSaved?.(saved);
+      setSuccess('Preferred remote tool saved.');
+      setTimeout(() => setSuccess(undefined), 4000);
+    } catch (err) {
+      setSelected(previous);
+      setError(err instanceof Error ? err.message : 'Failed to save your preferred remote tool');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [onSaved, selected]);
+
+  if (!mayUseRemoteAccess) return null;
+
+  const enabled = (directory?.providers ?? []).filter((p) => p.enabled);
+  const defaultName = directory?.defaultProviderId
+    ? directory.providers.find((p) => p.id === directory.defaultProviderId)?.name
+    : undefined;
+
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-xs" data-testid="remote-tool-settings">
+      <div className="flex items-center gap-2">
+        <MonitorSmartphone className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+        <h2 className="text-lg font-semibold">Preferred remote tool</h2>
+      </div>
+      <p className="text-sm text-muted-foreground mt-1 mb-4">
+        Which remote-access tool Connect uses for you. Only affects your own sessions.
+      </p>
+
+      {loadFailed ? (
+        <p className="text-sm text-destructive">
+          Couldn&apos;t load the available remote tools. Reload the page to try again.
+        </p>
+      ) : !directory ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : enabled.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No remote tools are configured for your organization yet.
+        </p>
+      ) : (
+        <>
+          <label htmlFor="remote-tool-preference" className="sr-only">Preferred remote tool</label>
+          <select
+            id="remote-tool-preference"
+            className="rounded-md border bg-background px-3 py-1.5 text-sm"
+            value={selected}
+            disabled={isSaving}
+            onChange={(e) => void handleChange(e.target.value)}
+          >
+            <option value={USE_DEFAULT}>
+              {defaultName ? `Use organization default (${defaultName})` : 'Use organization default'}
+            </option>
+            {enabled.map((p) => (
+              <option key={p.id} value={p.id}>{p.name}</option>
+            ))}
+          </select>
+          {/* A preference naming a provider that is no longer enabled would
+              otherwise vanish from the select with no explanation. */}
+          {selected !== USE_DEFAULT && !enabled.some((p) => p.id === selected) && (
+            <p className="text-sm text-muted-foreground mt-2">
+              Your saved tool is no longer available, so sessions use the organization default.
+            </p>
+          )}
+        </>
+      )}
+
+      {success && (
+        <div className="mt-3 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-600">
+          {success}
+        </div>
+      )}
+      {error && (
+        <div className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/ThemingSettings.tsx
+++ b/apps/web/src/components/settings/ThemingSettings.tsx
@@ -61,7 +61,15 @@ const localeOptions = [
   { value: 'it-IT' as const, labelKey: 'language.itITLabel', defaultLabel: 'Italiano (Italia)', descriptionKey: 'language.itITDescription', defaultDescription: 'Italian (Italy)' },
 ];
 
-function resolveAppearance(preferences?: UserPreferences | null): Required<UserPreferences> {
+/**
+ * The appearance subset of UserPreferences. Was `Required<UserPreferences>`,
+ * which silently meant "every preference" and broke as soon as a non-appearance
+ * preference was added (#3389's remoteAccessProviderId). Naming the keys keeps
+ * this type honest about what the appearance controls own.
+ */
+type AppearancePreferences = Required<Pick<UserPreferences, 'theme' | 'density' | 'font' | 'timeFormat' | 'locale'>>;
+
+function resolveAppearance(preferences?: UserPreferences | null): AppearancePreferences {
   return {
     theme: normalizeTheme(preferences?.theme) ?? readThemePreference(),
     density: normalizeDensity(preferences?.density) ?? readDensity(),
@@ -117,9 +125,9 @@ export default function ThemingSettings({ preferences, onSaved }: ThemingSetting
   }, []);
 
   const handleAppearanceChange = async (
-    patch: Partial<Pick<Required<UserPreferences>, 'theme' | 'density' | 'font' | 'timeFormat' | 'locale'>>
+    patch: Partial<AppearancePreferences>
   ) => {
-    const next: Required<UserPreferences> = {
+    const next: AppearancePreferences = {
       theme: patch.theme ?? themePreference,
       density: patch.density ?? densityPreference,
       font: patch.font ?? fontPreference,

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -26,6 +26,14 @@ export interface UserPreferences {
   font?: FontPreference;
   timeFormat?: TimeFormatPreference;
   locale?: LocalePreference;
+  /**
+   * #3389: the technician's preferred remote-access provider. An ID only — it
+   * SELECTS from the tenant's configured providers and never supplies a URL
+   * template, password or custom-field key, which is what keeps the launcher's
+   * post-substitution scheme guard meaningful. An unknown or since-disabled id
+   * falls back to the tenant default server-side rather than failing a launch.
+   */
+  remoteAccessProviderId?: string;
 }
 
 /** A single permission grant ({ resource, action }), mirroring the API. */


### PR DESCRIPTION
Closes #3389. The profile UI you assigned on #3391, plus the slim provider endpoint it needs.

> **CI on this PR is red for reasons unrelated to the diff.** It branched from `main`, which currently cannot `pnpm install --frozen-lockfile` (duplicated `hono` key — fix is up as **#3436**, 6 deleted lines, green). Every job dies at install. It goes green once #3436 lands. Full gate results below are from a local run against a deduped lockfile; the lockfile is **not** part of this diff.

## 1. `GET /remote/providers`

Returns `{ providers: [{ id, name, enabled }], defaultProviderId }` and nothing else.

**The projection is the point.** `RemoteAccessProvider` also carries `urlTemplate`, `customFieldKey` and `password`, which live in the encrypted `partners.settings` blob. Today the only way to enumerate providers is `GET /orgs/partners/me`, which is partner-scope gated *and* returns that whole blob — the exposure path #3404 exists to avoid. The mapping is field-by-field rather than a spread, so a credential-bearing field added to the type later cannot silently start shipping.

**It lives in `routes/remote/`** because that router already applies exactly the right gate globally: `authMiddleware` + `remote:access` + `requireMfa`, with no partner-scope requirement. Same permission that guards issuing a launch URL — if you can launch, you can list. Added directly to `index.ts` rather than as a sub-router to stay clear of the `use('*')` mount-leak shape.

**It escalates past RLS, deliberately and narrowly.** `partners`' SELECT policy is `breeze_has_partner_access(id)`, and `computeAccessiblePartnerIds` returns `[]` for `scope === 'organization'` — so the technician who needs this cannot read the partner row under their own context. The read uses `runOutsideDbContext(() => withSystemDbAccessContext(...))`; a *bare* `withSystemDbAccessContext` would not work, since it early-returns inside a request and silently keeps the caller's scope. Escalating is only defensible because every caller projects through `toProviderSummaries` first, and the module comment says so.

That same RLS gap is why I filed **#3419** against the launcher's own partner read. `readPartnerRemoteAccessSettings` here is written to be the shared helper that fix can adopt, so the escalated read exists once rather than twice — but I have not touched the launcher, since you had not said whether you wanted that fix.

## 2. The profile control

`RemoteToolSettings`, mounted next to `ThemingSettings` in `ProfilePage`, writing `users.preferences.remoteAccessProviderId` through the existing `saveUserPreferences` → `PATCH /users/me` path. No migration, no new column.

Offers only **enabled** providers plus an explicit "Use organization default (*name*)". Choosing the default writes `undefined`, not `''`, so the server sees an absent preference.

**One deviation from your instruction, flagged rather than buried.** You said hide the control for non-partner sessions. That was premised on the only endpoint being partner-scope gated — this PR removes that constraint, so hiding it there would now hide it from exactly the org-scoped technicians it is for. Instead it gates on the **`remote:access` permission**, which is what the endpoint itself requires: a user who cannot launch a session is never offered a preference that could not take effect, and the fetch is skipped entirely rather than merely hidden.

Your underlying point — don't ship an empty select — is kept, and sharpened into three distinct states rather than one:

| State | UI |
|---|---|
| no `remote:access` | renders nothing, no request made |
| tenant has none configured | "No remote tools are configured for your organization yet." |
| request failed | "Couldn't load the available remote tools." |

Collapsing the last two into an empty list would tell a technician their org is misconfigured when the network hiccuped. A saved preference naming a since-disabled provider also gets an explicit line rather than vanishing from the select.

## 3. One adjacent edit, and why it was unavoidable

`ThemingSettings` typed its appearance state as `Required<UserPreferences>`, which silently meant "every preference" and stopped compiling the moment a non-appearance preference existed. Narrowed to a named `AppearancePreferences = Required<Pick<UserPreferences, 'theme' | 'density' | 'font' | 'timeFormat' | 'locale'>>` — the same five keys the file already enumerated on the next line. Behaviour identical; the type now says what it meant.

## Verification

**Two control runs**, one per security-relevant property:

- Replace the API projection with a spread → the two leak tests fail (exact key set, and a by-value check that the serialized response contains no password/template/field key).
- Remove the UI capability gate → the no-permission test fails, including its assertion that the endpoint is never called.

- **API:** `tsc --noEmit` exit 0; `vitest run` **1326 files / 21600 passed**; Trivy `secret,misconfig` HIGH/CRITICAL on `apps/api/src` clean.
- **Web:** `tsc --noEmit` exit 0; `vitest run` **554 files / 5322 passed** (includes `ThemingSettings`, so the type change above is covered).
- No schema, migration or dependency changes. 8 files, +515/−5.

## Not in scope

`#3402`'s availability check and `#3404`'s org-restriction work both want this endpoint; neither is touched here. `#3401` dangling defaults is yours in #3406 — this only declines to *report* a dangling default rather than fixing how one is created.
