### PR TITLE
fix(web,api): four defects found by the UI QA sweep

### DIFF
--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1037,6 +1037,67 @@ describe('org routes', () => {
       expect(res.status).toBe(200);
       expect(capturedUpdateData?.aiForOfficeEnabled).toBeUndefined();
     });
+
+    describe('contact.website scheme allowlist', () => {
+      // The website is rendered as a link in branded PDFs, invoices and email
+      // footers, so an unvalidated scheme here is stored XSS that fires for
+      // whoever opens the document. It used to accept any string and persist
+      // the payload verbatim on a 200.
+      function seedPartner() {
+        vi.mocked(db.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+              limit: vi.fn().mockResolvedValue([{ id: 'partner-123', name: 'P', settings: {} }])
+            })
+          })
+        } as any);
+      }
+
+      async function patchWebsite(website: string) {
+        return app.request('/orgs/partners/me', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ settings: { contact: { website } } })
+        });
+      }
+
+      it.each([
+        ['javascript:alert(1)'],
+        ['data:text/html,<script>alert(1)</script>'],
+        ['vbscript:msgbox(1)'],
+        ['acme.example.com'], // schemeless — not a full URL, cannot be linkified safely
+      ])('rejects %s with 400 and never writes it', async (website) => {
+        setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+        seedPartner();
+        const setSpy = vi.fn();
+        vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+        const res = await patchWebsite(website);
+
+        expect(res.status).toBe(400);
+        expect(setSpy).not.toHaveBeenCalled();
+      });
+
+      it.each([['https://acme.example.com'], ['http://acme.example.com/path'], ['']])(
+        'accepts %s',
+        async (website) => {
+          setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+          seedPartner();
+          vi.mocked(db.update).mockReturnValue({
+            set: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([{ id: 'partner-123', name: 'P', settings: {} }])
+              })
+            })
+          } as any);
+
+          const res = await patchWebsite(website);
+
+          expect(res.status).toBe(200);
+        }
+      );
+    });
   });
 
   describe('PATCH /orgs/partners/me — ticketing.inbound merge safety', () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -479,7 +479,32 @@ const partnerSettingsSchema = z.object({
     name: z.string().optional(),
     email: z.string().email().optional().or(z.literal('')),
     phone: z.string().optional(),
-    website: z.string().optional()
+    // This value is rendered as a link in branded PDFs, invoices and email
+    // footers, so an unvalidated `javascript:`/`data:text/html,...` here is
+    // stored XSS that fires for whoever opens the document — including the
+    // partner's own customers. It previously accepted any string and persisted
+    // the payload verbatim on a 200, while the launcher template field a few
+    // hundred lines below in this same file already gated on a scheme
+    // allowlist. Restricted to http/https only: unlike a remote-access
+    // launcher, a company website has no legitimate custom-scheme use.
+    website: z
+      .string()
+      .max(2000)
+      .refine(
+        (v) => {
+          if (v === '') return true;
+          let parsed: URL;
+          try {
+            parsed = new URL(v);
+          } catch {
+            return false;
+          }
+          return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+        },
+        'Website must be a full http:// or https:// URL',
+      )
+      .optional()
+      .or(z.literal(''))
   }).optional(),
   address: z.object({
     street1: z.string().max(255).optional(),

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -11,6 +11,10 @@ vi.mock('drizzle-orm', async (importOriginal) => {
   return {
     ...actual,
     inArray: vi.fn((...args: Parameters<typeof actual.inArray>) => actual.inArray(...args)),
+    // Spied for the scripts dual-axis assertions: the partner-wide branch is
+    // the only thing in this route that pairs isNull(orgId) with eq(partnerId).
+    eq: vi.fn((...args: Parameters<typeof actual.eq>) => actual.eq(...args)),
+    isNull: vi.fn((...args: Parameters<typeof actual.isNull>) => actual.isNull(...args)),
   };
 });
 
@@ -35,6 +39,7 @@ vi.mock('../db/schema', () => ({
   scripts: {
     id: 'scripts.id',
     orgId: 'scripts.orgId',
+    partnerId: 'scripts.partnerId',
     name: 'scripts.name',
     description: 'scripts.description'
   },
@@ -48,9 +53,13 @@ vi.mock('../db/schema', () => ({
   }
 }));
 
+const authState = vi.hoisted(() => ({
+  current: null as Record<string, unknown> | null,
+}));
+
 vi.mock('../middleware/auth', () => ({
   authMiddleware: vi.fn((c: any, next: any) => {
-    c.set('auth', {
+    c.set('auth', authState.current ?? {
       user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
       scope: 'organization',
       orgId: 'org-1',
@@ -88,7 +97,7 @@ vi.mock('../services/permissions', () => ({
 }));
 
 import { db } from '../db';
-import { inArray } from 'drizzle-orm';
+import { eq, inArray, isNull } from 'drizzle-orm';
 import { getUserPermissions } from '../services/permissions';
 
 describe('search routes', () => {
@@ -96,6 +105,7 @@ describe('search routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    authState.current = null;
     app = new Hono();
     app.route('/search', searchRoutes);
   });
@@ -397,4 +407,65 @@ describe('search routes', () => {
       expect(body.results.some((r: { type?: string }) => r.type === 'devices')).toBe(true);
     });
   });
+
+  describe('scripts dual-axis visibility', () => {
+    // Scripts are org_id XOR partner_id. A strict org condition hides every
+    // partner-wide script from global search, so a tech could see a script on
+    // /scripts and get zero Cmd+K results for its exact name.
+    function stubThreeSelects() {
+      const empty = () => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      });
+      vi.mocked(db.select)
+        .mockReturnValueOnce(empty() as never)
+        .mockReturnValueOnce(empty() as never)
+        .mockReturnValueOnce(empty() as never);
+    }
+
+    it('widens the scripts filter to partner-wide rows for a partner-scoped caller', async () => {
+      authState.current = {
+        user: { id: 'user-1', email: 'p@example.com', name: 'Partner User' },
+        scope: 'partner',
+        orgId: null,
+        partnerId: 'partner-9',
+        accessibleOrgIds: ['org-1'],
+        canAccessOrg: () => true,
+        orgCondition: (col: unknown) => inArray(col as never, ['org-1'] as never),
+      };
+      stubThreeSelects();
+
+      const res = await app.request('/search?q=cleanup');
+
+      expect(res.status).toBe(200);
+      expect(vi.mocked(isNull)).toHaveBeenCalledWith('scripts.orgId');
+      expect(vi.mocked(eq)).toHaveBeenCalledWith('scripts.partnerId', 'partner-9');
+    });
+
+    it('does NOT widen for an org-scoped caller, even though it carries a partnerId', async () => {
+      // RLS is stricter than the app layer here: an org token never passes
+      // breeze_has_partner_access, so widening would ask for rows the database
+      // refuses to return and the two layers would disagree.
+      authState.current = {
+        user: { id: 'user-1', email: 'o@example.com', name: 'Org User' },
+        scope: 'organization',
+        orgId: 'org-1',
+        partnerId: 'partner-9',
+        accessibleOrgIds: ['org-1'],
+        canAccessOrg: () => true,
+        orgCondition: (col: unknown) => inArray(col as never, ['org-1'] as never),
+      };
+      stubThreeSelects();
+
+      const res = await app.request('/search?q=cleanup');
+
+      expect(res.status).toBe(200);
+      expect(vi.mocked(eq)).not.toHaveBeenCalledWith('scripts.partnerId', expect.anything());
+    });
+  });
+
 });

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -79,6 +79,22 @@ searchRoutes.get('/', zValidator('query', searchQuerySchema), async (c) => {
     return auth.orgCondition(column);
   };
 
+  // Scripts are dual-axis (org_id XOR partner_id), so a strict org condition
+  // hides every partner-wide script from global search — a tech could see a
+  // script on /scripts and get zero results for its exact name in Cmd+K.
+  //
+  // Gated on `scope === 'partner'` deliberately: an org-scoped token carries a
+  // partnerId but never passes `breeze_has_partner_access`, so widening the
+  // app-layer condition for it would ask for rows RLS refuses to return —
+  // RLS is stricter than the app layer here, and the two must not disagree.
+  const scriptsOrgCondition = (() => {
+    const orgOwned = orgConditionFor(scripts.orgId);
+    // No org condition at all means a system-scoped caller: already unfiltered.
+    if (!orgOwned) return undefined;
+    if (auth?.scope !== 'partner' || !auth.partnerId) return orgOwned;
+    return or(orgOwned, and(isNull(scripts.orgId), eq(scripts.partnerId, auth.partnerId)));
+  })();
+
   // Site-axis narrowing (app-layer only; RLS does NOT enforce site isolation).
   // mirrors core.ts:~424-435 / reports/data.ts:~67-72.
   const allowedSiteIds = (userPerms as UserPermissions | null)?.allowedSiteIds;
@@ -138,7 +154,7 @@ searchRoutes.get('/', zValidator('query', searchQuerySchema), async (c) => {
             description: scripts.description
           })
           .from(scripts)
-          .where(orgConditionFor(scripts.orgId) ? and(orgConditionFor(scripts.orgId) as never, scriptQuery as never) : scriptQuery)
+          .where(scriptsOrgCondition ? and(scriptsOrgCondition as never, scriptQuery as never) : scriptQuery)
           .limit(perCategoryLimit)
       : Promise.resolve([]),
     canReadAlerts

--- a/apps/web/src/components/alerts/NotificationChannelForm.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelForm.tsx
@@ -30,19 +30,6 @@ const pagerdutyConfigSchema = z.object({
   severity: z.enum(['critical', 'error', 'warning', 'info']).optional()
 });
 
-const webhookConfigSchema = z.object({
-  url: z.string().url('Invalid URL').min(1, 'URL is required'),
-  method: z.enum(['POST', 'PUT', 'PATCH']).optional(),
-  headers: z.array(z.object({
-    key: z.string().min(1, 'Header key is required'),
-    value: z.string()
-  })).optional(),
-  authType: z.enum(['none', 'basic', 'bearer']).optional(),
-  authUsername: z.string().optional(),
-  authPassword: z.string().optional(),
-  authToken: z.string().optional()
-});
-
 const smsConfigSchema = z.object({
   phoneNumbers: z.array(z.string().min(1, 'Phone number is required')).min(1, 'At least one phone number is required')
 });

--- a/apps/web/src/components/alerts/NotificationChannelsPage.tsx
+++ b/apps/web/src/components/alerts/NotificationChannelsPage.tsx
@@ -260,7 +260,14 @@ export default function NotificationChannelsPage() {
         config = {
           url: values.webhookUrl,
           method: values.webhookMethod,
-          headers: values.webhookHeaders?.filter(h => h.key) ?? [],
+          // The form models headers as a repeatable [{key,value}] list, but the
+          // API requires a Record<string,string> and rejects anything else with
+          // "Headers must be an object" — so every webhook channel save 400'd.
+          // Convert at the boundary rather than reshaping the field array,
+          // which is the right UI model for add/remove rows.
+          headers: Object.fromEntries(
+            (values.webhookHeaders ?? []).filter(h => h.key).map(h => [h.key, h.value])
+          ),
           authType: values.webhookAuthType,
           authUsername: values.webhookAuthUsername,
           authPassword: values.webhookAuthPassword,
@@ -347,9 +354,17 @@ export default function NotificationChannelsPage() {
       case 'webhook':
         base.webhookUrl = config.url as string;
         base.webhookMethod = config.method as 'POST' | 'PUT' | 'PATCH';
+        // Mirror of the outbound conversion. The array branch is kept because
+        // any channel saved before the fix — or hand-written via the API —
+        // may still carry the old shape.
         base.webhookHeaders = Array.isArray(config.headers)
           ? (config.headers as { key: string; value: string }[])
-          : [];
+          : config.headers && typeof config.headers === 'object'
+            ? Object.entries(config.headers as Record<string, string>).map(([key, value]) => ({
+                key,
+                value: String(value),
+              }))
+            : [];
         base.webhookAuthType = config.authType as 'none' | 'basic' | 'bearer';
         base.webhookAuthUsername = config.authUsername as string;
         base.webhookAuthPassword = config.authPassword as string;

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -59,6 +59,15 @@ export default function ScriptForm({
   isSystemScript = false,
 }: ScriptFormProps) {
   const { t } = useTranslation('scripts');
+  // Resolved after mount, never during render. Reading `navigator` inline made
+  // SSR emit "Ctrl+S" while the client's first render produced "⌘S" on macOS,
+  // which React reports as a hydration mismatch on every Mac visit. Starting
+  // from the server's value and correcting in an effect keeps the first client
+  // render byte-identical to the SSR output.
+  const [saveShortcut, setSaveShortcut] = useState('Ctrl+S');
+  useEffect(() => {
+    if (navigator.platform?.includes('Mac')) setSaveShortcut('⌘S');
+  }, []);
   const [editorMounted, setEditorMounted] = useState(false);
   const editorInstanceRef = useRef<Parameters<NonNullable<EditorProps['onMount']>>[0] | null>(null);
   const [paramsOpen, setParamsOpen] = useState(false);
@@ -726,9 +735,7 @@ export default function ScriptForm({
       {/* Form Actions */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="hidden text-xs text-muted-foreground sm:block">
-          {t('scriptForm.keyboardSave', {
-            shortcut: typeof navigator !== 'undefined' && navigator.platform?.includes('Mac') ? '⌘S' : 'Ctrl+S'
-          })}
+          {t('scriptForm.keyboardSave', { shortcut: saveShortcut })}
         </p>
         <div className="flex flex-col gap-3 sm:flex-row">
           <button


### PR DESCRIPTION
Found by a Playwright UI QA sweep of the routes changed since v0.104.0. All four are on `main`, independent of each other, and none is caused by the release diff.

## 1. Cmd+K search omits every partner-wide script

`GET /api/v1/search` filtered `scripts` with a strict org condition. Scripts are dual-axis (`org_id` XOR `partner_id`), so a tech could see a script on `/scripts` and get **zero results** searching its exact name.

Widened to `orgCondition OR (org_id IS NULL AND partner_id = …)`, gated on `scope === 'partner'`. That gate is load-bearing: an org-scoped token carries a `partnerId` but never passes `breeze_has_partner_access`, so widening for it would request rows RLS refuses and put the app layer and the database in disagreement.

Swept the other searched tables — `devices` is org-only, and the route queries alert *instances*, not the dual-axis `alert_templates` — so `scripts` was the only gap.

## 2. Partner `contact.website` accepted `javascript:` (stored XSS)

`PATCH /orgs/partners/me` returned **200** and persisted `javascript:alert(1)` and `data:text/html,…` verbatim. The field was `z.string().optional()` with no validation.

It matters because that value is rendered as a link in **branded PDFs, invoices, and email footers** — so the payload fires for the partner's own customers, not just internal users. A launcher-template field a few hundred lines above in the same file already gates on a scheme allowlist, so this was an isolated omission rather than a systemic one.

Restricted to `http`/`https`. Unlike a remote-access launcher, a company website has no legitimate custom-scheme use.

## 3. Webhook notification channels could not be created at all

Every save 400'd with `"Headers must be an object"`. The form models headers as a repeatable `[{key,value}]` list — the right UI model for add/remove rows — but the API requires `Record<string,string>`.

Converted at the transform boundary in both directions. The inbound array branch is kept, since channels saved before this fix may still carry the old shape. Also deleted `webhookConfigSchema` — dead code that asserted the wrong wire shape and would have re-taught the same mistake to the next reader.

## 4. Hydration mismatch on `/scripts/new`

The save-shortcut label read `navigator.platform` during render, so SSR emitted `Ctrl+S` while the client's first render produced `⌘S`, throwing a React hydration error on every Mac visit. Resolved in an effect so the first client render matches the SSR output.

## Testing

- 7 new cases for the website allowlist (4 rejected including a schemeless value, 3 accepted).
- 2 new cases for search: partner scope widens, org scope does **not**.
- Both new guards were confirmed to **fail** against the pre-fix code, not just pass after it.
- 223 API and 234 web tests pass across the affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)