### PR TITLE
feat(ee): merge Workspace into the monorepo as a built-in extension

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -824,6 +824,21 @@ MANAGED_SOFTWARE_POLICY_MODE=compat
 # BILLING_SERVICE_API_KEY=
 
 # --------------------------------------------
+# Built-in extensions (optional, OFF)
+# --------------------------------------------
+# First-party extensions ship inside the API image but are NOT loaded unless the
+# deployment switches them on, so a deployment that does not want one pays
+# nothing for it — no migrations, no schema, no infrastructure requirements.
+# Each flag is strict: only the exact string "true" enables it.
+#
+# Workspace (file/email indexing, content search). Enabling it requires a
+# PostgreSQL image with the pgvector extension available — its migrations run
+# `CREATE EXTENSION vector` on API boot, and a stock postgres:16-alpine will
+# fail the boot with `extension "vector" is not available`. The
+# POSTGRES_IMAGE_REF default below already includes it.
+# BREEZE_WORKSPACE_ENABLED=true
+
+# --------------------------------------------
 # Docker Deployment
 # --------------------------------------------
 # Stable Compose project name for container labels and Docker named volumes.
@@ -852,10 +867,11 @@ BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:${BREEZE_VERSION}
 # (e.g. `caddy@sha256:<digest>` from `docker buildx imagetools inspect caddy:2-alpine`).
 CADDY_IMAGE_REF=caddy:2-alpine
 # pgvector/pgvector is the official Postgres image + the vector extension
-# pre-installed. Required as of the Workspace built-in, whose migrations
-# (ee/workspace/migrations/*.sql) run `CREATE EXTENSION vector` on API boot
-# for content embeddings. Same Postgres major version as stock, just with
-# the extension baked in.
+# pre-installed. Required only when BREEZE_WORKSPACE_ENABLED=true (above),
+# whose migrations (ee/workspace/migrations/*.sql) run `CREATE EXTENSION
+# vector` on API boot for content embeddings. Same Postgres major version as
+# stock, just with the extension baked in — kept as the default so enabling
+# Workspace later needs no database swap.
 POSTGRES_IMAGE_REF=pgvector/pgvector:pg16
 REDIS_IMAGE_REF=redis:7-alpine
 COTURN_IMAGE_REF=coturn/coturn:latest

--- a/.env.example
+++ b/.env.example
@@ -872,6 +872,18 @@ CADDY_IMAGE_REF=caddy:2-alpine
 # vector` on API boot for content embeddings. Same Postgres major version as
 # stock, just with the extension baked in — kept as the default so enabling
 # Workspace later needs no database swap.
+#
+# UPGRADE CAVEAT — do NOT swap this image over an EXISTING data volume.
+# postgres:16-alpine is built against musl; pgvector/pgvector:pg16 is built
+# against glibc. The two disagree about collation versions, so starting one over
+# a data directory initialized by the other logs a collation version mismatch
+# and leaves every text index (and every unique constraint on a text column)
+# potentially inconsistent until it is rebuilt — which can silently return wrong
+# rows, not just fail loudly. If you are already running and want to switch,
+# either dump and restore into a freshly-initialized volume, or run
+# `REINDEX DATABASE <dbname>;` after the first start on the new image (and
+# `ALTER DATABASE <dbname> REFRESH COLLATION VERSION;`). If you do not need
+# Workspace, the simplest answer is to keep the image you already have.
 POSTGRES_IMAGE_REF=pgvector/pgvector:pg16
 REDIS_IMAGE_REF=redis:7-alpine
 COTURN_IMAGE_REF=coturn/coturn:latest

--- a/.env.example
+++ b/.env.example
@@ -851,7 +851,12 @@ BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:${BREEZE_VERSION}
 # Breeze is tested against. Override to digest-pinned refs in production
 # (e.g. `caddy@sha256:<digest>` from `docker buildx imagetools inspect caddy:2-alpine`).
 CADDY_IMAGE_REF=caddy:2-alpine
-POSTGRES_IMAGE_REF=postgres:16-alpine
+# pgvector/pgvector is the official Postgres image + the vector extension
+# pre-installed. Required as of the Workspace built-in, whose migrations
+# (ee/workspace/migrations/*.sql) run `CREATE EXTENSION vector` on API boot
+# for content embeddings. Same Postgres major version as stock, just with
+# the extension baked in.
+POSTGRES_IMAGE_REF=pgvector/pgvector:pg16
 REDIS_IMAGE_REF=redis:7-alpine
 COTURN_IMAGE_REF=coturn/coturn:latest
 #

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -41,10 +41,12 @@ jobs:
     timeout-minutes: 10
 
     services:
-      # pgvector-enabled image required: this job boots the API directly
-      # (`pnpm --filter=@breeze/api start`), which now runs the Workspace
-      # built-in's ee/workspace/migrations/*.sql (CREATE EXTENSION vector)
-      # on boot. Stock postgres:16-alpine lacks the extension.
+      # pgvector-enabled image, though this job no longer NEEDS it: built-in
+      # extensions load only when their enable flag is set, and this job
+      # leaves BREEZE_WORKSPACE_ENABLED unset, so ee/workspace/migrations/
+      # *.sql (CREATE EXTENSION vector) never runs. Kept to match the image
+      # .env.example ships, so the boot proved here is the one self-hosters
+      # run — a stock postgres:16-alpine would boot identically.
       postgres:
         image: pgvector/pgvector:pg16
         env:
@@ -87,13 +89,10 @@ jobs:
       - name: Build API
         run: pnpm --filter=@breeze/api build
 
-      - name: Build workspace web bundle
-        # The built-in loader fails production boot hard when
-        # ee/workspace/dist/web is missing (a real from-source deploy must
-        # build it — see docker/Dockerfile.api's builder stage, which runs
-        # this same command right after the API build). This job boots with
-        # NODE_ENV=production from a plain checkout, so it must build it too.
-        run: pnpm --filter @breeze/ext-workspace build:web
+      # NOTE: no `ee/workspace` web build here, deliberately — see the same
+      # note in ci-smoke-binary-source-local.yml. This job leaves
+      # BREEZE_WORKSPACE_ENABLED unset, so the built-in never loads and its
+      # dist/web is never required.
 
       - name: Boot API in BINARY_SOURCE=github mode
         env:

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -87,6 +87,14 @@ jobs:
       - name: Build API
         run: pnpm --filter=@breeze/api build
 
+      - name: Build workspace web bundle
+        # The built-in loader fails production boot hard when
+        # ee/workspace/dist/web is missing (a real from-source deploy must
+        # build it — see docker/Dockerfile.api's builder stage, which runs
+        # this same command right after the API build). This job boots with
+        # NODE_ENV=production from a plain checkout, so it must build it too.
+        run: pnpm --filter @breeze/ext-workspace build:web
+
       - name: Boot API in BINARY_SOURCE=github mode
         env:
           # Authenticate binarySync's github API call so we don't hit the

--- a/.github/workflows/ci-smoke-binary-source-github.yml
+++ b/.github/workflows/ci-smoke-binary-source-github.yml
@@ -41,8 +41,12 @@ jobs:
     timeout-minutes: 10
 
     services:
+      # pgvector-enabled image required: this job boots the API directly
+      # (`pnpm --filter=@breeze/api start`), which now runs the Workspace
+      # built-in's ee/workspace/migrations/*.sql (CREATE EXTENSION vector)
+      # on boot. Stock postgres:16-alpine lacks the extension.
       postgres:
-        image: postgres:16-alpine
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: breeze
           POSTGRES_PASSWORD: breeze

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -31,10 +31,12 @@ jobs:
     timeout-minutes: 10
 
     services:
-      # pgvector-enabled image required: this job boots the API directly
-      # (`pnpm --filter=@breeze/api start`), which now runs the Workspace
-      # built-in's ee/workspace/migrations/*.sql (CREATE EXTENSION vector)
-      # on boot. Stock postgres:16-alpine lacks the extension.
+      # pgvector-enabled image, though this job no longer NEEDS it: built-in
+      # extensions load only when their enable flag is set, and this job
+      # leaves BREEZE_WORKSPACE_ENABLED unset, so ee/workspace/migrations/
+      # *.sql (CREATE EXTENSION vector) never runs. Kept to match the image
+      # .env.example ships, so the boot proved here is the one self-hosters
+      # run — a stock postgres:16-alpine would boot identically.
       postgres:
         image: pgvector/pgvector:pg16
         env:
@@ -77,13 +79,13 @@ jobs:
       - name: Build API
         run: pnpm --filter=@breeze/api build
 
-      - name: Build workspace web bundle
-        # The built-in loader fails production boot hard when
-        # ee/workspace/dist/web is missing (a real from-source deploy must
-        # build it — see docker/Dockerfile.api's builder stage, which runs
-        # this same command right after the API build). This job boots with
-        # NODE_ENV=production from a plain checkout, so it must build it too.
-        run: pnpm --filter @breeze/ext-workspace build:web
+      # NOTE: no `ee/workspace` web build here, deliberately. Built-in
+      # extensions are OFF unless the deployment sets their enable flag, and
+      # this job leaves BREEZE_WORKSPACE_ENABLED unset — so it proves the
+      # DEFAULT-OFF boot from a plain checkout: no built-in migrations, no
+      # dist/web requirement (which is what used to force a build:web step
+      # here), and no pgvector dependency. Flag-ON coverage lives in the
+      # integration shard-1 boot step in ci.yml.
 
       - name: Stage a fake local agent binary
         env:

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -77,6 +77,14 @@ jobs:
       - name: Build API
         run: pnpm --filter=@breeze/api build
 
+      - name: Build workspace web bundle
+        # The built-in loader fails production boot hard when
+        # ee/workspace/dist/web is missing (a real from-source deploy must
+        # build it — see docker/Dockerfile.api's builder stage, which runs
+        # this same command right after the API build). This job boots with
+        # NODE_ENV=production from a plain checkout, so it must build it too.
+        run: pnpm --filter @breeze/ext-workspace build:web
+
       - name: Stage a fake local agent binary
         env:
           WORKSPACE: ${{ github.workspace }}

--- a/.github/workflows/ci-smoke-binary-source-local.yml
+++ b/.github/workflows/ci-smoke-binary-source-local.yml
@@ -31,8 +31,12 @@ jobs:
     timeout-minutes: 10
 
     services:
+      # pgvector-enabled image required: this job boots the API directly
+      # (`pnpm --filter=@breeze/api start`), which now runs the Workspace
+      # built-in's ee/workspace/migrations/*.sql (CREATE EXTENSION vector)
+      # on boot. Stock postgres:16-alpine lacks the extension.
       postgres:
-        image: postgres:16-alpine
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: breeze
           POSTGRES_PASSWORD: breeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1783,7 +1783,19 @@ jobs:
             kill "$BOOT_PID" 2>/dev/null || true
             exit 1
           fi
-          kill "$BOOT_PID"
+          # Guarded like the two failure branches above: under this step's
+          # default `bash -e`, an unguarded `kill` on an already-exited PID
+          # (e.g. the process crashed on its own between logging the
+          # built-in load line and this kill — a real failure worth seeing,
+          # just not one that should undo an already-successful migration
+          # load) would abort the step on a bare "process not found" with no
+          # log content, making a correct migration load look like an
+          # unexplained CI failure. Dump the log in that case so it's
+          # diagnosable either way.
+          if ! kill "$BOOT_PID" 2>/dev/null; then
+            echo "API process had already exited after logging the built-in load line — dumping its output:"
+            cat /tmp/ee-workspace-boot.log
+          fi
           wait "$BOOT_PID" 2>/dev/null || true
 
       - name: Integration-test workspace (ee)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1832,24 +1832,36 @@ jobs:
           # Bound the wait for graceful shutdown instead of an unbounded
           # `wait "$BOOT_PID"`, which could otherwise eat the whole job
           # ceiling if the process ignores SIGTERM or hangs mid-shutdown.
-          # Poll for the process (group leader) to exit for up to 30s, then
-          # force-kill the group as a guarded fallback.
+          # Poll the GROUP, not $BOOT_PID: the leader (pnpm's wrapper) can
+          # exit seconds before the node/tsx descendants finish shutting
+          # down, and watching only the leader cuts the grace period short
+          # (observed on the first live run of this step). Count only
+          # NON-ZOMBIE members: `kill -0` "succeeds" against a zombie, but a
+          # zombie is dead — unreaped only because its parent died with it —
+          # and cannot touch the DB. The step's shell cannot reap
+          # grandchildren; init does so asynchronously after SIGKILL, so a
+          # zombie-only group must be treated as gone, not as a survivor
+          # (also observed live: `[node]`/`[esbuild] <defunct>` tripping a
+          # naive `kill -0 -- -PGID` assert).
+          live_in_group() {
+            ps -eo pgid=,stat= | awk -v p="$PGID" '$1 == p && $2 !~ /^Z/' | wc -l
+          }
           for _ in $(seq 1 30); do
-            kill -0 "$BOOT_PID" 2>/dev/null || break
+            [ "$(live_in_group)" -gt 0 ] || break
             sleep 1
           done
           kill -9 -- "-$PGID" 2>/dev/null || true
           wait "$BOOT_PID" 2>/dev/null || true
-          # Fail CLOSED on a surviving process group. `kill -0 -- -PGID`
-          # succeeding means at least one process in it is still alive after
-          # SIGTERM + 30s + SIGKILL — i.e. a fully-booted API (schedulers,
-          # reconciler, job workers) is still writing to the very DB shard the
-          # next step tests against. That is a flake generator, so it must
-          # stop the job rather than be inherited by the suite below.
-          if kill -0 -- "-$PGID" 2>/dev/null; then
+          # Fail CLOSED on a genuinely surviving process group — but give
+          # SIGKILL a moment to land before judging (delivery is async).
+          for _ in $(seq 1 10); do
+            [ "$(live_in_group)" -gt 0 ] || break
+            sleep 1
+          done
+          if [ "$(live_in_group)" -gt 0 ]; then
             echo "API process group $PGID survived SIGTERM and SIGKILL. A live API would keep writing to"
             echo "this step's DB shard and poison the workspace integration suite that runs next."
-            ps -o pid,pgid,cmd -e | awk -v pgid="$PGID" '$2 == pgid' || true
+            ps -eo pid,pgid,stat,cmd | awk -v pgid="$PGID" '$2 == pgid' || true
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1768,6 +1768,11 @@ jobs:
           NODE_ENV: test
           AUTO_MIGRATE: 'true'
           API_PORT: '3199'
+          # Built-in extensions are OFF by default per deployment; this step
+          # exists only to apply workspace's migrations, so it must opt in.
+          # The shard DB is the pgvector-capable docker-compose.test.yml
+          # postgres, so `CREATE EXTENSION vector` succeeds here.
+          BREEZE_WORKSPACE_ENABLED: 'true'
         run: |
           # Launch in its own process group (setsid) so the group can be
           # killed as a unit below. `pnpm exec` execs a shell wrapper around
@@ -1822,6 +1827,10 @@ jobs:
         env:
           DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
           DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
+          # Set for the same reason as the boot step above: should any part of
+          # this suite boot the host or consult the built-in enable flag, it
+          # must see the extension it is testing as enabled.
+          BREEZE_WORKSPACE_ENABLED: 'true'
         run: pnpm --filter @breeze/ext-workspace test:integration
 
       # Dedicated exact-role enforcement runner. The general integration config
@@ -1928,10 +1937,12 @@ jobs:
           BREEZE_PORTAL_IMAGE_REF=ghcr.io/lanternops/breeze/portal:latest
           BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:latest
           CADDY_IMAGE_REF=caddy:2-alpine
-          # pgvector-enabled image required: the Workspace built-in runs
-          # ee/workspace/migrations/*.sql (CREATE EXTENSION vector) on API
-          # boot. Stock postgres:16-alpine lacks the extension and the API
-          # fails to start. Matches docker-compose.test.yml's pg16 major.
+          # Mirrors .env.example's default. This stack deliberately leaves
+          # BREEZE_WORKSPACE_ENABLED unset, so it exercises the DEFAULT-OFF
+          # built-in path end to end (no workspace migrations, no pgvector
+          # requirement); the image is pgvector-capable anyway so that a
+          # self-hoster who later flips the flag needs no database swap, which
+          # is exactly the shape .env.example ships.
           POSTGRES_IMAGE_REF=pgvector/pgvector:pg16
           REDIS_IMAGE_REF=redis:7-alpine
           COTURN_IMAGE_REF=coturn/coturn:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,16 @@ jobs:
       - name: Type-check legacy extension adapter
         run: pnpm --filter @breeze/extension-api typecheck
 
+      # ee/workspace's own unit + typecheck coverage (424 tests). The
+      # apps/api typecheck step below separately covers the server code
+      # through the static built-in-extension import; this covers the rest
+      # (web/, __tests__/) that apps/api's tsconfig doesn't reach.
+      - name: Test workspace (ee)
+        run: pnpm --filter @breeze/ext-workspace test
+
+      - name: Type-check workspace (ee)
+        run: pnpm --filter @breeze/ext-workspace typecheck
+
       - name: Run API tests
         run: pnpm test --filter=@breeze/api
 
@@ -1727,6 +1737,61 @@ jobs:
         # --shard reaches vitest. Sharding only splits the file list; files
         # within a shard still run sequentially (fileParallelism: false).
         run: pnpm --filter=@breeze/api test:integration --shard=${{ matrix.shard }}/4
+
+      # ee/workspace's integration suite expects its own tables
+      # (workspace_sources, workspace_file_index, ...) to already exist on
+      # this DB — it has no self-provisioning of its own. Those tables are
+      # created by loadBuiltinExtensions() (apps/api/src/extensions/
+      # builtinExtensions.ts), which — unlike core migrations — runs ONLY at
+      # actual `apps/api` server boot (src/index.ts), never inside the
+      # vitest integration suite's globalSetup (which calls core
+      # autoMigrate() only; see src/db/autoMigrate.ts's planMigrations,
+      # which reads the LEGACY extensions/ dir, not the built-in registry).
+      # Boot the real server once, against this shard's already
+      # core-migrated :5433 DB, wait for its "loaded built-in" line, then
+      # stop it — the same `tsx src/index.ts` boot Task 4 of the ee-merge
+      # plan verified applies workspace's migrations (idempotently on
+      # repeat boots). Shard 1 only: a single-DB schema prerequisite for the
+      # step below, not a sharded suite in itself.
+      - name: Boot API once to apply built-in extension migrations (ee)
+        if: matrix.shard == 1
+        env:
+          DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
+          DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
+          BREEZE_APP_DB_PASSWORD: breeze_test
+          POSTGRES_PASSWORD: breeze_test
+          REDIS_URL: redis://localhost:6380
+          JWT_SECRET: ci-smoke-k7x9Qm4pR2vL8nW5jT3yF6hB0cA1dE4gI7
+          APP_ENCRYPTION_KEY: ci-smoke-Xz9Lm3Kp7Wn2Qr5Tv8Yb0Hd4Fg6Jc1Ae3
+          MFA_ENCRYPTION_KEY: ci-smoke-Nm4Rp8Ws2Kv6Tq0Yh3Bd7Fg1Jc5Le9Ax2
+          AGENT_ENROLLMENT_SECRET: ci-smoke-agent-enrollment-secret-value
+          NODE_ENV: test
+          AUTO_MIGRATE: 'true'
+          API_PORT: '3199'
+        run: |
+          pnpm --filter=@breeze/api exec tsx src/index.ts > /tmp/ee-workspace-boot.log 2>&1 &
+          BOOT_PID=$!
+          if ! timeout 90 bash -c 'until grep -qE "loaded built-in \"workspace\"|CRITICAL" /tmp/ee-workspace-boot.log 2>/dev/null; do sleep 1; done'; then
+            echo "Timed out waiting for the built-in extension boot line:"
+            cat /tmp/ee-workspace-boot.log
+            kill "$BOOT_PID" 2>/dev/null || true
+            exit 1
+          fi
+          if grep -q CRITICAL /tmp/ee-workspace-boot.log; then
+            echo "API boot failed before loading built-in extensions:"
+            cat /tmp/ee-workspace-boot.log
+            kill "$BOOT_PID" 2>/dev/null || true
+            exit 1
+          fi
+          kill "$BOOT_PID"
+          wait "$BOOT_PID" 2>/dev/null || true
+
+      - name: Integration-test workspace (ee)
+        if: matrix.shard == 1
+        env:
+          DATABASE_URL: postgresql://breeze_test:breeze_test@localhost:5433/breeze_test
+          DATABASE_URL_APP: postgresql://breeze_app:breeze_test@localhost:5433/breeze_test
+        run: pnpm --filter @breeze/ext-workspace test:integration
 
       # Dedicated exact-role enforcement runner. The general integration config
       # excludes it because this suite manages a temporary BYPASSRLS role and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1769,33 +1769,52 @@ jobs:
           AUTO_MIGRATE: 'true'
           API_PORT: '3199'
         run: |
-          pnpm --filter=@breeze/api exec tsx src/index.ts > /tmp/ee-workspace-boot.log 2>&1 &
+          # Launch in its own process group (setsid) so the group can be
+          # killed as a unit below. `pnpm exec` execs a shell wrapper around
+          # `tsx`, which in turn is a node process running a child worker —
+          # SIGTERM sent to just $! (pnpm exec's PID) is not guaranteed to
+          # propagate to the actual tsx/node descendants, so a "killed" boot
+          # can leave a fully-booted API (schedulers, reconciler, ...)
+          # running into the next step against this same DB shard: a flake
+          # generator. `kill -- -"$BOOT_PID"` below sends to the whole
+          # group instead of just the leader.
+          setsid pnpm --filter=@breeze/api exec tsx src/index.ts > /tmp/ee-workspace-boot.log 2>&1 &
           BOOT_PID=$!
-          if ! timeout 90 bash -c 'until grep -qE "loaded built-in \"workspace\"|CRITICAL" /tmp/ee-workspace-boot.log 2>/dev/null; do sleep 1; done'; then
+          if ! timeout 180 bash -c 'until grep -qE "loaded built-in \"workspace\"|CRITICAL" /tmp/ee-workspace-boot.log 2>/dev/null; do sleep 1; done'; then
             echo "Timed out waiting for the built-in extension boot line:"
             cat /tmp/ee-workspace-boot.log
-            kill "$BOOT_PID" 2>/dev/null || true
+            kill -- "-$BOOT_PID" 2>/dev/null || true
             exit 1
           fi
           if grep -q CRITICAL /tmp/ee-workspace-boot.log; then
             echo "API boot failed before loading built-in extensions:"
             cat /tmp/ee-workspace-boot.log
-            kill "$BOOT_PID" 2>/dev/null || true
+            kill -- "-$BOOT_PID" 2>/dev/null || true
             exit 1
           fi
           # Guarded like the two failure branches above: under this step's
-          # default `bash -e`, an unguarded `kill` on an already-exited PID
-          # (e.g. the process crashed on its own between logging the
+          # default `bash -e`, an unguarded `kill` on an already-exited
+          # group (e.g. the process crashed on its own between logging the
           # built-in load line and this kill — a real failure worth seeing,
           # just not one that should undo an already-successful migration
           # load) would abort the step on a bare "process not found" with no
           # log content, making a correct migration load look like an
           # unexplained CI failure. Dump the log in that case so it's
           # diagnosable either way.
-          if ! kill "$BOOT_PID" 2>/dev/null; then
-            echo "API process had already exited after logging the built-in load line — dumping its output:"
+          if ! kill -- "-$BOOT_PID" 2>/dev/null; then
+            echo "API process group had already exited after logging the built-in load line — dumping its output:"
             cat /tmp/ee-workspace-boot.log
           fi
+          # Bound the wait for graceful shutdown instead of an unbounded
+          # `wait "$BOOT_PID"`, which could otherwise eat the whole job
+          # ceiling if the process ignores SIGTERM or hangs mid-shutdown.
+          # Poll for the process (group leader) to exit for up to 30s, then
+          # force-kill the group as a guarded fallback.
+          for _ in $(seq 1 30); do
+            kill -0 "$BOOT_PID" 2>/dev/null || break
+            sleep 1
+          done
+          kill -9 -- "-$BOOT_PID" 2>/dev/null || true
           wait "$BOOT_PID" 2>/dev/null || true
 
       - name: Integration-test workspace (ee)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1774,6 +1774,12 @@ jobs:
           # postgres, so `CREATE EXTENSION vector` succeeds here.
           BREEZE_WORKSPACE_ENABLED: 'true'
         run: |
+          # The fatal boot sentinel. A BARE `CRITICAL` is not usable as one:
+          # non-fatal worker-init messages also print `[CRITICAL]` and can race
+          # into this same log, which would fail the step on a boot that
+          # actually succeeded. Only `index.ts`'s startup-failure line means
+          # "boot died".
+          FATAL='\[CRITICAL\] API startup failed'
           # Launch in its own process group (setsid) so the group can be
           # killed as a unit below. `pnpm exec` execs a shell wrapper around
           # `tsx`, which in turn is a node process running a child worker —
@@ -1781,34 +1787,47 @@ jobs:
           # propagate to the actual tsx/node descendants, so a "killed" boot
           # can leave a fully-booted API (schedulers, reconciler, ...)
           # running into the next step against this same DB shard: a flake
-          # generator. `kill -- -"$BOOT_PID"` below sends to the whole
-          # group instead of just the leader.
-          setsid pnpm --filter=@breeze/api exec tsx src/index.ts > /tmp/ee-workspace-boot.log 2>&1 &
+          # generator. `kill -- -"$PGID"` below sends to the whole group.
+          #
+          # $! is the setsid PID, which is NOT reliably the new group's ID
+          # (setsid may fork), so the group records its own ID from inside:
+          # the inner shell IS the group leader, and `$$` is therefore the
+          # pgid. Everything below kills by that recorded value.
+          setsid bash -c 'echo $$ > /tmp/ee-boot.pgid; exec pnpm --filter=@breeze/api exec tsx src/index.ts' > /tmp/ee-workspace-boot.log 2>&1 &
           BOOT_PID=$!
-          if ! timeout 180 bash -c 'until grep -qE "loaded built-in \"workspace\"|CRITICAL" /tmp/ee-workspace-boot.log 2>/dev/null; do sleep 1; done'; then
+          if ! timeout 180 bash -c "until grep -qE 'loaded built-in \"workspace\"|$FATAL' /tmp/ee-workspace-boot.log 2>/dev/null; do sleep 1; done"; then
             echo "Timed out waiting for the built-in extension boot line:"
             cat /tmp/ee-workspace-boot.log
-            kill -- "-$BOOT_PID" 2>/dev/null || true
+            kill -- "-$(cat /tmp/ee-boot.pgid 2>/dev/null || echo "$BOOT_PID")" 2>/dev/null || true
             exit 1
           fi
-          if grep -q CRITICAL /tmp/ee-workspace-boot.log; then
+          if grep -q "$FATAL" /tmp/ee-workspace-boot.log; then
             echo "API boot failed before loading built-in extensions:"
             cat /tmp/ee-workspace-boot.log
-            kill -- "-$BOOT_PID" 2>/dev/null || true
+            kill -- "-$(cat /tmp/ee-boot.pgid 2>/dev/null || echo "$BOOT_PID")" 2>/dev/null || true
             exit 1
           fi
+          PGID="$(cat /tmp/ee-boot.pgid 2>/dev/null || echo "$BOOT_PID")"
           # Guarded like the two failure branches above: under this step's
           # default `bash -e`, an unguarded `kill` on an already-exited
           # group (e.g. the process crashed on its own between logging the
-          # built-in load line and this kill — a real failure worth seeing,
-          # just not one that should undo an already-successful migration
-          # load) would abort the step on a bare "process not found" with no
-          # log content, making a correct migration load look like an
-          # unexplained CI failure. Dump the log in that case so it's
-          # diagnosable either way.
-          if ! kill -- "-$BOOT_PID" 2>/dev/null; then
+          # built-in load line and this kill) would abort the step on a bare
+          # "process not found" with no log content, making a correct
+          # migration load look like an unexplained CI failure. Dump the log
+          # so it's diagnosable either way — and then decide: an already-dead
+          # group that ALSO logged the fatal sentinel is a genuine boot
+          # failure that merely happened to log the built-in line first, and
+          # must fail the step rather than be waved through.
+          if ! kill -- "-$PGID" 2>/dev/null; then
             echo "API process group had already exited after logging the built-in load line — dumping its output:"
             cat /tmp/ee-workspace-boot.log
+            if grep -q "$FATAL" /tmp/ee-workspace-boot.log; then
+              echo "The API logged the built-in load line and then FAILED startup — the schema this step is"
+              echo "supposed to guarantee may be incomplete, so the workspace integration suite below would"
+              echo "fail confusingly. Failing here instead."
+              exit 1
+            fi
+            echo "::warning::API exited on its own after loading built-in extensions (no startup failure logged); migrations were applied, continuing."
           fi
           # Bound the wait for graceful shutdown instead of an unbounded
           # `wait "$BOOT_PID"`, which could otherwise eat the whole job
@@ -1819,8 +1838,20 @@ jobs:
             kill -0 "$BOOT_PID" 2>/dev/null || break
             sleep 1
           done
-          kill -9 -- "-$BOOT_PID" 2>/dev/null || true
+          kill -9 -- "-$PGID" 2>/dev/null || true
           wait "$BOOT_PID" 2>/dev/null || true
+          # Fail CLOSED on a surviving process group. `kill -0 -- -PGID`
+          # succeeding means at least one process in it is still alive after
+          # SIGTERM + 30s + SIGKILL — i.e. a fully-booted API (schedulers,
+          # reconciler, job workers) is still writing to the very DB shard the
+          # next step tests against. That is a flake generator, so it must
+          # stop the job rather than be inherited by the suite below.
+          if kill -0 -- "-$PGID" 2>/dev/null; then
+            echo "API process group $PGID survived SIGTERM and SIGKILL. A live API would keep writing to"
+            echo "this step's DB shard and poison the workspace integration suite that runs next."
+            ps -o pid,pgid,cmd -e | awk -v pgid="$PGID" '$2 == pgid' || true
+            exit 1
+          fi
 
       - name: Integration-test workspace (ee)
         if: matrix.shard == 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1928,7 +1928,11 @@ jobs:
           BREEZE_PORTAL_IMAGE_REF=ghcr.io/lanternops/breeze/portal:latest
           BREEZE_BINARIES_IMAGE_REF=ghcr.io/lanternops/breeze/binaries:latest
           CADDY_IMAGE_REF=caddy:2-alpine
-          POSTGRES_IMAGE_REF=postgres:16-alpine
+          # pgvector-enabled image required: the Workspace built-in runs
+          # ee/workspace/migrations/*.sql (CREATE EXTENSION vector) on API
+          # boot. Stock postgres:16-alpine lacks the extension and the API
+          # fails to start. Matches docker-compose.test.yml's pg16 major.
+          POSTGRES_IMAGE_REF=pgvector/pgvector:pg16
           REDIS_IMAGE_REF=redis:7-alpine
           COTURN_IMAGE_REF=coturn/coturn:latest
           # Required in production by config/validate.ts (#625) — without

--- a/README.md
+++ b/README.md
@@ -502,9 +502,11 @@ Self-hosted: your data never leaves your infrastructure. Cloud-hosted: data is i
 
 ## License
 
-Breeze is licensed under [AGPL-3.0](LICENSE).
-
-You can use, modify, and self-host Breeze freely. If you modify Breeze and offer it as a service, you must open source your modifications under the same license.
+Breeze is [AGPL-3.0](LICENSE) licensed, with one exception: everything under
+the [`ee/`](ee/) directory is covered by the
+[Breeze Commercial License](ee/LICENSE) (source-visible, requires a
+commercial agreement for production use). This is the same open-core layout
+used by projects like Cal.com.
 
 ---
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -21,6 +21,9 @@ COPY packages/shared/package.json ./packages/shared/
 # creates the workspace symlinks the API's tsup bundle resolves at build time.
 COPY packages/extension-api/package.json ./packages/extension-api/
 COPY packages/extension-sdk/package.json ./packages/extension-sdk/
+COPY packages/extension-web-sdk/package.json ./packages/extension-web-sdk/
+COPY packages/extension-testkit/package.json ./packages/extension-testkit/
+COPY ee/workspace/package.json ./ee/workspace/
 
 # Install all dependencies
 RUN pnpm install --frozen-lockfile --prefer-offline
@@ -36,11 +39,18 @@ ENV NODE_ENV=${NODE_ENV}
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules
 COPY --from=deps /app/packages ./packages
+COPY --from=deps /app/ee ./ee
 
 # Copy source code
 COPY apps/api ./apps/api
 COPY packages ./packages
+COPY ee ./ee
 COPY tsconfig.json ./
+
+# Build the built-in workspace extension's web bundle. Its server code needs
+# no separate build step here -- the API's own tsup build (below) bundles
+# @breeze/ext-workspace source directly via noExternal: [/^@breeze\//].
+RUN pnpm --filter @breeze/ext-workspace build:web
 
 # Build the API
 WORKDIR /app/apps/api
@@ -72,6 +82,11 @@ COPY --from=builder --chown=hono:nodejs /app/apps/api/package.json ./apps/api/pa
 COPY --from=deps --chown=hono:nodejs /app/apps/api/node_modules ./apps/api/node_modules
 COPY --from=deps --chown=hono:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=hono:nodejs /app/packages ./packages
+
+# Built-in extensions: this runner's WORKDIR ends at /app/apps/api (see below),
+# and builtinRegistry.ts's CJS-bundle fallback resolves packageDir relative to
+# process.cwd() -- so the copy destination must be apps/api/ee, not /app/ee.
+COPY --from=builder --chown=hono:nodejs /app/ee ./apps/api/ee
 
 # Copy migration files for auto-migrate on startup
 COPY --from=builder --chown=hono:nodejs /app/apps/api/migrations ./apps/api/migrations

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -42,6 +42,7 @@
     "@anthropic-ai/sdk": "^0.115.0",
     "@aws-sdk/client-s3": "^3.1100.0",
     "@aws-sdk/s3-request-presigner": "^3.1096.0",
+    "@breeze/ext-workspace": "workspace:*",
     "@breeze/extension-api": "workspace:*",
     "@breeze/extension-sdk": "workspace:*",
     "@breeze/shared": "workspace:*",

--- a/apps/api/src/config/dockerfileWorkspaceManifests.test.ts
+++ b/apps/api/src/config/dockerfileWorkspaceManifests.test.ts
@@ -78,13 +78,13 @@ function readJson(file: string): Record<string, unknown> {
 }
 
 /**
- * pnpm-workspace.yaml uses `apps/*` / `packages/*`. Rather than pull in a YAML
- * parser for two globs, enumerate the two directories directly and assert below
- * that the workspace file still says what we assume.
+ * pnpm-workspace.yaml uses `apps/*` / `packages/*` / `ee/*`. Rather than pull in
+ * a YAML parser for three globs, enumerate the three directories directly and
+ * assert below that the workspace file still says what we assume.
  */
 function loadWorkspacePackages(): Map<string, WorkspacePackage> {
   const byName = new Map<string, WorkspacePackage>();
-  for (const root of ['apps', 'packages']) {
+  for (const root of ['apps', 'packages', 'ee']) {
     for (const entry of readdirSync(path.join(REPO_ROOT, root), { withFileTypes: true })) {
       if (!entry.isDirectory()) continue;
       const dir = `${root}/${entry.name}`;
@@ -351,7 +351,8 @@ describe('Dockerfile workspace-manifest copy scope', () => {
     const workspaceYaml = readFileSync(path.join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8');
     expect(workspaceYaml).toMatch(/^\s*-\s*'apps\/\*'\s*$/m);
     expect(workspaceYaml).toMatch(/^\s*-\s*'packages\/\*'\s*$/m);
-    expect(workspaceYaml).not.toMatch(/^\s*-\s*'(?!apps\/\*|packages\/\*)/m);
+    expect(workspaceYaml).toMatch(/^\s*-\s*'ee\/\*'\s*$/m);
+    expect(workspaceYaml).not.toMatch(/^\s*-\s*'(?!apps\/\*|packages\/\*|ee\/\*)/m);
   });
 
   it('leaves no Dockerfile silently unchecked', () => {

--- a/apps/api/src/config/extensionBundledDependencies.test.ts
+++ b/apps/api/src/config/extensionBundledDependencies.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import tsupConfig from '../../tsup.config';
+
+/**
+ * Guard against the "dangling third-party external" class of bug (found in review during
+ * the workspace-ee-merge branch, before either production image ever shipped).
+ *
+ * apps/api's tsup build bundles the built-in ee/workspace extension's SOURCE via
+ * `noExternal: [/^@breeze\//, ...]` (@breeze/ext-workspace re-exports it). By default,
+ * tsup treats a bare import as external (left as a literal `require()` in dist/index.cjs,
+ * resolved from node_modules at runtime) only when that specifier is one of apps/api's OWN
+ * declared `dependencies` -- everything else reachable from a noExternal-matched module
+ * gets bundled by esbuild's ordinary default (bundle=true unless externalized).
+ *
+ * That means any ee/workspace runtime dependency that is NOT also an apps/api dependency
+ * gets bundled automatically today -- but only as a SIDE EFFECT of apps/api happening not
+ * to depend on it itself. That's an accident, not a decision: if apps/api ever gained its
+ * own same-named dependency (for an unrelated reason), the package would silently flip to
+ * externalized, and neither production Dockerfile provisions ee/workspace's own
+ * node_modules into the deployed image -- so the next boot would crash with
+ * "Cannot find module '<pkg>'" the first time that code path executed, with nothing in CI
+ * to catch it (the guard test in dockerfileWorkspaceManifests.test.ts checks Dockerfile
+ * COPY completeness, not what tsup actually chooses to bundle vs. externalize).
+ *
+ * This test pins the actual contract: every ee/workspace runtime dependency must be either
+ * (a) also declared as an apps/api dependency -- so it deliberately stays external and
+ * resolves from apps/api's own deployed node_modules, which both production Dockerfiles DO
+ * provision -- or (b) explicitly listed in apps/api/tsup.config.ts's `noExternal`, an
+ * intentional, reviewed decision to ship it bundled instead. A dependency in neither
+ * bucket is exactly the bug this guards against.
+ */
+
+const API_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const REPO_ROOT = path.resolve(API_ROOT, '../..');
+
+function readJson(file: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>;
+}
+
+function dependencyNames(manifest: Record<string, unknown>): Set<string> {
+  return new Set(Object.keys((manifest.dependencies ?? {}) as Record<string, string>));
+}
+
+const apiManifest = readJson(path.join(API_ROOT, 'package.json'));
+const workspaceManifest = readJson(path.join(REPO_ROOT, 'ee/workspace/package.json'));
+
+const apiDeps = dependencyNames(apiManifest);
+const workspaceDeps = dependencyNames(workspaceManifest);
+
+/** Non-`@breeze/*` names: those are handled by the separate `/^@breeze\//` regex entry. */
+const workspaceThirdPartyDeps = [...workspaceDeps].filter((name) => !name.startsWith('@breeze/'));
+
+function noExternalStrings(): Set<string> {
+  const entries = tsupConfig.noExternal;
+  const list = Array.isArray(entries) ? entries : entries ? [entries] : [];
+  return new Set(list.filter((entry): entry is string => typeof entry === 'string'));
+}
+
+describe('ee/workspace bundled-dependency contract (apps/api/tsup.config.ts)', () => {
+  it('every ee/workspace third-party runtime dependency is either an apps/api dependency or explicitly noExternal', () => {
+    const noExternal = noExternalStrings();
+    const dangling = workspaceThirdPartyDeps.filter(
+      (name) => !apiDeps.has(name) && !noExternal.has(name),
+    );
+
+    expect(
+      dangling,
+      `ee/workspace/package.json declares ${dangling.join(', ')} as a runtime dependency, but ` +
+        "it is neither an apps/api dependency (which would keep it external and resolvable from " +
+        "apps/api's own deployed node_modules) nor listed in apps/api/tsup.config.ts's noExternal " +
+        '(which would ship it bundled into dist/index.cjs). Left as-is, tsup bundles it today only ' +
+        "by accident (apps/api doesn't happen to depend on it), which breaks silently the moment " +
+        'that stops being true. Either add it to apps/api/tsup.config.ts noExternal (if pure JS, no ' +
+        'native bindings) or add it to apps/api/package.json dependencies (if it should stay external).',
+    ).toEqual([]);
+  });
+
+  it('every explicitly-bundled third-party entry in noExternal is still a real ee/workspace dependency', () => {
+    const noExternal = [...noExternalStrings()].filter((name) => name !== 'dotenv');
+    const stale = noExternal.filter((name) => !workspaceThirdPartyDeps.includes(name));
+
+    expect(
+      stale,
+      `apps/api/tsup.config.ts's noExternal lists ${stale.join(', ')} as explicitly bundled for ` +
+        "ee/workspace, but ee/workspace/package.json no longer declares it as a runtime dependency " +
+        '(or it moved to apps/api\'s own dependencies, where it belongs instead). Remove the stale ' +
+        'entry so noExternal stays an accurate record of what is deliberately inlined.',
+    ).toEqual([]);
+  });
+
+  it('explicitly-bundled entries do not shadow an apps/api dependency of the same name', () => {
+    const noExternal = [...noExternalStrings()].filter((name) => name !== 'dotenv');
+    const redundant = noExternal.filter((name) => apiDeps.has(name));
+
+    expect(
+      redundant,
+      `apps/api/tsup.config.ts's noExternal explicitly bundles ${redundant.join(', ')}, but apps/api ` +
+        'already depends on it directly -- it would stay external (and resolve fine from the deployed ' +
+        'node_modules) without the explicit entry. Remove it from noExternal to avoid bundling a ' +
+        "second, possibly-different-versioned copy alongside apps/api's own.",
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/config/extensionBundledDependencies.test.ts
+++ b/apps/api/src/config/extensionBundledDependencies.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { Options } from 'tsup';
 import { describe, expect, it } from 'vitest';
-import tsupConfig from '../../tsup.config';
+import tsupConfigExport from '../../tsup.config';
 
 /**
  * Guard against the "dangling third-party external" class of bug (found in review during
@@ -53,8 +54,31 @@ const workspaceDeps = dependencyNames(workspaceManifest);
 /** Non-`@breeze/*` names: those are handled by the separate `/^@breeze\//` regex entry. */
 const workspaceThirdPartyDeps = [...workspaceDeps].filter((name) => !name.startsWith('@breeze/'));
 
+/**
+ * `defineConfig`'s return type is `Options | Options[] | ((overrideOptions: Options) =>
+ * MaybePromise<Options | Options[]>)` -- tsup supports multi-build-config arrays and a
+ * factory-function form, neither of which `apps/api/tsup.config.ts` uses today (it exports
+ * one static `Options` object). Narrow explicitly rather than asserting: if the config ever
+ * switches shape, this guard should fail loudly and say why, not silently stop checking.
+ */
+function resolveTsupOptions(config: typeof tsupConfigExport): Options {
+  if (typeof config === 'function') {
+    throw new Error(
+      "apps/api/tsup.config.ts now exports the factory-function form of defineConfig; this " +
+        'guard only understands a static Options object. Update resolveTsupOptions to match.',
+    );
+  }
+  if (Array.isArray(config)) {
+    throw new Error(
+      'apps/api/tsup.config.ts now exports multiple build configs (an Options[] array); this ' +
+        'guard only understands a single Options object. Update resolveTsupOptions to match.',
+    );
+  }
+  return config;
+}
+
 function noExternalStrings(): Set<string> {
-  const entries = tsupConfig.noExternal;
+  const entries = resolveTsupOptions(tsupConfigExport).noExternal;
   const list = Array.isArray(entries) ? entries : entries ? [entries] : [];
   return new Set(list.filter((entry): entry is string => typeof entry === 'string'));
 }

--- a/apps/api/src/extensions/builtinExtensions.test.ts
+++ b/apps/api/src/extensions/builtinExtensions.test.ts
@@ -1,16 +1,34 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 import {
   parseExtensionManifestV1,
   type BreezeExtensionV1,
   type ExtensionManifestV1,
 } from '@breeze/extension-sdk';
+
+// Hermetic: the tenant-export suite below reads getExtensionTenancy(), which
+// otherwise scans the repo's extensions/ root for source extensions. Stubbing
+// discovery keeps these assertions about the BUILT-IN declarations only. The
+// loading tests never reach these ports (the harness overrides both).
+vi.mock('./discovery', () => ({
+  discoverExtensions: () => [],
+  listSourceExtensionCandidates: () => [],
+  resolveExtensionsRoot: () => '/nonexistent/extensions',
+}));
+
 import {
   BUILTIN_EXTENSION_NAMES,
+  builtinTenancyDeclarations,
   loadBuiltinExtensions,
   type BuiltinExtension,
   type BuiltinPorts,
 } from './builtinExtensions';
+import {
+  getExtensionOrgExportColumns,
+  registerRuntimeExtensionTenancy,
+  resetExtensionTenancyCacheForTests,
+} from './tenancyRegistry';
+import { getTenantExportPolicyRegistry } from '../services/tenantExportPolicyRegistry';
 import {
   ExtensionContributionRegistry,
   type StagedExtensionContributions,
@@ -416,5 +434,68 @@ describe('loadBuiltinExtensions — helperRoutes staging', () => {
 describe('BUILTIN_EXTENSION_NAMES', () => {
   it('names the workspace extension (the first and only built-in)', () => {
     expect([...BUILTIN_EXTENSION_NAMES]).toEqual(['workspace']);
+  });
+});
+
+/**
+ * Publishing a built-in's tenancy is not free: `getExtensionOrgExportColumns()`
+ * walks EVERY published declaration's `orgCascadeDeleteTables` and THROWS on the
+ * first table with no export classification. That throw surfaces at
+ * `getTenantExportPolicyRegistry()` — i.e. on the GDPR right-of-access export
+ * path — so a built-in that declares cascade tables without `orgExportColumns`
+ *500s every org's data export from the moment it boots, with nothing in the
+ * boot logs. These tests pin the whole classification, against the REAL
+ * manifest.
+ */
+describe('built-in tenancy participates in the tenant-export contract', () => {
+  afterEach(() => {
+    resetExtensionTenancyCacheForTests();
+  });
+
+  function publishBuiltinTenancy() {
+    for (const declaration of builtinTenancyDeclarations()) {
+      registerRuntimeExtensionTenancy(declaration);
+    }
+  }
+
+  it('classifies every org-cascade table the workspace built-in declares', () => {
+    const [workspace] = builtinTenancyDeclarations();
+    expect(workspace?.orgCascadeDeleteTables.length).toBeGreaterThan(0);
+    publishBuiltinTenancy();
+
+    // Without `tenancy.orgExportColumns` in ee/workspace/manifest.json this
+    // throws `[tenantExport] extension table "..." is missing an export
+    // classification`.
+    const classified = getExtensionOrgExportColumns();
+    expect(Object.keys(classified).sort()).toEqual(
+      [...workspace!.orgCascadeDeleteTables].sort(),
+    );
+
+    // Every table classifies a non-empty column set, and include/exclude never
+    // overlap (assertUniqueExportColumns throws otherwise).
+    for (const [table, policy] of Object.entries(classified)) {
+      expect(
+        policy.include.length + policy.exclude.length,
+        `table ${table} classifies no columns`,
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('builds the tenant-export policy registry the export path actually calls', () => {
+    publishBuiltinTenancy();
+    const registry = getTenantExportPolicyRegistry();
+
+    for (const table of builtinTenancyDeclarations()[0]!.orgCascadeDeleteTables) {
+      expect(registry[table]?.organizationKey, `missing policy for ${table}`).toBe('org_id');
+    }
+  });
+
+  it('excludes the encrypted source credential while exporting the tenant-owned columns', () => {
+    publishBuiltinTenancy();
+    const sources = getTenantExportPolicyRegistry()['workspace_sources'];
+
+    expect(sources?.columns['credential_enc']?.decision).toBe('exclude');
+    expect(sources?.columns['root_path']?.decision).toBe('include');
+    expect(sources?.columns['display_name']?.decision).toBe('include');
   });
 });

--- a/apps/api/src/extensions/builtinExtensions.test.ts
+++ b/apps/api/src/extensions/builtinExtensions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 import {
   parseExtensionManifestV1,
@@ -19,10 +19,12 @@ vi.mock('./discovery', () => ({
 import {
   BUILTIN_EXTENSION_NAMES,
   builtinTenancyDeclarations,
+  isBuiltinEnabled,
   loadBuiltinExtensions,
   type BuiltinExtension,
   type BuiltinPorts,
 } from './builtinExtensions';
+import { BUILTINS } from './builtinRegistry';
 import {
   getExtensionOrgExportColumns,
   registerRuntimeExtensionTenancy,
@@ -143,6 +145,7 @@ class InMemoryExtensionStateBackend implements ExtensionStateBackend {
 const NAME = 'demo-builtin';
 const NAMESPACE = 'demo-ns';
 const VERSION = '1.4.0';
+const ENABLE_ENV_VAR = 'BREEZE_DEMO_BUILTIN_ENABLED';
 
 function fixtureManifest(overrides: Partial<ExtensionManifestV1> = {}): ExtensionManifestV1 {
   return {
@@ -185,6 +188,7 @@ function fixtureBuiltin(overrides: Partial<BuiltinExtension> = {}): BuiltinExten
     packageDir: 'ee/demo-builtin',
     packageName: '@breeze/ext-demo-builtin',
     helperRoutes: false,
+    enableEnvVar: ENABLE_ENV_VAR,
     ...overrides,
   };
 }
@@ -227,6 +231,8 @@ function createHarness(overrides: {
   const stateStore = overrides.stateStore
     ?? new ExtensionStateStore(new InMemoryExtensionStateBackend());
   const calls: string[] = [];
+  /** Counts privileged-connection opens, which the DISABLED path must never do. */
+  const migrationSqlOpens = { count: 0 };
   const rateLimitPrefixes: string[] = [];
   const registeredWebAssets: Array<{ name: string; asset: RegisterableExtensionWebAsset }> = [];
 
@@ -240,9 +246,10 @@ function createHarness(overrides: {
     builtins: overrides.builtins ?? [fixtureBuiltin()],
     declaredRuntimeNames: () => new Set<string>(),
     sourceCandidates: () => [],
-    createMigrationSql: () => null,
+    createMigrationSql: () => { migrationSqlOpens.count += 1; return null; },
     runMigrations: async () => { calls.push('migration'); },
     publishTenancy: () => { calls.push('tenancy'); },
+    anyDeclaredTableExists: async () => { calls.push('probe'); return false; },
     ...(overrides.realStage ? {} : {
       stageExtension: async (_module: BreezeExtensionV1, manifest: ExtensionManifestV1) => {
         calls.push('stage');
@@ -263,13 +270,31 @@ function createHarness(overrides: {
     registry,
     stateStore,
     calls,
+    migrationSqlOpens,
     rateLimitPrefixes,
     registeredWebAssets,
     load: () => loadBuiltinExtensions({ registry, stateStore, ports }),
   };
 }
 
+/**
+ * Switch the fixture built-in ON for a suite that exercises the loading
+ * pipeline. Deliberately a raw `process.env` write rather than `vi.stubEnv`:
+ * one test below stubs NODE_ENV and calls `vi.unstubAllEnvs()` mid-test, which
+ * would otherwise silently un-enable the built-in for the rest of that test.
+ */
+function enableFixtureBuiltin(): void {
+  beforeEach(() => {
+    process.env[ENABLE_ENV_VAR] = 'true';
+  });
+  afterEach(() => {
+    delete process.env[ENABLE_ENV_VAR];
+  });
+}
+
 describe('loadBuiltinExtensions', () => {
+  enableFixtureBuiltin();
+
   it('activates a built-in through the staged pipeline with enabled=true on first boot', async () => {
     const h = createHarness();
     await h.load();
@@ -388,6 +413,182 @@ describe('loadBuiltinExtensions', () => {
     });
     await expect(h.load()).rejects.toThrow(/permission denied/);
   });
+
+  /**
+   * The pgvector case is the ONE migration failure with a known cause and two
+   * concrete remedies, and the raw Postgres error names neither. Everything
+   * else must reach the operator unedited.
+   */
+  it('rewrites a pgvector-shaped migration failure into an actionable error', async () => {
+    const h = createHarness({
+      ports: {
+        runMigrations: async () => {
+          throw new Error('extension "vector" is not available');
+        },
+      },
+    });
+
+    const error = await h.load().then(() => null, (e: unknown) => e as Error);
+    expect(error?.message).toContain('pgvector');
+    expect(error?.message).toContain('pgvector/pgvector:pg16');
+    expect(error?.message).toContain(ENABLE_ENV_VAR);
+    // The original text survives, and so does the original error as `cause`.
+    expect(error?.message).toContain('extension "vector" is not available');
+    expect((error?.cause as Error)?.message).toBe('extension "vector" is not available');
+  });
+
+  it('rethrows an unrelated migration failure untouched', async () => {
+    const boom = new Error('relation "widgets" already exists');
+    const h = createHarness({ ports: { runMigrations: async () => { throw boom; } } });
+
+    await expect(h.load()).rejects.toBe(boom);
+  });
+});
+
+/**
+ * The DEPLOYMENT enable flag. Being compiled into the image makes a built-in
+ * available, not loaded: a deployment that never asked for it must boot with no
+ * migrations, no schema and none of the built-in's infrastructure requirements
+ * (workspace's pgvector) — while a deployment that enabled it ONCE and later
+ * switched it off must still boot, with its orphaned tables accounted for.
+ */
+describe('loadBuiltinExtensions — deployment enable flag', () => {
+  afterEach(() => {
+    delete process.env[ENABLE_ENV_VAR];
+  });
+
+  /** A built-in whose tenancy actually declares tables, so the probe matters. */
+  const TENANT_TABLES = ['demo_files', 'demo_projects'];
+  function tenantedBuiltin(): BuiltinExtension {
+    return fixtureBuiltin({
+      manifest: fixtureManifest({
+        tenancy: {
+          // Deliberately overlapping across the four lists: the probe must see
+          // the DEDUPED union, not one list or four copies.
+          orgCascadeDeleteTables: ['demo_projects', 'demo_files'],
+          deviceCascadeDeleteTables: ['demo_files'],
+          deviceOrgDenormalizedTables: [],
+          deviceOrgMoveDeleteTables: ['demo_files'],
+        },
+      } as Partial<ExtensionManifestV1>),
+    });
+  }
+
+  function captureWarnings() {
+    return vi.spyOn(console, 'warn').mockImplementation(() => {});
+  }
+
+  it('loads nothing at all when the flag is unset', async () => {
+    const warn = captureWarnings();
+    try {
+      const h = createHarness();
+      await expect(h.load()).resolves.toBeUndefined();
+
+      // No phase ran, nothing is live, and the privileged migration connection
+      // was never even opened (so a plain-Postgres deployment boots clean).
+      expect(h.calls).toEqual([]);
+      expect(h.migrationSqlOpens.count).toBe(0);
+      expect(h.registry.get(NAME)).toBeUndefined();
+      expect(await h.stateStore.get(NAME)).toBeNull();
+      expect(h.registeredWebAssets).toEqual([]);
+
+      // Exactly ONE structured skip line, naming the flag to set.
+      expect(warn).toHaveBeenCalledTimes(1);
+      const line = warn.mock.calls[0]!.join(' ');
+      expect(line).toContain('builtin_extension_disabled');
+      expect(line).toContain(`"extension":"${NAME}"`);
+      expect(line).toContain(`"enableFlag":"${ENABLE_ENV_VAR}"`);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it.each(['', 'false', '1', 'TRUE', 'yes'])(
+    'stays off for the non-strict value %o',
+    async (value) => {
+      process.env[ENABLE_ENV_VAR] = value;
+      const warn = captureWarnings();
+      try {
+        const h = createHarness();
+        await h.load();
+        expect(h.calls).toEqual([]);
+        expect(h.registry.get(NAME)).toBeUndefined();
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
+
+  // A previously-enabled deployment left `demo_*` on the database. Without the
+  // declaration, the loader's and the reconciler's unaccounted-public-tables
+  // sweeps abort boot on those tables, and org-deletion cascades skip them.
+  it('publishes tenancy — and ONLY tenancy — when the built-in left tables behind', async () => {
+    const warn = captureWarnings();
+    try {
+      const probed: Array<readonly string[]> = [];
+      const h = createHarness({
+        builtins: [tenantedBuiltin()],
+        ports: {
+          anyDeclaredTableExists: async (tables) => {
+            probed.push(tables);
+            return true;
+          },
+        },
+      });
+      await h.load();
+
+      expect(h.calls).toEqual(['tenancy']);
+      expect(h.migrationSqlOpens.count).toBe(0);
+      expect(h.registry.get(NAME)).toBeUndefined();
+      expect(await h.stateStore.get(NAME)).toBeNull();
+
+      // The probe sees the deduped, sorted union of all four tenancy lists.
+      expect(probed).toEqual([TENANT_TABLES]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // The other direction: declaring tables that were never created would point
+  // core's cascade/export SQL at nonexistent relations.
+  it('publishes nothing when the built-in has no tables on the database', async () => {
+    const warn = captureWarnings();
+    try {
+      const h = createHarness({
+        builtins: [tenantedBuiltin()],
+        ports: { anyDeclaredTableExists: async () => false },
+      });
+      await h.load();
+
+      expect(h.calls).toEqual([]);
+      expect(h.migrationSqlOpens.count).toBe(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('skips the probe entirely for a built-in that declares no tenancy tables', async () => {
+    const warn = captureWarnings();
+    try {
+      const h = createHarness();
+      await h.load();
+      expect(h.calls).not.toContain('probe');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // The one-delivery-path gate is not flag-aware on purpose: a collision is a
+  // misconfiguration whether or not this deployment switched the built-in on.
+  it('still fails boot on a delivery-path collision while disabled', async () => {
+    const warn = captureWarnings();
+    try {
+      const h = createHarness({ ports: { declaredRuntimeNames: () => new Set([NAME]) } });
+      await expect(h.load()).rejects.toThrow(/extensions\.yaml/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });
 
 /**
@@ -401,6 +602,8 @@ describe('loadBuiltinExtensions', () => {
  * override), because the staged manifest is exactly what that function decides.
  */
 describe('loadBuiltinExtensions — helperRoutes staging', () => {
+  enableFixtureBuiltin();
+
   it('stages helperRoutes:true onto the manifest the registry session sees', async () => {
     const manifest = fixtureManifest();
     const h = createHarness({
@@ -434,6 +637,27 @@ describe('loadBuiltinExtensions — helperRoutes staging', () => {
 describe('BUILTIN_EXTENSION_NAMES', () => {
   it('names the workspace extension (the first and only built-in)', () => {
     expect([...BUILTIN_EXTENSION_NAMES]).toEqual(['workspace']);
+  });
+
+  /**
+   * The flag NAME is a deployment contract — it appears in .env.example, both
+   * dev composes, docker-compose.yml, the CI boot step and the deploy docs — so
+   * renaming it silently would leave every one of those switching nothing.
+   */
+  it('gates the workspace built-in on BREEZE_WORKSPACE_ENABLED, default off', () => {
+    const workspace = BUILTINS.find((builtin) => builtin.manifest.name === 'workspace');
+    expect(workspace?.enableEnvVar).toBe('BREEZE_WORKSPACE_ENABLED');
+
+    const previous = process.env.BREEZE_WORKSPACE_ENABLED;
+    try {
+      delete process.env.BREEZE_WORKSPACE_ENABLED;
+      expect(isBuiltinEnabled(workspace!)).toBe(false);
+      process.env.BREEZE_WORKSPACE_ENABLED = 'true';
+      expect(isBuiltinEnabled(workspace!)).toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env.BREEZE_WORKSPACE_ENABLED;
+      else process.env.BREEZE_WORKSPACE_ENABLED = previous;
+    }
   });
 });
 

--- a/apps/api/src/extensions/builtinExtensions.test.ts
+++ b/apps/api/src/extensions/builtinExtensions.test.ts
@@ -235,6 +235,10 @@ function createHarness(overrides: {
   const migrationSqlOpens = { count: 0 };
   const rateLimitPrefixes: string[] = [];
   const registeredWebAssets: Array<{ name: string; asset: RegisterableExtensionWebAsset }> = [];
+  /** Every manifest handed to publishTenancy — the declaration that goes LIVE. */
+  const publishedTenancy: ExtensionManifestV1[] = [];
+  /** Every (name, declaration) pair the RLS tripwire port was asked to verify. */
+  const validatedTenancy: Array<{ name: string; tenancy: ExtensionManifestV1['tenancy'] }> = [];
 
   const activate = registry.activate.bind(registry);
   vi.spyOn(registry, 'activate').mockImplementation((staged) => {
@@ -247,23 +251,38 @@ function createHarness(overrides: {
     declaredRuntimeNames: () => new Set<string>(),
     sourceCandidates: () => [],
     createMigrationSql: () => { migrationSqlOpens.count += 1; return null; },
-    runMigrations: async () => { calls.push('migration'); },
-    publishTenancy: () => { calls.push('tenancy'); },
-    anyDeclaredTableExists: async () => { calls.push('probe'); return false; },
+    runMigrations: async () => {},
+    publishTenancy: (manifest) => { calls.push('tenancy'); publishedTenancy.push(manifest); },
+    existingDeclaredTables: async () => { calls.push('probe'); return []; },
     ...(overrides.realStage ? {} : {
       stageExtension: async (_module: BreezeExtensionV1, manifest: ExtensionManifestV1) => {
         calls.push('stage');
         return fakeStaged(manifest);
       },
     }),
-    validateTenancy: async () => { calls.push('validate'); },
+    validateTenancyDeclaration: async (name, tenancy) => {
+      calls.push('validate');
+      validatedTenancy.push({ name, tenancy });
+    },
     registerRateLimitSkip: (prefix) => { rateLimitPrefixes.push(prefix); },
+    webDistExists: () => true,
     readWebDist: () => FIXTURE_WEB_ASSET,
     registerWebAsset: (name, asset) => {
       calls.push('web');
       registeredWebAssets.push({ name, asset });
     },
     ...overrides.ports,
+  };
+
+  // The migration phase records itself OUTSIDE the stub, wrapping whatever
+  // implementation survived the override merge. Tests that make migrations FAIL
+  // replace `runMigrations` wholesale, and with the recording living inside the
+  // default stub those tests could not tell "stopped AT the migration phase"
+  // from "never got there".
+  const runMigrations = ports.runMigrations!;
+  ports.runMigrations = async (builtin, sql, stateStore) => {
+    calls.push('migration');
+    await runMigrations(builtin, sql, stateStore);
   };
 
   return {
@@ -273,6 +292,8 @@ function createHarness(overrides: {
     migrationSqlOpens,
     rateLimitPrefixes,
     registeredWebAssets,
+    publishedTenancy,
+    validatedTenancy,
     load: () => loadBuiltinExtensions({ registry, stateStore, ports }),
   };
 }
@@ -373,19 +394,25 @@ describe('loadBuiltinExtensions', () => {
   });
 
   it('production boot fails when the web dist is missing; dev warns and skips web asset', async () => {
-    const missing = () => { throw enoent('missing /app/ee/demo-builtin/dist/web'); };
+    // The ABSENT-DIRECTORY condition is now decided by an explicit existence
+    // check, not by catching ENOENT around the whole operation — so this is
+    // what a missing bundle looks like, and `readWebDist` is never reached.
+    const noWebDir = { webDistExists: () => false, readWebDist: () => { throw new Error('must not be called'); } };
 
     vi.stubEnv('NODE_ENV', 'production');
     try {
-      const prod = createHarness({ ports: { readWebDist: missing } });
-      await expect(prod.load()).rejects.toThrow(/missing \/app\/ee\/demo-builtin\/dist\/web/);
+      const prod = createHarness({ ports: noWebDir });
+      const error = await prod.load().then(() => null, (e: unknown) => e as Error);
+      expect(error?.message).toContain('misbuilt');
+      expect(error?.message).toMatch(/dist[/\\]web/);
+      expect(error?.message).toContain('build:web');
     } finally {
       vi.unstubAllEnvs();
     }
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const dev = createHarness({ ports: { readWebDist: missing } });
+      const dev = createHarness({ ports: noWebDir });
       await expect(dev.load()).resolves.toBeUndefined();
 
       // Server routes still activate — API-only development needs no web build.
@@ -401,17 +428,28 @@ describe('loadBuiltinExtensions', () => {
     }
   });
 
-  // A non-ENOENT failure is a real fault (permissions, corrupt tree) and must
-  // never be downgraded to a dev warning.
-  it('propagates a non-ENOENT web-dist failure even outside production', async () => {
+  // A failure from a PRESENT web dist is a real fault (permissions, a file
+  // vanishing mid-walk, a corrupt tree) and must never be downgraded to a dev
+  // warning — including when it happens to carry `code: 'ENOENT'`, which the
+  // previous catch-based shape swallowed outside production.
+  it.each([
+    ['a permissions failure', Object.assign(new Error('permission denied'), { code: 'EACCES' })],
+    ['an ENOENT mid-walk (a file vanished under the walker)', enoent('ENOENT: no such file, open .../dist/web/chunk.js')],
+  ])('propagates %s from a PRESENT web dist even outside production', async (_label, boom) => {
+    const h = createHarness({
+      ports: { webDistExists: () => true, readWebDist: () => { throw boom; } },
+    });
+    await expect(h.load()).rejects.toBe(boom);
+  });
+
+  // The registration itself is not inside a lenient branch either.
+  it('propagates a web-asset registration failure', async () => {
     const h = createHarness({
       ports: {
-        readWebDist: () => {
-          throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
-        },
+        registerWebAsset: () => { throw enoent('registry write failed'); },
       },
     });
-    await expect(h.load()).rejects.toThrow(/permission denied/);
+    await expect(h.load()).rejects.toThrow(/registry write failed/);
   });
 
   /**
@@ -435,6 +473,15 @@ describe('loadBuiltinExtensions', () => {
     // The original text survives, and so does the original error as `cause`.
     expect(error?.message).toContain('extension "vector" is not available');
     expect((error?.cause as Error)?.message).toBe('extension "vector" is not available');
+
+    // A failed migration aborts the pipeline AT the migration phase: nothing
+    // downstream ran, so no tenancy was published for tables that do not exist,
+    // nothing is live, and no `installed_extensions` row was seeded claiming an
+    // active version. (This is the state the DISABLED path then has to survive
+    // on the next boot — see the partial-schema test below.)
+    expect(h.calls).toEqual(['migration']);
+    expect(h.registry.get(NAME)).toBeUndefined();
+    expect(await h.stateStore.get(NAME)).toBeNull();
   });
 
   it('rethrows an unrelated migration failure untouched', async () => {
@@ -442,6 +489,10 @@ describe('loadBuiltinExtensions', () => {
     const h = createHarness({ ports: { runMigrations: async () => { throw boom; } } });
 
     await expect(h.load()).rejects.toBe(boom);
+
+    expect(h.calls).toEqual(['migration']);
+    expect(h.registry.get(NAME)).toBeUndefined();
+    expect(await h.stateStore.get(NAME)).toBeNull();
   });
 });
 
@@ -498,6 +549,10 @@ describe('loadBuiltinExtensions — deployment enable flag', () => {
       expect(line).toContain('builtin_extension_disabled');
       expect(line).toContain(`"extension":"${NAME}"`);
       expect(line).toContain(`"enableFlag":"${ENABLE_ENV_VAR}"`);
+      // UNSET is reported as an explicit null, not an empty string, so it reads
+      // differently from a flag that was set to something wrong.
+      expect(line).toContain('"observedValue":null');
+      expect(line).toContain('opt-in per deployment');
     } finally {
       warn.mockRestore();
     }
@@ -519,31 +574,63 @@ describe('loadBuiltinExtensions — deployment enable flag', () => {
     },
   );
 
+  /**
+   * `BREEZE_WORKSPACE_ENABLED=1` looks enabled to a human reading the compose
+   * file, and the old skip line said only "this one is not enabled" — which
+   * reads as a lie to the operator who just set it. The value-strictness has to
+   * be in the log, along with what was actually observed.
+   */
+  it.each(['1', 'TRUE', 'yes', 'false', ''])(
+    'reports the observed value and a value-strict reason when the flag is set to %o',
+    async (value) => {
+      process.env[ENABLE_ENV_VAR] = value;
+      const warn = captureWarnings();
+      try {
+        await createHarness().load();
+
+        const line = warn.mock.calls[0]!.join(' ');
+        expect(line).toContain(`"observedValue":${JSON.stringify(value)}`);
+        expect(line).toContain('is SET but is not the exact string');
+        expect(line).toContain('value-strict');
+        // ...and NOT the never-configured wording.
+        expect(line).not.toContain('opt-in per deployment');
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
+
   // A previously-enabled deployment left `demo_*` on the database. Without the
   // declaration, the loader's and the reconciler's unaccounted-public-tables
   // sweeps abort boot on those tables, and org-deletion cascades skip them.
-  it('publishes tenancy — and ONLY tenancy — when the built-in left tables behind', async () => {
+  it('publishes tenancy — and ONLY tenancy (plus its RLS check) — when the built-in left tables behind', async () => {
     const warn = captureWarnings();
     try {
       const probed: Array<readonly string[]> = [];
       const h = createHarness({
         builtins: [tenantedBuiltin()],
         ports: {
-          anyDeclaredTableExists: async (tables) => {
+          existingDeclaredTables: async (tables) => {
             probed.push(tables);
-            return true;
+            return [...tables];
           },
         },
       });
       await h.load();
 
-      expect(h.calls).toEqual(['tenancy']);
+      expect(h.calls).toEqual(['tenancy', 'validate']);
       expect(h.migrationSqlOpens.count).toBe(0);
       expect(h.registry.get(NAME)).toBeUndefined();
       expect(await h.stateStore.get(NAME)).toBeNull();
 
       // The probe sees the deduped, sorted union of all four tenancy lists.
       expect(probed).toEqual([TENANT_TABLES]);
+
+      // Everything present: the declaration goes out WHOLE, and no
+      // partial-schema warning is emitted.
+      expect(h.publishedTenancy[0]?.tenancy).toEqual(tenantedBuiltin().manifest.tenancy);
+      const warnings = warn.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(warnings).not.toContain('builtin_extension_partial_schema');
     } finally {
       warn.mockRestore();
     }
@@ -556,12 +643,118 @@ describe('loadBuiltinExtensions — deployment enable flag', () => {
     try {
       const h = createHarness({
         builtins: [tenantedBuiltin()],
-        ports: { anyDeclaredTableExists: async () => false },
+        ports: { existingDeclaredTables: async () => [] },
       });
       await h.load();
 
       expect(h.calls).toEqual([]);
       expect(h.migrationSqlOpens.count).toBe(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  /**
+   * THE PARTIAL-SCHEMA CASE — the state a failed enabled boot actually leaves
+   * behind, and the one the old boolean probe could not represent.
+   *
+   * Enabling the built-in on a database that cannot satisfy its migrations
+   * aborts boot part-way through the file sequence, so the files that committed
+   * leave their tables and the rest never run. (Workspace on stock Postgres:
+   * three files apply, the fourth dies on `CREATE EXTENSION vector`.) Unsetting
+   * the flag then reaches this path with SOME tables present — and a yes/no
+   * probe answered "yes", which published the WHOLE manifest declaration and
+   * pointed org-cascade and tenant-export SQL at relations that were never
+   * created. Only the present subset may be declared.
+   */
+  it('publishes a FILTERED declaration — and warns — when only SOME of the tables exist', async () => {
+    const warn = captureWarnings();
+    try {
+      const h = createHarness({
+        builtins: [tenantedBuiltin()],
+        // `demo_projects`' migration never committed; `demo_files`' did.
+        ports: { existingDeclaredTables: async () => ['demo_files'] },
+      });
+      await h.load();
+
+      expect(h.calls).toEqual(['tenancy', 'validate']);
+
+      // Every one of the four lists is narrowed to the tables that EXIST —
+      // `demo_projects` appears in none of them.
+      const published = h.publishedTenancy[0]?.tenancy;
+      expect(published).toEqual({
+        orgCascadeDeleteTables: ['demo_files'],
+        deviceCascadeDeleteTables: ['demo_files'],
+        deviceOrgDenormalizedTables: [],
+        deviceOrgMoveDeleteTables: ['demo_files'],
+      });
+      expect(JSON.stringify(published)).not.toContain('demo_projects');
+
+      // The RLS tripwire runs over the SAME filtered declaration — asserting the
+      // manifest's whole tenancy here would fail on the table that isn't there,
+      // and skipping the assertion would leave an orphaned table holding tenant
+      // rows with no boot-time RLS check at all.
+      expect(h.validatedTenancy).toEqual([{ name: NAME, tenancy: published }]);
+
+      // ...and the half-migrated state is an operator problem, not a silent one.
+      const warnings = warn.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(warnings).toContain('builtin_extension_partial_schema');
+      expect(warnings).toContain('"presentTables":["demo_files"]');
+      expect(warnings).toContain('"missingTables":["demo_projects"]');
+      expect(warnings).toContain(`"enableFlag":"${ENABLE_ENV_VAR}"`);
+      expect(warnings).toContain('org-cascade and tenant-export will NOT cover');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // The published declaration is the object the tripwire sees, and the
+  // manifest's own tenancy must not be mutated on the way there — a later
+  // reader (builtinTenancyDeclarations, the export registry) would inherit the
+  // narrowing and forget tables that merely need their migration re-run.
+  it('leaves the built-in\'s own manifest tenancy untouched while filtering', async () => {
+    const warn = captureWarnings();
+    try {
+      const builtin = tenantedBuiltin();
+      const before = structuredClone(builtin.manifest.tenancy);
+      const h = createHarness({
+        builtins: [builtin],
+        ports: { existingDeclaredTables: async () => ['demo_files'] },
+      });
+      await h.load();
+
+      expect(builtin.manifest.tenancy).toEqual(before);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  /**
+   * A probe failure on the DISABLED path is the confusing one: nothing about
+   * this built-in was asked for, so a bare postgres error reads as an
+   * unexplained boot abort. The wrap has to say which built-in, that it is
+   * switched OFF, and why a switched-off built-in queries the database at all.
+   */
+  it('wraps a probe failure with the disabled-path context, preserving the cause', async () => {
+    const warn = captureWarnings();
+    try {
+      const boom = new Error('connection refused');
+      const h = createHarness({
+        builtins: [tenantedBuiltin()],
+        ports: { existingDeclaredTables: async () => { throw boom; } },
+      });
+
+      const error = await h.load().then(() => null, (e: unknown) => e as Error);
+      expect(error?.message).toContain(NAME);
+      expect(error?.message).toContain('DISABLED');
+      expect(error?.message).toContain(ENABLE_ENV_VAR);
+      expect(error?.message).toContain('EARLIER enabled boot');
+      // Names the tables it was asking about, so the operator can check by hand.
+      expect(error?.message).toContain('demo_files');
+      expect(error?.cause).toBe(boom);
+
+      // Nothing was published on a probe we could not trust.
+      expect(h.calls).toEqual([]);
     } finally {
       warn.mockRestore();
     }

--- a/apps/api/src/extensions/builtinExtensions.test.ts
+++ b/apps/api/src/extensions/builtinExtensions.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import {
+  parseExtensionManifestV1,
+  type BreezeExtensionV1,
+  type ExtensionManifestV1,
+} from '@breeze/extension-sdk';
+import {
+  BUILTIN_EXTENSION_NAMES,
+  loadBuiltinExtensions,
+  type BuiltinExtension,
+  type BuiltinPorts,
+} from './builtinExtensions';
+import {
+  ExtensionContributionRegistry,
+  type StagedExtensionContributions,
+} from './contributionRegistry';
+import {
+  ExtensionStateStore,
+  type ExtensionStateBackend,
+  type ExtensionStateRecord,
+  type ObservedExtensionInput,
+} from './stateStore';
+import type { ExtensionLifecycleState } from '../db/schema/extensions';
+import type { RegisterableExtensionWebAsset } from './webAssets';
+
+/**
+ * The built-in loading path is exercised entirely through injected ports — the
+ * same seam `reconcileExtensions` uses — so these tests need no database, no
+ * bundle, no filesystem, and never import `@breeze/ext-workspace` themselves:
+ * the built-in LIST is itself a port, so a fixture extension stands in for the
+ * real one. Only the last suite (`BUILTIN_EXTENSION_NAMES`) looks at the real
+ * registration, and only at its name.
+ *
+ * The in-memory state backend mirrors reconciler.test.ts's (which mirrors the
+ * Drizzle backend's semantics): a fresh row is born `enabled: true` /
+ * `lifecycle_state: 'discovered'`, and re-observing an existing row never
+ * disturbs `enabled` or the lifecycle state.
+ */
+class InMemoryExtensionStateBackend implements ExtensionStateBackend {
+  private readonly rows = new Map<string, ExtensionStateRecord>();
+  private readonly floors = new Map<string, Map<string, string>>();
+
+  async upsertObserved(input: ObservedExtensionInput): Promise<void> {
+    const existing = this.rows.get(input.name);
+    if (existing) {
+      if (input.configuredVersion !== undefined) existing.configuredVersion = input.configuredVersion;
+      if (input.activeVersion !== undefined) existing.activeVersion = input.activeVersion;
+      existing.updatedAt = new Date();
+      return;
+    }
+    this.rows.set(input.name, {
+      name: input.name,
+      configuredVersion: input.configuredVersion ?? null,
+      activeVersion: input.activeVersion ?? null,
+      artifactDigest: input.digest ?? null,
+      publisherId: input.publisher ?? null,
+      manifestApiVersion: input.manifestApiVersion ?? null,
+      serverSdkVersion: input.serverSdkVersion ?? null,
+      webSdkVersion: input.webSdkVersion ?? null,
+      enabled: true,
+      lifecycleState: 'discovered',
+      lastErrorCategory: null,
+      lastErrorMessage: null,
+      migratedAt: null,
+      activatedAt: null,
+      updatedAt: new Date(),
+    });
+  }
+
+  async setEnabled(name: string, enabled: boolean): Promise<void> {
+    const row = this.rows.get(name);
+    if (row) { row.enabled = enabled; row.updatedAt = new Date(); }
+  }
+
+  async getRow(name: string): Promise<ExtensionStateRecord | null> {
+    const row = this.rows.get(name);
+    return row ? { ...row } : null;
+  }
+
+  async listRows(): Promise<ExtensionStateRecord[]> {
+    return [...this.rows.values()]
+      .map((row) => ({ ...row }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async recordFailure(
+    name: string,
+    state: Extract<ExtensionLifecycleState, 'failed' | 'incompatible'>,
+    category: string,
+    message: string,
+  ): Promise<void> {
+    const row = this.rows.get(name);
+    if (!row) return;
+    row.lifecycleState = state;
+    row.lastErrorCategory = category;
+    row.lastErrorMessage = message;
+    row.updatedAt = new Date();
+  }
+
+  async recordActive(name: string, activeVersion: string | null): Promise<void> {
+    const row = this.rows.get(name);
+    if (!row) return;
+    row.lifecycleState = 'active';
+    row.lastErrorCategory = null;
+    row.lastErrorMessage = null;
+    row.activatedAt = new Date();
+    row.updatedAt = new Date();
+    if (activeVersion !== null) row.activeVersion = activeVersion;
+  }
+
+  async insertSchemaFloor(name: string, version: string, floor: string): Promise<void> {
+    let byVersion = this.floors.get(name);
+    if (!byVersion) { byVersion = new Map(); this.floors.set(name, byVersion); }
+    byVersion.set(version, floor);
+  }
+
+  async listSchemaFloors(name: string): Promise<string[]> {
+    return [...(this.floors.get(name)?.values() ?? [])];
+  }
+}
+
+/** Fixture built-in. `routeNamespace` deliberately differs from `name` so the
+ *  rate-limit-prefix assertions prove BOTH mount forms are registered. */
+const NAME = 'demo-builtin';
+const NAMESPACE = 'demo-ns';
+const VERSION = '1.4.0';
+
+function fixtureManifest(overrides: Partial<ExtensionManifestV1> = {}): ExtensionManifestV1 {
+  return {
+    apiVersion: 'breeze.extensions/v1',
+    name: NAME,
+    version: VERSION,
+    routeNamespace: NAMESPACE,
+    requires: { breeze: '>=0.1.0', serverSdk: '^1.0.0', webSdk: '^1.0.0', capabilities: [] },
+    server: { entry: 'server/index.cjs' },
+    migrationsDir: 'migrations',
+    schemaCompatibilityFloor: '1.0.0',
+    publicRoutes: [],
+    agentRoutes: true,
+    jobs: [],
+    aiTools: [],
+    tenancy: {
+      orgCascadeDeleteTables: [],
+      deviceCascadeDeleteTables: [],
+      deviceOrgDenormalizedTables: [],
+      deviceOrgMoveDeleteTables: [],
+    },
+    ...overrides,
+  } as unknown as ExtensionManifestV1;
+}
+
+function fixtureModule(): BreezeExtensionV1 {
+  return {
+    register(registrar) {
+      const app = new Hono();
+      app.get('/health', (c) => c.json({ ok: true }));
+      registrar.mountRoute(app);
+    },
+  };
+}
+
+function fixtureBuiltin(overrides: Partial<BuiltinExtension> = {}): BuiltinExtension {
+  return {
+    module: fixtureModule(),
+    manifest: fixtureManifest(),
+    packageDir: 'ee/demo-builtin',
+    packageName: '@breeze/ext-demo-builtin',
+    helperRoutes: false,
+    ...overrides,
+  };
+}
+
+function fakeStaged(manifest: ExtensionManifestV1): StagedExtensionContributions {
+  return {
+    name: manifest.name,
+    version: manifest.version,
+    manifest,
+    routeApp: { composeInto: () => {} },
+    jobs: new Map(),
+    aiTools: new Map(),
+    enabled: true,
+  };
+}
+
+const FIXTURE_WEB_ASSET: RegisterableExtensionWebAsset = {
+  root: '/app/ee/demo-builtin/dist',
+  digest: `sha256:${'b'.repeat(64)}`,
+  files: new Map([['web/index.js', { sha256: 'c'.repeat(64), uncompressedSize: 12 }]]),
+};
+
+function enoent(message: string): Error {
+  return Object.assign(new Error(message), { code: 'ENOENT' });
+}
+
+/**
+ * Every phase is a recording stub, and `registry.activate` is recorded into the
+ * SAME ordered log — so the phase order (migration → tenancy → stage → validate
+ * → activate) is provable rather than merely plausible.
+ */
+function createHarness(overrides: {
+  builtins?: readonly BuiltinExtension[];
+  stateStore?: ExtensionStateStore;
+  /** Drive the REAL `defaultStageExtension` instead of the recording stub. */
+  realStage?: boolean;
+  ports?: Partial<BuiltinPorts>;
+} = {}) {
+  const registry = new ExtensionContributionRegistry();
+  const stateStore = overrides.stateStore
+    ?? new ExtensionStateStore(new InMemoryExtensionStateBackend());
+  const calls: string[] = [];
+  const rateLimitPrefixes: string[] = [];
+  const registeredWebAssets: Array<{ name: string; asset: RegisterableExtensionWebAsset }> = [];
+
+  const activate = registry.activate.bind(registry);
+  vi.spyOn(registry, 'activate').mockImplementation((staged) => {
+    calls.push('activate');
+    activate(staged);
+  });
+
+  const ports: Partial<BuiltinPorts> = {
+    builtins: overrides.builtins ?? [fixtureBuiltin()],
+    declaredRuntimeNames: () => new Set<string>(),
+    sourceCandidates: () => [],
+    createMigrationSql: () => null,
+    runMigrations: async () => { calls.push('migration'); },
+    publishTenancy: () => { calls.push('tenancy'); },
+    ...(overrides.realStage ? {} : {
+      stageExtension: async (_module: BreezeExtensionV1, manifest: ExtensionManifestV1) => {
+        calls.push('stage');
+        return fakeStaged(manifest);
+      },
+    }),
+    validateTenancy: async () => { calls.push('validate'); },
+    registerRateLimitSkip: (prefix) => { rateLimitPrefixes.push(prefix); },
+    readWebDist: () => FIXTURE_WEB_ASSET,
+    registerWebAsset: (name, asset) => {
+      calls.push('web');
+      registeredWebAssets.push({ name, asset });
+    },
+    ...overrides.ports,
+  };
+
+  return {
+    registry,
+    stateStore,
+    calls,
+    rateLimitPrefixes,
+    registeredWebAssets,
+    load: () => loadBuiltinExtensions({ registry, stateStore, ports }),
+  };
+}
+
+describe('loadBuiltinExtensions', () => {
+  it('activates a built-in through the staged pipeline with enabled=true on first boot', async () => {
+    const h = createHarness();
+    await h.load();
+
+    // Phase order, proven by the recording stubs' call sequence.
+    expect(h.calls).toEqual(['migration', 'tenancy', 'stage', 'validate', 'activate', 'web']);
+
+    const snapshot = h.registry.get(NAME);
+    expect(snapshot?.enabled).toBe(true);
+    expect(snapshot?.version).toBe(VERSION);
+
+    // First boot seeds the row and defaults it ENABLED, then marks it active.
+    const row = await h.stateStore.get(NAME);
+    expect(row?.enabled).toBe(true);
+    expect(row?.activeVersion).toBe(VERSION);
+    expect(row?.lifecycleState).toBe('active');
+
+    expect(h.registeredWebAssets).toEqual([{ name: NAME, asset: FIXTURE_WEB_ASSET }]);
+  });
+
+  it('respects a persisted enabled=false on later boots', async () => {
+    const stateStore = new ExtensionStateStore(new InMemoryExtensionStateBackend());
+    // A prior boot observed it; an operator then disabled it.
+    await stateStore.upsertObserved({ name: NAME, activeVersion: VERSION });
+    await stateStore.setEnabled(NAME, false);
+
+    const setEnabled = vi.spyOn(stateStore, 'setEnabled');
+    const h = createHarness({ stateStore });
+    await h.load();
+
+    // The routes activate but the snapshot is DISABLED, so the enabled gate
+    // 404s them — and the persisted flag was never rewritten.
+    expect(h.registry.get(NAME)?.enabled).toBe(false);
+    expect(setEnabled).not.toHaveBeenCalled();
+    expect((await stateStore.get(NAME))?.enabled).toBe(false);
+  });
+
+  it('fails boot when extensions.yaml declares a built-in name', async () => {
+    const h = createHarness({ ports: { declaredRuntimeNames: () => new Set([NAME]) } });
+
+    await expect(h.load()).rejects.toThrow(/built-in/i);
+    await expect(h.load()).rejects.toThrow(/extensions\.yaml/);
+
+    // Fails BEFORE any phase runs: nothing migrated, nothing staged, nothing live.
+    expect(h.calls).toEqual([]);
+    expect(h.registry.get(NAME)).toBeUndefined();
+  });
+
+  it('fails boot when a legacy source dir shadows a built-in name', async () => {
+    const h = createHarness({ ports: { sourceCandidates: () => [NAME] } });
+
+    await expect(h.load()).rejects.toThrow(/built-in/i);
+    await expect(h.load()).rejects.toThrow(/source director/i);
+
+    expect(h.calls).toEqual([]);
+    expect(h.registry.get(NAME)).toBeUndefined();
+  });
+
+  it('registers agent rate-limit skip prefixes when agentRoutes is true', async () => {
+    const h = createHarness();
+    await h.load();
+
+    expect(h.rateLimitPrefixes).toEqual([
+      `/api/v1/ext/${NAME}/agent/`,
+      `/api/v1/${NAMESPACE}/agent/`,
+    ]);
+  });
+
+  it('registers no rate-limit skip prefixes when agentRoutes is false', async () => {
+    const h = createHarness({
+      builtins: [fixtureBuiltin({ manifest: fixtureManifest({ agentRoutes: false }) })],
+    });
+    await h.load();
+
+    expect(h.rateLimitPrefixes).toEqual([]);
+  });
+
+  it('production boot fails when the web dist is missing; dev warns and skips web asset', async () => {
+    const missing = () => { throw enoent('missing /app/ee/demo-builtin/dist/web'); };
+
+    vi.stubEnv('NODE_ENV', 'production');
+    try {
+      const prod = createHarness({ ports: { readWebDist: missing } });
+      await expect(prod.load()).rejects.toThrow(/missing \/app\/ee\/demo-builtin\/dist\/web/);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const dev = createHarness({ ports: { readWebDist: missing } });
+      await expect(dev.load()).resolves.toBeUndefined();
+
+      // Server routes still activate — API-only development needs no web build.
+      expect(dev.registry.get(NAME)?.enabled).toBe(true);
+      expect(dev.registeredWebAssets).toEqual([]);
+      expect(dev.calls).not.toContain('web');
+
+      const warning = warn.mock.calls.map((args) => args.join(' ')).join('\n');
+      expect(warning).toContain('builtin_web_dist_missing');
+      expect(warning).toContain('build:web');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // A non-ENOENT failure is a real fault (permissions, corrupt tree) and must
+  // never be downgraded to a dev warning.
+  it('propagates a non-ENOENT web-dist failure even outside production', async () => {
+    const h = createHarness({
+      ports: {
+        readWebDist: () => {
+          throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+        },
+      },
+    });
+    await expect(h.load()).rejects.toThrow(/permission denied/);
+  });
+});
+
+/**
+ * Restores the `/helper/*` auth coverage that was dropped along with the
+ * workspace legacy manifest: the gateway keys core helper auth off the
+ * `helperRoutes` flag on the STAGED manifest (gateway.ts), while the flag is
+ * NOT part of the strict v1 wire schema. Both halves must hold at once —
+ * gateway-visible flag present, strict parse of the clean manifest unpolluted.
+ *
+ * These use the REAL `defaultStageExtension` (no `stageExtension` port
+ * override), because the staged manifest is exactly what that function decides.
+ */
+describe('loadBuiltinExtensions — helperRoutes staging', () => {
+  it('stages helperRoutes:true onto the manifest the registry session sees', async () => {
+    const manifest = fixtureManifest();
+    const h = createHarness({
+      builtins: [fixtureBuiltin({ manifest, helperRoutes: true })],
+      realStage: true,
+    });
+    await h.load();
+
+    const staged = h.registry.get(NAME)?.manifest as
+      (ExtensionManifestV1 & { helperRoutes?: boolean }) | undefined;
+    expect(staged?.helperRoutes).toBe(true);
+
+    // ...and the CLEAN manifest is untouched, so the strict v1 parse still passes.
+    expect(Object.hasOwn(manifest, 'helperRoutes')).toBe(false);
+    expect(() => parseExtensionManifestV1(manifest)).not.toThrow();
+  });
+
+  it('leaves the staged manifest unflagged when the built-in does not opt in', async () => {
+    const h = createHarness({
+      builtins: [fixtureBuiltin({ helperRoutes: false })],
+      realStage: true,
+    });
+    await h.load();
+
+    const staged = h.registry.get(NAME)?.manifest as
+      (ExtensionManifestV1 & { helperRoutes?: boolean }) | undefined;
+    expect(staged?.helperRoutes).toBeUndefined();
+  });
+});
+
+describe('BUILTIN_EXTENSION_NAMES', () => {
+  it('names the workspace extension (the first and only built-in)', () => {
+    expect([...BUILTIN_EXTENSION_NAMES]).toEqual(['workspace']);
+  });
+});

--- a/apps/api/src/extensions/builtinExtensions.ts
+++ b/apps/api/src/extensions/builtinExtensions.ts
@@ -1,0 +1,381 @@
+// The startup loading path for BUILT-IN extensions: first-party extensions that
+// are compiled into the core image and imported statically, rather than
+// acquired as signed runtime bundles.
+//
+// It mirrors the reconciler's phase order for everything that still applies —
+// migration → tenancy → stage → validate → activate → web asset — and drops the
+// phases that only make sense for a third-party artifact (acquire / trust /
+// verify / extract / load): the code is already here, already ours, already
+// covered by the core image's own supply chain.
+//
+// Failure policy differs from `reconcileExtensions` on purpose. A runtime bundle
+// may be OPTIONAL, so its failure is recorded and stepped over. A built-in is
+// first-party REQUIRED code shipped inside the image: any phase failure
+// propagates and aborts boot. There is no half-working built-in state to
+// preserve, and silently degrading one would hide a broken image.
+//
+// Every I/O seam is an injectable PORT (the same seam `reconcileExtensions`
+// uses), so these behaviors are unit-testable with no bundle, filesystem or DB —
+// including the built-in LIST itself, so tests never load the real extension.
+import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres from 'postgres';
+import {
+  parseExtensionManifestV1,
+  type BreezeExtensionV1,
+  type ExtensionManifestV1,
+} from '@breeze/extension-sdk';
+import workspaceExtension from '@breeze/ext-workspace';
+import type {
+  ExtensionContributionRegistry,
+  StagedExtensionContributions,
+} from './contributionRegistry';
+import type { ExtensionStateStore } from './stateStore';
+import { defaultStageExtension } from './reconciler';
+import { reconcileExtensionMigrations, type MigratableExtension } from './migrator';
+import { registerRuntimeExtensionTenancy } from './tenancyRegistry';
+import { assertExtensionTenancyRls } from './tenancyTripwire';
+import { registerExtensionWebAsset, type RegisterableExtensionWebAsset } from './webAssets';
+import { declaredRuntimeExtensionNames } from './loader';
+import { listSourceExtensionCandidates, resolveExtensionsRoot } from './discovery';
+import { registerGlobalRateLimitSkipPrefix } from '../middleware/globalRateLimit';
+
+/** One statically-imported, first-party extension. */
+export interface BuiltinExtension {
+  /** The v1 module, imported at build time into the core bundle. */
+  module: BreezeExtensionV1;
+  /** Its parsed v1 manifest (read from the package's manifest.json). */
+  manifest: ExtensionManifestV1;
+  /** Package dir under the repo/image root, e.g. 'ee/workspace'. */
+  packageDir: string;
+  /** Package name, used only to name the build command in operator messages. */
+  packageName: string;
+  /**
+   * Opt in to core helper auth on `/helper/*` (the legacy `helperRoutes` flag
+   * the gateway reads off the STAGED manifest; see defaultStageExtension).
+   */
+  helperRoutes: boolean;
+}
+
+/**
+ * Resolve `<repo or image root>/<packageDir>`. Dev walks up from this file
+ * (src/extensions → apps/api → apps → repo); the CJS Docker bundle falls back to
+ * cwd (`/app`), where the Dockerfile copies `ee/<name>/{migrations,dist}`. Same
+ * pattern as discovery.ts's `resolveExtensionsRoot`.
+ */
+export function resolveBuiltinRoot(packageDir: string): string {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const fromSource = path.resolve(path.dirname(thisFile), '..', '..', '..', '..', packageDir);
+    if (existsSync(fromSource)) return fromSource;
+  } catch {
+    // CJS bundle: the import.meta shim may not resolve to a real path.
+  }
+  return path.join(process.cwd(), packageDir);
+}
+
+function loadBuiltinManifest(root: string): ExtensionManifestV1 {
+  return parseExtensionManifestV1(
+    JSON.parse(readFileSync(path.join(root, 'manifest.json'), 'utf8')),
+  );
+}
+
+/**
+ * The built-in's migration files, read from the package directory. A built-in
+ * has no signed inventory to read them out of: the files ship inside the core
+ * image, so the image itself is the integrity boundary.
+ */
+function readDiskMigrations(
+  root: string,
+  migrationsDir: string,
+): MigratableExtension['migrations'] {
+  const dir = path.join(root, migrationsDir);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort((a, b) => a.localeCompare(b))
+    .map((filename) => ({ filename, sql: readFileSync(path.join(dir, filename), 'utf8') }));
+}
+
+/**
+ * Hash `<pkg>/dist/web` at boot into the inventory shape
+ * {@link registerExtensionWebAsset} expects — members named `web/<relpath>`,
+ * root `<pkg>/dist` — with a digest over the sorted inventory so the
+ * digest-addressed asset route stays cache-coherent across deploys (a built-in
+ * has no signed `artifactDigest` to borrow).
+ *
+ * Throws an ENOENT-coded error when the web bundle was never built.
+ */
+export function readWebDist(root: string): RegisterableExtensionWebAsset {
+  const distRoot = path.join(root, 'dist');
+  const webDir = path.join(distRoot, 'web');
+  if (!existsSync(webDir)) {
+    throw Object.assign(new Error(`missing ${webDir}`), { code: 'ENOENT' });
+  }
+  const files = new Map<string, { sha256: string; uncompressedSize: number }>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+        continue;
+      }
+      const bytes = readFileSync(full);
+      files.set(path.relative(distRoot, full).split(path.sep).join('/'), {
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+        uncompressedSize: bytes.length,
+      });
+    }
+  };
+  walk(webDir);
+  const digest = createHash('sha256')
+    .update([...files.keys()].sort().map((key) => `${key}:${files.get(key)!.sha256}`).join('\n'))
+    .digest('hex');
+  return { root: distRoot, digest: `sha256:${digest}`, files };
+}
+
+/**
+ * The built-in registry. Adding an entry here is the ONLY way an extension
+ * becomes built-in; the collision gates below then make that name unavailable to
+ * both other delivery paths.
+ */
+const BUILTINS: readonly BuiltinExtension[] = [
+  {
+    module: workspaceExtension,
+    manifest: loadBuiltinManifest(resolveBuiltinRoot('ee/workspace')),
+    packageDir: 'ee/workspace',
+    packageName: '@breeze/ext-workspace',
+    // Workspace's /helper/* tree is called by the device helper, so it needs
+    // core helper auth rather than the user default-deny.
+    helperRoutes: true,
+  },
+];
+
+export const BUILTIN_EXTENSION_NAMES: ReadonlySet<string> = new Set(
+  BUILTINS.map((builtin) => builtin.manifest.name),
+);
+
+/**
+ * `reconcileExtensionMigrations`'s rolling-update gate refuses to apply a
+ * bundle whose schema floor is above the still-serving active version, and the
+ * escape hatch is an operator flipping `rollout: replace` in extensions.yaml.
+ * A built-in has no such entry — its code and its migrations ship together
+ * inside the core image, on the core image's own deploy cadence — so a
+ * 'rolling' gate here could only wedge boot with no way out. Built-ins
+ * therefore migrate like core migrations do (autoMigrate applies core SQL with
+ * no such gate): raising a built-in's `schemaCompatibilityFloor` is a breaking
+ * change that must be coordinated with the core deploy, exactly as a breaking
+ * core migration is.
+ */
+const BUILTIN_MIGRATION_ROLLOUT = 'replace' as const;
+
+/**
+ * Every I/O seam the built-in loader touches, as a port — mirroring
+ * {@link import('./reconciler').ReconcilePorts}. Production builds the real set
+ * via {@link buildDefaultPorts}; tests inject fakes.
+ */
+export interface BuiltinPorts {
+  /** The built-ins to load. A port so tests never import the real package. */
+  builtins: readonly BuiltinExtension[];
+  /** Names declared in the runtime deployment config (extensions.yaml). */
+  declaredRuntimeNames(): ReadonlySet<string>;
+  /** Legacy source-directory extension names present on disk. */
+  sourceCandidates(): readonly string[];
+  /** The privileged migration connection, opened once and closed in a finally. */
+  createMigrationSql(): postgres.Sql | null;
+  runMigrations(
+    builtin: BuiltinExtension,
+    sql: postgres.Sql | null,
+    stateStore: ExtensionStateStore,
+  ): Promise<void>;
+  publishTenancy(manifest: ExtensionManifestV1): void;
+  stageExtension(
+    module: BreezeExtensionV1,
+    manifest: ExtensionManifestV1,
+    opts: { helperRoutes: boolean },
+  ): Promise<StagedExtensionContributions>;
+  validateTenancy(
+    staged: StagedExtensionContributions,
+    manifest: ExtensionManifestV1,
+  ): Promise<void>;
+  registerRateLimitSkip(prefix: string): void;
+  readWebDist(root: string): RegisterableExtensionWebAsset;
+  registerWebAsset(name: string, asset: RegisterableExtensionWebAsset): void;
+}
+
+export interface LoadBuiltinExtensionsArgs {
+  registry: ExtensionContributionRegistry;
+  stateStore: ExtensionStateStore;
+  /** Test seam: overrides merged over {@link buildDefaultPorts}. */
+  ports?: Partial<BuiltinPorts>;
+}
+
+function buildDefaultPorts(args: LoadBuiltinExtensionsArgs): BuiltinPorts {
+  return {
+    builtins: BUILTINS,
+    declaredRuntimeNames: () => declaredRuntimeExtensionNames(resolveExtensionsRoot()),
+    sourceCandidates: () => listSourceExtensionCandidates(),
+    createMigrationSql: () => {
+      // The migration connection is privileged (it issues extension DDL). Never
+      // substitute a guessed DSN for a missing DATABASE_URL — mirroring
+      // buildDefaultPorts.createMigrationSql in reconciler.ts.
+      const databaseUrl = process.env.DATABASE_URL;
+      if (!databaseUrl) {
+        throw new Error('DATABASE_URL is required to run built-in extension migrations');
+      }
+      return postgres(databaseUrl, { max: 2 });
+    },
+    runMigrations: async (builtin, sql, stateStore) => {
+      if (!sql) throw new Error('migration client is unavailable');
+      const root = resolveBuiltinRoot(builtin.packageDir);
+      await reconcileExtensionMigrations(
+        {
+          name: builtin.manifest.name,
+          version: builtin.manifest.version,
+          schemaCompatibilityFloor: builtin.manifest.schemaCompatibilityFloor,
+          migrations: readDiskMigrations(root, builtin.manifest.migrationsDir),
+        },
+        sql,
+        stateStore,
+        BUILTIN_MIGRATION_ROLLOUT,
+      );
+    },
+    publishTenancy: (manifest) => registerRuntimeExtensionTenancy(manifest.tenancy),
+    stageExtension: (module, manifest, opts) =>
+      defaultStageExtension(module, manifest, args.registry, undefined, opts),
+    validateTenancy: (_staged, manifest) =>
+      assertExtensionTenancyRls(manifest.name, manifest.tenancy),
+    registerRateLimitSkip: registerGlobalRateLimitSkipPrefix,
+    readWebDist,
+    registerWebAsset: registerExtensionWebAsset,
+  };
+}
+
+/**
+ * One delivery path per extension name.
+ *
+ * `registry.activate()` REPLACES a same-name snapshot, so a runtime artifact
+ * reconciled after this loader would silently shadow the built-in — and a failed
+ * optional artifact would withdraw the built-in's live routes. The legacy loader
+ * enforces the same rule between its two paths (loader.ts); this extends it to
+ * the third. Both gates run before ANY phase, so a collision costs nothing but a
+ * failed boot.
+ */
+function assertNoDeliveryPathCollision(ports: BuiltinPorts): void {
+  const builtins = ports.builtins;
+  if (builtins.length === 0) return;
+
+  const runtimeNames = ports.declaredRuntimeNames();
+  const sourceNames = new Set(ports.sourceCandidates());
+  for (const { manifest } of builtins) {
+    if (runtimeNames.has(manifest.name)) {
+      throw new Error(
+        `[extensions] "${manifest.name}" is a BUILT-IN extension AND is declared as a runtime artifact in extensions.yaml; one delivery path per extension name — remove the extensions.yaml entry`,
+      );
+    }
+    if (sourceNames.has(manifest.name)) {
+      throw new Error(
+        `[extensions] "${manifest.name}" is a BUILT-IN extension AND is present as a legacy source directory; one delivery path per extension name — remove the source directory`,
+      );
+    }
+  }
+}
+
+/**
+ * Register the built-in's web bundle, or explain why it is missing.
+ *
+ * In PRODUCTION a missing `dist/web` means a misbuilt image and fails boot: the
+ * extension's pages would 404 at runtime with nothing in the logs tying it back
+ * to the build. In development it is the ordinary API-only case, so one
+ * structured warning is emitted and the server routes activate regardless. Any
+ * NON-ENOENT failure (permissions, an unreadable tree) always propagates — it is
+ * a real fault, not an absent optional build.
+ */
+function registerBuiltinWebAsset(builtin: BuiltinExtension, ports: BuiltinPorts): void {
+  const name = builtin.manifest.name;
+  try {
+    ports.registerWebAsset(name, ports.readWebDist(resolveBuiltinRoot(builtin.packageDir)));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code !== 'ENOENT' || process.env.NODE_ENV === 'production') throw error;
+    console.warn(
+      `[extensions] ${JSON.stringify({
+        event: 'builtin_web_dist_missing',
+        extension: name,
+        packageDir: builtin.packageDir,
+        message: 'built-in web bundle is not built; server routes are active but its pages will not load',
+        remedy: `pnpm --filter ${builtin.packageName} build:web`,
+      })}`,
+    );
+  }
+}
+
+/**
+ * Load every built-in extension at startup. The single entry point boot wires
+ * in; resolves when all built-ins are activated, and REJECTS (aborting boot) if
+ * any phase of any built-in fails.
+ */
+export async function loadBuiltinExtensions(args: LoadBuiltinExtensionsArgs): Promise<void> {
+  const ports: BuiltinPorts = { ...buildDefaultPorts(args), ...args.ports };
+  const { registry, stateStore } = args;
+  if (ports.builtins.length === 0) return;
+
+  assertNoDeliveryPathCollision(ports);
+
+  const sql = ports.createMigrationSql();
+  try {
+    for (const builtin of ports.builtins) {
+      const { manifest } = builtin;
+      const name = manifest.name;
+
+      await ports.runMigrations(builtin, sql, stateStore);
+
+      // Publish tenancy the instant migrations succeed — before staging — so
+      // cascade/device-move handling for the tables that now exist survives a
+      // later failure or a disable (same rationale as reconciler.ts).
+      ports.publishTenancy(manifest);
+
+      const staged = await ports.stageExtension(builtin.module, manifest, {
+        helperRoutes: builtin.helperRoutes,
+      });
+      await ports.validateTenancy(staged, manifest);
+
+      // Seed the persisted row from the manifest's facts. A built-in has no
+      // artifact digest or publisher: it is delivered by the core image itself.
+      const existing = await stateStore.get(name);
+      await stateStore.upsertObserved({
+        name,
+        configuredVersion: manifest.version,
+        activeVersion: manifest.version,
+        manifestApiVersion: manifest.apiVersion,
+        serverSdkVersion: manifest.requires.serverSdk,
+        webSdkVersion: manifest.requires.webSdk ?? null,
+      });
+      // FIRST boot only: default the runtime flag to enabled. On every later
+      // boot the persisted flag is authoritative, so an operator's disable
+      // survives restarts and deploys.
+      if (existing === null) await stateStore.setEnabled(name, true);
+
+      // Activation reads the SAME durable flag runtime bundles do, so the
+      // enabled gate, the platform-admin enable/disable surface and the
+      // per-org install gate all behave identically for a built-in.
+      registry.activate({ ...staged, enabled: await stateStore.isEnabled(name) });
+      if (staged.routeApp && manifest.agentRoutes === true) {
+        ports.registerRateLimitSkip(`/api/v1/ext/${name}/agent/`);
+        ports.registerRateLimitSkip(`/api/v1/${manifest.routeNamespace}/agent/`);
+      }
+      await stateStore.recordActive(name, manifest.version);
+
+      // NOTE: deliberately no registerExtensionRoot. Fault attribution keys on
+      // extracted-bundle stack paths; a built-in is compiled into the core
+      // image, so its faults correctly attribute to core.
+      registerBuiltinWebAsset(builtin, ports);
+
+      console.log(`[extensions] loaded built-in "${name}" ${manifest.version}`);
+    }
+  } finally {
+    if (sql) await sql.end();
+  }
+}

--- a/apps/api/src/extensions/builtinExtensions.ts
+++ b/apps/api/src/extensions/builtinExtensions.ts
@@ -5,8 +5,9 @@
 // Compiled in ≠ loaded. Each built-in carries a deployment enable flag
 // (BuiltinExtension.enableEnvVar) and is OFF by default; only an explicitly
 // enabled built-in runs the pipeline below. See skipDisabledBuiltin for what a
-// switched-off built-in still does (one log line, plus its tenancy declaration
-// if and only if its tables are already on the database).
+// switched-off built-in still does (one log line, plus a tenancy declaration
+// narrowed to whichever of its tables are actually on the database — none, some
+// or all — and the RLS tripwire over that declaration).
 //
 // It mirrors the reconciler's phase order for everything that still applies —
 // migration → tenancy → stage → validate → activate → web asset — and drops the
@@ -28,6 +29,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import postgres from 'postgres';
 import type { BreezeExtensionV1, ExtensionManifestV1 } from '@breeze/extension-sdk';
+import type { ExtensionTenancyDeclaration } from '@breeze/extension-api';
 import {
   BUILTINS,
   resolveBuiltinRoot,
@@ -135,22 +137,76 @@ export function isBuiltinEnabled(builtin: BuiltinExtension): boolean {
 /**
  * Every distinct table the manifest's tenancy declaration names, sorted — the
  * exact set that publishing the declaration would hand to core's cascade,
- * device-move and tenant-export code.
+ * device-move and tenant-export code, plus the `nonTenantTables` opt-out list.
+ *
+ * `nonTenantTables` is included deliberately even though core's cascade/export
+ * code never touches it: the RLS tripwire {@link assertExtensionTenancyRls}
+ * VERIFIES the opt-out against the live catalog and reports a declared-but-
+ * absent entry as a boot-failing problem. Since the disabled path now publishes
+ * a declaration filtered to the tables that actually exist (and asserts RLS over
+ * it), the opt-out list has to be probed and filtered alongside the four tenant
+ * lists or a partially-migrated database would abort boot on it.
  */
 function declaredTenancyTables(manifest: ExtensionManifestV1): string[] {
   const { tenancy } = manifest;
-  // `deviceOrgMoveDeleteTables` is optional in the v1 schema; the rest are not.
+  // `deviceOrgMoveDeleteTables` and `nonTenantTables` are optional in the v1
+  // schema; the other three are not.
   return [
     ...new Set([
       ...tenancy.orgCascadeDeleteTables,
       ...tenancy.deviceCascadeDeleteTables,
       ...tenancy.deviceOrgDenormalizedTables,
       ...(tenancy.deviceOrgMoveDeleteTables ?? []),
+      ...(tenancy.nonTenantTables ?? []),
     ]),
   ].sort();
 }
 
-/** The pgvector-unavailable fragment Postgres puts in `CREATE EXTENSION vector`'s error. */
+/**
+ * A copy of `tenancy` with every table LIST narrowed to the tables in `present`.
+ *
+ * Pure — no I/O, no mutation of the input — because it is the load-bearing half
+ * of the disabled path's partial-schema handling (see
+ * {@link skipDisabledBuiltin}) and has to be assertable on its own.
+ *
+ * `orgExportColumns` is deliberately left WHOLE. The export registry
+ * (`getExtensionOrgExportColumns`) iterates `orgCascadeDeleteTables` and looks
+ * each entry UP in `orgExportColumns`; a classification for a table that is no
+ * longer declared is never read, so it is inert. Dropping entries would only
+ * risk desynchronising the two halves for no benefit.
+ */
+export function filterTenancyDeclaration(
+  tenancy: ExtensionTenancyDeclaration,
+  present: ReadonlySet<string>,
+): ExtensionTenancyDeclaration {
+  const keep = (tables: readonly string[]): string[] =>
+    tables.filter((table) => present.has(table));
+  return {
+    ...tenancy,
+    orgCascadeDeleteTables: keep(tenancy.orgCascadeDeleteTables),
+    deviceCascadeDeleteTables: keep(tenancy.deviceCascadeDeleteTables),
+    deviceOrgDenormalizedTables: keep(tenancy.deviceOrgDenormalizedTables),
+    // Preserve "absent" vs "present but empty" for the two optional lists: the
+    // v1 schema distinguishes them, and manufacturing an empty array where the
+    // manifest had none would change what a downstream `?? []` observes.
+    ...(tenancy.deviceOrgMoveDeleteTables === undefined
+      ? {}
+      : { deviceOrgMoveDeleteTables: keep(tenancy.deviceOrgMoveDeleteTables) }),
+    ...(tenancy.nonTenantTables === undefined
+      ? {}
+      : { nonTenantTables: keep(tenancy.nonTenantTables) }),
+  };
+}
+
+/**
+ * The pgvector-unavailable fragment Postgres puts in `CREATE EXTENSION vector`'s
+ * error. It matches the ENGLISH server message; a server running under another
+ * `lc_messages` locale simply falls through and the operator sees the raw
+ * Postgres error, which is the safe direction. Do NOT loosen this to something
+ * locale-independent-looking (e.g. just `vector`) — a broad match would
+ * reinterpret unrelated failures as a pgvector problem and send operators after
+ * the wrong remedy.
+ */
 const PGVECTOR_UNAVAILABLE_FRAGMENT = '"vector" is not available';
 
 /**
@@ -210,25 +266,89 @@ export interface BuiltinPorts {
   ): Promise<void>;
   publishTenancy(manifest: ExtensionManifestV1): void;
   /**
-   * Do ANY of these public tables already exist? Used ONLY on the disabled
-   * path, to decide whether a switched-off built-in's tenancy declaration still
-   * has to be published (see {@link skipDisabledBuiltin}). Opens and closes its
-   * own short-lived connection — the disabled path never opens the privileged
-   * migration connection, and must not leave one behind either.
+   * WHICH of these public tables already exist — the present SUBSET, not a
+   * yes/no. Used ONLY on the disabled path, where it decides both whether a
+   * switched-off built-in's tenancy declaration still has to be published AND
+   * which tables that declaration may name (see {@link skipDisabledBuiltin}: a
+   * PARTIAL schema must publish a partial declaration, never the whole
+   * manifest's). Opens and closes its own short-lived connection — the disabled
+   * path never opens the privileged migration connection, and must not leave one
+   * behind either.
    */
-  anyDeclaredTableExists(tables: readonly string[]): Promise<boolean>;
+  existingDeclaredTables(tables: readonly string[]): Promise<string[]>;
   stageExtension(
     module: BreezeExtensionV1,
     manifest: ExtensionManifestV1,
     opts: { helperRoutes: boolean },
   ): Promise<StagedExtensionContributions>;
-  validateTenancy(
-    staged: StagedExtensionContributions,
-    manifest: ExtensionManifestV1,
+  /**
+   * The boot-time RLS tripwire over ONE tenancy declaration. Takes the
+   * declaration rather than the manifest because the disabled path asserts over
+   * a FILTERED copy (only the tables that exist), which is the declaration that
+   * actually gets published — asserting the manifest's whole tenancy there would
+   * fail on every table whose migration never ran.
+   */
+  validateTenancyDeclaration(
+    extensionName: string,
+    tenancy: ExtensionTenancyDeclaration,
   ): Promise<void>;
   registerRateLimitSkip(prefix: string): void;
+  /** Is `<root>/dist/web` present? An I/O seam, hence a port (see registerBuiltinWebAsset). */
+  webDistExists(root: string): boolean;
   readWebDist(root: string): RegisterableExtensionWebAsset;
   registerWebAsset(name: string, asset: RegisterableExtensionWebAsset): void;
+}
+
+/**
+ * The production {@link BuiltinPorts.existingDeclaredTables}: which of `tables`
+ * exist as ordinary/partitioned tables in `public`, on a short-lived connection
+ * of its own.
+ *
+ * Exported so `builtinTableProbe.integration.test.ts` can drive this exact SQL
+ * against a real server. It is the one query on the disabled path that the unit
+ * tests cannot cover — they stub the port — and the previous binding shape in
+ * this function was broken against a live Postgres while passing every unit
+ * test.
+ */
+export async function defaultExistingDeclaredTables(
+  tables: readonly string[],
+): Promise<string[]> {
+  if (tables.length === 0) return [];
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error(
+      'DATABASE_URL is required to check whether a disabled built-in extension left tables behind',
+    );
+  }
+  // ONE round trip, one connection, always closed. The names are bound as a
+  // plain scalar IN-list via postgres.js's documented `sql([...])` list helper —
+  // deliberately NO array parameter: binding a `text[]` (via sql.array or a
+  // ::json cast) mis-serialized against a real server ("malformed array
+  // literal"; caught by the live default-off boot check).
+  //
+  // `pg_class`, not `information_schema.tables`: the information_schema views
+  // are filtered by the CURRENT ROLE'S PRIVILEGES, so a table the connecting
+  // role holds no privilege on reads as ABSENT — which on this path would
+  // silently drop it from the published declaration and reintroduce exactly the
+  // unaccounted-table boot abort the declaration exists to prevent. pg_class is
+  // privilege-independent, and `relkind IN ('r','p')` says "ordinary or
+  // partitioned TABLE" precisely, with no views/matviews/indexes slipping in.
+  const sql = postgres(databaseUrl, { max: 1 });
+  try {
+    const rows = await sql<{ name: string }[]>`
+      SELECT c.relname AS name
+      FROM pg_class c
+      JOIN pg_namespace ns ON ns.oid = c.relnamespace
+      WHERE ns.nspname = 'public'
+        AND c.relkind IN ('r', 'p')
+        AND c.relname IN ${sql([...tables])}
+    `;
+    return rows.map((row) => row.name);
+  } finally {
+    // A close failure must never REPLACE the probe's own result or error: an
+    // exception thrown from a `finally` discards the in-flight one.
+    await sql.end().catch(() => {});
+  }
 }
 
 export interface LoadBuiltinExtensionsArgs {
@@ -269,38 +389,13 @@ function buildDefaultPorts(args: LoadBuiltinExtensionsArgs): BuiltinPorts {
       );
     },
     publishTenancy: (manifest) => registerRuntimeExtensionTenancy(manifest.tenancy),
-    anyDeclaredTableExists: async (tables) => {
-      if (tables.length === 0) return false;
-      const databaseUrl = process.env.DATABASE_URL;
-      if (!databaseUrl) {
-        throw new Error(
-          'DATABASE_URL is required to check whether a disabled built-in extension left tables behind',
-        );
-      }
-      // ONE round trip, one connection, always closed. The names are bound as
-      // a plain scalar IN-list via postgres.js's documented `sql([...])` list
-      // helper — deliberately NO array parameter: binding a `text[]` (via
-      // sql.array or a ::json cast) mis-serialized against a real server
-      // ("malformed array literal"; caught by the live default-off boot check —
-      // the unit tests stub this port, so only a real boot exercises this SQL).
-      const sql = postgres(databaseUrl, { max: 1 });
-      try {
-        const rows = await sql<{ present: boolean }[]>`
-          SELECT EXISTS (
-            SELECT 1 FROM information_schema.tables
-            WHERE table_schema = 'public' AND table_name IN ${sql([...tables])}
-          ) AS present
-        `;
-        return rows[0]?.present === true;
-      } finally {
-        await sql.end();
-      }
-    },
+    existingDeclaredTables: defaultExistingDeclaredTables,
     stageExtension: (module, manifest, opts) =>
       defaultStageExtension(module, manifest, args.registry, undefined, opts),
-    validateTenancy: (_staged, manifest) =>
-      assertExtensionTenancyRls(manifest.name, manifest.tenancy),
+    validateTenancyDeclaration: (extensionName, tenancy) =>
+      assertExtensionTenancyRls(extensionName, tenancy),
     registerRateLimitSkip: registerGlobalRateLimitSkipPrefix,
+    webDistExists: (root) => existsSync(path.join(root, 'dist', 'web')),
     readWebDist,
     registerWebAsset: registerExtensionWebAsset,
   };
@@ -342,27 +437,42 @@ function assertNoDeliveryPathCollision(ports: BuiltinPorts): void {
  * In PRODUCTION a missing `dist/web` means a misbuilt image and fails boot: the
  * extension's pages would 404 at runtime with nothing in the logs tying it back
  * to the build. In development it is the ordinary API-only case, so one
- * structured warning is emitted and the server routes activate regardless. Any
- * NON-ENOENT failure (permissions, an unreadable tree) always propagates — it is
- * a real fault, not an absent optional build.
+ * structured warning is emitted and the server routes activate regardless.
+ *
+ * The absent-bundle case is decided by an EXPLICIT existence check, not by
+ * catching `ENOENT` around the whole operation. Catching was too wide: a walk
+ * error inside `readWebDist` (a file vanishing mid-walk, a dangling symlink) or
+ * an ENOENT thrown by `registerWebAsset` itself would have been swallowed as
+ * "not built" in every non-production environment. Now only the one condition
+ * this policy is about — the directory is not there — takes the lenient branch;
+ * every other failure, in every environment, propagates and aborts boot.
  */
 function registerBuiltinWebAsset(builtin: BuiltinExtension, ports: BuiltinPorts): void {
   const name = builtin.manifest.name;
-  try {
-    ports.registerWebAsset(name, ports.readWebDist(resolveBuiltinRoot(builtin.packageDir)));
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException)?.code;
-    if (code !== 'ENOENT' || process.env.NODE_ENV === 'production') throw error;
+  const root = resolveBuiltinRoot(builtin.packageDir);
+  if (!ports.webDistExists(root)) {
+    const webDir = path.join(root, 'dist', 'web');
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        `[extensions] built-in "${name}" has no web bundle at ${webDir} — this image is misbuilt. ` +
+          `The release build runs "pnpm --filter ${builtin.packageName} build:web" and COPYs ` +
+          `"${builtin.packageDir}/dist" into the image; without it the extension's pages 404 at ` +
+          'runtime with nothing in the logs pointing back at the build.',
+      );
+    }
     console.warn(
       `[extensions] ${JSON.stringify({
         event: 'builtin_web_dist_missing',
         extension: name,
         packageDir: builtin.packageDir,
+        webDir,
         message: 'built-in web bundle is not built; server routes are active but its pages will not load',
         remedy: `pnpm --filter ${builtin.packageName} build:web`,
       })}`,
     );
+    return;
   }
+  ports.registerWebAsset(name, ports.readWebDist(root));
 }
 
 /**
@@ -386,27 +496,93 @@ function registerBuiltinWebAsset(builtin: BuiltinExtension, ports: BuiltinPorts)
  *     issues SQL against each one, which would now name relations that were
  *     never created.
  *
- * Hence the existence probe — one query over the whole declared list, on its
- * own connection, closed before returning.
+ * And the two cases are not exhaustive: a PARTIAL schema is a real, reachable
+ * state. Enabling the built-in on a database that cannot satisfy its migrations
+ * aborts boot mid-sequence, leaving the tables from the files that DID commit
+ * and none from the files that did not. (Concretely: workspace on a stock
+ * `postgres:16-alpine` gets three of its migration files applied and dies on the
+ * fourth's `CREATE EXTENSION vector`.) Unsetting the flag then reaches this
+ * function with SOME tables present. Publishing the manifest's WHOLE declaration
+ * there would point org-cascade and tenant-export SQL at the relations that were
+ * never created — the exact harm the second bullet describes, just triggered by
+ * a half-finished migration run instead of a never-started one.
+ *
+ * So the probe returns the present SUBSET and what gets published is a
+ * declaration FILTERED to it. That is safe in both directions: the two
+ * unaccounted-table sweeps only examine tables that EXIST, so a filtered
+ * declaration still accounts for every one of them, while cascade/export/
+ * device-move never name a missing relation. A partial set also earns a
+ * structured warning — a half-migrated built-in is an operator problem, not a
+ * steady state.
+ *
+ * Finally, the published declaration gets the SAME boot-time RLS tripwire the
+ * enabled path applies. Orphaned tables still hold tenant rows; whether the
+ * feature is switched on has no bearing on whether those rows are protected.
  */
 async function skipDisabledBuiltin(
   builtin: BuiltinExtension,
   ports: BuiltinPorts,
 ): Promise<void> {
   const { manifest } = builtin;
+  const raw = process.env[builtin.enableEnvVar];
   console.warn(
     `[extensions] ${JSON.stringify({
       event: 'builtin_extension_disabled',
       extension: manifest.name,
-      reason: 'built-in extensions are opt-in per deployment and this one is not enabled',
+      reason:
+        raw === undefined
+          ? 'built-in extensions are opt-in per deployment and this one is not enabled'
+          : `${builtin.enableEnvVar} is SET but is not the exact string "true"; the flag is ` +
+            'value-strict (no "1"/"TRUE"/"yes"), so this built-in stays OFF',
       enableFlag: builtin.enableEnvVar,
+      // Distinguishes "never configured" from "configured wrong" in the log
+      // itself, so a typo'd flag does not read identically to an absent one.
+      observedValue: raw === undefined ? null : raw,
     })}`,
   );
 
   const tables = declaredTenancyTables(manifest);
   if (tables.length === 0) return;
-  if (!(await ports.anyDeclaredTableExists(tables))) return;
-  ports.publishTenancy(manifest);
+
+  let present: readonly string[];
+  try {
+    present = await ports.existingDeclaredTables(tables);
+  } catch (error) {
+    throw new Error(
+      `[extensions] could not determine which of built-in "${manifest.name}"'s declared tables ` +
+        `exist on this database. This built-in is DISABLED (${builtin.enableEnvVar} is not "true"), ` +
+        'and the probe still runs because tables created by an EARLIER enabled boot must keep ' +
+        'their tenancy declared — otherwise the boot-time unaccounted-public-tables sweeps read ' +
+        'them as belonging to no manifest and abort, and org-deletion cascades silently skip their ' +
+        `rows. Declared tables: ${tables.join(', ')}.`,
+      { cause: error },
+    );
+  }
+  if (present.length === 0) return;
+
+  const presentSet = new Set(present);
+  const missing = tables.filter((table) => !presentSet.has(table));
+  if (missing.length > 0) {
+    console.warn(
+      `[extensions] ${JSON.stringify({
+        event: 'builtin_extension_partial_schema',
+        extension: manifest.name,
+        enableFlag: builtin.enableEnvVar,
+        presentTables: [...presentSet].sort(),
+        missingTables: missing,
+        impact:
+          'publishing only the tables that exist; org-cascade and tenant-export will NOT cover ' +
+          'the missing ones',
+        remedy:
+          `enable this built-in (${builtin.enableEnvVar}=true) on a database that satisfies its ` +
+          'requirements so its migrations finish, or drop the orphaned tables',
+      })}`,
+    );
+  }
+
+  const filteredTenancy = filterTenancyDeclaration(manifest.tenancy, presentSet);
+  ports.publishTenancy({ ...manifest, tenancy: filteredTenancy });
+  await ports.validateTenancyDeclaration(manifest.name, filteredTenancy);
 }
 
 /**
@@ -474,7 +650,7 @@ export async function loadBuiltinExtensions(args: LoadBuiltinExtensionsArgs): Pr
       const staged = await ports.stageExtension(builtin.module, manifest, {
         helperRoutes: builtin.helperRoutes,
       });
-      await ports.validateTenancy(staged, manifest);
+      await ports.validateTenancyDeclaration(name, manifest.tenancy);
 
       // Seed the persisted row from the manifest's facts. A built-in has no
       // artifact digest or publisher: it is delivered by the core image itself.
@@ -510,6 +686,19 @@ export async function loadBuiltinExtensions(args: LoadBuiltinExtensionsArgs): Pr
       console.log(`[extensions] loaded built-in "${name}" ${manifest.version}`);
     }
   } finally {
-    if (sql) await sql.end();
+    // Closing the privileged pool must never REPLACE the error that got us
+    // here: an exception out of a `finally` discards the in-flight one, so a
+    // failed close would erase (say) the pgvector diagnosis and leave the
+    // operator with a connection-teardown message instead. Still warn, so a
+    // close failure stays visible rather than vanishing.
+    if (sql) {
+      await sql.end().catch((error: unknown) => {
+        console.warn(
+          `[extensions] failed to close the built-in migration connection: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+    }
   }
 }

--- a/apps/api/src/extensions/builtinExtensions.ts
+++ b/apps/api/src/extensions/builtinExtensions.ts
@@ -20,14 +20,13 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import postgres from 'postgres';
+import type { BreezeExtensionV1, ExtensionManifestV1 } from '@breeze/extension-sdk';
 import {
-  parseExtensionManifestV1,
-  type BreezeExtensionV1,
-  type ExtensionManifestV1,
-} from '@breeze/extension-sdk';
-import workspaceExtension from '@breeze/ext-workspace';
+  BUILTINS,
+  resolveBuiltinRoot,
+  type BuiltinExtension,
+} from './builtinRegistry';
 import type {
   ExtensionContributionRegistry,
   StagedExtensionContributions,
@@ -42,45 +41,8 @@ import { declaredRuntimeExtensionNames } from './loader';
 import { listSourceExtensionCandidates, resolveExtensionsRoot } from './discovery';
 import { registerGlobalRateLimitSkipPrefix } from '../middleware/globalRateLimit';
 
-/** One statically-imported, first-party extension. */
-export interface BuiltinExtension {
-  /** The v1 module, imported at build time into the core bundle. */
-  module: BreezeExtensionV1;
-  /** Its parsed v1 manifest (read from the package's manifest.json). */
-  manifest: ExtensionManifestV1;
-  /** Package dir under the repo/image root, e.g. 'ee/workspace'. */
-  packageDir: string;
-  /** Package name, used only to name the build command in operator messages. */
-  packageName: string;
-  /**
-   * Opt in to core helper auth on `/helper/*` (the legacy `helperRoutes` flag
-   * the gateway reads off the STAGED manifest; see defaultStageExtension).
-   */
-  helperRoutes: boolean;
-}
-
-/**
- * Resolve `<repo or image root>/<packageDir>`. Dev walks up from this file
- * (src/extensions → apps/api → apps → repo); the CJS Docker bundle falls back to
- * cwd (`/app`), where the Dockerfile copies `ee/<name>/{migrations,dist}`. Same
- * pattern as discovery.ts's `resolveExtensionsRoot`.
- */
-export function resolveBuiltinRoot(packageDir: string): string {
-  try {
-    const thisFile = fileURLToPath(import.meta.url);
-    const fromSource = path.resolve(path.dirname(thisFile), '..', '..', '..', '..', packageDir);
-    if (existsSync(fromSource)) return fromSource;
-  } catch {
-    // CJS bundle: the import.meta shim may not resolve to a real path.
-  }
-  return path.join(process.cwd(), packageDir);
-}
-
-function loadBuiltinManifest(root: string): ExtensionManifestV1 {
-  return parseExtensionManifestV1(
-    JSON.parse(readFileSync(path.join(root, 'manifest.json'), 'utf8')),
-  );
-}
+export { BUILTIN_EXTENSION_NAMES, builtinTenancyDeclarations } from './builtinRegistry';
+export type { BuiltinExtension } from './builtinRegistry';
 
 /**
  * The built-in's migration files, read from the package directory. A built-in
@@ -135,27 +97,6 @@ export function readWebDist(root: string): RegisterableExtensionWebAsset {
     .digest('hex');
   return { root: distRoot, digest: `sha256:${digest}`, files };
 }
-
-/**
- * The built-in registry. Adding an entry here is the ONLY way an extension
- * becomes built-in; the collision gates below then make that name unavailable to
- * both other delivery paths.
- */
-const BUILTINS: readonly BuiltinExtension[] = [
-  {
-    module: workspaceExtension,
-    manifest: loadBuiltinManifest(resolveBuiltinRoot('ee/workspace')),
-    packageDir: 'ee/workspace',
-    packageName: '@breeze/ext-workspace',
-    // Workspace's /helper/* tree is called by the device helper, so it needs
-    // core helper auth rather than the user default-deny.
-    helperRoutes: true,
-  },
-];
-
-export const BUILTIN_EXTENSION_NAMES: ReadonlySet<string> = new Set(
-  BUILTINS.map((builtin) => builtin.manifest.name),
-);
 
 /**
  * `reconcileExtensionMigrations`'s rolling-update gate refuses to apply a
@@ -316,6 +257,24 @@ function registerBuiltinWebAsset(builtin: BuiltinExtension, ports: BuiltinPorts)
  * Load every built-in extension at startup. The single entry point boot wires
  * in; resolves when all built-ins are activated, and REJECTS (aborting boot) if
  * any phase of any built-in fails.
+ *
+ * BOOT ORDER IS PART OF THE CONTRACT: call this AFTER `loadSourceExtensions`
+ * and BEFORE `reconcileExtensions`.
+ *
+ *   • BEFORE `reconcileExtensions` — mandatory. The reconciler ends with one
+ *     repo-wide `assertNoUnaccountedPublicTables(getExtensionTenancy())` sweep
+ *     whenever extensions.yaml declares at least one extension. If built-ins
+ *     load after that sweep, their tenancy has not been published yet while
+ *     their tables already exist (created by an earlier boot's migrations), so
+ *     the sweep reads every `workspace_*` table as belonging to no manifest and
+ *     aborts. The FIRST boot would survive (no tables yet) and every boot after
+ *     it would fail — the worst possible failure shape.
+ *   • AFTER `loadSourceExtensions` — the legacy loader stages and activates the
+ *     deprecated source-directory path first; running built-ins first would let
+ *     a built-in's activation be observed by that loader's own gates. Its
+ *     repo-wide sweep is made built-in-aware through
+ *     {@link builtinTenancyDeclarations} (loader.ts), so this ordering needs no
+ *     tenancy to have been published yet.
  */
 export async function loadBuiltinExtensions(args: LoadBuiltinExtensionsArgs): Promise<void> {
   const ports: BuiltinPorts = { ...buildDefaultPorts(args), ...args.ports };

--- a/apps/api/src/extensions/builtinExtensions.ts
+++ b/apps/api/src/extensions/builtinExtensions.ts
@@ -2,6 +2,12 @@
 // are compiled into the core image and imported statically, rather than
 // acquired as signed runtime bundles.
 //
+// Compiled in ≠ loaded. Each built-in carries a deployment enable flag
+// (BuiltinExtension.enableEnvVar) and is OFF by default; only an explicitly
+// enabled built-in runs the pipeline below. See skipDisabledBuiltin for what a
+// switched-off built-in still does (one log line, plus its tenancy declaration
+// if and only if its tables are already on the database).
+//
 // It mirrors the reconciler's phase order for everything that still applies —
 // migration → tenancy → stage → validate → activate → web asset — and drops the
 // phases that only make sense for a third-party artifact (acquire / trust /
@@ -113,6 +119,77 @@ export function readWebDist(root: string): RegisterableExtensionWebAsset {
 const BUILTIN_MIGRATION_ROLLOUT = 'replace' as const;
 
 /**
+ * Is this built-in switched ON for this deployment?
+ *
+ * Strict-string convention, matching `BREEZE_LEGACY_SOURCE_EXTENSIONS` in
+ * loader.ts: anything other than the exact string `'true'` — unset, empty,
+ * `'1'`, `'TRUE'` — leaves the built-in unloaded. Default OFF is the point:
+ * being compiled into the image must not oblige every deployment to satisfy the
+ * built-in's infrastructure requirements (workspace needs pgvector) or carry its
+ * schema.
+ */
+export function isBuiltinEnabled(builtin: BuiltinExtension): boolean {
+  return process.env[builtin.enableEnvVar] === 'true';
+}
+
+/**
+ * Every distinct table the manifest's tenancy declaration names, sorted — the
+ * exact set that publishing the declaration would hand to core's cascade,
+ * device-move and tenant-export code.
+ */
+function declaredTenancyTables(manifest: ExtensionManifestV1): string[] {
+  const { tenancy } = manifest;
+  // `deviceOrgMoveDeleteTables` is optional in the v1 schema; the rest are not.
+  return [
+    ...new Set([
+      ...tenancy.orgCascadeDeleteTables,
+      ...tenancy.deviceCascadeDeleteTables,
+      ...tenancy.deviceOrgDenormalizedTables,
+      ...(tenancy.deviceOrgMoveDeleteTables ?? []),
+    ]),
+  ].sort();
+}
+
+/** The pgvector-unavailable fragment Postgres puts in `CREATE EXTENSION vector`'s error. */
+const PGVECTOR_UNAVAILABLE_FRAGMENT = '"vector" is not available';
+
+/**
+ * Run a built-in's migrations, translating ONE known-and-actionable
+ * infrastructure failure into an operator-facing error.
+ *
+ * `CREATE EXTENSION vector` on a stock Postgres image fails with a bare
+ * `extension "vector" is not available` and an SQL file name — true, but it
+ * names neither the requirement nor either way out, and it aborts boot. The
+ * match is deliberately narrow (that one message fragment); everything else
+ * rethrows untouched rather than being reinterpreted.
+ */
+async function runBuiltinMigrations(
+  builtin: BuiltinExtension,
+  sql: postgres.Sql | null,
+  stateStore: ExtensionStateStore,
+  ports: BuiltinPorts,
+): Promise<void> {
+  try {
+    await ports.runMigrations(builtin, sql, stateStore);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes(PGVECTOR_UNAVAILABLE_FRAGMENT)) throw error;
+    throw new Error(
+      [
+        `[extensions] built-in "${builtin.manifest.name}" is enabled ` +
+          `(${builtin.enableEnvVar}=true) but its migrations require the PostgreSQL ` +
+          '"vector" (pgvector) extension, which this database does not provide.',
+        'Either:',
+        '  - run a pgvector-enabled Postgres image (e.g. pgvector/pgvector:pg16), or',
+        `  - unset ${builtin.enableEnvVar} (or set it to "false") to leave this built-in unloaded.`,
+        `Original error: ${message}`,
+      ].join('\n'),
+      { cause: error },
+    );
+  }
+}
+
+/**
  * Every I/O seam the built-in loader touches, as a port — mirroring
  * {@link import('./reconciler').ReconcilePorts}. Production builds the real set
  * via {@link buildDefaultPorts}; tests inject fakes.
@@ -132,6 +209,14 @@ export interface BuiltinPorts {
     stateStore: ExtensionStateStore,
   ): Promise<void>;
   publishTenancy(manifest: ExtensionManifestV1): void;
+  /**
+   * Do ANY of these public tables already exist? Used ONLY on the disabled
+   * path, to decide whether a switched-off built-in's tenancy declaration still
+   * has to be published (see {@link skipDisabledBuiltin}). Opens and closes its
+   * own short-lived connection — the disabled path never opens the privileged
+   * migration connection, and must not leave one behind either.
+   */
+  anyDeclaredTableExists(tables: readonly string[]): Promise<boolean>;
   stageExtension(
     module: BreezeExtensionV1,
     manifest: ExtensionManifestV1,
@@ -184,6 +269,33 @@ function buildDefaultPorts(args: LoadBuiltinExtensionsArgs): BuiltinPorts {
       );
     },
     publishTenancy: (manifest) => registerRuntimeExtensionTenancy(manifest.tenancy),
+    anyDeclaredTableExists: async (tables) => {
+      if (tables.length === 0) return false;
+      const databaseUrl = process.env.DATABASE_URL;
+      if (!databaseUrl) {
+        throw new Error(
+          'DATABASE_URL is required to check whether a disabled built-in extension left tables behind',
+        );
+      }
+      // ONE round trip, one connection, always closed. The names are bound as
+      // a plain scalar IN-list via postgres.js's documented `sql([...])` list
+      // helper — deliberately NO array parameter: binding a `text[]` (via
+      // sql.array or a ::json cast) mis-serialized against a real server
+      // ("malformed array literal"; caught by the live default-off boot check —
+      // the unit tests stub this port, so only a real boot exercises this SQL).
+      const sql = postgres(databaseUrl, { max: 1 });
+      try {
+        const rows = await sql<{ present: boolean }[]>`
+          SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name IN ${sql([...tables])}
+          ) AS present
+        `;
+        return rows[0]?.present === true;
+      } finally {
+        await sql.end();
+      }
+    },
     stageExtension: (module, manifest, opts) =>
       defaultStageExtension(module, manifest, args.registry, undefined, opts),
     validateTenancy: (_staged, manifest) =>
@@ -254,9 +366,57 @@ function registerBuiltinWebAsset(builtin: BuiltinExtension, ports: BuiltinPorts)
 }
 
 /**
- * Load every built-in extension at startup. The single entry point boot wires
- * in; resolves when all built-ins are activated, and REJECTS (aborting boot) if
- * any phase of any built-in fails.
+ * The DISABLED path: everything a switched-off built-in still owes the boot,
+ * which is one log line and — conditionally — its tenancy declaration.
+ *
+ * No migrations, no staging, no activation, no `installed_extensions` row, no
+ * web-dist requirement: a deployment that never enabled this built-in must boot
+ * on plain Postgres with none of the built-in's infrastructure.
+ *
+ * Tenancy is the one exception, and it cuts BOTH ways:
+ *
+ *   • If the built-in's tables EXIST (a previous boot had it enabled and its
+ *     migrations ran), the declaration must still be published. Two sweeps —
+ *     the legacy loader's and the reconciler's repo-wide
+ *     `assertNoUnaccountedPublicTables` — would otherwise read those orphaned
+ *     `workspace_*` tables as belonging to no manifest and abort boot, and
+ *     org-deletion cascades would silently skip the rows in them.
+ *   • If they DO NOT exist, publishing is actively harmful: core cascade,
+ *     device-move and tenant-export code iterates the declared tables and
+ *     issues SQL against each one, which would now name relations that were
+ *     never created.
+ *
+ * Hence the existence probe — one query over the whole declared list, on its
+ * own connection, closed before returning.
+ */
+async function skipDisabledBuiltin(
+  builtin: BuiltinExtension,
+  ports: BuiltinPorts,
+): Promise<void> {
+  const { manifest } = builtin;
+  console.warn(
+    `[extensions] ${JSON.stringify({
+      event: 'builtin_extension_disabled',
+      extension: manifest.name,
+      reason: 'built-in extensions are opt-in per deployment and this one is not enabled',
+      enableFlag: builtin.enableEnvVar,
+    })}`,
+  );
+
+  const tables = declaredTenancyTables(manifest);
+  if (tables.length === 0) return;
+  if (!(await ports.anyDeclaredTableExists(tables))) return;
+  ports.publishTenancy(manifest);
+}
+
+/**
+ * Load every ENABLED built-in extension at startup. The single entry point boot
+ * wires in; resolves when all enabled built-ins are activated, and REJECTS
+ * (aborting boot) if any phase of any of them fails.
+ *
+ * Each built-in carries its own deployment enable flag (see
+ * {@link isBuiltinEnabled}) and is OFF unless the deployment says otherwise;
+ * a disabled one takes {@link skipDisabledBuiltin} instead of the pipeline.
  *
  * BOOT ORDER IS PART OF THE CONTRACT: call this AFTER `loadSourceExtensions`
  * and BEFORE `reconcileExtensions`.
@@ -281,15 +441,30 @@ export async function loadBuiltinExtensions(args: LoadBuiltinExtensionsArgs): Pr
   const { registry, stateStore } = args;
   if (ports.builtins.length === 0) return;
 
+  // The gate is deliberately NOT flag-aware: a built-in's name is reserved by
+  // the registry whether or not this deployment switched it on, so a colliding
+  // extensions.yaml entry or source directory is a misconfiguration to shout
+  // about either way — and shouting about it only when the flag happens to be
+  // set would make the collision surface for the first time on the day someone
+  // enables the built-in.
   assertNoDeliveryPathCollision(ports);
+
+  const enabled: BuiltinExtension[] = [];
+  for (const builtin of ports.builtins) {
+    if (isBuiltinEnabled(builtin)) enabled.push(builtin);
+    else await skipDisabledBuiltin(builtin, ports);
+  }
+  // Nothing to load: return BEFORE createMigrationSql, which both demands
+  // DATABASE_URL and opens a privileged connection.
+  if (enabled.length === 0) return;
 
   const sql = ports.createMigrationSql();
   try {
-    for (const builtin of ports.builtins) {
+    for (const builtin of enabled) {
       const { manifest } = builtin;
       const name = manifest.name;
 
-      await ports.runMigrations(builtin, sql, stateStore);
+      await runBuiltinMigrations(builtin, sql, stateStore, ports);
 
       // Publish tenancy the instant migrations succeed — before staging — so
       // cascade/device-move handling for the tables that now exist survives a

--- a/apps/api/src/extensions/builtinRegistry.test.ts
+++ b/apps/api/src/extensions/builtinRegistry.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadBuiltinManifest, resolveBuiltinRoot } from './builtinRegistry';
+
+/**
+ * Exercises `resolveBuiltinRoot` / `loadBuiltinManifest`'s candidate order
+ * against real fixture trees, faking `process.cwd()` the way a bundled API
+ * process would see it in each of the runtime contexts the resolver targets
+ * (dev tsx/vitest, both Docker images, and a bundle run from a plain repo
+ * checkout). No neighboring test in this directory fakes cwd yet, so this
+ * uses `vi.spyOn(process, 'cwd')` directly — the standard vitest seam.
+ *
+ * A fresh, never-real packageDir name is used throughout (`ee/fixture-builtin`
+ * rather than `ee/workspace`) so the resolver's REAL source-file walk-up
+ * (which points at this actual repo checkout) can never accidentally match a
+ * fixture-tree candidate or mask a miss.
+ */
+
+const MANIFEST = {
+  apiVersion: 'breeze.extensions/v1',
+  name: 'fixture-builtin',
+  version: '1.0.0',
+  routeNamespace: 'fixture-builtin',
+  requires: { breeze: '>=1.0.0', serverSdk: '^1.0.0', capabilities: [] },
+  server: { entry: 'server/index.cjs' },
+  migrationsDir: 'migrations',
+  schemaCompatibilityFloor: '1.0.0',
+  jobs: [],
+  aiTools: [],
+  tenancy: {
+    orgCascadeDeleteTables: [],
+    deviceCascadeDeleteTables: [],
+    deviceOrgDenormalizedTables: [],
+  },
+};
+
+const PACKAGE_DIR = 'ee/fixture-builtin';
+
+let root: string;
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+function scaffold(base: string): void {
+  const dir = join(base, PACKAGE_DIR);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'manifest.json'), JSON.stringify(MANIFEST));
+}
+
+describe('resolveBuiltinRoot', () => {
+  it('resolves from process.cwd() itself when the manifest sits there', () => {
+    root = mkdtempSync(join(tmpdir(), 'breeze-builtin-'));
+    scaffold(root);
+    vi.spyOn(process, 'cwd').mockReturnValue(root);
+
+    expect(resolveBuiltinRoot(PACKAGE_DIR)).toBe(join(root, PACKAGE_DIR));
+  });
+
+  it('resolves from a cwd-ancestor level (bundle run from apps/api in a checkout)', () => {
+    root = mkdtempSync(join(tmpdir(), 'breeze-builtin-'));
+    scaffold(root);
+    // Mirrors the failing CI shape: cwd = <repo>/apps/api, manifest lives at
+    // <repo>/ee/fixture-builtin, i.e. cwd/../../ee/fixture-builtin.
+    const cwd = join(root, 'apps', 'api');
+    mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+
+    expect(resolveBuiltinRoot(PACKAGE_DIR)).toBe(join(cwd, '..', '..', PACKAGE_DIR));
+  });
+
+  it('does not resolve past the bounded 3-ancestor search', () => {
+    root = mkdtempSync(join(tmpdir(), 'breeze-builtin-'));
+    scaffold(root);
+    // 4 levels up from cwd is one hop beyond the bounded search — must miss.
+    const cwd = join(root, 'a', 'b', 'c', 'd');
+    mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+
+    expect(resolveBuiltinRoot(PACKAGE_DIR)).toBe(join(cwd, PACKAGE_DIR));
+  });
+
+  it('falls back to cwd/<packageDir> when no candidate has a manifest', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'breeze-builtin-empty-'));
+    root = cwd;
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+
+    expect(resolveBuiltinRoot(PACKAGE_DIR)).toBe(join(cwd, PACKAGE_DIR));
+  });
+
+  it('ignores an empty mount-point directory that has no manifest.json', () => {
+    // A dir can exist (e.g. a mounted-but-unpopulated BREEZE_EXTENSIONS_DIR)
+    // without a manifest; the resolver must not treat dir-existence as a hit.
+    const cwd = mkdtempSync(join(tmpdir(), 'breeze-builtin-mount-'));
+    root = cwd;
+    mkdirSync(join(cwd, PACKAGE_DIR), { recursive: true }); // dir, no manifest.json
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+
+    expect(resolveBuiltinRoot(PACKAGE_DIR)).toBe(join(cwd, PACKAGE_DIR));
+  });
+});
+
+describe('loadBuiltinManifest', () => {
+  it('parses the manifest found at a cwd-ancestor level', () => {
+    root = mkdtempSync(join(tmpdir(), 'breeze-builtin-'));
+    scaffold(root);
+    const cwd = join(root, 'apps', 'api');
+    mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+
+    const manifest = loadBuiltinManifest(PACKAGE_DIR);
+    expect(manifest.name).toBe('fixture-builtin');
+    expect(manifest.version).toBe('1.0.0');
+  });
+
+  it('throws a contextual error naming the package and every candidate tried when missing everywhere', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'breeze-builtin-miss-'));
+    root = cwd;
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+
+    let thrown: unknown;
+    try {
+      loadBuiltinManifest(PACKAGE_DIR);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    // Names the package.
+    expect(message).toContain(PACKAGE_DIR);
+    // Names the cwd-rooted candidates actually tried (the source walk-up
+    // candidate points into the real repo, so it isn't asserted here).
+    expect(message).toContain(join(cwd, PACKAGE_DIR, 'manifest.json'));
+    expect(message).toContain(join(cwd, '..', PACKAGE_DIR, 'manifest.json'));
+    expect(message).toContain(join(cwd, '..', '..', PACKAGE_DIR, 'manifest.json'));
+    expect(message).toContain(join(cwd, '..', '..', '..', PACKAGE_DIR, 'manifest.json'));
+    // Names the runtime contract so the failure is diagnosable from the
+    // message alone, not a bare ENOENT.
+    expect(message).toMatch(/Dockerfile|COPY/i);
+    expect(message).toMatch(/process\.cwd\(\)/);
+  });
+
+  it('propagates a non-ENOENT read failure unwrapped (e.g. permission denied)', () => {
+    root = mkdtempSync(join(tmpdir(), 'breeze-builtin-'));
+    const dir = join(root, PACKAGE_DIR);
+    mkdirSync(dir, { recursive: true });
+    // A directory named manifest.json triggers EISDIR on read, not ENOENT —
+    // must NOT be downgraded to the "missing everywhere" message.
+    mkdirSync(join(dir, 'manifest.json'));
+    vi.spyOn(process, 'cwd').mockReturnValue(root);
+
+    expect(() => loadBuiltinManifest(PACKAGE_DIR)).toThrow(
+      /EISDIR|illegal operation/i,
+    );
+  });
+});

--- a/apps/api/src/extensions/builtinRegistry.ts
+++ b/apps/api/src/extensions/builtinRegistry.ts
@@ -36,26 +36,91 @@ export interface BuiltinExtension {
 }
 
 /**
- * Resolve `<repo or image root>/<packageDir>`. Dev walks up from this file
- * (src/extensions → apps/api → apps → repo); the CJS Docker bundle falls back to
- * cwd (`/app`), where the Dockerfile copies `ee/<name>/{manifest.json,migrations,dist}`.
- * Same pattern as discovery.ts's `resolveExtensionsRoot`.
+ * Ordered, bounded candidates for `<root>/<packageDir>`, most-trustworthy
+ * first — {@link resolveBuiltinRoot} and {@link loadBuiltinManifest} both walk
+ * this SAME list so a miss can be reported against exactly what was tried:
+ *
+ *   1. the source-file walk-up (src/extensions → apps/api → apps → repo) —
+ *      exact for dev tsx/vitest, where this file's real location is on disk.
+ *   2. `process.cwd()` — exact for both Docker images: the Dockerfile COPYs
+ *      `<packageDir>/{manifest.json,migrations,dist}` to the image root, and
+ *      the process is always started from there.
+ *   3. up to 3 ancestors of `process.cwd()` — covers running the bundle from
+ *      inside a plain repo checkout (e.g. `cwd = <repo>/apps/api`, so
+ *      `<repo>/ee/workspace` is `cwd/../../ee/workspace`).
+ *
+ * Deliberately bounded — no unbounded upward search.
  */
-export function resolveBuiltinRoot(packageDir: string): string {
+function candidateBuiltinRoots(packageDir: string): string[] {
+  const candidates: string[] = [];
   try {
     const thisFile = fileURLToPath(import.meta.url);
-    const fromSource = path.resolve(path.dirname(thisFile), '..', '..', '..', '..', packageDir);
-    if (existsSync(fromSource)) return fromSource;
+    candidates.push(path.resolve(path.dirname(thisFile), '..', '..', '..', '..', packageDir));
   } catch {
     // CJS bundle: the import.meta shim may not resolve to a real path.
+  }
+  const cwd = process.cwd();
+  candidates.push(path.join(cwd, packageDir));
+  candidates.push(path.join(cwd, '..', packageDir));
+  candidates.push(path.join(cwd, '..', '..', packageDir));
+  candidates.push(path.join(cwd, '..', '..', '..', packageDir));
+  return candidates;
+}
+
+/**
+ * Resolve `<repo or image root>/<packageDir>`: the first candidate (see
+ * {@link candidateBuiltinRoots}) whose `manifest.json` actually exists — not
+ * just the directory, so an empty mount-point dir (e.g. the prod image's
+ * `BREEZE_EXTENSIONS_DIR` mount) can never shadow the real root. Falls back to
+ * `cwd/<packageDir>` when nothing matched, so callers (and error messages)
+ * still get a sensible expected path rather than an arbitrary walk-up guess.
+ */
+export function resolveBuiltinRoot(packageDir: string): string {
+  for (const candidate of candidateBuiltinRoots(packageDir)) {
+    if (existsSync(path.join(candidate, 'manifest.json'))) return candidate;
   }
   return path.join(process.cwd(), packageDir);
 }
 
-function loadBuiltinManifest(root: string): ExtensionManifestV1 {
-  return parseExtensionManifestV1(
-    JSON.parse(readFileSync(path.join(root, 'manifest.json'), 'utf8')),
-  );
+/**
+ * Build the contextual error for a built-in whose manifest could not be found
+ * in ANY candidate root — naming the package, every path tried, and the
+ * Dockerfile/runtime contract that's supposed to guarantee one of them exists,
+ * so the failure is diagnosable from the message alone instead of a bare
+ * `ENOENT` with no indication of what root(s) were even considered.
+ */
+function missingBuiltinManifestMessage(packageDir: string): string {
+  const tried = candidateBuiltinRoots(packageDir).map((root) => path.join(root, 'manifest.json'));
+  return [
+    `[extensions] could not find manifest.json for built-in "${packageDir}". Tried:`,
+    ...tried.map((manifestPath) => `  - ${manifestPath}`),
+    '',
+    'Runtime contract: the release Dockerfile COPYs ' +
+      `"${packageDir}/{manifest.json,migrations,dist}" into the image root, so ` +
+      'process.cwd() must be the image root (typically /app) in production. ' +
+      `In a plain repo checkout, the manifest is expected at "<repo>/${packageDir}", ` +
+      'found either by walking up from this compiled file (dev) or by walking up ' +
+      'to 3 ancestors of process.cwd() (e.g. running the bundled API from apps/api).',
+  ].join('\n');
+}
+
+/**
+ * Read and parse a built-in's manifest, resolving its root the same way
+ * {@link resolveBuiltinRoot} does. A miss is NOT a bare `ENOENT` — every
+ * candidate root was already computed to resolve `root`, so re-using that list
+ * to name what was tried costs nothing and turns an opaque boot failure into
+ * an actionable one.
+ */
+export function loadBuiltinManifest(packageDir: string): ExtensionManifestV1 {
+  const root = resolveBuiltinRoot(packageDir);
+  let raw: string;
+  try {
+    raw = readFileSync(path.join(root, 'manifest.json'), 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
+    throw new Error(missingBuiltinManifestMessage(packageDir));
+  }
+  return parseExtensionManifestV1(JSON.parse(raw));
 }
 
 /**
@@ -66,7 +131,7 @@ function loadBuiltinManifest(root: string): ExtensionManifestV1 {
 export const BUILTINS: readonly BuiltinExtension[] = [
   {
     module: workspaceExtension,
-    manifest: loadBuiltinManifest(resolveBuiltinRoot('ee/workspace')),
+    manifest: loadBuiltinManifest('ee/workspace'),
     packageDir: 'ee/workspace',
     packageName: '@breeze/ext-workspace',
     // Workspace's /helper/* tree is called by the device helper, so it needs

--- a/apps/api/src/extensions/builtinRegistry.ts
+++ b/apps/api/src/extensions/builtinRegistry.ts
@@ -33,6 +33,20 @@ export interface BuiltinExtension {
    * the gateway reads off the STAGED manifest; see defaultStageExtension).
    */
   helperRoutes: boolean;
+  /**
+   * The DEPLOYMENT enable flag for this built-in. Being compiled into the image
+   * makes a built-in *available*, not *loaded*: the loading pipeline runs only
+   * when `process.env[enableEnvVar] === 'true'` (strict string, matching
+   * `BREEZE_LEGACY_SOURCE_EXTENSIONS` in loader.ts). Default OFF, so a
+   * deployment that never asks for the built-in never pays for its migrations,
+   * its infrastructure requirements (workspace needs pgvector) or its routes.
+   *
+   * This is a DIFFERENT switch from the persisted `installed_extensions.enabled`
+   * flag: that one is per-deployment operator state stored in the DB and toggled
+   * at runtime by a platform admin; this one is boot-time deployment
+   * configuration that decides whether the built-in is loaded at all.
+   */
+  enableEnvVar: string;
 }
 
 /**
@@ -137,6 +151,9 @@ export const BUILTINS: readonly BuiltinExtension[] = [
     // Workspace's /helper/* tree is called by the device helper, so it needs
     // core helper auth rather than the user default-deny.
     helperRoutes: true,
+    // Default OFF: workspace's migrations require a pgvector-enabled Postgres,
+    // which a stock `postgres:16-alpine` deployment does not have.
+    enableEnvVar: 'BREEZE_WORKSPACE_ENABLED',
   },
 ];
 
@@ -153,6 +170,17 @@ export const BUILTIN_EXTENSION_NAMES: ReadonlySet<string> = new Set(
  * (loader.ts). That sweep runs before `loadBuiltinExtensions` has published
  * anything, so without this accessor every `workspace_*` table created on an
  * earlier boot reads as belonging to no manifest and the sweep aborts boot.
+ *
+ * DELIBERATELY STATIC — it ignores {@link BuiltinExtension.enableEnvVar}, and
+ * must keep doing so. The sweep only examines tables that EXIST, so declaring a
+ * table that was never created is inert there, while gating the accessor on the
+ * enable flag would resurrect exactly the failure it was written to prevent: a
+ * deployment that enabled workspace once (creating `workspace_*`) and later
+ * unset the flag would have those tables read as unaccounted and abort boot.
+ * The narrower, existence-checked publication that the DISABLED path performs
+ * (builtinExtensions.ts) is a different thing: that one feeds the live tenancy
+ * registry, which core cascade/export code iterates and issues SQL against, so
+ * it must never name a table that does not exist.
  */
 export function builtinTenancyDeclarations(): ExtensionTenancyDeclaration[] {
   return BUILTINS.map((builtin) => builtin.manifest.tenancy);

--- a/apps/api/src/extensions/builtinRegistry.ts
+++ b/apps/api/src/extensions/builtinRegistry.ts
@@ -127,14 +127,34 @@ function missingBuiltinManifestMessage(packageDir: string): string {
  */
 export function loadBuiltinManifest(packageDir: string): ExtensionManifestV1 {
   const root = resolveBuiltinRoot(packageDir);
+  const manifestPath = path.join(root, 'manifest.json');
   let raw: string;
   try {
-    raw = readFileSync(path.join(root, 'manifest.json'), 'utf8');
+    raw = readFileSync(manifestPath, 'utf8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
     throw new Error(missingBuiltinManifestMessage(packageDir));
   }
-  return parseExtensionManifestV1(JSON.parse(raw));
+  // A FOUND-but-unreadable manifest is a different failure from a missing one,
+  // and its raw form says nothing about where it came from: `JSON.parse` throws
+  // "Unexpected end of JSON input" and the zod parse throws a path-less list of
+  // field issues. Neither names the file. This module runs at IMPORT time (see
+  // BUILTINS below), so that bare error is the entire diagnostic an operator
+  // gets for a boot that died before the first log line — hence the path, the
+  // byte length (a truncated COPY's tell) and the likely cause.
+  try {
+    return parseExtensionManifestV1(JSON.parse(raw));
+  } catch (error) {
+    throw new Error(
+      `[extensions] built-in "${packageDir}" has an unreadable manifest at ${manifestPath} ` +
+        `(${raw.length} bytes). It exists but could not be parsed as a valid v1 manifest, which ` +
+        'means a misbuilt image or a truncated/partial COPY of the package directory rather than ' +
+        `a configuration mistake. Original error: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      { cause: error },
+    );
+  }
 }
 
 /**

--- a/apps/api/src/extensions/builtinRegistry.ts
+++ b/apps/api/src/extensions/builtinRegistry.ts
@@ -1,0 +1,94 @@
+// The BUILT-IN extension registry: first-party extensions compiled into the
+// core image and imported statically.
+//
+// Deliberately a LEAF module — it imports the built-in packages, the manifest
+// parser and node fs/path, and nothing else from `src/extensions/`. The loading
+// pipeline (builtinExtensions.ts) and the legacy source loader (loader.ts) both
+// need to see this registry, and loader.ts is itself imported by
+// builtinExtensions.ts; keeping the registry here is what stops that from being
+// an import cycle.
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseExtensionManifestV1,
+  type BreezeExtensionV1,
+  type ExtensionManifestV1,
+} from '@breeze/extension-sdk';
+import type { ExtensionTenancyDeclaration } from '@breeze/extension-api';
+import workspaceExtension from '@breeze/ext-workspace';
+
+/** One statically-imported, first-party extension. */
+export interface BuiltinExtension {
+  /** The v1 module, imported at build time into the core bundle. */
+  module: BreezeExtensionV1;
+  /** Its parsed v1 manifest (read from the package's manifest.json). */
+  manifest: ExtensionManifestV1;
+  /** Package dir under the repo/image root, e.g. 'ee/workspace'. */
+  packageDir: string;
+  /** Package name, used only to name the build command in operator messages. */
+  packageName: string;
+  /**
+   * Opt in to core helper auth on `/helper/*` (the legacy `helperRoutes` flag
+   * the gateway reads off the STAGED manifest; see defaultStageExtension).
+   */
+  helperRoutes: boolean;
+}
+
+/**
+ * Resolve `<repo or image root>/<packageDir>`. Dev walks up from this file
+ * (src/extensions → apps/api → apps → repo); the CJS Docker bundle falls back to
+ * cwd (`/app`), where the Dockerfile copies `ee/<name>/{manifest.json,migrations,dist}`.
+ * Same pattern as discovery.ts's `resolveExtensionsRoot`.
+ */
+export function resolveBuiltinRoot(packageDir: string): string {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const fromSource = path.resolve(path.dirname(thisFile), '..', '..', '..', '..', packageDir);
+    if (existsSync(fromSource)) return fromSource;
+  } catch {
+    // CJS bundle: the import.meta shim may not resolve to a real path.
+  }
+  return path.join(process.cwd(), packageDir);
+}
+
+function loadBuiltinManifest(root: string): ExtensionManifestV1 {
+  return parseExtensionManifestV1(
+    JSON.parse(readFileSync(path.join(root, 'manifest.json'), 'utf8')),
+  );
+}
+
+/**
+ * Adding an entry here is the ONLY way an extension becomes built-in; the
+ * collision gates in builtinExtensions.ts then make that name unavailable to
+ * both other delivery paths.
+ */
+export const BUILTINS: readonly BuiltinExtension[] = [
+  {
+    module: workspaceExtension,
+    manifest: loadBuiltinManifest(resolveBuiltinRoot('ee/workspace')),
+    packageDir: 'ee/workspace',
+    packageName: '@breeze/ext-workspace',
+    // Workspace's /helper/* tree is called by the device helper, so it needs
+    // core helper auth rather than the user default-deny.
+    helperRoutes: true,
+  },
+];
+
+export const BUILTIN_EXTENSION_NAMES: ReadonlySet<string> = new Set(
+  BUILTINS.map((builtin) => builtin.manifest.name),
+);
+
+/**
+ * Every built-in's tenancy declaration, as a pure read of the compiled-in
+ * manifests — available BEFORE (and independently of) the loading pipeline that
+ * publishes them to the tenancy registry.
+ *
+ * This exists for the legacy source loader's repo-wide unaccounted-tables sweep
+ * (loader.ts). That sweep runs before `loadBuiltinExtensions` has published
+ * anything, so without this accessor every `workspace_*` table created on an
+ * earlier boot reads as belonging to no manifest and the sweep aborts boot.
+ */
+export function builtinTenancyDeclarations(): ExtensionTenancyDeclaration[] {
+  return BUILTINS.map((builtin) => builtin.manifest.tenancy);
+}

--- a/apps/api/src/extensions/builtinTableProbe.integration.test.ts
+++ b/apps/api/src/extensions/builtinTableProbe.integration.test.ts
@@ -1,0 +1,136 @@
+import '../__tests__/integration/setup';
+import postgres, { type Sql } from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { defaultExistingDeclaredTables } from './builtinExtensions';
+
+/**
+ * The disabled built-in's table-existence probe, against a REAL Postgres.
+ *
+ * WHY THIS FILE EXISTS. `defaultExistingDeclaredTables` is the one piece of the
+ * disabled path that no unit test can reach: `builtinExtensions.test.ts` drives
+ * everything through injected ports, so the port's own SQL is stubbed out in
+ * every one of those tests. That gap has already cost once — the first version
+ * of this query bound the table names as a `text[]` parameter, which passed the
+ * whole unit suite and then failed against a live server with `malformed array
+ * literal`, aborting boot for every deployment that had ever enabled the
+ * built-in. The query is now an `IN ${sql([...])}` list over `pg_class`; this
+ * suite is what proves that shape actually executes and returns the right subset
+ * for the three cases the caller distinguishes:
+ *
+ *   - NONE present   → publish nothing (declaring absent tables would point
+ *                      cascade/export SQL at relations that do not exist).
+ *   - SOME present   → publish a declaration FILTERED to the present subset.
+ *   - ALL present    → publish the whole declaration.
+ *
+ * A >1-element list is used throughout on purpose: the binding bug that
+ * motivated this file only appears with multiple names.
+ *
+ * DATABASE. It provisions its OWN throwaway database rather than using the
+ * shared `breeze_test`, for two reasons: this test CREATEs and DROPs tables in
+ * `public`, and a stray leftover there would read as an "unaccounted public
+ * table" to every other suite's tenancy tripwire; and the probe needs no core
+ * schema at all, so there is nothing to gain from migrating one. The name
+ * matches the test-DB safety allowlist (`/^breeze_test(_[a-z0-9]+)?$/`), and
+ * `DROP DATABASE ... WITH (FORCE)` runs first so an interrupted previous run
+ * cannot leave anything behind. Mutating `process.env.DATABASE_URL` around the
+ * calls is safe ONLY because the integration config sets `fileParallelism:
+ * false` (vitest.integration.config.ts) — the same argument
+ * `twoReplicaReconcile.integration.test.ts` documents.
+ */
+const THROWAWAY_DB = 'breeze_test_probe';
+
+const BASE_DATABASE_URL =
+  process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+
+function withDbName(connectionUrl: string, databaseName: string): string {
+  const parsed = new URL(connectionUrl);
+  parsed.pathname = `/${databaseName}`;
+  return parsed.toString();
+}
+
+const PROBE_DATABASE_URL = withDbName(BASE_DATABASE_URL, THROWAWAY_DB);
+
+/** Deliberately more than one name — see the header. */
+const DECLARED = ['probe_alpha', 'probe_beta', 'probe_gamma'] as const;
+
+describe('defaultExistingDeclaredTables (the disabled built-in table probe) against real Postgres', () => {
+  let baseAdmin: Sql;
+  let probeAdmin: Sql;
+  let previousDatabaseUrl: string | undefined;
+
+  /** Run the real port with DATABASE_URL pointed at the throwaway DB. */
+  async function probe(tables: readonly string[]): Promise<string[]> {
+    previousDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = PROBE_DATABASE_URL;
+    try {
+      return (await defaultExistingDeclaredTables(tables)).sort();
+    } finally {
+      if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = previousDatabaseUrl;
+    }
+  }
+
+  beforeAll(async () => {
+    baseAdmin = postgres(BASE_DATABASE_URL, { max: 1, onnotice: () => {} });
+    await baseAdmin.unsafe(`DROP DATABASE IF EXISTS ${THROWAWAY_DB} WITH (FORCE)`);
+    await baseAdmin.unsafe(`CREATE DATABASE ${THROWAWAY_DB}`);
+    probeAdmin = postgres(PROBE_DATABASE_URL, { max: 1, onnotice: () => {} });
+  });
+
+  afterAll(async () => {
+    // Close the throwaway pool BEFORE dropping the database; FORCE also
+    // terminates any session the probe's own short-lived pool left behind.
+    if (probeAdmin) await probeAdmin.end({ timeout: 5 });
+    if (baseAdmin) {
+      await baseAdmin.unsafe(`DROP DATABASE IF EXISTS ${THROWAWAY_DB} WITH (FORCE)`);
+      await baseAdmin.end({ timeout: 5 });
+    }
+  });
+
+  it('returns an empty list when NONE of the declared tables exist', async () => {
+    expect(await probe(DECLARED)).toEqual([]);
+  });
+
+  it('returns ONLY the present subset when SOME exist (the partial-schema case)', async () => {
+    // Exactly the shape a boot that died part-way through the migration file
+    // sequence leaves behind: one file's table committed, the rest never ran.
+    await probeAdmin.unsafe('CREATE TABLE probe_beta (id int NOT NULL)');
+    try {
+      expect(await probe(DECLARED)).toEqual(['probe_beta']);
+    } finally {
+      await probeAdmin.unsafe('DROP TABLE IF EXISTS probe_beta');
+    }
+  });
+
+  it('returns every name when ALL exist', async () => {
+    for (const table of DECLARED) {
+      await probeAdmin.unsafe(`CREATE TABLE ${table} (id int NOT NULL)`);
+    }
+    try {
+      expect(await probe(DECLARED)).toEqual([...DECLARED].sort());
+    } finally {
+      for (const table of DECLARED) {
+        await probeAdmin.unsafe(`DROP TABLE IF EXISTS ${table}`);
+      }
+    }
+  });
+
+  // `relkind IN ('r','p')` is the whole reason this is pg_class and not a
+  // `to_regclass`-per-name loop: a VIEW named like a declared table must not be
+  // reported as present. Publishing tenancy for it would hand core's cascade
+  // code a relation it cannot DELETE from.
+  it('does not report a VIEW that shares a declared table name', async () => {
+    await probeAdmin.unsafe('CREATE VIEW probe_alpha AS SELECT 1 AS id');
+    try {
+      expect(await probe(DECLARED)).toEqual([]);
+    } finally {
+      await probeAdmin.unsafe('DROP VIEW IF EXISTS probe_alpha');
+    }
+  });
+
+  // The caller short-circuits on an empty declaration, but the port must not
+  // build `IN ()` — invalid SQL — if it is ever reached with one.
+  it('short-circuits an empty list without touching the database', async () => {
+    expect(await probe([])).toEqual([]);
+  });
+});

--- a/apps/api/src/extensions/loader.test.ts
+++ b/apps/api/src/extensions/loader.test.ts
@@ -452,6 +452,58 @@ describe('mountExtensions', () => {
       warn.mockRestore();
     });
 
+    /** One pg_class catalog row shaped as the tripwire's projection expects. */
+    function catalogRow(tableName: string) {
+      return {
+        table_name: tableName,
+        relkind: 'r',
+        rls_enabled: true,
+        rls_forced: true,
+        policy_count: 1,
+        tenant_column_count: 1,
+        tenant_fk_count: 1,
+      };
+    }
+
+    // The THIRD delivery path. Built-in extensions publish their tenancy inside
+    // loadBuiltinExtensions, which runs AFTER this loader — but their tables
+    // were created by an earlier boot's migrations and are in the catalog NOW.
+    // Unless the sweep reads the compiled-in built-in manifests directly, every
+    // boot after the first aborts here.
+    it('accounts for BUILT-IN extension tables in the repo-wide sweep', async () => {
+      scaffoldRuntimeExtension(root);
+      const { db } = await import('../db');
+      (db.execute as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([catalogRow('workspace_file_index')]);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+
+      await expect(loadSourceExtensions(registry, root)).resolves.toBeUndefined();
+
+      expect(registry.get('demo')).toBeDefined();
+      expect(db.execute).toHaveBeenCalledTimes(2);
+      warn.mockRestore();
+    });
+
+    it('still fails the sweep for a table no manifest — core, source, or built-in — declares', async () => {
+      scaffoldRuntimeExtension(root);
+      const { db } = await import('../db');
+      (db.execute as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([catalogRow('workspace_file_index'), catalogRow('rogue_docs')]);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const registry = new ExtensionContributionRegistry();
+
+      const error = await loadSourceExtensions(registry, root).catch((e) => e as Error);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(/rogue_docs/);
+      // The built-in's table is accounted for; only the genuine stray is named.
+      expect((error as Error).message).not.toMatch(/workspace_file_index/);
+      warn.mockRestore();
+    });
+
     it('still runs the repo-wide sweep itself when NO runtime artifacts are declared', async () => {
       scaffoldRuntimeExtension(root);
       const { db } = await import('../db');

--- a/apps/api/src/extensions/loader.ts
+++ b/apps/api/src/extensions/loader.ts
@@ -161,8 +161,11 @@ const DEPRECATION_DOCS = 'docs/extensions/build-time-transition.md';
  * same extensions root. Only names are extracted — full validation stays the
  * reconciler's job (config.ts) — but a PRESENT-yet-unreadable file fails
  * closed: the same-name gate cannot prove the absence of a collision.
+ *
+ * Exported because the BUILT-IN loading path (builtinExtensions.ts) enforces
+ * the same one-delivery-path-per-name gate against this exact set.
  */
-function declaredRuntimeExtensionNames(root: string): Set<string> {
+export function declaredRuntimeExtensionNames(root: string): Set<string> {
   const configPath = path.join(root, 'extensions.yaml');
   if (!existsSync(configPath)) return new Set();
   let raw: unknown;

--- a/apps/api/src/extensions/loader.ts
+++ b/apps/api/src/extensions/loader.ts
@@ -31,6 +31,7 @@ import {
   legacyExtensionHelperAuthMiddleware,
 } from './gateway';
 import { assertExtensionTenancyRls, assertNoUnaccountedPublicTables } from './tenancyTripwire';
+import { builtinTenancyDeclarations } from './builtinRegistry';
 import { aiTools, hasCoreAiToolName } from '../services/aiTools';
 import { db } from '../db';
 import { createAuditLogAsync } from '../services/auditService';
@@ -264,8 +265,18 @@ export async function loadSourceExtensions(
   // same sweep once per boot AFTER publishing runtime tenancy, over
   // getExtensionTenancy()'s union of source manifests and runtime
   // declarations, so deferring keeps the fail-closed contract.
+  //
+  // BUILT-INS are the third delivery path and have exactly the same problem in
+  // this branch: `loadBuiltinExtensions` runs AFTER this loader, so no built-in
+  // tenancy has been published yet, while its tables were created by an earlier
+  // boot's migrations. Reading the compiled-in manifests directly
+  // (builtinTenancyDeclarations — a pure accessor, no publication side effects)
+  // accounts for them without weakening the sweep for anything else.
   if (runtimeNames.size === 0) {
-    await assertNoUnaccountedPublicTables(discovered.map((extension) => extension.manifest.tenancy));
+    await assertNoUnaccountedPublicTables([
+      ...discovered.map((extension) => extension.manifest.tenancy),
+      ...builtinTenancyDeclarations(),
+    ]);
   }
 
   const aiToolOwners = new Map<string, string>();

--- a/apps/api/src/extensions/reconciler.ts
+++ b/apps/api/src/extensions/reconciler.ts
@@ -450,14 +450,27 @@ export async function loadServerEntry(
  * the session's declared-vs-registered checks bind to what the manifest
  * actually declares. The returned contributions are NOT live: only
  * `registry.activate` exposes them.
+ *
+ * `opts.helperRoutes` stages the legacy `helperRoutes` flag ON TOP of the
+ * manifest, exactly as loader.ts does for source extensions: the gateway reads
+ * the flag off the STAGED manifest to apply core helper auth to `/helper/*`
+ * (gateway.ts), but the flag is not part of the strict v1 wire schema, so the
+ * CLEAN manifest — never the augmented one — is what `parseExtensionManifestV1`
+ * validates below. Only the built-in loading path (builtinExtensions.ts) passes
+ * it today; signed bundles cannot opt in until the flag lands in the v1 schema
+ * as capability 'server.helper-routes.v1'.
  */
 export async function defaultStageExtension(
   module: BreezeExtensionV1,
   manifest: ExtensionManifestV1,
   registry: ExtensionContributionRegistry,
   orgInstalls: Pick<ExtensionOrgInstallStore, 'installedOrgs'> = createExtensionOrgInstallStore(),
+  opts: { helperRoutes?: boolean } = {},
 ): Promise<StagedExtensionContributions> {
-  const session = registry.begin(manifest);
+  const stagedManifest: ExtensionManifestV1 = opts.helperRoutes
+    ? ({ ...manifest, helperRoutes: true } as ExtensionManifestV1 & { helperRoutes: true })
+    : manifest;
+  const session = registry.begin(stagedManifest);
 
   // The session registrar already IS the v1 ExtensionRegistrar; wrap only the
   // aiTool channel so a signed bundle can never shadow a core tool name.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -341,6 +341,7 @@ import { createCorsOriginResolver } from './services/corsOrigins';
 import { validateConfig } from './config/validate';
 import { initializeDatabaseForStartup } from './db/databaseStartup';
 import { loadSourceExtensions } from './extensions/loader';
+import { loadBuiltinExtensions } from './extensions/builtinExtensions';
 import { extensionContributionRegistry } from './extensions/contributionRegistry';
 import { mountExtensionGateway } from './extensions/gateway';
 import { createOrgInstalledReader } from './extensions/orgInstallGate';
@@ -1954,6 +1955,14 @@ async function bootstrap(): Promise<void> {
   }
 
   await loadSourceExtensions(extensionContributionRegistry);
+
+  // Built-in (first-party, statically imported) extensions: same staged v1
+  // pipeline as signed bundles, no artifact verification. Any failure aborts
+  // boot — built-ins are required code, not optional deployments.
+  await loadBuiltinExtensions({
+    registry: extensionContributionRegistry,
+    stateStore: extensionStateStore,
+  });
 
   // Reconcile SIGNED runtime-extension bundles declared in extensions.yaml. Core
   // + legacy-extension migrations already ran (initializeDatabaseForStartup

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -20,6 +20,29 @@ export default defineConfig({
   // feed's UNION ALL query builder — failing the build for ~150 bytes of unused
   // .d.cts. Disable it; the Dockerfile and runbook only ever run dist/*.cjs.
   dts: false,
-  // All @breeze/* workspace packages are source-only (main → src/index.ts), so bundle them; exclude future prebuilt packages here.
-  noExternal: [/^@breeze\//, 'dotenv'],
+  // All @breeze/* workspace packages are source-only (main → src/index.ts), so bundle
+  // them; exclude future prebuilt packages here.
+  //
+  // 'mailparser' and 'v9u-smb2' are third-party runtime dependencies of the built-in
+  // ee/workspace extension (bundled above via @breeze/ext-workspace) that are NOT among
+  // apps/api's own `dependencies`. Both production Dockerfiles deploy only apps/api's own
+  // dependency closure into the runner image's node_modules (docker/Dockerfile.api's
+  // `pnpm deploy --prod`; apps/api/Dockerfile's direct node_modules copy) -- neither
+  // provisions ee/workspace's node_modules at runtime. Left off this list, tsup would
+  // still attempt to bundle them by default (they're absent from apps/api's own
+  // package.json, so tsup's "external = apps/api's declared deps" heuristic wouldn't
+  // externalize them either) -- but that's an ACCIDENT of apps/api not happening to
+  // depend on them itself, not a decision, and it would silently break (dangling
+  // `require()` in dist/index.cjs, "Cannot find module" at boot) if apps/api ever gained
+  // its own same-named dependency for an unrelated reason. Listing them here makes the
+  // inlining a deliberate, explicit contract instead. Both are pure JS with no native
+  // bindings (verified: no `gypfile`, no `.node` binaries in their dependency trees) --
+  // safe to bundle. See apps/api/src/config/extensionBundledDependencies.test.ts for the
+  // guard that keeps this list in sync with ee/workspace/package.json.
+  //
+  // Anything ee/workspace depends on that IS also one of apps/api's own dependencies
+  // (today: @anthropic-ai/sdk, drizzle-orm, hono, zod) is deliberately left OFF this
+  // list: it stays external and resolves from apps/api's own deployed node_modules,
+  // which pnpm already dedupes at install time -- smaller bundle, one copy on disk.
+  noExternal: [/^@breeze\//, 'dotenv', 'mailparser', 'v9u-smb2'],
 });

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -133,6 +133,11 @@ export default defineConfig({
       // pool) and forks real child processes against `:5433`. Belongs to
       // vitest.integration.config.ts (already in its include).
       'src/extensions/twoReplicaReconcile.integration.test.ts',
+      // Disabled built-in extension's table-existence probe against a real
+      // server: imports `__tests__/integration/setup` (real postgres pool) and
+      // provisions its own throwaway database. Belongs to
+      // vitest.integration.config.ts (already in its include).
+      'src/extensions/builtinTableProbe.integration.test.ts',
       // Reset-password reveal secret lifecycle (CAS burn + expiry-reaper
       // sweep): imports `__tests__/integration/setup` (real postgres pool
       // + autoMigrate) and lives in src/services/actionIntents/ outside the

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -237,6 +237,14 @@ export default defineConfig({
       // guards the two-query split — a mocked unit test cannot catch the
       // collapsed LEFT JOIN LATERAL form that reads never-scanned as clean.
       'src/services/managementPostureReport.integration.test.ts',
+      // Co-located real-DB integration test for the DISABLED built-in
+      // extension's table-existence probe. The unit suite drives that path
+      // entirely through injected ports, so the port's own SQL is stubbed in
+      // every one of those tests — and its first version passed all of them
+      // while failing against a live server ("malformed array literal"),
+      // aborting boot for any deployment that had ever enabled the built-in.
+      // This runs the real query against real Postgres.
+      'src/extensions/builtinTableProbe.integration.test.ts',
     ],
     exclude: [
       // Uses fresh request-pool modules and manages its own temporary role;

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -27,6 +27,17 @@ The core stack (`docker-compose.yml`) includes:
 
 The `pgvector` extension is required **only if you enable the Workspace built-in** (`BREEZE_WORKSPACE_ENABLED=true`), which uses it for content embeddings. Workspace ships inside the API image but is off by default: with the flag unset, no Workspace migrations run and any Postgres 16 image works. The bundled `POSTGRES_IMAGE_REF` default is pgvector-capable regardless, so enabling Workspace later needs no database swap — supply your own Postgres image and you must provide `pgvector` yourself before setting the flag, or the API will fail to start with `extension "vector" is not available`.
 
+<Aside type="caution" title="Do not swap Postgres images over an existing data volume">
+`postgres:16-alpine` is built against **musl**; `pgvector/pgvector:pg16` is built against **glibc**. Starting one image over a data directory initialized by the other produces a **collation version mismatch**: Postgres warns at startup, and every text index (including unique constraints on text columns) is potentially inconsistent until rebuilt — which can return wrong rows rather than failing loudly.
+
+If you are already running on a stock image and want Workspace, either:
+
+- dump and restore into a freshly-initialized volume on the new image, or
+- after the first start on the new image, run `REINDEX DATABASE <dbname>;` followed by `ALTER DATABASE <dbname> REFRESH COLLATION VERSION;`.
+
+If you do not need Workspace, keep the Postgres image you are already running.
+</Aside>
+
 An optional monitoring stack (Prometheus, Grafana, Alertmanager, Loki, Promtail, exporters) is available as a separate overlay — see [Monitoring](#adding-monitoring).
 
 An optional **`m365-graph-read-executor`** sidecar (published as `ghcr.io/lanternops/breeze/m365-graph-read-executor`) isolates the Microsoft 365 customer Graph-read certificate and Key Vault access away from the API. It is only exercised when Customer Graph-read consent is enabled (`M365_CUSTOMER_GRAPH_READ_ONBOARDING_ENABLED=true`); otherwise it sits idle and can be left undeployed. It is not part of the bundled compose files by default — see [Customer Microsoft 365 Graph-read consent](/deploy/environment/#customer-microsoft-365-graph-read-consent-optional) for the full variable contract, including the private base URL and read-only signing-key mount it depends on.

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -21,9 +21,11 @@ The core stack (`docker-compose.yml`) includes:
 | **API** | `ghcr.io/lanternops/breeze/api` | Hono API server |
 | **Web** | `ghcr.io/lanternops/breeze/web` | Astro SSR dashboard |
 | **Portal** | `ghcr.io/lanternops/breeze/portal` | Astro SSR customer portal, served under `/portal` (see [Customer Portal](/features/portal/)) |
-| **PostgreSQL** | `postgres:16-alpine` | Primary database |
+| **PostgreSQL** | `pgvector/pgvector:pg16` | Primary database |
 | **Redis** | `redis:7-alpine` | Job queue, caching, rate limiting |
 | **Coturn** | `coturn/coturn:4-alpine` | TURN relay server for WebRTC remote desktop (opt-in via `--profile turn`) |
+
+The `pgvector` extension is required as of the Workspace built-in, which uses it for content embeddings — the bundled `POSTGRES_IMAGE_REF` default already includes it, so no action is needed unless you supply your own Postgres image.
 
 An optional monitoring stack (Prometheus, Grafana, Alertmanager, Loki, Promtail, exporters) is available as a separate overlay — see [Monitoring](#adding-monitoring).
 

--- a/apps/docs/src/content/docs/deploy/production.mdx
+++ b/apps/docs/src/content/docs/deploy/production.mdx
@@ -25,7 +25,7 @@ The core stack (`docker-compose.yml`) includes:
 | **Redis** | `redis:7-alpine` | Job queue, caching, rate limiting |
 | **Coturn** | `coturn/coturn:4-alpine` | TURN relay server for WebRTC remote desktop (opt-in via `--profile turn`) |
 
-The `pgvector` extension is required as of the Workspace built-in, which uses it for content embeddings — the bundled `POSTGRES_IMAGE_REF` default already includes it, so no action is needed unless you supply your own Postgres image.
+The `pgvector` extension is required **only if you enable the Workspace built-in** (`BREEZE_WORKSPACE_ENABLED=true`), which uses it for content embeddings. Workspace ships inside the API image but is off by default: with the flag unset, no Workspace migrations run and any Postgres 16 image works. The bundled `POSTGRES_IMAGE_REF` default is pgvector-capable regardless, so enabling Workspace later needs no database swap — supply your own Postgres image and you must provide `pgvector` yourself before setting the flag, or the API will fail to start with `extension "vector" is not available`.
 
 An optional monitoring stack (Prometheus, Grafana, Alertmanager, Loki, Promtail, exporters) is available as a separate overlay — see [Monitoring](#adding-monitoring).
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -69,6 +69,26 @@ DATABASE_URL=postgresql://admin_user:password@host:port/dbname?sslmode=require
 BREEZE_APP_DB_PASSWORD=
 # DATABASE_URL_APP=postgresql://breeze_app:password@host:port/dbname?sslmode=require
 
+# ── Built-in extensions (optional, OFF) ─────────────────────────────
+# First-party extensions ship inside the API image but are NOT loaded unless the
+# deployment switches them on. Each flag is strict: only the exact string "true"
+# enables it. Left unset (the default), nothing changes — no migrations, no
+# schema, no extra infrastructure requirement.
+#
+# Workspace (file/email indexing, content search) needs the PostgreSQL pgvector
+# extension: its migrations run `CREATE EXTENSION vector` on API boot, and a
+# managed Postgres without pgvector available will fail the boot with
+# `extension "vector" is not available`. Confirm pgvector is installable on the
+# managed instance in DATABASE_URL above BEFORE setting this.
+#
+# UPGRADE CAVEAT for self-managed Postgres containers: postgres:16-alpine is
+# musl-built and pgvector/pgvector:pg16 is glibc-built, so swapping one image for
+# the other over an EXISTING data volume triggers a collation version mismatch
+# and leaves text indexes inconsistent until rebuilt. Dump/restore into a fresh
+# volume, or run `REINDEX DATABASE <dbname>;` after the first start on the new
+# image. If you do not need Workspace, keep the Postgres you already run.
+# BREEZE_WORKSPACE_ENABLED=true
+
 # ── Redis ───────────────────────────────────────────────────────────
 # REQUIRED in production. Empty values are rejected by the redis container,
 # and the API refuses to boot in production if REDIS_URL/REDIS_PASSWORD is

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -242,6 +242,12 @@ services:
       TURN_PORT: ${TURN_PORT:-3478}
       TURN_SECRET: ${TURN_SECRET:-}
       TURN_CREDENTIAL_TTL_SECONDS: ${TURN_CREDENTIAL_TTL_SECONDS:-600}
+      # Built-in extensions ship inside the API image but load only when the
+      # deployment switches them on (default off, and value-strict: only the
+      # exact string "true"). Workspace additionally requires pgvector to be
+      # available on the managed Postgres in DATABASE_URL — see the note beside
+      # this variable in deploy/.env.example.
+      BREEZE_WORKSPACE_ENABLED: ${BREEZE_WORKSPACE_ENABLED:-false}
       TRUST_PROXY_HEADERS: "true"
       TRUSTED_PROXY_CIDRS: "${TRUSTED_PROXY_CIDRS:-172.30.0.11/32}"
       # This reference stack is fronted by Cloudflare (cloudflared → Caddy), so

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -92,6 +92,8 @@ services:
       - ./apps/api/src:/app/apps/api/src:cached
       - ./apps/api/migrations:/app/apps/api/migrations:ro
       - ./packages/shared/src:/app/packages/shared/src:cached
+      - ./ee/workspace/src:/app/ee/workspace/src:cached
+      - ./ee/workspace/migrations:/app/ee/workspace/migrations:ro
       # Mount config files
       - ./apps/api/package.json:/app/apps/api/package.json:ro
       - ./apps/api/tsconfig.json:/app/apps/api/tsconfig.json:ro

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -86,8 +86,11 @@ services:
       BINARY_SOURCE: ${BINARY_SOURCE:-github}
       BREEZE_VERSION: ${BREEZE_VERSION:-latest}
       # Built-in extensions are off by default per deployment; dev is where
-      # Workspace is developed, and this stack's postgres is already pgvector.
-      BREEZE_WORKSPACE_ENABLED: "true"
+      # Workspace is developed, and this stack's postgres is already pgvector —
+      # hence the default of "true" here. Still interpolated (not hardcoded), so
+      # a developer can switch it off in .env to reproduce the default-off boot
+      # path without editing this file. Matches docker-compose.yml's convention.
+      BREEZE_WORKSPACE_ENABLED: ${BREEZE_WORKSPACE_ENABLED:-true}
     ports:
       - "3001:3001"
     volumes:
@@ -97,6 +100,10 @@ services:
       - ./packages/shared/src:/app/packages/shared/src:cached
       - ./ee/workspace/src:/app/ee/workspace/src:cached
       - ./ee/workspace/migrations:/app/ee/workspace/migrations:ro
+      # The manifest is BAKED into the image, so without this mount a local edit
+      # to its tenancy / orgExportColumns is invisible to the running container
+      # while the migrations beside it are live — the two would silently drift.
+      - ./ee/workspace/manifest.json:/app/ee/workspace/manifest.json:ro
       # Mount config files
       - ./apps/api/package.json:/app/apps/api/package.json:ro
       - ./apps/api/tsconfig.json:/app/apps/api/tsconfig.json:ro

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,6 +85,9 @@ services:
       PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:3001}
       BINARY_SOURCE: ${BINARY_SOURCE:-github}
       BREEZE_VERSION: ${BREEZE_VERSION:-latest}
+      # Built-in extensions are off by default per deployment; dev is where
+      # Workspace is developed, and this stack's postgres is already pgvector.
+      BREEZE_WORKSPACE_ENABLED: "true"
     ports:
       - "3001:3001"
     volumes:

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -33,6 +33,10 @@ services:
       - ./packages/shared/src:/app/packages/shared/src:cached
       - ./ee/workspace/src:/app/ee/workspace/src:cached
       - ./ee/workspace/migrations:/app/ee/workspace/migrations:ro
+      # The manifest is BAKED into the image, so without this mount a local edit
+      # to its tenancy / orgExportColumns is invisible to the running container
+      # while the migrations beside it are live — the two would silently drift.
+      - ./ee/workspace/manifest.json:/app/ee/workspace/manifest.json:ro
       # Mount config files
       - ./apps/api/package.json:/app/apps/api/package.json:ro
       - ./apps/api/tsconfig.json:/app/apps/api/tsconfig.json:ro

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -73,6 +73,11 @@ services:
       BREEZE_BILLING_URL: ${BREEZE_BILLING_URL:-http://billing:3002}
       PUBLIC_ACTIVATION_BASE_URL: ${PUBLIC_ACTIVATION_BASE_URL:-http://localhost:4321}
       BREEZE_REGION: ${BREEZE_REGION:-us}
+      # Built-in extensions are off by default per deployment (the base mapping
+      # resolves to false). Dev is where Workspace is developed — and the ee
+      # source mounts above are pointless without it — so switch it on here.
+      # Requires the pgvector Postgres image the base stack already defaults to.
+      BREEZE_WORKSPACE_ENABLED: ${BREEZE_WORKSPACE_ENABLED:-true}
     healthcheck:
       test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3001/health']
       start_period: 60s

--- a/docker-compose.override.yml.dev
+++ b/docker-compose.override.yml.dev
@@ -31,6 +31,8 @@ services:
       - ./apps/api/src:/app/apps/api/src:cached
       - ./apps/api/migrations:/app/apps/api/migrations:ro
       - ./packages/shared/src:/app/packages/shared/src:cached
+      - ./ee/workspace/src:/app/ee/workspace/src:cached
+      - ./ee/workspace/migrations:/app/ee/workspace/migrations:ro
       # Mount config files
       - ./apps/api/package.json:/app/apps/api/package.json:ro
       - ./apps/api/tsconfig.json:/app/apps/api/tsconfig.json:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,6 +303,10 @@ services:
       TURN_SECRET: ${TURN_SECRET:-}
       TURN_CREDENTIAL_TTL_SECONDS: ${TURN_CREDENTIAL_TTL_SECONDS:-600}
       E2E_MODE: ${E2E_MODE:-}
+      # Built-in extensions ship inside the API image but load only when the
+      # deployment switches them on (default off). Workspace additionally needs
+      # a pgvector-capable Postgres — see POSTGRES_IMAGE_REF in .env.example.
+      BREEZE_WORKSPACE_ENABLED: ${BREEZE_WORKSPACE_ENABLED:-false}
       # MCP OAuth (off by default, opt-in via env)
       MCP_OAUTH_ENABLED: ${MCP_OAUTH_ENABLED:-false}
       OAUTH_ISSUER: ${OAUTH_ISSUER:-}

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -8,6 +8,9 @@ COPY apps/api/package.json ./apps/api/
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/extension-api/package.json ./packages/extension-api/
 COPY packages/extension-sdk/package.json ./packages/extension-sdk/
+COPY packages/extension-web-sdk/package.json ./packages/extension-web-sdk/
+COPY packages/extension-testkit/package.json ./packages/extension-testkit/
+COPY ee/workspace/package.json ./ee/workspace/
 RUN pnpm install --frozen-lockfile
 
 FROM base AS builder
@@ -17,8 +20,12 @@ COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules
 COPY --from=deps /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY --from=deps /app/packages/extension-api/node_modules ./packages/extension-api/node_modules
 COPY --from=deps /app/packages/extension-sdk/node_modules ./packages/extension-sdk/node_modules
+COPY --from=deps /app/packages/extension-web-sdk/node_modules ./packages/extension-web-sdk/node_modules
+COPY --from=deps /app/packages/extension-testkit/node_modules ./packages/extension-testkit/node_modules
+COPY --from=deps /app/ee/workspace/node_modules ./ee/workspace/node_modules
 COPY . .
 RUN pnpm --filter @breeze/api build
+RUN pnpm --filter @breeze/ext-workspace build:web
 # Create a self-contained deployment (resolves pnpm symlinks).
 # pnpm 10's deploy command requires workspace deps be declared injected.
 # TODO: declare @breeze/shared (and other workspace deps) as injected in
@@ -53,9 +60,17 @@ COPY --from=builder --chown=hono:nodejs /deployed/package.json ./
 
 # Copy migration files for auto-migrate on startup
 COPY --from=builder --chown=hono:nodejs /app/apps/api/migrations ./migrations
-# The stock image contains public SDK/host code only — no extension source or
-# builds are baked in. Deployments deliver extensions as SIGNED runtime bundles
-# by mounting extensions.yaml (+ artifacts) into this directory; it is created
+
+# Built-in extensions: migrations + prebuilt web assets, resolved at runtime
+# relative to cwd (/app) by builtinExtensions.ts.
+COPY --from=builder --chown=hono:nodejs /app/ee/workspace/migrations ./ee/workspace/migrations
+COPY --from=builder --chown=hono:nodejs /app/ee/workspace/manifest.json ./ee/workspace/manifest.json
+COPY --from=builder --chown=hono:nodejs /app/ee/workspace/dist ./ee/workspace/dist
+
+# The stock image contains AGPL core + built-in ee/ code (compiled into
+# dist/index.cjs plus the runtime assets copied above). Third-party
+# extensions still arrive only as SIGNED runtime bundles, delivered by
+# mounting extensions.yaml (+ artifacts) into this directory; it is created
 # empty so the mount point exists and is owned by the runtime user.
 RUN mkdir -p /app/extensions && chown hono:nodejs /app/extensions
 ENV BREEZE_EXTENSIONS_DIR=/app/extensions

--- a/docker/Dockerfile.api.dev
+++ b/docker/Dockerfile.api.dev
@@ -20,6 +20,13 @@ COPY packages/extension-sdk/package.json ./packages/extension-sdk/
 # `pnpm install` below), so its manifest must be here or pnpm aborts with
 # ERR_PNPM_WORKSPACE_PKG_NOT_FOUND.
 COPY packages/extension-cli/package.json ./packages/extension-cli/
+# apps/api statically imports the built-in @breeze/ext-workspace extension
+# (builtinRegistry.ts), which depends on extension-web-sdk and, as a
+# devDependency, extension-testkit. Same ERR_PNPM_WORKSPACE_PKG_NOT_FOUND
+# risk as extension-cli above if any manifest here is missing.
+COPY packages/extension-web-sdk/package.json ./packages/extension-web-sdk/
+COPY packages/extension-testkit/package.json ./packages/extension-testkit/
+COPY ee/workspace/package.json ./ee/workspace/
 
 # Install all dependencies (including devDependencies for development)
 RUN pnpm install
@@ -30,6 +37,12 @@ COPY packages/shared ./packages/shared
 COPY packages/extension-api ./packages/extension-api
 COPY packages/extension-sdk ./packages/extension-sdk
 COPY packages/extension-cli ./packages/extension-cli
+COPY packages/extension-web-sdk ./packages/extension-web-sdk
+COPY packages/extension-testkit ./packages/extension-testkit
+# Built-in extension source + manifest.json + migrations (no build:web here --
+# builtinExtensions.ts tolerates a missing dist/web outside production, just
+# warns and keeps the extension's server routes active).
+COPY ee/workspace ./ee/workspace
 
 # Set working directory to api
 WORKDIR /app/apps/api

--- a/docs/extensions/build-time-transition.md
+++ b/docs/extensions/build-time-transition.md
@@ -23,6 +23,13 @@ below are unaffected. The stock image therefore contains AGPL core plus
 built-in `ee/` code — "extension-free" in the removal-gate sense refers to
 *externally delivered* extension code only.
 
+A built-in can carry a **deployment enable flag** (`BuiltinExtension.enableEnvVar`)
+and is not loaded unless that variable is exactly `"true"`; Workspace's is
+**`BREEZE_WORKSPACE_ENABLED`**, default off. A disabled built-in runs no
+migrations and activates nothing, emitting one structured
+`builtin_extension_disabled` warning naming the flag — it still publishes its
+tenancy declaration if its tables already exist from an earlier enabled boot.
+
 ## What changed
 
 - Stock images (`docker/Dockerfile.api`, `apps/api/Dockerfile`) no longer

--- a/docs/extensions/build-time-transition.md
+++ b/docs/extensions/build-time-transition.md
@@ -7,8 +7,21 @@ and the loader imported their entry at boot. That path is **deprecated**. The
 supported delivery mechanism is a **signed runtime bundle**: a
 `breeze-ext`-packed artifact declared in `extensions.yaml`, verified against a
 pinned digest and trusted publisher key, migrated, staged through the v1 SDK
-contract, and activated by the reconciler — all against a stock Breeze image
-that contains public SDK/host code only.
+contract, and activated by the reconciler. Third-party delivery still targets
+a stock Breeze image — see "Built-in (first-party) extensions" below for how
+that image's contents changed as of 2026-08.
+
+## Built-in (first-party) extensions
+
+Since 2026-08, first-party extensions under `ee/` (currently `ee/workspace`)
+are compiled into the API image and registered at boot through the same
+staged v1 pipeline as signed bundles (`builtinExtensions.ts`) — no signing,
+no artifact verification, no source-directory scan. This path is reserved
+for code that lives in this repository. Third-party delivery remains signed
+runtime bundles; the deprecated source-directory path and its removal gate
+below are unaffected. The stock image therefore contains AGPL core plus
+built-in `ee/` code — "extension-free" in the removal-gate sense refers to
+*externally delivered* extension code only.
 
 ## What changed
 
@@ -52,8 +65,10 @@ Removal additionally requires ALL of:
    and the blocking API CI gate described in `sdk-compatibility.md`) are green
    on the release candidate.
 2. A published migration guide covering the source-directory → signed-bundle
-   conversion (pack, sign, declare in `extensions.yaml`), with
-   `breeze-workspace` as the reference implementation.
+   conversion (pack, sign, declare in `extensions.yaml`). `breeze-workspace`
+   no longer fits as the reference implementation (it moved to the built-in
+   `ee/` path, not signed-bundle delivery); a different third-party extension
+   on the signed-bundle path is needed as the guide's worked example.
 3. A release-note entry announcing the removal.
 
 What removal covers: `loadSourceExtensions`, `discoverExtensions`'
@@ -79,6 +94,8 @@ bump; the v1 SDK remains governed by the separate policy in
 4. Remove the source checkout from `extensions/` (or leave it and drop the
    flag: it will be skipped with a warning; the same NAME cannot be both).
 
-The end-to-end conformance reference is the `breeze-workspace` repository
-(`test/conformance`), which proves this pipeline against an unmodified stock
-image.
+The end-to-end conformance reference is `apps/api/src/extensions/packerConformance.test.ts`,
+which proves this pipeline against an unmodified stock image. (Prior to
+2026-08, the `breeze-workspace` repository's own live stock-host conformance
+suite played this role; it is retired now that Workspace is a built-in
+extension rather than a third-party signed-bundle reference.)

--- a/docs/superpowers/plans/2026-08-11-workspace-ee-merge.md
+++ b/docs/superpowers/plans/2026-08-11-workspace-ee-merge.md
@@ -1,0 +1,682 @@
+# Workspace → ee/workspace Merge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the private `LanternOps/breeze-workspace` extension into the breeze monorepo at `ee/workspace/`, loaded as a statically-imported **built-in extension**, and delete the two-repo packaging seam.
+
+**Architecture:** The workspace package becomes a pnpm workspace member (`@breeze/ext-workspace`) that `apps/api` imports directly. A new `builtinExtensions.ts` feeds its module + v1 manifest through the same staging pipeline signed bundles use (`defaultStageExtension` → tenancy tripwires → `registry.activate`), plus disk-based migrations and boot-time-hashed web assets. The signed-runtime-bundle platform is untouched.
+
+**Tech Stack:** pnpm 10 workspaces, tsup (CJS bundle; `noExternal: [/^@breeze\//]` already bundles workspace packages into the API image), Hono, Drizzle, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-workspace-ee-merge-design.md`
+
+## Global Constraints
+
+- **Sequencing:** breeze#3032 (tenant-scoped installs) merges FIRST. It touches extension registration/state; wherever this plan references `ExtensionStateStore` methods (`upsertObserved`, `setEnabled`, `isEnabled`, `recordActive`), re-read `apps/api/src/extensions/stateStore.ts` post-merge and use the merged signatures. Requirements stand regardless: workspace seeds enabled on first boot, later boots respect the persisted flag.
+- **Branch base:** new branch off `origin/main` after #3032. Cherry-pick spec commit `05c8ffda6` if `ToddHebebrand/client-ext-seam-w4` is dropped. Do NOT touch the ~25 uncommitted `apps/docs` edits in Todd's tree.
+- **The real typecheck gate** is `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --project apps/api/tsconfig.json` (strict, `noUncheckedIndexedAccess`). The package's own `typecheck` passing is NOT sufficient once apps/api imports it.
+- Source move is byte-identical where possible: no drive-by refactors of workspace services/routes/tests.
+- All commands run from the breeze repo root unless stated. Source repo: `/Users/toddhebebrand/breeze-workspace` (pin `git rev-parse HEAD` there as `<WS_SHA>`).
+- Package manager: `pnpm@10.33.4`. Never edit `pnpm-lock.yaml` by hand.
+
+---
+
+### Task 1: Import workspace source as `ee/workspace` pnpm member
+
+**Files:**
+- Modify: `pnpm-workspace.yaml` (add `ee/*`)
+- Create: `ee/workspace/` — copied `src/`, `migrations/`, `manifest.json`, `tsconfig.json`, `tsup.server.config.ts`, `tsup.web.config.ts`, `vitest.config.ts`, `vitest.integration.config.ts` from the workspace repo
+- Create: `ee/workspace/package.json` (rewritten — see below)
+
+**Interfaces:**
+- Produces: package `@breeze/ext-workspace` whose default export (from `src/index.ts`) is a `BreezeExtensionV1` (`register(registrar, context)`), plus `ee/workspace/manifest.json` (v1, `name: "workspace"`), `ee/workspace/migrations/*.sql`, and a `build:web` script emitting `ee/workspace/dist/web/index.js`.
+
+- [ ] **Step 1: Add `ee/*` to the workspace globs**
+
+In `pnpm-workspace.yaml` `packages:` add a third entry:
+
+```yaml
+packages:
+  - 'apps/*'
+  - 'packages/*'
+  - 'ee/*'
+```
+
+- [ ] **Step 2: Copy the source at a pinned SHA**
+
+```bash
+cd /Users/toddhebebrand/breeze-workspace && git rev-parse HEAD   # record as <WS_SHA>
+mkdir -p /Users/toddhebebrand/breeze/ee/workspace
+cd /Users/toddhebebrand/breeze/ee/workspace
+for p in src migrations manifest.json tsconfig.json tsup.server.config.ts tsup.web.config.ts vitest.config.ts vitest.integration.config.ts; do
+  cp -R /Users/toddhebebrand/breeze-workspace/$p .
+done
+```
+
+Do NOT copy: `vendor/`, `scripts/`, `dev/`, `test/`, `dist/`, `breeze-extension.json` (legacy manifest — the built-in path is v1-only), `vitest.conformance.config.ts`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `manifest.json`→keep (v1), `docs/` (stays in the archived repo). If `vitest.integration.config.ts` references a repo-root `.env.test`, repoint it at breeze's test-env convention (see what `apps/api`'s integration tests load) in Task 6.
+
+- [ ] **Step 3: Write the new package.json**
+
+Create `ee/workspace/package.json` (replaces the old one entirely — old name was `@lanternops/breeze-ext-workspace` with `file:vendor/*.tgz` deps):
+
+```json
+{
+  "name": "@breeze/ext-workspace",
+  "version": "0.2.0",
+  "private": true,
+  "license": "SEE LICENSE IN ../LICENSE",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build:web": "tsup --config tsup.web.config.ts",
+    "test": "vitest run --config vitest.config.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.112.3",
+    "@breeze/extension-sdk": "workspace:*",
+    "@breeze/extension-web-sdk": "workspace:*",
+    "drizzle-orm": "0.45.2",
+    "hono": "4.12.31",
+    "mailparser": "^3.9.14",
+    "v9u-smb2": "^1.0.6",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@breeze/extension-testkit": "workspace:*",
+    "@types/mailparser": "^3.4.6",
+    "@types/node": "22.19.3",
+    "dotenv": "16.6.1",
+    "happy-dom": "^20.11.0",
+    "postgres": "3.4.9",
+    "tsup": "8.3.5",
+    "tsx": "^4.23.1",
+    "typescript": "5.7.2",
+    "vitest": "4.1.9"
+  }
+}
+```
+
+Note `main: src/index.ts` — every `@breeze/*` package is source-only (apps/api's tsup bundles them via `noExternal`), so no server build script is needed; drop `tsup.server.config.ts` if nothing references it after this step. Pin exact versions to whatever breeze's lockfile already holds for shared deps (`drizzle-orm`, `hono`, `zod`, `vitest`) — check `pnpm why <dep>` and match to avoid duplicate majors.
+
+- [ ] **Step 4: Install and typecheck the package standalone**
+
+```bash
+pnpm install
+pnpm --filter @breeze/ext-workspace typecheck
+pnpm --filter @breeze/ext-workspace build:web && ls ee/workspace/dist/web/index.js
+```
+
+Expected: install resolves `workspace:*` to `packages/extension-sdk` etc.; typecheck passes (hostTypes.ts already targets the real v1 SDK types, not the vendored tarball — same package, now by symlink); web build emits `dist/web/index.js`.
+
+- [ ] **Step 5: Run the package's unit tests**
+
+```bash
+pnpm --filter @breeze/ext-workspace test
+```
+
+Expected: PASS (these are the same tests that passed in the standalone repo). Integration tests are deferred to Task 6 (need DB env wiring).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pnpm-workspace.yaml pnpm-lock.yaml ee/workspace
+git commit -m "feat(ee): import breeze-workspace as ee/workspace (@breeze/ext-workspace)
+
+Source imported from LanternOps/breeze-workspace @ <WS_SHA>.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `ee/` commercial license
+
+**Files:**
+- Create: `ee/LICENSE`
+- Modify: `README.md` (licensing section), `LICENSE` (no content change — add a pointer paragraph to README instead if LICENSE must stay pristine GNU text; the AGPL text itself must not be edited)
+
+- [ ] **Step 1: Write `ee/LICENSE`**
+
+Model on Cal.com's commercial license (`https://github.com/calcom/cal.com/blob/main/packages/features/ee/LICENSE`), adapted:
+
+```
+The Breeze Commercial License (the "Commercial License")
+Copyright (c) 2026 LanternOps, Inc.
+
+With regard to the Breeze Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, a commercial agreement with LanternOps, Inc., or
+other agreements governing the use of the Software, and otherwise have a valid
+license for the correct number of users, devices, or endpoints.
+
+Subject to the foregoing sentence, you are free to modify this Software and
+publish patches to the Software. You agree that LanternOps, Inc. and/or its
+licensors (as applicable) retain all right, title and interest in and to all
+such modifications and/or patches, and all such modifications and/or patches
+may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid commercial license for the Software. You may not copy,
+modify, create derivative works of, publicly display, publicly perform,
+sublicense or distribute this Software except as expressly permitted above.
+
+Any use of the Software outside of a valid commercial agreement is strictly
+prohibited. For clarity, the Software outside of the "ee" directory is
+licensed under AGPL-3.0 as described in the repository root LICENSE file.
+
+This Commercial License applies only to the part of this Software that is in
+the "ee" directory. The full text of this Commercial License shall be included
+in all copies or substantial portions of the Software covered by it.
+```
+
+- [ ] **Step 2: Update the root README licensing section**
+
+Find the existing license mention (`grep -n -i "license\|AGPL" README.md`) and replace/extend with:
+
+```markdown
+## License
+
+Breeze is [AGPL-3.0](LICENSE) licensed, with one exception: everything under
+the [`ee/`](ee/) directory is covered by the
+[Breeze Commercial License](ee/LICENSE) (source-visible, requires a
+commercial agreement for production use). This is the same open-core layout
+used by projects like Cal.com.
+```
+
+- [ ] **Step 3: Verify + commit**
+
+Run `pnpm lint` (README/markdown untouched by lint is fine — this confirms nothing broke). Commit:
+
+```bash
+git add ee/LICENSE README.md
+git commit -m "docs(ee): commercial license for the ee/ directory
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Built-in extension loader (`builtinExtensions.ts`)
+
+The heart of the change. Mirrors the reconciler's phase order (migration → tenancy → stage → validate → activate) minus acquire/trust/verify/extract, for statically imported extensions.
+
+**Files:**
+- Create: `apps/api/src/extensions/builtinExtensions.ts`
+- Create: `apps/api/src/extensions/builtinExtensions.test.ts`
+- Modify: `apps/api/src/extensions/loader.ts` (export `declaredRuntimeExtensionNames`)
+- Modify: `apps/api/src/extensions/reconciler.ts` (`defaultStageExtension` gains an options param for `helperRoutes`)
+- Modify: `apps/api/package.json` (add `"@breeze/ext-workspace": "workspace:*"` to dependencies)
+
+**Interfaces:**
+- Consumes: `@breeze/ext-workspace` default export (`BreezeExtensionV1`), `ee/workspace/manifest.json`, `defaultStageExtension(module, manifest, registry, opts?)`, `reconcileExtensionMigrations(migratable, sql, stateStore, rollout?)` (`apps/api/src/extensions/migrator.ts:147` — verify the rollout param's post-#3032 type; pass `undefined`), `registerRuntimeExtensionTenancy`, `assertExtensionTenancyRls`, `registerExtensionWebAsset(name, {root, digest, files})`, `registerGlobalRateLimitSkipPrefix`, `ExtensionStateStore` (`upsertObserved`/`get`/`setEnabled`/`recordActive`/`isEnabled`).
+- Produces: `export async function loadBuiltinExtensions(args: { registry: ExtensionContributionRegistry; stateStore: ExtensionStateStore }): Promise<void>` — the single entry Task 4 wires into boot. Also `export const BUILTIN_EXTENSION_NAMES: ReadonlySet<string>`.
+
+- [ ] **Step 1: Export the runtime-name helper from loader.ts**
+
+In `apps/api/src/extensions/loader.ts`, change `function declaredRuntimeExtensionNames(` to `export function declaredRuntimeExtensionNames(`. No behavior change.
+
+- [ ] **Step 2: Extend `defaultStageExtension` for the helper-routes flag**
+
+Workspace's `/helper/*` tree needs core helper auth. The gateway reads a legacy `helperRoutes` flag off the STAGED manifest (`apps/api/src/extensions/gateway.ts:36`), but the flag is not in the strict v1 wire schema — `loader.ts` stages an augmented manifest and strips before `parseExtensionManifestV1`. Give the reconciler's stage function the same ability:
+
+```ts
+export async function defaultStageExtension(
+  module: BreezeExtensionV1,
+  manifest: ExtensionManifestV1,
+  registry: ExtensionContributionRegistry,
+  opts?: { helperRoutes?: boolean },
+): Promise<StagedExtensionContributions> {
+  const stagedManifest = opts?.helperRoutes ? { ...manifest, helperRoutes: true } : manifest;
+  const session = registry.begin(stagedManifest);
+  // ... registrar + context construction unchanged ...
+  await module.register(registrar, context);
+  parseExtensionManifestV1(manifest);   // parse the CLEAN manifest, as before
+  return session.finish();
+}
+```
+
+Existing call sites (`buildDefaultPorts`'s `stageExtension`) pass no `opts` — unchanged behavior. Run `pnpm --filter @breeze/api exec vitest run src/extensions/reconciler.test.ts` to confirm no regression before proceeding.
+
+- [ ] **Step 3: Write the failing tests**
+
+`apps/api/src/extensions/builtinExtensions.test.ts`. Follow `reconciler.test.ts`'s conventions for building an `ExtensionContributionRegistry` and an in-memory state store (reuse its test backend helper; post-#3032, mirror whatever reconciler.test.ts then uses). Inject fakes through the args object — the loader accepts port overrides exactly like `reconcileExtensions` does, so tests never touch a real DB or the real workspace package:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { loadBuiltinExtensions, BUILTIN_EXTENSION_NAMES } from './builtinExtensions';
+
+// Minimal passing fixture: a manifest cloned from ee/workspace/manifest.json's
+// shape but with empty tenancy tables, and a module whose register() mounts one
+// route. Build both inline; do not import @breeze/ext-workspace in unit tests.
+
+describe('loadBuiltinExtensions', () => {
+  it('activates a built-in through the staged pipeline with enabled=true on first boot', async () => {
+    // fresh registry + empty in-memory state store; ports: runMigrations,
+    // publishTenancy, validateTenancy, registerWebAsset stubbed to record calls
+    // → expect registry contains the extension, stateStore row exists with
+    // enabled=true, activeVersion set, and phase order was
+    // migration → tenancy → stage → validate → activate (assert via the
+    // recording stubs' call sequence).
+  });
+
+  it('respects a persisted enabled=false on later boots', async () => {
+    // seed the store with { name, enabled: false } → after load, the registry
+    // snapshot for the extension has enabled=false (routes 404 via enabledGate)
+    // and setEnabled was NOT called.
+  });
+
+  it('fails boot when extensions.yaml declares a built-in name', async () => {
+    // ports.declaredRuntimeNames returns Set(['workspace']) → rejects with an
+    // error naming both delivery paths.
+  });
+
+  it('fails boot when a legacy source dir shadows a built-in name', async () => {
+    // ports.sourceCandidates returns ['workspace'] → rejects.
+  });
+
+  it('registers agent rate-limit skip prefixes when agentRoutes is true', async () => {
+    // ports.registerRateLimitSkip recorder → expect /api/v1/ext/<name>/agent/
+    // and /api/v1/<routeNamespace>/agent/.
+  });
+
+  it('production boot fails when the web dist is missing; dev warns and skips web asset', async () => {
+    // ports.readWebDist throws ENOENT: with NODE_ENV=production → rejects;
+    // otherwise → resolves, registerWebAsset not called, warning logged.
+  });
+});
+```
+
+Flesh each `it` into real assertions while writing Step 5's implementation — the six behaviors above are the required coverage, and each must assert on recorded calls, not just "no throw".
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/extensions/builtinExtensions.test.ts
+```
+
+Expected: FAIL — module `./builtinExtensions` not found.
+
+- [ ] **Step 5: Implement `builtinExtensions.ts`**
+
+Shape (real code; adjust identifiers to post-#3032 stateStore):
+
+```ts
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres from 'postgres';
+import type { BreezeExtensionV1 } from '@breeze/extension-sdk';
+import { parseExtensionManifestV1, type ExtensionManifestV1 } from '@breeze/extension-sdk';
+import workspaceExtension from '@breeze/ext-workspace';
+import type { ExtensionContributionRegistry } from './contributionRegistry';
+import type { ExtensionStateStore } from './stateStore';
+import { defaultStageExtension } from './reconciler';
+import { reconcileExtensionMigrations, type MigratableExtension } from './migrator';
+import { registerRuntimeExtensionTenancy } from './tenancyRegistry';
+import { assertExtensionTenancyRls } from './tenancyTripwire';
+import { registerExtensionWebAsset } from './webAssets';
+import { declaredRuntimeExtensionNames } from './loader';
+import { listSourceExtensionCandidates, resolveExtensionsRoot } from './discovery';
+import { registerGlobalRateLimitSkipPrefix } from '../middleware/globalRateLimit';
+
+interface BuiltinExtension {
+  module: BreezeExtensionV1;
+  manifest: ExtensionManifestV1;
+  /** package dir under the repo/image root, e.g. 'ee/workspace' */
+  packageDir: string;
+  helperRoutes: boolean;
+}
+
+/** Resolve <repo or image root>/<packageDir>: dev walks up from this file
+ *  (src/extensions → apps/api → apps → repo); the CJS Docker bundle falls back
+ *  to cwd (/app), where the Dockerfile copies ee/workspace/{migrations,dist}.
+ *  Same pattern as discovery.ts's resolveExtensionsRoot. */
+function resolveBuiltinRoot(packageDir: string): string {
+  try {
+    const thisFile = fileURLToPath(import.meta.url);
+    const fromSource = path.resolve(path.dirname(thisFile), '..', '..', '..', '..', packageDir);
+    if (existsSync(fromSource)) return fromSource;
+  } catch { /* CJS bundle: import.meta shim may not resolve a real path */ }
+  return path.join(process.cwd(), packageDir);
+}
+
+function loadBuiltinManifest(root: string): ExtensionManifestV1 {
+  return parseExtensionManifestV1(
+    JSON.parse(readFileSync(path.join(root, 'manifest.json'), 'utf8')),
+  );
+}
+
+function readDiskMigrations(root: string, migrationsDir: string): MigratableExtension['migrations'] {
+  const dir = path.join(root, migrationsDir);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort((a, b) => a.localeCompare(b))
+    .map((filename) => ({ filename, sql: readFileSync(path.join(dir, filename), 'utf8') }));
+}
+
+/** Hash dist/web at boot into the inventory shape registerExtensionWebAsset
+ *  expects (members named `web/<relpath>`, root = <pkg>/dist), with a digest
+ *  over the sorted inventory so the digest-addressed asset route stays
+ *  cache-coherent across deploys. */
+function readWebDist(root: string): { root: string; digest: string; files: Map<string, { sha256: string; uncompressedSize: number }> } {
+  const distRoot = path.join(root, 'dist');
+  const webDir = path.join(distRoot, 'web');
+  if (!existsSync(webDir)) throw Object.assign(new Error(`missing ${webDir}`), { code: 'ENOENT' });
+  const files = new Map<string, { sha256: string; uncompressedSize: number }>();
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (statSync(full).isDirectory()) { walk(full); continue; }
+      const bytes = readFileSync(full);
+      files.set(path.relative(distRoot, full).split(path.sep).join('/'), {
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+        uncompressedSize: bytes.length,
+      });
+    }
+  };
+  walk(webDir);
+  const digest = createHash('sha256')
+    .update([...files.keys()].sort().map((k) => `${k}:${files.get(k)!.sha256}`).join('\n'))
+    .digest('hex');
+  return { root: distRoot, digest, files };
+}
+
+const BUILTINS: BuiltinExtension[] = [
+  {
+    module: workspaceExtension,
+    manifest: loadBuiltinManifest(resolveBuiltinRoot('ee/workspace')),
+    packageDir: 'ee/workspace',
+    helperRoutes: true,
+  },
+];
+
+export const BUILTIN_EXTENSION_NAMES: ReadonlySet<string> = new Set(
+  BUILTINS.map((b) => b.manifest.name),
+);
+
+export async function loadBuiltinExtensions(args: {
+  registry: ExtensionContributionRegistry;
+  stateStore: ExtensionStateStore;
+  ports?: Partial<BuiltinPorts>;   // test seam, mirroring reconcileExtensions
+}): Promise<void> { /* ... */ }
+```
+
+Body of `loadBuiltinExtensions`, per built-in, in this order (each phase overridable via `ports` exactly like `buildDefaultPorts`):
+
+1. **Collision gates:** `declaredRuntimeExtensionNames(resolveExtensionsRoot())` and `listSourceExtensionCandidates()` must not contain the built-in's name — throw a boot-failing error naming both paths otherwise ("one delivery path per extension name", extending the tripwire in `loader.ts:235`).
+2. **Migrations:** construct the `MigratableExtension` (`name`, `version`, `schemaCompatibilityFloor` from the manifest, `migrations` via `readDiskMigrations`), open `postgres(process.env.DATABASE_URL, { max: 2 })` (fail fast if unset, mirroring `buildDefaultPorts.createMigrationSql`), call `reconcileExtensionMigrations(migratable, sql, args.stateStore, undefined)`, `await sql.end()` in a finally.
+3. **Tenancy publish:** `registerRuntimeExtensionTenancy(manifest.tenancy)`.
+4. **Stage:** `await defaultStageExtension(module, manifest, args.registry, { helperRoutes })`.
+5. **Validate:** `await assertExtensionTenancyRls(manifest.name, manifest.tenancy)`.
+6. **State seed:** `await stateStore.upsertObserved({ name, configuredVersion: manifest.version, activeVersion: manifest.version, manifestApiVersion: manifest.apiVersion, serverSdkVersion: manifest.requires.serverSdk, webSdkVersion: manifest.requires.webSdk ?? null })`; if `await stateStore.get(name)` had been `null` BEFORE the upsert, `await stateStore.setEnabled(name, true)` (first boot defaults enabled; later boots never touch the flag); `await stateStore.recordActive(name, manifest.version)`.
+7. **Activate:** `args.registry.activate({ ...staged, enabled: await stateStore.isEnabled(name) })`; if `staged.routeApp && manifest.agentRoutes === true`, register both rate-limit skip prefixes (`/api/v1/ext/<name>/agent/`, `/api/v1/<routeNamespace>/agent/`).
+8. **Web asset:** `readWebDist(root)` → `registerExtensionWebAsset(name, asset)`. On ENOENT: `NODE_ENV === 'production'` → rethrow (boot fails — an image without the web bundle is misbuilt); otherwise log one structured warning (`builtin_web_dist_missing`, naming `pnpm --filter @breeze/ext-workspace build:web`) and skip — server routes still activate so API-only dev needs no web build.
+
+Errors are NOT caught-and-continued: built-ins are first-party required code — any phase failure propagates and aborts boot (unlike optional runtime bundles). Do not call `registerExtensionRoot` (fault attribution keys on extracted-root stack paths; built-ins are bundled into the core image, so faults correctly attribute to core).
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/extensions/builtinExtensions.test.ts src/extensions/reconciler.test.ts src/extensions/loader.test.ts
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Add the dependency + run the real typecheck gate**
+
+Add to `apps/api/package.json` dependencies: `"@breeze/ext-workspace": "workspace:*"`, then:
+
+```bash
+pnpm install
+NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --project apps/api/tsconfig.json
+```
+
+Expected: clean. This is where `noUncheckedIndexedAccess` errors inside workspace code would first surface — fix them in `ee/workspace` (narrowing only, no logic changes) if any appear. Check `apps/api/tsconfig.json`'s `include`/`references` — if workspace src is not pulled in via the import graph automatically, tsc will say so with unresolved-module errors; add a path mapping only if needed (the pnpm symlink normally suffices).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/extensions/builtinExtensions.ts apps/api/src/extensions/builtinExtensions.test.ts \
+  apps/api/src/extensions/loader.ts apps/api/src/extensions/reconciler.ts apps/api/package.json pnpm-lock.yaml
+git commit -m "feat(extensions): built-in extension loading path; workspace is the first built-in
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Boot wiring
+
+**Files:**
+- Modify: `apps/api/src/index.ts` (around line 1618 — after `loadSourceExtensions`, before `reconcileExtensions`)
+
+**Interfaces:**
+- Consumes: `loadBuiltinExtensions({ registry, stateStore })` from Task 3; the existing `extensionContributionRegistry` and `extensionStateStore` singletons already in scope at that call site.
+
+- [ ] **Step 1: Wire the call**
+
+```ts
+await loadSourceExtensions(extensionContributionRegistry);
+
+// Built-in (first-party, statically imported) extensions: same staged v1
+// pipeline as signed bundles, no artifact verification. Any failure aborts
+// boot — built-ins are required code, not optional deployments.
+await loadBuiltinExtensions({
+  registry: extensionContributionRegistry,
+  stateStore: extensionStateStore,
+});
+
+await reconcileExtensions({ /* unchanged */ });
+```
+
+Import `loadBuiltinExtensions` alongside the existing `loadSourceExtensions` import (`apps/api/src/index.ts:287`).
+
+- [ ] **Step 2: Boot it against the dev stack**
+
+```bash
+pnpm --filter @breeze/ext-workspace build:web
+pnpm --filter @breeze/api dev   # or the compose dev flow Todd uses; watch boot logs
+```
+
+Expected boot log lines: workspace migrations reconcile (idempotent — the dev DB already has the tables from the seam era; the migrator's ledger handles re-runs), `activated "workspace" at /api/v1/ext/workspace`, no tenancy tripwire errors. Then smoke:
+
+```bash
+curl -s localhost:3001/api/v1/ext/workspace/health   # expect 401/403 (auth-gated), NOT 404
+```
+
+A 404 means the enabled gate is off — check the `installed_extensions` row for `workspace` (`enabled` must be true; Task 3 Step 5.6 seeds it).
+
+- [ ] **Step 3: Run the API extension suite + commit**
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/extensions/
+git add apps/api/src/index.ts
+git commit -m "feat(api): load built-in extensions at boot
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Docker image
+
+**Files:**
+- Modify: `docker/Dockerfile.api` (deps COPY list, builder build steps, runner COPY list, stock-image comment)
+- Check-only: `docker/Dockerfile.api.dev` (bind-mount dev flow — usually needs nothing; verify `ee/` is inside the mounted tree)
+
+- [ ] **Step 1: deps stage — add the package manifests**
+
+After the existing `COPY packages/extension-sdk/package.json ./packages/extension-sdk/` line add:
+
+```dockerfile
+COPY packages/extension-web-sdk/package.json ./packages/extension-web-sdk/
+COPY packages/extension-testkit/package.json ./packages/extension-testkit/
+COPY ee/workspace/package.json ./ee/workspace/
+```
+
+(extension-web-sdk/testkit only if `pnpm install --frozen-lockfile` in the image fails without them — `workspace:*` deps of ee/workspace must be present. Test by building.)
+
+- [ ] **Step 2: builder stage — build the web bundle**
+
+After `RUN pnpm --filter @breeze/api build` add:
+
+```dockerfile
+RUN pnpm --filter @breeze/ext-workspace build:web
+```
+
+(The server code needs no separate build — tsup bundles it into `dist/index.cjs` via the static import.)
+
+- [ ] **Step 3: runner stage — copy migrations + web dist**
+
+After the `COPY ... /app/apps/api/migrations ./migrations` line add:
+
+```dockerfile
+# Built-in extensions: migrations + prebuilt web assets, resolved at runtime
+# relative to cwd (/app) by builtinExtensions.ts.
+COPY --from=builder --chown=hono:nodejs /app/ee/workspace/migrations ./ee/workspace/migrations
+COPY --from=builder --chown=hono:nodejs /app/ee/workspace/manifest.json ./ee/workspace/manifest.json
+COPY --from=builder --chown=hono:nodejs /app/ee/workspace/dist ./ee/workspace/dist
+```
+
+Also update the stock-image comment above the `mkdir -p /app/extensions` line: the image now contains AGPL core + built-in `ee/` code; third-party extensions still arrive only as signed runtime bundles.
+
+- [ ] **Step 4: Build and boot the image**
+
+```bash
+docker build -f docker/Dockerfile.api -t breeze-api:ee-merge .
+docker run --rm breeze-api:ee-merge node -e "require('node:fs').accessSync('/app/ee/workspace/dist/web/index.js'); require('node:fs').accessSync('/app/ee/workspace/manifest.json'); console.log('ok')"
+```
+
+Expected: build succeeds; `ok`. If a full boot against a throwaway DB is cheap in this environment (compose ci profile), do it and verify the `activated "workspace"` log line from a production-mode bundle.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/Dockerfile.api
+git commit -m "build(docker): bake built-in ee/workspace migrations + web assets into the API image
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: CI + integration tests
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (Test API job — add workspace steps next to the extension-sdk steps at lines ~135-144)
+- Modify: `ee/workspace/vitest.integration.config.ts` (env loading repointed at breeze conventions)
+- Check: `eslint` root config covers `ee/` (run `pnpm lint`; if `ee/` is ignored/unmatched, add it to the lint globs)
+
+- [ ] **Step 1: Repoint the integration config's env**
+
+Read how the old config loaded `.env.test` (repo-root of the OLD repo) and how breeze's `apps/api` integration tests get DB env in CI (`grep -n "env.test\|DATABASE_URL" .github/workflows/ci.yml apps/api/vitest*.config.ts`). Make `ee/workspace/vitest.integration.config.ts` load the same source breeze uses. The integration suite's self-provisioned throwaway-DB pattern (`breeze_test_<suffix>`, created + `autoMigrate()`d in beforeAll, FORCE-dropped in afterAll) is kept as-is — never point it at the shared `breeze_test`.
+
+- [ ] **Step 2: Add CI steps**
+
+In the Test API job, after the extension-sdk test/typecheck steps:
+
+```yaml
+      - name: Test workspace (ee)
+        run: pnpm --filter @breeze/ext-workspace test
+
+      - name: Type-check workspace (ee)
+        run: pnpm --filter @breeze/ext-workspace typecheck
+
+      - name: Integration-test workspace (ee)
+        run: pnpm --filter @breeze/ext-workspace test:integration
+```
+
+Place the integration step wherever the job has a Postgres service available — if the Test API job lacks one, put it in the job that runs `apps/api` integration tests instead (find it: `grep -n "postgres" .github/workflows/ci.yml`). The apps/api typecheck step at ci.yml:108 already covers workspace code via the static import — no new step needed for the strict gate.
+
+- [ ] **Step 3: Run everything locally as CI would**
+
+```bash
+pnpm lint
+pnpm --filter @breeze/ext-workspace test
+pnpm --filter @breeze/ext-workspace test:integration
+NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --project apps/api/tsconfig.json
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml ee/workspace/vitest.integration.config.ts
+git commit -m "ci: run ee/workspace tests in breeze CI
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Seam demolition + docs
+
+**Files:**
+- Delete: `extensions/workspace` (the symlink in the breeze repo)
+- Modify: `docs/extensions/build-time-transition.md` (document the built-in path as a distinct first-party mode)
+- Modify: `extensions/README.md` (delivery-path list)
+- Check: root `package.json` — Todd's machine-local UNSTAGED `pnpm.overrides` edit for vendored SDKs, and the untracked compose-override `./package.json:/app/package.json` mount. These are not in git; leave a checklist item for Todd rather than editing his tree: **"Todd: discard the local root-package.json overrides edit + delete the compose override mount — both are dead now."**
+
+- [ ] **Step 1: Remove the symlink**
+
+```bash
+git rm --cached extensions/workspace 2>/dev/null || true   # only if it was ever tracked
+rm extensions/workspace
+```
+
+(It points at `~/orca/workspaces/breeze-workspace/demo-preparation-bcre`; nothing in-repo may reference it — verify with `grep -rn "extensions/workspace" --include="*.ts" --include="*.yml" --include="*.yaml" apps packages docker .github | grep -v node_modules`. Any hit is a dev-flow reference to update to `ee/workspace`.)
+
+- [ ] **Step 2: Docs**
+
+In `docs/extensions/build-time-transition.md`, add a short section after the intro:
+
+```markdown
+## Built-in (first-party) extensions
+
+Since 2026-08, first-party extensions under `ee/` (currently `ee/workspace`)
+are compiled into the API image and registered at boot through the same
+staged v1 pipeline as signed bundles (`builtinExtensions.ts`) — no signing,
+no artifact verification, no source-directory scan. This path is reserved
+for code that lives in this repository. Third-party delivery remains signed
+runtime bundles; the deprecated source-directory path and its removal gate
+below are unaffected. The stock image therefore contains AGPL core plus
+built-in `ee/` code — "extension-free" in the removal-gate sense refers to
+*externally delivered* extension code only.
+```
+
+Update `extensions/README.md`'s description of the directory to note first-party extensions live in `ee/`, not here. Run the doc-verify workflow's local equivalent if one exists (`ls scripts | grep -i doc`).
+
+- [ ] **Step 3: Full suite + commit**
+
+```bash
+pnpm --filter @breeze/api exec vitest run src/extensions/ && pnpm lint
+git add -A extensions docs/extensions
+git commit -m "chore(extensions): retire the workspace symlink dev flow; document the built-in path
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(ee): merge Workspace into the monorepo as a built-in extension" --body "..."
+```
+
+PR body: link the spec, summarize the built-in path, list the deletion inventory, and include the two Todd checklist items (local overrides edit; compose override mount). End with the standard generation footer.
+
+---
+
+### Task 8: Archive the private repo (after the PR merges)
+
+Manual/gh steps — no code. **Do not run until the breeze PR is merged and a dev boot has been verified by Todd.**
+
+- [ ] **Step 1: Migrate open items** — `gh issue list -R LanternOps/breeze-workspace --state open` and `gh pr list -R LanternOps/breeze-workspace --state open`; re-file still-relevant items as breeze issues (label `ee/workspace`), close the rest with a pointer to the merge PR.
+- [ ] **Step 2: Final README** — commit a README banner to breeze-workspace main: "Merged into LanternOps/breeze at `ee/workspace` as of <merge-SHA> (imported at <WS_SHA>). This repo is archived; history lives here."
+- [ ] **Step 3: Archive** — `gh repo archive LanternOps/breeze-workspace --yes`.
+- [ ] **Step 4: Local cleanup checklist for Todd** — the `~/orca/workspaces/breeze-workspace/*` worktrees and `~/breeze-workspace` clone are now historical; the `client-ext-seam-w4` branch's two commits (clientSurfaces/clientPanels legacy-path carry, web-module CORS allowlist) get triaged: keep what serves the third-party platform, drop what existed only for the seam.

--- a/docs/superpowers/specs/2026-08-11-workspace-ee-merge-design.md
+++ b/docs/superpowers/specs/2026-08-11-workspace-ee-merge-design.md
@@ -1,0 +1,157 @@
+# Workspace → `ee/workspace` merge (design)
+
+**Date:** 2026-08-11
+**Status:** Approved direction (Todd, 2026-08-11); implementation plan to follow
+**Supersedes:** the open-core seam consolidation directive of 2026-07-20 and the
+seam-based W4 approach (`ToddHebebrand/client-ext-seam-w4`)
+
+## Decision
+
+Move the Breeze Workspace extension (`LanternOps/breeze-workspace`, private)
+into the public breeze monorepo at `ee/workspace/`, loaded as a **built-in
+extension** (static import), under a commercial license. The two-repo split,
+vendored-SDK tarballs, signing/packing pipeline, and symlink dev flow are
+retired for Workspace. The signed-runtime-bundle platform itself stays intact
+for third-party extensions.
+
+## Why
+
+The extension seam was built to keep proprietary Workspace code out of the
+public AGPL repo. In practice the split imposed a heavy per-change tax:
+vendored `file:vendor/*.tgz` SDK deps, a frozen Ed25519-signed wire format,
+stage/validate/pack scripts, a live stock-host conformance suite, a
+machine-local `pnpm.overrides` hack, a symlinked `extensions/workspace` dev
+flow with compose-override mounts, and cross-repo PR sequencing on nearly
+every change.
+
+Two facts change the calculus:
+
+1. **AGPL-3.0 already provides the protection that matters most** — no one can
+   run a modified Workspace as closed SaaS without publishing changes.
+2. **An `ee/` directory with a commercial license** (the Cal.com pattern:
+   AGPL repo, `ee/` under commercial terms) preserves the "source-visible but
+   not free to resell" lever at near-zero cost, without a second repo.
+
+Merging also dissolves the entire 6-point breeze↔workspace coupling backlog
+(see "Ripple effects").
+
+## Design
+
+### 1. Repo layout & licensing
+
+- Workspace source lands at `ee/workspace/` in breeze, copied from
+  `LanternOps/breeze-workspace` at a pinned SHA, with attribution in the
+  commit message. The private repo is archived (read-only) as the history
+  record.
+- `pnpm-workspace.yaml` gains `ee/*`. The package is renamed
+  `@breeze/ext-workspace` (from `@lanternops/breeze-ext-workspace`) and
+  depends on `@breeze/extension-sdk` / `@breeze/extension-web-sdk` via
+  `workspace:*`.
+- Deleted along with the move: `vendor/` tarballs, `.stubs/`, the packer /
+  sign / stage / validate scripts, the root-`package.json` `pnpm.overrides`
+  entries (currently an unstaged machine-local edit) and the compose-override
+  `package.json` mount, and the `extensions/workspace` symlink.
+- Licensing: `ee/LICENSE` carries the commercial license; root `LICENSE` /
+  `README.md` get one paragraph: everything except `ee/` is AGPL-3.0, `ee/`
+  is covered by the Breeze Commercial License. `ee/workspace/package.json`
+  sets `"license"` accordingly. No runtime license-key gating for now
+  (nothing to gate; can be added if Workspace becomes a sold tier).
+
+### 2. Loading: built-in extension path
+
+A third delivery mode alongside signed runtime bundles and the deprecated
+source-directory scan — **built-in**:
+
+- `apps/api/src/extensions/builtinExtensions.ts` statically imports the
+  workspace package's parsed manifest and v1 register entry and feeds them
+  through the **same v1 host pipeline** as runtime bundles: staged
+  contribution registry, default-deny gateway, tenancy/RLS tripwires,
+  enabled-gate. Workspace remains org-gated exactly as today (DB row per
+  enabled org).
+- No signing, no bundle verification, no discovery scan, no
+  `BREEZE_LEGACY_SOURCE_EXTENSIONS` flag involvement.
+- Static import means tsup bundles Workspace into the API image and
+  `apps/api`'s strict tsconfig (`noUncheckedIndexedAccess` etc.) typechecks
+  it — the extension-cli-style "passes its own gate, fails apps/api's" bug
+  class disappears.
+- The "one delivery path per extension name" boot-failure tripwire extends to
+  built-ins: a runtime artifact or source dir named `workspace` fails boot.
+- The legacy one-arg-`register()` bridge inside the extension is deleted; the
+  built-in path makes the v1 two-arg call directly.
+
+### 3. Migrations
+
+Mechanism unchanged: the extension migrator runs
+`ee/workspace/migrations/*.sql` (idempotent, RLS via
+`breeze_has_org_access`, one transaction per file, no inner BEGIN/COMMIT).
+The built-in registration hands the migrator a `migrationsDir` resolved from
+the package; the API Docker build copies that directory into the image so the
+CJS bundle can find it at boot.
+
+### 4. Web contributions
+
+The contribution / web-asset registry mechanism is kept as-is. Assets are
+produced by the package's normal in-repo build (`tsup.web.config.ts`) and
+served from the package's dist output instead of an unpacked signed artifact.
+Portal-side loading code does not change.
+
+### 5. Tests & CI
+
+- Workspace unit + integration tests join breeze CI as a normal workspace
+  member (same runner as other packages). The isolated-throwaway-DB pattern
+  for full-`reconcileExtensions` integration tests is unchanged.
+- The live stock-host conformance suite is retired as a Workspace gate. The
+  platform keeps its own conformance coverage via the fixtures in
+  `apps/api` (`packerConformance.test.ts` etc.) — it no longer needs
+  Workspace as its reference guinea pig.
+- Docs stating "stock images contain public SDK/host code only" are updated:
+  images now contain AGPL core + `ee/` code; the *runtime-bundle* path still
+  ships nothing third-party in the image.
+
+## Ripple effects
+
+The July coupling inventory dissolves:
+
+1. Legacy loader bridge → deleted (built-in makes the v1 call directly).
+2. Root `pnpm.overrides` machine-local hack + compose mount → deleted
+   (`workspace:*` resolution).
+3. Symlink dev flow → deleted (code is in-repo; dev loop = edit, tsx reload).
+4. W4 client-ai plumbing → the dilemma (move core auth/DLP/add-in code
+   private, or freeze a public seam contract) is cancelled. Add-ins and
+   `packages/office-addin-core` stay in core; Workspace imports them
+   directly. Remaining W4 scope is pure feature work (Workspace content in
+   the in-Excel assistant, org-policy gating, DLP coverage for workspace
+   sources) done as ordinary same-repo development.
+5. Gateway `/agent/:agentId` contract negotiation → moot for Workspace
+   (first-party code uses the gateway as-is; no frozen contract needed).
+6. Duplicate e2e coverage across repos → collapses into breeze CI.
+
+## Sequencing & in-flight work
+
+- **breeze#3032 (tenant-scoped installs, open):** touches extension
+  registration (incl. the new-org registration table every extension must be
+  entered in). Merge #3032 first; the built-in path registers Workspace
+  through that machinery so org-gating keeps working.
+- **`ToddHebebrand/client-ext-seam-w4` (local branch, 2 commits ahead of
+  main + ~25 uncommitted docs edits):** the seam-based W4 approach this
+  design supersedes. Its commits (clientSurfaces/clientPanels through the
+  legacy load path; CORS allowlist for the extension web-module route) should
+  be triaged: keep what serves the third-party platform generally, drop what
+  existed only to reach Workspace across the seam. The uncommitted
+  `apps/docs` edits look unrelated and need separate triage.
+- The workspace repo's open PRs/issues migrate or close at archive time.
+
+## Non-goals
+
+- Dismantling the signed-runtime-bundle platform (stays, for third parties).
+- Moving `breeze-worktrack` in-repo (unaffected; can follow later if wanted).
+- Folding Workspace UI directly into `apps/web` pages (Option B); the
+  contribution mechanism is kept.
+- Runtime license-key enforcement for `ee/` features.
+- Moving Office add-ins or `office-addin-core` anywhere — they stay in core.
+
+## Estimated shape
+
+One focused breeze PR (source move + built-in path + build/CI wiring + license
+files + doc updates), plus archiving the private repo. Roughly a day of
+work once #3032 is merged.

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,27 @@
+The Breeze Commercial License (the "Commercial License")
+Copyright (c) 2026 LanternOps, Inc.
+
+With regard to the Breeze Software:
+
+This software and associated documentation files (the "Software") may only be
+used in production, if you (and any entity that you represent) have agreed to,
+and are in compliance with, a commercial agreement with LanternOps, Inc., or
+other agreements governing the use of the Software, and otherwise have a valid
+license for the correct number of users, devices, or endpoints.
+
+Subject to the foregoing sentence, you are free to modify this Software and
+publish patches to the Software. You agree that LanternOps, Inc. and/or its
+licensors (as applicable) retain all right, title and interest in and to all
+such modifications and/or patches, and all such modifications and/or patches
+may only be used, copied, modified, displayed, distributed, or otherwise
+exploited with a valid commercial license for the Software. You may not copy,
+modify, create derivative works of, publicly display, publicly perform,
+sublicense or distribute this Software except as expressly permitted above.
+
+Any use of the Software outside of a valid commercial agreement is strictly
+prohibited. For clarity, the Software outside of the "ee" directory is
+licensed under AGPL-3.0 as described in the repository root LICENSE file.
+
+This Commercial License applies only to the part of this Software that is in
+the "ee" directory. The full text of this Commercial License shall be included
+in all copies or substantial portions of the Software covered by it.

--- a/ee/workspace/eslint.config.js
+++ b/ee/workspace/eslint.config.js
@@ -1,0 +1,21 @@
+import tsParser from '@typescript-eslint/parser';
+
+// Flat config (ESLint v9+), mirroring packages/shared and apps/api: TS
+// parser, latest ESM, no custom rules yet. `ee/` was previously unmatched by
+// `pnpm lint` (turbo only runs a package's `lint` script if it defines one,
+// and this package didn't) — this file plus the `lint` script below give it
+// the same coverage as the rest of the workspace.
+export default [
+  { ignores: ['dist/**', 'node_modules/**'] },
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    // Match the prior .eslintrc behavior (flat config defaults this to 'warn').
+    linterOptions: { reportUnusedDisableDirectives: 'off' },
+    rules: {},
+  },
+];

--- a/ee/workspace/manifest.json
+++ b/ee/workspace/manifest.json
@@ -41,8 +41,8 @@
         "exclude": []
       },
       "workspace_crawl_runs": {
-        "include": ["id", "org_id", "source_id", "device_id", "device_key", "status", "started_at", "last_activity_at", "completed_at", "cursor", "stats", "error_reason"],
-        "exclude": []
+        "include": ["id", "org_id", "source_id", "device_id", "device_key", "status", "started_at", "last_activity_at", "completed_at", "stats", "error_reason"],
+        "exclude": ["cursor"]
       },
       "workspace_email_filings": {
         "include": ["id", "org_id", "file_index_id", "status", "suggested_project_key", "suggested_project_label", "matched_entity_type", "matched_entity_value", "confidence", "rationale", "decided_project_key", "decided_label", "decided_at", "created_at", "updated_at"],

--- a/ee/workspace/manifest.json
+++ b/ee/workspace/manifest.json
@@ -26,6 +26,60 @@
     "orgCascadeDeleteTables": ["memory_blocks", "workspace_content_chunks", "workspace_content_entities", "workspace_crawl_runs", "workspace_email_filings", "workspace_file_activity", "workspace_file_content", "workspace_file_enrichment", "workspace_file_index", "workspace_org_settings", "workspace_project_crosswalk", "workspace_projects", "workspace_sources"],
     "deviceCascadeDeleteTables": ["workspace_file_index"],
     "deviceOrgDenormalizedTables": ["workspace_file_activity"],
-    "deviceOrgMoveDeleteTables": ["workspace_file_index"]
+    "deviceOrgMoveDeleteTables": ["workspace_file_index"],
+    "orgExportColumns": {
+      "memory_blocks": {
+        "include": ["id", "org_id", "partner_id", "block_type", "subject_key", "content", "confidence", "authored_by_run_id", "confirmed_at", "retracted_at", "superseded_by_id", "created_at", "updated_at"],
+        "exclude": []
+      },
+      "workspace_content_chunks": {
+        "include": ["id", "org_id", "file_index_id", "chunk_index", "text", "created_at"],
+        "exclude": ["embedding"]
+      },
+      "workspace_content_entities": {
+        "include": ["id", "org_id", "file_index_id", "entity_type", "value_norm", "value_raw", "origin", "created_at"],
+        "exclude": []
+      },
+      "workspace_crawl_runs": {
+        "include": ["id", "org_id", "source_id", "device_id", "device_key", "status", "started_at", "last_activity_at", "completed_at", "cursor", "stats", "error_reason"],
+        "exclude": []
+      },
+      "workspace_email_filings": {
+        "include": ["id", "org_id", "file_index_id", "status", "suggested_project_key", "suggested_project_label", "matched_entity_type", "matched_entity_value", "confidence", "rationale", "decided_project_key", "decided_label", "decided_at", "created_at", "updated_at"],
+        "exclude": []
+      },
+      "workspace_file_activity": {
+        "include": ["id", "org_id", "user_id", "file_index_id", "device_id", "action", "created_at", "helper_user"],
+        "exclude": []
+      },
+      "workspace_file_content": {
+        "include": ["id", "org_id", "file_index_id", "content_hash", "source_size", "source_mtime", "extracted_text", "status", "error_reason", "extracted_at", "created_at", "updated_at", "dlp_findings"],
+        "exclude": []
+      },
+      "workspace_file_enrichment": {
+        "include": ["id", "org_id", "file_index_id", "inferred_project_key", "inferred_project_label", "inferred_doc_type", "doc_date", "declared_project_key", "declared_project_label", "email_meta", "confidence", "model", "enriched_at", "created_at", "updated_at"],
+        "exclude": []
+      },
+      "workspace_file_index": {
+        "include": ["id", "org_id", "source_id", "device_id", "device_key", "rel_path", "parent_path", "name", "is_dir", "ext", "mime", "size", "mtime", "ctime", "attrs", "last_seen_at", "deleted_at", "created_at", "updated_at"],
+        "exclude": []
+      },
+      "workspace_org_settings": {
+        "include": ["org_id", "content_enabled", "created_at", "updated_at"],
+        "exclude": ["dlp_config"]
+      },
+      "workspace_project_crosswalk": {
+        "include": ["id", "org_id", "entity_type", "value_norm", "project_key", "project_label", "evidence_count", "sample_file_ids", "mined_at", "created_at", "updated_at"],
+        "exclude": []
+      },
+      "workspace_projects": {
+        "include": ["id", "org_id", "project_key", "label", "aliases", "created_at", "updated_at"],
+        "exclude": []
+      },
+      "workspace_sources": {
+        "include": ["id", "org_id", "kind", "display_name", "root_path", "crawl_device_id", "visibility_group_ids", "exclude_globs", "watch", "crawl_cadence_minutes", "status", "status_detail", "error_reason", "last_complete_run_at", "created_at", "updated_at"],
+        "exclude": ["credential_enc", "crawl_cursor"]
+      }
+    }
   }
 }

--- a/ee/workspace/manifest.json
+++ b/ee/workspace/manifest.json
@@ -1,0 +1,31 @@
+{
+  "apiVersion": "breeze.extensions/v1",
+  "name": "workspace",
+  "version": "0.2.0",
+  "routeNamespace": "workspace",
+  "requires": {
+    "breeze": ">=0.1.0 <0.2.0",
+    "serverSdk": "^1.0.0",
+    "webSdk": "^1.0.0",
+    "capabilities": ["server.routes.v1", "server.agent-routes.v1", "server.db.rls.v1", "server.secrets.v1", "server.audit.v1", "web.pages.v1", "web.navigation.v1", "web.slots.v1"]
+  },
+  "server": { "entry": "server/index.cjs" },
+  "web": {
+    "entry": "web/index.js",
+    "pages": [{ "id": "sources", "path": "/extensions/workspace/sources", "element": "workspace-sources-page" }],
+    "navigation": [{ "id": "sources", "label": "Workspace Sources", "path": "/extensions/workspace/sources", "order": 100 }],
+    "slots": [{ "id": "device-index", "slot": "device.detail.tabs", "contractVersion": 1, "label": "Workspace", "element": "workspace-device-index", "order": 100 }]
+  },
+  "migrationsDir": "migrations",
+  "schemaCompatibilityFloor": "0.2.0",
+  "publicRoutes": [],
+  "agentRoutes": true,
+  "jobs": [],
+  "aiTools": [],
+  "tenancy": {
+    "orgCascadeDeleteTables": ["memory_blocks", "workspace_content_chunks", "workspace_content_entities", "workspace_crawl_runs", "workspace_email_filings", "workspace_file_activity", "workspace_file_content", "workspace_file_enrichment", "workspace_file_index", "workspace_org_settings", "workspace_project_crosswalk", "workspace_projects", "workspace_sources"],
+    "deviceCascadeDeleteTables": ["workspace_file_index"],
+    "deviceOrgDenormalizedTables": ["workspace_file_activity"],
+    "deviceOrgMoveDeleteTables": ["workspace_file_index"]
+  }
+}

--- a/ee/workspace/migrations/2026-07-10-workspace-foundation.sql
+++ b/ee/workspace/migrations/2026-07-10-workspace-foundation.sql
@@ -1,0 +1,128 @@
+-- 2026-07-10: Breeze Workspace extension foundation (phase 1).
+-- Four org-scoped (RLS shape 1) tables:
+--   workspace_sources        — indexed source roots (SMB shares / local profiles)
+--   workspace_file_index     — file + directory metadata index (is_dir/parent_path serve the browser view)
+--   workspace_file_activity  — per-user open/reveal/copy events (recents + department views)
+--   memory_blocks            — Wick-shaped memory foundation (agents author; humans confirm/correct/retract)
+-- Tenancy: all four carry org_id → auto-discovered by the RLS coverage contract
+-- test; cascade/move registration via breeze-extension.json tenancy block.
+-- Device FKs use ON DELETE SET NULL (detach) as of this phase — superseded for
+-- workspace_file_index.device_id (CASCADE + manifest deviceCascadeDeleteTables
+-- entry) in 2026-07-12-crawler.sql.
+-- Idempotent; autoMigrate wraps the file in a transaction — no inner BEGIN/COMMIT.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'workspace_source_kind') THEN
+    CREATE TYPE workspace_source_kind AS ENUM ('smb_share', 'local_profile');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'workspace_source_status') THEN
+    CREATE TYPE workspace_source_status AS ENUM ('active', 'paused', 'error');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'workspace_file_action') THEN
+    CREATE TYPE workspace_file_action AS ENUM ('open', 'reveal', 'copy_path');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS workspace_sources (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  kind workspace_source_kind NOT NULL,
+  display_name text NOT NULL,
+  root_path text NOT NULL,
+  crawl_device_id uuid REFERENCES devices(id) ON DELETE SET NULL,
+  visibility_group_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+  credential_ref uuid,
+  crawl_cadence_minutes integer NOT NULL DEFAULT 360,
+  crawl_cursor jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status workspace_source_status NOT NULL DEFAULT 'active',
+  status_detail text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS wsp_sources_org_idx ON workspace_sources(org_id);
+
+CREATE TABLE IF NOT EXISTS workspace_file_index (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  source_id uuid NOT NULL REFERENCES workspace_sources(id) ON DELETE CASCADE,
+  rel_path text NOT NULL,
+  parent_path text NOT NULL DEFAULT '',
+  name text NOT NULL,
+  is_dir boolean NOT NULL DEFAULT false,
+  ext text,
+  mime text,
+  size bigint,
+  mtime timestamptz,
+  ctime timestamptz,
+  attrs jsonb NOT NULL DEFAULT '{}'::jsonb,
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_file_index_unique ON workspace_file_index(org_id, source_id, rel_path);
+CREATE INDEX IF NOT EXISTS wsp_file_index_parent_idx ON workspace_file_index(org_id, source_id, parent_path);
+CREATE INDEX IF NOT EXISTS wsp_file_index_org_idx ON workspace_file_index(org_id);
+-- Trigram search indexes require pg_extension pg_trgm; create extension only if
+-- available (managed PG has it), skip with a RAISE WARNING otherwise (phase 3
+-- hard-requires it).
+DO $$
+BEGIN
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  CREATE INDEX IF NOT EXISTS wsp_file_index_name_trgm ON workspace_file_index USING gin (name gin_trgm_ops);
+  CREATE INDEX IF NOT EXISTS wsp_file_index_path_trgm ON workspace_file_index USING gin (rel_path gin_trgm_ops);
+EXCEPTION WHEN insufficient_privilege OR undefined_file THEN
+  RAISE WARNING 'pg_trgm unavailable — skipping trigram indexes (search phase requires them)';
+END $$;
+
+CREATE TABLE IF NOT EXISTS workspace_file_activity (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  file_index_id uuid NOT NULL REFERENCES workspace_file_index(id) ON DELETE CASCADE,
+  device_id uuid REFERENCES devices(id) ON DELETE SET NULL,
+  action workspace_file_action NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS wsp_file_activity_org_user_idx ON workspace_file_activity(org_id, user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS wsp_file_activity_device_idx ON workspace_file_activity(device_id);
+
+-- memory_blocks: Wick's exact shape (see internal/specs/2026-06-13 §5).
+-- Agents author; humans confirm/correct/retract. No actor column by design
+-- ("track work, not workers") — the subject lives in subject_key.
+CREATE TABLE IF NOT EXISTS memory_blocks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  partner_id uuid,
+  block_type varchar(64) NOT NULL,
+  subject_key varchar(280) NOT NULL,
+  content jsonb NOT NULL,
+  confidence varchar(16) NOT NULL DEFAULT 'medium',
+  authored_by_run_id uuid REFERENCES ai_sessions(id) ON DELETE SET NULL,
+  confirmed_at timestamptz,
+  retracted_at timestamptz,
+  superseded_by_id uuid REFERENCES memory_blocks(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS memory_blocks_org_subject_idx ON memory_blocks(org_id, subject_key);
+
+-- RLS: shape 1 (direct org_id) on all four tables.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['workspace_sources','workspace_file_index','workspace_file_activity','memory_blocks']
+  LOOP
+    EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+    EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_select ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_insert ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_update ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_delete ON %I', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_select ON %I FOR SELECT USING (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_insert ON %I FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_update ON %I FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_delete ON %I FOR DELETE USING (public.breeze_has_org_access(org_id))', t);
+  END LOOP;
+END $$;

--- a/ee/workspace/migrations/2026-07-12-crawler.sql
+++ b/ee/workspace/migrations/2026-07-12-crawler.sql
@@ -1,0 +1,79 @@
+-- 2026-07-12: Breeze Workspace extension crawler foundation (phase 2).
+-- Adds org-scoped crawl runs, a device dimension to the file index, and
+-- crawler credential/configuration fields to workspace sources.
+-- Tenancy: workspace_crawl_runs carries org_id and uses RLS shape 1.
+-- Device FKs: crawl_runs detach (SET NULL, history); file_index rows CASCADE
+-- with their device (deliberate deviation from phase 1 — see inline comment).
+-- Idempotent; autoMigrate wraps the file in a transaction — no inner BEGIN/COMMIT.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'workspace_crawl_status') THEN
+    CREATE TYPE workspace_crawl_status AS ENUM ('running', 'complete', 'failed', 'abandoned');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS workspace_crawl_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  source_id uuid NOT NULL REFERENCES workspace_sources(id) ON DELETE CASCADE,
+  device_id uuid REFERENCES devices(id) ON DELETE SET NULL,
+  device_key uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000',
+  status workspace_crawl_status NOT NULL DEFAULT 'running',
+  started_at timestamptz NOT NULL DEFAULT now(),
+  last_activity_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  cursor text,
+  stats jsonb NOT NULL DEFAULT '{}'::jsonb,
+  error_reason text
+);
+CREATE INDEX IF NOT EXISTS wsp_crawl_runs_org_source_status_idx
+  ON workspace_crawl_runs(org_id, source_id, status);
+
+-- CASCADE (not the phase-1 SET NULL convention) is deliberate: a deleted
+-- device's local_profile rows are unreachable garbage and must go with it,
+-- and device_key (COALESCE(device_id, zero-uuid)) must never go stale.
+ALTER TABLE workspace_file_index
+  ADD COLUMN IF NOT EXISTS device_id uuid REFERENCES devices(id) ON DELETE CASCADE;
+ALTER TABLE workspace_file_index
+  ADD COLUMN IF NOT EXISTS device_key uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000';
+DO $$
+DECLARE updated_count bigint;
+BEGIN
+  UPDATE workspace_file_index
+  SET device_key = COALESCE(device_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  WHERE device_key IS DISTINCT FROM COALESCE(device_id, '00000000-0000-0000-0000-000000000000'::uuid);
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  IF updated_count > 0 THEN
+    RAISE WARNING 'aligned % workspace_file_index device keys', updated_count;
+  END IF;
+END $$;
+DROP INDEX IF EXISTS wsp_file_index_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_file_index_org_source_device_rel_path_unique
+  ON workspace_file_index(org_id, source_id, device_key, rel_path);
+
+ALTER TABLE workspace_sources ADD COLUMN IF NOT EXISTS credential_enc text;
+ALTER TABLE workspace_sources DROP COLUMN IF EXISTS credential_ref;
+ALTER TABLE workspace_sources ADD COLUMN IF NOT EXISTS exclude_globs jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE workspace_sources ADD COLUMN IF NOT EXISTS watch boolean NOT NULL DEFAULT false;
+ALTER TABLE workspace_sources ADD COLUMN IF NOT EXISTS error_reason text;
+ALTER TABLE workspace_sources ADD COLUMN IF NOT EXISTS last_complete_run_at timestamptz;
+
+-- RLS: shape 1 (direct org_id) on workspace_crawl_runs.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['workspace_crawl_runs']
+  LOOP
+    EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+    EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_select ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_insert ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_update ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_delete ON %I', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_select ON %I FOR SELECT USING (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_insert ON %I FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_update ON %I FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_delete ON %I FOR DELETE USING (public.breeze_has_org_access(org_id))', t);
+  END LOOP;
+END $$;

--- a/ee/workspace/migrations/2026-07-18-finder.sql
+++ b/ee/workspace/migrations/2026-07-18-finder.sql
@@ -1,0 +1,15 @@
+-- 2026-07-18-finder.sql — finder (phase 3) support.
+-- workspace_file_activity: helper sessions have no users-table identity.
+-- user_id becomes nullable; helper_user is a device-local display label
+-- (max 100 chars, matches core helper session label), never authorization.
+
+ALTER TABLE workspace_file_activity ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE workspace_file_activity ADD COLUMN IF NOT EXISTS helper_user varchar(100);
+
+-- Recents: latest activity per device (+ optional label filter).
+CREATE INDEX IF NOT EXISTS wsp_file_activity_org_device_idx
+  ON workspace_file_activity (org_id, device_id, created_at DESC);
+
+-- Search ordering: recency tiebreak within an org.
+CREATE INDEX IF NOT EXISTS wsp_file_index_org_mtime_idx
+  ON workspace_file_index (org_id, mtime DESC NULLS LAST);

--- a/ee/workspace/migrations/2026-07-19-content-chunks.sql
+++ b/ee/workspace/migrations/2026-07-19-content-chunks.sql
@@ -1,0 +1,38 @@
+-- 2026-07-19: Workspace content phase, part 2 — vector chunks (dev-preview).
+-- SPLIT from 2026-07-19-content.sql deliberately: this file hard-requires the
+-- pgvector extension (pgvector/pgvector image swap, verified on the dev and
+-- test stacks 2026-07-18). CREATE EXTENSION vector fails on plain postgres —
+-- do not merge this into an environment whose image has not been swapped.
+-- RLS shape 1; org cascade registered in breeze-extension.json.
+-- Idempotent; autoMigrate wraps the file in a transaction — no inner BEGIN/COMMIT.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS workspace_content_chunks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  file_index_id uuid NOT NULL REFERENCES workspace_file_index(id) ON DELETE CASCADE,
+  chunk_index integer NOT NULL,
+  text text NOT NULL,
+  embedding vector(1024),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_content_chunks_file_chunk_unique
+  ON workspace_content_chunks(file_index_id, chunk_index);
+CREATE INDEX IF NOT EXISTS wsp_content_chunks_org_idx ON workspace_content_chunks(org_id);
+CREATE INDEX IF NOT EXISTS wsp_content_chunks_embedding_hnsw
+  ON workspace_content_chunks USING hnsw (embedding vector_cosine_ops);
+
+DO $$
+BEGIN
+  EXECUTE 'ALTER TABLE workspace_content_chunks ENABLE ROW LEVEL SECURITY';
+  EXECUTE 'ALTER TABLE workspace_content_chunks FORCE ROW LEVEL SECURITY';
+  EXECUTE 'DROP POLICY IF EXISTS breeze_org_isolation_select ON workspace_content_chunks';
+  EXECUTE 'DROP POLICY IF EXISTS breeze_org_isolation_insert ON workspace_content_chunks';
+  EXECUTE 'DROP POLICY IF EXISTS breeze_org_isolation_update ON workspace_content_chunks';
+  EXECUTE 'DROP POLICY IF EXISTS breeze_org_isolation_delete ON workspace_content_chunks';
+  EXECUTE 'CREATE POLICY breeze_org_isolation_select ON workspace_content_chunks FOR SELECT USING (public.breeze_has_org_access(org_id))';
+  EXECUTE 'CREATE POLICY breeze_org_isolation_insert ON workspace_content_chunks FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))';
+  EXECUTE 'CREATE POLICY breeze_org_isolation_update ON workspace_content_chunks FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id))';
+  EXECUTE 'CREATE POLICY breeze_org_isolation_delete ON workspace_content_chunks FOR DELETE USING (public.breeze_has_org_access(org_id))';
+END $$;

--- a/ee/workspace/migrations/2026-07-19-content.sql
+++ b/ee/workspace/migrations/2026-07-19-content.sql
@@ -1,0 +1,188 @@
+-- 2026-07-19: Workspace content phase, part 1 (dev-preview; lexical/entity layer).
+-- Six org-scoped (RLS shape 1) tables:
+--   workspace_file_content      — per-file extracted text + idempotency snapshot + FTS
+--   workspace_content_entities  — deterministic (regex) + LLM person/org entity index
+--   workspace_file_enrichment   — LLM-inferred metadata; declared vs inferred side-by-side
+--   workspace_projects          — per-org project registry (key, label, aliases)
+--   workspace_project_crosswalk — counterparty IDs mined from filed project documents/email
+--   workspace_email_filings     — classify-one-email suggestions + human decisions
+-- The vector/chunks table lands in a LATER migration (requires the pgvector
+-- image on every stack; this file must apply cleanly on plain postgres).
+--
+-- Preview scope: all writers/readers of these tables sit behind the
+-- WORKSPACE_CONTENT_PREVIEW env flag (default off; never on in production).
+-- DLP-on-ingest is explicitly DEFERRED to the Knowledge phase (spec
+-- 2026-07-09 §12 phase 6): extracted_text is stored without content
+-- inspection/redaction. Nothing in this preview claims DLP or governance.
+-- Idempotent; autoMigrate wraps the file in a transaction — no inner BEGIN/COMMIT.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'workspace_content_status') THEN
+    CREATE TYPE workspace_content_status AS ENUM ('extracted', 'failed', 'skipped_too_large', 'skipped_binary');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'workspace_filing_status') THEN
+    CREATE TYPE workspace_filing_status AS ENUM ('suggested', 'confirmed', 'reassigned');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'workspace_filing_confidence') THEN
+    CREATE TYPE workspace_filing_confidence AS ENUM ('high', 'low');
+  END IF;
+END $$;
+
+-- Extraction state. "Pending" is the ABSENCE of a row (or a stale
+-- source_size/source_mtime snapshot vs workspace_file_index) — no pending enum
+-- value, so re-crawls never need a backfill pass here.
+CREATE TABLE IF NOT EXISTS workspace_file_content (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  file_index_id uuid NOT NULL REFERENCES workspace_file_index(id) ON DELETE CASCADE,
+  content_hash text,
+  source_size bigint,
+  source_mtime timestamptz,
+  extracted_text text,
+  status workspace_content_status NOT NULL,
+  error_reason text,
+  extracted_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_file_content_file_unique ON workspace_file_content(file_index_id);
+CREATE INDEX IF NOT EXISTS wsp_file_content_org_idx ON workspace_file_content(org_id);
+CREATE INDEX IF NOT EXISTS wsp_file_content_fts_idx
+  ON workspace_file_content USING gin (to_tsvector('english', coalesce(extracted_text, '')));
+
+-- Entity index. Deterministic regex pass owns the structured types
+-- (apn/po/wdr/invoice/permit/job); the LLM pass may only add person/org rows.
+-- value_norm is the canonical form (uppercased, '#'/whitespace stripped) —
+-- query-side detection MUST normalize identically (src/content/entities.ts).
+CREATE TABLE IF NOT EXISTS workspace_content_entities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  file_index_id uuid NOT NULL REFERENCES workspace_file_index(id) ON DELETE CASCADE,
+  entity_type text NOT NULL,
+  value_norm text NOT NULL,
+  value_raw text,
+  origin text NOT NULL DEFAULT 'regex',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_content_entities_unique
+  ON workspace_content_entities(org_id, file_index_id, entity_type, value_norm);
+CREATE INDEX IF NOT EXISTS wsp_content_entities_lookup_idx
+  ON workspace_content_entities(org_id, entity_type, value_norm);
+DO $$
+BEGIN
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  CREATE INDEX IF NOT EXISTS wsp_content_entities_value_trgm
+    ON workspace_content_entities USING gin (value_norm gin_trgm_ops);
+EXCEPTION WHEN insufficient_privilege OR undefined_file THEN
+  RAISE WARNING 'pg_trgm unavailable — skipping entity trigram index';
+END $$;
+
+-- Inferred metadata (LLM) next to the declared location (derived from
+-- rel_path) so the finder can SHOW disagreement rather than silently "fix" it.
+-- email_meta is written by the mailparser extraction step, never by the LLM.
+CREATE TABLE IF NOT EXISTS workspace_file_enrichment (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  file_index_id uuid NOT NULL REFERENCES workspace_file_index(id) ON DELETE CASCADE,
+  inferred_project_key text,
+  inferred_project_label text,
+  inferred_doc_type text,
+  doc_date date,
+  declared_project_key text,
+  declared_project_label text,
+  email_meta jsonb,
+  confidence varchar(16),
+  model text,
+  enriched_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_file_enrichment_file_unique ON workspace_file_enrichment(file_index_id);
+CREATE INDEX IF NOT EXISTS wsp_file_enrichment_org_idx ON workspace_file_enrichment(org_id);
+CREATE INDEX IF NOT EXISTS wsp_file_enrichment_inferred_project_idx
+  ON workspace_file_enrichment(org_id, inferred_project_key);
+
+-- Project registry, derived from declared folder structure during ingest.
+CREATE TABLE IF NOT EXISTS workspace_projects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  project_key text NOT NULL,
+  label text NOT NULL,
+  aliases jsonb NOT NULL DEFAULT '[]'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_projects_org_key_unique ON workspace_projects(org_id, project_key);
+DO $$
+BEGIN
+  CREATE INDEX IF NOT EXISTS wsp_projects_label_trgm
+    ON workspace_projects USING gin (label gin_trgm_ops);
+EXCEPTION WHEN insufficient_privilege OR undefined_file THEN
+  RAISE WARNING 'pg_trgm unavailable — skipping project label trigram index';
+END $$;
+
+-- Crosswalk: which counterparty identifier (PO/WDR/invoice/permit) belongs to
+-- which project, mined from documents/email already filed under a declared
+-- project. evidence_count counts DISTINCT files, never mentions.
+CREATE TABLE IF NOT EXISTS workspace_project_crosswalk (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  entity_type text NOT NULL,
+  value_norm text NOT NULL,
+  project_key text NOT NULL,
+  project_label text,
+  evidence_count integer NOT NULL DEFAULT 0,
+  sample_file_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+  mined_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_project_crosswalk_unique
+  ON workspace_project_crosswalk(org_id, entity_type, value_norm, project_key);
+CREATE INDEX IF NOT EXISTS wsp_project_crosswalk_org_idx ON workspace_project_crosswalk(org_id);
+
+-- Filing suggestions + decisions for unfiled email. decided_label is the
+-- device-local helper display label (matches workspace_file_activity.helper_user
+-- semantics) — never an authorization input, no user FK by design.
+CREATE TABLE IF NOT EXISTS workspace_email_filings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  file_index_id uuid NOT NULL REFERENCES workspace_file_index(id) ON DELETE CASCADE,
+  status workspace_filing_status NOT NULL DEFAULT 'suggested',
+  suggested_project_key text,
+  suggested_project_label text,
+  matched_entity_type text,
+  matched_entity_value text,
+  confidence workspace_filing_confidence NOT NULL DEFAULT 'low',
+  rationale text,
+  decided_project_key text,
+  decided_label varchar(100),
+  decided_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_email_filings_file_unique ON workspace_email_filings(file_index_id);
+CREATE INDEX IF NOT EXISTS wsp_email_filings_org_status_idx ON workspace_email_filings(org_id, status);
+
+-- RLS: shape 1 (direct org_id) on all six tables.
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'workspace_file_content','workspace_content_entities','workspace_file_enrichment',
+    'workspace_projects','workspace_project_crosswalk','workspace_email_filings'
+  ]
+  LOOP
+    EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+    EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_select ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_insert ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_update ON %I', t);
+    EXECUTE format('DROP POLICY IF EXISTS breeze_org_isolation_delete ON %I', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_select ON %I FOR SELECT USING (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_insert ON %I FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_update ON %I FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id))', t);
+    EXECUTE format('CREATE POLICY breeze_org_isolation_delete ON %I FOR DELETE USING (public.breeze_has_org_access(org_id))', t);
+  END LOOP;
+END $$;

--- a/ee/workspace/migrations/2026-07-24-org-settings-dlp.sql
+++ b/ee/workspace/migrations/2026-07-24-org-settings-dlp.sql
@@ -1,0 +1,41 @@
+-- W2: per-org governance settings + DLP-on-ingest columns.
+-- workspace_org_settings is org-scoped (RLS shape 1, same as the six content
+-- tables in 2026-07-19-content.sql) but keyed directly by org_id (one row per
+-- org) rather than a synthetic id — a single settings row per tenant.
+-- Idempotent; autoMigrate wraps the file in a transaction — no inner BEGIN/COMMIT.
+
+CREATE TABLE IF NOT EXISTS workspace_org_settings (
+  org_id uuid PRIMARY KEY,
+  content_enabled boolean NOT NULL DEFAULT false,
+  dlp_config jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- DLP-on-ingest findings.
+ALTER TABLE workspace_file_content
+  ADD COLUMN IF NOT EXISTS dlp_findings jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- 'blocked_dlp' becomes a legal value of the existing `status` column.
+-- Correction vs the original plan text: status is the workspace_content_status
+-- ENUM (not a text column) in this codebase, so it needs an explicit ADD
+-- VALUE — see src/schema/content.ts for the drizzle-side note. Safe inside
+-- autoMigrate's wrapping transaction (PG12+: ADD VALUE may run in a
+-- transaction as long as the new value isn't used in that same transaction,
+-- which it isn't here).
+ALTER TYPE workspace_content_status ADD VALUE IF NOT EXISTS 'blocked_dlp';
+
+-- RLS: shape 1 (direct org_id) on workspace_org_settings.
+DO $$
+BEGIN
+  ALTER TABLE workspace_org_settings ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE workspace_org_settings FORCE ROW LEVEL SECURITY;
+  DROP POLICY IF EXISTS breeze_org_isolation_select ON workspace_org_settings;
+  DROP POLICY IF EXISTS breeze_org_isolation_insert ON workspace_org_settings;
+  DROP POLICY IF EXISTS breeze_org_isolation_update ON workspace_org_settings;
+  DROP POLICY IF EXISTS breeze_org_isolation_delete ON workspace_org_settings;
+  CREATE POLICY breeze_org_isolation_select ON workspace_org_settings FOR SELECT USING (public.breeze_has_org_access(org_id));
+  CREATE POLICY breeze_org_isolation_insert ON workspace_org_settings FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+  CREATE POLICY breeze_org_isolation_update ON workspace_org_settings FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id));
+  CREATE POLICY breeze_org_isolation_delete ON workspace_org_settings FOR DELETE USING (public.breeze_has_org_access(org_id));
+END $$;

--- a/ee/workspace/package.json
+++ b/ee/workspace/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@breeze/ext-workspace",
+  "version": "0.2.0",
+  "private": true,
+  "license": "SEE LICENSE IN ../LICENSE",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build:web": "tsup --config tsup.web.config.ts",
+    "test": "vitest run --config vitest.config.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.112.3",
+    "@breeze/extension-sdk": "workspace:*",
+    "@breeze/extension-web-sdk": "workspace:*",
+    "drizzle-orm": "0.45.2",
+    "hono": "4.13.1",
+    "mailparser": "^3.9.14",
+    "v9u-smb2": "^1.0.6",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@breeze/extension-testkit": "workspace:*",
+    "@types/mailparser": "^3.4.6",
+    "@types/node": "^26.2.0",
+    "dotenv": "16.6.1",
+    "happy-dom": "^20.11.0",
+    "postgres": "3.4.9",
+    "tsup": "8.5.1",
+    "tsx": "^4.23.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/ee/workspace/package.json
+++ b/ee/workspace/package.json
@@ -7,6 +7,7 @@
   "main": "src/index.ts",
   "scripts": {
     "build:web": "tsup --config tsup.web.config.ts",
+    "lint": "eslint src",
     "test": "vitest run --config vitest.config.ts",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit"

--- a/ee/workspace/src/__tests__/content.integration.test.ts
+++ b/ee/workspace/src/__tests__/content.integration.test.ts
@@ -1,0 +1,164 @@
+// Content phase (dev-preview) — migration/RLS/lifecycle integration coverage.
+// Mirrors workspaceRls.integration.test.ts bootstrap (:5433 stack, breeze_app
+// role, asOrg GUC scoping). Covers, per new content table:
+//   - RLS shape 1: org A context can neither read nor forge org B rows
+//   - migration idempotency: the SQL file re-applies cleanly on a migrated DB
+//   - tombstone semantics: content/entity rows SURVIVE a soft-delete (cascade
+//     only fires on hard delete) — retrieval joins are responsible for hiding
+//     them (covered by the search suite)
+//   - file hard-delete cascades content/entities/enrichment/filings
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let partnerA: string, partnerB: string, orgA: string, orgB: string;
+let sourceA: string, sourceB: string, fileA: string, fileB: string;
+
+const CONTENT_TABLES = [
+  'workspace_file_content', 'workspace_content_entities', 'workspace_file_enrichment',
+  'workspace_projects', 'workspace_project_crosswalk', 'workspace_email_filings',
+] as const;
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  partnerA = randomUUID(); partnerB = randomUUID();
+  orgA = randomUUID(); orgB = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug)
+              VALUES (${partnerA}, 'wsp-content-a', ${`wsp-content-a-${sfx}`}),
+                     (${partnerB}, 'wsp-content-b', ${`wsp-content-b-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${orgA}, ${partnerA}, 'wsp-content-org-a', ${`wsp-content-org-a-${sfx}`}),
+                     (${orgB}, ${partnerB}, 'wsp-content-org-b', ${`wsp-content-org-b-${sfx}`})`;
+  sourceA = randomUUID(); sourceB = randomUUID();
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path)
+              VALUES (${sourceA}, ${orgA}, 'smb_share', 'a share', '\\\\srv\\a'),
+                     (${sourceB}, ${orgB}, 'smb_share', 'b share', '\\\\srv\\b')`;
+  fileA = randomUUID(); fileB = randomUUID();
+  await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, parent_path, name)
+              VALUES (${fileA}, ${orgA}, ${sourceA}, 'Projects/x/doc.md', 'Projects/x', 'doc.md'),
+                     (${fileB}, ${orgB}, ${sourceB}, 'Projects/y/doc.md', 'Projects/y', 'doc.md')`;
+  // Org B fixture rows (the foil the org-A context must never see).
+  await admin`INSERT INTO workspace_file_content (org_id, file_index_id, status, extracted_text)
+              VALUES (${orgB}, ${fileB}, 'extracted', 'org b secret text')`;
+  await admin`INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm)
+              VALUES (${orgB}, ${fileB}, 'po', 'PO 9999')`;
+  await admin`INSERT INTO workspace_file_enrichment (org_id, file_index_id, inferred_doc_type)
+              VALUES (${orgB}, ${fileB}, 'deed')`;
+  await admin`INSERT INTO workspace_projects (org_id, project_key, label)
+              VALUES (${orgB}, '9999-001', 'Org B Project')`;
+  await admin`INSERT INTO workspace_project_crosswalk (org_id, entity_type, value_norm, project_key, evidence_count)
+              VALUES (${orgB}, 'po', 'PO 9999', '9999-001', 3)`;
+  await admin`INSERT INTO workspace_email_filings (org_id, file_index_id)
+              VALUES (${orgB}, ${fileB})`;
+});
+
+afterAll(async () => {
+  for (const t of CONTENT_TABLES) {
+    await admin.unsafe(`DELETE FROM ${t} WHERE org_id IN ($1, $2)`, [orgA, orgB]);
+  }
+  await admin`DELETE FROM workspace_file_index WHERE org_id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM workspace_sources WHERE org_id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM organizations WHERE id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM partners WHERE id IN (${partnerA}, ${partnerB})`;
+  await admin.end(); await app.end();
+});
+
+async function asOrgA<T>(fn: (tx: postgres.TransactionSql) => Promise<T>): Promise<T> {
+  return app.begin(async (tx) => {
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${orgA}, true),
+                    set_config('breeze.accessible_org_ids', ${orgA}, true),
+                    set_config('breeze.accessible_partner_ids', ${partnerA}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(tx);
+  }) as Promise<T>;
+}
+
+describe('content migration idempotency', () => {
+  it('re-applies cleanly on an already-migrated database', async () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const sql = readFileSync(join(here, '../../migrations/2026-07-19-content.sql'), 'utf8');
+    await admin.begin(async (tx) => { await tx.unsafe(sql); });
+    // and again, outside a fresh transaction, to be sure
+    await admin.begin(async (tx) => { await tx.unsafe(sql); });
+  });
+});
+
+describe('content tables RLS (cross-tenant as breeze_app)', () => {
+  it('org A context reads zero org B rows from every content table', async () => {
+    for (const t of CONTENT_TABLES) {
+      const rows = await asOrgA((tx) => tx.unsafe(`SELECT id FROM ${t} WHERE org_id = $1`, [orgB]));
+      expect(rows, t).toHaveLength(0);
+    }
+  });
+
+  it('org A context cannot forge org B rows (insert forbidden per table)', async () => {
+    const inserts: Record<(typeof CONTENT_TABLES)[number], () => Promise<unknown>> = {
+      workspace_file_content: () => asOrgA((tx) =>
+        tx`INSERT INTO workspace_file_content (org_id, file_index_id, status) VALUES (${orgB}, ${fileB}, 'failed')`),
+      workspace_content_entities: () => asOrgA((tx) =>
+        tx`INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm) VALUES (${orgB}, ${fileB}, 'po', 'PO 1')`),
+      workspace_file_enrichment: () => asOrgA((tx) =>
+        tx`INSERT INTO workspace_file_enrichment (org_id, file_index_id) VALUES (${orgB}, ${fileB})`),
+      workspace_projects: () => asOrgA((tx) =>
+        tx`INSERT INTO workspace_projects (org_id, project_key, label) VALUES (${orgB}, 'x', 'x')`),
+      workspace_project_crosswalk: () => asOrgA((tx) =>
+        tx`INSERT INTO workspace_project_crosswalk (org_id, entity_type, value_norm, project_key) VALUES (${orgB}, 'po', 'PO 1', 'x')`),
+      workspace_email_filings: () => asOrgA((tx) =>
+        tx`INSERT INTO workspace_email_filings (org_id, file_index_id) VALUES (${orgB}, ${fileB})`),
+    };
+    for (const t of CONTENT_TABLES) {
+      await expect(inserts[t](), t).rejects.toThrow(
+        new RegExp(`row-level security policy for table "${t}"`),
+      );
+    }
+  });
+
+  it('org A can write and read back its own content rows', async () => {
+    await asOrgA(async (tx) => {
+      await tx`INSERT INTO workspace_file_content (org_id, file_index_id, status, extracted_text, content_hash, source_size)
+               VALUES (${orgA}, ${fileA}, 'extracted', 'the quick brown fox', 'abc123', 19)`;
+      await tx`INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm)
+               VALUES (${orgA}, ${fileA}, 'apn', '057-071-012')`;
+    });
+    const rows = await asOrgA((tx) =>
+      tx`SELECT extracted_text FROM workspace_file_content WHERE file_index_id = ${fileA}`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].extracted_text).toBe('the quick brown fox');
+  });
+});
+
+describe('lifecycle: tombstone vs hard delete', () => {
+  it('soft-delete (tombstone) leaves content and entity rows in place', async () => {
+    await admin`UPDATE workspace_file_index SET deleted_at = now() WHERE id = ${fileA}`;
+    const content = await admin`SELECT id FROM workspace_file_content WHERE file_index_id = ${fileA}`;
+    const entities = await admin`SELECT id FROM workspace_content_entities WHERE file_index_id = ${fileA}`;
+    expect(content).toHaveLength(1);
+    expect(entities).toHaveLength(1);
+    // resurrect for the next test
+    await admin`UPDATE workspace_file_index SET deleted_at = NULL WHERE id = ${fileA}`;
+  });
+
+  it('hard delete of the file cascades content/entities/enrichment/filings', async () => {
+    await admin`INSERT INTO workspace_file_enrichment (org_id, file_index_id, inferred_doc_type)
+                VALUES (${orgA}, ${fileA}, 'memo')`;
+    await admin`INSERT INTO workspace_email_filings (org_id, file_index_id) VALUES (${orgA}, ${fileA})`;
+    await admin`DELETE FROM workspace_file_index WHERE id = ${fileA}`;
+    for (const t of ['workspace_file_content', 'workspace_content_entities', 'workspace_file_enrichment', 'workspace_email_filings']) {
+      const rows = await admin.unsafe(`SELECT id FROM ${t} WHERE file_index_id = $1`, [fileA]);
+      expect(rows, t).toHaveLength(0);
+    }
+  });
+});

--- a/ee/workspace/src/__tests__/contentSearch.integration.test.ts
+++ b/ee/workspace/src/__tests__/contentSearch.integration.test.ts
@@ -1,0 +1,308 @@
+// Hybrid retrieval — real-DB integration (:5433). Seeds a miniature estate
+// shaped like the demo corpus traps: entity-only matches (APN in body, not
+// name), the misfile shape (sole FTS-AND hit vs many name matches), project
+// resolution, tombstone/visibility exclusion, and the disagreement flag.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createContentSearchService } from '../services/contentSearchService';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partner: string, org: string, source: string, hiddenSource: string;
+const DEVICE = randomUUID();
+
+interface SeedFile {
+  key: string;
+  rel: string;
+  text?: string;
+  entities?: Array<{ type: string; value: string }>;
+  enrichment?: Record<string, string | null>;
+  tombstoned?: boolean;
+  sourceOverride?: string;
+  /** Content chunks (workspace_content_chunks). Defaults to a single chunk of `text`. */
+  chunks?: string[];
+}
+
+// A chunk longer than the 700-char passage byte cap, matching "easement".
+const LONG_EASEMENT_CHUNK = `easement continuation: ${'the parties further covenant and agree regarding the said easement across the parcel. '.repeat(12)}`;
+
+const ids: Record<string, string> = {};
+
+const SEED: SeedFile[] = [
+  {
+    key: 'scan34',
+    rel: 'Projects/2024-007 Vine Hill Winery Site Plan/scan_0034.md',
+    text: 'GRANT OF EASEMENT. Kowalski Family Trust grants to the City of Fairoaks an easement for the Henderson Road Water Main Replacement Project across APN 042-330-021.',
+    entities: [{ type: 'apn', value: '042-330-021' }],
+    enrichment: {
+      inferred_project_key: '2023-041', inferred_project_label: 'Henderson Water Main Replacement',
+      inferred_doc_type: 'easement deed',
+      declared_project_key: '2024-007', declared_project_label: 'Vine Hill Winery Site Plan',
+    },
+    // Two chunks: the deed body (the top passage) plus an over-cap continuation
+    // that proves snippet byte-capping.
+    chunks: [
+      'GRANT OF EASEMENT. Kowalski Family Trust grants to the City of Fairoaks an easement for the Henderson Road Water Main Replacement Project across APN 042-330-021.',
+      LONG_EASEMENT_CHUNK,
+    ],
+  },
+  // Name-match foils: "henderson" in path/name but no "easement" in body.
+  ...Array.from({ length: 8 }, (_, i) => ({
+    key: `hend${i}`,
+    rel: `Projects/2023-041 Henderson Water Main Replacement/henderson-doc-${i}.md`,
+    text: `Progress notes ${i} for the water main job. Pipe staging and paving.`,
+  })),
+  {
+    key: 'ros',
+    rel: 'Projects/2019-112 Quail Hollow Estates ROS/record_of_survey.md',
+    text: 'Record of survey narrative for Quail Hollow Estates, APN 057-071-012 and APN 057-071-013.',
+    entities: [{ type: 'apn', value: '057-071-012' }, { type: 'apn', value: '057-071-013' }],
+  },
+  {
+    key: 'corner',
+    rel: 'Projects/2019-112 Quail Hollow Estates ROS/CornerRecord.md',
+    text: 'Corner record, found pipe at the northwest corner of Lot 3, APN 057-071-012.',
+    entities: [{ type: 'apn', value: '057-071-012' }],
+  },
+  {
+    key: 'title-email',
+    rel: 'Emails/2019-112/title order request.eml',
+    text: 'Subject: title order\n\nPlease open a title order for APN 057-071-012.',
+    entities: [{ type: 'apn', value: '057-071-012' }],
+  },
+  // A file whose NAME carries the APN-ish digits but body does not (trigram foil).
+  { key: 'foil', rel: 'Legacy/057-scan-index.md', text: 'Old scanning index, no parcels here.' },
+  { key: 'tomb', rel: 'Projects/2019-112 Quail Hollow Estates ROS/tombstoned.md', text: 'APN 057-071-012 haunted file', entities: [{ type: 'apn', value: '057-071-012' }], tombstoned: true },
+  // hidden's chunk is a STRONG lexical match for "easement henderson" — the
+  // visibility scope, not weak ranking, is what must keep it unreachable.
+  {
+    key: 'hidden', rel: 'Secret/hidden.md', text: 'APN 057-071-012 in a hidden source',
+    entities: [{ type: 'apn', value: '057-071-012' }], sourceOverride: 'hidden',
+    chunks: ['GRANT OF EASEMENT for the Henderson Road Water Main Replacement — this hidden passage must never surface.'],
+  },
+];
+
+async function asOrg<T>(fn: (svc: ReturnType<typeof createContentSearchService>) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } })
+      .session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(createContentSearchService(transaction as unknown as WorkspaceDatabase));
+  });
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partner = randomUUID(); org = randomUUID(); source = randomUUID(); hiddenSource = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug) VALUES (${partner}, 'wsp-search', ${`wsp-search-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${org}, ${partner}, 'wsp-search-org', ${`wsp-search-org-${sfx}`})`;
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, visibility_group_ids)
+              VALUES (${source}, ${org}, 'smb_share', 'estate', '\\\\srv\\estate', '[]'::jsonb),
+                     (${hiddenSource}, ${org}, 'smb_share', 'hidden', '\\\\srv\\hidden', '["g1"]'::jsonb)`;
+  await admin`INSERT INTO workspace_projects (org_id, project_key, label)
+              VALUES (${org}, '2019-112', 'Quail Hollow Estates ROS'),
+                     (${org}, '2023-041', 'Henderson Water Main Replacement')`;
+  for (const f of SEED) {
+    const id = randomUUID();
+    ids[f.key] = id;
+    const srcId = f.sourceOverride === 'hidden' ? hiddenSource : source;
+    const name = f.rel.split('/').pop()!;
+    const parent = f.rel.slice(0, f.rel.lastIndexOf('/'));
+    const ext = name.includes('.') ? name.split('.').pop()!.toLowerCase() : null;
+    await admin`INSERT INTO workspace_file_index
+        (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime, deleted_at)
+        VALUES (${id}, ${org}, ${srcId}, ${f.rel}, ${parent}, ${name}, false, ${ext}, 500, now(),
+                ${f.tombstoned ? admin`now()` : null})`;
+    if (f.text) {
+      await admin`INSERT INTO workspace_file_content (org_id, file_index_id, status, extracted_text, source_size, source_mtime)
+                  VALUES (${org}, ${id}, 'extracted', ${f.text}, 500, now())`;
+    }
+    // Chunks power the passages() retrieval arms. No embedder in tests →
+    // embedding stays NULL and only the FTS/trigram arms rank them.
+    const chunks = f.chunks ?? (f.text ? [f.text] : []);
+    for (let i = 0; i < chunks.length; i += 1) {
+      await admin`INSERT INTO workspace_content_chunks (org_id, file_index_id, chunk_index, text)
+                  VALUES (${org}, ${id}, ${i}, ${chunks[i]})`;
+    }
+    for (const e of f.entities ?? []) {
+      await admin`INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm, origin)
+                  VALUES (${org}, ${id}, ${e.type}, ${e.value}, 'regex')`;
+    }
+    if (f.enrichment) {
+      await admin`INSERT INTO workspace_file_enrichment ${admin({
+        org_id: org, file_index_id: id, ...f.enrichment,
+      })}`;
+    }
+  }
+});
+
+afterAll(async () => {
+  for (const t of ['workspace_content_chunks', 'workspace_content_entities', 'workspace_file_enrichment',
+    'workspace_file_content', 'workspace_projects', 'workspace_file_index', 'workspace_sources']) {
+    await admin.unsafe(`DELETE FROM ${t} WHERE org_id = $1`, [org]);
+  }
+  await admin`DELETE FROM organizations WHERE id = ${org}`;
+  await admin`DELETE FROM partners WHERE id = ${partner}`;
+  await admin.end(); await app.end();
+});
+
+describe('hybrid content search (RRF, real DB)', () => {
+  it('Beat-2 shape: an APN query surfaces entity-carrying files above the name foil', async () => {
+    const results = await asOrg((svc) => svc.search(org, DEVICE, { q: '057-071-012' }));
+    const top3 = results.slice(0, 3).map((r) => r.id);
+    expect(top3).toEqual(expect.arrayContaining([ids.ros, ids.corner, ids['title-email']]));
+    // hidden-source and tombstoned entity hits never appear at all
+    const all = results.map((r) => r.id);
+    expect(all).not.toContain(ids.tomb);
+    expect(all).not.toContain(ids.hidden);
+    // matched entities are reported for the UI
+    expect(results[0].matchedEntities).toEqual([{ type: 'apn', value: '057-071-012' }]);
+  });
+
+  it('Beat-3 shape: "Henderson easement" ranks the misfiled deed first with the disagreement flag', async () => {
+    const results = await asOrg((svc) => svc.search(org, DEVICE, { q: 'Henderson easement' }));
+    expect(results[0].id).toBe(ids.scan34);
+    expect(results[0].metadataDisagreement).toBe(true);
+    expect(results[0].inferredDocType).toBe('easement deed');
+    expect(results[0].declaredProjectLabel).toBe('Vine Hill Winery Site Plan');
+    expect(results[0].snippet).toMatch(/easement/i);
+  });
+
+  it('project resolution: "the Quail Hollow parcel" pulls the 2019-112 set', async () => {
+    const results = await asOrg((svc) => svc.search(org, DEVICE, { q: 'the Quail Hollow parcel' }));
+    const top3 = results.slice(0, 3).map((r) => r.id);
+    expect(top3).toEqual(expect.arrayContaining([ids.ros]));
+    const all = results.map((r) => r.id);
+    expect(all).toEqual(expect.arrayContaining([ids.ros, ids.corner, ids['title-email']]));
+  });
+
+  it('groups emails distinctly and keeps filename search working (Beat 1)', async () => {
+    const results = await asOrg((svc) => svc.search(org, DEVICE, { q: '057-071-012' }));
+    const email = results.find((r) => r.id === ids['title-email']);
+    expect(email?.group).toBe('email');
+
+    const byName = await asOrg((svc) => svc.search(org, DEVICE, { q: 'CornerRecord' }));
+    expect(byName.map((r) => r.id)).toContain(ids.corner);
+  });
+
+  it('project/docType filters narrow to the enriched deed, excluding the unenriched name foils', async () => {
+    const all = await asOrg((svc) => svc.search(org, DEVICE, { q: 'henderson' }));
+    expect(all.map((r) => r.id)).toContain(ids.scan34);
+    expect(all.length).toBeGreaterThan(1); // the 8 unenriched name foils also match "henderson"
+
+    const byDocType = await asOrg((svc) => svc.search(org, DEVICE, {
+      q: 'henderson', docType: 'easement deed',
+    }));
+    expect(byDocType.map((r) => r.id)).toEqual([ids.scan34]);
+    expect(byDocType.length).toBeLessThan(all.length);
+
+    const byProject = await asOrg((svc) => svc.search(org, DEVICE, {
+      q: 'henderson', project: 'Henderson Water Main Replacement',
+    }));
+    expect(byProject.map((r) => r.id)).toEqual([ids.scan34]);
+
+    const noMatch = await asOrg((svc) => svc.search(org, DEVICE, {
+      q: 'henderson', docType: 'no-such-doc-type',
+    }));
+    expect(noMatch).toEqual([]);
+  });
+
+  it('respects sourceId scoping and limit clamping', async () => {
+    const results = await asOrg((svc) => svc.search(org, DEVICE, {
+      q: '057-071-012', sourceId: hiddenSource,
+    }));
+    expect(results).toEqual([]); // hidden source is not visible → empty scope
+
+    const limited = await asOrg((svc) => svc.search(org, DEVICE, { q: 'the', limit: 2 }));
+    expect(limited.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('passages (visibility-scoped chunk retrieval, real DB)', () => {
+  it('ranks the easement chunk first, populates openPath for smb, and byte-caps snippets', async () => {
+    const passages = await asOrg((svc) => svc.passages(org, 'easement henderson', { helperDeviceId: DEVICE }));
+    expect(passages.length).toBeGreaterThan(0);
+    expect(passages.length).toBeLessThanOrEqual(6);
+    expect(passages[0].fileIndexId).toBe(ids.scan34);
+    expect(passages[0].sourceId).toBe(source);
+    expect(passages[0].snippet).toMatch(/easement/i);
+    expect(passages[0].openPath).toBe(
+      '\\\\srv\\estate\\Projects\\2024-007 Vine Hill Winery Site Plan\\scan_0034.md',
+    );
+    for (const p of passages) {
+      expect(p.snippet.length).toBeLessThanOrEqual(700);
+      expect(p.fileIndexId).not.toBe(ids.tomb);
+      expect(p.fileIndexId).not.toBe(ids.hidden);
+    }
+  });
+
+  it('never surfaces a passage from a hidden source even when it is the strongest lexical match', async () => {
+    // hidden's chunk literally contains "easement" and "Henderson" — only the
+    // fail-closed visibility scope keeps it out of the result set.
+    const passages = await asOrg((svc) => svc.passages(org, 'easement henderson', { helperDeviceId: DEVICE }));
+    expect(passages.map((p) => p.fileIndexId)).not.toContain(ids.hidden);
+  });
+
+  it('fileIndexId narrows retrieval to that single file', async () => {
+    const broad = await asOrg((svc) => svc.passages(org, 'water main', { helperDeviceId: DEVICE }));
+    expect(broad.length).toBeGreaterThan(1);
+    const narrowed = await asOrg((svc) => svc.passages(org, 'water main', {
+      helperDeviceId: DEVICE, fileIndexId: ids.scan34,
+    }));
+    expect(narrowed.length).toBeGreaterThan(0);
+    expect(narrowed.every((p) => p.fileIndexId === ids.scan34)).toBe(true);
+    expect(narrowed.length).toBeLessThan(broad.length);
+  });
+
+  it('caps at 6 passages and truncates an over-cap snippet to 700 chars', async () => {
+    const capped = await asOrg((svc) => svc.passages(org, 'water main', { helperDeviceId: DEVICE, limit: 50 }));
+    expect(capped.length).toBeLessThanOrEqual(6);
+    // scan34's long continuation chunk exceeds 700 chars pre-cap → proves the cap bites.
+    const easement = await asOrg((svc) => svc.passages(org, 'easement', { helperDeviceId: DEVICE }));
+    expect(easement.some((p) => p.snippet.length === 700)).toBe(true);
+    expect(easement.every((p) => p.snippet.length <= 700)).toBe(true);
+  });
+});
+
+describe('group intersection (claim-scoped visibility)', () => {
+  // The hidden source carries visibility_group_ids ['g1']. A caller whose claim
+  // set overlaps it now reaches its file (search) and its chunk (passages)
+  // through the SAME shared predicate — the fail-closed default ([]) keeps them
+  // out, and a non-overlapping claim (['g3']) does too.
+  it('search surfaces the hidden-source entity hit only for an overlapping claim', async () => {
+    const member = await asOrg((svc) => svc.search(org, DEVICE, { q: '057-071-012' }, ['g1']));
+    expect(member.map((r) => r.id)).toContain(ids.hidden);
+
+    for (const claims of [[], ['g3']]) {
+      const scoped = await asOrg((svc) => svc.search(org, DEVICE, { q: '057-071-012' }, claims));
+      expect(scoped.map((r) => r.id)).not.toContain(ids.hidden);
+    }
+  });
+
+  it('passages retrieves the hidden-source chunk only for an overlapping claim', async () => {
+    const member = await asOrg((svc) => svc.passages(org, 'easement henderson', { helperDeviceId: DEVICE }, ['g1']));
+    expect(member.map((p) => p.fileIndexId)).toContain(ids.hidden);
+
+    for (const claims of [[], ['g3']]) {
+      const scoped = await asOrg((svc) => svc.passages(org, 'easement henderson', { helperDeviceId: DEVICE }, claims));
+      expect(scoped.map((p) => p.fileIndexId)).not.toContain(ids.hidden);
+    }
+  });
+});

--- a/ee/workspace/src/__tests__/crawler.integration.test.ts
+++ b/ee/workspace/src/__tests__/crawler.integration.test.ts
@@ -1,0 +1,545 @@
+import { randomUUID } from 'node:crypto';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createBatchUpsertService, type BatchEntry } from '../services/batchUpsertService';
+import { createCrawlRunsService } from '../services/crawlRunsService';
+import { createSourcesService } from '../services/sourcesService';
+
+const ADMIN_URL = process.env.DATABASE_URL
+  ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP
+  ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
+if (new URL(ADMIN_URL).port === '5432' || new URL(APP_URL).port === '5432') {
+  throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+}
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partnerId: string;
+let orgId: string;
+let siteId: string;
+let deviceA: string;
+let deviceB: string;
+let smbSourceId: string;
+let localSourceId: string;
+
+type AppContext = {
+  tx: postgres.TransactionSql;
+  sources: ReturnType<typeof createSourcesService>;
+  runs: ReturnType<typeof createCrawlRunsService>;
+  batches: ReturnType<typeof createBatchUpsertService>;
+};
+
+async function asOrg<T>(fn: (context: AppContext) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } })
+      .session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${orgId}, true),
+                    set_config('breeze.accessible_org_ids', ${orgId}, true),
+                    set_config('breeze.accessible_partner_ids', ${partnerId}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    const db = transaction as unknown as WorkspaceDatabase;
+    return fn({
+      tx,
+      sources: createSourcesService(db),
+      runs: createCrawlRunsService(db),
+      batches: createBatchUpsertService(db),
+    });
+  });
+}
+
+function entry(
+  relPath: string,
+  options: Partial<Omit<BatchEntry, 'relPath'>> = {},
+): BatchEntry {
+  const slash = relPath.lastIndexOf('/');
+  const name = relPath.slice(slash + 1);
+  return {
+    relPath,
+    parentPath: slash < 0 ? '' : relPath.slice(0, slash),
+    name,
+    isDir: false,
+    size: 100,
+    mtime: '2026-07-12T12:00:00.000Z',
+    ctime: null,
+    ext: name.includes('.') ? name.split('.').at(-1) : null,
+    attrs: {},
+    ...options,
+  };
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partnerId = randomUUID();
+  orgId = randomUUID();
+  siteId = randomUUID();
+  deviceA = randomUUID();
+  deviceB = randomUUID();
+  const suffix = randomUUID();
+
+  await admin`INSERT INTO partners (id, name, slug)
+              VALUES (${partnerId}, 'workspace crawler integration', ${`wsp-crawler-${suffix}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${orgId}, ${partnerId}, 'workspace crawler org', ${`wsp-crawler-org-${suffix}`})`;
+  await admin`INSERT INTO sites (id, org_id, name)
+              VALUES (${siteId}, ${orgId}, 'workspace crawler site')`;
+  await admin`INSERT INTO devices
+                (id, org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version)
+              VALUES
+                (${deviceA}, ${orgId}, ${siteId}, ${`wsp-crawler-a-${suffix}`}, 'crawler-a', 'windows', '11', 'amd64', 'test'),
+                (${deviceB}, ${orgId}, ${siteId}, ${`wsp-crawler-b-${suffix}`}, 'crawler-b', 'windows', '11', 'amd64', 'test')`;
+
+  await asOrg(async ({ sources, tx }) => {
+    const smb = await sources.create(orgId, {
+      kind: 'smb_share',
+      displayName: 'Crawler SMB share',
+      rootPath: '\\\\server\\share',
+      crawlDeviceId: deviceA,
+      visibilityGroupIds: [],
+      crawlCadenceMinutes: 60,
+      excludeGlobs: [],
+      watch: false,
+      status: 'active',
+    });
+    const local = await sources.create(orgId, {
+      kind: 'local_profile',
+      displayName: 'Crawler local profiles',
+      rootPath: '/Users',
+      crawlDeviceId: null,
+      visibilityGroupIds: [],
+      crawlCadenceMinutes: 60,
+      excludeGlobs: [],
+      watch: false,
+      status: 'active',
+    });
+    smbSourceId = smb.id;
+    localSourceId = local.id;
+
+    const rows = await tx<Array<{ id: string; kind: string; crawl_device_id: string | null }>>`
+      SELECT id, kind, crawl_device_id
+      FROM workspace_sources
+      WHERE org_id = ${orgId}
+      ORDER BY kind`;
+    expect(rows).toEqual([
+      { id: smbSourceId, kind: 'smb_share', crawl_device_id: deviceA },
+      { id: localSourceId, kind: 'local_profile', crawl_device_id: null },
+    ]);
+  });
+});
+
+afterAll(async () => {
+  if (!admin) return;
+  try {
+    await admin`DELETE FROM workspace_file_activity WHERE org_id = ${orgId}`;
+    await admin`DELETE FROM workspace_crawl_runs WHERE org_id = ${orgId}`;
+    await admin`DELETE FROM workspace_file_index WHERE org_id = ${orgId}`;
+    await admin`DELETE FROM workspace_sources WHERE org_id = ${orgId}`;
+    await admin`DELETE FROM devices WHERE id IN (${deviceA}, ${deviceB})`;
+    await admin`DELETE FROM sites WHERE id = ${siteId}`;
+    await admin`DELETE FROM organizations WHERE id = ${orgId}`;
+    await admin`DELETE FROM partners WHERE id = ${partnerId}`;
+  } finally {
+    await admin.end();
+    await app?.end();
+  }
+});
+
+describe.sequential('workspace crawler end-to-end integration', () => {
+  it('completes an SMB crawl, sweeps stale rows, resurrects a victim, and preserves rows on failure', async () => {
+    let firstRunId = '';
+    let firstRunStartedAt = new Date(0);
+
+    await asOrg(async ({ runs }) => {
+      const started = await runs.start(orgId, smbSourceId, deviceA);
+      expect(started).not.toHaveProperty('conflict');
+      if (!('run' in started)) throw new Error('expected the first SMB run to start');
+      firstRunId = started.run.id;
+      firstRunStartedAt = started.run.startedAt;
+    });
+
+    await asOrg(async ({ batches }) => {
+      await batches.upsertBatch(orgId, smbSourceId, ZERO_UUID, [
+        entry('docs', { isDir: true, size: 0, ext: null }),
+        entry('docs/guide.txt'),
+      ]);
+    });
+    await asOrg(async ({ batches, tx }) => {
+      await batches.upsertBatch(orgId, smbSourceId, ZERO_UUID, [entry('readme.md')]);
+
+      const rows = await tx<Array<{
+        rel_path: string;
+        is_dir: boolean;
+        device_key: string;
+        deleted_at: string | null;
+        last_seen_at: string;
+      }>>`
+        SELECT rel_path, is_dir, device_key, deleted_at, last_seen_at
+        FROM workspace_file_index
+        WHERE org_id = ${orgId} AND source_id = ${smbSourceId}
+        ORDER BY rel_path`;
+      expect(rows).toHaveLength(3);
+      expect(rows.map((row) => [row.rel_path, row.is_dir])).toEqual([
+        ['docs', true],
+        ['docs/guide.txt', false],
+        ['readme.md', false],
+      ]);
+      expect(rows.every((row) => row.device_key === ZERO_UUID && row.deleted_at === null)).toBe(true);
+      expect(rows.every((row) => new Date(row.last_seen_at).getTime() >= firstRunStartedAt.getTime()))
+        .toBe(true);
+    });
+
+    const victimId = randomUUID();
+    await admin`INSERT INTO workspace_file_index
+                  (id, org_id, source_id, device_id, device_key, rel_path, parent_path, name,
+                   is_dir, size, mtime, last_seen_at, deleted_at)
+                VALUES
+                  (${victimId}, ${orgId}, ${smbSourceId}, null, ${ZERO_UUID},
+                   'stale/victim.txt', 'stale', 'victim.txt', false, 7, now() - interval '2 hours',
+                   now() - interval '2 hours', null)`;
+
+    await asOrg(async ({ runs, tx }) => {
+      await runs.finish(orgId, firstRunId, deviceA, { complete: true, stats: { seen: 3 } });
+      const [run] = await tx<Array<{ status: string; completed_at: string | null }>>`
+        SELECT status, completed_at FROM workspace_crawl_runs WHERE id = ${firstRunId}`;
+      const files = await tx<Array<{ rel_path: string; deleted_at: string | null }>>`
+        SELECT rel_path, deleted_at
+        FROM workspace_file_index
+        WHERE org_id = ${orgId} AND source_id = ${smbSourceId}
+        ORDER BY rel_path`;
+      const [source] = await tx<Array<{ status: string; last_complete_run_at: string | null }>>`
+        SELECT status, last_complete_run_at FROM workspace_sources WHERE id = ${smbSourceId}`;
+
+      expect(run?.status).toBe('complete');
+      expect(run?.completed_at).toEqual(expect.any(String));
+      expect(files.find((row) => row.rel_path === 'stale/victim.txt')?.deleted_at)
+        .toEqual(expect.any(String));
+      expect(files.filter((row) => row.rel_path !== 'stale/victim.txt'))
+        .toHaveLength(3);
+      expect(files.filter((row) => row.rel_path !== 'stale/victim.txt')
+        .every((row) => row.deleted_at === null)).toBe(true);
+      expect(source?.status).toBe('active');
+      expect(source?.last_complete_run_at).toEqual(expect.any(String));
+    });
+
+    let resurrectionRunId = '';
+    let resurrectionLastSeenAt = '';
+    let resurrectionRunStartedAt = '';
+    await asOrg(async ({ runs }) => {
+      const started = await runs.start(orgId, smbSourceId, deviceA);
+      if (!('run' in started)) throw new Error('expected the resurrection run to start');
+      resurrectionRunId = started.run.id;
+    });
+    await asOrg(async ({ batches, tx }) => {
+      await batches.upsertBatch(orgId, smbSourceId, ZERO_UUID, [entry('stale/victim.txt')]);
+
+      const [victim] = await tx<Array<{
+        id: string;
+        deleted_at: string | null;
+        last_seen_at: string;
+        run_started_at: string;
+      }>>`
+        SELECT f.id, f.deleted_at, f.last_seen_at, r.started_at AS run_started_at
+        FROM workspace_file_index f
+        JOIN workspace_crawl_runs r ON r.id = ${resurrectionRunId}
+        WHERE f.org_id = ${orgId} AND f.source_id = ${smbSourceId}
+          AND f.device_key = ${ZERO_UUID} AND f.rel_path = 'stale/victim.txt'`;
+      expect(victim).toMatchObject({ id: victimId, deleted_at: null });
+      expect(new Date(victim?.last_seen_at ?? 0).getTime())
+        .toBeGreaterThanOrEqual(new Date(victim?.run_started_at ?? 0).getTime());
+      resurrectionLastSeenAt = victim?.last_seen_at ?? '';
+      resurrectionRunStartedAt = victim?.run_started_at ?? '';
+    });
+
+    await asOrg(async ({ runs, tx }) => {
+      await runs.finish(orgId, resurrectionRunId, deviceA, { complete: true, stats: { seen: 1 } });
+      const [run] = await tx<Array<{ status: string }>>`
+        SELECT status FROM workspace_crawl_runs WHERE id = ${resurrectionRunId}`;
+      const [readback] = await tx<Array<{ deleted_at: string | null }>>`
+        SELECT deleted_at FROM workspace_file_index WHERE id = ${victimId}`;
+      expect(run?.status).toBe('complete');
+      expect(
+        readback?.deleted_at,
+        `resurrected row was swept: last_seen_at=${resurrectionLastSeenAt}, run.started_at=${resurrectionRunStartedAt}`,
+      ).toBeNull();
+    });
+
+    const failureSurvivorId = randomUUID();
+    await admin`INSERT INTO workspace_file_index
+                  (id, org_id, source_id, device_id, device_key, rel_path, parent_path, name,
+                   is_dir, size, mtime, last_seen_at, deleted_at)
+                VALUES
+                  (${failureSurvivorId}, ${orgId}, ${smbSourceId}, null, ${ZERO_UUID},
+                   'stale/auth-survivor.txt', 'stale', 'auth-survivor.txt', false, 8,
+                   now() - interval '3 hours', now() - interval '3 hours', null)`;
+
+    let failureRunId = '';
+    await asOrg(async ({ runs }) => {
+      const started = await runs.start(orgId, smbSourceId, deviceA);
+      if (!('run' in started)) throw new Error('expected the failed run to start');
+      failureRunId = started.run.id;
+    });
+    await asOrg(async ({ runs, tx }) => {
+      await runs.finish(orgId, failureRunId, deviceA, {
+        complete: false,
+        errorReason: 'auth failed: invalid SMB credentials',
+      });
+
+      const [run] = await tx<Array<{ status: string; error_reason: string | null }>>`
+        SELECT status, error_reason FROM workspace_crawl_runs WHERE id = ${failureRunId}`;
+      const [source] = await tx<Array<{ status: string; error_reason: string | null }>>`
+        SELECT status, error_reason FROM workspace_sources WHERE id = ${smbSourceId}`;
+      const [survivor] = await tx<Array<{ deleted_at: string | null }>>`
+        SELECT deleted_at FROM workspace_file_index WHERE id = ${failureSurvivorId}`;
+      const aliveCount = await tx<Array<{ count: number }>>`
+        SELECT count(*)::int AS count
+        FROM workspace_file_index
+        WHERE org_id = ${orgId} AND source_id = ${smbSourceId} AND deleted_at IS NULL`;
+
+      expect(run).toEqual({ status: 'failed', error_reason: 'auth failed: invalid SMB credentials' });
+      expect(source).toEqual({ status: 'error', error_reason: 'auth failed: invalid SMB credentials' });
+      expect(survivor?.deleted_at).toBeNull();
+      expect(aliveCount[0]?.count).toBe(2);
+    });
+  });
+
+  it('isolates local-profile sweeps by device key even when relative paths overlap', async () => {
+    let deviceBRunId = '';
+    await asOrg(async ({ runs }) => {
+      const started = await runs.start(orgId, localSourceId, deviceB);
+      if (!('run' in started)) throw new Error('expected device B local-profile run to start');
+      deviceBRunId = started.run.id;
+    });
+    await asOrg(async ({ batches, tx }) => {
+      await batches.upsertBatch(orgId, localSourceId, deviceB, [
+        entry('shared/overlap.txt'),
+        entry('device-b/only.txt'),
+      ]);
+      const rows = await tx<Array<{ rel_path: string; device_key: string }>>`
+        SELECT rel_path, device_key
+        FROM workspace_file_index
+        WHERE org_id = ${orgId} AND source_id = ${localSourceId} AND device_key = ${deviceB}
+        ORDER BY rel_path`;
+      expect(rows).toEqual([
+        { rel_path: 'device-b/only.txt', device_key: deviceB },
+        { rel_path: 'shared/overlap.txt', device_key: deviceB },
+      ]);
+    });
+
+    const staleAId = randomUUID();
+    await admin`UPDATE workspace_file_index
+                SET last_seen_at = now() - interval '2 hours'
+                WHERE org_id = ${orgId} AND source_id = ${localSourceId} AND device_key = ${deviceB}`;
+    await admin`INSERT INTO workspace_file_index
+                  (id, org_id, source_id, device_id, device_key, rel_path, parent_path, name,
+                   is_dir, size, last_seen_at, deleted_at)
+                VALUES
+                  (${staleAId}, ${orgId}, ${localSourceId}, ${deviceA}, ${deviceA},
+                   'device-a/stale.txt', 'device-a', 'stale.txt', false, 1,
+                   now() - interval '2 hours', null)`;
+
+    let deviceARunId = '';
+    await asOrg(async ({ runs }) => {
+      const started = await runs.start(orgId, localSourceId, deviceA);
+      if (!('run' in started)) throw new Error('expected device A local-profile run to start');
+      deviceARunId = started.run.id;
+    });
+    await asOrg(async ({ batches }) => {
+      await batches.upsertBatch(orgId, localSourceId, deviceA, [
+        entry('shared/overlap.txt'),
+        entry('device-a/only.txt'),
+      ]);
+    });
+    await asOrg(async ({ runs, tx }) => {
+      await runs.finish(orgId, deviceARunId, deviceA, { complete: true, stats: { seen: 2 } });
+
+      const rows = await tx<Array<{
+        id: string;
+        rel_path: string;
+        device_key: string;
+        deleted_at: string | null;
+      }>>`
+        SELECT id, rel_path, device_key, deleted_at
+        FROM workspace_file_index
+        WHERE org_id = ${orgId} AND source_id = ${localSourceId}
+        ORDER BY device_key, rel_path`;
+      const overlapRows = rows.filter((row) => row.rel_path === 'shared/overlap.txt');
+      const deviceBRows = rows.filter((row) => row.device_key === deviceB);
+      const [runB] = await tx<Array<{ status: string }>>`
+        SELECT status FROM workspace_crawl_runs WHERE id = ${deviceBRunId}`;
+
+      expect(rows).toHaveLength(5);
+      expect(overlapRows).toHaveLength(2);
+      expect(new Set(overlapRows.map((row) => row.device_key))).toEqual(new Set([deviceA, deviceB]));
+      expect(rows.find((row) => row.id === staleAId)?.deleted_at).toEqual(expect.any(String));
+      expect(deviceBRows).toHaveLength(2);
+      expect(deviceBRows.every((row) => row.deleted_at === null)).toBe(true);
+      expect(runB?.status).toBe('running');
+    });
+  });
+
+  // Depends on the auth-failure test above leaving the SMB source in status
+  // 'error': the next complete run must heal it (status active, reason
+  // cleared) or fixed credentials leave the source stuck in error forever.
+  it('recovers an errored source to active on the next complete run', async () => {
+    await asOrg(async ({ tx }) => {
+      const [before] = await tx<Array<{ status: string }>>`
+        SELECT status FROM workspace_sources WHERE id = ${smbSourceId}`;
+      expect(before?.status).toBe('error');
+    });
+
+    let recoveryRunId = '';
+    await asOrg(async ({ runs }) => {
+      const started = await runs.start(orgId, smbSourceId, deviceA);
+      if (!('run' in started)) throw new Error('expected the recovery run to start');
+      recoveryRunId = started.run.id;
+    });
+    await asOrg(async ({ batches }) => {
+      await batches.upsertBatch(orgId, smbSourceId, ZERO_UUID, [entry('docs/guide.txt')]);
+    });
+    await asOrg(async ({ runs, tx }) => {
+      await runs.finish(orgId, recoveryRunId, deviceA, { complete: true, stats: { seen: 1 } });
+      const [source] = await tx<Array<{ status: string; error_reason: string | null }>>`
+        SELECT status, error_reason FROM workspace_sources WHERE id = ${smbSourceId}`;
+      expect(source).toEqual({ status: 'active', error_reason: null });
+    });
+  });
+
+  it('surfaces a non-auth failure on the source without flipping its status', async () => {
+    let runId = '';
+    await asOrg(async ({ runs }) => {
+      const started = await runs.start(orgId, smbSourceId, deviceA);
+      if (!('run' in started)) throw new Error('expected the io-failure run to start');
+      runId = started.run.id;
+    });
+    await asOrg(async ({ runs, tx }) => {
+      await runs.finish(orgId, runId, deviceA, {
+        complete: false,
+        errorReason: 'share unreachable: connection timed out',
+      });
+      const [source] = await tx<Array<{ status: string; error_reason: string | null }>>`
+        SELECT status, error_reason FROM workspace_sources WHERE id = ${smbSourceId}`;
+      // Visible to admins via errorReason, but a transient failure must not
+      // park the source in 'error' (that state is reserved for credential
+      // problems needing re-entry).
+      expect(source).toEqual({
+        status: 'active',
+        error_reason: 'share unreachable: connection timed out',
+      });
+    });
+  });
+
+  it('answers a retried finish idempotently against the real status machine', async () => {
+    let runId = '';
+    await asOrg(async ({ runs }) => {
+      const started = await runs.start(orgId, smbSourceId, deviceA);
+      if (!('run' in started)) throw new Error('expected the idempotency run to start');
+      runId = started.run.id;
+    });
+    await asOrg(async ({ runs }) => {
+      const first = await runs.finish(orgId, runId, deviceA, { complete: true });
+      expect(first).toHaveProperty('tombstoned');
+      // Lost-response retry: same device, same run, already terminal.
+      const retry = await runs.finish(orgId, runId, deviceA, { complete: true });
+      expect(retry).toEqual({ alreadyFinished: true });
+    });
+  });
+
+  it('admits exactly one run across truly concurrent starts on separate connections', async () => {
+    // The advisory-lock serialization only means something across real
+    // connections — a shared max:1 pool would serialize at the pool instead.
+    const app2 = postgres(APP_URL, { max: 1 });
+    const appDb2 = drizzle(app2);
+    const asOrgOn = async <T>(
+      dbClient: ReturnType<typeof drizzle>,
+      fn: (context: AppContext) => Promise<T>,
+    ): Promise<T> => dbClient.transaction(async (transaction) => {
+      const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } })
+        .session.client;
+      await tx`SELECT set_config('breeze.scope', 'organization', true),
+                      set_config('breeze.org_id', ${orgId}, true),
+                      set_config('breeze.accessible_org_ids', ${orgId}, true),
+                      set_config('breeze.accessible_partner_ids', ${partnerId}, true),
+                      set_config('breeze.user_id', '', true),
+                      set_config('breeze.current_partner_id', '', true)`;
+      const db = transaction as unknown as WorkspaceDatabase;
+      return fn({
+        tx,
+        sources: createSourcesService(db),
+        runs: createCrawlRunsService(db),
+        batches: createBatchUpsertService(db),
+      });
+    });
+
+    try {
+      const raceSourceId = await asOrg(async ({ sources }) => (await sources.create(orgId, {
+        kind: 'local_profile',
+        displayName: 'Crawler race source',
+        rootPath: '/Users',
+        crawlDeviceId: null,
+        visibilityGroupIds: [],
+        crawlCadenceMinutes: 60,
+        excludeGlobs: [],
+        watch: false,
+        status: 'active',
+      })).id);
+
+      const [first, second] = await Promise.all([
+        asOrgOn(appDb, ({ runs }) => runs.start(orgId, raceSourceId, deviceA)),
+        asOrgOn(appDb2, ({ runs }) => runs.start(orgId, raceSourceId, deviceA)),
+      ]);
+
+      const runsStarted = [first, second].filter((result) => 'run' in result);
+      const conflicts = [first, second].filter((result) => 'conflict' in result);
+      expect(runsStarted).toHaveLength(1);
+      expect(conflicts).toHaveLength(1);
+
+      const rows = await admin`SELECT id FROM workspace_crawl_runs
+                               WHERE org_id = ${orgId} AND source_id = ${raceSourceId}
+                                 AND status = 'running'`;
+      expect(rows).toHaveLength(1);
+    } finally {
+      await app2.end();
+    }
+  });
+
+  it('abandons a stale active run before creating its replacement', async () => {
+    const staleRunId = randomUUID();
+    await admin`INSERT INTO workspace_crawl_runs
+                  (id, org_id, source_id, device_id, device_key, status, started_at, last_activity_at)
+                VALUES
+                  (${staleRunId}, ${orgId}, ${localSourceId}, ${deviceA}, ${deviceA}, 'running',
+                   now() - interval '2 hours', now() - interval '2 hours')`;
+
+    await asOrg(async ({ runs, tx }) => {
+      const started = await runs.start(orgId, localSourceId, deviceA);
+      if (!('run' in started)) throw new Error('expected a replacement run to start');
+      const rows = await tx<Array<{
+        id: string;
+        status: string;
+        completed_at: string | null;
+        last_activity_at: string;
+      }>>`
+        SELECT id, status, completed_at, last_activity_at
+        FROM workspace_crawl_runs
+        WHERE id IN (${staleRunId}, ${started.run.id})
+        ORDER BY started_at`;
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0]?.id).toBe(staleRunId);
+      expect(rows[0]?.status).toBe('abandoned');
+      expect(rows[0]?.completed_at).toEqual(expect.any(String));
+      expect(rows[1]).toMatchObject({ id: started.run.id, status: 'running', completed_at: null });
+      expect(new Date(rows[1]?.last_activity_at ?? 0).getTime())
+        .toBeGreaterThan(new Date(rows[0]?.last_activity_at ?? 0).getTime());
+    });
+  });
+});

--- a/ee/workspace/src/__tests__/deviceSummary.integration.test.ts
+++ b/ee/workspace/src/__tests__/deviceSummary.integration.test.ts
@@ -1,0 +1,316 @@
+// Real-SQL cover for the device summary aggregate. The unit suite records what
+// the service asks the database for; this one proves the query actually runs
+// under the org-scoped (RLS-enforcing) connection and returns the right
+// numbers — including the tombstone exclusion, the DISTINCT source count, the
+// completed-runs filter, and the cross-org 404.
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createDeviceSummaryService } from '../services/deviceSummaryService';
+
+const ADMIN_URL = process.env.DATABASE_URL
+  ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP
+  ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+
+if (new URL(ADMIN_URL).port === '5432' || new URL(APP_URL).port === '5432') {
+  throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+}
+
+const COMPLETED_AT = new Date('2026-07-12T10:00:00.000Z');
+const OLDER_COMPLETED_AT = new Date('2026-07-11T10:00:00.000Z');
+const LAST_ACTIVITY_AT = new Date('2026-07-12T11:30:00.000Z');
+// A terminal-but-failed run that stamped completed_at AFTER the last good crawl.
+const FAILED_COMPLETED_AT = new Date('2026-07-12T12:00:00.000Z');
+// Newer than every device-scoped timestamp, so SMB rows moving in or out of a
+// device's summary are immediately visible in the timestamps.
+const SMB_CRAWL_AT = new Date('2026-07-13T09:00:00.000Z');
+// Newer still, and owned by a DIFFERENT device: if the owned-sources subquery
+// ever loses its crawl_device_id anchor, this timestamp surfaces on deviceA.
+const FOREIGN_SMB_CRAWL_AT = new Date('2026-07-14T09:00:00.000Z');
+const SHARED_DEVICE_KEY = '00000000-0000-0000-0000-000000000000';
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partnerId: string;
+let orgA: string;
+let orgB: string;
+let siteA: string;
+let siteB: string;
+let deviceA: string;
+let otherDeviceA: string;
+let smbOnlyDeviceA: string;
+let deviceB: string;
+let sourceOne: string;
+let sourceTwo: string;
+
+/** Run fn as breeze_app inside the given org's access context. */
+async function asOrg<T>(
+  orgId: string,
+  fn: (service: ReturnType<typeof createDeviceSummaryService>) => Promise<T>,
+): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } })
+      .session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${orgId}, true),
+                    set_config('breeze.accessible_org_ids', ${orgId}, true),
+                    set_config('breeze.accessible_partner_ids', ${partnerId}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(createDeviceSummaryService(transaction as unknown as WorkspaceDatabase));
+  });
+}
+
+/**
+ * Stand up an SMB share in orgA crawled by `crawlDeviceId`, with source-scoped
+ * index rows and one completed source-scoped run, run `fn`, then remove it.
+ * Source-scoped means device_id NULL / device_key = the shared zero uuid, per
+ * runScope.ts — the owning device appears only as crawl_device_id.
+ *
+ * Torn down in a finally so a failing assertion cannot leak rows into the
+ * later tests in this sequential suite.
+ */
+async function withSmbSource(
+  crawlDeviceId: string,
+  relPaths: string[],
+  crawledAt: Date,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const smbSource = randomUUID();
+  await admin`INSERT INTO workspace_sources
+                (id, org_id, kind, display_name, root_path, crawl_device_id)
+              VALUES (${smbSource}, ${orgA}, 'smb_share', 'summary smb', '\\\\srv\\share', ${crawlDeviceId})`;
+  for (const relPath of relPaths) {
+    await admin`INSERT INTO workspace_file_index
+                  (org_id, source_id, device_id, device_key, rel_path, name)
+                VALUES (${orgA}, ${smbSource}, NULL, ${SHARED_DEVICE_KEY}, ${relPath}, ${relPath})`;
+  }
+  await admin`INSERT INTO workspace_crawl_runs
+                (org_id, source_id, device_id, device_key, status, started_at, last_activity_at, completed_at)
+              VALUES (${orgA}, ${smbSource}, NULL, ${SHARED_DEVICE_KEY}, 'complete',
+                      ${crawledAt}, ${crawledAt}, ${crawledAt})`;
+  try {
+    await fn();
+  } finally {
+    await admin`DELETE FROM workspace_crawl_runs WHERE source_id = ${smbSource}`;
+    await admin`DELETE FROM workspace_file_index WHERE source_id = ${smbSource}`;
+    await admin`DELETE FROM workspace_sources WHERE id = ${smbSource}`;
+  }
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partnerId = randomUUID();
+  orgA = randomUUID();
+  orgB = randomUUID();
+  siteA = randomUUID();
+  siteB = randomUUID();
+  deviceA = randomUUID();
+  otherDeviceA = randomUUID();
+  smbOnlyDeviceA = randomUUID();
+  deviceB = randomUUID();
+  sourceOne = randomUUID();
+  sourceTwo = randomUUID();
+  const suffix = randomUUID();
+
+  await admin`INSERT INTO partners (id, name, slug)
+              VALUES (${partnerId}, 'workspace summary integration', ${`wsp-summary-${suffix}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${orgA}, ${partnerId}, 'wsp summary org a', ${`wsp-summary-a-${suffix}`}),
+                     (${orgB}, ${partnerId}, 'wsp summary org b', ${`wsp-summary-b-${suffix}`})`;
+  await admin`INSERT INTO sites (id, org_id, name)
+              VALUES (${siteA}, ${orgA}, 'wsp summary site a'),
+                     (${siteB}, ${orgB}, 'wsp summary site b')`;
+  await admin`INSERT INTO devices
+                (id, org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version)
+              VALUES
+                (${deviceA}, ${orgA}, ${siteA}, ${`wsp-sum-a-${suffix}`}, 'sum-a', 'windows', '11', 'amd64', 'test'),
+                (${otherDeviceA}, ${orgA}, ${siteA}, ${`wsp-sum-a2-${suffix}`}, 'sum-a2', 'windows', '11', 'amd64', 'test'),
+                (${smbOnlyDeviceA}, ${orgA}, ${siteA}, ${`wsp-sum-a3-${suffix}`}, 'sum-a3', 'windows', '11', 'amd64', 'test'),
+                (${deviceB}, ${orgB}, ${siteB}, ${`wsp-sum-b-${suffix}`}, 'sum-b', 'windows', '11', 'amd64', 'test')`;
+
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, crawl_device_id)
+              VALUES (${sourceOne}, ${orgA}, 'local_profile', 'summary one', '/Users', NULL),
+                     (${sourceTwo}, ${orgA}, 'local_profile', 'summary two', '/Shared', NULL)`;
+
+  // deviceA: 3 live rows across 2 sources + 1 tombstone (must not be counted).
+  await admin`INSERT INTO workspace_file_index
+                (org_id, source_id, device_id, device_key, rel_path, name, deleted_at)
+              VALUES
+                (${orgA}, ${sourceOne}, ${deviceA}, ${deviceA}, 'a/one.txt', 'one.txt', NULL),
+                (${orgA}, ${sourceOne}, ${deviceA}, ${deviceA}, 'a/two.txt', 'two.txt', NULL),
+                (${orgA}, ${sourceTwo}, ${deviceA}, ${deviceA}, 'b/three.txt', 'three.txt', NULL),
+                (${orgA}, ${sourceOne}, ${deviceA}, ${deviceA}, 'a/gone.txt', 'gone.txt', now())`;
+  // Same org, different device — must never bleed into deviceA's counts.
+  await admin`INSERT INTO workspace_file_index
+                (org_id, source_id, device_id, device_key, rel_path, name)
+              VALUES (${orgA}, ${sourceOne}, ${otherDeviceA}, ${otherDeviceA}, 'c/other.txt', 'other.txt')`;
+
+  await admin`INSERT INTO workspace_crawl_runs
+                (org_id, source_id, device_id, device_key, status, started_at, last_activity_at, completed_at)
+              VALUES
+                (${orgA}, ${sourceOne}, ${deviceA}, ${deviceA}, 'complete',
+                 ${OLDER_COMPLETED_AT}, ${OLDER_COMPLETED_AT}, ${OLDER_COMPLETED_AT}),
+                (${orgA}, ${sourceOne}, ${deviceA}, ${deviceA}, 'complete',
+                 ${COMPLETED_AT}, ${COMPLETED_AT}, ${COMPLETED_AT}),
+                (${orgA}, ${sourceTwo}, ${deviceA}, ${deviceA}, 'failed',
+                 ${COMPLETED_AT}, ${LAST_ACTIVITY_AT}, NULL),
+                -- A terminal-but-unsuccessful run that still stamped
+                -- completed_at, and stamped it LATER than the last good crawl.
+                -- Without the status filter this would masquerade as the last
+                -- successful crawl.
+                (${orgA}, ${sourceTwo}, ${deviceA}, ${deviceA}, 'abandoned',
+                 ${COMPLETED_AT}, ${LAST_ACTIVITY_AT}, ${FAILED_COMPLETED_AT})`;
+});
+
+afterAll(async () => {
+  if (!admin) return;
+  try {
+    await admin`DELETE FROM workspace_crawl_runs WHERE org_id IN (${orgA}, ${orgB})`;
+    await admin`DELETE FROM workspace_file_index WHERE org_id IN (${orgA}, ${orgB})`;
+    await admin`DELETE FROM workspace_sources WHERE org_id IN (${orgA}, ${orgB})`;
+    await admin`DELETE FROM devices WHERE id IN (${deviceA}, ${otherDeviceA}, ${smbOnlyDeviceA}, ${deviceB})`;
+    await admin`DELETE FROM sites WHERE id IN (${siteA}, ${siteB})`;
+    await admin`DELETE FROM organizations WHERE id IN (${orgA}, ${orgB})`;
+    await admin`DELETE FROM partners WHERE id = ${partnerId}`;
+  } finally {
+    await admin.end();
+    await app?.end();
+  }
+});
+
+describe.sequential('device summary aggregate against real SQL', () => {
+  it('counts live rows and distinct sources, excluding tombstones and other devices', async () => {
+    const summary = await asOrg(orgA, (service) => service.summarize(orgA, deviceA));
+    expect(summary).not.toBeNull();
+    expect(summary?.indexedFiles).toBe(3);
+    expect(summary?.visibleSources).toBe(2);
+  });
+
+  it('takes lastSuccessfulCrawlAt from completed runs only, and lastActivityAt from all runs', async () => {
+    const summary = await asOrg(orgA, (service) => service.summarize(orgA, deviceA));
+    expect(summary?.lastSuccessfulCrawlAt?.toISOString()).toBe(COMPLETED_AT.toISOString());
+    // The failed run carries the newest activity; it must still count here and
+    // must NOT become a "successful crawl".
+    expect(summary?.lastActivityAt?.toISOString()).toBe(LAST_ACTIVITY_AT.toISOString());
+  });
+
+  it('reports null timestamps for a never-crawled device without borrowing another device rows', async () => {
+    const summary = await asOrg(orgA, (service) => service.summarize(orgA, otherDeviceA));
+    expect(summary).toEqual({
+      deviceId: otherDeviceA,
+      indexedFiles: 1,
+      visibleSources: 1,
+      lastSuccessfulCrawlAt: null,
+      lastActivityAt: null,
+    });
+  });
+
+  // SMB content is source-scoped: device_id NULL / device_key = shared zero
+  // uuid, with the owning device named by workspace_sources.crawl_device_id
+  // (see runScope.ts). These three tests pin the union semantic — a device's
+  // summary covers what it is RESPONSIBLE for indexing — and, crucially, that
+  // the union stays anchored to the owning device.
+  it('counts the SMB content it crawls alongside its own device-scoped content', async () => {
+    await withSmbSource(deviceA, ['s/one.txt', 's/two.txt'], SMB_CRAWL_AT, async () => {
+      const summary = await asOrg(orgA, (service) => service.summarize(orgA, deviceA));
+      // 3 device-scoped live rows across 2 sources, plus 2 SMB rows on 1 more.
+      expect(summary?.indexedFiles).toBe(5);
+      expect(summary?.visibleSources).toBe(3);
+      // The SMB run is the newest, and it is a real crawl by this device.
+      expect(summary?.lastSuccessfulCrawlAt?.toISOString()).toBe(SMB_CRAWL_AT.toISOString());
+      expect(summary?.lastActivityAt?.toISOString()).toBe(SMB_CRAWL_AT.toISOString());
+    });
+  });
+
+  // The regression this change exists to fix: before the union, a device whose
+  // only job was crawling an SMB share reported 0 / 0 / null while crawling
+  // successfully.
+  it('reports real numbers for a device whose only role is crawling an SMB share', async () => {
+    await withSmbSource(smbOnlyDeviceA, ['s/one.txt', 's/two.txt'], SMB_CRAWL_AT, async () => {
+      const summary = await asOrg(orgA, (service) => service.summarize(orgA, smbOnlyDeviceA));
+      expect(summary).toEqual({
+        deviceId: smbOnlyDeviceA,
+        indexedFiles: 2,
+        visibleSources: 1,
+        lastSuccessfulCrawlAt: SMB_CRAWL_AT,
+        lastActivityAt: SMB_CRAWL_AT,
+      });
+    });
+  });
+
+  // THE cross-device control, written to fail if the owned-sources subquery
+  // loses its `crawl_device_id = <device>` anchor. Dropping that anchor widens
+  // the union to every source-scoped row in the org, so this share — crawled by
+  // otherDeviceA, and carrying the newest timestamp of any row in the org —
+  // would land in deviceA's summary and in smbOnlyDeviceA's.
+  it('never counts an SMB source crawled by a different device in the same org', async () => {
+    await withSmbSource(otherDeviceA, ['x/one.txt', 'x/two.txt'], FOREIGN_SMB_CRAWL_AT, async () => {
+      const summary = await asOrg(orgA, (service) => service.summarize(orgA, deviceA));
+      expect(summary?.indexedFiles).toBe(3);
+      expect(summary?.visibleSources).toBe(2);
+      expect(summary?.lastSuccessfulCrawlAt?.toISOString()).toBe(COMPLETED_AT.toISOString());
+      expect(summary?.lastActivityAt?.toISOString()).toBe(LAST_ACTIVITY_AT.toISOString());
+
+      // A device with no content of its own must stay at zero, not inherit it.
+      const bystander = await asOrg(orgA, (service) => service.summarize(orgA, smbOnlyDeviceA));
+      expect(bystander).toEqual({
+        deviceId: smbOnlyDeviceA,
+        indexedFiles: 0,
+        visibleSources: 0,
+        lastSuccessfulCrawlAt: null,
+        lastActivityAt: null,
+      });
+    });
+  });
+
+  // crawl_device_id is only meaningful for smb_share, but routes/sources.ts
+  // validateSmbConfig returns early for local_profile, so a local_profile
+  // source may legally carry one. The owned-sources branch matches only
+  // source-scoped rows (device_id IS NULL) precisely so that such a source
+  // cannot attribute another device's device-scoped rows to its crawl device.
+  it('never counts another device rows on a local_profile source it happens to crawl', async () => {
+    const sharedLocal = randomUUID();
+    await admin`INSERT INTO workspace_sources
+                  (id, org_id, kind, display_name, root_path, crawl_device_id)
+                VALUES (${sharedLocal}, ${orgA}, 'local_profile', 'summary shared local', '/Users', ${deviceA})`;
+    // A device-scoped row owned by a DIFFERENT device on that same source.
+    await admin`INSERT INTO workspace_file_index
+                  (org_id, source_id, device_id, device_key, rel_path, name)
+                VALUES (${orgA}, ${sharedLocal}, ${otherDeviceA}, ${otherDeviceA}, 'l/other.txt', 'other.txt')`;
+    await admin`INSERT INTO workspace_crawl_runs
+                  (org_id, source_id, device_id, device_key, status, started_at, last_activity_at, completed_at)
+                VALUES (${orgA}, ${sharedLocal}, ${otherDeviceA}, ${otherDeviceA}, 'complete',
+                        ${FOREIGN_SMB_CRAWL_AT}, ${FOREIGN_SMB_CRAWL_AT}, ${FOREIGN_SMB_CRAWL_AT})`;
+    try {
+      const summary = await asOrg(orgA, (service) => service.summarize(orgA, deviceA));
+      expect(summary?.indexedFiles).toBe(3);
+      expect(summary?.visibleSources).toBe(2);
+      expect(summary?.lastSuccessfulCrawlAt?.toISOString()).toBe(COMPLETED_AT.toISOString());
+      expect(summary?.lastActivityAt?.toISOString()).toBe(LAST_ACTIVITY_AT.toISOString());
+    } finally {
+      await admin`DELETE FROM workspace_crawl_runs WHERE source_id = ${sharedLocal}`;
+      await admin`DELETE FROM workspace_file_index WHERE source_id = ${sharedLocal}`;
+      await admin`DELETE FROM workspace_sources WHERE id = ${sharedLocal}`;
+    }
+  });
+
+  it('makes a device in another org indistinguishable from one that does not exist', async () => {
+    const crossOrg = await asOrg(orgA, (service) => service.summarize(orgA, deviceB));
+    const missing = await asOrg(orgA, (service) => service.summarize(orgA, randomUUID()));
+    expect(crossOrg).toBeNull();
+    expect(missing).toBeNull();
+  });
+
+  it('does not leak counts across orgs even when asked for a foreign org id', async () => {
+    // RLS is the backstop; the explicit org predicate is the first control.
+    const spoofed = await asOrg(orgA, (service) => service.summarize(orgB, deviceB));
+    expect(spoofed).toBeNull();
+  });
+});

--- a/ee/workspace/src/__tests__/dlpIngest.integration.test.ts
+++ b/ee/workspace/src/__tests__/dlpIngest.integration.test.ts
@@ -1,0 +1,311 @@
+// DLP-on-ingest — real-DB integration (:5433 stack, breeze_app role). DLP runs
+// ONCE, at ingest, between extraction and any persistence/embedding: 'redact'
+// detectors rewrite the stored text (and therefore chunks, entities, and what
+// the embedder/enrichment LLM ever see); a 'block' detector short-circuits the
+// file to status=blocked_dlp with no text, no chunks, and no embedder call.
+// Patterned on ingest/contentSearch harnesses: seeding via breeze_test, running
+// via breeze_app under the org access context, in-memory fakes for reader/
+// embedder/LLM (no network, no real APIs).
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createContentIngestService } from '../services/contentIngestService';
+import { createEnrichmentService, type AnthropicLike } from '../services/enrichmentService';
+import { FakeEmbedder, EMBEDDING_DIM, type Embedder } from '../content/embedder';
+import type { ContentByteReader, ContentSourceRef } from '../content/byteReader';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+// A real Luhn-valid test card + a plausible SSN. These live only in the
+// in-memory reader below — never on disk.
+const RAW_CARD = '4111 1111 1111 1111';
+const RAW_CARD_DIGITS = '4111111111111111';
+const RAW_SSN = '123-45-6789';
+
+// redact-case file: a card number to redact, plus a PO number that is NOT a DLP
+// target and must survive redaction as an extracted entity.
+const REDACT_REL = 'Projects/Accounting/payment-record.md';
+const REDACT_BYTES = `Vendor payment record. PO 4021. Charge the card ${RAW_CARD} for the outstanding balance.`;
+// block-case file: an SSN under a config that blocks SSNs.
+const BLOCK_REL = 'Projects/HR/new-hire-onboarding.md';
+const BLOCK_BYTES = `New hire onboarding. Employee SSN: ${RAW_SSN} on file with payroll.`;
+
+// transition-case file: ingested CLEAN first (chunks + regex entities land),
+// then its bytes change to something a block detector trips. The same-hash
+// short-circuit only skips DLP on UNCHANGED bytes, so changed bytes are the
+// reliable path to force a clean → blocked_dlp transition.
+const TRANSITION_REL = 'Projects/Legal/roster.md';
+const TRANSITION_CLEAN_BYTES = 'Team roster for the Legal matter. PO 7788 covers outside counsel. Kickoff next week.';
+const TRANSITION_BLOCK_SSN = '567-89-1234';
+const TRANSITION_BLOCK_BYTES = `Updated roster. Employee SSN: ${TRANSITION_BLOCK_SSN} added to payroll records.`;
+
+// One org config: cards redact, SSNs block. The redact file has no SSN so it
+// redacts; the block file has an SSN so it blocks.
+const DLP_CONFIG = {
+  detectors: {
+    credit_card: 'redact', ssn: 'block', iban: 'off', api_key: 'off', email: 'off', phone: 'off',
+  },
+  customPatterns: [],
+};
+
+/** In-memory reader: rel_path → bytes. No disk, no network. */
+class MapReader implements ContentByteReader {
+  constructor(private readonly files: Record<string, string>) {}
+  async read(_source: ContentSourceRef, relPath: string): Promise<Buffer> {
+    const body = this.files[relPath];
+    if (body === undefined) throw new Error(`no fixture for ${relPath}`);
+    return Buffer.from(body, 'utf8');
+  }
+}
+
+/** FakeEmbedder that records every text it is asked to embed. */
+class CapturingEmbedder implements Embedder {
+  readonly seen: string[] = [];
+  private inner = new FakeEmbedder();
+  async embed(texts: string[], _inputType: 'document' | 'query'): Promise<number[][]> {
+    this.seen.push(...texts);
+    return this.inner.embed(texts);
+  }
+}
+
+/** Anthropic-like client that records the user prompt and returns a valid, minimal result. */
+class CapturingAnthropic implements AnthropicLike {
+  readonly prompts: string[] = [];
+  messages = {
+    create: async (args: unknown): Promise<{ content: Array<{ type: string; text?: string }> }> => {
+      const msgs = (args as { messages?: Array<{ content?: string }> }).messages ?? [];
+      for (const m of msgs) if (typeof m.content === 'string') this.prompts.push(m.content);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            docType: 'payment record', projectKey: null, projectLabel: null,
+            docDate: null, confidence: 'low', people: [],
+          }),
+        }],
+      };
+    },
+  };
+}
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partner: string, org: string, source: string;
+const fileIds: Record<string, string> = {};
+
+async function withOrgTx<T>(fn: (db: WorkspaceDatabase) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } }).session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(transaction as unknown as WorkspaceDatabase);
+  });
+}
+
+const capturingEmbedder = new CapturingEmbedder();
+
+async function ingest(batch: number) {
+  return withOrgTx((db) => createContentIngestService(db, {
+    reader: new MapReader({ [REDACT_REL]: REDACT_BYTES, [BLOCK_REL]: BLOCK_BYTES }),
+    embedder: capturingEmbedder,
+  }).run(org, batch));
+}
+
+// Ingest with a caller-supplied byte map — used by the transition case, whose
+// bytes for the SAME rel_path change between the clean and blocked runs.
+async function ingestWith(files: Record<string, string>, batch: number) {
+  return withOrgTx((db) => createContentIngestService(db, {
+    reader: new MapReader(files),
+    embedder: capturingEmbedder,
+  }).run(org, batch));
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partner = randomUUID(); org = randomUUID(); source = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug) VALUES (${partner}, 'wsp-dlp', ${`wsp-dlp-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${org}, ${partner}, 'wsp-dlp-org', ${`wsp-dlp-org-${sfx}`})`;
+  await admin`INSERT INTO workspace_org_settings (org_id, content_enabled, dlp_config)
+              VALUES (${org}, true, ${JSON.stringify(DLP_CONFIG)}::jsonb)`;
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, visibility_group_ids)
+              VALUES (${source}, ${org}, 'smb_share', 'dlp estate', '\\\\127.0.0.1\\dlp', '[]'::jsonb)`;
+  for (const rel of [REDACT_REL, BLOCK_REL]) {
+    const id = randomUUID();
+    fileIds[rel] = id;
+    const parent = rel.slice(0, rel.lastIndexOf('/'));
+    const name = rel.split('/').pop()!;
+    await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime)
+                VALUES (${id}, ${org}, ${source}, ${rel}, ${parent}, ${name}, false, 'md', 100, now())`;
+  }
+});
+
+afterAll(async () => {
+  for (const t of ['workspace_content_chunks', 'workspace_content_entities', 'workspace_file_enrichment',
+    'workspace_file_content', 'workspace_projects', 'workspace_file_index', 'workspace_sources',
+    'workspace_org_settings']) {
+    await admin.unsafe(`DELETE FROM ${t} WHERE org_id = $1`, [org]);
+  }
+  await admin`DELETE FROM organizations WHERE id = ${org}`;
+  await admin`DELETE FROM partners WHERE id = ${partner}`;
+  await admin.end(); await app.end();
+});
+
+describe('DLP-on-ingest (real DB)', () => {
+  it('drains both files, redacting one and blocking the other in a single run', async () => {
+    const run = await ingest(10);
+    expect(run.errors).toEqual([]);
+    expect(run.processed).toBe(2);
+    expect(run.remaining).toBe(0);
+  });
+
+  it('redact case: stored text, chunks, entities, and the embedder see only redacted text', async () => {
+    const redactId = fileIds[REDACT_REL];
+    const [row] = await admin`SELECT status, extracted_text, dlp_findings
+                              FROM workspace_file_content WHERE file_index_id = ${redactId}`;
+    expect(row.status).toBe('extracted');
+    expect(row.extracted_text).toContain('[REDACTED:credit_card]');
+    expect(row.extracted_text).not.toContain(RAW_CARD_DIGITS);
+    expect(row.extracted_text).not.toContain('4111');
+
+    // dlp_findings records the redaction
+    const findings = row.dlp_findings as Array<{ detector: string; action: string; count: number }>;
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ detector: 'credit_card', action: 'redact', count: 1 }),
+    ]));
+
+    // FTS over the stored text cannot surface the raw card number
+    const [{ n: ftsHits }] = await admin`
+      SELECT count(*)::int AS n FROM workspace_file_content
+      WHERE org_id = ${org}
+        AND to_tsvector('simple', coalesce(extracted_text, '')) @@ plainto_tsquery('simple', ${RAW_CARD_DIGITS})`;
+    expect(ftsHits).toBe(0);
+
+    // chunks carry redacted text only
+    const chunks = await admin`SELECT text, vector_dims(embedding) AS dims
+                               FROM workspace_content_chunks WHERE file_index_id = ${redactId}`;
+    expect(chunks.length).toBeGreaterThan(0);
+    for (const ch of chunks) {
+      expect(ch.text as string).not.toContain('4111');
+      expect(ch.text as string).toContain('[REDACTED:credit_card]');
+      expect(Number(ch.dims)).toBe(EMBEDDING_DIM);
+    }
+
+    // entities (PO number) are extracted from the redacted text — PO is not a
+    // DLP target and survives redaction.
+    const entities = await admin`SELECT entity_type, value_norm FROM workspace_content_entities
+                                 WHERE file_index_id = ${redactId}`;
+    const po = entities.filter((e) => e.entity_type === 'po').map((e) => e.value_norm);
+    expect(po).toEqual(['PO 4021']);
+
+    // the embedder never saw the raw card, only the redacted token
+    expect(capturingEmbedder.seen.some((t) => t.includes('4111'))).toBe(false);
+    expect(capturingEmbedder.seen.some((t) => t.includes('[REDACTED:credit_card]'))).toBe(true);
+  });
+
+  it('block case: blocked_dlp status, no text, no chunks, embedder never called', async () => {
+    const blockId = fileIds[BLOCK_REL];
+    const [row] = await admin`SELECT status, extracted_text, dlp_findings
+                              FROM workspace_file_content WHERE file_index_id = ${blockId}`;
+    expect(row.status).toBe('blocked_dlp');
+    expect(row.extracted_text).toBeNull();
+    const findings = row.dlp_findings as Array<{ detector: string; action: string }>;
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ detector: 'ssn', action: 'block' }),
+    ]));
+
+    const chunks = await admin`SELECT id FROM workspace_content_chunks WHERE file_index_id = ${blockId}`;
+    expect(chunks).toHaveLength(0);
+
+    // the SSN never reached the embedder
+    expect(capturingEmbedder.seen.some((t) => t.includes('123-45-6789'))).toBe(false);
+  });
+
+  it('block case: the blocked file is skipped, not retried, on the next run', async () => {
+    const before = capturingEmbedder.seen.length;
+    const rerun = await ingest(10);
+    expect(rerun.processed).toBe(0);
+    expect(rerun.remaining).toBe(0);
+    // no new embedding work — nothing re-ingested
+    expect(capturingEmbedder.seen.length).toBe(before);
+    const blockId = fileIds[BLOCK_REL];
+    const [row] = await admin`SELECT status FROM workspace_file_content WHERE file_index_id = ${blockId}`;
+    expect(row.status).toBe('blocked_dlp');
+  });
+
+  it('enrichment case: the LLM prompt is built from redacted text, never the raw value', async () => {
+    const client = new CapturingAnthropic();
+    const res = await withOrgTx((db) => createEnrichmentService(db, { client }).run(org, 10));
+    expect(res.errors).toEqual([]);
+    // only the redacted (extracted) file is enrichable; the blocked file is not
+    expect(client.prompts.length).toBe(1);
+    const prompt = client.prompts[0];
+    expect(prompt).toContain('[REDACTED:credit_card]');
+    expect(prompt).not.toContain('4111');
+    expect(prompt).not.toContain(RAW_CARD_DIGITS);
+  });
+
+  it('transition case: a clean file that later blocks purges its stale chunks + regex entities', async () => {
+    // A separate file, added here so it does not perturb the batch counts above.
+    const transitionId = randomUUID();
+    const parent = TRANSITION_REL.slice(0, TRANSITION_REL.lastIndexOf('/'));
+    const name = TRANSITION_REL.split('/').pop()!;
+    await admin`INSERT INTO workspace_file_index
+                  (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime)
+                VALUES (${transitionId}, ${org}, ${source}, ${TRANSITION_REL}, ${parent}, ${name},
+                        false, 'md', 100, now())`;
+
+    // v1: clean bytes ingest → extracted, with chunks and a regex PO entity.
+    const clean = await ingestWith({ [TRANSITION_REL]: TRANSITION_CLEAN_BYTES }, 10);
+    expect(clean.errors).toEqual([]);
+    expect(clean.processed).toBe(1);
+
+    const [cleanRow] = await admin`SELECT status FROM workspace_file_content
+                                   WHERE file_index_id = ${transitionId}`;
+    expect(cleanRow.status).toBe('extracted');
+    const chunksBefore = await admin`SELECT id FROM workspace_content_chunks
+                                     WHERE file_index_id = ${transitionId}`;
+    expect(chunksBefore.length).toBeGreaterThan(0);
+    const entitiesBefore = await admin`SELECT id FROM workspace_content_entities
+                                       WHERE file_index_id = ${transitionId} AND origin = 'regex'`;
+    expect(entitiesBefore.length).toBeGreaterThan(0);
+
+    // Bump the snapshot so the file is pending again, then feed v2 bytes that
+    // trip the SSN block detector. Different bytes ⇒ no same-hash short-circuit,
+    // so DLP re-applies and the file transitions extracted → blocked_dlp.
+    await admin`UPDATE workspace_file_index SET size = 200, mtime = now()
+                WHERE id = ${transitionId}`;
+    const blocked = await ingestWith({ [TRANSITION_REL]: TRANSITION_BLOCK_BYTES }, 10);
+    expect(blocked.errors).toEqual([]);
+    expect(blocked.processed).toBe(1);
+
+    const [blockedRow] = await admin`SELECT status, extracted_text FROM workspace_file_content
+                                     WHERE file_index_id = ${transitionId}`;
+    expect(blockedRow.status).toBe('blocked_dlp');
+    expect(blockedRow.extracted_text).toBeNull();
+
+    // The stale chunks from the clean ingest must be gone — the passages/chunk
+    // scope reads straight from this table with no status join, so any survivor
+    // stays retrievable after the block.
+    const chunksAfter = await admin`SELECT id FROM workspace_content_chunks
+                                    WHERE file_index_id = ${transitionId}`;
+    expect(chunksAfter).toHaveLength(0);
+
+    // The regex-derived entities from the clean ingest must be gone too.
+    const entitiesAfter = await admin`SELECT id FROM workspace_content_entities
+                                      WHERE file_index_id = ${transitionId} AND origin = 'regex'`;
+    expect(entitiesAfter).toHaveLength(0);
+  });
+});

--- a/ee/workspace/src/__tests__/filing.integration.test.ts
+++ b/ee/workspace/src/__tests__/filing.integration.test.ts
@@ -1,0 +1,239 @@
+// Crosswalk miner + filing pipeline — real-DB integration (:5433).
+// Seeds the corpus's trap shapes: PO 4021 dominance, the PO 5117 foil, and
+// the LS 8841 license/invoice digit collision. No LLM, no network — the
+// pipeline under test is deterministic.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createCrosswalkService } from '../services/crosswalkService';
+import { createFilingService } from '../services/filingService';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partner: string, org: string, source: string, hiddenSource: string;
+const ids: Record<string, string> = {};
+
+interface SeedFile {
+  key: string;
+  rel: string;
+  entities?: Array<{ type: string; value: string; origin?: string }>;
+  declared?: { key: string; label: string };
+  emailMeta?: object;
+  /** Seed into the hidden ('["g1"]') source instead of the visible estate. */
+  sourceOverride?: 'hidden';
+}
+
+const SEED: SeedFile[] = [
+  // PO 4021 → 2023-041, four distinct filed files (dominant)
+  { key: 'h1', rel: 'Emails/2023-041/po issued.eml', entities: [{ type: 'po', value: 'PO 4021' }] },
+  { key: 'h2', rel: 'Emails/2023-041/re po cortez.eml', entities: [{ type: 'po', value: 'PO 4021' }] },
+  { key: 'h3', rel: 'Emails/2023-041/invoice 1 jtran.eml', entities: [{ type: 'po', value: 'PO 4021' }, { type: 'invoice', value: 'INV 23-1088' }, { type: 'person', value: 'Jenny Tran', origin: 'llm' }] },
+  { key: 'h4', rel: 'Projects/2023-041 Henderson Water Main Replacement/transmittal.md', entities: [{ type: 'po', value: 'PO 4021' }] },
+  // Jenny Tran also on a second Henderson file (participant-fallback evidence)
+  { key: 'h5', rel: 'Emails/2023-041/status jtran.eml', entities: [{ type: 'person', value: 'Jenny Tran', origin: 'llm' }] },
+  // PO 5117 → 2025-012 foil (two files, dominant for ITS value)
+  { key: 't1', rel: 'Emails/2025-012/drain down window.eml', entities: [{ type: 'po', value: 'PO 5117' }] },
+  { key: 't2', rel: 'Projects/2025-012 Fairoaks Tank No 2 Seismic Retrofit/eval.md', entities: [{ type: 'po', value: 'PO 5117' }] },
+  // LS 8841 license trap on a Millbrook file
+  { key: 'm1', rel: 'Projects/2020-088 Millbrook Acres Wildfire Rebuild/monument recovery.md', entities: [{ type: 'license', value: 'LS 8841' }] },
+  // split entity: WDR-9999-0001 filed 1× under two projects (non-dominant)
+  { key: 's1', rel: 'Projects/2023-041 Henderson Water Main Replacement/noa.md', entities: [{ type: 'wdr', value: 'WDR-9999-0001' }] },
+  { key: 's2', rel: 'Projects/2025-012 Fairoaks Tank No 2 Seismic Retrofit/noa-copy.md', entities: [{ type: 'wdr', value: 'WDR-9999-0001' }] },
+  // unfiled targets
+  {
+    key: 'hero', rel: 'Emails/Unfiled/new - re PO 4021 pipe submittal.eml',
+    entities: [{ type: 'po', value: 'PO 4021' }, { type: 'org', value: 'City of Fairoaks', origin: 'llm' }],
+    emailMeta: { subject: 'RE: PO 4021 - pipe submittal resubmittal', from: 'Paul Deluca <pdeluca@fairoaksca.gov>' },
+  },
+  {
+    key: 'ambiguous', rel: 'Emails/Unfiled/pacific coast repro invoice question.eml',
+    entities: [{ type: 'invoice', value: 'INV 8841' }, { type: 'person', value: 'Jenny Tran', origin: 'llm' }],
+    emailMeta: { subject: 'invoice question', from: 'Pacific Coast Repro' },
+  },
+  {
+    key: 'split-mail', rel: 'Emails/Unfiled/wdr question.eml',
+    entities: [{ type: 'wdr', value: 'WDR-9999-0001' }],
+  },
+  // Fallback-hole guard: Ghost Analyst's ONLY participant evidence lives in a
+  // hidden ('["g1"]') source. The participant fallback must not use it to file
+  // a visible email — before Task 6 the fallback query had no source join.
+  {
+    key: 'ghost-file', rel: 'Projects/2099-999 Ghost Project/ghost.md',
+    entities: [{ type: 'person', value: 'Ghost Analyst', origin: 'llm' }],
+    sourceOverride: 'hidden',
+  },
+  {
+    key: 'ghost-mail', rel: 'Emails/Unfiled/ghost participant question.eml',
+    entities: [{ type: 'person', value: 'Ghost Analyst', origin: 'llm' }],
+    emailMeta: { subject: 'ghost question', from: 'Ghost Analyst' },
+  },
+];
+
+async function asOrg<T>(fn: (svcs: {
+  crosswalk: ReturnType<typeof createCrosswalkService>;
+  filing: ReturnType<typeof createFilingService>;
+}) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } })
+      .session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    const db = transaction as unknown as WorkspaceDatabase;
+    const crosswalk = createCrosswalkService(db);
+    const filing = createFilingService(db, { crosswalkService: crosswalk });
+    return fn({ crosswalk, filing });
+  });
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partner = randomUUID(); org = randomUUID(); source = randomUUID(); hiddenSource = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug) VALUES (${partner}, 'wsp-filing', ${`wsp-filing-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${org}, ${partner}, 'wsp-filing-org', ${`wsp-filing-org-${sfx}`})`;
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, visibility_group_ids)
+              VALUES (${source}, ${org}, 'smb_share', 'estate', '\\\\srv\\estate', '[]'::jsonb),
+                     (${hiddenSource}, ${org}, 'smb_share', 'hidden', '\\\\srv\\hidden', '["g1"]'::jsonb)`;
+  await admin`INSERT INTO workspace_projects (org_id, project_key, label)
+              VALUES (${org}, '2023-041', 'Henderson Water Main Replacement'),
+                     (${org}, '2025-012', 'Fairoaks Tank No 2 Seismic Retrofit'),
+                     (${org}, '2020-088', 'Millbrook Acres Wildfire Rebuild')`;
+  for (const f of SEED) {
+    const id = randomUUID();
+    ids[f.key] = id;
+    const name = f.rel.split('/').pop()!;
+    const parent = f.rel.slice(0, f.rel.lastIndexOf('/'));
+    const ext = name.split('.').pop()!.toLowerCase();
+    const srcId = f.sourceOverride === 'hidden' ? hiddenSource : source;
+    await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime)
+                VALUES (${id}, ${org}, ${srcId}, ${f.rel}, ${parent}, ${name}, false, ${ext}, 100, now())`;
+    for (const e of f.entities ?? []) {
+      await admin`INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm, origin)
+                  VALUES (${org}, ${id}, ${e.type}, ${e.value}, ${e.origin ?? 'regex'})`;
+    }
+    // enrichment declared_* rows power the participant fallback
+    const m = f.rel.match(/^(?:Projects|Short Term)\/(\d{4}-\d{3})|^Emails\/(\d{4}-\d{3})\//);
+    const declaredKey = m ? (m[1] ?? m[2]) : null;
+    if (declaredKey || f.emailMeta) {
+      await admin`INSERT INTO workspace_file_enrichment (org_id, file_index_id, declared_project_key, declared_project_label, email_meta)
+                  VALUES (${org}, ${id}, ${declaredKey},
+                          ${declaredKey === '2023-041' ? 'Henderson Water Main Replacement' : declaredKey === '2025-012' ? 'Fairoaks Tank No 2 Seismic Retrofit' : declaredKey === '2020-088' ? 'Millbrook Acres Wildfire Rebuild' : null},
+                          ${f.emailMeta ? JSON.stringify(f.emailMeta) : null}::jsonb)`;
+    }
+  }
+});
+
+afterAll(async () => {
+  for (const t of ['workspace_email_filings', 'workspace_project_crosswalk', 'workspace_content_entities',
+    'workspace_file_enrichment', 'workspace_file_content', 'workspace_projects',
+    'workspace_file_index', 'workspace_sources']) {
+    await admin.unsafe(`DELETE FROM ${t} WHERE org_id = $1`, [org]);
+  }
+  await admin`DELETE FROM organizations WHERE id = ${org}`;
+  await admin`DELETE FROM partners WHERE id = ${partner}`;
+  await admin.end(); await app.end();
+});
+
+describe('crosswalk miner', () => {
+  it('mines distinct-file evidence per (entity, project) and is idempotent', async () => {
+    const first = await asOrg(({ crosswalk }) => crosswalk.run(org));
+    expect(first.mined).toBeGreaterThanOrEqual(4);
+    const again = await asOrg(({ crosswalk }) => crosswalk.run(org));
+    expect(again.mined).toBe(first.mined);
+
+    const po4021 = await asOrg(({ crosswalk }) => crosswalk.lookup(org, 'po', 'PO 4021'));
+    expect(po4021).toHaveLength(1);
+    expect(po4021[0]).toMatchObject({ projectKey: '2023-041', evidenceCount: 4 });
+
+    // the unfiled hero email contributes NO evidence (no declared project)
+    const rows = await admin`SELECT sample_file_ids FROM workspace_project_crosswalk
+                             WHERE org_id = ${org} AND value_norm = 'PO 4021'`;
+    expect(rows[0].sample_file_ids).not.toContain(ids.hero);
+  });
+});
+
+describe('filing pipeline', () => {
+  it('lists only unfiled emails', async () => {
+    const filings = await asOrg(({ filing }) => filing.list(org));
+    const rels = filings.map((f) => f.relPath);
+    expect(rels).toEqual(expect.arrayContaining([
+      'Emails/Unfiled/new - re PO 4021 pipe submittal.eml',
+      'Emails/Unfiled/pacific coast repro invoice question.eml',
+    ]));
+    expect(rels).not.toContain('Emails/2023-041/po issued.eml');
+  });
+
+  it('hero email: dominant crosswalk hit → HIGH confidence, Henderson, org-flavored rationale', async () => {
+    const filing = await asOrg(({ filing: f }) => f.classify(org, ids.hero));
+    expect(filing).toMatchObject({
+      suggestedProjectKey: '2023-041',
+      suggestedProjectLabel: 'Henderson Water Main Replacement',
+      confidence: 'high',
+      matchedEntityType: 'po',
+      matchedEntityValue: 'PO 4021',
+      status: 'suggested',
+    });
+    expect(filing?.rationale).toBe('matched City of Fairoaks PO #4021');
+  });
+
+  it('ambiguous email: LS 8841 never matches invoice 8841; participant fallback is LOW', async () => {
+    const filing = await asOrg(({ filing: f }) => f.classify(org, ids.ambiguous));
+    expect(filing?.confidence).toBe('low');
+    expect(filing?.suggestedProjectKey).not.toBe('2020-088'); // the collision trap
+    expect(filing?.suggestedProjectKey).toBe('2023-041'); // Jenny Tran evidence
+    expect(filing?.rationale).toMatch(/Jenny Tran/);
+  });
+
+  it('participant fallback ignores evidence from hidden sources (fallback hole gated)', async () => {
+    // Ghost Analyst appears only in a hidden ('["g1"]') source. With the
+    // participant fallback now visibility-gated (groupIds [] → ungrouped only),
+    // that evidence is excluded, so the email gets no suggestion at all rather
+    // than being misfiled to the hidden project 2099-999.
+    const filing = await asOrg(({ filing: f }) => f.classify(org, ids['ghost-mail']));
+    expect(filing?.suggestedProjectKey).toBeNull();
+    expect(filing?.suggestedProjectKey).not.toBe('2099-999');
+  });
+
+  it('split-evidence entity (1v1 files) is never HIGH', async () => {
+    const filing = await asOrg(({ filing: f }) => f.classify(org, ids['split-mail']));
+    expect(filing?.confidence).toBe('low');
+  });
+
+  it('assign confirms on the suggested project and reassigns otherwise; unknown project → null', async () => {
+    const confirmed = await asOrg(({ filing: f }) => f.assign(org, ids.hero, '2023-041', 'Front desk'));
+    expect(confirmed?.status).toBe('confirmed');
+    expect(confirmed?.decidedProjectKey).toBe('2023-041');
+
+    const reassigned = await asOrg(({ filing: f }) => f.assign(org, ids.ambiguous, '2025-012', null));
+    expect(reassigned?.status).toBe('reassigned');
+
+    const bogus = await asOrg(({ filing: f }) => f.assign(org, ids.hero, '9999-999', null));
+    expect(bogus).toBeNull();
+  });
+
+  it('re-classify never overwrites a human decision', async () => {
+    // hero was confirmed to 2023-041 in the previous test
+    const after = await asOrg(({ filing: f }) => f.classify(org, ids.hero));
+    expect(after?.status).toBe('confirmed');
+    expect(after?.decidedProjectKey).toBe('2023-041');
+  });
+
+  it('classify answers null for filed emails and unknown files (route 404s)', async () => {
+    expect(await asOrg(({ filing: f }) => f.classify(org, ids.h1))).toBeNull();
+    expect(await asOrg(({ filing: f }) => f.classify(org, randomUUID()))).toBeNull();
+  });
+});

--- a/ee/workspace/src/__tests__/finder.integration.test.ts
+++ b/ee/workspace/src/__tests__/finder.integration.test.ts
@@ -1,0 +1,500 @@
+import { randomUUID } from 'node:crypto';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createActivityService } from '../services/activityService';
+import { createFileQueryService } from '../services/fileQueryService';
+import { createSourcesService } from '../services/sourcesService';
+
+const ADMIN_URL = process.env.DATABASE_URL
+  ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP
+  ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
+if (new URL(ADMIN_URL).port === '5432' || new URL(APP_URL).port === '5432') {
+  throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+}
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+
+// Org A (the org under test) and its estate.
+let partnerA: string;
+let orgA: string;
+let siteA: string;
+let device1: string;
+let device2: string;
+let smbVisibleId: string;
+let smbHiddenId: string;
+let localSourceId: string;
+
+// Org B (RLS / cross-org foil), fully seeded by admin.
+let partnerB: string;
+let orgB: string;
+let orgBSourceId: string;
+
+// File-index fixture ids (org A unless suffixed B).
+let dirDocsId: string;
+let fileReportId: string; // docs/henderson-report.pdf (smb, name match)
+let fileNotesId: string; // docs/meeting-notes.txt (smb)
+let fileScanId: string; // archive/henderson/scan-0034.txt (smb, rel_path-only match)
+let fileRootId: string; // readme.md (smb, root listing)
+let fileTombstoneId: string; // docs/henderson-old.pdf (smb, deleted_at set)
+let fileHiddenId: string; // docs/henderson-hidden.pdf (hidden source)
+let fileDev1Id: string; // profile/henderson-dev1.txt (local, device 1)
+let fileDev2Id: string; // profile/henderson-dev2.txt (local, device 2)
+let fileOrgBId: string; // docs/henderson-b.pdf (org B)
+// filed/ fixture for Finding 4a: subdirs must stay navigable under a Browse
+// filter. Names avoid 'henderson' so the search tests above are unaffected.
+let filedSubAId: string; // filed/sub-alpha (smb, dir)
+let filedSubBId: string; // filed/sub-beta (smb, dir)
+let filedMatchId: string; // filed/permit-app.pdf (smb, enriched: 'permit application')
+let filedFoilId: string; // filed/foil-note.txt (smb, unenriched foil)
+
+type AppContext = {
+  tx: postgres.TransactionSql;
+  sources: ReturnType<typeof createSourcesService>;
+  files: ReturnType<typeof createFileQueryService>;
+  activity: ReturnType<typeof createActivityService>;
+};
+
+/** Run fn as breeze_app inside org A's access context (mirrors withDbAccessContext set_configs). */
+async function asOrgA<T>(fn: (context: AppContext) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } })
+      .session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${orgA}, true),
+                    set_config('breeze.accessible_org_ids', ${orgA}, true),
+                    set_config('breeze.accessible_partner_ids', ${partnerA}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    const db = transaction as unknown as WorkspaceDatabase;
+    return fn({
+      tx,
+      sources: createSourcesService(db),
+      files: createFileQueryService(db),
+      activity: createActivityService(db),
+    });
+  });
+}
+
+/** Admin-seeded file row; RLS-exempt writer so fixtures can span orgs/partitions. */
+async function seedFile(input: {
+  orgId: string;
+  sourceId: string;
+  deviceId?: string | null;
+  deviceKey?: string;
+  relPath: string;
+  isDir?: boolean;
+  ext?: string | null;
+  mtimeDaysAgo?: number;
+  deleted?: boolean;
+}): Promise<string> {
+  const id = randomUUID();
+  const slash = input.relPath.lastIndexOf('/');
+  const name = input.relPath.slice(slash + 1);
+  const parentPath = slash < 0 ? '' : input.relPath.slice(0, slash);
+  const days = input.mtimeDaysAgo ?? 1;
+  await admin`INSERT INTO workspace_file_index
+                (id, org_id, source_id, device_id, device_key, rel_path, parent_path, name,
+                 is_dir, ext, size, mtime, last_seen_at, deleted_at)
+              VALUES
+                (${id}, ${input.orgId}, ${input.sourceId}, ${input.deviceId ?? null},
+                 ${input.deviceKey ?? ZERO_UUID}, ${input.relPath}, ${parentPath}, ${name},
+                 ${input.isDir ?? false}, ${input.ext ?? null}, ${input.isDir ? 0 : 100},
+                 ${admin`now() - make_interval(days => ${days})`}, now(),
+                 ${input.deleted ? admin`now()` : null})`;
+  return id;
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partnerA = randomUUID();
+  partnerB = randomUUID();
+  orgA = randomUUID();
+  orgB = randomUUID();
+  siteA = randomUUID();
+  device1 = randomUUID();
+  device2 = randomUUID();
+  orgBSourceId = randomUUID();
+  const suffix = randomUUID();
+
+  await admin`INSERT INTO partners (id, name, slug)
+              VALUES (${partnerA}, 'wsp finder a', ${`wsp-finder-a-${suffix}`}),
+                     (${partnerB}, 'wsp finder b', ${`wsp-finder-b-${suffix}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${orgA}, ${partnerA}, 'wsp finder org a', ${`wsp-finder-org-a-${suffix}`}),
+                     (${orgB}, ${partnerB}, 'wsp finder org b', ${`wsp-finder-org-b-${suffix}`})`;
+  await admin`INSERT INTO sites (id, org_id, name)
+              VALUES (${siteA}, ${orgA}, 'wsp finder site')`;
+  await admin`INSERT INTO devices
+                (id, org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version)
+              VALUES
+                (${device1}, ${orgA}, ${siteA}, ${`wsp-finder-1-${suffix}`}, 'finder-1', 'windows', '11', 'amd64', 'test'),
+                (${device2}, ${orgA}, ${siteA}, ${`wsp-finder-2-${suffix}`}, 'finder-2', 'windows', '11', 'amd64', 'test')`;
+
+  // Org A sources go through the real service under the org RLS context.
+  await asOrgA(async ({ sources }) => {
+    const visible = await sources.create(orgA, {
+      kind: 'smb_share',
+      displayName: 'Alder Creek',
+      rootPath: '\\\\srv\\alder',
+      crawlDeviceId: device1,
+      visibilityGroupIds: [],
+      crawlCadenceMinutes: 60,
+      excludeGlobs: [],
+      watch: false,
+      status: 'active',
+    });
+    const hidden = await sources.create(orgA, {
+      kind: 'smb_share',
+      displayName: 'Hidden share',
+      rootPath: '\\\\srv\\hidden',
+      crawlDeviceId: device1,
+      visibilityGroupIds: ['g1'], // non-empty group list must FAIL CLOSED
+      crawlCadenceMinutes: 60,
+      excludeGlobs: [],
+      watch: false,
+      status: 'active',
+    });
+    const local = await sources.create(orgA, {
+      kind: 'local_profile',
+      displayName: 'Local profiles',
+      rootPath: '/Users',
+      crawlDeviceId: null,
+      visibilityGroupIds: [],
+      crawlCadenceMinutes: 60,
+      excludeGlobs: [],
+      watch: false,
+      status: 'active',
+    });
+    smbVisibleId = visible.id;
+    smbHiddenId = hidden.id;
+    localSourceId = local.id;
+  });
+
+  // Org B estate is a pure foil — admin-seeded, never touched through asOrgA.
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path)
+              VALUES (${orgBSourceId}, ${orgB}, 'smb_share', 'b share', '\\\\srv\\bravo')`;
+
+  dirDocsId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'docs', isDir: true,
+  });
+  fileReportId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'docs/henderson-report.pdf', ext: 'pdf', mtimeDaysAgo: 1,
+  });
+  fileNotesId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'docs/meeting-notes.txt', ext: 'txt', mtimeDaysAgo: 2,
+  });
+  fileScanId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'archive/henderson/scan-0034.txt', ext: 'txt', mtimeDaysAgo: 3,
+  });
+  fileRootId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'readme.md', ext: 'md', mtimeDaysAgo: 4,
+  });
+  fileTombstoneId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'docs/henderson-old.pdf', ext: 'pdf', deleted: true,
+  });
+  fileHiddenId = await seedFile({
+    orgId: orgA, sourceId: smbHiddenId, relPath: 'docs/henderson-hidden.pdf', ext: 'pdf',
+  });
+  fileDev1Id = await seedFile({
+    orgId: orgA, sourceId: localSourceId, deviceId: device1, deviceKey: device1,
+    relPath: 'profile/henderson-dev1.txt', ext: 'txt',
+  });
+  fileDev2Id = await seedFile({
+    orgId: orgA, sourceId: localSourceId, deviceId: device2, deviceKey: device2,
+    relPath: 'profile/henderson-dev2.txt', ext: 'txt',
+  });
+  fileOrgBId = await seedFile({
+    orgId: orgB, sourceId: orgBSourceId, relPath: 'docs/henderson-b.pdf', ext: 'pdf',
+  });
+
+  // filed/ holds two subdirs, one enriched file, and one unenriched foil — all
+  // under parent_path 'filed' so they never surface in the root or docs/ browse
+  // assertions above. Finding 4a: a filtered Browse must keep the subdirs.
+  filedSubAId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'filed/sub-alpha', isDir: true,
+  });
+  filedSubBId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'filed/sub-beta', isDir: true,
+  });
+  filedMatchId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'filed/permit-app.pdf', ext: 'pdf', mtimeDaysAgo: 1,
+  });
+  filedFoilId = await seedFile({
+    orgId: orgA, sourceId: smbVisibleId, relPath: 'filed/foil-note.txt', ext: 'txt', mtimeDaysAgo: 2,
+  });
+
+  // Enrichment for the docs/ report and the filed/ match only — meeting-notes
+  // and foil-note stay unenriched so a browse narrowed by project or docType
+  // must drop them. Proves the EXISTS predicates narrow real rows, not just
+  // render in the SQL text.
+  await admin`INSERT INTO workspace_file_enrichment
+                (org_id, file_index_id, inferred_project_label, inferred_doc_type)
+              VALUES
+                (${orgA}, ${fileReportId}, 'Henderson Water Main Replacement', 'easement deed'),
+                (${orgA}, ${filedMatchId}, 'Filed Project X', 'permit application')`;
+});
+
+afterAll(async () => {
+  if (!admin) return;
+  try {
+    await admin`DELETE FROM workspace_file_activity WHERE org_id IN (${orgA}, ${orgB})`;
+    await admin`DELETE FROM workspace_file_index WHERE org_id IN (${orgA}, ${orgB})`;
+    await admin`DELETE FROM workspace_sources WHERE org_id IN (${orgA}, ${orgB})`;
+    await admin`DELETE FROM devices WHERE id IN (${device1}, ${device2})`;
+    await admin`DELETE FROM sites WHERE id = ${siteA}`;
+    await admin`DELETE FROM organizations WHERE id IN (${orgA}, ${orgB})`;
+    await admin`DELETE FROM partners WHERE id IN (${partnerA}, ${partnerB})`;
+  } finally {
+    await admin.end();
+    await app?.end();
+  }
+});
+
+describe.sequential('workspace finder end-to-end integration', () => {
+  it('lists only active empty-visibility sources (fail closed on group lists)', async () => {
+    const sources = await asOrgA(({ files }) => files.visibleSources(orgA));
+    expect(sources.map((s) => s.id).sort()).toEqual([smbVisibleId, localSourceId].sort());
+    expect(sources.find((s) => s.id === smbHiddenId)).toBeUndefined();
+  });
+
+  it('searches by name and rel_path, ranks name matches first, and leaks nothing', async () => {
+    const results = await asOrgA(({ files }) => files.search(orgA, device1, { q: 'henderson' }));
+    const ids = results.map((r) => r.id);
+
+    // Name match, rel_path-only match, and device 1's own local row all hit.
+    expect(ids).toContain(fileReportId);
+    expect(ids).toContain(fileScanId);
+    expect(ids).toContain(fileDev1Id);
+
+    // Tombstoned, hidden-source, cross-org, and other-device rows never appear.
+    expect(ids).not.toContain(fileTombstoneId);
+    expect(ids).not.toContain(fileHiddenId);
+    expect(ids).not.toContain(fileOrgBId);
+    expect(ids).not.toContain(fileDev2Id);
+
+    // Plausible-first: the strong name match outranks the rel_path-only match.
+    expect(ids.indexOf(fileReportId)).toBeLessThan(ids.indexOf(fileScanId));
+
+    // openPath is the UNC join for smb files, null for local-profile rows.
+    expect(results.find((r) => r.id === fileReportId)?.openPath)
+      .toBe('\\\\srv\\alder\\docs\\henderson-report.pdf');
+    expect(results.find((r) => r.id === fileDev1Id)?.openPath).toBeNull();
+  });
+
+  it('scopes local-profile search rows to the calling device', async () => {
+    const asDevice2 = await asOrgA(({ files }) => files.search(orgA, device2, { q: 'henderson' }));
+    const ids = asDevice2.map((r) => r.id);
+    expect(ids).toContain(fileDev2Id);
+    expect(ids).not.toContain(fileDev1Id);
+  });
+
+  it('honors search filters: sourceId, ext, and limit', async () => {
+    const smbOnly = await asOrgA(({ files }) => files.search(orgA, device1, {
+      q: 'henderson', sourceId: smbVisibleId,
+    }));
+    expect(smbOnly.map((r) => r.id).sort()).toEqual([fileReportId, fileScanId].sort());
+
+    const pdfOnly = await asOrgA(({ files }) => files.search(orgA, device1, {
+      q: 'henderson', ext: 'pdf',
+    }));
+    expect(pdfOnly.map((r) => r.id)).toEqual([fileReportId]);
+
+    const limited = await asOrgA(({ files }) => files.search(orgA, device1, {
+      q: 'henderson', limit: 1,
+    }));
+    expect(limited).toHaveLength(1);
+  });
+
+  it('browses an exact parent_path, dirs first, tombstones excluded', async () => {
+    const root = await asOrgA(({ files }) => files.browse(orgA, device1, smbVisibleId, ''));
+    expect(root.map((r) => [r.id, r.isDir])).toEqual([
+      [dirDocsId, true],
+      [fileRootId, false],
+    ]);
+    // Directories never carry an openPath.
+    expect(root.find((r) => r.id === dirDocsId)?.openPath).toBeNull();
+
+    const docs = await asOrgA(({ files }) => files.browse(orgA, device1, smbVisibleId, 'docs'));
+    expect(docs.map((r) => r.id)).toEqual([fileReportId, fileNotesId]);
+    expect(docs.map((r) => r.id)).not.toContain(fileTombstoneId);
+  });
+
+  it('narrows a browsed directory by project and by docType against real enrichment rows', async () => {
+    // docs/ holds the enriched report plus the unenriched meeting-notes foil.
+    const unfiltered = await asOrgA(({ files }) => files.browse(orgA, device1, smbVisibleId, 'docs'));
+    expect(unfiltered.map((r) => r.id)).toEqual([fileReportId, fileNotesId]);
+
+    // docType narrows to the sole enriched row — the foil is dropped.
+    const byDocType = await asOrgA(({ files }) =>
+      files.browse(orgA, device1, smbVisibleId, 'docs', { docType: 'easement deed' }));
+    expect(byDocType.map((r) => r.id)).toEqual([fileReportId]);
+    expect(byDocType.length).toBeLessThan(unfiltered.length);
+
+    // project narrows identically.
+    const byProject = await asOrgA(({ files }) =>
+      files.browse(orgA, device1, smbVisibleId, 'docs', {
+        project: 'Henderson Water Main Replacement',
+      }));
+    expect(byProject.map((r) => r.id)).toEqual([fileReportId]);
+
+    // Both predicates AND together on the same (enriched) row.
+    const both = await asOrgA(({ files }) =>
+      files.browse(orgA, device1, smbVisibleId, 'docs', {
+        project: 'Henderson Water Main Replacement', docType: 'easement deed',
+      }));
+    expect(both.map((r) => r.id)).toEqual([fileReportId]);
+
+    // A value no enrichment row carries narrows to empty.
+    const noMatch = await asOrgA(({ files }) =>
+      files.browse(orgA, device1, smbVisibleId, 'docs', { docType: 'no-such-doc-type' }));
+    expect(noMatch).toEqual([]);
+  });
+
+  it('keeps subdirectories navigable when a Browse filter is active (Finding 4a)', async () => {
+    // filed/ = two subdirs + one enriched file + one unenriched foil.
+    const unfiltered = await asOrgA(({ files }) => files.browse(orgA, device1, smbVisibleId, 'filed'));
+    expect(unfiltered.map((r) => r.id)).toEqual([
+      filedSubAId, filedSubBId, filedFoilId, filedMatchId,
+    ]);
+
+    // With a docType filter active, the enrichment predicate must NOT hide the
+    // subdirectories (they carry no enrichment row) — dirs-first, then the sole
+    // enriched file. The unenriched foil is dropped.
+    const filtered = await asOrgA(({ files }) =>
+      files.browse(orgA, device1, smbVisibleId, 'filed', { docType: 'permit application' }));
+    expect(filtered.map((r) => r.id)).toEqual([filedSubAId, filedSubBId, filedMatchId]);
+    expect(filtered.map((r) => r.id)).not.toContain(filedFoilId);
+    // Directories still carry no openPath even when they survive a filter.
+    expect(filtered.find((r) => r.id === filedSubAId)?.openPath).toBeNull();
+  });
+
+  it('returns nothing when browsing a hidden or unknown source', async () => {
+    const hidden = await asOrgA(({ files }) => files.browse(orgA, device1, smbHiddenId, 'docs'));
+    expect(hidden).toEqual([]);
+    const unknown = await asOrgA(({ files }) => files.browse(orgA, device1, randomUUID(), ''));
+    expect(unknown).toEqual([]);
+  });
+
+  it('partitions local-profile browsing per device', async () => {
+    const dev1 = await asOrgA(({ files }) => files.browse(orgA, device1, localSourceId, 'profile'));
+    expect(dev1.map((r) => r.id)).toEqual([fileDev1Id]);
+    const dev2 = await asOrgA(({ files }) => files.browse(orgA, device2, localSourceId, 'profile'));
+    expect(dev2.map((r) => r.id)).toEqual([fileDev2Id]);
+  });
+
+  it('getFile enforces visibility and partition', async () => {
+    const ok = await asOrgA(({ files }) => files.getFile(orgA, device1, fileReportId));
+    expect(ok?.openPath).toBe('\\\\srv\\alder\\docs\\henderson-report.pdf');
+    expect(await asOrgA(({ files }) => files.getFile(orgA, device1, fileHiddenId))).toBeNull();
+    expect(await asOrgA(({ files }) => files.getFile(orgA, device1, fileDev2Id))).toBeNull();
+    expect(await asOrgA(({ files }) => files.getFile(orgA, device1, fileOrgBId))).toBeNull();
+  });
+
+  it('refuses to record activity for tombstoned, hidden, cross-org, or unknown files', async () => {
+    await asOrgA(async ({ activity }) => {
+      for (const fileIndexId of [fileTombstoneId, fileHiddenId, fileOrgBId, randomUUID()]) {
+        expect(await activity.record(orgA, {
+          fileIndexId, deviceId: device1, helperUser: 'Front Desk', action: 'open',
+        })).toEqual({ notFound: true });
+      }
+      // Another device's local-profile row is outside device 1's partition.
+      expect(await activity.record(orgA, {
+        fileIndexId: fileDev2Id, deviceId: device1, helperUser: 'Front Desk', action: 'open',
+      })).toEqual({ notFound: true });
+    });
+    const rows = await admin`SELECT id FROM workspace_file_activity WHERE org_id = ${orgA}`;
+    expect(rows).toHaveLength(0);
+  });
+
+  it('records helper activity with a NULL user_id (finder migration applied)', async () => {
+    await asOrgA(async ({ activity }) => {
+      expect(await activity.record(orgA, {
+        fileIndexId: fileReportId, deviceId: device1, helperUser: 'Front Desk', action: 'open',
+      })).toEqual({ recorded: true });
+    });
+    const rows = await admin<Array<{ user_id: string | null; helper_user: string; device_id: string }>>`
+      SELECT user_id, helper_user, device_id
+      FROM workspace_file_activity
+      WHERE org_id = ${orgA} AND file_index_id = ${fileReportId}`;
+    expect(rows).toEqual([{ user_id: null, helper_user: 'Front Desk', device_id: device1 }]);
+  });
+
+  it('round-trips recents with label filtering and DISTINCT ON dedupe', async () => {
+    await asOrgA(async ({ activity }) => {
+      // Second touch of the same file must not duplicate it in recents.
+      expect(await activity.record(orgA, {
+        fileIndexId: fileReportId, deviceId: device1, helperUser: 'Front Desk', action: 'copy_path',
+      })).toEqual({ recorded: true });
+      // A different label on the same device.
+      expect(await activity.record(orgA, {
+        fileIndexId: fileDev1Id, deviceId: device1, helperUser: 'Back Office', action: 'open',
+      })).toEqual({ recorded: true });
+    });
+
+    const frontDesk = await asOrgA(({ activity }) => activity.recents(orgA, device1, 'Front Desk'));
+    expect(frontDesk.map((r) => r.id)).toEqual([fileReportId]);
+
+    const backOffice = await asOrgA(({ activity }) => activity.recents(orgA, device1, 'Back Office'));
+    expect(backOffice.map((r) => r.id)).toEqual([fileDev1Id]);
+
+    const nobody = await asOrgA(({ activity }) => activity.recents(orgA, device1, 'Nobody'));
+    expect(nobody).toEqual([]);
+
+    // Null label = all activity on this device, deduped per file.
+    const all = await asOrgA(({ activity }) => activity.recents(orgA, device1, null));
+    expect(all.map((r) => r.id).sort()).toEqual([fileReportId, fileDev1Id].sort());
+  });
+
+  it('keeps recents device-scoped', async () => {
+    const dev2Recents = await asOrgA(({ activity }) => activity.recents(orgA, device2, null));
+    expect(dev2Recents).toEqual([]);
+  });
+
+  it('spans devices in the department feed without exposing who or where', async () => {
+    // Device 2 touches a shared smb file; a hidden-source touch is forged by
+    // admin to prove the feed still excludes it.
+    await asOrgA(async ({ activity }) => {
+      expect(await activity.record(orgA, {
+        fileIndexId: fileNotesId, deviceId: device2, helperUser: 'Ops', action: 'open',
+      })).toEqual({ recorded: true });
+    });
+    await admin`INSERT INTO workspace_file_activity (org_id, file_index_id, device_id, action)
+                VALUES (${orgA}, ${fileHiddenId}, ${device1}, 'open')`;
+
+    const department = await asOrgA(({ activity }) => activity.departmentRecent(orgA, device1));
+    const ids = department.map((r) => r.id);
+    expect(ids).toContain(fileReportId); // device 1's activity
+    expect(ids).toContain(fileNotesId); // device 2's activity — the feed spans devices
+    expect(ids).not.toContain(fileHiddenId);
+    expect(ids).not.toContain(fileOrgBId);
+    // Device 1's own local file is in its partition; device 2 must not see it.
+    const asDevice2 = await asOrgA(({ activity }) => activity.departmentRecent(orgA, device2));
+    expect(asDevice2.map((r) => r.id)).not.toContain(fileDev1Id);
+
+    // No who/which-device attribution leaves the service ("track work, not workers").
+    for (const row of department) {
+      expect(row).not.toHaveProperty('deviceId');
+      expect(row).not.toHaveProperty('helperUser');
+      expect(row).not.toHaveProperty('userId');
+      expect(typeof row.lastActivityAt).toBe('string');
+    }
+  });
+
+  it('never returns org B rows under org A RLS context, even by direct id probe', async () => {
+    // Belt (service org filter) and suspenders (RLS): read org B's row raw.
+    const raw = await asOrgA(({ tx }) => tx`
+      SELECT id FROM workspace_file_index WHERE id = ${fileOrgBId}`);
+    expect(raw).toHaveLength(0);
+    const search = await asOrgA(({ files }) => files.search(orgA, device1, { q: 'henderson-b' }));
+    expect(search.map((r) => r.id)).not.toContain(fileOrgBId);
+  });
+});

--- a/ee/workspace/src/__tests__/fixtures/estate/Emails/2023-041/po-4021-issued.eml
+++ b/ee/workspace/src/__tests__/fixtures/estate/Emails/2023-041/po-4021-issued.eml
@@ -1,0 +1,6 @@
+From: Paul Deluca <pdeluca@fairoaksca.gov>
+To: Maria Cortez <mcortez@aldercreekeng.com>
+Subject: PO 4021 issued
+Date: 15 Aug 2023 09:00:00 -0700
+
+Notice to proceed under PO 4021.

--- a/ee/workspace/src/__tests__/fixtures/estate/Projects/2023-041 Henderson Water Main Replacement/transmittal.md
+++ b/ee/workspace/src/__tests__/fixtures/estate/Projects/2023-041 Henderson Water Main Replacement/transmittal.md
@@ -1,0 +1,5 @@
+# Transmittal T-001
+
+90% plans for the Henderson Road Water Main Replacement Project.
+Reference City of Fairoaks PO #4021 and APN 042-330-021.
+Signed L.S. 4102 (Deubel).

--- a/ee/workspace/src/__tests__/fixtures/estate/photo.jpg
+++ b/ee/workspace/src/__tests__/fixtures/estate/photo.jpg
@@ -1,0 +1,1 @@
+binarybytes

--- a/ee/workspace/src/__tests__/ingest.integration.test.ts
+++ b/ee/workspace/src/__tests__/ingest.integration.test.ts
@@ -1,0 +1,162 @@
+// Content ingest runner — real-DB integration (:5433 stack, breeze_app role,
+// MountedDirReader over the in-repo fixture estate). Covers the pending
+// predicate, extraction/entity/project writes, snapshot idempotency,
+// mtime-driven re-ingest, and tombstone exclusion. No network, no real APIs.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createContentIngestService } from '../services/contentIngestService';
+import { MountedDirReader } from '../content/byteReader';
+import { FakeEmbedder, EMBEDDING_DIM } from '../content/embedder';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'estate');
+
+const FILES = [
+  { rel: 'Projects/2023-041 Henderson Water Main Replacement/transmittal.md', name: 'transmittal.md' },
+  { rel: 'Emails/2023-041/po-4021-issued.eml', name: 'po-4021-issued.eml' },
+  { rel: 'photo.jpg', name: 'photo.jpg' },
+] as const;
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let partner: string, org: string, source: string;
+const fileIds: Record<string, string> = {};
+
+let appDb: ReturnType<typeof drizzle>;
+
+/** Run fn as breeze_app inside the org's access context (mirrors withDbAccessContext set_configs). */
+async function asOrg<T>(fn: (svc: ReturnType<typeof createContentIngestService>) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } })
+      .session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    const db = transaction as unknown as WorkspaceDatabase;
+    const svc = createContentIngestService(db, {
+      reader: new MountedDirReader({ [source]: FIXTURES }),
+      embedder: new FakeEmbedder(), // plumbing only — never behind real search results
+    });
+    return fn(svc);
+  });
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partner = randomUUID(); org = randomUUID(); source = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug) VALUES (${partner}, 'wsp-ingest', ${`wsp-ingest-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${org}, ${partner}, 'wsp-ingest-org', ${`wsp-ingest-org-${sfx}`})`;
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, visibility_group_ids)
+              VALUES (${source}, ${org}, 'smb_share', 'fixture estate', '\\\\127.0.0.1\\fixtures', '[]'::jsonb)`;
+  for (const f of FILES) {
+    const id = randomUUID();
+    fileIds[f.rel] = id;
+    const parent = f.rel.includes('/') ? f.rel.slice(0, f.rel.lastIndexOf('/')) : '';
+    await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, parent_path, name, is_dir, size, mtime)
+                VALUES (${id}, ${org}, ${source}, ${f.rel}, ${parent}, ${f.name}, false, 100, now())`;
+  }
+});
+
+afterAll(async () => {
+  for (const t of ['workspace_content_chunks', 'workspace_content_entities', 'workspace_file_enrichment', 'workspace_file_content',
+    'workspace_projects', 'workspace_file_index', 'workspace_sources']) {
+    await admin.unsafe(`DELETE FROM ${t} WHERE org_id = $1`, [org]);
+  }
+  await admin`DELETE FROM organizations WHERE id = ${org}`;
+  await admin`DELETE FROM partners WHERE id = ${partner}`;
+  await admin.end(); await app.end();
+});
+
+describe('content ingest runner (real DB + fixture estate)', () => {
+  it('drains pending files to zero and writes content/entities/projects', async () => {
+    const first = await asOrg((svc) => svc.run(org, 2));
+    expect(first.processed).toBe(2);
+    expect(first.errors).toEqual([]);
+    expect(first.remaining).toBeGreaterThan(0);
+
+    const second = await asOrg((svc) => svc.run(org, 10));
+    expect(second.remaining).toBe(0);
+    expect(second.errors).toEqual([]);
+
+    const status = await asOrg((svc) => svc.status(org));
+    expect(status).toMatchObject({ eligible: 3, extracted: 2, skippedBinary: 1, failed: 0, pending: 0 });
+
+    // entities from the markdown transmittal
+    const mdId = fileIds[FILES[0].rel];
+    const entities = await admin`SELECT entity_type, value_norm FROM workspace_content_entities
+                                 WHERE file_index_id = ${mdId} ORDER BY entity_type, value_norm`;
+    const byType: Record<string, string[]> = {};
+    for (const e of entities) (byType[e.entity_type as string] ??= []).push(e.value_norm as string);
+    expect(byType.po).toEqual(['PO 4021']);
+    expect(byType.apn).toEqual(['042-330-021']);
+    expect(byType.license).toEqual(['LS 4102']);
+    expect(byType.invoice).toBeUndefined();
+
+    // project registry from the declared folder
+    const projects = await admin`SELECT project_key, label FROM workspace_projects WHERE org_id = ${org}`;
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toMatchObject({ project_key: '2023-041', label: 'Henderson Water Main Replacement' });
+
+    // email meta written deterministically on the enrichment row
+    const emlId = fileIds[FILES[1].rel];
+    const [enr] = await admin`SELECT email_meta FROM workspace_file_enrichment WHERE file_index_id = ${emlId}`;
+    expect(enr.email_meta).toMatchObject({ subject: 'PO 4021 issued' });
+
+    // chunks written with 1024-dim embeddings for extracted files only
+    const chunks = await admin`SELECT file_index_id, chunk_index, vector_dims(embedding) AS dims
+                               FROM workspace_content_chunks WHERE org_id = ${org}`;
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    for (const ch of chunks) expect(Number(ch.dims)).toBe(EMBEDDING_DIM);
+    const chunkFiles = new Set(chunks.map((ch) => ch.file_index_id as string));
+    expect(chunkFiles.has(mdId)).toBe(true);
+    expect(chunkFiles.has(fileIds['photo.jpg'])).toBe(false);
+  });
+
+  it('is idempotent while the snapshot is fresh and re-ingests on mtime change', async () => {
+    const noop = await asOrg((svc) => svc.run(org, 10));
+    expect(noop.processed).toBe(0);
+    expect(noop.remaining).toBe(0);
+
+    const mdId = fileIds[FILES[0].rel];
+    await admin`UPDATE workspace_file_index SET mtime = now() + interval '1 minute' WHERE id = ${mdId}`;
+    const rerun = await asOrg((svc) => svc.run(org, 10));
+    expect(rerun.processed).toBe(1);
+    expect(rerun.remaining).toBe(0);
+  });
+
+  it('excludes tombstoned files from pending', async () => {
+    const mdId = fileIds[FILES[0].rel];
+    await admin`UPDATE workspace_file_index SET deleted_at = now(), mtime = now() + interval '2 minute' WHERE id = ${mdId}`;
+    const run = await asOrg((svc) => svc.run(org, 10));
+    expect(run.processed).toBe(0);
+    await admin`UPDATE workspace_file_index SET deleted_at = NULL WHERE id = ${mdId}`;
+  });
+
+  it('records a failed row (with snapshot) when bytes cannot be read, and the loop advances', async () => {
+    const ghost = randomUUID();
+    await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, parent_path, name, is_dir, size, mtime)
+                VALUES (${ghost}, ${org}, ${source}, 'missing/ghost.md', 'missing', 'ghost.md', false, 5, now())`;
+    const run = await asOrg((svc) => svc.run(org, 10));
+    expect(run.errors).toHaveLength(1);
+    expect(run.errors[0].relPath).toBe('missing/ghost.md');
+    expect(run.remaining).toBe(0); // failed row carries the snapshot; not pending anymore
+    const [row] = await admin`SELECT status, error_reason FROM workspace_file_content WHERE file_index_id = ${ghost}`;
+    expect(row.status).toBe('failed');
+    expect(row.error_reason).toBeTruthy();
+  });
+});

--- a/ee/workspace/src/__tests__/visibilityIntersection.integration.test.ts
+++ b/ee/workspace/src/__tests__/visibilityIntersection.integration.test.ts
@@ -1,0 +1,302 @@
+// Shared visibility predicate + group intersection — real-DB integration
+// (:5433). ONE rule (src/services/visibility.ts) now governs source visibility
+// across every read surface. This proves the group-intersection arm of that
+// rule end-to-end: a grouped source ('["g1","g2"]') becomes visible exactly
+// when the caller's claim set overlaps it, and stays hidden for the empty set
+// (today's fail-closed default) and a non-overlapping set — asserted on
+// fileQuery search/browse, every (lexical) hybrid arm, the passages path,
+// recents, the department feed, and the filing list. An ungrouped source is
+// visible under all three claim sets (the control).
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createFileQueryService } from '../services/fileQueryService';
+import { createContentSearchService } from '../services/contentSearchService';
+import { createActivityService } from '../services/activityService';
+import { createFilingService } from '../services/filingService';
+import { createCrosswalkService } from '../services/crosswalkService';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+// Claim sets: MEMBER overlaps the grouped source's {g1,g2}; NON_MEMBER does
+// not; EMPTY is the routes' fail-closed default (ungrouped-only).
+const MEMBER = ['g1'];
+const NON_MEMBER = ['g3'];
+const EMPTY: string[] = [];
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partner: string, org: string, site: string, openSource: string, groupedSource: string;
+const DEVICE = randomUUID();
+const ids: Record<string, string> = {};
+
+type Services = {
+  files: ReturnType<typeof createFileQueryService>;
+  content: ReturnType<typeof createContentSearchService>;
+  activity: ReturnType<typeof createActivityService>;
+  filing: ReturnType<typeof createFilingService>;
+};
+
+async function asOrg<T>(fn: (svc: Services) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } }).session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    const db = transaction as unknown as WorkspaceDatabase;
+    const crosswalk = createCrosswalkService(db);
+    return fn({
+      files: createFileQueryService(db),
+      content: createContentSearchService(db),
+      activity: createActivityService(db),
+      filing: createFilingService(db, { crosswalkService: crosswalk }),
+    });
+  });
+}
+
+interface SeedFile {
+  key: string;
+  src: 'grouped' | 'open';
+  rel: string;
+  text?: string;
+  entities?: Array<{ type: string; value: string; origin?: string }>;
+  enrichment?: Record<string, string | null>;
+  emailMeta?: object;
+  /** Seed one workspace_file_activity row for DEVICE against this file. */
+  activity?: boolean;
+}
+
+const SEED: SeedFile[] = [
+  // Grouped-source document: exercises the entity, FTS, trigram, and project
+  // arms plus the passages chunk. Only a claim overlapping {g1,g2} sees it.
+  {
+    key: 'gf', src: 'grouped',
+    rel: 'Grouped/2030-100 Restricted Reservoir/restricted-plan.md',
+    text: 'GRANT OF EASEMENT restricted reservoir gladstone parcel across APN 099-100-200.',
+    entities: [{ type: 'apn', value: '099-100-200' }],
+    enrichment: {
+      inferred_project_key: '2030-100', inferred_project_label: 'Restricted Reservoir',
+      inferred_doc_type: 'easement deed',
+      declared_project_key: '2030-100', declared_project_label: 'Restricted Reservoir',
+    },
+    activity: true,
+  },
+  // Grouped-source unfiled email: exercises the filing list.
+  {
+    key: 'ge', src: 'grouped', rel: 'Grouped/Unfiled/restricted intake.eml',
+    entities: [{ type: 'person', value: 'Restricted Person', origin: 'llm' }],
+    emailMeta: { subject: 'restricted intake', from: 'Restricted Person' },
+  },
+  // Ungrouped-source control document: visible under every claim set.
+  {
+    key: 'of', src: 'open',
+    rel: 'Open/2031-200 Public Reservoir/public-plan.md',
+    text: 'public reservoir gladstone parcel across APN 099-100-201.',
+    entities: [{ type: 'apn', value: '099-100-201' }],
+    enrichment: {
+      inferred_project_key: '2031-200', inferred_project_label: 'Public Reservoir',
+      declared_project_key: '2031-200', declared_project_label: 'Public Reservoir',
+    },
+    activity: true,
+  },
+  // Ungrouped-source control email.
+  {
+    key: 'oe', src: 'open', rel: 'Open/Unfiled/public intake.eml',
+    entities: [{ type: 'person', value: 'Public Person', origin: 'llm' }],
+    emailMeta: { subject: 'public intake', from: 'Public Person' },
+  },
+];
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partner = randomUUID(); org = randomUUID(); site = randomUUID();
+  openSource = randomUUID(); groupedSource = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug) VALUES (${partner}, 'wsp-vis', ${`wsp-vis-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${org}, ${partner}, 'wsp-vis-org', ${`wsp-vis-org-${sfx}`})`;
+  // A real device row: workspace_file_activity.device_id carries an FK.
+  await admin`INSERT INTO sites (id, org_id, name) VALUES (${site}, ${org}, 'wsp-vis-site')`;
+  await admin`INSERT INTO devices
+                (id, org_id, site_id, agent_id, hostname, os_type, os_version, architecture, agent_version)
+              VALUES (${DEVICE}, ${org}, ${site}, ${`wsp-vis-dev-${sfx}`}, 'vis-1', 'windows', '11', 'amd64', 'test')`;
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, visibility_group_ids)
+              VALUES (${openSource}, ${org}, 'smb_share', 'open estate', '\\\\srv\\open', '[]'::jsonb),
+                     (${groupedSource}, ${org}, 'smb_share', 'grouped estate', '\\\\srv\\grouped', '["g1","g2"]'::jsonb)`;
+  await admin`INSERT INTO workspace_projects (org_id, project_key, label)
+              VALUES (${org}, '2030-100', 'Restricted Reservoir'),
+                     (${org}, '2031-200', 'Public Reservoir')`;
+  for (const f of SEED) {
+    const id = randomUUID();
+    ids[f.key] = id;
+    const srcId = f.src === 'grouped' ? groupedSource : openSource;
+    const name = f.rel.split('/').pop()!;
+    const parent = f.rel.slice(0, f.rel.lastIndexOf('/'));
+    const ext = name.includes('.') ? name.split('.').pop()!.toLowerCase() : null;
+    await admin`INSERT INTO workspace_file_index
+        (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime)
+        VALUES (${id}, ${org}, ${srcId}, ${f.rel}, ${parent}, ${name}, false, ${ext}, 500, now())`;
+    if (f.text) {
+      await admin`INSERT INTO workspace_file_content (org_id, file_index_id, status, extracted_text, source_size, source_mtime)
+                  VALUES (${org}, ${id}, 'extracted', ${f.text}, 500, now())`;
+      await admin`INSERT INTO workspace_content_chunks (org_id, file_index_id, chunk_index, text)
+                  VALUES (${org}, ${id}, 0, ${f.text})`;
+    }
+    for (const e of f.entities ?? []) {
+      await admin`INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm, origin)
+                  VALUES (${org}, ${id}, ${e.type}, ${e.value}, ${e.origin ?? 'regex'})`;
+    }
+    if (f.enrichment || f.emailMeta) {
+      await admin`INSERT INTO workspace_file_enrichment ${admin({
+        org_id: org, file_index_id: id,
+        ...(f.enrichment ?? {}),
+        ...(f.emailMeta ? { email_meta: JSON.stringify(f.emailMeta) } : {}),
+      })}`;
+    }
+    if (f.activity) {
+      await admin`INSERT INTO workspace_file_activity (org_id, file_index_id, device_id, action)
+                  VALUES (${org}, ${id}, ${DEVICE}, 'open')`;
+    }
+  }
+});
+
+afterAll(async () => {
+  for (const t of ['workspace_file_activity', 'workspace_content_chunks', 'workspace_content_entities',
+    'workspace_file_enrichment', 'workspace_file_content', 'workspace_projects',
+    'workspace_file_index', 'workspace_sources']) {
+    await admin.unsafe(`DELETE FROM ${t} WHERE org_id = $1`, [org]);
+  }
+  await admin`DELETE FROM devices WHERE id = ${DEVICE}`;
+  await admin`DELETE FROM sites WHERE id = ${site}`;
+  await admin`DELETE FROM organizations WHERE id = ${org}`;
+  await admin`DELETE FROM partners WHERE id = ${partner}`;
+  await admin.end(); await app.end();
+});
+
+describe('shared visibility predicate — group intersection', () => {
+  describe('fileQueryService', () => {
+    it('visibleSources admits the grouped source only for an overlapping claim', async () => {
+      const member = await asOrg(({ files }) => files.visibleSources(org, MEMBER));
+      expect(member.map((s) => s.id).sort()).toEqual([openSource, groupedSource].sort());
+
+      for (const claims of [EMPTY, NON_MEMBER]) {
+        const rows = await asOrg(({ files }) => files.visibleSources(org, claims));
+        const sourceIds = rows.map((s) => s.id);
+        expect(sourceIds).toContain(openSource); // ungrouped control always visible
+        expect(sourceIds).not.toContain(groupedSource);
+      }
+    });
+
+    it('search returns the grouped file only for an overlapping claim; the ungrouped control always', async () => {
+      const member = await asOrg(({ files }) => files.search(org, DEVICE, { q: 'restricted' }, MEMBER));
+      expect(member.map((r) => r.id)).toContain(ids.gf);
+
+      for (const claims of [EMPTY, NON_MEMBER]) {
+        const hidden = await asOrg(({ files }) => files.search(org, DEVICE, { q: 'restricted' }, claims));
+        expect(hidden.map((r) => r.id)).not.toContain(ids.gf);
+        const control = await asOrg(({ files }) => files.search(org, DEVICE, { q: 'public' }, claims));
+        expect(control.map((r) => r.id)).toContain(ids.of);
+      }
+    });
+
+    it('browse returns the grouped folder only for an overlapping claim', async () => {
+      const parent = 'Grouped/2030-100 Restricted Reservoir';
+      const member = await asOrg(({ files }) => files.browse(org, DEVICE, groupedSource, parent, {}, MEMBER));
+      expect(member.map((r) => r.id)).toEqual([ids.gf]);
+
+      for (const claims of [EMPTY, NON_MEMBER]) {
+        const hidden = await asOrg(({ files }) => files.browse(org, DEVICE, groupedSource, parent, {}, claims));
+        expect(hidden).toEqual([]); // hidden source → empty, indistinguishable from unknown
+      }
+    });
+  });
+
+  describe('contentSearchService hybrid arms', () => {
+    // One query per arm trigger shape (vector arm is embedder-gated and absent
+    // in integration, like the rest of the suite). Every arm shares the one
+    // visibility scope tail, so the intersection holds on all of them.
+    const arms: Array<{ name: string; q: string }> = [
+      { name: 'entity token', q: '099-100-200' },
+      { name: 'FTS phrase', q: 'restricted reservoir' },
+      { name: 'trigram fragment', q: 'restricted-plan' },
+      { name: 'project key', q: '2030-100' },
+    ];
+    for (const arm of arms) {
+      it(`${arm.name}: grouped file surfaces only for an overlapping claim`, async () => {
+        const member = await asOrg(({ content }) => content.search(org, DEVICE, { q: arm.q }, MEMBER));
+        expect(member.map((r) => r.id)).toContain(ids.gf);
+
+        for (const claims of [EMPTY, NON_MEMBER]) {
+          const hidden = await asOrg(({ content }) => content.search(org, DEVICE, { q: arm.q }, claims));
+          expect(hidden.map((r) => r.id)).not.toContain(ids.gf);
+        }
+      });
+    }
+
+    it('the ungrouped control document surfaces under every claim set', async () => {
+      for (const claims of [EMPTY, NON_MEMBER, MEMBER]) {
+        const rows = await asOrg(({ content }) => content.search(org, DEVICE, { q: 'public reservoir' }, claims));
+        expect(rows.map((r) => r.id)).toContain(ids.of);
+      }
+    });
+  });
+
+  describe('contentSearchService passages (cited-RAG path)', () => {
+    it('never retrieves the grouped source chunk without an overlapping claim', async () => {
+      const member = await asOrg(({ content }) => content.passages(org, 'easement restricted', { helperDeviceId: DEVICE }, MEMBER));
+      expect(member.map((p) => p.fileIndexId)).toContain(ids.gf);
+
+      for (const claims of [EMPTY, NON_MEMBER]) {
+        const hidden = await asOrg(({ content }) => content.passages(org, 'easement restricted', { helperDeviceId: DEVICE }, claims));
+        expect(hidden.map((p) => p.fileIndexId)).not.toContain(ids.gf);
+      }
+    });
+  });
+
+  describe('activityService', () => {
+    it('recents surfaces grouped-source activity only for an overlapping claim', async () => {
+      const member = await asOrg(({ activity }) => activity.recents(org, DEVICE, null, undefined, MEMBER));
+      expect(member.map((r) => r.id)).toContain(ids.gf);
+
+      for (const claims of [EMPTY, NON_MEMBER]) {
+        const hidden = await asOrg(({ activity }) => activity.recents(org, DEVICE, null, undefined, claims));
+        expect(hidden.map((r) => r.id)).not.toContain(ids.gf);
+        expect(hidden.map((r) => r.id)).toContain(ids.of); // ungrouped control
+      }
+    });
+
+    it('department feed spans grouped activity only for an overlapping claim', async () => {
+      const member = await asOrg(({ activity }) => activity.departmentRecent(org, DEVICE, undefined, MEMBER));
+      expect(member.map((r) => r.id)).toContain(ids.gf);
+
+      for (const claims of [EMPTY, NON_MEMBER]) {
+        const hidden = await asOrg(({ activity }) => activity.departmentRecent(org, DEVICE, undefined, claims));
+        expect(hidden.map((r) => r.id)).not.toContain(ids.gf);
+        expect(hidden.map((r) => r.id)).toContain(ids.of); // ungrouped control
+      }
+    });
+  });
+
+  describe('filingService', () => {
+    it('list includes the grouped-source email only for an overlapping claim', async () => {
+      const member = await asOrg(({ filing }) => filing.list(org, MEMBER));
+      expect(member.map((r) => r.relPath)).toContain('Grouped/Unfiled/restricted intake.eml');
+
+      for (const claims of [EMPTY, NON_MEMBER]) {
+        const rels = (await asOrg(({ filing }) => filing.list(org, claims))).map((r) => r.relPath);
+        expect(rels).not.toContain('Grouped/Unfiled/restricted intake.eml');
+        expect(rels).toContain('Open/Unfiled/public intake.eml'); // ungrouped control
+      }
+    });
+  });
+});

--- a/ee/workspace/src/__tests__/workspaceRls.integration.test.ts
+++ b/ee/workspace/src/__tests__/workspaceRls.integration.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let partnerA: string, partnerB: string, orgA: string, orgB: string, sourceA: string, sourceB: string;
+let userA: string, userB: string, fileA: string, fileB: string;
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  partnerA = randomUUID(); partnerB = randomUUID();
+  orgA = randomUUID(); orgB = randomUUID();
+  const fixtureSuffix = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug)
+              VALUES (${partnerA}, 'wsp-rls-a', ${`wsp-rls-a-${fixtureSuffix}`}),
+                     (${partnerB}, 'wsp-rls-b', ${`wsp-rls-b-${fixtureSuffix}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${orgA}, ${partnerA}, 'wsp-org-a', ${`wsp-org-a-${fixtureSuffix}`}),
+                     (${orgB}, ${partnerB}, 'wsp-org-b', ${`wsp-org-b-${fixtureSuffix}`})`;
+  userA = randomUUID();
+  userB = randomUUID();
+  await admin`INSERT INTO users (id, partner_id, org_id, email, name)
+              VALUES (${userA}, ${partnerA}, ${orgA}, ${`wsp-rls-a-${fixtureSuffix}@example.test`}, 'wsp user a'),
+                     (${userB}, ${partnerB}, ${orgB}, ${`wsp-rls-b-${fixtureSuffix}@example.test`}, 'wsp user b')`;
+  sourceA = randomUUID();
+  sourceB = randomUUID();
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path)
+              VALUES (${sourceA}, ${orgA}, 'smb_share', 'a share', '\\\\srv\\a'),
+                     (${sourceB}, ${orgB}, 'smb_share', 'b share', '\\\\srv\\b')`;
+  fileA = randomUUID();
+  fileB = randomUUID();
+  await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, name)
+              VALUES (${fileA}, ${orgA}, ${sourceA}, 'activity/file-a.txt', 'file-a.txt'),
+                     (${fileB}, ${orgB}, ${sourceB}, 'activity/file.txt', 'file.txt')`;
+});
+
+afterAll(async () => {
+  await admin`DELETE FROM workspace_file_activity WHERE org_id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM workspace_crawl_runs WHERE org_id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM workspace_file_index WHERE org_id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM workspace_sources WHERE org_id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM memory_blocks WHERE org_id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM users WHERE id IN (${userA}, ${userB})`;
+  await admin`DELETE FROM organizations WHERE id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM partners WHERE id IN (${partnerA}, ${partnerB})`;
+  await admin.end(); await app.end();
+});
+
+/** Run fn as breeze_app inside org A's access context (mirrors withDbAccessContext set_configs). */
+async function asOrgA<T>(fn: (sql: postgres.TransactionSql) => Promise<T>): Promise<T> {
+  return app.begin(async (tx) => {
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${orgA}, true),
+                    set_config('breeze.accessible_org_ids', ${orgA}, true),
+                    set_config('breeze.accessible_partner_ids', ${partnerA}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(tx);
+  }) as Promise<T>;
+}
+
+async function expectRlsViolation(p: Promise<unknown>, table: string) {
+  await expect(p).rejects.toThrow(
+    new RegExp(`row-level security policy for table "${table}"`)
+  );
+}
+
+describe('workspace extension RLS (cross-tenant forge as breeze_app)', () => {
+  it('workspace_sources: org A context cannot insert an org B row', async () => {
+    await expectRlsViolation(
+      asOrgA((tx) => tx`INSERT INTO workspace_sources (org_id, kind, display_name, root_path)
+                        VALUES (${orgB}, 'smb_share', 'forged', '\\\\srv\\x')`),
+      'workspace_sources'
+    );
+  });
+
+  it('workspace_file_index: forged org B row is rejected', async () => {
+    await expectRlsViolation(
+      asOrgA((tx) => tx`INSERT INTO workspace_file_index (org_id, source_id, rel_path, name)
+                        VALUES (${orgB}, ${sourceB}, 'a/b.docx', 'b.docx')`),
+      'workspace_file_index'
+    );
+  });
+
+  it('workspace_file_index: org A context cannot READ org B rows', async () => {
+    const seededId = randomUUID();
+    await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, name)
+                VALUES (${seededId}, ${orgB}, ${sourceB}, 'secret/doc.pdf', 'doc.pdf')`;
+    const rows = await asOrgA((tx) => tx`SELECT id FROM workspace_file_index WHERE id = ${seededId}`);
+    expect(rows).toHaveLength(0); // RLS silent-0-row read, not an error
+    await admin`DELETE FROM workspace_file_index WHERE id = ${seededId}`;
+  });
+
+  it('workspace_file_index: insert without device fields defaults device_key', async () => {
+    const id = randomUUID();
+    const rows = await asOrgA((tx) => tx`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, name)
+                                         VALUES (${id}, ${orgA}, ${sourceA}, 'default-device/file.txt', 'file.txt')
+                                         RETURNING device_key`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.device_key).toBe('00000000-0000-0000-0000-000000000000');
+    await admin`DELETE FROM workspace_file_index WHERE id = ${id}`;
+  });
+
+  it('workspace_crawl_runs: forged org B row is rejected', async () => {
+    await expectRlsViolation(
+      asOrgA((tx) => tx`INSERT INTO workspace_crawl_runs (org_id, source_id)
+                        VALUES (${orgB}, ${sourceB})`),
+      'workspace_crawl_runs'
+    );
+  });
+
+  it('workspace_crawl_runs: same-org insert succeeds (policies are not deny-all)', async () => {
+    const id = randomUUID();
+    await asOrgA((tx) => tx`INSERT INTO workspace_crawl_runs (id, org_id, source_id)
+                            VALUES (${id}, ${orgA}, ${sourceA})`);
+    await admin`DELETE FROM workspace_crawl_runs WHERE id = ${id}`;
+  });
+
+  it('workspace_crawl_runs: org A context cannot READ org B rows', async () => {
+    const seededId = randomUUID();
+    await admin`INSERT INTO workspace_crawl_runs (id, org_id, source_id)
+                VALUES (${seededId}, ${orgB}, ${sourceB})`;
+    const rows = await asOrgA((tx) => tx`SELECT id FROM workspace_crawl_runs WHERE id = ${seededId}`);
+    expect(rows).toHaveLength(0); // RLS silent-0-row read, not an error
+    await admin`DELETE FROM workspace_crawl_runs WHERE id = ${seededId}`;
+  });
+
+  it('workspace_file_activity: forged org B row is rejected', async () => {
+    await expectRlsViolation(
+      asOrgA((tx) => tx`INSERT INTO workspace_file_activity (org_id, user_id, file_index_id, action)
+                        VALUES (${orgB}, ${userB}, ${fileB}, 'open')`),
+      'workspace_file_activity'
+    );
+  });
+
+  it('memory_blocks: forged org B row is rejected', async () => {
+    await expectRlsViolation(
+      asOrgA((tx) => tx`INSERT INTO memory_blocks (org_id, block_type, subject_key, content)
+                        VALUES (${orgB}, 'reference', 'doc:forged', '{"note":"x"}'::jsonb)`),
+      'memory_blocks'
+    );
+  });
+
+  it('memory_blocks: same-org insert succeeds (policies are not deny-all)', async () => {
+    const id = randomUUID();
+    await asOrgA((tx) => tx`INSERT INTO memory_blocks (id, org_id, block_type, subject_key, content)
+                            VALUES (${id}, ${orgA}, 'reference', 'doc:ok', '{"note":"ok"}'::jsonb)`);
+    await admin`DELETE FROM memory_blocks WHERE id = ${id}`;
+  });
+
+  it('workspace_file_activity: same-org insert succeeds (policies are not deny-all)', async () => {
+    const id = randomUUID();
+    await asOrgA((tx) => tx`INSERT INTO workspace_file_activity (id, org_id, user_id, file_index_id, action)
+                            VALUES (${id}, ${orgA}, ${userA}, ${fileA}, 'open')`);
+    await admin`DELETE FROM workspace_file_activity WHERE id = ${id}`;
+  });
+});
+
+// Every table × every operation: a SELECT/UPDATE/DELETE policy regression on
+// any one table must fail here, not survive because only INSERT was forged.
+describe('workspace extension RLS matrix (READ/UPDATE/DELETE isolation, all tables)', () => {
+  type MatrixCase = {
+    table: string;
+    seedOrgB: (id: string) => Promise<unknown>;
+    forgeUpdate: (tx: postgres.TransactionSql, id: string) => Promise<postgres.RowList<postgres.Row[]>>;
+    cleanup: (id: string) => Promise<unknown>;
+  };
+
+  // Closures read the beforeAll-assigned fixtures at call time.
+  const cases: MatrixCase[] = [
+    {
+      table: 'workspace_sources',
+      seedOrgB: (id) => admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path)
+                              VALUES (${id}, ${orgB}, 'smb_share', 'matrix', '\\\\srv\\m')`,
+      forgeUpdate: (tx, id) => tx`UPDATE workspace_sources SET display_name = 'forged' WHERE id = ${id}`,
+      cleanup: (id) => admin`DELETE FROM workspace_sources WHERE id = ${id}`,
+    },
+    {
+      table: 'workspace_file_index',
+      seedOrgB: (id) => admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, name)
+                              VALUES (${id}, ${orgB}, ${sourceB}, ${`matrix/${id}.txt`}, 'm.txt')`,
+      forgeUpdate: (tx, id) => tx`UPDATE workspace_file_index SET name = 'forged' WHERE id = ${id}`,
+      cleanup: (id) => admin`DELETE FROM workspace_file_index WHERE id = ${id}`,
+    },
+    {
+      table: 'workspace_crawl_runs',
+      seedOrgB: (id) => admin`INSERT INTO workspace_crawl_runs (id, org_id, source_id)
+                              VALUES (${id}, ${orgB}, ${sourceB})`,
+      forgeUpdate: (tx, id) => tx`UPDATE workspace_crawl_runs SET status = 'abandoned' WHERE id = ${id}`,
+      cleanup: (id) => admin`DELETE FROM workspace_crawl_runs WHERE id = ${id}`,
+    },
+    {
+      table: 'workspace_file_activity',
+      seedOrgB: (id) => admin`INSERT INTO workspace_file_activity (id, org_id, user_id, file_index_id, action)
+                              VALUES (${id}, ${orgB}, ${userB}, ${fileB}, 'open')`,
+      forgeUpdate: (tx, id) => tx`UPDATE workspace_file_activity SET action = 'reveal' WHERE id = ${id}`,
+      cleanup: (id) => admin`DELETE FROM workspace_file_activity WHERE id = ${id}`,
+    },
+    {
+      table: 'memory_blocks',
+      seedOrgB: (id) => admin`INSERT INTO memory_blocks (id, org_id, block_type, subject_key, content)
+                              VALUES (${id}, ${orgB}, 'reference', 'doc:matrix', '{}'::jsonb)`,
+      forgeUpdate: (tx, id) => tx`UPDATE memory_blocks SET confidence = 'high' WHERE id = ${id}`,
+      cleanup: (id) => admin`DELETE FROM memory_blocks WHERE id = ${id}`,
+    },
+  ];
+
+  for (const c of cases) {
+    it(`${c.table}: org A context cannot READ an org B row`, async () => {
+      const id = randomUUID();
+      await c.seedOrgB(id);
+      try {
+        const rows = await asOrgA((tx) => tx`SELECT id FROM ${tx(c.table)} WHERE id = ${id}`);
+        expect(rows).toHaveLength(0); // RLS silent-0-row read, not an error
+      } finally {
+        await c.cleanup(id);
+      }
+    });
+
+    it(`${c.table}: org A context cannot UPDATE an org B row`, async () => {
+      const id = randomUUID();
+      await c.seedOrgB(id);
+      try {
+        const result = await asOrgA((tx) => c.forgeUpdate(tx, id));
+        expect(result.count).toBe(0); // USING filters the row: silent no-op
+      } finally {
+        await c.cleanup(id);
+      }
+    });
+
+    it(`${c.table}: org A context cannot DELETE an org B row`, async () => {
+      const id = randomUUID();
+      await c.seedOrgB(id);
+      try {
+        const result = await asOrgA((tx) => tx`DELETE FROM ${tx(c.table)} WHERE id = ${id}`);
+        expect(result.count).toBe(0);
+        const survivors = await admin`SELECT id FROM ${admin(c.table)} WHERE id = ${id}`;
+        expect(survivors).toHaveLength(1); // the row must still exist
+      } finally {
+        await c.cleanup(id);
+      }
+    });
+  }
+});
+
+// workspace_org_settings (W2): org_id IS the primary key (one settings row
+// per org), so it doesn't fit the id-keyed MatrixCase shape above — a
+// dedicated probe instead.
+describe('workspace_org_settings RLS (W2 governance settings, cross-tenant)', () => {
+  it('org A context cannot READ org B settings row', async () => {
+    await admin`INSERT INTO workspace_org_settings (org_id, content_enabled, dlp_config)
+                VALUES (${orgB}, true, '{"detectors":{"ssn":"redact"}}'::jsonb)`;
+    try {
+      const rows = await asOrgA((tx) => tx`SELECT org_id FROM workspace_org_settings WHERE org_id = ${orgB}`);
+      expect(rows).toHaveLength(0); // RLS silent-0-row read, not an error
+    } finally {
+      await admin`DELETE FROM workspace_org_settings WHERE org_id = ${orgB}`;
+    }
+  });
+
+  it('org A context cannot forge an insert for org B', async () => {
+    await expectRlsViolation(
+      asOrgA((tx) => tx`INSERT INTO workspace_org_settings (org_id, content_enabled)
+                        VALUES (${orgB}, true)`),
+      'workspace_org_settings'
+    );
+  });
+
+  it('org A context cannot UPDATE an org B settings row', async () => {
+    await admin`INSERT INTO workspace_org_settings (org_id, content_enabled)
+                VALUES (${orgB}, false)`;
+    try {
+      const result = await asOrgA((tx) => tx`UPDATE workspace_org_settings
+                                             SET content_enabled = true WHERE org_id = ${orgB}`);
+      expect(result.count).toBe(0); // USING filters the row: silent no-op
+    } finally {
+      await admin`DELETE FROM workspace_org_settings WHERE org_id = ${orgB}`;
+    }
+  });
+
+  it('org A context cannot DELETE an org B settings row', async () => {
+    await admin`INSERT INTO workspace_org_settings (org_id, content_enabled)
+                VALUES (${orgB}, false)`;
+    try {
+      const result = await asOrgA((tx) => tx`DELETE FROM workspace_org_settings WHERE org_id = ${orgB}`);
+      expect(result.count).toBe(0);
+      const survivors = await admin`SELECT org_id FROM workspace_org_settings WHERE org_id = ${orgB}`;
+      expect(survivors).toHaveLength(1); // the row must still exist
+    } finally {
+      await admin`DELETE FROM workspace_org_settings WHERE org_id = ${orgB}`;
+    }
+  });
+
+  it('same-org insert succeeds (policy is not deny-all)', async () => {
+    await asOrgA((tx) => tx`INSERT INTO workspace_org_settings (org_id, content_enabled)
+                            VALUES (${orgA}, true)`);
+    await admin`DELETE FROM workspace_org_settings WHERE org_id = ${orgA}`;
+  });
+});

--- a/ee/workspace/src/content/byteReader.test.ts
+++ b/ee/workspace/src/content/byteReader.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  MountedDirReader, SmbByteReader, parseMountMap, parseHostMap, parseUncRoot,
+} from './byteReader';
+
+describe('parse helpers', () => {
+  it('parses a mount map env value', () => {
+    expect(parseMountMap('a=/x/y,b=/z')).toEqual({ a: '/x/y', b: '/z' });
+    expect(parseMountMap(undefined)).toEqual({});
+  });
+  it('parses a host map env value', () => {
+    expect(parseHostMap('127.0.0.1=host.docker.internal')).toEqual({ '127.0.0.1': 'host.docker.internal' });
+  });
+  it('parses a UNC root into host and share', () => {
+    expect(parseUncRoot('\\\\127.0.0.1\\alder-creek')).toEqual({ host: '127.0.0.1', share: 'alder-creek' });
+    expect(() => parseUncRoot('C:\\local')).toThrow();
+  });
+});
+
+describe('MountedDirReader', () => {
+  let base: string;
+  const source = { id: 'src-1', orgId: 'org-1', kind: 'smb_share', rootPath: '\\\\127.0.0.1\\alder-creek' };
+
+  beforeAll(() => {
+    base = mkdtempSync(join(tmpdir(), 'wsp-content-'));
+    mkdirSync(join(base, 'Projects'), { recursive: true });
+    writeFileSync(join(base, 'Projects', 'doc.md'), 'hello');
+    writeFileSync(join(base, 'secret-outside'), 'nope'); // sibling of the traversal target
+  });
+  afterAll(() => rmSync(base, { recursive: true, force: true }));
+
+  it('reads a file under the mapped root', async () => {
+    const reader = new MountedDirReader({ 'src-1': base });
+    const buf = await reader.read(source, 'Projects/doc.md');
+    expect(buf.toString()).toBe('hello');
+  });
+
+  it('rejects path traversal', async () => {
+    const reader = new MountedDirReader({ 'src-1': join(base, 'Projects') });
+    await expect(reader.read(source, '../secret-outside')).rejects.toThrow(/traversal|outside/i);
+  });
+
+  it('rejects a symlink inside the root that points outside it', async () => {
+    symlinkSync(join(base, 'secret-outside'), join(base, 'Projects', 'sneaky-link'));
+    const reader = new MountedDirReader({ 'src-1': join(base, 'Projects') });
+    await expect(reader.read(source, 'sneaky-link')).rejects.toThrow(/symlink/i);
+  });
+
+  it('rejects a source with no mapping', async () => {
+    const reader = new MountedDirReader({});
+    await expect(reader.read(source, 'Projects/doc.md')).rejects.toThrow(/no mount mapping/i);
+  });
+});
+
+describe('SmbByteReader', () => {
+  const source = { id: 'src-1', orgId: 'org-1', kind: 'smb_share', rootPath: '\\\\127.0.0.1\\alder-creek' };
+
+  it('connects with the decrypted credential, rewrites the host, and reads with backslashes', async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const reads: string[] = [];
+    const credCalls: string[] = [];
+    const reader = new SmbByteReader({
+      getCredential: async (orgId, sourceId) => {
+        credCalls.push(`${orgId}/${sourceId}`);
+        return { username: 'breeze', password: 'breezepass', domain: null };
+      },
+      hostMap: { '127.0.0.1': 'host.docker.internal' },
+      smbFactory: (opts) => {
+        calls.push(opts as unknown as Record<string, unknown>);
+        return {
+          readFile: async (p: string) => { reads.push(p); return Buffer.from('bytes'); },
+          disconnect: () => {},
+        };
+      },
+    });
+    const buf = await reader.read(source, 'Projects/2019-112 Quail Hollow Estates ROS/deed.md');
+    expect(buf.toString()).toBe('bytes');
+    expect(calls[0].share).toBe('\\\\host.docker.internal\\alder-creek');
+    expect(calls[0].username).toBe('breeze');
+    expect(credCalls).toEqual(['org-1/src-1']);
+    expect(reads[0]).toBe('Projects\\2019-112 Quail Hollow Estates ROS\\deed.md');
+  });
+
+  it('fails when no credential is stored', async () => {
+    const reader = new SmbByteReader({
+      getCredential: async () => null,
+      hostMap: {},
+      smbFactory: () => { throw new Error('must not connect'); },
+    });
+    await expect(reader.read(source, 'x.md')).rejects.toThrow(/credential/i);
+  });
+
+  it('reuses one client per source', async () => {
+    let connects = 0;
+    const reader = new SmbByteReader({
+      getCredential: async () => ({ username: 'u', password: 'p', domain: null }),
+      hostMap: {},
+      smbFactory: () => {
+        connects += 1;
+        return { readFile: async () => Buffer.from('x'), disconnect: () => {} };
+      },
+    });
+    await reader.read(source, 'a.md');
+    await reader.read(source, 'b.md');
+    expect(connects).toBe(1);
+  });
+});

--- a/ee/workspace/src/content/byteReader.ts
+++ b/ee/workspace/src/content/byteReader.ts
@@ -47,7 +47,8 @@ export function parseHostMap(env: string | undefined): Record<string, string> {
 export function parseUncRoot(rootPath: string): { host: string; share: string } {
   const m = rootPath.match(/^\\\\([^\\]+)\\([^\\]+)\\?$/);
   if (!m) throw new Error(`not a UNC root path: ${rootPath}`);
-  return { host: m[1], share: m[2] };
+  // Both groups are structurally guaranteed by the match above.
+  return { host: m[1]!, share: m[2]! };
 }
 
 export class MountedDirReader implements ContentByteReader {

--- a/ee/workspace/src/content/byteReader.ts
+++ b/ee/workspace/src/content/byteReader.ts
@@ -1,0 +1,164 @@
+// Byte readers for content ingest (dev-preview; per-org content flag).
+//
+// Design decision (2026-07-18 spike): the primary reader is a server-side SMB
+// read with the STORED SOURCE CREDENTIAL (v9u-smb2, NTLMv2). It exercises the
+// same credential path the crawler uses and works for any reachable share.
+// Caveats, both dev-acceptable and documented in dev/README.md:
+//   - NTLM needs MD4 → the API process requires NODE_OPTIONS=--openssl-legacy-provider
+//     (set only in the untracked dev compose override).
+//   - In-container, the share host may need rewriting (WORKSPACE_CONTENT_SMB_HOST_MAP,
+//     e.g. "127.0.0.1=host.docker.internal").
+// MountedDirReader is the fallback: map source id → local dir via
+// WORKSPACE_CONTENT_MOUNT_MAP for estates whose bytes are locally mounted.
+//
+// DLP runs downstream in contentIngestService, between extraction and
+// persistence; bytes read here flow to the extraction step, whose text is then
+// DLP-inspected (redact before store, block before embed) before any storage.
+import { readFile, realpath } from 'node:fs/promises';
+import { resolve, sep } from 'node:path';
+
+export interface ContentSourceRef {
+  id: string;
+  orgId: string;
+  kind: string;
+  rootPath: string;
+}
+
+export interface ContentByteReader {
+  read(source: ContentSourceRef, relPath: string): Promise<Buffer>;
+}
+
+/** Parse "id=/path,id2=/path2" (WORKSPACE_CONTENT_MOUNT_MAP). */
+export function parseMountMap(env: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const pair of (env ?? '').split(',')) {
+    const i = pair.indexOf('=');
+    if (i > 0) out[pair.slice(0, i).trim()] = pair.slice(i + 1).trim();
+  }
+  return out;
+}
+
+/** Parse "host=replacement,…" (WORKSPACE_CONTENT_SMB_HOST_MAP). */
+export function parseHostMap(env: string | undefined): Record<string, string> {
+  return parseMountMap(env);
+}
+
+/** \\host\share → { host, share }. Throws on anything that is not UNC. */
+export function parseUncRoot(rootPath: string): { host: string; share: string } {
+  const m = rootPath.match(/^\\\\([^\\]+)\\([^\\]+)\\?$/);
+  if (!m) throw new Error(`not a UNC root path: ${rootPath}`);
+  return { host: m[1], share: m[2] };
+}
+
+export class MountedDirReader implements ContentByteReader {
+  constructor(private readonly mountMap: Record<string, string>) {}
+
+  async read(source: ContentSourceRef, relPath: string): Promise<Buffer> {
+    const base = this.mountMap[source.id];
+    if (!base) throw new Error(`no mount mapping for source ${source.id}`);
+    const absBase = await realpath(resolve(base));
+    const target = resolve(absBase, relPath);
+    if (target !== absBase && !target.startsWith(absBase + sep)) {
+      throw new Error(`path traversal outside mount root: ${relPath}`);
+    }
+    // Re-check after resolving symlinks: a link inside the root pointing
+    // outside it must not smuggle bytes in (the crawler indexes names only,
+    // but the share contents are not under our control).
+    const real = await realpath(target);
+    if (real !== absBase && !real.startsWith(absBase + sep)) {
+      throw new Error(`path traversal outside mount root (symlink): ${relPath}`);
+    }
+    return readFile(real);
+  }
+}
+
+export interface SmbClientLike {
+  readFile(path: string): Promise<Buffer>;
+  disconnect(): void;
+}
+
+export interface SmbConnectOptions {
+  share: string;
+  domain: string;
+  username: string;
+  password: string;
+}
+
+export interface SmbByteReaderDeps {
+  /** Decrypted source credential (credentialService.decryptForContentIngest). */
+  getCredential(orgId: string, sourceId: string): Promise<{ username: string; password: string; domain: string | null } | null>;
+  hostMap: Record<string, string>;
+  /** Injectable for tests; defaults to a v9u-smb2 client. */
+  smbFactory?: (opts: SmbConnectOptions) => SmbClientLike;
+}
+
+async function defaultSmbFactory(opts: SmbConnectOptions): Promise<SmbClientLike> {
+  const mod = await import('v9u-smb2');
+  const SMB2 = (mod as { default?: unknown }).default ?? mod;
+  const client = new (SMB2 as new (o: object) => {
+    readFile(p: string): Promise<Buffer>;
+    disconnect(): void;
+  })({ ...opts, autoCloseTimeout: 0 });
+  return client;
+}
+
+export class SmbByteReader implements ContentByteReader {
+  private clients = new Map<string, SmbClientLike | Promise<SmbClientLike>>();
+
+  constructor(private readonly deps: SmbByteReaderDeps) {}
+
+  private async clientFor(source: ContentSourceRef): Promise<SmbClientLike> {
+    const existing = this.clients.get(source.id);
+    if (existing) return existing;
+    const pending = (async () => {
+      const cred = await this.deps.getCredential(source.orgId, source.id);
+      if (!cred) throw new Error(`no credential stored for source ${source.id}`);
+      const { host, share } = parseUncRoot(source.rootPath);
+      const mappedHost = this.deps.hostMap[host] ?? host;
+      const opts: SmbConnectOptions = {
+        share: `\\\\${mappedHost}\\${share}`,
+        domain: cred.domain ?? 'WORKGROUP',
+        username: cred.username,
+        password: cred.password,
+      };
+      return this.deps.smbFactory ? this.deps.smbFactory(opts) : defaultSmbFactory(opts);
+    })();
+    this.clients.set(source.id, pending);
+    try {
+      const client = await pending;
+      this.clients.set(source.id, client);
+      return client;
+    } catch (error) {
+      this.clients.delete(source.id);
+      throw error;
+    }
+  }
+
+  async read(source: ContentSourceRef, relPath: string): Promise<Buffer> {
+    const client = await this.clientFor(source);
+    return client.readFile(relPath.replace(/\//g, '\\'));
+  }
+
+  disconnectAll(): void {
+    for (const c of this.clients.values()) {
+      if (c instanceof Promise) continue;
+      try { c.disconnect(); } catch { /* best effort */ }
+    }
+    this.clients.clear();
+  }
+}
+
+/**
+ * Default reader wiring: mounted-dir when WORKSPACE_CONTENT_MOUNT_MAP is set
+ * (dev fallback), otherwise SMB with the stored source credential (primary).
+ */
+export function buildContentReader(
+  getCredential: SmbByteReaderDeps['getCredential'],
+): ContentByteReader {
+  const mountMap = parseMountMap(process.env.WORKSPACE_CONTENT_MOUNT_MAP);
+  if (Object.keys(mountMap).length > 0) return new MountedDirReader(mountMap);
+  return new SmbByteReader({
+    getCredential,
+    hostMap: parseHostMap(process.env.WORKSPACE_CONTENT_SMB_HOST_MAP),
+  });
+}

--- a/ee/workspace/src/content/dlp.test.ts
+++ b/ee/workspace/src/content/dlp.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { applyDlpToText } from './dlp';
+import { DEFAULT_DLP_CONFIG, type DlpConfig } from '../services/orgSettingsService';
+
+describe('applyDlpToText', () => {
+  // ── credit_card ────────────────────────────────────────────────────────────
+  it('redacts a Luhn-valid card number and records the finding', () => {
+    const r = applyDlpToText('card 4111 1111 1111 1111 ok', DEFAULT_DLP_CONFIG);
+    expect(r.text).toBe('card [REDACTED:credit_card] ok');
+    expect(r.findings).toEqual([{ detector: 'credit_card', action: 'redact', count: 1 }]);
+    expect(r.blocked).toBe(false);
+  });
+
+  it('does not flag a Luhn-invalid 16-digit number', () => {
+    const r = applyDlpToText('card 4111 1111 1111 1112 ok', DEFAULT_DLP_CONFIG);
+    expect(r.text).toBe('card 4111 1111 1111 1112 ok');
+    expect(r.findings).toEqual([]);
+    expect(r.blocked).toBe(false);
+  });
+
+  // ── ssn ────────────────────────────────────────────────────────────────────
+  it('redacts a plausible dashed SSN', () => {
+    const r = applyDlpToText('ssn 536-90-4399 on file', DEFAULT_DLP_CONFIG);
+    expect(r.text).toBe('ssn [REDACTED:ssn] on file');
+    expect(r.findings).toEqual([{ detector: 'ssn', action: 'redact', count: 1 }]);
+  });
+
+  it('excludes SSNs in invalid ranges (area 000)', () => {
+    const r = applyDlpToText('ssn 000-12-3456 nah', DEFAULT_DLP_CONFIG);
+    expect(r.text).toBe('ssn 000-12-3456 nah');
+    expect(r.findings).toEqual([]);
+  });
+
+  it('block action blocks the whole text', () => {
+    const cfg: DlpConfig = {
+      ...DEFAULT_DLP_CONFIG,
+      detectors: { ...DEFAULT_DLP_CONFIG.detectors, ssn: 'block' as const },
+    };
+    expect(applyDlpToText('ssn 536-90-4399', cfg).blocked).toBe(true);
+  });
+
+  it('block short-circuits redaction but the findings list is still complete', () => {
+    const cfg: DlpConfig = {
+      ...DEFAULT_DLP_CONFIG,
+      detectors: { ...DEFAULT_DLP_CONFIG.detectors, ssn: 'block' as const },
+    };
+    const r = applyDlpToText('card 4111 1111 1111 1111 and ssn 536-90-4399', cfg);
+    expect(r.blocked).toBe(true);
+    expect(r.findings).toEqual(
+      expect.arrayContaining([
+        { detector: 'credit_card', action: 'redact', count: 1 },
+        { detector: 'ssn', action: 'block', count: 1 },
+      ]),
+    );
+    expect(r.findings).toHaveLength(2);
+  });
+
+  // ── iban ───────────────────────────────────────────────────────────────────
+  it('redacts a checksum-valid IBAN', () => {
+    const r = applyDlpToText('iban DE89370400440532013000 ok', DEFAULT_DLP_CONFIG);
+    expect(r.text).toBe('iban [REDACTED:iban] ok');
+    expect(r.findings).toEqual([{ detector: 'iban', action: 'redact', count: 1 }]);
+  });
+
+  it('does not flag an IBAN-shaped string that fails the mod-97 checksum', () => {
+    const r = applyDlpToText('iban DE89370400440532013001 ok', DEFAULT_DLP_CONFIG);
+    expect(r.text).toBe('iban DE89370400440532013001 ok');
+    expect(r.findings).toEqual([]);
+  });
+
+  // ── api_key ────────────────────────────────────────────────────────────────
+  it('redacts an entropy-prefixed API key', () => {
+    const r = applyDlpToText('key sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWX1234 leaked', DEFAULT_DLP_CONFIG);
+    expect(r.text).toBe('key [REDACTED:api_key] leaked');
+    expect(r.findings).toEqual([{ detector: 'api_key', action: 'redact', count: 1 }]);
+  });
+
+  // ── email / phone (off by default) ────────────────────────────────────────
+  it('off action neither changes text nor records a finding', () => {
+    const r = applyDlpToText('reach jane.doe@example.com anytime', DEFAULT_DLP_CONFIG);
+    expect(r.text).toBe('reach jane.doe@example.com anytime');
+    expect(r.findings).toEqual([]);
+    expect(r.blocked).toBe(false);
+  });
+
+  it('log action leaves text unchanged but records the finding', () => {
+    const cfg: DlpConfig = {
+      ...DEFAULT_DLP_CONFIG,
+      detectors: { ...DEFAULT_DLP_CONFIG.detectors, email: 'log' as const },
+    };
+    const r = applyDlpToText('reach jane.doe@example.com anytime', cfg);
+    expect(r.text).toBe('reach jane.doe@example.com anytime');
+    expect(r.findings).toEqual([{ detector: 'email', action: 'log', count: 1 }]);
+    expect(r.blocked).toBe(false);
+  });
+
+  it('redacts an E.164-ish phone number when enabled', () => {
+    const cfg: DlpConfig = {
+      ...DEFAULT_DLP_CONFIG,
+      detectors: { ...DEFAULT_DLP_CONFIG.detectors, phone: 'redact' as const },
+    };
+    const r = applyDlpToText('call +1 415-555-2671 now', cfg);
+    expect(r.text).toBe('call [REDACTED:phone] now');
+    expect(r.findings).toEqual([{ detector: 'phone', action: 'redact', count: 1 }]);
+  });
+
+  // ── custom patterns ───────────────────────────────────────────────────────
+  it('custom pattern with named action applies', () => {
+    const cfg: DlpConfig = {
+      ...DEFAULT_DLP_CONFIG,
+      customPatterns: [{ name: 'ticket_id', pattern: 'TICKET-\\d+', action: 'redact' }],
+    };
+    const r = applyDlpToText('see TICKET-4821 for details', cfg);
+    expect(r.text).toBe('see [REDACTED:ticket_id] for details');
+    expect(r.findings).toEqual([{ detector: 'ticket_id', action: 'redact', count: 1 }]);
+  });
+
+  // ── invariant: idempotence ────────────────────────────────────────────────
+  it('is idempotent: re-scanning redacted output yields zero findings', () => {
+    const first = applyDlpToText('card 4111 1111 1111 1111 ssn 536-90-4399', DEFAULT_DLP_CONFIG);
+    const second = applyDlpToText(first.text, DEFAULT_DLP_CONFIG);
+    expect(second.findings).toEqual([]);
+    expect(second.text).toBe(first.text);
+    expect(second.blocked).toBe(false);
+  });
+
+  it('is idempotent when a dashed SSN redaction token leaves behind an unrelated bare 9-digit number', () => {
+    // The dashed SSN triggers redaction with no "ssn"/"social security"
+    // keyword elsewhere in the source text, so the bare-digit branch never
+    // runs on pass 1 and '123456789' is untouched. The emitted
+    // '[REDACTED:ssn]' token must not itself be read as context on a
+    // re-scan, or pass 2 would newly (and wrongly) flag '123456789'.
+    const first = applyDlpToText('id 536-90-4399 next id 123456789 end', DEFAULT_DLP_CONFIG);
+    expect(first.text).toBe('id [REDACTED:ssn] next id 123456789 end');
+    expect(first.findings).toEqual([{ detector: 'ssn', action: 'redact', count: 1 }]);
+
+    const second = applyDlpToText(first.text, DEFAULT_DLP_CONFIG);
+    expect(second.findings).toEqual([]);
+    expect(second.text).toBe(first.text);
+    expect(second.blocked).toBe(false);
+  });
+});

--- a/ee/workspace/src/content/dlp.ts
+++ b/ee/workspace/src/content/dlp.ts
@@ -1,0 +1,357 @@
+/**
+ * Workspace DLP engine — pure-TS scan/redact pipeline for text leaving the
+ * workspace (chat prompts, content bodies, etc). No I/O; consumes the
+ * DlpConfig produced by org settings (src/services/orgSettingsService.ts).
+ *
+ * Detector SEMANTICS are ported from the read-only reference at
+ * ~/breeze/apps/api/src/services/clientAiDlp.ts and
+ * ~/breeze/apps/api/src/services/clientAiDlpDetectors.ts (client-ai's DLP
+ * chokepoint). Cross-repo import isn't possible (open-core boundary), so
+ * this is a deliberate local reimplementation, not duplication to flag.
+ * Detector names here use the workspace's DetectorId spelling
+ * (credit_card / api_key, snake_case) rather than client-ai's camelCase.
+ *
+ * Order of operations mirrors the reference: scan every enabled detector
+ * over the full text first (findings list is always complete), THEN decide
+ * outcome — any 'block' match short-circuits redaction (the caller should
+ * not persist/forward the text), otherwise 'redact' matches are replaced
+ * with `[REDACTED:<detector>]` tokens (redaction is itself idempotent: a
+ * re-scan of already-redacted output finds nothing) and 'log' matches are
+ * recorded without touching the text. 'off' detectors are not scanned.
+ */
+
+import type { DetectorId, DlpAction, DlpConfig } from '../services/orgSettingsService';
+
+export interface DlpFinding {
+  detector: string;
+  action: DlpAction;
+  count: number;
+}
+
+export interface DlpTextResult {
+  text: string;
+  findings: DlpFinding[];
+  blocked: boolean;
+}
+
+interface Match {
+  /** Inclusive start offset. */
+  start: number;
+  /** Exclusive end offset. */
+  end: number;
+}
+
+interface CompiledRule {
+  name: string;
+  action: DlpAction;
+  detect: (text: string) => Match[];
+}
+
+/** Merge overlapping/nested spans (sorted output). */
+function mergeMatches(matches: Match[]): Match[] {
+  if (matches.length <= 1) return matches;
+  const sorted = [...matches].sort((a, b) => a.start - b.start || a.end - b.end);
+  const merged: Match[] = [{ ...sorted[0]! }];
+  for (let i = 1; i < sorted.length; i++) {
+    const cur = sorted[i]!;
+    const last = merged[merged.length - 1]!;
+    if (cur.start <= last.end) {
+      last.end = Math.max(last.end, cur.end);
+    } else {
+      merged.push({ ...cur });
+    }
+  }
+  return merged;
+}
+
+function spansOf(text: string, re: RegExp): Match[] {
+  const out: Match[] = [];
+  for (const m of text.matchAll(re)) {
+    out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+  }
+  return out;
+}
+
+// ── credit_card ──────────────────────────────────────────────────────────────
+// 13–19 digits with optional single space/dash separators, Luhn-validated.
+// Digit lookarounds pin both edges so runs of 20+ digits never match.
+const CARD_CANDIDATE = /(?<!\d)(?:\d[ -]?){12,18}\d(?!\d)/g;
+
+function luhnCheck(digits: string): boolean {
+  if (digits.length < 13 || digits.length > 19) return false;
+  let sum = 0;
+  let double = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48;
+    if (d < 0 || d > 9) return false;
+    if (double) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    double = !double;
+  }
+  return sum % 10 === 0;
+}
+
+function detectCreditCard(text: string): Match[] {
+  const out: Match[] = [];
+  for (const m of text.matchAll(CARD_CANDIDATE)) {
+    const digits = m[0].replace(/[ -]/g, '');
+    if (digits.length >= 13 && digits.length <= 19 && luhnCheck(digits)) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+    }
+  }
+  return out;
+}
+
+// ── ssn ──────────────────────────────────────────────────────────────────────
+const SSN_DASHED = /\b(\d{3})-(\d{2})-(\d{4})\b/g;
+const SSN_BARE = /(?<![\d.-])\d{9}(?![\d.-])/g;
+const SSN_CONTEXT = /\bssns?\b|social\s*security/i;
+
+// Matches a redaction token this engine itself emits, e.g. `[REDACTED:ssn]`.
+// `ssnContextPresent` must not treat that literal "ssn" (or any other
+// detector name) as user-authored context, or a re-scan of already-redacted
+// output would spuriously "discover" context and start flagging unrelated
+// bare 9-digit numbers — breaking the documented idempotence invariant.
+const REDACTION_TOKEN = /\[REDACTED:[^[\]]*\]/g;
+
+/**
+ * Blank out already-emitted `[REDACTED:...]` tokens before scanning, while
+ * preserving string length/offsets so match positions still line up with
+ * the original `text`. The space filler is neither a digit nor a
+ * word character, so it can't itself satisfy any detector pattern or
+ * the word-boundary checks the punctuation it replaces could.
+ */
+function maskRedactionTokens(text: string): string {
+  return text.replace(REDACTION_TOKEN, (m) => ' '.repeat(m.length));
+}
+
+function ssnContextPresent(text: string): boolean {
+  return SSN_CONTEXT.test(text);
+}
+
+function plausibleSsn(area: string, group: string, serial: string): boolean {
+  const a = Number(area);
+  if (a === 0 || a === 666 || a >= 900) return false;
+  if (group === '00') return false;
+  if (serial === '0000') return false;
+  return true;
+}
+
+function detectSsn(text: string): Match[] {
+  // Scan a copy with any prior [REDACTED:...] tokens masked out, so this
+  // detector's own output can never leak context keywords or digit runs
+  // back into itself on a re-scan (see maskRedactionTokens above).
+  const scanText = maskRedactionTokens(text);
+  const out: Match[] = [];
+  for (const m of scanText.matchAll(SSN_DASHED)) {
+    if (plausibleSsn(m[1]!, m[2]!, m[3]!)) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+    }
+  }
+  // Bare-9-digit matching only activates when an SSN keyword appears
+  // somewhere in the text (avoids flagging arbitrary 9-digit IDs).
+  if (ssnContextPresent(scanText)) {
+    for (const m of scanText.matchAll(SSN_BARE)) {
+      const v = m[0];
+      if (plausibleSsn(v.slice(0, 3), v.slice(3, 5), v.slice(5))) {
+        out.push({ start: m.index ?? 0, end: (m.index ?? 0) + v.length });
+      }
+    }
+  }
+  return mergeMatches(out);
+}
+
+// ── iban ─────────────────────────────────────────────────────────────────────
+// Unspaced canonical IBAN shape. Spaced presentation is a documented non-goal.
+const IBAN_CANDIDATE = /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g;
+
+/** ISO 13616 mod-97: move first 4 chars to the end, A→10..Z→35, remainder must be 1. */
+function ibanMod97(candidate: string): boolean {
+  const rearranged = candidate.slice(4) + candidate.slice(0, 4);
+  let remainder = 0;
+  for (let i = 0; i < rearranged.length; i++) {
+    const ch = rearranged[i]!;
+    const value = ch >= 'A' && ch <= 'Z' ? String(ch.charCodeAt(0) - 55) : ch;
+    for (let j = 0; j < value.length; j++) {
+      const digit = value.charCodeAt(j) - 48;
+      if (digit < 0 || digit > 9) return false;
+      remainder = (remainder * 10 + digit) % 97;
+    }
+  }
+  return remainder === 1;
+}
+
+function detectIban(text: string): Match[] {
+  const out: Match[] = [];
+  for (const m of text.matchAll(IBAN_CANDIDATE)) {
+    if (ibanMod97(m[0])) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+    }
+  }
+  return out;
+}
+
+// ── api_key ──────────────────────────────────────────────────────────────────
+// Specific entropy-prefixed token shapes, plus generic bearer-ish blobs
+// post-filtered for mixed character classes.
+const API_KEY_PATTERNS: RegExp[] = [
+  /\bsk-(?:ant-|proj-)?[A-Za-z0-9_-]{16,}\b/g,
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{16,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\b/g, // JWT
+  /\bbrz_[0-9a-f]{32,64}\b/g,
+];
+
+const HEX_BLOB = /\b[0-9a-f]{32,128}\b/g;
+const BASE64_BLOB = /(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{32,256}={0,2}(?![A-Za-z0-9+/=])/g;
+
+function detectApiKey(text: string): Match[] {
+  const out: Match[] = [];
+  for (const re of API_KEY_PATTERNS) {
+    out.push(...spansOf(text, re));
+  }
+  for (const m of text.matchAll(HEX_BLOB)) {
+    const v = m[0];
+    if (/\d/.test(v) && /[a-f]/.test(v)) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + v.length });
+    }
+  }
+  for (const m of text.matchAll(BASE64_BLOB)) {
+    const v = m[0];
+    if (/[a-z]/.test(v) && /[A-Z]/.test(v) && /\d/.test(v)) {
+      out.push({ start: m.index ?? 0, end: (m.index ?? 0) + v.length });
+    }
+  }
+  // JWTs/keys often double-match the generic blobs — merge so counts are honest.
+  return mergeMatches(out);
+}
+
+// ── email / phone (off by default) ───────────────────────────────────────────
+const EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+
+// NANP-ish with required separators or +country/parens. Bare 10-digit runs do
+// NOT match (they'd collide with IDs and partial card runs).
+const PHONE =
+  /(?<![\d.-])(?:\+\d{1,3}[ .-]?)?(?:\(\d{3}\)[ .-]?|\d{3}[ .-])\d{3}[ .-]?\d{4}(?![\d-])/g;
+
+function detectEmail(text: string): Match[] {
+  return spansOf(text, EMAIL);
+}
+
+function detectPhone(text: string): Match[] {
+  return spansOf(text, PHONE);
+}
+
+const BUILTIN_DETECTORS: Array<[DetectorId, (text: string) => Match[]]> = [
+  ['credit_card', detectCreditCard],
+  ['ssn', detectSsn],
+  ['iban', detectIban],
+  ['api_key', detectApiKey],
+  ['email', detectEmail],
+  ['phone', detectPhone],
+];
+
+function compileRules(config: DlpConfig): CompiledRule[] {
+  const rules: CompiledRule[] = [];
+  for (const [name, detect] of BUILTIN_DETECTORS) {
+    const action = config.detectors[name];
+    if (action === 'off') continue;
+    rules.push({ name, action, detect });
+  }
+
+  for (const custom of config.customPatterns) {
+    if (custom.action === 'off') continue;
+    let re: RegExp;
+    try {
+      re = new RegExp(custom.pattern, 'gu');
+    } catch {
+      // Malformed pattern: normalizeDlp() already rejects these at write
+      // time, so this only guards out-of-band data. Skip rather than throw
+      // — a pure scan function should not crash the caller.
+      continue;
+    }
+    rules.push({
+      name: custom.name,
+      action: custom.action,
+      detect: (text: string) => {
+        const out: Match[] = [];
+        for (const m of text.matchAll(re)) {
+          // Zero-width matches (e.g. an all-optional custom group) carry no
+          // redactable span; matchAll already advances past them safely on
+          // its own, so skip and keep scanning rather than abandoning the
+          // rest of the text.
+          if (m[0].length === 0) continue;
+          out.push({ start: m.index ?? 0, end: (m.index ?? 0) + m[0].length });
+        }
+        return out;
+      },
+    });
+  }
+  return rules;
+}
+
+/** Replace spans right-to-left; overlapping spans merge, earliest span's rule labels the token. */
+function replaceSpans(text: string, spans: Array<{ span: Match; rule: string }>): string {
+  const sorted = [...spans].sort(
+    (a, b) => a.span.start - b.span.start || a.span.end - b.span.end,
+  );
+  const merged: Array<{ start: number; end: number; rule: string }> = [];
+  for (const { span, rule } of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && span.start < last.end) {
+      last.end = Math.max(last.end, span.end);
+    } else {
+      merged.push({ start: span.start, end: span.end, rule });
+    }
+  }
+  let out = text;
+  for (let i = merged.length - 1; i >= 0; i--) {
+    const m = merged[i];
+    if (!m) continue;
+    out = `${out.slice(0, m.start)}[REDACTED:${m.rule}]${out.slice(m.end)}`;
+  }
+  return out;
+}
+
+/**
+ * Scan `text` against every enabled detector/custom pattern in `config`.
+ * Findings are always complete (the full scan runs before any short-circuit).
+ * If any matched rule's action is 'block', redaction is skipped and the
+ * original text is returned alongside `blocked: true` — the caller is
+ * responsible for refusing to persist/forward it. Otherwise 'redact' matches
+ * are replaced with `[REDACTED:<detector>]` tokens; 'log' matches are
+ * recorded but leave the text untouched; 'off' detectors are never scanned.
+ */
+export function applyDlpToText(text: string, config: DlpConfig): DlpTextResult {
+  const rules = compileRules(config);
+
+  const matchesByRule: Array<{ rule: CompiledRule; spans: Match[] }> = [];
+  for (const rule of rules) {
+    const spans = rule.detect(text);
+    if (spans.length > 0) matchesByRule.push({ rule, spans });
+  }
+
+  const findings: DlpFinding[] = matchesByRule.map(({ rule, spans }) => ({
+    detector: rule.name,
+    action: rule.action,
+    count: spans.length,
+  }));
+
+  const blocked = matchesByRule.some(({ rule }) => rule.action === 'block');
+  if (blocked) {
+    return { text, findings, blocked: true };
+  }
+
+  const redactSpans: Array<{ span: Match; rule: string }> = [];
+  for (const { rule, spans } of matchesByRule) {
+    if (rule.action !== 'redact') continue;
+    for (const span of spans) redactSpans.push({ span, rule: rule.name });
+  }
+  const outText = redactSpans.length > 0 ? replaceSpans(text, redactSpans) : text;
+
+  return { text: outText, findings, blocked: false };
+}

--- a/ee/workspace/src/content/embedder.test.ts
+++ b/ee/workspace/src/content/embedder.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  chunkText, FakeEmbedder, VoyageEmbedder, toVectorLiteral, EMBEDDING_DIM,
+} from './embedder';
+
+describe('chunkText', () => {
+  it('packs paragraphs to ~1200 chars without splitting them', () => {
+    const paras = Array.from({ length: 10 }, (_, i) => `Paragraph ${i} `.repeat(20).trim());
+    const chunks = chunkText(paras.join('\n\n'));
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(1600);
+    // nothing lost
+    expect(chunks.join(' ')).toContain('Paragraph 9');
+  });
+
+  it('hard-splits a monster paragraph', () => {
+    const chunks = chunkText('x'.repeat(5000));
+    expect(chunks.length).toBe(Math.ceil(5000 / 1200));
+  });
+
+  it('returns one chunk for short text and none for empty', () => {
+    expect(chunkText('short note')).toEqual(['short note']);
+    expect(chunkText('  \n  ')).toEqual([]);
+  });
+});
+
+describe('FakeEmbedder', () => {
+  it('is deterministic, unit-norm, and 1024-dim', async () => {
+    const e = new FakeEmbedder();
+    const [a1] = await e.embed(['hello']);
+    const [a2] = await e.embed(['hello']);
+    const [b] = await e.embed(['world']);
+    expect(a1).toEqual(a2);
+    expect(a1).toHaveLength(EMBEDDING_DIM);
+    expect(a1).not.toEqual(b);
+    const norm = Math.sqrt(a1.reduce((s, v) => s + v * v, 0));
+    expect(norm).toBeCloseTo(1, 6);
+  });
+});
+
+describe('VoyageEmbedder', () => {
+  it('posts the batch and returns vectors in input order', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      data: [
+        { index: 1, embedding: [2, 2] },
+        { index: 0, embedding: [1, 1] },
+      ],
+    }), { status: 200 }));
+    const e = new VoyageEmbedder('key', 'voyage-3', 100, fetchImpl as unknown as typeof fetch);
+    const out = await e.embed(['a', 'b'], 'document');
+    expect(out).toEqual([[1, 1], [2, 2]]);
+    const [, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({ input: ['a', 'b'], input_type: 'document' });
+  });
+
+  it('throws on the soft rate cap rather than hammering the API', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ data: [] }), { status: 200 }));
+    const e = new VoyageEmbedder('key', 'voyage-3', 2, fetchImpl as unknown as typeof fetch);
+    await e.embed(['a'], 'query');
+    await e.embed(['b'], 'query');
+    await expect(e.embed(['c'], 'query')).rejects.toThrow(/voyage_rate_limited/);
+  });
+
+  it('surfaces API errors with status', async () => {
+    const fetchImpl = vi.fn(async () => new Response('nope', { status: 401 }));
+    const e = new VoyageEmbedder('bad', 'voyage-3', 100, fetchImpl as unknown as typeof fetch);
+    await expect(e.embed(['a'], 'query')).rejects.toThrow(/401/);
+  });
+});
+
+describe('toVectorLiteral', () => {
+  it('formats a pgvector literal', () => {
+    expect(toVectorLiteral([1, -0.5, 0])).toBe('[1,-0.5,0]');
+  });
+});

--- a/ee/workspace/src/content/embedder.ts
+++ b/ee/workspace/src/content/embedder.ts
@@ -64,7 +64,7 @@ export class FakeEmbedder implements Embedder {
           seed = createHash('sha256').update(seed).digest();
           offset = 0;
         }
-        vec[i] = (seed[offset] - 127.5) / 127.5;
+        vec[i] = (seed[offset]! - 127.5) / 127.5;
         offset += 1;
       }
       const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0));

--- a/ee/workspace/src/content/embedder.ts
+++ b/ee/workspace/src/content/embedder.ts
@@ -1,0 +1,112 @@
+// Embeddings for content chunks (dev-preview). Pattern copied from hive's
+// colony-memory embedder: a narrow Embedder interface, a Voyage AI
+// implementation with a sliding-window soft rate cap, and a deterministic
+// FakeEmbedder for tests (FakeEmbedder is acceptable ONLY in plumbing tests —
+// never behind a real search result; see the demo gate rules).
+import { createHash } from 'node:crypto';
+
+export const EMBEDDING_DIM = 1024;
+
+export interface Embedder {
+  /** One vector per input text, EMBEDDING_DIM wide. */
+  embed(texts: string[], inputType: 'document' | 'query'): Promise<number[][]>;
+}
+
+export class VoyageEmbedder implements Embedder {
+  private requestTimestamps: number[] = [];
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly model = 'voyage-3',
+    private readonly requestsPerMinute = 100,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  private throttle(): void {
+    const now = Date.now();
+    this.requestTimestamps = this.requestTimestamps.filter((t) => now - t < 60_000);
+    if (this.requestTimestamps.length >= this.requestsPerMinute) {
+      throw new Error(`voyage_rate_limited:${this.requestTimestamps.length}/${this.requestsPerMinute}rpm`);
+    }
+    this.requestTimestamps.push(now);
+  }
+
+  async embed(texts: string[], inputType: 'document' | 'query'): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    this.throttle();
+    const res = await this.fetchImpl('https://api.voyageai.com/v1/embeddings', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${this.apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ model: this.model, input: texts, input_type: inputType }),
+    });
+    if (!res.ok) {
+      throw new Error(`voyage embeddings failed: ${res.status} ${(await res.text()).slice(0, 200)}`);
+    }
+    const body = await res.json() as { data: Array<{ index: number; embedding: number[] }> };
+    const out: number[][] = new Array(texts.length);
+    for (const item of body.data) out[item.index] = item.embedding;
+    return out;
+  }
+}
+
+/** Deterministic sha256-derived unit vectors; plumbing tests only. */
+export class FakeEmbedder implements Embedder {
+  async embed(texts: string[]): Promise<number[][]> {
+    return texts.map((text) => {
+      const vec = new Array<number>(EMBEDDING_DIM);
+      let seed = createHash('sha256').update(text).digest();
+      let offset = 0;
+      for (let i = 0; i < EMBEDDING_DIM; i += 1) {
+        if (offset >= seed.length) {
+          seed = createHash('sha256').update(seed).digest();
+          offset = 0;
+        }
+        vec[i] = (seed[offset] - 127.5) / 127.5;
+        offset += 1;
+      }
+      const norm = Math.sqrt(vec.reduce((s, v) => s + v * v, 0));
+      return vec.map((v) => v / norm);
+    });
+  }
+}
+
+/** Voyage when a key exists, otherwise undefined (vector arm disabled). */
+export function buildEmbedder(): Embedder | undefined {
+  const key = process.env.VOYAGE_API_KEY;
+  return key ? new VoyageEmbedder(key) : undefined;
+}
+
+/** pgvector literal for a numeric vector. */
+export function toVectorLiteral(vec: number[]): string {
+  return `[${vec.join(',')}]`;
+}
+
+const CHUNK_TARGET = 1200;
+const CHUNK_MAX = 1600;
+
+/**
+ * Paragraph-aware chunking: split on blank lines, pack paragraphs up to
+ * ~CHUNK_TARGET chars, hard-split anything longer than CHUNK_MAX.
+ */
+export function chunkText(text: string): string[] {
+  const paragraphs = text.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean);
+  const chunks: string[] = [];
+  let current = '';
+  const flush = () => { if (current.trim()) chunks.push(current.trim()); current = ''; };
+  for (const para of paragraphs) {
+    if (para.length > CHUNK_MAX) {
+      flush();
+      for (let i = 0; i < para.length; i += CHUNK_TARGET) {
+        chunks.push(para.slice(i, i + CHUNK_TARGET));
+      }
+      continue;
+    }
+    if (current.length + para.length + 2 > CHUNK_TARGET && current) flush();
+    current = current ? `${current}\n\n${para}` : para;
+  }
+  flush();
+  return chunks;
+}

--- a/ee/workspace/src/content/entities.test.ts
+++ b/ee/workspace/src/content/entities.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { extractEntities, normalizeQueryEntities } from './entities';
+
+const byType = (text: string) => {
+  const out: Record<string, string[]> = {};
+  for (const e of extractEntities(text)) (out[e.type] ??= []).push(e.valueNorm);
+  return out;
+};
+
+describe('extractEntities — structured regex pass', () => {
+  it('finds APNs with and without the APN prefix', () => {
+    const t = 'parcel APN 057-071-012 adjoins 057-071-013 per the record.';
+    expect(byType(t).apn).toEqual(['057-071-012', '057-071-013']);
+  });
+
+  it('normalizes PO variants to one canonical form', () => {
+    for (const variant of ['PO 4021', 'PO #4021', 'PO#4021', 'P.O. 4021', 'po 4021']) {
+      expect(byType(variant).po, variant).toEqual(['PO 4021']);
+    }
+  });
+
+  it('does NOT treat a P.O. Box as a purchase order', () => {
+    expect(byType('mail to P.O. Box 4021, Fairoaks CA').po).toBeUndefined();
+  });
+
+  it('extracts WDR and permit-style agency references', () => {
+    const t = 'per WDR-2023-0117 and fish passage ref FP-26-1142.';
+    expect(byType(t).wdr).toEqual(['WDR-2023-0117']);
+    expect(byType(t).permit).toEqual(['FP-26-1142']);
+  });
+
+  it('extracts invoice numbers with prefixes intact', () => {
+    const t = 'see invoice 8841 and Invoice #23-1088; also inv 92-311.';
+    expect(byType(t).invoice).toEqual(['INV 8841', 'INV 23-1088', 'INV 92-311']);
+  });
+
+  it('classifies surveyor license numbers as license, never invoice (LS 8841 trap)', () => {
+    const t = 'signed L.S. 4102 (Deubel); stamp LS 8841 appears on the mylar.';
+    const r = byType(t);
+    expect(r.license).toEqual(['LS 4102', 'LS 8841']);
+    expect(r.invoice).toBeUndefined();
+  });
+
+  it('extracts job/project numbers, bare and prefixed', () => {
+    const t = 'Job 87-143 retracement; carried into 2020-088 and project no. 2023-041.';
+    const r = byType(t);
+    expect(r.job).toEqual(expect.arrayContaining(['87-143', '2020-088', '2023-041']));
+  });
+
+  it('does not read an APN as a job number', () => {
+    const r = byType('APN 057-071-012');
+    expect(r.job ?? []).not.toContain('057-071');
+  });
+
+  it('dedupes repeated mentions within one document', () => {
+    const t = 'PO 4021 ... again PO #4021 ... same order.';
+    expect(byType(t).po).toEqual(['PO 4021']);
+  });
+
+  it('never matches glued tokens (part/lot-number shapes)', () => {
+    expect(byType('unit PO4021 on the packing slip').po).toBeUndefined();
+    expect(byType('ref inv92311 stamped').invoice).toBeUndefined();
+    expect(byType('mylar LS8841 margin note').license).toBeUndefined();
+  });
+});
+
+describe('normalizeQueryEntities — query-side detection', () => {
+  it('uses the same normalizer as ingest', () => {
+    const q = normalizeQueryEntities('anything about PO#4021 or 057-071-012?');
+    expect(q).toEqual(expect.arrayContaining([
+      { type: 'po', valueNorm: 'PO 4021' },
+      { type: 'apn', valueNorm: '057-071-012' },
+    ]));
+  });
+  it('returns empty for prose-only queries', () => {
+    expect(normalizeQueryEntities('the Quail Hollow parcel')).toEqual([]);
+  });
+});

--- a/ee/workspace/src/content/entities.ts
+++ b/ee/workspace/src/content/entities.ts
@@ -1,0 +1,81 @@
+// Deterministic entity extraction (content phase, dev-preview).
+// The structured types below are owned by THIS regex pass — the LLM enrichment
+// pass may only contribute person/org entities. Query-side detection
+// (normalizeQueryEntities) reuses the exact same patterns/normalizer so an
+// entity typed at ingest always matches the same string typed into search.
+export type EntityType =
+  | 'apn' | 'po' | 'wdr' | 'invoice' | 'permit' | 'job' | 'license'
+  | 'person' | 'org';
+
+export interface ExtractedEntity {
+  type: EntityType;
+  valueNorm: string;
+  valueRaw: string;
+}
+
+interface Pattern {
+  type: EntityType;
+  re: RegExp;
+  norm: (m: RegExpMatchArray) => string;
+}
+
+// Order matters only for readability; matches are deduped by (type, valueNorm).
+const PATTERNS: Pattern[] = [
+  // Assessor parcel numbers: 057-071-012 (the "APN" literal is optional).
+  { type: 'apn', re: /\b(\d{3}-\d{3}-\d{3})\b/g, norm: (m) => m[1] },
+  // Purchase orders: PO 4021, P.O. #4021, po#4021 — but never a P.O. Box, and
+  // never a glued token (PO4021 is a part/lot-number shape, not a PO mention):
+  // at least one space/# separator is required before the digits.
+  { type: 'po', re: /\bP\.?O\.?[\s#]+(?!Box\b)(\d{3,6})\b/gi, norm: (m) => `PO ${m[1]}` },
+  // Water board / waste discharge requirement ids: WDR-2023-0117.
+  { type: 'wdr', re: /\bWDR[- ]?(\d{4})[- ]?(\d{4})\b/gi, norm: (m) => `WDR-${m[1]}-${m[2]}` },
+  // Agency reference ids like FP-26-1142 (fish passage). WDR is caught above;
+  // exclude it here so one mention never lands in two buckets.
+  { type: 'permit', re: /\b(?!WDR)([A-Z]{2,3}-\d{2,4}-\d{3,5})\b/g, norm: (m) => m[1] },
+  // Invoices: invoice 8841, Invoice #23-1088, inv 92-311 (separator required —
+  // same glued-token rule as PO).
+  { type: 'invoice', re: /\binv(?:oice)?\.?[\s#]+(\d{2,4}(?:-\d{3,4})?)\b/gi, norm: (m) => `INV ${m[1]}` },
+  // Surveyor license stamps: L.S. 4102, LS 8841. Extracted so the digits can
+  // NEVER be mistaken for an invoice/PO (the corpus plants this collision).
+  { type: 'license', re: /\bL\.?S\.?[\s#]+(\d{3,5})\b/g, norm: (m) => `LS ${m[1]}` },
+  // Job / project numbers: Job 87-143, bare 2023-041 (yyyy-nnn or yy-nnn).
+  { type: 'job', re: /\b(\d{2}|\d{4})-(\d{3})\b/g, norm: (m) => `${m[1]}-${m[2]}` },
+];
+
+/**
+ * Extract typed, normalized entities from document text. Deduped by
+ * (type, valueNorm); a job-number match that is part of an APN is dropped.
+ */
+export function extractEntities(text: string): ExtractedEntity[] {
+  const seen = new Set<string>();
+  const out: ExtractedEntity[] = [];
+  const apnSpans: Array<[number, number]> = [];
+
+  for (const p of PATTERNS) {
+    for (const m of text.matchAll(p.re)) {
+      const index = m.index ?? 0;
+      if (p.type === 'apn') apnSpans.push([index, index + m[0].length]);
+      // A yy-nnn "job" hit inside an APN span is APN noise, not a job number.
+      if (p.type === 'job' && apnSpans.some(([s, e]) => index >= s && index < e)) continue;
+      const valueNorm = p.norm(m).toUpperCase().replace(/\s+/g, ' ').trim()
+        // preserve APN/job digit groups exactly as matched (norm above), but
+        // canonicalize prefixed forms: strip any stray '#'
+        .replace(/#/g, '');
+      const key = `${p.type}:${valueNorm}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ type: p.type, valueNorm, valueRaw: m[0] });
+    }
+  }
+  return out;
+}
+
+/** Query-side entity detection — same patterns, same normalizer as ingest. */
+export function normalizeQueryEntities(query: string): Array<Pick<ExtractedEntity, 'type' | 'valueNorm'>> {
+  // license/job hits in queries are far more often prose (years, phone
+  // fragments) than a deliberate lookup; keep the high-precision types only.
+  const QUERY_TYPES: ReadonlySet<EntityType> = new Set(['apn', 'po', 'wdr', 'invoice', 'permit']);
+  return extractEntities(query)
+    .filter((e) => QUERY_TYPES.has(e.type))
+    .map(({ type, valueNorm }) => ({ type, valueNorm }));
+}

--- a/ee/workspace/src/content/entities.ts
+++ b/ee/workspace/src/content/entities.ts
@@ -22,7 +22,7 @@ interface Pattern {
 // Order matters only for readability; matches are deduped by (type, valueNorm).
 const PATTERNS: Pattern[] = [
   // Assessor parcel numbers: 057-071-012 (the "APN" literal is optional).
-  { type: 'apn', re: /\b(\d{3}-\d{3}-\d{3})\b/g, norm: (m) => m[1] },
+  { type: 'apn', re: /\b(\d{3}-\d{3}-\d{3})\b/g, norm: (m) => m[1]! },
   // Purchase orders: PO 4021, P.O. #4021, po#4021 — but never a P.O. Box, and
   // never a glued token (PO4021 is a part/lot-number shape, not a PO mention):
   // at least one space/# separator is required before the digits.
@@ -31,7 +31,7 @@ const PATTERNS: Pattern[] = [
   { type: 'wdr', re: /\bWDR[- ]?(\d{4})[- ]?(\d{4})\b/gi, norm: (m) => `WDR-${m[1]}-${m[2]}` },
   // Agency reference ids like FP-26-1142 (fish passage). WDR is caught above;
   // exclude it here so one mention never lands in two buckets.
-  { type: 'permit', re: /\b(?!WDR)([A-Z]{2,3}-\d{2,4}-\d{3,5})\b/g, norm: (m) => m[1] },
+  { type: 'permit', re: /\b(?!WDR)([A-Z]{2,3}-\d{2,4}-\d{3,5})\b/g, norm: (m) => m[1]! },
   // Invoices: invoice 8841, Invoice #23-1088, inv 92-311 (separator required —
   // same glued-token rule as PO).
   { type: 'invoice', re: /\binv(?:oice)?\.?[\s#]+(\d{2,4}(?:-\d{3,4})?)\b/gi, norm: (m) => `INV ${m[1]}` },

--- a/ee/workspace/src/content/extract.test.ts
+++ b/ee/workspace/src/content/extract.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { extractContent } from './extract';
+
+const EML = Buffer.from([
+  'From: Paul Deluca <pdeluca@fairoaksca.gov>',
+  'To: Maria Cortez <mcortez@aldercreekeng.com>',
+  'Cc: Ray Otero <rotero@fairoaksca.gov>',
+  'Subject: RE: PO 4021 - pipe submittal resubmittal',
+  'Date: 16 Jul 2024 08:26:40 -0700',
+  '',
+  'Maria,',
+  '',
+  'Only DR-18 was approved for PO 4021.',
+  '',
+  'Paul',
+].join('\r\n'));
+
+describe('extractContent', () => {
+  it('extracts markdown as utf8 with a sha256 of the bytes', async () => {
+    const bytes = Buffer.from('# Grant of Easement\n\nHenderson Road Water Main Replacement Project.');
+    const r = await extractContent('scan_0034.md', bytes, 2 * 1024 * 1024);
+    expect(r.status).toBe('extracted');
+    if (r.status !== 'extracted') return;
+    expect(r.text).toContain('Grant of Easement');
+    expect(r.contentHash).toBe(createHash('sha256').update(bytes).digest('hex'));
+    expect(r.emailMeta).toBeNull();
+  });
+
+  it('treats .TXT (any case) as text', async () => {
+    const r = await extractContent('SCAN0007.TXT', Buffer.from('RECORD OF SURVEY'), 1024);
+    expect(r.status).toBe('extracted');
+  });
+
+  it('parses .eml: searchable text includes subject, participants, and body; emailMeta is structured', async () => {
+    const r = await extractContent('new - re PO 4021.eml', EML, 2 * 1024 * 1024);
+    expect(r.status).toBe('extracted');
+    if (r.status !== 'extracted') return;
+    expect(r.text).toContain('RE: PO 4021 - pipe submittal resubmittal');
+    expect(r.text).toContain('Only DR-18 was approved');
+    expect(r.text).toContain('pdeluca@fairoaksca.gov');
+    expect(r.emailMeta).toMatchObject({
+      from: expect.stringContaining('pdeluca@fairoaksca.gov'),
+      subject: 'RE: PO 4021 - pipe submittal resubmittal',
+    });
+    expect(r.emailMeta?.to?.[0]).toContain('mcortez@aldercreekeng.com');
+  });
+
+  it('skips unknown extensions as binary', async () => {
+    const r = await extractContent('photo.jpg', Buffer.from([0xff, 0xd8, 0xff]), 1024);
+    expect(r.status).toBe('skipped_binary');
+  });
+
+  it('skips oversized files', async () => {
+    const r = await extractContent('big.md', Buffer.alloc(2048, 97), 1024);
+    expect(r.status).toBe('skipped_too_large');
+  });
+});

--- a/ee/workspace/src/content/extract.ts
+++ b/ee/workspace/src/content/extract.ts
@@ -1,0 +1,84 @@
+// Text extraction (content phase, dev-preview).
+// This module extracts text ONLY; it stores nothing. DLP runs downstream in
+// contentIngestService, between extraction and persistence: the text returned
+// here is inspected there before anything is stored — 'redact' hits rewrite it,
+// a 'block' hit drops it (no text, no chunks).
+import { createHash } from 'node:crypto';
+import { simpleParser, type AddressObject } from 'mailparser';
+
+export interface EmailMeta {
+  from?: string;
+  to?: string[];
+  cc?: string[];
+  subject?: string;
+  date?: string;
+}
+
+export type ExtractionResult =
+  | { status: 'extracted'; text: string; contentHash: string; emailMeta: EmailMeta | null }
+  | { status: 'skipped_binary' }
+  | { status: 'skipped_too_large' }
+  | { status: 'failed'; errorReason: string };
+
+// Extraction allowlist. Everything else is skipped_binary — this is what keeps
+// non-text estate content (and anything unexpected on the share) out of the
+// content store entirely.
+const TEXT_EXTS = new Set(['md', 'txt', 'text', 'markdown']);
+const EMAIL_EXTS = new Set(['eml']);
+
+const addressText = (a: AddressObject | AddressObject[] | undefined): string[] => {
+  if (!a) return [];
+  const list = Array.isArray(a) ? a : [a];
+  return list.map((x) => x.text).filter(Boolean);
+};
+
+export async function extractContent(
+  name: string,
+  bytes: Buffer,
+  maxBytes: number,
+): Promise<ExtractionResult> {
+  const ext = name.includes('.') ? name.split('.').pop()!.toLowerCase() : '';
+  const isText = TEXT_EXTS.has(ext);
+  const isEmail = EMAIL_EXTS.has(ext);
+  if (!isText && !isEmail) return { status: 'skipped_binary' };
+  if (bytes.length > maxBytes) return { status: 'skipped_too_large' };
+
+  const contentHash = createHash('sha256').update(bytes).digest('hex');
+  try {
+    if (isText) {
+      return { status: 'extracted', text: bytes.toString('utf8'), contentHash, emailMeta: null };
+    }
+    const parsed = await simpleParser(bytes);
+    const from = parsed.from?.text;
+    const to = addressText(parsed.to);
+    const cc = addressText(parsed.cc);
+    const subject = parsed.subject ?? undefined;
+    const body = (parsed.text && parsed.text.trim().length > 0)
+      ? parsed.text
+      // html-only mail: crude tag strip is enough for search text
+      : (parsed.html ? String(parsed.html).replace(/<[^>]+>/g, ' ') : '');
+    // Searchable text carries the headers inline so subject/participant terms
+    // match without a separate field search.
+    const text = [
+      subject ? `Subject: ${subject}` : null,
+      from ? `From: ${from}` : null,
+      to.length ? `To: ${to.join(', ')}` : null,
+      cc.length ? `Cc: ${cc.join(', ')}` : null,
+      '',
+      body,
+    ].filter((l): l is string => l !== null).join('\n');
+    const emailMeta: EmailMeta = {
+      from,
+      to: to.length ? to : undefined,
+      cc: cc.length ? cc : undefined,
+      subject,
+      date: parsed.date?.toISOString(),
+    };
+    return { status: 'extracted', text, contentHash, emailMeta };
+  } catch (error) {
+    return {
+      status: 'failed',
+      errorReason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/ee/workspace/src/content/projects.test.ts
+++ b/ee/workspace/src/content/projects.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { deriveDeclaredProject } from './projects';
+
+describe('deriveDeclaredProject — declared location from rel_path', () => {
+  it('derives key + label from a Projects folder', () => {
+    expect(deriveDeclaredProject('Projects/2023-041 Henderson Water Main Replacement/plans.md'))
+      .toEqual({ key: '2023-041', label: 'Henderson Water Main Replacement' });
+  });
+
+  it('derives from Short Term folders including nested subfolders', () => {
+    expect(deriveDeclaredProject('Short Term/2026-018 Casella Creek Culvert/02 Correspondence/notes.txt'))
+      .toEqual({ key: '2026-018', label: 'Casella Creek Culvert' });
+  });
+
+  it('derives key (no label) from Emails/<key>/ folders', () => {
+    expect(deriveDeclaredProject('Emails/2023-041/2023-08-15 deluca PO 4021 issued.eml'))
+      .toEqual({ key: '2023-041', label: null });
+  });
+
+  it('returns null for Unfiled email', () => {
+    expect(deriveDeclaredProject('Emails/Unfiled/new - re PO 4021.eml')).toBeNull();
+  });
+
+  it('returns null for loose files at a root (misfile targets stay unclaimed)', () => {
+    expect(deriveDeclaredProject('Short Term/fish passage memo review comments.md')).toBeNull();
+    expect(deriveDeclaredProject('Legacy/SCAN0007.TXT')).toBeNull();
+    expect(deriveDeclaredProject('todo.txt')).toBeNull();
+  });
+
+  it('ignores folders that do not start with a job-number key', () => {
+    expect(deriveDeclaredProject('Projects/Miscellaneous/notes.md')).toBeNull();
+  });
+});

--- a/ee/workspace/src/content/projects.ts
+++ b/ee/workspace/src/content/projects.ts
@@ -1,0 +1,31 @@
+// Declared-project derivation from a file's rel_path (content phase).
+// The declared location is what the folder structure CLAIMS about a file; the
+// enrichment pass stores it next to the LLM-inferred project so disagreement
+// (a misfile) can be shown, never silently corrected.
+export interface DeclaredProject {
+  key: string;
+  label: string | null;
+}
+
+// A project folder is the first path segment under Projects/ or Short Term/
+// whose name starts with a job-number key ("2023-041 Henderson Water Main…").
+// Email folders declare by bare key: Emails/2023-041/…  Anything else —
+// Unfiled, loose root files, Legacy — declares nothing (returns null).
+const PROJECT_ROOTS = new Set(['Projects', 'Short Term']);
+const KEY_FOLDER_RE = /^(\d{4}-\d{3})(?:\s+(.+))?$/;
+const EMAIL_KEY_RE = /^\d{4}-\d{3}$/;
+
+export function deriveDeclaredProject(relPath: string): DeclaredProject | null {
+  const segments = relPath.split('/').filter((s) => s.length > 0);
+  // A declared project needs root/<project folder>/<file…> — a file sitting
+  // directly under a root (or at the share root) is unclaimed by design.
+  if (segments.length < 3) return null;
+  const [root, folder] = segments;
+  if (root === 'Emails') {
+    return EMAIL_KEY_RE.test(folder) ? { key: folder, label: null } : null;
+  }
+  if (!PROJECT_ROOTS.has(root)) return null;
+  const m = folder.match(KEY_FOLDER_RE);
+  if (!m) return null;
+  return { key: m[1], label: m[2]?.trim() || null };
+}

--- a/ee/workspace/src/content/projects.ts
+++ b/ee/workspace/src/content/projects.ts
@@ -20,12 +20,14 @@ export function deriveDeclaredProject(relPath: string): DeclaredProject | null {
   // A declared project needs root/<project folder>/<file…> — a file sitting
   // directly under a root (or at the share root) is unclaimed by design.
   if (segments.length < 3) return null;
-  const [root, folder] = segments;
+  // `segments.length >= 3` above guarantees both of these are present.
+  const root = segments[0]!;
+  const folder = segments[1]!;
   if (root === 'Emails') {
     return EMAIL_KEY_RE.test(folder) ? { key: folder, label: null } : null;
   }
   if (!PROJECT_ROOTS.has(root)) return null;
   const m = folder.match(KEY_FOLDER_RE);
   if (!m) return null;
-  return { key: m[1], label: m[2]?.trim() || null };
+  return { key: m[1]!, label: m[2]?.trim() || null };
 }

--- a/ee/workspace/src/hostTypes.ts
+++ b/ee/workspace/src/hostTypes.ts
@@ -1,0 +1,95 @@
+/**
+ * The single seam between Workspace and the v1 extension host contract.
+ *
+ * The legacy `@breeze/extension-api` adapter package is gone. Of the six types
+ * it exported, only two have v1 equivalents (`BreezeExtensionV1` and
+ * `ExtensionRuntimeContext`); the rest are re-declared here.
+ *
+ * These local declarations are deliberate — the v1 SDK does NOT export them.
+ * Do not "fix" this file by importing them from `@breeze/extension-sdk`:
+ *
+ * - `ExtensionAuditEvent`: v1 loosened the host's `audit()` parameter to
+ *   `Record<string, unknown>`. Workspace keeps emitting a structured, typed
+ *   event so a typo in an audit call site is still a compile error. It is a
+ *   `type` (not an `interface`) on purpose: only a type alias is assignable to
+ *   `Record<string, unknown>`, which is what lets `context.audit` satisfy
+ *   `WorkspaceAudit`.
+ * - `ExtensionAgentContext`: never existed in v1; it is the shape the host
+ *   gateway puts on `c.get('agent')` for agent-authenticated requests.
+ * - `WorkspaceDatabase`: see below.
+ */
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { ExtensionRuntimeContext } from '@breeze/extension-sdk';
+
+export type {
+  BreezeExtensionV1,
+  ExtensionRegistrar,
+  ExtensionRuntimeContext,
+} from '@breeze/extension-sdk';
+
+/**
+ * The Drizzle handle every Workspace service actually queries through.
+ *
+ * v1 types `context.db` loosely (`Record<string, unknown> & { execute() }`),
+ * but at runtime the host supplies the **org-scoped Drizzle connection**, and
+ * that connection is what enforces RLS. Narrowing it is therefore a single,
+ * documented adapter at the registration boundary (`asWorkspaceDatabase`)
+ * rather than a cast scattered through every service — and it must never be
+ * widened into a permissive fake, which would hide a real tenancy defect
+ * behind a green suite.
+ */
+export type WorkspaceDatabase = PostgresJsDatabase;
+
+/** Narrow the host's loosely-typed `context.db` to the org-scoped Drizzle handle. */
+export function asWorkspaceDatabase(db: ExtensionRuntimeContext['db']): WorkspaceDatabase {
+  return db as unknown as WorkspaceDatabase;
+}
+
+/** Column-level encryption seam; v1 has it inline on the runtime context. */
+export type ExtensionSecrets = ExtensionRuntimeContext['secrets'];
+
+/** Level-first host logger: `log('error', message, fields?)`. */
+export type ExtensionLog = ExtensionRuntimeContext['log'];
+
+/** Structured audit event Workspace emits (see the note at the top of the file). */
+export type ExtensionAuditEvent = {
+  orgId: string;
+  actorType: 'user' | 'agent' | 'system';
+  actorId: string;
+  action: string;
+  resourceType: string;
+  resourceId?: string;
+  result: 'success' | 'failure';
+  errorMessage?: string;
+  /** Structured event payload (W2/W7 content + helper events carry one). */
+  details?: Record<string, unknown>;
+};
+
+/** Audit sink as Workspace consumes it; `context.audit` is assignable to this. */
+export type WorkspaceAudit = (event: ExtensionAuditEvent) => Promise<void>;
+
+/** Agent identity the host gateway attaches to agent-authenticated requests. */
+export interface ExtensionAgentContext {
+  deviceId: string;
+  agentId: string;
+  orgId: string;
+  siteId: string | null;
+  role: string;
+}
+
+/**
+ * Helper (tray) device identity the host gateway attaches to /helper/*
+ * requests. Mirrors core's `HelperDevice` (apps/api middleware/helperAuth):
+ * the gateway applies core helper auth when the legacy-manifest `helperRoutes`
+ * flag is set, so this is the shape found on `c.get('helperDevice')`.
+ */
+export interface ExtensionHelperDevice {
+  id: string;
+  agentId: string;
+  orgId: string;
+  siteId: string | null;
+  hostname: string;
+  osType: string;
+  osVersion: string;
+  agentVersion: string;
+}

--- a/ee/workspace/src/index.test.ts
+++ b/ee/workspace/src/index.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+import { stageExtensionForTest } from '@breeze/extension-testkit';
+import type {
+  BreezeExtensionV1,
+  ExtensionRegistrar,
+  ExtensionRuntimeContext,
+} from './hostTypes';
+import manifest from '../manifest.json';
+import workspaceExtension from './index';
+
+const ORG_ID = '22222222-2222-4222-8222-222222222222';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const SOURCE_ID = '55555555-5555-4555-8555-555555555555';
+const RUN_ID = '66666666-6666-4666-8666-666666666666';
+
+/**
+ * Chainable Drizzle stand-in: every terminal call resolves to `rows`. Used only
+ * to prove the registration wiring reaches the right handler — the services'
+ * own suites cover query behavior against recorded SQL.
+ */
+function fakeDb(rows: unknown[] = [], onQuery?: () => void) {
+  const settle = () => {
+    onQuery?.();
+    const result = Promise.resolve(rows) as Promise<unknown[]> & Record<string, unknown>;
+    for (const method of ['limit', 'orderBy', 'returning']) {
+      (result as Record<string, unknown>)[method] = () => {
+        onQuery?.();
+        return Promise.resolve(rows);
+      };
+    }
+    return result;
+  };
+  const db: Record<string, unknown> = {
+    execute: async () => { onQuery?.(); return rows; },
+    select: () => ({ from: () => ({ where: settle }) }),
+    insert: () => ({ values: () => ({ returning: async () => { onQuery?.(); return rows; } }) }),
+    update: () => ({ set: () => ({ where: () => ({ returning: async () => { onQuery?.(); return rows; } }) }) }),
+    delete: () => ({ where: () => ({ returning: async () => { onQuery?.(); return rows; } }) }),
+  };
+  return db as unknown as ExtensionRuntimeContext['db'];
+}
+
+class CapturingRegistrar implements ExtensionRegistrar {
+  readonly apps: Hono[] = [];
+  readonly jobs: string[] = [];
+  readonly aiTools: string[] = [];
+  mountRoute(app: Hono): void { this.apps.push(app); }
+  registerJob(job: { name: string }): void { this.jobs.push(job.name); }
+  registerAiTool(name: string): void { this.aiTools.push(name); }
+}
+
+function runtimeContext(overrides: Partial<ExtensionRuntimeContext> = {}): ExtensionRuntimeContext {
+  return {
+    db: fakeDb(),
+    secrets: {
+      encryptForColumn: (_table, _column, plaintext) => plaintext,
+      decryptForColumn: (_table, _column, ciphertext) => ciphertext,
+    },
+    audit: async () => {},
+    log: () => {},
+    config: Object.freeze({}),
+    // NOTE (ee/workspace import): `tenancy` is required on ExtensionRuntimeContext
+    // in the monorepo's @breeze/extension-sdk (added since the vendored 1.0.0
+    // tarball this suite was written against). No test here exercises it, so a
+    // benign stub satisfies the type without asserting real per-org semantics.
+    tenancy: { installedOrgs: async () => [] },
+    ...overrides,
+  };
+}
+
+const HELPER_DEVICE = {
+  id: DEVICE_ID,
+  agentId: 'agent-1',
+  orgId: ORG_ID,
+  siteId: null,
+  hostname: 'FRONT-DESK-01',
+  osType: 'windows',
+  osVersion: '11',
+  agentVersion: '1.0.0',
+};
+
+/**
+ * Mount the extension the way the host does: a single app behind the gateway,
+ * which has already applied the manifest-declared auth boundary and attached
+ * the caller identity. The extension itself owns neither.
+ */
+async function stagedApp(options: {
+  context?: Partial<ExtensionRuntimeContext>;
+  auth?: Record<string, unknown> | null;
+  agent?: Record<string, unknown> | null;
+  helper?: Record<string, unknown> | null;
+} = {}) {
+  const registrar = new CapturingRegistrar();
+  await workspaceExtension.register(registrar, runtimeContext(options.context));
+  const outer = new Hono();
+  outer.use('*', async (c, next) => {
+    const auth = options.auth === undefined
+      ? { user: { id: USER_ID }, scope: 'system', accessibleOrgIds: null }
+      : options.auth;
+    if (auth) c.set('auth' as never, auth as never);
+    const agent = options.agent === undefined
+      ? { deviceId: DEVICE_ID, agentId: 'agent-1', orgId: ORG_ID, siteId: null, role: 'agent' }
+      : options.agent;
+    if (agent) c.set('agent' as never, agent as never);
+    const helper = options.helper === undefined ? HELPER_DEVICE : options.helper;
+    if (helper) c.set('helperDevice' as never, helper as never);
+    await next();
+  });
+  const app = registrar.apps[0];
+  if (!app) throw new Error('extension mounted no app');
+  outer.route('/api/v1/ext/workspace', app);
+  return outer;
+}
+
+describe('workspace extension registration (v1 contract)', () => {
+  it('stages cleanly against the v1 recorder without touching the database', async () => {
+    // No `opts.db`: the testkit context THROWS on any db access, so this
+    // passing is the proof that register() does no database work — services
+    // only hold the handle.
+    const result = await stageExtensionForTest(workspaceExtension, manifest);
+    expect(result.issues).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.recorded).toEqual({ routes: 1, jobs: [], aiTools: [] });
+  });
+
+  it('reports a throwing register as a single register_threw issue with an empty recorder', async () => {
+    const broken: BreezeExtensionV1 = {
+      register() { throw new Error('register exploded'); },
+    };
+    const result = await stageExtensionForTest(broken, manifest);
+    expect(result.ok).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]?.code).toBe('register_threw');
+    expect(result.recorded).toEqual({ routes: 0, jobs: [], aiTools: [] });
+  });
+
+  it('mounts health, sources, device-summary and agent paths on one app', async () => {
+    const outer = await stagedApp();
+
+    const health = await outer.request('/api/v1/ext/workspace/health');
+    expect(health.status).toBe(200);
+    expect(await health.json()).toEqual({ ok: true, extension: 'workspace' });
+
+    const sources = await outer.request(`/api/v1/ext/workspace/sources?orgId=${ORG_ID}`);
+    expect(sources.status).toBe(200);
+    expect(await sources.json()).toEqual({ sources: [] });
+
+    // Reaches the device-summary handler (its own 404 body), not Hono's
+    // unmounted-route default.
+    const summary = await outer.request(
+      `/api/v1/ext/workspace/devices/${DEVICE_ID}/summary?orgId=${ORG_ID}`,
+    );
+    expect(summary.status).toBe(404);
+    expect(await summary.json()).toEqual({ error: 'Device not found' });
+
+    const agent = await outer.request('/api/v1/ext/workspace/agent/crawl-config');
+    expect(agent.status).toBe(200);
+  });
+
+  // Gateway path shape: the host gateway authenticates extension agent traffic
+  // as /agent/:agentId/* (device id in the path), while the phase-2 wire spec
+  // uses flat /agent/*. Both shapes must resolve the same routes, and the
+  // :agentId segment must never become identity (identity is c.get('agent')).
+  it('serves the agent routes under both /agent and /agent/:agentId mounts', async () => {
+    const outer = await stagedApp();
+    expect((await outer.request('/api/v1/ext/workspace/agent/crawl-config')).status).toBe(200);
+    expect((await outer.request('/api/v1/ext/workspace/agent/abc123/crawl-config')).status).toBe(200);
+    const nested = await outer.request('/api/v1/ext/workspace/agent/abc123/nope');
+    expect(nested.status).toBe(404);
+    expect(await nested.json()).toEqual({ error: 'not found' });
+  });
+
+  // Still extension-owned under a single-app mount: without the catch-all an
+  // unmatched /agent/* request falls through to the user routes below it.
+  it('answers unmatched /agent/* with 404 instead of falling through to user routes', async () => {
+    const outer = await stagedApp();
+    const res = await outer.request('/api/v1/ext/workspace/agent/sources');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not found' });
+
+    const nested = await outer.request('/api/v1/ext/workspace/agent/devices/x/summary');
+    expect(nested.status).toBe(404);
+    expect(await nested.json()).toEqual({ error: 'not found' });
+  });
+
+  // Identity presence is a host invariant: the gateway applies the
+  // manifest-declared agent boundary before dispatch. But 68bf21d removed
+  // ctx.agentAuthMiddleware, which is what used to GUARANTEE c.get('agent'),
+  // and every agent handler dereferences it unconditionally. Without an
+  // explicit guard the tree fails closed only incidentally — a TypeError
+  // surfacing through onError as a 500 — while adminGate on the user side fails
+  // closed deliberately with a 403. This asserts the agent side is explicit
+  // too: a missing identity is 401, not a 500 from a dereference.
+  it.each([
+    ['GET', '/agent/crawl-config'],
+    ['POST', '/agent/runs'],
+    ['POST', `/agent/sources/${SOURCE_ID}/credential`],
+    ['POST', `/agent/sources/${SOURCE_ID}/events`],
+    ['POST', `/agent/runs/${RUN_ID}/batch`],
+    ['POST', `/agent/runs/${RUN_ID}/complete`],
+  ])('rejects %s %s with 401 when no agent identity is present', async (method, path) => {
+    const outer = await stagedApp({ agent: null });
+    const res = await outer.request(`/api/v1/ext/workspace${path}`, {
+      method,
+      ...(method === 'POST'
+        ? { headers: { 'content-type': 'application/json' }, body: '{}' }
+        : {}),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'agent identity required' });
+  });
+
+  // The guard must fail closed WITHOUT swallowing the catch-all: an
+  // authenticated agent hitting an unmatched /agent/* path still gets the
+  // extension's own 404, not a 401 and not a fall-through to the user routes.
+  it('keeps the /agent catch-all reachable for an authenticated agent', async () => {
+    const outer = await stagedApp();
+    const res = await outer.request('/api/v1/ext/workspace/agent/nope');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not found' });
+  });
+
+  // The helper tree mirrors the agent tree: the host applies core helper auth
+  // on /helper/* (legacy-manifest helperRoutes flag), so the extension's own
+  // guard is what turns a missing identity into an explicit 401 instead of a
+  // TypeError-shaped 500.
+  it('serves /helper routes for an identified helper and 404s unmatched helper paths', async () => {
+    const outer = await stagedApp();
+    const capabilities = await outer.request('/api/v1/ext/workspace/helper/capabilities');
+    expect(capabilities.status).toBe(200);
+    expect(await capabilities.json()).toEqual({
+      ok: true,
+      features: ['search', 'browse', 'recents', 'open'],
+    });
+    // The catch-all keeps unmatched helper paths out of the user app.
+    const nope = await outer.request('/api/v1/ext/workspace/helper/nope');
+    expect(nope.status).toBe(404);
+    expect(await nope.json()).toEqual({ error: 'not found' });
+  });
+
+  it.each([
+    ['GET', '/helper/capabilities'],
+    ['GET', '/helper/sources'],
+  ])('rejects %s %s with 401 when no helper identity is present', async (method, path) => {
+    const outer = await stagedApp({ helper: null });
+    const res = await outer.request(`/api/v1/ext/workspace${path}`, { method });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'helper identity required' });
+  });
+
+  // Content routes stay behind the per-org content flag (W2 Task 3): disabled
+  // (no settings row) → 404 even for an authed admin; enabled via the org's
+  // settings row → the route exists.
+  it('gates content routes on the per-org content flag', async () => {
+    const disabled = await stagedApp();
+    expect((await disabled.request(`/api/v1/ext/workspace/content/status?orgId=${ORG_ID}`))
+      .status).toBe(404);
+
+    const enabled = await stagedApp({
+      context: {
+        db: fakeDb([{ orgId: ORG_ID, contentEnabled: true, dlpConfig: {} }]),
+      },
+    });
+    const res = await enabled.request(`/api/v1/ext/workspace/content/status?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+  });
+
+  // A silent text/plain 500 was invisible in production; the JSON error shape
+  // and the log line are both load-bearing, and the handler must survive the
+  // host mounting the extension via route().
+  it('answers unhandled route errors with the JSON error shape and a level-first log line', async () => {
+    const logs: Array<[string, string]> = [];
+    const outer = await stagedApp({
+      context: {
+        db: fakeDb([], () => { throw new Error('connection reset'); }),
+        log: (level, message) => { logs.push([level, message]); },
+      },
+    });
+
+    const agentRes = await outer.request('/api/v1/ext/workspace/agent/crawl-config');
+    expect(agentRes.status).toBe(500);
+    expect(agentRes.headers.get('content-type')).toContain('application/json');
+    expect(await agentRes.json()).toEqual({ error: 'internal error' });
+
+    const userRes = await outer.request(`/api/v1/ext/workspace/sources?orgId=${ORG_ID}`);
+    expect(userRes.status).toBe(500);
+    expect(await userRes.json()).toEqual({ error: 'internal error' });
+
+    const helperRes = await outer.request('/api/v1/ext/workspace/helper/sources');
+    expect(helperRes.status).toBe(500);
+    expect(await helperRes.json()).toEqual({ error: 'internal error' });
+
+    const unhandled = logs.filter(([, message]) => message.includes('workspace unhandled error'));
+    expect(unhandled).toHaveLength(3);
+    expect(unhandled.every(([level]) => level === 'error')).toBe(true);
+    expect(unhandled.some(([, message]) => message.includes('connection reset'))).toBe(true);
+  });
+
+  // The host logger must reach the sources routes: an audit-transport failure
+  // is fail-open by design, so the log line is the only signal that a hole was
+  // punched in the audit trail. Dropping `log` from the deps object hides it.
+  it('threads the host logger into the sources routes so audit-write failures stay visible', async () => {
+    const logs: Array<[string, string]> = [];
+    const outer = await stagedApp({
+      context: {
+        audit: async () => { throw new Error('audit queue unavailable'); },
+        log: (level, message) => { logs.push([level, message]); },
+      },
+    });
+    const res = await outer.request(
+      `/api/v1/ext/workspace/sources/55555555-5555-4555-8555-555555555555?orgId=${ORG_ID}`,
+      { method: 'DELETE' },
+    );
+    expect(res.status).toBe(404);
+    expect(logs).toContainEqual([
+      'error',
+      expect.stringContaining('workspace audit write failed') as unknown as string,
+    ]);
+  });
+
+  it('logs registration at info level through the level-first host logger', async () => {
+    const log = vi.fn();
+    const registrar = new CapturingRegistrar();
+    await workspaceExtension.register(registrar, runtimeContext({ log }));
+    expect(log).toHaveBeenCalledWith('info', expect.stringContaining('workspace'));
+    expect(log.mock.calls.every(([level]) => (
+      ['debug', 'info', 'warn', 'error'].includes(level as string)
+    ))).toBe(true);
+  });
+
+  /**
+   * AUTH-BOUNDARY RELOCATION.
+   *
+   * Under the legacy contract the extension attached ctx.authMiddleware,
+   * ctx.agentAuthMiddleware and ctx.helperAuthMiddleware itself, and this
+   * suite asserted an agent token was rejected on user routes and required on
+   * agent routes. v1 removed all three fields: the host gateway applies the
+   * declared boundary (`agentRoutes: true`, `publicRoutes: []`, and the
+   * legacy-manifest `helperRoutes` flag for /helper/*) BEFORE dispatch. Those
+   * specific assertions therefore cannot survive here — the boundary is not
+   * the extension's to enforce any more.
+   *
+   * What remains extension-owned and is still covered: the /agent and /helper
+   * catch-all 404s, the identity guards, the onError JSON shape, and the admin
+   * gate on every user route. The declared boundary itself is asserted against
+   * the manifests below and in manifest.test.ts.
+   */
+  it('no longer attaches host auth middleware and declares the boundary in the manifests', async () => {
+    const source = workspaceExtension.register.toString();
+    expect(source).not.toContain('authMiddleware');
+    expect(source).not.toContain('agentAuthMiddleware');
+    expect(source).not.toContain('helperAuthMiddleware');
+    expect(manifest.publicRoutes).toEqual([]);
+    expect(manifest.agentRoutes).toBe(true);
+    // NOTE (ee/workspace import): the legacy breeze-extension.json manifest
+    // and its helperRoutes flag are not carried into the monorepo — the
+    // built-in host path is v1-only (manifest.json) — so the assertion that
+    // used to pin legacyManifest.helperRoutes === true was dropped here.
+  });
+
+  // The admin gate is what still stands between a user route and another org's
+  // data, so register() must not reorder it away from the user mounts.
+  it.each([
+    ['organization', [ORG_ID]],
+    ['partner', ['33333333-3333-4333-8333-333333333333']],
+    ['partner', null],
+  ] as const)('rejects %s scope with accessibleOrgIds=%j on user routes through register()', async (scope, accessibleOrgIds) => {
+    const outer = await stagedApp({
+      auth: { user: { id: USER_ID }, scope, accessibleOrgIds },
+    });
+    for (const path of ['sources', `devices/${DEVICE_ID}/summary`]) {
+      const res = await outer.request(`/api/v1/ext/workspace/${path}?orgId=${ORG_ID}`);
+      expect(res.status).toBe(403);
+    }
+  });
+});

--- a/ee/workspace/src/index.ts
+++ b/ee/workspace/src/index.ts
@@ -1,0 +1,158 @@
+import { Hono } from 'hono';
+import Anthropic from '@anthropic-ai/sdk';
+import { asWorkspaceDatabase, type BreezeExtensionV1, type WorkspaceDatabase } from './hostTypes';
+import { createAgentRoutes } from './routes/agent';
+import { createContentRoutes } from './routes/content';
+import { createDeviceSummaryRoutes } from './routes/deviceSummary';
+import { createHelperRoutes } from './routes/helper';
+import { createSourcesRoutes } from './routes/sources';
+import { buildContentReader } from './content/byteReader';
+import { buildEmbedder } from './content/embedder';
+import { createActivityService } from './services/activityService';
+import { createBatchUpsertService } from './services/batchUpsertService';
+import { createContentIngestService } from './services/contentIngestService';
+import { createContentSearchService } from './services/contentSearchService';
+import { createCrosswalkService } from './services/crosswalkService';
+import { createEnrichmentService, type AnthropicLike } from './services/enrichmentService';
+import { createFilingService } from './services/filingService';
+import { createCrawlRunsService } from './services/crawlRunsService';
+import { createCredentialService } from './services/credentialService';
+import { createDeviceSummaryService } from './services/deviceSummaryService';
+import { createFileQueryService } from './services/fileQueryService';
+import { createSourcesService } from './services/sourcesService';
+import { getOrgSettings } from './services/orgSettingsService';
+
+/**
+ * Enrichment needs an Anthropic key; construct lazily and only when the
+ * content preview could ever serve it. Absent key → routes answer 503 rather
+ * than crashing registration. Import stays dynamic-free: the SDK reads
+ * ANTHROPIC_API_KEY from the environment at construction.
+ */
+function buildEnrichmentService(
+  db: WorkspaceDatabase,
+): ReturnType<typeof createEnrichmentService> | undefined {
+  if (!process.env.ANTHROPIC_API_KEY) return undefined;
+  return createEnrichmentService(db, {
+    client: new Anthropic() as unknown as AnthropicLike,
+  });
+}
+
+const workspaceExtension: BreezeExtensionV1 = {
+  register(registrar, context) {
+    const app = new Hono();
+    // The host supplies the org-scoped (RLS-enforcing) Drizzle connection; the
+    // narrowing lives in hostTypes.ts so no service carries its own cast.
+    const db = asWorkspaceDatabase(context.db);
+    // Per-org content flag (W2 Task 3): the single switch for the content
+    // preview surface, replacing the process-wide WORKSPACE_CONTENT_PREVIEW
+    // env var. Content is enabled iff getOrgSettings(orgId).contentEnabled.
+    const getSettings = (orgId: string) => getOrgSettings(db, orgId);
+    const sourcesService = createSourcesService(db);
+    const credentialService = createCredentialService(db, context.secrets, getSettings);
+    const crosswalkService = createCrosswalkService(db);
+    const filingService = createFilingService(db, { crosswalkService });
+
+    // No auth middleware is attached here: the host gateway applies the
+    // manifest-declared boundary before dispatch — agent auth on /agent/*,
+    // core helper auth on /helper/* (legacy-manifest helperRoutes flag), user
+    // auth everywhere else (publicRoutes: []) — and puts the caller identity
+    // on the request.
+    app.get('/health', (c) => c.json({ ok: true, extension: 'workspace' }));
+
+    // Mount order is load-bearing. Hono composes matching handlers in
+    // registration order, so /agent and /helper must be mounted before the
+    // user routes: each tree — including its catch-all — has to answer first,
+    // or an unmatched /agent/* or /helper/* request would fall through to the
+    // admin-gated user routes below.
+    const agentApp = new Hono();
+    agentApp.route('/', createAgentRoutes({
+      sourcesService,
+      credentialService,
+      crawlRunsService: createCrawlRunsService(db),
+      batchUpsertService: createBatchUpsertService(db),
+      audit: context.audit,
+      log: context.log,
+    }));
+    // The host gateway authenticates extension agent traffic on
+    // /agent/:agentId/... (device identity in the path, mirroring core's
+    // /api/v1/agents/:id/* convention), while the phase-2 wire spec — and the
+    // Go client's default endpoint base — use flat /agent/... paths. Mount the
+    // agent surface under both shapes: the :agentId segment is consumed here
+    // purely for routing (identity always comes from c.get('agent'), bound by
+    // auth to the token, never from the path).
+    //
+    // No catch-all INSIDE agentApp: under the dual mount a flat
+    // /agent/crawl-config first matches the /agent/:agentId mount (the segment
+    // parses as an agent id, inner path '/'), and an inner catch-all would
+    // answer 404 there before the flat /agent mount could route it. The
+    // catch-alls live on the outer app, after both mounts, so real routes win.
+    app.route('/agent/:agentId', agentApp);
+    app.route('/agent', agentApp);
+    app.all('/agent', (c) => c.json({ error: 'not found' }, 404));
+    app.all('/agent/*', (c) => c.json({ error: 'not found' }, 404));
+
+    const helperApp = new Hono();
+    helperApp.route('/', createHelperRoutes({
+      fileQueryService: createFileQueryService(db),
+      activityService: createActivityService(db),
+      contentSearchService: createContentSearchService(db, { embedder: buildEmbedder() }),
+      filingService,
+      getSettings,
+      audit: context.audit,
+      log: context.log,
+    }));
+    helperApp.all('*', (c) => c.json({ error: 'not found' }, 404));
+    app.route('/helper', helperApp);
+
+    app.route('/', createSourcesRoutes({
+      sourcesService,
+      credentialService,
+      audit: context.audit,
+      // Threaded so audit-write failures are reported rather than silently
+      // leaving a hole in the audit trail.
+      log: context.log,
+    }));
+    // Content phase (dev-preview): every route except /content/settings 404s
+    // unless content is enabled for the org (getOrgSettings). DLP runs at
+    // ingest (redact before store, block before embed); never enable in
+    // production (see README).
+    app.route('/', createContentRoutes({
+      contentIngestService: createContentIngestService(db, {
+        reader: buildContentReader(
+          (orgId, sourceId) => credentialService.decryptForContentIngest(orgId, sourceId),
+        ),
+        maxBytes: process.env.WORKSPACE_CONTENT_MAX_BYTES
+          ? Number(process.env.WORKSPACE_CONTENT_MAX_BYTES)
+          : undefined,
+        embedder: buildEmbedder(),
+      }),
+      enrichmentService: buildEnrichmentService(db),
+      crosswalkService,
+      db,
+      audit: context.audit,
+      log: context.log,
+    }));
+    app.route('/', createDeviceSummaryRoutes({
+      deviceSummaryService: createDeviceSummaryService(db),
+    }));
+
+    // Unhandled service/DB exceptions must come back as the JSON error shape
+    // every agent and admin response uses (never Hono's text/plain default),
+    // and must leave a log line — a silent text 500 was invisible in
+    // production. Hono carries a sub-app's onError through route(), so this
+    // handler survives however the host mounts the extension.
+    app.onError((error, c) => {
+      context.log(
+        'error',
+        `workspace unhandled error ${c.req.method} ${c.req.path}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+      );
+      return c.json({ error: 'internal error' }, 500);
+    });
+
+    registrar.mountRoute(app);
+    context.log('info', 'workspace extension registered');
+  },
+};
+
+export default workspaceExtension;

--- a/ee/workspace/src/manifest.test.ts
+++ b/ee/workspace/src/manifest.test.ts
@@ -1,0 +1,41 @@
+import manifest from '../manifest.json';
+import { assertManifestConformance } from '@breeze/extension-testkit';
+import { describe, expect, it } from 'vitest';
+
+describe('Workspace manifest', () => {
+  it('conforms to the supported v1 contracts', () => {
+    expect(assertManifestConformance(manifest)).toEqual({ ok: true, issues: [] });
+  });
+
+  // A capability the code uses but the manifest omits is invisible to
+  // assertManifestConformance, which validates the manifest in isolation and
+  // cannot see code. A host that provisions runtime facilities from the granted
+  // capability set would then hand this extension no secrets and no audit sink:
+  // encryptForColumn throws on the first SMB credential write, and audit
+  // silently no-ops. Each entry below is pinned to its call site so a capability
+  // cannot be dropped from the manifest while the code still depends on it.
+  it.each([
+    ['server.routes.v1', 'registrar.mountRoute in src/index.ts'],
+    ['server.agent-routes.v1', 'the /agent sub-app in src/routes/agent.ts'],
+    ['server.db.rls.v1', 'context.db via asWorkspaceDatabase in src/hostTypes.ts'],
+    ['server.secrets.v1', 'context.secrets.encryptForColumn in src/services/credentialService.ts'],
+    ['server.audit.v1', 'context.audit in src/routes/agent.ts and src/routes/sources.ts'],
+    ['web.pages.v1', 'manifest.web.pages'],
+    ['web.navigation.v1', 'manifest.web.navigation'],
+    ['web.slots.v1', 'manifest.web.slots'],
+  ])('declares %s, required by %s', (capability) => {
+    expect(manifest.requires.capabilities).toContain(capability);
+  });
+
+  // NOTE (ee/workspace import): the legacy breeze-extension.json manifest
+  // is not carried into the monorepo — the built-in host path is v1-only
+  // (manifest.json) — so the parity check that used to compare it against
+  // manifest.json was dropped here.
+
+  it('declares the page and device slot under the Workspace namespace', () => {
+    expect(manifest.web.pages[0].path).toBe('/extensions/workspace/sources');
+    expect(manifest.web.slots[0]).toMatchObject({
+      slot: 'device.detail.tabs', contractVersion: 1, element: 'workspace-device-index',
+    });
+  });
+});

--- a/ee/workspace/src/manifestExportColumns.test.ts
+++ b/ee/workspace/src/manifestExportColumns.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `tenancy.orgExportColumns` must classify EVERY live column of EVERY table in
+ * `tenancy.orgCascadeDeleteTables` — include or exclude, no third option.
+ *
+ * The host enforces this against `information_schema` at export time
+ * (buildTenantExportPlan → "policy columns do not match live table"), which
+ * means a migration that adds a column without touching the manifest breaks the
+ * GDPR right-of-access export for every org in the deployment, and does so
+ * silently until someone requests an export. This test moves that failure to
+ * the commit that adds the column: it parses the migration DDL and diffs it
+ * against the manifest.
+ */
+
+const ROOT = path.resolve(__dirname, '..');
+
+/** Column names per table, replaying CREATE TABLE / ADD COLUMN / DROP COLUMN. */
+function columnsFromMigrations(): Map<string, string[]> {
+  const dir = path.join(ROOT, 'migrations');
+  const columns = new Map<string, string[]>();
+  const add = (table: string, column: string) => {
+    const existing = columns.get(table) ?? [];
+    if (!existing.includes(column)) existing.push(column);
+    columns.set(table, existing);
+  };
+
+  for (const file of readdirSync(dir).filter((f) => f.endsWith('.sql')).sort()) {
+    const sql = readFileSync(path.join(dir, file), 'utf8');
+
+    for (const match of sql.matchAll(/CREATE TABLE IF NOT EXISTS (\w+) \(\n([\s\S]*?)\n\);/g)) {
+      const table = match[1]!;
+      for (const rawLine of match[2]!.split('\n')) {
+        const line = rawLine.trim();
+        if (line === '' || line.startsWith('--')) continue;
+        const column = /^([a-z_]+) /.exec(line)?.[1];
+        if (column === undefined) continue;
+        // Table-level constraint clauses are not columns.
+        if (['primary', 'unique', 'constraint', 'foreign', 'check'].includes(column)) continue;
+        add(table, column);
+      }
+    }
+
+    for (const match of sql.matchAll(/ALTER TABLE (\w+)\s+ADD COLUMN IF NOT EXISTS (\w+)/g)) {
+      add(match[1]!, match[2]!);
+    }
+    for (const match of sql.matchAll(/ALTER TABLE (\w+)\s+DROP COLUMN IF EXISTS (\w+)/g)) {
+      const existing = columns.get(match[1]!);
+      if (existing) columns.set(match[1]!, existing.filter((c) => c !== match[2]!));
+    }
+  }
+  return columns;
+}
+
+interface ManifestTenancy {
+  orgCascadeDeleteTables: string[];
+  orgExportColumns?: Record<string, { include: string[]; exclude: string[] }>;
+}
+
+const tenancy = (
+  JSON.parse(readFileSync(path.join(ROOT, 'manifest.json'), 'utf8')) as {
+    tenancy: ManifestTenancy;
+  }
+).tenancy;
+
+describe('manifest tenancy.orgExportColumns', () => {
+  const migrationColumns = columnsFromMigrations();
+
+  it('parses the migration DDL it is diffing against', () => {
+    // Guards the parser itself: a silently-empty parse would make every
+    // assertion below vacuous.
+    expect(migrationColumns.size).toBeGreaterThanOrEqual(
+      tenancy.orgCascadeDeleteTables.length,
+    );
+  });
+
+  it.each(tenancy.orgCascadeDeleteTables)(
+    'classifies every column of %s exactly once',
+    (table) => {
+      const live = migrationColumns.get(table);
+      expect(live, `no CREATE TABLE found for ${table}`).toBeDefined();
+
+      const policy = tenancy.orgExportColumns?.[table];
+      expect(policy, `no orgExportColumns entry for ${table}`).toBeDefined();
+
+      const classified = [...policy!.include, ...policy!.exclude];
+      expect([...classified].sort()).toEqual([...live!].sort());
+      // No column may be both included and excluded (the host rejects overlap).
+      expect(new Set(classified).size).toBe(classified.length);
+    },
+  );
+
+  it('never exports the encrypted source credential', () => {
+    expect(tenancy.orgExportColumns?.workspace_sources?.exclude)
+      .toContain('credential_enc');
+  });
+});

--- a/ee/workspace/src/routes/adminGate.ts
+++ b/ee/workspace/src/routes/adminGate.ts
@@ -1,0 +1,48 @@
+import type { MiddlewareHandler } from 'hono';
+
+export interface WorkspaceAuthContext {
+  user: {
+    id: string;
+    email?: string;
+    name?: string;
+    isPlatformAdmin?: boolean;
+  };
+  scope: 'system' | 'partner' | 'organization';
+  orgId?: string | null;
+  partnerId?: string | null;
+  accessibleOrgIds: string[] | null;
+}
+
+export type WorkspaceRouteEnv = {
+  Variables: {
+    auth: WorkspaceAuthContext;
+    workspaceOrgId: string;
+  };
+};
+
+export const adminGate: MiddlewareHandler<WorkspaceRouteEnv> = async (c, next) => {
+  const auth = c.get('auth');
+  if (!auth || (auth.scope !== 'partner' && auth.scope !== 'system')) {
+    return c.json({ error: 'Admin access required' }, 403);
+  }
+
+  const orgId = c.req.query('orgId')?.trim();
+  if (!orgId) {
+    return c.json({ error: 'orgId is required' }, 400);
+  }
+
+  // accessibleOrgIds: null is the "unrestricted" sentinel and is honored for
+  // system scope only. Partner-scoped principals must always carry an explicit
+  // org list — a missing list (e.g. an upstream lookup failure populating
+  // null) fails closed instead of granting cross-tenant access.
+  if (auth.scope !== 'system' && !Array.isArray(auth.accessibleOrgIds)) {
+    return c.json({ error: 'Organization access denied' }, 403);
+  }
+  if (Array.isArray(auth.accessibleOrgIds) && !auth.accessibleOrgIds.includes(orgId)) {
+    return c.json({ error: 'Organization access denied' }, 403);
+  }
+
+  c.set('workspaceOrgId', orgId);
+  await next();
+};
+

--- a/ee/workspace/src/routes/agent.test.ts
+++ b/ee/workspace/src/routes/agent.test.ts
@@ -1,0 +1,502 @@
+import { gzipSync } from 'node:zlib';
+import { Hono } from 'hono';
+import type { ExtensionAgentContext, ExtensionAuditEvent } from '../hostTypes';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAgentRoutes, type WorkspaceAgentRouteEnv } from './agent';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const SOURCE_ID = '22222222-2222-4222-8222-222222222222';
+const RUN_ID = '33333333-3333-4333-8333-333333333333';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+const OTHER_DEVICE_ID = '55555555-5555-4555-8555-555555555555';
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
+const agent: ExtensionAgentContext = {
+  deviceId: DEVICE_ID,
+  agentId: 'agent-1',
+  orgId: ORG_ID,
+  siteId: '66666666-6666-4666-8666-666666666666',
+  role: 'agent',
+};
+
+function source(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SOURCE_ID,
+    orgId: ORG_ID,
+    kind: 'smb_share' as const,
+    displayName: 'Shared files',
+    rootPath: '\\\\server\\share',
+    crawlDeviceId: DEVICE_ID,
+    visibilityGroupIds: [],
+    hasCredential: true,
+    excludeGlobs: ['**/.git/**'],
+    watch: false,
+    crawlCadenceMinutes: 60,
+    crawlCursor: {},
+    status: 'active' as const,
+    statusDetail: null,
+    errorReason: null,
+    lastCompleteRunAt: new Date('2026-07-12T10:00:00.000Z'),
+    createdAt: new Date('2026-07-12T09:00:00.000Z'),
+    updatedAt: new Date('2026-07-12T09:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function run(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RUN_ID,
+    orgId: ORG_ID,
+    sourceId: SOURCE_ID,
+    deviceId: null,
+    deviceKey: ZERO_UUID,
+    status: 'running' as const,
+    startedAt: new Date('2026-07-12T10:01:00.000Z'),
+    lastActivityAt: new Date('2026-07-12T10:02:00.000Z'),
+    completedAt: null,
+    cursor: 'folder/one',
+    stats: {},
+    errorReason: null,
+    ...overrides,
+  };
+}
+
+const entry = {
+  relPath: 'folder/report.txt',
+  parentPath: 'folder',
+  name: 'report.txt',
+  isDir: false,
+  size: 12,
+  mtime: '2026-07-12T10:00:00.000Z',
+  ctime: null,
+  ext: 'txt',
+  attrs: {},
+};
+
+function makeHarness(agentValue = agent) {
+  const sourcesService = {
+    get: vi.fn(async (_orgId: string, id: string) => {
+      const row = source();
+      return row.id === id ? row : null;
+    }),
+    listForDevice: vi.fn(async () => [source()]),
+  };
+  const credentialService = {
+    decryptForDevice: vi.fn(async () => ({ username: 'alice', password: 'secret', domain: null })),
+  };
+  const crawlRunsService = {
+    start: vi.fn(async () => ({ run: run() })),
+    touch: vi.fn(async () => 1),
+    finish: vi.fn(async () => ({ tombstoned: 0 })),
+    getActive: vi.fn(async () => run()),
+    getById: vi.fn(async () => run()),
+  };
+  const batchUpsertService = {
+    upsertBatch: vi.fn(async (_orgId: string, _sourceId: string, _deviceKey: string, entries: unknown[]) => ({
+      inserted: entries.length,
+      expected: entries.length,
+    })),
+    tombstonePaths: vi.fn(async () => 2),
+  };
+  const audit = vi.fn(async (_event: ExtensionAuditEvent) => {});
+  const log = vi.fn();
+  const app = new Hono<WorkspaceAgentRouteEnv>();
+  app.use('*', async (c, next) => {
+    c.set('agent', agentValue);
+    await next();
+  });
+  app.route('/', createAgentRoutes({
+    sourcesService,
+    credentialService,
+    crawlRunsService,
+    batchUpsertService,
+    audit,
+    log,
+  }));
+  return {
+    app,
+    sourcesService,
+    credentialService,
+    crawlRunsService,
+    batchUpsertService,
+    audit,
+    log,
+  };
+}
+
+function jsonRequest(body: unknown) {
+  return {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.WORKSPACE_CRAWL_ENABLED;
+});
+
+describe('workspace agent routes', () => {
+  it('builds crawl config from device-visible sources and active runs', async () => {
+    const h = makeHarness();
+    const res = await h.app.request('/crawl-config');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      enabled: true,
+      pollIntervalSeconds: 300,
+      limits: { maxBatchBytes: 921600, maxBatchEntries: 2000, walkOpsPerSecond: 200 },
+      sources: [{
+        id: SOURCE_ID,
+        kind: 'smb_share',
+        rootPath: '\\\\server\\share',
+        cadenceMinutes: 60,
+        excludeGlobs: ['**/.git/**'],
+        hasCredential: true,
+        lastCompleteRunAt: '2026-07-12T10:00:00.000Z',
+        activeRun: { runId: RUN_ID, startedAt: '2026-07-12T10:01:00.000Z', cursor: 'folder/one' },
+        watch: false,
+      }],
+    });
+    expect(h.sourcesService.listForDevice).toHaveBeenCalledWith(ORG_ID, DEVICE_ID);
+    expect(h.crawlRunsService.getActive).toHaveBeenCalledWith(ORG_ID, SOURCE_ID, DEVICE_ID);
+  });
+
+  it('honors the kill switch without querying sources', async () => {
+    process.env.WORKSPACE_CRAWL_ENABLED = 'false';
+    const h = makeHarness();
+    const res = await h.app.request('/crawl-config');
+    expect(await res.json()).toEqual({ enabled: false, pollIntervalSeconds: 300, sources: [] });
+    expect(h.sourcesService.listForDevice).not.toHaveBeenCalled();
+  });
+
+  it('audits successful and missing credential fetches and disables caching', async () => {
+    const h = makeHarness();
+    const success = await h.app.request(`/sources/${SOURCE_ID}/credential`, { method: 'POST' });
+    expect(success.status).toBe(200);
+    expect(success.headers.get('cache-control')).toBe('no-store');
+    expect(await success.json()).toEqual({ username: 'alice', password: 'secret', domain: null });
+
+    h.credentialService.decryptForDevice.mockResolvedValueOnce(null as never);
+    const missing = await h.app.request(`/sources/${SOURCE_ID}/credential`, { method: 'POST' });
+    expect(missing.status).toBe(404);
+    expect(missing.headers.get('cache-control')).toBe('no-store');
+    expect(h.audit).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      orgId: ORG_ID,
+      actorType: 'agent',
+      actorId: DEVICE_ID,
+      action: 'workspace.source.credential.fetch',
+      resourceId: SOURCE_ID,
+      result: 'success',
+    }));
+    expect(h.audit).toHaveBeenNthCalledWith(2, expect.objectContaining({ result: 'failure' }));
+  });
+
+  it('audits an invalid credential source ID as an indistinguishable 404 without service access', async () => {
+    const h = makeHarness();
+    const res = await h.app.request('/sources/not-a-uuid/credential', { method: 'POST' });
+    expect(res.status).toBe(404);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(await res.json()).toEqual({ error: 'not found' });
+    expect(h.credentialService.decryptForDevice).not.toHaveBeenCalled();
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({
+      resourceId: 'not-a-uuid',
+      result: 'failure',
+    }));
+  });
+
+  it('returns 404 when starting a run for another device SMB source', async () => {
+    const h = makeHarness();
+    h.sourcesService.listForDevice.mockResolvedValueOnce([]);
+    const res = await h.app.request('/runs', jsonRequest({ sourceId: SOURCE_ID }));
+    expect(res.status).toBe(404);
+    expect(h.crawlRunsService.start).not.toHaveBeenCalled();
+  });
+
+  it('validates run creation and maps active-run conflicts to 409', async () => {
+    const h = makeHarness();
+    const invalid = await h.app.request('/runs', jsonRequest({ sourceId: 'not-a-uuid' }));
+    expect(invalid.status).toBe(400);
+    h.crawlRunsService.start.mockResolvedValueOnce({ conflict: true } as never);
+    const conflict = await h.app.request('/runs', jsonRequest({ sourceId: SOURCE_ID }));
+    expect(conflict.status).toBe(409);
+    expect(await conflict.json()).toEqual({ error: 'run already active' });
+  });
+
+  it('logs unexpected run-start failures and returns 500', async () => {
+    const h = makeHarness();
+    h.crawlRunsService.start.mockRejectedValueOnce(new Error('database unavailable'));
+    const res = await h.app.request('/runs', jsonRequest({ sourceId: SOURCE_ID }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'failed to start run' });
+    expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining('workspace agent run start failed'));
+    expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining(SOURCE_ID));
+    expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining('database unavailable'));
+  });
+
+  it('keeps typed unassigned/missing run starts indistinguishable as 404', async () => {
+    const h = makeHarness();
+    const { SourceNotAssignedError, SourceNotFoundError } =
+      await import('../services/crawlRunsService');
+    h.crawlRunsService.start.mockRejectedValueOnce(new SourceNotAssignedError());
+    const unassigned = await h.app.request('/runs', jsonRequest({ sourceId: SOURCE_ID }));
+    expect(unassigned.status).toBe(404);
+    expect(await unassigned.json()).toEqual({ error: 'not found' });
+
+    h.crawlRunsService.start.mockRejectedValueOnce(new SourceNotFoundError());
+    const missing = await h.app.request('/runs', jsonRequest({ sourceId: SOURCE_ID }));
+    expect(missing.status).toBe(404);
+    expect(h.log).not.toHaveBeenCalled();
+  });
+
+  it('gunzips a valid batch, upserts it, and advances the cursor', async () => {
+    const h = makeHarness();
+    const encoded = gzipSync(JSON.stringify({ cursor: entry.relPath, entries: [entry] }));
+    const res = await h.app.request(`/runs/${RUN_ID}/batch`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'content-encoding': 'gzip' },
+      body: encoded,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ inserted: 1, expected: 1 });
+    expect(h.batchUpsertService.upsertBatch).toHaveBeenCalledWith(ORG_ID, SOURCE_ID, ZERO_UUID, [entry]);
+    expect(h.crawlRunsService.touch).toHaveBeenCalledWith(ORG_ID, RUN_ID, entry.relPath, { seen: 1 });
+    expect(h.crawlRunsService.getById).toHaveBeenCalledWith(ORG_ID, RUN_ID);
+  });
+
+  it('returns 413 when a gzip body expands past the 4 MB decoded cap', async () => {
+    const h = makeHarness();
+    const encoded = gzipSync('x'.repeat(4 * 1024 * 1024 + 1));
+    const res = await h.app.request(`/runs/${RUN_ID}/batch`, {
+      method: 'POST',
+      headers: { 'content-encoding': 'gzip' },
+      body: encoded,
+    });
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'batch too large' });
+  });
+
+  it('returns 413 for more than 2000 entries and 400 for malformed JSON', async () => {
+    const h = makeHarness();
+    const oversized = await h.app.request(`/runs/${RUN_ID}/batch`, jsonRequest({
+      cursor: 'last',
+      entries: Array.from({ length: 2001 }, () => entry),
+    }));
+    expect(oversized.status).toBe(413);
+    const malformed = await h.app.request(`/runs/${RUN_ID}/batch`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{',
+    });
+    expect(malformed.status).toBe(400);
+    expect(h.batchUpsertService.upsertBatch).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for a foreign run and 409 for a visible non-running run', async () => {
+    const h = makeHarness();
+    h.crawlRunsService.getById.mockResolvedValueOnce(null as never);
+    const foreign = await h.app.request(`/runs/${RUN_ID}/batch`, jsonRequest({ cursor: 'last', entries: [] }));
+    expect(foreign.status).toBe(404);
+
+    h.crawlRunsService.getById.mockResolvedValueOnce(run({ status: 'failed' }));
+    const stopped = await h.app.request(`/runs/${RUN_ID}/batch`, jsonRequest({ cursor: 'last', entries: [] }));
+    expect(stopped.status).toBe(409);
+  });
+
+  it('returns 409 for an older stopped run on a paused SMB source still assigned to this device', async () => {
+    const h = makeHarness();
+    h.sourcesService.listForDevice.mockResolvedValueOnce([]);
+    h.sourcesService.get.mockResolvedValueOnce(source({ status: 'paused' }));
+    h.crawlRunsService.getById.mockResolvedValueOnce(run({ status: 'failed' }));
+    const res = await h.app.request(
+      `/runs/${RUN_ID}/batch`,
+      jsonRequest({ cursor: 'last', entries: [] }),
+    );
+    expect(res.status).toBe(409);
+    expect(h.sourcesService.get).toHaveBeenCalledWith(ORG_ID, SOURCE_ID);
+    expect(h.crawlRunsService.getById).toHaveBeenCalledWith(ORG_ID, RUN_ID);
+  });
+
+  it('passes complete=false to finish and returns zero tombstones without route-side sweep calls', async () => {
+    const h = makeHarness();
+    // Wire field is `error` — exactly what the Go agent serializes (json:"error").
+    const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({
+      complete: false,
+      stats: { seen: 9, errors: 1 },
+      error: 'authenticate: session setup failed',
+    }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ tombstoned: 0 });
+    expect(h.crawlRunsService.finish).toHaveBeenCalledWith(ORG_ID, RUN_ID, DEVICE_ID, {
+      complete: false,
+      stats: { seen: 9, errors: 1 },
+      errorReason: 'authenticate: session setup failed',
+    });
+    expect(h.batchUpsertService.tombstonePaths).not.toHaveBeenCalled();
+  });
+
+  it('rejects the legacy errorReason wire field (strict schema locks the Go contract)', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({
+      complete: false,
+      errorReason: 'cancelled',
+    }));
+    expect(res.status).toBe(400);
+    expect(h.crawlRunsService.finish).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when finish cannot find a run owned by this device', async () => {
+    const h = makeHarness();
+    h.crawlRunsService.finish.mockResolvedValueOnce({ notFound: true } as never);
+    const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({ complete: true }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for an invalid completion run ID without calling finish', async () => {
+    const h = makeHarness();
+    const res = await h.app.request('/runs/not-a-uuid/complete', jsonRequest({ complete: true }));
+    expect(res.status).toBe(404);
+    expect(h.crawlRunsService.finish).not.toHaveBeenCalled();
+  });
+
+  it('applies local-profile events using the calling device as device key', async () => {
+    const h = makeHarness();
+    h.sourcesService.listForDevice.mockResolvedValueOnce([source({
+      kind: 'local_profile',
+      rootPath: '/Users',
+      crawlDeviceId: null,
+      hasCredential: false,
+      watch: true,
+    })]);
+    const res = await h.app.request(`/sources/${SOURCE_ID}/events`, jsonRequest({
+      upserts: [entry],
+      deletes: ['folder/deleted.txt'],
+    }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ inserted: 1, expected: 1, tombstoned: 2 });
+    expect(h.batchUpsertService.upsertBatch).toHaveBeenCalledWith(ORG_ID, SOURCE_ID, DEVICE_ID, [entry]);
+    expect(h.batchUpsertService.tombstonePaths).toHaveBeenCalledWith(
+      ORG_ID,
+      SOURCE_ID,
+      DEVICE_ID,
+      ['folder/deleted.txt'],
+    );
+  });
+
+  it('hides SMB and non-visible sources from the events endpoint', async () => {
+    const h = makeHarness();
+    const smb = await h.app.request(`/sources/${SOURCE_ID}/events`, jsonRequest({ upserts: [], deletes: [] }));
+    expect(smb.status).toBe(404);
+    h.sourcesService.listForDevice.mockResolvedValueOnce([]);
+    const hidden = await h.app.request(`/sources/${SOURCE_ID}/events`, jsonRequest({ upserts: [], deletes: [] }));
+    expect(hidden.status).toBe(404);
+  });
+
+  it('answers a non-UUID batch run ID with the contract 404 before any service access', async () => {
+    const h = makeHarness();
+    const res = await h.app.request('/runs/not-a-uuid/batch', jsonRequest({ cursor: 'c', entries: [] }));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not found' });
+    expect(h.crawlRunsService.getById).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when the run goes terminal between the ownership check and the cursor write', async () => {
+    const h = makeHarness();
+    h.crawlRunsService.touch.mockResolvedValueOnce(0);
+    const res = await h.app.request(`/runs/${RUN_ID}/batch`, jsonRequest({ cursor: 'c', entries: [entry] }));
+    // The entries were written idempotently but the cursor was NOT persisted;
+    // reporting 200 here would silently lose the agent's resume position.
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'run not active' });
+  });
+
+  it('rejects a batch entry with an unparseable mtime as 400 before any write', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(`/runs/${RUN_ID}/batch`, jsonRequest({
+      cursor: 'c',
+      entries: [{ ...entry, mtime: 'not-a-date' }],
+    }));
+    expect(res.status).toBe(400);
+    expect(h.batchUpsertService.upsertBatch).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative and fractional sizes destined for the bigint column', async () => {
+    const h = makeHarness();
+    for (const size of [-1, 1.5]) {
+      const res = await h.app.request(`/runs/${RUN_ID}/batch`, jsonRequest({
+        cursor: 'c',
+        entries: [{ ...entry, size }],
+      }));
+      expect(res.status).toBe(400);
+    }
+    expect(h.batchUpsertService.upsertBatch).not.toHaveBeenCalled();
+  });
+
+  it('accepts offset timestamps as the Go agent may emit them', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(`/runs/${RUN_ID}/batch`, jsonRequest({
+      cursor: 'c',
+      entries: [{ ...entry, mtime: '2026-07-12T12:00:00.123456789+02:00' }],
+    }));
+    expect(res.status).toBe(200);
+  });
+
+  it('answers a retried complete idempotently instead of 404', async () => {
+    const h = makeHarness();
+    h.crawlRunsService.finish.mockResolvedValueOnce({ alreadyFinished: true } as never);
+    const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({ complete: true }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ tombstoned: 0, alreadyFinished: true });
+  });
+
+  it('rejects the contradictory complete=true plus error as 400', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({
+      complete: true,
+      error: 'should not be here',
+    }));
+    expect(res.status).toBe(400);
+    expect(h.crawlRunsService.finish).not.toHaveBeenCalled();
+  });
+
+  it('treats FALSE and 0 as the kill switch and logs its activation', async () => {
+    for (const value of ['FALSE', '0', ' false ']) {
+      process.env.WORKSPACE_CRAWL_ENABLED = value;
+      const h = makeHarness();
+      const res = await h.app.request('/crawl-config');
+      expect(await res.json()).toMatchObject({ enabled: false });
+      expect(h.log).toHaveBeenCalledWith('warn', expect.stringContaining('kill switch active'));
+    }
+  });
+
+  it('returns a 500 with a contextual log when credential decrypt fails, distinct from 404', async () => {
+    const h = makeHarness();
+    const { CredentialDecryptError } = await import('../services/credentialService');
+    h.credentialService.decryptForDevice.mockRejectedValueOnce(
+      new CredentialDecryptError(new Error('wrong key')),
+    );
+    const res = await h.app.request(`/sources/${SOURCE_ID}/credential`, { method: 'POST' });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'credential fetch failed' });
+    expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining('credential decrypt failed'));
+    expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining(SOURCE_ID));
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({ result: 'failure' }));
+  });
+
+  it('still serves the credential when the audit transport fails, but logs the gap', async () => {
+    const h = makeHarness();
+    h.audit.mockRejectedValue(new Error('audit queue unavailable'));
+    const res = await h.app.request(`/sources/${SOURCE_ID}/credential`, { method: 'POST' });
+    // Pinned contract: audit-transport failure is fail-open (matching the
+    // admin routes) — the credential fetch itself succeeded and the agent
+    // needs it; the audit hole is surfaced via the log.
+    expect(res.status).toBe(200);
+    expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining('audit write failed'));
+  });
+
+  it('derives all service identity arguments from c.get(agent)', async () => {
+    const h = makeHarness({ ...agent, deviceId: OTHER_DEVICE_ID });
+    await h.app.request(`/sources/${SOURCE_ID}/credential`, { method: 'POST' });
+    expect(h.credentialService.decryptForDevice).toHaveBeenCalledWith(ORG_ID, SOURCE_ID, OTHER_DEVICE_ID);
+  });
+});

--- a/ee/workspace/src/routes/agent.ts
+++ b/ee/workspace/src/routes/agent.ts
@@ -1,0 +1,415 @@
+import type { ExtensionAgentContext, ExtensionLog, WorkspaceAudit } from '../hostTypes';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import {
+  batchEntrySchema,
+  createBatchUpsertService,
+  MAX_BATCH_ENTRIES,
+} from '../services/batchUpsertService';
+import {
+  createCrawlRunsService,
+  SourceNotAssignedError,
+  SourceNotFoundError,
+  type CrawlRunRow,
+} from '../services/crawlRunsService';
+import { CredentialDecryptError, createCredentialService } from '../services/credentialService';
+import { createSourcesService, type SafeSourceRow } from '../services/sourcesService';
+import { matchesScope, scopeForDevice } from '../services/runScope';
+import { DecodedBodyTooLargeError, readDecodedBody } from './gunzip';
+
+// Soft limit advertised to agents via /crawl-config so well-behaved clients
+// size their batches; the enforced hard cap is MAX_DECODED_BODY_BYTES in
+// gunzip.ts (4 MiB), leaving headroom for imprecise-but-honest clients.
+const MAX_BATCH_BYTES = 921_600;
+const POLL_INTERVAL_SECONDS = 300;
+const WALK_OPS_PER_SECOND = 200;
+
+export interface WorkspaceAgentRouteEnv {
+  Variables: { agent: ExtensionAgentContext };
+}
+
+type SourcesService = Pick<
+  ReturnType<typeof createSourcesService>,
+  'get' | 'listForDevice'
+>;
+type CredentialService = Pick<ReturnType<typeof createCredentialService>, 'decryptForDevice'>;
+type CrawlRunsService = Pick<
+  ReturnType<typeof createCrawlRunsService>,
+  'start' | 'touch' | 'finish' | 'getActive' | 'getById'
+>;
+type BatchUpsertService = Pick<
+  ReturnType<typeof createBatchUpsertService>,
+  'upsertBatch' | 'tombstonePaths'
+>;
+
+export interface AgentRouteDeps {
+  sourcesService: SourcesService;
+  credentialService: CredentialService;
+  crawlRunsService: CrawlRunsService;
+  batchUpsertService: BatchUpsertService;
+  audit: WorkspaceAudit;
+  log: ExtensionLog;
+}
+
+const startSchema = z.object({ sourceId: z.uuid() }).strict();
+const batchSchema = z.object({
+  cursor: z.string().max(65_536),
+  entries: z.array(batchEntrySchema).max(MAX_BATCH_ENTRIES),
+}).strict();
+// Wire field is `error` (spec §2.5; the Go agent serializes json:"error").
+// Mapped to the service's errorReason at the call site. A complete run
+// carrying an error string is contradictory input and rejected outright
+// rather than silently discarding the error.
+const completeSchema = z.object({
+  complete: z.boolean(),
+  stats: z.record(z.string(), z.unknown()).optional(),
+  error: z.string().max(2000).optional(),
+}).strict().superRefine((body, ctx) => {
+  if (body.complete && body.error !== undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['error'],
+      message: 'error is only valid when complete is false',
+    });
+  }
+});
+const eventsSchema = z.object({
+  upserts: z.array(batchEntrySchema).max(MAX_BATCH_ENTRIES),
+  deletes: z.array(z.string().max(4096)).max(MAX_BATCH_ENTRIES),
+}).strict();
+
+type ParsedBody =
+  | { ok: true; value: unknown }
+  | { ok: false; status: 400 | 413; kind: 'too_large' | 'malformed_json' | 'malformed_encoding' };
+
+async function parseBody(request: Request): Promise<ParsedBody> {
+  try {
+    return { ok: true, value: JSON.parse(await readDecodedBody(request)) as unknown };
+  } catch (error) {
+    if (error instanceof DecodedBodyTooLargeError) {
+      return { ok: false, status: 413, kind: 'too_large' };
+    }
+    return {
+      ok: false,
+      status: 400,
+      kind: error instanceof SyntaxError ? 'malformed_json' : 'malformed_encoding',
+    };
+  }
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// Ownership mirrors the scope the run was created under (runScope.ts): SMB
+// runs are source-scoped and owned by the assigned crawl device; local_profile
+// runs are owned by the device they are keyed to. Gates batch/complete writes.
+function isOwnedRun(source: SafeSourceRow, run: CrawlRunRow, deviceId: string): boolean {
+  const scope = scopeForDevice(source, deviceId);
+  return scope !== null && matchesScope(run, scope);
+}
+
+function serializeDate(value: Date | null): string | null {
+  return value?.toISOString() ?? null;
+}
+
+function crawlKillSwitchActive(): boolean {
+  const raw = process.env.WORKSPACE_CRAWL_ENABLED?.trim().toLowerCase();
+  return raw === 'false' || raw === '0';
+}
+
+export function createAgentRoutes(deps: AgentRouteDeps): Hono<WorkspaceAgentRouteEnv> {
+  const app = new Hono<WorkspaceAgentRouteEnv>();
+
+  // Fail closed on missing agent identity, explicitly and in one place.
+  //
+  // Every handler below dereferences c.get('agent') unconditionally, and the
+  // `agent` Variable is typed non-optional, because the host gateway applies
+  // the manifest-declared agent boundary (agentRoutes: true, publicRoutes: [])
+  // before dispatch. That is a host INVARIANT, not something this extension
+  // enforces — and commit 68bf21d removed ctx.agentAuthMiddleware, which is
+  // what previously guaranteed it inside the extension.
+  //
+  // Without this guard the tree still fails closed, but only incidentally and
+  // inconsistently: a dereference TypeError surfacing through onError as a 500
+  // on some routes, and a body-validation 400 on the routes that parse before
+  // they read the identity. Neither states the actual reason. routes/adminGate
+  // fails closed deliberately (403) on the user side; this restores the
+  // symmetry on the agent side with the status that names the condition.
+  //
+  // Registered before the route handlers so it runs ahead of them, and scoped
+  // to this sub-app so it travels with createAgentRoutes wherever it is
+  // mounted. It deliberately does NOT absorb the caller's path: an
+  // authenticated agent hitting an unmatched /agent/* path still falls through
+  // to the catch-all 404 mounted alongside this app in index.ts.
+  app.use('*', async (c, next) => {
+    if (!c.get('agent')) {
+      deps.log('warn', `workspace agent request without identity ${c.req.method} ${c.req.path}`);
+      return c.json({ error: 'agent identity required' }, 401);
+    }
+    await next();
+  });
+
+  async function visibleSources(agent: ExtensionAgentContext): Promise<SafeSourceRow[]> {
+    return deps.sourcesService.listForDevice(agent.orgId, agent.deviceId);
+  }
+
+  // Audit transport failures must not change a request's outcome, but they
+  // must never be invisible either — an undetectably incomplete audit trail is
+  // its own incident.
+  async function guardedAudit(
+    event: Parameters<WorkspaceAudit>[0],
+    context: string,
+  ): Promise<void> {
+    try {
+      await deps.audit(event);
+    } catch (error) {
+      deps.log('error', `workspace agent audit write failed (${context}): ${errorDetail(error)}`);
+    }
+  }
+
+  function logBodyRejected(agent: ExtensionAgentContext, route: string, kind: string): void {
+    deps.log(
+      'warn',
+      `workspace agent ${route} body rejected (${kind}) org=${agent.orgId} device=${agent.deviceId}`,
+    );
+  }
+
+  async function resolveRun(
+    agent: ExtensionAgentContext,
+    runId: string,
+  ): Promise<
+    | { state: 'running'; run: CrawlRunRow }
+    | { state: 'stopped' }
+    | { state: 'missing' }
+  > {
+    // Pre-validate before the id reaches a uuid-typed column: a malformed id
+    // must be the contract 404, not a Postgres 22P02 surfacing as a 500.
+    if (!z.uuid().safeParse(runId).success) return { state: 'missing' };
+    const run = await deps.crawlRunsService.getById(agent.orgId, runId);
+    if (!run) return { state: 'missing' };
+    const source = await deps.sourcesService.get(agent.orgId, run.sourceId);
+    if (!source || !isOwnedRun(source, run, agent.deviceId)) return { state: 'missing' };
+    return run.status === 'running'
+      ? { state: 'running', run }
+      : { state: 'stopped' };
+  }
+
+  app.get('/crawl-config', async (c) => {
+    if (crawlKillSwitchActive()) {
+      deps.log('warn', 'workspace crawl kill switch active (WORKSPACE_CRAWL_ENABLED)');
+      return c.json({ enabled: false, pollIntervalSeconds: POLL_INTERVAL_SECONDS, sources: [] });
+    }
+    const agent = c.get('agent');
+    const sources = await visibleSources(agent);
+    const configuredSources = await Promise.all(sources.map(async (source) => {
+      const active = await deps.crawlRunsService.getActive(agent.orgId, source.id, agent.deviceId);
+      return {
+        id: source.id,
+        kind: source.kind,
+        rootPath: source.rootPath,
+        cadenceMinutes: source.crawlCadenceMinutes,
+        excludeGlobs: source.excludeGlobs,
+        hasCredential: source.kind === 'smb_share' && source.hasCredential,
+        lastCompleteRunAt: serializeDate(source.lastCompleteRunAt),
+        activeRun: active === null ? null : {
+          runId: active.id,
+          startedAt: active.startedAt.toISOString(),
+          cursor: active.cursor,
+        },
+        watch: source.kind === 'local_profile' ? source.watch : false,
+      };
+    }));
+    return c.json({
+      enabled: true,
+      pollIntervalSeconds: POLL_INTERVAL_SECONDS,
+      limits: {
+        maxBatchBytes: MAX_BATCH_BYTES,
+        maxBatchEntries: MAX_BATCH_ENTRIES,
+        walkOpsPerSecond: WALK_OPS_PER_SECOND,
+      },
+      sources: configuredSources,
+    });
+  });
+
+  app.post('/sources/:id/credential', async (c) => {
+    c.header('Cache-Control', 'no-store');
+    const agent = c.get('agent');
+    const sourceId = c.req.param('id');
+    const audit = (result: 'success' | 'failure') => guardedAudit({
+      orgId: agent.orgId,
+      actorType: 'agent',
+      actorId: agent.deviceId,
+      action: 'workspace.source.credential.fetch',
+      resourceType: 'workspace_source',
+      resourceId: sourceId,
+      result,
+    }, `credential.fetch source=${sourceId}`);
+    if (!z.uuid().safeParse(sourceId).success) {
+      await audit('failure');
+      return c.json({ error: 'not found' }, 404);
+    }
+    try {
+      const credential = await deps.credentialService.decryptForDevice(
+        agent.orgId,
+        sourceId,
+        agent.deviceId,
+      );
+      if (credential === null) {
+        await audit('failure');
+        return c.json({ error: 'not found' }, 404);
+      }
+      await audit('success');
+      return c.json(credential);
+    } catch (error) {
+      await audit('failure');
+      const label = error instanceof CredentialDecryptError ? 'credential decrypt' : 'credential fetch';
+      deps.log(
+        'error',
+        `workspace agent ${label} failed source=${sourceId} org=${agent.orgId} ` +
+        `device=${agent.deviceId}: ${errorDetail(error)}`,
+      );
+      return c.json({ error: 'credential fetch failed' }, 500);
+    }
+  });
+
+  app.post('/runs', async (c) => {
+    const parsed = startSchema.safeParse(await c.req.json().catch(() => undefined));
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const agent = c.get('agent');
+    const sources = await visibleSources(agent);
+    if (!sources.some((source) => source.id === parsed.data.sourceId)) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    try {
+      const result = await deps.crawlRunsService.start(
+        agent.orgId,
+        parsed.data.sourceId,
+        agent.deviceId,
+      );
+      if ('conflict' in result) return c.json({ error: 'run already active' }, 409);
+      return c.json({ runId: result.run.id, startedAt: result.run.startedAt.toISOString() });
+    } catch (error) {
+      if (error instanceof SourceNotFoundError || error instanceof SourceNotAssignedError) {
+        return c.json({ error: 'not found' }, 404);
+      }
+      deps.log(
+        'error',
+        `workspace agent run start failed source=${parsed.data.sourceId} ` +
+        `org=${agent.orgId} device=${agent.deviceId}: ${errorDetail(error)}`,
+      );
+      return c.json({ error: 'failed to start run' }, 500);
+    }
+  });
+
+  app.post('/runs/:runId/batch', async (c) => {
+    const agent = c.get('agent');
+    const runId = c.req.param('runId');
+    const decoded = await parseBody(c.req.raw);
+    if (!decoded.ok) {
+      if (decoded.status === 400) logBodyRejected(agent, `batch run=${runId}`, decoded.kind);
+      return c.json(
+        { error: decoded.status === 413 ? 'batch too large' : 'invalid request' },
+        decoded.status,
+      );
+    }
+    // Checked before Zod so oversized batches get 413 (agent splits and
+    // retries) rather than a generic 400 (agent drops the batch).
+    const rawEntries = typeof decoded.value === 'object' && decoded.value !== null &&
+      'entries' in decoded.value && Array.isArray(decoded.value.entries)
+      ? decoded.value.entries
+      : null;
+    if (rawEntries !== null && rawEntries.length > MAX_BATCH_ENTRIES) {
+      return c.json({ error: 'batch too large' }, 413);
+    }
+    const parsed = batchSchema.safeParse(decoded.value);
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const resolved = await resolveRun(agent, runId);
+    if (resolved.state === 'missing') return c.json({ error: 'not found' }, 404);
+    if (resolved.state === 'stopped') return c.json({ error: 'run not active' }, 409);
+    const result = await deps.batchUpsertService.upsertBatch(
+      agent.orgId,
+      resolved.run.sourceId,
+      resolved.run.deviceKey,
+      parsed.data.entries,
+    );
+    const touched = await deps.crawlRunsService.touch(agent.orgId, runId, parsed.data.cursor, {
+      seen: parsed.data.entries.length,
+    });
+    if (touched === 0) {
+      // The run went terminal between resolveRun and touch: the entries were
+      // written (idempotently — a retry is safe) but the cursor and stats were
+      // not. Reporting success here would silently lose the agent's cursor.
+      return c.json({ error: 'run not active' }, 409);
+    }
+    return c.json(result);
+  });
+
+  app.post('/runs/:runId/complete', async (c) => {
+    const parsed = completeSchema.safeParse(await c.req.json().catch(() => undefined));
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const agent = c.get('agent');
+    const runId = c.req.param('runId');
+    if (!z.uuid().safeParse(runId).success) return c.json({ error: 'not found' }, 404);
+    const result = await deps.crawlRunsService.finish(
+      agent.orgId,
+      runId,
+      agent.deviceId,
+      {
+        complete: parsed.data.complete,
+        stats: parsed.data.stats,
+        errorReason: parsed.data.error,
+      },
+    );
+    if ('notFound' in result) return c.json({ error: 'not found' }, 404);
+    // A retried complete (lost response) is answered idempotently; the
+    // tombstone sweep already ran on the first attempt.
+    if ('alreadyFinished' in result) return c.json({ tombstoned: 0, alreadyFinished: true });
+    return c.json({ tombstoned: result.tombstoned });
+  });
+
+  app.post('/sources/:id/events', async (c) => {
+    const agent = c.get('agent');
+    const sourceId = c.req.param('id');
+    const decoded = await parseBody(c.req.raw);
+    if (!decoded.ok) {
+      if (decoded.status === 400) logBodyRejected(agent, `events source=${sourceId}`, decoded.kind);
+      return c.json(
+        { error: decoded.status === 413 ? 'batch too large' : 'invalid request' },
+        decoded.status,
+      );
+    }
+    // Same 413-before-Zod rule as the batch route; this pre-check must track
+    // eventsSchema's field names.
+    if (typeof decoded.value === 'object' && decoded.value !== null) {
+      const body = decoded.value as Record<string, unknown>;
+      if (
+        (Array.isArray(body.upserts) && body.upserts.length > MAX_BATCH_ENTRIES) ||
+        (Array.isArray(body.deletes) && body.deletes.length > MAX_BATCH_ENTRIES)
+      ) {
+        return c.json({ error: 'batch too large' }, 413);
+      }
+    }
+    const parsed = eventsSchema.safeParse(decoded.value);
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const source = (await visibleSources(agent)).find((candidate) => (
+      candidate.id === sourceId && candidate.kind === 'local_profile'
+    ));
+    if (!source) return c.json({ error: 'not found' }, 404);
+    const upserted = await deps.batchUpsertService.upsertBatch(
+      agent.orgId,
+      sourceId,
+      agent.deviceId,
+      parsed.data.upserts,
+    );
+    const tombstoned = await deps.batchUpsertService.tombstonePaths(
+      agent.orgId,
+      sourceId,
+      agent.deviceId,
+      parsed.data.deletes,
+    );
+    return c.json({ ...upserted, tombstoned });
+  });
+
+  return app;
+}

--- a/ee/workspace/src/routes/content.test.ts
+++ b/ee/workspace/src/routes/content.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createContentRoutes, type ContentRouteDeps } from './content';
+import type { WorkspaceRouteEnv } from './adminGate';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const ORG_B = '99999999-9999-4999-8999-999999999999';
+
+/** Extract bound literals from a drizzle condition (mirrors credentialService.test.ts). */
+function boundValues(value: unknown): unknown[] {
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value') ? [candidate.value] : [];
+  return [...own, ...(candidate.queryChunks ?? []).flatMap(boundValues)];
+}
+
+/**
+ * In-memory drizzle-stub backing getOrgSettings/putOrgSettings, filtered by the
+ * orgId bound into the WHERE clause so two orgs can coexist in one process:
+ * select(...).from(...).where(eq(orgId)) resolves only that org's row(s);
+ * insert(...).values(...).onConflictDoUpdate(...) upserts by orgId so a
+ * PUT-then-GET in the same test observes the write.
+ */
+function fakeSettingsDb(initialRows: Record<string, unknown>[] = []) {
+  const rows = [...initialRows];
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async (condition: unknown) => {
+          const vals = boundValues(condition);
+          return rows.filter((r) => vals.includes(r.orgId));
+        }),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((row: Record<string, unknown>) => ({
+        onConflictDoUpdate: vi.fn(async ({ set }: { set: Record<string, unknown> }) => {
+          const idx = rows.findIndex((r) => r.orgId === row.orgId);
+          if (idx === -1) rows.push(row);
+          else rows[idx] = { ...rows[idx], ...set };
+        }),
+      })),
+    })),
+  };
+  return db as unknown as WorkspaceDatabase;
+}
+
+/** A settings db with content already enabled for the given orgs. */
+function enabledDb(...orgIds: string[]) {
+  return fakeSettingsDb(orgIds.map((orgId) => ({ orgId, contentEnabled: true, dlpConfig: {} })));
+}
+
+function makeApp(overrides: Partial<ContentRouteDeps> = {}, auth?: object | null) {
+  const ingest = {
+    run: vi.fn(async () => ({ processed: 2, remaining: 5, errors: [] })),
+    status: vi.fn(async () => ({
+      eligible: 10, extracted: 3, failed: 1, skippedTooLarge: 0, skippedBinary: 1, pending: 5,
+    })),
+  };
+  const deps: ContentRouteDeps = {
+    contentIngestService: ingest as unknown as ContentRouteDeps['contentIngestService'],
+    // Default to content-enabled for ORG_ID so the behavior suites exercise the
+    // live routes; gating/settings suites pass an explicit db.
+    db: enabledDb(ORG_ID),
+    audit: vi.fn(async () => {}),
+    log: vi.fn(),
+    ...overrides,
+  };
+  const app = new Hono<WorkspaceRouteEnv>();
+  app.use('*', async (c, next) => {
+    if (auth !== null) {
+      c.set('auth', (auth ?? {
+        user: { id: 'admin-1' }, scope: 'partner', accessibleOrgIds: [ORG_ID],
+      }) as WorkspaceRouteEnv['Variables']['auth']);
+    }
+    await next();
+  });
+  app.route('/', createContentRoutes(deps));
+  return { app, ingest, deps };
+}
+
+describe('content routes — per-org content flag gating', () => {
+  it('404s content routes when content is disabled for the org (auth resolved first)', async () => {
+    const { app, ingest } = makeApp({ db: fakeSettingsDb() }); // no row → disabled
+    for (const [method, path] of [
+      ['POST', `/content/ingest-run?orgId=${ORG_ID}`],
+      ['GET', `/content/status?orgId=${ORG_ID}`],
+    ] as const) {
+      const res = await app.request(path, { method });
+      expect(res.status, `${method} ${path}`).toBe(404);
+    }
+    expect(ingest.run).not.toHaveBeenCalled();
+  });
+
+  // Deliberate observable change (W2 Task 3): the flag gate now runs AFTER
+  // adminGate, so an unauthenticated probe hits auth before the feature 404.
+  it('rejects an unauthenticated probe at the admin gate, before the feature check', async () => {
+    const { app, ingest } = makeApp({ db: fakeSettingsDb() }, null); // no auth context at all
+    const res = await app.request(`/content/status?orgId=${ORG_ID}`);
+    expect(res.status).toBe(403);
+    expect(ingest.status).not.toHaveBeenCalled();
+  });
+
+  it('serves routes when content is enabled for the org', async () => {
+    const { app } = makeApp({ db: enabledDb(ORG_ID) });
+    const res = await app.request(`/content/status?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ pending: 5, extracted: 3 });
+  });
+
+  // The per-org property the env var could never express: enabled for A,
+  // disabled for B, one process, one db.
+  it('gates per org in the same process: A enabled → 200, B disabled → 404', async () => {
+    const { app, ingest } = makeApp({ db: enabledDb(ORG_ID) }, {
+      user: { id: 'admin-1' }, scope: 'system', accessibleOrgIds: null,
+    });
+    const a = await app.request(`/content/status?orgId=${ORG_ID}`);
+    expect(a.status).toBe(200);
+    const b = await app.request(`/content/status?orgId=${ORG_B}`);
+    expect(b.status).toBe(404);
+    expect(ingest.status).toHaveBeenCalledTimes(1);
+    expect(ingest.status).toHaveBeenCalledWith(ORG_ID);
+  });
+});
+
+describe('content routes — behavior (content enabled)', () => {
+  it('requires admin scope', async () => {
+    const { app } = makeApp({}, {
+      user: { id: 'u1' }, scope: 'organization', orgId: ORG_ID, accessibleOrgIds: [ORG_ID],
+    });
+    const res = await app.request(`/content/ingest-run?orgId=${ORG_ID}`, { method: 'POST' });
+    expect(res.status).toBe(403);
+  });
+
+  it('requires orgId', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/content/status');
+    expect(res.status).toBe(400);
+  });
+
+  it('runs an ingest batch and audits the run', async () => {
+    const { app, ingest, deps } = makeApp();
+    const res = await app.request(`/content/ingest-run?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ batch: 25 }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ processed: 2, remaining: 5, errors: [] });
+    expect(ingest.run).toHaveBeenCalledWith(ORG_ID, 25);
+    expect(deps.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.content.ingest_run',
+      orgId: ORG_ID,
+      result: 'success',
+    }));
+  });
+
+  it('defaults the batch size and rejects out-of-range/unknown fields', async () => {
+    const { app, ingest } = makeApp();
+    const ok = await app.request(`/content/ingest-run?orgId=${ORG_ID}`, { method: 'POST' });
+    expect(ok.status).toBe(200);
+    expect(ingest.run).toHaveBeenCalledWith(ORG_ID, 10);
+
+    const bad = await app.request(`/content/ingest-run?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ batch: 1000 }),
+    });
+    expect(bad.status).toBe(400);
+
+    const unknown = await app.request(`/content/ingest-run?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ batch: 5, nope: true }),
+    });
+    expect(unknown.status).toBe(400);
+  });
+
+  it('enrich-run answers 503 when no enrichment service is configured', async () => {
+    const { app } = makeApp();
+    const res = await app.request(`/content/enrich-run?orgId=${ORG_ID}`, { method: 'POST' });
+    expect(res.status).toBe(503);
+  });
+
+  it('enrich-run drives the enrichment service and audits', async () => {
+    const enrichment = { run: vi.fn(async () => ({ processed: 3, remaining: 1, errors: [] })) };
+    const { app, deps } = makeApp({
+      enrichmentService: enrichment as unknown as ContentRouteDeps['enrichmentService'],
+    });
+    const res = await app.request(`/content/enrich-run?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ batch: 3 }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ processed: 3, remaining: 1, errors: [] });
+    expect(enrichment.run).toHaveBeenCalledWith(ORG_ID, 3);
+    expect(deps.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.content.enrich_run',
+    }));
+  });
+
+  it('reports per-file errors in the response body', async () => {
+    const { app } = makeApp({
+      contentIngestService: {
+        run: vi.fn(async () => ({
+          processed: 1, remaining: 0,
+          errors: [{ fileIndexId: 'f1', relPath: 'a/b.md', error: 'smb read failed' }],
+        })),
+        status: vi.fn(),
+      } as unknown as ContentRouteDeps['contentIngestService'],
+    });
+    const res = await app.request(`/content/ingest-run?orgId=${ORG_ID}`, { method: 'POST' });
+    const body = await res.json();
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0].relPath).toBe('a/b.md');
+  });
+});
+
+describe('content routes — settings (exempt from the content flag gate)', () => {
+  it('GET returns defaults for an un-provisioned org even while content is disabled', async () => {
+    const { app } = makeApp({ db: fakeSettingsDb() });
+    const res = await app.request(`/content/settings?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contentEnabled).toBe(false);
+    expect(body.dlpConfig.detectors.ssn).toBe('redact');
+    expect(body.dlpConfig.customPatterns).toEqual([]);
+  });
+
+  it('PUT flips contentEnabled and round-trips through GET', async () => {
+    const db = fakeSettingsDb();
+    const { app } = makeApp({ db });
+
+    const putRes = await app.request(`/content/settings?orgId=${ORG_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ contentEnabled: true }),
+    });
+    expect(putRes.status).toBe(200);
+    expect((await putRes.json()).contentEnabled).toBe(true);
+
+    const getRes = await app.request(`/content/settings?orgId=${ORG_ID}`);
+    expect((await getRes.json()).contentEnabled).toBe(true);
+  });
+
+  it('normalizes an invalid detector action to the safe default', async () => {
+    const { app } = makeApp({ db: fakeSettingsDb() });
+    const res = await app.request(`/content/settings?orgId=${ORG_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ dlpConfig: { detectors: { ssn: 'nonsense' } } }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.dlpConfig.detectors.ssn).toBe('redact');
+  });
+
+  it('rejects unknown top-level keys', async () => {
+    const { app } = makeApp({ db: fakeSettingsDb() });
+    const res = await app.request(`/content/settings?orgId=${ORG_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ contentEnabled: true, nope: true }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('requires admin scope, same as the other content routes', async () => {
+    const { app } = makeApp({ db: fakeSettingsDb() }, {
+      user: { id: 'u1' }, scope: 'organization', orgId: ORG_ID, accessibleOrgIds: [ORG_ID],
+    });
+    const res = await app.request(`/content/settings?orgId=${ORG_ID}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('audits the settings update', async () => {
+    const { app, deps } = makeApp({ db: fakeSettingsDb() });
+    await app.request(`/content/settings?orgId=${ORG_ID}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ contentEnabled: true }),
+    });
+    expect(deps.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.content.settings_update',
+      orgId: ORG_ID,
+      result: 'success',
+    }));
+  });
+});

--- a/ee/workspace/src/routes/content.ts
+++ b/ee/workspace/src/routes/content.ts
@@ -1,0 +1,204 @@
+// Admin content routes (dev-preview). EVERYTHING here except /content/settings
+// 404s when content is disabled for the org — but only after adminGate has
+// resolved the org, so an unauthenticated probe hits auth first. /content/settings
+// is the switch itself and must work while content is disabled.
+// DLP runs at ingest, between extraction and persistence; see contentIngestService.
+import type { ExtensionLog, WorkspaceAudit, WorkspaceDatabase } from '../hostTypes';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { createContentIngestService } from '../services/contentIngestService';
+import type { createCrosswalkService } from '../services/crosswalkService';
+import type { createEnrichmentService } from '../services/enrichmentService';
+import { getOrgSettings, putOrgSettings, type DlpConfig } from '../services/orgSettingsService';
+import { adminGate, type WorkspaceRouteEnv } from './adminGate';
+
+export interface ContentRouteDeps {
+  contentIngestService: Pick<ReturnType<typeof createContentIngestService>, 'run' | 'status'>;
+  /** Absent when ANTHROPIC_API_KEY is not configured → enrich-run answers 503. */
+  enrichmentService?: Pick<ReturnType<typeof createEnrichmentService>, 'run'>;
+  crosswalkService?: Pick<ReturnType<typeof createCrosswalkService>, 'run'>;
+  /** Backs the org settings routes (getOrgSettings/putOrgSettings). */
+  db: WorkspaceDatabase;
+  audit: WorkspaceAudit;
+  log: ExtensionLog;
+}
+
+const ingestRunSchema = z.strictObject({
+  batch: z.number().int().min(1).max(100).default(10),
+});
+
+// Detector actions and custom-pattern actions are accepted as plain strings
+// here — orgSettingsService.normalizeDlp is the one place that validates
+// them against the known DlpAction set and collapses anything unrecognized
+// (e.g. a typo'd action) to the safe per-detector default. This schema only
+// enforces shape and rejects unknown keys.
+const putSettingsSchema = z.strictObject({
+  contentEnabled: z.boolean().optional(),
+  dlpConfig: z.strictObject({
+    detectors: z.record(z.string(), z.string()).optional(),
+    customPatterns: z.array(z.strictObject({
+      name: z.string(),
+      pattern: z.string(),
+      action: z.string(),
+    })).optional(),
+  }).optional(),
+});
+
+export function createContentRoutes(deps: ContentRouteDeps): Hono<WorkspaceRouteEnv> {
+  const routes = new Hono<WorkspaceRouteEnv>();
+
+  // adminGate first so the org is resolved (and unauthenticated probes hit
+  // auth) before the per-org content flag is consulted.
+  routes.use('/content/*', adminGate);
+  routes.use('/content/*', async (c, next) => {
+    // /content/settings is the switch that flips contentEnabled — it must stay
+    // reachable while content is disabled, so it is exempt from this gate.
+    if (c.req.path.endsWith('/content/settings')) return next();
+    const s = await getOrgSettings(deps.db, c.get('workspaceOrgId'));
+    if (!s.contentEnabled) return c.json({ error: 'not_found' }, 404);
+    await next();
+  });
+
+  routes.post('/content/ingest-run', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    const auth = c.get('auth');
+    let body: unknown = {};
+    try {
+      const raw = await c.req.text();
+      body = raw.trim().length > 0 ? JSON.parse(raw) : {};
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    const parsed = ingestRunSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid request', details: parsed.error.issues }, 400);
+    }
+    try {
+      const result = await deps.contentIngestService.run(orgId, parsed.data.batch);
+      await deps.audit({
+        actorType: 'user',
+        actorId: auth.user.id,
+        orgId,
+        action: 'workspace.content.ingest_run',
+        resourceType: 'workspace_source',
+        result: 'success',
+        details: {
+          processed: result.processed,
+          remaining: result.remaining,
+          errorCount: result.errors.length,
+        },
+      });
+      return c.json(result);
+    } catch (error) {
+      await deps.audit({
+        actorType: 'user',
+        actorId: auth.user.id,
+        orgId,
+        action: 'workspace.content.ingest_run',
+        resourceType: 'workspace_source',
+        result: 'failure',
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  });
+
+  routes.get('/content/status', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    return c.json(await deps.contentIngestService.status(orgId));
+  });
+
+  routes.post('/content/enrich-run', async (c) => {
+    if (!deps.enrichmentService) {
+      return c.json({ error: 'enrichment unavailable (no model credentials configured)' }, 503);
+    }
+    const orgId = c.get('workspaceOrgId');
+    const auth = c.get('auth');
+    let body: unknown = {};
+    try {
+      const raw = await c.req.text();
+      body = raw.trim().length > 0 ? JSON.parse(raw) : {};
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    const parsed = ingestRunSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid request', details: parsed.error.issues }, 400);
+    }
+    const result = await deps.enrichmentService.run(orgId, parsed.data.batch);
+    await deps.audit({
+      actorType: 'user',
+      actorId: auth.user.id,
+      orgId,
+      action: 'workspace.content.enrich_run',
+      resourceType: 'workspace_source',
+      result: 'success',
+      details: {
+        processed: result.processed,
+        remaining: result.remaining,
+        errorCount: result.errors.length,
+      },
+    });
+    return c.json(result);
+  });
+
+  routes.get('/content/settings', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    const settings = await getOrgSettings(deps.db, orgId);
+    return c.json(settings);
+  });
+
+  routes.put('/content/settings', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    const auth = c.get('auth');
+    let body: unknown = {};
+    try {
+      const raw = await c.req.text();
+      body = raw.trim().length > 0 ? JSON.parse(raw) : {};
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    const parsed = putSettingsSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid request', details: parsed.error.issues }, 400);
+    }
+    const settings = await putOrgSettings(deps.db, orgId, {
+      ...(parsed.data.contentEnabled !== undefined ? { contentEnabled: parsed.data.contentEnabled } : {}),
+      // Cast: the schema above validates shape only, not detector/action
+      // enum membership — putOrgSettings's normalizeDlp is the source of
+      // truth for that and safely defaults anything invalid.
+      ...(parsed.data.dlpConfig !== undefined
+        ? { dlpConfig: parsed.data.dlpConfig as unknown as DlpConfig }
+        : {}),
+    });
+    await deps.audit({
+      actorType: 'user',
+      actorId: auth.user.id,
+      orgId,
+      action: 'workspace.content.settings_update',
+      resourceType: 'workspace_org_settings',
+      result: 'success',
+      details: { contentEnabled: settings.contentEnabled },
+    });
+    return c.json(settings);
+  });
+
+  routes.post('/content/crosswalk-run', async (c) => {
+    if (!deps.crosswalkService) return c.json({ error: 'crosswalk unavailable' }, 503);
+    const orgId = c.get('workspaceOrgId');
+    const auth = c.get('auth');
+    const result = await deps.crosswalkService.run(orgId);
+    await deps.audit({
+      actorType: 'user',
+      actorId: auth.user.id,
+      orgId,
+      action: 'workspace.content.crosswalk_run',
+      resourceType: 'workspace_source',
+      result: 'success',
+      details: { mined: result.mined },
+    });
+    return c.json(result);
+  });
+
+  return routes;
+}

--- a/ee/workspace/src/routes/deviceSummary.test.ts
+++ b/ee/workspace/src/routes/deviceSummary.test.ts
@@ -1,0 +1,200 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceAuthContext, WorkspaceRouteEnv } from './adminGate';
+import { createDeviceSummaryRoutes } from './deviceSummary';
+import type { DeviceSummary } from '../services/deviceSummaryService';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+
+function auth(overrides: Partial<WorkspaceAuthContext> = {}): WorkspaceAuthContext {
+  return {
+    user: { id: USER_ID },
+    scope: 'system',
+    accessibleOrgIds: null,
+    ...overrides,
+  };
+}
+
+function summary(overrides: Partial<DeviceSummary> = {}): DeviceSummary {
+  return {
+    deviceId: DEVICE_ID,
+    indexedFiles: 7,
+    visibleSources: 2,
+    lastSuccessfulCrawlAt: new Date('2026-07-12T10:00:00.000Z'),
+    lastActivityAt: new Date('2026-07-12T11:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function harness(authContext: WorkspaceAuthContext = auth()) {
+  const summarize = vi.fn(async (_orgId: string, _deviceId: string) => summary() as DeviceSummary | null);
+  const deviceSummaryService = { summarize };
+  const app = new Hono<WorkspaceRouteEnv>();
+  app.use('*', async (c, next) => {
+    c.set('auth', authContext);
+    await next();
+  });
+  app.route('/', createDeviceSummaryRoutes({ deviceSummaryService }));
+  return { app, summarize };
+}
+
+function url(orgId: string | null = ORG_ID, deviceId = DEVICE_ID): string {
+  const query = orgId === null ? '' : `?orgId=${orgId}`;
+  return `/devices/${deviceId}/summary${query}`;
+}
+
+describe('device summary route', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns the aggregate summary for an admin of the requested org', async () => {
+    const h = harness();
+    const res = await h.app.request(url());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      deviceId: DEVICE_ID,
+      indexedFiles: 7,
+      visibleSources: 2,
+      lastSuccessfulCrawlAt: '2026-07-12T10:00:00.000Z',
+      lastActivityAt: '2026-07-12T11:00:00.000Z',
+    });
+    expect(h.summarize).toHaveBeenCalledWith(ORG_ID, DEVICE_ID);
+  });
+
+  // Disclosure boundary: the response body carries aggregates only. If the
+  // handler ever spreads a service row instead of projecting these five
+  // fields, this fails.
+  it('returns exactly the five aggregate fields and no indexed detail', async () => {
+    const h = harness();
+    h.summarize.mockResolvedValue({
+      ...summary(),
+      // Fields a future service change might start returning; none may escape.
+      ...({
+        relPath: 'Finance/2026/payroll.xlsx',
+        errorReason: 'SMB mount denied for \\\\fileserver\\payroll',
+        statusDetail: 'auth failure',
+        credentialEnc: 'ciphertext',
+      } as unknown as Partial<DeviceSummary>),
+    });
+    const res = await h.app.request(url());
+    const body = await res.json() as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual([
+      'deviceId', 'indexedFiles', 'lastActivityAt', 'lastSuccessfulCrawlAt', 'visibleSources',
+    ]);
+    const serialized = JSON.stringify(body);
+    for (const leak of ['payroll', 'fileserver', 'relPath', 'errorReason', 'statusDetail', 'ciphertext']) {
+      expect(serialized).not.toContain(leak);
+    }
+  });
+
+  it('reports zero rows as zeros and null timestamps, not an error', async () => {
+    const h = harness();
+    h.summarize.mockResolvedValue(summary({
+      indexedFiles: 0,
+      visibleSources: 0,
+      lastSuccessfulCrawlAt: null,
+      lastActivityAt: null,
+    }));
+    const res = await h.app.request(url());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      deviceId: DEVICE_ID,
+      indexedFiles: 0,
+      visibleSources: 0,
+      lastSuccessfulCrawlAt: null,
+      lastActivityAt: null,
+    });
+  });
+
+  it('requires orgId', async () => {
+    const h = harness();
+    const res = await h.app.request(url(null));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'orgId is required' });
+    expect(h.summarize).not.toHaveBeenCalled();
+  });
+
+  it('rejects organization-scope callers', async () => {
+    const h = harness(auth({ scope: 'organization', accessibleOrgIds: [ORG_ID] }));
+    const res = await h.app.request(url());
+    expect(res.status).toBe(403);
+    expect(h.summarize).not.toHaveBeenCalled();
+  });
+
+  it('allows a partner admin for an org inside accessibleOrgIds', async () => {
+    const h = harness(auth({ scope: 'partner', accessibleOrgIds: [ORG_ID] }));
+    const res = await h.app.request(url());
+    expect(res.status).toBe(200);
+    expect(h.summarize).toHaveBeenCalledWith(ORG_ID, DEVICE_ID);
+  });
+
+  it('rejects a partner admin for an org outside accessibleOrgIds', async () => {
+    const h = harness(auth({ scope: 'partner', accessibleOrgIds: [OTHER_ORG_ID] }));
+    const res = await h.app.request(url());
+    expect(res.status).toBe(403);
+    expect(h.summarize).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for a partner admin carrying a null accessibleOrgIds', async () => {
+    const h = harness(auth({ scope: 'partner', accessibleOrgIds: null }));
+    const res = await h.app.request(url());
+    expect(res.status).toBe(403);
+    expect(h.summarize).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthenticated caller', async () => {
+    const app = new Hono<WorkspaceRouteEnv>();
+    const summarize = vi.fn(async () => summary() as DeviceSummary | null);
+    app.route('/', createDeviceSummaryRoutes({ deviceSummaryService: { summarize } }));
+    const res = await app.request(url());
+    expect(res.status).toBe(403);
+    expect(summarize).not.toHaveBeenCalled();
+  });
+
+  // No existence oracle: a device in another org and a device that does not
+  // exist must be byte-identical responses.
+  it('answers a device/org mismatch and an unknown device identically', async () => {
+    const h = harness();
+    h.summarize.mockResolvedValue(null);
+    const mismatch = await h.app.request(url(ORG_ID, DEVICE_ID));
+    const unknown = await h.app.request(url(ORG_ID, '99999999-9999-4999-8999-999999999999'));
+    expect(mismatch.status).toBe(404);
+    expect(unknown.status).toBe(404);
+    expect(await mismatch.text()).toEqual(await unknown.text());
+  });
+
+  it('answers a malformed device id as the same 404 without touching the service', async () => {
+    const h = harness();
+    h.summarize.mockResolvedValue(null);
+    const known = await h.app.request(url(ORG_ID, DEVICE_ID));
+    const knownBody = await known.text();
+    const malformed = await h.app.request(url(ORG_ID, 'not-a-uuid'));
+    expect(malformed.status).toBe(404);
+    expect(await malformed.text()).toEqual(knownBody);
+    // Only the well-formed id reached the service; a malformed uuid must never
+    // reach a uuid-typed column and surface as a 500.
+    expect(h.summarize).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the gated orgId, never a caller-supplied body or header org', async () => {
+    const h = harness(auth({ scope: 'partner', accessibleOrgIds: [ORG_ID] }));
+    const res = await h.app.request(`${url()}&orgId=${OTHER_ORG_ID}`);
+    // Hono returns the first value for a repeated query key; the gate and the
+    // service must agree on it, and it must be the one that passed the gate.
+    expect(res.status).toBe(200);
+    expect(h.summarize).toHaveBeenCalledWith(ORG_ID, DEVICE_ID);
+  });
+
+  // The handler must query with the value the gate authorized, not with the
+  // raw query string. adminGate normalizes (trims) the orgId, so re-reading
+  // c.req.query('orgId') here would query with a different value than the one
+  // that passed authorization.
+  it('queries with the gate-normalized orgId, not the raw query value', async () => {
+    const h = harness(auth({ scope: 'partner', accessibleOrgIds: [ORG_ID] }));
+    const res = await h.app.request(`/devices/${DEVICE_ID}/summary?orgId=%20${ORG_ID}%20`);
+    expect(res.status).toBe(200);
+    expect(h.summarize).toHaveBeenCalledWith(ORG_ID, DEVICE_ID);
+  });
+});

--- a/ee/workspace/src/routes/deviceSummary.ts
+++ b/ee/workspace/src/routes/deviceSummary.ts
@@ -1,0 +1,51 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { createDeviceSummaryService } from '../services/deviceSummaryService';
+import { adminGate, type WorkspaceRouteEnv } from './adminGate';
+
+type DeviceSummaryService = Pick<
+  ReturnType<typeof createDeviceSummaryService>,
+  'summarize'
+>;
+
+export interface DeviceSummaryRouteDeps {
+  deviceSummaryService: DeviceSummaryService;
+}
+
+// One body for "unknown device" and "device in another org". Keeping them
+// byte-identical is what stops this endpoint from being an existence oracle
+// for devices the caller cannot see.
+const NOT_FOUND_BODY = { error: 'Device not found' } as const;
+
+export function createDeviceSummaryRoutes(deps: DeviceSummaryRouteDeps): Hono<WorkspaceRouteEnv> {
+  const app = new Hono<WorkspaceRouteEnv>();
+  // Org-admin authz plus the orgId the rest of the handler is scoped to.
+  // adminGate fails closed for partner scope without an explicit
+  // accessibleOrgIds array.
+  app.use('*', adminGate);
+
+  app.get('/devices/:deviceId/summary', async (c) => {
+    const deviceId = c.req.param('deviceId');
+    // Pre-validate before the id reaches a uuid-typed column: a malformed id
+    // must be the contract 404, not a Postgres 22P02 surfacing as a 500.
+    if (!z.uuid().safeParse(deviceId).success) return c.json(NOT_FOUND_BODY, 404);
+
+    // The org comes from the gate, never straight from the request: the value
+    // the handler queries with must be the value that was authorized.
+    const summary = await deps.deviceSummaryService.summarize(c.get('workspaceOrgId'), deviceId);
+    if (!summary) return c.json(NOT_FOUND_BODY, 404);
+
+    // Explicit aggregate-only projection. Never widen this to a spread of the
+    // service row — indexed paths, file names, credential state and crawl
+    // error detail must not cross this boundary.
+    return c.json({
+      deviceId: summary.deviceId,
+      indexedFiles: summary.indexedFiles,
+      visibleSources: summary.visibleSources,
+      lastSuccessfulCrawlAt: summary.lastSuccessfulCrawlAt,
+      lastActivityAt: summary.lastActivityAt,
+    });
+  });
+
+  return app;
+}

--- a/ee/workspace/src/routes/gunzip.ts
+++ b/ee/workspace/src/routes/gunzip.ts
@@ -1,0 +1,33 @@
+import { gunzipSync } from 'node:zlib';
+
+export const MAX_DECODED_BODY_BYTES = 4 * 1024 * 1024;
+
+export class DecodedBodyTooLargeError extends Error {
+  constructor() {
+    super('Decoded request body exceeds the limit');
+    this.name = 'DecodedBodyTooLargeError';
+  }
+}
+
+export async function readDecodedBody(request: Request): Promise<string> {
+  const encoded = Buffer.from(await request.arrayBuffer());
+  const isGzip = request.headers.get('content-encoding')?.toLowerCase().includes('gzip') ?? false;
+
+  if (!isGzip) {
+    if (encoded.byteLength > MAX_DECODED_BODY_BYTES) throw new DecodedBodyTooLargeError();
+    return encoded.toString('utf8');
+  }
+
+  try {
+    return gunzipSync(encoded, { maxOutputLength: MAX_DECODED_BODY_BYTES }).toString('utf8');
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      error.code === 'ERR_BUFFER_TOO_LARGE'
+    ) {
+      throw new DecodedBodyTooLargeError();
+    }
+    throw error;
+  }
+}

--- a/ee/workspace/src/routes/helper.test.ts
+++ b/ee/workspace/src/routes/helper.test.ts
@@ -1,0 +1,776 @@
+import { Hono } from 'hono';
+import type { ExtensionAuditEvent, ExtensionHelperDevice } from '../hostTypes';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHelperRoutes, type WorkspaceHelperRouteEnv } from './helper';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const ORG_B = '88888888-8888-4888-8888-888888888888';
+const SOURCE_ID = '22222222-2222-4222-8222-222222222222';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+const DEVICE_B_ID = '55555555-5555-4555-8555-555555555555';
+const FILE_ID = '77777777-7777-4777-8777-777777777777';
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
+const helperDevice: ExtensionHelperDevice = {
+  id: DEVICE_ID,
+  agentId: 'agent-1',
+  orgId: ORG_ID,
+  siteId: '66666666-6666-4666-8666-666666666666',
+  hostname: 'FRONT-DESK-01',
+  osType: 'windows',
+  osVersion: '11',
+  agentVersion: '1.0.0',
+};
+
+const deviceOrgB: ExtensionHelperDevice = { ...helperDevice, id: DEVICE_B_ID, orgId: ORG_B };
+
+function visibleSource(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SOURCE_ID,
+    displayName: 'Alder Creek (dev)',
+    kind: 'smb_share' as const,
+    rootPath: '\\\\srv\\alder',
+    ...overrides,
+  };
+}
+
+function file(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FILE_ID,
+    sourceId: SOURCE_ID,
+    deviceKey: ZERO_UUID,
+    relPath: 'clients/henderson/report.pdf',
+    parentPath: 'clients/henderson',
+    name: 'report.pdf',
+    isDir: false,
+    ext: 'pdf',
+    size: 1024,
+    mtime: '2026-07-12T10:00:00.000Z',
+    openPath: '\\\\srv\\alder\\clients\\henderson\\report.pdf',
+    ...overrides,
+  };
+}
+
+function contentServices() {
+  return {
+    search: vi.fn(async () => [{
+      ...file(),
+      snippet: '…<b>Henderson</b> easement…',
+      inferredDocType: 'easement deed',
+      inferredProjectKey: '2023-041',
+      inferredProjectLabel: 'Henderson Water Main Replacement',
+      declaredProjectKey: '2024-007',
+      declaredProjectLabel: 'Vine Hill Winery Site Plan',
+      metadataDisagreement: true,
+      group: 'document' as const,
+      matchedEntities: [],
+    }]),
+    passages: vi.fn(async () => [{
+      fileIndexId: FILE_ID,
+      relPath: 'clients/henderson/report.pdf',
+      sourceId: SOURCE_ID,
+      openPath: '\\\\srv\\alder\\clients\\henderson\\report.pdf',
+      snippet: 'GRANT OF EASEMENT for the Henderson Road project.',
+      score: 0.042,
+    }]),
+  };
+}
+
+/**
+ * `contentEnabled` seeds the injected per-org content flag (Task 3, replacing
+ * the WORKSPACE_CONTENT_PREVIEW env var). Default off — the finder base surface
+ * must work while content is disabled.
+ */
+function makeHarness(options: { contentSearch?: boolean; contentEnabled?: boolean } = {}) {
+  const fileQueryService = {
+    visibleSources: vi.fn(async () => [visibleSource()]),
+    search: vi.fn(async () => [file()]),
+    browse: vi.fn(async () => [file()]),
+  };
+  const contentSearchService = options.contentSearch === false ? undefined : contentServices();
+  const activityService = {
+    record: vi.fn(async (): Promise<{ recorded: true } | { notFound: true }> => (
+      { recorded: true }
+    )),
+    recents: vi.fn(async () => [file()]),
+    departmentRecent: vi.fn(async () => [
+      { ...file(), lastActivityAt: '2026-07-13T09:00:00.000Z' },
+    ]),
+  };
+  const getSettings = vi.fn(async (_orgId: string) => ({ contentEnabled: options.contentEnabled ?? false }));
+  const audit = vi.fn(async (_event: ExtensionAuditEvent) => {});
+  const log = vi.fn();
+  const app = new Hono<WorkspaceHelperRouteEnv>();
+  // Fake of the injected core helper auth middleware: 401 without a bearer
+  // token, otherwise sets the helperDevice context like the real one.
+  app.use('*', async (c, next) => {
+    if (!c.req.header('authorization')) {
+      return c.json({ error: 'Missing or invalid Authorization header' }, 401);
+    }
+    c.set('helperDevice', helperDevice);
+    await next();
+  });
+  app.route('/', createHelperRoutes({
+    fileQueryService, activityService, contentSearchService, getSettings, audit, log,
+  }));
+  return { app, fileQueryService, activityService, contentSearchService, getSettings, audit, log };
+}
+
+const authed = { headers: { authorization: 'Bearer brz_helper-token' } };
+
+function postActivity(body: unknown) {
+  return {
+    method: 'POST',
+    headers: { authorization: 'Bearer brz_helper-token', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('workspace helper routes', () => {
+  describe('authentication', () => {
+    it('rejects every helper path without the auth context, capabilities included', async () => {
+      const { app, fileQueryService, activityService } = makeHarness();
+      const paths: Array<[string, RequestInit | undefined]> = [
+        ['/capabilities', undefined],
+        ['/sources', undefined],
+        ['/search?q=henderson', undefined],
+        [`/browse?sourceId=${SOURCE_ID}`, undefined],
+        ['/recents', undefined],
+        ['/activity', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ fileIndexId: FILE_ID, action: 'open' }),
+        }],
+      ];
+      for (const [path, init] of paths) {
+        const res = await app.request(path, init);
+        expect(res.status, path).toBe(401);
+      }
+      expect(fileQueryService.search).not.toHaveBeenCalled();
+      expect(fileQueryService.browse).not.toHaveBeenCalled();
+      expect(activityService.record).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /capabilities', () => {
+    it('reports the finder feature set', async () => {
+      const { app } = makeHarness();
+      const res = await app.request('/capabilities', authed);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        ok: true,
+        features: ['search', 'browse', 'recents', 'open'],
+      });
+    });
+  });
+
+  describe('GET /sources', () => {
+    it('lists visible sources without leaking rootPath', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request('/sources', authed);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        sources: [{ id: SOURCE_ID, displayName: 'Alder Creek (dev)', kind: 'smb_share' }],
+      });
+      expect(fileQueryService.visibleSources).toHaveBeenCalledWith(ORG_ID, []);
+    });
+  });
+
+  describe('GET /search', () => {
+    it('passes the caller identity and all filters to the query service', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request(
+        `/search?q=henderson&sourceId=${SOURCE_ID}&ext=pdf` +
+        '&modifiedAfter=2026-01-01T00:00:00.000Z&modifiedBefore=2026-07-01T00:00:00.000Z&limit=5',
+        authed,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ results: [file()] });
+      expect(fileQueryService.search).toHaveBeenCalledWith(ORG_ID, DEVICE_ID, {
+        q: 'henderson',
+        sourceId: SOURCE_ID,
+        ext: 'pdf',
+        modifiedAfter: '2026-01-01T00:00:00.000Z',
+        modifiedBefore: '2026-07-01T00:00:00.000Z',
+        limit: 5,
+      }, []);
+    });
+
+    it('searches with only q', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request('/search?q=x', authed);
+      expect(res.status).toBe(200);
+      expect(fileQueryService.search).toHaveBeenCalledWith(ORG_ID, DEVICE_ID, { q: 'x' }, []);
+    });
+
+    it('rejects a missing q with 400', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request('/search', authed);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'invalid request' });
+      expect(fileQueryService.search).not.toHaveBeenCalled();
+    });
+
+    it('rejects an oversized q with 400', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request(`/search?q=${'a'.repeat(201)}`, authed);
+      expect(res.status).toBe(400);
+      expect(fileQueryService.search).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-numeric limit with 400', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request('/search?q=x&limit=abc', authed);
+      expect(res.status).toBe(400);
+      expect(fileQueryService.search).not.toHaveBeenCalled();
+    });
+
+    it('uses the legacy path when content is disabled, even with the service wired', async () => {
+      const { app, fileQueryService, contentSearchService } = makeHarness();
+      const res = await app.request('/search?q=x', authed);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ results: [file()] });
+      expect(fileQueryService.search).toHaveBeenCalled();
+      expect(contentSearchService?.search).not.toHaveBeenCalled();
+    });
+
+    it('uses the hybrid path when content is enabled for the org', async () => {
+      const { app, fileQueryService, contentSearchService } = makeHarness({ contentEnabled: true });
+      const res = await app.request('/search?q=Henderson easement', authed);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results[0]).toMatchObject({
+        inferredDocType: 'easement deed',
+        metadataDisagreement: true,
+        group: 'document',
+      });
+      expect(contentSearchService?.search).toHaveBeenCalledWith(
+        ORG_ID, DEVICE_ID, expect.objectContaining({ q: 'Henderson easement' }), [],
+      );
+      expect(fileQueryService.search).not.toHaveBeenCalled();
+    });
+
+    it('falls back to legacy when no content service is wired, content flag regardless', async () => {
+      const { app, fileQueryService } = makeHarness({ contentSearch: false, contentEnabled: true });
+      const res = await app.request('/search?q=x', authed);
+      expect(res.status).toBe(200);
+      expect(fileQueryService.search).toHaveBeenCalled();
+    });
+
+    it('accepts project/docType filters and forwards them to the hybrid search service', async () => {
+      const { app, contentSearchService } = makeHarness({ contentEnabled: true });
+      const res = await app.request(
+        '/search?q=henderson&project=Henderson%20Water%20Main%20Replacement&docType=easement',
+        authed,
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results.every((r: { inferredDocType: string }) => r.inferredDocType === 'easement deed'))
+        .toBe(true);
+      expect(contentSearchService?.search).toHaveBeenCalledWith(ORG_ID, DEVICE_ID, {
+        q: 'henderson',
+        project: 'Henderson Water Main Replacement',
+        docType: 'easement',
+      }, []);
+    });
+
+    it('accepts project/docType filters on the legacy path too', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request('/search?q=x&docType=easement', authed);
+      expect(res.status).toBe(200);
+      expect(fileQueryService.search).toHaveBeenCalledWith(ORG_ID, DEVICE_ID, {
+        q: 'x', docType: 'easement',
+      }, []);
+    });
+  });
+
+  describe('filing routes (dev-preview gating)', () => {
+    const FILING = {
+      fileIndexId: FILE_ID, relPath: 'Emails/Unfiled/x.eml', name: 'x.eml', emailMeta: null,
+      status: 'suggested', suggestedProjectKey: '2023-041',
+      suggestedProjectLabel: 'Henderson Water Main Replacement',
+      matchedEntityType: 'po', matchedEntityValue: 'PO 4021', confidence: 'high',
+      rationale: 'matched City of Fairoaks PO #4021', decidedProjectKey: null,
+    };
+    const filingService = {
+      list: vi.fn(async () => [FILING]),
+      classify: vi.fn(async () => FILING),
+      assign: vi.fn(async () => ({ ...FILING, status: 'reassigned', decidedProjectKey: '2025-012' })),
+      projects: vi.fn(async () => [{ key: '2023-041', label: 'Henderson Water Main Replacement' }]),
+    };
+
+    function makeFilingApp(contentEnabled = false) {
+      const base = makeHarness();
+      const app = new Hono<WorkspaceHelperRouteEnv>();
+      app.use('*', async (c, next) => {
+        if (!c.req.header('authorization')) return c.json({ error: 'unauthorized' }, 401);
+        c.set('helperDevice', helperDevice);
+        await next();
+      });
+      app.route('/', createHelperRoutes({
+        fileQueryService: base.fileQueryService,
+        activityService: base.activityService,
+        contentSearchService: base.contentSearchService,
+        filingService: filingService as never,
+        getSettings: vi.fn(async (_orgId: string) => ({ contentEnabled })),
+        audit: base.audit,
+        log: base.log,
+      }));
+      return app;
+    }
+
+    it('404s every filing route when content is disabled', async () => {
+      const app = makeFilingApp();
+      for (const [method, path, body] of [
+        ['GET', '/filing', undefined],
+        ['GET', '/content/projects', undefined],
+        ['POST', '/filing/classify', { fileIndexId: FILE_ID }],
+        ['POST', `/filing/${FILE_ID}/assign`, { projectKey: '2023-041' }],
+      ] as const) {
+        const res = await app.request(path, {
+          method,
+          headers: { authorization: 'Bearer t', 'content-type': 'application/json' },
+          ...(body ? { body: JSON.stringify(body) } : {}),
+        });
+        expect(res.status, `${method} ${path}`).toBe(404);
+      }
+      expect(filingService.classify).not.toHaveBeenCalled();
+    });
+
+    it('serves list/classify/assign/projects when content is enabled', async () => {
+      const app = makeFilingApp(true);
+      const list = await app.request('/filing', authed);
+      expect(list.status).toBe(200);
+      expect((await list.json()).filings[0].rationale).toBe('matched City of Fairoaks PO #4021');
+
+      const classify = await app.request('/filing/classify', {
+        method: 'POST',
+        headers: { authorization: 'Bearer t', 'content-type': 'application/json' },
+        body: JSON.stringify({ fileIndexId: FILE_ID }),
+      });
+      expect(classify.status).toBe(200);
+      expect(filingService.classify).toHaveBeenCalledWith(ORG_ID, FILE_ID, []);
+
+      const assign = await app.request(`/filing/${FILE_ID}/assign`, {
+        method: 'POST',
+        headers: { authorization: 'Bearer t', 'content-type': 'application/json' },
+        body: JSON.stringify({ projectKey: '2025-012', helperUser: 'Front desk' }),
+      });
+      expect(assign.status).toBe(200);
+      expect(filingService.assign).toHaveBeenCalledWith(ORG_ID, FILE_ID, '2025-012', 'Front desk', []);
+
+      const projects = await app.request('/content/projects', authed);
+      expect((await projects.json()).projects).toHaveLength(1);
+    });
+
+    it('rejects malformed classify/assign requests', async () => {
+      const app = makeFilingApp(true);
+      const nonUuid = await app.request('/filing/classify', {
+        method: 'POST',
+        headers: { authorization: 'Bearer t', 'content-type': 'application/json' },
+        body: JSON.stringify({ fileIndexId: 'not-a-uuid' }),
+      });
+      expect(nonUuid.status).toBe(404);
+      const extraField = await app.request(`/filing/${FILE_ID}/assign`, {
+        method: 'POST',
+        headers: { authorization: 'Bearer t', 'content-type': 'application/json' },
+        body: JSON.stringify({ projectKey: 'x', nope: 1 }),
+      });
+      expect(extraField.status).toBe(400);
+    });
+
+    it('capabilities reports filing features when the service is wired', async () => {
+      const app = makeFilingApp(true);
+      const res = await app.request('/content/capabilities', authed);
+      expect(await res.json()).toEqual({
+        enabled: true, features: ['contentSearch', 'filing', 'projects'],
+      });
+    });
+  });
+
+  describe('GET /content/passages', () => {
+    it('404s when content is disabled for the org', async () => {
+      const { app, contentSearchService } = makeHarness();
+      const res = await app.request('/content/passages?q=easement', authed);
+      expect(res.status).toBe(404);
+      expect(contentSearchService?.passages).not.toHaveBeenCalled();
+    });
+
+    it('404s when content is enabled but no content service is wired', async () => {
+      const { app } = makeHarness({ contentSearch: false, contentEnabled: true });
+      const res = await app.request('/content/passages?q=easement', authed);
+      expect(res.status).toBe(404);
+    });
+
+    it('requires helper auth', async () => {
+      const { app } = makeHarness({ contentEnabled: true });
+      const res = await app.request('/content/passages?q=easement');
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a missing q with 400', async () => {
+      const { app, contentSearchService } = makeHarness({ contentEnabled: true });
+      const res = await app.request('/content/passages', authed);
+      expect(res.status).toBe(400);
+      expect(contentSearchService?.passages).not.toHaveBeenCalled();
+    });
+
+    it('returns visibility-scoped passages and forwards the caller identity', async () => {
+      const { app, contentSearchService } = makeHarness({ contentEnabled: true });
+      const res = await app.request('/content/passages?q=Henderson easement', authed);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.passages[0]).toEqual({
+        fileIndexId: FILE_ID,
+        relPath: 'clients/henderson/report.pdf',
+        sourceId: SOURCE_ID,
+        openPath: '\\\\srv\\alder\\clients\\henderson\\report.pdf',
+        snippet: 'GRANT OF EASEMENT for the Henderson Road project.',
+        score: 0.042,
+      });
+      expect(contentSearchService?.passages).toHaveBeenCalledWith(
+        ORG_ID, 'Henderson easement', { helperDeviceId: DEVICE_ID }, [],
+      );
+    });
+
+    it('forwards fileIndexId and limit when provided', async () => {
+      const { app, contentSearchService } = makeHarness({ contentEnabled: true });
+      const res = await app.request(
+        `/content/passages?q=easement&fileIndexId=${FILE_ID}&limit=3`, authed,
+      );
+      expect(res.status).toBe(200);
+      expect(contentSearchService?.passages).toHaveBeenCalledWith(
+        ORG_ID, 'easement', { helperDeviceId: DEVICE_ID, fileIndexId: FILE_ID, limit: 3 }, [],
+      );
+    });
+
+    it('404s a malformed fileIndexId before the service runs', async () => {
+      const { app, contentSearchService } = makeHarness({ contentEnabled: true });
+      const res = await app.request('/content/passages?q=easement&fileIndexId=not-a-uuid', authed);
+      expect(res.status).toBe(404);
+      expect(contentSearchService?.passages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /content/capabilities', () => {
+    it('404s when content is disabled for the org', async () => {
+      const { app } = makeHarness();
+      const res = await app.request('/content/capabilities', authed);
+      expect(res.status).toBe(404);
+    });
+
+    it('404s when content is enabled but no service is wired', async () => {
+      const { app } = makeHarness({ contentSearch: false, contentEnabled: true });
+      const res = await app.request('/content/capabilities', authed);
+      expect(res.status).toBe(404);
+    });
+
+    it('reports content features when enabled', async () => {
+      const { app } = makeHarness({ contentEnabled: true });
+      const res = await app.request('/content/capabilities', authed);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ enabled: true, features: ['contentSearch'] });
+    });
+
+    it('requires helper auth', async () => {
+      const { app } = makeHarness({ contentEnabled: true });
+      const res = await app.request('/content/capabilities');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // The per-org property the WORKSPACE_CONTENT_PREVIEW env var could never
+  // express: org A enabled, org B disabled, one process, one route tree —
+  // driven entirely by the injected getSettings(orgId).
+  describe('per-org content flag (A enabled, B disabled, same process)', () => {
+    const filingService = {
+      list: vi.fn(async () => []),
+      classify: vi.fn(async () => null),
+      assign: vi.fn(async () => null),
+      projects: vi.fn(async () => []),
+    };
+
+    function makePerOrgApp() {
+      const base = makeHarness();
+      const getSettings = vi.fn(async (orgId: string) => ({ contentEnabled: orgId === ORG_ID }));
+      const app = new Hono<WorkspaceHelperRouteEnv>();
+      app.use('*', async (c, next) => {
+        if (!c.req.header('authorization')) return c.json({ error: 'unauthorized' }, 401);
+        c.set('helperDevice', c.req.header('x-org') === 'B' ? deviceOrgB : helperDevice);
+        await next();
+      });
+      app.route('/', createHelperRoutes({
+        fileQueryService: base.fileQueryService,
+        activityService: base.activityService,
+        contentSearchService: base.contentSearchService,
+        filingService: filingService as never,
+        getSettings,
+        audit: base.audit,
+        log: base.log,
+      }));
+      return { app, base };
+    }
+
+    const asA = authed;
+    const asB = { headers: { authorization: 'Bearer brz_helper-token', 'x-org': 'B' } };
+
+    it('/search: A takes the hybrid path, B takes the legacy path', async () => {
+      const { app, base } = makePerOrgApp();
+      const a = await app.request('/search?q=easement', asA);
+      expect(a.status).toBe(200);
+      expect(base.contentSearchService?.search).toHaveBeenCalledWith(
+        ORG_ID, DEVICE_ID, expect.objectContaining({ q: 'easement' }), [],
+      );
+
+      const b = await app.request('/search?q=easement', asB);
+      expect(b.status).toBe(200);
+      expect(base.fileQueryService.search).toHaveBeenCalledWith(
+        ORG_B, DEVICE_B_ID, expect.objectContaining({ q: 'easement' }), [],
+      );
+      // B never reached the content service.
+      expect(base.contentSearchService?.search).toHaveBeenCalledTimes(1);
+    });
+
+    it('/content/capabilities: 200 for A, 404 for B', async () => {
+      const { app } = makePerOrgApp();
+      expect((await app.request('/content/capabilities', asA)).status).toBe(200);
+      expect((await app.request('/content/capabilities', asB)).status).toBe(404);
+    });
+
+    it('/content/passages: served for A, 404 for B', async () => {
+      const { app, base } = makePerOrgApp();
+      expect((await app.request('/content/passages?q=easement', asA)).status).toBe(200);
+      const b = await app.request('/content/passages?q=easement', asB);
+      expect(b.status).toBe(404);
+      expect(base.contentSearchService?.passages).toHaveBeenCalledTimes(1);
+    });
+
+    it('filing: served for A, 404 for B', async () => {
+      const { app } = makePerOrgApp();
+      expect((await app.request('/filing', asA)).status).toBe(200);
+      const b = await app.request('/filing', asB);
+      expect(b.status).toBe(404);
+      expect(filingService.list).toHaveBeenCalledTimes(1);
+      expect(filingService.list).toHaveBeenCalledWith(ORG_ID, []);
+    });
+  });
+
+  describe('GET /browse', () => {
+    it('lists entries at the source root by default', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request(`/browse?sourceId=${SOURCE_ID}`, authed);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ entries: [file()] });
+      expect(fileQueryService.browse).toHaveBeenCalledWith(ORG_ID, DEVICE_ID, SOURCE_ID, '', {}, []);
+    });
+
+    it('passes parentPath through', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request(
+        `/browse?sourceId=${SOURCE_ID}&parentPath=${encodeURIComponent('clients/henderson')}`,
+        authed,
+      );
+      expect(res.status).toBe(200);
+      expect(fileQueryService.browse).toHaveBeenCalledWith(
+        ORG_ID, DEVICE_ID, SOURCE_ID, 'clients/henderson', {}, [],
+      );
+    });
+
+    it('accepts project/docType filters and forwards them to fileQueryService.browse', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request(
+        `/browse?sourceId=${SOURCE_ID}` +
+        `&project=${encodeURIComponent('Henderson Water Main Replacement')}&docType=easement`,
+        authed,
+      );
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ entries: [file()] });
+      expect(fileQueryService.browse).toHaveBeenCalledWith(
+        ORG_ID, DEVICE_ID, SOURCE_ID, '',
+        { project: 'Henderson Water Main Replacement', docType: 'easement' }, [],
+      );
+    });
+
+    it('answers 404 for an unknown-or-hidden source without touching the index', async () => {
+      const { app, fileQueryService } = makeHarness();
+      fileQueryService.visibleSources.mockResolvedValueOnce([]);
+      const res = await app.request(`/browse?sourceId=${SOURCE_ID}`, authed);
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'not found' });
+      expect(fileQueryService.browse).not.toHaveBeenCalled();
+    });
+
+    it('answers 404 for a malformed sourceId before any query runs', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request('/browse?sourceId=not-a-uuid', authed);
+      expect(res.status).toBe(404);
+      expect(fileQueryService.visibleSources).not.toHaveBeenCalled();
+      expect(fileQueryService.browse).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing sourceId with 400', async () => {
+      const { app } = makeHarness();
+      const res = await app.request('/browse', authed);
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an oversized parentPath with 400', async () => {
+      const { app, fileQueryService } = makeHarness();
+      const res = await app.request(
+        `/browse?sourceId=${SOURCE_ID}&parentPath=${'a'.repeat(4097)}`,
+        authed,
+      );
+      expect(res.status).toBe(400);
+      expect(fileQueryService.browse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /recents', () => {
+    it('returns the device recents and the department feed', async () => {
+      const { app, activityService } = makeHarness();
+      const res = await app.request('/recents', authed);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        recent: [file()],
+        department: [{ ...file(), lastActivityAt: '2026-07-13T09:00:00.000Z' }],
+      });
+      expect(activityService.recents).toHaveBeenCalledWith(ORG_ID, DEVICE_ID, null, undefined, []);
+      expect(activityService.departmentRecent).toHaveBeenCalledWith(ORG_ID, DEVICE_ID, undefined, []);
+    });
+
+    it('filters recents by the helperUser label when provided', async () => {
+      const { app, activityService } = makeHarness();
+      const res = await app.request(`/recents?helperUser=${encodeURIComponent('Dana K')}`, authed);
+      expect(res.status).toBe(200);
+      expect(activityService.recents).toHaveBeenCalledWith(ORG_ID, DEVICE_ID, 'Dana K', undefined, []);
+    });
+
+    it('rejects an oversized helperUser with 400', async () => {
+      const { app, activityService } = makeHarness();
+      const res = await app.request(`/recents?helperUser=${'a'.repeat(101)}`, authed);
+      expect(res.status).toBe(400);
+      expect(activityService.recents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /activity', () => {
+    it('records the activity and writes the audit event', async () => {
+      const { app, activityService, audit } = makeHarness();
+      const res = await app.request('/activity', postActivity({
+        fileIndexId: FILE_ID,
+        action: 'open',
+        helperUser: 'Dana',
+      }));
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual({ recorded: true });
+      expect(activityService.record).toHaveBeenCalledWith(ORG_ID, {
+        fileIndexId: FILE_ID,
+        deviceId: DEVICE_ID,
+        helperUser: 'Dana',
+        action: 'open',
+      }, []);
+      expect(audit).toHaveBeenCalledWith({
+        orgId: ORG_ID,
+        actorType: 'agent',
+        actorId: DEVICE_ID,
+        action: 'workspace.file.open',
+        resourceType: 'workspace_file',
+        resourceId: FILE_ID,
+        details: { helperUser: 'Dana', fileIndexId: FILE_ID },
+        result: 'success',
+      });
+    });
+
+    it('records a null helperUser when the label is absent', async () => {
+      const { app, activityService } = makeHarness();
+      const res = await app.request('/activity', postActivity({
+        fileIndexId: FILE_ID,
+        action: 'copy_path',
+      }));
+      expect(res.status).toBe(201);
+      expect(activityService.record).toHaveBeenCalledWith(ORG_ID, {
+        fileIndexId: FILE_ID,
+        deviceId: DEVICE_ID,
+        helperUser: null,
+        action: 'copy_path',
+      }, []);
+    });
+
+    it('answers 404 (and does not audit) when the file is unknown, hidden, or tombstoned', async () => {
+      const { app, activityService, audit } = makeHarness();
+      activityService.record.mockResolvedValueOnce({ notFound: true });
+      const res = await app.request('/activity', postActivity({
+        fileIndexId: FILE_ID,
+        action: 'open',
+      }));
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'not found' });
+      expect(audit).not.toHaveBeenCalled();
+    });
+
+    it('answers 404 for a malformed fileIndexId before the service runs', async () => {
+      const { app, activityService } = makeHarness();
+      const res = await app.request('/activity', postActivity({
+        fileIndexId: 'not-a-uuid',
+        action: 'open',
+      }));
+      expect(res.status).toBe(404);
+      expect(activityService.record).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown action with 400', async () => {
+      const { app } = makeHarness();
+      const res = await app.request('/activity', postActivity({
+        fileIndexId: FILE_ID,
+        action: 'delete',
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects unexpected fields with 400 (strict body)', async () => {
+      const { app } = makeHarness();
+      const res = await app.request('/activity', postActivity({
+        fileIndexId: FILE_ID,
+        action: 'open',
+        extra: true,
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects an oversized helperUser with 400', async () => {
+      const { app } = makeHarness();
+      const res = await app.request('/activity', postActivity({
+        fileIndexId: FILE_ID,
+        action: 'open',
+        helperUser: 'a'.repeat(101),
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a malformed JSON body with 400', async () => {
+      const { app } = makeHarness();
+      const res = await app.request('/activity', {
+        method: 'POST',
+        headers: { authorization: 'Bearer brz_helper-token', 'content-type': 'application/json' },
+        body: '{nope',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('keeps the response successful when the audit write fails, but logs it', async () => {
+      const { app, audit, log } = makeHarness();
+      audit.mockRejectedValueOnce(new Error('audit pipe closed'));
+      const res = await app.request('/activity', postActivity({
+        fileIndexId: FILE_ID,
+        action: 'open',
+      }));
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual({ recorded: true });
+      expect(log).toHaveBeenCalledWith('error', expect.stringContaining('audit write failed'));
+    });
+  });
+});

--- a/ee/workspace/src/routes/helper.ts
+++ b/ee/workspace/src/routes/helper.ts
@@ -1,0 +1,329 @@
+import type {
+  ExtensionAuditEvent,
+  ExtensionHelperDevice,
+  ExtensionLog,
+  WorkspaceAudit,
+} from '../hostTypes';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { createActivityService } from '../services/activityService';
+import { createContentSearchService } from '../services/contentSearchService';
+import { createFileQueryService } from '../services/fileQueryService';
+import { createFilingService } from '../services/filingService';
+
+// End-user finder surface, authenticated by the core helper (Breeze Assist
+// device-token) middleware — the gateway maps /helper/* here when the manifest
+// sets helperRoutes. The helper session carries a device identity only; the
+// optional helperUser label is device-local display text, never authorization.
+
+export interface WorkspaceHelperRouteEnv {
+  Variables: { helperDevice: ExtensionHelperDevice };
+}
+
+type FileQueryService = Pick<
+  ReturnType<typeof createFileQueryService>,
+  'visibleSources' | 'search' | 'browse'
+>;
+type ActivityService = Pick<
+  ReturnType<typeof createActivityService>,
+  'record' | 'recents' | 'departmentRecent'
+>;
+
+export interface HelperRouteDeps {
+  fileQueryService: FileQueryService;
+  activityService: ActivityService;
+  /**
+   * Content-preview retrieval (dev-preview). Only consulted when content is
+   * enabled for the caller's org; while disabled the legacy search path below
+   * runs untouched — byte-identical responses (snapshot-tested).
+   */
+  contentSearchService?: Pick<ReturnType<typeof createContentSearchService>, 'search' | 'passages'>;
+  /** Filing panel backend (dev-preview); absent or content disabled → routes 404. */
+  filingService?: Pick<ReturnType<typeof createFilingService>, 'list' | 'classify' | 'assign' | 'projects'>;
+  /**
+   * Per-org content flag (W2 Task 3): resolves the caller org's content
+   * setting. Replaces the process-wide WORKSPACE_CONTENT_PREVIEW env var, so
+   * content affordances can be on for one org and off for another in the same
+   * process. Read once per request off the authenticated device's orgId.
+   */
+  getSettings: (orgId: string) => Promise<{ contentEnabled: boolean }>;
+  audit: WorkspaceAudit;
+  log: ExtensionLog;
+}
+
+// What this phase actually ships; the Helper hides its Files view when this
+// endpoint is absent (404) and keys per-feature affordances off this list.
+const HELPER_FEATURES = ['search', 'browse', 'recents', 'open'] as const;
+
+const searchQuerySchema = z.object({
+  q: z.string().min(1).max(200),
+  sourceId: z.uuid().optional(),
+  ext: z.string().min(1).max(100).optional(),
+  modifiedAfter: z.iso.datetime().optional(),
+  modifiedBefore: z.iso.datetime().optional(),
+  project: z.string().min(1).max(200).optional(),
+  docType: z.string().min(1).max(200).optional(),
+  limit: z.coerce.number().int().optional(),
+});
+const browseQuerySchema = z.object({
+  // uuid-ness is checked separately so a malformed id is the contract 404
+  // (unknown-or-hidden source), mirroring the agent routes' 22P02 guard.
+  sourceId: z.string().min(1),
+  parentPath: z.string().max(4096).default(''),
+  // Same optional shape as searchQuerySchema's project/docType — see the
+  // Architecture note authorizing these two params on browse as well.
+  project: z.string().min(1).max(200).optional(),
+  docType: z.string().min(1).max(200).optional(),
+});
+const passagesQuerySchema = z.object({
+  q: z.string().min(1).max(200),
+  fileIndexId: z.string().min(1).optional(),
+  limit: z.coerce.number().int().optional(),
+});
+const recentsQuerySchema = z.object({
+  helperUser: z.string().max(100).optional(),
+});
+const activitySchema = z.object({
+  fileIndexId: z.string(),
+  action: z.enum(['open', 'reveal', 'copy_path']),
+  helperUser: z.string().max(100).optional(),
+}).strict();
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createHelperRoutes(deps: HelperRouteDeps): Hono<WorkspaceHelperRouteEnv> {
+  const app = new Hono<WorkspaceHelperRouteEnv>();
+
+  // Audit transport failures must not change a request's outcome, but they
+  // must never be invisible either (same rule as the agent routes).
+  async function guardedAudit(
+    event: ExtensionAuditEvent,
+    context: string,
+  ): Promise<void> {
+    try {
+      await deps.audit(event);
+    } catch (error) {
+      deps.log('error', `workspace helper audit write failed (${context}): ${errorDetail(error)}`);
+    }
+  }
+
+  // Fail closed on missing helper identity, explicitly and in one place. The
+  // host gateway applies core helper auth on /helper/* (legacy-manifest
+  // helperRoutes flag) and every handler below dereferences
+  // c.get('helperDevice') unconditionally — without this guard a missing
+  // identity would only fail incidentally, as a TypeError surfacing through
+  // onError as a 500, instead of the status that names the condition.
+  app.use('*', async (c, next) => {
+    if (!c.get('helperDevice')) {
+      deps.log('warn', `workspace helper request without identity ${c.req.method} ${c.req.path}`);
+      return c.json({ error: 'helper identity required' }, 401);
+    }
+    await next();
+  });
+
+  app.get('/capabilities', (c) => c.json({ ok: true, features: [...HELPER_FEATURES] }));
+
+  app.get('/sources', async (c) => {
+    const device = c.get('helperDevice');
+    // groupIds [] — helper auth carries no Entra group claims yet, so every
+    // read fails closed to ungrouped sources (see visibility.ts).
+    const sources = await deps.fileQueryService.visibleSources(device.orgId, []);
+    // rootPath stays server-side; the wire shape is id/displayName/kind only.
+    return c.json({
+      sources: sources.map(({ id, displayName, kind }) => ({ id, displayName, kind })),
+    });
+  });
+
+  app.get('/search', async (c) => {
+    const parsed = searchQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const device = c.get('helperDevice');
+    if (deps.contentSearchService && (await deps.getSettings(device.orgId)).contentEnabled) {
+      const results = await deps.contentSearchService.search(device.orgId, device.id, parsed.data, []);
+      return c.json({ results });
+    }
+    const results = await deps.fileQueryService.search(device.orgId, device.id, parsed.data, []);
+    return c.json({ results });
+  });
+
+  // Content-preview capability probe: the Helper shows content affordances
+  // (snippets, inferred metadata, filing) only when this answers 200. With
+  // content disabled for the org it 404s — existing endpoint shapes never
+  // change based on the flag.
+  app.get('/content/capabilities', async (c) => {
+    const device = c.get('helperDevice');
+    if (!deps.contentSearchService || !(await deps.getSettings(device.orgId)).contentEnabled) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const features = ['contentSearch'];
+    if (deps.filingService) features.push('filing', 'projects');
+    return c.json({ enabled: true, features });
+  });
+
+  // Cited-RAG retrieval: visibility-scoped content passages for the chat
+  // file-passages tool. Content-preview only — 404s under the same gate as the
+  // rest of the /content/* surface (the caller org's content setting).
+  app.get('/content/passages', async (c) => {
+    const device = c.get('helperDevice');
+    if (!deps.contentSearchService?.passages || !(await deps.getSettings(device.orgId)).contentEnabled) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const parsed = passagesQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    // A malformed fileIndexId is the contract 404 (unknown-or-hidden file),
+    // mirroring the browse/activity 22P02 guard — never a 500.
+    if (parsed.data.fileIndexId !== undefined
+        && !z.uuid().safeParse(parsed.data.fileIndexId).success) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const passages = await deps.contentSearchService.passages(device.orgId, parsed.data.q, {
+      helperDeviceId: device.id,
+      ...(parsed.data.fileIndexId !== undefined ? { fileIndexId: parsed.data.fileIndexId } : {}),
+      ...(parsed.data.limit !== undefined ? { limit: parsed.data.limit } : {}),
+    }, []);
+    return c.json({ passages });
+  });
+
+  // ---- Filing panel (dev-preview) ---------------------------------------
+  // Per-org gate: filing is available only when a filing service is wired AND
+  // content is enabled for the caller's org (W2 Task 3).
+  const filingAvailable = async (orgId: string) =>
+    Boolean(deps.filingService) && (await deps.getSettings(orgId)).contentEnabled;
+
+  app.get('/filing', async (c) => {
+    const device = c.get('helperDevice');
+    if (!(await filingAvailable(device.orgId))) return c.json({ error: 'not found' }, 404);
+    return c.json({ filings: await deps.filingService!.list(device.orgId, []) });
+  });
+
+  app.get('/content/projects', async (c) => {
+    const device = c.get('helperDevice');
+    if (!(await filingAvailable(device.orgId))) return c.json({ error: 'not found' }, 404);
+    return c.json({ projects: await deps.filingService!.projects(device.orgId) });
+  });
+
+  const classifySchema = z.object({ fileIndexId: z.string() }).strict();
+  app.post('/filing/classify', async (c) => {
+    const device = c.get('helperDevice');
+    if (!(await filingAvailable(device.orgId))) return c.json({ error: 'not found' }, 404);
+    const parsed = classifySchema.safeParse(await c.req.json().catch(() => undefined));
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    if (!z.uuid().safeParse(parsed.data.fileIndexId).success) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const filing = await deps.filingService!.classify(device.orgId, parsed.data.fileIndexId, []);
+    if (!filing) return c.json({ error: 'not found' }, 404);
+    await guardedAudit({
+      orgId: device.orgId,
+      actorType: 'agent',
+      actorId: device.id,
+      action: 'workspace.filing.classify',
+      resourceType: 'workspace_file',
+      resourceId: parsed.data.fileIndexId,
+      details: {
+        suggestedProjectKey: filing.suggestedProjectKey,
+        confidence: filing.confidence,
+      },
+      result: 'success',
+    }, `filing classify file=${parsed.data.fileIndexId}`);
+    return c.json({ filing });
+  });
+
+  const assignSchema = z.object({
+    projectKey: z.string().min(1).max(40),
+    helperUser: z.string().max(100).optional(),
+  }).strict();
+  app.post('/filing/:fileIndexId/assign', async (c) => {
+    const device = c.get('helperDevice');
+    if (!(await filingAvailable(device.orgId))) return c.json({ error: 'not found' }, 404);
+    const fileIndexId = c.req.param('fileIndexId');
+    if (!z.uuid().safeParse(fileIndexId).success) return c.json({ error: 'not found' }, 404);
+    const parsed = assignSchema.safeParse(await c.req.json().catch(() => undefined));
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const filing = await deps.filingService!.assign(
+      device.orgId, fileIndexId, parsed.data.projectKey, parsed.data.helperUser ?? null, [],
+    );
+    if (!filing) return c.json({ error: 'not found' }, 404);
+    await guardedAudit({
+      orgId: device.orgId,
+      actorType: 'agent',
+      actorId: device.id,
+      action: 'workspace.filing.assign',
+      resourceType: 'workspace_file',
+      resourceId: fileIndexId,
+      details: { projectKey: parsed.data.projectKey, helperUser: parsed.data.helperUser ?? null },
+      result: 'success',
+    }, `filing assign file=${fileIndexId}`);
+    return c.json({ filing });
+  });
+
+  app.get('/browse', async (c) => {
+    const parsed = browseQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    if (!z.uuid().safeParse(parsed.data.sourceId).success) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const device = c.get('helperDevice');
+    // An unknown or hidden source must be indistinguishable: both 404 before
+    // the file index is touched (visibility fails closed).
+    const visible = await deps.fileQueryService.visibleSources(device.orgId, []);
+    if (!visible.some((source) => source.id === parsed.data.sourceId)) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const entries = await deps.fileQueryService.browse(
+      device.orgId,
+      device.id,
+      parsed.data.sourceId,
+      parsed.data.parentPath,
+      { project: parsed.data.project, docType: parsed.data.docType },
+      [],
+    );
+    return c.json({ entries });
+  });
+
+  app.get('/recents', async (c) => {
+    const parsed = recentsQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const device = c.get('helperDevice');
+    const helperUser = parsed.data.helperUser ?? null;
+    const [recent, department] = await Promise.all([
+      deps.activityService.recents(device.orgId, device.id, helperUser, undefined, []),
+      deps.activityService.departmentRecent(device.orgId, device.id, undefined, []),
+    ]);
+    return c.json({ recent, department });
+  });
+
+  app.post('/activity', async (c) => {
+    const parsed = activitySchema.safeParse(await c.req.json().catch(() => undefined));
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    if (!z.uuid().safeParse(parsed.data.fileIndexId).success) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const device = c.get('helperDevice');
+    const helperUser = parsed.data.helperUser ?? null;
+    const result = await deps.activityService.record(device.orgId, {
+      fileIndexId: parsed.data.fileIndexId,
+      deviceId: device.id,
+      helperUser,
+      action: parsed.data.action,
+    }, []);
+    // notFound covers unknown, tombstoned, AND hidden-source files — the
+    // activity API must never confirm a file outside the caller's view.
+    if ('notFound' in result) return c.json({ error: 'not found' }, 404);
+    await guardedAudit({
+      orgId: device.orgId,
+      actorType: 'agent',
+      actorId: device.id,
+      action: `workspace.file.${parsed.data.action}`,
+      resourceType: 'workspace_file',
+      resourceId: parsed.data.fileIndexId,
+      details: { helperUser, fileIndexId: parsed.data.fileIndexId },
+      result: 'success',
+    }, `activity file=${parsed.data.fileIndexId}`);
+    return c.json({ recorded: true }, 201);
+  });
+
+  return app;
+}

--- a/ee/workspace/src/routes/sources.test.ts
+++ b/ee/workspace/src/routes/sources.test.ts
@@ -1,0 +1,458 @@
+import { Hono } from 'hono';
+import type { ExtensionAuditEvent } from '../hostTypes';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceAuthContext, WorkspaceRouteEnv } from './adminGate';
+import { createSourcesRoutes } from './sources';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_ORG_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const SOURCE_ID = '22222222-2222-2222-2222-222222222222';
+const USER_ID = '33333333-3333-3333-3333-333333333333';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+
+const sourceInput = {
+  kind: 'smb_share' as const,
+  displayName: 'Shared documents',
+  rootPath: '\\\\fileserver\\documents',
+  crawlDeviceId: DEVICE_ID,
+  visibilityGroupIds: ['55555555-5555-4555-8555-555555555555'],
+  crawlCadenceMinutes: 60,
+  excludeGlobs: ['**/.git/**'],
+  watch: true,
+  status: 'active' as const,
+};
+
+// Service-layer rows are SafeSourceRow: credentialEnc never leaves the
+// service; consumers see the computed hasCredential instead.
+function source(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SOURCE_ID,
+    orgId: ORG_ID,
+    ...sourceInput,
+    hasCredential: true,
+    crawlCursor: {},
+    statusDetail: null,
+    errorReason: null,
+    lastCompleteRunAt: null,
+    createdAt: new Date('2026-07-12T10:00:00.000Z'),
+    updatedAt: new Date('2026-07-12T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function auth(overrides: Partial<WorkspaceAuthContext> = {}): WorkspaceAuthContext {
+  return {
+    user: {
+      id: USER_ID,
+      email: 'admin@example.com',
+      name: 'Workspace Admin',
+      isPlatformAdmin: false,
+    },
+    scope: 'partner',
+    orgId: null,
+    partnerId: '66666666-6666-6666-6666-666666666666',
+    accessibleOrgIds: [ORG_ID],
+    ...overrides,
+  };
+}
+
+function makeHarness(authValue = auth()) {
+  const sourcesService = {
+    list: vi.fn(async () => [source()]),
+    get: vi.fn(async () => source()),
+    create: vi.fn(async (_orgId: string, input: typeof sourceInput) => source(input)),
+    update: vi.fn(async () => source({ displayName: 'Updated documents' })),
+    remove: vi.fn(async () => true),
+    listRuns: vi.fn(async () => [{
+      id: '77777777-7777-4777-8777-777777777777',
+      orgId: ORG_ID,
+      sourceId: SOURCE_ID,
+      deviceId: DEVICE_ID,
+      deviceKey: DEVICE_ID,
+      status: 'complete' as const,
+      startedAt: new Date('2026-07-12T10:00:00.000Z'),
+      lastActivityAt: new Date('2026-07-12T10:01:00.000Z'),
+      completedAt: new Date('2026-07-12T10:02:00.000Z'),
+      cursor: null,
+      stats: {},
+      errorReason: null,
+    }]),
+  };
+  const credentialService = {
+    set: vi.fn(async () => true),
+    clear: vi.fn(async () => true),
+  };
+  const audit = vi.fn(async (_event: ExtensionAuditEvent) => {});
+  const log = vi.fn();
+  const app = new Hono<WorkspaceRouteEnv>();
+  app.use('*', async (c, next) => {
+    c.set('auth', authValue);
+    await next();
+  });
+  app.route('/', createSourcesRoutes({ sourcesService, credentialService, audit, log }));
+  return { app, sourcesService, credentialService, audit, log };
+}
+
+function jsonRequest(method: string, body?: unknown) {
+  return {
+    method,
+    headers: { 'content-type': 'application/json' },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sources admin routes', () => {
+  it('rejects organization-scoped callers', async () => {
+    const h = makeHarness(auth({ scope: 'organization', orgId: ORG_ID }));
+    const res = await h.app.request(`/sources?orgId=${ORG_ID}`);
+    expect(res.status).toBe(403);
+    expect(h.sourcesService.list).not.toHaveBeenCalled();
+  });
+
+  it('requires orgId before listing sources', async () => {
+    const h = makeHarness();
+    const res = await h.app.request('/sources');
+    expect(res.status).toBe(400);
+    expect(h.sourcesService.list).not.toHaveBeenCalled();
+  });
+
+  it('rejects a partner without access to the requested organization', async () => {
+    const h = makeHarness(auth({ accessibleOrgIds: [OTHER_ORG_ID] }));
+    const res = await h.app.request(`/sources?orgId=${ORG_ID}`);
+    expect(res.status).toBe(403);
+    expect(h.sourcesService.list).not.toHaveBeenCalled();
+  });
+
+  it('allows system scope when accessibleOrgIds is null', async () => {
+    const h = makeHarness(auth({ scope: 'system', accessibleOrgIds: null }));
+    const res = await h.app.request(`/sources?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+    expect(h.sourcesService.list).toHaveBeenCalledWith(ORG_ID);
+  });
+
+  it('lists only allowlisted public source data with hasCredential', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(`/sources?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { sources: Array<Record<string, unknown>> };
+    expect(body.sources[0]).toMatchObject({ id: SOURCE_ID, hasCredential: true });
+    expect(Object.keys(body.sources[0] ?? {}).sort()).toEqual([
+      'id',
+      'orgId',
+      'kind',
+      'displayName',
+      'rootPath',
+      'crawlDeviceId',
+      'visibilityGroupIds',
+      'crawlCadenceMinutes',
+      'excludeGlobs',
+      'watch',
+      'status',
+      'errorReason',
+      'lastCompleteRunAt',
+      'createdAt',
+      'updatedAt',
+      'hasCredential',
+    ].sort());
+  });
+
+  it('supports partner-scoped CRUD and audits each mutation action', async () => {
+    const h = makeHarness();
+
+    const createRes = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', sourceInput),
+    );
+    expect(createRes.status).toBe(201);
+    expect(h.sourcesService.create).toHaveBeenCalledWith(ORG_ID, sourceInput);
+
+    const detailRes = await h.app.request(`/sources/${SOURCE_ID}?orgId=${ORG_ID}`);
+    expect(detailRes.status).toBe(200);
+    const detail = await detailRes.json() as Record<string, unknown>;
+    expect(detail).toMatchObject({ id: SOURCE_ID, hasCredential: true });
+    expect(detail).not.toHaveProperty('credentialEnc');
+
+    const patch = { displayName: 'Updated documents', status: 'paused' };
+    const patchRes = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      jsonRequest('PATCH', patch),
+    );
+    expect(patchRes.status).toBe(200);
+    expect(h.sourcesService.update).toHaveBeenCalledWith(ORG_ID, SOURCE_ID, patch);
+
+    const deleteRes = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      { method: 'DELETE' },
+    );
+    expect(deleteRes.status).toBe(200);
+    expect(h.sourcesService.remove).toHaveBeenCalledWith(ORG_ID, SOURCE_ID);
+
+    expect(h.audit.mock.calls.map(([event]) => event.action)).toEqual([
+      'workspace.source.create',
+      'workspace.source.update',
+      'workspace.source.delete',
+    ]);
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({
+      actorType: 'user',
+      actorId: USER_ID,
+      orgId: ORG_ID,
+      resourceType: 'workspace_source',
+      resourceId: SOURCE_ID,
+      result: 'success',
+    }));
+  });
+
+  it('validates create and patch bodies before calling the service', async () => {
+    const h = makeHarness();
+    const createRes = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', { ...sourceInput, displayName: '' }),
+    );
+    expect(createRes.status).toBe(400);
+
+    const patchRes = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      jsonRequest('PATCH', { crawlCadenceMinutes: 0 }),
+    );
+    expect(patchRes.status).toBe(400);
+    expect(h.sourcesService.create).not.toHaveBeenCalled();
+    expect(h.sourcesService.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid SMB configurations before calling the service', async () => {
+    const h = makeHarness();
+    const invalidCreate = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', {
+        ...sourceInput,
+        crawlDeviceId: null,
+      }),
+    );
+    expect(invalidCreate.status).toBe(400);
+
+    h.sourcesService.get.mockResolvedValueOnce(source({
+      kind: 'local_profile',
+      rootPath: '/Users',
+      crawlDeviceId: null,
+    }));
+    const invalidPatch = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      jsonRequest('PATCH', { kind: 'smb_share' }),
+    );
+    expect(invalidPatch.status).toBe(400);
+    expect(h.sourcesService.create).not.toHaveBeenCalled();
+    expect(h.sourcesService.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty patch without touching the source', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      jsonRequest('PATCH', {}),
+    );
+    expect(res.status).toBe(400);
+    expect(h.sourcesService.get).not.toHaveBeenCalled();
+    expect(h.sourcesService.update).not.toHaveBeenCalled();
+  });
+
+  it('sets parsed credentials without echoing secrets and audits the action', async () => {
+    const h = makeHarness();
+    const credential = { username: 'alice', password: 'very-secret', domain: 'ACME' };
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}/credential?orgId=${ORG_ID}`,
+      jsonRequest('PUT', credential),
+    );
+    expect(res.status).toBe(200);
+    expect(h.credentialService.set).toHaveBeenCalledWith(ORG_ID, SOURCE_ID, credential);
+    const body = await res.json() as Record<string, unknown>;
+    expect(JSON.stringify(body)).not.toContain('alice');
+    expect(JSON.stringify(body)).not.toContain('very-secret');
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.source.credential.set',
+      resourceId: SOURCE_ID,
+      result: 'success',
+    }));
+  });
+
+  it('rejects invalid credentials before calling the service', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}/credential?orgId=${ORG_ID}`,
+      jsonRequest('PUT', { username: '', password: '' }),
+    );
+    expect(res.status).toBe(400);
+    expect(h.credentialService.set).not.toHaveBeenCalled();
+  });
+
+  it('does not copy credential service exception text into the audit event', async () => {
+    const h = makeHarness();
+    h.credentialService.set.mockRejectedValueOnce(new Error('password=very-secret'));
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}/credential?orgId=${ORG_ID}`,
+      jsonRequest('PUT', { username: 'alice', password: 'very-secret' }),
+    );
+    expect(res.status).toBe(500);
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.source.credential.set',
+      result: 'failure',
+      errorMessage: 'Credential operation failed',
+    }));
+  });
+
+  it('clears credentials and audits the action', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}/credential?orgId=${ORG_ID}`,
+      { method: 'DELETE' },
+    );
+    expect(res.status).toBe(200);
+    expect(h.credentialService.clear).toHaveBeenCalledWith(ORG_ID, SOURCE_ID);
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.source.credential.clear',
+      resourceId: SOURCE_ID,
+      result: 'success',
+    }));
+  });
+
+  it('returns 404 and a failure audit when a scoped mutation misses', async () => {
+    const h = makeHarness();
+    h.sourcesService.remove.mockResolvedValueOnce(false);
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}?orgId=${ORG_ID}`,
+      { method: 'DELETE' },
+    );
+    expect(res.status).toBe(404);
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.source.delete',
+      resourceId: SOURCE_ID,
+      result: 'failure',
+    }));
+  });
+
+  it('audits a service exception as failure and returns a sanitized 500', async () => {
+    const h = makeHarness();
+    h.sourcesService.create.mockRejectedValueOnce(new Error('database exploded'));
+    const res = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', sourceInput),
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Failed to create source' });
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.source.create',
+      result: 'failure',
+      errorMessage: 'database exploded',
+    }));
+  });
+
+  it('does not misreport a committed mutation when audit delivery rejects, but logs the gap', async () => {
+    const h = makeHarness();
+    h.audit.mockRejectedValue(new Error('audit queue unavailable'));
+    const res = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', sourceInput),
+    );
+    expect(res.status).toBe(201);
+    expect(h.sourcesService.create).toHaveBeenCalledOnce();
+    expect(h.audit).toHaveBeenCalledOnce();
+    // The hole in the audit trail must be observable.
+    expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining('audit write failed'));
+    expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining('workspace.source.create'));
+  });
+
+  it('keeps the service failure response stable when failure audit delivery rejects', async () => {
+    const h = makeHarness();
+    h.sourcesService.create.mockRejectedValueOnce(new Error('database exploded'));
+    h.audit.mockRejectedValue(new Error('audit queue unavailable'));
+    const res = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', sourceInput),
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Failed to create source' });
+    expect(h.audit).toHaveBeenCalledOnce();
+  });
+
+  it('returns 404 when a source is absent in the requested organization', async () => {
+    const h = makeHarness();
+    h.sourcesService.get.mockResolvedValueOnce(null as never);
+    const res = await h.app.request(`/sources/${SOURCE_ID}?orgId=${ORG_ID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects credential writes for non-SMB sources without calling the service', async () => {
+    const h = makeHarness();
+    h.sourcesService.get.mockResolvedValueOnce(source({
+      kind: 'local_profile', rootPath: '/Users', crawlDeviceId: null,
+    }) as never);
+    const res = await h.app.request(
+      `/sources/${SOURCE_ID}/credential?orgId=${ORG_ID}`,
+      jsonRequest('PUT', { username: 'alice', password: 'secret' }),
+    );
+    expect(res.status).toBe(400);
+    expect(h.credentialService.set).not.toHaveBeenCalled();
+    expect(h.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.source.credential.set',
+      result: 'failure',
+    }));
+  });
+
+  it('maps a service validation error to 400 with its message', async () => {
+    const h = makeHarness();
+    const { SourceValidationError } = await import('../services/sourcesService');
+    h.sourcesService.create.mockRejectedValueOnce(
+      new SourceValidationError('smb_share requires crawlDeviceId'),
+    );
+    const res = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', sourceInput),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'smb_share requires crawlDeviceId' });
+  });
+
+  it('rejects a crawl cadence that would overflow the integer column', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(
+      `/sources?orgId=${ORG_ID}`,
+      jsonRequest('POST', { ...sourceInput, crawlCadenceMinutes: 9_000_000_000 }),
+    );
+    expect(res.status).toBe(400);
+    expect(h.sourcesService.create).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a partner arrives without an accessible-orgs list', async () => {
+    const h = makeHarness(auth({ accessibleOrgIds: null }));
+    const res = await h.app.request(`/sources?orgId=${ORG_ID}`);
+    expect(res.status).toBe(403);
+    expect(h.sourcesService.list).not.toHaveBeenCalled();
+  });
+
+  it('lists runs through the public projection without cursor or deviceKey', async () => {
+    const h = makeHarness();
+    const res = await h.app.request(`/sources/${SOURCE_ID}/runs?orgId=${ORG_ID}`);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { runs: Array<Record<string, unknown>> };
+    expect(body.runs[0]).toMatchObject({ sourceId: SOURCE_ID, status: 'complete' });
+    expect(body.runs[0]).not.toHaveProperty('cursor');
+    expect(body.runs[0]).not.toHaveProperty('deviceKey');
+  });
+
+  it('lists runs with a default of 20 and enforces the maximum of 100', async () => {
+    const h = makeHarness();
+    const defaultRes = await h.app.request(`/sources/${SOURCE_ID}/runs?orgId=${ORG_ID}`);
+    expect(defaultRes.status).toBe(200);
+    expect(h.sourcesService.listRuns).toHaveBeenCalledWith(ORG_ID, SOURCE_ID, 20);
+
+    const maxRes = await h.app.request(`/sources/${SOURCE_ID}/runs?orgId=${ORG_ID}&limit=100`);
+    expect(maxRes.status).toBe(200);
+    expect(h.sourcesService.listRuns).toHaveBeenLastCalledWith(ORG_ID, SOURCE_ID, 100);
+
+    const invalidRes = await h.app.request(`/sources/${SOURCE_ID}/runs?orgId=${ORG_ID}&limit=101`);
+    expect(invalidRes.status).toBe(400);
+  });
+});

--- a/ee/workspace/src/routes/sources.ts
+++ b/ee/workspace/src/routes/sources.ts
@@ -1,0 +1,337 @@
+import type { ExtensionLog, WorkspaceAudit } from '../hostTypes';
+import { Hono, type Context } from 'hono';
+import { z } from 'zod';
+import {
+  createCredentialService,
+} from '../services/credentialService';
+import {
+  createSourcesService,
+  SourceValidationError,
+  type CrawlRunRow,
+  type SafeSourceRow,
+} from '../services/sourcesService';
+import { adminGate, type WorkspaceRouteEnv } from './adminGate';
+
+type SourcesService = Pick<
+  ReturnType<typeof createSourcesService>,
+  'list' | 'get' | 'create' | 'update' | 'remove' | 'listRuns'
+>;
+type CredentialService = Pick<
+  ReturnType<typeof createCredentialService>,
+  'set' | 'clear'
+>;
+
+export interface SourcesRouteDeps {
+  sourcesService: SourcesService;
+  credentialService: CredentialService;
+  audit: WorkspaceAudit;
+  log: ExtensionLog;
+}
+
+type SmbConfig = {
+  kind?: 'smb_share' | 'local_profile';
+  rootPath?: string;
+  crawlDeviceId?: string | null;
+};
+
+function validateSmbConfig(input: SmbConfig, ctx: z.RefinementCtx): void {
+  if (input.kind !== 'smb_share') return;
+  if (!input.crawlDeviceId) {
+    ctx.addIssue({ code: 'custom', path: ['crawlDeviceId'], message: 'SMB sources require a crawl device' });
+  }
+  if (!input.rootPath?.startsWith('\\\\')) {
+    ctx.addIssue({ code: 'custom', path: ['rootPath'], message: 'SMB sources require a UNC root path' });
+  }
+}
+
+// crawl_cadence_minutes is an int4 column; the cap (one year) exists so an
+// oversized-but-valid JSON number is a 400 here, not an overflow 500 at the DB.
+const MAX_CADENCE_MINUTES = 525_600;
+
+const sourceInputBaseSchema = z.object({
+  kind: z.enum(['smb_share', 'local_profile']),
+  displayName: z.string().min(1).max(256),
+  rootPath: z.string().min(1).max(4096),
+  crawlDeviceId: z.uuid().nullable().optional(),
+  visibilityGroupIds: z.array(z.uuid()).max(256),
+  crawlCadenceMinutes: z.number().int().positive().max(MAX_CADENCE_MINUTES),
+  excludeGlobs: z.array(z.string().max(1024)).max(256),
+  watch: z.boolean(),
+  status: z.enum(['active', 'paused']),
+}).strict();
+
+const sourceInputSchema = sourceInputBaseSchema.superRefine(validateSmbConfig);
+const sourcePatchSchema = sourceInputBaseSchema.partial().refine(
+  (patch) => Object.keys(patch).length > 0,
+  { message: 'At least one source field is required' },
+);
+const smbConfigSchema = z.object({
+  kind: z.enum(['smb_share', 'local_profile']),
+  rootPath: z.string(),
+  crawlDeviceId: z.uuid().nullable().optional(),
+}).superRefine(validateSmbConfig);
+const credentialSchema = z.object({
+  username: z.string().min(1).max(512),
+  password: z.string().min(1).max(512),
+  domain: z.string().max(512).optional(),
+}).strict();
+const runLimitSchema = z.coerce.number().int().min(1).max(100);
+
+type MutationAction =
+  | 'workspace.source.create'
+  | 'workspace.source.update'
+  | 'workspace.source.delete'
+  | 'workspace.source.credential.set'
+  | 'workspace.source.credential.clear';
+
+function publicSource(row: SafeSourceRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    kind: row.kind,
+    displayName: row.displayName,
+    rootPath: row.rootPath,
+    crawlDeviceId: row.crawlDeviceId,
+    visibilityGroupIds: row.visibilityGroupIds,
+    crawlCadenceMinutes: row.crawlCadenceMinutes,
+    excludeGlobs: row.excludeGlobs,
+    watch: row.watch,
+    status: row.status,
+    errorReason: row.errorReason,
+    lastCompleteRunAt: row.lastCompleteRunAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    hasCredential: row.hasCredential,
+  };
+}
+
+// Projection for admin run listings; cursor and deviceKey are internal
+// (agent-resume state and the NULL-proof index key) and stay server-side.
+function publicRun(run: CrawlRunRow): Record<string, unknown> {
+  return {
+    id: run.id,
+    sourceId: run.sourceId,
+    deviceId: run.deviceId,
+    status: run.status,
+    startedAt: run.startedAt,
+    lastActivityAt: run.lastActivityAt,
+    completedAt: run.completedAt,
+    stats: run.stats,
+    errorReason: run.errorReason,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isForeignKeyViolation(error: unknown): boolean {
+  return typeof error === 'object' && error !== null &&
+    'code' in error && (error as { code?: unknown }).code === '23503';
+}
+
+export function createSourcesRoutes(deps: SourcesRouteDeps): Hono<WorkspaceRouteEnv> {
+  const app = new Hono<WorkspaceRouteEnv>();
+  app.use('*', adminGate);
+
+  const audit = async (
+    auth: WorkspaceRouteEnv['Variables']['auth'],
+    orgId: string,
+    action: MutationAction,
+    result: 'success' | 'failure',
+    resourceId?: string,
+    error?: unknown,
+  ) => {
+    const auditErrorMessage = error === undefined
+      ? undefined
+      : action.startsWith('workspace.source.credential.')
+        ? 'Credential operation failed'
+        : errorMessage(error);
+    try {
+      await deps.audit({
+        actorType: 'user',
+        actorId: auth.user.id,
+        orgId,
+        action,
+        resourceType: 'workspace_source',
+        ...(resourceId === undefined ? {} : { resourceId }),
+        result,
+        ...(auditErrorMessage === undefined ? {} : { errorMessage: auditErrorMessage }),
+      });
+    } catch (auditError) {
+      // Audit transport failure must not rewrite the outcome of an already-
+      // completed mutation — but it must be visible: an undetectable hole in
+      // the audit trail is an incident of its own.
+      deps.log(
+        'error',
+        `workspace audit write failed action=${action} org=${orgId}` +
+        `${resourceId === undefined ? '' : ` resource=${resourceId}`}: ${errorMessage(auditError)}`,
+      );
+    }
+  };
+
+  const readBody = async <T>(
+    c: Context<WorkspaceRouteEnv>,
+    schema: z.ZodType<T>,
+  ): Promise<{ data: T } | { response: Response }> => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return { response: c.json({ error: 'Invalid JSON body' }, 400) };
+    }
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      return { response: c.json({ error: 'Invalid request body' }, 400) };
+    }
+    return { data: parsed.data };
+  };
+
+  app.get('/sources', async (c) => {
+    const rows = await deps.sourcesService.list(c.get('workspaceOrgId'));
+    return c.json({ sources: rows.map(publicSource) });
+  });
+
+  app.post('/sources', async (c) => {
+    const parsed = await readBody(c, sourceInputSchema);
+    if ('response' in parsed) return parsed.response;
+    const auth = c.get('auth');
+    const orgId = c.get('workspaceOrgId');
+    try {
+      const created = await deps.sourcesService.create(orgId, parsed.data);
+      await audit(auth, orgId, 'workspace.source.create', 'success', created.id);
+      return c.json(publicSource(created), 201);
+    } catch (error) {
+      await audit(auth, orgId, 'workspace.source.create', 'failure', undefined, error);
+      if (error instanceof SourceValidationError) {
+        return c.json({ error: error.message }, 400);
+      }
+      if (isForeignKeyViolation(error)) {
+        return c.json({ error: 'crawlDeviceId does not reference a known device' }, 400);
+      }
+      return c.json({ error: 'Failed to create source' }, 500);
+    }
+  });
+
+  app.get('/sources/:id', async (c) => {
+    const row = await deps.sourcesService.get(c.get('workspaceOrgId'), c.req.param('id'));
+    if (!row) return c.json({ error: 'Source not found' }, 404);
+    return c.json(publicSource(row));
+  });
+
+  app.patch('/sources/:id', async (c) => {
+    const parsed = await readBody(c, sourcePatchSchema);
+    if ('response' in parsed) return parsed.response;
+    const auth = c.get('auth');
+    const orgId = c.get('workspaceOrgId');
+    const sourceId = c.req.param('id');
+    try {
+      const existing = await deps.sourcesService.get(orgId, sourceId);
+      if (!existing) {
+        await audit(auth, orgId, 'workspace.source.update', 'failure', sourceId);
+        return c.json({ error: 'Source not found' }, 404);
+      }
+      const mergedConfig = smbConfigSchema.safeParse({
+        kind: parsed.data.kind ?? existing.kind,
+        rootPath: parsed.data.rootPath ?? existing.rootPath,
+        crawlDeviceId: parsed.data.crawlDeviceId === undefined
+          ? existing.crawlDeviceId
+          : parsed.data.crawlDeviceId,
+      });
+      if (!mergedConfig.success) {
+        return c.json({ error: 'Invalid request body' }, 400);
+      }
+      const updated = await deps.sourcesService.update(orgId, sourceId, parsed.data);
+      if (!updated) {
+        await audit(auth, orgId, 'workspace.source.update', 'failure', sourceId);
+        return c.json({ error: 'Source not found' }, 404);
+      }
+      await audit(auth, orgId, 'workspace.source.update', 'success', sourceId);
+      return c.json(publicSource(updated));
+    } catch (error) {
+      await audit(auth, orgId, 'workspace.source.update', 'failure', sourceId, error);
+      if (isForeignKeyViolation(error)) {
+        return c.json({ error: 'crawlDeviceId does not reference a known device' }, 400);
+      }
+      return c.json({ error: 'Failed to update source' }, 500);
+    }
+  });
+
+  app.delete('/sources/:id', async (c) => {
+    const auth = c.get('auth');
+    const orgId = c.get('workspaceOrgId');
+    const sourceId = c.req.param('id');
+    try {
+      const removed = await deps.sourcesService.remove(orgId, sourceId);
+      if (!removed) {
+        await audit(auth, orgId, 'workspace.source.delete', 'failure', sourceId);
+        return c.json({ error: 'Source not found' }, 404);
+      }
+      await audit(auth, orgId, 'workspace.source.delete', 'success', sourceId);
+      return c.json({ success: true });
+    } catch (error) {
+      await audit(auth, orgId, 'workspace.source.delete', 'failure', sourceId, error);
+      return c.json({ error: 'Failed to delete source' }, 500);
+    }
+  });
+
+  app.put('/sources/:id/credential', async (c) => {
+    const parsed = await readBody(c, credentialSchema);
+    if ('response' in parsed) return parsed.response;
+    const auth = c.get('auth');
+    const orgId = c.get('workspaceOrgId');
+    const sourceId = c.req.param('id');
+    try {
+      const source = await deps.sourcesService.get(orgId, sourceId);
+      if (!source) {
+        await audit(auth, orgId, 'workspace.source.credential.set', 'failure', sourceId);
+        return c.json({ error: 'Source not found' }, 404);
+      }
+      if (source.kind !== 'smb_share') {
+        await audit(auth, orgId, 'workspace.source.credential.set', 'failure', sourceId);
+        return c.json({ error: 'Credentials apply only to SMB sources' }, 400);
+      }
+      const stored = await deps.credentialService.set(orgId, sourceId, parsed.data);
+      if (!stored) {
+        await audit(auth, orgId, 'workspace.source.credential.set', 'failure', sourceId);
+        return c.json({ error: 'Source not found' }, 404);
+      }
+      await audit(auth, orgId, 'workspace.source.credential.set', 'success', sourceId);
+      return c.json({ success: true });
+    } catch (error) {
+      await audit(auth, orgId, 'workspace.source.credential.set', 'failure', sourceId, error);
+      return c.json({ error: 'Failed to set credential' }, 500);
+    }
+  });
+
+  app.delete('/sources/:id/credential', async (c) => {
+    const auth = c.get('auth');
+    const orgId = c.get('workspaceOrgId');
+    const sourceId = c.req.param('id');
+    try {
+      const cleared = await deps.credentialService.clear(orgId, sourceId);
+      if (!cleared) {
+        await audit(auth, orgId, 'workspace.source.credential.clear', 'failure', sourceId);
+        return c.json({ error: 'Source not found' }, 404);
+      }
+      await audit(auth, orgId, 'workspace.source.credential.clear', 'success', sourceId);
+      return c.json({ success: true });
+    } catch (error) {
+      await audit(auth, orgId, 'workspace.source.credential.clear', 'failure', sourceId, error);
+      return c.json({ error: 'Failed to clear credential' }, 500);
+    }
+  });
+
+  app.get('/sources/:id/runs', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    const sourceId = c.req.param('id');
+    const parsedLimit = runLimitSchema.safeParse(c.req.query('limit') ?? 20);
+    if (!parsedLimit.success) return c.json({ error: 'Invalid limit' }, 400);
+    const source = await deps.sourcesService.get(orgId, sourceId);
+    if (!source) return c.json({ error: 'Source not found' }, 404);
+    const runs = await deps.sourcesService.listRuns(orgId, sourceId, parsedLimit.data);
+    return c.json({ runs: runs.map(publicRun) });
+  });
+
+  return app;
+}

--- a/ee/workspace/src/schema/content.ts
+++ b/ee/workspace/src/schema/content.ts
@@ -1,0 +1,160 @@
+// Content phase (dev-preview) table mirrors. As with workspace.ts, the SQL in
+// migrations/ is the DDL source of truth — FKs, RLS policies, FTS/trigram
+// indexes, and the vector column (later migration) do not appear here.
+// All readers/writers of these tables sit behind the per-org content flag
+// (default off; never on in production). DLP runs at ingest, between extraction
+// and persistence: stored extracted_text is post-redaction, and files a 'block'
+// detector trips persist no text (status = blocked_dlp).
+import {
+  pgTable, uuid, text, varchar, bigint, integer, timestamp, jsonb, pgEnum, date,
+  index, uniqueIndex, vector,
+} from 'drizzle-orm/pg-core';
+import { workspaceFileIndex } from './workspace';
+
+// W2: 'blocked_dlp' added by migrations/2026-07-24-org-settings-dlp.sql
+// (ALTER TYPE ... ADD VALUE) — content that DLP blocked at ingest time.
+export const workspaceContentStatus = pgEnum('workspace_content_status', [
+  'extracted', 'failed', 'skipped_too_large', 'skipped_binary', 'blocked_dlp',
+]);
+export const workspaceFilingStatus = pgEnum('workspace_filing_status', [
+  'suggested', 'confirmed', 'reassigned',
+]);
+export const workspaceFilingConfidence = pgEnum('workspace_filing_confidence', ['high', 'low']);
+
+// "Pending" is the absence of a row (or a stale source_size/source_mtime
+// snapshot vs workspace_file_index) — there is no pending enum value.
+// W2: dlp_findings (added by migrations/2026-07-24-org-settings-dlp.sql)
+// carries the detector hits behind a 'blocked_dlp' status decision.
+export const workspaceFileContent = pgTable('workspace_file_content', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  fileIndexId: uuid('file_index_id').notNull()
+    .references(() => workspaceFileIndex.id, { onDelete: 'cascade' }),
+  contentHash: text('content_hash'),
+  sourceSize: bigint('source_size', { mode: 'number' }),
+  sourceMtime: timestamp('source_mtime', { withTimezone: true }),
+  extractedText: text('extracted_text'),
+  status: workspaceContentStatus('status').notNull(),
+  errorReason: text('error_reason'),
+  dlpFindings: jsonb('dlp_findings').$type<unknown[]>().notNull().default([]),
+  extractedAt: timestamp('extracted_at', { withTimezone: true }).notNull().defaultNow(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex('wsp_file_content_file_unique').on(t.fileIndexId),
+  index('wsp_file_content_org_idx').on(t.orgId),
+]);
+
+// value_norm is canonical (uppercased, '#'/whitespace stripped); query-side
+// detection must use the same normalizer (src/content/entities.ts).
+export const workspaceContentEntities = pgTable('workspace_content_entities', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  fileIndexId: uuid('file_index_id').notNull()
+    .references(() => workspaceFileIndex.id, { onDelete: 'cascade' }),
+  entityType: text('entity_type').notNull(),
+  valueNorm: text('value_norm').notNull(),
+  valueRaw: text('value_raw'),
+  origin: text('origin').notNull().default('regex'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex('wsp_content_entities_unique').on(t.orgId, t.fileIndexId, t.entityType, t.valueNorm),
+  index('wsp_content_entities_lookup_idx').on(t.orgId, t.entityType, t.valueNorm),
+]);
+
+// Declared location is stored NEXT TO the inferred metadata so the finder can
+// show disagreement, never silently "fix" it. email_meta comes from the
+// mailparser extraction step, not the LLM.
+export const workspaceFileEnrichment = pgTable('workspace_file_enrichment', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  fileIndexId: uuid('file_index_id').notNull()
+    .references(() => workspaceFileIndex.id, { onDelete: 'cascade' }),
+  inferredProjectKey: text('inferred_project_key'),
+  inferredProjectLabel: text('inferred_project_label'),
+  inferredDocType: text('inferred_doc_type'),
+  docDate: date('doc_date'),
+  declaredProjectKey: text('declared_project_key'),
+  declaredProjectLabel: text('declared_project_label'),
+  emailMeta: jsonb('email_meta').$type<{
+    from?: string; to?: string[]; cc?: string[]; subject?: string; date?: string;
+  } | null>(),
+  confidence: varchar('confidence', { length: 16 }),
+  model: text('model'),
+  enrichedAt: timestamp('enriched_at', { withTimezone: true }).notNull().defaultNow(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex('wsp_file_enrichment_file_unique').on(t.fileIndexId),
+  index('wsp_file_enrichment_org_idx').on(t.orgId),
+  index('wsp_file_enrichment_inferred_project_idx').on(t.orgId, t.inferredProjectKey),
+]);
+
+export const workspaceProjects = pgTable('workspace_projects', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  projectKey: text('project_key').notNull(),
+  label: text('label').notNull(),
+  aliases: jsonb('aliases').$type<string[]>().notNull().default([]),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [uniqueIndex('wsp_projects_org_key_unique').on(t.orgId, t.projectKey)]);
+
+// evidence_count counts DISTINCT files, never mentions (re-runs must not
+// inflate it — the miner recomputes rather than increments).
+export const workspaceProjectCrosswalk = pgTable('workspace_project_crosswalk', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  entityType: text('entity_type').notNull(),
+  valueNorm: text('value_norm').notNull(),
+  projectKey: text('project_key').notNull(),
+  projectLabel: text('project_label'),
+  evidenceCount: integer('evidence_count').notNull().default(0),
+  sampleFileIds: jsonb('sample_file_ids').$type<string[]>().notNull().default([]),
+  minedAt: timestamp('mined_at', { withTimezone: true }).notNull().defaultNow(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex('wsp_project_crosswalk_unique').on(t.orgId, t.entityType, t.valueNorm, t.projectKey),
+  index('wsp_project_crosswalk_org_idx').on(t.orgId),
+]);
+
+// Vector chunks (part-2 migration; requires the pgvector image). Embeddings
+// are 1024-dim voyage-3 by convention (src/content/embedder.ts).
+export const workspaceContentChunks = pgTable('workspace_content_chunks', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  fileIndexId: uuid('file_index_id').notNull()
+    .references(() => workspaceFileIndex.id, { onDelete: 'cascade' }),
+  chunkIndex: integer('chunk_index').notNull(),
+  text: text('text').notNull(),
+  embedding: vector('embedding', { dimensions: 1024 }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex('wsp_content_chunks_file_chunk_unique').on(t.fileIndexId, t.chunkIndex),
+  index('wsp_content_chunks_org_idx').on(t.orgId),
+]);
+
+// decided_label mirrors workspace_file_activity.helper_user semantics: a
+// device-local display label, never authorization. No user FK by design.
+export const workspaceEmailFilings = pgTable('workspace_email_filings', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  fileIndexId: uuid('file_index_id').notNull()
+    .references(() => workspaceFileIndex.id, { onDelete: 'cascade' }),
+  status: workspaceFilingStatus('status').notNull().default('suggested'),
+  suggestedProjectKey: text('suggested_project_key'),
+  suggestedProjectLabel: text('suggested_project_label'),
+  matchedEntityType: text('matched_entity_type'),
+  matchedEntityValue: text('matched_entity_value'),
+  confidence: workspaceFilingConfidence('confidence').notNull().default('low'),
+  rationale: text('rationale'),
+  decidedProjectKey: text('decided_project_key'),
+  decidedLabel: varchar('decided_label', { length: 100 }),
+  decidedAt: timestamp('decided_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex('wsp_email_filings_file_unique').on(t.fileIndexId),
+  index('wsp_email_filings_org_status_idx').on(t.orgId, t.status),
+]);

--- a/ee/workspace/src/schema/coreRefs.ts
+++ b/ee/workspace/src/schema/coreRefs.ts
@@ -1,0 +1,13 @@
+// Read-only references to core-platform tables that Workspace does NOT own.
+//
+// These declarations exist solely so scoped read queries can be expressed in
+// Drizzle. Workspace never migrates, writes, or extends these tables — the
+// platform owns their DDL and their RLS policies. Only the columns Workspace
+// actually reads are declared; do not grow this file into a mirror of the
+// platform schema.
+import { pgTable, uuid } from 'drizzle-orm/pg-core';
+
+export const devices = pgTable('devices', {
+  id: uuid('id').primaryKey(),
+  orgId: uuid('org_id').notNull(),
+});

--- a/ee/workspace/src/schema/memoryBlocks.ts
+++ b/ee/workspace/src/schema/memoryBlocks.ts
@@ -1,0 +1,22 @@
+import {
+  pgTable, uuid, varchar, jsonb, timestamp, index, type AnyPgColumn,
+} from 'drizzle-orm/pg-core';
+
+/** Wick's exact shape — see internal/specs/2026-06-13 §5. Do not add an actor column. */
+export const memoryBlocks = pgTable('memory_blocks', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  partnerId: uuid('partner_id'),
+  blockType: varchar('block_type', { length: 64 }).notNull(),
+  subjectKey: varchar('subject_key', { length: 280 }).notNull(),
+  content: jsonb('content').notNull(),
+  confidence: varchar('confidence', { length: 16 })
+    .$type<'low' | 'medium' | 'high'>().notNull().default('medium'),
+  authoredByRunId: uuid('authored_by_run_id'),
+  confirmedAt: timestamp('confirmed_at', { withTimezone: true }),
+  retractedAt: timestamp('retracted_at', { withTimezone: true }),
+  supersededById: uuid('superseded_by_id')
+    .references((): AnyPgColumn => memoryBlocks.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [index('memory_blocks_org_subject_idx').on(t.orgId, t.subjectKey)]);

--- a/ee/workspace/src/schema/orgSettings.ts
+++ b/ee/workspace/src/schema/orgSettings.ts
@@ -1,0 +1,13 @@
+// NOTE: the SQL in migrations/ is the DDL source of truth (FKs, RLS
+// policies) — see migrations/2026-07-24-org-settings-dlp.sql. Do not
+// generate migrations from this definition with drizzle-kit.
+import { pgTable, uuid, boolean, jsonb, timestamp } from 'drizzle-orm/pg-core';
+
+// One row per org (org_id is the primary key, not a synthetic id).
+export const workspaceOrgSettings = pgTable('workspace_org_settings', {
+  orgId: uuid('org_id').primaryKey(),
+  contentEnabled: boolean('content_enabled').notNull().default(false),
+  dlpConfig: jsonb('dlp_config').$type<Record<string, unknown>>().notNull().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});

--- a/ee/workspace/src/schema/schema.test.ts
+++ b/ee/workspace/src/schema/schema.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { getTableColumns, getTableName } from 'drizzle-orm';
+import {
+  workspaceSources, workspaceFileIndex, workspaceFileActivity, workspaceCrawlRuns,
+} from './workspace';
+import { memoryBlocks } from './memoryBlocks';
+import {
+  workspaceFileContent, workspaceContentEntities, workspaceFileEnrichment,
+  workspaceProjects, workspaceProjectCrosswalk, workspaceEmailFilings,
+  workspaceContentChunks,
+} from './content';
+
+describe('schema ↔ migration parity (names)', () => {
+  it('table names match the migration', () => {
+    expect(getTableName(workspaceSources)).toBe('workspace_sources');
+    expect(getTableName(workspaceCrawlRuns)).toBe('workspace_crawl_runs');
+    expect(getTableName(workspaceFileIndex)).toBe('workspace_file_index');
+    expect(getTableName(workspaceFileActivity)).toBe('workspace_file_activity');
+    expect(getTableName(memoryBlocks)).toBe('memory_blocks');
+  });
+  it('memory_blocks has no actor/user column ("track work, not workers")', () => {
+    const cols = Object.values(getTableColumns(memoryBlocks)).map((c) => c.name);
+    expect(cols).not.toContain('user_id');
+    expect(cols).toContain('subject_key');
+    expect(cols).toContain('superseded_by_id');
+  });
+  it('file index carries the browser-view columns', () => {
+    const cols = Object.values(getTableColumns(workspaceFileIndex)).map((c) => c.name);
+    expect(cols).toEqual(expect.arrayContaining([
+      'is_dir', 'parent_path', 'rel_path', 'deleted_at', 'device_id', 'device_key',
+    ]));
+  });
+  it('sources carry crawler credentials and configuration columns', () => {
+    const cols = Object.values(getTableColumns(workspaceSources)).map((c) => c.name);
+    expect(cols).toEqual(expect.arrayContaining([
+      'credential_enc', 'exclude_globs', 'watch', 'error_reason', 'last_complete_run_at',
+    ]));
+    expect(cols).not.toContain('credential_ref');
+  });
+  it('file activity is helper-compatible (nullable user_id, helper_user label)', () => {
+    const columns = getTableColumns(workspaceFileActivity);
+    expect(Object.values(columns).map((c) => c.name)).toContain('helper_user');
+    expect(columns.helperUser.name).toBe('helper_user');
+    expect(columns.helperUser.notNull).toBe(false);
+    expect(columns.userId.notNull).toBe(false);
+  });
+  it('content tables carry the migration names', () => {
+    expect(getTableName(workspaceFileContent)).toBe('workspace_file_content');
+    expect(getTableName(workspaceContentEntities)).toBe('workspace_content_entities');
+    expect(getTableName(workspaceFileEnrichment)).toBe('workspace_file_enrichment');
+    expect(getTableName(workspaceProjects)).toBe('workspace_projects');
+    expect(getTableName(workspaceProjectCrosswalk)).toBe('workspace_project_crosswalk');
+    expect(getTableName(workspaceEmailFilings)).toBe('workspace_email_filings');
+  });
+  it('file content carries the idempotency snapshot and status', () => {
+    const columns = getTableColumns(workspaceFileContent);
+    const names = Object.values(columns).map((c) => c.name);
+    expect(names).toEqual(expect.arrayContaining([
+      'org_id', 'file_index_id', 'content_hash', 'source_size', 'source_mtime',
+      'extracted_text', 'status', 'error_reason', 'extracted_at',
+    ]));
+    expect(columns.status.enumValues).toEqual([
+      'extracted', 'failed', 'skipped_too_large', 'skipped_binary', 'blocked_dlp',
+    ]);
+  });
+  it('enrichment stores declared vs inferred (Beat 3 disagreement)', () => {
+    const names = Object.values(getTableColumns(workspaceFileEnrichment)).map((c) => c.name);
+    expect(names).toEqual(expect.arrayContaining([
+      'inferred_project_key', 'inferred_project_label', 'inferred_doc_type', 'doc_date',
+      'declared_project_key', 'declared_project_label', 'email_meta', 'confidence',
+      'model', 'enriched_at',
+    ]));
+  });
+  it('entities are typed and normalized', () => {
+    const names = Object.values(getTableColumns(workspaceContentEntities)).map((c) => c.name);
+    expect(names).toEqual(expect.arrayContaining([
+      'org_id', 'file_index_id', 'entity_type', 'value_norm',
+    ]));
+  });
+  it('crosswalk rows carry distinct-file evidence, filings carry decisions', () => {
+    const xw = Object.values(getTableColumns(workspaceProjectCrosswalk)).map((c) => c.name);
+    expect(xw).toEqual(expect.arrayContaining([
+      'entity_type', 'value_norm', 'project_key', 'project_label', 'evidence_count',
+      'sample_file_ids', 'mined_at',
+    ]));
+    const filings = getTableColumns(workspaceEmailFilings);
+    const names = Object.values(filings).map((c) => c.name);
+    expect(names).toEqual(expect.arrayContaining([
+      'status', 'suggested_project_key', 'suggested_project_label', 'matched_entity_type',
+      'matched_entity_value', 'confidence', 'rationale', 'decided_project_key',
+      'decided_label', 'decided_at', 'updated_at',
+    ]));
+    expect(filings.status.enumValues).toEqual(['suggested', 'confirmed', 'reassigned']);
+    expect(filings.confidence.enumValues).toEqual(['high', 'low']);
+    // Filing decisions are labeled with the device-local helper label, never identity.
+    expect(names).not.toContain('user_id');
+  });
+  it('content chunks carry 1024-dim embeddings keyed by (file, chunk_index)', () => {
+    expect(getTableName(workspaceContentChunks)).toBe('workspace_content_chunks');
+    const columns = getTableColumns(workspaceContentChunks);
+    const names = Object.values(columns).map((c) => c.name);
+    expect(names).toEqual(expect.arrayContaining([
+      'org_id', 'file_index_id', 'chunk_index', 'text', 'embedding',
+    ]));
+  });
+  it('projects registry keys are per-org', () => {
+    const names = Object.values(getTableColumns(workspaceProjects)).map((c) => c.name);
+    expect(names).toEqual(expect.arrayContaining(['org_id', 'project_key', 'label', 'aliases']));
+  });
+  it('crawl runs match the crawler migration columns and status enum', () => {
+    const columns = getTableColumns(workspaceCrawlRuns);
+    expect(Object.values(columns).map((c) => c.name)).toEqual([
+      'id', 'org_id', 'source_id', 'device_id', 'device_key', 'status', 'started_at',
+      'last_activity_at', 'completed_at', 'cursor', 'stats', 'error_reason',
+    ]);
+    expect(columns.status.enumValues).toEqual(['running', 'complete', 'failed', 'abandoned']);
+  });
+});

--- a/ee/workspace/src/schema/workspace.ts
+++ b/ee/workspace/src/schema/workspace.ts
@@ -1,0 +1,97 @@
+// NOTE: the SQL files in migrations/ are the DDL source of truth — they carry
+// FKs to core-platform tables (organizations, devices, users, ai_sessions),
+// the RLS policies, and the trigram indexes, none of which appear here. Do not
+// generate migrations from these definitions with drizzle-kit.
+import {
+  pgTable, uuid, text, varchar, boolean, bigint, integer, timestamp, jsonb, pgEnum,
+  index, uniqueIndex,
+} from 'drizzle-orm/pg-core';
+
+export const workspaceSourceKind = pgEnum('workspace_source_kind', ['smb_share', 'local_profile']);
+export const workspaceSourceStatus = pgEnum('workspace_source_status', ['active', 'paused', 'error']);
+export const workspaceFileAction = pgEnum('workspace_file_action', ['open', 'reveal', 'copy_path']);
+export const workspaceCrawlStatus = pgEnum('workspace_crawl_status', [
+  'running', 'complete', 'failed', 'abandoned',
+]);
+
+export const workspaceSources = pgTable('workspace_sources', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  kind: workspaceSourceKind('kind').notNull(),
+  displayName: text('display_name').notNull(),
+  rootPath: text('root_path').notNull(),
+  crawlDeviceId: uuid('crawl_device_id'),
+  visibilityGroupIds: jsonb('visibility_group_ids').$type<string[]>().notNull().default([]),
+  credentialEnc: text('credential_enc'),
+  excludeGlobs: jsonb('exclude_globs').$type<string[]>().notNull().default([]),
+  watch: boolean('watch').notNull().default(false),
+  crawlCadenceMinutes: integer('crawl_cadence_minutes').notNull().default(360),
+  // Reserved (no writer yet): crawlCursor — run cursors live on
+  // workspace_crawl_runs.cursor; statusDetail — errorReason is used instead.
+  crawlCursor: jsonb('crawl_cursor').notNull().default({}),
+  status: workspaceSourceStatus('status').notNull().default('active'),
+  statusDetail: text('status_detail'),
+  errorReason: text('error_reason'),
+  lastCompleteRunAt: timestamp('last_complete_run_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [index('wsp_sources_org_idx').on(t.orgId)]);
+
+export const workspaceFileIndex = pgTable('workspace_file_index', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  sourceId: uuid('source_id').notNull().references(() => workspaceSources.id, { onDelete: 'cascade' }),
+  deviceId: uuid('device_id'),
+  // NULL-proof stand-in for device_id in the unique index below (unique
+  // indexes treat NULLs as distinct); zero-uuid = source-scoped/SMB rows.
+  // Invariant device_key = COALESCE(device_id, zero-uuid) is app-enforced
+  // only — every writer must go through services/runScope.ts.
+  deviceKey: uuid('device_key').notNull().default('00000000-0000-0000-0000-000000000000'),
+  relPath: text('rel_path').notNull(),
+  parentPath: text('parent_path').notNull().default(''),
+  name: text('name').notNull(),
+  isDir: boolean('is_dir').notNull().default(false),
+  ext: text('ext'),
+  mime: text('mime'),
+  size: bigint('size', { mode: 'number' }),
+  mtime: timestamp('mtime', { withTimezone: true }),
+  ctime: timestamp('ctime', { withTimezone: true }),
+  attrs: jsonb('attrs').notNull().default({}),
+  lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull().defaultNow(),
+  deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex('wsp_file_index_org_source_device_rel_path_unique')
+    .on(t.orgId, t.sourceId, t.deviceKey, t.relPath),
+  index('wsp_file_index_parent_idx').on(t.orgId, t.sourceId, t.parentPath),
+]);
+
+export const workspaceCrawlRuns = pgTable('workspace_crawl_runs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  sourceId: uuid('source_id').notNull().references(() => workspaceSources.id, { onDelete: 'cascade' }),
+  deviceId: uuid('device_id'),
+  // Same COALESCE(device_id, zero-uuid) convention as workspace_file_index —
+  // see services/runScope.ts.
+  deviceKey: uuid('device_key').notNull().default('00000000-0000-0000-0000-000000000000'),
+  status: workspaceCrawlStatus('status').notNull().default('running'),
+  startedAt: timestamp('started_at', { withTimezone: true }).notNull().defaultNow(),
+  lastActivityAt: timestamp('last_activity_at', { withTimezone: true }).notNull().defaultNow(),
+  completedAt: timestamp('completed_at', { withTimezone: true }),
+  cursor: text('cursor'),
+  stats: jsonb('stats').$type<Record<string, unknown>>().notNull().default({}),
+  errorReason: text('error_reason'),
+}, (t) => [index('wsp_crawl_runs_org_source_status_idx').on(t.orgId, t.sourceId, t.status)]);
+
+export const workspaceFileActivity = pgTable('workspace_file_activity', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  userId: uuid('user_id'),
+  fileIndexId: uuid('file_index_id').notNull().references(() => workspaceFileIndex.id, { onDelete: 'cascade' }),
+  deviceId: uuid('device_id'),
+  // Device-local free-text display label for helper sessions (never authorization).
+  helperUser: varchar('helper_user', { length: 100 }),
+  action: workspaceFileAction('action').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [index('wsp_file_activity_org_user_idx').on(t.orgId, t.userId, t.createdAt.desc())]);

--- a/ee/workspace/src/services/activityService.test.ts
+++ b/ee/workspace/src/services/activityService.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { SHARED_DEVICE_KEY } from './runScope';
+import { createActivityService } from './activityService';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SMB_SOURCE_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const FILE_ID = '88888888-8888-8888-8888-888888888888';
+
+/**
+ * Values reachable from a raw drizzle sql template. Raw templates store bound
+ * params as bare primitives between StringChunks (crawlRunsService.test.ts
+ * convention), so primitives count as bound values here.
+ */
+function boundValues(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => item && typeof item === 'object' ? boundValues(item) : [item]);
+  }
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value')
+    ? (Array.isArray(candidate.value) ? candidate.value : [candidate.value])
+    : [];
+  return [
+    ...own,
+    ...(candidate.queryChunks ?? []).flatMap((item) =>
+      item && typeof item === 'object' ? boundValues(item) : [item]),
+  ];
+}
+
+/** Approximate SQL text of a drizzle expression (columns as bare names, params as ?). */
+function sqlText(value: unknown): string {
+  if (value == null) return '';
+  if (Array.isArray(value)) return value.map(sqlText).join('');
+  if (typeof value !== 'object') return String(value);
+  const c = value as Record<string, unknown>;
+  if ('encoder' in c) return '?';
+  if (Array.isArray(c.queryChunks)) return (c.queryChunks as unknown[]).map(sqlText).join('');
+  if (Array.isArray(c.value) && (c.value as unknown[]).every((x) => typeof x === 'string')) {
+    return (c.value as string[]).join('');
+  }
+  if (typeof c.name === 'string') return c.name;
+  return '';
+}
+
+/** A joined activity/file/source row as raw execute() returns it (snake_case, bigint as string). */
+function joinedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FILE_ID,
+    source_id: SMB_SOURCE_ID,
+    device_key: SHARED_DEVICE_KEY,
+    rel_path: 'a/b.pdf',
+    parent_path: 'a',
+    name: 'b.pdf',
+    is_dir: false,
+    ext: 'pdf',
+    size: '10',
+    mtime: new Date('2026-07-01T00:00:00Z'),
+    kind: 'smb_share',
+    root_path: '\\\\srv\\share',
+    last_activity_at: new Date('2026-07-02T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function makeDb(executeResults: unknown[][] = []) {
+  let executeIndex = 0;
+  const executed: unknown[] = [];
+  const insertValues: unknown[] = [];
+  const db = {
+    execute: vi.fn(async (query: unknown) => {
+      executed.push(query);
+      return executeResults[executeIndex++] ?? [];
+    }),
+    insert: vi.fn(() => ({
+      values: vi.fn(async (value: unknown) => {
+        insertValues.push(value);
+      }),
+    })),
+  };
+  return { db: db as unknown as WorkspaceDatabase, raw: db, executed, insertValues };
+}
+
+const MAPPED_SMB_FILE = {
+  id: FILE_ID,
+  sourceId: SMB_SOURCE_ID,
+  deviceKey: SHARED_DEVICE_KEY,
+  relPath: 'a/b.pdf',
+  parentPath: 'a',
+  name: 'b.pdf',
+  isDir: false,
+  ext: 'pdf',
+  size: 10,
+  mtime: '2026-07-01T00:00:00.000Z',
+  openPath: '\\\\srv\\share\\a\\b.pdf',
+};
+
+describe('activityService', () => {
+  describe('record', () => {
+    it('returns notFound and writes nothing when the file is unknown, tombstoned, or hidden', async () => {
+      const { db, raw, executed, insertValues } = makeDb([[]]);
+      const result = await createActivityService(db).record(ORG_ID, {
+        fileIndexId: FILE_ID, deviceId: DEVICE_ID, helperUser: 'Dana', action: 'open',
+      });
+      expect(result).toEqual({ notFound: true });
+      expect(raw.insert).not.toHaveBeenCalled();
+      expect(insertValues).toEqual([]);
+      // The verification query itself must encode every fail-closed rule.
+      const text = sqlText(executed[0]);
+      expect(text).toContain('deleted_at is null');
+      expect(text).toContain("'[]'::jsonb");
+      expect(text).toContain("'active'");
+      const values = boundValues(executed[0]);
+      expect(values).toContain(ORG_ID);
+      expect(values).toContain(FILE_ID);
+      expect(values).toContain(DEVICE_ID);
+      expect(values).toContain(SHARED_DEVICE_KEY);
+    });
+
+    it('inserts a device-attributed row with null user_id and the helper label', async () => {
+      const { db, insertValues } = makeDb([[{ id: FILE_ID }]]);
+      const result = await createActivityService(db).record(ORG_ID, {
+        fileIndexId: FILE_ID, deviceId: DEVICE_ID, helperUser: 'Dana', action: 'copy_path',
+      });
+      expect(result).toEqual({ recorded: true });
+      expect(insertValues).toEqual([{
+        orgId: ORG_ID,
+        userId: null,
+        fileIndexId: FILE_ID,
+        deviceId: DEVICE_ID,
+        helperUser: 'Dana',
+        action: 'copy_path',
+      }]);
+    });
+
+    it('inserts a null helper label unchanged', async () => {
+      const { db, insertValues } = makeDb([[{ id: FILE_ID }]]);
+      await createActivityService(db).record(ORG_ID, {
+        fileIndexId: FILE_ID, deviceId: DEVICE_ID, helperUser: null, action: 'open',
+      });
+      expect(insertValues[0]).toMatchObject({ userId: null, helperUser: null, action: 'open' });
+    });
+  });
+
+  describe('recents', () => {
+    it('returns the latest activity per file, newest first, mapped like search results', async () => {
+      const { db, executed } = makeDb([[joinedRow()]]);
+      const result = await createActivityService(db).recents(ORG_ID, DEVICE_ID, null);
+      expect(result).toEqual([MAPPED_SMB_FILE]);
+      const text = sqlText(executed[0]);
+      expect(text).toContain('distinct on (a.file_index_id)');
+      expect(text).toContain('order by a.file_index_id, a.created_at desc');
+      expect(text).toContain('order by t.last_activity_at desc');
+      expect(text).toContain('deleted_at is null');
+      expect(text).toContain("'[]'::jsonb");
+      const values = boundValues(executed[0]);
+      expect(values).toContain(DEVICE_ID);
+      expect(values).toContain(SHARED_DEVICE_KEY);
+    });
+
+    it('filters by helper label only when one is provided', async () => {
+      const { db, executed } = makeDb([[], []]);
+      const service = createActivityService(db);
+      await service.recents(ORG_ID, DEVICE_ID, 'Dana');
+      expect(sqlText(executed[0])).toContain('helper_user');
+      expect(boundValues(executed[0])).toContain('Dana');
+      await service.recents(ORG_ID, DEVICE_ID, null);
+      expect(sqlText(executed[1])).not.toContain('helper_user');
+    });
+
+    it('maps local-profile rows to a null openPath', async () => {
+      const { db } = makeDb([[joinedRow({ kind: 'local_profile', device_key: DEVICE_ID })]]);
+      const result = await createActivityService(db).recents(ORG_ID, DEVICE_ID, null);
+      expect(result[0]?.openPath).toBeNull();
+    });
+
+    it('clamps the limit to 1..50 and defaults to 20', async () => {
+      const { db, executed } = makeDb([[], [], []]);
+      const service = createActivityService(db);
+      await service.recents(ORG_ID, DEVICE_ID, null, 0);
+      await service.recents(ORG_ID, DEVICE_ID, null, 500);
+      await service.recents(ORG_ID, DEVICE_ID, null);
+      expect(boundValues(executed[0])).toContain(1);
+      expect(boundValues(executed[1])).toContain(50);
+      expect(boundValues(executed[2])).toContain(20);
+    });
+  });
+
+  describe('departmentRecent', () => {
+    it('aggregates the newest activity per file org-wide with no actor attribution', async () => {
+      const { db, executed } = makeDb([[joinedRow()]]);
+      const result = await createActivityService(db).departmentRecent(ORG_ID, DEVICE_ID);
+      expect(result).toEqual([{ ...MAPPED_SMB_FILE, lastActivityAt: '2026-07-02T00:00:00.000Z' }]);
+      const text = sqlText(executed[0]);
+      expect(text).toContain('max(a.created_at)');
+      expect(text).toContain('group by a.file_index_id');
+      // Substrate stays "track work, not workers": no who/which-device columns.
+      expect(text).not.toContain('helper_user');
+      expect(text).not.toContain('a.device_id');
+    });
+
+    it('restricts rows to visible sources and the caller-visible partition', async () => {
+      const { db, executed } = makeDb([[]]);
+      await createActivityService(db).departmentRecent(ORG_ID, DEVICE_ID);
+      const text = sqlText(executed[0]);
+      expect(text).toContain("'[]'::jsonb");
+      expect(text).toContain("'active'");
+      expect(text).toContain('deleted_at is null');
+      const values = boundValues(executed[0]);
+      expect(values).toContain(DEVICE_ID);
+      expect(values).toContain(SHARED_DEVICE_KEY);
+    });
+
+    it('clamps the limit to 1..50 and defaults to 20', async () => {
+      const { db, executed } = makeDb([[], [], []]);
+      const service = createActivityService(db);
+      await service.departmentRecent(ORG_ID, DEVICE_ID, 0);
+      await service.departmentRecent(ORG_ID, DEVICE_ID, 500);
+      await service.departmentRecent(ORG_ID, DEVICE_ID);
+      expect(boundValues(executed[0])).toContain(1);
+      expect(boundValues(executed[1])).toContain(50);
+      expect(boundValues(executed[2])).toContain(20);
+    });
+  });
+});

--- a/ee/workspace/src/services/activityService.ts
+++ b/ee/workspace/src/services/activityService.ts
@@ -1,0 +1,187 @@
+import type { WorkspaceDatabase } from '../hostTypes';
+import { sql, type SQL } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { workspaceFileActivity } from '../schema/workspace';
+import type { FinderFile } from './fileQueryService';
+import { SHARED_DEVICE_KEY } from './runScope';
+import { visibleSourcePredicateSql } from './visibility';
+
+export type ActivityAction = 'open' | 'reveal' | 'copy_path';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+function clampLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(limit)));
+}
+
+/**
+ * The visible-sources join for the raw DISTINCT ON / aggregate queries below.
+ * The visibility rule itself is the shared predicate in visibility.ts (aliased
+ * `s`); empty `groupIds` fails closed to ungrouped sources.
+ */
+function visibleSourceJoinSql(groupIds: string[]): SQL {
+  return sql`
+  join workspace_sources s
+    on s.id = f.source_id
+   and s.org_id = f.org_id
+   and ${visibleSourcePredicateSql(sql, groupIds)}`;
+}
+
+/**
+ * Partition rule (defence-in-depth atop RLS): smb rows live under the shared
+ * device key and are org-visible; local-profile rows only exist for the device
+ * that produced them. Applied to every read AND to record()'s verification so
+ * the activity API can never confirm (or later surface) a file outside the
+ * calling device's partition.
+ */
+function partitionSql(helperDeviceId: string): SQL {
+  return sql`((s.kind = 'smb_share' and f.device_key = ${SHARED_DEVICE_KEY})
+    or (s.kind = 'local_profile' and f.device_key = ${helperDeviceId}))`;
+}
+
+const fileColumnsSql = sql`
+  f.id, f.source_id, f.device_key, f.rel_path, f.parent_path, f.name,
+  f.is_dir, f.ext, f.size, f.mtime, s.kind, s.root_path`;
+
+/** A joined file/source row as raw execute() returns it (snake_case; bigint as string). */
+interface JoinedFileRow {
+  id: string;
+  source_id: string;
+  device_key: string;
+  rel_path: string;
+  parent_path: string;
+  name: string;
+  is_dir: boolean;
+  ext: string | null;
+  size: string | number | null;
+  mtime: Date | string | null;
+  kind: 'smb_share' | 'local_profile';
+  root_path: string;
+  last_activity_at: Date | string;
+}
+
+// Same openPath rule as fileQueryService.openPathFor (duplicated because the
+// raw rows here carry kind/root_path inline rather than a VisibleSource).
+function toFinderFile(row: JoinedFileRow): FinderFile {
+  const openPath = !row.is_dir && row.kind === 'smb_share'
+    ? `${row.root_path}\\${row.rel_path.replaceAll('/', '\\')}`
+    : null;
+  return {
+    id: row.id,
+    sourceId: row.source_id,
+    deviceKey: row.device_key,
+    relPath: row.rel_path,
+    parentPath: row.parent_path,
+    name: row.name,
+    isDir: row.is_dir,
+    ext: row.ext,
+    size: row.size === null ? null : Number(row.size),
+    mtime: row.mtime === null ? null : new Date(row.mtime).toISOString(),
+    openPath,
+  };
+}
+
+export function createActivityService(db: WorkspaceDatabase) {
+  const d = db;
+
+  return {
+    /**
+     * Verifies the file exists, is not tombstoned, and sits in a source/partition
+     * the calling device may see (else notFound — hidden files must never leak
+     * through the activity API), then inserts with user_id = NULL: helper
+     * sessions have no users-table identity, only the free-text device-local
+     * label (never authorization).
+     */
+    async record(
+      orgId: string,
+      input: {
+        fileIndexId: string;
+        deviceId: string;
+        helperUser: string | null;
+        action: ActivityAction;
+      },
+      groupIds: string[] = [],
+    ): Promise<{ recorded: true } | { notFound: true }> {
+      const visible = await d.execute(sql`
+        select f.id
+        from workspace_file_index f
+        ${visibleSourceJoinSql(groupIds)}
+        where f.org_id = ${orgId}
+          and f.id = ${input.fileIndexId}
+          and f.deleted_at is null
+          and ${partitionSql(input.deviceId)}`);
+      if (visible.length === 0) return { notFound: true };
+      await d.insert(workspaceFileActivity).values({
+        orgId,
+        userId: null,
+        fileIndexId: input.fileIndexId,
+        deviceId: input.deviceId,
+        helperUser: input.helperUser,
+        action: input.action,
+      });
+      return { recorded: true };
+    },
+
+    /** Latest activity per file for one device (DISTINCT ON), newest first. */
+    async recents(
+      orgId: string,
+      deviceId: string,
+      helperUser: string | null,
+      limit?: number,
+      groupIds: string[] = [],
+    ): Promise<FinderFile[]> {
+      const rows = await d.execute(sql`
+        select t.* from (
+          select distinct on (a.file_index_id)
+            ${fileColumnsSql},
+            a.created_at as last_activity_at
+          from workspace_file_activity a
+          join workspace_file_index f on f.id = a.file_index_id and f.org_id = a.org_id
+          ${visibleSourceJoinSql(groupIds)}
+          where a.org_id = ${orgId}
+            and a.device_id = ${deviceId}
+            ${helperUser === null ? sql`` : sql`and a.helper_user = ${helperUser}`}
+            and f.deleted_at is null
+            and ${partitionSql(deviceId)}
+          order by a.file_index_id, a.created_at desc
+        ) t
+        order by t.last_activity_at desc
+        limit ${clampLimit(limit)}`);
+      return (rows as unknown as JoinedFileRow[]).map(toFinderFile);
+    },
+
+    /**
+     * Org-wide "recently active in your company" feed: MAX(created_at) per file,
+     * visible sources and the caller's partition only, and deliberately WITHOUT
+     * who/which-device attribution — the substrate tracks work, not workers
+     * (no per-person feed in v1).
+     */
+    async departmentRecent(
+      orgId: string,
+      helperDeviceId: string,
+      limit?: number,
+      groupIds: string[] = [],
+    ): Promise<Array<FinderFile & { lastActivityAt: string }>> {
+      const rows = await d.execute(sql`
+        select ${fileColumnsSql}, x.last_activity_at
+        from (
+          select a.file_index_id, max(a.created_at) as last_activity_at
+          from workspace_file_activity a
+          where a.org_id = ${orgId}
+          group by a.file_index_id
+        ) x
+        join workspace_file_index f on f.id = x.file_index_id and f.org_id = ${orgId}
+        ${visibleSourceJoinSql(groupIds)}
+        where f.deleted_at is null
+          and ${partitionSql(helperDeviceId)}
+        order by x.last_activity_at desc
+        limit ${clampLimit(limit)}`);
+      return (rows as unknown as JoinedFileRow[]).map((row) => ({
+        ...toFinderFile(row),
+        lastActivityAt: new Date(row.last_activity_at).toISOString(),
+      }));
+    },
+  };
+}

--- a/ee/workspace/src/services/batchUpsertService.test.ts
+++ b/ee/workspace/src/services/batchUpsertService.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { SQL } from 'drizzle-orm';
+import { workspaceFileIndex } from '../schema/workspace';
+import { createBatchUpsertService, MAX_BATCH_ENTRIES, type BatchEntry } from './batchUpsertService';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SOURCE_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const OTHER_ORG_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+function boundValues(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => item && typeof item === 'object' ? boundValues(item) : [item]);
+  }
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value')
+    ? (Array.isArray(candidate.value) ? candidate.value : [candidate.value])
+    : [];
+  return [...own, ...(candidate.queryChunks ?? []).flatMap(boundValues)];
+}
+
+function containsIdentity(value: unknown, target: unknown): boolean {
+  if (value === target) return true;
+  if (Array.isArray(value)) return value.some((item) => containsIdentity(item, target));
+  if (!value || typeof value !== 'object') return false;
+  return ((value as { queryChunks?: unknown[] }).queryChunks ?? [])
+    .some((item) => containsIdentity(item, target));
+}
+
+function sqlText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(sqlText).join('');
+  if (!value || typeof value !== 'object') return '';
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Array.isArray(candidate.value) && candidate.value.every((part) => typeof part === 'string')
+    ? candidate.value.join('')
+    : '';
+  return own + (candidate.queryChunks ?? []).map(sqlText).join('');
+}
+
+function expectDatabaseNow(value: unknown): void {
+  expect(value).toBeInstanceOf(SQL);
+  expect(sqlText(value)).toBe('now()');
+}
+
+function entry(index = 0): BatchEntry {
+  return {
+    relPath: `folder/file-${index}.txt`, parentPath: 'folder', name: `file-${index}.txt`,
+    isDir: false, size: index, mtime: '2026-07-12T12:00:00.000Z', ctime: null,
+    ext: 'txt', attrs: { hidden: false },
+  };
+}
+
+function makeDb() {
+  const batches: Array<Record<string, unknown>[]> = [];
+  const conflicts: unknown[] = [];
+  const db = {
+    insert: vi.fn((table: unknown) => {
+      expect(table).toBe(workspaceFileIndex);
+      return {
+        values: vi.fn((rows: Array<Record<string, unknown>>) => {
+          batches.push(rows);
+          return {
+            onConflictDoUpdate: vi.fn((config: unknown) => {
+              conflicts.push(config);
+              return { returning: vi.fn(async () => rows.map((_, i) => ({ id: String(i) }))) };
+            }),
+          };
+        }),
+      };
+    }),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(async () => [{ id: '1' }, { id: '2' }]) })) })),
+    })),
+  };
+  return { db: db as unknown as WorkspaceDatabase, raw: db, batches, conflicts };
+}
+
+describe('batchUpsertService', () => {
+  it('exports the route validation ceiling', () => {
+    expect(MAX_BATCH_ENTRIES).toBe(2000);
+  });
+
+  it('maps entries to scoped rows and reports inserted and expected counts', async () => {
+    const h = makeDb();
+    await expect(createBatchUpsertService(h.db).upsertBatch(ORG_ID, SOURCE_ID, DEVICE_ID, [entry()]))
+      .resolves.toEqual({ inserted: 1, expected: 1 });
+    expect(h.batches[0]?.[0]).toMatchObject({
+      orgId: ORG_ID, sourceId: SOURCE_ID, deviceId: DEVICE_ID, deviceKey: DEVICE_ID,
+      relPath: 'folder/file-0.txt', mtime: new Date('2026-07-12T12:00:00.000Z'),
+    });
+    expectDatabaseNow(h.batches[0]?.[0]?.lastSeenAt);
+    expectDatabaseNow(h.batches[0]?.[0]?.updatedAt);
+  });
+
+  it('uses the four-column conflict target and clears deletedAt to resurrect rows', async () => {
+    const h = makeDb();
+    await createBatchUpsertService(h.db).upsertBatch(ORG_ID, SOURCE_ID, DEVICE_ID, [entry()]);
+    expect(h.conflicts[0]).toMatchObject({
+      target: [workspaceFileIndex.orgId, workspaceFileIndex.sourceId, workspaceFileIndex.deviceKey, workspaceFileIndex.relPath],
+      set: expect.objectContaining({ deletedAt: null }),
+    });
+  });
+
+  it('chunks 2,001 entries into exactly five writes of at most 500', async () => {
+    const h = makeDb();
+    const entries = Array.from({ length: 2001 }, (_, i) => entry(i));
+    await expect(createBatchUpsertService(h.db).upsertBatch(ORG_ID, SOURCE_ID, DEVICE_ID, entries))
+      .resolves.toEqual({ inserted: 2001, expected: 2001 });
+    expect(h.raw.insert).toHaveBeenCalledTimes(5);
+    expect(h.batches.map((batch) => batch.length)).toEqual([500, 500, 500, 500, 1]);
+  });
+
+  it('deduplicates relPath across a batch with the last entry winning', async () => {
+    const h = makeDb();
+    const first = entry();
+    const last = { ...entry(), name: 'replacement.txt', size: 42, attrs: { hidden: true } };
+
+    await expect(createBatchUpsertService(h.db).upsertBatch(
+      ORG_ID, SOURCE_ID, DEVICE_ID, [first, last],
+    )).resolves.toEqual({ inserted: 1, expected: 2 });
+    expect(h.batches).toHaveLength(1);
+    expect(h.batches[0]).toHaveLength(1);
+    expect(h.batches[0]?.[0]).toMatchObject({
+      relPath: first.relPath,
+      name: 'replacement.txt',
+      size: 42,
+      attrs: { hidden: true },
+    });
+  });
+
+  it('performs no insert for an empty batch', async () => {
+    const h = makeDb();
+    await expect(createBatchUpsertService(h.db).upsertBatch(ORG_ID, SOURCE_ID, DEVICE_ID, []))
+      .resolves.toEqual({ inserted: 0, expected: 0 });
+    expect(h.raw.insert).not.toHaveBeenCalled();
+  });
+
+  it('tombstones exact paths and skips an empty path list', async () => {
+    const rows = [
+      { id: 'match-a', orgId: ORG_ID, sourceId: SOURCE_ID, deviceKey: DEVICE_ID, relPath: 'a.txt', deletedAt: null as Date | null },
+      { id: 'match-b', orgId: ORG_ID, sourceId: SOURCE_ID, deviceKey: DEVICE_ID, relPath: 'b.txt', deletedAt: null as Date | null },
+      { id: 'cross-org', orgId: OTHER_ORG_ID, sourceId: SOURCE_ID, deviceKey: DEVICE_ID, relPath: 'a.txt', deletedAt: null as Date | null },
+      { id: 'wrong-source', orgId: ORG_ID, sourceId: OTHER_ORG_ID, deviceKey: DEVICE_ID, relPath: 'a.txt', deletedAt: null as Date | null },
+      { id: 'wrong-device', orgId: ORG_ID, sourceId: SOURCE_ID, deviceKey: OTHER_ORG_ID, relPath: 'a.txt', deletedAt: null as Date | null },
+      { id: 'not-requested', orgId: ORG_ID, sourceId: SOURCE_ID, deviceKey: DEVICE_ID, relPath: 'c.txt', deletedAt: null as Date | null },
+      { id: 'already-deleted', orgId: ORG_ID, sourceId: SOURCE_ID, deviceKey: DEVICE_ID, relPath: 'a.txt', deletedAt: new Date('2026-01-01') as Date | null },
+    ];
+    const alreadyDeletedAt = rows.at(-1)?.deletedAt;
+    let tombstoneSet: Record<string, unknown> | undefined;
+    const update = vi.fn(() => ({
+      set: vi.fn((setValue: Record<string, unknown>) => {
+        tombstoneSet = setValue;
+        return {
+          where: vi.fn((condition: unknown) => ({
+            returning: vi.fn(async () => {
+              const values = boundValues(condition);
+              const requested = values.filter((value) => value === 'a.txt' || value === 'b.txt') as string[];
+              const requiresUndeleted = containsIdentity(condition, workspaceFileIndex.deletedAt);
+              const matches = rows.filter((row) =>
+                (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+                (!values.includes(SOURCE_ID) || row.sourceId === SOURCE_ID) &&
+                (!values.includes(DEVICE_ID) || row.deviceKey === DEVICE_ID) &&
+                (requested.length === 0 || requested.includes(row.relPath)) &&
+                (!requiresUndeleted || row.deletedAt === null));
+              for (const row of matches) row.deletedAt = new Date();
+              return matches.map(({ id }) => ({ id }));
+            }),
+          })),
+        };
+      }),
+    }));
+    const service = createBatchUpsertService({ update } as unknown as WorkspaceDatabase);
+    await expect(service.tombstonePaths(ORG_ID, SOURCE_ID, DEVICE_ID, ['a.txt', 'b.txt'])).resolves.toBe(2);
+    await expect(service.tombstonePaths(ORG_ID, SOURCE_ID, DEVICE_ID, [])).resolves.toBe(0);
+    expect(rows.slice(0, 2).every((row) => row.deletedAt instanceof Date)).toBe(true);
+    expect(rows.slice(2, -1).every((row) => row.deletedAt === null)).toBe(true);
+    expect(rows.at(-1)?.deletedAt).toBe(alreadyDeletedAt);
+    expect(update).toHaveBeenCalledTimes(1);
+    expectDatabaseNow(tombstoneSet?.deletedAt);
+    expectDatabaseNow(tombstoneSet?.updatedAt);
+  });
+});

--- a/ee/workspace/src/services/batchUpsertService.ts
+++ b/ee/workspace/src/services/batchUpsertService.ts
@@ -1,0 +1,122 @@
+import type { WorkspaceDatabase } from '../hostTypes';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { z } from 'zod';
+import { workspaceFileIndex } from '../schema/workspace';
+import { deviceIdFromKey } from './runScope';
+
+export const MAX_BATCH_ENTRIES = 2000;
+const UPSERT_CHUNK_SIZE = 500;
+
+// Wire shape for one file-index entry (spec §2.4; the Go agent serializes
+// these). Timestamps are validated as ISO-8601 here so a garbage mtime is a
+// 400 at the boundary instead of an Invalid Date exploding mid-chunk after
+// earlier chunks already committed.
+export const batchEntrySchema = z.object({
+  relPath: z.string().max(4096),
+  parentPath: z.string().max(4096),
+  name: z.string().max(512),
+  isDir: z.boolean(),
+  size: z.number().int().nonnegative(),
+  mtime: z.iso.datetime({ offset: true }),
+  ctime: z.iso.datetime({ offset: true }).nullable().optional(),
+  ext: z.string().max(64).nullable().optional(),
+  attrs: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+export type BatchEntry = z.infer<typeof batchEntrySchema>;
+
+export function createBatchUpsertService(d: WorkspaceDatabase) {
+  return {
+    /**
+     * Chunks intentionally run without one encompassing transaction. Upserts are
+     * idempotent, so callers recover by retrying; sweep execution remains gated on
+     * an explicit complete finish.
+     *
+     * Entries are deduplicated by relPath before writing, last entry wins —
+     * required because ON CONFLICT DO UPDATE cannot touch the same row twice in
+     * one statement ("cannot affect row a second time"). The returned `inserted`
+     * counts rows written post-dedup (inserts and updates alike) while `expected`
+     * echoes the raw entry count, so inserted < expected simply means the batch
+     * carried duplicate relPaths — it is NOT a partial-failure signal. Both
+     * fields go over the wire to the Go agent verbatim.
+     */
+    async upsertBatch(
+      orgId: string,
+      sourceId: string,
+      deviceKey: string,
+      entries: BatchEntry[],
+    ): Promise<{ inserted: number; expected: number }> {
+      const deduplicatedEntries = [...new Map(
+        entries.map((entry) => [entry.relPath, entry]),
+      ).values()];
+      let inserted = 0;
+      for (let offset = 0; offset < deduplicatedEntries.length; offset += UPSERT_CHUNK_SIZE) {
+        const chunk = deduplicatedEntries.slice(offset, offset + UPSERT_CHUNK_SIZE);
+        const rows = chunk.map((entry) => ({
+          orgId,
+          sourceId,
+          deviceId: deviceIdFromKey(deviceKey),
+          deviceKey,
+          relPath: entry.relPath,
+          parentPath: entry.parentPath,
+          name: entry.name,
+          isDir: entry.isDir,
+          size: entry.size,
+          mtime: new Date(entry.mtime),
+          ctime: entry.ctime ? new Date(entry.ctime) : null,
+          ext: entry.ext ?? null,
+          attrs: entry.attrs ?? {},
+          lastSeenAt: sql`now()`,
+          deletedAt: null,
+          updatedAt: sql`now()`,
+        }));
+
+        const written = await d.insert(workspaceFileIndex).values(rows)
+          .onConflictDoUpdate({
+            target: [
+              workspaceFileIndex.orgId,
+              workspaceFileIndex.sourceId,
+              workspaceFileIndex.deviceKey,
+              workspaceFileIndex.relPath,
+            ],
+            set: {
+              name: sql`excluded.name`,
+              parentPath: sql`excluded.parent_path`,
+              isDir: sql`excluded.is_dir`,
+              size: sql`excluded.size`,
+              mtime: sql`excluded.mtime`,
+              ctime: sql`excluded.ctime`,
+              ext: sql`excluded.ext`,
+              attrs: sql`excluded.attrs`,
+              lastSeenAt: sql`now()`,
+              deletedAt: null,
+              updatedAt: sql`now()`,
+            },
+          })
+          .returning({ id: workspaceFileIndex.id });
+        inserted += written.length;
+      }
+      return { inserted, expected: entries.length };
+    },
+
+    async tombstonePaths(
+      orgId: string,
+      sourceId: string,
+      deviceKey: string,
+      relPaths: string[],
+    ): Promise<number> {
+      if (relPaths.length === 0) return 0;
+      const rows = await d.update(workspaceFileIndex)
+        .set({ deletedAt: sql`now()`, updatedAt: sql`now()` })
+        .where(and(
+          eq(workspaceFileIndex.orgId, orgId),
+          eq(workspaceFileIndex.sourceId, sourceId),
+          eq(workspaceFileIndex.deviceKey, deviceKey),
+          inArray(workspaceFileIndex.relPath, relPaths),
+          isNull(workspaceFileIndex.deletedAt),
+        ))
+        .returning({ id: workspaceFileIndex.id });
+      return rows.length;
+    },
+  };
+}

--- a/ee/workspace/src/services/contentIngestService.ts
+++ b/ee/workspace/src/services/contentIngestService.ts
@@ -327,7 +327,7 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
             for (let i = 0; i < chunks.length; i += 1) {
               await d.execute(sql`
                 INSERT INTO workspace_content_chunks (org_id, file_index_id, chunk_index, text, embedding)
-                VALUES (${orgId}, ${file.id}, ${i}, ${chunks[i]}, ${toVectorLiteral(vectors[i])}::vector)
+                VALUES (${orgId}, ${file.id}, ${i}, ${chunks[i]}, ${toVectorLiteral(vectors[i]!)}::vector)
               `);
             }
           }

--- a/ee/workspace/src/services/contentIngestService.ts
+++ b/ee/workspace/src/services/contentIngestService.ts
@@ -1,0 +1,387 @@
+// Content ingest runner (dev-preview; per-org content flag).
+//
+// Batch-per-request by design: the caller (admin route) processes up to N
+// pending files INSIDE the request, where the org RLS context is valid, and
+// returns {processed, remaining} so a dev loop can drive it to zero. No
+// detached worker, no queue — FORCE RLS makes a fire-and-forget async runner
+// a footgun (no org GUCs on its connections), and the preview estate is a
+// couple hundred files.
+//
+// "Pending" = a live, non-tombstoned file in a visible smb_share source whose
+// content row is missing or whose (source_size, source_mtime) snapshot is
+// stale. A matching sha256 short-circuits re-extraction (snapshot refresh
+// only). Failures/skips also store the snapshot so one broken file cannot
+// wedge the loop.
+//
+// DLP-on-ingest (W2): DLP runs ONCE here, right after extractContent and
+// BEFORE any persistence or embedding. The org's DlpConfig is fetched once per
+// run. A 'block'-action detector hit short-circuits the file to
+// status='blocked_dlp' with no text, no chunks, and no embedder call (the
+// snapshot is still written, so a blocked file is skipped — not retried — on
+// the next run). Otherwise 'redact' hits rewrite the text and EVERYTHING
+// downstream (stored extracted_text, entities, chunks, embeddings, and the
+// enrichment prompt) is derived from that redacted text. Entities
+// (extractEntities) therefore run on the redacted text: structured entity IDs
+// (PO/APN/etc.) are not DLP targets and survive redaction, while any redacted
+// span is already gone before entity extraction sees it.
+import type { WorkspaceDatabase } from '../hostTypes';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { ContentByteReader } from '../content/byteReader';
+import { chunkText, toVectorLiteral, type Embedder } from '../content/embedder';
+import { extractContent, type EmailMeta } from '../content/extract';
+import { extractEntities } from '../content/entities';
+import { deriveDeclaredProject } from '../content/projects';
+import { applyDlpToText, type DlpFinding } from '../content/dlp';
+import { getOrgSettings } from './orgSettingsService';
+
+export interface IngestError {
+  fileIndexId: string;
+  relPath: string;
+  error: string;
+}
+
+export interface IngestRunResult {
+  processed: number;
+  remaining: number;
+  errors: IngestError[];
+}
+
+export interface IngestStatus {
+  eligible: number;
+  extracted: number;
+  failed: number;
+  skippedTooLarge: number;
+  skippedBinary: number;
+  pending: number;
+}
+
+interface PendingRow {
+  id: string;
+  source_id: string;
+  rel_path: string;
+  name: string;
+  size: string | number | null;
+  mtime: string | null;
+  root_path: string;
+  source_kind: string;
+  content_hash: string | null;
+}
+
+export interface ContentIngestDeps {
+  reader: ContentByteReader;
+  maxBytes?: number;
+  /** Absent → chunk/embedding writes are skipped entirely (lexical-only). */
+  embedder?: Embedder;
+}
+
+const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
+
+// Predicate shared by run/status: live files in visible smb_share sources.
+// Visibility mirrors fileQueryService: active + empty visibility_group_ids
+// (fail closed on non-empty).
+const eligibleFilesSql = (orgId: string) => sql`
+  FROM workspace_file_index fi
+  JOIN workspace_sources s
+    ON s.id = fi.source_id AND s.org_id = fi.org_id
+  WHERE fi.org_id = ${orgId}
+    AND fi.deleted_at IS NULL
+    AND fi.is_dir = false
+    AND s.kind = 'smb_share'
+    AND s.status = 'active'
+    AND s.visibility_group_ids = '[]'::jsonb
+`;
+
+const pendingPredicateSql = sql`
+  AND (
+    c.id IS NULL
+    OR c.source_size IS DISTINCT FROM fi.size
+    OR c.source_mtime IS DISTINCT FROM fi.mtime
+  )
+`;
+
+export function createContentIngestService(db: WorkspaceDatabase, deps: ContentIngestDeps) {
+  const d = db;
+  const maxBytes = deps.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  async function pendingCount(orgId: string): Promise<number> {
+    const res = await d.execute(sql`
+      SELECT count(*)::int AS n
+      ${eligibleFilesSql(orgId)}
+      ${sql`AND NOT EXISTS (
+        SELECT 1 FROM workspace_file_content c
+        WHERE c.file_index_id = fi.id
+          AND c.source_size IS NOT DISTINCT FROM fi.size
+          AND c.source_mtime IS NOT DISTINCT FROM fi.mtime
+      )`}
+    `);
+    return Number((res as unknown as Array<{ n: number }>)[0]?.n ?? 0);
+  }
+
+  async function replaceRegexEntities(
+    orgId: string,
+    fileIndexId: string,
+    text: string,
+  ): Promise<void> {
+    const entities = extractEntities(text);
+    await d.execute(sql`
+      DELETE FROM workspace_content_entities
+      WHERE org_id = ${orgId} AND file_index_id = ${fileIndexId} AND origin = 'regex'
+    `);
+    for (const e of entities) {
+      await d.execute(sql`
+        INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm, value_raw, origin)
+        VALUES (${orgId}, ${fileIndexId}, ${e.type}, ${e.valueNorm}, ${e.valueRaw}, 'regex')
+        ON CONFLICT (org_id, file_index_id, entity_type, value_norm) DO NOTHING
+      `);
+    }
+  }
+
+  async function upsertDeclaredProject(orgId: string, relPath: string): Promise<void> {
+    const declared = deriveDeclaredProject(relPath);
+    if (!declared) return;
+    const label = declared.label ?? declared.key;
+    // A real label (folder name) may replace a key-only placeholder, never the
+    // other way round.
+    await d.execute(sql`
+      INSERT INTO workspace_projects (org_id, project_key, label)
+      VALUES (${orgId}, ${declared.key}, ${label})
+      ON CONFLICT (org_id, project_key) DO UPDATE
+        SET label = EXCLUDED.label, updated_at = now()
+        WHERE workspace_projects.label = workspace_projects.project_key
+          AND EXCLUDED.label <> EXCLUDED.project_key
+    `);
+  }
+
+  async function upsertContentRow(
+    orgId: string,
+    fileIndexId: string,
+    row: {
+      contentHash: string | null;
+      sourceSize: number | null;
+      sourceMtime: string | null;
+      extractedText: string | null;
+      status: 'extracted' | 'failed' | 'skipped_too_large' | 'skipped_binary' | 'blocked_dlp';
+      errorReason: string | null;
+      emailMeta: EmailMeta | null;
+      // Always written (defaults to []), so a file that transitions from a
+      // prior blocked/redacted ingest to a clean one resets its findings.
+      dlpFindings: DlpFinding[];
+    },
+  ): Promise<void> {
+    await d.execute(sql`
+      INSERT INTO workspace_file_content
+        (org_id, file_index_id, content_hash, source_size, source_mtime, extracted_text, status, error_reason, dlp_findings)
+      VALUES
+        (${orgId}, ${fileIndexId}, ${row.contentHash}, ${row.sourceSize},
+         ${row.sourceMtime}, ${row.extractedText}, ${row.status}::workspace_content_status, ${row.errorReason},
+         ${JSON.stringify(row.dlpFindings)}::jsonb)
+      ON CONFLICT (file_index_id) DO UPDATE SET
+        content_hash = EXCLUDED.content_hash,
+        source_size = EXCLUDED.source_size,
+        source_mtime = EXCLUDED.source_mtime,
+        extracted_text = EXCLUDED.extracted_text,
+        status = EXCLUDED.status,
+        error_reason = EXCLUDED.error_reason,
+        dlp_findings = EXCLUDED.dlp_findings,
+        extracted_at = now(),
+        updated_at = now()
+    `);
+    // email_meta lives on the enrichment row (written deterministically here,
+    // never by the LLM; the enrichment pass fills the inferred_* columns).
+    if (row.emailMeta) {
+      await d.execute(sql`
+        INSERT INTO workspace_file_enrichment (org_id, file_index_id, email_meta)
+        VALUES (${orgId}, ${fileIndexId}, ${JSON.stringify(row.emailMeta)}::jsonb)
+        ON CONFLICT (file_index_id) DO UPDATE SET
+          email_meta = EXCLUDED.email_meta, updated_at = now()
+      `);
+    }
+  }
+
+  return {
+    async run(orgId: string, batch: number): Promise<IngestRunResult> {
+      // DLP config is per-org and stable for the whole run — fetch it once.
+      const { dlpConfig } = await getOrgSettings(db, orgId);
+      const pending = await d.execute(sql`
+        SELECT fi.id, fi.source_id, fi.rel_path, fi.name, fi.size, fi.mtime,
+               s.root_path, s.kind AS source_kind, c.content_hash
+        FROM workspace_file_index fi
+        JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+        LEFT JOIN workspace_file_content c ON c.file_index_id = fi.id
+        WHERE fi.org_id = ${orgId}
+          AND fi.deleted_at IS NULL
+          AND fi.is_dir = false
+          AND s.kind = 'smb_share'
+          AND s.status = 'active'
+          AND s.visibility_group_ids = '[]'::jsonb
+          ${pendingPredicateSql}
+        ORDER BY fi.rel_path
+        LIMIT ${batch}
+      `) as unknown as PendingRow[];
+
+      const errors: IngestError[] = [];
+      let processed = 0;
+
+      for (const file of pending) {
+        const source = { id: file.source_id, orgId, kind: file.source_kind, rootPath: file.root_path };
+        const sourceSize = file.size === null ? null : Number(file.size);
+        const sourceMtime = file.mtime;
+        // Once the content row is durably 'extracted', a later failure (entity
+        // replace, project upsert) must NOT overwrite it with a failed row —
+        // that would destroy good text AND, because the snapshot matches, park
+        // the file outside the pending set forever.
+        let contentRowWritten = false;
+        try {
+          const bytes = await deps.reader.read(source, file.rel_path);
+          const result = await extractContent(file.name, bytes, maxBytes);
+
+          if (result.status !== 'extracted') {
+            // failed / skipped_* — no text, nothing for DLP to inspect.
+            await upsertContentRow(orgId, file.id, {
+              contentHash: null,
+              sourceSize,
+              sourceMtime,
+              extractedText: null,
+              status: result.status,
+              errorReason: result.status === 'failed' ? result.errorReason : null,
+              emailMeta: null,
+              dlpFindings: [],
+            });
+            contentRowWritten = true;
+            processed += 1;
+            continue;
+          }
+
+          if (file.content_hash === result.contentHash) {
+            // Same bytes as last time — refresh the snapshot only. The prior
+            // run already applied DLP to these exact bytes, so its verdict
+            // (redacted text or blocked_dlp) stands untouched.
+            await d.execute(sql`
+              UPDATE workspace_file_content
+              SET source_size = ${sourceSize}, source_mtime = ${sourceMtime}, updated_at = now()
+              WHERE org_id = ${orgId} AND file_index_id = ${file.id}
+            `);
+            processed += 1;
+            continue;
+          }
+
+          // DLP runs ONCE, here, between extraction and any persistence/embed.
+          const dlp = applyDlpToText(result.text, dlpConfig);
+          if (dlp.blocked) {
+            // Block before store/embed: persist a blocked_dlp row carrying the
+            // findings and the snapshot (so it is skipped, not retried, next
+            // run) — no text, no entities, no chunks, no embedder call.
+            await upsertContentRow(orgId, file.id, {
+              contentHash: null,
+              sourceSize,
+              sourceMtime,
+              extractedText: null,
+              status: 'blocked_dlp',
+              errorReason: null,
+              emailMeta: null,
+              dlpFindings: dlp.findings,
+            });
+            contentRowWritten = true;
+            // A PRIOR clean ingest of this same file may have left chunks and
+            // regex entities behind; the passages/chunk scope has no join to
+            // the content status, so they would stay retrievable after the
+            // transition to blocked_dlp. Purge them (same delete idiom the
+            // extracted path uses) so a blocked file surfaces nothing.
+            await d.execute(sql`
+              DELETE FROM workspace_content_chunks
+              WHERE org_id = ${orgId} AND file_index_id = ${file.id}
+            `);
+            await d.execute(sql`
+              DELETE FROM workspace_content_entities
+              WHERE org_id = ${orgId} AND file_index_id = ${file.id} AND origin = 'regex'
+            `);
+            processed += 1;
+            continue;
+          }
+
+          // Redacted (or clean) text is the ONLY text that flows downstream.
+          const cleanText = dlp.text;
+          await upsertContentRow(orgId, file.id, {
+            contentHash: result.contentHash,
+            sourceSize,
+            sourceMtime,
+            extractedText: cleanText,
+            status: 'extracted',
+            errorReason: null,
+            emailMeta: result.emailMeta,
+            dlpFindings: dlp.findings,
+          });
+          contentRowWritten = true;
+          await replaceRegexEntities(orgId, file.id, cleanText);
+          await upsertDeclaredProject(orgId, file.rel_path);
+          if (deps.embedder) {
+            const chunks = chunkText(cleanText);
+            const vectors = await deps.embedder.embed(chunks, 'document');
+            // delete-then-insert per file: stale chunks must never linger
+            // after a shrink/rewrite.
+            await d.execute(sql`
+              DELETE FROM workspace_content_chunks
+              WHERE org_id = ${orgId} AND file_index_id = ${file.id}
+            `);
+            for (let i = 0; i < chunks.length; i += 1) {
+              await d.execute(sql`
+                INSERT INTO workspace_content_chunks (org_id, file_index_id, chunk_index, text, embedding)
+                VALUES (${orgId}, ${file.id}, ${i}, ${chunks[i]}, ${toVectorLiteral(vectors[i])}::vector)
+              `);
+            }
+          }
+          processed += 1;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!contentRowWritten) {
+            // Read/extract/first-write failure: record a failed row WITH the
+            // snapshot so the loop advances; re-ingest by touching the file.
+            try {
+              await upsertContentRow(orgId, file.id, {
+                contentHash: null,
+                sourceSize,
+                sourceMtime,
+                extractedText: null,
+                status: 'failed',
+                errorReason: message,
+                emailMeta: null,
+                dlpFindings: [],
+              });
+            } catch { /* keep the original error */ }
+          }
+          // else: the extraction is durable; only the entity/project pass
+          // failed — surface the error but leave the extracted row intact.
+          errors.push({ fileIndexId: file.id, relPath: file.rel_path, error: message });
+        }
+      }
+
+      return { processed, remaining: await pendingCount(orgId), errors };
+    },
+
+    async status(orgId: string): Promise<IngestStatus> {
+      const [eligibleRes, statusRes, pending] = await Promise.all([
+        d.execute(sql`SELECT count(*)::int AS n ${eligibleFilesSql(orgId)}`),
+        d.execute(sql`
+          SELECT c.status, count(*)::int AS n
+          FROM workspace_file_content c
+          WHERE c.org_id = ${orgId}
+          GROUP BY c.status
+        `),
+        pendingCount(orgId),
+      ]);
+      const counts: Record<string, number> = {};
+      for (const row of statusRes as unknown as Array<{ status: string; n: number }>) {
+        counts[row.status] = Number(row.n);
+      }
+      return {
+        eligible: Number((eligibleRes as unknown as Array<{ n: number }>)[0]?.n ?? 0),
+        extracted: counts.extracted ?? 0,
+        failed: counts.failed ?? 0,
+        skippedTooLarge: counts.skipped_too_large ?? 0,
+        skippedBinary: counts.skipped_binary ?? 0,
+        pending,
+      };
+    },
+  };
+}

--- a/ee/workspace/src/services/contentSearchService.test.ts
+++ b/ee/workspace/src/services/contentSearchService.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { fuseRrf, ARM_WEIGHTS } from './contentSearchService';
+
+describe('fuseRrf — weighted reciprocal rank fusion', () => {
+  it('a rank-1 hit in a heavy arm beats a rank-1 hit in a light arm', () => {
+    const fused = fuseRrf([
+      { weight: ARM_WEIGHTS.ftsAnd, ids: ['deed'] },
+      { weight: ARM_WEIGHTS.trigram, ids: ['near-name'] },
+    ]);
+    expect(fused[0].id).toBe('deed');
+  });
+
+  it('the Beat-3 shape: one FTS-AND hit outranks a deep trigram arm', () => {
+    // scan_0034 is the sole AND match; a dozen Henderson-named files fill the
+    // trigram arm. The single heavy hit must win the fusion.
+    const trigramArm = Array.from({ length: 12 }, (_, i) => `henderson-file-${i}`);
+    const fused = fuseRrf([
+      { weight: ARM_WEIGHTS.ftsAnd, ids: ['scan_0034'] },
+      { weight: ARM_WEIGHTS.trigram, ids: trigramArm },
+      { weight: ARM_WEIGHTS.ftsOr, ids: [...trigramArm.slice(0, 5), 'scan_0034'] },
+    ]);
+    expect(fused[0].id).toBe('scan_0034');
+  });
+
+  it('membership in multiple arms accumulates', () => {
+    const fused = fuseRrf([
+      { weight: 1.0, ids: ['a', 'b'] },
+      { weight: 1.0, ids: ['b', 'a'] },
+      { weight: 0.8, ids: ['b'] },
+    ]);
+    expect(fused[0].id).toBe('b');
+    // a: 1/61 + 1/62; b: 1/62 + 1/61 + 0.8/61 — b strictly higher
+    expect(fused[0].score).toBeGreaterThan(fused[1].score);
+  });
+
+  it('is deterministic for ties (stable id ordering)', () => {
+    const fused = fuseRrf([{ weight: 1.0, ids: ['z'] }, { weight: 1.0, ids: ['m'] }]);
+    expect(fused.map((f) => f.id)).toEqual(['m', 'z']);
+  });
+
+  it('returns empty for no arms or empty arms', () => {
+    expect(fuseRrf([])).toEqual([]);
+    expect(fuseRrf([{ weight: 2, ids: [] }])).toEqual([]);
+  });
+});

--- a/ee/workspace/src/services/contentSearchService.ts
+++ b/ee/workspace/src/services/contentSearchService.ts
@@ -1,0 +1,528 @@
+// Hybrid content retrieval (dev-preview; per-org content flag).
+//
+// Weighted Reciprocal Rank Fusion over independent arms, fused per-file:
+//   entity exact-match  3.0   (query-side detection uses the ingest normalizer)
+//   FTS-AND             2.5   (websearch_to_tsquery — all terms must match)
+//   project resolution  2.0   (query ~ workspace_projects label/key/aliases)
+//   name/relPath trigram 1.0  (the legacy finder arm — Beat 1 unregressed)
+//   FTS-OR relaxed      0.8   (any term; low weight, recall backstop)
+//   vector              1.0   (lands with the chunks migration; absent = skipped)
+// RRF (score = Σ w/(60+rank)) instead of raw score mixing: the arms' scores
+// are not commensurable, and normalization bugs — not ranking taste — are how
+// a misfiled deed loses to a folder full of near-name matches.
+//
+// Every arm shares one scoped FROM/WHERE tail: deleted_at IS NULL, fail-closed
+// source visibility, and the same partition rule as fileQueryService (smb rows
+// under the shared key, local_profile rows device-scoped).
+import type { WorkspaceDatabase } from '../hostTypes';
+import { sql, type SQL } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { normalizeQueryEntities } from '../content/entities';
+import { toVectorLiteral, type Embedder } from '../content/embedder';
+import type { FinderFile, SearchFilters, VisibleSource } from './fileQueryService';
+import { SHARED_DEVICE_KEY } from './runScope';
+import { visibleSourcePredicateSql } from './visibility';
+
+export interface ContentSearchResult extends FinderFile {
+  snippet: string | null;
+  inferredDocType: string | null;
+  inferredProjectKey: string | null;
+  inferredProjectLabel: string | null;
+  declaredProjectKey: string | null;
+  declaredProjectLabel: string | null;
+  metadataDisagreement: boolean;
+  group: 'document' | 'email';
+  matchedEntities: Array<{ type: string; value: string }>;
+}
+
+/**
+ * A ranked content fragment for cited RAG. Retrieval runs over
+ * workspace_content_chunks through the SAME fail-closed visible-sources scope
+ * as search(); a passage whose source is outside the caller's visibility is
+ * unreachable by construction. `snippet` is byte-capped deterministically.
+ */
+export interface ContentPassage {
+  fileIndexId: string;
+  relPath: string;
+  sourceId: string;
+  openPath: string | null;
+  snippet: string;
+  score: number;
+}
+
+export interface PassageOptions {
+  /** Same device partition rule as search (local_profile rows device-scoped). */
+  helperDeviceId: string;
+  /** Restrict retrieval to a single file's chunks. */
+  fileIndexId?: string;
+  /** Passage cap; defaults to and is clamped at PASSAGE_MAX. */
+  limit?: number;
+}
+
+export interface RrfArm {
+  weight: number;
+  /** file ids, best first */
+  ids: string[];
+}
+
+const RRF_K = 60;
+
+/** Weighted reciprocal-rank fusion; returns ids best-first with their scores. */
+export function fuseRrf(arms: RrfArm[]): Array<{ id: string; score: number }> {
+  const scores = new Map<string, number>();
+  for (const arm of arms) {
+    arm.ids.forEach((id, rank) => {
+      scores.set(id, (scores.get(id) ?? 0) + arm.weight / (RRF_K + rank + 1));
+    });
+  }
+  return [...scores.entries()]
+    .map(([id, score]) => ({ id, score }))
+    .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+}
+
+export const ARM_WEIGHTS = {
+  entity: 3.0,
+  ftsAnd: 2.5,
+  project: 2.0,
+  trigram: 1.0,
+  ftsOr: 0.8,
+  vector: 1.0,
+} as const;
+
+const ARM_LIMIT = 50;
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+// Passages are bounded so the chat model never receives an unbounded chunk
+// dump: at most PASSAGE_MAX fragments, each snippet capped to PASSAGE_SNIPPET_CHARS.
+const PASSAGE_MAX = 6;
+const PASSAGE_SNIPPET_CHARS = 700;
+
+function clampPassageLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) return PASSAGE_MAX;
+  return Math.min(PASSAGE_MAX, Math.max(1, Math.floor(limit)));
+}
+
+/**
+ * Postgres array literal for a string[] bound parameter. drizzle's raw sql
+ * template binds a JS array as a scalar, so arrays travel as an explicit
+ * '{"a","b"}' literal with a ::text[]/::uuid[] cast at the call site.
+ */
+function pgArrayLiteral(values: string[]): string {
+  return `{${values.map((v) => `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(',')}}`;
+}
+
+function clampLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(limit)));
+}
+
+interface IdRow { id: string }
+
+interface HydratedRow {
+  id: string;
+  source_id: string;
+  device_key: string;
+  rel_path: string;
+  parent_path: string;
+  name: string;
+  is_dir: boolean;
+  ext: string | null;
+  size: string | number | null;
+  mtime: string | Date | null;
+  snippet: string | null;
+  inferred_doc_type: string | null;
+  inferred_project_key: string | null;
+  inferred_project_label: string | null;
+  declared_project_key: string | null;
+  declared_project_label: string | null;
+  matched_entities: Array<{ type: string; value: string }> | null;
+}
+
+function openPathFor(source: VisibleSource, relPath: string): string | null {
+  if (source.kind !== 'smb_share') return null;
+  return `${source.rootPath}\\${relPath.replaceAll('/', '\\')}`;
+}
+
+export interface ContentSearchDeps {
+  /** Absent → the vector arm is skipped (lexical/entity arms carry the load). */
+  embedder?: Embedder;
+}
+
+export function createContentSearchService(db: WorkspaceDatabase, deps: ContentSearchDeps = {}) {
+  const d = db;
+
+  async function visibleSources(orgId: string, groupIds: string[] = []): Promise<VisibleSource[]> {
+    const rows = await d.execute(sql`
+      SELECT s.id, s.display_name, s.kind, s.root_path
+      FROM workspace_sources s
+      WHERE s.org_id = ${orgId} AND ${visibleSourcePredicateSql(sql, groupIds)}
+      ORDER BY s.display_name ASC
+    `) as unknown as Array<{
+      id: string; display_name: string; kind: 'smb_share' | 'local_profile'; root_path: string;
+    }>;
+    return rows.map((r) => ({ id: r.id, displayName: r.display_name, kind: r.kind, rootPath: r.root_path }));
+  }
+
+  return {
+    async search(
+      orgId: string,
+      helperDeviceId: string,
+      filters: SearchFilters,
+      groupIds: string[] = [],
+    ): Promise<ContentSearchResult[]> {
+      const visible = await visibleSources(orgId, groupIds);
+      const scoped = filters.sourceId
+        ? visible.filter((s) => s.id === filters.sourceId)
+        : visible;
+      if (scoped.length === 0) return [];
+      const sourceIds = scoped.map((s) => s.id);
+
+      const extraFilters: SQL[] = [];
+      if (filters.ext) extraFilters.push(sql`AND fi.ext = ${filters.ext}`);
+      if (filters.modifiedAfter) extraFilters.push(sql`AND fi.mtime >= ${new Date(filters.modifiedAfter)}`);
+      if (filters.modifiedBefore) extraFilters.push(sql`AND fi.mtime <= ${new Date(filters.modifiedBefore)}`);
+      // en is only joined in the final hydration SELECT below, so the guard
+      // here is an EXISTS against workspace_file_enrichment (same predicate
+      // shape as fileQueryService's search) rather than a bare column ref.
+      if (filters.project) {
+        extraFilters.push(sql`AND EXISTS (
+          SELECT 1 FROM workspace_file_enrichment wfe
+          WHERE wfe.file_index_id = fi.id AND wfe.inferred_project_label = ${filters.project}
+        )`);
+      }
+      if (filters.docType) {
+        extraFilters.push(sql`AND EXISTS (
+          SELECT 1 FROM workspace_file_enrichment wfe
+          WHERE wfe.file_index_id = fi.id AND wfe.inferred_doc_type = ${filters.docType}
+        )`);
+      }
+      const extras = extraFilters.length > 0 ? sql.join(extraFilters, sql` `) : sql``;
+
+      // Shared scope tail. c is joined so FTS arms can reference it; the other
+      // arms simply ignore it.
+      const scope = sql`
+        FROM workspace_file_index fi
+        JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+        LEFT JOIN workspace_file_content c
+          ON c.file_index_id = fi.id AND c.status = 'extracted'
+        WHERE fi.org_id = ${orgId}
+          AND fi.deleted_at IS NULL
+          AND fi.is_dir = false
+          AND fi.source_id = ANY(${pgArrayLiteral(sourceIds)}::uuid[])
+          AND (
+            (s.kind = 'smb_share' AND fi.device_key = ${SHARED_DEVICE_KEY})
+            OR (s.kind = 'local_profile' AND fi.device_key = ${helperDeviceId})
+          )
+          ${extras}
+      `;
+
+      const q = filters.q;
+      const queryEntities = normalizeQueryEntities(q);
+      const entityKeys = queryEntities.map((e) => `${e.type}:${e.valueNorm}`);
+      const orQuery = q.trim().split(/\s+/).filter(Boolean).join(' OR ');
+
+      // Project resolution: the best-matching registry entry, if any.
+      const projectHit = await d.execute(sql`
+        SELECT p.project_key
+        FROM workspace_projects p
+        WHERE p.org_id = ${orgId}
+          AND (
+            similarity(p.label, ${q}) > 0.3
+            OR p.label ILIKE ${'%' + q + '%'}
+            OR ${q} ILIKE '%' || p.project_key || '%'
+            OR EXISTS (
+              SELECT 1 FROM jsonb_array_elements_text(p.aliases) a(alias)
+              WHERE similarity(a.alias, ${q}) > 0.3
+            )
+          )
+        ORDER BY similarity(p.label, ${q}) DESC
+        LIMIT 1
+      `) as unknown as Array<{ project_key: string }>;
+      const projectKey = projectHit[0]?.project_key ?? null;
+
+      // Vector arm: embed the query once; max cosine similarity per file over
+      // its chunks. Fail-soft — an embeddings outage degrades to lexical arms.
+      const vectorArm: Promise<IdRow[]> = (async () => {
+        if (!deps.embedder) return [];
+        try {
+          const [qVec] = await deps.embedder.embed([q], 'query');
+          if (!qVec) return [];
+          return await d.execute(sql`
+            SELECT fi.id
+            ${scope}
+            AND EXISTS (SELECT 1 FROM workspace_content_chunks ch
+                        WHERE ch.file_index_id = fi.id AND ch.embedding IS NOT NULL)
+            ORDER BY (
+              SELECT min(ch.embedding <=> ${toVectorLiteral(qVec)}::vector)
+              FROM workspace_content_chunks ch
+              WHERE ch.org_id = ${orgId} AND ch.file_index_id = fi.id AND ch.embedding IS NOT NULL
+            ) ASC,
+            fi.mtime DESC NULLS LAST, fi.id ASC
+            LIMIT ${ARM_LIMIT}
+          `) as unknown as IdRow[];
+        } catch {
+          return [];
+        }
+      })();
+
+      const [entityIds, ftsAndIds, ftsOrIds, trigramIds, projectIds, vectorIds] = await Promise.all([
+        entityKeys.length === 0 ? Promise.resolve([] as IdRow[]) : d.execute(sql`
+          SELECT fi.id,
+                 (SELECT count(*) FROM workspace_content_entities e
+                  WHERE e.org_id = ${orgId} AND e.file_index_id = fi.id
+                    AND (e.entity_type || ':' || e.value_norm) = ANY(${pgArrayLiteral(entityKeys)}::text[])) AS hits
+          ${scope}
+          AND EXISTS (
+            SELECT 1 FROM workspace_content_entities e
+            WHERE e.org_id = ${orgId} AND e.file_index_id = fi.id
+              AND (e.entity_type || ':' || e.value_norm) = ANY(${pgArrayLiteral(entityKeys)}::text[])
+          )
+          ORDER BY hits DESC, fi.mtime DESC NULLS LAST, fi.id ASC
+          LIMIT ${ARM_LIMIT}
+        `) as unknown as Promise<IdRow[]>,
+        d.execute(sql`
+          SELECT fi.id
+          ${scope}
+          AND c.id IS NOT NULL
+          AND to_tsvector('english', coalesce(c.extracted_text, '')) @@ websearch_to_tsquery('english', ${q})
+          ORDER BY ts_rank(to_tsvector('english', coalesce(c.extracted_text, '')),
+                           websearch_to_tsquery('english', ${q})) DESC,
+                   fi.mtime DESC NULLS LAST, fi.id ASC
+          LIMIT ${ARM_LIMIT}
+        `) as unknown as Promise<IdRow[]>,
+        orQuery.length === 0 ? Promise.resolve([] as IdRow[]) : d.execute(sql`
+          SELECT fi.id
+          ${scope}
+          AND c.id IS NOT NULL
+          AND to_tsvector('english', coalesce(c.extracted_text, '')) @@ websearch_to_tsquery('english', ${orQuery})
+          ORDER BY ts_rank(to_tsvector('english', coalesce(c.extracted_text, '')),
+                           websearch_to_tsquery('english', ${orQuery})) DESC,
+                   fi.mtime DESC NULLS LAST, fi.id ASC
+          LIMIT ${ARM_LIMIT}
+        `) as unknown as Promise<IdRow[]>,
+        d.execute(sql`
+          SELECT fi.id
+          ${scope}
+          AND (fi.name % ${q} OR fi.name ILIKE ${'%' + q + '%'} OR fi.rel_path ILIKE ${'%' + q + '%'})
+          ORDER BY greatest(similarity(fi.name, ${q}), similarity(fi.rel_path, ${q}) * 0.8) DESC,
+                   fi.mtime DESC NULLS LAST, fi.id ASC
+          LIMIT ${ARM_LIMIT}
+        `) as unknown as Promise<IdRow[]>,
+        projectKey === null ? Promise.resolve([] as IdRow[]) : d.execute(sql`
+          SELECT fi.id
+          ${scope}
+          AND (
+            fi.rel_path ILIKE ${'%' + projectKey + '%'}
+            OR EXISTS (
+              SELECT 1 FROM workspace_file_enrichment en
+              WHERE en.file_index_id = fi.id AND en.org_id = ${orgId}
+                AND (en.inferred_project_key = ${projectKey} OR en.declared_project_key = ${projectKey})
+            )
+          )
+          ORDER BY (to_tsvector('english', coalesce(c.extracted_text, '')) @@ websearch_to_tsquery('english', ${orQuery || q})) DESC,
+                   ts_rank(to_tsvector('english', coalesce(c.extracted_text, '')),
+                           websearch_to_tsquery('english', ${orQuery || q})) DESC,
+                   fi.mtime DESC NULLS LAST, fi.id ASC
+          LIMIT ${ARM_LIMIT}
+        `) as unknown as Promise<IdRow[]>,
+        vectorArm,
+      ]);
+
+      const fused = fuseRrf([
+        { weight: ARM_WEIGHTS.entity, ids: entityIds.map((r) => r.id) },
+        { weight: ARM_WEIGHTS.ftsAnd, ids: ftsAndIds.map((r) => r.id) },
+        { weight: ARM_WEIGHTS.project, ids: projectIds.map((r) => r.id) },
+        { weight: ARM_WEIGHTS.trigram, ids: trigramIds.map((r) => r.id) },
+        { weight: ARM_WEIGHTS.ftsOr, ids: ftsOrIds.map((r) => r.id) },
+        { weight: ARM_WEIGHTS.vector, ids: vectorIds.map((r) => r.id) },
+      ]);
+      const limit = clampLimit(filters.limit);
+      const top = fused.slice(0, limit);
+      if (top.length === 0) return [];
+      const topIds = top.map((t) => t.id);
+      const scoreById = new Map(top.map((t) => [t.id, t.score]));
+
+      const rows = await d.execute(sql`
+        SELECT fi.id, fi.source_id, fi.device_key, fi.rel_path, fi.parent_path,
+               fi.name, fi.is_dir, fi.ext, fi.size, fi.mtime,
+               CASE WHEN c.extracted_text IS NULL THEN NULL
+                    ELSE ts_headline('english', c.extracted_text,
+                                     websearch_to_tsquery('english', ${orQuery || q}),
+                                     'MaxWords=30, MinWords=10, MaxFragments=1')
+               END AS snippet,
+               en.inferred_doc_type, en.inferred_project_key, en.inferred_project_label,
+               en.declared_project_key, en.declared_project_label,
+               (SELECT jsonb_agg(jsonb_build_object('type', e.entity_type, 'value', e.value_norm))
+                FROM workspace_content_entities e
+                WHERE e.org_id = ${orgId} AND e.file_index_id = fi.id
+                  AND (e.entity_type || ':' || e.value_norm) = ANY(${pgArrayLiteral(entityKeys)}::text[])) AS matched_entities
+        FROM workspace_file_index fi
+        LEFT JOIN workspace_file_content c
+          ON c.file_index_id = fi.id AND c.status = 'extracted'
+        LEFT JOIN workspace_file_enrichment en ON en.file_index_id = fi.id
+        WHERE fi.org_id = ${orgId} AND fi.id = ANY(${pgArrayLiteral(topIds)}::uuid[])
+      `) as unknown as HydratedRow[];
+
+      const sourceById = new Map(scoped.map((s) => [s.id, s]));
+      const results: ContentSearchResult[] = [];
+      for (const row of rows) {
+        const source = sourceById.get(row.source_id);
+        if (!source) continue;
+        const disagreement = row.inferred_project_key !== null
+          && row.declared_project_key !== null
+          && row.inferred_project_key !== row.declared_project_key;
+        results.push({
+          id: row.id,
+          sourceId: row.source_id,
+          deviceKey: row.device_key,
+          relPath: row.rel_path,
+          parentPath: row.parent_path,
+          name: row.name,
+          isDir: row.is_dir,
+          ext: row.ext,
+          size: row.size === null ? null : Number(row.size),
+          mtime: row.mtime ? new Date(row.mtime).toISOString() : null,
+          openPath: openPathFor(source, row.rel_path),
+          score: scoreById.get(row.id),
+          snippet: row.snippet,
+          inferredDocType: row.inferred_doc_type,
+          inferredProjectKey: row.inferred_project_key,
+          inferredProjectLabel: row.inferred_project_label,
+          declaredProjectKey: row.declared_project_key,
+          declaredProjectLabel: row.declared_project_label,
+          metadataDisagreement: disagreement,
+          group: row.ext === 'eml' ? 'email' : 'document',
+          matchedEntities: row.matched_entities ?? [],
+        });
+      }
+      results.sort((a, b) => (b.score ?? 0) - (a.score ?? 0) || a.id.localeCompare(b.id));
+      return results;
+    },
+
+    /**
+     * Chunk-level retrieval for cited RAG. Ranks workspace_content_chunks with
+     * the FTS-AND / FTS-OR / trigram arms (plus the vector arm when an embedder
+     * is configured — absent → degrade to lexical, like ingest), fused by RRF.
+     * Chunks are joined to the file index through the SAME fail-closed
+     * visible-sources scope as search(), so a passage from a source outside the
+     * caller's visibility can never appear. Truncated deterministically:
+     * top-PASSAGE_MAX, each snippet byte-capped.
+     */
+    async passages(
+      orgId: string,
+      q: string,
+      opts: PassageOptions,
+      groupIds: string[] = [],
+    ): Promise<ContentPassage[]> {
+      const visible = await visibleSources(orgId, groupIds);
+      if (visible.length === 0) return [];
+      const sourceIds = visible.map((s) => s.id);
+      const orQuery = q.trim().split(/\s+/).filter(Boolean).join(' OR ');
+      const fileFilter = opts.fileIndexId ? sql`AND fi.id = ${opts.fileIndexId}` : sql``;
+
+      // Chunk scope: identical visibility/partition tail as search's file scope,
+      // rooted at workspace_content_chunks and restricted to the chunks table.
+      const scope = sql`
+        FROM workspace_content_chunks ch
+        JOIN workspace_file_index fi ON fi.id = ch.file_index_id AND fi.org_id = ch.org_id
+        JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+        WHERE ch.org_id = ${orgId}
+          AND fi.deleted_at IS NULL
+          AND fi.is_dir = false
+          AND fi.source_id = ANY(${pgArrayLiteral(sourceIds)}::uuid[])
+          AND (
+            (s.kind = 'smb_share' AND fi.device_key = ${SHARED_DEVICE_KEY})
+            OR (s.kind = 'local_profile' AND fi.device_key = ${opts.helperDeviceId})
+          )
+          ${fileFilter}
+      `;
+
+      // Vector arm: max cosine similarity over embedded chunks. Fail-soft — an
+      // embeddings outage (or no key) degrades to the lexical arms.
+      const vectorArm: Promise<IdRow[]> = (async () => {
+        if (!deps.embedder) return [];
+        try {
+          const [qVec] = await deps.embedder.embed([q], 'query');
+          if (!qVec) return [];
+          return await d.execute(sql`
+            SELECT ch.id
+            ${scope}
+            AND ch.embedding IS NOT NULL
+            ORDER BY ch.embedding <=> ${toVectorLiteral(qVec)}::vector ASC, ch.id ASC
+            LIMIT ${ARM_LIMIT}
+          `) as unknown as IdRow[];
+        } catch {
+          return [];
+        }
+      })();
+
+      const [ftsAndIds, ftsOrIds, trigramIds, vectorIds] = await Promise.all([
+        d.execute(sql`
+          SELECT ch.id
+          ${scope}
+          AND to_tsvector('english', ch.text) @@ websearch_to_tsquery('english', ${q})
+          ORDER BY ts_rank(to_tsvector('english', ch.text),
+                           websearch_to_tsquery('english', ${q})) DESC, ch.id ASC
+          LIMIT ${ARM_LIMIT}
+        `) as unknown as Promise<IdRow[]>,
+        orQuery.length === 0 ? Promise.resolve([] as IdRow[]) : d.execute(sql`
+          SELECT ch.id
+          ${scope}
+          AND to_tsvector('english', ch.text) @@ websearch_to_tsquery('english', ${orQuery})
+          ORDER BY ts_rank(to_tsvector('english', ch.text),
+                           websearch_to_tsquery('english', ${orQuery})) DESC, ch.id ASC
+          LIMIT ${ARM_LIMIT}
+        `) as unknown as Promise<IdRow[]>,
+        d.execute(sql`
+          SELECT ch.id
+          ${scope}
+          AND (ch.text ILIKE ${'%' + q + '%'} OR ${q} <% ch.text)
+          ORDER BY word_similarity(${q}, ch.text) DESC, ch.id ASC
+          LIMIT ${ARM_LIMIT}
+        `) as unknown as Promise<IdRow[]>,
+        vectorArm,
+      ]);
+
+      const fused = fuseRrf([
+        { weight: ARM_WEIGHTS.ftsAnd, ids: ftsAndIds.map((r) => r.id) },
+        { weight: ARM_WEIGHTS.ftsOr, ids: ftsOrIds.map((r) => r.id) },
+        { weight: ARM_WEIGHTS.trigram, ids: trigramIds.map((r) => r.id) },
+        { weight: ARM_WEIGHTS.vector, ids: vectorIds.map((r) => r.id) },
+      ]);
+      const top = fused.slice(0, clampPassageLimit(opts.limit));
+      if (top.length === 0) return [];
+      const topIds = top.map((t) => t.id);
+      const scoreById = new Map(top.map((t) => [t.id, t.score]));
+
+      const rows = await d.execute(sql`
+        SELECT ch.id, ch.file_index_id, ch.text, fi.source_id, fi.rel_path
+        FROM workspace_content_chunks ch
+        JOIN workspace_file_index fi ON fi.id = ch.file_index_id AND fi.org_id = ch.org_id
+        WHERE ch.org_id = ${orgId} AND ch.id = ANY(${pgArrayLiteral(topIds)}::uuid[])
+      `) as unknown as Array<{
+        id: string; file_index_id: string; text: string; source_id: string; rel_path: string;
+      }>;
+
+      const sourceById = new Map(visible.map((s) => [s.id, s]));
+      const passages: ContentPassage[] = [];
+      for (const row of rows) {
+        // Defense in depth: the arms already scope to visible sources, and this
+        // guard drops anything that somehow isn't — a hidden-source passage is
+        // unreachable on both paths.
+        const source = sourceById.get(row.source_id);
+        if (!source) continue;
+        passages.push({
+          fileIndexId: row.file_index_id,
+          relPath: row.rel_path,
+          sourceId: row.source_id,
+          openPath: openPathFor(source, row.rel_path),
+          snippet: row.text.slice(0, PASSAGE_SNIPPET_CHARS),
+          score: scoreById.get(row.id) ?? 0,
+        });
+      }
+      passages.sort((a, b) => b.score - a.score || a.fileIndexId.localeCompare(b.fileIndexId));
+      return passages;
+    },
+  };
+}

--- a/ee/workspace/src/services/crawlRunsService.test.ts
+++ b/ee/workspace/src/services/crawlRunsService.test.ts
@@ -1,0 +1,613 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { SQL } from 'drizzle-orm';
+import { workspaceCrawlRuns, workspaceFileIndex, workspaceSources } from '../schema/workspace';
+import { createCrawlRunsService, STALE_RUN_MINUTES } from './crawlRunsService';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SOURCE_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_A = '33333333-3333-3333-3333-333333333333';
+const DEVICE_B = '44444444-4444-4444-4444-444444444444';
+const RUN_ID = '55555555-5555-5555-5555-555555555555';
+const CROSS_ORG_RUN_ID = '66666666-6666-6666-6666-666666666666';
+const WRONG_RUN_ID = '77777777-7777-7777-7777-777777777777';
+const WRONG_SOURCE_RUN_ID = '88888888-8888-8888-8888-888888888888';
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
+function boundValues(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => item && typeof item === 'object' ? boundValues(item) : [item]);
+  }
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value')
+    ? (Array.isArray(candidate.value) ? candidate.value : [candidate.value])
+    : [];
+  return [
+    ...own,
+    ...(candidate.queryChunks ?? []).flatMap((item) =>
+      item && typeof item === 'object' ? boundValues(item) : [item]),
+  ];
+}
+
+function containsIdentity(value: unknown, target: unknown): boolean {
+  if (value === target) return true;
+  if (Array.isArray(value)) return value.some((item) => containsIdentity(item, target));
+  if (!value || typeof value !== 'object') return false;
+  return ((value as { queryChunks?: unknown[] }).queryChunks ?? [])
+    .some((item) => containsIdentity(item, target));
+}
+
+function sqlText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(sqlText).join('');
+  if (!value || typeof value !== 'object') return '';
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Array.isArray(candidate.value) && candidate.value.every((part) => typeof part === 'string')
+    ? candidate.value.join('')
+    : '';
+  return own + (candidate.queryChunks ?? []).map(sqlText).join('');
+}
+
+function expectDatabaseNow(value: unknown): void {
+  expect(value).toBeInstanceOf(SQL);
+  expect(sqlText(value)).toBe('now()');
+}
+
+function run(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RUN_ID,
+    orgId: ORG_ID,
+    sourceId: SOURCE_ID,
+    deviceId: DEVICE_A,
+    deviceKey: DEVICE_A,
+    status: 'running',
+    startedAt: new Date('2026-07-12T10:00:00.000Z'),
+    lastActivityAt: new Date(),
+    completedAt: null,
+    cursor: null,
+    stats: {},
+    errorReason: null,
+    ...overrides,
+  };
+}
+
+function makeDb(
+  selectResults: unknown[][] = [],
+  updateReturns: unknown[][] = [],
+  sourceKind: 'smb_share' | 'local_profile' = 'local_profile',
+) {
+  let selectIndex = 0;
+  let updateIndex = 0;
+  const updateTables: unknown[] = [];
+  const updateSets: unknown[] = [];
+  const insertValues: unknown[] = [];
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => table === workspaceSources
+            ? [{ kind: sourceKind, crawlDeviceId: DEVICE_A }]
+            : selectResults[selectIndex++] ?? []),
+        })),
+      })),
+    })),
+    update: vi.fn((table: unknown) => {
+      updateTables.push(table);
+      return {
+        set: vi.fn((value: unknown) => {
+          updateSets.push(value);
+          return {
+            where: vi.fn(() => ({
+              returning: vi.fn(async () => updateReturns[updateIndex++] ?? []),
+            })),
+          };
+        }),
+      };
+    }),
+    insert: vi.fn(() => ({
+      values: vi.fn((value: unknown) => {
+        insertValues.push(value);
+        return {
+          returning: vi.fn(async () => [run({
+            ...(value as Record<string, unknown>),
+            startedAt: new Date('2026-07-12T12:00:00.000Z'),
+            lastActivityAt: new Date('2026-07-12T12:00:00.000Z'),
+          })]),
+        };
+      }),
+    })),
+    execute: vi.fn(async () => []),
+  };
+  const withTransaction = Object.assign(db, {
+    transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(db)),
+  });
+  return {
+    db: withTransaction as unknown as WorkspaceDatabase,
+    raw: withTransaction,
+    updateTables,
+    updateSets,
+    insertValues,
+  };
+}
+
+function makeStatefulFinishDb(options: { failSourceUpdate?: boolean } = {}) {
+  const startedAt = new Date('2026-07-12T10:00:00.000Z');
+  const files = [
+    { id: 'file-a', orgId: ORG_ID, sourceId: SOURCE_ID, deviceKey: DEVICE_A, lastSeenAt: new Date('2026-07-12T09:00:00Z'), deletedAt: null as Date | null },
+    { id: 'file-b', orgId: ORG_ID, sourceId: SOURCE_ID, deviceKey: DEVICE_B, lastSeenAt: new Date('2026-07-12T09:00:00Z'), deletedAt: null as Date | null },
+    { id: 'cross-org', orgId: DEVICE_B, sourceId: SOURCE_ID, deviceKey: DEVICE_A, lastSeenAt: new Date('2026-07-12T09:00:00Z'), deletedAt: null as Date | null },
+    { id: 'wrong-source', orgId: ORG_ID, sourceId: DEVICE_B, deviceKey: DEVICE_A, lastSeenAt: new Date('2026-07-12T09:00:00Z'), deletedAt: null as Date | null },
+  ];
+  const runs = [
+    run({ id: CROSS_ORG_RUN_ID, orgId: DEVICE_B, sourceId: SOURCE_ID, status: 'running' }),
+    run({ id: WRONG_RUN_ID, orgId: ORG_ID, sourceId: SOURCE_ID, status: 'running' }),
+    run({ id: WRONG_SOURCE_RUN_ID, orgId: ORG_ID, sourceId: DEVICE_B, status: 'running' }),
+    run({ id: RUN_ID, orgId: ORG_ID, sourceId: SOURCE_ID, deviceId: DEVICE_A, deviceKey: DEVICE_A, startedAt }),
+  ];
+  const updateTables: unknown[] = [];
+  const updateSets: unknown[] = [];
+  const selectedTables: unknown[] = [];
+  const runConditions: unknown[] = [];
+  const db: Record<string, unknown> = {};
+  db.select = vi.fn(() => ({
+    from: vi.fn((table: unknown) => ({
+      where: vi.fn((condition: unknown) => ({
+        limit: vi.fn(async () => {
+          selectedTables.push(table);
+          const values = boundValues(condition);
+          if (table === workspaceSources) {
+            const sourceRows = [
+              { id: SOURCE_ID, orgId: DEVICE_B, kind: 'local_profile', crawlDeviceId: DEVICE_A },
+              { id: DEVICE_B, orgId: ORG_ID, kind: 'local_profile', crawlDeviceId: DEVICE_A },
+              { id: SOURCE_ID, orgId: ORG_ID, kind: 'local_profile', crawlDeviceId: DEVICE_A },
+            ];
+            return sourceRows.filter((row) =>
+              (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+              (!values.includes(SOURCE_ID) || row.id === SOURCE_ID)).slice(0, 1);
+          }
+          if (table !== workspaceCrawlRuns) return [];
+          runConditions.push(condition);
+          return runs.filter((row) =>
+            (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+            (!values.includes(RUN_ID) || row.id === RUN_ID) &&
+            (!values.includes(SOURCE_ID) || row.sourceId === SOURCE_ID) &&
+            (!values.includes('running') || row.status === 'running')).slice(0, 1);
+        }),
+      })),
+    })),
+  }));
+  db.update = vi.fn((table: unknown) => {
+    updateTables.push(table);
+    return {
+      set: vi.fn((setValue: Record<string, unknown>) => {
+        updateSets.push(setValue);
+        return {
+          where: vi.fn((condition: unknown) => ({
+            returning: vi.fn(async () => {
+              if (table === workspaceSources && options.failSourceUpdate) {
+                throw new Error('source update failed');
+              }
+              if (table === workspaceCrawlRuns) {
+                runConditions.push(condition);
+                const values = boundValues(condition);
+                const matches = runs.filter((row) =>
+                  (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+                  (!values.includes(RUN_ID) || row.id === RUN_ID) &&
+                  (!values.includes('running') || row.status === 'running'));
+                matches.forEach((row) => { row.status = setValue.status as string; });
+                return matches.map(({ id }) => ({ id }));
+              }
+              if (table !== workspaceFileIndex) return [];
+              const values = boundValues(condition);
+              const threshold = values.find((value) => value instanceof Date) as Date | undefined;
+              const matching = files.filter((file) =>
+                (!values.includes(ORG_ID) || file.orgId === ORG_ID) &&
+                (!values.includes(SOURCE_ID) || file.sourceId === SOURCE_ID) &&
+                (!values.includes(DEVICE_A) || file.deviceKey === DEVICE_A) &&
+                file.deletedAt === null && (!threshold || file.lastSeenAt < threshold));
+              for (const file of matching) file.deletedAt = new Date();
+              return matching.map(({ id }) => ({ id }));
+            }),
+          })),
+        };
+      }),
+    };
+  });
+  db.transaction = vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+    const snapshot = files.map((file) => file.deletedAt);
+    const runSnapshot = runs.map((row) => row.status);
+    try {
+      return await callback(db);
+    } catch (error) {
+      files.forEach((file, index) => { file.deletedAt = snapshot[index] ?? null; });
+      runs.forEach((row, index) => { row.status = runSnapshot[index] ?? row.status; });
+      throw error;
+    }
+  });
+  db.execute = vi.fn(async () => []);
+  return {
+    db: db as unknown as WorkspaceDatabase, raw: db, files, runs,
+    updateTables, updateSets, selectedTables, runConditions,
+  };
+}
+
+describe('crawlRunsService', () => {
+  it('exports the exact stale-run threshold', () => {
+    expect(STALE_RUN_MINUTES).toBe(60);
+  });
+
+  it('returns a conflict for a fresh running crawl', async () => {
+    const rows = [
+      run({
+        id: WRONG_SOURCE_RUN_ID,
+        sourceId: DEVICE_B,
+        lastActivityAt: new Date(Date.now() - 61 * 60_000),
+      }),
+      run({ lastActivityAt: new Date() }),
+    ];
+    const rawDb = {
+      execute: vi.fn(async () => []),
+      select: vi.fn(() => ({ from: vi.fn((table: unknown) => ({
+        where: vi.fn((condition: unknown) => ({ limit: vi.fn(async () => {
+          const values = boundValues(condition);
+          if (table === workspaceSources) return [{ kind: 'local_profile', crawlDeviceId: DEVICE_A }];
+          return rows.filter((row) =>
+            (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+            (!values.includes(SOURCE_ID) || row.sourceId === SOURCE_ID) &&
+            (!values.includes('running') || row.status === 'running')).slice(0, 1);
+        }) })),
+      })) })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => ({
+            returning: vi.fn(async () => {
+              expect(sqlText(condition)).toContain("now() - ( * interval '1 minute')");
+              expect(boundValues(condition)).toContain(STALE_RUN_MINUTES);
+              return [];
+            }),
+          })),
+        })),
+      })),
+      insert: vi.fn(),
+    };
+    const db = Object.assign(rawDb, {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(rawDb)),
+    });
+    await expect(createCrawlRunsService(db as unknown as WorkspaceDatabase).start(ORG_ID, SOURCE_ID, DEVICE_A))
+      .resolves.toEqual({ conflict: true });
+    expect(rawDb.update).toHaveBeenCalledTimes(1);
+    expect(rawDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('abandons a run older than 60 minutes before creating its replacement', async () => {
+    const stale = run({ lastActivityAt: new Date(Date.now() - 61 * 60_000) });
+    const h = makeDb([[stale]], [[stale]]);
+    const result = await createCrawlRunsService(h.db).start(ORG_ID, SOURCE_ID, DEVICE_A);
+    expect(result).toHaveProperty('run');
+    expect(h.updateTables[0]).toBe(workspaceCrawlRuns);
+    expect(h.updateSets[0]).toMatchObject({ status: 'abandoned' });
+    expectDatabaseNow((h.updateSets[0] as Record<string, unknown>).completedAt);
+    expect(h.insertValues[0]).toMatchObject({
+      orgId: ORG_ID, sourceId: SOURCE_ID, deviceId: DEVICE_A, deviceKey: DEVICE_A, status: 'running',
+    });
+    expectDatabaseNow((h.insertValues[0] as Record<string, unknown>).startedAt);
+    expectDatabaseNow((h.insertValues[0] as Record<string, unknown>).lastActivityAt);
+  });
+
+  it('starts a run when no active crawl exists', async () => {
+    const h = makeDb([[]]);
+    await expect(createCrawlRunsService(h.db).start(ORG_ID, SOURCE_ID, DEVICE_A))
+      .resolves.toHaveProperty('run');
+    expect(h.raw.update).not.toHaveBeenCalled();
+    expect(h.raw.insert).toHaveBeenCalledTimes(1);
+    expect(h.raw.transaction).toHaveBeenCalledTimes(1);
+    expect(h.raw.execute).toHaveBeenCalledTimes(1);
+    expectDatabaseNow((h.insertValues[0] as Record<string, unknown>).startedAt);
+    expectDatabaseNow((h.insertValues[0] as Record<string, unknown>).lastActivityAt);
+  });
+
+  it('serializes repeated starts and inserts only once before returning conflict', async () => {
+    const h = makeDb([[], [run({ lastActivityAt: new Date() })]]);
+    const service = createCrawlRunsService(h.db);
+    await expect(service.start(ORG_ID, SOURCE_ID, DEVICE_A)).resolves.toHaveProperty('run');
+    await expect(service.start(ORG_ID, SOURCE_ID, DEVICE_A)).resolves.toEqual({ conflict: true });
+    expect(h.raw.transaction).toHaveBeenCalledTimes(2);
+    expect(h.raw.execute).toHaveBeenCalledTimes(2);
+    expect(h.raw.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('stores an SMB run with a null device id and zero device key', async () => {
+    const h = makeDb([[]], [], 'smb_share');
+    await createCrawlRunsService(h.db).start(ORG_ID, SOURCE_ID, DEVICE_A);
+    expect(h.insertValues[0]).toMatchObject({
+      orgId: ORG_ID, sourceId: SOURCE_ID, deviceId: null, deviceKey: ZERO_UUID,
+    });
+  });
+
+  it('rejects SMB start from an unassigned device', async () => {
+    const h = makeDb([[]], [], 'smb_share');
+    await expect(createCrawlRunsService(h.db).start(ORG_ID, SOURCE_ID, DEVICE_B))
+      .rejects.toThrow('Workspace source is not assigned to this device');
+    expect(h.raw.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns null for SMB active lookup from an unassigned device', async () => {
+    const h = makeDb([[run({ deviceId: null, deviceKey: ZERO_UUID })]], [], 'smb_share');
+    await expect(createCrawlRunsService(h.db).getActive(ORG_ID, SOURCE_ID, DEVICE_B)).resolves.toBeNull();
+  });
+
+  it('returns notFound for SMB finish from an unassigned device', async () => {
+    const h = makeDb([[run({ deviceId: null, deviceKey: ZERO_UUID })]], [], 'smb_share');
+    await expect(createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_B, { complete: false }))
+      .resolves.toEqual({ notFound: true });
+    expect(h.raw.update).not.toHaveBeenCalled();
+  });
+
+  it('finds an SMB active run through its zero-key dimension', async () => {
+    const smbRun = run({ deviceId: null, deviceKey: ZERO_UUID });
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn((table: unknown) => ({
+          where: vi.fn((condition: unknown) => ({
+            limit: vi.fn(async () => {
+              if (table === workspaceSources) return [{ kind: 'smb_share', crawlDeviceId: DEVICE_A }];
+              const values = boundValues(condition);
+              return values.includes(ZERO_UUID) ? [smbRun] : [];
+            }),
+          })),
+        })),
+      })),
+    } as unknown as WorkspaceDatabase;
+    await expect(createCrawlRunsService(db).getActive(ORG_ID, SOURCE_ID, DEVICE_A)).resolves.toEqual(smbRun);
+  });
+
+  it('finishes an SMB run by resolving its zero-key dimension', async () => {
+    const smbRun = run({ deviceId: null, deviceKey: ZERO_UUID });
+    const updateSets: unknown[] = [];
+    const selectedTables: unknown[] = [];
+    const rawDb = {
+      select: vi.fn(() => ({
+        from: vi.fn((table: unknown) => {
+          selectedTables.push(table);
+          return {
+            where: vi.fn((condition: unknown) => ({
+              limit: vi.fn(async () => {
+                if (table === workspaceSources) return [{ kind: 'smb_share', crawlDeviceId: DEVICE_A }];
+                const values = boundValues(condition);
+                return values.includes(RUN_ID) ? [smbRun] : [];
+              }),
+            })),
+          };
+        }),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((value: unknown) => {
+          updateSets.push(value);
+          return { where: vi.fn(() => ({ returning: vi.fn(async () => [{ id: RUN_ID }]) })) };
+        }),
+      })),
+      execute: vi.fn(async () => []),
+    };
+    const db = Object.assign(rawDb, {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(rawDb)),
+    });
+    await expect(createCrawlRunsService(db as unknown as WorkspaceDatabase).finish(ORG_ID, RUN_ID, DEVICE_A, {
+      complete: false, errorReason: 'network timeout',
+    })).resolves.toEqual({ tombstoned: 0 });
+    expect(updateSets[0]).toMatchObject({ status: 'failed' });
+    expect(selectedTables).toContain(workspaceSources);
+  });
+
+  it('touches activity, cursor, and increments seen stats in one run update', async () => {
+    const h = makeDb();
+    await createCrawlRunsService(h.db).touch(ORG_ID, RUN_ID, 'next-page', { seen: 17 });
+    expect(h.updateTables).toEqual([workspaceCrawlRuns]);
+    expect(h.updateSets[0]).toMatchObject({ cursor: 'next-page' });
+    expectDatabaseNow((h.updateSets[0] as Record<string, unknown>).lastActivityAt);
+    expect(h.updateSets[0]).toHaveProperty('stats');
+  });
+
+  it('touch scopes on org, run, and running status, and reports the updated count', async () => {
+    const conditions: unknown[] = [];
+    const makeTouchDb = (returningRows: unknown[]) => ({
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => {
+            conditions.push(condition);
+            return { returning: vi.fn(async () => returningRows) };
+          }),
+        })),
+      })),
+    }) as unknown as WorkspaceDatabase;
+
+    await expect(createCrawlRunsService(makeTouchDb([{ id: RUN_ID }]))
+      .touch(ORG_ID, RUN_ID, 'cursor', { seen: 1 })).resolves.toBe(1);
+    expect(boundValues(conditions[0])).toEqual(
+      expect.arrayContaining([ORG_ID, RUN_ID, 'running']),
+    );
+    expect(containsIdentity(conditions[0], workspaceCrawlRuns.orgId)).toBe(true);
+    expect(containsIdentity(conditions[0], workspaceCrawlRuns.id)).toBe(true);
+    expect(containsIdentity(conditions[0], workspaceCrawlRuns.status)).toBe(true);
+
+    // 0 means the run went terminal and the cursor/stats were NOT persisted —
+    // the route must turn this into a 409 rather than reporting success.
+    await expect(createCrawlRunsService(makeTouchDb([]))
+      .touch(ORG_ID, RUN_ID, 'cursor', { seen: 1 })).resolves.toBe(0);
+  });
+
+  it('an incomplete finish never sweeps and marks an auth failure on the source', async () => {
+    const h = makeDb([[run()]], [[{ id: RUN_ID }], []]);
+    await expect(createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_A, {
+      complete: false, errorReason: 'Authentication denied', stats: { seen: 4 },
+    })).resolves.toEqual({ tombstoned: 0 });
+    expect(h.updateTables).toEqual([workspaceCrawlRuns, workspaceSources]);
+    expect(h.updateTables).not.toContain(workspaceFileIndex);
+    expect(h.updateSets[0]).toMatchObject({
+      status: 'failed', errorReason: 'Authentication denied', stats: { seen: 4 },
+    });
+    expectDatabaseNow((h.updateSets[0] as Record<string, unknown>).completedAt);
+    expectDatabaseNow((h.updateSets[0] as Record<string, unknown>).lastActivityAt);
+    expectDatabaseNow((h.updateSets[1] as Record<string, unknown>).updatedAt);
+    expect(h.updateSets[1]).toMatchObject({ status: 'error', errorReason: 'Authentication denied' });
+    expect(h.raw.transaction).toHaveBeenCalledTimes(1);
+    expect(h.raw.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('a non-auth failure records the reason on the source without flipping status, and never sweeps', async () => {
+    const h = makeDb([[run()]], [[{ id: RUN_ID }]]);
+    await createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_A, {
+      complete: false, errorReason: 'network timeout',
+    });
+    // The failure must be visible on the source (errorReason) so admins can
+    // see a crawl that stopped advancing — but only auth failures park the
+    // source in status 'error'.
+    expect(h.updateTables).toEqual([workspaceCrawlRuns, workspaceSources]);
+    expect(h.updateTables).not.toContain(workspaceFileIndex);
+    expect(h.updateSets[1]).toMatchObject({ errorReason: 'network timeout' });
+    expect(h.updateSets[1]).not.toHaveProperty('status');
+  });
+
+  it('a failed finish without an error reason still surfaces a fallback reason on the source', async () => {
+    const h = makeDb([[run()]], [[{ id: RUN_ID }]]);
+    await createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_A, { complete: false });
+    expect(h.updateSets[1]).toMatchObject({ errorReason: 'crawl failed' });
+    expect(h.updateSets[1]).not.toHaveProperty('status');
+  });
+
+  it('finishing an already-terminal owned run is an idempotent no-op', async () => {
+    const h = makeDb([[run({ status: 'complete' })]]);
+    await expect(createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_A, { complete: true }))
+      .resolves.toEqual({ alreadyFinished: true });
+    expect(h.raw.update).not.toHaveBeenCalled();
+    expect(h.raw.insert).not.toHaveBeenCalled();
+  });
+
+  it('allows only one terminal transition across duplicate failed finishes', async () => {
+    const h = makeDb([[run()], []], [[{ id: RUN_ID }]]);
+    const service = createCrawlRunsService(h.db);
+    await expect(service.finish(ORG_ID, RUN_ID, DEVICE_A, { complete: false })).resolves.toEqual({ tombstoned: 0 });
+    await expect(service.finish(ORG_ID, RUN_ID, DEVICE_A, { complete: false })).resolves.toEqual({ notFound: true });
+    expect(h.updateTables.filter((table) => table === workspaceCrawlRuns)).toHaveLength(1);
+    expect(h.raw.transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('rolls back a failed auth terminal transition when the source update fails', async () => {
+    let status = 'running';
+    const db: Record<string, unknown> = {};
+    db.execute = vi.fn(async () => []);
+    db.select = vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => table === workspaceSources
+            ? [{ kind: 'local_profile', crawlDeviceId: DEVICE_A }]
+            : status === 'running' ? [run({ status })] : []),
+        })),
+      })),
+    }));
+    db.update = vi.fn((table: unknown) => ({
+      set: vi.fn((setValue: { status?: string }) => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => {
+            if (table === workspaceSources) throw new Error('source update failed');
+            if (table === workspaceCrawlRuns) status = setValue.status ?? status;
+            return [{ id: RUN_ID }];
+          }),
+        })),
+      })),
+    }));
+    db.transaction = vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+      const snapshot = status;
+      try { return await callback(db); } catch (error) { status = snapshot; throw error; }
+    });
+    await expect(createCrawlRunsService(db as unknown as WorkspaceDatabase).finish(
+      ORG_ID, RUN_ID, DEVICE_A, { complete: false, errorReason: 'auth denied' },
+    )).rejects.toThrow('source update failed');
+    expect(status).toBe('running');
+  });
+
+  it('a complete finish performs one device-scoped sweep then completes run and source', async () => {
+    const h = makeStatefulFinishDb();
+    await expect(createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_A, {
+      complete: true, stats: { seen: 12 },
+    })).resolves.toEqual({ tombstoned: 1 });
+
+    expect(h.updateTables).toEqual([workspaceCrawlRuns, workspaceFileIndex, workspaceSources]);
+    expect(h.updateTables.filter((table) => table === workspaceFileIndex)).toHaveLength(1);
+    expect(h.raw.transaction).toHaveBeenCalledTimes(1);
+    expect(h.files[0]).toMatchObject({ deviceKey: DEVICE_A, deletedAt: expect.any(Date) });
+    expect(h.files.slice(1).every((file) => file.deletedAt === null)).toBe(true);
+    expect(h.runs.filter((row) => row.status === 'complete')).toHaveLength(1);
+    expectDatabaseNow((h.updateSets[0] as Record<string, unknown>).completedAt);
+    expectDatabaseNow((h.updateSets[0] as Record<string, unknown>).lastActivityAt);
+    expectDatabaseNow((h.updateSets[1] as Record<string, unknown>).deletedAt);
+    expectDatabaseNow((h.updateSets[1] as Record<string, unknown>).updatedAt);
+    expectDatabaseNow((h.updateSets[2] as Record<string, unknown>).lastCompleteRunAt);
+    expectDatabaseNow((h.updateSets[2] as Record<string, unknown>).updatedAt);
+    // The ownership lookup no longer filters on status (idempotency needs the
+    // terminal row); the status guard lives in the transition UPDATE.
+    const firstLookup = h.runConditions[0];
+    expect(boundValues(firstLookup)).toEqual(expect.arrayContaining([ORG_ID, RUN_ID]));
+    expect(containsIdentity(firstLookup, workspaceCrawlRuns.orgId)).toBe(true);
+    expect(containsIdentity(firstLookup, workspaceCrawlRuns.id)).toBe(true);
+    const transitionUpdate = h.runConditions[1];
+    expect(boundValues(transitionUpdate)).toEqual(expect.arrayContaining([ORG_ID, RUN_ID, 'running']));
+    expect(containsIdentity(transitionUpdate, workspaceCrawlRuns.status)).toBe(true);
+    const runUpdates = h.updateTables.filter((table) => table === workspaceCrawlRuns).length;
+    const sweeps = h.updateTables.filter((table) => table === workspaceFileIndex).length;
+    // A retried complete (lost response) answers idempotently and re-runs
+    // neither the transition nor the sweep.
+    await expect(createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_A, { complete: true }))
+      .resolves.toEqual({ alreadyFinished: true });
+    expect(h.updateTables.filter((table) => table === workspaceCrawlRuns)).toHaveLength(runUpdates);
+    expect(h.updateTables.filter((table) => table === workspaceFileIndex)).toHaveLength(sweeps);
+  });
+
+  it('rolls back a completed sweep when the source completion update fails', async () => {
+    const h = makeStatefulFinishDb({ failSourceUpdate: true });
+    await expect(createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_A, { complete: true }))
+      .rejects.toThrow('source update failed');
+    expect(h.raw.transaction).toHaveBeenCalledTimes(1);
+    expect(h.files.every((file) => file.deletedAt === null)).toBe(true);
+    expect(h.runs.at(-1)?.status).toBe('running');
+  });
+
+  it('returns notFound without writes when the scoped run is absent or device mismatched', async () => {
+    const h = makeDb([[]]);
+    await expect(createCrawlRunsService(h.db).finish(ORG_ID, RUN_ID, DEVICE_A, { complete: true }))
+      .resolves.toEqual({ notFound: true });
+    expect(h.raw.update).not.toHaveBeenCalled();
+  });
+
+  it('gets the active run or null for a source and device', async () => {
+    const row = run();
+    const h = makeDb([[row], []]);
+    const service = createCrawlRunsService(h.db);
+    await expect(service.getActive(ORG_ID, SOURCE_ID, DEVICE_A)).resolves.toEqual(row);
+    await expect(service.getActive(ORG_ID, SOURCE_ID, DEVICE_A)).resolves.toBeNull();
+  });
+
+  it('gets a run by org and id while hiding cross-org and missing rows', async () => {
+    const crossOrg = run({ orgId: DEVICE_B });
+    const correct = run();
+    const rows = [crossOrg, correct];
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => ({
+            limit: vi.fn(async () => {
+              const values = boundValues(condition);
+              return rows.filter((row) =>
+                values.includes(row.orgId) && values.includes(row.id)).slice(0, 1);
+            }),
+          })),
+        })),
+      })),
+    } as unknown as WorkspaceDatabase;
+    const service = createCrawlRunsService(db);
+
+    await expect(service.getById(ORG_ID, RUN_ID)).resolves.toEqual(correct);
+    rows.pop();
+    await expect(service.getById(ORG_ID, RUN_ID)).resolves.toBeNull();
+    await expect(service.getById(ORG_ID, WRONG_RUN_ID)).resolves.toBeNull();
+  });
+});

--- a/ee/workspace/src/services/crawlRunsService.ts
+++ b/ee/workspace/src/services/crawlRunsService.ts
@@ -1,0 +1,280 @@
+// All sweep-relevant timestamps use the database clock. Host clocks must never
+// enter the last_seen_at/started_at comparison that decides which rows to tombstone.
+import type { WorkspaceDatabase } from '../hostTypes';
+import { and, eq, isNull, lt, sql } from 'drizzle-orm';
+import { workspaceCrawlRuns, workspaceFileIndex, workspaceSources } from '../schema/workspace';
+import { matchesScope, scopeForDevice, type RunScope } from './runScope';
+
+export type CrawlRunRow = typeof workspaceCrawlRuns.$inferSelect;
+export const STALE_RUN_MINUTES = 60;
+
+export class SourceNotFoundError extends Error {
+  constructor() {
+    super('Workspace source not found');
+    this.name = 'SourceNotFoundError';
+  }
+}
+
+export class SourceNotAssignedError extends Error {
+  constructor() {
+    super('Workspace source is not assigned to this device');
+    this.name = 'SourceNotAssignedError';
+  }
+}
+
+type ScopeResolution =
+  | { ok: true; scope: RunScope }
+  | { ok: false; reason: 'source_missing' | 'not_assigned' };
+
+export function createCrawlRunsService(d: WorkspaceDatabase) {
+  async function resolveScope(
+    queryDb: WorkspaceDatabase,
+    orgId: string,
+    sourceId: string,
+    deviceId: string,
+  ): Promise<ScopeResolution> {
+    const [source] = await queryDb.select({
+      kind: workspaceSources.kind,
+      crawlDeviceId: workspaceSources.crawlDeviceId,
+    })
+      .from(workspaceSources)
+      .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, sourceId)))
+      .limit(1);
+    if (!source) return { ok: false, reason: 'source_missing' };
+    const scope = scopeForDevice(source, deviceId);
+    if (!scope) return { ok: false, reason: 'not_assigned' };
+    return { ok: true, scope };
+  }
+
+  async function acquireLock(queryDb: WorkspaceDatabase, orgId: string, key: string): Promise<void> {
+    await queryDb.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`${orgId}:${key}`}, 0))`);
+  }
+
+  async function findActive(
+    queryDb: WorkspaceDatabase,
+    orgId: string,
+    sourceId: string,
+    scope: RunScope,
+  ): Promise<CrawlRunRow | null> {
+    const [row] = await queryDb.select().from(workspaceCrawlRuns)
+      .where(and(
+        eq(workspaceCrawlRuns.orgId, orgId),
+        eq(workspaceCrawlRuns.sourceId, sourceId),
+        scope.deviceId === null
+          ? isNull(workspaceCrawlRuns.deviceId)
+          : eq(workspaceCrawlRuns.deviceId, scope.deviceId),
+        eq(workspaceCrawlRuns.deviceKey, scope.deviceKey),
+        eq(workspaceCrawlRuns.status, 'running'),
+      ))
+      .limit(1);
+    return row ?? null;
+  }
+
+  // Tolerates a source deleted mid-request (returns null) so one vanished
+  // source cannot fail a whole /crawl-config response.
+  async function getActive(
+    orgId: string,
+    sourceId: string,
+    deviceId: string,
+  ): Promise<CrawlRunRow | null> {
+    const resolution = await resolveScope(d, orgId, sourceId, deviceId);
+    if (!resolution.ok) return null;
+    return findActive(d, orgId, sourceId, resolution.scope);
+  }
+
+  async function getById(orgId: string, runId: string): Promise<CrawlRunRow | null> {
+    const [row] = await d.select().from(workspaceCrawlRuns)
+      .where(and(
+        eq(workspaceCrawlRuns.orgId, orgId),
+        eq(workspaceCrawlRuns.id, runId),
+      ))
+      .limit(1);
+    return row ?? null;
+  }
+
+  return {
+    async start(
+      orgId: string,
+      sourceId: string,
+      deviceId: string,
+    ): Promise<{ run: CrawlRunRow } | { conflict: true }> {
+      return d.transaction(async (transaction) => {
+        const tx = transaction as unknown as WorkspaceDatabase;
+        await acquireLock(tx, orgId, sourceId);
+        const resolution = await resolveScope(tx, orgId, sourceId, deviceId);
+        if (!resolution.ok) {
+          throw resolution.reason === 'source_missing'
+            ? new SourceNotFoundError()
+            : new SourceNotAssignedError();
+        }
+        const active = await findActive(tx, orgId, sourceId, resolution.scope);
+        if (active) {
+          // A 'running' run whose last_activity_at is older than STALE_RUN_MINUTES
+          // is presumed crashed: abandon it and take over. The guarded UPDATE
+          // (status = 'running' AND stale) means a concurrent touch wins the race
+          // and we conflict instead of hijacking a live run.
+          const abandoned = await tx.update(workspaceCrawlRuns)
+            .set({ status: 'abandoned', completedAt: sql`now()` })
+            .where(and(
+              eq(workspaceCrawlRuns.orgId, orgId),
+              eq(workspaceCrawlRuns.id, active.id),
+              eq(workspaceCrawlRuns.status, 'running'),
+              lt(
+                workspaceCrawlRuns.lastActivityAt,
+                sql`now() - (${STALE_RUN_MINUTES} * interval '1 minute')`,
+              ),
+            ))
+            .returning({ id: workspaceCrawlRuns.id });
+          if (abandoned.length === 0) return { conflict: true } as const;
+        }
+
+        const [created] = await tx.insert(workspaceCrawlRuns).values({
+          orgId,
+          sourceId,
+          deviceId: resolution.scope.deviceId,
+          deviceKey: resolution.scope.deviceKey,
+          status: 'running',
+          startedAt: sql`now()`,
+          lastActivityAt: sql`now()`,
+        }).returning();
+        if (!created) throw new Error('Failed to start workspace crawl');
+        return { run: created };
+      });
+    },
+
+    /**
+     * Advances the cursor and merges the seen-count delta into stats. Returns the
+     * number of rows updated: 0 means the run is no longer 'running' (finished or
+     * abandoned between the caller's ownership check and this write) and the
+     * cursor/stats were NOT persisted — callers must surface that to the agent
+     * instead of reporting success.
+     */
+    async touch(
+      orgId: string,
+      runId: string,
+      cursor: string,
+      statsDelta: { seen: number },
+    ): Promise<number> {
+      const updated = await d.update(workspaceCrawlRuns)
+        .set({
+          cursor,
+          lastActivityAt: sql`now()`,
+          stats: sql<Record<string, unknown>>`
+            coalesce(${workspaceCrawlRuns.stats}, '{}'::jsonb) ||
+            jsonb_build_object(
+              'seen',
+              coalesce((${workspaceCrawlRuns.stats}->>'seen')::bigint, 0) + ${statsDelta.seen}
+            )
+          `,
+        })
+        .where(and(
+          eq(workspaceCrawlRuns.orgId, orgId),
+          eq(workspaceCrawlRuns.id, runId),
+          eq(workspaceCrawlRuns.status, 'running'),
+        ))
+        .returning({ id: workspaceCrawlRuns.id });
+      return updated.length;
+    },
+
+    /**
+     * Terminal transition for a run. Idempotent for the owning device: finishing
+     * an already-terminal run returns { alreadyFinished: true } (a lost-response
+     * retry is normal HTTP client behavior and must not read as "run never
+     * existed"); { notFound: true } is reserved for runs that don't exist or
+     * aren't owned by this device.
+     *
+     * When opts.stats is provided it replaces the stored object wholesale
+     * (unlike touch's incremental merge) — send the complete final stats, not a
+     * delta. When omitted, the touch-accumulated stats survive.
+     */
+    async finish(
+      orgId: string,
+      runId: string,
+      deviceId: string,
+      opts: { complete: boolean; stats?: object; errorReason?: string },
+    ): Promise<{ tombstoned: number } | { notFound: true } | { alreadyFinished: true }> {
+      return d.transaction(async (transaction) => {
+        const tx = transaction as unknown as WorkspaceDatabase;
+        await acquireLock(tx, orgId, runId);
+        const [run] = await tx.select().from(workspaceCrawlRuns)
+          .where(and(
+            eq(workspaceCrawlRuns.orgId, orgId),
+            eq(workspaceCrawlRuns.id, runId),
+          ))
+          .limit(1);
+        if (!run) return { notFound: true } as const;
+        const resolution = await resolveScope(tx, orgId, run.sourceId, deviceId);
+        if (!resolution.ok || !matchesScope(run, resolution.scope)) {
+          return { notFound: true } as const;
+        }
+        if (run.status !== 'running') return { alreadyFinished: true } as const;
+        const transitioned = await tx.update(workspaceCrawlRuns)
+          .set({
+            status: opts.complete ? 'complete' : 'failed',
+            completedAt: sql`now()`,
+            lastActivityAt: sql`now()`,
+            errorReason: opts.complete ? null : opts.errorReason ?? null,
+            ...(opts.stats === undefined
+              ? {}
+              : { stats: opts.stats as Record<string, unknown> }),
+          })
+          .where(and(
+            eq(workspaceCrawlRuns.orgId, orgId),
+            eq(workspaceCrawlRuns.id, runId),
+            eq(workspaceCrawlRuns.status, 'running'),
+          ))
+          .returning({ id: workspaceCrawlRuns.id });
+        if (transitioned.length === 0) return { alreadyFinished: true } as const;
+
+        if (!opts.complete) {
+          // Every failure is surfaced on the source so admins can see a crawl
+          // that quietly stopped advancing. Only auth-classified failures park
+          // the source in status 'error' (prompting credential re-entry);
+          // transient failures leave it 'active'. The /auth/i match on the
+          // agent's error prose is a heuristic contract with the Go agent's
+          // error wording (spec §2.5) — promote to a structured error code when
+          // the wire schema next changes.
+          const isAuthFailure = opts.errorReason !== undefined && /auth/i.test(opts.errorReason);
+          await tx.update(workspaceSources)
+            .set({
+              ...(isAuthFailure ? { status: 'error' as const } : {}),
+              errorReason: opts.errorReason ?? 'crawl failed',
+              updatedAt: sql`now()`,
+            })
+            .where(and(
+              eq(workspaceSources.orgId, orgId),
+              eq(workspaceSources.id, run.sourceId),
+            ))
+            .returning({ id: workspaceSources.id });
+          return { tombstoned: 0 };
+        }
+
+        const swept = await tx.update(workspaceFileIndex)
+          .set({ deletedAt: sql`now()`, updatedAt: sql`now()` })
+          .where(and(
+            eq(workspaceFileIndex.orgId, run.orgId),
+            eq(workspaceFileIndex.sourceId, run.sourceId),
+            eq(workspaceFileIndex.deviceKey, run.deviceKey),
+            isNull(workspaceFileIndex.deletedAt),
+            lt(workspaceFileIndex.lastSeenAt, run.startedAt),
+          ))
+          .returning({ id: workspaceFileIndex.id });
+
+        await tx.update(workspaceSources)
+          .set({
+            status: 'active',
+            errorReason: null,
+            lastCompleteRunAt: sql`now()`,
+            updatedAt: sql`now()`,
+          })
+          .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, run.sourceId)))
+          .returning({ id: workspaceSources.id });
+
+        return { tombstoned: swept.length };
+      });
+    },
+
+    getActive,
+    getById,
+  };
+}

--- a/ee/workspace/src/services/credentialService.test.ts
+++ b/ee/workspace/src/services/credentialService.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ExtensionSecrets, WorkspaceDatabase } from '../hostTypes';
+import { createCredentialService, CredentialDecryptError } from './credentialService';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SOURCE_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const OTHER_ORG_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+// The injected content-flag lookup (Task 3): replaces the process-wide
+// WORKSPACE_CONTENT_PREVIEW env var with a per-org getOrgSettings read. A
+// constant-true stub stands in for it everywhere decryptForContentIngest is
+// not the subject under test.
+const settingsStub = (contentEnabled: boolean) => async () => ({ contentEnabled });
+
+function boundValues(value: unknown): unknown[] {
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value') ? [candidate.value] : [];
+  return [...own, ...(candidate.queryChunks ?? []).flatMap(boundValues)];
+}
+
+function makeHarness(row?: Record<string, unknown>) {
+  const sets: unknown[] = [];
+  const db = {
+    update: vi.fn(() => ({
+      set: vi.fn((value: unknown) => {
+        sets.push(value);
+        return { where: vi.fn(() => ({ returning: vi.fn(async () => [{ id: SOURCE_ID }]) })) };
+      }),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn(async () => row ? [row] : []) })) })),
+    })),
+  };
+  const secrets = {
+    encryptForColumn: vi.fn(() => 'ciphertext'),
+    decryptForColumn: vi.fn(() => JSON.stringify({ username: 'alice', password: 'secret', domain: 'ACME' })),
+  };
+  return {
+    db: db as unknown as WorkspaceDatabase,
+    raw: db,
+    secrets: secrets as unknown as ExtensionSecrets,
+    rawSecrets: secrets,
+    sets,
+  };
+}
+
+describe('credentialService', () => {
+  it('encrypts credentials with the workspace column AAD and stores ciphertext', async () => {
+    const h = makeHarness();
+    const cred = { username: 'alice', password: 'secret', domain: 'ACME' };
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).set(ORG_ID, SOURCE_ID, cred)).resolves.toBe(true);
+    expect(h.rawSecrets.encryptForColumn).toHaveBeenCalledWith(
+      'workspace_sources', 'credential_enc', JSON.stringify(cred),
+    );
+    expect(h.sets[0]).toMatchObject({ credentialEnc: 'ciphertext', updatedAt: expect.any(Date) });
+  });
+
+  it('clears a credential and reports a scoped miss', async () => {
+    const h = makeHarness();
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).clear(ORG_ID, SOURCE_ID)).resolves.toBe(true);
+    expect(h.sets[0]).toMatchObject({ credentialEnc: null });
+
+    h.raw.update.mockReturnValueOnce({
+      set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(async () => []) })) })),
+    });
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).clear(ORG_ID, SOURCE_ID)).resolves.toBe(false);
+  });
+
+  it('decrypts credentials only for the assigned SMB crawler device', async () => {
+    const h = makeHarness({
+      kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: 'ciphertext',
+    });
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).decryptForDevice(ORG_ID, SOURCE_ID, DEVICE_ID))
+      .resolves.toEqual({ username: 'alice', password: 'secret', domain: 'ACME' });
+    expect(h.rawSecrets.decryptForColumn).toHaveBeenCalledWith(
+      'workspace_sources', 'credential_enc', 'ciphertext',
+    );
+  });
+
+  it.each([
+    ['the wrong device', { kind: 'smb_share', crawlDeviceId: '44444444-4444-4444-4444-444444444444', credentialEnc: 'ciphertext' }],
+    ['a local-profile source', { kind: 'local_profile', crawlDeviceId: DEVICE_ID, credentialEnc: 'ciphertext' }],
+    ['a source without a credential', { kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: null }],
+  ])('returns null for %s without decrypting', async (_case, row) => {
+    const h = makeHarness(row);
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).decryptForDevice(ORG_ID, SOURCE_ID, DEVICE_ID))
+      .resolves.toBeNull();
+    expect(h.rawSecrets.decryptForColumn).not.toHaveBeenCalled();
+  });
+
+  it('normalizes an omitted decrypted domain to null', async () => {
+    const h = makeHarness({ kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: 'ciphertext' });
+    h.rawSecrets.decryptForColumn.mockReturnValueOnce(JSON.stringify({ username: 'alice', password: 'secret' }));
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).decryptForDevice(ORG_ID, SOURCE_ID, DEVICE_ID))
+      .resolves.toEqual({ username: 'alice', password: 'secret', domain: null });
+  });
+
+  // Decrypt failures must be distinguishable from "no credential": null is
+  // reserved for true absence; corruption/rotation problems throw so the route
+  // can 500 with a log line instead of a silent 404.
+  it('throws CredentialDecryptError when credential decryption fails', async () => {
+    const h = makeHarness({ kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: 'ciphertext' });
+    h.rawSecrets.decryptForColumn.mockImplementationOnce(() => { throw new Error('corrupt ciphertext'); });
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).decryptForDevice(ORG_ID, SOURCE_ID, DEVICE_ID))
+      .rejects.toBeInstanceOf(CredentialDecryptError);
+  });
+
+  it('throws CredentialDecryptError when decrypted credentials are invalid JSON', async () => {
+    const h = makeHarness({ kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: 'ciphertext' });
+    h.rawSecrets.decryptForColumn.mockReturnValueOnce('not-json');
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).decryptForDevice(ORG_ID, SOURCE_ID, DEVICE_ID))
+      .rejects.toBeInstanceOf(CredentialDecryptError);
+  });
+
+  it('throws CredentialDecryptError when the decrypted plaintext fails shape validation', async () => {
+    const h = makeHarness({ kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: 'ciphertext' });
+    // Valid JSON, wrong shape: a blind cast would serialize this into a 200
+    // with missing fields and the agent would attempt SMB auth with blanks.
+    h.rawSecrets.decryptForColumn.mockReturnValueOnce(JSON.stringify({ user: 'alice' }));
+    await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).decryptForDevice(ORG_ID, SOURCE_ID, DEVICE_ID))
+      .rejects.toBeInstanceOf(CredentialDecryptError);
+  });
+
+  describe('decryptForContentIngest (dev-preview, org-scoped)', () => {
+    it('is hard-disabled when content is not enabled for the org', async () => {
+      const h = makeHarness({ kind: 'smb_share', credentialEnc: 'ciphertext' });
+      await expect(createCredentialService(h.db, h.secrets, settingsStub(false)).decryptForContentIngest(ORG_ID, SOURCE_ID))
+        .rejects.toThrow(/content preview disabled/);
+      expect(h.rawSecrets.decryptForColumn).not.toHaveBeenCalled();
+    });
+
+    it('decrypts without a device gate when content is enabled for the org', async () => {
+      const h = makeHarness({ kind: 'smb_share', credentialEnc: 'ciphertext' });
+      await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).decryptForContentIngest(ORG_ID, SOURCE_ID))
+        .resolves.toEqual({ username: 'alice', password: 'secret', domain: 'ACME' });
+    });
+
+    // The per-org property the env var could never express: two orgs, one
+    // process, opposite outcomes — driven entirely by getOrgSettings.
+    it('gates per org in the same process: enabled org decrypts, disabled org throws', async () => {
+      const getSettings = async (orgId: string) => ({ contentEnabled: orgId === ORG_ID });
+      const enabled = makeHarness({ kind: 'smb_share', credentialEnc: 'ciphertext' });
+      await expect(createCredentialService(enabled.db, enabled.secrets, getSettings).decryptForContentIngest(ORG_ID, SOURCE_ID))
+        .resolves.toEqual({ username: 'alice', password: 'secret', domain: 'ACME' });
+      const disabled = makeHarness({ kind: 'smb_share', credentialEnc: 'ciphertext' });
+      await expect(createCredentialService(disabled.db, disabled.secrets, getSettings).decryptForContentIngest(OTHER_ORG_ID, SOURCE_ID))
+        .rejects.toThrow(/content preview disabled/);
+      expect(disabled.rawSecrets.decryptForColumn).not.toHaveBeenCalled();
+    });
+
+    it('returns null for non-smb or credential-less sources', async () => {
+      const local = makeHarness({ kind: 'local_profile', credentialEnc: 'ciphertext' });
+      await expect(createCredentialService(local.db, local.secrets, settingsStub(true)).decryptForContentIngest(ORG_ID, SOURCE_ID))
+        .resolves.toBeNull();
+      const bare = makeHarness({ kind: 'smb_share', credentialEnc: null });
+      await expect(createCredentialService(bare.db, bare.secrets, settingsStub(true)).decryptForContentIngest(ORG_ID, SOURCE_ID))
+        .resolves.toBeNull();
+    });
+
+    it('throws CredentialDecryptError on corrupt ciphertext', async () => {
+      const h = makeHarness({ kind: 'smb_share', credentialEnc: 'ciphertext' });
+      h.rawSecrets.decryptForColumn.mockImplementationOnce(() => { throw new Error('bad'); });
+      await expect(createCredentialService(h.db, h.secrets, settingsStub(true)).decryptForContentIngest(ORG_ID, SOURCE_ID))
+        .rejects.toBeInstanceOf(CredentialDecryptError);
+    });
+  });
+
+  it('scopes credential writes to smb_share sources', async () => {
+    const conditions: unknown[] = [];
+    const db = {
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => {
+            conditions.push(condition);
+            return { returning: vi.fn(async () => []) };
+          }),
+        })),
+      })),
+    } as unknown as WorkspaceDatabase;
+    const secrets = {
+      encryptForColumn: vi.fn(() => 'ciphertext'),
+      decryptForColumn: vi.fn(),
+    } as unknown as ExtensionSecrets;
+    await expect(
+      createCredentialService(db, secrets, settingsStub(true)).set(ORG_ID, SOURCE_ID, { username: 'a', password: 'b' }),
+    ).resolves.toBe(false);
+    expect(boundValues(conditions[0])).toEqual(
+      expect.arrayContaining([ORG_ID, SOURCE_ID, 'smb_share']),
+    );
+  });
+
+  it('scopes credential writes and decrypt reads by exact org and source predicates', async () => {
+    const rows = [
+      { id: SOURCE_ID, orgId: OTHER_ORG_ID, kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: 'cross-org' },
+      { id: OTHER_ORG_ID, orgId: ORG_ID, kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: 'wrong-source' },
+      { id: SOURCE_ID, orgId: ORG_ID, kind: 'smb_share', crawlDeviceId: DEVICE_ID, credentialEnc: 'old' },
+    ];
+    const db = {
+      update: vi.fn(() => ({
+        set: vi.fn((setValue: { credentialEnc: string | null }) => ({
+          where: vi.fn((condition: unknown) => ({
+            returning: vi.fn(async () => {
+              const values = boundValues(condition);
+              const matches = rows.filter((row) =>
+                (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+                (!values.includes(SOURCE_ID) || row.id === SOURCE_ID));
+              for (const row of matches) row.credentialEnc = setValue.credentialEnc ?? '';
+              return matches.map(({ id }) => ({ id }));
+            }),
+          })),
+        })),
+      })),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => ({
+            limit: vi.fn(async () => {
+              const values = boundValues(condition);
+              return rows.filter((row) =>
+                (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+                (!values.includes(SOURCE_ID) || row.id === SOURCE_ID)).slice(0, 1);
+            }),
+          })),
+        })),
+      })),
+    } as unknown as WorkspaceDatabase;
+    const rawSecrets = {
+      encryptForColumn: vi.fn(() => 'new-cipher'),
+      decryptForColumn: vi.fn((_table: string, _column: string, ciphertext: string) => ciphertext === 'new-cipher'
+        ? JSON.stringify({ username: 'alice', password: 'secret' })
+        : JSON.stringify({ username: 'wrong', password: 'wrong' })),
+    };
+    const service = createCredentialService(db, rawSecrets as unknown as ExtensionSecrets, settingsStub(true));
+    await expect(service.set(ORG_ID, SOURCE_ID, { username: 'alice', password: 'secret' })).resolves.toBe(true);
+    expect(rows.map((row) => row.credentialEnc)).toEqual(['cross-org', 'wrong-source', 'new-cipher']);
+    await expect(service.decryptForDevice(ORG_ID, SOURCE_ID, DEVICE_ID))
+      .resolves.toEqual({ username: 'alice', password: 'secret', domain: null });
+    expect(rawSecrets.decryptForColumn).toHaveBeenCalledWith(
+      'workspace_sources', 'credential_enc', 'new-cipher',
+    );
+    await expect(service.clear(ORG_ID, SOURCE_ID)).resolves.toBe(true);
+    expect(rows.map((row) => row.credentialEnc)).toEqual(['cross-org', 'wrong-source', '']);
+  });
+});

--- a/ee/workspace/src/services/credentialService.ts
+++ b/ee/workspace/src/services/credentialService.ts
@@ -1,0 +1,141 @@
+import type { ExtensionSecrets, WorkspaceDatabase } from '../hostTypes';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { workspaceSources } from '../schema/workspace';
+
+const storedCredentialSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+  domain: z.string().optional(),
+});
+
+type Credential = z.infer<typeof storedCredentialSchema>;
+type DecryptedCredential = { username: string; password: string; domain: string | null };
+
+/**
+ * A credential row exists but its ciphertext cannot be decrypted, parsed, or
+ * shape-validated. Deliberately distinct from "no credential" (null): a wrong
+ * key, corrupt ciphertext, or plaintext schema drift must surface as a server
+ * error with a log line — never as an indistinguishable 404 while
+ * /crawl-config still reports hasCredential: true.
+ */
+export class CredentialDecryptError extends Error {
+  constructor(cause: unknown) {
+    super('Workspace credential decrypt failed');
+    this.name = 'CredentialDecryptError';
+    this.cause = cause;
+  }
+}
+
+const TABLE = 'workspace_sources';
+const COLUMN = 'credential_enc';
+
+export function createCredentialService(
+  d: WorkspaceDatabase,
+  secrets: ExtensionSecrets,
+  // Per-org content flag (W2 Task 3), injected constructor-style. Replaces the
+  // process-wide WORKSPACE_CONTENT_PREVIEW env var so decryptForContentIngest
+  // can be gated on the calling org's settings, not a global switch.
+  getSettings: (orgId: string) => Promise<{ contentEnabled: boolean }>,
+) {
+  return {
+    async set(orgId: string, sourceId: string, cred: Credential): Promise<boolean> {
+      const ciphertext = secrets.encryptForColumn(TABLE, COLUMN, JSON.stringify(cred));
+      const rows = await d.update(workspaceSources)
+        .set({ credentialEnc: ciphertext, updatedAt: new Date() })
+        .where(and(
+          eq(workspaceSources.orgId, orgId),
+          eq(workspaceSources.id, sourceId),
+          // Only SMB sources carry credentials; local_profile writes are rejected
+          // here so unreachable ciphertext can never be stored.
+          eq(workspaceSources.kind, 'smb_share'),
+        ))
+        .returning({ id: workspaceSources.id });
+      return rows.length > 0;
+    },
+
+    async clear(orgId: string, sourceId: string): Promise<boolean> {
+      const rows = await d.update(workspaceSources)
+        .set({ credentialEnc: null, updatedAt: new Date() })
+        .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, sourceId)))
+        .returning({ id: workspaceSources.id });
+      return rows.length > 0;
+    },
+
+    /**
+     * Returns null only for true absence (unknown source, wrong kind, source not
+     * assigned to this device, or no credential stored). Decrypt/parse/shape
+     * failures throw CredentialDecryptError.
+     */
+    async decryptForDevice(
+      orgId: string,
+      sourceId: string,
+      deviceId: string,
+    ): Promise<DecryptedCredential | null> {
+      const [source] = await d.select({
+        kind: workspaceSources.kind,
+        crawlDeviceId: workspaceSources.crawlDeviceId,
+        credentialEnc: workspaceSources.credentialEnc,
+      }).from(workspaceSources)
+        .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, sourceId)))
+        .limit(1);
+
+      if (
+        !source || source.kind !== 'smb_share' ||
+        source.crawlDeviceId !== deviceId || !source.credentialEnc
+      ) {
+        return null;
+      }
+
+      let parsed: Credential;
+      try {
+        const plaintext = secrets.decryptForColumn(TABLE, COLUMN, source.credentialEnc);
+        parsed = storedCredentialSchema.parse(JSON.parse(plaintext));
+      } catch (error) {
+        throw new CredentialDecryptError(error);
+      }
+      return { username: parsed.username, password: parsed.password, domain: parsed.domain ?? null };
+    },
+
+    /**
+     * Org-scoped decrypt for the server-side content-ingest reader
+     * (dev-preview). Unlike decryptForDevice this is NOT device-gated — the
+     * ingest worker has no device identity — which is a deliberate,
+     * preview-only widening of the credential surface:
+     *   - hard-disabled unless content is enabled for the org (defense in
+     *     depth; the routes that reach here are themselves gated on the same
+     *     per-org setting), and
+     *   - the bytes this credential unlocks are DLP-inspected at ingest
+     *     (extracted text is redacted before store; a 'block' hit persists no
+     *     text), but this remains a preview-only widening — never enable in
+     *     production.
+     * Same null-vs-throw contract as decryptForDevice.
+     */
+    async decryptForContentIngest(
+      orgId: string,
+      sourceId: string,
+    ): Promise<DecryptedCredential | null> {
+      const settings = await getSettings(orgId);
+      if (!settings.contentEnabled) {
+        throw new Error('content preview disabled');
+      }
+      const [source] = await d.select({
+        kind: workspaceSources.kind,
+        credentialEnc: workspaceSources.credentialEnc,
+      }).from(workspaceSources)
+        .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, sourceId)))
+        .limit(1);
+
+      if (!source || source.kind !== 'smb_share' || !source.credentialEnc) return null;
+
+      let parsed: Credential;
+      try {
+        const plaintext = secrets.decryptForColumn(TABLE, COLUMN, source.credentialEnc);
+        parsed = storedCredentialSchema.parse(JSON.parse(plaintext));
+      } catch (error) {
+        throw new CredentialDecryptError(error);
+      }
+      return { username: parsed.username, password: parsed.password, domain: parsed.domain ?? null };
+    },
+  };
+}

--- a/ee/workspace/src/services/crosswalkService.ts
+++ b/ee/workspace/src/services/crosswalkService.ts
@@ -1,0 +1,125 @@
+// Crosswalk miner (dev-preview; per-org content flag).
+//
+// Mines counterparty identifiers (PO/WDR/invoice/permit — the deterministic
+// regex types only) from files whose PATH declares a project, producing
+// (entity → project) evidence rows. Evidence counts DISTINCT FILES, never
+// mentions, and the miner RECOMPUTES the whole org's table on every run —
+// re-runs can never inflate counts.
+//
+// The dominance rule (is this mapping trustworthy enough to auto-file?) lives
+// with the consumer (filingService), not here: the miner records evidence,
+// the classifier judges it.
+import type { WorkspaceDatabase } from '../hostTypes';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { deriveDeclaredProject } from '../content/projects';
+
+export const STRONG_TYPES = ['po', 'wdr', 'invoice', 'permit'] as const;
+const SAMPLE_LIMIT = 5;
+
+export interface CrosswalkRow {
+  entityType: string;
+  valueNorm: string;
+  projectKey: string;
+  projectLabel: string | null;
+  evidenceCount: number;
+}
+
+interface EvidenceEntry {
+  entityType: string;
+  valueNorm: string;
+  projectKey: string;
+  files: Set<string>;
+}
+
+export function createCrosswalkService(db: WorkspaceDatabase) {
+  const d = db;
+
+  return {
+    /** Recompute the org's crosswalk. Returns the mined mapping count. */
+    async run(orgId: string): Promise<{ mined: number }> {
+      const rows = await d.execute(sql`
+        SELECT e.entity_type, e.value_norm, e.file_index_id, fi.rel_path
+        FROM workspace_content_entities e
+        JOIN workspace_file_index fi ON fi.id = e.file_index_id
+        WHERE e.org_id = ${orgId}
+          AND fi.deleted_at IS NULL
+          AND e.entity_type IN ('po', 'wdr', 'invoice', 'permit')
+      `) as unknown as Array<{
+        entity_type: string; value_norm: string; file_index_id: string; rel_path: string;
+      }>;
+
+      const labels = new Map<string, string>();
+      for (const p of await d.execute(sql`
+        SELECT project_key, label FROM workspace_projects WHERE org_id = ${orgId}
+      `) as unknown as Array<{ project_key: string; label: string }>) {
+        labels.set(p.project_key, p.label);
+      }
+
+      // (type, value, project) → distinct file ids. Declared project comes
+      // from the file's PATH (the filing humans already did), never inference.
+      // Structured (JSON) key — value_norm itself contains spaces.
+      const evidence = new Map<string, EvidenceEntry>();
+      for (const row of rows) {
+        const declared = deriveDeclaredProject(row.rel_path);
+        if (!declared) continue;
+        const key = JSON.stringify([row.entity_type, row.value_norm, declared.key]);
+        let entry = evidence.get(key);
+        if (!entry) {
+          entry = {
+            entityType: row.entity_type,
+            valueNorm: row.value_norm,
+            projectKey: declared.key,
+            files: new Set(),
+          };
+          evidence.set(key, entry);
+        }
+        entry.files.add(row.file_index_id);
+      }
+
+      await d.execute(sql`DELETE FROM workspace_project_crosswalk WHERE org_id = ${orgId}`);
+      let mined = 0;
+      for (const { entityType, valueNorm, projectKey, files } of evidence.values()) {
+        await d.execute(sql`
+          INSERT INTO workspace_project_crosswalk
+            (org_id, entity_type, value_norm, project_key, project_label,
+             evidence_count, sample_file_ids, mined_at)
+          VALUES
+            (${orgId}, ${entityType}, ${valueNorm}, ${projectKey},
+             ${labels.get(projectKey) ?? null}, ${files.size},
+             ${JSON.stringify([...files].slice(0, SAMPLE_LIMIT))}::jsonb, now())
+          ON CONFLICT (org_id, entity_type, value_norm, project_key) DO UPDATE SET
+            project_label = EXCLUDED.project_label,
+            evidence_count = EXCLUDED.evidence_count,
+            sample_file_ids = EXCLUDED.sample_file_ids,
+            mined_at = now(),
+            updated_at = now()
+        `);
+        mined += 1;
+      }
+      return { mined };
+    },
+
+    /** Evidence rows for one entity value, strongest first. */
+    async lookup(orgId: string, entityType: string, valueNorm: string): Promise<CrosswalkRow[]> {
+      const rows = await d.execute(sql`
+        SELECT entity_type, value_norm, project_key, project_label, evidence_count
+        FROM workspace_project_crosswalk
+        WHERE org_id = ${orgId} AND entity_type = ${entityType} AND value_norm = ${valueNorm}
+        ORDER BY evidence_count DESC, project_key ASC
+      `) as unknown as Array<{
+        entity_type: string; value_norm: string; project_key: string;
+        project_label: string | null; evidence_count: number;
+      }>;
+      return rows.map((r) => ({
+        entityType: r.entity_type,
+        valueNorm: r.value_norm,
+        projectKey: r.project_key,
+        projectLabel: r.project_label,
+        evidenceCount: Number(r.evidence_count),
+      }));
+    },
+  };
+}
+
+export type CrosswalkService = ReturnType<typeof createCrosswalkService>;

--- a/ee/workspace/src/services/deviceSummaryService.test.ts
+++ b/ee/workspace/src/services/deviceSummaryService.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createDeviceSummaryService } from './deviceSummaryService';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+
+const dialect = new PgDialect();
+
+/** Render a recorded Drizzle where-clause to real SQL text plus bound params. */
+function rendered(where: unknown): { sql: string; params: unknown[] } {
+  const query = dialect.sqlToQuery(where as never);
+  return { sql: query.sql, params: query.params };
+}
+
+/**
+ * Every `"<column>" = $N` in the rendered SQL, resolved to the value actually
+ * bound at position N — i.e. what this column is compared against.
+ *
+ * Asserting `params).toContain(ORG_ID)` only binds the PRESENCE of a value, not
+ * which column carries it: transposing the arguments of the device lookup to
+ * `and(eq(devices.orgId, deviceId), eq(devices.id, orgId))` leaves both values
+ * present and such a test green. Pairing column to value is what catches it.
+ */
+function boundTo(query: { sql: string; params: unknown[] }, column: string): unknown[] {
+  // The leading quote anchors the column name, so "org_id" cannot match a probe
+  // for "id", nor "crawl_device_id" a probe for "device_id".
+  const occurrences = query.sql.matchAll(new RegExp(`"${column}"\\s*=\\s*\\$(\\d+)`, 'g'));
+  return [...occurrences].map((match) => query.params[Number(match[1]) - 1]);
+}
+
+/**
+ * Fake handle that records the projection and where-clause of every query and
+ * replays canned rows in call order. It is deliberately NOT permissive: it
+ * records exactly what the service asked the database for, so a test can fail
+ * when a tenancy predicate or a projection narrowing is removed.
+ */
+function makeDb(resultsByCall: unknown[][]) {
+  const selects: unknown[] = [];
+  const wheres: unknown[] = [];
+  let call = 0;
+  const db = {
+    select: vi.fn((projection?: unknown) => {
+      const index = call;
+      call += 1;
+      selects.push(projection);
+      return {
+        from: vi.fn(() => ({
+          where: vi.fn((clause: unknown) => {
+            wheres.push(clause);
+            const rows = resultsByCall[index] ?? [];
+            const result = Promise.resolve(rows) as Promise<unknown[]> & {
+              limit: (n: number) => Promise<unknown[]>;
+            };
+            result.limit = async () => rows;
+            return result;
+          }),
+        })),
+      };
+    }),
+  };
+  return { db: db as unknown as WorkspaceDatabase, selects, wheres };
+}
+
+const deviceFound = [{ id: DEVICE_ID }];
+
+function harness(overrides: {
+  device?: unknown[];
+  files?: unknown[];
+  runs?: unknown[];
+} = {}) {
+  const h = makeDb([
+    overrides.device ?? deviceFound,
+    overrides.files ?? [{ indexedFiles: 7, visibleSources: 2 }],
+    overrides.runs ?? [{
+      lastSuccessfulCrawlAt: new Date('2026-07-12T10:00:00.000Z'),
+      lastActivityAt: new Date('2026-07-12T11:00:00.000Z'),
+    }],
+  ]);
+  return { ...h, service: createDeviceSummaryService(h.db) };
+}
+
+describe('deviceSummaryService', () => {
+  it('aggregates indexed files, live sources and crawl timestamps for one device', async () => {
+    const { service } = harness();
+    await expect(service.summarize(ORG_ID, DEVICE_ID)).resolves.toEqual({
+      deviceId: DEVICE_ID,
+      indexedFiles: 7,
+      visibleSources: 2,
+      lastSuccessfulCrawlAt: new Date('2026-07-12T10:00:00.000Z'),
+      lastActivityAt: new Date('2026-07-12T11:00:00.000Z'),
+    });
+  });
+
+  it('returns zeros and null timestamps when the device has no workspace rows', async () => {
+    const { service } = harness({
+      files: [{ indexedFiles: 0, visibleSources: 0 }],
+      runs: [{ lastSuccessfulCrawlAt: null, lastActivityAt: null }],
+    });
+    await expect(service.summarize(ORG_ID, DEVICE_ID)).resolves.toEqual({
+      deviceId: DEVICE_ID,
+      indexedFiles: 0,
+      visibleSources: 0,
+      lastSuccessfulCrawlAt: null,
+      lastActivityAt: null,
+    });
+  });
+
+  it('tolerates an empty aggregate row rather than reporting NaN or undefined', async () => {
+    const { service } = harness({ files: [], runs: [] });
+    await expect(service.summarize(ORG_ID, DEVICE_ID)).resolves.toEqual({
+      deviceId: DEVICE_ID,
+      indexedFiles: 0,
+      visibleSources: 0,
+      lastSuccessfulCrawlAt: null,
+      lastActivityAt: null,
+    });
+  });
+
+  it('returns null for a device that is not in the requested org, without aggregating', async () => {
+    const { service, db } = harness({ device: [] });
+    await expect(service.summarize(OTHER_ORG_ID, DEVICE_ID)).resolves.toBeNull();
+    // The aggregate queries must never run for a device the caller cannot see.
+    expect((db.select as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
+  });
+
+  // Tenancy: RLS is the backstop, not the only control. Every query must carry
+  // an explicit org + device predicate, and each value must be bound to the
+  // column it belongs to. Deleting either eq(), or transposing its arguments,
+  // fails these.
+  it('scopes the device existence lookup by both org and device', async () => {
+    const { service, wheres } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const query = rendered(wheres[0]);
+    expect(boundTo(query, 'org_id')).toEqual([ORG_ID]);
+    expect(boundTo(query, 'id')).toEqual([DEVICE_ID]);
+  });
+
+  it('scopes the file-index aggregate by org and device and excludes tombstones', async () => {
+    const { service, wheres } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const query = rendered(wheres[1]);
+    // Twice: the aggregate's own org predicate, plus the owned-sources subquery.
+    expect(boundTo(query, 'org_id')).toEqual([ORG_ID, ORG_ID]);
+    expect(boundTo(query, 'device_id')).toEqual([DEVICE_ID]);
+    // Tombstones (soft-deleted rows) must not be counted as indexed files.
+    expect(query.sql).toMatch(/"deleted_at" is null/);
+  });
+
+  it('scopes the crawl-run aggregate by org and device', async () => {
+    const { service, wheres } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const query = rendered(wheres[2]);
+    expect(boundTo(query, 'org_id')).toEqual([ORG_ID, ORG_ID]);
+    expect(boundTo(query, 'device_id')).toEqual([DEVICE_ID]);
+  });
+
+  // Scope (see the header comment on the service): these aggregates report what
+  // a device is RESPONSIBLE for indexing, which is the union of its own
+  // device-scoped rows and the source-scoped (SMB) rows of the sources it
+  // crawls. A device whose only job is crawling an SMB share must not read as
+  // idle.
+  it.each([
+    ['file-index', 1],
+    ['crawl-run', 2],
+  ])('unions device-scoped rows with rows of sources the device crawls (%s)', async (_label, index) => {
+    const { service, wheres } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const query = rendered(wheres[index]);
+    expect(query.sql).toContain('"device_id" = $');
+    expect(query.sql).toMatch(/=\s+\$\d+ or .*"source_id" in \(select/);
+    expect(query.sql).toContain('from "workspace_sources"');
+  });
+
+  // THE cross-device control. The owned-sources subquery must be anchored on
+  // crawl_device_id = <device> (and org_id = <org>). Widening it to every
+  // source in the org would pull in SMB rows owned by OTHER devices — a
+  // cross-device leak that no other assertion here would notice.
+  it.each([
+    ['file-index', 1],
+    ['crawl-run', 2],
+  ])('anchors the owned-sources subquery on crawl_device_id and org_id (%s)', async (_label, index) => {
+    const { service, wheres } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const query = rendered(wheres[index]);
+    expect(query.sql).toContain('"workspace_sources"."crawl_device_id"');
+    expect(boundTo(query, 'crawl_device_id')).toEqual([DEVICE_ID]);
+    expect(query.sql).toContain('"workspace_sources"."org_id"');
+  });
+
+  // The owned-sources branch must additionally require device_id IS NULL, i.e.
+  // match only SOURCE-scoped rows. crawl_device_id is only meaningful for
+  // smb_share, but nothing forbids a local_profile source from carrying one
+  // (routes/sources.ts validateSmbConfig returns early for local_profile).
+  // Without this, such a source would attribute every OTHER device's
+  // device-scoped rows on it to this device.
+  it.each([
+    ['file-index', 1],
+    ['crawl-run', 2],
+  ])('restricts the owned-sources branch to source-scoped rows (%s)', async (_label, index) => {
+    const { service, wheres } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const query = rendered(wheres[index]);
+    expect(query.sql).toMatch(/"device_id" is null and "[a-z_]+"\."source_id" in \(select/);
+  });
+
+  // THE conjunction control. `boundTo` only proves the org value is bound to
+  // the org_id column somewhere in the SQL; it does not prove that predicate
+  // is AND-ed against the rest of the where-clause rather than OR-ed into it.
+  // Mutating `and(eq(orgId), responsibleFor(...))` to
+  // `and(or(eq(orgId), responsibleFor(...)))` keeps every `boundTo` assertion
+  // above green (the value is still bound to org_id) while silently turning
+  // the explicit org predicate into a no-op: any row `responsibleFor` matches
+  // is returned regardless of org. That is the defence-in-depth layer
+  // vanishing, leaving RLS as the only control — exactly the case this
+  // predicate exists to cover if RLS is ever misconfigured. Asserting the
+  // literal `"org_id" = $N and` substring (not just presence of `and`
+  // anywhere in the SQL) catches that the org predicate is conjoined at the
+  // top level, not buried inside an `or(...)`.
+  //
+  // wheres[0] — the `devices` existence lookup — is the most security-relevant
+  // of the three: it is the AUTHORIZATION GATE. Rewriting its
+  // `and(eq(devices.orgId), eq(devices.id))` to `or(...)` makes a foreign-org
+  // deviceId resolve, so summarize() returns 200 with zeroed aggregates instead
+  // of null -> 404, recreating exactly the existence oracle that
+  // routes/deviceSummary.ts exists to prevent. Every `boundTo` assertion above
+  // stays green under that mutation, because both values are still bound to
+  // their own columns; only the conjunction assertion catches it.
+  it.each([
+    ['device-lookup', 'devices', 0],
+    ['file-index', 'workspace_file_index', 1],
+    ['crawl-run', 'workspace_crawl_runs', 2],
+  ])('conjoins the org predicate with the rest of the where-clause (%s)', async (_label, table, index) => {
+    const { service, wheres } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const query = rendered(wheres[index]);
+    // Table-qualified: the ownedSources subquery also carries its own
+    // "workspace_sources"."org_id" = $N and ..., which is unaffected by the
+    // mutation this test targets. Anchoring on the outer table's own org_id
+    // is what distinguishes the top-level predicate from that subquery one.
+    expect(query.sql).toMatch(new RegExp(`"${table}"\\."org_id" = \\$\\d+ and`));
+  });
+
+  it('counts visible sources as DISTINCT live source ids on the device', async () => {
+    const { service, selects } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const projection = rendered((selects[1] as Record<string, unknown>).visibleSources);
+    expect(projection.sql.toLowerCase()).toContain('count(distinct');
+    expect(projection.sql).toContain('"source_id"');
+  });
+
+  it('restricts lastSuccessfulCrawlAt to completed runs only', async () => {
+    const { service, selects } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const runProjection = selects[2] as Record<string, unknown>;
+    const success = rendered(runProjection.lastSuccessfulCrawlAt);
+    expect(success.sql.toLowerCase()).toContain('filter (where');
+    expect(success.sql).toContain('"completed_at"');
+    expect(success.params).toContain('complete');
+    // lastActivityAt is deliberately unfiltered by status.
+    const activity = rendered(runProjection.lastActivityAt);
+    expect(activity.sql).toContain('"last_activity_at"');
+    expect(activity.sql.toLowerCase()).not.toContain('filter (where');
+  });
+
+  // Disclosure boundary: the service must never fetch file paths, names,
+  // credentials or crawl error reasons. A route cannot leak what it never
+  // receives, so the narrowing lives in the projection itself.
+  it('never projects paths, names, credentials or error detail', async () => {
+    const { service, selects } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    const forbidden = [
+      'rel_path', 'parent_path', 'name', 'credential_enc',
+      'error_reason', 'status_detail', 'root_path', 'cursor',
+    ];
+    for (const projection of selects.slice(1)) {
+      const keys = Object.keys(projection as Record<string, unknown>);
+      const text = keys
+        .map((key) => rendered((projection as Record<string, unknown>)[key]).sql)
+        .join(' ');
+      for (const column of forbidden) {
+        expect(text).not.toContain(`"${column}"`);
+      }
+    }
+  });
+
+  // RLS context: the org-scoped connection the host handed to register() is
+  // the connection that enforces RLS. The service must issue every query
+  // through that injected handle and never open one of its own.
+  it('issues every query through the injected org-scoped handle', async () => {
+    const { service, db } = harness();
+    await service.summarize(ORG_ID, DEVICE_ID);
+    expect((db.select as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(3);
+  });
+});

--- a/ee/workspace/src/services/deviceSummaryService.ts
+++ b/ee/workspace/src/services/deviceSummaryService.ts
@@ -1,0 +1,144 @@
+import type { WorkspaceDatabase } from '../hostTypes';
+import { and, eq, isNull, or, sql, type SQL } from 'drizzle-orm';
+import { devices } from '../schema/coreRefs';
+import { workspaceCrawlRuns, workspaceFileIndex, workspaceSources } from '../schema/workspace';
+
+/**
+ * Aggregate-only view of one device's Workspace footprint.
+ *
+ * SCOPE — content this device is RESPONSIBLE FOR INDEXING, which is not the
+ * same as content stored against it. Per services/runScope.ts, local_profile
+ * content is device-scoped (device_id = device) while SMB content is
+ * source-scoped and stored org-wide as device_id = NULL, even though exactly
+ * one device crawls it (workspace_sources.crawl_device_id). All five fields
+ * are therefore the UNION of:
+ *   - device-scoped rows: device_id = <device>, and
+ *   - source-scoped rows whose source_id is one this device crawls, i.e. is in
+ *     (select id from workspace_sources where org_id = <org>
+ *                                        and crawl_device_id = <device>).
+ * A device whose only role is crawling an SMB share reports real numbers here,
+ * not zeros. (An earlier revision counted device-scoped rows only, which made
+ * exactly that device look idle while it was crawling successfully.)
+ *
+ * Do NOT simplify the union by dropping the device predicate and counting all
+ * source-scoped rows in the org: that pulls in SMB rows owned by OTHER devices,
+ * a cross-device leak. The subquery is anchored on crawl_device_id AND org_id
+ * for that reason, and `responsibleFor` below is the single place it is expressed.
+ *
+ * `visibleSources` counts DISTINCT source ids with live rows in the file index.
+ * It has nothing to do with workspace_sources.visibilityGroupIds — no
+ * per-group visibility filtering happens here.
+ *
+ * Deliberately carries no indexed paths, file names, source names, credential
+ * state, crawl error reasons or statusDetail. This is a disclosure boundary:
+ * the queries below project only these aggregates, so a route cannot leak what
+ * it never receives.
+ */
+export interface DeviceSummary {
+  deviceId: string;
+  indexedFiles: number;
+  visibleSources: number;
+  lastSuccessfulCrawlAt: Date | null;
+  lastActivityAt: Date | null;
+}
+
+function toCount(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) return value;
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}
+
+/**
+ * "Rows this device is responsible for": its own device-scoped rows, plus the
+ * source-scoped rows of the sources it crawls.
+ *
+ * The owned-sources subquery carries BOTH crawl_device_id = <device> (so one
+ * device never counts another's SMB content) and org_id = <org> (defence in
+ * depth alongside RLS). Both predicates are load-bearing; neither is redundant.
+ */
+function responsibleFor(
+  table: typeof workspaceFileIndex | typeof workspaceCrawlRuns,
+  orgId: string,
+  deviceId: string,
+): SQL {
+  const ownedSources = and(
+    eq(workspaceSources.orgId, orgId),
+    eq(workspaceSources.crawlDeviceId, deviceId),
+  );
+  return or(
+    eq(table.deviceId, deviceId),
+    // isNull() keeps this branch to SOURCE-scoped rows. crawl_device_id is only
+    // meaningful for smb_share, but routes/sources.ts does not forbid a
+    // local_profile source from carrying one; without this guard such a source
+    // would attribute every OTHER device's device-scoped rows to this device.
+    and(
+      isNull(table.deviceId),
+      sql`${table.sourceId} in (select ${workspaceSources.id} from ${workspaceSources} where ${ownedSources})`,
+    ),
+  ) as SQL;
+}
+
+export function createDeviceSummaryService(d: WorkspaceDatabase) {
+  return {
+    /**
+     * Returns null when the device is unknown to the requested org — which is
+     * the same answer for "device does not exist" and "device belongs to
+     * another org", so the endpoint is not an existence oracle.
+     *
+     * Every query carries an explicit org + device predicate even though the
+     * handle is the host's org-scoped (RLS-enforcing) connection: RLS is the
+     * backstop here, not the only control.
+     */
+    async summarize(orgId: string, deviceId: string): Promise<DeviceSummary | null> {
+      const [device] = await d.select({ id: devices.id })
+        .from(devices)
+        .where(and(eq(devices.orgId, orgId), eq(devices.id, deviceId)))
+        .limit(1);
+      if (!device) return null;
+
+      const [counts] = await d.select({
+        indexedFiles: sql<number>`count(*)::int`,
+        // "Visible sources" = sources with at least one live (non-tombstoned)
+        // indexed row on this device. It is intentionally derived from the file
+        // index rather than from workspace_sources: a configured-but-never-
+        // crawled source has nothing visible on the device yet.
+        visibleSources: sql<number>`count(distinct ${workspaceFileIndex.sourceId})::int`,
+      })
+        .from(workspaceFileIndex)
+        .where(and(
+          eq(workspaceFileIndex.orgId, orgId),
+          responsibleFor(workspaceFileIndex, orgId, deviceId),
+          isNull(workspaceFileIndex.deletedAt),
+        ));
+
+      // Both timestamps come from workspace_crawl_runs. workspace_file_activity
+      // records per-user file opens and is not needed for this aggregate, so it
+      // stays out of the disclosure surface entirely.
+      const [timestamps] = await d.select({
+        lastSuccessfulCrawlAt: sql<Date | null>`max(${workspaceCrawlRuns.completedAt}) filter (where ${eq(workspaceCrawlRuns.status, 'complete')})`,
+        lastActivityAt: sql<Date | null>`max(${workspaceCrawlRuns.lastActivityAt})`,
+      })
+        .from(workspaceCrawlRuns)
+        .where(and(
+          eq(workspaceCrawlRuns.orgId, orgId),
+          responsibleFor(workspaceCrawlRuns, orgId, deviceId),
+        ));
+
+      return {
+        deviceId,
+        indexedFiles: toCount(counts?.indexedFiles),
+        visibleSources: toCount(counts?.visibleSources),
+        lastSuccessfulCrawlAt: toDate(timestamps?.lastSuccessfulCrawlAt),
+        lastActivityAt: toDate(timestamps?.lastActivityAt),
+      };
+    },
+  };
+}

--- a/ee/workspace/src/services/enrichmentService.test.ts
+++ b/ee/workspace/src/services/enrichmentService.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import {
+  buildEnrichmentPrompt, createEnrichmentService, extractJson, type AnthropicLike,
+} from './enrichmentService';
+
+const ORG = '11111111-1111-1111-1111-111111111111';
+
+function fakeClient(reply: string | (() => string)): AnthropicLike {
+  return {
+    messages: {
+      create: vi.fn(async () => ({
+        content: [{ type: 'text', text: typeof reply === 'function' ? reply() : reply }],
+      })),
+    },
+  };
+}
+
+const GOOD = JSON.stringify({
+  docType: 'easement deed',
+  projectKey: '2023-041',
+  projectLabel: 'Henderson Water Main Replacement',
+  docDate: '2023-10-12',
+  confidence: 'high',
+  people: [
+    { name: 'Kowalski Family Trust', kind: 'org' },
+    { name: 'City of Fairoaks', kind: 'org' },
+  ],
+});
+
+describe('extractJson', () => {
+  it('parses bare and fenced JSON objects', () => {
+    expect(extractJson('{"a":1}', 't')).toEqual({ a: 1 });
+    expect(extractJson('```json\n{"a":1}\n```', 't')).toEqual({ a: 1 });
+    expect(extractJson('noise before {"a":1} after', 't')).toEqual({ a: 1 });
+  });
+  it('throws with a labeled error when no object is present', () => {
+    expect(() => extractJson('nothing here', 'wsp')).toThrow(/wsp/);
+  });
+});
+
+describe('buildEnrichmentPrompt', () => {
+  it('carries the path, registry, and truncated text', () => {
+    const p = buildEnrichmentPrompt({
+      relPath: 'Projects/x/scan.md',
+      text: 'BODY '.repeat(10_000),
+      projects: [{ key: '2023-041', label: 'Henderson Water Main Replacement' }],
+    });
+    expect(p).toContain('File path: Projects/x/scan.md');
+    expect(p).toContain('2023-041 — Henderson Water Main Replacement');
+    expect(p.length).toBeLessThan(13_000);
+  });
+});
+
+describe('classifyOne', () => {
+  const db = {} as unknown as WorkspaceDatabase;
+
+  it('returns the validated result for well-formed output', async () => {
+    const svc = createEnrichmentService(db, { client: fakeClient(GOOD), model: 'claude-haiku-4-5' });
+    const r = await svc.classifyOne('Projects/x/scan.md', 'text', []);
+    expect(r).toMatchObject({ docType: 'easement deed', projectKey: '2023-041', confidence: 'high' });
+    expect(r?.people).toHaveLength(2);
+  });
+
+  it('fails soft (null) on malformed JSON', async () => {
+    const svc = createEnrichmentService(db, { client: fakeClient('not json at all') });
+    expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
+  });
+
+  it('fails soft (null) on schema violations', async () => {
+    const svc = createEnrichmentService(db, {
+      client: fakeClient(JSON.stringify({ docType: 'x', confidence: 'very sure', people: [] })),
+    });
+    expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
+  });
+
+  it('fails soft (null) when the client throws', async () => {
+    const client: AnthropicLike = {
+      messages: { create: vi.fn(async () => { throw new Error('rate limited'); }) },
+    };
+    const svc = createEnrichmentService(db, { client });
+    expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
+  });
+});

--- a/ee/workspace/src/services/enrichmentService.ts
+++ b/ee/workspace/src/services/enrichmentService.ts
@@ -1,0 +1,236 @@
+// LLM enrichment pass (dev-preview; per-org content flag).
+//
+// Per extracted file, a single cheap-model call infers: document type, the
+// project the CONTENT belongs to, a document date, and person/org entities.
+// The inferred project is stored NEXT TO the declared location (derived from
+// the path) so the finder can show disagreement — never silently refile.
+//
+// Division of labor (hard rule): the deterministic regex pass owns the
+// structured entity types (apn/po/wdr/invoice/permit/job/license); this pass
+// may only ADD person/org entities and never touches regex-origin rows.
+//
+// Pattern follows hive's extractor-model/classifier shape: injectable
+// Anthropic-like client, system prompt + JSON extraction + strict Zod,
+// fail-soft per file (an LLM hiccup marks the file unenriched, never throws
+// out of the batch).
+//
+// DLP invariant (W2): this pass never re-runs DLP. It reads
+// workspace_file_content.extracted_text for status='extracted' rows only, and
+// that text was ALREADY redacted at ingest (contentIngestService applies DLP
+// once, before persistence). DLP-blocked files never reach status='extracted',
+// so they are never enriched. Every enrichment prompt is therefore built from
+// stored, already-redacted text — no raw sensitive value can reach the LLM here.
+import type { WorkspaceDatabase } from '../hostTypes';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { z } from 'zod';
+import { deriveDeclaredProject } from '../content/projects';
+
+export interface AnthropicLike {
+  messages: {
+    create: (args: unknown) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+  };
+}
+
+export interface EnrichmentDeps {
+  client: AnthropicLike;
+  model?: string;
+}
+
+const DEFAULT_MODEL = 'claude-haiku-4-5';
+const MAX_TEXT_CHARS = 12_000;
+const MAX_PEOPLE = 12;
+
+const resultSchema = z.object({
+  docType: z.string().min(1).max(120).nullable(),
+  projectKey: z.string().max(40).nullable(),
+  projectLabel: z.string().max(200).nullable(),
+  docDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable(),
+  confidence: z.enum(['high', 'medium', 'low']),
+  people: z.array(z.object({
+    name: z.string().min(1).max(120),
+    kind: z.enum(['person', 'org']),
+  })).max(MAX_PEOPLE),
+});
+
+export type EnrichmentResult = z.infer<typeof resultSchema>;
+
+const SYSTEM = [
+  'You classify one document from a small civil-engineering/land-surveying firm.',
+  'Given the file path and body text, return ONLY a JSON object:',
+  '{ "docType": short noun phrase for what the document IS (e.g. "easement deed",',
+  '  "record of survey narrative", "meeting notes", "transmittal", "invoice email",',
+  '  "agency review letter") or null if unclear;',
+  '  "projectKey": the firm job number the CONTENT belongs to, chosen from the',
+  '  provided project registry (format NNNN-NNN) or null if none fits — judge by',
+  '  the body text, NOT by the folder the file sits in;',
+  '  "projectLabel": the registry label for that key (or a short name from the',
+  '  text if the registry lacks it), or null;',
+  '  "docDate": the document\'s own date as YYYY-MM-DD, or null;',
+  '  "confidence": "high" | "medium" | "low" for the project inference;',
+  '  "people": up to 12 distinct people/organizations that appear, as',
+  '  [{"name": "...", "kind": "person"|"org"}] }.',
+  'Never invent identifiers. If the text contradicts the folder location, trust the text.',
+].join('\n');
+
+/** Extract the first JSON object from (possibly fenced) model output. */
+export function extractJson(text: string, label: string): unknown {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : text;
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`${label}: no JSON object in model output: ${text.slice(0, 200)}`);
+  }
+  return JSON.parse(candidate.slice(start, end + 1));
+}
+
+export function buildEnrichmentPrompt(input: {
+  relPath: string;
+  text: string;
+  projects: Array<{ key: string; label: string }>;
+}): string {
+  const registry = input.projects.map((p) => `  ${p.key} — ${p.label}`).join('\n');
+  return [
+    `File path: ${input.relPath}`,
+    '',
+    'Project registry:',
+    registry.length > 0 ? registry : '  (empty)',
+    '',
+    'Document text:',
+    input.text.slice(0, MAX_TEXT_CHARS),
+  ].join('\n');
+}
+
+interface PendingEnrichmentRow {
+  id: string;
+  rel_path: string;
+  extracted_text: string;
+}
+
+export function createEnrichmentService(db: WorkspaceDatabase, deps: EnrichmentDeps) {
+  const d = db;
+  const model = deps.model ?? process.env.WORKSPACE_CONTENT_LLM_MODEL ?? DEFAULT_MODEL;
+
+  async function classifyOne(
+    relPath: string,
+    text: string,
+    projects: Array<{ key: string; label: string }>,
+  ): Promise<EnrichmentResult | null> {
+    try {
+      const res = await deps.client.messages.create({
+        model,
+        max_tokens: 1024,
+        system: SYSTEM,
+        messages: [{ role: 'user', content: buildEnrichmentPrompt({ relPath, text, projects }) }],
+      });
+      const raw = res.content.find((c) => c.type === 'text')?.text ?? '';
+      return resultSchema.parse(extractJson(raw, 'workspace-enrich'));
+    } catch {
+      return null; // fail-soft: an LLM/parse hiccup never breaks the batch
+    }
+  }
+
+  return {
+    classifyOne,
+
+    /**
+     * Enrich up to `batch` extracted-but-unenriched files. Returns
+     * {processed, remaining, errors} like the ingest runner. A file whose LLM
+     * call fails is recorded with model=null and stays re-enrichable.
+     */
+    async run(orgId: string, batch: number): Promise<{
+      processed: number;
+      remaining: number;
+      errors: Array<{ fileIndexId: string; relPath: string; error: string }>;
+    }> {
+      const projects = (await d.execute(sql`
+        SELECT project_key, label FROM workspace_projects
+        WHERE org_id = ${orgId} ORDER BY project_key
+      `) as unknown as Array<{ project_key: string; label: string }>)
+        .map((p) => ({ key: p.project_key, label: p.label }));
+      const projectByKey = new Map(projects.map((p) => [p.key, p.label]));
+
+      const pendingSql = sql`
+        FROM workspace_file_content c
+        JOIN workspace_file_index fi ON fi.id = c.file_index_id
+        LEFT JOIN workspace_file_enrichment en
+          ON en.file_index_id = c.file_index_id AND en.enriched_at IS NOT NULL
+        WHERE c.org_id = ${orgId}
+          AND c.status = 'extracted'
+          AND fi.deleted_at IS NULL
+          AND (en.id IS NULL OR en.model IS NULL)
+      `;
+      const pending = await d.execute(sql`
+        SELECT fi.id, fi.rel_path, c.extracted_text
+        ${pendingSql}
+        ORDER BY fi.rel_path
+        LIMIT ${batch}
+      `) as unknown as PendingEnrichmentRow[];
+
+      const errors: Array<{ fileIndexId: string; relPath: string; error: string }> = [];
+      let processed = 0;
+
+      for (const file of pending) {
+        const declared = deriveDeclaredProject(file.rel_path);
+        const declaredLabel = declared
+          ? (declared.label ?? projectByKey.get(declared.key) ?? null)
+          : null;
+        const result = await classifyOne(file.rel_path, file.extracted_text, projects);
+        const inferredKey = result?.projectKey ?? null;
+        const inferredLabel = result?.projectLabel
+          ?? (inferredKey ? projectByKey.get(inferredKey) ?? null : null);
+
+        try {
+          await d.execute(sql`
+            INSERT INTO workspace_file_enrichment
+              (org_id, file_index_id, inferred_project_key, inferred_project_label,
+               inferred_doc_type, doc_date, declared_project_key, declared_project_label,
+               confidence, model, enriched_at)
+            VALUES
+              (${orgId}, ${file.id}, ${inferredKey}, ${inferredLabel},
+               ${result?.docType ?? null}, ${result?.docDate ?? null},
+               ${declared?.key ?? null}, ${declaredLabel},
+               ${result?.confidence ?? null}, ${result ? model : null}, now())
+            ON CONFLICT (file_index_id) DO UPDATE SET
+              inferred_project_key = EXCLUDED.inferred_project_key,
+              inferred_project_label = EXCLUDED.inferred_project_label,
+              inferred_doc_type = EXCLUDED.inferred_doc_type,
+              doc_date = EXCLUDED.doc_date,
+              declared_project_key = EXCLUDED.declared_project_key,
+              declared_project_label = EXCLUDED.declared_project_label,
+              confidence = EXCLUDED.confidence,
+              model = EXCLUDED.model,
+              enriched_at = now(),
+              updated_at = now()
+          `);
+          for (const person of result?.people ?? []) {
+            const norm = person.name.trim().replace(/\s+/g, ' ');
+            if (!norm) continue;
+            await d.execute(sql`
+              INSERT INTO workspace_content_entities
+                (org_id, file_index_id, entity_type, value_norm, value_raw, origin)
+              VALUES (${orgId}, ${file.id}, ${person.kind}, ${norm}, ${person.name}, 'llm')
+              ON CONFLICT (org_id, file_index_id, entity_type, value_norm) DO NOTHING
+            `);
+          }
+          if (!result) {
+            errors.push({ fileIndexId: file.id, relPath: file.rel_path, error: 'llm classification failed' });
+          }
+          processed += 1;
+        } catch (error) {
+          errors.push({
+            fileIndexId: file.id,
+            relPath: file.rel_path,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+
+      const remainingRes = await d.execute(sql`
+        SELECT count(*)::int AS n ${pendingSql}
+      `) as unknown as Array<{ n: number }>;
+      return { processed, remaining: Number(remainingRes[0]?.n ?? 0), errors };
+    },
+  };
+}

--- a/ee/workspace/src/services/enrichmentService.ts
+++ b/ee/workspace/src/services/enrichmentService.ts
@@ -76,7 +76,7 @@ const SYSTEM = [
 /** Extract the first JSON object from (possibly fenced) model output. */
 export function extractJson(text: string, label: string): unknown {
   const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
-  const candidate = fenced ? fenced[1] : text;
+  const candidate = fenced?.[1] ?? text;
   const start = candidate.indexOf('{');
   const end = candidate.lastIndexOf('}');
   if (start === -1 || end === -1 || end < start) {

--- a/ee/workspace/src/services/fileQueryService.test.ts
+++ b/ee/workspace/src/services/fileQueryService.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { workspaceSources } from '../schema/workspace';
+import { SHARED_DEVICE_KEY } from './runScope';
+import { createFileQueryService } from './fileQueryService';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const OTHER_DEVICE_ID = '44444444-4444-4444-4444-444444444444';
+const SMB_SOURCE_ID = '22222222-2222-2222-2222-222222222222';
+const LOCAL_SOURCE_ID = '55555555-5555-5555-5555-555555555555';
+const HIDDEN_SOURCE_ID = '66666666-6666-6666-6666-666666666666';
+const PAUSED_SOURCE_ID = '77777777-7777-7777-7777-777777777777';
+const FILE_ID = '88888888-8888-8888-8888-888888888888';
+const UNKNOWN_ID = '99999999-9999-9999-9999-999999999999';
+
+/** Bound parameter values reachable from a drizzle condition (Params only). */
+function boundValues(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value.flatMap(boundValues);
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = 'encoder' in candidate && Object.prototype.hasOwnProperty.call(candidate, 'value')
+    ? [candidate.value]
+    : [];
+  return [...own, ...(candidate.queryChunks ?? []).flatMap(boundValues)];
+}
+
+/** Approximate SQL text of a drizzle expression (columns as bare names, params as ?). */
+function sqlText(value: unknown): string {
+  if (value == null) return '';
+  if (Array.isArray(value)) return value.map(sqlText).join('');
+  if (typeof value !== 'object') return String(value);
+  const c = value as Record<string, unknown>;
+  if ('encoder' in c) return '?';
+  if (Array.isArray(c.queryChunks)) return (c.queryChunks as unknown[]).map(sqlText).join('');
+  if (Array.isArray(c.value) && (c.value as unknown[]).every((x) => typeof x === 'string')) {
+    return (c.value as string[]).join('');
+  }
+  if (typeof c.name === 'string') return c.name;
+  return '';
+}
+
+function sourceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SMB_SOURCE_ID,
+    orgId: ORG_ID,
+    kind: 'smb_share',
+    displayName: 'Alder Creek',
+    rootPath: '\\\\srv\\share',
+    status: 'active',
+    visibilityGroupIds: [] as string[],
+    ...overrides,
+  };
+}
+
+function fileRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: FILE_ID,
+    orgId: ORG_ID,
+    sourceId: SMB_SOURCE_ID,
+    deviceId: null,
+    deviceKey: SHARED_DEVICE_KEY,
+    relPath: 'a/b.pdf',
+    parentPath: 'a',
+    name: 'b.pdf',
+    isDir: false,
+    ext: 'pdf',
+    mime: null,
+    size: 10,
+    mtime: new Date('2026-07-01T00:00:00Z'),
+    ctime: null,
+    attrs: {},
+    lastSeenAt: new Date(),
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+const smbSource = sourceRow();
+const localSource = sourceRow({
+  id: LOCAL_SOURCE_ID, kind: 'local_profile', displayName: 'Profiles', rootPath: '/Users',
+});
+const hiddenSource = sourceRow({
+  id: HIDDEN_SOURCE_ID, displayName: 'Hidden', visibilityGroupIds: ['g1'],
+});
+const pausedSource = sourceRow({ id: PAUSED_SOURCE_ID, displayName: 'Paused', status: 'paused' });
+
+/** Emulates the sources query: org bound, active status bound, '[]'::jsonb inline. */
+function sourceMatches(row: ReturnType<typeof sourceRow>, condition: unknown): boolean {
+  const values = boundValues(condition);
+  const text = sqlText(condition);
+  if (!values.includes(row.orgId)) return false;
+  if (values.includes('active') && row.status !== 'active') return false;
+  if (text.includes("'[]'::jsonb") && (row.visibilityGroupIds as string[]).length > 0) return false;
+  return true;
+}
+
+/**
+ * Emulates file-index predicates from what the service binds: a row is only
+ * reachable when its sourceId and deviceKey were both bound (partition rule),
+ * tombstones require an explicit deleted_at IS NULL predicate, and a bound
+ * `false` (is_dir = false) excludes directories.
+ */
+function fileMatches(row: ReturnType<typeof fileRow>, condition: unknown): boolean {
+  const values = boundValues(condition);
+  const text = sqlText(condition);
+  if (!values.includes(row.sourceId)) return false;
+  if (!values.includes(row.deviceKey)) return false;
+  if (text.includes('deleted_at') && text.includes('is null') && row.deletedAt) return false;
+  if (values.includes(false) && row.isDir) return false;
+  return true;
+}
+
+function makeDb(
+  sources: Array<ReturnType<typeof sourceRow>> = [],
+  files: Array<ReturnType<typeof fileRow>> = [],
+) {
+  const captured = {
+    limits: [] as number[],
+    orderBys: [] as unknown[][],
+    fileWheres: [] as unknown[],
+    fileQueries: 0,
+  };
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => {
+        if (table === workspaceSources) {
+          return {
+            where: vi.fn((condition: unknown) => ({
+              orderBy: vi.fn(async () => sources.filter((row) => sourceMatches(row, condition))),
+            })),
+          };
+        }
+        captured.fileQueries += 1;
+        return {
+          where: vi.fn((condition: unknown) => {
+            captured.fileWheres.push(condition);
+            const matched = files.filter((row) => fileMatches(row, condition));
+            return {
+              orderBy: vi.fn((...exprs: unknown[]) => {
+                captured.orderBys.push(exprs);
+                return Object.assign(Promise.resolve(matched), {
+                  limit: vi.fn(async (n: number) => {
+                    captured.limits.push(n);
+                    return matched.slice(0, n);
+                  }),
+                });
+              }),
+              // Direct .limit (no orderBy) is the single-row getFile path: the
+              // id must have been bound for a row to be reachable.
+              limit: vi.fn(async (n: number) =>
+                matched.filter((row) => boundValues(condition).includes(row.id)).slice(0, n)),
+            };
+          }),
+        };
+      }),
+    })),
+  };
+  return { db: db as unknown as WorkspaceDatabase, captured };
+}
+
+describe('fileQueryService', () => {
+  describe('visibleSources', () => {
+    it('fails closed: only active sources with an empty visibility group list', async () => {
+      const { db } = makeDb([smbSource, localSource, hiddenSource, pausedSource]);
+      const result = await createFileQueryService(db).visibleSources(ORG_ID);
+      expect(result.map((s) => s.id)).toEqual([SMB_SOURCE_ID, LOCAL_SOURCE_ID]);
+    });
+  });
+
+  describe('search', () => {
+    it('returns visible smb rows with a UNC openPath; hidden-source and tombstoned rows never appear', async () => {
+      const { db } = makeDb(
+        [smbSource, hiddenSource],
+        [
+          fileRow({ score: 0.9 }),
+          fileRow({ id: UNKNOWN_ID, sourceId: HIDDEN_SOURCE_ID, name: 'b-hidden.pdf' }),
+          fileRow({ id: PAUSED_SOURCE_ID, name: 'b-gone.pdf', deletedAt: new Date() }),
+        ],
+      );
+      const results = await createFileQueryService(db).search(ORG_ID, DEVICE_ID, { q: 'b' });
+      expect(results).toEqual([{
+        id: FILE_ID,
+        sourceId: SMB_SOURCE_ID,
+        deviceKey: SHARED_DEVICE_KEY,
+        relPath: 'a/b.pdf',
+        parentPath: 'a',
+        name: 'b.pdf',
+        isDir: false,
+        ext: 'pdf',
+        size: 10,
+        mtime: '2026-07-01T00:00:00.000Z',
+        openPath: '\\\\srv\\share\\a\\b.pdf',
+        score: 0.9,
+      }]);
+    });
+
+    it('never returns another device\'s local-profile rows; local openPath is null', async () => {
+      const mine = fileRow({ sourceId: LOCAL_SOURCE_ID, deviceId: DEVICE_ID, deviceKey: DEVICE_ID });
+      const theirs = fileRow({
+        id: UNKNOWN_ID, sourceId: LOCAL_SOURCE_ID, deviceId: OTHER_DEVICE_ID, deviceKey: OTHER_DEVICE_ID,
+      });
+      const { db } = makeDb([localSource], [mine, theirs]);
+      const results = await createFileQueryService(db).search(ORG_ID, DEVICE_ID, { q: 'b' });
+      expect(results.map((r) => r.id)).toEqual([FILE_ID]);
+      expect(results[0]?.openPath).toBeNull();
+    });
+
+    it('clamps the limit to 1..100 and defaults to 25', async () => {
+      const { db, captured } = makeDb([smbSource], [fileRow()]);
+      const service = createFileQueryService(db);
+      await service.search(ORG_ID, DEVICE_ID, { q: 'b', limit: 0 });
+      await service.search(ORG_ID, DEVICE_ID, { q: 'b', limit: 500 });
+      await service.search(ORG_ID, DEVICE_ID, { q: 'b' });
+      expect(captured.limits).toEqual([1, 100, 25]);
+    });
+
+    it('returns [] without querying the file index when the sourceId filter is hidden or unknown', async () => {
+      const { db, captured } = makeDb([smbSource, hiddenSource], [fileRow()]);
+      const service = createFileQueryService(db);
+      await expect(service.search(ORG_ID, DEVICE_ID, { q: 'b', sourceId: HIDDEN_SOURCE_ID }))
+        .resolves.toEqual([]);
+      await expect(service.search(ORG_ID, DEVICE_ID, { q: 'b', sourceId: UNKNOWN_ID }))
+        .resolves.toEqual([]);
+      expect(captured.fileQueries).toBe(0);
+    });
+
+    it('orders by trigram score, then mtime desc nulls last', async () => {
+      const { db, captured } = makeDb([smbSource], [fileRow()]);
+      await createFileQueryService(db).search(ORG_ID, DEVICE_ID, { q: 'b' });
+      const order = (captured.orderBys[0] ?? []).map(sqlText);
+      expect(order[0]).toContain('greatest(similarity(');
+      expect(order[0]).toContain('desc');
+      expect(order[1]).toContain('mtime');
+      expect(order[1]).toContain('nulls last');
+    });
+
+    it('includes project and docType predicates only when set', async () => {
+      const { db, captured } = makeDb([smbSource], [fileRow()]);
+      const service = createFileQueryService(db);
+      await service.search(ORG_ID, DEVICE_ID, { q: 'b' });
+      await service.search(ORG_ID, DEVICE_ID, {
+        q: 'b', project: 'Henderson Water Main Replacement', docType: 'easement',
+      });
+      const withoutFilters = sqlText(captured.fileWheres[0]);
+      const withFilters = sqlText(captured.fileWheres[1]);
+      expect(withoutFilters).not.toContain('inferred_project_label');
+      expect(withoutFilters).not.toContain('inferred_doc_type');
+      expect(withFilters).toContain('inferred_project_label =');
+      expect(withFilters).toContain('inferred_doc_type =');
+      // The two guarded EXISTS fragments are raw sql-template interpolations
+      // (not drizzle-encoded Params), so their literal values surface in the
+      // rendered text itself rather than through boundValues() — which only
+      // walks encoder-based Param chunks (eq/inArray/etc elsewhere in the
+      // file). sqlText already proves both predicates render with '='.
+      expect(withFilters).toContain('Henderson Water Main Replacement');
+      expect(withFilters).toContain('easement');
+      // Defence-in-depth: each EXISTS is org-correlated to the file-index row.
+      expect(withFilters).toContain('wfe.org_id = workspace_file_index.org_id');
+    });
+  });
+
+  describe('browse', () => {
+    it('lists one visible source dirs-first; dirs and local-profile rows carry no openPath', async () => {
+      const dir = fileRow({
+        id: UNKNOWN_ID, relPath: 'a', parentPath: '', name: 'a', isDir: true, ext: null, size: null,
+      });
+      const file = fileRow({ relPath: 'b.pdf', parentPath: '', name: 'b.pdf' });
+      const { db, captured } = makeDb([smbSource], [dir, file]);
+      const entries = await createFileQueryService(db).browse(ORG_ID, DEVICE_ID, SMB_SOURCE_ID, '');
+      expect(entries).toHaveLength(2);
+      expect(entries.find((e) => e.isDir)?.openPath).toBeNull();
+      expect(entries.find((e) => !e.isDir)?.openPath).toBe('\\\\srv\\share\\b.pdf');
+      expect(boundValues(captured.fileWheres[0]).includes('')).toBe(true);
+      const order = (captured.orderBys[0] ?? []).map(sqlText);
+      expect(order[0]).toContain('is_dir');
+      expect(order[0]).toContain('desc');
+      expect(order[1]).toContain('name');
+      expect(order[1]).toContain('asc');
+    });
+
+    it('scopes local-profile browsing to the calling device', async () => {
+      const mine = fileRow({
+        sourceId: LOCAL_SOURCE_ID, deviceId: DEVICE_ID, deviceKey: DEVICE_ID, parentPath: '',
+      });
+      const theirs = fileRow({
+        id: UNKNOWN_ID, sourceId: LOCAL_SOURCE_ID, deviceId: OTHER_DEVICE_ID,
+        deviceKey: OTHER_DEVICE_ID, parentPath: '',
+      });
+      const { db } = makeDb([localSource], [mine, theirs]);
+      const entries = await createFileQueryService(db).browse(ORG_ID, DEVICE_ID, LOCAL_SOURCE_ID, '');
+      expect(entries.map((e) => e.id)).toEqual([FILE_ID]);
+    });
+
+    it('returns [] for a hidden or unknown source without touching the file index', async () => {
+      const { db, captured } = makeDb([smbSource, hiddenSource], [fileRow()]);
+      const service = createFileQueryService(db);
+      await expect(service.browse(ORG_ID, DEVICE_ID, HIDDEN_SOURCE_ID, '')).resolves.toEqual([]);
+      await expect(service.browse(ORG_ID, DEVICE_ID, UNKNOWN_ID, '')).resolves.toEqual([]);
+      expect(captured.fileQueries).toBe(0);
+    });
+
+    it('includes project and docType predicates only when set', async () => {
+      const { db, captured } = makeDb([smbSource], [fileRow()]);
+      const service = createFileQueryService(db);
+      await service.browse(ORG_ID, DEVICE_ID, SMB_SOURCE_ID, '');
+      await service.browse(ORG_ID, DEVICE_ID, SMB_SOURCE_ID, '', {
+        project: 'Henderson Water Main Replacement', docType: 'easement',
+      });
+      const withoutFilters = sqlText(captured.fileWheres[0]);
+      const withFilters = sqlText(captured.fileWheres[1]);
+      expect(withoutFilters).not.toContain('inferred_project_label');
+      expect(withoutFilters).not.toContain('inferred_doc_type');
+      expect(withFilters).toContain('inferred_project_label =');
+      expect(withFilters).toContain('inferred_doc_type =');
+      expect(withFilters).toContain('Henderson Water Main Replacement');
+      expect(withFilters).toContain('easement');
+      // Defence-in-depth: each EXISTS is org-correlated to the file-index row.
+      expect(withFilters).toContain('wfe.org_id = workspace_file_index.org_id');
+      // Finding 4a: in Browse the enrichment predicates must not hide
+      // directories — each is OR'd with is_dir = true so subfolders stay
+      // navigable. The bypass binds a boolean `true` that no other browse
+      // predicate binds; the unfiltered browse never binds it.
+      expect(boundValues(captured.fileWheres[1])).toContain(true);
+      expect(boundValues(captured.fileWheres[0])).not.toContain(true);
+    });
+  });
+
+  describe('getFile', () => {
+    it('maps a visible file; unknown, tombstoned, and hidden-source ids resolve to null', async () => {
+      const tombstonedId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+      const hiddenFileId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+      const { db } = makeDb(
+        [smbSource, hiddenSource],
+        [
+          fileRow(),
+          fileRow({ id: tombstonedId, deletedAt: new Date() }),
+          fileRow({ id: hiddenFileId, sourceId: HIDDEN_SOURCE_ID }),
+        ],
+      );
+      const service = createFileQueryService(db);
+      await expect(service.getFile(ORG_ID, DEVICE_ID, FILE_ID)).resolves.toMatchObject({
+        id: FILE_ID,
+        openPath: '\\\\srv\\share\\a\\b.pdf',
+        mtime: '2026-07-01T00:00:00.000Z',
+      });
+      await expect(service.getFile(ORG_ID, DEVICE_ID, tombstonedId)).resolves.toBeNull();
+      await expect(service.getFile(ORG_ID, DEVICE_ID, hiddenFileId)).resolves.toBeNull();
+      await expect(service.getFile(ORG_ID, DEVICE_ID, UNKNOWN_ID)).resolves.toBeNull();
+    });
+  });
+});

--- a/ee/workspace/src/services/fileQueryService.ts
+++ b/ee/workspace/src/services/fileQueryService.ts
@@ -1,0 +1,284 @@
+import type { WorkspaceDatabase } from '../hostTypes';
+import {
+  and, asc, desc, eq, getTableColumns, gte, ilike, inArray, isNull, lte, or, sql, type SQL,
+} from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { workspaceFileIndex, workspaceSources } from '../schema/workspace';
+import { SHARED_DEVICE_KEY } from './runScope';
+import { visibleSourceConditions } from './visibility';
+
+export interface FinderFile {
+  id: string;
+  sourceId: string;
+  deviceKey: string;
+  relPath: string;
+  parentPath: string;
+  name: string;
+  isDir: boolean;
+  ext: string | null;
+  size: number | null;
+  mtime: string | null;
+  openPath: string | null;
+  score?: number;
+}
+
+export interface SearchFilters {
+  q: string;
+  sourceId?: string;
+  ext?: string;
+  modifiedAfter?: string;
+  modifiedBefore?: string;
+  /** Equality match against workspace_file_enrichment.inferred_project_label. */
+  project?: string;
+  /** Equality match against workspace_file_enrichment.inferred_doc_type. */
+  docType?: string;
+  limit?: number; // default 25, max 100
+}
+
+export interface BrowseFilters {
+  /** Equality match against workspace_file_enrichment.inferred_project_label. */
+  project?: string;
+  /** Equality match against workspace_file_enrichment.inferred_doc_type. */
+  docType?: string;
+}
+
+export interface VisibleSource {
+  id: string;
+  displayName: string;
+  kind: 'smb_share' | 'local_profile';
+  rootPath: string;
+}
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+function clampLimit(limit?: number): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(limit)));
+}
+
+type FileRow = typeof workspaceFileIndex.$inferSelect;
+
+/**
+ * openPath is what the Helper hands to the OS. Only SMB files carry one (the
+ * source root is UNC-canonical, so join with backslashes); local-profile rows
+ * resolve same-device paths client-side from relPath, and directories are
+ * never opened in place.
+ */
+function openPathFor(source: VisibleSource, relPath: string, isDir: boolean): string | null {
+  if (isDir || source.kind !== 'smb_share') return null;
+  return `${source.rootPath}\\${relPath.replaceAll('/', '\\')}`;
+}
+
+/**
+ * project/docType narrowing shared by search() and browse(): enrichment
+ * (inferred_project_label / inferred_doc_type) lives on a separate table —
+ * workspace_file_enrichment — with no join in either query, so each predicate
+ * is an EXISTS correlated on file_index_id rather than a plain eq() like the
+ * ext filter. Each EXISTS is also org-correlated (wfe.org_id = the file's
+ * org_id) as defence-in-depth atop RLS. Returns one SQL condition per set
+ * filter (empty when neither is set).
+ *
+ * `dirsBypass` (Browse only): directories carry no enrichment row, so a raw
+ * EXISTS would drop every subfolder from a filtered Browse and strand
+ * navigation. When set, each predicate is OR'd with is_dir = true so directory
+ * rows always pass while files still must match. Search leaves this off — it
+ * already excludes directories (is_dir = false), so no bypass is needed.
+ */
+function enrichmentConditions(
+  filters: { project?: string; docType?: string },
+  { dirsBypass = false }: { dirsBypass?: boolean } = {},
+): SQL[] {
+  const conditions: SQL[] = [];
+  const keepDirs = (exists: SQL): SQL =>
+    dirsBypass ? (or(eq(workspaceFileIndex.isDir, true), exists) as SQL) : exists;
+  if (filters.project) {
+    conditions.push(keepDirs(sql`exists (
+      select 1 from workspace_file_enrichment wfe
+      where wfe.file_index_id = workspace_file_index.id
+        and wfe.org_id = workspace_file_index.org_id
+        and wfe.inferred_project_label = ${filters.project}
+    )`));
+  }
+  if (filters.docType) {
+    conditions.push(keepDirs(sql`exists (
+      select 1 from workspace_file_enrichment wfe
+      where wfe.file_index_id = workspace_file_index.id
+        and wfe.org_id = workspace_file_index.org_id
+        and wfe.inferred_doc_type = ${filters.docType}
+    )`));
+  }
+  return conditions;
+}
+
+function toFinderFile(row: FileRow, source: VisibleSource, score?: number): FinderFile {
+  return {
+    id: row.id,
+    sourceId: row.sourceId,
+    deviceKey: row.deviceKey,
+    relPath: row.relPath,
+    parentPath: row.parentPath,
+    name: row.name,
+    isDir: row.isDir,
+    ext: row.ext,
+    size: row.size,
+    mtime: row.mtime ? new Date(row.mtime).toISOString() : null,
+    openPath: openPathFor(source, row.relPath, row.isDir),
+    ...(score === undefined ? {} : { score }),
+  };
+}
+
+/**
+ * Partition rule (defence-in-depth atop RLS): smb_share rows live under the
+ * shared device key and are org-visible; local_profile rows are visible only
+ * to the device that produced them. Undefined means "no visible partition" —
+ * callers must return empty without touching the file index.
+ */
+function partitionFilter(visible: VisibleSource[], helperDeviceId: string): SQL | undefined {
+  const smbIds = visible.filter((s) => s.kind === 'smb_share').map((s) => s.id);
+  const localIds = visible.filter((s) => s.kind === 'local_profile').map((s) => s.id);
+  const branches: Array<SQL | undefined> = [];
+  if (smbIds.length > 0) {
+    branches.push(and(
+      inArray(workspaceFileIndex.sourceId, smbIds),
+      eq(workspaceFileIndex.deviceKey, SHARED_DEVICE_KEY),
+    ));
+  }
+  if (localIds.length > 0) {
+    branches.push(and(
+      inArray(workspaceFileIndex.sourceId, localIds),
+      eq(workspaceFileIndex.deviceKey, helperDeviceId),
+    ));
+  }
+  if (branches.length === 0) return undefined;
+  return or(...branches);
+}
+
+export function createFileQueryService(db: WorkspaceDatabase) {
+  const d = db;
+
+  /**
+   * Visibility resolution, shared by every read below (no row escapes it). The
+   * rule itself lives in visibility.ts — the single definition of source
+   * visibility. Empty `groupIds` fails closed (only ungrouped sources); helper
+   * auth carries no Entra group claims yet, so the routes pass `[]`.
+   */
+  async function visibleSources(orgId: string, groupIds: string[] = []): Promise<VisibleSource[]> {
+    return d.select({
+      id: workspaceSources.id,
+      displayName: workspaceSources.displayName,
+      kind: workspaceSources.kind,
+      rootPath: workspaceSources.rootPath,
+    })
+      .from(workspaceSources)
+      .where(and(
+        eq(workspaceSources.orgId, orgId),
+        visibleSourceConditions(groupIds),
+      ))
+      .orderBy(asc(workspaceSources.displayName));
+  }
+
+  return {
+    visibleSources,
+
+    async search(
+      orgId: string,
+      helperDeviceId: string,
+      filters: SearchFilters,
+      groupIds: string[] = [],
+    ): Promise<FinderFile[]> {
+      const visible = await visibleSources(orgId, groupIds);
+      const scoped = filters.sourceId
+        ? visible.filter((s) => s.id === filters.sourceId)
+        : visible;
+      const partition = partitionFilter(scoped, helperDeviceId);
+      if (!partition) return [];
+
+      const q = filters.q;
+      const score = sql<number>`greatest(similarity(${workspaceFileIndex.name}, ${q}), similarity(${workspaceFileIndex.relPath}, ${q}) * 0.8)`;
+      const conditions: Array<SQL | undefined> = [
+        eq(workspaceFileIndex.orgId, orgId),
+        isNull(workspaceFileIndex.deletedAt),
+        eq(workspaceFileIndex.isDir, false),
+        partition,
+        or(
+          sql`${workspaceFileIndex.name} % ${q}`,
+          ilike(workspaceFileIndex.name, `%${q}%`),
+          ilike(workspaceFileIndex.relPath, `%${q}%`),
+        ),
+      ];
+      if (filters.ext) conditions.push(eq(workspaceFileIndex.ext, filters.ext));
+      if (filters.modifiedAfter) {
+        conditions.push(gte(workspaceFileIndex.mtime, new Date(filters.modifiedAfter)));
+      }
+      if (filters.modifiedBefore) {
+        conditions.push(lte(workspaceFileIndex.mtime, new Date(filters.modifiedBefore)));
+      }
+      // project/docType narrowing (EXISTS on workspace_file_enrichment) is
+      // shared verbatim with browse() — see enrichmentConditions().
+      conditions.push(...enrichmentConditions(filters));
+
+      const rows = await d.select({ ...getTableColumns(workspaceFileIndex), score })
+        .from(workspaceFileIndex)
+        .where(and(...conditions))
+        .orderBy(desc(score), sql`${workspaceFileIndex.mtime} desc nulls last`)
+        .limit(clampLimit(filters.limit));
+
+      const byId = new Map(scoped.map((s) => [s.id, s]));
+      return rows.flatMap((row) => {
+        const source = byId.get(row.sourceId);
+        return source ? [toFinderFile(row, source, row.score)] : [];
+      });
+    },
+
+    async browse(
+      orgId: string,
+      helperDeviceId: string,
+      sourceId: string,
+      parentPath: string,
+      filters: BrowseFilters = {},
+      groupIds: string[] = [],
+    ): Promise<FinderFile[]> {
+      const visible = await visibleSources(orgId, groupIds);
+      const source = visible.find((s) => s.id === sourceId);
+      if (!source) return [];
+      const deviceKey = source.kind === 'smb_share' ? SHARED_DEVICE_KEY : helperDeviceId;
+      const conditions: Array<SQL | undefined> = [
+        eq(workspaceFileIndex.orgId, orgId),
+        eq(workspaceFileIndex.sourceId, sourceId),
+        eq(workspaceFileIndex.deviceKey, deviceKey),
+        eq(workspaceFileIndex.parentPath, parentPath),
+        isNull(workspaceFileIndex.deletedAt),
+      ];
+      // Same project/docType narrowing as search(), but directories must stay
+      // navigable under an active filter — see enrichmentConditions(dirsBypass).
+      conditions.push(...enrichmentConditions(filters, { dirsBypass: true }));
+      const rows = await d.select().from(workspaceFileIndex)
+        .where(and(...conditions))
+        .orderBy(desc(workspaceFileIndex.isDir), asc(workspaceFileIndex.name));
+      return rows.map((row) => toFinderFile(row, source));
+    },
+
+    async getFile(
+      orgId: string,
+      helperDeviceId: string,
+      fileId: string,
+      groupIds: string[] = [],
+    ): Promise<FinderFile | null> {
+      const visible = await visibleSources(orgId, groupIds);
+      const partition = partitionFilter(visible, helperDeviceId);
+      if (!partition) return null;
+      const [row] = await d.select().from(workspaceFileIndex)
+        .where(and(
+          eq(workspaceFileIndex.orgId, orgId),
+          eq(workspaceFileIndex.id, fileId),
+          isNull(workspaceFileIndex.deletedAt),
+          partition,
+        ))
+        .limit(1);
+      if (!row) return null;
+      const source = visible.find((s) => s.id === row.sourceId);
+      return source ? toFinderFile(row, source) : null;
+    },
+  };
+}

--- a/ee/workspace/src/services/filingService.ts
+++ b/ee/workspace/src/services/filingService.ts
@@ -139,7 +139,9 @@ export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
         if (!(STRONG_TYPES as readonly string[]).includes(e.entity_type)) continue;
         const hits = await deps.crosswalkService.lookup(orgId, e.entity_type, e.value_norm);
         if (hits.length === 0) continue;
-        const [winner, runnerUp] = hits;
+        // `hits.length === 0` was skipped above, so hits[0] is present.
+        const winner = hits[0]!;
+        const runnerUp = hits[1];
         const dominant = winner.evidenceCount >= DOMINANCE_MIN_EVIDENCE
           && (!runnerUp || winner.evidenceCount >= DOMINANCE_MARGIN * runnerUp.evidenceCount);
         // An org participant mentioned in the email makes the rationale read

--- a/ee/workspace/src/services/filingService.ts
+++ b/ee/workspace/src/services/filingService.ts
@@ -1,0 +1,286 @@
+// Classify-one-email filing pipeline (dev-preview; per-org content flag).
+//
+// Confidence rules (fixed, deterministic — never a vibe):
+//   HIGH — a strong entity (po/wdr/invoice/permit) in the email hits the
+//   crosswalk with DOMINANT evidence: ≥2 distinct files for the winning
+//   project AND (no competing project OR winner ≥ 2× the runner-up).
+//   LOW  — everything else: person/org-participant evidence (however
+//   suggestive), non-dominant crosswalk hits, or no candidates at all.
+//   Person evidence can suggest, never auto-confirm.
+// Matching is strict on (entity_type, value_norm) — the corpus plants
+// "LS 8841" (a license) against "invoice 8841" precisely to punish
+// value-only matching.
+import type { WorkspaceDatabase } from '../hostTypes';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { deriveDeclaredProject } from '../content/projects';
+import { STRONG_TYPES, type CrosswalkService } from './crosswalkService';
+import { visibleSourcePredicateSql } from './visibility';
+
+export interface FilingRecord {
+  fileIndexId: string;
+  relPath: string;
+  name: string;
+  emailMeta: { from?: string; to?: string[]; subject?: string; date?: string } | null;
+  status: 'suggested' | 'confirmed' | 'reassigned' | null;
+  suggestedProjectKey: string | null;
+  suggestedProjectLabel: string | null;
+  matchedEntityType: string | null;
+  matchedEntityValue: string | null;
+  confidence: 'high' | 'low' | null;
+  rationale: string | null;
+  decidedProjectKey: string | null;
+}
+
+export interface FilingDeps {
+  crosswalkService: Pick<CrosswalkService, 'lookup'>;
+}
+
+const DOMINANCE_MIN_EVIDENCE = 2;
+const DOMINANCE_MARGIN = 2;
+
+/** Display form for a matched entity ("PO 4021" → "PO #4021"). */
+function displayEntity(type: string, valueNorm: string): string {
+  if (type === 'po') return valueNorm.replace(/^PO /, 'PO #');
+  if (type === 'invoice') return valueNorm.replace(/^INV /, 'invoice #');
+  return valueNorm;
+}
+
+export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
+  const d = db;
+
+  async function unfiledEmails(orgId: string, groupIds: string[] = []): Promise<Array<{
+    id: string; rel_path: string; name: string; email_meta: FilingRecord['emailMeta'];
+  }>> {
+    const rows = await d.execute(sql`
+      SELECT fi.id, fi.rel_path, fi.name, en.email_meta
+      FROM workspace_file_index fi
+      JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+      LEFT JOIN workspace_file_enrichment en ON en.file_index_id = fi.id
+      WHERE fi.org_id = ${orgId}
+        AND fi.deleted_at IS NULL
+        AND fi.is_dir = false
+        AND fi.ext = 'eml'
+        AND ${visibleSourcePredicateSql(sql, groupIds)}
+      ORDER BY fi.rel_path
+    `) as unknown as Array<{
+      id: string; rel_path: string; name: string; email_meta: FilingRecord['emailMeta'];
+    }>;
+    return rows.filter((r) => deriveDeclaredProject(r.rel_path) === null);
+  }
+
+  async function filingRowsFor(orgId: string, fileIds: string[]): Promise<Map<string, Record<string, unknown>>> {
+    if (fileIds.length === 0) return new Map();
+    const rows = await d.execute(sql`
+      SELECT file_index_id, status, suggested_project_key, suggested_project_label,
+             matched_entity_type, matched_entity_value, confidence, rationale,
+             decided_project_key
+      FROM workspace_email_filings
+      WHERE org_id = ${orgId}
+    `) as unknown as Array<Record<string, unknown> & { file_index_id: string }>;
+    return new Map(rows.map((r) => [r.file_index_id, r]));
+  }
+
+  function toRecord(
+    file: { id: string; rel_path: string; name: string; email_meta: FilingRecord['emailMeta'] },
+    filing: Record<string, unknown> | undefined,
+  ): FilingRecord {
+    return {
+      fileIndexId: file.id,
+      relPath: file.rel_path,
+      name: file.name,
+      emailMeta: file.email_meta ?? null,
+      status: (filing?.status as FilingRecord['status']) ?? null,
+      suggestedProjectKey: (filing?.suggested_project_key as string | null) ?? null,
+      suggestedProjectLabel: (filing?.suggested_project_label as string | null) ?? null,
+      matchedEntityType: (filing?.matched_entity_type as string | null) ?? null,
+      matchedEntityValue: (filing?.matched_entity_value as string | null) ?? null,
+      confidence: (filing?.confidence as FilingRecord['confidence']) ?? null,
+      rationale: (filing?.rationale as string | null) ?? null,
+      decidedProjectKey: (filing?.decided_project_key as string | null) ?? null,
+    };
+  }
+
+  return {
+    async list(orgId: string, groupIds: string[] = []): Promise<FilingRecord[]> {
+      const emails = await unfiledEmails(orgId, groupIds);
+      const filings = await filingRowsFor(orgId, emails.map((e) => e.id));
+      return emails.map((e) => toRecord(e, filings.get(e.id)));
+    },
+
+    /**
+     * Classify one unfiled email. Returns null when the file is unknown,
+     * tombstoned, hidden, not an email, or not unfiled (404 at the route).
+     */
+    async classify(orgId: string, fileIndexId: string, groupIds: string[] = []): Promise<FilingRecord | null> {
+      const emails = await unfiledEmails(orgId, groupIds);
+      const email = emails.find((e) => e.id === fileIndexId);
+      if (!email) return null;
+
+      // Deterministic entity order: strongest lead types first, then value —
+      // Postgres row order is otherwise unspecified and the first dominant
+      // hit wins below.
+      const entities = await d.execute(sql`
+        SELECT entity_type, value_norm FROM workspace_content_entities
+        WHERE org_id = ${orgId} AND file_index_id = ${fileIndexId}
+        ORDER BY array_position(ARRAY['po','wdr','permit','invoice','org','person'], entity_type)
+                 NULLS LAST,
+                 value_norm ASC
+      `) as unknown as Array<{ entity_type: string; value_norm: string }>;
+
+      let suggestion: {
+        projectKey: string; projectLabel: string | null;
+        matchedType: string | null; matchedValue: string | null;
+        confidence: 'high' | 'low'; rationale: string;
+      } | null = null;
+
+      // 1) Strong-entity crosswalk with dominance.
+      for (const e of entities) {
+        if (!(STRONG_TYPES as readonly string[]).includes(e.entity_type)) continue;
+        const hits = await deps.crosswalkService.lookup(orgId, e.entity_type, e.value_norm);
+        if (hits.length === 0) continue;
+        const [winner, runnerUp] = hits;
+        const dominant = winner.evidenceCount >= DOMINANCE_MIN_EVIDENCE
+          && (!runnerUp || winner.evidenceCount >= DOMINANCE_MARGIN * runnerUp.evidenceCount);
+        // An org participant mentioned in the email makes the rationale read
+        // the way a person would say it ("matched City of Fairoaks PO #4021").
+        const orgEntity = entities.find((x) => x.entity_type === 'org');
+        const rationale = `matched ${orgEntity ? `${orgEntity.value_norm} ` : ''}${displayEntity(e.entity_type, e.value_norm)}`;
+        if (dominant) {
+          suggestion = {
+            projectKey: winner.projectKey,
+            projectLabel: winner.projectLabel,
+            matchedType: e.entity_type,
+            matchedValue: e.value_norm,
+            confidence: 'high',
+            rationale,
+          };
+          break;
+        }
+        // non-dominant crosswalk hit: keep as a LOW fallback unless something
+        // better shows up
+        suggestion ??= {
+          projectKey: winner.projectKey,
+          projectLabel: winner.projectLabel,
+          matchedType: e.entity_type,
+          matchedValue: e.value_norm,
+          confidence: 'low',
+          rationale: `${rationale} — evidence is thin (${winner.evidenceCount} file${winner.evidenceCount === 1 ? '' : 's'})`,
+        };
+      }
+
+      // 2) Participant fallback (people/orgs shared with filed project files) —
+      //    forced LOW, never auto-confirmed.
+      if (!suggestion || suggestion.confidence === 'low') {
+        const people = entities.filter((e) => e.entity_type === 'person' || e.entity_type === 'org');
+        if (people.length > 0) {
+          const names = people.map((p) => p.value_norm);
+          const candidates = await d.execute(sql`
+            SELECT en.declared_project_key AS project_key,
+                   max(en.declared_project_label) AS project_label,
+                   e.value_norm,
+                   count(DISTINCT e.file_index_id) AS files
+            FROM workspace_content_entities e
+            JOIN workspace_file_enrichment en ON en.file_index_id = e.file_index_id
+            JOIN workspace_file_index fi ON fi.id = e.file_index_id
+            JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+            WHERE e.org_id = ${orgId}
+              AND fi.deleted_at IS NULL
+              AND ${visibleSourcePredicateSql(sql, groupIds)}
+              AND e.entity_type IN ('person', 'org')
+              AND e.value_norm = ANY(${'{' + names.map((n) => `"${n.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(',') + '}'}::text[])
+              AND en.declared_project_key IS NOT NULL
+            GROUP BY en.declared_project_key, e.value_norm
+            ORDER BY files DESC, project_key ASC
+            LIMIT 5
+          `) as unknown as Array<{
+            project_key: string; project_label: string | null; value_norm: string; files: number;
+          }>;
+          const best = candidates[0];
+          if (best && (!suggestion || Number(best.files) > 1)) {
+            suggestion = {
+              projectKey: best.project_key,
+              projectLabel: best.project_label,
+              matchedType: null,
+              matchedValue: best.value_norm,
+              confidence: 'low',
+              rationale: `${best.value_norm} appears in ${best.files} ${best.project_label ?? best.project_key} file${Number(best.files) === 1 ? '' : 's'}`,
+            };
+          }
+        }
+      }
+
+      await d.execute(sql`
+        INSERT INTO workspace_email_filings
+          (org_id, file_index_id, status, suggested_project_key, suggested_project_label,
+           matched_entity_type, matched_entity_value, confidence, rationale)
+        VALUES
+          (${orgId}, ${fileIndexId}, 'suggested', ${suggestion?.projectKey ?? null},
+           ${suggestion?.projectLabel ?? null}, ${suggestion?.matchedType ?? null},
+           ${suggestion?.matchedValue ?? null},
+           ${(suggestion?.confidence ?? 'low')}::workspace_filing_confidence,
+           ${suggestion?.rationale ?? 'no filing signal found'})
+        ON CONFLICT (file_index_id) DO UPDATE SET
+          status = 'suggested',
+          suggested_project_key = EXCLUDED.suggested_project_key,
+          suggested_project_label = EXCLUDED.suggested_project_label,
+          matched_entity_type = EXCLUDED.matched_entity_type,
+          matched_entity_value = EXCLUDED.matched_entity_value,
+          confidence = EXCLUDED.confidence,
+          rationale = EXCLUDED.rationale,
+          updated_at = now()
+        -- A human decision is never silently overwritten by a re-classify:
+        -- decided rows keep their status and decided_* values.
+        WHERE workspace_email_filings.decided_project_key IS NULL
+      `);
+      const filings = await filingRowsFor(orgId, [fileIndexId]);
+      return toRecord(email, filings.get(fileIndexId));
+    },
+
+    /**
+     * One-click (re)assign. Confirms when the choice matches the suggestion,
+     * reassigns otherwise. Returns null for unknown file/filing or project.
+     */
+    async assign(
+      orgId: string,
+      fileIndexId: string,
+      projectKey: string,
+      decidedLabel: string | null,
+      groupIds: string[] = [],
+    ): Promise<FilingRecord | null> {
+      const project = (await d.execute(sql`
+        SELECT project_key FROM workspace_projects
+        WHERE org_id = ${orgId} AND project_key = ${projectKey}
+      `) as unknown as Array<{ project_key: string }>)[0];
+      if (!project) return null;
+      const updated = await d.execute(sql`
+        UPDATE workspace_email_filings SET
+          status = CASE WHEN suggested_project_key = ${projectKey}
+                        THEN 'confirmed'::workspace_filing_status
+                        ELSE 'reassigned'::workspace_filing_status END,
+          decided_project_key = ${projectKey},
+          decided_label = ${decidedLabel},
+          decided_at = now(),
+          updated_at = now()
+        WHERE org_id = ${orgId} AND file_index_id = ${fileIndexId}
+        RETURNING file_index_id
+      `) as unknown as Array<{ file_index_id: string }>;
+      if (updated.length === 0) return null;
+      const emails = await unfiledEmails(orgId, groupIds);
+      const email = emails.find((e) => e.id === fileIndexId);
+      if (!email) return null;
+      const filings = await filingRowsFor(orgId, [fileIndexId]);
+      return toRecord(email, filings.get(fileIndexId));
+    },
+
+    async projects(orgId: string): Promise<Array<{ key: string; label: string }>> {
+      const rows = await d.execute(sql`
+        SELECT project_key, label FROM workspace_projects
+        WHERE org_id = ${orgId} ORDER BY project_key
+      `) as unknown as Array<{ project_key: string; label: string }>;
+      return rows.map((r) => ({ key: r.project_key, label: r.label }));
+    },
+  };
+}
+
+export type FilingService = ReturnType<typeof createFilingService>;

--- a/ee/workspace/src/services/orgSettingsService.test.ts
+++ b/ee/workspace/src/services/orgSettingsService.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { getOrgSettings, DEFAULT_DLP_CONFIG } from './orgSettingsService';
+
+/** drizzle-stub pattern (mirrors credentialService.test.ts): select(...).from(...).where(...) resolves rows. */
+function fakeDbReturning(rows: Record<string, unknown>[]) {
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({ where: vi.fn(async () => rows) })),
+    })),
+  };
+  return db as unknown as WorkspaceDatabase;
+}
+
+describe('orgSettingsService', () => {
+  it('defaults to disabled + default DLP config when no row exists', async () => {
+    const db = fakeDbReturning([]); // helper: select(...).from(...).where(...) resolves []
+    const s = await getOrgSettings(db, 'org-1');
+    expect(s.contentEnabled).toBe(false);
+    expect(s.dlpConfig).toEqual(DEFAULT_DLP_CONFIG);
+  });
+
+  it('collapses unknown detector actions to the safe default (default-deny)', async () => {
+    const db = fakeDbReturning([{ orgId: 'org-1', contentEnabled: true,
+      dlpConfig: { detectors: { credit_card: 'shout', ssn: 'redact' } } }]);
+    const s = await getOrgSettings(db, 'org-1');
+    expect(s.dlpConfig.detectors.credit_card).toBe('redact'); // unknown → detector's default
+    expect(s.dlpConfig.detectors.ssn).toBe('redact');
+  });
+
+  it('returns an independent dlpConfig object when no row exists, not the shared module-level singleton', async () => {
+    const db = fakeDbReturning([]);
+    const s = await getOrgSettings(db, 'org-1');
+    // Reference identity, not just deep equality: a caller mutating the
+    // returned dlpConfig in place must never corrupt DEFAULT_DLP_CONFIG for
+    // every other org that later hits the same no-row branch.
+    expect(s.dlpConfig).not.toBe(DEFAULT_DLP_CONFIG);
+    expect(s.dlpConfig.detectors).not.toBe(DEFAULT_DLP_CONFIG.detectors);
+  });
+
+  it('DEFAULT_DLP_CONFIG is frozen (including nested detectors) as a defensive backstop', () => {
+    expect(Object.isFrozen(DEFAULT_DLP_CONFIG)).toBe(true);
+    expect(Object.isFrozen(DEFAULT_DLP_CONFIG.detectors)).toBe(true);
+  });
+});

--- a/ee/workspace/src/services/orgSettingsService.ts
+++ b/ee/workspace/src/services/orgSettingsService.ts
@@ -1,0 +1,121 @@
+import type { WorkspaceDatabase } from '../hostTypes';
+import { eq, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { workspaceOrgSettings } from '../schema/orgSettings';
+
+export type DlpAction = 'block' | 'redact' | 'log' | 'off';
+export type DetectorId = 'credit_card' | 'iban' | 'ssn' | 'api_key' | 'email' | 'phone';
+
+export interface DlpConfig {
+  detectors: Record<DetectorId, DlpAction>;
+  customPatterns: Array<{ name: string; pattern: string; action: DlpAction }>;
+}
+
+export interface OrgSettings {
+  contentEnabled: boolean;
+  dlpConfig: DlpConfig;
+}
+
+const ACTIONS: DlpAction[] = ['block', 'redact', 'log', 'off'];
+
+// Mirrors client-ai defaults (apps/api/src/services/clientAiDlp.ts): financial
+// and credential detectors default to redact; contact detectors default off.
+//
+// Frozen (including the nested `detectors` object) so that any accidental
+// in-place mutation by a caller — e.g. a future DLP-enforcement task doing
+// `settings.dlpConfig.detectors[id] = override` — throws immediately in
+// strict mode rather than silently corrupting this shared, process-wide
+// default for every org that has no settings row. Callers should still
+// treat this as logically read-only and prefer a fresh copy (see
+// `normalizeDlp(undefined)`, used by `getOrgSettings`'s no-row branch)
+// rather than relying on the freeze alone.
+export const DEFAULT_DLP_CONFIG: DlpConfig = Object.freeze({
+  detectors: Object.freeze({
+    credit_card: 'redact',
+    iban: 'redact',
+    ssn: 'redact',
+    api_key: 'redact',
+    email: 'off',
+    phone: 'off',
+  }),
+  customPatterns: [],
+}) as DlpConfig;
+
+/**
+ * Default-deny normalization: any missing, unknown, or malformed piece of a
+ * stored DLP config collapses to the safe default rather than being trusted
+ * as-is. This is the one place downstream DLP enforcement may assume a fully
+ * valid DlpConfig shape.
+ */
+function normalizeDlp(raw: unknown): DlpConfig {
+  const rawObj = (raw && typeof raw === 'object' ? raw as Record<string, unknown> : {});
+  const rawDetectors = (rawObj.detectors && typeof rawObj.detectors === 'object'
+    ? rawObj.detectors as Record<string, unknown>
+    : {});
+
+  const detectors = {} as Record<DetectorId, DlpAction>;
+  for (const key of Object.keys(DEFAULT_DLP_CONFIG.detectors) as DetectorId[]) {
+    const candidate = rawDetectors[key];
+    detectors[key] = (typeof candidate === 'string' && ACTIONS.includes(candidate as DlpAction))
+      ? candidate as DlpAction
+      : DEFAULT_DLP_CONFIG.detectors[key];
+  }
+
+  const rawPatterns = Array.isArray(rawObj.customPatterns) ? rawObj.customPatterns : [];
+  const customPatterns: DlpConfig['customPatterns'] = [];
+  for (const entry of rawPatterns) {
+    if (!entry || typeof entry !== 'object') continue;
+    const { name, pattern, action } = entry as Record<string, unknown>;
+    if (typeof name !== 'string' || typeof pattern !== 'string') continue;
+    if (typeof action !== 'string' || !ACTIONS.includes(action as DlpAction)) continue;
+    try {
+      void new RegExp(pattern); // validity check only, the RegExp itself is discarded
+    } catch {
+      continue; // malformed pattern: drop the entry rather than trust it
+    }
+    customPatterns.push({ name, pattern, action: action as DlpAction });
+  }
+
+  return { detectors, customPatterns };
+}
+
+export async function getOrgSettings(db: WorkspaceDatabase, orgId: string): Promise<OrgSettings> {
+  const d = db;
+  const rows = await d.select().from(workspaceOrgSettings).where(eq(workspaceOrgSettings.orgId, orgId));
+  // normalizeDlp(undefined) builds a fresh, independent DlpConfig (equal in
+  // value to DEFAULT_DLP_CONFIG but not the same reference), so callers can
+  // never mutate the shared module-level singleton via this path.
+  if (rows.length === 0) return { contentEnabled: false, dlpConfig: normalizeDlp(undefined) };
+  const raw = rows[0] as { contentEnabled?: unknown; dlpConfig?: unknown };
+  return {
+    contentEnabled: raw.contentEnabled === true,
+    dlpConfig: normalizeDlp(raw.dlpConfig),
+  };
+}
+
+export async function putOrgSettings(
+  db: WorkspaceDatabase,
+  orgId: string,
+  patch: { contentEnabled?: boolean; dlpConfig?: DlpConfig },
+): Promise<OrgSettings> {
+  const d = db;
+  const contentEnabled = patch.contentEnabled ?? false;
+  // The dlpConfig column is typed as a generic jsonb bag; DlpConfig is a
+  // plain JSON-shaped object, so this cast is a widening, not an unsafe one.
+  const dlpConfig = normalizeDlp(patch.dlpConfig) as unknown as Record<string, unknown>;
+
+  await d.insert(workspaceOrgSettings)
+    .values({ orgId, contentEnabled, dlpConfig, updatedAt: sql`now()` })
+    .onConflictDoUpdate({
+      target: workspaceOrgSettings.orgId,
+      set: {
+        // Partial patches leave the unspecified field untouched — only
+        // overwrite what the caller actually provided.
+        ...(patch.contentEnabled !== undefined ? { contentEnabled: patch.contentEnabled } : {}),
+        ...(patch.dlpConfig !== undefined ? { dlpConfig } : {}),
+        updatedAt: sql`now()`,
+      },
+    });
+
+  return getOrgSettings(db, orgId);
+}

--- a/ee/workspace/src/services/runScope.ts
+++ b/ee/workspace/src/services/runScope.ts
@@ -1,0 +1,52 @@
+/**
+ * The run/index "scope" convention, in one place.
+ *
+ * SMB sources are crawled source-scoped: exactly one org-wide partition,
+ * stored as deviceId = NULL with deviceKey = SHARED_DEVICE_KEY. local_profile
+ * sources are crawled device-scoped: one partition per device, stored as
+ * deviceId = deviceKey = <device>.
+ *
+ * deviceKey exists because the unique index on workspace_file_index is
+ * (org_id, source_id, device_key, rel_path) and Postgres treats NULLs as
+ * distinct in unique indexes — keying on nullable device_id would let SMB rows
+ * duplicate freely. The invariant device_key = COALESCE(device_id, zero-uuid)
+ * is enforced by application code only (no DB trigger); every writer must go
+ * through this module.
+ */
+export const SHARED_DEVICE_KEY = '00000000-0000-0000-0000-000000000000';
+
+export type RunScope = { deviceId: string | null; deviceKey: string };
+
+export function smbScope(): RunScope {
+  return { deviceId: null, deviceKey: SHARED_DEVICE_KEY };
+}
+
+export function deviceScope(deviceId: string): RunScope {
+  return { deviceId, deviceKey: deviceId };
+}
+
+/**
+ * The scope a device may operate under for a source; null when the source is
+ * not assigned to that device (SMB sources are owned by their crawl device).
+ */
+export function scopeForDevice(
+  source: { kind: 'smb_share' | 'local_profile'; crawlDeviceId: string | null },
+  deviceId: string,
+): RunScope | null {
+  if (source.kind === 'smb_share') {
+    return source.crawlDeviceId === deviceId ? smbScope() : null;
+  }
+  return deviceScope(deviceId);
+}
+
+export function matchesScope(
+  row: { deviceId: string | null; deviceKey: string },
+  scope: RunScope,
+): boolean {
+  return row.deviceId === scope.deviceId && row.deviceKey === scope.deviceKey;
+}
+
+/** Inverse of the COALESCE convention: shared key maps back to a NULL device. */
+export function deviceIdFromKey(deviceKey: string): string | null {
+  return deviceKey === SHARED_DEVICE_KEY ? null : deviceKey;
+}

--- a/ee/workspace/src/services/sourcesService.test.ts
+++ b/ee/workspace/src/services/sourcesService.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { workspaceCrawlRuns, workspaceSources } from '../schema/workspace';
+import { createSourcesService, type SourceInput } from './sourcesService';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+const SOURCE_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_ID = '33333333-3333-3333-3333-333333333333';
+const OTHER_DEVICE_ID = '44444444-4444-4444-4444-444444444444';
+
+function boundValues(value: unknown): unknown[] {
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value') ? [candidate.value] : [];
+  return [...own, ...(candidate.queryChunks ?? []).flatMap(boundValues)];
+}
+
+function source(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SOURCE_ID,
+    orgId: ORG_ID,
+    kind: 'local_profile',
+    displayName: 'Profiles',
+    rootPath: '/Users',
+    crawlDeviceId: DEVICE_ID,
+    visibilityGroupIds: [],
+    credentialEnc: null,
+    excludeGlobs: [],
+    watch: true,
+    crawlCadenceMinutes: 60,
+    crawlCursor: {},
+    status: 'active',
+    statusDetail: null,
+    errorReason: null,
+    lastCompleteRunAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// Mirror of the service's redaction: consumers get rows without credentialEnc
+// plus a computed hasCredential.
+function safe(row: Record<string, unknown>) {
+  const { credentialEnc, ...rest } = row;
+  return { ...rest, hasCredential: Boolean(credentialEnc) };
+}
+
+const input: SourceInput = {
+  kind: 'local_profile',
+  displayName: 'Profiles',
+  rootPath: '/Users',
+  crawlDeviceId: DEVICE_ID,
+  visibilityGroupIds: [],
+  crawlCadenceMinutes: 60,
+  excludeGlobs: ['**/.git/**'],
+  watch: true,
+  status: 'active',
+};
+
+function makeDb(selectResults: unknown[][] = []) {
+  let selectIndex = 0;
+  const inserted: unknown[] = [];
+  const updated: unknown[] = [];
+  const selectedTables: unknown[] = [];
+  const select = vi.fn(() => ({
+    from: vi.fn((table: unknown) => {
+      selectedTables.push(table);
+      return {
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => selectResults[selectIndex++] ?? []),
+          orderBy: vi.fn(() => table === workspaceCrawlRuns
+            ? { limit: vi.fn(async () => selectResults[selectIndex++] ?? []) }
+            : Promise.resolve(selectResults[selectIndex++] ?? [])),
+        })),
+      };
+    }),
+  }));
+  const db = {
+    select,
+    insert: vi.fn(() => ({
+      values: vi.fn((value: unknown) => {
+        inserted.push(value);
+        return { returning: vi.fn(async () => [source(value as Record<string, unknown>)]) };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((value: unknown) => {
+        updated.push(value);
+        return {
+          where: vi.fn(() => ({
+            returning: vi.fn(async () => [source(value as Record<string, unknown>)]),
+          })),
+        };
+      }),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn(() => ({ returning: vi.fn(async () => [{ id: SOURCE_ID }]) })),
+    })),
+  };
+  return { db: db as unknown as WorkspaceDatabase, raw: db, inserted, updated, selectedTables };
+}
+
+describe('sourcesService', () => {
+  it('lists and gets sources scoped through query predicates', async () => {
+    const row = source();
+    const { db, raw } = makeDb([[row], [row]]);
+    const service = createSourcesService(db);
+
+    await expect(service.list(ORG_ID)).resolves.toEqual([safe(row)]);
+    await expect(service.get(ORG_ID, SOURCE_ID)).resolves.toEqual(safe(row));
+    expect(raw.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('never returns credentialEnc and computes hasCredential from it', async () => {
+    const withCred = source({ credentialEnc: 'ciphertext' });
+    const { db } = makeDb([[withCred]]);
+    const result = await createSourcesService(db).get(ORG_ID, SOURCE_ID);
+    expect(result).not.toBeNull();
+    expect(result).not.toHaveProperty('credentialEnc');
+    expect(result?.hasCredential).toBe(true);
+  });
+
+  it('returns null when a source is absent', async () => {
+    const { db } = makeDb([[]]);
+    await expect(createSourcesService(db).get(ORG_ID, SOURCE_ID)).resolves.toBeNull();
+  });
+
+  it('creates a source with the complete input', async () => {
+    const { db, inserted } = makeDb();
+    const result = await createSourcesService(db).create(ORG_ID, input);
+    expect(result.id).toBe(SOURCE_ID);
+    expect(inserted).toEqual([expect.objectContaining({ orgId: ORG_ID, ...input })]);
+  });
+
+  it.each([
+    [{ ...input, kind: 'smb_share', crawlDeviceId: null, rootPath: '\\\\server\\share' }, 'crawlDeviceId'],
+    [{ ...input, kind: 'smb_share', crawlDeviceId: DEVICE_ID, rootPath: '/mnt/share' }, 'UNC'],
+  ] as const)('rejects invalid SMB input', async (badInput, message) => {
+    const { db, raw } = makeDb();
+    await expect(createSourcesService(db).create(ORG_ID, badInput)).rejects.toThrow(message);
+    expect(raw.insert).not.toHaveBeenCalled();
+  });
+
+  it('updates a source and returns null when no scoped row matches', async () => {
+    const first = makeDb();
+    await expect(createSourcesService(first.db).update(ORG_ID, SOURCE_ID, { status: 'paused' }))
+      .resolves.toMatchObject({ status: 'paused' });
+    expect(first.updated[0]).toMatchObject({ status: 'paused', updatedAt: expect.any(Date) });
+
+    const second = makeDb();
+    second.raw.update.mockReturnValueOnce({
+      set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn(async () => []) })) })),
+    });
+    await expect(createSourcesService(second.db).update(ORG_ID, SOURCE_ID, {})).resolves.toBeNull();
+  });
+
+  it('removes only a matching scoped source', async () => {
+    const yes = makeDb();
+    await expect(createSourcesService(yes.db).remove(ORG_ID, SOURCE_ID)).resolves.toBe(true);
+
+    const no = makeDb();
+    no.raw.delete.mockReturnValueOnce({
+      where: vi.fn(() => ({ returning: vi.fn(async () => []) })),
+    });
+    await expect(createSourcesService(no.db).remove(ORG_ID, SOURCE_ID)).resolves.toBe(false);
+  });
+
+  it('lists active local-profile and assigned sources for a device', async () => {
+    const activeLocal = source({ id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' });
+    const assignedSmb = source({
+      id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', kind: 'smb_share', crawlDeviceId: DEVICE_ID,
+    });
+    const paused = source({ id: 'cccccccc-cccc-cccc-cccc-cccccccccccc', status: 'paused' });
+    const wrongDeviceSmb = source({
+      id: 'dddddddd-dddd-dddd-dddd-dddddddddddd', kind: 'smb_share', crawlDeviceId: OTHER_DEVICE_ID,
+    });
+    const crossOrgLocal = source({ id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', orgId: OTHER_DEVICE_ID });
+    const rows = [activeLocal, assignedSmb, paused, wrongDeviceSmb, crossOrgLocal];
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn((condition: unknown) => ({
+            orderBy: vi.fn(async () => {
+              const values = boundValues(condition);
+              return rows.filter((row) =>
+                (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+                (!values.includes('active') || row.status === 'active') &&
+                (
+                  !values.includes('local_profile') ||
+                  row.kind === 'local_profile' ||
+                  !values.includes(DEVICE_ID) ||
+                  row.crawlDeviceId === DEVICE_ID
+                ));
+            }),
+          })),
+        })),
+      })),
+    } as unknown as WorkspaceDatabase;
+
+    await expect(createSourcesService(db).listForDevice(ORG_ID, DEVICE_ID))
+      .resolves.toEqual([safe(activeLocal), safe(assignedSmb)]);
+  });
+
+  it('lists crawl runs from the runs table with the requested limit', async () => {
+    const run = { id: '55555555-5555-5555-5555-555555555555', sourceId: SOURCE_ID };
+    const { db, selectedTables } = makeDb([[run]]);
+    await expect(createSourcesService(db).listRuns(ORG_ID, SOURCE_ID, 7)).resolves.toEqual([run]);
+    expect(selectedTables).toEqual([workspaceCrawlRuns]);
+    expect(selectedTables).not.toContain(workspaceSources);
+  });
+
+  it('uses exact org/source predicates for get, update, remove, and listRuns', async () => {
+    const crossOrg = source({ orgId: OTHER_DEVICE_ID });
+    const wrongId = source({ id: OTHER_DEVICE_ID });
+    const correct = source();
+    const sources = [crossOrg, wrongId, correct];
+    const runs = [
+      { id: 'cross-org', orgId: OTHER_DEVICE_ID, sourceId: SOURCE_ID },
+      { id: 'wrong-source', orgId: ORG_ID, sourceId: OTHER_DEVICE_ID },
+      { id: 'correct-run', orgId: ORG_ID, sourceId: SOURCE_ID },
+    ];
+    const filter = (rows: Array<Record<string, unknown>>, condition: unknown) => {
+      const values = boundValues(condition);
+      return rows.filter((row) =>
+        (!values.includes(ORG_ID) || row.orgId === ORG_ID) &&
+        (!values.includes(SOURCE_ID) || row.id === SOURCE_ID || row.sourceId === SOURCE_ID));
+    };
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn((table: unknown) => ({
+          where: vi.fn((condition: unknown) => ({
+            limit: vi.fn(async (limit: number) => filter(table === workspaceSources ? sources : runs, condition).slice(0, limit)),
+            orderBy: vi.fn(() => table === workspaceCrawlRuns
+              ? { limit: vi.fn(async (limit: number) => filter(runs, condition).slice(0, limit)) }
+              : Promise.resolve(filter(sources, condition))),
+          })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((patch: Record<string, unknown>) => ({
+          where: vi.fn((condition: unknown) => ({
+            returning: vi.fn(async () => {
+              const matches = filter(sources, condition);
+              matches.forEach((row) => Object.assign(row, patch));
+              return matches;
+            }),
+          })),
+        })),
+      })),
+      delete: vi.fn(() => ({
+        where: vi.fn((condition: unknown) => ({
+          returning: vi.fn(async () => {
+            const matches = filter(sources, condition);
+            matches.forEach((row) => sources.splice(sources.indexOf(row as typeof correct), 1));
+            return matches.map(({ id }) => ({ id }));
+          }),
+        })),
+      })),
+    } as unknown as WorkspaceDatabase;
+    const service = createSourcesService(db);
+    await expect(service.get(ORG_ID, SOURCE_ID)).resolves.toMatchObject({ orgId: ORG_ID, id: SOURCE_ID });
+    await expect(service.update(ORG_ID, SOURCE_ID, { status: 'paused' }))
+      .resolves.toMatchObject({ orgId: ORG_ID, id: SOURCE_ID });
+    expect(crossOrg.status).toBe('active');
+    expect(wrongId.status).toBe('active');
+    await expect(service.listRuns(ORG_ID, SOURCE_ID, 10)).resolves.toEqual([runs[2]]);
+    await expect(service.remove(ORG_ID, SOURCE_ID)).resolves.toBe(true);
+    expect(sources).toEqual([crossOrg, wrongId]);
+    expect(sources.some((row) => row.id === OTHER_DEVICE_ID && row.orgId === ORG_ID)).toBe(true);
+  });
+
+  it('plain list derives tenant filtering from the bound org value', async () => {
+    const crossOrg = source({ orgId: OTHER_DEVICE_ID });
+    const correct = source();
+    const rows = [crossOrg, correct];
+    const db = { select: vi.fn(() => ({ from: vi.fn(() => ({
+      where: vi.fn((condition: unknown) => ({ orderBy: vi.fn(async () => {
+        const values = boundValues(condition);
+        return rows.filter((row) => !values.includes(ORG_ID) || row.orgId === ORG_ID);
+      }) })),
+    })) })) } as unknown as WorkspaceDatabase;
+    await expect(createSourcesService(db).list(ORG_ID)).resolves.toEqual([safe(correct)]);
+  });
+
+  it('clears the stored credential when a patch flips the kind to local_profile', async () => {
+    const flip = makeDb();
+    await createSourcesService(flip.db).update(ORG_ID, SOURCE_ID, { kind: 'local_profile' });
+    expect(flip.updated[0]).toMatchObject({ kind: 'local_profile', credentialEnc: null });
+
+    const keep = makeDb();
+    await createSourcesService(keep.db).update(ORG_ID, SOURCE_ID, { status: 'paused' });
+    expect(keep.updated[0]).not.toHaveProperty('credentialEnc');
+  });
+});

--- a/ee/workspace/src/services/sourcesService.ts
+++ b/ee/workspace/src/services/sourcesService.ts
@@ -1,0 +1,129 @@
+import type { WorkspaceDatabase } from '../hostTypes';
+import { and, desc, eq, or } from 'drizzle-orm';
+import { workspaceCrawlRuns, workspaceSources } from '../schema/workspace';
+
+export interface SourceInput {
+  kind: 'smb_share' | 'local_profile';
+  displayName: string;
+  rootPath: string;
+  crawlDeviceId?: string | null;
+  visibilityGroupIds: string[];
+  crawlCadenceMinutes: number;
+  excludeGlobs: string[];
+  watch: boolean;
+  status: 'active' | 'paused';
+}
+
+type SourceRow = typeof workspaceSources.$inferSelect;
+export type CrawlRunRow = typeof workspaceCrawlRuns.$inferSelect;
+
+/**
+ * What every consumer outside the credential service gets: the raw row minus
+ * credentialEnc, plus a computed hasCredential. Ciphertext never leaves this
+ * module — a route cannot leak what it never receives. The credential service
+ * reads credential_enc through its own scoped query.
+ */
+export type SafeSourceRow = Omit<SourceRow, 'credentialEnc'> & { hasCredential: boolean };
+
+function toSafeRow(row: SourceRow): SafeSourceRow {
+  const { credentialEnc, ...rest } = row;
+  return { ...rest, hasCredential: Boolean(credentialEnc) };
+}
+
+/** User-input problem (400-class), as opposed to an internal failure. */
+export class SourceValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SourceValidationError';
+  }
+}
+
+function validateCreate(input: SourceInput): void {
+  if (input.kind !== 'smb_share') return;
+  if (!input.crawlDeviceId) {
+    throw new SourceValidationError('smb_share requires crawlDeviceId');
+  }
+  if (!/^\\\\/.test(input.rootPath)) {
+    throw new SourceValidationError('smb_share rootPath must be a UNC path');
+  }
+}
+
+export function createSourcesService(d: WorkspaceDatabase) {
+  return {
+    async list(orgId: string): Promise<SafeSourceRow[]> {
+      const rows = await d.select().from(workspaceSources)
+        .where(eq(workspaceSources.orgId, orgId))
+        .orderBy(workspaceSources.displayName);
+      return rows.map(toSafeRow);
+    },
+
+    async get(orgId: string, id: string): Promise<SafeSourceRow | null> {
+      const [row] = await d.select().from(workspaceSources)
+        .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, id)))
+        .limit(1);
+      return row ? toSafeRow(row) : null;
+    },
+
+    async create(orgId: string, input: SourceInput): Promise<SafeSourceRow> {
+      validateCreate(input);
+      const [row] = await d.insert(workspaceSources).values({ orgId, ...input }).returning();
+      if (!row) throw new Error('Failed to create workspace source');
+      return toSafeRow(row);
+    },
+
+    async update(
+      orgId: string,
+      id: string,
+      patch: Partial<SourceInput>,
+    ): Promise<SafeSourceRow | null> {
+      const [row] = await d.update(workspaceSources)
+        .set({
+          ...patch,
+          // Flipping a source away from smb_share would strand unreachable
+          // ciphertext (credentials are only served for SMB sources) — clear it.
+          ...(patch.kind === 'local_profile' ? { credentialEnc: null } : {}),
+          updatedAt: new Date(),
+        })
+        .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, id)))
+        .returning();
+      return row ? toSafeRow(row) : null;
+    },
+
+    async remove(orgId: string, id: string): Promise<boolean> {
+      const rows = await d.delete(workspaceSources)
+        .where(and(eq(workspaceSources.orgId, orgId), eq(workspaceSources.id, id)))
+        .returning({ id: workspaceSources.id });
+      return rows.length > 0;
+    },
+
+    /**
+     * Agent-visible sources for a device. Visibility rules: only status
+     * 'active' sources are handed to agents (paused and errored sources are
+     * withheld); every local_profile source is visible to every device in the
+     * org; smb_share sources are visible only to their assigned crawl device.
+     */
+    async listForDevice(orgId: string, deviceId: string): Promise<SafeSourceRow[]> {
+      const rows = await d.select().from(workspaceSources)
+        .where(and(
+          eq(workspaceSources.orgId, orgId),
+          eq(workspaceSources.status, 'active'),
+          or(
+            eq(workspaceSources.kind, 'local_profile'),
+            eq(workspaceSources.crawlDeviceId, deviceId),
+          ),
+        ))
+        .orderBy(workspaceSources.displayName);
+      return rows.map(toSafeRow);
+    },
+
+    async listRuns(orgId: string, sourceId: string, limit = 50): Promise<CrawlRunRow[]> {
+      return d.select().from(workspaceCrawlRuns)
+        .where(and(
+          eq(workspaceCrawlRuns.orgId, orgId),
+          eq(workspaceCrawlRuns.sourceId, sourceId),
+        ))
+        .orderBy(desc(workspaceCrawlRuns.startedAt))
+        .limit(limit);
+    },
+  };
+}

--- a/ee/workspace/src/services/visibility.ts
+++ b/ee/workspace/src/services/visibility.ts
@@ -1,0 +1,57 @@
+// The single definition of source visibility, shared by every read path that
+// resolves which workspace_sources a caller may see: fileQueryService (query
+// builder), contentSearchService (all hybrid arms AND the passages path),
+// activityService, and filingService (list, classify, and the participant
+// fallback). There is exactly ONE rule here — change it here and every surface
+// changes together.
+//
+// The rule: a source is visible iff it is active AND either it is ungrouped
+// (visibility_group_ids = '[]') OR its group list overlaps the caller's claim
+// set (jsonb `?|` array-overlap). Empty claims (`groupIds: []`) reduce to
+// today's fail-closed behavior — only ungrouped sources are visible — because
+// `?|` against an empty array is always false. Helper auth carries no Entra
+// group claims yet, so the routes pass `[]` and grouped sources stay hidden
+// until claims exist.
+import { and, eq, or, sql as drizzleSql, type SQL } from 'drizzle-orm';
+import { workspaceSources } from '../schema/workspace';
+
+type SqlTag = typeof drizzleSql;
+
+/**
+ * Postgres text[] literal for a string[] bound value. jsonb `?|` needs a
+ * text[] on its right-hand side; drizzle's sql tag has no array helper, so the
+ * claim set travels as an escaped '{"a","b"}' literal cast to ::text[] (the
+ * same idiom the content services use for their id arrays). Empty → '{}'.
+ */
+function pgTextArray(values: string[]): string {
+  return `{${values.map((v) => `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(',')}}`;
+}
+
+/**
+ * The source-visibility rule as a raw-SQL predicate fragment, for the services
+ * whose queries are raw execute() SQL (content search incl. the passages path,
+ * activity, filing). `alias` qualifies the workspace_sources columns — every
+ * raw call site joins the table as `s`, which is the default.
+ */
+export function visibleSourcePredicateSql(sql: SqlTag, groupIds: string[], alias = 's'): SQL {
+  const status = sql.raw(`${alias}.status`);
+  const groups = sql.raw(`${alias}.visibility_group_ids`);
+  return sql`${status} = 'active' AND (${groups} = '[]'::jsonb
+    OR ${groups} ?| ${pgTextArray(groupIds)}::text[])`;
+}
+
+/**
+ * The drizzle-conditions twin of visibleSourcePredicateSql, for
+ * fileQueryService's query-builder reads. Same rule expressed over the
+ * workspace_sources columns (drizzle qualifies them for us). Returns a single
+ * AND-combined condition to drop into an existing `and(...)`.
+ */
+export function visibleSourceConditions(groupIds: string[]): SQL {
+  return and(
+    eq(workspaceSources.status, 'active'),
+    or(
+      drizzleSql`${workspaceSources.visibilityGroupIds} = '[]'::jsonb`,
+      drizzleSql`${workspaceSources.visibilityGroupIds} ?| ${pgTextArray(groupIds)}::text[]`,
+    ),
+  )!;
+}

--- a/ee/workspace/src/web/api.test.ts
+++ b/ee/workspace/src/web/api.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MAX_RESPONSE_LENGTH,
+  WORKSPACE_API_BASE,
+  WorkspaceApiError,
+  buildWorkspaceUrl,
+  createWorkspaceApi,
+  type SourceInput,
+} from './api';
+
+const ORG_ID = 'org-1';
+const SOURCE_ID = 'src-1';
+const DEVICE_ID = 'dev-1';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function sourceRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: SOURCE_ID,
+    orgId: ORG_ID,
+    kind: 'smb_share',
+    displayName: 'Finance Share',
+    rootPath: '\\\\fs01\\finance',
+    crawlDeviceId: 'dev-9',
+    visibilityGroupIds: [],
+    crawlCadenceMinutes: 1440,
+    excludeGlobs: [],
+    watch: true,
+    status: 'active',
+    errorReason: null,
+    lastCompleteRunAt: '2026-07-12T10:00:00.000Z',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-10T00:00:00.000Z',
+    hasCredential: true,
+    ...overrides,
+  };
+}
+
+function sourceInput(): SourceInput {
+  return {
+    kind: 'smb_share',
+    displayName: 'Finance Share',
+    rootPath: '\\\\fs01\\finance',
+    crawlDeviceId: 'dev-9',
+    visibilityGroupIds: [],
+    crawlCadenceMinutes: 1440,
+    excludeGlobs: [],
+    watch: true,
+    status: 'active',
+  };
+}
+
+describe('buildWorkspaceUrl', () => {
+  it('builds relative URLs under the workspace API base', () => {
+    expect(buildWorkspaceUrl('sources', { orgId: ORG_ID }))
+      .toBe(`${WORKSPACE_API_BASE}sources?orgId=org-1`);
+  });
+
+  it.each([
+    ['absolute URL', 'https://evil.test/x'],
+    ['absolute URL, uppercase scheme', 'HTTPS://evil.test/x'],
+    ['javascript scheme', 'javascript:alert(1)'],
+    ['protocol-relative URL', '//evil.test/x'],
+    ['rooted path (caller-supplied origin/path)', '/api/v1/ext/workspace/sources'],
+    ['parent traversal', '../secrets'],
+    ['embedded parent traversal', 'sources/../../admin'],
+    ['percent-encoded traversal', 'sources/%2e%2e/admin'],
+    ['backslash path', 'sources\\admin'],
+    ['query smuggling', 'sources/x?orgId=other'],
+    ['fragment smuggling', 'sources/x#frag'],
+  ])('refuses %s', (_label, path) => {
+    expect(() => buildWorkspaceUrl(path)).toThrowError(WorkspaceApiError);
+    try {
+      buildWorkspaceUrl(path);
+    } catch (error) {
+      expect((error as WorkspaceApiError).kind).toBe('protocol');
+    }
+  });
+});
+
+describe('createWorkspaceApi', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => jsonResponse({ sources: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('lists sources with the orgId query param and same-origin credentials', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sources: [sourceRow()] }));
+    const sources = await createWorkspaceApi().listSources(ORG_ID);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${WORKSPACE_API_BASE}sources?orgId=org-1`);
+    expect(init.credentials).toBe('same-origin');
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(sources).toHaveLength(1);
+    expect(sources[0]?.displayName).toBe('Finance Share');
+  });
+
+  it('creates a source with a JSON POST', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(sourceRow(), 201));
+    const created = await createWorkspaceApi().createSource(ORG_ID, sourceInput());
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${WORKSPACE_API_BASE}sources?orgId=org-1`);
+    expect(init.method).toBe('POST');
+    expect(new Headers(init.headers).get('content-type')).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toEqual(sourceInput());
+    expect(created.id).toBe(SOURCE_ID);
+  });
+
+  it('fetches, patches, and deletes a single source', async () => {
+    const api = createWorkspaceApi();
+    fetchMock.mockResolvedValueOnce(jsonResponse(sourceRow()));
+    await api.getSource(ORG_ID, SOURCE_ID);
+    fetchMock.mockResolvedValueOnce(jsonResponse(sourceRow({ displayName: 'Renamed' })));
+    await api.updateSource(ORG_ID, SOURCE_ID, { displayName: 'Renamed' });
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true }));
+    await api.deleteSource(ORG_ID, SOURCE_ID);
+
+    const calls = fetchMock.mock.calls as [string, RequestInit][];
+    expect(calls[0]?.[0]).toBe(`${WORKSPACE_API_BASE}sources/src-1?orgId=org-1`);
+    expect(calls[1]?.[1]?.method).toBe('PATCH');
+    expect(JSON.parse(calls[1]?.[1]?.body as string)).toEqual({ displayName: 'Renamed' });
+    expect(calls[2]?.[1]?.method).toBe('DELETE');
+    for (const [, init] of calls) {
+      expect(init.credentials).toBe('same-origin');
+    }
+  });
+
+  it('sets and clears credentials against the credential subresource', async () => {
+    const api = createWorkspaceApi();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true }));
+    await api.setCredential(ORG_ID, SOURCE_ID, { username: 'svc', password: 'p', domain: 'CORP' });
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true }));
+    await api.clearCredential(ORG_ID, SOURCE_ID);
+
+    const calls = fetchMock.mock.calls as [string, RequestInit][];
+    expect(calls[0]?.[0]).toBe(`${WORKSPACE_API_BASE}sources/src-1/credential?orgId=org-1`);
+    expect(calls[0]?.[1]?.method).toBe('PUT');
+    expect(JSON.parse(calls[0]?.[1]?.body as string))
+      .toEqual({ username: 'svc', password: 'p', domain: 'CORP' });
+    expect(calls[1]?.[0]).toBe(`${WORKSPACE_API_BASE}sources/src-1/credential?orgId=org-1`);
+    expect(calls[1]?.[1]?.method).toBe('DELETE');
+  });
+
+  it('lists crawl runs with a limit', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ runs: [] }));
+    await createWorkspaceApi().listRuns(ORG_ID, SOURCE_ID);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(`${WORKSPACE_API_BASE}sources/src-1/runs?orgId=org-1&limit=20`);
+  });
+
+  it('returns only the five aggregate device summary fields, stripping extras', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      deviceId: DEVICE_ID,
+      indexedFiles: 12,
+      visibleSources: 3,
+      lastSuccessfulCrawlAt: '2026-07-12T10:00:00.000Z',
+      lastActivityAt: '2026-07-13T11:30:00.000Z',
+      sampleFileNames: ['secret.docx'],
+      indexedPaths: ['\\\\fs01\\finance\\secret.docx'],
+    }));
+    const summary = await createWorkspaceApi().getDeviceSummary(ORG_ID, DEVICE_ID);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(`${WORKSPACE_API_BASE}devices/dev-1/summary?orgId=org-1`);
+    expect(Object.keys(summary).sort()).toEqual([
+      'deviceId',
+      'indexedFiles',
+      'lastActivityAt',
+      'lastSuccessfulCrawlAt',
+      'visibleSources',
+    ]);
+    expect(JSON.stringify(summary)).not.toContain('secret.docx');
+  });
+
+  it('refuses hostile path segments without calling fetch', async () => {
+    const api = createWorkspaceApi();
+    await expect(api.getSource(ORG_ID, '../../admin')).rejects.toMatchObject({ kind: 'protocol' });
+    await expect(api.getDeviceSummary(ORG_ID, 'dev/../../x')).rejects.toMatchObject({ kind: 'protocol' });
+    // Query/fragment smuggling through an id must die in the segment check.
+    await expect(api.getSource(ORG_ID, 'x?orgId=other')).rejects.toMatchObject({ kind: 'protocol' });
+    await expect(api.getSource(ORG_ID, 'x#frag')).rejects.toMatchObject({ kind: 'protocol' });
+    await expect(api.getSource(ORG_ID, 'x y')).rejects.toMatchObject({ kind: 'protocol' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('passes the caller AbortSignal through to fetch', async () => {
+    const controller = new AbortController();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sources: [] }));
+    await createWorkspaceApi().listSources(ORG_ID, { signal: controller.signal });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it('normalizes 400 responses and never adopts the server string as its own message', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: '<b>nope</b>' }, 400));
+    const error = await createWorkspaceApi().listSources(ORG_ID).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(WorkspaceApiError);
+    const apiError = error as WorkspaceApiError;
+    expect(apiError.kind).toBe('invalid-request');
+    expect(apiError.status).toBe(400);
+    expect(apiError.message).not.toContain('<');
+    expect(apiError.detail).toBe('<b>nope</b>');
+  });
+
+  it.each([
+    [401, 'unauthorized'],
+    [403, 'unauthorized'],
+    [404, 'not-found'],
+    [500, 'server'],
+  ])('maps HTTP %d to kind %s', async (status, kind) => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'x' }, status));
+    await expect(createWorkspaceApi().listSources(ORG_ID)).rejects.toMatchObject({ kind, status });
+  });
+
+  it('caps oversized response bodies', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('x'.repeat(MAX_RESPONSE_LENGTH + 1), { status: 200 }));
+    await expect(createWorkspaceApi().listSources(ORG_ID)).rejects.toMatchObject({ kind: 'protocol' });
+  });
+
+  it('rejects non-JSON and wrong-shape success bodies as protocol errors', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('<html>hi</html>', { status: 200 }));
+    await expect(createWorkspaceApi().listSources(ORG_ID)).rejects.toMatchObject({ kind: 'protocol' });
+    fetchMock.mockResolvedValueOnce(jsonResponse({ unexpected: true }));
+    await expect(createWorkspaceApi().listSources(ORG_ID)).rejects.toMatchObject({ kind: 'protocol' });
+  });
+
+  it('normalizes network failures without echoing the underlying message', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('ECONNREFUSED secret-host'));
+    const error = await createWorkspaceApi().listSources(ORG_ID).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(WorkspaceApiError);
+    expect((error as WorkspaceApiError).kind).toBe('network');
+    expect((error as WorkspaceApiError).message).not.toContain('secret-host');
+  });
+
+  it('maps aborts to the aborted kind', async () => {
+    fetchMock.mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'));
+    await expect(createWorkspaceApi().listSources(ORG_ID)).rejects.toMatchObject({ kind: 'aborted' });
+  });
+});

--- a/ee/workspace/src/web/api.ts
+++ b/ee/workspace/src/web/api.ts
@@ -1,0 +1,322 @@
+/**
+ * Shared safe API client for the Workspace web contributions.
+ *
+ * Every request this module issues:
+ * - resolves ONLY relative paths below the extension's own API namespace
+ *   (`/api/v1/ext/workspace/`) — callers cannot supply origins, rooted paths,
+ *   schemes, traversal, or percent-encoded segments;
+ * - sends `credentials: 'same-origin'` and nothing else;
+ * - caps response bodies before parsing;
+ * - normalizes failures into {@link WorkspaceApiError} without ever adopting a
+ *   server-supplied string as its own `message` (server text is preserved
+ *   separately on `detail` for callers that render it as textContent).
+ */
+
+export const WORKSPACE_API_BASE = '/api/v1/ext/workspace/';
+
+/** Upper bound on response text length before the body is refused. */
+export const MAX_RESPONSE_LENGTH = 1_000_000;
+
+export type WorkspaceApiErrorKind =
+  | 'protocol'
+  | 'invalid-request'
+  | 'unauthorized'
+  | 'not-found'
+  | 'server'
+  | 'network'
+  | 'aborted';
+
+const KIND_MESSAGES: Record<WorkspaceApiErrorKind, string> = {
+  protocol: 'The Workspace API returned an unexpected response.',
+  'invalid-request': 'The request was rejected as invalid.',
+  unauthorized: 'You are not authorized for this Workspace resource.',
+  'not-found': 'The Workspace resource was not found.',
+  server: 'The Workspace API failed to process the request.',
+  network: 'The Workspace API could not be reached.',
+  aborted: 'The request was aborted.',
+};
+
+export class WorkspaceApiError extends Error {
+  readonly kind: WorkspaceApiErrorKind;
+  readonly status?: number;
+  /** Server-supplied error text, if any. Render via textContent only. */
+  readonly detail?: string;
+
+  constructor(kind: WorkspaceApiErrorKind, options: { status?: number; detail?: string } = {}) {
+    super(KIND_MESSAGES[kind]);
+    this.name = 'WorkspaceApiError';
+    this.kind = kind;
+    this.status = options.status;
+    this.detail = options.detail;
+  }
+}
+
+/** One path segment interpolated from caller data (ids). */
+const SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+/** A URL scheme prefix, e.g. "https:", "javascript:". */
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+function refuse(): never {
+  throw new WorkspaceApiError('protocol');
+}
+
+function assertSegment(segment: string): string {
+  if (!SEGMENT_RE.test(segment) || segment.includes('..')) refuse();
+  return segment;
+}
+
+/**
+ * Build a same-origin URL below {@link WORKSPACE_API_BASE} from a relative
+ * path. Rejects anything that could escape the namespace: absolute URLs,
+ * schemes, protocol-relative and rooted paths, backslashes, parent traversal,
+ * and percent-encoding (extension API paths never legitimately contain '%').
+ */
+export function buildWorkspaceUrl(path: string, params?: Record<string, string>): string {
+  if (
+    path.length === 0
+    || path.startsWith('/')
+    || path.includes('\\')
+    || path.includes('%')
+    || path.includes('..')
+    // '?' and '#' in the path would smuggle query params or truncate the
+    // ones this client appends (e.g. an id of "x?orgId=other").
+    || path.includes('?')
+    || path.includes('#')
+    || SCHEME_RE.test(path)
+  ) {
+    refuse();
+  }
+  for (const segment of path.split('/')) {
+    if (segment.length === 0) refuse();
+  }
+  const query = params ? `?${new URLSearchParams(params).toString()}` : '';
+  return `${WORKSPACE_API_BASE}${path}${query}`;
+}
+
+/** Wire shape of a source row as `publicSource` (src/routes/sources.ts) emits it. */
+export interface SourceRow {
+  id: string;
+  orgId: string;
+  kind: string;
+  displayName: string;
+  rootPath: string;
+  crawlDeviceId: string | null;
+  visibilityGroupIds: string[];
+  crawlCadenceMinutes: number;
+  excludeGlobs: string[];
+  watch: boolean;
+  status: string;
+  errorReason: string | null;
+  lastCompleteRunAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  hasCredential: boolean;
+}
+
+export interface SourceInput {
+  kind: string;
+  displayName: string;
+  rootPath: string;
+  crawlDeviceId?: string | null;
+  visibilityGroupIds?: string[];
+  crawlCadenceMinutes?: number;
+  excludeGlobs?: string[];
+  watch?: boolean;
+  status?: string;
+}
+
+export interface CredentialInput {
+  username: string;
+  password: string;
+  domain?: string;
+}
+
+export interface CrawlRunRow {
+  id: string;
+  sourceId: string;
+  deviceId: string | null;
+  status: string;
+  startedAt: string | null;
+  lastActivityAt: string | null;
+  completedAt: string | null;
+  stats: Record<string, unknown> | null;
+  errorReason: string | null;
+}
+
+/** The five aggregate fields — never widened (no filenames, no paths). */
+export interface DeviceSummary {
+  deviceId: string;
+  indexedFiles: number;
+  visibleSources: number;
+  lastSuccessfulCrawlAt: string | null;
+  lastActivityAt: string | null;
+}
+
+export interface RequestOptions {
+  signal?: AbortSignal;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function request(
+  url: string,
+  init: { method?: string; body?: unknown; signal?: AbortSignal } = {},
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: init.method ?? 'GET',
+      credentials: 'same-origin',
+      signal: init.signal,
+      ...(init.body !== undefined
+        ? {
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(init.body),
+        }
+        : {}),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new WorkspaceApiError('aborted');
+    }
+    // Never echo the underlying failure text — it can carry hosts/paths.
+    throw new WorkspaceApiError('network');
+  }
+
+  const text = await response.text();
+  if (text.length > MAX_RESPONSE_LENGTH) refuse();
+
+  let body: unknown;
+  try {
+    body = text.length === 0 ? {} : JSON.parse(text);
+  } catch {
+    if (response.ok) refuse();
+    body = {};
+  }
+
+  if (!response.ok) {
+    const detail = isRecord(body) && typeof body.error === 'string' ? body.error : undefined;
+    const kind: WorkspaceApiErrorKind = response.status === 400
+      ? 'invalid-request'
+      : response.status === 401 || response.status === 403
+        ? 'unauthorized'
+        : response.status === 404
+          ? 'not-found'
+          : 'server';
+    throw new WorkspaceApiError(kind, { status: response.status, detail });
+  }
+
+  return body;
+}
+
+function expectRecord(body: unknown): Record<string, unknown> {
+  if (!isRecord(body)) refuse();
+  return body;
+}
+
+function expectSourceRow(body: unknown): SourceRow {
+  const record = expectRecord(body);
+  if (typeof record.id !== 'string' || typeof record.displayName !== 'string') refuse();
+  return record as unknown as SourceRow;
+}
+
+export function createWorkspaceApi() {
+  return {
+    async listSources(orgId: string, options: RequestOptions = {}): Promise<SourceRow[]> {
+      const body = expectRecord(await request(
+        buildWorkspaceUrl('sources', { orgId }),
+        { signal: options.signal },
+      ));
+      if (!Array.isArray(body.sources)) refuse();
+      return body.sources.map(expectSourceRow);
+    },
+
+    async createSource(orgId: string, input: SourceInput, options: RequestOptions = {}): Promise<SourceRow> {
+      return expectSourceRow(await request(
+        buildWorkspaceUrl('sources', { orgId }),
+        { method: 'POST', body: input, signal: options.signal },
+      ));
+    },
+
+    async getSource(orgId: string, id: string, options: RequestOptions = {}): Promise<SourceRow> {
+      return expectSourceRow(await request(
+        buildWorkspaceUrl(`sources/${assertSegment(id)}`, { orgId }),
+        { signal: options.signal },
+      ));
+    },
+
+    async updateSource(
+      orgId: string,
+      id: string,
+      patch: Partial<SourceInput>,
+      options: RequestOptions = {},
+    ): Promise<SourceRow> {
+      return expectSourceRow(await request(
+        buildWorkspaceUrl(`sources/${assertSegment(id)}`, { orgId }),
+        { method: 'PATCH', body: patch, signal: options.signal },
+      ));
+    },
+
+    async deleteSource(orgId: string, id: string, options: RequestOptions = {}): Promise<void> {
+      expectRecord(await request(
+        buildWorkspaceUrl(`sources/${assertSegment(id)}`, { orgId }),
+        { method: 'DELETE', signal: options.signal },
+      ));
+    },
+
+    async setCredential(
+      orgId: string,
+      id: string,
+      credential: CredentialInput,
+      options: RequestOptions = {},
+    ): Promise<void> {
+      expectRecord(await request(
+        buildWorkspaceUrl(`sources/${assertSegment(id)}/credential`, { orgId }),
+        { method: 'PUT', body: credential, signal: options.signal },
+      ));
+    },
+
+    async clearCredential(orgId: string, id: string, options: RequestOptions = {}): Promise<void> {
+      expectRecord(await request(
+        buildWorkspaceUrl(`sources/${assertSegment(id)}/credential`, { orgId }),
+        { method: 'DELETE', signal: options.signal },
+      ));
+    },
+
+    async listRuns(orgId: string, sourceId: string, options: RequestOptions = {}): Promise<CrawlRunRow[]> {
+      const body = expectRecord(await request(
+        buildWorkspaceUrl(`sources/${assertSegment(sourceId)}/runs`, { orgId, limit: '20' }),
+        { signal: options.signal },
+      ));
+      if (!Array.isArray(body.runs)) refuse();
+      return body.runs as CrawlRunRow[];
+    },
+
+    async getDeviceSummary(
+      orgId: string,
+      deviceId: string,
+      options: RequestOptions = {},
+    ): Promise<DeviceSummary> {
+      const record = expectRecord(await request(
+        buildWorkspaceUrl(`devices/${assertSegment(deviceId)}/summary`, { orgId }),
+        { signal: options.signal },
+      ));
+      if (typeof record.deviceId !== 'string') refuse();
+      // Explicit aggregate-only projection: extra fields in the response are
+      // dropped here, mirroring the server's own projection boundary.
+      return {
+        deviceId: record.deviceId,
+        indexedFiles: Number(record.indexedFiles ?? 0),
+        visibleSources: Number(record.visibleSources ?? 0),
+        lastSuccessfulCrawlAt: typeof record.lastSuccessfulCrawlAt === 'string'
+          ? record.lastSuccessfulCrawlAt
+          : null,
+        lastActivityAt: typeof record.lastActivityAt === 'string' ? record.lastActivityAt : null,
+      };
+    },
+  };
+}
+
+export type WorkspaceApi = ReturnType<typeof createWorkspaceApi>;

--- a/ee/workspace/src/web/baseElement.ts
+++ b/ee/workspace/src/web/baseElement.ts
@@ -1,0 +1,96 @@
+/**
+ * Base class for Workspace Custom Elements.
+ *
+ * Provides the three host-contract behaviors every element needs:
+ * - a Shadow DOM root with the shared stylesheet;
+ * - an `updateComplete` promise that settles when the current render/fetch
+ *   cycle does (the host and tests await it);
+ * - an AbortSignal that is aborted on disconnect so in-flight fetches never
+ *   outlive the element.
+ *
+ * Rendering rule (load-bearing): API-derived strings reach the DOM only via
+ * `textContent` (see `el()`); nothing in a subclass may assign `innerHTML`
+ * from data.
+ */
+import { WORKSPACE_STYLES } from './styles';
+
+export abstract class WorkspaceBaseElement extends HTMLElement {
+  protected readonly root: ShadowRoot;
+  #abort = new AbortController();
+  #updateComplete: Promise<void> = Promise.resolve();
+
+  constructor() {
+    super();
+    this.root = this.attachShadow({ mode: 'open' });
+    const style = document.createElement('style');
+    style.textContent = WORKSPACE_STYLES;
+    this.root.append(style);
+  }
+
+  /** Settles when the in-flight render/fetch cycle does. Never rejects. */
+  get updateComplete(): Promise<void> {
+    return this.#updateComplete;
+  }
+
+  /** Register the current async cycle as the one `updateComplete` awaits. */
+  protected track(cycle: Promise<void>): void {
+    this.#updateComplete = cycle.then(
+      () => undefined,
+      () => undefined,
+    );
+  }
+
+  /** Abort signal tied to element lifetime; fresh again after a reconnect. */
+  protected get signal(): AbortSignal {
+    if (this.#abort.signal.aborted) this.#abort = new AbortController();
+    return this.#abort.signal;
+  }
+
+  disconnectedCallback(): void {
+    this.#abort.abort();
+  }
+
+  /** Remove everything but the stylesheet. */
+  protected clearContent(): void {
+    for (const child of [...this.root.children]) {
+      if (child.tagName !== 'STYLE') child.remove();
+    }
+  }
+
+  /**
+   * The one DOM construction helper: strings become `textContent`, never
+   * markup.
+   */
+  protected el<K extends keyof HTMLElementTagNameMap>(
+    tag: K,
+    props: { text?: string; className?: string; attrs?: Record<string, string> } = {},
+    children: Array<Node | string> = [],
+  ): HTMLElementTagNameMap[K] {
+    const node = document.createElement(tag);
+    if (props.text !== undefined) node.textContent = props.text;
+    if (props.className !== undefined) node.className = props.className;
+    for (const [name, value] of Object.entries(props.attrs ?? {})) {
+      node.setAttribute(name, value);
+    }
+    for (const child of children) {
+      node.append(typeof child === 'string' ? document.createTextNode(child) : child);
+    }
+    return node;
+  }
+
+  protected renderStatus(message: string): void {
+    this.clearContent();
+    this.root.append(this.el('p', { text: message, attrs: { role: 'status' } }));
+  }
+
+  protected renderError(message: string, onRetry?: () => void): void {
+    this.clearContent();
+    const alert = this.el('p', { text: message, className: 'error', attrs: { role: 'alert' } });
+    this.root.append(alert);
+    if (onRetry) {
+      const retry = this.el('button', { text: 'Retry', attrs: { type: 'button' } });
+      retry.addEventListener('click', onRetry);
+      this.root.append(retry);
+    }
+  }
+}

--- a/ee/workspace/src/web/deviceIndex.test.ts
+++ b/ee/workspace/src/web/deviceIndex.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EXTENSION_HOST_EVENT_NAME, type ExtensionHostEventV1 } from '@breeze/extension-web-sdk';
+import { defineWorkspaceElements, WorkspaceDeviceIndex } from './index';
+import { WORKSPACE_API_BASE } from './api';
+
+const ORG_ID = 'org-1';
+const DEVICE_ID = 'dev-1';
+
+function tabContext(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    contractVersion: 1,
+    deviceId: DEVICE_ID,
+    organizationId: ORG_ID,
+    siteId: 'site-1',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function summary(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    deviceId: DEVICE_ID,
+    indexedFiles: 12,
+    visibleSources: 3,
+    lastSuccessfulCrawlAt: '2026-07-12T10:00:00.000Z',
+    lastActivityAt: '2026-07-13T11:30:00.000Z',
+    ...overrides,
+  };
+}
+
+async function mountTab(context: Record<string, unknown> = tabContext()): Promise<WorkspaceDeviceIndex> {
+  const element = document.createElement('workspace-device-index') as WorkspaceDeviceIndex;
+  document.body.append(element);
+  element.context = context;
+  await element.updateComplete;
+  return element;
+}
+
+describe('workspace-device-index', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let hostEvents: ExtensionHostEventV1[];
+  const captureEvent = (event: Event): void => {
+    hostEvents.push((event as CustomEvent).detail as ExtensionHostEventV1);
+  };
+
+  beforeEach(() => {
+    defineWorkspaceElements();
+    fetchMock = vi.fn(async () => jsonResponse(summary()));
+    vi.stubGlobal('fetch', fetchMock);
+    hostEvents = [];
+    document.addEventListener(EXTENSION_HOST_EVENT_NAME, captureEvent);
+  });
+
+  afterEach(() => {
+    document.removeEventListener(EXTENSION_HOST_EVENT_NAME, captureEvent);
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches the aggregate summary for the device in context', async () => {
+    await mountTab();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${WORKSPACE_API_BASE}devices/${DEVICE_ID}/summary?orgId=${ORG_ID}`);
+    expect(init.credentials).toBe('same-origin');
+  });
+
+  it('renders only aggregate device indexing data', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(summary({
+      sampleFileNames: ['secret.docx'],
+      indexedPaths: ['\\\\fs01\\finance\\secret.docx'],
+    })));
+    const element = await mountTab();
+    const text = element.shadowRoot?.textContent ?? '';
+    expect(text).toContain('12 indexed files');
+    expect(text).toContain('3 visible sources');
+    expect(text).not.toContain('secret.docx');
+  });
+
+  it.each([
+    ['missing deviceId', tabContext({ deviceId: undefined })],
+    ['wrong contract version', tabContext({ contractVersion: 2 })],
+    ['extra fields (strict schema)', tabContext({ extra: 1 })],
+  ])('renders an error and makes no network call for a malformed context: %s', async (_label, context) => {
+    const element = await mountTab(context as Record<string, unknown>);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(element.shadowRoot?.querySelector('[role="alert"]')?.textContent)
+      .toContain('invalid host context');
+  });
+
+  it('renders a quiet empty state when the device has no index (404)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'Device not found' }, 404));
+    const element = await mountTab();
+    expect(element.shadowRoot?.querySelector('[role="status"]')?.textContent)
+      .toContain('no Workspace index');
+  });
+
+  it('shows an unauthorized message on 403 without echoing server text', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: '<b>forbidden</b>' }, 403));
+    const element = await mountTab();
+    const alert = element.shadowRoot?.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('not authorized');
+    expect(element.shadowRoot?.querySelector('b')).toBeNull();
+  });
+
+  it('navigates to the sources page through the typed host event', async () => {
+    const element = await mountTab();
+    [...element.shadowRoot!.querySelectorAll('button')]
+      .find((b) => b.textContent === 'Manage sources')!
+      .click();
+    expect(hostEvents).toContainEqual({
+      version: 1, type: 'navigate', path: '/extensions/workspace/sources',
+    });
+  });
+
+  it('aborts the in-flight request when disconnected', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      capturedSignal = init.signal as AbortSignal;
+      return new Promise<Response>(() => {});
+    });
+    const element = document.createElement('workspace-device-index') as WorkspaceDeviceIndex;
+    document.body.append(element);
+    element.context = tabContext();
+    expect(capturedSignal).toBeDefined();
+    element.remove();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  it('defines elements idempotently across repeated entry evaluation', () => {
+    expect(() => {
+      defineWorkspaceElements();
+      defineWorkspaceElements();
+    }).not.toThrow();
+  });
+});

--- a/ee/workspace/src/web/deviceIndex.ts
+++ b/ee/workspace/src/web/deviceIndex.ts
@@ -1,0 +1,91 @@
+/**
+ * <workspace-device-index> — the Workspace tab on a device's detail page.
+ *
+ * Renders ONLY the five aggregate fields the device-summary endpoint exposes.
+ * Never widen this to filenames, paths, or credential state — the server's
+ * projection and the API client's projection both enforce the same boundary,
+ * and this element is the third copy of that rule.
+ */
+import {
+  parseDeviceDetailTabContextV1,
+  dispatchExtensionHostEvent,
+  type DeviceDetailTabContextV1,
+} from '@breeze/extension-web-sdk';
+import { createWorkspaceApi, WorkspaceApiError, type WorkspaceApi } from './api';
+import { WorkspaceBaseElement } from './baseElement';
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'never';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'never' : date.toLocaleString();
+}
+
+export class WorkspaceDeviceIndex extends WorkspaceBaseElement {
+  #api: WorkspaceApi = createWorkspaceApi();
+  #context: DeviceDetailTabContextV1 | null = null;
+
+  set context(value: unknown) {
+    let parsed: DeviceDetailTabContextV1;
+    try {
+      parsed = parseDeviceDetailTabContextV1(value);
+    } catch {
+      this.#context = null;
+      // Malformed host context: render the failure, make NO network call.
+      this.renderError('Workspace received an invalid host context.');
+      return;
+    }
+    this.#context = parsed;
+    this.track(this.#load());
+  }
+
+  get context(): DeviceDetailTabContextV1 | null {
+    return this.#context;
+  }
+
+  async #load(): Promise<void> {
+    if (!this.#context) return;
+    this.renderStatus('Loading device index…');
+    let summary;
+    try {
+      summary = await this.#api.getDeviceSummary(
+        this.#context.organizationId,
+        this.#context.deviceId,
+        { signal: this.signal },
+      );
+    } catch (error) {
+      if (error instanceof WorkspaceApiError && error.kind === 'aborted') return;
+      if (error instanceof WorkspaceApiError && error.kind === 'not-found') {
+        this.clearContent();
+        this.root.append(this.el('p', {
+          text: 'This device has no Workspace index yet.',
+          className: 'muted',
+          attrs: { role: 'status' },
+        }));
+        return;
+      }
+      const message = error instanceof WorkspaceApiError && error.kind === 'unauthorized'
+        ? 'You are not authorized to view this device’s Workspace index.'
+        : 'The Workspace index for this device could not be loaded.';
+      this.renderError(message, () => this.track(this.#load()));
+      return;
+    }
+
+    this.clearContent();
+    const stats = this.el('ul', { className: 'stats' }, [
+      this.el('li', { text: `${summary.indexedFiles} indexed files` }),
+      this.el('li', { text: `${summary.visibleSources} visible sources` }),
+      this.el('li', { text: `Last successful crawl: ${formatTimestamp(summary.lastSuccessfulCrawlAt)}` }),
+      this.el('li', { text: `Last activity: ${formatTimestamp(summary.lastActivityAt)}` }),
+    ]);
+    const manage = this.el('button', { text: 'Manage sources', attrs: { type: 'button' } });
+    manage.addEventListener('click', () => {
+      // Navigation goes through the typed host event — never window.location.
+      dispatchExtensionHostEvent(this, {
+        version: 1,
+        type: 'navigate',
+        path: '/extensions/workspace/sources',
+      });
+    });
+    this.root.append(this.el('h2', { text: 'Workspace index' }), stats, manage);
+  }
+}

--- a/ee/workspace/src/web/index.ts
+++ b/ee/workspace/src/web/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Workspace web entry: registers both Custom Elements, idempotently.
+ *
+ * This module has no side effects beyond element definitions — no API calls,
+ * no timers, no DOM mutation. The host may load the entry more than once
+ * (see the testkit's web idempotency probe), so every definition is guarded
+ * by customElements.get().
+ */
+import { WorkspaceDeviceIndex } from './deviceIndex';
+import { WorkspaceSourcesPage } from './sourcesPage';
+
+export function defineWorkspaceElements(): void {
+  if (!customElements.get('workspace-sources-page')) {
+    customElements.define('workspace-sources-page', WorkspaceSourcesPage);
+  }
+  if (!customElements.get('workspace-device-index')) {
+    customElements.define('workspace-device-index', WorkspaceDeviceIndex);
+  }
+}
+
+defineWorkspaceElements();
+
+export { WorkspaceSourcesPage } from './sourcesPage';
+export { WorkspaceDeviceIndex } from './deviceIndex';

--- a/ee/workspace/src/web/sourcesPage.test.ts
+++ b/ee/workspace/src/web/sourcesPage.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EXTENSION_HOST_EVENT_NAME, type ExtensionHostEventV1 } from '@breeze/extension-web-sdk';
+import { defineWorkspaceElements, WorkspaceSourcesPage } from './index';
+import { WORKSPACE_API_BASE } from './api';
+
+const ORG_ID = 'org-1';
+
+function pageContext(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    contractVersion: 1,
+    extensionName: 'workspace',
+    path: '/extensions/workspace/sources',
+    organizationId: ORG_ID,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function sourceRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'src-1',
+    orgId: ORG_ID,
+    kind: 'smb_share',
+    displayName: 'Finance Share',
+    rootPath: '\\\\fs01\\finance',
+    crawlDeviceId: 'dev-9',
+    visibilityGroupIds: [],
+    crawlCadenceMinutes: 1440,
+    excludeGlobs: [],
+    watch: true,
+    status: 'active',
+    errorReason: null,
+    lastCompleteRunAt: '2026-07-12T10:00:00.000Z',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-10T00:00:00.000Z',
+    hasCredential: true,
+    ...overrides,
+  };
+}
+
+async function mountPage(context: Record<string, unknown> = pageContext()): Promise<WorkspaceSourcesPage> {
+  const element = document.createElement('workspace-sources-page') as WorkspaceSourcesPage;
+  document.body.append(element);
+  element.context = context;
+  await element.updateComplete;
+  return element;
+}
+
+function shadowText(element: HTMLElement): string {
+  return element.shadowRoot?.textContent ?? '';
+}
+
+describe('workspace-sources-page', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let hostEvents: ExtensionHostEventV1[];
+  const captureEvent = (event: Event): void => {
+    hostEvents.push((event as CustomEvent).detail as ExtensionHostEventV1);
+  };
+
+  beforeEach(() => {
+    defineWorkspaceElements();
+    fetchMock = vi.fn(async () => jsonResponse({ sources: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+    hostEvents = [];
+    document.addEventListener(EXTENSION_HOST_EVENT_NAME, captureEvent);
+  });
+
+  afterEach(() => {
+    document.removeEventListener(EXTENSION_HOST_EVENT_NAME, captureEvent);
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+  });
+
+  it('loads sources for the host organization context', async () => {
+    await mountPage();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${WORKSPACE_API_BASE}sources?orgId=${ORG_ID}`);
+    expect(init.credentials).toBe('same-origin');
+  });
+
+  it.each([
+    ['missing organizationId', pageContext({ organizationId: undefined })],
+    ['wrong contract version', pageContext({ contractVersion: 2 })],
+    ['extra fields (strict schema)', pageContext({ extra: true })],
+    ['not an object', 'nope'],
+  ])('renders an error and makes no network call for a malformed context: %s', async (_label, context) => {
+    const element = await mountPage(context as Record<string, unknown>);
+    expect(fetchMock).not.toHaveBeenCalled();
+    const alert = element.shadowRoot?.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('invalid host context');
+  });
+
+  it('renders source rows as inert text, never as markup', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      sources: [sourceRow({ displayName: '<img src=x onerror="window.pwned=1">' })],
+    }));
+    const element = await mountPage();
+    expect(element.shadowRoot?.querySelector('img')).toBeNull();
+    expect(shadowText(element)).toContain('<img src=x onerror="window.pwned=1">');
+    expect((window as unknown as Record<string, unknown>).pwned).toBeUndefined();
+  });
+
+  it('shows an accessible empty state', async () => {
+    const element = await mountPage();
+    const status = element.shadowRoot?.querySelector('[role="status"]');
+    expect(status?.textContent).toContain('No sources yet');
+  });
+
+  it('shows an unauthorized message on 403', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'forbidden' }, 403));
+    const element = await mountPage();
+    const alert = element.shadowRoot?.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('not authorized');
+  });
+
+  it('offers retry after a server error, and retry refetches', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500));
+    const element = await mountPage();
+    const retry = [...element.shadowRoot!.querySelectorAll('button')]
+      .find((b) => b.textContent === 'Retry');
+    expect(retry).toBeDefined();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sources: [sourceRow()] }));
+    retry!.click();
+    await element.updateComplete;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(shadowText(element)).toContain('Finance Share');
+  });
+
+  it('creates a source, sets its credential, clears the secret fields, and emits a success toast', async () => {
+    const element = await mountPage();
+    const addButton = [...element.shadowRoot!.querySelectorAll('button')]
+      .find((b) => b.textContent === 'Add source')!;
+    addButton.click();
+    const form = element.shadowRoot!.querySelector('form')!;
+    const setField = (name: string, value: string): void => {
+      (form.querySelector(`[name="${name}"]`) as HTMLInputElement).value = value;
+    };
+    setField('displayName', 'Ops Share');
+    setField('rootPath', '\\\\fs02\\ops');
+    setField('crawlDeviceId', 'dev-2');
+    setField('credentialUsername', 'svc-crawl');
+    setField('credentialPassword', 'hunter2');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(sourceRow({ id: 'src-2', displayName: 'Ops Share' }), 201));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sources: [sourceRow({ id: 'src-2', displayName: 'Ops Share' })] }));
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await element.updateComplete;
+
+    const calls = fetchMock.mock.calls as [string, RequestInit][];
+    expect(calls[1]?.[0]).toBe(`${WORKSPACE_API_BASE}sources?orgId=${ORG_ID}`);
+    expect(calls[1]?.[1]?.method).toBe('POST');
+    const created = JSON.parse(calls[1]?.[1]?.body as string) as Record<string, unknown>;
+    expect(created.displayName).toBe('Ops Share');
+    // The server's create schema is strict AND total — these must be present
+    // or every real create 400s (mocked fetch cannot catch that).
+    expect(created).toMatchObject({
+      kind: 'smb_share', visibilityGroupIds: [], excludeGlobs: [], watch: true, status: 'active',
+    });
+    // The credential travels on the credential subresource, never the source body.
+    expect(created).not.toHaveProperty('credential');
+    expect(created).not.toHaveProperty('credentialPassword');
+    expect(calls[2]?.[0]).toBe(`${WORKSPACE_API_BASE}sources/src-2/credential?orgId=${ORG_ID}`);
+    expect(calls[2]?.[1]?.method).toBe('PUT');
+    expect(JSON.parse(calls[2]?.[1]?.body as string)).toEqual({ username: 'svc-crawl', password: 'hunter2' });
+
+    expect(hostEvents).toContainEqual({
+      version: 1, type: 'toast', tone: 'success', message: 'Source created.',
+    });
+    // Secrets must not survive after submit — not in the live DOM, and not in
+    // the (now detached) form either: a detached node still holds its values
+    // for anything retaining a reference to it.
+    expect((form.querySelector('[name="credentialPassword"]') as HTMLInputElement).value).toBe('');
+    expect((form.querySelector('[name="credentialUsername"]') as HTMLInputElement).value).toBe('');
+    for (const input of element.shadowRoot!.querySelectorAll('input')) {
+      expect(input.value).not.toBe('hunter2');
+      expect(input.value).not.toBe('svc-crawl');
+    }
+    expect(shadowText(element)).not.toContain('hunter2');
+  });
+
+  it('clears credential fields and emits an error toast when the save fails', async () => {
+    const element = await mountPage();
+    [...element.shadowRoot!.querySelectorAll('button')]
+      .find((b) => b.textContent === 'Add source')!
+      .click();
+    const form = element.shadowRoot!.querySelector('form')!;
+    (form.querySelector('[name="displayName"]') as HTMLInputElement).value = 'X';
+    (form.querySelector('[name="rootPath"]') as HTMLInputElement).value = '\\\\fs\\x';
+    (form.querySelector('[name="credentialPassword"]') as HTMLInputElement).value = 'hunter2';
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'nope' }, 400));
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await element.updateComplete;
+    expect(hostEvents).toContainEqual({
+      version: 1, type: 'toast', tone: 'error', message: 'Source creation failed.',
+    });
+    expect((form.querySelector('[name="credentialPassword"]') as HTMLInputElement).value).toBe('');
+  });
+
+  it('preserves typed form input — including the credential — across a Kind switch', async () => {
+    const element = await mountPage();
+    [...element.shadowRoot!.querySelectorAll('button')]
+      .find((b) => b.textContent === 'Add source')!
+      .click();
+    let form = element.shadowRoot!.querySelector('form')!;
+    const setField = (name: string, value: string): void => {
+      (form.querySelector(`[name="${name}"]`) as HTMLInputElement).value = value;
+    };
+    setField('displayName', 'Ops Share');
+    setField('rootPath', '\\\\fs02\\ops');
+    setField('crawlDeviceId', 'dev-2');
+    setField('credentialUsername', 'svc-crawl');
+    setField('credentialPassword', 'hunter2');
+
+    const kindSelect = form.querySelector('[name="kind"]') as HTMLSelectElement;
+    kindSelect.value = 'local_profile';
+    kindSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    form = element.shadowRoot!.querySelector('form')!;
+    // Shared fields survive the switch away from smb_share…
+    expect((form.querySelector('[name="displayName"]') as HTMLInputElement).value).toBe('Ops Share');
+    expect((form.querySelector('[name="rootPath"]') as HTMLInputElement).value).toBe('\\\\fs02\\ops');
+
+    const back = form.querySelector('[name="kind"]') as HTMLSelectElement;
+    back.value = 'smb_share';
+    back.dispatchEvent(new Event('change', { bubbles: true }));
+    form = element.shadowRoot!.querySelector('form')!;
+    // …and the SMB fields, credential included, are back after returning.
+    expect((form.querySelector('[name="displayName"]') as HTMLInputElement).value).toBe('Ops Share');
+    expect((form.querySelector('[name="crawlDeviceId"]') as HTMLInputElement).value).toBe('dev-2');
+    expect((form.querySelector('[name="credentialUsername"]') as HTMLInputElement).value).toBe('svc-crawl');
+    expect((form.querySelector('[name="credentialPassword"]') as HTMLInputElement).value).toBe('hunter2');
+
+    // Reopening the form starts clean — the draft must not leak the secret
+    // into a fresh create flow.
+    const addButton = [...element.shadowRoot!.querySelectorAll('button')]
+      .find((b) => b.textContent === 'Add source')!;
+    addButton.click(); // close
+    addButton.click(); // reopen
+    form = element.shadowRoot!.querySelector('form')!;
+    expect((form.querySelector('[name="credentialPassword"]') as HTMLInputElement).value).toBe('');
+    expect((form.querySelector('[name="displayName"]') as HTMLInputElement).value).toBe('');
+  });
+
+  it('deletes only after explicit confirmation', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sources: [sourceRow()] }));
+    const element = await mountPage();
+    const del = [...element.shadowRoot!.querySelectorAll('button')]
+      .find((b) => b.textContent === 'Delete')!;
+    del.click();
+    // No DELETE yet — confirmation required first.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true }));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sources: [] }));
+    const confirm = [...element.shadowRoot!.querySelectorAll('button')]
+      .find((b) => b.textContent === 'Confirm delete')!;
+    confirm.click();
+    await element.updateComplete;
+    const calls = fetchMock.mock.calls as [string, RequestInit][];
+    expect(calls[1]?.[0]).toBe(`${WORKSPACE_API_BASE}sources/src-1?orgId=${ORG_ID}`);
+    expect(calls[1]?.[1]?.method).toBe('DELETE');
+    expect(hostEvents).toContainEqual({
+      version: 1, type: 'toast', tone: 'success', message: 'Source deleted.',
+    });
+  });
+
+  it('aborts the in-flight request when disconnected', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+      capturedSignal = init.signal as AbortSignal;
+      return new Promise<Response>(() => {}); // never resolves
+    });
+    const element = document.createElement('workspace-sources-page') as WorkspaceSourcesPage;
+    document.body.append(element);
+    element.context = pageContext();
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+    element.remove();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+});

--- a/ee/workspace/src/web/sourcesPage.ts
+++ b/ee/workspace/src/web/sourcesPage.ts
@@ -1,0 +1,322 @@
+/**
+ * <workspace-sources-page> — the Workspace sources administration page.
+ *
+ * The host assigns `context` (ExtensionPageContextV1); everything else is
+ * fetched through the safe API client. All API data reaches the DOM as
+ * textContent via `el()` — never markup. Mutations announce themselves to the
+ * host through typed toast events.
+ */
+import {
+  parseExtensionPageContextV1,
+  dispatchExtensionHostEvent,
+  type ExtensionPageContextV1,
+} from '@breeze/extension-web-sdk';
+import {
+  createWorkspaceApi,
+  WorkspaceApiError,
+  type SourceInput,
+  type SourceRow,
+  type WorkspaceApi,
+} from './api';
+import { WorkspaceBaseElement } from './baseElement';
+
+type FormMode =
+  | { kind: 'closed' }
+  | { kind: 'create' }
+  | { kind: 'edit'; source: SourceRow };
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return 'never';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? 'never' : date.toLocaleString();
+}
+
+export class WorkspaceSourcesPage extends WorkspaceBaseElement {
+  #api: WorkspaceApi = createWorkspaceApi();
+  #context: ExtensionPageContextV1 | null = null;
+  #sources: SourceRow[] = [];
+  #form: FormMode = { kind: 'closed' };
+  #confirmingDelete: string | null = null;
+  #formKind = 'smb_share';
+  /**
+   * Live field values captured before a mid-edit re-render (the Kind switch
+   * rebuilds the form). Without this, toggling Kind silently wiped every
+   * typed value — including a credential, which then never reached
+   * setCredential and the source saved credential-less under a success toast.
+   */
+  #draft: Record<string, string> | null = null;
+
+  set context(value: unknown) {
+    let parsed: ExtensionPageContextV1;
+    try {
+      parsed = parseExtensionPageContextV1(value);
+    } catch {
+      this.#context = null;
+      // Malformed host context: render the failure, make NO network call.
+      this.renderError('Workspace received an invalid host context.');
+      return;
+    }
+    this.#context = parsed;
+    this.track(this.#load());
+  }
+
+  get context(): ExtensionPageContextV1 | null {
+    return this.#context;
+  }
+
+  async #load(): Promise<void> {
+    if (!this.#context) return;
+    this.renderStatus('Loading sources…');
+    try {
+      this.#sources = await this.#api.listSources(this.#context.organizationId, {
+        signal: this.signal,
+      });
+    } catch (error) {
+      if (error instanceof WorkspaceApiError && error.kind === 'aborted') return;
+      const message = error instanceof WorkspaceApiError && error.kind === 'unauthorized'
+        ? 'You are not authorized to manage Workspace sources.'
+        : 'Workspace sources could not be loaded.';
+      this.renderError(message, () => this.track(this.#load()));
+      return;
+    }
+    this.#render();
+  }
+
+  #toast(tone: 'success' | 'error', message: string): void {
+    dispatchExtensionHostEvent(this, { version: 1, type: 'toast', tone, message });
+  }
+
+  #render(): void {
+    this.clearContent();
+    const heading = this.el('h1', { text: 'Workspace Sources' });
+    const addButton = this.el('button', { text: 'Add source', attrs: { type: 'button' } });
+    addButton.addEventListener('click', () => {
+      this.#form = this.#form.kind === 'create' ? { kind: 'closed' } : { kind: 'create' };
+      this.#formKind = 'smb_share';
+      this.#draft = null;
+      this.#render();
+    });
+    this.root.append(heading, addButton);
+
+    if (this.#form.kind !== 'closed') this.root.append(this.#renderForm());
+
+    if (this.#sources.length === 0) {
+      this.root.append(this.el('p', {
+        text: 'No sources yet. Add one to start indexing.',
+        className: 'muted',
+        attrs: { role: 'status' },
+      }));
+      return;
+    }
+    this.root.append(this.#renderTable());
+  }
+
+  #renderTable(): HTMLTableElement {
+    const head = this.el('tr', {}, [
+      this.el('th', { text: 'Name' }),
+      this.el('th', { text: 'Kind' }),
+      this.el('th', { text: 'Path' }),
+      this.el('th', { text: 'Status' }),
+      this.el('th', { text: 'Last crawl' }),
+      this.el('th', { text: 'Credential' }),
+      this.el('th', { text: 'Actions' }),
+    ]);
+    const rows = this.#sources.map((source) => this.#renderRow(source));
+    return this.el('table', {}, [this.el('thead', {}, [head]), this.el('tbody', {}, rows)]);
+  }
+
+  #renderRow(source: SourceRow): HTMLTableRowElement {
+    const actions = this.el('div', { className: 'row-actions' });
+    if (this.#confirmingDelete === source.id) {
+      const confirm = this.el('button', {
+        text: 'Confirm delete',
+        className: 'danger',
+        attrs: { type: 'button' },
+      });
+      confirm.addEventListener('click', () => this.track(this.#deleteSource(source)));
+      const cancel = this.el('button', { text: 'Cancel', attrs: { type: 'button' } });
+      cancel.addEventListener('click', () => {
+        this.#confirmingDelete = null;
+        this.#render();
+      });
+      actions.append(confirm, cancel);
+    } else {
+      const edit = this.el('button', { text: 'Edit', attrs: { type: 'button' } });
+      edit.addEventListener('click', () => {
+        this.#form = { kind: 'edit', source };
+        this.#formKind = source.kind;
+        this.#draft = null;
+        this.#render();
+      });
+      const remove = this.el('button', {
+        text: 'Delete',
+        className: 'danger',
+        attrs: { type: 'button' },
+      });
+      remove.addEventListener('click', () => {
+        this.#confirmingDelete = source.id;
+        this.#render();
+      });
+      actions.append(edit, remove);
+    }
+
+    const status = source.errorReason ? `${source.status} (error)` : source.status;
+    return this.el('tr', {}, [
+      this.el('td', { text: source.displayName }),
+      this.el('td', { text: source.kind }),
+      this.el('td', { text: source.rootPath }),
+      this.el('td', { text: status }),
+      this.el('td', { text: formatTimestamp(source.lastCompleteRunAt) }),
+      this.el('td', { text: source.hasCredential ? 'set' : 'none' }),
+      this.el('td', {}, [actions]),
+    ]);
+  }
+
+  #renderForm(): HTMLFormElement {
+    const editing = this.#form.kind === 'edit' ? this.#form.source : null;
+    const form = this.el('form', { attrs: { 'aria-label': editing ? 'Edit source' : 'Create source' } });
+
+    const input = (
+      name: string,
+      label: string,
+      value: string,
+      attrs: Record<string, string> = {},
+    ): HTMLLabelElement => {
+      const field = this.el('input', { attrs: { name, ...attrs } });
+      field.value = value;
+      return this.el('label', { text: label }, [field]);
+    };
+
+    const kindSelect = this.el('select', { attrs: { name: 'kind' } });
+    for (const kind of ['smb_share', 'local_profile']) {
+      const option = this.el('option', { text: kind, attrs: { value: kind } });
+      if (kind === this.#formKind) option.setAttribute('selected', '');
+      kindSelect.append(option);
+    }
+    kindSelect.addEventListener('change', () => {
+      // Capture live values before the rebuild, or the switch discards
+      // everything the user typed (see #draft). Merge, don't replace: a form
+      // variant that omits some fields (local_folder has no SMB fields) must
+      // not wipe the values captured for them on an earlier switch.
+      this.#draft = { ...this.#draft, ...this.#captureDraft(form) };
+      this.#formKind = kindSelect.value;
+      this.#render();
+    });
+
+    const seed = (name: string, fallback: string): string => this.#draft?.[name] ?? fallback;
+
+    form.append(
+      this.el('h2', { text: editing ? `Edit ${editing.displayName}` : 'New source' }),
+      input('displayName', 'Display name', seed('displayName', editing?.displayName ?? '')),
+      this.el('label', { text: 'Kind' }, [kindSelect]),
+      input('rootPath', 'Root path', seed('rootPath', editing?.rootPath ?? '')),
+    );
+    if (this.#formKind === 'smb_share') {
+      // Type-specific SMB fields: the crawl device and the share credential.
+      form.append(
+        input('crawlDeviceId', 'Crawl device id', seed('crawlDeviceId', editing?.crawlDeviceId ?? '')),
+        input('credentialUsername', 'Credential username', seed('credentialUsername', ''), { autocomplete: 'off' }),
+        input('credentialPassword', 'Credential password', seed('credentialPassword', ''), {
+          type: 'password',
+          autocomplete: 'new-password',
+        }),
+        input('credentialDomain', 'Credential domain', seed('credentialDomain', ''), { autocomplete: 'off' }),
+      );
+    }
+    form.append(
+      input('crawlCadenceMinutes', 'Crawl cadence (minutes)', seed('crawlCadenceMinutes', String(editing?.crawlCadenceMinutes ?? 1440)), { type: 'number', min: '1' }),
+      this.el('button', { text: editing ? 'Save changes' : 'Create source', attrs: { type: 'submit' } }),
+    );
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      this.track(this.#submitForm(form, editing));
+    });
+    return form;
+  }
+
+  #captureDraft(form: HTMLFormElement): Record<string, string> {
+    const draft: Record<string, string> = {};
+    for (const field of form.querySelectorAll<HTMLInputElement | HTMLSelectElement>('[name]')) {
+      draft[field.getAttribute('name')!] = field.value;
+    }
+    return draft;
+  }
+
+  #readForm(form: HTMLFormElement): SourceInput & {
+    credential: { username: string; password: string; domain: string };
+  } {
+    const value = (name: string): string =>
+      (form.querySelector(`[name="${name}"]`) as HTMLInputElement | HTMLSelectElement | null)?.value ?? '';
+    // The server schema is strict AND total: every field below is required,
+    // so the page supplies the fixed defaults for what the form doesn't ask.
+    return {
+      kind: value('kind'),
+      displayName: value('displayName'),
+      rootPath: value('rootPath'),
+      crawlDeviceId: value('crawlDeviceId') || null,
+      crawlCadenceMinutes: Number(value('crawlCadenceMinutes')) || 1440,
+      visibilityGroupIds: [],
+      excludeGlobs: [],
+      watch: true,
+      status: 'active',
+      credential: {
+        username: value('credentialUsername'),
+        password: value('credentialPassword'),
+        domain: value('credentialDomain'),
+      },
+    };
+  }
+
+  #clearCredentialFields(form: HTMLFormElement): void {
+    // Secrets never linger in the DOM after submit — success or failure.
+    for (const name of ['credentialUsername', 'credentialPassword', 'credentialDomain']) {
+      const field = form.querySelector(`[name="${name}"]`) as HTMLInputElement | null;
+      if (field) field.value = '';
+    }
+  }
+
+  async #submitForm(form: HTMLFormElement, editing: SourceRow | null): Promise<void> {
+    if (!this.#context) return;
+    const orgId = this.#context.organizationId;
+    const { credential, ...fields } = this.#readForm(form);
+    try {
+      let saved: SourceRow;
+      if (editing) {
+        saved = await this.#api.updateSource(orgId, editing.id, fields, { signal: this.signal });
+      } else {
+        saved = await this.#api.createSource(orgId, fields, { signal: this.signal });
+      }
+      if (credential.username && credential.password) {
+        await this.#api.setCredential(orgId, saved.id, {
+          username: credential.username,
+          password: credential.password,
+          ...(credential.domain ? { domain: credential.domain } : {}),
+        }, { signal: this.signal });
+      }
+      this.#clearCredentialFields(form);
+      this.#draft = null;
+      this.#form = { kind: 'closed' };
+      this.#toast('success', editing ? 'Source updated.' : 'Source created.');
+      await this.#load();
+    } catch (error) {
+      this.#clearCredentialFields(form);
+      this.#draft = null;
+      if (error instanceof WorkspaceApiError && error.kind === 'aborted') return;
+      this.#toast('error', editing ? 'Source update failed.' : 'Source creation failed.');
+    }
+  }
+
+  async #deleteSource(source: SourceRow): Promise<void> {
+    if (!this.#context) return;
+    try {
+      await this.#api.deleteSource(this.#context.organizationId, source.id, { signal: this.signal });
+      this.#confirmingDelete = null;
+      this.#toast('success', 'Source deleted.');
+      await this.#load();
+    } catch (error) {
+      if (error instanceof WorkspaceApiError && error.kind === 'aborted') return;
+      this.#toast('error', 'Source deletion failed.');
+    }
+  }
+}

--- a/ee/workspace/src/web/styles.ts
+++ b/ee/workspace/src/web/styles.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared Shadow DOM stylesheet. Static string only — nothing here may ever be
+ * interpolated from API data.
+ */
+export const WORKSPACE_STYLES = `
+:host {
+  display: block;
+  font-family: system-ui, -apple-system, sans-serif;
+  color: inherit;
+}
+h1, h2 {
+  font-size: 1.1rem;
+  margin: 0 0 0.75rem;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th, td {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 15%, transparent);
+  font-size: 0.9rem;
+}
+button {
+  font: inherit;
+  padding: 0.3rem 0.7rem;
+  border-radius: 0.375rem;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+button.danger { color: #b91c1c; border-color: #b91c1c; }
+form {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 28rem;
+  margin: 0.75rem 0;
+}
+label {
+  display: grid;
+  gap: 0.15rem;
+  font-size: 0.85rem;
+}
+input, select {
+  font: inherit;
+  padding: 0.3rem 0.45rem;
+  border-radius: 0.375rem;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+  background: transparent;
+  color: inherit;
+}
+.error { color: #b91c1c; }
+.muted { opacity: 0.7; }
+.stats { display: grid; gap: 0.3rem; margin: 0; padding: 0; list-style: none; }
+.row-actions { display: flex; gap: 0.4rem; }
+`;

--- a/ee/workspace/tsconfig.json
+++ b/ee/workspace/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/ee/workspace/tsup.web.config.ts
+++ b/ee/workspace/tsup.web.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'tsup';
+
+/**
+ * Web bundle: one same-origin ESM graph rooted at dist/web/index.js, exactly
+ * what manifest.json's `web.entry` names.
+ *
+ * The host loads the entry by URL (`loadEntry`) with no import map, so bare
+ * specifiers cannot resolve in the browser — the web SDK and zod are bundled
+ * IN (the plan's "externalize only if the host exposes the exact public
+ * import map" condition does not hold). check-bundle enforces that no static
+ * or dynamic bare import survives in the output.
+ */
+export default defineConfig({
+  entry: { index: 'src/web/index.ts' },
+  outDir: 'dist/web',
+  format: ['esm'],
+  platform: 'browser',
+  target: 'es2022',
+  dts: false,
+  sourcemap: false,
+  minify: false,
+  splitting: false,
+  clean: true,
+  noExternal: [/.*/],
+});

--- a/ee/workspace/vitest.config.ts
+++ b/ee/workspace/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+// Two projects so only src/web runs in a DOM (happy-dom) environment; the
+// rest of the unit suite keeps running in node exactly as before.
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
+          exclude: ['src/__tests__/**/*.integration.test.ts', 'src/web/**'],
+        },
+      },
+      {
+        test: {
+          name: 'web',
+          environment: 'happy-dom',
+          include: ['src/web/**/*.test.ts'],
+        },
+      },
+    ],
+  },
+});

--- a/ee/workspace/vitest.integration.config.ts
+++ b/ee/workspace/vitest.integration.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { config } from 'dotenv';
+// Repo-root .env.test (gitignored; see .env.test.example). The old
+// '../../.env.test' path assumed this repo sat at extensions/workspace inside
+// the monorepo and silently resolved to a nonexistent file standalone (#14).
+// A missing file is fine — the suites fall back to the shared :5433 test-stack
+// defaults baked into each *.integration.test.ts.
+config({ path: '.env.test' });
+
+export default defineConfig({
+  test: {
+    include: ['src/__tests__/**/*.integration.test.ts'],
+    fileParallelism: false,
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});

--- a/ee/workspace/vitest.integration.config.ts
+++ b/ee/workspace/vitest.integration.config.ts
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vitest/config';
 import { config } from 'dotenv';
-// Repo-root .env.test (gitignored; see .env.test.example). The old
-// '../../.env.test' path assumed this repo sat at extensions/workspace inside
-// the monorepo and silently resolved to a nonexistent file standalone (#14).
-// A missing file is fine — the suites fall back to the shared :5433 test-stack
-// defaults baked into each *.integration.test.ts.
-config({ path: '.env.test' });
+// Repo-root .env.test (gitignored; breeze's own convention — see
+// apps/api/vitest.integration.config.ts, which loads the same path from the
+// same nesting depth: ee/workspace and apps/api both sit one level under the
+// breeze repo root). A missing file is fine — CI sets DATABASE_URL /
+// DATABASE_URL_APP directly via the job env, and locally the suites fall
+// back to the shared :5433 test-stack defaults baked into each
+// *.integration.test.ts.
+config({ path: '../../.env.test' });
 
 export default defineConfig({
   test: {

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -12,6 +12,14 @@
 > same extension name — the boot fails rather than letting one silently shadow
 > the other. Stock images no longer build or bake in `extensions/*` sources.
 
+First-party extensions maintained in this repository (currently
+`ee/workspace`) do not live here — they are compiled into the API image as
+**built-in** extensions, registered at boot through
+`apps/api/src/extensions/builtinExtensions.ts` (no signing, no runtime
+artifact, no source-directory scan; see
+`docs/extensions/build-time-transition.md`, "Built-in (first-party)
+extensions"). This directory is exclusively for third-party delivery.
+
 This directory hosts the runtime deployment config (`extensions.yaml`) and,
 during the compatibility window only, legacy source extension checkouts:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.1096.0
         version: 3.1096.0
+      '@breeze/ext-workspace':
+        specifier: workspace:*
+        version: link:../../ee/workspace
       '@breeze/extension-api':
         specifier: workspace:*
         version: link:../../packages/extension-api
@@ -15482,7 +15485,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.86.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,7 +300,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
@@ -1164,6 +1164,64 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
 
+  ee/workspace:
+    dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.112.3
+        version: 0.112.5(zod@4.4.3)
+      '@breeze/extension-sdk':
+        specifier: workspace:*
+        version: link:../../packages/extension-sdk
+      '@breeze/extension-web-sdk':
+        specifier: workspace:*
+        version: link:../../packages/extension-web-sdk
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(gel@2.2.0)(pg@8.22.0)(postgres@3.4.9)
+      hono:
+        specifier: 4.13.1
+        version: 4.13.1
+      mailparser:
+        specifier: ^3.9.14
+        version: 3.9.15
+      v9u-smb2:
+        specifier: ^1.0.6
+        version: 1.0.6
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@breeze/extension-testkit':
+        specifier: workspace:*
+        version: link:../../packages/extension-testkit
+      '@types/mailparser':
+        specifier: ^3.4.6
+        version: 3.4.6
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.2.0
+      dotenv:
+        specifier: 16.6.1
+        version: 16.6.1
+      happy-dom:
+        specifier: ^20.11.0
+        version: 20.11.1
+      postgres:
+        specifier: 3.4.9
+        version: 3.4.9
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(typescript@5.9.3)(yaml@2.9.0)
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.11
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+
   packages/extension-api:
     dependencies:
       '@breeze/extension-sdk':
@@ -1405,6 +1463,15 @@ packages:
       '@anthropic-ai/sdk': '>=0.93.0'
       '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.112.5':
+    resolution: {integrity: sha512-FaaGkyS4/zW4n+8Pr9jQkyo5zWcBNw+R+heCLXdoKDUEuALbPALBk6zLAlmsU+veREiaATxVG0TwkK/cQ3NZsQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@anthropic-ai/sdk@0.115.0':
     resolution: {integrity: sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==}
@@ -4378,19 +4445,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.62.0':
     resolution: {integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.62.0':
@@ -4398,19 +4455,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.62.0':
     resolution: {integrity: sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.62.0':
@@ -4418,19 +4465,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.62.0':
     resolution: {integrity: sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.62.0':
@@ -4438,23 +4475,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
@@ -4462,23 +4487,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
@@ -4486,23 +4499,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
@@ -4510,23 +4511,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
@@ -4534,23 +4523,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
@@ -4558,21 +4535,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -4582,51 +4547,25 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openbsd-x64@4.62.0':
     resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
     cpu: [x64]
     os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@rollup/rollup-openharmony-arm64@4.62.0':
     resolution: {integrity: sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.62.0':
     resolution: {integrity: sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.62.0':
@@ -4634,18 +4573,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.62.0':
     resolution: {integrity: sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     cpu: [x64]
     os: [win32]
 
@@ -4659,6 +4588,11 @@ packages:
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@selderee/plugin-htmlparser2@0.12.0':
+    resolution: {integrity: sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==}
+    peerDependencies:
+      selderee: ~0.12.0
 
   '@sentry-internal/browser-utils@10.38.0':
     resolution: {integrity: sha512-UOJtYmdcxHCcV0NPfXFff/a95iXl/E0EhuQ1y0uE0BuZDMupWSF5t2BgC4HaE5Aw3RTjDF3XkSHWoIF6ohy7eA==}
@@ -5600,9 +5534,6 @@ packages:
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -5662,6 +5593,9 @@ packages:
 
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
+  '@types/mailparser@3.4.6':
+    resolution: {integrity: sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -5930,6 +5864,9 @@ packages:
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
+  '@zone-eu/mailsplit@5.4.15':
+    resolution: {integrity: sha512-c7ZpxauvF4AEkDJlKDYO7iMUtMuqJMBnDWNff1cyx+d7zaBVR3iFEmXhNHOVoMmVyVF3pTZLsLIJsEFKDldOAA==}
+
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -5950,11 +5887,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.17.0:
-    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.18.0:
     resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
@@ -7020,6 +6952,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge-ts@7.1.6:
+    resolution: {integrity: sha512-gQhL1ksGBLQbHeAo47YU6cs2ahd3Pv+8PFYoWogNZbQnNwQyOh9Ad5kbeHFiWwbKdeWQJ5Z7Y7mwb9ew2hXBLw==}
+    engines: {node: '>=16.0.0'}
+
   deepmerge@3.3.0:
     resolution: {integrity: sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==}
     engines: {node: '>=0.10.0'}
@@ -7314,6 +7250,10 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-japanese@2.2.0:
+    resolution: {integrity: sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==}
+    engines: {node: '>=8.10.0'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -7363,9 +7303,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -8097,6 +8034,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   hermes-compiler@250829098.0.16:
     resolution: {integrity: sha512-xsgzk+mUyvt9t1nUbF8USBlYxajTUtPJhVZ86q85s/SEoMKCF+52YZcudb0ENSnV3T3lV9mgB3s6R7+pH90zgw==}
 
@@ -8152,6 +8093,10 @@ packages:
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  html-to-text@10.0.0:
+    resolution: {integrity: sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==}
+    engines: {node: '>=20.19.0'}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -8653,6 +8598,9 @@ packages:
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
+  leac@0.7.0:
+    resolution: {integrity: sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -8660,6 +8608,15 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libbase64@1.3.0:
+    resolution: {integrity: sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==}
+
+  libmime@5.4.2:
+    resolution: {integrity: sha512-+IQnCOdPiufGBkOii+Ze8F7iniyBzOwvWDbn1DyExBpc9pT2B3IEMQi7GUc/PpqhNUh/sr1SG9UXDITQoR0VIA==}
+
+  libqp@2.1.1:
+    resolution: {integrity: sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -8945,6 +8902,9 @@ packages:
 
   magicast@0.5.4:
     resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  mailparser@3.9.15:
+    resolution: {integrity: sha512-/5hgybKDMKFS05jAh8OPeEE7N53lj8nF6ywlo89VPjF2TtwqIQbjaxumQWnJIkmaagnJ6u1eansMOViHFxIXwQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -9468,6 +9428,10 @@ packages:
     resolution: {integrity: sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==}
     engines: {node: '>=6.0.0'}
 
+  nodemailer@9.0.5:
+    resolution: {integrity: sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==}
+    engines: {node: '>=6.0.0'}
+
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -9490,6 +9454,9 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  ntlm2@0.3.0:
+    resolution: {integrity: sha512-q4QRTBGjLhxMnoUFPak6IKehlGMsWp14Vu+VU4JdxMeS4Olm7/N7+HJlqrYesUCI0RBoc40rXvFO3WENpGDBbw==}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -9683,6 +9650,9 @@ packages:
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
+  parseley@0.13.1:
+    resolution: {integrity: sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -9728,6 +9698,9 @@ packages:
 
   pdfkit@0.19.1:
     resolution: {integrity: sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==}
+
+  peberminta@0.10.0:
+    resolution: {integrity: sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -10579,11 +10552,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.60.1:
-    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.62.0:
     resolution: {integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -10646,6 +10614,9 @@ packages:
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+
+  selderee@0.12.0:
+    resolution: {integrity: sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==}
 
   semifies@1.0.0:
     resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
@@ -11056,17 +11027,9 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -11075,6 +11038,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
 
   tldts-core@7.4.9:
     resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
@@ -11442,6 +11409,10 @@ packages:
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
+
+  v9u-smb2@1.0.6:
+    resolution: {integrity: sha512-xXFGQzOL0X6E//le+1rlEeyam+3jgk2vNSqs/2h1XuyIog5l47+hL3KcZh4fA4qTBuwFiEfH1sG7ZFpPT6VtWQ==}
+    engines: {node: '>=10'}
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -11835,18 +11806,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.21.1:
-    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
@@ -12044,6 +12003,13 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.181
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.181
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.181
+
+  '@anthropic-ai/sdk@0.112.5(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@anthropic-ai/sdk@0.115.0(zod@4.4.3)':
     dependencies:
@@ -13336,7 +13302,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -15661,151 +15627,76 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.62.0':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.60.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.62.0':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.62.0':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.62.0':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.62.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.62.0':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.62.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.62.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.62.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.0':
@@ -15818,6 +15709,12 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
     optional: true
+
+  '@selderee/plugin-htmlparser2@0.12.0(selderee@0.12.0)':
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      selderee: 0.12.0
 
   '@sentry-internal/browser-utils@10.38.0':
     dependencies:
@@ -16825,8 +16722,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
-  '@types/estree@1.0.8': {}
-
   '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@5.1.1':
@@ -16903,6 +16798,11 @@ snapshots:
 
   '@types/long@4.0.2':
     optional: true
+
+  '@types/mailparser@3.4.6':
+    dependencies:
+      '@types/node': 26.2.0
+      iconv-lite: 0.6.3
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -17147,7 +17047,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -17173,14 +17073,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))':
     dependencies:
@@ -17274,6 +17166,12 @@ snapshots:
 
   '@xterm/xterm@6.0.0': {}
 
+  '@zone-eu/mailsplit@5.4.15':
+    dependencies:
+      libbase64: 1.3.0
+      libmime: 5.4.2
+      libqp: 2.1.1
+
   abbrev@2.0.0:
     optional: true
 
@@ -17291,15 +17189,9 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-jsx@5.3.2(acorn@8.17.0):
-    dependencies:
-      acorn: 8.17.0
-
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
-
-  acorn@8.17.0: {}
 
   acorn@8.18.0: {}
 
@@ -17930,9 +17822,9 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
-  bundle-require@5.1.0(esbuild@0.28.1):
+  bundle-require@5.1.0(esbuild@0.28.2):
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -18543,6 +18435,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge-ts@7.1.6: {}
+
   deepmerge@3.3.0: {}
 
   deepmerge@4.3.1: {}
@@ -18724,6 +18618,8 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding-japanese@2.2.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -18766,8 +18662,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@2.3.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -18916,8 +18810,8 @@ snapshots:
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1:
@@ -19298,10 +19192,6 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -19381,7 +19271,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-      rollup: 4.60.1
+      rollup: 4.62.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -19691,7 +19581,7 @@ snapshots:
       buffer-image-size: 0.6.4
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.21.1
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -19899,6 +19789,8 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  he@1.2.0: {}
+
   hermes-compiler@250829098.0.16: {}
 
   hermes-estree@0.35.0: {}
@@ -19952,6 +19844,14 @@ snapshots:
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  html-to-text@10.0.0:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
+      deepmerge-ts: 7.1.6
+      dom-serializer: 2.0.0
+      htmlparser2: 10.1.0
+      selderee: 0.12.0
 
   html-to-text@9.0.5:
     dependencies:
@@ -20504,12 +20404,25 @@ snapshots:
   leac@0.6.0:
     optional: true
 
+  leac@0.7.0: {}
+
   leven@3.1.0: {}
 
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libbase64@1.3.0: {}
+
+  libmime@5.4.2:
+    dependencies:
+      encoding-japanese: 2.2.0
+      iconv-lite: 0.7.3
+      libbase64: 1.3.0
+      libqp: 2.1.1
+
+  libqp@2.1.1: {}
 
   lie@3.3.0:
     dependencies:
@@ -20742,6 +20655,19 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       source-map-js: 1.2.1
+
+  mailparser@3.9.15:
+    dependencies:
+      '@zone-eu/mailsplit': 5.4.15
+      encoding-japanese: 2.2.0
+      he: 1.2.0
+      html-to-text: 10.0.0
+      iconv-lite: 0.7.3
+      libmime: 5.4.2
+      linkify-it: 5.0.2
+      nodemailer: 9.0.5
+      punycode.js: 2.3.1
+      tlds: 1.261.0
 
   make-dir@4.0.0:
     dependencies:
@@ -21614,6 +21540,8 @@ snapshots:
 
   nodemailer@9.0.3: {}
 
+  nodemailer@9.0.5: {}
+
   nopt@7.2.1:
     dependencies:
       abbrev: 2.0.0
@@ -21638,6 +21566,10 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  ntlm2@0.3.0:
+    dependencies:
+      extend: 3.0.2
 
   nullthrows@1.1.1: {}
 
@@ -21902,6 +21834,11 @@ snapshots:
       peberminta: 0.9.0
     optional: true
 
+  parseley@0.13.1:
+    dependencies:
+      leac: 0.7.0
+      peberminta: 0.10.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -21946,6 +21883,8 @@ snapshots:
       js-md5: 0.8.3
       linebreak: 1.1.0
       png-js: 1.1.0
+
+  peberminta@0.10.0: {}
 
   peberminta@0.9.0:
     optional: true
@@ -22941,37 +22880,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.3
       '@rolldown/binding-win32-x64-msvc': 1.2.3
 
-  rollup@4.60.1:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
-      fsevents: 2.3.3
-
   rollup@4.62.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -23002,7 +22910,6 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.62.0
       '@rollup/rollup-win32-x64-msvc': 4.62.0
       fsevents: 2.3.3
-    optional: true
 
   rope-sequence@1.3.4: {}
 
@@ -23075,6 +22982,10 @@ snapshots:
     dependencies:
       parseley: 0.12.1
     optional: true
+
+  selderee@0.12.0:
+    dependencies:
+      parseley: 0.13.1
 
   semifies@1.0.0: {}
 
@@ -23586,14 +23497,7 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:
@@ -23601,6 +23505,8 @@ snapshots:
       picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
+
+  tlds@1.261.0: {}
 
   tldts-core@7.4.9: {}
 
@@ -23650,22 +23556,22 @@ snapshots:
 
   tsup@8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.28.1)
+      bundle-require: 5.1.0(esbuild@0.28.2)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.28.1
+      esbuild: 0.28.2
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.60.1
+      rollup: 4.62.0
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.26
@@ -23918,6 +23824,11 @@ snapshots:
 
   uuid@14.0.1: {}
 
+  v9u-smb2@1.0.6:
+    dependencies:
+      ntlm2: 0.3.0
+      readable-stream: 3.6.2
+
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
@@ -23986,22 +23897,6 @@ snapshots:
       tsx: 4.23.11
       yaml: 2.9.0
 
-  vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.33.0
-      picomatch: 4.0.5
-      postcss: 8.5.26
-      rolldown: 1.2.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.2.0
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      terser: 5.49.2
-      tsx: 4.23.11
-      yaml: 2.9.0
-
   vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -24031,15 +23926,15 @@ snapshots:
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@1.21.7)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
@@ -24062,49 +23957,18 @@ snapshots:
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 26.2.0
-      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      happy-dom: 20.11.1
-      jsdom: 30.0.1(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -24124,15 +23988,15 @@ snapshots:
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)
@@ -24364,8 +24228,6 @@ snapshots:
   ws@7.5.13: {}
 
   ws@8.21.0: {}
-
-  ws@8.21.1: {}
 
   ws@8.21.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+  - 'ee/*'
 
 # pnpm 11+ refuses to run install scripts unless they're in this allowlist.
 # Add packages here only after confirming what their install script does:


### PR DESCRIPTION
## Summary

Moves the Breeze Workspace extension (formerly `LanternOps/breeze-workspace`,
private) into this repo at `ee/workspace/` (`@breeze/ext-workspace`), loaded
as a **built-in extension** — statically imported, compiled into the API
image, and registered at boot through the same staged v1 host pipeline
(contribution registry, default-deny gateway, tenancy/RLS tripwires) that
signed runtime bundles use, but with no signing, no artifact verification,
and no source-directory scan. This path is reserved for first-party code
that lives in this repository (currently just `ee/workspace`); third-party
extensions are unaffected and continue to arrive exclusively as signed
runtime bundles declared in `extensions.yaml`. `ee/` carries the Breeze
Commercial License; everything else in the repo remains AGPL-3.0. The two-repo
split, vendored-SDK tarballs, Ed25519 signing/packing pipeline, live
stock-host conformance suite, machine-local `pnpm.overrides` hack, and
symlinked `extensions/workspace` dev flow are all retired for Workspace — see
the deletion/retirement inventory below.

Spec: `docs/superpowers/specs/2026-08-11-workspace-ee-merge-design.md`
Plan: `docs/superpowers/plans/2026-08-11-workspace-ee-merge.md`

## Deletion / retirement inventory

- **`extensions/workspace` symlink dev flow** — retired. The symlink itself
  is untracked and gitignored (`extensions/*` in `.gitignore`, except
  `README.md`) in every checkout, including the main `~/breeze` checkout, so
  there was never anything for this branch to `git rm`. It does not exist at
  all in this worktree. See the Todd checklist below for removing it from
  disk in the main checkout.
- **Vendored-SDK tarballs / `.stubs/`** — deleted with the source move
  (Task 1/2); Workspace now depends on `@breeze/extension-sdk` /
  `@breeze/extension-web-sdk` via `workspace:*`, same as every other
  extension in this repo.
- **Packer / sign / stage / validate pipeline usage for Workspace** — retired.
  The signed-runtime-bundle platform itself is unchanged and stays in place
  for third-party extensions.
- **Live stock-host conformance suite** — retired as a Workspace gate. The
  platform's own conformance coverage (`apps/api/src/extensions/packerConformance.test.ts`)
  no longer needs Workspace as its reference guinea pig; `docs/extensions/build-time-transition.md`
  now points to that fixture instead.
- **Root `package.json` `pnpm.overrides` for vendored Workspace SDKs, and the
  compose-override `./package.json:/app/package.json` mount** — both were
  already outside git (a machine-local unstaged edit and an untracked compose
  override respectively), so neither is touched by this branch's diff. Left
  as a Todd checklist item (below) rather than editing his tree.
- **`LanternOps/breeze-workspace` (private repo)** — to be archived
  read-only as the history record once this PR merges; not part of this
  branch's diff.

## Built-in extension path (what actually changed under the hood)

- `apps/api/src/extensions/builtinExtensions.ts` (Task 3) statically imports
  the workspace package's parsed manifest and v1 register entry and feeds
  them through the same staged v1 pipeline as runtime bundles.
- `apps/api/src/index.ts` calls `loadBuiltinExtensions()` at boot, strictly
  between `loadSourceExtensions()` and the signed-bundle `reconcileExtensions()`
  call (Task 4); any built-in load failure aborts boot.
- Migrations: unchanged mechanism — the extension migrator runs
  `ee/workspace/migrations/*.sql`; the built-in registration hands it a
  resolved `migrationsDir`.
- **Three Dockerfiles** were found to need this wiring, not one:
  `docker/Dockerfile.api`, `apps/api/Dockerfile` (the actual published
  release image — `.github/workflows/release.yml` and
  `edge-image-api.yml` build from this file, not `docker/Dockerfile.api`),
  and `docker/Dockerfile.api.dev` (the hot-reload dev flow). All three now
  bake in `ee/workspace`'s manifest, `node_modules`, source/build output, and
  migrations, each honoring its own runtime `WORKDIR`/`process.cwd()`
  convention for where `builtinRegistry.ts`'s built-in-root resolution looks
  (`/app/ee/workspace` for the two images whose runner stays at `/app`;
  `/app/apps/api/ee/workspace` for `apps/api/Dockerfile`, whose runner ends
  at `WORKDIR /app/apps/api`). Each was verified with a real `docker build` +
  `docker run` smoke check (Task 5).
- `apps/api/tsup.config.ts`'s `noExternal` explicitly lists Workspace's two
  non-`@breeze/*` third-party runtime deps (`mailparser`, `v9u-smb2`) so
  their inline bundling is a documented, guarded contract rather than an
  implicit side effect of apps/api's own dependency list; a new static guard
  test (`apps/api/src/config/extensionBundledDependencies.test.ts`) catches
  the next genuinely-dangling dependency before it reaches a Docker build.
- CI (`.github/workflows/ci.yml`, Task 6): `ee/workspace` unit tests +
  typecheck run in the `test-api` job (no DB needed). The integration suite
  needs `workspace_*` tables, which only come from a real `loadBuiltinExtensions()`
  boot (nothing in the existing test harness — CI or local — ever ran that
  path before this branch); a new "Boot API once to apply built-in extension
  migrations" step runs `tsx src/index.ts` with `AUTO_MIGRATE=true` against
  the job's Postgres service, waits for the `loaded built-in "workspace"` log
  line (or a `CRITICAL` failure) with a 180s timeout, then stops it (own
  process group via `setsid`, bounded shutdown wait with a `kill -9`
  fallback) — before the `ee/workspace` integration-test step runs. Both new
  steps are gated `if: matrix.shard == 1` since the suite needs exactly one
  DB, not a sharded slice. **Note:** these steps have never executed in a
  real Actions run — watch this PR's first CI run before merging.

## Docs

- `docs/extensions/build-time-transition.md` — added a "Built-in (first-party)
  extensions" section documenting the new delivery mode as distinct from
  signed bundles and the deprecated source-directory path. Also reconciled
  now-stale claims found via
  `grep -rn "public SDK/host code only\|stock image" docs/extensions extensions/README.md docker/`:
  the old "stock image contains public SDK/host code only" line, and the
  file's two now-inaccurate `breeze-workspace`-as-reference-implementation /
  conformance-reference mentions (Workspace no longer takes the
  source-directory → signed-bundle path, so it no longer fits as that
  guide's worked example; the conformance reference is now
  `apps/api/src/extensions/packerConformance.test.ts`). `docker/Dockerfile.api`'s
  own stock-image comment was already corrected in Task 5.
- `extensions/README.md` — added a note that first-party extensions
  (`ee/workspace`) do not live in this directory; it is exclusively for
  third-party signed-bundle delivery.

## Verification

- `grep -rn "extensions/workspace" --include="*.ts" --include="*.yml" --include="*.yaml" apps packages docker .github | grep -v node_modules` — clean, no hits.
- `pnpm --filter @breeze/api exec vitest run src/extensions/ src/config/` — 32 files / 700 tests passed.
- `pnpm lint` — 6/6 packages, clean (includes `@breeze/ext-workspace`'s own `eslint src`).
- `pnpm test:docs-automation` (the doc-verify CI's guard) — 5/5 passed.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit --project apps/api/tsconfig.json` — clean (Task 5's final fix round).

## Final whole-branch review

An independent final review (spec-vs-branch, cross-task seams, security, prod
readiness) returned "ready with fixes"; all three fixes landed in `422b38d2a`
(CI boot-step process-group kill + bounded wait + 180s window; `workspace_crawl_runs.cursor`
excluded from tenant export — it's an opaque agent resume token, matching the
sibling `crawl_cursor` exclusion; `ee/workspace/src` + `migrations` mounted
into both docker dev compose flows so in-container tsx sees ee edits).
Recommended follow-up issues (not blocking): (1) built-in `installed_extensions`
lifecycle polish — record `activeVersion` only after activation, drop the
redundant first-boot `setEnabled`, add a mid-pipeline-failure test; (2)
routeNamespace-level collision gate across all three delivery paths (name-only
today, pre-existing gap). One open design question for Todd: should
`ee/workspace/manifest.json` declare `tenancy.installScope: "org"` now that
tenant-scoped installs (#3032) exist, or stay server-scoped with org-gating via
`workspace_org_settings` as before? Current behavior matches pre-merge.

## Deployment note: Workspace is opt-in (`BREEZE_WORKSPACE_ENABLED`)

Built-ins now carry a deployment enable flag; Workspace's is `BREEZE_WORKSPACE_ENABLED`, **default OFF** (commit `19534184f`). With the flag unset, the API runs no workspace migrations, requires no pgvector, and requires no web bundle — any Postgres 16 image boots clean (one structured `builtin_extension_disabled` log line). Setting it to exactly `"true"` loads Workspace through the full pipeline, and **then** pgvector is required: a plain-postgres DB fails boot with an actionable error naming both remedies (pgvector image, or unset the flag). A previously-enabled deployment that turns the flag off keeps its tables safe — the disabled path publishes the tenancy declaration iff the tables exist, so cascades/exports/sweeps stay correct. Dev composes set the flag; the stock `POSTGRES_IMAGE_REF` default stays `pgvector/pgvector:pg16` so enabling later needs no DB swap. CI covers both paths: shard-1 integration boots flag-on; the compose Smoke Test and both binary-source jobs prove the default-off boot. Verified live in three boots: plain-pg flag-off, pgvector flag-on, and flag-off-with-existing-tables.

## Todd checklist

- [ ] Discard the machine-local, unstaged root `package.json` `pnpm.overrides`
      edit for vendored Workspace SDKs — dead now that Workspace resolves via
      `workspace:*` in-repo.
- [ ] Delete the untracked compose-override `./package.json:/app/package.json`
      mount — dead for the same reason.
- [ ] Remove the `extensions/workspace` symlink from the main `~/breeze`
      checkout if still present (`rm extensions/workspace`) — it is untracked
      and gitignored, so nothing in this PR removes it automatically; it just
      becomes a stale, unused symlink once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


