### PR TITLE
fix(agent): probe Full Disk Access in-process in CheckFDA instead of via sqlite3 subprocess

### DIFF
--- a/agent/internal/tcc/grant_darwin.go
+++ b/agent/internal/tcc/grant_darwin.go
@@ -3,6 +3,7 @@
 package tcc
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -210,13 +211,6 @@ func detectTCCSchemaForDB(dbPath string) ([]string, error) {
 	return columns, nil
 }
 
-// isAlreadyGranted checks if a TCC entry already exists and is allowed
-// (auth_value=2) for the agent binary. Kept as a thin wrapper so CheckFDA
-// and other agent-scoped callers don't have to pass the binary path.
-func isAlreadyGranted(dbPath, service string) (bool, error) {
-	return isAlreadyGrantedForBinary(dbPath, service, agentBinaryPath)
-}
-
 // isAlreadyGrantedForBinary checks if a TCC entry already exists and is
 // allowed (auth_value=2) for the given binary path. Does not filter on
 // indirect_object_identifier because older macOS TCC schemas may lack that
@@ -383,30 +377,42 @@ func getUserTCCDBPaths() []string {
 	return paths
 }
 
-// CheckFDA queries the system TCC database (as root) to determine whether the
-// agent binary has been granted Full Disk Access (kTCCServiceSystemPolicyAllFiles).
-// This is used as a daemon-side fallback when the user helper's os.Open probe
-// returns false — which happens on macOS 12 where even FDA-granted user-context
+// CheckFDA reports whether the agent daemon itself holds Full Disk Access,
+// by attempting to open the system TCC database in-process. macOS attributes
+// the permission check to the binary issuing the open() call, so this reflects
+// the daemon's own effective grant. It must NOT shell out to sqlite3: on
+// macOS 13+ the check is attributed to the sqlite3 subprocess, which holds no
+// FDA, so a subprocess-based query is denied regardless of the agent's grant
+// (issue #3380).
+//
+// This is used as a daemon-side fallback when the user helper's probe returns
+// false — which happens on macOS 12 where even FDA-granted user-context
 // processes cannot open the system TCC database.
 //
-// Returns true only if the agent binary has an explicit auth_value=2 entry.
-// Returns false (without error) if the database is unreadable or the entry is
-// missing, so callers can safely treat the result as a best-effort check.
+// Returns false (without error) when not root or when the database cannot be
+// opened, so callers can safely treat the result as a best-effort check.
 func CheckFDA() bool {
 	if os.Getuid() != 0 {
 		log.Debug("CheckFDA skipped — not running as root")
 		return false
 	}
-	if _, err := os.Stat(systemTCCDBPath); err != nil {
-		log.Debug("CheckFDA: cannot stat TCC database", "error", err.Error())
-		return false
-	}
-	granted, err := isAlreadyGranted(systemTCCDBPath, "kTCCServiceSystemPolicyAllFiles")
+	return checkFDAAtPath(systemTCCDBPath)
+}
+
+// checkFDAAtPath probes Full Disk Access by opening dbPath in-process.
+// Permission errors mean FDA is denied; other errors (e.g. ENOENT if Apple
+// moves the DB in a future macOS version) are logged and treated as denied.
+func checkFDAAtPath(dbPath string) bool {
+	f, err := os.Open(dbPath)
 	if err != nil {
-		log.Warn("CheckFDA: query failed", "error", err.Error())
+		if !errors.Is(err, os.ErrPermission) {
+			log.Warn("CheckFDA probe got unexpected error (not permission denied)",
+				"path", dbPath, "error", err.Error())
+		}
 		return false
 	}
-	return granted
+	f.Close()
+	return true
 }
 
 // sqlStr wraps a string value for SQL, escaping single quotes.

--- a/agent/internal/tcc/grant_darwin_test.go
+++ b/agent/internal/tcc/grant_darwin_test.go
@@ -4,6 +4,7 @@ package tcc
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -81,6 +82,52 @@ func TestExpectedServices(t *testing.T) {
 		if svc.Name != wantName {
 			t.Errorf("service %q: expected name %q, got %q", svc.Service, wantName, svc.Name)
 		}
+	}
+}
+
+func TestCheckFDAAtPath_OpenableFile(t *testing.T) {
+	// A file this process can open means the OS granted the read —
+	// the probe must report FDA as held.
+	path := filepath.Join(t.TempDir(), "TCC.db")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !checkFDAAtPath(path) {
+		t.Error("checkFDAAtPath = false for an openable file, want true")
+	}
+}
+
+func TestCheckFDAAtPath_PermissionDenied(t *testing.T) {
+	// EACCES/EPERM on open is exactly how TCC denies access without FDA.
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses file mode bits; test requires non-root execution")
+	}
+	path := filepath.Join(t.TempDir(), "TCC.db")
+	if err := os.WriteFile(path, []byte("stub"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if checkFDAAtPath(path) {
+		t.Error("checkFDAAtPath = true for a permission-denied file, want false")
+	}
+}
+
+func TestCheckFDAAtPath_MissingFile(t *testing.T) {
+	// ENOENT (e.g. Apple moves the DB in a future macOS) must read as
+	// denied, never as granted.
+	path := filepath.Join(t.TempDir(), "does-not-exist.db")
+	if checkFDAAtPath(path) {
+		t.Error("checkFDAAtPath = true for a missing file, want false")
+	}
+}
+
+func TestCheckFDA_NotRoot(t *testing.T) {
+	// The daemon-side fallback only means anything for the root daemon;
+	// non-root callers must get false, not a probe against file modes.
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root execution")
+	}
+	if CheckFDA() {
+		t.Error("CheckFDA = true when not running as root, want false")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the FDA-misreporting half of #3380 (the "Full Disk Access Required" banner appearing after agent restarts/upgrades even when FDA is granted).

`CheckFDA()` — the daemon-side fallback the heartbeat uses to rescue false negatives from the user helper's FDA probe — shelled out to `/usr/bin/sqlite3` to query the system TCC database. On macOS 13+ the OS attributes the permission check to the *subprocess's* binary, which holds no FDA, so the query was always denied and `CheckFDA()` was structurally dead: it could never return true on any SIP-enabled Mac. A transient false from the helper probe (e.g. right after a restart) therefore became a hard false in the heartbeat → permission banner, matching the canary evidence in the issue thread (FDA + Accessibility flipped false on upgrade while Screen Recording — probed via a different, user-level path — survived).

## Change

- Replace the subprocess SQL query with an in-process `os.Open` probe of the system TCC DB — the same technique as the helper's `probeFullDiskAccess()` (`userhelper/tcc_darwin.go`). The open is attributed to the daemon binary itself, so the result reflects the daemon's actual effective grant. Root-only gate unchanged.
- Remove `isAlreadyGranted()`, whose only caller was the old `CheckFDA` body.
- Add unit tests for the probe (openable / permission-denied / missing file) and the not-root gate.

This intentionally does **not** touch the larger self-heal write path (`EnsurePermissions`) — that design question (in-process writes with a real csreq binding vs. retiring self-heal in favor of MDM PPPC) is still open on the issue pending reporter data.

## Testing

- `go test -race ./internal/tcc/...` green (macOS)
- `go vet`, full `go build ./...` green
- Cross-compile check: `GOOS=linux` (tcc + heartbeat) and `GOOS=windows` (tcc) build clean
- Independent code review round: ship verdict, no findings

Refs #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)