### PR TITLE
fix(ee/workspace): catch up to breeze-workspace main — W3 dashboard, W4 filing card, content graduation

### DIFF
--- a/apps/api/src/extensions/builtinExtensions.test.ts
+++ b/apps/api/src/extensions/builtinExtensions.test.ts
@@ -852,6 +852,20 @@ describe('BUILTIN_EXTENSION_NAMES', () => {
       else process.env.BREEZE_WORKSPACE_ENABLED = previous;
     }
   });
+
+  /**
+   * Workspace's /helper/* tree is called by the device helper, so it must sit
+   * behind core helper auth rather than the user default-deny. On the built-in
+   * path that boundary is declared ONLY by this field — the legacy
+   * breeze-extension.json the upstream repo asserted it from is not part of
+   * this delivery mode. Dropping the field would silently move helper traffic
+   * to authMiddleware (see the gateway's helperRoutes arm), so it is pinned
+   * against the real registry entry, not a fixture.
+   */
+  it('keeps workspace /helper/* behind core helper auth', () => {
+    const workspace = BUILTINS.find((builtin) => builtin.manifest.name === 'workspace');
+    expect(workspace?.helperRoutes).toBe(true);
+  });
 });
 
 /**

--- a/ee/workspace/manifest.json
+++ b/ee/workspace/manifest.json
@@ -12,8 +12,8 @@
   "server": { "entry": "server/index.cjs" },
   "web": {
     "entry": "web/index.js",
-    "pages": [{ "id": "sources", "path": "/extensions/workspace/sources", "element": "workspace-sources-page" }],
-    "navigation": [{ "id": "sources", "label": "Workspace Sources", "path": "/extensions/workspace/sources", "order": 100 }],
+    "pages": [{ "id": "sources", "path": "/extensions/workspace/sources", "element": "workspace-sources-page" }, { "id": "dashboard", "path": "/extensions/workspace/dashboard", "element": "workspace-dashboard" }],
+    "navigation": [{ "id": "sources", "label": "Workspace Sources", "path": "/extensions/workspace/sources", "order": 100 }, { "id": "dashboard", "label": "Workspace Dashboard", "path": "/extensions/workspace/dashboard", "order": 50 }],
     "slots": [{ "id": "device-index", "slot": "device.detail.tabs", "contractVersion": 1, "label": "Workspace", "element": "workspace-device-index", "order": 100 }]
   },
   "migrationsDir": "migrations",
@@ -23,7 +23,7 @@
   "jobs": [],
   "aiTools": [],
   "tenancy": {
-    "orgCascadeDeleteTables": ["memory_blocks", "workspace_content_chunks", "workspace_content_entities", "workspace_crawl_runs", "workspace_email_filings", "workspace_file_activity", "workspace_file_content", "workspace_file_enrichment", "workspace_file_index", "workspace_org_settings", "workspace_project_crosswalk", "workspace_projects", "workspace_sources"],
+    "orgCascadeDeleteTables": ["memory_blocks", "workspace_content_chunks", "workspace_content_entities", "workspace_crawl_runs", "workspace_email_filings", "workspace_file_activity", "workspace_file_content", "workspace_file_enrichment", "workspace_file_index", "workspace_ingest_jobs", "workspace_org_settings", "workspace_project_crosswalk", "workspace_projects", "workspace_sources"],
     "deviceCascadeDeleteTables": ["workspace_file_index"],
     "deviceOrgDenormalizedTables": ["workspace_file_activity"],
     "deviceOrgMoveDeleteTables": ["workspace_file_index"],
@@ -63,6 +63,10 @@
       "workspace_file_index": {
         "include": ["id", "org_id", "source_id", "device_id", "device_key", "rel_path", "parent_path", "name", "is_dir", "ext", "mime", "size", "mtime", "ctime", "attrs", "last_seen_at", "deleted_at", "created_at", "updated_at"],
         "exclude": []
+      },
+      "workspace_ingest_jobs": {
+        "include": ["id", "org_id", "source_id", "crawl_run_id", "trigger", "phase", "status", "force", "attempts", "max_attempts", "next_attempt_at", "stats", "last_error", "started_at", "finished_at", "created_at", "updated_at"],
+        "exclude": ["cursor"]
       },
       "workspace_org_settings": {
         "include": ["org_id", "content_enabled", "created_at", "updated_at"],

--- a/ee/workspace/migrations/2026-07-25-ingest-jobs.sql
+++ b/ee/workspace/migrations/2026-07-25-ingest-jobs.sql
@@ -1,0 +1,62 @@
+-- W3: productized ingest — delta-triggered incremental ingest job state.
+-- One live job per (org, source-partition); advancement is in-request batch
+-- continuation (see src/services/ingestJobRunner.ts). RLS shape 1; registered
+-- in breeze-extension.json orgCascadeDeleteTables.
+-- autoMigrate wraps this file in a transaction: CREATE TYPE is safe here
+-- (only ALTER TYPE ADD VALUE is not — see 2026-07-24-org-settings-dlp.sql:23-26).
+
+DO $$ BEGIN
+  CREATE TYPE workspace_ingest_trigger AS ENUM ('crawl_complete', 'manual', 'reingest');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE workspace_ingest_phase AS ENUM ('ingest', 'enrich', 'crosswalk');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE workspace_ingest_job_status AS ENUM ('pending', 'running', 'complete', 'failed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS workspace_ingest_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES organizations(id),
+  source_id uuid REFERENCES workspace_sources(id) ON DELETE CASCADE,
+  crawl_run_id uuid REFERENCES workspace_crawl_runs(id) ON DELETE SET NULL,
+  trigger workspace_ingest_trigger NOT NULL,
+  phase workspace_ingest_phase NOT NULL DEFAULT 'ingest',
+  status workspace_ingest_job_status NOT NULL DEFAULT 'pending',
+  force boolean NOT NULL DEFAULT false,
+  attempts integer NOT NULL DEFAULT 0,
+  max_attempts integer NOT NULL DEFAULT 8,
+  next_attempt_at timestamptz NOT NULL DEFAULT now(),
+  cursor text,
+  stats jsonb NOT NULL DEFAULT '{}'::jsonb,
+  last_error text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS wsp_ingest_jobs_org_status_idx
+  ON workspace_ingest_jobs (org_id, status, next_attempt_at);
+
+-- One live job per org+source partition. Zero-uuid stands in for org-wide
+-- (source_id IS NULL), mirroring the device_key COALESCE idiom (runScope.ts:9-15).
+CREATE UNIQUE INDEX IF NOT EXISTS wsp_ingest_jobs_one_active_idx
+  ON workspace_ingest_jobs (org_id, COALESCE(source_id, '00000000-0000-0000-0000-000000000000'::uuid))
+  WHERE status IN ('pending', 'running');
+
+DO $$
+BEGIN
+  ALTER TABLE workspace_ingest_jobs ENABLE ROW LEVEL SECURITY;
+  ALTER TABLE workspace_ingest_jobs FORCE ROW LEVEL SECURITY;
+  DROP POLICY IF EXISTS breeze_org_isolation_select ON workspace_ingest_jobs;
+  DROP POLICY IF EXISTS breeze_org_isolation_insert ON workspace_ingest_jobs;
+  DROP POLICY IF EXISTS breeze_org_isolation_update ON workspace_ingest_jobs;
+  DROP POLICY IF EXISTS breeze_org_isolation_delete ON workspace_ingest_jobs;
+  CREATE POLICY breeze_org_isolation_select ON workspace_ingest_jobs FOR SELECT USING (public.breeze_has_org_access(org_id));
+  CREATE POLICY breeze_org_isolation_insert ON workspace_ingest_jobs FOR INSERT WITH CHECK (public.breeze_has_org_access(org_id));
+  CREATE POLICY breeze_org_isolation_update ON workspace_ingest_jobs FOR UPDATE USING (public.breeze_has_org_access(org_id)) WITH CHECK (public.breeze_has_org_access(org_id));
+  CREATE POLICY breeze_org_isolation_delete ON workspace_ingest_jobs FOR DELETE USING (public.breeze_has_org_access(org_id));
+END $$;

--- a/ee/workspace/src/__tests__/client-filing.integration.test.ts
+++ b/ee/workspace/src/__tests__/client-filing.integration.test.ts
@@ -1,0 +1,510 @@
+// /client filing surface — real-DB integration (:5433, two-role).
+//
+// This suite exists to close a gap the unit suites structurally cannot:
+// Task 6's matcher tests mock db.execute, so its visibility gate, org scoping,
+// and date window were only ever proven at SQL-TEXT level. Everything below is
+// behavioral, against real rows under the RLS-enforced app role:
+//   - a file under a GROUPED source is unreachable through /client/filing/match
+//     (groupIds [] → ungrouped only, fail closed);
+//   - an identical-subject email in ANOTHER org is never returned;
+//   - the 7-day window includes its boundary and excludes the far side of it.
+// Plus the cross-path invariant the demo depends on: filing the same email to
+// the same project through /client and through the device/helper route
+// converges on ONE row with a stable status.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { Hono } from 'hono';
+import type { ExtensionHelperDevice, WorkspaceDatabase } from '../hostTypes';
+import { createCrosswalkService } from '../services/crosswalkService';
+import { createEmailMatchService } from '../services/emailMatchService';
+import { createFileQueryService } from '../services/fileQueryService';
+import { createActivityService } from '../services/activityService';
+import { createFilingService, type FilingRecord } from '../services/filingService';
+import { getOrgSettings } from '../services/orgSettingsService';
+import { createClientRoutes } from '../routes/client';
+import { createHelperRoutes } from '../routes/helper';
+import type { WorkspaceAuthContext, WorkspaceRouteEnv } from '../routes/adminGate';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partner: string;
+/** orgA: the demo org (content ON). orgB: a second tenant with a colliding
+ * subject. orgOff: content never enabled (no settings row → default-deny). */
+let orgA: string, orgB: string, orgOff: string;
+let visibleSource: string, groupedSource: string, orgBSource: string;
+const ids: Record<string, string> = {};
+
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+const DEVICE_ID = '44444444-4444-4444-8444-444444444444';
+/** Anchor for every seeded email date; the window probes are offsets of it. */
+const BASE = new Date('2026-07-14T10:00:00.000Z');
+const day = (n: number) => new Date(BASE.getTime() + n * 86_400_000).toISOString();
+const minutes = (n: number) => new Date(BASE.getTime() + n * 60_000).toISOString();
+
+interface SeedFile {
+  key: string;
+  org: 'A' | 'B';
+  rel: string;
+  source?: 'visible' | 'grouped' | 'orgB';
+  entities?: Array<{ type: string; value: string; origin?: string }>;
+  emailMeta?: { subject: string; from: string; date: string; messageId?: string };
+}
+
+const HERO_SUBJECT = 'PO 4021 pipe submittal';
+const GROUPED_SUBJECT = 'grouped source only submittal';
+const CROSS_ORG_SUBJECT = 'cross tenant only submittal';
+const SHARED_SUBJECT = 'shared subject both tenants';
+const WINDOW_SUBJECT = 'window boundary probe';
+
+const SEED: SeedFile[] = [
+  // Crosswalk evidence: PO 4021 on two filed Henderson files → dominant.
+  { key: 'ev1', org: 'A', rel: 'Projects/2023-041 Henderson Water Main Replacement/transmittal.md', entities: [{ type: 'po', value: 'PO 4021' }] },
+  { key: 'ev2', org: 'A', rel: 'Emails/2023-041/po issued.eml', entities: [{ type: 'po', value: 'PO 4021' }] },
+  // The message the pane opens on.
+  {
+    key: 'hero', org: 'A', rel: 'Emails/Unfiled/re po 4021 pipe submittal.eml',
+    entities: [{ type: 'po', value: 'PO 4021' }, { type: 'org', value: 'City of Fairoaks', origin: 'llm' }],
+    emailMeta: {
+      subject: `RE: ${HERO_SUBJECT}`,
+      from: 'Paul Deluca <pdeluca@fairoaksca.gov>',
+      date: BASE.toISOString(),
+      messageId: 'hero-4021@fairoaksca.gov',
+    },
+  },
+  // Visibility: identical shape, but its source carries a group claim the
+  // client session does not have.
+  {
+    key: 'grouped', org: 'A', rel: 'Emails/Unfiled/grouped submittal.eml', source: 'grouped',
+    emailMeta: { subject: GROUPED_SUBJECT, from: 'pdeluca@fairoaksca.gov', date: BASE.toISOString(), messageId: 'grouped@fairoaksca.gov' },
+  },
+  // Org scoping: only tenant B has this subject…
+  {
+    key: 'crossOnly', org: 'B', rel: 'Emails/Unfiled/cross tenant submittal.eml', source: 'orgB',
+    emailMeta: { subject: CROSS_ORG_SUBJECT, from: 'pdeluca@fairoaksca.gov', date: BASE.toISOString(), messageId: 'cross@fairoaksca.gov' },
+  },
+  // …and both tenants have this one, byte-identical.
+  {
+    key: 'sharedA', org: 'A', rel: 'Emails/Unfiled/shared subject a.eml',
+    emailMeta: { subject: SHARED_SUBJECT, from: 'pdeluca@fairoaksca.gov', date: BASE.toISOString() },
+  },
+  {
+    key: 'sharedB', org: 'B', rel: 'Emails/Unfiled/shared subject b.eml', source: 'orgB',
+    emailMeta: { subject: SHARED_SUBJECT, from: 'pdeluca@fairoaksca.gov', date: BASE.toISOString() },
+  },
+  // Date window boundary.
+  {
+    key: 'window', org: 'A', rel: 'Emails/Unfiled/window boundary probe.eml',
+    emailMeta: { subject: WINDOW_SUBJECT, from: 'pdeluca@fairoaksca.gov', date: BASE.toISOString() },
+  },
+];
+
+function orgAuth(orgId: string): WorkspaceAuthContext {
+  return {
+    user: { id: USER_ID, email: 'jenny@fairoaksca.gov', name: 'Jenny Tran' },
+    scope: 'organization',
+    orgId,
+    partnerId: undefined,
+    accessibleOrgIds: [orgId],
+  } as WorkspaceAuthContext;
+}
+
+function helperDevice(orgId: string): ExtensionHelperDevice {
+  return {
+    id: DEVICE_ID, agentId: 'agent-1', orgId, siteId: null,
+    hostname: 'FRONT-DESK-01', osType: 'windows', osVersion: '11', agentVersion: '1.0.0',
+  };
+}
+
+/**
+ * Run one request through the real extension routes inside an RLS-scoped
+ * transaction — the same session-variable contract the host establishes, and
+ * the reason these assertions are worth more than the mocked unit suites.
+ */
+async function request(
+  orgId: string,
+  path: string,
+  init: RequestInit = {},
+  options: { auth?: WorkspaceAuthContext | null; surface?: 'client' | 'helper' } = {},
+): Promise<Response> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } }).session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${orgId}, true),
+                    set_config('breeze.accessible_org_ids', ${orgId}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', ${USER_ID}, true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    const db = transaction as unknown as WorkspaceDatabase;
+    const filingService = createFilingService(db, { crosswalkService: createCrosswalkService(db) });
+    const getSettings = async (id: string) => ({
+      contentEnabled: (await getOrgSettings(db, id)).contentEnabled,
+    });
+    const server = new Hono<WorkspaceRouteEnv>();
+    if (options.surface === 'helper') {
+      server.use('*', async (c, next) => {
+        c.set('helperDevice' as never, helperDevice(orgId) as never);
+        await next();
+      });
+      server.route('/', createHelperRoutes({
+        fileQueryService: createFileQueryService(db),
+        activityService: createActivityService(db),
+        filingService,
+        getSettings,
+        audit: async () => {},
+        log: () => {},
+      }) as unknown as Hono<WorkspaceRouteEnv>);
+    } else {
+      const auth = options.auth === undefined ? orgAuth(orgId) : options.auth;
+      server.use('*', async (c, next) => {
+        if (auth) c.set('auth', auth);
+        await next();
+      });
+      server.route('/', createClientRoutes({
+        emailMatchService: createEmailMatchService(db),
+        filingService,
+        getSettings,
+        audit: async () => {},
+        log: () => {},
+      }));
+    }
+    return server.request(path, init);
+  });
+}
+
+/** Same RLS-scoped transaction, but handing the raw services to the caller —
+ * used for the inverse control on the visibility gate. */
+async function inOrg<T>(orgId: string, fn: (db: WorkspaceDatabase) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } }).session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${orgId}, true),
+                    set_config('breeze.accessible_org_ids', ${orgId}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', ${USER_ID}, true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(transaction as unknown as WorkspaceDatabase);
+  });
+}
+
+function matchPath(params: Record<string, string>): string {
+  const query = new URLSearchParams(params).toString();
+  return `/filing/match?${query}`;
+}
+
+type MatchBody = { match: { fileIndexId: string; tier: number; filing: FilingRecord | null } | null };
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partner = randomUUID();
+  orgA = randomUUID(); orgB = randomUUID(); orgOff = randomUUID();
+  visibleSource = randomUUID(); groupedSource = randomUUID(); orgBSource = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug) VALUES (${partner}, 'wsp-client', ${`wsp-client-${sfx}`})`;
+  for (const [id, label] of [[orgA, 'a'], [orgB, 'b'], [orgOff, 'off']] as const) {
+    await admin`INSERT INTO organizations (id, partner_id, name, slug)
+                VALUES (${id}, ${partner}, ${`wsp-client-${label}`}, ${`wsp-client-${label}-${sfx}`})`;
+  }
+  // Content ON for the two tenants that serve the client surface; orgOff gets
+  // NO settings row at all — default-deny is the behavior under test.
+  await admin`INSERT INTO workspace_org_settings (org_id, content_enabled)
+              VALUES (${orgA}, true), (${orgB}, true)`;
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, visibility_group_ids)
+              VALUES (${visibleSource}, ${orgA}, 'smb_share', 'estate', '\\\\srv\\estate', '[]'::jsonb),
+                     (${groupedSource}, ${orgA}, 'smb_share', 'legal', '\\\\srv\\legal', '["g1"]'::jsonb),
+                     (${orgBSource}, ${orgB}, 'smb_share', 'estate-b', '\\\\srv\\estate-b', '[]'::jsonb)`;
+  await admin`INSERT INTO workspace_projects (org_id, project_key, label)
+              VALUES (${orgA}, '2023-041', 'Henderson Water Main Replacement'),
+                     (${orgA}, '2025-012', 'Fairoaks Tank No 2 Seismic Retrofit')`;
+
+  for (const f of SEED) {
+    const id = randomUUID();
+    ids[f.key] = id;
+    const org = f.org === 'A' ? orgA : orgB;
+    const srcId = f.source === 'grouped' ? groupedSource : f.source === 'orgB' ? orgBSource : visibleSource;
+    const name = f.rel.split('/').pop()!;
+    const parent = f.rel.slice(0, f.rel.lastIndexOf('/'));
+    const ext = name.split('.').pop()!.toLowerCase();
+    await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime)
+                VALUES (${id}, ${org}, ${srcId}, ${f.rel}, ${parent}, ${name}, false, ${ext}, 100, now())`;
+    for (const e of f.entities ?? []) {
+      await admin`INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm, origin)
+                  VALUES (${org}, ${id}, ${e.type}, ${e.value}, ${e.origin ?? 'regex'})`;
+    }
+    const m = f.rel.match(/^Projects\/(\d{4}-\d{3})|^Emails\/(\d{4}-\d{3})\//);
+    const declaredKey = m ? (m[1] ?? m[2]) : null;
+    if (declaredKey || f.emailMeta) {
+      // admin.json(), NOT `${JSON.stringify(x)}::jsonb`: postgres.js treats the
+      // ::jsonb cast as a type hint and JSON-encodes the string it is given, so
+      // the stringify form lands a jsonb STRING SCALAR in the column and every
+      // `email_meta ->> 'subject'` in the matcher reads null. Seeding it wrong
+      // would have made this whole suite pass vacuously.
+      await admin`INSERT INTO workspace_file_enrichment (org_id, file_index_id, declared_project_key, declared_project_label, email_meta)
+                  VALUES (${org}, ${id}, ${declaredKey},
+                          ${declaredKey === '2023-041' ? 'Henderson Water Main Replacement' : null},
+                          ${f.emailMeta ? admin.json(f.emailMeta) : null})`;
+    }
+  }
+
+  // Mine the crosswalk so the hero email's classify has real evidence.
+  await appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } }).session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${orgA}, true),
+                    set_config('breeze.accessible_org_ids', ${orgA}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    await createCrosswalkService(transaction as unknown as WorkspaceDatabase).run(orgA);
+  });
+});
+
+afterAll(async () => {
+  for (const org of [orgA, orgB, orgOff]) {
+    for (const t of ['workspace_email_filings', 'workspace_project_crosswalk', 'workspace_content_entities',
+      'workspace_file_enrichment', 'workspace_file_content', 'workspace_projects',
+      'workspace_file_index', 'workspace_org_settings', 'workspace_sources']) {
+      await admin.unsafe(`DELETE FROM ${t} WHERE org_id = $1`, [org]);
+    }
+    await admin`DELETE FROM organizations WHERE id = ${org}`;
+  }
+  await admin`DELETE FROM partners WHERE id = ${partner}`;
+  await admin.end(); await app.end();
+});
+
+describe('/client gate and content gate (real DB)', () => {
+  it('serves an organization-scoped session', async () => {
+    const res = await request(orgA, '/content/projects');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      projects: [
+        { key: '2023-041', label: 'Henderson Water Main Replacement' },
+        { key: '2025-012', label: 'Fairoaks Tank No 2 Seismic Retrofit' },
+      ],
+    });
+  });
+
+  it('rejects a partner-scoped principal with 403 — /client is end-user only', async () => {
+    const res = await request(orgA, '/content/projects', {}, {
+      auth: { ...orgAuth(orgA), scope: 'partner', partnerId: partner } as WorkspaceAuthContext,
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('404s content_disabled for an org with no settings row (default-deny)', async () => {
+    const res = await request(orgOff, '/content/projects');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'content_disabled' });
+  });
+});
+
+describe('GET /client/filing/match (real DB)', () => {
+  it('matches the open message and classifies it on demand', async () => {
+    const res = await request(orgA, matchPath({
+      subject: `RE: ${HERO_SUBJECT}`,
+      sender: 'pdeluca@fairoaksca.gov',
+      date: minutes(30),
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as MatchBody;
+    expect(body.match?.fileIndexId).toBe(ids.hero);
+    expect(body.match?.tier).toBe(2);
+    // classify-on-demand ran against real crosswalk evidence
+    expect(body.match?.filing).toMatchObject({
+      status: 'suggested',
+      suggestedProjectKey: '2023-041',
+      confidence: 'high',
+      matchedEntityValue: 'PO 4021',
+    });
+  });
+
+  it('matches on internetMessageId at tier 1', async () => {
+    const res = await request(orgA, matchPath({
+      subject: 'anything at all', internetMessageId: '<Hero-4021@fairoaksca.gov>',
+    }));
+    const body = await res.json() as MatchBody;
+    expect(body.match?.fileIndexId).toBe(ids.hero);
+    expect(body.match?.tier).toBe(1);
+  });
+
+  // VISIBILITY (behavioral, not SQL-text): the file exists, is an .eml, is in
+  // the caller's org, and its subject/date match exactly — the ONLY reason it
+  // must not come back is that its source carries a group claim the client
+  // session does not have (groupIds []).
+  it('never matches a file whose source is grouped', async () => {
+    const byDate = await request(orgA, matchPath({
+      subject: GROUPED_SUBJECT, sender: 'pdeluca@fairoaksca.gov', date: BASE.toISOString(),
+    }));
+    expect(await byDate.json()).toEqual({ match: null });
+
+    // …and not through the strongest tier either.
+    const byMessageId = await request(orgA, matchPath({
+      subject: GROUPED_SUBJECT, internetMessageId: 'grouped@fairoaksca.gov',
+    }));
+    expect(await byMessageId.json()).toEqual({ match: null });
+
+    // INVERSE CONTROL — without this the two nulls above would be satisfied by
+    // a mis-seeded row that nothing could ever match. Handed the group claim
+    // the client session lacks, the very same probe finds the very same file:
+    // the group gate is the only thing hiding it.
+    const withClaim = await inOrg(orgA, (db) => createEmailMatchService(db).match(orgA, {
+      subject: GROUPED_SUBJECT, sender: 'pdeluca@fairoaksca.gov', dateISO: BASE.toISOString(),
+    }, ['g1']));
+    expect(withClaim).toEqual({ fileIndexId: ids.grouped, tier: 2 });
+  });
+
+  // ORG SCOPING (behavioral): identical subject, identical sender, identical
+  // date — different tenant.
+  it('never matches an identical-subject email in another org', async () => {
+    const foreignOnly = await request(orgA, matchPath({
+      subject: CROSS_ORG_SUBJECT, sender: 'pdeluca@fairoaksca.gov', date: BASE.toISOString(),
+    }));
+    expect(await foreignOnly.json()).toEqual({ match: null });
+
+    // Inverse control: tenant B finds its own file with the identical probe.
+    const ownedByB = await request(orgB, matchPath({
+      subject: CROSS_ORG_SUBJECT, sender: 'pdeluca@fairoaksca.gov', date: BASE.toISOString(),
+    }));
+    expect(((await ownedByB.json()) as MatchBody).match?.fileIndexId).toBe(ids.crossOnly);
+
+    // Both tenants hold the same subject: each sees only its own file, and the
+    // collision does not make the match ambiguous across the tenant boundary.
+    const fromA = await request(orgA, matchPath({
+      subject: SHARED_SUBJECT, sender: 'pdeluca@fairoaksca.gov', date: BASE.toISOString(),
+    }));
+    expect(((await fromA.json()) as MatchBody).match?.fileIndexId).toBe(ids.sharedA);
+
+    const fromB = await request(orgB, matchPath({
+      subject: SHARED_SUBJECT, sender: 'pdeluca@fairoaksca.gov', date: BASE.toISOString(),
+    }));
+    expect(((await fromB.json()) as MatchBody).match?.fileIndexId).toBe(ids.sharedB);
+  });
+
+  // DATE WINDOW (behavioral, real timestamptz arithmetic): inclusive at ±7d.
+  it.each([
+    ['inside the window (+6d)', day(6), true],
+    ['on the boundary (+7d exactly)', day(7), true],
+    ['on the boundary (-7d exactly)', day(-7), true],
+    ['past the boundary (+7d 1m)', new Date(BASE.getTime() + 7 * 86_400_000 + 60_000).toISOString(), false],
+    ['past the boundary (-8d)', day(-8), false],
+  ])('date window: %s → matched=%s', async (_label, probeDate, expected) => {
+    const res = await request(orgA, matchPath({ subject: WINDOW_SUBJECT, date: probeDate }));
+    const body = await res.json() as MatchBody;
+    expect(body.match?.fileIndexId ?? null).toBe(expected ? ids.window : null);
+  });
+
+  it('answers match null when nothing in the estate resembles the probe', async () => {
+    const res = await request(orgA, matchPath({
+      subject: 'no such message anywhere', date: BASE.toISOString(),
+    }));
+    expect(await res.json()).toEqual({ match: null });
+  });
+});
+
+describe('POST /client/filing/:id/assign (real DB)', () => {
+  async function assign(orgId: string, fileIndexId: string, projectKey: string) {
+    return request(orgId, `/filing/${fileIndexId}/assign`, {
+      method: 'POST',
+      body: JSON.stringify({ projectKey }),
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  async function filingRows(fileIndexId: string) {
+    return admin`SELECT status, decided_project_key, decided_label
+                 FROM workspace_email_filings WHERE file_index_id = ${fileIndexId}`;
+  }
+
+  it('404s an unknown project and a malformed id without writing anything', async () => {
+    expect((await assign(orgA, ids.window, '9999-999')).status).toBe(404);
+    expect((await assign(orgA, 'not-a-uuid', '2023-041')).status).toBe(404);
+  });
+
+  // The invariant the demo rests on: the pane and the tray file into the SAME
+  // row. Same fileIndexId + same projectKey through either path converges —
+  // one row, stable status, no duplicate.
+  it('is idempotent with the device/helper filing path', async () => {
+    // The hero email already has a suggestion (classified via /filing/match).
+    const viaClient = await assign(orgA, ids.hero, '2023-041');
+    expect(viaClient.status).toBe(200);
+    expect(((await viaClient.json()) as { filing: FilingRecord }).filing).toMatchObject({
+      status: 'confirmed', decidedProjectKey: '2023-041',
+    });
+    const afterClient = await filingRows(ids.hero);
+    expect(afterClient).toHaveLength(1);
+    expect(afterClient[0].decided_label).toBe('Jenny Tran');
+
+    // Same file, same project, the OTHER path (helper/device route).
+    const viaHelper = await request(orgA, `/filing/${ids.hero}/assign`, {
+      method: 'POST',
+      body: JSON.stringify({ projectKey: '2023-041', helperUser: 'Front desk' }),
+      headers: { 'content-type': 'application/json' },
+    }, { surface: 'helper' });
+    expect(viaHelper.status).toBe(200);
+    expect(((await viaHelper.json()) as { filing: FilingRecord }).filing).toMatchObject({
+      status: 'confirmed', decidedProjectKey: '2023-041',
+    });
+
+    const afterHelper = await filingRows(ids.hero);
+    expect(afterHelper).toHaveLength(1);
+    expect(afterHelper[0].status).toBe('confirmed');
+    expect(afterHelper[0].decided_project_key).toBe('2023-041');
+
+    // And back through /client once more: still one row, still confirmed.
+    expect((await assign(orgA, ids.hero, '2023-041')).status).toBe(200);
+    const afterRepeat = await filingRows(ids.hero);
+    expect(afterRepeat).toHaveLength(1);
+    expect(afterRepeat[0].status).toBe('confirmed');
+  });
+
+  it('re-matching after a decision returns the decided row without re-classifying', async () => {
+    const res = await request(orgA, matchPath({
+      subject: `RE: ${HERO_SUBJECT}`, sender: 'pdeluca@fairoaksca.gov', date: BASE.toISOString(),
+    }));
+    const body = await res.json() as MatchBody;
+    expect(body.match?.filing).toMatchObject({
+      status: 'confirmed', decidedProjectKey: '2023-041',
+    });
+  });
+
+  it('cannot file a file that belongs to another org', async () => {
+    const res = await assign(orgA, ids.crossOnly, '2023-041');
+    expect(res.status).toBe(404);
+    // Tenant B classified this file for itself earlier; tenant A's attempt
+    // must leave that row completely undecided.
+    const rows = await filingRows(ids.crossOnly);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: 'suggested', decided_project_key: null });
+  });
+
+  // C-1 regression. A 404 alone is NOT evidence the write was blocked: the
+  // UPDATE used to run keyed on (org_id, file_index_id) only, and the
+  // visibility check happened afterwards — so a caller with no group claims
+  // could blind-write a human filing decision onto a file it is forbidden to
+  // see and still be told "not found". Seed a filing row on the grouped file
+  // (as admin — nothing the client surface can reach could ever create one)
+  // so the assertion has something to be mutated, then prove it is untouched.
+  it('cannot file a file whose source is grouped — and writes nothing', async () => {
+    await admin`INSERT INTO workspace_email_filings
+                  (org_id, file_index_id, status, suggested_project_key, confidence, rationale)
+                VALUES (${orgA}, ${ids.grouped}, 'suggested', '2025-012', 'low', 'seeded for the write-gate probe')
+                ON CONFLICT (file_index_id) DO NOTHING`;
+
+    const res = await assign(orgA, ids.grouped, '2023-041');
+    expect(res.status).toBe(404);
+
+    const rows = await filingRows(ids.grouped);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      status: 'suggested', decided_project_key: null, decided_label: null,
+    });
+  });
+});

--- a/ee/workspace/src/__tests__/content.integration.test.ts
+++ b/ee/workspace/src/__tests__/content.integration.test.ts
@@ -1,4 +1,4 @@
-// Content phase (dev-preview) — migration/RLS/lifecycle integration coverage.
+// Content layer — migration/RLS/lifecycle integration coverage.
 // Mirrors workspaceRls.integration.test.ts bootstrap (:5433 stack, breeze_app
 // role, asOrg GUC scoping). Covers, per new content table:
 //   - RLS shape 1: org A context can neither read nor forge org B rows

--- a/ee/workspace/src/__tests__/dashboard.integration.test.ts
+++ b/ee/workspace/src/__tests__/dashboard.integration.test.ts
@@ -1,0 +1,315 @@
+// W3 Task 6: dashboardService.summary — real-DB integration (:5433 stack,
+// breeze_app role). Seeds one org with two sources (one grouped — proves the
+// org-operator-scope decision: the dashboard counts grouped sources, unlike
+// every visibility-scoped helper read), a full spread of content statuses
+// (incl. blocked_dlp), an enrichment gap, chunks, a mixed filing pool (incl.
+// one declared-path email that must be EXCLUDED), activity, a project +
+// crosswalk, and one ingest job — then asserts summary() numbers against the
+// seed arithmetic by hand. A second org proves the RLS probe: querying org
+// A's id from org B's session context reads back an all-zero summary, not an
+// error and not org A's data (silent-0-row RLS, same idiom as
+// ingestJobs.integration.test.ts / visibilityIntersection.integration.test.ts).
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { WorkspaceDatabase } from '../hostTypes';
+import type { ContentByteReader } from '../content/byteReader';
+import { createContentIngestService } from '../services/contentIngestService';
+import { createDashboardService } from '../services/dashboardService';
+import { createIngestJobsService } from '../services/ingestJobsService';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partnerA: string, partnerB: string, orgA: string, orgB: string;
+let source1: string, source2: string;
+let runRunning: string, runComplete: string;
+let jobId: string;
+const ids: Record<string, string> = {};
+
+const FIXED_SIZE = 1000;
+const FIXED_MTIME = new Date('2026-07-10T00:00:00Z');
+
+// Never actually read: status()/summary() do not touch bytes.
+const stubReader: ContentByteReader = { read: async () => { throw new Error('unused in this suite'); } };
+
+/** Run fn as breeze_app inside the given org's access context (mirrors withDbAccessContext). */
+async function withOrg<T>(org: string, partner: string, fn: (db: WorkspaceDatabase) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } }).session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(transaction as unknown as WorkspaceDatabase);
+  }) as Promise<T>;
+}
+
+function dashboardFor(db: WorkspaceDatabase) {
+  const contentIngest = createContentIngestService(db, { reader: stubReader });
+  return createDashboardService(db, { contentIngestStatus: (orgId) => contentIngest.status(orgId) });
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+
+  partnerA = randomUUID(); partnerB = randomUUID();
+  orgA = randomUUID(); orgB = randomUUID();
+  source1 = randomUUID(); source2 = randomUUID();
+  runRunning = randomUUID(); runComplete = randomUUID();
+  jobId = randomUUID();
+  const sfx = randomUUID();
+
+  await admin`INSERT INTO partners (id, name, slug)
+              VALUES (${partnerA}, 'wsp-dash-a', ${`wsp-dash-a-${sfx}`}),
+                     (${partnerB}, 'wsp-dash-b', ${`wsp-dash-b-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${orgA}, ${partnerA}, 'wsp-dash-org-a', ${`wsp-dash-org-a-${sfx}`}),
+                     (${orgB}, ${partnerB}, 'wsp-dash-org-b', ${`wsp-dash-org-b-${sfx}`})`;
+
+  // Two sources: source1 ungrouped+active (content-eligible), source2
+  // GROUPED — the org-operator-scope pin: the sources card must still count
+  // it, unlike every visibility-scoped helper read.
+  await admin`INSERT INTO workspace_sources
+                (id, org_id, kind, display_name, root_path, visibility_group_ids, status, last_complete_run_at)
+              VALUES
+                (${source1}, ${orgA}, 'smb_share', 'Alpha SMB', '\\\\srv\\alpha', '[]'::jsonb, 'active',
+                 '2026-07-15T00:00:00Z'),
+                (${source2}, ${orgA}, 'smb_share', 'Bravo Grouped', '\\\\srv\\bravo', '["g1"]'::jsonb, 'active', NULL)`;
+
+  // A running crawl run (must surface as activeRun) and a completed one
+  // (must NOT — only status='running' qualifies).
+  await admin`INSERT INTO workspace_crawl_runs (id, org_id, source_id, status, started_at)
+              VALUES (${runRunning}, ${orgA}, ${source1}, 'running', now() - interval '30 minutes'),
+                     (${runComplete}, ${orgA}, ${source1}, 'complete', now() - interval '2 hours')`;
+
+  // File spread under source1: content-status coverage (f1..f6), a live dir
+  // (f7), a tombstoned file (f8, excluded everywhere), and the filing pool
+  // (f9..f13, one of which — f13 — DECLARES a project via its path and must
+  // be excluded from every filing count).
+  const fileRows: Array<{
+    key: string; relPath: string; isDir?: boolean; deleted?: boolean; lastSeenAt?: string;
+  }> = [
+    { key: 'f1', relPath: 'Docs/f1.md', lastSeenAt: '2026-07-19T01:00:00Z' },
+    { key: 'f2', relPath: 'Docs/f2.md', lastSeenAt: '2026-07-19T02:00:00Z' }, // newest live row
+    { key: 'f3', relPath: 'Docs/f3.md', lastSeenAt: '2026-07-19T00:30:00Z' },
+    { key: 'f4', relPath: 'Docs/f4.pdf', lastSeenAt: '2026-07-19T00:20:00Z' },
+    { key: 'f5', relPath: 'Docs/f5.jpg', lastSeenAt: '2026-07-19T00:10:00Z' },
+    { key: 'f6', relPath: 'Docs/f6.md', lastSeenAt: '2026-07-19T00:05:00Z' },
+    // newestSeenAt spans ALL live rows, not just files — give the dir a seen
+    // time older than f2 so it doesn't accidentally become "newest" via the
+    // now()-defaulted fallback below.
+    { key: 'f7', relPath: 'Docs', isDir: true, lastSeenAt: '2026-07-19T00:15:00Z' },
+    { key: 'f8', relPath: 'Docs/gone.md', deleted: true },
+    // f9-f13 are live rows too — every lastSeenAt below stays older than f2's
+    // so newestSeenAt has exactly one candidate.
+    { key: 'f9', relPath: 'Unfiled/none.eml', lastSeenAt: '2026-07-19T00:04:00Z' },
+    { key: 'f10', relPath: 'Unfiled/suggested.eml', lastSeenAt: '2026-07-19T00:03:00Z' },
+    { key: 'f11', relPath: 'Unfiled/confirmed.eml', lastSeenAt: '2026-07-19T00:02:00Z' },
+    { key: 'f12', relPath: 'Unfiled/reassigned.eml', lastSeenAt: '2026-07-19T00:01:00Z' },
+    { key: 'f13', relPath: 'Projects/2023-041 Henderson/note.eml', lastSeenAt: '2026-07-19T00:00:30Z' },
+  ];
+  for (const f of fileRows) {
+    const id = randomUUID();
+    ids[f.key] = id;
+    const name = f.relPath.split('/').pop()!;
+    const parent = f.relPath.includes('/') ? f.relPath.slice(0, f.relPath.lastIndexOf('/')) : '';
+    const ext = name.includes('.') ? name.split('.').pop()!.toLowerCase() : null;
+    const size = f.isDir ? null : FIXED_SIZE;
+    const mtime = f.isDir ? null : FIXED_MTIME;
+    await admin`INSERT INTO workspace_file_index
+        (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime, last_seen_at, deleted_at)
+        VALUES (${id}, ${orgA}, ${source1}, ${f.relPath}, ${parent}, ${name}, ${f.isDir ?? false}, ${ext},
+                ${size}, ${mtime}, ${f.lastSeenAt ? new Date(f.lastSeenAt) : new Date()},
+                ${f.deleted ? new Date() : null})`;
+  }
+  // source2's single (grouped) file — proves the sources card counts it.
+  const g1 = randomUUID();
+  ids.g1 = g1;
+  await admin`INSERT INTO workspace_file_index
+      (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime, last_seen_at)
+      VALUES (${g1}, ${orgA}, ${source2}, 'GroupDocs/g1.md', 'GroupDocs', 'g1.md', false, 'md', 500,
+              ${FIXED_MTIME}, '2026-07-19T03:00:00Z')`;
+
+  // Content rows: two extracted (f1 enriched, f2 not — enrichPending pin),
+  // one of each failure/skip mode, one blocked_dlp. Snapshots match the file
+  // rows exactly so none of these six is "pending" (only f9-f13 are).
+  await admin`INSERT INTO workspace_file_content
+      (org_id, file_index_id, content_hash, source_size, source_mtime, extracted_text, status)
+      VALUES
+        (${orgA}, ${ids.f1}, 'hash-f1', ${FIXED_SIZE}, ${FIXED_MTIME}, 'body one', 'extracted'),
+        (${orgA}, ${ids.f2}, 'hash-f2', ${FIXED_SIZE}, ${FIXED_MTIME}, 'body two', 'extracted'),
+        (${orgA}, ${ids.f3}, NULL, ${FIXED_SIZE}, ${FIXED_MTIME}, NULL, 'failed'),
+        (${orgA}, ${ids.f4}, NULL, ${FIXED_SIZE}, ${FIXED_MTIME}, NULL, 'skipped_too_large'),
+        (${orgA}, ${ids.f5}, NULL, ${FIXED_SIZE}, ${FIXED_MTIME}, NULL, 'skipped_binary'),
+        (${orgA}, ${ids.f6}, NULL, ${FIXED_SIZE}, ${FIXED_MTIME}, NULL, 'blocked_dlp')`;
+
+  // f1 is enriched (model set); f2 deliberately is not → enrichPending pins to 1.
+  await admin`INSERT INTO workspace_file_enrichment (org_id, file_index_id, model, enriched_at)
+              VALUES (${orgA}, ${ids.f1}, 'claude-haiku-4-5', now())`;
+
+  // Three chunks, all on f1.
+  await admin`INSERT INTO workspace_content_chunks (org_id, file_index_id, chunk_index, text)
+              VALUES (${orgA}, ${ids.f1}, 0, 'chunk 0'),
+                     (${orgA}, ${ids.f1}, 1, 'chunk 1'),
+                     (${orgA}, ${ids.f1}, 2, 'chunk 2')`;
+
+  // Filing pool: f9 untouched, f10 suggested+high-confidence, f11 confirmed,
+  // f12 reassigned. f13 (declared path) gets NO filing row and must never
+  // appear in any filing count regardless.
+  await admin`INSERT INTO workspace_email_filings
+      (org_id, file_index_id, status, suggested_project_key, suggested_project_label, confidence,
+       decided_project_key)
+      VALUES
+        (${orgA}, ${ids.f10}, 'suggested', '2023-041', 'Henderson', 'high', NULL),
+        (${orgA}, ${ids.f11}, 'confirmed', '2023-041', 'Henderson', 'low', '2023-041'),
+        (${orgA}, ${ids.f12}, 'reassigned', '2023-099', 'Other Job', 'low', '2023-041')`;
+
+  // Project + crosswalk.
+  await admin`INSERT INTO workspace_projects (org_id, project_key, label)
+              VALUES (${orgA}, '2023-041', 'Henderson')`;
+  await admin`INSERT INTO workspace_project_crosswalk
+      (org_id, entity_type, value_norm, project_key, project_label, evidence_count)
+      VALUES (${orgA}, 'po', 'PO 1', '2023-041', 'Henderson', 3),
+             (${orgA}, 'invoice', 'INV 9', '2023-041', 'Henderson', 2)`;
+
+  // Activity: f1 has two events (one within the 7-day window, one outside —
+  // pins the events7d filter without moving last_activity_at); f2 has one,
+  // strictly older than f1's most recent, pinning the recency ORDER BY.
+  await admin`INSERT INTO workspace_file_activity (org_id, file_index_id, action, created_at)
+              VALUES (${orgA}, ${ids.f1}, 'open', now() - interval '1 day'),
+                     (${orgA}, ${ids.f1}, 'open', now() - interval '10 days'),
+                     (${orgA}, ${ids.f2}, 'open', now() - interval '2 days')`;
+
+  // One ingest job — GET /dashboard/jobs is a thin proxy over
+  // ingestJobsService.list, exercised directly against real PG here.
+  await admin`INSERT INTO workspace_ingest_jobs (id, org_id, source_id, trigger, status)
+              VALUES (${jobId}, ${orgA}, ${source1}, 'manual', 'pending')`;
+});
+
+afterAll(async () => {
+  await admin`DELETE FROM workspace_project_crosswalk WHERE org_id = ${orgA}`;
+  await admin`DELETE FROM workspace_projects WHERE org_id = ${orgA}`;
+  // Cascades away file_index, file_content, entities, enrichment, chunks,
+  // email_filings, file_activity, crawl_runs, and ingest_jobs.
+  await admin`DELETE FROM workspace_sources WHERE org_id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM organizations WHERE id IN (${orgA}, ${orgB})`;
+  await admin`DELETE FROM partners WHERE id IN (${partnerA}, ${partnerB})`;
+  await admin.end(); await app.end();
+});
+
+describe('dashboardService.summary (W3 Task 6, real PG as breeze_app)', () => {
+  it('sources: counts BOTH sources including the grouped one (org-operator scope)', async () => {
+    const { sources } = await withOrg(orgA, partnerA, (db) => dashboardFor(db).summary(orgA));
+
+    expect(sources).toHaveLength(2);
+    const bySourceId = new Map(sources.map((s) => [s.id, s]));
+
+    const alpha = bySourceId.get(source1)!;
+    expect(alpha).toMatchObject({
+      name: 'Alpha SMB', kind: 'smb_share', status: 'active',
+      lastCompleteRunAt: '2026-07-15T00:00:00.000Z',
+      liveFiles: 11, liveDirs: 1, tombstoned: 1,
+      newestSeenAt: '2026-07-19T02:00:00.000Z',
+    });
+    expect(alpha.activeRun).toMatchObject({ id: runRunning, status: 'running' });
+    expect(alpha.activeRun?.id).not.toBe(runComplete);
+
+    // The grouped source — this is the pin: it IS present and counted.
+    const bravo = bySourceId.get(source2)!;
+    expect(bravo).toMatchObject({
+      name: 'Bravo Grouped', kind: 'smb_share', status: 'active',
+      lastCompleteRunAt: null, liveFiles: 1, liveDirs: 0, tombstoned: 0,
+      newestSeenAt: '2026-07-19T03:00:00.000Z', activeRun: null,
+    });
+  });
+
+  it('ingest: eligible/status counts (incl. blockedDlp), pending, enrichPending, chunks', async () => {
+    const { ingest } = await withOrg(orgA, partnerA, (db) => dashboardFor(db).summary(orgA));
+
+    // eligible = source1's live non-dir files only (source2 is grouped, excluded
+    // from the ingest-eligibility predicate): f1..f6, f9..f13 = 11.
+    expect(ingest.eligible).toBe(11);
+    expect(ingest.extracted).toBe(2);
+    expect(ingest.failed).toBe(1);
+    expect(ingest.skippedTooLarge).toBe(1);
+    expect(ingest.skippedBinary).toBe(1);
+    expect(ingest.blockedDlp).toBe(1);
+    // pending = eligible files with no matching content snapshot: f9..f13 (5).
+    expect(ingest.pending).toBe(5);
+    expect(ingest.enrichPending).toBe(1); // f2 only
+    expect(ingest.chunks).toBe(3);
+  });
+
+  it('filing: unfiled/suggested/confirmed/reassigned/highConfidence partition; declared path excluded', async () => {
+    const { filing } = await withOrg(orgA, partnerA, (db) => dashboardFor(db).summary(orgA));
+
+    // Pool = f9 (untouched) + f10 (suggested) — both still undecided.
+    expect(filing.unfiled).toBe(2);
+    expect(filing.suggested).toBe(1);
+    expect(filing.confirmed).toBe(1);
+    expect(filing.reassigned).toBe(1);
+    expect(filing.highConfidence).toBe(1);
+
+    expect(filing.queue).toHaveLength(2);
+    const byId = new Map(filing.queue.map((q) => [q.id, q]));
+    expect(byId.get(ids.f9)).toMatchObject({ relPath: 'Unfiled/none.eml', suggestedProjectLabel: null, confidence: null });
+    expect(byId.get(ids.f10)).toMatchObject({ relPath: 'Unfiled/suggested.eml', suggestedProjectLabel: 'Henderson', confidence: 'high' });
+    // f13 (declared path) must never appear, in the queue or the counts.
+    expect(byId.has(ids.f13)).toBe(false);
+  });
+
+  it('activity: top-15 by recency with 7-day event counts, org-wide', async () => {
+    const { activity } = await withOrg(orgA, partnerA, (db) => dashboardFor(db).summary(orgA));
+
+    expect(activity).toHaveLength(2);
+    expect(activity[0]).toMatchObject({ fileIndexId: ids.f1, events7d: 1 }); // 1-day-ago event only
+    expect(activity[1]).toMatchObject({ fileIndexId: ids.f2, events7d: 1 });
+    expect(new Date(activity[0].lastActivityAt).getTime()).toBeGreaterThan(new Date(activity[1].lastActivityAt).getTime());
+  });
+
+  it('projects: filed (confirmed+suggested, not reassigned), crosswalk rows, summed evidence', async () => {
+    const { projects } = await withOrg(orgA, partnerA, (db) => dashboardFor(db).summary(orgA));
+
+    expect(projects).toEqual([
+      { projectKey: '2023-041', label: 'Henderson', filedEmails: 2, crosswalkEntities: 2, evidenceFiles: 5 },
+    ]);
+  });
+
+  it('generatedAt is a DB-clock ISO timestamp', async () => {
+    const before = Date.now();
+    const { generatedAt } = await withOrg(orgA, partnerA, (db) => dashboardFor(db).summary(orgA));
+    const ts = new Date(generatedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before - 60_000); // sanity bound, not host-clock equality
+    expect(ts).toBeLessThanOrEqual(Date.now() + 60_000);
+  });
+
+  it('ingestJobsService.list surfaces the seeded job (dashboard/jobs proxy target)', async () => {
+    const jobs = await withOrg(orgA, partnerA, (db) => createIngestJobsService(db).list(orgA));
+    expect(jobs.map((j) => j.id)).toContain(jobId);
+  });
+
+  it('RLS probe: org B session reading org A\'s id gets an all-zero summary, not org A\'s data', async () => {
+    const summary = await withOrg(orgB, partnerB, (db) => dashboardFor(db).summary(orgA));
+
+    expect(summary.sources).toEqual([]);
+    expect(summary.ingest).toEqual({
+      eligible: 0, extracted: 0, failed: 0, skippedTooLarge: 0, skippedBinary: 0,
+      blockedDlp: 0, pending: 0, enrichPending: 0, chunks: 0,
+    });
+    expect(summary.filing).toEqual({
+      unfiled: 0, suggested: 0, confirmed: 0, reassigned: 0, highConfidence: 0, queue: [],
+    });
+    expect(summary.activity).toEqual([]);
+    expect(summary.projects).toEqual([]);
+  });
+});

--- a/ee/workspace/src/__tests__/dlpIngest.integration.test.ts
+++ b/ee/workspace/src/__tests__/dlpIngest.integration.test.ts
@@ -52,6 +52,26 @@ const DLP_CONFIG = {
   customPatterns: [],
 };
 
+// force re-scan case: a file that is CLEAN under DLP_CONFIG (email off) but that
+// a later, tightened config (email block) must flip to blocked_dlp — WITHOUT any
+// byte change. Carries a PO number (a regex entity that lands on the clean pass
+// and must be purged on the forced block). This is W2's a22f079 scenario reached
+// via force instead of a byte change.
+const FORCE_REL = 'Projects/Comms/team-memo.md';
+const FORCE_CLEAN_BYTES = 'Team memo. PO 5501 covers the project. Reach alex@example.com with any questions.';
+const DLP_CONFIG_EMAIL_BLOCK = {
+  detectors: {
+    credit_card: 'redact', ssn: 'block', iban: 'off', api_key: 'off', email: 'block', phone: 'off',
+  },
+  customPatterns: [],
+};
+
+// transient case: a pending file whose byte read fails (source down). The run
+// must abort and leave NO content row, so the file stays pending and re-ingests
+// cleanly once the source is back.
+const TRANSIENT_REL = 'Projects/Ops/status-note.md';
+const TRANSIENT_BYTES = 'Ops status note. PO 6602 tracked. All systems nominal.';
+
 /** In-memory reader: rel_path → bytes. No disk, no network. */
 class MapReader implements ContentByteReader {
   constructor(private readonly files: Record<string, string>) {}
@@ -125,6 +145,32 @@ async function ingest(batch: number) {
 async function ingestWith(files: Record<string, string>, batch: number) {
   return withOrgTx((db) => createContentIngestService(db, {
     reader: new MapReader(files),
+    embedder: capturingEmbedder,
+  }).run(org, batch));
+}
+
+// Forced sweep: re-scans EVERY eligible file against the current config. The
+// map must therefore cover every live file's current bytes, or a missing
+// fixture would read-fail and abort the sweep.
+async function ingestForce(files: Record<string, string>, batch: number) {
+  return withOrgTx((db) => createContentIngestService(db, {
+    reader: new MapReader(files),
+    embedder: capturingEmbedder,
+  }).run(org, batch, { force: true }));
+}
+
+/** Reader that fails the read for one rel_path (source-down simulation). */
+class DownReader implements ContentByteReader {
+  constructor(private readonly down: string) {}
+  async read(_source: ContentSourceRef, relPath: string): Promise<Buffer> {
+    if (relPath === this.down) throw new Error('connect ECONNREFUSED 127.0.0.1:445');
+    throw new Error(`no fixture for ${relPath}`);
+  }
+}
+
+async function ingestWithReader(rd: ContentByteReader, batch: number) {
+  return withOrgTx((db) => createContentIngestService(db, {
+    reader: rd,
     embedder: capturingEmbedder,
   }).run(org, batch));
 }
@@ -307,5 +353,88 @@ describe('DLP-on-ingest (real DB)', () => {
     const entitiesAfter = await admin`SELECT id FROM workspace_content_entities
                                       WHERE file_index_id = ${transitionId} AND origin = 'regex'`;
     expect(entitiesAfter).toHaveLength(0);
+  });
+
+  it('force re-scan flips a stored clean file to blocked_dlp after tightening the config (no byte change)', async () => {
+    const forceId = randomUUID();
+    fileIds[FORCE_REL] = forceId;
+    const parent = FORCE_REL.slice(0, FORCE_REL.lastIndexOf('/'));
+    const name = FORCE_REL.split('/').pop()!;
+    await admin`INSERT INTO workspace_file_index
+                  (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime)
+                VALUES (${forceId}, ${org}, ${source}, ${FORCE_REL}, ${parent}, ${name}, false, 'md', 100, now())`;
+
+    // v1: clean ingest under DLP_CONFIG (email off) → extracted, chunks + PO entity.
+    const clean = await ingestWith({ [FORCE_REL]: FORCE_CLEAN_BYTES }, 10);
+    expect(clean.errors).toEqual([]);
+    expect(clean.transient).toBeNull();
+    const [cleanRow] = await admin`SELECT status, extracted_text FROM workspace_file_content
+                                   WHERE file_index_id = ${forceId}`;
+    expect(cleanRow.status).toBe('extracted');
+    expect(cleanRow.extracted_text as string).toContain('alex@example.com'); // email survived (off)
+    const chunksBefore = await admin`SELECT id FROM workspace_content_chunks WHERE file_index_id = ${forceId}`;
+    expect(chunksBefore.length).toBeGreaterThan(0);
+    const entitiesBefore = await admin`SELECT id FROM workspace_content_entities
+                                       WHERE file_index_id = ${forceId} AND origin = 'regex'`;
+    expect(entitiesBefore.length).toBeGreaterThan(0);
+
+    // Tighten the org config so email now BLOCKS — same bytes, new verdict.
+    await admin`UPDATE workspace_org_settings SET dlp_config = ${JSON.stringify(DLP_CONFIG_EMAIL_BLOCK)}::jsonb
+                WHERE org_id = ${org}`;
+
+    // Forced sweep re-applies DLP to every eligible file — supply the full
+    // estate's current bytes so no read aborts the sweep.
+    const forced = await ingestForce({
+      [REDACT_REL]: REDACT_BYTES,
+      [BLOCK_REL]: BLOCK_BYTES,
+      [TRANSITION_REL]: TRANSITION_BLOCK_BYTES,
+      [FORCE_REL]: FORCE_CLEAN_BYTES,
+    }, 50);
+    expect(forced.errors).toEqual([]);
+    expect(forced.transient).toBeNull();
+
+    const [forcedRow] = await admin`SELECT status, extracted_text, dlp_findings FROM workspace_file_content
+                                    WHERE file_index_id = ${forceId}`;
+    expect(forcedRow.status).toBe('blocked_dlp');
+    expect(forcedRow.extracted_text).toBeNull();
+    const findings = forcedRow.dlp_findings as Array<{ detector: string; action: string }>;
+    expect(findings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ detector: 'email', action: 'block' }),
+    ]));
+
+    // Stale chunks + regex entities from the clean pass must be purged — the
+    // passages/chunk scope has no status join, so any survivor stays retrievable.
+    const chunksAfter = await admin`SELECT id FROM workspace_content_chunks WHERE file_index_id = ${forceId}`;
+    expect(chunksAfter).toHaveLength(0);
+    const entitiesAfter = await admin`SELECT id FROM workspace_content_entities
+                                      WHERE file_index_id = ${forceId} AND origin = 'regex'`;
+    expect(entitiesAfter).toHaveLength(0);
+  });
+
+  it('a transient read failure leaves the file pending (no row) and it re-ingests once the source is back', async () => {
+    const transientId = randomUUID();
+    fileIds[TRANSIENT_REL] = transientId;
+    const parent = TRANSIENT_REL.slice(0, TRANSIENT_REL.lastIndexOf('/'));
+    const name = TRANSIENT_REL.split('/').pop()!;
+    await admin`INSERT INTO workspace_file_index
+                  (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime)
+                VALUES (${transientId}, ${org}, ${source}, ${TRANSIENT_REL}, ${parent}, ${name}, false, 'md', 100, now())`;
+
+    // Source down: the only pending file read-fails → the run aborts and writes
+    // nothing for it.
+    const down = await ingestWithReader(new DownReader(TRANSIENT_REL), 10);
+    expect(down.transient).not.toBeNull();
+    expect(down.transient!.reason).toMatch(/reader:.*ECONNREFUSED/);
+    expect(down.processed).toBe(0);
+    const absent = await admin`SELECT id FROM workspace_file_content WHERE file_index_id = ${transientId}`;
+    expect(absent).toHaveLength(0); // fully pending: no failed/blocked row parked it
+
+    // Source back: the still-pending file ingests cleanly.
+    const back = await ingestWith({ [TRANSIENT_REL]: TRANSIENT_BYTES }, 10);
+    expect(back.errors).toEqual([]);
+    expect(back.transient).toBeNull();
+    expect(back.processed).toBe(1);
+    const [row] = await admin`SELECT status FROM workspace_file_content WHERE file_index_id = ${transientId}`;
+    expect(row.status).toBe('extracted');
   });
 });

--- a/ee/workspace/src/__tests__/filing.integration.test.ts
+++ b/ee/workspace/src/__tests__/filing.integration.test.ts
@@ -25,7 +25,7 @@ interface SeedFile {
   rel: string;
   entities?: Array<{ type: string; value: string; origin?: string }>;
   declared?: { key: string; label: string };
-  emailMeta?: object;
+  emailMeta?: Record<string, string>;
   /** Seed into the hidden ('["g1"]') source instead of the visible estate. */
   sourceOverride?: 'hidden';
 }
@@ -129,10 +129,15 @@ beforeAll(async () => {
     const m = f.rel.match(/^(?:Projects|Short Term)\/(\d{4}-\d{3})|^Emails\/(\d{4}-\d{3})\//);
     const declaredKey = m ? (m[1] ?? m[2]) : null;
     if (declaredKey || f.emailMeta) {
+      // admin.json(), never a stringify + ::jsonb cast: postgres.js reads the
+      // cast as a type hint and JSON-encodes the string it is handed, landing a
+      // jsonb STRING SCALAR in the column — after which every
+      // `email_meta ->> 'subject'` reads null and email assertions pass
+      // vacuously. Same note as client-filing.integration.test.ts.
       await admin`INSERT INTO workspace_file_enrichment (org_id, file_index_id, declared_project_key, declared_project_label, email_meta)
                   VALUES (${org}, ${id}, ${declaredKey},
                           ${declaredKey === '2023-041' ? 'Henderson Water Main Replacement' : declaredKey === '2025-012' ? 'Fairoaks Tank No 2 Seismic Retrofit' : declaredKey === '2020-088' ? 'Millbrook Acres Wildfire Rebuild' : null},
-                          ${f.emailMeta ? JSON.stringify(f.emailMeta) : null}::jsonb)`;
+                          ${f.emailMeta ? admin.json(f.emailMeta) : null})`;
     }
   }
 });

--- a/ee/workspace/src/__tests__/fixtures/emails/with-message-id.eml
+++ b/ee/workspace/src/__tests__/fixtures/emails/with-message-id.eml
@@ -1,0 +1,7 @@
+From: Paul Deluca <pdeluca@fairoaksca.gov>
+To: Maria Cortez <mcortez@aldercreekeng.com>
+Subject: PO 4021 issued
+Date: 15 Aug 2023 09:00:00 -0700
+Message-ID: <CAF7x2Q9Abc123@mail.fairoaksca.gov>
+
+Notice to proceed under PO 4021.

--- a/ee/workspace/src/__tests__/forceSweep.integration.test.ts
+++ b/ee/workspace/src/__tests__/forceSweep.integration.test.ts
@@ -1,0 +1,168 @@
+// Force-sweep convergence — real-DB integration (:5433 stack, breeze_app role).
+//
+// Regression for the estate-sized-batch bug: contentIngestService.run reported
+// `remaining` via the NON-force snapshot count, which is already 0 for an
+// already-extracted estate. A force sweep over MORE files than the batch size
+// therefore re-walked only the first batch and reported remaining=0, so the job
+// runner phase-completed after visiting a fraction of the estate — retrying
+// could never advance. The fix returns a FORCE-AWARE remaining: the count of
+// eligible files not yet refreshed at/after forceSince this sweep, which drains
+// to 0 exactly when the whole estate has been re-walked.
+//
+// Harness mirrors the ingest/dlp integration suites: seed via breeze_test, run
+// via breeze_app under the org access context, in-memory reader + FakeEmbedder.
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createContentIngestService } from '../services/contentIngestService';
+import { FakeEmbedder } from '../content/embedder';
+import type { ContentByteReader, ContentSourceRef } from '../content/byteReader';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+// A five-file estate driven with batch=2 — deliberately larger than one batch,
+// the case the non-force snapshot count masked.
+const RELS = [
+  'Projects/A/one.md',
+  'Projects/A/two.md',
+  'Projects/B/three.md',
+  'Projects/B/four.md',
+  'Projects/C/five.md',
+];
+const BATCH = 2;
+const files: Record<string, string> = Object.fromEntries(
+  RELS.map((rel, i) => [rel, `Document ${i}. PO ${4000 + i} covers the work. Body text for ${rel}.`]),
+);
+
+// DLP off for every detector — this suite is about sweep convergence, not DLP.
+const DLP_CONFIG = {
+  detectors: { credit_card: 'off', ssn: 'off', iban: 'off', api_key: 'off', email: 'off', phone: 'off' },
+  customPatterns: [],
+};
+
+class MapReader implements ContentByteReader {
+  constructor(private readonly map: Record<string, string>) {}
+  async read(_source: ContentSourceRef, relPath: string): Promise<Buffer> {
+    const body = this.map[relPath];
+    if (body === undefined) throw new Error(`no fixture for ${relPath}`);
+    return Buffer.from(body, 'utf8');
+  }
+}
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partner: string, org: string, source: string;
+const fileIds: Record<string, string> = {};
+
+async function withOrgTx<T>(fn: (db: WorkspaceDatabase) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } }).session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(transaction as unknown as WorkspaceDatabase);
+  });
+}
+
+function run(batch: number, opts?: { force?: boolean; forceSince?: Date }) {
+  return withOrgTx((db) => createContentIngestService(db, {
+    reader: new MapReader(files),
+    embedder: new FakeEmbedder(), // plumbing only
+  }).run(org, batch, opts));
+}
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+  partner = randomUUID(); org = randomUUID(); source = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug) VALUES (${partner}, 'wsp-force', ${`wsp-force-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${org}, ${partner}, 'wsp-force-org', ${`wsp-force-org-${sfx}`})`;
+  await admin`INSERT INTO workspace_org_settings (org_id, content_enabled, dlp_config)
+              VALUES (${org}, true, ${JSON.stringify(DLP_CONFIG)}::jsonb)`;
+  await admin`INSERT INTO workspace_sources (id, org_id, kind, display_name, root_path, visibility_group_ids)
+              VALUES (${source}, ${org}, 'smb_share', 'force estate', '\\\\127.0.0.1\\force', '[]'::jsonb)`;
+  for (const rel of RELS) {
+    const id = randomUUID();
+    fileIds[rel] = id;
+    const parent = rel.slice(0, rel.lastIndexOf('/'));
+    const name = rel.split('/').pop()!;
+    await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, parent_path, name, is_dir, ext, size, mtime)
+                VALUES (${id}, ${org}, ${source}, ${rel}, ${parent}, ${name}, false, 'md', 100, now())`;
+  }
+});
+
+afterAll(async () => {
+  for (const t of ['workspace_content_chunks', 'workspace_content_entities', 'workspace_file_enrichment',
+    'workspace_file_content', 'workspace_projects', 'workspace_file_index', 'workspace_sources',
+    'workspace_org_settings']) {
+    await admin.unsafe(`DELETE FROM ${t} WHERE org_id = $1`, [org]);
+  }
+  await admin`DELETE FROM organizations WHERE id = ${org}`;
+  await admin`DELETE FROM partners WHERE id = ${partner}`;
+  await admin.end(); await app.end();
+});
+
+describe('force-sweep convergence across a multi-batch estate (real DB)', () => {
+  it('a repeated force sweep re-walks EVERY file, decreasing remaining monotonically to 0', async () => {
+    // 1. Non-force drain: all five files become extracted in one pass.
+    const seeded = await run(50);
+    expect(seeded.errors).toEqual([]);
+    expect(seeded.processed).toBe(5);
+    expect(seeded.remaining).toBe(0);
+
+    // 2. forceSince = a DB-clock instant AFTER the initial extract, so every
+    //    file's stored updated_at is strictly earlier (mirrors the job runner
+    //    passing the job's DB-sourced started_at). DB-sourced to avoid any
+    //    app-vs-DB clock skew.
+    const [{ now }] = await admin`SELECT now() AS now` as unknown as Array<{ now: Date }>;
+    const forceSince = new Date(now);
+
+    // 3. Drive batch=2 force sweeps to convergence. Before the fix, the FIRST
+    //    sweep already reported remaining=0 (non-force snapshot count) after
+    //    touching only two files, and the loop terminated early.
+    const remainings: number[] = [];
+    let visited = 0;
+    let guard = 0;
+    for (;;) {
+      if (guard++ > 20) throw new Error('force sweep failed to converge');
+      const r = await run(BATCH, { force: true, forceSince });
+      expect(r.errors).toEqual([]);
+      expect(r.transient).toBeNull();
+      remainings.push(r.remaining);
+      visited += r.processed;
+      if (r.remaining === 0) break;
+      // Each non-final sweep must make progress, or it would loop forever.
+      expect(r.processed).toBeGreaterThan(0);
+    }
+
+    // remaining decreased monotonically (non-increasing) and reached 0. With
+    // five files and batch=2 the sequence is [3, 1, 0].
+    expect(remainings[remainings.length - 1]).toBe(0);
+    for (let i = 1; i < remainings.length; i += 1) {
+      expect(remainings[i]).toBeLessThan(remainings[i - 1]);
+    }
+    // The sweep visited more files than a single batch — it did NOT stop early.
+    expect(visited).toBeGreaterThan(BATCH);
+
+    // 4. Every eligible file's content row was re-walked this sweep: its
+    //    updated_at is at/after forceSince.
+    const stale = await admin`
+      SELECT count(*)::int AS n
+      FROM workspace_file_content c
+      JOIN workspace_file_index fi ON fi.id = c.file_index_id
+      WHERE c.org_id = ${org} AND fi.deleted_at IS NULL AND fi.is_dir = false
+        AND c.updated_at < ${forceSince.toISOString()}::timestamptz` as unknown as Array<{ n: number }>;
+    expect(stale[0].n).toBe(0);
+  });
+});

--- a/ee/workspace/src/__tests__/ingest.integration.test.ts
+++ b/ee/workspace/src/__tests__/ingest.integration.test.ts
@@ -147,16 +147,33 @@ describe('content ingest runner (real DB + fixture estate)', () => {
     await admin`UPDATE workspace_file_index SET deleted_at = NULL WHERE id = ${mdId}`;
   });
 
-  it('records a failed row (with snapshot) when bytes cannot be read, and the loop advances', async () => {
+  it('force re-sweep binds a forceSince Date against the real driver (no param-serialization crash)', async () => {
+    // Regression: forceSince (the runner passes job.startedAt, a JS Date) is used
+    // in the force pending predicate. Bound raw, postgres.js throws
+    // ERR_INVALID_ARG_TYPE in Bind ("… Received an instance of Date"); it must be
+    // serialized as an ISO ::timestamptz. A future forceSince selects every file
+    // so this also exercises a real force re-read end to end.
+    const future = new Date(Date.now() + 60_000);
+    const run = await asOrg((svc) => svc.run(org, 10, { force: true, forceSince: future }));
+    expect(run.transient).toBeNull();
+    expect(run.processed).toBeGreaterThan(0);
+    expect(typeof run.remaining).toBe('number');
+  });
+
+  it('treats an unreadable file as transient: aborts the batch, parks no row, stays re-ingestable', async () => {
+    // W3: a byte-read failure is a source-down signal, not a bad file. The run
+    // aborts the remaining batch and writes NOTHING for the unreadable file, so
+    // it stays fully pending and re-ingests once the source recovers — the old
+    // behavior (a parked `failed` row) would have wrongly retired it.
     const ghost = randomUUID();
     await admin`INSERT INTO workspace_file_index (id, org_id, source_id, rel_path, parent_path, name, is_dir, size, mtime)
                 VALUES (${ghost}, ${org}, ${source}, 'missing/ghost.md', 'missing', 'ghost.md', false, 5, now())`;
     const run = await asOrg((svc) => svc.run(org, 10));
-    expect(run.errors).toHaveLength(1);
-    expect(run.errors[0].relPath).toBe('missing/ghost.md');
-    expect(run.remaining).toBe(0); // failed row carries the snapshot; not pending anymore
-    const [row] = await admin`SELECT status, error_reason FROM workspace_file_content WHERE file_index_id = ${ghost}`;
-    expect(row.status).toBe('failed');
-    expect(row.error_reason).toBeTruthy();
+    expect(run.transient).not.toBeNull();
+    expect(run.transient!.reason).toMatch(/reader:/);
+    expect(run.errors).toEqual([]); // transient is reported via .transient, not .errors
+    const rows = await admin`SELECT id FROM workspace_file_content WHERE file_index_id = ${ghost}`;
+    expect(rows).toHaveLength(0); // no failed/blocked row parked it — still pending
+    await admin`DELETE FROM workspace_file_index WHERE id = ${ghost}`;
   });
 });

--- a/ee/workspace/src/__tests__/ingestJobs.integration.test.ts
+++ b/ee/workspace/src/__tests__/ingestJobs.integration.test.ts
@@ -1,0 +1,317 @@
+// W3: workspace_ingest_jobs — RLS shape 1 cross-tenant probe + the
+// one-active-job-per-partition partial unique index. Mirrors the
+// workspaceRls.integration.test.ts bootstrap (:5433 stack, breeze_app role,
+// asOrg GUC scoping) — see also visibilityIntersection.integration.test.ts
+// for the same ADMIN_URL/APP_URL/port-guard/asOrg shape.
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import postgres from 'postgres';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createIngestJobsService } from '../services/ingestJobsService';
+import { createIngestJobRunner } from '../services/ingestJobRunner';
+
+const ADMIN_URL = process.env.DATABASE_URL ?? 'postgresql://breeze_test:breeze_test@localhost:5433/breeze_test';
+const APP_URL = process.env.DATABASE_URL_APP ?? 'postgresql://breeze_app:breeze_test@localhost:5433/breeze_test';
+if (new URL(ADMIN_URL).port === '5432') throw new Error('refusing to run against :5432 — use the test stack (:5433)');
+
+let admin: postgres.Sql;
+let app: postgres.Sql;
+let appDb: ReturnType<typeof drizzle>;
+let partnerA: string, partnerB: string, orgA: string, orgB: string;
+let partnerC: string, orgC: string;
+
+beforeAll(async () => {
+  admin = postgres(ADMIN_URL, { max: 1 });
+  app = postgres(APP_URL, { max: 1 });
+  appDb = drizzle(app);
+
+  // Idempotently apply the migration — the shared :5433 stack may not yet
+  // carry this table (or may have been reprovisioned by another branch's
+  // integration run; see dev/README.md's re-apply gotcha).
+  const here = dirname(fileURLToPath(import.meta.url));
+  const sql = readFileSync(join(here, '../../migrations/2026-07-25-ingest-jobs.sql'), 'utf8');
+  await admin.begin(async (tx) => { await tx.unsafe(sql); });
+
+  partnerA = randomUUID(); partnerB = randomUUID(); partnerC = randomUUID();
+  orgA = randomUUID(); orgB = randomUUID(); orgC = randomUUID();
+  const sfx = randomUUID();
+  await admin`INSERT INTO partners (id, name, slug)
+              VALUES (${partnerA}, 'wsp-ingest-jobs-a', ${`wsp-ingest-jobs-a-${sfx}`}),
+                     (${partnerB}, 'wsp-ingest-jobs-b', ${`wsp-ingest-jobs-b-${sfx}`}),
+                     (${partnerC}, 'wsp-ingest-jobs-c', ${`wsp-ingest-jobs-c-${sfx}`})`;
+  await admin`INSERT INTO organizations (id, partner_id, name, slug)
+              VALUES (${orgA}, ${partnerA}, 'wsp-ingest-jobs-org-a', ${`wsp-ingest-jobs-org-a-${sfx}`}),
+                     (${orgB}, ${partnerB}, 'wsp-ingest-jobs-org-b', ${`wsp-ingest-jobs-org-b-${sfx}`}),
+                     (${orgC}, ${partnerC}, 'wsp-ingest-jobs-org-c', ${`wsp-ingest-jobs-org-c-${sfx}`})`;
+});
+
+afterAll(async () => {
+  await admin`DELETE FROM workspace_ingest_jobs WHERE org_id IN (${orgA}, ${orgB}, ${orgC})`;
+  await admin`DELETE FROM organizations WHERE id IN (${orgA}, ${orgB}, ${orgC})`;
+  await admin`DELETE FROM partners WHERE id IN (${partnerA}, ${partnerB}, ${partnerC})`;
+  await admin.end(); await app.end();
+});
+
+/** Run the service as breeze_app inside an org's access context (mirrors withDbAccessContext). */
+async function withOrg<T>(org: string, partner: string, fn: (db: WorkspaceDatabase) => Promise<T>): Promise<T> {
+  return appDb.transaction(async (transaction) => {
+    const tx = (transaction as unknown as { session: { client: postgres.TransactionSql } }).session.client;
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(transaction as unknown as WorkspaceDatabase);
+  }) as Promise<T>;
+}
+
+/** Run fn as breeze_app inside the given org's access context (mirrors withDbAccessContext set_configs). */
+async function asOrg<T>(org: string, partner: string, fn: (tx: postgres.TransactionSql) => Promise<T>): Promise<T> {
+  return app.begin(async (tx) => {
+    await tx`SELECT set_config('breeze.scope', 'organization', true),
+                    set_config('breeze.org_id', ${org}, true),
+                    set_config('breeze.accessible_org_ids', ${org}, true),
+                    set_config('breeze.accessible_partner_ids', ${partner}, true),
+                    set_config('breeze.user_id', '', true),
+                    set_config('breeze.current_partner_id', '', true)`;
+    return fn(tx);
+  }) as Promise<T>;
+}
+
+describe('workspace_ingest_jobs RLS (W3, cross-tenant as breeze_app)', () => {
+  it('org A can insert a job and read it back', async () => {
+    const id = randomUUID();
+    await asOrg(orgA, partnerA, (tx) =>
+      tx`INSERT INTO workspace_ingest_jobs (id, org_id, trigger) VALUES (${id}, ${orgA}, 'manual')`);
+    try {
+      const rows = await asOrg(orgA, partnerA, (tx) =>
+        tx`SELECT id FROM workspace_ingest_jobs WHERE id = ${id}`);
+      expect(rows).toHaveLength(1);
+    } finally {
+      await admin`DELETE FROM workspace_ingest_jobs WHERE id = ${id}`;
+    }
+  });
+
+  it('org B context reads zero rows for org A jobs', async () => {
+    const id = randomUUID();
+    await admin`INSERT INTO workspace_ingest_jobs (id, org_id, trigger) VALUES (${id}, ${orgA}, 'manual')`;
+    try {
+      const rows = await asOrg(orgB, partnerB, (tx) =>
+        tx`SELECT id FROM workspace_ingest_jobs WHERE org_id = ${orgA}`);
+      expect(rows).toHaveLength(0); // RLS silent-0-row read, not an error
+    } finally {
+      await admin`DELETE FROM workspace_ingest_jobs WHERE id = ${id}`;
+    }
+  });
+
+  it('org B context cannot forge an insert for org A (RLS WITH CHECK)', async () => {
+    await expect(
+      asOrg(orgB, partnerB, (tx) =>
+        tx`INSERT INTO workspace_ingest_jobs (org_id, trigger) VALUES (${orgA}, 'manual')`)
+    ).rejects.toThrow(/row-level security policy for table "workspace_ingest_jobs"/);
+  });
+
+  it('one-active-job-per-partition: a second pending/running insert for the same (org, NULL source) throws', async () => {
+    const first = randomUUID();
+    await asOrg(orgA, partnerA, (tx) =>
+      tx`INSERT INTO workspace_ingest_jobs (id, org_id, trigger, status) VALUES (${first}, ${orgA}, 'manual', 'pending')`);
+    try {
+      await expect(
+        asOrg(orgA, partnerA, (tx) =>
+          tx`INSERT INTO workspace_ingest_jobs (org_id, trigger, status) VALUES (${orgA}, 'manual', 'pending')`)
+      ).rejects.toThrow(/duplicate key value violates unique constraint "wsp_ingest_jobs_one_active_idx"/);
+    } finally {
+      await admin`DELETE FROM workspace_ingest_jobs WHERE id = ${first}`;
+    }
+  });
+
+  it('completing the active job frees the partial index for a new insert', async () => {
+    const first = randomUUID();
+    await asOrg(orgA, partnerA, (tx) =>
+      tx`INSERT INTO workspace_ingest_jobs (id, org_id, trigger, status) VALUES (${first}, ${orgA}, 'manual', 'pending')`);
+    await asOrg(orgA, partnerA, (tx) =>
+      tx`UPDATE workspace_ingest_jobs SET status = 'complete', updated_at = now() WHERE id = ${first}`);
+    const second = randomUUID();
+    await asOrg(orgA, partnerA, (tx) =>
+      tx`INSERT INTO workspace_ingest_jobs (id, org_id, trigger, status) VALUES (${second}, ${orgA}, 'manual', 'pending')`);
+    await admin`DELETE FROM workspace_ingest_jobs WHERE id IN (${first}, ${second})`;
+  });
+});
+
+describe('ingestJobsService lifecycle (W3, real PG as breeze_app)', () => {
+  const svc = (db: WorkspaceDatabase) => createIngestJobsService(db);
+
+  it('drives ensure → claim → progress → yield → transient backoff → phase_complete → complete', async () => {
+    // ensure: a fresh org-wide job is created pending in the ingest phase
+    const ensured = await withOrg(orgC, partnerC, (db) => svc(db).ensureJob(orgC, { trigger: 'manual' }));
+    expect(ensured.created).toBe(true);
+    expect(ensured.job.status).toBe('pending');
+    expect(ensured.job.phase).toBe('ingest');
+    const jobId = ensured.job.id;
+
+    // ensure again is idempotent for a live partition: same job, created=false
+    const again = await withOrg(orgC, partnerC, (db) => svc(db).ensureJob(orgC, { trigger: 'manual' }));
+    expect(again.created).toBe(false);
+    expect(again.job.id).toBe(jobId);
+
+    // claim: pending → running, started_at stamped from the DB clock
+    const claimed = await withOrg(orgC, partnerC, (db) => svc(db).claimDue(orgC));
+    expect(claimed?.id).toBe(jobId);
+    expect(claimed?.status).toBe('running');
+    expect(claimed?.startedAt).toBeInstanceOf(Date);
+
+    // progress: cursor + shallow stats merge, heartbeat bump
+    await withOrg(orgC, partnerC, (db) =>
+      svc(db).recordProgress(orgC, jobId, { cursor: 'page-2', statsPatch: { seen: 5 } }));
+    const afterProgress = await withOrg(orgC, partnerC, (db) => svc(db).get(orgC, jobId));
+    expect(afterProgress?.cursor).toBe('page-2');
+    expect(afterProgress?.stats).toMatchObject({ seen: 5 });
+
+    // counter accumulation: counterPatch keys SUM SQL-side across calls while
+    // statsPatch keys overwrite. Two `ingested` deltas (2 then 3) → stored 5;
+    // `remaining` (absolute) keeps only the last write; `seen` is untouched.
+    await withOrg(orgC, partnerC, (db) =>
+      svc(db).recordProgress(orgC, jobId, { counterPatch: { ingested: 2 }, statsPatch: { remaining: 9 } }));
+    await withOrg(orgC, partnerC, (db) =>
+      svc(db).recordProgress(orgC, jobId, { counterPatch: { ingested: 3 }, statsPatch: { remaining: 4 } }));
+    const afterCounters = await withOrg(orgC, partnerC, (db) => svc(db).get(orgC, jobId));
+    expect(afterCounters?.stats).toMatchObject({ ingested: 5, remaining: 4, seen: 5 });
+
+    // yield: budget spent, work remains → pending, immediately due again
+    const yielded = await withOrg(orgC, partnerC, (db) => svc(db).release(orgC, jobId, { kind: 'yield' }));
+    expect(yielded?.status).toBe('pending');
+    const reclaimed = await withOrg(orgC, partnerC, (db) => svc(db).claimDue(orgC));
+    expect(reclaimed?.id).toBe(jobId);
+    expect(reclaimed?.status).toBe('running');
+
+    // transient error: attempts → 1, pending, next_attempt_at pushed into the future
+    const transient = await withOrg(orgC, partnerC, (db) =>
+      svc(db).release(orgC, jobId, { kind: 'transient_error', error: 'flaky read' }));
+    expect(transient?.status).toBe('pending');
+    expect(transient?.attempts).toBe(1);
+    expect(transient?.lastError).toBe('flaky read');
+    const [{ future }] = await admin`
+      SELECT next_attempt_at > now() AS future FROM workspace_ingest_jobs WHERE id = ${jobId}`;
+    expect(future).toBe(true);
+
+    // not due while backing off: claim returns null
+    const notDue = await withOrg(orgC, partnerC, (db) => svc(db).claimDue(orgC));
+    expect(notDue).toBeNull();
+
+    // time-travel the backoff into the past (admin conn) and re-claim
+    await admin`UPDATE workspace_ingest_jobs SET next_attempt_at = now() - interval '1 second' WHERE id = ${jobId}`;
+    const afterBackoff = await withOrg(orgC, partnerC, (db) => svc(db).claimDue(orgC));
+    expect(afterBackoff?.id).toBe(jobId);
+    expect(afterBackoff?.status).toBe('running');
+
+    // phase_complete: → enrich, attempts reset, cursor cleared, pending + due
+    const phased = await withOrg(orgC, partnerC, (db) =>
+      svc(db).release(orgC, jobId, { kind: 'phase_complete', nextPhase: 'enrich' }));
+    expect(phased?.phase).toBe('enrich');
+    expect(phased?.attempts).toBe(0);
+    expect(phased?.cursor).toBeNull();
+    expect(phased?.status).toBe('pending');
+
+    // claim the enrich phase, then complete it
+    const enrichClaim = await withOrg(orgC, partnerC, (db) => svc(db).claimDue(orgC));
+    expect(enrichClaim?.id).toBe(jobId);
+    const done = await withOrg(orgC, partnerC, (db) => svc(db).release(orgC, jobId, { kind: 'complete' }));
+    expect(done?.status).toBe('complete');
+    expect(done?.finishedAt).toBeInstanceOf(Date);
+
+    // drained: nothing due
+    expect(await withOrg(orgC, partnerC, (db) => svc(db).claimDue(orgC))).toBeNull();
+
+    await admin`DELETE FROM workspace_ingest_jobs WHERE id = ${jobId}`;
+  });
+
+  it('reclaims a running job whose heartbeat is older than the 5-minute stale window', async () => {
+    const staleId = randomUUID();
+    await admin`INSERT INTO workspace_ingest_jobs (id, org_id, trigger, status, started_at, updated_at)
+                VALUES (${staleId}, ${orgC}, 'manual', 'running',
+                        now() - interval '6 minutes', now() - interval '6 minutes')`;
+    const reclaimed = await withOrg(orgC, partnerC, (db) => svc(db).claimDue(orgC));
+    expect(reclaimed?.id).toBe(staleId);
+    expect(reclaimed?.status).toBe('running');
+    await admin`DELETE FROM workspace_ingest_jobs WHERE id = ${staleId}`;
+  });
+
+  it('claimDue returns null when the org has no due jobs', async () => {
+    expect(await withOrg(orgC, partnerC, (db) => svc(db).claimDue(orgC))).toBeNull();
+  });
+});
+
+// W3 Task 5, Step 5: the runner's own state-machine unit tests (ingestJobRunner.test.ts)
+// fake the jobs service; this smoke test flips that — a REAL, RLS-scoped
+// jobsService against PG, driven by the runner with fake content/enrichment/
+// crosswalk services. No HTTP: this exercises exactly the in-request
+// ensure→advance wiring the agent/admin routes call, without a live server.
+describe('ingestJobRunner smoke (W3, real PG jobs service + fake content services)', () => {
+  it('drives ensure -> advance through ingest -> enrich -> crosswalk -> complete against real PG', async () => {
+    const contentIngest = { run: vi.fn(async () => ({ processed: 1, remaining: 0, errors: [], transient: null })) };
+    const enrichment = { run: vi.fn(async () => ({ processed: 1, remaining: 0, errors: [] })) };
+    const crosswalk = { run: vi.fn(async () => ({ mined: 0 })) };
+    const getSettings = vi.fn(async () => ({ contentEnabled: true }));
+
+    function runnerFor(db: WorkspaceDatabase) {
+      return createIngestJobRunner({
+        jobs: createIngestJobsService(db),
+        contentIngest,
+        enrichment,
+        crosswalk,
+        getSettings,
+        log: () => {},
+      });
+    }
+
+    const ensured = await withOrg(orgC, partnerC, (db) =>
+      createIngestJobsService(db).ensureJob(orgC, { trigger: 'manual' }));
+    expect(ensured.created).toBe(true);
+    expect(ensured.job.phase).toBe('ingest');
+    const jobId = ensured.job.id;
+
+    // advance #1: claims the pending ingest-phase job, runs one fake ingest
+    // batch (remaining: 0) -> phase_complete -> enrich, handed back pending.
+    const afterIngest = await withOrg(orgC, partnerC, (db) =>
+      runnerFor(db).advance(orgC, { budgetMs: 5_000, batch: 8 }));
+    expect(afterIngest.advanced).toBe(true);
+    expect(afterIngest.job?.id).toBe(jobId);
+    expect(afterIngest.job?.phase).toBe('enrich');
+    expect(afterIngest.job?.status).toBe('pending');
+    expect(contentIngest.run).toHaveBeenCalledTimes(1);
+    expect(enrichment.run).not.toHaveBeenCalled();
+
+    // advance #2: claims the enrich-phase job, one fake enrich batch
+    // (remaining: 0) -> phase_complete -> crosswalk.
+    const afterEnrich = await withOrg(orgC, partnerC, (db) =>
+      runnerFor(db).advance(orgC, { budgetMs: 5_000, batch: 8 }));
+    expect(afterEnrich.job?.phase).toBe('crosswalk');
+    expect(afterEnrich.job?.status).toBe('pending');
+    expect(enrichment.run).toHaveBeenCalledTimes(1);
+    expect(crosswalk.run).not.toHaveBeenCalled();
+
+    // advance #3: claims the crosswalk-phase job, runs crosswalk once -> complete.
+    const afterCrosswalk = await withOrg(orgC, partnerC, (db) =>
+      runnerFor(db).advance(orgC, { budgetMs: 5_000, batch: 8 }));
+    expect(afterCrosswalk.job?.status).toBe('complete');
+    expect(afterCrosswalk.job?.finishedAt).toBeInstanceOf(Date);
+    expect(crosswalk.run).toHaveBeenCalledTimes(1);
+
+    // W3 binding constraint: every advancement path consults
+    // getOrgSettings(...).contentEnabled per org — verify the runner honors a
+    // false read by never claiming, on a freshly ensured job.
+    const ensured2 = await withOrg(orgC, partnerC, (db) =>
+      createIngestJobsService(db).ensureJob(orgC, { trigger: 'manual' }));
+    getSettings.mockResolvedValueOnce({ contentEnabled: false });
+    const blocked = await withOrg(orgC, partnerC, (db) =>
+      runnerFor(db).advance(orgC, { budgetMs: 5_000, batch: 8 }));
+    expect(blocked).toEqual({ advanced: false, job: null });
+
+    await admin`DELETE FROM workspace_ingest_jobs WHERE id IN (${jobId}, ${ensured2.job.id})`;
+  });
+});

--- a/ee/workspace/src/content/byteReader.test.ts
+++ b/ee/workspace/src/content/byteReader.test.ts
@@ -107,4 +107,39 @@ describe('SmbByteReader', () => {
     await reader.read(source, 'b.md');
     expect(connects).toBe(1);
   });
+
+  it('times out a read that never resolves (black-holed source) instead of hanging', async () => {
+    const reader = new SmbByteReader({
+      getCredential: async () => ({ username: 'u', password: 'p', domain: null }),
+      hostMap: {},
+      readTimeoutMs: 30,
+      // readFile never settles — models a severed/partitioned SMB connection.
+      smbFactory: () => ({ readFile: () => new Promise<Buffer>(() => {}), disconnect: () => {} }),
+    });
+    await expect(reader.read(source, 'x.md')).rejects.toThrow(/timed out/i);
+  });
+
+  it('evicts the wedged client after a failed read so the next read reconnects', async () => {
+    let connects = 0;
+    let disconnects = 0;
+    let call = 0;
+    const reader = new SmbByteReader({
+      getCredential: async () => ({ username: 'u', password: 'p', domain: null }),
+      hostMap: {},
+      readTimeoutMs: 30,
+      smbFactory: () => {
+        connects += 1;
+        return {
+          // First client's read hangs (times out); a fresh client's read succeeds.
+          readFile: () => (call++ === 0 ? new Promise<Buffer>(() => {}) : Promise.resolve(Buffer.from('ok'))),
+          disconnect: () => { disconnects += 1; },
+        };
+      },
+    });
+    await expect(reader.read(source, 'a.md')).rejects.toThrow(/timed out/i);
+    const buf = await reader.read(source, 'b.md');
+    expect(buf.toString()).toBe('ok');
+    expect(connects).toBe(2); // evicted → reconnected, not reused
+    expect(disconnects).toBe(1); // wedged client was disconnected on eviction
+  });
 });

--- a/ee/workspace/src/content/byteReader.ts
+++ b/ee/workspace/src/content/byteReader.ts
@@ -1,4 +1,4 @@
-// Byte readers for content ingest (dev-preview; per-org content flag).
+// Byte readers for content ingest (per-org content flag).
 //
 // Design decision (2026-07-18 spike): the primary reader is a server-side SMB
 // read with the STORED SOURCE CREDENTIAL (v9u-smb2, NTLMv2). It exercises the
@@ -91,6 +91,31 @@ export interface SmbByteReaderDeps {
   hostMap: Record<string, string>;
   /** Injectable for tests; defaults to a v9u-smb2 client. */
   smbFactory?: (opts: SmbConnectOptions) => SmbClientLike;
+  /**
+   * Bound on a single SMB read (which triggers the lazy connect). A source that
+   * becomes unreachable by REFUSING gives a fast socket error, but one that is
+   * black-holed (firewall drop / network partition — the common production
+   * failure) never answers the SYN, so v9u-smb2 would hang the read forever and
+   * wedge the ingest job as 'running'. This cap converts that into a normal
+   * transient (`reader: … timed out`), which the runner backs off and retries.
+   */
+  readTimeoutMs?: number;
+}
+
+export const DEFAULT_SMB_READ_TIMEOUT_MS = 8_000;
+
+/**
+ * Reject if `promise` has not settled within `ms`. The underlying operation is
+ * not cancelable (the SMB socket stays hung), so a swallow-handler is attached
+ * to keep a late rejection from surfacing as an unhandledRejection.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  promise.catch(() => { /* swallow settlement that arrives after the timeout */ });
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 async function defaultSmbFactory(opts: SmbConnectOptions): Promise<SmbClientLike> {
@@ -105,8 +130,21 @@ async function defaultSmbFactory(opts: SmbConnectOptions): Promise<SmbClientLike
 
 export class SmbByteReader implements ContentByteReader {
   private clients = new Map<string, SmbClientLike | Promise<SmbClientLike>>();
+  private readonly readTimeoutMs: number;
 
-  constructor(private readonly deps: SmbByteReaderDeps) {}
+  constructor(private readonly deps: SmbByteReaderDeps) {
+    this.readTimeoutMs = deps.readTimeoutMs ?? DEFAULT_SMB_READ_TIMEOUT_MS;
+  }
+
+  /** Drop (and best-effort disconnect) the cached client for a source so the
+   *  next read reconnects fresh instead of reusing a wedged/dead socket. */
+  private evict(sourceId: string): void {
+    const c = this.clients.get(sourceId);
+    this.clients.delete(sourceId);
+    if (c && !(c instanceof Promise)) {
+      try { c.disconnect(); } catch { /* best effort */ }
+    }
+  }
 
   private async clientFor(source: ContentSourceRef): Promise<SmbClientLike> {
     const existing = this.clients.get(source.id);
@@ -137,7 +175,19 @@ export class SmbByteReader implements ContentByteReader {
 
   async read(source: ContentSourceRef, relPath: string): Promise<Buffer> {
     const client = await this.clientFor(source);
-    return client.readFile(relPath.replace(/\//g, '\\'));
+    try {
+      return await withTimeout(
+        client.readFile(relPath.replace(/\//g, '\\')),
+        this.readTimeoutMs,
+        `smb read timed out after ${this.readTimeoutMs}ms`,
+      );
+    } catch (err) {
+      // A failed or timed-out read may have wedged the cached connection; drop it
+      // so the retry reconnects fresh. The throw propagates to contentIngest,
+      // which wraps it as a `reader:` transient (source-down → back off + retry).
+      this.evict(source.id);
+      throw err;
+    }
   }
 
   disconnectAll(): void {
@@ -158,8 +208,10 @@ export function buildContentReader(
 ): ContentByteReader {
   const mountMap = parseMountMap(process.env.WORKSPACE_CONTENT_MOUNT_MAP);
   if (Object.keys(mountMap).length > 0) return new MountedDirReader(mountMap);
+  const timeoutEnv = Number(process.env.WORKSPACE_CONTENT_SMB_TIMEOUT_MS);
   return new SmbByteReader({
     getCredential,
     hostMap: parseHostMap(process.env.WORKSPACE_CONTENT_SMB_HOST_MAP),
+    readTimeoutMs: Number.isFinite(timeoutEnv) && timeoutEnv > 0 ? timeoutEnv : undefined,
   });
 }

--- a/ee/workspace/src/content/embedder.test.ts
+++ b/ee/workspace/src/content/embedder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   chunkText, FakeEmbedder, VoyageEmbedder, toVectorLiteral, EMBEDDING_DIM,
 } from './embedder';
+import { TransientIngestError } from '../services/ingestErrors';
 
 describe('chunkText', () => {
   it('packs paragraphs to ~1200 chars without splitting them', () => {
@@ -65,6 +66,21 @@ describe('VoyageEmbedder', () => {
     const fetchImpl = vi.fn(async () => new Response('nope', { status: 401 }));
     const e = new VoyageEmbedder('bad', 'voyage-3', 100, fetchImpl as unknown as typeof fetch);
     await expect(e.embed(['a'], 'query')).rejects.toThrow(/401/);
+  });
+
+  it('maps a fetch timeout to a TransientIngestError and passes an abort signal', async () => {
+    // A black-holed embedder must not hang an advance ~300s (undici default) —
+    // AbortSignal.timeout fires a TimeoutError we surface as transient so the
+    // ingest runner backs off the batch instead of wedging on a dead provider.
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      const err = new Error('The operation was aborted due to timeout');
+      err.name = 'TimeoutError';
+      throw err;
+    });
+    const e = new VoyageEmbedder('key', 'voyage-3', 100, fetchImpl as unknown as typeof fetch);
+    await expect(e.embed(['a'], 'document')).rejects.toBeInstanceOf(TransientIngestError);
+    await expect(e.embed(['b'], 'document')).rejects.toThrow(/voyage: timed out/);
   });
 });
 

--- a/ee/workspace/src/content/embedder.ts
+++ b/ee/workspace/src/content/embedder.ts
@@ -1,9 +1,10 @@
-// Embeddings for content chunks (dev-preview). Pattern copied from hive's
+// Embeddings for content chunks. Pattern copied from hive's
 // colony-memory embedder: a narrow Embedder interface, a Voyage AI
 // implementation with a sliding-window soft rate cap, and a deterministic
 // FakeEmbedder for tests (FakeEmbedder is acceptable ONLY in plumbing tests —
 // never behind a real search result; see the demo gate rules).
 import { createHash } from 'node:crypto';
+import { TransientIngestError } from '../services/ingestErrors';
 
 export const EMBEDDING_DIM = 1024;
 
@@ -26,7 +27,9 @@ export class VoyageEmbedder implements Embedder {
     const now = Date.now();
     this.requestTimestamps = this.requestTimestamps.filter((t) => now - t < 60_000);
     if (this.requestTimestamps.length >= this.requestsPerMinute) {
-      throw new Error(`voyage_rate_limited:${this.requestTimestamps.length}/${this.requestsPerMinute}rpm`);
+      // Transient: the source-side embedder is back-pressuring. The ingest
+      // runner aborts the batch and retries whole rather than parking files.
+      throw new TransientIngestError(`voyage_rate_limited:${this.requestTimestamps.length}/${this.requestsPerMinute}rpm`);
     }
     this.requestTimestamps.push(now);
   }
@@ -34,16 +37,33 @@ export class VoyageEmbedder implements Embedder {
   async embed(texts: string[], inputType: 'document' | 'query'): Promise<number[][]> {
     if (texts.length === 0) return [];
     this.throttle();
-    const res = await this.fetchImpl('https://api.voyageai.com/v1/embeddings', {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${this.apiKey}`,
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({ model: this.model, input: texts, input_type: inputType }),
-    });
+    // Bound the request: a black-holed embedder would otherwise hang an advance
+    // for undici's ~300s default, brushing the runner's 5-minute stale-reclaim
+    // window. A timeout is a network/service condition (not a bad file), so it
+    // maps to a transient — the ingest runner backs off the batch and retries
+    // whole rather than parking files as failed.
+    const timeoutMs = Number(process.env.WORKSPACE_CONTENT_VOYAGE_TIMEOUT_MS) || 15_000;
+    let res: Awaited<ReturnType<typeof fetch>>;
+    try {
+      res = await this.fetchImpl('https://api.voyageai.com/v1/embeddings', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${this.apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ model: this.model, input: texts, input_type: inputType }),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      if (error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
+        throw new TransientIngestError(`voyage: timed out after ${timeoutMs}ms`);
+      }
+      throw error;
+    }
     if (!res.ok) {
-      throw new Error(`voyage embeddings failed: ${res.status} ${(await res.text()).slice(0, 200)}`);
+      // Transient: a non-200 from the embedding API is a network/service
+      // condition, not a bad file — retry the batch rather than fail files.
+      throw new TransientIngestError(`voyage embeddings failed: ${res.status} ${(await res.text()).slice(0, 200)}`);
     }
     const body = await res.json() as { data: Array<{ index: number; embedding: number[] }> };
     const out: number[][] = new Array(texts.length);

--- a/ee/workspace/src/content/entities.ts
+++ b/ee/workspace/src/content/entities.ts
@@ -1,4 +1,4 @@
-// Deterministic entity extraction (content phase, dev-preview).
+// Deterministic entity extraction for the content layer.
 // The structured types below are owned by THIS regex pass — the LLM enrichment
 // pass may only contribute person/org entities. Query-side detection
 // (normalizeQueryEntities) reuses the exact same patterns/normalizer so an

--- a/ee/workspace/src/content/extract.test.ts
+++ b/ee/workspace/src/content/extract.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 import { extractContent } from './extract';
+
+const FIXTURES_DIR = path.join(__dirname, '..', '__tests__', 'fixtures');
 
 const EML = Buffer.from([
   'From: Paul Deluca <pdeluca@fairoaksca.gov>',
@@ -44,6 +48,28 @@ describe('extractContent', () => {
       subject: 'RE: PO 4021 - pipe submittal resubmittal',
     });
     expect(r.emailMeta?.to?.[0]).toContain('mcortez@aldercreekeng.com');
+  });
+
+  it('captures messageId, angle brackets stripped and lowercased, when the header is present', async () => {
+    const bytes = await readFile(path.join(FIXTURES_DIR, 'emails', 'with-message-id.eml'));
+    const r = await extractContent('with-message-id.eml', bytes, 2 * 1024 * 1024);
+    expect(r.status).toBe('extracted');
+    if (r.status !== 'extracted') return;
+    expect(r.emailMeta?.messageId).toBe('caf7x2q9abc123@mail.fairoaksca.gov');
+  });
+
+  it('leaves messageId absent (and the rest of meta unchanged) for mail with no Message-ID header', async () => {
+    const bytes = await readFile(
+      path.join(FIXTURES_DIR, 'estate', 'Emails', '2023-041', 'po-4021-issued.eml'),
+    );
+    const r = await extractContent('po-4021-issued.eml', bytes, 2 * 1024 * 1024);
+    expect(r.status).toBe('extracted');
+    if (r.status !== 'extracted') return;
+    expect(r.emailMeta?.messageId).toBeUndefined();
+    expect(r.emailMeta).toMatchObject({
+      from: expect.stringContaining('pdeluca@fairoaksca.gov'),
+      subject: 'PO 4021 issued',
+    });
   });
 
   it('skips unknown extensions as binary', async () => {

--- a/ee/workspace/src/content/extract.ts
+++ b/ee/workspace/src/content/extract.ts
@@ -1,4 +1,4 @@
-// Text extraction (content phase, dev-preview).
+// Text extraction for the content layer.
 // This module extracts text ONLY; it stores nothing. DLP runs downstream in
 // contentIngestService, between extraction and persistence: the text returned
 // here is inspected there before anything is stored — 'redact' hits rewrite it,
@@ -12,6 +12,11 @@ export interface EmailMeta {
   cc?: string[];
   subject?: string;
   date?: string;
+  /** RFC 5322 Message-ID, angle brackets stripped and lowercased. Absent when
+   * the source mail carries no Message-ID header — the demo corpus fixture
+   * (PO-4021) is exactly this case, which is why the matcher (Task 6) never
+   * relies on tier 1 alone. */
+  messageId?: string;
 }
 
 export type ExtractionResult =
@@ -67,12 +72,16 @@ export async function extractContent(
       '',
       body,
     ].filter((l): l is string => l !== null).join('\n');
+    const messageId = parsed.messageId
+      ? parsed.messageId.trim().replace(/^<+|>+$/g, '').toLowerCase() || undefined
+      : undefined;
     const emailMeta: EmailMeta = {
       from,
       to: to.length ? to : undefined,
       cc: cc.length ? cc : undefined,
       subject,
       date: parsed.date?.toISOString(),
+      messageId,
     };
     return { status: 'extracted', text, contentHash, emailMeta };
   } catch (error) {

--- a/ee/workspace/src/index.test.ts
+++ b/ee/workspace/src/index.test.ts
@@ -262,40 +262,37 @@ describe('workspace extension registration (v1 contract)', () => {
     accessibleOrgIds: [ORG_ID],
   };
 
-  it('serves /client routes for an organization-scoped session once content is enabled', async () => {
-    const outer = await stagedApp({
-      auth: CLIENT_AUTH,
-      context: { db: fakeDb([{ orgId: ORG_ID, contentEnabled: true, dlpConfig: {} }]) },
-    });
-    const projects = await outer.request('/api/v1/ext/workspace/client/content/projects');
-    expect(projects.status).toBe(200);
-
-    // The catch-all keeps unmatched client paths out of the admin-gated user app.
-    const nope = await outer.request('/api/v1/ext/workspace/client/nope');
-    expect(nope.status).toBe(404);
-    expect(await nope.json()).toEqual({ error: 'not found' });
-  });
-
-  it('404s the client tree while content is disabled for the org (default-deny)', async () => {
-    const outer = await stagedApp({ auth: CLIENT_AUTH });
-    const res = await outer.request('/api/v1/ext/workspace/client/content/projects');
-    expect(res.status).toBe(404);
-    expect(await res.json()).toEqual({ error: 'content_disabled' });
-  });
-
-  // /client is the end-user surface: an operator principal must not reach it
-  // even though the same principal is welcome on the admin routes.
+  /**
+   * NOTE (ee/workspace catch-up): upstream mounted the real /client routes here
+   * and these cases asserted clientGate's behavior through them (200 for an
+   * organization-scoped session, 404 while the content flag is off, 403 for an
+   * operator principal). This repo does not mount them — core's client-ai proxy,
+   * the only caller that legitimately produces the organization-scoped context
+   * clientGate expects, is unmerged, and on the extension gateway's default arm
+   * an ORDINARY organization-scoped browser session satisfies that gate too. See
+   * the comment at the mount site in index.ts.
+   *
+   * What is pinned instead is the property that survives the surface being
+   * withheld, and the one that actually matters for safety: every /client/* path
+   * answers a flat 404 and NOTHING falls through to the admin-gated user routes
+   * below. clientGate's own logic keeps its direct coverage in
+   * src/routes/clientGate.test.ts; restoring the mount means restoring the
+   * upstream form of these cases.
+   */
   it.each([
-    ['system', { user: { id: USER_ID }, scope: 'system', accessibleOrgIds: null }],
+    ['an organization-scoped session', CLIENT_AUTH],
+    ['a system principal', { user: { id: USER_ID }, scope: 'system', accessibleOrgIds: null }],
     ['no auth at all', null],
-  ])('rejects a %s principal on /client with 403', async (_label, auth) => {
+  ])('404s the unmounted /client tree for %s, never falling through to the admin routes', async (_label, auth) => {
     const outer = await stagedApp({
       auth,
       context: { db: fakeDb([{ orgId: ORG_ID, contentEnabled: true, dlpConfig: {} }]) },
     });
-    const res = await outer.request('/api/v1/ext/workspace/client/content/projects');
-    expect(res.status).toBe(403);
-    expect(await res.json()).toEqual({ error: 'organization access required' });
+    for (const path of ['/client/content/projects', '/client/filing/match', '/client/nope']) {
+      const res = await outer.request(`/api/v1/ext/workspace${path}`);
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: 'not found' });
+    }
   });
 
   // Content routes stay behind the per-org content flag (W2 Task 3): disabled

--- a/ee/workspace/src/index.test.ts
+++ b/ee/workspace/src/index.test.ts
@@ -250,6 +250,54 @@ describe('workspace extension registration (v1 contract)', () => {
     expect(await res.json()).toEqual({ error: 'helper identity required' });
   });
 
+  // The client tree (W4) is the Outlook add-in's surface: core's generic
+  // client proxy authenticates the pane user and dispatches under /client/*
+  // with an organization-scoped auth context. Mounted before the admin-gated
+  // user routes, with its own catch-all, exactly like /helper.
+  const CLIENT_AUTH = {
+    user: { id: USER_ID, email: 'jenny@example.test', name: 'Jenny Tran' },
+    scope: 'organization',
+    orgId: ORG_ID,
+    partnerId: undefined,
+    accessibleOrgIds: [ORG_ID],
+  };
+
+  it('serves /client routes for an organization-scoped session once content is enabled', async () => {
+    const outer = await stagedApp({
+      auth: CLIENT_AUTH,
+      context: { db: fakeDb([{ orgId: ORG_ID, contentEnabled: true, dlpConfig: {} }]) },
+    });
+    const projects = await outer.request('/api/v1/ext/workspace/client/content/projects');
+    expect(projects.status).toBe(200);
+
+    // The catch-all keeps unmatched client paths out of the admin-gated user app.
+    const nope = await outer.request('/api/v1/ext/workspace/client/nope');
+    expect(nope.status).toBe(404);
+    expect(await nope.json()).toEqual({ error: 'not found' });
+  });
+
+  it('404s the client tree while content is disabled for the org (default-deny)', async () => {
+    const outer = await stagedApp({ auth: CLIENT_AUTH });
+    const res = await outer.request('/api/v1/ext/workspace/client/content/projects');
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'content_disabled' });
+  });
+
+  // /client is the end-user surface: an operator principal must not reach it
+  // even though the same principal is welcome on the admin routes.
+  it.each([
+    ['system', { user: { id: USER_ID }, scope: 'system', accessibleOrgIds: null }],
+    ['no auth at all', null],
+  ])('rejects a %s principal on /client with 403', async (_label, auth) => {
+    const outer = await stagedApp({
+      auth,
+      context: { db: fakeDb([{ orgId: ORG_ID, contentEnabled: true, dlpConfig: {} }]) },
+    });
+    const res = await outer.request('/api/v1/ext/workspace/client/content/projects');
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'organization access required' });
+  });
+
   // Content routes stay behind the per-org content flag (W2 Task 3): disabled
   // (no settings row) → 404 even for an authed admin; enabled via the org's
   // settings row → the route exists.
@@ -355,9 +403,10 @@ describe('workspace extension registration (v1 contract)', () => {
     expect(manifest.publicRoutes).toEqual([]);
     expect(manifest.agentRoutes).toBe(true);
     // NOTE (ee/workspace import): the legacy breeze-extension.json manifest
-    // and its helperRoutes flag are not carried into the monorepo — the
-    // built-in host path is v1-only (manifest.json) — so the assertion that
-    // used to pin legacyManifest.helperRoutes === true was dropped here.
+    // this used to pin `helperRoutes === true` from was dropped here. The
+    // built-in path carries the flag as an explicit field on the `BUILTINS`
+    // entry in apps/api/src/extensions/builtinRegistry.ts, which is where the
+    // equivalent assertion now lives.
   });
 
   // The admin gate is what still stands between a user route and another org's

--- a/ee/workspace/src/index.ts
+++ b/ee/workspace/src/index.ts
@@ -2,7 +2,6 @@ import { Hono } from 'hono';
 import Anthropic from '@anthropic-ai/sdk';
 import { asWorkspaceDatabase, type BreezeExtensionV1, type WorkspaceDatabase } from './hostTypes';
 import { createAgentRoutes } from './routes/agent';
-import { createClientRoutes } from './routes/client';
 import { createContentRoutes } from './routes/content';
 import { createDashboardRoutes } from './routes/dashboard';
 import { createDeviceSummaryRoutes } from './routes/deviceSummary';
@@ -21,7 +20,6 @@ import { createFilingService } from './services/filingService';
 import { createCrawlRunsService } from './services/crawlRunsService';
 import { createCredentialService } from './services/credentialService';
 import { createDeviceSummaryService } from './services/deviceSummaryService';
-import { createEmailMatchService } from './services/emailMatchService';
 import { createFileQueryService } from './services/fileQueryService';
 import { createIngestJobsService } from './services/ingestJobsService';
 import { createIngestJobRunner, type EnrichRunResult } from './services/ingestJobRunner';
@@ -152,21 +150,37 @@ const workspaceExtension: BreezeExtensionV1 = {
     helperApp.all('*', (c) => c.json({ error: 'not found' }, 404));
     app.route('/helper', helperApp);
 
-    // W4: the Outlook add-in's end-user surface. Core's generic client proxy
-    // authenticates the pane user through the client-ai Entra exchange and
-    // dispatches here under /client/* with an organization-scoped auth
-    // context; clientGate (inside createClientRoutes) admits only that shape.
-    // Mounted with the same discipline as /helper — before the admin-gated
-    // user routes, with its own catch-all so an unmatched /client/* request
-    // can never fall through to them.
+    // W4: the Outlook add-in's end-user surface — DELIBERATELY NOT MOUNTED HERE.
+    //
+    // Upstream (LanternOps/breeze-workspace) mounted `/client/*` at this point,
+    // because there it was only ever reachable through core's generic client-ai
+    // proxy: that proxy dispatches under its own `/api/v1/client-ai/ext/:extension/*`
+    // mount with a synthesized organization-scoped context, and clientGate
+    // (inside createClientRoutes) admits exactly that shape.
+    //
+    // That proxy does not exist in this repo yet — it is unmerged, on
+    // ToddHebebrand/client-ext-seam-w4. Mounting `/client` here anyway would
+    // NOT reach it; the extension gateway would route `/client/*` down its
+    // default arm, i.e. an ordinary browser session JWT. clientGate checks the
+    // SHAPE of the auth context, not its provenance, so any organization-scoped
+    // Breeze user would satisfy it — and `/client/*` would become the only
+    // Workspace surface an org-scoped user can reach at all, since adminGate
+    // rejects that scope outright. That is an intra-org authorization gap (mail
+    // metadata search, filing decisions overwritable by any org user), so the
+    // mount waits for its dispatcher.
+    //
+    // Everything else about the surface is ported and tested; restoring it means
+    // routing createClientRoutes into the app below, and belongs with whichever
+    // commits from that branch land the proxy. Note when doing so that the
+    // proxy's synthesized context sets no `principal` field, so a provenance
+    // check on clientGate cannot key off `principal.kind` as-is.
+    //
+    // The prefix is still claimed by a bare catch-all, for the same reason the
+    // real mount had one: without it, `/client/*` falls through to the
+    // admin-gated user routes below and answers their `adminGate` 403 instead,
+    // which both leaks that the prefix is unhandled and puts the tree one
+    // routing change away from the admin surface.
     const clientApp = new Hono();
-    clientApp.route('/', createClientRoutes({
-      emailMatchService: createEmailMatchService(db),
-      filingService,
-      getSettings,
-      audit: context.audit,
-      log: context.log,
-    }));
     clientApp.all('*', (c) => c.json({ error: 'not found' }, 404));
     app.route('/client', clientApp);
 

--- a/ee/workspace/src/index.ts
+++ b/ee/workspace/src/index.ts
@@ -2,7 +2,9 @@ import { Hono } from 'hono';
 import Anthropic from '@anthropic-ai/sdk';
 import { asWorkspaceDatabase, type BreezeExtensionV1, type WorkspaceDatabase } from './hostTypes';
 import { createAgentRoutes } from './routes/agent';
+import { createClientRoutes } from './routes/client';
 import { createContentRoutes } from './routes/content';
+import { createDashboardRoutes } from './routes/dashboard';
 import { createDeviceSummaryRoutes } from './routes/deviceSummary';
 import { createHelperRoutes } from './routes/helper';
 import { createSourcesRoutes } from './routes/sources';
@@ -13,18 +15,22 @@ import { createBatchUpsertService } from './services/batchUpsertService';
 import { createContentIngestService } from './services/contentIngestService';
 import { createContentSearchService } from './services/contentSearchService';
 import { createCrosswalkService } from './services/crosswalkService';
+import { createDashboardService } from './services/dashboardService';
 import { createEnrichmentService, type AnthropicLike } from './services/enrichmentService';
 import { createFilingService } from './services/filingService';
 import { createCrawlRunsService } from './services/crawlRunsService';
 import { createCredentialService } from './services/credentialService';
 import { createDeviceSummaryService } from './services/deviceSummaryService';
+import { createEmailMatchService } from './services/emailMatchService';
 import { createFileQueryService } from './services/fileQueryService';
+import { createIngestJobsService } from './services/ingestJobsService';
+import { createIngestJobRunner, type EnrichRunResult } from './services/ingestJobRunner';
 import { createSourcesService } from './services/sourcesService';
 import { getOrgSettings } from './services/orgSettingsService';
 
 /**
  * Enrichment needs an Anthropic key; construct lazily and only when the
- * content preview could ever serve it. Absent key → routes answer 503 rather
+ * content layer could ever serve it. Absent key → routes answer 503 rather
  * than crashing registration. Import stays dynamic-free: the SDK reads
  * ANTHROPIC_API_KEY from the environment at construction.
  */
@@ -44,13 +50,52 @@ const workspaceExtension: BreezeExtensionV1 = {
     // narrowing lives in hostTypes.ts so no service carries its own cast.
     const db = asWorkspaceDatabase(context.db);
     // Per-org content flag (W2 Task 3): the single switch for the content
-    // preview surface, replacing the process-wide WORKSPACE_CONTENT_PREVIEW
-    // env var. Content is enabled iff getOrgSettings(orgId).contentEnabled.
+    // layer, replacing the process-wide WORKSPACE_CONTENT_PREVIEW env var.
+    // Content is enabled iff getOrgSettings(orgId).contentEnabled.
     const getSettings = (orgId: string) => getOrgSettings(db, orgId);
     const sourcesService = createSourcesService(db);
     const credentialService = createCredentialService(db, context.secrets, getSettings);
     const crosswalkService = createCrosswalkService(db);
     const filingService = createFilingService(db, { crosswalkService });
+
+    // W3: productized ingest. contentIngestService/enrichmentService are
+    // constructed once here (rather than inline at createContentRoutes' call
+    // site) so the SAME instances back both the admin content routes and the
+    // in-request runner the agent poke and the admin advance endpoint share.
+    // No background worker/queue/scheduler anywhere in this file — advance()
+    // only ever runs inside an authenticated request.
+    const contentIngestService = createContentIngestService(db, {
+      reader: buildContentReader(
+        (orgId, sourceId) => credentialService.decryptForContentIngest(orgId, sourceId),
+      ),
+      maxBytes: process.env.WORKSPACE_CONTENT_MAX_BYTES
+        ? Number(process.env.WORKSPACE_CONTENT_MAX_BYTES)
+        : undefined,
+      // Embedder-absent (no VOYAGE_API_KEY) is a normal deploy shape:
+      // contentIngestService.run skips the embed call and the runner drives
+      // the ingest phase exactly the same either way.
+      embedder: buildEmbedder(),
+    });
+    const enrichmentService = buildEnrichmentService(db);
+    // Enrichment-absent (no ANTHROPIC_API_KEY) must still let the runner
+    // construct and drive a job through: this no-op stand-in reports the
+    // enrich phase already drained, so the pipeline advances straight to
+    // crosswalk instead of the runner failing to construct at all. The admin
+    // /content/enrich-run route (content.ts) still answers 503 directly, so a
+    // caller asking for enrichment explicitly gets an honest error — this
+    // stand-in only governs the automatic in-request advancement path.
+    const enrichmentForRunner = enrichmentService ?? {
+      run: async (): Promise<EnrichRunResult> => ({ processed: 0, remaining: 0, errors: [] }),
+    };
+    const ingestJobsService = createIngestJobsService(db);
+    const ingestRunner = createIngestJobRunner({
+      jobs: ingestJobsService,
+      contentIngest: contentIngestService,
+      enrichment: enrichmentForRunner,
+      crosswalk: crosswalkService,
+      getSettings,
+      log: (msg) => context.log('warn', `workspace ingest runner: ${msg}`),
+    });
 
     // No auth middleware is attached here: the host gateway applies the
     // manifest-declared boundary before dispatch — agent auth on /agent/*,
@@ -70,6 +115,9 @@ const workspaceExtension: BreezeExtensionV1 = {
       credentialService,
       crawlRunsService: createCrawlRunsService(db),
       batchUpsertService: createBatchUpsertService(db),
+      ingestJobs: ingestJobsService,
+      ingestRunner,
+      getSettings,
       audit: context.audit,
       log: context.log,
     }));
@@ -104,6 +152,24 @@ const workspaceExtension: BreezeExtensionV1 = {
     helperApp.all('*', (c) => c.json({ error: 'not found' }, 404));
     app.route('/helper', helperApp);
 
+    // W4: the Outlook add-in's end-user surface. Core's generic client proxy
+    // authenticates the pane user through the client-ai Entra exchange and
+    // dispatches here under /client/* with an organization-scoped auth
+    // context; clientGate (inside createClientRoutes) admits only that shape.
+    // Mounted with the same discipline as /helper — before the admin-gated
+    // user routes, with its own catch-all so an unmatched /client/* request
+    // can never fall through to them.
+    const clientApp = new Hono();
+    clientApp.route('/', createClientRoutes({
+      emailMatchService: createEmailMatchService(db),
+      filingService,
+      getSettings,
+      audit: context.audit,
+      log: context.log,
+    }));
+    clientApp.all('*', (c) => c.json({ error: 'not found' }, 404));
+    app.route('/client', clientApp);
+
     app.route('/', createSourcesRoutes({
       sourcesService,
       credentialService,
@@ -112,25 +178,30 @@ const workspaceExtension: BreezeExtensionV1 = {
       // leaving a hole in the audit trail.
       log: context.log,
     }));
-    // Content phase (dev-preview): every route except /content/settings 404s
-    // unless content is enabled for the org (getOrgSettings). DLP runs at
-    // ingest (redact before store, block before embed); never enable in
-    // production (see README).
+    // Content layer: every route except /content/settings and the admin job
+    // endpoints (/content/jobs, /content/jobs/advance) answers
+    // 404 {"error":"not_found"} unless the org has contentEnabled set
+    // (getOrgSettings), default-deny on a missing row. DLP runs
+    // unconditionally at ingest — redact before store, block before embed
+    // (see README).
     app.route('/', createContentRoutes({
-      contentIngestService: createContentIngestService(db, {
-        reader: buildContentReader(
-          (orgId, sourceId) => credentialService.decryptForContentIngest(orgId, sourceId),
-        ),
-        maxBytes: process.env.WORKSPACE_CONTENT_MAX_BYTES
-          ? Number(process.env.WORKSPACE_CONTENT_MAX_BYTES)
-          : undefined,
-        embedder: buildEmbedder(),
-      }),
-      enrichmentService: buildEnrichmentService(db),
+      contentIngestService,
+      enrichmentService,
       crosswalkService,
+      ingestJobs: ingestJobsService,
+      ingestRunner,
       db,
       audit: context.audit,
       log: context.log,
+    }));
+    // W3 Task 6: admin dashboard read model. Shares the contentIngestService
+    // instance built above (single source of truth for the ingest card, same
+    // instance the admin content routes and the in-request runner use).
+    app.route('/', createDashboardRoutes({
+      dashboardService: createDashboardService(db, {
+        contentIngestStatus: (orgId) => contentIngestService.status(orgId),
+      }),
+      ingestJobs: ingestJobsService,
     }));
     app.route('/', createDeviceSummaryRoutes({
       deviceSummaryService: createDeviceSummaryService(db),
@@ -155,4 +226,35 @@ const workspaceExtension: BreezeExtensionV1 = {
   },
 };
 
-export default workspaceExtension;
+/**
+ * Legacy-host bridge. breeze main's `stageLegacyExtension` (apps/api
+ * src/extensions/loader.ts:136) still calls `register(context)` with ONE
+ * argument whose `mountRoute` delegates to the staging registrar, while the
+ * v1 contract this extension adopted in #11 is `register(registrar, context)`.
+ * Detect the single-argument call and re-split it; also adapt the legacy
+ * single-argument `log(message)` to the v1 `log(level, message)` signature.
+ * Remove once the host loader makes the two-argument v1 call (Plan 05
+ * follow-up — flagged in the W3 ledger).
+ */
+const legacyHostBridge: BreezeExtensionV1 = {
+  register(...args: unknown[]) {
+    if (args.length >= 2 && args[1] !== undefined) {
+      return workspaceExtension.register(
+        ...(args as Parameters<BreezeExtensionV1['register']>),
+      );
+    }
+    const legacy = args[0] as {
+      mountRoute: (app: unknown) => void;
+      log: (message: string) => void;
+    };
+    const registrar = {
+      mountRoute: (app: unknown) => legacy.mountRoute(app),
+    } as Parameters<BreezeExtensionV1['register']>[0];
+    const context = Object.create(legacy) as Parameters<BreezeExtensionV1['register']>[1];
+    (context as { log: (level: string, message: string) => void }).log = (level, message) =>
+      legacy.log(`[${level}] ${message}`);
+    return workspaceExtension.register(registrar, context);
+  },
+};
+
+export default legacyHostBridge;

--- a/ee/workspace/src/manifest.test.ts
+++ b/ee/workspace/src/manifest.test.ts
@@ -27,15 +27,58 @@ describe('Workspace manifest', () => {
     expect(manifest.requires.capabilities).toContain(capability);
   });
 
-  // NOTE (ee/workspace import): the legacy breeze-extension.json manifest
-  // is not carried into the monorepo — the built-in host path is v1-only
-  // (manifest.json) — so the parity check that used to compare it against
-  // manifest.json was dropped here.
+  /**
+   * NOTE (ee/workspace import): the legacy `breeze-extension.json` manifest was
+   * dropped by the built-in merge, so the two tests that pinned it — the
+   * semantic-equivalence check against manifest.json, and the assertions that
+   * it declares `clientSurfaces: [{ pathPrefix: '/client' }]` and the
+   * `workspace-filing-card` `clientPanels` row — were removed here. The
+   * built-in path carries the one legacy flag it still needs (`helperRoutes`)
+   * as an explicit field on the `BUILTINS` entry in
+   * apps/api/src/extensions/builtinRegistry.ts instead of reading a file.
+   *
+   * The client surface itself has NO core-side declaration in this repo yet:
+   * core's generic client-ai proxy, and the loader support that carries
+   * `clientSurfaces`/`clientPanels`, are unmerged. `/client/*` therefore mounts
+   * under the extension gateway and fails closed (clientGate demands an
+   * organization-scoped context) until that platform work lands.
+   *
+   * The negative halves below still hold and are kept: the FROZEN, `.strict()`
+   * v1 wire schema rejects both keys, which is why they never rode
+   * manifest.json in the first place.
+   */
+  it('keeps the frozen v1 manifest free of the not-yet-standardized client key', () => {
+    expect(manifest).not.toHaveProperty('clientSurfaces');
+    expect(assertManifestConformance({ ...manifest, clientSurfaces: [{ pathPrefix: '/client' }] }))
+      .toMatchObject({ ok: false });
+  });
+
+  it('keeps the frozen v1 manifest free of the not-yet-standardized clientPanels key', () => {
+    expect(manifest).not.toHaveProperty('clientPanels');
+    expect(assertManifestConformance({
+      ...manifest,
+      clientPanels: [{ host: 'outlook', surface: 'message-read', element: 'workspace-filing-card', module: 'web/index.js' }],
+    })).toMatchObject({ ok: false });
+  });
 
   it('declares the page and device slot under the Workspace namespace', () => {
     expect(manifest.web.pages[0].path).toBe('/extensions/workspace/sources');
     expect(manifest.web.slots[0]).toMatchObject({
       slot: 'device.detail.tabs', contractVersion: 1, element: 'workspace-device-index',
+    });
+  });
+
+  it('contributes the dashboard page and its navigation entry', () => {
+    expect(manifest.web.pages).toContainEqual({
+      id: 'dashboard',
+      path: '/extensions/workspace/dashboard',
+      element: 'workspace-dashboard',
+    });
+    expect(manifest.web.navigation).toContainEqual({
+      id: 'dashboard',
+      label: 'Workspace Dashboard',
+      path: '/extensions/workspace/dashboard',
+      order: 50,
     });
   });
 });

--- a/ee/workspace/src/routes/agent.test.ts
+++ b/ee/workspace/src/routes/agent.test.ts
@@ -2,7 +2,7 @@ import { gzipSync } from 'node:zlib';
 import { Hono } from 'hono';
 import type { ExtensionAgentContext, ExtensionAuditEvent } from '../hostTypes';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createAgentRoutes, type WorkspaceAgentRouteEnv } from './agent';
+import { createAgentRoutes, type AgentRouteDeps, type WorkspaceAgentRouteEnv } from './agent';
 
 const ORG_ID = '11111111-1111-4111-8111-111111111111';
 const SOURCE_ID = '22222222-2222-4222-8222-222222222222';
@@ -100,6 +100,13 @@ function makeHarness(agentValue = agent) {
   };
   const audit = vi.fn(async (_event: ExtensionAuditEvent) => {});
   const log = vi.fn();
+  const ingestJobs = {
+    ensureJob: vi.fn(async () => ({ job: { id: 'job-1' }, created: true })),
+  } as unknown as AgentRouteDeps['ingestJobs'] & { ensureJob: ReturnType<typeof vi.fn> };
+  const ingestRunner = {
+    advance: vi.fn(async () => ({ advanced: false, job: null })),
+  } as unknown as AgentRouteDeps['ingestRunner'] & { advance: ReturnType<typeof vi.fn> };
+  const getSettings = vi.fn(async () => ({ contentEnabled: true }));
   const app = new Hono<WorkspaceAgentRouteEnv>();
   app.use('*', async (c, next) => {
     c.set('agent', agentValue);
@@ -110,6 +117,9 @@ function makeHarness(agentValue = agent) {
     credentialService,
     crawlRunsService,
     batchUpsertService,
+    ingestJobs,
+    ingestRunner,
+    getSettings,
     audit,
     log,
   }));
@@ -119,6 +129,9 @@ function makeHarness(agentValue = agent) {
     credentialService,
     crawlRunsService,
     batchUpsertService,
+    ingestJobs,
+    ingestRunner,
+    getSettings,
     audit,
     log,
   };
@@ -498,5 +511,87 @@ describe('workspace agent routes', () => {
     const h = makeHarness({ ...agent, deviceId: OTHER_DEVICE_ID });
     await h.app.request(`/sources/${SOURCE_ID}/credential`, { method: 'POST' });
     expect(h.credentialService.decryptForDevice).toHaveBeenCalledWith(ORG_ID, SOURCE_ID, OTHER_DEVICE_ID);
+  });
+
+  describe('complete-hook job creation (W3)', () => {
+    it('creates an ingest job when content is enabled for the org', async () => {
+      const h = makeHarness();
+      const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({ complete: true }));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ tombstoned: 0 });
+      expect(h.getSettings).toHaveBeenCalledWith(ORG_ID);
+      expect(h.ingestJobs.ensureJob).toHaveBeenCalledWith(ORG_ID, {
+        sourceId: SOURCE_ID,
+        crawlRunId: RUN_ID,
+        trigger: 'crawl_complete',
+      });
+    });
+
+    it('skips job creation when content is disabled for the org', async () => {
+      const h = makeHarness();
+      h.getSettings.mockResolvedValueOnce({ contentEnabled: false });
+      const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({ complete: true }));
+      expect(res.status).toBe(200);
+      expect(h.ingestJobs.ensureJob).not.toHaveBeenCalled();
+    });
+
+    it('never 500s the complete response when ensureJob throws', async () => {
+      const h = makeHarness();
+      h.ingestJobs.ensureJob.mockRejectedValueOnce(new Error('db unavailable'));
+      const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({ complete: true }));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ tombstoned: 0 });
+      expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining('ingest job'));
+    });
+
+    it('does not create a job for an alreadyFinished (retried) complete', async () => {
+      const h = makeHarness();
+      h.crawlRunsService.finish.mockResolvedValueOnce({ alreadyFinished: true } as never);
+      const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({ complete: true }));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ tombstoned: 0, alreadyFinished: true });
+      expect(h.ingestJobs.ensureJob).not.toHaveBeenCalled();
+      expect(h.getSettings).not.toHaveBeenCalled();
+    });
+
+    it('does not create a job for a complete=false (failed) finish', async () => {
+      const h = makeHarness();
+      const res = await h.app.request(`/runs/${RUN_ID}/complete`, jsonRequest({ complete: false }));
+      expect(res.status).toBe(200);
+      expect(h.ingestJobs.ensureJob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('crawl-config ingest piggyback (W3)', () => {
+    it('invokes runner.advance with the agent poke budget/batch on a normal poll', async () => {
+      const h = makeHarness();
+      const { AGENT_POKE_BUDGET_MS, AGENT_POKE_BATCH } = await import('../services/ingestJobRunner');
+      const res = await h.app.request('/crawl-config');
+      expect(res.status).toBe(200);
+      expect(h.ingestRunner.advance).toHaveBeenCalledWith(ORG_ID, {
+        budgetMs: AGENT_POKE_BUDGET_MS,
+        batch: AGENT_POKE_BATCH,
+      });
+    });
+
+    it('invokes runner.advance even when the crawl kill switch is active', async () => {
+      process.env.WORKSPACE_CRAWL_ENABLED = 'false';
+      const h = makeHarness();
+      const { AGENT_POKE_BUDGET_MS, AGENT_POKE_BATCH } = await import('../services/ingestJobRunner');
+      const res = await h.app.request('/crawl-config');
+      expect(await res.json()).toEqual({ enabled: false, pollIntervalSeconds: 300, sources: [] });
+      expect(h.ingestRunner.advance).toHaveBeenCalledWith(ORG_ID, {
+        budgetMs: AGENT_POKE_BUDGET_MS,
+        batch: AGENT_POKE_BATCH,
+      });
+    });
+
+    it('never fails the crawl-config response when advance throws', async () => {
+      const h = makeHarness();
+      h.ingestRunner.advance.mockRejectedValueOnce(new Error('advance blew up'));
+      const res = await h.app.request('/crawl-config');
+      expect(res.status).toBe(200);
+      expect(h.log).toHaveBeenCalledWith('error', expect.stringContaining('advance blew up'));
+    });
   });
 });

--- a/ee/workspace/src/routes/agent.ts
+++ b/ee/workspace/src/routes/agent.ts
@@ -15,6 +15,10 @@ import {
 import { CredentialDecryptError, createCredentialService } from '../services/credentialService';
 import { createSourcesService, type SafeSourceRow } from '../services/sourcesService';
 import { matchesScope, scopeForDevice } from '../services/runScope';
+import type { createIngestJobsService } from '../services/ingestJobsService';
+import {
+  AGENT_POKE_BATCH, AGENT_POKE_BUDGET_MS, type createIngestJobRunner,
+} from '../services/ingestJobRunner';
 import { DecodedBodyTooLargeError, readDecodedBody } from './gunzip';
 
 // Soft limit advertised to agents via /crawl-config so well-behaved clients
@@ -41,12 +45,22 @@ type BatchUpsertService = Pick<
   ReturnType<typeof createBatchUpsertService>,
   'upsertBatch' | 'tombstonePaths'
 >;
+// W3: the complete-hook only ever ensures a job (never claims/advances one
+// itself), so it needs nothing else off the jobs service.
+type IngestJobsService = Pick<ReturnType<typeof createIngestJobsService>, 'ensureJob'>;
+// W3: the crawl-config piggyback only ever pokes the runner's budgeted
+// advance — claiming/releasing stays entirely inside the runner.
+type IngestJobRunner = Pick<ReturnType<typeof createIngestJobRunner>, 'advance'>;
 
 export interface AgentRouteDeps {
   sourcesService: SourcesService;
   credentialService: CredentialService;
   crawlRunsService: CrawlRunsService;
   batchUpsertService: BatchUpsertService;
+  ingestJobs: IngestJobsService;
+  ingestRunner: IngestJobRunner;
+  /** Per-org content flag (W2 Task 3 pattern) — gates complete-hook job creation. */
+  getSettings: (orgId: string) => Promise<{ contentEnabled: boolean }>;
   audit: WorkspaceAudit;
   log: ExtensionLog;
 }
@@ -175,6 +189,26 @@ export function createAgentRoutes(deps: AgentRouteDeps): Hono<WorkspaceAgentRout
     );
   }
 
+  // W3: piggyback a budgeted ingest advance onto the agent's existing poll.
+  // There is no background worker — this in-request nudge is what keeps a
+  // live job moving between explicit admin advances. Runs even when crawling
+  // itself is kill-switched (content gating is the runner's own per-org
+  // settings check, independent of crawl). Must NEVER perturb the poll
+  // response: any throw is caught and logged, not surfaced.
+  async function pokeIngest(agent: ExtensionAgentContext): Promise<void> {
+    try {
+      await deps.ingestRunner.advance(agent.orgId, {
+        budgetMs: AGENT_POKE_BUDGET_MS,
+        batch: AGENT_POKE_BATCH,
+      });
+    } catch (error) {
+      deps.log(
+        'error',
+        `workspace ingest poke failed org=${agent.orgId} device=${agent.deviceId}: ${errorDetail(error)}`,
+      );
+    }
+  }
+
   async function resolveRun(
     agent: ExtensionAgentContext,
     runId: string,
@@ -196,11 +230,14 @@ export function createAgentRoutes(deps: AgentRouteDeps): Hono<WorkspaceAgentRout
   }
 
   app.get('/crawl-config', async (c) => {
+    const agent = c.get('agent');
     if (crawlKillSwitchActive()) {
       deps.log('warn', 'workspace crawl kill switch active (WORKSPACE_CRAWL_ENABLED)');
+      // Piggyback runs even with crawling kill-switched: content gating is
+      // per-org via the runner's own settings check, independent of crawl.
+      await pokeIngest(agent);
       return c.json({ enabled: false, pollIntervalSeconds: POLL_INTERVAL_SECONDS, sources: [] });
     }
-    const agent = c.get('agent');
     const sources = await visibleSources(agent);
     const configuredSources = await Promise.all(sources.map(async (source) => {
       const active = await deps.crawlRunsService.getActive(agent.orgId, source.id, agent.deviceId);
@@ -220,7 +257,7 @@ export function createAgentRoutes(deps: AgentRouteDeps): Hono<WorkspaceAgentRout
         watch: source.kind === 'local_profile' ? source.watch : false,
       };
     }));
-    return c.json({
+    const payload = {
       enabled: true,
       pollIntervalSeconds: POLL_INTERVAL_SECONDS,
       limits: {
@@ -229,7 +266,11 @@ export function createAgentRoutes(deps: AgentRouteDeps): Hono<WorkspaceAgentRout
         walkOpsPerSecond: WALK_OPS_PER_SECOND,
       },
       sources: configuredSources,
-    });
+    };
+    // Piggyback AFTER the response payload is built (Flag 4: adds up to
+    // ~AGENT_POKE_BUDGET_MS to this poll while a job is live).
+    await pokeIngest(agent);
+    return c.json(payload);
   });
 
   app.post('/sources/:id/credential', async (c) => {
@@ -363,8 +404,32 @@ export function createAgentRoutes(deps: AgentRouteDeps): Hono<WorkspaceAgentRout
     );
     if ('notFound' in result) return c.json({ error: 'not found' }, 404);
     // A retried complete (lost response) is answered idempotently; the
-    // tombstone sweep already ran on the first attempt.
+    // tombstone sweep already ran on the first attempt — and so did any job
+    // creation, so this path must NOT re-ensure one.
     if ('alreadyFinished' in result) return c.json({ tombstoned: 0, alreadyFinished: true });
+
+    // W3 complete-hook: a genuinely fresh, successful finish nudges
+    // productized ingest into motion. Job creation must NEVER fail (or even
+    // slow down the wire contract of) the agent's complete response — every
+    // failure mode here is caught and logged, never surfaced.
+    if (parsed.data.complete) {
+      try {
+        if ((await deps.getSettings(agent.orgId)).contentEnabled) {
+          const run = await deps.crawlRunsService.getById(agent.orgId, runId);
+          await deps.ingestJobs.ensureJob(agent.orgId, {
+            sourceId: run?.sourceId ?? null,
+            crawlRunId: runId,
+            trigger: 'crawl_complete',
+          });
+        }
+      } catch (error) {
+        deps.log(
+          'error',
+          `workspace ingest job creation failed run=${runId} org=${agent.orgId}: ${errorDetail(error)}`,
+        );
+      }
+    }
+
     return c.json({ tombstoned: result.tombstoned });
   });
 

--- a/ee/workspace/src/routes/client.test.ts
+++ b/ee/workspace/src/routes/client.test.ts
@@ -1,0 +1,309 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+import type { ExtensionAuditEvent } from '../hostTypes';
+import type { FilingRecord } from '../services/filingService';
+import { createClientRoutes } from './client';
+import type { WorkspaceAuthContext, WorkspaceRouteEnv } from './adminGate';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+const FILE_ID = '77777777-7777-4777-8777-777777777777';
+
+function orgAuth(overrides: Partial<WorkspaceAuthContext> = {}): WorkspaceAuthContext {
+  return {
+    user: { id: USER_ID, email: 'jenny@fairoaksca.gov', name: 'Jenny Tran' },
+    scope: 'organization',
+    orgId: ORG_ID,
+    partnerId: undefined,
+    accessibleOrgIds: [ORG_ID],
+    ...overrides,
+  } as WorkspaceAuthContext;
+}
+
+function record(overrides: Partial<FilingRecord> = {}): FilingRecord {
+  return {
+    fileIndexId: FILE_ID,
+    relPath: 'Emails/Unfiled/re PO 4021 pipe submittal.eml',
+    name: 're PO 4021 pipe submittal.eml',
+    emailMeta: { subject: 'RE: PO 4021 - pipe submittal', from: 'pdeluca@fairoaksca.gov' },
+    status: null,
+    suggestedProjectKey: null,
+    suggestedProjectLabel: null,
+    matchedEntityType: null,
+    matchedEntityValue: null,
+    confidence: null,
+    rationale: null,
+    decidedProjectKey: null,
+    ...overrides,
+  };
+}
+
+const SUGGESTED = record({
+  status: 'suggested',
+  suggestedProjectKey: '2023-041',
+  suggestedProjectLabel: 'Henderson Water Main Replacement',
+  matchedEntityType: 'po',
+  matchedEntityValue: 'PO 4021',
+  confidence: 'high',
+  rationale: 'matched City of Fairoaks PO #4021',
+});
+
+function makeHarness(options: {
+  contentEnabled?: boolean;
+  auth?: WorkspaceAuthContext | null;
+  match?: { fileIndexId: string; tier: 1 | 2 | 3 } | null;
+  fileable?: FilingRecord | null;
+} = {}) {
+  const emailMatchService = {
+    match: vi.fn(async () => (options.match === undefined
+      ? { fileIndexId: FILE_ID, tier: 2 as const }
+      : options.match)),
+  };
+  const filingService = {
+    get: vi.fn(async (): Promise<FilingRecord | null> => (
+      options.fileable === undefined ? record() : options.fileable)),
+    classify: vi.fn(async (): Promise<FilingRecord | null> => SUGGESTED),
+    assign: vi.fn(async (): Promise<FilingRecord | null> => record({
+      status: 'confirmed', decidedProjectKey: '2023-041',
+    })),
+    projects: vi.fn(async () => [{ key: '2023-041', label: 'Henderson Water Main Replacement' }]),
+  };
+  const getSettings = vi.fn(async (_orgId: string) => ({
+    contentEnabled: options.contentEnabled ?? true,
+  }));
+  const audit = vi.fn(async (_event: ExtensionAuditEvent) => {});
+  const log = vi.fn();
+  const app = new Hono<WorkspaceRouteEnv>();
+  const auth = options.auth === undefined ? orgAuth() : options.auth;
+  app.use('*', async (c, next) => {
+    if (auth) c.set('auth', auth);
+    await next();
+  });
+  app.route('/', createClientRoutes({ emailMatchService, filingService, getSettings, audit, log }));
+  return { app, emailMatchService, filingService, getSettings, audit, log };
+}
+
+const MATCH_QUERY = '/filing/match?subject=RE%3A%20PO%204021%20-%20pipe%20submittal'
+  + '&sender=pdeluca%40fairoaksca.gov&date=2026-07-14T10%3A00%3A00.000Z';
+
+describe('client filing routes — gate', () => {
+  it.each([
+    ['GET', MATCH_QUERY],
+    ['GET', '/content/projects'],
+    ['POST', `/filing/${FILE_ID}/assign`],
+  ])('rejects %s %s for a partner-scoped principal with 403', async (method, path) => {
+    const { app, filingService } = makeHarness({ auth: orgAuth({ scope: 'partner' }) });
+    const res = await app.request(path, {
+      method,
+      ...(method === 'POST'
+        ? { body: JSON.stringify({ projectKey: '2023-041' }), headers: { 'content-type': 'application/json' } }
+        : {}),
+    });
+    expect(res.status).toBe(403);
+    expect(filingService.get).not.toHaveBeenCalled();
+    expect(filingService.assign).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request with no auth context', async () => {
+    const { app } = makeHarness({ auth: null });
+    expect((await app.request(MATCH_QUERY)).status).toBe(403);
+  });
+});
+
+describe('client filing routes — content gate', () => {
+  it.each([
+    ['GET', MATCH_QUERY],
+    ['GET', '/content/projects'],
+  ])('answers %s %s with 404 content_disabled when content is off for the org', async (_m, path) => {
+    const { app, filingService, emailMatchService } = makeHarness({ contentEnabled: false });
+    const res = await app.request(path);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'content_disabled' });
+    expect(emailMatchService.match).not.toHaveBeenCalled();
+    expect(filingService.projects).not.toHaveBeenCalled();
+  });
+
+  it('answers assign with 404 content_disabled when content is off for the org', async () => {
+    const { app, filingService } = makeHarness({ contentEnabled: false });
+    const res = await app.request(`/filing/${FILE_ID}/assign`, {
+      method: 'POST',
+      body: JSON.stringify({ projectKey: '2023-041' }),
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'content_disabled' });
+    expect(filingService.assign).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /filing/match', () => {
+  it('matches the open message and classifies on demand when no filing row exists', async () => {
+    const { app, emailMatchService, filingService, audit } = makeHarness();
+    const res = await app.request(MATCH_QUERY);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      match: { fileIndexId: FILE_ID, tier: 2, filing: SUGGESTED },
+    });
+    // org from the auth context, groupIds [] (fail closed: ungrouped only)
+    expect(emailMatchService.match).toHaveBeenCalledWith(ORG_ID, {
+      subject: 'RE: PO 4021 - pipe submittal',
+      sender: 'pdeluca@fairoaksca.gov',
+      dateISO: '2026-07-14T10:00:00.000Z',
+    }, []);
+    expect(filingService.classify).toHaveBeenCalledWith(ORG_ID, FILE_ID, []);
+    // The matched file is looked up ONE row at a time — never by scanning the
+    // org's whole unfiled list to `.find()` a single id (every pane open pays
+    // that cost, on an estate with thousands of unfiled emails).
+    expect(filingService.get).toHaveBeenCalledWith(ORG_ID, FILE_ID, []);
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_ID,
+      actorType: 'user',
+      actorId: USER_ID,
+      action: 'workspace.filing.classify',
+      resourceType: 'workspace_file',
+      resourceId: FILE_ID,
+      result: 'success',
+      details: expect.objectContaining({ via: 'client' }),
+    }));
+  });
+
+  it('passes the internetMessageId through for the tier-1 arm', async () => {
+    const { app, emailMatchService } = makeHarness({ match: { fileIndexId: FILE_ID, tier: 1 } });
+    const res = await app.request(`${MATCH_QUERY}&internetMessageId=%3Cabc%40mail%3E`);
+    expect(res.status).toBe(200);
+    expect(emailMatchService.match).toHaveBeenCalledWith(ORG_ID, expect.objectContaining({
+      internetMessageId: '<abc@mail>',
+    }), []);
+  });
+
+  it('does not re-classify when the matched email already carries a filing row', async () => {
+    const { app, filingService, audit } = makeHarness({ fileable: SUGGESTED });
+    const res = await app.request(MATCH_QUERY);
+    expect(await res.json()).toEqual({
+      match: { fileIndexId: FILE_ID, tier: 2, filing: SUGGESTED },
+    });
+    expect(filingService.classify).not.toHaveBeenCalled();
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it('answers match null when no crawled email matches the probe', async () => {
+    const { app, filingService } = makeHarness({ match: null });
+    const res = await app.request(MATCH_QUERY);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ match: null });
+    expect(filingService.classify).not.toHaveBeenCalled();
+  });
+
+  // The matched file is outside the caller's filing view (already filed under a
+  // project path, tombstoned, or hidden): report the match, never a filing row
+  // synthesized from nothing.
+  it('reports a null filing when the matched file is not a fileable email in view', async () => {
+    const { app, filingService } = makeHarness({ fileable: null });
+    const res = await app.request(MATCH_QUERY);
+    expect(await res.json()).toEqual({ match: { fileIndexId: FILE_ID, tier: 2, filing: null } });
+    expect(filingService.classify).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing subject', '/filing/match?sender=a%40b.com'],
+    ['unknown key', `${MATCH_QUERY}&orgId=${ORG_ID}`],
+    ['non-ISO date', '/filing/match?subject=hi&date=yesterday'],
+    ['blank subject', '/filing/match?subject='],
+  ])('rejects a %s query with 400', async (_label, path) => {
+    const { app, emailMatchService } = makeHarness();
+    const res = await app.request(path);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid request' });
+    expect(emailMatchService.match).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /filing/:fileIndexId/assign', () => {
+  async function assign(app: Hono<WorkspaceRouteEnv>, fileIndexId: string, body: unknown) {
+    return app.request(`/filing/${fileIndexId}/assign`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('assigns and audits with the end user as actor', async () => {
+    const { app, filingService, audit } = makeHarness();
+    const res = await assign(app, FILE_ID, { projectKey: '2023-041' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      filing: record({ status: 'confirmed', decidedProjectKey: '2023-041' }),
+    });
+    // decidedLabel is the end user's display name; groupIds [] as everywhere.
+    expect(filingService.assign)
+      .toHaveBeenCalledWith(ORG_ID, FILE_ID, '2023-041', 'Jenny Tran', []);
+    expect(audit).toHaveBeenCalledWith(expect.objectContaining({
+      orgId: ORG_ID,
+      actorType: 'user',
+      actorId: USER_ID,
+      action: 'workspace.filing.assign',
+      resourceType: 'workspace_file',
+      resourceId: FILE_ID,
+      result: 'success',
+      details: { projectKey: '2023-041', via: 'client' },
+    }));
+  });
+
+  it('passes a reassignment through unchanged', async () => {
+    const { app, filingService } = makeHarness();
+    filingService.assign.mockResolvedValueOnce(record({
+      status: 'reassigned', decidedProjectKey: '2025-012',
+    }));
+    const res = await assign(app, FILE_ID, { projectKey: '2025-012' });
+    expect((await res.json() as { filing: FilingRecord }).filing.status).toBe('reassigned');
+  });
+
+  it('answers 404 for an unknown file or project (service null)', async () => {
+    const { app, filingService } = makeHarness();
+    filingService.assign.mockResolvedValueOnce(null);
+    const res = await assign(app, FILE_ID, { projectKey: '9999-999' });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'not found' });
+  });
+
+  it('answers 404 for a malformed fileIndexId without touching the service', async () => {
+    const { app, filingService } = makeHarness();
+    const res = await assign(app, 'not-a-uuid', { projectKey: '2023-041' });
+    expect(res.status).toBe(404);
+    expect(filingService.assign).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unknown key', { projectKey: '2023-041', orgId: ORG_ID }],
+    ['empty projectKey', { projectKey: '' }],
+    ['over-long projectKey', { projectKey: 'x'.repeat(41) }],
+    ['wrong type', { projectKey: 7 }],
+    ['no body at all', undefined],
+  ])('rejects a %s body with 400', async (_label, body) => {
+    const { app, filingService } = makeHarness();
+    const res = await assign(app, FILE_ID, body);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid request' });
+    expect(filingService.assign).not.toHaveBeenCalled();
+  });
+
+  it('keeps a failed audit write from changing the outcome, but logs it', async () => {
+    const { app, audit, log } = makeHarness();
+    audit.mockRejectedValueOnce(new Error('audit sink down'));
+    const res = await assign(app, FILE_ID, { projectKey: '2023-041' });
+    expect(res.status).toBe(200);
+    expect(log).toHaveBeenCalledWith('error', expect.stringContaining('audit sink down'));
+  });
+});
+
+describe('GET /content/projects', () => {
+  it('returns the org project list', async () => {
+    const { app, filingService } = makeHarness();
+    const res = await app.request('/content/projects');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      projects: [{ key: '2023-041', label: 'Henderson Water Main Replacement' }],
+    });
+    expect(filingService.projects).toHaveBeenCalledWith(ORG_ID);
+  });
+});

--- a/ee/workspace/src/routes/client.ts
+++ b/ee/workspace/src/routes/client.ts
@@ -1,0 +1,209 @@
+// End-user client surface (W4): the three calls the Outlook add-in pane's
+// filing card makes, mounted by the host under /client/*.
+//
+// Boundary: core's generic client proxy authenticates the pane user through
+// the client-ai Entra exchange and hands this extension an organization-scoped
+// auth context; `clientGate` (below, applied to every route in this tree)
+// accepts only that shape. Nothing here reads an org from the request.
+//
+// Governance, applied uniformly and non-negotiably:
+//  - org-settings content gate, default-deny (no settings row → DISABLED), so
+//    an org that has not turned the content preview on has no client surface
+//    at all — 404 `content_disabled`, never a 403/500 that leaks existence;
+//  - every query that returns file data passes groupIds `[]` into the single
+//    visibility predicate (services/visibility.ts): ungrouped sources only,
+//    the same fail-closed stance the helper surface takes, because an Entra
+//    session carries no Workspace group claims yet;
+//  - every mutating call is audited with the END USER as actor and
+//    `via: 'client'`, so a client-filed email is distinguishable from the
+//    device/helper path in the audit trail.
+import type { ExtensionAuditEvent, ExtensionLog, WorkspaceAudit } from '../hostTypes';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import type { EmailMatchService } from '../services/emailMatchService';
+import type { FilingRecord, FilingService } from '../services/filingService';
+import { clientGate } from './clientGate';
+import type { WorkspaceRouteEnv } from './adminGate';
+
+/**
+ * PUBLISHED CONTRACT for Tasks 8/9 (the add-in pane and the beat script).
+ *
+ * `filing` is deliberately `FilingRecord | null`, a documented widening of the
+ * brief's `FilingRecord`: a match can be a file the caller may SEE but cannot
+ * FILE — already filed under a project path, or tombstoned — and there is no
+ * honest filing record for it. Suppressing the match would be worse (the pane
+ * would claim it found nothing about a message it demonstrably located), and
+ * synthesizing an empty record would be a lie. So: `match !== null` means "we
+ * know which .eml this is"; `match.filing !== null` means "and you may file
+ * it". The pane MUST treat `filing: null` as a read-only identification —
+ * `POST /filing/:id/assign` will answer 404 for that id.
+ */
+export interface ClientMatchResponse {
+  match: {
+    fileIndexId: string;
+    tier: 1 | 2 | 3;
+    filing: FilingRecord | null;
+  } | null;
+}
+
+/** `POST /client/filing/:fileIndexId/assign` → 200. */
+export interface ClientAssignResponse {
+  filing: FilingRecord;
+}
+
+/** `GET /client/content/projects` → 200. */
+export interface ClientProjectsResponse {
+  projects: Array<{ key: string; label: string }>;
+}
+
+export interface ClientRouteDeps {
+  emailMatchService: Pick<EmailMatchService, 'match'>;
+  filingService: Pick<FilingService, 'get' | 'classify' | 'assign' | 'projects'>;
+  /** Per-org content flag; no settings row means disabled (default-deny). */
+  getSettings: (orgId: string) => Promise<{ contentEnabled: boolean }>;
+  audit: WorkspaceAudit;
+  log: ExtensionLog;
+}
+
+/** Entra sessions carry no Workspace visibility-group claims yet: every read
+ * on this surface fails closed to ungrouped sources. One constant so the
+ * stance is visible, and changing it is a deliberate single edit. */
+const CLIENT_GROUP_IDS: string[] = [];
+
+const matchQuerySchema = z.strictObject({
+  subject: z.string().min(1).max(500),
+  sender: z.string().min(1).max(320).optional(),
+  date: z.iso.datetime().optional(),
+  internetMessageId: z.string().min(1).max(998).optional(),
+});
+
+const assignSchema = z.strictObject({
+  projectKey: z.string().min(1).max(40),
+});
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createClientRoutes(deps: ClientRouteDeps): Hono<WorkspaceRouteEnv> {
+  const app = new Hono<WorkspaceRouteEnv>();
+
+  async function guardedAudit(event: ExtensionAuditEvent, context: string): Promise<void> {
+    try {
+      await deps.audit(event);
+    } catch (error) {
+      deps.log('error', `workspace client audit write failed (${context}): ${errorDetail(error)}`);
+    }
+  }
+
+  // Auth boundary first, then the per-org content gate — an unauthorized
+  // caller must never be able to probe whether an org has content enabled.
+  app.use('*', clientGate);
+  app.use('*', async (c, next) => {
+    const settings = await deps.getSettings(c.get('workspaceOrgId'));
+    if (!settings.contentEnabled) return c.json({ error: 'content_disabled' }, 404);
+    await next();
+  });
+
+  /**
+   * Which crawled .eml is the message currently open in Outlook, and what do
+   * we suggest filing it under?
+   *
+   * Classify-on-demand: the pane opens on mail that has usually never been
+   * looked at by the filing pipeline, so a matched email with no filing row is
+   * classified right here (filingService.classify never overwrites a human
+   * decision, so this is safe to call repeatedly). A matched file that is not
+   * a fileable email in the caller's view — already filed under a project
+   * path, tombstoned, or in a hidden source — is reported as a match with a
+   * null filing rather than being hidden or synthesized.
+   */
+  app.get('/filing/match', async (c) => {
+    const parsed = matchQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const orgId = c.get('workspaceOrgId');
+
+    const match = await deps.emailMatchService.match(orgId, {
+      subject: parsed.data.subject,
+      ...(parsed.data.sender !== undefined ? { sender: parsed.data.sender } : {}),
+      ...(parsed.data.date !== undefined ? { dateISO: parsed.data.date } : {}),
+      ...(parsed.data.internetMessageId !== undefined
+        ? { internetMessageId: parsed.data.internetMessageId }
+        : {}),
+    }, CLIENT_GROUP_IDS);
+    if (!match) return c.json({ match: null } satisfies ClientMatchResponse);
+
+    const fileable = await deps.filingService.get(orgId, match.fileIndexId, CLIENT_GROUP_IDS);
+    let filing: FilingRecord | null = fileable;
+    if (fileable && fileable.status === null) {
+      filing = await deps.filingService.classify(orgId, match.fileIndexId, CLIENT_GROUP_IDS);
+      if (filing) {
+        const auth = c.get('auth');
+        await guardedAudit({
+          orgId,
+          actorType: 'user',
+          actorId: auth.user.id,
+          action: 'workspace.filing.classify',
+          resourceType: 'workspace_file',
+          resourceId: match.fileIndexId,
+          details: {
+            suggestedProjectKey: filing.suggestedProjectKey,
+            confidence: filing.confidence,
+            tier: match.tier,
+            via: 'client',
+          },
+          result: 'success',
+        }, `filing classify file=${match.fileIndexId}`);
+      }
+    }
+
+    return c.json({
+      match: { fileIndexId: match.fileIndexId, tier: match.tier, filing },
+    } satisfies ClientMatchResponse);
+  });
+
+  /**
+   * One-click file. Idempotent with the device/helper path by construction:
+   * both call the same `filingService.assign`, whose UPDATE is keyed on the
+   * (unique) file_index_id, so the same file + project through either path
+   * converges to one row with the same status.
+   *
+   * A malformed id is the contract 404 (unknown-or-hidden file), never a 500 —
+   * same 22P02 guard as the helper route.
+   */
+  app.post('/filing/:fileIndexId/assign', async (c) => {
+    const fileIndexId = c.req.param('fileIndexId');
+    if (!z.uuid().safeParse(fileIndexId).success) return c.json({ error: 'not found' }, 404);
+    const parsed = assignSchema.safeParse(await c.req.json().catch(() => undefined));
+    if (!parsed.success) return c.json({ error: 'invalid request' }, 400);
+    const orgId = c.get('workspaceOrgId');
+    const auth = c.get('auth');
+    // decided_label is display text for "who filed it" — the end user's name,
+    // falling back to their address. It is never authorization.
+    const decidedLabel = auth.user.name ?? auth.user.email ?? null;
+
+    const filing = await deps.filingService.assign(
+      orgId, fileIndexId, parsed.data.projectKey, decidedLabel, CLIENT_GROUP_IDS,
+    );
+    if (!filing) return c.json({ error: 'not found' }, 404);
+    await guardedAudit({
+      orgId,
+      actorType: 'user',
+      actorId: auth.user.id,
+      action: 'workspace.filing.assign',
+      resourceType: 'workspace_file',
+      resourceId: fileIndexId,
+      details: { projectKey: parsed.data.projectKey, via: 'client' },
+      result: 'success',
+    }, `filing assign file=${fileIndexId}`);
+    return c.json({ filing } satisfies ClientAssignResponse);
+  });
+
+  /** Project picker contents for the card's reassign control. */
+  app.get('/content/projects', async (c) => {
+    return c.json({
+      projects: await deps.filingService.projects(c.get('workspaceOrgId')),
+    } satisfies ClientProjectsResponse);
+  });
+
+  return app;
+}

--- a/ee/workspace/src/routes/clientGate.test.ts
+++ b/ee/workspace/src/routes/clientGate.test.ts
@@ -1,0 +1,106 @@
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { clientGate } from './clientGate';
+import type { WorkspaceAuthContext, WorkspaceRouteEnv } from './adminGate';
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_ORG = '99999999-9999-4999-8999-999999999999';
+const PARTNER_ID = '22222222-2222-4222-8222-222222222222';
+const USER_ID = '33333333-3333-4333-8333-333333333333';
+
+/** Exactly what the core /client/* proxy synthesizes for an add-in session. */
+function orgAuth(overrides: Partial<WorkspaceAuthContext> = {}): WorkspaceAuthContext {
+  return {
+    user: { id: USER_ID, email: 'jenny@fairoaksca.gov', name: 'Jenny Tran' },
+    scope: 'organization',
+    orgId: ORG_ID,
+    partnerId: undefined,
+    accessibleOrgIds: [ORG_ID],
+    ...overrides,
+  } as WorkspaceAuthContext;
+}
+
+function gatedApp(auth: WorkspaceAuthContext | null) {
+  const app = new Hono<WorkspaceRouteEnv>();
+  app.use('*', async (c, next) => {
+    if (auth) c.set('auth', auth);
+    await next();
+  });
+  app.use('*', clientGate);
+  app.get('/probe', (c) => c.json({ orgId: c.get('workspaceOrgId') }));
+  return app;
+}
+
+describe('clientGate', () => {
+  it('admits an organization-scoped session and pins the org from the auth context', async () => {
+    const res = await gatedApp(orgAuth()).request('/probe');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: ORG_ID });
+  });
+
+  // The inverse of adminGate on purpose: /client is the end-user surface. A
+  // partner- or system-scoped principal belongs on the admin surface, and
+  // must not be able to drive an end-user filing action here.
+  it.each([
+    ['partner', { scope: 'partner' as const, partnerId: PARTNER_ID }],
+    ['system', { scope: 'system' as const, accessibleOrgIds: null }],
+  ])('rejects %s scope with 403', async (_label, overrides) => {
+    const res = await gatedApp(orgAuth(overrides)).request('/probe');
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'organization access required' });
+  });
+
+  it.each([
+    ['missing orgId', { orgId: undefined }],
+    ['null orgId', { orgId: null }],
+    ['blank orgId', { orgId: '   ' }],
+  ])('rejects organization scope with %s', async (_label, overrides) => {
+    const res = await gatedApp(orgAuth(overrides)).request('/probe');
+    expect(res.status).toBe(403);
+  });
+
+  // Identity presence is a host invariant, but the handlers dereference the
+  // org unconditionally: a missing auth var must name the condition here
+  // rather than surface as a TypeError 500.
+  it('rejects a request with no auth context at all', async () => {
+    const res = await gatedApp(null).request('/probe');
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'organization access required' });
+  });
+
+  // The whole security story of this surface is "the actor is the end user":
+  // every mutating handler dereferences `auth.user.id` and writes it into the
+  // audit row. A context with no usable identity must be denied HERE, not
+  // produce a TypeError 500 (match/assign) or — far worse — a successful
+  // filing carrying `actorId: undefined` in the audit trail.
+  it.each([
+    ['no user at all', { user: undefined }],
+    ['user with no id', { user: { email: 'jenny@fairoaksca.gov' } }],
+    ['user with a blank id', { user: { id: '   ', email: 'jenny@fairoaksca.gov' } }],
+    ['user with a non-string id', { user: { id: 7 } }],
+  ])('rejects organization scope with %s', async (_label, overrides) => {
+    const res = await gatedApp(orgAuth(overrides as Partial<WorkspaceAuthContext>)).request('/probe');
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'organization access required' });
+  });
+
+  // The proxy pins one org; an org outside the caller's own accessible set is
+  // an upstream defect and must fail closed rather than be honored.
+  it('rejects when the pinned org is absent from accessibleOrgIds', async () => {
+    const res = await gatedApp(orgAuth({ accessibleOrgIds: [OTHER_ORG] })).request('/probe');
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects organization scope carrying no accessible org list', async () => {
+    const res = await gatedApp(orgAuth({ accessibleOrgIds: null })).request('/probe');
+    expect(res.status).toBe(403);
+  });
+
+  // adminGate reads ?orgId from the query; clientGate must NEVER let a query
+  // parameter influence which org is served.
+  it('ignores an orgId query parameter', async () => {
+    const res = await gatedApp(orgAuth()).request(`/probe?orgId=${OTHER_ORG}`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: ORG_ID });
+  });
+});

--- a/ee/workspace/src/routes/clientGate.ts
+++ b/ee/workspace/src/routes/clientGate.ts
@@ -1,0 +1,57 @@
+import type { MiddlewareHandler } from 'hono';
+import type { WorkspaceRouteEnv } from './adminGate';
+
+/**
+ * The /client/* boundary: the end-user surface the Outlook add-in pane talks
+ * to through core's generic client proxy.
+ *
+ * The proxy authenticates the pane's user via the client-ai Entra exchange and
+ * synthesizes an ORGANIZATION-scoped auth context — `{ user, scope:
+ * 'organization', orgId, partnerId: undefined, accessibleOrgIds: [orgId] }` —
+ * before dispatching here.
+ *
+ * This is deliberately the INVERSE of `adminGate`, and the difference is the
+ * whole point of having two gates:
+ *
+ *  - adminGate admits partner/system scope and reads the target org from
+ *    `?orgId`, because an MSP operator legitimately acts across orgs.
+ *  - clientGate admits ONLY organization scope, and takes the org from the
+ *    authenticated context — never from the query, the body, or the path. A
+ *    partner- or system-scoped principal is rejected here rather than
+ *    silently upgraded: these routes file mail on an end user's behalf and
+ *    attribute the action to `auth.user.id`, so an operator token must not be
+ *    able to drive them.
+ *
+ * Everything fails closed: no auth var, a non-organization scope, a blank org,
+ * or an org outside the caller's own accessible set all answer the same 403.
+ */
+export const clientGate: MiddlewareHandler<WorkspaceRouteEnv> = async (c, next) => {
+  const deny = () => c.json({ error: 'organization access required' }, 403);
+
+  const auth = c.get('auth');
+  if (!auth || auth.scope !== 'organization') return deny();
+
+  const orgId = typeof auth.orgId === 'string' ? auth.orgId.trim() : '';
+  if (!orgId) return deny();
+
+  // The proxy pins exactly one org and lists it. A pinned org that is not in
+  // the caller's own accessible set means the upstream context is inconsistent
+  // (or forged) — refuse rather than trust the more permissive half of it.
+  // `null` (adminGate's unrestricted sentinel) is never honored on this
+  // surface: an end-user session is always explicitly scoped.
+  if (!Array.isArray(auth.accessibleOrgIds) || !auth.accessibleOrgIds.includes(orgId)) {
+    return deny();
+  }
+
+  // Identity is load-bearing here, not decoration: the handlers attribute every
+  // filing action to `auth.user.id` in the audit trail, and that is the entire
+  // security story of an end-user surface. `user` is typed non-optional, but a
+  // synthesized or partial context would otherwise either throw a TypeError
+  // (500) or — worse — file the email successfully and write `actorId:
+  // undefined`. An unattributable actor is denied, not accommodated.
+  const userId = (auth.user as { id?: unknown } | undefined)?.id;
+  if (typeof userId !== 'string' || userId.trim() === '') return deny();
+
+  c.set('workspaceOrgId', orgId);
+  await next();
+};

--- a/ee/workspace/src/routes/content.test.ts
+++ b/ee/workspace/src/routes/content.test.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import type { WorkspaceDatabase } from '../hostTypes';
 import { createContentRoutes, type ContentRouteDeps } from './content';
 import type { WorkspaceRouteEnv } from './adminGate';
+import { TransientIngestError } from '../services/ingestErrors';
 
 const ORG_ID = '11111111-1111-1111-1111-111111111111';
 const ORG_B = '99999999-9999-4999-8999-999999999999';
@@ -58,8 +59,17 @@ function makeApp(overrides: Partial<ContentRouteDeps> = {}, auth?: object | null
       eligible: 10, extracted: 3, failed: 1, skippedTooLarge: 0, skippedBinary: 1, pending: 5,
     })),
   };
+  const ingestJobs = {
+    ensureJob: vi.fn(async () => ({ job: { id: 'job-1', orgId: ORG_ID }, created: true })),
+    list: vi.fn(async () => [{ id: 'job-1', orgId: ORG_ID }]),
+  };
+  const ingestRunner = {
+    advance: vi.fn(async () => ({ advanced: true, job: { id: 'job-1', orgId: ORG_ID } })),
+  };
   const deps: ContentRouteDeps = {
     contentIngestService: ingest as unknown as ContentRouteDeps['contentIngestService'],
+    ingestJobs: ingestJobs as unknown as ContentRouteDeps['ingestJobs'],
+    ingestRunner: ingestRunner as unknown as ContentRouteDeps['ingestRunner'],
     // Default to content-enabled for ORG_ID so the behavior suites exercise the
     // live routes; gating/settings suites pass an explicit db.
     db: enabledDb(ORG_ID),
@@ -77,7 +87,7 @@ function makeApp(overrides: Partial<ContentRouteDeps> = {}, auth?: object | null
     await next();
   });
   app.route('/', createContentRoutes(deps));
-  return { app, ingest, deps };
+  return { app, ingest, ingestJobs, ingestRunner, deps };
 }
 
 describe('content routes — per-org content flag gating', () => {
@@ -201,6 +211,31 @@ describe('content routes — behavior (content enabled)', () => {
     }));
   });
 
+  it('enrich-run answers 503 when the provider is rate-limited/down (TransientIngestError)', async () => {
+    const enrichment = { run: vi.fn(async () => { throw new TransientIngestError('anthropic_429'); }) };
+    const { app, deps } = makeApp({
+      enrichmentService: enrichment as unknown as ContentRouteDeps['enrichmentService'],
+    });
+    const res = await app.request(`/content/enrich-run?orgId=${ORG_ID}`, { method: 'POST' });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: 'enrichment provider unavailable or rate limited; retry later',
+    });
+    // A transient cap is not a successful run — nothing is audited as success.
+    expect(deps.audit).not.toHaveBeenCalledWith(expect.objectContaining({
+      action: 'workspace.content.enrich_run',
+    }));
+  });
+
+  it('enrich-run rethrows a non-transient error (surfaces as 500)', async () => {
+    const enrichment = { run: vi.fn(async () => { throw new Error('kaboom'); }) };
+    const { app } = makeApp({
+      enrichmentService: enrichment as unknown as ContentRouteDeps['enrichmentService'],
+    });
+    const res = await app.request(`/content/enrich-run?orgId=${ORG_ID}`, { method: 'POST' });
+    expect(res.status).toBe(500);
+  });
+
   it('reports per-file errors in the response body', async () => {
     const { app } = makeApp({
       contentIngestService: {
@@ -287,5 +322,107 @@ describe('content routes — settings (exempt from the content flag gate)', () =
       orgId: ORG_ID,
       result: 'success',
     }));
+  });
+});
+
+describe('content routes — admin job API (W3, exempt from the content flag gate)', () => {
+  it('POST /content/jobs creates a manual job', async () => {
+    const { app, ingestJobs } = makeApp();
+    const res = await app.request(`/content/jobs?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ job: { id: 'job-1', orgId: ORG_ID }, created: true });
+    expect(ingestJobs.ensureJob).toHaveBeenCalledWith(ORG_ID, {
+      sourceId: undefined,
+      crawlRunId: undefined,
+      trigger: 'manual',
+      force: false,
+    });
+  });
+
+  it('POST /content/jobs with force uses the reingest trigger', async () => {
+    const { app, ingestJobs } = makeApp();
+    const res = await app.request(`/content/jobs?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ sourceId: '22222222-2222-4222-8222-222222222222', force: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(ingestJobs.ensureJob).toHaveBeenCalledWith(ORG_ID, {
+      sourceId: '22222222-2222-4222-8222-222222222222',
+      crawlRunId: undefined,
+      trigger: 'reingest',
+      force: true,
+    });
+  });
+
+  it('POST /content/jobs/advance clamps budgetMs and batch and forwards to the runner', async () => {
+    const { app, ingestRunner } = makeApp();
+    const res = await app.request(`/content/jobs/advance?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ budgetMs: 999_999, batch: 999 }),
+    });
+    expect(res.status).toBe(400);
+    expect(ingestRunner.advance).not.toHaveBeenCalled();
+
+    const ok = await app.request(`/content/jobs/advance?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ budgetMs: 5000, batch: 10 }),
+    });
+    expect(ok.status).toBe(200);
+    expect(ingestRunner.advance).toHaveBeenCalledWith(ORG_ID, { budgetMs: 5000, batch: 10 });
+  });
+
+  it('POST /content/jobs/advance defaults budget/batch when omitted', async () => {
+    const { app, ingestRunner } = makeApp();
+    const res = await app.request(`/content/jobs/advance?orgId=${ORG_ID}`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(ingestRunner.advance).toHaveBeenCalledWith(ORG_ID, { budgetMs: undefined, batch: undefined });
+  });
+
+  it('GET /content/jobs lists jobs for the org', async () => {
+    const { app, ingestJobs } = makeApp();
+    const res = await app.request(`/content/jobs?orgId=${ORG_ID}&limit=5`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ jobs: [{ id: 'job-1', orgId: ORG_ID }] });
+    expect(ingestJobs.list).toHaveBeenCalledWith(ORG_ID, 5);
+  });
+
+  it('all three job endpoints work while content is disabled for the org', async () => {
+    const { app, ingestJobs, ingestRunner } = makeApp({ db: fakeSettingsDb() }); // no row → disabled
+    const create = await app.request(`/content/jobs?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(create.status).toBe(200);
+    const advance = await app.request(`/content/jobs/advance?orgId=${ORG_ID}`, { method: 'POST' });
+    expect(advance.status).toBe(200);
+    const list = await app.request(`/content/jobs?orgId=${ORG_ID}`);
+    expect(list.status).toBe(200);
+    expect(ingestJobs.ensureJob).toHaveBeenCalled();
+    expect(ingestRunner.advance).toHaveBeenCalled();
+    expect(ingestJobs.list).toHaveBeenCalled();
+  });
+
+  it('403s all three job endpoints without partner/system scope (adminGate)', async () => {
+    const { app } = makeApp({}, {
+      user: { id: 'u1' }, scope: 'organization', orgId: ORG_ID, accessibleOrgIds: [ORG_ID],
+    });
+    const create = await app.request(`/content/jobs?orgId=${ORG_ID}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(create.status).toBe(403);
+    const advance = await app.request(`/content/jobs/advance?orgId=${ORG_ID}`, { method: 'POST' });
+    expect(advance.status).toBe(403);
+    const list = await app.request(`/content/jobs?orgId=${ORG_ID}`);
+    expect(list.status).toBe(403);
   });
 });

--- a/ee/workspace/src/routes/content.ts
+++ b/ee/workspace/src/routes/content.ts
@@ -1,4 +1,4 @@
-// Admin content routes (dev-preview). EVERYTHING here except /content/settings
+// Admin content routes. EVERYTHING here except /content/settings
 // 404s when content is disabled for the org — but only after adminGate has
 // resolved the org, so an unauthenticated probe hits auth first. /content/settings
 // is the switch itself and must work while content is disabled.
@@ -9,14 +9,26 @@ import { z } from 'zod';
 import type { createContentIngestService } from '../services/contentIngestService';
 import type { createCrosswalkService } from '../services/crosswalkService';
 import type { createEnrichmentService } from '../services/enrichmentService';
+import type { createIngestJobsService } from '../services/ingestJobsService';
+import type { createIngestJobRunner } from '../services/ingestJobRunner';
 import { getOrgSettings, putOrgSettings, type DlpConfig } from '../services/orgSettingsService';
+import { isTransientIngestError } from '../services/ingestErrors';
 import { adminGate, type WorkspaceRouteEnv } from './adminGate';
+
+// Paths exempt from the content-enabled 404 gate below: the settings switch
+// itself, and (W3) the admin job API — job visibility (and the ability to
+// trigger/advance a job) must survive content-off, same rationale as
+// /content/settings.
+const CONTENT_FLAG_GATE_EXEMPT_SUFFIXES = ['/content/settings', '/content/jobs', '/content/jobs/advance'];
 
 export interface ContentRouteDeps {
   contentIngestService: Pick<ReturnType<typeof createContentIngestService>, 'run' | 'status'>;
   /** Absent when ANTHROPIC_API_KEY is not configured → enrich-run answers 503. */
   enrichmentService?: Pick<ReturnType<typeof createEnrichmentService>, 'run'>;
   crosswalkService?: Pick<ReturnType<typeof createCrosswalkService>, 'run'>;
+  // W3: the admin job API's create/list surface — advancement lives on ingestRunner.
+  ingestJobs: Pick<ReturnType<typeof createIngestJobsService>, 'ensureJob' | 'list'>;
+  ingestRunner: Pick<ReturnType<typeof createIngestJobRunner>, 'advance'>;
   /** Backs the org settings routes (getOrgSettings/putOrgSettings). */
   db: WorkspaceDatabase;
   audit: WorkspaceAudit;
@@ -44,6 +56,16 @@ const putSettingsSchema = z.strictObject({
   }).optional(),
 });
 
+// W3 admin job API request shapes.
+const createJobSchema = z.strictObject({
+  sourceId: z.uuid().optional(),
+  force: z.boolean().optional(),
+});
+const advanceJobSchema = z.strictObject({
+  budgetMs: z.number().int().min(1).max(15_000).optional(),
+  batch: z.number().int().min(1).max(32).optional(),
+});
+
 export function createContentRoutes(deps: ContentRouteDeps): Hono<WorkspaceRouteEnv> {
   const routes = new Hono<WorkspaceRouteEnv>();
 
@@ -51,9 +73,10 @@ export function createContentRoutes(deps: ContentRouteDeps): Hono<WorkspaceRoute
   // auth) before the per-org content flag is consulted.
   routes.use('/content/*', adminGate);
   routes.use('/content/*', async (c, next) => {
-    // /content/settings is the switch that flips contentEnabled — it must stay
-    // reachable while content is disabled, so it is exempt from this gate.
-    if (c.req.path.endsWith('/content/settings')) return next();
+    // /content/settings is the switch that flips contentEnabled, and (W3) the
+    // admin job endpoints must stay reachable so job visibility/triggering
+    // survives content-off — both are exempt from this gate.
+    if (CONTENT_FLAG_GATE_EXEMPT_SUFFIXES.some((suffix) => c.req.path.endsWith(suffix))) return next();
     const s = await getOrgSettings(deps.db, c.get('workspaceOrgId'));
     if (!s.contentEnabled) return c.json({ error: 'not_found' }, 404);
     await next();
@@ -125,7 +148,19 @@ export function createContentRoutes(deps: ContentRouteDeps): Hono<WorkspaceRoute
     if (!parsed.success) {
       return c.json({ error: 'invalid request', details: parsed.error.issues }, 400);
     }
-    const result = await deps.enrichmentService.run(orgId, parsed.data.batch);
+    // Task 4 made classifyOne rethrow Anthropic 429/>=500 as a
+    // TransientIngestError; surface that as a retryable 503 rather than letting
+    // app.onError turn a provider rate cap into an opaque 500. Non-transient
+    // failures still propagate to the 500 path.
+    let result;
+    try {
+      result = await deps.enrichmentService.run(orgId, parsed.data.batch);
+    } catch (e) {
+      if (isTransientIngestError(e)) {
+        return c.json({ error: 'enrichment provider unavailable or rate limited; retry later' }, 503);
+      }
+      throw e;
+    }
     await deps.audit({
       actorType: 'user',
       actorId: auth.user.id,
@@ -198,6 +233,63 @@ export function createContentRoutes(deps: ContentRouteDeps): Hono<WorkspaceRoute
       details: { mined: result.mined },
     });
     return c.json(result);
+  });
+
+  // W3 admin job API: org-operator scope (adminGate above already enforces
+  // partner/system scope), all active sources — NO groupIds/visibility
+  // filtering. Exempt from the content-enabled gate above (job visibility
+  // must survive content-off).
+  routes.post('/content/jobs', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    let body: unknown = {};
+    try {
+      const raw = await c.req.text();
+      body = raw.trim().length > 0 ? JSON.parse(raw) : {};
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    const parsed = createJobSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid request', details: parsed.error.issues }, 400);
+    }
+    const force = parsed.data.force ?? false;
+    const { job, created } = await deps.ingestJobs.ensureJob(orgId, {
+      sourceId: parsed.data.sourceId,
+      crawlRunId: undefined,
+      trigger: force ? 'reingest' : 'manual',
+      force,
+    });
+    return c.json({ job, created });
+  });
+
+  routes.post('/content/jobs/advance', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    let body: unknown = {};
+    try {
+      const raw = await c.req.text();
+      body = raw.trim().length > 0 ? JSON.parse(raw) : {};
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    const parsed = advanceJobSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid request', details: parsed.error.issues }, 400);
+    }
+    const result = await deps.ingestRunner.advance(orgId, {
+      budgetMs: parsed.data.budgetMs,
+      batch: parsed.data.batch,
+    });
+    return c.json(result);
+  });
+
+  routes.get('/content/jobs', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    const rawLimit = c.req.query('limit');
+    const limit = rawLimit !== undefined && Number.isFinite(Number(rawLimit))
+      ? Number(rawLimit)
+      : undefined;
+    const jobs = await deps.ingestJobs.list(orgId, limit);
+    return c.json({ jobs });
   });
 
   return routes;

--- a/ee/workspace/src/routes/dashboard.ts
+++ b/ee/workspace/src/routes/dashboard.ts
@@ -1,0 +1,38 @@
+// W3 Task 6: admin dashboard routes. Org-operator scope (adminGate resolves
+// and authorizes the org, same as sources.ts) — no per-org content-flag gate:
+// the dashboard is a read model over whatever the org has, including "content
+// is off" (all-zero ingest/filing/projects cards, sources card still useful).
+import { Hono } from 'hono';
+import type { createDashboardService } from '../services/dashboardService';
+import type { createIngestJobsService } from '../services/ingestJobsService';
+import { adminGate, type WorkspaceRouteEnv } from './adminGate';
+
+export interface DashboardRouteDeps {
+  dashboardService: Pick<ReturnType<typeof createDashboardService>, 'summary'>;
+  // Thin proxy over the same admin job listing content.ts's GET /content/jobs
+  // exposes — the dashboard polls this endpoint instead of re-deriving job
+  // state itself.
+  ingestJobs: Pick<ReturnType<typeof createIngestJobsService>, 'list'>;
+}
+
+export function createDashboardRoutes(deps: DashboardRouteDeps): Hono<WorkspaceRouteEnv> {
+  const routes = new Hono<WorkspaceRouteEnv>();
+  routes.use('*', adminGate);
+
+  routes.get('/dashboard/summary', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    return c.json(await deps.dashboardService.summary(orgId));
+  });
+
+  routes.get('/dashboard/jobs', async (c) => {
+    const orgId = c.get('workspaceOrgId');
+    const rawLimit = c.req.query('limit');
+    const limit = rawLimit !== undefined && Number.isFinite(Number(rawLimit))
+      ? Number(rawLimit)
+      : undefined;
+    const jobs = await deps.ingestJobs.list(orgId, limit);
+    return c.json({ jobs });
+  });
+
+  return routes;
+}

--- a/ee/workspace/src/routes/helper.test.ts
+++ b/ee/workspace/src/routes/helper.test.ts
@@ -288,7 +288,7 @@ describe('workspace helper routes', () => {
     });
   });
 
-  describe('filing routes (dev-preview gating)', () => {
+  describe('filing routes (content gating)', () => {
     const FILING = {
       fileIndexId: FILE_ID, relPath: 'Emails/Unfiled/x.eml', name: 'x.eml', emailMeta: null,
       status: 'suggested', suggestedProjectKey: '2023-041',

--- a/ee/workspace/src/routes/helper.ts
+++ b/ee/workspace/src/routes/helper.ts
@@ -33,12 +33,12 @@ export interface HelperRouteDeps {
   fileQueryService: FileQueryService;
   activityService: ActivityService;
   /**
-   * Content-preview retrieval (dev-preview). Only consulted when content is
+   * Content retrieval for the content layer. Only consulted when content is
    * enabled for the caller's org; while disabled the legacy search path below
    * runs untouched — byte-identical responses (snapshot-tested).
    */
   contentSearchService?: Pick<ReturnType<typeof createContentSearchService>, 'search' | 'passages'>;
-  /** Filing panel backend (dev-preview); absent or content disabled → routes 404. */
+  /** Filing panel backend; absent or content disabled → routes 404. */
   filingService?: Pick<ReturnType<typeof createFilingService>, 'list' | 'classify' | 'assign' | 'projects'>;
   /**
    * Per-org content flag (W2 Task 3): resolves the caller org's content
@@ -148,7 +148,7 @@ export function createHelperRoutes(deps: HelperRouteDeps): Hono<WorkspaceHelperR
     return c.json({ results });
   });
 
-  // Content-preview capability probe: the Helper shows content affordances
+  // Content capability probe: the Helper shows content affordances
   // (snippets, inferred metadata, filing) only when this answers 200. With
   // content disabled for the org it 404s — existing endpoint shapes never
   // change based on the flag.
@@ -163,8 +163,8 @@ export function createHelperRoutes(deps: HelperRouteDeps): Hono<WorkspaceHelperR
   });
 
   // Cited-RAG retrieval: visibility-scoped content passages for the chat
-  // file-passages tool. Content-preview only — 404s under the same gate as the
-  // rest of the /content/* surface (the caller org's content setting).
+  // file-passages tool. 404s under the same gate as the rest of the
+  // /content/* surface (the caller org's content setting).
   app.get('/content/passages', async (c) => {
     const device = c.get('helperDevice');
     if (!deps.contentSearchService?.passages || !(await deps.getSettings(device.orgId)).contentEnabled) {
@@ -186,7 +186,7 @@ export function createHelperRoutes(deps: HelperRouteDeps): Hono<WorkspaceHelperR
     return c.json({ passages });
   });
 
-  // ---- Filing panel (dev-preview) ---------------------------------------
+  // ---- Filing panel -------------------------------------------------------
   // Per-org gate: filing is available only when a filing service is wired AND
   // content is enabled for the caller's org (W2 Task 3).
   const filingAvailable = async (orgId: string) =>

--- a/ee/workspace/src/schema/content.ts
+++ b/ee/workspace/src/schema/content.ts
@@ -1,10 +1,10 @@
-// Content phase (dev-preview) table mirrors. As with workspace.ts, the SQL in
+// Content layer table mirrors. As with workspace.ts, the SQL in
 // migrations/ is the DDL source of truth — FKs, RLS policies, FTS/trigram
 // indexes, and the vector column (later migration) do not appear here.
-// All readers/writers of these tables sit behind the per-org content flag
-// (default off; never on in production). DLP runs at ingest, between extraction
-// and persistence: stored extracted_text is post-redaction, and files a 'block'
-// detector trips persist no text (status = blocked_dlp).
+// All readers/writers of these tables sit behind the per-org content flag.
+// DLP runs at ingest, between extraction and persistence: stored extracted_text
+// is post-redaction, and files a 'block' detector trips persist no text
+// (status = blocked_dlp).
 import {
   pgTable, uuid, text, varchar, bigint, integer, timestamp, jsonb, pgEnum, date,
   index, uniqueIndex, vector,

--- a/ee/workspace/src/schema/ingestJobs.ts
+++ b/ee/workspace/src/schema/ingestJobs.ts
@@ -1,0 +1,51 @@
+// W3: productized ingest — delta-triggered incremental ingest job state.
+// NOTE: the SQL in migrations/ is the DDL source of truth (FKs, RLS
+// policies, the partial unique index) — see
+// migrations/2026-07-25-ingest-jobs.sql. Do not generate migrations from
+// this definition with drizzle-kit.
+import {
+  pgTable, uuid, text, boolean, integer, timestamp, jsonb, pgEnum, index,
+} from 'drizzle-orm/pg-core';
+import { workspaceSources, workspaceCrawlRuns } from './workspace';
+
+export const workspaceIngestTrigger = pgEnum('workspace_ingest_trigger', [
+  'crawl_complete', 'manual', 'reingest',
+]);
+export const workspaceIngestPhase = pgEnum('workspace_ingest_phase', [
+  'ingest', 'enrich', 'crosswalk',
+]);
+export const workspaceIngestJobStatus = pgEnum('workspace_ingest_job_status', [
+  'pending', 'running', 'complete', 'failed',
+]);
+
+export type IngestTrigger = 'crawl_complete' | 'manual' | 'reingest';
+export type IngestPhase = 'ingest' | 'enrich' | 'crosswalk';
+export type IngestJobStatus = 'pending' | 'running' | 'complete' | 'failed';
+
+// One live job per (org, source-partition) — enforced by the partial unique
+// index wsp_ingest_jobs_one_active_idx (org_id, COALESCE(source_id,
+// zero-uuid)) WHERE status IN ('pending', 'running'); source_id NULL means
+// org-wide. Advancement is in-request batch continuation
+// (src/services/ingestJobRunner.ts), never a background worker.
+export const workspaceIngestJobs = pgTable('workspace_ingest_jobs', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull(),
+  sourceId: uuid('source_id').references(() => workspaceSources.id, { onDelete: 'cascade' }),
+  crawlRunId: uuid('crawl_run_id').references(() => workspaceCrawlRuns.id, { onDelete: 'set null' }),
+  trigger: workspaceIngestTrigger('trigger').notNull(),
+  phase: workspaceIngestPhase('phase').notNull().default('ingest'),
+  status: workspaceIngestJobStatus('status').notNull().default('pending'),
+  force: boolean('force').notNull().default(false),
+  attempts: integer('attempts').notNull().default(0),
+  maxAttempts: integer('max_attempts').notNull().default(8),
+  nextAttemptAt: timestamp('next_attempt_at', { withTimezone: true }).notNull().defaultNow(),
+  cursor: text('cursor'),
+  stats: jsonb('stats').$type<Record<string, unknown>>().notNull().default({}),
+  lastError: text('last_error'),
+  startedAt: timestamp('started_at', { withTimezone: true }),
+  finishedAt: timestamp('finished_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  index('wsp_ingest_jobs_org_status_idx').on(t.orgId, t.status, t.nextAttemptAt),
+]);

--- a/ee/workspace/src/services/contentIngestService.test.ts
+++ b/ee/workspace/src/services/contentIngestService.test.ts
@@ -1,0 +1,358 @@
+// contentIngestService — unit tests for the W3 additive behavior: the
+// transient/permanent error taxonomy, per-file write atomicity (embed OUTSIDE
+// the persist tx), and force-mode DLP re-scan. Extraction, DLP, entities,
+// projects and org-settings are mocked so these tests exercise the service's
+// control flow only; the real DLP/extraction behavior is pinned by the
+// dlpIngest integration suite.
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import type { ContentByteReader } from '../content/byteReader';
+import type { Embedder } from '../content/embedder';
+import { TransientIngestError } from './ingestErrors';
+
+vi.mock('../content/extract', () => ({ extractContent: vi.fn() }));
+vi.mock('../content/dlp', () => ({ applyDlpToText: vi.fn() }));
+vi.mock('../content/entities', () => ({ extractEntities: vi.fn(() => []) }));
+vi.mock('../content/projects', () => ({ deriveDeclaredProject: vi.fn(() => null) }));
+vi.mock('./orgSettingsService', () => ({
+  getOrgSettings: vi.fn(async () => ({
+    contentEnabled: true,
+    dlpConfig: { detectors: {}, customPatterns: [] },
+  })),
+}));
+
+import { createContentIngestService } from './contentIngestService';
+import { extractContent } from '../content/extract';
+import { applyDlpToText } from '../content/dlp';
+
+const extractMock = extractContent as unknown as Mock;
+const dlpMock = applyDlpToText as unknown as Mock;
+
+const ORG = '11111111-1111-1111-1111-111111111111';
+
+// Flatten a drizzle SQL object to its literal fragments so we can classify a
+// query (params are not needed for routing; captured separately via boundValues).
+function sqlText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(sqlText).join('');
+  if (!value || typeof value !== 'object') return '';
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Array.isArray(candidate.value) && candidate.value.every((p) => typeof p === 'string')
+    ? candidate.value.join('')
+    : '';
+  return own + (candidate.queryChunks ?? []).map(sqlText).join('');
+}
+
+function boundValues(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => (item && typeof item === 'object' ? boundValues(item) : [item]));
+  }
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value')
+    ? (Array.isArray(candidate.value) ? candidate.value : [candidate.value])
+    : [];
+  return [
+    ...own,
+    ...(candidate.queryChunks ?? []).flatMap((item) => (item && typeof item === 'object' ? boundValues(item) : [item])),
+  ];
+}
+
+function classify(text: string): string {
+  if (text.includes('ORDER BY fi.rel_path')) return 'pending';
+  if (text.includes('count(*)::int AS n') && text.includes('c.updated_at')) return 'forceCount';
+  if (text.includes('count(*)::int AS n') && text.includes('NOT EXISTS')) return 'count';
+  if (text.includes('INSERT INTO workspace_file_content')) return 'upsertContent';
+  if (text.includes('UPDATE workspace_file_content')) return 'snapshotUpdate';
+  if (text.includes('DELETE FROM workspace_content_chunks')) return 'deleteChunks';
+  if (text.includes('INSERT INTO workspace_content_chunks')) return 'insertChunk';
+  if (text.includes('DELETE FROM workspace_content_entities')) return 'deleteEntities';
+  if (text.includes('INSERT INTO workspace_content_entities')) return 'insertEntity';
+  if (text.includes('workspace_projects')) return 'project';
+  if (text.includes('workspace_file_enrichment')) return 'enrichment';
+  return 'other';
+}
+
+interface Call { kind: string; text: string; values: unknown[] }
+
+function pendingRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'file-a', source_id: 'src-1', rel_path: 'Docs/a.md', name: 'a.md',
+    size: 100, mtime: '2026-01-01T00:00:00Z', root_path: '\\\\srv\\share', source_kind: 'smb_share',
+    content_hash: null, content_status: null, extracted_text: null, ...over,
+  };
+}
+
+function makeDb(pendingRows: unknown[], remaining = 0) {
+  const calls: Call[] = [];
+  const execute = vi.fn(async (q: unknown) => {
+    const text = sqlText(q);
+    const kind = classify(text);
+    calls.push({ kind, text, values: boundValues(q) });
+    if (kind === 'pending') return pendingRows;
+    if (kind === 'count' || kind === 'forceCount') return [{ n: remaining }];
+    return [];
+  });
+  const db: Record<string, unknown> = { execute };
+  db.transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn(db));
+  return { db: db as unknown as WorkspaceDatabase, raw: db, calls, execute };
+}
+
+function reader(fn: (rel: string) => Buffer | Promise<Buffer>): ContentByteReader {
+  return { read: vi.fn(async (_src, rel: string) => fn(rel)) };
+}
+
+function recordingEmbedder(calls: Call[], opts: { throwTransient?: boolean } = {}): Embedder {
+  return {
+    embed: vi.fn(async (texts: string[]) => {
+      calls.push({ kind: 'embed', text: '', values: [] });
+      if (opts.throwTransient) throw new TransientIngestError('voyage_rate_limited:5/2rpm');
+      return texts.map(() => [0.1, 0.2, 0.3]);
+    }),
+  };
+}
+
+const kindsOf = (calls: Call[]) => calls.map((c) => c.kind);
+
+beforeEach(() => {
+  extractMock.mockReset();
+  dlpMock.mockReset();
+  // Defaults: text file extracts cleanly; DLP passes it through untouched.
+  extractMock.mockImplementation(async (_name: string, bytes: Buffer) => ({
+    status: 'extracted', text: bytes.toString('utf8'), contentHash: 'hash-default', emailMeta: null,
+  }));
+  dlpMock.mockImplementation((text: string) => ({ text, findings: [], blocked: false }));
+});
+
+describe('contentIngestService.run — transient taxonomy', () => {
+  it('reader ECONNREFUSED aborts the batch after N processed, writing no row for the failed file', async () => {
+    const { db, calls } = makeDb([
+      pendingRow({ id: 'file-a', rel_path: 'Docs/a.md', name: 'a.md' }),
+      pendingRow({ id: 'file-b', rel_path: 'Docs/b.md', name: 'b.md' }),
+    ]);
+    const rd = reader((rel) => {
+      if (rel === 'Docs/b.md') throw new Error('connect ECONNREFUSED 10.0.0.5:445');
+      return Buffer.from('clean body', 'utf8');
+    });
+    const svc = createContentIngestService(db, { reader: rd, embedder: recordingEmbedder(calls) });
+
+    const res = await svc.run(ORG, 10);
+
+    expect(res.transient).not.toBeNull();
+    expect(res.transient!.reason).toMatch(/reader:.*ECONNREFUSED/);
+    expect(res.transient!.abortedAfter).toBe(1); // file-a processed before file-b aborted
+    expect(res.processed).toBe(1);
+    // Only file-a's content row was written; file-b never got a row (no failed row either).
+    expect(kindsOf(calls).filter((k) => k === 'upsertContent')).toHaveLength(1);
+  });
+
+  it('embedder transient failure writes nothing and never reaches a chunk DELETE', async () => {
+    const { db, calls, raw } = makeDb([pendingRow()]);
+    const svc = createContentIngestService(db, {
+      reader: reader(() => Buffer.from('needs embedding', 'utf8')),
+      embedder: recordingEmbedder(calls, { throwTransient: true }),
+    });
+
+    const res = await svc.run(ORG, 10);
+
+    expect(res.transient).not.toBeNull();
+    expect(res.transient!.reason).toMatch(/voyage_rate_limited/);
+    expect(res.transient!.abortedAfter).toBe(0);
+    expect(res.processed).toBe(0);
+    // embed happened, but the persist tx never opened → no content row, no chunk writes.
+    expect(kindsOf(calls)).toContain('embed');
+    expect(kindsOf(calls)).not.toContain('upsertContent');
+    expect(kindsOf(calls)).not.toContain('deleteChunks');
+    expect(kindsOf(calls)).not.toContain('insertChunk');
+    expect(raw.transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('contentIngestService.run — permanent path (pinned W2 behavior)', () => {
+  it('a permanent extract failure writes a failed row + snapshot and the loop continues', async () => {
+    extractMock.mockResolvedValue({ status: 'failed', errorReason: 'parse boom' });
+    const { db, calls } = makeDb([pendingRow({ size: 100 })]);
+    const svc = createContentIngestService(db, {
+      reader: reader(() => Buffer.from('junk', 'utf8')),
+      embedder: recordingEmbedder(calls),
+    });
+
+    const res = await svc.run(ORG, 10);
+
+    expect(res.transient).toBeNull();
+    expect(res.errors).toEqual([]);
+    expect(res.processed).toBe(1);
+    const upsert = calls.find((c) => c.kind === 'upsertContent')!;
+    expect(upsert).toBeDefined();
+    // failed status + snapshot size (100) + reason are all bound into the row.
+    expect(upsert.values).toContain('failed');
+    expect(upsert.values).toContain('parse boom');
+    expect(upsert.values).toContain(100);
+  });
+});
+
+describe('contentIngestService.run — per-file atomicity ordering', () => {
+  it('embeds BEFORE opening the persist tx (embed precedes content-row write and chunk DELETE)', async () => {
+    const { db, calls, raw } = makeDb([pendingRow()]);
+    const svc = createContentIngestService(db, {
+      reader: reader(() => Buffer.from('body to embed', 'utf8')),
+      embedder: recordingEmbedder(calls),
+    });
+
+    const res = await svc.run(ORG, 10);
+
+    expect(res.processed).toBe(1);
+    expect(res.transient).toBeNull();
+    expect(raw.transaction).toHaveBeenCalledTimes(1);
+    const ks = kindsOf(calls);
+    const iEmbed = ks.indexOf('embed');
+    const iUpsert = ks.indexOf('upsertContent');
+    const iDelete = ks.indexOf('deleteChunks');
+    const iInsert = ks.indexOf('insertChunk');
+    expect(iEmbed).toBeGreaterThanOrEqual(0);
+    expect(iEmbed).toBeLessThan(iUpsert);
+    expect(iEmbed).toBeLessThan(iDelete);
+    expect(iDelete).toBeLessThan(iInsert);
+  });
+});
+
+describe('contentIngestService.run — same-hash short-circuit vs force', () => {
+  const H = 'hash-1';
+
+  it('non-force same-hash refreshes the snapshot only and never re-applies DLP or embeds', async () => {
+    extractMock.mockResolvedValue({ status: 'extracted', text: 'hello', contentHash: H, emailMeta: null });
+    const { db, calls } = makeDb([pendingRow({ content_hash: H, content_status: 'extracted', extracted_text: 'hello' })]);
+    const embedder = recordingEmbedder(calls);
+    const svc = createContentIngestService(db, { reader: reader(() => Buffer.from('hello', 'utf8')), embedder });
+
+    const res = await svc.run(ORG, 10);
+
+    expect(res.processed).toBe(1);
+    expect(dlpMock).not.toHaveBeenCalled();
+    expect((embedder.embed as Mock)).not.toHaveBeenCalled();
+    expect(kindsOf(calls)).toContain('snapshotUpdate');
+    expect(kindsOf(calls)).not.toContain('upsertContent');
+  });
+
+  it('force re-applies DLP to same-hash bytes; an unchanged verdict skips the chunk rewrite', async () => {
+    extractMock.mockResolvedValue({ status: 'extracted', text: 'hello', contentHash: H, emailMeta: null });
+    dlpMock.mockReturnValue({ text: 'hello', findings: [], blocked: false }); // identical outcome
+    const { db, calls } = makeDb([pendingRow({ content_hash: H, content_status: 'extracted', extracted_text: 'hello' })]);
+    const embedder = recordingEmbedder(calls);
+    const svc = createContentIngestService(db, { reader: reader(() => Buffer.from('hello', 'utf8')), embedder });
+
+    const res = await svc.run(ORG, 10, { force: true });
+
+    expect(res.processed).toBe(1);
+    expect(dlpMock).toHaveBeenCalledTimes(1); // DLP re-applied despite same hash
+    expect((embedder.embed as Mock)).not.toHaveBeenCalled(); // nothing changed → no re-embed
+    expect(kindsOf(calls)).toContain('snapshotUpdate');
+    expect(kindsOf(calls)).not.toContain('deleteChunks');
+    expect(kindsOf(calls)).not.toContain('insertChunk');
+    expect(kindsOf(calls)).not.toContain('upsertContent');
+  });
+
+  it('force reports the force-aware remaining (unvisited files), not the non-force snapshot count', async () => {
+    const forceSince = new Date('2026-07-19T00:00:00Z');
+    // Two rows come back for this batch (the mock ignores LIMIT); both extract
+    // cleanly with matching snapshots, so the NON-force pendingCount would be 0.
+    // The force-aware count instead reports 3 files this sweep has not yet
+    // visited — the value that must drive phase completion.
+    const { db, calls } = makeDb([
+      pendingRow({ id: 'file-a', rel_path: 'a.md' }),
+      pendingRow({ id: 'file-b', rel_path: 'b.md' }),
+    ], 3);
+    const svc = createContentIngestService(db, {
+      reader: reader(() => Buffer.from('body', 'utf8')),
+      embedder: recordingEmbedder(calls),
+    });
+
+    const res = await svc.run(ORG, 2, { force: true, forceSince });
+
+    expect(res.processed).toBe(2);
+    // Force-aware remaining surfaces the unvisited files, NOT 0.
+    expect(res.remaining).toBe(3);
+    // The count is the force-aware query (joins content, filters updated_at) —
+    // never the non-force NOT EXISTS snapshot count.
+    const countKinds = calls
+      .filter((c) => c.kind === 'forceCount' || c.kind === 'count')
+      .map((c) => c.kind);
+    expect(countKinds).toContain('forceCount');
+    expect(countKinds).not.toContain('count');
+    // forceSince is bound as an ISO ::timestamptz string (never a raw Date).
+    const forceCount = calls.find((c) => c.kind === 'forceCount')!;
+    expect(forceCount.values).toContain(forceSince.toISOString());
+  });
+
+  it('force flips a previously-clean file to blocked_dlp and purges chunks + regex entities', async () => {
+    extractMock.mockResolvedValue({ status: 'extracted', text: 'ssn here', contentHash: H, emailMeta: null });
+    dlpMock.mockReturnValue({ text: 'ssn here', findings: [{ detector: 'ssn', action: 'block', count: 1 }], blocked: true });
+    const { db, calls } = makeDb([pendingRow({ content_hash: H, content_status: 'extracted', extracted_text: 'ssn here' })]);
+    const embedder = recordingEmbedder(calls);
+    const svc = createContentIngestService(db, { reader: reader(() => Buffer.from('ssn here', 'utf8')), embedder });
+
+    const res = await svc.run(ORG, 10, { force: true });
+
+    expect(res.processed).toBe(1);
+    expect(dlpMock).toHaveBeenCalledTimes(1);
+    expect((embedder.embed as Mock)).not.toHaveBeenCalled();
+    const upsert = calls.find((c) => c.kind === 'upsertContent')!;
+    expect(upsert.values).toContain('blocked_dlp');
+    expect(kindsOf(calls)).toContain('deleteChunks');
+    expect(kindsOf(calls)).toContain('deleteEntities');
+  });
+});
+
+// WS-1 graduation guarantee: the spec's central claim is that no un-DLP'd
+// text ever reaches persistence or a vendor (the embedder). This is a
+// characterization test, not TDD red-green — it pins behavior the service
+// already implements (see the DLP-on-ingest block in contentIngestService.ts,
+// between extractContent and any persist/embed call). A failure here means
+// the graduation premise is wrong and must be escalated, not "fixed" by
+// editing this test.
+describe('DLP chokepoint (graduation guarantee)', () => {
+  it('never calls the embedder for a DLP-blocked file', async () => {
+    extractMock.mockResolvedValue({
+      status: 'extracted', text: 'SSN 123-45-6789', contentHash: 'h1', emailMeta: null,
+    });
+    dlpMock.mockReturnValue({
+      text: 'SSN [REDACTED]',
+      findings: [{ detector: 'ssn', action: 'block', count: 1 }],
+      blocked: true,
+    });
+
+    const { db } = makeDb([pendingRow()]);
+    const embed = vi.fn(async () => [[0.1]]);
+    const service = createContentIngestService(db, {
+      reader: reader(() => Buffer.from('irrelevant', 'utf8')),
+      embedder: { embed } as unknown as Embedder,
+    });
+
+    await service.run(ORG, 10);
+
+    expect(embed).not.toHaveBeenCalled();
+  });
+
+  it('passes only post-DLP text to the embedder for a clean file', async () => {
+    extractMock.mockResolvedValue({
+      status: 'extracted', text: 'card 4111111111111111', contentHash: 'h2', emailMeta: null,
+    });
+    dlpMock.mockReturnValue({
+      text: 'card [REDACTED]',
+      findings: [{ detector: 'pan', action: 'redact', count: 1 }],
+      blocked: false,
+    });
+
+    const { db } = makeDb([pendingRow()]);
+    const embed = vi.fn(async () => [[0.1]]);
+    const service = createContentIngestService(db, {
+      reader: reader(() => Buffer.from('irrelevant', 'utf8')),
+      embedder: { embed } as unknown as Embedder,
+    });
+
+    await service.run(ORG, 10);
+
+    const embedded = embed.mock.calls.flat(2).join(' ');
+    expect(embedded).not.toContain('4111111111111111');
+    expect(embedded).toContain('[REDACTED]');
+  });
+});

--- a/ee/workspace/src/services/contentIngestService.ts
+++ b/ee/workspace/src/services/contentIngestService.ts
@@ -426,6 +426,19 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
           if (deps.embedder) {
             chunks = chunkText(cleanText);
             vectors = await deps.embedder.embed(chunks, 'document');
+            // The embedder fills a fixed-length array from a remote response
+            // keyed by the item's own `index`, so a short or misindexed
+            // response leaves holes rather than a shorter array. Unchecked,
+            // that surfaces as a TypeError inside the transaction below when a
+            // hole reaches toVectorLiteral. A service-response fault is
+            // transient by this module's taxonomy: abort the batch and leave
+            // the file pending rather than persisting a `failed` row that
+            // would park it out of the retry set.
+            if (vectors.length !== chunks.length || vectors.some((v) => v === undefined)) {
+              throw new TransientIngestError(
+                `embedder returned ${vectors.length} usable vectors for ${chunks.length} chunks`,
+              );
+            }
           }
 
           // Persist the whole new version atomically: content row + entities +

--- a/ee/workspace/src/services/contentIngestService.ts
+++ b/ee/workspace/src/services/contentIngestService.ts
@@ -1,4 +1,4 @@
-// Content ingest runner (dev-preview; per-org content flag).
+// Content ingest runner (per-org content flag).
 //
 // Batch-per-request by design: the caller (admin route) processes up to N
 // pending files INSIDE the request, where the org RLS context is valid, and
@@ -34,6 +34,7 @@ import { extractEntities } from '../content/entities';
 import { deriveDeclaredProject } from '../content/projects';
 import { applyDlpToText, type DlpFinding } from '../content/dlp';
 import { getOrgSettings } from './orgSettingsService';
+import { TransientIngestError, isTransientIngestError } from './ingestErrors';
 
 export interface IngestError {
   fileIndexId: string;
@@ -45,6 +46,29 @@ export interface IngestRunResult {
   processed: number;
   remaining: number;
   errors: IngestError[];
+  // A transient (source-likely-down) failure aborts the remaining batch and is
+  // reported here; the failed file is left fully pending (no row written). Null
+  // when the whole batch drained without a transient abort.
+  transient: { reason: string; abortedAfter: number } | null;
+}
+
+/** Anything with `.execute` — the db handle or a transaction handle. */
+type Executor = Pick<WorkspaceDatabase, 'execute'>;
+
+export interface IngestRunOptions {
+  /**
+   * Re-scan every eligible file against the CURRENT DlpConfig, bypassing both
+   * the snapshot-pending filter and the same-hash short-circuit. Used to
+   * re-apply DLP after an org tightens its config without waiting for the
+   * underlying bytes to change.
+   */
+  force?: boolean;
+  /**
+   * Force-only convergence guard: exclude files whose content row was already
+   * refreshed at/after this instant, so a repeated forced sweep terminates.
+   * The caller (job runner) passes the job's DB-sourced started_at.
+   */
+  forceSince?: Date;
 }
 
 export interface IngestStatus {
@@ -53,6 +77,9 @@ export interface IngestStatus {
   failed: number;
   skippedTooLarge: number;
   skippedBinary: number;
+  // W3 (Task 6): DLP-blocked files (see status() below). Additive — safe for
+  // every existing consumer of this type.
+  blockedDlp: number;
   pending: number;
 }
 
@@ -66,6 +93,9 @@ interface PendingRow {
   root_path: string;
   source_kind: string;
   content_hash: string | null;
+  // Stored content row state — used by the force re-embed-avoidance check.
+  content_status: string | null;
+  extracted_text: string | null;
 }
 
 export interface ContentIngestDeps {
@@ -118,18 +148,49 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
     return Number((res as unknown as Array<{ n: number }>)[0]?.n ?? 0);
   }
 
+  // Force-aware pending count: how many eligible files THIS sweep has not yet
+  // re-walked. A forced run re-visits every eligible file regardless of its
+  // snapshot, so the non-force pendingCount (already 0 for an extracted estate)
+  // cannot measure force progress — an estate larger than one batch would report
+  // remaining=0 after the first batch and the job would phase-complete having
+  // visited only a fraction of it. A file is "visited" once its content row is
+  // refreshed at/after forceSince (every processed file bumps updated_at), so
+  // this mirrors the force SELECT arm and drains to 0 exactly when the whole
+  // estate has been re-walked. Without forceSince the sweep has no convergence
+  // guard, so every eligible file still counts as pending.
+  async function forcePendingCount(orgId: string, forceSince?: Date): Promise<number> {
+    const unvisitedArm = forceSince
+      ? sql`AND (c.updated_at IS NULL OR c.updated_at < ${forceSince.toISOString()}::timestamptz)`
+      : sql``;
+    const res = await d.execute(sql`
+      SELECT count(*)::int AS n
+      FROM workspace_file_index fi
+      JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+      LEFT JOIN workspace_file_content c ON c.file_index_id = fi.id
+      WHERE fi.org_id = ${orgId}
+        AND fi.deleted_at IS NULL
+        AND fi.is_dir = false
+        AND s.kind = 'smb_share'
+        AND s.status = 'active'
+        AND s.visibility_group_ids = '[]'::jsonb
+        ${unvisitedArm}
+    `);
+    return Number((res as unknown as Array<{ n: number }>)[0]?.n ?? 0);
+  }
+
   async function replaceRegexEntities(
+    exec: Executor,
     orgId: string,
     fileIndexId: string,
     text: string,
   ): Promise<void> {
     const entities = extractEntities(text);
-    await d.execute(sql`
+    await exec.execute(sql`
       DELETE FROM workspace_content_entities
       WHERE org_id = ${orgId} AND file_index_id = ${fileIndexId} AND origin = 'regex'
     `);
     for (const e of entities) {
-      await d.execute(sql`
+      await exec.execute(sql`
         INSERT INTO workspace_content_entities (org_id, file_index_id, entity_type, value_norm, value_raw, origin)
         VALUES (${orgId}, ${fileIndexId}, ${e.type}, ${e.valueNorm}, ${e.valueRaw}, 'regex')
         ON CONFLICT (org_id, file_index_id, entity_type, value_norm) DO NOTHING
@@ -137,13 +198,13 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
     }
   }
 
-  async function upsertDeclaredProject(orgId: string, relPath: string): Promise<void> {
+  async function upsertDeclaredProject(exec: Executor, orgId: string, relPath: string): Promise<void> {
     const declared = deriveDeclaredProject(relPath);
     if (!declared) return;
     const label = declared.label ?? declared.key;
     // A real label (folder name) may replace a key-only placeholder, never the
     // other way round.
-    await d.execute(sql`
+    await exec.execute(sql`
       INSERT INTO workspace_projects (org_id, project_key, label)
       VALUES (${orgId}, ${declared.key}, ${label})
       ON CONFLICT (org_id, project_key) DO UPDATE
@@ -154,6 +215,7 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
   }
 
   async function upsertContentRow(
+    exec: Executor,
     orgId: string,
     fileIndexId: string,
     row: {
@@ -169,7 +231,7 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
       dlpFindings: DlpFinding[];
     },
   ): Promise<void> {
-    await d.execute(sql`
+    await exec.execute(sql`
       INSERT INTO workspace_file_content
         (org_id, file_index_id, content_hash, source_size, source_mtime, extracted_text, status, error_reason, dlp_findings)
       VALUES
@@ -190,7 +252,7 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
     // email_meta lives on the enrichment row (written deterministically here,
     // never by the LLM; the enrichment pass fills the inferred_* columns).
     if (row.emailMeta) {
-      await d.execute(sql`
+      await exec.execute(sql`
         INSERT INTO workspace_file_enrichment (org_id, file_index_id, email_meta)
         VALUES (${orgId}, ${fileIndexId}, ${JSON.stringify(row.emailMeta)}::jsonb)
         ON CONFLICT (file_index_id) DO UPDATE SET
@@ -200,12 +262,32 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
   }
 
   return {
-    async run(orgId: string, batch: number): Promise<IngestRunResult> {
+    async run(orgId: string, batch: number, opts?: IngestRunOptions): Promise<IngestRunResult> {
       // DLP config is per-org and stable for the whole run — fetch it once.
       const { dlpConfig } = await getOrgSettings(db, orgId);
+      const force = opts?.force === true;
+      const forceSince = force ? opts?.forceSince : undefined;
+      // Force re-scans EVERY eligible file against the current DlpConfig, so it
+      // drops the snapshot-mismatch arm of pendingPredicateSql (the single
+      // non-force truth) and instead adds a convergence guard: a file whose
+      // content row was already refreshed at/after forceSince in this sweep is
+      // excluded, so a repeated forced sweep terminates. Non-force keeps the
+      // shared snapshot predicate untouched.
+      const pendingArm = force
+        ? (forceSince
+          // forceSince is a DB-origin timestamp (the job's started_at) round-
+          // tripped through the host as a Date. Bind it as an ISO string with an
+          // explicit ::timestamptz cast — the postgres.js driver cannot serialize
+          // a raw Date parameter (it lands in Buffer.byteLength and throws), and
+          // the rest of the extension already crosses the driver boundary as
+          // toISOString() strings (contentSearchService/dashboardService/etc.).
+          ? sql`AND (c.updated_at IS NULL OR c.updated_at < ${forceSince.toISOString()}::timestamptz)`
+          : sql``)
+        : pendingPredicateSql;
       const pending = await d.execute(sql`
         SELECT fi.id, fi.source_id, fi.rel_path, fi.name, fi.size, fi.mtime,
-               s.root_path, s.kind AS source_kind, c.content_hash
+               s.root_path, s.kind AS source_kind,
+               c.content_hash, c.status AS content_status, c.extracted_text
         FROM workspace_file_index fi
         JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
         LEFT JOIN workspace_file_content c ON c.file_index_id = fi.id
@@ -215,30 +297,42 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
           AND s.kind = 'smb_share'
           AND s.status = 'active'
           AND s.visibility_group_ids = '[]'::jsonb
-          ${pendingPredicateSql}
+          ${pendingArm}
         ORDER BY fi.rel_path
         LIMIT ${batch}
       `) as unknown as PendingRow[];
 
       const errors: IngestError[] = [];
       let processed = 0;
+      let transient: IngestRunResult['transient'] = null;
 
       for (const file of pending) {
         const source = { id: file.source_id, orgId, kind: file.source_kind, rootPath: file.root_path };
         const sourceSize = file.size === null ? null : Number(file.size);
         const sourceMtime = file.mtime;
-        // Once the content row is durably 'extracted', a later failure (entity
-        // replace, project upsert) must NOT overwrite it with a failed row —
-        // that would destroy good text AND, because the snapshot matches, park
-        // the file outside the pending set forever.
+        // Guards the failed-row fallback in the catch: once the file's new
+        // version is durably persisted (or a failed/blocked row is written),
+        // a later throw must NOT overwrite it with a failed row.
         let contentRowWritten = false;
         try {
-          const bytes = await deps.reader.read(source, file.rel_path);
+          // Byte fetch is the transient seam: a source that is down (SMB read
+          // refused) must not park the file as failed — it aborts the batch and
+          // is retried whole. Everything thrown AFTER bytes are in hand
+          // (extraction/parsing) stays permanent.
+          let bytes: Buffer;
+          try {
+            bytes = await deps.reader.read(source, file.rel_path);
+          } catch (readError) {
+            throw new TransientIngestError(
+              `reader: ${readError instanceof Error ? readError.message : String(readError)}`,
+              { cause: readError },
+            );
+          }
           const result = await extractContent(file.name, bytes, maxBytes);
 
           if (result.status !== 'extracted') {
             // failed / skipped_* — no text, nothing for DLP to inspect.
-            await upsertContentRow(orgId, file.id, {
+            await upsertContentRow(d, orgId, file.id, {
               contentHash: null,
               sourceSize,
               sourceMtime,
@@ -253,10 +347,11 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
             continue;
           }
 
-          if (file.content_hash === result.contentHash) {
+          if (!force && file.content_hash === result.contentHash) {
             // Same bytes as last time — refresh the snapshot only. The prior
             // run already applied DLP to these exact bytes, so its verdict
-            // (redacted text or blocked_dlp) stands untouched.
+            // (redacted text or blocked_dlp) stands untouched. Force skips this
+            // arm so DLP re-applies with the CURRENT config.
             await d.execute(sql`
               UPDATE workspace_file_content
               SET source_size = ${sourceSize}, source_mtime = ${sourceMtime}, updated_at = now()
@@ -271,8 +366,10 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
           if (dlp.blocked) {
             // Block before store/embed: persist a blocked_dlp row carrying the
             // findings and the snapshot (so it is skipped, not retried, next
-            // run) — no text, no entities, no chunks, no embedder call.
-            await upsertContentRow(orgId, file.id, {
+            // run) — no text, no entities, no chunks, no embedder call. Under
+            // force this is also the clean→blocked transition path when a
+            // newly-tightened config now blocks a previously-clean file.
+            await upsertContentRow(d, orgId, file.id, {
               contentHash: null,
               sourceSize,
               sourceMtime,
@@ -302,43 +399,82 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
 
           // Redacted (or clean) text is the ONLY text that flows downstream.
           const cleanText = dlp.text;
-          await upsertContentRow(orgId, file.id, {
-            contentHash: result.contentHash,
-            sourceSize,
-            sourceMtime,
-            extractedText: cleanText,
-            status: 'extracted',
-            errorReason: null,
-            emailMeta: result.emailMeta,
-            dlpFindings: dlp.findings,
-          });
-          contentRowWritten = true;
-          await replaceRegexEntities(orgId, file.id, cleanText);
-          await upsertDeclaredProject(orgId, file.rel_path);
-          if (deps.embedder) {
-            const chunks = chunkText(cleanText);
-            const vectors = await deps.embedder.embed(chunks, 'document');
-            // delete-then-insert per file: stale chunks must never linger
-            // after a shrink/rewrite.
+
+          // Force re-embed avoidance: if the file is already stored as
+          // 'extracted' with byte-identical text, the (possibly changed) config
+          // did not affect this file. Refresh snapshot + findings + updated_at
+          // only; skip the entity/chunk rewrite and the embedder call entirely.
+          if (force && file.content_status === 'extracted' && file.extracted_text === cleanText) {
             await d.execute(sql`
-              DELETE FROM workspace_content_chunks
+              UPDATE workspace_file_content
+              SET source_size = ${sourceSize}, source_mtime = ${sourceMtime},
+                  content_hash = ${result.contentHash},
+                  dlp_findings = ${JSON.stringify(dlp.findings)}::jsonb,
+                  updated_at = now()
               WHERE org_id = ${orgId} AND file_index_id = ${file.id}
             `);
-            for (let i = 0; i < chunks.length; i += 1) {
-              await d.execute(sql`
-                INSERT INTO workspace_content_chunks (org_id, file_index_id, chunk_index, text, embedding)
-                VALUES (${orgId}, ${file.id}, ${i}, ${chunks[i]}, ${toVectorLiteral(vectors[i]!)}::vector)
-              `);
-            }
+            processed += 1;
+            continue;
           }
+
+          // Embed BEFORE opening the transaction — never hold a tx across a
+          // network call. A transient embed failure throws here, before any
+          // write, leaving the file's old content row and old chunks fully
+          // intact (and pending, since the snapshot is untouched).
+          let chunks: string[] = [];
+          let vectors: number[][] = [];
+          if (deps.embedder) {
+            chunks = chunkText(cleanText);
+            vectors = await deps.embedder.embed(chunks, 'document');
+          }
+
+          // Persist the whole new version atomically: content row + entities +
+          // project + chunks land together or not at all (savepoint rollback),
+          // so extracted_text and chunks can never diverge.
+          await d.transaction(async (tx) => {
+            await upsertContentRow(tx, orgId, file.id, {
+              contentHash: result.contentHash,
+              sourceSize,
+              sourceMtime,
+              extractedText: cleanText,
+              status: 'extracted',
+              errorReason: null,
+              emailMeta: result.emailMeta,
+              dlpFindings: dlp.findings,
+            });
+            await replaceRegexEntities(tx, orgId, file.id, cleanText);
+            await upsertDeclaredProject(tx, orgId, file.rel_path);
+            if (deps.embedder) {
+              // delete-then-insert per file: stale chunks must never linger
+              // after a shrink/rewrite.
+              await tx.execute(sql`
+                DELETE FROM workspace_content_chunks
+                WHERE org_id = ${orgId} AND file_index_id = ${file.id}
+              `);
+              for (let i = 0; i < chunks.length; i += 1) {
+                await tx.execute(sql`
+                  INSERT INTO workspace_content_chunks (org_id, file_index_id, chunk_index, text, embedding)
+                  VALUES (${orgId}, ${file.id}, ${i}, ${chunks[i]}, ${toVectorLiteral(vectors[i]!)}::vector)
+                `);
+              }
+            }
+          });
+          contentRowWritten = true;
           processed += 1;
         } catch (error) {
+          if (isTransientIngestError(error)) {
+            // Source likely down — abort the rest of the batch and leave this
+            // file fully pending (no row written, no snapshot refresh).
+            transient = { reason: error.message, abortedAfter: processed };
+            break;
+          }
           const message = error instanceof Error ? error.message : String(error);
           if (!contentRowWritten) {
-            // Read/extract/first-write failure: record a failed row WITH the
-            // snapshot so the loop advances; re-ingest by touching the file.
+            // Permanent read/extract/first-write failure: record a failed row
+            // WITH the snapshot so the loop advances; re-ingest by touching the
+            // file.
             try {
-              await upsertContentRow(orgId, file.id, {
+              await upsertContentRow(d, orgId, file.id, {
                 contentHash: null,
                 sourceSize,
                 sourceMtime,
@@ -350,13 +486,20 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
               });
             } catch { /* keep the original error */ }
           }
-          // else: the extraction is durable; only the entity/project pass
-          // failed — surface the error but leave the extracted row intact.
+          // else: a durable row already exists for this file; surface the error
+          // but leave that row intact.
           errors.push({ fileIndexId: file.id, relPath: file.rel_path, error: message });
         }
       }
 
-      return { processed, remaining: await pendingCount(orgId), errors };
+      // A force sweep converges on the force-aware count (files not yet
+      // re-walked this sweep); non-force stays on the single snapshot-pending
+      // truth. Reporting the non-force count for a force job is the estate-
+      // sized-batch bug that let a job phase-complete after one batch.
+      const remaining = force
+        ? await forcePendingCount(orgId, forceSince)
+        : await pendingCount(orgId);
+      return { processed, remaining, errors, transient };
     },
 
     async status(orgId: string): Promise<IngestStatus> {
@@ -380,6 +523,7 @@ export function createContentIngestService(db: WorkspaceDatabase, deps: ContentI
         failed: counts.failed ?? 0,
         skippedTooLarge: counts.skipped_too_large ?? 0,
         skippedBinary: counts.skipped_binary ?? 0,
+        blockedDlp: counts.blocked_dlp ?? 0,
         pending,
       };
     },

--- a/ee/workspace/src/services/contentSearchService.ts
+++ b/ee/workspace/src/services/contentSearchService.ts
@@ -1,4 +1,4 @@
-// Hybrid content retrieval (dev-preview; per-org content flag).
+// Hybrid content retrieval (per-org content flag).
 //
 // Weighted Reciprocal Rank Fusion over independent arms, fused per-file:
 //   entity exact-match  3.0   (query-side detection uses the ingest normalizer)

--- a/ee/workspace/src/services/credentialService.test.ts
+++ b/ee/workspace/src/services/credentialService.test.ts
@@ -123,7 +123,7 @@ describe('credentialService', () => {
       .rejects.toBeInstanceOf(CredentialDecryptError);
   });
 
-  describe('decryptForContentIngest (dev-preview, org-scoped)', () => {
+  describe('decryptForContentIngest (content gating, org-scoped)', () => {
     it('is hard-disabled when content is not enabled for the org', async () => {
       const h = makeHarness({ kind: 'smb_share', credentialEnc: 'ciphertext' });
       await expect(createCredentialService(h.db, h.secrets, settingsStub(false)).decryptForContentIngest(ORG_ID, SOURCE_ID))

--- a/ee/workspace/src/services/credentialService.ts
+++ b/ee/workspace/src/services/credentialService.ts
@@ -98,17 +98,16 @@ export function createCredentialService(
     },
 
     /**
-     * Org-scoped decrypt for the server-side content-ingest reader
-     * (dev-preview). Unlike decryptForDevice this is NOT device-gated — the
-     * ingest worker has no device identity — which is a deliberate,
-     * preview-only widening of the credential surface:
+     * Org-scoped decrypt for the server-side content-ingest reader. Unlike
+     * decryptForDevice this is NOT device-gated — the ingest worker has no
+     * device identity — which is a deliberate widening of the credential
+     * surface, guarded two ways:
      *   - hard-disabled unless content is enabled for the org (defense in
      *     depth; the routes that reach here are themselves gated on the same
      *     per-org setting), and
      *   - the bytes this credential unlocks are DLP-inspected at ingest
      *     (extracted text is redacted before store; a 'block' hit persists no
-     *     text), but this remains a preview-only widening — never enable in
-     *     production.
+     *     text).
      * Same null-vs-throw contract as decryptForDevice.
      */
     async decryptForContentIngest(

--- a/ee/workspace/src/services/crosswalkService.ts
+++ b/ee/workspace/src/services/crosswalkService.ts
@@ -1,4 +1,4 @@
-// Crosswalk miner (dev-preview; per-org content flag).
+// Crosswalk miner (per-org content flag).
 //
 // Mines counterparty identifiers (PO/WDR/invoice/permit — the deterministic
 // regex types only) from files whose PATH declares a project, producing

--- a/ee/workspace/src/services/dashboardService.test.ts
+++ b/ee/workspace/src/services/dashboardService.test.ts
@@ -1,0 +1,222 @@
+// dashboardService — unit tests for the admin dashboard read model. All
+// queries are mocked (dispatched by a distinctive SQL fragment per card, the
+// same idiom as contentIngestService.test.ts's `classify` helper) so these
+// tests pin the summary ASSEMBLY (mapping, JS-side unfiled-pool partition,
+// queue cap, empty-org zeros) without a real DB. The real SQL is pinned by
+// dashboard.integration.test.ts.
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createDashboardService } from './dashboardService';
+import type { IngestStatus } from './contentIngestService';
+
+const ORG = '11111111-1111-1111-1111-111111111111';
+
+// Render the static SQL text of a drizzle `sql` template (params drop out) —
+// mirrors the sqlText walk in ingestJobsService.test.ts / contentIngestService.test.ts.
+function sqlText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(sqlText).join('');
+  if (!value || typeof value !== 'object') return '';
+  const c = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Array.isArray(c.value) && c.value.every((p) => typeof p === 'string')
+    ? c.value.join('')
+    : '';
+  return own + (c.queryChunks ?? []).map(sqlText).join('');
+}
+
+function classify(text: string): string {
+  if (text.includes('FROM workspace_sources s')) return 'sources';
+  if (text.includes('FROM workspace_content_chunks')) return 'chunks';
+  if (text.includes('en.model IS NULL')) return 'enrichPending';
+  if (text.includes("fi.ext = 'eml'")) return 'filing';
+  if (text.includes('FROM workspace_file_activity a')) return 'activity';
+  if (text.includes('FROM workspace_projects p')) return 'projects';
+  if (text.includes('SELECT now()')) return 'now';
+  throw new Error(`dashboardService test: unclassified query: ${text.slice(0, 200)}`);
+}
+
+function makeDb(rows: Partial<Record<string, unknown[]>> = {}) {
+  const calls: Array<{ kind: string; text: string }> = [];
+  const execute = vi.fn(async (q: unknown) => {
+    const text = sqlText(q);
+    const kind = classify(text);
+    calls.push({ kind, text });
+    return rows[kind] ?? [];
+  });
+  return { db: { execute } as unknown as WorkspaceDatabase, calls, execute };
+}
+
+const emptyStatus: IngestStatus = {
+  eligible: 0, extracted: 0, failed: 0, skippedTooLarge: 0, skippedBinary: 0, blockedDlp: 0, pending: 0,
+};
+
+describe('dashboardService.summary — shape assembly (mocked queries)', () => {
+  it('empty org: no rows anywhere → an all-zero summary, never throws', async () => {
+    const { db } = makeDb({ now: [{ ts: '2026-07-19T00:00:00Z' }] });
+    const contentIngestStatus = vi.fn(async () => emptyStatus);
+    const svc = createDashboardService(db, { contentIngestStatus });
+
+    const summary = await svc.summary(ORG);
+
+    expect(summary.sources).toEqual([]);
+    expect(summary.ingest).toEqual({
+      eligible: 0, extracted: 0, failed: 0, skippedTooLarge: 0, skippedBinary: 0,
+      blockedDlp: 0, pending: 0, enrichPending: 0, chunks: 0,
+    });
+    expect(summary.filing).toEqual({
+      unfiled: 0, suggested: 0, confirmed: 0, reassigned: 0, highConfidence: 0, queue: [],
+    });
+    expect(summary.activity).toEqual([]);
+    expect(summary.projects).toEqual([]);
+    expect(summary.generatedAt).toBe('2026-07-19T00:00:00.000Z');
+    expect(contentIngestStatus).toHaveBeenCalledWith(ORG);
+  });
+
+  it('sources: maps counts, active run, and null timestamps correctly', async () => {
+    const { db } = makeDb({
+      sources: [
+        {
+          id: 'src-1', display_name: 'Fileserver', kind: 'smb_share', status: 'active',
+          last_complete_run_at: '2026-07-18T10:00:00Z',
+          live_files: 5, live_dirs: 2, tombstoned: 1,
+          newest_seen_at: '2026-07-19T09:00:00Z',
+          active_run_id: 'run-1', active_run_status: 'running',
+          active_run_started_at: '2026-07-19T08:00:00Z', active_run_stats: { seen: 3 },
+        },
+        {
+          id: 'src-2', display_name: 'Archive', kind: 'local_profile', status: 'paused',
+          last_complete_run_at: null,
+          live_files: 0, live_dirs: 0, tombstoned: 0, newest_seen_at: null,
+          active_run_id: null, active_run_status: null, active_run_started_at: null, active_run_stats: null,
+        },
+      ],
+    });
+    const svc = createDashboardService(db, { contentIngestStatus: vi.fn(async () => emptyStatus) });
+
+    const { sources } = await svc.summary(ORG);
+
+    expect(sources).toEqual([
+      {
+        id: 'src-1', name: 'Fileserver', kind: 'smb_share', status: 'active',
+        lastCompleteRunAt: '2026-07-18T10:00:00.000Z',
+        liveFiles: 5, liveDirs: 2, tombstoned: 1, newestSeenAt: '2026-07-19T09:00:00.000Z',
+        activeRun: { id: 'run-1', status: 'running', startedAt: '2026-07-19T08:00:00.000Z', stats: { seen: 3 } },
+      },
+      {
+        id: 'src-2', name: 'Archive', kind: 'local_profile', status: 'paused',
+        lastCompleteRunAt: null,
+        liveFiles: 0, liveDirs: 0, tombstoned: 0, newestSeenAt: null,
+        activeRun: null,
+      },
+    ]);
+  });
+
+  it('ingest: forwards contentIngestStatus fields (incl. blockedDlp) and adds enrichPending/chunks', async () => {
+    const { db } = makeDb({
+      enrichPending: [{ n: 4 }],
+      chunks: [{ n: 42 }],
+    });
+    const status: IngestStatus = {
+      eligible: 20, extracted: 12, failed: 1, skippedTooLarge: 2, skippedBinary: 1, blockedDlp: 3, pending: 5,
+    };
+    const svc = createDashboardService(db, { contentIngestStatus: vi.fn(async () => status) });
+
+    const { ingest } = await svc.summary(ORG);
+
+    expect(ingest).toEqual({
+      eligible: 20, extracted: 12, failed: 1, skippedTooLarge: 2, skippedBinary: 1,
+      blockedDlp: 3, pending: 5, enrichPending: 4, chunks: 42,
+    });
+  });
+
+  it('filing: partitions the unfiled-email pool by status and caps the queue at 10', async () => {
+    // 12 candidate .eml rows under an undeclared folder (2 segments →
+    // deriveDeclaredProject returns null) plus one already-declared control
+    // that must be excluded from every count.
+    const undeclared = Array.from({ length: 12 }, (_, i) => ({
+      id: `f-${i}`, rel_path: `Unfiled/mail-${i}.eml`, name: `mail-${i}.eml`,
+      status: i < 8 ? null : (i < 10 ? 'suggested' : (i === 10 ? 'confirmed' : 'reassigned')),
+      suggested_project_label: i >= 8 ? 'Henderson' : null,
+      confidence: i === 9 ? 'high' : null,
+    }));
+    const declaredControl = {
+      id: 'f-declared', rel_path: 'Projects/2023-041 Henderson/note.eml', name: 'note.eml',
+      status: null, suggested_project_label: null, confidence: null,
+    };
+    const { db } = makeDb({ filing: [...undeclared, declaredControl] });
+    const svc = createDashboardService(db, { contentIngestStatus: vi.fn(async () => emptyStatus) });
+
+    const { filing } = await svc.summary(ORG);
+
+    // 8 untouched + 2 suggested = 10 still-undecided ("unfiled"); 1 confirmed; 1 reassigned.
+    expect(filing.unfiled).toBe(10);
+    expect(filing.suggested).toBe(2);
+    expect(filing.confirmed).toBe(1);
+    expect(filing.reassigned).toBe(1);
+    expect(filing.highConfidence).toBe(1); // the single suggested+high row (i === 9)
+    expect(filing.queue).toHaveLength(10); // capped, even though the undecided pool is exactly 10
+    expect(filing.queue.every((q) => q.relPath.startsWith('Unfiled/'))).toBe(true);
+    expect(filing.queue.map((q) => q.id)).not.toContain('f-declared');
+    // A suggested row in the queue carries its suggestion; an untouched one does not.
+    expect(filing.queue[8]).toMatchObject({ id: 'f-8', suggestedProjectLabel: 'Henderson', confidence: null });
+    expect(filing.queue[0]).toMatchObject({ id: 'f-0', suggestedProjectLabel: null, confidence: null });
+  });
+
+  it('filing: queue caps at 10 even when the undecided pool exceeds it', async () => {
+    const rows = Array.from({ length: 15 }, (_, i) => ({
+      id: `f-${i}`, rel_path: `Unfiled/mail-${i}.eml`, name: `mail-${i}.eml`,
+      status: null, suggested_project_label: null, confidence: null,
+    }));
+    const { db } = makeDb({ filing: rows });
+    const svc = createDashboardService(db, { contentIngestStatus: vi.fn(async () => emptyStatus) });
+
+    const { filing } = await svc.summary(ORG);
+
+    expect(filing.unfiled).toBe(15);
+    expect(filing.queue).toHaveLength(10);
+  });
+
+  it('activity: maps recency-ordered rows with 7-day event counts', async () => {
+    const { db } = makeDb({
+      activity: [
+        { file_index_id: 'f-1', name: 'a.md', rel_path: 'Projects/x/a.md', last_activity_at: '2026-07-19T12:00:00Z', events_7d: 3 },
+      ],
+    });
+    const svc = createDashboardService(db, { contentIngestStatus: vi.fn(async () => emptyStatus) });
+
+    const { activity } = await svc.summary(ORG);
+
+    expect(activity).toEqual([{
+      fileIndexId: 'f-1', name: 'a.md', relPath: 'Projects/x/a.md',
+      lastActivityAt: '2026-07-19T12:00:00.000Z', events7d: 3,
+    }]);
+  });
+
+  it('projects: maps per-project filed/crosswalk/evidence counts', async () => {
+    const { db } = makeDb({
+      projects: [
+        { project_key: '2023-041', label: 'Henderson', filed_emails: 4, crosswalk_entities: 6, evidence_files: 9 },
+      ],
+    });
+    const svc = createDashboardService(db, { contentIngestStatus: vi.fn(async () => emptyStatus) });
+
+    const { projects } = await svc.summary(ORG);
+
+    expect(projects).toEqual([
+      { projectKey: '2023-041', label: 'Henderson', filedEmails: 4, crosswalkEntities: 6, evidenceFiles: 9 },
+    ]);
+  });
+
+  it('passes orgId through to every query and to contentIngestStatus', async () => {
+    const { db, calls } = makeDb();
+    const contentIngestStatus = vi.fn(async () => emptyStatus);
+    const svc = createDashboardService(db, { contentIngestStatus });
+
+    await svc.summary(ORG);
+
+    expect(contentIngestStatus).toHaveBeenCalledWith(ORG);
+    for (const call of calls) {
+      if (call.kind === 'now') continue; // SELECT now() carries no org_id
+      expect(call.text).toContain('org_id');
+    }
+  });
+});

--- a/ee/workspace/src/services/dashboardService.ts
+++ b/ee/workspace/src/services/dashboardService.ts
@@ -1,0 +1,293 @@
+// W3 Task 6: admin dashboard read model. ADMIN/org-operator scope — every
+// query here reads the WHOLE org (all sources, incl. grouped ones) and
+// deliberately does NOT thread visibleSourcePredicateSql/groupIds through:
+// an org operator manages the estate, not a slice of it (see the Global
+// Constraints note on the sources card and dashboard.integration.test.ts's
+// grouped-source pin).
+//
+// Every card is a single round-trip query (no N+1); summary() fans them out
+// with Promise.all, mirroring contentIngestService.status()'s existing
+// concurrent-execute() pattern on the same request-scoped handle. The one
+// exception is the filing card: "declared project" is derived from rel_path
+// in JS (content/projects.ts), so that predicate can't live in SQL — the
+// query fetches the full eml/live/undeclared-candidate set and the pool
+// filter + unfiled/suggested/confirmed/reassigned partition + queue cap all
+// happen in JS, exactly like filingService.unfiledEmails.
+//
+// generatedAt is read from the DATABASE clock (SELECT now()), never
+// `new Date()` — Global Constraints: timestamps/comparisons use the DB
+// clock, never host clocks.
+import type { WorkspaceDatabase } from '../hostTypes';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { deriveDeclaredProject } from '../content/projects';
+import type { IngestStatus } from './contentIngestService';
+
+export interface DashboardSummary {
+  sources: Array<{
+    id: string; name: string; kind: string; status: string;
+    lastCompleteRunAt: string | null; liveFiles: number; liveDirs: number;
+    tombstoned: number; newestSeenAt: string | null;
+    activeRun: { id: string; status: string; startedAt: string; stats: unknown } | null;
+  }>;
+  ingest: {
+    eligible: number; extracted: number; failed: number; skippedTooLarge: number;
+    skippedBinary: number; blockedDlp: number; pending: number;
+    enrichPending: number; chunks: number;
+  };
+  filing: {
+    unfiled: number; suggested: number; confirmed: number; reassigned: number;
+    highConfidence: number;
+    queue: Array<{
+      id: string; name: string; relPath: string;
+      suggestedProjectLabel: string | null; confidence: string | null;
+    }>;
+  };
+  activity: Array<{
+    fileIndexId: string; name: string; relPath: string;
+    lastActivityAt: string; events7d: number;
+  }>;
+  projects: Array<{
+    projectKey: string; label: string; filedEmails: number;
+    crosswalkEntities: number; evidenceFiles: number;
+  }>;
+  generatedAt: string;
+}
+
+export interface DashboardServiceDeps {
+  contentIngestStatus(orgId: string): Promise<IngestStatus>;
+}
+
+interface SourceRow {
+  id: string; display_name: string; kind: string; status: string;
+  last_complete_run_at: string | Date | null;
+  live_files: number | string; live_dirs: number | string; tombstoned: number | string;
+  newest_seen_at: string | Date | null;
+  active_run_id: string | null; active_run_status: string | null;
+  active_run_started_at: string | Date | null; active_run_stats: unknown;
+}
+
+interface UnfiledCandidateRow {
+  id: string; rel_path: string; name: string;
+  status: 'suggested' | 'confirmed' | 'reassigned' | null;
+  suggested_project_label: string | null;
+  confidence: string | null;
+}
+
+interface ActivityRow {
+  file_index_id: string; name: string; rel_path: string;
+  last_activity_at: string | Date; events_7d: number | string;
+}
+
+interface ProjectRow {
+  project_key: string; label: string;
+  filed_emails: number | string; crosswalk_entities: number | string; evidence_files: number | string;
+}
+
+function toIsoOrNull(v: string | Date | null): string | null {
+  return v === null ? null : new Date(v).toISOString();
+}
+
+export function createDashboardService(db: WorkspaceDatabase, deps: DashboardServiceDeps) {
+  const d = db;
+
+  async function sourcesCard(orgId: string): Promise<DashboardSummary['sources']> {
+    const rows = await d.execute(sql`
+      SELECT s.id, s.display_name, s.kind, s.status, s.last_complete_run_at,
+             COALESCE(fc.live_files, 0)::int AS live_files,
+             COALESCE(fc.live_dirs, 0)::int AS live_dirs,
+             COALESCE(fc.tombstoned, 0)::int AS tombstoned,
+             fc.newest_seen_at,
+             ar.id AS active_run_id, ar.status AS active_run_status,
+             ar.started_at AS active_run_started_at, ar.stats AS active_run_stats
+      FROM workspace_sources s
+      LEFT JOIN LATERAL (
+        SELECT
+          COUNT(*) FILTER (WHERE fi.deleted_at IS NULL AND NOT fi.is_dir) AS live_files,
+          COUNT(*) FILTER (WHERE fi.deleted_at IS NULL AND fi.is_dir) AS live_dirs,
+          COUNT(*) FILTER (WHERE fi.deleted_at IS NOT NULL) AS tombstoned,
+          MAX(fi.last_seen_at) FILTER (WHERE fi.deleted_at IS NULL) AS newest_seen_at
+        FROM workspace_file_index fi
+        WHERE fi.org_id = s.org_id AND fi.source_id = s.id
+      ) fc ON true
+      LEFT JOIN LATERAL (
+        SELECT cr.id, cr.status, cr.started_at, cr.stats
+        FROM workspace_crawl_runs cr
+        WHERE cr.org_id = s.org_id AND cr.source_id = s.id AND cr.status = 'running'
+        ORDER BY cr.started_at DESC
+        LIMIT 1
+      ) ar ON true
+      WHERE s.org_id = ${orgId}
+      ORDER BY s.display_name
+    `) as unknown as SourceRow[];
+
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.display_name,
+      kind: r.kind,
+      status: r.status,
+      lastCompleteRunAt: toIsoOrNull(r.last_complete_run_at),
+      liveFiles: Number(r.live_files),
+      liveDirs: Number(r.live_dirs),
+      tombstoned: Number(r.tombstoned),
+      newestSeenAt: toIsoOrNull(r.newest_seen_at),
+      activeRun: r.active_run_id === null ? null : {
+        id: r.active_run_id,
+        status: r.active_run_status as string,
+        startedAt: new Date(r.active_run_started_at as string | Date).toISOString(),
+        stats: r.active_run_stats,
+      },
+    }));
+  }
+
+  async function ingestCard(orgId: string): Promise<DashboardSummary['ingest']> {
+    const [status, enrichPendingRes, chunksRes] = await Promise.all([
+      deps.contentIngestStatus(orgId),
+      // Same pending-enrichment predicate as enrichmentService.run's pendingSql
+      // (extracted, live, no enrichment row or a row whose model is still null).
+      d.execute(sql`
+        SELECT count(*)::int AS n
+        FROM workspace_file_content c
+        JOIN workspace_file_index fi ON fi.id = c.file_index_id AND fi.org_id = c.org_id
+        LEFT JOIN workspace_file_enrichment en
+          ON en.file_index_id = c.file_index_id AND en.enriched_at IS NOT NULL
+        WHERE c.org_id = ${orgId}
+          AND c.status = 'extracted'
+          AND fi.deleted_at IS NULL
+          AND (en.id IS NULL OR en.model IS NULL)
+      `),
+      d.execute(sql`SELECT count(*)::int AS n FROM workspace_content_chunks WHERE org_id = ${orgId}`),
+    ]);
+    return {
+      eligible: status.eligible,
+      extracted: status.extracted,
+      failed: status.failed,
+      skippedTooLarge: status.skippedTooLarge,
+      skippedBinary: status.skippedBinary,
+      blockedDlp: status.blockedDlp,
+      pending: status.pending,
+      enrichPending: Number((enrichPendingRes as unknown as Array<{ n: number }>)[0]?.n ?? 0),
+      chunks: Number((chunksRes as unknown as Array<{ n: number }>)[0]?.n ?? 0),
+    };
+  }
+
+  async function filingCard(orgId: string): Promise<DashboardSummary['filing']> {
+    // Same base predicate as filingService.unfiledEmails (.eml, live) minus the
+    // visibility predicate — org-operator scope sees every source. The
+    // declared-project filter is JS-only (deriveDeclaredProject), so it is
+    // applied below, not in SQL.
+    const rows = await d.execute(sql`
+      SELECT fi.id, fi.rel_path, fi.name, ef.status, ef.suggested_project_label, ef.confidence
+      FROM workspace_file_index fi
+      LEFT JOIN workspace_email_filings ef ON ef.file_index_id = fi.id AND ef.org_id = fi.org_id
+      WHERE fi.org_id = ${orgId}
+        AND fi.deleted_at IS NULL
+        AND fi.is_dir = false
+        AND fi.ext = 'eml'
+      ORDER BY fi.rel_path
+    `) as unknown as UnfiledCandidateRow[];
+
+    const pool = rows.filter((r) => deriveDeclaredProject(r.rel_path) === null);
+
+    // A filing row's status enum is only ever 'suggested' | 'confirmed' |
+    // 'reassigned' (default 'suggested' on classify(), flipped to
+    // confirmed/reassigned by assign()); no row at all means never classified.
+    // "unfiled" = still undecided — no row, or a live 'suggested' row that
+    // hasn't been acted on yet. confirmed/reassigned are DECIDED and leave
+    // the unfiled bucket even though the file's path never moved.
+    const unfiledPool = pool.filter((r) => r.status === null || r.status === 'suggested');
+    const suggested = pool.filter((r) => r.status === 'suggested');
+    const confirmed = pool.filter((r) => r.status === 'confirmed');
+    const reassigned = pool.filter((r) => r.status === 'reassigned');
+    const highConfidence = pool.filter((r) => r.status === 'suggested' && r.confidence === 'high');
+
+    return {
+      unfiled: unfiledPool.length,
+      suggested: suggested.length,
+      confirmed: confirmed.length,
+      reassigned: reassigned.length,
+      highConfidence: highConfidence.length,
+      queue: unfiledPool.slice(0, 10).map((r) => ({
+        id: r.id,
+        name: r.name,
+        relPath: r.rel_path,
+        suggestedProjectLabel: r.suggested_project_label,
+        confidence: r.confidence,
+      })),
+    };
+  }
+
+  async function activityCard(orgId: string): Promise<DashboardSummary['activity']> {
+    const rows = await d.execute(sql`
+      SELECT fi.id AS file_index_id, fi.name, fi.rel_path, x.last_activity_at, x.events_7d
+      FROM (
+        SELECT a.file_index_id, MAX(a.created_at) AS last_activity_at,
+               COUNT(*) FILTER (WHERE a.created_at > now() - interval '7 days') AS events_7d
+        FROM workspace_file_activity a
+        WHERE a.org_id = ${orgId}
+        GROUP BY a.file_index_id
+      ) x
+      JOIN workspace_file_index fi ON fi.id = x.file_index_id AND fi.org_id = ${orgId}
+      WHERE fi.deleted_at IS NULL
+      ORDER BY x.last_activity_at DESC
+      LIMIT 15
+    `) as unknown as ActivityRow[];
+
+    return rows.map((r) => ({
+      fileIndexId: r.file_index_id,
+      name: r.name,
+      relPath: r.rel_path,
+      lastActivityAt: new Date(r.last_activity_at).toISOString(),
+      events7d: Number(r.events_7d),
+    }));
+  }
+
+  async function projectsCard(orgId: string): Promise<DashboardSummary['projects']> {
+    const rows = await d.execute(sql`
+      SELECT p.project_key, p.label,
+        COALESCE(f.filed_emails, 0)::int AS filed_emails,
+        COALESCE(c.crosswalk_entities, 0)::int AS crosswalk_entities,
+        COALESCE(c.evidence_files, 0)::int AS evidence_files
+      FROM workspace_projects p
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS filed_emails
+        FROM workspace_email_filings ef
+        WHERE ef.org_id = p.org_id
+          AND (
+            (ef.status = 'confirmed' AND ef.decided_project_key = p.project_key)
+            OR (ef.status = 'suggested' AND ef.suggested_project_key = p.project_key)
+          )
+      ) f ON true
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*) AS crosswalk_entities, COALESCE(SUM(pc.evidence_count), 0) AS evidence_files
+        FROM workspace_project_crosswalk pc
+        WHERE pc.org_id = p.org_id AND pc.project_key = p.project_key
+      ) c ON true
+      WHERE p.org_id = ${orgId}
+      ORDER BY p.project_key
+    `) as unknown as ProjectRow[];
+
+    return rows.map((r) => ({
+      projectKey: r.project_key,
+      label: r.label,
+      filedEmails: Number(r.filed_emails),
+      crosswalkEntities: Number(r.crosswalk_entities),
+      evidenceFiles: Number(r.evidence_files),
+    }));
+  }
+
+  return {
+    async summary(orgId: string): Promise<DashboardSummary> {
+      const [sources, ingest, filing, activity, projects, nowRes] = await Promise.all([
+        sourcesCard(orgId),
+        ingestCard(orgId),
+        filingCard(orgId),
+        activityCard(orgId),
+        projectsCard(orgId),
+        d.execute(sql`SELECT now() AS ts`),
+      ]);
+      const ts = (nowRes as unknown as Array<{ ts: string | Date }>)[0]?.ts ?? new Date();
+      return { sources, ingest, filing, activity, projects, generatedAt: new Date(ts).toISOString() };
+    },
+  };
+}

--- a/ee/workspace/src/services/emailMatchService.test.ts
+++ b/ee/workspace/src/services/emailMatchService.test.ts
@@ -1,0 +1,182 @@
+// Tiered .eml matcher for the Outlook filing panel (W4): given the open
+// message's subject/sender/date (and, when Graph hands us one, its
+// internetMessageId), answer which crawled .eml file it is. Mocked db exec —
+// see filing.integration.test.ts for the real-DB seed pattern this mirrors.
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { createEmailMatchService, normalizeSubject } from './emailMatchService';
+
+const ORG_ID = '11111111-1111-1111-1111-111111111111';
+
+/**
+ * Values reachable from a raw drizzle sql template. Raw templates store bound
+ * params as bare primitives between StringChunks (crawlRunsService.test.ts /
+ * activityService.test.ts convention), so primitives count as bound values here.
+ */
+function boundValues(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => (item && typeof item === 'object' ? boundValues(item) : [item]));
+  }
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value')
+    ? (Array.isArray(candidate.value) ? candidate.value : [candidate.value])
+    : [];
+  return [
+    ...own,
+    ...(candidate.queryChunks ?? []).flatMap((item) =>
+      (item && typeof item === 'object' ? boundValues(item) : [item])),
+  ];
+}
+
+/** Approximate SQL text of a drizzle expression (columns as bare names, params as ?). */
+function sqlText(value: unknown): string {
+  if (value == null) return '';
+  if (Array.isArray(value)) return value.map(sqlText).join('');
+  if (typeof value !== 'object') return String(value);
+  const c = value as Record<string, unknown>;
+  if ('encoder' in c) return '?';
+  if (Array.isArray(c.queryChunks)) return (c.queryChunks as unknown[]).map(sqlText).join('');
+  if (Array.isArray(c.value) && (c.value as unknown[]).every((x) => typeof x === 'string')) {
+    return (c.value as string[]).join('');
+  }
+  if (typeof c.name === 'string') return c.name;
+  return '';
+}
+
+function makeDb(executeResults: unknown[][] = []) {
+  let executeIndex = 0;
+  const executed: unknown[] = [];
+  const db = {
+    execute: vi.fn(async (query: unknown) => {
+      executed.push(query);
+      return executeResults[executeIndex++] ?? [];
+    }),
+  };
+  return { db: db as unknown as WorkspaceDatabase, executed };
+}
+
+describe('normalizeSubject', () => {
+  it.each([
+    ['RE: PO 4021 issued', 'po 4021 issued'],
+    ['Fwd: Re: PO 4021 issued', 'po 4021 issued'],
+    ['fw:re:FW: PO 4021 issued', 'po 4021 issued'],
+    ['  PO   4021   issued  ', 'po 4021 issued'],
+    ['PO 4021 issued', 'po 4021 issued'],
+    ['REISSUE: PO 4021', 'reissue: po 4021'], // "re" only strips as a labeled prefix, not any leading "re"
+    ['', ''],
+  ])('normalizes %j to %j', (input, expected) => {
+    expect(normalizeSubject(input)).toBe(expected);
+  });
+});
+
+describe('createEmailMatchService.match', () => {
+  it('tier 1: exact messageId match wins without needing subject/date', async () => {
+    const { db, executed } = makeDb([[{ id: 'file-1' }]]);
+    const result = await createEmailMatchService(db).match(ORG_ID, {
+      subject: 'irrelevant for tier 1',
+      internetMessageId: '<ABC123@Mail.Example.com>',
+    });
+    expect(result).toEqual({ fileIndexId: 'file-1', tier: 1 });
+    expect(executed).toHaveLength(1); // tier 1 hit short-circuits — no date-window query follows
+    const text = sqlText(executed[0]);
+    expect(text).toContain("email_meta ->> 'messageId'");
+    expect(text).toContain("fi.ext = 'eml'");
+    const values = boundValues(executed[0]);
+    expect(values).toContain(ORG_ID);
+    // normalized: angle brackets stripped, lowercased
+    expect(values).toContain('abc123@mail.example.com');
+  });
+
+  it('tier 2: subject + sender + 7-day window hit when the row carries no messageId (PO-4021 shape)', async () => {
+    const { db } = makeDb([[
+      { id: 'decoy', email_meta: { subject: 'unrelated thread', from: 'x@y.com', date: '2023-08-15T16:00:00.000Z' } },
+      {
+        id: 'file-2',
+        email_meta: {
+          subject: 'PO 4021 issued', from: 'Paul Deluca <pdeluca@fairoaksca.gov>',
+          date: '2023-08-15T16:00:00.000Z',
+        },
+      },
+    ]]);
+    const result = await createEmailMatchService(db).match(ORG_ID, {
+      subject: 'RE: PO 4021 issued',
+      sender: 'pdeluca@fairoaksca.gov',
+      dateISO: '2023-08-16T16:00:00.000Z',
+    });
+    expect(result).toEqual({ fileIndexId: 'file-2', tier: 2 });
+  });
+
+  it('tier 3: forwarded probe (different sender) still hits on subject + date window alone', async () => {
+    const { db } = makeDb([[
+      {
+        id: 'file-3',
+        email_meta: {
+          subject: 'PO 4021 issued', from: 'Paul Deluca <pdeluca@fairoaksca.gov>',
+          date: '2023-08-15T16:00:00.000Z',
+        },
+      },
+    ]]);
+    const result = await createEmailMatchService(db).match(ORG_ID, {
+      subject: 'FW: PO 4021 issued',
+      sender: 'someone-else@example.com',
+      dateISO: '2023-08-16T16:00:00.000Z',
+    });
+    expect(result).toEqual({ fileIndexId: 'file-3', tier: 3 });
+  });
+
+  it('ambiguous tier 2 (two sender-matching candidates) falls through tier 3 to null', async () => {
+    const { db } = makeDb([[
+      {
+        id: 'file-a',
+        email_meta: {
+          subject: 'PO 4021 issued', from: 'Paul Deluca <pdeluca@fairoaksca.gov>',
+          date: '2023-08-15T16:00:00.000Z',
+        },
+      },
+      {
+        id: 'file-b',
+        email_meta: {
+          subject: 'PO 4021 issued', from: 'Paul Deluca <pdeluca@fairoaksca.gov>',
+          date: '2023-08-16T12:00:00.000Z',
+        },
+      },
+    ]]);
+    const result = await createEmailMatchService(db).match(ORG_ID, {
+      subject: 'PO 4021 issued',
+      sender: 'pdeluca@fairoaksca.gov',
+      dateISO: '2023-08-16T16:00:00.000Z',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('visibility: gates on visibleSourcePredicateSql, so groupIds=[] hides a grouped source', async () => {
+    const { db, executed } = makeDb([[]]);
+    const result = await createEmailMatchService(db).match(ORG_ID, {
+      subject: 'PO 4021 issued',
+      dateISO: '2023-08-16T16:00:00.000Z',
+    }, []);
+    expect(result).toBeNull();
+    const text = sqlText(executed[0]);
+    expect(text).toContain("'[]'::jsonb");
+    expect(text).toContain('visibility_group_ids');
+  });
+
+  it('org bound: org_id is threaded into the query so cross-org rows never surface', async () => {
+    const { db, executed } = makeDb([[]]);
+    const result = await createEmailMatchService(db).match(ORG_ID, {
+      subject: 'PO 4021 issued',
+      dateISO: '2023-08-16T16:00:00.000Z',
+    });
+    expect(result).toBeNull();
+    expect(sqlText(executed[0])).toContain('fi.org_id');
+    expect(boundValues(executed[0])).toContain(ORG_ID);
+  });
+
+  it('returns null with no query when the probe has neither messageId nor dateISO', async () => {
+    const { db, executed } = makeDb([]);
+    const result = await createEmailMatchService(db).match(ORG_ID, { subject: 'PO 4021 issued' });
+    expect(result).toBeNull();
+    expect(executed).toHaveLength(0);
+  });
+});

--- a/ee/workspace/src/services/emailMatchService.ts
+++ b/ee/workspace/src/services/emailMatchService.ts
@@ -1,0 +1,142 @@
+// Tiered .eml matcher for the Outlook filing panel (W4). Given the subject,
+// sender, date, and (when Graph hands us one) internetMessageId of the
+// message currently open in Outlook, answer which crawled .eml file in the
+// estate it is — or null.
+//
+// Tier 1 (messageId) is the strongest signal but the demo corpus (PO-4021)
+// carries no Message-ID header at all, which is exactly the case tiers 2/3
+// exist for: never assume tier 1 alone is enough coverage.
+//   1 = messageId equality.
+//   2 = normalizedSubject + sender email + |date - email_meta.date| <= 7d.
+//   3 = normalizedSubject + date window only (catches forwards, where the
+//       sender changes but the subject and rough timing survive).
+// The first tier with EXACTLY ONE candidate wins. Zero or multiple
+// candidates in a tier means "try the next tier"; null when every tier
+// misses. Tier 3's candidate set is a superset of tier 2's (same subject +
+// date window, sender unconstrained), so an ambiguous tier 2 is also
+// ambiguous at tier 3 — it falls all the way through to null, not to some
+// arbitrary pick.
+import { sql } from 'drizzle-orm';
+import type { WorkspaceDatabase } from '../hostTypes';
+import { visibleSourcePredicateSql } from './visibility';
+
+const SEVEN_DAYS_SECONDS = 7 * 24 * 60 * 60;
+
+export interface EmailProbe {
+  subject: string;
+  sender?: string;
+  dateISO?: string;
+  internetMessageId?: string;
+}
+
+export type EmailMatch = { fileIndexId: string; tier: 1 | 2 | 3 };
+
+interface CandidateRow {
+  id: string;
+  email_meta: { subject?: string; from?: string; date?: string } | null;
+}
+
+/** Strip repeated leading re:/fw:/fwd: (case-insensitive), collapse whitespace,
+ * casefold, trim. Only a labeled "word:" prefix is stripped — "REISSUE: ..."
+ * is untouched because "reissue" isn't one of the three tokens. */
+export function normalizeSubject(s: string): string {
+  let out = s ?? '';
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(/^\s*(?:re|fw|fwd)\s*:\s*/i, '');
+  } while (out !== prev);
+  return out.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/** Same normalization extract.ts applies when it captures parsed.messageId:
+ * angle brackets stripped, lowercased. Applied here to the probe's id so it
+ * compares equal to what was persisted at ingest time. */
+function normalizeMessageId(id: string): string {
+  return id.trim().replace(/^<+|>+$/g, '').toLowerCase();
+}
+
+/** Bare lowercase email address out of either a raw address or a "Name
+ * <addr>" mailbox string (the shape mailparser's AddressObject#text produces,
+ * which is what email_meta.from / the probe's sender carry). */
+function senderEmail(text: string | undefined): string | null {
+  if (!text) return null;
+  const angle = text.match(/<([^>]+)>/);
+  // The capture group is structurally guaranteed by the match above.
+  const raw = (angle?.[1] ?? text).trim().toLowerCase();
+  return raw || null;
+}
+
+export function createEmailMatchService(db: WorkspaceDatabase) {
+  const d = db;
+
+  async function tier1Candidates(
+    orgId: string, groupIds: string[], normalizedMessageId: string,
+  ): Promise<Array<{ id: string }>> {
+    return await d.execute(sql`
+      SELECT fi.id
+      FROM workspace_file_index fi
+      JOIN workspace_file_enrichment en ON en.file_index_id = fi.id
+      JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+      WHERE fi.org_id = ${orgId}
+        AND fi.ext = 'eml'
+        AND fi.deleted_at IS NULL
+        AND ${visibleSourcePredicateSql(sql, groupIds)}
+        AND en.email_meta ->> 'messageId' = ${normalizedMessageId}
+    `) as unknown as Array<{ id: string }>;
+  }
+
+  /** Rows within the 7-day window of the probe date, org-bound and visibility-
+   * gated. Subject/sender agreement is decided in JS (below) against these —
+   * normalizeSubject's repeated-prefix stripping isn't worth reproducing as
+   * a SQL predicate. */
+  async function dateWindowCandidates(
+    orgId: string, groupIds: string[], dateISO: string,
+  ): Promise<CandidateRow[]> {
+    return await d.execute(sql`
+      SELECT fi.id, en.email_meta
+      FROM workspace_file_index fi
+      JOIN workspace_file_enrichment en ON en.file_index_id = fi.id
+      JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+      WHERE fi.org_id = ${orgId}
+        AND fi.ext = 'eml'
+        AND fi.deleted_at IS NULL
+        AND ${visibleSourcePredicateSql(sql, groupIds)}
+        AND en.email_meta IS NOT NULL
+        AND en.email_meta ->> 'date' IS NOT NULL
+        AND abs(extract(epoch from ((en.email_meta ->> 'date')::timestamptz - ${dateISO}::timestamptz)))
+          <= ${SEVEN_DAYS_SECONDS}
+    `) as unknown as CandidateRow[];
+  }
+
+  return {
+    normalizeSubject,
+
+    async match(orgId: string, probe: EmailProbe, groupIds: string[] = []): Promise<EmailMatch | null> {
+      if (probe.internetMessageId) {
+        const rows = await tier1Candidates(orgId, groupIds, normalizeMessageId(probe.internetMessageId));
+        if (rows.length === 1) return { fileIndexId: rows[0]!.id, tier: 1 };
+      }
+
+      if (!probe.dateISO) return null;
+
+      const candidates = await dateWindowCandidates(orgId, groupIds, probe.dateISO);
+      const probeSubject = normalizeSubject(probe.subject);
+      const probeSender = senderEmail(probe.sender);
+      const subjectMatches = candidates.filter(
+        (c) => normalizeSubject(c.email_meta?.subject ?? '') === probeSubject,
+      );
+
+      if (probeSender) {
+        const tier2 = subjectMatches.filter((c) => senderEmail(c.email_meta?.from) === probeSender);
+        if (tier2.length === 1) return { fileIndexId: tier2[0]!.id, tier: 2 };
+      }
+
+      if (subjectMatches.length === 1) return { fileIndexId: subjectMatches[0]!.id, tier: 3 };
+
+      return null;
+    },
+  };
+}
+
+export type EmailMatchService = ReturnType<typeof createEmailMatchService>;

--- a/ee/workspace/src/services/enrichmentService.test.ts
+++ b/ee/workspace/src/services/enrichmentService.test.ts
@@ -3,6 +3,7 @@ import type { WorkspaceDatabase } from '../hostTypes';
 import {
   buildEnrichmentPrompt, createEnrichmentService, extractJson, type AnthropicLike,
 } from './enrichmentService';
+import { TransientIngestError, isTransientIngestError } from './ingestErrors';
 
 const ORG = '11111111-1111-1111-1111-111111111111';
 
@@ -74,11 +75,31 @@ describe('classifyOne', () => {
     expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
   });
 
-  it('fails soft (null) when the client throws', async () => {
+  it('fails soft (null) when the client throws a plain (statusless) error', async () => {
     const client: AnthropicLike = {
       messages: { create: vi.fn(async () => { throw new Error('rate limited'); }) },
     };
     const svc = createEnrichmentService(db, { client });
+    expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
+  });
+
+  function throwingClient(err: unknown): AnthropicLike {
+    return { messages: { create: vi.fn(async () => { throw err; }) } };
+  }
+
+  it('rethrows an APIError 429 as TransientIngestError (rate cap backs the job off)', async () => {
+    const svc = createEnrichmentService(db, { client: throwingClient({ status: 429, message: 'rate' }) });
+    await expect(svc.classifyOne('a.md', 'text', [])).rejects.toThrow(TransientIngestError);
+    await expect(svc.classifyOne('a.md', 'text', [])).rejects.toSatisfy(isTransientIngestError);
+  });
+
+  it('rethrows an APIError >= 500 as TransientIngestError (provider outage)', async () => {
+    const svc = createEnrichmentService(db, { client: throwingClient({ status: 503 }) });
+    await expect(svc.classifyOne('a.md', 'text', [])).rejects.toThrow(TransientIngestError);
+  });
+
+  it('keeps fail-soft null for a non-retryable APIError (e.g. 400)', async () => {
+    const svc = createEnrichmentService(db, { client: throwingClient({ status: 400 }) });
     expect(await svc.classifyOne('a.md', 'text', [])).toBeNull();
   });
 });

--- a/ee/workspace/src/services/enrichmentService.ts
+++ b/ee/workspace/src/services/enrichmentService.ts
@@ -1,4 +1,4 @@
-// LLM enrichment pass (dev-preview; per-org content flag).
+// LLM enrichment pass (per-org content flag).
 //
 // Per extracted file, a single cheap-model call infers: document type, the
 // project the CONTENT belongs to, a document date, and person/org entities.
@@ -25,6 +25,19 @@ import { sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { z } from 'zod';
 import { deriveDeclaredProject } from '../content/projects';
+import { TransientIngestError } from './ingestErrors';
+
+/**
+ * An Anthropic-style APIError we must treat as transient: a 429 (rate cap) or
+ * any 5xx (provider outage). These must back the whole ingest job off with
+ * retry — NOT fail-soft into a null-model row on every pending file (which would
+ * park those files out of the enrichment queue until a manual re-run). Every
+ * other failure (bad JSON, schema miss, 4xx, generic error) stays fail-soft.
+ */
+function isRetryableApiError(err: unknown): err is { status: number } {
+  const status = (err as { status?: unknown } | null | undefined)?.status;
+  return typeof status === 'number' && (status === 429 || status >= 500);
+}
 
 export interface AnthropicLike {
   messages: {
@@ -126,7 +139,12 @@ export function createEnrichmentService(db: WorkspaceDatabase, deps: EnrichmentD
       });
       const raw = res.content.find((c) => c.type === 'text')?.text ?? '';
       return resultSchema.parse(extractJson(raw, 'workspace-enrich'));
-    } catch {
+    } catch (err) {
+      // Rate cap / provider outage must back the job off (the runner releases it
+      // with backoff), not burn a null-model row into every pending file.
+      if (isRetryableApiError(err)) {
+        throw new TransientIngestError(`enrich_provider_${err.status}`, { cause: err });
+      }
       return null; // fail-soft: an LLM/parse hiccup never breaks the batch
     }
   }

--- a/ee/workspace/src/services/filingService.ts
+++ b/ee/workspace/src/services/filingService.ts
@@ -1,4 +1,4 @@
-// Classify-one-email filing pipeline (dev-preview; per-org content flag).
+// Classify-one-email filing pipeline (per-org content flag).
 //
 // Confidence rules (fixed, deterministic — never a vibe):
 //   HIGH — a strong entity (po/wdr/invoice/permit) in the email hits the
@@ -49,7 +49,17 @@ function displayEntity(type: string, valueNorm: string): string {
 export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
   const d = db;
 
-  async function unfiledEmails(orgId: string, groupIds: string[] = []): Promise<Array<{
+  /**
+   * Every unfiled, visible .eml in the org — or, when `fileIndexId` is given,
+   * just that one row. The single-file form exists because the /client match
+   * path resolves ONE id per pane open: scanning the org's whole unfiled list
+   * to `.find()` it is O(estate) for an O(1) question. Both forms run the
+   * identical predicate, so the visibility/fileability semantics cannot drift
+   * between them.
+   */
+  async function unfiledEmails(
+    orgId: string, groupIds: string[] = [], fileIndexId?: string,
+  ): Promise<Array<{
     id: string; rel_path: string; name: string; email_meta: FilingRecord['emailMeta'];
   }>> {
     const rows = await d.execute(sql`
@@ -61,12 +71,19 @@ export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
         AND fi.deleted_at IS NULL
         AND fi.is_dir = false
         AND fi.ext = 'eml'
+        ${fileIndexId === undefined ? sql`` : sql`AND fi.id = ${fileIndexId}`}
         AND ${visibleSourcePredicateSql(sql, groupIds)}
       ORDER BY fi.rel_path
     `) as unknown as Array<{
       id: string; rel_path: string; name: string; email_meta: FilingRecord['emailMeta'];
     }>;
     return rows.filter((r) => deriveDeclaredProject(r.rel_path) === null);
+  }
+
+  /** One unfiled, visible email; null when unknown, tombstoned, hidden by the
+   * caller's group claims, not an .eml, or already filed under a project path. */
+  async function unfiledEmail(orgId: string, fileIndexId: string, groupIds: string[]) {
+    return (await unfiledEmails(orgId, groupIds, fileIndexId))[0] ?? null;
   }
 
   async function filingRowsFor(orgId: string, fileIds: string[]): Promise<Map<string, Record<string, unknown>>> {
@@ -77,6 +94,10 @@ export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
              decided_project_key
       FROM workspace_email_filings
       WHERE org_id = ${orgId}
+        -- Semantic no-op (the caller maps by id anyway), but the single-file
+        -- callers — get/classify/assign — must not scan the org's filing table
+        -- to read back one row.
+        ${fileIds.length === 1 ? sql`AND file_index_id = ${fileIds[0]}` : sql``}
     `) as unknown as Array<Record<string, unknown> & { file_index_id: string }>;
     return new Map(rows.map((r) => [r.file_index_id, r]));
   }
@@ -109,12 +130,23 @@ export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
     },
 
     /**
+     * One filing record by file id, under the caller's visibility. Same null
+     * conditions as `classify` — unknown, tombstoned, hidden, not an .eml, or
+     * already filed under a project path — and never creates a row.
+     */
+    async get(orgId: string, fileIndexId: string, groupIds: string[] = []): Promise<FilingRecord | null> {
+      const email = await unfiledEmail(orgId, fileIndexId, groupIds);
+      if (!email) return null;
+      const filings = await filingRowsFor(orgId, [fileIndexId]);
+      return toRecord(email, filings.get(fileIndexId));
+    },
+
+    /**
      * Classify one unfiled email. Returns null when the file is unknown,
      * tombstoned, hidden, not an email, or not unfiled (404 at the route).
      */
     async classify(orgId: string, fileIndexId: string, groupIds: string[] = []): Promise<FilingRecord | null> {
-      const emails = await unfiledEmails(orgId, groupIds);
-      const email = emails.find((e) => e.id === fileIndexId);
+      const email = await unfiledEmail(orgId, fileIndexId, groupIds);
       if (!email) return null;
 
       // Deterministic entity order: strongest lead types first, then value —
@@ -242,6 +274,15 @@ export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
     /**
      * One-click (re)assign. Confirms when the choice matches the suggestion,
      * reassigns otherwise. Returns null for unknown file/filing or project.
+     *
+     * The visibility gate is enforced BEFORE and INSIDE the write, never after
+     * it. That ordering is the whole point: this is the one mutating path an
+     * end user drives, and a decision written onto a file the caller may not
+     * see is a real write even if the response is a 404. The pre-check makes
+     * the common case cheap and also covers fileability (already filed under a
+     * project path — a JS-side path rule that cannot live in SQL); the EXISTS
+     * in the UPDATE makes the visibility half atomic and true for any future
+     * caller, whatever it checked first.
      */
     async assign(
       orgId: string,
@@ -250,6 +291,8 @@ export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
       decidedLabel: string | null,
       groupIds: string[] = [],
     ): Promise<FilingRecord | null> {
+      const email = await unfiledEmail(orgId, fileIndexId, groupIds);
+      if (!email) return null;
       const project = (await d.execute(sql`
         SELECT project_key FROM workspace_projects
         WHERE org_id = ${orgId} AND project_key = ${projectKey}
@@ -265,12 +308,18 @@ export function createFilingService(db: WorkspaceDatabase, deps: FilingDeps) {
           decided_at = now(),
           updated_at = now()
         WHERE org_id = ${orgId} AND file_index_id = ${fileIndexId}
+          AND EXISTS (
+            SELECT 1
+            FROM workspace_file_index fi
+            JOIN workspace_sources s ON s.id = fi.source_id AND s.org_id = fi.org_id
+            WHERE fi.id = ${fileIndexId}
+              AND fi.org_id = ${orgId}
+              AND fi.deleted_at IS NULL
+              AND ${visibleSourcePredicateSql(sql, groupIds)}
+          )
         RETURNING file_index_id
       `) as unknown as Array<{ file_index_id: string }>;
       if (updated.length === 0) return null;
-      const emails = await unfiledEmails(orgId, groupIds);
-      const email = emails.find((e) => e.id === fileIndexId);
-      if (!email) return null;
       const filings = await filingRowsFor(orgId, [fileIndexId]);
       return toRecord(email, filings.get(fileIndexId));
     },

--- a/ee/workspace/src/services/ingestErrors.ts
+++ b/ee/workspace/src/services/ingestErrors.ts
@@ -1,0 +1,24 @@
+// Ingest error taxonomy (W3). Two classes of per-file failure during a content
+// ingest run:
+//
+//  - TRANSIENT: the source is likely down (SMB read refused, embedder rate-limit
+//    or non-200). Retrying the same file later is the right move, so the runner
+//    must NOT persist a failed/blocked row (which would park the file outside
+//    the pending set) — it aborts the remaining batch and leaves the file fully
+//    pending. Marked by the `transient` brand so it survives being re-thrown /
+//    wrapped across module boundaries.
+//
+//  - PERMANENT (everything else, i.e. any plain Error): the file itself is bad
+//    (extraction/parse failure). The runner records a `failed` row + snapshot so
+//    the file is skipped-not-retried and one broken file cannot wedge the loop.
+export class TransientIngestError extends Error {
+  readonly transient = true as const;
+  constructor(message: string, opts?: { cause?: unknown }) {
+    super(message, opts);
+    this.name = 'TransientIngestError';
+  }
+}
+
+export function isTransientIngestError(e: unknown): e is TransientIngestError {
+  return e instanceof Error && (e as { transient?: boolean }).transient === true;
+}

--- a/ee/workspace/src/services/ingestJobRunner.test.ts
+++ b/ee/workspace/src/services/ingestJobRunner.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createIngestJobRunner, DEFAULT_BATCH, type EnrichRunResult } from './ingestJobRunner';
+import type { IngestJobRow, createIngestJobsService } from './ingestJobsService';
+import type { IngestRunResult } from './contentIngestService';
+import { TransientIngestError } from './ingestErrors';
+
+const ORG = '11111111-1111-1111-1111-111111111111';
+const JOB = '22222222-2222-2222-2222-222222222222';
+
+function makeJob(over: Partial<IngestJobRow> = {}): IngestJobRow {
+  return {
+    id: JOB, orgId: ORG, sourceId: null, crawlRunId: null,
+    trigger: 'manual', phase: 'ingest', status: 'running', force: false,
+    attempts: 0, maxAttempts: 8, nextAttemptAt: new Date('2026-07-19T00:00:00Z'),
+    cursor: null, stats: {}, lastError: null,
+    startedAt: new Date('2026-07-19T00:00:00Z'), finishedAt: null,
+    createdAt: new Date('2026-07-19T00:00:00Z'), updatedAt: new Date('2026-07-19T00:00:00Z'),
+    ...over,
+  };
+}
+
+// A jobs-service double: only the methods the runner touches carry behavior.
+function mockJobs(over: Record<string, unknown> = {}) {
+  const jobs = {
+    claimDue: vi.fn(async () => null as IngestJobRow | null),
+    release: vi.fn(async () => makeJob({ status: 'pending' })),
+    recordProgress: vi.fn(async () => {}),
+    ensureJob: vi.fn(),
+    list: vi.fn(),
+    get: vi.fn(),
+    ...over,
+  };
+  return jobs as unknown as ReturnType<typeof createIngestJobsService> & typeof jobs;
+}
+
+function ingestResult(over: Partial<IngestRunResult> = {}): IngestRunResult {
+  return { processed: 0, remaining: 0, errors: [], transient: null, ...over };
+}
+
+// Clock that walks a fixed sequence and then holds its last value (so a loop
+// that keeps polling after the sequence never spins on an undefined budget).
+function seqClock(values: number[]): () => number {
+  let i = 0;
+  return () => (i < values.length ? values[i++] : values[values.length - 1]);
+}
+
+function baseDeps(over: Record<string, unknown> = {}) {
+  return {
+    jobs: mockJobs(),
+    contentIngest: { run: vi.fn(async () => ingestResult()) },
+    enrichment: { run: vi.fn(async (): Promise<EnrichRunResult> => ({ processed: 0, remaining: 0, errors: [] })) },
+    crosswalk: { run: vi.fn(async () => ({ mined: 0 })) },
+    getSettings: vi.fn(async () => ({ contentEnabled: true })),
+    log: vi.fn(),
+    clock: () => 0,
+    ...over,
+  };
+}
+
+describe('ingestJobRunner.advance', () => {
+  it('no-ops when content is disabled for the org (never claims)', async () => {
+    const deps = baseDeps({ getSettings: vi.fn(async () => ({ contentEnabled: false })) });
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG);
+    expect(res).toEqual({ advanced: false, job: null });
+    expect(deps.jobs.claimDue).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when no job is due', async () => {
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(null);
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG);
+    expect(res).toEqual({ advanced: false, job: null });
+    expect(deps.contentIngest.run).not.toHaveBeenCalled();
+  });
+
+  it('drives ingest → enrich → crosswalk → complete across advance() calls', async () => {
+    const deps = baseDeps();
+    // advance #1: ingest phase drains in one batch.
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'ingest' }));
+    deps.contentIngest.run.mockResolvedValueOnce(ingestResult({ processed: 3, remaining: 0 }));
+    const runner = createIngestJobRunner(deps as never);
+
+    const r1 = await runner.advance(ORG);
+    expect(r1.advanced).toBe(true);
+    expect(deps.contentIngest.run).toHaveBeenCalledWith(ORG, DEFAULT_BATCH, undefined);
+    expect(deps.jobs.recordProgress).toHaveBeenCalledWith(ORG, JOB, {
+      counterPatch: { ingested: 3, ingestErrors: 0 },
+      statsPatch: { remaining: 0 },
+    });
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'phase_complete', nextPhase: 'enrich',
+    });
+
+    // advance #2: enrich phase drains in one batch.
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'enrich' }));
+    deps.enrichment.run.mockResolvedValueOnce({ processed: 2, remaining: 0, errors: [] });
+    const r2 = await runner.advance(ORG);
+    expect(r2.advanced).toBe(true);
+    expect(deps.enrichment.run).toHaveBeenCalledWith(ORG, DEFAULT_BATCH);
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'phase_complete', nextPhase: 'crosswalk',
+    });
+
+    // advance #3: crosswalk recompute then complete.
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'crosswalk' }));
+    const r3 = await runner.advance(ORG);
+    expect(r3.advanced).toBe(true);
+    expect(deps.crosswalk.run).toHaveBeenCalledWith(ORG);
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, { kind: 'complete' });
+  });
+
+  it('passes force + forceSince from the job into the ingest run', async () => {
+    const started = new Date('2026-07-19T12:00:00Z');
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'ingest', force: true, startedAt: started }));
+    deps.contentIngest.run.mockResolvedValueOnce(ingestResult({ processed: 1, remaining: 0 }));
+    const runner = createIngestJobRunner(deps as never);
+    await runner.advance(ORG);
+    expect(deps.contentIngest.run).toHaveBeenCalledWith(ORG, DEFAULT_BATCH, {
+      force: true, forceSince: started,
+    });
+  });
+
+  it('force ingest does NOT phase-complete while the force-aware remaining is > 0', async () => {
+    // A force sweep over an estate larger than one batch: the first batch
+    // re-walks `batch` files (processed 8) but the force-aware remaining still
+    // reports 42 unvisited files, so the phase must NOT complete. Only a later
+    // batch whose force-aware remaining hits 0 phase-completes. This is the
+    // estate-sized-batch convergence bug: before the fix, remaining came from
+    // the non-force snapshot count (already 0) and the job silently completed
+    // after visiting only the first batch.
+    const deps = baseDeps({ clock: seqClock([0, 0, 0, 4000]) });
+    deps.jobs.claimDue.mockResolvedValueOnce(
+      makeJob({ phase: 'ingest', force: true, startedAt: new Date('2026-07-19T00:00:00Z') }),
+    );
+    deps.contentIngest.run
+      .mockResolvedValueOnce(ingestResult({ processed: 8, remaining: 42 }))
+      .mockResolvedValueOnce(ingestResult({ processed: 8, remaining: 0 }));
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG, { budgetMs: 4000 });
+    expect(res.advanced).toBe(true);
+    // Two batches ran; the first (remaining 42) did not complete the phase.
+    expect(deps.contentIngest.run).toHaveBeenCalledTimes(2);
+    // Only ONE phase_complete release — from the batch that reached remaining 0.
+    const releaseCalls = deps.jobs.release.mock.calls as unknown as Array<[string, string, { kind: string }]>;
+    const completeCalls = releaseCalls.filter(([, , rel]) => rel.kind === 'phase_complete');
+    expect(completeCalls).toHaveLength(1);
+    expect(deps.jobs.release).toHaveBeenLastCalledWith(ORG, JOB, {
+      kind: 'phase_complete', nextPhase: 'enrich',
+    });
+  });
+
+  it('force ingest completes the phase when a batch makes no progress (degenerate sweep guard)', async () => {
+    // A force sweep whose batch processes nothing (every file already visited /
+    // wedged) but reports remaining > 0 must not loop across pokes forever:
+    // processed 0 with no transient completes the ingest phase.
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(
+      makeJob({ phase: 'ingest', force: true, startedAt: new Date('2026-07-19T00:00:00Z') }),
+    );
+    deps.contentIngest.run.mockResolvedValueOnce(ingestResult({ processed: 0, remaining: 7 }));
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG);
+    expect(res.advanced).toBe(true);
+    expect(deps.contentIngest.run).toHaveBeenCalledTimes(1);
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'phase_complete', nextPhase: 'enrich',
+    });
+  });
+
+  it('releases transient_error when ingest reports a transient (no progress record)', async () => {
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'ingest' }));
+    deps.contentIngest.run.mockResolvedValueOnce(
+      ingestResult({ processed: 2, remaining: 5, transient: { reason: 'smb_read_refused', abortedAfter: 2 } }),
+    );
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG);
+    expect(res.advanced).toBe(true);
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'transient_error', error: 'smb_read_refused',
+    });
+    expect(deps.jobs.recordProgress).not.toHaveBeenCalled();
+  });
+
+  it('releases transient_error when enrich throws a TransientIngestError', async () => {
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'enrich' }));
+    deps.enrichment.run.mockRejectedValueOnce(new TransientIngestError('enrich_provider_429'));
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG);
+    expect(res.advanced).toBe(true);
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'transient_error', error: 'enrich_provider_429',
+    });
+  });
+
+  it('yields with progress recorded when the budget is exhausted mid-ingest', async () => {
+    const deps = baseDeps({ clock: seqClock([0, 0, 4000]) });
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'ingest' }));
+    deps.contentIngest.run.mockResolvedValueOnce(ingestResult({ processed: 8, remaining: 5 }));
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG, { budgetMs: 4000 });
+    expect(res.advanced).toBe(true);
+    expect(deps.jobs.recordProgress).toHaveBeenCalledWith(ORG, JOB, {
+      counterPatch: { ingested: 8, ingestErrors: 0 },
+      statsPatch: { remaining: 5 },
+    });
+    expect(deps.contentIngest.run).toHaveBeenCalledTimes(1);
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, { kind: 'yield' });
+  });
+
+  it('skips a wedged enrich phase (never-drains) to crosswalk with enrichSkipped', async () => {
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'enrich' }));
+    // Same non-draining result every batch: 3 files processed, all errored,
+    // remaining stuck at 3 (permanently-unclassifiable, model stays NULL).
+    const stuck = {
+      processed: 3, remaining: 3,
+      errors: [
+        { fileIndexId: 'a', relPath: 'a', error: 'x' },
+        { fileIndexId: 'b', relPath: 'b', error: 'x' },
+        { fileIndexId: 'c', relPath: 'c', error: 'x' },
+      ],
+    };
+    deps.enrichment.run.mockResolvedValue(stuck);
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG);
+    expect(res.advanced).toBe(true);
+    // Baseline iteration + trip iteration.
+    expect(deps.enrichment.run).toHaveBeenCalledTimes(2);
+    expect(deps.jobs.recordProgress).toHaveBeenCalledWith(ORG, JOB, {
+      statsPatch: { enrichSkipped: 3 },
+    });
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'phase_complete', nextPhase: 'crosswalk',
+    });
+  });
+
+  it('persists the never-drains baseline across advance() calls (single-batch budget wedge)', async () => {
+    // Budget permits exactly one enrich batch per advance: t0=0, one loop
+    // iteration, then the clock jumps past the budget so the loop exits.
+    const deps = baseDeps({ clock: seqClock([0, 0, 4000]) });
+    const stuck = {
+      processed: 3, remaining: 3,
+      errors: [
+        { fileIndexId: 'a', relPath: 'a', error: 'x' },
+        { fileIndexId: 'b', relPath: 'b', error: 'x' },
+        { fileIndexId: 'c', relPath: 'c', error: 'x' },
+      ],
+    };
+    deps.enrichment.run.mockResolvedValue(stuck);
+    const runner = createIngestJobRunner(deps as never);
+
+    // advance #1: fresh enrich job (no baseline in stats) — one batch runs, the
+    // in-advance guard can't fire yet, so it records the baseline and yields.
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'enrich', stats: {} }));
+    const r1 = await runner.advance(ORG, { budgetMs: 4000 });
+    expect(r1.advanced).toBe(true);
+    expect(deps.enrichment.run).toHaveBeenCalledTimes(1);
+    expect(deps.jobs.recordProgress).toHaveBeenCalledWith(ORG, JOB, {
+      statsPatch: { lastEnrichRemaining: 3 },
+    });
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, { kind: 'yield' });
+
+    // advance #2: same job re-claimed carrying the persisted baseline. The very
+    // first batch makes no net progress (remaining >= baseline, all errored) →
+    // skip to crosswalk with enrichSkipped, WITHOUT a second in-advance batch.
+    deps.jobs.claimDue.mockResolvedValueOnce(
+      makeJob({ phase: 'enrich', stats: { lastEnrichRemaining: 3 } }),
+    );
+    const r2 = await runner.advance(ORG, { budgetMs: 4000 });
+    expect(r2.advanced).toBe(true);
+    expect(deps.enrichment.run).toHaveBeenCalledTimes(2); // exactly one more batch, not a re-burn loop
+    expect(deps.jobs.recordProgress).toHaveBeenCalledWith(ORG, JOB, {
+      statsPatch: { enrichSkipped: 3 },
+    });
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, {
+      kind: 'phase_complete', nextPhase: 'crosswalk',
+    });
+  });
+
+  it('releases fatal_error and does not throw on an unexpected failure', async () => {
+    const deps = baseDeps();
+    deps.jobs.claimDue.mockResolvedValueOnce(makeJob({ phase: 'ingest' }));
+    deps.contentIngest.run.mockRejectedValueOnce(new Error('boom'));
+    const runner = createIngestJobRunner(deps as never);
+    const res = await runner.advance(ORG);
+    expect(res.advanced).toBe(true);
+    expect(deps.jobs.release).toHaveBeenCalledWith(ORG, JOB, expect.objectContaining({
+      kind: 'fatal_error',
+      error: expect.stringContaining('boom'),
+    }));
+  });
+});

--- a/ee/workspace/src/services/ingestJobRunner.ts
+++ b/ee/workspace/src/services/ingestJobRunner.ts
@@ -1,0 +1,208 @@
+// W3: ingestJobRunner — the budgeted, in-request phase pipeline that drives one
+// claimed ingest job through ingest → enrich → crosswalk → complete.
+//
+// There is NO background worker, queue, or timer: advance() is invoked from an
+// authenticated agent/admin request handler (Tasks 5/6). It claims the single
+// due job for the org, works a wall-clock budget in batches, and hands the job
+// back to `pending` so the next request continues it. Because a phase_complete
+// release flips the job back to `pending`, each advance() call carries a job
+// through at most ONE phase; the caller (or the next poke) re-claims it in the
+// next phase.
+//
+// All staleness / due / backoff decisions live in jobsService against the DB
+// clock. The injectable `clock` here bounds ONLY the in-memory work budget and
+// is faked in unit tests; it never enters a persisted timestamp comparison.
+import type { IngestJobRow, createIngestJobsService } from './ingestJobsService';
+import type { IngestRunResult } from './contentIngestService';
+import { isTransientIngestError } from './ingestErrors';
+
+export const DEFAULT_ADVANCE_BUDGET_MS = 4_000;
+export const AGENT_POKE_BUDGET_MS = 3_000;
+export const DEFAULT_BATCH = 8;
+// Kept at 2 (not 4): advance()'s budget is checked only BETWEEN batches, so one
+// batch against a slow SMB share can overrun the poke budget by up to a full
+// batch inside a single GET /crawl-config. The Go agent's crawl-config HTTP
+// client caps that request at 30s (agent/internal/workspaceindex/client.go
+// requestTimeout), and per-file SMB reads are bounded at 8s
+// (WORKSPACE_CONTENT_SMB_TIMEOUT_MS), so 2 files keeps the worst-case overrun
+// comfortably inside the agent's timeout.
+export const AGENT_POKE_BATCH = 2;
+
+/** The enrichment pass's per-run result shape (mirrors enrichmentService.run). */
+export interface EnrichRunResult {
+  processed: number;
+  remaining: number;
+  errors: Array<{ fileIndexId: string; relPath: string; error: string }>;
+}
+
+export interface AdvanceResult {
+  advanced: boolean;
+  job: IngestJobRow | null;
+}
+
+export function createIngestJobRunner(deps: {
+  jobs: ReturnType<typeof createIngestJobsService>;
+  contentIngest: {
+    run(orgId: string, batch: number, opts?: { force?: boolean; forceSince?: Date }): Promise<IngestRunResult>;
+  };
+  enrichment: { run(orgId: string, batch: number): Promise<EnrichRunResult> };
+  crosswalk: { run(orgId: string): Promise<unknown> };
+  getSettings(orgId: string): Promise<{ contentEnabled: boolean }>;
+  log(msg: string): void;
+  clock?: () => number; // injectable for budget tests; default Date.now
+}): { advance(orgId: string, opts?: { budgetMs?: number; batch?: number }): Promise<AdvanceResult> } {
+  const clock = deps.clock ?? Date.now;
+
+  async function advance(
+    orgId: string,
+    opts?: { budgetMs?: number; batch?: number },
+  ): Promise<AdvanceResult> {
+    const budgetMs = opts?.budgetMs ?? DEFAULT_ADVANCE_BUDGET_MS;
+    const batch = opts?.batch ?? DEFAULT_BATCH;
+
+    // 1. Content disabled for this org: any queued job sits pending and
+    //    harmless (it still surfaces on the dashboard). Never claim.
+    const { contentEnabled } = await deps.getSettings(orgId);
+    if (!contentEnabled) return { advanced: false, job: null };
+
+    // 2. Atomically claim the single due job (or reclaim a stale running one).
+    const job = await deps.jobs.claimDue(orgId);
+    if (!job) return { advanced: false, job: null };
+
+    const t0 = clock();
+    // Never-drains tracking for the enrich phase. `prevEnrichRemaining` scopes
+    // to consecutive batches within THIS advance() call; `persistedEnrichBaseline`
+    // (from stats.lastEnrichRemaining, written after each enrich batch) carries
+    // the baseline ACROSS advance() calls, so a budget that permits only one
+    // enrich batch per poke still detects a wedge instead of re-burning LLM
+    // calls forever.
+    let prevEnrichRemaining = Number.POSITIVE_INFINITY;
+    const rawEnrichBaseline = job.stats?.lastEnrichRemaining;
+    const persistedEnrichBaseline =
+      typeof rawEnrichBaseline === 'number' ? rawEnrichBaseline : Number.POSITIVE_INFINITY;
+
+    try {
+      // 3. Work the current phase in batches until the budget is spent. Every
+      //    phase transition (or terminal state) releases and returns, so the
+      //    phase is invariant across this loop's lifetime.
+      while (clock() - t0 < budgetMs) {
+        if (job.phase === 'ingest') {
+          const r = await deps.contentIngest.run(
+            orgId,
+            batch,
+            job.force ? { force: true, forceSince: job.startedAt ?? undefined } : undefined,
+          );
+          if (r.transient) {
+            // Source likely down: back the whole job off, leave files pending.
+            deps.log(`ingest job ${job.id}: transient (${r.transient.reason}) — backing off`);
+            const released = await deps.jobs.release(orgId, job.id, {
+              kind: 'transient_error',
+              error: r.transient.reason,
+            });
+            return { advanced: true, job: released };
+          }
+          await deps.jobs.recordProgress(orgId, job.id, {
+            // ingested/ingestErrors are running totals — accumulate them so a
+            // multi-batch ingest doesn't reset to the last batch's counts.
+            counterPatch: { ingested: r.processed, ingestErrors: r.errors.length },
+            statsPatch: { remaining: r.remaining },
+          });
+          if (r.remaining === 0) {
+            const released = await deps.jobs.release(orgId, job.id, {
+              kind: 'phase_complete',
+              nextPhase: 'enrich',
+            });
+            return { advanced: true, job: released };
+          }
+          // Degenerate-sweep guard: a batch that advanced nothing (processed 0)
+          // and is not a source-down transient (those return above) can never
+          // progress on a re-poke — the same files would be re-selected forever.
+          // Complete the phase so a force/reingest job whose remaining is
+          // non-zero yet unworkable can't loop across pokes. (The r.remaining===0
+          // check above already handles the normal drained case.)
+          if (r.processed === 0 && !r.transient) {
+            deps.log(`ingest job ${job.id}: no progress this batch — completing ingest phase`);
+            const released = await deps.jobs.release(orgId, job.id, {
+              kind: 'phase_complete',
+              nextPhase: 'enrich',
+            });
+            return { advanced: true, job: released };
+          }
+          continue;
+        }
+
+        if (job.phase === 'enrich') {
+          const r = await deps.enrichment.run(orgId, batch);
+          if (r.remaining === 0) {
+            const released = await deps.jobs.release(orgId, job.id, {
+              kind: 'phase_complete',
+              nextPhase: 'crosswalk',
+            });
+            return { advanced: true, job: released };
+          }
+          // Never-drains guard: a batch that "processed" files without shrinking
+          // the pending set, where every processed file errored, is wedged on
+          // permanently-unclassifiable rows (their enrichment row stays
+          // model=NULL, so they never leave the pending predicate). Skipping the
+          // phase keeps the job moving; those files stay re-enrichable by the
+          // legacy admin loop, by design. We compare the fresh batch against
+          // BOTH baselines — the in-advance one (consecutive batches this call)
+          // and the persisted one (across advance() calls) — so single-batch
+          // budgets still trip the guard instead of re-burning LLM calls.
+          const madeNoProgress = r.processed > 0 && r.errors.length === r.processed;
+          if (
+            madeNoProgress &&
+            (r.remaining >= prevEnrichRemaining || r.remaining >= persistedEnrichBaseline)
+          ) {
+            deps.log(`enrich job ${job.id}: ${r.remaining} unclassifiable — skipping to crosswalk`);
+            await deps.jobs.recordProgress(orgId, job.id, {
+              statsPatch: { enrichSkipped: r.remaining },
+            });
+            const released = await deps.jobs.release(orgId, job.id, {
+              kind: 'phase_complete',
+              nextPhase: 'crosswalk',
+            });
+            return { advanced: true, job: released };
+          }
+          // Persist the baseline so the NEXT advance() can detect a wedge even
+          // when this poke only had budget for a single enrich batch.
+          await deps.jobs.recordProgress(orgId, job.id, {
+            statsPatch: { lastEnrichRemaining: r.remaining },
+          });
+          prevEnrichRemaining = r.remaining;
+          continue;
+        }
+
+        // phase === 'crosswalk': recompute the org's crosswalk once, then done.
+        await deps.crosswalk.run(orgId);
+        const released = await deps.jobs.release(orgId, job.id, { kind: 'complete' });
+        return { advanced: true, job: released };
+      }
+
+      // 4. Budget spent with work still pending — hand the job back to pending.
+      const released = await deps.jobs.release(orgId, job.id, { kind: 'yield' });
+      return { advanced: true, job: released };
+    } catch (e) {
+      // 5. Any throw is contained: callers are request handlers and must never
+      //    see a 500 from ingest advancement. A TransientIngestError (e.g. the
+      //    enrich pass hitting a provider rate cap) backs off; anything else
+      //    fails the job so one bad state can't wedge the loop forever.
+      if (isTransientIngestError(e)) {
+        deps.log(`ingest job ${job.id}: transient throw (${e.message}) — backing off`);
+        const released = await deps.jobs.release(orgId, job.id, {
+          kind: 'transient_error',
+          error: e.message,
+        });
+        return { advanced: true, job: released };
+      }
+      deps.log(`ingest job ${job.id}: fatal — ${String(e).slice(0, 500)}`);
+      const released = await deps.jobs.release(orgId, job.id, {
+        kind: 'fatal_error',
+        error: String(e).slice(0, 500),
+      });
+      return { advanced: true, job: released };
+    }
+  }
+
+  return { advance };
+}

--- a/ee/workspace/src/services/ingestJobsService.test.ts
+++ b/ee/workspace/src/services/ingestJobsService.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkspaceDatabase } from '../hostTypes';
+import {
+  createIngestJobsService, backoffMs, ORG_WIDE_SOURCE_KEY,
+  STALE_JOB_MINUTES, BACKOFF_BASE_MS, BACKOFF_CAP_MS,
+} from './ingestJobsService';
+
+const ORG = '11111111-1111-1111-1111-111111111111';
+const JOB = '22222222-2222-2222-2222-222222222222';
+
+// Render the static SQL text of a drizzle `sql` template (params drop out —
+// they are not part of the fragment we assert on). Mirrors the sqlText walk in
+// crawlRunsService.test.ts.
+function sqlText(value: unknown): string {
+  if (Array.isArray(value)) return value.map(sqlText).join('');
+  if (!value || typeof value !== 'object') return '';
+  const c = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Array.isArray(c.value) && c.value.every((p) => typeof p === 'string')
+    ? c.value.join('')
+    : '';
+  return own + (c.queryChunks ?? []).map(sqlText).join('');
+}
+
+// Flatten the bound param values of a drizzle SQL object.
+function boundValues(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => (item && typeof item === 'object' ? boundValues(item) : [item]));
+  }
+  if (!value || typeof value !== 'object') return [];
+  const candidate = value as { value?: unknown; queryChunks?: unknown[] };
+  const own = Object.prototype.hasOwnProperty.call(candidate, 'value')
+    ? (Array.isArray(candidate.value) ? candidate.value : [candidate.value])
+    : [];
+  return [
+    ...own,
+    ...(candidate.queryChunks ?? []).flatMap((item) =>
+      (item && typeof item === 'object' ? boundValues(item) : [item])),
+  ];
+}
+
+function rawJob(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: JOB, org_id: ORG, source_id: null, crawl_run_id: null,
+    trigger: 'manual', phase: 'ingest', status: 'running', force: false,
+    attempts: 0, max_attempts: 8, next_attempt_at: new Date('2026-07-19T00:00:00Z'),
+    cursor: null, stats: {}, last_error: null,
+    started_at: new Date('2026-07-19T00:00:00Z'), finished_at: null,
+    created_at: new Date('2026-07-19T00:00:00Z'), updated_at: new Date('2026-07-19T00:00:00Z'),
+    ...over,
+  };
+}
+
+function makeDb(results: unknown[][] = []) {
+  const calls: unknown[] = [];
+  let i = 0;
+  const db = {
+    execute: vi.fn(async (q: unknown) => { calls.push(q); return results[i++] ?? []; }),
+  };
+  return { db: db as unknown as WorkspaceDatabase, calls, raw: db };
+}
+
+describe('ingestJobsService', () => {
+  it('exports the produced constants verbatim', () => {
+    expect(ORG_WIDE_SOURCE_KEY).toBe('00000000-0000-0000-0000-000000000000');
+    expect(STALE_JOB_MINUTES).toBe(5);
+    expect(BACKOFF_BASE_MS).toBe(30_000);
+    expect(BACKOFF_CAP_MS).toBe(1_800_000);
+  });
+
+  it('backoffMs doubles per attempt and caps at 30 minutes', () => {
+    expect(backoffMs(1)).toBe(30_000);
+    expect(backoffMs(2)).toBe(60_000);
+    expect(backoffMs(5)).toBe(480_000);
+    expect(backoffMs(10)).toBe(1_800_000);
+  });
+
+  it('release yield → pending, next_attempt_at now(), guarded on running', async () => {
+    const h = makeDb([[rawJob({ status: 'pending' })]]);
+    const row = await createIngestJobsService(h.db).release(ORG, JOB, { kind: 'yield' });
+    const text = sqlText(h.calls[0]);
+    expect(text).toContain("status = 'pending'");
+    expect(text).toContain('next_attempt_at = now()');
+    expect(text).toContain('updated_at = now()');
+    expect(text).toContain("status = 'running'"); // WHERE guard
+    expect(row?.status).toBe('pending');
+  });
+
+  it('release phase_complete → pending, phase set, cursor null, attempts reset', async () => {
+    const h = makeDb([[rawJob({ status: 'pending', phase: 'enrich', attempts: 0 })]]);
+    await createIngestJobsService(h.db).release(ORG, JOB, { kind: 'phase_complete', nextPhase: 'enrich' });
+    const text = sqlText(h.calls[0]);
+    expect(text).toContain("status = 'pending'");
+    expect(text).toContain('phase =');
+    expect(text).toContain('cursor = NULL');
+    expect(text).toContain('attempts = 0');
+    expect(text).toContain('next_attempt_at = now()');
+    expect(boundValues(h.calls[0])).toContain('enrich');
+  });
+
+  it('release complete → complete, finished_at now()', async () => {
+    const h = makeDb([[rawJob({ status: 'complete' })]]);
+    await createIngestJobsService(h.db).release(ORG, JOB, { kind: 'complete' });
+    const text = sqlText(h.calls[0]);
+    expect(text).toContain("status = 'complete'");
+    expect(text).toContain('finished_at = now()');
+  });
+
+  it('release fatal_error → failed, finished_at now(), records error', async () => {
+    const h = makeDb([[rawJob({ status: 'failed' })]]);
+    await createIngestJobsService(h.db).release(ORG, JOB, { kind: 'fatal_error', error: 'boom' });
+    const text = sqlText(h.calls[0]);
+    expect(text).toContain("status = 'failed'");
+    expect(text).toContain('last_error =');
+    expect(text).toContain('finished_at = now()');
+    expect(boundValues(h.calls[0])).toContain('boom');
+  });
+
+  it('release transient_error (attempts+1 < max) → pending with backoff', async () => {
+    const h = makeDb([
+      [{ attempts: 0, max_attempts: 8 }],          // status/attempts probe
+      [rawJob({ status: 'pending', attempts: 1 })], // UPDATE returning
+    ]);
+    const row = await createIngestJobsService(h.db).release(ORG, JOB, { kind: 'transient_error', error: 'net' });
+    expect(h.raw.execute).toHaveBeenCalledTimes(2);
+    const upd = sqlText(h.calls[1]);
+    expect(upd).toContain("status = 'pending'");
+    expect(upd).toContain('next_attempt_at = now() + (');
+    expect(upd).toContain('attempts =');
+    // backoffMs(1) === 30_000 must be the bound delay
+    expect(boundValues(h.calls[1])).toContain(30_000);
+    expect(row?.attempts).toBe(1);
+  });
+
+  it('release transient_error (attempts+1 >= max) → failed, finished_at now()', async () => {
+    const h = makeDb([
+      [{ attempts: 7, max_attempts: 8 }],
+      [rawJob({ status: 'failed', attempts: 8 })],
+    ]);
+    await createIngestJobsService(h.db).release(ORG, JOB, { kind: 'transient_error', error: 'net' });
+    const upd = sqlText(h.calls[1]);
+    expect(upd).toContain("status = 'failed'");
+    expect(upd).toContain('finished_at = now()');
+  });
+
+  it('release transient_error returns null (no UPDATE) when the job is not running', async () => {
+    const h = makeDb([[]]); // probe finds no running row
+    const row = await createIngestJobsService(h.db).release(ORG, JOB, { kind: 'transient_error', error: 'x' });
+    expect(row).toBeNull();
+    expect(h.raw.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('release returns null when the guarded UPDATE touches zero rows', async () => {
+    const h = makeDb([[]]);
+    expect(await createIngestJobsService(h.db).release(ORG, JOB, { kind: 'yield' })).toBeNull();
+  });
+
+  it('claimDue emits a single atomic claim with FOR UPDATE SKIP LOCKED', async () => {
+    const h = makeDb([[rawJob({ status: 'running' })]]);
+    const row = await createIngestJobsService(h.db).claimDue(ORG);
+    const text = sqlText(h.calls[0]);
+    expect(text).toContain('FOR UPDATE SKIP LOCKED');
+    expect(text).toContain("status = 'running'");
+    expect(text).toContain('next_attempt_at <= now()');
+    expect(text).toContain("interval '1 minute'"); // stale reclaim, scaled by the constant
+    expect(boundValues(h.calls[0])).toContain(STALE_JOB_MINUTES); // interpolated, not a literal
+    expect(row?.id).toBe(JOB);
+  });
+
+  it('claimDue returns null when nothing is due', async () => {
+    const h = makeDb([[]]);
+    expect(await createIngestJobsService(h.db).claimDue(ORG)).toBeNull();
+  });
+
+  it('recordProgress merges stats, sets cursor, and heartbeats updated_at', async () => {
+    const h = makeDb([[]]);
+    await createIngestJobsService(h.db).recordProgress(ORG, JOB, { cursor: 'p2', statsPatch: { seen: 3 } });
+    const text = sqlText(h.calls[0]);
+    expect(text).toContain('updated_at = now()');
+    expect(text).toContain('cursor =');
+    expect(text).toContain('stats = stats ||');
+    expect(boundValues(h.calls[0])).toEqual(expect.arrayContaining([ORG, JOB, 'p2']));
+  });
+
+  it('recordProgress accumulates counterPatch keys in SQL while overwrite-merging statsPatch', async () => {
+    const h = makeDb([[]]);
+    await createIngestJobsService(h.db).recordProgress(ORG, JOB, {
+      counterPatch: { ingested: 3, ingestErrors: 1 },
+      statsPatch: { remaining: 5 },
+    });
+    const text = sqlText(h.calls[0]);
+    // statsPatch keeps overwrite-merge...
+    expect(text).toContain('stats || ');
+    // ...while each counterPatch key accumulates COALESCE(current,0)+delta via jsonb_set.
+    expect(text).toContain('jsonb_set(');
+    expect(text).toContain('COALESCE((stats->>');
+    expect(text).toContain('::bigint, 0) +');
+    expect(text).toContain('updated_at = now()');
+    // both counter keys and their deltas are bound params (no literal injection).
+    expect(boundValues(h.calls[0])).toEqual(
+      expect.arrayContaining([ORG, JOB, 'ingested', 'ingestErrors', 3, 1]),
+    );
+  });
+
+  it('list clamps the limit to [1,50] and orders newest first', async () => {
+    const wide = makeDb([[]]);
+    await createIngestJobsService(wide.db).list(ORG, 999);
+    expect(sqlText(wide.calls[0])).toContain('ORDER BY created_at DESC');
+    expect(boundValues(wide.calls[0])).toContain(50);
+
+    const narrow = makeDb([[]]);
+    await createIngestJobsService(narrow.db).list(ORG, 0);
+    expect(boundValues(narrow.calls[0])).toContain(1);
+  });
+
+  it('ensureJob returns created:true when the insert lands a row', async () => {
+    const h = makeDb([[rawJob({ status: 'pending' })]]);
+    const res = await createIngestJobsService(h.db).ensureJob(ORG, { trigger: 'manual' });
+    expect(res.created).toBe(true);
+    expect(res.job.id).toBe(JOB);
+    expect(sqlText(h.calls[0])).toContain('WHERE NOT EXISTS');
+  });
+
+  it('ensureJob returns the existing live job when the insert is skipped', async () => {
+    const h = makeDb([[], [rawJob({ status: 'running', force: false })]]);
+    const res = await createIngestJobsService(h.db).ensureJob(ORG, { trigger: 'manual' });
+    expect(res.created).toBe(false);
+    expect(res.job.id).toBe(JOB);
+  });
+
+  it('ensureJob force-upgrades a live non-force job', async () => {
+    const h = makeDb([
+      [],                                              // insert skipped
+      [rawJob({ status: 'running', force: false })],   // existing live job
+      [rawJob({ status: 'running', force: true })],    // upgraded
+    ]);
+    const res = await createIngestJobsService(h.db).ensureJob(ORG, { trigger: 'reingest', force: true });
+    expect(res.created).toBe(false);
+    expect(res.job.force).toBe(true);
+    expect(h.raw.execute).toHaveBeenCalledTimes(3);
+    expect(sqlText(h.calls[2])).toContain('force = true');
+  });
+
+  it('get returns null when the row is absent', async () => {
+    const h = makeDb([[]]);
+    expect(await createIngestJobsService(h.db).get(ORG, JOB)).toBeNull();
+  });
+});

--- a/ee/workspace/src/services/ingestJobsService.ts
+++ b/ee/workspace/src/services/ingestJobsService.ts
@@ -1,0 +1,319 @@
+// W3: ingestJobsService — the in-request state machine behind productized
+// ingest. There is NO background worker: every advancement (claim → work a
+// budget → release) runs inside an authenticated request (see the runner in a
+// later task). All timestamp math uses the DATABASE clock (now()); host clocks
+// never enter a comparison that decides which job is due or stale.
+//
+// Structure mirrors crawlRunsService.ts: a factory over the org-scoped Drizzle
+// handle, raw `sql` fragments, and an explicit org_id in every WHERE (belt to
+// RLS's suspenders). The one-live-job-per-(org, source) invariant is enforced
+// by the partial unique index wsp_ingest_jobs_one_active_idx — ensureJob works
+// with that index, it does not re-check it in application code.
+import { sql } from 'drizzle-orm';
+import type { WorkspaceDatabase } from '../hostTypes';
+import type { IngestTrigger, IngestPhase, IngestJobStatus } from '../schema/ingestJobs';
+
+/** source_id IS NULL (org-wide) collapses to this key in the partial unique index. */
+export const ORG_WIDE_SOURCE_KEY = '00000000-0000-0000-0000-000000000000';
+/** A 'running' job un-heartbeated this long is presumed dead and reclaimable.
+ *  claimDue interpolates this constant into its stale-reclaim interval. */
+export const STALE_JOB_MINUTES = 5;
+export const BACKOFF_BASE_MS = 30_000;
+export const BACKOFF_CAP_MS = 1_800_000;
+
+/** Deterministic exponential backoff (no jitter): min(BASE * 2**(attempts-1), CAP). */
+export function backoffMs(attempts: number): number {
+  const raw = BACKOFF_BASE_MS * 2 ** (attempts - 1);
+  return Math.min(raw, BACKOFF_CAP_MS);
+}
+
+export interface IngestJobRow {
+  id: string;
+  orgId: string;
+  sourceId: string | null;
+  crawlRunId: string | null;
+  trigger: IngestTrigger;
+  phase: IngestPhase;
+  status: IngestJobStatus;
+  force: boolean;
+  attempts: number;
+  maxAttempts: number;
+  nextAttemptAt: Date;
+  cursor: string | null;
+  stats: Record<string, unknown>;
+  lastError: string | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type ReleaseOutcome =
+  | { kind: 'yield' }
+  | { kind: 'phase_complete'; nextPhase: IngestPhase }
+  | { kind: 'complete' }
+  | { kind: 'transient_error'; error: string }
+  | { kind: 'fatal_error'; error: string };
+
+type Raw = Record<string, unknown>;
+
+function rawRows(res: unknown): Raw[] {
+  return res as unknown as Raw[];
+}
+
+function firstRaw(res: unknown): Raw | null {
+  return rawRows(res)[0] ?? null;
+}
+
+// Raw `sql`.execute() returns unmapped driver values: timestamptz comes back as
+// a string (int/bool/jsonb are already native), so timestamps are coerced to
+// Date here to honor the IngestJobRow contract.
+function toDate(v: unknown): Date {
+  return v instanceof Date ? v : new Date(v as string);
+}
+function toDateOrNull(v: unknown): Date | null {
+  return v == null ? null : toDate(v);
+}
+
+function mapRow(r: Raw): IngestJobRow {
+  return {
+    id: r.id as string,
+    orgId: r.org_id as string,
+    sourceId: (r.source_id as string | null) ?? null,
+    crawlRunId: (r.crawl_run_id as string | null) ?? null,
+    trigger: r.trigger as IngestTrigger,
+    phase: r.phase as IngestPhase,
+    status: r.status as IngestJobStatus,
+    force: r.force as boolean,
+    attempts: Number(r.attempts),
+    maxAttempts: Number(r.max_attempts),
+    nextAttemptAt: toDate(r.next_attempt_at),
+    cursor: (r.cursor as string | null) ?? null,
+    stats: (r.stats as Record<string, unknown>) ?? {},
+    lastError: (r.last_error as string | null) ?? null,
+    startedAt: toDateOrNull(r.started_at),
+    finishedAt: toDateOrNull(r.finished_at),
+    createdAt: toDate(r.created_at),
+    updatedAt: toDate(r.updated_at),
+  };
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === '23505';
+}
+
+export function createIngestJobsService(db: WorkspaceDatabase) {
+  const d = db;
+
+  async function ensureJob(
+    orgId: string,
+    opts: { sourceId?: string | null; crawlRunId?: string | null; trigger: IngestTrigger; force?: boolean },
+  ): Promise<{ job: IngestJobRow; created: boolean }> {
+    const sourceId = opts.sourceId ?? null;
+    const crawlRunId = opts.crawlRunId ?? null;
+    const force = opts.force ?? false;
+
+    // The partial unique index is not expressible as ON CONFLICT (partial
+    // predicate), so we INSERT ... WHERE NOT EXISTS and fall back to a select.
+    // A concurrent racer that slips past NOT EXISTS is caught by the index
+    // (23505) and lands in the same fallback. Bounded retry covers the rare
+    // case where the live job completes between our skip and our select.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      let inserted: Raw | null = null;
+      try {
+        inserted = firstRaw(await d.execute(sql`
+          INSERT INTO workspace_ingest_jobs (org_id, source_id, crawl_run_id, trigger, force)
+          SELECT ${orgId}::uuid, ${sourceId}::uuid, ${crawlRunId}::uuid,
+                 ${opts.trigger}::workspace_ingest_trigger, ${force}
+          WHERE NOT EXISTS (
+            SELECT 1 FROM workspace_ingest_jobs
+            WHERE org_id = ${orgId}
+              AND COALESCE(source_id, ${ORG_WIDE_SOURCE_KEY}::uuid)
+                  = COALESCE(${sourceId}::uuid, ${ORG_WIDE_SOURCE_KEY}::uuid)
+              AND status IN ('pending', 'running')
+          )
+          RETURNING *`));
+      } catch (err) {
+        if (!isUniqueViolation(err)) throw err;
+        inserted = null;
+      }
+      if (inserted) return { job: mapRow(inserted), created: true };
+
+      const existingRaw = firstRaw(await d.execute(sql`
+        SELECT * FROM workspace_ingest_jobs
+        WHERE org_id = ${orgId}
+          AND COALESCE(source_id, ${ORG_WIDE_SOURCE_KEY}::uuid)
+              = COALESCE(${sourceId}::uuid, ${ORG_WIDE_SOURCE_KEY}::uuid)
+          AND status IN ('pending', 'running')
+        ORDER BY created_at
+        LIMIT 1`));
+      if (!existingRaw) continue; // live job vanished mid-race — retry the insert
+
+      const existing = mapRow(existingRaw);
+      if (force && !existing.force) {
+        // A re-ingest request upgrades a live job to force in place.
+        const upgraded = firstRaw(await d.execute(sql`
+          UPDATE workspace_ingest_jobs SET force = true, updated_at = now()
+          WHERE org_id = ${orgId} AND id = ${existing.id}
+          RETURNING *`));
+        if (!upgraded) continue; // job completed under us — retry
+        return { job: mapRow(upgraded), created: false };
+      }
+      return { job: existing, created: false };
+    }
+    throw new Error('ensureJob: could not settle the active ingest job');
+  }
+
+  async function claimDue(orgId: string): Promise<IngestJobRow | null> {
+    // Single-statement atomic claim. FOR UPDATE SKIP LOCKED lets concurrent
+    // requests each grab a distinct due job without an advisory lock. Budgets
+    // are ≤ ~5s, so a 'running' row older than 5 minutes is a dead holder.
+    const r = firstRaw(await d.execute(sql`
+      UPDATE workspace_ingest_jobs
+      SET status = 'running', started_at = COALESCE(started_at, now()), updated_at = now()
+      WHERE id = (
+        SELECT id FROM workspace_ingest_jobs
+        WHERE org_id = ${orgId} AND (
+          (status = 'pending' AND next_attempt_at <= now())
+          OR (status = 'running' AND updated_at < now() - (${STALE_JOB_MINUTES} * interval '1 minute'))
+        )
+        ORDER BY created_at
+        LIMIT 1
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING *`));
+    return r ? mapRow(r) : null;
+  }
+
+  async function recordProgress(
+    orgId: string,
+    jobId: string,
+    patch: {
+      cursor?: string | null;
+      /** Absolute keys: overwrite-merged into stats (e.g. `remaining`). */
+      statsPatch?: Record<string, unknown>;
+      /** Delta keys: accumulated SQL-side so multi-batch advances sum, not
+       *  overwrite (e.g. `ingested`, `ingestErrors`). */
+      counterPatch?: Record<string, number>;
+    },
+  ): Promise<void> {
+    const setCursor = patch.cursor !== undefined;
+    const hasStats = patch.statsPatch !== undefined;
+    const hasCounters = patch.counterPatch !== undefined;
+
+    // Compose one stats mutation expression: statsPatch keys overwrite-merge
+    // (`stats || patch`); each counterPatch key then accumulates via jsonb_set,
+    // reading its base from the ORIGINAL `stats` column so counters are
+    // independent of the overwrite-merge and of one another. A job spanning >1
+    // batch therefore SUMS per-batch deltas instead of showing only the last.
+    let statsExpr = sql`stats`;
+    if (hasStats) {
+      statsExpr = sql`${statsExpr} || ${JSON.stringify(patch.statsPatch)}::jsonb`;
+    }
+    if (hasCounters) {
+      for (const [key, delta] of Object.entries(patch.counterPatch!)) {
+        statsExpr = sql`jsonb_set(${statsExpr}, ARRAY[${key}], to_jsonb(COALESCE((stats->>${key})::bigint, 0) + ${delta}))`;
+      }
+    }
+    const setStats = hasStats || hasCounters;
+    // updated_at is the claim heartbeat, so it bumps on every progress write.
+    await d.execute(sql`
+      UPDATE workspace_ingest_jobs
+      SET updated_at = now()
+        ${setCursor ? sql`, cursor = ${patch.cursor}` : sql``}
+        ${setStats ? sql`, stats = ${statsExpr}` : sql``}
+      WHERE org_id = ${orgId} AND id = ${jobId}`);
+  }
+
+  async function release(
+    orgId: string,
+    jobId: string,
+    outcome: ReleaseOutcome,
+  ): Promise<IngestJobRow | null> {
+    // Every branch guards WHERE status = 'running': 0 rows means someone else
+    // reclaimed this job (stale-takeover) and the caller must drop it.
+    switch (outcome.kind) {
+      case 'yield': {
+        const r = firstRaw(await d.execute(sql`
+          UPDATE workspace_ingest_jobs
+          SET status = 'pending', next_attempt_at = now(), updated_at = now()
+          WHERE org_id = ${orgId} AND id = ${jobId} AND status = 'running'
+          RETURNING *`));
+        return r ? mapRow(r) : null;
+      }
+      case 'phase_complete': {
+        const r = firstRaw(await d.execute(sql`
+          UPDATE workspace_ingest_jobs
+          SET status = 'pending', phase = ${outcome.nextPhase}::workspace_ingest_phase,
+              cursor = NULL, attempts = 0, next_attempt_at = now(), updated_at = now()
+          WHERE org_id = ${orgId} AND id = ${jobId} AND status = 'running'
+          RETURNING *`));
+        return r ? mapRow(r) : null;
+      }
+      case 'complete': {
+        const r = firstRaw(await d.execute(sql`
+          UPDATE workspace_ingest_jobs
+          SET status = 'complete', finished_at = now(), updated_at = now()
+          WHERE org_id = ${orgId} AND id = ${jobId} AND status = 'running'
+          RETURNING *`));
+        return r ? mapRow(r) : null;
+      }
+      case 'fatal_error': {
+        const r = firstRaw(await d.execute(sql`
+          UPDATE workspace_ingest_jobs
+          SET status = 'failed', last_error = ${outcome.error}, finished_at = now(), updated_at = now()
+          WHERE org_id = ${orgId} AND id = ${jobId} AND status = 'running'
+          RETURNING *`));
+        return r ? mapRow(r) : null;
+      }
+      case 'transient_error': {
+        // Read the live attempt count so the pending-vs-failed decision (and the
+        // backoff exponent) is made in JS from backoffMs — the single source of
+        // truth for the schedule. The read is guarded on running so a reclaimed
+        // job releases as null.
+        const probe = firstRaw(await d.execute(sql`
+          SELECT attempts, max_attempts FROM workspace_ingest_jobs
+          WHERE org_id = ${orgId} AND id = ${jobId} AND status = 'running'`));
+        if (!probe) return null;
+        const newAttempts = Number(probe.attempts) + 1;
+        const maxAttempts = Number(probe.max_attempts);
+        if (newAttempts >= maxAttempts) {
+          const r = firstRaw(await d.execute(sql`
+            UPDATE workspace_ingest_jobs
+            SET attempts = ${newAttempts}, last_error = ${outcome.error},
+                status = 'failed', finished_at = now(), updated_at = now()
+            WHERE org_id = ${orgId} AND id = ${jobId} AND status = 'running'
+            RETURNING *`));
+          return r ? mapRow(r) : null;
+        }
+        const delay = backoffMs(newAttempts);
+        const r = firstRaw(await d.execute(sql`
+          UPDATE workspace_ingest_jobs
+          SET attempts = ${newAttempts}, last_error = ${outcome.error}, status = 'pending',
+              next_attempt_at = now() + (${delay} * interval '1 millisecond'), updated_at = now()
+          WHERE org_id = ${orgId} AND id = ${jobId} AND status = 'running'
+          RETURNING *`));
+        return r ? mapRow(r) : null;
+      }
+    }
+  }
+
+  async function list(orgId: string, limit = 50): Promise<IngestJobRow[]> {
+    const clamped = Math.max(1, Math.min(50, Math.floor(limit)));
+    return rawRows(await d.execute(sql`
+      SELECT * FROM workspace_ingest_jobs
+      WHERE org_id = ${orgId}
+      ORDER BY created_at DESC
+      LIMIT ${clamped}`)).map(mapRow);
+  }
+
+  async function get(orgId: string, jobId: string): Promise<IngestJobRow | null> {
+    const r = firstRaw(await d.execute(sql`
+      SELECT * FROM workspace_ingest_jobs
+      WHERE org_id = ${orgId} AND id = ${jobId}
+      LIMIT 1`));
+    return r ? mapRow(r) : null;
+  }
+
+  return { ensureJob, claimDue, recordProgress, release, list, get };
+}

--- a/ee/workspace/src/web/dashboard.test.ts
+++ b/ee/workspace/src/web/dashboard.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildViewModel,
+  WorkspaceDashboard,
+  type DashboardJob,
+  type DashboardSummary,
+} from './dashboard';
+import { defineWorkspaceElements } from './index';
+
+function emptySummary(): DashboardSummary {
+  return {
+    sources: [],
+    ingest: {
+      eligible: 0, extracted: 0, failed: 0, skippedTooLarge: 0,
+      skippedBinary: 0, blockedDlp: 0, pending: 0, enrichPending: 0, chunks: 0,
+    },
+    filing: { unfiled: 0, suggested: 0, confirmed: 0, reassigned: 0, highConfidence: 0, queue: [] },
+    activity: [],
+    projects: [],
+    generatedAt: '2026-07-19T12:00:00.000Z',
+  };
+}
+
+function baseJob(over: Partial<DashboardJob> = {}): DashboardJob {
+  return {
+    id: 'job-1',
+    sourceId: null,
+    trigger: 'manual',
+    phase: 'ingest',
+    status: 'pending',
+    attempts: 0,
+    maxAttempts: 8,
+    nextAttemptAt: '2026-07-19T12:00:00.000Z',
+    lastError: null,
+    startedAt: null,
+    finishedAt: null,
+    ...over,
+  };
+}
+
+describe('buildViewModel', () => {
+  it('carries the ingest funnel through unchanged, and the fixture satisfies the funnel invariant', () => {
+    // pending + extracted + blockedDlp + skippedTooLarge + skippedBinary = eligible
+    // (failed files are also live-content rows but are not part of the
+    // eligible-file partition test fixture below; kept 0 to keep the
+    // invariant legible.)
+    const summary = emptySummary();
+    summary.sources = [{
+      id: 's1', name: 'Alder Creek (dev)', kind: 'smb_share', status: 'active',
+      lastCompleteRunAt: '2026-07-19T11:00:00.000Z', liveFiles: 144, liveDirs: 30,
+      tombstoned: 0, newestSeenAt: '2026-07-19T11:00:00.000Z', activeRun: null,
+    }];
+    summary.ingest = {
+      eligible: 100,
+      extracted: 60,
+      failed: 0,
+      skippedTooLarge: 5,
+      skippedBinary: 5,
+      blockedDlp: 10,
+      pending: 20,
+      enrichPending: 12,
+      chunks: 340,
+    };
+    const { pending, extracted, blockedDlp, skippedTooLarge, skippedBinary, eligible } = summary.ingest;
+    expect(pending + extracted + blockedDlp + skippedTooLarge + skippedBinary).toBe(eligible);
+
+    const vm = buildViewModel(summary, []);
+
+    expect(vm.cards.coverage.funnel).toEqual({
+      eligible: 100, extracted: 60, pending: 20, blockedDlp: 10,
+      skippedTooLarge: 5, skippedBinary: 5, failed: 0, enrichPending: 12, chunks: 340,
+    });
+    expect(vm.cards.coverage.isEmpty).toBe(false);
+  });
+
+  it('renders a "retrying" banner for a pending job with a future next_attempt_at and prior attempts', () => {
+    const now = new Date('2026-07-19T12:00:00.000Z');
+    const job = baseJob({
+      status: 'pending',
+      attempts: 2,
+      maxAttempts: 8,
+      nextAttemptAt: '2026-07-19T12:02:00.000Z',
+      lastError: 'reader: ECONNREFUSED',
+    });
+    const vm = buildViewModel(emptySummary(), [job], now);
+    expect(vm.jobBanner).toBe('retrying (attempt 2/8): reader: ECONNREFUSED');
+  });
+
+  it('renders a "failed after N attempts" banner for a failed job', () => {
+    const job = baseJob({
+      status: 'failed',
+      attempts: 8,
+      maxAttempts: 8,
+      lastError: 'reader: ECONNREFUSED',
+      finishedAt: '2026-07-19T12:10:00.000Z',
+    });
+    const vm = buildViewModel(emptySummary(), [job]);
+    expect(vm.jobBanner).toBe('failed after 8 attempts: reader: ECONNREFUSED');
+  });
+
+  it('does not treat a freshly-queued pending job (0 attempts, due now) as retrying', () => {
+    const now = new Date('2026-07-19T12:00:00.000Z');
+    const job = baseJob({ status: 'pending', attempts: 0, nextAttemptAt: '2026-07-19T11:59:00.000Z' });
+    const vm = buildViewModel(emptySummary(), [job], now);
+    expect(vm.jobBanner).toBeNull();
+  });
+
+  it('surfaces a running-job banner when no job has failed or is retrying', () => {
+    const job = baseJob({ status: 'running', phase: 'enrich', attempts: 1 });
+    const vm = buildViewModel(emptySummary(), [job]);
+    expect(vm.jobBanner).toBe('running: enrich');
+  });
+
+  it('flags every card empty for an all-zero summary and no jobs', () => {
+    const vm = buildViewModel(emptySummary(), []);
+    expect(vm.cards.coverage.isEmpty).toBe(true);
+    expect(vm.cards.unfiledMail.isEmpty).toBe(true);
+    expect(vm.cards.recentActivity.isEmpty).toBe(true);
+    expect(vm.cards.projects.isEmpty).toBe(true);
+    expect(vm.jobBanner).toBeNull();
+    expect(vm.jobsStrip).toEqual([]);
+    expect(vm.generatedAt).toBe('2026-07-19T12:00:00.000Z');
+  });
+
+  it('caps the unfiled queue passthrough and reports counts + high confidence', () => {
+    const summary = emptySummary();
+    summary.filing = {
+      unfiled: 23,
+      suggested: 20,
+      confirmed: 2,
+      reassigned: 1,
+      highConfidence: 9,
+      queue: [
+        { id: 'f1', name: 'a.eml', relPath: 'Inbox/a.eml', suggestedProjectLabel: 'Henderson', confidence: 'high' },
+      ],
+    };
+    const vm = buildViewModel(summary, []);
+    expect(vm.cards.unfiledMail).toEqual({
+      isEmpty: false,
+      count: 23,
+      highConfidence: 9,
+      queue: summary.filing.queue,
+    });
+  });
+
+  it('maps the projects card to filings + crosswalk strength', () => {
+    const summary = emptySummary();
+    summary.projects = [
+      { projectKey: 'henderson', label: 'Henderson Water Main Replacement', filedEmails: 4, crosswalkEntities: 12, evidenceFiles: 30 },
+    ];
+    const vm = buildViewModel(summary, []);
+    expect(vm.cards.projects).toEqual({
+      isEmpty: false,
+      items: [{ projectKey: 'henderson', label: 'Henderson Water Main Replacement', filings: 4, crosswalkStrength: 12 }],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Element-level smoke: registration + one host-context render, mirroring
+// sourcesPage.test's environment/setup (happy-dom). Reaching the DOM only
+// through textContent is the base element's load-bearing rule; the injection
+// case pins it for the ported dashboard too.
+// ---------------------------------------------------------------------------
+
+const ORG_ID = 'org-1';
+
+function pageContext(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    contractVersion: 1,
+    extensionName: 'workspace',
+    path: '/extensions/workspace/dashboard',
+    organizationId: ORG_ID,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function populatedSummary(): DashboardSummary {
+  const summary = emptySummary();
+  summary.sources = [{
+    id: 's1', name: 'Alder Creek (dev)', kind: 'smb_share', status: 'active',
+    lastCompleteRunAt: '2026-07-19T11:00:00.000Z', liveFiles: 144, liveDirs: 30,
+    tombstoned: 0, newestSeenAt: '2026-07-19T11:00:00.000Z', activeRun: null,
+  }];
+  summary.ingest.chunks = 340;
+  return summary;
+}
+
+async function mountDashboard(context: Record<string, unknown> = pageContext()): Promise<WorkspaceDashboard> {
+  const element = document.createElement('workspace-dashboard') as WorkspaceDashboard;
+  document.body.append(element);
+  element.context = context;
+  await element.updateComplete;
+  return element;
+}
+
+describe('workspace-dashboard element', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    defineWorkspaceElements();
+    fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/dashboard/summary')) return jsonResponse(populatedSummary());
+      if (url.includes('/dashboard/jobs')) return jsonResponse({ jobs: [] });
+      return jsonResponse({}, 404);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+  });
+
+  it('registers the workspace-dashboard custom element idempotently', () => {
+    defineWorkspaceElements();
+    expect(customElements.get('workspace-dashboard')).toBe(WorkspaceDashboard);
+  });
+
+  it('reads its org-scoped summary same-origin under the extension namespace', async () => {
+    await mountDashboard();
+    const summaryCall = fetchMock.mock.calls.find(([url]) => String(url).includes('/dashboard/summary'));
+    expect(summaryCall, JSON.stringify(fetchMock.mock.calls)).toBeDefined();
+    const [url, init] = summaryCall as [string, RequestInit];
+    expect(url).toBe(`/api/v1/ext/workspace/dashboard/summary?orgId=${ORG_ID}`);
+    expect(init.credentials).toBe('same-origin');
+  });
+
+  it('renders the coverage card from the fetched summary', async () => {
+    const element = await mountDashboard();
+    const text = element.shadowRoot?.textContent ?? '';
+    expect(text).toContain('Coverage & freshness');
+    expect(text).toContain('Alder Creek (dev)');
+    expect(text).toContain('chunks');
+  });
+
+  it('renders an error and makes no network call for a malformed host context', async () => {
+    const element = await mountDashboard(pageContext({ contractVersion: 2 }));
+    expect(fetchMock).not.toHaveBeenCalled();
+    const alert = element.shadowRoot?.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('invalid host context');
+  });
+});

--- a/ee/workspace/src/web/dashboard.ts
+++ b/ee/workspace/src/web/dashboard.ts
@@ -1,0 +1,594 @@
+/**
+ * <workspace-dashboard> — the org-operator estate dashboard page.
+ *
+ * Ported from the W3 dev-harness element onto the shipped web pipeline
+ * (Plan 05): it extends {@link WorkspaceBaseElement} (Shadow DOM + the shared
+ * stylesheet + the disconnect AbortSignal) and reaches the DOM only through
+ * `el()` — API-derived strings become `textContent`, never markup.
+ *
+ * Two mounts share this one element:
+ *   1. Portal mount (manifest web.pages.v1) — the host assigns `context`
+ *      (ExtensionPageContextV1), parsed exactly as sourcesPage.ts does, and
+ *      the dashboard reads its org-scoped summary/jobs same-origin under the
+ *      extension's own `/api/v1/ext/workspace/` namespace.
+ *   2. Dev mount (dev/dashboard, droppable) — the `api-base` / `org-id` /
+ *      `token` attributes drive a cross-origin fetch against a running dev
+ *      API (the legacy `/api/v1/workspace/` namespace).
+ *
+ * The render model is separated from the DOM: {@link buildViewModel} is a pure
+ * (summary + jobs -> view model) function, unit-tested without a host. The
+ * element below is a thin templating layer over it.
+ *
+ * UX: calm/editorial, light default. Amber is reserved for system-state
+ * signaling only (a retrying/failed/running job banner) — this surface never
+ * announces "AI".
+ */
+import {
+  parseExtensionPageContextV1,
+  type ExtensionPageContextV1,
+} from '@breeze/extension-web-sdk';
+import { buildWorkspaceUrl } from './api';
+import { WorkspaceBaseElement } from './baseElement';
+
+// ---------------------------------------------------------------------------
+// Wire types — mirror src/services/dashboardService.ts's DashboardSummary and
+// src/services/ingestJobsService.ts's IngestJobRow as they arrive over JSON
+// (Date fields serialize to ISO strings).
+// ---------------------------------------------------------------------------
+
+export interface DashboardSource {
+  id: string; name: string; kind: string; status: string;
+  lastCompleteRunAt: string | null; liveFiles: number; liveDirs: number;
+  tombstoned: number; newestSeenAt: string | null;
+  activeRun: { id: string; status: string; startedAt: string; stats: unknown } | null;
+}
+
+export interface DashboardIngest {
+  eligible: number; extracted: number; failed: number; skippedTooLarge: number;
+  skippedBinary: number; blockedDlp: number; pending: number;
+  enrichPending: number; chunks: number;
+}
+
+export interface DashboardFilingQueueItem {
+  id: string; name: string; relPath: string;
+  suggestedProjectLabel: string | null; confidence: string | null;
+}
+
+export interface DashboardFiling {
+  unfiled: number; suggested: number; confirmed: number; reassigned: number;
+  highConfidence: number; queue: DashboardFilingQueueItem[];
+}
+
+export interface DashboardActivityItem {
+  fileIndexId: string; name: string; relPath: string;
+  lastActivityAt: string; events7d: number;
+}
+
+export interface DashboardProject {
+  projectKey: string; label: string; filedEmails: number;
+  crosswalkEntities: number; evidenceFiles: number;
+}
+
+export interface DashboardSummary {
+  sources: DashboardSource[];
+  ingest: DashboardIngest;
+  filing: DashboardFiling;
+  activity: DashboardActivityItem[];
+  projects: DashboardProject[];
+  generatedAt: string;
+}
+
+export interface DashboardJob {
+  id: string;
+  sourceId: string | null;
+  trigger: string;
+  phase: 'ingest' | 'enrich' | 'crosswalk';
+  status: 'pending' | 'running' | 'complete' | 'failed';
+  attempts: number;
+  maxAttempts: number;
+  nextAttemptAt: string;
+  lastError: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// View model — the pure, unit-testable render model.
+// ---------------------------------------------------------------------------
+
+export interface CoverageSourceRow {
+  id: string; name: string; kind: string; status: string;
+  liveFiles: number; newestSeenAt: string | null; activeRunStatus: string | null;
+}
+
+export interface CoverageCard {
+  isEmpty: boolean;
+  sources: CoverageSourceRow[];
+  funnel: {
+    eligible: number; extracted: number; pending: number; blockedDlp: number;
+    skippedTooLarge: number; skippedBinary: number; failed: number;
+    enrichPending: number; chunks: number;
+  };
+}
+
+export interface UnfiledMailCard {
+  isEmpty: boolean;
+  count: number;
+  highConfidence: number;
+  queue: DashboardFilingQueueItem[];
+}
+
+export interface RecentActivityCard {
+  isEmpty: boolean;
+  items: DashboardActivityItem[];
+}
+
+export interface ProjectsCardItem {
+  projectKey: string; label: string; filings: number; crosswalkStrength: number;
+}
+
+export interface ProjectsCard {
+  isEmpty: boolean;
+  items: ProjectsCardItem[];
+}
+
+export interface JobsStripRow {
+  id: string; status: DashboardJob['status']; phase: DashboardJob['phase'];
+  attempts: number; maxAttempts: number; nextAttemptAt: string; lastError: string | null;
+}
+
+export interface DashboardViewModel {
+  generatedAt: string | null;
+  cards: {
+    coverage: CoverageCard;
+    unfiledMail: UnfiledMailCard;
+    recentActivity: RecentActivityCard;
+    projects: ProjectsCard;
+  };
+  jobBanner: string | null;
+  jobsStrip: JobsStripRow[];
+}
+
+function buildJobBanner(jobs: DashboardJob[], now: Date): string | null {
+  const failed = jobs.find((j) => j.status === 'failed');
+  if (failed) {
+    return `failed after ${failed.attempts} attempts: ${failed.lastError ?? 'unknown error'}`;
+  }
+  const retrying = jobs.find((j) => (
+    j.status === 'pending'
+    && j.attempts > 0
+    && new Date(j.nextAttemptAt).getTime() > now.getTime()
+  ));
+  if (retrying) {
+    return `retrying (attempt ${retrying.attempts}/${retrying.maxAttempts}): ${retrying.lastError ?? 'unknown error'}`;
+  }
+  const running = jobs.find((j) => j.status === 'running');
+  if (running) {
+    return `running: ${running.phase}`;
+  }
+  return null;
+}
+
+/** Pure: (summary, jobs) -> view model. No DOM. Unit-tested without a host. */
+export function buildViewModel(
+  summary: DashboardSummary,
+  jobs: DashboardJob[],
+  now: Date = new Date(),
+): DashboardViewModel {
+  const coverage: CoverageCard = {
+    isEmpty: summary.sources.length === 0,
+    sources: summary.sources.map((s) => ({
+      id: s.id,
+      name: s.name,
+      kind: s.kind,
+      status: s.status,
+      liveFiles: s.liveFiles,
+      newestSeenAt: s.newestSeenAt,
+      activeRunStatus: s.activeRun ? s.activeRun.status : null,
+    })),
+    funnel: {
+      eligible: summary.ingest.eligible,
+      extracted: summary.ingest.extracted,
+      pending: summary.ingest.pending,
+      blockedDlp: summary.ingest.blockedDlp,
+      skippedTooLarge: summary.ingest.skippedTooLarge,
+      skippedBinary: summary.ingest.skippedBinary,
+      failed: summary.ingest.failed,
+      enrichPending: summary.ingest.enrichPending,
+      chunks: summary.ingest.chunks,
+    },
+  };
+
+  const unfiledMail: UnfiledMailCard = {
+    isEmpty: summary.filing.unfiled === 0,
+    count: summary.filing.unfiled,
+    highConfidence: summary.filing.highConfidence,
+    queue: summary.filing.queue,
+  };
+
+  const recentActivity: RecentActivityCard = {
+    isEmpty: summary.activity.length === 0,
+    items: summary.activity,
+  };
+
+  const projects: ProjectsCard = {
+    isEmpty: summary.projects.length === 0,
+    items: summary.projects.map((p) => ({
+      projectKey: p.projectKey,
+      label: p.label,
+      filings: p.filedEmails,
+      crosswalkStrength: p.crosswalkEntities,
+    })),
+  };
+
+  return {
+    generatedAt: summary.generatedAt ?? null,
+    cards: { coverage, unfiledMail, recentActivity, projects },
+    jobBanner: buildJobBanner(jobs, now),
+    jobsStrip: jobs.map((j) => ({
+      id: j.id,
+      status: j.status,
+      phase: j.phase,
+      attempts: j.attempts,
+      maxAttempts: j.maxAttempts,
+      nextAttemptAt: j.nextAttemptAt,
+      lastError: j.lastError,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DOM layer.
+// ---------------------------------------------------------------------------
+
+/**
+ * Dashboard-scoped stylesheet. Static string only — nothing here is ever
+ * interpolated from API data, same rule as styles.ts. Appended alongside the
+ * shared WORKSPACE_STYLES (the base element injects that one); clearContent
+ * preserves every STYLE node, so both survive a re-render.
+ */
+const DASHBOARD_STYLES = `
+.ws-dash {
+  color: #2a2723;
+  background: #f6f5f2;
+  padding: 20px;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  box-sizing: border-box;
+}
+.ws-dash * { box-sizing: border-box; }
+.ws-banner {
+  grid-column: 1 / -1;
+  background: #fdf3dd;
+  border: 1px solid #e8c976;
+  color: #6b5217;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+}
+.ws-jobs-strip {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: #6b6558;
+}
+.ws-jobs-strip .job {
+  background: #fff;
+  border: 1px solid #e4e0d8;
+  border-radius: 6px;
+  padding: 4px 8px;
+}
+.ws-card {
+  background: #ffffff;
+  border: 1px solid #e4e0d8;
+  border-radius: 10px;
+  padding: 16px;
+}
+.ws-card h3 {
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #4a4638;
+  text-transform: uppercase;
+}
+.ws-empty { color: #8a8574; font-size: 13px; }
+.ws-source-row, .ws-queue-row, .ws-activity-row, .ws-project-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid #f0eee7;
+  font-size: 13px;
+}
+.ws-source-row:last-child, .ws-queue-row:last-child,
+.ws-activity-row:last-child, .ws-project-row:last-child { border-bottom: none; }
+.ws-muted { color: #8a8574; font-size: 12px; }
+.ws-funnel { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px; font-size: 12px; color: #6b6558; }
+.ws-funnel b { color: #2a2723; }
+`;
+
+function formatTimestamp(iso: string | null): string {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+  });
+}
+
+/**
+ * The resolved data plane for one mount: the two endpoint URLs plus the
+ * RequestInit that carries the credentials for whichever mount resolved it.
+ */
+interface ResolvedConfig {
+  summaryUrl: string;
+  jobsUrl: string;
+  init: RequestInit;
+}
+
+// The dev-harness attribute mount targets a dev API's legacy namespace; the
+// portal mount stays same-origin under the extension's own /ext/ namespace
+// (buildWorkspaceUrl). Kept as one constant so the two mounts read alike.
+const DEV_NAMESPACE = '/api/v1/workspace';
+
+const SUMMARY_POLL_MS = 60_000;
+const JOBS_POLL_MS = 10_000;
+
+export class WorkspaceDashboard extends WorkspaceBaseElement {
+  #context: ExtensionPageContextV1 | null = null;
+  #summaryTimer: ReturnType<typeof setInterval> | null = null;
+  #jobsTimer: ReturnType<typeof setInterval> | null = null;
+  #visibilityHandler: (() => void) | null = null;
+  #lastSummary: DashboardSummary | null = null;
+  #lastJobs: DashboardJob[] = [];
+  #started = false;
+
+  constructor() {
+    super();
+    // Append the dashboard-scoped stylesheet beside the shared one the base
+    // element already injected; clearContent() preserves every STYLE node.
+    const style = document.createElement('style');
+    style.textContent = DASHBOARD_STYLES;
+    this.root.append(style);
+  }
+
+  static get observedAttributes(): string[] {
+    return ['api-base', 'org-id', 'token'];
+  }
+
+  set context(value: unknown) {
+    let parsed: ExtensionPageContextV1;
+    try {
+      parsed = parseExtensionPageContextV1(value);
+    } catch {
+      this.#context = null;
+      // Malformed host context: render the failure, make NO network call.
+      this.renderError('Workspace received an invalid host context.');
+      return;
+    }
+    this.#context = parsed;
+    this.#restart();
+  }
+
+  get context(): ExtensionPageContextV1 | null {
+    return this.#context;
+  }
+
+  connectedCallback(): void {
+    // The portal mount assigns context before connect (which already started
+    // the cycle); the dev mount arrives connected with attributes only.
+    if (!this.#started) this.#restart();
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this.#restart();
+  }
+
+  disconnectedCallback(): void {
+    this.#stopTimers();
+    this.#started = false;
+    // Aborts in-flight fetches (base element contract).
+    super.disconnectedCallback();
+  }
+
+  // Config resolution order: (1) host-assigned `context` (portal mount,
+  // parsed to ExtensionPageContextV1) → same-origin under the extension's own
+  // namespace; (2) dev-mount attributes → cross-origin against a dev API's
+  // legacy namespace; (3) neither present → the missing-context state.
+  #resolveConfig(): ResolvedConfig | null {
+    if (this.#context) {
+      return {
+        summaryUrl: buildWorkspaceUrl('dashboard/summary', { orgId: this.#context.organizationId }),
+        jobsUrl: buildWorkspaceUrl('dashboard/jobs', { orgId: this.#context.organizationId }),
+        init: { credentials: 'same-origin' },
+      };
+    }
+    const orgId = this.getAttribute('org-id');
+    if (orgId) {
+      const apiBase = this.getAttribute('api-base') ?? '';
+      const token = this.getAttribute('token');
+      const query = `?orgId=${encodeURIComponent(orgId)}`;
+      return {
+        summaryUrl: `${apiBase}${DEV_NAMESPACE}/dashboard/summary${query}`,
+        jobsUrl: `${apiBase}${DEV_NAMESPACE}/dashboard/jobs${query}`,
+        init: token ? { headers: { Authorization: `Bearer ${token}` } } : { credentials: 'include' },
+      };
+    }
+    return null;
+  }
+
+  #restart(): void {
+    this.#stopTimers();
+    const config = this.#resolveConfig();
+    if (!config) {
+      this.#started = false;
+      this.renderStatus(
+        'Missing org context — this element needs a portal-assigned context or api-base/org-id attributes.',
+      );
+      return;
+    }
+    this.#started = true;
+    this.renderStatus('Loading estate…');
+    this.track(this.#refresh(config));
+
+    // A live estate view: poll both feeds while the tab is visible. Timers are
+    // torn down on disconnect (and re-armed on the next mount), so nothing
+    // outlives the element.
+    this.#summaryTimer = setInterval(() => {
+      if (!document.hidden) void this.#fetchSummary(config);
+    }, SUMMARY_POLL_MS);
+    this.#jobsTimer = setInterval(() => {
+      if (!document.hidden) void this.#fetchJobs(config);
+    }, JOBS_POLL_MS);
+    this.#visibilityHandler = () => {
+      if (!document.hidden) void this.#refresh(config);
+    };
+    document.addEventListener('visibilitychange', this.#visibilityHandler);
+  }
+
+  #stopTimers(): void {
+    if (this.#summaryTimer !== null) { clearInterval(this.#summaryTimer); this.#summaryTimer = null; }
+    if (this.#jobsTimer !== null) { clearInterval(this.#jobsTimer); this.#jobsTimer = null; }
+    if (this.#visibilityHandler) {
+      document.removeEventListener('visibilitychange', this.#visibilityHandler);
+      this.#visibilityHandler = null;
+    }
+  }
+
+  #refresh(config: ResolvedConfig): Promise<void> {
+    return Promise.all([this.#fetchSummary(config), this.#fetchJobs(config)]).then(() => undefined);
+  }
+
+  #isAbort(error: unknown): boolean {
+    return error instanceof DOMException && error.name === 'AbortError';
+  }
+
+  async #fetchSummary(config: ResolvedConfig): Promise<void> {
+    try {
+      const res = await fetch(config.summaryUrl, { ...config.init, signal: this.signal });
+      if (!res.ok) throw new Error(`summary fetch failed: ${res.status}`);
+      this.#lastSummary = (await res.json()) as DashboardSummary;
+      this.#paint();
+    } catch (error) {
+      if (this.#isAbort(error)) return;
+      this.renderError('The Workspace dashboard could not be loaded.', () => {
+        this.track(this.#refresh(config));
+      });
+    }
+  }
+
+  async #fetchJobs(config: ResolvedConfig): Promise<void> {
+    try {
+      const res = await fetch(config.jobsUrl, { ...config.init, signal: this.signal });
+      if (!res.ok) throw new Error(`jobs fetch failed: ${res.status}`);
+      const body = (await res.json()) as { jobs?: DashboardJob[] };
+      this.#lastJobs = body.jobs ?? [];
+      this.#paint();
+    } catch (error) {
+      if (this.#isAbort(error)) return;
+      // A jobs-poll failure must not blank an already-rendered summary; the
+      // next tick retries.
+      // eslint-disable-next-line no-console
+      console.error('workspace-dashboard: jobs poll failed', error);
+    }
+  }
+
+  #paint(): void {
+    if (!this.#lastSummary) return;
+    const vm = buildViewModel(this.#lastSummary, this.#lastJobs);
+    this.clearContent();
+    const dash = this.el('div', { className: 'ws-dash' });
+    if (vm.jobBanner) {
+      dash.append(this.el('div', { className: 'ws-banner', text: vm.jobBanner, attrs: { role: 'status' } }));
+    }
+    dash.append(
+      this.#coverageCard(vm.cards.coverage),
+      this.#unfiledCard(vm.cards.unfiledMail),
+      this.#activityCard(vm.cards.recentActivity),
+      this.#projectsCard(vm.cards.projects),
+    );
+    const strip = this.#jobsStrip(vm.jobsStrip);
+    if (strip) dash.append(strip);
+    this.root.append(dash);
+  }
+
+  #card(title: string, children: Array<Node | string>): HTMLElement {
+    return this.el('section', { className: 'ws-card' }, [this.el('h3', { text: title }), ...children]);
+  }
+
+  #empty(message: string): HTMLElement {
+    return this.el('p', { text: message, className: 'ws-empty' });
+  }
+
+  #coverageCard(c: CoverageCard): HTMLElement {
+    if (c.isEmpty) return this.#card('Coverage & freshness', [this.#empty('No sources yet.')]);
+    const rows = c.sources.map((s) => this.el('div', { className: 'ws-source-row' }, [
+      this.el('span', { text: s.activeRunStatus ? `${s.name} · running` : s.name }),
+      this.el('span', { className: 'ws-muted', text: `${s.liveFiles} files · ${formatTimestamp(s.newestSeenAt)}` }),
+    ]));
+    return this.#card('Coverage & freshness', [...rows, this.#funnel(c.funnel)]);
+  }
+
+  #funnel(f: CoverageCard['funnel']): HTMLElement {
+    const item = (label: string, value: number): HTMLElement =>
+      this.el('span', {}, [`${label} `, this.el('b', { text: String(value) })]);
+    return this.el('div', { className: 'ws-funnel' }, [
+      item('eligible', f.eligible),
+      item('extracted', f.extracted),
+      item('pending', f.pending),
+      item('blocked (dlp)', f.blockedDlp),
+      item('skipped', f.skippedTooLarge + f.skippedBinary),
+      item('failed', f.failed),
+      item('enrich pending', f.enrichPending),
+      item('chunks', f.chunks),
+    ]);
+  }
+
+  #unfiledCard(u: UnfiledMailCard): HTMLElement {
+    const title = u.isEmpty
+      ? 'Unfiled mail'
+      : `Unfiled mail (${u.count}, ${u.highConfidence} high-confidence)`;
+    if (u.isEmpty) return this.#card(title, [this.#empty('Nothing unfiled.')]);
+    const rows = u.queue.map((q) => this.el('div', { className: 'ws-queue-row' }, [
+      this.el('span', { text: q.name }),
+      this.el('span', {
+        className: 'ws-muted',
+        text: q.suggestedProjectLabel
+          ? `${q.suggestedProjectLabel}${q.confidence ? ` (${q.confidence})` : ''}`
+          : '—',
+      }),
+    ]));
+    return this.#card(title, rows);
+  }
+
+  #activityCard(a: RecentActivityCard): HTMLElement {
+    if (a.isEmpty) return this.#card('Recent activity', [this.#empty('No activity yet.')]);
+    const rows = a.items.map((i) => this.el('div', { className: 'ws-activity-row' }, [
+      this.el('span', { text: i.name }),
+      this.el('span', { className: 'ws-muted', text: `${formatTimestamp(i.lastActivityAt)} · ${i.events7d}/7d` }),
+    ]));
+    return this.#card('Recent activity', rows);
+  }
+
+  #projectsCard(p: ProjectsCard): HTMLElement {
+    if (p.isEmpty) return this.#card('Projects', [this.#empty('No projects yet.')]);
+    const rows = p.items.map((i) => this.el('div', { className: 'ws-project-row' }, [
+      this.el('span', { text: i.label }),
+      this.el('span', { className: 'ws-muted', text: `${i.filings} filings · ${i.crosswalkStrength} crosswalk` }),
+    ]));
+    return this.#card('Projects', rows);
+  }
+
+  #jobsStrip(rows: JobsStripRow[]): HTMLElement | null {
+    if (rows.length === 0) return null;
+    const chips = rows.map((j) => this.el('span', {
+      className: 'job',
+      text: `${j.phase} · ${j.status} · attempt ${j.attempts}/${j.maxAttempts}${j.lastError ? ` · ${j.lastError}` : ''}`,
+    }));
+    return this.el('div', { className: 'ws-jobs-strip' }, chips);
+  }
+}

--- a/ee/workspace/src/web/filingCard.test.ts
+++ b/ee/workspace/src/web/filingCard.test.ts
@@ -1,0 +1,449 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineWorkspaceElements, WorkspaceFilingCard } from './index';
+import type { ClientPanelContext, ClientPanelItem } from './filingCard';
+
+function item(overrides: Partial<ClientPanelItem> = {}): ClientPanelItem {
+  return {
+    subject: 'PO #4021 — Alder Creek',
+    sender: 'vendor@example.com',
+    dateISO: '2026-07-19T12:00:00.000Z',
+    internetMessageId: '<abc@mail>',
+    itemId: 'AAMk-item-1',
+    ...overrides,
+  };
+}
+
+function context(overrides: Partial<ClientPanelContext> = {}): ClientPanelContext {
+  return {
+    host: 'outlook',
+    item: item(),
+    fetchJson: vi.fn(),
+    ...overrides,
+  };
+}
+
+function shadowText(element: HTMLElement): string {
+  return element.shadowRoot?.textContent ?? '';
+}
+
+function shadowChildCount(element: HTMLElement): number {
+  return element.shadowRoot
+    ? [...element.shadowRoot.children].filter((c) => c.tagName !== 'STYLE').length
+    : 0;
+}
+
+/** A promise the test controls the resolution/rejection of. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function matchResponse(over: Record<string, unknown> = {}): unknown {
+  return {
+    match: {
+      fileIndexId: 'file-1',
+      tier: 1,
+      filing: {
+        fileIndexId: 'file-1',
+        relPath: 'inbox/po-4021.eml',
+        name: 'po-4021.eml',
+        emailMeta: null,
+        status: 'suggested',
+        suggestedProjectKey: 'alder-creek',
+        suggestedProjectLabel: 'Alder Creek',
+        matchedEntityType: 'po',
+        matchedEntityValue: 'PO 4021',
+        confidence: 'high',
+        rationale: 'matched PO #4021',
+        decidedProjectKey: null,
+        ...over,
+      },
+    },
+  };
+}
+
+function projectsResponse(): unknown {
+  return {
+    projects: [
+      { key: 'alder-creek', label: 'Alder Creek' },
+      { key: 'birchwood', label: 'Birchwood' },
+    ],
+  };
+}
+
+async function mount(ctx: ClientPanelContext): Promise<WorkspaceFilingCard> {
+  const element = document.createElement('workspace-filing-card') as WorkspaceFilingCard;
+  document.body.append(element);
+  element.context = ctx;
+  await element.updateComplete;
+  return element;
+}
+
+describe('workspace-filing-card', () => {
+  beforeEach(() => {
+    defineWorkspaceElements();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('renders nothing when item is null', async () => {
+    const fetchJson = vi.fn();
+    const el = await mount(context({ item: null, fetchJson }));
+    expect(fetchJson).not.toHaveBeenCalled();
+    expect(shadowChildCount(el)).toBe(0);
+  });
+
+  it('goes loading -> suggested, rendering the project label and confidence', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path.startsWith('/client/filing/match')) return matchResponse();
+      if (path === '/client/content/projects') return projectsResponse();
+      throw new Error(`unexpected path ${path}`);
+    });
+    const el = await mount(context({ fetchJson }));
+
+    expect(fetchJson.mock.calls[0][0]).toContain('/client/filing/match?');
+    expect(fetchJson.mock.calls[0][0]).toContain('subject=');
+    expect(fetchJson.mock.calls[0][0]).toContain('internetMessageId=');
+
+    const text = shadowText(el);
+    expect(text).toContain('Filed to');
+    expect(text).toContain('Alder Creek');
+    expect(text).toContain('high');
+    expect(el.shadowRoot?.querySelector('button')?.textContent).toBe('File');
+  });
+
+  it('File click posts assign and re-renders filed', async () => {
+    const fetchJson = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path.startsWith('/client/filing/match')) return matchResponse();
+      if (path === '/client/content/projects') return projectsResponse();
+      if (path === '/client/filing/file-1/assign') {
+        expect(init?.method).toBe('POST');
+        expect(JSON.parse(String(init?.body))).toEqual({ projectKey: 'alder-creek' });
+        return {
+          filing: {
+            fileIndexId: 'file-1',
+            relPath: 'inbox/po-4021.eml',
+            name: 'po-4021.eml',
+            emailMeta: null,
+            status: 'confirmed',
+            suggestedProjectKey: 'alder-creek',
+            suggestedProjectLabel: 'Alder Creek',
+            matchedEntityType: 'po',
+            matchedEntityValue: 'PO 4021',
+            confidence: 'high',
+            rationale: 'matched PO #4021',
+            decidedProjectKey: 'alder-creek',
+          },
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    const el = await mount(context({ fetchJson }));
+
+    const fileButton = [...(el.shadowRoot?.querySelectorAll('button') ?? [])]
+      .find((b) => b.textContent === 'File') as HTMLButtonElement;
+    fileButton.click();
+    await el.updateComplete;
+
+    expect(fetchJson).toHaveBeenCalledWith('/client/filing/file-1/assign', expect.objectContaining({
+      method: 'POST',
+    }));
+    const text = shadowText(el);
+    expect(text).toContain('Alder Creek');
+    expect(el.shadowRoot?.querySelector('button')?.textContent).toBe('Change');
+  });
+
+  it('Reassign flow posts the chosen key', async () => {
+    const fetchJson = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path.startsWith('/client/filing/match')) return matchResponse();
+      if (path === '/client/content/projects') return projectsResponse();
+      if (path === '/client/filing/file-1/assign') {
+        expect(JSON.parse(String(init?.body))).toEqual({ projectKey: 'birchwood' });
+        return {
+          filing: {
+            fileIndexId: 'file-1',
+            relPath: 'inbox/po-4021.eml',
+            name: 'po-4021.eml',
+            emailMeta: null,
+            status: 'reassigned',
+            suggestedProjectKey: 'alder-creek',
+            suggestedProjectLabel: 'Alder Creek',
+            matchedEntityType: 'po',
+            matchedEntityValue: 'PO 4021',
+            confidence: 'high',
+            rationale: 'matched PO #4021',
+            decidedProjectKey: 'birchwood',
+          },
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    const el = await mount(context({ fetchJson }));
+
+    const reassignButton = [...(el.shadowRoot?.querySelectorAll('button') ?? [])]
+      .find((b) => b.textContent === 'Reassign') as HTMLButtonElement;
+    reassignButton.click();
+    await el.updateComplete;
+
+    const select = el.shadowRoot?.querySelector('select') as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    expect([...select.options].map((o) => o.value)).toEqual(['alder-creek', 'birchwood']);
+    select.value = 'birchwood';
+    select.dispatchEvent(new Event('change'));
+
+    const confirmButton = [...(el.shadowRoot?.querySelectorAll('button') ?? [])]
+      .find((b) => b.textContent === 'Confirm') as HTMLButtonElement;
+    confirmButton.click();
+    await el.updateComplete;
+
+    expect(fetchJson).toHaveBeenCalledWith('/client/filing/file-1/assign', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ projectKey: 'birchwood' }),
+    }));
+    const text = shadowText(el);
+    expect(text).toContain('Birchwood');
+    expect(el.shadowRoot?.querySelector('button')?.textContent).toBe('Change');
+  });
+
+  it('Reassign confirm posts the option actually shown in the picker, even when the seeded key is not in the project list', async () => {
+    // suggestedProjectKey is not among the projects the /content/projects
+    // fetch returns, so the <select> falls back to its first option
+    // ('alder-creek') while any naively-seeded selection state would still
+    // hold the stale, off-list key. Confirm must post what the user sees.
+    const fetchJson = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path.startsWith('/client/filing/match')) {
+        return matchResponse({ suggestedProjectKey: 'zeta-not-in-list', suggestedProjectLabel: 'Zeta' });
+      }
+      if (path === '/client/content/projects') return projectsResponse();
+      if (path === '/client/filing/file-1/assign') {
+        expect(JSON.parse(String(init?.body))).toEqual({ projectKey: 'alder-creek' });
+        return {
+          filing: {
+            fileIndexId: 'file-1',
+            relPath: 'inbox/po-4021.eml',
+            name: 'po-4021.eml',
+            emailMeta: null,
+            status: 'reassigned',
+            suggestedProjectKey: 'zeta-not-in-list',
+            suggestedProjectLabel: 'Zeta',
+            matchedEntityType: 'po',
+            matchedEntityValue: 'PO 4021',
+            confidence: 'high',
+            rationale: 'matched PO #4021',
+            decidedProjectKey: 'alder-creek',
+          },
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    const el = await mount(context({ fetchJson }));
+
+    const reassignButton = [...(el.shadowRoot?.querySelectorAll('button') ?? [])]
+      .find((b) => b.textContent === 'Reassign') as HTMLButtonElement;
+    reassignButton.click();
+    await el.updateComplete;
+
+    const select = el.shadowRoot?.querySelector('select') as HTMLSelectElement;
+    // Nothing matches the seeded key, so the browser defaults to option 0.
+    expect(select.value).toBe('alder-creek');
+
+    // The user never touches the <select> — just confirms what is displayed.
+    const confirmButton = [...(el.shadowRoot?.querySelectorAll('button') ?? [])]
+      .find((b) => b.textContent === 'Confirm') as HTMLButtonElement;
+    confirmButton.click();
+    await el.updateComplete;
+
+    expect(fetchJson).toHaveBeenCalledWith('/client/filing/file-1/assign', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ projectKey: 'alder-creek' }),
+    }));
+  });
+
+  it('renders nothing on no-match', async () => {
+    const fetchJson = vi.fn(async () => ({ match: null }));
+    const el = await mount(context({ fetchJson }));
+    expect(shadowChildCount(el)).toBe(0);
+  });
+
+  it('shows an error state with a retry button on fetch rejection, and retry re-fetches', async () => {
+    let calls = 0;
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path.startsWith('/client/filing/match')) {
+        calls += 1;
+        if (calls === 1) throw new Error('network down');
+        return matchResponse();
+      }
+      if (path === '/client/content/projects') return projectsResponse();
+      throw new Error(`unexpected path ${path}`);
+    });
+    const el = await mount(context({ fetchJson }));
+
+    expect(el.shadowRoot?.querySelector('[role="alert"]')).toBeTruthy();
+    const retry = el.shadowRoot?.querySelector('button') as HTMLButtonElement;
+    expect(retry.textContent).toBe('Retry');
+    retry.click();
+    await el.updateComplete;
+
+    expect(shadowText(el)).toContain('Alder Creek');
+  });
+
+  it('a context re-assignment while a fetch is in flight does not let the stale response paint over the new card', async () => {
+    const first = deferred<unknown>();
+    const fetchJsonA = vi.fn((path: string) => {
+      if (path.startsWith('/client/filing/match')) return first.promise;
+      return Promise.resolve(projectsResponse());
+    });
+    const element = document.createElement('workspace-filing-card') as WorkspaceFilingCard;
+    document.body.append(element);
+
+    element.context = context({ item: item({ subject: 'first message' }), fetchJson: fetchJsonA });
+    // Do not await — the fetch above is still pending.
+
+    // Message B resolves to a DIFFERENT suggestion (not an empty/no-match
+    // render) so that "still on screen after A resolves" is a real signal,
+    // not indistinguishable from a broken element that painted nothing.
+    const fetchJsonB = vi.fn(async (path: string) => {
+      if (path.startsWith('/client/filing/match')) {
+        return matchResponse({ suggestedProjectKey: 'birchwood', suggestedProjectLabel: 'Birchwood' });
+      }
+      return projectsResponse();
+    });
+    element.context = context({ item: item({ subject: 'second message' }), fetchJson: fetchJsonB });
+    await element.updateComplete;
+    expect(shadowText(element)).toContain('Birchwood');
+
+    // Now let the first (stale) fetch resolve with a different suggestion.
+    // It must NOT overwrite what message B already painted.
+    first.resolve(matchResponse());
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(shadowText(element)).toContain('Birchwood');
+    expect(shadowText(element)).not.toContain('Alder Creek');
+  });
+
+  it('does not paint after the element is disconnected, even if fetchJson ignores the abort signal', async () => {
+    // A misbehaving (or fake, as here) fetchJson that never rejects on abort
+    // must not be the only thing standing between a detached element and a
+    // paint into its now-orphaned shadow root.
+    const pending = deferred<unknown>();
+    const fetchJson = vi.fn((path: string) => {
+      if (path.startsWith('/client/filing/match')) return pending.promise;
+      return Promise.resolve(projectsResponse());
+    });
+    const element = document.createElement('workspace-filing-card') as WorkspaceFilingCard;
+    document.body.append(element);
+    element.context = context({ fetchJson });
+    expect(shadowText(element)).toContain('Loading');
+
+    element.remove(); // disconnectedCallback fires and aborts the signal
+    pending.resolve(matchResponse()); // ...but fetchJson above ignores that
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(shadowText(element)).toContain('Loading');
+    expect(shadowText(element)).not.toContain('Alder Creek');
+  });
+
+  it('loads and renders even when context is assigned before the element is connected to the DOM', async () => {
+    // The host's assignment order relative to append is unspecified (Task 5's
+    // ExtensionPanelHost does not exist yet). The element must not carry a
+    // silent ordering requirement whose failure mode is a permanently blank
+    // pane.
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path.startsWith('/client/filing/match')) return matchResponse();
+      if (path === '/client/content/projects') return projectsResponse();
+      throw new Error(`unexpected path ${path}`);
+    });
+    const element = document.createElement('workspace-filing-card') as WorkspaceFilingCard;
+    element.context = context({ fetchJson }); // assigned BEFORE append
+    document.body.append(element);
+    await element.updateComplete;
+
+    expect(fetchJson).toHaveBeenCalled();
+    expect(shadowText(element)).toContain('Alder Creek');
+  });
+
+  it('does not offer Reassign when the projects list failed to load', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path.startsWith('/client/filing/match')) return matchResponse();
+      if (path === '/client/content/projects') throw new Error('projects down');
+      throw new Error(`unexpected path ${path}`);
+    });
+    const el = await mount(context({ fetchJson }));
+
+    const buttonLabels = [...(el.shadowRoot?.querySelectorAll('button') ?? [])].map((b) => b.textContent);
+    expect(buttonLabels).toContain('File');
+    expect(buttonLabels).not.toContain('Reassign');
+  });
+
+  it('does not offer Change (reassign) on a decided filing when the projects list failed to load', async () => {
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path.startsWith('/client/filing/match')) {
+        return matchResponse({ status: 'confirmed', decidedProjectKey: 'alder-creek' });
+      }
+      if (path === '/client/content/projects') throw new Error('projects down');
+      throw new Error(`unexpected path ${path}`);
+    });
+    const el = await mount(context({ fetchJson }));
+
+    // Projects fetch failed, so the decided label falls back to the raw key
+    // (per the existing degrade-gracefully behavior) — the point of this
+    // test is the missing Reassign/Change entry point, not the label text.
+    expect(shadowText(el)).toContain('alder-creek');
+    const buttonLabels = [...(el.shadowRoot?.querySelectorAll('button') ?? [])].map((b) => b.textContent);
+    expect(buttonLabels).not.toContain('Change');
+  });
+
+  it('URL-encodes fileIndexId when building the assign path', async () => {
+    const rawId = 'file/needs encoding';
+    const matchWithOddId = {
+      match: {
+        fileIndexId: rawId,
+        tier: 1,
+        filing: {
+          fileIndexId: rawId,
+          relPath: 'inbox/po-4021.eml',
+          name: 'po-4021.eml',
+          emailMeta: null,
+          status: 'suggested',
+          suggestedProjectKey: 'alder-creek',
+          suggestedProjectLabel: 'Alder Creek',
+          matchedEntityType: 'po',
+          matchedEntityValue: 'PO 4021',
+          confidence: 'high',
+          rationale: 'matched PO #4021',
+          decidedProjectKey: null,
+        },
+      },
+    };
+    const fetchJson = vi.fn(async (path: string) => {
+      if (path.startsWith('/client/filing/match')) return matchWithOddId;
+      if (path === '/client/content/projects') return projectsResponse();
+      if (path.startsWith('/client/filing/')) {
+        return { filing: { ...matchWithOddId.match.filing, status: 'confirmed', decidedProjectKey: 'alder-creek' } };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+    const el = await mount(context({ fetchJson }));
+
+    const fileButton = [...(el.shadowRoot?.querySelectorAll('button') ?? [])]
+      .find((b) => b.textContent === 'File') as HTMLButtonElement;
+    fileButton.click();
+    await el.updateComplete;
+
+    expect(fetchJson).toHaveBeenCalledWith(
+      `/client/filing/${encodeURIComponent(rawId)}/assign`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/ee/workspace/src/web/filingCard.ts
+++ b/ee/workspace/src/web/filingCard.ts
@@ -1,0 +1,334 @@
+/**
+ * <workspace-filing-card> — the Outlook add-in pane's filing card.
+ *
+ * Mounted by the generic client-panel host (Task 5's `ExtensionPanelHost`)
+ * above the chat thread. The host assigns `context` as a PROPERTY, and
+ * RE-ASSIGNS it whole every time the user switches the open message —
+ * `context.item` is the only thing that changes across those assignments,
+ * `context.fetchJson` is the host's authenticated client for this org's
+ * `/client/*` surface (never construct a URL or touch a token here).
+ *
+ * Concurrency (load-bearing): a context re-assignment while a fetch from the
+ * PREVIOUS assignment is still in flight must never let that stale response
+ * paint over the new message's card. Every async cycle captures the
+ * generation token current when it started and re-checks it before every
+ * paint; a mismatch means a newer `context=` happened meanwhile and the
+ * cycle silently stops. The base element's disconnect AbortSignal is passed
+ * into every `fetchJson` call as a second guard (element removed from the
+ * DOM entirely, not just re-targeted).
+ */
+import { WorkspaceBaseElement } from './baseElement';
+
+// ---------------------------------------------------------------------------
+// Task 5 contract — the property the host assigns.
+// ---------------------------------------------------------------------------
+
+export interface ClientPanelItem {
+  subject: string;
+  sender: string;
+  dateISO: string;
+  internetMessageId?: string;
+  itemId?: string;
+}
+
+export interface ClientPanelContext {
+  host: 'outlook';
+  item: ClientPanelItem | null;
+  /** Already authenticated by the host. Throws on non-OK responses. */
+  fetchJson: (path: string, init?: RequestInit) => Promise<unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Wire types — mirror src/routes/client.ts's ClientMatchResponse /
+// ClientAssignResponse / ClientProjectsResponse as they arrive over JSON.
+// Duplicated here (not imported) the same way dashboard.ts mirrors its
+// service types: the web bundle never depends on server-side modules.
+// ---------------------------------------------------------------------------
+
+interface FilingRecord {
+  fileIndexId: string;
+  relPath: string;
+  name: string;
+  emailMeta: { from?: string; to?: string[]; subject?: string; date?: string } | null;
+  status: 'suggested' | 'confirmed' | 'reassigned' | null;
+  suggestedProjectKey: string | null;
+  suggestedProjectLabel: string | null;
+  matchedEntityType: string | null;
+  matchedEntityValue: string | null;
+  confidence: 'high' | 'low' | null;
+  rationale: string | null;
+  decidedProjectKey: string | null;
+}
+
+interface ClientMatchResponse {
+  match: { fileIndexId: string; tier: 1 | 2 | 3; filing: FilingRecord | null } | null;
+}
+
+interface ClientAssignResponse {
+  filing: FilingRecord;
+}
+
+interface ClientProjectsResponse {
+  projects: Array<{ key: string; label: string }>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Narrow an unknown `fetchJson` result to the match response shape. */
+function expectMatchResponse(body: unknown): ClientMatchResponse {
+  if (!isRecord(body) || !('match' in body)) throw new Error('malformed /client/filing/match response');
+  return body as unknown as ClientMatchResponse;
+}
+
+function expectAssignResponse(body: unknown): ClientAssignResponse {
+  if (!isRecord(body) || !isRecord(body.filing)) throw new Error('malformed assign response');
+  return body as unknown as ClientAssignResponse;
+}
+
+function expectProjectsResponse(body: unknown): ClientProjectsResponse {
+  if (!isRecord(body) || !Array.isArray(body.projects)) throw new Error('malformed projects response');
+  return body as unknown as ClientProjectsResponse;
+}
+
+function matchQuery(item: ClientPanelItem): string {
+  const params = new URLSearchParams();
+  params.set('subject', item.subject);
+  if (item.sender) params.set('sender', item.sender);
+  if (item.dateISO) params.set('date', item.dateISO);
+  if (item.internetMessageId) params.set('internetMessageId', item.internetMessageId);
+  return `/client/filing/match?${params.toString()}`;
+}
+
+function isAbort(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+export class WorkspaceFilingCard extends WorkspaceBaseElement {
+  #context: ClientPanelContext | null = null;
+  #generation = 0;
+  #match: ClientMatchResponse['match'] = null;
+  #projects: Array<{ key: string; label: string }> = [];
+  #reassigning = false;
+
+  set context(value: ClientPanelContext) {
+    this.#context = value;
+    const gen = ++this.#generation;
+    this.#match = null;
+    this.#projects = [];
+    this.#reassigning = false;
+
+    if (!value.item) {
+      // No message open: render nothing, make no network call.
+      this.clearContent();
+      this.track(Promise.resolve());
+      return;
+    }
+    this.track(this.#load(value, value.item, gen));
+  }
+
+  get context(): ClientPanelContext | null {
+    return this.#context;
+  }
+
+  // A generation match alone isn't enough: the host's `fetchJson` is not
+  // guaranteed to honor the disconnect AbortSignal (its contract is
+  // unverified — see the Task 8 report), so also refuse to paint into a
+  // shadow root that is no longer attached to the document.
+  //
+  // Used for every POST-await check. Do NOT use it for the synchronous
+  // entry into `#load` (see the comment there) — the host's assignment
+  // order relative to append is unspecified, and gating on `isConnected`
+  // before any await ever runs would silently drop the whole load cycle
+  // for an element configured before it is mounted.
+  #current(gen: number): boolean {
+    return gen === this.#generation && this.isConnected;
+  }
+
+  async #load(ctx: ClientPanelContext, item: ClientPanelItem, gen: number): Promise<void> {
+    // Entered synchronously from the `context` setter, before any await has
+    // run — `gen` cannot be stale yet, so only the generation is checked
+    // here (always true at this exact call site, kept for defensiveness).
+    // `isConnected` is intentionally NOT checked yet: the host may assign
+    // `context` before appending the element to the DOM (or race the two),
+    // and by the time the fetch below resolves the append will typically
+    // already have happened. Connectedness is enforced at every point after
+    // an await via `#current`, which is where a stale paint would actually
+    // occur.
+    if (gen !== this.#generation) return;
+    this.clearContent();
+    this.root.append(this.el('p', {
+      text: 'Loading filing suggestion…',
+      className: 'muted skeleton',
+      attrs: { role: 'status' },
+    }));
+
+    let match: ClientMatchResponse['match'];
+    try {
+      const body = await ctx.fetchJson(matchQuery(item), { signal: this.signal });
+      if (!this.#current(gen)) return;
+      match = expectMatchResponse(body).match;
+    } catch (error) {
+      if (isAbort(error) || !this.#current(gen)) return;
+      this.#renderErrorState(ctx, item, gen);
+      return;
+    }
+
+    // No identified file, or a matched file the caller may see but not file
+    // (already filed under a project path, tombstoned): nothing actionable
+    // to show. Rendering nothing is neutral, not a claim that no match was
+    // found server-side — the server contract still returned the match.
+    if (!match || !match.filing) {
+      if (!this.#current(gen)) return;
+      this.#match = null;
+      this.clearContent();
+      return;
+    }
+
+    let projects: Array<{ key: string; label: string }> = [];
+    try {
+      const body = await ctx.fetchJson('/client/content/projects', { signal: this.signal });
+      if (!this.#current(gen)) return;
+      projects = expectProjectsResponse(body).projects;
+    } catch (error) {
+      if (isAbort(error) || !this.#current(gen)) return;
+      // The reassign picker degrades (falls back to raw keys) rather than
+      // the whole card failing over a non-essential fetch.
+    }
+
+    if (!this.#current(gen)) return;
+    this.#match = match;
+    this.#projects = projects;
+    this.#reassigning = false;
+    this.#paint(ctx, gen);
+  }
+
+  #renderErrorState(ctx: ClientPanelContext, item: ClientPanelItem, gen: number): void {
+    this.renderError('The filing suggestion could not be loaded.', () => {
+      this.track(this.#load(ctx, item, gen));
+    });
+  }
+
+  #projectLabel(key: string | null): string | null {
+    if (!key) return null;
+    return this.#projects.find((p) => p.key === key)?.label ?? key;
+  }
+
+  #paint(ctx: ClientPanelContext, gen: number): void {
+    if (!this.#current(gen)) return;
+    this.clearContent();
+    const filing = this.#match?.filing;
+    if (!filing) return;
+
+    const card = this.el('div', { className: 'ws-filing' });
+    card.append(this.el('span', { className: 'ws-filing-label', text: 'Filed to' }));
+
+    if (filing.status === 'confirmed' || filing.status === 'reassigned') {
+      const decidedLabel = this.#projectLabel(filing.decidedProjectKey)
+        ?? filing.suggestedProjectLabel
+        ?? filing.decidedProjectKey
+        ?? 'Filed';
+      card.append(this.el('span', { className: 'ws-filing-project', text: decidedLabel }));
+      if (this.#reassigning && this.#projects.length > 0) {
+        card.append(this.#reassignForm(ctx, gen, filing));
+      } else if (this.#projects.length > 0) {
+        // No project list (the /client/content/projects fetch failed) means
+        // the reassign picker would render with zero options and no way to
+        // confirm — offering "Change" in that state is a dead end, so it is
+        // withheld rather than shown broken.
+        const change = this.el('button', { text: 'Change', attrs: { type: 'button' } });
+        change.addEventListener('click', () => {
+          this.#reassigning = true;
+          this.#paint(ctx, gen);
+        });
+        card.append(change);
+      }
+    } else {
+      // 'suggested' (classify-on-demand always sets a status, so this is the
+      // only remaining branch once filing !== null).
+      const label = filing.suggestedProjectLabel ?? filing.suggestedProjectKey ?? 'Unknown project';
+      card.append(this.el('span', { className: 'ws-filing-project', text: label }));
+      if (filing.confidence) {
+        card.append(this.el('span', {
+          className: `ws-filing-badge ws-filing-badge-${filing.confidence}`,
+          text: filing.confidence,
+        }));
+      }
+      if (this.#reassigning && this.#projects.length > 0) {
+        card.append(this.#reassignForm(ctx, gen, filing));
+      } else {
+        const fileButton = this.el('button', { text: 'File', attrs: { type: 'button' } });
+        fileButton.addEventListener('click', () => {
+          if (!filing.suggestedProjectKey) return;
+          this.track(this.#assign(ctx, gen, filing.suggestedProjectKey));
+        });
+        card.append(fileButton);
+        // See the 'confirmed'/'reassigned' branch above: withhold Reassign
+        // (rather than opening a picker with zero options) when the
+        // projects list failed to load.
+        if (this.#projects.length > 0) {
+          const reassignButton = this.el('button', { text: 'Reassign', attrs: { type: 'button' } });
+          reassignButton.addEventListener('click', () => {
+            this.#reassigning = true;
+            this.#paint(ctx, gen);
+          });
+          card.append(reassignButton);
+        }
+      }
+    }
+
+    this.root.append(card);
+  }
+
+  #reassignForm(ctx: ClientPanelContext, gen: number, filing: FilingRecord): HTMLElement {
+    const select = this.el('select', { attrs: { 'aria-label': 'Project' } });
+    const seeded = filing.decidedProjectKey ?? filing.suggestedProjectKey ?? this.#projects[0]?.key ?? '';
+    for (const project of this.#projects) {
+      const option = this.el('option', { text: project.label, attrs: { value: project.key } });
+      if (project.key === seeded) option.setAttribute('selected', '');
+      select.append(option);
+    }
+    // No listener-tracked selection state: if `seeded` isn't among
+    // `this.#projects` (suggestion outside the returned set, or the
+    // projects fetch failed), the browser silently falls back to option 0
+    // and `select.value` reflects that. Confirm must post exactly what the
+    // picker displays, so it reads `select.value` directly rather than a
+    // variable that could drift from what's on screen.
+    const confirm = this.el('button', { text: 'Confirm', attrs: { type: 'button' } });
+    confirm.addEventListener('click', () => {
+      if (!select.value) return;
+      this.track(this.#assign(ctx, gen, select.value));
+    });
+    const cancel = this.el('button', { text: 'Cancel', attrs: { type: 'button' } });
+    cancel.addEventListener('click', () => {
+      this.#reassigning = false;
+      this.#paint(ctx, gen);
+    });
+
+    return this.el('div', { className: 'ws-filing-reassign' }, [select, confirm, cancel]);
+  }
+
+  async #assign(ctx: ClientPanelContext, gen: number, projectKey: string): Promise<void> {
+    if (!this.#current(gen) || !this.#match) return;
+    const fileIndexId = this.#match.fileIndexId;
+    try {
+      const body = await ctx.fetchJson(`/client/filing/${encodeURIComponent(fileIndexId)}/assign`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ projectKey }),
+        signal: this.signal,
+      });
+      if (!this.#current(gen)) return;
+      const { filing } = expectAssignResponse(body);
+      this.#match = { ...this.#match, filing };
+      this.#reassigning = false;
+      this.#paint(ctx, gen);
+    } catch (error) {
+      if (isAbort(error) || !this.#current(gen)) return;
+      this.renderError('The filing change could not be saved.', () => {
+        this.track(this.#assign(ctx, gen, projectKey));
+      });
+    }
+  }
+}

--- a/ee/workspace/src/web/index.ts
+++ b/ee/workspace/src/web/index.ts
@@ -6,7 +6,9 @@
  * (see the testkit's web idempotency probe), so every definition is guarded
  * by customElements.get().
  */
+import { WorkspaceDashboard } from './dashboard';
 import { WorkspaceDeviceIndex } from './deviceIndex';
+import { WorkspaceFilingCard } from './filingCard';
 import { WorkspaceSourcesPage } from './sourcesPage';
 
 export function defineWorkspaceElements(): void {
@@ -16,9 +18,17 @@ export function defineWorkspaceElements(): void {
   if (!customElements.get('workspace-device-index')) {
     customElements.define('workspace-device-index', WorkspaceDeviceIndex);
   }
+  if (!customElements.get('workspace-dashboard')) {
+    customElements.define('workspace-dashboard', WorkspaceDashboard);
+  }
+  if (!customElements.get('workspace-filing-card')) {
+    customElements.define('workspace-filing-card', WorkspaceFilingCard);
+  }
 }
 
 defineWorkspaceElements();
 
 export { WorkspaceSourcesPage } from './sourcesPage';
 export { WorkspaceDeviceIndex } from './deviceIndex';
+export { WorkspaceDashboard } from './dashboard';
+export { WorkspaceFilingCard } from './filingCard';

--- a/ee/workspace/src/web/styles.ts
+++ b/ee/workspace/src/web/styles.ts
@@ -55,4 +55,23 @@ input, select {
 .muted { opacity: 0.7; }
 .stats { display: grid; gap: 0.3rem; margin: 0; padding: 0; list-style: none; }
 .row-actions { display: flex; gap: 0.4rem; }
+.skeleton { display: inline-block; }
+.ws-filing {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+.ws-filing-label { opacity: 0.7; font-size: 0.85rem; }
+.ws-filing-project { font-weight: 600; }
+.ws-filing-badge {
+  font-size: 0.75rem;
+  padding: 0.05rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+}
+.ws-filing-badge-high { color: #15803d; border-color: #15803d; }
+.ws-filing-badge-low { color: #b45309; border-color: #b45309; }
+.ws-filing-reassign { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
 `;


### PR DESCRIPTION
Closes #3478.

## Why

The ee/workspace merge (#3455) imported `LanternOps/breeze-workspace` @ `c5799345b` — three commits behind that repo's `origin/main` (`4e1afda`). The merge plan pinned `<WS_SHA>` from a local clone's `git rev-parse HEAD` **without fetching first**, and that clone was stale. The import commit recorded the SHA accurately; it was just the wrong SHA to pin.

Nothing was wrong with the *mechanism* #3455 built — the built-in extension path, Docker wiring, CI boot-step and flag gating are all fine. The payload was a three-week-old snapshot.

## What this ports

| upstream | PR | what |
|---|---|---|
| `f090145` | #19 | W3 dashboard v1 + productized ingest — delta-triggered jobs with retry/backoff |
| `ad2222d` | #20 | W4 Outlook filing card — client gate, tiered email matcher, filing panel |
| `4e1afda` | #21 | content layer graduated out of dev-preview + Gate 0 verdict |

New modules: `ingestJobsService`, `ingestJobRunner`, `ingestErrors`, `schema/ingestJobs`, `routes/dashboard`, `routes/client`, `routes/clientGate`, `services/dashboardService`, `services/emailMatchService`, `web/dashboard`, `web/filingCard`. New migration: `2026-07-25-ingest-jobs.sql`.

## What is deliberately NOT ported

The upstream delta also touched `.gitignore`, `README.md`, `breeze-extension.json`, `dev/`, `docs/superpowers/` and `test/conformance/` — every one of those is a category #3455's retirement inventory dropped on purpose, so carrying them now would undo that decision.

Two upstream design docs in that set stay out of this **public** repo deliberately: `2026-07-28-extension-trust-boundary-finding.md` is a security finding whose own header states it lives in the private repo on purpose and reserves disclosure as an explicit decision, and `2026-07-28-gate0-findings.md` is the probe writeup it references. Both remain in the archived repo's history. **Flagging for a disclosure call rather than making one.**

## Import adaptations re-applied at the newer SHA

- **`orgExportColumns` is an ee-merge addition upstream never had.** A wholesale manifest copy silently dropped it; the `manifestExportColumns` guard test caught that immediately. Restored, and extended with a `workspace_ingest_jobs` entry — `cursor` excluded as an opaque resume token, matching the sibling `workspace_crawl_runs` exclusion.
- **`apps/api`'s tsconfig is stricter than `ee/workspace`'s own** (`noUncheckedIndexedAccess`). The ported code needed the same non-null adaptations #3455 applied to five files, plus four new sites in `emailMatchService`. Worth knowing: `pnpm --filter @breeze/ext-workspace typecheck` passes *without* them — the apps/api project typecheck is the real gate, because ee/workspace compiles into its bundle.
- **The dropped legacy `breeze-extension.json` is no longer importable**, so the tests pinning it were removed. Two covered W4's `clientSurfaces`/`clientPanels`; their negative halves (the frozen `.strict()` v1 schema rejects both keys) are kept. The `helperRoutes` guarantee those tests protected now lives as an explicit field on the `BUILTINS` entry in `builtinRegistry.ts`.

## Known gap: `/client/*` has no core-side dispatcher

W4's client surface is ported but **not reachable**. Core's generic client-ai session proxy and the loader support that carries `clientSurfaces`/`clientPanels` are unmerged — four commits sitting on `ToddHebebrand/client-ext-seam-w4` (`701cc541a`, `55db2327a`, `e9860b560`, `d9ffc0131`). `clientGate` demands an organization-scoped context, so the surface fails closed until that platform work lands. Porting it now keeps ee/workspace a faithful mirror of the archived repo; activating it is a separate decision about which of those four commits serve the third-party platform generally.

## Verification

- `ee/workspace`: **586/586** unit (was 424), **151/151** integration (was 112)
- `apps/api` extensions+config: **731/731**, including the `dockerfileWorkspaceManifests` and `extensionBundledDependencies` guards
- Strict `tsc --project apps/api/tsconfig.json`: clean
- `eslint src`: clean; web bundle builds (576 KB)
- **Live flag-on boot** against pgvector: `2026-07-25-ingest-jobs.sql` applies incrementally on an existing schema (RLS enabled+forced, 4 org-isolation policies, both indexes incl. the partial unique index), `[extensions] loaded built-in "workspace" 0.2.0`, `/health` 200, zero CRITICAL lines
- `apps/api` `builtinTableProbe.integration.test.ts` passes with the 14-table declaration. `twoReplicaReconcile.integration.test.ts` timed out once and passed on re-run — the known shared-`:5433` non-hermetic flakiness (#3475), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)