### PR TITLE
fix(api): quote PDF image blocks overlap the text that follows them

### DIFF
--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -2,13 +2,43 @@ import { describe, it, expect } from 'vitest';
 import zlib from 'node:zlib';
 import PDFKitDocument from 'pdfkit';
 import { PDFDocument } from 'pdf-lib';
-import { renderQuotePdf, contractUploadedMarker, columnsFor } from './quotePdf';
+import { renderQuotePdf, contractUploadedMarker, columnsFor, imageIntrinsicSize } from './quotePdf';
 
-// A minimal valid 1x1 transparent PNG (the smallest real PNG pdfkit will accept).
-const ONE_BY_ONE_PNG = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
-  'base64',
-);
+// Encode a real, pdfkit-decodable grayscale PNG of the given dimensions. The
+// previous hand-pasted base64 fixture was NOT decodable by pdfkit ("Incomplete
+// or corrupt PNG file") — every doc.image() draw of it silently hit the
+// catch-and-continue branch, which let the image-cursor overlap bug ship with
+// green tests.
+function crc32(buf: Buffer): number {
+  let crc = ~0;
+  for (const byte of buf) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return ~crc >>> 0;
+}
+function pngChunk(type: string, data: Buffer): Buffer {
+  const body = Buffer.concat([Buffer.from(type, 'latin1'), data]);
+  const len = Buffer.alloc(4); len.writeUInt32BE(data.length);
+  const crc = Buffer.alloc(4); crc.writeUInt32BE(crc32(body));
+  return Buffer.concat([len, body, crc]);
+}
+function makePng(width: number, height: number): Buffer {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 0; // grayscale
+  const scanlines = Buffer.alloc(height * (width + 1), 0x80); // filter byte + pixels
+  for (let r = 0; r < height; r++) scanlines[r * (width + 1)] = 0; // filter: none
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', zlib.deflateSync(scanlines)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+const ONE_BY_ONE_PNG = makePng(1, 1);
 
 // pdfkit flate-compresses its content streams, so the drawn text isn't greppable
 // in the raw bytes. Inflate every stream, then decode the show-text operands.
@@ -720,5 +750,89 @@ describe('renderQuotePdf', () => {
       );
       expect(buf.subarray(0, 4).toString()).toBe('%PDF');
     });
+  });
+
+  describe('image block flow (regression: doc.image never advances pdfkit cursor)', () => {
+    // The 1x1 PNG in a 200x400 fit box draws at 200x200 (pdfkit fit upscales
+    // proportionally: scale = min(200/1, 400/1) = 200).
+    const imageBlock = (id: string, sortOrder: number) =>
+      ({ id, blockType: 'image', sortOrder, content: { imageId: `img-${id}`, width: 200 } });
+
+    it('text after an image block starts below the image, not on top of it', async () => {
+      const buf = await renderQuotePdf(
+        { id: 'q1', quoteNumber: 'Q-9', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '0.00', currencyCode: 'USD' },
+        [
+          { id: 'b1', blockType: 'rich_text', sortOrder: 0, content: { html: '<p>MARKERBEFORE</p>' } },
+          imageBlock('b2', 1),
+          { id: 'b3', blockType: 'rich_text', sortOrder: 2, content: { html: '<p>MARKERAFTER</p>' } },
+        ],
+        [],
+        async () => ({ data: ONE_BY_ONE_PNG }),
+        {},
+      );
+      const positioned = extractPositionedPdfText(buf);
+      const before = positioned.find((f) => f.text.includes('MARKERBEFORE'))!;
+      const after = positioned.find((f) => f.text.includes('MARKERAFTER'))!;
+      expect(before).toBeDefined();
+      expect(after).toBeDefined();
+      // The 200pt-tall image sits between them; the shipped overlap bug put
+      // MARKERAFTER ~20pt below MARKERBEFORE, straight across the image.
+      expect(after.y - before.y).toBeGreaterThanOrEqual(200);
+    });
+
+    it('a run of tall images paginates instead of overflowing the bottom margin', async () => {
+      const buf = await renderQuotePdf(
+        { id: 'q1', quoteNumber: 'Q-10', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '0.00', currencyCode: 'USD' },
+        [1, 2, 3, 4].map((n) => imageBlock(`b${n}`, n)),
+        [],
+        async () => ({ data: ONE_BY_ONE_PNG }),
+        {},
+      );
+      // 4 x ~206pt of image cannot fit one A4 content column (~742pt).
+      const pages = (await PDFDocument.load(buf)).getPageCount();
+      expect(pages).toBeGreaterThanOrEqual(2);
+    });
+
+    it('cover page: a wrapping preparedForName pushes the address down instead of overlapping it', async () => {
+      const buf = await renderQuotePdf(
+        {
+          id: 'q1', quoteNumber: 'Q-11', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '0.00', currencyCode: 'USD',
+          coverPage: { enabled: true, title: 'Proposal', preparedForName: 'Cassidy Lowrey — Animal Health at Home Veterinary Practice LLC' },
+          billToAddress: { line1: '406 10th Street', city: 'Berthoud', region: 'CO', postalCode: '80513' },
+        } as never,
+        [], [], async () => null, {},
+      );
+      const positioned = extractPositionedPdfText(buf);
+      const nameBottom = Math.max(...positioned.filter((f) => f.text.includes('Animal Health')).map((f) => f.y));
+      const address = positioned.find((f) => f.text.includes('406 10th Street'))!;
+      expect(address).toBeDefined();
+      expect(Number.isFinite(nameBottom)).toBe(true);
+      // Address must start below the wrapped name's LAST line (12pt font ≈
+      // 14pt line height); the shipped bug drew it at a fixed one-line offset.
+      expect(address.y).toBeGreaterThan(nameBottom + 10);
+    });
+  });
+});
+
+describe('imageIntrinsicSize', () => {
+  it('parses PNG IHDR dimensions', () => {
+    expect(imageIntrinsicSize(ONE_BY_ONE_PNG)).toEqual({ width: 1, height: 1 });
+  });
+
+  it('parses JPEG SOF dimensions (skipping APP segments)', () => {
+    // SOI, APP0 (JFIF stub), SOF0 with height 30 / width 20.
+    const jpeg = Buffer.concat([
+      Buffer.from([0xff, 0xd8]),
+      Buffer.from([0xff, 0xe0, 0x00, 0x10]), Buffer.alloc(14), // APP0, len 16
+      Buffer.from([0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x1e, 0x00, 0x14]), Buffer.alloc(10), // SOF0: h=30 w=20
+    ]);
+    expect(imageIntrinsicSize(jpeg)).toEqual({ width: 20, height: 30 });
+  });
+
+  it('returns null for unparseable buffers', () => {
+    expect(imageIntrinsicSize(Buffer.from('not an image at all'))).toBeNull();
+    expect(imageIntrinsicSize(Buffer.alloc(0))).toBeNull();
+    // WebP (RIFF) — pdfkit can't embed it and the probe doesn't parse it.
+    expect(imageIntrinsicSize(Buffer.from('RIFF0000WEBPVP8 '))).toBeNull();
   });
 });

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -246,6 +246,46 @@ function ensureSpace(doc: PDFKit.PDFDocument, y: number, needed = 40): number {
   return y;
 }
 
+/**
+ * Intrinsic pixel dimensions of a PNG or JPEG buffer (the two formats pdfkit
+ * can embed). PNG: IHDR is always the first chunk, width/height at bytes
+ * 16/20. JPEG: scan marker segments for a frame header (SOF0–SOF15, minus the
+ * DHT/DAC/RST family), height/width at offsets 5/7 of the segment payload.
+ * Returns null for anything unparseable — callers fall back to the fit-box
+ * height, trading whitespace for the guarantee that following content never
+ * lands on top of the image (doc.image with explicit x/y does NOT advance
+ * pdfkit's cursor, so the drawn height must be computed here).
+ */
+export function imageIntrinsicSize(buf: Buffer): { width: number; height: number } | null {
+  try {
+    if (buf.length >= 24 && buf.readUInt32BE(0) === 0x89504e47 && buf.toString('latin1', 12, 16) === 'IHDR') {
+      const width = buf.readUInt32BE(16);
+      const height = buf.readUInt32BE(20);
+      return width > 0 && height > 0 ? { width, height } : null;
+    }
+    if (buf.length >= 4 && buf[0] === 0xff && buf[1] === 0xd8) {
+      let off = 2;
+      while (off + 9 < buf.length) {
+        if (buf.readUInt8(off) !== 0xff) return null;
+        const marker = buf.readUInt8(off + 1);
+        if (marker === 0xd8 || (marker >= 0xd0 && marker <= 0xd9)) { off += 2; continue; } // standalone markers
+        const segLen = buf.readUInt16BE(off + 2);
+        if (segLen < 2) return null;
+        const isSof = marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+        if (isSof) {
+          const height = buf.readUInt16BE(off + 5);
+          const width = buf.readUInt16BE(off + 7);
+          return width > 0 && height > 0 ? { width, height } : null;
+        }
+        off += 2 + segLen;
+      }
+    }
+  } catch {
+    /* fall through to null */
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Line table: qty | description | unit | total. Right-aligned money columns,
 // matching invoicePdf's table styling (uppercase grey headers, 1px rule).
@@ -644,7 +684,10 @@ async function renderCoverPage(
   if (preparedForName) {
     doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED FOR', c.left, rowY);
     doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(preparedForName, c.left, rowY + 14, { width: colW });
-    let addrY = rowY + 30;
+    // Start the address at the name's real bottom edge (doc.y) — a name long
+    // enough to wrap painted the address on top of its second line when this
+    // assumed a fixed one-line name height.
+    let addrY = Math.max(rowY + 30, doc.y + 4);
     doc.fillColor('#4b5563').fontSize(9).font('Helvetica');
     for (const line of addressLines(quote.billToAddress as BillToAddress | null)) {
       doc.text(line, c.left, addrY, { width: colW });
@@ -658,7 +701,7 @@ async function renderCoverPage(
     const seller = (quote.sellerSnapshot as SellerSnapshot | null) ?? null;
     doc.fillColor('#9ca3af').fontSize(9).font('Helvetica-Bold').text('PREPARED BY', rightX, rowY);
     doc.fillColor('#111827').fontSize(12).font('Helvetica-Bold').text(seller?.name ?? partnerName, rightX, rowY + 14, { width: colW });
-    let addrY = rowY + 30;
+    let addrY = Math.max(rowY + 30, doc.y + 4); // same wrap-safe start as PREPARED FOR
     doc.fillColor('#4b5563').fontSize(9).font('Helvetica');
     for (const line of sellerAddressLines(seller)) {
       doc.text(line, rightX, addrY, { width: colW });
@@ -805,10 +848,21 @@ export async function renderQuotePdf(
         img = null;
       }
       if (img?.data) {
-        const fitWidth = Number((b.content as { width?: number }).width ?? 400);
+        const fitWidth = Math.min(Number((b.content as { width?: number }).width ?? 400), c.contentWidth);
+        const fitHeight = 400;
+        // doc.image() with explicit x/y never advances pdfkit's cursor, so the
+        // drawn height must be computed up front — both to reserve page space
+        // (a tall image near the bottom margin would otherwise overflow the
+        // page) and to advance y past the image (stale-cursor overlap shipped
+        // as text painting straight over every image block).
+        const dims = imageIntrinsicSize(img.data);
+        const drawnHeight = dims
+          ? Math.min(fitWidth / dims.width, fitHeight / dims.height) * dims.height
+          : fitHeight;
+        y = ensureSpace(doc, y, Math.min(drawnHeight, doc.page.height - doc.page.margins.top - doc.page.margins.bottom) + 6);
         try {
-          doc.image(img.data, c.left, y, { fit: [Math.min(fitWidth, c.contentWidth), 400] });
-          y = doc.y + 6;
+          doc.image(img.data, c.left, y, { fit: [fitWidth, fitHeight] });
+          y += drawnHeight + 6;
         } catch (e) {
           // A corrupt/unsupported image must not abort the whole document.
           console.error('[quotePdf] doc.image failed', imageId, e instanceof Error ? e.message : e);


### PR DESCRIPTION
## Problem

Every quote/proposal PDF with image blocks rendered following text **on top of** the images ([pdfkit's `doc.image()` with explicit x/y never advances the text cursor](https://pdfkit.org/docs/images.html), and the block walker read the stale cursor afterwards). Found while recreating a 21-page PandaDoc proposal as a Breeze quote — every interior photo had paragraphs painted across it.

Two more members of the same stale-cursor family fixed alongside:
- A tall image near the bottom margin overflowed the page (only 50pt was reserved before drawing); images now reserve their real drawn height and paginate.
- The cover page's PREPARED FOR / PREPARED BY address columns assumed a one-line name — a wrapping `preparedForName` drew the address over the name's second line.

## Fix

- New `imageIntrinsicSize()` probe (PNG IHDR + JPEG SOF scan) computes the drawn height for pdfkit's `fit` box up front; the image branch reserves that space and advances `y` past it. Unparseable buffers degrade to the fit-box height — whitespace, never overlap.
- Cover address columns start at `doc.y` (the name's real bottom edge) instead of a fixed one-line offset.

## Why the tests were green

The test suite's hand-pasted 1x1 PNG fixture was **never decodable by pdfkit** — every `doc.image()` call in tests threw "Incomplete or corrupt PNG file" into the swallow-and-continue branch, so no test ever exercised a successful image draw. Replaced with a real in-test PNG encoder (grayscale, proper CRC32), which also strengthens the pre-existing image/thumbnail tests.

New regression coverage: text-below-image position assertion, tall-image pagination, wrapped-cover-name vs address position, and unit tests for the dimension probe (PNG / JPEG / garbage / WebP→null).

## Testing
- `vitest run src/services/quotePdf.test.ts` — 36/36
- `tsc --noEmit` on @breeze/api — clean
- Visually verified against the real proposal that surfaced the bug (Q-2026-0015): images now flow correctly with text below

🤖 Generated with [Claude Code](https://claude.com/claude-code)