### PR TITLE
fix(api): quote PDF contract {{client.name}} on drafts + full-bleed cover background

### DIFF
--- a/apps/api/src/routes/portal/quotes.ts
+++ b/apps/api/src/routes/portal/quotes.ts
@@ -111,12 +111,6 @@ quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
   ));
   const [brand] = await db.select({ logoUrl: portalBranding.logoUrl, primaryColor: portalBranding.primaryColor, footerText: portalBranding.footerText }).from(portalBranding).where(eq(portalBranding.orgId, quote.orgId)).limit(1);
   const loadImage = async (imageId: string) => { const img = await readQuoteImage(imageId, id); return img ? { data: img.data } : null; };
-  // Pre-fetch the same render data Task 13's portal detail route uses
-  // (system-context read of pinned template versions) and shape it for the
-  // renderer: substituted HTML per authored contract block, plus any uploaded
-  // contract PDFs to append after rendering (pdfkit can't draw an existing
-  // PDF's pages — see pdfMerge.ts).
-  const { contractRenderData, uploads } = await loadContractPdfInputs(blocks, quote);
   const { renderQuotePdf } = await import('../../services/quotePdf');
   // Legacy/draft docs have no frozen snapshot; synthesize from the live partner so
   // the From block still renders (issued docs use the frozen column).
@@ -129,6 +123,16 @@ quoteRoutes.get('/quotes/:id/pdf', zValidator('param', idParam), async (c) => {
     depositDueTotal: totals.depositDueTotal,
     categoryBreakdown: totals.categoryBreakdown,
   };
+  // Pre-fetch the same render data Task 13's portal detail route uses
+  // (system-context read of pinned template versions) and shape it for the
+  // renderer: substituted HTML per authored contract block, plus any uploaded
+  // contract PDFs to append after rendering (pdfkit can't draw an existing
+  // PDF's pages — see pdfMerge.ts).
+  // Takes quoteForRender (not the raw row) so {{client.name}}/{{seller.*}} resolve
+  // from the same overlaid fields the page renderer uses — the portal only serves
+  // frozen (sent+) quotes today, but the admin draft-PDF route shipped exactly
+  // this raw-vs-overlaid split as a blank {{client.name}} in contract text.
+  const { contractRenderData, uploads } = await loadContractPdfInputs(blocks, quoteForRender);
   const pdf = await renderQuotePdf(quoteForRender, blocks, lines, loadImage, {
     partnerName: partner?.name ?? 'Proposal', logoUrl: brand?.logoUrl ?? null, primaryColor: brand?.primaryColor ?? null,
     footer: quote.terms ?? partner?.invoiceFooter ?? brand?.footerText ?? null, currencyCode: quote.currencyCode ?? partner?.currencyCode ?? 'USD',

--- a/apps/api/src/routes/quotes/quotes.test.ts
+++ b/apps/api/src/routes/quotes/quotes.test.ts
@@ -96,7 +96,7 @@ vi.mock('../../middleware/auth', () => ({
 import { quoteRoutes } from './index';
 import * as svc from '../../services/quoteService';
 import { QuoteServiceError } from '../../services/quoteTypes';
-import { renderContractBlocksForClient, loadContractBlockAuthoring } from '../../services/contractTemplateRender';
+import { renderContractBlocksForClient, loadContractBlockAuthoring, loadContractPdfInputs } from '../../services/contractTemplateRender';
 import { ContractTemplateServiceError } from '../../services/contractTemplateService';
 
 function app() {
@@ -593,6 +593,25 @@ describe('quote crud + lines routes', () => {
       expect(q.id).toBe(QUOTE_ID);
       expect(blocks).toHaveLength(2);
       expect(lines).toHaveLength(1);
+    });
+
+    it('hands the billTo-overlaid quote to loadContractPdfInputs so {{client.name}} resolves on drafts', async () => {
+      (svc.getQuote as any).mockResolvedValue(quoteFixture);
+      dbRows.next = [
+        [{ name: 'Acme MSP', footer: null, currency: 'USD' }],
+        [{ logoUrl: null, primaryColor: null, footerText: null }]
+      ];
+      pdf.render.mockResolvedValue(Buffer.from('%PDF-1.4 test'));
+
+      await app().request(`/${QUOTE_ID}/pdf`, { method: 'GET' });
+
+      // A draft's raw row has billToName null (frozen only at send); contract
+      // auto-variables resolve from the quote arg passed HERE, so it must be the
+      // overlaid render row. Passing the raw row shipped as a blank
+      // {{client.name}} in the contract text while the page header — rendered
+      // from the overlaid row — showed the customer name fine.
+      const [, quoteArg] = (loadContractPdfInputs as any).mock.calls.at(-1) ?? [];
+      expect(quoteArg?.billToName).toBe('Acme Customer');
     });
 
     it('returns 404 when the quote is not found / cross-tenant (QUOTE_NOT_FOUND)', async () => {

--- a/apps/api/src/routes/quotes/quotes.ts
+++ b/apps/api/src/routes/quotes/quotes.ts
@@ -270,7 +270,11 @@ quoteCrudRoutes.get('/:id/pdf', scopes, readPerm, zValidator('param', idParam), 
     // renderer: substituted HTML per authored contract block, plus any uploaded
     // contract PDFs to append after rendering (pdfkit can't draw an existing
     // PDF's pages — see pdfMerge.ts).
-    const { contractRenderData, uploads } = await loadContractPdfInputs(blocks, quote);
+    // Must receive quoteForRender (the billTo-overlaid row), not the raw quote:
+    // on a DRAFT the raw row's billToName is still null, so {{client.name}} (and
+    // client.address) blank-fill in the contract text while the page header —
+    // rendered from quoteForRender three lines down — shows the org name fine.
+    const { contractRenderData, uploads } = await loadContractPdfInputs(blocks, quoteForRender);
 
     const { renderQuotePdf } = await import('../../services/quotePdf');
     const pdf = await renderQuotePdf(quoteForRender, blocks, lines, loadImage, branding, loadCatalogImage, contractRenderData);

--- a/apps/api/src/services/quotePdf.test.ts
+++ b/apps/api/src/services/quotePdf.test.ts
@@ -793,6 +793,25 @@ describe('renderQuotePdf', () => {
       expect(pages).toBeGreaterThanOrEqual(2);
     });
 
+    it('cover page: with a cover image the title moves into the bottom legibility band; without one it stays at the top', async () => {
+      const base = {
+        id: 'q1', quoteNumber: 'Q-12', oneTimeTotal: '0.00', monthlyRecurringTotal: '0.00', annualRecurringTotal: '0.00', total: '0.00', currencyCode: 'USD',
+      };
+      const withImage = await renderQuotePdf(
+        { ...base, coverPage: { enabled: true, title: 'FULLBLEEDTITLE', coverImageId: 'img-cover' } } as never,
+        [], [], async () => ({ data: ONE_BY_ONE_PNG }), {},
+      );
+      const withoutImage = await renderQuotePdf(
+        { ...base, coverPage: { enabled: true, title: 'FULLBLEEDTITLE' } } as never,
+        [], [], async () => null, {},
+      );
+      const titleY = (buf: Buffer) => extractPositionedPdfText(buf).find((f) => f.text.includes('FULLBLEEDTITLE'))!.y;
+      // Full-bleed background → title sits inside the bottom band (>= 62% of
+      // the A4 page height); classic no-image cover keeps it under the top margin.
+      expect(titleY(withImage)).toBeGreaterThanOrEqual(841.89 * 0.62);
+      expect(titleY(withoutImage)).toBeLessThan(200);
+    });
+
     it('cover page: a wrapping preparedForName pushes the address down instead of overlapping it', async () => {
       const buf = await renderQuotePdf(
         {

--- a/apps/api/src/services/quotePdf.ts
+++ b/apps/api/src/services/quotePdf.ts
@@ -644,14 +644,11 @@ async function renderCoverPage(
   // Branding wordmark (mirrors the main document header's plain-text wordmark —
   // this renderer has no logo-image loader; logoUrl is a remote URL and the
   // renderer must stay network-free/pure).
-  doc.fillColor('#111827').fontSize(16).font('Helvetica-Bold').text(partnerName, c.left, top);
-
-  // Cover image: top ~55% of the page, full content width. A failed/absent
-  // load degrades to "no image" — never aborts the document (same discipline
-  // as every other image draw in this file).
-  const imageTop = top + 30;
-  const imageAreaHeight = doc.page.height * 0.55 - imageTop;
-  let imageBottom = imageTop;
+  // Cover image: full-bleed page background (cover-fit, clipped to the page —
+  // pdfkit's `cover` scales but does not crop). A failed/absent load degrades
+  // to "no image" — never aborts the document (same discipline as every other
+  // image draw in this file). Drawn FIRST so every text element paints on top.
+  let hasBackground = false;
   if (cp.coverImageId) {
     let img: { data: Buffer } | null = null;
     try {
@@ -662,17 +659,48 @@ async function renderCoverPage(
     }
     if (img?.data) {
       try {
-        doc.image(img.data, c.left, imageTop, { fit: [c.contentWidth, imageAreaHeight] });
-        imageBottom = imageTop + imageAreaHeight;
+        doc.save();
+        doc.rect(0, 0, doc.page.width, doc.page.height).clip();
+        doc.image(img.data, 0, 0, { cover: [doc.page.width, doc.page.height] });
+        doc.restore();
+        hasBackground = true;
       } catch (e) {
         console.error('[quotePdf] cover doc.image failed', cp.coverImageId, e instanceof Error ? e.message : e);
       }
     }
   }
 
-  // Title (24pt bold).
+  // Legibility scrim over arbitrary artwork: a near-opaque white band across
+  // the bottom of the page carries the title + prepared-for/by (and the page
+  // footer, which draws later in the same region). Skipped when there is no
+  // background — plain white pages need no scrim.
+  const bandTop = doc.page.height * 0.62;
+  if (hasBackground) {
+    doc.save();
+    doc.fillOpacity(0.94);
+    doc.rect(0, bandTop, doc.page.width, doc.page.height - bandTop).fill('#ffffff');
+    doc.restore();
+  }
+
+  // Branding wordmark (mirrors the main document header's plain-text wordmark —
+  // this renderer has no logo-image loader; logoUrl is a remote URL and the
+  // renderer must stay network-free/pure). On a background image it sits on a
+  // translucent white pill so it survives busy artwork.
+  if (hasBackground) {
+    doc.save();
+    doc.fontSize(16).font('Helvetica-Bold');
+    const wordW = doc.widthOfString(partnerName);
+    doc.fillOpacity(0.85);
+    doc.roundedRect(c.left - 10, top - 8, wordW + 20, 34, 6).fill('#ffffff');
+    doc.restore();
+  }
+  doc.fillColor('#111827').fontSize(16).font('Helvetica-Bold').text(partnerName, c.left, top);
+
+  // Title (24pt bold): inside the bottom band on a background cover, else in
+  // the classic position under the top margin.
   if (cp.title?.trim()) {
-    doc.fillColor('#111827').fontSize(24).font('Helvetica-Bold').text(cp.title.trim(), c.left, imageBottom + 24, { width: c.contentWidth });
+    const titleY = hasBackground ? bandTop + 28 : top + 54;
+    doc.fillColor('#111827').fontSize(24).font('Helvetica-Bold').text(cp.title.trim(), c.left, titleY, { width: c.contentWidth });
   }
 
   // Prepared for / Prepared by, side by side at the bottom of the page.


### PR DESCRIPTION
## Problem

Found reviewing a real draft proposal PDF after v0.105.1: the embedded contract text rendered `Service Address: 's primary place of business` and `A. ("Company") wishes to contract…` — `{{client.name}}` resolved to empty, while the same page's PREPARED FOR header showed the customer name correctly.

Root cause: `GET /quotes/:id/pdf` builds a billTo-overlaid `quoteForRender` (drafts have `billToName` null until send freezes it, so the route overlays the org name) but passed the **raw** quote row to `loadContractPdfInputs`, where `resolveAutoVariables` reads `quote.billToName ?? ''`. Header path got the overlay; contract-variable path didn't.

## Scope

- **Admin draft PDF download: live bug, fixed** — pass `quoteForRender` to `loadContractPdfInputs`.
- **Portal PDF route: latent only** (portal serves frozen sent+ quotes) — same reorder applied for consistency.
- **Send email PDF / portal view / acceptance snapshot: were never affected** — those paths freeze billTo before rendering (`quoteLifecycle` `frozenQuote`), verified.

## Testing
- New route regression test: asserts `loadContractPdfInputs` receives the overlaid row (`billToName` resolved) on a draft.
- `vitest run` quotes + portal route suites — 156/156.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: full-bleed cover page

The cover image now renders as the background of the entire front page (cover-fit, clipped) instead of a fitted box in the top half. A ~94%-opacity white band across the bottom of the page keeps the title, PREPARED FOR/BY, and footer legible over any artwork; the partner wordmark sits on a translucent pill. Covers without an image keep the previous layout. New positional regression test asserts the title moves into the bottom band with an image and stays at the top without one.