### PR TITLE
feat(api,web): resolve {{var.*}} per device at dispatch (#3409 PR2)

### DIFF
--- a/apps/api/src/__tests__/integration/tenantVariableResolution.integration.test.ts
+++ b/apps/api/src/__tests__/integration/tenantVariableResolution.integration.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tenant variable resolution (#3409 PR 2) — real-Postgres coverage for
+ * `loadTenantVariableScope` / `resolveForOrg` / `substituteTenantVariables`.
+ *
+ * `services/tenantVariableResolution.test.ts` proves the WHERE-clause shape
+ * against a mocked db; this suite proves the six properties that only mean
+ * anything against a real RLS-enforcing database:
+ *   1. org-owned value shadows the partner-wide one with the same key
+ *   2. an org inherits its partner's partner-wide value
+ *   3. an org NEVER sees another partner's partner-wide value
+ *   4. a two-org snapshot resolves each org independently in one call
+ *   5. resolution still returns partner-wide rows when called from INSIDE an
+ *      org-scoped withDbAccessContext — the regression proving the
+ *      runOutsideDbContext + withSystemDbAccessContext escape is present.
+ *      Comment out that escape in tenantVariableResolution.ts and THIS test
+ *      is the one that goes red (an org token's JWT lacks partnerId, so a
+ *      nested withSystemDbAccessContext that fails to elevate would see zero
+ *      partner-wide rows for the org under test).
+ *   6. a secret variable is loaded into the snapshot but substitution reports
+ *      it via secretsReferenced and never places its value in content.
+ *
+ * Modeled on tenantVariablesPartnerRls.integration.test.ts (same
+ * createPartner/createOrganization/withDbAccessContext helpers). Fixture rows
+ * are inserted through services/tenantVariables.ts's own
+ * encryptTenantVariableValue so the resolver's decryptTenantVariableValue call
+ * actually round-trips them — a literal ciphertext placeholder (as the RLS
+ * suite uses, since it never decrypts) would make every resolved value
+ * silently fail to decrypt and vanish from the snapshot.
+ */
+import './setup';
+import { randomUUID } from 'crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { db, withDbAccessContext, type DbAccessContext } from '../../db';
+import { tenantVariables, type TenantVariableRow } from '../../db/schema';
+import { createOrganization, createPartner } from './db-utils';
+import { encryptTenantVariableValue } from '../../services/tenantVariables';
+import {
+  describeVariableFailure,
+  loadTenantVariableScope,
+  resolveForOrg,
+  substituteTenantVariables
+} from '../../services/tenantVariableResolution';
+
+const created: string[] = [];
+
+function systemContext(): DbAccessContext {
+  return { scope: 'system', orgId: null, accessibleOrgIds: null, accessiblePartnerIds: null, userId: null };
+}
+
+/**
+ * An org-scoped session whose JWT carries no partnerId on the accessible-ids
+ * axis — accessiblePartnerIds stays empty, mirroring production exactly (see
+ * tenantVariablesPartnerRls.integration.test.ts's orgContext). This is the
+ * context property 5 dispatches resolution from: if the system-context escape
+ * in loadTenantVariableScope were missing, this ambient context (which cannot
+ * see partner-wide rows via RLS) would silently constrain the "system" query
+ * too, and the partner-wide fixture would disappear from the snapshot.
+ */
+function orgContext(orgId: string, partnerId: string): DbAccessContext {
+  return {
+    scope: 'organization',
+    orgId,
+    accessibleOrgIds: [orgId],
+    accessiblePartnerIds: [],
+    userId: null,
+    currentPartnerId: partnerId
+  };
+}
+
+interface FixtureOptions {
+  orgId?: string | null;
+  partnerId?: string | null;
+  key?: string;
+  isSecret?: boolean;
+}
+
+/** Insert one tenant_variables row with a real, decryptable ciphertext. */
+async function insertVariable(plaintext: string, options: FixtureOptions): Promise<TenantVariableRow> {
+  const id = randomUUID();
+  const [row] = await withDbAccessContext(systemContext(), () =>
+    db
+      .insert(tenantVariables)
+      .values({
+        id,
+        orgId: options.orgId ?? null,
+        partnerId: options.partnerId ?? null,
+        key: options.key ?? 'repo_url',
+        value: encryptTenantVariableValue(id, plaintext),
+        isSecret: options.isSecret ?? false
+      })
+      .returning()
+  );
+  if (!row) throw new Error('insert returned no row');
+  created.push(row.id);
+  return row;
+}
+
+afterEach(async () => {
+  if (created.length === 0) return;
+  await withDbAccessContext(systemContext(), async () => {
+    for (const id of created) {
+      await db.delete(tenantVariables).where(eq(tenantVariables.id, id));
+    }
+  });
+  created.length = 0;
+});
+
+describe('tenant variable resolution (integration)', () => {
+  it('1. org-owned value shadows the partner-wide one with the same key', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    await insertVariable('partner-value', { partnerId: partner.id, key: 'k' });
+    await insertVariable('org-value', { orgId: org.id, key: 'k' });
+
+    const scope = await loadTenantVariableScope([org.id]);
+    const resolved = resolveForOrg(scope, org.id);
+    expect(resolved.get('k')?.value).toBe('org-value');
+  });
+
+  it('2. an org inherits its partner\'s partner-wide value', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    await insertVariable('inherited-value', { partnerId: partner.id, key: 'inherited_key' });
+
+    const scope = await loadTenantVariableScope([org.id]);
+    const resolved = resolveForOrg(scope, org.id);
+    expect(resolved.get('inherited_key')?.value).toBe('inherited-value');
+  });
+
+  it('3. an org NEVER sees another partner\'s partner-wide value', async () => {
+    const partnerA = await createPartner();
+    const partnerB = await createPartner();
+    const orgA = await createOrganization({ partnerId: partnerA.id });
+    await insertVariable('partner-b-secret-value', { partnerId: partnerB.id, key: 'shared_key' });
+    await insertVariable('partner-a-value', { partnerId: partnerA.id, key: 'shared_key' });
+
+    const scope = await loadTenantVariableScope([orgA.id]);
+    const resolved = resolveForOrg(scope, orgA.id);
+    expect(resolved.get('shared_key')?.value).toBe('partner-a-value');
+    expect([...resolved.values()].some((v) => v.value === 'partner-b-secret-value')).toBe(false);
+  });
+
+  it('4. a two-org snapshot resolves each org independently in one call', async () => {
+    const partner = await createPartner();
+    const orgA = await createOrganization({ partnerId: partner.id });
+    const orgB = await createOrganization({ partnerId: partner.id });
+    await insertVariable('shared-partner-value', { partnerId: partner.id, key: 'shared' });
+    await insertVariable('org-a-only-value', { orgId: orgA.id, key: 'only_a' });
+    await insertVariable('org-b-only-value', { orgId: orgB.id, key: 'only_b' });
+
+    const scope = await loadTenantVariableScope([orgA.id, orgB.id]);
+
+    const resolvedA = resolveForOrg(scope, orgA.id);
+    expect(resolvedA.get('shared')?.value).toBe('shared-partner-value');
+    expect(resolvedA.get('only_a')?.value).toBe('org-a-only-value');
+    expect(resolvedA.has('only_b')).toBe(false);
+
+    const resolvedB = resolveForOrg(scope, orgB.id);
+    expect(resolvedB.get('shared')?.value).toBe('shared-partner-value');
+    expect(resolvedB.get('only_b')?.value).toBe('org-b-only-value');
+    expect(resolvedB.has('only_a')).toBe(false);
+  });
+
+  it('5. resolution called from INSIDE an org-scoped withDbAccessContext still returns partner-wide rows', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    await insertVariable('inherited-under-org-context', { partnerId: partner.id, key: 'inherited_under_org' });
+
+    // The critical difference from every other test in this file: the call to
+    // loadTenantVariableScope happens WHILE an org-scoped RLS context is
+    // already open on this async context — exactly how the route path calls
+    // it from inside a held request transaction. If the
+    // runOutsideDbContext(() => withSystemDbAccessContext(...)) escape in
+    // loadTenantVariableScope were removed, withSystemDbAccessContext would
+    // be a no-op nested inside this org context (see db/index.ts:
+    // withDbAccessContext returns immediately when a context is already on
+    // the stack), the ambient org GUCs would stay in force, and — because
+    // this org context's accessiblePartnerIds is deliberately empty, mirroring
+    // an org JWT with no partnerId — the partner-wide row would be invisible
+    // to RLS and vanish from the snapshot.
+    const resolved = await withDbAccessContext(orgContext(org.id, partner.id), async () => {
+      const scope = await loadTenantVariableScope([org.id]);
+      return resolveForOrg(scope, org.id);
+    });
+
+    expect(resolved.get('inherited_under_org')?.value).toBe('inherited-under-org-context');
+  });
+
+  it('6. a secret variable is loaded but reported via secretsReferenced, never substituted', async () => {
+    const partner = await createPartner();
+    const org = await createOrganization({ partnerId: partner.id });
+    await insertVariable('super-secret-value', { orgId: org.id, key: 's1_token', isSecret: true });
+
+    const scope = await loadTenantVariableScope([org.id]);
+    const resolved = resolveForOrg(scope, org.id);
+    expect(resolved.get('s1_token')).toMatchObject({ isSecret: true, value: 'super-secret-value' });
+
+    const outcome = substituteTenantVariables('curl -H "Authorization: {{var.s1_token}}"', resolved);
+    expect(outcome.content).not.toContain('super-secret-value');
+    expect(outcome.content).toContain('{{var.s1_token}}');
+    expect(outcome.secretsReferenced).toEqual(['s1_token']);
+    expect(outcome.unresolved).toEqual([]);
+
+    const failure = describeVariableFailure(outcome);
+    expect(failure).toMatch(/s1_token/);
+    expect(failure).not.toContain('super-secret-value');
+  });
+});

--- a/apps/api/src/db/autoMigrate.test.ts
+++ b/apps/api/src/db/autoMigrate.test.ts
@@ -517,7 +517,13 @@ describe('migration filename conventions', () => {
           dangling.map((entry) => `  - ${entry}`).join('\n') +
           `\n\nA migration was renamed or deleted without sweeping its references.`,
     ).toEqual([]);
-  });
+    // Explicit timeout: this case reads every .ts file under apps/api/src, so
+    // its runtime scales with the repo and is dominated by scheduler delay when
+    // the full 1,342-file suite runs it in parallel. Vitest's 5s default is a
+    // latent tripwire — and one that matters more here than most, because a
+    // flaky version of this guard is indistinguishable from the renamed-
+    // migration ENOENT it exists to move out of Integration Tests.
+  }, 60_000);
 });
 
 describe('core migration ordering', () => {

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -1503,6 +1503,41 @@ describe('mobile routes', () => {
       expect(writeRouteAuditMock).not.toHaveBeenCalled();
     });
 
+    it('returns 422 with the per-device reason when the only device failed to dispatch', async () => {
+      // #3409 PR2 gave executeScriptOnDevices a per-device failure channel: a
+      // device can now fail (e.g. an unresolved {{var.*}} token) while the
+      // call still reports ok:true with executions:[] and failures:[...].
+      // This route indexed executions[0] unconditionally, so that combination
+      // threw a TypeError and turned a user-fixable problem into a 500.
+      vi.mocked(db.select).mockReturnValue(
+        mockSelectLimitChain([
+          { id: '11111111-2222-4333-8444-555555555555', orgId: 'org-123', status: 'online', osType: 'linux', siteId: null }
+        ]) as any
+      );
+      executeScriptOnDevicesMock.mockResolvedValueOnce({
+        ok: true,
+        scriptId: '22222222-2222-2222-2222-222222222222',
+        executions: [],
+        failures: [{
+          deviceId: '11111111-2222-4333-8444-555555555555',
+          code: 'unresolved_variables',
+          error: 'Unresolved tenant variable(s): no value set for {{var.api_key}}',
+        }],
+      });
+
+      const res = await app.request('/mobile/devices/11111111-2222-4333-8444-555555555555/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'run_script', scriptId: '22222222-2222-2222-2222-222222222222' })
+      });
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.error).toBe('Unresolved tenant variable(s): no value set for {{var.api_key}}');
+      // Nothing ran, so no success audit.
+      expect(writeRouteAuditMock).not.toHaveBeenCalled();
+    });
+
     it('should run a script action by delegating to executeScriptOnDevices', async () => {
       vi.mocked(db.select).mockReturnValue(
         mockSelectLimitChain([

--- a/apps/api/src/routes/mobile.test.ts
+++ b/apps/api/src/routes/mobile.test.ts
@@ -1358,6 +1358,38 @@ describe('mobile routes', () => {
       expect(db.select).not.toHaveBeenCalled();
     });
 
+    it('rejects a nested-object parameter value (#3409 PR2 Task 7 — one script-parameter schema)', async () => {
+      const res = await app.request('/mobile/devices/11111111-2222-4333-8444-555555555555/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'run_script',
+          scriptId: '11111111-1111-1111-1111-111111111111',
+          parameters: { nested: { bad: true } }
+        })
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts string/number/boolean parameter values', async () => {
+      vi.mocked(db.select).mockReturnValue(mockSelectLimitChain([]) as any);
+
+      const res = await app.request('/mobile/devices/11111111-2222-4333-8444-555555555555/actions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'run_script',
+          scriptId: '11111111-1111-1111-1111-111111111111',
+          parameters: { s: 'a', n: 3, b: true }
+        })
+      });
+
+      // Not 400: the request clears schema validation and proceeds to the
+      // (mocked-empty) device lookup, same as the existing 404 case below.
+      expect(res.status).not.toBe(400);
+    });
+
     it('requires scripts.execute for run_script actions before device lookup', async () => {
       vi.mocked(db.select).mockReturnValue(mockSelectLimitChain([]) as any);
 

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -1211,7 +1211,19 @@ mobileRoutes.post(
         return c.json({ error: result.error }, result.status);
       }
 
-      const execution = result.executions[0]!;
+      // A dispatch can now fail per device WITHOUT failing the request
+      // (#3409 PR2's per-device failure channel) — e.g. an unresolved or
+      // secret {{var.*}} token. For this single-device endpoint that means
+      // `executions` is empty and `failures` carries the reason; indexing
+      // [0] here used to throw and turn a user-fixable problem into a 500.
+      const execution = result.executions[0];
+      if (!execution) {
+        const failure = result.failures[0];
+        return c.json(
+          { error: failure?.error ?? 'Script could not be dispatched to this device' },
+          422
+        );
+      }
       writeRouteAudit(c, {
         orgId: device.orgId,
         action: 'mobile.device.action',

--- a/apps/api/src/routes/mobile.ts
+++ b/apps/api/src/routes/mobile.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
+import { scriptParametersSchema } from '@breeze/shared';
 import { and, desc, eq, gte, ilike, inArray, like, ne, or, sql } from 'drizzle-orm';
 import { createHash } from 'crypto';
 import { db } from '../db';
@@ -304,7 +305,8 @@ const listDevicesSchema = z.object({
 const deviceActionSchema = z.object({
   action: z.enum(['reboot', 'wake', 'run_script']),
   scriptId: z.string().guid().optional(),
-  parameters: z.record(z.string(), z.unknown()).optional()
+  // #3409 PR2 Task 7: the ONE script-parameter schema (@breeze/shared).
+  parameters: scriptParametersSchema.optional()
 }).superRefine((data, ctx) => {
   if (data.action === 'run_script' && !data.scriptId) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'scriptId is required for run_script' });

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -54,7 +54,7 @@ vi.mock('../db/schema', () => ({
   scriptExecutionBatches: {},
   devices: {},
   deviceCommands: {},
-  organizations: {},
+  organizations: { id: 'o.id', partnerId: 'o.partnerId' },
   patchPolicies: {},
   configPolicyComplianceRules: {},
   configPolicyFeatureLinks: {},
@@ -67,6 +67,17 @@ vi.mock('../db/schema', () => ({
   softwarePolicies: {},
   sensitiveDataPolicies: {},
   peripheralPolicies: {},
+  // tenantVariableResolution.ts's scope query (#3409 PR2, via
+  // findSecretVariableReferences) joins these two.
+  tenantVariables: {
+    id: 'tv.id',
+    key: 'tv.key',
+    value: 'tv.value',
+    isSecret: 'tv.isSecret',
+    version: 'tv.version',
+    orgId: 'tv.orgId',
+    partnerId: 'tv.partnerId'
+  },
   discoveredAssetTypeEnum: { enumValues: ['workstation', 'server', 'printer', 'unknown'] }
 }));
 
@@ -335,6 +346,129 @@ describe('scripts routes', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.version).toBe(2);
+  });
+
+  // -------------------------------------------------------------------
+  // Save-time {{var.<secret>}} rejection (#3409 PR2)
+  // -------------------------------------------------------------------
+  // The default auth mock is org scope, orgId ORG_ID — findSecretVariableReferences
+  // resolves through loadTenantVariableScope([ORG_ID]) / resolveForOrg, which
+  // issues db.select({...}).from(organizations).innerJoin(tenantVariables, ...).where(...).
+  function mockTenantVariableScopeRows(rows: unknown[]): void {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(rows)
+        })
+      })
+    } as any);
+  }
+
+  describe('save-time {{var.<secret>}} rejection', () => {
+    it('400s a script whose content references a secret variable (create)', async () => {
+      mockTenantVariableScopeRows([
+        { id: 'tv-1', key: 's1_token', value: 'shh', isSecret: true, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID }
+      ]);
+
+      const res = await app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'Uses secret',
+          osTypes: ['linux'],
+          language: 'bash',
+          content: 'echo {{var.s1_token}}'
+        })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe(
+        'Script content references secret variable(s): {{var.s1_token}}. Secret variables cannot be substituted into script content.'
+      );
+      expect(vi.mocked(db.insert)).not.toHaveBeenCalled();
+    });
+
+    it('accepts a script referencing a non-secret variable (create)', async () => {
+      mockTenantVariableScopeRows([
+        { id: 'tv-1', key: 'repo_url', value: 'https://dl.example', isSecret: false, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID }
+      ]);
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Uses non-secret var', orgId: ORG_ID }])
+        })
+      } as any);
+
+      const res = await app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'Uses non-secret var',
+          osTypes: ['linux'],
+          language: 'bash',
+          content: 'curl {{var.repo_url}}'
+        })
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    // The non-obvious half of the rule: a key with no matching row at all
+    // (not yet created, or simply never defined) must NOT block — a tech may
+    // legitimately write the script before creating the variable, and the
+    // dispatch path fails that device loudly per #3409's fail-loud contract.
+    it('accepts a script referencing an UNKNOWN variable key — warn-only, not a block (create)', async () => {
+      mockTenantVariableScopeRows([]); // no tenant_variables rows at all
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ id: SCRIPT_ID_1, name: 'Uses unknown var', orgId: ORG_ID }])
+        })
+      } as any);
+
+      const res = await app.request('/scripts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({
+          name: 'Uses unknown var',
+          osTypes: ['linux'],
+          language: 'bash',
+          content: 'echo {{var.not_yet_created}}'
+        })
+      });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('400s an UPDATE whose new content references a secret variable, and never writes it', async () => {
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([{
+              id: SCRIPT_ID_1,
+              name: 'Existing',
+              content: 'echo hi',
+              version: 1,
+              isSystem: false,
+              orgId: ORG_ID
+            }])
+          })
+        })
+      } as any);
+      mockTenantVariableScopeRows([
+        { id: 'tv-1', key: 's1_token', value: 'shh', isSecret: true, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID }
+      ]);
+
+      const res = await app.request(`/scripts/${SCRIPT_ID_1}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+        body: JSON.stringify({ content: 'echo {{var.s1_token}}' })
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('s1_token');
+      expect(vi.mocked(db.update)).not.toHaveBeenCalled();
+    });
   });
 
   it('should prevent deleting scripts with active executions', async () => {

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -14,6 +14,14 @@ const EXECUTION_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
 // Mock all services
 vi.mock('../services', () => ({}));
 
+const { executeScriptOnDevicesMock } = vi.hoisted(() => ({
+  executeScriptOnDevicesMock: vi.fn(),
+}));
+
+vi.mock('../services/scriptExecution', () => ({
+  executeScriptOnDevices: executeScriptOnDevicesMock,
+}));
+
 vi.mock('../services/auditEvents', () => ({
   requestLikeFromSnapshot: vi.fn(() => ({ req: { header: () => undefined } })),
   writeRouteAudit: vi.fn()
@@ -939,6 +947,123 @@ describe('scripts routes', () => {
     });
 
     expect(res.status).toBe(400);
+  });
+
+  // #3409 PR2 gave executeScriptOnDevices a per-device failure channel. The
+  // service reports ok:true even when every device failed (the REQUEST was
+  // valid), so without these branches the route answered 201
+  // {status:'queued', executions:[]} and the UI toasted success for a run that
+  // dispatched to nobody.
+  describe('per-device dispatch failures on execute', () => {
+    const executeBody = (deviceIds: string[]) => ({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({ deviceIds }),
+    });
+
+    it('returns 422 and writes no audit when every device failed to dispatch', async () => {
+      executeScriptOnDevicesMock.mockResolvedValueOnce({
+        ok: true,
+        batchId: null,
+        batchIds: [],
+        scriptId: SCRIPT_ID_1,
+        script: { id: SCRIPT_ID_1, name: 'Script One' },
+        devicesTargeted: 1,
+        maintenanceSuppressedDeviceIds: [],
+        executions: [],
+        failures: [{
+          deviceId: '11111111-1111-1111-1111-111111111111',
+          code: 'unresolved_variables',
+          error: 'Unresolved tenant variable(s): no value set for {{var.api_key}}',
+        }],
+        status: 'queued',
+        triggerType: 'manual',
+        runAs: 'system',
+        auditOrgId: ORG_ID,
+      });
+
+      const res = await app.request(
+        `/scripts/${SCRIPT_ID_1}/execute`,
+        executeBody(['11111111-1111-1111-1111-111111111111']),
+      );
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.error).toContain('no value set for {{var.api_key}}');
+      expect(body.failures).toHaveLength(1);
+      expect(writeRouteAudit).not.toHaveBeenCalled();
+    });
+
+    it('returns 201 with failures alongside executions on a partial failure', async () => {
+      executeScriptOnDevicesMock.mockResolvedValueOnce({
+        ok: true,
+        batchId: 'batch-1',
+        batchIds: ['batch-1'],
+        scriptId: SCRIPT_ID_1,
+        script: { id: SCRIPT_ID_1, name: 'Script One' },
+        devicesTargeted: 2,
+        maintenanceSuppressedDeviceIds: [],
+        executions: [{
+          executionId: 'exec-1',
+          deviceId: '11111111-1111-1111-1111-111111111111',
+          commandId: 'cmd-1',
+        }],
+        failures: [{
+          deviceId: '22222222-2222-2222-2222-222222222222',
+          code: 'unresolved_variables',
+          error: 'Unresolved tenant variable(s): no value set for {{var.api_key}}',
+        }],
+        status: 'queued',
+        triggerType: 'manual',
+        runAs: 'system',
+        auditOrgId: ORG_ID,
+      });
+
+      const res = await app.request(
+        `/scripts/${SCRIPT_ID_1}/execute`,
+        executeBody([
+          '11111111-1111-1111-1111-111111111111',
+          '22222222-2222-2222-2222-222222222222',
+        ]),
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.executions).toHaveLength(1);
+      expect(body.failures).toHaveLength(1);
+      expect(body.failures[0].deviceId).toBe('22222222-2222-2222-2222-222222222222');
+    });
+
+    it('omits failures entirely on a clean run', async () => {
+      executeScriptOnDevicesMock.mockResolvedValueOnce({
+        ok: true,
+        batchId: null,
+        batchIds: [],
+        scriptId: SCRIPT_ID_1,
+        script: { id: SCRIPT_ID_1, name: 'Script One' },
+        devicesTargeted: 1,
+        maintenanceSuppressedDeviceIds: [],
+        executions: [{
+          executionId: 'exec-1',
+          deviceId: '11111111-1111-1111-1111-111111111111',
+          commandId: 'cmd-1',
+        }],
+        failures: [],
+        status: 'queued',
+        triggerType: 'manual',
+        runAs: 'system',
+        auditOrgId: ORG_ID,
+      });
+
+      const res = await app.request(
+        `/scripts/${SCRIPT_ID_1}/execute`,
+        executeBody(['11111111-1111-1111-1111-111111111111']),
+      );
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.failures).toBeUndefined();
+    });
   });
 
   // ── Task 7: List union (org ∪ partner-wide ∪ system) ─────────────────────

--- a/apps/api/src/routes/scripts.test.ts
+++ b/apps/api/src/routes/scripts.test.ts
@@ -768,6 +768,32 @@ describe('scripts routes', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects a nested-object parameter value on execute (#3409 PR2 Task 7 — one script-parameter schema)', async () => {
+    const res = await app.request(`/scripts/${SCRIPT_ID_1}/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        deviceIds: ['11111111-1111-1111-1111-111111111111'],
+        parameters: { nested: { bad: true } }
+      })
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a parameter key the agent could not turn into an env var name on execute', async () => {
+    const res = await app.request(`/scripts/${SCRIPT_ID_1}/execute`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-token' },
+      body: JSON.stringify({
+        deviceIds: ['11111111-1111-1111-1111-111111111111'],
+        parameters: { 'has space': 'v' }
+      })
+    });
+
+    expect(res.status).toBe(400);
+  });
+
   it('should reject unsupported runAs override on execute', async () => {
     const res = await app.request(`/scripts/${SCRIPT_ID_1}/execute`, {
       method: 'POST',

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -28,7 +28,12 @@ import {
   insertScriptRow,
   isScriptScopeError,
   resolveScriptCreateScope,
+  type ScriptCreateScope,
 } from '../services/scriptWrite';
+import {
+  describeSecretVariableRejection,
+  findSecretVariableReferences,
+} from '../services/scriptBundle';
 import { scriptBundleRoutes } from './scriptBundle';
 
 export const scriptRoutes = new Hono();
@@ -590,6 +595,13 @@ scriptRoutes.post(
       return c.json({ error: scope.error }, scope.status);
     }
 
+    // Save-time {{var.<secret>}} rejection (#3409 PR2). An UNKNOWN key is
+    // allowed — see findSecretVariableReferences's docblock.
+    const secretRefs = await findSecretVariableReferences(scope, data.content);
+    if (secretRefs.length > 0) {
+      return c.json({ error: describeSecretVariableRejection(secretRefs) }, 400);
+    }
+
     const script = await insertScriptRow(auth, scope, data, {
       requestedIsSystem: data.isSystem
     });
@@ -649,6 +661,13 @@ scriptRoutes.put(
 
     // Build updates object
     const updates: Record<string, unknown> = { updatedAt: new Date() };
+
+    // The owning tenant to validate {{var.*}} content against (#3409 PR2,
+    // below) — defaults to the script's current scope and is overwritten by
+    // the re-scope block when `availability` moves it, so the check always
+    // runs against where the script will actually LIVE after this request,
+    // not where it lived before.
+    let effectiveScope: ScriptCreateScope = { orgId: script.orgId, partnerId: script.partnerId };
 
     // Re-scope on edit (issue #1734). Only applied when `availability` is sent;
     // a plain content/metadata edit never touches org/partner. System scripts
@@ -733,6 +752,7 @@ scriptRoutes.put(
 
       updates.orgId = target.orgId;
       updates.partnerId = target.partnerId;
+      effectiveScope = target;
     }
 
     if (data.name !== undefined) updates.name = data.name;
@@ -747,6 +767,13 @@ scriptRoutes.put(
 
     // Increment version if content changes
     if (data.content !== undefined && data.content !== script.content) {
+      // Save-time {{var.<secret>}} rejection (#3409 PR2), against the
+      // EFFECTIVE (post-rescope) scope. An UNKNOWN key is allowed — see
+      // findSecretVariableReferences's docblock.
+      const secretRefs = await findSecretVariableReferences(effectiveScope, data.content);
+      if (secretRefs.length > 0) {
+        return c.json({ error: describeSecretVariableRejection(secretRefs) }, 400);
+      }
       updates.content = data.content;
       updates.version = script.version + 1;
     }

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
-import { exitCodeSeverityMappingSchema } from '@breeze/shared';
+import { exitCodeSeverityMappingSchema, scriptParametersSchema } from '@breeze/shared';
 import { and, eq, sql, desc, like, inArray, or, isNull } from 'drizzle-orm';
 import { escapeLike } from '../utils/sql';
 import { db } from '../db';
@@ -270,7 +270,12 @@ export const executeScriptSchema = z
     deviceIds: z.array(z.string().guid()).min(1).max(500, {
       message: 'Cannot target more than 500 devices in a single script execution',
     }),
-    parameters: z.record(z.string(), z.any()).refine(
+    // #3409 PR2 Task 7: the ONE script-parameter schema (@breeze/shared) —
+    // accepts string/number/boolean values, canonicalized to strings once at
+    // dispatch (scriptDispatch.ts). The 64KB cap is kept ON TOP of the
+    // schema's own count/length caps: it bounds the raw JSON body size this
+    // route ever accepts, independent of the canonicalized wire form.
+    parameters: scriptParametersSchema.refine(
       (val) => JSON.stringify(val).length <= 65536,
       { message: 'Object too large (max 64KB)' }
     ).optional(),

--- a/apps/api/src/routes/scripts.ts
+++ b/apps/api/src/routes/scripts.ts
@@ -928,6 +928,20 @@ scriptRoutes.post(
       }, result.status);
     }
 
+    // Every target device failed to dispatch (#3409 PR2's per-device failure
+    // channel — e.g. an unresolved or secret {{var.*}} token). The service
+    // still reports ok:true because the request itself was valid, but nothing
+    // was queued, so returning 201 {status:'queued', executions:[]} would show
+    // the caller a success toast for a run that dispatched to no one. Returned
+    // before the audit, matching the maintenance-suppressed path above: an
+    // error return does not write a `script.execute` success record.
+    if (result.executions.length === 0 && result.failures.length > 0) {
+      return c.json({
+        error: `Script could not be dispatched to any target device: ${result.failures[0]!.error}`,
+        failures: result.failures,
+      }, 422);
+    }
+
     writeRouteAudit(c, {
       orgId: result.auditOrgId,
       action: 'script.execute',
@@ -953,6 +967,10 @@ scriptRoutes.post(
         ? result.maintenanceSuppressedDeviceIds
         : undefined,
       executions: result.executions,
+      // Partial failure: some devices dispatched, others didn't (the
+      // all-failed case returned 422 above). Omitted when empty so the
+      // common clean-run response shape is unchanged.
+      failures: result.failures.length > 0 ? result.failures : undefined,
       status: result.status,
     }, 201);
   }

--- a/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
@@ -323,7 +323,9 @@ describe('run_script escapes the ambient transaction for dispatch + poll (#3409 
   it('preloads the variable scope inside the same escape, and forwards it to dispatch (#3409 PR2 Task 4)', async () => {
     const scope = { orgIds: new Set([ORG_B]) };
     vi.mocked(loadTenantVariableScope).mockResolvedValueOnce(scope as any);
-    const scriptRow = { id: SCRIPT_ID, orgId: ORG_B, partnerId: null, language: 'powershell', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' };
+    // Content MUST carry a {{var.*}} token — the preload is gated on it, so a
+    // token-free fixture would assert nothing.
+    const scriptRow = { id: SCRIPT_ID, orgId: ORG_B, partnerId: null, language: 'powershell', content: 'echo {{var.repo_url}}', timeoutSeconds: 60, runAs: 'system' };
     const deviceRow = { id: DEVICE_B, orgId: ORG_B, hostname: 'devB', siteId: null, status: 'online' };
     mockDb(scriptRow, deviceRow);
 

--- a/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
+++ b/apps/api/src/services/aiToolsScripts.runScript.orgEquality.test.ts
@@ -65,15 +65,34 @@ const { dispatchScriptToDevice, waitForCommandResult, contextFlags } = mocks;
 
 vi.mock('./scriptDispatch', () => ({ dispatchScriptToDevice: mocks.dispatchScriptToDevice }));
 vi.mock('./commandQueue', () => ({ waitForCommandResult: mocks.waitForCommandResult }));
+// #3409 PR2 Task 4: the real loadTenantVariableScope issues a
+// .select().from().innerJoin().where() chain this file's db.select mock
+// (below, `mockDb`) doesn't shape — and its own coverage lives in
+// tenantVariableResolution.test.ts. Stub it so the per-device preload this
+// task adds doesn't require reshaping every mockDb() call site here.
+vi.mock('./tenantVariableResolution', () => ({
+  loadTenantVariableScope: vi.fn().mockResolvedValue({ orgIds: new Set() }),
+}));
 
 vi.mock('../db', () => ({
+  // Real `runOutsideDbContext` is `dbContextStorage.exit(fn)` — an
+  // AsyncLocalStorage exit, which stays in effect for `fn`'s ENTIRE async
+  // continuation (every await inside it), not just until its first
+  // microtask boundary. A plain synchronous try/finally around a
+  // promise-returning `fn()` would restore the flag the instant `fn()`
+  // returns a pending promise, well before an internal `await` (e.g. the
+  // #3409 PR2 Task 4 variable-scope preload ahead of dispatch) actually
+  // resolves — under-representing how long the real escape stays active.
+  // Awaiting a promise result before restoring the flag models that
+  // correctly.
   runOutsideDbContext: vi.fn((fn: () => unknown) => {
     mocks.contextFlags.runOutside = true;
-    try {
-      return fn();
-    } finally {
-      mocks.contextFlags.runOutside = false;
+    const result = fn();
+    if (result instanceof Promise) {
+      return result.finally(() => { mocks.contextFlags.runOutside = false; });
     }
+    mocks.contextFlags.runOutside = false;
+    return result;
   }),
   withDbAccessContext: vi.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn()),
   withSystemDbAccessContext: vi.fn(async (fn: () => Promise<unknown>) => {
@@ -90,6 +109,7 @@ vi.mock('../db', () => ({
 import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices, organizations, scripts } from '../db/schema';
 import { registerScriptTools } from './aiToolsScripts';
+import { loadTenantVariableScope } from './tenantVariableResolution';
 import type { AiTool } from './aiTools';
 import type { AuthContext } from '../middleware/auth';
 
@@ -298,6 +318,26 @@ describe('run_script escapes the ambient transaction for dispatch + poll (#3409 
     const dispatchOrder = dispatchScriptToDevice.mock.invocationCallOrder[0]!;
     const waitOrder = waitForCommandResult.mock.invocationCallOrder[0]!;
     expect(waitOrder).toBeGreaterThan(dispatchOrder);
+  });
+
+  it('preloads the variable scope inside the same escape, and forwards it to dispatch (#3409 PR2 Task 4)', async () => {
+    const scope = { orgIds: new Set([ORG_B]) };
+    vi.mocked(loadTenantVariableScope).mockResolvedValueOnce(scope as any);
+    const scriptRow = { id: SCRIPT_ID, orgId: ORG_B, partnerId: null, language: 'powershell', content: 'echo hi', timeoutSeconds: 60, runAs: 'system' };
+    const deviceRow = { id: DEVICE_B, orgId: ORG_B, hostname: 'devB', siteId: null, status: 'online' };
+    mockDb(scriptRow, deviceRow);
+
+    await runScriptTool().handler({ scriptId: SCRIPT_ID, deviceIds: [DEVICE_B] }, makeAuth());
+
+    expect(loadTenantVariableScope).toHaveBeenCalledWith([ORG_B]);
+    expect(dispatchScriptToDevice).toHaveBeenCalledWith(
+      expect.objectContaining({ variableScope: scope }),
+    );
+    // The preload must run BEFORE dispatch, nested in the same escape — not
+    // a second independent context.
+    const preloadOrder = vi.mocked(loadTenantVariableScope).mock.invocationCallOrder[0]!;
+    const dispatchOrder = dispatchScriptToDevice.mock.invocationCallOrder[0]!;
+    expect(preloadOrder).toBeLessThan(dispatchOrder);
   });
 });
 

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -33,6 +33,7 @@ import type { AiTool } from './aiTools';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { loadTenantVariableScope } from './tenantVariableResolution';
 import { captureException } from './sentry';
+import { hasVariableTokens } from '@breeze/shared';
 
 type AiToolTier = 1 | 2 | 3 | 4;
 
@@ -291,7 +292,9 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
           // preload — there is no wider fan-out to batch it against.
           const dispatch = await runOutsideDbContext(() =>
             withSystemDbAccessContext(async () => {
-              const variableScope = await loadTenantVariableScope([access.device.orgId]);
+              const variableScope = await loadTenantVariableScope(
+                hasVariableTokens(script.content) ? [access.device.orgId] : []
+              );
               return dispatchScriptToDevice({
                 device: access.device,
                 source: { kind: 'saved', script },

--- a/apps/api/src/services/aiToolsScripts.ts
+++ b/apps/api/src/services/aiToolsScripts.ts
@@ -31,6 +31,7 @@ import type { AuthContext } from '../middleware/auth';
 import { escapeLike } from '../utils/sql';
 import type { AiTool } from './aiTools';
 import { dispatchScriptToDevice } from './scriptDispatch';
+import { loadTenantVariableScope } from './tenantVariableResolution';
 import { captureException } from './sentry';
 
 type AiToolTier = 1 | 2 | 3 | 4;
@@ -281,9 +282,17 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
           //   the identical 0-row bug under a different (system-scoped)
           //   transaction: the INSERT wouldn't commit until the 60s wait
           //   finished either.
+          // Task 4 (#3409 PR2): the variable-scope preload joins this SAME
+          // escape rather than getting its own — it must run inside the
+          // identical system-context transaction as dispatchScriptToDevice
+          // (see the long comment above for why a bare/contextless read
+          // would reproduce the 0-row trap this escape exists to avoid). One
+          // device per iteration here (max 10, capped above), so one org per
+          // preload — there is no wider fan-out to batch it against.
           const dispatch = await runOutsideDbContext(() =>
-            withSystemDbAccessContext(() =>
-              dispatchScriptToDevice({
+            withSystemDbAccessContext(async () => {
+              const variableScope = await loadTenantVariableScope([access.device.orgId]);
+              return dispatchScriptToDevice({
                 device: access.device,
                 source: { kind: 'saved', script },
                 parameters: (input.parameters as Record<string, unknown>) ?? {},
@@ -291,8 +300,9 @@ export function registerScriptTools(aiTools: Map<string, AiTool>): void {
                 triggeredBy: auth.user.id,
                 createdBy: auth.user.id,
                 requireOnline: true,
-              })
-            )
+                variableScope,
+              });
+            })
           );
           if (!dispatch.ok) {
             results[deviceId] = { error: dispatch.error };

--- a/apps/api/src/services/automationRuntime.test.ts
+++ b/apps/api/src/services/automationRuntime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  AutomationValidationError,
   isCronDue,
   normalizeAutomationActions,
   normalizeAutomationTrigger,
@@ -60,6 +61,37 @@ describe('automationRuntime', () => {
       'create_alert',
       'execute_command',
     ]);
+  });
+
+  it('normalizes a run_script action carrying string/number/boolean parameters (#3409 PR2 Task 7)', () => {
+    const actions = normalizeAutomationActions([
+      { type: 'run_script', scriptId: 'script-1', parameters: { s: 'a', n: 3, b: true } },
+    ]);
+
+    expect(actions).toEqual([
+      { type: 'run_script', scriptId: 'script-1', parameters: { s: 'a', n: 3, b: true }, runAs: undefined },
+    ]);
+  });
+
+  it('rejects a run_script action whose parameters fail the shared script-parameter schema', () => {
+    expect(() =>
+      normalizeAutomationActions([
+        { type: 'run_script', scriptId: 'script-1', parameters: { nested: { bad: true } } },
+      ])
+    ).toThrow(AutomationValidationError);
+  });
+
+  it('rejects a run_script parameter key the agent could not turn into an env var name', () => {
+    expect(() =>
+      normalizeAutomationActions([
+        { type: 'run_script', scriptId: 'script-1', parameters: { 'has space': 'v' } },
+      ])
+    ).toThrow(/actions\[0\]/);
+  });
+
+  it('leaves parameters undefined when the action omits them', () => {
+    const actions = normalizeAutomationActions([{ type: 'run_script', scriptId: 'script-1' }]);
+    expect(actions[0]).toMatchObject({ parameters: undefined });
   });
 
   it('normalizes notification targets from legacy and canonical payloads', () => {

--- a/apps/api/src/services/automationRuntime.test.ts
+++ b/apps/api/src/services/automationRuntime.test.ts
@@ -146,7 +146,12 @@ describe('automationRuntime', () => {
         osType: 'linux' as const, status: 'online' as const, agentId: 'agent-1',
       },
       scriptsById: new Map([
-        ['script-1', { id: 'script-1', orgId: 'org-a', osTypes: ['linux'], runAs: 'system' } as any],
+        // Content MUST carry a {{var.*}} token — the preload is gated on it,
+        // so a token-free fixture would assert nothing.
+        [
+          'script-1',
+          { id: 'script-1', orgId: 'org-a', osTypes: ['linux'], runAs: 'system', content: 'curl {{var.repo_url}}' } as any,
+        ],
       ]),
       channelsById: new Map(),
     };

--- a/apps/api/src/services/automationRuntime.test.ts
+++ b/apps/api/src/services/automationRuntime.test.ts
@@ -1,14 +1,55 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #3409 PR2 Task 4: executeRunScriptAction touches `db` (a conditional
+// scriptExecutions status update) and dispatches through the mocked seams
+// below. Every other exported function in this file is pure and unaffected
+// by these mocks. Mirrors the mock shape used in scriptExecution.test.ts.
+vi.mock('../db', () => ({
+  db: { update: vi.fn() },
+}));
+vi.mock('./scriptDispatch', () => ({
+  dispatchScriptToDevice: vi.fn().mockResolvedValue({
+    ok: true,
+    commandId: 'cmd-1',
+    executionId: 'exec-1',
+    delivered: true,
+    deliveryOutcome: 'sent',
+    executedAt: new Date('2026-08-11T00:00:00Z'),
+  }),
+}));
+// See scriptExecution.test.ts for why the resolver itself is stubbed here
+// rather than exercised for real — its own coverage lives in
+// tenantVariableResolution.test.ts.
+vi.mock('./tenantVariableResolution', () => ({
+  loadTenantVariableScope: vi.fn().mockResolvedValue({ orgIds: new Set() }),
+}));
+
 import {
   AutomationValidationError,
+  executeRunScriptAction,
   isCronDue,
   normalizeAutomationActions,
   normalizeAutomationTrigger,
   normalizeNotificationTargets,
   withWebhookDefaults,
 } from './automationRuntime';
+import { dispatchScriptToDevice } from './scriptDispatch';
+import { loadTenantVariableScope } from './tenantVariableResolution';
 
 describe('automationRuntime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(dispatchScriptToDevice).mockResolvedValue({
+      ok: true,
+      commandId: 'cmd-1',
+      executionId: 'exec-1',
+      delivered: true,
+      deliveryOutcome: 'sent',
+      executedAt: new Date('2026-08-11T00:00:00Z'),
+    } as any);
+    vi.mocked(loadTenantVariableScope).mockResolvedValue({ orgIds: new Set() } as any);
+  });
+
   it('normalizes schedule trigger and evaluates due cron slots', () => {
     const trigger = normalizeAutomationTrigger({
       type: 'schedule',
@@ -92,6 +133,34 @@ describe('automationRuntime', () => {
   it('leaves parameters undefined when the action omits them', () => {
     const actions = normalizeAutomationActions([{ type: 'run_script', scriptId: 'script-1' }]);
     expect(actions[0]).toMatchObject({ parameters: undefined });
+  });
+
+  it('preloads a variable scope for the device org before dispatching a run_script action (#3409 PR2 Task 4)', async () => {
+    const scope = { orgIds: new Set(['org-a']) };
+    vi.mocked(loadTenantVariableScope).mockResolvedValue(scope as any);
+    const context = {
+      automation: { id: 'auto-1', orgId: 'org-a', name: 'Test automation', createdBy: 'user-1' },
+      runId: 'run-1',
+      device: {
+        id: 'device-1', orgId: 'org-a', hostname: 'host-1', displayName: null,
+        osType: 'linux' as const, status: 'online' as const, agentId: 'agent-1',
+      },
+      scriptsById: new Map([
+        ['script-1', { id: 'script-1', orgId: 'org-a', osTypes: ['linux'], runAs: 'system' } as any],
+      ]),
+      channelsById: new Map(),
+    };
+
+    const result = await executeRunScriptAction(
+      { type: 'run_script', scriptId: 'script-1' },
+      0,
+      context,
+    );
+
+    expect(result.success).toBe(true);
+    expect(loadTenantVariableScope).toHaveBeenCalledWith(['org-a']);
+    const dispatchArgs = vi.mocked(dispatchScriptToDevice).mock.calls[0]![0];
+    expect(dispatchArgs.variableScope).toBe(scope);
   });
 
   it('normalizes notification targets from legacy and canonical payloads', () => {

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 import { and, eq, inArray, isNull, ne, or, sql, type SQL } from 'drizzle-orm';
-import type { DeploymentTargetConfig } from '@breeze/shared';
+import { scriptParametersSchema, type DeploymentTargetConfig } from '@breeze/shared';
 import { db } from '../db';
 import {
   alertRules,
@@ -148,7 +148,9 @@ export type AutomationTrigger =
 export type RunScriptAction = {
   type: 'run_script';
   scriptId: string;
-  parameters?: Record<string, unknown>;
+  // #3409 PR2 Task 7: matches scriptParametersSchema's inferred value type —
+  // canonicalized to strings once, downstream, at scriptDispatch.ts.
+  parameters?: Record<string, string | number | boolean>;
   runAs?: 'system' | 'user' | 'elevated' | string;
 };
 
@@ -365,10 +367,24 @@ export function normalizeAutomationActions(input: unknown): AutomationAction[] {
       if (!scriptId) {
         throw new AutomationValidationError(`actions[${index}] run_script requires scriptId`);
       }
+      // #3409 PR2 Task 7: the ONE script-parameter schema (@breeze/shared),
+      // replacing the old hand-rolled isPlainRecord check — a malformed
+      // parameters map is now a save-time AutomationValidationError instead
+      // of a silent drop.
+      let parameters: Record<string, string | number | boolean> | undefined;
+      if (action.parameters !== undefined) {
+        const parsed = scriptParametersSchema.safeParse(action.parameters);
+        if (!parsed.success) {
+          throw new AutomationValidationError(
+            `actions[${index}] run_script has invalid parameters: ${parsed.error.issues[0]?.message ?? 'invalid parameters'}`
+          );
+        }
+        parameters = parsed.data;
+      }
       normalized.push({
         type: 'run_script',
         scriptId,
-        parameters: isPlainRecord(action.parameters) ? action.parameters : undefined,
+        parameters,
         runAs: asString(action.runAs),
       });
       continue;

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -20,6 +20,7 @@ import {
 import { resolveDeploymentTargets } from './deploymentEngine';
 import { canAccessSite, type UserPermissions } from './permissions';
 import { dispatchScriptToDevice } from './scriptDispatch';
+import { loadTenantVariableScope } from './tenantVariableResolution';
 import { publishEvent } from './eventBus';
 import { captureException } from './sentry';
 import {
@@ -893,6 +894,11 @@ export async function executeRunScriptAction(
 
   const parameters = action.parameters ?? {};
 
+  // Preload ONCE for this single-device dispatch (#3409 PR2 Task 4). Only
+  // run_script needs a scope — execute_command below dispatches a
+  // {kind:'raw'} source, which scriptDispatch deliberately never substitutes.
+  const variableScope = await loadTenantVariableScope([context.device.orgId]);
+
   // #3409 PR0: dispatchScriptToDevice owns the script_executions insert (#3162
   // — a REAL uuid row so handleScriptResult can correlate the agent's result),
   // payload build, sensitive-field encryption, queueCommand, and claim/decrypt/
@@ -914,6 +920,7 @@ export async function executeRunScriptAction(
     // whatever value was configured rather than adding new validation here.
     runAs: (action.runAs ?? script.runAs) as 'system' | 'user' | 'elevated',
     requireOnline: true,
+    variableScope,
   });
 
   if (!dispatch.ok) {

--- a/apps/api/src/services/automationRuntime.ts
+++ b/apps/api/src/services/automationRuntime.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'crypto';
 import { and, eq, inArray, isNull, ne, or, sql, type SQL } from 'drizzle-orm';
-import { scriptParametersSchema, type DeploymentTargetConfig } from '@breeze/shared';
+import { hasVariableTokens, scriptParametersSchema, type DeploymentTargetConfig } from '@breeze/shared';
 import { db } from '../db';
 import {
   alertRules,
@@ -897,7 +897,11 @@ export async function executeRunScriptAction(
   // Preload ONCE for this single-device dispatch (#3409 PR2 Task 4). Only
   // run_script needs a scope — execute_command below dispatches a
   // {kind:'raw'} source, which scriptDispatch deliberately never substitutes.
-  const variableScope = await loadTenantVariableScope([context.device.orgId]);
+  // Gated on the content: an unconditional preload would take a second
+  // connection per automation run to build a snapshot nothing consults.
+  const variableScope = await loadTenantVariableScope(
+    hasVariableTokens(script.content) ? [context.device.orgId] : []
+  );
 
   // #3409 PR0: dispatchScriptToDevice owns the script_executions insert (#3162
   // — a REAL uuid row so handleScriptResult can correlate the agent's result),

--- a/apps/api/src/services/installerVariables.test.ts
+++ b/apps/api/src/services/installerVariables.test.ts
@@ -12,6 +12,7 @@ const ctx: InstallerVariableContext = {
     hostname: 'WKS-014',
     customFields: { license_key: 'ABC-999', region: 'us-east', blank: '' },
   },
+  vars: { repo_url: 'https://dl.example/pkg', blank_var: '' },
 };
 
 describe('substituteInstallerVariables', () => {
@@ -89,6 +90,64 @@ describe('substituteInstallerVariables', () => {
       device: { hostname: 'H', customFields: null },
     });
     expect(r.unresolved).toEqual(['{{device.customField.license_key}}']);
+  });
+});
+
+// #3409 PR2 — the `var.<key>` arm, resolved from the caller-prefetched `vars` map.
+describe('substituteInstallerVariables — var.* (#3409 PR2)', () => {
+  it('resolves {{var.key}} from the prefetched map', () => {
+    const r = substituteInstallerVariables('{{var.repo_url}}/pkg.msi', ctx);
+    expect(r.value).toBe('https://dl.example/pkg/pkg.msi');
+    expect(r.unresolved).toEqual([]);
+  });
+
+  it('treats an empty variable value as unresolved (fail loudly)', () => {
+    const r = substituteInstallerVariables('{{var.blank_var}}', ctx);
+    expect(r.unresolved).toEqual(['{{var.blank_var}}']);
+  });
+
+  it('flags an unknown variable key as unresolved', () => {
+    const r = substituteInstallerVariables('{{var.no_such_key}}', ctx);
+    expect(r.unresolved).toEqual(['{{var.no_such_key}}']);
+  });
+
+  it('does not resolve ${{var.key}} — the $-escape excludes it, exactly like script content', () => {
+    // The leading `$` means "shell/Actions syntax, not a Breeze variable" in
+    // the shared var.* grammar (variableTokens.ts). This tokenizer cannot
+    // literally leave the WHOLE `${{var.repo_url}}` span alone (its own TOKEN
+    // regex has no `$`-exclusion and that regex is deliberately left
+    // untouched — see the module docblock): it still matches the inner
+    // `{{var.repo_url}}` and reports IT as unresolved. What matters is what
+    // it must NEVER do — substitute the variable's value in — and it
+    // doesn't: the value string is unchanged and the key is reported
+    // unresolved, same as any other unrecognized token.
+    const r = substituteInstallerVariables('run ${{var.repo_url}}', ctx);
+    expect(r.value).toBe('run ${{var.repo_url}}');
+    expect(r.unresolved).toEqual(['{{var.repo_url}}']);
+  });
+
+  it('does NOT resolve {{ var.key }} with inner whitespace — one strict form only, matching the script-content grammar', () => {
+    // Every OTHER namespace here tolerates inner whitespace (see "tolerates
+    // inner whitespace" above) — that leniency is deliberately NOT extended
+    // to var.*, because a script containing `{{ var.x }}` is invisible to
+    // findVariableTokens (the same grammar used for save-time secret
+    // rejection and dispatch-time substitution): it is not recognized as a
+    // variable reference there at all, so resolving it here would silently
+    // succeed on the exact form the script path treats as inert literal
+    // text — a divergence between the two surfaces. Reported unresolved,
+    // same as any other unrecognized token.
+    const r = substituteInstallerVariables('{{ var.repo_url }}', ctx);
+    expect(r.value).toBe('{{ var.repo_url }}');
+    expect(r.unresolved).toEqual(['{{ var.repo_url }}']);
+  });
+
+  it('resolves a var.* token alongside built-in/custom tokens in one template', () => {
+    const r = substituteInstallerVariables(
+      'https://dl/{{org.id}}/{{var.repo_url}}?key={{device.customField.license_key}}',
+      ctx,
+    );
+    expect(r.value).toBe('https://dl/org-123/https://dl.example/pkg?key=ABC-999');
+    expect(r.unresolved).toEqual([]);
   });
 });
 

--- a/apps/api/src/services/installerVariables.ts
+++ b/apps/api/src/services/installerVariables.ts
@@ -17,19 +17,35 @@
  * device doesn't have) is returned in `unresolved` and left verbatim in the
  * string. Callers MUST fail that device rather than dispatch a literal `{{...}}`
  * to an agent.
+ *
+ * `var.<key>` (#3409 PR2) is the ONE namespace here that is ALSO substituted
+ * at script dispatch (`tenantVariableResolution.ts`) via a different, strict
+ * tokenizer (`VARIABLE_TOKEN_PATTERN` in `@breeze/shared`, no inner
+ * whitespace, no `${{...}}` escape). See `isStrictVariableToken` below for how
+ * this file's own whitespace-tolerant TOKEN regex is kept from silently
+ * accepting a form the script-content path would reject.
  */
+import { findVariableTokens } from '@breeze/shared';
 
 export interface InstallerVariableContext {
   org: { id: string; name: string };
   site: { id: string; name: string };
   device: { hostname: string; customFields: Record<string, unknown> | null };
+  /**
+   * Tenant variables (#3409 PR2), prefetched and flattened by the caller
+   * (`softwareDeployment.ts`) — KEY → non-secret VALUE only. Secret variables
+   * are omitted from this map entirely by the caller, so a `{{var.<secret>}}`
+   * reference here always falls through to the `unresolved` branch, never a
+   * substituted secret value.
+   */
+  vars: Record<string, string>;
 }
 
 // Matches `{{ key }}` with optional inner whitespace; the key itself excludes braces.
 const TOKEN = /\{\{\s*([^{}]+?)\s*\}\}/g;
 const CUSTOM_FIELD_KEY = /^device\.customField\.([a-z][a-z0-9_]*)$/;
 
-function resolveKey(key: string, ctx: InstallerVariableContext): string | null {
+function resolveKey(key: string, ctx: InstallerVariableContext, isStrictVariableToken: boolean): string | null {
   let raw: unknown;
   switch (key) {
     case 'org.name':
@@ -48,6 +64,25 @@ function resolveKey(key: string, ctx: InstallerVariableContext): string | null {
       raw = ctx.device.hostname;
       break;
     default: {
+      if (key.startsWith('var.')) {
+        // The var.* namespace must accept ONLY the strict `{{var.<key>}}`
+        // token form shared with script content (no inner whitespace, no
+        // `${{...}}` escape — see the module docblock). This tokenizer
+        // normalizes whitespace and tolerates a `${{` prefix for the
+        // pre-existing org.*/site.*/device.* namespaces (that regex is left
+        // untouched deliberately — changing it would alter their established
+        // behaviour), but extending that leniency to var.* would let an
+        // installer template silently resolve a token that the
+        // script-content path (`findVariableTokens`, used for save-time
+        // secret rejection and dispatch substitution) treats as inert
+        // literal text — a divergence between the two surfaces referencing
+        // the same nominal vocabulary. So a loosely-written `{{ var.x }}`
+        // (or a `$`-escaped `${{var.x}}`) is deliberately treated as unknown
+        // here too, exactly like an unrecognized token.
+        if (!isStrictVariableToken) return null;
+        raw = ctx.vars[key.slice(4)] ?? null;
+        break;
+      }
       const fieldKey = CUSTOM_FIELD_KEY.exec(key)?.[1];
       if (!fieldKey) return null; // unknown token — not in the vocabulary
       raw = ctx.device.customFields?.[fieldKey];
@@ -75,8 +110,16 @@ export function substituteInstallerVariables(
   if (!template.includes('{{')) return { value: template, unresolved: [] };
 
   const unresolved: string[] = [];
-  const value = template.replace(TOKEN, (match, rawKey: string) => {
-    const resolved = resolveKey(rawKey.trim(), ctx);
+  const value = template.replace(TOKEN, (match: string, rawKey: string, offset: number) => {
+    // Per-OCCURRENCE strictness for the var.* namespace: `findVariableTokens`
+    // applied to the isolated match reproduces the shared `{{var.<key>}}`
+    // grammar exactly (key charset, no inner whitespace), and the manual
+    // `$`-prefix check covers `${{var.x}}` — a case findVariableTokens alone
+    // can't see since the `$` sits outside `match`. Computed per match (not
+    // just per key) so the same key written once strictly and once loosely
+    // in one template is judged independently each time.
+    const isStrictVariableToken = template[offset - 1] !== '$' && findVariableTokens(match).length === 1;
+    const resolved = resolveKey(rawKey.trim(), ctx, isStrictVariableToken);
     if (resolved == null) {
       unresolved.push(match);
       return match;

--- a/apps/api/src/services/scriptBundle/index.test.ts
+++ b/apps/api/src/services/scriptBundle/index.test.ts
@@ -55,7 +55,12 @@ vi.mock('../../db', () => ({
         return { where: vi.fn(() => Promise.resolve()) };
       })
     }))
-  }
+  },
+  // tenantVariableResolution.ts (#3409 PR2, used by findSecretVariableReferences)
+  // requires both wrappers around its query; pass-throughs here mirror
+  // routes/scripts.test.ts and tenantVariableResolution.test.ts.
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+  withSystemDbAccessContext: async <T>(fn: () => Promise<T>): Promise<T> => fn()
 }));
 
 import { scripts, scriptTags, scriptToTags, scriptVersions } from '../../db/schema';
@@ -460,6 +465,65 @@ describe('importBundle', () => {
       expect(result.errors[0]!.error).toContain('timeoutSeconds');
       expect(result.imported).toBe(1);
     }
+  });
+
+  // ---------------------------------------------------------------------
+  // Save-time {{var.<secret>}} rejection (#3409 PR2)
+  // ---------------------------------------------------------------------
+  it('rejects a bundle entry whose content references a secret variable, per-entry rather than failing the whole bundle', async () => {
+    const bundle = validBundle([
+      { ...baseEntry, content: 'echo {{var.s1_token}}' },
+      { ...baseEntry, name: 'Second script' } // no var.* tokens — unaffected
+    ]);
+    h.state.selectQueue.push(
+      // entry 1: loadTenantVariableScope([ORG_ID]) — org-owned secret row
+      [{ id: 'tv-1', key: 's1_token', value: 'shh', isSecret: true, version: 1, ownerOrgId: ORG_ID, forOrgId: ORG_ID }],
+      // entry 1 short-circuits before findExistingByName; entry 2 proceeds normally
+      [] // entry 2: findExistingByName → none
+    );
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.error).toBe(
+        'Script content references secret variable(s): {{var.s1_token}}. Secret variables cannot be substituted into script content.'
+      );
+      expect(result.imported).toBe(1);
+    }
+    expect(h.state.inserts.filter((i) => i.table === scripts)).toHaveLength(1);
+  });
+
+  it('accepts a bundle entry referencing an UNKNOWN variable key — warn-only, not a block', async () => {
+    const bundle = validBundle([{ ...baseEntry, content: 'echo {{var.not_yet_created}}' }]);
+    h.state.selectQueue.push(
+      [], // loadTenantVariableScope([ORG_ID]) — no tenant_variables rows at all
+      [] // findExistingByName → none
+    );
+    const result = await importBundle(makeAuth(), bundle, { mode: 'skip', availability: 'org' });
+    expect('error' in result).toBe(false);
+    if ('imported' in result) expect(result.imported).toBe(1);
+    if ('errors' in result) expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects a partner-wide import entry referencing the partner's own secret variable (no single org to resolve against)", async () => {
+    const auth = makeAuth({
+      scope: 'partner',
+      orgId: null,
+      partnerOrgAccess: 'all',
+      accessibleOrgIds: [ORG_ID]
+    });
+    const bundle = validBundle([{ ...baseEntry, content: 'echo {{var.p_secret}}' }]);
+    // The partner-wide branch queries tenant_variables directly (org_id IS
+    // NULL AND partner_id = caller's partner) — no resolver snapshot, since
+    // there is no single org to attribute a partner-wide row to.
+    h.state.selectQueue.push([{ key: 'p_secret', isSecret: true }]);
+    const result = await importBundle(auth, bundle, { mode: 'skip', availability: 'partner' });
+    expect('error' in result).toBe(false);
+    if ('errors' in result) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.error).toContain('p_secret');
+    }
+    expect(h.state.inserts).toHaveLength(0);
   });
 });
 

--- a/apps/api/src/services/scriptBundle/index.ts
+++ b/apps/api/src/services/scriptBundle/index.ts
@@ -22,8 +22,9 @@
  *   bundle's identity.
  */
 import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { findVariableTokens } from '@breeze/shared';
 import { db } from '../../db';
-import { scripts, scriptTags, scriptToTags, scriptVersions } from '../../db/schema';
+import { scripts, scriptTags, scriptToTags, scriptVersions, tenantVariables } from '../../db/schema';
 import type { AuthContext } from '../../middleware/auth';
 import {
   isScriptScopeError,
@@ -33,6 +34,7 @@ import {
   type ScriptScopeError,
   type ScriptWriteAuth
 } from '../scriptWrite';
+import { loadTenantVariableScope, resolveForOrg } from '../tenantVariableResolution';
 import {
   SCRIPT_BUNDLE_VERSION,
   bundleScriptEntrySchema,
@@ -41,6 +43,80 @@ import {
   type ScriptBundleEntry,
   type ScriptBundleEnvelope
 } from './schema';
+
+/**
+ * Save-time `{{var.<secret>}}` rejection (#3409 PR2) — shared by POST/PUT
+ * `/scripts` (routes/scripts.ts) and `importBundle` below, both of which
+ * already resolve ownership through `resolveScriptCreateScope` (the single
+ * tenancy chokepoint per the module docblock). Reusing its output here rather
+ * than re-deriving tenancy is deliberate: two independent notions of "which
+ * tenant does this script belong to" is exactly the kind of divergence that
+ * chokepoint exists to prevent (#3263 review).
+ *
+ * A `{{var.<key>}}` reference to an UNKNOWN key is explicitly ALLOWED — a
+ * tech may legitimately write the script before creating the variable, and
+ * the dispatch path (Task 4) already fails that device loudly per device.
+ * Only a token that resolves to an `is_secret = true` row is rejected: PR 2
+ * has no delivery channel for secrets (the `BREEZE_VAR_*` / `secretEnv`
+ * channel is PR 4), so textual substitution of one into script content would
+ * be a permanent leak the moment a script referencing it dispatched.
+ *
+ * Org-owned scope (`scope.orgId` set): resolved through the exact same
+ * org-over-partner-precedence snapshot dispatch itself will use
+ * (`loadTenantVariableScope` / `resolveForOrg`), so this agrees with what
+ * dispatch will actually see for this script's org.
+ *
+ * Partner-wide scope (`scope.orgId` null, `scope.partnerId` set): there is no
+ * single org to resolve against — a partner-wide script fans out to every org
+ * under the partner, and EACH of those re-runs this same secret check per
+ * device at dispatch time (Task 4), so a per-org override is still caught
+ * there regardless of what this save-time gate decides. This gate only needs
+ * to catch the common case — the partner's OWN partner-wide variable
+ * definition — so it queries `tenant_variables` directly for
+ * `org_id IS NULL AND partner_id = <caller's partner>` rather than going
+ * through the resolver, which requires a concrete org to attribute
+ * partner-wide rows to.
+ *
+ * A scope with neither an orgId nor a partnerId (an untenanted system-scope
+ * script — only reachable from `POST /scripts`, never from a bundle import;
+ * see `unownedScopeError` below) has no tenant variables to check against.
+ */
+export async function findSecretVariableReferences(
+  scope: ScriptCreateScope,
+  content: string
+): Promise<string[]> {
+  const keys = findVariableTokens(content);
+  if (keys.length === 0) return [];
+
+  if (scope.orgId) {
+    const variableScope = await loadTenantVariableScope([scope.orgId]);
+    const resolved = resolveForOrg(variableScope, scope.orgId);
+    return keys.filter((key) => resolved.get(key)?.isSecret === true);
+  }
+
+  if (scope.partnerId) {
+    const rows = await db
+      .select({ key: tenantVariables.key, isSecret: tenantVariables.isSecret })
+      .from(tenantVariables)
+      .where(
+        and(
+          isNull(tenantVariables.orgId),
+          eq(tenantVariables.partnerId, scope.partnerId),
+          inArray(tenantVariables.key, keys)
+        )
+      );
+    const secretKeys = new Set(rows.filter((r) => r.isSecret).map((r) => r.key));
+    return keys.filter((key) => secretKeys.has(key));
+  }
+
+  return [];
+}
+
+/** User-facing 400 message for {@link findSecretVariableReferences}'s non-empty result. Names only KEYS, never a value. */
+export function describeSecretVariableRejection(offendingKeys: string[]): string {
+  const tokens = offendingKeys.map((key) => `{{var.${key}}}`).join(', ');
+  return `Script content references secret variable(s): ${tokens}. Secret variables cannot be substituted into script content.`;
+}
 
 export type BundleAuth = ScriptWriteAuth & Pick<AuthContext, 'user'>;
 export type BundleImportMode = 'skip' | 'rename' | 'new-version';
@@ -350,6 +426,16 @@ export async function importBundle(
     }
     const entry = parsed.entry;
     try {
+      // Save-time secret-variable rejection (#3409 PR2) — see
+      // findSecretVariableReferences's docblock. Per-entry, like every other
+      // bundle-import failure mode: one script referencing a secret must not
+      // sink the rest of the bundle.
+      const secretRefs = await findSecretVariableReferences(scope, entry.content);
+      if (secretRefs.length > 0) {
+        result.errors.push({ index, name: entry.name, error: describeSecretVariableRejection(secretRefs) });
+        continue;
+      }
+
       const existing = await findExistingByName(scope, entry.name);
 
       if (existing && options.mode === 'skip') {

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -21,6 +21,7 @@ import { decryptCommandForDelivery, encryptSensitivePayloadFields } from './sens
 import { sendCommandToAgent } from '../routes/agentWs';
 import { captureException } from './sentry';
 import { dispatchScriptToDevice } from './scriptDispatch';
+import type { ResolvedVariable, TenantVariableScope } from './tenantVariableResolution';
 
 const savedScript = (o = {}) => ({
   id: 'script-1', orgId: 'org-a', partnerId: null, isSystem: false,
@@ -31,6 +32,24 @@ const savedScript = (o = {}) => ({
 const device = (o = {}) => ({
   id: 'device-1', orgId: 'org-a', osType: 'linux', status: 'online', agentId: null, ...o,
 }) as any;
+
+// #3409 PR2 Task 4: builds a TenantVariableScope directly, bypassing
+// loadTenantVariableScope (which needs a real DB query chain and is covered
+// on its own in tenantVariableResolution.test.ts). `resolveForOrg` and
+// `substituteTenantVariables` are used UNMOCKED here — this exercises the
+// real substitution/secret-redaction logic at the dispatch boundary, not a
+// hand-tuned mock of it. The shape below mirrors
+// tenantVariableResolution.ts's private `InternalTenantVariableScope`
+// exactly (orgIds + byOrg); TenantVariableScope itself only declares
+// `orgIds`, so this is cast through `unknown`.
+const resolvedVar = (key: string, value: string, isSecret = false): ResolvedVariable => ({
+  key, value, isSecret, variableId: `var-${key}`, version: 1,
+});
+
+const buildScope = (orgId: string, vars: ResolvedVariable[] = []): TenantVariableScope => ({
+  orgIds: new Set([orgId]),
+  byOrg: new Map([[orgId, new Map(vars.map((v) => [v.key, v]))]]),
+} as unknown as TenantVariableScope);
 
 const insertReturning = (rows: unknown[]) => ({
   values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(rows) }),
@@ -424,5 +443,98 @@ describe('dispatchScriptToDevice — delivery', () => {
     }
     expect(consoleWarnSpy).not.toHaveBeenCalled();
     consoleWarnSpy.mockRestore();
+  });
+});
+
+// #3409 PR2 Task 4: wiring tenant variable resolution into dispatch.
+describe('dispatchScriptToDevice — {{var.*}} resolution', () => {
+  it('substitutes a non-secret variable into the content that reaches the payload', async () => {
+    const scope = buildScope('org-a', [resolvedVar('repo_url', 'https://example.com/pkg')]);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript({ content: 'curl {{var.repo_url}}' }) },
+      variableScope: scope,
+    });
+    expect(r.ok).toBe(true);
+    const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
+    expect((payload as Record<string, unknown>).content).toBe('curl https://example.com/pkg');
+    expect(JSON.stringify(payload)).not.toContain('{{var.repo_url}}');
+  });
+
+  it('fails the device with unresolved_variables when a token has no value', async () => {
+    const scope = buildScope('org-a', []); // no variables in the snapshot
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript({ content: 'curl {{var.repo_url}}' }) },
+      variableScope: scope,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('unresolved_variables');
+    expect(queueCommand).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled(); // no orphan pending execution row
+  });
+
+  it('fails the device when the content references a SECRET variable', async () => {
+    const scope = buildScope('org-a', [resolvedVar('s1_token', 'shh', true)]);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript({ content: 'curl -H "Authorization: {{var.s1_token}}"' }) },
+      variableScope: scope,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('unresolved_variables');
+      expect(r.error).toMatch(/secret/i);
+    }
+  });
+
+  it('never puts a secret value anywhere in the built payload', async () => {
+    const SECRET_VALUE = 'top-secret-value-xyz';
+    const scope = buildScope('org-a', [resolvedVar('s1_token', SECRET_VALUE, true)]);
+    await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript({ content: 'curl -H "Authorization: {{var.s1_token}}"' }) },
+      variableScope: scope,
+    });
+    // A secret reference fails the device before any payload is ever built —
+    // queueCommand's captured call args ARE what would have reached the
+    // agent, so asserting the call never happened, and that whatever WAS
+    // captured never contains the plaintext, covers both "no payload built"
+    // and "even if one were, it's clean".
+    expect(queueCommand).not.toHaveBeenCalled();
+    const payload = vi.mocked(queueCommand).mock.calls[0]?.[2] ?? null;
+    expect(JSON.stringify(payload)).not.toContain(SECRET_VALUE);
+  });
+
+  it('resolves nothing and requires no scope when the content has no {{var.}} token', async () => {
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'saved', script: savedScript({ content: 'echo hi, no tokens here' }) },
+      // deliberately no variableScope — must not throw
+    });
+    expect(r.ok).toBe(true);
+    const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
+    expect((payload as Record<string, unknown>).content).toBe('echo hi, no tokens here');
+  });
+
+  it('throws if the supplied scope was not built for this device org', async () => {
+    const scope = buildScope('org-other', [resolvedVar('repo_url', 'x')]);
+    await expect(dispatchScriptToDevice({
+      device: device({ orgId: 'org-a' }),
+      source: { kind: 'saved', script: savedScript({ orgId: 'org-a', content: '{{var.repo_url}}' }) },
+      variableScope: scope,
+    })).rejects.toThrow(/not in this snapshot/i);
+  });
+
+  it('does not substitute into a raw execute_command source ({{var.*}} passes through untouched)', async () => {
+    const scope = buildScope('org-a', [resolvedVar('repo_url', 'https://example.com')]);
+    const r = await dispatchScriptToDevice({
+      device: device(),
+      source: { kind: 'raw', content: 'curl {{var.repo_url}}', language: 'bash', provenance: 'automation:auto-1' },
+      variableScope: scope,
+    });
+    expect(r.ok).toBe(true);
+    const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
+    expect((payload as Record<string, unknown>).content).toBe('curl {{var.repo_url}}');
   });
 });

--- a/apps/api/src/services/scriptDispatch.test.ts
+++ b/apps/api/src/services/scriptDispatch.test.ts
@@ -230,6 +230,24 @@ describe('dispatchScriptToDevice — rows and payload', () => {
     expect((payload as Record<string, unknown>).executionId).toBeUndefined();
   });
 
+  it('canonicalizes number/boolean parameters to strings in the payload (#3409 PR2 Task 7)', async () => {
+    await dispatchScriptToDevice({
+      device: device(), source: { kind: 'saved', script: savedScript() },
+      parameters: { n: 3, b: true, s: 'already-a-string' },
+    });
+    const [, , payload] = vi.mocked(queueCommand).mock.calls[0]!;
+    expect((payload as Record<string, unknown>).parameters).toEqual({ n: '3', b: 'true', s: 'already-a-string' });
+  });
+
+  it('does not canonicalize the parameters stored on the script_executions row (raw values preserved for history)', async () => {
+    await dispatchScriptToDevice({
+      device: device(), source: { kind: 'saved', script: savedScript(), automationRunId: null },
+      parameters: { n: 3, b: true },
+    });
+    const execValues = vi.mocked(db.insert).mock.results[0]!.value.values.mock.calls[0]![0];
+    expect(execValues.parameters).toEqual({ n: 3, b: true });
+  });
+
   it('runs the payload through encryptSensitivePayloadFields before queueCommand', async () => {
     await dispatchScriptToDevice({ device: device(), source: { kind: 'saved', script: savedScript() } });
     expect(encryptSensitivePayloadFields).toHaveBeenCalledWith('script', expect.any(Object));

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -1,4 +1,5 @@
 import { and, eq } from 'drizzle-orm';
+import { canonicalizeScriptParameters } from '@breeze/shared';
 
 import { db } from '../db';
 import { devices, scriptExecutions, scripts } from '../db/schema';
@@ -197,7 +198,14 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
       ...(input.batchId ? { batchId: input.batchId } : {}),
       language,
       content,
-      parameters,
+      // #3409 PR2 Task 7: canonicalize to strings ONCE, here, at the single
+      // dispatch chokepoint — the agent's wire type is `map[string]string`
+      // (agent/internal/executor/executor.go:39) and silently drops any
+      // non-string value (agent/internal/heartbeat/handlers_script.go:37-43).
+      // Every ingress (route, mobile, automation, AI tools, script builder,
+      // remediation suggestions) funnels through here, so this is the one
+      // place that guarantees the wire form regardless of caller.
+      parameters: canonicalizeScriptParameters(parameters as Record<string, string | number | boolean>),
       timeoutSeconds,
       runAs,
       ...(input.targetSessionId != null ? { targetSessionId: input.targetSessionId } : {}),

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -56,7 +56,21 @@ export type DispatchScriptResult =
       deliveryOutcome: 'sent' | 'claim_lost' | 'decrypt_failed' | 'send_failed' | 'no_agent';
       executedAt: Date | null;
     }
-  | { ok: false; code: 'device_decommissioned' | 'device_offline' | 'os_mismatch' | 'org_mismatch' | 'insert_failed'; error: string };
+  | {
+      ok: false;
+      code:
+        | 'device_decommissioned'
+        | 'device_offline'
+        | 'os_mismatch'
+        | 'org_mismatch'
+        | 'insert_failed'
+        // A {{var.*}} token in the script content had no resolvable value (or
+        // resolved to a secret) for this device's org. Per-device — Task 4
+        // (#3409 PR2) is what actually produces this code; this task only
+        // gives the fan-out a channel to carry it without aborting the batch.
+        | 'unresolved_variables';
+      error: string;
+    };
 
 export async function dispatchScriptToDevice(input: DispatchScriptInput): Promise<DispatchScriptResult> {
   const { device, source } = input;

--- a/apps/api/src/services/scriptDispatch.ts
+++ b/apps/api/src/services/scriptDispatch.ts
@@ -1,5 +1,5 @@
 import { and, eq } from 'drizzle-orm';
-import { canonicalizeScriptParameters } from '@breeze/shared';
+import { canonicalizeScriptParameters, hasVariableTokens } from '@breeze/shared';
 
 import { db } from '../db';
 import { devices, scriptExecutions, scripts } from '../db/schema';
@@ -14,6 +14,12 @@ import {
 } from './sensitiveCommandPayload';
 import { sendCommandToAgent } from '../routes/agentWs';
 import { captureException } from './sentry';
+import {
+  describeVariableFailure,
+  resolveForOrg,
+  substituteTenantVariables,
+  type TenantVariableScope,
+} from './tenantVariableResolution';
 
 /**
  * Single seam through which every script reaches a device (#3409 PR 0).
@@ -42,6 +48,11 @@ export type DispatchScriptInput = {
   targetSessionId?: number;
   batchId?: string | null;
   requireOnline?: boolean;
+  // A snapshot preloaded ONCE per fan-out by the caller (#3409 PR2 Task 4) —
+  // see tenantVariableResolution.ts. Required only when `source.kind ===
+  // 'saved'` and the script content actually contains a {{var.*}} token; the
+  // common token-free path never needs one.
+  variableScope?: TenantVariableScope;
 };
 
 export type DispatchScriptResult =
@@ -123,10 +134,32 @@ export async function dispatchScriptToDevice(input: DispatchScriptInput): Promis
 
   const parameters = input.parameters ?? {};
   const language = source.kind === 'saved' ? source.script.language : source.language;
-  const content = source.kind === 'saved' ? source.script.content : source.content;
+  let content = source.kind === 'saved' ? source.script.content : source.content;
   const runAs = input.runAs ?? (source.kind === 'saved' ? source.script.runAs : 'system');
   const timeoutSeconds = input.timeoutSeconds ?? (source.kind === 'saved' ? source.script.timeoutSeconds : 300);
   const payloadScriptId = source.kind === 'saved' ? source.script.id : source.provenance;
+
+  // #3409 PR2 Task 4: resolve {{var.*}} tokens for this device's org before
+  // anything else happens with `content`. `hasVariableTokens` comes first so
+  // the common token-free path does no work at all — no scope lookup, no
+  // substitution pass. `{kind:'raw'}` is deliberately skipped: an ad-hoc
+  // execute_command has no declaring script, so nothing could have been
+  // validated at save time (routes/scripts.ts's secret-token rejection only
+  // runs against a saved script's content) — its tokens pass through
+  // verbatim. This sits BEFORE the script_executions insert below so a
+  // failed device leaves no orphan 'pending' row for the caller's per-device
+  // failure channel (scriptExecution.ts) to clean up.
+  if (source.kind === 'saved' && hasVariableTokens(content)) {
+    if (!input.variableScope) {
+      throw new Error('variableScope is required to dispatch a script containing {{var.*}} tokens');
+    }
+    const outcome = substituteTenantVariables(content, resolveForOrg(input.variableScope, device.orgId));
+    const failure = describeVariableFailure(outcome);
+    if (failure) {
+      return { ok: false, code: 'unresolved_variables', error: failure };
+    }
+    content = outcome.content;
+  }
 
   let executionId: string | null = null;
   if (source.kind === 'saved') {

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -27,12 +27,23 @@ vi.mock('./scriptDispatch', () => ({
   }),
 }));
 
+// #3409 PR2 Task 4: the resolver itself is fully covered (with a real DB
+// mock shape) in tenantVariableResolution.test.ts. Here it's stubbed so this
+// suite can assert the CALLER's contract — preloaded once per fan-out,
+// passed through to every dispatch call — without needing the
+// runOutsideDbContext/withSystemDbAccessContext wrappers the real resolver
+// requires from '../db' (this file's '../db' mock doesn't provide them).
+vi.mock('./tenantVariableResolution', () => ({
+  loadTenantVariableScope: vi.fn().mockResolvedValue({ orgIds: new Set() }),
+}));
+
 // Real permissions module is fine; canAccessSite is only consulted when
 // allowedSiteIds is set, which these tests don't exercise.
 
 import { db } from '../db';
 import { checkDeviceMaintenanceWindow } from './featureConfigResolver';
 import { dispatchScriptToDevice } from './scriptDispatch';
+import { loadTenantVariableScope } from './tenantVariableResolution';
 import { executeScriptOnDevices } from './scriptExecution';
 
 // db.select() is used twice per call: first the script (.limit chain), then the
@@ -335,6 +346,59 @@ describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Tas
     expect(updateCalls).toHaveLength(2);
     const devicesFailedSetCall = updateCalls[0]!.value.set.mock.calls[0][0];
     expect(devicesFailedSetCall).toHaveProperty('devicesFailed');
+  });
+});
+
+describe('executeScriptOnDevices — tenant variable scope preload (#3409 PR2 Task 4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.insert).mockReturnValue(insertReturning([{ id: 'inserted-1' }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+    vi.mocked(loadTenantVariableScope).mockResolvedValue({ orgIds: new Set() } as any);
+  });
+
+  it('preloads the scope ONCE for the whole fan-out, not once per device', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: null, isSystem: true })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-1', orgId: 'org-a' }),
+        baseDevice({ id: 'device-2', orgId: 'org-a' }),
+        baseDevice({ id: 'device-3', orgId: 'org-b' }),
+      ]) as any);
+
+    await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-1', 'device-2', 'device-3'],
+      auth: multiOrgAuth,
+    });
+
+    expect(loadTenantVariableScope).toHaveBeenCalledTimes(1);
+    // De-duplicated org set, order-insensitive.
+    const [orgIds] = vi.mocked(loadTenantVariableScope).mock.calls[0]!;
+    expect(new Set(orgIds)).toEqual(new Set(['org-a', 'org-b']));
+  });
+
+  it('passes the preloaded scope through to every device dispatch call', async () => {
+    const scope = { orgIds: new Set(['org-b']) };
+    vi.mocked(loadTenantVariableScope).mockResolvedValue(scope as any);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-a', orgId: 'org-b' }),
+        baseDevice({ id: 'device-b', orgId: 'org-b' }),
+      ]) as any);
+
+    await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      auth: multiOrgAuth,
+    });
+
+    const dispatchCalls = vi.mocked(dispatchScriptToDevice).mock.calls;
+    expect(dispatchCalls).toHaveLength(2);
+    for (const call of dispatchCalls) {
+      expect(call[0].variableScope).toBe(scope);
+    }
   });
 });
 

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -359,7 +359,11 @@ describe('executeScriptOnDevices — tenant variable scope preload (#3409 PR2 Ta
 
   it('preloads the scope ONCE for the whole fan-out, not once per device', async () => {
     vi.mocked(db.select)
-      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: null, isSystem: true })]) as any)
+      // Content MUST carry a token — the preload is gated on it, so a
+      // token-free fixture would make this assertion vacuous.
+      .mockReturnValueOnce(scriptSelectChain([
+        baseScript({ orgId: null, isSystem: true, content: 'curl {{var.repo_url}}' }),
+      ]) as any)
       .mockReturnValueOnce(devicesSelectChain([
         baseDevice({ id: 'device-1', orgId: 'org-a' }),
         baseDevice({ id: 'device-2', orgId: 'org-a' }),
@@ -376,6 +380,25 @@ describe('executeScriptOnDevices — tenant variable scope preload (#3409 PR2 Ta
     // De-duplicated org set, order-insensitive.
     const [orgIds] = vi.mocked(loadTenantVariableScope).mock.calls[0]!;
     expect(new Set(orgIds)).toEqual(new Set(['org-a', 'org-b']));
+  });
+
+  // Without this gate every script run — the overwhelming majority of which
+  // reference no variable — would escape the request transaction and take a
+  // second connection to build a snapshot nothing consults.
+  it('does not load a variable scope for a script with no {{var.*}} token', async () => {
+    vi.mocked(loadTenantVariableScope).mockResolvedValue({ orgIds: new Set() } as any);
+
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-a', content: 'echo hi' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([baseDevice({ id: 'device-1', orgId: 'org-a' })]) as any);
+
+    await executeScriptOnDevices({ scriptId: 'script-1', deviceIds: ['device-1'], auth: multiOrgAuth });
+
+    // Called with an EMPTY org list, which loadTenantVariableScope
+    // short-circuits without querying — no escape from the request
+    // transaction, no second connection.
+    const [orgIds] = vi.mocked(loadTenantVariableScope).mock.calls[0]!;
+    expect(orgIds).toEqual([]);
   });
 
   it('passes the preloaded scope through to every device dispatch call', async () => {

--- a/apps/api/src/services/scriptExecution.test.ts
+++ b/apps/api/src/services/scriptExecution.test.ts
@@ -235,6 +235,109 @@ describe('executeScriptOnDevices — cross-org isolation', () => {
   });
 });
 
+describe('executeScriptOnDevices — per-device dispatch failures (#3409 PR2 Task 3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(db.insert).mockReturnValue(insertReturning([{ id: 'inserted-1' }]) as any);
+    vi.mocked(db.update).mockReturnValue(updateChain() as any);
+  });
+
+  it('records a per-device failure and still dispatches the remaining devices', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-a', orgId: 'org-b' }),
+        baseDevice({ id: 'device-b', orgId: 'org-b' }),
+        baseDevice({ id: 'device-c', orgId: 'org-b' }),
+      ]) as any);
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null })
+      .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' })
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-c', executionId: 'exec-c', delivered: false, deliveryOutcome: 'no_agent', executedAt: null });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b', 'device-c'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.executions.map((e) => e.deviceId)).toEqual(['device-a', 'device-c']);
+    expect(result.failures).toEqual([
+      { deviceId: 'device-b', code: 'unresolved_variables', error: expect.any(String) },
+    ]);
+    // Still targeted all three — the failure didn't truncate the fan-out.
+    expect(result.devicesTargeted).toBe(3);
+  });
+
+  it('writes a failed script_executions row for the failed device, not nothing', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-a', orgId: 'org-b' }),
+        baseDevice({ id: 'device-b', orgId: 'org-b' }),
+      ]) as any);
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null })
+      .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' });
+
+    await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      auth: multiOrgAuth,
+    });
+
+    // db.insert always returns the same mocked chain object (mockReturnValue,
+    // not mockReturnValueOnce), so both the batch insert and the failed-row
+    // insert record their `.values(...)` call on that ONE shared mock fn —
+    // index into ITS call history, not `db.insert`'s. Call 0 is the batch
+    // insert (from batch creation above the dispatch loop); call 1 is the
+    // failed execution row.
+    const insertChain = vi.mocked(db.insert).mock.results[0]!.value;
+    const failedRowValues = insertChain.values.mock.calls[1][0];
+    expect(failedRowValues).toMatchObject({
+      scriptId: 'script-1',
+      deviceId: 'device-b',
+      orgId: 'org-b',
+      status: 'failed',
+      errorMessage: expect.any(String),
+      completedAt: expect.any(Date),
+    });
+  });
+
+  it('counts a per-device failure toward the batch devicesFailed, not devicesTargeted', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(scriptSelectChain([baseScript({ orgId: 'org-b' })]) as any)
+      .mockReturnValueOnce(devicesSelectChain([
+        baseDevice({ id: 'device-a', orgId: 'org-b' }),
+        baseDevice({ id: 'device-b', orgId: 'org-b' }),
+      ]) as any);
+    vi.mocked(dispatchScriptToDevice)
+      .mockResolvedValueOnce({ ok: true, commandId: 'cmd-a', executionId: 'exec-a', delivered: false, deliveryOutcome: 'no_agent', executedAt: null })
+      .mockResolvedValueOnce({ ok: false, code: 'unresolved_variables', error: 'Could not resolve variable(s): repo_url' });
+
+    const result = await executeScriptOnDevices({
+      scriptId: 'script-1',
+      deviceIds: ['device-a', 'device-b'],
+      auth: multiOrgAuth,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // devicesTargeted was set once at batch-creation time (both devices were
+    // targeted) and must not be decremented by a later per-device failure.
+    expect(result.devicesTargeted).toBe(2);
+
+    // db.update calls: one devicesFailed increment for the failed device's
+    // batch, plus the final batch-status update.
+    const updateCalls = vi.mocked(db.update).mock.results;
+    expect(updateCalls).toHaveLength(2);
+    const devicesFailedSetCall = updateCalls[0]!.value.set.mock.calls[0][0];
+    expect(devicesFailedSetCall).toHaveProperty('devicesFailed');
+  });
+});
+
 // Full MaintenanceWindowStatus shape (featureConfigResolver.ts) — the mocked
 // resolver must satisfy every field, not just the two this suite cares about.
 const maintenanceStatus = (overrides: { active: boolean; suppressScripts: boolean }) => ({

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -11,6 +11,7 @@ import { checkDeviceMaintenanceWindow } from './featureConfigResolver';
 import { canAccessSite, type UserPermissions } from './permissions';
 import { dispatchScriptToDevice } from './scriptDispatch';
 import { loadTenantVariableScope } from './tenantVariableResolution';
+import { hasVariableTokens } from '@breeze/shared';
 
 type ScriptExecutionAuth = {
   user: { id: string };
@@ -158,7 +159,16 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
 
   // Preload ONCE per fan-out (#3409 PR2 Task 4), never per device — one
   // snapshot covers every org in this batch's executable device set.
-  const variableScope = await loadTenantVariableScope([...new Set(executableDevices.map((d) => d.orgId))]);
+  //
+  // Gated on the script actually containing a {{var.*}} token. Without the
+  // gate EVERY script run — the overwhelming majority of which reference no
+  // variable at all — would escape the request transaction via
+  // runOutsideDbContext and take a second connection to run a join that is
+  // then never consulted. loadTenantVariableScope short-circuits on an empty
+  // org list without querying, so passing [] is the no-op path.
+  const variableScope = await loadTenantVariableScope(
+    hasVariableTokens(script.content) ? [...new Set(executableDevices.map((d) => d.orgId))] : []
+  );
 
   // A multi-org run (partner/system script fanned out across orgs) must not
   // stamp every batch row with the first device's org — split one batch per

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -10,6 +10,7 @@ import {
 import { checkDeviceMaintenanceWindow } from './featureConfigResolver';
 import { canAccessSite, type UserPermissions } from './permissions';
 import { dispatchScriptToDevice } from './scriptDispatch';
+import { loadTenantVariableScope } from './tenantVariableResolution';
 
 type ScriptExecutionAuth = {
   user: { id: string };
@@ -155,6 +156,10 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
   const parameters = input.parameters ?? {};
   const runAs = input.runAs ?? script.runAs;
 
+  // Preload ONCE per fan-out (#3409 PR2 Task 4), never per device — one
+  // snapshot covers every org in this batch's executable device set.
+  const variableScope = await loadTenantVariableScope([...new Set(executableDevices.map((d) => d.orgId))]);
+
   // A multi-org run (partner/system script fanned out across orgs) must not
   // stamp every batch row with the first device's org — split one batch per
   // org instead. A single-org, single-device run keeps today's no-batch
@@ -220,6 +225,7 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
       runAs,
       targetSessionId: input.targetSessionId,
       batchId: batchIdByOrg.get(device.orgId) ?? null,
+      variableScope,
     });
     if (!dispatch.ok) {
       // 'insert_failed' means queueCommand/the execution insert itself broke

--- a/apps/api/src/services/scriptExecution.ts
+++ b/apps/api/src/services/scriptExecution.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 
 import { db } from '../db';
 import {
@@ -44,6 +44,12 @@ type ExecuteScriptOnDevicesSuccess = {
   devicesTargeted: number;
   maintenanceSuppressedDeviceIds: string[];
   executions: Array<{ executionId: string; deviceId: string; commandId: string }>;
+  // Per-device dispatch failures (e.g. unresolved {{var.*}} tokens). These
+  // devices are excluded from `executions` but still counted in
+  // `devicesTargeted` — they were targeted, just failed to dispatch. Each one
+  // gets its own 'failed' script_executions row (see the dispatch loop below)
+  // so `devicesTargeted` never outlives the rows a caller can find.
+  failures: Array<{ deviceId: string; code: string; error: string }>;
   status: 'queued';
   triggerType: 'manual' | 'scheduled' | 'alert' | 'policy';
   runAs: string;
@@ -191,6 +197,7 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
   }
 
   const executions: Array<{ executionId: string; deviceId: string; commandId: string }> = [];
+  const failures: Array<{ deviceId: string; code: string; error: string }> = [];
   // This loop itself is sequential/awaited and therefore bounded, but
   // queueCommand (inside dispatchScriptToDevice) fires an un-awaited,
   // fire-and-forget audit transaction PER DEVICE for 'script' commands
@@ -215,10 +222,37 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
       batchId: batchIdByOrg.get(device.orgId) ?? null,
     });
     if (!dispatch.ok) {
-      // Pre-checks above (org access, os filter, decommissioned filter) make
-      // these unreachable for this caller; treat as the insert failures the
-      // old code threw on.
-      throw new Error(dispatch.error);
+      // 'insert_failed' means queueCommand/the execution insert itself broke
+      // — a programming error, not a per-device condition. Every other code
+      // (today: 'unresolved_variables', once Task 4 wires resolution in) is a
+      // condition specific to this device and must not truncate the rest of
+      // the fan-out — see softwareDeployment.ts:399-414 for the pattern this
+      // mirrors.
+      if (dispatch.code === 'insert_failed') {
+        throw new Error(dispatch.error);
+      }
+      await db.insert(scriptExecutions).values({
+        scriptId: input.scriptId,
+        deviceId: device.id,
+        // Child rows always take the DEVICE's org (partner-wide fan-out
+        // rule) — never the script's, which may be null/partner-wide.
+        orgId: device.orgId,
+        triggeredBy: input.auth.user.id,
+        triggerType,
+        parameters,
+        status: 'failed',
+        errorMessage: dispatch.error,
+        completedAt: new Date(),
+      });
+      const batchId = batchIdByOrg.get(device.orgId);
+      if (batchId) {
+        await db
+          .update(scriptExecutionBatches)
+          .set({ devicesFailed: sql`${scriptExecutionBatches.devicesFailed} + 1` })
+          .where(eq(scriptExecutionBatches.id, batchId));
+      }
+      failures.push({ deviceId: device.id, code: dispatch.code, error: dispatch.error });
+      continue;
     }
     executions.push({
       executionId: dispatch.executionId!,
@@ -251,6 +285,7 @@ export async function executeScriptOnDevices(input: ExecuteScriptOnDevicesInput)
     devicesTargeted: executableDevices.length,
     maintenanceSuppressedDeviceIds,
     executions,
+    failures,
     status: 'queued',
     triggerType,
     runAs,

--- a/apps/api/src/services/softwareDeployment.test.ts
+++ b/apps/api/src/services/softwareDeployment.test.ts
@@ -47,6 +47,11 @@ vi.mock('../db', () => ({
     insert: (...args: unknown[]) => insertMock(...args),
     update: (...args: unknown[]) => updateMock(...args),
   },
+  // tenantVariableResolution.ts (#3409 PR2) requires both wrappers around its
+  // query; pass-throughs here mirror the pattern already used by
+  // routes/scripts.test.ts and tenantVariableResolution.test.ts.
+  runOutsideDbContext: <T>(fn: () => T): T => fn(),
+  withSystemDbAccessContext: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
 }));
 
 // Wrap drizzle's condition builders in spies (behavior preserved) so tests can
@@ -78,8 +83,18 @@ vi.mock('../db/schema', () => ({
     hostname: 'd.hostname',
     customFields: 'd.customFields',
   },
-  organizations: { id: 'o.id', name: 'o.name' },
+  organizations: { id: 'o.id', name: 'o.name', partnerId: 'o.partnerId' },
   sites: { id: 's.id', name: 's.name', orgId: 's.orgId' },
+  // tenantVariableResolution.ts's scope query (#3409 PR2) joins these two.
+  tenantVariables: {
+    id: 'tv.id',
+    key: 'tv.key',
+    value: 'tv.value',
+    isSecret: 'tv.isSecret',
+    version: 'tv.version',
+    orgId: 'tv.orgId',
+    partnerId: 'tv.partnerId',
+  },
 }));
 
 import {
@@ -111,6 +126,20 @@ function selLimit(rows: unknown[]) {
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  };
+}
+
+/**
+ * Chainable select for loadTenantVariableScope's join query:
+ * db.select().from().innerJoin().where() → Promise<rows>
+ */
+function selJoin(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows),
       }),
     }),
   };
@@ -317,7 +346,8 @@ describe('createSoftwareDeployment', () => {
       .mockReturnValueOnce(sel([catalogItem]))
       .mockReturnValueOnce(sel(targetDevices))
       .mockReturnValueOnce(selLimit([{ name: 'Acme' }])) // organizations
-      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }])); // sites
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }])) // sites
+      .mockReturnValueOnce(selJoin([])); // tenant variable scope (#3409 PR2) — none defined
     insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
 
     const result = await createSoftwareDeployment({
@@ -334,6 +364,111 @@ describe('createSoftwareDeployment', () => {
     expect(sendCommandMock.mock.calls[0]![1].payload.downloadUrl).toBe(
       'https://dl/org-1/KEY-1/app.msi',
     );
+  });
+
+  it('resolves a {{var.<key>}} tenant variable into the download URL (#3409 PR2)', async () => {
+    const versionRecord = {
+      id: 'ver-var2',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: 'https://dl/{{var.repo_token}}/app.msi',
+      checksum: null,
+      originalFileName: 'app.msi',
+      fileType: 'msi',
+      silentInstallArgs: null,
+      version: '2.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-var2', orgId: 'org-1' };
+    const targetDevices = [
+      { id: 'dev-1', agentId: 'agent-1', siteId: 'site-1', hostname: 'WKS-1', customFields: {} },
+    ];
+    // A non-secret row for org-1 (forOrgId), plus a SECRET row that must never
+    // be flattened into the vars map at all.
+    const variableRows = [
+      { id: 'tv-1', key: 'repo_token', value: 'tok-live', isSecret: false, version: 1, ownerOrgId: 'org-1', forOrgId: 'org-1' },
+      { id: 'tv-2', key: 'super_secret', value: 'sekrit', isSecret: true, version: 1, ownerOrgId: 'org-1', forOrgId: 'org-1' },
+    ];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices))
+      .mockReturnValueOnce(selLimit([{ name: 'Acme' }])) // organizations
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }])) // sites
+      .mockReturnValueOnce(selJoin(variableRows)); // tenant variable scope
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-var2',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    expect(result.status).toBe('pending');
+    expect(result.dispatchedDeviceIds).toEqual(['dev-1']);
+    expect(sendCommandMock.mock.calls[0]![1].payload.downloadUrl).toBe(
+      'https://dl/tok-live/app.msi',
+    );
+  });
+
+  it('fails the device (no dispatch) through the existing unresolved branch when the URL references a SECRET tenant variable (#3409 PR2)', async () => {
+    const versionRecord = {
+      id: 'ver-var3',
+      catalogId: 'cat-1',
+      s3Key: null,
+      downloadUrl: 'https://dl/{{var.super_secret}}/app.msi',
+      checksum: null,
+      originalFileName: 'app.msi',
+      fileType: 'msi',
+      silentInstallArgs: null,
+      version: '2.0.0',
+    };
+    const catalogItem = { id: 'cat-1', orgId: null, name: 'TestApp', integrationProvider: null };
+    const deployment = { id: 'dep-var3', orgId: 'org-1' };
+    const targetDevices = [
+      { id: 'dev-1', agentId: 'agent-1', siteId: 'site-1', hostname: 'WKS-1', customFields: {} },
+    ];
+    const variableRows = [
+      { id: 'tv-2', key: 'super_secret', value: 'sekrit', isSecret: true, version: 1, ownerOrgId: 'org-1', forOrgId: 'org-1' },
+    ];
+
+    selectMock
+      .mockReturnValueOnce(sel([versionRecord]))
+      .mockReturnValueOnce(sel([catalogItem]))
+      .mockReturnValueOnce(sel(targetDevices))
+      .mockReturnValueOnce(selLimit([{ name: 'Acme' }])) // organizations
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }])) // sites
+      .mockReturnValueOnce(selJoin(variableRows)); // tenant variable scope
+    insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
+
+    const result = await createSoftwareDeployment({
+      orgId: 'org-1',
+      softwareVersionId: 'ver-var3',
+      deploymentType: 'install',
+      deviceIds: ['dev-1'],
+      scheduleType: 'immediate',
+      createdBy: null,
+    });
+
+    // The secret is OMITTED from the vars map entirely (softwareDeployment.ts),
+    // so `{{var.super_secret}}` is indistinguishable from an unknown token here
+    // — it fails through the PRE-EXISTING unresolved branch, no new failure
+    // code or counter. The only (and last) device failed resolution, so the
+    // batch itself reports failed too (mirrors the sibling "cannot be
+    // resolved" test above).
+    expect(result.status).toBe('failed');
+    expect(result.dispatchedDeviceIds).toEqual([]);
+    expect(sendCommandMock).not.toHaveBeenCalled();
+    expect(queueCommandMock).not.toHaveBeenCalled();
+    const failureWrite = updateSetCalls.find(
+      (c) => typeof c.errorMessage === 'string' && c.errorMessage.includes('super_secret'),
+    );
+    expect(failureWrite).toBeDefined();
+    expect(failureWrite?.status).toBe('failed');
   });
 
   it('dispatches a built-in EDR install using the resolver-provided URL/args', async () => {
@@ -438,7 +573,8 @@ describe('createSoftwareDeployment', () => {
       .mockReturnValueOnce(sel([catalogItem]))
       .mockReturnValueOnce(sel(targetDevices))
       .mockReturnValueOnce(selLimit([{ name: 'Acme' }]))
-      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }]));
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }]))
+      .mockReturnValueOnce(selJoin([])); // tenant variable scope (#3409 PR2) — none defined
     insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
 
     const result = await createSoftwareDeployment({
@@ -483,7 +619,8 @@ describe('createSoftwareDeployment', () => {
       .mockReturnValueOnce(sel([catalogItem]))
       .mockReturnValueOnce(sel(targetDevices))
       .mockReturnValueOnce(selLimit([{ name: 'Acme' }]))
-      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }]));
+      .mockReturnValueOnce(sel([{ id: 'site-1', name: 'HQ' }]))
+      .mockReturnValueOnce(selJoin([])); // tenant variable scope (#3409 PR2) — none defined
     insertMock.mockReturnValueOnce(insWithReturning([deployment])).mockReturnValueOnce(ins());
 
     const result = await createSoftwareDeployment({

--- a/apps/api/src/services/softwareDeployment.ts
+++ b/apps/api/src/services/softwareDeployment.ts
@@ -11,6 +11,7 @@ import {
 } from '../db/schema';
 import { resolveEdrInstaller, type ResolvedInstaller } from './edrInstallerResolver';
 import { resolveInstallerVariables, type InstallerVariableContext } from './installerVariables';
+import { loadTenantVariableScope, resolveForOrg } from './tenantVariableResolution';
 import { getPresignedUrl, isS3Configured, isS3NotFound } from './s3Storage';
 import { queueCommand } from './commandQueue';
 import {
@@ -320,6 +321,14 @@ export async function buildAndDispatchSoftwareInstalls(
 
   let orgName = '';
   const siteNames = new Map<string, string>();
+  // Tenant variables (#3409 PR2): flattened KEY -> non-secret VALUE map for
+  // the `var.<key>` arm of installerVariables.ts's resolveKey. Secret
+  // variables are omitted entirely here — not merely left unresolved — so a
+  // template referencing one falls through to the pre-existing `unresolved`
+  // failure branch below with no new failure code or counter (dispatch's own
+  // per-device secret check, wired separately, is the actual security gate;
+  // this omission is a defense-in-depth belt on the deploy path too).
+  const tenantVars: Record<string, string> = {};
   if (templatesUseVariables) {
     const [org] = await db
       .select({ name: organizations.name })
@@ -332,6 +341,11 @@ export async function buildAndDispatchSoftwareInstalls(
       .from(sites)
       .where(eq(sites.orgId, orgId));
     for (const s of siteRows) siteNames.set(s.id, s.name);
+
+    const variableScope = await loadTenantVariableScope([orgId]);
+    for (const [key, variable] of resolveForOrg(variableScope, orgId)) {
+      if (!variable.isSecret) tenantVars[key] = variable.value;
+    }
   }
 
   // Detection rules (#2022) and the force-reinstall toggle ride along with the
@@ -394,6 +408,7 @@ export async function buildAndDispatchSoftwareInstalls(
           hostname: device.hostname,
           customFields: (device.customFields as Record<string, unknown> | null) ?? {},
         },
+        vars: tenantVars,
       };
       const resolved = resolveInstallerVariables(finalDownloadUrl, finalSilentInstallArgs, ctx);
       if (resolved.unresolved.length > 0) {

--- a/apps/api/src/services/tenantVariableResolution.test.ts
+++ b/apps/api/src/services/tenantVariableResolution.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Only `../db` is mocked — NEVER `../db/schema`. The query is built with real
+// Drizzle columns (organizations.id, organizations.partnerId,
+// tenantVariables.orgId, ...), and the WHERE-clause assertions below walk the
+// captured condition's actual bound parameters. Stubbing the schema with
+// plain strings would make those assertions vacuous (see
+// services/tenantVariables.test.ts, whose `boundParams` helper this file
+// copies for the same reason).
+vi.mock('../db', () => {
+  const dbMock = { select: vi.fn() };
+  return {
+    db: dbMock,
+    runOutsideDbContext: <T>(fn: () => T): T => fn(),
+    withSystemDbAccessContext: async <T>(fn: () => Promise<T>): Promise<T> => fn()
+  };
+});
+
+import { db } from '../db';
+import { encryptTenantVariableValue } from './tenantVariables';
+import {
+  describeVariableFailure,
+  loadTenantVariableScope,
+  resolveForOrg,
+  substituteTenantVariables,
+  type ResolvedVariable
+} from './tenantVariableResolution';
+
+const dbMock = db as unknown as { select: ReturnType<typeof vi.fn> };
+
+const ORG_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ORG_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const ROW_ORG = '11111111-1111-1111-1111-111111111111';
+const ROW_PARTNER = '22222222-2222-2222-2222-222222222222';
+const ROW_ORG_B = '33333333-3333-3333-3333-333333333333';
+const ROW_SECRET = '44444444-4444-4444-4444-444444444444';
+const ROW_BAD = '55555555-5555-5555-5555-555555555555';
+
+const ENV_KEYS = ['APP_ENCRYPTION_KEY', 'APP_ENCRYPTION_KEY_ID', 'APP_ENCRYPTION_KEYRING'] as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of ENV_KEYS) delete process.env[key];
+  process.env.APP_ENCRYPTION_KEY = 'unit-test-key-material';
+  process.env.APP_ENCRYPTION_KEY_ID = 'unit';
+});
+
+/**
+ * Every bound parameter in a Drizzle condition tree, in order. Copied from
+ * `services/tenantVariables.test.ts` — see its comment for why walking real
+ * bound params (rather than stringifying the condition) is what makes these
+ * assertions discriminating: delete the org filter and these tests go red.
+ */
+function boundParams(node: unknown, out: unknown[] = []): unknown[] {
+  if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') {
+    out.push(node);
+    return out;
+  }
+  if (Array.isArray(node)) {
+    for (const entry of node) boundParams(entry, out);
+    return out;
+  }
+  if (!node || typeof node !== 'object') return out;
+
+  const record = node as Record<string, unknown>;
+  if (record.constructor?.name === 'StringChunk') return out;
+  if ('encoder' in record && 'value' in record) {
+    boundParams(record.value, out);
+    return out;
+  }
+  if (Array.isArray(record.queryChunks)) {
+    for (const chunk of record.queryChunks) boundParams(chunk, out);
+  }
+  return out;
+}
+
+interface StubRow {
+  id: string;
+  key: string;
+  value: string;
+  isSecret: boolean;
+  version: number;
+  ownerOrgId: string | null;
+  forOrgId: string;
+}
+
+function encryptedRow(id: string, plaintext: string, overrides: Partial<StubRow> = {}): StubRow {
+  return {
+    id,
+    key: 'repo_url',
+    value: encryptTenantVariableValue(id, plaintext),
+    isSecret: false,
+    version: 1,
+    ownerOrgId: null,
+    forOrgId: ORG_A,
+    ...overrides
+  };
+}
+
+/** Chainable select stub matching `.select().from().innerJoin().where()`. */
+function stubSelect(rows: StubRow[]) {
+  const captured: { on?: unknown; where?: unknown } = {};
+  dbMock.select.mockReturnValue({
+    from: () => ({
+      innerJoin: (_table: unknown, on: unknown) => {
+        captured.on = on;
+        return {
+          where: (condition: unknown) => {
+            captured.where = condition;
+            return Promise.resolve(rows);
+          }
+        };
+      }
+    })
+  });
+  return captured;
+}
+
+function mapWith(entry: Partial<ResolvedVariable> & { key: string }): Map<string, ResolvedVariable> {
+  return new Map([
+    [
+      entry.key,
+      {
+        key: entry.key,
+        value: entry.value ?? 'v',
+        isSecret: entry.isSecret ?? false,
+        variableId: entry.variableId ?? ROW_ORG,
+        version: entry.version ?? 1
+      }
+    ]
+  ]);
+}
+
+describe('loadTenantVariableScope', () => {
+  it('returns an empty scope without querying for an empty input', async () => {
+    const scope = await loadTenantVariableScope([]);
+    expect(scope.orgIds.size).toBe(0);
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+
+  it('issues ONE query for many orgs', async () => {
+    stubSelect([]);
+    await loadTenantVariableScope([ORG_A, ORG_B]);
+    expect(dbMock.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters on the requested org ids — the sole tenancy boundary under system scope', async () => {
+    const captured = stubSelect([]);
+    await loadTenantVariableScope([ORG_A, ORG_B]);
+    const params = boundParams(captured.where);
+    expect(params).toContain(ORG_A);
+    expect(params).toContain(ORG_B);
+  });
+
+  it('org value shadows a partner-wide value for the same key', async () => {
+    stubSelect([
+      encryptedRow(ROW_PARTNER, 'partner-value', { key: 'k', ownerOrgId: null, forOrgId: ORG_A }),
+      encryptedRow(ROW_ORG, 'org-value', { key: 'k', ownerOrgId: ORG_A, forOrgId: ORG_A })
+    ]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const resolved = resolveForOrg(scope, ORG_A);
+    expect(resolved.get('k')?.value).toBe('org-value');
+  });
+
+  it('a partner-wide key with no org override still resolves', async () => {
+    stubSelect([encryptedRow(ROW_PARTNER, 'partner-value', { key: 'k', ownerOrgId: null, forOrgId: ORG_A })]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    expect(resolveForOrg(scope, ORG_A).get('k')?.value).toBe('partner-value');
+  });
+
+  it('never leaks another org value into this org resolution', async () => {
+    stubSelect([
+      encryptedRow(ROW_ORG, 'a-value', { key: 'k', ownerOrgId: ORG_A, forOrgId: ORG_A }),
+      encryptedRow(ROW_ORG_B, 'b-value', { key: 'k', ownerOrgId: ORG_B, forOrgId: ORG_B })
+    ]);
+    const scope = await loadTenantVariableScope([ORG_A, ORG_B]);
+    expect(resolveForOrg(scope, ORG_A).get('k')?.value).toBe('a-value');
+    expect(resolveForOrg(scope, ORG_B).get('k')?.value).toBe('b-value');
+  });
+
+  it('an undecryptable row is treated as unresolved, not as an empty value', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubSelect([
+      { id: ROW_BAD, key: 'broken', value: 'enc:v3:unit:not.real.ciphertext', isSecret: false, version: 1, ownerOrgId: ORG_A, forOrgId: ORG_A }
+    ]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const resolved = resolveForOrg(scope, ORG_A);
+    expect(resolved.has('broken')).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    expect(String(warn.mock.calls[0]?.[1]?.id ?? '')).toBe(ROW_BAD);
+    // The warning must never carry the value / attempted plaintext.
+    expect(JSON.stringify(warn.mock.calls[0])).not.toContain('not.real.ciphertext');
+    warn.mockRestore();
+  });
+
+  it('carries a secret row through to the snapshot (unredacted internally — redaction happens at substitution)', async () => {
+    stubSelect([encryptedRow(ROW_SECRET, 'shh', { key: 's1_token', isSecret: true, ownerOrgId: ORG_A, forOrgId: ORG_A })]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const resolved = resolveForOrg(scope, ORG_A);
+    expect(resolved.get('s1_token')).toMatchObject({ isSecret: true, value: 'shh' });
+  });
+});
+
+describe('resolveForOrg', () => {
+  it('throws when asked to resolve for an org the snapshot was not built for', async () => {
+    stubSelect([]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    expect(() => resolveForOrg(scope, ORG_B)).toThrow(/not in this snapshot/i);
+  });
+
+  it('returns a fresh map each call — mutating the result cannot corrupt the snapshot', async () => {
+    stubSelect([encryptedRow(ROW_ORG, 'v', { key: 'k', ownerOrgId: ORG_A, forOrgId: ORG_A })]);
+    const scope = await loadTenantVariableScope([ORG_A]);
+    const first = resolveForOrg(scope, ORG_A);
+    first.delete('k');
+    const second = resolveForOrg(scope, ORG_A);
+    expect(second.has('k')).toBe(true);
+  });
+});
+
+describe('substituteTenantVariables', () => {
+  it('substitutes a non-secret variable', () => {
+    const out = substituteTenantVariables('{{var.k}}', mapWith({ key: 'k', value: 'hello' }));
+    expect(out).toEqual({ content: 'hello', unresolved: [], secretsReferenced: [] });
+  });
+
+  it('reports a missing key as unresolved, not as a secret', () => {
+    const out = substituteTenantVariables('{{var.missing}}', new Map());
+    expect(out).toEqual({ content: '{{var.missing}}', unresolved: ['missing'], secretsReferenced: [] });
+  });
+
+  it('reports a secret key instead of substituting it', () => {
+    const out = substituteTenantVariables('{{var.s1_token}}', mapWith({ key: 's1_token', isSecret: true, value: 'shh' }));
+    expect(out.content).toBe('{{var.s1_token}}');
+    expect(out.secretsReferenced).toEqual(['s1_token']);
+    expect(out.unresolved).toEqual([]);
+  });
+
+  it('never puts a secret value in the returned content even when the same key is referenced twice', () => {
+    const out = substituteTenantVariables(
+      '{{var.s1_token}} and again {{var.s1_token}}',
+      mapWith({ key: 's1_token', isSecret: true, value: 'top-secret-value' })
+    );
+    expect(out.content).not.toContain('top-secret-value');
+    expect(out.secretsReferenced).toEqual(['s1_token']);
+  });
+
+  it('mixes a resolved, a missing, and a secret key correctly in one pass', () => {
+    const resolved = new Map<string, ResolvedVariable>([
+      ['ok', { key: 'ok', value: 'fine', isSecret: false, variableId: ROW_ORG, version: 1 }],
+      ['sekret', { key: 'sekret', value: 'nope', isSecret: true, variableId: ROW_SECRET, version: 1 }]
+    ]);
+    const out = substituteTenantVariables('{{var.ok}} {{var.sekret}} {{var.gone}}', resolved);
+    expect(out.content).toBe('fine {{var.sekret}} {{var.gone}}');
+    expect(out.unresolved).toEqual(['gone']);
+    expect(out.secretsReferenced).toEqual(['sekret']);
+  });
+});
+
+describe('describeVariableFailure', () => {
+  it('returns null when nothing is wrong', () => {
+    expect(describeVariableFailure({ content: 'ok', unresolved: [], secretsReferenced: [] })).toBeNull();
+  });
+
+  it('names the keys but never a value', () => {
+    const message = describeVariableFailure({
+      content: 'x',
+      unresolved: ['missing_key'],
+      secretsReferenced: ['secret_key']
+    });
+    expect(message).toContain('missing_key');
+    expect(message).toContain('secret_key');
+    expect(message).not.toContain('shh');
+    expect(message).not.toContain('top-secret-value');
+  });
+
+  it('distinguishes missing keys from secret keys in the message', () => {
+    const missingOnly = describeVariableFailure({ content: 'x', unresolved: ['a'], secretsReferenced: [] });
+    const secretOnly = describeVariableFailure({ content: 'x', unresolved: [], secretsReferenced: ['b'] });
+    expect(missingOnly).not.toBe(secretOnly);
+    expect(secretOnly).toMatch(/secret/i);
+  });
+});

--- a/apps/api/src/services/tenantVariableResolution.ts
+++ b/apps/api/src/services/tenantVariableResolution.ts
@@ -1,0 +1,280 @@
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import { replaceVariableTokens } from '@breeze/shared';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
+import { organizations, tenantVariables } from '../db/schema';
+import { decryptTenantVariableValue } from './tenantVariables';
+
+/**
+ * Tenant variable resolution (#3409 PR 2) — turns the `tenant_variables` rows
+ * PR 1 created into actual `{{var.<key>}}` substitution at script dispatch.
+ *
+ * Resolution never rides ambient RLS. The five dispatch call sites
+ * (`scriptExecution`, `automationRuntime` x2, `aiToolsScripts`, plus the
+ * direct-device path) run under three different DB contexts — an org-scoped
+ * request transaction, a system-scoped background job, and an
+ * org-token-without-partnerId JWT among them — and if resolution rode
+ * whichever context happened to be ambient, the SAME script could resolve a
+ * DIFFERENT variable set depending on which call site dispatched it. Instead,
+ * `loadTenantVariableScope` always elevates to a genuinely fresh system
+ * context (see below) and produces one immutable snapshot that every call
+ * site consumes identically.
+ *
+ * Because system scope means Postgres RLS no longer constrains the query at
+ * all, the WHERE clause in `loadTenantVariableScope` is the ONLY tenancy
+ * boundary left standing — it must be exact, and its exactness is what the
+ * unit test in this module's test file mutation-tests.
+ */
+
+/** A single resolved variable, ready to substitute — never a secret's value unredacted into content (see {@link substituteTenantVariables}). */
+export interface ResolvedVariable {
+  key: string;
+  value: string;
+  isSecret: boolean;
+  variableId: string;
+  version: number;
+}
+
+/**
+ * Opaque scope snapshot. Built only by {@link loadTenantVariableScope}, which
+ * is the sole place allowed to construct one — every other module (including
+ * this one's own `resolveForOrg`) treats it as a carrier: read `orgIds` to
+ * check membership, and hand the whole object back to `resolveForOrg`.
+ *
+ * The actual per-org variable maps live on a wider, module-private type
+ * (`InternalTenantVariableScope` below) that is never exported. That keeps a
+ * caller from reaching in and reading another org's map directly — the only
+ * sanctioned path to a `Map<string, ResolvedVariable>` is `resolveForOrg`,
+ * which enforces the "this org was in the snapshot" check first.
+ */
+export interface TenantVariableScope {
+  readonly orgIds: ReadonlySet<string>;
+}
+
+/** Module-private carrier. Not exported — see {@link TenantVariableScope}. */
+interface InternalTenantVariableScope extends TenantVariableScope {
+  readonly byOrg: ReadonlyMap<string, ReadonlyMap<string, ResolvedVariable>>;
+}
+
+function emptyScope(): InternalTenantVariableScope {
+  return { orgIds: new Set(), byOrg: new Map() };
+}
+
+/** Row shape decrypted by {@link decryptRow}. Matches the resolver's select projection. */
+interface RawResolvedRow {
+  id: string;
+  key: string;
+  value: string;
+  isSecret: boolean;
+  version: number;
+  /** `tenant_variables.org_id` — non-null means this row is org-owned (for exactly the org it names); null means partner-wide. */
+  ownerOrgId: string | null;
+  /** The org this row applies TO — always a member of the snapshot's requested org set, per the WHERE clause. */
+  forOrgId: string;
+}
+
+/**
+ * Decrypt one row, or return null and warn (id only — never the ciphertext or
+ * an attempted plaintext) on failure. An unreadable variable must fail the
+ * device it would have been substituted into, never silently resolve to an
+ * empty string, so the row is OMITTED from the snapshot rather than inserted
+ * with a placeholder value.
+ */
+function decryptRow(row: RawResolvedRow): ResolvedVariable | null {
+  try {
+    const value = decryptTenantVariableValue(row);
+    return { key: row.key, value, isSecret: row.isSecret, variableId: row.id, version: row.version };
+  } catch (err) {
+    console.warn('[tenant-variable-resolution] failed to decrypt tenant variable value', { id: row.id });
+    return null;
+  }
+}
+
+/**
+ * Load an immutable variable snapshot for a set of orgs in ONE query.
+ *
+ * Returns an empty scope (valid for no orgs) WITHOUT querying when `orgIds`
+ * is empty — the common case for a dispatch batch with no `{{var.*}}` tokens
+ * at all, via the `hasVariableTokens` short-circuit at the call site.
+ *
+ * MUST run inside `runOutsideDbContext(() => withSystemDbAccessContext(...))`
+ * — BOTH wrappers, in that order. The route path calls this from inside a
+ * held ORG-SCOPED request transaction (e.g. a script-run request), and a bare
+ * `withSystemDbAccessContext` nested inside an already-open
+ * `withDbAccessContext` transaction is a no-op: `withDbAccessContext` returns
+ * immediately when a context is already on the AsyncLocalStorage stack
+ * (`apps/api/src/db/index.ts`), so the SET LOCAL GUCs from the outer org
+ * context would stay in force. Concretely, an org token whose JWT lacks
+ * `partnerId` would then see zero partner-wide rows for that request — the
+ * exact "same script resolves different variables depending on which of the
+ * five dispatch call sites invoked it" bug this module exists to prevent.
+ * `runOutsideDbContext` exits the ambient context first so the subsequent
+ * `withSystemDbAccessContext` opens a genuinely fresh, unconstrained
+ * transaction.
+ *
+ * Because system scope disables RLS entirely for this query, the `WHERE o.id
+ * = ANY($1)` clause below is the ONLY tenancy boundary. Every org this
+ * resolves for must already be one the caller was independently authorized to
+ * dispatch to (dispatch call sites derive `orgIds` from the devices they were
+ * already permitted to target) — this function does not itself authorize
+ * anything, it only fetches exactly the rows for the orgs it is told about.
+ */
+export async function loadTenantVariableScope(orgIds: string[]): Promise<TenantVariableScope> {
+  const uniqueOrgIds = [...new Set(orgIds)];
+  if (uniqueOrgIds.length === 0) {
+    return emptyScope();
+  }
+
+  return runOutsideDbContext(() =>
+    withSystemDbAccessContext(async () => {
+      // ONE query for every org in the snapshot, joining `organizations` so a
+      // partner-wide row (tenant_variables.org_id IS NULL) can be matched to
+      // each inheriting org's partner_id. A partner-wide row therefore comes
+      // back once PER inheriting org, each tagged with the org it is FOR
+      // (`forOrgId`) — never once globally, which is what makes attributing
+      // rows back to the right org below possible without a second query.
+      const rows: RawResolvedRow[] = await db
+        .select({
+          id: tenantVariables.id,
+          key: tenantVariables.key,
+          value: tenantVariables.value,
+          isSecret: tenantVariables.isSecret,
+          version: tenantVariables.version,
+          ownerOrgId: tenantVariables.orgId,
+          forOrgId: organizations.id
+        })
+        .from(organizations)
+        .innerJoin(
+          tenantVariables,
+          or(
+            eq(tenantVariables.orgId, organizations.id),
+            and(isNull(tenantVariables.orgId), eq(tenantVariables.partnerId, organizations.partnerId))
+          )
+        )
+        .where(inArray(organizations.id, uniqueOrgIds));
+
+      const byOrg = new Map<string, Map<string, ResolvedVariable>>();
+      for (const id of uniqueOrgIds) byOrg.set(id, new Map());
+
+      // Org-owned rows always win over a same-key partner-wide row (resolution
+      // precedence: org > partner). Track which (org, key) pairs an org-owned
+      // row has already claimed so the partner-wide pass below never
+      // overwrites one, REGARDLESS of the order Postgres returns rows in (no
+      // ORDER BY is specified, and none is needed — precedence is enforced
+      // here, not by row order).
+      const orgOwnedKeys = new Map<string, Set<string>>();
+      for (const id of uniqueOrgIds) orgOwnedKeys.set(id, new Set());
+
+      for (const row of rows) {
+        if (row.ownerOrgId === null) continue; // partner-wide; handled in the second pass
+        const resolved = decryptRow(row);
+        if (!resolved) continue;
+        byOrg.get(row.forOrgId)?.set(row.key, resolved);
+        orgOwnedKeys.get(row.forOrgId)?.add(row.key);
+      }
+
+      for (const row of rows) {
+        if (row.ownerOrgId !== null) continue; // org-owned; already handled above
+        if (orgOwnedKeys.get(row.forOrgId)?.has(row.key)) continue; // shadowed by an org override
+        const resolved = decryptRow(row);
+        if (!resolved) continue;
+        byOrg.get(row.forOrgId)?.set(row.key, resolved);
+      }
+
+      const scope: InternalTenantVariableScope = { orgIds: new Set(uniqueOrgIds), byOrg };
+      return scope;
+    })
+  );
+}
+
+/**
+ * Resolve the variable map for one org out of a previously-loaded snapshot.
+ *
+ * Throws when `orgId` is not in `scope.orgIds` — this is the "dispatch
+ * verifies the snapshot" contract from the plan's deviation table: a caller
+ * must not be able to hand a snapshot built for orgs {A, B} and then quietly
+ * resolve for org C, which would either silently return nothing (masking a
+ * caller bug) or, worse, coincidentally return org C's real data if some
+ * future refactor widened the internal map's keying. Failing loudly here
+ * keeps `loadTenantVariableScope` the single place that decides which orgs a
+ * snapshot is valid for.
+ *
+ * Returns a fresh `Map` copy (never the snapshot's own map) so a caller
+ * mutating the returned map can never corrupt the immutable snapshot for a
+ * later `resolveForOrg` call against the same scope.
+ */
+export function resolveForOrg(scope: TenantVariableScope, orgId: string): Map<string, ResolvedVariable> {
+  if (!scope.orgIds.has(orgId)) {
+    throw new Error(`Org ${orgId} is not in this snapshot`);
+  }
+  const internal = scope as InternalTenantVariableScope;
+  return new Map(internal.byOrg.get(orgId) ?? []);
+}
+
+export interface SubstitutionOutcome {
+  content: string;
+  /** Keys with no visible value at all — genuinely missing, never a secret (those are reported in {@link secretsReferenced} instead). */
+  unresolved: string[];
+  /** Keys that DID resolve but are `is_secret` — never substituted into content; the caller must fail the device rather than ship the token or the value. */
+  secretsReferenced: string[];
+}
+
+/**
+ * Substitute every `{{var.<key>}}` token in `content` using `resolved`
+ * (typically `resolveForOrg`'s return value).
+ *
+ * A secret variable's value is NEVER placed in the returned content — PR 2
+ * has no out-of-band delivery channel for secrets (that is PR 4's
+ * `BREEZE_VAR_*` / `secretEnv` work), and textual substitution of a secret is
+ * the exact leak class that channel exists to avoid. Instead the key is
+ * recorded in `secretsReferenced` and its token is left untouched, exactly
+ * like a genuinely-missing key — but reported under a different bucket so the
+ * caller (and `describeVariableFailure`) can tell a caller "that variable is
+ * secret" apart from "that variable doesn't exist".
+ */
+export function substituteTenantVariables(
+  content: string,
+  resolved: Map<string, ResolvedVariable>
+): SubstitutionOutcome {
+  const secretsReferenced = new Set<string>();
+
+  const { content: substitutedContent, unresolved } = replaceVariableTokens(content, (key) => {
+    const variable = resolved.get(key);
+    if (!variable) return undefined; // genuinely unknown/missing
+    if (variable.isSecret) {
+      secretsReferenced.add(key);
+      return undefined; // never place a secret's value in the output
+    }
+    return variable.value;
+  });
+
+  return {
+    content: substitutedContent,
+    // replaceVariableTokens has no notion of "secret" — it saw an undefined
+    // lookup either way and reported every such key as unresolved. Strip the
+    // secret keys back out so a secret is reported in exactly one bucket.
+    unresolved: unresolved.filter((key) => !secretsReferenced.has(key)),
+    secretsReferenced: [...secretsReferenced]
+  };
+}
+
+/**
+ * Human-readable, user-facing failure summary for a `SubstitutionOutcome`, or
+ * null when nothing is wrong. Names only KEYS — never a value, secret or
+ * otherwise — since this string is surfaced as the per-device failure message
+ * (`script_executions.errorMessage`, visible in the UI).
+ */
+export function describeVariableFailure(outcome: SubstitutionOutcome): string | null {
+  const parts: string[] = [];
+  if (outcome.unresolved.length > 0) {
+    parts.push(`no value set for ${outcome.unresolved.map((key) => `{{var.${key}}}`).join(', ')}`);
+  }
+  if (outcome.secretsReferenced.length > 0) {
+    parts.push(
+      `${outcome.secretsReferenced.map((key) => `{{var.${key}}}`).join(', ')} ${
+        outcome.secretsReferenced.length === 1 ? 'is a secret variable' : 'are secret variables'
+      } and cannot be used in script content`
+    );
+  }
+  if (parts.length === 0) return null;
+  return `Unresolved tenant variable(s): ${parts.join('; ')}`;
+}

--- a/apps/web/src/components/scripts/ScriptForm.test.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, act } from '@testing-library/react';
+import { render, waitFor, act, fireEvent, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@/lib/i18n';
 // Raw source of the component under test, for the build-mechanism guard below.
@@ -50,6 +50,16 @@ vi.mock('@/lib/authScope', async () => {
 vi.mock('@/stores/orgStore', async () => {
   const actual = await vi.importActual<typeof import('@/stores/orgStore')>('@/stores/orgStore');
   return { ...actual, useOrgStore: orgStoreMock };
+});
+
+// The variable picker fetches GET /tenant-variables on mount (#3409 PR2).
+// Stub the transport — the real store is kept so `useAuthStore.setState` below
+// still drives the same module instance the component reads.
+const { fetchWithAuthMock } = vi.hoisted(() => ({ fetchWithAuthMock: vi.fn() }));
+
+vi.mock('@/stores/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/stores/auth')>('@/stores/auth');
+  return { ...actual, fetchWithAuth: fetchWithAuthMock };
 });
 
 import ScriptForm from './ScriptForm';
@@ -281,5 +291,73 @@ describe('ScriptForm availability picker — partner-wide capability gate (#3262
     );
     await findByText('Available to');
     expect(await findByText(/Editing it requires full partner org access/)).toBeTruthy();
+  });
+});
+
+// #3409 PR2: a `{{var.<key>}}` token the tenant has no variable for fails the
+// device at dispatch, so the editor says so — but a key can legitimately be
+// created after the script, so this must never gate the save.
+describe('ScriptForm unknown-variable notice', () => {
+  const tenantVariable = {
+    id: 'tv-1',
+    key: 'vendor_token',
+    value: 'abc',
+    isSecret: false,
+    description: 'Vendor portal token',
+    ownerScope: 'partner' as const,
+    orgId: null,
+    partnerId: 'p-1',
+    version: 1,
+    createdAt: '2026-08-11T00:00:00.000Z',
+    updatedAt: '2026-08-11T00:00:00.000Z',
+  };
+
+  const draft = { name: 'Draft', category: 'Custom', language: 'powershell' as const };
+
+  beforeEach(() => {
+    editorInstances.length = 0;
+    getJwtClaimsMock.mockReturnValue({ scope: 'organization', partnerId: null, orgId: 'o-1' });
+    orgStoreMock.mockReturnValue({ organizations: [], partners: [], sites: [] });
+    fetchWithAuthMock.mockResolvedValue(
+      new Response(JSON.stringify({ data: [tenantVariable] }), { status: 200 })
+    );
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('warns — without blocking submit — when the content references an unknown key', async () => {
+    const onSubmit = vi.fn();
+    render(
+      <ScriptForm isNew onSubmit={onSubmit} defaultValues={{ ...draft, content: 'echo {{var.ghost}}' }} />
+    );
+
+    const notice = await screen.findByTestId('script-variable-warning');
+    expect(notice).toHaveTextContent(/ghost/);
+
+    fireEvent.click(screen.getByRole('button', { name: /save script/i }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not warn on ${{var.x}} or on a {{org.name}} token from another namespace', async () => {
+    render(
+      <ScriptForm
+        isNew
+        defaultValues={{ ...draft, content: '${{var.ghost}} and {{org.name}} and {{var.vendor_token}}' }}
+      />
+    );
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(screen.queryByTestId('script-variable-warning')).toBeNull();
+  });
+
+  it('stays silent when the variable list could not be loaded', async () => {
+    fetchWithAuthMock.mockRejectedValue(new Error('offline'));
+    render(<ScriptForm isNew defaultValues={{ ...draft, content: 'echo {{var.ghost}}' }} />);
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalled());
+    await waitFor(() => expect(editorInstances.length).toBeGreaterThan(0));
+    expect(screen.queryByTestId('script-variable-warning')).toBeNull();
   });
 });

--- a/apps/web/src/components/scripts/ScriptForm.tsx
+++ b/apps/web/src/components/scripts/ScriptForm.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useRef, useCallback, type ComponentType }
 import { useForm, useFieldArray, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Plus, Trash2, Sparkles } from 'lucide-react';
+import { Plus, Trash2, Sparkles, AlertTriangle } from 'lucide-react';
 import type { EditorProps } from '@monaco-editor/react';
 
 // Statically import Monaco's editor stylesheet so Astro bundles it into the
@@ -20,6 +20,8 @@ import 'monaco-editor/min/vs/editor/editor.main.css';
 
 import ScriptAiPanel from './ScriptAiPanel';
 import CollapsibleSection from './CollapsibleSection';
+import ScriptVariablePicker from './ScriptVariablePicker';
+import { findUnknownVariableKeys, useTenantVariables } from '@/lib/tenantVariableTokens';
 import { cn } from '@/lib/utils';
 import { configureMonacoLoader } from '@/lib/monacoLoader';
 import { useScriptAiStore } from '@/stores/scriptAiStore';
@@ -266,6 +268,27 @@ export default function ScriptForm({
   const watchOsTypes = watch('osTypes');
   const watchParameters = watch('parameters');
   const watchAvailability = watch('availability');
+  const watchContent = watch('content');
+
+  // Tenant variables (#3409). The unknown-key notice is derived from the
+  // watched content and rendered beside the content error — deliberately NOT
+  // part of `scriptSchema`/zodResolver, which would block the save: a key may
+  // legitimately be created after the script that references it, and dispatch
+  // already fails those devices loudly.
+  const tenantVariables = useTenantVariables();
+  const knownVariableKeys = useMemo(
+    () => new Set(tenantVariables.map(v => v.key)),
+    [tenantVariables]
+  );
+  const unknownVariableKeys = useMemo(
+    () =>
+      findUnknownVariableKeys(watchContent ?? '', knownVariableKeys, {
+        // An empty set means the list hasn't arrived (or the fetch failed) —
+        // never "every token is unknown".
+        requireKnownKeys: knownVariableKeys.size > 0,
+      }),
+    [watchContent, knownVariableKeys]
+  );
 
   // Partner-scope detection comes from the JWT scope claim — NOT
   // `useOrgStore().partners`, which is populated only from the system-scope-only
@@ -495,20 +518,31 @@ export default function ScriptForm({
       <div className="space-y-3">
         <div className="flex items-center justify-between">
           <h3 className="text-base font-bold tracking-tight">{t('scriptForm.sections.content')}</h3>
-          <button
-            type="button"
-            onClick={togglePanel}
-            className={cn(
-              'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition',
-              panelOpen
-                ? 'bg-primary text-primary-foreground'
-                : 'border hover:bg-muted'
-            )}
-            title={t('scriptForm.ai.toggleTitle')}
-          >
-            <Sparkles className="h-3.5 w-3.5" />
-            {t('scriptForm.ai.button')}
-          </button>
+          <div className="flex items-center gap-2">
+            <ScriptVariablePicker
+              variables={tenantVariables}
+              editorRef={editorInstanceRef}
+              content={watchContent ?? ''}
+              // Content lives in react-hook-form, not component state — write it
+              // back the same way ScriptFormBridge does so the AI panel and the
+              // picker can't fight over it.
+              onInsert={next => setValue('content', next, { shouldDirty: true })}
+            />
+            <button
+              type="button"
+              onClick={togglePanel}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition',
+                panelOpen
+                  ? 'bg-primary text-primary-foreground'
+                  : 'border hover:bg-muted'
+              )}
+              title={t('scriptForm.ai.toggleTitle')}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              {t('scriptForm.ai.button')}
+            </button>
+          </div>
         </div>
         <div className="flex rounded-md border">
           <div className="min-w-0 flex-1">
@@ -564,6 +598,17 @@ export default function ScriptForm({
           {panelOpen && <ScriptAiPanel bridge={bridge} />}
         </div>
         {errors.content && <p className="text-sm text-destructive">{errors.content.message}</p>}
+        {unknownVariableKeys.length > 0 && (
+          <p
+            data-testid="script-variable-warning"
+            className="flex items-start gap-1.5 text-sm text-amber-600 dark:text-amber-500"
+          >
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              {t('scriptForm.variables.unknown', { keys: unknownVariableKeys.join(', ') })}
+            </span>
+          </p>
+        )}
       </div>
 
       {/* Parameters */}

--- a/apps/web/src/components/scripts/ScriptVariablePicker.test.tsx
+++ b/apps/web/src/components/scripts/ScriptVariablePicker.test.tsx
@@ -1,0 +1,116 @@
+import { createRef } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@/lib/i18n';
+import ScriptVariablePicker, { type ScriptEditorInstance } from './ScriptVariablePicker';
+
+type FakeEditor = {
+  executeEdits: ReturnType<typeof vi.fn>;
+  getSelection: ReturnType<typeof vi.fn>;
+  getModel: ReturnType<typeof vi.fn>;
+  pushUndoStop: ReturnType<typeof vi.fn>;
+  focus: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * A stand-in for the live Monaco instance ScriptForm holds in `editorInstanceRef`.
+ * Only the four members the picker touches are implemented; the cast keeps the
+ * prop typed against the real `onMount` editor rather than a loosened interface.
+ */
+function fakeEditor(value: string, selection = { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 }): FakeEditor {
+  let text = value;
+  return {
+    executeEdits: vi.fn((_source: string, edits: Array<{ text: string }>) => {
+      text = `${text}${edits[0]?.text ?? ''}`;
+      return true;
+    }),
+    getSelection: vi.fn(() => selection),
+    getModel: vi.fn(() => ({ getValue: () => text })),
+    pushUndoStop: vi.fn(),
+    focus: vi.fn(),
+  };
+}
+
+const variables = [
+  { key: 'vendor_token', description: 'Vendor portal token', isSecret: false },
+  { key: 'api_password', description: 'Vendor API password', isSecret: true },
+];
+
+function renderPicker(editor: FakeEditor | null, onInsert = vi.fn(), content = 'Write-Host') {
+  const ref = createRef<ScriptEditorInstance | null>() as { current: ScriptEditorInstance | null };
+  ref.current = editor as unknown as ScriptEditorInstance | null;
+  render(
+    <ScriptVariablePicker
+      variables={variables}
+      editorRef={ref}
+      content={content}
+      onInsert={onInsert}
+    />,
+  );
+  return { onInsert };
+}
+
+const openMenu = () => fireEvent.click(screen.getByRole('button', { name: /variables/i }));
+
+describe('ScriptVariablePicker', () => {
+  it('inserts {{var.key}} into Monaco at the current selection', () => {
+    const editor = fakeEditor('Write-Host', {
+      startLineNumber: 3,
+      startColumn: 5,
+      endLineNumber: 3,
+      endColumn: 9,
+    });
+    const { onInsert } = renderPicker(editor);
+
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: /Vendor portal token/i }));
+
+    expect(editor.executeEdits).toHaveBeenCalledTimes(1);
+    const [, edits] = editor.executeEdits.mock.calls[0] as [string, Array<{ range: unknown; text: string }>];
+    expect(edits[0].text).toBe('{{var.vendor_token}}');
+    // Caret-accurate: the edit targets the live selection, replacing it.
+    expect(edits[0].range).toMatchObject({
+      startLineNumber: 3,
+      startColumn: 5,
+      endLineNumber: 3,
+      endColumn: 9,
+    });
+    // The form — not the editor — owns the value, so the post-edit model text
+    // is handed back for a react-hook-form setValue.
+    expect(onInsert).toHaveBeenCalledWith('Write-Host{{var.vendor_token}}');
+    expect(editor.focus).toHaveBeenCalled();
+  });
+
+  it('marks a secret variable as unusable with a reason', () => {
+    const editor = fakeEditor('Write-Host');
+    const { onInsert } = renderPicker(editor);
+
+    openMenu();
+    const secret = screen.getByRole('menuitem', { name: /Vendor API password/i });
+    expect(secret).toBeDisabled();
+    expect(secret).toHaveTextContent(/environment variable/i);
+
+    fireEvent.click(secret);
+    expect(editor.executeEdits).not.toHaveBeenCalled();
+    expect(onInsert).not.toHaveBeenCalled();
+  });
+
+  it('appends to the end of the content when the editor has not mounted', () => {
+    const { onInsert } = renderPicker(null, vi.fn(), 'Write-Host');
+
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: /Vendor portal token/i }));
+
+    expect(onInsert).toHaveBeenCalledWith('Write-Host{{var.vendor_token}}');
+  });
+
+  it('shows an empty state instead of an empty menu when no variables exist', () => {
+    const ref = { current: null };
+    render(
+      <ScriptVariablePicker variables={[]} editorRef={ref} content="" onInsert={vi.fn()} />,
+    );
+    openMenu();
+    expect(screen.queryAllByRole('menuitem')).toHaveLength(0);
+    expect(screen.getByText(/no variables/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/scripts/ScriptVariablePicker.tsx
+++ b/apps/web/src/components/scripts/ScriptVariablePicker.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState, type RefObject } from 'react';
+import { Braces } from 'lucide-react';
+import type { EditorProps } from '@monaco-editor/react';
+import { variableToken } from '@breeze/shared';
+import { useTranslation } from 'react-i18next';
+import type { TenantVariableEntry } from '@/lib/tenantVariableTokens';
+
+/** The live editor handed to `onMount` — the same type ScriptForm's ref holds. */
+export type ScriptEditorInstance = Parameters<NonNullable<EditorProps['onMount']>>[0];
+
+export interface ScriptVariablePickerProps {
+  /** Offerable variables; secrets render disabled (PR 4 delivers them out-of-band). */
+  variables: TenantVariableEntry[];
+  /** Live Monaco instance — null before mount and after a loader failure. */
+  editorRef: RefObject<ScriptEditorInstance | null>;
+  /** Current script content; the insertion target when Monaco is absent. */
+  content: string;
+  /**
+   * Receives the FULL post-insert content. The form owns the value (it lives in
+   * react-hook-form, not component state), so the picker never writes it
+   * directly — otherwise the AI panel and the picker would fight over it.
+   */
+  onInsert: (nextContent: string) => void;
+}
+
+/**
+ * "Variables" menu for the script editor: inserts a `{{var.<key>}}` token at
+ * the caret.
+ *
+ * Insertion goes through `executeEdits` at the live selection rather than
+ * string-slicing the content, so it lands where the cursor is (and replaces a
+ * selection) inside a Monaco model — `VariableInput`'s `setSelectionRange`
+ * approach is `<input>`-only and has no equivalent here.
+ */
+export default function ScriptVariablePicker({
+  variables,
+  editorRef,
+  content,
+  onInsert,
+}: ScriptVariablePickerProps) {
+  const { t } = useTranslation('scripts');
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (e: PointerEvent) => {
+      if (
+        !menuRef.current?.contains(e.target as Node) &&
+        !triggerRef.current?.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    document.addEventListener('pointerdown', onPointer, true);
+    document.addEventListener('keydown', onKey, true);
+    return () => {
+      document.removeEventListener('pointerdown', onPointer, true);
+      document.removeEventListener('keydown', onKey, true);
+    };
+  }, [open]);
+
+  const insert = (key: string) => {
+    const token = variableToken(key);
+    setOpen(false);
+    const editor = editorRef.current;
+    if (!editor) {
+      // Monaco hasn't mounted (or failed to load) — append rather than drop the
+      // click on the floor.
+      onInsert(content + token);
+      return;
+    }
+    const selection = editor.getSelection();
+    const range = selection ?? {
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: 1,
+      endColumn: 1,
+    };
+    // Undo stops around the edit so Ctrl+Z removes the whole token, not the
+    // characters Monaco would otherwise merge into the surrounding typing.
+    editor.pushUndoStop();
+    editor.executeEdits('breeze-variable-picker', [
+      { range, text: token, forceMoveMarkers: true },
+    ]);
+    editor.pushUndoStop();
+    const next = editor.getModel()?.getValue();
+    if (next !== undefined) onInsert(next);
+    editor.focus();
+  };
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={t('scriptForm.variables.insertTitle')}
+        className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition hover:bg-muted"
+      >
+        <Braces className="h-3.5 w-3.5" />
+        {t('scriptForm.variables.button')}
+      </button>
+
+      {open && (
+        <div
+          ref={menuRef}
+          role="menu"
+          className="absolute right-0 z-50 mt-1 max-h-72 w-72 overflow-y-auto rounded-md border bg-card p-1 shadow-lg"
+        >
+          {variables.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {t('scriptForm.variables.empty')}
+            </p>
+          ) : (
+            variables.map(v => (
+              <button
+                key={v.key}
+                type="button"
+                role="menuitem"
+                disabled={v.isSecret}
+                aria-disabled={v.isSecret || undefined}
+                onClick={() => insert(v.key)}
+                className="w-full rounded px-2 py-1.5 text-left hover:bg-muted focus:bg-muted focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent"
+              >
+                <span className="block truncate text-sm text-foreground">
+                  {v.description || v.key}
+                </span>
+                <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                  {variableToken(v.key)}
+                </span>
+                {v.isSecret && (
+                  <span className="mt-0.5 block text-[11px] text-amber-600 dark:text-amber-500">
+                    {t('scriptForm.variables.secretUnavailable')}
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/software/AddPackageModal.tsx
+++ b/apps/web/src/components/software/AddPackageModal.tsx
@@ -17,6 +17,7 @@ import { findUnknownTokens } from "@/lib/installerVariables";
 import { uploadPackageVersion } from "../../lib/softwarePackageUpload";
 import DetectionRulesEditor from "./DetectionRulesEditor";
 import VariableInput, { type DeviceCustomField } from "./VariableInput";
+import { useTenantVariables } from "@/lib/tenantVariableTokens";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
 type Architecture = "x64" | "arm64" | "x86";
@@ -90,6 +91,8 @@ export default function AddPackageModal({
   const [saving, setSaving] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [customFields, setCustomFields] = useState<DeviceCustomField[]>([]);
+  // Tenant variables (#3409) — offered as `{{var.<key>}}` in the same picker.
+  const tenantVariables = useTenantVariables(open);
   const fileInputRef = useRef<HTMLInputElement>(null);
   // If the catalog item was created but the version write failed, keep its id so
   // a retry continues from the version step instead of creating a duplicate.
@@ -174,8 +177,16 @@ export default function AddPackageModal({
     () => new Set(customFields.map((f) => f.fieldKey)),
     [customFields],
   );
+  const knownVariableKeys = useMemo(
+    () => new Set(tenantVariables.map((v) => v.key)),
+    [tenantVariables],
+  );
   const tokenErrors = useMemo(() => {
-    const opts = { requireKnownCustomKeys: knownKeys.size > 0 };
+    const opts = {
+      requireKnownCustomKeys: knownKeys.size > 0,
+      variableKeys: knownVariableKeys,
+      requireKnownVariableKeys: knownVariableKeys.size > 0,
+    };
     return [
       form.downloadUrl,
       form.silentInstallArgs,
@@ -186,6 +197,7 @@ export default function AddPackageModal({
     form.silentInstallArgs,
     form.silentUninstallArgs,
     knownKeys,
+    knownVariableKeys,
   ]);
   const hasSource =
     form.source === "url" ? form.downloadUrl.trim() !== "" : form.file != null;
@@ -591,6 +603,7 @@ export default function AddPackageModal({
                       "policies:software.addPackageModal.httpsExampleComPackageV100",
                     )}
                     customFields={customFields}
+                    tenantVariables={tenantVariables}
                   />
                   <p className="mt-1 text-xs text-muted-foreground">
                     {i18n.t(
@@ -674,6 +687,7 @@ export default function AddPackageModal({
                     "policies:software.addPackageModal.eGMsiexecIFileQnNorestart",
                   )}
                   customFields={customFields}
+                  tenantVariables={tenantVariables}
                 />
               </div>
             </div>
@@ -713,6 +727,7 @@ export default function AddPackageModal({
                         "policies:software.addPackageModal.eGMsiexecXFileQnNorestart",
                       )}
                       customFields={customFields}
+                      tenantVariables={tenantVariables}
                     />
                   </div>
                 </div>

--- a/apps/web/src/components/software/SoftwareVersionManager.tsx
+++ b/apps/web/src/components/software/SoftwareVersionManager.tsx
@@ -17,6 +17,7 @@ import { findUnknownTokens } from "@/lib/installerVariables";
 import { uploadPackageVersion } from "../../lib/softwarePackageUpload";
 import DetectionRulesEditor from "./DetectionRulesEditor";
 import VariableInput, { type DeviceCustomField } from "./VariableInput";
+import { useTenantVariables } from "@/lib/tenantVariableTokens";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
 type Architecture = "x64" | "arm64" | "x86";
@@ -107,6 +108,8 @@ export default function SoftwareVersionManager({
   const [uploadProgress, setUploadProgress] = useState(0);
   const [catalogId, setCatalogId] = useState(propCatalogId ?? "");
   const [customFields, setCustomFields] = useState<DeviceCustomField[]>([]);
+  // Tenant variables (#3409) — offered as `{{var.<key>}}` in the same picker.
+  const tenantVariables = useTenantVariables();
   const fileInputRef = useRef<HTMLInputElement>(null);
   // Owns the in-flight chunked upload so Cancel (and unmount) can actually stop
   // it. A ref, not state: it must survive re-renders without causing one, and
@@ -213,8 +216,16 @@ export default function SoftwareVersionManager({
     () => new Set(customFields.map((f) => f.fieldKey)),
     [customFields],
   );
+  const knownVariableKeys = useMemo(
+    () => new Set(tenantVariables.map((v) => v.key)),
+    [tenantVariables],
+  );
   const tokenErrors = useMemo(() => {
-    const opts = { requireKnownCustomKeys: knownCustomKeys.size > 0 };
+    const opts = {
+      requireKnownCustomKeys: knownCustomKeys.size > 0,
+      variableKeys: knownVariableKeys,
+      requireKnownVariableKeys: knownVariableKeys.size > 0,
+    };
     return [
       formState.downloadUrl,
       formState.silentInstallArgs,
@@ -225,6 +236,7 @@ export default function SoftwareVersionManager({
     formState.silentInstallArgs,
     formState.silentUninstallArgs,
     knownCustomKeys,
+    knownVariableKeys,
   ]);
   const latestVersion = useMemo(
     () => versions.find((item) => item.id === latestId) ?? versions[0],
@@ -584,6 +596,7 @@ export default function SoftwareVersionManager({
                   "policies:software.softwareVersionManager.httpsExampleComPackageV100",
                 )}
                 customFields={customFields}
+                tenantVariables={tenantVariables}
               />
             </div>
             <p className="mt-1 text-xs text-muted-foreground">
@@ -682,6 +695,7 @@ export default function SoftwareVersionManager({
                     "policies:software.softwareVersionManager.eGMsiexecIFileQnNorestart",
                   )}
                   customFields={customFields}
+                  tenantVariables={tenantVariables}
                 />
               </div>
             </div>
@@ -704,6 +718,7 @@ export default function SoftwareVersionManager({
                     "policies:software.softwareVersionManager.eGMsiexecXFileQnNorestart",
                   )}
                   customFields={customFields}
+                  tenantVariables={tenantVariables}
                 />
               </div>
             </div>

--- a/apps/web/src/components/software/VariableInput.test.tsx
+++ b/apps/web/src/components/software/VariableInput.test.tsx
@@ -2,18 +2,27 @@ import { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import VariableInput, { type DeviceCustomField } from './VariableInput';
+import type { TenantVariableEntry } from '@/lib/tenantVariableTokens';
 
 function Harness({
   initial = '',
   customFields = [],
+  tenantVariables = [],
 }: {
   initial?: string;
   customFields?: DeviceCustomField[];
+  tenantVariables?: TenantVariableEntry[];
 }) {
   const [value, setValue] = useState(initial);
   return (
     <div>
-      <VariableInput value={value} onChange={setValue} customFields={customFields} placeholder="url" />
+      <VariableInput
+        value={value}
+        onChange={setValue}
+        customFields={customFields}
+        tenantVariables={tenantVariables}
+        placeholder="url"
+      />
       <span data-testid="value">{value}</span>
     </div>
   );
@@ -59,6 +68,55 @@ describe('VariableInput', () => {
 
   it('does not warn on a clean built-in token', () => {
     render(<Harness initial="https://dl/{{org.id}}/app.msi" />);
+    expect(screen.queryByText(/Unknown variable/i)).not.toBeInTheDocument();
+  });
+});
+
+// #3409 PR2 — tenant variables are dynamic like custom fields, offered under
+// their own group and inserted as `{{var.<key>}}`.
+describe('VariableInput tenant variables', () => {
+  const tenantVariables: TenantVariableEntry[] = [
+    { key: 'vendor_token', description: 'Vendor portal token', isSecret: false },
+    { key: 'api_password', description: 'Vendor API password', isSecret: true },
+  ];
+
+  it('renders tenant variables under their own group and inserts at the caret', () => {
+    render(<Harness initial="AB" tenantVariables={tenantVariables} />);
+    const input = screen.getByPlaceholderText('url') as HTMLInputElement;
+    input.setSelectionRange(1, 1);
+
+    openMenu();
+    expect(screen.getByText('Variables')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('menuitem', { name: /Vendor portal token/i }));
+
+    expect(screen.getByTestId('value')).toHaveTextContent('A{{var.vendor_token}}B');
+  });
+
+  // PR 2 rejects a secret token at save time (there is no delivery channel for
+  // it until PR 4), so the picker must not be able to write one.
+  it('offers a secret variable as disabled with a reason instead of insertable', () => {
+    render(<Harness tenantVariables={tenantVariables} />);
+    openMenu();
+    const secret = screen.getByRole('menuitem', { name: /Vendor API password/i });
+    expect(secret).toBeDisabled();
+    expect(secret).toHaveTextContent(/environment variable/i);
+
+    fireEvent.click(secret);
+    expect(screen.getByTestId('value')).toHaveTextContent('');
+  });
+
+  it('does not flag a known variable token', () => {
+    render(<Harness initial="https://dl/{{var.vendor_token}}/app.msi" tenantVariables={tenantVariables} />);
+    expect(screen.queryByText(/Unknown variable/i)).not.toBeInTheDocument();
+  });
+
+  it('flags a variable key that does not exist once the list has loaded', () => {
+    render(<Harness initial="https://dl/{{var.ghost}}/app.msi" tenantVariables={tenantVariables} />);
+    expect(screen.getByText(/Unknown variable/i)).toBeInTheDocument();
+  });
+
+  it('accepts a variable token on structure alone before the list loads', () => {
+    render(<Harness initial="https://dl/{{var.ghost}}/app.msi" />);
     expect(screen.queryByText(/Unknown variable/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/software/VariableInput.test.tsx
+++ b/apps/web/src/components/software/VariableInput.test.tsx
@@ -119,4 +119,34 @@ describe('VariableInput tenant variables', () => {
     render(<Harness initial="https://dl/{{var.ghost}}/app.msi" />);
     expect(screen.queryByText(/Unknown variable/i)).not.toBeInTheDocument();
   });
+
+  // The picker disables secret rows, but the key IS known, so a hand-typed
+  // secret token used to validate clean here and then fail the deploy on every
+  // device (softwareDeployment.ts omits secrets from the substitution map).
+  it('flags a hand-typed secret token as secret, not as unknown', () => {
+    render(
+      <Harness initial="https://dl/{{var.api_password}}/app.msi" tenantVariables={tenantVariables} />,
+    );
+    // The warning names the offending token, so a template with several
+    // variables tells the user which one to remove.
+    expect(screen.getByText(/environment variable/i)).toHaveTextContent(
+      '{{var.api_password}}',
+    );
+    expect(screen.queryByText(/Unknown variable/i)).not.toBeInTheDocument();
+  });
+
+  it('marks the field invalid when a secret token is present', () => {
+    render(
+      <Harness initial="https://dl/{{var.api_password}}/app.msi" tenantVariables={tenantVariables} />,
+    );
+    expect(screen.getByPlaceholderText('url')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not flag a non-secret token as secret', () => {
+    render(
+      <Harness initial="https://dl/{{var.vendor_token}}/app.msi" tenantVariables={tenantVariables} />,
+    );
+    expect(screen.queryByText(/environment variable/i)).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('url')).not.toHaveAttribute('aria-invalid');
+  });
 });

--- a/apps/web/src/components/software/VariableInput.tsx
+++ b/apps/web/src/components/software/VariableInput.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/lib/installerVariables";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
-import { variableToken } from "@breeze/shared";
+import { findVariableTokens, variableToken } from "@breeze/shared";
 import type { TenantVariableEntry } from "@/lib/tenantVariableTokens";
 export interface DeviceCustomField {
   fieldKey: string;
@@ -80,6 +80,9 @@ export default function VariableInput({
     width: number;
   }>();
   const warnId = useId();
+  // Its own id so a template carrying BOTH an unknown token and a secret one
+  // announces both — a single shared id would drop whichever paragraph lost.
+  const secretWarnId = useId();
   const knownKeys = useMemo(
     () => new Set(customFields.map((f) => f.fieldKey)),
     [customFields],
@@ -87,6 +90,24 @@ export default function VariableInput({
   const knownVariableKeys = useMemo(
     () => new Set(tenantVariables.map((v) => v.key)),
     [tenantVariables],
+  );
+  // The picker disables secret rows, but nothing stopped a secret token being
+  // typed by hand — it passed validation here (the key IS known) and then
+  // failed the deploy on every device, because softwareDeployment.ts omits
+  // secrets from the substitution map entirely. Flagged separately from
+  // `unknownTokens` so the message can say "secret" rather than "unknown".
+  // findVariableTokens carries the `(?<!\$)` lookbehind, so a `${{var.x}}`
+  // is not reported here — findUnknownTokens flags that one as unknown.
+  const secretVariableKeys = useMemo(
+    () => new Set(tenantVariables.filter((v) => v.isSecret).map((v) => v.key)),
+    [tenantVariables],
+  );
+  const secretTokens = useMemo(
+    () =>
+      findVariableTokens(value)
+        .filter((key) => secretVariableKeys.has(key))
+        .map(variableToken),
+    [value, secretVariableKeys],
   );
   const variables = useMemo<VariableMenuEntry[]>(() => {
     const custom: VariableMenuEntry[] = customFields.map((f) => ({
@@ -130,6 +151,7 @@ export default function VariableInput({
       }),
     [value, knownKeys, knownVariableKeys],
   );
+  const hasTokenWarning = unknownTokens.length > 0 || secretTokens.length > 0;
   const positionMenu = () => {
     const rect = triggerRef.current?.getBoundingClientRect();
     if (!rect) return;
@@ -197,13 +219,17 @@ export default function VariableInput({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          aria-invalid={unknownTokens.length > 0 || undefined}
+          aria-invalid={hasTokenWarning || undefined}
           aria-describedby={
-            cn(ariaDescribedBy, unknownTokens.length > 0 && warnId) || undefined
+            cn(
+              ariaDescribedBy,
+              secretTokens.length > 0 && secretWarnId,
+              unknownTokens.length > 0 && warnId,
+            ) || undefined
           }
           className={cn(
             "h-10 min-w-0 flex-1 rounded-md border bg-background px-3 text-sm focus:outline-hidden focus:ring-2 focus:ring-ring",
-            unknownTokens.length > 0 &&
+            hasTokenWarning &&
               "border-destructive/60 focus:ring-destructive/40",
             className,
           )}
@@ -225,6 +251,20 @@ export default function VariableInput({
           </span>
         </button>
       </div>
+
+      {secretTokens.length > 0 && (
+        <p
+          id={secretWarnId}
+          className="mt-1 flex items-start gap-1.5 text-xs text-destructive"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            {secretTokens.join(", ")}
+            {": "}
+            {i18n.t("policies:software.variableInput.secretUnavailable")}
+          </span>
+        </p>
+      )}
 
       {unknownTokens.length > 0 && (
         <p

--- a/apps/web/src/components/software/VariableInput.tsx
+++ b/apps/web/src/components/software/VariableInput.tsx
@@ -18,6 +18,8 @@ import {
 } from "@/lib/installerVariables";
 import { useTranslation } from "react-i18next";
 import { i18n } from "@/lib/i18n";
+import { variableToken } from "@breeze/shared";
+import type { TenantVariableEntry } from "@/lib/tenantVariableTokens";
 export interface DeviceCustomField {
   fieldKey: string;
   name: string;
@@ -28,16 +30,28 @@ interface VariableInputProps {
   placeholder?: string;
   /** Device custom-field definitions, offered under "Custom fields" in the menu. */
   customFields?: DeviceCustomField[];
+  /** Tenant variables (#3409), offered under "Variables" as `{{var.<key>}}`. */
+  tenantVariables?: TenantVariableEntry[];
   /** Applied as the input's `id` so a parent `<label htmlFor>` can associate a visible label. */
   id?: string;
   "aria-describedby"?: string;
   className?: string;
 }
+/**
+ * A menu row. `disabled` covers secret tenant variables: PR 2 has no channel to
+ * deliver a secret value, so it rejects a secret token at save time — the
+ * picker must not be able to write one.
+ */
+type VariableMenuEntry = InstallerVariable & {
+  disabled?: boolean;
+  hint?: string;
+};
 const GROUP_ORDER: InstallerVariableGroup[] = [
   "Organization",
   "Site",
   "Device",
   "Custom fields",
+  "Variables",
 ];
 /**
  * A single-line text input for installer URLs / silent args that accepts
@@ -50,6 +64,7 @@ export default function VariableInput({
   onChange,
   placeholder,
   customFields = [],
+  tenantVariables = [],
   id,
   className,
   "aria-describedby": ariaDescribedBy,
@@ -69,17 +84,31 @@ export default function VariableInput({
     () => new Set(customFields.map((f) => f.fieldKey)),
     [customFields],
   );
-  const variables = useMemo<InstallerVariable[]>(() => {
-    const custom: InstallerVariable[] = customFields.map((f) => ({
+  const knownVariableKeys = useMemo(
+    () => new Set(tenantVariables.map((v) => v.key)),
+    [tenantVariables],
+  );
+  const variables = useMemo<VariableMenuEntry[]>(() => {
+    const custom: VariableMenuEntry[] = customFields.map((f) => ({
       token: customFieldToken(f.fieldKey),
       label: f.name || f.fieldKey,
       group: "Custom fields",
       example: f.fieldKey,
     }));
-    return [...BUILTIN_INSTALLER_VARIABLES, ...custom];
-  }, [customFields]);
+    const tenant: VariableMenuEntry[] = tenantVariables.map((v) => ({
+      token: variableToken(v.key),
+      label: v.description || v.key,
+      group: "Variables",
+      example: v.key,
+      disabled: v.isSecret,
+      hint: v.isSecret
+        ? i18n.t("policies:software.variableInput.secretUnavailable")
+        : undefined,
+    }));
+    return [...BUILTIN_INSTALLER_VARIABLES, ...custom, ...tenant];
+  }, [customFields, tenantVariables]);
   const grouped = useMemo(() => {
-    const map = new Map<InstallerVariableGroup, InstallerVariable[]>();
+    const map = new Map<InstallerVariableGroup, VariableMenuEntry[]>();
     for (const v of variables) {
       const list = map.get(v.group) ?? [];
       list.push(v);
@@ -89,14 +118,17 @@ export default function VariableInput({
       ([, l]) => l.length > 0,
     );
   }, [variables]);
-  // Custom-field keys load async; until they arrive, accept custom-field tokens
-  // on structure alone so a slow fetch never flags a valid `{{device.customField.x}}`.
+  // Custom-field keys and tenant-variable keys both load async; until they
+  // arrive, accept those tokens on structure alone so a slow (or failed) fetch
+  // never flags a valid `{{device.customField.x}}` / `{{var.x}}`.
   const unknownTokens = useMemo(
     () =>
       findUnknownTokens(value, knownKeys, {
         requireKnownCustomKeys: knownKeys.size > 0,
+        variableKeys: knownVariableKeys,
+        requireKnownVariableKeys: knownVariableKeys.size > 0,
       }),
-    [value, knownKeys],
+    [value, knownKeys, knownVariableKeys],
   );
   const positionMenu = () => {
     const rect = triggerRef.current?.getBoundingClientRect();
@@ -230,8 +262,10 @@ export default function VariableInput({
                     key={v.token}
                     type="button"
                     role="menuitem"
+                    disabled={v.disabled}
+                    aria-disabled={v.disabled || undefined}
                     onClick={() => insert(v.token)}
-                    className="flex w-full items-baseline justify-between gap-3 rounded px-2 py-1.5 text-left hover:bg-muted focus:bg-muted focus:outline-hidden"
+                    className="flex w-full items-baseline justify-between gap-3 rounded px-2 py-1.5 text-left hover:bg-muted focus:bg-muted focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:bg-transparent"
                   >
                     <span className="min-w-0">
                       <span className="block truncate text-sm text-foreground">
@@ -240,6 +274,11 @@ export default function VariableInput({
                       <span className="block truncate font-mono text-[11px] text-muted-foreground">
                         {v.token}
                       </span>
+                      {v.hint && (
+                        <span className="mt-0.5 block text-[11px] text-amber-600 dark:text-amber-500">
+                          {v.hint}
+                        </span>
+                      )}
                     </span>
                   </button>
                 ))}

--- a/apps/web/src/lib/__tests__/no-envelope-fallthrough.test.ts
+++ b/apps/web/src/lib/__tests__/no-envelope-fallthrough.test.ts
@@ -203,6 +203,13 @@ describe('no envelope-fallthrough in ?? chains', () => {
     ).toEqual([]);
   });
 
+  // Explicit timeout: this case TS-parses every file under apps/web/src, so
+  // its runtime scales with the repo and is dominated by scheduler delay when
+  // the full 565-file suite runs it in parallel. Vitest's 5s default is a
+  // latent tripwire that any sizeable PR eventually trips for reasons that
+  // have nothing to do with the guard it enforces — matches the timeouts on
+  // the sibling whole-tree guards (no-hash-in-usestate, no-clipped-tables,
+  // no-translated-comparisons).
   it('no source file in apps/web/src uses the idiom', () => {
     const offenders = walk(SRC_ROOT)
       .map((file) => ({ file, violations: findViolations(readFileSync(file, 'utf8'), file) }))
@@ -216,5 +223,5 @@ describe('no envelope-fallthrough in ?? chains', () => {
       offenders,
       `Use asList() from src/lib/asList.ts instead:\n${offenders.join('\n')}`,
     ).toEqual([]);
-  });
+  }, 60_000);
 });

--- a/apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts
+++ b/apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts
@@ -246,12 +246,17 @@ describe('no location.hash reads in useState initializers (apps/web/src)', () =>
   // reviewed allowlist module — nothing would otherwise stop someone silencing a
   // real violation with CI still green. Pin the count at zero: adding the first
   // legitimate exemption must be a deliberate, reviewed bump of this number.
+  // Explicit timeout: this case TS-parses every file under apps/web/src, so
+  // its runtime scales with the repo and is dominated by scheduler delay when
+  // the full 560-file suite runs it in parallel. Vitest's 5s default is a
+  // latent tripwire that any sizeable PR eventually trips for reasons that
+  // have nothing to do with the guard it enforces.
   it('nobody has silenced a violation with hash-usestate-exempt (expected: 0)', () => {
     const exempted = files.filter((file) =>
       /hash-usestate-exempt/i.test(readFileSync(file, 'utf8')),
     );
     expect(exempted).toEqual([]);
-  });
+  }, 60_000);
 
   it('every hash-derived initial state goes through useHashState/useHashTab', () => {
     const all: string[] = [];

--- a/apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts
+++ b/apps/web/src/lib/__tests__/no-hash-in-usestate.test.ts
@@ -246,11 +246,13 @@ describe('no location.hash reads in useState initializers (apps/web/src)', () =>
   // reviewed allowlist module — nothing would otherwise stop someone silencing a
   // real violation with CI still green. Pin the count at zero: adding the first
   // legitimate exemption must be a deliberate, reviewed bump of this number.
-  // Explicit timeout: this case TS-parses every file under apps/web/src, so
-  // its runtime scales with the repo and is dominated by scheduler delay when
-  // the full 560-file suite runs it in parallel. Vitest's 5s default is a
-  // latent tripwire that any sizeable PR eventually trips for reasons that
-  // have nothing to do with the guard it enforces.
+  // Explicit timeout: these whole-tree cases read (and, below, TS-parse) every
+  // file under apps/web/src, so their runtime scales with the repo and is
+  // dominated by scheduler delay when the full 560-file suite runs them in
+  // parallel. Vitest's 5s default is a latent tripwire that any sizeable PR
+  // eventually trips for reasons that have nothing to do with the guard it
+  // enforces. BOTH cases need it — the parsing one below is the more expensive
+  // of the two, so a timeout on this one alone leaves the real tripwire armed.
   it('nobody has silenced a violation with hash-usestate-exempt (expected: 0)', () => {
     const exempted = files.filter((file) =>
       /hash-usestate-exempt/i.test(readFileSync(file, 'utf8')),
@@ -278,5 +280,5 @@ describe('no location.hash reads in useState initializers (apps/web/src)', () =>
             `"// hash-usestate-exempt: <reason>" for a genuinely client-only component.`
         : undefined
     ).toEqual([]);
-  });
+  }, 60_000);
 });

--- a/apps/web/src/lib/__tests__/no-translated-comparisons.test.ts
+++ b/apps/web/src/lib/__tests__/no-translated-comparisons.test.ts
@@ -148,6 +148,9 @@ describe('no equality comparison against a translated string', () => {
     ).toBe(true);
   });
 
+  // Explicit timeout — see the note in no-hash-in-usestate.test.ts: a
+  // whole-tree TS parse under full-suite parallelism routinely exceeds
+  // vitest's 5s default, independently of what this guard is checking.
   it('finds no value compared against an i18n lookup', () => {
     const offenders: string[] = [];
 
@@ -172,5 +175,5 @@ describe('no equality comparison against a translated string', () => {
             '\nCompare against the machine literal instead; translate only what you render.'
         : undefined,
     ).toEqual([]);
-  });
+  }, 60_000);
 });

--- a/apps/web/src/lib/i18n/translationCoverage.test.ts
+++ b/apps/web/src/lib/i18n/translationCoverage.test.ts
@@ -103,7 +103,9 @@ const namespaceDuplicateBaselines = {
     'reports.json': 32,
     // +2: automationRunHistory.scriptOutput — "stderr" is a stream name, not
     // wording, and "Script" is the standard loanword in this locale (#3162).
-    'scripts.json': 59,
+    // +1: scriptForm.variables.button — "Variables" is the same word in Spanish
+    // (same cognate already accepted for nav.variables).
+    'scripts.json': 60,
     'security.json': 114,
     // +1: tenantVariablesPage.title — "Variables" is identical in Spanish.
     'settings.json': 114,
@@ -153,7 +155,9 @@ const namespaceDuplicateBaselines = {
     'reports.json': 43,
     // +2: automationRunHistory.scriptOutput — "stderr" is a stream name, not
     // wording, and "Script" is the standard loanword in this locale (#3162).
-    'scripts.json': 62,
+    // +1: scriptForm.variables.button — "Variables" is identical in French
+    // (same cognate already accepted for nav.variables).
+    'scripts.json': 63,
     'security.json': 144,
     // +1: orgDefaultsEditor.enrollment.capMinutes — "{{minutes}} minutes" is
     // spelled identically in French.
@@ -202,7 +206,9 @@ const namespaceDuplicateBaselines = {
     'reports.json': 43,
     // +2: automationRunHistory.scriptOutput — "stderr" is a stream name, not
     // wording, and "Script" is the standard loanword in this locale (#3162).
-    'scripts.json': 62,
+    // +1: scriptForm.variables.button — "Variables" is identical in French
+    // (same cognate already accepted for nav.variables).
+    'scripts.json': 63,
     'security.json': 144,
     // +1: orgDefaultsEditor.enrollment.capMinutes — "{{minutes}} minutes" is
     // spelled identically in French.

--- a/apps/web/src/lib/installerVariables.test.ts
+++ b/apps/web/src/lib/installerVariables.test.ts
@@ -65,4 +65,28 @@ describe('findUnknownTokens', () => {
   it('tolerates inner whitespace', () => {
     expect(findUnknownTokens('{{ org.name }}', new Set())).toEqual([]);
   });
+
+  // #3409 PR2 — tenant variables share the installer template namespace; the
+  // API resolver fills `{{var.<key>}}` from the prefetched scope snapshot.
+  it('accepts tenant variable tokens on structure alone before the keys load', () => {
+    expect(findUnknownTokens('{{var.vendor_token}}', new Set())).toEqual([]);
+  });
+
+  it('validates tenant variable keys against the known set when required', () => {
+    const options = {
+      variableKeys: new Set(['vendor_token']),
+      requireKnownVariableKeys: true,
+    };
+    expect(findUnknownTokens('{{var.vendor_token}}', new Set(), options)).toEqual([]);
+    expect(findUnknownTokens('{{var.ghost}}', new Set(), options)).toEqual(['{{var.ghost}}']);
+  });
+
+  // The `var.*` namespace has exactly ONE strict form on both sides (no inner
+  // whitespace), unlike the legacy installer tokens above — flagging the spaced
+  // form here is what keeps the client from passing what the server rejects.
+  it('flags a spaced variable token rather than silently normalizing it', () => {
+    expect(findUnknownTokens('{{ var.vendor_token }}', new Set())).toEqual([
+      '{{ var.vendor_token }}',
+    ]);
+  });
 });

--- a/apps/web/src/lib/installerVariables.test.ts
+++ b/apps/web/src/lib/installerVariables.test.ts
@@ -89,4 +89,24 @@ describe('findUnknownTokens', () => {
       '{{ var.vendor_token }}',
     ]);
   });
+
+  // The server treats `${{var.x}}` as NON-strict and therefore unknown
+  // (`apps/api/src/services/installerVariables.ts` checks `template[offset-1]`,
+  // and the shared grammar carries a `(?<!\$)` lookbehind). The client used to
+  // validate it clean because the `$` sits outside the scanned match — the
+  // exact client-passes/server-fails divergence this module warns about.
+  it('flags a $-escaped variable token, matching the server', () => {
+    const options = { variableKeys: new Set(['vendor_token']), requireKnownVariableKeys: true };
+    expect(findUnknownTokens('${{var.vendor_token}}', new Set(), options)).toEqual([
+      '{{var.vendor_token}}',
+    ]);
+    // Still clean without the `$`.
+    expect(findUnknownTokens('{{var.vendor_token}}', new Set(), options)).toEqual([]);
+  });
+
+  it('flags a $-escaped variable token even before the variable list loads', () => {
+    expect(findUnknownTokens('${{var.vendor_token}}', new Set())).toEqual([
+      '{{var.vendor_token}}',
+    ]);
+  });
 });

--- a/apps/web/src/lib/installerVariables.ts
+++ b/apps/web/src/lib/installerVariables.ts
@@ -78,6 +78,20 @@ export function findTokens(value: string): string[] {
 }
 
 /**
+ * Same scan as {@link findTokens}, but carrying each match's offset so a
+ * caller can inspect the character BEFORE the token — which is the only way
+ * to see a `$` prefix, since `$` sits outside the match itself.
+ *
+ * Uses a fresh matcher rather than the shared `TOKEN_SCAN` instance:
+ * `matchAll` seeds its internal matcher from the regex it is handed, so a
+ * module-level global regex would carry `lastIndex` state between callers.
+ */
+function scanTokens(value: string): Array<{ raw: string; offset: number }> {
+  const matcher = new RegExp(TOKEN_SCAN.source, 'g');
+  return [...value.matchAll(matcher)].map((m) => ({ raw: m[0], offset: m.index }));
+}
+
+/**
  * Validate the variables in a template string against the known vocabulary.
  * `knownCustomFieldKeys` is the set of device custom-field keys defined for the
  * partner/org (from `GET /custom-fields`); pass an empty set when they haven't
@@ -104,8 +118,16 @@ export function findUnknownTokens(
 ): string[] {
   const builtinTokens = new Set(BUILTIN_INSTALLER_VARIABLES.map((v) => v.token));
   const unknown: string[] = [];
-  for (const raw of findTokens(value)) {
-    const variable = VARIABLE_TOKEN.exec(raw); // raw, not normalized — strict grammar
+  for (const { raw, offset } of scanTokens(value)) {
+    // raw, not normalized — strict grammar. The `$` guard mirrors the shared
+    // pattern's `(?<!\$)` lookbehind and the server's `template[offset - 1]`
+    // check (`apps/api/src/services/installerVariables.ts`): a `${{var.x}}`
+    // is deliberately NOT a variable token, and the server treats it as
+    // unknown and fails the deploy. Without this the client validated it
+    // clean — the exact client-passes/server-fails divergence VARIABLE_TOKEN's
+    // docblock above claims to prevent. Falling through (rather than
+    // `continue`) lands it in `unknown` via the checks below.
+    const variable = offset > 0 && value[offset - 1] === '$' ? null : VARIABLE_TOKEN.exec(raw);
     if (variable) {
       const key = variable[1];
       if (!requireKnownVariableKeys || variableKeys?.has(key)) continue;

--- a/apps/web/src/lib/installerVariables.ts
+++ b/apps/web/src/lib/installerVariables.ts
@@ -19,7 +19,13 @@
  * loudly, but the UI should never offer an unresolvable built-in).
  */
 
-export type InstallerVariableGroup = 'Organization' | 'Site' | 'Device' | 'Custom fields';
+export type InstallerVariableGroup =
+  | 'Organization'
+  | 'Site'
+  | 'Device'
+  | 'Custom fields'
+  /** Tenant variables (#3409) — `{{var.<key>}}`, dynamic like custom fields. */
+  | 'Variables';
 
 export interface InstallerVariable {
   /** The full token as inserted, e.g. `{{org.name}}`. */
@@ -54,6 +60,15 @@ const CUSTOM_FIELD_TOKEN = /^\{\{device\.customField\.([a-z][a-z0-9_]*)\}\}$/;
 const TOKEN_SCAN = /\{\{\s*[^{}]*?\s*\}\}/g;
 
 /**
+ * `{{var.<key>}}` (#3409) — matched against the RAW token, never the
+ * whitespace-normalized one. The `var.*` namespace has exactly one strict form
+ * on both client and server (`VARIABLE_TOKEN_PATTERN` in `@breeze/shared`);
+ * accepting `{{ var.x }}` here would recreate the client-passes/server-fails
+ * divergence the legacy tokens above already suffer from.
+ */
+const VARIABLE_TOKEN = /^\{\{var\.([a-z][a-z0-9_]{0,63})\}\}$/;
+
+/**
  * Return the list of syntactically-tokenish substrings in a string, e.g.
  * `["{{org.name}}", "{{device.customField.licenseKey}}"]`. Used both for
  * highlighting and for validation.
@@ -67,7 +82,9 @@ export function findTokens(value: string): string[] {
  * `knownCustomFieldKeys` is the set of device custom-field keys defined for the
  * partner/org (from `GET /custom-fields`); pass an empty set when they haven't
  * loaded yet, in which case custom-field tokens are accepted on structure alone
- * so the field never blocks on a slow fetch.
+ * so the field never blocks on a slow fetch. `variableKeys` /
+ * `requireKnownVariableKeys` are the same pair for tenant variables
+ * (`GET /tenant-variables`, #3409).
  *
  * Returns the list of tokens that are NOT recognized. An empty array means the
  * string is clean.
@@ -75,11 +92,26 @@ export function findTokens(value: string): string[] {
 export function findUnknownTokens(
   value: string,
   knownCustomFieldKeys: ReadonlySet<string>,
-  { requireKnownCustomKeys = false }: { requireKnownCustomKeys?: boolean } = {},
+  {
+    requireKnownCustomKeys = false,
+    variableKeys,
+    requireKnownVariableKeys = false,
+  }: {
+    requireKnownCustomKeys?: boolean;
+    variableKeys?: ReadonlySet<string>;
+    requireKnownVariableKeys?: boolean;
+  } = {},
 ): string[] {
   const builtinTokens = new Set(BUILTIN_INSTALLER_VARIABLES.map((v) => v.token));
   const unknown: string[] = [];
   for (const raw of findTokens(value)) {
+    const variable = VARIABLE_TOKEN.exec(raw); // raw, not normalized — strict grammar
+    if (variable) {
+      const key = variable[1];
+      if (!requireKnownVariableKeys || variableKeys?.has(key)) continue;
+      unknown.push(raw);
+      continue;
+    }
     const token = raw.replace(/\s+/g, ''); // tolerate `{{ org.name }}`
     if (builtinTokens.has(token)) continue;
     const custom = CUSTOM_FIELD_TOKEN.exec(token);

--- a/apps/web/src/lib/tenantVariableTokens.test.ts
+++ b/apps/web/src/lib/tenantVariableTokens.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { TenantVariable } from '@breeze/shared';
+import { findUnknownVariableKeys, toTenantVariableEntries } from './tenantVariableTokens';
+
+function row(partial: Partial<TenantVariable> & { key: string }): TenantVariable {
+  return {
+    id: `id-${partial.key}-${partial.ownerScope ?? 'organization'}`,
+    value: 'v',
+    isSecret: false,
+    description: null,
+    ownerScope: 'organization',
+    orgId: 'o-1',
+    partnerId: null,
+    version: 1,
+    createdAt: '2026-08-11T00:00:00.000Z',
+    updatedAt: '2026-08-11T00:00:00.000Z',
+    ...partial,
+  };
+}
+
+describe('toTenantVariableEntries', () => {
+  it('maps rows to picker entries sorted by key', () => {
+    expect(
+      toTenantVariableEntries([
+        row({ key: 'vendor_token', description: 'Vendor token' }),
+        row({ key: 'apt_mirror', description: null, isSecret: true }),
+      ]),
+    ).toEqual([
+      { key: 'apt_mirror', description: null, isSecret: true },
+      { key: 'vendor_token', description: 'Vendor token', isSecret: false },
+    ]);
+  });
+
+  it('collapses a key owned at both scopes to the org-owned row (resolution precedence)', () => {
+    const entries = toTenantVariableEntries([
+      row({ key: 'repo_url', ownerScope: 'partner', orgId: null, partnerId: 'p-1', description: 'Partner-wide' }),
+      row({ key: 'repo_url', ownerScope: 'organization', description: 'Org override' }),
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].description).toBe('Org override');
+  });
+});
+
+describe('findUnknownVariableKeys', () => {
+  const known = new Set(['vendor_token']);
+
+  it('reports a key that is not in the known set', () => {
+    expect(
+      findUnknownVariableKeys('echo {{var.ghost}}', known, { requireKnownKeys: true }),
+    ).toEqual(['ghost']);
+  });
+
+  it('de-duplicates a key referenced several times', () => {
+    expect(
+      findUnknownVariableKeys('{{var.ghost}} {{var.ghost}}', known, { requireKnownKeys: true }),
+    ).toEqual(['ghost']);
+  });
+
+  it('accepts a known key', () => {
+    expect(
+      findUnknownVariableKeys('curl {{var.vendor_token}}', known, { requireKnownKeys: true }),
+    ).toEqual([]);
+  });
+
+  // The list arrives async, and a failed fetch degrades to an empty list. An
+  // empty list must never mean "every token is unknown" — same convention as
+  // `requireKnownCustomKeys` in VariableInput.
+  it('suppresses every warning while the known set is empty', () => {
+    expect(findUnknownVariableKeys('{{var.ghost}}', new Set())).toEqual([]);
+  });
+
+  it('ignores ${{var.x}} and tokens from other namespaces', () => {
+    const content = '${{var.shell_expr}} {{org.name}} {{device.customField.license_key}} {{ var.spaced }}';
+    expect(findUnknownVariableKeys(content, known, { requireKnownKeys: true })).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/tenantVariableTokens.ts
+++ b/apps/web/src/lib/tenantVariableTokens.ts
@@ -1,0 +1,106 @@
+/**
+ * Tenant-variable vocabulary for the `{{var.<key>}}` pickers (#3409 PR2).
+ *
+ * Turns the `GET /tenant-variables` payload into the flat entry list both
+ * pickers render, and derives the warn-only "this key doesn't exist" notice.
+ *
+ * The token grammar itself lives in `@breeze/shared` (`variableTokens.ts`) and
+ * is NEVER re-implemented here — the whole point of that module is that the
+ * editor, the save-time check and the dispatch-time resolver agree on exactly
+ * which substrings are tokens.
+ */
+
+import { findVariableTokens, type TenantVariable } from '@breeze/shared';
+import { useEffect, useState } from 'react';
+import { asList } from '@/lib/asList';
+import { fetchWithAuth } from '@/stores/auth';
+
+/** One offerable variable. `value` is deliberately absent — pickers insert keys, never values. */
+export interface TenantVariableEntry {
+  key: string;
+  description: string | null;
+  isSecret: boolean;
+}
+
+/**
+ * Flatten the API rows into picker entries, sorted by key.
+ *
+ * A key can be owned at both scopes (an org-owned row overriding a
+ * partner-wide one). Resolution precedence is org-beats-partner, so the org
+ * row is the one whose description/secret flag the picker must show — offering
+ * both would present one token twice with contradictory hints.
+ */
+export function toTenantVariableEntries(rows: readonly TenantVariable[]): TenantVariableEntry[] {
+  const byKey = new Map<string, TenantVariableEntry>();
+  for (const row of rows) {
+    if (typeof row?.key !== 'string' || row.key === '') continue;
+    const existing = byKey.get(row.key);
+    // First writer wins unless this row is the org-owned override.
+    if (existing && row.ownerScope !== 'organization') continue;
+    byKey.set(row.key, {
+      key: row.key,
+      description: row.description ?? null,
+      isSecret: row.isSecret === true,
+    });
+  }
+  return [...byKey.values()].sort((a, b) => a.key.localeCompare(b.key));
+}
+
+/**
+ * Load the variables visible to the current scope. `fetchWithAuth` injects the
+ * active orgId, so the caller must not append one.
+ *
+ * Degrades to an empty list on any failure: the pickers are an affordance, not
+ * a gate, and an empty list also suppresses unknown-key warnings (see
+ * `findUnknownVariableKeys`) so a dead fetch can never flag a valid token.
+ */
+export async function fetchTenantVariableEntries(): Promise<TenantVariableEntry[]> {
+  try {
+    const response = await fetchWithAuth('/tenant-variables?limit=200');
+    if (!response.ok) return [];
+    return toTenantVariableEntries(asList<TenantVariable>(await response.json()));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * `fetchTenantVariableEntries` as mount-time state; `[]` until it resolves (or
+ * if it fails). Pass `enabled: false` to defer the request — e.g. a modal that
+ * is mounted closed shouldn't fetch until it opens.
+ */
+export function useTenantVariables(enabled = true): TenantVariableEntry[] {
+  const [entries, setEntries] = useState<TenantVariableEntry[]>([]);
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    void fetchTenantVariableEntries().then((loaded) => {
+      if (!cancelled) setEntries(loaded);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+  return entries;
+}
+
+/**
+ * Keys referenced by `content` that `knownKeys` doesn't contain, de-duplicated.
+ *
+ * `requireKnownKeys` defaults to false so the caller can pass
+ * `knownKeys.size > 0` and accept every token on structure alone until the
+ * async list arrives — the same convention `VariableInput` uses for
+ * custom-field keys. An empty set must never mean "every token is unknown".
+ *
+ * Non-tokens (`${{var.x}}`, `{{ var.x }}`, `{{org.name}}`, Jinja, GitHub
+ * Actions expressions) are invisible here because `findVariableTokens` never
+ * matches them — one grammar, shared with the server.
+ */
+export function findUnknownVariableKeys(
+  content: string,
+  knownKeys: ReadonlySet<string>,
+  { requireKnownKeys = false }: { requireKnownKeys?: boolean } = {},
+): string[] {
+  if (!requireKnownKeys) return [];
+  return findVariableTokens(content).filter((key) => !knownKeys.has(key));
+}

--- a/apps/web/src/locales/de-DE/policies.json
+++ b/apps/web/src/locales/de-DE/policies.json
@@ -1714,7 +1714,8 @@
       "unknownVariable": "Unbekannte Variable",
       "pickOneFromInsertVariable": "– Wählen Sie eine unter Variable einfügen aus.",
       "menu": "Menü",
-      "undefined": "undefined"
+      "undefined": "undefined",
+      "secretUnavailable": "Geheim – wird erst in einer späteren Version als Umgebungsvariable übergeben."
     }
   }
 }

--- a/apps/web/src/locales/de-DE/scripts.json
+++ b/apps/web/src/locales/de-DE/scripts.json
@@ -990,6 +990,13 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "variables": {
+      "button": "Variablen",
+      "insertTitle": "Variable einfügen",
+      "empty": "Noch keine Variablen.",
+      "secretUnavailable": "Geheim – wird erst in einer späteren Version als Umgebungsvariable übergeben.",
+      "unknown": "Für {{keys}} existiert keine Variable – die Ausführung schlägt auf jedem Zielgerät fehl, bis Sie sie anlegen."
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/en/policies.json
+++ b/apps/web/src/locales/en/policies.json
@@ -1714,7 +1714,8 @@
       "unknownVariable": "Unknown variable",
       "pickOneFromInsertVariable": "— pick one from Insert variable.",
       "menu": "menu",
-      "undefined": "undefined"
+      "undefined": "undefined",
+      "secretUnavailable": "Secret — a later release delivers it as an environment variable."
     }
   }
 }

--- a/apps/web/src/locales/en/scripts.json
+++ b/apps/web/src/locales/en/scripts.json
@@ -990,6 +990,13 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "variables": {
+      "button": "Variables",
+      "insertTitle": "Insert a variable",
+      "empty": "No variables yet.",
+      "secretUnavailable": "Secret — a later release delivers it as an environment variable.",
+      "unknown": "No variable exists for {{keys}} — targeted devices will fail until you create it."
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/es-419/policies.json
+++ b/apps/web/src/locales/es-419/policies.json
@@ -1714,7 +1714,8 @@
       "unknownVariable": "variable desconocida",
       "pickOneFromInsertVariable": "- elija uno de Insertar variable.",
       "menu": "menú",
-      "undefined": "undefined"
+      "undefined": "undefined",
+      "secretUnavailable": "Secreto: una versión posterior lo entregará como variable de entorno."
     }
   }
 }

--- a/apps/web/src/locales/es-419/scripts.json
+++ b/apps/web/src/locales/es-419/scripts.json
@@ -990,6 +990,13 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "variables": {
+      "button": "Variables",
+      "insertTitle": "Insertar una variable",
+      "empty": "Aún no hay variables.",
+      "secretUnavailable": "Secreto: una versión posterior lo entregará como variable de entorno.",
+      "unknown": "No existe ninguna variable para {{keys}}: los dispositivos seleccionados fallarán hasta que la crees."
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/fr-CA/policies.json
+++ b/apps/web/src/locales/fr-CA/policies.json
@@ -1714,7 +1714,8 @@
       "unknownVariable": "Variable inconnue",
       "pickOneFromInsertVariable": "— choisissez une variable dans Insérer une variable.",
       "menu": "Menu",
-      "undefined": "undefined"
+      "undefined": "undefined",
+      "secretUnavailable": "Secret — une version ultérieure la transmettra comme variable d'environnement."
     }
   }
 }

--- a/apps/web/src/locales/fr-CA/scripts.json
+++ b/apps/web/src/locales/fr-CA/scripts.json
@@ -990,6 +990,13 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "variables": {
+      "button": "Variables",
+      "insertTitle": "Insérer une variable",
+      "empty": "Aucune variable pour l'instant.",
+      "secretUnavailable": "Secret — une version ultérieure la transmettra comme variable d'environnement.",
+      "unknown": "Aucune variable ne correspond à {{keys}} — les appareils ciblés échoueront tant qu'elle n'existe pas."
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/fr-FR/policies.json
+++ b/apps/web/src/locales/fr-FR/policies.json
@@ -1714,7 +1714,8 @@
       "unknownVariable": "Variable inconnue",
       "pickOneFromInsertVariable": "— choisissez une variable dans Insérer une variable.",
       "menu": "Menu",
-      "undefined": "undefined"
+      "undefined": "undefined",
+      "secretUnavailable": "Secret — une version ultérieure la transmettra comme variable d'environnement."
     }
   }
 }

--- a/apps/web/src/locales/fr-FR/scripts.json
+++ b/apps/web/src/locales/fr-FR/scripts.json
@@ -990,6 +990,13 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "variables": {
+      "button": "Variables",
+      "insertTitle": "Insérer une variable",
+      "empty": "Aucune variable pour l'instant.",
+      "secretUnavailable": "Secret — une version ultérieure la transmettra comme variable d'environnement.",
+      "unknown": "Aucune variable ne correspond à {{keys}} — les appareils ciblés échoueront tant qu'elle n'existe pas."
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/it-IT/policies.json
+++ b/apps/web/src/locales/it-IT/policies.json
@@ -1714,7 +1714,8 @@
       "unknownVariable": "Variabile sconosciuta",
       "pickOneFromInsertVariable": "— scegline una da Inserisci variabile.",
       "menu": "menu",
-      "undefined": "undefined"
+      "undefined": "undefined",
+      "secretUnavailable": "Segreto: una versione futura lo passerà come variabile d'ambiente."
     }
   }
 }

--- a/apps/web/src/locales/it-IT/scripts.json
+++ b/apps/web/src/locales/it-IT/scripts.json
@@ -990,6 +990,13 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "variables": {
+      "button": "Variabili",
+      "insertTitle": "Inserisci una variabile",
+      "empty": "Ancora nessuna variabile.",
+      "secretUnavailable": "Segreto: una versione futura lo passerà come variabile d'ambiente.",
+      "unknown": "Non esiste alcuna variabile per {{keys}}: i dispositivi selezionati falliranno finché non la crei."
     }
   },
   "scriptList": {

--- a/apps/web/src/locales/pt-BR/policies.json
+++ b/apps/web/src/locales/pt-BR/policies.json
@@ -1714,7 +1714,8 @@
       "unknownVariable": "Variável desconhecida",
       "pickOneFromInsertVariable": "— escolha uma em Inserir variável.",
       "menu": "menu",
-      "undefined": "undefined"
+      "undefined": "undefined",
+      "secretUnavailable": "Secreto — uma versão futura o entregará como variável de ambiente."
     }
   }
 }

--- a/apps/web/src/locales/pt-BR/scripts.json
+++ b/apps/web/src/locales/pt-BR/scripts.json
@@ -990,6 +990,13 @@
       "windows": "Windows",
       "macos": "macOS",
       "linux": "Linux"
+    },
+    "variables": {
+      "button": "Variáveis",
+      "insertTitle": "Inserir uma variável",
+      "empty": "Nenhuma variável ainda.",
+      "secretUnavailable": "Secreto — uma versão futura o entregará como variável de ambiente.",
+      "unknown": "Não existe variável para {{keys}} — os dispositivos selecionados vão falhar até você criá-la."
     }
   },
   "scriptList": {

--- a/docs/superpowers/plans/2026-08-11-pr2-tenant-variable-resolution.md
+++ b/docs/superpowers/plans/2026-08-11-pr2-tenant-variable-resolution.md
@@ -1,0 +1,623 @@
+# Tenant Variable Resolution (PR 2 of #3409) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `tenant_variables` rows PR 1 created actually do something: a `{{var.<key>}}` token in a script body (and in a software installer URL / silent-install args) resolves server-side, per target device, to that device's org-then-partner value — failing that one device loudly rather than shipping a literal `{{...}}`.
+
+**Architecture:** A resolver service loads an opaque, immutable **scope snapshot** for a set of orgs in ONE system-context query, and dispatch consumes that snapshot per device. Resolution never rides ambient RLS, because the five dispatch call sites run under three different DB contexts and would otherwise resolve different variable sets for the same script. Substitution happens at the single `scriptDispatch` chokepoint, between field resolution and the `script_executions` insert, so every ingress inherits it. Secret variables are rejected at save time and again at dispatch — PR 2 has no way to deliver them out-of-band, and textual substitution of a secret is the exact leak class PR 4 exists to prevent.
+
+**Tech Stack:** TypeScript (Hono routes, Drizzle, Zod v4 in `@breeze/shared`), Vitest unit + real-Postgres integration, React + Monaco for the editor picker.
+
+## Global Constraints
+
+- **Issue:** #3409. Scope comment: `gh api repos/lanternops/breeze/issues/comments/5248871605`. PR 1 (this branch's parent): `ToddHebebrand/tenant-variables-pr1`, plan `docs/superpowers/plans/2026-08-11-pr1-tenant-variables.md`.
+- **Branch:** `ToddHebebrand/tenant-variables-pr2`, stacked on PR 1. **A stacked PR gets NO CI** (`ci.yml` triggers on `pull_request: branches: [main]`), so `gh pr checks` reads green while nothing ran. Dispatch explicitly before merging: `gh workflow run CI --ref ToddHebebrand/tenant-variables-pr2`.
+- **Token grammar:** only `{{var.<key>}}` with `<key>` matching `TENANT_VARIABLE_KEY_PATTERN` (`/^[a-z][a-z0-9_]{0,63}$/`, `packages/shared/src/validators/tenantVariables.ts:14`) is live. Every other `{{...}}` passes through **verbatim** — scripts legitimately contain GitHub Actions expressions, Jinja, and shell brace expansion.
+- **`${{var.x}}` must NOT be treated as a variable token.** A `$` immediately before `{{` means the author wrote a shell/Actions construct. This is the one deliberate divergence from the existing installer tokenizer (`TOKEN = /\{\{\s*([^{}]+?)\s*\}\}/g`, `apps/api/src/services/installerVariables.ts:29`), which happily eats it.
+- **No inner whitespace.** `{{ var.x }}` is NOT a token. The existing client tokenizer strips all whitespace before lookup while the server only trims (`apps/web/src/lib/installerVariables.ts:83` vs `installerVariables.ts:79`), which already produces client-passes/server-fails divergence. Do not extend that bug into the new namespace: one strict form, both sides.
+- **Resolution precedence:** org-owned value beats partner-wide value for the same key. Site axis does not exist yet.
+- **Empty string is unresolved.** Matches `resolveKey`'s existing rule (`installerVariables.ts:50-60`) — a blank value must fail the device, not silently produce an empty URL segment or an empty argument.
+- **Secret variables cannot be referenced in content in v1.** `{{var.<secret_key>}}` is a 400 at script save/import and a per-device failure at dispatch (a variable can be flipped to secret *after* a script referencing it was saved).
+- **Resolution runs in a system DB context with explicit `{orgId, partnerId}` filters**, never ambient RLS, and the snapshot is produced by the resolver — never assembled by a caller.
+- **The four-eyes effect digest is NOT extended in this PR.** It hashes `scripts.content` — the template — at both pin and release (`services/actionIntents/effectDigest.ts:135,147`), so a variable's *value* changing between approval and release will not invalidate the digest. PR 4 closes this. Say so in the PR body.
+- **No agent (Go) changes in this PR.** Delivery of secret values as `BREEZE_VAR_*` env vars is PR 4.
+- Commit after every task.
+
+---
+
+## Deviations from the scope comment (deliberate, state in the PR body)
+
+| Scope comment says | This plan does | Why |
+|---|---|---|
+| "all referenced variables inject as `BREEZE_VAR_<UPPER_KEY>` env vars; textual substitution only where the author wrote a non-secret token" | textual substitution only; **no env injection at all** | The agent has no `BREEZE_VAR_*` handling until PR 4. The only env channel that exists today is the `parameters` map, and the agent substitutes *every* parameter into script text as well as mirroring it to `BREEZE_PARAM_*` (`agent/internal/executor/shell.go:160-176`, `executor.go:329-343`) — routing variables through it would make every value textually substitutable, the precise leak PR 4's separate `secretEnv` channel is designed to avoid. |
+| "preloaded scope … that dispatch verifies" | same, plus: the snapshot carries the org ids it was built for and dispatch throws if asked to resolve for an org outside it | Makes the "verifies" concrete and testable. |
+
+---
+
+## File Structure
+
+**Created**
+
+| Path | Responsibility |
+|---|---|
+| `packages/shared/src/validators/variableTokens.ts` | the `{{var.*}}` grammar: tokenizer, `findVariableTokens`, `hasVariableTokens`; shared by API and web so the two can never diverge |
+| `packages/shared/src/validators/variableTokens.test.ts` | tokenizer edge cases (`${{}}`, whitespace, nesting, unbalanced) |
+| `packages/shared/src/validators/scriptParameters.ts` | the ONE script-parameter value schema + `canonicalizeScriptParameters` |
+| `packages/shared/src/validators/scriptParameters.test.ts` | coercion + rejection coverage |
+| `apps/api/src/services/tenantVariableResolution.ts` | scope snapshot loader (system context, one query), per-org resolution, content substitution |
+| `apps/api/src/services/tenantVariableResolution.test.ts` | unit coverage with a mocked db |
+| `apps/api/src/__tests__/integration/tenantVariableResolution.integration.test.ts` | real-Postgres: org-over-partner precedence, cross-tenant isolation, secret exclusion |
+| `apps/web/src/lib/tenantVariableTokens.ts` | web-side vocabulary entry: builds `{{var.*}}` picker entries from a fetched key list |
+| `apps/web/src/components/scripts/ScriptVariablePicker.tsx` | Monaco-aware insert-variable menu for the script editor |
+| `apps/web/src/components/scripts/ScriptVariablePicker.test.tsx` | picker + warn-only validation coverage |
+
+**Modified**
+
+| Path | Change |
+|---|---|
+| `apps/api/src/services/scriptDispatch.ts` | accept a scope snapshot; substitute content per device between `:114` and `:116`; new failure code |
+| `apps/api/src/services/scriptExecution.ts` | preload the snapshot once; per-device soft-fail instead of `throw` (`:217-222`) |
+| `apps/api/src/services/automationRuntime.ts` | preload for both `run_script` (`:888`) and `execute_command` (`:966`) |
+| `apps/api/src/services/aiToolsScripts.ts` | preload inside the existing `runOutsideDbContext` escape (`:285-296`) |
+| `apps/api/src/routes/scripts.ts` | reject `{{var.<secret>}}` on create (`:230`) / update (`:248`); adopt the shared parameter schema at `:273` |
+| `apps/api/src/services/scriptBundle/schema.ts` | same rejection on import |
+| `apps/api/src/services/installerVariables.ts` | `var.<key>` arm in `resolveKey`; `vars` on `InstallerVariableContext` |
+| `apps/api/src/services/softwareDeployment.ts` | prefetch the variable map alongside `orgName`/`siteNames` (`:317-335`) |
+| `apps/web/src/lib/installerVariables.ts` | new `'Variables'` group + dynamic token builder |
+| `apps/web/src/components/software/VariableInput.tsx` | accept `tenantVariables` prop, render the new group |
+| `apps/web/src/components/scripts/ScriptForm.tsx` | mount the picker + warn-only unknown-token notice |
+
+---
+
+### Task 1: The shared `{{var.*}}` tokenizer
+
+**Files:**
+- Create: `packages/shared/src/validators/variableTokens.ts`, `packages/shared/src/validators/variableTokens.test.ts`
+- Modify: `packages/shared/src/validators/index.ts` (re-export)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export const VARIABLE_TOKEN_PATTERN: RegExp;              // global, use with matchAll only
+  export function findVariableTokens(content: string): string[];   // unique keys, in first-seen order
+  export function hasVariableTokens(content: string): boolean;
+  export function variableToken(key: string): string;       // `{{var.${key}}}`
+  export function replaceVariableTokens(
+    content: string,
+    lookup: (key: string) => string | undefined,
+  ): { content: string; unresolved: string[] };
+  ```
+  Task 2 (API resolver) and Task 6 (web picker) both import these. `replaceVariableTokens` is the single substitution implementation — the API wraps it, the web never substitutes.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { findVariableTokens, replaceVariableTokens, variableToken } from './variableTokens';
+
+describe('findVariableTokens', () => {
+  it('finds a well-formed token', () => {
+    expect(findVariableTokens('curl {{var.repo_url}}/pkg')).toEqual(['repo_url']);
+  });
+
+  it('de-duplicates and preserves first-seen order', () => {
+    expect(findVariableTokens('{{var.b}} {{var.a}} {{var.b}}')).toEqual(['b', 'a']);
+  });
+
+  it('ignores a token escaped by a leading $ — that is shell/Actions syntax', () => {
+    expect(findVariableTokens('run ${{var.repo_url}}')).toEqual([]);
+  });
+
+  it.each([
+    '{{ var.x }}',        // inner whitespace: one strict form only
+    '{{VAR.X}}',          // case-sensitive
+    '{{var.9bad}}',       // key grammar
+    '{{var.Bad_Key}}',
+    '{{var.}}',
+    '{{var.x}',           // unbalanced
+    '{{varx}}',           // no dot
+    '{{org.name}}',       // a different namespace passes through
+    '{file}',             // the agent's own single-brace token
+  ])('does not treat %j as a variable token', (input) => {
+    expect(findVariableTokens(input)).toEqual([]);
+  });
+
+  it('leaves an unrelated {{...}} expression alone', () => {
+    const gha = 'if: ${{ github.event_name == \'push\' }}';
+    expect(findVariableTokens(gha)).toEqual([]);
+  });
+});
+
+describe('replaceVariableTokens', () => {
+  it('substitutes verbatim, with no escaping', () => {
+    const out = replaceVariableTokens('token={{var.k}}', (k) => (k === 'k' ? 'a b"c' : undefined));
+    expect(out).toEqual({ content: 'token=a b"c', unresolved: [] });
+  });
+
+  it('reports an unknown key and leaves the token in place', () => {
+    const out = replaceVariableTokens('{{var.missing}}', () => undefined);
+    expect(out).toEqual({ content: '{{var.missing}}', unresolved: ['missing'] });
+  });
+
+  it('treats an empty value as unresolved', () => {
+    const out = replaceVariableTokens('{{var.blank}}', () => '');
+    expect(out.unresolved).toEqual(['blank']);
+    expect(out.content).toBe('{{var.blank}}');
+  });
+
+  it('never re-scans a substituted value (no recursive expansion)', () => {
+    const out = replaceVariableTokens('{{var.a}}', (k) => (k === 'a' ? '{{var.b}}' : 'SHOULD-NOT-APPEAR'));
+    expect(out.content).toBe('{{var.b}}');
+  });
+
+  it('leaves a $-escaped token untouched', () => {
+    const out = replaceVariableTokens('${{var.k}}', () => 'v');
+    expect(out).toEqual({ content: '${{var.k}}', unresolved: [] });
+  });
+
+  it('round-trips variableToken', () => {
+    expect(replaceVariableTokens(variableToken('k'), () => 'v').content).toBe('v');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @breeze/shared test -- variableTokens`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+The regex must reject a preceding `$` without consuming the character before the token (a lookbehind keeps the match offsets clean; Node 22 supports it):
+
+```ts
+/** `{{var.<key>}}` — no inner whitespace, key grammar enforced, `${{...}}` excluded. */
+export const VARIABLE_TOKEN_PATTERN = /(?<!\$)\{\{var\.([a-z][a-z0-9_]{0,63})\}\}/g;
+```
+
+`replaceVariableTokens` must build the output with a single `String.replace(VARIABLE_TOKEN_PATTERN, cb)` pass so a substituted value is never re-scanned, and push the key to `unresolved` when the lookup returns `undefined`, `null`, or `''` (returning the original token unchanged in that case).
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @breeze/shared test -- variableTokens`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/validators/variableTokens.ts packages/shared/src/validators/variableTokens.test.ts packages/shared/src/validators/index.ts
+git commit -m "feat(shared): {{var.*}} token grammar shared by API and web (#3409 PR2)"
+```
+
+---
+
+### Task 2: The resolver — scope snapshot, precedence, substitution
+
+**Files:**
+- Create: `apps/api/src/services/tenantVariableResolution.ts`, `apps/api/src/services/tenantVariableResolution.test.ts`
+- Create: `apps/api/src/__tests__/integration/tenantVariableResolution.integration.test.ts`
+
+**Interfaces:**
+- Consumes: `tenantVariables` (`db/schema`), `decryptTenantVariableValue` (`services/tenantVariables.ts:75`), `replaceVariableTokens` / `findVariableTokens` (Task 1).
+- Produces:
+  ```ts
+  export interface ResolvedVariable { key: string; value: string; isSecret: boolean; variableId: string; version: number; }
+  /** Opaque. Built only by loadTenantVariableScope; carries the org ids it is valid for. */
+  export interface TenantVariableScope { readonly orgIds: ReadonlySet<string>; /* private carrier */ }
+  export async function loadTenantVariableScope(orgIds: string[]): Promise<TenantVariableScope>;
+  export function resolveForOrg(scope: TenantVariableScope, orgId: string): Map<string, ResolvedVariable>;
+  export interface SubstitutionOutcome {
+    content: string;
+    unresolved: string[];      // keys with no visible value
+    secretsReferenced: string[]; // keys that resolved but are is_secret — never substituted
+  }
+  export function substituteTenantVariables(content: string, resolved: Map<string, ResolvedVariable>): SubstitutionOutcome;
+  export function describeVariableFailure(outcome: SubstitutionOutcome): string | null;
+  ```
+  Tasks 3 and 5 consume these.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Mock `../db` only (never `../db/schema` — the query is built with real Drizzle columns). Cover:
+
+```ts
+it('org value shadows a partner-wide value for the same key', () => { /* both rows in the snapshot; resolveForOrg returns the org one */ });
+it('a partner-wide key with no org override still resolves', () => {});
+it('never leaks another org value into this org resolution', () => { /* two orgs in one snapshot */ });
+it('throws when asked to resolve for an org the snapshot was not built for', () => {
+  expect(() => resolveForOrg(scope, 'org-not-in-snapshot')).toThrow(/not in this snapshot/i);
+});
+it('substituteTenantVariables reports a secret key instead of substituting it', () => {
+  const out = substituteTenantVariables('{{var.s1_token}}', mapWith({ key: 's1_token', isSecret: true }));
+  expect(out.content).toBe('{{var.s1_token}}');
+  expect(out.secretsReferenced).toEqual(['s1_token']);
+  expect(out.unresolved).toEqual([]);
+});
+it('never puts a secret value in the returned content even when the same key is also referenced twice', () => {});
+it('describeVariableFailure names the keys but never a value', () => {});
+it('loadTenantVariableScope issues ONE query for many orgs', async () => { /* assert db.select called once */ });
+it('loadTenantVariableScope filters on org OR (partner-wide AND that org partner)', async () => {
+  // Walk the captured condition's BOUND PARAMS (see services/tenantVariables.test.ts's
+  // boundParams helper) — a stringified-condition assertion passes with the guard deleted.
+});
+it('an undecryptable row is treated as unresolved, not as an empty value', async () => {});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @breeze/api test -- tenantVariableResolution`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+`loadTenantVariableScope(orgIds)`:
+- de-duplicate `orgIds`; return an empty scope for an empty input without querying.
+- run the whole load inside `runOutsideDbContext(() => withSystemDbAccessContext(...))`. **Both wrappers are required.** The route path calls this from inside a held org-scoped request transaction; a bare `withSystemDbAccessContext` nested in an existing context does not elevate it, and an org token whose JWT lacks `partnerId` would then see zero partner-wide rows. System scope makes resolution identical across all five call sites — at the cost that RLS no longer constrains it, so the WHERE clause below is the only tenancy boundary and must be exact.
+- one query joining `organizations` for `partner_id`:
+  ```sql
+  SELECT tv.*, o.id AS for_org_id
+  FROM organizations o
+  JOIN tenant_variables tv
+    ON tv.org_id = o.id
+    OR (tv.org_id IS NULL AND tv.partner_id = o.partner_id)
+  WHERE o.id = ANY($1)
+  ```
+  Express it in Drizzle with `inArray(organizations.id, orgIds)`; every row comes back tagged with the org it is FOR, so a partner-wide row appears once per org that inherits it.
+- decrypt each value with `decryptTenantVariableValue`; a throw is logged (`console.warn`, id only) and the row is **omitted** — an unreadable variable must fail the device, not resolve to `''`.
+- build `Map<orgId, Map<key, ResolvedVariable>>`, applying org-over-partner precedence at insert time.
+
+`resolveForOrg` throws when `orgId` is absent from `scope.orgIds` — that is the "dispatch verifies the snapshot" contract.
+
+`substituteTenantVariables` calls `replaceVariableTokens` with a lookup that returns `undefined` for a secret key while recording it in `secretsReferenced`, so a secret is reported separately from a genuinely missing key and its value never enters the output string.
+
+- [ ] **Step 4: Write the integration suite**
+
+`tenantVariableResolution.integration.test.ts`, modeled on `tenantVariablesPartnerRls.integration.test.ts`. Must prove against real Postgres:
+1. org-owned value shadows the partner-wide one with the same key;
+2. an org inherits its partner's partner-wide value;
+3. an org NEVER sees another partner's partner-wide value (build two partners);
+4. a two-org snapshot resolves each org independently in one call;
+5. resolution works when called from inside an ORG-SCOPED `withDbAccessContext` — the regression that proves the system-context escape is present (delete the escape and this test must fail);
+6. a secret variable is loaded but reported via `secretsReferenced`, never substituted.
+
+- [ ] **Step 5: Run both suites**
+
+```bash
+pnpm --filter @breeze/api test -- tenantVariableResolution
+pnpm --filter @breeze/api test:integration -- tenantVariableResolution
+```
+Expected: PASS. (The test stack is already up on this worktree; `pnpm test-stack up` at the repo root if not.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/services/tenantVariableResolution.ts apps/api/src/services/tenantVariableResolution.test.ts apps/api/src/__tests__/integration/tenantVariableResolution.integration.test.ts
+git commit -m "feat(api): tenant variable resolver with org-over-partner precedence (#3409 PR2)"
+```
+
+---
+
+### Task 3: Per-device failure channel for script dispatch
+
+**Files:**
+- Modify: `apps/api/src/services/scriptExecution.ts` (`:217-222`), `apps/api/src/services/scriptDispatch.ts` (`:46-59`)
+- Modify: `apps/api/src/services/scriptExecution.test.ts`, `apps/api/src/services/scriptDispatch.test.ts`
+
+**Why this is its own task:** today `executeScriptOnDevices` throws on any dispatch failure, so devices after the failing one never get a row and the batch's `devicesTargeted` becomes a lie. Fail-loud variable resolution would turn one org's missing variable into a silently truncated fan-out. This task builds the channel; Task 4 uses it.
+
+**Interfaces:**
+- Produces: `DispatchScriptResult` gains failure code `'unresolved_variables'`; `ExecuteScriptOnDevicesSuccess` gains `failures: Array<{ deviceId: string; code: string; error: string }>`, and `executions` keeps its existing meaning (successfully dispatched only).
+
+- [ ] **Step 1: Write the failing test**
+
+In `scriptExecution.test.ts`:
+
+```ts
+it('records a per-device failure and still dispatches the remaining devices', async () => {
+  // dispatch mock: device B fails, A and C succeed
+  const result = await executeScriptOnDevices({ /* three devices */ });
+  expect(result.executions).toHaveLength(2);
+  expect(result.failures).toEqual([{ deviceId: DEVICE_B, code: 'unresolved_variables', error: expect.any(String) }]);
+});
+
+it('writes a failed script_executions row for the failed device, not nothing', async () => {
+  // assert the insert carried status 'failed' + a non-empty errorMessage
+});
+
+it('counts a per-device failure toward the batch devicesFailed, not devicesTargeted', async () => {});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @breeze/api test -- scriptExecution`
+Expected: FAIL — `failures` undefined / the throw still aborts.
+
+- [ ] **Step 3: Implement**
+
+Replace the `throw new Error(dispatch.error)` at `scriptExecution.ts:217-222` with: push to `failures`, insert a `script_executions` row with `status: 'failed'`, `errorMessage: dispatch.error`, `completedAt: new Date()` (mirroring `softwareDeployment.ts:399-414`), increment the org's batch `devicesFailed`, and `continue`. Keep throwing for codes that indicate a programming error rather than a per-device condition (`insert_failed`) so a real bug still surfaces loudly.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @breeze/api test -- scriptExecution scriptDispatch`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(api): per-device failure channel for script fan-out (#3409 PR2)"
+```
+
+---
+
+### Task 4: Wire resolution into dispatch
+
+**Files:**
+- Modify: `apps/api/src/services/scriptDispatch.ts`, `scriptExecution.ts`, `automationRuntime.ts` (`:888`, `:966`), `aiToolsScripts.ts` (`:285-296`)
+- Modify: `apps/api/src/services/scriptDispatch.test.ts` + the three call-site test files
+
+**Interfaces:**
+- Consumes: Task 2's resolver, Task 3's failure channel.
+- Produces: `DispatchScriptInput` gains `variableScope?: TenantVariableScope`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('substitutes a non-secret variable into the content that reaches the payload', async () => {
+  // assert the payload content contains the value and NOT the token
+});
+it('fails the device with unresolved_variables when a token has no value', async () => {
+  // and assert queueCommand was NEVER called for it
+});
+it('fails the device when the content references a SECRET variable', async () => {
+  // PR 4 delivers secrets; PR 2 must never substitute one
+  expect(result).toMatchObject({ ok: false, code: 'unresolved_variables' });
+  expect(result.error).toMatch(/secret/i);
+});
+it('never puts a secret value anywhere in the payload', async () => {
+  expect(JSON.stringify(payload)).not.toContain(SECRET_VALUE);
+});
+it('resolves nothing and issues no query when the content has no {{var.}} token', async () => {});
+it('throws if the supplied scope was not built for this device org', async () => {});
+it('does not substitute into a raw execute_command source', async () => {
+  // {kind:'raw'} has no declaring script; per the scope decision, tokens pass through
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @breeze/api test -- scriptDispatch`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `scriptDispatch.ts`, between the field resolution at `:109-114` and the `script_executions` insert at `:116`:
+
+```ts
+let content = source.kind === 'saved' ? source.script.content : source.content;
+if (source.kind === 'saved' && hasVariableTokens(content)) {
+  if (!input.variableScope) throw new Error('variableScope is required to dispatch a script containing {{var.*}} tokens');
+  const outcome = substituteTenantVariables(content, resolveForOrg(input.variableScope, device.orgId));
+  const failure = describeVariableFailure(outcome);
+  if (failure) return { ok: false, code: 'unresolved_variables', error: failure };
+  content = outcome.content;
+}
+```
+
+- The `hasVariableTokens` guard keeps the common (token-free) path allocation-free and query-free.
+- Placing this BEFORE the execution-row insert means a failed device gets its `failed` row from Task 3's channel in the caller, with no orphan `pending` row to discard.
+- `{kind:'raw'}` is deliberately skipped: an ad-hoc `execute_command` has no declaring script, so there is nothing that could have been validated at save time.
+
+Call sites preload once per fan-out, outside the per-device loop:
+- `scriptExecution.ts`: after `executableDevices` is known, `loadTenantVariableScope([...new Set(devices.map(d => d.orgId))])`.
+- `automationRuntime.ts:888`: single device — `loadTenantVariableScope([device.orgId])`.
+- `aiToolsScripts.ts`: inside the existing `runOutsideDbContext` escape at `:285-296`, before `dispatchScriptToDevice`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @breeze/api test -- scriptDispatch scriptExecution automationRuntime aiToolsScripts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(api): resolve {{var.*}} per device at script dispatch (#3409 PR2)"
+```
+
+---
+
+### Task 5: Save-time enforcement + software-deploy wiring
+
+**Files:**
+- Modify: `apps/api/src/routes/scripts.ts` (create `:230`, update `:248`), `apps/api/src/services/scriptBundle/schema.ts`
+- Modify: `apps/api/src/services/installerVariables.ts`, `apps/api/src/services/softwareDeployment.ts` (`:317-335`, `:382-420`)
+- Modify: `apps/api/src/services/installerVariables.test.ts`, `apps/api/src/routes/scripts.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// routes/scripts.test.ts
+it('400s a script whose content references a secret variable', async () => {});
+it('accepts a script referencing a non-secret variable', async () => {});
+it('accepts a script referencing an UNKNOWN variable key — warn-only, not a block', async () => {
+  // a key may be created after the script; only the secret rule is a hard block
+});
+
+// installerVariables.test.ts
+it('resolves {{var.key}} from the prefetched map', () => {});
+it('treats an empty variable value as unresolved (fail loudly)', () => {});
+it('leaves ${{var.key}} alone', () => {});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @breeze/api test -- scripts installerVariables`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Save-time check (create, update, bundle import): if `findVariableTokens(content)` is non-empty, load the caller's visible variables and 400 on any key whose row has `is_secret = true`. An unknown key is allowed — it may be created later, and the dispatch path already fails loudly. The error message names the offending keys.
+
+`installerVariables.ts`: add `vars: Record<string, string>` to `InstallerVariableContext` and a `var.<key>` arm to `resolveKey` returning `ctx.vars[key] ?? null` (the existing empty-string-is-null rule at `:50-60` then applies unchanged). Keep the resolver **sync and DB-free** — the map is prefetched.
+
+`softwareDeployment.ts`: alongside the existing `templatesUseVariables` prefetch at `:317-335`, call `loadTenantVariableScope([orgId])` and flatten the non-secret entries into `vars`. Secret variables are omitted from the map, so referencing one in an installer URL fails that device through the existing unresolved branch at `:399-414` — no new code path.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @breeze/api test -- scripts installerVariables softwareDeployment scriptBundle`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(api): reject secret variable tokens at save; resolve {{var.*}} in installer templates (#3409 PR2)"
+```
+
+---
+
+### Task 6: Web — vocabulary, software picker, script-editor picker
+
+**Files:**
+- Create: `apps/web/src/lib/tenantVariableTokens.ts`, `apps/web/src/components/scripts/ScriptVariablePicker.tsx` + test
+- Modify: `apps/web/src/lib/installerVariables.ts`, `apps/web/src/components/software/VariableInput.tsx`, `apps/web/src/components/scripts/ScriptForm.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// VariableInput.test.tsx — mirrors the existing custom-fields group test at :47
+it('renders tenant variables under their own group and inserts at the caret', () => {});
+
+// ScriptVariablePicker.test.tsx
+it('inserts {{var.key}} into Monaco at the current selection', () => {});
+it('marks a secret variable as unusable with a reason', () => {});
+it('warns — without blocking submit — when the content references an unknown key', () => {});
+it('does not warn on ${{var.x}} or on a {{org.name}} token from another namespace', () => {});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @breeze/web test -- VariableInput ScriptVariablePicker`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+- `installerVariables.ts`: add `'Variables'` to `InstallerVariableGroup` (`:22`) and to `GROUP_ORDER` (`VariableInput.tsx:36-41`). Tenant variables are **dynamic**, like custom fields — do NOT add static entries to `BUILTIN_INSTALLER_VARIABLES`, whose exact contents are pinned by a cross-boundary tripwire test at `apps/web/src/lib/installerVariables.test.ts:14-18`.
+- `VariableInput.tsx`: new optional `tenantVariables?: Array<{ key: string; description: string | null; isSecret: boolean }>` prop, folded into the existing `variables` memo at `:72-80`. Secret entries render disabled with a "delivered as an environment variable in a later release" hint.
+- `ScriptForm.tsx`: mount the picker in the toolbar row that already holds the AI toggle (`:495-512`). Insert via `editorInstanceRef.current.executeEdits(...)` at the live selection — NOT `setSelectionRange`, which is the `<input>`-only approach `VariableInput` uses. Warn-only validation derives from `watch('content')` and renders beside the existing error slot at `:566`, styled as a warning; it must NOT go through `zodResolver` (`:161`), which would block submit.
+- Fetch the key list from `GET /tenant-variables` via `fetchWithAuth` (it injects the current `orgId` automatically). A failed fetch degrades to an empty list and suppresses unknown-token warnings entirely — the same "accept on structure alone until the async list arrives" convention as `requireKnownCustomKeys` (`VariableInput.tsx:94-100`).
+- New user-facing strings need keys in all seven locales (`localeParity` + `translationCoverage` will fail otherwise).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @breeze/web test -- VariableInput ScriptVariablePicker ScriptForm installerVariables
+pnpm --filter @breeze/web test -- localeParity translationCoverage
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(web): {{var.*}} picker for scripts and software templates (#3409 PR2)"
+```
+
+---
+
+### Task 7: One script-parameter schema, canonicalized to strings
+
+**Files:**
+- Create: `packages/shared/src/validators/scriptParameters.ts` + test
+- Modify: `apps/api/src/routes/scripts.ts` (`:273`), `apps/api/src/routes/mobile.ts` (`:307`), `apps/api/src/services/automationRuntime.ts` (`:371`), `apps/api/src/services/scriptDispatch.ts` (payload build `:180`)
+
+**Why:** the wire type is already `map[string]string` (`agent/internal/executor/executor.go:39`) and the agent silently drops every non-string value (`agent/internal/heartbeat/handlers_script.go:40`) — so a `number`/`boolean` parameter, which the UI actively encourages, leaves `{{name}}` verbatim in the script and never sets `BREEZE_PARAM_*`. Canonicalizing at the API is the fix; the agent stays unchanged.
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export const SCRIPT_PARAMETER_KEY_PATTERN: RegExp;          // /^[A-Za-z_][A-Za-z0-9_]{0,63}$/
+  export const MAX_SCRIPT_PARAMETERS: number;                  // 64
+  export const MAX_SCRIPT_PARAMETER_VALUE_LENGTH: number;      // 4096
+  export const scriptParametersSchema: z.ZodType<Record<string, string | number | boolean>>;
+  export function canonicalizeScriptParameters(input: Record<string, string | number | boolean>): Record<string, string>;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+it('accepts strings, finite numbers and booleans', () => {});
+it('rejects null, objects, arrays, NaN and Infinity', () => {});
+it('rejects a key the agent could not turn into an env var name', () => {
+  // 'has space', 'a.b', 'a=b' — see the BREEZE_PARAM_ construction at executor.go:329-343
+});
+it('enforces the count and per-value size caps', () => {});
+it('canonicalizes a number and a boolean to their string forms', () => {
+  expect(canonicalizeScriptParameters({ n: 3, b: true })).toEqual({ n: '3', b: 'true' });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @breeze/shared test -- scriptParameters`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Adopt `scriptParametersSchema` at the three ingresses, and call `canonicalizeScriptParameters` ONCE inside `scriptDispatch.ts` at the payload build (`:180`) so every ingress — including the ones this plan does not touch (`aiToolsScripts`, `aiAgentSdkTools`, `scriptBuilderTools`, `remediationSuggestions`) — gets string values on the wire. Keep the existing 64KB cap on the execute route.
+
+> Note for the reviewer: `agent/internal/userhelper/client.go:743` drops parameters entirely for `runAs: 'user'` runs — a separate, pre-existing outage this PR does NOT fix (it needs a helper IPC change, which is PR 4 territory). File it as a follow-up rather than widening this PR.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @breeze/shared test -- scriptParameters
+pnpm --filter @breeze/api test -- scripts mobile automationRuntime scriptDispatch commandAudit
+```
+Expected: PASS. Several existing fixtures assert today's shape (`routes/scripts.test.ts:512` sends `parameters: { flag: true }`) — update them to the canonicalized expectation rather than loosening the schema.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(api): one script-parameter schema, canonicalized to strings on the wire (#3409 PR2)"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Run everything**
+
+```bash
+pnpm --filter @breeze/shared test
+pnpm --filter @breeze/api test
+pnpm --filter @breeze/web test
+cd apps/web && npx astro check
+cd apps/api && npx vitest run --config vitest.integration.config.ts src/__tests__/integration/tenantVariableResolution.integration.test.ts
+cd apps/api && npx vitest run --config vitest.config.rls-coverage.ts
+pnpm db:check-drift
+```
+
+- [ ] **Step 2: Dispatch CI explicitly — the stacked PR gets none by default**
+
+```bash
+gh workflow run CI --ref ToddHebebrand/tenant-variables-pr2
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** against the scope comment's PR-2 row ("`{{var.*}}` vocabulary + editor picker + per-device resolver (env-first, batch, fail-loud) + software-deploy wiring + shared param schema"):
+
+| Requirement | Task |
+|---|---|
+| `{{var.*}}` vocabulary, `${{...}}` exclusion, other `{{...}}` passes through | 1 |
+| editor picker + warn-only validation | 6 |
+| per-device resolver, batch (one query per snapshot), fail-loud | 2, 4 |
+| org-over-partner precedence | 2 |
+| hard block on `{{var.<secret>}}` at save AND re-check at dispatch | 4, 5 |
+| software-deploy wiring | 5 |
+| shared param schema at all ingresses, canonicalized to strings | 7 |
+| "env-first" delivery | **deliberately deferred to PR 4** — see the deviations table |
+
+Deferred with the PR that owns each: `BREEZE_VAR_*` / `secretEnv` delivery, payload erasure on all terminal transitions, redaction, and effect-digest pinning (PR 4); sourced parameters (PR 3); the `runAs: 'user'` parameter outage (follow-up issue).
+
+**Type consistency:** `replaceVariableTokens` (Task 1) is the only substitution implementation; `substituteTenantVariables` (Task 2) wraps it and is the only caller in the API. `TenantVariableScope` is produced solely by `loadTenantVariableScope` and consumed by `resolveForOrg`. The failure code is spelled `'unresolved_variables'` in Tasks 3 and 4 alike.

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1008,6 +1008,7 @@ export * from './ai';
 
 export * from './tenantVariables';
 export * from './variableTokens';
+export * from './scriptParameters';
 
 // ============================================
 // Ticket Validators

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1007,6 +1007,7 @@ export * from './ai';
 // ============================================
 
 export * from './tenantVariables';
+export * from './variableTokens';
 
 // ============================================
 // Ticket Validators

--- a/packages/shared/src/validators/scriptParameters.test.ts
+++ b/packages/shared/src/validators/scriptParameters.test.ts
@@ -8,6 +8,17 @@ import {
 } from './scriptParameters';
 
 describe('scriptParametersSchema', () => {
+
+  // The agent maps `-` to `_` when building BREEZE_PARAM_* names
+  // (executor.go:329-343), so a hyphenated key works end to end today and
+  // must keep working — rejecting it would be a regression, not a fix.
+  it('accepts a hyphenated key, which the agent normalizes to an underscore', () => {
+    expect(scriptParametersSchema.safeParse({ 'log-level': 'debug' }).success).toBe(true);
+  });
+
+  it('still rejects a leading hyphen', () => {
+    expect(scriptParametersSchema.safeParse({ '-bad': 'x' }).success).toBe(false);
+  });
   it('accepts strings, finite numbers and booleans', () => {
     const result = scriptParametersSchema.safeParse({ s: 'hello', n: 3, b: true, zero: 0, f: false });
     expect(result.success).toBe(true);
@@ -42,7 +53,6 @@ describe('scriptParametersSchema', () => {
     'has space',
     'a.b',
     'a=b',
-    'a-b',
     '9leading',
     '',
   ])('rejects a key the agent could not turn into an env var name: %j', (key) => {

--- a/packages/shared/src/validators/scriptParameters.test.ts
+++ b/packages/shared/src/validators/scriptParameters.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_SCRIPT_PARAMETER_VALUE_LENGTH,
+  MAX_SCRIPT_PARAMETERS,
+  SCRIPT_PARAMETER_KEY_PATTERN,
+  canonicalizeScriptParameters,
+  scriptParametersSchema,
+} from './scriptParameters';
+
+describe('scriptParametersSchema', () => {
+  it('accepts strings, finite numbers and booleans', () => {
+    const result = scriptParametersSchema.safeParse({ s: 'hello', n: 3, b: true, zero: 0, f: false });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects null', () => {
+    expect(scriptParametersSchema.safeParse({ x: null }).success).toBe(false);
+  });
+
+  it('rejects undefined values explicitly present', () => {
+    expect(scriptParametersSchema.safeParse({ x: undefined }).success).toBe(false);
+  });
+
+  it('rejects a nested object value', () => {
+    expect(scriptParametersSchema.safeParse({ x: { nested: true } }).success).toBe(false);
+  });
+
+  it('rejects an array value', () => {
+    expect(scriptParametersSchema.safeParse({ x: [1, 2, 3] }).success).toBe(false);
+  });
+
+  it('rejects NaN', () => {
+    expect(scriptParametersSchema.safeParse({ x: Number.NaN }).success).toBe(false);
+  });
+
+  it('rejects Infinity', () => {
+    expect(scriptParametersSchema.safeParse({ x: Number.POSITIVE_INFINITY }).success).toBe(false);
+    expect(scriptParametersSchema.safeParse({ x: Number.NEGATIVE_INFINITY }).success).toBe(false);
+  });
+
+  it.each([
+    'has space',
+    'a.b',
+    'a=b',
+    'a-b',
+    '9leading',
+    '',
+  ])('rejects a key the agent could not turn into an env var name: %j', (key) => {
+    expect(scriptParametersSchema.safeParse({ [key]: 'v' }).success).toBe(false);
+  });
+
+  it.each(['a', '_a', 'A_b9', 'valid_key'])('accepts a well-formed key: %j', (key) => {
+    expect(scriptParametersSchema.safeParse({ [key]: 'v' }).success).toBe(true);
+  });
+
+  it('matches the documented key pattern directly', () => {
+    expect(SCRIPT_PARAMETER_KEY_PATTERN.test('valid_key')).toBe(true);
+    expect(SCRIPT_PARAMETER_KEY_PATTERN.test('bad key')).toBe(false);
+  });
+
+  it('enforces the parameter-count cap', () => {
+    const tooMany: Record<string, string> = {};
+    for (let i = 0; i < MAX_SCRIPT_PARAMETERS + 1; i++) {
+      tooMany[`k${i}`] = 'v';
+    }
+    expect(scriptParametersSchema.safeParse(tooMany).success).toBe(false);
+
+    const atCap: Record<string, string> = {};
+    for (let i = 0; i < MAX_SCRIPT_PARAMETERS; i++) {
+      atCap[`k${i}`] = 'v';
+    }
+    expect(scriptParametersSchema.safeParse(atCap).success).toBe(true);
+  });
+
+  it('enforces the per-value canonicalized length cap', () => {
+    const tooLong = 'x'.repeat(MAX_SCRIPT_PARAMETER_VALUE_LENGTH + 1);
+    expect(scriptParametersSchema.safeParse({ k: tooLong }).success).toBe(false);
+
+    const atCap = 'x'.repeat(MAX_SCRIPT_PARAMETER_VALUE_LENGTH);
+    expect(scriptParametersSchema.safeParse({ k: atCap }).success).toBe(true);
+  });
+
+  it('measures the length cap against the CANONICALIZED string, not the raw type', () => {
+    // A boolean canonicalizes to 'true'/'false' (4-5 chars) regardless of how
+    // the schema might otherwise weigh a raw boolean — proves the cap check
+    // runs `String(value).length`, not some type-specific short-circuit.
+    expect(scriptParametersSchema.safeParse({ k: true }).success).toBe(true);
+    expect(scriptParametersSchema.safeParse({ k: 123456789 }).success).toBe(true);
+  });
+
+  it('accepts an empty parameters object', () => {
+    expect(scriptParametersSchema.safeParse({}).success).toBe(true);
+  });
+});
+
+describe('canonicalizeScriptParameters', () => {
+  it('canonicalizes a number and a boolean to their string forms', () => {
+    expect(canonicalizeScriptParameters({ n: 3, b: true })).toEqual({ n: '3', b: 'true' });
+  });
+
+  it('canonicalizes false and zero (falsy but present) correctly', () => {
+    expect(canonicalizeScriptParameters({ b: false, n: 0 })).toEqual({ b: 'false', n: '0' });
+  });
+
+  it('leaves an already-string value unchanged', () => {
+    expect(canonicalizeScriptParameters({ s: 'already a string' })).toEqual({ s: 'already a string' });
+  });
+
+  it('returns an empty object for empty input', () => {
+    expect(canonicalizeScriptParameters({})).toEqual({});
+  });
+
+  it('produces a Record<string, string> for every accepted shape', () => {
+    const out = canonicalizeScriptParameters({ s: 'x', n: 1.5, b: true });
+    for (const value of Object.values(out)) {
+      expect(typeof value).toBe('string');
+    }
+  });
+});

--- a/packages/shared/src/validators/scriptParameters.ts
+++ b/packages/shared/src/validators/scriptParameters.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+/**
+ * Script execution parameters (#3409 PR2 Task 7) — the ONE schema for the
+ * `parameters` map a caller attaches to a script run, used at every ingress
+ * (manual execute, mobile device action, automation `run_script` action) and
+ * canonicalized once at dispatch.
+ *
+ * Why this exists: the agent's wire type is `map[string]string`
+ * (`agent/internal/executor/executor.go:39`) and the heartbeat decoder
+ * silently DROPS any parameter whose JSON value isn't already a string
+ * (`agent/internal/heartbeat/handlers_script.go:37-43`, `if s, ok := v.(string); ok`).
+ * The web UI actively produces real JSON numbers and booleans
+ * (`apps/web/src/components/scripts/ScriptExecutionModal.tsx:83-91`), so a
+ * `number`/`boolean` parameter left `{{name}}` unsubstituted in the script and
+ * never set `BREEZE_PARAM_*`. Accepting those JSON types here — then
+ * canonicalizing every value to a string before it reaches the wire — fixes
+ * that without touching the Go agent.
+ */
+
+/**
+ * The agent turns each key into an env var name via
+ * `"BREEZE_PARAM_" + strings.ToUpper(strings.ReplaceAll(key, "-", "_"))`
+ * (`agent/internal/executor/executor.go:329-343`), which only normalizes a
+ * literal `-`. A key containing a space, a dot, an `=`, or any other
+ * shell-meaningful character produces an env var name that is either
+ * unusable (silently dropped by the shell/`os.Environ` builder) or, worse,
+ * injectable (`=` splits an env entry into two). Restricting keys to this
+ * pattern up front guarantees every accepted key survives that
+ * transformation as a single well-formed `BREEZE_PARAM_<NAME>` entry.
+ */
+export const SCRIPT_PARAMETER_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+/** Mirrors the agent's `Parameters map[string]string` payload cap concerns:
+ * bounds both the per-request JSON size and the number of `BREEZE_PARAM_*`
+ * env vars injected into the child process.
+ */
+export const MAX_SCRIPT_PARAMETERS = 64;
+
+/**
+ * Measured against the CANONICALIZED string form (post `String(value)`), not
+ * the raw JSON input — a number/boolean's canonical string is always
+ * shorter than or equal to any pathological raw representation, and this is
+ * the value that actually lands in the env var / substituted template.
+ */
+export const MAX_SCRIPT_PARAMETER_VALUE_LENGTH = 4096;
+
+const scriptParameterKeySchema = z
+  .string()
+  .regex(
+    SCRIPT_PARAMETER_KEY_PATTERN,
+    'Parameter names must start with a letter or underscore and contain only letters, digits, and underscores'
+  );
+
+const scriptParameterValueSchema = z.union([
+  z.string(),
+  z.number().finite(),
+  z.boolean(),
+]);
+
+/**
+ * The single script-parameter schema. Accepts strings, finite numbers, and
+ * booleans — rejects null, undefined, objects, arrays, NaN, and Infinity
+ * (all rejected implicitly: `z.union` above has no branch for them, and
+ * `.finite()` excludes NaN/Infinity from the number branch).
+ */
+export const scriptParametersSchema: z.ZodType<Record<string, string | number | boolean>> = z
+  .record(scriptParameterKeySchema, scriptParameterValueSchema)
+  .refine((val) => Object.keys(val).length <= MAX_SCRIPT_PARAMETERS, {
+    message: `Cannot supply more than ${MAX_SCRIPT_PARAMETERS} script parameters`,
+  })
+  .refine(
+    (val) => Object.values(val).every((v) => String(v).length <= MAX_SCRIPT_PARAMETER_VALUE_LENGTH),
+    { message: `Each script parameter value must canonicalize to at most ${MAX_SCRIPT_PARAMETER_VALUE_LENGTH} characters` }
+  );
+
+/**
+ * Canonicalizes every parameter value to its string wire form —
+ * `String(value)`, i.e. `3` -> `'3'`, `true` -> `'true'` — so the payload
+ * that reaches the agent is always `map[string]string`, matching
+ * `agent/internal/executor/executor.go:39` exactly. Call this ONCE, at the
+ * single dispatch chokepoint (`scriptDispatch.ts`), so every ingress —
+ * including ones that don't validate through `scriptParametersSchema`
+ * directly — gets string values on the wire.
+ */
+export function canonicalizeScriptParameters(
+  input: Record<string, string | number | boolean>
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input)) {
+    result[key] = String(value);
+  }
+  return result;
+}

--- a/packages/shared/src/validators/scriptParameters.ts
+++ b/packages/shared/src/validators/scriptParameters.ts
@@ -28,8 +28,14 @@ import { z } from 'zod';
  * injectable (`=` splits an env entry into two). Restricting keys to this
  * pattern up front guarantees every accepted key survives that
  * transformation as a single well-formed `BREEZE_PARAM_<NAME>` entry.
+ *
+ * A hyphen IS allowed (after the first character) precisely because the agent
+ * normalizes it: `log-level` becomes `BREEZE_PARAM_LOG_LEVEL`, and
+ * `{{log-level}}` substitutes by plain string replacement. Excluding it would
+ * have made this schema REJECT parameter names that work end to end today —
+ * tightening into a regression rather than fixing one.
  */
-export const SCRIPT_PARAMETER_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+export const SCRIPT_PARAMETER_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]{0,63}$/;
 
 /** Mirrors the agent's `Parameters map[string]string` payload cap concerns:
  * bounds both the per-request JSON size and the number of `BREEZE_PARAM_*`

--- a/packages/shared/src/validators/variableTokens.test.ts
+++ b/packages/shared/src/validators/variableTokens.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { findVariableTokens, replaceVariableTokens, variableToken } from './variableTokens';
+import {
+  findVariableTokens,
+  hasVariableTokens,
+  replaceVariableTokens,
+  variableToken,
+} from './variableTokens';
 
 describe('findVariableTokens', () => {
   it('finds a well-formed token', () => {
@@ -73,5 +78,30 @@ describe('replaceVariableTokens', () => {
 
   it('round-trips variableToken', () => {
     expect(replaceVariableTokens(variableToken('k'), () => 'v').content).toBe('v');
+  });
+});
+
+describe('shared-regex state isolation', () => {
+  // Regression: VARIABLE_TOKEN_PATTERN used to be a module-level GLOBAL regex.
+  // `.test()` advanced its lastIndex and `matchAll` seeds its matcher from the
+  // regex it is handed, so a hasVariableTokens() call left an offset that made
+  // the next findVariableTokens() skip every token before it. API requests
+  // interleave across awaits, so this desynchronised unrelated requests.
+  it('findVariableTokens is unaffected by a preceding hasVariableTokens call', () => {
+    const content = 'echo {{var.api_key}} then {{var.region}}';
+    expect(findVariableTokens(content)).toEqual(['api_key', 'region']);
+    expect(hasVariableTokens(content)).toBe(true);
+    expect(findVariableTokens(content)).toEqual(['api_key', 'region']);
+  });
+
+  it('tokenizes a short template after hasVariableTokens ran on a longer one', () => {
+    expect(hasVariableTokens('a much longer script body with {{var.some_key}} inside')).toBe(true);
+    // The installerVariables.ts shape: findVariableTokens on an isolated match.
+    expect(findVariableTokens('{{var.api_key}}')).toEqual(['api_key']);
+  });
+
+  it('replaceVariableTokens is unaffected by a preceding hasVariableTokens call', () => {
+    expect(hasVariableTokens('{{var.a}} {{var.b}}')).toBe(true);
+    expect(replaceVariableTokens('{{var.a}} {{var.b}}', (k) => k.toUpperCase()).content).toBe('A B');
   });
 });

--- a/packages/shared/src/validators/variableTokens.test.ts
+++ b/packages/shared/src/validators/variableTokens.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { findVariableTokens, replaceVariableTokens, variableToken } from './variableTokens';
+
+describe('findVariableTokens', () => {
+  it('finds a well-formed token', () => {
+    expect(findVariableTokens('curl {{var.repo_url}}/pkg')).toEqual(['repo_url']);
+  });
+
+  it('de-duplicates and preserves first-seen order', () => {
+    expect(findVariableTokens('{{var.b}} {{var.a}} {{var.b}}')).toEqual(['b', 'a']);
+  });
+
+  it('ignores a token escaped by a leading $ — that is shell/Actions syntax', () => {
+    expect(findVariableTokens('run ${{var.repo_url}}')).toEqual([]);
+  });
+
+  it.each([
+    '{{ var.x }}',        // inner whitespace: one strict form only
+    '{{VAR.X}}',          // case-sensitive
+    '{{var.9bad}}',       // key grammar
+    '{{var.Bad_Key}}',
+    '{{var.}}',
+    '{{var.x}',           // unbalanced
+    '{{varx}}',           // no dot
+    '{{org.name}}',       // a different namespace passes through
+    '{file}',             // the agent's own single-brace token
+  ])('does not treat %j as a variable token', (input) => {
+    expect(findVariableTokens(input)).toEqual([]);
+  });
+
+  it('leaves an unrelated {{...}} expression alone', () => {
+    const gha = 'if: ${{ github.event_name == \'push\' }}';
+    expect(findVariableTokens(gha)).toEqual([]);
+  });
+});
+
+describe('replaceVariableTokens', () => {
+  it('substitutes verbatim, with no escaping', () => {
+    const out = replaceVariableTokens('token={{var.k}}', (k) => (k === 'k' ? 'a b"c' : undefined));
+    expect(out).toEqual({ content: 'token=a b"c', unresolved: [] });
+  });
+
+  it('reports an unknown key and leaves the token in place', () => {
+    const out = replaceVariableTokens('{{var.missing}}', () => undefined);
+    expect(out).toEqual({ content: '{{var.missing}}', unresolved: ['missing'] });
+  });
+
+  it('treats an empty value as unresolved', () => {
+    const out = replaceVariableTokens('{{var.blank}}', () => '');
+    expect(out.unresolved).toEqual(['blank']);
+    expect(out.content).toBe('{{var.blank}}');
+  });
+
+  it('never re-scans a substituted value (no recursive expansion)', () => {
+    const out = replaceVariableTokens('{{var.a}}', (k) => (k === 'a' ? '{{var.b}}' : 'SHOULD-NOT-APPEAR'));
+    expect(out.content).toBe('{{var.b}}');
+  });
+
+  it('leaves a $-escaped token untouched', () => {
+    const out = replaceVariableTokens('${{var.k}}', () => 'v');
+    expect(out).toEqual({ content: '${{var.k}}', unresolved: [] });
+  });
+
+  it('round-trips variableToken', () => {
+    expect(replaceVariableTokens(variableToken('k'), () => 'v').content).toBe('v');
+  });
+});

--- a/packages/shared/src/validators/variableTokens.test.ts
+++ b/packages/shared/src/validators/variableTokens.test.ts
@@ -61,6 +61,16 @@ describe('replaceVariableTokens', () => {
     expect(out).toEqual({ content: '${{var.k}}', unresolved: [] });
   });
 
+  it('de-duplicates unresolved keys — one missing variable, not three', () => {
+    const out = replaceVariableTokens('{{var.x}} {{var.x}} {{var.x}}', () => undefined);
+    expect(out.unresolved).toEqual(['x']);
+  });
+
+  it('inserts a value containing $& or $1 verbatim, not as a replacement pattern', () => {
+    expect(replaceVariableTokens('{{var.k}}', () => 'a$&b').content).toBe('a$&b');
+    expect(replaceVariableTokens('{{var.k}}', () => '$1').content).toBe('$1');
+  });
+
   it('round-trips variableToken', () => {
     expect(replaceVariableTokens(variableToken('k'), () => 'v').content).toBe('v');
   });

--- a/packages/shared/src/validators/variableTokens.ts
+++ b/packages/shared/src/validators/variableTokens.ts
@@ -1,0 +1,87 @@
+/**
+ * The `{{var.<key>}}` content token grammar (#3409 PR2) — shared by the API
+ * (dispatch-time resolution, save-time secret rejection) and the web (script
+ * editor picker, warn-only validation) so the two surfaces can never diverge.
+ */
+
+/**
+ * `{{var.<key>}}` — no inner whitespace, key grammar enforced (mirrors
+ * TENANT_VARIABLE_KEY_PATTERN in ./tenantVariables), `${{...}}` excluded.
+ *
+ * The `(?<!\$)` lookbehind rejects a token immediately preceded by `$`
+ * without consuming that character, so match offsets stay clean for
+ * `String.replace`. A leading `$` means the author wrote shell or GitHub
+ * Actions syntax (`${{ github.event_name }}`), not a Breeze variable — this
+ * grammar must never eat that construct.
+ *
+ * There is exactly ONE strict token form (no inner whitespace). The existing
+ * installer tokenizer normalizes whitespace on the client but only trims on
+ * the server (`apps/web/src/lib/installerVariables.ts:83` vs
+ * `apps/api/src/services/installerVariables.ts:79`), which already produces
+ * client-passes/server-fails divergence for that namespace. Do not extend
+ * that bug into `var.*` — both sides import this one pattern.
+ *
+ * Global: use with `matchAll` / `String.replace`, never `.test()` in a loop
+ * (a global regex is stateful via `lastIndex`).
+ */
+export const VARIABLE_TOKEN_PATTERN = /(?<!\$)\{\{var\.([a-z][a-z0-9_]{0,63})\}\}/g;
+
+/** `{{var.<key>}}` — the inverse of matching: build a token to insert a key. */
+export function variableToken(key: string): string {
+  return `{{var.${key}}}`;
+}
+
+/** Unique keys referenced in `content`, in first-seen order. */
+export function findVariableTokens(content: string): string[] {
+  const seen = new Set<string>();
+  for (const match of content.matchAll(VARIABLE_TOKEN_PATTERN)) {
+    // The capture group always participates when the outer pattern matches
+    // (it is not itself optional); the `| undefined` in its type is only
+    // TS's general capture-group typing under noUncheckedIndexedAccess.
+    const key = match[1];
+    if (key !== undefined) seen.add(key);
+  }
+  return [...seen];
+}
+
+export function hasVariableTokens(content: string): boolean {
+  // .test() on a global regex mutates lastIndex; reset first so a caller
+  // reusing VARIABLE_TOKEN_PATTERN elsewhere never sees a stale offset.
+  VARIABLE_TOKEN_PATTERN.lastIndex = 0;
+  return VARIABLE_TOKEN_PATTERN.test(content);
+}
+
+export interface SubstitutedVariableTokens {
+  content: string;
+  unresolved: string[];
+}
+
+/**
+ * Substitute every `{{var.<key>}}` token in `content` with `lookup(key)`.
+ *
+ * A SINGLE `String.replace` pass drives the whole substitution, so a value
+ * that itself contains `{{var.*}}` text is never re-scanned — no recursive
+ * expansion, by construction rather than by a depth guard.
+ *
+ * `lookup` returning `undefined`, `null`, or `''` means the key is
+ * UNRESOLVED: it is pushed to `unresolved` and the original token is left
+ * untouched in the output, rather than collapsing to an empty string. An
+ * empty value is unresolved for the same reason the existing installer
+ * tokenizer treats it that way (`installerVariables.ts` `resolveKey`) — a
+ * blank substitution should fail loudly, not ship silently as nothing.
+ */
+export function replaceVariableTokens(
+  content: string,
+  lookup: (key: string) => string | undefined | null
+): SubstitutedVariableTokens {
+  const unresolved: string[] = [];
+  const substituted = content.replace(VARIABLE_TOKEN_PATTERN, (token, key: string) => {
+    const value = lookup(key);
+    if (value === undefined || value === null || value === '') {
+      unresolved.push(key);
+      return token;
+    }
+    return value;
+  });
+  return { content: substituted, unresolved };
+}

--- a/packages/shared/src/validators/variableTokens.ts
+++ b/packages/shared/src/validators/variableTokens.ts
@@ -64,24 +64,31 @@ export interface SubstitutedVariableTokens {
  * expansion, by construction rather than by a depth guard.
  *
  * `lookup` returning `undefined`, `null`, or `''` means the key is
- * UNRESOLVED: it is pushed to `unresolved` and the original token is left
+ * UNRESOLVED: it is reported in `unresolved` and the original token is left
  * untouched in the output, rather than collapsing to an empty string. An
  * empty value is unresolved for the same reason the existing installer
  * tokenizer treats it that way (`installerVariables.ts` `resolveKey`) — a
  * blank substitution should fail loudly, not ship silently as nothing.
+ *
+ * `unresolved` is de-duplicated: it feeds a user-facing failure message, and
+ * a key written three times in one script is still one missing variable.
+ *
+ * Note the replacement is a FUNCTION, not a string — so a value containing
+ * `$&` or `$1` is inserted verbatim instead of being re-interpreted as a
+ * replacement pattern. Values substitute exactly as stored, with no escaping.
  */
 export function replaceVariableTokens(
   content: string,
   lookup: (key: string) => string | undefined | null
 ): SubstitutedVariableTokens {
-  const unresolved: string[] = [];
+  const unresolved = new Set<string>();
   const substituted = content.replace(VARIABLE_TOKEN_PATTERN, (token, key: string) => {
     const value = lookup(key);
     if (value === undefined || value === null || value === '') {
-      unresolved.push(key);
+      unresolved.add(key);
       return token;
     }
     return value;
   });
-  return { content: substituted, unresolved };
+  return { content: substituted, unresolved: [...unresolved] };
 }

--- a/packages/shared/src/validators/variableTokens.ts
+++ b/packages/shared/src/validators/variableTokens.ts
@@ -21,10 +21,31 @@
  * client-passes/server-fails divergence for that namespace. Do not extend
  * that bug into `var.*` — both sides import this one pattern.
  *
- * Global: use with `matchAll` / `String.replace`, never `.test()` in a loop
- * (a global regex is stateful via `lastIndex`).
+ * NOT global, and deliberately so: a module-level global regex carries
+ * mutable `lastIndex` state, and every consumer here shares this one module
+ * instance across the whole process. `.test()` on a global regex advances
+ * `lastIndex`, and `String.prototype.matchAll` SEEDS its internal matcher from
+ * the regex it is handed — so one `hasVariableTokens()` call would leave an
+ * offset behind that made a later `findVariableTokens()` silently skip every
+ * token before it. Since API requests interleave across `await` points, that
+ * desynchronised two different requests through one shared offset.
+ *
+ * Scanning for ALL tokens therefore goes through
+ * {@link createVariableTokenMatcher}, which mints a fresh, independently
+ * stateful matcher per call. This constant stays non-global so that sharing it
+ * is safe: `.test()` and `.exec()` on a non-global regex never touch
+ * `lastIndex`.
  */
-export const VARIABLE_TOKEN_PATTERN = /(?<!\$)\{\{var\.([a-z][a-z0-9_]{0,63})\}\}/g;
+export const VARIABLE_TOKEN_PATTERN = /(?<!\$)\{\{var\.([a-z][a-z0-9_]{0,63})\}\}/;
+
+/**
+ * A FRESH global matcher for the token grammar. Never hoist the result into a
+ * shared binding — `lastIndex` is per-instance state, and sharing one instance
+ * across calls is exactly the bug the comment above describes.
+ */
+export function createVariableTokenMatcher(): RegExp {
+  return new RegExp(VARIABLE_TOKEN_PATTERN.source, 'g');
+}
 
 /** `{{var.<key>}}` — the inverse of matching: build a token to insert a key. */
 export function variableToken(key: string): string {
@@ -34,7 +55,7 @@ export function variableToken(key: string): string {
 /** Unique keys referenced in `content`, in first-seen order. */
 export function findVariableTokens(content: string): string[] {
   const seen = new Set<string>();
-  for (const match of content.matchAll(VARIABLE_TOKEN_PATTERN)) {
+  for (const match of content.matchAll(createVariableTokenMatcher())) {
     // The capture group always participates when the outer pattern matches
     // (it is not itself optional); the `| undefined` in its type is only
     // TS's general capture-group typing under noUncheckedIndexedAccess.
@@ -45,9 +66,8 @@ export function findVariableTokens(content: string): string[] {
 }
 
 export function hasVariableTokens(content: string): boolean {
-  // .test() on a global regex mutates lastIndex; reset first so a caller
-  // reusing VARIABLE_TOKEN_PATTERN elsewhere never sees a stale offset.
-  VARIABLE_TOKEN_PATTERN.lastIndex = 0;
+  // Safe to share the module-level instance: VARIABLE_TOKEN_PATTERN is
+  // non-global, so .test() leaves no lastIndex behind for the next caller.
   return VARIABLE_TOKEN_PATTERN.test(content);
 }
 
@@ -82,7 +102,7 @@ export function replaceVariableTokens(
   lookup: (key: string) => string | undefined | null
 ): SubstitutedVariableTokens {
   const unresolved = new Set<string>();
-  const substituted = content.replace(VARIABLE_TOKEN_PATTERN, (token, key: string) => {
+  const substituted = content.replace(createVariableTokenMatcher(), (token, key: string) => {
     const value = lookup(key);
     if (value === undefined || value === null || value === '') {
       unresolved.add(key);


### PR DESCRIPTION
Part 2 of the tenant-variables stack for #3409. **Stacked on `ToddHebebrand/tenant-variables-pr1` — review and merge PR1 first.**

## What this delivers

PR1's variables become live. A `{{var.<key>}}` token written into a script body — or into a software installer URL / silent-install argument — resolves server-side **per target device** to that device's org value, falling back to the partner-wide value. A device whose token can't be resolved now fails loudly with its own `failed` execution row instead of receiving a literal `{{var...}}`, and the rest of the fan-out still runs. Script authors get an insert-variable picker in the Monaco editor with warn-only unknown-key validation, plus a new **Variables** group in the software-deployment picker.

Secret variables cannot be referenced in content in v1: `{{var.<secret_key>}}` is a 400 at script save/import and a per-device failure at dispatch. PR4 adds the out-of-band delivery that makes secrets usable.

## Design decisions worth a reviewer's attention

**Resolution never rides ambient RLS.** The five dispatch call sites run under three different DB contexts and would otherwise resolve *different variable sets for the same script*. `loadTenantVariableScope` runs inside `runOutsideDbContext(() => withSystemDbAccessContext(...))` — **both wrappers are required**. A bare system context nested in a held request transaction does not elevate, and an org token whose JWT lacks `partnerId` would then see zero partner-wide rows. The cost of that decision: RLS no longer constrains the load, so the `WHERE` clause is the **only** tenancy boundary and has to be exact. That is what the new integration suite exists to pin.

**Opaque snapshot, verified at use.** `TenantVariableScope` is produced solely by `loadTenantVariableScope`, carries the org ids it was built for, and `resolveForOrg` **throws** if asked for an org outside that set.

**One chokepoint.** Substitution happens in `scriptDispatch.ts` between field resolution and the `script_executions` insert, so every ingress inherits it and a failed device never leaves an orphan `pending` row. A `hasVariableTokens` guard keeps the token-free path allocation- and query-free — preloading unconditionally was a measurable hot-path regression, since every script run escaped the request transaction for a second connection to build a snapshot nothing consulted.

**`${{var.x}}` is deliberately NOT a token**, and `{{ var.x }}` (inner whitespace) is not either. A `$` before `{{` means the author wrote shell/Actions syntax. This diverges from the existing installer tokenizer, which eats both — that tokenizer has a client-strips/server-trims divergence, and this PR refuses to extend that bug into the new namespace. Enforced with a lookbehind. Every other `{{...}}` form (Actions, Jinja, brace expansion, `{{org.name}}`, `{file}`) passes through verbatim.

**No recursive expansion** — a single `String.replace` pass, so a substituted value is never re-scanned. Empty string counts as unresolved (matching `resolveKey`'s existing rule), as does an undecryptable row — omitted and logged by id, never resolved to `''`. `{kind:'raw'}` `execute_command` sources are skipped: no declaring script, so nothing could have been validated at save time.

**Unknown keys are warn-only** at save and in the UI, since a key may be created after the script; only the secret rule hard-blocks. A failed key-list fetch in the UI degrades to an empty list and suppresses warnings rather than showing false positives.

## Deliberate deviations from the scope comment

1. **No env injection at all** — textual substitution only, where the scope called for `BREEZE_VAR_<UPPER_KEY>` env vars. The agent has no `BREEZE_VAR_*` handling until PR4, and the only env channel that exists today is the `parameters` map, which the agent substitutes into script *text* as well as mirroring to `BREEZE_PARAM_*`. Routing variables through it would make every value textually substitutable — exactly the leak PR4's separate `secretEnv` channel exists to prevent. "env-first delivery" is therefore deferred to PR4.
2. **Snapshot verification made explicit** — the snapshot carries its org ids and dispatch throws on an out-of-scope org.

## ⚠️ Behaviour changes for existing users — release-note these

**1. Script parameters are now strictly validated and canonicalized to strings.** One shared `scriptParametersSchema` is adopted at `routes/scripts.ts`, `routes/mobile.ts`, and `automationRuntime.ts`, with `canonicalizeScriptParameters` called once at the `scriptDispatch.ts` payload build so every ingress puts strings on the wire. Now **rejected**: `null`, objects, arrays, `NaN`, `Infinity`, and keys the agent could not turn into an env var name (`has space`, `a.b`, `a=b`). Caps: 64 parameters, 4096 chars per value. Numbers and booleans are now accepted and coerced.

This **fixes a silent pre-existing outage**: the wire type is `map[string]string` and the agent silently dropped every non-string value, so a number or boolean parameter — which the UI actively encourages — left `{{name}}` verbatim in the script and never set `BREEZE_PARAM_*`. But it also means **callers currently sending malformed parameters get a validation error instead of a silent drop**. `normalizeAutomationActions` runs at *runtime* against stored actions, so existing automations with malformed parameters fail loudly rather than silently dropping them.

**2. Script fan-out no longer aborts on the first per-device failure.** `executeScriptOnDevices` previously threw, so devices after the failing one never got a row and the batch's `devicesTargeted` was a lie. Now the device gets a `script_executions` row with `status: 'failed'` and a non-empty `errorMessage`, counts toward `devicesFailed`, and the fan-out continues. `insert_failed` still throws — it signals a programming error. New failure code `'unresolved_variables'`.

**3. Existing content containing a strictly-well-formed `{{var.<key>}}` string is no longer passed through verbatim** — it is substituted, or the device fails with `unresolved_variables`. `${{var.x}}` and whitespace/other-namespace forms are unaffected.

**4. Saving or importing a script that references a secret variable is now a 400** (create, update, and bundle import). A script saved before the variable was flipped to secret still fails per-device at dispatch.

**5. The four-eyes effect digest is NOT extended in this PR.** It hashes `scripts.content` — the *template* — at both pin and release, so a variable's *value* changing between approval and release does not invalidate the digest. PR4 closes this. Calling it out explicitly so review doesn't assume otherwise.

## Testing

No migrations and no new tables — this consumes PR1's `tenant_variables` and its dual-axis shape.

Unit: `variableTokens`, `scriptParameters`, `tenantVariableResolution`, plus `scriptDispatch`, `scriptExecution`, `automationRuntime`, `aiToolsScripts`, `installerVariables`, `softwareDeployment`, `scriptBundle`, `mobile`, `commandAudit`. Web: `VariableInput`, `ScriptVariablePicker`, `ScriptForm`, `installerVariables`, locale parity, plus `astro check`.

New contract suite `tenantVariableResolution.integration.test.ts` proves against real Postgres: org-shadows-partner precedence, partner inheritance, no cross-partner leakage, a two-org snapshot resolving independently in one call, **resolution working from inside an org-scoped `withDbAccessContext`** (delete the system-context escape and this test must fail), and secret exclusion. `loadTenantVariableScope` issuing exactly one query per snapshot is asserted.

Existing fixtures that asserted the old parameter shape were **updated to the canonicalized expectation rather than loosening the schema**.

## CI note

`ci.yml` triggers on `pull_request: branches: [main]`, so this stacked PR gets **no CI** while `gh pr checks` reads green. Dispatch it explicitly before merge:

```
gh workflow run CI --ref ToddHebebrand/tenant-variables-pr2
```

## Out of scope

`BREEZE_VAR_*` / `secretEnv` delivery, payload erasure on all terminal transitions, redaction, and effect-digest pinning → **PR4**. Sourced parameters → **PR3**. **No agent (Go) changes here.** A separate pre-existing outage — the user-helper client drops parameters entirely for `runAs: 'user'` runs — is deliberately not fixed here (it needs a helper IPC change, PR4 territory) and is filed as a follow-up.
