### PR TITLE
fix(api): persist send_email_reason on the direct quote send path

### DIFF
--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -387,7 +387,8 @@ describe('sendQuote email delivery status', () => {
   it('reports no_billing_contact (and sends nothing) when the org has no billing email', async () => {
     queueThroughClaim({ name: 'Customer Co', taxId: null, billingContact: null });
     // No billingContact → the email branch short-circuits before the
-    // portalBranding read, straight to the final re-select.
+    // portalBranding read, straight to the outcome marker and the re-select.
+    queueResult([]); // outcome-marker update
     queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent' }]);
 
     const result = await sendQuote('q1', actor);
@@ -401,6 +402,7 @@ describe('sendQuote email delivery status', () => {
   it('reports send_failed when the email provider throws (send still commits)', async () => {
     queueThroughClaim({ name: 'Customer Co', taxId: null, billingContact: { email: 'billing@customer.example' } });
     queueResult([]); // portalBranding — none configured
+    queueResult([]); // outcome-marker update
     queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent' }]); // final re-select
     sendEmailMock.mockRejectedValue(new Error('smtp down'));
 
@@ -414,6 +416,7 @@ describe('sendQuote email delivery status', () => {
   it('reports pdf_render_failed (and never calls the email transport) when building the attachment throws', async () => {
     queueThroughClaim({ name: 'Customer Co', taxId: null, billingContact: { email: 'billing@customer.example' } });
     queueResult([]); // portalBranding — none configured
+    queueResult([]); // outcome-marker update
     queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent' }]); // final re-select
     vi.mocked(renderQuotePdf).mockRejectedValueOnce(new Error('pdfkit blew up'));
 
@@ -423,6 +426,34 @@ describe('sendQuote email delivery status', () => {
     expect(result.emailReason).toBe('pdf_render_failed');
     expect(sendEmailMock).not.toHaveBeenCalled(); // never reached the transport
     expect(result.quote.status).toBe('sent'); // the send itself still commits
+  });
+
+  // #3502: a direct send that fails delivery must leave a marker, or the detail
+  // page shows "Sent" with no banner and the customer silently got nothing.
+  it('persists send_email_reason so a failed direct send raises the banner', async () => {
+    queueThroughClaim({ name: 'Customer Co', taxId: null, billingContact: { email: 'billing@customer.example' } });
+    queueResult([]); // portalBranding — none configured
+    queueResult([]); // outcome-marker update
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent', sendEmailReason: 'send_failed' }]);
+    sendEmailMock.mockRejectedValue(new Error('smtp down'));
+
+    const result = await sendQuote('q1', actor);
+
+    expect(result.emailReason).toBe('send_failed');
+    // The write itself, not just the returned row: the banner reads the column.
+    expect(setCalls.some((p) => p.sendEmailReason === 'send_failed')).toBe(true);
+  });
+
+  it('writes no outcome marker when the send succeeds (the claim already cleared it)', async () => {
+    queueThroughClaim({ name: 'Customer Co', taxId: null, billingContact: { email: 'billing@customer.example' } });
+    queueResult([]); // portalBranding — none configured
+    queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent' }]); // final re-select
+
+    const result = await sendQuote('q1', actor);
+
+    expect(result.emailed).toBe(true);
+    expect(result.emailReason).toBeUndefined();
+    expect(setCalls.some((p) => p.sendEmailReason === 'send_failed')).toBe(false);
   });
 
   it('reports emailed:true with no reason on a successful send', async () => {

--- a/apps/api/src/services/quoteLifecycle.test.ts
+++ b/apps/api/src/services/quoteLifecycle.test.ts
@@ -444,7 +444,7 @@ describe('sendQuote email delivery status', () => {
     expect(setCalls.some((p) => p.sendEmailReason === 'send_failed')).toBe(true);
   });
 
-  it('writes no outcome marker when the send succeeds (the claim already cleared it)', async () => {
+  it('writes exactly one sendEmailReason on a successful send: the claim clearing it', async () => {
     queueThroughClaim({ name: 'Customer Co', taxId: null, billingContact: { email: 'billing@customer.example' } });
     queueResult([]); // portalBranding — none configured
     queueResult([{ id: 'q1', orgId: 'org1', partnerId: 'p1', status: 'sent' }]); // final re-select
@@ -453,7 +453,13 @@ describe('sendQuote email delivery status', () => {
 
     expect(result.emailed).toBe(true);
     expect(result.emailReason).toBeUndefined();
-    expect(setCalls.some((p) => p.sendEmailReason === 'send_failed')).toBe(false);
+    // Exactly one `.set()` carries sendEmailReason (the draft→sent claim, which
+    // clears it) — a successful send must not add a second bookkeeping write.
+    // Asserting the COUNT rather than the absence of a value: a stray
+    // `{ sendEmailReason: null }` update would slip past a value-only check.
+    const reasonWrites = setCalls.filter((p) => 'sendEmailReason' in p);
+    expect(reasonWrites).toHaveLength(1);
+    expect(reasonWrites[0]?.sendEmailReason).toBeNull();
   });
 
   it('reports emailed:true with no reason on a successful send', async () => {

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -247,8 +247,15 @@ export async function sendQuote(
   // status flip, which is the honest outcome — the email having already left is
   // a pre-existing property of sending inside the request transaction, not
   // something this write introduces.
+  // Scoped by orgId as well as id, not because the request path needs it (forced
+  // RLS covers that, and getQuote already enforced actor access) but because the
+  // scheduled-send worker calls this under a SYSTEM context where RLS is not the
+  // boundary. An id-only write there has nothing but the id standing between it
+  // and the wrong row.
   if (emailReason) {
-    await db.update(quotes).set({ sendEmailReason: emailReason, updatedAt: new Date() }).where(eq(quotes.id, id));
+    await db.update(quotes)
+      .set({ sendEmailReason: emailReason, updatedAt: new Date() })
+      .where(and(eq(quotes.id, id), eq(quotes.orgId, quote.orgId)));
   }
 
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -231,6 +231,25 @@ export async function sendQuote(
     quote, blocks, lines, partnerRow, quoteNumber, acceptUrl, frozenQuote, billingRecipient, opts,
   });
 
+  // Persist THIS attempt's outcome, matching resendQuote and the scheduled-send
+  // worker: without it a direct send whose PDF render or transport failed is
+  // marked sent with send_email_reason NULL, so the detail page's "no email was
+  // delivered" banner never fires and nobody learns the customer got nothing.
+  // The draft→sent claim above already cleared the column, so only a failure
+  // needs writing back.
+  //
+  // Bookkeeping only, and it runs AFTER the email has left: a throw here would
+  // surface as "could not send" for a message the customer already has, and the
+  // tech's natural next move is to send it a second time. Swallow it instead.
+  if (emailReason) {
+    try {
+      await db.update(quotes).set({ sendEmailReason: emailReason, updatedAt: new Date() }).where(eq(quotes.id, id));
+    } catch (err) {
+      console.error(`[quoteLifecycle] send delivered for quote ${id} but persisting its outcome failed:`, err);
+      captureException(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);
   return { quote: updated!, emailed, emailReason, acceptUrl };
 }
@@ -290,14 +309,12 @@ interface DeliverQuoteEmailInput {
  * Best effort by contract: every failure is swallowed into an `emailReason` so
  * the caller's transaction still commits.
  *
- * Callers differ in what they do with that reason, and the difference is
- * user-visible: resendQuote and the scheduled-send worker
- * (jobs/quoteSendQueue.ts) PERSIST it to quotes.send_email_reason, which is
- * what raises the detail page's "no email was delivered" banner. The direct
- * sendQuote path returns it in the response only — so a failed immediate send
- * (MCP, bulk-send, a body-less POST /send) leaves send_email_reason NULL and
- * shows no banner. That gap predates this function and is NOT fixed here; do
- * not assume symmetry when debugging a missing banner.
+ * All three callers persist that reason to quotes.send_email_reason, which is
+ * what raises the detail page's "no email was delivered" banner: sendQuote,
+ * resendQuote, and the scheduled-send worker (jobs/quoteSendQueue.ts). Keep it
+ * that way when adding a fourth. A caller that only returns the reason marks
+ * the quote sent with the column NULL, so the banner never fires and nobody
+ * learns the customer received nothing (#3502).
  */
 async function deliverQuoteEmail(
   { quote, blocks, lines, partnerRow, quoteNumber, acceptUrl, frozenQuote, billingRecipient, opts }: DeliverQuoteEmailInput,

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -238,16 +238,17 @@ export async function sendQuote(
   // The draft→sent claim above already cleared the column, so only a failure
   // needs writing back.
   //
-  // Bookkeeping only, and it runs AFTER the email has left: a throw here would
-  // surface as "could not send" for a message the customer already has, and the
-  // tech's natural next move is to send it a second time. Swallow it instead.
+  // Deliberately NOT wrapped in try/catch. This runs inside the request-wide
+  // transaction opened by withDbAccessContext, so a statement error here leaves
+  // that transaction aborted: catching the rejection would not roll back to a
+  // savepoint, the re-select below would fail with "current transaction is
+  // aborted" anyway, and the whole draft→sent claim would roll back regardless.
+  // A catch would only hide where it started. Failing here is atomic with the
+  // status flip, which is the honest outcome — the email having already left is
+  // a pre-existing property of sending inside the request transaction, not
+  // something this write introduces.
   if (emailReason) {
-    try {
-      await db.update(quotes).set({ sendEmailReason: emailReason, updatedAt: new Date() }).where(eq(quotes.id, id));
-    } catch (err) {
-      console.error(`[quoteLifecycle] send delivered for quote ${id} but persisting its outcome failed:`, err);
-      captureException(err instanceof Error ? err : new Error(String(err)));
-    }
+    await db.update(quotes).set({ sendEmailReason: emailReason, updatedAt: new Date() }).where(eq(quotes.id, id));
   }
 
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);

--- a/apps/api/src/services/quoteLifecycle.ts
+++ b/apps/api/src/services/quoteLifecycle.ts
@@ -247,15 +247,15 @@ export async function sendQuote(
   // status flip, which is the honest outcome — the email having already left is
   // a pre-existing property of sending inside the request transaction, not
   // something this write introduces.
-  // Scoped by orgId as well as id, not because the request path needs it (forced
-  // RLS covers that, and getQuote already enforced actor access) but because the
-  // scheduled-send worker calls this under a SYSTEM context where RLS is not the
-  // boundary. An id-only write there has nothing but the id standing between it
-  // and the wrong row.
+  // Matched on id alone, deliberately: the SAME predicate the draft→sent claim
+  // above used. Adding `orgId` here looks like defence-in-depth and is not —
+  // `quote` was read BEFORE the claim, and updateQuote can reassign a draft's
+  // org (quoteService.ts, `set.orgId = targetOrgId`). A concurrent move would
+  // leave the claim succeeding on id+status while this write matched ZERO rows
+  // against the stale org, silently losing the outcome this function exists to
+  // record. Keep the write bound to the row the claim actually took.
   if (emailReason) {
-    await db.update(quotes)
-      .set({ sendEmailReason: emailReason, updatedAt: new Date() })
-      .where(and(eq(quotes.id, id), eq(quotes.orgId, quote.orgId)));
+    await db.update(quotes).set({ sendEmailReason: emailReason, updatedAt: new Date() }).where(eq(quotes.id, id));
   }
 
   const [updated] = await db.select().from(quotes).where(eq(quotes.id, id)).limit(1);


### PR DESCRIPTION
Fixes #3502.

`sendQuote` swallows every delivery failure into an `emailReason` so the send still commits, but it was the only one of the three send paths that never wrote that reason to `quotes.send_email_reason`:

| Path | Persisted before | Now |
|---|---|---|
| `resendQuote` | yes | yes |
| scheduled send worker (`jobs/quoteSendQueue.ts`) | yes | yes |
| `sendQuote` (`POST /quotes/:id/send`) | **no** | yes |

That column is what raises the detail page's "Proposal marked Sent, but no email was delivered" banner, so a direct send whose PDF render or transport failed was marked **Sent** with the column NULL and showed nothing at all. The customer never received the proposal and the quote gave no sign of it. This is the path used by MCP, bulk-send, API-key callers and "Send now"; the web composer normally goes through `/schedule-send`, which was already covered.

## The change

Persist the reason after `deliverQuoteEmail`, in `resendQuote`'s shape. The write runs after the email has left, so a failure there is swallowed onto the returned row rather than surfacing as "could not send" for a message the customer already has, where the tech's natural next move is to send it a second time. The draft to sent claim already clears the column, so only a failure needs writing back, and the existing re-select and return are untouched.

Also simplifies `deliverQuoteEmail`'s contract comment, which existed to document the asymmetry this removes.

## Tests

The three existing failure-path cases each needed one more queued mock result, because the Drizzle mock queue is sequential and the new UPDATE consumes one. Added:

- `persists send_email_reason so a failed direct send raises the banner` — asserts the write itself via `setCalls` rather than the returned row, since the banner reads the column.
- `writes no outcome marker when the send succeeds` — guards against reintroducing a stale marker on the happy path. Being precise: this one passes with or without the fix, so it is a regression guard, not a reproducer.

## Verification

Run locally on node 22.23.2 (matching `.nvmrc`), deps installed `--frozen-lockfile`:

```
vitest src/services/quoteLifecycle.test.ts        58 passed (58)
vitest quote services + routes + quoteSendQueue   383 passed (383), 23 files
tsc --noEmit -p apps/api/tsconfig.json            exit 0, no output
```

Control run, fix reverted and tests kept: 4 failed, including `persists send_email_reason so a failed direct send raises the banner`. So the new persistence test genuinely fails without the change.

Not run locally: the RLS and integration contract suites, which need a live database. This touches no schema, no migration and no tenancy surface, so I would not expect them to be affected.


---

## Known risks (adversarial review, recorded per review charter)

This PR makes the "no email was delivered" banner fire for the direct-send path — the reported bug. It does **not** make quote delivery idempotent. Three risks were surfaced by adversarial review and are left for follow-up rather than silently carried:

1. **Transaction-boundary duplicate send (pre-existing, marginally widened here).** `sendQuote` claims draft→sent then renders the PDF and calls the provider while the request-wide transaction is still open. A statement failure after delivery rolls back `status='sent'` while the customer has the email; a retry re-claims the draft and sends a second copy. The unguarded re-select already had this property; this PR adds one more statement inside that window. Correct fix is a transactional outbox.
2. **`send_email_reason` is a lossy scalar with no attempt identity.** `resendQuote` has no claim/lock, so overlapping resends are last-commit-wins: a slow failure can overwrite a newer success (false warning) or a slow success can clear a newer failure (false reassurance). A per-attempt id with `WHERE id = ? AND delivery_attempt_id = ?` would make the column truthful.
3. **Unit tests cannot prove SQL targeting.** The Drizzle mock treats `.where()` as a no-op, so the persistence assertion passes even if production matched zero rows or the wrong row. A real-Postgres test with two controlled resends plus an injected post-email failure is needed; it belongs with the outbox work.

Downstream readers of the now-populated column: `QuoteSendOutcomeBanners`/toast (`QuoteActions.tsx`), tenant export (`tenantExportPolicyRegistry.ts`, already classified), MCP/AI quote tools. The public portal DTO is allowlisted and does **not** expose it — no portal leak.
