### PR TITLE
fix(shared): accept null for the nullable monitoring watch fields

### DIFF
--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -925,13 +925,22 @@ export const monitoringInlineSettingsSchema = z.object({
   watches: z.array(z.object({
     watchType: z.enum(['service', 'process']),
     name: z.string().min(1).max(255),
-    displayName: z.string().max(255).optional(),
+    // These three are the only watch columns without NOT NULL
+    // (config_policy_monitoring_watches.display_name / cpu_threshold_percent /
+    // memory_threshold_mb). The write path stores an unset value as `?? null`
+    // and the read path returns that null verbatim, so the editor loads a saved
+    // watch carrying nulls and posts them straight back. `.optional()` alone
+    // rejected them, which made an existing policy impossible to re-save once
+    // any watch had an unset field (#3491, #3492). Keep in sync with the
+    // columns, same as updateDeviceSchema.displayName above. Consumers already
+    // treat null and undefined alike (`!= null` in agents/helpers.ts).
+    displayName: z.string().max(255).nullable().optional(),
     enabled: z.boolean().default(true),
     alertOnStop: z.boolean().default(true),
     alertAfterConsecutiveFailures: z.number().int().min(1).max(100).default(2),
     alertSeverity: z.enum(['critical', 'high', 'medium', 'low', 'info']).default('high'),
-    cpuThresholdPercent: z.number().min(0).max(100).optional(),
-    memoryThresholdMb: z.number().min(0).optional(),
+    cpuThresholdPercent: z.number().min(0).max(100).nullable().optional(),
+    memoryThresholdMb: z.number().min(0).nullable().optional(),
     thresholdDurationSeconds: z.number().int().min(0).max(86400).default(300),
     autoRestart: z.boolean().default(false),
     maxRestartAttempts: z.number().int().min(0).max(50).default(3),

--- a/packages/shared/src/validators/index_inline_settings.test.ts
+++ b/packages/shared/src/validators/index_inline_settings.test.ts
@@ -405,6 +405,48 @@ describe('monitoringInlineSettingsSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  // #3491/#3492: a saved watch loads back from the DB with nulls in the three
+  // nullable columns, and the editor posts them straight back. Rejecting null
+  // made an existing policy impossible to re-save once any watch had an unset
+  // field — the reported error named exactly these three paths.
+  it('should accept a saved watch round-tripped with null optional fields', () => {
+    const result = monitoringInlineSettingsSchema.safeParse({
+      watches: [
+        {
+          watchType: 'service',
+          name: 'wuauserv',
+          displayName: null,
+          cpuThresholdPercent: null,
+          memoryThresholdMb: null,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Preserved as null rather than coerced: the write path stores `?? null`
+      // and the agent delivery check is `!= null`, so both spellings behave
+      // identically downstream.
+      const watch = result.data.watches[0];
+      expect(watch?.displayName).toBeNull();
+      expect(watch?.cpuThresholdPercent).toBeNull();
+      expect(watch?.memoryThresholdMb).toBeNull();
+    }
+  });
+
+  it('should still reject a wrong-typed threshold, not just anything non-number', () => {
+    expect(
+      monitoringInlineSettingsSchema.safeParse({
+        watches: [{ watchType: 'process', name: 'nginx', cpuThresholdPercent: 'high' }],
+      }).success
+    ).toBe(false);
+    // and the range check survives the nullable change
+    expect(
+      monitoringInlineSettingsSchema.safeParse({
+        watches: [{ watchType: 'process', name: 'nginx', cpuThresholdPercent: 101 }],
+      }).success
+    ).toBe(false);
+  });
+
   it('should reject checkIntervalSeconds below 10', () => {
     expect(
       monitoringInlineSettingsSchema.safeParse({ checkIntervalSeconds: 9 }).success

--- a/packages/shared/src/validators/index_inline_settings.test.ts
+++ b/packages/shared/src/validators/index_inline_settings.test.ts
@@ -433,16 +433,20 @@ describe('monitoringInlineSettingsSchema', () => {
     }
   });
 
-  it('should still reject a wrong-typed threshold, not just anything non-number', () => {
+  // Covers all three widened fields, not just one: nullable must not become
+  // "accepts anything". Type and range checks have to survive the change.
+  it.each([
+    ['displayName wrong type', { displayName: 42 }],
+    ['displayName too long', { displayName: 'x'.repeat(256) }],
+    ['cpuThresholdPercent wrong type', { cpuThresholdPercent: 'high' }],
+    ['cpuThresholdPercent above max', { cpuThresholdPercent: 101 }],
+    ['cpuThresholdPercent below min', { cpuThresholdPercent: -1 }],
+    ['memoryThresholdMb wrong type', { memoryThresholdMb: 'lots' }],
+    ['memoryThresholdMb below min', { memoryThresholdMb: -1 }],
+  ])('still rejects %s after the nullable widening', (_label, patch) => {
     expect(
       monitoringInlineSettingsSchema.safeParse({
-        watches: [{ watchType: 'process', name: 'nginx', cpuThresholdPercent: 'high' }],
-      }).success
-    ).toBe(false);
-    // and the range check survives the nullable change
-    expect(
-      monitoringInlineSettingsSchema.safeParse({
-        watches: [{ watchType: 'process', name: 'nginx', cpuThresholdPercent: 101 }],
+        watches: [{ watchType: 'process', name: 'nginx', ...patch }],
       }).success
     ).toBe(false);
   });


### PR DESCRIPTION
Fixes #3491. Also fixes #3492, which is the same report from the same reporter (two Discord messages, identical error text and repro).

## What broke

Adding a watch to an **existing** Monitoring policy failed with:

```
watches.0.displayName: Invalid input: expected string, received null
watches.0.cpuThresholdPercent: Invalid input: expected number, received null
watches.0.memoryThresholdMb: Invalid input: expected number, received null
```

Those three fields are exactly the only columns on `config_policy_monitoring_watches` declared without `NOT NULL`:

```ts
displayName: varchar('display_name', { length: 255 }),   // nullable
cpuThresholdPercent: real('cpu_threshold_percent'),      // nullable
memoryThresholdMb: real('memory_threshold_mb'),          // nullable
```

Every other watch column is `.notNull().default(...)`, which is why the error names these three and nothing else.

The round trip: the write path stores an unset value as `?? null`, the read path returns that null verbatim, and the editor merges the loaded watch over its defaults so the null survives into editor state and is posted straight back. `monitoringInlineSettingsSchema` declared all three `.optional()` but not `.nullable()`, so **zod rejected the API's own stored representation**.

That accounts for every symptom in the report, including the odd ones: a brand-new watch has never round-tripped through the DB so it stays `undefined` and saves fine; a policy reopened after navigating away carries nulls and poisons any later save; deleting every watch clears the null-bearing entries so saving newly-added ones works again.

## Why fix the schema rather than normalise on read

The columns genuinely are nullable, and null is what the API already persists and returns, so the request schema should accept the shape the API itself emits. Normalising null to undefined on read would change the response contract for existing consumers and still leave the schema rejecting a value the database legitimately holds.

It also fixes callers beyond the web editor. Any MCP or direct-API client that reads a policy and posts it back hits the same wall, and a web-only fix would leave those broken.

Downstream treatment is already null-safe, which is what makes this safe to widen:

- `apps/api/src/routes/agents/helpers.ts` gates delivery on `if (w.cpuThresholdPercent != null)` / `!= null`, loose equality, so null and undefined behave identically.
- `displayName` is never sent to the agent at all.

This matches the existing precedent on `updateDeviceSchema.displayName` in the same file, which is `.nullable().optional()` with a comment for exactly this reason.

## Tests

- `should accept a saved watch round-tripped with null optional fields` reproduces the bug, and asserts the values stay null rather than being silently coerced.
- `should still reject a wrong-typed threshold` pins that widening to nullable did not weaken type or range checking (`'high'` and `101` both still rejected). Being precise: this one passes with or without the fix, so it is a regression guard, not a reproducer.

## Verification

Run locally on node 22.23.2 (matching `.nvmrc`), deps installed `--frozen-lockfile`:

```
vitest packages/shared (full)      1750 passed (1750), 69 files
tsc --noEmit packages/shared       exit 0, no output
tsc --noEmit apps/api              exit 0, no output
```

Control run, fix reverted and tests kept: **1 failed**, the new round-trip test, and nothing else.

`apps/api` typechecking clean is the meaningful signal that widening the schema type did not break a consumer. No web file imports this schema.

## One observation, deliberately not fixed here

`MonitoringTab.tsx` types these fields locally as `displayName?: string` and `cpuThresholdPercent?: number`, but the API has always been able to hand it null. That type inaccuracy predates this change and is unaffected by it, so I left it alone rather than widen the scope. Worth a separate look if you want the editor types to match the wire shape.
