### PR TITLE
fix(viewer): name libfuse2t64 for the Linux AppImage on Debian 13 / Ubuntu 24.04+ (#3415)

### DIFF
--- a/apps/docs/src/content/docs/features/remote-access.mdx
+++ b/apps/docs/src/content/docs/features/remote-access.mdx
@@ -491,7 +491,8 @@ The package that provides it was renamed as part of Debian's 64-bit `time_t` (`t
 | Debian 13 (trixie) and newer, Ubuntu 24.04 LTS and newer | `libfuse2t64` |
 | Debian 12 and older, Ubuntu 22.04 and older | `libfuse2` |
 | Fedora / RHEL | `fuse-libs` |
-| Arch / openSUSE | `fuse2` |
+| Arch | `fuse2` |
+| openSUSE | `libfuse2` (plus `fuse` for `fusermount`) |
 
 ```bash
 # Debian 13 / Ubuntu 24.04+

--- a/apps/docs/src/content/docs/features/remote-access.mdx
+++ b/apps/docs/src/content/docs/features/remote-access.mdx
@@ -451,7 +451,82 @@ Remote-access providers are configured per partner under **Settings → Remote**
 
 ---
 
+## Linux viewer (AppImage)
+
+The Linux build of the Breeze Viewer ships as a single AppImage, `breeze-viewer-linux.AppImage`. Unlike the Windows MSI and the macOS DMG it is not installed — you download it, mark it executable, and run it once so it can register itself as the handler for `breeze://` links. Until that first run, choosing **Connect Desktop** in the console has nothing to hand the session to, and the download card reappears on every attempt.
+
+<Steps>
+
+1. Mark the download executable:
+
+   ```bash
+   chmod +x ~/Downloads/breeze-viewer-linux.AppImage
+   ```
+
+2. Run it once. A small "Breeze Viewer is ready" window confirms it launched and registered the `breeze://` scheme. You can close that window — the console reopens the viewer when a session starts.
+
+   ```bash
+   ~/Downloads/breeze-viewer-linux.AppImage
+   ```
+
+3. Confirm the scheme is claimed:
+
+   ```bash
+   xdg-mime query default x-scheme-handler/breeze
+   # → breeze-viewer.desktop
+   ```
+
+</Steps>
+
+Keep the AppImage at a stable path. The registration records the absolute path it was run from, so moving or deleting the file after the first run leaves `breeze://` pointing at a file that no longer exists — run it again from the new location to refresh the entry.
+
+### FUSE 2 is required
+
+The AppImage runtime mounts itself with FUSE 2 at launch. On a distribution that no longer ships FUSE 2 by default, the AppImage exits immediately with a message about `libfuse.so.2`, `dlopen`, or `fusermount`, and no window ever appears.
+
+The package that provides it was renamed as part of Debian's 64-bit `time_t` (`t64`) transition, which is why the familiar package name no longer resolves on current releases:
+
+| Distribution | Package to install |
+|---|---|
+| Debian 13 (trixie) and newer, Ubuntu 24.04 LTS and newer | `libfuse2t64` |
+| Debian 12 and older, Ubuntu 22.04 and older | `libfuse2` |
+| Fedora / RHEL | `fuse-libs` |
+| Arch / openSUSE | `fuse2` |
+
+```bash
+# Debian 13 / Ubuntu 24.04+
+sudo apt install libfuse2t64
+```
+
+`sudo apt install libfuse2` also works on those releases — apt reports `Note, selecting 'libfuse2t64' instead of 'libfuse2'` and installs the renamed package. That message is informational, not an error.
+
+### Running without FUSE
+
+If you cannot install FUSE 2 — a hardened host, a container, or a policy that forbids the `fuse` kernel module — the AppImage can unpack itself to a temporary directory and run from there instead of mounting:
+
+```bash
+~/Downloads/breeze-viewer-linux.AppImage --appimage-extract-and-run
+```
+
+This works for a one-off session but is not a substitute for the first run above: the `Exec=` line written into the desktop entry does not carry the flag, so `breeze://` links launched from the console still take the FUSE path. To make the fallback permanent, set it in the environment the desktop session inherits:
+
+```bash
+# e.g. in ~/.profile
+export APPIMAGE_EXTRACT_AND_RUN=1
+```
+
+Extract-and-run unpacks the whole bundle on every launch, so sessions start noticeably slower and each launch writes to `$TMPDIR`. Installing FUSE 2 is the better outcome where it is allowed.
+
+### Viewer launches but no window appears
+
+If the process shows up in `ps` but nothing is drawn, FUSE is working and the problem is the desktop stack, not packaging — typically a host GTK module or `gvfs` build that is incompatible with the bundled runtime. Run the AppImage from a terminal and read the messages: `Failed to load module` and `undefined symbol` lines name the offending host library. Starting with a clean environment (`env -i DISPLAY=$DISPLAY HOME=$HOME ~/Downloads/breeze-viewer-linux.AppImage`) confirms whether a host module is being injected.
+
+---
+
 ## Troubleshooting
+
+**Linux viewer does nothing when run.**
+The AppImage needs FUSE 2 to mount itself. On Debian 13 / Ubuntu 24.04+ the package is `libfuse2t64`, not `libfuse2`. See [Linux viewer (AppImage)](#linux-viewer-appimage) for the per-distribution package names and the `--appimage-extract-and-run` fallback.
 
 **Session stuck in `connecting`.**
 WebRTC negotiation failed and the viewer has not yet fallen back to WebSocket. Confirm the device is online and the agent WebSocket connection is active (check the device detail page). Common causes:

--- a/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.test.tsx
@@ -289,6 +289,25 @@ describe('ConnectDesktopButton — viewer-not-installed fallback card', () => {
     expect(screen.getByRole('link', { name: /download for linux/i })).toBeInTheDocument();
   });
 
+  it('names libfuse2t64 for Linux users whose AppImage exits with no window', async () => {
+    // Debian 13 / Ubuntu 24.04+ renamed libfuse2 to libfuse2t64 in the t64
+    // transition. Telling the user only "chmod +x and run it" leaves them at a
+    // silent exit with nothing to search for (issue #3415), and the widely
+    // quoted `apt install libfuse2` prints a "selecting libfuse2t64 instead"
+    // note that reads like a failure.
+    downloadMock.mockReturnValue({
+      os: 'linux',
+      label: 'Linux',
+      url: 'https://example.test/breeze-viewer-linux.AppImage',
+      filename: 'breeze-viewer-linux.AppImage',
+    });
+
+    await reachFallbackCard();
+
+    expect(screen.getByText(/libfuse2t64/i)).toBeInTheDocument();
+    expect(screen.getByText(/--appimage-extract-and-run/i)).toBeInTheDocument();
+  });
+
   it('omits the Linux first-run hint on other platforms', async () => {
     downloadMock.mockReturnValue({
       os: 'macos',
@@ -301,6 +320,7 @@ describe('ConnectDesktopButton — viewer-not-installed fallback card', () => {
 
     expect(screen.getByRole('link', { name: /download for macos/i })).toBeInTheDocument();
     expect(screen.queryByText(/chmod \+x/i)).toBeNull();
+    expect(screen.queryByText(/libfuse2t64/i)).toBeNull();
   });
 
   it('renders the restored fallback copy, not the humanized key placeholders', async () => {

--- a/apps/web/src/components/remote/ConnectDesktopButton.tsx
+++ b/apps/web/src/components/remote/ConnectDesktopButton.tsx
@@ -610,9 +610,21 @@ export default function ConnectDesktopButton({ deviceId, className = '', compact
                         saying so, downloading looks like it did nothing and this
                         same card reappears on every attempt (issue #2614). */}
                     {downloadInfo.os === 'linux' && (
-                      <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
-                        {t('connectDesktopButton.fallback.linuxFirstRun')}
-                      </p>
+                      <>
+                        <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+                          {t('connectDesktopButton.fallback.linuxFirstRun')}
+                        </p>
+                        {/* The AppImage mounts itself with FUSE 2, which current
+                            Debian/Ubuntu no longer ship by default. Worse, the
+                            package was renamed by the t64 transition, so the
+                            widely-quoted `apt install libfuse2` looks wrong when
+                            apt answers "selecting 'libfuse2t64' instead". Without
+                            naming the real package the run above just exits with
+                            no window and the user is stuck (issue #3415). */}
+                        <p className="mt-1.5 text-xs text-amber-700 dark:text-amber-400">
+                          {t('connectDesktopButton.fallback.linuxFuse')}
+                        </p>
+                      </>
                     )}
                     <div className="mt-2.5 flex items-center gap-3">
                       <a

--- a/apps/web/src/locales/de-DE/remote.json
+++ b/apps/web/src/locales/de-DE/remote.json
@@ -46,6 +46,7 @@
     },
     "fallback": {
       "linuxFirstRun": "Machen Sie die heruntergeladene Datei unter Linux ausführbar (chmod +x) und starten Sie sie einmal. Damit wird der Viewer registriert und Sitzungen öffnen sich danach automatisch.",
+      "linuxFuse": "Wenn sie sich ohne Fenster beendet, fehlt FUSE 2: Installieren Sie libfuse2t64 (Debian 13 / Ubuntu 24.04+) bzw. libfuse2 auf älteren Versionen, oder starten Sie sie mit --appimage-extract-and-run.",
       "title": "Viewer nicht geöffnet?",
       "viewerDescription": "Wenn sich der Viewer geöffnet hat, können Sie dies schließen. Andernfalls laden Sie ihn unten herunter.",
       "vncDescription": "Öffnen Sie die VNC-Sitzung stattdessen im Browser."

--- a/apps/web/src/locales/en/remote.json
+++ b/apps/web/src/locales/en/remote.json
@@ -46,6 +46,7 @@
     },
     "fallback": {
       "linuxFirstRun": "On Linux, make the download executable (chmod +x) and run it once. That registers the viewer, so sessions open automatically from then on.",
+      "linuxFuse": "If it exits without opening a window, it needs FUSE 2: install libfuse2t64 (Debian 13 / Ubuntu 24.04+) or libfuse2 on older releases, or run it with --appimage-extract-and-run.",
       "title": "Viewer didn't open?",
       "viewerDescription": "If the viewer opened, you can dismiss this. Otherwise, download it below.",
       "vncDescription": "Open the VNC session in your browser instead."

--- a/apps/web/src/locales/es-419/remote.json
+++ b/apps/web/src/locales/es-419/remote.json
@@ -46,6 +46,7 @@
     },
     "fallback": {
       "linuxFirstRun": "En Linux, haz que el archivo descargado sea ejecutable (chmod +x) y ábrelo una vez. Eso registra el visor y, a partir de entonces, las sesiones se abren automáticamente.",
+      "linuxFuse": "Si se cierra sin abrir ninguna ventana, necesita FUSE 2: instala libfuse2t64 (Debian 13 / Ubuntu 24.04+) o libfuse2 en versiones anteriores, o ejecútalo con --appimage-extract-and-run.",
       "title": "¿No se abrió el visor?",
       "viewerDescription": "Si el visor se abrió, puedes descartar esto. Si no, descárgalo abajo.",
       "vncDescription": "Abre la sesión VNC en tu navegador."

--- a/apps/web/src/locales/fr-CA/remote.json
+++ b/apps/web/src/locales/fr-CA/remote.json
@@ -46,6 +46,7 @@
     },
     "fallback": {
       "linuxFirstRun": "Sous Linux, rendez le fichier téléchargé exécutable (chmod +x) et lancez-le une fois. Cela enregistre la visionneuse ; les sessions s'ouvriront ensuite automatiquement.",
+      "linuxFuse": "S'il se ferme sans ouvrir de fenêtre, il lui faut FUSE 2 : installez libfuse2t64 (Debian 13 / Ubuntu 24.04+) ou libfuse2 sur les versions antérieures, ou lancez-le avec --appimage-extract-and-run.",
       "title": "La visionneuse ne s'est pas ouverte ?",
       "viewerDescription": "Si la visionneuse s'est ouverte, vous pouvez ignorer ce message. Sinon, téléchargez-la ci-dessous.",
       "vncDescription": "Ouvrez plutôt la session VNC dans votre navigateur."

--- a/apps/web/src/locales/fr-FR/remote.json
+++ b/apps/web/src/locales/fr-FR/remote.json
@@ -46,6 +46,7 @@
     },
     "fallback": {
       "linuxFirstRun": "Sous Linux, rendez le fichier téléchargé exécutable (chmod +x) et lancez-le une fois. Cela enregistre la visionneuse ; les sessions s'ouvriront ensuite automatiquement.",
+      "linuxFuse": "S'il se ferme sans ouvrir de fenêtre, il lui faut FUSE 2 : installez libfuse2t64 (Debian 13 / Ubuntu 24.04+) ou libfuse2 sur les versions antérieures, ou lancez-le avec --appimage-extract-and-run.",
       "title": "La visionneuse ne s'est pas ouverte ?",
       "viewerDescription": "Si la visionneuse s'est ouverte, vous pouvez ignorer ce message. Sinon, téléchargez-la ci-dessous.",
       "vncDescription": "Ouvrez plutôt la session VNC dans votre navigateur."

--- a/apps/web/src/locales/it-IT/remote.json
+++ b/apps/web/src/locales/it-IT/remote.json
@@ -46,6 +46,7 @@
     },
     "fallback": {
       "linuxFirstRun": "Su Linux, rendi eseguibile il file scaricato (chmod +x) ed eseguilo una volta. In questo modo il visualizzatore viene registrato e da quel momento le sessioni si apriranno automaticamente.",
+      "linuxFuse": "Se si chiude senza aprire alcuna finestra, serve FUSE 2: installa libfuse2t64 (Debian 13 / Ubuntu 24.04+) oppure libfuse2 sulle versioni precedenti, o eseguilo con --appimage-extract-and-run.",
       "title": "Il visualizzatore non si è aperto?",
       "viewerDescription": "Se il visualizzatore si è aperto, puoi chiudere questo messaggio. In caso contrario, scaricalo qui sotto.",
       "vncDescription": "Apri invece la sessione VNC nel browser."

--- a/apps/web/src/locales/pt-BR/remote.json
+++ b/apps/web/src/locales/pt-BR/remote.json
@@ -46,6 +46,7 @@
     },
     "fallback": {
       "linuxFirstRun": "No Linux, torne o arquivo baixado executável (chmod +x) e execute-o uma vez. Isso registra o visualizador, e as sessões passam a abrir automaticamente.",
+      "linuxFuse": "Se ele encerrar sem abrir nenhuma janela, é porque falta o FUSE 2: instale libfuse2t64 (Debian 13 / Ubuntu 24.04+) ou libfuse2 em versões anteriores, ou execute-o com --appimage-extract-and-run.",
       "title": "O visualizador não abriu?",
       "viewerDescription": "Se o visualizador abriu, você pode dispensar este aviso. Caso contrário, baixe-o abaixo.",
       "vncDescription": "Abra a sessão VNC no seu navegador."


### PR DESCRIPTION
## Problem

The Linux viewer ships as an AppImage, whose runtime mounts itself with **FUSE 2**. Debian's 64-bit `time_t` (`t64`) transition renamed the providing package, so on Debian 13 (trixie) and Ubuntu 24.04+ the widely-quoted `apt install libfuse2` answers:

```
Note, selecting 'libfuse2t64' instead of 'libfuse2'
```

— which reads like a failure. Nothing in Breeze told the user what the real prerequisite was. The AppImage exits with no window and no actionable message, and the console's "Viewer didn't open?" card reappears on every attempt.

Before this change, `libfuse`, `FUSE`, `fuse2`, and `appimage-extract-and-run` appeared **nowhere in the repo** — no preflight, no docs, no UI copy. And there is no Linux viewer install script to carry a check: the AppImage is downloaded by the browser and run by hand, with registration done by the app itself in Rust. So the fix is guidance, placed in the two spots a stuck user actually looks.

## Changes

**Docs** — new **Linux viewer (AppImage)** section in `features/remote-access.mdx`:

- first-run / `breeze://` registration steps, plus `xdg-mime query default x-scheme-handler/breeze` to verify, and the "keep it at a stable path" caveat (registration records an absolute path)
- per-distribution FUSE 2 package table: `libfuse2t64` (Debian 13+/Ubuntu 24.04+), `libfuse2` (older), `fuse-libs` (Fedora/RHEL), `fuse2` (Arch/openSUSE) — and an explicit note that the apt "selecting libfuse2t64 instead" message is informational
- `--appimage-extract-and-run` and `APPIMAGE_EXTRACT_AND_RUN=1` fallbacks for hosts where FUSE can't be installed, including the caveat that the desktop entry's `Exec=` line does **not** carry the flag, so `breeze://` launches still take the FUSE path
- a separate entry for the adjacent "process runs but no window appears" host-GTK/gvfs case (#2614)
- a Troubleshooting entry that points at the section

**Web** — the Linux-only hint on the Connect Desktop fallback card now names the package and the fallback flag alongside the existing `chmod +x` line. New `connectDesktopButton.fallback.linuxFuse` key added in all seven locales.

## Scope note

Publishing a `.deb` alongside the AppImage would also solve this (Tauri's `targets: "all"` already produces one) and would be the stronger long-term packaging answer. It is deliberately **not** in this PR: it touches the signed release manifest, `binarySource.ts`, the web download UI, and the updater, and cannot be verified without cutting a release. Worth tracking separately.

Also worth noting: the reporter's own message shows apt *did* install `libfuse2t64` successfully, so FUSE may not have been their final blocker — the host-GTK case from #2614 is the other candidate, and the new section covers both paths rather than asserting one root cause.

## Verification

- `vitest run src/components/remote/ConnectDesktopButton.test.tsx` — 17 passed (2 new: names `libfuse2t64` + `--appimage-extract-and-run` on Linux; asserts absence on other platforms)
- `vitest run src/lib/i18n/` — 7 files, 98 passed (locale parity, translation coverage, terminology, extraction quality)
- `tsc --noEmit` (apps/web) — clean
- `astro check` + `astro build` (apps/docs) — 0 errors, 164 pages built

Closes #3415

🤖 Generated with [Claude Code](https://claude.com/claude-code)