### PR TITLE
fix(agent): survive gopsutil darwin netstat panic in metrics collection (#3459)

### DIFF
--- a/agent/internal/collectors/metrics.go
+++ b/agent/internal/collectors/metrics.go
@@ -135,8 +135,14 @@ func (c *MetricsCollector) Collect() (*SystemMetrics, error) {
 
 	// Network — aggregate totals (backward-compatible)
 	netIO, err := safeNetIOCounters(false)
-	if err != nil {
-		logNetIOPanic(false, err)
+	if err != nil || len(netIO) == 0 {
+		// Drop the baseline. c.lastTime advances every cycle regardless, so
+		// carrying a stale counter across a missed sample would make the next
+		// successful cycle divide a multi-interval byte delta by a single
+		// interval — reporting a bandwidth spike that never happened. A zero
+		// baseline is re-seeded below and simply skips one sample instead.
+		c.lastNetIn = 0
+		c.lastNetOut = 0
 	}
 	if err == nil && len(netIO) > 0 {
 		currentIn := netIO[0].BytesRecv
@@ -160,7 +166,9 @@ func (c *MetricsCollector) Collect() (*SystemMetrics, error) {
 	// Network — per-interface bandwidth
 	perIface, err := safeNetIOCounters(true)
 	if err != nil {
-		logNetIOPanic(true, err)
+		// Same reasoning as the aggregate baseline above: a stale per-interface
+		// snapshot across a missed sample would fabricate a rate spike.
+		clear(c.lastIface)
 	}
 	if err == nil {
 		hasHistory := !c.lastTime.IsZero() && elapsed > 1 && elapsed < 300

--- a/agent/internal/collectors/metrics.go
+++ b/agent/internal/collectors/metrics.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
-	"github.com/shirou/gopsutil/v3/net"
 	"github.com/shirou/gopsutil/v3/process"
 )
 
@@ -135,7 +134,10 @@ func (c *MetricsCollector) Collect() (*SystemMetrics, error) {
 	c.collectDiskActivity(metrics, elapsed)
 
 	// Network — aggregate totals (backward-compatible)
-	netIO, err := net.IOCounters(false)
+	netIO, err := safeNetIOCounters(false)
+	if err != nil {
+		logNetIOPanic(false, err)
+	}
 	if err == nil && len(netIO) > 0 {
 		currentIn := netIO[0].BytesRecv
 		currentOut := netIO[0].BytesSent
@@ -156,7 +158,10 @@ func (c *MetricsCollector) Collect() (*SystemMetrics, error) {
 	}
 
 	// Network — per-interface bandwidth
-	perIface, err := net.IOCounters(true)
+	perIface, err := safeNetIOCounters(true)
+	if err != nil {
+		logNetIOPanic(true, err)
+	}
 	if err == nil {
 		hasHistory := !c.lastTime.IsZero() && elapsed > 1 && elapsed < 300
 		seen := make(map[string]bool)

--- a/agent/internal/collectors/netio_safe.go
+++ b/agent/internal/collectors/netio_safe.go
@@ -1,0 +1,50 @@
+package collectors
+
+import (
+	"errors"
+	"log/slog"
+	"sync"
+
+	"github.com/shirou/gopsutil/v3/net"
+)
+
+// netIOStackLogged ensures the (large) panic stack is logged once per process
+// rather than on every collection cycle — on an affected host the panic recurs
+// every heartbeat, and the stack is only diagnostic value the first time.
+var netIOStackLogged sync.Once
+
+// safeNetIOCounters wraps gopsutil's net.IOCounters, converting a panic into an
+// error so the rest of the metrics sample (CPU, RAM, disk) still gets reported.
+//
+// Why this is needed: gopsutil's darwin implementation reads columns[0] and
+// columns[2] of each `netstat -ibdnW` line with no length check
+// (net/net_darwin.go parseNetstatLine), so a line with fewer fields than
+// expected panics with "index out of range". On newer macOS that has taken down
+// the metrics goroutine mid-heartbeat (issue #3459).
+//
+// Upgrading does NOT fix this: the same unguarded indexing is still present in
+// gopsutil v4.26.7, so there is no released version to move to. Guarding at our
+// own call site is the fix until upstream adds the bounds check.
+//
+// Behaviour on panic matches gopsutil's own error path for a malformed line
+// (parseNetstatOutput already fails the whole call on any unparsable line), so
+// this loses no data that would otherwise have been collected — it only stops
+// the crash from escaping.
+func safeNetIOCounters(pernic bool) (stats []net.IOCountersStat, err error) {
+	defer recoverAs("net.IOCounters", &err)
+	return net.IOCounters(pernic)
+}
+
+// logNetIOPanic reports a recovered net.IOCounters panic. Ordinary
+// (non-panic) IOCounters errors are left to the caller's existing handling.
+func logNetIOPanic(pernic bool, err error) {
+	var panicErr *PanicError
+	if !errors.As(err, &panicErr) {
+		return
+	}
+	slog.Warn("network IO counters panicked; skipping network metrics this cycle",
+		"pernic", pernic, "error", panicErr.Error())
+	netIOStackLogged.Do(func() {
+		slog.Warn("network IO counters panic stack", "stack", panicErr.Stack)
+	})
+}

--- a/agent/internal/collectors/netio_safe.go
+++ b/agent/internal/collectors/netio_safe.go
@@ -1,17 +1,14 @@
 package collectors
 
 import (
-	"errors"
-	"log/slog"
-	"sync"
-
 	"github.com/shirou/gopsutil/v3/net"
 )
 
-// netIOStackLogged ensures the (large) panic stack is logged once per process
-// rather than on every collection cycle — on an affected host the panic recurs
-// every heartbeat, and the stack is only diagnostic value the first time.
-var netIOStackLogged sync.Once
+// netIOCounters is the gopsutil entry point used by safeNetIOCounters. It is a
+// variable purely so tests can inject a panicking implementation — there is no
+// other way to exercise the recovery path, since whether the real gopsutil
+// panics depends on the host's `netstat` output.
+var netIOCounters = net.IOCounters
 
 // safeNetIOCounters wraps gopsutil's net.IOCounters, converting a panic into an
 // error so the rest of the metrics sample (CPU, RAM, disk) still gets reported.
@@ -23,28 +20,16 @@ var netIOStackLogged sync.Once
 // the metrics goroutine mid-heartbeat (issue #3459).
 //
 // Upgrading does NOT fix this: the same unguarded indexing is still present in
-// gopsutil v4.26.7, so there is no released version to move to. Guarding at our
-// own call site is the fix until upstream adds the bounds check.
+// gopsutil v4.26.7, whose first len(columns) check sits after both accesses, so
+// there is no released version to move to. Guarding at our own call site is the
+// fix until upstream adds the bounds check.
 //
 // Behaviour on panic matches gopsutil's own error path for a malformed line
 // (parseNetstatOutput already fails the whole call on any unparsable line), so
 // this loses no data that would otherwise have been collected — it only stops
-// the crash from escaping.
+// the crash from escaping. recoverAs reports the panic to Sentry and logs it,
+// so recovery here is not a silent failure.
 func safeNetIOCounters(pernic bool) (stats []net.IOCountersStat, err error) {
 	defer recoverAs("net.IOCounters", &err)
-	return net.IOCounters(pernic)
-}
-
-// logNetIOPanic reports a recovered net.IOCounters panic. Ordinary
-// (non-panic) IOCounters errors are left to the caller's existing handling.
-func logNetIOPanic(pernic bool, err error) {
-	var panicErr *PanicError
-	if !errors.As(err, &panicErr) {
-		return
-	}
-	slog.Warn("network IO counters panicked; skipping network metrics this cycle",
-		"pernic", pernic, "error", panicErr.Error())
-	netIOStackLogged.Do(func() {
-		slog.Warn("network IO counters panic stack", "stack", panicErr.Stack)
-	})
+	return netIOCounters(pernic)
 }

--- a/agent/internal/collectors/netio_safe_test.go
+++ b/agent/internal/collectors/netio_safe_test.go
@@ -1,0 +1,47 @@
+package collectors
+
+import (
+	"errors"
+	"testing"
+)
+
+// safeNetIOCounters must not panic on any supported platform. On a healthy host
+// it returns stats; on a host whose netstat output trips the gopsutil darwin
+// parser (issue #3459) it must return an error rather than crashing the caller.
+func TestSafeNetIOCountersNeverPanics(t *testing.T) {
+	for _, pernic := range []bool{false, true} {
+		stats, err := safeNetIOCounters(pernic)
+		if err != nil {
+			// An error is an acceptable outcome (no netstat, parse failure, or a
+			// recovered panic) — the contract is only that we got here at all.
+			var panicErr *PanicError
+			if errors.As(err, &panicErr) {
+				t.Logf("pernic=%v recovered a gopsutil panic as expected: %v", pernic, err)
+			}
+			continue
+		}
+		if stats == nil {
+			t.Fatalf("pernic=%v: nil stats with nil error", pernic)
+		}
+	}
+}
+
+// MetricsCollector.Collect must survive a network-stats failure — the rest of
+// the sample (CPU, RAM, disk) is what keeps heartbeats useful.
+func TestMetricsCollectSurvivesNetworkFailure(t *testing.T) {
+	c := NewMetricsCollector()
+	metrics, err := Guard("metrics", c.Collect)
+	if err != nil {
+		t.Fatalf("Collect returned an error: %v", err)
+	}
+	if metrics == nil {
+		t.Fatal("Collect returned nil metrics")
+	}
+}
+
+func TestLogNetIOPanicIgnoresOrdinaryErrors(t *testing.T) {
+	// Must not panic or mis-handle a plain error; there is nothing to assert on
+	// the log output, only that a non-PanicError is a no-op.
+	logNetIOPanic(false, errors.New("netstat: executable file not found in $PATH"))
+	logNetIOPanic(true, nil)
+}

--- a/agent/internal/collectors/netio_safe_test.go
+++ b/agent/internal/collectors/netio_safe_test.go
@@ -3,45 +3,140 @@ package collectors
 import (
 	"errors"
 	"testing"
+
+	"github.com/shirou/gopsutil/v3/net"
 )
 
-// safeNetIOCounters must not panic on any supported platform. On a healthy host
-// it returns stats; on a host whose netstat output trips the gopsutil darwin
-// parser (issue #3459) it must return an error rather than crashing the caller.
-func TestSafeNetIOCountersNeverPanics(t *testing.T) {
-	for _, pernic := range []bool{false, true} {
-		stats, err := safeNetIOCounters(pernic)
-		if err != nil {
-			// An error is an acceptable outcome (no netstat, parse failure, or a
-			// recovered panic) — the contract is only that we got here at all.
-			var panicErr *PanicError
-			if errors.As(err, &panicErr) {
-				t.Logf("pernic=%v recovered a gopsutil panic as expected: %v", pernic, err)
-			}
-			continue
-		}
-		if stats == nil {
-			t.Fatalf("pernic=%v: nil stats with nil error", pernic)
-		}
+func swapNetIOCounters(t *testing.T, fn func(bool) ([]net.IOCountersStat, error)) {
+	t.Helper()
+	orig := netIOCounters
+	netIOCounters = fn
+	t.Cleanup(func() { netIOCounters = orig })
+}
+
+// The core regression for #3459: a panic inside gopsutil must come back as an
+// error, not unwind the caller.
+func TestSafeNetIOCountersConvertsPanicToError(t *testing.T) {
+	swapNetIOCounters(t, func(bool) ([]net.IOCountersStat, error) {
+		// The exact shape of the gopsutil darwin bug: parseNetstatLine reads
+		// columns[2] of a line that only has one field.
+		columns := []string{"lo0"}
+		_ = columns[2]
+		return nil, nil
+	})
+
+	stats, err := safeNetIOCounters(false)
+	if err == nil {
+		t.Fatal("expected an error, got nil — the panic was not converted")
+	}
+	if stats != nil {
+		t.Fatalf("expected nil stats on panic, got %v", stats)
+	}
+	var panicErr *PanicError
+	if !errors.As(err, &panicErr) {
+		t.Fatalf("expected *PanicError, got %T", err)
+	}
+	if panicErr.Op != "net.IOCounters" {
+		t.Fatalf("Op = %q, want %q", panicErr.Op, "net.IOCounters")
+	}
+	if !errors.As(err, &panicErr) || panicErr.Stack == "" {
+		t.Fatal("expected a captured stack")
 	}
 }
 
-// MetricsCollector.Collect must survive a network-stats failure — the rest of
-// the sample (CPU, RAM, disk) is what keeps heartbeats useful.
-func TestMetricsCollectSurvivesNetworkFailure(t *testing.T) {
+func TestSafeNetIOCountersPassesThrough(t *testing.T) {
+	want := []net.IOCountersStat{{Name: "en0", BytesRecv: 100, BytesSent: 200}}
+	swapNetIOCounters(t, func(bool) ([]net.IOCountersStat, error) { return want, nil })
+
+	got, err := safeNetIOCounters(false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].BytesRecv != 100 {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestSafeNetIOCountersPassesThroughOrdinaryError(t *testing.T) {
+	sentinel := errors.New("netstat: executable file not found in $PATH")
+	swapNetIOCounters(t, func(bool) ([]net.IOCountersStat, error) { return nil, sentinel })
+
+	if _, err := safeNetIOCounters(true); !errors.Is(err, sentinel) {
+		t.Fatalf("got %v, want %v", err, sentinel)
+	}
+}
+
+// MetricsCollector.Collect must still produce a usable sample when the network
+// source is crashing — CPU/RAM/disk are what keep heartbeats meaningful.
+func TestMetricsCollectSurvivesNetworkPanic(t *testing.T) {
+	swapNetIOCounters(t, func(bool) ([]net.IOCountersStat, error) {
+		panic("index out of range [2] with length 1")
+	})
+
 	c := NewMetricsCollector()
 	metrics, err := Guard("metrics", c.Collect)
 	if err != nil {
-		t.Fatalf("Collect returned an error: %v", err)
+		t.Fatalf("Collect must not fail because the network source panicked: %v", err)
 	}
 	if metrics == nil {
 		t.Fatal("Collect returned nil metrics")
 	}
+	if metrics.NetworkInBytes != 0 || metrics.BandwidthInBps != 0 {
+		t.Fatalf("expected no network figures when the source panicked, got in=%d bps=%d",
+			metrics.NetworkInBytes, metrics.BandwidthInBps)
+	}
+	if len(metrics.InterfaceStats) != 0 {
+		t.Fatalf("expected no interface stats, got %d", len(metrics.InterfaceStats))
+	}
 }
 
-func TestLogNetIOPanicIgnoresOrdinaryErrors(t *testing.T) {
-	// Must not panic or mis-handle a plain error; there is nothing to assert on
-	// the log output, only that a non-PanicError is a no-op.
-	logNetIOPanic(false, errors.New("netstat: executable file not found in $PATH"))
-	logNetIOPanic(true, nil)
+// A missed sample must not turn into a fabricated bandwidth spike on the next
+// successful cycle: lastTime advances every cycle, so a stale byte baseline
+// would divide a multi-interval delta by a single interval.
+func TestMetricsDropsNetworkBaselineAfterFailedSample(t *testing.T) {
+	c := NewMetricsCollector()
+
+	// Cycle 1: healthy, seeds the baseline.
+	swapNetIOCounters(t, func(bool) ([]net.IOCountersStat, error) {
+		return []net.IOCountersStat{{Name: "en0", BytesRecv: 1_000, BytesSent: 1_000}}, nil
+	})
+	if _, err := c.Collect(); err != nil {
+		t.Fatalf("cycle 1: %v", err)
+	}
+	if c.lastNetIn != 1_000 {
+		t.Fatalf("cycle 1 should have seeded the baseline, got %d", c.lastNetIn)
+	}
+
+	// Cycle 2: the source panics. The baseline must be dropped, not kept.
+	netIOCounters = func(bool) ([]net.IOCountersStat, error) {
+		panic("index out of range [2] with length 1")
+	}
+	if _, err := c.Collect(); err != nil {
+		t.Fatalf("cycle 2: %v", err)
+	}
+	if c.lastNetIn != 0 || c.lastNetOut != 0 {
+		t.Fatalf("baseline must be dropped after a failed sample, got in=%d out=%d",
+			c.lastNetIn, c.lastNetOut)
+	}
+	if len(c.lastIface) != 0 {
+		t.Fatalf("per-interface baseline must be cleared, got %d entries", len(c.lastIface))
+	}
+
+	// Cycle 3: healthy again, with a counter far ahead of the cycle-1 value.
+	// Because the baseline was dropped, this cycle reports no throughput
+	// rather than attributing two intervals of traffic to one.
+	netIOCounters = func(bool) ([]net.IOCountersStat, error) {
+		return []net.IOCountersStat{{Name: "en0", BytesRecv: 9_000_000, BytesSent: 9_000_000}}, nil
+	}
+	metrics, err := c.Collect()
+	if err != nil {
+		t.Fatalf("cycle 3: %v", err)
+	}
+	if metrics.NetworkInBytes != 0 || metrics.BandwidthInBps != 0 {
+		t.Fatalf("recovery cycle fabricated throughput: in=%d bps=%d",
+			metrics.NetworkInBytes, metrics.BandwidthInBps)
+	}
+	if c.lastNetIn != 9_000_000 {
+		t.Fatalf("recovery cycle should re-seed the baseline, got %d", c.lastNetIn)
+	}
 }

--- a/agent/internal/collectors/safe.go
+++ b/agent/internal/collectors/safe.go
@@ -3,6 +3,10 @@ package collectors
 import (
 	"fmt"
 	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/breeze-rmm/agent/internal/observability"
 )
 
 // PanicError reports a panic that was recovered while running a collector (or a
@@ -23,8 +27,36 @@ func (e *PanicError) Error() string {
 	return fmt.Sprintf("panic in %s: %v", e.Op, e.Value)
 }
 
+// panicReportInterval throttles Sentry reporting per (op, panic value). A
+// collector panic caused by a bad host condition recurs on every collection
+// cycle — every ~60s for metrics — so reporting unconditionally would flood
+// Sentry from a single device. One event per key per interval keeps the signal
+// (including the fact that it is still happening) without the flood.
+const panicReportInterval = time.Hour
+
+var (
+	panicReportMu   sync.Mutex
+	panicReportSeen = map[string]time.Time{}
+)
+
+// shouldReportPanic reports whether this (op, value) pair is due for a Sentry
+// event, and records the decision. Split out so tests can exercise the
+// throttle without touching Sentry.
+func shouldReportPanic(op string, value any, now time.Time) bool {
+	key := fmt.Sprintf("%s|%v", op, value)
+
+	panicReportMu.Lock()
+	defer panicReportMu.Unlock()
+
+	if last, ok := panicReportSeen[key]; ok && now.Sub(last) < panicReportInterval {
+		return false
+	}
+	panicReportSeen[key] = now
+	return true
+}
+
 // recoverAs is a deferred helper that converts a panic into a *PanicError stored
-// in *err. It must be called via defer:
+// in *err, and reports it to Sentry. It must be called via defer:
 //
 //	func doThing() (err error) {
 //	    defer recoverAs("thing", &err)
@@ -33,15 +65,25 @@ func (e *PanicError) Error() string {
 //
 // A panic leaves the function's other (named or unnamed) results at their zero
 // values, so callers must treat a non-nil error as "no usable result".
+//
+// Reporting happens here rather than at the call sites because converting a
+// panic into an error stops it reaching any enclosing observability.Recoverer.
+// Without this the crash would be invisible to fleet telemetry — which is how
+// issue #3459 was noticed in the first place — and the stack would be dropped.
 func recoverAs(op string, err *error) {
 	if r := recover(); r != nil {
-		*err = &PanicError{Op: op, Value: r, Stack: string(debug.Stack())}
+		stack := string(debug.Stack())
+		*err = &PanicError{Op: op, Value: r, Stack: stack}
+		if shouldReportPanic(op, r, time.Now()) {
+			observability.ReportPanic("collectors."+op, r, stack)
+		}
 	}
 }
 
 // Guard runs fn and converts any panic it raises into a *PanicError, so that a
 // crash inside one collector degrades that collector instead of killing the
-// goroutine driving the whole collection loop.
+// goroutine driving the whole collection loop. The panic is still reported to
+// Sentry (throttled per op + panic value), so recovering does not hide it.
 //
 // On panic the returned result is the zero value for T (nil for the pointer and
 // slice types the collectors return), so callers must check err before using it

--- a/agent/internal/collectors/safe.go
+++ b/agent/internal/collectors/safe.go
@@ -1,0 +1,56 @@
+package collectors
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// PanicError reports a panic that was recovered while running a collector (or a
+// third-party library called by one). It is returned in place of the collector's
+// normal error so callers can degrade the affected metric instead of losing the
+// goroutine, while still being able to tell a crash apart from an ordinary
+// collection failure via errors.As.
+type PanicError struct {
+	// Op names the operation that panicked, e.g. "metrics" or "net.IOCounters".
+	Op string
+	// Value is whatever was passed to panic().
+	Value any
+	// Stack is the goroutine stack captured at recover time.
+	Stack string
+}
+
+func (e *PanicError) Error() string {
+	return fmt.Sprintf("panic in %s: %v", e.Op, e.Value)
+}
+
+// recoverAs is a deferred helper that converts a panic into a *PanicError stored
+// in *err. It must be called via defer:
+//
+//	func doThing() (err error) {
+//	    defer recoverAs("thing", &err)
+//	    ...
+//	}
+//
+// A panic leaves the function's other (named or unnamed) results at their zero
+// values, so callers must treat a non-nil error as "no usable result".
+func recoverAs(op string, err *error) {
+	if r := recover(); r != nil {
+		*err = &PanicError{Op: op, Value: r, Stack: string(debug.Stack())}
+	}
+}
+
+// Guard runs fn and converts any panic it raises into a *PanicError, so that a
+// crash inside one collector degrades that collector instead of killing the
+// goroutine driving the whole collection loop.
+//
+// On panic the returned result is the zero value for T (nil for the pointer and
+// slice types the collectors return), so callers must check err before using it
+// — the same contract they already have for ordinary collection errors.
+//
+// Motivating case: gopsutil's darwin netstat parser panics on unexpected
+// `netstat -ibdnW` output and took down the metrics/heartbeat goroutine
+// (issue #3459). A third-party parsing bug should never be fatal to collection.
+func Guard[T any](op string, fn func() (T, error)) (result T, err error) {
+	defer recoverAs(op, &err)
+	return fn()
+}

--- a/agent/internal/collectors/safe.go
+++ b/agent/internal/collectors/safe.go
@@ -2,6 +2,7 @@ package collectors
 
 import (
 	"fmt"
+	"regexp"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -32,24 +33,52 @@ func (e *PanicError) Error() string {
 // cycle — every ~60s for metrics — so reporting unconditionally would flood
 // Sentry from a single device. One event per key per interval keeps the signal
 // (including the fact that it is still happening) without the flood.
-const panicReportInterval = time.Hour
+const (
+	panicReportInterval = time.Hour
+	// panicReportKeyMax caps the key length so a panic value carrying command
+	// output or a long path can't retain an oversized string.
+	panicReportKeyMax = 160
+	// panicReportMaxKeys bounds the throttle map. The agent runs for months, so
+	// an unbounded map is a slow leak; on overflow we drop the whole table,
+	// which at worst re-reports each live panic once.
+	panicReportMaxKeys = 256
+)
 
 var (
 	panicReportMu   sync.Mutex
 	panicReportSeen = map[string]time.Time{}
+	// panicReportDigits collapses the varying operands that Go runtime panics
+	// embed ("index out of range [17] with length 12") so repeats of the SAME
+	// bug share one key. Without this the key differs on nearly every
+	// occurrence, which both grows the map without bound and defeats the
+	// throttle entirely — the flood it exists to prevent.
+	panicReportDigits = regexp.MustCompile(`\d+`)
 )
+
+// panicReportKey builds a throttle key that identifies the panic SITE and shape
+// rather than its exact text.
+func panicReportKey(op string, value any) string {
+	key := op + "|" + panicReportDigits.ReplaceAllString(fmt.Sprintf("%v", value), "#")
+	if len(key) > panicReportKeyMax {
+		key = key[:panicReportKeyMax]
+	}
+	return key
+}
 
 // shouldReportPanic reports whether this (op, value) pair is due for a Sentry
 // event, and records the decision. Split out so tests can exercise the
 // throttle without touching Sentry.
 func shouldReportPanic(op string, value any, now time.Time) bool {
-	key := fmt.Sprintf("%s|%v", op, value)
+	key := panicReportKey(op, value)
 
 	panicReportMu.Lock()
 	defer panicReportMu.Unlock()
 
 	if last, ok := panicReportSeen[key]; ok && now.Sub(last) < panicReportInterval {
 		return false
+	}
+	if len(panicReportSeen) >= panicReportMaxKeys {
+		panicReportSeen = make(map[string]time.Time, panicReportMaxKeys)
 	}
 	panicReportSeen[key] = now
 	return true

--- a/agent/internal/collectors/safe_test.go
+++ b/agent/internal/collectors/safe_test.go
@@ -96,9 +96,7 @@ func TestGuardDoesNotPropagatePanicToCaller(t *testing.T) {
 // panics on every cycle doesn't flood, while a DIFFERENT panic still reports
 // immediately.
 func TestShouldReportPanicThrottlesPerOpAndValue(t *testing.T) {
-	panicReportMu.Lock()
-	panicReportSeen = map[string]time.Time{}
-	panicReportMu.Unlock()
+	resetPanicReportState()
 
 	base := time.Now()
 	val := "index out of range [2] with length 1"
@@ -120,6 +118,58 @@ func TestShouldReportPanicThrottlesPerOpAndValue(t *testing.T) {
 	if !shouldReportPanic("software", val, base.Add(time.Minute)) {
 		t.Fatal("a different op must report immediately")
 	}
+}
+
+// Go runtime panics embed varying operands. If those reached the throttle key
+// verbatim, the same recurring bug would report on every cycle — the flood the
+// throttle exists to prevent — and grow the map without bound.
+func TestShouldReportPanicThrottlesAcrossVaryingOperands(t *testing.T) {
+	resetPanicReportState()
+
+	base := time.Now()
+	if !shouldReportPanic("metrics", "index out of range [2] with length 1", base) {
+		t.Fatal("first occurrence must report")
+	}
+	if shouldReportPanic("metrics", "index out of range [17] with length 12", base.Add(time.Minute)) {
+		t.Fatal("same bug with different operands must be throttled, not re-reported")
+	}
+}
+
+func TestShouldReportPanicBoundsMapGrowth(t *testing.T) {
+	resetPanicReportState()
+
+	now := time.Now()
+	for i := 0; i < panicReportMaxKeys*3; i++ {
+		// Alphabetic-only distinct ops: digit-normalisation must not be what
+		// keeps this map small, or the test would pass with no bound at all.
+		shouldReportPanic(alphaOpName(i), "boom", now)
+	}
+
+	panicReportMu.Lock()
+	size := len(panicReportSeen)
+	panicReportMu.Unlock()
+
+	if size > panicReportMaxKeys {
+		t.Fatalf("throttle map grew to %d entries, want <= %d", size, panicReportMaxKeys)
+	}
+}
+
+// alphaOpName renders i in base-26 using letters only.
+func alphaOpName(i int) string {
+	name := ""
+	for {
+		name = string(rune('a'+i%26)) + name
+		i /= 26
+		if i == 0 {
+			return "op" + name
+		}
+	}
+}
+
+func resetPanicReportState() {
+	panicReportMu.Lock()
+	panicReportSeen = map[string]time.Time{}
+	panicReportMu.Unlock()
 }
 
 func TestPanicErrorMessage(t *testing.T) {

--- a/agent/internal/collectors/safe_test.go
+++ b/agent/internal/collectors/safe_test.go
@@ -1,0 +1,100 @@
+package collectors
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestGuardPassesThroughSuccess(t *testing.T) {
+	got, err := Guard("ok", func() (int, error) { return 42, nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("got %d, want 42", got)
+	}
+}
+
+func TestGuardPassesThroughError(t *testing.T) {
+	sentinel := errors.New("collector failed")
+	got, err := Guard("failing", func() (*SystemMetrics, error) { return nil, sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("got err %v, want %v", err, sentinel)
+	}
+	if got != nil {
+		t.Fatalf("got %v, want nil result", got)
+	}
+	var panicErr *PanicError
+	if errors.As(err, &panicErr) {
+		t.Fatal("ordinary error must not be reported as a PanicError")
+	}
+}
+
+func TestGuardRecoversPanicAsError(t *testing.T) {
+	tests := []struct {
+		name      string
+		panicWith any
+		wantMsg   string
+	}{
+		{"runtime error", nil, "index out of range"},
+		{"string panic", "boom", "panic in metrics: boom"},
+		{"error panic", errors.New("kaboom"), "panic in metrics: kaboom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Guard("metrics", func() (*SystemMetrics, error) {
+				if tt.panicWith == nil {
+					// Reproduce the shape of the gopsutil darwin netstat bug:
+					// indexing a short slice (issue #3459).
+					columns := []string{"only-one-field"}
+					_ = columns[2]
+					return nil, nil
+				}
+				panic(tt.panicWith)
+			})
+
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if got != nil {
+				t.Fatalf("expected nil result on panic, got %v", got)
+			}
+			var panicErr *PanicError
+			if !errors.As(err, &panicErr) {
+				t.Fatalf("expected *PanicError, got %T", err)
+			}
+			if panicErr.Op != "metrics" {
+				t.Fatalf("Op = %q, want %q", panicErr.Op, "metrics")
+			}
+			if !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantMsg)
+			}
+			if !strings.Contains(panicErr.Stack, "collectors.") {
+				t.Fatalf("stack does not look like a real stack: %q", panicErr.Stack)
+			}
+		})
+	}
+}
+
+// The whole point of the guard is that the caller's goroutine survives, so
+// assert the panic really does not propagate past Guard.
+func TestGuardDoesNotPropagatePanicToCaller(t *testing.T) {
+	done := make(chan error, 1)
+	go func() {
+		_, err := Guard("goroutine", func() (int, error) { panic("collector exploded") })
+		done <- err
+	}()
+	if err := <-done; err == nil {
+		t.Fatal("goroutine should have received an error instead of dying")
+	}
+}
+
+func TestPanicErrorMessage(t *testing.T) {
+	err := &PanicError{Op: "net.IOCounters", Value: "index out of range [2] with length 1"}
+	want := "panic in net.IOCounters: index out of range [2] with length 1"
+	if err.Error() != want {
+		t.Fatalf("Error() = %q, want %q", err.Error(), want)
+	}
+}

--- a/agent/internal/collectors/safe_test.go
+++ b/agent/internal/collectors/safe_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGuardPassesThroughSuccess(t *testing.T) {
@@ -88,6 +89,36 @@ func TestGuardDoesNotPropagatePanicToCaller(t *testing.T) {
 	}()
 	if err := <-done; err == nil {
 		t.Fatal("goroutine should have received an error instead of dying")
+	}
+}
+
+// Sentry reporting is throttled per (op, panic value) so a collector that
+// panics on every cycle doesn't flood, while a DIFFERENT panic still reports
+// immediately.
+func TestShouldReportPanicThrottlesPerOpAndValue(t *testing.T) {
+	panicReportMu.Lock()
+	panicReportSeen = map[string]time.Time{}
+	panicReportMu.Unlock()
+
+	base := time.Now()
+	val := "index out of range [2] with length 1"
+
+	if !shouldReportPanic("metrics", val, base) {
+		t.Fatal("first occurrence must report")
+	}
+	if shouldReportPanic("metrics", val, base.Add(time.Minute)) {
+		t.Fatal("a repeat inside the interval must be throttled")
+	}
+	if !shouldReportPanic("metrics", val, base.Add(panicReportInterval+time.Second)) {
+		t.Fatal("a repeat after the interval must report again")
+	}
+	// A different panic value on the same op is a different bug.
+	if !shouldReportPanic("metrics", "nil pointer dereference", base.Add(time.Minute)) {
+		t.Fatal("a different panic value must report immediately")
+	}
+	// A different op with the same value is a different site.
+	if !shouldReportPanic("software", val, base.Add(time.Minute)) {
+		t.Fatal("a different op must report immediately")
 	}
 }
 

--- a/agent/internal/heartbeat/handlers.go
+++ b/agent/internal/heartbeat/handlers.go
@@ -322,7 +322,7 @@ func safeModeRebootNotice(delayMinutes int) string {
 func handleCollectSoftware(_ *Heartbeat, cmd Command) tools.CommandResult {
 	start := time.Now()
 	collector := collectors.NewSoftwareCollector()
-	software, err := collector.Collect()
+	software, err := collectors.Guard("software", collector.Collect)
 	if err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
@@ -406,7 +406,7 @@ func handleTerminalStop(h *Heartbeat, cmd Command) tools.CommandResult {
 
 func handleCollectBootPerformance(h *Heartbeat, cmd Command) tools.CommandResult {
 	start := time.Now()
-	metrics, err := h.bootCol.Collect()
+	metrics, err := collectors.Guard("bootPerformance", h.bootCol.Collect)
 	if err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}
@@ -450,7 +450,7 @@ func handleCollectReliabilityMetrics(h *Heartbeat, _ Command) tools.CommandResul
 		return tools.NewErrorResult(fmt.Errorf("reliability collector unavailable"), time.Since(start).Milliseconds())
 	}
 
-	metrics, err := h.reliabilityCol.Collect()
+	metrics, err := collectors.Guard("reliability", h.reliabilityCol.Collect)
 	if err != nil {
 		return tools.NewErrorResult(err, time.Since(start).Milliseconds())
 	}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1901,6 +1901,8 @@ func (h *Heartbeat) claimPatchScanLocked(now time.Time, interval time.Duration) 
 // runProcessSampler periodically captures a top-N process snapshot and POSTs it,
 // on its own ticker decoupled from the heartbeat (spec: process-sample pipeline).
 func (h *Heartbeat) runProcessSampler() {
+	// Launched as a bare goroutine; without this a panic takes down the process.
+	defer observability.Recoverer("heartbeat.processSampler")
 	configured := h.config.ProcessSampleIntervalSeconds
 	secs := clampProcessSampleInterval(configured)
 	if secs != configured {
@@ -1998,7 +2000,10 @@ func (h *Heartbeat) submitPeripheralEvents(events []peripheral.PeripheralEvent) 
 }
 
 func (h *Heartbeat) sendHardwareInventory() {
-	hw, err := h.hardwareCol.CollectHardware()
+	// Launched as a bare goroutine; without this a panic takes down the process.
+	defer observability.Recoverer("heartbeat.hardwareInventory")
+
+	hw, err := collectors.Guard("hardware", h.hardwareCol.CollectHardware)
 	if err != nil {
 		log.Error("failed to collect hardware info", "error", err.Error())
 		return
@@ -2682,6 +2687,9 @@ func (h *Heartbeat) sendPolicyConfigState() {
 }
 
 func (h *Heartbeat) sendPatchInventory() {
+	// Launched as a bare goroutine; without this a panic takes down the process.
+	defer observability.Recoverer("heartbeat.patchInventory")
+
 	pendingItems, installedItems, coveredSources, err := h.collectPatchInventory()
 	if err != nil {
 		log.Warn("patch inventory collection warning", "error", err.Error())
@@ -2705,7 +2713,17 @@ func (h *Heartbeat) sendPatchInventory() {
 		return
 	}
 
-	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, "", true, coveredSources)
+	// A failed pending collection that yielded nothing must NOT be uploaded as a
+	// full sweep: an empty pending list with full=true and no coveredSources
+	// tombstones every pending patch on the device (#2217). We still get here
+	// when installedItems is non-empty, so send those and leave pending alone
+	// rather than sweeping on the strength of a collection that crashed.
+	fullSweep := err == nil || len(pendingItems) > 0
+	if !fullSweep {
+		log.Warn("pending patch collection failed and produced no items — uploading installed only, skipping full sweep")
+	}
+
+	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, "", fullSweep, coveredSources)
 	if pendingErr != nil {
 		log.Warn("failed to send pending patch inventory", "error", pendingErr.Error())
 	}
@@ -3293,6 +3311,9 @@ func (h *Heartbeat) sendBootPerformance(metrics *collectors.BootPerformanceMetri
 // survives restarts (#1906); on any failure the persisted gate is left stale
 // so the next restart retries.
 func (h *Heartbeat) sendReliabilityMetrics(sentAt time.Time) {
+	// Launched as a bare goroutine; without this a panic takes down the process.
+	defer observability.Recoverer("heartbeat.reliabilityMetrics")
+
 	if h.reliabilityCol == nil {
 		return
 	}

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -1504,7 +1504,7 @@ func (h *Heartbeat) Start() {
 						go func() {
 							defer observability.Recoverer("heartbeat.bootPerformance")
 							log.Info("detected recent boot, collecting boot performance")
-							metrics, err := h.bootCol.Collect()
+							metrics, err := collectors.Guard("bootPerformance", h.bootCol.Collect)
 							if err != nil {
 								log.Error("failed to collect boot performance", "error", err.Error())
 								return
@@ -2039,7 +2039,7 @@ func (h *Heartbeat) sendAppleWarrantyInfo() {
 }
 
 func (h *Heartbeat) sendSoftwareInventory() {
-	software, err := h.softwareCol.Collect()
+	software, err := collectors.Guard("software", h.softwareCol.Collect)
 	if err != nil {
 		log.Error("failed to collect software inventory", "error", err.Error())
 		return
@@ -2087,7 +2087,7 @@ func (h *Heartbeat) sendNetworkInventory() {
 	payload := map[string]any{"adapters": adapters}
 	vpnLabel := "vpns skipped"
 	if h.vpnCol != nil {
-		if detected, vErr := h.vpnCol.Collect(); vErr != nil {
+		if detected, vErr := collectors.Guard("vpn", h.vpnCol.Collect); vErr != nil {
 			log.Warn("failed to collect VPN presence", "error", vErr.Error())
 		} else {
 			if detected == nil {
@@ -3005,8 +3005,10 @@ func (h *Heartbeat) installedPatchesToMaps(patches []patching.InstalledPatch) []
 }
 
 func (h *Heartbeat) collectPatchInventoryFromCollectors() ([]map[string]any, []map[string]any, error) {
-	patches, collectErr := h.patchCol.Collect()
-	installedPatches, installedErr := h.patchCol.CollectInstalled(90 * 24 * time.Hour)
+	patches, collectErr := collectors.Guard("patches", h.patchCol.Collect)
+	installedPatches, installedErr := collectors.Guard("installedPatches", func() ([]collectors.InstalledPatchInfo, error) {
+		return h.patchCol.CollectInstalled(90 * 24 * time.Hour)
+	})
 
 	pendingItems := make([]map[string]any, len(patches))
 	for i, patch := range patches {
@@ -3120,7 +3122,7 @@ func (h *Heartbeat) mapPatchSeverity(severity string) string {
 }
 
 func (h *Heartbeat) sendConnectionsInventory() {
-	connections, err := h.connectionsCol.Collect()
+	connections, err := collectors.Guard("connections", h.connectionsCol.Collect)
 	if err != nil {
 		log.Error("failed to collect connections", "error", err.Error())
 		return
@@ -3149,7 +3151,7 @@ func (h *Heartbeat) sendConnectionsInventory() {
 }
 
 func (h *Heartbeat) sendEventLogs() {
-	events, err := h.eventLogCol.Collect()
+	events, err := collectors.Guard("eventLogs", h.eventLogCol.Collect)
 	if err != nil {
 		log.Error("failed to collect event logs", "error", err.Error())
 		return
@@ -3237,7 +3239,7 @@ func (h *Heartbeat) sendSessionInventory() {
 		return
 	}
 
-	sessions, err := h.sessionCol.Collect()
+	sessions, err := collectors.Guard("sessions", h.sessionCol.Collect)
 	if err != nil {
 		log.Warn("failed to collect sessions", "error", err.Error())
 		return
@@ -3295,7 +3297,7 @@ func (h *Heartbeat) sendReliabilityMetrics(sentAt time.Time) {
 		return
 	}
 
-	metrics, err := h.reliabilityCol.Collect()
+	metrics, err := collectors.Guard("reliability", h.reliabilityCol.Collect)
 	if err != nil {
 		log.Error("failed to collect reliability metrics", "error", err.Error())
 		return
@@ -3756,7 +3758,7 @@ func (h *Heartbeat) sendHeartbeat() {
 		return
 	}
 
-	metrics, err := h.metricsCol.Collect()
+	metrics, err := collectors.Guard("metrics", h.metricsCol.Collect)
 	metricsAvailable := true
 	if err != nil {
 		log.Error("failed to collect metrics", "error", err.Error())

--- a/agent/internal/heartbeat/heartbeat.go
+++ b/agent/internal/heartbeat/heartbeat.go
@@ -2713,14 +2713,17 @@ func (h *Heartbeat) sendPatchInventory() {
 		return
 	}
 
-	// A failed pending collection that yielded nothing must NOT be uploaded as a
-	// full sweep: an empty pending list with full=true and no coveredSources
-	// tombstones every pending patch on the device (#2217). We still get here
-	// when installedItems is non-empty, so send those and leave pending alone
-	// rather than sweeping on the strength of a collection that crashed.
-	fullSweep := err == nil || len(pendingItems) > 0
+	// A failed pending collection that yielded nothing must NOT be uploaded as an
+	// unbounded full sweep: an empty pending list with full=true and a NIL
+	// coveredSources tombstones every pending patch on the device (#2217). That
+	// combination only arises on the legacy collector path, which reports no
+	// per-provider coverage. A non-nil coveredSources already narrows the sweep
+	// to the buckets that genuinely scanned clean (failed providers are excluded
+	// upstream), so it stays a full sweep even after an error — suppressing it
+	// there would strand already-installed patches as pending indefinitely.
+	fullSweep := err == nil || len(pendingItems) > 0 || coveredSources != nil
 	if !fullSweep {
-		log.Warn("pending patch collection failed and produced no items — uploading installed only, skipping full sweep")
+		log.Warn("pending patch collection failed and produced no items with no coverage info — uploading installed only, skipping full sweep")
 	}
 
 	pendingErr, installedErr := h.sendPatchInventoryData(pendingItems, installedItems, "", fullSweep, coveredSources)

--- a/agent/internal/observability/sentry.go
+++ b/agent/internal/observability/sentry.go
@@ -85,24 +85,37 @@ func CaptureException(err error) {
 //	}()
 func Recoverer(where string) {
 	if r := recover(); r != nil {
-		var err error
-		switch v := r.(type) {
-		case error:
-			err = v
-		case string:
-			err = errors.New(v)
-		default:
-			err = errors.New("panic in " + where)
-		}
-		stack := string(debug.Stack())
-		sentry.WithScope(func(scope *sentry.Scope) {
-			scope.SetTag("where", where)
-			// SetContext is the v0.46+ replacement for the removed SetExtra.
-			scope.SetContext("panic", sentry.Context{"stack": stack})
-			sentry.CaptureException(err)
-		})
-		slog.Error("recovered panic", "where", where, "err", err.Error())
+		ReportPanic(where, r, string(debug.Stack()))
 	}
+}
+
+// ReportPanic reports an ALREADY-recovered panic to Sentry with the stack +
+// context, then logs via slog. Use it when the panic was recovered elsewhere
+// and converted into a value (e.g. collectors.Guard turns a collector panic
+// into an error so the goroutine survives) — such a panic never reaches an
+// enclosing Recoverer, so without this call it would be invisible to fleet
+// telemetry. `value` is the recover() result and `stack` the stack captured at
+// recover time.
+//
+// Recoverer is the deferred form of this; both funnel through here so the two
+// paths report identically.
+func ReportPanic(where string, value any, stack string) {
+	var err error
+	switch v := value.(type) {
+	case error:
+		err = v
+	case string:
+		err = errors.New(v)
+	default:
+		err = errors.New("panic in " + where)
+	}
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetTag("where", where)
+		// SetContext is the v0.46+ replacement for the removed SetExtra.
+		scope.SetContext("panic", sentry.Context{"stack": stack})
+		sentry.CaptureException(err)
+	})
+	slog.Error("recovered panic", "where", where, "err", err.Error())
 }
 
 // scrubEvent redacts secrets from event fields before transmission.


### PR DESCRIPTION
Closes #3459

## Root cause

gopsutil's darwin `net.IOCounters` parses `netstat -ibdnW` output line by line. `parseNetstatLine` (`net/net_darwin.go`) reads `columns[0]` and `columns[2]` **before** any length check:

```go
columns = strings.Fields(line)
if columns[0] == "Name" { ... }                                   // line 31
if subMatch := netstatLinkRegexp.FindStringSubmatch(columns[2]);  // line 37  <-- panics
...
numberColumns := len(columns)                                     // line 46  first length check
```

Line 37 is exactly the frame in the reported stack. A `netstat` line with fewer fields than expected panics with `index out of range [2] with length 1`; the panic propagated out of `MetricsCollector.Collect` and killed the goroutine driving metrics/heartbeat collection until the agent restarted.

## Note on the suggested gopsutil upgrade

The issue proposed upgrading to v4 for "darwin netstat parsing fixes". **I verified that v4 does not fix this** — `v4.26.7`'s `parseNetstatLine` has the identical unguarded `columns[0]` / `columns[2]` accesses, with the first `len(columns)` check still at line 46, after both. There is no released gopsutil version to move to, so a v3 → v4 migration across 33 agent files would have been churn that fixed nothing and re-risked every other gopsutil call site on customer machines. Left on v3.24.5 and guarded at our own call sites instead.

Worth reporting upstream separately; this PR is the agent-side containment.

## The fix

**1. Targeted: `safeNetIOCounters` (`internal/collectors/netio_safe.go`)**

Wraps `net.IOCounters` and converts a panic into an error, so a bad netstat line degrades only the *network* portion of the sample — CPU, RAM and disk still get reported. This matches gopsutil's own behaviour for a malformed line (`parseNetstatOutput` already fails the whole call on any unparsable line), so no data that would otherwise have been collected is lost; it only stops the crash escaping. The panic is logged via `slog`, with the (large) stack logged once per process rather than on every collection cycle — on an affected host the panic recurs every heartbeat.

**2. Structural: `collectors.Guard[T]` (`internal/collectors/safe.go`)**

Generic wrapper that converts a panic in any collector into a `*PanicError` instead of unwinding the caller's goroutine:

```go
metrics, err := collectors.Guard("metrics", h.metricsCol.Collect)
```

Applied to all 12 collector entry points in the heartbeat paths (metrics, software, patches, installed patches, connections, event logs, sessions, reliability, boot performance, VPN). Every one of those callers already handles a collection error by logging and marking the subsystem degraded, so the panic now flows into that existing path — no new error handling, no new silent failures. `PanicError` carries the op, the panic value and the stack, and is distinguishable via `errors.As` so a crash is never mistaken for an ordinary collection failure.

On panic the guarded result is the zero value (nil for the pointer/slice types collectors return), which is the same contract callers already have for an error return.

## Verification

- `go build ./...` — clean
- `go vet ./internal/collectors/... ./internal/heartbeat/...` — clean (only a pre-existing cgo warning from `go-m1cpu`)
- `go test -race ./...` — green
- New tests (`safe_test.go`, `netio_safe_test.go`) cover: panic → error conversion for runtime/string/error panics, pass-through of success and of ordinary errors, `errors.As` discrimination, stack capture, that a panic does **not** propagate to the calling goroutine, and that `safeNetIOCounters` / `MetricsCollector.Collect` never panic. One case reproduces the exact `index out of range [2] with length 1` shape from the report.

Not reproducible on demand — this machine's current `netstat -ibdnW` output is all 11/12-field lines — so the fix is verified by construction and by the panic-shape test rather than by triggering the real netstat condition.

## Review round (second commit)

`/pr-review-toolkit:review-pr` (code-reviewer + silent-failure-hunter) raised five consequential findings, all addressed in `cb052c4ac`:

1. **Guarded panics no longer reached Sentry** (both reviewers, independently). Converting a panic to an error stopped it reaching the enclosing `observability.Recoverer` — so this fix would have made *this class of bug* invisible to fleet telemetry, which is how #3459 was noticed in the first place. `recoverAs` now reports via a new `observability.ReportPanic` (shared with `Recoverer`, so both paths report identically), throttled to one event per `(op, panic value)` per hour so a per-cycle panic can't flood from one device. The captured stack is no longer discarded.

2. **Recovery fabricated a bandwidth spike.** `c.lastTime` advances every cycle, but the network byte baselines only updated on success — so the first good cycle after a failed sample divided a multi-interval delta by a single interval. On an affected macOS host that would have been the steady state, and it feeds bandwidth alerting. Both aggregate and per-interface baselines are now dropped on a failed sample, so recovery skips one sample instead of inventing traffic. Mutation-tested: reverting the fix fails the new test.

3. **Patch inventory could tombstone every pending patch.** A panic in the pending collector left `pendingItems` empty while `installedItems` stayed populated, falling through to a `full=true` upload with no `coveredSources` — the #2217 failure mode. A failed collection producing no pending items no longer performs a full sweep.

4. **The genuinely process-fatal paths were still unguarded.** `sendHardwareInventory`, `sendPatchInventory`, `sendReliabilityMetrics` and `runProcessSampler` are bare goroutines with no recoverer, where a panic kills the *whole process* — strictly worse than #3459's single dead loop. Added `observability.Recoverer` to each, plus `Guard` on `CollectHardware` (shells out and parses output, same risk profile as `parseNetstatLine`).

5. **Two tests were vacuous.** `net.IOCounters` is now injectable, so the panic→error conversion is tested directly rather than asserted against whatever the host's `netstat` happens to emit — the previous version's error branch was unreachable.

Not changed: the server still can't distinguish "network unknown" from "idle". The network fields are `omitempty`, so a skipped sample omits the keys rather than sending a false `0`, which is the honest encoding available without a schema change. Flagged for follow-up rather than widened here.

## Verification (final)

- `go build ./...`, `go vet`, `gofmt` — clean
- `go test -race ./internal/collectors/... ./internal/heartbeat/... ./internal/observability/...` — all green
- `go test -race ./...` — green apart from two pre-existing environmental failures in untouched packages (`internal/patching` homebrew `brew outdated` 120s timeout, `internal/workspaceindex` fsnotify debounce flake); neither package is in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

