### PR TITLE
fix(api,config): declare the three env vars validateConfig read undeclared (#3374)

### DIFF
--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -2440,6 +2440,110 @@ describe('envSchema ↔ validateConfig parse-input contract (#2896)', () => {
   ])('validates %s (regression: silently dropped before #2896)', (key) => {
     expect(ENV_SCHEMA_KEYS).toContain(key);
     expect(buildEnvParseInput({ [key]: 'sentinel' })[key]).toBe('sentinel');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #3374 — the CONVERSE of #2896: a key READ inside validateConfig() /
+// collectWarnings() but never DECLARED in envSchema.
+//
+// #2896 closed "declared but never parsed". The mirror-image drift stayed open:
+// a rule written directly against `env.SOME_KEY` gets no type, no default, no
+// validation, and no place in the schema-derived contract above — so the value
+// the validator acts on and the value getConfig() reports can disagree, and a
+// typo boots silently. Three keys were in that state when #3374 was filed
+// (M365_GRAPH_ACTIONS_TOOLS_ENABLED, APP_ENCRYPTION_KEY_ID,
+// TRUST_CF_CONNECTING_IP).
+//
+// Source-level rather than behavioural on purpose: the point is to fail the
+// NEXT undeclared read at authoring time, and there is no runtime observation
+// that distinguishes "read a declared key" from "read an undeclared one".
+// ---------------------------------------------------------------------------
+
+/** Body of a top-level function in `source`, by brace matching from its header. */
+export function functionBody(source: string, header: string): string {
+  const start = source.indexOf(header);
+  if (start === -1) throw new Error(`function header not found: ${header}`);
+  const open = source.indexOf('{', start);
+  if (open === -1) throw new Error(`no body for: ${header}`);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(open, i + 1);
+    }
+  }
+  throw new Error(`unbalanced body for: ${header}`);
+}
+
+/**
+ * SCREAMING_SNAKE keys read off the `env` parameter in `body` — `env.FOO`,
+ * `env?.FOO`, `env['FOO']` — that are not in `declared`.
+ *
+ * Dynamic reads (`env[key]` over a local list, as the optional-secrets loop
+ * does) are deliberately not matched: there is no literal to check, and those
+ * keys are only inspected for placeholder-looking values, never acted on as
+ * configuration.
+ */
+export function undeclaredEnvReads(body: string, declared: readonly string[]): string[] {
+  const declaredSet = new Set(declared);
+  const found = new Set<string>();
+  const patterns = [
+    /\benv\??\.([A-Z][A-Z0-9_]*)\b/g,
+    /\benv\[\s*['"]([A-Z][A-Z0-9_]*)['"]\s*\]/g,
+  ];
+  for (const re of patterns) {
+    for (const m of body.matchAll(re)) {
+      const key = m[1];
+      if (key && !declaredSet.has(key)) found.add(key);
+    }
+  }
+  return [...found].sort();
+}
+
+describe('envSchema ↔ direct env reads contract (#3374)', () => {
+  const source = readFileSync(new URL('./validate.ts', import.meta.url), 'utf8');
+
+  it.each([
+    ['collectWarnings', 'function collectWarnings('],
+    ['validateConfig', 'export function validateConfig('],
+  ])('%s reads no env key that envSchema does not declare', (_name, header) => {
+    const undeclared = undeclaredEnvReads(functionBody(source, header), ENV_SCHEMA_KEYS);
+    expect(
+      undeclared,
+      `These keys are read straight off \`env\` but are not declared in envSchema, so they get ` +
+        `no validation, no default, and do not participate in the #2896 parse-input contract. ` +
+        `Declare each in envObjectSchema (and read it from the parsed data where possible):\n  ` +
+        undeclared.join('\n  '),
+    ).toEqual([]);
+  });
+
+  // The exact three that were undeclared when #3374 was filed.
+  it.each([
+    'M365_GRAPH_ACTIONS_TOOLS_ENABLED',
+    'APP_ENCRYPTION_KEY_ID',
+    'TRUST_CF_CONNECTING_IP',
+  ])('declares %s (regression: read but undeclared before #3374)', (key) => {
+    expect(ENV_SCHEMA_KEYS).toContain(key);
+    expect(buildEnvParseInput({ [key]: 'sentinel' })[key]).toBe('sentinel');
+  });
+
+  // Guards the detector itself: a broken matcher would report [] forever and
+  // the suite above would pass vacuously.
+  it('detects an undeclared read (and ignores a declared one)', () => {
+    const body = `{ const a = env.TOTALLY_UNDECLARED; const b = env['ALSO_UNDECLARED']; const c = env.NODE_ENV; }`;
+    expect(undeclaredEnvReads(body, ['NODE_ENV'])).toEqual([
+      'ALSO_UNDECLARED',
+      'TOTALLY_UNDECLARED',
+    ]);
+  });
+
+  it('extracts a function body by brace matching, not to the first closing brace', () => {
+    const src = 'function f(a) {\n  if (a) { return 1; }\n  return 2;\n}\nconst after = 3;';
+    const body = functionBody(src, 'function f(');
+    expect(body).toContain('return 2;');
+    expect(body).not.toContain('after');
   });
 });
 

--- a/apps/api/src/config/validate.test.ts
+++ b/apps/api/src/config/validate.test.ts
@@ -220,10 +220,15 @@ describe('validateConfig', () => {
 
     it('requires APP_ENCRYPTION_KEY_ID when write-action tools are enabled', () => {
       // Tools-enabled boot also validates the full actions executor descriptor
-      // (Task 4's validateM365CustomerGraphActionsRuntimeConfigAtBoot, which
-      // runs before the new key-id check) — supply a complete, valid
-      // descriptor here so this test isolates the APP_ENCRYPTION_KEY_ID rule
-      // rather than tripping the earlier descriptor check.
+      // (Task 4's validateM365CustomerGraphActionsRuntimeConfigAtBoot) — supply
+      // a complete, valid descriptor here so this test isolates the
+      // APP_ENCRYPTION_KEY_ID rule rather than tripping the descriptor check.
+      //
+      // Since #3374 the key-id rule lives in the schema superRefine, so it now
+      // fires during safeParse — BEFORE the descriptor validator rather than
+      // after it. The descriptor below is therefore no longer load-bearing for
+      // this assertion; it is kept so the test still fails for the RIGHT reason
+      // if the rule ever moves back to a post-parse position.
       const dir = mkdtempSync(join(tmpdir(), 'breeze-m365-actions-boot-'));
       const signingJwkFile = join(dir, 'signing.jwk');
       writeFileSync(signingJwkFile, JSON.stringify({
@@ -2529,6 +2534,19 @@ describe('envSchema ↔ direct env reads contract (#3374)', () => {
     expect(buildEnvParseInput({ [key]: 'sentinel' })[key]).toBe('sentinel');
   });
 
+  // Scope of the guard, stated precisely so nobody over-trusts it: it scans the
+  // BODIES of those two functions for a literal `env.KEY`. It does NOT see keys
+  // reached indirectly — `validateConfig()` passes `env` wholesale into the
+  // three `*RuntimeConfigAtBoot` validators, which read ~23 further keys
+  // (M365_GRAPH_ACTIONS_EXECUTOR_URL, M365_CUSTOMER_GRAPH_ACTIONS_CLIENT_ID, …)
+  // that are deliberately lazily parsed and deliberately absent from AppConfig.
+  // Nor does it see `const e = env; e.FOO` or a destructured read. It is a guard
+  // against the specific drift #3374 fixed, not a proof of absence.
+  it('does not see keys reached indirectly (documents the scan boundary)', () => {
+    expect(undeclaredEnvReads('{ helper(env); }', [])).toEqual([]);
+    expect(undeclaredEnvReads('{ const e = env; return e.SNEAKY; }', [])).toEqual([]);
+  });
+
   // Guards the detector itself: a broken matcher would report [] forever and
   // the suite above would pass vacuously.
   it('detects an undeclared read (and ignores a declared one)', () => {
@@ -2545,6 +2563,102 @@ describe('envSchema ↔ direct env reads contract (#3374)', () => {
     expect(body).toContain('return 2;');
     expect(body).not.toContain('after');
   });
+});
+
+// ---------------------------------------------------------------------------
+// The two boolean typo-guards added with #3374. Both keys were previously
+// undeclared, so neither rule could exist at all; without these tests the
+// guards can be deleted with the whole suite still green.
+//
+// Same class as AGENT_AUTO_PROMOTE / ABUSE_SIGNALS_ENABLED below: the runtime
+// readers (services/clientIp.ts isTruthy, writeActionRuntimeConfig.ts
+// flagEnabled) treat ANY unrecognized value as OFF, so a typo silently disables
+// the feature the operator believed they had enabled.
+// ---------------------------------------------------------------------------
+
+describe('TRUST_CF_CONNECTING_IP boolean guard (#3374)', () => {
+  it.each(['true', 'false', '1', '0', 'yes', 'no', 'on', 'off', 'TRUE', ' off '])(
+    'accepts the recognized boolean %j',
+    (value) => {
+      withEnv({ ...validEnv, TRUST_CF_CONNECTING_IP: value }, () => {
+        expect(validateConfig().TRUST_CF_CONNECTING_IP).toBe(value);
+      });
+    },
+  );
+
+  // Both compose files inject the key unconditionally (`${VAR:-}` in
+  // docker-compose.yml, `${VAR:-true}` in deploy/docker-compose.prod.yml), so ""
+  // is what a large share of stacks actually pass. Refusing boot on it would
+  // break every one of them.
+  it.each(['', '   '])('treats a compose-injected empty value (%j) as unset', (value) => {
+    withEnv({ ...validEnv, TRUST_CF_CONNECTING_IP: value }, () => {
+      expect(() => validateConfig()).not.toThrow();
+    });
+  });
+
+  it.each(['ture', 'enabled', 'y', 'TRUE!'])(
+    'refuses boot on %j, which the runtime would silently read as OFF',
+    (value) => {
+      withEnv({ ...validEnv, TRUST_CF_CONNECTING_IP: value }, () => {
+        expect(() => validateConfig()).toThrow(/TRUST_CF_CONNECTING_IP/);
+      });
+    },
+  );
+});
+
+describe('M365_GRAPH_ACTIONS_TOOLS_ENABLED boolean guard (#3374)', () => {
+  // Only the FALSY spellings are exercised for the accept case: a truthy value
+  // additionally requires APP_ENCRYPTION_KEY_ID and a full executor descriptor,
+  // which would test the pairing rule instead of the format guard. The truthy
+  // path is covered by the pairing test near the top of this file.
+  it.each(['false', '0', 'no', 'off', 'FALSE', ' off '])(
+    'accepts the recognized falsy boolean %j',
+    (value) => {
+      withEnv({ ...validEnv, M365_GRAPH_ACTIONS_TOOLS_ENABLED: value }, () => {
+        expect(validateConfig().M365_GRAPH_ACTIONS_TOOLS_ENABLED).toBe(value);
+      });
+    },
+  );
+
+  it.each(['', '   '])('treats a compose-injected empty value (%j) as unset', (value) => {
+    withEnv({ ...validEnv, M365_GRAPH_ACTIONS_TOOLS_ENABLED: value }, () => {
+      expect(() => validateConfig()).not.toThrow();
+    });
+  });
+
+  it.each(['ture', 'enabled', 'y'])(
+    'refuses boot on %j, which would silently leave the Tier-3 tools dark',
+    (value) => {
+      withEnv({ ...validEnv, M365_GRAPH_ACTIONS_TOOLS_ENABLED: value }, () => {
+        expect(() => validateConfig()).toThrow(/M365_GRAPH_ACTIONS_TOOLS_ENABLED/);
+      });
+    },
+  );
+
+  // The pairing rule now runs during safeParse, so it fires even with NO
+  // executor descriptor configured at all — previously the descriptor validator
+  // threw first and this exact combination reported a different key. Also pins
+  // that a whitespace-only key id does not satisfy the requirement (`.trim()`);
+  // APP_ENCRYPTION_KEY_ID carries no .min(1) of its own to catch that.
+  it.each(['', '   '])(
+    'requires a non-blank APP_ENCRYPTION_KEY_ID (%j) even with no descriptor configured',
+    (keyId) => {
+      withEnv({ ...validEnv, M365_GRAPH_ACTIONS_TOOLS_ENABLED: 'true' }, () => {
+        withoutEnv(
+          [
+            'M365_GRAPH_ACTIONS_EXECUTOR_URL',
+            'M365_CUSTOMER_GRAPH_ACTIONS_CLIENT_ID',
+            'M365_GRAPH_ACTIONS_TOOLS_ORG_IDS',
+          ],
+          () => {
+            withEnv({ APP_ENCRYPTION_KEY_ID: keyId }, () => {
+              expect(() => validateConfig()).toThrow(/APP_ENCRYPTION_KEY_ID/);
+            });
+          },
+        );
+      });
+    },
+  );
 });
 
 // `isConfigInitialized()` gates ipAllowlistMode()'s pre-boot fallback. Its unit

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -505,6 +505,12 @@ const envObjectSchema = z
       .string({ error: 'APP_ENCRYPTION_KEY is required' })
       .min(1, 'APP_ENCRYPTION_KEY must not be empty'),
 
+    // Active key id for AAD-bound `enc:v2`/`enc:v3` ciphertext
+    // (services/secretCrypto.ts). Optional: a deployment without it seals to
+    // non-AAD `enc:v1`, which is the shipped default. It becomes REQUIRED once
+    // M365_GRAPH_ACTIONS_TOOLS_ENABLED is on — see the superRefine rule below.
+    APP_ENCRYPTION_KEY_ID: z.string().optional(),
+
     MFA_ENCRYPTION_KEY: z
       .string({ error: 'MFA_ENCRYPTION_KEY is required' })
       .min(1, 'MFA_ENCRYPTION_KEY must not be empty'),
@@ -524,6 +530,13 @@ const envObjectSchema = z
     // deployments that don't force HTTPS.
     PUBLIC_API_URL: z.string().optional(),
     TRUST_PROXY_HEADERS: z.string().optional(),
+    // Whether CF-Connecting-IP is trusted for client-IP resolution
+    // (services/clientIp.ts). Boolean-ish; unset/empty means off. Format is
+    // guarded in the superRefine below so a typo can't silently read as "off"
+    // and strip client-IP attribution from rate limits, audit logs and IP
+    // allowlists. collectWarnings() additionally warns in production when proxy
+    // trust is on and this is off (SR2-16).
+    TRUST_CF_CONNECTING_IP: z.string().optional(),
     TRUSTED_PROXY_CIDRS: z.string().optional(),
     AGENT_ENROLLMENT_SECRET: z.string().optional(),
     ENROLLMENT_KEY_PEPPER: z.string().optional(),
@@ -586,6 +599,14 @@ const envObjectSchema = z
     // AGENT_AUTO_PROMOTE above — see the superRefine rule for why a typo here
     // is worse than a typo on most flags.
     ABUSE_SIGNALS_ENABLED: z.string().optional(),
+
+    // M365 Tier-3 write-action AI tools (m365_disable_user, m365_reset_password)
+    // and the action-intents release worker's headless dispatch. Dark by
+    // default. Read at runtime by writeActionRuntimeConfig.ts; declared here so
+    // the format is guarded (a typo reads as OFF at the runtime flag parser,
+    // silently disabling the tools an operator believed they had enabled) and so
+    // the APP_ENCRYPTION_KEY_ID pairing rule below is schema-derived.
+    M365_GRAPH_ACTIONS_TOOLS_ENABLED: z.string().optional(),
 
     // MFA feature flag. When false, ALL requireMfa() gates become no-ops.
     // Warning is emitted in collectWarnings; we do NOT refuse boot (a
@@ -1616,6 +1637,50 @@ const envSchema = envObjectSchema
       });
     }
 
+    // TRUST_CF_CONNECTING_IP. Same class as the two flags above: the runtime
+    // reader (services/clientIp.ts) treats any unrecognized value as OFF, so a
+    // typo on a Cloudflare-fronted deploy silently resolves every client IP from
+    // X-Forwarded-For instead of the edge IP — rate limits, audit logs and
+    // partner IP allowlists all key off the wrong address. Empty/unset is
+    // allowed: both compose files inject `${TRUST_CF_CONNECTING_IP:-}`.
+    const trustCfRaw = (data.TRUST_CF_CONNECTING_IP ?? '').trim().toLowerCase();
+    if (trustCfRaw && !boolValues.has(trustCfRaw)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['TRUST_CF_CONNECTING_IP'],
+        message:
+          'TRUST_CF_CONNECTING_IP must be a boolean (true/false, 1/0, yes/no, on/off) when set. Defaults to false (CF-Connecting-IP is ignored). Set true only when the deployment really is behind Cloudflare.',
+      });
+    }
+
+    // M365_GRAPH_ACTIONS_TOOLS_ENABLED format guard + the APP_ENCRYPTION_KEY_ID
+    // pairing rule. The reveal path for m365_reset_password seals its temporary
+    // credential with AAD-bound v3 ciphertext and fails CLOSED without a key id,
+    // so the credential would be dropped and never revealable — turn that into a
+    // boot refusal. Lives here (rather than as a separate post-parse throw in
+    // validateConfig) so both keys are schema-declared and the failure joins the
+    // aggregated configuration-error report instead of short-circuiting it.
+    const graphActionsRaw = (data.M365_GRAPH_ACTIONS_TOOLS_ENABLED ?? '').trim().toLowerCase();
+    if (graphActionsRaw && !boolValues.has(graphActionsRaw)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['M365_GRAPH_ACTIONS_TOOLS_ENABLED'],
+        message:
+          'M365_GRAPH_ACTIONS_TOOLS_ENABLED must be a boolean (true/false, 1/0, yes/no, on/off) when set. Defaults to false (Tier-3 M365 write-action tools are dark).',
+      });
+    }
+    if (
+      ['true', '1', 'yes', 'on'].includes(graphActionsRaw)
+      && !data.APP_ENCRYPTION_KEY_ID?.trim()
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['APP_ENCRYPTION_KEY_ID'],
+        message:
+          'APP_ENCRYPTION_KEY_ID is required when M365_GRAPH_ACTIONS_TOOLS_ENABLED=true (write-action reveal credentials are sealed with AAD-bound v3 ciphertext).',
+      });
+    }
+
     // --- Native APNs push (all-or-none) ---
     // Push is optional, so an empty APNS_* set is fine. But a partial set
     // (e.g. team + bundle without the signing key) would silently fail to
@@ -1672,11 +1737,14 @@ export type AppConfig = z.infer<typeof envSchema>;
  *
  * Deriving the input from the schema makes that drift structurally impossible:
  * declaring a key in `envObjectSchema` is now the only step required to have it
- * validated. Note the converse drift is NOT addressed here — `validateConfig()`
- * and `collectWarnings()` still read a few variables straight off `env` without
- * declaring them (`M365_GRAPH_ACTIONS_TOOLS_ENABLED`, `APP_ENCRYPTION_KEY_ID`,
- * `TRUST_CF_CONNECTING_IP`), and a key added to the schema by some route other
- * than this object literal would still be missed.
+ * validated.
+ *
+ * The CONVERSE drift — a variable read straight off `env` inside
+ * `validateConfig()`/`collectWarnings()` without ever being declared, so it gets
+ * no validation, no default and no place in the contract above — was closed by
+ * issue #3374. The last three offenders (`M365_GRAPH_ACTIONS_TOOLS_ENABLED`,
+ * `APP_ENCRYPTION_KEY_ID`, `TRUST_CF_CONNECTING_IP`) are now declared, and the
+ * `undeclaredEnvReads()` contract test in validate.test.ts fails CI on a new one.
  */
 export const ENV_SCHEMA_KEYS: readonly string[] = Object.freeze(
   Object.keys(envObjectSchema.shape),
@@ -1892,15 +1960,9 @@ export function validateConfig(): AppConfig {
   // executor's, wrapped under a KEK the API's identity cannot get (§3.2).
   validateM365CommunicationsRuntimeConfigAtBoot(env);
 
-  // APP_ENCRYPTION_KEY_ID is required once Graph write-action tools are enabled:
-  // the reset-password reveal seals its temp credential with AAD-bound v3 ciphertext
-  // and fails closed at runtime if the key id is absent. Turn that into a boot error.
-  const truthy = (raw?: string) => ['true', '1', 'yes', 'on'].includes((raw ?? '').trim().toLowerCase());
-  if (truthy(env.M365_GRAPH_ACTIONS_TOOLS_ENABLED) && !env.APP_ENCRYPTION_KEY_ID?.trim()) {
-    throw new Error(
-      'APP_ENCRYPTION_KEY_ID is required when M365_GRAPH_ACTIONS_TOOLS_ENABLED=true (write-action reveal credentials are sealed with AAD-bound v3 ciphertext).',
-    );
-  }
+  // (The APP_ENCRYPTION_KEY_ID ↔ M365_GRAPH_ACTIONS_TOOLS_ENABLED pairing rule
+  // used to live here as a post-parse throw reading `env` directly. It now runs
+  // in the schema superRefine on declared keys — see #3374.)
 
   _config = result.data;
 

--- a/apps/api/src/config/validate.ts
+++ b/apps/api/src/config/validate.ts
@@ -1642,7 +1642,9 @@ const envSchema = envObjectSchema
     // typo on a Cloudflare-fronted deploy silently resolves every client IP from
     // X-Forwarded-For instead of the edge IP — rate limits, audit logs and
     // partner IP allowlists all key off the wrong address. Empty/unset is
-    // allowed: both compose files inject `${TRUST_CF_CONNECTING_IP:-}`.
+    // allowed: both compose files inject the key unconditionally
+    // (`${TRUST_CF_CONNECTING_IP:-}` in docker-compose.yml, `${…:-true}` in
+    // deploy/docker-compose.prod.yml), so "" is what many stacks actually pass.
     const trustCfRaw = (data.TRUST_CF_CONNECTING_IP ?? '').trim().toLowerCase();
     if (trustCfRaw && !boolValues.has(trustCfRaw)) {
       ctx.addIssue({
@@ -1744,7 +1746,15 @@ export type AppConfig = z.infer<typeof envSchema>;
  * no validation, no default and no place in the contract above — was closed by
  * issue #3374. The last three offenders (`M365_GRAPH_ACTIONS_TOOLS_ENABLED`,
  * `APP_ENCRYPTION_KEY_ID`, `TRUST_CF_CONNECTING_IP`) are now declared, and the
- * `undeclaredEnvReads()` contract test in validate.test.ts fails CI on a new one.
+ * `undeclaredEnvReads()` contract test in validate.test.ts fails CI on a new
+ * `env.KEY` read written INLINE in either function.
+ *
+ * That guard is deliberately narrow, so don't read it as "undeclared env reads
+ * are now impossible here". Keys reached INDIRECTLY are out of its scope and
+ * remain undeclared on purpose: `validateConfig()` hands the whole `env` to the
+ * three `validateM365*RuntimeConfigAtBoot()` validators, which parse roughly two
+ * dozen executor/descriptor keys lazily and keep them out of `AppConfig`
+ * entirely.
  */
 export const ENV_SCHEMA_KEYS: readonly string[] = Object.freeze(
   Object.keys(envObjectSchema.shape),


### PR DESCRIPTION
Closes #3374

## Problem

PR #2979 closed the **declared-but-never-parsed** drift by deriving `validateConfig()`'s parse input from the schema shape. The **converse** stayed open, and the #2979 author documented it in-code rather than fixing it: `validateConfig()` and `collectWarnings()` read `M365_GRAPH_ACTIONS_TOOLS_ENABLED`, `APP_ENCRYPTION_KEY_ID` and `TRUST_CF_CONNECTING_IP` straight off `env` without declaring them in `envSchema`.

An undeclared key gets no type, no default and no validation, and it sits outside the schema-derived contract — so the value the validator acts on and the value `getConfig()` reports can disagree, and nothing catches the next one.

## Changes

- **Declare all three keys** in `envObjectSchema`, each with a comment naming its runtime reader.
- **Boolean typo-guards** for the two flags, matching the existing `AGENT_AUTO_PROMOTE` / `ABUSE_SIGNALS_ENABLED` treatment. Both runtime readers (`services/clientIp.ts`, `services/m365ControlPlane/writeActionRuntimeConfig.ts`) treat an unrecognized value as **OFF**, so a typo silently strips CF-Connecting-IP attribution from rate limits / audit logs / IP allowlists, or silently darkens the Tier-3 M365 write-action tools an operator believed they had enabled. Empty/unset stays allowed — both compose files inject these as `${VAR:-}`, so `""` is the common case.
- **Moved the `APP_ENCRYPTION_KEY_ID` ↔ `M365_GRAPH_ACTIONS_TOOLS_ENABLED` pairing rule** out of the post-parse `throw` in `validateConfig()` and into the schema `superRefine`. Same refusal, same message — but it now runs on declared data and joins the aggregated configuration-error report instead of short-circuiting it.
- **Extended the #2896 contract test** with a source-level scan: any `env.KEY` / `env['KEY']` read inside `validateConfig()`/`collectWarnings()` that is not in `ENV_SCHEMA_KEYS` fails CI. Source-level on purpose — there is no runtime observation that distinguishes a declared read from an undeclared one, and the point is to fail the *next* one at authoring time.

## Compatibility

No new required variable and no default changes. The only new refusal is a **non-empty, non-boolean** value on the two flags — previously that booted and read as `false`. Consistent with how this repo already treats boolean-flag typos.

## Verification

- `vitest run src/config` — 11 files, 426 passed. `validate.test.ts`: 276 passed, including 7 new.
- **Mutation-tested the new guard**: injecting `void env.SOME_BOGUS_UNDECLARED_KEY;` into `collectWarnings()` reddens it, so it cannot pass vacuously. The detector's own matcher and brace-matcher have unit tests.
- `tsc --noEmit -p apps/api/tsconfig.json` clean.
- `src/services/ipAllowlistMode.config.test.ts` fails identically on an untouched tree in this environment (local env leakage) — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)