### PR TITLE
fix(api,web,shared): http/https allowlist for partner website URLs (#3430)

### DIFF
--- a/apps/api/src/routes/invoices/settings.test.ts
+++ b/apps/api/src/routes/invoices/settings.test.ts
@@ -69,6 +69,32 @@ describe('billing settings routes', () => {
     expect(svc.updatePartnerBillingSettings).not.toHaveBeenCalled();
   });
 
+  // #3430 — billingWebsite is snapshotted onto issued invoices/quotes and
+  // rendered in branded PDFs and the customer portal, so a dangerous scheme
+  // must be rejected at the boundary rather than persisted on a 200.
+  it.each(['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>', 'file:///etc/passwd'])(
+    'PATCH /partner/billing-settings rejects billingWebsite %j (→ 400, no service call)',
+    async (billingWebsite) => {
+      const res = await invoiceSettingsRoutes.request('/partner/billing-settings', jsonBody({
+        currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30, billingWebsite
+      }));
+      expect(res.status).toBe(400);
+      expect(svc.updatePartnerBillingSettings).not.toHaveBeenCalled();
+    }
+  );
+
+  it('PATCH /partner/billing-settings accepts an https billingWebsite', async () => {
+    const res = await invoiceSettingsRoutes.request('/partner/billing-settings', jsonBody({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingWebsite: 'https://acme.example.com'
+    }));
+    expect(res.status).toBe(200);
+    expect(svc.updatePartnerBillingSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ billingWebsite: 'https://acme.example.com' }),
+      expect.objectContaining({ partnerId: 'p1' })
+    );
+  });
+
   it('PATCH /orgs/:orgId/billing-settings updates org config', async () => {
     (svc.updateOrgBillingSettings as any).mockResolvedValue({ id: ORG_ID, taxExempt: true, taxRate: null });
     const res = await invoiceSettingsRoutes.request(`/orgs/${ORG_ID}/billing-settings`, jsonBody({

--- a/apps/api/src/routes/orgs.test.ts
+++ b/apps/api/src/routes/orgs.test.ts
@@ -1098,6 +1098,79 @@ describe('org routes', () => {
         }
       );
     });
+
+    // The three sibling URL fields share the same helper as contact.website but
+    // had NO coverage of their own — the suite stayed 213/213 green with all
+    // three guards deleted (#3430 review). They are defense-in-depth (egress is
+    // separately guarded by safeFetch), which is exactly why a silent
+    // regression here would go unnoticed.
+    describe('sibling URL fields share the scheme allowlist', () => {
+      function seedPartner() {
+        vi.mocked(db.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+              limit: vi.fn().mockResolvedValue([{ id: 'partner-123', name: 'P', settings: {} }])
+            })
+          })
+        } as any);
+      }
+
+      async function patchSettings(settings: Record<string, unknown>) {
+        return app.request('/orgs/partners/me', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ settings })
+        });
+      }
+
+      const BAD = 'javascript:alert(1)';
+      const cases: Array<[string, Record<string, unknown>, Record<string, unknown>]> = [
+        [
+          'notifications.slackWebhookUrl',
+          { notifications: { slackWebhookUrl: BAD } },
+          { notifications: { slackWebhookUrl: 'https://hooks.slack.example/x' } },
+        ],
+        [
+          'notifications.webhooks[]',
+          { notifications: { webhooks: [BAD] } },
+          { notifications: { webhooks: ['https://hooks.example.com/x'] } },
+        ],
+        [
+          'eventLogs.elasticsearchUrl',
+          { eventLogs: { elasticsearchUrl: BAD } },
+          { eventLogs: { elasticsearchUrl: 'https://es.example.com:9200' } },
+        ],
+      ];
+
+      it.each(cases)('rejects a dangerous scheme on %s with 400 and never writes it', async (_label, bad) => {
+        setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+        seedPartner();
+        const setSpy = vi.fn();
+        vi.mocked(db.update).mockReturnValue({ set: setSpy } as any);
+
+        const res = await patchSettings(bad);
+
+        expect(res.status).toBe(400);
+        expect(setSpy).not.toHaveBeenCalled();
+      });
+
+      it.each(cases)('accepts an https value on %s', async (_label, _bad, good) => {
+        setAuthContext({ scope: 'partner', partnerId: 'partner-123' });
+        seedPartner();
+        vi.mocked(db.update).mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'partner-123', name: 'P', settings: {} }])
+            })
+          })
+        } as any);
+
+        const res = await patchSettings(good);
+
+        expect(res.status).toBe(200);
+      });
+    });
   });
 
   describe('PATCH /orgs/partners/me — ticketing.inbound merge safety', () => {

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -468,12 +468,20 @@ const supportedLocales = ['en', 'pt-BR', 'es-419', 'fr-FR', 'fr-CA', 'de-DE', 'i
  * The partner-settings URL fields below are restricted to http/https by the
  * shared `httpUrlValue`/`httpUrlField` helpers (`@breeze/shared`). They split
  * into two risk classes and both land on the same guard:
- *  - values rendered as links (contact.website → branded PDFs, invoices, email
- *    footers), where `javascript:`/`data:text/html,…` is stored XSS against the
- *    partner's own customers;
+ *
+ *  - `contact.website` — a partner-authored value shaped like a link. Its only
+ *    consumers today are this settings form itself (PartnerSettingsPage /
+ *    PartnerCompanyTab), so there is no live XSS sink; the guard is here so the
+ *    first person to put it in an `href` inherits a safe value. NOTE: the
+ *    website printed on branded PDFs/invoices/quotes is a DIFFERENT column,
+ *    `partners.billing_website` (see `buildSellerSnapshot`), validated by
+ *    `partnerBillingSettingsSchema` in `@breeze/shared`.
  *  - values the SERVER dials outbound (Slack webhook, extra webhooks, the
- *    Elasticsearch endpoint), where `file://` and friends are an SSRF/scheme-
- *    confusion problem rather than an XSS one.
+ *    Elasticsearch endpoint), where a non-http scheme like `file://` is a
+ *    scheme-confusion problem rather than an XSS one. This guard covers the
+ *    SCHEME only — it is NOT an SSRF control, and deliberately still permits
+ *    `http://localhost` / link-local hosts, which some self-hosted deployments
+ *    legitimately point at.
  *
  * None has a legitimate custom-scheme use — unlike the remote-access launcher
  * template further down this file, which deliberately allows `rustdesk:` and

--- a/apps/api/src/routes/orgs.ts
+++ b/apps/api/src/routes/orgs.ts
@@ -28,7 +28,7 @@ import { captureException } from '../services/sentry';
 import { encryptColumnValueForWrite } from '../services/encryptedColumnRegistry';
 import { syncBillingContactRow, syncSiteContactRow } from '../services/contacts/compat';
 import { escapeLike } from '../utils/sql';
-import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE, normalizeVersionPin, PINNABLE_COMPONENTS, agentVersionPinsSchema, enrollmentDefaultsSchema } from '@breeze/shared';
+import { isAllowedLauncherScheme, isValidIanaTimezone, canonicalizeTimezone, isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE, normalizeVersionPin, PINNABLE_COMPONENTS, agentVersionPinsSchema, enrollmentDefaultsSchema, httpUrlValue, httpUrlField } from '@breeze/shared';
 import type { IpAllowlistStatus, ResolvedEnrollmentDefaults, SupportedLocale } from '@breeze/shared';
 import { getEnrollmentDefaultsForOrg } from '../services/enrollmentDefaults';
 import { isValidIpOrCidr } from '../services/ipMatch';
@@ -464,10 +464,10 @@ const dayScheduleSchema = z.object({
 
 const supportedLocales = ['en', 'pt-BR', 'es-419', 'fr-FR', 'fr-CA', 'de-DE', 'it-IT'] as const satisfies readonly SupportedLocale[];
 
-/**
- * A partner-settings URL restricted to http/https.
- *
- * These fields split into two risk classes and both land here:
+/*
+ * The partner-settings URL fields below are restricted to http/https by the
+ * shared `httpUrlValue`/`httpUrlField` helpers (`@breeze/shared`). They split
+ * into two risk classes and both land on the same guard:
  *  - values rendered as links (contact.website → branded PDFs, invoices, email
  *    footers), where `javascript:`/`data:text/html,…` is stored XSS against the
  *    partner's own customers;
@@ -475,36 +475,13 @@ const supportedLocales = ['en', 'pt-BR', 'es-419', 'fr-FR', 'fr-CA', 'de-DE', 'i
  *    Elasticsearch endpoint), where `file://` and friends are an SSRF/scheme-
  *    confusion problem rather than an XSS one.
  *
- * All four were plain `z.string()` and persisted whatever was sent on a 200.
  * None has a legitimate custom-scheme use — unlike the remote-access launcher
  * template further down this file, which deliberately allows `rustdesk:` and
  * similar and therefore keeps its own wider allowlist.
  *
- * Empty string is accepted so a field can be cleared.
+ * The helpers used to live here; they moved to the shared package (#3430) so
+ * the web form and the billing-settings schema enforce the identical rule.
  */
-function httpUrlValue(label: string) {
-  return z
-    .string()
-    .max(2000)
-    .refine(
-      (v) => {
-        if (v === '') return true;
-        let parsed: URL;
-        try {
-          parsed = new URL(v);
-        } catch {
-          return false;
-        }
-        return parsed.protocol === 'https:' || parsed.protocol === 'http:';
-      },
-      `${label} must be a full http:// or https:// URL`,
-    );
-}
-
-/** Optional/clearable form of {@link httpUrlValue}, for standalone fields. */
-function httpUrlField(label: string) {
-  return httpUrlValue(label).optional().or(z.literal(''));
-}
 
 const partnerSettingsSchema = z.object({
   // Partner tz is the canonical default for every downstream tz field (#1318),

--- a/apps/api/src/services/sellerSnapshot.ts
+++ b/apps/api/src/services/sellerSnapshot.ts
@@ -45,6 +45,15 @@ export function buildSellerSnapshot(partner: PartnerContactFields | null | undef
     },
     phone: partner?.billingPhone ?? null,
     email: partner?.billingEmail ?? null,
+    // DO NOT LINKIFY `website` downstream without adding an output-side scheme
+    // filter first (#3430). Writes are http/https-only as of #3430, but:
+    //  - rows predating that guard may still hold any string, and
+    //  - this snapshot is frozen into `invoices.seller_snapshot` /
+    //    `quotes.seller_snapshot` (immutable jsonb, never re-validated on read),
+    //    so a later scrub of `partners.billing_website` will NOT reach documents
+    //    already issued.
+    // Every current render site (quotePdf, invoicePdf, the web + portal document
+    // views) emits this as plain text, which is what keeps legacy values inert.
     website: partner?.billingWebsite ?? null,
   };
 }

--- a/apps/web/src/components/billing/PartnerBillingSettings.test.tsx
+++ b/apps/web/src/components/billing/PartnerBillingSettings.test.tsx
@@ -116,4 +116,65 @@ describe('PartnerBillingSettings', () => {
       expect(body.billingAddressLine1).toBeNull();
     });
   });
+
+  // #3430 — this form PATCHes the FULL payload, so a legacy scheme-less
+  // billingWebsite would 400 an unrelated edit with only a toast naming the
+  // wire field. The inline guard points at the offending field first.
+  describe('billingWebsite scheme guard', () => {
+    const loaded = (billingWebsite: string | null) => json({
+      currencyCode: 'USD', defaultTaxRate: null, invoiceNumberPrefix: 'INV',
+      invoiceTermsDays: 30, invoiceFooter: null, billingWebsite,
+    });
+
+    it('flags a legacy scheme-less value loaded from the server and blocks the save', async () => {
+      fetchMock.mockResolvedValue(loaded('acme.test'));
+      render(<PartnerBillingSettings />);
+      await waitFor(() => expect(screen.getByTestId('partner-billing-settings')).toBeInTheDocument());
+
+      expect(screen.getByTestId('partner-billing-website-error')).toBeInTheDocument();
+      const input = screen.getByTestId('partner-billing-website');
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+      expect(input.getAttribute('aria-describedby')).toBe('pb-website-error');
+
+      const saveBtn = screen.getByTestId('partner-billing-save') as HTMLButtonElement;
+      expect(saveBtn.disabled).toBe(true);
+      fireEvent.click(saveBtn);
+      await waitFor(() => {
+        const patch = fetchMock.mock.calls.find((c) => (c[1] as RequestInit)?.method === 'PATCH');
+        expect(patch).toBeFalsy();
+      });
+    });
+
+    it.each(['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>', 'file:///etc/passwd'])(
+      'flags %j typed into the field',
+      async (value) => {
+        fetchMock.mockResolvedValue(loaded(null));
+        render(<PartnerBillingSettings />);
+        await waitFor(() => expect(screen.getByTestId('partner-billing-settings')).toBeInTheDocument());
+
+        fireEvent.change(screen.getByTestId('partner-billing-website'), { target: { value } });
+        expect(screen.getByTestId('partner-billing-website-error')).toBeInTheDocument();
+        expect((screen.getByTestId('partner-billing-save') as HTMLButtonElement).disabled).toBe(true);
+      },
+    );
+
+    it('clears the error and re-enables the save once corrected', async () => {
+      fetchMock.mockResolvedValue(loaded('acme.test'));
+      render(<PartnerBillingSettings />);
+      await waitFor(() => expect(screen.getByTestId('partner-billing-settings')).toBeInTheDocument());
+      expect(screen.getByTestId('partner-billing-website-error')).toBeInTheDocument();
+
+      fireEvent.change(screen.getByTestId('partner-billing-website'), { target: { value: 'https://acme.test' } });
+      expect(screen.queryByTestId('partner-billing-website-error')).toBeNull();
+      expect((screen.getByTestId('partner-billing-save') as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('does not flag an empty website', async () => {
+      fetchMock.mockResolvedValue(loaded(null));
+      render(<PartnerBillingSettings />);
+      await waitFor(() => expect(screen.getByTestId('partner-billing-settings')).toBeInTheDocument());
+      expect(screen.queryByTestId('partner-billing-website-error')).toBeNull();
+      expect((screen.getByTestId('partner-billing-save') as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
 });

--- a/apps/web/src/components/billing/PartnerBillingSettings.tsx
+++ b/apps/web/src/components/billing/PartnerBillingSettings.tsx
@@ -5,6 +5,7 @@ import { fetchWithAuth } from '../../stores/auth';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, handleActionError } from '../../lib/runAction';
 import { pctFromFraction } from './invoiceTypes';
+import { isHttpUrl, httpUrlErrorMessage } from '@breeze/shared';
 
 const UNAUTHORIZED = () => void navigateTo('/login', { replace: true });
 
@@ -93,8 +94,17 @@ export default function PartnerBillingSettings() {
 
   useEffect(() => { void load(); }, [load]);
 
+  // #3430 — billingWebsite is now http/https-only server-side. This form PATCHes
+  // the FULL payload, so a legacy scheme-less value loaded at :79 would 400 an
+  // otherwise-unrelated edit (tax rate, invoice prefix) with only a toast naming
+  // the wire field. Flagging it inline points at the field that actually needs
+  // fixing, before the round-trip.
+  const websiteTrimmed = website.trim();
+  const websiteInvalid = websiteTrimmed !== '' && !isHttpUrl(websiteTrimmed);
+
   const save = useCallback(async () => {
     if (saving) return;
+    if (websiteInvalid) return;
     setSaving(true);
     try {
       const pct = taxPercent.trim();
@@ -135,7 +145,7 @@ export default function PartnerBillingSettings() {
     } finally {
       setSaving(false);
     }
-  }, [saving, currencyCode, taxPercent, prefix, termsDays, markupPercent, autoTaxHardware, aiStyle, footer,
+  }, [saving, websiteInvalid, currencyCode, taxPercent, prefix, termsDays, markupPercent, autoTaxHardware, aiStyle, footer,
       companyName, phone, website, addr1, addr2, city, region, postal, country, terms, load]);
 
   if (loading) return <p className="text-sm text-muted-foreground">{t('partnerBillingSettings.loading')}</p>;
@@ -275,8 +285,15 @@ export default function PartnerBillingSettings() {
               id="pb-website" type="text" value={website}
               onChange={(e) => setWebsite(e.target.value)}
               data-testid="partner-billing-website"
+              aria-invalid={websiteInvalid || undefined}
+              aria-describedby={websiteInvalid ? 'pb-website-error' : undefined}
               className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
             />
+            {websiteInvalid && (
+              <p id="pb-website-error" data-testid="partner-billing-website-error" className="mt-1 text-sm text-destructive">
+                {httpUrlErrorMessage(t('partnerBillingSettings.company.website'))}
+              </p>
+            )}
           </div>
         </div>
         <div className="mt-4">
@@ -349,7 +366,7 @@ export default function PartnerBillingSettings() {
 
       <div className="flex justify-end">
         <button
-          type="button" onClick={() => void save()} disabled={saving}
+          type="button" onClick={() => void save()} disabled={saving || websiteInvalid}
           data-testid="partner-billing-save"
           className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
         >

--- a/apps/web/src/components/settings/PartnerCompanyTab.test.tsx
+++ b/apps/web/src/components/settings/PartnerCompanyTab.test.tsx
@@ -94,4 +94,45 @@ describe('PartnerCompanyTab', () => {
     fireEvent.change(textarea, { target: { value: 'Cheers,\nAcme' } });
     expect(onEmailSignatureChange).toHaveBeenCalledWith('Cheers,\nAcme');
   });
+
+  // #3430 — the Website field previously accepted any string, including
+  // javascript:/data: URIs, with no client-side feedback at all.
+  describe('website scheme validation', () => {
+    it('shows no error for an empty or valid website', () => {
+      renderTab({ contact: {} });
+      expect(screen.queryByTestId('contact-website-error')).toBeNull();
+    });
+
+    it.each(['https://acme.com', 'http://acme.com', 'https://acme.com/a?b=1'])(
+      'accepts %s without an error',
+      (value) => {
+        renderTab({ contact: { website: value } });
+        expect(screen.queryByTestId('contact-website-error')).toBeNull();
+      }
+    );
+
+    it.each([
+      'javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      'acme.com',
+    ])('flags %j as invalid', (value) => {
+      renderTab({ contact: { website: value } });
+      const err = screen.getByTestId('contact-website-error');
+      expect(err.textContent).toContain('http:// or https://');
+      const input = screen.getByLabelText('Website') as HTMLInputElement;
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+      expect(input.getAttribute('aria-describedby')).toBe('contact-website-error');
+    });
+
+    it('still reports the typed value back to the parent so it is not silently stripped', () => {
+      const { onContactChange } = renderTab({ contact: {} });
+      const input = screen.getByLabelText('Website');
+      fireEvent.change(input, { target: { value: 'javascript:alert(1)' } });
+      expect(onContactChange).toHaveBeenCalledWith(
+        expect.objectContaining({ website: 'javascript:alert(1)' })
+      );
+    });
+  });
 });

--- a/apps/web/src/components/settings/PartnerCompanyTab.tsx
+++ b/apps/web/src/components/settings/PartnerCompanyTab.tsx
@@ -1,5 +1,6 @@
 import { Building2, MapPin, User, Mail, Phone, Globe } from 'lucide-react';
 import type { PartnerSettings } from '@breeze/shared';
+import { isHttpUrl, httpUrlErrorMessage } from '@breeze/shared';
 import { useTranslation } from 'react-i18next';
 import '@/lib/i18n';
 
@@ -41,6 +42,11 @@ export default function PartnerCompanyTab({
   const setContact = (field: keyof Contact, value: string) => {
     onContactChange({ ...contact, [field]: value });
   };
+  // Mirrors the server-side http/https allowlist on `contact.website` (#3430).
+  // Empty is fine — the field is clearable — so only a populated, non-http(s)
+  // value is flagged. The parent also blocks the save with the same rule.
+  const websiteValue = (contact.website || '').trim();
+  const websiteInvalid = websiteValue !== '' && !isHttpUrl(websiteValue);
 
   return (
     <div className="space-y-6">
@@ -203,7 +209,14 @@ export default function PartnerCompanyTab({
               onChange={(e) => setContact('website', e.target.value)}
               placeholder={t('partnerCompany.placeholders.website')}
               className={inputClass}
+              aria-invalid={websiteInvalid || undefined}
+              aria-describedby={websiteInvalid ? 'contact-website-error' : undefined}
             />
+            {websiteInvalid && (
+              <p id="contact-website-error" data-testid="contact-website-error" className="text-sm text-destructive">
+                {httpUrlErrorMessage(t('partnerCompany.website'))}
+              </p>
+            )}
           </div>
         </div>
       </section>

--- a/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.test.tsx
@@ -347,6 +347,60 @@ describe('PartnerSettingsPage Company tab', () => {
     expect(body.settings.address.city).toBe('Denver');
   });
 
+  // #3430 — the Website field reached the API unvalidated. handleSave now blocks
+  // the round-trip so the user gets a reason instead of a raw server 400.
+  describe('website scheme guard blocks the save', () => {
+    const loadedPartner = () =>
+      makeJsonResponse({
+        id: 'partner-1', name: 'Acme MSP', slug: 'acme', type: 'partner', plan: 'pro',
+        createdAt: '2026-02-09T00:00:00.000Z',
+        settings: {
+          timezone: 'UTC', dateFormat: 'MM/DD/YYYY', timeFormat: '12h', language: 'en',
+          businessHours: { preset: 'business' }, contact: {}, address: {},
+        },
+      });
+
+    const patchCalls = () =>
+      fetchWithAuthMock.mock.calls.filter(
+        ([, init]) => (init as RequestInit | undefined)?.method === 'PATCH'
+      );
+
+    it.each(['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>', 'acme.com'])(
+      'does not PATCH when the website is %j',
+      async (bad) => {
+        fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+        fetchWithAuthMock.mockResolvedValueOnce(loadedPartner());
+
+        render(<PartnerSettingsPage />);
+        const websiteInput = await screen.findByLabelText(/website/i);
+        const user = userEvent.setup();
+        await user.type(websiteInput, bad);
+        await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+        expect(patchCalls()).toHaveLength(0);
+      }
+    );
+
+    it('PATCHes a valid https website, trimmed', async () => {
+      fetchWithAuthMock.mockResolvedValue(makeJsonResponse({ data: [] }));
+      fetchWithAuthMock.mockResolvedValueOnce(loadedPartner());
+      fetchWithAuthMock.mockResolvedValueOnce(
+        makeJsonResponse({ id: 'partner-1', name: 'Acme MSP', settings: {} })
+      );
+
+      render(<PartnerSettingsPage />);
+      const websiteInput = await screen.findByLabelText(/website/i);
+      const user = userEvent.setup();
+      await user.type(websiteInput, '  https://acme.com  ');
+      await user.click(screen.getByRole('button', { name: /save settings/i }));
+
+      const calls = patchCalls();
+      expect(calls).toHaveLength(1);
+      const body = JSON.parse((calls[0]![1] as RequestInit).body as string);
+      expect(body.settings.contact.website).toBe('https://acme.com');
+    });
+  });
+
   const partnerWithSignature = (emailSignature: string | null) => ({
     id: 'partner-1',
     name: 'Acme MSP',

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -397,7 +397,10 @@ export default function PartnerSettingsPage() {
         name: contactName || undefined,
         email: contactEmail || undefined,
         phone: contactPhone || undefined,
-        website: contactWebsite || undefined
+        // Trimmed to match the predicate the guard above applied — sending the
+        // untrimmed value made a whitespace-only entry pass the client check
+        // and then fail server-side with no inline error to explain it.
+        website: contactWebsite.trim() || undefined
       },
       address: {
         street1: address.street1 || undefined,

--- a/apps/web/src/components/settings/PartnerSettingsPage.tsx
+++ b/apps/web/src/components/settings/PartnerSettingsPage.tsx
@@ -47,7 +47,7 @@ import type {
   InheritableRemoteAccessSettings,
   IpAllowlistStatus
 } from '@breeze/shared';
-import { isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE } from '@breeze/shared';
+import { isValidMaintenanceWindow, MAINTENANCE_WINDOW_ERROR_MESSAGE, isHttpUrl, httpUrlErrorMessage } from '@breeze/shared';
 import { navigateTo } from '@/lib/navigation';
 import { runAction, ActionError } from '@/lib/runAction';
 import { useTranslation } from 'react-i18next';
@@ -373,6 +373,14 @@ export default function PartnerSettingsPage() {
     const mw = defaultsData.maintenanceWindow;
     if (typeof mw === 'string' && mw.trim() !== '' && !isValidMaintenanceWindow(mw)) {
       setError(MAINTENANCE_WINDOW_ERROR_MESSAGE);
+      return;
+    }
+
+    // Same shape for the company Website (#3430): the server rejects any scheme
+    // outside http/https, so block the round-trip here and say why. The field is
+    // clearable, hence the non-empty guard.
+    if (contactWebsite.trim() !== '' && !isHttpUrl(contactWebsite.trim())) {
+      setError(httpUrlErrorMessage('Website'));
       return;
     }
 

--- a/packages/shared/src/validators/httpUrl.test.ts
+++ b/packages/shared/src/validators/httpUrl.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isHttpUrl,
+  httpUrlValue,
+  httpUrlField,
+  nullableHttpUrlField,
+  httpUrlErrorMessage,
+  HTTP_URL_MAX_LENGTH,
+} from './httpUrl';
+
+// The payloads #3430 was filed for. Kept as a named list so every schema
+// helper below is exercised against the same corpus.
+const DANGEROUS = [
+  'javascript:alert(1)',
+  'JavaScript:alert(1)',
+  'javascript:alert(document.cookie)',
+  'data:text/html,<script>alert(1)</script>',
+  'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+  'vbscript:msgbox(1)',
+  'file:///etc/passwd',
+  'about:blank',
+  'blob:https://example.com/1234',
+  'view-source:https://example.com',
+  'chrome://settings',
+  'jar:https://example.com!/',
+  'filesystem:https://example.com/temporary/x',
+  // Whitespace/control-char obfuscation that a naive `startsWith('javascript:')`
+  // check would miss but `new URL()` still resolves to the javascript scheme.
+  'java\nscript:alert(1)',
+  'java\tscript:alert(1)',
+  ' javascript:alert(1)',
+];
+
+const VALID = [
+  'https://example.com',
+  'http://example.com',
+  'https://example.com/path?q=1#frag',
+  'HTTPS://EXAMPLE.COM',
+  'http://localhost:3000',
+  'https://sub.domain.example.co.uk/a/b',
+];
+
+describe('isHttpUrl', () => {
+  it.each(VALID)('accepts %s', (value) => {
+    expect(isHttpUrl(value)).toBe(true);
+  });
+
+  it.each(DANGEROUS)('rejects %j', (value) => {
+    expect(isHttpUrl(value)).toBe(false);
+  });
+
+  it('rejects relative and scheme-less values', () => {
+    for (const v of ['example.com', '//example.com', '/path', '', '   ']) {
+      expect(isHttpUrl(v)).toBe(false);
+    }
+  });
+});
+
+describe('httpUrlValue', () => {
+  const schema = httpUrlValue('Website');
+
+  it.each(VALID)('parses %s', (value) => {
+    expect(schema.parse(value)).toBe(value);
+  });
+
+  it.each(DANGEROUS)('rejects %j with the labelled message', (value) => {
+    const result = schema.safeParse(value);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(httpUrlErrorMessage('Website'));
+    }
+  });
+
+  it('accepts empty string so the field can be cleared', () => {
+    expect(schema.parse('')).toBe('');
+  });
+
+  it('rejects rather than silently stripping a bad value', () => {
+    // Regression guard for #3430: a transform that dropped the value would make
+    // a rejected save look like a successful one that lost the field.
+    const result = schema.safeParse('javascript:alert(1)');
+    expect(result.success).toBe(false);
+  });
+
+  it('enforces the default max length', () => {
+    const long = `https://example.com/${'a'.repeat(HTTP_URL_MAX_LENGTH)}`;
+    expect(schema.safeParse(long).success).toBe(false);
+  });
+
+  it('honours a caller-supplied max length', () => {
+    const narrow = httpUrlValue('Website', 30);
+    expect(narrow.safeParse('https://example.com').success).toBe(true);
+    expect(narrow.safeParse(`https://example.com/${'a'.repeat(40)}`).success).toBe(false);
+  });
+});
+
+describe('httpUrlField', () => {
+  const schema = httpUrlField('Website');
+
+  it('accepts undefined and empty string', () => {
+    expect(schema.parse(undefined)).toBeUndefined();
+    expect(schema.parse('')).toBe('');
+  });
+
+  it('still rejects dangerous schemes', () => {
+    for (const value of DANGEROUS) {
+      expect(schema.safeParse(value).success).toBe(false);
+    }
+  });
+});
+
+describe('nullableHttpUrlField', () => {
+  const schema = nullableHttpUrlField('Billing website', 255);
+
+  it('accepts null, undefined and empty string', () => {
+    expect(schema.parse(null)).toBeNull();
+    expect(schema.parse(undefined)).toBeUndefined();
+    expect(schema.parse('')).toBe('');
+  });
+
+  it('accepts a valid https URL', () => {
+    expect(schema.parse('https://example.com')).toBe('https://example.com');
+  });
+
+  it('still rejects dangerous schemes', () => {
+    for (const value of DANGEROUS) {
+      expect(schema.safeParse(value).success).toBe(false);
+    }
+  });
+
+  it('applies the narrowed max length', () => {
+    expect(schema.safeParse(`https://example.com/${'a'.repeat(300)}`).success).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/httpUrl.ts
+++ b/packages/shared/src/validators/httpUrl.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+// Shared http(s)-only URL guard for tenant-authored URL fields (#3430).
+//
+// These are values a partner admin types into a settings form and that the
+// product later either renders (partner Website on branded invoices, quotes
+// and PDFs) or dials outbound (Slack webhook, Elasticsearch endpoint). Neither
+// class has a legitimate custom-scheme use, so both get the same narrow
+// allowlist: `http:` and `https:`, nothing else.
+//
+// Contrast with `remoteAccessLauncherScheme.ts`, which deliberately keeps a
+// WIDER, denylist-backed rule because partners genuinely need `rustdesk:` and
+// other custom protocol handlers there. That file is the exception; this one is
+// the default for anything shaped like a plain web address.
+//
+// Reject rather than silently strip — a field the server quietly cleared looks
+// to the user like the save failed (#3430).
+
+/** Max length accepted by {@link httpUrlValue} unless a caller narrows it. */
+export const HTTP_URL_MAX_LENGTH = 2000;
+
+/**
+ * True when `value` parses as an absolute URL whose scheme is `http` or
+ * `https`. Empty string is NOT accepted here — clearability is a schema-level
+ * concern, expressed by {@link httpUrlField}.
+ *
+ * `new URL()` is the parser on purpose: it normalises the odd-but-legal forms
+ * (`HTTP://`, `java\nscript:`) that a hand-rolled regex on the raw string
+ * mishandles.
+ */
+export function isHttpUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+}
+
+/** Human-readable rejection message, shared by the API schemas and the web forms. */
+export function httpUrlErrorMessage(label: string): string {
+  return `${label} must be a full http:// or https:// URL`;
+}
+
+/**
+ * Required-shaped http(s) URL string. Empty string is accepted so a field can
+ * be cleared without tripping the scheme check.
+ */
+export function httpUrlValue(label: string, maxLength: number = HTTP_URL_MAX_LENGTH) {
+  return z
+    .string()
+    .max(maxLength)
+    .refine((v) => v === '' || isHttpUrl(v), httpUrlErrorMessage(label));
+}
+
+/** Optional/clearable form of {@link httpUrlValue}, for standalone fields. */
+export function httpUrlField(label: string, maxLength: number = HTTP_URL_MAX_LENGTH) {
+  return httpUrlValue(label, maxLength).optional().or(z.literal(''));
+}
+
+/**
+ * Nullable + optional form, for settings columns that store `NULL` to mean
+ * "unset" (the billing/seller profile fields).
+ */
+export function nullableHttpUrlField(label: string, maxLength: number = HTTP_URL_MAX_LENGTH) {
+  return httpUrlValue(label, maxLength).nullable().optional();
+}

--- a/packages/shared/src/validators/httpUrl.ts
+++ b/packages/shared/src/validators/httpUrl.ts
@@ -3,10 +3,15 @@ import { z } from 'zod';
 // Shared http(s)-only URL guard for tenant-authored URL fields (#3430).
 //
 // These are values a partner admin types into a settings form and that the
-// product later either renders (partner Website on branded invoices, quotes
-// and PDFs) or dials outbound (Slack webhook, Elasticsearch endpoint). Neither
-// class has a legitimate custom-scheme use, so both get the same narrow
-// allowlist: `http:` and `https:`, nothing else.
+// product later either renders (`partners.billing_website` → the seller block
+// on branded invoices, quotes and PDFs) or dials outbound (Slack webhook,
+// Elasticsearch endpoint). Neither class has a legitimate custom-scheme use,
+// so both get the same narrow allowlist: `http:` and `https:`, nothing else.
+//
+// SCOPE: this is a scheme guard, NOT an SSRF control. `http://localhost:9200`
+// and link-local addresses still pass, deliberately — self-hosted deployments
+// legitimately point the Elasticsearch endpoint at them. Anything that needs
+// egress restrictions has to add them separately.
 //
 // Contrast with `remoteAccessLauncherScheme.ts`, which deliberately keeps a
 // WIDER, denylist-backed rule because partners genuinely need `rustdesk:` and

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -14,6 +14,7 @@ import {
 export * from './reliability';
 export * from './businessEmail';
 export * from './remoteAccessLauncherScheme';
+export * from './httpUrl';
 export * from './remoteAccessInlineSettings';
 export * from './safeRelativePath';
 export * from './authenticator';

--- a/packages/shared/src/validators/invoices.test.ts
+++ b/packages/shared/src/validators/invoices.test.ts
@@ -61,6 +61,42 @@ describe('partnerBillingSettingsSchema', () => {
     expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: 10000 }).success).toBe(false);
     expect(partnerBillingSettingsSchema.safeParse({ ...base, defaultMarkupPercent: 12.345 }).success).toBe(false); // multipleOf 0.01
   });
+
+  // #3430 — billingWebsite was a bare z.string() while the twin field on
+  // partner settings (contact.website) was already http/https-only. It is
+  // snapshotted onto every issued invoice/quote and rendered in branded PDFs
+  // and the customer portal, so it gets the same guard.
+  describe('billingWebsite scheme validation', () => {
+    const base = { currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30 };
+
+    it.each(['https://acme.com', 'http://acme.com', 'https://acme.com/support?a=1', ''])(
+      'accepts %j',
+      (billingWebsite) => {
+        expect(partnerBillingSettingsSchema.safeParse({ ...base, billingWebsite }).success).toBe(true);
+      }
+    );
+
+    it('accepts null and undefined (field is clearable/optional)', () => {
+      expect(partnerBillingSettingsSchema.safeParse({ ...base, billingWebsite: null }).success).toBe(true);
+      expect(partnerBillingSettingsSchema.safeParse({ ...base }).success).toBe(true);
+    });
+
+    it.each([
+      'javascript:alert(1)',
+      'JavaScript:alert(document.cookie)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      'acme.com',
+    ])('rejects %j', (billingWebsite) => {
+      expect(partnerBillingSettingsSchema.safeParse({ ...base, billingWebsite }).success).toBe(false);
+    });
+
+    it('keeps the 255-char cap', () => {
+      const long = `https://acme.com/${'a'.repeat(300)}`;
+      expect(partnerBillingSettingsSchema.safeParse({ ...base, billingWebsite: long }).success).toBe(false);
+    });
+  });
 });
 
 
@@ -68,13 +104,27 @@ describe('partnerBillingSettingsSchema — contact fields', () => {
   it('accepts the new seller contact + T&C fields', () => {
     const parsed = partnerBillingSettingsSchema.parse({
       currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
-      billingCompanyName: 'Acme MSP LLC', billingPhone: '+1 555 0100', billingWebsite: 'acme.test',
+      billingCompanyName: 'Acme MSP LLC', billingPhone: '+1 555 0100', billingWebsite: 'https://acme.test',
       billingAddressLine1: '1 Main St', billingAddressCity: 'Austin', billingAddressRegion: 'TX',
       billingAddressPostalCode: '78701', billingAddressCountry: 'US',
       billingTermsAndConditions: 'Net 30. Late fee 1.5%/mo.',
     });
     expect(parsed.billingCompanyName).toBe('Acme MSP LLC');
     expect(parsed.billingAddressCountry).toBe('US');
+    expect(parsed.billingWebsite).toBe('https://acme.test');
+  });
+
+  // Behaviour change from #3430, called out explicitly: a scheme-less hostname
+  // is no longer accepted on write. This matches the already-shipped rule on
+  // the twin `contact.website` field (PATCH /partners/me) rather than silently
+  // guessing a scheme. Existing stored values still READ back fine; only a
+  // re-save of the billing profile requires correcting the field.
+  it('rejects a scheme-less hostname rather than assuming https', () => {
+    const result = partnerBillingSettingsSchema.safeParse({
+      currencyCode: 'USD', invoiceNumberPrefix: 'INV', invoiceTermsDays: 30,
+      billingWebsite: 'acme.test',
+    });
+    expect(result.success).toBe(false);
   });
 
   it('rejects a 3-letter country code', () => {

--- a/packages/shared/src/validators/invoices.ts
+++ b/packages/shared/src/validators/invoices.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 // const — a `string[]` intermediate would widen the schema to z.enum(string)).
 import { INVOICE_STATUSES, PAYMENT_METHODS } from '../types/billing-enums';
 import { BULK_ID_LIMIT } from '../constants';
+import { nullableHttpUrlField } from './httpUrl';
 
 const money = z.number().nonnegative().multipleOf(0.01);
 const positiveQty = z.number().positive().multipleOf(0.01);
@@ -101,7 +102,10 @@ export const partnerBillingSettingsSchema = z.object({
   // Seller "From" contact profile (snapshotted onto each document at issue).
   billingCompanyName: z.string().max(255).nullable().optional(),
   billingPhone: z.string().max(40).nullable().optional(),
-  billingWebsite: z.string().max(255).nullable().optional(),
+  // Snapshotted onto every issued invoice/quote and rendered in the branded
+  // PDF, the portal document shell and the web document views, so it must be a
+  // real web address rather than an arbitrary scheme (#3430).
+  billingWebsite: nullableHttpUrlField('Billing website', 255),
   billingAddressLine1: z.string().max(255).nullable().optional(),
   billingAddressLine2: z.string().max(255).nullable().optional(),
   billingAddressCity: z.string().max(120).nullable().optional(),


### PR DESCRIPTION
Closes #3430.

## What was actually left

The issue pointed at `apps/api/src/routes/orgs.ts:482` (`website: z.string().optional()`). That specific field was **already fixed** by #3442 / #3448, which landed an inline `httpUrlValue` helper in `orgs.ts` — those PRs never referenced #3430, so the issue stayed open. I verified against `origin/main` before starting.

Two parts of the issue were still genuinely open, and one of them is the field that matters more.

### 1. `billingWebsite` — the partner Website that actually reaches renderers

`packages/shared/src/validators/invoices.ts:104` was still `z.string().max(255).nullable().optional()`. This is the **other** partner Website field (Billing → seller profile), and it is the one that is snapshotted onto every issued document and rendered downstream:

- `apps/api/src/services/sellerSnapshot.ts:48` / `publicQuoteDto.ts:34` → `seller.website`
- `apps/web/.../InvoiceDocument.tsx:106`, `QuoteDocument.tsx:366`, `InvoiceDetail.tsx:507`, `QuoteDetail.tsx:313`
- `apps/portal/src/components/portal/documentShell.tsx:71`
- PDFs: `quotePdf.ts:814`, `invoicePdf.ts:165,259`

All of those are **text, not `href`** today, so — as with the original report — this is a missing control, not a live XSS. It is the field most likely to become a link, since it is the one printed on customer-facing documents.

### 2. The web form had no validation at all

`PartnerCompanyTab.tsx` is presentational: `<input type="url">` with no `<form>` wrapper, so native validation never fires, and `PartnerSettingsPage.handleSave` did no check. `javascript:alert(1)` round-tripped to the API and came back as a raw 400.

## The fix

New shared validator `packages/shared/src/validators/httpUrl.ts`, following the `remoteAccessLauncherScheme.ts` precedent the issue asked for:

- `isHttpUrl(v)` — `new URL()` parse + `http:`/`https:` protocol check. Using the URL parser rather than a regex is deliberate: it normalises `HTTP://` and the control-char obfuscations (`java\nscript:`) that a `startsWith` check misses.
- `httpUrlValue(label, max)` / `httpUrlField(label, max)` / `nullableHttpUrlField(label, max)` zod helpers, plus `httpUrlErrorMessage(label)` shared with the web form.
- **Rejects rather than strips**, per the issue — a silently-cleared field reads as a failed save.

Wired into:
- `partnerBillingSettingsSchema.billingWebsite` → `nullableHttpUrlField('Billing website', 255)` (the actual gap).
- `orgs.ts` — deletes its local copy of the helper and imports the shared one, so `contact.website`, `slackWebhookUrl`, `webhooks[]` and `elasticsearchUrl` keep identical behaviour from one source.
- `PartnerCompanyTab` — inline `aria-invalid` + `aria-describedby` error; `PartnerSettingsPage.handleSave` blocks the round-trip, matching the existing maintenance-window precedent 8 lines above it.

### Behaviour change worth a release note

A **scheme-less hostname** (`acme.com`) is no longer accepted when *saving* billing settings — it must be `https://acme.com`. This matches the already-shipped rule on the twin `contact.website` field rather than guessing a scheme. Existing stored values still **read** back fine; only a re-save of the billing profile requires correcting the field. One existing test fixture used `acme.test` and was updated, with an explicit test pinning the new rejection.

## Traced, and *not* a sink

`branding.websiteUrl` at `BuiltinPackageDetail.tsx:64` — the issue flagged this as worth tracing. It **cannot** reach tenant data: `getProviderBranding()` returns a hardcoded record (`providerBranding.ts:18-36`) with literal `https://www.huntress.com` / `https://www.sentinelone.com`. Not attacker-controllable. This is the only `href` on any `websiteUrl` in the repo.

## Sweep — noted, not fixed here

The issue asked whether this is a class. It is, but the rest is a different blast radius and doesn't belong in this PR:

| Location | Field | Gap |
|---|---|---|
| `apps/api/src/routes/orgs.ts:617` | partner `branding.logoUrl` | `z.string().max(400_000)` with **no scheme check**, while the near-identical `partnerLoginBranding.ts:23` restricts to `https://` or `data:image/(png\|jpeg\|webp);base64`. The inconsistency is the finding. |
| `packages/shared/src/validators/index.ts:331` | org `elasticsearchUrl` | `z.string().trim().optional()` — the org-level log-forwarding path is looser than the partner-level one now sharing `httpUrlField`. Server-dialled, so SSRF-shaped. |
| `apps/api/src/routes/orgs.ts:218` | `siteContactSchema` | `.passthrough()`, so a `website` on a **site** contact is accepted unvalidated. |
| `apps/web/.../NotificationChannelForm.tsx:51,53,56` | webhook URLs | bare `z.string().optional()` in one variant while lines 20/25 of the same file use `.url()`. |
| `packages/shared/src/validators/index.ts:796` | `siteUrl` (OneDrive) | bare, but SharePoint-sourced rather than partner branding. |

`supportUrl` / `documentationUrl` / `iconUrl` / `faviconUrl` don't exist in partner/org schemas. Portal branding logo/customDomain aren't admin-writable (`portal.ts` is `.strict()`).

## Testing

- `packages/shared/src/validators/httpUrl.test.ts` — new, 55 tests. Corpus covers `javascript:`, `data:`, `vbscript:`, `file:`, `about:`, `blob:`, `view-source:`, `chrome:`, `jar:`, `filesystem:`, plus whitespace/control-char obfuscation and case variants; explicitly asserts reject-not-strip and the clearability of empty string.
- `invoices.test.ts` — `billingWebsite` accept/reject matrix, null/undefined clearability, the 255 cap, and the scheme-less-hostname behaviour change.
- `invoices/settings.test.ts` — route-level 400 with **no service call** for three dangerous schemes, plus a 200 path asserting the value reaches the service. Proves the guard at the HTTP boundary, not just in the schema.
- `PartnerCompanyTab.test.tsx` — 9 new tests: error shown/hidden, `aria-invalid`/`aria-describedby` wiring, and that the typed value is still reported to the parent (not silently dropped).

Green: shared 153 · `apps/api/src/routes/orgs.test.ts` 213 · `invoices/settings.test.ts` 10 · `apps/web/src/components/settings/` 520 (60 files). `tsc --noEmit` clean for shared, api and web; `astro check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (addressed in `616915d41`)

Three reviewers (code-reviewer, silent-failure-hunter, pr-test-analyzer). Two Important findings, both raised independently by two reviewers, both fixed:

**1. Legacy scheme-less `billingWebsite` blocked the entire billing form.** `PartnerBillingSettings.tsx` PATCHes the *full* payload and repopulates the stored value, so a partner whose `billing_website` holds a scheme-less hostname — legal until this PR — could not save a tax-rate or prefix change without a 400 on a field they never touched. The form now carries the same inline `aria-invalid` / `aria-describedby` error as the Company tab, and Save is disabled until it's corrected. 5 new tests, including the legacy-value load case.

**2. The rationale comment named the wrong column.** It claimed `contact.website` reaches branded PDFs/invoices/email footers. It does not — those read `partners.billing_website` via `buildSellerSnapshot`; `contact.website` has no consumer outside the settings form. Since that comment is what a future reader will use to decide whether the guard can be relaxed, it's corrected in both `orgs.ts` and the shared validator. The SSRF claim is narrowed in the same pass: this is a **scheme** guard, not an egress control, and `http://localhost` still passes deliberately (self-hosted Elasticsearch). Reviewers confirmed the three outbound-dialled fields are separately SSRF-guarded by `safeFetch`.

Also fixed:

- **Coverage hole in the code this PR restructured.** `orgs.test.ts` stayed **213/213 green with the `slackWebhookUrl`, `webhooks[]` and `elasticsearchUrl` guards deleted**. Now covered, and mutation-checked — I removed all three guards and confirmed exactly the three new cases fail, then restored.
- **Trim asymmetry I introduced.** `PartnerSettingsPage` validated `contactWebsite.trim()` but submitted it untrimmed, so a whitespace-only entry passed the client check and failed server-side with no inline error. Trimmed on submit; tests for both the block-the-save and trimmed-happy paths.
- **`sellerSnapshot.ts` now records why the seller website must not be linkified** without an output-side filter. Reviewers confirmed every current render site is plain text (no `href`, no PDFKit `link:` option, `escapeHtml` on the HTML path), so legacy values are inert — but `invoices.seller_snapshot` / `quotes.seller_snapshot` are immutable jsonb never re-validated on read, so a later scrub of the source column would not reach already-issued documents. The comment is the durable guard against someone linkifying it later.

Reviewers found **no bypass** in the allowlist — `new URL()` + `protocol` was probed against tab/newline/NUL obfuscation, backslash normalization, scheme-relative, mixed case and unicode hosts — and confirmed the change is **write-path only**, with `orgs.ts` semantics preserved exactly by the extraction.

### Open question for the maintainer

Nothing backfills existing `partners.billing_website` rows. The inline guard makes a legacy value discoverable and fixable in the UI, which I think is the right level of response given every render site is inert text — but if you'd rather scrub or normalize the column, that's a data decision I've deliberately left to you.

## Verification after the review round

- `apps/api`: `orgs.test.ts` + `invoices/settings.test.ts` → 229 passed
- `apps/web`: `components/settings/` + `components/billing/` → 1128 passed (138 files)
- `packages/shared`: full validator suite → 1315 passed (43 files)
- `tsc --noEmit` clean for api, web and shared; `astro check` 0 errors
