### PR TITLE
fix(security): bump Go toolchain to 1.26.6 to clear six stdlib advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 
 env:
   PNPM_VERSION: '10.34.5'
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.6'
 
 # SR-007: least-privilege default. CI runs on every PR (including forks) and
 # only needs to read the repo. Any job needing more must opt in per-job.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.26.6'
           cache-dependency-path: agent/go.sum
 
       - name: Initialize CodeQL

--- a/.github/workflows/dev-build-agent.yml
+++ b/.github/workflows/dev-build-agent.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.6'
 
 jobs:
   resolve:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   PNPM_VERSION: '10.34.5'
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.6'
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   PNPM_VERSION: '10.34.5'
-  GO_VERSION: '1.25.12'
+  GO_VERSION: '1.26.6'
 
 # Least-privilege default; the SARIF-uploading job opts into
 # security-events: write per-job below.
@@ -59,6 +59,12 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+
+      # Runs before Setup Go on purpose: this job only proves the toolchain it
+      # was handed is clean, so a pin that drifts anywhere else (release.yml
+      # builds the shipped binary) would scan one Go and ship another.
+      - name: Check Go toolchain pins agree
+        run: bash scripts/security/check-go-version-pins.sh
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7

--- a/agent/go.mod
+++ b/agent/go.mod
@@ -1,6 +1,6 @@
 module github.com/breeze-rmm/agent
 
-go 1.25.10
+go 1.26.6
 
 require (
 	cloud.google.com/go/storage v1.64.0

--- a/apps/docs/src/content/docs/agents/building.mdx
+++ b/apps/docs/src/content/docs/agents/building.mdx
@@ -10,7 +10,7 @@ import { Aside } from '@astrojs/starlight/components';
 
 ## Prerequisites
 
-- Go 1.25 or later
+- Go 1.26.6 or later
 - Make
 - (Optional) `go-winres` for Windows resource embedding
 - (Optional) WiX Toolset + PowerShell for MSI packaging

--- a/apps/docs/src/content/docs/getting-started/prerequisites.mdx
+++ b/apps/docs/src/content/docs/getting-started/prerequisites.mdx
@@ -78,9 +78,9 @@ Caddy will automatically provision a TLS certificate from Let's Encrypt once DNS
 Only needed if building the agent from source (pre-built binaries are available):
 
 ```bash
-# Go 1.25+
-wget https://go.dev/dl/go1.25.0.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.25.0.linux-amd64.tar.gz
+# Go 1.26.6+
+wget https://go.dev/dl/go1.26.6.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.26.6.linux-amd64.tar.gz
 export PATH=$PATH:/usr/local/go/bin
 ```
 

--- a/scripts/security/check-go-version-pins.sh
+++ b/scripts/security/check-go-version-pins.sh
@@ -9,6 +9,12 @@
 #   - the `go` directive in agent/go.mod
 #   - two public docs pages that tell self-hosters what to install
 #
+# DELIBERATELY EXCLUDED: selfhost-signing-template/.github/workflows/ci.yml
+# pins go-version 1.24. That file is a template copied into a SELF-HOSTER'S
+# own repository, where it only installs actionlint — it never builds the
+# Breeze agent, so it is not one of "our" toolchain pins and is out of the
+# .github/workflows/*.yml glob on purpose, not by oversight.
+#
 # Why this guard exists: the pin was bumped 1.25.12 -> 1.26.6 to clear six
 # stdlib advisories (GO-2026-5026/5942/5972/6088/6090/6218). Five of the six
 # are also fixed in 1.25.13, but GO-2026-5942 (dnsmessage SVCB/HTTPS RR panic,
@@ -62,12 +68,21 @@ for file in .github/workflows/*.yml; do
 done
 
 # --- public docs telling self-hosters which toolchain to install ------------
+# Presence alone is not enough: a page that says "install Go 1.25.12" while
+# mentioning the current pin somewhere else would pass a grep -q and still
+# hand self-hosters an unpatched toolchain. Require the pin AND the absence
+# of any older 1.25.x reference.
 for doc in \
   apps/docs/src/content/docs/agents/building.mdx \
   apps/docs/src/content/docs/getting-started/prerequisites.mdx
 do
   grep -qF "$pinned" "$doc" \
     || note "$doc does not mention $pinned — self-hosters would install an unpatched toolchain"
+  # Trailing char must be non-DIGIT, not non-[digit-or-dot]: "Go 1.25.12." at
+  # the end of a sentence ends in '.', and excluding '.' here made this check
+  # silently miss the very case it exists for.
+  stale="$(grep -nE '(^|[^0-9.])(go)?1\.25(\.[0-9]+)?([^0-9]|$)' "$doc" || true)"
+  [ -z "$stale" ] || note "$doc still references Go 1.25: $(head -1 <<<"$stale")"
 done
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/security/check-go-version-pins.sh
+++ b/scripts/security/check-go-version-pins.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# check-go-version-pins.sh — keep every Go toolchain pin in the repo agreeing.
+#
+# The Go pin is not stored in one place. It lives in:
+#   - GO_VERSION env in .github/workflows/{ci,security,release,dev-build-agent}.yml
+#   - a HARD-CODED go-version literal in .github/workflows/codeql.yml
+#     (that job sets no GO_VERSION env, so it silently keeps its own pin)
+#   - the `go` directive in agent/go.mod
+#   - two public docs pages that tell self-hosters what to install
+#
+# Why this guard exists: the pin was bumped 1.25.12 -> 1.26.6 to clear six
+# stdlib advisories (GO-2026-5026/5942/5972/6088/6090/6218). Five of the six
+# are also fixed in 1.25.13, but GO-2026-5942 (dnsmessage SVCB/HTTPS RR panic,
+# reachable from heartbeat.handleNetworkDnsCheck -> net.Resolver.LookupCNAME)
+# has NO fix on the 1.25 branch — stdlib fixed it only in 1.26.6. So a pin
+# that drifts backward to any 1.25.x silently reintroduces a remote panic in
+# the agent that ships to customer machines, and the Go Vulnerability Check
+# job is the only thing that would notice.
+#
+# A stale pin in ONE of these files is invisible: CI stays green on the files
+# that agree, and the disagreeing one either builds a release binary with the
+# wrong toolchain (release.yml) or scans a different stdlib than it ships
+# (security.yml). Same failure shape as the Node pin, which drifted across
+# four locations undetected.
+#
+# The `go` directive is the load-bearing one for anybody building from source:
+# with the default GOTOOLCHAIN=auto it makes Go fetch >= the pinned toolchain
+# instead of building a vulnerable binary on whatever is installed.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+fail=0
+note() { echo "FAIL $*" >&2; fail=1; }
+
+# --- source of truth: agent/go.mod -----------------------------------------
+pinned="$(sed -nE 's/^go ([0-9]+\.[0-9]+\.[0-9]+)$/\1/p' agent/go.mod)"
+if [ -z "$pinned" ]; then
+  echo "FAIL agent/go.mod has no fully-qualified 'go X.Y.Z' directive." >&2
+  echo "     A two-part directive (go 1.26) permits any patch release, which" >&2
+  echo "     defeats the point: the advisories above are patch-level fixes." >&2
+  exit 1
+fi
+echo "pinned Go toolchain (agent/go.mod): $pinned"
+
+# --- every GO_VERSION env in workflows -------------------------------------
+for file in .github/workflows/*.yml; do
+  while IFS= read -r v; do
+    [ "$v" = "$pinned" ] || note "$file GO_VERSION=$v != $pinned (agent/go.mod)"
+  done < <(sed -nE "s/^[[:space:]]*GO_VERSION:[[:space:]]*['\"]?([^'\"[:space:]]+)['\"]?.*/\1/p" "$file")
+done
+
+# --- literal go-version: pins that bypass GO_VERSION entirely ---------------
+# `go-version: ${{ env.GO_VERSION }}` is fine; a bare literal is its own pin.
+for file in .github/workflows/*.yml; do
+  while IFS= read -r v; do
+    [[ "$v" == *'{{'* ]] && continue
+    [ "$v" = "$pinned" ] || note "$file hard-codes go-version: $v != $pinned"
+  done < <(sed -nE "s/^[[:space:]]*go-version:[[:space:]]*['\"]?([^'\"[:space:]]+)['\"]?.*/\1/p" "$file")
+done
+
+# --- public docs telling self-hosters which toolchain to install ------------
+for doc in \
+  apps/docs/src/content/docs/agents/building.mdx \
+  apps/docs/src/content/docs/getting-started/prerequisites.mdx
+do
+  grep -qF "$pinned" "$doc" \
+    || note "$doc does not mention $pinned — self-hosters would install an unpatched toolchain"
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "Go toolchain pins disagree. Update every location above together." >&2
+  exit 1
+fi
+echo "check-go-version-pins: all Go toolchain pins agree on $pinned."

--- a/scripts/security/run-govulncheck.sh
+++ b/scripts/security/run-govulncheck.sh
@@ -28,6 +28,23 @@ while IFS= read -r id; do
     echo "ALLOWLISTED $id — reviewed exception, see scripts/security/govulncheck-allowlist.txt"
   else
     echo "FAIL $id — symbol-level vulnerability not in the allowlist" >&2
+    # Print the call trace, not just the id. Without this the log proves only
+    # THAT something is reachable, so any later claim about WHICH agent path
+    # reaches it has to be re-derived by hand — and source reading is a weaker
+    # instrument than govulncheck's own symbol analysis, so that re-derivation
+    # can fail to confirm a real finding.
+    #
+    # trace[0] is the VULNERABLE symbol; the LAST element is the frame in our
+    # own code that reaches it. Both halves matter: the first says what is
+    # broken, the last says which agent path exposes us to it.
+    jq -r --arg id "$id" \
+      'select(.finding != null) | .finding
+       | select(.osv == $id) | select(.trace[0].function != null)
+       | (.trace[0] | "\(.package // .module).\(.function)") as $vuln
+       | (.trace[-1]) as $ours
+       | "     \($vuln)  <-  \($ours.package // $ours.module).\($ours.function)"
+         + ($ours.position | if . then " (\(.filename):\(.line))" else "" end)' \
+      "$out_file" | sort -u >&2
     fail=1
   fi
 done <<<"$found"


### PR DESCRIPTION
`Go Vulnerability Check` is red on **every open PR** (#3511, #3512, #3514, #3515, #3518, and #3510) and would redden `main` at its next scheduled run. No repo change caused it — govulncheck resolves against a live advisory database, so the same tree that passed on `497d0297f` at 20:40Z failed hours later.

## The six findings

All symbol-level, all stdlib, all reachable from agent code:

| Advisory | Package | Issue |
|---|---|---|
| GO-2026-6218 | `net/url` | quadratic `resolvePath` |
| GO-2026-6090 | `crypto/tls` | unbounded post-handshake messages |
| GO-2026-6088 | `encoding/xml` | missing recursion depth guard |
| GO-2026-5972 | `encoding/asn1` | missing recursion depth guard |
| GO-2026-5026 | `net/http` | idna punycode labels not rejected |
| GO-2026-5942 | `net` (dnsmessage) | panic on invalid SVCB/HTTPS RR |

## Why 1.26.6 and not 1.25.13

1.25.13 is the tempting minimal bump and it clears **five of the six**. It does not clear **GO-2026-5942** — stdlib fixed that one only on the 1.26 branch (OSV records `fixed=1.26.6`, no 1.25 backport).

I verified this empirically rather than trusting the advisory range:

```
GOTOOLCHAIN=go1.25.13 → GO-2026-5051 (allowlisted), GO-2026-5942   ❌
GOTOOLCHAIN=go1.26.6  → GO-2026-5051 (allowlisted)                 ✅
```

That finding matters more than its position in the list suggests. The trace is `heartbeat.handleNetworkDnsCheck` → `net.Resolver.LookupCNAME` — a panic triggerable by a DNS response, in the agent that runs on customer machines.

Allowlisting it was not an option. The allowlist's own documented bar is *"the advisory must have NO fixed release to upgrade to"*, and one exists.

## Scope

- `GO_VERSION` in `ci` / `security` / `release` / `dev-build-agent`, **plus the hard-coded literal in `codeql.yml`** — that job defines no `GO_VERSION` and quietly keeps its own pin.
- `agent/go.mod` `go` directive, so the fix binds for anyone building from source and not only for binaries we release. With the default `GOTOOLCHAIN=auto` this *fetches* 1.26.6 rather than erroring; it only bites an explicit `GOTOOLCHAIN=local` on 1.25.
- The two docs pages that tell self-hosters which toolchain to install.
- **`scripts/security/check-go-version-pins.sh`**, run first in the `go-vuln` job. That job only proves the toolchain it was handed is clean, so a pin drifting anywhere else means we scan one Go and ship another.

## Verification

- `go build`, `go vet`, `go test -race ./...` — green, 69 packages, exit 0. The test run had `go.mod` **already** at 1.26.6, so it exercised Go 1.26 GODEBUG defaults rather than 1.25 compatibility ones.
- `scripts/security/run-govulncheck.sh` (the real CI gate) exits 0.
- The new pin guard is **mutation-tested** — it fails when a workflow drifts back to 1.25.13, when the `codeql.yml` literal drifts, when `go.mod` loses patch precision (`go 1.26`), and when the docs advertise 1.25.

## Behaviour changes carried by the `go` directive

The `go` line gates GODEBUG defaults, so Go 1.26 semantics now apply. I checked each against agent code:

- **`cryptocustomrand=0`** — inert. `math/rand` appears only in backoff jitter and never reaches a crypto API.
- **`urlstrictcolons=1`** — `url.Parse` now rejects unbracketed IPv6 and malformed host colons. The agent parses a configured `ServerURL` (`config/validate.go:87`, `config/serverurl.go:82`), so a self-hoster who wrote `https://fd00::1:8080/` instead of `https://[fd00::1]:8080/` is now rejected at config validation rather than silently misparsed. **Worth a release note.**
- **`tlsmlkem`** — two additional hybrid PQ key exchanges offered. Hybrid ML-KEM has been on by default since 1.24, so this is incremental rather than new.
- **`urlmaxqueryparams=10000`, `httpcookiemaxnum=3000`, `htmlmetacontenturlescape`** — no agent path approaches these.

## Merge order

This does **not** fix `Trivy Filesystem Scan`, the other repo-wide red check. #3510 (nanoid `CVE-2026-67213`, @bdunncompany) covers that one. Neither PR can go fully green on its own — whichever lands first needs `--admin`, then the other rebases clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)