### PR TITLE
fix(api,shared): correct z.coerce.boolean() query-param footgun (8 sites, 9 params)

### DIFF
--- a/apps/api/src/routes/catalog/distributors.ts
+++ b/apps/api/src/routes/catalog/distributors.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../../lib/validation';
 import { z } from 'zod';
+import { optionalQueryBoolean } from '@breeze/shared';
 import { requireMfa, requirePermission, requireScope, dbAccessContextFromAuth, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
 import { checkSsrfSafe } from '../../services/ssrfGuard';
@@ -348,7 +349,7 @@ const sftpConfigSchema = z.object({
 
 const sftpListSchema = z.object({
   q: z.string().max(120).optional(),
-  inStockOnly: z.coerce.boolean().optional(),
+  inStockOnly: optionalQueryBoolean,
   limit: z.coerce.number().int().min(1).max(200).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });

--- a/apps/api/src/routes/cisHardening.ts
+++ b/apps/api/src/routes/cisHardening.ts
@@ -2,6 +2,7 @@ import { Hono, type Context } from 'hono';
 import { zValidator } from '../lib/validation';
 import { and, desc, eq, gte, inArray, isNull, lte, or, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
+import { optionalQueryBoolean } from '@breeze/shared';
 
 import { db } from '../db';
 import {
@@ -28,7 +29,7 @@ const baselineLevelSchema = z.enum(['l1', 'l2', 'custom']);
 const listBaselinesQuerySchema = z.object({
   orgId: z.string().guid().optional(),
   osType: osTypeSchema.optional(),
-  active: z.coerce.boolean().optional(),
+  active: optionalQueryBoolean,
   limit: z.coerce.number().int().positive().max(200).optional(),
   offset: z.coerce.number().int().min(0).optional(),
 });

--- a/apps/api/src/routes/contracts/documents.ts
+++ b/apps/api/src/routes/contracts/documents.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { optionalQueryBoolean } from '@breeze/shared';
 import { zValidator } from '../../lib/validation';
 import { requireScope, requirePermission, type AuthContext } from '../../middleware/auth';
 import { PERMISSIONS } from '../../services/permissions';
@@ -24,7 +25,7 @@ const writePerm = requirePermission(PERMISSIONS.CONTRACTS_WRITE.resource, PERMIS
 const idParam = z.object({ id: z.string().guid() });
 const listQuery = z.object({
   contractId: z.string().guid().optional(),
-  unattached: z.coerce.boolean().optional(),
+  unattached: optionalQueryBoolean,
 });
 const linkBody = z.object({ contractId: z.string().guid() });
 

--- a/apps/api/src/routes/contracts/templates.ts
+++ b/apps/api/src/routes/contracts/templates.ts
@@ -8,6 +8,7 @@ import {
   createContractTemplateSchema,
   updateContractTemplateSchema,
   createTemplateVersionSchema,
+  optionalQueryBoolean,
 } from '@breeze/shared';
 import {
   listTemplates,
@@ -36,7 +37,7 @@ const writePerm = requirePermission(PERMISSIONS.CONTRACTS_WRITE.resource, PERMIS
 
 const idParam = z.object({ id: z.string().guid() });
 const versionIdParam = idParam.extend({ versionId: z.string().guid() });
-const listQuery = z.object({ includeArchived: z.coerce.boolean().optional() });
+const listQuery = z.object({ includeArchived: optionalQueryBoolean });
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 

--- a/apps/api/src/routes/monitoring.ts
+++ b/apps/api/src/routes/monitoring.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
+import { optionalQueryBoolean } from '@breeze/shared';
 import { and, desc, eq, gte, inArray, isNotNull, lte, or, sql } from 'drizzle-orm';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { db } from '../db';
@@ -119,7 +120,7 @@ async function resolveSiteAllowedAssetIds(orgId: string, perms: UserPermissions 
 
 const listAssetsSchema = z.object({
   orgId: z.string().guid().optional(),
-  includeUnconfigured: z.coerce.boolean().optional()
+  includeUnconfigured: optionalQueryBoolean
 });
 
 monitoringRoutes.get(

--- a/apps/api/src/routes/pax8.ts
+++ b/apps/api/src/routes/pax8.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context, type Next } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
+import { optionalQueryBoolean } from '@breeze/shared';
 import { and, desc, eq, sql, type SQL } from 'drizzle-orm';
 import { db } from '../db';
 import {
@@ -91,7 +92,7 @@ const subscriptionQuerySchema = z.object({
   partnerId: z.string().guid().optional(),
   integrationId: z.string().guid().optional(),
   orgId: z.string().guid().optional(),
-  unmappedOnly: z.coerce.boolean().optional(),
+  unmappedOnly: optionalQueryBoolean,
   limit: z.coerce.number().int().min(1).max(500).default(100),
 });
 

--- a/apps/api/src/routes/plugins.ts
+++ b/apps/api/src/routes/plugins.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { zValidator } from '../lib/validation';
 import { z } from 'zod';
+import { optionalQueryBoolean } from '@breeze/shared';
 import { eq, and, ilike, sql, desc } from 'drizzle-orm';
 import { authMiddleware, requireMfa, requirePermission, requireScope } from '../middleware/auth';
 import { db } from '../db';
@@ -65,7 +66,7 @@ const catalogQuerySchema = z.object({
   type: z.enum(['integration', 'automation', 'reporting', 'collector', 'notification', 'ui']).optional(),
   category: z.string().optional(),
   search: z.string().optional(),
-  verified: z.coerce.boolean().optional(),
+  verified: optionalQueryBoolean,
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().positive().max(100).default(20)
 });

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1026,6 +1026,7 @@ export * from './scriptParameters';
 
 export * from './tickets';
 export * from './ticketForms';
+export * from './queryParams';
 export * from './timeEntries';
 export * from './portal';
 export * from './ticketConfig';

--- a/packages/shared/src/validators/queryParams.test.ts
+++ b/packages/shared/src/validators/queryParams.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { optionalQueryBoolean } from './queryParams';
+
+describe('optionalQueryBoolean', () => {
+  const schema = optionalQueryBoolean;
+
+  it('parses the string form correctly — including the z.coerce.boolean footgun cases', () => {
+    // The whole point: these must NOT be truthiness-coerced to true.
+    expect(schema.parse('false')).toBe(false);
+    expect(schema.parse('0')).toBe(false);
+    expect(schema.parse('no')).toBe(false);
+    expect(schema.parse('off')).toBe(false);
+    expect(schema.parse('FALSE')).toBe(false);
+    expect(schema.parse(' false ')).toBe(false);
+
+    expect(schema.parse('true')).toBe(true);
+    expect(schema.parse('1')).toBe(true);
+    expect(schema.parse('yes')).toBe(true);
+    expect(schema.parse('on')).toBe(true);
+    expect(schema.parse('TRUE')).toBe(true);
+  });
+
+  it('absent stays undefined (no filter); a bare flag stays false (preserves old coerce)', () => {
+    expect(schema.parse(undefined)).toBeUndefined();
+    // Boolean('') === false, so ?flag with no value kept meaning false, not "unfiltered".
+    expect(schema.parse('')).toBe(false);
+    expect(schema.parse('   ')).toBe(false);
+  });
+
+  it('passes real booleans through', () => {
+    expect(schema.parse(true)).toBe(true);
+    expect(schema.parse(false)).toBe(false);
+  });
+
+  it('rejects garbage rather than silently coercing it', () => {
+    expect(schema.safeParse('maybe').success).toBe(false);
+    expect(schema.safeParse('2').success).toBe(false);
+    expect(schema.safeParse('truthy').success).toBe(false);
+  });
+
+  it('documents the bug it replaces: z.coerce.boolean() coerces "false" to true', () => {
+    expect(z.coerce.boolean().parse('false')).toBe(true); // the footgun, for the record
+    expect(optionalQueryBoolean.parse('false')).toBe(false); // the fix
+  });
+});
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/**
+ * Regression guard for the whole class: no query/validator schema may use
+ * z.coerce.boolean() again — it silently coerces "false"/"0" to true. Use
+ * optionalQueryBoolean (this file) instead. Scans the route + shared-validator
+ * trees the same way bodyLimit.test.ts scans for body-limit drift.
+ */
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name === '__tests__') continue;
+      out.push(...tsFiles(full));
+    } else if (e.name.endsWith('.ts') && !e.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// packages/shared/src/validators -> repo root is five levels up.
+const repoRoot = resolve(__dirname, '..', '..', '..', '..');
+
+describe('no z.coerce.boolean() on external input (regression guard)', () => {
+  it('every route + shared validator uses optionalQueryBoolean, never z.coerce.boolean()', () => {
+    const roots = [
+      join(repoRoot, 'apps', 'api', 'src', 'routes'),
+      join(repoRoot, 'packages', 'shared', 'src', 'validators'),
+    ].filter((d) => {
+      try { return statSync(d).isDirectory(); } catch { return false; }
+    });
+    // Fail loudly if the scan root ever stops resolving (would pass vacuously).
+    expect(roots.length).toBe(2);
+
+    const offenders: string[] = [];
+    for (const root of roots) {
+      for (const file of tsFiles(root)) {
+        // Exempt ONLY the canonical helper itself (its doc comment names the
+        // anti-pattern on purpose). Match the exact path, not any queryParams.ts.
+        if (file === join(repoRoot, 'packages', 'shared', 'src', 'validators', 'queryParams.ts')) continue;
+        const src = readFileSync(file, 'utf8');
+        src.split('\n').forEach((line, i) => {
+          // strip a // tail and skip JSDoc/`*` comment lines so a documenting
+          // mention can't false-positive; the literal call is what matters.
+          const trimmed = line.trimStart();
+          if (trimmed.startsWith('*') || trimmed.startsWith('/*')) return;
+          const code = line.replace(/\/\/.*$/, '');
+          if (/z\.coerce\.boolean\s*\(/.test(code)) {
+            offenders.push(`${file.slice(repoRoot.length + 1)}:${i + 1}`);
+          }
+        });
+      }
+    }
+    expect(offenders, `use optionalQueryBoolean instead:\n${offenders.join('\n')}`).toEqual([]);
+  });
+});

--- a/packages/shared/src/validators/queryParams.ts
+++ b/packages/shared/src/validators/queryParams.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * Correct tri-state boolean for QUERY-STRING params.
+ *
+ * `z.coerce.boolean()` is a footgun for query params: it uses JavaScript
+ * truthiness, so every non-empty string — including the literal `"false"` and
+ * `"0"` — coerces to `true`. A filter like `?approved=false` therefore silently
+ * matched the opposite set (returned HTTP 200 with wrong results). This parses
+ * the string form instead:
+ *
+ *   'true' | '1' | 'yes' | 'on'   -> true
+ *   'false'| '0' | 'no'  | 'off'  -> false   (case-insensitive, trimmed)
+ *   '' (bare `?flag`)             -> false    (preserves the old coerce
+ *                                              behavior: Boolean('') === false,
+ *                                              so a bare flag stays a real value)
+ *   absent (undefined)            -> undefined (no filter — this is .optional())
+ *   anything else                 -> ZodError (reject; the old coerce turned
+ *                                              garbage like "2" into true, which
+ *                                              is exactly the bug — do NOT keep it)
+ *
+ * The only intended behavior changes vs z.coerce.boolean() are (1) the fix
+ * itself — "false"/"0"/etc now correctly parse to false — and (2) garbage now
+ * 400s instead of silently meaning true. Bare/absent semantics are preserved.
+ *
+ * Reuse this everywhere a boolean arrives via the query string. The pre-existing
+ * ad-hoc helpers (routes/networkShared, routes/backup/schemas, routes/analytics,
+ * the catalog.ts enum idiom) predate it, use their own accepted-value languages,
+ * and are left as-is; consolidating them onto this helper is a separate cleanup.
+ */
+const TRUE = new Set(['true', '1', 'yes', 'on']);
+const FALSE = new Set(['false', '0', 'no', 'off', '']);
+
+export const optionalQueryBoolean = z.preprocess((value) => {
+  if (value === undefined) return undefined;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const v = value.trim().toLowerCase();
+    if (TRUE.has(v)) return true;
+    if (FALSE.has(v)) return false;
+  }
+  return value; // fall through to z.boolean() which rejects it
+}, z.boolean().optional());

--- a/packages/shared/src/validators/timeEntries.ts
+++ b/packages/shared/src/validators/timeEntries.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { optionalQueryBoolean } from './queryParams';
 
 export const billingStatusSchema = z.enum(['not_billed', 'billed', 'no_charge', 'contract']);
 export type BillingStatus = z.infer<typeof billingStatusSchema>;
@@ -45,9 +46,9 @@ export const listTimeEntriesQuerySchema = z.object({
   orgId: z.string().guid().optional(),
   from: z.coerce.date().optional(),
   to: z.coerce.date().optional(),
-  running: z.coerce.boolean().optional(),
+  running: optionalQueryBoolean,
   billingStatus: billingStatusSchema.optional(),
-  approved: z.coerce.boolean().optional(),
+  approved: optionalQueryBoolean,
   limit: z.coerce.number().int().min(1).max(200).default(50),
   offset: z.coerce.number().int().min(0).default(0)
 });


### PR DESCRIPTION
## The bug

`z.coerce.boolean()` uses JavaScript truthiness, so **any non-empty query string — including the literal `"false"` and `"0"` — coerces to `true`**. Nine optional filter params across eight sites were inverted: `?approved=false` silently returned the *approved* set, `?active=false` returned *active* baselines, `?includeArchived=false` still included archived. HTTP 200 with wrong results and no signal to the caller.

Found by an exhaustive Codex silent-failure audit of `origin/main`.

## The fix

A canonical `optionalQueryBoolean` helper (`packages/shared/src/validators/queryParams.ts`), exported via `@breeze/shared`:

| input | result |
|---|---|
| `true` / `1` / `yes` / `on` | `true` |
| `false` / `0` / `no` / `off` (case-insensitive) | `false` |
| `''` (bare `?flag`) | `false` — preserves `Boolean('') === false` |
| absent | `undefined` (no filter; `.optional()`) |
| garbage (`2`, `enabled`, …) | `ZodError` (400) |

The **only** intended behavior changes vs the old coerce are the fix itself and rejecting garbage rather than treating it as `true`. Bare-flag and absent semantics are preserved exactly.

Replaces all nine sites: shared `timeEntries` (`running`, `approved`); routes `catalog/distributors` (`inStockOnly`), `cisHardening` (`active`), `contracts/documents` (`unattached`), `contracts/templates` (`includeArchived`), `monitoring` (`includeUnconfigured`), `pax8` (`unmappedOnly`), `plugins` (`verified`).

## Adversarial review — what it caught and what I'm recording

An independent review of the first cut caught a **real regression I'd introduced**: I initially mapped `''` (a bare `?flag`) to `undefined`, which would have *removed* the filter for `?verified`/`?running`/`?approved`/`?active` where the old code treated `''` as `false`. The Breeze web UI only ever sends `?flag=true`, so it was unaffected, but the documented external plugin `verified` param could send bare flags. **Fixed:** `'' → false`, so bare-flag behavior is preserved and the fix is a true drop-in.

Recorded, not silently carried:

1. **Garbage now 400s instead of meaning `true`.** This is an intentional contract tightening. The web UI never sends garbage; an external caller sending `?flag=2` would now get a 400 instead of a silent `true`. I believe rejecting is correct, but it's a validation-contract change worth your sign-off.
2. **No affected-route integration test.** The helper has thorough unit tests and `zValidator('query')` composition was confirmed by review, but I did not add a route-level test proving the 400 body and that `"false"` reaches the service as `false`. Noted as a gap; happy to add one.
3. **The repo has multiple incompatible query-boolean "languages"** (`networkShared`, `backup/schemas`, `analytics`, the `catalog.ts` enum idiom, plus manual `=== 'true'` in ~10 routes). This PR does not consolidate them — they were already correct — but the regression guard is a textual check that won't catch a manual `=== 'true'` variant. Consolidation is a worthwhile separate cleanup.

## Verification

node 22.23.2: `queryParams` 6/6 (incl. the regression guard), full shared suite **1831/1831**, 18 affected api route suites **287 passed**, shared + api `tsc --noEmit` clean.
