### PR TITLE
fix(api): resolve AI agent-version pins in a real system context

### DIFF
--- a/apps/api/src/services/aiToolsAgentMgmt.test.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.test.ts
@@ -36,7 +36,7 @@ vi.mock('../routes/agents/helpers', () => ({
     a === 'amd64' || a === 'arm64' ? a : a === 'x86_64' ? 'amd64' : a == null ? null : null,
 }));
 
-import { db } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import type { AuthContext } from '../middleware/auth';
 import type { AiTool } from './aiTools';
 import { executeCommand } from './commandQueue';
@@ -119,6 +119,24 @@ describe('query_agent_versions check_upgrades — pin-aware target (#2124)', () 
     expect(result.latestVersion).toBe('0.90.0'); // global latest still reported for context
     // Devices on global-latest 0.90.0 are "outdated" relative to the 0.80.0 holdback pin.
     expect(result.totalOutdated).toBe(3);
+  });
+
+  it('resolves the pin in a real system context: runOutsideDbContext wraps withSystemDbAccessContext wraps the resolver (#3516 class)', async () => {
+    // The bug: a bare withSystemDbAccessContext short-circuits under the ambient
+    // org context makeHandler re-enters per tool call, so the partner-axis pin is
+    // invisible. Assert the fix's nesting by invocation order — and note that on
+    // the pre-fix code runOutsideDbContext was never called here at all.
+    mockSelectSequence([[{ version: '0.90.0' }], [{ currentVersion: '0.90.0', count: 1 }]]);
+    await tool.handler({ action: 'check_upgrades' }, makeAuth());
+
+    expect(vi.mocked(runOutsideDbContext)).toHaveBeenCalled();
+    expect(vi.mocked(withSystemDbAccessContext)).toHaveBeenCalled();
+    const outsideOrder = vi.mocked(runOutsideDbContext).mock.invocationCallOrder[0]!;
+    const systemOrder = vi.mocked(withSystemDbAccessContext).mock.invocationCallOrder[0]!;
+    const resolverOrder = vi.mocked(getOrgAgentUpdateConfig).mock.invocationCallOrder[0]!;
+    // outer-to-inner: runOutsideDbContext -> withSystemDbAccessContext -> resolver
+    expect(outsideOrder).toBeLessThan(systemOrder);
+    expect(systemOrder).toBeLessThan(resolverOrder);
   });
 
   it('a multi-org (non-org-scoped) caller is told pins are not reflected', async () => {

--- a/apps/api/src/services/aiToolsAgentMgmt.ts
+++ b/apps/api/src/services/aiToolsAgentMgmt.ts
@@ -7,7 +7,7 @@
  * - trigger_agent_restart (Tier 3): Ask the watchdog to restart a wedged/silent agent
  */
 
-import { db, withSystemDbAccessContext } from '../db';
+import { db, runOutsideDbContext, withSystemDbAccessContext } from '../db';
 import { devices, agentVersions } from '../db/schema';
 import { eq, ne, and, desc, sql, inArray, SQL } from 'drizzle-orm';
 import type { AuthContext } from '../middleware/auth';
@@ -123,7 +123,7 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
         let note: string | undefined;
         if (auth.orgId) {
           try {
-            const cfg = await withSystemDbAccessContext(() => getOrgAgentUpdateConfig(auth.orgId!));
+            const cfg = await runOutsideDbContext(() => withSystemDbAccessContext(() => getOrgAgentUpdateConfig(auth.orgId!)));
             if (cfg.pins.agent) {
               effectiveTarget = cfg.pins.agent;
               pinned = true;
@@ -278,7 +278,7 @@ export function registerAgentMgmtTools(aiTools: Map<string, AiTool>): void {
             // same pattern the heartbeat and aiAgent use. Isolate per org so one
             // org's resolver failure doesn't abort the whole batch.
             try {
-              const cfg = await withSystemDbAccessContext(() => getOrgAgentUpdateConfig(d.orgId));
+              const cfg = await runOutsideDbContext(() => withSystemDbAccessContext(() => getOrgAgentUpdateConfig(d.orgId)));
               pinByOrg.set(d.orgId, cfg.pins.agent);
             } catch {
               failedOrgs.add(d.orgId);


### PR DESCRIPTION
Fixes a partner-pin integrity bug in the AI agent-management tools, found by an exhaustive Codex tenancy audit of `origin/main`.

## The bug

`query_agent_versions check_upgrades` (the "needs upgrade" count) and `trigger_agent_upgrade` (bulk device resolution) resolve each org's effective agent pin via `withSystemDbAccessContext(() => getOrgAgentUpdateConfig(orgId))`. That resolver `LEFT JOIN`s `organizations → partners` to read inherited/partner-set pins, and the `partners` row requires `breeze_has_partner_access` — which an **org-scoped** RLS context can't satisfy.

These handlers run inside an ambient **org** context: the chat SDK query is created inside `runOutsideDbContext` (so tool handlers don't inherit the request transaction), and `aiAgentSdkTools.makeHandler` then re-enters a fresh org context per tool call. Because `withDbAccessContext` short-circuits when a context is already active (`if (dbContextStorage.getStore()) return fn()`), the bare `withSystemDbAccessContext` **never switched to system scope** — it stayed org-scoped, the partner join returned `null`, and the tool silently fell back to the org pin or global latest.

**Impact:** a partner that pinned the agent to a known-good version has that pin ignored by the AI's upgrade count and dispatch — it reports/dispatches against the wrong target.

## The fix

Wrap both calls in `runOutsideDbContext(() => withSystemDbAccessContext(...))` — the exact idiom already used at `agents/commands.ts:314`, `alerts/alerts.ts:972`, `alerts/channels.ts:541`. `runOutsideDbContext` is a no-op when already outside a context.

## Tenancy safety

No data-exposure change: the system read is constrained to the passed `orgId` (`auth.orgId` for the count; device-derived `d.orgId` for the bulk path, after every device is access-checked) and joins only that org's own `partner_id`. Codex confirmed no caller can select another org/partner's pin at this boundary.

## Verification

Adds a regression test asserting the nesting by invocation order (`runOutsideDbContext → withSystemDbAccessContext → resolver`) — **it fails on the pre-fix code**, where `runOutsideDbContext` was never called at this site. A real-DB integration test (partner pin visible only under system scope) would be stronger and is noted as a follow-up. `aiToolsAgentMgmt` 18/18, api `tsc --noEmit` clean.
